### PR TITLE
Removes the REAL definition from wpilib.h

### DIFF
--- a/wpilibc/athena/include/WPILib.h
+++ b/wpilibc/athena/include/WPILib.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#define REAL
-
 #include "ADXL345_I2C.h"
 #include "ADXL345_SPI.h"
 #include "ADXL362.h"


### PR DESCRIPTION
Interferes with OpenCV, and is heavy namespace polution anyway.