### PR TITLE
Removed sync group from SpeedController interface

### DIFF
--- a/wpilibc/athena/include/CANJaguar.h
+++ b/wpilibc/athena/include/CANJaguar.h
@@ -92,9 +92,11 @@ class CANJaguar : public MotorSafety,
   void SetVoltageMode(QuadEncoderStruct, uint16_t codesPerRev);
   void SetVoltageMode(PotentiometerStruct);
 
+  void Set(float value, uint8_t syncGroup);
+
   // CANSpeedController interface
   virtual float Get() const override;
-  virtual void Set(float value, uint8_t syncGroup = 0) override;
+  virtual void Set(float value) override;
   virtual void Disable() override;
   virtual void SetP(double p) override;
   virtual void SetI(double i) override;

--- a/wpilibc/athena/include/CANSpeedController.h
+++ b/wpilibc/athena/include/CANSpeedController.h
@@ -64,7 +64,7 @@ class CANSpeedController : public SpeedController {
   };
 
   virtual float Get() const = 0;
-  virtual void Set(float value, uint8_t syncGroup = 0) = 0;
+  virtual void Set(float value) = 0;
   virtual void StopMotor() = 0;
   virtual void Disable() = 0;
   virtual void SetP(double p) = 0;

--- a/wpilibc/athena/include/CANTalon.h
+++ b/wpilibc/athena/include/CANTalon.h
@@ -242,7 +242,7 @@ class CANTalon : public MotorSafety,
 
   // CANSpeedController interface
   virtual float Get() const override;
-  virtual void Set(float value, uint8_t syncGroup = 0) override;
+  virtual void Set(float value) override;
   virtual void Reset() override;
   virtual void SetSetpoint(float value) override;
   virtual void Disable() override;

