### PR TITLE
Makes SensorBase checks use HAL check methods

### DIFF
--- a/hal/include/HAL/DIO.h
+++ b/hal/include/HAL/DIO.h
@@ -16,8 +16,8 @@ extern "C" {
 #endif
 HAL_DigitalHandle HAL_InitializeDIOPort(HAL_PortHandle port_handle,
                                         HAL_Bool input, int32_t* status);
+HAL_Bool HAL_CheckDIOChannel(int32_t channel);
 void HAL_FreeDIOPort(HAL_DigitalHandle dio_port_handle);
-
 HAL_DigitalPWMHandle HAL_AllocateDigitalPWM(int32_t* status);
 void HAL_FreeDigitalPWM(HAL_DigitalPWMHandle pwmGenerator, int32_t* status);
 void HAL_SetDigitalPWMRate(double rate, int32_t* status);

--- a/hal/include/HAL/PDP.h
+++ b/hal/include/HAL/PDP.h
@@ -15,6 +15,7 @@
 extern "C" {
 #endif
 void HAL_InitializePDP(int32_t module, int32_t* status);
+HAL_Bool HAL_CheckPDPChannel(int32_t channel);
 HAL_Bool HAL_CheckPDPModule(int32_t module);
 double HAL_GetPDPTemperature(int32_t module, int32_t* status);
 double HAL_GetPDPVoltage(int32_t module, int32_t* status);

--- a/hal/include/HAL/Solenoid.h
+++ b/hal/include/HAL/Solenoid.h
@@ -18,7 +18,7 @@ HAL_SolenoidHandle HAL_InitializeSolenoidPort(HAL_PortHandle port_handle,
                                               int32_t* status);
 void HAL_FreeSolenoidPort(HAL_SolenoidHandle solenoid_port_handle);
 HAL_Bool HAL_CheckSolenoidModule(int32_t module);
-HAL_Bool HAL_CheckSolenoidPin(int32_t pin);
+HAL_Bool HAL_CheckSolenoidChannel(int32_t pin);
 HAL_Bool HAL_GetSolenoid(HAL_SolenoidHandle solenoid_port_handle,
                          int32_t* status);
 int32_t HAL_GetAllSolenoids(int32_t module, int32_t* status);

--- a/hal/lib/athena/AnalogInput.cpp
+++ b/hal/lib/athena/AnalogInput.cpp
@@ -85,7 +85,7 @@ HAL_Bool HAL_CheckAnalogModule(int32_t module) { return module == 1; }
  * @return Analog channel is valid
  */
 HAL_Bool HAL_CheckAnalogInputChannel(int32_t pin) {
-  return (pin < kNumAnalogInputs) && (pin >= 0);
+  return pin < kNumAnalogInputs && pin >= 0;
 }
 
 /**

--- a/hal/lib/athena/AnalogOutput.cpp
+++ b/hal/lib/athena/AnalogOutput.cpp
@@ -70,7 +70,7 @@ void HAL_FreeAnalogOutputPort(HAL_AnalogOutputHandle analog_output_handle) {
  * @return Analog channel is valid
  */
 HAL_Bool HAL_CheckAnalogOutputChannel(int32_t pin) {
-  return (pin < kNumAnalogOutputs) && (pin >= 0);
+  return pin < kNumAnalogOutputs && pin >= 0;
 }
 
 void HAL_SetAnalogOutput(HAL_AnalogOutputHandle analog_output_handle,

--- a/hal/lib/athena/Compressor.cpp
+++ b/hal/lib/athena/Compressor.cpp
@@ -32,7 +32,7 @@ HAL_CompressorHandle HAL_InitializeCompressor(int32_t module, int32_t* status) {
 }
 
 HAL_Bool HAL_CheckCompressorModule(int32_t module) {
-  return (module < kNumPCMModules) && (module >= 0);
+  return module < kNumPCMModules && module >= 0;
 }
 
 HAL_Bool HAL_GetCompressor(HAL_CompressorHandle compressor_handle,

--- a/hal/lib/athena/DIO.cpp
+++ b/hal/lib/athena/DIO.cpp
@@ -87,6 +87,10 @@ HAL_DigitalHandle HAL_InitializeDIOPort(HAL_PortHandle port_handle,
   return handle;
 }
 
+HAL_Bool HAL_CheckDIOChannel(int32_t channel) {
+  return channel < kNumDigitalPins && channel >= 0;
+}
+
 void HAL_FreeDIOPort(HAL_DigitalHandle dio_port_handle) {
   // no status, so no need to check for a proper free.
   digitalPinHandles.Free(dio_port_handle, HAL_HandleEnum::DIO);

--- a/hal/lib/athena/PDP.cpp
+++ b/hal/lib/athena/PDP.cpp
@@ -29,7 +29,11 @@ void HAL_InitializePDP(int32_t module, int32_t* status) {
 }
 
 HAL_Bool HAL_CheckPDPModule(int32_t module) {
-  return (module < kNumPDPModules) && (module >= 0);
+  return module < kNumPDPModules && module >= 0;
+}
+
+HAL_Bool HAL_CheckPDPChannel(int32_t channel) {
+  return channel < kNumPDPChannels && channel >= 0;
 }
 
 double HAL_GetPDPTemperature(int32_t module, int32_t* status) {

--- a/hal/lib/athena/PWM.cpp
+++ b/hal/lib/athena/PWM.cpp
@@ -101,7 +101,7 @@ void HAL_FreePWMPort(HAL_DigitalHandle pwm_port_handle, int32_t* status) {
 }
 
 HAL_Bool HAL_CheckPWMChannel(int32_t pin) {
-  return (pin < kNumPWMPins) && (pin >= 0);
+  return pin < kNumPWMPins && pin >= 0;
 }
 
 void HAL_SetPWMConfig(HAL_DigitalHandle pwm_port_handle, double max,

--- a/hal/lib/athena/Relay.cpp
+++ b/hal/lib/athena/Relay.cpp
@@ -73,7 +73,7 @@ HAL_Bool HAL_CheckRelayChannel(int32_t pin) {
   // roboRIO only has 4 headers, and the FPGA has
   // seperate functions for forward and reverse,
   // instead of seperate pin IDs
-  return (pin < kNumRelayHeaders) && (pin >= 0);
+  return pin < kNumRelayHeaders && pin >= 0;
 }
 
 /**

--- a/hal/lib/athena/Solenoid.cpp
+++ b/hal/lib/athena/Solenoid.cpp
@@ -43,7 +43,7 @@ HAL_SolenoidHandle HAL_InitializeSolenoidPort(HAL_PortHandle port_handle,
   }
 
   // initializePCM will check the module
-  if (!HAL_CheckSolenoidPin(pin)) {
+  if (!HAL_CheckSolenoidChannel(pin)) {
     *status = RESOURCE_OUT_OF_RANGE;
     return HAL_kInvalidHandle;
   }
@@ -75,11 +75,11 @@ void HAL_FreeSolenoidPort(HAL_SolenoidHandle solenoid_port_handle) {
 }
 
 HAL_Bool HAL_CheckSolenoidModule(int32_t module) {
-  return (module < kNumPCMModules) && (module >= 0);
+  return module < kNumPCMModules && module >= 0;
 }
 
-HAL_Bool HAL_CheckSolenoidPin(int32_t pin) {
-  return (pin < kNumSolenoidPins) && (pin >= 0);
+HAL_Bool HAL_CheckSolenoidChannel(int32_t pin) {
+  return pin < kNumSolenoidPins && pin >= 0;
 }
 
 HAL_Bool HAL_GetSolenoid(HAL_SolenoidHandle solenoid_port_handle,

--- a/wpilibc/athena/include/SensorBase.h
+++ b/wpilibc/athena/include/SensorBase.h
@@ -1,0 +1,47 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) FIRST 2008-2016. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <stdint.h>
+
+#include "Base.h"
+#include "ErrorBase.h"
+
+/**
+ * Base class for all sensors.
+ * Stores most recent status information as well as containing utility functions
+ * for checking channels and error processing.
+ */
+class SensorBase : public ErrorBase {
+ public:
+  SensorBase() = default;
+  virtual ~SensorBase() = default;
+
+  SensorBase(const SensorBase&) = delete;
+  SensorBase& operator=(const SensorBase&) = delete;
+
+  static int GetDefaultSolenoidModule() { return 0; }
+
+  static bool CheckSolenoidModule(int moduleNumber);
+  static bool CheckDigitalChannel(int channel);
+  static bool CheckRelayChannel(int channel);
+  static bool CheckPWMChannel(int channel);
+  static bool CheckAnalogInput(int channel);
+  static bool CheckAnalogOutput(int channel);
+  static bool CheckSolenoidChannel(int channel);
+  static bool CheckPDPChannel(int channel);
+
+  static const int kDigitalChannels;
+  static const int kAnalogInputs;
+  static const int kAnalogOutputs;
+  static const int kSolenoidChannels;
+  static const int kSolenoidModules;
+  static const int kPwmChannels;
+  static const int kRelayChannels;
+  static const int kPDPChannels;
+};

--- a/wpilibc/athena/src/SensorBase.cpp
+++ b/wpilibc/athena/src/SensorBase.cpp
@@ -11,23 +11,21 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
-const uint32_t SensorBase::kDigitalChannels;
-const uint32_t SensorBase::kAnalogInputs;
-const uint32_t SensorBase::kSolenoidChannels;
-const uint32_t SensorBase::kSolenoidModules;
-const uint32_t SensorBase::kPwmChannels;
-const uint32_t SensorBase::kRelayChannels;
-const uint32_t SensorBase::kPDPChannels;
-const uint32_t SensorBase::kChassisSlots;
+const int SensorBase::kDigitalChannels = HAL_GetNumDigitalPins();
+const int SensorBase::kAnalogInputs = HAL_GetNumAnalogInputs();
+const int SensorBase::kSolenoidChannels = HAL_GetNumSolenoidPins();
+const int SensorBase::kSolenoidModules = HAL_GetNumPCMModules();
+const int SensorBase::kPwmChannels = HAL_GetNumPWMPins();
+const int SensorBase::kRelayChannels = HAL_GetNumRelayHeaders();
+const int SensorBase::kPDPChannels = HAL_GetNumPDPChannels();
 
 /**
  * Check that the solenoid module number is valid.
  *
  * @return Solenoid module is valid and present
  */
-bool SensorBase::CheckSolenoidModule(uint8_t moduleNumber) {
-  if (moduleNumber < 64) return true;
-  return false;
+bool SensorBase::CheckSolenoidModule(int moduleNumber) {
+  return HAL_CheckSolenoidModule(moduleNumber);
 }
 
 /**
@@ -38,9 +36,8 @@ bool SensorBase::CheckSolenoidModule(uint8_t moduleNumber) {
  *
  * @return Digital channel is valid
  */
-bool SensorBase::CheckDigitalChannel(uint32_t channel) {
-  if (channel < kDigitalChannels) return true;
-  return false;
+bool SensorBase::CheckDigitalChannel(int channel) {
+  return HAL_CheckDIOChannel(channel);
 }
 
 /**
@@ -51,8 +48,8 @@ bool SensorBase::CheckDigitalChannel(uint32_t channel) {
  *
  * @return Relay channel is valid
  */
-bool SensorBase::CheckRelayChannel(uint32_t channel) {
-  return HAL_CheckRelayChannel((uint8_t)channel);
+bool SensorBase::CheckRelayChannel(int channel) {
+  return HAL_CheckRelayChannel(channel);
 }
 
 /**
@@ -63,9 +60,8 @@ bool SensorBase::CheckRelayChannel(uint32_t channel) {
  *
  * @return PWM channel is valid
  */
-bool SensorBase::CheckPWMChannel(uint32_t channel) {
-  if (channel < kPwmChannels) return true;
-  return false;
+bool SensorBase::CheckPWMChannel(int channel) {
+  return HAL_CheckPWMChannel(channel);
 }
 
 /**
@@ -76,9 +72,8 @@ bool SensorBase::CheckPWMChannel(uint32_t channel) {
  *
  * @return Analog channel is valid
  */
-bool SensorBase::CheckAnalogInput(uint32_t channel) {
-  if (channel < kAnalogInputs) return true;
-  return false;
+bool SensorBase::CheckAnalogInput(int channel) {
+  return HAL_CheckAnalogInputChannel(channel);
 }
 
 /**
@@ -89,9 +84,8 @@ bool SensorBase::CheckAnalogInput(uint32_t channel) {
  *
  * @return Analog channel is valid
  */
-bool SensorBase::CheckAnalogOutput(uint32_t channel) {
-  if (channel < kAnalogOutputs) return true;
-  return false;
+bool SensorBase::CheckAnalogOutput(int channel) {
+  return HAL_CheckAnalogOutputChannel(channel);
 }
 
 /**
@@ -99,9 +93,8 @@ bool SensorBase::CheckAnalogOutput(uint32_t channel) {
  *
  * @return Solenoid channel is valid
  */
-bool SensorBase::CheckSolenoidChannel(uint32_t channel) {
-  if (channel < kSolenoidChannels) return true;
-  return false;
+bool SensorBase::CheckSolenoidChannel(int channel) {
+  return HAL_CheckSolenoidChannel(channel);
 }
 
 /**
@@ -109,7 +102,6 @@ bool SensorBase::CheckSolenoidChannel(uint32_t channel) {
  *
  * @return PDP channel is valid
  */
-bool SensorBase::CheckPDPChannel(uint32_t channel) {
-  if (channel < kPDPChannels) return true;
-  return false;
+bool SensorBase::CheckPDPChannel(int channel) {
+  return HAL_CheckPDPModule(channel);
 }

--- a/wpilibc/sim/include/SensorBase.h
+++ b/wpilibc/sim/include/SensorBase.h
@@ -25,24 +25,23 @@ class SensorBase : public ErrorBase {
   SensorBase(const SensorBase&) = delete;
   SensorBase& operator=(const SensorBase&) = delete;
 
-  static uint32_t GetDefaultSolenoidModule() { return 0; }
+  static int GetDefaultSolenoidModule() { return 0; }
 
-  static bool CheckSolenoidModule(uint8_t moduleNumber);
-  static bool CheckDigitalChannel(uint32_t channel);
-  static bool CheckRelayChannel(uint32_t channel);
-  static bool CheckPWMChannel(uint32_t channel);
-  static bool CheckAnalogInput(uint32_t channel);
-  static bool CheckAnalogOutput(uint32_t channel);
-  static bool CheckSolenoidChannel(uint32_t channel);
-  static bool CheckPDPChannel(uint32_t channel);
+  static bool CheckSolenoidModule(int moduleNumber);
+  static bool CheckDigitalChannel(int channel);
+  static bool CheckRelayChannel(int channel);
+  static bool CheckPWMChannel(int channel);
+  static bool CheckAnalogInput(int channel);
+  static bool CheckAnalogOutput(int channel);
+  static bool CheckSolenoidChannel(int channel);
+  static bool CheckPDPChannel(int channel);
 
-  static const uint32_t kDigitalChannels = 26;
-  static const uint32_t kAnalogInputs = 8;
-  static const uint32_t kAnalogOutputs = 2;
-  static const uint32_t kSolenoidChannels = 8;
-  static const uint32_t kSolenoidModules = 2;
-  static const uint32_t kPwmChannels = 20;
-  static const uint32_t kRelayChannels = 8;
-  static const uint32_t kPDPChannels = 16;
-  static const uint32_t kChassisSlots = 8;
+  static const int kDigitalChannels = 26;
+  static const int kAnalogInputs = 8;
+  static const int kAnalogOutputs = 2;
+  static const int kSolenoidChannels = 8;
+  static const int kSolenoidModules = 63;
+  static const int kPwmChannels = 20;
+  static const int kRelayChannels = 8;
+  static const int kPDPChannels = 16;
 };

--- a/wpilibc/sim/src/SensorBase.cpp
+++ b/wpilibc/sim/src/SensorBase.cpp
@@ -9,34 +9,33 @@
 
 #include "WPIErrors.h"
 
-const uint32_t SensorBase::kDigitalChannels;
-const uint32_t SensorBase::kAnalogInputs;
-const uint32_t SensorBase::kSolenoidChannels;
-const uint32_t SensorBase::kSolenoidModules;
-const uint32_t SensorBase::kPwmChannels;
-const uint32_t SensorBase::kRelayChannels;
-const uint32_t SensorBase::kPDPChannels;
-const uint32_t SensorBase::kChassisSlots;
+const int SensorBase::kDigitalChannels;
+const int SensorBase::kAnalogInputs;
+const int SensorBase::kSolenoidChannels;
+const int SensorBase::kSolenoidModules;
+const int SensorBase::kPwmChannels;
+const int SensorBase::kRelayChannels;
+const int SensorBase::kPDPChannels;
 
 /**
  * Check that the solenoid module number is valid.
  *
- * @return Solenoid module is valid and present
+ * @return Solenoid module number is valid
  */
-bool SensorBase::CheckSolenoidModule(uint8_t moduleNumber) {
-  return 1 <= moduleNumber && moduleNumber <= 2;  // TODO: Fix for Athena
+bool SensorBase::CheckSolenoidModule(int moduleNumber) {
+  return moduleNumber >= 0 && moduleNumber < kSolenoidModules;
 }
 
 /**
  * Check that the digital channel number is valid.
  *
  * Verify that the channel number is one of the legal channel numbers. Channel
- * numbers are 1-based.
+ * numbers are 0-based.
  *
  * @return Digital channel is valid
  */
-bool SensorBase::CheckDigitalChannel(uint32_t channel) {
-  if (channel > 0 && channel <= kDigitalChannels) return true;
+bool SensorBase::CheckDigitalChannel(int channel) {
+  if (channel >= 0 && channel < kDigitalChannels) return true;
   return false;
 }
 
@@ -44,12 +43,12 @@ bool SensorBase::CheckDigitalChannel(uint32_t channel) {
  * Check that the digital channel number is valid.
  *
  * Verify that the channel number is one of the legal channel numbers. Channel
- * numbers are 1-based.
+ * numbers are 0-based.
  *
  * @return Relay channel is valid
  */
-bool SensorBase::CheckRelayChannel(uint32_t channel) {
-  if (channel > 0 && channel <= kRelayChannels) return true;
+bool SensorBase::CheckRelayChannel(int channel) {
+  if (channel >= 0 && channel < kRelayChannels) return true;
   return false;
 }
 
@@ -57,12 +56,12 @@ bool SensorBase::CheckRelayChannel(uint32_t channel) {
  * Check that the digital channel number is valid.
  *
  * Verify that the channel number is one of the legal channel numbers. Channel
- * numbers are 1-based.
+ * numbers are 0-based.
  *
  * @return PWM channel is valid
  */
-bool SensorBase::CheckPWMChannel(uint32_t channel) {
-  if (channel > 0 && channel <= kPwmChannels) return true;
+bool SensorBase::CheckPWMChannel(int channel) {
+  if (channel >= 0 && channel < kPwmChannels) return true;
   return false;
 }
 
@@ -70,12 +69,12 @@ bool SensorBase::CheckPWMChannel(uint32_t channel) {
  * Check that the analog input number is valid.
  *
  * Verify that the analog input number is one of the legal channel numbers.
- * Channel numbers are 1-based.
+ * Channel numbers are 0-based.
  *
  * @return Analog channel is valid
  */
-bool SensorBase::CheckAnalogInput(uint32_t channel) {
-  if (channel > 0 && channel <= kAnalogInputs) return true;
+bool SensorBase::CheckAnalogInput(int channel) {
+  if (channel >= 0 && channel < kAnalogInputs) return true;
   return false;
 }
 
@@ -83,12 +82,12 @@ bool SensorBase::CheckAnalogInput(uint32_t channel) {
  * Check that the analog output number is valid.
  *
  * Verify that the analog output number is one of the legal channel numbers.
- * Channel numbers are 1-based.
+ * Channel numbers are 0-based.
  *
  * @return Analog channel is valid
  */
-bool SensorBase::CheckAnalogOutput(uint32_t channel) {
-  if (channel > 0 && channel <= kAnalogOutputs) return true;
+bool SensorBase::CheckAnalogOutput(int channel) {
+  if (channel >= 0 && channel < kAnalogOutputs) return true;
   return false;
 }
 
@@ -97,8 +96,8 @@ bool SensorBase::CheckAnalogOutput(uint32_t channel) {
  *
  * @return Solenoid channel is valid
  */
-bool SensorBase::CheckSolenoidChannel(uint32_t channel) {
-  if (channel > 0 && channel <= kSolenoidChannels) return true;
+bool SensorBase::CheckSolenoidChannel(int channel) {
+  if (channel >= 0 && channel < kSolenoidChannels) return true;
   return false;
 }
 
@@ -107,7 +106,7 @@ bool SensorBase::CheckSolenoidChannel(uint32_t channel) {
  *
  * @return PDP channel is valid
  */
-bool SensorBase::CheckPDPChannel(uint32_t channel) {
-  if (channel > 0 && channel <= kPDPChannels) return true;
+bool SensorBase::CheckPDPChannel(int channel) {
+  if (channel >= 0 && channel < kPDPChannels) return true;
   return false;
 }

--- a/wpilibj/src/athena/cpp/lib/DIOJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/DIOJNI.cpp
@@ -49,9 +49,21 @@ Java_edu_wpi_first_wpilibj_hal_DIOJNI_initializeDIOPort(
 }
 
 /*
-* Class:     edu_wpi_first_wpilibj_hal_DIOJNI
-* Method:    freeDIOPort
-* Signature: (I)V;
+ * Class:     edu_wpi_first_wpilibj_hal_DIOJNI
+ * Method:    checkDIOChannel
+ * Signature: (I)Z;
+*/
+JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_hal_DIOJNI_checkDIOChannel(
+    JNIEnv *env, jclass, jint channel) {
+  DIOJNI_LOG(logDEBUG) << "Calling DIOJNI checkDIOChannel";
+  DIOJNI_LOG(logDEBUG) << "Channel = " << channel;
+  return HAL_CheckDIOChannel(channel);
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_hal_DIOJNI
+ * Method:    freeDIOPort
+ * Signature: (I)V;
 */
 JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_DIOJNI_freeDIOPort(
     JNIEnv *env, jclass, jint id) {

--- a/wpilibj/src/athena/cpp/lib/PDPJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/PDPJNI.cpp
@@ -26,6 +26,26 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_PDPJNI_initializePDP(
 
 /*
  * Class:     edu_wpi_first_wpilibj_hal_PDPJNI
+ * Method:    checkPDPChannel
+ * Signature: (I)Z;
+*/
+JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_hal_PDPJNI_checkPDPChannel(
+    JNIEnv *env, jclass, jint channel) {
+  return HAL_CheckPDPChannel(channel);
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_hal_PDPJNI
+ * Method:    checkPDPModule
+ * Signature: (I)Z;
+*/
+JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_hal_PDPJNI_checkPDPModule(
+    JNIEnv *env, jclass, jint module) {
+  return HAL_CheckPDPModule(module);
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_hal_PDPJNI
  * Method:    getPDPTemperature
  * Signature: (I)D
  */

--- a/wpilibj/src/athena/cpp/lib/PWMJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/PWMJNI.cpp
@@ -48,6 +48,18 @@ Java_edu_wpi_first_wpilibj_hal_PWMJNI_initializePWMPort(
 }
 
 /*
+ * Class:     edu_wpi_first_wpilibj_hal_PWMJNI
+ * Method:    checkPWMChannel
+ * Signature: (I)Z;
+*/
+JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_hal_PWMJNI_checkPWMChannel(
+    JNIEnv *env, jclass, jint channel) {
+  PWMJNI_LOG(logDEBUG) << "Calling PWMJNI checkPWMChannel";
+  PWMJNI_LOG(logDEBUG) << "Channel = " << channel;
+  return HAL_CheckPWMChannel(channel);
+}
+
+/*
 * Class:     edu_wpi_first_wpilibj_hal_DIOJNI
 * Method:    freeDIOPort
 * Signature: (I)V;

--- a/wpilibj/src/athena/cpp/lib/SolenoidJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/SolenoidJNI.cpp
@@ -51,6 +51,30 @@ Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_initializeSolenoidPort(
 
 /*
  * Class:     edu_wpi_first_wpilibj_hal_SolenoidJNI
+ * Method:    checkSolenoidChannel
+ * Signature: (I)Z;
+*/
+JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_checkSolenoidChannel(
+    JNIEnv *env, jclass, jint channel) {
+  SOLENOIDJNI_LOG(logDEBUG) << "Calling SolenoidJNI checkSolenoidChannel";
+  SOLENOIDJNI_LOG(logDEBUG) << "Channel = " << channel;
+  return HAL_CheckSolenoidChannel(channel);
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_hal_SolenoidJNI
+ * Method:    checkSolenoidModule
+ * Signature: (I)Z;
+*/
+JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_checkSolenoidModule(
+    JNIEnv *env, jclass, jint module) {
+  SOLENOIDJNI_LOG(logDEBUG) << "Calling SolenoidJNI checkSolenoidModule";
+  SOLENOIDJNI_LOG(logDEBUG) << "Module = " << module;
+  return HAL_CheckSolenoidModule(module);
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_hal_SolenoidJNI
  * Method:    freeSolenoidPort
  * Signature: (I)V
  */

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/SensorBase.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/SensorBase.java
@@ -7,8 +7,14 @@
 
 package edu.wpi.first.wpilibj;
 
+import edu.wpi.first.wpilibj.hal.AnalogJNI;
 import edu.wpi.first.wpilibj.hal.ConstantsJNI;
+import edu.wpi.first.wpilibj.hal.DIOJNI;
+import edu.wpi.first.wpilibj.hal.PDPJNI;
+import edu.wpi.first.wpilibj.hal.PWMJNI;
 import edu.wpi.first.wpilibj.hal.PortsJNI;
+import edu.wpi.first.wpilibj.hal.RelayJNI;
+import edu.wpi.first.wpilibj.hal.SolenoidJNI;
 
 /**
  * Base class for all sensors. Stores most recent status information as well as containing utility
@@ -43,7 +49,7 @@ public abstract class SensorBase { // TODO: Refactor
   /**
    * Number of relay channels per roboRIO.
    */
-  public static final int kRelayChannels = PortsJNI.getNumRelayPins();
+  public static final int kRelayChannels = PortsJNI.getNumRelayHeaders();
   /**
    * Number of power distribution channels.
    */
@@ -81,6 +87,9 @@ public abstract class SensorBase { // TODO: Refactor
    * @param moduleNumber The solenoid module module number to check.
    */
   protected static void checkSolenoidModule(final int moduleNumber) {
+    if (!SolenoidJNI.checkSolenoidModule(moduleNumber)) {
+      throw new IndexOutOfBoundsException("Requested solenoid module number is out of range");
+    }
   }
 
   /**
@@ -90,7 +99,7 @@ public abstract class SensorBase { // TODO: Refactor
    * @param channel The channel number to check.
    */
   protected static void checkDigitalChannel(final int channel) {
-    if (channel < 0 || channel >= kDigitalChannels) {
+    if (!DIOJNI.checkDIOChannel(channel)) {
       throw new IndexOutOfBoundsException("Requested digital channel number is out of range.");
     }
   }
@@ -102,7 +111,7 @@ public abstract class SensorBase { // TODO: Refactor
    * @param channel The channel number to check.
    */
   protected static void checkRelayChannel(final int channel) {
-    if (channel < 0 || channel >= kRelayChannels) {
+    if (!RelayJNI.checkRelayChannel(channel)) {
       throw new IndexOutOfBoundsException("Requested relay channel number is out of range.");
     }
   }
@@ -114,7 +123,7 @@ public abstract class SensorBase { // TODO: Refactor
    * @param channel The channel number to check.
    */
   protected static void checkPWMChannel(final int channel) {
-    if (channel < 0 || channel >= kPwmChannels) {
+    if (!PWMJNI.checkPWMChannel(channel)) {
       throw new IndexOutOfBoundsException("Requested PWM channel number is out of range.");
     }
   }
@@ -126,7 +135,7 @@ public abstract class SensorBase { // TODO: Refactor
    * @param channel The channel number to check.
    */
   protected static void checkAnalogInputChannel(final int channel) {
-    if (channel < 0 || channel >= kAnalogInputChannels) {
+    if (!AnalogJNI.checkAnalogInputChannel(channel)) {
       throw new IndexOutOfBoundsException("Requested analog input channel number is out of range.");
     }
   }
@@ -138,7 +147,7 @@ public abstract class SensorBase { // TODO: Refactor
    * @param channel The channel number to check.
    */
   protected static void checkAnalogOutputChannel(final int channel) {
-    if (channel < 0 || channel >= kAnalogOutputChannels) {
+    if (!AnalogJNI.checkAnalogOutputChannel(channel)) {
       throw new IndexOutOfBoundsException(
           "Requested analog output channel number is out of range.");
     }
@@ -150,7 +159,7 @@ public abstract class SensorBase { // TODO: Refactor
    * @param channel The channel number to check.
    */
   protected static void checkSolenoidChannel(final int channel) {
-    if (channel < 0 || channel >= kSolenoidChannels) {
+    if (!SolenoidJNI.checkSolenoidChannel(channel)) {
       throw new IndexOutOfBoundsException("Requested solenoid channel number is out of range.");
     }
   }
@@ -162,7 +171,7 @@ public abstract class SensorBase { // TODO: Refactor
    * @param channel The channel number to check.
    */
   protected static void checkPDPChannel(final int channel) {
-    if (channel < 0 || channel >= kPDPChannels) {
+    if (!PDPJNI.checkPDPChannel(channel)) {
       throw new IndexOutOfBoundsException("Requested PDP channel number is out of range.");
     }
   }
@@ -173,7 +182,7 @@ public abstract class SensorBase { // TODO: Refactor
    * @param module The module number to check.
    */
   protected static void checkPDPModule(final int module) {
-    if (module < 0 || module > kPDPModules) {
+    if (!PDPJNI.checkPDPModule(module)) {
       throw new IndexOutOfBoundsException("Requested PDP module number is out of range.");
     }
   }

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/DIOJNI.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/DIOJNI.java
@@ -11,6 +11,8 @@ package edu.wpi.first.wpilibj.hal;
 public class DIOJNI extends JNIWrapper {
   public static native int initializeDIOPort(int halPortHandle, boolean input);
 
+  public static native boolean checkDIOChannel(int channel);
+
   public static native void freeDIOPort(int dioPortHandle);
 
   public static native void setDIO(int dioPortHandle, short value);

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/PDPJNI.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/PDPJNI.java
@@ -11,6 +11,10 @@ package edu.wpi.first.wpilibj.hal;
 public class PDPJNI extends JNIWrapper {
   public static native void initializePDP(int module);
 
+  public static native boolean checkPDPModule(int module);
+
+  public static native boolean checkPDPChannel(int channel);
+
   public static native double getPDPTemperature(int module);
 
   public static native double getPDPVoltage(int module);

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/PWMJNI.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/PWMJNI.java
@@ -13,6 +13,8 @@ import edu.wpi.first.wpilibj.PWMConfigDataResult;
 public class PWMJNI extends DIOJNI {
   public static native int initializePWMPort(int halPortHandle);
 
+  public static native boolean checkPWMChannel(int channel);
+
   public static native void freePWMPort(int pwmPortHandle);
 
   public static native void setPWMConfigRaw(int pwmPortHandle, int maxPwm,

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/SolenoidJNI.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/SolenoidJNI.java
@@ -10,6 +10,10 @@ package edu.wpi.first.wpilibj.hal;
 public class SolenoidJNI extends JNIWrapper {
   public static native int initializeSolenoidPort(int halPortHandle);
 
+  public static native boolean checkSolenoidModule(int module);
+
+  public static native boolean checkSolenoidChannel(int channel);
+
   public static native void freeSolenoidPort(int portHandle);
 
   public static native void setSolenoid(int portHandle, boolean on);


### PR DESCRIPTION
I don't know what the proper way to make the constants for size use the HAL functions in C++. Java it works fine because of how static final works, but C++ would make the variables non const.