### PR TITLE
Add Travis Badge to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WPILib Project
 
+[![Build Status](https://travis-ci.org/wpilibsuite/allwpilib.svg?branch=master)](https://travis-ci.org/wpilibsuite/allwpilib)
+
 Welcome to the WPILib project. This repository contains the HAL, WPILibJ, and WPILibC projcts. These are the core libraries for creating robot programs for the roboRIO.
 
 - [WPILib Mission](#wpilib-mission)


### PR DESCRIPTION
This provides a quick navigation link to our travis build.
Additionally, it makes it so that the master build status can be confirmed quickly.