### PR TITLE
Remove _initialize, _interrupted, _execute, _end.

### DIFF
--- a/wpilibc/shared/include/Commands/Command.h
+++ b/wpilibc/shared/include/Commands/Command.h
@@ -107,10 +107,6 @@ class Command : public ErrorBase, public NamedSendable, public ITableListener {
   virtual void End();
   virtual void Interrupted();
 
-  virtual void _Initialize();
-  virtual void _Interrupted();
-  virtual void _Execute();
-  virtual void _End();
   virtual void _Cancel();
 
   friend class ConditionalCommand;

--- a/wpilibc/shared/include/Commands/CommandGroup.h
+++ b/wpilibc/shared/include/Commands/CommandGroup.h
@@ -55,10 +55,6 @@ class CommandGroup : public Command {
   virtual bool IsFinished();
   virtual void End();
   virtual void Interrupted();
-  virtual void _Initialize();
-  virtual void _Interrupted();
-  virtual void _Execute();
-  virtual void _End();
 
  private:
   void CancelConflicts(Command* command);

--- a/wpilibc/shared/include/Commands/ConditionalCommand.h
+++ b/wpilibc/shared/include/Commands/ConditionalCommand.h
@@ -54,7 +54,6 @@ class ConditionalCommand : public Command {
    */
   virtual bool Condition() = 0;
 
-  void _Initialize() override;
   void _Cancel() override;
   bool IsFinished() override;
   void Interrupted() override;

--- a/wpilibc/shared/include/Commands/PIDCommand.h
+++ b/wpilibc/shared/include/Commands/PIDCommand.h
@@ -39,9 +39,8 @@ class PIDCommand : public Command, public PIDOutput, public PIDSource {
 
  protected:
   std::shared_ptr<PIDController> GetPIDController() const;
-  virtual void _Initialize();
-  virtual void _Interrupted();
-  virtual void _End();
+  virtual void Interrupted();
+  virtual void End();
   void SetSetpoint(double setpoint);
   double GetSetpoint() const;
   double GetPosition();

--- a/wpilibc/shared/src/Commands/Command.cpp
+++ b/wpilibc/shared/src/Commands/Command.cpp
@@ -137,10 +137,8 @@ void Command::Removed() {
   if (m_initialized) {
     if (IsCanceled()) {
       Interrupted();
-      _Interrupted();
     } else {
       End();
-      _End();
     }
   }
   m_initialized = false;
@@ -180,10 +178,8 @@ bool Command::Run() {
   if (!m_initialized) {
     m_initialized = true;
     StartTiming();
-    _Initialize();
     Initialize();
   }
-  _Execute();
   Execute();
   return !IsFinished();
 }
@@ -219,14 +215,6 @@ void Command::End() {}
  * method within this method, as done here.</p>
  */
 void Command::Interrupted() { End(); }
-
-void Command::_Initialize() {}
-
-void Command::_Interrupted() {}
-
-void Command::_Execute() {}
-
-void Command::_End() {}
 
 /**
  * Called to indicate that the timer should start.

--- a/wpilibc/shared/src/Commands/CommandGroup.cpp
+++ b/wpilibc/shared/src/Commands/CommandGroup.cpp
@@ -172,9 +172,9 @@ void CommandGroup::AddParallel(Command* command, double timeout) {
   for (; iter != requirements.end(); iter++) Requires(*iter);
 }
 
-void CommandGroup::_Initialize() { m_currentCommandIndex = -1; }
+void CommandGroup::Initialize() { m_currentCommandIndex = -1; }
 
-void CommandGroup::_Execute() {
+void CommandGroup::Execute() {
   CommandGroupEntry entry;
   Command* cmd = nullptr;
   bool firstRun = false;
@@ -242,7 +242,7 @@ void CommandGroup::_Execute() {
   }
 }
 
-void CommandGroup::_End() {
+void CommandGroup::End() {
   // Theoretically, we don't have to check this, but we do if teams override the
   // IsFinished method
   if (m_currentCommandIndex != -1 &&
@@ -260,20 +260,6 @@ void CommandGroup::_End() {
   }
   m_children.clear();
 }
-
-void CommandGroup::_Interrupted() { _End(); }
-
-// Can be overwritten by teams
-void CommandGroup::Initialize() {}
-
-// Can be overwritten by teams
-void CommandGroup::Execute() {}
-
-// Can be overwritten by teams
-void CommandGroup::End() {}
-
-// Can be overwritten by teams
-void CommandGroup::Interrupted() {}
 
 bool CommandGroup::IsFinished() {
   return static_cast<size_t>(m_currentCommandIndex) >= m_commands.size() &&

--- a/wpilibc/shared/src/Commands/ConditionalCommand.cpp
+++ b/wpilibc/shared/src/Commands/ConditionalCommand.cpp
@@ -46,7 +46,7 @@ ConditionalCommand::ConditionalCommand(const std::string& name, Command* onTrue,
   for (auto requirement : m_onFalse->GetRequirements()) Requires(requirement);
 }
 
-void ConditionalCommand::_Initialize() {
+void ConditionalCommand::Initialize() {
   if (Condition()) {
     m_chosenCommand = m_onTrue;
   } else {

--- a/wpilibc/shared/src/Commands/PIDCommand.cpp
+++ b/wpilibc/shared/src/Commands/PIDCommand.cpp
@@ -41,11 +41,9 @@ PIDCommand::PIDCommand(double p, double i, double d, double period) {
   m_controller = std::make_shared<PIDController>(p, i, d, this, this, period);
 }
 
-void PIDCommand::_Initialize() { m_controller->Enable(); }
+void PIDCommand::Initialize() { m_controller->Enable(); }
 
-void PIDCommand::_End() { m_controller->Disable(); }
-
-void PIDCommand::_Interrupted() { _End(); }
+void PIDCommand::End() { m_controller->Disable(); }
 
 void PIDCommand::SetSetpointRelative(double deltaSetpoint) {
   SetSetpoint(GetSetpoint() + deltaSetpoint);

--- a/wpilibj/src/shared/java/edu/wpi/first/wpilibj/command/Command.java
+++ b/wpilibj/src/shared/java/edu/wpi/first/wpilibj/command/Command.java
@@ -207,10 +207,8 @@ public abstract class Command implements NamedSendable {
     if (m_initialized) {
       if (isCanceled()) {
         interrupted();
-        _interrupted();
       } else {
         end();
-        _end();
       }
     }
     m_initialized = false;
@@ -236,10 +234,8 @@ public abstract class Command implements NamedSendable {
     if (!m_initialized) {
       m_initialized = true;
       startTiming();
-      _initialize();
       initialize();
     }
-    _execute();
     execute();
     return !isFinished();
   }
@@ -250,24 +246,10 @@ public abstract class Command implements NamedSendable {
   protected void initialize() {}
 
   /**
-   * A shadow method called before {@link Command#initialize() initialize()}.
-   */
-  @SuppressWarnings("MethodName")
-  void _initialize() {
-  }
-
-  /**
    * The execute method is called repeatedly until this Command either finishes or is canceled.
    */
   @SuppressWarnings("MethodName")
   protected void execute() {}
-
-  /**
-   * A shadow method called before {@link Command#execute() execute()}.
-   */
-  @SuppressWarnings("MethodName")
-  void _execute() {
-  }
 
   /**
    * Returns whether this command is finished. If it is, then the command will be removed and {@link
@@ -293,13 +275,6 @@ public abstract class Command implements NamedSendable {
   protected void end() {}
 
   /**
-   * A shadow method called after {@link Command#end() end()}.
-   */
-  @SuppressWarnings("MethodName")
-  void _end() {
-  }
-
-  /**
    * Called when the command ends because somebody called {@link Command#cancel() cancel()} or
    * another command shared the same requirements as this one, and booted it out.
    *
@@ -312,12 +287,6 @@ public abstract class Command implements NamedSendable {
   protected void interrupted() {
     end();
   }
-
-  /**
-   * A shadow method called after {@link Command#interrupted() interrupted()}.
-   */
-  @SuppressWarnings("MethodName")
-  void _interrupted() {}
 
   /**
    * Called to indicate that the timer should start. This is called right before {@link

--- a/wpilibj/src/shared/java/edu/wpi/first/wpilibj/command/CommandGroup.java
+++ b/wpilibj/src/shared/java/edu/wpi/first/wpilibj/command/CommandGroup.java
@@ -210,12 +210,12 @@ public class CommandGroup extends Command {
   }
 
   @SuppressWarnings("MethodName")
-  void _initialize() {
+  protected void initialize() {
     m_currentCommandIndex = -1;
   }
 
   @SuppressWarnings("MethodName")
-  void _execute() {
+  protected void execute() {
     Entry entry = null;
     Command cmd = null;
     boolean firstRun = false;
@@ -283,7 +283,7 @@ public class CommandGroup extends Command {
   }
 
   @SuppressWarnings("MethodName")
-  void _end() {
+  protected void end() {
     // Theoretically, we don't have to check this, but we do if teams override
     // the isFinished method
     if (m_currentCommandIndex != -1 && m_currentCommandIndex < m_commands.size()) {
@@ -301,11 +301,6 @@ public class CommandGroup extends Command {
     m_children.removeAllElements();
   }
 
-  @SuppressWarnings("MethodName")
-  void _interrupted() {
-    _end();
-  }
-
   /**
    * Returns true if all the {@link Command Commands} in this group have been started and have
    * finished.
@@ -317,22 +312,6 @@ public class CommandGroup extends Command {
    */
   protected boolean isFinished() {
     return m_currentCommandIndex >= m_commands.size() && m_children.isEmpty();
-  }
-
-  // Can be overwritten by teams
-  protected void initialize() {
-  }
-
-  // Can be overwritten by teams
-  protected void execute() {
-  }
-
-  // Can be overwritten by teams
-  protected void end() {
-  }
-
-  // Can be overwritten by teams
-  protected void interrupted() {
   }
 
   /**

--- a/wpilibj/src/shared/java/edu/wpi/first/wpilibj/command/ConditionalCommand.java
+++ b/wpilibj/src/shared/java/edu/wpi/first/wpilibj/command/ConditionalCommand.java
@@ -125,7 +125,7 @@ public abstract class ConditionalCommand extends Command {
    * Calls {@link ConditionalCommand#condition()} and runs the proper command.
    */
   @Override
-  protected void _initialize() {
+  protected void initialize() {
     if (condition()) {
       m_chosenCommand = m_onTrue;
     } else {

--- a/wpilibj/src/shared/java/edu/wpi/first/wpilibj/command/PIDCommand.java
+++ b/wpilibj/src/shared/java/edu/wpi/first/wpilibj/command/PIDCommand.java
@@ -117,20 +117,14 @@ public abstract class PIDCommand extends Command implements Sendable {
 
   @Override
   @SuppressWarnings("MethodName")
-  void _initialize() {
+  void initialize() {
     m_controller.enable();
   }
 
   @Override
   @SuppressWarnings("MethodName")
-  void _end() {
+  void end() {
     m_controller.disable();
-  }
-
-  @Override
-  @SuppressWarnings("MethodName")
-  void _interrupted() {
-    _end();
   }
 
   /**


### PR DESCRIPTION
The places that used them (CommandGroup, ConditionalCommand, PIDCommand, and the command runner in Command) all now use the non-underscored versions.

Filed in issue #514

Reasoning:

When my team was programming the robot this year, we came upon the situation where we needed to use the decorator pattern to allow for us to programmatically input the distance we needed to drive for autonomous (in our case this was by having drive team measure the distance to the airship each match.)

Normally we would have this as a constant and just enter it in the constructor of the DriveToDistance Command.  This however wouldn't allow us to have the runtime distance input.  We wanted to just have a custom `initialize()` before the `CommandGroup` was initialized that would add all the commands then, but we were worried that since we couldn't explicitly place the `CommandGroup.initialize()` call after our custom initialize, it might cause the command addition to do nothing.