### PR TITLE
SolenoidBase functions are now static

### DIFF
--- a/wpilibc/athena/include/SolenoidBase.h
+++ b/wpilibc/athena/include/SolenoidBase.h
@@ -20,20 +20,23 @@ namespace frc {
 class SolenoidBase : public SensorBase {
  public:
   virtual ~SolenoidBase() = default;
-  int GetAll(int module = 0) const;
+  static int GetAll(int module);
+  int GetAll() const;
 
-  int GetPCMSolenoidBlackList(int module) const;
-  bool GetPCMSolenoidVoltageStickyFault(int module) const;
-  bool GetPCMSolenoidVoltageFault(int module) const;
-  void ClearAllPCMStickyFaults(int module);
+  static int GetPCMSolenoidBlackList(int module);
+  int GetPCMSolenoidBlackList() const;
+  static bool GetPCMSolenoidVoltageStickyFault(int module);
+  bool GetPCMSolenoidVoltageStickyFault() const;
+  static bool GetPCMSolenoidVoltageFault(int module);
+  bool GetPCMSolenoidVoltageFault() const;
+  static void ClearAllPCMStickyFaults(int module);
+  void ClearAllPCMStickyFaults();
 
  protected:
   explicit SolenoidBase(int pcmID);
   static const int m_maxModules = 63;
   static const int m_maxPorts = 8;
-  // static void* m_ports[m_maxModules][m_maxPorts];
-  int m_moduleNumber;  ///< Slot number where the module is plugged into
-                       /// the chassis.
+  int m_moduleNumber;  // PCM module number
 };
 
 }  // namespace frc

--- a/wpilibc/athena/src/SolenoidBase.cpp
+++ b/wpilibc/athena/src/SolenoidBase.cpp
@@ -22,14 +22,39 @@ SolenoidBase::SolenoidBase(int moduleNumber) : m_moduleNumber(moduleNumber) {}
 /**
  * Read all 8 solenoids as a single byte
  *
+ * @param module the module to read from
  * @return The current value of all 8 solenoids on the module.
  */
