### PR TITLE
Removes StatusIsFatal checks from PDP

### DIFF
--- a/wpilibc/athena/src/PowerDistributionPanel.cpp
+++ b/wpilibc/athena/src/PowerDistributionPanel.cpp
@@ -39,7 +39,6 @@ PowerDistributionPanel::PowerDistributionPanel(int module) : m_module(module) {
  * @return The voltage of the PDP in volts
  */
 double PowerDistributionPanel::GetVoltage() const {
-  if (StatusIsFatal()) return 0;
   int32_t status = 0;
 
   double voltage = HAL_GetPDPVoltage(m_module, &status);
@@ -57,7 +56,6 @@ double PowerDistributionPanel::GetVoltage() const {
  * @return The temperature of the PDP in degrees Celsius
  */
 double PowerDistributionPanel::GetTemperature() const {
-  if (StatusIsFatal()) return 0;
   int32_t status = 0;
 
   double temperature = HAL_GetPDPTemperature(m_module, &status);
@@ -75,7 +73,6 @@ double PowerDistributionPanel::GetTemperature() const {
  * @return The current of one of the PDP channels (channels 0-15) in Amperes
  */
 double PowerDistributionPanel::GetCurrent(int channel) const {
-  if (StatusIsFatal()) return 0;
   int32_t status = 0;
 
   if (!CheckPDPChannel(channel)) {
@@ -99,7 +96,6 @@ double PowerDistributionPanel::GetCurrent(int channel) const {
  * @return The the total current drawn from the PDP channels in Amperes
  */
 double PowerDistributionPanel::GetTotalCurrent() const {
-  if (StatusIsFatal()) return 0;
   int32_t status = 0;
 
   double current = HAL_GetPDPTotalCurrent(m_module, &status);
@@ -117,7 +113,6 @@ double PowerDistributionPanel::GetTotalCurrent() const {
  * @return The the total power drawn from the PDP channels in Watts
  */
 double PowerDistributionPanel::GetTotalPower() const {
-  if (StatusIsFatal()) return 0;
   int32_t status = 0;
 
   double power = HAL_GetPDPTotalPower(m_module, &status);
@@ -135,7 +130,6 @@ double PowerDistributionPanel::GetTotalPower() const {
  * @return The the total energy drawn from the PDP channels in Joules
  */
 double PowerDistributionPanel::GetTotalEnergy() const {
-  if (StatusIsFatal()) return 0;
   int32_t status = 0;
 
   double energy = HAL_GetPDPTotalEnergy(m_module, &status);
@@ -153,7 +147,6 @@ double PowerDistributionPanel::GetTotalEnergy() const {
  * @see PowerDistributionPanel#GetTotalEnergy
  */
 void PowerDistributionPanel::ResetTotalEnergy() {
-  if (StatusIsFatal()) return;
   int32_t status = 0;
 
   HAL_ResetPDPTotalEnergy(m_module, &status);
@@ -167,7 +160,6 @@ void PowerDistributionPanel::ResetTotalEnergy() {
  * Remove all of the fault flags on the PDP.
  */
 void PowerDistributionPanel::ClearStickyFaults() {
-  if (StatusIsFatal()) return;
   int32_t status = 0;
 
   HAL_ClearPDPStickyFaults(m_module, &status);


### PR DESCRIPTION
The exceptions were removed from Java because these fail more often then
not. Teams are noticing this in C++ as well. In addition for some reason
ClearErrors() is causing about 0.5 seconds of lag. That's another issue,
but this will match Java and solve that issue for users.