### PR TITLE
Replaced ternary operators with if statements

### DIFF
--- a/hal/src/main/native/athena/PWM.cpp
+++ b/hal/src/main/native/athena/PWM.cpp
@@ -19,24 +19,39 @@ using namespace hal;
 static inline int32_t GetMaxPositivePwm(DigitalPort* port) {
   return port->maxPwm;
 }
+
 static inline int32_t GetMinPositivePwm(DigitalPort* port) {
-  return port->eliminateDeadband ? port->deadbandMaxPwm : port->centerPwm + 1;
+  if (port->eliminateDeadband) {
+    return port->deadbandMaxPwm;
+  } else {
+    return port->centerPwm + 1;
+  }
 }
+
 static inline int32_t GetCenterPwm(DigitalPort* port) {
   return port->centerPwm;
 }
+
 static inline int32_t GetMaxNegativePwm(DigitalPort* port) {
-  return port->eliminateDeadband ? port->deadbandMinPwm : port->centerPwm - 1;
+  if (port->eliminateDeadband) {
+    return port->deadbandMinPwm;
+  } else {
+    return port->centerPwm - 1;
+  }
 }
+
 static inline int32_t GetMinNegativePwm(DigitalPort* port) {
   return port->minPwm;
 }
+
 static inline int32_t GetPositiveScaleFactor(DigitalPort* port) {
   return GetMaxPositivePwm(port) - GetMinPositivePwm(port);
 }  ///< The scale for positive speeds.
+
 static inline int32_t GetNegativeScaleFactor(DigitalPort* port) {
   return GetMaxNegativePwm(port) - GetMinNegativePwm(port);
 }  ///< The scale for negative speeds.
+
 static inline int32_t GetFullRangeScaleFactor(DigitalPort* port) {
   return GetMaxPositivePwm(port) - GetMinNegativePwm(port);
 }  ///< The scale for positions.

--- a/hal/src/main/native/include/HAL/cpp/Log.h
+++ b/hal/src/main/native/include/HAL/cpp/Log.h
@@ -52,7 +52,9 @@ inline Log::Log() {}
 inline llvm::raw_ostream& Log::Get(TLogLevel level) {
   oss << "- " << NowTime();
   oss << " " << ToString(level) << ": ";
-  oss << std::string(level > logDEBUG ? level - logDEBUG : 0, '\t');
+  if (level > logDEBUG) {
+    oss << std::string(level - logDEBUG, '\t');
+  }
   return oss;
 }
 

--- a/wpilibc/src/main/native/cpp/DoubleSolenoid.cpp
+++ b/wpilibc/src/main/native/cpp/DoubleSolenoid.cpp
@@ -154,6 +154,7 @@ DoubleSolenoid::Value DoubleSolenoid::Get() const {
   if (valueReverse) return kReverse;
   return kOff;
 }
+
 /**
  * Check if the forward solenoid is blacklisted.
  *
@@ -165,8 +166,9 @@ DoubleSolenoid::Value DoubleSolenoid::Get() const {
  */
 bool DoubleSolenoid::IsFwdSolenoidBlackListed() const {
   int blackList = GetPCMSolenoidBlackList(m_moduleNumber);
-  return (blackList & m_forwardMask) ? 1 : 0;
+  return (blackList & m_forwardMask) != 0;
 }
