### PR TITLE
Remove static_assert for sizeof(uint32_t) <= sizeof(void*)

### DIFF
--- a/hal/lib/athena/SPI.cpp
+++ b/hal/lib/athena/SPI.cpp
@@ -16,9 +16,6 @@
 #include "HAL/cpp/priority_mutex.h"
 #include "spilib/spi-lib.h"
 
-static_assert(sizeof(uint32_t) <= sizeof(void*),
-              "This file shoves uint32_ts into pointers.");
-
 using namespace hal;
 
 static int32_t m_spiCS0Handle = 0;


### PR DESCRIPTION
According to #192, we don't cast integers to pointers anymore. The size static_assert is unnecessary.