### PR TITLE
Miscellaneous formatting and style fixes for integration tests

### DIFF
--- a/wpilibcIntegrationTests/include/command/MockCommand.h
+++ b/wpilibcIntegrationTests/include/command/MockCommand.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <Commands/Command.h>
+#include "Commands/Command.h"
 
 namespace frc {
 

--- a/wpilibcIntegrationTests/include/command/MockConditionalCommand.h
+++ b/wpilibcIntegrationTests/include/command/MockConditionalCommand.h
@@ -7,8 +7,7 @@
 
 #pragma once
 
-#include <Commands/ConditionalCommand.h>
-
+#include "Commands/ConditionalCommand.h"
 #include "command/MockCommand.h"
 
 namespace frc {

--- a/wpilibcIntegrationTests/src/RelayTest.cpp
+++ b/wpilibcIntegrationTests/src/RelayTest.cpp
@@ -36,6 +36,7 @@ class RelayTest : public testing::Test {
 
   void Reset() { m_relay->Set(Relay::kOff); }
 };
+
 /**
  * Test the relay by setting it forward, reverse, off, and on.
  */


### PR DESCRIPTION
Added newline before comment block and replaced angle brackets around includes
with quotation marks. All other integration tests use quotation marks for WPILib
includes.