### PR TITLE
CameraServer: Always update addresses when updating stream values.

### DIFF
--- a/wpilibc/athena/src/CameraServer.cpp
+++ b/wpilibc/athena/src/CameraServer.cpp
@@ -412,12 +412,10 @@ CameraServer::CameraServer()
           }
           case cs::VideoEvent::kSinkSourceChanged:
           case cs::VideoEvent::kSinkCreated:
-          case cs::VideoEvent::kSinkDestroyed: {
-            UpdateStreamValues();
-            break;
-          }
+          case cs::VideoEvent::kSinkDestroyed:
           case cs::VideoEvent::kNetworkInterfacesChanged: {
             m_addresses = cs::GetNetworkInterfaces();
+            UpdateStreamValues();
             break;
           }
           default:

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/CameraServer.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/CameraServer.java
@@ -436,12 +436,10 @@ public class CameraServer {
         }
         case kSinkSourceChanged:
         case kSinkCreated:
-        case kSinkDestroyed: {
-          updateStreamValues();
-          break;
-        }
+        case kSinkDestroyed:
         case kNetworkInterfacesChanged: {
           m_addresses = CameraServerJNI.getNetworkInterfaces();
+          updateStreamValues();
           break;
         }
         default:


### PR DESCRIPTION
This should prevent (as currently happens) occassionally getting just the
mDNS address in the stream value.