### PR TITLE
Switches CANJNI to use byte[] rather then ByteBuffer, and throws exceptions for invalid platforms

### DIFF
--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/can/CANJNI.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/can/CANJNI.java
@@ -23,10 +23,10 @@ public class CANJNI extends JNIWrapper {
 
   @SuppressWarnings("MethodName")
   public static native void FRCNetCommCANSessionMuxSendMessage(int messageID,
-                                                                            ByteBuffer data,
-                                                                            int periodMs);
+                                                               byte[] data,
+                                                               int periodMs);
 
   @SuppressWarnings("MethodName")
-  public static native ByteBuffer FRCNetCommCANSessionMuxReceiveMessage(
+  public static native byte[] FRCNetCommCANSessionMuxReceiveMessage(
       IntBuffer messageID, int messageIDMask, ByteBuffer timeStamp);
 }


### PR DESCRIPTION
Fixes #567