### PR TITLE
Adds safe serial port write methods

### DIFF
--- a/wpilibc/athena/include/SerialPort.h
+++ b/wpilibc/athena/include/SerialPort.h
@@ -10,6 +10,8 @@
 #include <string>
 
 #include "ErrorBase.h"
+#include "llvm/StringRef.h"
+#include "support/deprecated.h"
 
 namespace frc {
 
@@ -60,7 +62,12 @@ class SerialPort : public ErrorBase {
   void DisableTermination();
   int GetBytesReceived();
   int Read(char* buffer, int count);
+  WPI_DEPRECATED(
+      "Potential for unexpected behavior. Please use StringRef overload for "
+      "custom length buffers using std::string")
   int Write(const std::string& buffer, int count);
+  int Write(const char* buffer, int count);
+  int Write(llvm::StringRef buffer);
   void SetTimeout(double timeout);
   void SetReadBufferSize(int size);
   void SetWriteBufferSize(int size);

--- a/wpilibc/athena/src/SerialPort.cpp
+++ b/wpilibc/athena/src/SerialPort.cpp
@@ -135,16 +135,41 @@ int SerialPort::Read(char* buffer, int count) {
 }
 
 /**
+ * Write raw bytes to the buffer. Deprecated, please use StringRef overload. Use
+ * Write({data, len}) to get a buffer that is shorter then the length of the
+ * std::string.
+ *
+ * @param buffer Pointer to the buffer to read the bytes from. If string.size()
+ * is less then count, only the length of string.size() will be sent.
+ * @param count  The maximum number of bytes to write.
+ * @return The number of bytes actually written into the port.
+ */
+int SerialPort::Write(const std::string& buffer, int count) {
+  return Write(llvm::StringRef(
+      buffer.data(), std::min(static_cast<int>(buffer.size()), count)));
+}
+
+/**
  * Write raw bytes to the buffer.
  *
  * @param buffer Pointer to the buffer to read the bytes from.
  * @param count  The maximum number of bytes to write.
  * @return The number of bytes actually written into the port.
  */
-int SerialPort::Write(const std::string& buffer, int count) {
+int SerialPort::Write(const char* buffer, int count) {
+  return Write(llvm::StringRef(buffer, static_cast<size_t>(count)));
+}
+
+/**
+ * Write raw bytes to the buffer.
+ *
+ * @param buffer StringRef to the buffer to read the bytes from.
+ * @return The number of bytes actually written into the port.
+ */
+int SerialPort::Write(llvm::StringRef buffer) {
   int32_t status = 0;
   int retVal = HAL_WriteSerial(static_cast<HAL_SerialPort>(m_port),
-                               buffer.c_str(), count, &status);
+                               buffer.data(), buffer.size(), &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
   return retVal;
 }


### PR DESCRIPTION
The old method had a fairly large race condition, and the way the docs
were written could cause users to get confused. Up for discussion on
adding the old API back and deprecating it, however I think this is
probably a change were we want a full break. The break will also affect
only teams sending a std::string directly to the API, and will most
likely fix teams trying to send a char* to the API.