### PR TITLE
Merge this once FRCUserProgram is given CAP_SYS_NICE capability by Eclipse deploy

### DIFF
--- a/wpilibcIntegrationTests/src/FRCUserProgram/cpp/MutexTest.cpp
+++ b/wpilibcIntegrationTests/src/FRCUserProgram/cpp/MutexTest.cpp
@@ -222,10 +222,8 @@ class InversionTestRunner {
   bool m_success = false;
 };
 
-// TODO: Fix roborio permissions to run as root.
-
 // Priority inversion test.
-TEST(MutexTest, DISABLED_PriorityInversionTest) {
+TEST(MutexTest, PriorityInversionTest) {
   InversionTestRunner<hal::priority_mutex> runner;
   std::thread runner_thread(std::ref(runner));
   runner_thread.join();
@@ -233,7 +231,7 @@ TEST(MutexTest, DISABLED_PriorityInversionTest) {
 }
 
 // Verify that the non-priority inversion mutex doesn't pass the test.
-TEST(MutexTest, DISABLED_StdMutexPriorityInversionTest) {
+TEST(MutexTest, StdMutexPriorityInversionTest) {
   InversionTestRunner<std::mutex> runner;
   std::thread runner_thread(std::ref(runner));
   runner_thread.join();
@@ -250,7 +248,7 @@ TEST(MutexTest, TryLock) {
 }
 
 // Priority inversion test.
-TEST(MutexTest, DISABLED_ReentrantPriorityInversionTest) {
+TEST(MutexTest, ReentrantPriorityInversionTest) {
   InversionTestRunner<hal::priority_recursive_mutex> runner;
   std::thread runner_thread(std::ref(runner));
   runner_thread.join();


### PR DESCRIPTION
With the CAP_SYS_NICE capability provided by calling setcap, FRCUserProgram can set real-time priorities. The Task class setting a default real-time priority in its constructor has been reenabled as well as the relevant mutex priority inversion tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wpilibsuite/allwpilib/74)

<!-- Reviewable:end -->
