### PR TITLE
Adds project and classpath ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,7 @@ NO
 
 # VSCode
 .vscode/
+
+#classpaths and projects
+.project
+.classpath


### PR DESCRIPTION
VsCode now supports Java, but it creates these files, and there is no
way to turn it off. Will be adding this to a few other repos too.