### PR TITLE
Switches handles back to std::array

### DIFF
--- a/hal/include/HAL/handles/DigitalHandleResource.h
+++ b/hal/include/HAL/handles/DigitalHandleResource.h
@@ -9,8 +9,8 @@
 
 #include <stdint.h>
 
+#include <array>
 #include <memory>
-#include <vector>
 
 #include "HAL/Errors.h"
 #include "HAL/Types.h"
@@ -39,22 +39,15 @@ class DigitalHandleResource {
  public:
   DigitalHandleResource(const DigitalHandleResource&) = delete;
   DigitalHandleResource operator=(const DigitalHandleResource&) = delete;
-  DigitalHandleResource();
+  DigitalHandleResource() = default;
   THandle Allocate(int16_t index, HAL_HandleEnum enumValue, int32_t* status);
   std::shared_ptr<TStruct> Get(THandle handle, HAL_HandleEnum enumValue);
   void Free(THandle handle, HAL_HandleEnum enumValue);
 
  private:
-  // Dynamic array to shrink HAL file size.
-  std::unique_ptr<std::shared_ptr<TStruct>[]> m_structures;
-  std::unique_ptr<priority_mutex[]> m_handleMutexes;
+  std::array<std::shared_ptr<TStruct>, size> m_structures;
+  std::array<priority_mutex, size> m_handleMutexes;
 };
-
-template <typename THandle, typename TStruct, int16_t size>
-DigitalHandleResource<THandle, TStruct, size>::DigitalHandleResource() {
-  m_structures = std::make_unique<std::shared_ptr<TStruct>[]>(size);
-  m_handleMutexes = std::make_unique<priority_mutex[]>(size);
-}
 
 template <typename THandle, typename TStruct, int16_t size>
 THandle DigitalHandleResource<THandle, TStruct, size>::Allocate(

--- a/hal/include/HAL/handles/IndexedHandleResource.h
+++ b/hal/include/HAL/handles/IndexedHandleResource.h
@@ -9,8 +9,8 @@
 
 #include <stdint.h>
 
+#include <array>
 #include <memory>
-#include <vector>
 
 #include "HAL/Errors.h"
 #include "HAL/Types.h"
@@ -40,24 +40,15 @@ class IndexedHandleResource {
  public:
   IndexedHandleResource(const IndexedHandleResource&) = delete;
   IndexedHandleResource operator=(const IndexedHandleResource&) = delete;
-  IndexedHandleResource();
+  IndexedHandleResource() = default;
   THandle Allocate(int16_t index, int32_t* status);
   std::shared_ptr<TStruct> Get(THandle handle);
   void Free(THandle handle);
 
  private:
-  // Dynamic array to shrink HAL file size.
-  std::unique_ptr<std::shared_ptr<TStruct>[]> m_structures;
-  std::unique_ptr<priority_mutex[]> m_handleMutexes;
+  std::array<std::shared_ptr<TStruct>, size> m_structures;
+  std::array<priority_mutex, size> m_handleMutexes;
 };
-
-template <typename THandle, typename TStruct, int16_t size,
-          HAL_HandleEnum enumValue>
-IndexedHandleResource<THandle, TStruct, size,
-                      enumValue>::IndexedHandleResource() {
-  m_structures = std::make_unique<std::shared_ptr<TStruct>[]>(size);
-  m_handleMutexes = std::make_unique<priority_mutex[]>(size);
-}
 
 template <typename THandle, typename TStruct, int16_t size,
           HAL_HandleEnum enumValue>

--- a/hal/include/HAL/handles/LimitedClassedHandleResource.h
+++ b/hal/include/HAL/handles/LimitedClassedHandleResource.h
@@ -9,8 +9,8 @@
 
 #include <stdint.h>
 
+#include <array>
 #include <memory>
-#include <vector>
 
 #include "HAL/Types.h"
 #include "HAL/cpp/make_unique.h"
@@ -39,25 +39,16 @@ class LimitedClassedHandleResource {
   LimitedClassedHandleResource(const LimitedClassedHandleResource&) = delete;
   LimitedClassedHandleResource operator=(const LimitedClassedHandleResource&) =
       delete;
-  LimitedClassedHandleResource();
+  LimitedClassedHandleResource() = default;
   THandle Allocate(std::shared_ptr<TStruct> toSet);
   std::shared_ptr<TStruct> Get(THandle handle);
   void Free(THandle handle);
 
  private:
-  // Dynamic array to shrink HAL file size.
-  std::unique_ptr<std::shared_ptr<TStruct>[]> m_structures;
-  std::unique_ptr<priority_mutex[]> m_handleMutexes;
+  std::array<std::shared_ptr<TStruct>, size> m_structures;
+  std::array<priority_mutex, size> m_handleMutexes;
   priority_mutex m_allocateMutex;
 };
-
-template <typename THandle, typename TStruct, int16_t size,
-          HAL_HandleEnum enumValue>
-LimitedClassedHandleResource<THandle, TStruct, size,
-                             enumValue>::LimitedClassedHandleResource() {
-  m_structures = std::make_unique<std::shared_ptr<TStruct>[]>(size);
-  m_handleMutexes = std::make_unique<priority_mutex[]>(size);
-}
 
 template <typename THandle, typename TStruct, int16_t size,
           HAL_HandleEnum enumValue>

--- a/hal/include/HAL/handles/LimitedHandleResource.h
+++ b/hal/include/HAL/handles/LimitedHandleResource.h
@@ -9,8 +9,8 @@
 
 #include <stdint.h>
 
+#include <array>
 #include <memory>
-#include <vector>
 
 #include "HAL/Types.h"
 #include "HAL/cpp/make_unique.h"
@@ -37,25 +37,16 @@ class LimitedHandleResource {
  public:
   LimitedHandleResource(const LimitedHandleResource&) = delete;
   LimitedHandleResource operator=(const LimitedHandleResource&) = delete;
-  LimitedHandleResource();
+  LimitedHandleResource() = default;
   THandle Allocate();
   std::shared_ptr<TStruct> Get(THandle handle);
   void Free(THandle handle);
 
  private:
-  // Dynamic array to shrink HAL file size.
-  std::unique_ptr<std::shared_ptr<TStruct>[]> m_structures;
-  std::unique_ptr<priority_mutex[]> m_handleMutexes;
+  std::array<std::shared_ptr<TStruct>, size> m_structures;
+  std::array<priority_mutex, size> m_handleMutexes;
   priority_mutex m_allocateMutex;
 };
-
-template <typename THandle, typename TStruct, int16_t size,
-          HAL_HandleEnum enumValue>
-LimitedHandleResource<THandle, TStruct, size,
-                      enumValue>::LimitedHandleResource() {
-  m_structures = std::make_unique<std::shared_ptr<TStruct>[]>(size);
-  m_handleMutexes = std::make_unique<priority_mutex[]>(size);
-}
 
 template <typename THandle, typename TStruct, int16_t size,
           HAL_HandleEnum enumValue>


### PR DESCRIPTION
The binary size is being increased much less then when we originally
tried this. Using static arrays save a pointer indirection and will help
with cache in real time cases.