### PR TITLE
Added extensions to .styleguide

### DIFF
--- a/.styleguide
+++ b/.styleguide
@@ -1,3 +1,16 @@
+cExtensions {
+}
+
+cppExtensions {
+  cpp
+  h
+  inc
+}
+
+otherExtensions {
+  java
+}
+
 genFolderExclude {
   \.vscode
   FRC_FPGA_ChipObject


### PR DESCRIPTION
wpilibsuite/styleguide is going to use extensions specified in .styleguide instead of hardcoded extensions (see #4). This PR should be merged first to maintain correct operation of format.py.