### PR TITLE
Namespace all wpilibc functions/classes into "frc" namespace.

### DIFF
--- a/wpilibc/athena.gradle
+++ b/wpilibc/athena.gradle
@@ -11,6 +11,7 @@ model {
             targetPlatform 'arm'
             binaries.all {
                 tasks.withType(CppCompile) {
+                    cppCompiler.args "-DNAMESPACED_WPILIB"
                     addNiLibraryLinks(linker, targetPlatform)
                     addNetworkTablesLibraryLinks(it, linker, targetPlatform)
                 }

--- a/wpilibc/athena/include/ADXL345_I2C.h
+++ b/wpilibc/athena/include/ADXL345_I2C.h
@@ -14,6 +14,8 @@
 #include "LiveWindow/LiveWindowSendable.h"
 #include "interfaces/Accelerometer.h"
 
+namespace frc {
+
 /**
  * ADXL345 Accelerometer on I2C.
  *
@@ -81,3 +83,5 @@ class ADXL345_I2C : public Accelerometer, public LiveWindowSendable {
  private:
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/ADXL345_SPI.h
+++ b/wpilibc/athena/include/ADXL345_SPI.h
@@ -15,6 +15,8 @@
 #include "SensorBase.h"
 #include "interfaces/Accelerometer.h"
 
+namespace frc {
+
 class DigitalInput;
 class DigitalOutput;
 
@@ -83,3 +85,5 @@ class ADXL345_SPI : public Accelerometer, public LiveWindowSendable {
  private:
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/ADXL362.h
+++ b/wpilibc/athena/include/ADXL362.h
@@ -15,6 +15,8 @@
 #include "SensorBase.h"
 #include "interfaces/Accelerometer.h"
 
+namespace frc {
+
 class DigitalInput;
 class DigitalOutput;
 
@@ -62,3 +64,5 @@ class ADXL362 : public Accelerometer, public LiveWindowSendable {
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/ADXRS450_Gyro.h
+++ b/wpilibc/athena/include/ADXRS450_Gyro.h
@@ -14,6 +14,8 @@
 #include "Notifier.h"
 #include "SPI.h"
 
+namespace frc {
+
 /**
  * Use a rate gyro to return the robots heading relative to a starting position.
  * The Gyro class tracks the robots heading based on the starting position. As
@@ -41,3 +43,5 @@ class ADXRS450_Gyro : public GyroBase {
 
   uint16_t ReadRegister(int reg);
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/AnalogAccelerometer.h
+++ b/wpilibc/athena/include/AnalogAccelerometer.h
@@ -15,6 +15,8 @@
 #include "PIDSource.h"
 #include "SensorBase.h"
 
+namespace frc {
+
 /**
  * Handle operation of an analog accelerometer.
  * The accelerometer reads acceleration directly through the sensor. Many
@@ -51,3 +53,5 @@ class AnalogAccelerometer : public SensorBase,
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/AnalogGyro.h
+++ b/wpilibc/athena/include/AnalogGyro.h
@@ -12,6 +12,8 @@
 #include "GyroBase.h"
 #include "HAL/Types.h"
 
+namespace frc {
+
 class AnalogInput;
 
 /**
@@ -58,3 +60,5 @@ class AnalogGyro : public GyroBase {
  private:
   HAL_GyroHandle m_gyroHandle = HAL_kInvalidHandle;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/AnalogInput.h
+++ b/wpilibc/athena/include/AnalogInput.h
@@ -15,6 +15,8 @@
 #include "PIDSource.h"
 #include "SensorBase.h"
 
+namespace frc {
+
 /**
  * Analog input class.
  *
@@ -87,3 +89,5 @@ class AnalogInput : public SensorBase,
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/AnalogOutput.h
+++ b/wpilibc/athena/include/AnalogOutput.h
@@ -16,6 +16,8 @@
 #include "LiveWindow/LiveWindowSendable.h"
 #include "SensorBase.h"
 
+namespace frc {
+
 /**
  * MXP analog output class.
  */
@@ -40,3 +42,5 @@ class AnalogOutput : public SensorBase, public LiveWindowSendable {
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/AnalogPotentiometer.h
+++ b/wpilibc/athena/include/AnalogPotentiometer.h
@@ -14,6 +14,8 @@
 #include "LiveWindow/LiveWindowSendable.h"
 #include "interfaces/Potentiometer.h"
 
+namespace frc {
+
 /**
  * Class for reading analog potentiometers. Analog potentiometers read
  * in an analog voltage that corresponds to a position. The position is
@@ -90,3 +92,5 @@ class AnalogPotentiometer : public Potentiometer, public LiveWindowSendable {
   double m_fullRange, m_offset;
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/AnalogTrigger.h
+++ b/wpilibc/athena/include/AnalogTrigger.h
@@ -13,6 +13,8 @@
 #include "HAL/Types.h"
 #include "SensorBase.h"
 
+namespace frc {
+
 class AnalogInput;
 
 class AnalogTrigger : public SensorBase {
@@ -39,3 +41,5 @@ class AnalogTrigger : public SensorBase {
   AnalogInput* m_analogInput = nullptr;
   bool m_ownsAnalog = false;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/AnalogTriggerOutput.h
+++ b/wpilibc/athena/include/AnalogTriggerOutput.h
@@ -10,6 +10,8 @@
 #include "DigitalSource.h"
 #include "HAL/AnalogTrigger.h"
 
+namespace frc {
+
 class AnalogTrigger;
 
 /**
@@ -67,3 +69,5 @@ class AnalogTriggerOutput : public DigitalSource {
   const AnalogTrigger& m_trigger;
   AnalogTriggerType m_outputType;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/AnalogTriggerType.h
+++ b/wpilibc/athena/include/AnalogTriggerType.h
@@ -7,9 +7,13 @@
 
 #pragma once
 
+namespace frc {
+
 enum class AnalogTriggerType {
   kInWindow = 0,
   kState = 1,
   kRisingPulse = 2,
   kFallingPulse = 3
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/BuiltInAccelerometer.h
+++ b/wpilibc/athena/include/BuiltInAccelerometer.h
@@ -14,6 +14,8 @@
 #include "SensorBase.h"
 #include "interfaces/Accelerometer.h"
 
+namespace frc {
+
 /**
  * Built-in accelerometer.
  *
@@ -42,3 +44,5 @@ class BuiltInAccelerometer : public Accelerometer,
  private:
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/CANSpeedController.h
+++ b/wpilibc/athena/include/CANSpeedController.h
@@ -9,6 +9,8 @@
 
 #include "SpeedController.h"
 
+namespace frc {
+
 /**
  * Interface for "smart" CAN-based speed controllers.
  */
@@ -98,3 +100,5 @@ class CANSpeedController : public SpeedController {
   // virtual void SetControlMode(ControlMode mode) = 0;
   // virtual ControlMode GetControlMode() const = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/CameraServer.h
+++ b/wpilibc/athena/include/CameraServer.h
@@ -19,6 +19,8 @@
 #include "USBCamera.h"
 #include "nivision.h"
 
+namespace frc {
+
 class CameraServer : public ErrorBase {
  private:
   static constexpr uint16_t kPort = 1180;
@@ -80,3 +82,5 @@ class CameraServer : public ErrorBase {
 
   void SetSize(int size);
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Compressor.h
+++ b/wpilibc/athena/include/Compressor.h
@@ -15,6 +15,8 @@
 #include "SensorBase.h"
 #include "tables/ITableListener.h"
 
+namespace frc {
+
 /**
  * PCM compressor
  */
@@ -63,3 +65,5 @@ class Compressor : public SensorBase,
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/ControllerPower.h
+++ b/wpilibc/athena/include/ControllerPower.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+namespace frc {
+
 class ControllerPower {
  public:
   static float GetInputVoltage();
@@ -24,3 +26,5 @@ class ControllerPower {
   static bool GetEnabled6V();
   static int GetFaultCount6V();
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Counter.h
+++ b/wpilibc/athena/include/Counter.h
@@ -17,6 +17,8 @@
 #include "LiveWindow/LiveWindowSendable.h"
 #include "SensorBase.h"
 
+namespace frc {
+
 class DigitalGlitchFilter;
 
 /**
@@ -113,3 +115,5 @@ class Counter : public SensorBase,
   std::shared_ptr<ITable> m_table;
   friend class DigitalGlitchFilter;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/CounterBase.h
+++ b/wpilibc/athena/include/CounterBase.h
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+namespace frc {
+
 /**
  * Interface for counting the number of ticks on a digital input channel.
  * Encoders, Gear tooth sensors, and counters should all subclass this so it can
@@ -29,3 +31,5 @@ class CounterBase {
   virtual bool GetStopped() const = 0;
   virtual bool GetDirection() const = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/DigitalGlitchFilter.h
+++ b/wpilibc/athena/include/DigitalGlitchFilter.h
@@ -12,6 +12,8 @@
 #include "DigitalSource.h"
 #include "HAL/cpp/priority_mutex.h"
 
+namespace frc {
+
 class Encoder;
 class Counter;
 
@@ -50,3 +52,5 @@ class DigitalGlitchFilter : public SensorBase {
   static priority_mutex m_mutex;
   static ::std::array<bool, 3> m_filterAllocated;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/DigitalInput.h
+++ b/wpilibc/athena/include/DigitalInput.h
@@ -15,6 +15,8 @@
 #include "DigitalSource.h"
 #include "LiveWindow/LiveWindowSendable.h"
 
+namespace frc {
+
 class DigitalGlitchFilter;
 
 /**
@@ -51,3 +53,5 @@ class DigitalInput : public DigitalSource, public LiveWindowSendable {
   std::shared_ptr<ITable> m_table;
   friend class DigitalGlitchFilter;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/DigitalOutput.h
+++ b/wpilibc/athena/include/DigitalOutput.h
@@ -15,6 +15,8 @@
 #include "LiveWindow/LiveWindowSendable.h"
 #include "tables/ITableListener.h"
 
+namespace frc {
+
 /**
  * Class to write to digital outputs.
  * Write values to the digital output channels. Other devices implemented
@@ -58,3 +60,5 @@ class DigitalOutput : public DigitalSource,
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/DigitalSource.h
+++ b/wpilibc/athena/include/DigitalSource.h
@@ -10,6 +10,8 @@
 #include "HAL/Types.h"
 #include "InterruptableSensorBase.h"
 
+namespace frc {
+
 /**
  * DigitalSource Interface.
  * The DigitalSource represents all the possible inputs for a counter or a
@@ -28,3 +30,5 @@ class DigitalSource : public InterruptableSensorBase {
   virtual bool IsAnalogTrigger() const = 0;
   virtual int GetChannel() const = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/DoubleSolenoid.h
+++ b/wpilibc/athena/include/DoubleSolenoid.h
@@ -15,6 +15,8 @@
 #include "SolenoidBase.h"
 #include "tables/ITableListener.h"
 
+namespace frc {
+
 /**
  * DoubleSolenoid class for running 2 channels of high voltage Digital Output
  * (PCM).
@@ -55,3 +57,5 @@ class DoubleSolenoid : public SolenoidBase,
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/DriverStation.h
+++ b/wpilibc/athena/include/DriverStation.h
@@ -19,6 +19,8 @@
 #include "RobotState.h"
 #include "SensorBase.h"
 
+namespace frc {
+
 /**
  * Provide access to the network communication data to / from the Driver
  * Station.
@@ -137,3 +139,5 @@ class DriverStation : public SensorBase, public RobotStateInterface {
 
   double m_nextMessageTime = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Encoder.h
+++ b/wpilibc/athena/include/Encoder.h
@@ -17,6 +17,8 @@
 #include "PIDSource.h"
 #include "SensorBase.h"
 
+namespace frc {
+
 class DigitalSource;
 class DigitalGlitchFilter;
 
@@ -105,3 +107,5 @@ class Encoder : public SensorBase,
   std::shared_ptr<ITable> m_table;
   friend class DigitalGlitchFilter;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/GearTooth.h
+++ b/wpilibc/athena/include/GearTooth.h
@@ -12,6 +12,8 @@
 
 #include "Counter.h"
 
+namespace frc {
+
 /**
  * Alias for counter class.
  * Implement the gear tooth sensor supplied by FIRST. Currently there is no
@@ -31,3 +33,5 @@ class GearTooth : public Counter {
 
   std::string GetSmartDashboardType() const override;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/I2C.h
+++ b/wpilibc/athena/include/I2C.h
@@ -9,6 +9,8 @@
 
 #include "SensorBase.h"
 
+namespace frc {
+
 /**
  * I2C bus interface class.
  *
@@ -40,3 +42,5 @@ class I2C : SensorBase {
   Port m_port;
   int m_deviceAddress;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Internal/HardwareHLReporting.h
+++ b/wpilibc/athena/include/Internal/HardwareHLReporting.h
@@ -9,8 +9,12 @@
 
 #include "HLUsageReporting.h"
 
+namespace frc {
+
 class HardwareHLReporting : public HLUsageReportingInterface {
  public:
   virtual void ReportScheduler();
   virtual void ReportSmartDashboard();
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/InterruptableSensorBase.h
+++ b/wpilibc/athena/include/InterruptableSensorBase.h
@@ -13,6 +13,8 @@
 #include "HAL/Interrupts.h"
 #include "SensorBase.h"
 
+namespace frc {
+
 class InterruptableSensorBase : public SensorBase {
  public:
   enum WaitResult {
@@ -48,3 +50,5 @@ class InterruptableSensorBase : public SensorBase {
   HAL_InterruptHandle m_interrupt = HAL_kInvalidHandle;
   void AllocateInterrupts(bool watcher);
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/IterativeRobot.h
+++ b/wpilibc/athena/include/IterativeRobot.h
@@ -9,6 +9,8 @@
 
 #include "RobotBase.h"
 
+namespace frc {
+
 /**
  * IterativeRobot implements a specific type of Robot Program framework,
  * extending the RobotBase class.
@@ -68,3 +70,5 @@ class IterativeRobot : public RobotBase {
   bool m_teleopInitialized = false;
   bool m_testInitialized = false;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Jaguar.h
+++ b/wpilibc/athena/include/Jaguar.h
@@ -9,6 +9,8 @@
 
 #include "PWMSpeedController.h"
 
+namespace frc {
+
 /**
  * Luminary Micro / Vex Robotics Jaguar Speed Controller with PWM control
  */
@@ -17,3 +19,5 @@ class Jaguar : public PWMSpeedController {
   explicit Jaguar(int channel);
   virtual ~Jaguar() = default;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Joystick.h
+++ b/wpilibc/athena/include/Joystick.h
@@ -16,6 +16,8 @@
 #include "ErrorBase.h"
 #include "GenericHID.h"
 
+namespace frc {
+
 class DriverStation;
 
 /**
@@ -116,3 +118,5 @@ class Joystick : public GenericHID, public ErrorBase {
   uint16_t m_leftRumble = 0;
   uint16_t m_rightRumble = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/MotorSafety.h
+++ b/wpilibc/athena/include/MotorSafety.h
@@ -11,6 +11,8 @@
 
 #include <sstream>
 
+namespace frc {
+
 class MotorSafety {
  public:
   virtual void SetExpiration(float timeout) = 0;
@@ -21,3 +23,5 @@ class MotorSafety {
   virtual bool IsSafetyEnabled() const = 0;
   virtual void GetDescription(std::ostringstream& desc) const = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/MotorSafetyHelper.h
+++ b/wpilibc/athena/include/MotorSafetyHelper.h
@@ -12,6 +12,8 @@
 #include "ErrorBase.h"
 #include "HAL/cpp/priority_mutex.h"
 
+namespace frc {
+
 class MotorSafety;
 
 class MotorSafetyHelper : public ErrorBase {
@@ -43,3 +45,5 @@ class MotorSafetyHelper : public ErrorBase {
   // protect accesses to the list of helpers
   static priority_recursive_mutex m_listMutex;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Notifier.h
+++ b/wpilibc/athena/include/Notifier.h
@@ -15,6 +15,8 @@
 #include "HAL/Notifier.h"
 #include "HAL/cpp/priority_mutex.h"
 
+namespace frc {
+
 typedef std::function<void()> TimerEventHandler;
 
 class Notifier : public ErrorBase {
@@ -56,3 +58,5 @@ class Notifier : public ErrorBase {
   // true if this is a periodic event
   bool m_periodic = false;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/PWM.h
+++ b/wpilibc/athena/include/PWM.h
@@ -15,6 +15,8 @@
 #include "SensorBase.h"
 #include "tables/ITableListener.h"
 
+namespace frc {
+
 /**
  * Class implements the PWM generation in the FPGA.
  *
@@ -78,3 +80,5 @@ class PWM : public SensorBase,
   int m_channel;
   HAL_DigitalHandle m_handle;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/PWMSpeedController.h
+++ b/wpilibc/athena/include/PWMSpeedController.h
@@ -10,6 +10,8 @@
 #include "SafePWM.h"
 #include "SpeedController.h"
 
+namespace frc {
+
 /**
  * Common base class for all PWM Speed Controllers
  */
@@ -32,3 +34,5 @@ class PWMSpeedController : public SafePWM, public SpeedController {
  private:
   bool m_isInverted = false;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/PowerDistributionPanel.h
+++ b/wpilibc/athena/include/PowerDistributionPanel.h
@@ -13,6 +13,8 @@
 #include "LiveWindow/LiveWindowSendable.h"
 #include "SensorBase.h"
 
+namespace frc {
+
 /**
  * Class for getting voltage, current, temperature, power and energy from the
  * CAN PDP.
@@ -42,3 +44,5 @@ class PowerDistributionPanel : public SensorBase, public LiveWindowSendable {
   std::shared_ptr<ITable> m_table;
   int m_module;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Preferences.h
+++ b/wpilibc/athena/include/Preferences.h
@@ -16,6 +16,8 @@
 #include "networktables/NetworkTable.h"
 #include "tables/ITableListener.h"
 
+namespace frc {
+
 /**
  * The preferences class provides a relatively simple way to save important
  * values to the roboRIO to access the next time the roboRIO is booted.
@@ -69,3 +71,5 @@ class Preferences : public ErrorBase {
   };
   Listener m_listener;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Relay.h
+++ b/wpilibc/athena/include/Relay.h
@@ -17,6 +17,8 @@
 #include "tables/ITable.h"
 #include "tables/ITableListener.h"
 
+namespace frc {
+
 class MotorSafetyHelper;
 
 /**
@@ -73,3 +75,5 @@ class Relay : public MotorSafety,
 
   std::unique_ptr<MotorSafetyHelper> m_safetyHelper;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/RobotBase.h
+++ b/wpilibc/athena/include/RobotBase.h
@@ -13,6 +13,8 @@
 #include "Base.h"
 #include "HAL/HAL.h"
 
+namespace frc {
+
 class DriverStation;
 
 #define START_ROBOT_CLASS(_ClassName_)                                       \
@@ -56,3 +58,5 @@ class RobotBase {
 
   DriverStation& m_ds;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/RobotDrive.h
+++ b/wpilibc/athena/include/RobotDrive.h
@@ -14,6 +14,8 @@
 #include "MotorSafety.h"
 #include "MotorSafetyHelper.h"
 
+namespace frc {
+
 class SpeedController;
 class GenericHID;
 
@@ -118,3 +120,5 @@ class RobotDrive : public MotorSafety, public ErrorBase {
     return motors;
   }
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/SD540.h
+++ b/wpilibc/athena/include/SD540.h
@@ -9,6 +9,8 @@
 
 #include "PWMSpeedController.h"
 
+namespace frc {
+
 /**
  * Mindsensors SD540 Speed Controller
  */
@@ -17,3 +19,5 @@ class SD540 : public PWMSpeedController {
   explicit SD540(int channel);
   virtual ~SD540() = default;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/SPI.h
+++ b/wpilibc/athena/include/SPI.h
@@ -9,6 +9,8 @@
 
 #include "SensorBase.h"
 
+namespace frc {
+
 class DigitalOutput;
 class DigitalInput;
 
@@ -68,3 +70,5 @@ class SPI : public SensorBase {
  private:
   void Init();
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/SafePWM.h
+++ b/wpilibc/athena/include/SafePWM.h
@@ -14,6 +14,8 @@
 #include "MotorSafetyHelper.h"
 #include "PWM.h"
 
+namespace frc {
+
 /**
  * A safe version of the PWM class.
  * It is safe because it implements the MotorSafety interface that provides
@@ -39,3 +41,5 @@ class SafePWM : public PWM, public MotorSafety {
  private:
   std::unique_ptr<MotorSafetyHelper> m_safetyHelper;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/SampleRobot.h
+++ b/wpilibc/athena/include/SampleRobot.h
@@ -9,6 +9,8 @@
 
 #include "RobotBase.h"
 
+namespace frc {
+
 class SampleRobot : public RobotBase {
  public:
   SampleRobot();
@@ -24,3 +26,5 @@ class SampleRobot : public RobotBase {
  private:
   bool m_robotMainOverridden;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/SensorBase.h
+++ b/wpilibc/athena/include/SensorBase.h
@@ -12,6 +12,8 @@
 #include "Base.h"
 #include "ErrorBase.h"
 
+namespace frc {
+
 /**
  * Base class for all sensors.
  * Stores most recent status information as well as containing utility functions
@@ -45,3 +47,5 @@ class SensorBase : public ErrorBase {
   static const int kRelayChannels;
   static const int kPDPChannels;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/SerialPort.h
+++ b/wpilibc/athena/include/SerialPort.h
@@ -11,6 +11,8 @@
 
 #include "ErrorBase.h"
 
+namespace frc {
+
 /**
  * Driver for the RS-232 serial port on the roboRIO.
  *
@@ -72,3 +74,5 @@ class SerialPort : public ErrorBase {
   bool m_consoleModeEnabled = false;
   int m_port;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Servo.h
+++ b/wpilibc/athena/include/Servo.h
@@ -13,6 +13,8 @@
 #include "SafePWM.h"
 #include "SpeedController.h"
 
+namespace frc {
+
 /**
  * Standard hobby style servo.
  *
@@ -52,3 +54,5 @@ class Servo : public SafePWM {
   static constexpr float kDefaultMaxServoPWM = 2.4;
   static constexpr float kDefaultMinServoPWM = .6;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Solenoid.h
+++ b/wpilibc/athena/include/Solenoid.h
@@ -15,6 +15,8 @@
 #include "SolenoidBase.h"
 #include "tables/ITableListener.h"
 
+namespace frc {
+
 /**
  * Solenoid class for running high voltage Digital Output (PCM).
  *
@@ -46,3 +48,5 @@ class Solenoid : public SolenoidBase,
   int m_channel;  ///< The channel on the module to control.
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/SolenoidBase.h
+++ b/wpilibc/athena/include/SolenoidBase.h
@@ -11,6 +11,8 @@
 
 #include "SensorBase.h"
 
+namespace frc {
+
 /**
  * SolenoidBase class is the common base class for the Solenoid and
  * DoubleSolenoid classes.
@@ -33,3 +35,5 @@ class SolenoidBase : public SensorBase {
   int m_moduleNumber;  ///< Slot number where the module is plugged into
                        /// the chassis.
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Spark.h
+++ b/wpilibc/athena/include/Spark.h
@@ -9,6 +9,8 @@
 
 #include "PWMSpeedController.h"
 
+namespace frc {
+
 /**
  * REV Robotics Speed Controller
  */
@@ -17,3 +19,5 @@ class Spark : public PWMSpeedController {
   explicit Spark(int channel);
   virtual ~Spark() = default;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/SpeedController.h
+++ b/wpilibc/athena/include/SpeedController.h
@@ -9,6 +9,8 @@
 
 #include "PIDOutput.h"
 
+namespace frc {
+
 /**
  * Interface for speed controlling devices.
  */
@@ -51,3 +53,5 @@ class SpeedController : public PIDOutput {
    */
   virtual void StopMotor() = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Talon.h
+++ b/wpilibc/athena/include/Talon.h
@@ -9,6 +9,8 @@
 
 #include "PWMSpeedController.h"
 
+namespace frc {
+
 /**
  * Cross the Road Electronics (CTRE) Talon and Talon SR Speed Controller
  */
@@ -17,3 +19,5 @@ class Talon : public PWMSpeedController {
   explicit Talon(int channel);
   virtual ~Talon() = default;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/TalonSRX.h
+++ b/wpilibc/athena/include/TalonSRX.h
@@ -9,6 +9,8 @@
 
 #include "PWMSpeedController.h"
 
+namespace frc {
+
 /**
  * Cross the Road Electronics (CTRE) Talon SRX Speed Controller with PWM control
  */
@@ -17,3 +19,5 @@ class TalonSRX : public PWMSpeedController {
   explicit TalonSRX(int channel);
   virtual ~TalonSRX() = default;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/USBCamera.h
+++ b/wpilibc/athena/include/USBCamera.h
@@ -14,6 +14,8 @@
 #include "NIIMAQdx.h"
 #include "nivision.h"
 
+namespace frc {
+
 typedef enum whiteBalance_enum {
   kFixedIndoor = 3000,
   kFixedOutdoor1 = 4000,
@@ -120,3 +122,5 @@ class USBCamera : public ErrorBase {
   void GetImage(Image* image);
   int GetImageData(void* buffer, int bufferSize);
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Ultrasonic.h
+++ b/wpilibc/athena/include/Ultrasonic.h
@@ -18,6 +18,8 @@
 #include "PIDSource.h"
 #include "SensorBase.h"
 
+namespace frc {
+
 class DigitalInput;
 class DigitalOutput;
 
@@ -96,3 +98,5 @@ class Ultrasonic : public SensorBase,
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Victor.h
+++ b/wpilibc/athena/include/Victor.h
@@ -9,6 +9,8 @@
 
 #include "PWMSpeedController.h"
 
+namespace frc {
+
 /**
  * Vex Robotics Victor 888 Speed Controller
  *
@@ -20,3 +22,5 @@ class Victor : public PWMSpeedController {
   explicit Victor(int channel);
   virtual ~Victor() = default;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/VictorSP.h
+++ b/wpilibc/athena/include/VictorSP.h
@@ -9,6 +9,8 @@
 
 #include "PWMSpeedController.h"
 
+namespace frc {
+
 /**
  * Vex Robotics Victor SP Speed Controller
  */
@@ -17,3 +19,5 @@ class VictorSP : public PWMSpeedController {
   explicit VictorSP(int channel);
   virtual ~VictorSP() = default;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Vision/AxisCamera.h
+++ b/wpilibc/athena/include/Vision/AxisCamera.h
@@ -17,6 +17,8 @@
 #include "Vision/HSLImage.h"
 #include "nivision.h"
 
+namespace frc {
+
 /**
  * Axis M1011 network camera
  */
@@ -121,3 +123,5 @@ class AxisCamera : public ErrorBase {
 
   int CreateCameraSocket(std::string const& requestString, bool setError);
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Vision/BaeUtilities.h
+++ b/wpilibc/athena/include/Vision/BaeUtilities.h
@@ -19,6 +19,8 @@
 #define LOG_FATAL __FILE__, __FUNCTION__, __LINE__, FATAL_TYPE
 #define LOG_DEBUG __FILE__, __FUNCTION__, __LINE__, DEBUG_TYPE
 
+namespace frc {
+
 /*   Enumerated Types */
 
 /** debug levels */
@@ -69,3 +71,5 @@ void panForTarget(Servo* panServo, double sinStart);
 int processFile(char* inputFile, char* outputString, int lineNumber);
 int emptyString(char* string);
 void stripString(char* string);
+
+}  // namespace frc

--- a/wpilibc/athena/include/Vision/BinaryImage.h
+++ b/wpilibc/athena/include/Vision/BinaryImage.h
@@ -18,6 +18,8 @@
  */
 #include "Vision/VisionAPI.h"
 
+namespace frc {
+
 class BinaryImage : public MonoImage {
  public:
   virtual ~BinaryImage() = default;
@@ -42,3 +44,5 @@ class BinaryImage : public MonoImage {
   static bool CompareParticleSizes(ParticleAnalysisReport particle1,
                                    ParticleAnalysisReport particle2);
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Vision/ColorImage.h
+++ b/wpilibc/athena/include/Vision/ColorImage.h
@@ -11,6 +11,8 @@
 #include "ImageBase.h"
 #include "Threshold.h"
 
+namespace frc {
+
 class ColorImage : public ImageBase {
  public:
   explicit ColorImage(ImageType type);
@@ -69,3 +71,5 @@ class ColorImage : public ImageBase {
   void ReplaceSecondColorPlane(ColorMode mode, MonoImage* plane);
   void ReplaceThirdColorPlane(ColorMode mode, MonoImage* plane);
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Vision/FrcError.h
+++ b/wpilibc/athena/include/Vision/FrcError.h
@@ -27,6 +27,10 @@
 #define ERR_CAMERA_TASK_INPUT_OUT_OF_RANGE 166210  // AxisCamera.cpp
 #define ERR_CAMERA_COMMAND_FAILURE 166211          // AxisCamera.cpp
 
+namespace frc {
+
 /* error handling functions */
 int GetLastVisionError();
 const char* GetVisionErrorText(int errorCode);
+
+}  // namespace frc

--- a/wpilibc/athena/include/Vision/HSLImage.h
+++ b/wpilibc/athena/include/Vision/HSLImage.h
@@ -9,6 +9,8 @@
 
 #include "ColorImage.h"
 
+namespace frc {
+
 /**
  * A color image represented in HSL color space at 3 bytes per pixel.
  */
@@ -18,3 +20,5 @@ class HSLImage : public ColorImage {
   explicit HSLImage(const char* fileName);
   virtual ~HSLImage() = default;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Vision/ImageBase.h
+++ b/wpilibc/athena/include/Vision/ImageBase.h
@@ -12,6 +12,8 @@
 
 #define DEFAULT_BORDER_SIZE 3
 
+namespace frc {
+
 class ImageBase : public ErrorBase {
  public:
   explicit ImageBase(ImageType type);
@@ -24,3 +26,5 @@ class ImageBase : public ErrorBase {
  protected:
   Image* m_imaqImage;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Vision/MonoImage.h
+++ b/wpilibc/athena/include/Vision/MonoImage.h
@@ -11,6 +11,8 @@
 
 #include "ImageBase.h"
 
+namespace frc {
+
 class MonoImage : public ImageBase {
  public:
   MonoImage();
@@ -22,3 +24,5 @@ class MonoImage : public ImageBase {
   std::vector<EllipseMatch>* DetectEllipses(
       EllipseDescriptor* ellipseDescriptor);
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Vision/RGBImage.h
+++ b/wpilibc/athena/include/Vision/RGBImage.h
@@ -9,6 +9,8 @@
 
 #include "ColorImage.h"
 
+namespace frc {
+
 /**
  * A color image represented in RGB color space at 3 bytes per pixel.
  */
@@ -18,3 +20,5 @@ class RGBImage : public ColorImage {
   explicit RGBImage(const char* fileName);
   virtual ~RGBImage() = default;
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Vision/Threshold.h
+++ b/wpilibc/athena/include/Vision/Threshold.h
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+namespace frc {
+
 /**
  * Color threshold values.
  * This object represnts the threshold values for any type of color object
@@ -26,3 +28,5 @@ class Threshold {
   Threshold(int plane1Low, int plane1High, int plane2Low, int plane2High,
             int plane3Low, int plane3High);
 };
+
+}  // namespace frc

--- a/wpilibc/athena/include/Vision/VisionAPI.h
+++ b/wpilibc/athena/include/Vision/VisionAPI.h
@@ -16,6 +16,8 @@
 #define DEFAULT_BORDER_SIZE 3            // VisionAPI.frcCreateImage
 #define DEFAULT_SATURATION_THRESHOLD 40  // TrackAPI.FindColor
 
+namespace frc {
+
 /* Forward Declare Data Structures */
 typedef struct FindEdgeOptions_struct FindEdgeOptions;
 typedef struct CircularEdgeReport_struct CircularEdgeReport;
@@ -174,3 +176,5 @@ int frcExtractColorPlanes(const Image* image, ColorMode mode, Image* plane1,
                           Image* plane2, Image* plane3);
 int frcExtractHuePlane(const Image* image, Image* huePlane);
 int frcExtractHuePlane(const Image* image, Image* huePlane, int minSaturation);
+
+}  // namespace frc

--- a/wpilibc/athena/src/ADXL345_I2C.cpp
+++ b/wpilibc/athena/src/ADXL345_I2C.cpp
@@ -11,6 +11,8 @@
 #include "I2C.h"
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 const int ADXL345_I2C::kAddress;
 const int ADXL345_I2C::kPowerCtlRegister;
 const int ADXL345_I2C::kDataFormatRegister;

--- a/wpilibc/athena/src/ADXL345_SPI.cpp
+++ b/wpilibc/athena/src/ADXL345_SPI.cpp
@@ -12,6 +12,8 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 const int ADXL345_SPI::kPowerCtlRegister;
 const int ADXL345_SPI::kDataFormatRegister;
 const int ADXL345_SPI::kDataRegister;

--- a/wpilibc/athena/src/ADXL362.cpp
+++ b/wpilibc/athena/src/ADXL362.cpp
@@ -13,6 +13,8 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 static int kRegWrite = 0x0A;
 static int kRegRead = 0x0B;
 

--- a/wpilibc/athena/src/ADXRS450_Gyro.cpp
+++ b/wpilibc/athena/src/ADXRS450_Gyro.cpp
@@ -12,6 +12,8 @@
 #include "LiveWindow/LiveWindow.h"
 #include "Timer.h"
 
+using namespace frc;
+
 static constexpr double kSamplePeriod = 0.001;
 static constexpr double kCalibrationSampleTime = 5.0;
 static constexpr double kDegreePerSecondPerLSB = 0.0125;

--- a/wpilibc/athena/src/AnalogAccelerometer.cpp
+++ b/wpilibc/athena/src/AnalogAccelerometer.cpp
@@ -11,6 +11,8 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Common function for initializing the accelerometer.
  */

--- a/wpilibc/athena/src/AnalogGyro.cpp
+++ b/wpilibc/athena/src/AnalogGyro.cpp
@@ -15,6 +15,8 @@
 #include "Timer.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 const int AnalogGyro::kOversampleBits;
 const int AnalogGyro::kAverageBits;
 constexpr float AnalogGyro::kSamplesPerSecond;

--- a/wpilibc/athena/src/AnalogInput.cpp
+++ b/wpilibc/athena/src/AnalogInput.cpp
@@ -14,6 +14,8 @@
 #include "Timer.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 const int AnalogInput::kAccumulatorModuleNumber;
 const int AnalogInput::kAccumulatorNumChannels;
 const int AnalogInput::kAccumulatorChannels[] = {0, 1};

--- a/wpilibc/athena/src/AnalogOutput.cpp
+++ b/wpilibc/athena/src/AnalogOutput.cpp
@@ -14,6 +14,8 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Construct an analog output on the given channel.
  *

--- a/wpilibc/athena/src/AnalogPotentiometer.cpp
+++ b/wpilibc/athena/src/AnalogPotentiometer.cpp
@@ -9,6 +9,8 @@
 
 #include "ControllerPower.h"
 
+using namespace frc;
+
 /**
  * Construct an Analog Potentiometer object from a channel number.
  *

--- a/wpilibc/athena/src/AnalogTrigger.cpp
+++ b/wpilibc/athena/src/AnalogTrigger.cpp
@@ -13,6 +13,8 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Constructor for an analog trigger given a channel number.
  *

--- a/wpilibc/athena/src/AnalogTriggerOutput.cpp
+++ b/wpilibc/athena/src/AnalogTriggerOutput.cpp
@@ -11,6 +11,8 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Create an object that represents one of the four outputs from an analog
  * trigger.

--- a/wpilibc/athena/src/BuiltInAccelerometer.cpp
+++ b/wpilibc/athena/src/BuiltInAccelerometer.cpp
@@ -11,6 +11,8 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Constructor.
  *

--- a/wpilibc/athena/src/CameraServer.cpp
+++ b/wpilibc/athena/src/CameraServer.cpp
@@ -18,6 +18,8 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 constexpr uint8_t CameraServer::kMagicNumber[];
 
 CameraServer* CameraServer::GetInstance() {

--- a/wpilibc/athena/src/Compressor.cpp
+++ b/wpilibc/athena/src/Compressor.cpp
@@ -10,6 +10,8 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Constructor.
  *

--- a/wpilibc/athena/src/ControllerPower.cpp
+++ b/wpilibc/athena/src/ControllerPower.cpp
@@ -13,6 +13,8 @@
 #include "HAL/HAL.h"
 #include "HAL/Power.h"
 
+using namespace frc;
+
 /**
  * Get the input voltage to the robot controller.
  *

--- a/wpilibc/athena/src/Counter.cpp
+++ b/wpilibc/athena/src/Counter.cpp
@@ -12,6 +12,8 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Create an instance of a counter where no sources are selected.
  *

--- a/wpilibc/athena/src/DigitalGlitchFilter.cpp
+++ b/wpilibc/athena/src/DigitalGlitchFilter.cpp
@@ -16,6 +16,8 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 std::array<bool, 3> DigitalGlitchFilter::m_filterAllocated = {
     {false, false, false}};
 priority_mutex DigitalGlitchFilter::m_mutex;

--- a/wpilibc/athena/src/DigitalInput.cpp
+++ b/wpilibc/athena/src/DigitalInput.cpp
@@ -14,6 +14,8 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Create an instance of a Digital Input class.
  *

--- a/wpilibc/athena/src/DigitalOutput.cpp
+++ b/wpilibc/athena/src/DigitalOutput.cpp
@@ -13,6 +13,8 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Create an instance of a digital output.
  *

--- a/wpilibc/athena/src/DoubleSolenoid.cpp
+++ b/wpilibc/athena/src/DoubleSolenoid.cpp
@@ -13,6 +13,8 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Constructor.
  *

--- a/wpilibc/athena/src/DriverStation.cpp
+++ b/wpilibc/athena/src/DriverStation.cpp
@@ -18,6 +18,8 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 const double JOYSTICK_UNPLUGGED_MESSAGE_INTERVAL = 1.0;
 
 const int DriverStation::kJoystickPorts;

--- a/wpilibc/athena/src/Encoder.cpp
+++ b/wpilibc/athena/src/Encoder.cpp
@@ -12,6 +12,8 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Common initialization code for Encoders.
  *

--- a/wpilibc/athena/src/GearTooth.cpp
+++ b/wpilibc/athena/src/GearTooth.cpp
@@ -9,6 +9,8 @@
 
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 constexpr double GearTooth::kGearToothThreshold;
 
 /**

--- a/wpilibc/athena/src/I2C.cpp
+++ b/wpilibc/athena/src/I2C.cpp
@@ -10,6 +10,8 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Constructor.
  *

--- a/wpilibc/athena/src/Internal/HardwareHLReporting.cpp
+++ b/wpilibc/athena/src/Internal/HardwareHLReporting.cpp
@@ -9,6 +9,8 @@
 
 #include "HAL/HAL.h"
 
+using namespace frc;
+
 void HardwareHLReporting::ReportScheduler() {
   HAL_Report(HALUsageReporting::kResourceType_Command,
              HALUsageReporting::kCommand_Scheduler);

--- a/wpilibc/athena/src/InterruptableSensorBase.cpp
+++ b/wpilibc/athena/src/InterruptableSensorBase.cpp
@@ -11,6 +11,8 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 InterruptableSensorBase::InterruptableSensorBase() {}
 
 /**

--- a/wpilibc/athena/src/IterativeRobot.cpp
+++ b/wpilibc/athena/src/IterativeRobot.cpp
@@ -13,6 +13,8 @@
 #include "SmartDashboard/SmartDashboard.h"
 #include "networktables/NetworkTable.h"
 
+using namespace frc;
+
 /**
  * Provide an alternate "main loop" via StartCompetition().
  *

--- a/wpilibc/athena/src/Jaguar.cpp
+++ b/wpilibc/athena/src/Jaguar.cpp
@@ -10,6 +10,8 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 /**
  * Constructor for a Jaguar connected via PWM.
  *

--- a/wpilibc/athena/src/Joystick.cpp
+++ b/wpilibc/athena/src/Joystick.cpp
@@ -13,6 +13,8 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 const int Joystick::kDefaultXAxis;
 const int Joystick::kDefaultYAxis;
 const int Joystick::kDefaultZAxis;

--- a/wpilibc/athena/src/MotorSafetyHelper.cpp
+++ b/wpilibc/athena/src/MotorSafetyHelper.cpp
@@ -14,6 +14,8 @@
 #include "Timer.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 std::set<MotorSafetyHelper*> MotorSafetyHelper::m_helperList;
 priority_recursive_mutex MotorSafetyHelper::m_listMutex;
 

--- a/wpilibc/athena/src/Notifier.cpp
+++ b/wpilibc/athena/src/Notifier.cpp
@@ -12,6 +12,8 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 priority_mutex Notifier::m_destructorMutex;
 
 /**

--- a/wpilibc/athena/src/PIDController.cpp
+++ b/wpilibc/athena/src/PIDController.cpp
@@ -15,6 +15,8 @@
 #include "PIDOutput.h"
 #include "PIDSource.h"
 
+using namespace frc;
+
 static const std::string kP = "p";
 static const std::string kI = "i";
 static const std::string kD = "d";

--- a/wpilibc/athena/src/PWM.cpp
+++ b/wpilibc/athena/src/PWM.cpp
@@ -13,6 +13,8 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Allocate a PWM given a channel number.
  *

--- a/wpilibc/athena/src/PWMSpeedController.cpp
+++ b/wpilibc/athena/src/PWMSpeedController.cpp
@@ -7,6 +7,8 @@
 
 #include "PWMSpeedController.h"
 
+using namespace frc;
+
 /**
  * Constructor for a PWM Speed Controller connected via PWM.
  *

--- a/wpilibc/athena/src/PowerDistributionPanel.cpp
+++ b/wpilibc/athena/src/PowerDistributionPanel.cpp
@@ -13,6 +13,8 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 PowerDistributionPanel::PowerDistributionPanel() : PowerDistributionPanel(0) {}
 
 /**

--- a/wpilibc/athena/src/Preferences.cpp
+++ b/wpilibc/athena/src/Preferences.cpp
@@ -12,6 +12,8 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /** The Preferences table name */
 static const char* kTableName = "Preferences";
 

--- a/wpilibc/athena/src/Relay.cpp
+++ b/wpilibc/athena/src/Relay.cpp
@@ -14,6 +14,8 @@
 #include "MotorSafetyHelper.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Relay constructor given a channel.
  *

--- a/wpilibc/athena/src/RobotBase.cpp
+++ b/wpilibc/athena/src/RobotBase.cpp
@@ -18,6 +18,8 @@
 #include "WPILibVersion.h"
 #include "networktables/NetworkTable.h"
 
+using namespace frc;
+
 /**
  * Constructor for a generic robot program.
  *

--- a/wpilibc/athena/src/RobotDrive.cpp
+++ b/wpilibc/athena/src/RobotDrive.cpp
@@ -17,6 +17,8 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 const int RobotDrive::kMaxNumberOfMotors;
 
 static auto make_shared_nodelete(SpeedController* ptr) {

--- a/wpilibc/athena/src/SD540.cpp
+++ b/wpilibc/athena/src/SD540.cpp
@@ -10,6 +10,8 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 /**
  * Note that the SD540 uses the following bounds for PWM values. These values
  * should work reasonably well for most controllers, but if users experience

--- a/wpilibc/athena/src/SPI.cpp
+++ b/wpilibc/athena/src/SPI.cpp
@@ -12,6 +12,8 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Constructor
  *

--- a/wpilibc/athena/src/SafePWM.cpp
+++ b/wpilibc/athena/src/SafePWM.cpp
@@ -7,6 +7,8 @@
 
 #include "SafePWM.h"
 
+using namespace frc;
+
 /**
  * Constructor for a SafePWM object taking a channel number.
  *

--- a/wpilibc/athena/src/SampleRobot.cpp
+++ b/wpilibc/athena/src/SampleRobot.cpp
@@ -13,6 +13,8 @@
 #include "Timer.h"
 #include "networktables/NetworkTable.h"
 
+using namespace frc;
+
 SampleRobot::SampleRobot() : m_robotMainOverridden(true) {}
 
 /**

--- a/wpilibc/athena/src/SensorBase.cpp
+++ b/wpilibc/athena/src/SensorBase.cpp
@@ -11,6 +11,8 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 const int SensorBase::kDigitalChannels = HAL_GetNumDigitalChannels();
 const int SensorBase::kAnalogInputs = HAL_GetNumAnalogInputs();
 const int SensorBase::kSolenoidChannels = HAL_GetNumSolenoidChannels();

--- a/wpilibc/athena/src/SerialPort.cpp
+++ b/wpilibc/athena/src/SerialPort.cpp
@@ -12,6 +12,8 @@
 // static ViStatus _VI_FUNCH ioCompleteHandler (ViSession vi, ViEventType
 // eventType, ViEvent event, ViAddr userHandle);
 
+using namespace frc;
+
 /**
  * Create an instance of a Serial Port class.
  *

--- a/wpilibc/athena/src/Servo.cpp
+++ b/wpilibc/athena/src/Servo.cpp
@@ -9,6 +9,8 @@
 
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 constexpr float Servo::kMaxServoAngle;
 constexpr float Servo::kMinServoAngle;
 

--- a/wpilibc/athena/src/Solenoid.cpp
+++ b/wpilibc/athena/src/Solenoid.cpp
@@ -13,6 +13,8 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Constructor using the default PCM ID (0).
  *

--- a/wpilibc/athena/src/SolenoidBase.cpp
+++ b/wpilibc/athena/src/SolenoidBase.cpp
@@ -9,6 +9,8 @@
 
 #include "HAL/HAL.h"
 
+using namespace frc;
+
 /**
  * Constructor
  *

--- a/wpilibc/athena/src/Spark.cpp
+++ b/wpilibc/athena/src/Spark.cpp
@@ -10,6 +10,8 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 /**
  * Note that the Spark uses the following bounds for PWM values. These values
  * should work reasonably well for most controllers, but if users experience

--- a/wpilibc/athena/src/Talon.cpp
+++ b/wpilibc/athena/src/Talon.cpp
@@ -10,6 +10,8 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 /**
  * Constructor for a Talon (original or Talon SR).
  *

--- a/wpilibc/athena/src/TalonSRX.cpp
+++ b/wpilibc/athena/src/TalonSRX.cpp
@@ -10,6 +10,8 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 /**
  * Construct a TalonSRX connected via PWM.
  *

--- a/wpilibc/athena/src/Timer.cpp
+++ b/wpilibc/athena/src/Timer.cpp
@@ -15,6 +15,8 @@
 #include "HAL/HAL.h"
 #include "Utility.h"
 
+namespace frc {
+
 /**
  * Pause the task for a specified time.
  *
@@ -47,6 +49,10 @@ double GetTime() {
   return duration_cast<duration<double>>(system_clock::now().time_since_epoch())
       .count();
 }
+
+}  // namespace frc
+
+using namespace frc;
 
 // for compatibility with msvc12--see C2864
 const double Timer::kRolloverTime = (1ll << 32) / 1e6;

--- a/wpilibc/athena/src/USBCamera.cpp
+++ b/wpilibc/athena/src/USBCamera.cpp
@@ -17,6 +17,8 @@
 
 #include "Utility.h"
 
+using namespace frc;
+
 // This macro expands the given imaq function to ensure that it is called and
 // properly checked for an error, calling the wpi_setImaqErrorWithContext
 // macro

--- a/wpilibc/athena/src/Ultrasonic.cpp
+++ b/wpilibc/athena/src/Ultrasonic.cpp
@@ -16,6 +16,8 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 // Time (sec) for the ping trigger pulse.
 constexpr double Ultrasonic::kPingTime;
 // Priority that the ultrasonic round robin task runs.

--- a/wpilibc/athena/src/Utility.cpp
+++ b/wpilibc/athena/src/Utility.cpp
@@ -19,6 +19,8 @@
 #include "HAL/HAL.h"
 #include "nivision.h"
 
+using namespace frc;
+
 /**
  * Assert implementation.
  * This allows breakpoints to be set on an assert.
@@ -122,6 +124,8 @@ bool wpi_assertNotEqual_impl(int valueA, int valueB, const char* valueAString,
   return valueA != valueB;
 }
 
+namespace frc {
+
 /**
  * Return the FPGA Version number.
  *
@@ -221,3 +225,5 @@ std::string GetStackTrace(int offset) {
 
   return trace.str();
 }
+
+}  // namespace frc

--- a/wpilibc/athena/src/Victor.cpp
+++ b/wpilibc/athena/src/Victor.cpp
@@ -10,6 +10,8 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 /**
  * Constructor for a Victor.
  *

--- a/wpilibc/athena/src/VictorSP.cpp
+++ b/wpilibc/athena/src/VictorSP.cpp
@@ -10,6 +10,8 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 /**
  * Constructor for a VictorSP.
  *

--- a/wpilibc/athena/src/Vision/AxisCamera.cpp
+++ b/wpilibc/athena/src/Vision/AxisCamera.cpp
@@ -21,6 +21,8 @@
 #include "Timer.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 static const int kMaxPacketSize = 1536;
 static const int kImageBufferAllocationIncrement = 1000;
 

--- a/wpilibc/athena/src/Vision/BaeUtilities.cpp
+++ b/wpilibc/athena/src/Vision/BaeUtilities.cpp
@@ -21,6 +21,8 @@
 #include "Servo.h"
 #include "Timer.h"
 
+namespace frc {
+
 /** @file
  *   Utility functions
  */
@@ -378,3 +380,5 @@ void stripString(char* string) {
   }
   string[j] = '\0';
 }
+
+}  // namespace frc

--- a/wpilibc/athena/src/Vision/BinaryImage.cpp
+++ b/wpilibc/athena/src/Vision/BinaryImage.cpp
@@ -11,6 +11,8 @@
 
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Get then number of particles for the image.
  *

--- a/wpilibc/athena/src/Vision/ColorImage.cpp
+++ b/wpilibc/athena/src/Vision/ColorImage.cpp
@@ -9,6 +9,8 @@
 
 #include "WPIErrors.h"
 
+using namespace frc;
+
 ColorImage::ColorImage(ImageType type) : ImageBase(type) {}
 
 /**

--- a/wpilibc/athena/src/Vision/FrcError.cpp
+++ b/wpilibc/athena/src/Vision/FrcError.cpp
@@ -9,6 +9,8 @@
 
 #include "nivision.h"
 
+namespace frc {
+
 /**
  * Get the error code returned from the NI Vision library
  * @return The last error code.
@@ -2400,3 +2402,5 @@ const char* GetVisionErrorText(int errorCode) {
 
   return errorText;
 }  // NOLINT
+
+}  // namespace frc

--- a/wpilibc/athena/src/Vision/HSLImage.cpp
+++ b/wpilibc/athena/src/Vision/HSLImage.cpp
@@ -7,6 +7,8 @@
 
 #include "Vision/HSLImage.h"
 
+using namespace frc;
+
 /**
  * Create a new image that uses the Hue, Saturation, and Luminance planes.
  */

--- a/wpilibc/athena/src/Vision/ImageBase.cpp
+++ b/wpilibc/athena/src/Vision/ImageBase.cpp
@@ -9,6 +9,8 @@
 
 #include "nivision.h"
 
+using namespace frc;
+
 /**
  * Create a new instance of an ImageBase.
  *

--- a/wpilibc/athena/src/Vision/MonoImage.cpp
+++ b/wpilibc/athena/src/Vision/MonoImage.cpp
@@ -9,6 +9,8 @@
 
 #include "nivision.h"
 
+using namespace frc;
+
 MonoImage::MonoImage() : ImageBase(IMAQ_IMAGE_U8) {}
 
 /**

--- a/wpilibc/athena/src/Vision/RGBImage.cpp
+++ b/wpilibc/athena/src/Vision/RGBImage.cpp
@@ -7,6 +7,8 @@
 
 #include "Vision/RGBImage.h"
 
+using namespace frc;
+
 /**
  * Create a new image that uses Red, Green, and Blue planes.
  */

--- a/wpilibc/athena/src/Vision/Threshold.cpp
+++ b/wpilibc/athena/src/Vision/Threshold.cpp
@@ -7,6 +7,8 @@
 
 #include "Vision/Threshold.h"
 
+using namespace frc;
+
 Threshold::Threshold(int new_plane1Low, int new_plane1High, int new_plane2Low,
                      int new_plane2High, int new_plane3Low,
                      int new_plane3High) {

--- a/wpilibc/athena/src/Vision/VisionAPI.cpp
+++ b/wpilibc/athena/src/Vision/VisionAPI.cpp
@@ -12,6 +12,8 @@
 #include "Vision/BaeUtilities.h"
 #include "Vision/FrcError.h"
 
+namespace frc {
+
 int VisionAPI_debugFlag = 1;
 #define DPRINTF \
   if (VisionAPI_debugFlag) dprintf
@@ -827,3 +829,5 @@ int frcExtractHuePlane(const Image* image, Image* huePlane) {
 int frcExtractHuePlane(const Image* image, Image* huePlane, int minSaturation) {
   return frcExtractColorPlanes(image, IMAQ_HSL, huePlane, nullptr, nullptr);
 }
+
+}  // namespace frc

--- a/wpilibc/shared/include/Base.h
+++ b/wpilibc/shared/include/Base.h
@@ -56,6 +56,8 @@ using decay_t = typename decay<T>::type;
 #endif
 #endif
 
+namespace frc {
+
 // A struct to use as a deleter when a std::shared_ptr must wrap a raw pointer
 // that is being deleted by someone else.
 template <class T>
@@ -63,7 +65,12 @@ struct NullDeleter {
   void operator()(T*) const noexcept {};
 };
 
+}  // namespace frc
+
 #include <atomic>
+
+namespace frc {
+
 // Use this for determining whether the default move constructor has been
 // called on a containing object. This serves the purpose of allowing us to
 // use the default move constructor of an object for moving all the data around
@@ -78,3 +85,10 @@ struct HasBeenMoved {
   std::atomic<bool> moved{false};
   operator bool() const { return moved; }
 };
+
+}  // namespace frc
+
+// For backwards compatibility
+#ifndef NAMESPACED_WPILIB
+using namespace frc;  // NOLINT
+#endif

--- a/wpilibc/shared/include/Buttons/Button.h
+++ b/wpilibc/shared/include/Buttons/Button.h
@@ -10,6 +10,8 @@
 #include "Buttons/Trigger.h"
 #include "Commands/Command.h"
 
+namespace frc {
+
 /**
  * This class provides an easy way to link commands to OI inputs.
  *
@@ -30,3 +32,5 @@ class Button : public Trigger {
   virtual void CancelWhenPressed(Command* command);
   virtual void ToggleWhenPressed(Command* command);
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Buttons/ButtonScheduler.h
+++ b/wpilibc/shared/include/Buttons/ButtonScheduler.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+namespace frc {
+
 class Trigger;
 class Command;
 
@@ -22,3 +24,5 @@ class ButtonScheduler {
   Trigger* m_button;
   Command* m_command;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Buttons/CancelButtonScheduler.h
+++ b/wpilibc/shared/include/Buttons/CancelButtonScheduler.h
@@ -9,6 +9,8 @@
 
 #include "Buttons/ButtonScheduler.h"
 
+namespace frc {
+
 class Trigger;
 class Command;
 
@@ -21,3 +23,5 @@ class CancelButtonScheduler : public ButtonScheduler {
  private:
   bool pressedLast;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Buttons/HeldButtonScheduler.h
+++ b/wpilibc/shared/include/Buttons/HeldButtonScheduler.h
@@ -9,6 +9,8 @@
 
 #include "Buttons/ButtonScheduler.h"
 
+namespace frc {
+
 class Trigger;
 class Command;
 
@@ -18,3 +20,5 @@ class HeldButtonScheduler : public ButtonScheduler {
   virtual ~HeldButtonScheduler() = default;
   virtual void Execute();
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Buttons/InternalButton.h
+++ b/wpilibc/shared/include/Buttons/InternalButton.h
@@ -9,6 +9,8 @@
 
 #include "Buttons/Button.h"
 
+namespace frc {
+
 class InternalButton : public Button {
  public:
   InternalButton() = default;
@@ -24,3 +26,5 @@ class InternalButton : public Button {
   bool m_pressed = false;
   bool m_inverted = false;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Buttons/JoystickButton.h
+++ b/wpilibc/shared/include/Buttons/JoystickButton.h
@@ -10,6 +10,8 @@
 #include "Buttons/Button.h"
 #include "GenericHID.h"
 
+namespace frc {
+
 class JoystickButton : public Button {
  public:
   JoystickButton(GenericHID* joystick, int buttonNumber);
@@ -21,3 +23,5 @@ class JoystickButton : public Button {
   GenericHID* m_joystick;
   int m_buttonNumber;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Buttons/NetworkButton.h
+++ b/wpilibc/shared/include/Buttons/NetworkButton.h
@@ -12,6 +12,8 @@
 
 #include "Buttons/Button.h"
 
+namespace frc {
+
 class NetworkButton : public Button {
  public:
   NetworkButton(const std::string& tableName, const std::string& field);
@@ -24,3 +26,5 @@ class NetworkButton : public Button {
   std::shared_ptr<ITable> m_netTable;
   std::string m_field;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Buttons/PressedButtonScheduler.h
+++ b/wpilibc/shared/include/Buttons/PressedButtonScheduler.h
@@ -9,6 +9,8 @@
 
 #include "Buttons/ButtonScheduler.h"
 
+namespace frc {
+
 class Trigger;
 class Command;
 
@@ -18,3 +20,5 @@ class PressedButtonScheduler : public ButtonScheduler {
   virtual ~PressedButtonScheduler() = default;
   virtual void Execute();
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Buttons/ReleasedButtonScheduler.h
+++ b/wpilibc/shared/include/Buttons/ReleasedButtonScheduler.h
@@ -9,6 +9,8 @@
 
 #include "Buttons/ButtonScheduler.h"
 
+namespace frc {
+
 class Trigger;
 class Command;
 
@@ -18,3 +20,5 @@ class ReleasedButtonScheduler : public ButtonScheduler {
   virtual ~ReleasedButtonScheduler() = default;
   virtual void Execute();
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Buttons/ToggleButtonScheduler.h
+++ b/wpilibc/shared/include/Buttons/ToggleButtonScheduler.h
@@ -9,6 +9,8 @@
 
 #include "Buttons/ButtonScheduler.h"
 
+namespace frc {
+
 class Trigger;
 class Command;
 
@@ -21,3 +23,5 @@ class ToggleButtonScheduler : public ButtonScheduler {
  private:
   bool pressedLast;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Buttons/Trigger.h
+++ b/wpilibc/shared/include/Buttons/Trigger.h
@@ -12,6 +12,8 @@
 
 #include "SmartDashboard/Sendable.h"
 
+namespace frc {
+
 class Command;
 
 /**
@@ -48,3 +50,5 @@ class Trigger : public Sendable {
  protected:
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/CircularBuffer.h
+++ b/wpilibc/shared/include/CircularBuffer.h
@@ -10,6 +10,8 @@
 #include <cstddef>
 #include <vector>
 
+namespace frc {
+
 /**
  * This is a simple circular buffer so we don't need to "bucket brigade" copy
  * old values.
@@ -41,5 +43,7 @@ class CircularBuffer {
   size_t ModuloInc(size_t index);
   size_t ModuloDec(size_t index);
 };
+
+}  // namespace frc
 
 #include "CircularBuffer.inc"

--- a/wpilibc/shared/include/CircularBuffer.inc
+++ b/wpilibc/shared/include/CircularBuffer.inc
@@ -9,6 +9,8 @@
 
 #include <algorithm>
 
+namespace frc {
+
 template <class T>
 CircularBuffer<T>::CircularBuffer(size_t size) : m_data(size, 0) {}
 
@@ -183,3 +185,5 @@ size_t CircularBuffer<T>::ModuloDec(size_t index) {
     return index - 1;
   }
 }
+
+}  // namespace frc

--- a/wpilibc/shared/include/Commands/Command.h
+++ b/wpilibc/shared/include/Commands/Command.h
@@ -15,6 +15,8 @@
 #include "SmartDashboard/NamedSendable.h"
 #include "tables/ITableListener.h"
 
+namespace frc {
+
 class CommandGroup;
 class Subsystem;
 
@@ -178,3 +180,5 @@ class Command : public ErrorBase, public NamedSendable, public ITableListener {
  protected:
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Commands/CommandGroup.h
+++ b/wpilibc/shared/include/Commands/CommandGroup.h
@@ -14,6 +14,8 @@
 #include "Commands/Command.h"
 #include "Commands/CommandGroupEntry.h"
 
+namespace frc {
+
 /**
  * A {@link CommandGroup} is a list of commands which are executed in sequence.
  *
@@ -70,3 +72,5 @@ class CommandGroup : public Command {
   /** The current command, -1 signifies that none have been run */
   int m_currentCommandIndex = -1;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Commands/CommandGroupEntry.h
+++ b/wpilibc/shared/include/Commands/CommandGroupEntry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+namespace frc {
+
 class Command;
 
 class CommandGroupEntry {
@@ -25,3 +27,5 @@ class CommandGroupEntry {
   Command* m_command = nullptr;
   Sequence m_state = kSequence_InSequence;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Commands/PIDCommand.h
+++ b/wpilibc/shared/include/Commands/PIDCommand.h
@@ -15,6 +15,8 @@
 #include "PIDOutput.h"
 #include "PIDSource.h"
 
+namespace frc {
+
 class PIDCommand : public Command, public PIDOutput, public PIDSource {
  public:
   PIDCommand(const std::string& name, double p, double i, double d);
@@ -55,3 +57,5 @@ class PIDCommand : public Command, public PIDOutput, public PIDSource {
   void InitTable(std::shared_ptr<ITable> subtable) override;
   std::string GetSmartDashboardType() const override;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Commands/PIDSubsystem.h
+++ b/wpilibc/shared/include/Commands/PIDSubsystem.h
@@ -15,6 +15,8 @@
 #include "PIDOutput.h"
 #include "PIDSource.h"
 
+namespace frc {
+
 /**
  * This class is designed to handle the case where there is a {@link Subsystem}
  * which uses a single {@link PIDController} almost constantly (for instance,
@@ -70,3 +72,5 @@ class PIDSubsystem : public Subsystem, public PIDOutput, public PIDSource {
   void InitTable(std::shared_ptr<ITable> subtable) override;
   std::string GetSmartDashboardType() const override;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Commands/PrintCommand.h
+++ b/wpilibc/shared/include/Commands/PrintCommand.h
@@ -11,6 +11,8 @@
 
 #include "Commands/Command.h"
 
+namespace frc {
+
 class PrintCommand : public Command {
  public:
   explicit PrintCommand(const std::string& message);
@@ -26,3 +28,5 @@ class PrintCommand : public Command {
  private:
   std::string m_message;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Commands/Scheduler.h
+++ b/wpilibc/shared/include/Commands/Scheduler.h
@@ -21,6 +21,8 @@
 #include "SmartDashboard/SmartDashboard.h"
 #include "networktables/NetworkTable.h"
 
+namespace frc {
+
 class ButtonScheduler;
 class Subsystem;
 
@@ -67,3 +69,5 @@ class Scheduler : public ErrorBase, public NamedSendable {
   std::shared_ptr<ITable> m_table;
   bool m_runningCommandsChanged = false;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Commands/StartCommand.h
+++ b/wpilibc/shared/include/Commands/StartCommand.h
@@ -9,6 +9,8 @@
 
 #include "Commands/Command.h"
 
+namespace frc {
+
 class StartCommand : public Command {
  public:
   explicit StartCommand(Command* commandToStart);
@@ -24,3 +26,5 @@ class StartCommand : public Command {
  private:
   Command* m_commandToFork;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Commands/Subsystem.h
+++ b/wpilibc/shared/include/Commands/Subsystem.h
@@ -13,6 +13,8 @@
 #include "ErrorBase.h"
 #include "SmartDashboard/NamedSendable.h"
 
+namespace frc {
+
 class Command;
 
 class Subsystem : public ErrorBase, public NamedSendable {
@@ -46,3 +48,5 @@ class Subsystem : public ErrorBase, public NamedSendable {
  protected:
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Commands/WaitCommand.h
+++ b/wpilibc/shared/include/Commands/WaitCommand.h
@@ -11,6 +11,8 @@
 
 #include "Commands/Command.h"
 
+namespace frc {
+
 class WaitCommand : public Command {
  public:
   explicit WaitCommand(double timeout);
@@ -24,3 +26,5 @@ class WaitCommand : public Command {
   virtual void End();
   virtual void Interrupted();
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Commands/WaitForChildren.h
+++ b/wpilibc/shared/include/Commands/WaitForChildren.h
@@ -11,6 +11,8 @@
 
 #include "Commands/Command.h"
 
+namespace frc {
+
 class WaitForChildren : public Command {
  public:
   explicit WaitForChildren(double timeout);
@@ -24,3 +26,5 @@ class WaitForChildren : public Command {
   virtual void End();
   virtual void Interrupted();
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Commands/WaitUntilCommand.h
+++ b/wpilibc/shared/include/Commands/WaitUntilCommand.h
@@ -11,6 +11,8 @@
 
 #include "Commands/Command.h"
 
+namespace frc {
+
 class WaitUntilCommand : public Command {
  public:
   explicit WaitUntilCommand(double time);
@@ -27,3 +29,5 @@ class WaitUntilCommand : public Command {
  private:
   double m_time;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Controller.h
+++ b/wpilibc/shared/include/Controller.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+namespace frc {
+
 /**
  * Interface for Controllers.
  * Common interface for controllers. Controllers run control loops, the most
@@ -28,3 +30,5 @@ class Controller {
    */
   virtual void Disable() = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Error.h
+++ b/wpilibc/shared/include/Error.h
@@ -20,6 +20,8 @@
 #undef GetMessage
 #endif
 
+namespace frc {
+
 //  Forward declarations
 class ErrorBase;
 
@@ -59,3 +61,5 @@ class Error {
   const ErrorBase* m_originatingObject = nullptr;
   double m_timestamp = 0.0;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/ErrorBase.h
+++ b/wpilibc/shared/include/ErrorBase.h
@@ -39,11 +39,11 @@
   } while (0)
 #define wpi_setStaticError(object, code) \
   wpi_setStaticErrorWithContext(object, code, "")
-#define wpi_setGlobalErrorWithContext(code, context)                       \
-  do {                                                                     \
-    if ((code) != 0)                                                       \
-      ErrorBase::SetGlobalError((code), (context), __FILE__, __FUNCTION__, \
-                                __LINE__);                                 \
+#define wpi_setGlobalErrorWithContext(code, context)                \
+  do {                                                              \
+    if ((code) != 0)                                                \
+      ::frc::ErrorBase::SetGlobalError((code), (context), __FILE__, \
+                                       __FUNCTION__, __LINE__);     \
   } while (0)
 #define wpi_setGlobalError(code) wpi_setGlobalErrorWithContext(code, "")
 #define wpi_setWPIErrorWithContext(error, context)                    \
@@ -55,10 +55,12 @@
                       __FUNCTION__, __LINE__)
 #define wpi_setStaticWPIError(object, error) \
   wpi_setStaticWPIErrorWithContext(object, error, "")
-#define wpi_setGlobalWPIErrorWithContext(error, context)                   \
-  ErrorBase::SetGlobalWPIError((wpi_error_s_##error), (context), __FILE__, \
-                               __FUNCTION__, __LINE__)
+#define wpi_setGlobalWPIErrorWithContext(error, context)                \
+  ::frc::ErrorBase::SetGlobalWPIError((wpi_error_s_##error), (context), \
+                                      __FILE__, __FUNCTION__, __LINE__)
 #define wpi_setGlobalWPIError(error) wpi_setGlobalWPIErrorWithContext(error, "")
+
+namespace frc {
 
 /**
  * Base class for most objects.
@@ -114,3 +116,5 @@ class ErrorBase {
   static priority_mutex _globalErrorMutex;
   static Error _globalError;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Filters/Filter.h
+++ b/wpilibc/shared/include/Filters/Filter.h
@@ -11,6 +11,8 @@
 
 #include "PIDSource.h"
 
+namespace frc {
+
 /**
  * Interface for filters
  */
@@ -48,3 +50,5 @@ class Filter : public PIDSource {
  private:
   std::shared_ptr<PIDSource> m_source;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Filters/LinearDigitalFilter.h
+++ b/wpilibc/shared/include/Filters/LinearDigitalFilter.h
@@ -14,6 +14,8 @@
 #include "CircularBuffer.h"
 #include "Filter.h"
 
+namespace frc {
+
 /**
  * This class implements a linear, digital filter. All types of FIR and IIR
  * filters are supported. Static factory methods are provided to create commonly
@@ -100,3 +102,5 @@ class LinearDigitalFilter : public Filter {
   std::vector<double> m_inputGains;
   std::vector<double> m_outputGains;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/GenericHID.h
+++ b/wpilibc/shared/include/GenericHID.h
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+namespace frc {
+
 /**
  * GenericHID Interface.
  */
@@ -32,3 +34,5 @@ class GenericHID {
 
   virtual int GetPOV(int pov = 0) const = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/GyroBase.h
+++ b/wpilibc/shared/include/GyroBase.h
@@ -15,6 +15,8 @@
 #include "SensorBase.h"
 #include "interfaces/Gyro.h"
 
+namespace frc {
+
 /**
  * GyroBase is the common base class for Gyro implementations such as
  * AnalogGyro.
@@ -39,3 +41,5 @@ class GyroBase : public Gyro,
  private:
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/HLUsageReporting.h
+++ b/wpilibc/shared/include/HLUsageReporting.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+namespace frc {
+
 class HLUsageReportingInterface {
  public:
   virtual ~HLUsageReportingInterface() = default;
@@ -23,3 +25,5 @@ class HLUsageReporting {
   static void ReportScheduler();
   static void ReportSmartDashboard();
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/LiveWindow/LiveWindow.h
+++ b/wpilibc/shared/include/LiveWindow/LiveWindow.h
@@ -16,6 +16,8 @@
 #include "LiveWindow/LiveWindowSendable.h"
 #include "tables/ITable.h"
 
+namespace frc {
+
 struct LiveWindowComponent {
   std::string subsystem;
   std::string name;
@@ -81,3 +83,5 @@ class LiveWindow {
   bool m_enabled = false;
   bool m_firstTime = true;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/LiveWindow/LiveWindowSendable.h
+++ b/wpilibc/shared/include/LiveWindow/LiveWindowSendable.h
@@ -9,6 +9,8 @@
 
 #include "SmartDashboard/Sendable.h"
 
+namespace frc {
+
 /**
  * Live Window Sendable is a special type of object sendable to the live window.
  */
@@ -32,3 +34,5 @@ class LiveWindowSendable : public Sendable {
    */
   virtual void StopLiveWindowMode() = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/LiveWindow/LiveWindowStatusListener.h
+++ b/wpilibc/shared/include/LiveWindow/LiveWindowStatusListener.h
@@ -12,8 +12,12 @@
 #include "tables/ITable.h"
 #include "tables/ITableListener.h"
 
+namespace frc {
+
 class LiveWindowStatusListener : public ITableListener {
  public:
   virtual void ValueChanged(ITable* source, llvm::StringRef key,
                             std::shared_ptr<nt::Value> value, bool isNew);
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/PIDController.h
+++ b/wpilibc/shared/include/PIDController.h
@@ -21,6 +21,8 @@
 #include "PIDSource.h"
 #include "Timer.h"
 
+namespace frc {
+
 class PIDOutput;
 
 /**
@@ -147,3 +149,5 @@ class PIDController : public LiveWindowSendable,
   void StartLiveWindowMode() override;
   void StopLiveWindowMode() override;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/PIDInterface.h
+++ b/wpilibc/shared/include/PIDInterface.h
@@ -11,6 +11,8 @@
 #include "Controller.h"
 #include "LiveWindow/LiveWindow.h"
 
+namespace frc {
+
 class PIDInterface : public Controller {
   virtual void SetPID(double p, double i, double d) = 0;
   virtual double GetP() const = 0;
@@ -26,3 +28,5 @@ class PIDInterface : public Controller {
 
   virtual void Reset() = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/PIDOutput.h
+++ b/wpilibc/shared/include/PIDOutput.h
@@ -9,6 +9,8 @@
 
 #include "Base.h"
 
+namespace frc {
+
 /**
  * PIDOutput interface is a generic output for the PID class.
  * PWMs use this class.
@@ -19,3 +21,5 @@ class PIDOutput {
  public:
   virtual void PIDWrite(float output) = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/PIDSource.h
+++ b/wpilibc/shared/include/PIDSource.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+namespace frc {
+
 enum class PIDSourceType { kDisplacement, kRate };
 
 /**
@@ -23,3 +25,5 @@ class PIDSource {
  protected:
   PIDSourceType m_pidSource = PIDSourceType::kDisplacement;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Resource.h
+++ b/wpilibc/shared/include/Resource.h
@@ -16,6 +16,8 @@
 #include "ErrorBase.h"
 #include "HAL/cpp/priority_mutex.h"
 
+namespace frc {
+
 /**
  * The Resource class is a convenient way to track allocated resources.
  * It tracks them as indicies in the range [0 .. elements - 1].
@@ -45,3 +47,5 @@ class Resource : public ErrorBase {
 
   static priority_recursive_mutex m_createLock;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/RobotState.h
+++ b/wpilibc/shared/include/RobotState.h
@@ -9,6 +9,8 @@
 
 #include <memory>
 
+namespace frc {
+
 class RobotStateInterface {
  public:
   virtual ~RobotStateInterface() = default;
@@ -32,3 +34,5 @@ class RobotState {
   static bool IsAutonomous();
   static bool IsTest();
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/SmartDashboard/NamedSendable.h
+++ b/wpilibc/shared/include/SmartDashboard/NamedSendable.h
@@ -11,6 +11,8 @@
 
 #include "SmartDashboard/Sendable.h"
 
+namespace frc {
+
 /**
  * The interface for sendable objects that gives the sendable a default name in
  * the Smart Dashboard
@@ -24,3 +26,5 @@ class NamedSendable : public Sendable {
    */
   virtual std::string GetName() const = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/SmartDashboard/Sendable.h
+++ b/wpilibc/shared/include/SmartDashboard/Sendable.h
@@ -12,6 +12,8 @@
 
 #include "tables/ITable.h"
 
+namespace frc {
+
 class Sendable {
  public:
   /**
@@ -31,3 +33,5 @@ class Sendable {
    */
   virtual std::string GetSmartDashboardType() const = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/SmartDashboard/SendableChooser.h
+++ b/wpilibc/shared/include/SmartDashboard/SendableChooser.h
@@ -14,6 +14,8 @@
 #include "SmartDashboard/Sendable.h"
 #include "tables/ITable.h"
 
+namespace frc {
+
 /**
  * The {@link SendableChooser} class is a useful tool for presenting a selection
  * of options to the {@link SmartDashboard}.
@@ -44,3 +46,5 @@ class SendableChooser : public Sendable {
   std::map<std::string, void*> m_choices;
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/SmartDashboard/SmartDashboard.h
+++ b/wpilibc/shared/include/SmartDashboard/SmartDashboard.h
@@ -17,6 +17,8 @@
 #include "SmartDashboard/Sendable.h"
 #include "tables/ITable.h"
 
+namespace frc {
+
 class SmartDashboard : public SensorBase {
  public:
   static void init();
@@ -94,3 +96,5 @@ class SmartDashboard : public SensorBase {
    */
   static std::map<std::shared_ptr<ITable>, Sendable*> m_tablesToData;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Timer.h
+++ b/wpilibc/shared/include/Timer.h
@@ -10,6 +10,8 @@
 #include "Base.h"
 #include "HAL/cpp/priority_mutex.h"
 
+namespace frc {
+
 typedef void (*TimerInterruptHandler)(void* param);
 
 void Wait(double seconds);
@@ -51,3 +53,5 @@ class Timer {
   bool m_running = false;
   mutable priority_mutex m_mutex;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/Utility.h
+++ b/wpilibc/shared/include/Utility.h
@@ -46,8 +46,12 @@ bool wpi_assertNotEqual_impl(int valueA, int valueB, const char* valueAString,
 
 void wpi_suspendOnAssertEnabled(bool enabled);
 
+namespace frc {
+
 int GetFPGAVersion();
 int64_t GetFPGARevision();
 uint64_t GetFPGATime();
 bool GetUserButton();
 std::string GetStackTrace(int offset);
+
+}  // namespace frc

--- a/wpilibc/shared/include/interfaces/Accelerometer.h
+++ b/wpilibc/shared/include/interfaces/Accelerometer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+namespace frc {
+
 /**
  * Interface for 3-axis accelerometers
  */
@@ -45,3 +47,5 @@ class Accelerometer {
    */
   virtual double GetZ() = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/interfaces/Gyro.h
+++ b/wpilibc/shared/include/interfaces/Gyro.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+namespace frc {
+
 /**
  * Interface for yaw rate gyros
  */
@@ -54,3 +56,5 @@ class Gyro {
    */
   virtual double GetRate() const = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/include/interfaces/Potentiometer.h
+++ b/wpilibc/shared/include/interfaces/Potentiometer.h
@@ -9,6 +9,8 @@
 
 #include "PIDSource.h"
 
+namespace frc {
+
 /**
  * Interface for potentiometers.
  */
@@ -25,3 +27,5 @@ class Potentiometer : public PIDSource {
 
   void SetPIDSourceType(PIDSourceType pidSource) override;
 };
+
+}  // namespace frc

--- a/wpilibc/shared/src/Buttons/Button.cpp
+++ b/wpilibc/shared/src/Buttons/Button.cpp
@@ -7,6 +7,8 @@
 
 #include "Buttons/Button.h"
 
+using namespace frc;
+
 /**
  * Specifies the command to run when a button is first pressed.
  *

--- a/wpilibc/shared/src/Buttons/ButtonScheduler.cpp
+++ b/wpilibc/shared/src/Buttons/ButtonScheduler.cpp
@@ -9,6 +9,8 @@
 
 #include "Commands/Scheduler.h"
 
+using namespace frc;
+
 ButtonScheduler::ButtonScheduler(bool last, Trigger* button, Command* orders)
     : m_pressedLast(last), m_button(button), m_command(orders) {}
 

--- a/wpilibc/shared/src/Buttons/CancelButtonScheduler.cpp
+++ b/wpilibc/shared/src/Buttons/CancelButtonScheduler.cpp
@@ -10,6 +10,8 @@
 #include "Buttons/Button.h"
 #include "Commands/Command.h"
 
+using namespace frc;
+
 CancelButtonScheduler::CancelButtonScheduler(bool last, Trigger* button,
                                              Command* orders)
     : ButtonScheduler(last, button, orders) {

--- a/wpilibc/shared/src/Buttons/HeldButtonScheduler.cpp
+++ b/wpilibc/shared/src/Buttons/HeldButtonScheduler.cpp
@@ -10,6 +10,8 @@
 #include "Buttons/Button.h"
 #include "Commands/Command.h"
 
+using namespace frc;
+
 HeldButtonScheduler::HeldButtonScheduler(bool last, Trigger* button,
                                          Command* orders)
     : ButtonScheduler(last, button, orders) {}

--- a/wpilibc/shared/src/Buttons/InternalButton.cpp
+++ b/wpilibc/shared/src/Buttons/InternalButton.cpp
@@ -7,6 +7,8 @@
 
 #include "Buttons/InternalButton.h"
 
+using namespace frc;
+
 InternalButton::InternalButton(bool inverted)
     : m_pressed(inverted), m_inverted(inverted) {}
 

--- a/wpilibc/shared/src/Buttons/JoystickButton.cpp
+++ b/wpilibc/shared/src/Buttons/JoystickButton.cpp
@@ -7,6 +7,8 @@
 
 #include "Buttons/JoystickButton.h"
 
+using namespace frc;
+
 JoystickButton::JoystickButton(GenericHID* joystick, int buttonNumber)
     : m_joystick(joystick), m_buttonNumber(buttonNumber) {}
 

--- a/wpilibc/shared/src/Buttons/NetworkButton.cpp
+++ b/wpilibc/shared/src/Buttons/NetworkButton.cpp
@@ -9,6 +9,8 @@
 
 #include "networktables/NetworkTable.h"
 
+using namespace frc;
+
 NetworkButton::NetworkButton(const std::string& tableName,
                              const std::string& field)
     :  // TODO how is this supposed to work???

--- a/wpilibc/shared/src/Buttons/PressedButtonScheduler.cpp
+++ b/wpilibc/shared/src/Buttons/PressedButtonScheduler.cpp
@@ -10,6 +10,8 @@
 #include "Buttons/Button.h"
 #include "Commands/Command.h"
 
+using namespace frc;
+
 PressedButtonScheduler::PressedButtonScheduler(bool last, Trigger* button,
                                                Command* orders)
     : ButtonScheduler(last, button, orders) {}

--- a/wpilibc/shared/src/Buttons/ReleasedButtonScheduler.cpp
+++ b/wpilibc/shared/src/Buttons/ReleasedButtonScheduler.cpp
@@ -10,6 +10,8 @@
 #include "Buttons/Button.h"
 #include "Commands/Command.h"
 
+using namespace frc;
+
 ReleasedButtonScheduler::ReleasedButtonScheduler(bool last, Trigger* button,
                                                  Command* orders)
     : ButtonScheduler(last, button, orders) {}

--- a/wpilibc/shared/src/Buttons/ToggleButtonScheduler.cpp
+++ b/wpilibc/shared/src/Buttons/ToggleButtonScheduler.cpp
@@ -10,6 +10,8 @@
 #include "Buttons/Button.h"
 #include "Commands/Command.h"
 
+using namespace frc;
+
 ToggleButtonScheduler::ToggleButtonScheduler(bool last, Trigger* button,
                                              Command* orders)
     : ButtonScheduler(last, button, orders) {

--- a/wpilibc/shared/src/Buttons/Trigger.cpp
+++ b/wpilibc/shared/src/Buttons/Trigger.cpp
@@ -12,6 +12,8 @@
 #include "Buttons/ReleasedButtonScheduler.h"
 #include "Buttons/ToggleButtonScheduler.h"
 
+using namespace frc;
+
 bool Trigger::Grab() {
   if (Get()) {
     return true;

--- a/wpilibc/shared/src/Commands/Command.cpp
+++ b/wpilibc/shared/src/Commands/Command.cpp
@@ -15,6 +15,8 @@
 #include "Timer.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 static const std::string kName = "name";
 static const std::string kRunning = "running";
 static const std::string kIsParented = "isParented";

--- a/wpilibc/shared/src/Commands/CommandGroup.cpp
+++ b/wpilibc/shared/src/Commands/CommandGroup.cpp
@@ -9,6 +9,8 @@
 
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Creates a new {@link CommandGroup CommandGroup} with the given name.
  * @param name the name for this command group

--- a/wpilibc/shared/src/Commands/CommandGroupEntry.cpp
+++ b/wpilibc/shared/src/Commands/CommandGroupEntry.cpp
@@ -9,6 +9,8 @@
 
 #include "Commands/Command.h"
 
+using namespace frc;
+
 CommandGroupEntry::CommandGroupEntry(Command* command, Sequence state,
                                      double timeout)
     : m_timeout(timeout), m_command(command), m_state(state) {}

--- a/wpilibc/shared/src/Commands/PIDCommand.cpp
+++ b/wpilibc/shared/src/Commands/PIDCommand.cpp
@@ -9,6 +9,8 @@
 
 #include <cfloat>
 
+using namespace frc;
+
 PIDCommand::PIDCommand(const std::string& name, double p, double i, double d,
                        double f, double period)
     : Command(name) {

--- a/wpilibc/shared/src/Commands/PIDSubsystem.cpp
+++ b/wpilibc/shared/src/Commands/PIDSubsystem.cpp
@@ -9,6 +9,8 @@
 
 #include "PIDController.h"
 
+using namespace frc;
+
 /**
  * Instantiates a {@link PIDSubsystem} that will use the given p, i and d
  * values.

--- a/wpilibc/shared/src/Commands/PrintCommand.cpp
+++ b/wpilibc/shared/src/Commands/PrintCommand.cpp
@@ -10,6 +10,8 @@
 #include <cstdio>
 #include <sstream>
 
+using namespace frc;
+
 PrintCommand::PrintCommand(const std::string& message)
     : Command(((std::stringstream&)(std::stringstream("Print \"") << message
                                                                   << "\""))

--- a/wpilibc/shared/src/Commands/Scheduler.cpp
+++ b/wpilibc/shared/src/Commands/Scheduler.cpp
@@ -16,6 +16,8 @@
 #include "HLUsageReporting.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 Scheduler::Scheduler() { HLUsageReporting::ReportScheduler(); }
 
 /**

--- a/wpilibc/shared/src/Commands/StartCommand.cpp
+++ b/wpilibc/shared/src/Commands/StartCommand.cpp
@@ -7,6 +7,8 @@
 
 #include "Commands/StartCommand.h"
 
+using namespace frc;
+
 StartCommand::StartCommand(Command* commandToStart) : Command("StartCommand") {
   m_commandToFork = commandToStart;
 }

--- a/wpilibc/shared/src/Commands/Subsystem.cpp
+++ b/wpilibc/shared/src/Commands/Subsystem.cpp
@@ -11,6 +11,8 @@
 #include "Commands/Scheduler.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Creates a subsystem with the given name.
  *

--- a/wpilibc/shared/src/Commands/WaitCommand.cpp
+++ b/wpilibc/shared/src/Commands/WaitCommand.cpp
@@ -9,6 +9,8 @@
 
 #include <sstream>
 
+using namespace frc;
+
 WaitCommand::WaitCommand(double timeout)
     : Command(
           ((std::stringstream&)(std::stringstream("Wait(") << timeout << ")"))

--- a/wpilibc/shared/src/Commands/WaitForChildren.cpp
+++ b/wpilibc/shared/src/Commands/WaitForChildren.cpp
@@ -9,6 +9,8 @@
 
 #include "Commands/CommandGroup.h"
 
+using namespace frc;
+
 WaitForChildren::WaitForChildren(double timeout)
     : Command("WaitForChildren", timeout) {}
 

--- a/wpilibc/shared/src/Commands/WaitUntilCommand.cpp
+++ b/wpilibc/shared/src/Commands/WaitUntilCommand.cpp
@@ -9,6 +9,8 @@
 
 #include "Timer.h"
 
+using namespace frc;
+
 /**
  * A {@link WaitCommand} will wait until a certain match time before finishing.
  *

--- a/wpilibc/shared/src/Error.cpp
+++ b/wpilibc/shared/src/Error.cpp
@@ -13,6 +13,8 @@
 #include "Timer.h"
 #include "Utility.h"
 
+using namespace frc;
+
 void Error::Clone(const Error& error) {
   m_code = error.m_code;
   m_message = error.m_message;

--- a/wpilibc/shared/src/ErrorBase.cpp
+++ b/wpilibc/shared/src/ErrorBase.cpp
@@ -16,6 +16,8 @@
 #define WPI_ERRORS_DEFINE_STRINGS
 #include "WPIErrors.h"
 
+using namespace frc;
+
 priority_mutex ErrorBase::_globalErrorMutex;
 Error ErrorBase::_globalError;
 

--- a/wpilibc/shared/src/Filters/Filter.cpp
+++ b/wpilibc/shared/src/Filters/Filter.cpp
@@ -7,6 +7,8 @@
 
 #include "Filters/Filter.h"
 
+using namespace frc;
+
 Filter::Filter(std::shared_ptr<PIDSource> source) { m_source = source; }
 
 void Filter::SetPIDSourceType(PIDSourceType pidSource) {

--- a/wpilibc/shared/src/Filters/LinearDigitalFilter.cpp
+++ b/wpilibc/shared/src/Filters/LinearDigitalFilter.cpp
@@ -10,6 +10,8 @@
 #include <cassert>
 #include <cmath>
 
+using namespace frc;
+
 /**
  * Create a linear FIR or IIR filter.
  *

--- a/wpilibc/shared/src/GyroBase.cpp
+++ b/wpilibc/shared/src/GyroBase.cpp
@@ -10,6 +10,8 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Get the PIDOutput for the PIDSource base object. Can be set to return
  * angle or rate using SetPIDSourceType(). Defaults to angle.

--- a/wpilibc/shared/src/HLUsageReporting.cpp
+++ b/wpilibc/shared/src/HLUsageReporting.cpp
@@ -7,6 +7,8 @@
 
 #include "HLUsageReporting.h"
 
+using namespace frc;
+
 HLUsageReportingInterface* HLUsageReporting::impl = nullptr;
 
 void HLUsageReporting::SetImplementation(HLUsageReportingInterface* i) {

--- a/wpilibc/shared/src/LiveWindow/LiveWindow.cpp
+++ b/wpilibc/shared/src/LiveWindow/LiveWindow.cpp
@@ -12,6 +12,8 @@
 
 #include "networktables/NetworkTable.h"
 
+using namespace frc;
+
 /**
  * Get an instance of the LiveWindow main class.
  *

--- a/wpilibc/shared/src/LiveWindow/LiveWindowStatusListener.cpp
+++ b/wpilibc/shared/src/LiveWindow/LiveWindowStatusListener.cpp
@@ -9,6 +9,8 @@
 
 #include "Commands/Scheduler.h"
 
+using namespace frc;
+
 void LiveWindowStatusListener::ValueChanged(ITable* source, llvm::StringRef key,
                                             std::shared_ptr<nt::Value> value,
                                             bool isNew) {}

--- a/wpilibc/shared/src/PIDSource.cpp
+++ b/wpilibc/shared/src/PIDSource.cpp
@@ -7,6 +7,8 @@
 
 #include "PIDSource.h"
 
+using namespace frc;
+
 /**
  * Set which parameter you are using as a process control variable.
  *

--- a/wpilibc/shared/src/Resource.cpp
+++ b/wpilibc/shared/src/Resource.cpp
@@ -10,6 +10,8 @@
 #include "ErrorBase.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 priority_recursive_mutex Resource::m_createLock;
 
 /**

--- a/wpilibc/shared/src/RobotState.cpp
+++ b/wpilibc/shared/src/RobotState.cpp
@@ -9,6 +9,8 @@
 
 #include "Base.h"
 
+using namespace frc;
+
 std::shared_ptr<RobotStateInterface> RobotState::impl;
 
 void RobotState::SetImplementation(RobotStateInterface& i) {

--- a/wpilibc/shared/src/SmartDashboard/SendableChooser.cpp
+++ b/wpilibc/shared/src/SmartDashboard/SendableChooser.cpp
@@ -7,6 +7,8 @@
 
 #include "SmartDashboard/SendableChooser.h"
 
+using namespace frc;
+
 static const std::string kDefault = "default";
 static const std::string kOptions = "options";
 static const std::string kSelected = "selected";

--- a/wpilibc/shared/src/SmartDashboard/SmartDashboard.cpp
+++ b/wpilibc/shared/src/SmartDashboard/SmartDashboard.cpp
@@ -12,6 +12,8 @@
 #include "WPIErrors.h"
 #include "networktables/NetworkTable.h"
 
+using namespace frc;
+
 std::shared_ptr<ITable> SmartDashboard::m_table;
 std::map<std::shared_ptr<ITable>, Sendable*> SmartDashboard::m_tablesToData;
 

--- a/wpilibc/shared/src/interfaces/Potentiometer.cpp
+++ b/wpilibc/shared/src/interfaces/Potentiometer.cpp
@@ -9,6 +9,8 @@
 
 #include <Utility.h>
 
+using namespace frc;
+
 void Potentiometer::SetPIDSourceType(PIDSourceType pidSource) {
   if (wpi_assert(pidSource == PIDSourceType::kDisplacement)) {
     m_pidSource = pidSource;

--- a/wpilibc/sim/CMakeLists.txt
+++ b/wpilibc/sim/CMakeLists.txt
@@ -5,6 +5,8 @@ project(wpilibcSim)
 file(GLOB_RECURSE COM_SRC_FILES ../shared/src/*.cpp
   src/*.cpp)
 
+add_definitions(-DNAMESPACED_WPILIB)
+
 set (INCLUDE_FOLDERS include
   ../shared/include
   ../../hal/include

--- a/wpilibc/sim/include/AnalogGyro.h
+++ b/wpilibc/sim/include/AnalogGyro.h
@@ -12,6 +12,8 @@
 #include "GyroBase.h"
 #include "simulation/SimGyro.h"
 
+namespace frc {
+
 class AnalogInput;
 class AnalogModule;
 
@@ -49,3 +51,5 @@ class AnalogGyro : public GyroBase {
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/AnalogInput.h
+++ b/wpilibc/sim/include/AnalogInput.h
@@ -15,6 +15,8 @@
 #include "SensorBase.h"
 #include "simulation/SimFloatInput.h"
 
+namespace frc {
+
 /**
  * Analog input class.
  *
@@ -59,3 +61,5 @@ class AnalogInput : public SensorBase,
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/AnalogPotentiometer.h
+++ b/wpilibc/sim/include/AnalogPotentiometer.h
@@ -14,6 +14,8 @@
 #include "LiveWindow/LiveWindowSendable.h"
 #include "interfaces/Potentiometer.h"
 
+namespace frc {
+
 /**
  * Class for reading analog potentiometers. Analog potentiometers read
  * in an analog voltage that corresponds to a position. Usually the
@@ -93,3 +95,5 @@ class AnalogPotentiometer : public Potentiometer, public LiveWindowSendable {
    */
   void initPot(AnalogInput* input, double scale, double offset);
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/Counter.h
+++ b/wpilibc/sim/include/Counter.h
@@ -14,6 +14,8 @@
 #include "LiveWindow/LiveWindowSendable.h"
 #include "SensorBase.h"
 
+namespace frc {
+
 /**
  * Class for counting the number of ticks on a digital input channel.
  *
@@ -98,3 +100,5 @@ class Counter : public SensorBase,
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/CounterBase.h
+++ b/wpilibc/sim/include/CounterBase.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+namespace frc {
+
 /**
  * Interface for counting the number of ticks on a digital input channel.
  *
@@ -28,3 +30,5 @@ class CounterBase {
   virtual bool GetStopped() const = 0;
   virtual bool GetDirection() const = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/DigitalInput.h
+++ b/wpilibc/sim/include/DigitalInput.h
@@ -13,6 +13,8 @@
 #include "LiveWindow/LiveWindowSendable.h"
 #include "simulation/SimDigitalInput.h"
 
+namespace frc {
+
 /**
  * Class to read a digital input.
  *
@@ -43,3 +45,5 @@ class DigitalInput : public LiveWindowSendable {
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/DoubleSolenoid.h
+++ b/wpilibc/sim/include/DoubleSolenoid.h
@@ -14,6 +14,8 @@
 #include "simulation/SimContinuousOutput.h"
 #include "tables/ITableListener.h"
 
+namespace frc {
+
 /**
  * DoubleSolenoid class for running 2 channels of high voltage Digital Output
  * (PCM).
@@ -47,3 +49,5 @@ class DoubleSolenoid : public LiveWindowSendable, public ITableListener {
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/DriverStation.h
+++ b/wpilibc/sim/include/DriverStation.h
@@ -23,10 +23,12 @@
 #include <Winsock2.h>
 #endif
 
+using namespace gazebo;
+
+namespace frc {
+
 struct HALCommonControlData;
 class AnalogInput;
-
-using namespace gazebo;
 
 /**
  * Provide access to the network communication data to / from the Driver
@@ -143,3 +145,5 @@ class DriverStation : public SensorBase, public RobotStateInterface {
   msgs::DriverStationPtr state;
   msgs::FRCJoystickPtr joysticks[6];
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/Encoder.h
+++ b/wpilibc/sim/include/Encoder.h
@@ -18,6 +18,8 @@
 #include "SensorBase.h"
 #include "simulation/SimEncoder.h"
 
+namespace frc {
+
 /**
  * Class to read quad encoders.
  *
@@ -97,3 +99,5 @@ class Encoder : public SensorBase,
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/IterativeRobot.h
+++ b/wpilibc/sim/include/IterativeRobot.h
@@ -9,6 +9,8 @@
 
 #include "RobotBase.h"
 
+namespace frc {
+
 /**
  * IterativeRobot implements a specific type of Robot Program framework,
  * extending the RobotBase class.
@@ -68,3 +70,5 @@ class IterativeRobot : public RobotBase {
   bool m_teleopInitialized = false;
   bool m_testInitialized = false;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/Jaguar.h
+++ b/wpilibc/sim/include/Jaguar.h
@@ -11,6 +11,8 @@
 #include "SafePWM.h"
 #include "SpeedController.h"
 
+namespace frc {
+
 /**
  * Luminary Micro Jaguar Speed Control.
  */
@@ -24,3 +26,5 @@ class Jaguar : public SafePWM, public SpeedController {
 
   void PIDWrite(float output) override;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/Joystick.h
+++ b/wpilibc/sim/include/Joystick.h
@@ -12,6 +12,8 @@
 #include "ErrorBase.h"
 #include "GenericHID.h"
 
+namespace frc {
+
 class DriverStation;
 
 /**
@@ -77,3 +79,5 @@ class Joystick : public GenericHID, public ErrorBase {
   std::unique_ptr<int[]> m_axes;
   std::unique_ptr<int[]> m_buttons;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/MotorSafety.h
+++ b/wpilibc/sim/include/MotorSafety.h
@@ -11,6 +11,8 @@
 
 #include <sstream>
 
+namespace frc {
+
 class MotorSafety {
  public:
   virtual void SetExpiration(float timeout) = 0;
@@ -21,3 +23,5 @@ class MotorSafety {
   virtual bool IsSafetyEnabled() const = 0;
   virtual void GetDescription(std::ostringstream& desc) const = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/MotorSafetyHelper.h
+++ b/wpilibc/sim/include/MotorSafetyHelper.h
@@ -12,6 +12,8 @@
 #include "ErrorBase.h"
 #include "HAL/cpp/priority_mutex.h"
 
+namespace frc {
+
 class MotorSafety;
 
 class MotorSafetyHelper : public ErrorBase {
@@ -42,3 +44,5 @@ class MotorSafetyHelper : public ErrorBase {
   // protect accesses to the list of helpers
   static priority_recursive_mutex m_listMutex;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/Notifier.h
+++ b/wpilibc/sim/include/Notifier.h
@@ -16,6 +16,8 @@
 #include "ErrorBase.h"
 #include "HAL/cpp/priority_mutex.h"
 
+namespace frc {
+
 typedef std::function<void()> TimerEventHandler;
 
 class Notifier : public ErrorBase {
@@ -70,3 +72,5 @@ class Notifier : public ErrorBase {
   static std::atomic<bool> m_stopped;
   static void Run();
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/PWM.h
+++ b/wpilibc/sim/include/PWM.h
@@ -15,6 +15,8 @@
 #include "simulation/SimContinuousOutput.h"
 #include "tables/ITableListener.h"
 
+namespace frc {
+
 /**
  * Class implements the PWM generation in the FPGA.
  *
@@ -106,3 +108,5 @@ class PWM : public SensorBase,
   int m_channel;
   SimContinuousOutput* impl;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/Relay.h
+++ b/wpilibc/sim/include/Relay.h
@@ -17,6 +17,8 @@
 #include "tables/ITable.h"
 #include "tables/ITableListener.h"
 
+namespace frc {
+
 class MotorSafetyHelper;
 class DigitalModule;
 
@@ -73,3 +75,5 @@ class Relay : public MotorSafety,
   SimContinuousOutput* impl;
   bool go_pos, go_neg;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/RobotBase.h
+++ b/wpilibc/sim/include/RobotBase.h
@@ -21,6 +21,8 @@
     robot.StartCompetition();                                        \
   }
 
+namespace frc {
+
 /**
  * Implement a Robot Program framework.
  *
@@ -50,3 +52,5 @@ class RobotBase {
   DriverStation& m_ds;
   transport::SubscriberPtr time_sub;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/RobotDrive.h
+++ b/wpilibc/sim/include/RobotDrive.h
@@ -15,6 +15,8 @@
 #include "MotorSafety.h"
 #include "MotorSafetyHelper.h"
 
+namespace frc {
+
 class SpeedController;
 class GenericHID;
 
@@ -124,3 +126,5 @@ class RobotDrive : public MotorSafety, public ErrorBase {
     return motors;
   }
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/SafePWM.h
+++ b/wpilibc/sim/include/SafePWM.h
@@ -13,6 +13,8 @@
 #include "MotorSafetyHelper.h"
 #include "PWM.h"
 
+namespace frc {
+
 /**
  * A safe version of the PWM class.
  *
@@ -39,3 +41,5 @@ class SafePWM : public PWM, public MotorSafety {
  private:
   std::unique_ptr<MotorSafetyHelper> m_safetyHelper;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/SampleRobot.h
+++ b/wpilibc/sim/include/SampleRobot.h
@@ -9,6 +9,8 @@
 
 #include "RobotBase.h"
 
+namespace frc {
+
 class SampleRobot : public RobotBase {
  public:
   SampleRobot();
@@ -24,3 +26,5 @@ class SampleRobot : public RobotBase {
  private:
   bool m_robotMainOverridden;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/SensorBase.h
+++ b/wpilibc/sim/include/SensorBase.h
@@ -12,6 +12,8 @@
 #include "Base.h"
 #include "ErrorBase.h"
 
+namespace frc {
+
 /**
  * Base class for all sensors.
  * Stores most recent status information as well as containing utility functions
@@ -45,3 +47,5 @@ class SensorBase : public ErrorBase {
   static const int kRelayChannels = 8;
   static const int kPDPChannels = 16;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/Solenoid.h
+++ b/wpilibc/sim/include/Solenoid.h
@@ -14,6 +14,8 @@
 #include "simulation/SimContinuousOutput.h"
 #include "tables/ITableListener.h"
 
+namespace frc {
+
 /**
  * Solenoid class for running high voltage Digital Output (PCM).
  *
@@ -43,3 +45,5 @@ class Solenoid : public LiveWindowSendable, public ITableListener {
 
   std::shared_ptr<ITable> m_table;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/SpeedController.h
+++ b/wpilibc/sim/include/SpeedController.h
@@ -9,6 +9,8 @@
 
 #include "PIDOutput.h"
 
+namespace frc {
+
 /**
  * Interface for speed controlling devices.
  */
@@ -32,3 +34,5 @@ class SpeedController : public PIDOutput {
    */
   virtual void Disable() = 0;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/Talon.h
+++ b/wpilibc/sim/include/Talon.h
@@ -11,6 +11,8 @@
 #include "SafePWM.h"
 #include "SpeedController.h"
 
+namespace frc {
+
 /**
  * CTRE Talon Speed Controller.
  */
@@ -24,3 +26,5 @@ class Talon : public SafePWM, public SpeedController {
 
   void PIDWrite(float output) override;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/Victor.h
+++ b/wpilibc/sim/include/Victor.h
@@ -11,6 +11,8 @@
 #include "SafePWM.h"
 #include "SpeedController.h"
 
+namespace frc {
+
 /**
  * IFI Victor Speed Controller.
  */
@@ -24,3 +26,5 @@ class Victor : public SafePWM, public SpeedController {
 
   void PIDWrite(float output) override;
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/simulation/MainNode.h
+++ b/wpilibc/sim/include/simulation/MainNode.h
@@ -16,6 +16,8 @@
 
 using namespace gazebo;
 
+namespace frc {
+
 class MainNode {
  public:
   static MainNode* GetInstance() {
@@ -61,3 +63,5 @@ class MainNode {
     }
   }
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/simulation/SimContinuousOutput.h
+++ b/wpilibc/sim/include/simulation/SimContinuousOutput.h
@@ -21,6 +21,8 @@
 
 using namespace gazebo;
 
+namespace frc {
+
 class SimContinuousOutput {
  private:
   transport::PublisherPtr pub;
@@ -44,3 +46,5 @@ class SimContinuousOutput {
    */
   float Get();
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/simulation/SimDigitalInput.h
+++ b/wpilibc/sim/include/simulation/SimDigitalInput.h
@@ -15,6 +15,8 @@
 
 using namespace gazebo;
 
+namespace frc {
+
 class SimDigitalInput {
  public:
   explicit SimDigitalInput(std::string topic);
@@ -29,3 +31,5 @@ class SimDigitalInput {
   transport::SubscriberPtr sub;
   void callback(const msgs::ConstBoolPtr& msg);
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/simulation/SimEncoder.h
+++ b/wpilibc/sim/include/simulation/SimEncoder.h
@@ -16,6 +16,8 @@
 
 using namespace gazebo;
 
+namespace frc {
+
 class SimEncoder {
  public:
   explicit SimEncoder(std::string topic);
@@ -35,3 +37,5 @@ class SimEncoder {
   void positionCallback(const msgs::ConstFloat64Ptr& msg);
   void velocityCallback(const msgs::ConstFloat64Ptr& msg);
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/simulation/SimFloatInput.h
+++ b/wpilibc/sim/include/simulation/SimFloatInput.h
@@ -15,6 +15,8 @@
 
 using namespace gazebo;
 
+namespace frc {
+
 class SimFloatInput {
  public:
   explicit SimFloatInput(std::string topic);
@@ -29,3 +31,5 @@ class SimFloatInput {
   transport::SubscriberPtr sub;
   void callback(const msgs::ConstFloat64Ptr& msg);
 };
+
+}  // namespace frc

--- a/wpilibc/sim/include/simulation/SimGyro.h
+++ b/wpilibc/sim/include/simulation/SimGyro.h
@@ -15,6 +15,8 @@
 
 using namespace gazebo;
 
+namespace frc {
+
 class SimGyro {
  public:
   explicit SimGyro(std::string topic);
@@ -32,3 +34,5 @@ class SimGyro {
   void positionCallback(const msgs::ConstFloat64Ptr& msg);
   void velocityCallback(const msgs::ConstFloat64Ptr& msg);
 };
+
+}  // namespace frc

--- a/wpilibc/sim/src/AnalogGyro.cpp
+++ b/wpilibc/sim/src/AnalogGyro.cpp
@@ -13,6 +13,8 @@
 #include "Timer.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 const int AnalogGyro::kOversampleBits = 10;
 const int AnalogGyro::kAverageBits = 0;
 const float AnalogGyro::kSamplesPerSecond = 50.0;

--- a/wpilibc/sim/src/AnalogInput.cpp
+++ b/wpilibc/sim/src/AnalogInput.cpp
@@ -12,6 +12,8 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Construct an analog input.
  *

--- a/wpilibc/sim/src/AnalogPotentiometer.cpp
+++ b/wpilibc/sim/src/AnalogPotentiometer.cpp
@@ -7,6 +7,8 @@
 
 #include "AnalogPotentiometer.h"
 
+using namespace frc;
+
 /**
  * Common initialization code called by all constructors.
  */

--- a/wpilibc/sim/src/DigitalInput.cpp
+++ b/wpilibc/sim/src/DigitalInput.cpp
@@ -11,6 +11,8 @@
 
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Create an instance of a Digital Input class.
  * Creates a digital input given a channel and uses the default module.

--- a/wpilibc/sim/src/DoubleSolenoid.cpp
+++ b/wpilibc/sim/src/DoubleSolenoid.cpp
@@ -10,6 +10,8 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Constructor.
  *

--- a/wpilibc/sim/src/DriverStation.cpp
+++ b/wpilibc/sim/src/DriverStation.cpp
@@ -15,6 +15,8 @@
 #include "WPIErrors.h"
 #include "simulation/MainNode.h"
 
+using namespace frc;
+
 const int DriverStation::kBatteryChannel;
 const int DriverStation::kJoystickPorts;
 const int DriverStation::kJoystickAxes;

--- a/wpilibc/sim/src/Encoder.cpp
+++ b/wpilibc/sim/src/Encoder.cpp
@@ -12,6 +12,8 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Common initialization code for Encoders.
  * This code allocates resources for Encoders and is common to all constructors.

--- a/wpilibc/sim/src/IterativeRobot.cpp
+++ b/wpilibc/sim/src/IterativeRobot.cpp
@@ -17,6 +17,8 @@
 #include <unistd.h>
 #endif
 
+using namespace frc;
+
 /**
  * Provide an alternate "main loop" via StartCompetition().
  *

--- a/wpilibc/sim/src/Jaguar.cpp
+++ b/wpilibc/sim/src/Jaguar.cpp
@@ -9,6 +9,8 @@
 
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 /**
  * @param channel The PWM channel that the Jaguar is attached to.
  */

--- a/wpilibc/sim/src/Joystick.cpp
+++ b/wpilibc/sim/src/Joystick.cpp
@@ -13,6 +13,8 @@
 #include "DriverStation.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 const int Joystick::kDefaultXAxis;
 const int Joystick::kDefaultYAxis;
 const int Joystick::kDefaultZAxis;

--- a/wpilibc/sim/src/MotorSafetyHelper.cpp
+++ b/wpilibc/sim/src/MotorSafetyHelper.cpp
@@ -14,6 +14,8 @@
 #include "Timer.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 std::set<MotorSafetyHelper*> MotorSafetyHelper::m_helperList;
 priority_recursive_mutex MotorSafetyHelper::m_listMutex;
 

--- a/wpilibc/sim/src/Notifier.cpp
+++ b/wpilibc/sim/src/Notifier.cpp
@@ -11,6 +11,8 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 std::list<Notifier*> Notifier::timerQueue;
 priority_recursive_mutex Notifier::queueMutex;
 std::atomic<int> Notifier::refcount{0};

--- a/wpilibc/sim/src/PIDController.cpp
+++ b/wpilibc/sim/src/PIDController.cpp
@@ -13,6 +13,8 @@
 #include "PIDOutput.h"
 #include "PIDSource.h"
 
+using namespace frc;
+
 static const std::string kP = "p";
 static const std::string kI = "i";
 static const std::string kD = "d";

--- a/wpilibc/sim/src/PWM.cpp
+++ b/wpilibc/sim/src/PWM.cpp
@@ -12,6 +12,8 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 const float PWM::kDefaultPwmPeriod = 5.05;
 const float PWM::kDefaultPwmCenter = 1.5;
 const int PWM::kDefaultPwmStepsDown = 1000;

--- a/wpilibc/sim/src/Relay.cpp
+++ b/wpilibc/sim/src/Relay.cpp
@@ -13,6 +13,8 @@
 #include "MotorSafetyHelper.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 /**
  * Relay constructor given a channel.
  *

--- a/wpilibc/sim/src/RobotBase.cpp
+++ b/wpilibc/sim/src/RobotBase.cpp
@@ -10,6 +10,8 @@
 #include "RobotState.h"
 #include "Utility.h"
 
+using namespace frc;
+
 /**
  * Constructor for a generic robot program.
  *

--- a/wpilibc/sim/src/RobotDrive.cpp
+++ b/wpilibc/sim/src/RobotDrive.cpp
@@ -16,6 +16,8 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
+using namespace frc;
+
 const int RobotDrive::kMaxNumberOfMotors;
 
 static auto make_shared_nodelete(SpeedController* ptr) {

--- a/wpilibc/sim/src/SafePWM.cpp
+++ b/wpilibc/sim/src/SafePWM.cpp
@@ -10,6 +10,8 @@
 #include <memory>
 #include <sstream>
 
+using namespace frc;
+
 /**
  * Constructor for a SafePWM object taking a channel number.
  *

--- a/wpilibc/sim/src/SampleRobot.cpp
+++ b/wpilibc/sim/src/SampleRobot.cpp
@@ -21,6 +21,8 @@
 void sleep(unsigned int milliseconds) { Sleep(milliseconds); }
 #endif
 
+using namespace frc;
+
 SampleRobot::SampleRobot() : m_robotMainOverridden(true) {}
 
 /**

--- a/wpilibc/sim/src/SensorBase.cpp
+++ b/wpilibc/sim/src/SensorBase.cpp
@@ -9,6 +9,8 @@
 
 #include "WPIErrors.h"
 
+using namespace frc;
+
 const int SensorBase::kDigitalChannels;
 const int SensorBase::kAnalogInputs;
 const int SensorBase::kSolenoidChannels;

--- a/wpilibc/sim/src/Solenoid.cpp
+++ b/wpilibc/sim/src/Solenoid.cpp
@@ -13,6 +13,8 @@
 #include "WPIErrors.h"
 #include "simulation/simTime.h"
 
+using namespace frc;
+
 /**
  * Constructor.
  *

--- a/wpilibc/sim/src/Talon.cpp
+++ b/wpilibc/sim/src/Talon.cpp
@@ -9,6 +9,8 @@
 
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 /**
  * @param channel The PWM channel that the Talon is attached to.
  */

--- a/wpilibc/sim/src/Timer.cpp
+++ b/wpilibc/sim/src/Timer.cpp
@@ -26,6 +26,8 @@ void time_callback(const msgs::ConstFloat64Ptr& msg) {
 }
 }  // namespace wpilib
 
+namespace frc {
+
 /**
  * Pause the task for a specified time.
  *
@@ -64,6 +66,10 @@ double GetClock() { return Timer::GetFPGATimestamp(); }
 double GetTime() {
   return Timer::GetFPGATimestamp();  // The epoch starts when Gazebo starts
 }
+
+}  // namespace frc
+
+using namespace frc;
 
 // for compatibility with msvc12--see C2864
 const double Timer::kRolloverTime = (1ll << 32) / 1e6;

--- a/wpilibc/sim/src/Utility.cpp
+++ b/wpilibc/sim/src/Utility.cpp
@@ -20,6 +20,8 @@
 #include "Timer.h"
 #include "simulation/simTime.h"
 
+using namespace frc;
+
 static bool stackTraceEnabled = false;
 static bool suspendOnAssertEnabled = false;
 
@@ -143,6 +145,8 @@ bool wpi_assertNotEqual_impl(int valueA, int valueB, const std::string& message,
   return valueA != valueB;
 }
 
+namespace frc {
+
 /**
  * Read the microsecond-resolution timer on the FPGA.
  *
@@ -205,3 +209,5 @@ static std::string demangle(char const* mangledSymbol) {
 }
 std::string GetStackTrace(int offset) { return "no stack trace on windows"; }
 #endif
+
+}  // namespace frc

--- a/wpilibc/sim/src/Victor.cpp
+++ b/wpilibc/sim/src/Victor.cpp
@@ -9,6 +9,8 @@
 
 #include "LiveWindow/LiveWindow.h"
 
+using namespace frc;
+
 /**
  * @param channel The PWM channel that the Victor is attached to.
  */

--- a/wpilibc/sim/src/simulation/SimContinuousOutput.cpp
+++ b/wpilibc/sim/src/simulation/SimContinuousOutput.cpp
@@ -9,6 +9,8 @@
 
 #include "simulation/MainNode.h"
 
+using namespace frc;
+
 SimContinuousOutput::SimContinuousOutput(std::string topic) {
   pub = MainNode::Advertise<msgs::Float64>("~/simulator/" + topic);
   std::cout << "Initialized ~/simulator/" + topic << std::endl;

--- a/wpilibc/sim/src/simulation/SimDigitalInput.cpp
+++ b/wpilibc/sim/src/simulation/SimDigitalInput.cpp
@@ -9,6 +9,8 @@
 
 #include "simulation/MainNode.h"
 
+using namespace frc;
+
 SimDigitalInput::SimDigitalInput(std::string topic) {
   sub = MainNode::Subscribe("~/simulator/" + topic, &SimDigitalInput::callback,
                             this);

--- a/wpilibc/sim/src/simulation/SimEncoder.cpp
+++ b/wpilibc/sim/src/simulation/SimEncoder.cpp
@@ -9,6 +9,8 @@
 
 #include "simulation/MainNode.h"
 
+using namespace frc;
+
 SimEncoder::SimEncoder(std::string topic) {
   commandPub =
       MainNode::Advertise<msgs::GzString>("~/simulator/" + topic + "/control");

--- a/wpilibc/sim/src/simulation/SimFloatInput.cpp
+++ b/wpilibc/sim/src/simulation/SimFloatInput.cpp
@@ -9,6 +9,8 @@
 
 #include "simulation/MainNode.h"
 
+using namespace frc;
+
 SimFloatInput::SimFloatInput(std::string topic) {
   sub = MainNode::Subscribe("~/simulator/" + topic, &SimFloatInput::callback,
                             this);

--- a/wpilibc/sim/src/simulation/SimGyro.cpp
+++ b/wpilibc/sim/src/simulation/SimGyro.cpp
@@ -9,6 +9,8 @@
 
 #include "simulation/MainNode.h"
 
+using namespace frc;
+
 SimGyro::SimGyro(std::string topic) {
   commandPub =
       MainNode::Advertise<msgs::GzString>("~/simulator/" + topic + "/control");

--- a/wpilibcIntegrationTests/build.gradle
+++ b/wpilibcIntegrationTests/build.gradle
@@ -13,6 +13,7 @@ model {
             targetPlatform 'arm'
             binaries.all {
                 tasks.withType(CppCompile) {
+                    cppCompiler.args "-DNAMESPACED_WPILIB"
                     addNiLibraryLinks(linker, targetPlatform)
                     addStaticNetworkTablesLibraryLinks(it, linker, targetPlatform)
                 }

--- a/wpilibcIntegrationTests/include/command/MockCommand.h
+++ b/wpilibcIntegrationTests/include/command/MockCommand.h
@@ -9,6 +9,8 @@
 
 #include <Commands/Command.h>
 
+namespace frc {
+
 class MockCommand : public Command {
  private:
   int32_t m_initializeCount;
@@ -40,3 +42,5 @@ class MockCommand : public Command {
   int32_t GetInterruptedCount() { return m_interruptedCount; }
   bool HasInterrupted();
 };
+
+}  // namespace frc

--- a/wpilibcIntegrationTests/src/AnalogLoopTest.cpp
+++ b/wpilibcIntegrationTests/src/AnalogLoopTest.cpp
@@ -13,6 +13,8 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 static const double kDelayTime = 0.01;
 
 /**

--- a/wpilibcIntegrationTests/src/AnalogPotentiometerTest.cpp
+++ b/wpilibcIntegrationTests/src/AnalogPotentiometerTest.cpp
@@ -13,6 +13,8 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 static const double kScale = 270.0;
 static const double kAngle = 180.0;
 

--- a/wpilibcIntegrationTests/src/BuiltInAccelerometerTest.cpp
+++ b/wpilibcIntegrationTests/src/BuiltInAccelerometerTest.cpp
@@ -10,6 +10,8 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 static constexpr double kAccelerationTolerance = 0.1;
 /**
  * There's not much we can automatically test with the on-board accelerometer,

--- a/wpilibcIntegrationTests/src/CircularBufferTest.cpp
+++ b/wpilibcIntegrationTests/src/CircularBufferTest.cpp
@@ -11,6 +11,8 @@
 
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 static const std::array<double, 10> values = {
     751.848, 766.366, 342.657, 234.252, 716.126,
     132.344, 445.697, 22.727,  421.125, 799.913};

--- a/wpilibcIntegrationTests/src/CounterTest.cpp
+++ b/wpilibcIntegrationTests/src/CounterTest.cpp
@@ -14,6 +14,8 @@
 #include "Victor.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 static const double kMotorDelay = 2.5;
 
 static const double kMaxPeriod = 2.0;

--- a/wpilibcIntegrationTests/src/DIOLoopTest.cpp
+++ b/wpilibcIntegrationTests/src/DIOLoopTest.cpp
@@ -14,6 +14,8 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 static const double kCounterTime = 0.001;
 
 static const double kDelayTime = 0.1;

--- a/wpilibcIntegrationTests/src/DigitalGlitchFilterTest.cpp
+++ b/wpilibcIntegrationTests/src/DigitalGlitchFilterTest.cpp
@@ -12,6 +12,8 @@
 #include "Encoder.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 /**
  * Tests that configuring inputs to be filtered succeeds.
  *

--- a/wpilibcIntegrationTests/src/DriverStationTest.cpp
+++ b/wpilibcIntegrationTests/src/DriverStationTest.cpp
@@ -11,6 +11,8 @@
 #include "Utility.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 constexpr double TIMER_TOLERANCE = 0.2;
 constexpr int64_t TIMER_RUNTIME = 1000000;  // 1 second
 

--- a/wpilibcIntegrationTests/src/FakeEncoderTest.cpp
+++ b/wpilibcIntegrationTests/src/FakeEncoderTest.cpp
@@ -14,6 +14,8 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 static const double kDelayTime = 0.001;
 
 class FakeEncoderTest : public testing::Test {

--- a/wpilibcIntegrationTests/src/FilterNoiseTest.cpp
+++ b/wpilibcIntegrationTests/src/FilterNoiseTest.cpp
@@ -17,6 +17,8 @@
 #include "TestBench.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 enum FilterNoiseTestType { TEST_SINGLE_POLE_IIR, TEST_MOVAVG };
 
 std::ostream& operator<<(std::ostream& os, const FilterNoiseTestType& type) {

--- a/wpilibcIntegrationTests/src/FilterOutputTest.cpp
+++ b/wpilibcIntegrationTests/src/FilterOutputTest.cpp
@@ -17,6 +17,8 @@
 #include "TestBench.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 enum FilterOutputTestType { TEST_SINGLE_POLE_IIR, TEST_HIGH_PASS, TEST_MOVAVG };
 
 std::ostream& operator<<(std::ostream& os, const FilterOutputTestType& type) {

--- a/wpilibcIntegrationTests/src/MotorEncoderTest.cpp
+++ b/wpilibcIntegrationTests/src/MotorEncoderTest.cpp
@@ -14,6 +14,8 @@
 #include "Victor.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 enum MotorEncoderTestType { TEST_VICTOR, TEST_JAGUAR, TEST_TALON };
 
 std::ostream& operator<<(std::ostream& os, MotorEncoderTestType const& type) {

--- a/wpilibcIntegrationTests/src/MotorInvertingTest.cpp
+++ b/wpilibcIntegrationTests/src/MotorInvertingTest.cpp
@@ -13,6 +13,8 @@
 #include "Victor.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 enum MotorInvertingTestType { TEST_VICTOR, TEST_JAGUAR, TEST_TALON };
 static const double motorSpeed = 0.15;
 static const double delayTime = 0.5;

--- a/wpilibcIntegrationTests/src/NotifierTest.cpp
+++ b/wpilibcIntegrationTests/src/NotifierTest.cpp
@@ -11,6 +11,8 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 unsigned notifierCounter;
 
 void notifierHandler(void*) { notifierCounter++; }

--- a/wpilibcIntegrationTests/src/PCMTest.cpp
+++ b/wpilibcIntegrationTests/src/PCMTest.cpp
@@ -15,6 +15,8 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 /* The PCM switches the compressor up to a couple seconds after the pressure
         switch changes. */
 static const double kCompressorDelayTime = 3.0;

--- a/wpilibcIntegrationTests/src/PIDToleranceTest.cpp
+++ b/wpilibcIntegrationTests/src/PIDToleranceTest.cpp
@@ -12,6 +12,8 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 class PIDToleranceTest : public testing::Test {
  protected:
   const double setpoint = 50.0;

--- a/wpilibcIntegrationTests/src/PowerDistributionPanelTest.cpp
+++ b/wpilibcIntegrationTests/src/PowerDistributionPanelTest.cpp
@@ -14,6 +14,8 @@
 #include "Victor.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 static const double kMotorTime = 0.25;
 
 class PowerDistributionPanelTest : public testing::Test {

--- a/wpilibcIntegrationTests/src/PreferencesTest.cpp
+++ b/wpilibcIntegrationTests/src/PreferencesTest.cpp
@@ -14,6 +14,8 @@
 #include "gtest/gtest.h"
 #include "ntcore.h"
 
+using namespace frc;
+
 static const char* kFileName = "networktables.ini";
 static const double kSaveTime = 1.2;
 

--- a/wpilibcIntegrationTests/src/RelayTest.cpp
+++ b/wpilibcIntegrationTests/src/RelayTest.cpp
@@ -12,6 +12,8 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 static const double kDelayTime = 0.01;
 
 class RelayTest : public testing::Test {

--- a/wpilibcIntegrationTests/src/TestEnvironment.cpp
+++ b/wpilibcIntegrationTests/src/TestEnvironment.cpp
@@ -13,6 +13,8 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 class TestEnvironment : public testing::Environment {
   bool m_alreadySetUp = false;
 

--- a/wpilibcIntegrationTests/src/TiltPanCameraTest.cpp
+++ b/wpilibcIntegrationTests/src/TiltPanCameraTest.cpp
@@ -14,6 +14,8 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 static constexpr double kServoResetTime = 2.0;
 
 static constexpr double kTestAngle = 90.0;

--- a/wpilibcIntegrationTests/src/TimerTest.cpp
+++ b/wpilibcIntegrationTests/src/TimerTest.cpp
@@ -10,6 +10,8 @@
 #include "TestBench.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 static const double kWaitTime = 0.5;
 
 class TimerTest : public testing::Test {

--- a/wpilibcIntegrationTests/src/command/CommandTest.cpp
+++ b/wpilibcIntegrationTests/src/command/CommandTest.cpp
@@ -14,6 +14,8 @@
 #include "command/MockCommand.h"
 #include "gtest/gtest.h"
 
+using namespace frc;
+
 class CommandTest : public testing::Test {
  protected:
   void SetUp() override {

--- a/wpilibcIntegrationTests/src/command/MockCommand.cpp
+++ b/wpilibcIntegrationTests/src/command/MockCommand.cpp
@@ -7,6 +7,8 @@
 
 #include "command/MockCommand.h"
 
+using namespace frc;
+
 MockCommand::MockCommand() {
   m_initializeCount = 0;
   m_executeCount = 0;


### PR DESCRIPTION
Base.h provides a backwards compatibility shim (enabled unless
NAMESPACED_WPILIB is defined) that does a "using namespace frc".
However, as some header files do not include Base.h, this may
be a breaking change in some corner cases (with an easy fix).

Fixes #218.