### PR TITLE
Remove delay from periodic methods.

### DIFF
--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/IterativeRobot.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/IterativeRobot.java
@@ -223,7 +223,6 @@ public class IterativeRobot extends RobotBase {
       System.out.println("Default IterativeRobot.robotPeriodic() method... Overload me!");
       m_rpFirstRun = false;
     }
-    Timer.delay(0.001);
   }
 
   private boolean m_dpFirstRun = true;
@@ -244,7 +243,6 @@ public class IterativeRobot extends RobotBase {
       System.out.println("Default IterativeRobot.disabledPeriodic() method... Overload me!");
       m_dpFirstRun = false;
     }
-    Timer.delay(0.001);
   }
 
   private boolean m_apFirstRun = true;
@@ -265,7 +263,6 @@ public class IterativeRobot extends RobotBase {
       System.out.println("Default IterativeRobot.autonomousPeriodic() method... Overload me!");
       m_apFirstRun = false;
     }
-    Timer.delay(0.001);
   }
 
   private boolean m_tpFirstRun = true;
@@ -286,7 +283,6 @@ public class IterativeRobot extends RobotBase {
       System.out.println("Default IterativeRobot.teleopPeriodic() method... Overload me!");
       m_tpFirstRun = false;
     }
-    Timer.delay(0.001);
   }
 
   private boolean m_tmpFirstRun = true;


### PR DESCRIPTION
Removes the delay from the default IterativeRobot periodic methods.  

Per @ThadHouse's [comment](https://github.com/wpilibsuite/allwpilib/pull/240#r79291125)