### PR TITLE
Rename Notifier::m_handlerMutex to Notifier::m_notifyMutex

### DIFF
--- a/wpilibc/athena/include/Notifier.h
+++ b/wpilibc/athena/include/Notifier.h
@@ -53,6 +53,6 @@ class Notifier : public ErrorBase {
   // true if this is a periodic event
   bool m_periodic = false;
 
-  // held by interrupt manager task while handler call is in progress
-  priority_mutex m_handlerMutex;
+  // held HAL notifier while Notifier::Notify() call is in progress
+  priority_mutex m_notifyMutex;
 };

--- a/wpilibc/athena/src/Notifier.cpp
+++ b/wpilibc/athena/src/Notifier.cpp
@@ -39,7 +39,7 @@ Notifier::~Notifier() {
   /* Acquire the mutex; this makes certain that the handler is not being
    * executed by the interrupt manager.
    */
-  std::lock_guard<priority_mutex> lock(m_handlerMutex);
+  std::lock_guard<priority_mutex> lock(m_notifyMutex);
 }
 
 /**
@@ -66,11 +66,11 @@ void Notifier::Notify(uint64_t currentTimeInt, void* param) {
 
   auto handler = notifier->m_handler;
 
-  notifier->m_handlerMutex.lock();
+  notifier->m_notifyMutex.lock();
   notifier->m_processMutex.unlock();
 
   if (handler) handler();
-  notifier->m_handlerMutex.unlock();
+  notifier->m_notifyMutex.unlock();
 }
 
 /**
@@ -122,5 +122,5 @@ void Notifier::Stop() {
 
   // Wait for a currently executing handler to complete before returning from
   // Stop()
-  std::lock_guard<priority_mutex> sync(m_handlerMutex);
+  std::lock_guard<priority_mutex> sync(m_notifyMutex);
 }


### PR DESCRIPTION
A month ago, we discussed renaming this mutex to better reflect its current use, and this commit does that. The inline comment was also updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wpilibsuite/allwpilib/105)
<!-- Reviewable:end -->
