### PR TITLE
Clarified that PID controller runs in discrete time

### DIFF
--- a/wpilibc/shared/include/PIDController.h
+++ b/wpilibc/shared/include/PIDController.h
@@ -28,6 +28,10 @@ class PIDOutput;
  *
  * Creates a separate thread which reads the given PIDSource and takes
  * care of the integral calculations, as well as writing the given PIDOutput.
+ *
+ * This feedback controller runs in discrete time, so time deltas are not used
+ * in the integral and derivative calculations. Therefore, the sample rate
+ * affects the controller's behavior for a given set of PID constants.
  */
 class PIDController : public LiveWindowSendable,
                       public PIDInterface,

--- a/wpilibj/src/shared/java/edu/wpi/first/wpilibj/PIDController.java
+++ b/wpilibj/src/shared/java/edu/wpi/first/wpilibj/PIDController.java
@@ -19,7 +19,11 @@ import edu.wpi.first.wpilibj.util.BoundaryException;
  * Class implements a PID Control Loop.
  *
  * <p>Creates a separate thread which reads the given PIDSource and takes care of the integral
- * calculations, as well as writing the given PIDOutput
+ * calculations, as well as writing the given PIDOutput.
+ *
+ * <p>This feedback controller runs in discrete time, so time deltas are not used in the integral
+ * and derivative calculations. Therefore, the sample rate affects the controller's behavior for a
+ * given set of PID constants.
  */
 public class PIDController implements PIDInterface, LiveWindowSendable, Controller {
 


### PR DESCRIPTION
This was added to explain the apparent oversight with respect to controller behavior with different sample rates.