### PR TITLE
Command::IsFinished() is now const qualified

### DIFF
--- a/wpilibc/shared/include/Commands/Command.h
+++ b/wpilibc/shared/include/Commands/Command.h
@@ -98,7 +98,7 @@ class Command : public ErrorBase, public NamedSendable, public ITableListener {
    * @return whether this command is finished.
    * @see Command#isTimedOut() isTimedOut()
    */
-  virtual bool IsFinished() = 0;
+  virtual bool IsFinished() const = 0;
   /**
    * Called when the command ended peacefully.  This is where you may want
    * to wrap up loose ends, like shutting off a motor that was being used

--- a/wpilibc/shared/include/Commands/CommandGroup.h
+++ b/wpilibc/shared/include/Commands/CommandGroup.h
@@ -48,7 +48,7 @@ class CommandGroup : public Command {
  protected:
   virtual void Initialize();
   virtual void Execute();
-  virtual bool IsFinished();
+  virtual bool IsFinished() const;
   virtual void End();
   virtual void Interrupted();
   virtual void _Initialize();

--- a/wpilibc/shared/src/Commands/CommandGroup.cpp
+++ b/wpilibc/shared/src/Commands/CommandGroup.cpp
@@ -272,7 +272,7 @@ void CommandGroup::End() {}
 // Can be overwritten by teams
 void CommandGroup::Interrupted() {}
 
-bool CommandGroup::IsFinished() {
+bool CommandGroup::IsFinished() const {
   return (unsigned)m_currentCommandIndex >= m_commands.size() &&
          m_children.empty();
 }

--- a/wpilibcIntegrationTests/include/command/MockCommand.h
+++ b/wpilibcIntegrationTests/include/command/MockCommand.h
@@ -13,7 +13,7 @@ class MockCommand : public Command {
  private:
   int m_initializeCount;
   int m_executeCount;
-  int m_isFinishedCount;
+  mutable int m_isFinishedCount;
   bool m_hasFinished;
   int m_endCount;
   int m_interruptedCount;
@@ -21,7 +21,7 @@ class MockCommand : public Command {
  protected:
   virtual void Initialize();
   virtual void Execute();
-  virtual bool IsFinished();
+  virtual bool IsFinished() const;
   virtual void End();
   virtual void Interrupted();
 
@@ -32,7 +32,7 @@ class MockCommand : public Command {
 
   int GetExecuteCount() { return m_executeCount; }
   int GetIsFinishedCount() { return m_isFinishedCount; }
-  bool IsHasFinished() { return m_hasFinished; }
+  bool IsHasFinished() const { return m_hasFinished; }
   void SetHasFinished(bool hasFinished) { m_hasFinished = hasFinished; }
   int GetEndCount() { return m_endCount; }
   bool HasEnd();

--- a/wpilibcIntegrationTests/src/command/CommandTest.cpp
+++ b/wpilibcIntegrationTests/src/command/CommandTest.cpp
@@ -320,7 +320,7 @@ TEST_F(CommandTest,
 class ModifiedMockCommand : public MockCommand {
  public:
   ModifiedMockCommand() : MockCommand() { SetTimeout(2.0); }
-  bool IsFinished() override {
+  bool IsFinished() const override {
     return MockCommand::IsFinished() || IsTimedOut();
   }
 };

--- a/wpilibcIntegrationTests/src/command/MockCommand.cpp
+++ b/wpilibcIntegrationTests/src/command/MockCommand.cpp
@@ -20,7 +20,7 @@ void MockCommand::Initialize() { ++m_initializeCount; }
 
 void MockCommand::Execute() { ++m_executeCount; }
 
-bool MockCommand::IsFinished() {
+bool MockCommand::IsFinished() const {
   ++m_isFinishedCount;
   return IsHasFinished();
 }


### PR DESCRIPTION
This could potentially break things depending on how teams are using Command::IsFinished().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wpilibsuite/allwpilib/75)
<!-- Reviewable:end -->
