### PR TITLE
Fixes exception on camera creation without plugged in camera

### DIFF
--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/CameraServer.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/CameraServer.java
@@ -360,9 +360,13 @@ public class CameraServer {
               CameraServerJNI.getSourceDescription(event.sourceHandle));
           table.putBoolean("connected", CameraServerJNI.isSourceConnected(event.sourceHandle));
           table.putStringArray("streams", getSourceStreamValues(event.sourceHandle));
-          VideoMode mode = CameraServerJNI.getSourceVideoMode(event.sourceHandle);
-          table.setDefaultString("mode", videoModeToString(mode));
-          table.putStringArray("modes", getSourceModeValues(event.sourceHandle));
+          try {
+            VideoMode mode = CameraServerJNI.getSourceVideoMode(event.sourceHandle);
+            table.setDefaultString("mode", videoModeToString(mode));
+            table.putStringArray("modes", getSourceModeValues(event.sourceHandle));
+          } catch (VideoException ex) {
+            // Do nothing. Let the other event handlers update this if there is an error.
+          }
           break;
         }
         case kSourceDestroyed: {


### PR DESCRIPTION
Would throw if the camera was disconnected. We handle this properly at
the JNI level to not have this crash the entire program, but the error
is still kind of annoying, and not really an error.