### PR TITLE
Changes HAL to return -1 to 1 for joysticks

### DIFF
--- a/hal/include/HAL/HAL.hpp
+++ b/hal/include/HAL/HAL.hpp
@@ -174,7 +174,7 @@ static const size_t kMaxJoystickPOVs = 12;
 
 struct HALJoystickAxes {
   uint16_t count;
-  int16_t axes[kMaxJoystickAxes];
+  float axes[kMaxJoystickAxes];
 };
 
 struct HALJoystickPOVs {

--- a/wpilibc/Athena/src/DriverStation.cpp
+++ b/wpilibc/Athena/src/DriverStation.cpp
@@ -303,14 +303,8 @@ float DriverStation::GetStickAxis(uint32_t stick, uint32_t axis) {
           "Joystick Axis missing, check if all controllers are plugged in");
     return 0.0f;
   }
-
-  int8_t value = m_joystickAxes[stick].axes[axis];
-
-  if (value < 0) {
-    return value / 128.0f;
-  } else {
-    return value / 127.0f;
-  }
+  
+  return m_joystickAxes[stick].axes[axis];
 }
 
 /**

--- a/wpilibj/src/athena/cpp/lib/FRCNetworkCommunicationsLibrary.cpp
+++ b/wpilibj/src/athena/cpp/lib/FRCNetworkCommunicationsLibrary.cpp
@@ -146,7 +146,7 @@ Java_edu_wpi_first_wpilibj_communication_FRCNetworkCommunicationsLibrary_NativeH
  */
 JNIEXPORT jbyte JNICALL
 Java_edu_wpi_first_wpilibj_communication_FRCNetworkCommunicationsLibrary_HALGetJoystickAxes(
-    JNIEnv * env, jclass, jbyte joystickNum, jshortArray axesArray) {
+    JNIEnv * env, jclass, jbyte joystickNum, jfloatArray axesArray) {
   NETCOMM_LOG(logDEBUG) << "Calling HALJoystickAxes";
   HALJoystickAxes axes;
   HALGetJoystickAxes(joystickNum, &axes);
@@ -157,7 +157,7 @@ Java_edu_wpi_first_wpilibj_communication_FRCNetworkCommunicationsLibrary_HALGetJ
     ThrowIllegalArgumentException(env, "Native array size larger then passed in java array size");
   }
 
-  env->SetShortArrayRegion(axesArray, 0, axes.count, axes.axes);
+  env->SetFloatArrayRegion(axesArray, 0, axes.count, axes.axes);
 
   return axes.count;
 }

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -31,11 +31,11 @@ public class DriverStation implements RobotState.Interface {
   }
 
   private class HALJoystickAxes {
-    public short[] m_axes;
+    public float[] m_axes;
     public byte m_count;
 
     public HALJoystickAxes(int count) {
-      m_axes = new short[count];
+      m_axes = new float[count];
     }
   }
 

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/communication/FRCNetworkCommunicationsLibrary.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/communication/FRCNetworkCommunicationsLibrary.java
@@ -224,8 +224,8 @@ public class FRCNetworkCommunicationsLibrary extends JNIWrapper {
 
   public static int kMaxJoystickAxes = 12;
   public static int kMaxJoystickPOVs = 12;
-  
-  public static native byte HALGetJoystickAxes(byte joystickNum, short[] axesArray);
+
+  public static native byte HALGetJoystickAxes(byte joystickNum, float[] axesArray);
 
   public static native byte HALGetJoystickPOVs(byte joystickNum, short[] povsArray);
 


### PR DESCRIPTION
First part of the HAL changes. Returns -1 to 1 for joysticks instead of -128 to 127. Implemented by adding a new buffer type, and still keeping an old buffer instance. This saves allocations, at least in C++.

Sorry about the multiple commits. Dependent on #25, and that commit will go away then that gets rebased.