### PR TITLE
Switches internal joystick errors to take StringRef

### DIFF
--- a/wpilibc/athena/include/DriverStation.h
+++ b/wpilibc/athena/include/DriverStation.h
@@ -18,6 +18,7 @@
 #include "HAL/cpp/priority_mutex.h"
 #include "RobotState.h"
 #include "SensorBase.h"
+#include "llvm/StringRef.h"
 
 namespace frc {
 
@@ -96,8 +97,8 @@ class DriverStation : public SensorBase, public RobotStateInterface {
 
  private:
   DriverStation();
-  void ReportJoystickUnpluggedError(std::string message);
-  void ReportJoystickUnpluggedWarning(std::string message);
+  void ReportJoystickUnpluggedError(llvm::StringRef message);
+  void ReportJoystickUnpluggedWarning(llvm::StringRef message);
   void Run();
   void UpdateControlWord(bool force, HAL_ControlWord& controlWord) const;
 

--- a/wpilibc/athena/src/DriverStation.cpp
+++ b/wpilibc/athena/src/DriverStation.cpp
@@ -595,7 +595,7 @@ DriverStation::DriverStation() {
  * Reports errors related to unplugged joysticks
  * Throttles the errors so that they don't overwhelm the DS
  */
-void DriverStation::ReportJoystickUnpluggedError(std::string message) {
+void DriverStation::ReportJoystickUnpluggedError(llvm::StringRef message) {
   double currentTime = Timer::GetFPGATimestamp();
   if (currentTime > m_nextMessageTime) {
     ReportError(message);
@@ -608,7 +608,7 @@ void DriverStation::ReportJoystickUnpluggedError(std::string message) {
  *
  * Throttles the errors so that they don't overwhelm the DS.
  */
-void DriverStation::ReportJoystickUnpluggedWarning(std::string message) {
+void DriverStation::ReportJoystickUnpluggedWarning(llvm::StringRef message) {
   double currentTime = Timer::GetFPGATimestamp();
   if (currentTime > m_nextMessageTime) {
     ReportWarning(message);


### PR DESCRIPTION
Previously this would have allocated the std::string every time, even if
the message wasn't printed. Now takes a StringRef, and only converts to
std::string when the message actually gets printed.