### PR TITLE
Some general cleanups in the HAL

### DIFF
--- a/hal/lib/athena/Accelerometer.cpp
+++ b/hal/lib/athena/Accelerometer.cpp
@@ -9,6 +9,7 @@
 
 #include <cassert>
 #include <cstdio>
+#include <memory>
 
 #include <stdint.h>
 
@@ -25,7 +26,7 @@ static const uint8_t kControlTxRx = 1;
 static const uint8_t kControlStart = 2;
 static const uint8_t kControlStop = 4;
 
-static tAccel* accel = 0;
+static std::unique_ptr<tAccel> accel;
 static HAL_AccelerometerRange accelerometerRange;
 
 // Register addresses
@@ -84,7 +85,7 @@ static void initializeAccelerometer() {
   int32_t status;
 
   if (!accel) {
-    accel = tAccel::create(&status);
+    accel.reset(tAccel::create(&status));
 
     // Enable I2C
     accel->writeCNFG(1, &status);
@@ -124,8 +125,6 @@ static void writeRegister(Register reg, uint8_t data) {
   while (accel->readSTAT(&status) & 1) {
     if (HAL_GetFPGATime(&status) > initialTime + 1000) break;
   }
-
-  std::fflush(stdout);
 }
 
 static uint8_t readRegister(Register reg) {
@@ -154,8 +153,6 @@ static uint8_t readRegister(Register reg) {
   while (accel->readSTAT(&status) & 1) {
     if (HAL_GetFPGATime(&status) > initialTime + 1000) break;
   }
-
-  std::fflush(stdout);
 
   return accel->readDATI(&status);
 }

--- a/hal/lib/athena/AnalogInput.cpp
+++ b/hal/lib/athena/AnalogInput.cpp
@@ -63,8 +63,6 @@ HAL_AnalogInputHandle HAL_InitializeAnalogInputPort(HAL_PortHandle port_handle,
 }
 
 void HAL_FreeAnalogInputPort(HAL_AnalogInputHandle analog_port_handle) {
-  auto port = analogInputHandles.Get(analog_port_handle);
-  if (!port) return;
   // no status, so no need to check for a proper free.
   analogInputHandles.Free(analog_port_handle);
 }

--- a/hal/lib/athena/Counter.cpp
+++ b/hal/lib/athena/Counter.cpp
@@ -49,10 +49,6 @@ HAL_CounterHandle HAL_InitializeCounter(HAL_Counter_Mode mode, int32_t* index,
 }
 
 void HAL_FreeCounter(HAL_CounterHandle counter_handle, int32_t* status) {
-  auto counter = counterHandles.Get(counter_handle);
-  if (counter == nullptr) {  // don't throw status as unneccesary
-    return;
-  }
   counterHandles.Free(counter_handle);
 }
 

--- a/hal/lib/athena/FPGAEncoder.cpp
+++ b/hal/lib/athena/FPGAEncoder.cpp
@@ -84,12 +84,7 @@ HAL_FPGAEncoderHandle HAL_InitializeFPGAEncoder(
 
 void HAL_FreeFPGAEncoder(HAL_FPGAEncoderHandle fpga_encoder_handle,
                          int32_t* status) {
-  auto encoder = fpgaEncoderHandles.Get(fpga_encoder_handle);
   fpgaEncoderHandles.Free(fpga_encoder_handle);
-  if (encoder == nullptr) {
-    *status = HAL_HANDLE_ERROR;
-    return;
-  }
 }
 
 /**

--- a/hal/lib/athena/Interrupts.cpp
+++ b/hal/lib/athena/Interrupts.cpp
@@ -52,11 +52,6 @@ HAL_InterruptHandle HAL_InitializeInterrupts(HAL_Bool watcher,
 
 void HAL_CleanInterrupts(HAL_InterruptHandle interrupt_handle,
                          int32_t* status) {
-  auto anInterrupt = interruptHandles.Get(interrupt_handle);
-  if (anInterrupt == nullptr) {
-    *status = HAL_HANDLE_ERROR;
-    return;
-  }
   interruptHandles.Free(interrupt_handle);
 }
 


### PR DESCRIPTION
AnalogTrigger initialization checks are now in the correct order. Plus frees no longer grab the structure if it is not needed.