### PR TITLE
Remove use of std::chrono_literals (C++14 feature).

### DIFF
--- a/wpilibc/athena/src/TimedRobot.cpp
+++ b/wpilibc/athena/src/TimedRobot.cpp
@@ -12,7 +12,6 @@
 #include "HAL/HAL.h"
 
 using namespace frc;
-using namespace std::chrono_literals;
 
 /**
  * Provide an alternate "main loop" via StartCompetition().
@@ -22,7 +21,7 @@ void TimedRobot::StartCompetition() {
   m_startLoop = true;
   m_loop->StartPeriodic(m_period);
   while (true) {
-    std::this_thread::sleep_for(24h);
+    std::this_thread::sleep_for(std::chrono::hours(24));
   }
 }
 


### PR DESCRIPTION
This also gets allwpilib compiling again with gcc 4.8.