### PR TITLE
Added Joystick::GetAxisType()

### DIFF
--- a/wpilibc/athena/include/Joystick.h
+++ b/wpilibc/athena/include/Joystick.h
@@ -96,7 +96,7 @@ class Joystick : public GenericHID, public ErrorBase {
   Joystick::HIDType GetType() const;
   std::string GetName() const;
   int GetPort() const;
-  int GetAxisType(uint8_t axis) const;
+  int GetAxisType(int axis) const;
 
   int GetAxisCount() const;
   int GetButtonCount() const;

--- a/wpilibc/athena/src/Joystick.cpp
+++ b/wpilibc/athena/src/Joystick.cpp
@@ -284,10 +284,14 @@ std::string Joystick::GetName() const { return m_ds.GetJoystickName(m_port); }
  */
 int Joystick::GetPort() const { return m_port; }
 
-// int Joystick::GetAxisType(uint8_t axis) const
-//{
-//  return m_ds.GetJoystickAxisType(m_port, axis);
-//}
+/**
+ * Get the axis type of a joystick axis.
+ *
+ * @return the axis type of a joystick axis.
+ */
+int Joystick::GetAxisType(int axis) const {
+  return m_ds.GetJoystickAxisType(m_port, axis);
+}
 
 /**
  * Get the number of axis for a joystick.

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -437,6 +437,25 @@ public class DriverStation implements RobotState.Interface {
   }
 
   /**
+   * Returns the types of Axes on a given joystick port.
+   *
+   * @param stick The joystick port number
+   * @param axis The target axis
+   * @return What type of axis the axis is reporting to be
+   */
+  public int getJoystickAxisType(int stick, int axis) {
+    if (stick < 0 || stick >= kJoystickPorts) {
+      throw new RuntimeException("Joystick index is out of range, should be 0-5");
+    }
+
+    int retVal = -1;
+    synchronized (m_joystickMutex) {
+      retVal = HAL.getJoystickAxisType((byte) stick, (byte) axis);
+    }
+    return retVal;
+  }
+
+  /**
    * Gets a value indicating whether the Driver Station requires the robot to be enabled.
    *
    * @return True if the robot is enabled, false otherwise.

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/Joystick.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/Joystick.java
@@ -388,6 +388,15 @@ public class Joystick extends GenericHID {
   }
 
   /**
+   * Get the axis type of a joystick axis.
+   *
+   * @return the axis type of a joystick axis.
+   */
+  public int getAxisType(int axis) {
+    return m_ds.getJoystickAxisType(m_port, axis);
+  }
+
+  /**
    * Set the rumble output for the joystick. The DS currently supports 2 rumble values, left rumble
    * and right rumble.
    *


### PR DESCRIPTION
HAL joystick functions now use uint32_t for joystick number and DriverStation functions were rearranged in wpilibc and wpilibj to be consistent with wpilibc header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wpilibsuite/allwpilib/98)
<!-- Reviewable:end -->