--- a/wpilibc/athena/include/PWMSpeedController.h
+++ b/wpilibc/athena/include/PWMSpeedController.h
@@ -16,7 +16,7 @@
 class PWMSpeedController : public SafePWM, public SpeedController {
  public:
   virtual ~PWMSpeedController() = default;
-  virtual void Set(float value, uint8_t syncGroup = 0) override;
+  virtual void Set(float value) override;
   virtual float Get() const override;
   virtual void Disable() override;
   virtual void StopMotor() override;

--- a/wpilibc/athena/include/RobotDrive.h
+++ b/wpilibc/athena/include/RobotDrive.h
@@ -87,7 +87,6 @@ class RobotDrive : public MotorSafety, public ErrorBase {
   void SetInvertedMotor(MotorType motor, bool isInverted);
   void SetSensitivity(float sensitivity);
   void SetMaxOutput(double maxOutput);
-  void SetCANJaguarSyncGroup(uint8_t syncGroup);
 
   void SetExpiration(float timeout) override;
   float GetExpiration() const override;
@@ -111,7 +110,6 @@ class RobotDrive : public MotorSafety, public ErrorBase {
   std::shared_ptr<SpeedController> m_rearLeftMotor;
   std::shared_ptr<SpeedController> m_rearRightMotor;
   std::unique_ptr<MotorSafetyHelper> m_safetyHelper;
-  uint8_t m_syncGroup = 0;
 
  private:
   int32_t GetNumMotors() {

--- a/wpilibc/athena/include/SpeedController.h
+++ b/wpilibc/athena/include/SpeedController.h
@@ -20,10 +20,8 @@ class SpeedController : public PIDOutput {
    * Common interface for setting the speed of a speed controller.
    *
    * @param speed The speed to set.  Value should be between -1.0 and 1.0.
-   * @param syncGroup The update group to add this Set() to, pending
-   * UpdateSyncGroup().  If 0, update immediately.
    */
-  virtual void Set(float speed, uint8_t syncGroup = 0) = 0;
+  virtual void Set(float speed) = 0;
 
   /**
    * Common interface for getting the current set speed of a speed controller.

--- a/wpilibc/athena/src/CANJaguar.cpp
+++ b/wpilibc/athena/src/CANJaguar.cpp
@@ -1524,6 +1524,23 @@ void CANJaguar::SetVoltageMode(CANJaguar::PotentiometerStruct) {
 }
 
 /**
+ * Sets the output set-point value.
+ *
+ * The scale and the units depend on the mode the Jaguar is in.
+ * <p>In percentVbus Mode, the outputValue is from -1.0 to 1.0 (same as PWM
+ * Jaguar).
+ * <p>In voltage Mode, the outputValue is in volts.
+ * <p>In current Mode, the outputValue is in amps.
+ * <p>In speed Mode, the outputValue is in rotations/minute.
+ * <p>In position Mode, the outputValue is in rotations.
+ *
+ * @param outputValue The set-point to sent to the motor controller.
+ */
+void CANJaguar::Set(float outputValue) {
+  Set(outputValue, 0);
+}
+
+/**
  * Used internally. In order to set the control mode see the methods listed
  * below.
  *

--- a/wpilibc/athena/src/CANTalon.cpp
+++ b/wpilibc/athena/src/CANTalon.cpp
@@ -132,7 +132,7 @@ float CANTalon::Get() const {
  * @param outputValue The setpoint value, as described above.
  * @see SelectProfileSlot to choose between the two sets of gains.
  */
-void CANTalon::Set(float value, uint8_t syncGroup) {
+void CANTalon::Set(float value) {
   /* feed safety helper since caller just updated our output */
   m_safetyHelper->Feed();
 

--- a/wpilibc/athena/src/PWMSpeedController.cpp
+++ b/wpilibc/athena/src/PWMSpeedController.cpp
@@ -21,10 +21,9 @@ PWMSpeedController::PWMSpeedController(uint32_t channel) : SafePWM(channel) {}
  * The PWM value is set using a range of -1.0 to 1.0, appropriately
  * scaling the value for the FPGA.
  *
- * @param speed     The speed value between -1.0 and 1.0 to set.
- * @param syncGroup Unused interface.
+ * @param speed The speed value between -1.0 and 1.0 to set.
  */
-void PWMSpeedController::Set(float speed, uint8_t syncGroup) {
+void PWMSpeedController::Set(float speed) {
   SetSpeed(m_isInverted ? -speed : speed);
 }
 

--- a/wpilibc/athena/src/RobotDrive.cpp
+++ b/wpilibc/athena/src/RobotDrive.cpp
@@ -8,7 +8,6 @@
 #include "RobotDrive.h"
 
 #include <math.h>
-#include "CANJaguar.h"
 #include "GenericHID.h"
 #include "Joystick.h"
 #include "Talon.h"
@@ -522,17 +521,10 @@ void RobotDrive::MecanumDrive_Cartesian(float x, float y, float rotation,
 
   Normalize(wheelSpeeds);
 
-  m_frontLeftMotor->Set(wheelSpeeds[kFrontLeftMotor] * m_maxOutput,
-                        m_syncGroup);
-  m_frontRightMotor->Set(wheelSpeeds[kFrontRightMotor] * m_maxOutput,
-                         m_syncGroup);
-  m_rearLeftMotor->Set(wheelSpeeds[kRearLeftMotor] * m_maxOutput, m_syncGroup);
-  m_rearRightMotor->Set(wheelSpeeds[kRearRightMotor] * m_maxOutput,
-                        m_syncGroup);
-
-  if (m_syncGroup != 0) {
-    CANJaguar::UpdateSyncGroup(m_syncGroup);
-  }
+  m_frontLeftMotor->Set(wheelSpeeds[kFrontLeftMotor] * m_maxOutput);
+  m_frontRightMotor->Set(wheelSpeeds[kFrontRightMotor] * m_maxOutput);
+  m_rearLeftMotor->Set(wheelSpeeds[kRearLeftMotor] * m_maxOutput);
+  m_rearRightMotor->Set(wheelSpeeds[kRearRightMotor] * m_maxOutput);
 
   m_safetyHelper->Feed();
 }
@@ -578,17 +570,10 @@ void RobotDrive::MecanumDrive_Polar(float magnitude, float direction,
 
   Normalize(wheelSpeeds);
 
-  m_frontLeftMotor->Set(wheelSpeeds[kFrontLeftMotor] * m_maxOutput,
-                        m_syncGroup);
-  m_frontRightMotor->Set(wheelSpeeds[kFrontRightMotor] * m_maxOutput,
-                         m_syncGroup);
-  m_rearLeftMotor->Set(wheelSpeeds[kRearLeftMotor] * m_maxOutput, m_syncGroup);
-  m_rearRightMotor->Set(wheelSpeeds[kRearRightMotor] * m_maxOutput,
-                        m_syncGroup);
-
-  if (m_syncGroup != 0) {
-    CANJaguar::UpdateSyncGroup(m_syncGroup);
-  }
+  m_frontLeftMotor->Set(wheelSpeeds[kFrontLeftMotor] * m_maxOutput);
+  m_frontRightMotor->Set(wheelSpeeds[kFrontRightMotor] * m_maxOutput);
+  m_rearLeftMotor->Set(wheelSpeeds[kRearLeftMotor] * m_maxOutput);
+  m_rearRightMotor->Set(wheelSpeeds[kRearRightMotor] * m_maxOutput);
 
   m_safetyHelper->Feed();
 }
@@ -624,16 +609,12 @@ void RobotDrive::SetLeftRightMotorOutputs(float leftOutput, float rightOutput) {
   wpi_assert(m_rearLeftMotor != nullptr && m_rearRightMotor != nullptr);
 
   if (m_frontLeftMotor != nullptr)
-    m_frontLeftMotor->Set(Limit(leftOutput) * m_maxOutput, m_syncGroup);
-  m_rearLeftMotor->Set(Limit(leftOutput) * m_maxOutput, m_syncGroup);
+    m_frontLeftMotor->Set(Limit(leftOutput) * m_maxOutput);
+  m_rearLeftMotor->Set(Limit(leftOutput) * m_maxOutput);
 
   if (m_frontRightMotor != nullptr)
-    m_frontRightMotor->Set(-Limit(rightOutput) * m_maxOutput, m_syncGroup);
-  m_rearRightMotor->Set(-Limit(rightOutput) * m_maxOutput, m_syncGroup);
-
-  if (m_syncGroup != 0) {
-    CANJaguar::UpdateSyncGroup(m_syncGroup);
-  }
+    m_frontRightMotor->Set(-Limit(rightOutput) * m_maxOutput);
+  m_rearRightMotor->Set(-Limit(rightOutput) * m_maxOutput);
 
   m_safetyHelper->Feed();
 }
@@ -731,17 +712,6 @@ void RobotDrive::SetSensitivity(float sensitivity) {
  *                  functions.
  */
 void RobotDrive::SetMaxOutput(double maxOutput) { m_maxOutput = maxOutput; }
-
-/**
- * Set the number of the sync group for the motor controllers.  If the motor
- * controllers are {@link CANJaguar}s, then they will all be added to this sync
- * group, causing them to update their values at the same time.
- *
- * @param syncGroup the update group to add the motor controllers to
- */
-void RobotDrive::SetCANJaguarSyncGroup(uint8_t syncGroup) {
-  m_syncGroup = syncGroup;
-}
 
 void RobotDrive::SetExpiration(float timeout) {
   m_safetyHelper->SetExpiration(timeout);

--- a/wpilibc/sim/include/Jaguar.h
+++ b/wpilibc/sim/include/Jaguar.h
@@ -18,7 +18,7 @@ class Jaguar : public SafePWM, public SpeedController {
  public:
   explicit Jaguar(uint32_t channel);
   virtual ~Jaguar() = default;
-  virtual void Set(float value, uint8_t syncGroup = 0);
+  virtual void Set(float value);
   virtual float Get() const;
   virtual void Disable();
 

--- a/wpilibc/sim/include/SpeedController.h
+++ b/wpilibc/sim/include/SpeedController.h
@@ -18,11 +18,9 @@ class SpeedController : public PIDOutput {
   /**
    * Common interface for setting the speed of a speed controller.
    *
-   * @param speed     The speed to set.  Value should be between -1.0 and 1.0.
-   * @param syncGroup The update group to add this Set() to, pending
-   *                  UpdateSyncGroup().  If 0, update immediately.
+   * @param speed The speed to set.  Value should be between -1.0 and 1.0.
    */
-  virtual void Set(float speed, uint8_t syncGroup = 0) = 0;
+  virtual void Set(float speed) = 0;
   /**
    * Common interface for getting the current set speed of a speed controller.
    *

--- a/wpilibc/sim/include/Talon.h
+++ b/wpilibc/sim/include/Talon.h
@@ -18,7 +18,7 @@ class Talon : public SafePWM, public SpeedController {
  public:
   explicit Talon(uint32_t channel);
   virtual ~Talon() = default;
-  virtual void Set(float value, uint8_t syncGroup = 0);
+  virtual void Set(float value);
   virtual float Get() const;
   virtual void Disable();
 

--- a/wpilibc/sim/include/Victor.h
+++ b/wpilibc/sim/include/Victor.h
@@ -18,7 +18,7 @@ class Victor : public SafePWM, public SpeedController {
  public:
   explicit Victor(uint32_t channel);
   virtual ~Victor() = default;
-  virtual void Set(float value, uint8_t syncGroup = 0);
+  virtual void Set(float value);
   virtual float Get() const;
   virtual void Disable();
 

--- a/wpilibc/sim/src/Jaguar.cpp
+++ b/wpilibc/sim/src/Jaguar.cpp
@@ -35,10 +35,9 @@ Jaguar::Jaguar(uint32_t channel) : SafePWM(channel) {
  * The PWM value is set using a range of -1.0 to 1.0, appropriately
  * scaling the value for the FPGA.
  *
- * @param speed     The speed value between -1.0 and 1.0 to set.
- * @param syncGroup Unused interface.
+ * @param speed The speed value between -1.0 and 1.0 to set.
  */
-void Jaguar::Set(float speed, uint8_t syncGroup) { SetSpeed(speed); }
+void Jaguar::Set(float speed) { SetSpeed(speed); }
 
 /**
  * Get the recently set value of the PWM.

--- a/wpilibc/sim/src/RobotDrive.cpp
+++ b/wpilibc/sim/src/RobotDrive.cpp
@@ -506,22 +506,14 @@ void RobotDrive::MecanumDrive_Cartesian(float x, float y, float rotation,
 
   Normalize(wheelSpeeds);
 
-  uint8_t syncGroup = 0x80;
-
   m_frontLeftMotor->Set(wheelSpeeds[kFrontLeftMotor] *
-                            m_invertedMotors[kFrontLeftMotor] * m_maxOutput,
-                        syncGroup);
+                            m_invertedMotors[kFrontLeftMotor] * m_maxOutput);
   m_frontRightMotor->Set(wheelSpeeds[kFrontRightMotor] *
-                             m_invertedMotors[kFrontRightMotor] * m_maxOutput,
-                         syncGroup);
+                             m_invertedMotors[kFrontRightMotor] * m_maxOutput);
   m_rearLeftMotor->Set(wheelSpeeds[kRearLeftMotor] *
-                           m_invertedMotors[kRearLeftMotor] * m_maxOutput,
-                       syncGroup);
+                           m_invertedMotors[kRearLeftMotor] * m_maxOutput);
   m_rearRightMotor->Set(wheelSpeeds[kRearRightMotor] *
-                            m_invertedMotors[kRearRightMotor] * m_maxOutput,
-                        syncGroup);
-
-  // CANJaguar::UpdateSyncGroup(syncGroup);
+                            m_invertedMotors[kRearRightMotor] * m_maxOutput);
 
   // FIXME: m_safetyHelper->Feed();
 }
@@ -564,22 +556,14 @@ void RobotDrive::MecanumDrive_Polar(float magnitude, float direction,
 
   Normalize(wheelSpeeds);
 
-  uint8_t syncGroup = 0x80;
-
   m_frontLeftMotor->Set(wheelSpeeds[kFrontLeftMotor] *
-                            m_invertedMotors[kFrontLeftMotor] * m_maxOutput,
-                        syncGroup);
+                            m_invertedMotors[kFrontLeftMotor] * m_maxOutput);
   m_frontRightMotor->Set(wheelSpeeds[kFrontRightMotor] *
-                             m_invertedMotors[kFrontRightMotor] * m_maxOutput,
-                         syncGroup);
+                             m_invertedMotors[kFrontRightMotor] * m_maxOutput);
   m_rearLeftMotor->Set(wheelSpeeds[kRearLeftMotor] *
-                           m_invertedMotors[kRearLeftMotor] * m_maxOutput,
-                       syncGroup);
+                           m_invertedMotors[kRearLeftMotor] * m_maxOutput);
   m_rearRightMotor->Set(wheelSpeeds[kRearRightMotor] *
-                            m_invertedMotors[kRearRightMotor] * m_maxOutput,
-                        syncGroup);
-
-  // CANJaguar::UpdateSyncGroup(syncGroup);
+                            m_invertedMotors[kRearRightMotor] * m_maxOutput);
 
   // FIXME: m_safetyHelper->Feed();
 }
@@ -614,25 +598,17 @@ void RobotDrive::HolonomicDrive(float magnitude, float direction,
 void RobotDrive::SetLeftRightMotorOutputs(float leftOutput, float rightOutput) {
   wpi_assert(m_rearLeftMotor != nullptr && m_rearRightMotor != nullptr);
 
-  uint8_t syncGroup = 0x80;
-
   if (m_frontLeftMotor != nullptr)
     m_frontLeftMotor->Set(
-        Limit(leftOutput) * m_invertedMotors[kFrontLeftMotor] * m_maxOutput,
-        syncGroup);
+        Limit(leftOutput) * m_invertedMotors[kFrontLeftMotor] * m_maxOutput);
   m_rearLeftMotor->Set(
-      Limit(leftOutput) * m_invertedMotors[kRearLeftMotor] * m_maxOutput,
-      syncGroup);
+      Limit(leftOutput) * m_invertedMotors[kRearLeftMotor] * m_maxOutput);
 
   if (m_frontRightMotor != nullptr)
     m_frontRightMotor->Set(
-        -Limit(rightOutput) * m_invertedMotors[kFrontRightMotor] * m_maxOutput,
-        syncGroup);
+        -Limit(rightOutput) * m_invertedMotors[kFrontRightMotor] * m_maxOutput);
   m_rearRightMotor->Set(
-      -Limit(rightOutput) * m_invertedMotors[kRearRightMotor] * m_maxOutput,
-      syncGroup);
-
-  // CANJaguar::UpdateSyncGroup(syncGroup);
+      -Limit(rightOutput) * m_invertedMotors[kRearRightMotor] * m_maxOutput);
 
   // FIXME: m_safetyHelper->Feed();
 }

--- a/wpilibc/sim/src/Talon.cpp
+++ b/wpilibc/sim/src/Talon.cpp
@@ -40,10 +40,9 @@ Talon::Talon(uint32_t channel) : SafePWM(channel) {
  * The PWM value is set using a range of -1.0 to 1.0, appropriately
  * scaling the value for the FPGA.
  *
- * @param speed     The speed value between -1.0 and 1.0 to set.
- * @param syncGroup Unused interface.
+ * @param speed The speed value between -1.0 and 1.0 to set.
  */
-void Talon::Set(float speed, uint8_t syncGroup) { SetSpeed(speed); }
+void Talon::Set(float speed) { SetSpeed(speed); }
 
 /**
  * Get the recently set value of the PWM.

--- a/wpilibc/sim/src/Victor.cpp
+++ b/wpilibc/sim/src/Victor.cpp
@@ -42,10 +42,9 @@ Victor::Victor(uint32_t channel) : SafePWM(channel) {
  * The PWM value is set using a range of -1.0 to 1.0, appropriately
  * scaling the value for the FPGA.
  *
- * @param speed     The speed value between -1.0 and 1.0 to set.
- * @param syncGroup Unused interface.
+ * @param speed The speed value between -1.0 and 1.0 to set.
  */
-void Victor::Set(float speed, uint8_t syncGroup) { SetSpeed(speed); }
+void Victor::Set(float speed) { SetSpeed(speed); }
 
 /**
  * Get the recently set value of the PWM.

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/CANJaguar.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/CANJaguar.java
@@ -372,7 +372,6 @@ public class CANJaguar implements MotorSafety, PIDOutput, CANSpeedController {
    * @param syncGroup   The update group to add this set() to, pending UpdateSyncGroup(). If 0,
    *                    update immediately.
    */
-  @Override
   public void set(double outputValue, byte syncGroup) {
     int messageID;
     byte[] data = new byte[8];

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/CANTalon.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/CANTalon.java
@@ -418,17 +418,6 @@ public class CANTalon implements MotorSafety, PIDOutput, PIDSource, CANSpeedCont
   }
 
   /**
-   * Sets the output of the Talon.
-   *
-   * @param outputValue                See set().
-   * @param thisValueDoesNotDoAnything corresponds to syncGroup from Jaguar; not relevant here.
-   */
-  @Override
-  public void set(double outputValue, byte thisValueDoesNotDoAnything) {
-    set(outputValue);
-  }
-
-  /**
    * Sets the appropriate output on the talon, depending on the mode.
    *
    * <p>In PercentVbus, the output is between -1.0 and 1.0, with 0.0 as stopped. In Follower mode,

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/PWMSpeedController.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/PWMSpeedController.java
@@ -29,25 +29,6 @@ public abstract class PWMSpeedController extends SafePWM implements SpeedControl
    * <p>The PWM value is set using a range of -1.0 to 1.0, appropriately scaling the value for the
    * FPGA.
    *
-   * @param speed     The speed to set. Value should be between -1.0 and 1.0.
-   * @param syncGroup The update group to add this Set() to, pending UpdateSyncGroup(). If 0, update
-   *                  immediately.
-   * @deprecated For compatibility with CANJaguar
-   *
-   */
-  @Deprecated
-  @Override
-  public void set(double speed, byte syncGroup) {
-    setSpeed(m_isInverted ? -speed : speed);
-    Feed();
-  }
-
-  /**
-   * Set the PWM value.
-   *
-   * <p>The PWM value is set using a range of -1.0 to 1.0, appropriately scaling the value for the
-   * FPGA.
-   *
    * @param speed The speed value between -1.0 and 1.0 to set.
    */
   @Override

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/RobotDrive.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/RobotDrive.java
@@ -72,7 +72,6 @@ public class RobotDrive implements MotorSafety {
   protected SpeedController m_rearLeftMotor;
   protected SpeedController m_rearRightMotor;
   protected boolean m_allocatedSpeedControllers;
-  protected byte m_syncGroup = 0;
   protected static boolean kArcadeRatioCurve_Reported = false;
   protected static boolean kTank_Reported = false;
   protected static boolean kArcadeStandard_Reported = false;
@@ -503,14 +502,10 @@ public class RobotDrive implements MotorSafety {
     wheelSpeeds[MotorType.kRearRight_val] = xIn + yIn - rotation;
 
     normalize(wheelSpeeds);
-    m_frontLeftMotor.set(wheelSpeeds[MotorType.kFrontLeft_val] * m_maxOutput, m_syncGroup);
-    m_frontRightMotor.set(wheelSpeeds[MotorType.kFrontRight_val] * m_maxOutput, m_syncGroup);
-    m_rearLeftMotor.set(wheelSpeeds[MotorType.kRearLeft_val] * m_maxOutput, m_syncGroup);
-    m_rearRightMotor.set(wheelSpeeds[MotorType.kRearRight_val] * m_maxOutput, m_syncGroup);
-
-    if (m_syncGroup != 0) {
-      CANJaguar.updateSyncGroup(m_syncGroup);
-    }
+    m_frontLeftMotor.set(wheelSpeeds[MotorType.kFrontLeft_val] * m_maxOutput);
+    m_frontRightMotor.set(wheelSpeeds[MotorType.kFrontRight_val] * m_maxOutput);
+    m_rearLeftMotor.set(wheelSpeeds[MotorType.kRearLeft_val] * m_maxOutput);
+    m_rearRightMotor.set(wheelSpeeds[MotorType.kRearRight_val] * m_maxOutput);
 
     if (m_safetyHelper != null) {
       m_safetyHelper.feed();
@@ -551,14 +546,10 @@ public class RobotDrive implements MotorSafety {
 
     normalize(wheelSpeeds);
 
-    m_frontLeftMotor.set(wheelSpeeds[MotorType.kFrontLeft_val] * m_maxOutput, m_syncGroup);
-    m_frontRightMotor.set(wheelSpeeds[MotorType.kFrontRight_val] * m_maxOutput, m_syncGroup);
-    m_rearLeftMotor.set(wheelSpeeds[MotorType.kRearLeft_val] * m_maxOutput, m_syncGroup);
-    m_rearRightMotor.set(wheelSpeeds[MotorType.kRearRight_val] * m_maxOutput, m_syncGroup);
-
-    if (m_syncGroup != 0) {
-      CANJaguar.updateSyncGroup(m_syncGroup);
-    }
+    m_frontLeftMotor.set(wheelSpeeds[MotorType.kFrontLeft_val] * m_maxOutput);
+    m_frontRightMotor.set(wheelSpeeds[MotorType.kFrontRight_val] * m_maxOutput);
+    m_rearLeftMotor.set(wheelSpeeds[MotorType.kRearLeft_val] * m_maxOutput);
+    m_rearRightMotor.set(wheelSpeeds[MotorType.kRearRight_val] * m_maxOutput);
 
     if (m_safetyHelper != null) {
       m_safetyHelper.feed();
@@ -594,18 +585,14 @@ public class RobotDrive implements MotorSafety {
     }
 
     if (m_frontLeftMotor != null) {
-      m_frontLeftMotor.set(limit(leftOutput) * m_maxOutput, m_syncGroup);
+      m_frontLeftMotor.set(limit(leftOutput) * m_maxOutput);
     }
-    m_rearLeftMotor.set(limit(leftOutput) * m_maxOutput, m_syncGroup);
+    m_rearLeftMotor.set(limit(leftOutput) * m_maxOutput);
 
     if (m_frontRightMotor != null) {
-      m_frontRightMotor.set(-limit(rightOutput) * m_maxOutput, m_syncGroup);
+      m_frontRightMotor.set(-limit(rightOutput) * m_maxOutput);
     }
-    m_rearRightMotor.set(-limit(rightOutput) * m_maxOutput, m_syncGroup);
-
-    if (m_syncGroup != 0) {
-      CANJaguar.updateSyncGroup(m_syncGroup);
-    }
+    m_rearRightMotor.set(-limit(rightOutput) * m_maxOutput);
 
     if (m_safetyHelper != null) {
       m_safetyHelper.feed();
@@ -702,17 +689,6 @@ public class RobotDrive implements MotorSafety {
    */
   public void setMaxOutput(double maxOutput) {
     m_maxOutput = maxOutput;
-  }
-
-  /**
-   * Set the number of the sync group for the motor controllers. If the motor controllers are {@link
-   * CANJaguar}s, then they will all be added to this sync group, causing them to update their
-   * values at the same time.
-   *
-   * @param syncGroup the update group to add the motor controllers to
-   */
-  public void setCANJaguarSyncGroup(byte syncGroup) {
-    m_syncGroup = syncGroup;
   }
 
   /**

--- a/wpilibj/src/shared/java/edu/wpi/first/wpilibj/SpeedController.java
+++ b/wpilibj/src/shared/java/edu/wpi/first/wpilibj/SpeedController.java
@@ -22,15 +22,6 @@ public interface SpeedController extends PIDOutput {
   /**
    * Common interface for setting the speed of a speed controller.
    *
-   * @param speed     The speed to set. Value should be between -1.0 and 1.0.
-   * @param syncGroup The update group to add this Set() to, pending UpdateSyncGroup(). If 0, update
-   *                  immediately.
-   */
-  void set(double speed, byte syncGroup);
-
-  /**
-   * Common interface for setting the speed of a speed controller.
-   *
    * @param speed The speed to set. Value should be between -1.0 and 1.0.
    */
   void set(double speed);

--- a/wpilibj/src/sim/java/edu/wpi/first/wpilibj/Jaguar.java
+++ b/wpilibj/src/sim/java/edu/wpi/first/wpilibj/Jaguar.java
@@ -46,22 +46,6 @@ public class Jaguar implements SpeedController, PIDOutput, MotorSafety, LiveWind
   /**
    * Set the PWM value.
    *
-   * @param speed     The speed to set.  Value should be between -1.0 and 1.0.
-   * @param syncGroup The update group to add this Set() to, pending UpdateSyncGroup().  If 0,
-   *                  update immediately.
-   * @deprecated For compatibility with CANJaguar
-   *
-   * The PWM value is set using a range of -1.0 to 1.0, appropriately scaling the value for the
-   * FPGA.
-   */
-  @Deprecated
-  public void set(double speed, byte syncGroup) {
-    impl.set(speed, syncGroup);
-  }
-
-  /**
-   * Set the PWM value.
-   *
    * The PWM value is set using a range of -1.0 to 1.0, appropriately scaling the value for the
    * FPGA.
    *

--- a/wpilibj/src/sim/java/edu/wpi/first/wpilibj/RobotDrive.java
+++ b/wpilibj/src/sim/java/edu/wpi/first/wpilibj/RobotDrive.java
@@ -504,16 +504,14 @@ public class RobotDrive implements MotorSafety {
 
     normalize(wheelSpeeds);
 
-    byte syncGroup = (byte) 0x80;
-
     m_frontLeftMotor.set(wheelSpeeds[MotorType.kFrontLeft_val] * m_invertedMotors[MotorType
-        .kFrontLeft_val] * m_maxOutput, syncGroup);
+        .kFrontLeft_val] * m_maxOutput);
     m_frontRightMotor.set(wheelSpeeds[MotorType.kFrontRight_val] * m_invertedMotors[MotorType
-        .kFrontRight_val] * m_maxOutput, syncGroup);
+        .kFrontRight_val] * m_maxOutput);
     m_rearLeftMotor.set(wheelSpeeds[MotorType.kRearLeft_val] * m_invertedMotors[MotorType
-        .kRearLeft_val] * m_maxOutput, syncGroup);
+        .kRearLeft_val] * m_maxOutput);
     m_rearRightMotor.set(wheelSpeeds[MotorType.kRearRight_val] * m_invertedMotors[MotorType
-        .kRearRight_val] * m_maxOutput, syncGroup);
+        .kRearRight_val] * m_maxOutput);
 
     if (m_safetyHelper != null) m_safetyHelper.feed();
   }
@@ -551,16 +549,14 @@ public class RobotDrive implements MotorSafety {
 
     normalize(wheelSpeeds);
 
-    byte syncGroup = (byte) 0x80;
-
     m_frontLeftMotor.set(wheelSpeeds[MotorType.kFrontLeft_val] * m_invertedMotors[MotorType
-        .kFrontLeft_val] * m_maxOutput, syncGroup);
+        .kFrontLeft_val] * m_maxOutput);
     m_frontRightMotor.set(wheelSpeeds[MotorType.kFrontRight_val] * m_invertedMotors[MotorType
-        .kFrontRight_val] * m_maxOutput, syncGroup);
+        .kFrontRight_val] * m_maxOutput);
     m_rearLeftMotor.set(wheelSpeeds[MotorType.kRearLeft_val] * m_invertedMotors[MotorType
-        .kRearLeft_val] * m_maxOutput, syncGroup);
+        .kRearLeft_val] * m_maxOutput);
     m_rearRightMotor.set(wheelSpeeds[MotorType.kRearRight_val] * m_invertedMotors[MotorType
-        .kRearRight_val] * m_maxOutput, syncGroup);
+        .kRearRight_val] * m_maxOutput);
 
     if (m_safetyHelper != null) m_safetyHelper.feed();
   }
@@ -593,21 +589,19 @@ public class RobotDrive implements MotorSafety {
       throw new NullPointerException("Null motor provided");
     }
 
-    byte syncGroup = (byte) 0x80;
-
     if (m_frontLeftMotor != null) {
       m_frontLeftMotor.set(limit(leftOutput) * m_invertedMotors[MotorType.kFrontLeft_val] *
-          m_maxOutput, syncGroup);
+          m_maxOutput);
     }
     m_rearLeftMotor.set(limit(leftOutput) * m_invertedMotors[MotorType.kRearLeft_val] *
-        m_maxOutput, syncGroup);
+        m_maxOutput);
 
     if (m_frontRightMotor != null) {
       m_frontRightMotor.set(-limit(rightOutput) * m_invertedMotors[MotorType.kFrontRight_val] *
-          m_maxOutput, syncGroup);
+          m_maxOutput);
     }
     m_rearRightMotor.set(-limit(rightOutput) * m_invertedMotors[MotorType.kRearRight_val] *
-        m_maxOutput, syncGroup);
+        m_maxOutput);
 
     if (m_safetyHelper != null) m_safetyHelper.feed();
   }

--- a/wpilibj/src/sim/java/edu/wpi/first/wpilibj/Servo.java
+++ b/wpilibj/src/sim/java/edu/wpi/first/wpilibj/Servo.java
@@ -42,20 +42,6 @@ public class Servo implements SpeedController, LiveWindowSendable {
   }
 
   /**
-   * Set the PWM value.
-   *
-   * @param speed     The speed to set.  Value should be between -1.0 and 1.0.
-   * @param syncGroup The update group to add this Set() to, pending UpdateSyncGroup().  If 0,
-   *                  update immediately.
-   * @deprecated The PWM value is set using a range of -1.0 to 1.0, appropriately scaling the value
-   * for the FPGA.
-   */
-  @Deprecated
-  public void set(double speed, byte syncGroup) {
-    impl.set(speed, syncGroup);
-  }
-
-  /**
    * Write out the PID value as seen in the PIDOutput base object.
    *
    * @param output Write out the PWM value as was found in the PIDController

--- a/wpilibj/src/sim/java/edu/wpi/first/wpilibj/SpeedController.java
+++ b/wpilibj/src/sim/java/edu/wpi/first/wpilibj/SpeedController.java
@@ -22,15 +22,6 @@ public interface SpeedController extends PIDOutput {
   /**
    * Common interface for setting the speed of a speed controller.
    *
-   * @param speed     The speed to set.  Value should be between -1.0 and 1.0.
-   * @param syncGroup The update group to add this Set() to, pending UpdateSyncGroup().  If 0,
-   *                  update immediately.
-   */
-  void set(double speed, byte syncGroup);
-
-  /**
-   * Common interface for setting the speed of a speed controller.
-   *
    * @param speed The speed to set.  Value should be between -1.0 and 1.0.
    */
   void set(double speed);

--- a/wpilibj/src/sim/java/edu/wpi/first/wpilibj/Talon.java
+++ b/wpilibj/src/sim/java/edu/wpi/first/wpilibj/Talon.java
@@ -59,22 +59,6 @@ public class Talon implements SpeedController, PIDOutput, MotorSafety, LiveWindo
    * <p>The PWM value is set using a range of -1.0 to 1.0, appropriately scaling the value for the
    * FPGA.
    *
-   * @param speed     The speed to set.  Value should be between -1.0 and 1.0.
-   * @param syncGroup The update group to add this Set() to, pending UpdateSyncGroup().  If 0,
-   *                  update immediately.
-   * @deprecated For compatibility with CANJaguar
-   */
-  @Deprecated
-  public void set(double speed, byte syncGroup) {
-    m_impl.set(speed, syncGroup);
-  }
-
-  /**
-   * Set the PWM value.
-   *
-   * <p>The PWM value is set using a range of -1.0 to 1.0, appropriately scaling the value for the
-   * FPGA.
-   *
    * @param speed The speed value between -1.0 and 1.0 to set.
    */
   public void set(double speed) {

--- a/wpilibj/src/sim/java/edu/wpi/first/wpilibj/Victor.java
+++ b/wpilibj/src/sim/java/edu/wpi/first/wpilibj/Victor.java
@@ -61,22 +61,6 @@ public class Victor implements SpeedController, PIDOutput, MotorSafety, LiveWind
    * <p>The PWM value is set using a range of -1.0 to 1.0, appropriately scaling the value for the
    * FPGA.
    *
-   * @param speed     The speed to set.  Value should be between -1.0 and 1.0.
-   * @param syncGroup The update group to add this Set() to, pending UpdateSyncGroup().  If 0,
-   *                  update immediately.
-   * @deprecated For compatibility with CANJaguar.
-   */
-  @Deprecated
-  public void set(double speed, byte syncGroup) {
-    m_impl.set(speed, syncGroup);
-  }
-
-  /**
-   * Set the PWM value.
-   *
-   * <p>The PWM value is set using a range of -1.0 to 1.0, appropriately scaling the value for the
-   * FPGA.
-   *
    * @param speed The speed value between -1.0 and 1.0 to set.
    */
   public void set(double speed) {


### PR DESCRIPTION
CANJaguar is the only motor controller using sync groups, so that feature doesn't belong in an interface used by all motor controllers. If teams want to use sync groups, they should cast to the appropriate motor controller type themselves.