### PR TITLE
Formatter is now run after build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ cache:
     - $HOME/.gradle/wrapper/
 
 script:
+  - ./gradlew build -PmakeSim
+
+  # Run formatter after build to check how it handles generated files
   - wpiformat
   - git --no-pager diff --exit-code HEAD  # Ensure formatter made no changes
-  - ./gradlew build -PmakeSim


### PR DESCRIPTION
There have been reports of bugs in format.py after a build is run. This change will test that scenario.