### PR TITLE
Replaced .h C headers with c-prefixed version and added std:: prefix to C standard library usage

### DIFF
--- a/hal/include/HAL/HAL.h
+++ b/hal/include/HAL/HAL.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <math.h>
 #include <stdint.h>
 
 #include "Accelerometer.h"
@@ -205,10 +204,6 @@ struct HALJoystickDescriptor {
   uint8_t buttonCount;
   uint8_t povCount;
 };
-
-inline float intToFloat(int value) { return (float)value; }
-
-inline int floatToInt(float value) { return round(value); }
 
 extern "C" {
 extern const uint32_t dio_kNumSystems;

--- a/hal/include/HAL/Interrupts.h
+++ b/hal/include/HAL/Interrupts.h
@@ -7,10 +7,7 @@
 
 #pragma once
 
-#include <errno.h>
 #include <stdint.h>
-
-#include <iostream>
 
 extern "C" {
 typedef void (*InterruptHandlerFunction)(uint32_t interruptAssertedMask,

--- a/hal/lib/athena/Accelerometer.cpp
+++ b/hal/lib/athena/Accelerometer.cpp
@@ -7,9 +7,10 @@
 
 #include "HAL/Accelerometer.h"
 
-#include <assert.h>
+#include <cassert>
+#include <cstdio>
+
 #include <stdint.h>
-#include <stdio.h>
 
 #include "ChipObject.h"
 
@@ -125,7 +126,7 @@ static void writeRegister(Register reg, uint8_t data) {
     if (getFPGATime(&status) > initialTime + 1000) break;
   }
 
-  fflush(stdout);
+  std::fflush(stdout);
 }
 
 static uint8_t readRegister(Register reg) {
@@ -155,7 +156,7 @@ static uint8_t readRegister(Register reg) {
     if (getFPGATime(&status) > initialTime + 1000) break;
   }
 
-  fflush(stdout);
+  std::fflush(stdout);
 
   return accel->readDATI(&status);
 }

--- a/hal/lib/athena/Compressor.cpp
+++ b/hal/lib/athena/Compressor.cpp
@@ -7,8 +7,6 @@
 
 #include "HAL/Compressor.h"
 
-#include <iostream>
-
 #include "ctre/PCM.h"
 
 static const int NUM_MODULE_NUMBERS = 63;

--- a/hal/lib/athena/DIO.cpp
+++ b/hal/lib/athena/DIO.cpp
@@ -7,7 +7,7 @@
 
 #include "HAL/DIO.h"
 
-#include <math.h>
+#include <cmath>
 
 #include "DigitalInternal.h"
 
@@ -100,7 +100,7 @@ void setPWMDutyCycle(void* pwmGenerator, double dutyCycle, int32_t* status) {
     if (pwmPeriodPower < 4) {
       // The resolution of the duty cycle drops close to the highest
       // frequencies.
-      rawDutyCycle = rawDutyCycle / pow(2.0, 4 - pwmPeriodPower);
+      rawDutyCycle = rawDutyCycle / std::pow(2.0, 4 - pwmPeriodPower);
     }
     if (id < 4)
       digitalSystem->writePWMDutyCycleA(id, (uint8_t)rawDutyCycle, status);

--- a/hal/lib/athena/DigitalInternal.cpp
+++ b/hal/lib/athena/DigitalInternal.cpp
@@ -7,9 +7,6 @@
 
 #include "DigitalInternal.h"
 
-#include <math.h>
-#include <stdio.h>
-
 #include <mutex>
 #include <thread>
 
@@ -65,10 +62,6 @@ void initializeDigital(int32_t* status) {
   while (pwmSystem->readLoopTiming(status) == 0) std::this_thread::yield();
 
   if (pwmSystem->readLoopTiming(status) != kExpectedLoopTiming) {
-    // TODO: char err[128];
-    // TODO: sprintf(err, "DIO LoopTiming: %d, expecting: %lu\n",
-    // digitalModules[port->module-1]->readLoopTiming(status),
-    // kExpectedLoopTiming);
     *status = LOOP_TIMING_ERROR;  // NOTE: Doesn't display the error
   }
 
@@ -81,7 +74,6 @@ void initializeDigital(int32_t* status) {
   uint16_t minHigh = (uint16_t)(
       (kDefaultPwmCenter - kDefaultPwmStepsDown * loopTime) / loopTime + .5);
   pwmSystem->writeConfig_MinHigh(minHigh, status);
-  //  printf("MinHigh: %d\n", minHigh);
   // Ensure that PWM output values are set to OFF
   for (uint32_t pwm_index = 0; pwm_index < kPwmPins; pwm_index++) {
     // Initialize port structure

--- a/hal/lib/athena/Notifier.cpp
+++ b/hal/lib/athena/Notifier.cpp
@@ -7,7 +7,8 @@
 
 #include "HAL/Notifier.h"
 
-#include <stdlib.h>
+// For std::atexit()
+#include <cstdlib>
 
 #include <atomic>
 #include <mutex>

--- a/wpilibc/athena/include/RobotDrive.h
+++ b/wpilibc/athena/include/RobotDrive.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <stdlib.h>
-
 #include <memory>
 #include <sstream>
 

--- a/wpilibc/athena/include/Vision/ImageBase.h
+++ b/wpilibc/athena/include/Vision/ImageBase.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <stdio.h>
-
 #include "ErrorBase.h"
 #include "nivision.h"
 

--- a/wpilibc/athena/src/CANJaguar.cpp
+++ b/wpilibc/athena/src/CANJaguar.cpp
@@ -7,8 +7,7 @@
 
 #include "CANJaguar.h"
 
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
 
 #include "FRC_NetworkCommunication/CANSessionMux.h"
 #include "HAL/HAL.h"

--- a/wpilibc/athena/src/CameraServer.cpp
+++ b/wpilibc/athena/src/CameraServer.cpp
@@ -8,11 +8,11 @@
 #include "CameraServer.h"
 
 #include <netdb.h>
-#include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 #include <chrono>
+#include <cstring>
 #include <iostream>
 
 #include "Utility.h"
@@ -170,7 +170,7 @@ void CameraServer::Serve() {
 
   sockaddr_in address, clientAddress;
 
-  memset(&address, 0, sizeof(address));
+  std::memset(&address, 0, sizeof(address));
   address.sin_family = AF_INET;
   address.sin_addr.s_addr = htonl(INADDR_ANY);
   address.sin_port = htons(kPort);

--- a/wpilibc/athena/src/DriverStation.cpp
+++ b/wpilibc/athena/src/DriverStation.cpp
@@ -383,7 +383,7 @@ bool DriverStation::GetStickButton(uint32_t stick, uint8_t button) {
  */
 bool DriverStation::IsEnabled() const {
   HALControlWord controlWord;
-  memset(&controlWord, 0, sizeof(controlWord));
+  std::memset(&controlWord, 0, sizeof(controlWord));
   HALGetControlWord(&controlWord);
   return controlWord.enabled && controlWord.dsAttached;
 }
@@ -395,7 +395,7 @@ bool DriverStation::IsEnabled() const {
  */
 bool DriverStation::IsDisabled() const {
   HALControlWord controlWord;
-  memset(&controlWord, 0, sizeof(controlWord));
+  std::memset(&controlWord, 0, sizeof(controlWord));
   HALGetControlWord(&controlWord);
   return !(controlWord.enabled && controlWord.dsAttached);
 }
@@ -407,7 +407,7 @@ bool DriverStation::IsDisabled() const {
  */
 bool DriverStation::IsAutonomous() const {
   HALControlWord controlWord;
-  memset(&controlWord, 0, sizeof(controlWord));
+  std::memset(&controlWord, 0, sizeof(controlWord));
   HALGetControlWord(&controlWord);
   return controlWord.autonomous;
 }
@@ -419,7 +419,7 @@ bool DriverStation::IsAutonomous() const {
  */
 bool DriverStation::IsOperatorControl() const {
   HALControlWord controlWord;
-  memset(&controlWord, 0, sizeof(controlWord));
+  std::memset(&controlWord, 0, sizeof(controlWord));
   HALGetControlWord(&controlWord);
   return !(controlWord.autonomous || controlWord.test);
 }
@@ -442,7 +442,7 @@ bool DriverStation::IsTest() const {
  */
 bool DriverStation::IsDSAttached() const {
   HALControlWord controlWord;
-  memset(&controlWord, 0, sizeof(controlWord));
+  std::memset(&controlWord, 0, sizeof(controlWord));
   HALGetControlWord(&controlWord);
   return controlWord.dsAttached;
 }

--- a/wpilibc/athena/src/MotorSafetyHelper.cpp
+++ b/wpilibc/athena/src/MotorSafetyHelper.cpp
@@ -7,13 +7,12 @@
 
 #include "MotorSafetyHelper.h"
 
+#include <sstream>
+
 #include "DriverStation.h"
 #include "MotorSafety.h"
 #include "Timer.h"
 #include "WPIErrors.h"
-
-#include <stdio.h>
-#include <sstream>
 
 std::set<MotorSafetyHelper*> MotorSafetyHelper::m_helperList;
 priority_recursive_mutex MotorSafetyHelper::m_listMutex;

--- a/wpilibc/athena/src/PWM.cpp
+++ b/wpilibc/athena/src/PWM.cpp
@@ -162,12 +162,7 @@ void PWM::SetPosition(float pos) {
   // converting to int
   unsigned short rawValue =
       (int32_t)((pos * (float)GetFullRangeScaleFactor()) + GetMinNegativePwm());
-  //  printf("MinNegPWM: %d FullRangeScaleFactor: %d Raw value: %5d   Input "
-  // "value: %4.4f\n", GetMinNegativePwm(), GetFullRangeScaleFactor(), rawValue,
-  // pos);
 
-  // wpi_assert((rawValue >= GetMinNegativePwm()) && (rawValue <=
-  // GetMaxPositivePwm()));
   wpi_assert(rawValue != kPwmDisabled);
 
   // send the computed pwm value to the FPGA

--- a/wpilibc/athena/src/Preferences.cpp
+++ b/wpilibc/athena/src/Preferences.cpp
@@ -7,11 +7,10 @@
 
 #include "Preferences.h"
 
+#include <algorithm>
+
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
-
-#include <stdio.h>
-#include <algorithm>
 
 /** The Preferences table name */
 static const char* kTableName = "Preferences";
@@ -61,8 +60,8 @@ std::string Preferences::GetString(llvm::StringRef key,
 }
 
 /**
- * Returns the int at the given key.  If this table does not have a value
- * for that position, then the given defaultValue value will be returned.
+ * Returns the int at the given key.  If this table does not have a value for
+ * that position, then the given defaultValue value will be returned.
  *
  * @param key          the key
  * @param defaultValue the value to return if none exists in the table

--- a/wpilibc/athena/src/RobotBase.cpp
+++ b/wpilibc/athena/src/RobotBase.cpp
@@ -7,8 +7,7 @@
 
 #include "RobotBase.h"
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
 
 #include "DriverStation.h"
 #include "HAL/HAL.h"
@@ -28,7 +27,7 @@ void RobotBase::setInstance(RobotBase* robot) {
 RobotBase& RobotBase::getInstance() { return *m_instance; }
 
 void RobotBase::robotSetup(RobotBase* robot) {
-  printf("\n********** Robot program starting **********\n");
+  std::printf("\n********** Robot program starting **********\n");
   robot->StartCompetition();
 }
 

--- a/wpilibc/athena/src/SPI.cpp
+++ b/wpilibc/athena/src/SPI.cpp
@@ -7,7 +7,7 @@
 
 #include "SPI.h"
 
-#include <string.h>
+#include <cstring>
 
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
@@ -151,7 +151,7 @@ int32_t SPI::Read(bool initiate, uint8_t* dataReceived, uint8_t size) {
   int32_t retVal = 0;
   if (initiate) {
     auto dataToSend = new uint8_t[size];
-    memset(dataToSend, 0, size);
+    std::memset(dataToSend, 0, size);
     retVal = spiTransaction(m_port, dataToSend, dataReceived, size);
   } else
     retVal = spiRead(m_port, dataReceived, size);

--- a/wpilibc/athena/src/SerialPort.cpp
+++ b/wpilibc/athena/src/SerialPort.cpp
@@ -7,7 +7,6 @@
 
 #include "SerialPort.h"
 
-#include <stdarg.h>
 #include "HAL/HAL.h"
 
 // static ViStatus _VI_FUNCH ioCompleteHandler (ViSession vi, ViEventType

--- a/wpilibc/athena/src/Task.cpp
+++ b/wpilibc/athena/src/Task.cpp
@@ -7,9 +7,8 @@
 
 #include "Task.h"
 
-#include <errno.h>
-#include <stdio.h>
-#include <string.h>
+#include <cerrno>
+
 #include "WPIErrors.h"
 
 #ifndef OK

--- a/wpilibc/athena/src/Utility.cpp
+++ b/wpilibc/athena/src/Utility.cpp
@@ -9,11 +9,7 @@
 
 #include <cxxabi.h>
 #include <execinfo.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
-#include <iostream>
 #include <sstream>
 
 #include "HAL/HAL.h"

--- a/wpilibc/athena/src/Vision/BaeUtilities.cpp
+++ b/wpilibc/athena/src/Vision/BaeUtilities.cpp
@@ -5,11 +5,10 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-#include <math.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cmath>
+#include <cstdarg>
+#include <cstdio>
+
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -199,12 +198,12 @@ void ShowActivity(char* fmt, ...) {
 
   va_start(args, fmt);
 
-  vsprintf(text, fmt, args);
+  std::vsprintf(text, fmt, args);
 
   ai = ai == 3 ? 0 : ai + 1;
 
-  printf("%c %s \r", activity_indication_string[ai], text);
-  fflush(stdout);
+  std::printf("%c %s \r", activity_indication_string[ai], text);
+  std::fflush(stdout);
 
   va_end(args);
 }
@@ -238,7 +237,7 @@ double SinPosition(double* period, double sinStart) {
   // Adding sinStart to the part multiplied by PI, but not by 2, allows it to
   // work as described in the comments.
   sinArg = PI * ((2.0 * (GetTime() - timestamp)) + sinStart) / sinePeriod;
-  rtnVal = sin(sinArg);
+  rtnVal = std::sin(sinArg);
   return (rtnVal);
 }
 

--- a/wpilibc/athena/src/Vision/BinaryImage.cpp
+++ b/wpilibc/athena/src/Vision/BinaryImage.cpp
@@ -7,11 +7,9 @@
 
 #include "Vision/BinaryImage.h"
 
-#include <string.h>
+#include <cstring>
 
 #include "WPIErrors.h"
-
-using namespace std;
 
 /**
  * Get then number of particles for the image.
@@ -109,9 +107,9 @@ void BinaryImage::GetParticleAnalysisReport(int particleNumber,
  * @return a pointer to the vector of particle analysis reports. The caller
  *         must delete the vector when finished using it.
  */
-vector<ParticleAnalysisReport>*
+std::vector<ParticleAnalysisReport>*
 BinaryImage::GetOrderedParticleAnalysisReports() {
-  auto particles = new vector<ParticleAnalysisReport>;
+  auto particles = new std::vector<ParticleAnalysisReport>;
   int particleCount = GetNumberParticles();
   for (int particleIndex = 0; particleIndex < particleCount; particleIndex++) {
     particles->push_back(GetParticleAnalysisReport(particleIndex));
@@ -120,7 +118,7 @@ BinaryImage::GetOrderedParticleAnalysisReports() {
   //   both reports being compared... do it manually instead... while we're
   //   at it, we should provide a version that allows a preallocated buffer of
   //   ParticleAnalysisReport structures
-  sort(particles->begin(), particles->end(), CompareParticleSizes);
+  std::sort(particles->begin(), particles->end(), CompareParticleSizes);
   return particles;
 }
 
@@ -133,7 +131,7 @@ BinaryImage::GetOrderedParticleAnalysisReports() {
  */
 void BinaryImage::Write(const char* fileName) {
   RGBValue colorTable[256];
-  memset(colorTable, 0, sizeof(colorTable));
+  std::memset(colorTable, 0, sizeof(colorTable));
   colorTable[0].R = 0;
   colorTable[1].R = 255;
   colorTable[0].G = colorTable[1].G = 0;

--- a/wpilibc/athena/src/Vision/FrcError.cpp
+++ b/wpilibc/athena/src/Vision/FrcError.cpp
@@ -12,12 +12,7 @@
  * Get the error code returned from the NI Vision library
  * @return The last error code.
  */
-int GetLastVisionError() {
-  // int errorCode = imaqGetLastVisionError();     // error code: 0 = no error
-  // char* errorText = GetVisionErrorText(errorCode);
-  // dprintf (LOG_DEBUG, "Error = %i  %s ", errorCode, errorText);
-  return imaqGetLastError();
-}
+int GetLastVisionError() { return imaqGetLastError(); }
 
 /**
  * Get the error text for an NI Vision error code.

--- a/wpilibc/athena/src/Vision/MonoImage.cpp
+++ b/wpilibc/athena/src/Vision/MonoImage.cpp
@@ -8,8 +8,6 @@
 #include "Vision/MonoImage.h"
 #include "nivision.h"
 
-using namespace std;
-
 MonoImage::MonoImage() : ImageBase(IMAQ_IMAGE_U8) {}
 
 /**
@@ -23,14 +21,14 @@ MonoImage::MonoImage() : ImageBase(IMAQ_IMAGE_U8) {}
  * @param roi                   Region of Interest
  * @returns a vector of EllipseMatch structures (0 length vector on no match)
  */
-vector<EllipseMatch>* MonoImage::DetectEllipses(
+std::vector<EllipseMatch>* MonoImage::DetectEllipses(
     EllipseDescriptor* ellipseDescriptor, CurveOptions* curveOptions,
     ShapeDetectionOptions* shapeDetectionOptions, ROI* roi) {
   int numberOfMatches;
   EllipseMatch* e =
       imaqDetectEllipses(m_imaqImage, ellipseDescriptor, curveOptions,
                          shapeDetectionOptions, roi, &numberOfMatches);
-  auto ellipses = new vector<EllipseMatch>;
+  auto ellipses = new std::vector<EllipseMatch>;
   if (e == nullptr) {
     return ellipses;
   }
@@ -41,9 +39,9 @@ vector<EllipseMatch>* MonoImage::DetectEllipses(
   return ellipses;
 }
 
-vector<EllipseMatch>* MonoImage::DetectEllipses(
+std::vector<EllipseMatch>* MonoImage::DetectEllipses(
     EllipseDescriptor* ellipseDescriptor) {
-  vector<EllipseMatch>* ellipses =
+  std::vector<EllipseMatch>* ellipses =
       DetectEllipses(ellipseDescriptor, nullptr, nullptr, nullptr);
   return ellipses;
 }

--- a/wpilibc/athena/src/Vision/VisionAPI.cpp
+++ b/wpilibc/athena/src/Vision/VisionAPI.cpp
@@ -5,8 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-#include <stdarg.h>
-#include <stdlib.h>
+#include <cstdarg>
 
 #include "Vision/BaeUtilities.h"
 #include "Vision/FrcError.h"
@@ -652,7 +651,7 @@ int frcSmartThreshold(Image* dest, const Image* source,
  * @param rangeMin The lower boundary of the range of pixel values to keep
  * @param rangeMax The upper boundary of the range of pixel values to keep.
  *
- * @return int - error code: 0 = error. To get extended error information, call
+ * @return error code: 0 = error. To get extended error information, call
  *         GetLastError().
  */
 int frcSimpleThreshold(Image* dest, const Image* source, float rangeMin,
@@ -675,7 +674,7 @@ int frcSimpleThreshold(Image* dest, const Image* source, float rangeMin,
  * @param newValue The replacement value for pixels within the range. Use the
  *                 simplified call to leave the pixel values unchanged
  *
- * @return int - error code: 0 = error. To get extended error information, call
+ * @return error code: 0 = error. To get extended error information, call
  *         GetLastError().
  */
 int frcSimpleThreshold(Image* dest, const Image* source, float rangeMin,

--- a/wpilibc/shared/include/Base.h
+++ b/wpilibc/shared/include/Base.h
@@ -79,7 +79,8 @@ struct HasBeenMoved {
 
 // Define make_unique for C++11-only compilers
 #if __cplusplus == 201103L
-#include <cstddef>
+#include <stddef.h>
+
 #include <memory>
 #include <type_traits>
 #include <utility>

--- a/wpilibc/shared/include/SensorBase.h
+++ b/wpilibc/shared/include/SensorBase.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <stdio.h>
+#include <stdint.h>
+
 #include "Base.h"
 #include "ErrorBase.h"
 

--- a/wpilibc/shared/src/Error.cpp
+++ b/wpilibc/shared/src/Error.cpp
@@ -7,10 +7,6 @@
 
 #include "Error.h"
 
-#include <stdlib.h>
-#include <string.h>
-
-#include <iostream>
 #include <sstream>
 
 #include "DriverStation.h"

--- a/wpilibc/shared/src/ErrorBase.cpp
+++ b/wpilibc/shared/src/ErrorBase.cpp
@@ -7,8 +7,7 @@
 
 #include "ErrorBase.h"
 
-#include <errno.h>
-
+#include <cerrno>
 #include <iomanip>
 #include <sstream>
 

--- a/wpilibc/shared/src/SmartDashboard/SendableChooser.cpp
+++ b/wpilibc/shared/src/SmartDashboard/SendableChooser.cpp
@@ -7,8 +7,6 @@
 
 #include "SmartDashboard/SendableChooser.h"
 
-#include <stdio.h>
-
 static const std::string kDefault = "default";
 static const std::string kOptions = "options";
 static const std::string kSelected = "selected";

--- a/wpilibc/sim/include/RobotDrive.h
+++ b/wpilibc/sim/include/RobotDrive.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <stdlib.h>
+#include <stdint.h>
+
 #include <memory>
 #include "ErrorBase.h"
 #include "MotorSafety.h"

--- a/wpilibc/sim/src/AnalogGyro.cpp
+++ b/wpilibc/sim/src/AnalogGyro.cpp
@@ -6,6 +6,9 @@
 /*----------------------------------------------------------------------------*/
 
 #include "AnalogGyro.h"
+
+#include <cstdio>
+
 #include "LiveWindow/LiveWindow.h"
 #include "Timer.h"
 #include "WPIErrors.h"

--- a/wpilibc/sim/src/AnalogInput.cpp
+++ b/wpilibc/sim/src/AnalogInput.cpp
@@ -6,6 +6,9 @@
 /*----------------------------------------------------------------------------*/
 
 #include "AnalogInput.h"
+
+#include <cstdio>
+
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 

--- a/wpilibc/sim/src/DigitalInput.cpp
+++ b/wpilibc/sim/src/DigitalInput.cpp
@@ -6,6 +6,9 @@
 /*----------------------------------------------------------------------------*/
 
 #include "DigitalInput.h"
+
+#include <cstdio>
+
 #include "WPIErrors.h"
 
 /**

--- a/wpilibc/sim/src/Encoder.cpp
+++ b/wpilibc/sim/src/Encoder.cpp
@@ -6,6 +6,9 @@
 /*----------------------------------------------------------------------------*/
 
 #include "Encoder.h"
+
+#include <cstdio>
+
 #include "LiveWindow/LiveWindow.h"
 #include "Resource.h"
 #include "WPIErrors.h"
@@ -27,8 +30,8 @@
  *                         value will either exactly match the spec'd count or
  *                         be double (2x) the spec'd count.
  */
-void Encoder::InitEncoder(int channelA, int channelB, bool reverseDirection,
-                          EncodingType encodingType) {
+void Encoder::InitEncoder(int32_t channelA, int32_t channelB,
+                          bool reverseDirection, EncodingType encodingType) {
   m_table = nullptr;
   this->channelA = channelA;
   this->channelB = channelB;

--- a/wpilibc/sim/src/MotorSafetyHelper.cpp
+++ b/wpilibc/sim/src/MotorSafetyHelper.cpp
@@ -12,7 +12,6 @@
 #include "Timer.h"
 #include "WPIErrors.h"
 
-#include <stdio.h>
 #include <sstream>
 
 std::set<MotorSafetyHelper*> MotorSafetyHelper::m_helperList;

--- a/wpilibc/sim/src/SampleRobot.cpp
+++ b/wpilibc/sim/src/SampleRobot.cpp
@@ -7,7 +7,8 @@
 
 #include "SampleRobot.h"
 
-#include <stdio.h>
+#include <cstdio>
+
 #include "LiveWindow/LiveWindow.h"
 #include "SmartDashboard/SmartDashboard.h"
 #include "Timer.h"
@@ -29,7 +30,7 @@ SampleRobot::SampleRobot() : m_robotMainOverridden(true) {}
  * which will be called each time the robot enters the disabled state.
  */
 void SampleRobot::RobotInit() {
-  printf("Default %s() method... Override me!\n", __FUNCTION__);
+  std::printf("Default %s() method... Override me!\n", __FUNCTION__);
 }
 
 /**
@@ -39,7 +40,7 @@ void SampleRobot::RobotInit() {
  * field is disabled.
  */
 void SampleRobot::Disabled() {
-  printf("Default %s() method... Override me!\n", __FUNCTION__);
+  std::printf("Default %s() method... Override me!\n", __FUNCTION__);
 }
 
 /**
@@ -50,7 +51,7 @@ void SampleRobot::Disabled() {
  * robot enters the autonomous state.
  */
 void SampleRobot::Autonomous() {
-  printf("Default %s() method... Override me!\n", __FUNCTION__);
+  std::printf("Default %s() method... Override me!\n", __FUNCTION__);
 }
 
 /**
@@ -61,7 +62,7 @@ void SampleRobot::Autonomous() {
  * each time the robot enters the teleop state.
  */
 void SampleRobot::OperatorControl() {
-  printf("Default %s() method... Override me!\n", __FUNCTION__);
+  std::printf("Default %s() method... Override me!\n", __FUNCTION__);
 }
 
 /**
@@ -72,7 +73,7 @@ void SampleRobot::OperatorControl() {
  * test mode.
  */
 void SampleRobot::Test() {
-  printf("Default %s() method... Override me!\n", __FUNCTION__);
+  std::printf("Default %s() method... Override me!\n", __FUNCTION__);
 }
 
 /**

--- a/wpilibc/sim/src/Solenoid.cpp
+++ b/wpilibc/sim/src/Solenoid.cpp
@@ -6,6 +6,9 @@
 /*----------------------------------------------------------------------------*/
 
 #include "Solenoid.h"
+
+#include <cstdio>
+
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 #include "simulation/simTime.h"

--- a/wpilibc/sim/src/Timer.cpp
+++ b/wpilibc/sim/src/Timer.cpp
@@ -86,7 +86,7 @@ Timer::Timer() : m_startTime(0.0), m_accumulatedTime(0.0), m_running(false) {
  * start time stored in the timer class. If the clock is not running, then
  * return the time when it was last stopped.
  *
- * @return unsigned Current time value for this timer in seconds
+ * @return Current time value for this timer in seconds
  */
 double Timer::Get() const {
   double result;

--- a/wpilibc/sim/src/Utility.cpp
+++ b/wpilibc/sim/src/Utility.cpp
@@ -7,10 +7,7 @@
 
 #include "Utility.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
+#include <cstdio>
 #include <iostream>
 #include <sstream>
 #if not defined(_WIN32)
@@ -43,10 +40,10 @@ void wpi_suspendOnAssertEnabled(bool enabled) {
 static void wpi_handleTracing() {
   // if (stackTraceEnabled)
   // {
-  // 	printf("\n-----------<Stack Trace>----------------\n");
+  // 	std::printf("\n-----------<Stack Trace>----------------\n");
   // 	printCurrentStackTrace();
   // }
-  printf("\n");
+  std::printf("\n");
 }
 
 /**


### PR DESCRIPTION
This was not done to stdint.h for brevity in type names. Also added extern "C" to C HAL headers and removed "using namespace std;".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wpilibsuite/allwpilib/90)
<!-- Reviewable:end -->
