### PR TITLE
Switches indexed handles to shared_ptr

### DIFF
--- a/hal/lib/athena/handles/IndexedHandleResource.h
+++ b/hal/lib/athena/handles/IndexedHandleResource.h
@@ -12,14 +12,12 @@
 #include <memory>
 #include <vector>
 
+#include "HAL/Errors.h"
 #include "HAL/Handles.h"
 #include "HAL/cpp/priority_mutex.h"
 #include "HandlesInternal.h"
 
 namespace hal {
-
-constexpr int32_t IndexedResourceIndexOutOfRange = -1;
-constexpr int32_t IndexedResourceNotAllocated = -2;
 
 /**
  * The IndexedHandleResource class is a way to track handles. This version
@@ -41,57 +39,47 @@ class IndexedHandleResource {
  public:
   IndexedHandleResource(const IndexedHandleResource&) = delete;
   IndexedHandleResource operator=(const IndexedHandleResource&) = delete;
-  IndexedHandleResource();
-  THandle Allocate(int16_t index, const TStruct& toSet);
-  TStruct Get(THandle handle, int32_t* status);
+  IndexedHandleResource() = default;
+  THandle Allocate(int16_t index, int32_t* status);
+  std::shared_ptr<TStruct> Get(THandle handle);
   void Free(THandle handle);
 
  private:
-  TStruct m_structures[size];
-  bool m_allocated[size];
+  std::shared_ptr<TStruct> m_structures[size];
   priority_mutex m_handleMutexes[size];
 };
 
 template <typename THandle, typename TStruct, int16_t size,
           HalHandleEnum enumValue>
-IndexedHandleResource<THandle, TStruct, size,
-                      enumValue>::IndexedHandleResource() {
-  // ensure all allocations are initially false.
-  for (int i = 0; i < size; i++) {
-    m_allocated[i] = false;
-  }
-}
-
-template <typename THandle, typename TStruct, int16_t size,
-          HalHandleEnum enumValue>
 THandle IndexedHandleResource<THandle, TStruct, size, enumValue>::Allocate(
-    int16_t index, const TStruct& toSet) {
+    int16_t index, int32_t* status) {
   // don't aquire the lock if we can fail early.
-  if (index < 0 || index >= size) return HAL_INVALID_HANDLE;
+  if (index < 0 || index >= size) {
+    *status = PARAMETER_OUT_OF_RANGE;
+    return HAL_INVALID_HANDLE;
+  }
   std::lock_guard<priority_mutex> sync(m_handleMutexes[index]);
   // check for allocation, otherwise allocate and return a valid handle
-  if (m_allocated[index]) return HAL_INVALID_HANDLE;
-  m_allocated[index] = true;
-  m_structures[index] = toSet;
+  if (m_structures[index] != nullptr) {
+    *status = RESOURCE_IS_ALLOCATED;
+    return HAL_INVALID_HANDLE;
+  }
+  m_structures[index] = std::make_shared<TStruct>();
   return (THandle)hal::createHandle(index, enumValue);
 }
 
 template <typename THandle, typename TStruct, int16_t size,
           HalHandleEnum enumValue>
-TStruct IndexedHandleResource<THandle, TStruct, size, enumValue>::Get(
-    THandle handle, int32_t* status) {
+std::shared_ptr<TStruct>
+IndexedHandleResource<THandle, TStruct, size, enumValue>::Get(THandle handle) {
   // get handle index, and fail early if index out of range or wrong handle
   int16_t index = getHandleTypedIndex(handle, enumValue);
   if (index < 0 || index >= size) {
-    *status = IndexedResourceIndexOutOfRange;
-    return TStruct();
+    return nullptr;
   }
   std::lock_guard<priority_mutex> sync(m_handleMutexes[index]);
-  // check for already deallocated handle, then return structure
-  if (!m_allocated[index]) {
-    *status = IndexedResourceNotAllocated;
-    return TStruct();
-  }
+  // return structure. Null will propogate correctly, so no need to manually
+  // check.
   return m_structures[index];
 }
 
@@ -104,6 +92,6 @@ void IndexedHandleResource<THandle, TStruct, size, enumValue>::Free(
   if (index < 0 || index >= size) return;
   // lock and deallocated handle
   std::lock_guard<priority_mutex> sync(m_handleMutexes[index]);
-  m_allocated[index] = false;
+  m_structures[index].reset();
 }
 }


### PR DESCRIPTION
As discussed, the old method of was going to have issues, and was not
going to help in the case of the structs containing pointers. I think we
are just going to have to be careful, as guarenteeing the internal
pointers are const is going to be very difficult.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wpilibsuite/allwpilib/101)
<!-- Reviewable:end -->
