### PR TITLE
Make HAL headers C compatible when reasonable

### DIFF
--- a/hal/include/HAL/Accelerometer.h
+++ b/hal/include/HAL/Accelerometer.h
@@ -9,11 +9,14 @@
 
 #include "HAL/Types.h"
 
-enum HAL_AccelerometerRange : int32_t {
+/* clang-format off */
+HAL_ENUM_START(HAL_AccelerometerRange, int32_t) {
   HAL_AccelerometerRange_k2G = 0,
   HAL_AccelerometerRange_k4G = 1,
-  HAL_AccelerometerRange_k8G = 2,
-};
+  HAL_AccelerometerRange_k8G = 2
+}
+HAL_ENUM_END(HAL_AccelerometerRange, int32_t)
+/* clang-format on */
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/include/HAL/AnalogTrigger.h
+++ b/hal/include/HAL/AnalogTrigger.h
@@ -11,12 +11,15 @@
 
 #include "HAL/Types.h"
 
-enum HAL_AnalogTriggerType : int32_t {
+/* clang-format off */
+HAL_ENUM_START(HAL_AnalogTriggerType, int32_t) {
   HAL_Trigger_kInWindow = 0,
   HAL_Trigger_kState = 1,
   HAL_Trigger_kRisingPulse = 2,
   HAL_Trigger_kFallingPulse = 3
-};
+}
+HAL_ENUM_END(HAL_AnalogTriggerType, int32_t)
+/* clang-format on */
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/include/HAL/Counter.h
+++ b/hal/include/HAL/Counter.h
@@ -12,12 +12,15 @@
 #include "HAL/AnalogTrigger.h"
 #include "HAL/Types.h"
 
-enum HAL_Counter_Mode : int32_t {
+/* clang-format off */
+HAL_ENUM_START(HAL_Counter_Mode, int32_t) {
   HAL_Counter_kTwoPulse = 0,
   HAL_Counter_kSemiperiod = 1,
   HAL_Counter_kPulseLength = 2,
   HAL_Counter_kExternalDirection = 3
-};
+}
+HAL_ENUM_END(HAL_Counter_Mode, int32_t)
+/* clang-format on */
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/include/HAL/DriverStation.h
+++ b/hal/include/HAL/DriverStation.h
@@ -9,8 +9,6 @@
 
 #include <stdint.h>
 
-#include <cstddef>
-
 #include "HAL/Types.h"
 
 #define HAL_IO_CONFIG_DATA_SIZE 32
@@ -37,15 +35,19 @@ struct HAL_ControlWord {
   uint32_t dsAttached : 1;
   uint32_t control_reserved : 26;
 };
+typedef struct HAL_ControlWord HAL_ControlWord;
 
-enum HAL_AllianceStationID : int32_t {
+/* clang-format off */
+HAL_ENUM_START(HAL_AllianceStationID, int32_t) {
   HAL_AllianceStationID_kRed1,
   HAL_AllianceStationID_kRed2,
   HAL_AllianceStationID_kRed3,
   HAL_AllianceStationID_kBlue1,
   HAL_AllianceStationID_kBlue2,
   HAL_AllianceStationID_kBlue3,
-};
+}
+HAL_ENUM_END(HAL_AllianceStationID, int32_t)
+/* clang-format on */
 
 /* The maximum number of axes that will be stored in a single HALJoystickAxes
  * struct. This is used for allocating buffers, not bounds checking, since
@@ -58,16 +60,19 @@ struct HAL_JoystickAxes {
   int16_t count;
   float axes[HAL_kMaxJoystickAxes];
 };
+typedef struct HAL_JoystickAxes HAL_JoystickAxes;
 
 struct HAL_JoystickPOVs {
   int16_t count;
   int16_t povs[HAL_kMaxJoystickPOVs];
 };
+typedef struct HAL_JoystickPOVs HAL_JoystickPOVs;
 
 struct HAL_JoystickButtons {
   uint32_t buttons;
   uint8_t count;
 };
+typedef struct HAL_JoystickButtons HAL_JoystickButtons;
 
 struct HAL_JoystickDescriptor {
   uint8_t isXbox;
@@ -78,6 +83,7 @@ struct HAL_JoystickDescriptor {
   uint8_t buttonCount;
   uint8_t povCount;
 };
+typedef struct HAL_JoystickDescriptor HAL_JoystickDescriptor;
 
 #ifdef __cplusplus
 extern "C" {
@@ -118,8 +124,8 @@ void HAL_ObserveUserProgramAutonomous(void);
 void HAL_ObserveUserProgramTeleop(void);
 void HAL_ObserveUserProgramTest(void);
 
-#endif  // HAL_USE_LABVIEW
+#endif /* HAL_USE_LABVIEW */
 
 #ifdef __cplusplus
