### PR TITLE
Removed double-add of shared classpath. Fixes #157.

### DIFF
--- a/wpilibj/athena.gradle
+++ b/wpilibj/athena.gradle
@@ -82,7 +82,6 @@ jar {
             }
         }
         addClasspath sourceSets.athena.runtimeClasspath
-        addClasspath sourceSets.shared.runtimeClasspath
     }
 
     model {


### PR DESCRIPTION
This fixes the double-add of shared classpath. Note that simulation likely needs the same fix, but WSL does not support Gradle or Java yet, so I couldn't test it there. @bradamiller, I don't know who does sim now, but if they could try making this same change in wpilibj/simulation.gradle, try building, and seeing if ntcore.so is duplicated in the resulting jar I'll make the same change on this pull request.