### PR TITLE
Removed entries from .styleguide that are include in .gitignore

### DIFF
--- a/.styleguide
+++ b/.styleguide
@@ -15,7 +15,6 @@ otherExtensions {
 }
 
 genFolderExclude {
-  \.vscode
   FRC_FPGA_ChipObject
   NetworkCommunication
   ctre
@@ -38,15 +37,11 @@ genFileExclude {
 
 modifiableFolderExclude {
   \.git
-  \.gradle
-  __pycache__
-  build
   wpilibj/src/athena/cpp/include
   wpilibj/src/athena/cpp/lib
 }
 
 modifiableFileExclude {
-  \.jar$
   \.patch$
   \.png$
   \.py$


### PR DESCRIPTION
format.py now considers files that match patterns in .gitignore to be modifiable files. Therefore, listing them in .styleguide is redundant.