### PR TITLE
Adds way to set the Notifier thread RT priority

### DIFF
--- a/hal/include/HAL/Notifier.h
+++ b/hal/include/HAL/Notifier.h
@@ -25,6 +25,11 @@ void* HAL_GetNotifierParam(HAL_NotifierHandle notifierHandle, int32_t* status);
 void HAL_UpdateNotifierAlarm(HAL_NotifierHandle notifierHandle,
                              uint64_t triggerTime, int32_t* status);
 void HAL_StopNotifierAlarm(HAL_NotifierHandle notifierHandle, int32_t* status);
+HAL_Bool HAL_SetNotifierThreadPriority(HAL_NotifierHandle notifierHandle,
+                                       HAL_Bool realTime, int32_t priority,
+                                       int32_t* status);
+int32_t HAL_GetNotifierThreadPriority(HAL_NotifierHandle notifierHandle,
+                                      HAL_Bool* isRealTime, int32_t* status);
 #ifdef __cplusplus
 }
 #endif

--- a/hal/include/HAL/Threads.h
+++ b/hal/include/HAL/Threads.h
@@ -11,10 +11,10 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#define NativeThreadHandle const HANDLE*
+#define NativeThreadHandle const HANDLE
 #else
 #include <pthread.h>
-#define NativeThreadHandle const pthread_t*
+#define NativeThreadHandle const pthread_t
 #endif
 
 extern "C" {

--- a/hal/lib/athena/Threads.cpp
+++ b/hal/lib/athena/Threads.cpp
@@ -25,7 +25,7 @@ int32_t HAL_GetThreadPriority(NativeThreadHandle handle, HAL_Bool* isRealTime,
                               int32_t* status) {
   sched_param sch;
   int policy;
-  int success = pthread_getschedparam(*handle, &policy, &sch);
+  int success = pthread_getschedparam(handle, &policy, &sch);
   if (success == 0) {
     *status = 0;
   } else {
@@ -52,7 +52,7 @@ int32_t HAL_GetThreadPriority(NativeThreadHandle handle, HAL_Bool* isRealTime,
  */
 int32_t HAL_GetCurrentThreadPriority(HAL_Bool* isRealTime, int32_t* status) {
   auto thread = pthread_self();
-  return HAL_GetThreadPriority(&thread, isRealTime, status);
+  return HAL_GetThreadPriority(thread, isRealTime, status);
 }
 
 /**
@@ -69,7 +69,7 @@ int32_t HAL_GetCurrentThreadPriority(HAL_Bool* isRealTime, int32_t* status) {
  */
 HAL_Bool HAL_SetThreadPriority(NativeThreadHandle handle, HAL_Bool realTime,
                                int32_t priority, int32_t* status) {
-  if (handle == nullptr) {
+  if (handle == 0) {
     *status = NULL_PARAMETER;
     return false;
   }
@@ -87,13 +87,13 @@ HAL_Bool HAL_SetThreadPriority(NativeThreadHandle handle, HAL_Bool realTime,
 
   sched_param sch;
   int policy;
-  pthread_getschedparam(*handle, &policy, &sch);
+  pthread_getschedparam(handle, &policy, &sch);
   if (scheduler == SCHED_FIFO || scheduler == SCHED_RR)
     sch.sched_priority = priority;
   else
     // Only need to set 0 priority for non RT thread
     sch.sched_priority = 0;
-  if (pthread_setschedparam(*handle, scheduler, &sch)) {
+  if (pthread_setschedparam(handle, scheduler, &sch)) {
     *status = HAL_THREAD_PRIORITY_ERROR;
     return false;
   } else {
@@ -117,6 +117,6 @@ HAL_Bool HAL_SetThreadPriority(NativeThreadHandle handle, HAL_Bool realTime,
 HAL_Bool HAL_SetCurrentThreadPriority(HAL_Bool realTime, int32_t priority,
                                       int32_t* status) {
   auto thread = pthread_self();
-  return HAL_SetThreadPriority(&thread, realTime, priority, status);
+  return HAL_SetThreadPriority(thread, realTime, priority, status);
 }
 }

--- a/wpilibc/athena/include/Notifier.h
+++ b/wpilibc/athena/include/Notifier.h
@@ -35,6 +35,8 @@ class Notifier : public ErrorBase {
   Notifier(const Notifier&) = delete;
   Notifier& operator=(const Notifier&) = delete;
 
+  bool SetPriority(bool realTime, int priority);
+  int GetPriority(bool* isRealTime);
   void StartSingle(double delay);
   void StartPeriodic(double period);
   void Stop();

--- a/wpilibc/athena/src/Notifier.cpp
+++ b/wpilibc/athena/src/Notifier.cpp
@@ -8,6 +8,7 @@
 #include "Notifier.h"
 
 #include "HAL/HAL.h"
+#include "HAL/Threads.h"
 #include "Timer.h"
 #include "Utility.h"
 #include "WPIErrors.h"
@@ -85,6 +86,23 @@ void Notifier::Notify(uint64_t currentTimeInt, HAL_NotifierHandle handle) {
 
   if (handler) handler();
   notifier->m_processMutex.unlock();
+}
+
+bool Notifier::SetPriority(bool realTime, int priority) {
+  int32_t status = 0;
+  auto retVal =
+      HAL_SetNotifierThreadPriority(m_notifier, realTime, priority, &status);
+  wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
+  return retVal;
+}
+
+int Notifier::GetPriority(bool* isRealTime) {
+  int32_t status = 0;
+  HAL_Bool isRt = false;
+  auto retVal = HAL_GetNotifierThreadPriority(m_notifier, &isRt, &status);
+  wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
+  *isRealTime = isRt;
+  return retVal;
 }
 
 /**

--- a/wpilibc/athena/src/Threads.cpp
+++ b/wpilibc/athena/src/Threads.cpp
@@ -23,7 +23,7 @@ int GetThreadPriority(std::thread& thread, bool* isRealTime) {
   int32_t status = 0;
   HAL_Bool rt = false;
   auto native = thread.native_handle();
-  auto ret = HAL_GetThreadPriority(&native, &rt, &status);
+  auto ret = HAL_GetThreadPriority(native, &rt, &status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
   *isRealTime = rt;
   return ret;
@@ -58,7 +58,7 @@ int GetCurrentThreadPriority(bool* isRealTime) {
 bool SetThreadPriority(std::thread& thread, bool realTime, int priority) {
   int32_t status = 0;
   auto native = thread.native_handle();
-  auto ret = HAL_SetThreadPriority(&native, realTime, priority, &status);
+  auto ret = HAL_SetThreadPriority(native, realTime, priority, &status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
   return ret;
 }


### PR DESCRIPTION
Note Java has not been done yet, since I want to make sure the API is correct before going through the extra Java work.

Currently, it only supports setting the RT priority, and doesn't allow unsetting or resetting the priority. This is because it could actually affect other threads, and we can't allow that.