### PR TITLE
Enables Backtrace printing on SegFault

### DIFF
--- a/wpilibcIntegrationTests/build.gradle
+++ b/wpilibcIntegrationTests/build.gradle
@@ -16,7 +16,7 @@ model {
                     dependsOn addNetworkTablesLibraryLinks
                 }
 
-                cppCompiler.args '-pthread', '-Wno-unused-variable'
+                cppCompiler.args '-pthread', '-Wno-unused-variable', '-rdynamic', '-g'
                 linker.args '-pthread', '-Wno-unused-variable', '-Wl,-rpath,/opt/GenICam_v2_3/bin/Linux_armv7-a'
             }
             sources {

--- a/wpilibcIntegrationTests/gtest/src/gtest_main.cc
+++ b/wpilibcIntegrationTests/gtest/src/gtest_main.cc
@@ -31,7 +31,25 @@
 
 #include "gtest/gtest.h"
 
+#include <execinfo.h>
+
+// stack trace code found on StackOverflow at the following link
+// http://stackoverflow.com/questions/77005/how-to-generate-a-stacktrace-when-my-gcc-c-app-crashes
+void handler(int sig) {
+  void *array[10];
+  size_t size;
+
+  // get void*'s for all entries on the stack
+  size = backtrace(array, 10);
+
+  // print out all the frames to stderr
+  fprintf(stderr, "Error: signal %d:\n", sig);
+  backtrace_symbols_fd(array, size, STDERR_FILENO);
+  exit(1);
+}
+
 GTEST_API_ int main(int argc, char **argv) {
+  signal(SIGSEGV, handler);
   printf("Running main() from gtest_main.cc\n");
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/wpilibcIntegrationTests/src/DIOLoopTest.cpp
+++ b/wpilibcIntegrationTests/src/DIOLoopTest.cpp
@@ -50,7 +50,10 @@ class DIOLoopTest : public testing::Test {
  */
 TEST_F(DIOLoopTest, Loop) {
   Reset();
-
+  
+  // test code to see what a failure actually does.
+  int *foo = (int*)-1; // make a bad pointer
+  printf("%d\n", *foo);       // causes segfault
   m_output->Set(false);
   Wait(kDelayTime);
   EXPECT_FALSE(m_input->Get()) << "The digital output was turned off, but "


### PR DESCRIPTION
Should help enable easier debugging on a test failure in the future.