-int SolenoidBase::GetAll(int module) const {
+int SolenoidBase::GetAll(int module) {
   int value = 0;
   int32_t status = 0;
-  value = HAL_GetAllSolenoids(static_cast<int>(module), &status);
-  wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
+  value = HAL_GetAllSolenoids(module, &status);
+  wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
   return value;
+}
+
+/**
+ * Read all 8 solenoids as a single byte
+ *
+ * @return The current value of all 8 solenoids on the module.
+ */
+int SolenoidBase::GetAll() const {
+  return SolenoidBase::GetAll(m_moduleNumber);
+}
+
+/**
+ * Reads complete solenoid blacklist for all 8 solenoids as a single byte.
+ *
+ * If a solenoid is shorted, it is added to the blacklist and
+ * disabled until power cycle, or until faults are cleared.
+ * @see ClearAllPCMStickyFaults()
+ *
+ * @param module the module to read from
+ * @return The solenoid blacklist of all 8 solenoids on the module.
+ */
+int SolenoidBase::GetPCMSolenoidBlackList(int module) {
+  int32_t status = 0;
+  return HAL_GetPCMSolenoidBlackList(module, &status);
 }
 
 /**
@@ -41,28 +66,61 @@ int SolenoidBase::GetAll(int module) const {
  *
  * @return The solenoid blacklist of all 8 solenoids on the module.
  */
-int SolenoidBase::GetPCMSolenoidBlackList(int module) const {
+int SolenoidBase::GetPCMSolenoidBlackList() const {
+  return SolenoidBase::GetPCMSolenoidBlackList(m_moduleNumber);
+}
+
+/**
+ * @param module the module to read from
+ * @return true if PCM sticky fault is set : The common highside solenoid
+ *         voltage rail is too low, most likely a solenoid channel is shorted.
+ */
+bool SolenoidBase::GetPCMSolenoidVoltageStickyFault(int module) {
   int32_t status = 0;
-  return HAL_GetPCMSolenoidBlackList(static_cast<int>(module), &status);
+  return HAL_GetPCMSolenoidVoltageStickyFault(module, &status);
 }
 
 /**
  * @return true if PCM sticky fault is set : The common highside solenoid
  *         voltage rail is too low, most likely a solenoid channel is shorted.
  */
-bool SolenoidBase::GetPCMSolenoidVoltageStickyFault(int module) const {
+bool SolenoidBase::GetPCMSolenoidVoltageStickyFault() const {
+  return SolenoidBase::GetPCMSolenoidVoltageStickyFault(m_moduleNumber);
+}
+
+/**
+ * @param module the module to read from
+ * @return true if PCM is in fault state : The common highside solenoid voltage
+ *         rail is too low, most likely a solenoid channel is shorted.
+ */
+bool SolenoidBase::GetPCMSolenoidVoltageFault(int module) {
   int32_t status = 0;
-  return HAL_GetPCMSolenoidVoltageStickyFault(static_cast<int>(module),
-                                              &status);
+  return HAL_GetPCMSolenoidVoltageFault(module, &status);
 }
 
 /**
  * @return true if PCM is in fault state : The common highside solenoid voltage
  *         rail is too low, most likely a solenoid channel is shorted.
  */
-bool SolenoidBase::GetPCMSolenoidVoltageFault(int module) const {
+bool SolenoidBase::GetPCMSolenoidVoltageFault() const {
+  return SolenoidBase::GetPCMSolenoidVoltageFault(m_moduleNumber);
+}
+
+/**
+ * Clear ALL sticky faults inside PCM that Compressor is wired to.
+ *
+ * If a sticky fault is set, then it will be persistently cleared.  Compressor
+ * drive maybe momentarily disable while flags are being cleared. Care should
+ * be taken to not call this too frequently, otherwise normal compressor
+ * functionality may be prevented.
+ *
+ * If no sticky faults are set then this call will have no effect.
+ *
+ * @param module the module to read from
+ */
+void SolenoidBase::ClearAllPCMStickyFaults(int module) {
   int32_t status = 0;
-  return HAL_GetPCMSolenoidVoltageFault(static_cast<int>(module), &status);
+  return HAL_ClearAllPCMStickyFaults(module, &status);
 }
 
 /**
@@ -75,7 +133,6 @@ bool SolenoidBase::GetPCMSolenoidVoltageFault(int module) const {
  *
  * If no sticky faults are set then this call will have no effect.
  */
-void SolenoidBase::ClearAllPCMStickyFaults(int module) {
-  int32_t status = 0;
-  return HAL_ClearAllPCMStickyFaults(static_cast<int>(module), &status);
+void SolenoidBase::ClearAllPCMStickyFaults() {
+  SolenoidBase::ClearAllPCMStickyFaults(m_moduleNumber);
 }

--- a/wpilibj/src/athena/cpp/lib/SolenoidJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/SolenoidJNI.cpp
@@ -124,13 +124,13 @@ Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getSolenoid(
 /*
  * Class:     edu_wpi_first_wpilibj_hal_SolenoidJNI
  * Method:    getAllSolenoids
- * Signature: (B)Z
+ * Signature: (I)I
  */
-JNIEXPORT jbyte JNICALL
+JNIEXPORT jint JNICALL
 Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getAllSolenoids(
-    JNIEnv *env, jclass, jbyte module) {
+    JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
-  jbyte val = HAL_GetAllSolenoids(module, &status);
+  jint val = HAL_GetAllSolenoids(module, &status);
   CheckStatus(env, status);
   return val;
 }
@@ -138,11 +138,11 @@ Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getAllSolenoids(
 /*
  * Class:     edu_wpi_first_wpilibj_hal_SolenoidJNI
  * Method:    getPCMSolenoidBlackList
- * Signature: (B)I
+ * Signature: (I)I
  */
 JNIEXPORT jint JNICALL
 Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getPCMSolenoidBlackList(
-    JNIEnv *env, jclass, jbyte module) {
+    JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   jint val = HAL_GetPCMSolenoidBlackList(module, &status);
   CheckStatus(env, status);
@@ -151,11 +151,11 @@ Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getPCMSolenoidBlackList(
 /*
  * Class:     edu_wpi_first_wpilibj_hal_SolenoidJNI
  * Method:    getPCMSolenoidVoltageStickyFault
- * Signature: (B)Z
+ * Signature: (I)Z
  */
 JNIEXPORT jboolean JNICALL
 Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getPCMSolenoidVoltageStickyFault(
-    JNIEnv *env, jclass, jbyte module) {
+    JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   bool val = HAL_GetPCMSolenoidVoltageStickyFault(module, &status);
   CheckStatus(env, status);
@@ -164,11 +164,11 @@ Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getPCMSolenoidVoltageStickyFault(
 /*
  * Class:     edu_wpi_first_wpilibj_hal_SolenoidJNI
  * Method:    getPCMSolenoidVoltageFault
- * Signature: (B)Z
+ * Signature: (I)Z
  */
 JNIEXPORT jboolean JNICALL
 Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getPCMSolenoidVoltageFault(
-    JNIEnv *env, jclass, jbyte module) {
+    JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   bool val = HAL_GetPCMSolenoidVoltageFault(module, &status);
   CheckStatus(env, status);
@@ -177,11 +177,11 @@ Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getPCMSolenoidVoltageFault(
 /*
  * Class:     edu_wpi_first_wpilibj_hal_SolenoidJNI
  * Method:    clearAllPCMStickyFaults
- * Signature: (B)V
+ * Signature: (I)V
  */
 JNIEXPORT void JNICALL
 Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_clearAllPCMStickyFaults(
-    JNIEnv *env, jclass, jbyte module) {
+    JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   HAL_ClearAllPCMStickyFaults(module, &status);
   CheckStatus(env, status);

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/SolenoidBase.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/SolenoidBase.java
@@ -15,7 +15,7 @@ import edu.wpi.first.wpilibj.hal.SolenoidJNI;
  */
 public abstract class SolenoidBase extends SensorBase {
 
-  protected final byte m_moduleNumber; // The number of the solenoid module being used.
+  protected final int m_moduleNumber; // The number of the solenoid module being used.
 
   /**
    * Constructor.
@@ -23,7 +23,17 @@ public abstract class SolenoidBase extends SensorBase {
    * @param moduleNumber The PCM CAN ID
    */
   public SolenoidBase(final int moduleNumber) {
-    m_moduleNumber = (byte) moduleNumber;
+    m_moduleNumber = moduleNumber;
+  }
+
+  /**
+   * Read all 8 solenoids from the specified module as a single byte.
+   *
+   * @param moduleNumber the module number to read
+   * @return The current value of all 8 solenoids on the module.
+   */
+  public static int getAll(int moduleNumber) {
+    return SolenoidJNI.getAllSolenoids(moduleNumber);
   }
 
   /**
@@ -31,8 +41,21 @@ public abstract class SolenoidBase extends SensorBase {
    *
    * @return The current value of all 8 solenoids on this module.
    */
-  public byte getAll() {
-    return SolenoidJNI.getAllSolenoids(m_moduleNumber);
+  public int getAll() {
+    return SolenoidBase.getAll(m_moduleNumber);
+  }
+
+  /**
+   * Reads complete solenoid blacklist for all 8 solenoids as a single byte. If a solenoid is
+   * shorted, it is added to the blacklist and disabled until power cycle, or until faults are
+   * cleared.
+   *
+   * @param moduleNumber the module number to read
+   * @return The solenoid blacklist of all 8 solenoids on the module.
+   * @see #clearAllPCMStickyFaults()
+   */
+  public static int getPCMSolenoidBlackList(int moduleNumber) {
+    return SolenoidJNI.getPCMSolenoidBlackList(moduleNumber);
   }
 
   /**
@@ -43,8 +66,19 @@ public abstract class SolenoidBase extends SensorBase {
    * @return The solenoid blacklist of all 8 solenoids on the module.
    * @see #clearAllPCMStickyFaults()
    */
-  public byte getPCMSolenoidBlackList() {
-    return (byte) SolenoidJNI.getPCMSolenoidBlackList(m_moduleNumber);
+  public int getPCMSolenoidBlackList() {
+    return SolenoidBase.getPCMSolenoidBlackList(m_moduleNumber);
+  }
+
+  /**
+   * If true, the common highside solenoid voltage rail is too low, most likely a solenoid channel
+   * is shorted.
+   *
+   * @param moduleNumber the module number to read
+   * @return true if PCM sticky fault is set
+   */
+  public static boolean getPCMSolenoidVoltageStickyFault(int moduleNumber) {
+    return SolenoidJNI.getPCMSolenoidVoltageStickyFault(moduleNumber);
   }
 
   /**
@@ -54,7 +88,18 @@ public abstract class SolenoidBase extends SensorBase {
    * @return true if PCM sticky fault is set
    */
   public boolean getPCMSolenoidVoltageStickyFault() {
-    return SolenoidJNI.getPCMSolenoidVoltageStickyFault(m_moduleNumber);
+    return SolenoidBase.getPCMSolenoidVoltageStickyFault(m_moduleNumber);
+  }
+
+  /**
+   * The common highside solenoid voltage rail is too low, most likely a solenoid channel is
+   * shorted.
+   *
+   * @param moduleNumber the module number to read
+   * @return true if PCM is in fault state.
+   */
+  public static boolean getPCMSolenoidVoltageFault(int moduleNumber) {
+    return SolenoidJNI.getPCMSolenoidVoltageFault(moduleNumber);
   }
 
   /**
@@ -64,7 +109,22 @@ public abstract class SolenoidBase extends SensorBase {
    * @return true if PCM is in fault state.
    */
   public boolean getPCMSolenoidVoltageFault() {
-    return SolenoidJNI.getPCMSolenoidVoltageFault(m_moduleNumber);
+    return SolenoidBase.getPCMSolenoidVoltageFault(m_moduleNumber);
+  }
+
+  /**
+   * Clear ALL sticky faults inside PCM that Compressor is wired to.
+   *
+   * <p>If a sticky fault is set, then it will be persistently cleared. Compressor drive maybe
+   * momentarily disable while flags are being cleared. Care should be taken to not call this too
+   * frequently, otherwise normal compressor functionality may be prevented.
+   *
+   * <p>If no sticky faults are set then this call will have no effect.
+   *
+   * @param moduleNumber the module number to read
+   */
+  public static void clearAllPCMStickyFaults(int moduleNumber) {
+    SolenoidJNI.clearAllPCMStickyFaults(moduleNumber);
   }
 
   /**
@@ -77,6 +137,6 @@ public abstract class SolenoidBase extends SensorBase {
    * <p>If no sticky faults are set then this call will have no effect.
    */
   public void clearAllPCMStickyFaults() {
-    SolenoidJNI.clearAllPCMStickyFaults(m_moduleNumber);
+    SolenoidBase.clearAllPCMStickyFaults(m_moduleNumber);
   }
 }

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/SolenoidJNI.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/hal/SolenoidJNI.java
@@ -20,13 +20,13 @@ public class SolenoidJNI extends JNIWrapper {
 
   public static native boolean getSolenoid(int portHandle);
 
-  public static native byte getAllSolenoids(byte module);
+  public static native int getAllSolenoids(int module);
 
-  public static native int getPCMSolenoidBlackList(byte module);
+  public static native int getPCMSolenoidBlackList(int module);
 
-  public static native boolean getPCMSolenoidVoltageStickyFault(byte module);
+  public static native boolean getPCMSolenoidVoltageStickyFault(int module);
 
-  public static native boolean getPCMSolenoidVoltageFault(byte module);
+  public static native boolean getPCMSolenoidVoltageFault(int module);
 
-  public static native void clearAllPCMStickyFaults(byte module);
+  public static native void clearAllPCMStickyFaults(int module);
 }


### PR DESCRIPTION
Instance methods were kept around for backwards compat in Java. In C++,
the instance methods were changed to match Java. Also some cleanup to
the JNI layer to match updated variable types we missed.

Closes #416