### PR TITLE
Put language in version string

### DIFF
--- a/wpilibc/athena/src/RobotBase.cpp
+++ b/wpilibc/athena/src/RobotBase.cpp
@@ -42,6 +42,7 @@ RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
   file = std::fopen("/tmp/frc_versions/FRC_Lib_Version.ini", "w");
 
   if (file != nullptr) {
+    std::fputs("CPP: ", file);
     std::fputs(WPILibVersion, file);
     std::fclose(file);
   }

--- a/wpilibc/athena/src/RobotBase.cpp
+++ b/wpilibc/athena/src/RobotBase.cpp
@@ -42,7 +42,7 @@ RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
   file = std::fopen("/tmp/frc_versions/FRC_Lib_Version.ini", "w");
 
   if (file != nullptr) {
-    std::fputs("CPP: ", file);
+    std::fputs("C++ ", file);
     std::fputs(WPILibVersion, file);
     std::fclose(file);
   }

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -226,6 +226,7 @@ public abstract class RobotBase {
       file.createNewFile();
 
       try (FileOutputStream output = new FileOutputStream(file)) {
+        output.write("Java: ".getBytes());
         output.write(WPILibVersion.Version.getBytes());
       }
 

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -226,7 +226,7 @@ public abstract class RobotBase {
       file.createNewFile();
 
       try (FileOutputStream output = new FileOutputStream(file)) {
-        output.write("Java: ".getBytes());
+        output.write("Java ".getBytes());
         output.write(WPILibVersion.Version.getBytes());
       }
 


### PR DESCRIPTION
As a CSA, I found it very handy to look at what language
a team was using while checking SW versions on the DS.
That was removed when updating to 2017 versioning.