### PR TITLE
Implements locking in C++ DriverStation, and adds double buffering to DS Thread

### DIFF
--- a/wpilibc/Athena/include/DriverStation.h
+++ b/wpilibc/Athena/include/DriverStation.h
@@ -9,6 +9,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <memory>
 #include "HAL/HAL.hpp"
 #include "HAL/cpp/Semaphore.hpp"
 #include "HAL/cpp/priority_condition_variable.h"
@@ -100,10 +101,17 @@ class DriverStation : public SensorBase, public RobotStateInterface {
   void ReportJoystickUnpluggedWarning(std::string message);
   void Run();
 
-  HALJoystickAxes m_joystickAxes[kJoystickPorts];
-  HALJoystickPOVs m_joystickPOVs[kJoystickPorts];
-  HALJoystickButtons m_joystickButtons[kJoystickPorts];
-  HALJoystickDescriptor m_joystickDescriptor[kJoystickPorts];
+  std::unique_ptr<HALJoystickAxes[]> m_joystickAxes;
+  std::unique_ptr<HALJoystickPOVs[]> m_joystickPOVs;
+  std::unique_ptr<HALJoystickButtons[]> m_joystickButtons;
+  std::unique_ptr<HALJoystickDescriptor[]> m_joystickDescriptor;
+
+  // Cached Data
+  std::unique_ptr<HALJoystickAxes[]> m_joystickAxesCache;
+  std::unique_ptr<HALJoystickPOVs[]> m_joystickPOVsCache;
+  std::unique_ptr<HALJoystickButtons[]> m_joystickButtonsCache;
+  std::unique_ptr<HALJoystickDescriptor[]> m_joystickDescriptorCache;
+
   Task m_task;
   std::atomic<bool> m_isRunning{false};
   mutable Semaphore m_newControlData{Semaphore::kEmpty};
@@ -111,6 +119,7 @@ class DriverStation : public SensorBase, public RobotStateInterface {
   priority_mutex m_packetDataAvailableMutex;
   std::condition_variable_any m_waitForDataCond;
   priority_mutex m_waitForDataMutex;
+  mutable priority_mutex m_joystickDataMutex;
   bool m_userInDisabled = false;
   bool m_userInAutonomous = false;
   bool m_userInTeleop = false;

--- a/wpilibj/src/athena/cpp/lib/FRCNetworkCommunicationsLibrary.cpp
+++ b/wpilibj/src/athena/cpp/lib/FRCNetworkCommunicationsLibrary.cpp
@@ -142,37 +142,47 @@ Java_edu_wpi_first_wpilibj_communication_FRCNetworkCommunicationsLibrary_NativeH
 /*
  * Class: edu_wpi_first_wpilibj_communication_FRCNetworkCommunicationsLibrary
  * Method:    HALGetJoystickAxes
- * Signature: (B)[S
+ * Signature: (B[S)B
  */
-JNIEXPORT jshortArray JNICALL
+JNIEXPORT jbyte JNICALL
 Java_edu_wpi_first_wpilibj_communication_FRCNetworkCommunicationsLibrary_HALGetJoystickAxes(
-    JNIEnv *env, jclass, jbyte joystickNum) {
+    JNIEnv * env, jclass, jbyte joystickNum, jshortArray axesArray) {
   NETCOMM_LOG(logDEBUG) << "Calling HALJoystickAxes";
   HALJoystickAxes axes;
   HALGetJoystickAxes(joystickNum, &axes);
 
-  jshortArray axesArray = env->NewShortArray(axes.count);
+  jsize javaSize = env->GetArrayLength(axesArray);
+  if (axes.count > javaSize)
+  {
+    ThrowIllegalArgumentException(env, "Native array size larger then passed in java array size");
+  }
+
   env->SetShortArrayRegion(axesArray, 0, axes.count, axes.axes);
 
-  return axesArray;
+  return axes.count;
 }
 
 /*
  * Class: edu_wpi_first_wpilibj_communication_FRCNetworkCommunicationsLibrary
  * Method:    HALGetJoystickPOVs
- * Signature: (B)[S
+ * Signature: (B[S)B
  */
-JNIEXPORT jshortArray JNICALL
+JNIEXPORT jbyte JNICALL
 Java_edu_wpi_first_wpilibj_communication_FRCNetworkCommunicationsLibrary_HALGetJoystickPOVs(
-    JNIEnv *env, jclass, jbyte joystickNum) {
+    JNIEnv * env, jclass, jbyte joystickNum, jshortArray povsArray) {
   NETCOMM_LOG(logDEBUG) << "Calling HALJoystickPOVs";
   HALJoystickPOVs povs;
   HALGetJoystickPOVs(joystickNum, &povs);
 
-  jshortArray povsArray = env->NewShortArray(povs.count);
+  jsize javaSize = env->GetArrayLength(povsArray);
+  if (povs.count > javaSize)
+  {
+    ThrowIllegalArgumentException(env, "Native array size larger then passed in java array size");
+  }
+
   env->SetShortArrayRegion(povsArray, 0, povs.count, povs.povs);
 
-  return povsArray;
+  return povs.count;
 }
 
 /*

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/communication/FRCNetworkCommunicationsLibrary.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/communication/FRCNetworkCommunicationsLibrary.java
@@ -224,10 +224,10 @@ public class FRCNetworkCommunicationsLibrary extends JNIWrapper {
 
   public static int kMaxJoystickAxes = 12;
   public static int kMaxJoystickPOVs = 12;
+  
+  public static native byte HALGetJoystickAxes(byte joystickNum, short[] axesArray);
 
-  public static native short[] HALGetJoystickAxes(byte joystickNum);
-
-  public static native short[] HALGetJoystickPOVs(byte joystickNum);
+  public static native byte HALGetJoystickPOVs(byte joystickNum, short[] povsArray);
 
   public static native int HALGetJoystickButtons(byte joystickNum, ByteBuffer count);
 


### PR DESCRIPTION
Before, C++ had no locking on the driver station storage variables. That has been added. In addition, the data is no double buffered. This means that the 5ms that the DS loop used to take out of the main robot loop does not happen anymore.