### PR TITLE
Explicitly stops the PIDController Notifier before the destruction of the class

### DIFF
--- a/wpilibc/athena/src/PIDController.cpp
+++ b/wpilibc/athena/src/PIDController.cpp
@@ -78,6 +78,8 @@ void PIDController::Initialize(float Kp, float Ki, float Kd, float Kf,
 }
 
 PIDController::~PIDController() {
+  //forcefully stopping the notifier so the callback can successfully run. 
+  m_controlLoop->Stop();
   if (m_table != nullptr) m_table->RemoveTableListener(this);
 }
 


### PR DESCRIPTION
Testing to see if that could be the cause of the PID Controller SegFault.