### PR TITLE
Switches all notifiers created with the external API to be threaded

### DIFF
--- a/hal/include/HAL/Notifier.h
+++ b/hal/include/HAL/Notifier.h
@@ -20,8 +20,6 @@ typedef void (*HAL_NotifierProcessFunction)(uint64_t currentTime,
 
 HAL_NotifierHandle HAL_InitializeNotifier(HAL_NotifierProcessFunction process,
                                           void* param, int32_t* status);
-HAL_NotifierHandle HAL_InitializeNotifierThreaded(
-    HAL_NotifierProcessFunction process, void* param, int32_t* status);
 void HAL_CleanNotifier(HAL_NotifierHandle notifierHandle, int32_t* status);
 void* HAL_GetNotifierParam(HAL_NotifierHandle notifierHandle, int32_t* status);
 void HAL_UpdateNotifierAlarm(HAL_NotifierHandle notifierHandle,

--- a/hal/include/HAL/cpp/NotifierInternal.h
+++ b/hal/include/HAL/cpp/NotifierInternal.h
@@ -1,0 +1,15 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) FIRST 2017. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include "HAL/Types.h"
+
+extern "C" {
+HAL_NotifierHandle HAL_InitializeNotifierNonThreadedUnsafe(
+    HAL_NotifierProcessFunction process, void* param, int32_t* status);
+}

--- a/hal/lib/athena/HAL.cpp
+++ b/hal/lib/athena/HAL.cpp
@@ -25,6 +25,7 @@
 #include "HAL/DriverStation.h"
 #include "HAL/Errors.h"
 #include "HAL/Notifier.h"
+#include "HAL/cpp/NotifierInternal.h"
 #include "HAL/cpp/priority_mutex.h"
 #include "HAL/handles/HandlesInternal.h"
 #include "ctre/ctre.h"
@@ -306,7 +307,8 @@ int32_t HAL_Initialize(int32_t mode) {
   HAL_BaseInitialize(&status);
 
   if (!rolloverNotifier)
-    rolloverNotifier = HAL_InitializeNotifier(timerRollover, nullptr, &status);
+    rolloverNotifier = HAL_InitializeNotifierNonThreadedUnsafe(
+        timerRollover, nullptr, &status);
   if (status == 0) {
     uint64_t curTime = HAL_GetFPGATime(&status);
     if (status == 0)

--- a/wpilibj/src/athena/cpp/lib/NotifierJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/NotifierJNI.cpp
@@ -18,6 +18,7 @@
 #include "HAL/cpp/Log.h"
 #include "edu_wpi_first_wpilibj_hal_NotifierJNI.h"
 #include "support/SafeThread.h"
+#include "HAL/cpp/NotifierInternal.h"
 
 using namespace frc;
 
@@ -147,7 +148,8 @@ Java_edu_wpi_first_wpilibj_hal_NotifierJNI_initializeNotifier(
   notify->Start();
   notify->SetFunc(env, func, mid);
   int32_t status = 0;
-  HAL_NotifierHandle notifierHandle = HAL_InitializeNotifier(notifierHandler, notify, &status);
+  HAL_NotifierHandle notifierHandle = 
+      HAL_InitializeNotifierNonThreadedUnsafe(notifierHandler, notify, &status);
 
   NOTIFIERJNI_LOG(logDEBUG) << "Notifier Handle = " << notifierHandle;
   NOTIFIERJNI_LOG(logDEBUG) << "Status = " << status;


### PR DESCRIPTION
Testing showed this wasn't an issue with timing, and allows for more
safety in user code making mistakes. Places where the extra thread
wouldn't help have been kept non threaded, using a new internal API.