### PR TITLE
Set duplicate strategy for all jars and zips to prevent duplicates

### DIFF
--- a/simulation/SimDS/build.gradle
+++ b/simulation/SimDS/build.gradle
@@ -43,6 +43,8 @@ task simDsSources(type: Jar, dependsOn: classes) {
     description = 'Creates the sources jar for the SimDS'
     group = 'WPILib'
     classifier = 'sources'
+    duplicatesStrategy = 'exclude'
+
     from sourceSets.main.allJava
 }
 
@@ -50,6 +52,8 @@ task simDsJavadoc(type: Jar, dependsOn: javadoc) {
     description = 'Creates the javadoc jar for the SimDS'
     group = 'WPILib'
     classifier = 'javadoc'
+    duplicatesStrategy = 'exclude'
+
     from javadoc.destinationDir
 }
 

--- a/simulation/build.gradle
+++ b/simulation/build.gradle
@@ -31,5 +31,7 @@ task zip(type: Zip, dependsOn: [copy_resources,
     description = 'zip of all the resources for simulation'
     group = 'WPILib Simulation'
     baseName = 'simulation-trusty'
+    duplicatesStrategy = 'exclude'
+
     from "$simulationInstallDir"
 }

--- a/wpilibc/athena.gradle
+++ b/wpilibc/athena.gradle
@@ -34,6 +34,7 @@ task wpilibcZip(type: Zip) {
     group = 'WPILib'
     baseName = 'wpilibc'
     destinationDir = project.buildDir
+    duplicatesStrategy = 'exclude'
 
     // Include the static library file and header files from this project
     model {
@@ -161,6 +162,8 @@ if (checkDoxygen()) {
         description = 'Generates doxygen zip file for publishing'
         group = 'WPILib'
         dependsOn doxygen
+        duplicatesStrategy = 'exclude'
+
         from doxygen.outputDir
     }
 }

--- a/wpilibj/athena.gradle
+++ b/wpilibj/athena.gradle
@@ -105,6 +105,8 @@ task wpilibjSources(type: Jar, dependsOn: classes) {
     description = 'Creates the sources jar for the maven publishing routine'
     group = 'WPILib'
     classifier = 'sources'
+    duplicatesStrategy = 'exclude'
+
     from sourceSets.athena.allJava
     from sourceSets.shared.allJava
 }
@@ -136,6 +138,8 @@ task wpilibjJavadoc(type: Jar, dependsOn: javadoc) {
     description = 'Creates the javadoc jar for the maven publishing routine'
     group = 'WPILib'
     classifier = 'javadoc'
+    duplicatesStrategy = 'exclude'
+
     from javadoc.destinationDir
 }
 

--- a/wpilibj/simulation.gradle
+++ b/wpilibj/simulation.gradle
@@ -12,6 +12,8 @@ dependencies {
 task wpilibjSimJar(type: Jar, dependsOn: simClasses) {
     description = 'Creates the WPILibJSimulation Jar'
     group = 'WPILib Simulation'
+    duplicatesStrategy = 'exclude'
+
     def addClasspath = { classpath ->
         classpath.files.findAll { it.exists() }.each {
             if (file(it).directory) {
@@ -34,6 +36,8 @@ task wpilibjSimSources(type: Jar, dependsOn: simClasses) {
     description = 'Creates the wpilibjSimulation sources jar for the maven publishing routine'
     group = 'WPILib'
     classifier = 'sources'
+    duplicatesStrategy = 'exclude'
+
     from sourceSets.sim.allJava
     from sourceSets.shared.allJava
 }
@@ -50,6 +54,8 @@ task wpilibjSimJavadocJar(type: Jar, dependsOn: wpilibjSimJavadoc) {
     description = 'Creates the wpilibjSimulation javadoc jar for the maven publishing routine'
     group = 'WPILib'
     classifier = 'javadoc'
+    duplicatesStrategy = 'exclude'
+
     from wpilibjSimJavadoc.destinationDir
 }
 


### PR DESCRIPTION
This will prevent duplicates from appearing in any of our produced binaries, even accidentally.