### PR TITLE
Adds a gradle task to call the formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The gradlew wrapper only exists in the root of the main project, so be sure to r
 
 There are a few tasks other than `build` available. To see them, run the meta-task `tasks`. This will print a list of all available tasks, with a description of each task.
 
-format.py can be executed in either the styleguide or root directories of the repository via `python3 format.py` or `./format.py`.
+Formatting can be executed either via the `format` gradle task, or by executing format.py from either the styleguide or root directories of the repository via `python3 format.py` or `./format.py`. If using the gradle format command, arguments can be specified with `-PformatArgs="arg"`.
 
 ## Publishing
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,26 @@ subprojects {
 
 apply from: 'cppSettings.gradle'
 
+def formatArgs
+if (project.hasProperty('formatArgs')) {
+    if (project.formatArgs.allWhitespace) {
+        formatArgs = null
+    } else {
+        formatArgs = project.formatArgs
+    }
+} else {
+    formatArgs = null
+}
+
+task format(type: Exec) {
+    workingDir "${rootDir}"
+    if (formatArgs != null) {
+        commandLine 'python', './styleguide/format.py', formatArgs
+    } else {
+        commandLine 'python', './styleguide/format.py'
+    }
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '3.0'
 }


### PR DESCRIPTION
Not required by the build task, but there in case we want to have an
easier time to call format from a script.