### PR TITLE
Adds deprecation for Task API and Semaphore class

### DIFF
--- a/hal/include/HAL/cpp/Deprecate.h
+++ b/hal/include/HAL/cpp/Deprecate.h
@@ -1,0 +1,30 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) FIRST 2016. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+// [[deprecated(msg)]] is a C++14 feature not supported by MSVC or GCC < 4.9.
+// We provide an equivalent warning implementation for those compilers here.
+#ifndef WPI_DEPRECATED
+#if defined(_MSC_VER)
+#define WPI_DEPRECATED(msg) __declspec(deprecated(msg))
+#elif defined(__GNUC__)
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 8)
+#if __cplusplus > 201103L
+#define WPI_DEPRECATED(msg) [[deprecated(msg)]]
+#else
+#define WPI_DEPRECATED(msg) [[gnu::deprecated(msg)]]
+#endif
+#else
+#define WPI_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#endif
+#elif __cplusplus > 201103L
+#define WPI_DEPRECATED(msg) [[deprecated(msg)]]
+#else
+#define WPI_DEPRECATED(msg) /*nothing*/
+#endif
+#endif

--- a/hal/include/HAL/cpp/Semaphore.h
+++ b/hal/include/HAL/cpp/Semaphore.h
@@ -11,9 +11,12 @@
 
 #include <condition_variable>
 
+#include "HAL/cpp/Deprecate.h"
 #include "HAL/cpp/priority_mutex.h"
 
-class Semaphore {
+class WPI_DEPRECATED(
+    "Semaphore scheduled for removal in 2018. Recommended to replace with a "
+    "std::mutex and std::condition_variable") Semaphore {
  public:
   explicit Semaphore(int32_t count = 0);
   Semaphore(Semaphore&&);

--- a/wpilibc/athena/include/Task.h
+++ b/wpilibc/athena/include/Task.h
@@ -12,13 +12,16 @@
 
 #include "ErrorBase.h"
 #include "HAL/HAL.h"
+#include "HAL/cpp/Deprecate.h"
 
 namespace frc {
 
 /**
  * Wrapper class around std::thread that allows changing thread priority
  */
-class Task : public ErrorBase {
+class WPI_DEPRECATED(
+    "Task API scheduled for removal in 2018. Replace with std::thread") Task
+    : public ErrorBase {
  public:
   static const int kDefaultPriority = 60;
 


### PR DESCRIPTION
We still need to discuss what we want to do about priority_mutex and priority_condition_variable