### PR TITLE
Fixed issue with digital outputs used as pwm on mxp

### DIFF
--- a/hal/lib/athena/DIO.cpp
+++ b/hal/lib/athena/DIO.cpp
@@ -126,6 +126,10 @@ void setPWMDutyCycle(void* pwmGenerator, double dutyCycle, int32_t* status) {
 void setPWMOutputChannel(void* pwmGenerator, uint32_t pin, int32_t* status) {
   uint32_t id = (uint32_t)pwmGenerator;
   if (id > 5) return;
+  if (pin >= kNumHeaders) {       // if it is on the MXP
+    pin += kMXPDigitalPWMOffset;  // then to write as a digital PWM pin requires
+                                  // an offset to write on the correct pin
+  }
   digitalSystem->writePWMOutputSelect(id, pin, status);
 }
 

--- a/hal/lib/athena/DigitalInternal.h
+++ b/hal/lib/athena/DigitalInternal.h
@@ -16,7 +16,9 @@ namespace hal {
 constexpr uint32_t kNumHeaders = 10;  // Number of non-MXP pins
 constexpr uint32_t kDigitalPins = 26;
 constexpr uint32_t kPwmPins = 20;
-
+constexpr uint32_t kMXPDigitalPWMOffset = 6;  // MXP pins when used as digital
+                                              // output pwm are offset by 6 from
+                                              // actual value
 constexpr uint32_t kExpectedLoopTiming = 40;
 
 /**


### PR DESCRIPTION
When a digital output object that was tied to an mxp pin had enable pwm called on it
it would pwm on a pin 6 lower
 (although if this wasn't an mxp pin it wouldn't do anything at all.)
Fixed in Digital.cpp by adding 6 if it is an MXP pin in setPWMOutputChannel()
This should fix the CanJaguar test because when digitalOutputs used as PWM
were freed, the PWM generator was set to the number of pins, which meant it
was actually outputing on pin 20.

Change-Id: Ib48db3e6e3bf78659622145969d24011cc231ea6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wpilibsuite/allwpilib/14)
<!-- Reviewable:end -->
