### PR TITLE
Makes the CANJaguar test error status messages more useful

### DIFF
--- a/wpilibc/athena/include/DigitalOutput.h
+++ b/wpilibc/athena/include/DigitalOutput.h
@@ -27,6 +27,7 @@ class DigitalOutput : public DigitalSource,
   explicit DigitalOutput(uint32_t channel);
   virtual ~DigitalOutput();
   void Set(bool value);
+  bool Get();
   uint32_t GetChannel() const override;
   void Pulse(float length);
   bool IsPulsing() const;

--- a/wpilibc/athena/src/DigitalOutput.cpp
+++ b/wpilibc/athena/src/DigitalOutput.cpp
@@ -73,6 +73,20 @@ void DigitalOutput::Set(bool value) {
 }
 
 /**
+   * Gets the value being output from the Digital Output.
+   *
+   * @return the state of the digital output.
+   */
+bool DigitalOutput::Get() {
+  if (StatusIsFatal()) return false;
+
+  int32_t status = 0;
+  bool val = HAL_GetDIO(m_handle, &status);
+  wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
+  return val;
+}
+
+/**
  * @return The GPIO channel number that this object represents.
  */
 uint32_t DigitalOutput::GetChannel() const { return m_channel; }

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/DigitalOutput.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/DigitalOutput.java
@@ -65,6 +65,15 @@ public class DigitalOutput extends DigitalSource implements LiveWindowSendable {
   }
 
   /**
+   * Gets the value being output from the Digital Output.
+   *
+   * @return the state of the digital output.
+   */
+  public boolean get() {
+    return DIOJNI.getDIO(m_handle);
+  }
+
+  /**
    * @return The GPIO channel number that this object represents.
    */
   @Override

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/fixtures/CANMotorEncoderFixture.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/fixtures/CANMotorEncoderFixture.java
@@ -161,12 +161,12 @@ public abstract class CANMotorEncoderFixture extends MotorEncoderFixture<CANJagu
       status.append("\t" + "CANJaguar Motor = null" + "\n");
     }
     if (m_forwardLimit != null) {
-      status.append("\tForward Limit Output = " + m_forwardLimit + "\n");
+      status.append("\tForward Limit Output = " + m_forwardLimit.get() + "\n");
     } else {
       status.append("\tForward Limit Output = null" + "\n");
     }
     if (m_reverseLimit != null) {
-      status.append("\tReverse Limit Output = " + m_reverseLimit + "\n");
+      status.append("\tReverse Limit Output = " + m_reverseLimit.get() + "\n");
     } else {
       status.append("\tReverse Limit Output = null" + "\n");
     }


### PR DESCRIPTION
The previous version would just return the class name for the DigitalOutput port. Now it actually gets the dio port value for better readability.