### PR TITLE
Do not immediately run the next command when one command completes.

### DIFF
--- a/wpilibj/src/shared/java/edu/wpi/first/wpilibj/command/CommandGroup.java
+++ b/wpilibj/src/shared/java/edu/wpi/first/wpilibj/command/CommandGroup.java
@@ -230,15 +230,11 @@ public class CommandGroup extends Command {
         if (entry.isTimedOut()) {
           cmd._cancel();
         }
-        if (cmd.run()) {
-          break;
-        } else {
+        if (!cmd.run()) {
           cmd.removed();
           m_currentCommandIndex++;
-          firstRun = true;
-          cmd = null;
-          continue;
         }
+        break;
       }
 
       entry = (Entry) m_commands.elementAt(m_currentCommandIndex);


### PR DESCRIPTION
We discovered an issue where commands later in a CommandGroup sequence were still being initiated and executed even after the CommandGroup had been canceled. This is occurring because within the _execute code for CommandGroup, the next command is set up and its run() method called immediately after the previous command completes. Should that next command complete immediately (if it is an InstantCommand, for example), the following command would also immediately execute and so on. All of this occurs even though code within the first Command canceled the CommandGroup.

The suggested change causes the _execute method to always break out of its inner while loop when it starts with a running Command, regardless of whether that Command completed or not. This lets the Command.run method do its job of checking to see if the CommandGroup was canceled or not and end the group before any other Commands are initiated.

Note that any Commands running in parallel will still receive another iteration cycle, but will be canceled after that. That is, the inner for loop of CommandGroup's _execute method will still run.

Thanks!