### PR TITLE
C standard library functions and types are now prefixed with std::

### DIFF
--- a/hal/include/HAL/DriverStation.h
+++ b/hal/include/HAL/DriverStation.h
@@ -7,8 +7,9 @@
 
 #pragma once
 
-#include <stddef.h>
 #include <stdint.h>
+
+#include <cstddef>
 
 #include "HAL/Types.h"
 

--- a/hal/include/HAL/cpp/make_unique.h
+++ b/hal/include/HAL/cpp/make_unique.h
@@ -9,8 +9,7 @@
 
 // Define make_unique for C++11-only compilers
 #if __cplusplus == 201103L
-#include <stddef.h>
-
+#include <cstddef>
 #include <memory>
 #include <type_traits>
 #include <utility>

--- a/hal/lib/athena/DIO.cpp
+++ b/hal/lib/athena/DIO.cpp
@@ -143,8 +143,8 @@ void HAL_SetDigitalPWMRate(double rate, int32_t* status) {
   // higher freq.
   // TODO: Round in the linear rate domain.
   uint8_t pwmPeriodPower = static_cast<uint8_t>(
-      log(1.0 / (pwmSystem->readLoopTiming(status) * 0.25E-6 * rate)) /
-          log(2.0) +
+      std::log(1.0 / (pwmSystem->readLoopTiming(status) * 0.25E-6 * rate)) /
+          std::log(2.0) +
       0.5);
   digitalSystem->writePWMPeriodPower(pwmPeriodPower, status);
 }

--- a/hal/lib/athena/HAL.cpp
+++ b/hal/lib/athena/HAL.cpp
@@ -8,10 +8,10 @@
 #include "HAL/HAL.h"
 
 #include <signal.h>  // linux for kill
-#include <stdlib.h>
 #include <sys/prctl.h>
 #include <unistd.h>
 
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <mutex>

--- a/wpilibc/athena/src/CameraServer.cpp
+++ b/wpilibc/athena/src/CameraServer.cpp
@@ -206,7 +206,7 @@ void CameraServer::Serve() {
       continue;
     }
 
-    memcpy(&req, reqBuf, sizeof(req));
+    std::memcpy(&req, reqBuf, sizeof(req));
     req.fps = ntohl(req.fps);
     req.compression = ntohl(req.compression);
     req.size = ntohl(req.size);

--- a/wpilibc/athena/src/DriverStation.cpp
+++ b/wpilibc/athena/src/DriverStation.cpp
@@ -6,7 +6,7 @@
 /*----------------------------------------------------------------------------*/
 
 #include "DriverStation.h"
-#include <string.h>
+
 #include "AnalogInput.h"
 #include "FRC_NetworkCommunication/FRCComm.h"
 #include "HAL/cpp/Log.h"

--- a/wpilibc/athena/src/Joystick.cpp
+++ b/wpilibc/athena/src/Joystick.cpp
@@ -6,8 +6,9 @@
 /*----------------------------------------------------------------------------*/
 
 #include "Joystick.h"
-#include <math.h>
-#include <string.h>
+
+#include <cmath>
+
 #include "DriverStation.h"
 #include "WPIErrors.h"
 
