### PR TITLE
Fixed compilation with GCC 6

### DIFF
--- a/wpilibc/athena/src/CANJaguar.cpp
+++ b/wpilibc/athena/src/CANJaguar.cpp
@@ -8,6 +8,7 @@
 #include "CANJaguar.h"
 
 #include <cassert>
+#include <cmath>
 
 #include "FRC_NetworkCommunication/CANSessionMux.h"
 #include "HAL/HAL.h"
@@ -864,7 +865,7 @@ void CANJaguar::verify() {
       // The returned max output voltage is sometimes slightly higher or
       // lower than what was sent.  This should not trigger resending
       // the message.
-      if (std::abs(voltage - m_maxOutputVoltage) < 0.1) {
+      if (std::fabs(voltage - m_maxOutputVoltage) < 0.1) {
         m_maxOutputVoltageVerified = true;
       } else {
         // It's wrong - set it again

--- a/wpilibcIntegrationTests/src/CANJaguarTest.cpp
+++ b/wpilibcIntegrationTests/src/CANJaguarTest.cpp
@@ -7,6 +7,8 @@
 
 #include "CANJaguar.h"
 
+#include <cmath>
+
 #include "AnalogOutput.h"
 #include "DigitalOutput.h"
 #include "Relay.h"
@@ -221,7 +223,7 @@ TEST_F(CANJaguarTest, BrownOut) {
   for (int32_t i = 0; i < 10; i++) {
     SetJaguar(1.0f, setpoint);
 
-    if (std::abs(m_jaguar->GetPosition() - setpoint) <=
+    if (std::fabs(m_jaguar->GetPosition() - setpoint) <=
         kEncoderPositionTolerance) {
       return;
     }
@@ -336,7 +338,7 @@ TEST_F(CANJaguarTest, PositionModeWorks) {
   for (int32_t i = 0; i < 10; i++) {
     SetJaguar(1.0f, setpoint);
 
-    if (std::abs(m_jaguar->GetPosition() - setpoint) <=
+    if (std::fabs(m_jaguar->GetPosition() - setpoint) <=
         kEncoderPositionTolerance) {
       return;
     }
@@ -358,13 +360,13 @@ TEST_F(CANJaguarTest, DISABLED_CurrentModeWorks) {
 
   for (auto& setpoints_i : setpoints) {
     float setpoint = setpoints_i;
-    float expectedCurrent = std::abs(setpoints_i);
+    float expectedCurrent = std::fabs(setpoints_i);
 
     /* It should get to each setpoint within 10 seconds */
     for (int32_t j = 0; j < 10; j++) {
       SetJaguar(1.0, setpoint);
 
-      if (std::abs(m_jaguar->GetOutputCurrent() - expectedCurrent) <=
+      if (std::fabs(m_jaguar->GetOutputCurrent() - expectedCurrent) <=
           kCurrentTolerance) {
         break;
       }

--- a/wpilibcIntegrationTests/src/TiltPanCameraTest.cpp
+++ b/wpilibcIntegrationTests/src/TiltPanCameraTest.cpp
@@ -5,6 +5,8 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#include <cmath>
+
 #include "ADXL345_SPI.h"
 #include "AnalogGyro.h"
 #include "Servo.h"


### PR DESCRIPTION
Since newer versions of GCC emit more warnings and errors, I tried building WPILib with GCC 6.2.0. This patch fixes compilation errors that occurred.