### PR TITLE
Adds function to HAL to free malloc'd joystick name

### DIFF
--- a/hal/include/HAL/DriverStation.h
+++ b/hal/include/HAL/DriverStation.h
@@ -99,6 +99,7 @@ int32_t HAL_GetJoystickDescriptor(int32_t joystickNum,
 HAL_Bool HAL_GetJoystickIsXbox(int32_t joystickNum);
 int32_t HAL_GetJoystickType(int32_t joystickNum);
 char* HAL_GetJoystickName(int32_t joystickNum);
+void HAL_FreeJoystickName(char* name);
 int32_t HAL_GetJoystickAxisType(int32_t joystickNum, int32_t axis);
 int32_t HAL_SetJoystickOutputs(int32_t joystickNum, int64_t outputs,
                                int32_t leftRumble, int32_t rightRumble);

--- a/hal/lib/athena/FRCDriverStation.cpp
+++ b/hal/lib/athena/FRCDriverStation.cpp
@@ -205,6 +205,8 @@ char* HAL_GetJoystickName(int32_t joystickNum) {
   }
 }
 
+void HAL_FreeJoystickName(char* name) { std::free(name); }
+
 int32_t HAL_GetJoystickAxisType(int32_t joystickNum, int32_t axis) {
   HAL_JoystickDescriptor joystickDesc;
   if (HAL_GetJoystickDescriptor(joystickNum, &joystickDesc) < 0) {

--- a/wpilibj/src/athena/cpp/lib/HAL.cpp
+++ b/wpilibj/src/athena/cpp/lib/HAL.cpp
@@ -259,7 +259,7 @@ Java_edu_wpi_first_wpilibj_hal_HAL_getJoystickName(JNIEnv* env, jclass,
   NETCOMM_LOG(logDEBUG) << "Calling HAL_GetJoystickName";
   char *joystickName = HAL_GetJoystickName(port);
   jstring str = MakeJString(env, joystickName);
-  std::free(joystickName);
+  HAL_FreeJoystickName(joystickName);
   return str;
 }
 


### PR DESCRIPTION
No safe way to do this with interop, so a function is needed.