### PR TITLE
Fix apt-get update -q causing build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: java
 
 before_install:
   - sudo add-apt-repository ppa:wpilib/toolchain -y
-  - sudo apt-get update -q
+  - sudo apt-get update -q || true
   - sudo apt-get install frc-toolchain -y
 
 


### PR DESCRIPTION
`sudo apt-get update -q` can fail a site doesn't respond.
This is the solution proposed here:
Related https://github.com/travis-ci/travis-ci/issues/5221