### PR TITLE
Make some Iterative variables protected

### DIFF
--- a/wpilibc/athena/include/IterativeRobot.h
+++ b/wpilibc/athena/include/IterativeRobot.h
@@ -69,10 +69,9 @@ class IterativeRobot : public RobotBase {
  protected:
   virtual ~IterativeRobot() = default;
   IterativeRobot() = default;
-
- private:
   bool m_disabledInitialized = false;
   bool m_autonomousInitialized = false;
   bool m_teleopInitialized = false;
   bool m_testInitialized = false;
+
 };

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/IterativeRobot.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/IterativeRobot.java
@@ -35,10 +35,10 @@ import edu.wpi.first.wpilibj.livewindow.LiveWindow;
  * disabledPeriodic() - autonomousPeriodic() - teleopPeriodic() - testPeriodoc()
  */
 public class IterativeRobot extends RobotBase {
-  private boolean m_disabledInitialized;
-  private boolean m_autonomousInitialized;
-  private boolean m_teleopInitialized;
-  private boolean m_testInitialized;
+  protected boolean m_disabledInitialized;
+  protected boolean m_autonomousInitialized;
+  protected boolean m_teleopInitialized;
+  protected boolean m_testInitialized;
 
   /**
    * Constructor for RobotIterativeBase.
@@ -144,7 +144,7 @@ public class IterativeRobot extends RobotBase {
    * Determine if the appropriate next periodic function should be called. Call the periodic
    * functions whenever a packet is received from the Driver Station, or about every 20ms.
    */
-  private boolean nextPeriodReady() {
+  protected boolean nextPeriodReady() {
     return m_ds.isNewControlData();
   }
 
@@ -307,5 +307,6 @@ public class IterativeRobot extends RobotBase {
       System.out.println("Default IterativeRobot.testPeriodic() method... Overload me!");
       m_tmpFirstRun = false;
     }
+    Timer.delay(0.001);
   }
 }


### PR DESCRIPTION
Allows users to extend Iterative Robot without modifying wpilib.
Add delay to TestPeriodic in Java to match other Periodic methods
and C++.

Change-Id: Id069dbe1211b8e63fd8f5b65507095578adb7794