+
 /**
  * Check if the reverse solenoid is blacklisted.
  *
@@ -178,7 +180,7 @@ bool DoubleSolenoid::IsFwdSolenoidBlackListed() const {
  */
 bool DoubleSolenoid::IsRevSolenoidBlackListed() const {
   int blackList = GetPCMSolenoidBlackList(m_moduleNumber);
-  return (blackList & m_reverseMask) ? 1 : 0;
+  return (blackList & m_reverseMask) != 0;
 }
 
 void DoubleSolenoid::UpdateTable() {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -211,18 +211,20 @@ public class DriverStation implements RobotState.Interface {
     } else {
       locString = "";
     }
-    boolean haveLoc = false;
     String traceString = "";
-    for (int i = stackTraceFirst; i < stackTrace.length; i++) {
-      String loc = stackTrace[i].toString();
-      traceString += "\tat " + loc + "\n";
-      // get first user function
-      if (!haveLoc && !loc.startsWith("edu.wpi.first")) {
-        locString = loc;
-        haveLoc = true;
+    if (printTrace) {
+      boolean haveLoc = false;
+      for (int i = stackTraceFirst; i < stackTrace.length; i++) {
+        String loc = stackTrace[i].toString();
+        traceString += "\tat " + loc + "\n";
+        // get first user function
+        if (!haveLoc && !loc.startsWith("edu.wpi.first")) {
+          locString = loc;
+          haveLoc = true;
+        }
       }
     }
-    HAL.sendError(isError, code, false, error, locString, printTrace ? traceString : "", false);
+    HAL.sendError(isError, code, false, error, locString, traceString, true);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
@@ -8,7 +8,6 @@
 package edu.wpi.first.wpilibj.command;
 
 import java.util.Enumeration;
-import java.util.NoSuchElementException;
 
 import edu.wpi.first.networktables.EntryListenerFlags;
 import edu.wpi.first.networktables.NetworkTable;
@@ -43,47 +42,56 @@ import edu.wpi.first.wpilibj.Timer;
  * @see IllegalUseOfCommandException
  */
 public abstract class Command implements NamedSendable {
-
   /**
    * The name of this command.
    */
   private String m_name;
+
   /**
    * The time since this command was initialized.
    */
   private double m_startTime = -1;
+
   /**
    * The time (in seconds) before this command "times out" (or -1 if no timeout).
    */
   private double m_timeout = -1;
+
   /**
    * Whether or not this command has been initialized.
    */
   private boolean m_initialized = false;
+
   /**
-   * The requirements (or null if no requirements).
+   * The required subsystems.
    */
-  private Set m_requirements;
+  private final Set m_requirements = new Set();
+
   /**
    * Whether or not it is running.
    */
   private boolean m_running = false;
+
   /**
    * Whether or not it is interruptible.
    */
   private boolean m_interruptible = true;
+
   /**
    * Whether or not it has been canceled.
    */
   private boolean m_canceled = false;
+
   /**
    * Whether or not it has been locked.
    */
   private boolean m_locked = false;
+
   /**
    * Whether this command should run when the robot is disabled.
    */
   private boolean m_runWhenDisabled = false;
+
   /**
    * The {@link CommandGroup} this is in.
    */
@@ -191,9 +199,6 @@ public abstract class Command implements NamedSendable {
   protected synchronized void requires(Subsystem subsystem) {
     validate("Can not add new requirement to command");
     if (subsystem != null) {
-      if (m_requirements == null) {
-        m_requirements = new Set();
-      }
       m_requirements.add(subsystem);
     } else {
       throw new IllegalArgumentException("Subsystem must not be null.");
@@ -347,7 +352,7 @@ public abstract class Command implements NamedSendable {
    * Subsystems}) of this command
    */
   synchronized Enumeration getRequirements() {
-    return m_requirements == null ? emptyEnumeration : m_requirements.getElements();
+    return m_requirements.getElements();
   }
 
   /**
@@ -393,7 +398,7 @@ public abstract class Command implements NamedSendable {
    * in {@link CommandGroup}.
    */
   protected void clearRequirements() {
-    m_requirements = new Set();
+    m_requirements.clear();
   }
 
   /**
@@ -501,7 +506,7 @@ public abstract class Command implements NamedSendable {
    * @return whether or not the subsystem is required, or false if given null
    */
   public synchronized boolean doesRequire(Subsystem system) {
-    return m_requirements != null && m_requirements.contains(system);
+    return m_requirements.contains(system);
   }
 
   /**
@@ -534,20 +539,6 @@ public abstract class Command implements NamedSendable {
   public boolean willRunWhenDisabled() {
     return m_runWhenDisabled;
   }
-
-  /**
-   * An empty enumeration given whenever there are no requirements.
-   */
-  private static Enumeration emptyEnumeration = new Enumeration() {
-
-    public boolean hasMoreElements() {
-      return false;
-    }
-
-    public Object nextElement() {
-      throw new NoSuchElementException();
-    }
-  };
 
   /**
    * The string representation for a {@link Command} is by default its name.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Scheduler.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Scheduler.java
@@ -42,7 +42,10 @@ public class Scheduler implements NamedSendable {
    * @return the {@link Scheduler}
    */
   public static synchronized Scheduler getInstance() {
-    return instance == null ? instance = new Scheduler() : instance;
+    if (instance == null) {
+      instance = new Scheduler();
+    }
+    return instance;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Set.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Set.java
@@ -34,6 +34,10 @@ class Set {
     }
   }
 
+  public void clear() {
+      m_set.clear();
+  }
+
   public boolean contains(Object o) {
     return m_set.contains(o);
   }


### PR DESCRIPTION
Instances of the ternary operator were replaced with if statements if the result was either easier to understand or had no effect.