### PR TITLE
Fixes solenoid allocation error message

### DIFF
--- a/hal/lib/athena/Solenoid.cpp
+++ b/hal/lib/athena/Solenoid.cpp
@@ -55,8 +55,7 @@ HAL_SolenoidHandle HAL_InitializeSolenoidPort(HAL_PortHandle portHandle,
 
   auto handle =
       solenoidHandles.Allocate(module * kNumSolenoidChannels + channel, status);
-  if (handle == HAL_kInvalidHandle) {  // out of resources
-    *status = NO_AVAILABLE_RESOURCES;
+  if (*status != 0) {
     return HAL_kInvalidHandle;
   }
   auto solenoidPort = solenoidHandles.Get(handle);


### PR DESCRIPTION
The error was NO_AVAILABLE_RESOURCES, which is not the proper error to
return. Instead,  just return the error directly from the allocation.