-}  // extern "C"
+}
 #endif

--- a/hal/include/HAL/Encoder.h
+++ b/hal/include/HAL/Encoder.h
@@ -12,17 +12,24 @@
 #include "HAL/AnalogTrigger.h"
 #include "HAL/Types.h"
 
-enum HAL_EncoderIndexingType : int32_t {
+/* clang-format off */
+HAL_ENUM_START(HAL_EncoderIndexingType, int32_t) {
   HAL_kResetWhileHigh,
   HAL_kResetWhileLow,
   HAL_kResetOnFallingEdge,
   HAL_kResetOnRisingEdge
-};
-enum HAL_EncoderEncodingType : int32_t {
+}
+HAL_ENUM_END(HAL_EncoderIndexingType, int32_t)
+/* clang-format on */
+
+/* clang-format off */
+HAL_ENUM_START(HAL_EncoderEncodingType, int32_t) {
   HAL_Encoder_k1X,
   HAL_Encoder_k2X,
   HAL_Encoder_k4X
-};
+}
+HAL_ENUM_END(HAL_EncoderEncodingType, int32_t)
+/* clang-format on */
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/include/HAL/HAL.h
+++ b/hal/include/HAL/HAL.h
@@ -35,14 +35,22 @@
 #include "HAL/SerialPort.h"
 #include "HAL/Solenoid.h"
 
-#endif  // HAL_USE_LABVIEW
+#endif /* HAL_USE_LABVIEW */
 
 #include "FRC_NetworkCommunication/UsageReporting.h"
 #include "HAL/Types.h"
 
+#ifdef __cplusplus
 namespace HALUsageReporting = nUsageReporting;
+#endif
 
-enum HAL_RuntimeType : int32_t { HAL_Athena, HAL_Mock };
+/* clang-format off */
+HAL_ENUM_START(HAL_RuntimeType, int32_t) {
+  HAL_Athena,
+  HAL_Mock
+}
+HAL_ENUM_END(HAL_RuntimeType, int32_t)
+/* clang-format on */
 
 #ifdef __cplusplus
 extern "C" {
@@ -70,7 +78,7 @@ uint64_t HAL_GetFPGATime(int32_t* status);
 
 int32_t HAL_Initialize(int32_t mode);
 
-// ifdef's definition is to allow for default parameters in C++.
+/* ifdef's definition is to allow for default parameters in C++. */
 #ifdef __cplusplus
 int64_t HAL_Report(int32_t resource, int32_t instanceNumber,
                    int32_t context = 0, const char* feature = nullptr);
@@ -79,7 +87,7 @@ int64_t HAL_Report(int32_t resource, int32_t instanceNumber, int32_t context,
                    const char* feature);
 #endif
 
-#endif  // HAL_USE_LABVIEW
+#endif /* HAL_USE_LABVIEW */
 #ifdef __cplusplus
 }
 #endif

--- a/hal/include/HAL/I2C.h
+++ b/hal/include/HAL/I2C.h
@@ -9,7 +9,15 @@
 
 #include <stdint.h>
 
-enum HAL_I2CPort : int32_t { HAL_I2C_kOnboard = 0, HAL_I2C_kMXP };
+#include "HAL/Types.h"
+
+/* clang-format off */
+HAL_ENUM_START(HAL_I2CPort, int32_t) {
+  HAL_I2C_kOnboard = 0,
+  HAL_I2C_kMXP
+}
+HAL_ENUM_END(HAL_I2CPort, int32_t)
+/* clang-format on */
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/include/HAL/SPI.h
+++ b/hal/include/HAL/SPI.h
@@ -11,13 +11,16 @@
 
 #include "HAL/Types.h"
 
-enum HAL_SPIPort : int32_t {
+/* clang-format off */
+HAL_ENUM_START(HAL_SPIPort, int32_t) {
   HAL_SPI_kOnboardCS0 = 0,
   HAL_SPI_kOnboardCS1,
   HAL_SPI_kOnboardCS2,
   HAL_SPI_kOnboardCS3,
   HAL_SPI_kMXP
-};
+}
+HAL_ENUM_END(HAL_SPIPort, int32_t)
+/* clang-format on */
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/include/HAL/SerialPort.h
+++ b/hal/include/HAL/SerialPort.h
@@ -9,12 +9,17 @@
 
 #include <stdint.h>
 
