### PR TITLE
Fixed the fake potentiometer position test

### DIFF
--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/can/AbstractCANTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/can/AbstractCANTest.java
@@ -35,7 +35,7 @@ public abstract class AbstractCANTest extends AbstractComsSetup {
   public static final double kLimitSettlingTime = 20.0; // timeout in seconds
   public static final double kStartupTime = 0.50;
   public static final double kEncoderPositionTolerance = .75;
-  public static final double kPotentiometerPositionTolerance = 10.0 / 360.0; // +/-10
+  public static final double kPotentiometerPositionTolerance = 0.2; // +/-10
                                                                              // degrees
   public static final double kCurrentTolerance = 0.1;
 

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/can/CANPositionPotentiometerModeTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/can/CANPositionPotentiometerModeTest.java
@@ -139,7 +139,6 @@ public class CANPositionPotentiometerModeTest extends AbstractCANTest {
         new RunnableAssert("Waiting for potentiometer position to be correct") {
           @Override
           public void run() throws Exception {
-            getME().getMotor().set(0);
             assertEquals(
                 "CAN Jaguar should have returned the potentiometer position set by the analog output",
                 getME().getFakePot().getVoltage(), getME().getMotor().getPosition() * 3,


### PR DESCRIPTION
Also made it not spin the motor constantly at full speed during the test.

Change-Id: I4b517489ef56ebce0ef4a085a00e399b12440af9

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wpilibsuite/allwpilib/18)

<!-- Reviewable:end -->
