### PR TITLE
Fixes joystick button handling HAL JNI layer

### DIFF
--- a/wpilibj/src/athena/cpp/lib/HAL.cpp
+++ b/wpilibj/src/athena/cpp/lib/HAL.cpp
@@ -188,9 +188,9 @@ Java_edu_wpi_first_wpilibj_hal_HAL_getJoystickPOVs(JNIEnv* env, jclass,
 /*
  * Class: edu_wpi_first_wpilibj_hal_HAL
  * Method:    HAL_GetJoystickButtons
- * Signature: (BL)B
+ * Signature: (BL)I
  */
-JNIEXPORT jbyte JNICALL
+JNIEXPORT jint JNICALL
 Java_edu_wpi_first_wpilibj_hal_HAL_getJoystickButtons(JNIEnv* env, jclass,
                                                       jbyte joystickNum,
                                                       jobject count) {

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/HAL.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/HAL.java
@@ -92,7 +92,7 @@ public class HAL extends JNIWrapper {
 
   public static native short getJoystickPOVs(byte joystickNum, short[] povsArray);
 
-  public static native byte getJoystickButtons(byte joystickNum, ByteBuffer count);
+  public static native int getJoystickButtons(byte joystickNum, ByteBuffer count);
 
   public static native int setJoystickOutputs(byte joystickNum, int outputs, short leftRumble,
                                               short rightRumble);


### PR DESCRIPTION
This should fix issue #340 where joystick buttons >=8 do not work correctly in wpilibj.

Needed to update the HAL JNI layer to treat the button field as an int rather than a byte