-enum HAL_SerialPort : int32_t {
+#include "HAL/Types.h"
+
+/* clang-format off */
+HAL_ENUM_START(HAL_SerialPort, int32_t) {
   HAL_SerialPort_Onboard = 0,
   HAL_SerialPort_MXP = 1,
   HAL_SerialPort_USB1 = 2,
   HAL_SerialPort_USB2 = 3
-};
+}
+HAL_ENUM_END(HAL_SerialPort, int32_t)
+/* clang-format on */
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/include/HAL/Threads.h
+++ b/hal/include/HAL/Threads.h
@@ -17,7 +17,10 @@
 #define NativeThreadHandle const pthread_t*
 #endif
 
+#ifdef __cplusplus
 extern "C" {
+#endif
+
 int32_t HAL_GetThreadPriority(NativeThreadHandle handle, HAL_Bool* isRealTime,
                               int32_t* status);
 int32_t HAL_GetCurrentThreadPriority(HAL_Bool* isRealTime, int32_t* status);
@@ -25,4 +28,6 @@ HAL_Bool HAL_SetThreadPriority(NativeThreadHandle handle, HAL_Bool realTime,
                                int32_t priority, int32_t* status);
 HAL_Bool HAL_SetCurrentThreadPriority(HAL_Bool realTime, int32_t priority,
                                       int32_t* status);
+#ifdef __cplusplus
 }
+#endif

--- a/hal/include/HAL/Types.h
+++ b/hal/include/HAL/Types.h
@@ -44,3 +44,65 @@ typedef HAL_Handle HAL_RelayHandle;
 typedef HAL_Handle HAL_SolenoidHandle;
 
 typedef int32_t HAL_Bool;
+
+/** @def HAL_ENUM_START(name, type)
+ *
+ * This macro is used before the start of a typed enum declaration:
+
+@code{.cpp}
+HAL_ENUM_START(HAL_AccelerometerRange, int32_t) {
+    HAL_AccelerometerRange_k2G = 0,
+    HAL_AccelerometerRange_k4G = 1,
+    HAL_AccelerometerRange_k8G = 2
+}
+HAL_ENUM_END(HAL_AccelerometerRange, int32_t)
+@endcode
+
+ * In C this evaluates to:
+
+@code{.c}
+enum {
+    HAL_AccelerometerRange_k2G = 0,
+    HAL_AccelerometerRange_k4G = 1,
+    HAL_AccelerometerRange_k8G = 2
+};
+typedef int32_t HAL_AccelerometerRange;
+@endcode
+
+ * While in C++ this evaluates to:
+
+@code{.cpp}
+enum HAL_AccelerometerRange : int32_t {
+    HAL_AccelerometerRange_k2G = 0,
+    HAL_AccelerometerRange_k4G = 1,
+    HAL_AccelerometerRange_k8G = 2
+};
+@endcode
+
+ * This defines the constants @c HAL_AccelerometerRange_k2G,
+ * @c HAL_AccelerometerRange_k4G, and @c HAL_AccelerometerRange_k8G to @c 0,
+ * @c 1, and @c 2, respectively.  It also makes a 32 bit signed integer type
+ * called @c HAL_AccelerometerRange.
+ *
+ * We need the C version to use the typedefinition because otherwise we couldn't
+ * get the enumeration to be exactly 32 bits, required by the implementation of
+ * HAL.  The C++ code has to name the enumeration in order to use it as a
+ * namespace, for example @c HAL_AccelerometerRange::HAL_AccelerometerRange_k2G
+ * is used in code and therefore it must remain backwards compatible.
+ */
+/** @def HAL_ENUM_END(name, type)
+ *
+ * This macro is used after the body of a typed enum declaration.
+ *
+ * For more documentation see @link HAL_ENUM_START @endlink.
+ */
+
+#ifdef __cplusplus
+#define HAL_ENUM_START(name, type) enum name : type
+#define HAL_ENUM_END(name, type) ; /* NOLINT */
+#else
+#define HAL_ENUM_START(name, type) enum
+#define HAL_ENUM_END(name, type) \
+  ;                              \
+  typedef type name;
+#endif


### PR DESCRIPTION
Headers that only define C++ things like classes are not made to be C
compatible for obvious reasons.

Solves #476 