### PR TITLE
Use standard eclipse dialogs instead of Swing dialogs

### DIFF
--- a/eclipse-plugins/edu.wpi.first.wpilib.plugins.core/src/main/java/edu/wpi/first/wpilib/plugins/core/installer/AbstractInstaller.java
+++ b/eclipse-plugins/edu.wpi.first.wpilib.plugins.core/src/main/java/edu/wpi/first/wpilib/plugins/core/installer/AbstractInstaller.java
@@ -8,8 +8,6 @@ import java.io.OutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import javax.swing.JOptionPane;
-
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -17,6 +15,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.jface.dialogs.MessageDialog;
 
 import edu.wpi.first.wpilib.plugins.core.WPILibCore;
 
@@ -117,7 +116,7 @@ public abstract class AbstractInstaller {
 	protected void install() throws InstallException {
 		if(installLocation.exists()) {
 			if(!removeFileHandler(installLocation, true)) {
-				JOptionPane.showMessageDialog(null,
+				MessageDialog.openError(null, "Error",
 					String.format("Could not update the old wpilib folder.%n"
 							+ "Please close any WPILib tools and restart Eclipse."));
 			}

--- a/eclipse-plugins/edu.wpi.first.wpilib.plugins.core/src/main/java/edu/wpi/first/wpilib/plugins/core/launching/SimulationNotification.java
+++ b/eclipse-plugins/edu.wpi.first.wpilib.plugins.core/src/main/java/edu/wpi/first/wpilib/plugins/core/launching/SimulationNotification.java
@@ -6,10 +6,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import javax.swing.JOptionPane;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.jface.dialogs.MessageDialog;
 
 import edu.wpi.first.wpilib.plugins.core.WPILibCore;
 
@@ -21,8 +20,8 @@ public class SimulationNotification {
 	
 	public static void showUnsupported() {
 		String title = "Simulation Unsupported";
-		String message = SIMULATION_UNSUPPORTED_MSG; 
-		JOptionPane.showMessageDialog(null, message, title, JOptionPane.OK_OPTION);
+		String message = SIMULATION_UNSUPPORTED_MSG;
+		MessageDialog.openError(null, title, message);
 		try {
 			Desktop.getDesktop().browse(new URI(URL));
 		} catch (IOException e) {


### PR DESCRIPTION
- Swing dialog triggers freeze on Eclipse Luna on OSX 10.10