@@ -330,7 +331,7 @@ void Joystick::SetAxisChannel(AxisType axis, int channel) {
  * @return The magnitude of the direction vector
  */
 float Joystick::GetMagnitude() const {
-  return sqrt(pow(GetX(), 2) + pow(GetY(), 2));
+  return std::sqrt(std::pow(GetX(), 2) + std::pow(GetY(), 2));
 }
 
 /**
@@ -339,19 +340,21 @@ float Joystick::GetMagnitude() const {
  *
  * @return The direction of the vector in radians
  */
-float Joystick::GetDirectionRadians() const { return atan2(GetX(), -GetY()); }
+float Joystick::GetDirectionRadians() const {
+  return std::atan2(GetX(), -GetY());
+}
 
 /**
  * Get the direction of the vector formed by the joystick and its origin
  * in degrees.
  *
- * uses acos(-1) to represent Pi due to absence of readily accessible Pi
+ * uses std::acos(-1) to represent Pi due to absence of readily accessible Pi
  * constant in C++
  *
  * @return The direction of the vector in degrees
  */
 float Joystick::GetDirectionDegrees() const {
-  return (180 / acos(-1)) * GetDirectionRadians();
+  return (180 / std::acos(-1)) * GetDirectionRadians();
 }
 
 /**

--- a/wpilibc/athena/src/Vision/AxisCamera.cpp
+++ b/wpilibc/athena/src/Vision/AxisCamera.cpp
@@ -9,11 +9,11 @@
 
 #include <netdb.h>
 #include <netinet/in.h>
-#include <string.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <cstring>
 #include <iostream>
 #include <sstream>
 
@@ -442,12 +442,12 @@ void AxisCamera::ReadImagesFromCamera() {
         close(m_cameraSocket);
         return;
       }
-      strncat(initialReadBuffer, intermediateBuffer, 1);
+      std::strncat(initialReadBuffer, intermediateBuffer, 1);
       // trailingCounter ensures that we start looking for the 4 byte string
       // after
       // there is at least 4 bytes total. Kind of obscure.
       // look for 2 blank lines (\r\n)
-      if (nullptr != strstr(trailingPtr, "\r\n\r\n")) {
+      if (nullptr != std::strstr(trailingPtr, "\r\n\r\n")) {
         --counter;
       }
       if (++trailingCounter >= 4) {
@@ -455,7 +455,7 @@ void AxisCamera::ReadImagesFromCamera() {
       }
     }
     counter = 1;
-    char* contentLength = strstr(initialReadBuffer, "Content-Length: ");
+    char* contentLength = std::strstr(initialReadBuffer, "Content-Length: ");
     if (contentLength == nullptr) {
       wpi_setWPIErrorWithContext(IncompatibleMode,
                                  "No content-length token found in packet");

--- a/wpilibc/athena/src/Vision/BaeUtilities.cpp
+++ b/wpilibc/athena/src/Vision/BaeUtilities.cpp
@@ -146,14 +146,16 @@ void dprintf(const char* tempString, ...) {
       break;
     case DEBUG_FILE_ONLY:
       if ((outfile_fd = std::fopen(filepath, "a+")) != nullptr) {
-        fwrite(ss.str().c_str(), sizeof(char), ss.str().length(), outfile_fd);
+        std::fwrite(ss.str().c_str(), sizeof(char), ss.str().length(),
+                    outfile_fd);
         std::fclose(outfile_fd);
       }
       break;
     case DEBUG_SCREEN_AND_FILE:  // BOTH
       std::printf("%s", ss.str().c_str());
       if ((outfile_fd = std::fopen(filepath, "a+")) != nullptr) {
-        fwrite(ss.str().c_str(), sizeof(char), ss.str().length(), outfile_fd);
+        std::fwrite(ss.str().c_str(), sizeof(char), ss.str().length(),
+                    outfile_fd);
         std::fclose(outfile_fd);
       }
       break;

--- a/wpilibc/shared/include/CircularBuffer.h
+++ b/wpilibc/shared/include/CircularBuffer.h
@@ -7,8 +7,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <vector>
 
 /**

--- a/wpilibc/shared/src/Filters/LinearDigitalFilter.cpp
+++ b/wpilibc/shared/src/Filters/LinearDigitalFilter.cpp
@@ -7,8 +7,8 @@
 
 #include "Filters/LinearDigitalFilter.h"
 
-#include <assert.h>
-#include <math.h>
+#include <cassert>
+#include <cmath>
 
 /**
  * Create a linear FIR or IIR filter.

--- a/wpilibc/sim/src/DoubleSolenoid.cpp
+++ b/wpilibc/sim/src/DoubleSolenoid.cpp
@@ -6,7 +6,7 @@
 /*----------------------------------------------------------------------------*/
 
 #include "DoubleSolenoid.h"
-#include <string.h>
+
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 

--- a/wpilibc/sim/src/DriverStation.cpp
+++ b/wpilibc/sim/src/DriverStation.cpp
@@ -7,8 +7,6 @@
 
 #include "DriverStation.h"
 
-#include <string.h>
-
 #include <boost/mem_fn.hpp>
 
 #include "HAL/cpp/Log.h"

--- a/wpilibc/sim/src/Joystick.cpp
+++ b/wpilibc/sim/src/Joystick.cpp
@@ -6,8 +6,10 @@
 /*----------------------------------------------------------------------------*/
 
 #include "Joystick.h"
-#include <math.h>
+
+#include <cmath>
 #include <memory>
+
 #include "DriverStation.h"
 #include "WPIErrors.h"
 
@@ -254,7 +256,7 @@ void Joystick::SetAxisChannel(AxisType axis, int channel) {
  * @return The magnitude of the direction vector
  */
 float Joystick::GetMagnitude() const {
-  return sqrt(pow(GetX(), 2) + pow(GetY(), 2));
+  return std::sqrt(std::pow(GetX(), 2) + std::pow(GetY(), 2));
 }
 
 /**
@@ -263,17 +265,19 @@ float Joystick::GetMagnitude() const {
  *
  * @return The direction of the vector in radians
  */
-float Joystick::GetDirectionRadians() const { return atan2(GetX(), -GetY()); }
+float Joystick::GetDirectionRadians() const {
+  return std::atan2(GetX(), -GetY());
+}
 
 /**
  * Get the direction of the vector formed by the joystick and its origin
  * in degrees.
  *
- * uses acos(-1) to represent Pi due to absence of readily accessable PI
+ * uses std::acos(-1) to represent Pi due to absence of readily accessable PI
  * constant in C++
  *
  * @return The direction of the vector in degrees
  */
 float Joystick::GetDirectionDegrees() const {
-  return (180 / acos(-1)) * GetDirectionRadians();
+  return (180 / std::acos(-1)) * GetDirectionRadians();
 }

--- a/wpilibc/sim/src/RobotBase.cpp
+++ b/wpilibc/sim/src/RobotBase.cpp
@@ -6,10 +6,9 @@
 /*----------------------------------------------------------------------------*/
 
 #include "RobotBase.h"
+
 #include "RobotState.h"
 #include "Utility.h"
-
-#include <string.h>
 
 /**
  * Constructor for a generic robot program.

--- a/wpilibc/sim/src/RobotDrive.cpp
+++ b/wpilibc/sim/src/RobotDrive.cpp
@@ -6,15 +6,15 @@
 /*----------------------------------------------------------------------------*/
 
 #include "RobotDrive.h"
-#include <math.h>
+
+#include <algorithm>
+#include <cmath>
+
 #include "GenericHID.h"
 #include "Joystick.h"
 #include "Talon.h"
 #include "Utility.h"
 #include "WPIErrors.h"
-
-#undef max
-#include <algorithm>
 
 const int RobotDrive::kMaxNumberOfMotors;
 
@@ -214,13 +214,13 @@ void RobotDrive::Drive(float outputMagnitude, float curve) {
   }
 
   if (curve < 0) {
-    float value = log(-curve);
+    float value = std::log(-curve);
     float ratio = (value - m_sensitivity) / (value + m_sensitivity);
     if (ratio == 0) ratio = .0000000001;
     leftOutput = outputMagnitude / ratio;
     rightOutput = outputMagnitude;
   } else if (curve > 0) {
-    float value = log(curve);
+    float value = std::log(curve);
     float ratio = (value - m_sensitivity) / (value + m_sensitivity);
     if (ratio == 0) ratio = .0000000001;
     leftOutput = outputMagnitude;
@@ -541,11 +541,11 @@ void RobotDrive::MecanumDrive_Polar(float magnitude, float direction,
   }
 
   // Normalized for full power along the Cartesian axes.
-  magnitude = Limit(magnitude) * sqrt(2.0);
+  magnitude = Limit(magnitude) * std::sqrt(2.0);
   // The rollers are at 45 degree angles.
   double dirInRad = (direction + 45.0) * 3.14159 / 180.0;
-  double cosD = cos(dirInRad);
-  double sinD = sin(dirInRad);
+  double cosD = std::cos(dirInRad);
+  double sinD = std::sin(dirInRad);
 
   double wheelSpeeds[kMaxNumberOfMotors];
   wheelSpeeds[kFrontLeftMotor] = sinD * magnitude + rotation;
@@ -629,10 +629,10 @@ float RobotDrive::Limit(float num) {
  * Normalize all wheel speeds if the magnitude of any wheel is greater than 1.0.
  */
 void RobotDrive::Normalize(double* wheelSpeeds) {
-  double maxMagnitude = fabs(wheelSpeeds[0]);
+  double maxMagnitude = std::fabs(wheelSpeeds[0]);
   int i;
   for (i = 1; i < kMaxNumberOfMotors; i++) {
-    double temp = fabs(wheelSpeeds[i]);
+    double temp = std::fabs(wheelSpeeds[i]);
     if (maxMagnitude < temp) maxMagnitude = temp;
   }
   if (maxMagnitude > 1.0) {
@@ -646,8 +646,8 @@ void RobotDrive::Normalize(double* wheelSpeeds) {
  * Rotate a vector in Cartesian space.
  */
 void RobotDrive::RotateVector(double& x, double& y, double angle) {
-  double cosA = cos(angle * (3.14159 / 180.0));
-  double sinA = sin(angle * (3.14159 / 180.0));
+  double cosA = std::cos(angle * (3.14159 / 180.0));
+  double sinA = std::sin(angle * (3.14159 / 180.0));
   double xOut = x * cosA - y * sinA;
   double yOut = x * sinA + y * cosA;
   x = xOut;

--- a/wpilibc/sim/src/Utility.cpp
+++ b/wpilibc/sim/src/Utility.cpp
@@ -160,7 +160,7 @@ static std::string demangle(char const* mangledSymbol) {
   size_t length;
   int32_t status;
 
-  if (sscanf(mangledSymbol, "%*[^(]%*[^_]%255[^)+]", buffer)) {
+  if (std::sscanf(mangledSymbol, "%*[^(]%*[^_]%255[^)+]", buffer)) {
     char* symbol = abi::__cxa_demangle(buffer, nullptr, &length, &status);
 
     if (status == 0) {

--- a/wpilibcIntegrationTests/src/FilterNoiseTest.cpp
+++ b/wpilibcIntegrationTests/src/FilterNoiseTest.cpp
@@ -7,8 +7,7 @@
 
 #include "Filters/LinearDigitalFilter.h"  // NOLINT(build/include_order)
 
-#include <math.h>
-
+#include <cmath>
 #include <functional>
 #include <memory>
 #include <random>

--- a/wpilibcIntegrationTests/src/FilterOutputTest.cpp
+++ b/wpilibcIntegrationTests/src/FilterOutputTest.cpp
@@ -7,8 +7,7 @@
 
 #include "Filters/LinearDigitalFilter.h"  // NOLINT(build/include_order)
 
-#include <math.h>
-
+#include <cmath>
 #include <functional>
 #include <memory>
 #include <random>

--- a/wpilibcIntegrationTests/src/PreferencesTest.cpp
+++ b/wpilibcIntegrationTests/src/PreferencesTest.cpp
@@ -7,8 +7,7 @@
 
 #include "Preferences.h"  // NOLINT(build/include_order)
 
-#include <stdio.h>
-
+#include <cstdio>
 #include <fstream>
 
 #include "Timer.h"


### PR DESCRIPTION
See wpilibsuite/styleguide #8.