### PR TITLE
Fixed signatures of deleted assignment operators

### DIFF
--- a/hal/include/HAL/handles/DigitalHandleResource.h
+++ b/hal/include/HAL/handles/DigitalHandleResource.h
@@ -37,9 +37,10 @@ class DigitalHandleResource {
   friend class DigitalHandleResourceTest;
 
  public:
-  DigitalHandleResource(const DigitalHandleResource&) = delete;
-  DigitalHandleResource operator=(const DigitalHandleResource&) = delete;
   DigitalHandleResource() = default;
+  DigitalHandleResource(const DigitalHandleResource&) = delete;
+  DigitalHandleResource& operator=(const DigitalHandleResource&) = delete;
+
   THandle Allocate(int16_t index, HAL_HandleEnum enumValue, int32_t* status);
   std::shared_ptr<TStruct> Get(THandle handle, HAL_HandleEnum enumValue);
   void Free(THandle handle, HAL_HandleEnum enumValue);

--- a/hal/include/HAL/handles/IndexedClassedHandleResource.h
+++ b/hal/include/HAL/handles/IndexedClassedHandleResource.h
@@ -39,10 +39,11 @@ class IndexedClassedHandleResource {
   friend class IndexedClassedHandleResourceTest;
 
  public:
-  IndexedClassedHandleResource(const IndexedClassedHandleResource&) = delete;
-  IndexedClassedHandleResource operator=(const IndexedClassedHandleResource&) =
-      delete;
   IndexedClassedHandleResource();
+  IndexedClassedHandleResource(const IndexedClassedHandleResource&) = delete;
+  IndexedClassedHandleResource& operator=(const IndexedClassedHandleResource&) =
+      delete;
+
   THandle Allocate(int16_t index, std::shared_ptr<TStruct> toSet,
                    int32_t* status);
   std::shared_ptr<TStruct> Get(THandle handle);

--- a/hal/include/HAL/handles/IndexedHandleResource.h
+++ b/hal/include/HAL/handles/IndexedHandleResource.h
@@ -38,9 +38,10 @@ class IndexedHandleResource {
   friend class IndexedHandleResourceTest;
 
  public:
-  IndexedHandleResource(const IndexedHandleResource&) = delete;
-  IndexedHandleResource operator=(const IndexedHandleResource&) = delete;
   IndexedHandleResource() = default;
+  IndexedHandleResource(const IndexedHandleResource&) = delete;
+  IndexedHandleResource& operator=(const IndexedHandleResource&) = delete;
+
   THandle Allocate(int16_t index, int32_t* status);
   std::shared_ptr<TStruct> Get(THandle handle);
   void Free(THandle handle);

--- a/hal/include/HAL/handles/LimitedClassedHandleResource.h
+++ b/hal/include/HAL/handles/LimitedClassedHandleResource.h
@@ -36,10 +36,11 @@ class LimitedClassedHandleResource {
   friend class LimitedClassedHandleResourceTest;
 
  public:
-  LimitedClassedHandleResource(const LimitedClassedHandleResource&) = delete;
-  LimitedClassedHandleResource operator=(const LimitedClassedHandleResource&) =
-      delete;
   LimitedClassedHandleResource() = default;
+  LimitedClassedHandleResource(const LimitedClassedHandleResource&) = delete;
+  LimitedClassedHandleResource& operator=(const LimitedClassedHandleResource&) =
+      delete;
+
   THandle Allocate(std::shared_ptr<TStruct> toSet);
   std::shared_ptr<TStruct> Get(THandle handle);
   void Free(THandle handle);

--- a/hal/include/HAL/handles/LimitedHandleResource.h
+++ b/hal/include/HAL/handles/LimitedHandleResource.h
@@ -35,9 +35,10 @@ class LimitedHandleResource {
   friend class LimitedHandleResourceTest;
 
  public:
-  LimitedHandleResource(const LimitedHandleResource&) = delete;
-  LimitedHandleResource operator=(const LimitedHandleResource&) = delete;
   LimitedHandleResource() = default;
+  LimitedHandleResource(const LimitedHandleResource&) = delete;
+  LimitedHandleResource& operator=(const LimitedHandleResource&) = delete;
+
   THandle Allocate();
   std::shared_ptr<TStruct> Get(THandle handle);
   void Free(THandle handle);

--- a/hal/include/HAL/handles/UnlimitedHandleResource.h
+++ b/hal/include/HAL/handles/UnlimitedHandleResource.h
@@ -37,9 +37,10 @@ class UnlimitedHandleResource {
   friend class UnlimitedHandleResourceTest;
 
  public:
-  UnlimitedHandleResource(const UnlimitedHandleResource&) = delete;
-  UnlimitedHandleResource operator=(const UnlimitedHandleResource&) = delete;
   UnlimitedHandleResource() = default;
+  UnlimitedHandleResource(const UnlimitedHandleResource&) = delete;
+  UnlimitedHandleResource& operator=(const UnlimitedHandleResource&) = delete;
+
   THandle Allocate(std::shared_ptr<TStruct> structure);
   std::shared_ptr<TStruct> Get(THandle handle);
   void Free(THandle handle);


### PR DESCRIPTION
While it technically doesn't matter what the return type of the assignment operator is since it's deleted, assignment operators should return a reference instead of a value.