### PR TITLE
Adds way to reset and version all HAL handles

### DIFF
--- a/hal/build.gradle
+++ b/hal/build.gradle
@@ -18,6 +18,7 @@ model {
             binaries.all {
                 tasks.withType(CppCompile) {
                     cppCompiler.args "-DNAMESPACED_PRIORITY"
+                    cppCompiler.args "-DCONFIG_ATHENA"
                     addNiLibraryLinks(linker, targetPlatform)
                     addWpiUtilLibraryLinks(it, linker, targetPlatform)
                 }

--- a/hal/include/HAL/handles/IndexedHandleResource.h
+++ b/hal/include/HAL/handles/IndexedHandleResource.h
@@ -34,7 +34,7 @@ namespace hal {
  */
 template <typename THandle, typename TStruct, int16_t size,
           HAL_HandleEnum enumValue>
-class IndexedHandleResource {
+class IndexedHandleResource : public HandleBase {
   friend class IndexedHandleResourceTest;
 
  public:
@@ -45,6 +45,7 @@ class IndexedHandleResource {
   THandle Allocate(int16_t index, int32_t* status);
   std::shared_ptr<TStruct> Get(THandle handle);
   void Free(THandle handle);
+  void ResetHandles() override;
 
  private:
   std::array<std::shared_ptr<TStruct>, size> m_structures;
@@ -67,7 +68,7 @@ THandle IndexedHandleResource<THandle, TStruct, size, enumValue>::Allocate(
     return HAL_kInvalidHandle;
   }
   m_structures[index] = std::make_shared<TStruct>();
-  return static_cast<THandle>(hal::createHandle(index, enumValue));
+  return static_cast<THandle>(hal::createHandle(index, enumValue, m_version));
 }
 
 template <typename THandle, typename TStruct, int16_t size,
@@ -75,7 +76,7 @@ template <typename THandle, typename TStruct, int16_t size,
 std::shared_ptr<TStruct>
 IndexedHandleResource<THandle, TStruct, size, enumValue>::Get(THandle handle) {
   // get handle index, and fail early if index out of range or wrong handle
-  int16_t index = getHandleTypedIndex(handle, enumValue);
+  int16_t index = getHandleTypedIndex(handle, enumValue, m_version);
   if (index < 0 || index >= size) {
     return nullptr;
   }
@@ -90,10 +91,20 @@ template <typename THandle, typename TStruct, int16_t size,
 void IndexedHandleResource<THandle, TStruct, size, enumValue>::Free(
     THandle handle) {
   // get handle index, and fail early if index out of range or wrong handle
-  int16_t index = getHandleTypedIndex(handle, enumValue);
+  int16_t index = getHandleTypedIndex(handle, enumValue, m_version);
   if (index < 0 || index >= size) return;
   // lock and deallocated handle
   std::lock_guard<hal::priority_mutex> sync(m_handleMutexes[index]);
   m_structures[index].reset();
+}
+
+template <typename THandle, typename TStruct, int16_t size,
+          HAL_HandleEnum enumValue>
+void IndexedHandleResource<THandle, TStruct, size, enumValue>::ResetHandles() {
+  for (int i = 0; i < size; i++) {
+    std::lock_guard<hal::priority_mutex> sync(m_handleMutexes[i]);
+    m_structures[i].reset();
+  }
+  HandleBase::ResetHandles();
 }
 }  // namespace hal

--- a/hal/include/HAL/handles/LimitedHandleResource.h
+++ b/hal/include/HAL/handles/LimitedHandleResource.h
@@ -31,7 +31,7 @@ namespace hal {
  */
 template <typename THandle, typename TStruct, int16_t size,
           HAL_HandleEnum enumValue>
-class LimitedHandleResource {
+class LimitedHandleResource : public HandleBase {
   friend class LimitedHandleResourceTest;
 
  public:
@@ -42,6 +42,7 @@ class LimitedHandleResource {
   THandle Allocate();
   std::shared_ptr<TStruct> Get(THandle handle);
   void Free(THandle handle);
+  void ResetHandles() override;
 
  private:
   std::array<std::shared_ptr<TStruct>, size> m_structures;
@@ -60,7 +61,7 @@ THandle LimitedHandleResource<THandle, TStruct, size, enumValue>::Allocate() {
       // and allocate it.
       std::lock_guard<hal::priority_mutex> sync(m_handleMutexes[i]);
       m_structures[i] = std::make_shared<TStruct>();
-      return static_cast<THandle>(createHandle(i, enumValue));
+      return static_cast<THandle>(createHandle(i, enumValue, m_version));
     }
   }
   return HAL_kInvalidHandle;
@@ -71,7 +72,7 @@ template <typename THandle, typename TStruct, int16_t size,
 std::shared_ptr<TStruct>
 LimitedHandleResource<THandle, TStruct, size, enumValue>::Get(THandle handle) {
   // get handle index, and fail early if index out of range or wrong handle
-  int16_t index = getHandleTypedIndex(handle, enumValue);
+  int16_t index = getHandleTypedIndex(handle, enumValue, m_version);
   if (index < 0 || index >= size) {
     return nullptr;
   }
@@ -86,11 +87,24 @@ template <typename THandle, typename TStruct, int16_t size,
 void LimitedHandleResource<THandle, TStruct, size, enumValue>::Free(
     THandle handle) {
   // get handle index, and fail early if index out of range or wrong handle
-  int16_t index = getHandleTypedIndex(handle, enumValue);
+  int16_t index = getHandleTypedIndex(handle, enumValue, m_version);
   if (index < 0 || index >= size) return;
   // lock and deallocated handle
   std::lock_guard<hal::priority_mutex> sync(m_allocateMutex);
   std::lock_guard<hal::priority_mutex> lock(m_handleMutexes[index]);
   m_structures[index].reset();
+}
+
+template <typename THandle, typename TStruct, int16_t size,
+          HAL_HandleEnum enumValue>
+void LimitedHandleResource<THandle, TStruct, size, enumValue>::ResetHandles() {
+  {
+    std::lock_guard<hal::priority_mutex> lock(m_allocateMutex);
+    for (int i = 0; i < size; i++) {
+      std::lock_guard<hal::priority_mutex> sync(m_handleMutexes[i]);
+      m_structures[i].reset();
+    }
+  }
+  HandleBase::ResetHandles();
 }
 }  // namespace hal

--- a/hal/lib/athena/Compressor.cpp
+++ b/hal/lib/athena/Compressor.cpp
@@ -28,7 +28,7 @@ HAL_CompressorHandle HAL_InitializeCompressor(int32_t module, int32_t* status) {
   // handle with the module number as the index.
 
   return (HAL_CompressorHandle)createHandle(static_cast<int16_t>(module),
-                                            HAL_HandleEnum::Compressor);
+                                            HAL_HandleEnum::Compressor, 0);
 }
 
 HAL_Bool HAL_CheckCompressorModule(int32_t module) {
@@ -38,7 +38,7 @@ HAL_Bool HAL_CheckCompressorModule(int32_t module) {
 HAL_Bool HAL_GetCompressor(HAL_CompressorHandle compressorHandle,
                            int32_t* status) {
   int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor);
+      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
   if (index == InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
@@ -53,7 +53,7 @@ HAL_Bool HAL_GetCompressor(HAL_CompressorHandle compressorHandle,
 void HAL_SetCompressorClosedLoopControl(HAL_CompressorHandle compressorHandle,
                                         HAL_Bool value, int32_t* status) {
   int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor);
+      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
   if (index == InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return;
@@ -65,7 +65,7 @@ void HAL_SetCompressorClosedLoopControl(HAL_CompressorHandle compressorHandle,
 HAL_Bool HAL_GetCompressorClosedLoopControl(
     HAL_CompressorHandle compressorHandle, int32_t* status) {
   int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor);
+      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
   if (index == InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
@@ -80,7 +80,7 @@ HAL_Bool HAL_GetCompressorClosedLoopControl(
 HAL_Bool HAL_GetCompressorPressureSwitch(HAL_CompressorHandle compressorHandle,
                                          int32_t* status) {
   int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor);
+      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
   if (index == InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
@@ -95,7 +95,7 @@ HAL_Bool HAL_GetCompressorPressureSwitch(HAL_CompressorHandle compressorHandle,
 double HAL_GetCompressorCurrent(HAL_CompressorHandle compressorHandle,
                                 int32_t* status) {
   int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor);
+      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
   if (index == InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return 0;
@@ -109,7 +109,7 @@ double HAL_GetCompressorCurrent(HAL_CompressorHandle compressorHandle,
 HAL_Bool HAL_GetCompressorCurrentTooHighFault(
     HAL_CompressorHandle compressorHandle, int32_t* status) {
   int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor);
+      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
   if (index == InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
@@ -123,7 +123,7 @@ HAL_Bool HAL_GetCompressorCurrentTooHighFault(
 HAL_Bool HAL_GetCompressorCurrentTooHighStickyFault(
     HAL_CompressorHandle compressorHandle, int32_t* status) {
   int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor);
+      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
   if (index == InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
@@ -137,7 +137,7 @@ HAL_Bool HAL_GetCompressorCurrentTooHighStickyFault(
 HAL_Bool HAL_GetCompressorShortedStickyFault(
     HAL_CompressorHandle compressorHandle, int32_t* status) {
   int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor);
+      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
   if (index == InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
@@ -151,7 +151,7 @@ HAL_Bool HAL_GetCompressorShortedStickyFault(
 HAL_Bool HAL_GetCompressorShortedFault(HAL_CompressorHandle compressorHandle,
                                        int32_t* status) {
   int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor);
+      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
   if (index == InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
@@ -165,7 +165,7 @@ HAL_Bool HAL_GetCompressorShortedFault(HAL_CompressorHandle compressorHandle,
 HAL_Bool HAL_GetCompressorNotConnectedStickyFault(
     HAL_CompressorHandle compressorHandle, int32_t* status) {
   int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor);
+      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
   if (index == InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
@@ -179,7 +179,7 @@ HAL_Bool HAL_GetCompressorNotConnectedStickyFault(
 HAL_Bool HAL_GetCompressorNotConnectedFault(
     HAL_CompressorHandle compressorHandle, int32_t* status) {
   int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor);
+      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
   if (index == InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;

--- a/hal/lib/shared/handles/HandlesInternal.cpp
+++ b/hal/lib/shared/handles/HandlesInternal.cpp
@@ -7,7 +7,51 @@
 
 #include "HAL/handles/HandlesInternal.h"
 
+#include <algorithm>
+
+#include "HAL/cpp/priority_mutex.h"
+#include "llvm/SmallVector.h"
+
 namespace hal {
+static llvm::SmallVector<HandleBase*, 32> globalHandles;
+static priority_mutex globalHandleMutex;
+
+HandleBase::HandleBase() {
+  std::lock_guard<priority_mutex> lock(globalHandleMutex);
+  auto index = std::find(globalHandles.begin(), globalHandles.end(), this);
+  if (index == globalHandles.end()) {
+    globalHandles.push_back(this);
+  } else {
+    *index = this;
+  }
+}
+
+HandleBase::~HandleBase() {
+  std::lock_guard<priority_mutex> lock(globalHandleMutex);
+  auto index = std::find(globalHandles.begin(), globalHandles.end(), this);
+  if (index != globalHandles.end()) {
+    *index = nullptr;
+  }
+}
+
+void HandleBase::ResetHandles() {
+  m_version++;
+  if (m_version > 255) {
+    m_version = 0;
+  }
+}
+
+void HandleBase::ResetGlobalHandles() {
+  std::unique_lock<priority_mutex> lock(globalHandleMutex);
+  for (auto&& i : globalHandles) {
+    if (i != nullptr) {
+      lock.unlock();
+      i->ResetHandles();
+      lock.lock();
+    }
+  }
+}
+
 HAL_PortHandle createPortHandle(uint8_t channel, uint8_t module) {
   // set last 8 bits, then shift to first 8 bits
   HAL_PortHandle handle = static_cast<HAL_PortHandle>(HAL_HandleEnum::Port);
@@ -36,13 +80,16 @@ HAL_PortHandle createPortHandleForSPI(uint8_t channel) {
   return handle;
 }
 
-HAL_Handle createHandle(int16_t index, HAL_HandleEnum handleType) {
+HAL_Handle createHandle(int16_t index, HAL_HandleEnum handleType,
+                        int16_t version) {
   if (index < 0) return HAL_kInvalidHandle;
   uint8_t hType = static_cast<uint8_t>(handleType);
   if (hType == 0 || hType > 127) return HAL_kInvalidHandle;
   // set last 8 bits, then shift to first 8 bits
   HAL_Handle handle = hType;
-  handle = handle << 24;
+  handle = handle << 8;
+  handle += static_cast<uint8_t>(version);
+  handle = handle << 16;
   // add index to set last 16 bits
   handle += index;
   return handle;


### PR DESCRIPTION
Useful in the sim to force a full reset. On roboRIO, the information is
still created and added, but is not checked because of speed
considerations.  In addition, the reset functionality will do nothing.