### PR TITLE
Fixes formatting in error.cpp

### DIFF
--- a/wpilibc/shared/src/Error.cpp
+++ b/wpilibc/shared/src/Error.cpp
@@ -68,8 +68,8 @@ void Error::Report() {
 #if defined(_WIN32)
   const int MAX_DIR = 100;
   char basename[MAX_DIR];
-  _splitpath_s(m_filename.c_str(), nullptr, 0, basename, MAX_DIR, nullptr, 0, nullptr,
-               0);
+  _splitpath_s(m_filename.c_str(), nullptr, 0, basename, MAX_DIR, nullptr, 0,
+               nullptr, 0);
   locStream << basename;
 #else
   locStream << basename(m_filename.c_str());


### PR DESCRIPTION
It getting annoying to ignore this file every time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wpilibsuite/allwpilib/102)
<!-- Reviewable:end -->
