### PR TITLE
Fix RoboRIO Cross-Toolchain GCC Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ To build a specific subproject, such as WPILibC, you must access the subproject 
 ./gradlew :wpilibc:build
 ```
 
+If you have installed the FRC Toolchain to a directory other than the default, or if the Toolchain location is not on your System PATH, you can pass the `toolChainPath` property to specify where it is located. Example:
+
+```bash
+./gradlew build -PtoolChainPath=some/path/to/frc/toolchain/bin
+```
+
 If you also want simulation to be built, add -PmakeSim. This requires gazebo_transport. We have tested on 14.04 and 15.05, but any correct install of Gazebo should work, even on Windows if you build Gazebo from source. Correct means CMake needs to be able to find gazebo-config.cmake. See [The Gazebo website](https://gazebosim.org/) for installation instructions.
 
 ```bash

--- a/cppSettings.gradle
+++ b/cppSettings.gradle
@@ -171,6 +171,7 @@ subprojects {
                     if (toolChainPath != null)
                         path toolChainPath
                     target('roborio-arm') {
+                        cCompiler.executable = compilerPrefix + cCompiler.executable
                         cppCompiler.executable = compilerPrefix + cppCompiler.executable
                         linker.executable = compilerPrefix + linker.executable
                         assembler.executable = compilerPrefix + assembler.executable
@@ -207,6 +208,7 @@ subprojects {
 
         ext.binTool = { tool ->
             if (toolChainPath != null) return "${toolChainPath}/${compilerPrefix}${tool}"
+            return "${compilerPrefix}${tool}"
         }
 
         // This task adds the appropriate linker flags for the NI libraries

--- a/cppSettings.gradle
+++ b/cppSettings.gradle
@@ -72,7 +72,9 @@ task clean(type: Delete) {
     delete buildDir
 }
 
-ext.toolChainPath = null
+if (!hasProperty("toolChainPath")) {
+    ext.toolChainPath = null
+}
 
 subprojects {
     ext.defineWpiUtilProperties = {
@@ -196,7 +198,7 @@ subprojects {
             }
 
             platforms {
-                "roborio-arm" {
+                'roborio-arm' {
                     architecture 'arm'
                     operatingSystem 'linux'
                 }
@@ -229,9 +231,9 @@ subprojects {
                         def library = task.outputFile.absolutePath
                         def debugLibrary = task.outputFile.absolutePath + ".debug"
                         task.doLast {
-                            exec { commandLine binTool("objcopy"), '--only-keep-debug', library, debugLibrary }
-                            exec { commandLine binTool("strip"), '-g', library }
-                            exec { commandLine binTool("objcopy"), "--add-gnu-debuglink=$debugLibrary", library }
+                            exec { commandLine binTool('objcopy'), '--only-keep-debug', library, debugLibrary }
+                            exec { commandLine binTool('strip'), '-g', library }
+                            exec { commandLine binTool('objcopy'), "--add-gnu-debuglink=$debugLibrary", library }
                         }
                     }
                 }

--- a/cppSettings.gradle
+++ b/cppSettings.gradle
@@ -72,6 +72,8 @@ task clean(type: Delete) {
     delete buildDir
 }
 
+ext.toolChainPath = null
+
 subprojects {
     ext.defineWpiUtilProperties = {
         ext.wpiUtil = wpiUtilUnzipLocation
@@ -165,8 +167,10 @@ subprojects {
             }
             // Adds a custom toolchain for our compiler prefix and options
             toolChains {
-                gcc(Gcc) {
-                    target('arm') {
+                roborioGcc(Gcc) {
+                    if (toolChainPath != null)
+                        path toolChainPath
+                    target('roborio-arm') {
                         cppCompiler.executable = compilerPrefix + cppCompiler.executable
                         linker.executable = compilerPrefix + linker.executable
                         assembler.executable = compilerPrefix + assembler.executable
@@ -188,37 +192,10 @@ subprojects {
                         staticLibArchiver.executable = compilerPrefix + staticLibArchiver.executable
                     }
                 }
-                // Workaround for OS X. Macs for some reason want to use Xcode's gcc
-                // (which just wraps Clang), so we have to explicitly make it so
-                // that trying to compile with Clang will call gcc instead
-                macGcc(Clang) {
-                    target('arm') {
-                        cppCompiler.executable = compilerPrefix + 'g++'
-                        linker.executable = compilerPrefix + 'g++'
-                        assembler.executable = compilerPrefix + 'gcc'
-                        // Gradle auto-adds the -m32 argument to the linker and compiler. Our compiler only supports
-                        // arm, and doesn't understand this flag, so it is removed from both
-                        cppCompiler.withArguments { args ->
-                            args << '-std=c++1y' << '-Wformat=2' << '-Wall' << '-Wextra' << '-Werror' << '-pedantic'
-                            args << '-Wno-psabi' << '-Wno-unused-parameter' << '-fPIC' << '-Og' << '-g3' << '-rdynamic'
-                            //TODO: When the compiler allows us to actually call deprecated functions from within
-                            // deprecated function, remove this line (this will cause calling deprecated functions
-                            // to be treated as a warning rather than an error).
-                            args << '-Wno-error=deprecated-declarations'
-                            args.remove('-m32')
-                        }
-                        linker.withArguments { args ->
-                            args << '-rdynamic'
-                            args.remove('-m32')
-                        }
-                        staticLibArchiver.executable = compilerPrefix + 'ar'
-                    }
-                }
             }
 
-            // The only platform is arm linux
             platforms {
-                arm {
+                "roborio-arm" {
                     architecture 'arm'
                     operatingSystem 'linux'
                 }
@@ -227,6 +204,10 @@ subprojects {
 
         ext.niLibraryHeadersRoot = "${rootDir}/ni-libraries/include"
         ext.niLibraryHeadersChipObject = "${rootDir}/ni-libraries/include/FRC_FPGA_ChipObject"
+
+        ext.binTool = { tool ->
+            if (toolChainPath != null) return "${toolChainPath}/${compilerPrefix}${tool}"
+        }
 
         // This task adds the appropriate linker flags for the NI libraries
         ext.addNiLibraryLinks = { linker, targetPlatform ->
@@ -246,9 +227,9 @@ subprojects {
                         def library = task.outputFile.absolutePath
                         def debugLibrary = task.outputFile.absolutePath + ".debug"
                         task.doLast {
-                            exec { commandLine "${compilerPrefix}objcopy", '--only-keep-debug', library, debugLibrary }
-                            exec { commandLine "${compilerPrefix}strip", '-g', library }
-                            exec { commandLine "${compilerPrefix}objcopy", "--add-gnu-debuglink=$debugLibrary", library }
+                            exec { commandLine binTool("objcopy"), '--only-keep-debug', library, debugLibrary }
+                            exec { commandLine binTool("strip"), '-g', library }
+                            exec { commandLine binTool("objcopy"), "--add-gnu-debuglink=$debugLibrary", library }
                         }
                     }
                 }

--- a/hal/build.gradle
+++ b/hal/build.gradle
@@ -14,7 +14,7 @@ debugStripSetup(project)
 model {
     components {
         HALAthena(NativeLibrarySpec) {
-            targetPlatform 'arm'
+            targetPlatform 'roborio-arm'
             binaries.all {
                 tasks.withType(CppCompile) {
                     addNiLibraryLinks(linker, targetPlatform)

--- a/myRobotCpp/build.gradle
+++ b/myRobotCpp/build.gradle
@@ -10,7 +10,7 @@ ext.hal = project(':hal').projectDir.getAbsolutePath()
 model {
     components {
         myRobotcpp(NativeExecutableSpec) {
-            targetPlatform 'arm'
+            targetPlatform 'roborio-arm'
             binaries.all {
                 tasks.withType(CppCompile) {
                     addNiLibraryLinks(linker, targetPlatform)

--- a/wpilibc/athena.gradle
+++ b/wpilibc/athena.gradle
@@ -9,7 +9,7 @@ def ntSourceDir = "$buildDir/ntSources"
 model {
     components {
         wpilibc(NativeLibrarySpec) {
-            targetPlatform 'arm'
+            targetPlatform 'roborio-arm'
             binaries.all {
                 tasks.withType(CppCompile) {
                     dependsOn generateCppVersion

--- a/wpilibcIntegrationTests/build.gradle
+++ b/wpilibcIntegrationTests/build.gradle
@@ -11,7 +11,7 @@ ext.hal = project(':hal').projectDir.getAbsolutePath()
 model {
     components {
         FRCUserProgram(NativeExecutableSpec) {
-            targetPlatform 'arm'
+            targetPlatform 'roborio-arm'
             binaries.all {
                 tasks.withType(CppCompile) {
                     cppCompiler.args "-DNAMESPACED_WPILIB"

--- a/wpilibj/athena.gradle
+++ b/wpilibj/athena.gradle
@@ -30,7 +30,7 @@ defineWpiUtilProperties()
 model {
     components {
         wpilibJavaJNI(NativeLibrarySpec) {
-            targetPlatform 'arm'
+            targetPlatform 'roborio-arm'
             binaries.all {
                 tasks.withType(CppCompile) {
                     dependsOn jniHeaders
@@ -197,7 +197,7 @@ task checkJNISymbols() {
     doLast {
         defineCrossCompilerProperties()
         exec {
-            commandLine "${compilerPrefix}nm", lib
+            commandLine binTool("nm"), lib
             standardOutput = nmOutput
         }
         // Remove '\r' so we can check for full string contents

--- a/wpilibj/athena.gradle
+++ b/wpilibj/athena.gradle
@@ -197,7 +197,7 @@ task checkJNISymbols() {
     doLast {
         defineCrossCompilerProperties()
         exec {
-            commandLine binTool("nm"), lib
+            commandLine binTool('nm'), lib
             standardOutput = nmOutput
         }
         // Remove '\r' so we can check for full string contents


### PR DESCRIPTION
Currently, a hack exists in WPILib's build system regarding the RoboRIO Cross-Toolchain, in that an ARM target must be added to both the GCC and Clang toolchain to maintain build capabilities on Macintosh Systems. This is not necessary and causes the RoboRIO GCC Toolchain to be incorrectly identified as Clang on Mac systems. This PR fixes this hack.

The toolchains `visualCpp`, `gcc`, and `clang` are created by the Gradle Native Platform, and exist as 'default' toolchains should other toolchains not be declared by the buildscript. In the current version of the buildscript, both `gcc(Gcc)` and `macGcc(Clang)` are created (see [here](https://github.com/wpilibsuite/allwpilib/blob/master/cppSettings.gradle#L167-L216)). As described in the comment above `macGcc`, the hack is needed because Gradle thinks we are using XCode GCC, which is in fact Clang. However, this is not required. Gradle's Native Platform detects this XCode GCC using the output of the C Compiler Tool (gcc). Since `cCompiler.executable` is not declared in WPILib's buildscript, it defaults to system GCC. By declaring our own gcc (`arm-frc-linux-gnueabi-gcc`), it will check this tool instead and will correctly identify it as a buildable target.

I've also taken the liberty of renaming this toolchain from `gcc` to `roborioGcc` to make it more clear. The Native Platform has been renamed from `arm` to `roborio-arm` to be more clear and allow for possible future cross compiling on other ARM platforms, as well as to fit with `roborioGcc`. 

A project property, `toolChainPath`, has also been added. This allows the user to define where the toolchain is installed to if it is not present in the User's PATH (e.g. `gradlew build -PtoolChainPath=some/path/to/toolchain/bin`). This also fixes references to `objcopy`, `strip` and `nm`.

This pull request has been tested on Windows 10 Insider Build 14986 and OS X El Capitan Version 10.11.5