### PR TITLE
Fixes assertions to not crash StringRef

### DIFF
--- a/wpilibc/athena/src/Utility.cpp
+++ b/wpilibc/athena/src/Utility.cpp
@@ -41,7 +41,7 @@ bool wpi_assert_impl(bool conditionValue, llvm::StringRef conditionText,
 
     errorStream << "Assertion \"" << conditionText << "\" ";
 
-    if (message[0] != '\0') {
+    if (!message.empty()) {
       errorStream << "failed: " << message << std::endl;
     } else {
       errorStream << "failed." << std::endl;
@@ -78,7 +78,7 @@ void wpi_assertEqual_common_impl(llvm::StringRef valueA, llvm::StringRef valueB,
   errorStream << "Assertion \"" << valueA << " " << equalityType << " "
               << valueB << "\" ";
 
-  if (message[0] != '\0') {
+  if (!message.empty()) {
     errorStream << "failed: " << message << std::endl;
   } else {
     errorStream << "failed." << std::endl;

--- a/wpilibc/sim/src/Utility.cpp
+++ b/wpilibc/sim/src/Utility.cpp
@@ -69,7 +69,7 @@ bool wpi_assert_impl(bool conditionValue, llvm::StringRef conditionText,
     llvm::SmallString<128> fileTemp;
     errorStream << "of " << basename(fileName.c_str(fileTemp)) << " ";
 
-    if (message[0] != '\0') {
+    if (!message.empty()) {
       errorStream << "failed: " << message << std::endl;
     } else {
       errorStream << "failed." << std::endl;
@@ -98,7 +98,7 @@ void wpi_assertEqual_common_impl(int valueA, int valueB,
 
   // If an error message was specified, include it
   // Build error string
-  if (message.size() > 0) {
+  if (!message.empty()) {
     error << "Assertion failed: \"" << message << "\", \"" << valueA << "\" "
           << equalityType << " \"" << valueB << "\" in " << funcName << "() in "
           << fileName << " at line " << lineNumber << "\n";


### PR DESCRIPTION
We can't read [0] on an empty StringRef or the StringRef itself asserts.
Instead, we can just check if size() != 0

Closes #502