### PR TITLE
CameraServer: Fix LabVIEW dashboard OpenCV compatibility.

### DIFF
--- a/wpilibc/athena/src/CameraServer.cpp
+++ b/wpilibc/athena/src/CameraServer.cpp
@@ -38,7 +38,9 @@ static llvm::StringRef MakeSourceValue(CS_Source source,
       break;
     }
     case cs::VideoSource::kCv:
-      return "cv:";
+      // FIXME: Should be "cv:", but LabVIEW dashboard requires "usb:".
+      // https://github.com/wpilibsuite/allwpilib/issues/407
+      return "usb:";
     default:
       return "unknown:";
   }

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/CameraServer.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/CameraServer.java
@@ -69,7 +69,9 @@ public class CameraServer {
         // TODO
         return "ip:";
       case kCv:
-        return "cv:";
+        // FIXME: Should be "cv:", but LabVIEW dashboard requires "usb:".
+        // https://github.com/wpilibsuite/allwpilib/issues/407
+        return "usb:";
       default:
         return "unknown:";
     }


### PR DESCRIPTION
The current LabVIEW dashboard (Beta 4) requires the source type to be either
"usb:" or "ip:" and does not support "cv:".  To work around this, use a source
type of "usb:" for OpenCV sources as well.