### PR TITLE
Adds a maximum time based cache to HALControlWord data

### DIFF
--- a/wpilibc/athena/include/DriverStation.h
+++ b/wpilibc/athena/include/DriverStation.h
@@ -97,6 +97,7 @@ class DriverStation : public SensorBase, public RobotStateInterface {
   void ReportJoystickUnpluggedError(std::string message);
   void ReportJoystickUnpluggedWarning(std::string message);
   void Run();
+  void UpdateControlWord(bool force, HAL_ControlWord& controlWord) const;
 
   std::unique_ptr<HAL_JoystickAxes[]> m_joystickAxes;
   std::unique_ptr<HAL_JoystickPOVs[]> m_joystickPOVs;
@@ -120,5 +121,8 @@ class DriverStation : public SensorBase, public RobotStateInterface {
   bool m_userInAutonomous = false;
   bool m_userInTeleop = false;
   bool m_userInTest = false;
+  mutable HAL_ControlWord m_controlWordCache;
+  mutable std::chrono::steady_clock::time_point m_lastControlWordUpdate;
+  mutable priority_mutex m_controlWordMutex;
   double m_nextMessageTime = 0;
 };

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/ControlWord.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/ControlWord.java
@@ -11,15 +11,15 @@ package edu.wpi.first.wpilibj.hal;
  * A wrapper for the HALControlWord bitfield.
  */
 public class ControlWord {
-  private final boolean m_enabled;
-  private final boolean m_autonomous;
-  private final boolean m_test;
-  private final boolean m_emergencyStop;
-  private final boolean m_fmsAttached;
-  private final boolean m_dsAttached;
+  private boolean m_enabled;
+  private boolean m_autonomous;
+  private boolean m_test;
+  private boolean m_emergencyStop;
+  private boolean m_fmsAttached;
+  private boolean m_dsAttached;
 
-  protected ControlWord(boolean enabled, boolean autonomous, boolean test, boolean emergencyStop,
-                        boolean fmsAttached, boolean dsAttached) {
+  void update(boolean enabled, boolean autonomous, boolean test, boolean emergencyStop,
+              boolean fmsAttached, boolean dsAttached) {
     m_enabled = enabled;
     m_autonomous = autonomous;
     m_test = test;

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/HAL.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/HAL.java
@@ -57,9 +57,9 @@ public class HAL extends JNIWrapper {
   private static native int nativeGetControlWord();
 
   @SuppressWarnings("JavadocMethod")
-  public static ControlWord getControlWord() {
+  public static void getControlWord(ControlWord controlWord) {
     int word = nativeGetControlWord();
-    return new ControlWord((word & 1) != 0, ((word >> 1) & 1) != 0, ((word >> 2) & 1) != 0,
+    controlWord.update((word & 1) != 0, ((word >> 1) & 1) != 0, ((word >> 2) & 1) != 0,
         ((word >> 3) & 1) != 0, ((word >> 4) & 1) != 0, ((word >> 5) & 1) != 0);
   }
 


### PR DESCRIPTION
This is one of the calls with the delayed IPC. In the past, teams have
called an IsMode function so much that their code would start lagging.
This adds a cache, so the data is updated either when new data arrives
and we are notified of it, or after 50ms has passes since the last time
the cache was checked and updated.