### PR TITLE
Replaced "using namespace" declarations with scoping and "using" declarations

### DIFF
--- a/hal/include/HAL/cpp/Log.h
+++ b/hal/include/HAL/cpp/Log.h
@@ -100,26 +100,27 @@ inline std::string NowTime() {
   llvm::SmallString<128> buf;
   llvm::raw_svector_ostream oss(buf);
 
-  using namespace std::chrono;
-  auto now = system_clock::now().time_since_epoch();
+  using std::chrono::duration_cast;
+
+  auto now = std::chrono::system_clock::now().time_since_epoch();
 
   // Hours
-  auto count = duration_cast<hours>(now).count() % 24;
+  auto count = duration_cast<std::chrono::hours>(now).count() % 24;
   if (count < 10) oss << "0";
   oss << count << ":";
 
   // Minutes
-  count = duration_cast<minutes>(now).count() % 60;
+  count = duration_cast<std::chrono::minutes>(now).count() % 60;
   if (count < 10) oss << "0";
   oss << count << ":";
 
   // Seconds
-  count = duration_cast<seconds>(now).count() % 60;
+  count = duration_cast<std::chrono::seconds>(now).count() % 60;
   if (count < 10) oss << "0";
   oss << count << ".";
 
   // Milliseconds
-  oss << duration_cast<milliseconds>(now).count() % 1000;
+  oss << duration_cast<std::chrono::milliseconds>(now).count() % 1000;
 
   return oss.str();
 }

--- a/hal/lib/athena/Accelerometer.cpp
+++ b/hal/lib/athena/Accelerometer.cpp
@@ -16,8 +16,6 @@
 #include "HAL/ChipObject.h"
 #include "HAL/HAL.h"
 
-using namespace hal;
-
 // The 7-bit I2C address with a 0 "send" bit
 static const uint8_t kSendAddress = (0x1c << 1) | 0;
 
@@ -28,7 +26,7 @@ static const uint8_t kControlTxRx = 1;
 static const uint8_t kControlStart = 2;
 static const uint8_t kControlStop = 4;
 
-static std::unique_ptr<tAccel> accel;
+static std::unique_ptr<hal::tAccel> accel;
 static HAL_AccelerometerRange accelerometerRange;
 
 // Register addresses
@@ -87,7 +85,7 @@ static void initializeAccelerometer() {
   int32_t status;
 
   if (!accel) {
-    accel.reset(tAccel::create(&status));
+    accel.reset(hal::tAccel::create(&status));
 
     // Enable I2C
     accel->writeCNFG(1, &status);

--- a/hal/lib/athena/AnalogAccumulator.cpp
+++ b/hal/lib/athena/AnalogAccumulator.cpp
@@ -10,8 +10,6 @@
 #include "AnalogInternal.h"
 #include "HAL/HAL.h"
 
-using namespace hal;
-
 extern "C" {
 /**
  * Is the channel attached to an accumulator.
@@ -21,13 +19,13 @@ extern "C" {
  */
 HAL_Bool HAL_IsAccumulatorChannel(HAL_AnalogInputHandle analogPortHandle,
                                   int32_t* status) {
-  auto port = analogInputHandles.Get(analogPortHandle);
+  auto port = hal::analogInputHandles.Get(analogPortHandle);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return false;
   }
-  for (int32_t i = 0; i < kNumAccumulators; i++) {
-    if (port->channel == kAccumulatorChannels[i]) return true;
+  for (int32_t i = 0; i < hal::kNumAccumulators; i++) {
+    if (port->channel == hal::kAccumulatorChannels[i]) return true;
   }
   return false;
 }
@@ -54,7 +52,7 @@ void HAL_InitAccumulator(HAL_AnalogInputHandle analogPortHandle,
  */
 void HAL_ResetAccumulator(HAL_AnalogInputHandle analogPortHandle,
                           int32_t* status) {
-  auto port = analogInputHandles.Get(analogPortHandle);
+  auto port = hal::analogInputHandles.Get(analogPortHandle);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
@@ -83,7 +81,7 @@ void HAL_ResetAccumulator(HAL_AnalogInputHandle analogPortHandle,
  */
 void HAL_SetAccumulatorCenter(HAL_AnalogInputHandle analogPortHandle,
                               int32_t center, int32_t* status) {
-  auto port = analogInputHandles.Get(analogPortHandle);
+  auto port = hal::analogInputHandles.Get(analogPortHandle);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
@@ -103,7 +101,7 @@ void HAL_SetAccumulatorCenter(HAL_AnalogInputHandle analogPortHandle,
  */
 void HAL_SetAccumulatorDeadband(HAL_AnalogInputHandle analogPortHandle,
                                 int32_t deadband, int32_t* status) {
-  auto port = analogInputHandles.Get(analogPortHandle);
+  auto port = hal::analogInputHandles.Get(analogPortHandle);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
@@ -126,7 +124,7 @@ void HAL_SetAccumulatorDeadband(HAL_AnalogInputHandle analogPortHandle,
  */
 int64_t HAL_GetAccumulatorValue(HAL_AnalogInputHandle analogPortHandle,
                                 int32_t* status) {
-  auto port = analogInputHandles.Get(analogPortHandle);
+  auto port = hal::analogInputHandles.Get(analogPortHandle);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return 0;
@@ -150,7 +148,7 @@ int64_t HAL_GetAccumulatorValue(HAL_AnalogInputHandle analogPortHandle,
  */
 int64_t HAL_GetAccumulatorCount(HAL_AnalogInputHandle analogPortHandle,
                                 int32_t* status) {
-  auto port = analogInputHandles.Get(analogPortHandle);
+  auto port = hal::analogInputHandles.Get(analogPortHandle);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return 0;
@@ -174,7 +172,7 @@ int64_t HAL_GetAccumulatorCount(HAL_AnalogInputHandle analogPortHandle,
  */
 void HAL_GetAccumulatorOutput(HAL_AnalogInputHandle analogPortHandle,
                               int64_t* value, int64_t* count, int32_t* status) {
-  auto port = analogInputHandles.Get(analogPortHandle);
+  auto port = hal::analogInputHandles.Get(analogPortHandle);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
@@ -188,7 +186,7 @@ void HAL_GetAccumulatorOutput(HAL_AnalogInputHandle analogPortHandle,
     return;
   }
 
-  tAccumulator::tOutput output = port->accumulator->readOutput(status);
+  hal::tAccumulator::tOutput output = port->accumulator->readOutput(status);
 
   *value = output.Value;
   *count = output.Count;

--- a/hal/lib/athena/AnalogGyro.cpp
+++ b/hal/lib/athena/AnalogGyro.cpp
@@ -30,10 +30,9 @@ static constexpr double kSamplesPerSecond = 50.0;
 static constexpr double kCalibrationSampleTime = 5.0;
 static constexpr double kDefaultVoltsPerDegreePerSecond = 0.007;
 
-using namespace hal;
-
-static IndexedHandleResource<HAL_GyroHandle, AnalogGyro, kNumAccumulators,
-                             HAL_HandleEnum::AnalogGyro>
+static hal::IndexedHandleResource<HAL_GyroHandle, AnalogGyro,
+                                  hal::kNumAccumulators,
+                                  hal::HAL_HandleEnum::AnalogGyro>
     analogGyroHandles;
 
 static void Wait(double seconds) {
@@ -52,7 +51,7 @@ HAL_GyroHandle HAL_InitializeAnalogGyro(HAL_AnalogInputHandle analogHandle,
   }
 
   // handle known to be correct, so no need to type check
-  int16_t channel = getHandleIndex(analogHandle);
+  int16_t channel = hal::getHandleIndex(analogHandle);
 
   auto handle = analogGyroHandles.Allocate(channel, status);
 

--- a/hal/lib/athena/AnalogInternal.cpp
+++ b/hal/lib/athena/AnalogInternal.cpp
@@ -14,25 +14,25 @@
 #include "HAL/cpp/priority_mutex.h"
 #include "PortsInternal.h"
 
-namespace hal {
-priority_recursive_mutex analogRegisterWindowMutex;
-std::unique_ptr<tAI> analogInputSystem;
-std::unique_ptr<tAO> analogOutputSystem;
+hal::priority_recursive_mutex hal::analogRegisterWindowMutex;
+std::unique_ptr<hal::tAI> hal::analogInputSystem;
+std::unique_ptr<hal::tAO> hal::analogOutputSystem;
 
-IndexedHandleResource<HAL_AnalogInputHandle, hal::AnalogPort, kNumAnalogInputs,
-                      HAL_HandleEnum::AnalogInput>
-    analogInputHandles;
+hal::IndexedHandleResource<HAL_AnalogInputHandle, hal::AnalogPort,
+                           hal::kNumAnalogInputs,
+                           hal::HAL_HandleEnum::AnalogInput>
+    hal::analogInputHandles;
 
 static int32_t analogNumChannelsToActivate = 0;
 
 static std::atomic<bool> analogSystemInitialized{false};
 
-bool analogSampleRateSet = false;
+bool hal::analogSampleRateSet = false;
 
 /**
  * Initialize the analog System.
  */
-void initializeAnalog(int32_t* status) {
+void hal::initializeAnalog(int32_t* status) {
   if (analogSystemInitialized) return;
   std::lock_guard<priority_recursive_mutex> sync(analogRegisterWindowMutex);
   if (analogSystemInitialized) return;
@@ -48,7 +48,7 @@ void initializeAnalog(int32_t* status) {
  *
  * @return Active channels.
  */
-int32_t getAnalogNumActiveChannels(int32_t* status) {
+int32_t hal::getAnalogNumActiveChannels(int32_t* status) {
   int32_t scanSize = analogInputSystem->readConfig_ScanSize(status);
   if (scanSize == 0) return 8;
   return scanSize;
@@ -65,7 +65,7 @@ int32_t getAnalogNumActiveChannels(int32_t* status) {
  *
  * @return Value to write to the active channels field.
  */
-int32_t getAnalogNumChannelsToActivate(int32_t* status) {
+int32_t hal::getAnalogNumChannelsToActivate(int32_t* status) {
   if (analogNumChannelsToActivate == 0)
     return getAnalogNumActiveChannels(status);
   return analogNumChannelsToActivate;
@@ -78,7 +78,7 @@ int32_t getAnalogNumChannelsToActivate(int32_t* status) {
  *
  * @param samplesPerSecond The number of samples per channel per second.
  */
-void setAnalogSampleRate(double samplesPerSecond, int32_t* status) {
+void hal::setAnalogSampleRate(double samplesPerSecond, int32_t* status) {
   // TODO: This will change when variable size scan lists are implemented.
   // TODO: Need double comparison with epsilon.
   // wpi_assert(!sampleRateSet || GetSampleRate() == samplesPerSecond);
@@ -115,7 +115,6 @@ void setAnalogSampleRate(double samplesPerSecond, int32_t* status) {
  *
  * @param channels Number of active channels.
  */
-void setAnalogNumChannelsToActivate(int32_t channels) {
+void hal::setAnalogNumChannelsToActivate(int32_t channels) {
   analogNumChannelsToActivate = channels;
 }
-}  // namespace hal

--- a/hal/lib/athena/AnalogOutput.cpp
+++ b/hal/lib/athena/AnalogOutput.cpp
@@ -13,16 +13,15 @@
 #include "HAL/handles/IndexedHandleResource.h"
 #include "PortsInternal.h"
 
-using namespace hal;
-
 namespace {
 struct AnalogOutput {
   uint8_t channel;
 };
 }
 
-static IndexedHandleResource<HAL_AnalogOutputHandle, AnalogOutput,
-                             kNumAnalogOutputs, HAL_HandleEnum::AnalogOutput>
+static hal::IndexedHandleResource<HAL_AnalogOutputHandle, AnalogOutput,
+                                  hal::kNumAnalogOutputs,
+                                  hal::HAL_HandleEnum::AnalogOutput>
     analogOutputHandles;
 
 extern "C" {
@@ -32,12 +31,12 @@ extern "C" {
  */
 HAL_AnalogOutputHandle HAL_InitializeAnalogOutputPort(HAL_PortHandle portHandle,
                                                       int32_t* status) {
-  initializeAnalog(status);
+  hal::initializeAnalog(status);
 
   if (*status != 0) return HAL_kInvalidHandle;
 
-  int16_t channel = getPortHandleChannel(portHandle);
-  if (channel == InvalidHandleIndex) {
+  int16_t channel = hal::getPortHandleChannel(portHandle);
+  if (channel == hal::InvalidHandleIndex) {
     *status = PARAMETER_OUT_OF_RANGE;
     return HAL_kInvalidHandle;
   }
@@ -70,7 +69,7 @@ void HAL_FreeAnalogOutputPort(HAL_AnalogOutputHandle analogOutputHandle) {
  * @return Analog channel is valid
  */
 HAL_Bool HAL_CheckAnalogOutputChannel(int32_t channel) {
-  return channel < kNumAnalogOutputs && channel >= 0;
+  return channel < hal::kNumAnalogOutputs && channel >= 0;
 }
 
 void HAL_SetAnalogOutput(HAL_AnalogOutputHandle analogOutputHandle,
@@ -88,7 +87,7 @@ void HAL_SetAnalogOutput(HAL_AnalogOutputHandle analogOutputHandle,
   else if (voltage > 5.0)
     rawValue = 0x1000;
 
-  analogOutputSystem->writeMXP(port->channel, rawValue, status);
+  hal::analogOutputSystem->writeMXP(port->channel, rawValue, status);
 }
 
 double HAL_GetAnalogOutput(HAL_AnalogOutputHandle analogOutputHandle,
@@ -99,7 +98,7 @@ double HAL_GetAnalogOutput(HAL_AnalogOutputHandle analogOutputHandle,
     return 0.0;
   }
 
-  uint16_t rawValue = analogOutputSystem->readMXP(port->channel, status);
+  uint16_t rawValue = hal::analogOutputSystem->readMXP(port->channel, status);
 
   return rawValue * 5.0 / 0x1000;
 }

--- a/hal/lib/athena/AnalogTrigger.cpp
+++ b/hal/lib/athena/AnalogTrigger.cpp
@@ -14,18 +14,17 @@
 #include "HAL/handles/LimitedHandleResource.h"
 #include "PortsInternal.h"
 
-using namespace hal;
-
 namespace {
 struct AnalogTrigger {
-  std::unique_ptr<tAnalogTrigger> trigger;
+  std::unique_ptr<hal::tAnalogTrigger> trigger;
   HAL_AnalogInputHandle analogHandle;
   uint8_t index;
 };
 }
 
-static LimitedHandleResource<HAL_AnalogTriggerHandle, AnalogTrigger,
-                             kNumAnalogTriggers, HAL_HandleEnum::AnalogTrigger>
+static hal::LimitedHandleResource<HAL_AnalogTriggerHandle, AnalogTrigger,
+                                  hal::kNumAnalogTriggers,
+                                  hal::HAL_HandleEnum::AnalogTrigger>
     analogTriggerHandles;
 
 extern "C" {
@@ -33,7 +32,7 @@ extern "C" {
 HAL_AnalogTriggerHandle HAL_InitializeAnalogTrigger(
     HAL_AnalogInputHandle portHandle, int32_t* index, int32_t* status) {
   // ensure we are given a valid and active AnalogInput handle
-  auto analog_port = analogInputHandles.Get(portHandle);
+  auto analog_port = hal::analogInputHandles.Get(portHandle);
   if (analog_port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return HAL_kInvalidHandle;
@@ -49,10 +48,10 @@ HAL_AnalogTriggerHandle HAL_InitializeAnalogTrigger(
     return HAL_kInvalidHandle;
   }
   trigger->analogHandle = portHandle;
-  trigger->index = static_cast<uint8_t>(getHandleIndex(handle));
+  trigger->index = static_cast<uint8_t>(hal::getHandleIndex(handle));
   *index = trigger->index;
 
-  trigger->trigger.reset(tAnalogTrigger::create(trigger->index, status));
+  trigger->trigger.reset(hal::tAnalogTrigger::create(trigger->index, status));
   trigger->trigger->writeSourceSelect_Channel(analog_port->channel, status);
   return handle;
 }

--- a/hal/lib/athena/Compressor.cpp
+++ b/hal/lib/athena/Compressor.cpp
@@ -13,13 +13,11 @@
 #include "PortsInternal.h"
 #include "ctre/PCM.h"
 
-using namespace hal;
-
 extern "C" {
 
 HAL_CompressorHandle HAL_InitializeCompressor(int32_t module, int32_t* status) {
   // Use status to check for invalid index
-  initializePCM(module, status);
+  hal::initializePCM(module, status);
   if (*status != 0) {
     return HAL_kInvalidHandle;
   }
@@ -28,166 +26,174 @@ HAL_CompressorHandle HAL_InitializeCompressor(int32_t module, int32_t* status) {
   // handle with the module number as the index.
 
   return (HAL_CompressorHandle)createHandle(static_cast<int16_t>(module),
-                                            HAL_HandleEnum::Compressor, 0);
+                                            hal::HAL_HandleEnum::Compressor, 0);
 }
 
 HAL_Bool HAL_CheckCompressorModule(int32_t module) {
-  return module < kNumPCMModules && module >= 0;
+  return module < hal::kNumPCMModules && module >= 0;
 }
 
 HAL_Bool HAL_GetCompressor(HAL_CompressorHandle compressorHandle,
                            int32_t* status) {
-  int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
-  if (index == InvalidHandleIndex) {
+  int16_t index = hal::getHandleTypedIndex(compressorHandle,
+                                           hal::HAL_HandleEnum::Compressor, 0);
+  if (index == hal::InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
   }
   bool value;
 
-  *status = PCM_modules[index]->GetCompressor(value);
+  *status = hal::PCM_modules[index]->GetCompressor(value);
 
   return value;
 }
 
 void HAL_SetCompressorClosedLoopControl(HAL_CompressorHandle compressorHandle,
                                         HAL_Bool value, int32_t* status) {
-  int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
-  if (index == InvalidHandleIndex) {
+  int16_t index = hal::getHandleTypedIndex(compressorHandle,
+                                           hal::HAL_HandleEnum::Compressor, 0);
+  if (index == hal::InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return;
   }
 
-  *status = PCM_modules[index]->SetClosedLoopControl(value);
+  *status = hal::PCM_modules[index]->SetClosedLoopControl(value);
 }
 
 HAL_Bool HAL_GetCompressorClosedLoopControl(
     HAL_CompressorHandle compressorHandle, int32_t* status) {
-  int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
-  if (index == InvalidHandleIndex) {
+  int16_t index = hal::getHandleTypedIndex(compressorHandle,
+                                           hal::HAL_HandleEnum::Compressor, 0);
+  if (index == hal::InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
   }
   bool value;
 
-  *status = PCM_modules[index]->GetClosedLoopControl(value);
+  *status = hal::PCM_modules[index]->GetClosedLoopControl(value);
 
   return value;
 }
 
 HAL_Bool HAL_GetCompressorPressureSwitch(HAL_CompressorHandle compressorHandle,
                                          int32_t* status) {
-  int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
-  if (index == InvalidHandleIndex) {
+  int16_t index = hal::getHandleTypedIndex(compressorHandle,
+                                           hal::HAL_HandleEnum::Compressor, 0);
+  if (index == hal::InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
   }
   bool value;
 
-  *status = PCM_modules[index]->GetPressure(value);
+  *status = hal::PCM_modules[index]->GetPressure(value);
 
   return value;
 }
 
 double HAL_GetCompressorCurrent(HAL_CompressorHandle compressorHandle,
                                 int32_t* status) {
-  int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
-  if (index == InvalidHandleIndex) {
+  int16_t index = hal::getHandleTypedIndex(compressorHandle,
+                                           hal::HAL_HandleEnum::Compressor, 0);
+  if (index == hal::InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return 0;
   }
   float value;
 
-  *status = PCM_modules[index]->GetCompressorCurrent(value);
+  *status = hal::PCM_modules[index]->GetCompressorCurrent(value);
 
   return value;
 }
+
 HAL_Bool HAL_GetCompressorCurrentTooHighFault(
     HAL_CompressorHandle compressorHandle, int32_t* status) {
-  int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
-  if (index == InvalidHandleIndex) {
+  int16_t index = hal::getHandleTypedIndex(compressorHandle,
+                                           hal::HAL_HandleEnum::Compressor, 0);
+  if (index == hal::InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
   }
   bool value;
 
-  *status = PCM_modules[index]->GetCompressorCurrentTooHighFault(value);
+  *status = hal::PCM_modules[index]->GetCompressorCurrentTooHighFault(value);
 
   return value;
 }
+
 HAL_Bool HAL_GetCompressorCurrentTooHighStickyFault(
     HAL_CompressorHandle compressorHandle, int32_t* status) {
-  int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
-  if (index == InvalidHandleIndex) {
+  int16_t index = hal::getHandleTypedIndex(compressorHandle,
+                                           hal::HAL_HandleEnum::Compressor, 0);
+  if (index == hal::InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
   }
   bool value;
 
-  *status = PCM_modules[index]->GetCompressorCurrentTooHighStickyFault(value);
+  *status =
+      hal::PCM_modules[index]->GetCompressorCurrentTooHighStickyFault(value);
 
   return value;
 }
+
 HAL_Bool HAL_GetCompressorShortedStickyFault(
     HAL_CompressorHandle compressorHandle, int32_t* status) {
-  int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
-  if (index == InvalidHandleIndex) {
+  int16_t index = hal::getHandleTypedIndex(compressorHandle,
+                                           hal::HAL_HandleEnum::Compressor, 0);
+  if (index == hal::InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
   }
   bool value;
 
-  *status = PCM_modules[index]->GetCompressorShortedStickyFault(value);
+  *status = hal::PCM_modules[index]->GetCompressorShortedStickyFault(value);
 
   return value;
 }
+
 HAL_Bool HAL_GetCompressorShortedFault(HAL_CompressorHandle compressorHandle,
                                        int32_t* status) {
-  int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
-  if (index == InvalidHandleIndex) {
+  int16_t index = hal::getHandleTypedIndex(compressorHandle,
+                                           hal::HAL_HandleEnum::Compressor, 0);
+  if (index == hal::InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
   }
   bool value;
 
-  *status = PCM_modules[index]->GetCompressorShortedFault(value);
+  *status = hal::PCM_modules[index]->GetCompressorShortedFault(value);
 
   return value;
 }
+
 HAL_Bool HAL_GetCompressorNotConnectedStickyFault(
     HAL_CompressorHandle compressorHandle, int32_t* status) {
-  int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
-  if (index == InvalidHandleIndex) {
+  int16_t index = hal::getHandleTypedIndex(compressorHandle,
+                                           hal::HAL_HandleEnum::Compressor, 0);
+  if (index == hal::InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
   }
   bool value;
 
-  *status = PCM_modules[index]->GetCompressorNotConnectedStickyFault(value);
+  *status =
+      hal::PCM_modules[index]->GetCompressorNotConnectedStickyFault(value);
 
   return value;
 }
+
 HAL_Bool HAL_GetCompressorNotConnectedFault(
     HAL_CompressorHandle compressorHandle, int32_t* status) {
-  int16_t index =
-      getHandleTypedIndex(compressorHandle, HAL_HandleEnum::Compressor, 0);
-  if (index == InvalidHandleIndex) {
+  int16_t index = hal::getHandleTypedIndex(compressorHandle,
+                                           hal::HAL_HandleEnum::Compressor, 0);
+  if (index == hal::InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return false;
   }
   bool value;
 
-  *status = PCM_modules[index]->GetCompressorNotConnectedFault(value);
+  *status = hal::PCM_modules[index]->GetCompressorNotConnectedFault(value);
 
   return value;
 }
-}  // extern "C"
+}

--- a/hal/lib/athena/Constants.cpp
+++ b/hal/lib/athena/Constants.cpp
@@ -9,10 +9,8 @@
 
 #include "ConstantsInternal.h"
 
-using namespace hal;
-
 extern "C" {
 int32_t HAL_GetSystemClockTicksPerMicrosecond(void) {
-  return kSystemClockTicksPerMicrosecond;
+  return hal::kSystemClockTicksPerMicrosecond;
 }
 }

--- a/hal/lib/athena/Counter.cpp
+++ b/hal/lib/athena/Counter.cpp
@@ -13,17 +13,15 @@
 #include "HAL/handles/LimitedHandleResource.h"
 #include "PortsInternal.h"
 
-using namespace hal;
-
 namespace {
 struct Counter {
-  std::unique_ptr<tCounter> counter;
+  std::unique_ptr<hal::tCounter> counter;
   uint8_t index;
 };
 }
 
-static LimitedHandleResource<HAL_CounterHandle, Counter, kNumCounters,
-                             HAL_HandleEnum::Counter>
+static hal::LimitedHandleResource<HAL_CounterHandle, Counter, hal::kNumCounters,
+                                  hal::HAL_HandleEnum::Counter>
     counterHandles;
 
 extern "C" {
@@ -39,10 +37,10 @@ HAL_CounterHandle HAL_InitializeCounter(HAL_Counter_Mode mode, int32_t* index,
     *status = HAL_HANDLE_ERROR;
     return HAL_kInvalidHandle;
   }
-  counter->index = static_cast<uint8_t>(getHandleIndex(handle));
+  counter->index = static_cast<uint8_t>(hal::getHandleIndex(handle));
   *index = counter->index;
 
-  counter->counter.reset(tCounter::create(counter->index, status));
+  counter->counter.reset(hal::tCounter::create(counter->index, status));
   counter->counter->writeConfig_Mode(mode, status);
   counter->counter->writeTimerConfig_AverageSize(1, status);
   return handle;
@@ -79,9 +77,9 @@ void HAL_SetCounterUpSource(HAL_CounterHandle counterHandle,
   bool routingAnalogTrigger = false;
   uint8_t routingChannel = 0;
   uint8_t routingModule = 0;
-  bool success =
-      remapDigitalSource(digitalSourceHandle, analogTriggerType, routingChannel,
-                         routingModule, routingAnalogTrigger);
+  bool success = hal::remapDigitalSource(digitalSourceHandle, analogTriggerType,
+                                         routingChannel, routingModule,
+                                         routingAnalogTrigger);
   if (!success) {
     *status = HAL_HANDLE_ERROR;
     return;
@@ -157,9 +155,9 @@ void HAL_SetCounterDownSource(HAL_CounterHandle counterHandle,
   bool routingAnalogTrigger = false;
   uint8_t routingChannel = 0;
   uint8_t routingModule = 0;
-  bool success =
-      remapDigitalSource(digitalSourceHandle, analogTriggerType, routingChannel,
-                         routingModule, routingAnalogTrigger);
+  bool success = hal::remapDigitalSource(digitalSourceHandle, analogTriggerType,
+                                         routingChannel, routingModule,
+                                         routingAnalogTrigger);
   if (!success) {
     *status = HAL_HANDLE_ERROR;
     return;
@@ -269,7 +267,7 @@ void HAL_SetCounterPulseLengthMode(HAL_CounterHandle counterHandle,
   counter->counter->writeConfig_Mode(HAL_Counter_kPulseLength, status);
   counter->counter->writeConfig_PulseLengthThreshold(
       static_cast<uint32_t>(threshold * 1.0e6) *
-          kSystemClockTicksPerMicrosecond,
+          hal::kSystemClockTicksPerMicrosecond,
       status);
 }
 
@@ -350,7 +348,8 @@ double HAL_GetCounterPeriod(HAL_CounterHandle counterHandle, int32_t* status) {
     *status = HAL_HANDLE_ERROR;
     return 0.0;
   }
-  tCounter::tTimerOutput output = counter->counter->readTimerOutput(status);
+  hal::tCounter::tTimerOutput output =
+      counter->counter->readTimerOutput(status);
   double period;
   if (output.Stalled) {
     // Return infinity

--- a/hal/lib/athena/DigitalInternal.cpp
+++ b/hal/lib/athena/DigitalInternal.cpp
@@ -20,30 +20,29 @@
 #include "HAL/cpp/priority_mutex.h"
 #include "PortsInternal.h"
 
-namespace hal {
 // Create a mutex to protect changes to the DO PWM config
-priority_recursive_mutex digitalPwmMutex;
+hal::priority_recursive_mutex hal::digitalPwmMutex;
 
-std::unique_ptr<tDIO> digitalSystem;
-std::unique_ptr<tRelay> relaySystem;
-std::unique_ptr<tPWM> pwmSystem;
-std::unique_ptr<tSPI> spiSystem;
+std::unique_ptr<hal::tDIO> hal::digitalSystem;
+std::unique_ptr<hal::tRelay> hal::relaySystem;
+std::unique_ptr<hal::tPWM> hal::pwmSystem;
+std::unique_ptr<hal::tSPI> hal::spiSystem;
 
 static std::atomic<bool> digitalSystemsInitialized{false};
 static hal::priority_mutex initializeMutex;
 
-DigitalHandleResource<HAL_DigitalHandle, DigitalPort,
-                      kNumDigitalChannels + kNumPWMHeaders>
-    digitalChannelHandles;
+hal::DigitalHandleResource<HAL_DigitalHandle, hal::DigitalPort,
+                           hal::kNumDigitalChannels + hal::kNumPWMHeaders>
+    hal::digitalChannelHandles;
 
 /**
  * Initialize the digital system.
  */
-void initializeDigital(int32_t* status) {
+void hal::initializeDigital(int32_t* status) {
   // Initial check, as if it's true initialization has finished
   if (digitalSystemsInitialized) return;
 
-  std::lock_guard<hal::priority_mutex> lock(initializeMutex);
+  std::lock_guard<priority_mutex> lock(initializeMutex);
   // Second check in case another thread was waiting
   if (digitalSystemsInitialized) return;
 
@@ -105,15 +104,15 @@ void initializeDigital(int32_t* status) {
  * Map SPI channel numbers from their physical number (27 to 31) to their
  * position in the bit field.
  */
-int32_t remapSPIChannel(int32_t channel) { return channel - 26; }
+int32_t hal::remapSPIChannel(int32_t channel) { return channel - 26; }
 
 /**
  * Map DIO channel numbers from their physical number (10 to 26) to their
  * position in the bit field.
  */
-int32_t remapMXPChannel(int32_t channel) { return channel - 10; }
+int32_t hal::remapMXPChannel(int32_t channel) { return channel - 10; }
 
-int32_t remapMXPPWMChannel(int32_t channel) {
+int32_t hal::remapMXPPWMChannel(int32_t channel) {
   if (channel < 14) {
     return channel - 10;  // first block of 4 pwms (MXP 0-3)
   } else {
@@ -127,10 +126,10 @@ int32_t remapMXPPWMChannel(int32_t channel) {
  * channel else do normal digital input remapping based on channel number
  * (MXP)
  */
-bool remapDigitalSource(HAL_Handle digitalSourceHandle,
-                        HAL_AnalogTriggerType analogTriggerType,
-                        uint8_t& channel, uint8_t& module,
-                        bool& analogTrigger) {
+bool hal::remapDigitalSource(HAL_Handle digitalSourceHandle,
+                             HAL_AnalogTriggerType analogTriggerType,
+                             uint8_t& channel, uint8_t& module,
+                             bool& analogTrigger) {
   if (isHandleType(digitalSourceHandle, HAL_HandleEnum::AnalogTrigger)) {
     // If handle passed, index is not negative
     int32_t index = getHandleIndex(digitalSourceHandle);
@@ -157,4 +156,3 @@ bool remapDigitalSource(HAL_Handle digitalSourceHandle,
     return false;
   }
 }
-}  // namespace hal

--- a/hal/lib/athena/DigitalInternal.h
+++ b/hal/lib/athena/DigitalInternal.h
@@ -46,14 +46,17 @@ constexpr int32_t kExpectedLoopTiming = 40;
  * devices.
  */
 constexpr double kDefaultPwmPeriod = 5.05;
+
 /**
  * kDefaultPwmCenter is the PWM range center in ms
  */
 constexpr double kDefaultPwmCenter = 1.5;
+
 /**
  * kDefaultPWMStepsDown is the number of PWM steps below the centerpoint
  */
 constexpr int32_t kDefaultPwmStepsDown = 1000;
+
 constexpr int32_t kPwmDisabled = 0;
 
 // Create a mutex to protect changes to the DO PWM config

--- a/hal/lib/athena/Encoder.cpp
+++ b/hal/lib/athena/Encoder.cpp
@@ -15,14 +15,12 @@
 #include "HAL/handles/LimitedClassedHandleResource.h"
 #include "PortsInternal.h"
 
-using namespace hal;
-
-Encoder::Encoder(HAL_Handle digitalSourceHandleA,
-                 HAL_AnalogTriggerType analogTriggerTypeA,
-                 HAL_Handle digitalSourceHandleB,
-                 HAL_AnalogTriggerType analogTriggerTypeB,
-                 bool reverseDirection, HAL_EncoderEncodingType encodingType,
-                 int32_t* status) {
+hal::Encoder::Encoder(HAL_Handle digitalSourceHandleA,
+                      HAL_AnalogTriggerType analogTriggerTypeA,
+                      HAL_Handle digitalSourceHandleB,
+                      HAL_AnalogTriggerType analogTriggerTypeB,
+                      bool reverseDirection,
+                      HAL_EncoderEncodingType encodingType, int32_t* status) {
   m_encodingType = encodingType;
   switch (encodingType) {
     case HAL_Encoder_k4X: {
@@ -52,13 +50,13 @@ Encoder::Encoder(HAL_Handle digitalSourceHandleA,
   }
 }
 
-void Encoder::SetupCounter(HAL_Handle digitalSourceHandleA,
-                           HAL_AnalogTriggerType analogTriggerTypeA,
-                           HAL_Handle digitalSourceHandleB,
-                           HAL_AnalogTriggerType analogTriggerTypeB,
-                           bool reverseDirection,
-                           HAL_EncoderEncodingType encodingType,
-                           int32_t* status) {
+void hal::Encoder::SetupCounter(HAL_Handle digitalSourceHandleA,
+                                HAL_AnalogTriggerType analogTriggerTypeA,
+                                HAL_Handle digitalSourceHandleB,
+                                HAL_AnalogTriggerType analogTriggerTypeB,
+                                bool reverseDirection,
+                                HAL_EncoderEncodingType encodingType,
+                                int32_t* status) {
   m_encodingScale = encodingType == HAL_Encoder_k1X ? 1 : 2;
   m_counter =
       HAL_InitializeCounter(HAL_Counter_kExternalDirection, &m_index, status);
@@ -81,7 +79,7 @@ void Encoder::SetupCounter(HAL_Handle digitalSourceHandleA,
   HAL_SetCounterDownSourceEdge(m_counter, reverseDirection, true, status);
 }
 
-Encoder::~Encoder() {
+hal::Encoder::~Encoder() {
   if (m_counter != HAL_kInvalidHandle) {
     int32_t status = 0;
     HAL_FreeCounter(m_counter, &status);
@@ -92,11 +90,11 @@ Encoder::~Encoder() {
 }
 
 // CounterBase interface
-int32_t Encoder::Get(int32_t* status) const {
+int32_t hal::Encoder::Get(int32_t* status) const {
   return static_cast<int32_t>(GetRaw(status) * DecodingScaleFactor());
 }
 
-int32_t Encoder::GetRaw(int32_t* status) const {
+int32_t hal::Encoder::GetRaw(int32_t* status) const {
   if (m_counter) {
     return HAL_GetCounter(m_counter, status);
   } else {
@@ -104,11 +102,11 @@ int32_t Encoder::GetRaw(int32_t* status) const {
   }
 }
 
-int32_t Encoder::GetEncodingScale(int32_t* status) const {
+int32_t hal::Encoder::GetEncodingScale(int32_t* status) const {
   return m_encodingScale;
 }
 
-void Encoder::Reset(int32_t* status) {
+void hal::Encoder::Reset(int32_t* status) {
   if (m_counter) {
     HAL_ResetCounter(m_counter, status);
   } else {
@@ -116,7 +114,7 @@ void Encoder::Reset(int32_t* status) {
   }
 }
 
-double Encoder::GetPeriod(int32_t* status) const {
+double hal::Encoder::GetPeriod(int32_t* status) const {
   if (m_counter) {
     return HAL_GetCounterPeriod(m_counter, status) / DecodingScaleFactor();
   } else {
@@ -124,7 +122,7 @@ double Encoder::GetPeriod(int32_t* status) const {
   }
 }
 
-void Encoder::SetMaxPeriod(double maxPeriod, int32_t* status) {
+void hal::Encoder::SetMaxPeriod(double maxPeriod, int32_t* status) {
   if (m_counter) {
     HAL_SetCounterMaxPeriod(m_counter, maxPeriod, status);
   } else {
@@ -132,7 +130,7 @@ void Encoder::SetMaxPeriod(double maxPeriod, int32_t* status) {
   }
 }
 
-bool Encoder::GetStopped(int32_t* status) const {
+bool hal::Encoder::GetStopped(int32_t* status) const {
   if (m_counter) {
     return HAL_GetCounterStopped(m_counter, status);
   } else {
@@ -140,7 +138,7 @@ bool Encoder::GetStopped(int32_t* status) const {
   }
 }
 
-bool Encoder::GetDirection(int32_t* status) const {
+bool hal::Encoder::GetDirection(int32_t* status) const {
   if (m_counter) {
     return HAL_GetCounterDirection(m_counter, status);
   } else {
@@ -148,23 +146,24 @@ bool Encoder::GetDirection(int32_t* status) const {
   }
 }
 
-double Encoder::GetDistance(int32_t* status) const {
+double hal::Encoder::GetDistance(int32_t* status) const {
   return GetRaw(status) * DecodingScaleFactor() * m_distancePerPulse;
 }
 
-double Encoder::GetRate(int32_t* status) const {
+double hal::Encoder::GetRate(int32_t* status) const {
   return m_distancePerPulse / GetPeriod(status);
 }
 
-void Encoder::SetMinRate(double minRate, int32_t* status) {
+void hal::Encoder::SetMinRate(double minRate, int32_t* status) {
   SetMaxPeriod(m_distancePerPulse / minRate, status);
 }
 
-void Encoder::SetDistancePerPulse(double distancePerPulse, int32_t* status) {
+void hal::Encoder::SetDistancePerPulse(double distancePerPulse,
+                                       int32_t* status) {
   m_distancePerPulse = distancePerPulse;
 }
 
-void Encoder::SetReverseDirection(bool reverseDirection, int32_t* status) {
+void hal::Encoder::SetReverseDirection(bool reverseDirection, int32_t* status) {
   if (m_counter) {
     HAL_SetCounterReverseDirection(m_counter, reverseDirection, status);
   } else {
@@ -172,7 +171,8 @@ void Encoder::SetReverseDirection(bool reverseDirection, int32_t* status) {
   }
 }
 
-void Encoder::SetSamplesToAverage(int32_t samplesToAverage, int32_t* status) {
+void hal::Encoder::SetSamplesToAverage(int32_t samplesToAverage,
+                                       int32_t* status) {
   if (samplesToAverage < 1 || samplesToAverage > 127) {
     *status = PARAMETER_OUT_OF_RANGE;
     return;
@@ -184,7 +184,7 @@ void Encoder::SetSamplesToAverage(int32_t samplesToAverage, int32_t* status) {
   }
 }
 
-int32_t Encoder::GetSamplesToAverage(int32_t* status) const {
+int32_t hal::Encoder::GetSamplesToAverage(int32_t* status) const {
   if (m_counter) {
     return HAL_GetCounterSamplesToAverage(m_counter, status);
   } else {
@@ -192,9 +192,10 @@ int32_t Encoder::GetSamplesToAverage(int32_t* status) const {
   }
 }
 
-void Encoder::SetIndexSource(HAL_Handle digitalSourceHandle,
-                             HAL_AnalogTriggerType analogTriggerType,
-                             HAL_EncoderIndexingType type, int32_t* status) {
+void hal::Encoder::SetIndexSource(HAL_Handle digitalSourceHandle,
+                                  HAL_AnalogTriggerType analogTriggerType,
+                                  HAL_EncoderIndexingType type,
+                                  int32_t* status) {
   if (m_counter) {
     *status = HAL_COUNTER_NOT_SUPPORTED;
     return;
@@ -208,7 +209,7 @@ void Encoder::SetIndexSource(HAL_Handle digitalSourceHandle,
                                 status);
 }
 
-double Encoder::DecodingScaleFactor() const {
+double hal::Encoder::DecodingScaleFactor() const {
   switch (m_encodingType) {
     case HAL_Encoder_k1X:
       return 1.0;
@@ -221,18 +222,19 @@ double Encoder::DecodingScaleFactor() const {
   }
 }
 
-static LimitedClassedHandleResource<HAL_EncoderHandle, Encoder,
-                                    kNumEncoders + kNumCounters,
-                                    HAL_HandleEnum::Encoder>
+static hal::LimitedClassedHandleResource<HAL_EncoderHandle, hal::Encoder,
+                                         hal::kNumEncoders + hal::kNumCounters,
+                                         hal::HAL_HandleEnum::Encoder>
     encoderHandles;
 
 extern "C" {
+
 HAL_EncoderHandle HAL_InitializeEncoder(
     HAL_Handle digitalSourceHandleA, HAL_AnalogTriggerType analogTriggerTypeA,
     HAL_Handle digitalSourceHandleB, HAL_AnalogTriggerType analogTriggerTypeB,
     HAL_Bool reverseDirection, HAL_EncoderEncodingType encodingType,
     int32_t* status) {
-  auto encoder = std::make_shared<Encoder>(
+  auto encoder = std::make_shared<hal::Encoder>(
       digitalSourceHandleA, analogTriggerTypeA, digitalSourceHandleB,
       analogTriggerTypeB, reverseDirection, encodingType, status);
   if (*status != 0) return HAL_kInvalidHandle;  // return in creation error

--- a/hal/lib/athena/FPGAEncoder.cpp
+++ b/hal/lib/athena/FPGAEncoder.cpp
@@ -13,19 +13,18 @@
 #include "HAL/handles/LimitedHandleResource.h"
 #include "PortsInternal.h"
 
-using namespace hal;
-
 namespace {
 struct Encoder {
-  std::unique_ptr<tEncoder> encoder;
+  std::unique_ptr<hal::tEncoder> encoder;
   uint8_t index;
 };
 }
 
 static const double DECODING_SCALING_FACTOR = 0.25;
 
-static LimitedHandleResource<HAL_FPGAEncoderHandle, Encoder, kNumEncoders,
-                             HAL_HandleEnum::FPGAEncoder>
+static hal::LimitedHandleResource<HAL_FPGAEncoderHandle, Encoder,
+                                  hal::kNumEncoders,
+                                  hal::HAL_HandleEnum::FPGAEncoder>
     fpgaEncoderHandles;
 
 extern "C" {
@@ -36,15 +35,15 @@ HAL_FPGAEncoderHandle HAL_InitializeFPGAEncoder(
   bool routingAnalogTriggerA = false;
   uint8_t routingChannelA = 0;
   uint8_t routingModuleA = 0;
-  bool successA = remapDigitalSource(digitalSourceHandleA, analogTriggerTypeA,
-                                     routingChannelA, routingModuleA,
-                                     routingAnalogTriggerA);
+  bool successA = hal::remapDigitalSource(
+      digitalSourceHandleA, analogTriggerTypeA, routingChannelA, routingModuleA,
+      routingAnalogTriggerA);
   bool routingAnalogTriggerB = false;
   uint8_t routingChannelB = 0;
   uint8_t routingModuleB = 0;
-  bool successB = remapDigitalSource(digitalSourceHandleB, analogTriggerTypeB,
-                                     routingChannelB, routingModuleB,
-                                     routingAnalogTriggerB);
+  bool successB = hal::remapDigitalSource(
+      digitalSourceHandleB, analogTriggerTypeB, routingChannelB, routingModuleB,
+      routingAnalogTriggerB);
 
   if (!successA || !successB) {
     *status = HAL_HANDLE_ERROR;
@@ -63,10 +62,10 @@ HAL_FPGAEncoderHandle HAL_InitializeFPGAEncoder(
     return HAL_kInvalidHandle;
   }
 
-  encoder->index = static_cast<uint8_t>(getHandleIndex(handle));
+  encoder->index = static_cast<uint8_t>(hal::getHandleIndex(handle));
   *index = encoder->index;
   // TODO: if (index == ~0ul) { CloneError(quadEncoders); return; }
-  encoder->encoder.reset(tEncoder::create(encoder->index, status));
+  encoder->encoder.reset(hal::tEncoder::create(encoder->index, status));
   encoder->encoder->writeConfig_ASource_Module(routingModuleA, status);
   encoder->encoder->writeConfig_ASource_Channel(routingChannelA, status);
   encoder->encoder->writeConfig_ASource_AnalogTrigger(routingAnalogTriggerA,
@@ -134,7 +133,8 @@ double HAL_GetFPGAEncoderPeriod(HAL_FPGAEncoderHandle fpgaEncoderHandle,
     *status = HAL_HANDLE_ERROR;
     return 0.0;
   }
-  tEncoder::tTimerOutput output = encoder->encoder->readTimerOutput(status);
+  hal::tEncoder::tTimerOutput output =
+      encoder->encoder->readTimerOutput(status);
   double value;
   if (output.Stalled) {
     // Return infinity
@@ -278,9 +278,9 @@ void HAL_SetFPGAEncoderIndexSource(HAL_FPGAEncoderHandle fpgaEncoderHandle,
   bool routingAnalogTrigger = false;
   uint8_t routingChannel = 0;
   uint8_t routingModule = 0;
-  bool success =
-      remapDigitalSource(digitalSourceHandle, analogTriggerType, routingChannel,
-                         routingModule, routingAnalogTrigger);
+  bool success = hal::remapDigitalSource(digitalSourceHandle, analogTriggerType,
+                                         routingChannel, routingModule,
+                                         routingAnalogTrigger);
   if (!success) {
     *status = HAL_HANDLE_ERROR;
     return;

--- a/hal/lib/athena/FRCDriverStation.cpp
+++ b/hal/lib/athena/FRCDriverStation.cpp
@@ -138,6 +138,7 @@ int32_t HAL_GetJoystickButtons(int32_t joystickNum,
   return FRC_NetworkCommunication_getJoystickButtons(
       joystickNum, &buttons->buttons, &buttons->count);
 }
+
 /**
  * Retrieve the Joystick Descriptor for particular slot
  * @param desc [out] descriptor (data transfer object) to fill in.  desc is

--- a/hal/lib/athena/HAL.cpp
+++ b/hal/lib/athena/HAL.cpp
@@ -31,24 +31,20 @@
 #include "llvm/raw_ostream.h"
 #include "visa/visa.h"
 
-using namespace hal;
-
-static std::unique_ptr<tGlobal> global;
-static std::unique_ptr<tSysWatchdog> watchdog;
+static std::unique_ptr<hal::tGlobal> global;
+static std::unique_ptr<hal::tSysWatchdog> watchdog;
 
 static hal::priority_mutex timeMutex;
 static uint32_t timeEpoch = 0;
 static uint32_t prevFPGATime = 0;
 static HAL_NotifierHandle rolloverNotifier = 0;
 
-using namespace hal;
-
 extern "C" {
 
 HAL_PortHandle HAL_GetPort(int32_t channel) {
   // Dont allow a number that wouldn't fit in a uint8_t
   if (channel < 0 || channel >= 255) return HAL_kInvalidHandle;
-  return createPortHandle(channel, 1);
+  return hal::createPortHandle(channel, 1);
 }
 
 /**
@@ -58,7 +54,7 @@ HAL_PortHandle HAL_GetPortWithModule(int32_t module, int32_t channel) {
   // Dont allow a number that wouldn't fit in a uint8_t
   if (channel < 0 || channel >= 255) return HAL_kInvalidHandle;
   if (module < 0 || module >= 255) return HAL_kInvalidHandle;
-  return createPortHandle(channel, module);
+  return hal::createPortHandle(channel, module);
 }
 
 const char* HAL_GetErrorMessage(int32_t code) {
@@ -282,8 +278,8 @@ void HAL_BaseInitialize(int32_t* status) {
   nFPGA::nRoboRIO_FPGANamespace::g_currentTargetClass =
       nLoadOut::kTargetClass_RoboRIO;
 
-  global.reset(tGlobal::create(status));
-  watchdog.reset(tSysWatchdog::create(status));
+  global.reset(hal::tGlobal::create(status));
+  watchdog.reset(hal::tSysWatchdog::create(status));
   initialized = true;
 }
 

--- a/hal/lib/athena/OSSerialPort.cpp
+++ b/hal/lib/athena/OSSerialPort.cpp
@@ -220,12 +220,15 @@ int32_t HAL_WriteOSSerial(HAL_SerialPort port, const char* buffer,
                           int32_t count, int32_t* status) {
   return write(portHandles[port], buffer, count);
 }
+
 void HAL_FlushOSSerial(HAL_SerialPort port, int32_t* status) {
   tcdrain(portHandles[port]);
 }
+
 void HAL_ClearOSSerial(HAL_SerialPort port, int32_t* status) {
   tcflush(portHandles[port], TCIOFLUSH);
 }
+
 void HAL_CloseOSSerial(HAL_SerialPort port, int32_t* status) {
   close(portHandles[port]);
 }

--- a/hal/lib/athena/PCMInternal.cpp
+++ b/hal/lib/athena/PCMInternal.cpp
@@ -12,10 +12,9 @@
 #include "HAL/cpp/make_unique.h"
 #include "PortsInternal.h"
 
-namespace hal {
-std::unique_ptr<PCM> PCM_modules[kNumPCMModules];
+std::unique_ptr<PCM> hal::PCM_modules[kNumPCMModules];
 
-void initializePCM(int32_t module, int32_t* status) {
+void hal::initializePCM(int32_t module, int32_t* status) {
   if (!HAL_CheckSolenoidModule(module)) {
     *status = RESOURCE_OUT_OF_RANGE;
     return;
@@ -24,4 +23,3 @@ void initializePCM(int32_t module, int32_t* status) {
     PCM_modules[module] = std::make_unique<PCM>(module);
   }
 }
-}  // namespace hal

--- a/hal/lib/athena/PDP.cpp
+++ b/hal/lib/athena/PDP.cpp
@@ -15,9 +15,7 @@
 #include "PortsInternal.h"
 #include "ctre/PDP.h"
 
-using namespace hal;
-
-static std::unique_ptr<PDP> pdp[kNumPDPModules];
+static std::unique_ptr<PDP> pdp[hal::kNumPDPModules];
 
 static inline bool checkPDPInit(int32_t module, int32_t* status) {
   if (!HAL_CheckPDPModule(module)) {
@@ -44,11 +42,11 @@ void HAL_InitializePDP(int32_t module, int32_t* status) {
 }
 
 HAL_Bool HAL_CheckPDPModule(int32_t module) {
-  return module < kNumPDPModules && module >= 0;
+  return module < hal::kNumPDPModules && module >= 0;
 }
 
 HAL_Bool HAL_CheckPDPChannel(int32_t channel) {
-  return channel < kNumPDPChannels && channel >= 0;
+  return channel < hal::kNumPDPChannels && channel >= 0;
 }
 
 double HAL_GetPDPTemperature(int32_t module, int32_t* status) {

--- a/hal/lib/athena/PWM.cpp
+++ b/hal/lib/athena/PWM.cpp
@@ -14,62 +14,71 @@
 #include "HAL/handles/HandlesInternal.h"
 #include "PortsInternal.h"
 
-using namespace hal;
-
-static inline int32_t GetMaxPositivePwm(DigitalPort* port) {
+static inline int32_t GetMaxPositivePwm(hal::DigitalPort* port) {
   return port->maxPwm;
 }
-static inline int32_t GetMinPositivePwm(DigitalPort* port) {
+
+static inline int32_t GetMinPositivePwm(hal::DigitalPort* port) {
   return port->eliminateDeadband ? port->deadbandMaxPwm : port->centerPwm + 1;
 }
-static inline int32_t GetCenterPwm(DigitalPort* port) {
+
+static inline int32_t GetCenterPwm(hal::DigitalPort* port) {
   return port->centerPwm;
 }
-static inline int32_t GetMaxNegativePwm(DigitalPort* port) {
+
+static inline int32_t GetMaxNegativePwm(hal::DigitalPort* port) {
   return port->eliminateDeadband ? port->deadbandMinPwm : port->centerPwm - 1;
 }
-static inline int32_t GetMinNegativePwm(DigitalPort* port) {
+
+static inline int32_t GetMinNegativePwm(hal::DigitalPort* port) {
   return port->minPwm;
 }
-static inline int32_t GetPositiveScaleFactor(DigitalPort* port) {
+
+// The scale for positive speeds.
+static inline int32_t GetPositiveScaleFactor(hal::DigitalPort* port) {
   return GetMaxPositivePwm(port) - GetMinPositivePwm(port);
-}  ///< The scale for positive speeds.
-static inline int32_t GetNegativeScaleFactor(DigitalPort* port) {
+}
+
+// The scale for negative speeds.
+static inline int32_t GetNegativeScaleFactor(hal::DigitalPort* port) {
   return GetMaxNegativePwm(port) - GetMinNegativePwm(port);
-}  ///< The scale for negative speeds.
-static inline int32_t GetFullRangeScaleFactor(DigitalPort* port) {
+}
+
+// The scale for positions.
+static inline int32_t GetFullRangeScaleFactor(hal::DigitalPort* port) {
   return GetMaxPositivePwm(port) - GetMinNegativePwm(port);
-}  ///< The scale for positions.
+}
 
 extern "C" {
 
 HAL_DigitalHandle HAL_InitializePWMPort(HAL_PortHandle portHandle,
                                         int32_t* status) {
-  initializeDigital(status);
+  hal::initializeDigital(status);
 
   if (*status != 0) return HAL_kInvalidHandle;
 
-  int16_t channel = getPortHandleChannel(portHandle);
-  if (channel == InvalidHandleIndex || channel >= kNumPWMChannels) {
+  int16_t channel = hal::getPortHandleChannel(portHandle);
+  if (channel == hal::InvalidHandleIndex || channel >= hal::kNumPWMChannels) {
     *status = PARAMETER_OUT_OF_RANGE;
     return HAL_kInvalidHandle;
   }
 
   uint8_t origChannel = static_cast<uint8_t>(channel);
 
-  if (origChannel < kNumPWMHeaders) {
-    channel += kNumDigitalChannels;  // remap Headers to end of allocations
+  if (origChannel < hal::kNumPWMHeaders) {
+    channel += hal::kNumDigitalChannels;  // remap Headers to end of allocations
   } else {
-    channel = remapMXPPWMChannel(channel) + 10;  // remap MXP to proper channel
+    channel =
+        hal::remapMXPPWMChannel(channel) + 10;  // remap MXP to proper channel
   }
 
-  auto handle =
-      digitalChannelHandles.Allocate(channel, HAL_HandleEnum::PWM, status);
+  auto handle = hal::digitalChannelHandles.Allocate(
+      channel, hal::HAL_HandleEnum::PWM, status);
 
   if (*status != 0)
     return HAL_kInvalidHandle;  // failed to allocate. Pass error back.
 
-  auto port = digitalChannelHandles.Get(handle, HAL_HandleEnum::PWM);
+  auto port = hal::digitalChannelHandles.Get(handle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {  // would only occur on thread issue.
     *status = HAL_HANDLE_ERROR;
     return HAL_kInvalidHandle;
@@ -77,40 +86,43 @@ HAL_DigitalHandle HAL_InitializePWMPort(HAL_PortHandle portHandle,
 
   port->channel = origChannel;
 
-  int32_t bitToSet = 1 << remapMXPPWMChannel(port->channel);
+  int32_t bitToSet = 1 << hal::remapMXPPWMChannel(port->channel);
   uint16_t specialFunctions =
-      digitalSystem->readEnableMXPSpecialFunction(status);
-  digitalSystem->writeEnableMXPSpecialFunction(specialFunctions | bitToSet,
-                                               status);
+      hal::digitalSystem->readEnableMXPSpecialFunction(status);
+  hal::digitalSystem->writeEnableMXPSpecialFunction(specialFunctions | bitToSet,
+                                                    status);
 
   return handle;
 }
+
 void HAL_FreePWMPort(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
   }
 
-  if (port->channel > tPWM::kNumHdrRegisters - 1) {
-    int32_t bitToUnset = 1 << remapMXPPWMChannel(port->channel);
+  if (port->channel > hal::tPWM::kNumHdrRegisters - 1) {
+    int32_t bitToUnset = 1 << hal::remapMXPPWMChannel(port->channel);
     uint16_t specialFunctions =
-        digitalSystem->readEnableMXPSpecialFunction(status);
-    digitalSystem->writeEnableMXPSpecialFunction(specialFunctions & ~bitToUnset,
-                                                 status);
+        hal::digitalSystem->readEnableMXPSpecialFunction(status);
+    hal::digitalSystem->writeEnableMXPSpecialFunction(
+        specialFunctions & ~bitToUnset, status);
   }
 
-  digitalChannelHandles.Free(pwmPortHandle, HAL_HandleEnum::PWM);
+  hal::digitalChannelHandles.Free(pwmPortHandle, hal::HAL_HandleEnum::PWM);
 }
 
 HAL_Bool HAL_CheckPWMChannel(int32_t channel) {
-  return channel < kNumPWMChannels && channel >= 0;
+  return channel < hal::kNumPWMChannels && channel >= 0;
 }
 
 void HAL_SetPWMConfig(HAL_DigitalHandle pwmPortHandle, double max,
                       double deadbandMax, double center, double deadbandMin,
                       double min, int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
@@ -118,19 +130,24 @@ void HAL_SetPWMConfig(HAL_DigitalHandle pwmPortHandle, double max,
 
   // calculate the loop time in milliseconds
   double loopTime =
-      HAL_GetLoopTiming(status) / (kSystemClockTicksPerMicrosecond * 1e3);
+      HAL_GetLoopTiming(status) / (hal::kSystemClockTicksPerMicrosecond * 1e3);
   if (*status != 0) return;
 
-  int32_t maxPwm = static_cast<int32_t>((max - kDefaultPwmCenter) / loopTime +
-                                        kDefaultPwmStepsDown - 1);
-  int32_t deadbandMaxPwm = static_cast<int32_t>(
-      (deadbandMax - kDefaultPwmCenter) / loopTime + kDefaultPwmStepsDown - 1);
-  int32_t centerPwm = static_cast<int32_t>(
-      (center - kDefaultPwmCenter) / loopTime + kDefaultPwmStepsDown - 1);
-  int32_t deadbandMinPwm = static_cast<int32_t>(
-      (deadbandMin - kDefaultPwmCenter) / loopTime + kDefaultPwmStepsDown - 1);
-  int32_t minPwm = static_cast<int32_t>((min - kDefaultPwmCenter) / loopTime +
-                                        kDefaultPwmStepsDown - 1);
+  int32_t maxPwm =
+      static_cast<int32_t>((max - hal::kDefaultPwmCenter) / loopTime +
+                           hal::kDefaultPwmStepsDown - 1);
+  int32_t deadbandMaxPwm =
+      static_cast<int32_t>((deadbandMax - hal::kDefaultPwmCenter) / loopTime +
+                           hal::kDefaultPwmStepsDown - 1);
+  int32_t centerPwm =
+      static_cast<int32_t>((center - hal::kDefaultPwmCenter) / loopTime +
+                           hal::kDefaultPwmStepsDown - 1);
+  int32_t deadbandMinPwm =
+      static_cast<int32_t>((deadbandMin - hal::kDefaultPwmCenter) / loopTime +
+                           hal::kDefaultPwmStepsDown - 1);
+  int32_t minPwm =
+      static_cast<int32_t>((min - hal::kDefaultPwmCenter) / loopTime +
+                           hal::kDefaultPwmStepsDown - 1);
 
   port->maxPwm = maxPwm;
   port->deadbandMaxPwm = deadbandMaxPwm;
@@ -144,7 +161,8 @@ void HAL_SetPWMConfigRaw(HAL_DigitalHandle pwmPortHandle, int32_t maxPwm,
                          int32_t deadbandMaxPwm, int32_t centerPwm,
                          int32_t deadbandMinPwm, int32_t minPwm,
                          int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
@@ -161,7 +179,8 @@ void HAL_GetPWMConfigRaw(HAL_DigitalHandle pwmPortHandle, int32_t* maxPwm,
                          int32_t* deadbandMaxPwm, int32_t* centerPwm,
                          int32_t* deadbandMinPwm, int32_t* minPwm,
                          int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
@@ -175,7 +194,8 @@ void HAL_GetPWMConfigRaw(HAL_DigitalHandle pwmPortHandle, int32_t* maxPwm,
 
 void HAL_SetPWMEliminateDeadband(HAL_DigitalHandle pwmPortHandle,
                                  HAL_Bool eliminateDeadband, int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
@@ -185,7 +205,8 @@ void HAL_SetPWMEliminateDeadband(HAL_DigitalHandle pwmPortHandle,
 
 HAL_Bool HAL_GetPWMEliminateDeadband(HAL_DigitalHandle pwmPortHandle,
                                      int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return false;
@@ -203,16 +224,18 @@ HAL_Bool HAL_GetPWMEliminateDeadband(HAL_DigitalHandle pwmPortHandle,
  */
 void HAL_SetPWMRaw(HAL_DigitalHandle pwmPortHandle, int32_t value,
                    int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
   }
 
-  if (port->channel < tPWM::kNumHdrRegisters) {
-    pwmSystem->writeHdr(port->channel, value, status);
+  if (port->channel < hal::tPWM::kNumHdrRegisters) {
+    hal::pwmSystem->writeHdr(port->channel, value, status);
   } else {
-    pwmSystem->writeMXP(port->channel - tPWM::kNumHdrRegisters, value, status);
+    hal::pwmSystem->writeMXP(port->channel - hal::tPWM::kNumHdrRegisters, value,
+                             status);
   }
 }
 
@@ -227,7 +250,8 @@ void HAL_SetPWMRaw(HAL_DigitalHandle pwmPortHandle, int32_t value,
  */
 void HAL_SetPWMSpeed(HAL_DigitalHandle pwmPortHandle, double speed,
                      int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
@@ -237,7 +261,7 @@ void HAL_SetPWMSpeed(HAL_DigitalHandle pwmPortHandle, double speed,
     return;
   }
 
-  DigitalPort* dPort = port.get();
+  hal::DigitalPort* dPort = port.get();
 
   if (speed < -1.0) {
     speed = -1.0;
@@ -263,7 +287,7 @@ void HAL_SetPWMSpeed(HAL_DigitalHandle pwmPortHandle, double speed,
 
   if (!((rawValue >= GetMinNegativePwm(dPort)) &&
         (rawValue <= GetMaxPositivePwm(dPort))) ||
-      rawValue == kPwmDisabled) {
+      rawValue == hal::kPwmDisabled) {
     *status = HAL_PWM_SCALE_ERROR;
     return;
   }
@@ -282,7 +306,8 @@ void HAL_SetPWMSpeed(HAL_DigitalHandle pwmPortHandle, double speed,
  */
 void HAL_SetPWMPosition(HAL_DigitalHandle pwmPortHandle, double pos,
                         int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
@@ -291,7 +316,7 @@ void HAL_SetPWMPosition(HAL_DigitalHandle pwmPortHandle, double pos,
     *status = INCOMPATIBLE_STATE;
     return;
   }
-  DigitalPort* dPort = port.get();
+  hal::DigitalPort* dPort = port.get();
 
   if (pos < 0.0) {
     pos = 0.0;
@@ -305,7 +330,7 @@ void HAL_SetPWMPosition(HAL_DigitalHandle pwmPortHandle, double pos,
       (pos * static_cast<double>(GetFullRangeScaleFactor(dPort))) +
       GetMinNegativePwm(dPort));
 
-  if (rawValue == kPwmDisabled) {
+  if (rawValue == hal::kPwmDisabled) {
     *status = HAL_PWM_SCALE_ERROR;
     return;
   }
@@ -314,7 +339,7 @@ void HAL_SetPWMPosition(HAL_DigitalHandle pwmPortHandle, double pos,
 }
 
 void HAL_SetPWMDisabled(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
-  HAL_SetPWMRaw(pwmPortHandle, kPwmDisabled, status);
+  HAL_SetPWMRaw(pwmPortHandle, hal::kPwmDisabled, status);
 }
 
 /**
@@ -324,16 +349,18 @@ void HAL_SetPWMDisabled(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
  * @return The raw PWM value.
  */
 int32_t HAL_GetPWMRaw(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return 0;
   }
 
-  if (port->channel < tPWM::kNumHdrRegisters) {
-    return pwmSystem->readHdr(port->channel, status);
+  if (port->channel < hal::tPWM::kNumHdrRegisters) {
+    return hal::pwmSystem->readHdr(port->channel, status);
   } else {
-    return pwmSystem->readMXP(port->channel - tPWM::kNumHdrRegisters, status);
+    return hal::pwmSystem->readMXP(port->channel - hal::tPWM::kNumHdrRegisters,
+                                   status);
   }
 }
 
@@ -344,7 +371,8 @@ int32_t HAL_GetPWMRaw(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
  * @return The scaled PWM value.
  */
 double HAL_GetPWMSpeed(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return 0;
@@ -356,9 +384,9 @@ double HAL_GetPWMSpeed(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
 
   int32_t value = HAL_GetPWMRaw(pwmPortHandle, status);
   if (*status != 0) return 0;
-  DigitalPort* dPort = port.get();
+  hal::DigitalPort* dPort = port.get();
 
-  if (value == kPwmDisabled) {
+  if (value == hal::kPwmDisabled) {
     return 0.0;
   } else if (value > GetMaxPositivePwm(dPort)) {
     return 1.0;
@@ -382,7 +410,8 @@ double HAL_GetPWMSpeed(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
  * @return The scaled PWM value.
  */
 double HAL_GetPWMPosition(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return 0;
@@ -394,7 +423,7 @@ double HAL_GetPWMPosition(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
 
   int32_t value = HAL_GetPWMRaw(pwmPortHandle, status);
   if (*status != 0) return 0;
-  DigitalPort* dPort = port.get();
+  hal::DigitalPort* dPort = port.get();
 
   if (value < GetMinNegativePwm(dPort)) {
     return 0.0;
@@ -407,14 +436,15 @@ double HAL_GetPWMPosition(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
 }
 
 void HAL_LatchPWMZero(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
   }
 
-  pwmSystem->writeZeroLatch(port->channel, true, status);
-  pwmSystem->writeZeroLatch(port->channel, false, status);
+  hal::pwmSystem->writeZeroLatch(port->channel, true, status);
+  hal::pwmSystem->writeZeroLatch(port->channel, false, status);
 }
 
 /**
@@ -425,17 +455,19 @@ void HAL_LatchPWMZero(HAL_DigitalHandle pwmPortHandle, int32_t* status) {
  */
 void HAL_SetPWMPeriodScale(HAL_DigitalHandle pwmPortHandle, int32_t squelchMask,
                            int32_t* status) {
-  auto port = digitalChannelHandles.Get(pwmPortHandle, HAL_HandleEnum::PWM);
+  auto port =
+      hal::digitalChannelHandles.Get(pwmPortHandle, hal::HAL_HandleEnum::PWM);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
   }
 
-  if (port->channel < tPWM::kNumPeriodScaleHdrElements) {
-    pwmSystem->writePeriodScaleHdr(port->channel, squelchMask, status);
+  if (port->channel < hal::tPWM::kNumPeriodScaleHdrElements) {
+    hal::pwmSystem->writePeriodScaleHdr(port->channel, squelchMask, status);
   } else {
-    pwmSystem->writePeriodScaleMXP(
-        port->channel - tPWM::kNumPeriodScaleHdrElements, squelchMask, status);
+    hal::pwmSystem->writePeriodScaleMXP(
+        port->channel - hal::tPWM::kNumPeriodScaleHdrElements, squelchMask,
+        status);
   }
 }
 
@@ -445,8 +477,8 @@ void HAL_SetPWMPeriodScale(HAL_DigitalHandle pwmPortHandle, int32_t squelchMask,
  * @return The loop time
  */
 int32_t HAL_GetLoopTiming(int32_t* status) {
-  initializeDigital(status);
+  hal::initializeDigital(status);
   if (*status != 0) return 0;
-  return pwmSystem->readLoopTiming(status);
+  return hal::pwmSystem->readLoopTiming(status);
 }
 }

--- a/hal/lib/athena/Ports.cpp
+++ b/hal/lib/athena/Ports.cpp
@@ -9,25 +9,23 @@
 
 #include "PortsInternal.h"
 
-using namespace hal;
-
 extern "C" {
-int32_t HAL_GetNumAccumulators(void) { return kNumAccumulators; }
-int32_t HAL_GetNumAnalogTriggers(void) { return kNumAnalogTriggers; }
-int32_t HAL_GetNumAnalogInputs(void) { return kNumAnalogInputs; }
-int32_t HAL_GetNumAnalogOutputs(void) { return kNumAnalogOutputs; }
-int32_t HAL_GetNumCounters(void) { return kNumCounters; }
-int32_t HAL_GetNumDigitalHeaders(void) { return kNumDigitalHeaders; }
-int32_t HAL_GetNumPWMHeaders(void) { return kNumPWMHeaders; }
-int32_t HAL_GetNumDigitalChannels(void) { return kNumDigitalChannels; }
-int32_t HAL_GetNumPWMChannels(void) { return kNumPWMChannels; }
-int32_t HAL_GetNumDigitalPWMOutputs(void) { return kNumDigitalPWMOutputs; }
-int32_t HAL_GetNumEncoders(void) { return kNumEncoders; }
-int32_t HAL_GetNumInterrupts(void) { return kNumInterrupts; }
-int32_t HAL_GetNumRelayChannels(void) { return kNumRelayChannels; }
-int32_t HAL_GetNumRelayHeaders(void) { return kNumRelayHeaders; }
-int32_t HAL_GetNumPCMModules(void) { return kNumPCMModules; }
-int32_t HAL_GetNumSolenoidChannels(void) { return kNumSolenoidChannels; }
-int32_t HAL_GetNumPDPModules(void) { return kNumPDPModules; }
-int32_t HAL_GetNumPDPChannels(void) { return kNumPDPChannels; }
+int32_t HAL_GetNumAccumulators(void) { return hal::kNumAccumulators; }
+int32_t HAL_GetNumAnalogTriggers(void) { return hal::kNumAnalogTriggers; }
+int32_t HAL_GetNumAnalogInputs(void) { return hal::kNumAnalogInputs; }
+int32_t HAL_GetNumAnalogOutputs(void) { return hal::kNumAnalogOutputs; }
+int32_t HAL_GetNumCounters(void) { return hal::kNumCounters; }
+int32_t HAL_GetNumDigitalHeaders(void) { return hal::kNumDigitalHeaders; }
+int32_t HAL_GetNumPWMHeaders(void) { return hal::kNumPWMHeaders; }
+int32_t HAL_GetNumDigitalChannels(void) { return hal::kNumDigitalChannels; }
+int32_t HAL_GetNumPWMChannels(void) { return hal::kNumPWMChannels; }
+int32_t HAL_GetNumDigitalPWMOutputs(void) { return hal::kNumDigitalPWMOutputs; }
+int32_t HAL_GetNumEncoders(void) { return hal::kNumEncoders; }
+int32_t HAL_GetNumInterrupts(void) { return hal::kNumInterrupts; }
+int32_t HAL_GetNumRelayChannels(void) { return hal::kNumRelayChannels; }
+int32_t HAL_GetNumRelayHeaders(void) { return hal::kNumRelayHeaders; }
+int32_t HAL_GetNumPCMModules(void) { return hal::kNumPCMModules; }
+int32_t HAL_GetNumSolenoidChannels(void) { return hal::kNumSolenoidChannels; }
+int32_t HAL_GetNumPDPModules(void) { return hal::kNumPDPModules; }
+int32_t HAL_GetNumPDPChannels(void) { return hal::kNumPDPChannels; }
 }

--- a/hal/lib/athena/Power.cpp
+++ b/hal/lib/athena/Power.cpp
@@ -11,13 +11,11 @@
 
 #include "HAL/ChipObject.h"
 
-using namespace hal;
-
-static std::unique_ptr<tPower> power;
+static std::unique_ptr<hal::tPower> power;
 
 static void initializePower(int32_t* status) {
   if (power == nullptr) {
-    power.reset(tPower::create(status));
+    power.reset(hal::tPower::create(status));
   }
 }
 

--- a/hal/lib/athena/Solenoid.cpp
+++ b/hal/lib/athena/Solenoid.cpp
@@ -24,20 +24,19 @@ struct Solenoid {
 };
 }
 
-using namespace hal;
-
-static IndexedHandleResource<HAL_SolenoidHandle, Solenoid,
-                             kNumPCMModules * kNumSolenoidChannels,
-                             HAL_HandleEnum::Solenoid>
+static hal::IndexedHandleResource<HAL_SolenoidHandle, Solenoid,
+                                  hal::kNumPCMModules *
+                                      hal::kNumSolenoidChannels,
+                                  hal::HAL_HandleEnum::Solenoid>
     solenoidHandles;
 
 extern "C" {
 
 HAL_SolenoidHandle HAL_InitializeSolenoidPort(HAL_PortHandle portHandle,
                                               int32_t* status) {
-  int16_t channel = getPortHandleChannel(portHandle);
-  int16_t module = getPortHandleModule(portHandle);
-  if (channel == InvalidHandleIndex) {
+  int16_t channel = hal::getPortHandleChannel(portHandle);
+  int16_t module = hal::getPortHandleModule(portHandle);
+  if (channel == hal::InvalidHandleIndex) {
     *status = HAL_HANDLE_ERROR;
     return HAL_kInvalidHandle;
   }
@@ -48,13 +47,13 @@ HAL_SolenoidHandle HAL_InitializeSolenoidPort(HAL_PortHandle portHandle,
     return HAL_kInvalidHandle;
   }
 
-  initializePCM(module, status);
+  hal::initializePCM(module, status);
   if (*status != 0) {
     return HAL_kInvalidHandle;
   }
 
-  auto handle =
-      solenoidHandles.Allocate(module * kNumSolenoidChannels + channel, status);
+  auto handle = solenoidHandles.Allocate(
+      module * hal::kNumSolenoidChannels + channel, status);
   if (*status != 0) {
     return HAL_kInvalidHandle;
   }
@@ -74,11 +73,11 @@ void HAL_FreeSolenoidPort(HAL_SolenoidHandle solenoidPortHandle) {
 }
 
 HAL_Bool HAL_CheckSolenoidModule(int32_t module) {
-  return module < kNumPCMModules && module >= 0;
+  return module < hal::kNumPCMModules && module >= 0;
 }
 
 HAL_Bool HAL_CheckSolenoidChannel(int32_t channel) {
-  return channel < kNumSolenoidChannels && channel >= 0;
+  return channel < hal::kNumSolenoidChannels && channel >= 0;
 }
 
 HAL_Bool HAL_GetSolenoid(HAL_SolenoidHandle solenoidPortHandle,
@@ -90,16 +89,16 @@ HAL_Bool HAL_GetSolenoid(HAL_SolenoidHandle solenoidPortHandle,
   }
   bool value;
 
-  *status = PCM_modules[port->module]->GetSolenoid(port->channel, value);
+  *status = hal::PCM_modules[port->module]->GetSolenoid(port->channel, value);
 
   return value;
 }
 
 int32_t HAL_GetAllSolenoids(int32_t module, int32_t* status) {
-  if (!checkPCMInit(module, status)) return 0;
+  if (!hal::checkPCMInit(module, status)) return 0;
   uint8_t value;
 
-  *status = PCM_modules[module]->GetAllSolenoids(value);
+  *status = hal::PCM_modules[module]->GetAllSolenoids(value);
 
   return value;
 }
@@ -112,43 +111,46 @@ void HAL_SetSolenoid(HAL_SolenoidHandle solenoidPortHandle, HAL_Bool value,
     return;
   }
 
-  *status = PCM_modules[port->module]->SetSolenoid(port->channel, value);
+  *status = hal::PCM_modules[port->module]->SetSolenoid(port->channel, value);
 }
 
 void HAL_SetAllSolenoids(int32_t module, int32_t state, int32_t* status) {
-  if (!checkPCMInit(module, status)) return;
+  if (!hal::checkPCMInit(module, status)) return;
 
-  *status = PCM_modules[module]->SetAllSolenoids(state);
+  *status = hal::PCM_modules[module]->SetAllSolenoids(state);
 }
 
 int32_t HAL_GetPCMSolenoidBlackList(int32_t module, int32_t* status) {
-  if (!checkPCMInit(module, status)) return 0;
+  if (!hal::checkPCMInit(module, status)) return 0;
   uint8_t value;
 
-  *status = PCM_modules[module]->GetSolenoidBlackList(value);
+  *status = hal::PCM_modules[module]->GetSolenoidBlackList(value);
 
   return value;
 }
+
 HAL_Bool HAL_GetPCMSolenoidVoltageStickyFault(int32_t module, int32_t* status) {
-  if (!checkPCMInit(module, status)) return 0;
+  if (!hal::checkPCMInit(module, status)) return 0;
   bool value;
 
-  *status = PCM_modules[module]->GetSolenoidStickyFault(value);
+  *status = hal::PCM_modules[module]->GetSolenoidStickyFault(value);
 
   return value;
 }
+
 HAL_Bool HAL_GetPCMSolenoidVoltageFault(int32_t module, int32_t* status) {
-  if (!checkPCMInit(module, status)) return false;
+  if (!hal::checkPCMInit(module, status)) return false;
   bool value;
 
-  *status = PCM_modules[module]->GetSolenoidFault(value);
+  *status = hal::PCM_modules[module]->GetSolenoidFault(value);
 
   return value;
 }
-void HAL_ClearAllPCMStickyFaults(int32_t module, int32_t* status) {
-  if (!checkPCMInit(module, status)) return;
 
-  *status = PCM_modules[module]->ClearStickyFaults();
+void HAL_ClearAllPCMStickyFaults(int32_t module, int32_t* status) {
+  if (!hal::checkPCMInit(module, status)) return;
+
+  *status = hal::PCM_modules[module]->ClearStickyFaults();
 }
 
 }  // extern "C"

--- a/hal/lib/athena/cpp/SerialHelper.cpp
+++ b/hal/lib/athena/cpp/SerialHelper.cpp
@@ -21,17 +21,16 @@ constexpr const char* MxpResourceVISA = "ASRL2::INSTR";
 constexpr const char* OnboardResourceOS = "/dev/ttyS0";
 constexpr const char* MxpResourceOS = "/dev/ttyS1";
 
-namespace hal {
-std::string SerialHelper::m_usbNames[2]{"", ""};
+std::string hal::SerialHelper::m_usbNames[2]{"", ""};
 
-priority_mutex SerialHelper::m_nameMutex;
+hal::priority_mutex hal::SerialHelper::m_nameMutex;
 
-SerialHelper::SerialHelper() {
+hal::SerialHelper::SerialHelper() {
   viOpenDefaultRM(reinterpret_cast<ViSession*>(&m_resourceHandle));
 }
 
-std::string SerialHelper::GetVISASerialPortName(HAL_SerialPort port,
-                                                int32_t* status) {
+std::string hal::SerialHelper::GetVISASerialPortName(HAL_SerialPort port,
+                                                     int32_t* status) {
   if (port == HAL_SerialPort::HAL_SerialPort_Onboard) {
     return OnboardResourceVISA;
   } else if (port == HAL_SerialPort::HAL_SerialPort_MXP) {
@@ -57,8 +56,8 @@ std::string SerialHelper::GetVISASerialPortName(HAL_SerialPort port,
   }
 }
 
-std::string SerialHelper::GetOSSerialPortName(HAL_SerialPort port,
-                                              int32_t* status) {
+std::string hal::SerialHelper::GetOSSerialPortName(HAL_SerialPort port,
+                                                   int32_t* status) {
   if (port == HAL_SerialPort::HAL_SerialPort_Onboard) {
     return OnboardResourceOS;
   } else if (port == HAL_SerialPort::HAL_SerialPort_MXP) {
@@ -84,7 +83,8 @@ std::string SerialHelper::GetOSSerialPortName(HAL_SerialPort port,
   }
 }
 
-std::vector<std::string> SerialHelper::GetVISASerialPortList(int32_t* status) {
+std::vector<std::string> hal::SerialHelper::GetVISASerialPortList(
+    int32_t* status) {
   std::vector<std::string> retVec;
 
   // Always add 2 onboard ports
@@ -107,7 +107,8 @@ std::vector<std::string> SerialHelper::GetVISASerialPortList(int32_t* status) {
   return retVec;
 }
 
-std::vector<std::string> SerialHelper::GetOSSerialPortList(int32_t* status) {
+std::vector<std::string> hal::SerialHelper::GetOSSerialPortList(
+    int32_t* status) {
   std::vector<std::string> retVec;
 
   // Always add 2 onboard ports
@@ -130,7 +131,7 @@ std::vector<std::string> SerialHelper::GetOSSerialPortList(int32_t* status) {
   return retVec;
 }
 
-void SerialHelper::SortHubPathVector() {
+void hal::SerialHelper::SortHubPathVector() {
   m_sortedHubPath.clear();
   m_sortedHubPath = m_unsortedHubPath;
   std::sort(m_sortedHubPath.begin(), m_sortedHubPath.end(),
@@ -142,7 +143,7 @@ void SerialHelper::SortHubPathVector() {
             });
 }
 
-void SerialHelper::CoiteratedSort(
+void hal::SerialHelper::CoiteratedSort(
     llvm::SmallVectorImpl<llvm::SmallString<16>>& vec) {
   llvm::SmallVector<llvm::SmallString<16>, 4> sortedVec;
   for (auto& str : m_sortedHubPath) {
@@ -158,7 +159,7 @@ void SerialHelper::CoiteratedSort(
   vec = sortedVec;
 }
 
-void SerialHelper::QueryHubPaths(int32_t* status) {
+void hal::SerialHelper::QueryHubPaths(int32_t* status) {
   // VISA resource matching string
   const char* str = "?*";
   // Items needed for VISA
@@ -283,7 +284,8 @@ done:
   viClose(viList);
 }
 
-int32_t SerialHelper::GetIndexForPort(HAL_SerialPort port, int32_t* status) {
+int32_t hal::SerialHelper::GetIndexForPort(HAL_SerialPort port,
+                                           int32_t* status) {
   // Hold lock whenever we're using the names array
   std::lock_guard<hal::priority_mutex> lock(m_nameMutex);
 
@@ -339,5 +341,3 @@ int32_t SerialHelper::GetIndexForPort(HAL_SerialPort port, int32_t* status) {
 
   return retIndex;
 }
-
-}  // namespace hal

--- a/hal/lib/athena/cpp/priority_mutex.cpp
+++ b/hal/lib/athena/cpp/priority_mutex.cpp
@@ -7,24 +7,24 @@
 
 #include "HAL/cpp/priority_mutex.h"
 
-using namespace hal;
+void hal::priority_recursive_mutex::lock() { pthread_mutex_lock(&m_mutex); }
 
-void priority_recursive_mutex::lock() { pthread_mutex_lock(&m_mutex); }
+void hal::priority_recursive_mutex::unlock() { pthread_mutex_unlock(&m_mutex); }
 
-void priority_recursive_mutex::unlock() { pthread_mutex_unlock(&m_mutex); }
-
-bool priority_recursive_mutex::try_lock() noexcept {
+bool hal::priority_recursive_mutex::try_lock() noexcept {
   return !pthread_mutex_trylock(&m_mutex);
 }
 
-pthread_mutex_t* priority_recursive_mutex::native_handle() { return &m_mutex; }
+pthread_mutex_t* hal::priority_recursive_mutex::native_handle() {
+  return &m_mutex;
+}
 
-void priority_mutex::lock() { pthread_mutex_lock(&m_mutex); }
+void hal::priority_mutex::lock() { pthread_mutex_lock(&m_mutex); }
 
-void priority_mutex::unlock() { pthread_mutex_unlock(&m_mutex); }
+void hal::priority_mutex::unlock() { pthread_mutex_unlock(&m_mutex); }
 
-bool priority_mutex::try_lock() noexcept {
+bool hal::priority_mutex::try_lock() noexcept {
   return !pthread_mutex_trylock(&m_mutex);
 }
 
-pthread_mutex_t* priority_mutex::native_handle() { return &m_mutex; }
+pthread_mutex_t* hal::priority_mutex::native_handle() { return &m_mutex; }

--- a/wpilibc/athena/include/InterruptableSensorBase.h
+++ b/wpilibc/athena/include/InterruptableSensorBase.h
@@ -22,8 +22,8 @@ class InterruptableSensorBase : public SensorBase {
     kBoth = 0x101,
   };
 
-  InterruptableSensorBase();
   virtual ~InterruptableSensorBase() = default;
+
   virtual HAL_Handle GetPortHandleForRouting() const = 0;
   virtual AnalogTriggerType GetAnalogTriggerTypeForRouting() const = 0;
   virtual void RequestInterrupts(

--- a/wpilibc/athena/src/ADXL345_I2C.cpp
+++ b/wpilibc/athena/src/ADXL345_I2C.cpp
@@ -11,13 +11,11 @@
 #include "I2C.h"
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
-const int ADXL345_I2C::kAddress;
-const int ADXL345_I2C::kPowerCtlRegister;
-const int ADXL345_I2C::kDataFormatRegister;
-const int ADXL345_I2C::kDataRegister;
-constexpr double ADXL345_I2C::kGsPerLSB;
+const int frc::ADXL345_I2C::kAddress;
+const int frc::ADXL345_I2C::kPowerCtlRegister;
+const int frc::ADXL345_I2C::kDataFormatRegister;
+const int frc::ADXL345_I2C::kDataRegister;
+constexpr double frc::ADXL345_I2C::kGsPerLSB;
 
 /**
  * Constructs the ADXL345 Accelerometer over I2C.
@@ -26,7 +24,7 @@ constexpr double ADXL345_I2C::kGsPerLSB;
  * @param range         The range (+ or -) that the accelerometer will measure
  * @param deviceAddress The I2C address of the accelerometer (0x1D or 0x53)
  */
-ADXL345_I2C::ADXL345_I2C(I2C::Port port, Range range, int deviceAddress)
+frc::ADXL345_I2C::ADXL345_I2C(I2C::Port port, Range range, int deviceAddress)
     : m_i2c(port, deviceAddress) {
   // Turn on the measurements
   m_i2c.Write(kPowerCtlRegister, kPowerCtl_Measure);
@@ -38,16 +36,16 @@ ADXL345_I2C::ADXL345_I2C(I2C::Port port, Range range, int deviceAddress)
   LiveWindow::GetInstance()->AddSensor("ADXL345_I2C", port, this);
 }
 
-void ADXL345_I2C::SetRange(Range range) {
+void frc::ADXL345_I2C::SetRange(Range range) {
   m_i2c.Write(kDataFormatRegister,
               kDataFormat_FullRes | static_cast<uint8_t>(range));
 }
 
-double ADXL345_I2C::GetX() { return GetAcceleration(kAxis_X); }
+double frc::ADXL345_I2C::GetX() { return GetAcceleration(kAxis_X); }
 
-double ADXL345_I2C::GetY() { return GetAcceleration(kAxis_Y); }
+double frc::ADXL345_I2C::GetY() { return GetAcceleration(kAxis_Y); }
 
-double ADXL345_I2C::GetZ() { return GetAcceleration(kAxis_Z); }
+double frc::ADXL345_I2C::GetZ() { return GetAcceleration(kAxis_Z); }
 
 /**
  * Get the acceleration of one axis in Gs.
@@ -55,7 +53,7 @@ double ADXL345_I2C::GetZ() { return GetAcceleration(kAxis_Z); }
  * @param axis The axis to read from.
  * @return Acceleration of the ADXL345 in Gs.
  */
-double ADXL345_I2C::GetAcceleration(ADXL345_I2C::Axes axis) {
+double frc::ADXL345_I2C::GetAcceleration(frc::ADXL345_I2C::Axes axis) {
   int16_t rawAccel = 0;
   m_i2c.Read(kDataRegister + static_cast<int>(axis), sizeof(rawAccel),
              reinterpret_cast<uint8_t*>(&rawAccel));
@@ -68,7 +66,7 @@ double ADXL345_I2C::GetAcceleration(ADXL345_I2C::Axes axis) {
  * @return An object containing the acceleration measured on each axis of the
  *         ADXL345 in Gs.
  */
-ADXL345_I2C::AllAxes ADXL345_I2C::GetAccelerations() {
+frc::ADXL345_I2C::AllAxes frc::ADXL345_I2C::GetAccelerations() {
   AllAxes data = AllAxes();
   int16_t rawData[3];
   m_i2c.Read(kDataRegister, sizeof(rawData),
@@ -80,19 +78,19 @@ ADXL345_I2C::AllAxes ADXL345_I2C::GetAccelerations() {
   return data;
 }
 
-std::string ADXL345_I2C::GetSmartDashboardType() const {
+std::string frc::ADXL345_I2C::GetSmartDashboardType() const {
   return "3AxisAccelerometer";
 }
 
-void ADXL345_I2C::InitTable(std::shared_ptr<ITable> subtable) {
+void frc::ADXL345_I2C::InitTable(std::shared_ptr<ITable> subtable) {
   m_table = subtable;
   UpdateTable();
 }
 
-void ADXL345_I2C::UpdateTable() {
+void frc::ADXL345_I2C::UpdateTable() {
   m_table->PutNumber("X", GetX());
   m_table->PutNumber("Y", GetY());
   m_table->PutNumber("Z", GetZ());
 }
 
-std::shared_ptr<ITable> ADXL345_I2C::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::ADXL345_I2C::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/ADXL345_SPI.cpp
+++ b/wpilibc/athena/src/ADXL345_SPI.cpp
@@ -12,12 +12,10 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
-const int ADXL345_SPI::kPowerCtlRegister;
-const int ADXL345_SPI::kDataFormatRegister;
-const int ADXL345_SPI::kDataRegister;
-constexpr double ADXL345_SPI::kGsPerLSB;
+const int frc::ADXL345_SPI::kPowerCtlRegister;
+const int frc::ADXL345_SPI::kDataFormatRegister;
+const int frc::ADXL345_SPI::kDataRegister;
+constexpr double frc::ADXL345_SPI::kGsPerLSB;
 
 /**
  * Constructor.
@@ -25,7 +23,7 @@ constexpr double ADXL345_SPI::kGsPerLSB;
  * @param port  The SPI port the accelerometer is attached to
  * @param range The range (+ or -) that the accelerometer will measure
  */
-ADXL345_SPI::ADXL345_SPI(SPI::Port port, ADXL345_SPI::Range range)
+frc::ADXL345_SPI::ADXL345_SPI(SPI::Port port, frc::ADXL345_SPI::Range range)
     : m_spi(port) {
   m_spi.SetClockRate(500000);
   m_spi.SetMSBFirst();
@@ -47,7 +45,7 @@ ADXL345_SPI::ADXL345_SPI(SPI::Port port, ADXL345_SPI::Range range)
   LiveWindow::GetInstance()->AddSensor("ADXL345_SPI", port, this);
 }
 
-void ADXL345_SPI::SetRange(Range range) {
+void frc::ADXL345_SPI::SetRange(Range range) {
   uint8_t commands[2];
 
   // Specify the data format to read
@@ -56,11 +54,11 @@ void ADXL345_SPI::SetRange(Range range) {
   m_spi.Transaction(commands, commands, 2);
 }
 
-double ADXL345_SPI::GetX() { return GetAcceleration(kAxis_X); }
+double frc::ADXL345_SPI::GetX() { return GetAcceleration(kAxis_X); }
 
-double ADXL345_SPI::GetY() { return GetAcceleration(kAxis_Y); }
+double frc::ADXL345_SPI::GetY() { return GetAcceleration(kAxis_Y); }
 
-double ADXL345_SPI::GetZ() { return GetAcceleration(kAxis_Z); }
+double frc::ADXL345_SPI::GetZ() { return GetAcceleration(kAxis_Z); }
 
 /**
  * Get the acceleration of one axis in Gs.
@@ -68,7 +66,7 @@ double ADXL345_SPI::GetZ() { return GetAcceleration(kAxis_Z); }
  * @param axis The axis to read from.
  * @return Acceleration of the ADXL345 in Gs.
  */
-double ADXL345_SPI::GetAcceleration(ADXL345_SPI::Axes axis) {
+double frc::ADXL345_SPI::GetAcceleration(frc::ADXL345_SPI::Axes axis) {
   uint8_t buffer[3];
   uint8_t command[3] = {0, 0, 0};
   command[0] = (kAddress_Read | kAddress_MultiByte | kDataRegister) +
@@ -86,7 +84,7 @@ double ADXL345_SPI::GetAcceleration(ADXL345_SPI::Axes axis) {
  * @return An object containing the acceleration measured on each axis of the
  *         ADXL345 in Gs.
  */
-ADXL345_SPI::AllAxes ADXL345_SPI::GetAccelerations() {
+frc::ADXL345_SPI::AllAxes frc::ADXL345_SPI::GetAccelerations() {
   AllAxes data = AllAxes();
   uint8_t dataBuffer[7] = {0, 0, 0, 0, 0, 0, 0};
   int16_t rawData[3];
@@ -107,16 +105,16 @@ ADXL345_SPI::AllAxes ADXL345_SPI::GetAccelerations() {
   return data;
 }
 
-std::string ADXL345_SPI::GetSmartDashboardType() const {
+std::string frc::ADXL345_SPI::GetSmartDashboardType() const {
   return "3AxisAccelerometer";
 }
 
-void ADXL345_SPI::InitTable(std::shared_ptr<ITable> subtable) {
+void frc::ADXL345_SPI::InitTable(std::shared_ptr<ITable> subtable) {
   m_table = subtable;
   UpdateTable();
 }
 
-void ADXL345_SPI::UpdateTable() {
+void frc::ADXL345_SPI::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("X", GetX());
     m_table->PutNumber("Y", GetY());
@@ -124,4 +122,4 @@ void ADXL345_SPI::UpdateTable() {
   }
 }
 
-std::shared_ptr<ITable> ADXL345_SPI::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::ADXL345_SPI::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/ADXL362.cpp
+++ b/wpilibc/athena/src/ADXL362.cpp
@@ -13,8 +13,6 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
 static int kRegWrite = 0x0A;
 static int kRegRead = 0x0B;
 
@@ -37,7 +35,7 @@ static int kPowerCtl_Measure = 0x02;
  *
  * @param range The range (+ or -) that the accelerometer will measure.
  */
-ADXL362::ADXL362(Range range) : ADXL362(SPI::Port::kOnboardCS1, range) {}
+frc::ADXL362::ADXL362(Range range) : ADXL362(SPI::Port::kOnboardCS1, range) {}
 
 /**
  * Constructor.
@@ -45,7 +43,7 @@ ADXL362::ADXL362(Range range) : ADXL362(SPI::Port::kOnboardCS1, range) {}
  * @param port  The SPI port the accelerometer is attached to
  * @param range The range (+ or -) that the accelerometer will measure.
  */
-ADXL362::ADXL362(SPI::Port port, Range range) : m_spi(port) {
+frc::ADXL362::ADXL362(SPI::Port port, Range range) : m_spi(port) {
   m_spi.SetClockRate(3000000);
   m_spi.SetMSBFirst();
   m_spi.SetSampleDataOnFalling();
@@ -77,7 +75,7 @@ ADXL362::ADXL362(SPI::Port port, Range range) : m_spi(port) {
   LiveWindow::GetInstance()->AddSensor("ADXL362", port, this);
 }
 
-void ADXL362::SetRange(Range range) {
+void frc::ADXL362::SetRange(Range range) {
   if (m_gsPerLSB == 0.0) return;
 
   uint8_t commands[3];
@@ -103,11 +101,11 @@ void ADXL362::SetRange(Range range) {
   m_spi.Write(commands, 3);
 }
 
-double ADXL362::GetX() { return GetAcceleration(kAxis_X); }
+double frc::ADXL362::GetX() { return GetAcceleration(kAxis_X); }
 
-double ADXL362::GetY() { return GetAcceleration(kAxis_Y); }
+double frc::ADXL362::GetY() { return GetAcceleration(kAxis_Y); }
 
-double ADXL362::GetZ() { return GetAcceleration(kAxis_Z); }
+double frc::ADXL362::GetZ() { return GetAcceleration(kAxis_Z); }
 
 /**
  * Get the acceleration of one axis in Gs.
@@ -115,7 +113,7 @@ double ADXL362::GetZ() { return GetAcceleration(kAxis_Z); }
  * @param axis The axis to read from.
  * @return Acceleration of the ADXL362 in Gs.
  */
-double ADXL362::GetAcceleration(ADXL362::Axes axis) {
+double frc::ADXL362::GetAcceleration(frc::ADXL362::Axes axis) {
   if (m_gsPerLSB == 0.0) return 0.0;
 
   uint8_t buffer[4];
@@ -135,7 +133,7 @@ double ADXL362::GetAcceleration(ADXL362::Axes axis) {
  * @return An object containing the acceleration measured on each axis of the
  *         ADXL362 in Gs.
  */
-ADXL362::AllAxes ADXL362::GetAccelerations() {
+frc::ADXL362::AllAxes frc::ADXL362::GetAccelerations() {
   AllAxes data = AllAxes();
   if (m_gsPerLSB == 0.0) {
     data.XAxis = data.YAxis = data.ZAxis = 0.0;
@@ -162,16 +160,16 @@ ADXL362::AllAxes ADXL362::GetAccelerations() {
   return data;
 }
 
-std::string ADXL362::GetSmartDashboardType() const {
+std::string frc::ADXL362::GetSmartDashboardType() const {
   return "3AxisAccelerometer";
 }
 
-void ADXL362::InitTable(std::shared_ptr<ITable> subtable) {
+void frc::ADXL362::InitTable(std::shared_ptr<ITable> subtable) {
   m_table = subtable;
   UpdateTable();
 }
 
-void ADXL362::UpdateTable() {
+void frc::ADXL362::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("X", GetX());
     m_table->PutNumber("Y", GetY());
@@ -179,4 +177,4 @@ void ADXL362::UpdateTable() {
   }
 }
 
-std::shared_ptr<ITable> ADXL362::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::ADXL362::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/ADXRS450_Gyro.cpp
+++ b/wpilibc/athena/src/ADXRS450_Gyro.cpp
@@ -12,8 +12,6 @@
 #include "LiveWindow/LiveWindow.h"
 #include "Timer.h"
 
-using namespace frc;
-
 static constexpr double kSamplePeriod = 0.001;
 static constexpr double kCalibrationSampleTime = 5.0;
 static constexpr double kDegreePerSecondPerLSB = 0.0125;
@@ -39,7 +37,7 @@ static constexpr int kSNLowRegister = 0x10;
  * calculations are in progress, this is typically done when the robot is first
  * turned on while it's sitting at rest before the competition starts.
  */
-void ADXRS450_Gyro::Calibrate() {
+void frc::ADXRS450_Gyro::Calibrate() {
   Wait(0.1);
 
   m_spi.SetAccumulatorCenter(0);
@@ -54,14 +52,14 @@ void ADXRS450_Gyro::Calibrate() {
 /**
  * Gyro constructor on onboard CS0.
  */
-ADXRS450_Gyro::ADXRS450_Gyro() : ADXRS450_Gyro(SPI::kOnboardCS0) {}
+frc::ADXRS450_Gyro::ADXRS450_Gyro() : ADXRS450_Gyro(SPI::kOnboardCS0) {}
 
 /**
  * Gyro constructor on the specified SPI port.
  *
  * @param port The SPI port the gyro is attached to.
  */
-ADXRS450_Gyro::ADXRS450_Gyro(SPI::Port port) : m_spi(port) {
+frc::ADXRS450_Gyro::ADXRS450_Gyro(SPI::Port port) : m_spi(port) {
   m_spi.SetClockRate(3000000);
   m_spi.SetMSBFirst();
   m_spi.SetSampleDataOnRising();
@@ -100,7 +98,7 @@ static inline int BytesToIntBE(uint8_t* buf) {
   return result;
 }
 
-uint16_t ADXRS450_Gyro::ReadRegister(int reg) {
+uint16_t frc::ADXRS450_Gyro::ReadRegister(int reg) {
   int cmd = 0x80000000 | static_cast<int>(reg) << 17;
   if (!CalcParity(cmd)) cmd |= 1u;
 
@@ -123,7 +121,7 @@ uint16_t ADXRS450_Gyro::ReadRegister(int reg) {
  * significant drift in the gyro and it needs to be recalibrated after it has
  * been running.
  */
-void ADXRS450_Gyro::Reset() { m_spi.ResetAccumulator(); }
+void frc::ADXRS450_Gyro::Reset() { m_spi.ResetAccumulator(); }
 
 /**
  * Return the actual angle in degrees that the robot is currently facing.
@@ -137,7 +135,7 @@ void ADXRS450_Gyro::Reset() { m_spi.ResetAccumulator(); }
  * @return the current heading of the robot in degrees. This heading is based on
  *         integration of the returned rate from the gyro.
  */
-double ADXRS450_Gyro::GetAngle() const {
+double frc::ADXRS450_Gyro::GetAngle() const {
   return m_spi.GetAccumulatorValue() * kDegreePerSecondPerLSB * kSamplePeriod;
 }
 
@@ -148,7 +146,7 @@ double ADXRS450_Gyro::GetAngle() const {
  *
  * @return the current rate in degrees per second
  */
-double ADXRS450_Gyro::GetRate() const {
+double frc::ADXRS450_Gyro::GetRate() const {
   return static_cast<double>(m_spi.GetAccumulatorLastValue()) *
          kDegreePerSecondPerLSB;
 }

--- a/wpilibc/athena/src/AnalogAccelerometer.cpp
+++ b/wpilibc/athena/src/AnalogAccelerometer.cpp
@@ -11,12 +11,10 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
 /**
  * Common function for initializing the accelerometer.
  */
-void AnalogAccelerometer::InitAccelerometer() {
+void frc::AnalogAccelerometer::InitAccelerometer() {
   HAL_Report(HALUsageReporting::kResourceType_Accelerometer,
              m_analogInput->GetChannel());
   LiveWindow::GetInstance()->AddSensor("Accelerometer",
@@ -31,7 +29,7 @@ void AnalogAccelerometer::InitAccelerometer() {
  * @param channel The channel number for the analog input the accelerometer is
  *                connected to
  */
-AnalogAccelerometer::AnalogAccelerometer(int channel) {
+frc::AnalogAccelerometer::AnalogAccelerometer(int channel) {
   m_analogInput = std::make_shared<AnalogInput>(channel);
   InitAccelerometer();
 }
@@ -46,7 +44,7 @@ AnalogAccelerometer::AnalogAccelerometer(int channel) {
  * @param channel The existing AnalogInput object for the analog input the
  *                accelerometer is connected to
  */
-AnalogAccelerometer::AnalogAccelerometer(AnalogInput* channel)
+frc::AnalogAccelerometer::AnalogAccelerometer(AnalogInput* channel)
     : m_analogInput(channel, NullDeleter<AnalogInput>()) {
   if (channel == nullptr) {
     wpi_setWPIError(NullParameter);
@@ -65,7 +63,8 @@ AnalogAccelerometer::AnalogAccelerometer(AnalogInput* channel)
  * @param channel The existing AnalogInput object for the analog input the
  *                accelerometer is connected to
  */
-AnalogAccelerometer::AnalogAccelerometer(std::shared_ptr<AnalogInput> channel)
+frc::AnalogAccelerometer::AnalogAccelerometer(
+    std::shared_ptr<AnalogInput> channel)
     : m_analogInput(channel) {
   if (channel == nullptr) {
     wpi_setWPIError(NullParameter);
@@ -81,7 +80,7 @@ AnalogAccelerometer::AnalogAccelerometer(std::shared_ptr<AnalogInput> channel)
  *
  * @return The current acceleration of the sensor in Gs.
  */
-double AnalogAccelerometer::GetAcceleration() const {
+double frc::AnalogAccelerometer::GetAcceleration() const {
   return (m_analogInput->GetAverageVoltage() - m_zeroGVoltage) / m_voltsPerG;
 }
 
@@ -94,7 +93,7 @@ double AnalogAccelerometer::GetAcceleration() const {
  *
  * @param sensitivity The sensitivity of accelerometer in Volts per G.
  */
-void AnalogAccelerometer::SetSensitivity(double sensitivity) {
+void frc::AnalogAccelerometer::SetSensitivity(double sensitivity) {
   m_voltsPerG = sensitivity;
 }
 
@@ -106,34 +105,34 @@ void AnalogAccelerometer::SetSensitivity(double sensitivity) {
  *
  * @param zero The zero G voltage.
  */
-void AnalogAccelerometer::SetZero(double zero) { m_zeroGVoltage = zero; }
+void frc::AnalogAccelerometer::SetZero(double zero) { m_zeroGVoltage = zero; }
 
 /**
  * Get the Acceleration for the PID Source parent.
  *
  * @return The current acceleration in Gs.
  */
-double AnalogAccelerometer::PIDGet() { return GetAcceleration(); }
+double frc::AnalogAccelerometer::PIDGet() { return GetAcceleration(); }
 
-void AnalogAccelerometer::UpdateTable() {
+void frc::AnalogAccelerometer::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Value", GetAcceleration());
   }
 }
 
-void AnalogAccelerometer::StartLiveWindowMode() {}
+void frc::AnalogAccelerometer::StartLiveWindowMode() {}
 
-void AnalogAccelerometer::StopLiveWindowMode() {}
+void frc::AnalogAccelerometer::StopLiveWindowMode() {}
 
-std::string AnalogAccelerometer::GetSmartDashboardType() const {
+std::string frc::AnalogAccelerometer::GetSmartDashboardType() const {
   return "Accelerometer";
 }
 
-void AnalogAccelerometer::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::AnalogAccelerometer::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> AnalogAccelerometer::GetTable() const {
+std::shared_ptr<ITable> frc::AnalogAccelerometer::GetTable() const {
   return m_table;
 }

--- a/wpilibc/athena/src/AnalogGyro.cpp
+++ b/wpilibc/athena/src/AnalogGyro.cpp
@@ -17,13 +17,11 @@
 #include "Timer.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
-const int AnalogGyro::kOversampleBits;
-const int AnalogGyro::kAverageBits;
-constexpr double AnalogGyro::kSamplesPerSecond;
-constexpr double AnalogGyro::kCalibrationSampleTime;
-constexpr double AnalogGyro::kDefaultVoltsPerDegreePerSecond;
+const int frc::AnalogGyro::kOversampleBits;
+const int frc::AnalogGyro::kAverageBits;
+constexpr double frc::AnalogGyro::kSamplesPerSecond;
+constexpr double frc::AnalogGyro::kCalibrationSampleTime;
+constexpr double frc::AnalogGyro::kDefaultVoltsPerDegreePerSecond;
 
 /**
  * Gyro constructor using the Analog Input channel number.
@@ -31,7 +29,7 @@ constexpr double AnalogGyro::kDefaultVoltsPerDegreePerSecond;
  * @param channel The analog channel the gyro is connected to. Gyros can only
  *                be used on on-board Analog Inputs 0-1.
  */
-AnalogGyro::AnalogGyro(int channel)
+frc::AnalogGyro::AnalogGyro(int channel)
     : AnalogGyro(std::make_shared<AnalogInput>(channel)) {}
 
 /**
@@ -46,7 +44,7 @@ AnalogGyro::AnalogGyro(int channel)
  * @param channel A pointer to the AnalogInput object that the gyro is
  *                connected to.
  */
-AnalogGyro::AnalogGyro(AnalogInput* channel)
+frc::AnalogGyro::AnalogGyro(AnalogInput* channel)
     : AnalogGyro(
           std::shared_ptr<AnalogInput>(channel, NullDeleter<AnalogInput>())) {}
 
@@ -60,7 +58,7 @@ AnalogGyro::AnalogGyro(AnalogInput* channel)
  * @param channel A pointer to the AnalogInput object that the gyro is
  *                connected to.
  */
-AnalogGyro::AnalogGyro(std::shared_ptr<AnalogInput> channel)
+frc::AnalogGyro::AnalogGyro(std::shared_ptr<AnalogInput> channel)
     : m_analog(channel) {
   if (channel == nullptr) {
     wpi_setWPIError(NullParameter);
@@ -80,7 +78,7 @@ AnalogGyro::AnalogGyro(std::shared_ptr<AnalogInput> channel)
  *                value.
  * @param offset  Preset uncalibrated value to use as the gyro offset.
  */
-AnalogGyro::AnalogGyro(int channel, int center, double offset) {
+frc::AnalogGyro::AnalogGyro(int channel, int center, double offset) {
   m_analog = std::make_shared<AnalogInput>(channel);
   InitGyro();
   int32_t status = 0;
@@ -105,8 +103,8 @@ AnalogGyro::AnalogGyro(int channel, int center, double offset) {
  * @param channel A pointer to the AnalogInput object that the gyro is
  *                connected to.
  */
-AnalogGyro::AnalogGyro(std::shared_ptr<AnalogInput> channel, int center,
-                       double offset)
+frc::AnalogGyro::AnalogGyro(std::shared_ptr<AnalogInput> channel, int center,
+                            double offset)
     : m_analog(channel) {
   if (channel == nullptr) {
     wpi_setWPIError(NullParameter);
@@ -128,7 +126,7 @@ AnalogGyro::AnalogGyro(std::shared_ptr<AnalogInput> channel, int center,
  * AnalogGyro Destructor
  *
  */
-AnalogGyro::~AnalogGyro() { HAL_FreeAnalogGyro(m_gyroHandle); }
+frc::AnalogGyro::~AnalogGyro() { HAL_FreeAnalogGyro(m_gyroHandle); }
 
 /**
  * Reset the gyro.
@@ -137,7 +135,7 @@ AnalogGyro::~AnalogGyro() { HAL_FreeAnalogGyro(m_gyroHandle); }
  * significant drift in the gyro and it needs to be recalibrated after it has
  * been running.
  */
-void AnalogGyro::Reset() {
+void frc::AnalogGyro::Reset() {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_ResetAnalogGyro(m_gyroHandle, &status);
@@ -147,7 +145,7 @@ void AnalogGyro::Reset() {
 /**
  * Initialize the gyro.  Calibration is handled by Calibrate().
  */
-void AnalogGyro::InitGyro() {
+void frc::AnalogGyro::InitGyro() {
   if (StatusIsFatal()) return;
   if (m_gyroHandle == HAL_kInvalidHandle) {
     int32_t status = 0;
@@ -181,7 +179,7 @@ void AnalogGyro::InitGyro() {
                                        this);
 }
 
-void AnalogGyro::Calibrate() {
+void frc::AnalogGyro::Calibrate() {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_CalibrateAnalogGyro(m_gyroHandle, &status);
@@ -200,7 +198,7 @@ void AnalogGyro::Calibrate() {
  * @return the current heading of the robot in degrees. This heading is based on
  *         integration of the returned rate from the gyro.
  */
-double AnalogGyro::GetAngle() const {
+double frc::AnalogGyro::GetAngle() const {
   if (StatusIsFatal()) return 0.0;
   int32_t status = 0;
   double value = HAL_GetAnalogGyroAngle(m_gyroHandle, &status);
@@ -215,7 +213,7 @@ double AnalogGyro::GetAngle() const {
  *
  * @return the current rate in degrees per second
  */
-double AnalogGyro::GetRate() const {
+double frc::AnalogGyro::GetRate() const {
   if (StatusIsFatal()) return 0.0;
   int32_t status = 0;
   double value = HAL_GetAnalogGyroRate(m_gyroHandle, &status);
@@ -229,7 +227,7 @@ double AnalogGyro::GetRate() const {
  *
  * @return the current offset value
  */
-double AnalogGyro::GetOffset() const {
+double frc::AnalogGyro::GetOffset() const {
   if (StatusIsFatal()) return 0.0;
   int32_t status = 0;
   double value = HAL_GetAnalogGyroOffset(m_gyroHandle, &status);
@@ -243,7 +241,7 @@ double AnalogGyro::GetOffset() const {
  *
  * @return the current center value
  */
-int AnalogGyro::GetCenter() const {
+int frc::AnalogGyro::GetCenter() const {
   if (StatusIsFatal()) return 0;
   int32_t status = 0;
   int value = HAL_GetAnalogGyroCenter(m_gyroHandle, &status);
@@ -260,7 +258,7 @@ int AnalogGyro::GetCenter() const {
  *
  * @param voltsPerDegreePerSecond The sensitivity in Volts/degree/second
  */
-void AnalogGyro::SetSensitivity(double voltsPerDegreePerSecond) {
+void frc::AnalogGyro::SetSensitivity(double voltsPerDegreePerSecond) {
   int32_t status = 0;
   HAL_SetAnalogGyroVoltsPerDegreePerSecond(m_gyroHandle,
                                            voltsPerDegreePerSecond, &status);
@@ -276,7 +274,7 @@ void AnalogGyro::SetSensitivity(double voltsPerDegreePerSecond) {
  *
  * @param volts The size of the deadband in volts
  */
-void AnalogGyro::SetDeadband(double volts) {
+void frc::AnalogGyro::SetDeadband(double volts) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetAnalogGyroDeadband(m_gyroHandle, volts, &status);

--- a/wpilibc/athena/src/AnalogInput.cpp
+++ b/wpilibc/athena/src/AnalogInput.cpp
@@ -17,11 +17,9 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
-const int AnalogInput::kAccumulatorModuleNumber;
-const int AnalogInput::kAccumulatorNumChannels;
-const int AnalogInput::kAccumulatorChannels[] = {0, 1};
+const int frc::AnalogInput::kAccumulatorModuleNumber;
+const int frc::AnalogInput::kAccumulatorNumChannels;
+const int frc::AnalogInput::kAccumulatorChannels[] = {0, 1};
 
 /**
  * Construct an analog input.
@@ -29,7 +27,7 @@ const int AnalogInput::kAccumulatorChannels[] = {0, 1};
  * @param channel The channel number on the roboRIO to represent. 0-3 are
  *                on-board 4-7 are on the MXP port.
  */
-AnalogInput::AnalogInput(int channel) {
+frc::AnalogInput::AnalogInput(int channel) {
   llvm::SmallString<32> str;
   llvm::raw_svector_ostream buf(str);
   buf << "Analog Input " << channel;
@@ -59,7 +57,7 @@ AnalogInput::AnalogInput(int channel) {
 /**
  * Channel destructor.
  */
-AnalogInput::~AnalogInput() {
+frc::AnalogInput::~AnalogInput() {
   HAL_FreeAnalogInputPort(m_port);
   m_port = HAL_kInvalidHandle;
 }
@@ -73,7 +71,7 @@ AnalogInput::~AnalogInput() {
  *
  * @return A sample straight from this channel.
  */
-int AnalogInput::GetValue() const {
+int frc::AnalogInput::GetValue() const {
   if (StatusIsFatal()) return 0;
   int32_t status = 0;
   int value = HAL_GetAnalogValue(m_port, &status);
@@ -95,7 +93,7 @@ int AnalogInput::GetValue() const {
  *
  * @return A sample from the oversample and average engine for this channel.
  */
-int AnalogInput::GetAverageValue() const {
+int frc::AnalogInput::GetAverageValue() const {
   if (StatusIsFatal()) return 0;
   int32_t status = 0;
   int value = HAL_GetAnalogAverageValue(m_port, &status);
@@ -111,7 +109,7 @@ int AnalogInput::GetAverageValue() const {
  *
  * @return A scaled sample straight from this channel.
  */
-double AnalogInput::GetVoltage() const {
+double frc::AnalogInput::GetVoltage() const {
   if (StatusIsFatal()) return 0.0;
   int32_t status = 0;
   double voltage = HAL_GetAnalogVoltage(m_port, &status);
@@ -133,7 +131,7 @@ double AnalogInput::GetVoltage() const {
  * @return A scaled sample from the output of the oversample and average engine
  * for this channel.
  */
-double AnalogInput::GetAverageVoltage() const {
+double frc::AnalogInput::GetAverageVoltage() const {
   if (StatusIsFatal()) return 0.0;
   int32_t status = 0;
   double voltage = HAL_GetAnalogAverageVoltage(m_port, &status);
@@ -148,7 +146,7 @@ double AnalogInput::GetAverageVoltage() const {
  *
  * @return Least significant bit weight.
  */
-int AnalogInput::GetLSBWeight() const {
+int frc::AnalogInput::GetLSBWeight() const {
   if (StatusIsFatal()) return 0;
   int32_t status = 0;
   int lsbWeight = HAL_GetAnalogLSBWeight(m_port, &status);
@@ -163,7 +161,7 @@ int AnalogInput::GetLSBWeight() const {
  *
  * @return Offset constant.
  */
-int AnalogInput::GetOffset() const {
+int frc::AnalogInput::GetOffset() const {
   if (StatusIsFatal()) return 0;
   int32_t status = 0;
   int offset = HAL_GetAnalogOffset(m_port, &status);
@@ -176,7 +174,7 @@ int AnalogInput::GetOffset() const {
  *
  * @return The channel number.
  */
-int AnalogInput::GetChannel() const {
+int frc::AnalogInput::GetChannel() const {
   if (StatusIsFatal()) return 0;
   return m_channel;
 }
@@ -192,7 +190,7 @@ int AnalogInput::GetChannel() const {
  *
  * @param bits Number of bits of averaging.
  */
-void AnalogInput::SetAverageBits(int bits) {
+void frc::AnalogInput::SetAverageBits(int bits) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetAnalogAverageBits(m_port, bits, &status);
@@ -207,7 +205,7 @@ void AnalogInput::SetAverageBits(int bits) {
  *
  * @return Number of bits of averaging previously configured.
  */
-int AnalogInput::GetAverageBits() const {
+int frc::AnalogInput::GetAverageBits() const {
   int32_t status = 0;
   int averageBits = HAL_GetAnalogAverageBits(m_port, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -224,7 +222,7 @@ int AnalogInput::GetAverageBits() const {
  *
  * @param bits Number of bits of oversampling.
  */
-void AnalogInput::SetOversampleBits(int bits) {
+void frc::AnalogInput::SetOversampleBits(int bits) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetAnalogOversampleBits(m_port, bits, &status);
@@ -240,7 +238,7 @@ void AnalogInput::SetOversampleBits(int bits) {
  *
  * @return Number of bits of oversampling previously configured.
  */
-int AnalogInput::GetOversampleBits() const {
+int frc::AnalogInput::GetOversampleBits() const {
   if (StatusIsFatal()) return 0;
   int32_t status = 0;
   int oversampleBits = HAL_GetAnalogOversampleBits(m_port, &status);
@@ -253,7 +251,7 @@ int AnalogInput::GetOversampleBits() const {
  *
  * @return The analog input is attached to an accumulator.
  */
-bool AnalogInput::IsAccumulatorChannel() const {
+bool frc::AnalogInput::IsAccumulatorChannel() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool isAccum = HAL_IsAccumulatorChannel(m_port, &status);
@@ -264,7 +262,7 @@ bool AnalogInput::IsAccumulatorChannel() const {
 /**
  * Initialize the accumulator.
  */
-void AnalogInput::InitAccumulator() {
+void frc::AnalogInput::InitAccumulator() {
   if (StatusIsFatal()) return;
   m_accumulatorOffset = 0;
   int32_t status = 0;
@@ -280,7 +278,7 @@ void AnalogInput::InitAccumulator() {
  * @param initialValue The value that the accumulator should start from when
  *                     reset.
  */
-void AnalogInput::SetAccumulatorInitialValue(int64_t initialValue) {
+void frc::AnalogInput::SetAccumulatorInitialValue(int64_t initialValue) {
   if (StatusIsFatal()) return;
   m_accumulatorOffset = initialValue;
 }
@@ -288,7 +286,7 @@ void AnalogInput::SetAccumulatorInitialValue(int64_t initialValue) {
 /**
  * Resets the accumulator to the initial value.
  */
-void AnalogInput::ResetAccumulator() {
+void frc::AnalogInput::ResetAccumulator() {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_ResetAccumulator(m_port, &status);
@@ -315,7 +313,7 @@ void AnalogInput::ResetAccumulator() {
  * source from the accumulator channel. Because of this, any non-zero
  * oversample bits will affect the size of the value for this field.
  */
-void AnalogInput::SetAccumulatorCenter(int center) {
+void frc::AnalogInput::SetAccumulatorCenter(int center) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetAccumulatorCenter(m_port, center, &status);
@@ -325,7 +323,7 @@ void AnalogInput::SetAccumulatorCenter(int center) {
 /**
  * Set the accumulator's deadband.
  */
-void AnalogInput::SetAccumulatorDeadband(int deadband) {
+void frc::AnalogInput::SetAccumulatorDeadband(int deadband) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetAccumulatorDeadband(m_port, deadband, &status);
@@ -340,7 +338,7 @@ void AnalogInput::SetAccumulatorDeadband(int deadband) {
  *
  * @return The 64-bit value accumulated since the last Reset().
  */
-int64_t AnalogInput::GetAccumulatorValue() const {
+int64_t frc::AnalogInput::GetAccumulatorValue() const {
   if (StatusIsFatal()) return 0;
   int32_t status = 0;
   int64_t value = HAL_GetAccumulatorValue(m_port, &status);
@@ -356,7 +354,7 @@ int64_t AnalogInput::GetAccumulatorValue() const {
  *
  * @return The number of times samples from the channel were accumulated.
  */
-int64_t AnalogInput::GetAccumulatorCount() const {
+int64_t frc::AnalogInput::GetAccumulatorCount() const {
   if (StatusIsFatal()) return 0;
   int32_t status = 0;
   int64_t count = HAL_GetAccumulatorCount(m_port, &status);
@@ -373,7 +371,8 @@ int64_t AnalogInput::GetAccumulatorCount() const {
  * @param value Reference to the 64-bit accumulated output.
  * @param count Reference to the number of accumulation cycles.
  */
-void AnalogInput::GetAccumulatorOutput(int64_t& value, int64_t& count) const {
+void frc::AnalogInput::GetAccumulatorOutput(int64_t& value,
+                                            int64_t& count) const {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_GetAccumulatorOutput(m_port, &value, &count, &status);
@@ -389,7 +388,7 @@ void AnalogInput::GetAccumulatorOutput(int64_t& value, int64_t& count) const {
  *
  * @param samplesPerSecond The number of samples per second.
  */
-void AnalogInput::SetSampleRate(double samplesPerSecond) {
+void frc::AnalogInput::SetSampleRate(double samplesPerSecond) {
   int32_t status = 0;
   HAL_SetAnalogSampleRate(samplesPerSecond, &status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -400,7 +399,7 @@ void AnalogInput::SetSampleRate(double samplesPerSecond) {
  *
  * @return Sample rate.
  */
-double AnalogInput::GetSampleRate() {
+double frc::AnalogInput::GetSampleRate() {
   int32_t status = 0;
   double sampleRate = HAL_GetAnalogSampleRate(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -412,28 +411,28 @@ double AnalogInput::GetSampleRate() {
  *
  * @return The average voltage.
  */
-double AnalogInput::PIDGet() {
+double frc::AnalogInput::PIDGet() {
   if (StatusIsFatal()) return 0.0;
   return GetAverageVoltage();
 }
 
-void AnalogInput::UpdateTable() {
+void frc::AnalogInput::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Value", GetAverageVoltage());
   }
 }
 
-void AnalogInput::StartLiveWindowMode() {}
+void frc::AnalogInput::StartLiveWindowMode() {}
 
-void AnalogInput::StopLiveWindowMode() {}
+void frc::AnalogInput::StopLiveWindowMode() {}
 
-std::string AnalogInput::GetSmartDashboardType() const {
+std::string frc::AnalogInput::GetSmartDashboardType() const {
   return "Analog Input";
 }
 
-void AnalogInput::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::AnalogInput::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> AnalogInput::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::AnalogInput::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/AnalogOutput.cpp
+++ b/wpilibc/athena/src/AnalogOutput.cpp
@@ -16,8 +16,6 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
 /**
  * Construct an analog output on the given channel.
  *
@@ -25,7 +23,7 @@ using namespace frc;
  *
  * @param channel The channel number on the roboRIO to represent.
  */
-AnalogOutput::AnalogOutput(int channel) {
+frc::AnalogOutput::AnalogOutput(int channel) {
   llvm::SmallString<32> str;
   llvm::raw_svector_ostream buf(str);
   buf << "analog output " << channel;
@@ -59,19 +57,19 @@ AnalogOutput::AnalogOutput(int channel) {
  *
  * Frees analog output resource.
  */
-AnalogOutput::~AnalogOutput() { HAL_FreeAnalogOutputPort(m_port); }
+frc::AnalogOutput::~AnalogOutput() { HAL_FreeAnalogOutputPort(m_port); }
 
 /**
  * Get the channel of this AnalogOutput.
  */
-int AnalogOutput::GetChannel() { return m_channel; }
+int frc::AnalogOutput::GetChannel() { return m_channel; }
 
 /**
  * Set the value of the analog output.
  *
  * @param voltage The output value in Volts, from 0.0 to +5.0
  */
-void AnalogOutput::SetVoltage(double voltage) {
+void frc::AnalogOutput::SetVoltage(double voltage) {
   int32_t status = 0;
   HAL_SetAnalogOutput(m_port, voltage, &status);
 
@@ -83,7 +81,7 @@ void AnalogOutput::SetVoltage(double voltage) {
  *
  * @return The value in Volts, from 0.0 to +5.0
  */
-double AnalogOutput::GetVoltage() const {
+double frc::AnalogOutput::GetVoltage() const {
   int32_t status = 0;
   double voltage = HAL_GetAnalogOutput(m_port, &status);
 
@@ -92,23 +90,23 @@ double AnalogOutput::GetVoltage() const {
   return voltage;
 }
 
-void AnalogOutput::UpdateTable() {
+void frc::AnalogOutput::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Value", GetVoltage());
   }
 }
 
-void AnalogOutput::StartLiveWindowMode() {}
+void frc::AnalogOutput::StartLiveWindowMode() {}
 
-void AnalogOutput::StopLiveWindowMode() {}
+void frc::AnalogOutput::StopLiveWindowMode() {}
 
-std::string AnalogOutput::GetSmartDashboardType() const {
+std::string frc::AnalogOutput::GetSmartDashboardType() const {
   return "Analog Output";
 }
 
-void AnalogOutput::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::AnalogOutput::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> AnalogOutput::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::AnalogOutput::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/AnalogPotentiometer.cpp
+++ b/wpilibc/athena/src/AnalogPotentiometer.cpp
@@ -9,8 +9,6 @@
 
 #include "ControllerPower.h"
 
-using namespace frc;
-
 /**
  * Construct an Analog Potentiometer object from a channel number.
  *
@@ -21,8 +19,8 @@ using namespace frc;
  * @param offset    The angular value (in desired units) representing the
  *                  angular output at 0V.
  */
-AnalogPotentiometer::AnalogPotentiometer(int channel, double fullRange,
-                                         double offset)
+frc::AnalogPotentiometer::AnalogPotentiometer(int channel, double fullRange,
+                                              double offset)
     : m_analog_input(std::make_unique<AnalogInput>(channel)),
       m_fullRange(fullRange),
       m_offset(offset) {}
@@ -37,8 +35,8 @@ AnalogPotentiometer::AnalogPotentiometer(int channel, double fullRange,
  * @param offset    The angular value (in desired units) representing the
  *                  angular output at 0V.
  */
-AnalogPotentiometer::AnalogPotentiometer(AnalogInput* input, double fullRange,
-                                         double offset)
+frc::AnalogPotentiometer::AnalogPotentiometer(AnalogInput* input,
+                                              double fullRange, double offset)
     : m_analog_input(input, NullDeleter<AnalogInput>()),
       m_fullRange(fullRange),
       m_offset(offset) {}
@@ -53,8 +51,8 @@ AnalogPotentiometer::AnalogPotentiometer(AnalogInput* input, double fullRange,
  * @param offset    The angular value (in desired units) representing the
  *                  angular output at 0V.
  */
-AnalogPotentiometer::AnalogPotentiometer(std::shared_ptr<AnalogInput> input,
-                                         double fullRange, double offset)
+frc::AnalogPotentiometer::AnalogPotentiometer(
+    std::shared_ptr<AnalogInput> input, double fullRange, double offset)
     : m_analog_input(input), m_fullRange(fullRange), m_offset(offset) {}
 
 /**
@@ -63,7 +61,7 @@ AnalogPotentiometer::AnalogPotentiometer(std::shared_ptr<AnalogInput> input,
  * @return The current position of the potentiometer (in the units used for
  *         fullRange and offset).
  */
-double AnalogPotentiometer::Get() const {
+double frc::AnalogPotentiometer::Get() const {
   return (m_analog_input->GetVoltage() / ControllerPower::GetVoltage5V()) *
              m_fullRange +
          m_offset;
@@ -74,29 +72,29 @@ double AnalogPotentiometer::Get() const {
  *
  * @return The current reading.
  */
-double AnalogPotentiometer::PIDGet() { return Get(); }
+double frc::AnalogPotentiometer::PIDGet() { return Get(); }
 
 /**
  * @return the Smart Dashboard Type
  */
-std::string AnalogPotentiometer::GetSmartDashboardType() const {
+std::string frc::AnalogPotentiometer::GetSmartDashboardType() const {
   return "Analog Input";
 }
 
 /**
  * Live Window code, only does anything if live window is activated.
  */
-void AnalogPotentiometer::InitTable(std::shared_ptr<ITable> subtable) {
+void frc::AnalogPotentiometer::InitTable(std::shared_ptr<ITable> subtable) {
   m_table = subtable;
   UpdateTable();
 }
 
-void AnalogPotentiometer::UpdateTable() {
+void frc::AnalogPotentiometer::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Value", Get());
   }
 }
 
-std::shared_ptr<ITable> AnalogPotentiometer::GetTable() const {
+std::shared_ptr<ITable> frc::AnalogPotentiometer::GetTable() const {
   return m_table;
 }

--- a/wpilibc/athena/src/AnalogTrigger.cpp
+++ b/wpilibc/athena/src/AnalogTrigger.cpp
@@ -13,15 +13,13 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
 /**
  * Constructor for an analog trigger given a channel number.
  *
  * @param channel The channel number on the roboRIO to represent. 0-3 are
  *                on-board 4-7 are on the MXP port.
  */
-AnalogTrigger::AnalogTrigger(int channel)
+frc::AnalogTrigger::AnalogTrigger(int channel)
     : AnalogTrigger(new AnalogInput(channel)) {
   m_ownsAnalog = true;
 }
@@ -34,7 +32,7 @@ AnalogTrigger::AnalogTrigger(int channel)
  *
  * @param channel The pointer to the existing AnalogInput object
  */
-AnalogTrigger::AnalogTrigger(AnalogInput* input) {
+frc::AnalogTrigger::AnalogTrigger(AnalogInput* input) {
   m_analogInput = input;
   int32_t status = 0;
   int index = 0;
@@ -50,7 +48,7 @@ AnalogTrigger::AnalogTrigger(AnalogInput* input) {
   HAL_Report(HALUsageReporting::kResourceType_AnalogTrigger, input->m_channel);
 }
 
-AnalogTrigger::~AnalogTrigger() {
+frc::AnalogTrigger::~AnalogTrigger() {
   int32_t status = 0;
   HAL_CleanAnalogTrigger(m_trigger, &status);
 
@@ -68,7 +66,7 @@ AnalogTrigger::~AnalogTrigger() {
  * @param lower The lower limit of the trigger in ADC codes (12-bit values).
  * @param upper The upper limit of the trigger in ADC codes (12-bit values).
  */
-void AnalogTrigger::SetLimitsRaw(int lower, int upper) {
+void frc::AnalogTrigger::SetLimitsRaw(int lower, int upper) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetAnalogTriggerLimitsRaw(m_trigger, lower, upper, &status);
@@ -83,7 +81,7 @@ void AnalogTrigger::SetLimitsRaw(int lower, int upper) {
  * @param lower The lower limit of the trigger in Volts.
  * @param upper The upper limit of the trigger in Volts.
  */
-void AnalogTrigger::SetLimitsVoltage(double lower, double upper) {
+void frc::AnalogTrigger::SetLimitsVoltage(double lower, double upper) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetAnalogTriggerLimitsVoltage(m_trigger, lower, upper, &status);
@@ -99,7 +97,7 @@ void AnalogTrigger::SetLimitsVoltage(double lower, double upper) {
  * @param useAveragedValue If true, use the Averaged value, otherwise use the
  *                         instantaneous reading
  */
-void AnalogTrigger::SetAveraged(bool useAveragedValue) {
+void frc::AnalogTrigger::SetAveraged(bool useAveragedValue) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetAnalogTriggerAveraged(m_trigger, useAveragedValue, &status);
@@ -116,7 +114,7 @@ void AnalogTrigger::SetAveraged(bool useAveragedValue) {
  * @param useFilteredValue If true, use the 3 point rejection filter, otherwise
  *                         use the unfiltered value
  */
-void AnalogTrigger::SetFiltered(bool useFilteredValue) {
+void frc::AnalogTrigger::SetFiltered(bool useFilteredValue) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetAnalogTriggerFiltered(m_trigger, useFilteredValue, &status);
@@ -130,7 +128,7 @@ void AnalogTrigger::SetFiltered(bool useFilteredValue) {
  *
  * @return The index of the analog trigger.
  */
-int AnalogTrigger::GetIndex() const {
+int frc::AnalogTrigger::GetIndex() const {
   if (StatusIsFatal()) return -1;
   return m_index;
 }
@@ -142,7 +140,7 @@ int AnalogTrigger::GetIndex() const {
  *
  * @return True if the analog input is between the upper and lower limits.
  */
-bool AnalogTrigger::GetInWindow() {
+bool frc::AnalogTrigger::GetInWindow() {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool result = HAL_GetAnalogTriggerInWindow(m_trigger, &status);
@@ -160,7 +158,7 @@ bool AnalogTrigger::GetInWindow() {
  * @return True if above upper limit. False if below lower limit. If in
  *         Hysteresis, maintain previous state.
  */
-bool AnalogTrigger::GetTriggerState() {
+bool frc::AnalogTrigger::GetTriggerState() {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool result = HAL_GetAnalogTriggerTriggerState(m_trigger, &status);
@@ -177,7 +175,7 @@ bool AnalogTrigger::GetTriggerState() {
  * @param type An enum of the type of output object to create.
  * @return A pointer to a new AnalogTriggerOutput object.
  */
-std::shared_ptr<AnalogTriggerOutput> AnalogTrigger::CreateOutput(
+std::shared_ptr<frc::AnalogTriggerOutput> frc::AnalogTrigger::CreateOutput(
     AnalogTriggerType type) const {
   if (StatusIsFatal()) return nullptr;
   return std::shared_ptr<AnalogTriggerOutput>(

--- a/wpilibc/athena/src/AnalogTriggerOutput.cpp
+++ b/wpilibc/athena/src/AnalogTriggerOutput.cpp
@@ -11,8 +11,6 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
 /**
  * Create an object that represents one of the four outputs from an analog
  * trigger.
@@ -24,14 +22,14 @@ using namespace frc;
  * @param outputType An enum that specifies the output on the trigger to
  *                   represent.
  */
-AnalogTriggerOutput::AnalogTriggerOutput(const AnalogTrigger& trigger,
-                                         AnalogTriggerType outputType)
+frc::AnalogTriggerOutput::AnalogTriggerOutput(const AnalogTrigger& trigger,
+                                              AnalogTriggerType outputType)
     : m_trigger(trigger), m_outputType(outputType) {
   HAL_Report(HALUsageReporting::kResourceType_AnalogTriggerOutput,
              trigger.GetIndex(), static_cast<uint8_t>(outputType));
 }
 
-AnalogTriggerOutput::~AnalogTriggerOutput() {
+frc::AnalogTriggerOutput::~AnalogTriggerOutput() {
   if (m_interrupt != HAL_kInvalidHandle) {
     int32_t status = 0;
     HAL_CleanInterrupts(m_interrupt, &status);
@@ -45,7 +43,7 @@ AnalogTriggerOutput::~AnalogTriggerOutput() {
  *
  * @return The state of the analog trigger output.
  */
-bool AnalogTriggerOutput::Get() const {
+bool frc::AnalogTriggerOutput::Get() const {
   int32_t status = 0;
   bool result = HAL_GetAnalogTriggerOutput(
       m_trigger.m_trigger, static_cast<HAL_AnalogTriggerType>(m_outputType),
@@ -57,23 +55,24 @@ bool AnalogTriggerOutput::Get() const {
 /**
  * @return The HAL Handle to the specified source.
  */
-HAL_Handle AnalogTriggerOutput::GetPortHandleForRouting() const {
+HAL_Handle frc::AnalogTriggerOutput::GetPortHandleForRouting() const {
   return m_trigger.m_trigger;
 }
 
 /**
  * Is source an AnalogTrigger
  */
-bool AnalogTriggerOutput::IsAnalogTrigger() const { return true; }
+bool frc::AnalogTriggerOutput::IsAnalogTrigger() const { return true; }
 
 /**
  * @return The type of analog trigger output to be used.
  */
-AnalogTriggerType AnalogTriggerOutput::GetAnalogTriggerTypeForRouting() const {
+frc::AnalogTriggerType
+frc::AnalogTriggerOutput::GetAnalogTriggerTypeForRouting() const {
   return m_outputType;
 }
 
 /**
  * @return The channel of the source.
  */
-int AnalogTriggerOutput::GetChannel() const { return m_trigger.m_index; }
+int frc::AnalogTriggerOutput::GetChannel() const { return m_trigger.m_index; }

--- a/wpilibc/athena/src/BuiltInAccelerometer.cpp
+++ b/wpilibc/athena/src/BuiltInAccelerometer.cpp
@@ -12,14 +12,12 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
 /**
  * Constructor.
  *
  * @param range The range the accelerometer will measure
  */
-BuiltInAccelerometer::BuiltInAccelerometer(Range range) {
+frc::BuiltInAccelerometer::BuiltInAccelerometer(Range range) {
   SetRange(range);
 
   HAL_Report(HALUsageReporting::kResourceType_Accelerometer, 0, 0,
@@ -27,7 +25,7 @@ BuiltInAccelerometer::BuiltInAccelerometer(Range range) {
   LiveWindow::GetInstance()->AddSensor((std::string) "BuiltInAccel", 0, this);
 }
 
-void BuiltInAccelerometer::SetRange(Range range) {
+void frc::BuiltInAccelerometer::SetRange(Range range) {
   if (range == kRange_16G) {
     wpi_setWPIErrorWithContext(
         ParameterOutOfRange, "16G range not supported (use k2G, k4G, or k8G)");
@@ -41,28 +39,28 @@ void BuiltInAccelerometer::SetRange(Range range) {
 /**
  * @return The acceleration of the roboRIO along the X axis in g-forces
  */
-double BuiltInAccelerometer::GetX() { return HAL_GetAccelerometerX(); }
+double frc::BuiltInAccelerometer::GetX() { return HAL_GetAccelerometerX(); }
 
 /**
  * @return The acceleration of the roboRIO along the Y axis in g-forces
  */
-double BuiltInAccelerometer::GetY() { return HAL_GetAccelerometerY(); }
+double frc::BuiltInAccelerometer::GetY() { return HAL_GetAccelerometerY(); }
 
 /**
  * @return The acceleration of the roboRIO along the Z axis in g-forces
  */
-double BuiltInAccelerometer::GetZ() { return HAL_GetAccelerometerZ(); }
+double frc::BuiltInAccelerometer::GetZ() { return HAL_GetAccelerometerZ(); }
 
-std::string BuiltInAccelerometer::GetSmartDashboardType() const {
+std::string frc::BuiltInAccelerometer::GetSmartDashboardType() const {
   return "3AxisAccelerometer";
 }
 
-void BuiltInAccelerometer::InitTable(std::shared_ptr<ITable> subtable) {
+void frc::BuiltInAccelerometer::InitTable(std::shared_ptr<ITable> subtable) {
   m_table = subtable;
   UpdateTable();
 }
 
-void BuiltInAccelerometer::UpdateTable() {
+void frc::BuiltInAccelerometer::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("X", GetX());
     m_table->PutNumber("Y", GetY());
@@ -70,6 +68,6 @@ void BuiltInAccelerometer::UpdateTable() {
   }
 }
 
-std::shared_ptr<ITable> BuiltInAccelerometer::GetTable() const {
+std::shared_ptr<ITable> frc::BuiltInAccelerometer::GetTable() const {
   return m_table;
 }

--- a/wpilibc/athena/src/CameraServer.cpp
+++ b/wpilibc/athena/src/CameraServer.cpp
@@ -13,9 +13,7 @@
 #include "llvm/raw_ostream.h"
 #include "ntcore_cpp.h"
 
-using namespace frc;
-
-CameraServer* CameraServer::GetInstance() {
+frc::CameraServer* frc::CameraServer::GetInstance() {
   static CameraServer instance;
   return &instance;
 }
@@ -58,12 +56,12 @@ static std::string MakeStreamValue(llvm::StringRef address, int port) {
   return rv;
 }
 
-std::shared_ptr<ITable> CameraServer::GetSourceTable(CS_Source source) {
+std::shared_ptr<ITable> frc::CameraServer::GetSourceTable(CS_Source source) {
   std::lock_guard<std::mutex> lock(m_mutex);
   return m_tables.lookup(source);
 }
 
-std::vector<std::string> CameraServer::GetSinkStreamValues(CS_Sink sink) {
+std::vector<std::string> frc::CameraServer::GetSinkStreamValues(CS_Sink sink) {
   CS_Status status = 0;
 
   // Ignore all but MjpegServer
@@ -92,7 +90,8 @@ std::vector<std::string> CameraServer::GetSinkStreamValues(CS_Sink sink) {
   return values;
 }
 
-std::vector<std::string> CameraServer::GetSourceStreamValues(CS_Source source) {
+std::vector<std::string> frc::CameraServer::GetSourceStreamValues(
+    CS_Source source) {
   CS_Status status = 0;
 
   // Ignore all but HttpCamera
@@ -120,7 +119,7 @@ std::vector<std::string> CameraServer::GetSourceStreamValues(CS_Source source) {
   return values;
 }
 
-void CameraServer::UpdateStreamValues() {
+void frc::CameraServer::UpdateStreamValues() {
   std::lock_guard<std::mutex> lock(m_mutex);
   // Over all the sinks...
   for (const auto& i : m_sinks) {
@@ -307,7 +306,7 @@ static void PutSourcePropertyValue(ITable* table, const cs::VideoEvent& event,
   }
 }
 
-CameraServer::CameraServer()
+frc::CameraServer::CameraServer()
     : m_publishTable{NetworkTable::GetTable(kPublishName)},
       m_nextPort(kBasePort) {
   // We publish sources to NetworkTables using the following structure:
@@ -483,11 +482,11 @@ CameraServer::CameraServer()
       NT_NOTIFY_IMMEDIATE | NT_NOTIFY_UPDATE);
 }
 
-cs::UsbCamera CameraServer::StartAutomaticCapture() {
+cs::UsbCamera frc::CameraServer::StartAutomaticCapture() {
   return StartAutomaticCapture(m_defaultUsbDevice++);
 }
 
-cs::UsbCamera CameraServer::StartAutomaticCapture(int dev) {
+cs::UsbCamera frc::CameraServer::StartAutomaticCapture(int dev) {
   llvm::SmallString<64> buf;
   llvm::raw_svector_ostream name{buf};
   name << "USB Camera " << dev;
@@ -497,65 +496,66 @@ cs::UsbCamera CameraServer::StartAutomaticCapture(int dev) {
   return camera;
 }
 
-cs::UsbCamera CameraServer::StartAutomaticCapture(llvm::StringRef name,
-                                                  int dev) {
+cs::UsbCamera frc::CameraServer::StartAutomaticCapture(llvm::StringRef name,
+                                                       int dev) {
   cs::UsbCamera camera{name, dev};
   StartAutomaticCapture(camera);
   return camera;
 }
 
-cs::UsbCamera CameraServer::StartAutomaticCapture(llvm::StringRef name,
-                                                  llvm::StringRef path) {
+cs::UsbCamera frc::CameraServer::StartAutomaticCapture(llvm::StringRef name,
+                                                       llvm::StringRef path) {
   cs::UsbCamera camera{name, path};
   StartAutomaticCapture(camera);
   return camera;
 }
 
-cs::AxisCamera CameraServer::AddAxisCamera(llvm::StringRef host) {
+cs::AxisCamera frc::CameraServer::AddAxisCamera(llvm::StringRef host) {
   return AddAxisCamera("Axis Camera", host);
 }
 
-cs::AxisCamera CameraServer::AddAxisCamera(const char* host) {
+cs::AxisCamera frc::CameraServer::AddAxisCamera(const char* host) {
   return AddAxisCamera("Axis Camera", host);
 }
 
-cs::AxisCamera CameraServer::AddAxisCamera(const std::string& host) {
+cs::AxisCamera frc::CameraServer::AddAxisCamera(const std::string& host) {
   return AddAxisCamera("Axis Camera", host);
 }
 
-cs::AxisCamera CameraServer::AddAxisCamera(llvm::ArrayRef<std::string> hosts) {
+cs::AxisCamera frc::CameraServer::AddAxisCamera(
+    llvm::ArrayRef<std::string> hosts) {
   return AddAxisCamera("Axis Camera", hosts);
 }
 
-cs::AxisCamera CameraServer::AddAxisCamera(llvm::StringRef name,
-                                           llvm::StringRef host) {
+cs::AxisCamera frc::CameraServer::AddAxisCamera(llvm::StringRef name,
+                                                llvm::StringRef host) {
   cs::AxisCamera camera{name, host};
   StartAutomaticCapture(camera);
   return camera;
 }
 
-cs::AxisCamera CameraServer::AddAxisCamera(llvm::StringRef name,
-                                           const char* host) {
+cs::AxisCamera frc::CameraServer::AddAxisCamera(llvm::StringRef name,
+                                                const char* host) {
   cs::AxisCamera camera{name, host};
   StartAutomaticCapture(camera);
   return camera;
 }
 
-cs::AxisCamera CameraServer::AddAxisCamera(llvm::StringRef name,
-                                           const std::string& host) {
+cs::AxisCamera frc::CameraServer::AddAxisCamera(llvm::StringRef name,
+                                                const std::string& host) {
   cs::AxisCamera camera{name, host};
   StartAutomaticCapture(camera);
   return camera;
 }
 
-cs::AxisCamera CameraServer::AddAxisCamera(llvm::StringRef name,
-                                           llvm::ArrayRef<std::string> hosts) {
+cs::AxisCamera frc::CameraServer::AddAxisCamera(
+    llvm::StringRef name, llvm::ArrayRef<std::string> hosts) {
   cs::AxisCamera camera{name, hosts};
   StartAutomaticCapture(camera);
   return camera;
 }
 
-void CameraServer::StartAutomaticCapture(const cs::VideoSource& camera) {
+void frc::CameraServer::StartAutomaticCapture(const cs::VideoSource& camera) {
   llvm::SmallString<64> name{"serve_"};
   name += camera.GetName();
 
@@ -564,7 +564,7 @@ void CameraServer::StartAutomaticCapture(const cs::VideoSource& camera) {
   server.SetSource(camera);
 }
 
-cs::CvSink CameraServer::GetVideo() {
+cs::CvSink frc::CameraServer::GetVideo() {
   cs::VideoSource source;
   {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -582,7 +582,7 @@ cs::CvSink CameraServer::GetVideo() {
   return GetVideo(std::move(source));
 }
 
-cs::CvSink CameraServer::GetVideo(const cs::VideoSource& camera) {
+cs::CvSink frc::CameraServer::GetVideo(const cs::VideoSource& camera) {
   llvm::SmallString<64> name{"opencv_"};
   name += camera.GetName();
 
@@ -608,7 +608,7 @@ cs::CvSink CameraServer::GetVideo(const cs::VideoSource& camera) {
   return newsink;
 }
 
-cs::CvSink CameraServer::GetVideo(llvm::StringRef name) {
+cs::CvSink frc::CameraServer::GetVideo(llvm::StringRef name) {
   cs::VideoSource source;
   {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -625,14 +625,14 @@ cs::CvSink CameraServer::GetVideo(llvm::StringRef name) {
   return GetVideo(source);
 }
 
-cs::CvSource CameraServer::PutVideo(llvm::StringRef name, int width,
-                                    int height) {
+cs::CvSource frc::CameraServer::PutVideo(llvm::StringRef name, int width,
+                                         int height) {
   cs::CvSource source{name, cs::VideoMode::kMJPEG, width, height, 30};
   StartAutomaticCapture(source);
   return source;
 }
 
-cs::MjpegServer CameraServer::AddServer(llvm::StringRef name) {
+cs::MjpegServer frc::CameraServer::AddServer(llvm::StringRef name) {
   int port;
   {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -641,23 +641,23 @@ cs::MjpegServer CameraServer::AddServer(llvm::StringRef name) {
   return AddServer(name, port);
 }
 
-cs::MjpegServer CameraServer::AddServer(llvm::StringRef name, int port) {
+cs::MjpegServer frc::CameraServer::AddServer(llvm::StringRef name, int port) {
   cs::MjpegServer server{name, port};
   AddServer(server);
   return server;
 }
 
-void CameraServer::AddServer(const cs::VideoSink& server) {
+void frc::CameraServer::AddServer(const cs::VideoSink& server) {
   std::lock_guard<std::mutex> lock(m_mutex);
   m_sinks.emplace_second(server.GetName(), server);
 }
 
-void CameraServer::RemoveServer(llvm::StringRef name) {
+void frc::CameraServer::RemoveServer(llvm::StringRef name) {
   std::lock_guard<std::mutex> lock(m_mutex);
   m_sinks.erase(name);
 }
 
-cs::VideoSink CameraServer::GetServer() {
+cs::VideoSink frc::CameraServer::GetServer() {
   llvm::SmallString<64> name;
   {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -671,7 +671,7 @@ cs::VideoSink CameraServer::GetServer() {
   return GetServer(name);
 }
 
-cs::VideoSink CameraServer::GetServer(llvm::StringRef name) {
+cs::VideoSink frc::CameraServer::GetServer(llvm::StringRef name) {
   std::lock_guard<std::mutex> lock(m_mutex);
   auto it = m_sinks.find(name);
   if (it == m_sinks.end()) {
@@ -684,19 +684,19 @@ cs::VideoSink CameraServer::GetServer(llvm::StringRef name) {
   return it->second;
 }
 
-void CameraServer::AddCamera(const cs::VideoSource& camera) {
+void frc::CameraServer::AddCamera(const cs::VideoSource& camera) {
   std::string name = camera.GetName();
   std::lock_guard<std::mutex> lock(m_mutex);
   if (m_primarySourceName.empty()) m_primarySourceName = name;
   m_sources.emplace_second(name, camera);
 }
 
-void CameraServer::RemoveCamera(llvm::StringRef name) {
+void frc::CameraServer::RemoveCamera(llvm::StringRef name) {
   std::lock_guard<std::mutex> lock(m_mutex);
   m_sources.erase(name);
 }
 
-void CameraServer::SetSize(int size) {
+void frc::CameraServer::SetSize(int size) {
   std::lock_guard<std::mutex> lock(m_mutex);
   if (m_primarySourceName.empty()) return;
   auto it = m_sources.find(m_primarySourceName);

--- a/wpilibc/athena/src/Compressor.cpp
+++ b/wpilibc/athena/src/Compressor.cpp
@@ -13,14 +13,12 @@
 #include "HAL/Solenoid.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
 /**
  * Constructor.
  *
  * @param module The PCM ID to use (0-62)
  */
-Compressor::Compressor(int pcmID) : m_module(pcmID) {
+frc::Compressor::Compressor(int pcmID) : m_module(pcmID) {
   int32_t status = 0;
   m_compressorHandle = HAL_InitializeCompressor(m_module, &status);
   if (status != 0) {
@@ -35,7 +33,7 @@ Compressor::Compressor(int pcmID) : m_module(pcmID) {
  * Starts closed-loop control. Note that closed loop control is enabled by
  * default.
  */
-void Compressor::Start() {
+void frc::Compressor::Start() {
   if (StatusIsFatal()) return;
   SetClosedLoopControl(true);
 }
@@ -44,7 +42,7 @@ void Compressor::Start() {
  * Stops closed-loop control. Note that closed loop control is enabled by
  * default.
  */
-void Compressor::Stop() {
+void frc::Compressor::Stop() {
   if (StatusIsFatal()) return;
   SetClosedLoopControl(false);
 }
@@ -54,7 +52,7 @@ void Compressor::Stop() {
  *
  * @return true if the compressor is on
  */
-bool Compressor::Enabled() const {
+bool frc::Compressor::Enabled() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value;
@@ -73,7 +71,7 @@ bool Compressor::Enabled() const {
  *
  * @return true if pressure is low
  */
-bool Compressor::GetPressureSwitchValue() const {
+bool frc::Compressor::GetPressureSwitchValue() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value;
@@ -92,7 +90,7 @@ bool Compressor::GetPressureSwitchValue() const {
  *
  * @return The current through the compressor, in amps
  */
-double Compressor::GetCompressorCurrent() const {
+double frc::Compressor::GetCompressorCurrent() const {
   if (StatusIsFatal()) return 0;
   int32_t status = 0;
   double value;
@@ -113,7 +111,7 @@ double Compressor::GetCompressorCurrent() const {
  * @param on Set to true to enable closed loop control of the compressor. False
  *           to disable.
  */
-void Compressor::SetClosedLoopControl(bool on) {
+void frc::Compressor::SetClosedLoopControl(bool on) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
 
@@ -131,7 +129,7 @@ void Compressor::SetClosedLoopControl(bool on) {
  * @return True if closed loop control of the compressor is enabled. False if
  *         disabled.
  */
-bool Compressor::GetClosedLoopControl() const {
+bool frc::Compressor::GetClosedLoopControl() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value;
@@ -151,7 +149,7 @@ bool Compressor::GetClosedLoopControl() const {
  * @return true if PCM is in fault state : Compressor Drive is
  *         disabled due to compressor current being too high.
  */
-bool Compressor::GetCompressorCurrentTooHighFault() const {
+bool frc::Compressor::GetCompressorCurrentTooHighFault() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value;
@@ -175,7 +173,7 @@ bool Compressor::GetCompressorCurrentTooHighFault() const {
  * @return true if PCM sticky fault is set : Compressor Drive is
  *         disabled due to compressor current being too high.
  */
-bool Compressor::GetCompressorCurrentTooHighStickyFault() const {
+bool frc::Compressor::GetCompressorCurrentTooHighStickyFault() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value;
@@ -200,7 +198,7 @@ bool Compressor::GetCompressorCurrentTooHighStickyFault() const {
  * @return true if PCM sticky fault is set : Compressor output
  *         appears to be shorted.
  */
-bool Compressor::GetCompressorShortedStickyFault() const {
+bool frc::Compressor::GetCompressorShortedStickyFault() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value;
@@ -220,7 +218,7 @@ bool Compressor::GetCompressorShortedStickyFault() const {
  * @return true if PCM is in fault state : Compressor output
  *         appears to be shorted.
  */
-bool Compressor::GetCompressorShortedFault() const {
+bool frc::Compressor::GetCompressorShortedFault() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value;
@@ -243,7 +241,7 @@ bool Compressor::GetCompressorShortedFault() const {
  * @return true if PCM sticky fault is set : Compressor does not
  *         appear to be wired, i.e. compressor is not drawing enough current.
  */
-bool Compressor::GetCompressorNotConnectedStickyFault() const {
+bool frc::Compressor::GetCompressorNotConnectedStickyFault() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value;
@@ -263,7 +261,7 @@ bool Compressor::GetCompressorNotConnectedStickyFault() const {
  * @return true if PCM is in fault state : Compressor does not
  *         appear to be wired, i.e. compressor is not drawing enough current.
  */
-bool Compressor::GetCompressorNotConnectedFault() const {
+bool frc::Compressor::GetCompressorNotConnectedFault() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value;
@@ -287,7 +285,7 @@ bool Compressor::GetCompressorNotConnectedFault() const {
  *
  * If no sticky faults are set then this call will have no effect.
  */
-void Compressor::ClearAllPCMStickyFaults() {
+void frc::Compressor::ClearAllPCMStickyFaults() {
   if (StatusIsFatal()) return;
   int32_t status = 0;
 
@@ -298,28 +296,31 @@ void Compressor::ClearAllPCMStickyFaults() {
   }
 }
 
-void Compressor::UpdateTable() {
+void frc::Compressor::UpdateTable() {
   if (m_table) {
     m_table->PutBoolean("Enabled", Enabled());
     m_table->PutBoolean("Pressure switch", GetPressureSwitchValue());
   }
 }
 
-void Compressor::StartLiveWindowMode() {}
+void frc::Compressor::StartLiveWindowMode() {}
 
-void Compressor::StopLiveWindowMode() {}
+void frc::Compressor::StopLiveWindowMode() {}
 
-std::string Compressor::GetSmartDashboardType() const { return "Compressor"; }
+std::string frc::Compressor::GetSmartDashboardType() const {
+  return "Compressor";
+}
 
-void Compressor::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::Compressor::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> Compressor::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Compressor::GetTable() const { return m_table; }
 
-void Compressor::ValueChanged(ITable* source, llvm::StringRef key,
-                              std::shared_ptr<nt::Value> value, bool isNew) {
+void frc::Compressor::ValueChanged(ITable* source, llvm::StringRef key,
+                                   std::shared_ptr<nt::Value> value,
+                                   bool isNew) {
   if (!value->IsBoolean()) return;
   if (value->GetBoolean())
     Start();

--- a/wpilibc/athena/src/ControllerPower.cpp
+++ b/wpilibc/athena/src/ControllerPower.cpp
@@ -13,14 +13,12 @@
 #include "HAL/HAL.h"
 #include "HAL/Power.h"
 
-using namespace frc;
-
 /**
  * Get the input voltage to the robot controller.
  *
  * @return The controller input voltage value in Volts
  */
-double ControllerPower::GetInputVoltage() {
+double frc::ControllerPower::GetInputVoltage() {
   int32_t status = 0;
   double retVal = HAL_GetVinVoltage(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -32,7 +30,7 @@ double ControllerPower::GetInputVoltage() {
  *
  * @return The controller input current value in Amps
  */
-double ControllerPower::GetInputCurrent() {
+double frc::ControllerPower::GetInputCurrent() {
   int32_t status = 0;
   double retVal = HAL_GetVinCurrent(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -44,7 +42,7 @@ double ControllerPower::GetInputCurrent() {
  *
  * @return The controller 6V rail voltage value in Volts
  */
-double ControllerPower::GetVoltage6V() {
+double frc::ControllerPower::GetVoltage6V() {
   int32_t status = 0;
   double retVal = HAL_GetUserVoltage6V(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -56,7 +54,7 @@ double ControllerPower::GetVoltage6V() {
  *
  * @return The controller 6V rail output current value in Amps
  */
-double ControllerPower::GetCurrent6V() {
+double frc::ControllerPower::GetCurrent6V() {
   int32_t status = 0;
   double retVal = HAL_GetUserCurrent6V(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -69,7 +67,7 @@ double ControllerPower::GetCurrent6V() {
  *
  * @return The controller 6V rail enabled value. True for enabled.
  */
-bool ControllerPower::GetEnabled6V() {
+bool frc::ControllerPower::GetEnabled6V() {
   int32_t status = 0;
   bool retVal = HAL_GetUserActive6V(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -82,7 +80,7 @@ bool ControllerPower::GetEnabled6V() {
  *
  * @return The number of faults.
  */
-int ControllerPower::GetFaultCount6V() {
+int frc::ControllerPower::GetFaultCount6V() {
   int32_t status = 0;
   int retVal = HAL_GetUserCurrentFaults6V(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -94,7 +92,7 @@ int ControllerPower::GetFaultCount6V() {
  *
  * @return The controller 5V rail voltage value in Volts
  */
-double ControllerPower::GetVoltage5V() {
+double frc::ControllerPower::GetVoltage5V() {
   int32_t status = 0;
   double retVal = HAL_GetUserVoltage5V(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -106,7 +104,7 @@ double ControllerPower::GetVoltage5V() {
  *
  * @return The controller 5V rail output current value in Amps
  */
-double ControllerPower::GetCurrent5V() {
+double frc::ControllerPower::GetCurrent5V() {
   int32_t status = 0;
   double retVal = HAL_GetUserCurrent5V(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -119,7 +117,7 @@ double ControllerPower::GetCurrent5V() {
  *
  * @return The controller 5V rail enabled value. True for enabled.
  */
-bool ControllerPower::GetEnabled5V() {
+bool frc::ControllerPower::GetEnabled5V() {
   int32_t status = 0;
   bool retVal = HAL_GetUserActive5V(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -132,7 +130,7 @@ bool ControllerPower::GetEnabled5V() {
  *
  * @return The number of faults
  */
-int ControllerPower::GetFaultCount5V() {
+int frc::ControllerPower::GetFaultCount5V() {
   int32_t status = 0;
   int retVal = HAL_GetUserCurrentFaults5V(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -144,7 +142,7 @@ int ControllerPower::GetFaultCount5V() {
  *
  * @return The controller 3.3V rail voltage value in Volts
  */
-double ControllerPower::GetVoltage3V3() {
+double frc::ControllerPower::GetVoltage3V3() {
   int32_t status = 0;
   double retVal = HAL_GetUserVoltage3V3(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -156,7 +154,7 @@ double ControllerPower::GetVoltage3V3() {
  *
  * @return The controller 3.3V rail output current value in Amps
  */
-double ControllerPower::GetCurrent3V3() {
+double frc::ControllerPower::GetCurrent3V3() {
   int32_t status = 0;
   double retVal = HAL_GetUserCurrent3V3(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -169,7 +167,7 @@ double ControllerPower::GetCurrent3V3() {
  *
  * @return The controller 3.3V rail enabled value. True for enabled.
  */
-bool ControllerPower::GetEnabled3V3() {
+bool frc::ControllerPower::GetEnabled3V3() {
   int32_t status = 0;
   bool retVal = HAL_GetUserActive3V3(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -182,7 +180,7 @@ bool ControllerPower::GetEnabled3V3() {
  *
  * @return The number of faults
  */
-int ControllerPower::GetFaultCount3V3() {
+int frc::ControllerPower::GetFaultCount3V3() {
   int32_t status = 0;
   int retVal = HAL_GetUserCurrentFaults3V3(&status);
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));

--- a/wpilibc/athena/src/Counter.cpp
+++ b/wpilibc/athena/src/Counter.cpp
@@ -12,8 +12,6 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
 /**
  * Create an instance of a counter where no sources are selected.
  *
@@ -27,7 +25,7 @@ using namespace frc;
  *
  * @param mode The counter mode
  */
-Counter::Counter(Mode mode) {
+frc::Counter::Counter(Mode mode) {
   int32_t status = 0;
   m_counter = HAL_InitializeCounter((HAL_Counter_Mode)mode, &m_index, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -49,7 +47,7 @@ Counter::Counter(Mode mode) {
  * @param source A pointer to the existing DigitalSource object. It will be set
  *               as the Up Source.
  */
-Counter::Counter(DigitalSource* source) : Counter(kTwoPulse) {
+frc::Counter::Counter(DigitalSource* source) : Counter(kTwoPulse) {
   SetUpSource(source);
   ClearDownSource();
 }
@@ -67,7 +65,8 @@ Counter::Counter(DigitalSource* source) : Counter(kTwoPulse) {
  * @param source A pointer to the existing DigitalSource object. It will be
  *               set as the Up Source.
  */
-Counter::Counter(std::shared_ptr<DigitalSource> source) : Counter(kTwoPulse) {
+frc::Counter::Counter(std::shared_ptr<DigitalSource> source)
+    : Counter(kTwoPulse) {
   SetUpSource(source);
   ClearDownSource();
 }
@@ -82,7 +81,7 @@ Counter::Counter(std::shared_ptr<DigitalSource> source) : Counter(kTwoPulse) {
  * @param channel The DIO channel to use as the up source. 0-9 are on-board,
  *                10-25 are on the MXP
  */
-Counter::Counter(int channel) : Counter(kTwoPulse) {
+frc::Counter::Counter(int channel) : Counter(kTwoPulse) {
   SetUpSource(channel);
   ClearDownSource();
 }
@@ -97,7 +96,7 @@ Counter::Counter(int channel) : Counter(kTwoPulse) {
  *
  * @param trigger The reference to the existing AnalogTrigger object.
  */
-Counter::Counter(const AnalogTrigger& trigger) : Counter(kTwoPulse) {
+frc::Counter::Counter(const AnalogTrigger& trigger) : Counter(kTwoPulse) {
   SetUpSource(trigger.CreateOutput(AnalogTriggerType::kState));
   ClearDownSource();
 }
@@ -113,8 +112,8 @@ Counter::Counter(const AnalogTrigger& trigger) : Counter(kTwoPulse) {
  *                     source
  * @param inverted     True to invert the output (reverse the direction)
  */
-Counter::Counter(EncodingType encodingType, DigitalSource* upSource,
-                 DigitalSource* downSource, bool inverted)
+frc::Counter::Counter(EncodingType encodingType, DigitalSource* upSource,
+                      DigitalSource* downSource, bool inverted)
     : Counter(encodingType, std::shared_ptr<DigitalSource>(
                                 upSource, NullDeleter<DigitalSource>()),
               std::shared_ptr<DigitalSource>(downSource,
@@ -132,9 +131,9 @@ Counter::Counter(EncodingType encodingType, DigitalSource* upSource,
  *                     source
  * @param inverted     True to invert the output (reverse the direction)
  */
-Counter::Counter(EncodingType encodingType,
-                 std::shared_ptr<DigitalSource> upSource,
-                 std::shared_ptr<DigitalSource> downSource, bool inverted)
+frc::Counter::Counter(EncodingType encodingType,
+                      std::shared_ptr<DigitalSource> upSource,
+                      std::shared_ptr<DigitalSource> downSource, bool inverted)
     : Counter(kExternalDirection) {
   if (encodingType != k1X && encodingType != k2X) {
     wpi_setWPIErrorWithContext(
@@ -161,7 +160,7 @@ Counter::Counter(EncodingType encodingType,
 /**
  * Delete the Counter object.
  */
-Counter::~Counter() {
+frc::Counter::~Counter() {
   SetUpdateWhenEmpty(true);
 
   int32_t status = 0;
@@ -176,7 +175,7 @@ Counter::~Counter() {
  * @param channel The DIO channel to use as the up source. 0-9 are on-board,
  *                10-25 are on the MXP
  */
-void Counter::SetUpSource(int channel) {
+void frc::Counter::SetUpSource(int channel) {
   if (StatusIsFatal()) return;
   SetUpSource(std::make_shared<DigitalInput>(channel));
 }
@@ -187,8 +186,8 @@ void Counter::SetUpSource(int channel) {
  * @param analogTrigger The analog trigger object that is used for the Up Source
  * @param triggerType   The analog trigger output that will trigger the counter.
  */
-void Counter::SetUpSource(AnalogTrigger* analogTrigger,
-                          AnalogTriggerType triggerType) {
+void frc::Counter::SetUpSource(AnalogTrigger* analogTrigger,
+                               AnalogTriggerType triggerType) {
   SetUpSource(std::shared_ptr<AnalogTrigger>(analogTrigger,
                                              NullDeleter<AnalogTrigger>()),
               triggerType);
@@ -200,8 +199,8 @@ void Counter::SetUpSource(AnalogTrigger* analogTrigger,
  * @param analogTrigger The analog trigger object that is used for the Up Source
  * @param triggerType   The analog trigger output that will trigger the counter.
  */
-void Counter::SetUpSource(std::shared_ptr<AnalogTrigger> analogTrigger,
-                          AnalogTriggerType triggerType) {
+void frc::Counter::SetUpSource(std::shared_ptr<AnalogTrigger> analogTrigger,
+                               AnalogTriggerType triggerType) {
   if (StatusIsFatal()) return;
   SetUpSource(analogTrigger->CreateOutput(triggerType));
 }
@@ -213,7 +212,7 @@ void Counter::SetUpSource(std::shared_ptr<AnalogTrigger> analogTrigger,
  *
  * @param source Pointer to the DigitalSource object to set as the up source
  */
-void Counter::SetUpSource(std::shared_ptr<DigitalSource> source) {
+void frc::Counter::SetUpSource(std::shared_ptr<DigitalSource> source) {
   if (StatusIsFatal()) return;
   m_upSource = source;
   if (m_upSource->StatusIsFatal()) {
@@ -228,7 +227,7 @@ void Counter::SetUpSource(std::shared_ptr<DigitalSource> source) {
   }
 }
 
-void Counter::SetUpSource(DigitalSource* source) {
+void frc::Counter::SetUpSource(DigitalSource* source) {
   SetUpSource(
       std::shared_ptr<DigitalSource>(source, NullDeleter<DigitalSource>()));
 }
@@ -240,7 +239,7 @@ void Counter::SetUpSource(DigitalSource* source) {
  *
  * @param source Reference to the DigitalSource object to set as the up source
  */
-void Counter::SetUpSource(DigitalSource& source) {
+void frc::Counter::SetUpSource(DigitalSource& source) {
   SetUpSource(
       std::shared_ptr<DigitalSource>(&source, NullDeleter<DigitalSource>()));
 }
@@ -253,7 +252,7 @@ void Counter::SetUpSource(DigitalSource& source) {
  * @param risingEdge  True to trigger on rising edges
  * @param fallingEdge True to trigger on falling edges
  */
-void Counter::SetUpSourceEdge(bool risingEdge, bool fallingEdge) {
+void frc::Counter::SetUpSourceEdge(bool risingEdge, bool fallingEdge) {
   if (StatusIsFatal()) return;
   if (m_upSource == nullptr) {
     wpi_setWPIErrorWithContext(
@@ -268,7 +267,7 @@ void Counter::SetUpSourceEdge(bool risingEdge, bool fallingEdge) {
 /**
  * Disable the up counting source to the counter.
  */
-void Counter::ClearUpSource() {
+void frc::Counter::ClearUpSource() {
   if (StatusIsFatal()) return;
   m_upSource.reset();
   int32_t status = 0;
@@ -282,7 +281,7 @@ void Counter::ClearUpSource() {
  * @param channel The DIO channel to use as the up source. 0-9 are on-board,
  *                10-25 are on the MXP
  */
-void Counter::SetDownSource(int channel) {
+void frc::Counter::SetDownSource(int channel) {
   if (StatusIsFatal()) return;
   SetDownSource(std::make_shared<DigitalInput>(channel));
 }
@@ -294,8 +293,8 @@ void Counter::SetDownSource(int channel) {
  *                      Source
  * @param triggerType   The analog trigger output that will trigger the counter.
  */
-void Counter::SetDownSource(AnalogTrigger* analogTrigger,
-                            AnalogTriggerType triggerType) {
+void frc::Counter::SetDownSource(AnalogTrigger* analogTrigger,
+                                 AnalogTriggerType triggerType) {
   SetDownSource(std::shared_ptr<AnalogTrigger>(analogTrigger,
                                                NullDeleter<AnalogTrigger>()),
                 triggerType);
@@ -308,8 +307,8 @@ void Counter::SetDownSource(AnalogTrigger* analogTrigger,
  *                      Source
  * @param triggerType   The analog trigger output that will trigger the counter.
  */
-void Counter::SetDownSource(std::shared_ptr<AnalogTrigger> analogTrigger,
-                            AnalogTriggerType triggerType) {
+void frc::Counter::SetDownSource(std::shared_ptr<AnalogTrigger> analogTrigger,
+                                 AnalogTriggerType triggerType) {
   if (StatusIsFatal()) return;
   SetDownSource(analogTrigger->CreateOutput(triggerType));
 }
@@ -321,7 +320,7 @@ void Counter::SetDownSource(std::shared_ptr<AnalogTrigger> analogTrigger,
  *
  * @param source Pointer to the DigitalSource object to set as the down source
  */
-void Counter::SetDownSource(std::shared_ptr<DigitalSource> source) {
+void frc::Counter::SetDownSource(std::shared_ptr<DigitalSource> source) {
   if (StatusIsFatal()) return;
   m_downSource = source;
   if (m_downSource->StatusIsFatal()) {
@@ -336,7 +335,7 @@ void Counter::SetDownSource(std::shared_ptr<DigitalSource> source) {
   }
 }
 
-void Counter::SetDownSource(DigitalSource* source) {
+void frc::Counter::SetDownSource(DigitalSource* source) {
   SetDownSource(
       std::shared_ptr<DigitalSource>(source, NullDeleter<DigitalSource>()));
 }
@@ -348,7 +347,7 @@ void Counter::SetDownSource(DigitalSource* source) {
  *
  * @param source Reference to the DigitalSource object to set as the down source
  */
-void Counter::SetDownSource(DigitalSource& source) {
+void frc::Counter::SetDownSource(DigitalSource& source) {
   SetDownSource(
       std::shared_ptr<DigitalSource>(&source, NullDeleter<DigitalSource>()));
 }
@@ -361,7 +360,7 @@ void Counter::SetDownSource(DigitalSource& source) {
  * @param risingEdge  True to trigger on rising edges
  * @param fallingEdge True to trigger on falling edges
  */
-void Counter::SetDownSourceEdge(bool risingEdge, bool fallingEdge) {
+void frc::Counter::SetDownSourceEdge(bool risingEdge, bool fallingEdge) {
   if (StatusIsFatal()) return;
   if (m_downSource == nullptr) {
     wpi_setWPIErrorWithContext(
@@ -376,7 +375,7 @@ void Counter::SetDownSourceEdge(bool risingEdge, bool fallingEdge) {
 /**
  * Disable the down counting source to the counter.
  */
-void Counter::ClearDownSource() {
+void frc::Counter::ClearDownSource() {
   if (StatusIsFatal()) return;
   m_downSource.reset();
   int32_t status = 0;
@@ -389,7 +388,7 @@ void Counter::ClearDownSource() {
  *
  * Up and down counts are sourced independently from two inputs.
  */
-void Counter::SetUpDownCounterMode() {
+void frc::Counter::SetUpDownCounterMode() {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetCounterUpDownMode(m_counter, &status);
@@ -402,7 +401,7 @@ void Counter::SetUpDownCounterMode() {
  * Counts are sourced on the Up counter input.
  * The Down counter input represents the direction to count.
  */
-void Counter::SetExternalDirectionMode() {
+void frc::Counter::SetExternalDirectionMode() {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetCounterExternalDirectionMode(m_counter, &status);
@@ -414,7 +413,7 @@ void Counter::SetExternalDirectionMode() {
  *
  * Counts up on both rising and falling edges.
  */
-void Counter::SetSemiPeriodMode(bool highSemiPeriod) {
+void frc::Counter::SetSemiPeriodMode(bool highSemiPeriod) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetCounterSemiPeriodMode(m_counter, highSemiPeriod, &status);
@@ -430,7 +429,7 @@ void Counter::SetSemiPeriodMode(bool highSemiPeriod) {
  * @param threshold The pulse length beyond which the counter counts the
  *                  opposite direction.  Units are seconds.
  */
-void Counter::SetPulseLengthMode(double threshold) {
+void frc::Counter::SetPulseLengthMode(double threshold) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetCounterPulseLengthMode(m_counter, threshold, &status);
@@ -446,7 +445,7 @@ void Counter::SetPulseLengthMode(double threshold) {
  *
  * @return The number of samples being averaged (from 1 to 127)
  */
-int Counter::GetSamplesToAverage() const {
+int frc::Counter::GetSamplesToAverage() const {
   int32_t status = 0;
   int samples = HAL_GetCounterSamplesToAverage(m_counter, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -460,7 +459,7 @@ int Counter::GetSamplesToAverage() const {
  *
  * @param samplesToAverage The number of samples to average from 1 to 127.
  */
-void Counter::SetSamplesToAverage(int samplesToAverage) {
+void frc::Counter::SetSamplesToAverage(int samplesToAverage) {
   if (samplesToAverage < 1 || samplesToAverage > 127) {
     wpi_setWPIErrorWithContext(
         ParameterOutOfRange,
@@ -477,7 +476,7 @@ void Counter::SetSamplesToAverage(int samplesToAverage) {
  * Read the value at this instant. It may still be running, so it reflects the
  * current value. Next time it is read, it might have a different value.
  */
-int Counter::Get() const {
+int frc::Counter::Get() const {
   if (StatusIsFatal()) return 0;
   int32_t status = 0;
   int value = HAL_GetCounter(m_counter, &status);
@@ -491,7 +490,7 @@ int Counter::Get() const {
  * Set the counter value to zero. This doesn't effect the running state of the
  * counter, just sets the current value to zero.
  */
-void Counter::Reset() {
+void frc::Counter::Reset() {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_ResetCounter(m_counter, &status);
@@ -506,7 +505,7 @@ void Counter::Reset() {
  *
  * @returns The period between the last two pulses in units of seconds.
  */
-double Counter::GetPeriod() const {
+double frc::Counter::GetPeriod() const {
   if (StatusIsFatal()) return 0.0;
   int32_t status = 0;
   double value = HAL_GetCounterPeriod(m_counter, &status);
@@ -524,7 +523,7 @@ double Counter::GetPeriod() const {
  * @param maxPeriod The maximum period where the counted device is considered
  *                  moving in seconds.
  */
-void Counter::SetMaxPeriod(double maxPeriod) {
+void frc::Counter::SetMaxPeriod(double maxPeriod) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetCounterMaxPeriod(m_counter, maxPeriod, &status);
@@ -548,7 +547,7 @@ void Counter::SetMaxPeriod(double maxPeriod) {
  *
  * @param enabled True to enable update when empty
  */
-void Counter::SetUpdateWhenEmpty(bool enabled) {
+void frc::Counter::SetUpdateWhenEmpty(bool enabled) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetCounterUpdateWhenEmpty(m_counter, enabled, &status);
@@ -565,7 +564,7 @@ void Counter::SetUpdateWhenEmpty(bool enabled) {
  * @return Returns true if the most recent counter period exceeds the MaxPeriod
  *         value set by SetMaxPeriod.
  */
-bool Counter::GetStopped() const {
+bool frc::Counter::GetStopped() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value = HAL_GetCounterStopped(m_counter, &status);
@@ -578,7 +577,7 @@ bool Counter::GetStopped() const {
  *
  * @return The last direction the counter value changed.
  */
-bool Counter::GetDirection() const {
+bool frc::Counter::GetDirection() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value = HAL_GetCounterDirection(m_counter, &status);
@@ -594,28 +593,28 @@ bool Counter::GetDirection() const {
  *
  * @param reverseDirection true if the value counted should be negated.
  */
-void Counter::SetReverseDirection(bool reverseDirection) {
+void frc::Counter::SetReverseDirection(bool reverseDirection) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetCounterReverseDirection(m_counter, reverseDirection, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
 }
 
-void Counter::UpdateTable() {
+void frc::Counter::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Value", Get());
   }
 }
 
-void Counter::StartLiveWindowMode() {}
+void frc::Counter::StartLiveWindowMode() {}
 
-void Counter::StopLiveWindowMode() {}
+void frc::Counter::StopLiveWindowMode() {}
 
-std::string Counter::GetSmartDashboardType() const { return "Counter"; }
+std::string frc::Counter::GetSmartDashboardType() const { return "Counter"; }
 
-void Counter::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::Counter::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> Counter::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Counter::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/DigitalGlitchFilter.cpp
+++ b/wpilibc/athena/src/DigitalGlitchFilter.cpp
@@ -18,13 +18,11 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
-std::array<bool, 3> DigitalGlitchFilter::m_filterAllocated = {
+std::array<bool, 3> frc::DigitalGlitchFilter::m_filterAllocated = {
     {false, false, false}};
-hal::priority_mutex DigitalGlitchFilter::m_mutex;
+hal::priority_mutex frc::DigitalGlitchFilter::m_mutex;
 
-DigitalGlitchFilter::DigitalGlitchFilter() {
+frc::DigitalGlitchFilter::DigitalGlitchFilter() {
   std::lock_guard<hal::priority_mutex> sync(m_mutex);
   auto index =
       std::find(m_filterAllocated.begin(), m_filterAllocated.end(), false);
@@ -36,7 +34,7 @@ DigitalGlitchFilter::DigitalGlitchFilter() {
   HAL_Report(HALUsageReporting::kResourceType_DigitalFilter, m_channelIndex);
 }
 
-DigitalGlitchFilter::~DigitalGlitchFilter() {
+frc::DigitalGlitchFilter::~DigitalGlitchFilter() {
   if (m_channelIndex >= 0) {
     std::lock_guard<hal::priority_mutex> sync(m_mutex);
     m_filterAllocated[m_channelIndex] = false;
@@ -48,11 +46,12 @@ DigitalGlitchFilter::~DigitalGlitchFilter() {
  *
  * @param input The DigitalSource to add.
  */
-void DigitalGlitchFilter::Add(DigitalSource* input) {
+void frc::DigitalGlitchFilter::Add(DigitalSource* input) {
   DoAdd(input, m_channelIndex + 1);
 }
 
-void DigitalGlitchFilter::DoAdd(DigitalSource* input, int requested_index) {
+void frc::DigitalGlitchFilter::DoAdd(DigitalSource* input,
+                                     int requested_index) {
   // Some sources from Counters and Encoders are null.  By pushing the check
   // here, we catch the issue more generally.
   if (input) {
@@ -82,7 +81,7 @@ void DigitalGlitchFilter::DoAdd(DigitalSource* input, int requested_index) {
  *
  * @param input The Encoder to add.
  */
-void DigitalGlitchFilter::Add(Encoder* input) {
+void frc::DigitalGlitchFilter::Add(Encoder* input) {
   Add(input->m_aSource.get());
   if (StatusIsFatal()) {
     return;
@@ -95,7 +94,7 @@ void DigitalGlitchFilter::Add(Encoder* input) {
  *
  * @param input The Counter to add.
  */
-void DigitalGlitchFilter::Add(Counter* input) {
+void frc::DigitalGlitchFilter::Add(Counter* input) {
   Add(input->m_upSource.get());
   if (StatusIsFatal()) {
     return;
@@ -111,7 +110,7 @@ void DigitalGlitchFilter::Add(Counter* input) {
  *
  * @param input The DigitalSource to remove.
  */
-void DigitalGlitchFilter::Remove(DigitalSource* input) { DoAdd(input, 0); }
+void frc::DigitalGlitchFilter::Remove(DigitalSource* input) { DoAdd(input, 0); }
 
 /**
  * Removes an encoder from this filter.
@@ -121,7 +120,7 @@ void DigitalGlitchFilter::Remove(DigitalSource* input) { DoAdd(input, 0); }
  *
  * @param input The Encoder to remove.
  */
-void DigitalGlitchFilter::Remove(Encoder* input) {
+void frc::DigitalGlitchFilter::Remove(Encoder* input) {
   Remove(input->m_aSource.get());
   if (StatusIsFatal()) {
     return;
@@ -137,7 +136,7 @@ void DigitalGlitchFilter::Remove(Encoder* input) {
  *
  * @param input The Counter to remove.
  */
-void DigitalGlitchFilter::Remove(Counter* input) {
+void frc::DigitalGlitchFilter::Remove(Counter* input) {
   Remove(input->m_upSource.get());
   if (StatusIsFatal()) {
     return;
@@ -150,7 +149,7 @@ void DigitalGlitchFilter::Remove(Counter* input) {
  *
  * @param fpga_cycles The number of FPGA cycles.
  */
-void DigitalGlitchFilter::SetPeriodCycles(int fpga_cycles) {
+void frc::DigitalGlitchFilter::SetPeriodCycles(int fpga_cycles) {
   int32_t status = 0;
   HAL_SetFilterPeriod(m_channelIndex, fpga_cycles, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -161,7 +160,7 @@ void DigitalGlitchFilter::SetPeriodCycles(int fpga_cycles) {
  *
  * @param nanoseconds The number of nanoseconds.
  */
-void DigitalGlitchFilter::SetPeriodNanoSeconds(uint64_t nanoseconds) {
+void frc::DigitalGlitchFilter::SetPeriodNanoSeconds(uint64_t nanoseconds) {
   int32_t status = 0;
   int fpga_cycles =
       nanoseconds * HAL_GetSystemClockTicksPerMicrosecond() / 4 / 1000;
@@ -175,7 +174,7 @@ void DigitalGlitchFilter::SetPeriodNanoSeconds(uint64_t nanoseconds) {
  *
  * @return The number of cycles.
  */
-int DigitalGlitchFilter::GetPeriodCycles() {
+int frc::DigitalGlitchFilter::GetPeriodCycles() {
   int32_t status = 0;
   int fpga_cycles = HAL_GetFilterPeriod(m_channelIndex, &status);
 
@@ -189,7 +188,7 @@ int DigitalGlitchFilter::GetPeriodCycles() {
  *
  * @return The number of nanoseconds.
  */
-uint64_t DigitalGlitchFilter::GetPeriodNanoSeconds() {
+uint64_t frc::DigitalGlitchFilter::GetPeriodNanoSeconds() {
   int32_t status = 0;
   int fpga_cycles = HAL_GetFilterPeriod(m_channelIndex, &status);
 

--- a/wpilibc/athena/src/DigitalInput.cpp
+++ b/wpilibc/athena/src/DigitalInput.cpp
@@ -17,8 +17,6 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
 /**
  * Create an instance of a Digital Input class.
  *
@@ -26,7 +24,7 @@ using namespace frc;
  *
  * @param channel The DIO channel 0-9 are on-board, 10-25 are on the MXP port
  */
-DigitalInput::DigitalInput(int channel) {
+frc::DigitalInput::DigitalInput(int channel) {
   llvm::SmallString<32> str;
   llvm::raw_svector_ostream buf(str);
 
@@ -55,7 +53,7 @@ DigitalInput::DigitalInput(int channel) {
 /**
  * Free resources associated with the Digital Input class.
  */
-DigitalInput::~DigitalInput() {
+frc::DigitalInput::~DigitalInput() {
   if (StatusIsFatal()) return;
   if (m_interrupt != HAL_kInvalidHandle) {
     int32_t status = 0;
@@ -72,7 +70,7 @@ DigitalInput::~DigitalInput() {
  *
  * Retrieve the value of a single digital input channel from the FPGA.
  */
-bool DigitalInput::Get() const {
+bool frc::DigitalInput::Get() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value = HAL_GetDIO(m_handle, &status);
@@ -83,42 +81,45 @@ bool DigitalInput::Get() const {
 /**
  * @return The GPIO channel number that this object represents.
  */
-int DigitalInput::GetChannel() const { return m_channel; }
+int frc::DigitalInput::GetChannel() const { return m_channel; }
 
 /**
  * @return The HAL Handle to the specified source.
  */
-HAL_Handle DigitalInput::GetPortHandleForRouting() const { return m_handle; }
+HAL_Handle frc::DigitalInput::GetPortHandleForRouting() const {
+  return m_handle;
+}
 
 /**
  * Is source an AnalogTrigger
  */
-bool DigitalInput::IsAnalogTrigger() const { return false; }
+bool frc::DigitalInput::IsAnalogTrigger() const { return false; }
 
 /**
  * @return The type of analog trigger output to be used. 0 for Digitals
  */
-AnalogTriggerType DigitalInput::GetAnalogTriggerTypeForRouting() const {
-  return (AnalogTriggerType)0;
+frc::AnalogTriggerType frc::DigitalInput::GetAnalogTriggerTypeForRouting()
+    const {
+  return static_cast<AnalogTriggerType>(0);
 }
 
-void DigitalInput::UpdateTable() {
+void frc::DigitalInput::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutBoolean("Value", Get());
   }
 }
 
-void DigitalInput::StartLiveWindowMode() {}
+void frc::DigitalInput::StartLiveWindowMode() {}
 
-void DigitalInput::StopLiveWindowMode() {}
+void frc::DigitalInput::StopLiveWindowMode() {}
 
-std::string DigitalInput::GetSmartDashboardType() const {
+std::string frc::DigitalInput::GetSmartDashboardType() const {
   return "DigitalInput";
 }
 
-void DigitalInput::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::DigitalInput::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> DigitalInput::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::DigitalInput::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/DigitalOutput.cpp
+++ b/wpilibc/athena/src/DigitalOutput.cpp
@@ -16,8 +16,6 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
 /**
  * Create an instance of a digital output.
  *
@@ -26,7 +24,7 @@ using namespace frc;
  * @param channel The digital channel 0-9 are on-board, 10-25 are on the MXP
  *                port
  */
-DigitalOutput::DigitalOutput(int channel) {
+frc::DigitalOutput::DigitalOutput(int channel) {
   llvm::SmallString<32> str;
   llvm::raw_svector_ostream buf(str);
 
@@ -55,7 +53,7 @@ DigitalOutput::DigitalOutput(int channel) {
 /**
  * Free the resources associated with a digital output.
  */
-DigitalOutput::~DigitalOutput() {
+frc::DigitalOutput::~DigitalOutput() {
   if (m_table != nullptr) m_table->RemoveTableListener(this);
   if (StatusIsFatal()) return;
   // Disable the PWM in case it was running.
@@ -71,7 +69,7 @@ DigitalOutput::~DigitalOutput() {
  *
  * @param value 1 (true) for high, 0 (false) for disabled
  */
-void DigitalOutput::Set(bool value) {
+void frc::DigitalOutput::Set(bool value) {
   if (StatusIsFatal()) return;
 
   int32_t status = 0;
@@ -84,7 +82,7 @@ void DigitalOutput::Set(bool value) {
    *
    * @return the state of the digital output.
    */
-bool DigitalOutput::Get() const {
+bool frc::DigitalOutput::Get() const {
   if (StatusIsFatal()) return false;
 
   int32_t status = 0;
@@ -96,7 +94,7 @@ bool DigitalOutput::Get() const {
 /**
  * @return The GPIO channel number that this object represents.
  */
-int DigitalOutput::GetChannel() const { return m_channel; }
+int frc::DigitalOutput::GetChannel() const { return m_channel; }
 
 /**
  * Output a single pulse on the digital output line.
@@ -106,7 +104,7 @@ int DigitalOutput::GetChannel() const { return m_channel; }
  *
  * @param length The pulse length in seconds
  */
-void DigitalOutput::Pulse(double length) {
+void frc::DigitalOutput::Pulse(double length) {
   if (StatusIsFatal()) return;
 
   int32_t status = 0;
@@ -119,7 +117,7 @@ void DigitalOutput::Pulse(double length) {
  *
  * Determine if a previously started pulse is still going.
  */
-bool DigitalOutput::IsPulsing() const {
+bool frc::DigitalOutput::IsPulsing() const {
   if (StatusIsFatal()) return false;
 
   int32_t status = 0;
@@ -138,7 +136,7 @@ bool DigitalOutput::IsPulsing() const {
  *
  * @param rate The frequency to output all digital output PWM signals.
  */
-void DigitalOutput::SetPWMRate(double rate) {
+void frc::DigitalOutput::SetPWMRate(double rate) {
   if (StatusIsFatal()) return;
 
   int32_t status = 0;
@@ -159,7 +157,7 @@ void DigitalOutput::SetPWMRate(double rate) {
  *
  * @param initialDutyCycle The duty-cycle to start generating. [0..1]
  */
-void DigitalOutput::EnablePWM(double initialDutyCycle) {
+void frc::DigitalOutput::EnablePWM(double initialDutyCycle) {
   if (m_pwmGenerator != HAL_kInvalidHandle) return;
 
   int32_t status = 0;
@@ -182,7 +180,7 @@ void DigitalOutput::EnablePWM(double initialDutyCycle) {
  *
  * Free up one of the 6 DO PWM generator resources that were in use.
  */
-void DigitalOutput::DisablePWM() {
+void frc::DigitalOutput::DisablePWM() {
   if (StatusIsFatal()) return;
   if (m_pwmGenerator == HAL_kInvalidHandle) return;
 
@@ -206,7 +204,7 @@ void DigitalOutput::DisablePWM() {
  *
  * @param dutyCycle The duty-cycle to change to. [0..1]
  */
-void DigitalOutput::UpdateDutyCycle(double dutyCycle) {
+void frc::DigitalOutput::UpdateDutyCycle(double dutyCycle) {
   if (StatusIsFatal()) return;
 
   int32_t status = 0;
@@ -217,47 +215,51 @@ void DigitalOutput::UpdateDutyCycle(double dutyCycle) {
 /**
  * @return The HAL Handle to the specified source.
  */
-HAL_Handle DigitalOutput::GetPortHandleForRouting() const { return m_handle; }
+HAL_Handle frc::DigitalOutput::GetPortHandleForRouting() const {
+  return m_handle;
+}
 
 /**
  * Is source an AnalogTrigger
  */
-bool DigitalOutput::IsAnalogTrigger() const { return false; }
+bool frc::DigitalOutput::IsAnalogTrigger() const { return false; }
 
 /**
  * @return The type of analog trigger output to be used. 0 for Digitals
  */
-AnalogTriggerType DigitalOutput::GetAnalogTriggerTypeForRouting() const {
-  return (AnalogTriggerType)0;
+frc::AnalogTriggerType frc::DigitalOutput::GetAnalogTriggerTypeForRouting()
+    const {
+  return static_cast<AnalogTriggerType>(0);
 }
 
-void DigitalOutput::ValueChanged(ITable* source, llvm::StringRef key,
-                                 std::shared_ptr<nt::Value> value, bool isNew) {
+void frc::DigitalOutput::ValueChanged(ITable* source, llvm::StringRef key,
+                                      std::shared_ptr<nt::Value> value,
+                                      bool isNew) {
   if (!value->IsBoolean()) return;
   Set(value->GetBoolean());
 }
 
-void DigitalOutput::UpdateTable() {}
+void frc::DigitalOutput::UpdateTable() {}
 
-void DigitalOutput::StartLiveWindowMode() {
+void frc::DigitalOutput::StartLiveWindowMode() {
   if (m_table != nullptr) {
     m_table->AddTableListener("Value", this, true);
   }
 }
 
-void DigitalOutput::StopLiveWindowMode() {
+void frc::DigitalOutput::StopLiveWindowMode() {
   if (m_table != nullptr) {
     m_table->RemoveTableListener(this);
   }
 }
 
-std::string DigitalOutput::GetSmartDashboardType() const {
+std::string frc::DigitalOutput::GetSmartDashboardType() const {
   return "Digital Output";
 }
 
-void DigitalOutput::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::DigitalOutput::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> DigitalOutput::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::DigitalOutput::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/DoubleSolenoid.cpp
+++ b/wpilibc/athena/src/DoubleSolenoid.cpp
@@ -15,8 +15,6 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
 /**
  * Constructor.
  *
@@ -25,7 +23,7 @@ using namespace frc;
  * @param forwardChannel The forward channel number on the PCM (0..7).
  * @param reverseChannel The reverse channel number on the PCM (0..7).
  */
-DoubleSolenoid::DoubleSolenoid(int forwardChannel, int reverseChannel)
+frc::DoubleSolenoid::DoubleSolenoid(int forwardChannel, int reverseChannel)
     : DoubleSolenoid(GetDefaultSolenoidModule(), forwardChannel,
                      reverseChannel) {}
 
@@ -36,8 +34,8 @@ DoubleSolenoid::DoubleSolenoid(int forwardChannel, int reverseChannel)
  * @param forwardChannel The forward channel on the PCM to control (0..7).
  * @param reverseChannel The reverse channel on the PCM to control (0..7).
  */
-DoubleSolenoid::DoubleSolenoid(int moduleNumber, int forwardChannel,
-                               int reverseChannel)
+frc::DoubleSolenoid::DoubleSolenoid(int moduleNumber, int forwardChannel,
+                                    int reverseChannel)
     : SolenoidBase(moduleNumber),
       m_forwardChannel(forwardChannel),
       m_reverseChannel(reverseChannel) {
@@ -95,7 +93,7 @@ DoubleSolenoid::DoubleSolenoid(int moduleNumber, int forwardChannel,
 /**
  * Destructor.
  */
-DoubleSolenoid::~DoubleSolenoid() {
+frc::DoubleSolenoid::~DoubleSolenoid() {
   HAL_FreeSolenoidPort(m_forwardHandle);
   HAL_FreeSolenoidPort(m_reverseHandle);
   if (m_table != nullptr) m_table->RemoveTableListener(this);
@@ -106,7 +104,7 @@ DoubleSolenoid::~DoubleSolenoid() {
  *
  * @param value The value to set (Off, Forward or Reverse)
  */
-void DoubleSolenoid::Set(Value value) {
+void frc::DoubleSolenoid::Set(Value value) {
   if (StatusIsFatal()) return;
 
   bool forward = false;
@@ -139,7 +137,7 @@ void DoubleSolenoid::Set(Value value) {
  *
  * @return The current value of the solenoid.
  */
-DoubleSolenoid::Value DoubleSolenoid::Get() const {
+frc::DoubleSolenoid::Value frc::DoubleSolenoid::Get() const {
   if (StatusIsFatal()) return kOff;
   int fstatus = 0;
   int rstatus = 0;
@@ -162,7 +160,7 @@ DoubleSolenoid::Value DoubleSolenoid::Get() const {
  *
  * @return If solenoid is disabled due to short.
  */
-bool DoubleSolenoid::IsFwdSolenoidBlackListed() const {
+bool frc::DoubleSolenoid::IsFwdSolenoidBlackListed() const {
   int blackList = GetPCMSolenoidBlackList(m_moduleNumber);
   return (blackList & m_forwardMask) ? 1 : 0;
 }
@@ -175,14 +173,14 @@ bool DoubleSolenoid::IsFwdSolenoidBlackListed() const {
  *
  * @return If solenoid is disabled due to short.
  */
-bool DoubleSolenoid::IsRevSolenoidBlackListed() const {
+bool frc::DoubleSolenoid::IsRevSolenoidBlackListed() const {
   int blackList = GetPCMSolenoidBlackList(m_moduleNumber);
   return (blackList & m_reverseMask) ? 1 : 0;
 }
 
-void DoubleSolenoid::ValueChanged(ITable* source, llvm::StringRef key,
-                                  std::shared_ptr<nt::Value> value,
-                                  bool isNew) {
+void frc::DoubleSolenoid::ValueChanged(ITable* source, llvm::StringRef key,
+                                       std::shared_ptr<nt::Value> value,
+                                       bool isNew) {
   if (!value->IsString()) return;
   Value lvalue = kOff;
   if (value->GetString() == "Forward")
@@ -192,7 +190,7 @@ void DoubleSolenoid::ValueChanged(ITable* source, llvm::StringRef key,
   Set(lvalue);
 }
 
-void DoubleSolenoid::UpdateTable() {
+void frc::DoubleSolenoid::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutString(
         "Value", (Get() == kForward ? "Forward"
@@ -200,27 +198,29 @@ void DoubleSolenoid::UpdateTable() {
   }
 }
 
-void DoubleSolenoid::StartLiveWindowMode() {
+void frc::DoubleSolenoid::StartLiveWindowMode() {
   Set(kOff);
   if (m_table != nullptr) {
     m_table->AddTableListener("Value", this, true);
   }
 }
 
-void DoubleSolenoid::StopLiveWindowMode() {
+void frc::DoubleSolenoid::StopLiveWindowMode() {
   Set(kOff);
   if (m_table != nullptr) {
     m_table->RemoveTableListener(this);
   }
 }
 
-std::string DoubleSolenoid::GetSmartDashboardType() const {
+std::string frc::DoubleSolenoid::GetSmartDashboardType() const {
   return "Double Solenoid";
 }
 
-void DoubleSolenoid::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::DoubleSolenoid::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> DoubleSolenoid::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::DoubleSolenoid::GetTable() const {
+  return m_table;
+}

--- a/wpilibc/athena/src/DriverStation.cpp
+++ b/wpilibc/athena/src/DriverStation.cpp
@@ -20,13 +20,11 @@
 #include "WPIErrors.h"
 #include "llvm/SmallString.h"
 
-using namespace frc;
-
 const double JOYSTICK_UNPLUGGED_MESSAGE_INTERVAL = 1.0;
 
-const int DriverStation::kJoystickPorts;
+const int frc::DriverStation::kJoystickPorts;
 
-DriverStation::~DriverStation() {
+frc::DriverStation::~DriverStation() {
   m_isRunning = false;
   m_dsThread.join();
 }
@@ -36,7 +34,7 @@ DriverStation::~DriverStation() {
  *
  * @return Pointer to the DS instance
  */
-DriverStation& DriverStation::GetInstance() {
+frc::DriverStation& frc::DriverStation::GetInstance() {
   static DriverStation instance;
   return instance;
 }
@@ -46,7 +44,7 @@ DriverStation& DriverStation::GetInstance() {
  *
  * The error is also printed to the program console.
  */
-void DriverStation::ReportError(llvm::StringRef error) {
+void frc::DriverStation::ReportError(llvm::StringRef error) {
   llvm::SmallString<128> temp;
   HAL_SendError(1, 1, 0, error.c_str(temp), "", "", 1);
 }
@@ -56,7 +54,7 @@ void DriverStation::ReportError(llvm::StringRef error) {
  *
  * The warning is also printed to the program console.
  */
-void DriverStation::ReportWarning(llvm::StringRef error) {
+void frc::DriverStation::ReportWarning(llvm::StringRef error) {
   llvm::SmallString<128> temp;
   HAL_SendError(0, 1, 0, error.c_str(temp), "", "", 1);
 }
@@ -66,9 +64,10 @@ void DriverStation::ReportWarning(llvm::StringRef error) {
  *
  * The error is also printed to the program console.
  */
-void DriverStation::ReportError(bool is_error, int32_t code,
-                                llvm::StringRef error, llvm::StringRef location,
-                                llvm::StringRef stack) {
+void frc::DriverStation::ReportError(bool is_error, int32_t code,
+                                     llvm::StringRef error,
+                                     llvm::StringRef location,
+                                     llvm::StringRef stack) {
   llvm::SmallString<128> errorTemp;
   llvm::SmallString<128> locationTemp;
   llvm::SmallString<128> stackTemp;
@@ -85,7 +84,7 @@ void DriverStation::ReportError(bool is_error, int32_t code,
  * @param axis  The analog axis value to read from the joystick.
  * @return The value of the axis on the joystick.
  */
-double DriverStation::GetStickAxis(int stick, int axis) {
+double frc::DriverStation::GetStickAxis(int stick, int axis) {
   if (stick >= kJoystickPorts) {
     wpi_setWPIError(BadJoystickIndex);
     return 0;
@@ -111,7 +110,7 @@ double DriverStation::GetStickAxis(int stick, int axis) {
  *
  * @return the angle of the POV in degrees, or -1 if the POV is not pressed.
  */
-int DriverStation::GetStickPOV(int stick, int pov) {
+int frc::DriverStation::GetStickPOV(int stick, int pov) {
   if (stick >= kJoystickPorts) {
     wpi_setWPIError(BadJoystickIndex);
     return -1;
@@ -137,7 +136,7 @@ int DriverStation::GetStickPOV(int stick, int pov) {
  * @param stick The joystick to read.
  * @return The state of the buttons on the joystick.
  */
-int DriverStation::GetStickButtons(int stick) const {
+int frc::DriverStation::GetStickButtons(int stick) const {
   if (stick >= kJoystickPorts) {
     wpi_setWPIError(BadJoystickIndex);
     return 0;
@@ -153,7 +152,7 @@ int DriverStation::GetStickButtons(int stick) const {
  * @param button The button index, beginning at 1.
  * @return The state of the joystick button.
  */
-bool DriverStation::GetStickButton(int stick, int button) {
+bool frc::DriverStation::GetStickButton(int stick, int button) {
   if (stick >= kJoystickPorts) {
     wpi_setWPIError(BadJoystickIndex);
     return false;
@@ -182,7 +181,7 @@ bool DriverStation::GetStickButton(int stick, int button) {
  * @param stick The joystick port number
  * @return The number of axes on the indicated joystick
  */
-int DriverStation::GetStickAxisCount(int stick) const {
+int frc::DriverStation::GetStickAxisCount(int stick) const {
   if (stick >= kJoystickPorts) {
     wpi_setWPIError(BadJoystickIndex);
     return 0;
@@ -197,7 +196,7 @@ int DriverStation::GetStickAxisCount(int stick) const {
  * @param stick The joystick port number
  * @return The number of POVs on the indicated joystick
  */
-int DriverStation::GetStickPOVCount(int stick) const {
+int frc::DriverStation::GetStickPOVCount(int stick) const {
   if (stick >= kJoystickPorts) {
     wpi_setWPIError(BadJoystickIndex);
     return 0;
@@ -212,7 +211,7 @@ int DriverStation::GetStickPOVCount(int stick) const {
  * @param stick The joystick port number
  * @return The number of buttons on the indicated joystick
  */
-int DriverStation::GetStickButtonCount(int stick) const {
+int frc::DriverStation::GetStickButtonCount(int stick) const {
   if (stick >= kJoystickPorts) {
     wpi_setWPIError(BadJoystickIndex);
     return 0;
@@ -227,7 +226,7 @@ int DriverStation::GetStickButtonCount(int stick) const {
  * @param stick The joystick port number
  * @return A boolean that is true if the controller is an xbox controller.
  */
-bool DriverStation::GetJoystickIsXbox(int stick) const {
+bool frc::DriverStation::GetJoystickIsXbox(int stick) const {
   if (stick >= kJoystickPorts) {
     wpi_setWPIError(BadJoystickIndex);
     return false;
@@ -242,7 +241,7 @@ bool DriverStation::GetJoystickIsXbox(int stick) const {
  * @param stick The joystick port number
  * @return The HID type of joystick at the given port
  */
-int DriverStation::GetJoystickType(int stick) const {
+int frc::DriverStation::GetJoystickType(int stick) const {
   if (stick >= kJoystickPorts) {
     wpi_setWPIError(BadJoystickIndex);
     return -1;
@@ -257,7 +256,7 @@ int DriverStation::GetJoystickType(int stick) const {
  * @param stick The joystick port number
  * @return The name of the joystick at the given port
  */
-std::string DriverStation::GetJoystickName(int stick) const {
+std::string frc::DriverStation::GetJoystickName(int stick) const {
   if (stick >= kJoystickPorts) {
     wpi_setWPIError(BadJoystickIndex);
   }
@@ -272,7 +271,7 @@ std::string DriverStation::GetJoystickName(int stick) const {
  * @param stick The joystick port number and the target axis
  * @return What type of axis the axis is reporting to be
  */
-int DriverStation::GetJoystickAxisType(int stick, int axis) const {
+int frc::DriverStation::GetJoystickAxisType(int stick, int axis) const {
   if (stick >= kJoystickPorts) {
     wpi_setWPIError(BadJoystickIndex);
     return -1;
@@ -286,7 +285,7 @@ int DriverStation::GetJoystickAxisType(int stick, int axis) const {
  *
  * @return True if the robot is enabled and the DS is connected
  */
-bool DriverStation::IsEnabled() const {
+bool frc::DriverStation::IsEnabled() const {
   HAL_ControlWord controlWord;
   UpdateControlWord(false, controlWord);
   return controlWord.enabled && controlWord.dsAttached;
@@ -297,7 +296,7 @@ bool DriverStation::IsEnabled() const {
  *
  * @return True if the robot is explicitly disabled or the DS is not connected
  */
-bool DriverStation::IsDisabled() const {
+bool frc::DriverStation::IsDisabled() const {
   HAL_ControlWord controlWord;
   UpdateControlWord(false, controlWord);
   return !(controlWord.enabled && controlWord.dsAttached);
@@ -308,7 +307,7 @@ bool DriverStation::IsDisabled() const {
  *
  * @return True if the robot is being commanded to be in autonomous mode
  */
-bool DriverStation::IsAutonomous() const {
+bool frc::DriverStation::IsAutonomous() const {
   HAL_ControlWord controlWord;
   UpdateControlWord(false, controlWord);
   return controlWord.autonomous;
@@ -319,7 +318,7 @@ bool DriverStation::IsAutonomous() const {
  *
  * @return True if the robot is being commanded to be in teleop mode
  */
-bool DriverStation::IsOperatorControl() const {
+bool frc::DriverStation::IsOperatorControl() const {
   HAL_ControlWord controlWord;
   UpdateControlWord(false, controlWord);
   return !(controlWord.autonomous || controlWord.test);
@@ -330,7 +329,7 @@ bool DriverStation::IsOperatorControl() const {
  *
  * @return True if the robot is being commanded to be in test mode
  */
-bool DriverStation::IsTest() const {
+bool frc::DriverStation::IsTest() const {
   HAL_ControlWord controlWord;
   UpdateControlWord(false, controlWord);
   return controlWord.test;
@@ -341,7 +340,7 @@ bool DriverStation::IsTest() const {
  *
  * @return True if the DS is connected to the robot
  */
-bool DriverStation::IsDSAttached() const {
+bool frc::DriverStation::IsDSAttached() const {
   HAL_ControlWord controlWord;
   UpdateControlWord(false, controlWord);
   return controlWord.dsAttached;
@@ -356,7 +355,9 @@ bool DriverStation::IsDSAttached() const {
  *
  * @return True if the control data has been updated since the last call.
  */
-bool DriverStation::IsNewControlData() const { return HAL_IsNewControlData(); }
+bool frc::DriverStation::IsNewControlData() const {
+  return HAL_IsNewControlData();
+}
 
 /**
  * Is the driver station attached to a Field Management System?
@@ -364,7 +365,7 @@ bool DriverStation::IsNewControlData() const { return HAL_IsNewControlData(); }
  * @return True if the robot is competing on a field being controlled by a Field
  *         Management System
  */
-bool DriverStation::IsFMSAttached() const {
+bool frc::DriverStation::IsFMSAttached() const {
   HAL_ControlWord controlWord;
   UpdateControlWord(false, controlWord);
   return controlWord.fmsAttached;
@@ -378,7 +379,7 @@ bool DriverStation::IsFMSAttached() const {
  *
  * @return True if the FPGA outputs are enabled.
  */
-bool DriverStation::IsSysActive() const {
+bool frc::DriverStation::IsSysActive() const {
   int32_t status = 0;
   bool retVal = HAL_GetSystemActive(&status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -390,7 +391,7 @@ bool DriverStation::IsSysActive() const {
  *
  * @return True if the system is browned out
  */
-bool DriverStation::IsBrownedOut() const {
+bool frc::DriverStation::IsBrownedOut() const {
   int32_t status = 0;
   bool retVal = HAL_GetBrownedOut(&status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -404,7 +405,7 @@ bool DriverStation::IsBrownedOut() const {
  *
  * @return The Alliance enum (kRed, kBlue or kInvalid)
  */
-DriverStation::Alliance DriverStation::GetAlliance() const {
+frc::DriverStation::Alliance frc::DriverStation::GetAlliance() const {
   int32_t status = 0;
   auto allianceStationID = HAL_GetAllianceStation(&status);
   switch (allianceStationID) {
@@ -428,7 +429,7 @@ DriverStation::Alliance DriverStation::GetAlliance() const {
  *
  * @return The location of the driver station (1-3, 0 for invalid)
  */
-int DriverStation::GetLocation() const {
+int frc::DriverStation::GetLocation() const {
   int32_t status = 0;
   auto allianceStationID = HAL_GetAllianceStation(&status);
   switch (allianceStationID) {
@@ -454,7 +455,7 @@ int DriverStation::GetLocation() const {
  * This is a good way to delay processing until there is new driver station data
  * to act on.
  */
-void DriverStation::WaitForData() { WaitForData(0); }
+void frc::DriverStation::WaitForData() { WaitForData(0); }
 
 /**
  * Wait until a new packet comes from the driver station, or wait for a timeout.
@@ -472,7 +473,7 @@ void DriverStation::WaitForData() { WaitForData(0); }
  *
  * @return true if new data, otherwise false
  */
-bool DriverStation::WaitForData(double timeout) {
+bool frc::DriverStation::WaitForData(double timeout) {
   return static_cast<bool>(HAL_WaitForDSDataTimeout(timeout));
 }
 
@@ -491,7 +492,7 @@ bool DriverStation::WaitForData(double timeout) {
  *
  * @return Time remaining in current match period (auto or teleop)
  */
-double DriverStation::GetMatchTime() const {
+double frc::DriverStation::GetMatchTime() const {
   int32_t status;
   return HAL_GetMatchTime(&status);
 }
@@ -501,7 +502,7 @@ double DriverStation::GetMatchTime() const {
  *
  * @return The battery voltage in Volts.
  */
-double DriverStation::GetBatteryVoltage() const {
+double frc::DriverStation::GetBatteryVoltage() const {
   int32_t status = 0;
   double voltage = HAL_GetVinVoltage(&status);
   wpi_setErrorWithContext(status, "getVinVoltage");
@@ -515,7 +516,7 @@ double DriverStation::GetBatteryVoltage() const {
  * If no new data exists, it will just be returned, otherwise
  * the data will be copied from the DS polling loop.
  */
-void DriverStation::GetData() {
+void frc::DriverStation::GetData() {
   // Get the status of all of the joysticks, and save to the cache
   for (uint8_t stick = 0; stick < kJoystickPorts; stick++) {
     HAL_GetJoystickAxes(stick, &m_joystickAxesCache[stick]);
@@ -540,7 +541,7 @@ void DriverStation::GetData() {
  *
  * This is only called once the first time GetInstance() is called
  */
-DriverStation::DriverStation() {
+frc::DriverStation::DriverStation() {
   m_joystickAxes = std::make_unique<HAL_JoystickAxes[]>(kJoystickPorts);
   m_joystickPOVs = std::make_unique<HAL_JoystickPOVs[]>(kJoystickPorts);
   m_joystickButtons = std::make_unique<HAL_JoystickButtons[]>(kJoystickPorts);
@@ -571,14 +572,14 @@ DriverStation::DriverStation() {
     m_joystickDescriptorCache[i].name[0] = '\0';
   }
 
-  m_dsThread = std::thread(&DriverStation::Run, this);
+  m_dsThread = std::thread(&frc::DriverStation::Run, this);
 }
 
 /**
  * Reports errors related to unplugged joysticks
  * Throttles the errors so that they don't overwhelm the DS
  */
-void DriverStation::ReportJoystickUnpluggedError(llvm::StringRef message) {
+void frc::DriverStation::ReportJoystickUnpluggedError(llvm::StringRef message) {
   double currentTime = Timer::GetFPGATimestamp();
   if (currentTime > m_nextMessageTime) {
     ReportError(message);
@@ -591,7 +592,8 @@ void DriverStation::ReportJoystickUnpluggedError(llvm::StringRef message) {
  *
  * Throttles the errors so that they don't overwhelm the DS.
  */
-void DriverStation::ReportJoystickUnpluggedWarning(llvm::StringRef message) {
+void frc::DriverStation::ReportJoystickUnpluggedWarning(
+    llvm::StringRef message) {
   double currentTime = Timer::GetFPGATimestamp();
   if (currentTime > m_nextMessageTime) {
     ReportWarning(message);
@@ -599,7 +601,7 @@ void DriverStation::ReportJoystickUnpluggedWarning(llvm::StringRef message) {
   }
 }
 
-void DriverStation::Run() {
+void frc::DriverStation::Run() {
   m_isRunning = true;
   int period = 0;
   while (m_isRunning) {
@@ -626,8 +628,8 @@ void DriverStation::Run() {
  * have passed.
  * @param controlWord Structure to put the return control word data into.
  */
-void DriverStation::UpdateControlWord(bool force,
-                                      HAL_ControlWord& controlWord) const {
+void frc::DriverStation::UpdateControlWord(bool force,
+                                           HAL_ControlWord& controlWord) const {
   auto now = std::chrono::steady_clock::now();
   std::lock_guard<hal::priority_mutex> lock(m_controlWordMutex);
   // Update every 50 ms or on force.

--- a/wpilibc/athena/src/Encoder.cpp
+++ b/wpilibc/athena/src/Encoder.cpp
@@ -12,8 +12,6 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
 /**
  * Common initialization code for Encoders.
  *
@@ -32,7 +30,8 @@ using namespace frc;
  *                         value will either exactly match the spec'd count or
  *                         be double (2x) the spec'd count.
  */
-void Encoder::InitEncoder(bool reverseDirection, EncodingType encodingType) {
+void frc::Encoder::InitEncoder(bool reverseDirection,
+                               EncodingType encodingType) {
   int32_t status = 0;
   m_encoder = HAL_InitializeEncoder(
       m_aSource->GetPortHandleForRouting(),
@@ -71,8 +70,8 @@ void Encoder::InitEncoder(bool reverseDirection, EncodingType encodingType) {
  *                         value will either exactly match the spec'd count or
  *                         be double (2x) the spec'd count.
  */
-Encoder::Encoder(int aChannel, int bChannel, bool reverseDirection,
-                 EncodingType encodingType) {
+frc::Encoder::Encoder(int aChannel, int bChannel, bool reverseDirection,
+                      EncodingType encodingType) {
   m_aSource = std::make_shared<DigitalInput>(aChannel);
   m_bSource = std::make_shared<DigitalInput>(bChannel);
   InitEncoder(reverseDirection, encodingType);
@@ -101,8 +100,8 @@ Encoder::Encoder(int aChannel, int bChannel, bool reverseDirection,
  *                         value will either exactly match the spec'd count or
  *                         be double (2x) the spec'd count.
  */
-Encoder::Encoder(DigitalSource* aSource, DigitalSource* bSource,
-                 bool reverseDirection, EncodingType encodingType)
+frc::Encoder::Encoder(DigitalSource* aSource, DigitalSource* bSource,
+                      bool reverseDirection, EncodingType encodingType)
     : m_aSource(aSource, NullDeleter<DigitalSource>()),
       m_bSource(bSource, NullDeleter<DigitalSource>()) {
   if (m_aSource == nullptr || m_bSource == nullptr)
@@ -111,9 +110,9 @@ Encoder::Encoder(DigitalSource* aSource, DigitalSource* bSource,
     InitEncoder(reverseDirection, encodingType);
 }
 
-Encoder::Encoder(std::shared_ptr<DigitalSource> aSource,
-                 std::shared_ptr<DigitalSource> bSource, bool reverseDirection,
-                 EncodingType encodingType)
+frc::Encoder::Encoder(std::shared_ptr<DigitalSource> aSource,
+                      std::shared_ptr<DigitalSource> bSource,
+                      bool reverseDirection, EncodingType encodingType)
     : m_aSource(aSource), m_bSource(bSource) {
   if (m_aSource == nullptr || m_bSource == nullptr)
     wpi_setWPIError(NullParameter);
@@ -144,8 +143,8 @@ Encoder::Encoder(std::shared_ptr<DigitalSource> aSource,
  *                         value will either exactly match the spec'd count or
  *                         be double (2x) the spec'd count.
  */
-Encoder::Encoder(DigitalSource& aSource, DigitalSource& bSource,
-                 bool reverseDirection, EncodingType encodingType)
+frc::Encoder::Encoder(DigitalSource& aSource, DigitalSource& bSource,
+                      bool reverseDirection, EncodingType encodingType)
     : m_aSource(&aSource, NullDeleter<DigitalSource>()),
       m_bSource(&bSource, NullDeleter<DigitalSource>()) {
   InitEncoder(reverseDirection, encodingType);
@@ -156,7 +155,7 @@ Encoder::Encoder(DigitalSource& aSource, DigitalSource& bSource,
  *
  * Frees the FPGA resources associated with an Encoder.
  */
-Encoder::~Encoder() {
+frc::Encoder::~Encoder() {
   int32_t status = 0;
   HAL_FreeEncoder(m_encoder, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -167,7 +166,7 @@ Encoder::~Encoder() {
  *
  * Used to divide raw edge counts down to spec'd counts.
  */
-int Encoder::GetEncodingScale() const {
+int frc::Encoder::GetEncodingScale() const {
   int32_t status = 0;
   int val = HAL_GetEncoderEncodingScale(m_encoder, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -182,7 +181,7 @@ int Encoder::GetEncodingScale() const {
  *
  * @return Current raw count from the encoder
  */
-int Encoder::GetRaw() const {
+int frc::Encoder::GetRaw() const {
   if (StatusIsFatal()) return 0;
   int32_t status = 0;
   int value = HAL_GetEncoderRaw(m_encoder, &status);
@@ -199,7 +198,7 @@ int Encoder::GetRaw() const {
  * @return Current count from the Encoder adjusted for the 1x, 2x, or 4x scale
  *         factor.
  */
-int Encoder::Get() const {
+int frc::Encoder::Get() const {
   if (StatusIsFatal()) return 0;
   int32_t status = 0;
   int value = HAL_GetEncoder(m_encoder, &status);
@@ -212,7 +211,7 @@ int Encoder::Get() const {
  *
  * Resets the current count to zero on the encoder.
  */
-void Encoder::Reset() {
+void frc::Encoder::Reset() {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_ResetEncoder(m_encoder, &status);
@@ -230,7 +229,7 @@ void Encoder::Reset() {
  *
  * @return Period in seconds of the most recent pulse.
  */
-double Encoder::GetPeriod() const {
+double frc::Encoder::GetPeriod() const {
   if (StatusIsFatal()) return 0.0;
   int32_t status = 0;
   double value = HAL_GetEncoderPeriod(m_encoder, &status);
@@ -254,7 +253,7 @@ double Encoder::GetPeriod() const {
  *                  the FPGA will report the device stopped. This is expressed
  *                  in seconds.
  */
-void Encoder::SetMaxPeriod(double maxPeriod) {
+void frc::Encoder::SetMaxPeriod(double maxPeriod) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetEncoderMaxPeriod(m_encoder, maxPeriod, &status);
@@ -270,7 +269,7 @@ void Encoder::SetMaxPeriod(double maxPeriod) {
  *
  * @return True if the encoder is considered stopped.
  */
-bool Encoder::GetStopped() const {
+bool frc::Encoder::GetStopped() const {
   if (StatusIsFatal()) return true;
   int32_t status = 0;
   bool value = HAL_GetEncoderStopped(m_encoder, &status);
@@ -283,7 +282,7 @@ bool Encoder::GetStopped() const {
  *
  * @return The last direction the encoder value changed.
  */
-bool Encoder::GetDirection() const {
+bool frc::Encoder::GetDirection() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value = HAL_GetEncoderDirection(m_encoder, &status);
@@ -295,7 +294,7 @@ bool Encoder::GetDirection() const {
  * The scale needed to convert a raw counter value into a number of encoder
  * pulses.
  */
-double Encoder::DecodingScaleFactor() const {
+double frc::Encoder::DecodingScaleFactor() const {
   if (StatusIsFatal()) return 0.0;
   int32_t status = 0;
   double val = HAL_GetEncoderDecodingScaleFactor(m_encoder, &status);
@@ -309,7 +308,7 @@ double Encoder::DecodingScaleFactor() const {
  * @return The distance driven since the last reset as scaled by the value from
  *         SetDistancePerPulse().
  */
-double Encoder::GetDistance() const {
+double frc::Encoder::GetDistance() const {
   if (StatusIsFatal()) return 0.0;
   int32_t status = 0;
   double value = HAL_GetEncoderDistance(m_encoder, &status);
@@ -325,7 +324,7 @@ double Encoder::GetDistance() const {
  *
  * @return The current rate of the encoder.
  */
-double Encoder::GetRate() const {
+double frc::Encoder::GetRate() const {
   if (StatusIsFatal()) return 0.0;
   int32_t status = 0;
   double value = HAL_GetEncoderRate(m_encoder, &status);
@@ -339,7 +338,7 @@ double Encoder::GetRate() const {
  * @param minRate The minimum rate.  The units are in distance per second as
  *                scaled by the value from SetDistancePerPulse().
  */
-void Encoder::SetMinRate(double minRate) {
+void frc::Encoder::SetMinRate(double minRate) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetEncoderMinRate(m_encoder, minRate, &status);
@@ -363,7 +362,7 @@ void Encoder::SetMinRate(double minRate) {
  * @param distancePerPulse The scale factor that will be used to convert pulses
  *                         to useful units.
  */
-void Encoder::SetDistancePerPulse(double distancePerPulse) {
+void frc::Encoder::SetDistancePerPulse(double distancePerPulse) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetEncoderDistancePerPulse(m_encoder, distancePerPulse, &status);
@@ -378,7 +377,7 @@ void Encoder::SetDistancePerPulse(double distancePerPulse) {
  *
  * @param reverseDirection true if the encoder direction should be reversed
  */
-void Encoder::SetReverseDirection(bool reverseDirection) {
+void frc::Encoder::SetReverseDirection(bool reverseDirection) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetEncoderReverseDirection(m_encoder, reverseDirection, &status);
@@ -394,7 +393,7 @@ void Encoder::SetReverseDirection(bool reverseDirection) {
  *
  * @param samplesToAverage The number of samples to average from 1 to 127.
  */
-void Encoder::SetSamplesToAverage(int samplesToAverage) {
+void frc::Encoder::SetSamplesToAverage(int samplesToAverage) {
   if (samplesToAverage < 1 || samplesToAverage > 127) {
     wpi_setWPIErrorWithContext(
         ParameterOutOfRange,
@@ -415,7 +414,7 @@ void Encoder::SetSamplesToAverage(int samplesToAverage) {
  *
  * @return The number of samples being averaged (from 1 to 127)
  */
-int Encoder::GetSamplesToAverage() const {
+int frc::Encoder::GetSamplesToAverage() const {
   int32_t status = 0;
   int result = HAL_GetEncoderSamplesToAverage(m_encoder, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -427,7 +426,7 @@ int Encoder::GetSamplesToAverage() const {
  *
  * @return The current value of the selected source parameter.
  */
-double Encoder::PIDGet() {
+double frc::Encoder::PIDGet() {
   if (StatusIsFatal()) return 0.0;
   switch (GetPIDSourceType()) {
     case PIDSourceType::kDisplacement:
@@ -447,7 +446,8 @@ double Encoder::PIDGet() {
  * @param channel A DIO channel to set as the encoder index
  * @param type    The state that will cause the encoder to reset
  */
-void Encoder::SetIndexSource(int channel, Encoder::IndexingType type) {
+void frc::Encoder::SetIndexSource(int channel,
+                                  frc::Encoder::IndexingType type) {
   // Force digital input if just given an index
   m_indexSource = std::make_unique<DigitalInput>(channel);
   SetIndexSource(*m_indexSource.get(), type);
@@ -461,8 +461,8 @@ void Encoder::SetIndexSource(int channel, Encoder::IndexingType type) {
  * @param channel A digital source to set as the encoder index
  * @param type    The state that will cause the encoder to reset
  */
-void Encoder::SetIndexSource(const DigitalSource& source,
-                             Encoder::IndexingType type) {
+void frc::Encoder::SetIndexSource(const DigitalSource& source,
+                                  frc::Encoder::IndexingType type) {
   int32_t status = 0;
   HAL_SetEncoderIndexSource(
       m_encoder, source.GetPortHandleForRouting(),
@@ -471,14 +471,14 @@ void Encoder::SetIndexSource(const DigitalSource& source,
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
 }
 
-int Encoder::GetFPGAIndex() const {
+int frc::Encoder::GetFPGAIndex() const {
   int32_t status = 0;
   int val = HAL_GetEncoderFPGAIndex(m_encoder, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
   return val;
 }
 
-void Encoder::UpdateTable() {
+void frc::Encoder::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Speed", GetRate());
     m_table->PutNumber("Distance", GetDistance());
@@ -490,11 +490,11 @@ void Encoder::UpdateTable() {
   }
 }
 
-void Encoder::StartLiveWindowMode() {}
+void frc::Encoder::StartLiveWindowMode() {}
 
-void Encoder::StopLiveWindowMode() {}
+void frc::Encoder::StopLiveWindowMode() {}
 
-std::string Encoder::GetSmartDashboardType() const {
+std::string frc::Encoder::GetSmartDashboardType() const {
   int32_t status = 0;
   HAL_EncoderEncodingType type = HAL_GetEncoderEncodingType(m_encoder, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -504,9 +504,9 @@ std::string Encoder::GetSmartDashboardType() const {
     return "Encoder";
 }
 
-void Encoder::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::Encoder::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> Encoder::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Encoder::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/GearTooth.cpp
+++ b/wpilibc/athena/src/GearTooth.cpp
@@ -9,14 +9,12 @@
 
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
-constexpr double GearTooth::kGearToothThreshold;
+constexpr double frc::GearTooth::kGearToothThreshold;
 
 /**
  * Common code called by the constructors.
  */
-void GearTooth::EnableDirectionSensing(bool directionSensitive) {
+void frc::GearTooth::EnableDirectionSensing(bool directionSensitive) {
   if (directionSensitive) {
     SetPulseLengthMode(kGearToothThreshold);
   }
@@ -30,7 +28,8 @@ void GearTooth::EnableDirectionSensing(bool directionSensitive) {
  * @param directionSensitive True to enable the pulse length decoding in
  *                           hardware to specify count direction.
  */
-GearTooth::GearTooth(int channel, bool directionSensitive) : Counter(channel) {
+frc::GearTooth::GearTooth(int channel, bool directionSensitive)
+    : Counter(channel) {
   EnableDirectionSensing(directionSensitive);
   LiveWindow::GetInstance()->AddSensor("GearTooth", channel, this);
 }
@@ -45,7 +44,7 @@ GearTooth::GearTooth(int channel, bool directionSensitive) : Counter(channel) {
  * @param directionSensitive True to enable the pulse length decoding in
  *                           hardware to specify count direction.
  */
-GearTooth::GearTooth(DigitalSource* source, bool directionSensitive)
+frc::GearTooth::GearTooth(DigitalSource* source, bool directionSensitive)
     : Counter(source) {
   EnableDirectionSensing(directionSensitive);
 }
@@ -60,10 +59,12 @@ GearTooth::GearTooth(DigitalSource* source, bool directionSensitive)
  * @param directionSensitive True to enable the pulse length decoding in
  *                           hardware to specify count direction.
  */
-GearTooth::GearTooth(std::shared_ptr<DigitalSource> source,
-                     bool directionSensitive)
+frc::GearTooth::GearTooth(std::shared_ptr<DigitalSource> source,
+                          bool directionSensitive)
     : Counter(source) {
   EnableDirectionSensing(directionSensitive);
 }
 
-std::string GearTooth::GetSmartDashboardType() const { return "GearTooth"; }
+std::string frc::GearTooth::GetSmartDashboardType() const {
+  return "GearTooth";
+}

--- a/wpilibc/athena/src/GenericHID.cpp
+++ b/wpilibc/athena/src/GenericHID.cpp
@@ -10,9 +10,7 @@
 #include "DriverStation.h"
 #include "HAL/HAL.h"
 
-using namespace frc;
-
-GenericHID::GenericHID(int port) : m_ds(DriverStation::GetInstance()) {
+frc::GenericHID::GenericHID(int port) : m_ds(DriverStation::GetInstance()) {
   m_port = port;
 }
 
@@ -22,7 +20,7 @@ GenericHID::GenericHID(int port) : m_ds(DriverStation::GetInstance()) {
  * @param axis The axis to read, starting at 0.
  * @return The value of the axis.
  */
-double GenericHID::GetRawAxis(int axis) const {
+double frc::GenericHID::GetRawAxis(int axis) const {
   return m_ds.GetStickAxis(m_port, axis);
 }
 
@@ -36,7 +34,7 @@ double GenericHID::GetRawAxis(int axis) const {
  * @param button The button number to be read (starting at 1)
  * @return The state of the button.
  **/
-bool GenericHID::GetRawButton(int button) const {
+bool frc::GenericHID::GetRawButton(int button) const {
   return m_ds.GetStickButton(m_port, button);
 }
 
@@ -49,7 +47,7 @@ bool GenericHID::GetRawButton(int button) const {
  * @param pov The index of the POV to read (starting at 0)
  * @return the angle of the POV in degrees, or -1 if the POV is not pressed.
  */
-int GenericHID::GetPOV(int pov) const {
+int frc::GenericHID::GetPOV(int pov) const {
   return m_ds.GetStickPOV(GetPort(), pov);
 }
 
@@ -58,21 +56,23 @@ int GenericHID::GetPOV(int pov) const {
  *
  * @return the number of POVs for the current HID
  */
-int GenericHID::GetPOVCount() const { return m_ds.GetStickPOVCount(GetPort()); }
+int frc::GenericHID::GetPOVCount() const {
+  return m_ds.GetStickPOVCount(GetPort());
+}
 
 /**
  * Get the port number of the HID.
  *
  * @return The port number of the HID.
  */
-int GenericHID::GetPort() const { return m_port; }
+int frc::GenericHID::GetPort() const { return m_port; }
 
 /**
  * Get the type of the HID.
  *
  * @return the type of the HID.
  */
-GenericHID::HIDType GenericHID::GetType() const {
+frc::GenericHID::HIDType frc::GenericHID::GetType() const {
   return static_cast<HIDType>(m_ds.GetJoystickType(m_port));
 }
 
@@ -81,7 +81,9 @@ GenericHID::HIDType GenericHID::GetType() const {
  *
  * @return the name of the HID.
  */
-std::string GenericHID::GetName() const { return m_ds.GetJoystickName(m_port); }
+std::string frc::GenericHID::GetName() const {
+  return m_ds.GetJoystickName(m_port);
+}
 
 /**
  * Set a single HID output value for the HID.
@@ -90,7 +92,7 @@ std::string GenericHID::GetName() const { return m_ds.GetJoystickName(m_port); }
  * @param value        The value to set the output to
  */
 
-void GenericHID::SetOutput(int outputNumber, bool value) {
+void frc::GenericHID::SetOutput(int outputNumber, bool value) {
   m_outputs =
       (m_outputs & ~(1 << (outputNumber - 1))) | (value << (outputNumber - 1));
 
@@ -102,7 +104,7 @@ void GenericHID::SetOutput(int outputNumber, bool value) {
  *
  * @param value The 32 bit output value (1 bit for each output)
  */
-void GenericHID::SetOutputs(int value) {
+void frc::GenericHID::SetOutputs(int value) {
   m_outputs = value;
   HAL_SetJoystickOutputs(m_port, m_outputs, m_leftRumble, m_rightRumble);
 }
@@ -115,7 +117,7 @@ void GenericHID::SetOutputs(int value) {
  * @param type  Which rumble value to set
  * @param value The normalized value (0 to 1) to set the rumble to
  */
-void GenericHID::SetRumble(RumbleType type, double value) {
+void frc::GenericHID::SetRumble(RumbleType type, double value) {
   if (value < 0)
     value = 0;
   else if (value > 1)

--- a/wpilibc/athena/src/I2C.cpp
+++ b/wpilibc/athena/src/I2C.cpp
@@ -11,15 +11,13 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
 /**
  * Constructor.
  *
  * @param port          The I2C port to which the device is connected.
  * @param deviceAddress The address of the device on the I2C bus.
  */
-I2C::I2C(Port port, int deviceAddress)
+frc::I2C::I2C(Port port, int deviceAddress)
     : m_port(static_cast<HAL_I2CPort>(port)), m_deviceAddress(deviceAddress) {
   int32_t status = 0;
   HAL_InitializeI2C(m_port, &status);
@@ -31,7 +29,7 @@ I2C::I2C(Port port, int deviceAddress)
 /**
  * Destructor.
  */
-I2C::~I2C() { HAL_CloseI2C(m_port); }
+frc::I2C::~I2C() { HAL_CloseI2C(m_port); }
 
 /**
  * Generic transaction.
@@ -45,8 +43,8 @@ I2C::~I2C() { HAL_CloseI2C(m_port); }
  * @param receiveSize  Number of bytes to read from the device.
  * @return Transfer Aborted... false for success, true for aborted.
  */
-bool I2C::Transaction(uint8_t* dataToSend, int sendSize, uint8_t* dataReceived,
-                      int receiveSize) {
+bool frc::I2C::Transaction(uint8_t* dataToSend, int sendSize,
+                           uint8_t* dataReceived, int receiveSize) {
   int32_t status = 0;
   status = HAL_TransactionI2C(m_port, m_deviceAddress, dataToSend, sendSize,
                               dataReceived, receiveSize);
@@ -62,7 +60,7 @@ bool I2C::Transaction(uint8_t* dataToSend, int sendSize, uint8_t* dataReceived,
  *
  * @return Transfer Aborted... false for success, true for aborted.
  */
-bool I2C::AddressOnly() { return Transaction(nullptr, 0, nullptr, 0); }
+bool frc::I2C::AddressOnly() { return Transaction(nullptr, 0, nullptr, 0); }
 
 /**
  * Execute a write transaction with the device.
@@ -75,7 +73,7 @@ bool I2C::AddressOnly() { return Transaction(nullptr, 0, nullptr, 0); }
  * @param data            The byte to write to the register on the device.
  * @return Transfer Aborted... false for success, true for aborted.
  */
-bool I2C::Write(int registerAddress, uint8_t data) {
+bool frc::I2C::Write(int registerAddress, uint8_t data) {
   uint8_t buffer[2];
   buffer[0] = registerAddress;
   buffer[1] = data;
@@ -94,7 +92,7 @@ bool I2C::Write(int registerAddress, uint8_t data) {
  * @param count The number of bytes to be written.
  * @return Transfer Aborted... false for success, true for aborted.
  */
-bool I2C::WriteBulk(uint8_t* data, int count) {
+bool frc::I2C::WriteBulk(uint8_t* data, int count) {
   int32_t status = 0;
   status = HAL_WriteI2C(m_port, m_deviceAddress, data, count);
   return status < 0;
@@ -113,7 +111,7 @@ bool I2C::WriteBulk(uint8_t* data, int count) {
  *                        read from the device.
  * @return Transfer Aborted... false for success, true for aborted.
  */
-bool I2C::Read(int registerAddress, int count, uint8_t* buffer) {
+bool frc::I2C::Read(int registerAddress, int count, uint8_t* buffer) {
   if (count < 1) {
     wpi_setWPIErrorWithContext(ParameterOutOfRange, "count");
     return true;
@@ -137,7 +135,7 @@ bool I2C::Read(int registerAddress, int count, uint8_t* buffer) {
  * @param count  The number of bytes to read in the transaction.
  * @return Transfer Aborted... false for success, true for aborted.
  */
-bool I2C::ReadOnly(int count, uint8_t* buffer) {
+bool frc::I2C::ReadOnly(int count, uint8_t* buffer) {
   if (count < 1) {
     wpi_setWPIErrorWithContext(ParameterOutOfRange, "count");
     return true;
@@ -157,7 +155,8 @@ bool I2C::ReadOnly(int count, uint8_t* buffer) {
  * @param registerAddress The register to write on all devices on the bus.
  * @param data            The value to write to the devices.
  */
-// [[gnu::warning("I2C::Broadcast() is not implemented.")]] void I2C::Broadcast(
+// [[gnu::warning("frc::I2C::Broadcast() is not implemented.")]] void
+// frc::I2C::Broadcast(
 //     int registerAddress, uint8_t data) {}
 
 /**
@@ -175,8 +174,8 @@ bool I2C::ReadOnly(int count, uint8_t* buffer) {
  * @param expected        A buffer containing the values expected from the
  *                        device.
  */
-bool I2C::VerifySensor(int registerAddress, int count,
-                       const uint8_t* expected) {
+bool frc::I2C::VerifySensor(int registerAddress, int count,
+                            const uint8_t* expected) {
   // TODO: Make use of all 7 read bytes
   uint8_t deviceData[4];
   for (int i = 0, curRegisterAddress = registerAddress; i < count;

--- a/wpilibc/athena/src/Internal/HardwareHLReporting.cpp
+++ b/wpilibc/athena/src/Internal/HardwareHLReporting.cpp
@@ -9,13 +9,11 @@
 
 #include "HAL/HAL.h"
 
-using namespace frc;
-
-void HardwareHLReporting::ReportScheduler() {
+void frc::HardwareHLReporting::ReportScheduler() {
   HAL_Report(HALUsageReporting::kResourceType_Command,
              HALUsageReporting::kCommand_Scheduler);
 }
 
-void HardwareHLReporting::ReportSmartDashboard() {
+void frc::HardwareHLReporting::ReportSmartDashboard() {
   HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
 }

--- a/wpilibc/athena/src/InterruptableSensorBase.cpp
+++ b/wpilibc/athena/src/InterruptableSensorBase.cpp
@@ -11,10 +11,6 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
-InterruptableSensorBase::InterruptableSensorBase() {}
-
 /**
  * Request one of the 8 interrupts asynchronously on this digital input.
  *
@@ -23,7 +19,7 @@ InterruptableSensorBase::InterruptableSensorBase() {}
  * thread priority should use the synchronous method with their own spawned
  * thread. The default is interrupt on rising edges only.
  */
-void InterruptableSensorBase::RequestInterrupts(
+void frc::InterruptableSensorBase::RequestInterrupts(
     HAL_InterruptHandlerFunction handler, void* param) {
   if (StatusIsFatal()) return;
 
@@ -48,7 +44,7 @@ void InterruptableSensorBase::RequestInterrupts(
  * explicitly wait for the interrupt to occur using WaitForInterrupt.
  * The default is interrupt on rising edges only.
  */
-void InterruptableSensorBase::RequestInterrupts() {
+void frc::InterruptableSensorBase::RequestInterrupts() {
   if (StatusIsFatal()) return;
 
   wpi_assert(m_interrupt == HAL_kInvalidHandle);
@@ -64,7 +60,7 @@ void InterruptableSensorBase::RequestInterrupts() {
   SetUpSourceEdge(true, false);
 }
 
-void InterruptableSensorBase::AllocateInterrupts(bool watcher) {
+void frc::InterruptableSensorBase::AllocateInterrupts(bool watcher) {
   wpi_assert(m_interrupt == HAL_kInvalidHandle);
   // Expects the calling leaf class to allocate an interrupt index.
   int32_t status = 0;
@@ -77,7 +73,7 @@ void InterruptableSensorBase::AllocateInterrupts(bool watcher) {
  *
  * This deallocates all the chipobject structures and disables any interrupts.
  */
-void InterruptableSensorBase::CancelInterrupts() {
+void frc::InterruptableSensorBase::CancelInterrupts() {
   if (StatusIsFatal()) return;
   wpi_assert(m_interrupt != HAL_kInvalidHandle);
   int32_t status = 0;
@@ -98,9 +94,10 @@ void InterruptableSensorBase::CancelInterrupts() {
  *                       WaitForInterrupt was called.
  * @return What interrupts fired
  */
-InterruptableSensorBase::WaitResult InterruptableSensorBase::WaitForInterrupt(
-    double timeout, bool ignorePrevious) {
-  if (StatusIsFatal()) return InterruptableSensorBase::kTimeout;
+frc::InterruptableSensorBase::WaitResult
+frc::InterruptableSensorBase::WaitForInterrupt(double timeout,
+                                               bool ignorePrevious) {
+  if (StatusIsFatal()) return frc::InterruptableSensorBase::kTimeout;
   wpi_assert(m_interrupt != HAL_kInvalidHandle);
   int32_t status = 0;
   int result;
@@ -124,7 +121,7 @@ InterruptableSensorBase::WaitResult InterruptableSensorBase::WaitForInterrupt(
  * time to do the setup of the other options before starting to field
  * interrupts.
  */
-void InterruptableSensorBase::EnableInterrupts() {
+void frc::InterruptableSensorBase::EnableInterrupts() {
   if (StatusIsFatal()) return;
   wpi_assert(m_interrupt != HAL_kInvalidHandle);
   int32_t status = 0;
@@ -135,7 +132,7 @@ void InterruptableSensorBase::EnableInterrupts() {
 /**
  * Disable Interrupts without without deallocating structures.
  */
-void InterruptableSensorBase::DisableInterrupts() {
+void frc::InterruptableSensorBase::DisableInterrupts() {
   if (StatusIsFatal()) return;
   wpi_assert(m_interrupt != HAL_kInvalidHandle);
   int32_t status = 0;
@@ -152,7 +149,7 @@ void InterruptableSensorBase::DisableInterrupts() {
  *
  * @return Timestamp in seconds since boot.
  */
-double InterruptableSensorBase::ReadRisingTimestamp() {
+double frc::InterruptableSensorBase::ReadRisingTimestamp() {
   if (StatusIsFatal()) return 0.0;
   wpi_assert(m_interrupt != HAL_kInvalidHandle);
   int32_t status = 0;
@@ -170,7 +167,7 @@ double InterruptableSensorBase::ReadRisingTimestamp() {
  *
  * @return Timestamp in seconds since boot.
 */
-double InterruptableSensorBase::ReadFallingTimestamp() {
+double frc::InterruptableSensorBase::ReadFallingTimestamp() {
   if (StatusIsFatal()) return 0.0;
   wpi_assert(m_interrupt != HAL_kInvalidHandle);
   int32_t status = 0;
@@ -185,8 +182,8 @@ double InterruptableSensorBase::ReadFallingTimestamp() {
  * @param risingEdge  true to interrupt on rising edge
  * @param fallingEdge true to interrupt on falling edge
  */
-void InterruptableSensorBase::SetUpSourceEdge(bool risingEdge,
-                                              bool fallingEdge) {
+void frc::InterruptableSensorBase::SetUpSourceEdge(bool risingEdge,
+                                                   bool fallingEdge) {
   if (StatusIsFatal()) return;
   if (m_interrupt == HAL_kInvalidHandle) {
     wpi_setWPIErrorWithContext(

--- a/wpilibc/athena/src/IterativeRobot.cpp
+++ b/wpilibc/athena/src/IterativeRobot.cpp
@@ -10,9 +10,7 @@
 #include "DriverStation.h"
 #include "HAL/HAL.h"
 
-using namespace frc;
-
-IterativeRobot::IterativeRobot() {
+frc::IterativeRobot::IterativeRobot() {
   HAL_Report(HALUsageReporting::kResourceType_Framework,
              HALUsageReporting::kFramework_Iterative);
 }
@@ -23,7 +21,7 @@ IterativeRobot::IterativeRobot() {
  * This specific StartCompetition() implements "main loop" behaviour synced with
  * the DS packets.
  */
-void IterativeRobot::StartCompetition() {
+void frc::IterativeRobot::StartCompetition() {
   // Loop forever, calling the appropriate mode-dependent function
   while (true) {
     // wait for driver station data so the loop doesn't hog the CPU

--- a/wpilibc/athena/src/IterativeRobotBase.cpp
+++ b/wpilibc/athena/src/IterativeRobotBase.cpp
@@ -13,8 +13,6 @@
 #include "LiveWindow/LiveWindow.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
 /**
  * Robot-wide initialization code should go here.
  *
@@ -27,7 +25,7 @@ using namespace frc;
  * waits for enable will cause the robot to never indicate that the code is
  * ready, causing the robot to be bypassed in a match.
  */
-void IterativeRobotBase::RobotInit() {
+void frc::IterativeRobotBase::RobotInit() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -38,7 +36,7 @@ void IterativeRobotBase::RobotInit() {
  * called each time
  * the robot enters disabled mode.
  */
-void IterativeRobotBase::DisabledInit() {
+void frc::IterativeRobotBase::DisabledInit() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -48,7 +46,7 @@ void IterativeRobotBase::DisabledInit() {
  * Users should override this method for initialization code which will be
  * called each time the robot enters autonomous mode.
  */
-void IterativeRobotBase::AutonomousInit() {
+void frc::IterativeRobotBase::AutonomousInit() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -58,7 +56,7 @@ void IterativeRobotBase::AutonomousInit() {
  * Users should override this method for initialization code which will be
  * called each time the robot enters teleop mode.
  */
-void IterativeRobotBase::TeleopInit() {
+void frc::IterativeRobotBase::TeleopInit() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -68,7 +66,7 @@ void IterativeRobotBase::TeleopInit() {
  * Users should override this method for initialization code which will be
  * called each time the robot enters test mode.
  */
-void IterativeRobotBase::TestInit() {
+void frc::IterativeRobotBase::TestInit() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -78,7 +76,7 @@ void IterativeRobotBase::TestInit() {
  * This function is called each time a new packet is received from the driver
  * station.
  */
-void IterativeRobotBase::RobotPeriodic() {
+void frc::IterativeRobotBase::RobotPeriodic() {
   static bool firstRun = true;
   if (firstRun) {
     llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
@@ -93,7 +91,7 @@ void IterativeRobotBase::RobotPeriodic() {
  * new packet is received from the driver station and the robot is in disabled
  * mode.
  */
-void IterativeRobotBase::DisabledPeriodic() {
+void frc::IterativeRobotBase::DisabledPeriodic() {
   static bool firstRun = true;
   if (firstRun) {
     llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
@@ -108,7 +106,7 @@ void IterativeRobotBase::DisabledPeriodic() {
  * new packet is received from the driver station and the robot is in autonomous
  * mode.
  */
-void IterativeRobotBase::AutonomousPeriodic() {
+void frc::IterativeRobotBase::AutonomousPeriodic() {
   static bool firstRun = true;
   if (firstRun) {
     llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
@@ -123,7 +121,7 @@ void IterativeRobotBase::AutonomousPeriodic() {
  * new packet is received from the driver station and the robot is in teleop
  * mode.
  */
-void IterativeRobotBase::TeleopPeriodic() {
+void frc::IterativeRobotBase::TeleopPeriodic() {
   static bool firstRun = true;
   if (firstRun) {
     llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
@@ -137,7 +135,7 @@ void IterativeRobotBase::TeleopPeriodic() {
  * Users should override this method for code which will be called each time a
  * new packet is received from the driver station and the robot is in test mode.
  */
-void IterativeRobotBase::TestPeriodic() {
+void frc::IterativeRobotBase::TestPeriodic() {
   static bool firstRun = true;
   if (firstRun) {
     llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
@@ -145,14 +143,14 @@ void IterativeRobotBase::TestPeriodic() {
   }
 }
 
-IterativeRobotBase::IterativeRobotBase() {
+frc::IterativeRobotBase::IterativeRobotBase() {
   RobotInit();
 
   // Tell the DS that the robot is ready to be enabled
   HAL_ObserveUserProgramStarting();
 }
 
-void IterativeRobotBase::LoopFunc() {
+void frc::IterativeRobotBase::LoopFunc() {
   // Call the appropriate function depending upon the current robot mode
   if (IsDisabled()) {
     // call DisabledInit() if we are now just entering disabled mode from

--- a/wpilibc/athena/src/Jaguar.cpp
+++ b/wpilibc/athena/src/Jaguar.cpp
@@ -10,15 +10,13 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
 /**
  * Constructor for a Jaguar connected via PWM.
  *
  * @param channel The PWM channel that the Jaguar is attached to. 0-9 are
  *                on-board, 10-19 are on the MXP port
  */
-Jaguar::Jaguar(int channel) : PWMSpeedController(channel) {
+frc::Jaguar::Jaguar(int channel) : PWMSpeedController(channel) {
   /**
    * Input profile defined by Luminary Micro.
    *

--- a/wpilibc/athena/src/Joystick.cpp
+++ b/wpilibc/athena/src/Joystick.cpp
@@ -13,16 +13,14 @@
 #include "HAL/HAL.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
-const int Joystick::kDefaultXAxis;
-const int Joystick::kDefaultYAxis;
-const int Joystick::kDefaultZAxis;
-const int Joystick::kDefaultTwistAxis;
-const int Joystick::kDefaultThrottleAxis;
-const int Joystick::kDefaultTriggerButton;
-const int Joystick::kDefaultTopButton;
-static Joystick* joysticks[DriverStation::kJoystickPorts];
+const int frc::Joystick::kDefaultXAxis;
+const int frc::Joystick::kDefaultYAxis;
+const int frc::Joystick::kDefaultZAxis;
+const int frc::Joystick::kDefaultTwistAxis;
+const int frc::Joystick::kDefaultThrottleAxis;
+const int frc::Joystick::kDefaultTriggerButton;
+const int frc::Joystick::kDefaultTopButton;
+static frc::Joystick* joysticks[frc::DriverStation::kJoystickPorts];
 static bool joySticksInitialized = false;
 
 /**
@@ -33,7 +31,8 @@ static bool joySticksInitialized = false;
  * @param port The port on the Driver Station that the joystick is plugged into
  *             (0-5).
  */
-Joystick::Joystick(int port) : Joystick(port, kNumAxisTypes, kNumButtonTypes) {
+frc::Joystick::Joystick(int port)
+    : Joystick(port, kNumAxisTypes, kNumButtonTypes) {
   m_axes[kXAxis] = kDefaultXAxis;
   m_axes[kYAxis] = kDefaultYAxis;
   m_axes[kZAxis] = kDefaultZAxis;
@@ -57,7 +56,7 @@ Joystick::Joystick(int port) : Joystick(port, kNumAxisTypes, kNumButtonTypes) {
  * @param numAxisTypes   The number of axis types in the enum.
  * @param numButtonTypes The number of button types in the enum.
  */
-Joystick::Joystick(int port, int numAxisTypes, int numButtonTypes)
+frc::Joystick::Joystick(int port, int numAxisTypes, int numButtonTypes)
     : JoystickBase(port),
       m_ds(DriverStation::GetInstance()),
       m_axes(numAxisTypes),
@@ -73,7 +72,7 @@ Joystick::Joystick(int port, int numAxisTypes, int numButtonTypes)
   }
 }
 
-Joystick* Joystick::GetStickForPort(int port) {
+frc::Joystick* frc::Joystick::GetStickForPort(int port) {
   Joystick* stick = joysticks[port];
   if (stick == nullptr) {
     stick = new Joystick(port);
@@ -90,7 +89,7 @@ Joystick* Joystick::GetStickForPort(int port) {
  * @param hand This parameter is ignored for the Joystick class and is only
  *             here to complete the GenericHID interface.
  */
-double Joystick::GetX(JoystickHand hand) const {
+double frc::Joystick::GetX(JoystickHand hand) const {
   return GetRawAxis(m_axes[kXAxis]);
 }
 
@@ -102,7 +101,7 @@ double Joystick::GetX(JoystickHand hand) const {
  * @param hand This parameter is ignored for the Joystick class and is only
  *             here to complete the GenericHID interface.
  */
-double Joystick::GetY(JoystickHand hand) const {
+double frc::Joystick::GetY(JoystickHand hand) const {
   return GetRawAxis(m_axes[kYAxis]);
 }
 
@@ -111,7 +110,7 @@ double Joystick::GetY(JoystickHand hand) const {
  *
  * This depends on the mapping of the joystick connected to the current port.
  */
-double Joystick::GetZ(JoystickHand hand) const {
+double frc::Joystick::GetZ(JoystickHand hand) const {
   return GetRawAxis(m_axes[kZAxis]);
 }
 
@@ -120,14 +119,16 @@ double Joystick::GetZ(JoystickHand hand) const {
  *
  * This depends on the mapping of the joystick connected to the current port.
  */
-double Joystick::GetTwist() const { return GetRawAxis(m_axes[kTwistAxis]); }
+double frc::Joystick::GetTwist() const {
+  return GetRawAxis(m_axes[kTwistAxis]);
+}
 
 /**
  * Get the throttle value of the current joystick.
  *
  * This depends on the mapping of the joystick connected to the current port.
  */
-double Joystick::GetThrottle() const {
+double frc::Joystick::GetThrottle() const {
   return GetRawAxis(m_axes[kThrottleAxis]);
 }
 
@@ -141,7 +142,7 @@ double Joystick::GetThrottle() const {
  * @param axis The axis to read.
  * @return The value of the axis.
  */
-double Joystick::GetAxis(AxisType axis) const {
+double frc::Joystick::GetAxis(AxisType axis) const {
   switch (axis) {
     case kXAxis:
       return this->GetX();
@@ -168,7 +169,7 @@ double Joystick::GetAxis(AxisType axis) const {
  *             here to complete the GenericHID interface.
  * @return The state of the trigger.
  */
-bool Joystick::GetTrigger(JoystickHand hand) const {
+bool frc::Joystick::GetTrigger(JoystickHand hand) const {
   return GetRawButton(m_buttons[kTriggerButton]);
 }
 
@@ -181,7 +182,7 @@ bool Joystick::GetTrigger(JoystickHand hand) const {
  *             here to complete the GenericHID interface.
  * @return The state of the top button.
  */
-bool Joystick::GetTop(JoystickHand hand) const {
+bool frc::Joystick::GetTop(JoystickHand hand) const {
   return GetRawButton(m_buttons[kTopButton]);
 }
 
@@ -193,7 +194,7 @@ bool Joystick::GetTop(JoystickHand hand) const {
  * @param button The type of button to read.
  * @return The state of the button.
  */
-bool Joystick::GetButton(ButtonType button) const {
+bool frc::Joystick::GetButton(ButtonType button) const {
   switch (button) {
     case kTriggerButton:
       return GetTrigger();
@@ -209,14 +210,16 @@ bool Joystick::GetButton(ButtonType button) const {
  *
  * @return the number of axis for the current joystick
  */
-int Joystick::GetAxisCount() const { return m_ds.GetStickAxisCount(GetPort()); }
+int frc::Joystick::GetAxisCount() const {
+  return m_ds.GetStickAxisCount(GetPort());
+}
 
 /**
  * Get the axis type of a joystick axis.
  *
  * @return the axis type of a joystick axis.
  */
-int Joystick::GetAxisType(int axis) const {
+int frc::Joystick::GetAxisType(int axis) const {
   return m_ds.GetJoystickAxisType(GetPort(), axis);
 }
 
@@ -225,7 +228,7 @@ int Joystick::GetAxisType(int axis) const {
  *
  * @return the number of buttons on the current joystick
  */
-int Joystick::GetButtonCount() const {
+int frc::Joystick::GetButtonCount() const {
   return m_ds.GetStickButtonCount(GetPort());
 }
 
@@ -235,7 +238,7 @@ int Joystick::GetButtonCount() const {
  * @param axis The axis to look up the channel for.
  * @return The channel fr the axis.
  */
-int Joystick::GetAxisChannel(AxisType axis) const { return m_axes[axis]; }
+int frc::Joystick::GetAxisChannel(AxisType axis) const { return m_axes[axis]; }
 
 /**
  * Set the channel associated with a specified axis.
@@ -243,7 +246,7 @@ int Joystick::GetAxisChannel(AxisType axis) const { return m_axes[axis]; }
  * @param axis    The axis to set the channel for.
  * @param channel The channel to set the axis to.
  */
-void Joystick::SetAxisChannel(AxisType axis, int channel) {
+void frc::Joystick::SetAxisChannel(AxisType axis, int channel) {
   m_axes[axis] = channel;
 }
 
@@ -253,7 +256,7 @@ void Joystick::SetAxisChannel(AxisType axis, int channel) {
  *
  * @return The magnitude of the direction vector
  */
-double Joystick::GetMagnitude() const {
+double frc::Joystick::GetMagnitude() const {
   return std::sqrt(std::pow(GetX(), 2) + std::pow(GetY(), 2));
 }
 
@@ -263,7 +266,7 @@ double Joystick::GetMagnitude() const {
  *
  * @return The direction of the vector in radians
  */
-double Joystick::GetDirectionRadians() const {
+double frc::Joystick::GetDirectionRadians() const {
   return std::atan2(GetX(), -GetY());
 }
 
@@ -276,6 +279,6 @@ double Joystick::GetDirectionRadians() const {
  *
  * @return The direction of the vector in degrees
  */
-double Joystick::GetDirectionDegrees() const {
+double frc::Joystick::GetDirectionDegrees() const {
   return (180 / std::acos(-1)) * GetDirectionRadians();
 }

--- a/wpilibc/athena/src/MotorSafetyHelper.cpp
+++ b/wpilibc/athena/src/MotorSafetyHelper.cpp
@@ -14,10 +14,8 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
-std::set<MotorSafetyHelper*> MotorSafetyHelper::m_helperList;
-hal::priority_recursive_mutex MotorSafetyHelper::m_listMutex;
+std::set<frc::MotorSafetyHelper*> frc::MotorSafetyHelper::m_helperList;
+hal::priority_recursive_mutex frc::MotorSafetyHelper::m_listMutex;
 
 /**
  * The constructor for a MotorSafetyHelper object.
@@ -31,7 +29,7 @@ hal::priority_recursive_mutex MotorSafetyHelper::m_listMutex;
  * @param safeObject a pointer to the motor object implementing MotorSafety.
  *                   This is used to call the Stop() method on the motor.
  */
-MotorSafetyHelper::MotorSafetyHelper(MotorSafety* safeObject)
+frc::MotorSafetyHelper::MotorSafetyHelper(MotorSafety* safeObject)
     : m_safeObject(safeObject) {
   m_enabled = false;
   m_expiration = DEFAULT_SAFETY_EXPIRATION;
@@ -41,7 +39,7 @@ MotorSafetyHelper::MotorSafetyHelper(MotorSafety* safeObject)
   m_helperList.insert(this);
 }
 
-MotorSafetyHelper::~MotorSafetyHelper() {
+frc::MotorSafetyHelper::~MotorSafetyHelper() {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_listMutex);
   m_helperList.erase(this);
 }
@@ -50,7 +48,7 @@ MotorSafetyHelper::~MotorSafetyHelper() {
  * Feed the motor safety object.
  * Resets the timer on this object that is used to do the timeouts.
  */
-void MotorSafetyHelper::Feed() {
+void frc::MotorSafetyHelper::Feed() {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_syncMutex);
   m_stopTime = Timer::GetFPGATimestamp() + m_expiration;
 }
@@ -59,7 +57,7 @@ void MotorSafetyHelper::Feed() {
  * Set the expiration time for the corresponding motor safety object.
  * @param expirationTime The timeout value in seconds.
  */
-void MotorSafetyHelper::SetExpiration(double expirationTime) {
+void frc::MotorSafetyHelper::SetExpiration(double expirationTime) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_syncMutex);
   m_expiration = expirationTime;
 }
@@ -68,7 +66,7 @@ void MotorSafetyHelper::SetExpiration(double expirationTime) {
  * Retrieve the timeout value for the corresponding motor safety object.
  * @return the timeout value in seconds.
  */
-double MotorSafetyHelper::GetExpiration() const {
+double frc::MotorSafetyHelper::GetExpiration() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_syncMutex);
   return m_expiration;
 }
@@ -78,7 +76,7 @@ double MotorSafetyHelper::GetExpiration() const {
  * @return a true value if the motor is still operating normally and hasn't
  * timed out.
  */
-bool MotorSafetyHelper::IsAlive() const {
+bool frc::MotorSafetyHelper::IsAlive() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_syncMutex);
   return !m_enabled || m_stopTime > Timer::GetFPGATimestamp();
 }
@@ -89,7 +87,7 @@ bool MotorSafetyHelper::IsAlive() const {
  * its timeout value. If it has, the stop method is called, and the motor is
  * shut down until its value is updated again.
  */
-void MotorSafetyHelper::Check() {
+void frc::MotorSafetyHelper::Check() {
   DriverStation& ds = DriverStation::GetInstance();
   if (!m_enabled || ds.IsDisabled() || ds.IsTest()) return;
 
@@ -109,7 +107,7 @@ void MotorSafetyHelper::Check() {
  * Turn on and off the motor safety option for this PWM object.
  * @param enabled True if motor safety is enforced for this object
  */
-void MotorSafetyHelper::SetSafetyEnabled(bool enabled) {
+void frc::MotorSafetyHelper::SetSafetyEnabled(bool enabled) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_syncMutex);
   m_enabled = enabled;
 }
@@ -119,7 +117,7 @@ void MotorSafetyHelper::SetSafetyEnabled(bool enabled) {
  * Return if the motor safety is currently enabled for this devicce.
  * @return True if motor safety is enforced for this device
  */
-bool MotorSafetyHelper::IsSafetyEnabled() const {
+bool frc::MotorSafetyHelper::IsSafetyEnabled() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_syncMutex);
   return m_enabled;
 }
@@ -129,7 +127,7 @@ bool MotorSafetyHelper::IsSafetyEnabled() const {
  * This static  method is called periodically to poll all the motors and stop
  * any that have timed out.
  */
-void MotorSafetyHelper::CheckMotors() {
+void frc::MotorSafetyHelper::CheckMotors() {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_listMutex);
   for (auto elem : m_helperList) {
     elem->Check();

--- a/wpilibc/athena/src/PIDController.cpp
+++ b/wpilibc/athena/src/PIDController.cpp
@@ -15,8 +15,6 @@
 #include "PIDOutput.h"
 #include "PIDSource.h"
 
-using namespace frc;
-
 static const std::string kP = "p";
 static const std::string kI = "i";
 static const std::string kD = "d";
@@ -36,8 +34,9 @@ static const std::string kEnabled = "enabled";
  *               effects calculations of the integral and differental terms.
  *               The default is 50ms.
  */
-PIDController::PIDController(double Kp, double Ki, double Kd, PIDSource* source,
-                             PIDOutput* output, double period)
+frc::PIDController::PIDController(double Kp, double Ki, double Kd,
+                                  PIDSource* source, PIDOutput* output,
+                                  double period)
     : PIDController(Kp, Ki, Kd, 0.0, source, output, period) {}
 
 /**
@@ -52,10 +51,11 @@ PIDController::PIDController(double Kp, double Ki, double Kd, PIDSource* source,
  *               effects calculations of the integral and differental terms.
  *               The default is 50ms.
  */
-PIDController::PIDController(double Kp, double Ki, double Kd, double Kf,
-                             PIDSource* source, PIDOutput* output,
-                             double period) {
-  m_controlLoop = std::make_unique<Notifier>(&PIDController::Calculate, this);
+frc::PIDController::PIDController(double Kp, double Ki, double Kd, double Kf,
+                                  PIDSource* source, PIDOutput* output,
+                                  double period) {
+  m_controlLoop =
+      std::make_unique<Notifier>(&frc::PIDController::Calculate, this);
 
   m_P = Kp;
   m_I = Ki;
@@ -74,7 +74,7 @@ PIDController::PIDController(double Kp, double Ki, double Kd, double Kf,
   HAL_Report(HALUsageReporting::kResourceType_PIDController, instances);
 }
 
-PIDController::~PIDController() {
+frc::PIDController::~PIDController() {
   // forcefully stopping the notifier so the callback can successfully run.
   m_controlLoop->Stop();
   if (m_table != nullptr) m_table->RemoveTableListener(this);
@@ -84,7 +84,7 @@ PIDController::~PIDController() {
  * Read the input, calculate the output accordingly, and write to the output.
  * This should only be called by the Notifier.
  */
-void PIDController::Calculate() {
+void frc::PIDController::Calculate() {
   bool enabled;
   PIDSource* pidInput;
   PIDOutput* pidOutput;
@@ -175,7 +175,7 @@ void PIDController::Calculate() {
  * output measured in setpoint units per this controller's update period (see
  * the default period in this class's constructor).
  */
-double PIDController::CalculateFeedForward() {
+double frc::PIDController::CalculateFeedForward() {
   if (m_pidInput->GetPIDSourceType() == PIDSourceType::kRate) {
     return m_F * GetSetpoint();
   } else {
@@ -195,7 +195,7 @@ double PIDController::CalculateFeedForward() {
  * @param i Integral coefficient
  * @param d Differential coefficient
  */
-void PIDController::SetPID(double p, double i, double d) {
+void frc::PIDController::SetPID(double p, double i, double d) {
   {
     std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
     m_P = p;
@@ -220,7 +220,7 @@ void PIDController::SetPID(double p, double i, double d) {
  * @param d Differential coefficient
  * @param f Feed forward coefficient
  */
-void PIDController::SetPID(double p, double i, double d, double f) {
+void frc::PIDController::SetPID(double p, double i, double d, double f) {
   {
     std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
     m_P = p;
@@ -242,7 +242,7 @@ void PIDController::SetPID(double p, double i, double d, double f) {
  *
  * @return proportional coefficient
  */
-double PIDController::GetP() const {
+double frc::PIDController::GetP() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   return m_P;
 }
@@ -252,7 +252,7 @@ double PIDController::GetP() const {
  *
  * @return integral coefficient
  */
-double PIDController::GetI() const {
+double frc::PIDController::GetI() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   return m_I;
 }
@@ -262,7 +262,7 @@ double PIDController::GetI() const {
  *
  * @return differential coefficient
  */
-double PIDController::GetD() const {
+double frc::PIDController::GetD() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   return m_D;
 }
@@ -272,7 +272,7 @@ double PIDController::GetD() const {
  *
  * @return Feed forward coefficient
  */
-double PIDController::GetF() const {
+double frc::PIDController::GetF() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   return m_F;
 }
@@ -284,7 +284,7 @@ double PIDController::GetF() const {
  *
  * @return the latest calculated output
  */
-double PIDController::Get() const {
+double frc::PIDController::Get() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   return m_result;
 }
@@ -298,7 +298,7 @@ double PIDController::Get() const {
  *
  * @param continuous true turns on continuous, false turns off continuous
  */
-void PIDController::SetContinuous(bool continuous) {
+void frc::PIDController::SetContinuous(bool continuous) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   m_continuous = continuous;
 }
@@ -309,7 +309,8 @@ void PIDController::SetContinuous(bool continuous) {
  * @param minimumInput the minimum value expected from the input
  * @param maximumInput the maximum value expected from the output
  */
-void PIDController::SetInputRange(double minimumInput, double maximumInput) {
+void frc::PIDController::SetInputRange(double minimumInput,
+                                       double maximumInput) {
   {
     std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
     m_minimumInput = minimumInput;
@@ -325,7 +326,8 @@ void PIDController::SetInputRange(double minimumInput, double maximumInput) {
  * @param minimumOutput the minimum value to write to the output
  * @param maximumOutput the maximum value to write to the output
  */
-void PIDController::SetOutputRange(double minimumOutput, double maximumOutput) {
+void frc::PIDController::SetOutputRange(double minimumOutput,
+                                        double maximumOutput) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   m_minimumOutput = minimumOutput;
   m_maximumOutput = maximumOutput;
@@ -338,7 +340,7 @@ void PIDController::SetOutputRange(double minimumOutput, double maximumOutput) {
  *
  * @param setpoint the desired setpoint
  */
-void PIDController::SetSetpoint(double setpoint) {
+void frc::PIDController::SetSetpoint(double setpoint) {
   {
     std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
 
@@ -368,7 +370,7 @@ void PIDController::SetSetpoint(double setpoint) {
  *
  * @return the current setpoint
  */
-double PIDController::GetSetpoint() const {
+double frc::PIDController::GetSetpoint() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   return m_setpoint;
 }
@@ -378,7 +380,7 @@ double PIDController::GetSetpoint() const {
  *
  * @return the change in setpoint over time
  */
-double PIDController::GetDeltaSetpoint() const {
+double frc::PIDController::GetDeltaSetpoint() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   return (m_setpoint - m_prevSetpoint) / m_setpointTimer.Get();
 }
@@ -388,7 +390,7 @@ double PIDController::GetDeltaSetpoint() const {
  *
  * @return the current error
  */
-double PIDController::GetError() const {
+double frc::PIDController::GetError() const {
   double setpoint = GetSetpoint();
   {
     std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
@@ -399,7 +401,7 @@ double PIDController::GetError() const {
 /**
  * Sets what type of input the PID controller will use.
  */
-void PIDController::SetPIDSourceType(PIDSourceType pidSource) {
+void frc::PIDController::SetPIDSourceType(PIDSourceType pidSource) {
   m_pidInput->SetPIDSourceType(pidSource);
 }
 /**
@@ -407,7 +409,7 @@ void PIDController::SetPIDSourceType(PIDSourceType pidSource) {
  *
  * @return the PID controller input type
  */
-PIDSourceType PIDController::GetPIDSourceType() const {
+frc::PIDSourceType frc::PIDController::GetPIDSourceType() const {
   return m_pidInput->GetPIDSourceType();
 }
 
@@ -419,7 +421,7 @@ PIDSourceType PIDController::GetPIDSourceType() const {
  *
  * @return the average error
  */
-double PIDController::GetAvgError() const {
+double frc::PIDController::GetAvgError() const {
   double avgError = 0;
   {
     std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
@@ -435,7 +437,7 @@ double PIDController::GetAvgError() const {
  *
  * @param percentage error which is tolerable
  */
-void PIDController::SetTolerance(double percent) {
+void frc::PIDController::SetTolerance(double percent) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   m_toleranceType = kPercentTolerance;
   m_tolerance = percent;
@@ -447,7 +449,7 @@ void PIDController::SetTolerance(double percent) {
  *
  * @param percentage error which is tolerable
  */
-void PIDController::SetAbsoluteTolerance(double absTolerance) {
+void frc::PIDController::SetAbsoluteTolerance(double absTolerance) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   m_toleranceType = kAbsoluteTolerance;
   m_tolerance = absTolerance;
@@ -459,7 +461,7 @@ void PIDController::SetAbsoluteTolerance(double absTolerance) {
  *
  * @param percentage error which is tolerable
  */
-void PIDController::SetPercentTolerance(double percent) {
+void frc::PIDController::SetPercentTolerance(double percent) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   m_toleranceType = kPercentTolerance;
   m_tolerance = percent;
@@ -475,7 +477,7 @@ void PIDController::SetPercentTolerance(double percent) {
  *
  * @param bufLength Number of previous cycles to average. Defaults to 1.
  */
-void PIDController::SetToleranceBuffer(int bufLength) {
+void frc::PIDController::SetToleranceBuffer(int bufLength) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   m_bufLength = bufLength;
 
@@ -497,7 +499,7 @@ void PIDController::SetToleranceBuffer(int bufLength) {
  *
  * This will return false until at least one input value has been computed.
  */
-bool PIDController::OnTarget() const {
+bool frc::PIDController::OnTarget() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   if (m_buf.size() == 0) return false;
   double error = GetAvgError();
@@ -519,7 +521,7 @@ bool PIDController::OnTarget() const {
 /**
  * Begin running the PIDController.
  */
-void PIDController::Enable() {
+void frc::PIDController::Enable() {
   {
     std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
     m_enabled = true;
@@ -533,7 +535,7 @@ void PIDController::Enable() {
 /**
  * Stop running the PIDController, this sets the output to zero before stopping.
  */
-void PIDController::Disable() {
+void frc::PIDController::Disable() {
   {
     std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
     m_pidOutput->PIDWrite(0);
@@ -548,7 +550,7 @@ void PIDController::Disable() {
 /**
  * Return true if PIDController is enabled.
  */
-bool PIDController::IsEnabled() const {
+bool frc::PIDController::IsEnabled() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   return m_enabled;
 }
@@ -556,7 +558,7 @@ bool PIDController::IsEnabled() const {
 /**
  * Reset the previous error, the integral term, and disable the controller.
  */
-void PIDController::Reset() {
+void frc::PIDController::Reset() {
   Disable();
 
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
@@ -565,11 +567,11 @@ void PIDController::Reset() {
   m_result = 0;
 }
 
-std::string PIDController::GetSmartDashboardType() const {
+std::string frc::PIDController::GetSmartDashboardType() const {
   return "PIDController";
 }
 
-void PIDController::InitTable(std::shared_ptr<ITable> subtable) {
+void frc::PIDController::InitTable(std::shared_ptr<ITable> subtable) {
   if (m_table != nullptr) m_table->RemoveTableListener(this);
   m_table = subtable;
   if (m_table != nullptr) {
@@ -590,7 +592,7 @@ void PIDController::InitTable(std::shared_ptr<ITable> subtable) {
  * @param error The current error of the PID controller.
  * @return Error for continuous inputs.
  */
-double PIDController::GetContinuousError(double error) const {
+double frc::PIDController::GetContinuousError(double error) const {
   if (m_continuous &&
       std::fabs(error) > (m_maximumInput - m_minimumInput) / 2) {
     if (error > 0) {
@@ -603,10 +605,11 @@ double PIDController::GetContinuousError(double error) const {
   return error;
 }
 
-std::shared_ptr<ITable> PIDController::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::PIDController::GetTable() const { return m_table; }
 
-void PIDController::ValueChanged(ITable* source, llvm::StringRef key,
-                                 std::shared_ptr<nt::Value> value, bool isNew) {
+void frc::PIDController::ValueChanged(ITable* source, llvm::StringRef key,
+                                      std::shared_ptr<nt::Value> value,
+                                      bool isNew) {
   if (key == kP || key == kI || key == kD || key == kF) {
     if (m_P != m_table->GetNumber(kP, 0.0) ||
         m_I != m_table->GetNumber(kI, 0.0) ||
@@ -628,8 +631,8 @@ void PIDController::ValueChanged(ITable* source, llvm::StringRef key,
   }
 }
 
-void PIDController::UpdateTable() {}
+void frc::PIDController::UpdateTable() {}
 
-void PIDController::StartLiveWindowMode() { Disable(); }
+void frc::PIDController::StartLiveWindowMode() { Disable(); }
 
-void PIDController::StopLiveWindowMode() {}
+void frc::PIDController::StopLiveWindowMode() {}

--- a/wpilibc/athena/src/PWM.cpp
+++ b/wpilibc/athena/src/PWM.cpp
@@ -15,8 +15,6 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
 /**
  * Allocate a PWM given a channel number.
  *
@@ -27,7 +25,7 @@ using namespace frc;
  * @param channel The PWM channel number. 0-9 are on-board, 10-19 are on the
  *                MXP port
  */
-PWM::PWM(int channel) {
+frc::PWM::PWM(int channel) {
   llvm::SmallString<32> str;
   llvm::raw_svector_ostream buf(str);
 
@@ -63,7 +61,7 @@ PWM::PWM(int channel) {
  *
  * Free the resource associated with the PWM channel and set the value to 0.
  */
-PWM::~PWM() {
+frc::PWM::~PWM() {
   int32_t status = 0;
 
   HAL_SetPWMDisabled(m_handle, &status);
@@ -83,7 +81,7 @@ PWM::~PWM() {
  *                          Otherwise, keep the full range without modifying
  *                          any values.
  */
-void PWM::EnableDeadbandElimination(bool eliminateDeadband) {
+void frc::PWM::EnableDeadbandElimination(bool eliminateDeadband) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetPWMEliminateDeadband(m_handle, eliminateDeadband, &status);
@@ -103,8 +101,8 @@ void PWM::EnableDeadbandElimination(bool eliminateDeadband) {
  * @param deadbandMin The low end of the deadband pulse width in ms
  * @param min         The minimum pulse width in ms
  */
-void PWM::SetBounds(double max, double deadbandMax, double center,
-                    double deadbandMin, double min) {
+void frc::PWM::SetBounds(double max, double deadbandMax, double center,
+                         double deadbandMin, double min) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetPWMConfig(m_handle, max, deadbandMax, center, deadbandMin, min,
@@ -125,8 +123,8 @@ void PWM::SetBounds(double max, double deadbandMax, double center,
  * @param deadbandMin The low end of the deadband range
  * @param min         The minimum pwm value
  */
-void PWM::SetRawBounds(int max, int deadbandMax, int center, int deadbandMin,
-                       int min) {
+void frc::PWM::SetRawBounds(int max, int deadbandMax, int center,
+                            int deadbandMin, int min) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetPWMConfigRaw(m_handle, max, deadbandMax, center, deadbandMin, min,
@@ -147,8 +145,8 @@ void PWM::SetRawBounds(int max, int deadbandMax, int center, int deadbandMin,
  * @param deadbandMin The low end of the deadband range
  * @param min         The minimum pwm value
  */
-void PWM::GetRawBounds(int* max, int* deadbandMax, int* center,
-                       int* deadbandMin, int* min) {
+void frc::PWM::GetRawBounds(int* max, int* deadbandMax, int* center,
+                            int* deadbandMin, int* min) {
   int32_t status = 0;
   HAL_GetPWMConfigRaw(m_handle, max, deadbandMax, center, deadbandMin, min,
                       &status);
@@ -165,7 +163,7 @@ void PWM::GetRawBounds(int* max, int* deadbandMax, int* center,
  *
  * @param pos The position to set the servo between 0.0 and 1.0.
  */
-void PWM::SetPosition(double pos) {
+void frc::PWM::SetPosition(double pos) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetPWMPosition(m_handle, pos, &status);
@@ -182,7 +180,7 @@ void PWM::SetPosition(double pos) {
  *
  * @return The position the servo is set to between 0.0 and 1.0.
  */
-double PWM::GetPosition() const {
+double frc::PWM::GetPosition() const {
   if (StatusIsFatal()) return 0.0;
   int32_t status = 0;
   double position = HAL_GetPWMPosition(m_handle, &status);
@@ -203,7 +201,7 @@ double PWM::GetPosition() const {
  *
  * @param speed The speed to set the speed controller between -1.0 and 1.0.
  */
-void PWM::SetSpeed(double speed) {
+void frc::PWM::SetSpeed(double speed) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetPWMSpeed(m_handle, speed, &status);
@@ -222,7 +220,7 @@ void PWM::SetSpeed(double speed) {
  *
  * @return The most recently set speed between -1.0 and 1.0.
  */
-double PWM::GetSpeed() const {
+double frc::PWM::GetSpeed() const {
   if (StatusIsFatal()) return 0.0;
   int32_t status = 0;
   double speed = HAL_GetPWMSpeed(m_handle, &status);
@@ -237,7 +235,7 @@ double PWM::GetSpeed() const {
  *
  * @param value Raw PWM value.
  */
-void PWM::SetRaw(uint16_t value) {
+void frc::PWM::SetRaw(uint16_t value) {
   if (StatusIsFatal()) return;
 
   int32_t status = 0;
@@ -252,7 +250,7 @@ void PWM::SetRaw(uint16_t value) {
  *
  * @return Raw PWM control value.
  */
-uint16_t PWM::GetRaw() const {
+uint16_t frc::PWM::GetRaw() const {
   if (StatusIsFatal()) return 0;
 
   int32_t status = 0;
@@ -267,7 +265,7 @@ uint16_t PWM::GetRaw() const {
  *
  * @param mult The period multiplier to apply to this channel
  */
-void PWM::SetPeriodMultiplier(PeriodMultiplier mult) {
+void frc::PWM::SetPeriodMultiplier(PeriodMultiplier mult) {
   if (StatusIsFatal()) return;
 
   int32_t status = 0;
@@ -295,7 +293,7 @@ void PWM::SetPeriodMultiplier(PeriodMultiplier mult) {
  * Temporarily disables the PWM output. The next set call will reenable
  * the output.
  */
-void PWM::SetDisabled() {
+void frc::PWM::SetDisabled() {
   if (StatusIsFatal()) return;
 
   int32_t status = 0;
@@ -304,7 +302,7 @@ void PWM::SetDisabled() {
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
 }
 
-void PWM::SetZeroLatch() {
+void frc::PWM::SetZeroLatch() {
   if (StatusIsFatal()) return;
 
   int32_t status = 0;
@@ -313,37 +311,39 @@ void PWM::SetZeroLatch() {
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
 }
 
-void PWM::ValueChanged(ITable* source, llvm::StringRef key,
-                       std::shared_ptr<nt::Value> value, bool isNew) {
+void frc::PWM::ValueChanged(ITable* source, llvm::StringRef key,
+                            std::shared_ptr<nt::Value> value, bool isNew) {
   if (!value->IsDouble()) return;
   SetSpeed(value->GetDouble());
 }
 
-void PWM::UpdateTable() {
+void frc::PWM::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Value", GetSpeed());
   }
 }
 
-void PWM::StartLiveWindowMode() {
+void frc::PWM::StartLiveWindowMode() {
   SetSpeed(0);
   if (m_table != nullptr) {
     m_table->AddTableListener("Value", this, true);
   }
 }
 
-void PWM::StopLiveWindowMode() {
+void frc::PWM::StopLiveWindowMode() {
   SetSpeed(0);
   if (m_table != nullptr) {
     m_table->RemoveTableListener(this);
   }
 }
 
-std::string PWM::GetSmartDashboardType() const { return "Speed Controller"; }
+std::string frc::PWM::GetSmartDashboardType() const {
+  return "Speed Controller";
+}
 
-void PWM::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::PWM::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> PWM::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::PWM::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/PWMSpeedController.cpp
+++ b/wpilibc/athena/src/PWMSpeedController.cpp
@@ -7,15 +7,13 @@
 
 #include "PWMSpeedController.h"
 
-using namespace frc;
-
 /**
  * Constructor for a PWM Speed Controller connected via PWM.
  *
  * @param channel The PWM channel that the controller is attached to. 0-9 are
  *                on-board, 10-19 are on the MXP port
  */
-PWMSpeedController::PWMSpeedController(int channel) : SafePWM(channel) {}
+frc::PWMSpeedController::PWMSpeedController(int channel) : SafePWM(channel) {}
 
 /**
  * Set the PWM value.
@@ -25,7 +23,7 @@ PWMSpeedController::PWMSpeedController(int channel) : SafePWM(channel) {}
  *
  * @param speed The speed value between -1.0 and 1.0 to set.
  */
-void PWMSpeedController::Set(double speed) {
+void frc::PWMSpeedController::Set(double speed) {
   SetSpeed(m_isInverted ? -speed : speed);
 }
 
@@ -34,21 +32,21 @@ void PWMSpeedController::Set(double speed) {
  *
  * @return The most recently set value for the PWM between -1.0 and 1.0.
  */
-double PWMSpeedController::Get() const { return GetSpeed(); }
+double frc::PWMSpeedController::Get() const { return GetSpeed(); }
 
-void PWMSpeedController::SetInverted(bool isInverted) {
+void frc::PWMSpeedController::SetInverted(bool isInverted) {
   m_isInverted = isInverted;
 }
 
-bool PWMSpeedController::GetInverted() const { return m_isInverted; }
+bool frc::PWMSpeedController::GetInverted() const { return m_isInverted; }
 
-void PWMSpeedController::Disable() { SetDisabled(); }
+void frc::PWMSpeedController::Disable() { SetDisabled(); }
 
-void PWMSpeedController::StopMotor() { SafePWM::StopMotor(); }
+void frc::PWMSpeedController::StopMotor() { SafePWM::StopMotor(); }
 
 /**
  * Write out the PID value as seen in the PIDOutput base object.
  *
  * @param output Write out the PWM value as was found in the PIDController
  */
-void PWMSpeedController::PIDWrite(double output) { Set(output); }
+void frc::PWMSpeedController::PIDWrite(double output) { Set(output); }

--- a/wpilibc/athena/src/PowerDistributionPanel.cpp
+++ b/wpilibc/athena/src/PowerDistributionPanel.cpp
@@ -15,14 +15,14 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
-PowerDistributionPanel::PowerDistributionPanel() : PowerDistributionPanel(0) {}
+frc::PowerDistributionPanel::PowerDistributionPanel()
+    : PowerDistributionPanel(0) {}
 
 /**
  * Initialize the PDP.
  */
-PowerDistributionPanel::PowerDistributionPanel(int module) : m_module(module) {
+frc::PowerDistributionPanel::PowerDistributionPanel(int module)
+    : m_module(module) {
   int32_t status = 0;
   HAL_InitializePDP(m_module, &status);
   if (status != 0) {
@@ -38,7 +38,7 @@ PowerDistributionPanel::PowerDistributionPanel(int module) : m_module(module) {
  *
  * @return The voltage of the PDP in volts
  */
-double PowerDistributionPanel::GetVoltage() const {
+double frc::PowerDistributionPanel::GetVoltage() const {
   int32_t status = 0;
 
   double voltage = HAL_GetPDPVoltage(m_module, &status);
@@ -55,7 +55,7 @@ double PowerDistributionPanel::GetVoltage() const {
  *
  * @return The temperature of the PDP in degrees Celsius
  */
-double PowerDistributionPanel::GetTemperature() const {
+double frc::PowerDistributionPanel::GetTemperature() const {
   int32_t status = 0;
 
   double temperature = HAL_GetPDPTemperature(m_module, &status);
@@ -72,7 +72,7 @@ double PowerDistributionPanel::GetTemperature() const {
  *
  * @return The current of one of the PDP channels (channels 0-15) in Amperes
  */
-double PowerDistributionPanel::GetCurrent(int channel) const {
+double frc::PowerDistributionPanel::GetCurrent(int channel) const {
   int32_t status = 0;
 
   if (!CheckPDPChannel(channel)) {
@@ -96,7 +96,7 @@ double PowerDistributionPanel::GetCurrent(int channel) const {
  *
  * @return The the total current drawn from the PDP channels in Amperes
  */
-double PowerDistributionPanel::GetTotalCurrent() const {
+double frc::PowerDistributionPanel::GetTotalCurrent() const {
   int32_t status = 0;
 
   double current = HAL_GetPDPTotalCurrent(m_module, &status);
@@ -113,7 +113,7 @@ double PowerDistributionPanel::GetTotalCurrent() const {
  *
  * @return The the total power drawn from the PDP channels in Watts
  */
-double PowerDistributionPanel::GetTotalPower() const {
+double frc::PowerDistributionPanel::GetTotalPower() const {
   int32_t status = 0;
 
   double power = HAL_GetPDPTotalPower(m_module, &status);
@@ -130,7 +130,7 @@ double PowerDistributionPanel::GetTotalPower() const {
  *
  * @return The the total energy drawn from the PDP channels in Joules
  */
-double PowerDistributionPanel::GetTotalEnergy() const {
+double frc::PowerDistributionPanel::GetTotalEnergy() const {
   int32_t status = 0;
 
   double energy = HAL_GetPDPTotalEnergy(m_module, &status);
@@ -147,7 +147,7 @@ double PowerDistributionPanel::GetTotalEnergy() const {
  *
  * @see PowerDistributionPanel#GetTotalEnergy
  */
-void PowerDistributionPanel::ResetTotalEnergy() {
+void frc::PowerDistributionPanel::ResetTotalEnergy() {
   int32_t status = 0;
 
   HAL_ResetPDPTotalEnergy(m_module, &status);
@@ -160,7 +160,7 @@ void PowerDistributionPanel::ResetTotalEnergy() {
 /**
  * Remove all of the fault flags on the PDP.
  */
-void PowerDistributionPanel::ClearStickyFaults() {
+void frc::PowerDistributionPanel::ClearStickyFaults() {
   int32_t status = 0;
 
   HAL_ClearPDPStickyFaults(m_module, &status);
@@ -170,7 +170,7 @@ void PowerDistributionPanel::ClearStickyFaults() {
   }
 }
 
-void PowerDistributionPanel::UpdateTable() {
+void frc::PowerDistributionPanel::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Chan0", GetCurrent(0));
     m_table->PutNumber("Chan1", GetCurrent(1));
@@ -193,19 +193,19 @@ void PowerDistributionPanel::UpdateTable() {
   }
 }
 
-void PowerDistributionPanel::StartLiveWindowMode() {}
+void frc::PowerDistributionPanel::StartLiveWindowMode() {}
 
-void PowerDistributionPanel::StopLiveWindowMode() {}
+void frc::PowerDistributionPanel::StopLiveWindowMode() {}
 
-std::string PowerDistributionPanel::GetSmartDashboardType() const {
+std::string frc::PowerDistributionPanel::GetSmartDashboardType() const {
   return "PowerDistributionPanel";
 }
 
-void PowerDistributionPanel::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::PowerDistributionPanel::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> PowerDistributionPanel::GetTable() const {
+std::shared_ptr<ITable> frc::PowerDistributionPanel::GetTable() const {
   return m_table;
 }

--- a/wpilibc/athena/src/Preferences.cpp
+++ b/wpilibc/athena/src/Preferences.cpp
@@ -13,21 +13,20 @@
 #include "WPIErrors.h"
 #include "llvm/StringRef.h"
 
-using namespace frc;
-
 /** The Preferences table name */
 static llvm::StringRef kTableName{"Preferences"};
 
-void Preferences::Listener::ValueChanged(ITable* source, llvm::StringRef key,
-                                         std::shared_ptr<nt::Value> value,
-                                         bool isNew) {}
-void Preferences::Listener::ValueChangedEx(ITable* source, llvm::StringRef key,
-                                           std::shared_ptr<nt::Value> value,
-                                           uint32_t flags) {
+void frc::Preferences::Listener::ValueChanged(ITable* source,
+                                              llvm::StringRef key,
+                                              std::shared_ptr<nt::Value> value,
+                                              bool isNew) {}
+void frc::Preferences::Listener::ValueChangedEx(
+    ITable* source, llvm::StringRef key, std::shared_ptr<nt::Value> value,
+    uint32_t flags) {
   source->SetPersistent(key);
 }
 
-Preferences::Preferences() : m_table(NetworkTable::GetTable(kTableName)) {
+frc::Preferences::Preferences() : m_table(NetworkTable::GetTable(kTableName)) {
   m_table->AddTableListenerEx(&m_listener, NT_NOTIFY_NEW | NT_NOTIFY_IMMEDIATE);
   HAL_Report(HALUsageReporting::kResourceType_Preferences, 0);
 }
@@ -37,7 +36,7 @@ Preferences::Preferences() : m_table(NetworkTable::GetTable(kTableName)) {
  *
  * @return pointer to the {@link Preferences}
  */
-Preferences* Preferences::GetInstance() {
+frc::Preferences* frc::Preferences::GetInstance() {
   static Preferences instance;
   return &instance;
 }
@@ -47,7 +46,9 @@ Preferences* Preferences::GetInstance() {
  *
  * @return a vector of the keys
  */
-std::vector<std::string> Preferences::GetKeys() { return m_table->GetKeys(); }
+std::vector<std::string> frc::Preferences::GetKeys() {
+  return m_table->GetKeys();
+}
 
 /**
  * Returns the string at the given key.  If this table does not have a value
@@ -57,8 +58,8 @@ std::vector<std::string> Preferences::GetKeys() { return m_table->GetKeys(); }
  * @param defaultValue the value to return if none exists in the table
  * @return either the value in the table, or the defaultValue
  */
-std::string Preferences::GetString(llvm::StringRef key,
-                                   llvm::StringRef defaultValue) {
+std::string frc::Preferences::GetString(llvm::StringRef key,
+                                        llvm::StringRef defaultValue) {
   return m_table->GetString(key, defaultValue);
 }
 
@@ -70,7 +71,7 @@ std::string Preferences::GetString(llvm::StringRef key,
  * @param defaultValue the value to return if none exists in the table
  * @return either the value in the table, or the defaultValue
  */
-int Preferences::GetInt(llvm::StringRef key, int defaultValue) {
+int frc::Preferences::GetInt(llvm::StringRef key, int defaultValue) {
   return static_cast<int>(m_table->GetNumber(key, defaultValue));
 }
 
@@ -82,7 +83,7 @@ int Preferences::GetInt(llvm::StringRef key, int defaultValue) {
  * @param defaultValue the value to return if none exists in the table
  * @return either the value in the table, or the defaultValue
  */
-double Preferences::GetDouble(llvm::StringRef key, double defaultValue) {
+double frc::Preferences::GetDouble(llvm::StringRef key, double defaultValue) {
   return m_table->GetNumber(key, defaultValue);
 }
 
@@ -94,7 +95,7 @@ double Preferences::GetDouble(llvm::StringRef key, double defaultValue) {
  * @param defaultValue the value to return if none exists in the table
  * @return either the value in the table, or the defaultValue
  */
-float Preferences::GetFloat(llvm::StringRef key, float defaultValue) {
+float frc::Preferences::GetFloat(llvm::StringRef key, float defaultValue) {
   return m_table->GetNumber(key, defaultValue);
 }
 
@@ -106,7 +107,7 @@ float Preferences::GetFloat(llvm::StringRef key, float defaultValue) {
  * @param defaultValue the value to return if none exists in the table
  * @return either the value in the table, or the defaultValue
  */
-bool Preferences::GetBoolean(llvm::StringRef key, bool defaultValue) {
+bool frc::Preferences::GetBoolean(llvm::StringRef key, bool defaultValue) {
   return m_table->GetBoolean(key, defaultValue);
 }
 
@@ -118,7 +119,7 @@ bool Preferences::GetBoolean(llvm::StringRef key, bool defaultValue) {
  * @param defaultValue the value to return if none exists in the table
  * @return either the value in the table, or the defaultValue
  */
-int64_t Preferences::GetLong(llvm::StringRef key, int64_t defaultValue) {
+int64_t frc::Preferences::GetLong(llvm::StringRef key, int64_t defaultValue) {
   return static_cast<int64_t>(m_table->GetNumber(key, defaultValue));
 }
 
@@ -131,7 +132,7 @@ int64_t Preferences::GetLong(llvm::StringRef key, int64_t defaultValue) {
  * @param key   the key
  * @param value the value
  */
-void Preferences::PutString(llvm::StringRef key, llvm::StringRef value) {
+void frc::Preferences::PutString(llvm::StringRef key, llvm::StringRef value) {
   m_table->PutString(key, value);
   m_table->SetPersistent(key);
 }
@@ -144,7 +145,7 @@ void Preferences::PutString(llvm::StringRef key, llvm::StringRef value) {
  * @param key   the key
  * @param value the value
  */
-void Preferences::PutInt(llvm::StringRef key, int value) {
+void frc::Preferences::PutInt(llvm::StringRef key, int value) {
   m_table->PutNumber(key, value);
   m_table->SetPersistent(key);
 }
@@ -157,7 +158,7 @@ void Preferences::PutInt(llvm::StringRef key, int value) {
  * @param key   the key
  * @param value the value
  */
-void Preferences::PutDouble(llvm::StringRef key, double value) {
+void frc::Preferences::PutDouble(llvm::StringRef key, double value) {
   m_table->PutNumber(key, value);
   m_table->SetPersistent(key);
 }
@@ -170,7 +171,7 @@ void Preferences::PutDouble(llvm::StringRef key, double value) {
  * @param key   the key
  * @param value the value
  */
-void Preferences::PutFloat(llvm::StringRef key, float value) {
+void frc::Preferences::PutFloat(llvm::StringRef key, float value) {
   m_table->PutNumber(key, value);
   m_table->SetPersistent(key);
 }
@@ -183,7 +184,7 @@ void Preferences::PutFloat(llvm::StringRef key, float value) {
  * @param key   the key
  * @param value the value
  */
-void Preferences::PutBoolean(llvm::StringRef key, bool value) {
+void frc::Preferences::PutBoolean(llvm::StringRef key, bool value) {
   m_table->PutBoolean(key, value);
   m_table->SetPersistent(key);
 }
@@ -196,7 +197,7 @@ void Preferences::PutBoolean(llvm::StringRef key, bool value) {
  * @param key   the key
  * @param value the value
  */
-void Preferences::PutLong(llvm::StringRef key, int64_t value) {
+void frc::Preferences::PutLong(llvm::StringRef key, int64_t value) {
   m_table->PutNumber(key, value);
   m_table->SetPersistent(key);
 }
@@ -207,7 +208,7 @@ void Preferences::PutLong(llvm::StringRef key, int64_t value) {
  * @param key the key
  * @return if there is a value at the given key
  */
-bool Preferences::ContainsKey(llvm::StringRef key) {
+bool frc::Preferences::ContainsKey(llvm::StringRef key) {
   return m_table->ContainsKey(key);
 }
 
@@ -216,4 +217,4 @@ bool Preferences::ContainsKey(llvm::StringRef key) {
  *
  * @param key the key
  */
-void Preferences::Remove(llvm::StringRef key) { m_table->Delete(key); }
+void frc::Preferences::Remove(llvm::StringRef key) { m_table->Delete(key); }

--- a/wpilibc/athena/src/Relay.cpp
+++ b/wpilibc/athena/src/Relay.cpp
@@ -15,8 +15,6 @@
 #include "WPIErrors.h"
 #include "llvm/SmallString.h"
 
-using namespace frc;
-
 /**
  * Relay constructor given a channel.
  *
@@ -26,7 +24,7 @@ using namespace frc;
  * @param channel   The channel number (0-3).
  * @param direction The direction that the Relay object will control.
  */
-Relay::Relay(int channel, Relay::Direction direction)
+frc::Relay::Relay(int channel, frc::Relay::Direction direction)
     : m_channel(channel), m_direction(direction) {
   llvm::SmallString<128> str;
   llvm::raw_svector_ostream buf(str);
@@ -95,7 +93,7 @@ Relay::Relay(int channel, Relay::Direction direction)
  *
  * The relay channels are set to free and the relay output is turned off.
  */
-Relay::~Relay() {
+frc::Relay::~Relay() {
   int32_t status = 0;
   HAL_SetRelay(m_forwardHandle, false, &status);
   HAL_SetRelay(m_reverseHandle, false, &status);
@@ -121,7 +119,7 @@ Relay::~Relay() {
  *
  * @param value The state to set the relay.
  */
-void Relay::Set(Relay::Value value) {
+void frc::Relay::Set(frc::Relay::Value value) {
   if (StatusIsFatal()) return;
 
   int32_t status = 0;
@@ -180,9 +178,9 @@ void Relay::Set(Relay::Value value) {
  * When set to kForwardOnly or kReverseOnly, value is returned as kOn/kOff not
  * kForward/kReverse (per the recommendation in Set)
  *
- * @return The current state of the relay as a Relay::Value
+ * @return The current state of the relay as a frc::Relay::Value
  */
-Relay::Value Relay::Get() const {
+frc::Relay::Value frc::Relay::Get() const {
   int32_t status;
 
   if (m_direction == kForwardOnly) {
@@ -216,13 +214,13 @@ Relay::Value Relay::Get() const {
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
 }
 
-int Relay::GetChannel() const { return m_channel; }
+int frc::Relay::GetChannel() const { return m_channel; }
 
 /**
  * Set the expiration time for the Relay object
  * @param timeout The timeout (in seconds) for this relay object
  */
-void Relay::SetExpiration(double timeout) {
+void frc::Relay::SetExpiration(double timeout) {
   m_safetyHelper->SetExpiration(timeout);
 }
 
@@ -230,7 +228,9 @@ void Relay::SetExpiration(double timeout) {
  * Return the expiration time for the relay object.
  * @return The expiration time value.
  */
-double Relay::GetExpiration() const { return m_safetyHelper->GetExpiration(); }
+double frc::Relay::GetExpiration() const {
+  return m_safetyHelper->GetExpiration();
+}
 
 /**
  * Check if the relay object is currently alive or stopped due to a timeout.
@@ -238,7 +238,7 @@ double Relay::GetExpiration() const { return m_safetyHelper->GetExpiration(); }
  * @return a bool value that is true if the motor has NOT timed out and should
  *         still be running.
  */
-bool Relay::IsAlive() const { return m_safetyHelper->IsAlive(); }
+bool frc::Relay::IsAlive() const { return m_safetyHelper->IsAlive(); }
 
 /**
  * Stop the motor associated with this PWM object.
@@ -246,7 +246,7 @@ bool Relay::IsAlive() const { return m_safetyHelper->IsAlive(); }
  * This is called by the MotorSafetyHelper object when it has a timeout for this
  * relay and needs to stop it from running.
  */
-void Relay::StopMotor() { Set(kOff); }
+void frc::Relay::StopMotor() { Set(kOff); }
 
 /**
  * Enable/disable motor safety for this device.
@@ -255,7 +255,7 @@ void Relay::StopMotor() { Set(kOff); }
  *
  * @param enabled True if motor safety is enforced for this object
  */
-void Relay::SetSafetyEnabled(bool enabled) {
+void frc::Relay::SetSafetyEnabled(bool enabled) {
   m_safetyHelper->SetSafetyEnabled(enabled);
 }
 
@@ -264,16 +264,16 @@ void Relay::SetSafetyEnabled(bool enabled) {
  *
  * @returns True if motor safety is enforced for this object
  */
-bool Relay::IsSafetyEnabled() const {
+bool frc::Relay::IsSafetyEnabled() const {
   return m_safetyHelper->IsSafetyEnabled();
 }
 
-void Relay::GetDescription(llvm::raw_ostream& desc) const {
+void frc::Relay::GetDescription(llvm::raw_ostream& desc) const {
   desc << "Relay " << GetChannel();
 }
 
-void Relay::ValueChanged(ITable* source, llvm::StringRef key,
-                         std::shared_ptr<nt::Value> value, bool isNew) {
+void frc::Relay::ValueChanged(ITable* source, llvm::StringRef key,
+                              std::shared_ptr<nt::Value> value, bool isNew) {
   if (!value->IsString()) return;
   if (value->GetString() == "Off")
     Set(kOff);
@@ -285,7 +285,7 @@ void Relay::ValueChanged(ITable* source, llvm::StringRef key,
     Set(kOn);
 }
 
-void Relay::UpdateTable() {
+void frc::Relay::UpdateTable() {
   if (m_table != nullptr) {
     if (Get() == kOn) {
       m_table->PutString("Value", "On");
@@ -299,23 +299,23 @@ void Relay::UpdateTable() {
   }
 }
 
-void Relay::StartLiveWindowMode() {
+void frc::Relay::StartLiveWindowMode() {
   if (m_table != nullptr) {
     m_table->AddTableListener("Value", this, true);
   }
 }
 
-void Relay::StopLiveWindowMode() {
+void frc::Relay::StopLiveWindowMode() {
   if (m_table != nullptr) {
     m_table->RemoveTableListener(this);
   }
 }
 
-std::string Relay::GetSmartDashboardType() const { return "Relay"; }
+std::string frc::Relay::GetSmartDashboardType() const { return "Relay"; }
 
-void Relay::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::Relay::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> Relay::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Relay::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/RobotBase.cpp
+++ b/wpilibc/athena/src/RobotBase.cpp
@@ -20,9 +20,7 @@
 #include "WPILibVersion.h"
 #include "networktables/NetworkTable.h"
 
-using namespace frc;
-
-std::thread::id RobotBase::m_threadId;
+std::thread::id frc::RobotBase::m_threadId;
 
 /**
  * Constructor for a generic robot program.
@@ -35,7 +33,7 @@ std::thread::id RobotBase::m_threadId;
  * future it would be nice to put this code into it's own task that loads on
  * boot so ensure that it runs.
  */
-RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
+frc::RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
   m_threadId = std::this_thread::get_id();
 
   RobotState::SetImplementation(DriverStation::GetInstance());
@@ -67,43 +65,47 @@ RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
  * Determine if the Robot is currently enabled.
  * @return True if the Robot is currently enabled by the field controls.
  */
-bool RobotBase::IsEnabled() const { return m_ds.IsEnabled(); }
+bool frc::RobotBase::IsEnabled() const { return m_ds.IsEnabled(); }
 
 /**
  * Determine if the Robot is currently disabled.
  * @return True if the Robot is currently disabled by the field controls.
  */
-bool RobotBase::IsDisabled() const { return m_ds.IsDisabled(); }
+bool frc::RobotBase::IsDisabled() const { return m_ds.IsDisabled(); }
 
 /**
  * Determine if the robot is currently in Autonomous mode.
  * @return True if the robot is currently operating Autonomously as determined
  * by the field controls.
  */
-bool RobotBase::IsAutonomous() const { return m_ds.IsAutonomous(); }
+bool frc::RobotBase::IsAutonomous() const { return m_ds.IsAutonomous(); }
 
 /**
  * Determine if the robot is currently in Operator Control mode.
  * @return True if the robot is currently operating in Tele-Op mode as
  * determined by the field controls.
  */
-bool RobotBase::IsOperatorControl() const { return m_ds.IsOperatorControl(); }
+bool frc::RobotBase::IsOperatorControl() const {
+  return m_ds.IsOperatorControl();
+}
 
 /**
  * Determine if the robot is currently in Test mode.
  * @return True if the robot is currently running tests as determined by the
  * field controls.
  */
-bool RobotBase::IsTest() const { return m_ds.IsTest(); }
+bool frc::RobotBase::IsTest() const { return m_ds.IsTest(); }
 
 /**
  * Indicates if new data is available from the driver station.
  * @return Has new data arrived over the network since the last time this
  * function was called?
  */
-bool RobotBase::IsNewDataAvailable() const { return m_ds.IsNewControlData(); }
+bool frc::RobotBase::IsNewDataAvailable() const {
+  return m_ds.IsNewControlData();
+}
 
 /**
  * Gets the ID of the main robot thread
  */
-std::thread::id RobotBase::GetThreadId() { return m_threadId; }
+std::thread::id frc::RobotBase::GetThreadId() { return m_threadId; }

--- a/wpilibc/athena/src/RobotDrive.cpp
+++ b/wpilibc/athena/src/RobotDrive.cpp
@@ -17,13 +17,12 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
-using namespace frc;
+const int frc::RobotDrive::kMaxNumberOfMotors;
 
-const int RobotDrive::kMaxNumberOfMotors;
-
-static std::shared_ptr<SpeedController> make_shared_nodelete(
-    SpeedController* ptr) {
-  return std::shared_ptr<SpeedController>(ptr, NullDeleter<SpeedController>());
+static std::shared_ptr<frc::SpeedController> make_shared_nodelete(
+    frc::SpeedController* ptr) {
+  return std::shared_ptr<frc::SpeedController>(
+      ptr, frc::NullDeleter<frc::SpeedController>());
 }
 
 /*
@@ -41,7 +40,7 @@ static std::shared_ptr<SpeedController> make_shared_nodelete(
  * initialize all the motor assignments. The default timeout is set for the
  * robot drive.
  */
-void RobotDrive::InitRobotDrive() {
+void frc::RobotDrive::InitRobotDrive() {
   m_safetyHelper = std::make_unique<MotorSafetyHelper>(this);
   m_safetyHelper->SetSafetyEnabled(true);
 }
@@ -58,7 +57,7 @@ void RobotDrive::InitRobotDrive() {
  * @param rightMotorChannel The PWM channel number that drives the right motor.
  *                          0-9 are on-board, 10-19 are on the MXP port
  */
-RobotDrive::RobotDrive(int leftMotorChannel, int rightMotorChannel) {
+frc::RobotDrive::RobotDrive(int leftMotorChannel, int rightMotorChannel) {
   InitRobotDrive();
   m_rearLeftMotor = std::make_shared<Talon>(leftMotorChannel);
   m_rearRightMotor = std::make_shared<Talon>(rightMotorChannel);
@@ -81,8 +80,8 @@ RobotDrive::RobotDrive(int leftMotorChannel, int rightMotorChannel) {
  * @param rearRightMotor  Rear Right motor channel number. 0-9 are on-board,
  *                        10-19 are on the MXP port
  */
-RobotDrive::RobotDrive(int frontLeftMotor, int rearLeftMotor,
-                       int frontRightMotor, int rearRightMotor) {
+frc::RobotDrive::RobotDrive(int frontLeftMotor, int rearLeftMotor,
+                            int frontRightMotor, int rearRightMotor) {
   InitRobotDrive();
   m_rearLeftMotor = std::make_shared<Talon>(rearLeftMotor);
   m_rearRightMotor = std::make_shared<Talon>(rearRightMotor);
@@ -103,8 +102,8 @@ RobotDrive::RobotDrive(int frontLeftMotor, int rearLeftMotor,
  * @param leftMotor  The left SpeedController object used to drive the robot.
  * @param rightMotor The right SpeedController object used to drive the robot.
  */
-RobotDrive::RobotDrive(SpeedController* leftMotor,
-                       SpeedController* rightMotor) {
+frc::RobotDrive::RobotDrive(SpeedController* leftMotor,
+                            SpeedController* rightMotor) {
   InitRobotDrive();
   if (leftMotor == nullptr || rightMotor == nullptr) {
     wpi_setWPIError(NullParameter);
@@ -116,15 +115,15 @@ RobotDrive::RobotDrive(SpeedController* leftMotor,
 }
 
 // TODO: Change to rvalue references & move syntax.
-RobotDrive::RobotDrive(SpeedController& leftMotor,
-                       SpeedController& rightMotor) {
+frc::RobotDrive::RobotDrive(SpeedController& leftMotor,
+                            SpeedController& rightMotor) {
   InitRobotDrive();
   m_rearLeftMotor = make_shared_nodelete(&leftMotor);
   m_rearRightMotor = make_shared_nodelete(&rightMotor);
 }
 
-RobotDrive::RobotDrive(std::shared_ptr<SpeedController> leftMotor,
-                       std::shared_ptr<SpeedController> rightMotor) {
+frc::RobotDrive::RobotDrive(std::shared_ptr<SpeedController> leftMotor,
+                            std::shared_ptr<SpeedController> rightMotor) {
   InitRobotDrive();
   if (leftMotor == nullptr || rightMotor == nullptr) {
     wpi_setWPIError(NullParameter);
@@ -150,10 +149,10 @@ RobotDrive::RobotDrive(std::shared_ptr<SpeedController> leftMotor,
  * @param rearRightMotor  The back right SpeedController object used to drive
  *                        the robot.
  */
-RobotDrive::RobotDrive(SpeedController* frontLeftMotor,
-                       SpeedController* rearLeftMotor,
-                       SpeedController* frontRightMotor,
-                       SpeedController* rearRightMotor) {
+frc::RobotDrive::RobotDrive(SpeedController* frontLeftMotor,
+                            SpeedController* rearLeftMotor,
+                            SpeedController* frontRightMotor,
+                            SpeedController* rearRightMotor) {
   InitRobotDrive();
   if (frontLeftMotor == nullptr || rearLeftMotor == nullptr ||
       frontRightMotor == nullptr || rearRightMotor == nullptr) {
@@ -166,10 +165,10 @@ RobotDrive::RobotDrive(SpeedController* frontLeftMotor,
   m_rearRightMotor = make_shared_nodelete(rearRightMotor);
 }
 
-RobotDrive::RobotDrive(SpeedController& frontLeftMotor,
-                       SpeedController& rearLeftMotor,
-                       SpeedController& frontRightMotor,
-                       SpeedController& rearRightMotor) {
+frc::RobotDrive::RobotDrive(SpeedController& frontLeftMotor,
+                            SpeedController& rearLeftMotor,
+                            SpeedController& frontRightMotor,
+                            SpeedController& rearRightMotor) {
   InitRobotDrive();
   m_frontLeftMotor = make_shared_nodelete(&frontLeftMotor);
   m_rearLeftMotor = make_shared_nodelete(&rearLeftMotor);
@@ -177,10 +176,10 @@ RobotDrive::RobotDrive(SpeedController& frontLeftMotor,
   m_rearRightMotor = make_shared_nodelete(&rearRightMotor);
 }
 
-RobotDrive::RobotDrive(std::shared_ptr<SpeedController> frontLeftMotor,
-                       std::shared_ptr<SpeedController> rearLeftMotor,
-                       std::shared_ptr<SpeedController> frontRightMotor,
-                       std::shared_ptr<SpeedController> rearRightMotor) {
+frc::RobotDrive::RobotDrive(std::shared_ptr<SpeedController> frontLeftMotor,
+                            std::shared_ptr<SpeedController> rearLeftMotor,
+                            std::shared_ptr<SpeedController> frontRightMotor,
+                            std::shared_ptr<SpeedController> rearRightMotor) {
   InitRobotDrive();
   if (frontLeftMotor == nullptr || rearLeftMotor == nullptr ||
       frontRightMotor == nullptr || rearRightMotor == nullptr) {
@@ -215,7 +214,7 @@ RobotDrive::RobotDrive(std::shared_ptr<SpeedController> frontLeftMotor,
  * Conversely, turn radius r = -ln(curve)*w for a given value of curve and
  * wheelbase w.
  */
-void RobotDrive::Drive(double outputMagnitude, double curve) {
+void frc::RobotDrive::Drive(double outputMagnitude, double curve) {
   double leftOutput, rightOutput;
   static bool reported = false;
   if (!reported) {
@@ -252,8 +251,8 @@ void RobotDrive::Drive(double outputMagnitude, double curve) {
  * @param leftStick  The joystick to control the left side of the robot.
  * @param rightStick The joystick to control the right side of the robot.
  */
-void RobotDrive::TankDrive(GenericHID* leftStick, GenericHID* rightStick,
-                           bool squaredInputs) {
+void frc::RobotDrive::TankDrive(GenericHID* leftStick, GenericHID* rightStick,
+                                bool squaredInputs) {
   if (leftStick == nullptr || rightStick == nullptr) {
     wpi_setWPIError(NullParameter);
     return;
@@ -261,8 +260,8 @@ void RobotDrive::TankDrive(GenericHID* leftStick, GenericHID* rightStick,
   TankDrive(leftStick->GetY(), rightStick->GetY(), squaredInputs);
 }
 
-void RobotDrive::TankDrive(GenericHID& leftStick, GenericHID& rightStick,
-                           bool squaredInputs) {
+void frc::RobotDrive::TankDrive(GenericHID& leftStick, GenericHID& rightStick,
+                                bool squaredInputs) {
   TankDrive(leftStick.GetY(), rightStick.GetY(), squaredInputs);
 }
 
@@ -278,9 +277,9 @@ void RobotDrive::TankDrive(GenericHID& leftStick, GenericHID& rightStick,
  *                   robot.
  * @param rightAxis  The axis to select on the right side Joystick object.
  */
-void RobotDrive::TankDrive(GenericHID* leftStick, int leftAxis,
-                           GenericHID* rightStick, int rightAxis,
-                           bool squaredInputs) {
+void frc::RobotDrive::TankDrive(GenericHID* leftStick, int leftAxis,
+                                GenericHID* rightStick, int rightAxis,
+                                bool squaredInputs) {
   if (leftStick == nullptr || rightStick == nullptr) {
     wpi_setWPIError(NullParameter);
     return;
@@ -289,9 +288,9 @@ void RobotDrive::TankDrive(GenericHID* leftStick, int leftAxis,
             squaredInputs);
 }
 
-void RobotDrive::TankDrive(GenericHID& leftStick, int leftAxis,
-                           GenericHID& rightStick, int rightAxis,
-                           bool squaredInputs) {
+void frc::RobotDrive::TankDrive(GenericHID& leftStick, int leftAxis,
+                                GenericHID& rightStick, int rightAxis,
+                                bool squaredInputs) {
   TankDrive(leftStick.GetRawAxis(leftAxis), rightStick.GetRawAxis(rightAxis),
             squaredInputs);
 }
@@ -304,8 +303,8 @@ void RobotDrive::TankDrive(GenericHID& leftStick, int leftAxis,
  * @param leftValue  The value of the left stick.
  * @param rightValue The value of the right stick.
  */
-void RobotDrive::TankDrive(double leftValue, double rightValue,
-                           bool squaredInputs) {
+void frc::RobotDrive::TankDrive(double leftValue, double rightValue,
+                                bool squaredInputs) {
   static bool reported = false;
   if (!reported) {
     HAL_Report(HALUsageReporting::kResourceType_RobotDrive, GetNumMotors(),
@@ -339,7 +338,7 @@ void RobotDrive::TankDrive(double leftValue, double rightValue,
  * @param squaredInputs If true, the sensitivity will be increased for small
  *                      values
  */
-void RobotDrive::ArcadeDrive(GenericHID* stick, bool squaredInputs) {
+void frc::RobotDrive::ArcadeDrive(GenericHID* stick, bool squaredInputs) {
   // simply call the full-featured ArcadeDrive with the appropriate values
   ArcadeDrive(stick->GetY(), stick->GetX(), squaredInputs);
 }
@@ -357,7 +356,7 @@ void RobotDrive::ArcadeDrive(GenericHID* stick, bool squaredInputs) {
  * @param squaredInputs If true, the sensitivity will be increased for small
  *                      values
  */
-void RobotDrive::ArcadeDrive(GenericHID& stick, bool squaredInputs) {
+void frc::RobotDrive::ArcadeDrive(GenericHID& stick, bool squaredInputs) {
   // simply call the full-featured ArcadeDrive with the appropriate values
   ArcadeDrive(stick.GetY(), stick.GetX(), squaredInputs);
 }
@@ -378,9 +377,9 @@ void RobotDrive::ArcadeDrive(GenericHID& stick, bool squaredInputs) {
  * @param squaredInputs Setting this parameter to true increases the
  *                      sensitivity at lower speeds
  */
-void RobotDrive::ArcadeDrive(GenericHID* moveStick, int moveAxis,
-                             GenericHID* rotateStick, int rotateAxis,
-                             bool squaredInputs) {
+void frc::RobotDrive::ArcadeDrive(GenericHID* moveStick, int moveAxis,
+                                  GenericHID* rotateStick, int rotateAxis,
+                                  bool squaredInputs) {
   double moveValue = moveStick->GetRawAxis(moveAxis);
   double rotateValue = rotateStick->GetRawAxis(rotateAxis);
 
@@ -403,9 +402,9 @@ void RobotDrive::ArcadeDrive(GenericHID* moveStick, int moveAxis,
  * @param squaredInputs Setting this parameter to true increases the
  *                      sensitivity at lower speeds
  */
-void RobotDrive::ArcadeDrive(GenericHID& moveStick, int moveAxis,
-                             GenericHID& rotateStick, int rotateAxis,
-                             bool squaredInputs) {
+void frc::RobotDrive::ArcadeDrive(GenericHID& moveStick, int moveAxis,
+                                  GenericHID& rotateStick, int rotateAxis,
+                                  bool squaredInputs) {
   double moveValue = moveStick.GetRawAxis(moveAxis);
   double rotateValue = rotateStick.GetRawAxis(rotateAxis);
 
@@ -421,8 +420,8 @@ void RobotDrive::ArcadeDrive(GenericHID& moveStick, int moveAxis,
  * @param rotateValue   The value to use for the rotate right/left
  * @param squaredInputs If set, increases the sensitivity at low speeds
  */
-void RobotDrive::ArcadeDrive(double moveValue, double rotateValue,
-                             bool squaredInputs) {
+void frc::RobotDrive::ArcadeDrive(double moveValue, double rotateValue,
+                                  bool squaredInputs) {
   static bool reported = false;
   if (!reported) {
     HAL_Report(HALUsageReporting::kResourceType_RobotDrive, GetNumMotors(),
@@ -485,8 +484,9 @@ void RobotDrive::ArcadeDrive(double moveValue, double rotateValue,
  * @param gyroAngle The current angle reading from the gyro.  Use this to
  *                  implement field-oriented controls.
  */
-void RobotDrive::MecanumDrive_Cartesian(double x, double y, double rotation,
-                                        double gyroAngle) {
+void frc::RobotDrive::MecanumDrive_Cartesian(double x, double y,
+                                             double rotation,
+                                             double gyroAngle) {
   static bool reported = false;
   if (!reported) {
     HAL_Report(HALUsageReporting::kResourceType_RobotDrive, GetNumMotors(),
@@ -534,8 +534,8 @@ void RobotDrive::MecanumDrive_Cartesian(double x, double y, double rotation,
  * @param rotation  The rate of rotation for the robot that is completely
  *                  independent of the magnitute or direction. [-1.0..1.0]
  */
-void RobotDrive::MecanumDrive_Polar(double magnitude, double direction,
-                                    double rotation) {
+void frc::RobotDrive::MecanumDrive_Polar(double magnitude, double direction,
+                                         double rotation) {
   static bool reported = false;
   if (!reported) {
     HAL_Report(HALUsageReporting::kResourceType_RobotDrive, GetNumMotors(),
@@ -578,8 +578,8 @@ void RobotDrive::MecanumDrive_Polar(double magnitude, double direction,
  * @param rotation  The rate of rotation for the robot that is completely
  *                  independent of the magnitude or direction.  [-1.0..1.0]
  */
-void RobotDrive::HolonomicDrive(double magnitude, double direction,
-                                double rotation) {
+void frc::RobotDrive::HolonomicDrive(double magnitude, double direction,
+                                     double rotation) {
   MecanumDrive_Polar(magnitude, direction, rotation);
 }
 
@@ -593,8 +593,8 @@ void RobotDrive::HolonomicDrive(double magnitude, double direction,
  * @param leftOutput  The speed to send to the left side of the robot.
  * @param rightOutput The speed to send to the right side of the robot.
  */
-void RobotDrive::SetLeftRightMotorOutputs(double leftOutput,
-                                          double rightOutput) {
+void frc::RobotDrive::SetLeftRightMotorOutputs(double leftOutput,
+                                               double rightOutput) {
   wpi_assert(m_rearLeftMotor != nullptr && m_rearRightMotor != nullptr);
 
   if (m_frontLeftMotor != nullptr)
@@ -611,7 +611,7 @@ void RobotDrive::SetLeftRightMotorOutputs(double leftOutput,
 /**
  * Limit motor values to the -1.0 to +1.0 range.
  */
-double RobotDrive::Limit(double number) {
+double frc::RobotDrive::Limit(double number) {
   if (number > 1.0) {
     return 1.0;
   }
@@ -624,7 +624,7 @@ double RobotDrive::Limit(double number) {
 /**
  * Normalize all wheel speeds if the magnitude of any wheel is greater than 1.0.
  */
-void RobotDrive::Normalize(double* wheelSpeeds) {
+void frc::RobotDrive::Normalize(double* wheelSpeeds) {
   double maxMagnitude = std::fabs(wheelSpeeds[0]);
   for (int i = 1; i < kMaxNumberOfMotors; i++) {
     double temp = std::fabs(wheelSpeeds[i]);
@@ -640,7 +640,7 @@ void RobotDrive::Normalize(double* wheelSpeeds) {
 /**
  * Rotate a vector in Cartesian space.
  */
-void RobotDrive::RotateVector(double& x, double& y, double angle) {
+void frc::RobotDrive::RotateVector(double& x, double& y, double angle) {
   double cosA = std::cos(angle * (3.14159 / 180.0));
   double sinA = std::sin(angle * (3.14159 / 180.0));
   double xOut = x * cosA - y * sinA;
@@ -659,7 +659,7 @@ void RobotDrive::RotateVector(double& x, double& y, double angle) {
  * @param motor      The motor index to invert.
  * @param isInverted True if the motor should be inverted when operated.
  */
-void RobotDrive::SetInvertedMotor(MotorType motor, bool isInverted) {
+void frc::RobotDrive::SetInvertedMotor(MotorType motor, bool isInverted) {
   if (motor < 0 || motor > 3) {
     wpi_setWPIError(InvalidMotorIndex);
     return;
@@ -688,7 +688,7 @@ void RobotDrive::SetInvertedMotor(MotorType motor, bool isInverted) {
  * @param sensitivity Effectively sets the turning sensitivity (or turn radius
  *                    for a given value)
  */
-void RobotDrive::SetSensitivity(double sensitivity) {
+void frc::RobotDrive::SetSensitivity(double sensitivity) {
   m_sensitivity = sensitivity;
 }
 
@@ -699,31 +699,33 @@ void RobotDrive::SetSensitivity(double sensitivity) {
  * @param maxOutput Multiplied with the output percentage computed by the drive
  *                  functions.
  */
-void RobotDrive::SetMaxOutput(double maxOutput) { m_maxOutput = maxOutput; }
+void frc::RobotDrive::SetMaxOutput(double maxOutput) {
+  m_maxOutput = maxOutput;
+}
 
-void RobotDrive::SetExpiration(double timeout) {
+void frc::RobotDrive::SetExpiration(double timeout) {
   m_safetyHelper->SetExpiration(timeout);
 }
 
-double RobotDrive::GetExpiration() const {
+double frc::RobotDrive::GetExpiration() const {
   return m_safetyHelper->GetExpiration();
 }
 
-bool RobotDrive::IsAlive() const { return m_safetyHelper->IsAlive(); }
+bool frc::RobotDrive::IsAlive() const { return m_safetyHelper->IsAlive(); }
 
-bool RobotDrive::IsSafetyEnabled() const {
+bool frc::RobotDrive::IsSafetyEnabled() const {
   return m_safetyHelper->IsSafetyEnabled();
 }
 
-void RobotDrive::SetSafetyEnabled(bool enabled) {
+void frc::RobotDrive::SetSafetyEnabled(bool enabled) {
   m_safetyHelper->SetSafetyEnabled(enabled);
 }
 
-void RobotDrive::GetDescription(llvm::raw_ostream& desc) const {
+void frc::RobotDrive::GetDescription(llvm::raw_ostream& desc) const {
   desc << "RobotDrive";
 }
 
-void RobotDrive::StopMotor() {
+void frc::RobotDrive::StopMotor() {
   if (m_frontLeftMotor != nullptr) m_frontLeftMotor->StopMotor();
   if (m_frontRightMotor != nullptr) m_frontRightMotor->StopMotor();
   if (m_rearLeftMotor != nullptr) m_rearLeftMotor->StopMotor();

--- a/wpilibc/athena/src/SD540.cpp
+++ b/wpilibc/athena/src/SD540.cpp
@@ -10,8 +10,6 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
 /**
  * Note that the SD540 uses the following bounds for PWM values. These values
  * should work reasonably well for most controllers, but if users experience
@@ -33,7 +31,7 @@ using namespace frc;
  * @param channel The PWM channel that the SD540 is attached to. 0-9 are
  *                on-board, 10-19 are on the MXP port
  */
-SD540::SD540(int channel) : PWMSpeedController(channel) {
+frc::SD540::SD540(int channel) : PWMSpeedController(channel) {
   SetBounds(2.05, 1.55, 1.50, 1.44, .94);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);

--- a/wpilibc/athena/src/SPI.cpp
+++ b/wpilibc/athena/src/SPI.cpp
@@ -14,14 +14,12 @@
 #include "WPIErrors.h"
 #include "llvm/SmallVector.h"
 
-using namespace frc;
-
 /**
  * Constructor
  *
  * @param port the physical SPI port
  */
-SPI::SPI(Port port) : m_port(static_cast<HAL_SPIPort>(port)) {
+frc::SPI::SPI(Port port) : m_port(static_cast<HAL_SPIPort>(port)) {
   int32_t status = 0;
   HAL_InitializeSPI(m_port, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -34,7 +32,7 @@ SPI::SPI(Port port) : m_port(static_cast<HAL_SPIPort>(port)) {
 /**
  * Destructor.
  */
-SPI::~SPI() { HAL_CloseSPI(m_port); }
+frc::SPI::~SPI() { HAL_CloseSPI(m_port); }
 
 /**
  * Configure the rate of the generated clock signal.
@@ -44,13 +42,13 @@ SPI::~SPI() { HAL_CloseSPI(m_port); }
  *
  * @param hz The clock rate in Hertz.
  */
-void SPI::SetClockRate(double hz) { HAL_SetSPISpeed(m_port, hz); }
+void frc::SPI::SetClockRate(double hz) { HAL_SetSPISpeed(m_port, hz); }
 
 /**
  * Configure the order that bits are sent and received on the wire
  * to be most significant bit first.
  */
-void SPI::SetMSBFirst() {
+void frc::SPI::SetMSBFirst() {
   m_msbFirst = true;
   HAL_SetSPIOpts(m_port, m_msbFirst, m_sampleOnTrailing, m_clk_idle_high);
 }
@@ -59,7 +57,7 @@ void SPI::SetMSBFirst() {
  * Configure the order that bits are sent and received on the wire
  * to be least significant bit first.
  */
-void SPI::SetLSBFirst() {
+void frc::SPI::SetLSBFirst() {
   m_msbFirst = false;
   HAL_SetSPIOpts(m_port, m_msbFirst, m_sampleOnTrailing, m_clk_idle_high);
 }
@@ -68,7 +66,7 @@ void SPI::SetLSBFirst() {
  * Configure that the data is stable on the falling edge and the data
  * changes on the rising edge.
  */
-void SPI::SetSampleDataOnFalling() {
+void frc::SPI::SetSampleDataOnFalling() {
   m_sampleOnTrailing = true;
   HAL_SetSPIOpts(m_port, m_msbFirst, m_sampleOnTrailing, m_clk_idle_high);
 }
@@ -77,7 +75,7 @@ void SPI::SetSampleDataOnFalling() {
  * Configure that the data is stable on the rising edge and the data
  * changes on the falling edge.
  */
-void SPI::SetSampleDataOnRising() {
+void frc::SPI::SetSampleDataOnRising() {
   m_sampleOnTrailing = false;
   HAL_SetSPIOpts(m_port, m_msbFirst, m_sampleOnTrailing, m_clk_idle_high);
 }
@@ -86,7 +84,7 @@ void SPI::SetSampleDataOnRising() {
  * Configure the clock output line to be active low.
  * This is sometimes called clock polarity high or clock idle high.
  */
-void SPI::SetClockActiveLow() {
+void frc::SPI::SetClockActiveLow() {
   m_clk_idle_high = true;
   HAL_SetSPIOpts(m_port, m_msbFirst, m_sampleOnTrailing, m_clk_idle_high);
 }
@@ -95,7 +93,7 @@ void SPI::SetClockActiveLow() {
  * Configure the clock output line to be active high.
  * This is sometimes called clock polarity low or clock idle low.
  */
-void SPI::SetClockActiveHigh() {
+void frc::SPI::SetClockActiveHigh() {
   m_clk_idle_high = false;
   HAL_SetSPIOpts(m_port, m_msbFirst, m_sampleOnTrailing, m_clk_idle_high);
 }
@@ -103,7 +101,7 @@ void SPI::SetClockActiveHigh() {
 /**
  * Configure the chip select line to be active high.
  */
-void SPI::SetChipSelectActiveHigh() {
+void frc::SPI::SetChipSelectActiveHigh() {
   int32_t status = 0;
   HAL_SetSPIChipSelectActiveHigh(m_port, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -112,7 +110,7 @@ void SPI::SetChipSelectActiveHigh() {
 /**
  * Configure the chip select line to be active low.
  */
-void SPI::SetChipSelectActiveLow() {
+void frc::SPI::SetChipSelectActiveLow() {
   int32_t status = 0;
   HAL_SetSPIChipSelectActiveLow(m_port, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -125,7 +123,7 @@ void SPI::SetChipSelectActiveLow() {
  * If not running in output only mode, also saves the data received
  * on the MISO input during the transfer into the receive FIFO.
  */
-int SPI::Write(uint8_t* data, int size) {
+int frc::SPI::Write(uint8_t* data, int size) {
   int retVal = 0;
   retVal = HAL_WriteSPI(m_port, data, size);
   return retVal;
@@ -144,7 +142,7 @@ int SPI::Write(uint8_t* data, int size) {
  *                 that data is already in the receive FIFO from a previous
  *                 write.
  */
-int SPI::Read(bool initiate, uint8_t* dataReceived, int size) {
+int frc::SPI::Read(bool initiate, uint8_t* dataReceived, int size) {
   int retVal = 0;
   if (initiate) {
     llvm::SmallVector<uint8_t, 32> dataToSend;
@@ -163,7 +161,8 @@ int SPI::Read(bool initiate, uint8_t* dataReceived, int size) {
  * @param dataReceived Buffer to receive data from the device
  * @param size         The length of the transaction, in bytes
  */
-int SPI::Transaction(uint8_t* dataToSend, uint8_t* dataReceived, int size) {
+int frc::SPI::Transaction(uint8_t* dataToSend, uint8_t* dataReceived,
+                          int size) {
   int retVal = 0;
   retVal = HAL_TransactionSPI(m_port, dataToSend, dataReceived, size);
   return retVal;
@@ -184,9 +183,9 @@ int SPI::Transaction(uint8_t* dataToSend, uint8_t* dataReceived, int size) {
  * @param is_signed  Is data field signed?
  * @param big_endian Is device big endian?
  */
-void SPI::InitAccumulator(double period, int cmd, int xfer_size, int valid_mask,
-                          int valid_value, int data_shift, int data_size,
-                          bool is_signed, bool big_endian) {
+void frc::SPI::InitAccumulator(double period, int cmd, int xfer_size,
+                               int valid_mask, int valid_value, int data_shift,
+                               int data_size, bool is_signed, bool big_endian) {
   int32_t status = 0;
   HAL_InitSPIAccumulator(m_port, static_cast<int32_t>(period * 1e6), cmd,
                          xfer_size, valid_mask, valid_value, data_shift,
@@ -197,7 +196,7 @@ void SPI::InitAccumulator(double period, int cmd, int xfer_size, int valid_mask,
 /**
  * Frees the accumulator.
  */
-void SPI::FreeAccumulator() {
+void frc::SPI::FreeAccumulator() {
   int32_t status = 0;
   HAL_FreeSPIAccumulator(m_port, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -206,7 +205,7 @@ void SPI::FreeAccumulator() {
 /**
  * Resets the accumulator to zero.
  */
-void SPI::ResetAccumulator() {
+void frc::SPI::ResetAccumulator() {
   int32_t status = 0;
   HAL_ResetSPIAccumulator(m_port, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -220,7 +219,7 @@ void SPI::ResetAccumulator() {
  * accelerometers to make integration work and to take the device offset into
  * account when integrating.
  */
-void SPI::SetAccumulatorCenter(int center) {
+void frc::SPI::SetAccumulatorCenter(int center) {
   int32_t status = 0;
   HAL_SetSPIAccumulatorCenter(m_port, center, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -229,7 +228,7 @@ void SPI::SetAccumulatorCenter(int center) {
 /**
  * Set the accumulator's deadband.
  */
-void SPI::SetAccumulatorDeadband(int deadband) {
+void frc::SPI::SetAccumulatorDeadband(int deadband) {
   int32_t status = 0;
   HAL_SetSPIAccumulatorDeadband(m_port, deadband, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -238,7 +237,7 @@ void SPI::SetAccumulatorDeadband(int deadband) {
 /**
  * Read the last value read by the accumulator engine.
  */
-int SPI::GetAccumulatorLastValue() const {
+int frc::SPI::GetAccumulatorLastValue() const {
   int32_t status = 0;
   int retVal = HAL_GetSPIAccumulatorLastValue(m_port, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -250,7 +249,7 @@ int SPI::GetAccumulatorLastValue() const {
  *
  * @return The 64-bit value accumulated since the last Reset().
  */
-int64_t SPI::GetAccumulatorValue() const {
+int64_t frc::SPI::GetAccumulatorValue() const {
   int32_t status = 0;
   int64_t retVal = HAL_GetSPIAccumulatorValue(m_port, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -265,7 +264,7 @@ int64_t SPI::GetAccumulatorValue() const {
  *
  * @return The number of times samples from the channel were accumulated.
  */
-int64_t SPI::GetAccumulatorCount() const {
+int64_t frc::SPI::GetAccumulatorCount() const {
   int32_t status = 0;
   int64_t retVal = HAL_GetSPIAccumulatorCount(m_port, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -277,7 +276,7 @@ int64_t SPI::GetAccumulatorCount() const {
  *
  * @return The accumulated average value (value / count).
  */
-double SPI::GetAccumulatorAverage() const {
+double frc::SPI::GetAccumulatorAverage() const {
   int32_t status = 0;
   double retVal = HAL_GetSPIAccumulatorAverage(m_port, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -293,7 +292,7 @@ double SPI::GetAccumulatorAverage() const {
  * @param value Pointer to the 64-bit accumulated output.
  * @param count Pointer to the number of accumulation cycles.
  */
-void SPI::GetAccumulatorOutput(int64_t& value, int64_t& count) const {
+void frc::SPI::GetAccumulatorOutput(int64_t& value, int64_t& count) const {
   int32_t status = 0;
   HAL_GetSPIAccumulatorOutput(m_port, &value, &count, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));

--- a/wpilibc/athena/src/SafePWM.cpp
+++ b/wpilibc/athena/src/SafePWM.cpp
@@ -7,15 +7,13 @@
 
 #include "SafePWM.h"
 
-using namespace frc;
-
 /**
  * Constructor for a SafePWM object taking a channel number.
  *
  * @param channel The PWM channel number 0-9 are on-board, 10-19 are on the MXP
  *                port
  */
-SafePWM::SafePWM(int channel) : PWM(channel) {
+frc::SafePWM::SafePWM(int channel) : PWM(channel) {
   m_safetyHelper = std::make_unique<MotorSafetyHelper>(this);
   m_safetyHelper->SetSafetyEnabled(false);
 }
@@ -25,7 +23,7 @@ SafePWM::SafePWM(int channel) : PWM(channel) {
  *
  * @param timeout The timeout (in seconds) for this motor object
  */
-void SafePWM::SetExpiration(double timeout) {
+void frc::SafePWM::SetExpiration(double timeout) {
   m_safetyHelper->SetExpiration(timeout);
 }
 
@@ -34,7 +32,7 @@ void SafePWM::SetExpiration(double timeout) {
  *
  * @returns The expiration time value.
  */
-double SafePWM::GetExpiration() const {
+double frc::SafePWM::GetExpiration() const {
   return m_safetyHelper->GetExpiration();
 }
 
@@ -44,7 +42,7 @@ double SafePWM::GetExpiration() const {
  * @return a bool value that is true if the motor has NOT timed out and should
  *         still be running.
  */
-bool SafePWM::IsAlive() const { return m_safetyHelper->IsAlive(); }
+bool frc::SafePWM::IsAlive() const { return m_safetyHelper->IsAlive(); }
 
 /**
  * Stop the motor associated with this PWM object.
@@ -52,7 +50,7 @@ bool SafePWM::IsAlive() const { return m_safetyHelper->IsAlive(); }
  * This is called by the MotorSafetyHelper object when it has a timeout for this
  * PWM and needs to stop it from running.
  */
-void SafePWM::StopMotor() { SetDisabled(); }
+void frc::SafePWM::StopMotor() { SetDisabled(); }
 
 /**
  * Enable/disable motor safety for this device.
@@ -61,7 +59,7 @@ void SafePWM::StopMotor() { SetDisabled(); }
  *
  * @param enabled True if motor safety is enforced for this object
  */
-void SafePWM::SetSafetyEnabled(bool enabled) {
+void frc::SafePWM::SetSafetyEnabled(bool enabled) {
   m_safetyHelper->SetSafetyEnabled(enabled);
 }
 
@@ -70,11 +68,11 @@ void SafePWM::SetSafetyEnabled(bool enabled) {
  *
  * @returns True if motor safety is enforced for this object
  */
-bool SafePWM::IsSafetyEnabled() const {
+bool frc::SafePWM::IsSafetyEnabled() const {
   return m_safetyHelper->IsSafetyEnabled();
 }
 
-void SafePWM::GetDescription(llvm::raw_ostream& desc) const {
+void frc::SafePWM::GetDescription(llvm::raw_ostream& desc) const {
   desc << "PWM " << GetChannel();
 }
 
@@ -86,7 +84,7 @@ void SafePWM::GetDescription(llvm::raw_ostream& desc) const {
  *
  * @param speed Value to pass to the PWM class
  */
-void SafePWM::SetSpeed(double speed) {
+void frc::SafePWM::SetSpeed(double speed) {
   PWM::SetSpeed(speed);
   m_safetyHelper->Feed();
 }

--- a/wpilibc/athena/src/SampleRobot.cpp
+++ b/wpilibc/athena/src/SampleRobot.cpp
@@ -13,8 +13,6 @@
 #include "llvm/raw_ostream.h"
 #include "networktables/NetworkTable.h"
 
-using namespace frc;
-
 /**
  * Start a competition.
  *
@@ -25,7 +23,7 @@ using namespace frc;
  * other mode starts or the robot is disabled. Then go back and wait for the
  * robot to be enabled again.
  */
-void SampleRobot::StartCompetition() {
+void frc::SampleRobot::StartCompetition() {
   LiveWindow* lw = LiveWindow::GetInstance();
 
   RobotInit();
@@ -76,7 +74,7 @@ void SampleRobot::StartCompetition() {
  * waits for enable will cause the robot to never indicate that the code is
  * ready, causing the robot to be bypassed in a match.
  */
-void SampleRobot::RobotInit() {
+void frc::SampleRobot::RobotInit() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -86,7 +84,7 @@ void SampleRobot::RobotInit() {
  * Programmers should override this method to run code that should run while the
  * field is disabled.
  */
-void SampleRobot::Disabled() {
+void frc::SampleRobot::Disabled() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -97,7 +95,7 @@ void SampleRobot::Disabled() {
  * field is in the autonomous period. This will be called once each time the
  * robot enters the autonomous state.
  */
-void SampleRobot::Autonomous() {
+void frc::SampleRobot::Autonomous() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -108,7 +106,7 @@ void SampleRobot::Autonomous() {
  * field is in the Operator Control (tele-operated) period. This is called once
  * each time the robot enters the teleop state.
  */
-void SampleRobot::OperatorControl() {
+void frc::SampleRobot::OperatorControl() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -119,7 +117,7 @@ void SampleRobot::OperatorControl() {
  * robot is in test mode. This will be called once whenever the robot enters
  * test mode
  */
-void SampleRobot::Test() {
+void frc::SampleRobot::Test() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -135,9 +133,9 @@ void SampleRobot::Test() {
  * has not been overridden by a user subclass (i.e. the default version runs),
  * then the Autonomous() and OperatorControl() methods will be called.
  */
-void SampleRobot::RobotMain() { m_robotMainOverridden = false; }
+void frc::SampleRobot::RobotMain() { m_robotMainOverridden = false; }
 
-SampleRobot::SampleRobot() {
+frc::SampleRobot::SampleRobot() {
   HAL_Report(HALUsageReporting::kResourceType_Framework,
              HALUsageReporting::kFramework_Simple);
 }

--- a/wpilibc/athena/src/SensorBase.cpp
+++ b/wpilibc/athena/src/SensorBase.cpp
@@ -19,22 +19,20 @@
 #include "HAL/Solenoid.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
-const int SensorBase::kDigitalChannels = HAL_GetNumDigitalChannels();
-const int SensorBase::kAnalogInputs = HAL_GetNumAnalogInputs();
-const int SensorBase::kSolenoidChannels = HAL_GetNumSolenoidChannels();
-const int SensorBase::kSolenoidModules = HAL_GetNumPCMModules();
-const int SensorBase::kPwmChannels = HAL_GetNumPWMChannels();
-const int SensorBase::kRelayChannels = HAL_GetNumRelayHeaders();
-const int SensorBase::kPDPChannels = HAL_GetNumPDPChannels();
+const int frc::SensorBase::kDigitalChannels = HAL_GetNumDigitalChannels();
+const int frc::SensorBase::kAnalogInputs = HAL_GetNumAnalogInputs();
+const int frc::SensorBase::kSolenoidChannels = HAL_GetNumSolenoidChannels();
+const int frc::SensorBase::kSolenoidModules = HAL_GetNumPCMModules();
+const int frc::SensorBase::kPwmChannels = HAL_GetNumPWMChannels();
+const int frc::SensorBase::kRelayChannels = HAL_GetNumRelayHeaders();
+const int frc::SensorBase::kPDPChannels = HAL_GetNumPDPChannels();
 
 /**
  * Check that the solenoid module number is valid.
  *
  * @return Solenoid module is valid and present
  */
-bool SensorBase::CheckSolenoidModule(int moduleNumber) {
+bool frc::SensorBase::CheckSolenoidModule(int moduleNumber) {
   return HAL_CheckSolenoidModule(moduleNumber);
 }
 
@@ -46,7 +44,7 @@ bool SensorBase::CheckSolenoidModule(int moduleNumber) {
  *
  * @return Digital channel is valid
  */
-bool SensorBase::CheckDigitalChannel(int channel) {
+bool frc::SensorBase::CheckDigitalChannel(int channel) {
   return HAL_CheckDIOChannel(channel);
 }
 
@@ -58,7 +56,7 @@ bool SensorBase::CheckDigitalChannel(int channel) {
  *
  * @return Relay channel is valid
  */
-bool SensorBase::CheckRelayChannel(int channel) {
+bool frc::SensorBase::CheckRelayChannel(int channel) {
   return HAL_CheckRelayChannel(channel);
 }
 
@@ -70,7 +68,7 @@ bool SensorBase::CheckRelayChannel(int channel) {
  *
  * @return PWM channel is valid
  */
-bool SensorBase::CheckPWMChannel(int channel) {
+bool frc::SensorBase::CheckPWMChannel(int channel) {
   return HAL_CheckPWMChannel(channel);
 }
 
@@ -82,7 +80,7 @@ bool SensorBase::CheckPWMChannel(int channel) {
  *
  * @return Analog channel is valid
  */
-bool SensorBase::CheckAnalogInputChannel(int channel) {
+bool frc::SensorBase::CheckAnalogInputChannel(int channel) {
   return HAL_CheckAnalogInputChannel(channel);
 }
 
@@ -94,7 +92,7 @@ bool SensorBase::CheckAnalogInputChannel(int channel) {
  *
  * @return Analog channel is valid
  */
-bool SensorBase::CheckAnalogOutputChannel(int channel) {
+bool frc::SensorBase::CheckAnalogOutputChannel(int channel) {
   return HAL_CheckAnalogOutputChannel(channel);
 }
 
@@ -103,7 +101,7 @@ bool SensorBase::CheckAnalogOutputChannel(int channel) {
  *
  * @return Solenoid channel is valid
  */
-bool SensorBase::CheckSolenoidChannel(int channel) {
+bool frc::SensorBase::CheckSolenoidChannel(int channel) {
   return HAL_CheckSolenoidChannel(channel);
 }
 
@@ -112,6 +110,6 @@ bool SensorBase::CheckSolenoidChannel(int channel) {
  *
  * @return PDP channel is valid
  */
-bool SensorBase::CheckPDPChannel(int channel) {
+bool frc::SensorBase::CheckPDPChannel(int channel) {
   return HAL_CheckPDPModule(channel);
 }

--- a/wpilibc/athena/src/SerialPort.cpp
+++ b/wpilibc/athena/src/SerialPort.cpp
@@ -13,8 +13,6 @@
 // static ViStatus _VI_FUNCH ioCompleteHandler (ViSession vi, ViEventType
 // eventType, ViEvent event, ViAddr userHandle);
 
-using namespace frc;
-
 /**
  * Create an instance of a Serial Port class.
  *
@@ -26,9 +24,9 @@ using namespace frc;
  * @param stopBits The number of stop bits to use as defined by the enum
  *                 StopBits.
  */
-SerialPort::SerialPort(int baudRate, Port port, int dataBits,
-                       SerialPort::Parity parity,
-                       SerialPort::StopBits stopBits) {
+frc::SerialPort::SerialPort(int baudRate, Port port, int dataBits,
+                            frc::SerialPort::Parity parity,
+                            frc::SerialPort::StopBits stopBits) {
   int32_t status = 0;
 
   m_port = port;
@@ -64,7 +62,7 @@ SerialPort::SerialPort(int baudRate, Port port, int dataBits,
 /**
  * Destructor.
  */
-SerialPort::~SerialPort() {
+frc::SerialPort::~SerialPort() {
   int32_t status = 0;
   HAL_CloseSerial(static_cast<HAL_SerialPort>(m_port), &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -75,7 +73,7 @@ SerialPort::~SerialPort() {
  *
  * By default, flow control is disabled.
  */
-void SerialPort::SetFlowControl(SerialPort::FlowControl flowControl) {
+void frc::SerialPort::SetFlowControl(frc::SerialPort::FlowControl flowControl) {
   int32_t status = 0;
   HAL_SetSerialFlowControl(static_cast<HAL_SerialPort>(m_port), flowControl,
                            &status);
@@ -91,7 +89,7 @@ void SerialPort::SetFlowControl(SerialPort::FlowControl flowControl) {
  *
  * @param terminator The character to use for termination.
  */
-void SerialPort::EnableTermination(char terminator) {
+void frc::SerialPort::EnableTermination(char terminator) {
   int32_t status = 0;
   HAL_EnableSerialTermination(static_cast<HAL_SerialPort>(m_port), terminator,
                               &status);
@@ -101,7 +99,7 @@ void SerialPort::EnableTermination(char terminator) {
 /**
  * Disable termination behavior.
  */
-void SerialPort::DisableTermination() {
+void frc::SerialPort::DisableTermination() {
   int32_t status = 0;
   HAL_DisableSerialTermination(static_cast<HAL_SerialPort>(m_port), &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -112,7 +110,7 @@ void SerialPort::DisableTermination() {
  *
  * @return The number of bytes available to read
  */
-int SerialPort::GetBytesReceived() {
+int frc::SerialPort::GetBytesReceived() {
   int32_t status = 0;
   int retVal =
       HAL_GetSerialBytesReceived(static_cast<HAL_SerialPort>(m_port), &status);
@@ -127,7 +125,7 @@ int SerialPort::GetBytesReceived() {
  * @param count  The maximum number of bytes to read.
  * @return The number of bytes actually read into the buffer.
  */
-int SerialPort::Read(char* buffer, int count) {
+int frc::SerialPort::Read(char* buffer, int count) {
   int32_t status = 0;
   int retVal = HAL_ReadSerial(static_cast<HAL_SerialPort>(m_port), buffer,
                               count, &status);
@@ -142,7 +140,7 @@ int SerialPort::Read(char* buffer, int count) {
  * @param count  The maximum number of bytes to write.
  * @return The number of bytes actually written into the port.
  */
-int SerialPort::Write(const char* buffer, int count) {
+int frc::SerialPort::Write(const char* buffer, int count) {
   return Write(llvm::StringRef(buffer, static_cast<size_t>(count)));
 }
 
@@ -155,7 +153,7 @@ int SerialPort::Write(const char* buffer, int count) {
  * @param buffer StringRef to the buffer to read the bytes from.
  * @return The number of bytes actually written into the port.
  */
-int SerialPort::Write(llvm::StringRef buffer) {
+int frc::SerialPort::Write(llvm::StringRef buffer) {
   int32_t status = 0;
   int retVal = HAL_WriteSerial(static_cast<HAL_SerialPort>(m_port),
                                buffer.data(), buffer.size(), &status);
@@ -171,7 +169,7 @@ int SerialPort::Write(llvm::StringRef buffer) {
  *
  * @param timeout The number of seconds to to wait for I/O.
  */
-void SerialPort::SetTimeout(double timeout) {
+void frc::SerialPort::SetTimeout(double timeout) {
   int32_t status = 0;
   HAL_SetSerialTimeout(static_cast<HAL_SerialPort>(m_port), timeout, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -189,7 +187,7 @@ void SerialPort::SetTimeout(double timeout) {
  *
  * @param size The read buffer size.
  */
-void SerialPort::SetReadBufferSize(int size) {
+void frc::SerialPort::SetReadBufferSize(int size) {
   int32_t status = 0;
   HAL_SetSerialReadBufferSize(static_cast<HAL_SerialPort>(m_port), size,
                               &status);
@@ -204,7 +202,7 @@ void SerialPort::SetReadBufferSize(int size) {
  *
  * @param size The write buffer size.
  */
-void SerialPort::SetWriteBufferSize(int size) {
+void frc::SerialPort::SetWriteBufferSize(int size) {
   int32_t status = 0;
   HAL_SetSerialWriteBufferSize(static_cast<HAL_SerialPort>(m_port), size,
                                &status);
@@ -222,7 +220,8 @@ void SerialPort::SetWriteBufferSize(int size) {
  *
  * @param mode The write buffer mode.
  */
-void SerialPort::SetWriteBufferMode(SerialPort::WriteBufferMode mode) {
+void frc::SerialPort::SetWriteBufferMode(
+    frc::SerialPort::WriteBufferMode mode) {
   int32_t status = 0;
   HAL_SetSerialWriteMode(static_cast<HAL_SerialPort>(m_port), mode, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -234,7 +233,7 @@ void SerialPort::SetWriteBufferMode(SerialPort::WriteBufferMode mode) {
  * This is used when SetWriteBufferMode() is set to kFlushWhenFull to force a
  * flush before the buffer is full.
  */
-void SerialPort::Flush() {
+void frc::SerialPort::Flush() {
   int32_t status = 0;
   HAL_FlushSerial(static_cast<HAL_SerialPort>(m_port), &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
@@ -245,7 +244,7 @@ void SerialPort::Flush() {
  *
  * Empty the transmit and receive buffers in the device and formatted I/O.
  */
-void SerialPort::Reset() {
+void frc::SerialPort::Reset() {
   int32_t status = 0;
   HAL_ClearSerial(static_cast<HAL_SerialPort>(m_port), &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));

--- a/wpilibc/athena/src/Servo.cpp
+++ b/wpilibc/athena/src/Servo.cpp
@@ -9,19 +9,17 @@
 
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
+constexpr double frc::Servo::kMaxServoAngle;
+constexpr double frc::Servo::kMinServoAngle;
 
-constexpr double Servo::kMaxServoAngle;
-constexpr double Servo::kMinServoAngle;
-
-constexpr double Servo::kDefaultMaxServoPWM;
-constexpr double Servo::kDefaultMinServoPWM;
+constexpr double frc::Servo::kDefaultMaxServoPWM;
+constexpr double frc::Servo::kDefaultMinServoPWM;
 
 /**
  * @param channel The PWM channel to which the servo is attached. 0-9 are
  *                on-board, 10-19 are on the MXP port
  */
-Servo::Servo(int channel) : SafePWM(channel) {
+frc::Servo::Servo(int channel) : SafePWM(channel) {
   // Set minimum and maximum PWM values supported by the servo
   SetBounds(kDefaultMaxServoPWM, 0.0, 0.0, 0.0, kDefaultMinServoPWM);
 
@@ -29,7 +27,7 @@ Servo::Servo(int channel) : SafePWM(channel) {
   SetPeriodMultiplier(kPeriodMultiplier_4X);
 }
 
-Servo::~Servo() {
+frc::Servo::~Servo() {
   if (m_table != nullptr) {
     m_table->RemoveTableListener(this);
   }
@@ -43,14 +41,14 @@ Servo::~Servo() {
  *
  * @param value Position from 0.0 to 1.0.
  */
-void Servo::Set(double value) { SetPosition(value); }
+void frc::Servo::Set(double value) { SetPosition(value); }
 
 /**
  * Set the servo to offline.
  *
  * Set the servo raw value to 0 (undriven)
  */
-void Servo::SetOffline() { SetRaw(0); }
+void frc::Servo::SetOffline() { SetRaw(0); }
 
 /**
  * Get the servo position.
@@ -60,7 +58,7 @@ void Servo::SetOffline() { SetRaw(0); }
  *
  * @return Position from 0.0 to 1.0.
  */
-double Servo::Get() const { return GetPosition(); }
+double frc::Servo::Get() const { return GetPosition(); }
 
 /**
  * Set the servo angle.
@@ -76,7 +74,7 @@ double Servo::Get() const { return GetPosition(); }
  *
  * @param degrees The angle in degrees to set the servo.
  */
-void Servo::SetAngle(double degrees) {
+void frc::Servo::SetAngle(double degrees) {
   if (degrees < kMinServoAngle) {
     degrees = kMinServoAngle;
   } else if (degrees > kMaxServoAngle) {
@@ -94,39 +92,39 @@ void Servo::SetAngle(double degrees) {
  *
  * @return The angle in degrees to which the servo is set.
  */
-double Servo::GetAngle() const {
+double frc::Servo::GetAngle() const {
   return GetPosition() * GetServoAngleRange() + kMinServoAngle;
 }
 
-void Servo::ValueChanged(ITable* source, llvm::StringRef key,
-                         std::shared_ptr<nt::Value> value, bool isNew) {
+void frc::Servo::ValueChanged(ITable* source, llvm::StringRef key,
+                              std::shared_ptr<nt::Value> value, bool isNew) {
   if (!value->IsDouble()) return;
   Set(value->GetDouble());
 }
 
-void Servo::UpdateTable() {
+void frc::Servo::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Value", Get());
   }
 }
 
-void Servo::StartLiveWindowMode() {
+void frc::Servo::StartLiveWindowMode() {
   if (m_table != nullptr) {
     m_table->AddTableListener("Value", this, true);
   }
 }
 
-void Servo::StopLiveWindowMode() {
+void frc::Servo::StopLiveWindowMode() {
   if (m_table != nullptr) {
     m_table->RemoveTableListener(this);
   }
 }
 
-std::string Servo::GetSmartDashboardType() const { return "Servo"; }
+std::string frc::Servo::GetSmartDashboardType() const { return "Servo"; }
 
-void Servo::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::Servo::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> Servo::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Servo::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/Solenoid.cpp
+++ b/wpilibc/athena/src/Solenoid.cpp
@@ -15,14 +15,12 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
 /**
  * Constructor using the default PCM ID (0).
  *
  * @param channel The channel on the PCM to control (0..7).
  */
-Solenoid::Solenoid(int channel)
+frc::Solenoid::Solenoid(int channel)
     : Solenoid(GetDefaultSolenoidModule(), channel) {}
 
 /**
@@ -31,7 +29,7 @@ Solenoid::Solenoid(int channel)
  * @param moduleNumber The CAN ID of the PCM the solenoid is attached to
  * @param channel      The channel on the PCM to control (0..7).
  */
-Solenoid::Solenoid(int moduleNumber, int channel)
+frc::Solenoid::Solenoid(int moduleNumber, int channel)
     : SolenoidBase(moduleNumber), m_channel(channel) {
   llvm::SmallString<32> str;
   llvm::raw_svector_ostream buf(str);
@@ -65,7 +63,7 @@ Solenoid::Solenoid(int moduleNumber, int channel)
 /**
  * Destructor.
  */
-Solenoid::~Solenoid() {
+frc::Solenoid::~Solenoid() {
   HAL_FreeSolenoidPort(m_solenoidHandle);
   if (m_table != nullptr) m_table->RemoveTableListener(this);
 }
@@ -75,7 +73,7 @@ Solenoid::~Solenoid() {
  *
  * @param on Turn the solenoid output off or on.
  */
-void Solenoid::Set(bool on) {
+void frc::Solenoid::Set(bool on) {
   if (StatusIsFatal()) return;
   int32_t status = 0;
   HAL_SetSolenoid(m_solenoidHandle, on, &status);
@@ -87,7 +85,7 @@ void Solenoid::Set(bool on) {
  *
  * @return The current value of the solenoid.
  */
-bool Solenoid::Get() const {
+bool frc::Solenoid::Get() const {
   if (StatusIsFatal()) return false;
   int32_t status = 0;
   bool value = HAL_GetSolenoid(m_solenoidHandle, &status);
@@ -105,42 +103,42 @@ bool Solenoid::Get() const {
  *
  * @return If solenoid is disabled due to short.
  */
-bool Solenoid::IsBlackListed() const {
+bool frc::Solenoid::IsBlackListed() const {
   int value = GetPCMSolenoidBlackList(m_moduleNumber) & (1 << m_channel);
   return (value != 0);
 }
 
-void Solenoid::ValueChanged(ITable* source, llvm::StringRef key,
-                            std::shared_ptr<nt::Value> value, bool isNew) {
+void frc::Solenoid::ValueChanged(ITable* source, llvm::StringRef key,
+                                 std::shared_ptr<nt::Value> value, bool isNew) {
   if (!value->IsBoolean()) return;
   Set(value->GetBoolean());
 }
 
-void Solenoid::UpdateTable() {
+void frc::Solenoid::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutBoolean("Value", Get());
   }
 }
 
-void Solenoid::StartLiveWindowMode() {
+void frc::Solenoid::StartLiveWindowMode() {
   Set(false);
   if (m_table != nullptr) {
     m_table->AddTableListener("Value", this, true);
   }
 }
 
-void Solenoid::StopLiveWindowMode() {
+void frc::Solenoid::StopLiveWindowMode() {
   Set(false);
   if (m_table != nullptr) {
     m_table->RemoveTableListener(this);
   }
 }
 
-std::string Solenoid::GetSmartDashboardType() const { return "Solenoid"; }
+std::string frc::Solenoid::GetSmartDashboardType() const { return "Solenoid"; }
 
-void Solenoid::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::Solenoid::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> Solenoid::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Solenoid::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/SolenoidBase.cpp
+++ b/wpilibc/athena/src/SolenoidBase.cpp
@@ -10,14 +10,13 @@
 #include "HAL/HAL.h"
 #include "HAL/Solenoid.h"
 
-using namespace frc;
-
 /**
  * Constructor
  *
  * @param moduleNumber The CAN PCM ID.
  */
-SolenoidBase::SolenoidBase(int moduleNumber) : m_moduleNumber(moduleNumber) {}
+frc::SolenoidBase::SolenoidBase(int moduleNumber)
+    : m_moduleNumber(moduleNumber) {}
 
 /**
  * Read all 8 solenoids as a single byte
@@ -25,7 +24,7 @@ SolenoidBase::SolenoidBase(int moduleNumber) : m_moduleNumber(moduleNumber) {}
  * @param module the module to read from
  * @return The current value of all 8 solenoids on the module.
  */
-int SolenoidBase::GetAll(int module) {
+int frc::SolenoidBase::GetAll(int module) {
   int value = 0;
   int32_t status = 0;
   value = HAL_GetAllSolenoids(module, &status);
@@ -38,8 +37,8 @@ int SolenoidBase::GetAll(int module) {
  *
  * @return The current value of all 8 solenoids on the module.
  */
-int SolenoidBase::GetAll() const {
-  return SolenoidBase::GetAll(m_moduleNumber);
+int frc::SolenoidBase::GetAll() const {
+  return frc::SolenoidBase::GetAll(m_moduleNumber);
 }
 
 /**
@@ -52,7 +51,7 @@ int SolenoidBase::GetAll() const {
  * @param module the module to read from
  * @return The solenoid blacklist of all 8 solenoids on the module.
  */
-int SolenoidBase::GetPCMSolenoidBlackList(int module) {
+int frc::SolenoidBase::GetPCMSolenoidBlackList(int module) {
   int32_t status = 0;
   return HAL_GetPCMSolenoidBlackList(module, &status);
 }
@@ -66,8 +65,8 @@ int SolenoidBase::GetPCMSolenoidBlackList(int module) {
  *
  * @return The solenoid blacklist of all 8 solenoids on the module.
  */
-int SolenoidBase::GetPCMSolenoidBlackList() const {
-  return SolenoidBase::GetPCMSolenoidBlackList(m_moduleNumber);
+int frc::SolenoidBase::GetPCMSolenoidBlackList() const {
+  return frc::SolenoidBase::GetPCMSolenoidBlackList(m_moduleNumber);
 }
 
 /**
@@ -75,7 +74,7 @@ int SolenoidBase::GetPCMSolenoidBlackList() const {
  * @return true if PCM sticky fault is set : The common highside solenoid
  *         voltage rail is too low, most likely a solenoid channel is shorted.
  */
-bool SolenoidBase::GetPCMSolenoidVoltageStickyFault(int module) {
+bool frc::SolenoidBase::GetPCMSolenoidVoltageStickyFault(int module) {
   int32_t status = 0;
   return HAL_GetPCMSolenoidVoltageStickyFault(module, &status);
 }
@@ -84,8 +83,8 @@ bool SolenoidBase::GetPCMSolenoidVoltageStickyFault(int module) {
  * @return true if PCM sticky fault is set : The common highside solenoid
  *         voltage rail is too low, most likely a solenoid channel is shorted.
  */
-bool SolenoidBase::GetPCMSolenoidVoltageStickyFault() const {
-  return SolenoidBase::GetPCMSolenoidVoltageStickyFault(m_moduleNumber);
+bool frc::SolenoidBase::GetPCMSolenoidVoltageStickyFault() const {
+  return frc::SolenoidBase::GetPCMSolenoidVoltageStickyFault(m_moduleNumber);
 }
 
 /**
@@ -93,7 +92,7 @@ bool SolenoidBase::GetPCMSolenoidVoltageStickyFault() const {
  * @return true if PCM is in fault state : The common highside solenoid voltage
  *         rail is too low, most likely a solenoid channel is shorted.
  */
-bool SolenoidBase::GetPCMSolenoidVoltageFault(int module) {
+bool frc::SolenoidBase::GetPCMSolenoidVoltageFault(int module) {
   int32_t status = 0;
   return HAL_GetPCMSolenoidVoltageFault(module, &status);
 }
@@ -102,8 +101,8 @@ bool SolenoidBase::GetPCMSolenoidVoltageFault(int module) {
  * @return true if PCM is in fault state : The common highside solenoid voltage
  *         rail is too low, most likely a solenoid channel is shorted.
  */
-bool SolenoidBase::GetPCMSolenoidVoltageFault() const {
-  return SolenoidBase::GetPCMSolenoidVoltageFault(m_moduleNumber);
+bool frc::SolenoidBase::GetPCMSolenoidVoltageFault() const {
+  return frc::SolenoidBase::GetPCMSolenoidVoltageFault(m_moduleNumber);
 }
 
 /**
@@ -118,7 +117,7 @@ bool SolenoidBase::GetPCMSolenoidVoltageFault() const {
  *
  * @param module the module to read from
  */
-void SolenoidBase::ClearAllPCMStickyFaults(int module) {
+void frc::SolenoidBase::ClearAllPCMStickyFaults(int module) {
   int32_t status = 0;
   return HAL_ClearAllPCMStickyFaults(module, &status);
 }
@@ -133,6 +132,6 @@ void SolenoidBase::ClearAllPCMStickyFaults(int module) {
  *
  * If no sticky faults are set then this call will have no effect.
  */
-void SolenoidBase::ClearAllPCMStickyFaults() {
-  SolenoidBase::ClearAllPCMStickyFaults(m_moduleNumber);
+void frc::SolenoidBase::ClearAllPCMStickyFaults() {
+  frc::SolenoidBase::ClearAllPCMStickyFaults(m_moduleNumber);
 }

--- a/wpilibc/athena/src/Spark.cpp
+++ b/wpilibc/athena/src/Spark.cpp
@@ -10,8 +10,6 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
 /**
  * Note that the Spark uses the following bounds for PWM values. These values
  * should work reasonably well for most controllers, but if users experience
@@ -33,7 +31,7 @@ using namespace frc;
  * @param channel The PWM channel that the Spark is attached to. 0-9 are
  *                on-board, 10-19 are on the MXP port
  */
-Spark::Spark(int channel) : PWMSpeedController(channel) {
+frc::Spark::Spark(int channel) : PWMSpeedController(channel) {
   SetBounds(2.003, 1.55, 1.50, 1.46, .999);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);

--- a/wpilibc/athena/src/Talon.cpp
+++ b/wpilibc/athena/src/Talon.cpp
@@ -10,15 +10,13 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
 /**
  * Constructor for a Talon (original or Talon SR).
  *
  * @param channel The PWM channel number that the Talon is attached to. 0-9 are
  *                on-board, 10-19 are on the MXP port
  */
-Talon::Talon(int channel) : PWMSpeedController(channel) {
+frc::Talon::Talon(int channel) : PWMSpeedController(channel) {
   /* Note that the Talon uses the following bounds for PWM values. These values
    * should work reasonably well for most controllers, but if users experience
    * issues such as asymmetric behavior around the deadband or inability to

--- a/wpilibc/athena/src/TalonSRX.cpp
+++ b/wpilibc/athena/src/TalonSRX.cpp
@@ -10,15 +10,13 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
 /**
  * Construct a TalonSRX connected via PWM.
  *
  * @param channel The PWM channel that the TalonSRX is attached to. 0-9 are
  *                on-board, 10-19 are on the MXP port
  */
-TalonSRX::TalonSRX(int channel) : PWMSpeedController(channel) {
+frc::TalonSRX::TalonSRX(int channel) : PWMSpeedController(channel) {
   /* Note that the TalonSRX uses the following bounds for PWM values. These
    * values should work reasonably well for most controllers, but if users
    * experience issues such as asymmetric behavior around the deadband or

--- a/wpilibc/athena/src/Threads.cpp
+++ b/wpilibc/athena/src/Threads.cpp
@@ -12,6 +12,7 @@
 #include "HAL/HAL.h"
 
 namespace frc {
+
 /**
  * Get the thread priority for the specified thread.
  *
@@ -79,4 +80,5 @@ bool SetCurrentThreadPriority(bool realTime, int priority) {
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
   return ret;
 }
+
 }  // namespace frc

--- a/wpilibc/athena/src/TimedRobot.cpp
+++ b/wpilibc/athena/src/TimedRobot.cpp
@@ -11,17 +11,15 @@
 
 #include "HAL/HAL.h"
 
-using namespace frc;
-using namespace std::chrono_literals;
-
 /**
  * Provide an alternate "main loop" via StartCompetition().
  */
-void TimedRobot::StartCompetition() {
+void frc::TimedRobot::StartCompetition() {
   // Loop forever, calling the appropriate mode-dependent function
   m_startLoop = true;
   m_loop->StartPeriodic(m_period);
   while (true) {
+    using namespace std::chrono_literals;
     std::this_thread::sleep_for(24h);
   }
 }
@@ -35,7 +33,7 @@ void TimedRobot::StartCompetition() {
  *
  * @param period Period in seconds.
  */
-void TimedRobot::SetPeriod(double period) {
+void frc::TimedRobot::SetPeriod(double period) {
   m_period = period;
 
   if (m_startLoop) {
@@ -43,8 +41,8 @@ void TimedRobot::SetPeriod(double period) {
   }
 }
 
-TimedRobot::TimedRobot() {
-  m_loop = std::make_unique<Notifier>(&TimedRobot::LoopFunc, this);
+frc::TimedRobot::TimedRobot() {
+  m_loop = std::make_unique<Notifier>(&frc::TimedRobot::LoopFunc, this);
 
   // HAL_Report(HALUsageReporting::kResourceType_Framework,
   //            HALUsageReporting::kFramework_Periodic);
@@ -52,4 +50,4 @@ TimedRobot::TimedRobot() {
              HALUsageReporting::kFramework_Iterative);
 }
 
-TimedRobot::~TimedRobot() { m_loop->Stop(); }
+frc::TimedRobot::~TimedRobot() { m_loop->Stop(); }

--- a/wpilibc/athena/src/Timer.cpp
+++ b/wpilibc/athena/src/Timer.cpp
@@ -33,10 +33,10 @@ void Wait(double seconds) {
 
 /**
  * Return the FPGA system clock time in seconds.
- * This is deprecated and just forwards to Timer::GetFPGATimestamp().
+ * This is deprecated and just forwards to frc::Timer::GetFPGATimestamp().
  * @return Robot running time in seconds.
  */
-double GetClock() { return Timer::GetFPGATimestamp(); }
+double GetClock() { return frc::Timer::GetFPGATimestamp(); }
 
 /**
  * @brief Gives real-time clock system time with nanosecond resolution
@@ -44,17 +44,18 @@ double GetClock() { return Timer::GetFPGATimestamp(); }
  *         on Saturday.
  */
 double GetTime() {
-  using namespace std::chrono;
+  using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::system_clock;
+
   return duration_cast<duration<double>>(system_clock::now().time_since_epoch())
       .count();
 }
 
 }  // namespace frc
 
-using namespace frc;
-
 // for compatibility with msvc12--see C2864
-const double Timer::kRolloverTime = (1ll << 32) / 1e6;
+const double frc::Timer::kRolloverTime = (1ll << 32) / 1e6;
 /**
  * Create a new timer object.
  *
@@ -62,7 +63,7 @@ const double Timer::kRolloverTime = (1ll << 32) / 1e6;
  * not running and
  * must be started.
  */
-Timer::Timer() {
+frc::Timer::Timer() {
   // Creates a semaphore to control access to critical regions.
   // Initially 'open'
   Reset();
@@ -75,7 +76,7 @@ Timer::Timer() {
  *
  * @return Current time value for this timer in seconds
  */
-double Timer::Get() const {
+double frc::Timer::Get() const {
   double result;
   double currentTime = GetFPGATimestamp();
 
@@ -102,7 +103,7 @@ double Timer::Get() const {
  * Make the timer startTime the current time so new requests will be relative to
  * now.
  */
-void Timer::Reset() {
+void frc::Timer::Reset() {
   std::lock_guard<hal::priority_mutex> sync(m_mutex);
   m_accumulatedTime = 0;
   m_startTime = GetFPGATimestamp();
@@ -114,7 +115,7 @@ void Timer::Reset() {
  * Just set the running flag to true indicating that all time requests should be
  * relative to the system clock.
  */
-void Timer::Start() {
+void frc::Timer::Start() {
   std::lock_guard<hal::priority_mutex> sync(m_mutex);
   if (!m_running) {
     m_startTime = GetFPGATimestamp();
@@ -129,7 +130,7 @@ void Timer::Start() {
  * subsequent time requests to be read from the accumulated time rather than
  * looking at the system clock.
  */
-void Timer::Stop() {
+void frc::Timer::Stop() {
   double temp = Get();
 
   std::lock_guard<hal::priority_mutex> sync(m_mutex);
@@ -147,7 +148,7 @@ void Timer::Stop() {
  * @param period The period to check for (in seconds).
  * @return True if the period has passed.
  */
-bool Timer::HasPeriodPassed(double period) {
+bool frc::Timer::HasPeriodPassed(double period) {
   if (Get() > period) {
     std::lock_guard<hal::priority_mutex> sync(m_mutex);
     // Advance the start time by the period.
@@ -166,7 +167,7 @@ bool Timer::HasPeriodPassed(double period) {
  *
  * @returns Robot running time in seconds.
  */
-double Timer::GetFPGATimestamp() {
+double frc::Timer::GetFPGATimestamp() {
   // FPGA returns the timestamp in microseconds
   // Call the helper GetFPGATime() in Utility.cpp
   return GetFPGATime() * 1.0e-6;
@@ -185,6 +186,6 @@ double Timer::GetFPGATimestamp() {
  *
  * @return Match time in seconds since the beginning of autonomous
  */
-double Timer::GetMatchTime() {
+double frc::Timer::GetMatchTime() {
   return DriverStation::GetInstance().GetMatchTime();
 }

--- a/wpilibc/athena/src/Ultrasonic.cpp
+++ b/wpilibc/athena/src/Ultrasonic.cpp
@@ -16,19 +16,17 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
 // Time (sec) for the ping trigger pulse.
-constexpr double Ultrasonic::kPingTime;
+constexpr double frc::Ultrasonic::kPingTime;
 // Priority that the ultrasonic round robin task runs.
-const int Ultrasonic::kPriority;
+const int frc::Ultrasonic::kPriority;
 // Max time (ms) between readings.
-constexpr double Ultrasonic::kMaxUltrasonicTime;
-constexpr double Ultrasonic::kSpeedOfSoundInchesPerSec;
+constexpr double frc::Ultrasonic::kMaxUltrasonicTime;
+constexpr double frc::Ultrasonic::kSpeedOfSoundInchesPerSec;
 // automatic round robin mode
-std::atomic<bool> Ultrasonic::m_automaticEnabled{false};
-std::set<Ultrasonic*> Ultrasonic::m_sensors;
-std::thread Ultrasonic::m_thread;
+std::atomic<bool> frc::Ultrasonic::m_automaticEnabled{false};
+std::set<frc::Ultrasonic*> frc::Ultrasonic::m_sensors;
+std::thread frc::Ultrasonic::m_thread;
 
 /**
  * Background task that goes through the list of ultrasonic sensors and pings
@@ -40,7 +38,7 @@ std::thread Ultrasonic::m_thread;
  * will change while it's running. Make sure to disable automatic mode before
  * touching the list.
  */
-void Ultrasonic::UltrasonicChecker() {
+void frc::Ultrasonic::UltrasonicChecker() {
   while (m_automaticEnabled) {
     for (auto& sensor : m_sensors) {
       if (!m_automaticEnabled) break;
@@ -62,7 +60,7 @@ void Ultrasonic::UltrasonicChecker() {
  * automatic mode (round robin) when the new sensor is added, it is stopped,
  * the sensor is added, then automatic mode is restored.
  */
-void Ultrasonic::Initialize() {
+void frc::Ultrasonic::Initialize() {
   bool originalMode = m_automaticEnabled;
   SetAutomaticMode(false);  // kill task when adding a new sensor
   // link this instance on the list
@@ -94,7 +92,8 @@ void Ultrasonic::Initialize() {
  *                    round trip time of the ping, and the distance.
  * @param units       The units returned in either kInches or kMilliMeters
  */
-Ultrasonic::Ultrasonic(int pingChannel, int echoChannel, DistanceUnit units)
+frc::Ultrasonic::Ultrasonic(int pingChannel, int echoChannel,
+                            DistanceUnit units)
     : m_pingChannel(std::make_shared<DigitalOutput>(pingChannel)),
       m_echoChannel(std::make_shared<DigitalInput>(echoChannel)),
       m_counter(m_echoChannel) {
@@ -112,8 +111,8 @@ Ultrasonic::Ultrasonic(int pingChannel, int echoChannel, DistanceUnit units)
  *                    determine the range.
  * @param units       The units returned in either kInches or kMilliMeters
  */
-Ultrasonic::Ultrasonic(DigitalOutput* pingChannel, DigitalInput* echoChannel,
-                       DistanceUnit units)
+frc::Ultrasonic::Ultrasonic(DigitalOutput* pingChannel,
+                            DigitalInput* echoChannel, DistanceUnit units)
     : m_pingChannel(pingChannel, NullDeleter<DigitalOutput>()),
       m_echoChannel(echoChannel, NullDeleter<DigitalInput>()),
       m_counter(m_echoChannel) {
@@ -136,8 +135,8 @@ Ultrasonic::Ultrasonic(DigitalOutput* pingChannel, DigitalInput* echoChannel,
  *                    determine the range.
  * @param units       The units returned in either kInches or kMilliMeters
  */
-Ultrasonic::Ultrasonic(DigitalOutput& pingChannel, DigitalInput& echoChannel,
-                       DistanceUnit units)
+frc::Ultrasonic::Ultrasonic(DigitalOutput& pingChannel,
+                            DigitalInput& echoChannel, DistanceUnit units)
     : m_pingChannel(&pingChannel, NullDeleter<DigitalOutput>()),
       m_echoChannel(&echoChannel, NullDeleter<DigitalInput>()),
       m_counter(m_echoChannel) {
@@ -155,9 +154,9 @@ Ultrasonic::Ultrasonic(DigitalOutput& pingChannel, DigitalInput& echoChannel,
  *                    determine the range.
  * @param units       The units returned in either kInches or kMilliMeters
  */
-Ultrasonic::Ultrasonic(std::shared_ptr<DigitalOutput> pingChannel,
-                       std::shared_ptr<DigitalInput> echoChannel,
-                       DistanceUnit units)
+frc::Ultrasonic::Ultrasonic(std::shared_ptr<DigitalOutput> pingChannel,
+                            std::shared_ptr<DigitalInput> echoChannel,
+                            DistanceUnit units)
     : m_pingChannel(pingChannel),
       m_echoChannel(echoChannel),
       m_counter(m_echoChannel) {
@@ -173,7 +172,7 @@ Ultrasonic::Ultrasonic(std::shared_ptr<DigitalOutput> pingChannel,
  * stopped, then started again after this sensor is removed (provided this
  * wasn't the last sensor).
  */
-Ultrasonic::~Ultrasonic() {
+frc::Ultrasonic::~Ultrasonic() {
   bool wasAutomaticMode = m_automaticEnabled;
   SetAutomaticMode(false);
 
@@ -198,7 +197,7 @@ Ultrasonic::~Ultrasonic() {
  *                 prefered, it can be implemented by pinging the sensors
  *                 manually and waiting for the results to come back.
  */
-void Ultrasonic::SetAutomaticMode(bool enabling) {
+void frc::Ultrasonic::SetAutomaticMode(bool enabling) {
   if (enabling == m_automaticEnabled) return;  // ignore the case of no change
 
   m_automaticEnabled = enabling;
@@ -211,11 +210,11 @@ void Ultrasonic::SetAutomaticMode(bool enabling) {
       sensor->m_counter.Reset();
     }
 
-    m_thread = std::thread(&Ultrasonic::UltrasonicChecker);
+    m_thread = std::thread(&frc::Ultrasonic::UltrasonicChecker);
 
     // TODO: Currently, lvuser does not have permissions to set task priorities.
     // Until that is the case, uncommenting this will break user code that calls
-    // Ultrasonic::SetAutomicMode().
+    // frc::Ultrasonic::SetAutomicMode().
     // m_task.SetPriority(kPriority);
   } else {
     // Wait for background task to stop running
@@ -239,7 +238,7 @@ void Ultrasonic::SetAutomaticMode(bool enabling) {
  * should count the semi-period when it comes in. The counter is reset to make
  * the current value invalid.
  */
-void Ultrasonic::Ping() {
+void frc::Ultrasonic::Ping() {
   wpi_assert(!m_automaticEnabled);
   m_counter.Reset();  // reset the counter to zero (invalid data now)
   m_pingChannel->Pulse(
@@ -253,7 +252,7 @@ void Ultrasonic::Ping() {
  * the echo (return) signal. If the count is not at least 2, then the range has
  * not yet been measured, and is invalid.
  */
-bool Ultrasonic::IsRangeValid() const { return m_counter.Get() > 1; }
+bool frc::Ultrasonic::IsRangeValid() const { return m_counter.Get() > 1; }
 
 /**
  * Get the range in inches from the ultrasonic sensor.
@@ -262,7 +261,7 @@ bool Ultrasonic::IsRangeValid() const { return m_counter.Get() > 1; }
  *         sensor. If there is no valid value yet, i.e. at least one
  *         measurement hasn't completed, then return 0.
  */
-double Ultrasonic::GetRangeInches() const {
+double frc::Ultrasonic::GetRangeInches() const {
   if (IsRangeValid())
     return m_counter.GetPeriod() * kSpeedOfSoundInchesPerSec / 2.0;
   else
@@ -276,25 +275,25 @@ double Ultrasonic::GetRangeInches() const {
  *         sensor. If there is no valid value yet, i.e. at least one
  *         measurement hasn't completed, then return 0.
  */
-double Ultrasonic::GetRangeMM() const { return GetRangeInches() * 25.4; }
+double frc::Ultrasonic::GetRangeMM() const { return GetRangeInches() * 25.4; }
 
 /**
  * Get the range in the current DistanceUnit for the PIDSource base object.
  *
  * @return The range in DistanceUnit
  */
-double Ultrasonic::PIDGet() {
+double frc::Ultrasonic::PIDGet() {
   switch (m_units) {
-    case Ultrasonic::kInches:
+    case frc::Ultrasonic::kInches:
       return GetRangeInches();
-    case Ultrasonic::kMilliMeters:
+    case frc::Ultrasonic::kMilliMeters:
       return GetRangeMM();
     default:
       return 0.0;
   }
 }
 
-void Ultrasonic::SetPIDSourceType(PIDSourceType pidSource) {
+void frc::Ultrasonic::SetPIDSourceType(PIDSourceType pidSource) {
   if (wpi_assert(pidSource == PIDSourceType::kDisplacement)) {
     m_pidSource = pidSource;
   }
@@ -306,32 +305,34 @@ void Ultrasonic::SetPIDSourceType(PIDSourceType pidSource) {
  *
  * @param units The DistanceUnit that should be used.
  */
-void Ultrasonic::SetDistanceUnits(DistanceUnit units) { m_units = units; }
+void frc::Ultrasonic::SetDistanceUnits(DistanceUnit units) { m_units = units; }
 
 /**
  * Get the current DistanceUnit that is used for the PIDSource base object.
  *
  * @return The type of DistanceUnit that is being used.
  */
-Ultrasonic::DistanceUnit Ultrasonic::GetDistanceUnits() const {
+frc::Ultrasonic::DistanceUnit frc::Ultrasonic::GetDistanceUnits() const {
   return m_units;
 }
 
-void Ultrasonic::UpdateTable() {
+void frc::Ultrasonic::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Value", GetRangeInches());
   }
 }
 
-void Ultrasonic::StartLiveWindowMode() {}
+void frc::Ultrasonic::StartLiveWindowMode() {}
 
-void Ultrasonic::StopLiveWindowMode() {}
+void frc::Ultrasonic::StopLiveWindowMode() {}
 
-std::string Ultrasonic::GetSmartDashboardType() const { return "Ultrasonic"; }
+std::string frc::Ultrasonic::GetSmartDashboardType() const {
+  return "Ultrasonic";
+}
 
-void Ultrasonic::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::Ultrasonic::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> Ultrasonic::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Ultrasonic::GetTable() const { return m_table; }

--- a/wpilibc/athena/src/Utility.cpp
+++ b/wpilibc/athena/src/Utility.cpp
@@ -22,8 +22,6 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
 /**
  * Assert implementation.
  * This allows breakpoints to be set on an assert.
@@ -67,7 +65,7 @@ bool wpi_assert_impl(bool conditionValue, llvm::StringRef conditionText,
       errorStream << "failed.\n";
     }
 
-    std::string stack = GetStackTrace(2);
+    std::string stack = frc::GetStackTrace(2);
     std::string location = locStream.str();
     std::string error = errorStream.str();
 
@@ -122,7 +120,7 @@ void wpi_assertEqual_common_impl(llvm::StringRef valueA, llvm::StringRef valueB,
     errorStream << "failed.\n";
   }
 
-  std::string trace = GetStackTrace(3);
+  std::string trace = frc::GetStackTrace(3);
   std::string location = locStream.str();
   std::string error = errorStream.str();
 

--- a/wpilibc/athena/src/Victor.cpp
+++ b/wpilibc/athena/src/Victor.cpp
@@ -10,15 +10,13 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
 /**
  * Constructor for a Victor.
  *
  * @param channel The PWM channel number that the Victor is attached to. 0-9
  *                are on-board, 10-19 are on the MXP port
  */
-Victor::Victor(int channel) : PWMSpeedController(channel) {
+frc::Victor::Victor(int channel) : PWMSpeedController(channel) {
   /* Note that the Victor uses the following bounds for PWM values.  These
    * values were determined empirically and optimized for the Victor 888. These
    * values should work reasonably well for Victor 884 controllers as well but

--- a/wpilibc/athena/src/VictorSP.cpp
+++ b/wpilibc/athena/src/VictorSP.cpp
@@ -10,15 +10,13 @@
 #include "HAL/HAL.h"
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
 /**
  * Constructor for a VictorSP.
  *
  * @param channel The PWM channel that the VictorSP is attached to. 0-9 are
  *                on-board, 10-19 are on the MXP port
  */
-VictorSP::VictorSP(int channel) : PWMSpeedController(channel) {
+frc::VictorSP::VictorSP(int channel) : PWMSpeedController(channel) {
   /**
    * Note that the VictorSP uses the following bounds for PWM values. These
    * values should work reasonably well for most controllers, but if users

--- a/wpilibc/athena/src/XboxController.cpp
+++ b/wpilibc/athena/src/XboxController.cpp
@@ -10,8 +10,6 @@
 #include "DriverStation.h"
 #include "HAL/HAL.h"
 
-using namespace frc;
-
 /**
  * Construct an instance of an Xbox controller.
  *
@@ -20,7 +18,7 @@ using namespace frc;
  * @param port The port on the Driver Station that the joystick is plugged into
  *             (0-5).
  */
-XboxController::XboxController(int port)
+frc::XboxController::XboxController(int port)
     : GamepadBase(port), m_ds(DriverStation::GetInstance()) {
   // HAL_Report(HALUsageReporting::kResourceType_XboxController, port);
   HAL_Report(HALUsageReporting::kResourceType_Joystick, port);
@@ -31,7 +29,7 @@ XboxController::XboxController(int port)
  *
  * @param hand Side of controller whose value should be returned.
  */
-double XboxController::GetX(JoystickHand hand) const {
+double frc::XboxController::GetX(JoystickHand hand) const {
   if (hand == kLeftHand) {
     return GetRawAxis(0);
   } else {
@@ -44,7 +42,7 @@ double XboxController::GetX(JoystickHand hand) const {
  *
  * @param hand Side of controller whose value should be returned.
  */
-double XboxController::GetY(JoystickHand hand) const {
+double frc::XboxController::GetY(JoystickHand hand) const {
   if (hand == kLeftHand) {
     return GetRawAxis(1);
   } else {
@@ -57,7 +55,7 @@ double XboxController::GetY(JoystickHand hand) const {
  *
  * @param hand Side of controller whose value should be returned.
  */
-bool XboxController::GetBumper(JoystickHand hand) const {
+bool frc::XboxController::GetBumper(JoystickHand hand) const {
   if (hand == kLeftHand) {
     return GetRawButton(5);
   } else {
@@ -71,7 +69,7 @@ bool XboxController::GetBumper(JoystickHand hand) const {
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetStickButton(JoystickHand hand) const {
+bool frc::XboxController::GetStickButton(JoystickHand hand) const {
   if (hand == kLeftHand) {
     return GetRawButton(9);
   } else {
@@ -84,7 +82,7 @@ bool XboxController::GetStickButton(JoystickHand hand) const {
  *
  * @param hand Side of controller whose value should be returned.
  */
-double XboxController::GetTriggerAxis(JoystickHand hand) const {
+double frc::XboxController::GetTriggerAxis(JoystickHand hand) const {
   if (hand == kLeftHand) {
     return GetRawAxis(2);
   } else {
@@ -98,7 +96,7 @@ double XboxController::GetTriggerAxis(JoystickHand hand) const {
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetAButton() const { return GetRawButton(1); }
+bool frc::XboxController::GetAButton() const { return GetRawButton(1); }
 
 /**
  * Read the value of the B button on the controller.
@@ -106,7 +104,7 @@ bool XboxController::GetAButton() const { return GetRawButton(1); }
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetBButton() const { return GetRawButton(2); }
+bool frc::XboxController::GetBButton() const { return GetRawButton(2); }
 
 /**
  * Read the value of the X button on the controller.
@@ -114,7 +112,7 @@ bool XboxController::GetBButton() const { return GetRawButton(2); }
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetXButton() const { return GetRawButton(3); }
+bool frc::XboxController::GetXButton() const { return GetRawButton(3); }
 
 /**
  * Read the value of the Y button on the controller.
@@ -122,7 +120,7 @@ bool XboxController::GetXButton() const { return GetRawButton(3); }
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetYButton() const { return GetRawButton(4); }
+bool frc::XboxController::GetYButton() const { return GetRawButton(4); }
 
 /**
  * Read the value of the back button on the controller.
@@ -130,7 +128,7 @@ bool XboxController::GetYButton() const { return GetRawButton(4); }
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetBackButton() const { return GetRawButton(7); }
+bool frc::XboxController::GetBackButton() const { return GetRawButton(7); }
 
 /**
  * Read the value of the start button on the controller.
@@ -138,4 +136,4 @@ bool XboxController::GetBackButton() const { return GetRawButton(7); }
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetStartButton() const { return GetRawButton(8); }
+bool frc::XboxController::GetStartButton() const { return GetRawButton(8); }

--- a/wpilibc/athena/src/vision/VisionRunner.cpp
+++ b/wpilibc/athena/src/vision/VisionRunner.cpp
@@ -11,21 +11,19 @@
 #include "RobotBase.h"
 #include "opencv2/core/mat.hpp"
 
-using namespace frc;
-
 /**
  * Creates a new vision runner. It will take images from the {@code
  * videoSource}, and call the virtual DoProcess() method.
  *
  * @param videoSource the video source to use to supply images for the pipeline
  */
-VisionRunnerBase::VisionRunnerBase(cs::VideoSource videoSource)
+frc::VisionRunnerBase::VisionRunnerBase(cs::VideoSource videoSource)
     : m_image(std::make_unique<cv::Mat>()), m_cvSink("VisionRunner CvSink") {
   m_cvSink.SetSource(videoSource);
 }
 
 // Located here and not in header due to cv::Mat forward declaration.
-VisionRunnerBase::~VisionRunnerBase() {}
+frc::VisionRunnerBase::~VisionRunnerBase() {}
 
 /**
  * Runs the pipeline one time, giving it the next image from the video source
@@ -40,7 +38,7 @@ VisionRunnerBase::~VisionRunnerBase() {}
  * have their own ways to run the pipeline. Most teams, however, should just
  * use {@link #runForever} in its own thread using a std::thread.</p>
  */
-void VisionRunnerBase::RunOnce() {
+void frc::VisionRunnerBase::RunOnce() {
   if (std::this_thread::get_id() == RobotBase::GetThreadId()) {
     wpi_setErrnoErrorWithContext(
         "VisionRunner::RunOnce() cannot be called from the main robot thread");
@@ -63,7 +61,7 @@ void VisionRunnerBase::RunOnce() {
  * <p><strong>Do not call this method directly from the main
  * thread.</strong></p>
  */
-void VisionRunnerBase::RunForever() {
+void frc::VisionRunnerBase::RunForever() {
   if (std::this_thread::get_id() == RobotBase::GetThreadId()) {
     wpi_setErrnoErrorWithContext(
         "VisionRunner::RunForever() cannot be called from the main robot "

--- a/wpilibc/shared/src/Buttons/Button.cpp
+++ b/wpilibc/shared/src/Buttons/Button.cpp
@@ -7,14 +7,12 @@
 
 #include "Buttons/Button.h"
 
-using namespace frc;
-
 /**
  * Specifies the command to run when a button is first pressed.
  *
  * @param command The pointer to the command to run
  */
-void Button::WhenPressed(Command* command) { WhenActive(command); }
+void frc::Button::WhenPressed(Command* command) { WhenActive(command); }
 
 /**
  * Specifies the command to be scheduled while the button is pressed.
@@ -24,7 +22,7 @@ void Button::WhenPressed(Command* command) { WhenActive(command); }
  *
  * @param command The pointer to the command to run
  */
-void Button::WhileHeld(Command* command) { WhileActive(command); }
+void frc::Button::WhileHeld(Command* command) { WhileActive(command); }
 
 /**
  * Specifies the command to run when the button is released.
@@ -33,18 +31,22 @@ void Button::WhileHeld(Command* command) { WhileActive(command); }
  *
  * @param command The pointer to the command to run
  */
-void Button::WhenReleased(Command* command) { WhenInactive(command); }
+void frc::Button::WhenReleased(Command* command) { WhenInactive(command); }
 
 /**
  * Cancels the specificed command when the button is pressed.
  *
  * @param command The command to be canceled
  */
-void Button::CancelWhenPressed(Command* command) { CancelWhenActive(command); }
+void frc::Button::CancelWhenPressed(Command* command) {
+  CancelWhenActive(command);
+}
 
 /**
  * Toggle the specified command when the button is pressed.
  *
  * @param command The command to be toggled
  */
-void Button::ToggleWhenPressed(Command* command) { ToggleWhenActive(command); }
+void frc::Button::ToggleWhenPressed(Command* command) {
+  ToggleWhenActive(command);
+}

--- a/wpilibc/shared/src/Buttons/ButtonScheduler.cpp
+++ b/wpilibc/shared/src/Buttons/ButtonScheduler.cpp
@@ -9,9 +9,10 @@
 
 #include "Commands/Scheduler.h"
 
-using namespace frc;
-
-ButtonScheduler::ButtonScheduler(bool last, Trigger* button, Command* orders)
+frc::ButtonScheduler::ButtonScheduler(bool last, frc::Trigger* button,
+                                      frc::Command* orders)
     : m_pressedLast(last), m_button(button), m_command(orders) {}
 
-void ButtonScheduler::Start() { Scheduler::GetInstance()->AddButton(this); }
+void frc::ButtonScheduler::Start() {
+  Scheduler::GetInstance()->AddButton(this);
+}

--- a/wpilibc/shared/src/Buttons/CancelButtonScheduler.cpp
+++ b/wpilibc/shared/src/Buttons/CancelButtonScheduler.cpp
@@ -10,15 +10,13 @@
 #include "Buttons/Button.h"
 #include "Commands/Command.h"
 
-using namespace frc;
-
-CancelButtonScheduler::CancelButtonScheduler(bool last, Trigger* button,
-                                             Command* orders)
+frc::CancelButtonScheduler::CancelButtonScheduler(bool last, Trigger* button,
+                                                  Command* orders)
     : ButtonScheduler(last, button, orders) {
   pressedLast = m_button->Grab();
 }
 
-void CancelButtonScheduler::Execute() {
+void frc::CancelButtonScheduler::Execute() {
   if (m_button->Grab()) {
     if (!pressedLast) {
       pressedLast = true;

--- a/wpilibc/shared/src/Buttons/HeldButtonScheduler.cpp
+++ b/wpilibc/shared/src/Buttons/HeldButtonScheduler.cpp
@@ -10,13 +10,11 @@
 #include "Buttons/Button.h"
 #include "Commands/Command.h"
 
-using namespace frc;
-
-HeldButtonScheduler::HeldButtonScheduler(bool last, Trigger* button,
-                                         Command* orders)
+frc::HeldButtonScheduler::HeldButtonScheduler(bool last, Trigger* button,
+                                              Command* orders)
     : ButtonScheduler(last, button, orders) {}
 
-void HeldButtonScheduler::Execute() {
+void frc::HeldButtonScheduler::Execute() {
   if (m_button->Grab()) {
     m_pressedLast = true;
     m_command->Start();

--- a/wpilibc/shared/src/Buttons/InternalButton.cpp
+++ b/wpilibc/shared/src/Buttons/InternalButton.cpp
@@ -7,13 +7,11 @@
 
 #include "Buttons/InternalButton.h"
 
-using namespace frc;
-
-InternalButton::InternalButton(bool inverted)
+frc::InternalButton::InternalButton(bool inverted)
     : m_pressed(inverted), m_inverted(inverted) {}
 
-void InternalButton::SetInverted(bool inverted) { m_inverted = inverted; }
+void frc::InternalButton::SetInverted(bool inverted) { m_inverted = inverted; }
 
-void InternalButton::SetPressed(bool pressed) { m_pressed = pressed; }
+void frc::InternalButton::SetPressed(bool pressed) { m_pressed = pressed; }
 
-bool InternalButton::Get() { return m_pressed ^ m_inverted; }
+bool frc::InternalButton::Get() { return m_pressed ^ m_inverted; }

--- a/wpilibc/shared/src/Buttons/JoystickButton.cpp
+++ b/wpilibc/shared/src/Buttons/JoystickButton.cpp
@@ -7,9 +7,9 @@
 
 #include "Buttons/JoystickButton.h"
 
-using namespace frc;
-
-JoystickButton::JoystickButton(GenericHID* joystick, int buttonNumber)
+frc::JoystickButton::JoystickButton(GenericHID* joystick, int buttonNumber)
     : m_joystick(joystick), m_buttonNumber(buttonNumber) {}
 
-bool JoystickButton::Get() { return m_joystick->GetRawButton(m_buttonNumber); }
+bool frc::JoystickButton::Get() {
+  return m_joystick->GetRawButton(m_buttonNumber);
+}

--- a/wpilibc/shared/src/Buttons/NetworkButton.cpp
+++ b/wpilibc/shared/src/Buttons/NetworkButton.cpp
@@ -9,19 +9,17 @@
 
 #include "networktables/NetworkTable.h"
 
-using namespace frc;
-
-NetworkButton::NetworkButton(const std::string& tableName,
-                             const std::string& field)
+frc::NetworkButton::NetworkButton(const std::string& tableName,
+                                  const std::string& field)
     :  // TODO how is this supposed to work???
       m_netTable(NetworkTable::GetTable(tableName)),
       m_field(field) {}
 
-NetworkButton::NetworkButton(std::shared_ptr<ITable> table,
-                             const std::string& field)
+frc::NetworkButton::NetworkButton(std::shared_ptr<ITable> table,
+                                  const std::string& field)
     : m_netTable(table), m_field(field) {}
 
-bool NetworkButton::Get() {
+bool frc::NetworkButton::Get() {
   /*if (m_netTable->isConnected())
           return m_netTable->GetBoolean(m_field.c_str());
   else

--- a/wpilibc/shared/src/Buttons/PressedButtonScheduler.cpp
+++ b/wpilibc/shared/src/Buttons/PressedButtonScheduler.cpp
@@ -10,13 +10,11 @@
 #include "Buttons/Button.h"
 #include "Commands/Command.h"
 
-using namespace frc;
-
-PressedButtonScheduler::PressedButtonScheduler(bool last, Trigger* button,
-                                               Command* orders)
+frc::PressedButtonScheduler::PressedButtonScheduler(bool last, Trigger* button,
+                                                    Command* orders)
     : ButtonScheduler(last, button, orders) {}
 
-void PressedButtonScheduler::Execute() {
+void frc::PressedButtonScheduler::Execute() {
   if (m_button->Grab()) {
     if (!m_pressedLast) {
       m_pressedLast = true;

--- a/wpilibc/shared/src/Buttons/ReleasedButtonScheduler.cpp
+++ b/wpilibc/shared/src/Buttons/ReleasedButtonScheduler.cpp
@@ -10,13 +10,12 @@
 #include "Buttons/Button.h"
 #include "Commands/Command.h"
 
-using namespace frc;
-
-ReleasedButtonScheduler::ReleasedButtonScheduler(bool last, Trigger* button,
-                                                 Command* orders)
+frc::ReleasedButtonScheduler::ReleasedButtonScheduler(bool last,
+                                                      Trigger* button,
+                                                      Command* orders)
     : ButtonScheduler(last, button, orders) {}
 
-void ReleasedButtonScheduler::Execute() {
+void frc::ReleasedButtonScheduler::Execute() {
   if (m_button->Grab()) {
     m_pressedLast = true;
   } else {

--- a/wpilibc/shared/src/Buttons/ToggleButtonScheduler.cpp
+++ b/wpilibc/shared/src/Buttons/ToggleButtonScheduler.cpp
@@ -10,15 +10,13 @@
 #include "Buttons/Button.h"
 #include "Commands/Command.h"
 
-using namespace frc;
-
-ToggleButtonScheduler::ToggleButtonScheduler(bool last, Trigger* button,
-                                             Command* orders)
+frc::ToggleButtonScheduler::ToggleButtonScheduler(bool last, Trigger* button,
+                                                  Command* orders)
     : ButtonScheduler(last, button, orders) {
   pressedLast = m_button->Grab();
 }
 
-void ToggleButtonScheduler::Execute() {
+void frc::ToggleButtonScheduler::Execute() {
   if (m_button->Grab()) {
     if (!pressedLast) {
       pressedLast = true;

--- a/wpilibc/shared/src/Buttons/Trigger.cpp
+++ b/wpilibc/shared/src/Buttons/Trigger.cpp
@@ -12,9 +12,7 @@
 #include "Buttons/ReleasedButtonScheduler.h"
 #include "Buttons/ToggleButtonScheduler.h"
 
-using namespace frc;
-
-bool Trigger::Grab() {
+bool frc::Trigger::Grab() {
   if (Get()) {
     return true;
   } else if (m_table != nullptr) {
@@ -24,38 +22,38 @@ bool Trigger::Grab() {
   }
 }
 
-void Trigger::WhenActive(Command* command) {
+void frc::Trigger::WhenActive(Command* command) {
   auto pbs = new PressedButtonScheduler(Grab(), this, command);
   pbs->Start();
 }
 
-void Trigger::WhileActive(Command* command) {
+void frc::Trigger::WhileActive(Command* command) {
   auto hbs = new HeldButtonScheduler(Grab(), this, command);
   hbs->Start();
 }
 
-void Trigger::WhenInactive(Command* command) {
+void frc::Trigger::WhenInactive(Command* command) {
   auto rbs = new ReleasedButtonScheduler(Grab(), this, command);
   rbs->Start();
 }
 
-void Trigger::CancelWhenActive(Command* command) {
+void frc::Trigger::CancelWhenActive(Command* command) {
   auto cbs = new CancelButtonScheduler(Grab(), this, command);
   cbs->Start();
 }
 
-void Trigger::ToggleWhenActive(Command* command) {
+void frc::Trigger::ToggleWhenActive(Command* command) {
   auto tbs = new ToggleButtonScheduler(Grab(), this, command);
   tbs->Start();
 }
 
-std::string Trigger::GetSmartDashboardType() const { return "Button"; }
+std::string frc::Trigger::GetSmartDashboardType() const { return "Button"; }
 
-void Trigger::InitTable(std::shared_ptr<ITable> subtable) {
+void frc::Trigger::InitTable(std::shared_ptr<ITable> subtable) {
   m_table = subtable;
   if (m_table != nullptr) {
     m_table->PutBoolean("pressed", Get());
   }
 }
 
-std::shared_ptr<ITable> Trigger::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Trigger::GetTable() const { return m_table; }

--- a/wpilibc/shared/src/Commands/Command.cpp
+++ b/wpilibc/shared/src/Commands/Command.cpp
@@ -15,26 +15,24 @@
 #include "Timer.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
 static const std::string kName = "name";
 static const std::string kRunning = "running";
 static const std::string kIsParented = "isParented";
 
-int Command::m_commandCounter = 0;
+int frc::Command::m_commandCounter = 0;
 
 /**
  * Creates a new command.
  * The name of this command will be default.
  */
-Command::Command() : Command("", -1.0) {}
+frc::Command::Command() : Command("", -1.0) {}
 
 /**
  * Creates a new command with the given name and no timeout.
  *
  * @param name the name for this command
  */
-Command::Command(const std::string& name) : Command(name, -1.0) {}
+frc::Command::Command(const std::string& name) : Command(name, -1.0) {}
 
 /**
  * Creates a new command with the given timeout and a default name.
@@ -42,7 +40,7 @@ Command::Command(const std::string& name) : Command(name, -1.0) {}
  * @param timeout the time (in seconds) before this command "times out"
  * @see Command#isTimedOut() isTimedOut()
  */
-Command::Command(double timeout) : Command("", timeout) {}
+frc::Command::Command(double timeout) : Command("", timeout) {}
 
 /**
  * Creates a new command with the given name and timeout.
@@ -51,7 +49,7 @@ Command::Command(double timeout) : Command("", timeout) {}
  * @param timeout the time (in seconds) before this command "times out"
  * @see Command#isTimedOut() isTimedOut()
  */
-Command::Command(const std::string& name, double timeout) {
+frc::Command::Command(const std::string& name, double timeout) {
   // We use -1.0 to indicate no timeout.
   if (timeout < 0.0 && timeout != -1.0)
     wpi_setWPIErrorWithContext(ParameterOutOfRange, "timeout < 0.0");
@@ -66,7 +64,7 @@ Command::Command(const std::string& name, double timeout) {
   }
 }
 
-Command::~Command() {
+frc::Command::~Command() {
   if (m_table != nullptr) m_table->RemoveTableListener(this);
 }
 
@@ -77,7 +75,7 @@ Command::~Command() {
  *
  * @return the ID of this command
  */
-int Command::GetID() const { return m_commandID; }
+int frc::Command::GetID() const { return m_commandID; }
 
 /**
  * Sets the timeout of this command.
@@ -85,7 +83,7 @@ int Command::GetID() const { return m_commandID; }
  * @param timeout the timeout (in seconds)
  * @see Command#isTimedOut() isTimedOut()
  */
-void Command::SetTimeout(double timeout) {
+void frc::Command::SetTimeout(double timeout) {
   if (timeout < 0.0)
     wpi_setWPIErrorWithContext(ParameterOutOfRange, "timeout < 0.0");
   else
@@ -99,7 +97,7 @@ void Command::SetTimeout(double timeout) {
  *
  * @return the time since this command was initialized (in seconds).
  */
-double Command::TimeSinceInitialized() const {
+double frc::Command::TimeSinceInitialized() const {
   if (m_startTime < 0.0)
     return 0.0;
   else
@@ -118,7 +116,7 @@ double Command::TimeSinceInitialized() const {
  * @param subsystem the {@link Subsystem} required
  * @see Subsystem
  */
-void Command::Requires(Subsystem* subsystem) {
+void frc::Command::Requires(Subsystem* subsystem) {
   if (!AssertUnlocked("Can not add new requirement to command")) return;
 
   if (subsystem != nullptr)
@@ -133,7 +131,7 @@ void Command::Requires(Subsystem* subsystem) {
  * This will call {@link Command#interrupted() interrupted()} or
  * {@link Command#end() end()}.
  */
-void Command::Removed() {
+void frc::Command::Removed() {
   if (m_initialized) {
     if (IsCanceled()) {
       Interrupted();
@@ -156,7 +154,7 @@ void Command::Removed() {
  * necessarily do so immediately, and may in fact be canceled before initialize
  * is even called.</p>
  */
-void Command::Start() {
+void frc::Command::Start() {
   LockChanges();
   if (m_parent != nullptr)
     wpi_setWPIErrorWithContext(
@@ -171,7 +169,7 @@ void Command::Start() {
  *
  * @return whether or not the command should stay within the {@link Scheduler}.
  */
-bool Command::Run() {
+bool frc::Command::Run() {
   if (!m_runWhenDisabled && m_parent == nullptr && RobotState::IsDisabled())
     Cancel();
 
@@ -192,20 +190,20 @@ bool Command::Run() {
  * The initialize method is called the first time this Command is run after
  * being started.
  */
-void Command::Initialize() {}
+void frc::Command::Initialize() {}
 
 /**
  * The execute method is called repeatedly until this Command either finishes
  * or is canceled.
  */
-void Command::Execute() {}
+void frc::Command::Execute() {}
 
 /**
  * Called when the command ended peacefully.  This is where you may want
  * to wrap up loose ends, like shutting off a motor that was being used
  * in the command.
  */
-void Command::End() {}
+void frc::Command::End() {}
 
 /**
  * Called when the command ends because somebody called
@@ -218,15 +216,15 @@ void Command::End() {}
  * <p>Generally, it is useful to simply call the {@link Command#end() end()}
  * method within this method, as done here.</p>
  */
-void Command::Interrupted() { End(); }
+void frc::Command::Interrupted() { End(); }
 
-void Command::_Initialize() {}
+void frc::Command::_Initialize() {}
 
-void Command::_Interrupted() {}
+void frc::Command::_Interrupted() {}
 
-void Command::_Execute() {}
+void frc::Command::_Execute() {}
 
-void Command::_End() {}
+void frc::Command::_End() {}
 
 /**
  * Called to indicate that the timer should start.
@@ -234,7 +232,7 @@ void Command::_End() {}
  * This is called right before {@link Command#initialize() initialize()} is,
  * inside the {@link Command#run() run()} method.
  */
-void Command::StartTiming() { m_startTime = Timer::GetFPGATimestamp(); }
+void frc::Command::StartTiming() { m_startTime = Timer::GetFPGATimestamp(); }
 
 /**
  * Returns whether or not the
@@ -245,7 +243,7 @@ void Command::StartTiming() { m_startTime = Timer::GetFPGATimestamp(); }
  *
  * @return whether the time has expired
  */
-bool Command::IsTimedOut() const {
+bool frc::Command::IsTimedOut() const {
   return m_timeout != -1 && TimeSinceInitialized() >= m_timeout;
 }
 
@@ -256,14 +254,14 @@ bool Command::IsTimedOut() const {
  * @return the requirements (as an std::set of {@link Subsystem Subsystems}
  *         pointers) of this command
  */
-Command::SubsystemSet Command::GetRequirements() const {
+frc::Command::SubsystemSet frc::Command::GetRequirements() const {
   return m_requirements;
 }
 
 /**
  * Prevents further changes from being made.
  */
-void Command::LockChanges() { m_locked = true; }
+void frc::Command::LockChanges() { m_locked = true; }
 
 /**
  * If changes are locked, then this will generate a CommandIllegalUse error.
@@ -272,7 +270,7 @@ void Command::LockChanges() { m_locked = true; }
  *                message)
  * @return true if assert passed, false if assert failed
  */
-bool Command::AssertUnlocked(const std::string& message) {
+bool frc::Command::AssertUnlocked(const std::string& message) {
   if (m_locked) {
     std::string buf =
         message + " after being started or being added to a command group";
@@ -287,7 +285,7 @@ bool Command::AssertUnlocked(const std::string& message) {
  *
  * @param parent the parent
  */
-void Command::SetParent(CommandGroup* parent) {
+void frc::Command::SetParent(CommandGroup* parent) {
   if (parent == nullptr) {
     wpi_setWPIErrorWithContext(NullParameter, "parent");
   } else if (m_parent != nullptr) {
@@ -308,7 +306,7 @@ void Command::SetParent(CommandGroup* parent) {
  * {@link ConditionalCommand} so cancelling the chosen command works properly in
  * {@link CommandGroup}.
  */
-void Command::ClearRequirements() { m_requirements.clear(); }
+void frc::Command::ClearRequirements() { m_requirements.clear(); }
 
 /**
  * This is used internally to mark that the command has been started.
@@ -322,7 +320,7 @@ void Command::ClearRequirements() { m_requirements.clear(); }
  * It is very important that startRunning and removed be called in order or some
  * assumptions of the code will be broken.
  */
-void Command::StartRunning() {
+void frc::Command::StartRunning() {
   m_running = true;
   m_startTime = -1;
   if (m_table != nullptr) m_table->PutBoolean(kRunning, true);
@@ -336,7 +334,7 @@ void Command::StartRunning() {
  *
  * @return whether or not the command is running
  */
-bool Command::IsRunning() const { return m_running; }
+bool frc::Command::IsRunning() const { return m_running; }
 
 /**
  * This will cancel the current command.
@@ -349,7 +347,7 @@ bool Command::IsRunning() const { return m_running; }
  * <p>A command can not be canceled if it is a part of a command group, you
  * must cancel the command group instead.</p>
  */
-void Command::Cancel() {
+void frc::Command::Cancel() {
   if (m_parent != nullptr)
     wpi_setWPIErrorWithContext(
         CommandIllegalUse,
@@ -364,7 +362,7 @@ void Command::Cancel() {
  *
  * Should only be called by the parent command group.
  */
-void Command::_Cancel() {
+void frc::Command::_Cancel() {
   if (IsRunning()) m_canceled = true;
 }
 
@@ -373,21 +371,21 @@ void Command::_Cancel() {
  *
  * @return whether or not this has been canceled
  */
-bool Command::IsCanceled() const { return m_canceled; }
+bool frc::Command::IsCanceled() const { return m_canceled; }
 
 /**
  * Returns whether or not this command can be interrupted.
  *
  * @return whether or not this command can be interrupted
  */
-bool Command::IsInterruptible() const { return m_interruptible; }
+bool frc::Command::IsInterruptible() const { return m_interruptible; }
 
 /**
  * Sets whether or not this command can be interrupted.
  *
  * @param interruptible whether or not this command can be interrupted
  */
-void Command::SetInterruptible(bool interruptible) {
+void frc::Command::SetInterruptible(bool interruptible) {
   m_interruptible = interruptible;
 }
 
@@ -397,7 +395,7 @@ void Command::SetInterruptible(bool interruptible) {
  * @param system the system
  * @return whether or not the subsystem is required (false if given nullptr)
  */
-bool Command::DoesRequire(Subsystem* system) const {
+bool frc::Command::DoesRequire(Subsystem* system) const {
   return m_requirements.count(system) > 0;
 }
 
@@ -409,7 +407,7 @@ bool Command::DoesRequire(Subsystem* system) const {
  * @return the {@link CommandGroup} that this command is a part of (or null if
  *         not in group)
  */
-CommandGroup* Command::GetGroup() const { return m_parent; }
+frc::CommandGroup* frc::Command::GetGroup() const { return m_parent; }
 
 /**
  * Sets whether or not this {@link Command} should run when the robot is
@@ -420,7 +418,7 @@ CommandGroup* Command::GetGroup() const { return m_parent; }
  *
  * @param run whether or not this command should run when the robot is disabled
  */
-void Command::SetRunWhenDisabled(bool run) { m_runWhenDisabled = run; }
+void frc::Command::SetRunWhenDisabled(bool run) { m_runWhenDisabled = run; }
 
 /**
  * Returns whether or not this {@link Command} will run when the robot is
@@ -429,13 +427,13 @@ void Command::SetRunWhenDisabled(bool run) { m_runWhenDisabled = run; }
  * @return whether or not this {@link Command} will run when the robot is
  *         disabled, or if it will cancel itself
  */
-bool Command::WillRunWhenDisabled() const { return m_runWhenDisabled; }
+bool frc::Command::WillRunWhenDisabled() const { return m_runWhenDisabled; }
 
-std::string Command::GetName() const { return m_name; }
+std::string frc::Command::GetName() const { return m_name; }
 
-std::string Command::GetSmartDashboardType() const { return "Command"; }
+std::string frc::Command::GetSmartDashboardType() const { return "Command"; }
 
-void Command::InitTable(std::shared_ptr<ITable> subtable) {
+void frc::Command::InitTable(std::shared_ptr<ITable> subtable) {
   if (m_table != nullptr) m_table->RemoveTableListener(this);
   m_table = subtable;
   if (m_table != nullptr) {
@@ -446,10 +444,10 @@ void Command::InitTable(std::shared_ptr<ITable> subtable) {
   }
 }
 
-std::shared_ptr<ITable> Command::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Command::GetTable() const { return m_table; }
 
-void Command::ValueChanged(ITable* source, llvm::StringRef key,
-                           std::shared_ptr<nt::Value> value, bool isNew) {
+void frc::Command::ValueChanged(ITable* source, llvm::StringRef key,
+                                std::shared_ptr<nt::Value> value, bool isNew) {
   if (!value->IsBoolean()) return;
   if (value->GetBoolean()) {
     if (!IsRunning()) Start();

--- a/wpilibc/shared/src/Commands/CommandGroup.cpp
+++ b/wpilibc/shared/src/Commands/CommandGroup.cpp
@@ -9,13 +9,11 @@
 
 #include "WPIErrors.h"
 
-using namespace frc;
-
 /**
  * Creates a new {@link CommandGroup CommandGroup} with the given name.
  * @param name the name for this command group
  */
-CommandGroup::CommandGroup(const std::string& name) : Command(name) {}
+frc::CommandGroup::CommandGroup(const std::string& name) : Command(name) {}
 
 /**
  * Adds a new {@link Command Command} to the group.  The {@link Command Command}
@@ -29,7 +27,7 @@ CommandGroup::CommandGroup(const std::string& name) : Command(name) {}
  *
  * @param command The {@link Command Command} to be added
  */
-void CommandGroup::AddSequential(Command* command) {
+void frc::CommandGroup::AddSequential(Command* command) {
   if (command == nullptr) {
     wpi_setWPIErrorWithContext(NullParameter, "command");
     return;
@@ -65,7 +63,7 @@ void CommandGroup::AddSequential(Command* command) {
  * @param command The {@link Command Command} to be added
  * @param timeout The timeout (in seconds)
  */
-void CommandGroup::AddSequential(Command* command, double timeout) {
+void frc::CommandGroup::AddSequential(Command* command, double timeout) {
   if (command == nullptr) {
     wpi_setWPIErrorWithContext(NullParameter, "command");
     return;
@@ -106,7 +104,7 @@ void CommandGroup::AddSequential(Command* command, double timeout) {
  *
  * @param command The command to be added
  */
-void CommandGroup::AddParallel(Command* command) {
+void frc::CommandGroup::AddParallel(Command* command) {
   if (command == nullptr) {
     wpi_setWPIErrorWithContext(NullParameter, "command");
     return;
@@ -150,7 +148,7 @@ void CommandGroup::AddParallel(Command* command) {
  * @param command The command to be added
  * @param timeout The timeout (in seconds)
  */
-void CommandGroup::AddParallel(Command* command, double timeout) {
+void frc::CommandGroup::AddParallel(Command* command, double timeout) {
   if (command == nullptr) {
     wpi_setWPIErrorWithContext(NullParameter, "command");
     return;
@@ -172,9 +170,9 @@ void CommandGroup::AddParallel(Command* command, double timeout) {
     Requires(*iter);
 }
 
-void CommandGroup::_Initialize() { m_currentCommandIndex = -1; }
+void frc::CommandGroup::_Initialize() { m_currentCommandIndex = -1; }
 
-void CommandGroup::_Execute() {
+void frc::CommandGroup::_Execute() {
   CommandGroupEntry entry;
   Command* cmd = nullptr;
   bool firstRun = false;
@@ -241,7 +239,7 @@ void CommandGroup::_Execute() {
   }
 }
 
-void CommandGroup::_End() {
+void frc::CommandGroup::_End() {
   // Theoretically, we don't have to check this, but we do if teams override the
   // IsFinished method
   if (m_currentCommandIndex != -1 &&
@@ -259,26 +257,26 @@ void CommandGroup::_End() {
   m_children.clear();
 }
 
-void CommandGroup::_Interrupted() { _End(); }
+void frc::CommandGroup::_Interrupted() { _End(); }
 
 // Can be overwritten by teams
-void CommandGroup::Initialize() {}
+void frc::CommandGroup::Initialize() {}
 
 // Can be overwritten by teams
-void CommandGroup::Execute() {}
+void frc::CommandGroup::Execute() {}
 
 // Can be overwritten by teams
-void CommandGroup::End() {}
+void frc::CommandGroup::End() {}
 
 // Can be overwritten by teams
-void CommandGroup::Interrupted() {}
+void frc::CommandGroup::Interrupted() {}
 
-bool CommandGroup::IsFinished() {
+bool frc::CommandGroup::IsFinished() {
   return static_cast<size_t>(m_currentCommandIndex) >= m_commands.size() &&
          m_children.empty();
 }
 
-bool CommandGroup::IsInterruptible() const {
+bool frc::CommandGroup::IsInterruptible() const {
   if (!Command::IsInterruptible()) return false;
 
   if (m_currentCommandIndex != -1 &&
@@ -294,7 +292,7 @@ bool CommandGroup::IsInterruptible() const {
   return true;
 }
 
-void CommandGroup::CancelConflicts(Command* command) {
+void frc::CommandGroup::CancelConflicts(Command* command) {
   for (auto childIter = m_children.begin(); childIter != m_children.end();) {
     Command* child = childIter->m_command;
     bool erased = false;
@@ -314,4 +312,4 @@ void CommandGroup::CancelConflicts(Command* command) {
   }
 }
 
-int CommandGroup::GetSize() const { return m_children.size(); }
+int frc::CommandGroup::GetSize() const { return m_children.size(); }

--- a/wpilibc/shared/src/Commands/CommandGroupEntry.cpp
+++ b/wpilibc/shared/src/Commands/CommandGroupEntry.cpp
@@ -9,13 +9,11 @@
 
 #include "Commands/Command.h"
 
-using namespace frc;
-
-CommandGroupEntry::CommandGroupEntry(Command* command, Sequence state,
-                                     double timeout)
+frc::CommandGroupEntry::CommandGroupEntry(Command* command, Sequence state,
+                                          double timeout)
     : m_timeout(timeout), m_command(command), m_state(state) {}
 
-bool CommandGroupEntry::IsTimedOut() const {
+bool frc::CommandGroupEntry::IsTimedOut() const {
   if (m_timeout < 0.0) return false;
   double time = m_command->TimeSinceInitialized();
   if (time == 0.0) return false;

--- a/wpilibc/shared/src/Commands/ConditionalCommand.cpp
+++ b/wpilibc/shared/src/Commands/ConditionalCommand.cpp
@@ -9,9 +9,8 @@
 
 #include "Commands/Scheduler.h"
 
-using namespace frc;
-
-static void RequireAll(Command& command, Command* onTrue, Command* onFalse) {
+static void RequireAll(frc::Command& command, frc::Command* onTrue,
+                       frc::Command* onFalse) {
   if (onTrue != nullptr) {
     for (auto requirement : onTrue->GetRequirements())
       command.Requires(requirement);
@@ -30,7 +29,7 @@ static void RequireAll(Command& command, Command* onTrue, Command* onFalse) {
  * @param onFalse The Command to execute if {@link
  * ConditionalCommand#Condition()} returns false
  */
-ConditionalCommand::ConditionalCommand(Command* onTrue, Command* onFalse) {
+frc::ConditionalCommand::ConditionalCommand(Command* onTrue, Command* onFalse) {
   m_onTrue = onTrue;
   m_onFalse = onFalse;
 
@@ -46,8 +45,8 @@ ConditionalCommand::ConditionalCommand(Command* onTrue, Command* onFalse) {
  * @param onFalse The Command to execute if {@link
  * ConditionalCommand#Condition()} returns false
  */
-ConditionalCommand::ConditionalCommand(const std::string& name, Command* onTrue,
-                                       Command* onFalse)
+frc::ConditionalCommand::ConditionalCommand(const std::string& name,
+                                            Command* onTrue, Command* onFalse)
     : Command(name) {
   m_onTrue = onTrue;
   m_onFalse = onFalse;
@@ -55,7 +54,7 @@ ConditionalCommand::ConditionalCommand(const std::string& name, Command* onTrue,
   RequireAll(*this, onTrue, onFalse);
 }
 
-void ConditionalCommand::_Initialize() {
+void frc::ConditionalCommand::_Initialize() {
   if (Condition()) {
     m_chosenCommand = m_onTrue;
   } else {
@@ -73,7 +72,7 @@ void ConditionalCommand::_Initialize() {
   }
 }
 
-void ConditionalCommand::_Cancel() {
+void frc::ConditionalCommand::_Cancel() {
   if (m_chosenCommand != nullptr && m_chosenCommand->IsRunning()) {
     m_chosenCommand->Cancel();
   }
@@ -81,12 +80,12 @@ void ConditionalCommand::_Cancel() {
   Command::_Cancel();
 }
 
-bool ConditionalCommand::IsFinished() {
+bool frc::ConditionalCommand::IsFinished() {
   return m_chosenCommand != nullptr && m_chosenCommand->IsRunning() &&
          m_chosenCommand->IsFinished();
 }
 
-void ConditionalCommand::Interrupted() {
+void frc::ConditionalCommand::Interrupted() {
   if (m_chosenCommand != nullptr && m_chosenCommand->IsRunning()) {
     m_chosenCommand->Cancel();
   }

--- a/wpilibc/shared/src/Commands/InstantCommand.cpp
+++ b/wpilibc/shared/src/Commands/InstantCommand.cpp
@@ -7,12 +7,10 @@
 
 #include "Commands/InstantCommand.h"
 
-using namespace frc;
-
 /**
  * Creates a new {@link InstantCommand} with the given name.
  * @param name the name for this command
  */
-InstantCommand::InstantCommand(const std::string& name) : Command(name) {}
+frc::InstantCommand::InstantCommand(const std::string& name) : Command(name) {}
 
-bool InstantCommand::IsFinished() { return true; }
+bool frc::InstantCommand::IsFinished() { return true; }

--- a/wpilibc/shared/src/Commands/PIDCommand.cpp
+++ b/wpilibc/shared/src/Commands/PIDCommand.cpp
@@ -9,67 +9,71 @@
 
 #include <cfloat>
 
-using namespace frc;
-
-PIDCommand::PIDCommand(const std::string& name, double p, double i, double d,
-                       double f, double period)
+frc::PIDCommand::PIDCommand(const std::string& name, double p, double i,
+                            double d, double f, double period)
     : Command(name) {
   m_controller = std::make_shared<PIDController>(p, i, d, this, this, period);
 }
 
-PIDCommand::PIDCommand(double p, double i, double d, double f, double period) {
+frc::PIDCommand::PIDCommand(double p, double i, double d, double f,
+                            double period) {
   m_controller =
       std::make_shared<PIDController>(p, i, d, f, this, this, period);
 }
 
-PIDCommand::PIDCommand(const std::string& name, double p, double i, double d)
+frc::PIDCommand::PIDCommand(const std::string& name, double p, double i,
+                            double d)
     : Command(name) {
   m_controller = std::make_shared<PIDController>(p, i, d, this, this);
 }
 
-PIDCommand::PIDCommand(const std::string& name, double p, double i, double d,
-                       double period)
+frc::PIDCommand::PIDCommand(const std::string& name, double p, double i,
+                            double d, double period)
     : Command(name) {
   m_controller = std::make_shared<PIDController>(p, i, d, this, this, period);
 }
 
-PIDCommand::PIDCommand(double p, double i, double d) {
+frc::PIDCommand::PIDCommand(double p, double i, double d) {
   m_controller = std::make_shared<PIDController>(p, i, d, this, this);
 }
 
-PIDCommand::PIDCommand(double p, double i, double d, double period) {
+frc::PIDCommand::PIDCommand(double p, double i, double d, double period) {
   m_controller = std::make_shared<PIDController>(p, i, d, this, this, period);
 }
 
-void PIDCommand::_Initialize() { m_controller->Enable(); }
+void frc::PIDCommand::_Initialize() { m_controller->Enable(); }
 
-void PIDCommand::_End() { m_controller->Disable(); }
+void frc::PIDCommand::_End() { m_controller->Disable(); }
 
-void PIDCommand::_Interrupted() { _End(); }
+void frc::PIDCommand::_Interrupted() { _End(); }
 
-void PIDCommand::SetSetpointRelative(double deltaSetpoint) {
+void frc::PIDCommand::SetSetpointRelative(double deltaSetpoint) {
   SetSetpoint(GetSetpoint() + deltaSetpoint);
 }
 
-void PIDCommand::PIDWrite(double output) { UsePIDOutput(output); }
+void frc::PIDCommand::PIDWrite(double output) { UsePIDOutput(output); }
 
-double PIDCommand::PIDGet() { return ReturnPIDInput(); }
+double frc::PIDCommand::PIDGet() { return ReturnPIDInput(); }
 
-std::shared_ptr<PIDController> PIDCommand::GetPIDController() const {
+std::shared_ptr<frc::PIDController> frc::PIDCommand::GetPIDController() const {
   return m_controller;
 }
 
-void PIDCommand::SetSetpoint(double setpoint) {
+void frc::PIDCommand::SetSetpoint(double setpoint) {
   m_controller->SetSetpoint(setpoint);
 }
 
-double PIDCommand::GetSetpoint() const { return m_controller->GetSetpoint(); }
+double frc::PIDCommand::GetSetpoint() const {
+  return m_controller->GetSetpoint();
+}
 
-double PIDCommand::GetPosition() { return ReturnPIDInput(); }
+double frc::PIDCommand::GetPosition() { return ReturnPIDInput(); }
 
-std::string PIDCommand::GetSmartDashboardType() const { return "PIDCommand"; }
+std::string frc::PIDCommand::GetSmartDashboardType() const {
+  return "PIDCommand";
+}
 
-void PIDCommand::InitTable(std::shared_ptr<ITable> subtable) {
+void frc::PIDCommand::InitTable(std::shared_ptr<ITable> subtable) {
   m_controller->InitTable(subtable);
   Command::InitTable(subtable);
 }

--- a/wpilibc/shared/src/Commands/PIDSubsystem.cpp
+++ b/wpilibc/shared/src/Commands/PIDSubsystem.cpp
@@ -9,8 +9,6 @@
 
 #include "PIDController.h"
 
-using namespace frc;
-
 /**
  * Instantiates a {@link PIDSubsystem} that will use the given p, i and d
  * values.
@@ -20,8 +18,8 @@ using namespace frc;
  * @param i    the integral value
  * @param d    the derivative value
  */
-PIDSubsystem::PIDSubsystem(const std::string& name, double p, double i,
-                           double d)
+frc::PIDSubsystem::PIDSubsystem(const std::string& name, double p, double i,
+                                double d)
     : Subsystem(name) {
   m_controller = std::make_shared<PIDController>(p, i, d, this, this);
 }
@@ -36,8 +34,8 @@ PIDSubsystem::PIDSubsystem(const std::string& name, double p, double i,
  * @param d    the derivative value
  * @param f    the feedforward value
  */
-PIDSubsystem::PIDSubsystem(const std::string& name, double p, double i,
-                           double d, double f)
+frc::PIDSubsystem::PIDSubsystem(const std::string& name, double p, double i,
+                                double d, double f)
     : Subsystem(name) {
   m_controller = std::make_shared<PIDController>(p, i, d, f, this, this);
 }
@@ -56,8 +54,8 @@ PIDSubsystem::PIDSubsystem(const std::string& name, double p, double i,
  * @param f      the feedfoward value
  * @param period the time (in seconds) between calculations
  */
-PIDSubsystem::PIDSubsystem(const std::string& name, double p, double i,
-                           double d, double f, double period)
+frc::PIDSubsystem::PIDSubsystem(const std::string& name, double p, double i,
+                                double d, double f, double period)
     : Subsystem(name) {
   m_controller =
       std::make_shared<PIDController>(p, i, d, f, this, this, period);
@@ -73,7 +71,7 @@ PIDSubsystem::PIDSubsystem(const std::string& name, double p, double i,
  * @param i the integral value
  * @param d the derivative value
  */
-PIDSubsystem::PIDSubsystem(double p, double i, double d)
+frc::PIDSubsystem::PIDSubsystem(double p, double i, double d)
     : Subsystem("PIDSubsystem") {
   m_controller = std::make_shared<PIDController>(p, i, d, this, this);
 }
@@ -89,7 +87,7 @@ PIDSubsystem::PIDSubsystem(double p, double i, double d)
  * @param d the derivative value
  * @param f the feedforward value
  */
-PIDSubsystem::PIDSubsystem(double p, double i, double d, double f)
+frc::PIDSubsystem::PIDSubsystem(double p, double i, double d, double f)
     : Subsystem("PIDSubsystem") {
   m_controller = std::make_shared<PIDController>(p, i, d, f, this, this);
 }
@@ -107,8 +105,8 @@ PIDSubsystem::PIDSubsystem(double p, double i, double d, double f)
  * @param f      the feedforward value
  * @param period the time (in seconds) between calculations
  */
-PIDSubsystem::PIDSubsystem(double p, double i, double d, double f,
-                           double period)
+frc::PIDSubsystem::PIDSubsystem(double p, double i, double d, double f,
+                                double period)
     : Subsystem("PIDSubsystem") {
   m_controller =
       std::make_shared<PIDController>(p, i, d, f, this, this, period);
@@ -117,12 +115,12 @@ PIDSubsystem::PIDSubsystem(double p, double i, double d, double f,
 /**
  * Enables the internal {@link PIDController}.
  */
-void PIDSubsystem::Enable() { m_controller->Enable(); }
+void frc::PIDSubsystem::Enable() { m_controller->Enable(); }
 
 /**
   * Disables the internal {@link PIDController}.
   */
-void PIDSubsystem::Disable() { m_controller->Disable(); }
+void frc::PIDSubsystem::Disable() { m_controller->Disable(); }
 
 /**
  * Returns the {@link PIDController} used by this {@link PIDSubsystem}.
@@ -131,7 +129,7 @@ void PIDSubsystem::Disable() { m_controller->Disable(); }
  *
  * @return the {@link PIDController} used by this {@link PIDSubsystem}
  */
-std::shared_ptr<PIDController> PIDSubsystem::GetPIDController() {
+std::shared_ptr<frc::PIDController> frc::PIDSubsystem::GetPIDController() {
   return m_controller;
 }
 
@@ -143,7 +141,7 @@ std::shared_ptr<PIDController> PIDSubsystem::GetPIDController() {
  *
  * @param setpoint the new setpoint
  */
-void PIDSubsystem::SetSetpoint(double setpoint) {
+void frc::PIDSubsystem::SetSetpoint(double setpoint) {
   m_controller->SetSetpoint(setpoint);
 }
 
@@ -155,7 +153,7 @@ void PIDSubsystem::SetSetpoint(double setpoint) {
  *
  * @param deltaSetpoint the change in the setpoint
  */
-void PIDSubsystem::SetSetpointRelative(double deltaSetpoint) {
+void frc::PIDSubsystem::SetSetpointRelative(double deltaSetpoint) {
   SetSetpoint(GetSetpoint() + deltaSetpoint);
 }
 
@@ -164,7 +162,7 @@ void PIDSubsystem::SetSetpointRelative(double deltaSetpoint) {
  *
  * @return The current setpoint
  */
-double PIDSubsystem::GetSetpoint() { return m_controller->GetSetpoint(); }
+double frc::PIDSubsystem::GetSetpoint() { return m_controller->GetSetpoint(); }
 
 /**
  * Sets the maximum and minimum values expected from the input.
@@ -172,7 +170,8 @@ double PIDSubsystem::GetSetpoint() { return m_controller->GetSetpoint(); }
  * @param minimumInput the minimum value expected from the input
  * @param maximumInput the maximum value expected from the output
  */
-void PIDSubsystem::SetInputRange(double minimumInput, double maximumInput) {
+void frc::PIDSubsystem::SetInputRange(double minimumInput,
+                                      double maximumInput) {
   m_controller->SetInputRange(minimumInput, maximumInput);
 }
 
@@ -182,7 +181,8 @@ void PIDSubsystem::SetInputRange(double minimumInput, double maximumInput) {
  * @param minimumOutput the minimum value to write to the output
  * @param maximumOutput the maximum value to write to the output
  */
-void PIDSubsystem::SetOutputRange(double minimumOutput, double maximumOutput) {
+void frc::PIDSubsystem::SetOutputRange(double minimumOutput,
+                                       double maximumOutput) {
   m_controller->SetOutputRange(minimumOutput, maximumOutput);
 }
 
@@ -192,7 +192,7 @@ void PIDSubsystem::SetOutputRange(double minimumOutput, double maximumOutput) {
  *
  * @param absValue absolute error which is tolerable
  */
-void PIDSubsystem::SetAbsoluteTolerance(double absValue) {
+void frc::PIDSubsystem::SetAbsoluteTolerance(double absValue) {
   m_controller->SetAbsoluteTolerance(absValue);
 }
 
@@ -201,7 +201,7 @@ void PIDSubsystem::SetAbsoluteTolerance(double absValue) {
  *
  * @param percent percentage error which is tolerable
  */
-void PIDSubsystem::SetPercentTolerance(double percent) {
+void frc::PIDSubsystem::SetPercentTolerance(double percent) {
   m_controller->SetPercentTolerance(percent);
 }
 
@@ -220,29 +220,31 @@ void PIDSubsystem::SetPercentTolerance(double percent) {
  * @return true if the error is within the percentage tolerance of the input
  *         range
  */
-bool PIDSubsystem::OnTarget() const { return m_controller->OnTarget(); }
+bool frc::PIDSubsystem::OnTarget() const { return m_controller->OnTarget(); }
 
 /**
  * Returns the current position.
  *
  * @return the current position
  */
-double PIDSubsystem::GetPosition() { return ReturnPIDInput(); }
+double frc::PIDSubsystem::GetPosition() { return ReturnPIDInput(); }
 
 /**
  * Returns the current rate.
  *
  * @return the current rate
  */
-double PIDSubsystem::GetRate() { return ReturnPIDInput(); }
+double frc::PIDSubsystem::GetRate() { return ReturnPIDInput(); }
 
-void PIDSubsystem::PIDWrite(double output) { UsePIDOutput(output); }
+void frc::PIDSubsystem::PIDWrite(double output) { UsePIDOutput(output); }
 
-double PIDSubsystem::PIDGet() { return ReturnPIDInput(); }
+double frc::PIDSubsystem::PIDGet() { return ReturnPIDInput(); }
 
-std::string PIDSubsystem::GetSmartDashboardType() const { return "PIDCommand"; }
+std::string frc::PIDSubsystem::GetSmartDashboardType() const {
+  return "PIDCommand";
+}
 
-void PIDSubsystem::InitTable(std::shared_ptr<ITable> subtable) {
+void frc::PIDSubsystem::InitTable(std::shared_ptr<ITable> subtable) {
   m_controller->InitTable(subtable);
   Subsystem::InitTable(subtable);
 }

--- a/wpilibc/shared/src/Commands/PrintCommand.cpp
+++ b/wpilibc/shared/src/Commands/PrintCommand.cpp
@@ -9,11 +9,9 @@
 
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
-PrintCommand::PrintCommand(const std::string& message)
+frc::PrintCommand::PrintCommand(const std::string& message)
     : InstantCommand("Print \"" + message + "\"") {
   m_message = message;
 }
 
-void PrintCommand::Initialize() { llvm::outs() << m_message << "\n"; }
+void frc::PrintCommand::Initialize() { llvm::outs() << m_message << "\n"; }

--- a/wpilibc/shared/src/Commands/Scheduler.cpp
+++ b/wpilibc/shared/src/Commands/Scheduler.cpp
@@ -15,21 +15,19 @@
 #include "HLUsageReporting.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
-Scheduler::Scheduler() { HLUsageReporting::ReportScheduler(); }
+frc::Scheduler::Scheduler() { HLUsageReporting::ReportScheduler(); }
 
 /**
  * Returns the {@link Scheduler}, creating it if one does not exist.
  *
  * @return the {@link Scheduler}
  */
-Scheduler* Scheduler::GetInstance() {
+frc::Scheduler* frc::Scheduler::GetInstance() {
   static Scheduler instance;
   return &instance;
 }
 
-void Scheduler::SetEnabled(bool enabled) { m_enabled = enabled; }
+void frc::Scheduler::SetEnabled(bool enabled) { m_enabled = enabled; }
 
 /**
  * Add a command to be scheduled later.
@@ -39,7 +37,7 @@ void Scheduler::SetEnabled(bool enabled) { m_enabled = enabled; }
  *
  * @param command The command to be scheduled
  */
-void Scheduler::AddCommand(Command* command) {
+void frc::Scheduler::AddCommand(Command* command) {
   std::lock_guard<hal::priority_mutex> sync(m_additionsLock);
   if (std::find(m_additions.begin(), m_additions.end(), command) !=
       m_additions.end())
@@ -47,12 +45,12 @@ void Scheduler::AddCommand(Command* command) {
   m_additions.push_back(command);
 }
 
-void Scheduler::AddButton(ButtonScheduler* button) {
+void frc::Scheduler::AddButton(ButtonScheduler* button) {
   std::lock_guard<hal::priority_mutex> sync(m_buttonsLock);
   m_buttons.push_back(button);
 }
 
-void Scheduler::ProcessCommandAddition(Command* command) {
+void frc::Scheduler::ProcessCommandAddition(Command* command) {
   if (command == nullptr) return;
 
   // Check to make sure no adding during adding
@@ -109,7 +107,7 @@ void Scheduler::ProcessCommandAddition(Command* command) {
  * <li> Add Defaults </li>
  * </ol>
  */
-void Scheduler::Run() {
+void frc::Scheduler::Run() {
   // Get button input (going backwards preserves button priority)
   {
     if (!m_enabled) return;
@@ -173,7 +171,7 @@ void Scheduler::Run() {
  *
  * @param system the system
  */
-void Scheduler::RegisterSubsystem(Subsystem* subsystem) {
+void frc::Scheduler::RegisterSubsystem(Subsystem* subsystem) {
   if (subsystem == nullptr) {
     wpi_setWPIErrorWithContext(NullParameter, "subsystem");
     return;
@@ -186,7 +184,7 @@ void Scheduler::RegisterSubsystem(Subsystem* subsystem) {
  *
  * @param command the command to remove
  */
-void Scheduler::Remove(Command* command) {
+void frc::Scheduler::Remove(Command* command) {
   if (command == nullptr) {
     wpi_setWPIErrorWithContext(NullParameter, "command");
     return;
@@ -203,7 +201,7 @@ void Scheduler::Remove(Command* command) {
   command->Removed();
 }
 
-void Scheduler::RemoveAll() {
+void frc::Scheduler::RemoveAll() {
   while (m_commands.size() > 0) {
     Remove(*m_commands.begin());
   }
@@ -212,7 +210,7 @@ void Scheduler::RemoveAll() {
 /**
  * Completely resets the scheduler. Undefined behavior if running.
  */
-void Scheduler::ResetAll() {
+void frc::Scheduler::ResetAll() {
   RemoveAll();
   m_subsystems.clear();
   m_buttons.clear();
@@ -225,7 +223,7 @@ void Scheduler::ResetAll() {
  * Update the network tables associated with the Scheduler object on the
  * SmartDashboard.
  */
-void Scheduler::UpdateTable() {
+void frc::Scheduler::UpdateTable() {
   if (m_table != nullptr) {
     // Get the list of possible commands to cancel
     auto new_toCancel = m_table->GetValue("Cancel");
@@ -267,13 +265,15 @@ void Scheduler::UpdateTable() {
   }
 }
 
-std::string Scheduler::GetName() const { return "Scheduler"; }
+std::string frc::Scheduler::GetName() const { return "Scheduler"; }
 
-std::string Scheduler::GetType() const { return "Scheduler"; }
+std::string frc::Scheduler::GetType() const { return "Scheduler"; }
 
-std::string Scheduler::GetSmartDashboardType() const { return "Scheduler"; }
+std::string frc::Scheduler::GetSmartDashboardType() const {
+  return "Scheduler";
+}
 
-void Scheduler::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::Scheduler::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
 
   m_table->PutValue("Names", nt::Value::MakeStringArray(commands));
@@ -281,4 +281,4 @@ void Scheduler::InitTable(std::shared_ptr<ITable> subTable) {
   m_table->PutValue("Cancel", nt::Value::MakeDoubleArray(toCancel));
 }
 
-std::shared_ptr<ITable> Scheduler::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Scheduler::GetTable() const { return m_table; }

--- a/wpilibc/shared/src/Commands/StartCommand.cpp
+++ b/wpilibc/shared/src/Commands/StartCommand.cpp
@@ -7,11 +7,9 @@
 
 #include "Commands/StartCommand.h"
 
-using namespace frc;
-
-StartCommand::StartCommand(Command* commandToStart)
+frc::StartCommand::StartCommand(Command* commandToStart)
     : InstantCommand("StartCommand") {
   m_commandToFork = commandToStart;
 }
 
-void StartCommand::Initialize() { m_commandToFork->Start(); }
+void frc::StartCommand::Initialize() { m_commandToFork->Start(); }

--- a/wpilibc/shared/src/Commands/Subsystem.cpp
+++ b/wpilibc/shared/src/Commands/Subsystem.cpp
@@ -11,14 +11,12 @@
 #include "Commands/Scheduler.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
 /**
  * Creates a subsystem with the given name.
  *
  * @param name the name of the subsystem
  */
-Subsystem::Subsystem(const std::string& name) {
+frc::Subsystem::Subsystem(const std::string& name) {
   m_name = name;
   Scheduler::GetInstance()->RegisterSubsystem(this);
 }
@@ -32,7 +30,7 @@ Subsystem::Subsystem(const std::string& name) {
  *
  * This should be overridden by a Subsystem that has a default Command
  */
-void Subsystem::InitDefaultCommand() {}
+void frc::Subsystem::InitDefaultCommand() {}
 
 /**
  * Sets the default command.  If this is not called or is called with null,
@@ -43,7 +41,7 @@ void Subsystem::InitDefaultCommand() {}
  *
  * @param command the default command (or null if there should be none)
  */
-void Subsystem::SetDefaultCommand(Command* command) {
+void frc::Subsystem::SetDefaultCommand(Command* command) {
   if (command == nullptr) {
     m_defaultCommand = nullptr;
   } else {
@@ -79,7 +77,7 @@ void Subsystem::SetDefaultCommand(Command* command) {
  *
  * @return the default command
  */
-Command* Subsystem::GetDefaultCommand() {
+frc::Command* frc::Subsystem::GetDefaultCommand() {
   if (!m_initializedDefaultCommand) {
     m_initializedDefaultCommand = true;
     InitDefaultCommand();
@@ -92,7 +90,7 @@ Command* Subsystem::GetDefaultCommand() {
  *
  * @param command the new current command
  */
-void Subsystem::SetCurrentCommand(Command* command) {
+void frc::Subsystem::SetCurrentCommand(Command* command) {
   m_currentCommand = command;
   m_currentCommandChanged = true;
 }
@@ -102,12 +100,14 @@ void Subsystem::SetCurrentCommand(Command* command) {
  *
  * @return the command which currently claims this subsystem
  */
-Command* Subsystem::GetCurrentCommand() const { return m_currentCommand; }
+frc::Command* frc::Subsystem::GetCurrentCommand() const {
+  return m_currentCommand;
+}
 
 /**
  * When the run method of the scheduler is called this method will be called.
  */
-void Subsystem::Periodic() {}
+void frc::Subsystem::Periodic() {}
 
 /**
  * Call this to alert Subsystem that the current command is actually the
@@ -117,7 +117,7 @@ void Subsystem::Periodic() {}
  * {@link Scheduler} is going through the loop, only to be soon after given a
  * new one.  This will avoid that situation.
  */
-void Subsystem::ConfirmCommand() {
+void frc::Subsystem::ConfirmCommand() {
   if (m_currentCommandChanged) {
     if (m_table != nullptr) {
       if (m_currentCommand != nullptr) {
@@ -131,11 +131,13 @@ void Subsystem::ConfirmCommand() {
   }
 }
 
-std::string Subsystem::GetName() const { return m_name; }
+std::string frc::Subsystem::GetName() const { return m_name; }
 
-std::string Subsystem::GetSmartDashboardType() const { return "Subsystem"; }
+std::string frc::Subsystem::GetSmartDashboardType() const {
+  return "Subsystem";
+}
 
-void Subsystem::InitTable(std::shared_ptr<ITable> subtable) {
+void frc::Subsystem::InitTable(std::shared_ptr<ITable> subtable) {
   m_table = subtable;
   if (m_table != nullptr) {
     if (m_defaultCommand != nullptr) {
@@ -153,4 +155,4 @@ void Subsystem::InitTable(std::shared_ptr<ITable> subtable) {
   }
 }
 
-std::shared_ptr<ITable> Subsystem::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Subsystem::GetTable() const { return m_table; }

--- a/wpilibc/shared/src/Commands/TimedCommand.cpp
+++ b/wpilibc/shared/src/Commands/TimedCommand.cpp
@@ -7,15 +7,13 @@
 
 #include "Commands/TimedCommand.h"
 
-using namespace frc;
-
 /**
  * Creates a new TimedCommand with the given name and timeout.
  *
  * @param name    the name of the command
  * @param timeout the time (in seconds) before this command "times out"
  */
-TimedCommand::TimedCommand(const std::string& name, double timeout)
+frc::TimedCommand::TimedCommand(const std::string& name, double timeout)
     : Command(name, timeout) {}
 
 /**
@@ -23,9 +21,9 @@ TimedCommand::TimedCommand(const std::string& name, double timeout)
  *
  * @param timeout the time (in seconds) before this command "times out"
  */
-TimedCommand::TimedCommand(double timeout) : Command(timeout) {}
+frc::TimedCommand::TimedCommand(double timeout) : Command(timeout) {}
 
 /**
  * Ends command when timed out.
  */
-bool TimedCommand::IsFinished() { return IsTimedOut(); }
+bool frc::TimedCommand::IsFinished() { return IsTimedOut(); }

--- a/wpilibc/shared/src/Commands/WaitCommand.cpp
+++ b/wpilibc/shared/src/Commands/WaitCommand.cpp
@@ -7,15 +7,13 @@
 
 #include "Commands/WaitCommand.h"
 
-using namespace frc;
-
 /**
  * Creates a new WaitCommand with the given name and timeout.
  *
  * @param name    the name of the command
  * @param timeout the time (in seconds) before this command "times out"
  */
-WaitCommand::WaitCommand(double timeout)
+frc::WaitCommand::WaitCommand(double timeout)
     : TimedCommand("Wait(" + std::to_string(timeout) + ")", timeout) {}
 
 /**
@@ -23,5 +21,5 @@ WaitCommand::WaitCommand(double timeout)
  *
  * @param timeout the time (in seconds) before this command "times out"
  */
-WaitCommand::WaitCommand(const std::string& name, double timeout)
+frc::WaitCommand::WaitCommand(const std::string& name, double timeout)
     : TimedCommand(name, timeout) {}

--- a/wpilibc/shared/src/Commands/WaitForChildren.cpp
+++ b/wpilibc/shared/src/Commands/WaitForChildren.cpp
@@ -9,14 +9,12 @@
 
 #include "Commands/CommandGroup.h"
 
-using namespace frc;
-
-WaitForChildren::WaitForChildren(double timeout)
+frc::WaitForChildren::WaitForChildren(double timeout)
     : Command("WaitForChildren", timeout) {}
 
-WaitForChildren::WaitForChildren(const std::string& name, double timeout)
+frc::WaitForChildren::WaitForChildren(const std::string& name, double timeout)
     : Command(name, timeout) {}
 
-bool WaitForChildren::IsFinished() {
+bool frc::WaitForChildren::IsFinished() {
   return GetGroup() == nullptr || GetGroup()->GetSize() == 0;
 }

--- a/wpilibc/shared/src/Commands/WaitUntilCommand.cpp
+++ b/wpilibc/shared/src/Commands/WaitUntilCommand.cpp
@@ -9,8 +9,6 @@
 
 #include "Timer.h"
 
-using namespace frc;
-
 /**
  * A {@link WaitCommand} will wait until a certain match time before finishing.
  *
@@ -18,12 +16,12 @@ using namespace frc;
  * next command.
  * @see CommandGroup
  */
-WaitUntilCommand::WaitUntilCommand(double time)
+frc::WaitUntilCommand::WaitUntilCommand(double time)
     : Command("WaitUntilCommand", time) {
   m_time = time;
 }
 
-WaitUntilCommand::WaitUntilCommand(const std::string& name, double time)
+frc::WaitUntilCommand::WaitUntilCommand(const std::string& name, double time)
     : Command(name, time) {
   m_time = time;
 }
@@ -31,4 +29,6 @@ WaitUntilCommand::WaitUntilCommand(const std::string& name, double time)
 /**
  * Check if we've reached the actual finish time.
  */
-bool WaitUntilCommand::IsFinished() { return Timer::GetMatchTime() >= m_time; }
+bool frc::WaitUntilCommand::IsFinished() {
+  return Timer::GetMatchTime() >= m_time;
+}

--- a/wpilibc/shared/src/Error.cpp
+++ b/wpilibc/shared/src/Error.cpp
@@ -13,9 +13,7 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
-void Error::Clone(const Error& error) {
+void frc::Error::Clone(const Error& error) {
   m_code = error.m_code;
   m_message = error.m_message;
   m_filename = error.m_filename;
@@ -25,25 +23,25 @@ void Error::Clone(const Error& error) {
   m_timestamp = error.m_timestamp;
 }
 
-Error::Code Error::GetCode() const { return m_code; }
+frc::Error::Code frc::Error::GetCode() const { return m_code; }
 
-std::string Error::GetMessage() const { return m_message; }
+std::string frc::Error::GetMessage() const { return m_message; }
 
-std::string Error::GetFilename() const { return m_filename; }
+std::string frc::Error::GetFilename() const { return m_filename; }
 
-std::string Error::GetFunction() const { return m_function; }
+std::string frc::Error::GetFunction() const { return m_function; }
 
-int Error::GetLineNumber() const { return m_lineNumber; }
+int frc::Error::GetLineNumber() const { return m_lineNumber; }
 
-const ErrorBase* Error::GetOriginatingObject() const {
+const frc::ErrorBase* frc::Error::GetOriginatingObject() const {
   return m_originatingObject;
 }
 
-double Error::GetTimestamp() const { return m_timestamp; }
+double frc::Error::GetTimestamp() const { return m_timestamp; }
 
-void Error::Set(Code code, llvm::StringRef contextMessage,
-                llvm::StringRef filename, llvm::StringRef function,
-                int lineNumber, const ErrorBase* originatingObject) {
+void frc::Error::Set(Code code, llvm::StringRef contextMessage,
+                     llvm::StringRef filename, llvm::StringRef function,
+                     int lineNumber, const ErrorBase* originatingObject) {
   bool report = true;
 
   if (code == m_code && GetTime() - m_timestamp < 1) {
@@ -63,7 +61,7 @@ void Error::Set(Code code, llvm::StringRef contextMessage,
   }
 }
 
-void Error::Report() {
+void frc::Error::Report() {
   llvm::SmallString<128> buf;
   llvm::raw_svector_ostream locStream(buf);
   locStream << m_function << " [";
@@ -83,7 +81,7 @@ void Error::Report() {
                              GetStackTrace(4));
 }
 
-void Error::Clear() {
+void frc::Error::Clear() {
   m_code = 0;
   m_message = "";
   m_filename = "";

--- a/wpilibc/shared/src/ErrorBase.cpp
+++ b/wpilibc/shared/src/ErrorBase.cpp
@@ -18,23 +18,21 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
-hal::priority_mutex ErrorBase::_globalErrorMutex;
-Error ErrorBase::_globalError;
+hal::priority_mutex frc::ErrorBase::_globalErrorMutex;
+frc::Error frc::ErrorBase::_globalError;
 
 /**
  * @brief Retrieve the current error.
  * Get the current error information associated with this sensor.
  */
-Error& ErrorBase::GetError() { return m_error; }
+frc::Error& frc::ErrorBase::GetError() { return m_error; }
 
-const Error& ErrorBase::GetError() const { return m_error; }
+const frc::Error& frc::ErrorBase::GetError() const { return m_error; }
 
 /**
  * @brief Clear the current error information associated with this sensor.
  */
-void ErrorBase::ClearError() const { m_error.Clear(); }
+void frc::ErrorBase::ClearError() const { m_error.Clear(); }
 
 /**
  * @brief Set error information associated with a C library call that set an
@@ -45,9 +43,10 @@ void ErrorBase::ClearError() const { m_error.Clear(); }
  * @param function       Function of the error source
  * @param lineNumber     Line number of the error source
  */
-void ErrorBase::SetErrnoError(llvm::StringRef contextMessage,
-                              llvm::StringRef filename,
-                              llvm::StringRef function, int lineNumber) const {
+void frc::ErrorBase::SetErrnoError(llvm::StringRef contextMessage,
+                                   llvm::StringRef filename,
+                                   llvm::StringRef function,
+                                   int lineNumber) const {
   std::string err;
   int errNo = errno;
   if (errNo == 0) {
@@ -80,9 +79,10 @@ void ErrorBase::SetErrnoError(llvm::StringRef contextMessage,
  * @param function       Function of the error source
  * @param lineNumber     Line number of the error source
  */
-void ErrorBase::SetImaqError(int success, llvm::StringRef contextMessage,
-                             llvm::StringRef filename, llvm::StringRef function,
-                             int lineNumber) const {
+void frc::ErrorBase::SetImaqError(int success, llvm::StringRef contextMessage,
+                                  llvm::StringRef filename,
+                                  llvm::StringRef function,
+                                  int lineNumber) const {
   // If there was an error
   if (success <= 0) {
     llvm::SmallString<128> buf;
@@ -109,9 +109,9 @@ void ErrorBase::SetImaqError(int success, llvm::StringRef contextMessage,
  * @param function       Function of the error source
  * @param lineNumber     Line number of the error source
  */
-void ErrorBase::SetError(Error::Code code, llvm::StringRef contextMessage,
-                         llvm::StringRef filename, llvm::StringRef function,
-                         int lineNumber) const {
+void frc::ErrorBase::SetError(Error::Code code, llvm::StringRef contextMessage,
+                              llvm::StringRef filename,
+                              llvm::StringRef function, int lineNumber) const {
   //  If there was an error
   if (code != 0) {
     //  Set the current error information for this object.
@@ -138,11 +138,12 @@ void ErrorBase::SetError(Error::Code code, llvm::StringRef contextMessage,
  * @param function       Function of the error source
  * @param lineNumber     Line number of the error source
  */
-void ErrorBase::SetErrorRange(Error::Code code, int32_t minRange,
-                              int32_t maxRange, int32_t requestedValue,
-                              llvm::StringRef contextMessage,
-                              llvm::StringRef filename,
-                              llvm::StringRef function, int lineNumber) const {
+void frc::ErrorBase::SetErrorRange(Error::Code code, int32_t minRange,
+                                   int32_t maxRange, int32_t requestedValue,
+                                   llvm::StringRef contextMessage,
+                                   llvm::StringRef filename,
+                                   llvm::StringRef function,
+                                   int lineNumber) const {
   //  If there was an error
   if (code != 0) {
     size_t size = contextMessage.size() + 100;
@@ -172,10 +173,11 @@ void ErrorBase::SetErrorRange(Error::Code code, int32_t minRange,
  * @param function       Function of the error source
  * @param lineNumber     Line number of the error source
  */
-void ErrorBase::SetWPIError(llvm::StringRef errorMessage, Error::Code code,
-                            llvm::StringRef contextMessage,
-                            llvm::StringRef filename, llvm::StringRef function,
-                            int lineNumber) const {
+void frc::ErrorBase::SetWPIError(llvm::StringRef errorMessage, Error::Code code,
+                                 llvm::StringRef contextMessage,
+                                 llvm::StringRef filename,
+                                 llvm::StringRef function,
+                                 int lineNumber) const {
   std::string err = errorMessage.str() + ": " + contextMessage.str();
 
   //  Set the current error information for this object.
@@ -188,7 +190,7 @@ void ErrorBase::SetWPIError(llvm::StringRef errorMessage, Error::Code code,
   }
 }
 
-void ErrorBase::CloneError(const ErrorBase& rhs) const {
+void frc::ErrorBase::CloneError(const ErrorBase& rhs) const {
   m_error.Clone(rhs.GetError());
 }
 
@@ -197,11 +199,12 @@ void ErrorBase::CloneError(const ErrorBase& rhs) const {
  *
  * @return true if the current error is fatal.
  */
-bool ErrorBase::StatusIsFatal() const { return m_error.GetCode() < 0; }
+bool frc::ErrorBase::StatusIsFatal() const { return m_error.GetCode() < 0; }
 
-void ErrorBase::SetGlobalError(Error::Code code, llvm::StringRef contextMessage,
-                               llvm::StringRef filename,
-                               llvm::StringRef function, int lineNumber) {
+void frc::ErrorBase::SetGlobalError(Error::Code code,
+                                    llvm::StringRef contextMessage,
+                                    llvm::StringRef filename,
+                                    llvm::StringRef function, int lineNumber) {
   // If there was an error
   if (code != 0) {
     std::lock_guard<hal::priority_mutex> mutex(_globalErrorMutex);
@@ -212,10 +215,11 @@ void ErrorBase::SetGlobalError(Error::Code code, llvm::StringRef contextMessage,
   }
 }
 
-void ErrorBase::SetGlobalWPIError(llvm::StringRef errorMessage,
-                                  llvm::StringRef contextMessage,
-                                  llvm::StringRef filename,
-                                  llvm::StringRef function, int lineNumber) {
+void frc::ErrorBase::SetGlobalWPIError(llvm::StringRef errorMessage,
+                                       llvm::StringRef contextMessage,
+                                       llvm::StringRef filename,
+                                       llvm::StringRef function,
+                                       int lineNumber) {
   std::string err = errorMessage.str() + ": " + contextMessage.str();
 
   std::lock_guard<hal::priority_mutex> mutex(_globalErrorMutex);
@@ -228,7 +232,7 @@ void ErrorBase::SetGlobalWPIError(llvm::StringRef errorMessage,
 /**
  * Retrieve the current global error.
  */
-Error& ErrorBase::GetGlobalError() {
+frc::Error& frc::ErrorBase::GetGlobalError() {
   std::lock_guard<hal::priority_mutex> mutex(_globalErrorMutex);
   return _globalError;
 }

--- a/wpilibc/shared/src/Filters/Filter.cpp
+++ b/wpilibc/shared/src/Filters/Filter.cpp
@@ -7,16 +7,14 @@
 
 #include "Filters/Filter.h"
 
-using namespace frc;
+frc::Filter::Filter(std::shared_ptr<PIDSource> source) { m_source = source; }
 
-Filter::Filter(std::shared_ptr<PIDSource> source) { m_source = source; }
-
-void Filter::SetPIDSourceType(PIDSourceType pidSource) {
+void frc::Filter::SetPIDSourceType(PIDSourceType pidSource) {
   m_source->SetPIDSourceType(pidSource);
 }
 
-PIDSourceType Filter::GetPIDSourceType() const {
+frc::PIDSourceType frc::Filter::GetPIDSourceType() const {
   return m_source->GetPIDSourceType();
 }
 
-double Filter::PIDGetSource() { return m_source->PIDGet(); }
+double frc::Filter::PIDGetSource() { return m_source->PIDGet(); }

--- a/wpilibc/shared/src/Filters/LinearDigitalFilter.cpp
+++ b/wpilibc/shared/src/Filters/LinearDigitalFilter.cpp
@@ -10,8 +10,6 @@
 #include <cassert>
 #include <cmath>
 
-using namespace frc;
-
 /**
  * Create a linear FIR or IIR filter.
  *
@@ -19,9 +17,9 @@ using namespace frc;
  * @param ffGains The "feed forward" or FIR gains
  * @param fbGains The "feed back" or IIR gains
  */
-LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
-                                         std::initializer_list<double> ffGains,
-                                         std::initializer_list<double> fbGains)
+frc::LinearDigitalFilter::LinearDigitalFilter(
+    std::shared_ptr<PIDSource> source, std::initializer_list<double> ffGains,
+    std::initializer_list<double> fbGains)
     : Filter(source),
       m_inputs(ffGains.size()),
       m_outputs(fbGains.size()),
@@ -35,9 +33,9 @@ LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
  * @param ffGains The "feed forward" or FIR gains
  * @param fbGains The "feed back" or IIR gains
  */
-LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
-                                         std::initializer_list<double> ffGains,
-                                         const std::vector<double>& fbGains)
+frc::LinearDigitalFilter::LinearDigitalFilter(
+    std::shared_ptr<PIDSource> source, std::initializer_list<double> ffGains,
+    const std::vector<double>& fbGains)
     : Filter(source),
       m_inputs(ffGains.size()),
       m_outputs(fbGains.size()),
@@ -51,9 +49,9 @@ LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
  * @param ffGains The "feed forward" or FIR gains
  * @param fbGains The "feed back" or IIR gains
  */
-LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
-                                         const std::vector<double>& ffGains,
-                                         std::initializer_list<double> fbGains)
+frc::LinearDigitalFilter::LinearDigitalFilter(
+    std::shared_ptr<PIDSource> source, const std::vector<double>& ffGains,
+    std::initializer_list<double> fbGains)
     : Filter(source),
       m_inputs(ffGains.size()),
       m_outputs(fbGains.size()),
@@ -67,9 +65,9 @@ LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
  * @param ffGains The "feed forward" or FIR gains
  * @param fbGains The "feed back" or IIR gains
  */
-LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
-                                         const std::vector<double>& ffGains,
-                                         const std::vector<double>& fbGains)
+frc::LinearDigitalFilter::LinearDigitalFilter(
+    std::shared_ptr<PIDSource> source, const std::vector<double>& ffGains,
+    const std::vector<double>& fbGains)
     : Filter(source),
       m_inputs(ffGains.size()),
       m_outputs(fbGains.size()),
@@ -87,7 +85,7 @@ LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
  * @param timeConstant The discrete-time time constant in seconds
  * @param period       The period in seconds between samples taken by the user
  */
-LinearDigitalFilter LinearDigitalFilter::SinglePoleIIR(
+frc::LinearDigitalFilter frc::LinearDigitalFilter::SinglePoleIIR(
     std::shared_ptr<PIDSource> source, double timeConstant, double period) {
   double gain = std::exp(-period / timeConstant);
   return LinearDigitalFilter(std::move(source), {1.0 - gain}, {-gain});
@@ -104,7 +102,7 @@ LinearDigitalFilter LinearDigitalFilter::SinglePoleIIR(
  * @param timeConstant The discrete-time time constant in seconds
  * @param period       The period in seconds between samples taken by the user
  */
-LinearDigitalFilter LinearDigitalFilter::HighPass(
+frc::LinearDigitalFilter frc::LinearDigitalFilter::HighPass(
     std::shared_ptr<PIDSource> source, double timeConstant, double period) {
   double gain = std::exp(-period / timeConstant);
   return LinearDigitalFilter(std::move(source), {gain, -gain}, {-gain});
@@ -120,7 +118,7 @@ LinearDigitalFilter LinearDigitalFilter::HighPass(
  * @param taps   The number of samples to average over. Higher = smoother but
  *               slower
  */
-LinearDigitalFilter LinearDigitalFilter::MovingAverage(
+frc::LinearDigitalFilter frc::LinearDigitalFilter::MovingAverage(
     std::shared_ptr<PIDSource> source, int taps) {
   assert(taps > 0);
 
@@ -128,7 +126,7 @@ LinearDigitalFilter LinearDigitalFilter::MovingAverage(
   return LinearDigitalFilter(std::move(source), gains, {});
 }
 
-double LinearDigitalFilter::Get() const {
+double frc::LinearDigitalFilter::Get() const {
   double retVal = 0.0;
 
   // Calculate the new value
@@ -142,7 +140,7 @@ double LinearDigitalFilter::Get() const {
   return retVal;
 }
 
-void LinearDigitalFilter::Reset() {
+void frc::LinearDigitalFilter::Reset() {
   m_inputs.Reset();
   m_outputs.Reset();
 }
@@ -152,7 +150,7 @@ void LinearDigitalFilter::Reset() {
  *
  * @return The filtered value at this step
  */
-double LinearDigitalFilter::PIDGet() {
+double frc::LinearDigitalFilter::PIDGet() {
   double retVal = 0.0;
 
   // Rotate the inputs

--- a/wpilibc/shared/src/GamepadBase.cpp
+++ b/wpilibc/shared/src/GamepadBase.cpp
@@ -7,6 +7,4 @@
 
 #include "GamepadBase.h"
 
-using namespace frc;
-
-GamepadBase::GamepadBase(int port) : GenericHID(port) {}
+frc::GamepadBase::GamepadBase(int port) : GenericHID(port) {}

--- a/wpilibc/shared/src/GyroBase.cpp
+++ b/wpilibc/shared/src/GyroBase.cpp
@@ -10,15 +10,13 @@
 #include "LiveWindow/LiveWindow.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
 /**
  * Get the PIDOutput for the PIDSource base object. Can be set to return
  * angle or rate using SetPIDSourceType(). Defaults to angle.
  *
  * @return The PIDOutput (angle or rate, defaults to angle)
  */
-double GyroBase::PIDGet() {
+double frc::GyroBase::PIDGet() {
   switch (GetPIDSourceType()) {
     case PIDSourceType::kRate:
       return GetRate();
@@ -29,21 +27,21 @@ double GyroBase::PIDGet() {
   }
 }
 
-void GyroBase::UpdateTable() {
+void frc::GyroBase::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Value", GetAngle());
   }
 }
 
-void GyroBase::StartLiveWindowMode() {}
+void frc::GyroBase::StartLiveWindowMode() {}
 
-void GyroBase::StopLiveWindowMode() {}
+void frc::GyroBase::StopLiveWindowMode() {}
 
-std::string GyroBase::GetSmartDashboardType() const { return "Gyro"; }
+std::string frc::GyroBase::GetSmartDashboardType() const { return "Gyro"; }
 
-void GyroBase::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::GyroBase::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> GyroBase::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::GyroBase::GetTable() const { return m_table; }

--- a/wpilibc/shared/src/HLUsageReporting.cpp
+++ b/wpilibc/shared/src/HLUsageReporting.cpp
@@ -7,21 +7,19 @@
 
 #include "HLUsageReporting.h"
 
-using namespace frc;
+frc::HLUsageReportingInterface* frc::HLUsageReporting::impl = nullptr;
 
-HLUsageReportingInterface* HLUsageReporting::impl = nullptr;
-
-void HLUsageReporting::SetImplementation(HLUsageReportingInterface* i) {
+void frc::HLUsageReporting::SetImplementation(HLUsageReportingInterface* i) {
   impl = i;
 }
 
-void HLUsageReporting::ReportScheduler() {
+void frc::HLUsageReporting::ReportScheduler() {
   if (impl != nullptr) {
     impl->ReportScheduler();
   }
 }
 
-void HLUsageReporting::ReportSmartDashboard() {
+void frc::HLUsageReporting::ReportSmartDashboard() {
   if (impl != nullptr) {
     impl->ReportSmartDashboard();
   }

--- a/wpilibc/shared/src/JoystickBase.cpp
+++ b/wpilibc/shared/src/JoystickBase.cpp
@@ -7,6 +7,4 @@
 
 #include "JoystickBase.h"
 
-using namespace frc;
-
-JoystickBase::JoystickBase(int port) : GenericHID(port) {}
+frc::JoystickBase::JoystickBase(int port) : GenericHID(port) {}

--- a/wpilibc/shared/src/LiveWindow/LiveWindow.cpp
+++ b/wpilibc/shared/src/LiveWindow/LiveWindow.cpp
@@ -13,15 +13,13 @@
 #include "llvm/raw_ostream.h"
 #include "networktables/NetworkTable.h"
 
-using namespace frc;
-
 /**
  * Get an instance of the LiveWindow main class.
  *
  * This is a singleton to guarantee that there is only a single instance
  * regardless of how many times GetInstance is called.
  */
-LiveWindow* LiveWindow::GetInstance() {
+frc::LiveWindow* frc::LiveWindow::GetInstance() {
   static LiveWindow instance;
   return &instance;
 }
@@ -31,7 +29,7 @@ LiveWindow* LiveWindow::GetInstance() {
  *
  * Allocate the necessary tables.
  */
-LiveWindow::LiveWindow() : m_scheduler(Scheduler::GetInstance()) {
+frc::LiveWindow::LiveWindow() : m_scheduler(Scheduler::GetInstance()) {
   m_liveWindowTable = NetworkTable::GetTable("LiveWindow");
   m_statusTable = m_liveWindowTable->GetSubTable("~STATUS~");
 }
@@ -41,7 +39,7 @@ LiveWindow::LiveWindow() : m_scheduler(Scheduler::GetInstance()) {
  *
  * If it changes to enabled, start livewindow running otherwise stop it
  */
-void LiveWindow::SetEnabled(bool enabled) {
+void frc::LiveWindow::SetEnabled(bool enabled) {
   if (m_enabled == enabled) return;
   if (enabled) {
     if (m_firstTime) {
@@ -76,9 +74,9 @@ void LiveWindow::SetEnabled(bool enabled) {
 /**
  * @brief Use a STL smart pointer to share ownership of component.
  */
-void LiveWindow::AddSensor(const std::string& subsystem,
-                           const std::string& name,
-                           std::shared_ptr<LiveWindowSendable> component) {
+void frc::LiveWindow::AddSensor(const std::string& subsystem,
+                                const std::string& name,
+                                std::shared_ptr<LiveWindowSendable> component) {
   m_components[component].subsystem = subsystem;
   m_components[component].name = name;
   m_components[component].isSensor = true;
@@ -87,9 +85,9 @@ void LiveWindow::AddSensor(const std::string& subsystem,
 /**
  * @brief Pass a reference to LiveWindow and retain ownership of the component.
  */
-void LiveWindow::AddSensor(const std::string& subsystem,
-                           const std::string& name,
-                           LiveWindowSendable& component) {
+void frc::LiveWindow::AddSensor(const std::string& subsystem,
+                                const std::string& name,
+                                LiveWindowSendable& component) {
   AddSensor(subsystem, name, std::shared_ptr<LiveWindowSendable>(
                                  &component, [](LiveWindowSendable*) {}));
 }
@@ -98,9 +96,9 @@ void LiveWindow::AddSensor(const std::string& subsystem,
  * @brief Use a raw pointer to the LiveWindow.
  * @deprecated Prefer smart pointers or references.
  */
-void LiveWindow::AddSensor(const std::string& subsystem,
-                           const std::string& name,
-                           LiveWindowSendable* component) {
+void frc::LiveWindow::AddSensor(const std::string& subsystem,
+                                const std::string& name,
+                                LiveWindowSendable* component) {
   AddSensor(subsystem, name, std::shared_ptr<LiveWindowSendable>(
                                  component, NullDeleter<LiveWindowSendable>()));
 }
@@ -119,9 +117,9 @@ void LiveWindow::AddSensor(const std::string& subsystem,
 /**
  * @brief Use a STL smart pointer to share ownership of component.
  */
-void LiveWindow::AddActuator(const std::string& subsystem,
-                             const std::string& name,
-                             std::shared_ptr<LiveWindowSendable> component) {
+void frc::LiveWindow::AddActuator(
+    const std::string& subsystem, const std::string& name,
+    std::shared_ptr<LiveWindowSendable> component) {
   m_components[component].subsystem = subsystem;
   m_components[component].name = name;
   m_components[component].isSensor = false;
@@ -130,9 +128,9 @@ void LiveWindow::AddActuator(const std::string& subsystem,
 /**
  * @brief Pass a reference to LiveWindow and retain ownership of the component.
  */
-void LiveWindow::AddActuator(const std::string& subsystem,
-                             const std::string& name,
-                             LiveWindowSendable& component) {
+void frc::LiveWindow::AddActuator(const std::string& subsystem,
+                                  const std::string& name,
+                                  LiveWindowSendable& component) {
   AddActuator(subsystem, name, std::shared_ptr<LiveWindowSendable>(
                                    &component, [](LiveWindowSendable*) {}));
 }
@@ -141,9 +139,9 @@ void LiveWindow::AddActuator(const std::string& subsystem,
  * @brief Use a raw pointer to the LiveWindow.
  * @deprecated Prefer smart pointers or references.
  */
-void LiveWindow::AddActuator(const std::string& subsystem,
-                             const std::string& name,
-                             LiveWindowSendable* component) {
+void frc::LiveWindow::AddActuator(const std::string& subsystem,
+                                  const std::string& name,
+                                  LiveWindowSendable* component) {
   AddActuator(subsystem, name,
               std::shared_ptr<LiveWindowSendable>(
                   component, NullDeleter<LiveWindowSendable>()));
@@ -153,8 +151,8 @@ void LiveWindow::AddActuator(const std::string& subsystem,
 /**
  * Meant for internal use in other WPILib classes.
  */
-void LiveWindow::AddSensor(std::string type, int channel,
-                           LiveWindowSendable* component) {
+void frc::LiveWindow::AddSensor(std::string type, int channel,
+                                LiveWindowSendable* component) {
   llvm::SmallString<128> buf;
   llvm::raw_svector_ostream oss(buf);
   oss << type << "[" << channel << "]";
@@ -169,8 +167,8 @@ void LiveWindow::AddSensor(std::string type, int channel,
 /**
  * Meant for internal use in other WPILib classes.
  */
-void LiveWindow::AddActuator(std::string type, int channel,
-                             LiveWindowSendable* component) {
+void frc::LiveWindow::AddActuator(std::string type, int channel,
+                                  LiveWindowSendable* component) {
   llvm::SmallString<128> buf;
   llvm::raw_svector_ostream oss(buf);
   oss << type << "[" << channel << "]";
@@ -182,8 +180,8 @@ void LiveWindow::AddActuator(std::string type, int channel,
 /**
  * Meant for internal use in other WPILib classes.
  */
-void LiveWindow::AddActuator(std::string type, int module, int channel,
-                             LiveWindowSendable* component) {
+void frc::LiveWindow::AddActuator(std::string type, int module, int channel,
+                                  LiveWindowSendable* component) {
   llvm::SmallString<128> buf;
   llvm::raw_svector_ostream oss(buf);
   oss << type << "[" << module << "," << channel << "]";
@@ -198,7 +196,7 @@ void LiveWindow::AddActuator(std::string type, int module, int channel,
  * Actuators are handled through callbacks on their value changing from the
  * SmartDashboard widgets.
  */
-void LiveWindow::UpdateValues() {
+void frc::LiveWindow::UpdateValues() {
   for (auto& elem : m_sensors) {
     elem->UpdateTable();
   }
@@ -208,7 +206,7 @@ void LiveWindow::UpdateValues() {
  * This method is called periodically to cause the sensors to send new values
  * to the SmartDashboard.
  */
-void LiveWindow::Run() {
+void frc::LiveWindow::Run() {
   if (m_enabled) {
     UpdateValues();
   }
@@ -221,7 +219,7 @@ void LiveWindow::Run() {
  * sensor and actuator values to be created that are replaced with the custom
  * names from users calling addActuator and addSensor.
  */
-void LiveWindow::InitializeLiveWindowComponents() {
+void frc::LiveWindow::InitializeLiveWindowComponents() {
   for (auto& elem : m_components) {
     std::shared_ptr<LiveWindowSendable> component = elem.first;
     LiveWindowComponent c = elem.second;

--- a/wpilibc/shared/src/LiveWindow/LiveWindowStatusListener.cpp
+++ b/wpilibc/shared/src/LiveWindow/LiveWindowStatusListener.cpp
@@ -9,8 +9,6 @@
 
 #include "Commands/Scheduler.h"
 
-using namespace frc;
-
-void LiveWindowStatusListener::ValueChanged(ITable* source, llvm::StringRef key,
-                                            std::shared_ptr<nt::Value> value,
-                                            bool isNew) {}
+void frc::LiveWindowStatusListener::ValueChanged(
+    ITable* source, llvm::StringRef key, std::shared_ptr<nt::Value> value,
+    bool isNew) {}

--- a/wpilibc/shared/src/PIDSource.cpp
+++ b/wpilibc/shared/src/PIDSource.cpp
@@ -7,15 +7,15 @@
 
 #include "PIDSource.h"
 
-using namespace frc;
-
 /**
  * Set which parameter you are using as a process control variable.
  *
  * @param pidSource An enum to select the parameter.
  */
-void PIDSource::SetPIDSourceType(PIDSourceType pidSource) {
+void frc::PIDSource::SetPIDSourceType(PIDSourceType pidSource) {
   m_pidSource = pidSource;
 }
 
-PIDSourceType PIDSource::GetPIDSourceType() const { return m_pidSource; }
+frc::PIDSourceType frc::PIDSource::GetPIDSourceType() const {
+  return m_pidSource;
+}

--- a/wpilibc/shared/src/Resource.cpp
+++ b/wpilibc/shared/src/Resource.cpp
@@ -10,9 +10,7 @@
 #include "ErrorBase.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
-hal::priority_recursive_mutex Resource::m_createLock;
+hal::priority_recursive_mutex frc::Resource::m_createLock;
 
 /**
  * Allocate storage for a new instance of Resource.
@@ -21,7 +19,7 @@ hal::priority_recursive_mutex Resource::m_createLock;
  * resources have been allocated yet. The indicies of the resources are [0 ..
  * elements - 1].
  */
-Resource::Resource(uint32_t elements) {
+frc::Resource::Resource(uint32_t elements) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_createLock);
   m_isAllocated = std::vector<bool>(elements, false);
 }
@@ -37,8 +35,8 @@ Resource::Resource(uint32_t elements) {
  *                 track, that is, it will allocate resource numbers in the
  *                 range [0 .. elements - 1].
  */
-/*static*/ void Resource::CreateResourceObject(std::unique_ptr<Resource>& r,
-                                               uint32_t elements) {
+/*static*/ void frc::Resource::CreateResourceObject(
+    std::unique_ptr<Resource>& r, uint32_t elements) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_createLock);
   if (!r) {
     r = std::make_unique<Resource>(elements);
@@ -52,7 +50,7 @@ Resource::Resource(uint32_t elements) {
  * resource value within the range is located and returned after it is marked
  * allocated.
  */
-uint32_t Resource::Allocate(const std::string& resourceDesc) {
+uint32_t frc::Resource::Allocate(const std::string& resourceDesc) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_allocateLock);
   for (uint32_t i = 0; i < m_isAllocated.size(); i++) {
     if (!m_isAllocated[i]) {
@@ -70,7 +68,8 @@ uint32_t Resource::Allocate(const std::string& resourceDesc) {
  * The user requests a specific resource value, i.e. channel number and it is
  * verified unallocated, then returned.
  */
-uint32_t Resource::Allocate(uint32_t index, const std::string& resourceDesc) {
+uint32_t frc::Resource::Allocate(uint32_t index,
+                                 const std::string& resourceDesc) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_allocateLock);
   if (index >= m_isAllocated.size()) {
     wpi_setWPIErrorWithContext(ChannelIndexOutOfRange, resourceDesc);
@@ -91,7 +90,7 @@ uint32_t Resource::Allocate(uint32_t index, const std::string& resourceDesc) {
  * a channel assignment class, Free will release the resource value so it can
  * be reused somewhere else in the program.
  */
-void Resource::Free(uint32_t index) {
+void frc::Resource::Free(uint32_t index) {
   std::unique_lock<hal::priority_recursive_mutex> sync(m_allocateLock);
   if (index == std::numeric_limits<uint32_t>::max()) return;
   if (index >= m_isAllocated.size()) {

--- a/wpilibc/shared/src/RobotState.cpp
+++ b/wpilibc/shared/src/RobotState.cpp
@@ -9,48 +9,47 @@
 
 #include "Base.h"
 
-using namespace frc;
+std::shared_ptr<frc::RobotStateInterface> frc::RobotState::impl;
 
-std::shared_ptr<RobotStateInterface> RobotState::impl;
-
-void RobotState::SetImplementation(RobotStateInterface& i) {
+void frc::RobotState::SetImplementation(RobotStateInterface& i) {
   impl = std::shared_ptr<RobotStateInterface>(
       &i, NullDeleter<RobotStateInterface>());
 }
 
-void RobotState::SetImplementation(std::shared_ptr<RobotStateInterface> i) {
+void frc::RobotState::SetImplementation(
+    std::shared_ptr<RobotStateInterface> i) {
   impl = i;
 }
 
-bool RobotState::IsDisabled() {
+bool frc::RobotState::IsDisabled() {
   if (impl != nullptr) {
     return impl->IsDisabled();
   }
   return true;
 }
 
-bool RobotState::IsEnabled() {
+bool frc::RobotState::IsEnabled() {
   if (impl != nullptr) {
     return impl->IsEnabled();
   }
   return false;
 }
 
-bool RobotState::IsOperatorControl() {
+bool frc::RobotState::IsOperatorControl() {
   if (impl != nullptr) {
     return impl->IsOperatorControl();
   }
   return true;
 }
 
-bool RobotState::IsAutonomous() {
+bool frc::RobotState::IsAutonomous() {
   if (impl != nullptr) {
     return impl->IsAutonomous();
   }
   return false;
 }
 
-bool RobotState::IsTest() {
+bool frc::RobotState::IsTest() {
   if (impl != nullptr) {
     return impl->IsTest();
   }

--- a/wpilibc/shared/src/SmartDashboard/SendableChooserBase.cpp
+++ b/wpilibc/shared/src/SmartDashboard/SendableChooserBase.cpp
@@ -7,16 +7,14 @@
 
 #include "SmartDashboard/SendableChooserBase.h"
 
-using namespace frc;
+const char* frc::SendableChooserBase::kDefault = "default";
+const char* frc::SendableChooserBase::kOptions = "options";
+const char* frc::SendableChooserBase::kSelected = "selected";
 
-const char* SendableChooserBase::kDefault = "default";
-const char* SendableChooserBase::kOptions = "options";
-const char* SendableChooserBase::kSelected = "selected";
-
-std::shared_ptr<ITable> SendableChooserBase::GetTable() const {
+std::shared_ptr<ITable> frc::SendableChooserBase::GetTable() const {
   return m_table;
 }
 
-std::string SendableChooserBase::GetSmartDashboardType() const {
+std::string frc::SendableChooserBase::GetSmartDashboardType() const {
   return "String Chooser";
 }

--- a/wpilibc/shared/src/SmartDashboard/SmartDashboard.cpp
+++ b/wpilibc/shared/src/SmartDashboard/SmartDashboard.cpp
@@ -12,12 +12,11 @@
 #include "WPIErrors.h"
 #include "networktables/NetworkTable.h"
 
-using namespace frc;
+std::shared_ptr<ITable> frc::SmartDashboard::m_table;
+std::map<std::shared_ptr<ITable>, frc::Sendable*>
+    frc::SmartDashboard::m_tablesToData;
 
-std::shared_ptr<ITable> SmartDashboard::m_table;
-std::map<std::shared_ptr<ITable>, Sendable*> SmartDashboard::m_tablesToData;
-
-void SmartDashboard::init() {
+void frc::SmartDashboard::init() {
   m_table = NetworkTable::GetTable("SmartDashboard");
 
   HLUsageReporting::ReportSmartDashboard();
@@ -29,7 +28,7 @@ void SmartDashboard::init() {
    * @param key the key to search for
    * @return true if the table as a value assigned to the given key
    */
-bool SmartDashboard::ContainsKey(llvm::StringRef key) {
+bool frc::SmartDashboard::ContainsKey(llvm::StringRef key) {
   return m_table->ContainsKey(key);
 }
 
@@ -37,7 +36,7 @@ bool SmartDashboard::ContainsKey(llvm::StringRef key) {
  * @param types bitmask of types; 0 is treated as a "don't care".
  * @return keys currently in the table
  */
-std::vector<std::string> SmartDashboard::GetKeys(int types) {
+std::vector<std::string> frc::SmartDashboard::GetKeys(int types) {
   return m_table->GetKeys(types);
 }
 
@@ -46,7 +45,7 @@ std::vector<std::string> SmartDashboard::GetKeys(int types) {
  *
  * @param key the key to make persistent
  */
-void SmartDashboard::SetPersistent(llvm::StringRef key) {
+void frc::SmartDashboard::SetPersistent(llvm::StringRef key) {
   m_table->SetPersistent(key);
 }
 
@@ -56,7 +55,7 @@ void SmartDashboard::SetPersistent(llvm::StringRef key) {
  *
  * @param key the key name
  */
-void SmartDashboard::ClearPersistent(llvm::StringRef key) {
+void frc::SmartDashboard::ClearPersistent(llvm::StringRef key) {
   m_table->ClearPersistent(key);
 }
 
@@ -66,7 +65,7 @@ void SmartDashboard::ClearPersistent(llvm::StringRef key) {
  *
  * @param key the key name
  */
-bool SmartDashboard::IsPersistent(llvm::StringRef key) {
+bool frc::SmartDashboard::IsPersistent(llvm::StringRef key) {
   return m_table->IsPersistent(key);
 }
 
@@ -77,7 +76,7 @@ bool SmartDashboard::IsPersistent(llvm::StringRef key) {
  * @param key the key name
  * @param flags the flags to set (bitmask)
  */
-void SmartDashboard::SetFlags(llvm::StringRef key, unsigned int flags) {
+void frc::SmartDashboard::SetFlags(llvm::StringRef key, unsigned int flags) {
   m_table->SetFlags(key, flags);
 }
 
@@ -88,7 +87,7 @@ void SmartDashboard::SetFlags(llvm::StringRef key, unsigned int flags) {
  * @param key the key name
  * @param flags the flags to clear (bitmask)
  */
-void SmartDashboard::ClearFlags(llvm::StringRef key, unsigned int flags) {
+void frc::SmartDashboard::ClearFlags(llvm::StringRef key, unsigned int flags) {
   m_table->ClearFlags(key, flags);
 }
 
@@ -98,7 +97,7 @@ void SmartDashboard::ClearFlags(llvm::StringRef key, unsigned int flags) {
  * @param key the key name
  * @return the flags, or 0 if the key is not defined
  */
-unsigned int SmartDashboard::GetFlags(llvm::StringRef key) {
+unsigned int frc::SmartDashboard::GetFlags(llvm::StringRef key) {
   return m_table->GetFlags(key);
 }
 
@@ -107,7 +106,7 @@ unsigned int SmartDashboard::GetFlags(llvm::StringRef key) {
  *
  * @param key the key name
  */
-void SmartDashboard::Delete(llvm::StringRef key) { m_table->Delete(key); }
+void frc::SmartDashboard::Delete(llvm::StringRef key) { m_table->Delete(key); }
 
 /**
  * Maps the specified key to the specified value in this table.
@@ -118,7 +117,7 @@ void SmartDashboard::Delete(llvm::StringRef key) { m_table->Delete(key); }
  * @param keyName the key
  * @param value   the value
  */
-void SmartDashboard::PutData(llvm::StringRef key, Sendable* data) {
+void frc::SmartDashboard::PutData(llvm::StringRef key, Sendable* data) {
   if (data == nullptr) {
     wpi_setGlobalWPIErrorWithContext(NullParameter, "value");
     return;
@@ -138,7 +137,7 @@ void SmartDashboard::PutData(llvm::StringRef key, Sendable* data) {
  *
  * @param value the value
  */
-void SmartDashboard::PutData(NamedSendable* value) {
+void frc::SmartDashboard::PutData(NamedSendable* value) {
   if (value == nullptr) {
     wpi_setGlobalWPIErrorWithContext(NullParameter, "value");
     return;
@@ -152,7 +151,7 @@ void SmartDashboard::PutData(NamedSendable* value) {
  * @param keyName the key
  * @return the value
  */
-Sendable* SmartDashboard::GetData(llvm::StringRef key) {
+frc::Sendable* frc::SmartDashboard::GetData(llvm::StringRef key) {
   std::shared_ptr<ITable> subtable(m_table->GetSubTable(key));
   Sendable* data = m_tablesToData[subtable];
   if (data == nullptr) {
@@ -173,8 +172,8 @@ Sendable* SmartDashboard::GetData(llvm::StringRef key) {
  * @param value   the value
  * @return        False if the table key already exists with a different type
  */
-bool SmartDashboard::PutValue(llvm::StringRef keyName,
-                              std::shared_ptr<nt::Value> value) {
+bool frc::SmartDashboard::PutValue(llvm::StringRef keyName,
+                                   std::shared_ptr<nt::Value> value) {
   return m_table->PutValue(keyName, value);
 }
 
@@ -184,8 +183,8 @@ bool SmartDashboard::PutValue(llvm::StringRef keyName,
    * @param defaultValue the default value to set if key doesn't exist.
    * @returns False if the table key exists with a different type
    */
-bool SmartDashboard::SetDefaultValue(llvm::StringRef key,
-                                     std::shared_ptr<nt::Value> defaultValue) {
+bool frc::SmartDashboard::SetDefaultValue(
+    llvm::StringRef key, std::shared_ptr<nt::Value> defaultValue) {
   return m_table->SetDefaultValue(key, defaultValue);
 }
 
@@ -196,7 +195,8 @@ bool SmartDashboard::SetDefaultValue(llvm::StringRef key,
  * @param keyName the key
  * @param value   the object to retrieve the value into
  */
-std::shared_ptr<nt::Value> SmartDashboard::GetValue(llvm::StringRef keyName) {
+std::shared_ptr<nt::Value> frc::SmartDashboard::GetValue(
+    llvm::StringRef keyName) {
   return m_table->GetValue(keyName);
 }
 
@@ -210,7 +210,7 @@ std::shared_ptr<nt::Value> SmartDashboard::GetValue(llvm::StringRef keyName) {
  * @param value   the value
  * @return        False if the table key already exists with a different type
  */
-bool SmartDashboard::PutBoolean(llvm::StringRef keyName, bool value) {
+bool frc::SmartDashboard::PutBoolean(llvm::StringRef keyName, bool value) {
   return m_table->PutBoolean(keyName, value);
 }
 
@@ -220,7 +220,8 @@ bool SmartDashboard::PutBoolean(llvm::StringRef keyName, bool value) {
    * @param defaultValue the default value to set if key doesn't exist.
    * @returns False if the table key exists with a different type
    */
-bool SmartDashboard::SetDefaultBoolean(llvm::StringRef key, bool defaultValue) {
+bool frc::SmartDashboard::SetDefaultBoolean(llvm::StringRef key,
+                                            bool defaultValue) {
   return m_table->SetDefaultBoolean(key, defaultValue);
 }
 
@@ -232,7 +233,8 @@ bool SmartDashboard::SetDefaultBoolean(llvm::StringRef key, bool defaultValue) {
  * @param keyName the key
  * @return the value
  */
-bool SmartDashboard::GetBoolean(llvm::StringRef keyName, bool defaultValue) {
+bool frc::SmartDashboard::GetBoolean(llvm::StringRef keyName,
+                                     bool defaultValue) {
   return m_table->GetBoolean(keyName, defaultValue);
 }
 
@@ -246,7 +248,7 @@ bool SmartDashboard::GetBoolean(llvm::StringRef keyName, bool defaultValue) {
  * @param value   the value
  * @return        False if the table key already exists with a different type
  */
-bool SmartDashboard::PutNumber(llvm::StringRef keyName, double value) {
+bool frc::SmartDashboard::PutNumber(llvm::StringRef keyName, double value) {
   return m_table->PutNumber(keyName, value);
 }
 
@@ -256,8 +258,8 @@ bool SmartDashboard::PutNumber(llvm::StringRef keyName, double value) {
    * @param defaultValue the default value to set if key doesn't exist.
    * @returns False if the table key exists with a different type
    */
-bool SmartDashboard::SetDefaultNumber(llvm::StringRef key,
-                                      double defaultValue) {
+bool frc::SmartDashboard::SetDefaultNumber(llvm::StringRef key,
+                                           double defaultValue) {
   return m_table->SetDefaultNumber(key, defaultValue);
 }
 
@@ -269,7 +271,8 @@ bool SmartDashboard::SetDefaultNumber(llvm::StringRef key,
  * @param keyName the key
  * @return the value
  */
-double SmartDashboard::GetNumber(llvm::StringRef keyName, double defaultValue) {
+double frc::SmartDashboard::GetNumber(llvm::StringRef keyName,
+                                      double defaultValue) {
   return m_table->GetNumber(keyName, defaultValue);
 }
 
@@ -283,7 +286,8 @@ double SmartDashboard::GetNumber(llvm::StringRef keyName, double defaultValue) {
  * @param value   the value
  * @return        False if the table key already exists with a different type
  */
-bool SmartDashboard::PutString(llvm::StringRef keyName, llvm::StringRef value) {
+bool frc::SmartDashboard::PutString(llvm::StringRef keyName,
+                                    llvm::StringRef value) {
   return m_table->PutString(keyName, value);
 }
 
@@ -293,8 +297,8 @@ bool SmartDashboard::PutString(llvm::StringRef keyName, llvm::StringRef value) {
  * @param defaultValue the default value to set if key doesn't exist.
  * @returns False if the table key exists with a different type
  */
-bool SmartDashboard::SetDefaultString(llvm::StringRef key,
-                                      llvm::StringRef defaultValue) {
+bool frc::SmartDashboard::SetDefaultString(llvm::StringRef key,
+                                           llvm::StringRef defaultValue) {
   return m_table->SetDefaultString(key, defaultValue);
 }
 
@@ -306,8 +310,8 @@ bool SmartDashboard::SetDefaultString(llvm::StringRef key,
  * @param keyName the key
  * @return the value
  */
-std::string SmartDashboard::GetString(llvm::StringRef keyName,
-                                      llvm::StringRef defaultValue) {
+std::string frc::SmartDashboard::GetString(llvm::StringRef keyName,
+                                           llvm::StringRef defaultValue) {
   return m_table->GetString(keyName, defaultValue);
 }
 
@@ -321,8 +325,8 @@ std::string SmartDashboard::GetString(llvm::StringRef keyName,
    *       std::vector<bool> is special-cased in C++.  0 is false, any
    *       non-zero value is true.
    */
-bool SmartDashboard::PutBooleanArray(llvm::StringRef key,
-                                     llvm::ArrayRef<int> value) {
+bool frc::SmartDashboard::PutBooleanArray(llvm::StringRef key,
+                                          llvm::ArrayRef<int> value) {
   return m_table->PutBooleanArray(key, value);
 }
 
@@ -332,8 +336,8 @@ bool SmartDashboard::PutBooleanArray(llvm::StringRef key,
  * @param defaultValue the default value to set if key doesn't exist.
  * @returns False if the table key exists with a different type
  */
-bool SmartDashboard::SetDefaultBooleanArray(llvm::StringRef key,
-                                            llvm::ArrayRef<int> defaultValue) {
+bool frc::SmartDashboard::SetDefaultBooleanArray(
+    llvm::StringRef key, llvm::ArrayRef<int> defaultValue) {
   return m_table->SetDefaultBooleanArray(key, defaultValue);
 }
 
@@ -352,7 +356,7 @@ bool SmartDashboard::SetDefaultBooleanArray(llvm::StringRef key,
  *       because std::vector<bool> is special-cased in C++.  0 is false, any
  *       non-zero value is true.
  */
-std::vector<int> SmartDashboard::GetBooleanArray(
+std::vector<int> frc::SmartDashboard::GetBooleanArray(
     llvm::StringRef key, llvm::ArrayRef<int> defaultValue) {
   return m_table->GetBooleanArray(key, defaultValue);
 }
@@ -363,8 +367,8 @@ std::vector<int> SmartDashboard::GetBooleanArray(
  * @param value the value that will be assigned
  * @return False if the table key already exists with a different type
  */
-bool SmartDashboard::PutNumberArray(llvm::StringRef key,
-                                    llvm::ArrayRef<double> value) {
+bool frc::SmartDashboard::PutNumberArray(llvm::StringRef key,
+                                         llvm::ArrayRef<double> value) {
   return m_table->PutNumberArray(key, value);
 }
 
@@ -374,7 +378,7 @@ bool SmartDashboard::PutNumberArray(llvm::StringRef key,
  * @param defaultValue the default value to set if key doesn't exist.
  * @returns False if the table key exists with a different type
  */
-bool SmartDashboard::SetDefaultNumberArray(
+bool frc::SmartDashboard::SetDefaultNumberArray(
     llvm::StringRef key, llvm::ArrayRef<double> defaultValue) {
   return m_table->SetDefaultNumberArray(key, defaultValue);
 }
@@ -390,7 +394,7 @@ bool SmartDashboard::SetDefaultNumberArray(
  * @note This makes a copy of the array.  If the overhead of this is a
  *       concern, use GetValue() instead.
  */
-std::vector<double> SmartDashboard::GetNumberArray(
+std::vector<double> frc::SmartDashboard::GetNumberArray(
     llvm::StringRef key, llvm::ArrayRef<double> defaultValue) {
   return m_table->GetNumberArray(key, defaultValue);
 }
@@ -401,8 +405,8 @@ std::vector<double> SmartDashboard::GetNumberArray(
  * @param value the value that will be assigned
  * @return False if the table key already exists with a different type
  */
-bool SmartDashboard::PutStringArray(llvm::StringRef key,
-                                    llvm::ArrayRef<std::string> value) {
+bool frc::SmartDashboard::PutStringArray(llvm::StringRef key,
+                                         llvm::ArrayRef<std::string> value) {
   return m_table->PutStringArray(key, value);
 }
 
@@ -412,7 +416,7 @@ bool SmartDashboard::PutStringArray(llvm::StringRef key,
  * @param defaultValue the default value to set if key doesn't exist.
  * @returns False if the table key exists with a different type
  */
-bool SmartDashboard::SetDefaultStringArray(
+bool frc::SmartDashboard::SetDefaultStringArray(
     llvm::StringRef key, llvm::ArrayRef<std::string> defaultValue) {
   return m_table->SetDefaultStringArray(key, defaultValue);
 }
@@ -428,7 +432,7 @@ bool SmartDashboard::SetDefaultStringArray(
  * @note This makes a copy of the array.  If the overhead of this is a
  *       concern, use GetValue() instead.
  */
-std::vector<std::string> SmartDashboard::GetStringArray(
+std::vector<std::string> frc::SmartDashboard::GetStringArray(
     llvm::StringRef key, llvm::ArrayRef<std::string> defaultValue) {
   return m_table->GetStringArray(key, defaultValue);
 }
@@ -439,7 +443,7 @@ std::vector<std::string> SmartDashboard::GetStringArray(
  * @param value the value that will be assigned
  * @return False if the table key already exists with a different type
  */
-bool SmartDashboard::PutRaw(llvm::StringRef key, llvm::StringRef value) {
+bool frc::SmartDashboard::PutRaw(llvm::StringRef key, llvm::StringRef value) {
   return m_table->PutRaw(key, value);
 }
 
@@ -449,8 +453,8 @@ bool SmartDashboard::PutRaw(llvm::StringRef key, llvm::StringRef value) {
  * @param defaultValue the default value to set if key doesn't exist.
  * @returns False if the table key exists with a different type
  */
-bool SmartDashboard::SetDefaultRaw(llvm::StringRef key,
-                                   llvm::StringRef defaultValue) {
+bool frc::SmartDashboard::SetDefaultRaw(llvm::StringRef key,
+                                        llvm::StringRef defaultValue) {
   return m_table->SetDefaultRaw(key, defaultValue);
 }
 
@@ -465,7 +469,7 @@ bool SmartDashboard::SetDefaultRaw(llvm::StringRef key,
  * @note This makes a copy of the raw contents.  If the overhead of this is a
  *       concern, use GetValue() instead.
  */
-std::string SmartDashboard::GetRaw(llvm::StringRef key,
-                                   llvm::StringRef defaultValue) {
+std::string frc::SmartDashboard::GetRaw(llvm::StringRef key,
+                                        llvm::StringRef defaultValue) {
   return m_table->GetRaw(key, defaultValue);
 }

--- a/wpilibc/shared/src/interfaces/Potentiometer.cpp
+++ b/wpilibc/shared/src/interfaces/Potentiometer.cpp
@@ -9,9 +9,7 @@
 
 #include <Utility.h>
 
-using namespace frc;
-
-void Potentiometer::SetPIDSourceType(PIDSourceType pidSource) {
+void frc::Potentiometer::SetPIDSourceType(PIDSourceType pidSource) {
   if (wpi_assert(pidSource == PIDSourceType::kDisplacement)) {
     m_pidSource = pidSource;
   }

--- a/wpilibc/sim/src/AnalogGyro.cpp
+++ b/wpilibc/sim/src/AnalogGyro.cpp
@@ -13,13 +13,11 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
-const int AnalogGyro::kOversampleBits = 10;
-const int AnalogGyro::kAverageBits = 0;
-const double AnalogGyro::kSamplesPerSecond = 50.0;
-const double AnalogGyro::kCalibrationSampleTime = 5.0;
-const double AnalogGyro::kDefaultVoltsPerDegreePerSecond = 0.007;
+const int frc::AnalogGyro::kOversampleBits = 10;
+const int frc::AnalogGyro::kAverageBits = 0;
+const double frc::AnalogGyro::kSamplesPerSecond = 50.0;
+const double frc::AnalogGyro::kCalibrationSampleTime = 5.0;
+const double frc::AnalogGyro::kDefaultVoltsPerDegreePerSecond = 0.007;
 
 /**
  * Initialize the gyro.
@@ -31,7 +29,7 @@ const double AnalogGyro::kDefaultVoltsPerDegreePerSecond = 0.007;
  * this is typically done when the robot is first turned on while it's sitting
  * at rest before the competition starts.
  */
-void AnalogGyro::InitAnalogGyro(int channel) {
+void frc::AnalogGyro::InitAnalogGyro(int channel) {
   SetPIDSourceType(PIDSourceType::kDisplacement);
 
   llvm::SmallString<128> buf;
@@ -47,7 +45,7 @@ void AnalogGyro::InitAnalogGyro(int channel) {
  *
  * @param channel The analog channel the gyro is connected to.
  */
-AnalogGyro::AnalogGyro(int channel) { InitAnalogGyro(channel); }
+frc::AnalogGyro::AnalogGyro(int channel) { InitAnalogGyro(channel); }
 
 /**
  * Reset the gyro.
@@ -56,9 +54,9 @@ AnalogGyro::AnalogGyro(int channel) { InitAnalogGyro(channel); }
  * significant drift in the gyro and it needs to be recalibrated after it has
  * been running.
  */
-void AnalogGyro::Reset() { impl->Reset(); }
+void frc::AnalogGyro::Reset() { impl->Reset(); }
 
-void AnalogGyro::Calibrate() { Reset(); }
+void frc::AnalogGyro::Calibrate() { Reset(); }
 
 /**
  * Return the actual angle in degrees that the robot is currently facing.
@@ -72,7 +70,7 @@ void AnalogGyro::Calibrate() { Reset(); }
  * @return the current heading of the robot in degrees. This heading is based on
  *         integration of the returned rate from the gyro.
  */
-double AnalogGyro::GetAngle() const { return impl->GetAngle(); }
+double frc::AnalogGyro::GetAngle() const { return impl->GetAngle(); }
 
 /**
  * Return the rate of rotation of the gyro
@@ -81,4 +79,4 @@ double AnalogGyro::GetAngle() const { return impl->GetAngle(); }
  *
  * @return the current rate in degrees per second
  */
-double AnalogGyro::GetRate() const { return impl->GetVelocity(); }
+double frc::AnalogGyro::GetRate() const { return impl->GetVelocity(); }

--- a/wpilibc/sim/src/AnalogInput.cpp
+++ b/wpilibc/sim/src/AnalogInput.cpp
@@ -12,14 +12,12 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
 /**
  * Construct an analog input.
  *
  * @param channel The channel number to represent.
  */
-AnalogInput::AnalogInput(int channel) : m_channel(channel) {
+frc::AnalogInput::AnalogInput(int channel) : m_channel(channel) {
   llvm::SmallString<32> buf;
   llvm::raw_svector_ostream oss(buf);
   oss << "analog/" << channel;
@@ -36,7 +34,7 @@ AnalogInput::AnalogInput(int channel) : m_channel(channel) {
  *
  * @return A scaled sample straight from this channel.
  */
-double AnalogInput::GetVoltage() const { return m_impl->Get(); }
+double frc::AnalogInput::GetVoltage() const { return m_impl->Get(); }
 
 /**
  * Get a scaled sample from the output of the oversample and average engine for
@@ -50,39 +48,39 @@ double AnalogInput::GetVoltage() const { return m_impl->Get(); }
  * @return A scaled sample from the output of the oversample and average engine
  *         for this channel.
  */
-double AnalogInput::GetAverageVoltage() const { return m_impl->Get(); }
+double frc::AnalogInput::GetAverageVoltage() const { return m_impl->Get(); }
 
 /**
  * Get the channel number.
  *
  * @return The channel number.
  */
-int AnalogInput::GetChannel() const { return m_channel; }
+int frc::AnalogInput::GetChannel() const { return m_channel; }
 
 /**
  * Get the Average value for the PID Source base object.
  *
  * @return The average voltage.
  */
-double AnalogInput::PIDGet() { return GetAverageVoltage(); }
+double frc::AnalogInput::PIDGet() { return GetAverageVoltage(); }
 
-void AnalogInput::UpdateTable() {
+void frc::AnalogInput::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Value", GetAverageVoltage());
   }
 }
 
-void AnalogInput::StartLiveWindowMode() {}
+void frc::AnalogInput::StartLiveWindowMode() {}
 
-void AnalogInput::StopLiveWindowMode() {}
+void frc::AnalogInput::StopLiveWindowMode() {}
 
-std::string AnalogInput::GetSmartDashboardType() const {
+std::string frc::AnalogInput::GetSmartDashboardType() const {
   return "Analog Input";
 }
 
-void AnalogInput::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::AnalogInput::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> AnalogInput::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::AnalogInput::GetTable() const { return m_table; }

--- a/wpilibc/sim/src/AnalogPotentiometer.cpp
+++ b/wpilibc/sim/src/AnalogPotentiometer.cpp
@@ -7,37 +7,35 @@
 
 #include "AnalogPotentiometer.h"
 
-using namespace frc;
-
 /**
  * Common initialization code called by all constructors.
  */
-void AnalogPotentiometer::initPot(AnalogInput* input, double scale,
-                                  double offset) {
+void frc::AnalogPotentiometer::initPot(AnalogInput* input, double scale,
+                                       double offset) {
   m_scale = scale;
   m_offset = offset;
   m_analog_input = input;
 }
 
-AnalogPotentiometer::AnalogPotentiometer(int channel, double scale,
-                                         double offset) {
+frc::AnalogPotentiometer::AnalogPotentiometer(int channel, double scale,
+                                              double offset) {
   m_init_analog_input = true;
   initPot(new AnalogInput(channel), scale, offset);
 }
 
-AnalogPotentiometer::AnalogPotentiometer(AnalogInput* input, double scale,
-                                         double offset) {
+frc::AnalogPotentiometer::AnalogPotentiometer(AnalogInput* input, double scale,
+                                              double offset) {
   m_init_analog_input = false;
   initPot(input, scale, offset);
 }
 
-AnalogPotentiometer::AnalogPotentiometer(AnalogInput& input, double scale,
-                                         double offset) {
+frc::AnalogPotentiometer::AnalogPotentiometer(AnalogInput& input, double scale,
+                                              double offset) {
   m_init_analog_input = false;
   initPot(&input, scale, offset);
 }
 
-AnalogPotentiometer::~AnalogPotentiometer() {
+frc::AnalogPotentiometer::~AnalogPotentiometer() {
   if (m_init_analog_input) {
     delete m_analog_input;
     m_init_analog_input = false;
@@ -49,7 +47,7 @@ AnalogPotentiometer::~AnalogPotentiometer() {
  *
  * @return The current position of the potentiometer.
  */
-double AnalogPotentiometer::Get() const {
+double frc::AnalogPotentiometer::Get() const {
   return m_analog_input->GetVoltage() * m_scale + m_offset;
 }
 
@@ -58,29 +56,29 @@ double AnalogPotentiometer::Get() const {
  *
  * @return The current reading.
  */
-double AnalogPotentiometer::PIDGet() { return Get(); }
+double frc::AnalogPotentiometer::PIDGet() { return Get(); }
 
 /**
  * @return the Smart Dashboard Type
  */
-std::string AnalogPotentiometer::GetSmartDashboardType() const {
+std::string frc::AnalogPotentiometer::GetSmartDashboardType() const {
   return "Analog Input";
 }
 
 /**
  * Live Window code, only does anything if live window is activated.
  */
-void AnalogPotentiometer::InitTable(std::shared_ptr<ITable> subtable) {
+void frc::AnalogPotentiometer::InitTable(std::shared_ptr<ITable> subtable) {
   m_table = subtable;
   UpdateTable();
 }
 
-void AnalogPotentiometer::UpdateTable() {
+void frc::AnalogPotentiometer::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Value", Get());
   }
 }
 
-std::shared_ptr<ITable> AnalogPotentiometer::GetTable() const {
+std::shared_ptr<ITable> frc::AnalogPotentiometer::GetTable() const {
   return m_table;
 }

--- a/wpilibc/sim/src/DigitalInput.cpp
+++ b/wpilibc/sim/src/DigitalInput.cpp
@@ -11,15 +11,13 @@
 
 #include "WPIErrors.h"
 
-using namespace frc;
-
 /**
  * Create an instance of a Digital Input class.
  * Creates a digital input given a channel and uses the default module.
  *
  * @param channel The digital channel (1..14).
  */
-DigitalInput::DigitalInput(int channel) : m_channel(channel) {
+frc::DigitalInput::DigitalInput(int channel) : m_channel(channel) {
   std::ostringstream oss;
   oss << "dio/" << channel;
   m_impl = new SimDigitalInput(oss.str());
@@ -29,30 +27,30 @@ DigitalInput::DigitalInput(int channel) : m_channel(channel) {
  * Get the value from a digital input channel.
  * Retrieve the value of a single digital input channel from the FPGA.
  */
-int DigitalInput::Get() const { return m_impl->Get(); }
+int frc::DigitalInput::Get() const { return m_impl->Get(); }
 
 /**
  * @return The GPIO channel number that this object represents.
  */
-int DigitalInput::GetChannel() const { return m_channel; }
+int frc::DigitalInput::GetChannel() const { return m_channel; }
 
-void DigitalInput::UpdateTable() {
+void frc::DigitalInput::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutBoolean("Value", Get());
   }
 }
 
-void DigitalInput::StartLiveWindowMode() {}
+void frc::DigitalInput::StartLiveWindowMode() {}
 
-void DigitalInput::StopLiveWindowMode() {}
+void frc::DigitalInput::StopLiveWindowMode() {}
 
-std::string DigitalInput::GetSmartDashboardType() const {
+std::string frc::DigitalInput::GetSmartDashboardType() const {
   return "DigitalInput";
 }
 
-void DigitalInput::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::DigitalInput::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> DigitalInput::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::DigitalInput::GetTable() const { return m_table; }

--- a/wpilibc/sim/src/DoubleSolenoid.cpp
+++ b/wpilibc/sim/src/DoubleSolenoid.cpp
@@ -12,15 +12,13 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
 /**
  * Constructor.
  *
  * @param forwardChannel The forward channel on the module to control.
  * @param reverseChannel The reverse channel on the module to control.
  */
-DoubleSolenoid::DoubleSolenoid(int forwardChannel, int reverseChannel)
+frc::DoubleSolenoid::DoubleSolenoid(int forwardChannel, int reverseChannel)
     : DoubleSolenoid(1, forwardChannel, reverseChannel) {}
 
 /**
@@ -30,8 +28,8 @@ DoubleSolenoid::DoubleSolenoid(int forwardChannel, int reverseChannel)
  * @param forwardChannel The forward channel on the module to control.
  * @param reverseChannel The reverse channel on the module to control.
  */
-DoubleSolenoid::DoubleSolenoid(int moduleNumber, int forwardChannel,
-                               int reverseChannel) {
+frc::DoubleSolenoid::DoubleSolenoid(int moduleNumber, int forwardChannel,
+                                    int reverseChannel) {
   m_reversed = false;
   if (reverseChannel < forwardChannel) {  // Swap ports to get the right address
     int channel = reverseChannel;
@@ -49,7 +47,7 @@ DoubleSolenoid::DoubleSolenoid(int moduleNumber, int forwardChannel,
                                          forwardChannel, this);
 }
 
-DoubleSolenoid::~DoubleSolenoid() {
+frc::DoubleSolenoid::~DoubleSolenoid() {
   if (m_table != nullptr) m_table->RemoveTableListener(this);
 }
 
@@ -58,7 +56,7 @@ DoubleSolenoid::~DoubleSolenoid() {
  *
  * @param value Move the solenoid to forward, reverse, or don't move it.
  */
-void DoubleSolenoid::Set(Value value) {
+void frc::DoubleSolenoid::Set(Value value) {
   m_value = value;
   switch (value) {
     case kOff:
@@ -78,11 +76,11 @@ void DoubleSolenoid::Set(Value value) {
  *
  * @return The current value of the solenoid.
  */
-DoubleSolenoid::Value DoubleSolenoid::Get() const { return m_value; }
+frc::DoubleSolenoid::Value frc::DoubleSolenoid::Get() const { return m_value; }
 
-void DoubleSolenoid::ValueChanged(ITable* source, llvm::StringRef key,
-                                  std::shared_ptr<nt::Value> value,
-                                  bool isNew) {
+void frc::DoubleSolenoid::ValueChanged(ITable* source, llvm::StringRef key,
+                                       std::shared_ptr<nt::Value> value,
+                                       bool isNew) {
   if (!value->IsString()) return;
   Value lvalue = kOff;
   if (value->GetString() == "Forward")
@@ -92,7 +90,7 @@ void DoubleSolenoid::ValueChanged(ITable* source, llvm::StringRef key,
   Set(lvalue);
 }
 
-void DoubleSolenoid::UpdateTable() {
+void frc::DoubleSolenoid::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutString(
         "Value", (Get() == kForward ? "Forward"
@@ -100,27 +98,29 @@ void DoubleSolenoid::UpdateTable() {
   }
 }
 
-void DoubleSolenoid::StartLiveWindowMode() {
+void frc::DoubleSolenoid::StartLiveWindowMode() {
   Set(kOff);
   if (m_table != nullptr) {
     m_table->AddTableListener("Value", this, true);
   }
 }
 
-void DoubleSolenoid::StopLiveWindowMode() {
+void frc::DoubleSolenoid::StopLiveWindowMode() {
   Set(kOff);
   if (m_table != nullptr) {
     m_table->RemoveTableListener(this);
   }
 }
 
-std::string DoubleSolenoid::GetSmartDashboardType() const {
+std::string frc::DoubleSolenoid::GetSmartDashboardType() const {
   return "Double Solenoid";
 }
 
-void DoubleSolenoid::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::DoubleSolenoid::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> DoubleSolenoid::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::DoubleSolenoid::GetTable() const {
+  return m_table;
+}

--- a/wpilibc/sim/src/DriverStation.cpp
+++ b/wpilibc/sim/src/DriverStation.cpp
@@ -16,48 +16,46 @@
 #include "llvm/raw_ostream.h"
 #include "simulation/MainNode.h"
 
-using namespace frc;
-
-const int DriverStation::kBatteryChannel;
-const int DriverStation::kJoystickPorts;
-const int DriverStation::kJoystickAxes;
-const double DriverStation::kUpdatePeriod = 0.02;
-int DriverStation::m_updateNumber = 0;
+const int frc::DriverStation::kBatteryChannel;
+const int frc::DriverStation::kJoystickPorts;
+const int frc::DriverStation::kJoystickAxes;
+const double frc::DriverStation::kUpdatePeriod = 0.02;
+int frc::DriverStation::m_updateNumber = 0;
 
 /**
  * DriverStation contructor.
  *
  * This is only called once the first time GetInstance() is called
  */
-DriverStation::DriverStation() {
+frc::DriverStation::DriverStation() {
   state = gazebo::msgs::DriverStationPtr(new gazebo::msgs::DriverStation());
-  stateSub =
-      MainNode::Subscribe("~/ds/state", &DriverStation::stateCallback, this);
+  stateSub = MainNode::Subscribe("~/ds/state",
+                                 &frc::DriverStation::stateCallback, this);
   // TODO: for loop + boost bind
   joysticks[0] = gazebo::msgs::FRCJoystickPtr(new gazebo::msgs::FRCJoystick());
   joysticksSub[0] = MainNode::Subscribe(
-      "~/ds/joysticks/0", &DriverStation::joystickCallback0, this);
+      "~/ds/joysticks/0", &frc::DriverStation::joystickCallback0, this);
   joysticks[1] = gazebo::msgs::FRCJoystickPtr(new gazebo::msgs::FRCJoystick());
   joysticksSub[1] = MainNode::Subscribe(
-      "~/ds/joysticks/1", &DriverStation::joystickCallback1, this);
+      "~/ds/joysticks/1", &frc::DriverStation::joystickCallback1, this);
   joysticks[2] = gazebo::msgs::FRCJoystickPtr(new gazebo::msgs::FRCJoystick());
   joysticksSub[2] = MainNode::Subscribe(
-      "~/ds/joysticks/2", &DriverStation::joystickCallback2, this);
+      "~/ds/joysticks/2", &frc::DriverStation::joystickCallback2, this);
   joysticks[3] = gazebo::msgs::FRCJoystickPtr(new gazebo::msgs::FRCJoystick());
   joysticksSub[3] = MainNode::Subscribe(
-      "~/ds/joysticks/5", &DriverStation::joystickCallback3, this);
+      "~/ds/joysticks/5", &frc::DriverStation::joystickCallback3, this);
   joysticks[4] = gazebo::msgs::FRCJoystickPtr(new gazebo::msgs::FRCJoystick());
   joysticksSub[4] = MainNode::Subscribe(
-      "~/ds/joysticks/4", &DriverStation::joystickCallback4, this);
+      "~/ds/joysticks/4", &frc::DriverStation::joystickCallback4, this);
   joysticks[5] = gazebo::msgs::FRCJoystickPtr(new gazebo::msgs::FRCJoystick());
   joysticksSub[5] = MainNode::Subscribe(
-      "~/ds/joysticks/5", &DriverStation::joystickCallback5, this);
+      "~/ds/joysticks/5", &frc::DriverStation::joystickCallback5, this);
 }
 
 /**
  * Return a pointer to the singleton DriverStation.
  */
-DriverStation& DriverStation::GetInstance() {
+frc::DriverStation& frc::DriverStation::GetInstance() {
   static DriverStation instance;
   return instance;
 }
@@ -67,7 +65,7 @@ DriverStation& DriverStation::GetInstance() {
  *
  * @return The battery voltage.
  */
-double DriverStation::GetBatteryVoltage() const {
+double frc::DriverStation::GetBatteryVoltage() const {
   return 12.0;  // 12 volts all the time!
 }
 
@@ -79,7 +77,7 @@ double DriverStation::GetBatteryVoltage() const {
  * @param axis  The analog axis value to read from the joystick.
  * @return The value of the axis on the joystick.
  */
-double DriverStation::GetStickAxis(int stick, int axis) {
+double frc::DriverStation::GetStickAxis(int stick, int axis) {
   if (axis < 0 || axis > (kJoystickAxes - 1)) {
     wpi_setWPIError(BadJoystickAxis);
     return 0.0;
@@ -106,7 +104,7 @@ double DriverStation::GetStickAxis(int stick, int axis) {
  * @param button The button number to check.
  * @return If the button is pressed.
  */
-bool DriverStation::GetStickButton(int stick, int button) {
+bool frc::DriverStation::GetStickButton(int stick, int button) {
   if (stick < 0 || stick >= 6) {
     wpi_setWPIErrorWithContext(ParameterOutOfRange,
                                "stick must be between 0 and 5");
@@ -129,7 +127,7 @@ bool DriverStation::GetStickButton(int stick, int button) {
  * @param stick The joystick to read.
  * @return The state of the buttons on the joystick.
  */
-int16_t DriverStation::GetStickButtons(int stick) {
+int16_t frc::DriverStation::GetStickButtons(int stick) {
   if (stick < 0 || stick >= 6) {
     wpi_setWPIErrorWithContext(ParameterOutOfRange,
                                "stick must be between 0 and 5");
@@ -163,7 +161,7 @@ int16_t DriverStation::GetStickButtons(int stick) {
  *                Valid range is 1 - 4.
  * @return The analog voltage on the input.
  */
-double DriverStation::GetAnalogIn(int channel) {
+double frc::DriverStation::GetAnalogIn(int channel) {
   wpi_setWPIErrorWithContext(UnsupportedInSimulation, "GetAnalogIn");
   return 0.0;
 }
@@ -176,7 +174,7 @@ double DriverStation::GetAnalogIn(int channel) {
  *
  * @param channel The digital input to get. Valid range is 1 - 8.
  */
-bool DriverStation::GetDigitalIn(int channel) {
+bool frc::DriverStation::GetDigitalIn(int channel) {
   wpi_setWPIErrorWithContext(UnsupportedInSimulation, "GetDigitalIn");
   return false;
 }
@@ -190,7 +188,7 @@ bool DriverStation::GetDigitalIn(int channel) {
  * @param channel The digital output to set. Valid range is 1 - 8.
  * @param value   The state to set the digital output.
  */
-void DriverStation::SetDigitalOut(int channel, bool value) {
+void frc::DriverStation::SetDigitalOut(int channel, bool value) {
   wpi_setWPIErrorWithContext(UnsupportedInSimulation, "SetDigitalOut");
 }
 
@@ -200,30 +198,30 @@ void DriverStation::SetDigitalOut(int channel, bool value) {
  * @param channel The digital ouput to monitor. Valid range is 1 through 8.
  * @return A digital value being output on the Drivers Station.
  */
-bool DriverStation::GetDigitalOut(int channel) {
+bool frc::DriverStation::GetDigitalOut(int channel) {
   wpi_setWPIErrorWithContext(UnsupportedInSimulation, "GetDigitalOut");
   return false;
 }
 
-bool DriverStation::IsEnabled() const {
+bool frc::DriverStation::IsEnabled() const {
   std::unique_lock<std::recursive_mutex> lock(m_stateMutex);
   return state != nullptr ? state->enabled() : false;
 }
 
-bool DriverStation::IsDisabled() const { return !IsEnabled(); }
+bool frc::DriverStation::IsDisabled() const { return !IsEnabled(); }
 
-bool DriverStation::IsAutonomous() const {
+bool frc::DriverStation::IsAutonomous() const {
   std::unique_lock<std::recursive_mutex> lock(m_stateMutex);
   return state != nullptr
              ? state->state() == gazebo::msgs::DriverStation_State_AUTO
              : false;
 }
 
-bool DriverStation::IsOperatorControl() const {
+bool frc::DriverStation::IsOperatorControl() const {
   return !(IsAutonomous() || IsTest());
 }
 
-bool DriverStation::IsTest() const {
+bool frc::DriverStation::IsTest() const {
   std::unique_lock<std::recursive_mutex> lock(m_stateMutex);
   return state != nullptr
              ? state->state() == gazebo::msgs::DriverStation_State_TEST
@@ -235,7 +233,7 @@ bool DriverStation::IsTest() const {
  * @return True if the robot is competing on a field being controlled by a Field
  *         Management System
  */
-bool DriverStation::IsFMSAttached() const {
+bool frc::DriverStation::IsFMSAttached() const {
   return false;  // No FMS in simulation
 }
 
@@ -244,7 +242,7 @@ bool DriverStation::IsFMSAttached() const {
  * This could return kRed or kBlue.
  * @return The Alliance enum
  */
-DriverStation::Alliance DriverStation::GetAlliance() const {
+frc::DriverStation::Alliance frc::DriverStation::GetAlliance() const {
   // if (m_controlData->dsID_Alliance == 'R') return kRed;
   // if (m_controlData->dsID_Alliance == 'B') return kBlue;
   // wpi_assert(false);
@@ -256,7 +254,7 @@ DriverStation::Alliance DriverStation::GetAlliance() const {
  * This could return 1, 2, or 3.
  * @return The location of the driver station
  */
-int DriverStation::GetLocation() const {
+int frc::DriverStation::GetLocation() const {
   return -1;  // TODO: Support locations
 }
 
@@ -268,7 +266,7 @@ int DriverStation::GetLocation() const {
  * This is a good way to delay processing until there is new driver station data
  * to act on.
  */
-void DriverStation::WaitForData() { WaitForData(0); }
+void frc::DriverStation::WaitForData() { WaitForData(0); }
 
 /**
  * Wait until a new packet comes from the driver station, or wait for a timeout.
@@ -286,7 +284,7 @@ void DriverStation::WaitForData() { WaitForData(0); }
  *
  * @return true if new data, otherwise false
  */
-bool DriverStation::WaitForData(double timeout) {
+bool frc::DriverStation::WaitForData(double timeout) {
 #if defined(_MSC_VER) && _MSC_VER < 1900
   auto timeoutTime = std::chrono::steady_clock::now() +
                      std::chrono::duration<int64_t, std::nano>(
@@ -322,7 +320,7 @@ bool DriverStation::WaitForData(double timeout) {
  * referees)
  * @return Match time in seconds since the beginning of autonomous
  */
-double DriverStation::GetMatchTime() const {
+double frc::DriverStation::GetMatchTime() const {
   if (m_approxMatchTimeOffset < 0.0) return 0.0;
   return Timer::GetFPGATimestamp() - m_approxMatchTimeOffset;
 }
@@ -331,7 +329,7 @@ double DriverStation::GetMatchTime() const {
  * Report an error to the DriverStation messages window.
  * The error is also printed to the program console.
  */
-void DriverStation::ReportError(llvm::StringRef error) {
+void frc::DriverStation::ReportError(llvm::StringRef error) {
   llvm::outs() << error << "\n";
 }
 
@@ -339,7 +337,7 @@ void DriverStation::ReportError(llvm::StringRef error) {
  * Report a warning to the DriverStation messages window.
  * The warning is also printed to the program console.
  */
-void DriverStation::ReportWarning(llvm::StringRef error) {
+void frc::DriverStation::ReportWarning(llvm::StringRef error) {
   llvm::outs() << error << "\n";
 }
 
@@ -347,9 +345,10 @@ void DriverStation::ReportWarning(llvm::StringRef error) {
  * Report an error to the DriverStation messages window.
  * The error is also printed to the program console.
  */
-void DriverStation::ReportError(bool is_error, int code, llvm::StringRef error,
-                                llvm::StringRef location,
-                                llvm::StringRef stack) {
+void frc::DriverStation::ReportError(bool is_error, int code,
+                                     llvm::StringRef error,
+                                     llvm::StringRef location,
+                                     llvm::StringRef stack) {
   if (!location.empty())
     llvm::outs() << (is_error ? "Error" : "Warning") << " at " << location
                  << ": ";
@@ -361,9 +360,9 @@ void DriverStation::ReportError(bool is_error, int code, llvm::StringRef error,
  * Return the team number that the Driver Station is configured for.
  * @return The team number
  */
-uint16_t DriverStation::GetTeamNumber() const { return 348; }
+uint16_t frc::DriverStation::GetTeamNumber() const { return 348; }
 
-void DriverStation::stateCallback(
+void frc::DriverStation::stateCallback(
     const gazebo::msgs::ConstDriverStationPtr& msg) {
   {
     std::unique_lock<std::recursive_mutex> lock(m_stateMutex);
@@ -376,38 +375,38 @@ void DriverStation::stateCallback(
   m_waitForDataCond.notify_all();
 }
 
-void DriverStation::joystickCallback(
+void frc::DriverStation::joystickCallback(
     const gazebo::msgs::ConstFRCJoystickPtr& msg, int i) {
   std::unique_lock<std::recursive_mutex> lock(m_joystickMutex);
   *(joysticks[i]) = *msg;
 }
 
-void DriverStation::joystickCallback0(
+void frc::DriverStation::joystickCallback0(
     const gazebo::msgs::ConstFRCJoystickPtr& msg) {
   joystickCallback(msg, 0);
 }
 
-void DriverStation::joystickCallback1(
+void frc::DriverStation::joystickCallback1(
     const gazebo::msgs::ConstFRCJoystickPtr& msg) {
   joystickCallback(msg, 1);
 }
 
-void DriverStation::joystickCallback2(
+void frc::DriverStation::joystickCallback2(
     const gazebo::msgs::ConstFRCJoystickPtr& msg) {
   joystickCallback(msg, 2);
 }
 
-void DriverStation::joystickCallback3(
+void frc::DriverStation::joystickCallback3(
     const gazebo::msgs::ConstFRCJoystickPtr& msg) {
   joystickCallback(msg, 3);
 }
 
-void DriverStation::joystickCallback4(
+void frc::DriverStation::joystickCallback4(
     const gazebo::msgs::ConstFRCJoystickPtr& msg) {
   joystickCallback(msg, 4);
 }
 
-void DriverStation::joystickCallback5(
+void frc::DriverStation::joystickCallback5(
     const gazebo::msgs::ConstFRCJoystickPtr& msg) {
   joystickCallback(msg, 5);
 }

--- a/wpilibc/sim/src/Encoder.cpp
+++ b/wpilibc/sim/src/Encoder.cpp
@@ -12,8 +12,6 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
 /**
  * Common initialization code for Encoders.
  * This code allocates resources for Encoders and is common to all constructors.
@@ -31,8 +29,9 @@ using namespace frc;
  *                         value will either exactly match the spec'd count or
  *                         be double (2x) the spec'd count.
  */
-void Encoder::InitEncoder(int channelA, int channelB, bool reverseDirection,
-                          EncodingType encodingType) {
+void frc::Encoder::InitEncoder(int channelA, int channelB,
+                               bool reverseDirection,
+                               EncodingType encodingType) {
   m_table = nullptr;
   this->channelA = channelA;
   this->channelB = channelB;
@@ -79,8 +78,8 @@ void Encoder::InitEncoder(int channelA, int channelB, bool reverseDirection,
  *                         value will either exactly match the spec'd count or
  *                         be double (2x) the spec'd count.
  */
-Encoder::Encoder(int aChannel, int bChannel, bool reverseDirection,
-                 EncodingType encodingType) {
+frc::Encoder::Encoder(int aChannel, int bChannel, bool reverseDirection,
+                      EncodingType encodingType) {
   InitEncoder(aChannel, bChannel, reverseDirection, encodingType);
 }
 
@@ -106,7 +105,8 @@ Encoder::Encoder(int aChannel, int bChannel, bool reverseDirection,
  *                         value will either exactly match the spec'd count or
  *                         be double (2x) the spec'd count.
  */
-/* TODO: [Not Supported] Encoder::Encoder(DigitalSource *aSource, DigitalSource
+/* TODO: [Not Supported] frc::Encoder::Encoder(DigitalSource *aSource,
+DigitalSource
 *bSource, bool reverseDirection, EncodingType encodingType) :
         m_encoder(nullptr),
         m_counter(nullptr)
@@ -143,7 +143,7 @@ Encoder::Encoder(int aChannel, int bChannel, bool reverseDirection,
  *                         value will either exactly match the spec'd count or
  *                         be double (2x) the spec'd count.
  */
-/*// TODO: [Not Supported] Encoder::Encoder(DigitalSource &aSource,
+/*// TODO: [Not Supported] frc::Encoder::Encoder(DigitalSource &aSource,
 DigitalSource &bSource, bool reverseDirection, EncodingType encodingType) :
         m_encoder(nullptr),
         m_counter(nullptr)
@@ -160,7 +160,7 @@ DigitalSource &bSource, bool reverseDirection, EncodingType encodingType) :
  *
  * Resets the current count to zero on the encoder.
  */
-void Encoder::Reset() { impl->Reset(); }
+void frc::Encoder::Reset() { impl->Reset(); }
 
 /**
  * Determine if the encoder is stopped.
@@ -171,7 +171,7 @@ void Encoder::Reset() { impl->Reset(); }
  *
  * @return True if the encoder is considered stopped.
  */
-bool Encoder::GetStopped() const {
+bool frc::Encoder::GetStopped() const {
   throw "Simulation doesn't currently support this method.";
 }
 
@@ -180,7 +180,7 @@ bool Encoder::GetStopped() const {
  *
  * @return The last direction the encoder value changed.
  */
-bool Encoder::GetDirection() const {
+bool frc::Encoder::GetDirection() const {
   throw "Simulation doesn't currently support this method.";
 }
 
@@ -188,7 +188,7 @@ bool Encoder::GetDirection() const {
  * The scale needed to convert a raw counter value into a number of encoder
  * pulses.
  */
-double Encoder::DecodingScaleFactor() const {
+double frc::Encoder::DecodingScaleFactor() const {
   switch (m_encodingType) {
     case k1X:
       return 1.0;
@@ -206,7 +206,7 @@ double Encoder::DecodingScaleFactor() const {
  *
  * Used to divide raw edge counts down to spec'd counts.
  */
-int Encoder::GetEncodingScale() const { return m_encodingScale; }
+int frc::Encoder::GetEncodingScale() const { return m_encodingScale; }
 
 /**
  * Gets the raw value from the encoder.
@@ -216,7 +216,7 @@ int Encoder::GetEncodingScale() const { return m_encodingScale; }
  *
  * @return Current raw count from the encoder
  */
-int Encoder::GetRaw() const {
+int frc::Encoder::GetRaw() const {
   throw "Simulation doesn't currently support this method.";
 }
 
@@ -229,7 +229,7 @@ int Encoder::GetRaw() const {
  * @return Current count from the Encoder adjusted for the 1x, 2x, or 4x scale
  *         factor.
  */
-int Encoder::Get() const {
+int frc::Encoder::Get() const {
   throw "Simulation doesn't currently support this method.";
 }
 
@@ -245,7 +245,7 @@ int Encoder::Get() const {
  *
  * @return Period in seconds of the most recent pulse.
  */
-double Encoder::GetPeriod() const {
+double frc::Encoder::GetPeriod() const {
   throw "Simulation doesn't currently support this method.";
 }
 
@@ -265,7 +265,7 @@ double Encoder::GetPeriod() const {
  *                  FPGA will report the device stopped. This is expressed in
  *                  seconds.
  */
-void Encoder::SetMaxPeriod(double maxPeriod) {
+void frc::Encoder::SetMaxPeriod(double maxPeriod) {
   throw "Simulation doesn't currently support this method.";
 }
 
@@ -275,7 +275,7 @@ void Encoder::SetMaxPeriod(double maxPeriod) {
  * @return The distance driven since the last reset as scaled by the value from
  *         SetDistancePerPulse().
  */
-double Encoder::GetDistance() const {
+double frc::Encoder::GetDistance() const {
   return m_distancePerPulse * impl->GetPosition();
 }
 
@@ -287,7 +287,7 @@ double Encoder::GetDistance() const {
  *
  * @return The current rate of the encoder.
  */
-double Encoder::GetRate() const {
+double frc::Encoder::GetRate() const {
   return m_distancePerPulse * impl->GetVelocity();
 }
 
@@ -297,7 +297,7 @@ double Encoder::GetRate() const {
  * @param minRate The minimum rate.  The units are in distance per second as
  *                scaled by the value from SetDistancePerPulse().
  */
-void Encoder::SetMinRate(double minRate) {
+void frc::Encoder::SetMinRate(double minRate) {
   throw "Simulation doesn't currently support this method.";
 }
 
@@ -314,7 +314,7 @@ void Encoder::SetMinRate(double minRate) {
  * @param distancePerPulse The scale factor that will be used to convert pulses
  *                         to useful units.
  */
-void Encoder::SetDistancePerPulse(double distancePerPulse) {
+void frc::Encoder::SetDistancePerPulse(double distancePerPulse) {
   if (m_reverseDirection) {
     m_distancePerPulse = -distancePerPulse;
   } else {
@@ -330,7 +330,7 @@ void Encoder::SetDistancePerPulse(double distancePerPulse) {
  *
  * @param reverseDirection true if the encoder direction should be reversed
  */
-void Encoder::SetReverseDirection(bool reverseDirection) {
+void frc::Encoder::SetReverseDirection(bool reverseDirection) {
   throw "Simulation doesn't currently support this method.";
 }
 
@@ -340,7 +340,7 @@ void Encoder::SetReverseDirection(bool reverseDirection) {
  *
  * @param pidSource An enum to select the parameter.
  */
-void Encoder::SetPIDSourceType(PIDSourceType pidSource) {
+void frc::Encoder::SetPIDSourceType(PIDSourceType pidSource) {
   m_pidSource = pidSource;
 }
 
@@ -349,7 +349,7 @@ void Encoder::SetPIDSourceType(PIDSourceType pidSource) {
  *
  * @return The current value of the selected source parameter.
  */
-double Encoder::PIDGet() {
+double frc::Encoder::PIDGet() {
   switch (m_pidSource) {
     case PIDSourceType::kDisplacement:
       return GetDistance();
@@ -360,7 +360,7 @@ double Encoder::PIDGet() {
   }
 }
 
-void Encoder::UpdateTable() {
+void frc::Encoder::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Speed", GetRate());
     m_table->PutNumber("Distance", GetDistance());
@@ -370,20 +370,20 @@ void Encoder::UpdateTable() {
   }
 }
 
-void Encoder::StartLiveWindowMode() {}
+void frc::Encoder::StartLiveWindowMode() {}
 
-void Encoder::StopLiveWindowMode() {}
+void frc::Encoder::StopLiveWindowMode() {}
 
-std::string Encoder::GetSmartDashboardType() const {
+std::string frc::Encoder::GetSmartDashboardType() const {
   if (m_encodingType == k4X)
     return "Quadrature Encoder";
   else
     return "Encoder";
 }
 
-void Encoder::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::Encoder::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> Encoder::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Encoder::GetTable() const { return m_table; }

--- a/wpilibc/sim/src/GenericHID.cpp
+++ b/wpilibc/sim/src/GenericHID.cpp
@@ -9,9 +9,7 @@
 
 #include "DriverStation.h"
 
-using namespace frc;
-
-GenericHID::GenericHID(int port) : m_ds(DriverStation::GetInstance()) {
+frc::GenericHID::GenericHID(int port) : m_ds(DriverStation::GetInstance()) {
   m_port = port;
 }
 
@@ -21,7 +19,7 @@ GenericHID::GenericHID(int port) : m_ds(DriverStation::GetInstance()) {
  * @param axis The axis to read, starting at 0.
  * @return The value of the axis.
  */
-double GenericHID::GetRawAxis(int axis) const {
+double frc::GenericHID::GetRawAxis(int axis) const {
   return m_ds.GetStickAxis(m_port, axis);
 }
 
@@ -35,7 +33,7 @@ double GenericHID::GetRawAxis(int axis) const {
  * @param button The button number to be read (starting at 1)
  * @return The state of the button.
  **/
-bool GenericHID::GetRawButton(int button) const {
+bool frc::GenericHID::GetRawButton(int button) const {
   return m_ds.GetStickButton(m_port, button);
 }
 
@@ -48,35 +46,37 @@ bool GenericHID::GetRawButton(int button) const {
  * @param pov The index of the POV to read (starting at 0)
  * @return the angle of the POV in degrees, or -1 if the POV is not pressed.
  */
-int GenericHID::GetPOV(int pov) const { return 0; }
+int frc::GenericHID::GetPOV(int pov) const { return 0; }
 
 /**
  * Get the number of POVs for the HID.
  *
  * @return the number of POVs for the current HID
  */
-int GenericHID::GetPOVCount() const { return 0; }
+int frc::GenericHID::GetPOVCount() const { return 0; }
 
 /**
  * Get the port number of the HID.
  *
  * @return The port number of the HID.
  */
-int GenericHID::GetPort() const { return m_port; }
+int frc::GenericHID::GetPort() const { return m_port; }
 
 /**
  * Get the type of the HID.
  *
  * @return the type of the HID.
  */
-GenericHID::HIDType GenericHID::GetType() const { return HIDType::kUnknown; }
+frc::GenericHID::HIDType frc::GenericHID::GetType() const {
+  return HIDType::kUnknown;
+}
 
 /**
  * Get the name of the HID.
  *
  * @return the name of the HID.
  */
-std::string GenericHID::GetName() const { return ""; }
+std::string frc::GenericHID::GetName() const { return ""; }
 
 /**
  * Set a single HID output value for the HID.
@@ -85,7 +85,7 @@ std::string GenericHID::GetName() const { return ""; }
  * @param value        The value to set the output to
  */
 
-void GenericHID::SetOutput(int outputNumber, bool value) {
+void frc::GenericHID::SetOutput(int outputNumber, bool value) {
   m_outputs =
       (m_outputs & ~(1 << (outputNumber - 1))) | (value << (outputNumber - 1));
 }
@@ -95,7 +95,7 @@ void GenericHID::SetOutput(int outputNumber, bool value) {
  *
  * @param value The 32 bit output value (1 bit for each output)
  */
-void GenericHID::SetOutputs(int value) { m_outputs = value; }
+void frc::GenericHID::SetOutputs(int value) { m_outputs = value; }
 
 /**
  * Set the rumble output for the HID.
@@ -105,7 +105,7 @@ void GenericHID::SetOutputs(int value) { m_outputs = value; }
  * @param type  Which rumble value to set
  * @param value The normalized value (0 to 1) to set the rumble to
  */
-void GenericHID::SetRumble(RumbleType type, double value) {
+void frc::GenericHID::SetRumble(RumbleType type, double value) {
   if (value < 0)
     value = 0;
   else if (value > 1)

--- a/wpilibc/sim/src/IterativeRobot.cpp
+++ b/wpilibc/sim/src/IterativeRobot.cpp
@@ -17,8 +17,6 @@
 #include <unistd.h>
 #endif
 
-using namespace frc;
-
 /**
  * Provide an alternate "main loop" via StartCompetition().
  *
@@ -27,7 +25,7 @@ using namespace frc;
  * is called periodically, and a "fast loop" (a.k.a. "spin loop") that is
  * called as fast as possible with no delay between calls.
  */
-void IterativeRobot::StartCompetition() {
+void frc::IterativeRobot::StartCompetition() {
   LiveWindow* lw = LiveWindow::GetInstance();
   // first and one-time initialization
   NetworkTable::GetTable("LiveWindow")
@@ -109,7 +107,7 @@ void IterativeRobot::StartCompetition() {
  * will be called when the robot is first powered on.  It will be called
  * exactly 1 time.
  */
-void IterativeRobot::RobotInit() {
+void frc::IterativeRobot::RobotInit() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -119,7 +117,7 @@ void IterativeRobot::RobotInit() {
  * Users should override this method for initialization code which will be
  * called each time the robot enters disabled mode.
  */
-void IterativeRobot::DisabledInit() {
+void frc::IterativeRobot::DisabledInit() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -129,7 +127,7 @@ void IterativeRobot::DisabledInit() {
  * Users should override this method for initialization code which will be
  * called each time the robot enters autonomous mode.
  */
-void IterativeRobot::AutonomousInit() {
+void frc::IterativeRobot::AutonomousInit() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -139,7 +137,7 @@ void IterativeRobot::AutonomousInit() {
  * Users should override this method for initialization code which will be
  * called each time the robot enters teleop mode.
  */
-void IterativeRobot::TeleopInit() {
+void frc::IterativeRobot::TeleopInit() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -149,7 +147,7 @@ void IterativeRobot::TeleopInit() {
  * Users should override this method for initialization code which will be
  * called each time the robot enters test mode.
  */
-void IterativeRobot::TestInit() {
+void frc::IterativeRobot::TestInit() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -159,7 +157,7 @@ void IterativeRobot::TestInit() {
  * Users should override this method for code which will be called periodically
  * at a regular rate while the robot is in any mode.
  */
-void IterativeRobot::RobotPeriodic() {
+void frc::IterativeRobot::RobotPeriodic() {
   static bool firstRun = true;
   if (firstRun) {
     llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
@@ -173,7 +171,7 @@ void IterativeRobot::RobotPeriodic() {
  * Users should override this method for code which will be called periodically
  * at a regular rate while the robot is in disabled mode.
  */
-void IterativeRobot::DisabledPeriodic() {
+void frc::IterativeRobot::DisabledPeriodic() {
   static bool firstRun = true;
   if (firstRun) {
     llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
@@ -187,7 +185,7 @@ void IterativeRobot::DisabledPeriodic() {
  * Users should override this method for code which will be called periodically
  * at a regular rate while the robot is in autonomous mode.
  */
-void IterativeRobot::AutonomousPeriodic() {
+void frc::IterativeRobot::AutonomousPeriodic() {
   static bool firstRun = true;
   if (firstRun) {
     llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
@@ -201,7 +199,7 @@ void IterativeRobot::AutonomousPeriodic() {
  * Users should override this method for code which will be called periodically
  * at a regular rate while the robot is in teleop mode.
  */
-void IterativeRobot::TeleopPeriodic() {
+void frc::IterativeRobot::TeleopPeriodic() {
   static bool firstRun = true;
   if (firstRun) {
     llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
@@ -215,7 +213,7 @@ void IterativeRobot::TeleopPeriodic() {
  * Users should override this method for code which will be called periodically
  * at a regular rate while the robot is in test mode.
  */
-void IterativeRobot::TestPeriodic() {
+void frc::IterativeRobot::TestPeriodic() {
   static bool firstRun = true;
   if (firstRun) {
     llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";

--- a/wpilibc/sim/src/Jaguar.cpp
+++ b/wpilibc/sim/src/Jaguar.cpp
@@ -9,12 +9,10 @@
 
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
 /**
  * @param channel The PWM channel that the Jaguar is attached to.
  */
-Jaguar::Jaguar(int channel) : SafePWM(channel) {
+frc::Jaguar::Jaguar(int channel) : SafePWM(channel) {
   /*
    * Input profile defined by Luminary Micro.
    *
@@ -39,23 +37,23 @@ Jaguar::Jaguar(int channel) : SafePWM(channel) {
  *
  * @param speed The speed value between -1.0 and 1.0 to set.
  */
-void Jaguar::Set(double speed) { SetSpeed(speed); }
+void frc::Jaguar::Set(double speed) { SetSpeed(speed); }
 
 /**
  * Get the recently set value of the PWM.
  *
  * @return The most recently set value for the PWM between -1.0 and 1.0.
  */
-double Jaguar::Get() const { return GetSpeed(); }
+double frc::Jaguar::Get() const { return GetSpeed(); }
 
 /**
  * Common interface for disabling a motor.
  */
-void Jaguar::Disable() { SetRaw(kPwmDisabled); }
+void frc::Jaguar::Disable() { SetRaw(kPwmDisabled); }
 
 /**
  * Write out the PID value as seen in the PIDOutput base object.
  *
  * @param output Write out the PWM value as was found in the PIDController
  */
-void Jaguar::PIDWrite(double output) { Set(output); }
+void frc::Jaguar::PIDWrite(double output) { Set(output); }

--- a/wpilibc/sim/src/Joystick.cpp
+++ b/wpilibc/sim/src/Joystick.cpp
@@ -12,16 +12,14 @@
 #include "DriverStation.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
-const int Joystick::kDefaultXAxis;
-const int Joystick::kDefaultYAxis;
-const int Joystick::kDefaultZAxis;
-const int Joystick::kDefaultTwistAxis;
-const int Joystick::kDefaultThrottleAxis;
-const int Joystick::kDefaultTriggerButton;
-const int Joystick::kDefaultTopButton;
-static Joystick* joysticks[DriverStation::kJoystickPorts];
+const int frc::Joystick::kDefaultXAxis;
+const int frc::Joystick::kDefaultYAxis;
+const int frc::Joystick::kDefaultZAxis;
+const int frc::Joystick::kDefaultTwistAxis;
+const int frc::Joystick::kDefaultThrottleAxis;
+const int frc::Joystick::kDefaultTriggerButton;
+const int frc::Joystick::kDefaultTopButton;
+static frc::Joystick* joysticks[frc::DriverStation::kJoystickPorts];
 static bool joySticksInitialized = false;
 
 /**
@@ -32,7 +30,8 @@ static bool joySticksInitialized = false;
  * @param port The port on the Driver Station that the joystick is plugged into
  *             (0-5).
  */
-Joystick::Joystick(int port) : Joystick(port, kNumAxisTypes, kNumButtonTypes) {
+frc::Joystick::Joystick(int port)
+    : Joystick(port, kNumAxisTypes, kNumButtonTypes) {
   m_axes[kXAxis] = kDefaultXAxis;
   m_axes[kYAxis] = kDefaultYAxis;
   m_axes[kZAxis] = kDefaultZAxis;
@@ -54,7 +53,7 @@ Joystick::Joystick(int port) : Joystick(port, kNumAxisTypes, kNumButtonTypes) {
  * @param numAxisTypes   The number of axis types in the enum.
  * @param numButtonTypes The number of button types in the enum.
  */
-Joystick::Joystick(int port, int numAxisTypes, int numButtonTypes)
+frc::Joystick::Joystick(int port, int numAxisTypes, int numButtonTypes)
     : JoystickBase(port),
       m_ds(DriverStation::GetInstance()),
       m_axes(numAxisTypes),
@@ -70,7 +69,7 @@ Joystick::Joystick(int port, int numAxisTypes, int numButtonTypes)
   }
 }
 
-Joystick* Joystick::GetStickForPort(int port) {
+frc::Joystick* frc::Joystick::GetStickForPort(int port) {
   Joystick* stick = joysticks[port];
   if (stick == nullptr) {
     stick = new Joystick(port);
@@ -87,7 +86,7 @@ Joystick* Joystick::GetStickForPort(int port) {
  * @param hand This parameter is ignored for the Joystick class and is only
  *             here to complete the GenericHID interface.
  */
-double Joystick::GetX(JoystickHand hand) const {
+double frc::Joystick::GetX(JoystickHand hand) const {
   return GetRawAxis(m_axes[kXAxis]);
 }
 
@@ -99,7 +98,7 @@ double Joystick::GetX(JoystickHand hand) const {
  * @param hand This parameter is ignored for the Joystick class and is only
  *             here to complete the GenericHID interface.
  */
-double Joystick::GetY(JoystickHand hand) const {
+double frc::Joystick::GetY(JoystickHand hand) const {
   return GetRawAxis(m_axes[kYAxis]);
 }
 
@@ -108,7 +107,7 @@ double Joystick::GetY(JoystickHand hand) const {
  *
  * This depends on the mapping of the joystick connected to the current port.
  */
-double Joystick::GetZ(JoystickHand hand) const {
+double frc::Joystick::GetZ(JoystickHand hand) const {
   return GetRawAxis(m_axes[kZAxis]);
 }
 
@@ -117,14 +116,16 @@ double Joystick::GetZ(JoystickHand hand) const {
  *
  * This depends on the mapping of the joystick connected to the current port.
  */
-double Joystick::GetTwist() const { return GetRawAxis(m_axes[kTwistAxis]); }
+double frc::Joystick::GetTwist() const {
+  return GetRawAxis(m_axes[kTwistAxis]);
+}
 
 /**
  * Get the throttle value of the current joystick.
  *
  * This depends on the mapping of the joystick connected to the current port.
  */
-double Joystick::GetThrottle() const {
+double frc::Joystick::GetThrottle() const {
   return GetRawAxis(m_axes[kThrottleAxis]);
 }
 
@@ -138,7 +139,7 @@ double Joystick::GetThrottle() const {
  * @param axis The axis to read.
  * @return The value of the axis.
  */
-double Joystick::GetAxis(AxisType axis) const {
+double frc::Joystick::GetAxis(AxisType axis) const {
   switch (axis) {
     case kXAxis:
       return this->GetX();
@@ -165,7 +166,7 @@ double Joystick::GetAxis(AxisType axis) const {
  *             here to complete the GenericHID interface.
  * @return The state of the trigger.
  */
-bool Joystick::GetTrigger(JoystickHand hand) const {
+bool frc::Joystick::GetTrigger(JoystickHand hand) const {
   return GetRawButton(m_buttons[kTriggerButton]);
 }
 
@@ -178,7 +179,7 @@ bool Joystick::GetTrigger(JoystickHand hand) const {
  *             here to complete the GenericHID interface.
  * @return The state of the top button.
  */
-bool Joystick::GetTop(JoystickHand hand) const {
+bool frc::Joystick::GetTop(JoystickHand hand) const {
   return GetRawButton(m_buttons[kTopButton]);
 }
 
@@ -190,7 +191,7 @@ bool Joystick::GetTop(JoystickHand hand) const {
  * @param button The type of button to read.
  * @return The state of the button.
  */
-bool Joystick::GetButton(ButtonType button) const {
+bool frc::Joystick::GetButton(ButtonType button) const {
   switch (button) {
     case kTriggerButton:
       return GetTrigger();
@@ -206,21 +207,21 @@ bool Joystick::GetButton(ButtonType button) const {
  *
  * @return the number of axis for the current joystick
  */
-int Joystick::GetAxisCount() const { return 0; }
+int frc::Joystick::GetAxisCount() const { return 0; }
 
 /**
  * Get the axis type of a joystick axis.
  *
  * @return the axis type of a joystick axis.
  */
-int Joystick::GetAxisType(int axis) const { return 0; }
+int frc::Joystick::GetAxisType(int axis) const { return 0; }
 
 /**
  * Get the number of buttons for a joystick.
  *
  * @return the number of buttons on the current joystick
  */
-int Joystick::GetButtonCount() const { return 0; }
+int frc::Joystick::GetButtonCount() const { return 0; }
 
 /**
  * Get the channel currently associated with the specified axis.
@@ -228,7 +229,7 @@ int Joystick::GetButtonCount() const { return 0; }
  * @param axis The axis to look up the channel for.
  * @return The channel fr the axis.
  */
-int Joystick::GetAxisChannel(AxisType axis) const { return m_axes[axis]; }
+int frc::Joystick::GetAxisChannel(AxisType axis) const { return m_axes[axis]; }
 
 /**
  * Set the channel associated with a specified axis.
@@ -236,7 +237,7 @@ int Joystick::GetAxisChannel(AxisType axis) const { return m_axes[axis]; }
  * @param axis    The axis to set the channel for.
  * @param channel The channel to set the axis to.
  */
-void Joystick::SetAxisChannel(AxisType axis, int channel) {
+void frc::Joystick::SetAxisChannel(AxisType axis, int channel) {
   m_axes[axis] = channel;
 }
 
@@ -246,7 +247,7 @@ void Joystick::SetAxisChannel(AxisType axis, int channel) {
  *
  * @return The magnitude of the direction vector
  */
-double Joystick::GetMagnitude() const {
+double frc::Joystick::GetMagnitude() const {
   return std::sqrt(std::pow(GetX(), 2) + std::pow(GetY(), 2));
 }
 
@@ -256,7 +257,7 @@ double Joystick::GetMagnitude() const {
  *
  * @return The direction of the vector in radians
  */
-double Joystick::GetDirectionRadians() const {
+double frc::Joystick::GetDirectionRadians() const {
   return std::atan2(GetX(), -GetY());
 }
 
@@ -269,6 +270,6 @@ double Joystick::GetDirectionRadians() const {
  *
  * @return The direction of the vector in degrees
  */
-double Joystick::GetDirectionDegrees() const {
+double frc::Joystick::GetDirectionDegrees() const {
   return (180 / std::acos(-1)) * GetDirectionRadians();
 }

--- a/wpilibc/sim/src/MotorSafetyHelper.cpp
+++ b/wpilibc/sim/src/MotorSafetyHelper.cpp
@@ -14,10 +14,8 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
-std::set<MotorSafetyHelper*> MotorSafetyHelper::m_helperList;
-hal::priority_recursive_mutex MotorSafetyHelper::m_listMutex;
+std::set<frc::MotorSafetyHelper*> frc::MotorSafetyHelper::m_helperList;
+hal::priority_recursive_mutex frc::MotorSafetyHelper::m_listMutex;
 
 /**
  * The constructor for a MotorSafetyHelper object.
@@ -31,7 +29,7 @@ hal::priority_recursive_mutex MotorSafetyHelper::m_listMutex;
  * @param safeObject a pointer to the motor object implementing MotorSafety.
  *                   This is used to call the Stop() method on the motor.
  */
-MotorSafetyHelper::MotorSafetyHelper(MotorSafety* safeObject)
+frc::MotorSafetyHelper::MotorSafetyHelper(MotorSafety* safeObject)
     : m_safeObject(safeObject) {
   m_enabled = false;
   m_expiration = DEFAULT_SAFETY_EXPIRATION;
@@ -41,7 +39,7 @@ MotorSafetyHelper::MotorSafetyHelper(MotorSafety* safeObject)
   m_helperList.insert(this);
 }
 
-MotorSafetyHelper::~MotorSafetyHelper() {
+frc::MotorSafetyHelper::~MotorSafetyHelper() {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_listMutex);
   m_helperList.erase(this);
 }
@@ -51,7 +49,7 @@ MotorSafetyHelper::~MotorSafetyHelper() {
  *
  * Resets the timer on this object that is used to do the timeouts.
  */
-void MotorSafetyHelper::Feed() {
+void frc::MotorSafetyHelper::Feed() {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_syncMutex);
   m_stopTime = Timer::GetFPGATimestamp() + m_expiration;
 }
@@ -61,7 +59,7 @@ void MotorSafetyHelper::Feed() {
  *
  * @param expirationTime The timeout value in seconds.
  */
-void MotorSafetyHelper::SetExpiration(double expirationTime) {
+void frc::MotorSafetyHelper::SetExpiration(double expirationTime) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_syncMutex);
   m_expiration = expirationTime;
 }
@@ -71,7 +69,7 @@ void MotorSafetyHelper::SetExpiration(double expirationTime) {
  *
  * @return the timeout value in seconds.
  */
-double MotorSafetyHelper::GetExpiration() const {
+double frc::MotorSafetyHelper::GetExpiration() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_syncMutex);
   return m_expiration;
 }
@@ -82,7 +80,7 @@ double MotorSafetyHelper::GetExpiration() const {
  * @return a true value if the motor is still operating normally and hasn't
  *         timed out.
  */
-bool MotorSafetyHelper::IsAlive() const {
+bool frc::MotorSafetyHelper::IsAlive() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_syncMutex);
   return !m_enabled || m_stopTime > Timer::GetFPGATimestamp();
 }
@@ -94,7 +92,7 @@ bool MotorSafetyHelper::IsAlive() const {
  * its timeout value. If it has, the stop method is called, and the motor is
  * shut down until its value is updated again.
  */
-void MotorSafetyHelper::Check() {
+void frc::MotorSafetyHelper::Check() {
   DriverStation& ds = DriverStation::GetInstance();
   if (!m_enabled || ds.IsDisabled() || ds.IsTest()) return;
 
@@ -116,7 +114,7 @@ void MotorSafetyHelper::Check() {
  *
  * @param enabled True if motor safety is enforced for this object
  */
-void MotorSafetyHelper::SetSafetyEnabled(bool enabled) {
+void frc::MotorSafetyHelper::SetSafetyEnabled(bool enabled) {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_syncMutex);
   m_enabled = enabled;
 }
@@ -128,7 +126,7 @@ void MotorSafetyHelper::SetSafetyEnabled(bool enabled) {
  *
  * @return True if motor safety is enforced for this device
  */
-bool MotorSafetyHelper::IsSafetyEnabled() const {
+bool frc::MotorSafetyHelper::IsSafetyEnabled() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_syncMutex);
   return m_enabled;
 }
@@ -139,7 +137,7 @@ bool MotorSafetyHelper::IsSafetyEnabled() const {
  * This static method is called periodically to poll all the motors and stop
  * any that have timed out.
  */
-void MotorSafetyHelper::CheckMotors() {
+void frc::MotorSafetyHelper::CheckMotors() {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_listMutex);
   for (auto elem : m_helperList) {
     elem->Check();

--- a/wpilibc/sim/src/Notifier.cpp
+++ b/wpilibc/sim/src/Notifier.cpp
@@ -11,13 +11,11 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
-using namespace frc;
-
-std::list<Notifier*> Notifier::timerQueue;
-hal::priority_recursive_mutex Notifier::queueMutex;
-std::atomic<int> Notifier::refcount{0};
-std::thread Notifier::m_task;
-std::atomic<bool> Notifier::m_stopped(false);
+std::list<frc::Notifier*> frc::Notifier::timerQueue;
+hal::priority_recursive_mutex frc::Notifier::queueMutex;
+std::atomic<int> frc::Notifier::refcount{0};
+std::thread frc::Notifier::m_task;
+std::atomic<bool> frc::Notifier::m_stopped(false);
 
 /**
  * Create a Notifier for timer event notification.
@@ -25,7 +23,7 @@ std::atomic<bool> Notifier::m_stopped(false);
  * @param handler The handler is called at the notification time which is set
  *                using StartSingle or StartPeriodic.
  */
-Notifier::Notifier(TimerEventHandler handler) {
+frc::Notifier::Notifier(TimerEventHandler handler) {
   if (handler == nullptr)
     wpi_setWPIErrorWithContext(NullParameter, "handler must not be nullptr");
   m_handler = handler;
@@ -48,7 +46,7 @@ Notifier::Notifier(TimerEventHandler handler) {
  * All resources will be freed and the timer event will be removed from the
  * queue if necessary.
  */
-Notifier::~Notifier() {
+frc::Notifier::~Notifier() {
   {
     std::lock_guard<hal::priority_recursive_mutex> sync(queueMutex);
     DeleteFromQueue();
@@ -74,7 +72,7 @@ Notifier::~Notifier() {
  * WARNING: this method does not do synchronization! It must be called from
  * somewhere that is taking care of synchronizing access to the queue.
  */
-void Notifier::UpdateAlarm() {}
+void frc::Notifier::UpdateAlarm() {}
 
 /**
  * ProcessQueue is called whenever there is a timer interrupt.
@@ -83,7 +81,7 @@ void Notifier::UpdateAlarm() {}
  * long as its scheduled time is after the current time. Then the item is
  * removed or rescheduled (repetitive events) in the queue.
  */
-void Notifier::ProcessQueue(int mask, void* params) {
+void frc::Notifier::ProcessQueue(int mask, void* params) {
   Notifier* current;
 
   // keep processing events until no more
@@ -139,7 +137,7 @@ void Notifier::ProcessQueue(int mask, void* params) {
  * This ensures that the public methods only update the queue after finishing
  * inserting.
  */
-void Notifier::InsertInQueue(bool reschedule) {
+void frc::Notifier::InsertInQueue(bool reschedule) {
   if (reschedule) {
     m_expirationTime += m_period;
   } else {
@@ -180,7 +178,7 @@ void Notifier::InsertInQueue(bool reschedule) {
  * Remove this Notifier from the timer queue and adjust the next interrupt time
  * to reflect the current top of the queue.
  */
-void Notifier::DeleteFromQueue() {
+void frc::Notifier::DeleteFromQueue() {
   if (m_queued) {
     m_queued = false;
     wpi_assert(!timerQueue.empty());
@@ -201,7 +199,7 @@ void Notifier::DeleteFromQueue() {
  *
  * @param delay Seconds to wait before the handler is called.
  */
-void Notifier::StartSingle(double delay) {
+void frc::Notifier::StartSingle(double delay) {
   std::lock_guard<hal::priority_recursive_mutex> sync(queueMutex);
   m_periodic = false;
   m_period = delay;
@@ -219,7 +217,7 @@ void Notifier::StartSingle(double delay) {
  * @param period Period in seconds to call the handler starting one period after
  *               the call to this method.
  */
-void Notifier::StartPeriodic(double period) {
+void frc::Notifier::StartPeriodic(double period) {
   std::lock_guard<hal::priority_recursive_mutex> sync(queueMutex);
   m_periodic = true;
   m_period = period;
@@ -235,7 +233,7 @@ void Notifier::StartPeriodic(double period) {
  * registered handler is in progress, this function will block until the
  * handler call is complete.
  */
-void Notifier::Stop() {
+void frc::Notifier::Stop() {
   {
     std::lock_guard<hal::priority_recursive_mutex> sync(queueMutex);
     DeleteFromQueue();
@@ -245,9 +243,9 @@ void Notifier::Stop() {
   std::lock_guard<hal::priority_mutex> sync(m_handlerMutex);
 }
 
-void Notifier::Run() {
+void frc::Notifier::Run() {
   while (!m_stopped) {
-    Notifier::ProcessQueue(0, nullptr);
+    frc::Notifier::ProcessQueue(0, nullptr);
     bool isEmpty;
     {
       std::lock_guard<hal::priority_recursive_mutex> sync(queueMutex);

--- a/wpilibc/sim/src/PIDController.cpp
+++ b/wpilibc/sim/src/PIDController.cpp
@@ -13,8 +13,6 @@
 #include "PIDOutput.h"
 #include "PIDSource.h"
 
-using namespace frc;
-
 static const std::string kP = "p";
 static const std::string kI = "i";
 static const std::string kD = "d";
@@ -34,8 +32,9 @@ static const std::string kEnabled = "enabled";
  *               calculations of the integral and differental terms. The
  *               default is 50ms.
  */
-PIDController::PIDController(double Kp, double Ki, double Kd, PIDSource* source,
-                             PIDOutput* output, double period)
+frc::PIDController::PIDController(double Kp, double Ki, double Kd,
+                                  PIDSource* source, PIDOutput* output,
+                                  double period)
     : PIDController(Kp, Ki, Kd, 0.0, source, output, period) {}
 
 /**
@@ -50,9 +49,9 @@ PIDController::PIDController(double Kp, double Ki, double Kd, PIDSource* source,
  *               calculations of the integral and differental terms. The
  *               default is 50ms.
  */
-PIDController::PIDController(double Kp, double Ki, double Kd, double Kf,
-                             PIDSource* source, PIDOutput* output,
-                             double period) {
+frc::PIDController::PIDController(double Kp, double Ki, double Kd, double Kf,
+                                  PIDSource* source, PIDOutput* output,
+                                  double period) {
   m_table = nullptr;
 
   m_P = Kp;
@@ -80,7 +79,8 @@ PIDController::PIDController(double Kp, double Ki, double Kd, double Kf,
   m_pidOutput = output;
   m_period = period;
 
-  m_controlLoop = std::make_unique<Notifier>(&PIDController::Calculate, this);
+  m_controlLoop =
+      std::make_unique<Notifier>(&frc::PIDController::Calculate, this);
   m_controlLoop->StartPeriodic(m_period);
 
   static int instances = 0;
@@ -89,7 +89,7 @@ PIDController::PIDController(double Kp, double Ki, double Kd, double Kf,
   m_toleranceType = kNoTolerance;
 }
 
-PIDController::~PIDController() {
+frc::PIDController::~PIDController() {
   if (m_table != nullptr) m_table->RemoveTableListener(this);
 }
 
@@ -98,7 +98,7 @@ PIDController::~PIDController() {
  *
  * This should only be called by the Notifier.
  */
-void PIDController::Calculate() {
+void frc::PIDController::Calculate() {
   bool enabled;
   PIDSource* pidInput;
 
@@ -190,7 +190,7 @@ void PIDController::Calculate() {
  * output measured in setpoint units per this controller's update period (see
  * the default period in this class's constructor).
  */
-double PIDController::CalculateFeedForward() {
+double frc::PIDController::CalculateFeedForward() {
   if (m_pidInput->GetPIDSourceType() == PIDSourceType::kRate) {
     return m_F * GetSetpoint();
   } else {
@@ -210,7 +210,7 @@ double PIDController::CalculateFeedForward() {
  * @param i Integral coefficient
  * @param d Differential coefficient
  */
-void PIDController::SetPID(double p, double i, double d) {
+void frc::PIDController::SetPID(double p, double i, double d) {
   {
     std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
     m_P = p;
@@ -235,7 +235,7 @@ void PIDController::SetPID(double p, double i, double d) {
  * @param d Differential coefficient
  * @param f Feed forward coefficient
  */
-void PIDController::SetPID(double p, double i, double d, double f) {
+void frc::PIDController::SetPID(double p, double i, double d, double f) {
   {
     std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
     m_P = p;
@@ -257,7 +257,7 @@ void PIDController::SetPID(double p, double i, double d, double f) {
  *
  * @return proportional coefficient
  */
-double PIDController::GetP() const {
+double frc::PIDController::GetP() const {
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
   return m_P;
 }
@@ -267,7 +267,7 @@ double PIDController::GetP() const {
  *
  * @return integral coefficient
  */
-double PIDController::GetI() const {
+double frc::PIDController::GetI() const {
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
   return m_I;
 }
@@ -277,7 +277,7 @@ double PIDController::GetI() const {
  *
  * @return differential coefficient
  */
-double PIDController::GetD() const {
+double frc::PIDController::GetD() const {
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
   return m_D;
 }
@@ -287,7 +287,7 @@ double PIDController::GetD() const {
  *
  * @return Feed forward coefficient
  */
-double PIDController::GetF() const {
+double frc::PIDController::GetF() const {
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
   return m_F;
 }
@@ -299,7 +299,7 @@ double PIDController::GetF() const {
  *
  * @return the latest calculated output
  */
-double PIDController::Get() const {
+double frc::PIDController::Get() const {
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
   return m_result;
 }
@@ -313,7 +313,7 @@ double PIDController::Get() const {
  *
  * @param continuous Set to true turns on continuous, false turns off continuous
  */
-void PIDController::SetContinuous(bool continuous) {
+void frc::PIDController::SetContinuous(bool continuous) {
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
   m_continuous = continuous;
 }
@@ -324,7 +324,8 @@ void PIDController::SetContinuous(bool continuous) {
  * @param minimumInput the minimum value expected from the input
  * @param maximumInput the maximum value expected from the output
  */
-void PIDController::SetInputRange(double minimumInput, double maximumInput) {
+void frc::PIDController::SetInputRange(double minimumInput,
+                                       double maximumInput) {
   {
     std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
     m_minimumInput = minimumInput;
@@ -340,7 +341,8 @@ void PIDController::SetInputRange(double minimumInput, double maximumInput) {
  * @param minimumOutput the minimum value to write to the output
  * @param maximumOutput the maximum value to write to the output
  */
-void PIDController::SetOutputRange(double minimumOutput, double maximumOutput) {
+void frc::PIDController::SetOutputRange(double minimumOutput,
+                                        double maximumOutput) {
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
   m_minimumOutput = minimumOutput;
   m_maximumOutput = maximumOutput;
@@ -351,7 +353,7 @@ void PIDController::SetOutputRange(double minimumOutput, double maximumOutput) {
  *
  * @param setpoint the desired setpoint
  */
-void PIDController::SetSetpoint(double setpoint) {
+void frc::PIDController::SetSetpoint(double setpoint) {
   {
     std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
 
@@ -377,7 +379,7 @@ void PIDController::SetSetpoint(double setpoint) {
  *
  * @return the current setpoint
  */
-double PIDController::GetSetpoint() const {
+double frc::PIDController::GetSetpoint() const {
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
   return m_setpoint;
 }
@@ -387,7 +389,7 @@ double PIDController::GetSetpoint() const {
  *
  * @return the change in setpoint over time
  */
-double PIDController::GetDeltaSetpoint() const {
+double frc::PIDController::GetDeltaSetpoint() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   return (m_setpoint - m_prevSetpoint) / m_setpointTimer.Get();
 }
@@ -397,7 +399,7 @@ double PIDController::GetDeltaSetpoint() const {
  *
  * @return the current error
  */
-double PIDController::GetError() const {
+double frc::PIDController::GetError() const {
   double setpoint = GetSetpoint();
   {
     std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
@@ -408,7 +410,7 @@ double PIDController::GetError() const {
 /**
  * Sets what type of input the PID controller will use.
  */
-void PIDController::SetPIDSourceType(PIDSourceType pidSource) {
+void frc::PIDController::SetPIDSourceType(PIDSourceType pidSource) {
   m_pidInput->SetPIDSourceType(pidSource);
 }
 
@@ -417,7 +419,7 @@ void PIDController::SetPIDSourceType(PIDSourceType pidSource) {
  *
  * @return the PID controller input type
  */
-PIDSourceType PIDController::GetPIDSourceType() const {
+frc::PIDSourceType frc::PIDController::GetPIDSourceType() const {
   return m_pidInput->GetPIDSourceType();
 }
 
@@ -429,7 +431,7 @@ PIDSourceType PIDController::GetPIDSourceType() const {
  *
  * @return the average error
  */
-double PIDController::GetAvgError() const {
+double frc::PIDController::GetAvgError() const {
   double avgError = 0;
   {
     std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
@@ -445,7 +447,7 @@ double PIDController::GetAvgError() const {
  *
  * @param percent percentage error which is tolerable
  */
-void PIDController::SetTolerance(double percent) {
+void frc::PIDController::SetTolerance(double percent) {
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
   m_toleranceType = kPercentTolerance;
   m_tolerance = percent;
@@ -457,7 +459,7 @@ void PIDController::SetTolerance(double percent) {
  *
  * @param absTolerance absolute error which is tolerable
  */
-void PIDController::SetAbsoluteTolerance(double absTolerance) {
+void frc::PIDController::SetAbsoluteTolerance(double absTolerance) {
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
   m_toleranceType = kAbsoluteTolerance;
   m_tolerance = absTolerance;
@@ -469,7 +471,7 @@ void PIDController::SetAbsoluteTolerance(double absTolerance) {
  *
  * @param percent percentage error which is tolerable
  */
-void PIDController::SetPercentTolerance(double percent) {
+void frc::PIDController::SetPercentTolerance(double percent) {
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
   m_toleranceType = kPercentTolerance;
   m_tolerance = percent;
@@ -485,7 +487,7 @@ void PIDController::SetPercentTolerance(double percent) {
  * not register as on target for at least the specified bufLength cycles.
  * @param bufLength Number of previous cycles to average. Defaults to 1.
  */
-void PIDController::SetToleranceBuffer(int bufLength) {
+void frc::PIDController::SetToleranceBuffer(int bufLength) {
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
   m_bufLength = bufLength;
 
@@ -505,7 +507,7 @@ void PIDController::SetToleranceBuffer(int bufLength) {
  * setpoint. Ideally it should be based on being within the tolerance for some
  * period of time.
  */
-bool PIDController::OnTarget() const {
+bool frc::PIDController::OnTarget() const {
   std::lock_guard<hal::priority_recursive_mutex> sync(m_mutex);
   if (m_buf.size() == 0) return false;
   double error = GetError();
@@ -526,7 +528,7 @@ bool PIDController::OnTarget() const {
 /**
  * Begin running the PIDController.
  */
-void PIDController::Enable() {
+void frc::PIDController::Enable() {
   {
     std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
     m_enabled = true;
@@ -540,7 +542,7 @@ void PIDController::Enable() {
 /**
  * Stop running the PIDController, this sets the output to zero before stopping.
  */
-void PIDController::Disable() {
+void frc::PIDController::Disable() {
   {
     std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
     m_pidOutput->PIDWrite(0);
@@ -555,7 +557,7 @@ void PIDController::Disable() {
 /**
  * Return true if PIDController is enabled.
  */
-bool PIDController::IsEnabled() const {
+bool frc::PIDController::IsEnabled() const {
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
   return m_enabled;
 }
@@ -563,7 +565,7 @@ bool PIDController::IsEnabled() const {
 /**
  * Reset the previous error,, the integral term, and disable the controller.
  */
-void PIDController::Reset() {
+void frc::PIDController::Reset() {
   Disable();
 
   std::lock_guard<hal::priority_recursive_mutex> lock(m_mutex);
@@ -572,11 +574,11 @@ void PIDController::Reset() {
   m_result = 0;
 }
 
-std::string PIDController::GetSmartDashboardType() const {
+std::string frc::PIDController::GetSmartDashboardType() const {
   return "PIDController";
 }
 
-void PIDController::InitTable(std::shared_ptr<ITable> table) {
+void frc::PIDController::InitTable(std::shared_ptr<ITable> table) {
   if (m_table != nullptr) m_table->RemoveTableListener(this);
   m_table = table;
   if (m_table != nullptr) {
@@ -597,7 +599,7 @@ void PIDController::InitTable(std::shared_ptr<ITable> table) {
  * @param error The current error of the PID controller.
  * @return Error for continuous inputs.
  */
-double PIDController::GetContinuousError(double error) const {
+double frc::PIDController::GetContinuousError(double error) const {
   if (m_continuous) {
     if (std::fabs(error) > (m_maximumInput - m_minimumInput) / 2) {
       if (error > 0) {
@@ -611,10 +613,11 @@ double PIDController::GetContinuousError(double error) const {
   return error;
 }
 
-std::shared_ptr<ITable> PIDController::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::PIDController::GetTable() const { return m_table; }
 
-void PIDController::ValueChanged(ITable* source, llvm::StringRef key,
-                                 std::shared_ptr<nt::Value> value, bool isNew) {
+void frc::PIDController::ValueChanged(ITable* source, llvm::StringRef key,
+                                      std::shared_ptr<nt::Value> value,
+                                      bool isNew) {
   if (key == kP || key == kI || key == kD || key == kF) {
     if (m_P != m_table->GetNumber(kP, 0.0) ||
         m_I != m_table->GetNumber(kI, 0.0) ||
@@ -636,8 +639,8 @@ void PIDController::ValueChanged(ITable* source, llvm::StringRef key,
   }
 }
 
-void PIDController::UpdateTable() {}
+void frc::PIDController::UpdateTable() {}
 
-void PIDController::StartLiveWindowMode() { Disable(); }
+void frc::PIDController::StartLiveWindowMode() { Disable(); }
 
-void PIDController::StopLiveWindowMode() {}
+void frc::PIDController::StopLiveWindowMode() {}

--- a/wpilibc/sim/src/PWM.cpp
+++ b/wpilibc/sim/src/PWM.cpp
@@ -12,12 +12,10 @@
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
-const double PWM::kDefaultPwmPeriod = 5.05;
-const double PWM::kDefaultPwmCenter = 1.5;
-const int PWM::kDefaultPwmStepsDown = 1000;
-const int PWM::kPwmDisabled = 0;
+const double frc::PWM::kDefaultPwmPeriod = 5.05;
+const double frc::PWM::kDefaultPwmCenter = 1.5;
+const int frc::PWM::kDefaultPwmStepsDown = 1000;
+const int frc::PWM::kPwmDisabled = 0;
 
 /**
  * Allocate a PWM given a channel number.
@@ -29,7 +27,7 @@ const int PWM::kPwmDisabled = 0;
  * @param channel The PWM channel number. 0-9 are on-board, 10-19 are on the MXP
  *                port
  */
-PWM::PWM(int channel) {
+frc::PWM::PWM(int channel) {
   llvm::SmallString<32> buf;
   llvm::raw_svector_ostream oss(buf);
 
@@ -47,7 +45,7 @@ PWM::PWM(int channel) {
   m_centerPwm = kPwmDisabled;  // In simulation, the same thing.
 }
 
-PWM::~PWM() {
+frc::PWM::~PWM() {
   if (m_table != nullptr) m_table->RemoveTableListener(this);
 }
 
@@ -59,7 +57,7 @@ PWM::~PWM() {
  *                          Otherwise, keep the full range without modifying
  *                          any values.
  */
-void PWM::EnableDeadbandElimination(bool eliminateDeadband) {
+void frc::PWM::EnableDeadbandElimination(bool eliminateDeadband) {
   m_eliminateDeadband = eliminateDeadband;
 }
 
@@ -76,8 +74,8 @@ void PWM::EnableDeadbandElimination(bool eliminateDeadband) {
  * @param deadbandMin The low end of the deadband range
  * @param min         The minimum pwm value
  */
-void PWM::SetBounds(int max, int deadbandMax, int center, int deadbandMin,
-                    int min) {
+void frc::PWM::SetBounds(int max, int deadbandMax, int center, int deadbandMin,
+                         int min) {
   // Nothing to do in simulation.
 }
 
@@ -94,8 +92,8 @@ void PWM::SetBounds(int max, int deadbandMax, int center, int deadbandMin,
  * @param deadbandMin The low end of the deadband pulse width in ms
  * @param min         The minimum pulse width in ms
  */
-void PWM::SetBounds(double max, double deadbandMax, double center,
-                    double deadbandMin, double min) {
+void frc::PWM::SetBounds(double max, double deadbandMax, double center,
+                         double deadbandMin, double min) {
   // Nothing to do in simulation.
 }
 
@@ -109,7 +107,7 @@ void PWM::SetBounds(double max, double deadbandMax, double center,
  *
  * @param pos The position to set the servo between 0.0 and 1.0.
  */
-void PWM::SetPosition(double pos) {
+void frc::PWM::SetPosition(double pos) {
   if (pos < 0.0) {
     pos = 0.0;
   } else if (pos > 1.0) {
@@ -129,7 +127,7 @@ void PWM::SetPosition(double pos) {
  *
  * @return The position the servo is set to between 0.0 and 1.0.
  */
-double PWM::GetPosition() const {
+double frc::PWM::GetPosition() const {
   double value = impl->Get();
   if (value < 0.0) {
     return 0.0;
@@ -153,7 +151,7 @@ double PWM::GetPosition() const {
  *
  * @param speed The speed to set the speed controller between -1.0 and 1.0.
  */
-void PWM::SetSpeed(double speed) {
+void frc::PWM::SetSpeed(double speed) {
   // clamp speed to be in the range 1.0 >= speed >= -1.0
   if (speed < -1.0) {
     speed = -1.0;
@@ -176,7 +174,7 @@ void PWM::SetSpeed(double speed) {
  *
  * @return The most recently set speed between -1.0 and 1.0.
  */
-double PWM::GetSpeed() const {
+double frc::PWM::GetSpeed() const {
   double value = impl->Get();
   if (value > 1.0) {
     return 1.0;
@@ -194,7 +192,7 @@ double PWM::GetSpeed() const {
  *
  * @param value Raw PWM value.
  */
-void PWM::SetRaw(uint16_t value) {
+void frc::PWM::SetRaw(uint16_t value) {
   wpi_assert(value == kPwmDisabled);
   impl->Set(0);
 }
@@ -204,41 +202,43 @@ void PWM::SetRaw(uint16_t value) {
  *
  * @param mult The period multiplier to apply to this channel
  */
-void PWM::SetPeriodMultiplier(PeriodMultiplier mult) {
+void frc::PWM::SetPeriodMultiplier(PeriodMultiplier mult) {
   // Do nothing in simulation.
 }
 
-void PWM::ValueChanged(ITable* source, llvm::StringRef key,
-                       std::shared_ptr<nt::Value> value, bool isNew) {
+void frc::PWM::ValueChanged(ITable* source, llvm::StringRef key,
+                            std::shared_ptr<nt::Value> value, bool isNew) {
   if (!value->IsDouble()) return;
   SetSpeed(value->GetDouble());
 }
 
-void PWM::UpdateTable() {
+void frc::PWM::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutNumber("Value", GetSpeed());
   }
 }
 
-void PWM::StartLiveWindowMode() {
+void frc::PWM::StartLiveWindowMode() {
   SetSpeed(0);
   if (m_table != nullptr) {
     m_table->AddTableListener("Value", this, true);
   }
 }
 
-void PWM::StopLiveWindowMode() {
+void frc::PWM::StopLiveWindowMode() {
   SetSpeed(0);
   if (m_table != nullptr) {
     m_table->RemoveTableListener(this);
   }
 }
 
-std::string PWM::GetSmartDashboardType() const { return "Speed Controller"; }
+std::string frc::PWM::GetSmartDashboardType() const {
+  return "Speed Controller";
+}
 
-void PWM::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::PWM::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> PWM::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::PWM::GetTable() const { return m_table; }

--- a/wpilibc/sim/src/Relay.cpp
+++ b/wpilibc/sim/src/Relay.cpp
@@ -12,8 +12,6 @@
 #include "WPIErrors.h"
 #include "llvm/SmallString.h"
 
-using namespace frc;
-
 /**
  * Relay constructor given a channel.
  *
@@ -23,7 +21,7 @@ using namespace frc;
  * @param channel   The channel number (0-3).
  * @param direction The direction that the Relay object will control.
  */
-Relay::Relay(int channel, Relay::Direction direction)
+frc::Relay::Relay(int channel, frc::Relay::Direction direction)
     : m_channel(channel), m_direction(direction) {
   llvm::SmallString<32> buf;
   llvm::raw_svector_ostream oss(buf);
@@ -50,7 +48,7 @@ Relay::Relay(int channel, Relay::Direction direction)
  *
  * The relay channels are set to free and the relay output is turned off.
  */
-Relay::~Relay() {
+frc::Relay::~Relay() {
   impl->Set(0);
   if (m_table != nullptr) m_table->RemoveTableListener(this);
 }
@@ -70,7 +68,7 @@ Relay::~Relay() {
  *
  * @param value The state to set the relay.
  */
-void Relay::Set(Relay::Value value) {
+void frc::Relay::Set(frc::Relay::Value value) {
   switch (value) {
     case kOff:
       if (m_direction == kBothDirections || m_direction == kForwardOnly) {
@@ -124,9 +122,9 @@ void Relay::Set(Relay::Value value) {
  * When set to kForwardOnly or kReverseOnly, value is returned as kOn/kOff not
  * kForward/kReverse (per the recommendation in Set).
  *
- * @return The current state of the relay as a Relay::Value
+ * @return The current state of the relay as a frc::Relay::Value
  */
-Relay::Value Relay::Get() const {
+frc::Relay::Value frc::Relay::Get() const {
   // TODO: Don't assume that the go_pos and go_neg fields are correct?
   if ((go_pos || m_direction == kReverseOnly) &&
       (go_neg || m_direction == kForwardOnly)) {
@@ -140,14 +138,14 @@ Relay::Value Relay::Get() const {
   }
 }
 
-int Relay::GetChannel() const { return m_channel; }
+int frc::Relay::GetChannel() const { return m_channel; }
 
 /**
  * Set the expiration time for the Relay object.
  *
  * @param timeout The timeout (in seconds) for this relay object
  */
-void Relay::SetExpiration(double timeout) {
+void frc::Relay::SetExpiration(double timeout) {
   m_safetyHelper->SetExpiration(timeout);
 }
 
@@ -156,7 +154,9 @@ void Relay::SetExpiration(double timeout) {
  *
  * @return The expiration time value.
  */
-double Relay::GetExpiration() const { return m_safetyHelper->GetExpiration(); }
+double frc::Relay::GetExpiration() const {
+  return m_safetyHelper->GetExpiration();
+}
 
 /**
  * Check if the relay object is currently alive or stopped due to a timeout.
@@ -164,7 +164,7 @@ double Relay::GetExpiration() const { return m_safetyHelper->GetExpiration(); }
  * @return a bool value that is true if the motor has NOT timed out and should
  *         still be running.
  */
-bool Relay::IsAlive() const { return m_safetyHelper->IsAlive(); }
+bool frc::Relay::IsAlive() const { return m_safetyHelper->IsAlive(); }
 
 /**
  * Stop the motor associated with this PWM object.
@@ -172,7 +172,7 @@ bool Relay::IsAlive() const { return m_safetyHelper->IsAlive(); }
  * This is called by the MotorSafetyHelper object when it has a timeout for this
  * relay and needs to stop it from running.
  */
-void Relay::StopMotor() { Set(kOff); }
+void frc::Relay::StopMotor() { Set(kOff); }
 
 /**
  * Enable/disable motor safety for this device
@@ -181,7 +181,7 @@ void Relay::StopMotor() { Set(kOff); }
  *
  * @param enabled True if motor safety is enforced for this object
  */
-void Relay::SetSafetyEnabled(bool enabled) {
+void frc::Relay::SetSafetyEnabled(bool enabled) {
   m_safetyHelper->SetSafetyEnabled(enabled);
 }
 
@@ -190,16 +190,16 @@ void Relay::SetSafetyEnabled(bool enabled) {
  *
  * @return True if motor safety is enforced for this object
  */
-bool Relay::IsSafetyEnabled() const {
+bool frc::Relay::IsSafetyEnabled() const {
   return m_safetyHelper->IsSafetyEnabled();
 }
 
-void Relay::GetDescription(llvm::raw_ostream& desc) const {
+void frc::Relay::GetDescription(llvm::raw_ostream& desc) const {
   desc << "Relay " << GetChannel();
 }
 
-void Relay::ValueChanged(ITable* source, llvm::StringRef key,
-                         std::shared_ptr<nt::Value> value, bool isNew) {
+void frc::Relay::ValueChanged(ITable* source, llvm::StringRef key,
+                              std::shared_ptr<nt::Value> value, bool isNew) {
   if (!value->IsString()) return;
   if (value->GetString() == "Off")
     Set(kOff);
@@ -209,7 +209,7 @@ void Relay::ValueChanged(ITable* source, llvm::StringRef key,
     Set(kReverse);
 }
 
-void Relay::UpdateTable() {
+void frc::Relay::UpdateTable() {
   if (m_table != nullptr) {
     if (Get() == kOn) {
       m_table->PutString("Value", "On");
@@ -223,23 +223,23 @@ void Relay::UpdateTable() {
   }
 }
 
-void Relay::StartLiveWindowMode() {
+void frc::Relay::StartLiveWindowMode() {
   if (m_table != nullptr) {
     m_table->AddTableListener("Value", this, true);
   }
 }
 
-void Relay::StopLiveWindowMode() {
+void frc::Relay::StopLiveWindowMode() {
   if (m_table != nullptr) {
     m_table->RemoveTableListener(this);
   }
 }
 
-std::string Relay::GetSmartDashboardType() const { return "Relay"; }
+std::string frc::Relay::GetSmartDashboardType() const { return "Relay"; }
 
-void Relay::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::Relay::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> Relay::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Relay::GetTable() const { return m_table; }

--- a/wpilibc/sim/src/RobotBase.cpp
+++ b/wpilibc/sim/src/RobotBase.cpp
@@ -11,8 +11,6 @@
 #include "SmartDashboard/SmartDashboard.h"
 #include "Utility.h"
 
-using namespace frc;
-
 /**
  * Constructor for a generic robot program.
  *
@@ -24,7 +22,7 @@ using namespace frc;
  * future it would be nice to put this code into it's own task that loads on
  * boot so ensure that it runs.
  */
-RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
+frc::RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
   RobotState::SetImplementation(DriverStation::GetInstance());
   SmartDashboard::init();
   time_sub = MainNode::Subscribe("~/time", &wpilib::internal::time_callback);
@@ -35,14 +33,14 @@ RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
  *
  * @return True if the Robot is currently enabled by the field controls.
  */
-bool RobotBase::IsEnabled() const { return m_ds.IsEnabled(); }
+bool frc::RobotBase::IsEnabled() const { return m_ds.IsEnabled(); }
 
 /**
  * Determine if the Robot is currently disabled.
  *
  * @return True if the Robot is currently disabled by the field controls.
  */
-bool RobotBase::IsDisabled() const { return m_ds.IsDisabled(); }
+bool frc::RobotBase::IsDisabled() const { return m_ds.IsDisabled(); }
 
 /**
  * Determine if the robot is currently in Autnomous mode.
@@ -50,7 +48,7 @@ bool RobotBase::IsDisabled() const { return m_ds.IsDisabled(); }
  * @return True if the robot is currently operating Autonomously as determined
  *         by the field controls.
  */
-bool RobotBase::IsAutonomous() const { return m_ds.IsAutonomous(); }
+bool frc::RobotBase::IsAutonomous() const { return m_ds.IsAutonomous(); }
 
 /**
  * Determine if the robot is currently in Operator Control mode.
@@ -58,7 +56,9 @@ bool RobotBase::IsAutonomous() const { return m_ds.IsAutonomous(); }
  * @return True if the robot is currently operating in Tele-Op mode as
  *         determined by the field controls.
  */
-bool RobotBase::IsOperatorControl() const { return m_ds.IsOperatorControl(); }
+bool frc::RobotBase::IsOperatorControl() const {
+  return m_ds.IsOperatorControl();
+}
 
 /**
  * Determine if the robot is currently in Test mode.
@@ -66,4 +66,4 @@ bool RobotBase::IsOperatorControl() const { return m_ds.IsOperatorControl(); }
  * @return True if the robot is currently running tests as determined by the
  *         field controls.
  */
-bool RobotBase::IsTest() const { return m_ds.IsTest(); }
+bool frc::RobotBase::IsTest() const { return m_ds.IsTest(); }

--- a/wpilibc/sim/src/RobotDrive.cpp
+++ b/wpilibc/sim/src/RobotDrive.cpp
@@ -16,13 +16,12 @@
 #include "Utility.h"
 #include "WPIErrors.h"
 
-using namespace frc;
+const int frc::RobotDrive::kMaxNumberOfMotors;
 
-const int RobotDrive::kMaxNumberOfMotors;
-
-static std::shared_ptr<SpeedController> make_shared_nodelete(
-    SpeedController* ptr) {
-  return std::shared_ptr<SpeedController>(ptr, NullDeleter<SpeedController>());
+static std::shared_ptr<frc::SpeedController> make_shared_nodelete(
+    frc::SpeedController* ptr) {
+  return std::shared_ptr<frc::SpeedController>(
+      ptr, frc::NullDeleter<frc::SpeedController>());
 }
 
 /*
@@ -40,7 +39,7 @@ static std::shared_ptr<SpeedController> make_shared_nodelete(
  * initialize all the motor assignments. The default timeout is set for the
  * robot drive.
  */
-void RobotDrive::InitRobotDrive() {
+void frc::RobotDrive::InitRobotDrive() {
   // FIXME: m_safetyHelper = new MotorSafetyHelper(this);
   // FIXME: m_safetyHelper->SetSafetyEnabled(true);
 }
@@ -55,7 +54,7 @@ void RobotDrive::InitRobotDrive() {
  * @param leftMotorChannel  The PWM channel number that drives the left motor.
  * @param rightMotorChannel The PWM channel number that drives the right motor.
  */
-RobotDrive::RobotDrive(int leftMotorChannel, int rightMotorChannel) {
+frc::RobotDrive::RobotDrive(int leftMotorChannel, int rightMotorChannel) {
   InitRobotDrive();
   m_rearLeftMotor = std::make_shared<Talon>(leftMotorChannel);
   m_rearRightMotor = std::make_shared<Talon>(rightMotorChannel);
@@ -75,8 +74,8 @@ RobotDrive::RobotDrive(int leftMotorChannel, int rightMotorChannel) {
  * @param frontRightMotor Front right motor channel number
  * @param rearRightMotor  Rear Right motor channel number
  */
-RobotDrive::RobotDrive(int frontLeftMotor, int rearLeftMotor,
-                       int frontRightMotor, int rearRightMotor) {
+frc::RobotDrive::RobotDrive(int frontLeftMotor, int rearLeftMotor,
+                            int frontRightMotor, int rearRightMotor) {
   InitRobotDrive();
   m_rearLeftMotor = std::make_shared<Talon>(rearLeftMotor);
   m_rearRightMotor = std::make_shared<Talon>(rearRightMotor);
@@ -98,8 +97,8 @@ RobotDrive::RobotDrive(int frontLeftMotor, int rearLeftMotor,
  * @param leftMotor  The left SpeedController object used to drive the robot.
  * @param rightMotor the right SpeedController object used to drive the robot.
  */
-RobotDrive::RobotDrive(SpeedController* leftMotor,
-                       SpeedController* rightMotor) {
+frc::RobotDrive::RobotDrive(SpeedController* leftMotor,
+                            SpeedController* rightMotor) {
   InitRobotDrive();
   if (leftMotor == nullptr || rightMotor == nullptr) {
     wpi_setWPIError(NullParameter);
@@ -111,15 +110,15 @@ RobotDrive::RobotDrive(SpeedController* leftMotor,
 }
 
 // TODO: Change to rvalue references & move syntax.
-RobotDrive::RobotDrive(SpeedController& leftMotor,
-                       SpeedController& rightMotor) {
+frc::RobotDrive::RobotDrive(SpeedController& leftMotor,
+                            SpeedController& rightMotor) {
   InitRobotDrive();
   m_rearLeftMotor = make_shared_nodelete(&leftMotor);
   m_rearRightMotor = make_shared_nodelete(&rightMotor);
 }
 
-RobotDrive::RobotDrive(std::shared_ptr<SpeedController> leftMotor,
-                       std::shared_ptr<SpeedController> rightMotor) {
+frc::RobotDrive::RobotDrive(std::shared_ptr<SpeedController> leftMotor,
+                            std::shared_ptr<SpeedController> rightMotor) {
   InitRobotDrive();
   if (leftMotor == nullptr || rightMotor == nullptr) {
     wpi_setWPIError(NullParameter);
@@ -145,10 +144,10 @@ RobotDrive::RobotDrive(std::shared_ptr<SpeedController> leftMotor,
  * @param frontRightMotor The front right SpeedController object used to drive
  *                        the robot.
  */
-RobotDrive::RobotDrive(SpeedController* frontLeftMotor,
-                       SpeedController* rearLeftMotor,
-                       SpeedController* frontRightMotor,
-                       SpeedController* rearRightMotor) {
+frc::RobotDrive::RobotDrive(SpeedController* frontLeftMotor,
+                            SpeedController* rearLeftMotor,
+                            SpeedController* frontRightMotor,
+                            SpeedController* rearRightMotor) {
   InitRobotDrive();
   if (frontLeftMotor == nullptr || rearLeftMotor == nullptr ||
       frontRightMotor == nullptr || rearRightMotor == nullptr) {
@@ -161,10 +160,10 @@ RobotDrive::RobotDrive(SpeedController* frontLeftMotor,
   m_rearRightMotor = make_shared_nodelete(rearRightMotor);
 }
 
-RobotDrive::RobotDrive(SpeedController& frontLeftMotor,
-                       SpeedController& rearLeftMotor,
-                       SpeedController& frontRightMotor,
-                       SpeedController& rearRightMotor) {
+frc::RobotDrive::RobotDrive(SpeedController& frontLeftMotor,
+                            SpeedController& rearLeftMotor,
+                            SpeedController& frontRightMotor,
+                            SpeedController& rearRightMotor) {
   InitRobotDrive();
   m_frontLeftMotor = make_shared_nodelete(&frontLeftMotor);
   m_rearLeftMotor = make_shared_nodelete(&rearLeftMotor);
@@ -172,10 +171,10 @@ RobotDrive::RobotDrive(SpeedController& frontLeftMotor,
   m_rearRightMotor = make_shared_nodelete(&rearRightMotor);
 }
 
-RobotDrive::RobotDrive(std::shared_ptr<SpeedController> frontLeftMotor,
-                       std::shared_ptr<SpeedController> rearLeftMotor,
-                       std::shared_ptr<SpeedController> frontRightMotor,
-                       std::shared_ptr<SpeedController> rearRightMotor) {
+frc::RobotDrive::RobotDrive(std::shared_ptr<SpeedController> frontLeftMotor,
+                            std::shared_ptr<SpeedController> rearLeftMotor,
+                            std::shared_ptr<SpeedController> frontRightMotor,
+                            std::shared_ptr<SpeedController> rearRightMotor) {
   InitRobotDrive();
   if (frontLeftMotor == nullptr || rearLeftMotor == nullptr ||
       frontRightMotor == nullptr || rearRightMotor == nullptr) {
@@ -209,7 +208,7 @@ RobotDrive::RobotDrive(std::shared_ptr<SpeedController> frontLeftMotor,
  *                        radius r = -ln(curve)*w for a given value of curve and
  *                        wheelbase w.
  */
-void RobotDrive::Drive(double outputMagnitude, double curve) {
+void frc::RobotDrive::Drive(double outputMagnitude, double curve) {
   double leftOutput, rightOutput;
   static bool reported = false;
   if (!reported) {
@@ -244,8 +243,8 @@ void RobotDrive::Drive(double outputMagnitude, double curve) {
  * @param leftStick  The joystick to control the left side of the robot.
  * @param rightStick The joystick to control the right side of the robot.
  */
-void RobotDrive::TankDrive(GenericHID* leftStick, GenericHID* rightStick,
-                           bool squaredInputs) {
+void frc::RobotDrive::TankDrive(GenericHID* leftStick, GenericHID* rightStick,
+                                bool squaredInputs) {
   if (leftStick == nullptr || rightStick == nullptr) {
     wpi_setWPIError(NullParameter);
     return;
@@ -253,8 +252,8 @@ void RobotDrive::TankDrive(GenericHID* leftStick, GenericHID* rightStick,
   TankDrive(leftStick->GetY(), rightStick->GetY(), squaredInputs);
 }
 
-void RobotDrive::TankDrive(GenericHID& leftStick, GenericHID& rightStick,
-                           bool squaredInputs) {
+void frc::RobotDrive::TankDrive(GenericHID& leftStick, GenericHID& rightStick,
+                                bool squaredInputs) {
   TankDrive(leftStick.GetY(), rightStick.GetY(), squaredInputs);
 }
 
@@ -269,9 +268,9 @@ void RobotDrive::TankDrive(GenericHID& leftStick, GenericHID& rightStick,
  * @param rightStick The Joystick object to use for the right side of the robot.
  * @param rightAxis  The axis to select on the right side Joystick object.
  */
-void RobotDrive::TankDrive(GenericHID* leftStick, int leftAxis,
-                           GenericHID* rightStick, int rightAxis,
-                           bool squaredInputs) {
+void frc::RobotDrive::TankDrive(GenericHID* leftStick, int leftAxis,
+                                GenericHID* rightStick, int rightAxis,
+                                bool squaredInputs) {
   if (leftStick == nullptr || rightStick == nullptr) {
     wpi_setWPIError(NullParameter);
     return;
@@ -280,9 +279,9 @@ void RobotDrive::TankDrive(GenericHID* leftStick, int leftAxis,
             squaredInputs);
 }
 
-void RobotDrive::TankDrive(GenericHID& leftStick, int leftAxis,
-                           GenericHID& rightStick, int rightAxis,
-                           bool squaredInputs) {
+void frc::RobotDrive::TankDrive(GenericHID& leftStick, int leftAxis,
+                                GenericHID& rightStick, int rightAxis,
+                                bool squaredInputs) {
   TankDrive(leftStick.GetRawAxis(leftAxis), rightStick.GetRawAxis(rightAxis),
             squaredInputs);
 }
@@ -295,8 +294,8 @@ void RobotDrive::TankDrive(GenericHID& leftStick, int leftAxis,
  * @param leftValue  The value of the left stick.
  * @param rightValue The value of the right stick.
  */
-void RobotDrive::TankDrive(double leftValue, double rightValue,
-                           bool squaredInputs) {
+void frc::RobotDrive::TankDrive(double leftValue, double rightValue,
+                                bool squaredInputs) {
   static bool reported = false;
   if (!reported) {
     reported = true;
@@ -335,7 +334,7 @@ void RobotDrive::TankDrive(double leftValue, double rightValue,
  * @param squaredInputs If true, the sensitivity will be increased for small
  *                      values
  */
-void RobotDrive::ArcadeDrive(GenericHID* stick, bool squaredInputs) {
+void frc::RobotDrive::ArcadeDrive(GenericHID* stick, bool squaredInputs) {
   // simply call the full-featured ArcadeDrive with the appropriate values
   ArcadeDrive(stick->GetY(), stick->GetX(), squaredInputs);
 }
@@ -353,7 +352,7 @@ void RobotDrive::ArcadeDrive(GenericHID* stick, bool squaredInputs) {
  * @param squaredInputs If true, the sensitivity will be increased for small
  *                      values
  */
-void RobotDrive::ArcadeDrive(GenericHID& stick, bool squaredInputs) {
+void frc::RobotDrive::ArcadeDrive(GenericHID& stick, bool squaredInputs) {
   // simply call the full-featured ArcadeDrive with the appropriate values
   ArcadeDrive(stick.GetY(), stick.GetX(), squaredInputs);
 }
@@ -374,9 +373,9 @@ void RobotDrive::ArcadeDrive(GenericHID& stick, bool squaredInputs) {
  * @param squaredInputs Setting this parameter to true increases the sensitivity
  *                      at lower speeds
  */
-void RobotDrive::ArcadeDrive(GenericHID* moveStick, int moveAxis,
-                             GenericHID* rotateStick, int rotateAxis,
-                             bool squaredInputs) {
+void frc::RobotDrive::ArcadeDrive(GenericHID* moveStick, int moveAxis,
+                                  GenericHID* rotateStick, int rotateAxis,
+                                  bool squaredInputs) {
   double moveValue = moveStick->GetRawAxis(moveAxis);
   double rotateValue = rotateStick->GetRawAxis(rotateAxis);
 
@@ -399,9 +398,9 @@ void RobotDrive::ArcadeDrive(GenericHID* moveStick, int moveAxis,
  * @param squaredInputs Setting this parameter to true increases the sensitivity
  *                      at lower speeds
  */
-void RobotDrive::ArcadeDrive(GenericHID& moveStick, int moveAxis,
-                             GenericHID& rotateStick, int rotateAxis,
-                             bool squaredInputs) {
+void frc::RobotDrive::ArcadeDrive(GenericHID& moveStick, int moveAxis,
+                                  GenericHID& rotateStick, int rotateAxis,
+                                  bool squaredInputs) {
   double moveValue = moveStick.GetRawAxis(moveAxis);
   double rotateValue = rotateStick.GetRawAxis(rotateAxis);
 
@@ -417,8 +416,8 @@ void RobotDrive::ArcadeDrive(GenericHID& moveStick, int moveAxis,
  * @param rotateValue   The value to use for the rotate right/left
  * @param squaredInputs If set, increases the sensitivity at low speeds
  */
-void RobotDrive::ArcadeDrive(double moveValue, double rotateValue,
-                             bool squaredInputs) {
+void frc::RobotDrive::ArcadeDrive(double moveValue, double rotateValue,
+                                  bool squaredInputs) {
   static bool reported = false;
   if (!reported) {
     reported = true;
@@ -486,8 +485,9 @@ void RobotDrive::ArcadeDrive(double moveValue, double rotateValue,
  * @param gyroAngle The current angle reading from the gyro.  Use this to
  *                  implement field-oriented controls.
  */
-void RobotDrive::MecanumDrive_Cartesian(double x, double y, double rotation,
-                                        double gyroAngle) {
+void frc::RobotDrive::MecanumDrive_Cartesian(double x, double y,
+                                             double rotation,
+                                             double gyroAngle) {
   static bool reported = false;
   if (!reported) {
     reported = true;
@@ -536,8 +536,8 @@ void RobotDrive::MecanumDrive_Cartesian(double x, double y, double rotation,
  * @param rotation  The rate of rotation for the robot that is completely
  *                  independent of the magnitute or direction. [-1.0..1.0]
  */
-void RobotDrive::MecanumDrive_Polar(double magnitude, double direction,
-                                    double rotation) {
+void frc::RobotDrive::MecanumDrive_Polar(double magnitude, double direction,
+                                         double rotation) {
   static bool reported = false;
   if (!reported) {
     reported = true;
@@ -582,8 +582,8 @@ void RobotDrive::MecanumDrive_Polar(double magnitude, double direction,
  * @param rotation  The rate of rotation for the robot that is completely
  *                  independent of the magnitude or direction.  [-1.0..1.0]
  */
-void RobotDrive::HolonomicDrive(double magnitude, double direction,
-                                double rotation) {
+void frc::RobotDrive::HolonomicDrive(double magnitude, double direction,
+                                     double rotation) {
   MecanumDrive_Polar(magnitude, direction, rotation);
 }
 
@@ -597,8 +597,8 @@ void RobotDrive::HolonomicDrive(double magnitude, double direction,
  * @param leftOutput  The speed to send to the left side of the robot.
  * @param rightOutput The speed to send to the right side of the robot.
  */
-void RobotDrive::SetLeftRightMotorOutputs(double leftOutput,
-                                          double rightOutput) {
+void frc::RobotDrive::SetLeftRightMotorOutputs(double leftOutput,
+                                               double rightOutput) {
   wpi_assert(m_rearLeftMotor != nullptr && m_rearRightMotor != nullptr);
 
   if (m_frontLeftMotor != nullptr)
@@ -619,7 +619,7 @@ void RobotDrive::SetLeftRightMotorOutputs(double leftOutput,
 /**
  * Limit motor values to the -1.0 to +1.0 range.
  */
-double RobotDrive::Limit(double num) {
+double frc::RobotDrive::Limit(double num) {
   if (num > 1.0) {
     return 1.0;
   }
@@ -632,7 +632,7 @@ double RobotDrive::Limit(double num) {
 /**
  * Normalize all wheel speeds if the magnitude of any wheel is greater than 1.0.
  */
-void RobotDrive::Normalize(double* wheelSpeeds) {
+void frc::RobotDrive::Normalize(double* wheelSpeeds) {
   double maxMagnitude = std::fabs(wheelSpeeds[0]);
   for (int i = 1; i < kMaxNumberOfMotors; i++) {
     double temp = std::fabs(wheelSpeeds[i]);
@@ -648,7 +648,7 @@ void RobotDrive::Normalize(double* wheelSpeeds) {
 /**
  * Rotate a vector in Cartesian space.
  */
-void RobotDrive::RotateVector(double& x, double& y, double angle) {
+void frc::RobotDrive::RotateVector(double& x, double& y, double angle) {
   double cosA = std::cos(angle * (3.14159 / 180.0));
   double sinA = std::sin(angle * (3.14159 / 180.0));
   double xOut = x * cosA - y * sinA;
@@ -667,7 +667,7 @@ void RobotDrive::RotateVector(double& x, double& y, double angle) {
  * @param motor      The motor index to invert.
  * @param isInverted True if the motor should be inverted when operated.
  */
-void RobotDrive::SetInvertedMotor(MotorType motor, bool isInverted) {
+void frc::RobotDrive::SetInvertedMotor(MotorType motor, bool isInverted) {
   if (motor < 0 || motor > 3) {
     wpi_setWPIError(InvalidMotorIndex);
     return;
@@ -683,7 +683,7 @@ void RobotDrive::SetInvertedMotor(MotorType motor, bool isInverted) {
  * @param sensitivity Effectively sets the turning sensitivity (or turn radius
  *                    for a given value)
  */
-void RobotDrive::SetSensitivity(double sensitivity) {
+void frc::RobotDrive::SetSensitivity(double sensitivity) {
   m_sensitivity = sensitivity;
 }
 
@@ -694,33 +694,35 @@ void RobotDrive::SetSensitivity(double sensitivity) {
  * @param maxOutput Multiplied with the output percentage computed by the drive
  *                  functions.
  */
-void RobotDrive::SetMaxOutput(double maxOutput) { m_maxOutput = maxOutput; }
+void frc::RobotDrive::SetMaxOutput(double maxOutput) {
+  m_maxOutput = maxOutput;
+}
 
-void RobotDrive::SetExpiration(double timeout) {
+void frc::RobotDrive::SetExpiration(double timeout) {
   // FIXME: m_safetyHelper->SetExpiration(timeout);
 }
 
-double RobotDrive::GetExpiration() const {
+double frc::RobotDrive::GetExpiration() const {
   return -1;  // FIXME: return m_safetyHelper->GetExpiration();
 }
 
-bool RobotDrive::IsAlive() const {
+bool frc::RobotDrive::IsAlive() const {
   return true;  // FIXME: m_safetyHelper->IsAlive();
 }
 
-bool RobotDrive::IsSafetyEnabled() const {
+bool frc::RobotDrive::IsSafetyEnabled() const {
   return false;  // FIXME: return m_safetyHelper->IsSafetyEnabled();
 }
 
-void RobotDrive::SetSafetyEnabled(bool enabled) {
+void frc::RobotDrive::SetSafetyEnabled(bool enabled) {
   // FIXME: m_safetyHelper->SetSafetyEnabled(enabled);
 }
 
-void RobotDrive::GetDescription(llvm::raw_ostream& desc) const {
+void frc::RobotDrive::GetDescription(llvm::raw_ostream& desc) const {
   desc << "RobotDrive";
 }
 
-void RobotDrive::StopMotor() {
+void frc::RobotDrive::StopMotor() {
   if (m_frontLeftMotor != nullptr) m_frontLeftMotor->Disable();
   if (m_frontRightMotor != nullptr) m_frontRightMotor->Disable();
   if (m_rearLeftMotor != nullptr) m_rearLeftMotor->Disable();

--- a/wpilibc/sim/src/SafePWM.cpp
+++ b/wpilibc/sim/src/SafePWM.cpp
@@ -9,14 +9,12 @@
 
 #include <memory>
 
-using namespace frc;
-
 /**
  * Constructor for a SafePWM object taking a channel number.
  *
  * @param channel The PWM channel number (0..19).
  */
-SafePWM::SafePWM(int channel) : PWM(channel) {
+frc::SafePWM::SafePWM(int channel) : PWM(channel) {
   m_safetyHelper = std::make_unique<MotorSafetyHelper>(this);
   m_safetyHelper->SetSafetyEnabled(false);
 }
@@ -26,7 +24,7 @@ SafePWM::SafePWM(int channel) : PWM(channel) {
  *
  * @param timeout The timeout (in seconds) for this motor object
  */
-void SafePWM::SetExpiration(double timeout) {
+void frc::SafePWM::SetExpiration(double timeout) {
   m_safetyHelper->SetExpiration(timeout);
 }
 
@@ -35,7 +33,7 @@ void SafePWM::SetExpiration(double timeout) {
  *
  * @returns The expiration time value.
  */
-double SafePWM::GetExpiration() const {
+double frc::SafePWM::GetExpiration() const {
   return m_safetyHelper->GetExpiration();
 }
 
@@ -45,7 +43,7 @@ double SafePWM::GetExpiration() const {
  * @return a bool value that is true if the motor has NOT timed out and should
  *         still be running.
  */
-bool SafePWM::IsAlive() const { return m_safetyHelper->IsAlive(); }
+bool frc::SafePWM::IsAlive() const { return m_safetyHelper->IsAlive(); }
 
 /**
  * Stop the motor associated with this PWM object.
@@ -53,7 +51,7 @@ bool SafePWM::IsAlive() const { return m_safetyHelper->IsAlive(); }
  * This is called by the MotorSafetyHelper object when it has a timeout for this
  * PWM and needs to stop it from running.
  */
-void SafePWM::StopMotor() { SetRaw(kPwmDisabled); }
+void frc::SafePWM::StopMotor() { SetRaw(kPwmDisabled); }
 
 /**
  * Enable/disable motor safety for this device.
@@ -62,7 +60,7 @@ void SafePWM::StopMotor() { SetRaw(kPwmDisabled); }
  *
  * @param enabled True if motor safety is enforced for this object
  */
-void SafePWM::SetSafetyEnabled(bool enabled) {
+void frc::SafePWM::SetSafetyEnabled(bool enabled) {
   m_safetyHelper->SetSafetyEnabled(enabled);
 }
 
@@ -71,11 +69,11 @@ void SafePWM::SetSafetyEnabled(bool enabled) {
  *
  * @returns True if motor safety is enforced for this object
  */
-bool SafePWM::IsSafetyEnabled() const {
+bool frc::SafePWM::IsSafetyEnabled() const {
   return m_safetyHelper->IsSafetyEnabled();
 }
 
-void SafePWM::GetDescription(llvm::raw_ostream& desc) const {
+void frc::SafePWM::GetDescription(llvm::raw_ostream& desc) const {
   desc << "PWM " << GetChannel();
 }
 
@@ -87,7 +85,7 @@ void SafePWM::GetDescription(llvm::raw_ostream& desc) const {
  *
  * @param speed Value to pass to the PWM class
  */
-void SafePWM::SetSpeed(double speed) {
+void frc::SafePWM::SetSpeed(double speed) {
   PWM::SetSpeed(speed);
   m_safetyHelper->Feed();
 }

--- a/wpilibc/sim/src/SampleRobot.cpp
+++ b/wpilibc/sim/src/SampleRobot.cpp
@@ -19,9 +19,7 @@
 void sleep(unsigned int milliseconds) { Sleep(milliseconds); }
 #endif
 
-using namespace frc;
-
-SampleRobot::SampleRobot() : m_robotMainOverridden(true) {}
+frc::SampleRobot::SampleRobot() : m_robotMainOverridden(true) {}
 
 /**
  * Robot-wide initialization code should go here.
@@ -29,7 +27,7 @@ SampleRobot::SampleRobot() : m_robotMainOverridden(true) {}
  * Programmers should override this method for default Robot-wide initialization
  * which will be called each time the robot enters the disabled state.
  */
-void SampleRobot::RobotInit() {
+void frc::SampleRobot::RobotInit() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -39,7 +37,7 @@ void SampleRobot::RobotInit() {
  * Programmers should override this method to run code that should run while the
  * field is disabled.
  */
-void SampleRobot::Disabled() {
+void frc::SampleRobot::Disabled() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -50,7 +48,7 @@ void SampleRobot::Disabled() {
  * field is in the autonomous period. This will be called once each time the
  * robot enters the autonomous state.
  */
-void SampleRobot::Autonomous() {
+void frc::SampleRobot::Autonomous() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -61,7 +59,7 @@ void SampleRobot::Autonomous() {
  * field is in the Operator Control (tele-operated) period. This is called once
  * each time the robot enters the teleop state.
  */
-void SampleRobot::OperatorControl() {
+void frc::SampleRobot::OperatorControl() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -72,7 +70,7 @@ void SampleRobot::OperatorControl() {
  * robot is in test mode. This will be called once whenever the robot enters
  * test mode.
  */
-void SampleRobot::Test() {
+void frc::SampleRobot::Test() {
   llvm::outs() << "Default " << __FUNCTION__ << "() method... Overload me!\n";
 }
 
@@ -88,7 +86,7 @@ void SampleRobot::Test() {
  * has not been overridden by a user subclass (i.e. the default version runs),
  * then the Autonomous() and OperatorControl() methods will be called.
  */
-void SampleRobot::RobotMain() { m_robotMainOverridden = false; }
+void frc::SampleRobot::RobotMain() { m_robotMainOverridden = false; }
 
 /**
  * Start a competition.
@@ -100,7 +98,7 @@ void SampleRobot::RobotMain() { m_robotMainOverridden = false; }
  * other mode starts or the robot is disabled. Then go back and wait for the
  * robot to be enabled again.
  */
-void SampleRobot::StartCompetition() {
+void frc::SampleRobot::StartCompetition() {
   LiveWindow* lw = LiveWindow::GetInstance();
 
   NetworkTable::GetTable("LiveWindow")

--- a/wpilibc/sim/src/SensorBase.cpp
+++ b/wpilibc/sim/src/SensorBase.cpp
@@ -9,22 +9,20 @@
 
 #include "WPIErrors.h"
 
-using namespace frc;
-
-const int SensorBase::kDigitalChannels;
-const int SensorBase::kAnalogInputs;
-const int SensorBase::kSolenoidChannels;
-const int SensorBase::kSolenoidModules;
-const int SensorBase::kPwmChannels;
-const int SensorBase::kRelayChannels;
-const int SensorBase::kPDPChannels;
+const int frc::SensorBase::kDigitalChannels;
+const int frc::SensorBase::kAnalogInputs;
+const int frc::SensorBase::kSolenoidChannels;
+const int frc::SensorBase::kSolenoidModules;
+const int frc::SensorBase::kPwmChannels;
+const int frc::SensorBase::kRelayChannels;
+const int frc::SensorBase::kPDPChannels;
 
 /**
  * Check that the solenoid module number is valid.
  *
  * @return Solenoid module number is valid
  */
-bool SensorBase::CheckSolenoidModule(int moduleNumber) {
+bool frc::SensorBase::CheckSolenoidModule(int moduleNumber) {
   return moduleNumber >= 0 && moduleNumber < kSolenoidModules;
 }
 
@@ -36,7 +34,7 @@ bool SensorBase::CheckSolenoidModule(int moduleNumber) {
  *
  * @return Digital channel is valid
  */
-bool SensorBase::CheckDigitalChannel(int channel) {
+bool frc::SensorBase::CheckDigitalChannel(int channel) {
   if (channel >= 0 && channel < kDigitalChannels) return true;
   return false;
 }
@@ -49,7 +47,7 @@ bool SensorBase::CheckDigitalChannel(int channel) {
  *
  * @return Relay channel is valid
  */
-bool SensorBase::CheckRelayChannel(int channel) {
+bool frc::SensorBase::CheckRelayChannel(int channel) {
   if (channel >= 0 && channel < kRelayChannels) return true;
   return false;
 }
@@ -62,7 +60,7 @@ bool SensorBase::CheckRelayChannel(int channel) {
  *
  * @return PWM channel is valid
  */
-bool SensorBase::CheckPWMChannel(int channel) {
+bool frc::SensorBase::CheckPWMChannel(int channel) {
   if (channel >= 0 && channel < kPwmChannels) return true;
   return false;
 }
@@ -75,7 +73,7 @@ bool SensorBase::CheckPWMChannel(int channel) {
  *
  * @return Analog channel is valid
  */
-bool SensorBase::CheckAnalogInputChannel(int channel) {
+bool frc::SensorBase::CheckAnalogInputChannel(int channel) {
   if (channel >= 0 && channel < kAnalogInputs) return true;
   return false;
 }
@@ -88,7 +86,7 @@ bool SensorBase::CheckAnalogInputChannel(int channel) {
  *
  * @return Analog channel is valid
  */
-bool SensorBase::CheckAnalogOutputChannel(int channel) {
+bool frc::SensorBase::CheckAnalogOutputChannel(int channel) {
   if (channel >= 0 && channel < kAnalogOutputs) return true;
   return false;
 }
@@ -98,7 +96,7 @@ bool SensorBase::CheckAnalogOutputChannel(int channel) {
  *
  * @return Solenoid channel is valid
  */
-bool SensorBase::CheckSolenoidChannel(int channel) {
+bool frc::SensorBase::CheckSolenoidChannel(int channel) {
   if (channel >= 0 && channel < kSolenoidChannels) return true;
   return false;
 }
@@ -108,7 +106,7 @@ bool SensorBase::CheckSolenoidChannel(int channel) {
  *
  * @return PDP channel is valid
  */
-bool SensorBase::CheckPDPChannel(int channel) {
+bool frc::SensorBase::CheckPDPChannel(int channel) {
   if (channel >= 0 && channel < kPDPChannels) return true;
   return false;
 }

--- a/wpilibc/sim/src/Solenoid.cpp
+++ b/wpilibc/sim/src/Solenoid.cpp
@@ -13,14 +13,12 @@
 #include "llvm/raw_ostream.h"
 #include "simulation/simTime.h"
 
-using namespace frc;
-
 /**
  * Constructor.
  *
  * @param channel The channel on the solenoid module to control (1..8).
  */
-Solenoid::Solenoid(int channel) : Solenoid(1, channel) {}
+frc::Solenoid::Solenoid(int channel) : Solenoid(1, channel) {}
 
 /**
  * Constructor.
@@ -28,7 +26,7 @@ Solenoid::Solenoid(int channel) : Solenoid(1, channel) {}
  * @param moduleNumber The solenoid module (1 or 2).
  * @param channel      The channel on the solenoid module to control (1..8).
  */
-Solenoid::Solenoid(int moduleNumber, int channel) {
+frc::Solenoid::Solenoid(int moduleNumber, int channel) {
   llvm::SmallString<32> buf;
   llvm::raw_svector_ostream oss(buf);
   oss << "pneumatic/" << moduleNumber << "/" << channel;
@@ -38,7 +36,7 @@ Solenoid::Solenoid(int moduleNumber, int channel) {
                                          this);
 }
 
-Solenoid::~Solenoid() {
+frc::Solenoid::~Solenoid() {
   if (m_table != nullptr) m_table->RemoveTableListener(this);
 }
 
@@ -47,7 +45,7 @@ Solenoid::~Solenoid() {
  *
  * @param on Turn the solenoid output off or on.
  */
-void Solenoid::Set(bool on) {
+void frc::Solenoid::Set(bool on) {
   m_on = on;
   m_impl->Set(on ? 1 : -1);
 }
@@ -57,39 +55,39 @@ void Solenoid::Set(bool on) {
  *
  * @return The current value of the solenoid.
  */
-bool Solenoid::Get() const { return m_on; }
+bool frc::Solenoid::Get() const { return m_on; }
 
-void Solenoid::ValueChanged(ITable* source, llvm::StringRef key,
-                            std::shared_ptr<nt::Value> value, bool isNew) {
+void frc::Solenoid::ValueChanged(ITable* source, llvm::StringRef key,
+                                 std::shared_ptr<nt::Value> value, bool isNew) {
   if (!value->IsBoolean()) return;
   Set(value->GetBoolean());
 }
 
-void Solenoid::UpdateTable() {
+void frc::Solenoid::UpdateTable() {
   if (m_table != nullptr) {
     m_table->PutBoolean("Value", Get());
   }
 }
 
-void Solenoid::StartLiveWindowMode() {
+void frc::Solenoid::StartLiveWindowMode() {
   Set(false);
   if (m_table != nullptr) {
     m_table->AddTableListener("Value", this, true);
   }
 }
 
-void Solenoid::StopLiveWindowMode() {
+void frc::Solenoid::StopLiveWindowMode() {
   Set(false);
   if (m_table != nullptr) {
     m_table->RemoveTableListener(this);
   }
 }
 
-std::string Solenoid::GetSmartDashboardType() const { return "Solenoid"; }
+std::string frc::Solenoid::GetSmartDashboardType() const { return "Solenoid"; }
 
-void Solenoid::InitTable(std::shared_ptr<ITable> subTable) {
+void frc::Solenoid::InitTable(std::shared_ptr<ITable> subTable) {
   m_table = subTable;
   UpdateTable();
 }
 
-std::shared_ptr<ITable> Solenoid::GetTable() const { return m_table; }
+std::shared_ptr<ITable> frc::Solenoid::GetTable() const { return m_table; }

--- a/wpilibc/sim/src/Talon.cpp
+++ b/wpilibc/sim/src/Talon.cpp
@@ -9,12 +9,10 @@
 
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
 /**
  * @param channel The PWM channel that the Talon is attached to.
  */
-Talon::Talon(int channel) : SafePWM(channel) {
+frc::Talon::Talon(int channel) : SafePWM(channel) {
   /* Note that the Talon uses the following bounds for PWM values. These values
    * should work reasonably well for most controllers, but if users experience
    * issues such as asymmetric behavior around the deadband or inability to
@@ -43,23 +41,23 @@ Talon::Talon(int channel) : SafePWM(channel) {
  *
  * @param speed The speed value between -1.0 and 1.0 to set.
  */
-void Talon::Set(double speed) { SetSpeed(speed); }
+void frc::Talon::Set(double speed) { SetSpeed(speed); }
 
 /**
  * Get the recently set value of the PWM.
  *
  * @return The most recently set value for the PWM between -1.0 and 1.0.
  */
-double Talon::Get() const { return GetSpeed(); }
+double frc::Talon::Get() const { return GetSpeed(); }
 
 /**
  * Common interface for disabling a motor.
  */
-void Talon::Disable() { SetRaw(kPwmDisabled); }
+void frc::Talon::Disable() { SetRaw(kPwmDisabled); }
 
 /**
  * Write out the PID value as seen in the PIDOutput base object.
  *
  * @param output Write out the PWM value as was found in the PIDController
  */
-void Talon::PIDWrite(double output) { Set(output); }
+void frc::Talon::PIDWrite(double output) { Set(output); }

--- a/wpilibc/sim/src/Timer.cpp
+++ b/wpilibc/sim/src/Timer.cpp
@@ -52,11 +52,11 @@ void Wait(double seconds) {
 /*
  * Return the FPGA system clock time in seconds.
  *
- * This is deprecated and just forwards to Timer::GetFPGATimestamp().
+ * This is deprecated and just forwards to frc::Timer::GetFPGATimestamp().
  *
  * @returns Robot running time in seconds.
  */
-double GetClock() { return Timer::GetFPGATimestamp(); }
+double GetClock() { return frc::Timer::GetFPGATimestamp(); }
 
 /**
  * @brief Gives real-time clock system time with nanosecond resolution
@@ -64,22 +64,21 @@ double GetClock() { return Timer::GetFPGATimestamp(); }
  *         on Saturday (except in simulation).
  */
 double GetTime() {
-  return Timer::GetFPGATimestamp();  // The epoch starts when Gazebo starts
+  return frc::Timer::GetFPGATimestamp();  // The epoch starts when Gazebo starts
 }
 
 }  // namespace frc
 
-using namespace frc;
-
 // for compatibility with msvc12--see C2864
-const double Timer::kRolloverTime = (1ll << 32) / 1e6;
+const double frc::Timer::kRolloverTime = (1ll << 32) / 1e6;
 /**
  * Create a new timer object.
  *
  * Create a new timer object and reset the time to zero. The timer is initially
  * not running and must be started.
  */
-Timer::Timer() : m_startTime(0.0), m_accumulatedTime(0.0), m_running(false) {
+frc::Timer::Timer()
+    : m_startTime(0.0), m_accumulatedTime(0.0), m_running(false) {
   // Creates a semaphore to control access to critical regions.
   // Initially 'open'
   Reset();
@@ -94,7 +93,7 @@ Timer::Timer() : m_startTime(0.0), m_accumulatedTime(0.0), m_running(false) {
  *
  * @return Current time value for this timer in seconds
  */
-double Timer::Get() const {
+double frc::Timer::Get() const {
   double result;
   double currentTime = GetFPGATimestamp();
 
@@ -116,7 +115,7 @@ double Timer::Get() const {
  * Make the timer startTime the current time so new requests will be relative to
  * now.
  */
-void Timer::Reset() {
+void frc::Timer::Reset() {
   std::lock_guard<hal::priority_mutex> sync(m_mutex);
   m_accumulatedTime = 0;
   m_startTime = GetFPGATimestamp();
@@ -128,7 +127,7 @@ void Timer::Reset() {
  * Just set the running flag to true indicating that all time requests should be
  * relative to the system clock.
  */
-void Timer::Start() {
+void frc::Timer::Start() {
   std::lock_guard<hal::priority_mutex> sync(m_mutex);
   if (!m_running) {
     m_startTime = GetFPGATimestamp();
@@ -143,7 +142,7 @@ void Timer::Start() {
  * subsequent time requests to be read from the accumulated time rather than
  * looking at the system clock.
  */
-void Timer::Stop() {
+void frc::Timer::Stop() {
   double temp = Get();
 
   std::lock_guard<hal::priority_mutex> sync(m_mutex);
@@ -161,7 +160,7 @@ void Timer::Stop() {
  * @param period The period to check for (in seconds).
  * @return If the period has passed.
  */
-bool Timer::HasPeriodPassed(double period) {
+bool frc::Timer::HasPeriodPassed(double period) {
   if (Get() > period) {
     std::lock_guard<hal::priority_mutex> sync(m_mutex);
     // Advance the start time by the period.
@@ -180,7 +179,7 @@ bool Timer::HasPeriodPassed(double period) {
  *
  * @return Robot running time in seconds.
  */
-double Timer::GetFPGATimestamp() {
+double frc::Timer::GetFPGATimestamp() {
   // FPGA returns the timestamp in microseconds
   // Call the helper GetFPGATime() in Utility.cpp
   return wpilib::internal::simTime;
@@ -189,4 +188,4 @@ double Timer::GetFPGATimestamp() {
 /*
  * Not in a match.
  */
-double Timer::GetMatchTime() { return Timer::GetFPGATimestamp(); }
+double frc::Timer::GetMatchTime() { return frc::Timer::GetFPGATimestamp(); }

--- a/wpilibc/sim/src/Utility.cpp
+++ b/wpilibc/sim/src/Utility.cpp
@@ -19,8 +19,6 @@
 #include "llvm/raw_ostream.h"
 #include "simulation/simTime.h"
 
-using namespace frc;
-
 static bool stackTraceEnabled = false;
 static bool suspendOnAssertEnabled = false;
 

--- a/wpilibc/sim/src/Victor.cpp
+++ b/wpilibc/sim/src/Victor.cpp
@@ -9,12 +9,10 @@
 
 #include "LiveWindow/LiveWindow.h"
 
-using namespace frc;
-
 /**
  * @param channel The PWM channel that the Victor is attached to.
  */
-Victor::Victor(int channel) : SafePWM(channel) {
+frc::Victor::Victor(int channel) : SafePWM(channel) {
   /* Note that the Victor uses the following bounds for PWM values. These values
    * were determined empirically and optimized for the Victor 888. These values
    * should work reasonably well for Victor 884 controllers as well but if users
@@ -45,23 +43,23 @@ Victor::Victor(int channel) : SafePWM(channel) {
  *
  * @param speed The speed value between -1.0 and 1.0 to set.
  */
-void Victor::Set(double speed) { SetSpeed(speed); }
+void frc::Victor::Set(double speed) { SetSpeed(speed); }
 
 /**
  * Get the recently set value of the PWM.
  *
  * @return The most recently set value for the PWM between -1.0 and 1.0.
  */
-double Victor::Get() const { return GetSpeed(); }
+double frc::Victor::Get() const { return GetSpeed(); }
 
 /**
  * Common interface for disabling a motor.
  */
-void Victor::Disable() { SetRaw(kPwmDisabled); }
+void frc::Victor::Disable() { SetRaw(kPwmDisabled); }
 
 /**
  * Write out the PID value as seen in the PIDOutput base object.
  *
  * @param output Write out the PWM value as was found in the PIDController
  */
-void Victor::PIDWrite(double output) { Set(output); }
+void frc::Victor::PIDWrite(double output) { Set(output); }

--- a/wpilibc/sim/src/XboxController.cpp
+++ b/wpilibc/sim/src/XboxController.cpp
@@ -9,8 +9,6 @@
 
 #include "DriverStation.h"
 
-using namespace frc;
-
 /**
  * Construct an instance of an Xbox controller.
  *
@@ -19,7 +17,7 @@ using namespace frc;
  * @param port The port on the Driver Station that the joystick is plugged into
  *             (0-5).
  */
-XboxController::XboxController(int port)
+frc::XboxController::XboxController(int port)
     : GamepadBase(port), m_ds(DriverStation::GetInstance()) {}
 
 /**
@@ -27,7 +25,7 @@ XboxController::XboxController(int port)
  *
  * @param hand Side of controller whose value should be returned.
  */
-double XboxController::GetX(JoystickHand hand) const {
+double frc::XboxController::GetX(JoystickHand hand) const {
   if (hand == kLeftHand) {
     return GetRawAxis(0);
   } else {
@@ -40,7 +38,7 @@ double XboxController::GetX(JoystickHand hand) const {
  *
  * @param hand Side of controller whose value should be returned.
  */
-double XboxController::GetY(JoystickHand hand) const {
+double frc::XboxController::GetY(JoystickHand hand) const {
   if (hand == kLeftHand) {
     return GetRawAxis(1);
   } else {
@@ -53,7 +51,7 @@ double XboxController::GetY(JoystickHand hand) const {
  *
  * @param hand Side of controller whose value should be returned.
  */
-bool XboxController::GetBumper(JoystickHand hand) const {
+bool frc::XboxController::GetBumper(JoystickHand hand) const {
   if (hand == kLeftHand) {
     return GetRawButton(5);
   } else {
@@ -67,7 +65,7 @@ bool XboxController::GetBumper(JoystickHand hand) const {
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetStickButton(JoystickHand hand) const {
+bool frc::XboxController::GetStickButton(JoystickHand hand) const {
   if (hand == kLeftHand) {
     return GetRawButton(9);
   } else {
@@ -80,7 +78,7 @@ bool XboxController::GetStickButton(JoystickHand hand) const {
  *
  * @param hand Side of controller whose value should be returned.
  */
-double XboxController::GetTriggerAxis(JoystickHand hand) const {
+double frc::XboxController::GetTriggerAxis(JoystickHand hand) const {
   if (hand == kLeftHand) {
     return GetRawAxis(2);
   } else {
@@ -94,7 +92,7 @@ double XboxController::GetTriggerAxis(JoystickHand hand) const {
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetAButton() const { return GetRawButton(1); }
+bool frc::XboxController::GetAButton() const { return GetRawButton(1); }
 
 /**
  * Read the value of the B button on the controller.
@@ -102,7 +100,7 @@ bool XboxController::GetAButton() const { return GetRawButton(1); }
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetBButton() const { return GetRawButton(2); }
+bool frc::XboxController::GetBButton() const { return GetRawButton(2); }
 
 /**
  * Read the value of the X button on the controller.
@@ -110,7 +108,7 @@ bool XboxController::GetBButton() const { return GetRawButton(2); }
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetXButton() const { return GetRawButton(3); }
+bool frc::XboxController::GetXButton() const { return GetRawButton(3); }
 
 /**
  * Read the value of the Y button on the controller.
@@ -118,7 +116,7 @@ bool XboxController::GetXButton() const { return GetRawButton(3); }
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetYButton() const { return GetRawButton(4); }
+bool frc::XboxController::GetYButton() const { return GetRawButton(4); }
 
 /**
  * Read the value of the back button on the controller.
@@ -126,7 +124,7 @@ bool XboxController::GetYButton() const { return GetRawButton(4); }
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetBackButton() const { return GetRawButton(7); }
+bool frc::XboxController::GetBackButton() const { return GetRawButton(7); }
 
 /**
  * Read the value of the start button on the controller.
@@ -134,4 +132,4 @@ bool XboxController::GetBackButton() const { return GetRawButton(7); }
  * @param hand Side of controller whose value should be returned.
  * @return The state of the button.
  */
-bool XboxController::GetStartButton() const { return GetRawButton(8); }
+bool frc::XboxController::GetStartButton() const { return GetRawButton(8); }

--- a/wpilibc/sim/src/simulation/SimContinuousOutput.cpp
+++ b/wpilibc/sim/src/simulation/SimContinuousOutput.cpp
@@ -10,17 +10,15 @@
 #include "llvm/raw_ostream.h"
 #include "simulation/MainNode.h"
 
-using namespace frc;
-
-SimContinuousOutput::SimContinuousOutput(std::string topic) {
+frc::SimContinuousOutput::SimContinuousOutput(std::string topic) {
   pub = MainNode::Advertise<gazebo::msgs::Float64>("~/simulator/" + topic);
   llvm::outs() << "Initialized ~/simulator/" + topic << "\n";
 }
 
-void SimContinuousOutput::Set(double speed) {
+void frc::SimContinuousOutput::Set(double speed) {
   gazebo::msgs::Float64 msg;
   msg.set_data(speed);
   pub->Publish(msg);
 }
 
-double SimContinuousOutput::Get() { return speed; }
+double frc::SimContinuousOutput::Get() { return speed; }

--- a/wpilibc/sim/src/simulation/SimDigitalInput.cpp
+++ b/wpilibc/sim/src/simulation/SimDigitalInput.cpp
@@ -10,16 +10,14 @@
 #include "llvm/raw_ostream.h"
 #include "simulation/MainNode.h"
 
-using namespace frc;
-
-SimDigitalInput::SimDigitalInput(std::string topic) {
+frc::SimDigitalInput::SimDigitalInput(std::string topic) {
   sub = MainNode::Subscribe("~/simulator/" + topic, &SimDigitalInput::callback,
                             this);
   llvm::outs() << "Initialized ~/simulator/" + topic << "\n";
 }
 
-bool SimDigitalInput::Get() { return value; }
+bool frc::SimDigitalInput::Get() { return value; }
 
-void SimDigitalInput::callback(const gazebo::msgs::ConstBoolPtr& msg) {
+void frc::SimDigitalInput::callback(const gazebo::msgs::ConstBoolPtr& msg) {
   value = msg->data();
 }

--- a/wpilibc/sim/src/simulation/SimEncoder.cpp
+++ b/wpilibc/sim/src/simulation/SimEncoder.cpp
@@ -10,16 +10,14 @@
 #include "llvm/raw_ostream.h"
 #include "simulation/MainNode.h"
 
-using namespace frc;
-
-SimEncoder::SimEncoder(std::string topic) {
+frc::SimEncoder::SimEncoder(std::string topic) {
   commandPub = MainNode::Advertise<gazebo::msgs::GzString>("~/simulator/" +
                                                            topic + "/control");
 
   posSub = MainNode::Subscribe("~/simulator/" + topic + "/position",
-                               &SimEncoder::positionCallback, this);
+                               &frc::SimEncoder::positionCallback, this);
   velSub = MainNode::Subscribe("~/simulator/" + topic + "/velocity",
-                               &SimEncoder::velocityCallback, this);
+                               &frc::SimEncoder::velocityCallback, this);
 
   if (commandPub->WaitForConnection(
           gazebo::common::Time(5.0))) {  // Wait up to five seconds.
@@ -30,26 +28,28 @@ SimEncoder::SimEncoder(std::string topic) {
   }
 }
 
-void SimEncoder::Reset() { sendCommand("reset"); }
+void frc::SimEncoder::Reset() { sendCommand("reset"); }
 
-void SimEncoder::Start() { sendCommand("start"); }
+void frc::SimEncoder::Start() { sendCommand("start"); }
 
-void SimEncoder::Stop() { sendCommand("stop"); }
+void frc::SimEncoder::Stop() { sendCommand("stop"); }
 
-double SimEncoder::GetPosition() { return position; }
+double frc::SimEncoder::GetPosition() { return position; }
 
-double SimEncoder::GetVelocity() { return velocity; }
+double frc::SimEncoder::GetVelocity() { return velocity; }
 
-void SimEncoder::sendCommand(std::string cmd) {
+void frc::SimEncoder::sendCommand(std::string cmd) {
   gazebo::msgs::GzString msg;
   msg.set_data(cmd);
   commandPub->Publish(msg);
 }
 
-void SimEncoder::positionCallback(const gazebo::msgs::ConstFloat64Ptr& msg) {
+void frc::SimEncoder::positionCallback(
+    const gazebo::msgs::ConstFloat64Ptr& msg) {
   position = msg->data();
 }
 
-void SimEncoder::velocityCallback(const gazebo::msgs::ConstFloat64Ptr& msg) {
+void frc::SimEncoder::velocityCallback(
+    const gazebo::msgs::ConstFloat64Ptr& msg) {
   velocity = msg->data();
 }

--- a/wpilibc/sim/src/simulation/SimFloatInput.cpp
+++ b/wpilibc/sim/src/simulation/SimFloatInput.cpp
@@ -10,16 +10,14 @@
 #include "llvm/raw_ostream.h"
 #include "simulation/MainNode.h"
 
-using namespace frc;
-
-SimFloatInput::SimFloatInput(std::string topic) {
+frc::SimFloatInput::SimFloatInput(std::string topic) {
   sub = MainNode::Subscribe("~/simulator/" + topic, &SimFloatInput::callback,
                             this);
   llvm::outs() << "Initialized ~/simulator/" + topic << "\n";
 }
 
-double SimFloatInput::Get() { return value; }
+double frc::SimFloatInput::Get() { return value; }
 
-void SimFloatInput::callback(const gazebo::msgs::ConstFloat64Ptr& msg) {
+void frc::SimFloatInput::callback(const gazebo::msgs::ConstFloat64Ptr& msg) {
   value = msg->data();
 }

--- a/wpilibc/sim/src/simulation/SimGyro.cpp
+++ b/wpilibc/sim/src/simulation/SimGyro.cpp
@@ -10,16 +10,14 @@
 #include "llvm/raw_ostream.h"
 #include "simulation/MainNode.h"
 
-using namespace frc;
-
-SimGyro::SimGyro(std::string topic) {
+frc::SimGyro::SimGyro(std::string topic) {
   commandPub = MainNode::Advertise<gazebo::msgs::GzString>("~/simulator/" +
                                                            topic + "/control");
 
   posSub = MainNode::Subscribe("~/simulator/" + topic + "/position",
-                               &SimGyro::positionCallback, this);
+                               &frc::SimGyro::positionCallback, this);
   velSub = MainNode::Subscribe("~/simulator/" + topic + "/velocity",
-                               &SimGyro::velocityCallback, this);
+                               &frc::SimGyro::velocityCallback, this);
 
   if (commandPub->WaitForConnection(
           gazebo::common::Time(5.0))) {  // Wait up to five seconds.
@@ -30,22 +28,22 @@ SimGyro::SimGyro(std::string topic) {
   }
 }
 
-void SimGyro::Reset() { sendCommand("reset"); }
+void frc::SimGyro::Reset() { sendCommand("reset"); }
 
-double SimGyro::GetAngle() { return position; }
+double frc::SimGyro::GetAngle() { return position; }
 
-double SimGyro::GetVelocity() { return velocity; }
+double frc::SimGyro::GetVelocity() { return velocity; }
 
-void SimGyro::sendCommand(std::string cmd) {
+void frc::SimGyro::sendCommand(std::string cmd) {
   gazebo::msgs::GzString msg;
   msg.set_data(cmd);
   commandPub->Publish(msg);
 }
 
-void SimGyro::positionCallback(const gazebo::msgs::ConstFloat64Ptr& msg) {
+void frc::SimGyro::positionCallback(const gazebo::msgs::ConstFloat64Ptr& msg) {
   position = msg->data();
 }
 
-void SimGyro::velocityCallback(const gazebo::msgs::ConstFloat64Ptr& msg) {
+void frc::SimGyro::velocityCallback(const gazebo::msgs::ConstFloat64Ptr& msg) {
   velocity = msg->data();
 }

--- a/wpilibcIntegrationTests/include/command/MockCommand.h
+++ b/wpilibcIntegrationTests/include/command/MockCommand.h
@@ -9,9 +9,7 @@
 
 #include "Commands/Command.h"
 
-namespace frc {
-
-class MockCommand : public Command {
+class MockCommand : public frc::Command {
  public:
   MockCommand();
   int32_t GetInitializeCount() { return m_initializeCount; }
@@ -42,5 +40,3 @@ class MockCommand : public Command {
   int32_t m_endCount;
   int32_t m_interruptedCount;
 };
-
-}  // namespace frc

--- a/wpilibcIntegrationTests/include/command/MockConditionalCommand.h
+++ b/wpilibcIntegrationTests/include/command/MockConditionalCommand.h
@@ -10,9 +10,7 @@
 #include "Commands/ConditionalCommand.h"
 #include "command/MockCommand.h"
 
-namespace frc {
-
-class MockConditionalCommand : public ConditionalCommand {
+class MockConditionalCommand : public frc::ConditionalCommand {
  public:
   MockConditionalCommand(MockCommand* onTrue, MockCommand* onFalse);
   void SetCondition(bool condition);
@@ -23,5 +21,3 @@ class MockConditionalCommand : public ConditionalCommand {
  private:
   bool m_condition = false;
 };
-
-}  // namespace frc

--- a/wpilibcIntegrationTests/src/AnalogLoopTest.cpp
+++ b/wpilibcIntegrationTests/src/AnalogLoopTest.cpp
@@ -13,8 +13,6 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 static const double kDelayTime = 0.01;
 
 /**
@@ -22,12 +20,12 @@ static const double kDelayTime = 0.01;
  */
 class AnalogLoopTest : public testing::Test {
  protected:
-  AnalogInput* m_input;
-  AnalogOutput* m_output;
+  frc::AnalogInput* m_input;
+  frc::AnalogOutput* m_output;
 
   void SetUp() override {
-    m_input = new AnalogInput(TestBench::kFakeAnalogOutputChannel);
-    m_output = new AnalogOutput(TestBench::kAnalogOutputChannel);
+    m_input = new frc::AnalogInput(TestBench::kFakeAnalogOutputChannel);
+    m_output = new frc::AnalogOutput(TestBench::kAnalogOutputChannel);
   }
 
   void TearDown() override {
@@ -45,7 +43,7 @@ TEST_F(AnalogLoopTest, AnalogInputWorks) {
   for (int32_t i = 0; i < 50; i++) {
     m_output->SetVoltage(i / 10.0);
 
-    Wait(kDelayTime);
+    frc::Wait(kDelayTime);
 
     EXPECT_NEAR(m_output->GetVoltage(), m_input->GetVoltage(), 0.01);
   }
@@ -56,25 +54,25 @@ TEST_F(AnalogLoopTest, AnalogInputWorks) {
  * range correctly.
  */
 TEST_F(AnalogLoopTest, AnalogTriggerWorks) {
-  AnalogTrigger trigger(m_input);
+  frc::AnalogTrigger trigger(m_input);
   trigger.SetLimitsVoltage(2.0, 3.0);
 
   m_output->SetVoltage(1.0);
-  Wait(kDelayTime);
+  frc::Wait(kDelayTime);
 
   EXPECT_FALSE(trigger.GetInWindow())
       << "Analog trigger is in the window (2V, 3V)";
   EXPECT_FALSE(trigger.GetTriggerState()) << "Analog trigger is on";
 
   m_output->SetVoltage(2.5);
-  Wait(kDelayTime);
+  frc::Wait(kDelayTime);
 
   EXPECT_TRUE(trigger.GetInWindow())
       << "Analog trigger is not in the window (2V, 3V)";
   EXPECT_FALSE(trigger.GetTriggerState()) << "Analog trigger is on";
 
   m_output->SetVoltage(4.0);
-  Wait(kDelayTime);
+  frc::Wait(kDelayTime);
 
   EXPECT_FALSE(trigger.GetInWindow())
       << "Analog trigger is in the window (2V, 3V)";
@@ -86,17 +84,17 @@ TEST_F(AnalogLoopTest, AnalogTriggerWorks) {
  * a counter.
  */
 TEST_F(AnalogLoopTest, AnalogTriggerCounterWorks) {
-  AnalogTrigger trigger(m_input);
+  frc::AnalogTrigger trigger(m_input);
   trigger.SetLimitsVoltage(2.0, 3.0);
 
-  Counter counter(trigger);
+  frc::Counter counter(trigger);
 
   // Turn the analog output low and high 50 times
   for (int32_t i = 0; i < 50; i++) {
     m_output->SetVoltage(1.0);
-    Wait(kDelayTime);
+    frc::Wait(kDelayTime);
     m_output->SetVoltage(4.0);
-    Wait(kDelayTime);
+    frc::Wait(kDelayTime);
   }
 
   // The counter should be 50
@@ -110,22 +108,22 @@ static void InterruptHandler(uint32_t interruptAssertedMask, void* param) {
 
 TEST_F(AnalogLoopTest, AsynchronusInterruptWorks) {
   int32_t param = 0;
-  AnalogTrigger trigger(m_input);
+  frc::AnalogTrigger trigger(m_input);
   trigger.SetLimitsVoltage(2.0, 3.0);
 
   // Given an interrupt handler that sets an int32_t to 12345
-  std::shared_ptr<AnalogTriggerOutput> triggerOutput =
-      trigger.CreateOutput(AnalogTriggerType::kState);
+  std::shared_ptr<frc::AnalogTriggerOutput> triggerOutput =
+      trigger.CreateOutput(frc::AnalogTriggerType::kState);
   triggerOutput->RequestInterrupts(InterruptHandler, &param);
   triggerOutput->EnableInterrupts();
 
   // If the analog output moves from below to above the window
   m_output->SetVoltage(0.0);
-  Wait(kDelayTime);
+  frc::Wait(kDelayTime);
   m_output->SetVoltage(5.0);
   triggerOutput->CancelInterrupts();
 
   // Then the int32_t should be 12345
-  Wait(kDelayTime);
+  frc::Wait(kDelayTime);
   EXPECT_EQ(12345, param) << "The interrupt did not run.";
 }

--- a/wpilibcIntegrationTests/src/AnalogPotentiometerTest.cpp
+++ b/wpilibcIntegrationTests/src/AnalogPotentiometerTest.cpp
@@ -13,20 +13,18 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 static const double kScale = 270.0;
 static const double kAngle = 180.0;
 
 class AnalogPotentiometerTest : public testing::Test {
  protected:
-  AnalogOutput* m_fakePot;
-  AnalogPotentiometer* m_pot;
+  frc::AnalogOutput* m_fakePot;
+  frc::AnalogPotentiometer* m_pot;
 
   void SetUp() override {
-    m_fakePot = new AnalogOutput(TestBench::kAnalogOutputChannel);
-    m_pot =
-        new AnalogPotentiometer(TestBench::kFakeAnalogOutputChannel, kScale);
+    m_fakePot = new frc::AnalogOutput(TestBench::kAnalogOutputChannel);
+    m_pot = new frc::AnalogPotentiometer(TestBench::kFakeAnalogOutputChannel,
+                                         kScale);
   }
 
   void TearDown() override {
@@ -37,14 +35,14 @@ class AnalogPotentiometerTest : public testing::Test {
 
 TEST_F(AnalogPotentiometerTest, TestInitialSettings) {
   m_fakePot->SetVoltage(0.0);
-  Wait(0.1);
+  frc::Wait(0.1);
   EXPECT_NEAR(0.0, m_pot->Get(), 5.0)
       << "The potentiometer did not initialize to 0.";
 }
 
 TEST_F(AnalogPotentiometerTest, TestRangeValues) {
-  m_fakePot->SetVoltage(kAngle / kScale * ControllerPower::GetVoltage5V());
-  Wait(0.1);
+  m_fakePot->SetVoltage(kAngle / kScale * frc::ControllerPower::GetVoltage5V());
+  frc::Wait(0.1);
   EXPECT_NEAR(kAngle, m_pot->Get(), 2.0)
       << "The potentiometer did not measure the correct angle.";
 }

--- a/wpilibcIntegrationTests/src/BuiltInAccelerometerTest.cpp
+++ b/wpilibcIntegrationTests/src/BuiltInAccelerometerTest.cpp
@@ -10,19 +10,17 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 static constexpr double kAccelerationTolerance = 0.1;
 /**
  * There's not much we can automatically test with the on-board accelerometer,
  * but checking for gravity is probably good enough to tell that it's working.
  */
 TEST(BuiltInAccelerometerTest, Accelerometer) {
-  BuiltInAccelerometer accelerometer;
+  frc::BuiltInAccelerometer accelerometer;
 
   /* The testbench sometimes shakes a little from a previous test.  Give it
           some time. */
-  Wait(1.0);
+  frc::Wait(1.0);
 
   ASSERT_NEAR(0.0, accelerometer.GetX(), kAccelerationTolerance);
   ASSERT_NEAR(1.0, accelerometer.GetY(), kAccelerationTolerance);

--- a/wpilibcIntegrationTests/src/CircularBufferTest.cpp
+++ b/wpilibcIntegrationTests/src/CircularBufferTest.cpp
@@ -11,8 +11,6 @@
 
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 static const std::array<double, 10> values = {
     751.848, 766.366, 342.657, 234.252, 716.126,
     132.344, 445.697, 22.727,  421.125, 799.913};
@@ -24,7 +22,7 @@ static const std::array<double, 8> pushBackOut = {
     342.657, 234.252, 716.126, 132.344, 445.697, 22.727, 421.125, 799.913};
 
 TEST(CircularBufferTest, PushFrontTest) {
-  CircularBuffer<double> queue(8);
+  frc::CircularBuffer<double> queue(8);
 
   for (auto& value : values) {
     queue.PushFront(value);
@@ -36,7 +34,7 @@ TEST(CircularBufferTest, PushFrontTest) {
 }
 
 TEST(CircularBufferTest, PushBackTest) {
-  CircularBuffer<double> queue(8);
+  frc::CircularBuffer<double> queue(8);
 
   for (auto& value : values) {
     queue.PushBack(value);
@@ -48,7 +46,7 @@ TEST(CircularBufferTest, PushBackTest) {
 }
 
 TEST(CircularBufferTest, PushPopTest) {
-  CircularBuffer<double> queue(3);
+  frc::CircularBuffer<double> queue(3);
 
   // Insert three elements into the buffer
   queue.PushBack(1.0);
@@ -91,7 +89,7 @@ TEST(CircularBufferTest, PushPopTest) {
 }
 
 TEST(CircularBufferTest, ResetTest) {
-  CircularBuffer<double> queue(5);
+  frc::CircularBuffer<double> queue(5);
 
   for (size_t i = 1; i < 6; i++) {
     queue.PushBack(i);
@@ -105,7 +103,7 @@ TEST(CircularBufferTest, ResetTest) {
 }
 
 TEST(CircularBufferTest, ResizeTest) {
-  CircularBuffer<double> queue(5);
+  frc::CircularBuffer<double> queue(5);
 
   /* Buffer contains {1, 2, 3, _, _}
    *                  ^ front

--- a/wpilibcIntegrationTests/src/CounterTest.cpp
+++ b/wpilibcIntegrationTests/src/CounterTest.cpp
@@ -14,28 +14,26 @@
 #include "Victor.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 static const double kMotorDelay = 2.5;
 
 static const double kMaxPeriod = 2.0;
 
 class CounterTest : public testing::Test {
  protected:
-  Counter* m_talonCounter;
-  Counter* m_victorCounter;
-  Counter* m_jaguarCounter;
-  Talon* m_talon;
-  Victor* m_victor;
-  Jaguar* m_jaguar;
+  frc::Counter* m_talonCounter;
+  frc::Counter* m_victorCounter;
+  frc::Counter* m_jaguarCounter;
+  frc::Talon* m_talon;
+  frc::Victor* m_victor;
+  frc::Jaguar* m_jaguar;
 
   void SetUp() override {
-    m_talonCounter = new Counter(TestBench::kTalonEncoderChannelA);
-    m_victorCounter = new Counter(TestBench::kVictorEncoderChannelA);
-    m_jaguarCounter = new Counter(TestBench::kJaguarEncoderChannelA);
-    m_victor = new Victor(TestBench::kVictorChannel);
-    m_talon = new Talon(TestBench::kTalonChannel);
-    m_jaguar = new Jaguar(TestBench::kJaguarChannel);
+    m_talonCounter = new frc::Counter(TestBench::kTalonEncoderChannelA);
+    m_victorCounter = new frc::Counter(TestBench::kVictorEncoderChannelA);
+    m_jaguarCounter = new frc::Counter(TestBench::kJaguarEncoderChannelA);
+    m_victor = new frc::Victor(TestBench::kVictorChannel);
+    m_talon = new frc::Talon(TestBench::kTalonChannel);
+    m_jaguar = new frc::Jaguar(TestBench::kJaguarChannel);
   }
 
   void TearDown() override {
@@ -65,11 +63,11 @@ TEST_F(CounterTest, CountTalon) {
   Reset();
   /* Run the motor forward and determine if the counter is counting. */
   m_talon->Set(1.0);
-  Wait(0.5);
+  frc::Wait(0.5);
   EXPECT_NE(0.0, m_talonCounter->Get()) << "The counter did not count (talon)";
   /* Set the motor to 0 and determine if the counter resets to 0. */
   m_talon->Set(0.0);
-  Wait(0.5);
+  frc::Wait(0.5);
   m_talonCounter->Reset();
   EXPECT_FLOAT_EQ(0.0, m_talonCounter->Get())
       << "The counter did not restart to 0 (talon)";
@@ -79,12 +77,12 @@ TEST_F(CounterTest, CountVictor) {
   Reset();
   /* Run the motor forward and determine if the counter is counting. */
   m_victor->Set(1.0);
-  Wait(0.5);
+  frc::Wait(0.5);
   EXPECT_NE(0.0, m_victorCounter->Get())
       << "The counter did not count (victor)";
   /* Set the motor to 0 and determine if the counter resets to 0. */
   m_victor->Set(0.0);
-  Wait(0.5);
+  frc::Wait(0.5);
   m_victorCounter->Reset();
   EXPECT_FLOAT_EQ(0.0, m_victorCounter->Get())
       << "The counter did not restart to 0 (jaguar)";
@@ -94,12 +92,12 @@ TEST_F(CounterTest, CountJaguar) {
   Reset();
   /* Run the motor forward and determine if the counter is counting. */
   m_jaguar->Set(1.0);
-  Wait(0.5);
+  frc::Wait(0.5);
   EXPECT_NE(0.0, m_jaguarCounter->Get())
       << "The counter did not count (jaguar)";
   /* Set the motor to 0 and determine if the counter resets to 0. */
   m_jaguar->Set(0.0);
-  Wait(0.5);
+  frc::Wait(0.5);
   m_jaguarCounter->Reset();
   EXPECT_FLOAT_EQ(0.0, m_jaguarCounter->Get())
       << "The counter did not restart to 0 (jaguar)";
@@ -114,11 +112,11 @@ TEST_F(CounterTest, TalonGetStopped) {
   /* Set the Max Period of the counter and run the motor */
   m_talonCounter->SetMaxPeriod(kMaxPeriod);
   m_talon->Set(1.0);
-  Wait(0.5);
+  frc::Wait(0.5);
   EXPECT_FALSE(m_talonCounter->GetStopped()) << "The counter did not count.";
   /* Stop the motor and wait until the Max Period is exceeded */
   m_talon->Set(0.0);
-  Wait(kMotorDelay);
+  frc::Wait(kMotorDelay);
   EXPECT_TRUE(m_talonCounter->GetStopped())
       << "The counter did not stop counting.";
 }
@@ -128,11 +126,11 @@ TEST_F(CounterTest, VictorGetStopped) {
   /* Set the Max Period of the counter and run the motor */
   m_victorCounter->SetMaxPeriod(kMaxPeriod);
   m_victor->Set(1.0);
-  Wait(0.5);
+  frc::Wait(0.5);
   EXPECT_FALSE(m_victorCounter->GetStopped()) << "The counter did not count.";
   /* Stop the motor and wait until the Max Period is exceeded */
   m_victor->Set(0.0);
-  Wait(kMotorDelay);
+  frc::Wait(kMotorDelay);
   EXPECT_TRUE(m_victorCounter->GetStopped())
       << "The counter did not stop counting.";
 }
@@ -142,11 +140,11 @@ TEST_F(CounterTest, JaguarGetStopped) {
   /* Set the Max Period of the counter and run the motor */
   m_jaguarCounter->SetMaxPeriod(kMaxPeriod);
   m_jaguar->Set(1.0);
-  Wait(0.5);
+  frc::Wait(0.5);
   EXPECT_FALSE(m_jaguarCounter->GetStopped()) << "The counter did not count.";
   /* Stop the motor and wait until the Max Period is exceeded */
   m_jaguar->Set(0.0);
-  Wait(kMotorDelay);
+  frc::Wait(kMotorDelay);
   EXPECT_TRUE(m_jaguarCounter->GetStopped())
       << "The counter did not stop counting.";
 }

--- a/wpilibcIntegrationTests/src/DIOLoopTest.cpp
+++ b/wpilibcIntegrationTests/src/DIOLoopTest.cpp
@@ -14,8 +14,6 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 static const double kCounterTime = 0.001;
 
 static const double kDelayTime = 0.1;
@@ -29,12 +27,12 @@ static const double kSynchronousInterruptTimeTolerance = 0.01;
  */
 class DIOLoopTest : public testing::Test {
  protected:
-  DigitalInput* m_input;
-  DigitalOutput* m_output;
+  frc::DigitalInput* m_input;
+  frc::DigitalOutput* m_output;
 
   void SetUp() override {
-    m_input = new DigitalInput(TestBench::kLoop1InputChannel);
-    m_output = new DigitalOutput(TestBench::kLoop1OutputChannel);
+    m_input = new frc::DigitalInput(TestBench::kLoop1InputChannel);
+    m_output = new frc::DigitalOutput(TestBench::kLoop1OutputChannel);
   }
 
   void TearDown() override {
@@ -53,12 +51,12 @@ TEST_F(DIOLoopTest, Loop) {
   Reset();
 
   m_output->Set(false);
-  Wait(kDelayTime);
+  frc::Wait(kDelayTime);
   EXPECT_FALSE(m_input->Get()) << "The digital output was turned off, but "
                                << "the digital input is on.";
 
   m_output->Set(true);
-  Wait(kDelayTime);
+  frc::Wait(kDelayTime);
   EXPECT_TRUE(m_input->Get()) << "The digital output was turned on, but "
                               << "the digital input is off.";
 }
@@ -69,7 +67,7 @@ TEST_F(DIOLoopTest, DIOPWM) {
   Reset();
 
   m_output->Set(false);
-  Wait(kDelayTime);
+  frc::Wait(kDelayTime);
   EXPECT_FALSE(m_input->Get()) << "The digital output was turned off, but "
                                << "the digital input is on.";
 
@@ -77,34 +75,34 @@ TEST_F(DIOLoopTest, DIOPWM) {
   m_output->SetPWMRate(2.0);
   // Enable PWM, but leave it off
   m_output->EnablePWM(0.0);
-  Wait(0.5);
+  frc::Wait(0.5);
   m_output->UpdateDutyCycle(0.5);
   m_input->RequestInterrupts();
   m_input->SetUpSourceEdge(false, true);
-  InterruptableSensorBase::WaitResult result =
+  frc::InterruptableSensorBase::WaitResult result =
       m_input->WaitForInterrupt(3.0, true);
 
-  Wait(0.5);
+  frc::Wait(0.5);
   bool firstCycle = m_input->Get();
-  Wait(0.5);
+  frc::Wait(0.5);
   bool secondCycle = m_input->Get();
-  Wait(0.5);
+  frc::Wait(0.5);
   bool thirdCycle = m_input->Get();
-  Wait(0.5);
+  frc::Wait(0.5);
   bool forthCycle = m_input->Get();
-  Wait(0.5);
+  frc::Wait(0.5);
   bool fifthCycle = m_input->Get();
-  Wait(0.5);
+  frc::Wait(0.5);
   bool sixthCycle = m_input->Get();
-  Wait(0.5);
+  frc::Wait(0.5);
   bool seventhCycle = m_input->Get();
   m_output->DisablePWM();
-  Wait(0.5);
+  frc::Wait(0.5);
   bool firstAfterStop = m_input->Get();
-  Wait(0.5);
+  frc::Wait(0.5);
   bool secondAfterStop = m_input->Get();
 
-  EXPECT_EQ(InterruptableSensorBase::WaitResult::kFallingEdge, result)
+  EXPECT_EQ(frc::InterruptableSensorBase::WaitResult::kFallingEdge, result)
       << "WaitForInterrupt was not falling.";
 
   EXPECT_FALSE(firstCycle) << "Input not low after first delay";
@@ -125,16 +123,16 @@ TEST_F(DIOLoopTest, DIOPWM) {
 TEST_F(DIOLoopTest, FakeCounter) {
   Reset();
 
-  Counter counter(m_input);
+  frc::Counter counter(m_input);
 
   EXPECT_EQ(0, counter.Get()) << "Counter did not initialize to 0.";
 
   /* Count 100 ticks.  The counter value should be 100 after this loop. */
   for (int32_t i = 0; i < 100; i++) {
     m_output->Set(true);
-    Wait(kCounterTime);
+    frc::Wait(kCounterTime);
     m_output->Set(false);
-    Wait(kCounterTime);
+    frc::Wait(kCounterTime);
   }
 
   EXPECT_EQ(100, counter.Get()) << "Counter did not count up to 100.";
@@ -157,14 +155,14 @@ TEST_F(DIOLoopTest, AsynchronousInterruptWorks) {
   m_input->CancelInterrupts();
 
   // Then the int32_t should be 12345
-  Wait(kDelayTime);
+  frc::Wait(kDelayTime);
   EXPECT_EQ(12345, param) << "The interrupt did not run.";
 }
 
 static void* InterruptTriggerer(void* data) {
-  DigitalOutput* output = static_cast<DigitalOutput*>(data);
+  frc::DigitalOutput* output = static_cast<frc::DigitalOutput*>(data);
   output->Set(false);
-  Wait(kSynchronousInterruptTime);
+  frc::Wait(kSynchronousInterruptTime);
   output->Set(true);
   return nullptr;
 }
@@ -179,7 +177,7 @@ TEST_F(DIOLoopTest, SynchronousInterruptWorks) {
                  m_output);
 
   // Then this thread should pause and resume after that number of seconds
-  Timer timer;
+  frc::Timer timer;
   timer.Start();
   m_input->WaitForInterrupt(kSynchronousInterruptTime + 1.0);
   EXPECT_NEAR(kSynchronousInterruptTime, timer.Get(),

--- a/wpilibcIntegrationTests/src/DigitalGlitchFilterTest.cpp
+++ b/wpilibcIntegrationTests/src/DigitalGlitchFilterTest.cpp
@@ -12,8 +12,6 @@
 #include "Encoder.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 /**
  * Tests that configuring inputs to be filtered succeeds.
  *
@@ -22,27 +20,27 @@ using namespace frc;
  * make sure that the acutal configuration matches.
  */
 TEST(DigitalGlitchFilterTest, BasicTest) {
-  DigitalInput input1(1);
-  DigitalInput input2(2);
-  DigitalInput input3(3);
-  DigitalInput input4(4);
-  Encoder encoder5(5, 6);
-  Counter counter7(7);
+  frc::DigitalInput input1(1);
+  frc::DigitalInput input2(2);
+  frc::DigitalInput input3(3);
+  frc::DigitalInput input4(4);
+  frc::Encoder encoder5(5, 6);
+  frc::Counter counter7(7);
 
   // Check that we can make a single filter and set the period.
-  DigitalGlitchFilter filter1;
+  frc::DigitalGlitchFilter filter1;
   filter1.Add(&input1);
   filter1.SetPeriodNanoSeconds(4200);
 
   // Check that we can make a second filter with 2 inputs.
-  DigitalGlitchFilter filter2;
+  frc::DigitalGlitchFilter filter2;
   filter2.Add(&input2);
   filter2.Add(&input3);
   filter2.SetPeriodNanoSeconds(97100);
 
   // Check that we can make a third filter with an input, an encoder, and a
   // counter.
-  DigitalGlitchFilter filter3;
+  frc::DigitalGlitchFilter filter3;
   filter3.Add(&input4);
   filter3.Add(&encoder5);
   filter3.Add(&counter7);

--- a/wpilibcIntegrationTests/src/DriverStationTest.cpp
+++ b/wpilibcIntegrationTests/src/DriverStationTest.cpp
@@ -11,8 +11,6 @@
 #include "Utility.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 constexpr double TIMER_TOLERANCE = 0.2;
 constexpr int64_t TIMER_RUNTIME = 1000000;  // 1 second
 
@@ -22,13 +20,13 @@ class DriverStationTest : public testing::Test {};
  * Test if the WaitForData function works
  */
 TEST_F(DriverStationTest, WaitForData) {
-  uint64_t initialTime = GetFPGATime();
+  uint64_t initialTime = frc::GetFPGATime();
 
   for (int i = 0; i < 50; i++) {
-    DriverStation::GetInstance().WaitForData();
+    frc::DriverStation::GetInstance().WaitForData();
   }
 
-  uint64_t finalTime = GetFPGATime();
+  uint64_t finalTime = frc::GetFPGATime();
 
   EXPECT_NEAR(TIMER_RUNTIME, finalTime - initialTime,
               TIMER_TOLERANCE * TIMER_RUNTIME);

--- a/wpilibcIntegrationTests/src/FakeEncoderTest.cpp
+++ b/wpilibcIntegrationTests/src/FakeEncoderTest.cpp
@@ -14,33 +14,31 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 static const double kDelayTime = 0.001;
 
 class FakeEncoderTest : public testing::Test {
  protected:
-  DigitalOutput* m_outputA;
-  DigitalOutput* m_outputB;
-  AnalogOutput* m_indexOutput;
+  frc::DigitalOutput* m_outputA;
+  frc::DigitalOutput* m_outputB;
+  frc::AnalogOutput* m_indexOutput;
 
-  Encoder* m_encoder;
-  AnalogTrigger* m_indexAnalogTrigger;
-  std::shared_ptr<AnalogTriggerOutput> m_indexAnalogTriggerOutput;
+  frc::Encoder* m_encoder;
+  frc::AnalogTrigger* m_indexAnalogTrigger;
+  std::shared_ptr<frc::AnalogTriggerOutput> m_indexAnalogTriggerOutput;
 
   void SetUp() override {
-    m_outputA = new DigitalOutput(TestBench::kLoop2OutputChannel);
-    m_outputB = new DigitalOutput(TestBench::kLoop1OutputChannel);
-    m_indexOutput = new AnalogOutput(TestBench::kAnalogOutputChannel);
+    m_outputA = new frc::DigitalOutput(TestBench::kLoop2OutputChannel);
+    m_outputB = new frc::DigitalOutput(TestBench::kLoop1OutputChannel);
+    m_indexOutput = new frc::AnalogOutput(TestBench::kAnalogOutputChannel);
     m_outputA->Set(false);
     m_outputB->Set(false);
-    m_encoder = new Encoder(TestBench::kLoop1InputChannel,
-                            TestBench::kLoop2InputChannel);
+    m_encoder = new frc::Encoder(TestBench::kLoop1InputChannel,
+                                 TestBench::kLoop2InputChannel);
     m_indexAnalogTrigger =
-        new AnalogTrigger(TestBench::kFakeAnalogOutputChannel);
+        new frc::AnalogTrigger(TestBench::kFakeAnalogOutputChannel);
     m_indexAnalogTrigger->SetLimitsVoltage(2.0, 3.0);
     m_indexAnalogTriggerOutput =
-        m_indexAnalogTrigger->CreateOutput(AnalogTriggerType::kState);
+        m_indexAnalogTrigger->CreateOutput(frc::AnalogTriggerType::kState);
   }
 
   void TearDown() override {
@@ -58,24 +56,24 @@ class FakeEncoderTest : public testing::Test {
   void Simulate100QuadratureTicks() {
     for (int32_t i = 0; i < 100; i++) {
       m_outputA->Set(true);
-      Wait(kDelayTime);
+      frc::Wait(kDelayTime);
       m_outputB->Set(true);
-      Wait(kDelayTime);
+      frc::Wait(kDelayTime);
       m_outputA->Set(false);
-      Wait(kDelayTime);
+      frc::Wait(kDelayTime);
       m_outputB->Set(false);
-      Wait(kDelayTime);
+      frc::Wait(kDelayTime);
     }
   }
 
   void SetIndexHigh() {
     m_indexOutput->SetVoltage(5.0);
-    Wait(kDelayTime);
+    frc::Wait(kDelayTime);
   }
 
   void SetIndexLow() {
     m_indexOutput->SetVoltage(0.0);
-    Wait(kDelayTime);
+    frc::Wait(kDelayTime);
   }
 };
 
@@ -101,7 +99,7 @@ TEST_F(FakeEncoderTest, TestCountUp) {
  */
 TEST_F(FakeEncoderTest, TestResetWhileHigh) {
   m_encoder->SetIndexSource(*m_indexAnalogTriggerOutput,
-                            Encoder::IndexingType::kResetWhileHigh);
+                            frc::Encoder::IndexingType::kResetWhileHigh);
 
   SetIndexLow();
   Simulate100QuadratureTicks();
@@ -117,7 +115,7 @@ TEST_F(FakeEncoderTest, TestResetWhileHigh) {
  */
 TEST_F(FakeEncoderTest, TestResetOnRisingEdge) {
   m_encoder->SetIndexSource(*m_indexAnalogTriggerOutput,
-                            Encoder::IndexingType::kResetOnRisingEdge);
+                            frc::Encoder::IndexingType::kResetOnRisingEdge);
 
   SetIndexLow();
   Simulate100QuadratureTicks();
@@ -133,7 +131,7 @@ TEST_F(FakeEncoderTest, TestResetOnRisingEdge) {
  */
 TEST_F(FakeEncoderTest, TestResetWhileLow) {
   m_encoder->SetIndexSource(*m_indexAnalogTriggerOutput,
-                            Encoder::IndexingType::kResetWhileLow);
+                            frc::Encoder::IndexingType::kResetWhileLow);
 
   SetIndexHigh();
   Simulate100QuadratureTicks();
@@ -149,7 +147,7 @@ TEST_F(FakeEncoderTest, TestResetWhileLow) {
  */
 TEST_F(FakeEncoderTest, TestResetOnFallingEdge) {
   m_encoder->SetIndexSource(*m_indexAnalogTriggerOutput,
-                            Encoder::IndexingType::kResetOnFallingEdge);
+                            frc::Encoder::IndexingType::kResetOnFallingEdge);
 
   SetIndexHigh();
   Simulate100QuadratureTicks();

--- a/wpilibcIntegrationTests/src/FilterNoiseTest.cpp
+++ b/wpilibcIntegrationTests/src/FilterNoiseTest.cpp
@@ -17,8 +17,6 @@
 #include "TestBench.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 enum FilterNoiseTestType { TEST_SINGLE_POLE_IIR, TEST_MOVAVG };
 
 std::ostream& operator<<(std::ostream& os, const FilterNoiseTestType& type) {
@@ -34,22 +32,20 @@ std::ostream& operator<<(std::ostream& os, const FilterNoiseTestType& type) {
   return os;
 }
 
-using std::chrono::system_clock;
-
 constexpr double kStdDev = 10.0;
 
 /**
  * Adds Gaussian white noise to a function returning data. The noise will have
  * the standard deviation provided in the constructor.
  */
-class NoiseGenerator : public PIDSource {
+class NoiseGenerator : public frc::PIDSource {
  public:
   NoiseGenerator(double (*dataFunc)(double), double stdDev)
       : m_distr(0.0, stdDev) {
     m_dataFunc = dataFunc;
   }
 
-  void SetPIDSourceType(PIDSourceType pidSource) override {}
+  void SetPIDSourceType(frc::PIDSourceType pidSource) override {}
 
   double Get() { return m_dataFunc(m_count) + m_noise; }
 
@@ -78,7 +74,7 @@ class NoiseGenerator : public PIDSource {
  */
 class FilterNoiseTest : public testing::TestWithParam<FilterNoiseTestType> {
  protected:
-  std::unique_ptr<PIDSource> m_filter;
+  std::unique_ptr<frc::PIDSource> m_filter;
   std::shared_ptr<NoiseGenerator> m_noise;
 
   static double GetData(double t) { return 100.0 * std::sin(2.0 * M_PI * t); }
@@ -88,17 +84,17 @@ class FilterNoiseTest : public testing::TestWithParam<FilterNoiseTestType> {
 
     switch (GetParam()) {
       case TEST_SINGLE_POLE_IIR: {
-        m_filter = std::make_unique<LinearDigitalFilter>(
-            LinearDigitalFilter::SinglePoleIIR(
+        m_filter = std::make_unique<frc::LinearDigitalFilter>(
+            frc::LinearDigitalFilter::SinglePoleIIR(
                 m_noise, TestBench::kSinglePoleIIRTimeConstant,
                 TestBench::kFilterStep));
         break;
       }
 
       case TEST_MOVAVG: {
-        m_filter = std::make_unique<LinearDigitalFilter>(
-            LinearDigitalFilter::MovingAverage(m_noise,
-                                               TestBench::kMovAvgTaps));
+        m_filter = std::make_unique<frc::LinearDigitalFilter>(
+            frc::LinearDigitalFilter::MovingAverage(m_noise,
+                                                    TestBench::kMovAvgTaps));
         break;
       }
     }

--- a/wpilibcIntegrationTests/src/FilterOutputTest.cpp
+++ b/wpilibcIntegrationTests/src/FilterOutputTest.cpp
@@ -17,8 +17,6 @@
 #include "TestBench.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 enum FilterOutputTestType { TEST_SINGLE_POLE_IIR, TEST_HIGH_PASS, TEST_MOVAVG };
 
 std::ostream& operator<<(std::ostream& os, const FilterOutputTestType& type) {
@@ -37,11 +35,11 @@ std::ostream& operator<<(std::ostream& os, const FilterOutputTestType& type) {
   return os;
 }
 
-class DataWrapper : public PIDSource {
+class DataWrapper : public frc::PIDSource {
  public:
   explicit DataWrapper(double (*dataFunc)(double)) { m_dataFunc = dataFunc; }
 
-  virtual void SetPIDSourceType(PIDSourceType pidSource) {}
+  virtual void SetPIDSourceType(frc::PIDSourceType pidSource) {}
 
   virtual double PIDGet() {
     m_count += TestBench::kFilterStep;
@@ -62,7 +60,7 @@ class DataWrapper : public PIDSource {
  */
 class FilterOutputTest : public testing::TestWithParam<FilterOutputTestType> {
  protected:
-  std::unique_ptr<PIDSource> m_filter;
+  std::unique_ptr<frc::PIDSource> m_filter;
   std::shared_ptr<DataWrapper> m_data;
   double m_expectedOutput = 0.0;
 
@@ -75,8 +73,8 @@ class FilterOutputTest : public testing::TestWithParam<FilterOutputTestType> {
 
     switch (GetParam()) {
       case TEST_SINGLE_POLE_IIR: {
-        m_filter = std::make_unique<LinearDigitalFilter>(
-            LinearDigitalFilter::SinglePoleIIR(
+        m_filter = std::make_unique<frc::LinearDigitalFilter>(
+            frc::LinearDigitalFilter::SinglePoleIIR(
                 m_data, TestBench::kSinglePoleIIRTimeConstant,
                 TestBench::kFilterStep));
         m_expectedOutput = TestBench::kSinglePoleIIRExpectedOutput;
@@ -84,17 +82,18 @@ class FilterOutputTest : public testing::TestWithParam<FilterOutputTestType> {
       }
 
       case TEST_HIGH_PASS: {
-        m_filter =
-            std::make_unique<LinearDigitalFilter>(LinearDigitalFilter::HighPass(
-                m_data, TestBench::kHighPassTimeConstant,
-                TestBench::kFilterStep));
+        m_filter = std::make_unique<frc::LinearDigitalFilter>(
+            frc::LinearDigitalFilter::HighPass(m_data,
+                                               TestBench::kHighPassTimeConstant,
+                                               TestBench::kFilterStep));
         m_expectedOutput = TestBench::kHighPassExpectedOutput;
         break;
       }
 
       case TEST_MOVAVG: {
-        m_filter = std::make_unique<LinearDigitalFilter>(
-            LinearDigitalFilter::MovingAverage(m_data, TestBench::kMovAvgTaps));
+        m_filter = std::make_unique<frc::LinearDigitalFilter>(
+            frc::LinearDigitalFilter::MovingAverage(m_data,
+                                                    TestBench::kMovAvgTaps));
         m_expectedOutput = TestBench::kMovAvgExpectedOutput;
         break;
       }

--- a/wpilibcIntegrationTests/src/MotorEncoderTest.cpp
+++ b/wpilibcIntegrationTests/src/MotorEncoderTest.cpp
@@ -14,8 +14,6 @@
 #include "Victor.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 enum MotorEncoderTestType { TEST_VICTOR, TEST_JAGUAR, TEST_TALON };
 
 std::ostream& operator<<(std::ostream& os, MotorEncoderTestType const& type) {
@@ -42,27 +40,27 @@ static constexpr double kMotorTime = 0.5;
  */
 class MotorEncoderTest : public testing::TestWithParam<MotorEncoderTestType> {
  protected:
-  SpeedController* m_speedController;
-  Encoder* m_encoder;
+  frc::SpeedController* m_speedController;
+  frc::Encoder* m_encoder;
 
   void SetUp() override {
     switch (GetParam()) {
       case TEST_VICTOR:
-        m_speedController = new Victor(TestBench::kVictorChannel);
-        m_encoder = new Encoder(TestBench::kVictorEncoderChannelA,
-                                TestBench::kVictorEncoderChannelB);
+        m_speedController = new frc::Victor(TestBench::kVictorChannel);
+        m_encoder = new frc::Encoder(TestBench::kVictorEncoderChannelA,
+                                     TestBench::kVictorEncoderChannelB);
         break;
 
       case TEST_JAGUAR:
-        m_speedController = new Jaguar(TestBench::kJaguarChannel);
-        m_encoder = new Encoder(TestBench::kJaguarEncoderChannelA,
-                                TestBench::kJaguarEncoderChannelB);
+        m_speedController = new frc::Jaguar(TestBench::kJaguarChannel);
+        m_encoder = new frc::Encoder(TestBench::kJaguarEncoderChannelA,
+                                     TestBench::kJaguarEncoderChannelB);
         break;
 
       case TEST_TALON:
-        m_speedController = new Talon(TestBench::kTalonChannel);
-        m_encoder = new Encoder(TestBench::kTalonEncoderChannelA,
-                                TestBench::kTalonEncoderChannelB);
+        m_speedController = new frc::Talon(TestBench::kTalonChannel);
+        m_encoder = new frc::Encoder(TestBench::kTalonEncoderChannelA,
+                                     TestBench::kTalonEncoderChannelB);
         break;
     }
   }
@@ -86,7 +84,7 @@ TEST_P(MotorEncoderTest, Increment) {
 
   /* Drive the speed controller briefly to move the encoder */
   m_speedController->Set(0.2f);
-  Wait(kMotorTime);
+  frc::Wait(kMotorTime);
   m_speedController->Set(0.0);
 
   /* The encoder should be positive now */
@@ -102,7 +100,7 @@ TEST_P(MotorEncoderTest, Decrement) {
 
   /* Drive the speed controller briefly to move the encoder */
   m_speedController->Set(-0.2);
-  Wait(kMotorTime);
+  frc::Wait(kMotorTime);
   m_speedController->Set(0.0);
 
   /* The encoder should be positive now */
@@ -117,12 +115,12 @@ TEST_P(MotorEncoderTest, ClampSpeed) {
   Reset();
 
   m_speedController->Set(2.0);
-  Wait(kMotorTime);
+  frc::Wait(kMotorTime);
 
   EXPECT_FLOAT_EQ(1.0, m_speedController->Get());
 
   m_speedController->Set(-2.0);
-  Wait(kMotorTime);
+  frc::Wait(kMotorTime);
 
   EXPECT_FLOAT_EQ(-1.0, m_speedController->Get());
 }
@@ -133,15 +131,15 @@ TEST_P(MotorEncoderTest, ClampSpeed) {
 TEST_P(MotorEncoderTest, PositionPIDController) {
   Reset();
   double goal = 1000;
-  m_encoder->SetPIDSourceType(PIDSourceType::kDisplacement);
-  PIDController pid(0.001, 0.0005, 0.0, m_encoder, m_speedController);
+  m_encoder->SetPIDSourceType(frc::PIDSourceType::kDisplacement);
+  frc::PIDController pid(0.001, 0.0005, 0.0, m_encoder, m_speedController);
   pid.SetAbsoluteTolerance(50.0);
   pid.SetOutputRange(-0.2, 0.2);
   pid.SetSetpoint(goal);
 
   /* 10 seconds should be plenty time to get to the setpoint */
   pid.Enable();
-  Wait(10.0);
+  frc::Wait(10.0);
   pid.Disable();
 
   RecordProperty("PIDError", pid.GetError());
@@ -157,8 +155,8 @@ TEST_P(MotorEncoderTest, PositionPIDController) {
 TEST_P(MotorEncoderTest, VelocityPIDController) {
   Reset();
 
-  m_encoder->SetPIDSourceType(PIDSourceType::kRate);
-  PIDController pid(1e-5, 0.0, 3e-5, 8e-5, m_encoder, m_speedController);
+  m_encoder->SetPIDSourceType(frc::PIDSourceType::kRate);
+  frc::PIDController pid(1e-5, 0.0, 3e-5, 8e-5, m_encoder, m_speedController);
   pid.SetAbsoluteTolerance(200.0);
   pid.SetToleranceBuffer(50);
   pid.SetOutputRange(-0.3, 0.3);
@@ -166,7 +164,7 @@ TEST_P(MotorEncoderTest, VelocityPIDController) {
 
   /* 10 seconds should be plenty time to get to the setpoint */
   pid.Enable();
-  Wait(10.0);
+  frc::Wait(10.0);
   pid.Disable();
   RecordProperty("PIDError", pid.GetError());
 

--- a/wpilibcIntegrationTests/src/MotorInvertingTest.cpp
+++ b/wpilibcIntegrationTests/src/MotorInvertingTest.cpp
@@ -13,8 +13,6 @@
 #include "Victor.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 enum MotorInvertingTestType { TEST_VICTOR, TEST_JAGUAR, TEST_TALON };
 static const double motorSpeed = 0.15;
 static const double delayTime = 0.5;
@@ -36,29 +34,31 @@ std::ostream& operator<<(std::ostream& os, MotorInvertingTestType const& type) {
 class MotorInvertingTest
     : public testing::TestWithParam<MotorInvertingTestType> {
  protected:
-  SpeedController* m_speedController;
-  Encoder* m_encoder;
+  frc::SpeedController* m_speedController;
+  frc::Encoder* m_encoder;
+
   void SetUp() override {
     switch (GetParam()) {
       case TEST_VICTOR:
-        m_speedController = new Victor(TestBench::kVictorChannel);
-        m_encoder = new Encoder(TestBench::kVictorEncoderChannelA,
-                                TestBench::kVictorEncoderChannelB);
+        m_speedController = new frc::Victor(TestBench::kVictorChannel);
+        m_encoder = new frc::Encoder(TestBench::kVictorEncoderChannelA,
+                                     TestBench::kVictorEncoderChannelB);
         break;
 
       case TEST_JAGUAR:
-        m_speedController = new Jaguar(TestBench::kJaguarChannel);
-        m_encoder = new Encoder(TestBench::kJaguarEncoderChannelA,
-                                TestBench::kJaguarEncoderChannelB);
+        m_speedController = new frc::Jaguar(TestBench::kJaguarChannel);
+        m_encoder = new frc::Encoder(TestBench::kJaguarEncoderChannelA,
+                                     TestBench::kJaguarEncoderChannelB);
         break;
 
       case TEST_TALON:
-        m_speedController = new Talon(TestBench::kTalonChannel);
-        m_encoder = new Encoder(TestBench::kTalonEncoderChannelA,
-                                TestBench::kTalonEncoderChannelB);
+        m_speedController = new frc::Talon(TestBench::kTalonChannel);
+        m_encoder = new frc::Encoder(TestBench::kTalonEncoderChannelA,
+                                     TestBench::kTalonEncoderChannelB);
         break;
     }
   }
+
   void TearDown() override {
     delete m_speedController;
     delete m_encoder;
@@ -73,54 +73,82 @@ class MotorInvertingTest
 
 TEST_P(MotorInvertingTest, InvertingPositive) {
   Reset();
+
   m_speedController->Set(motorSpeed);
-  Wait(delayTime);
+
+  frc::Wait(delayTime);
+
   bool initDirection = m_encoder->GetDirection();
   m_speedController->SetInverted(true);
   m_speedController->Set(motorSpeed);
-  Wait(delayTime);
+
+  frc::Wait(delayTime);
+
   EXPECT_TRUE(m_encoder->GetDirection() != initDirection)
       << "Inverting with Positive value does not change direction";
+
   Reset();
 }
+
 TEST_P(MotorInvertingTest, InvertingNegative) {
   Reset();
+
   m_speedController->SetInverted(false);
   m_speedController->Set(-motorSpeed);
-  Wait(delayTime);
+
+  frc::Wait(delayTime);
+
   bool initDirection = m_encoder->GetDirection();
   m_speedController->SetInverted(true);
   m_speedController->Set(-motorSpeed);
-  Wait(delayTime);
+
+  frc::Wait(delayTime);
+
   EXPECT_TRUE(m_encoder->GetDirection() != initDirection)
       << "Inverting with Negative value does not change direction";
+
   Reset();
 }
+
 TEST_P(MotorInvertingTest, InvertingSwitchingPosToNeg) {
   Reset();
+
   m_speedController->SetInverted(false);
   m_speedController->Set(motorSpeed);
-  Wait(delayTime);
+
+  frc::Wait(delayTime);
+
   bool initDirection = m_encoder->GetDirection();
   m_speedController->SetInverted(true);
   m_speedController->Set(-motorSpeed);
-  Wait(delayTime);
+
+  frc::Wait(delayTime);
+
   EXPECT_TRUE(m_encoder->GetDirection() == initDirection)
       << "Inverting with Switching value does change direction";
+
   Reset();
 }
+
 TEST_P(MotorInvertingTest, InvertingSwitchingNegToPos) {
   Reset();
+
   m_speedController->SetInverted(false);
   m_speedController->Set(-motorSpeed);
-  Wait(delayTime);
+
+  frc::Wait(delayTime);
+
   bool initDirection = m_encoder->GetDirection();
   m_speedController->SetInverted(true);
   m_speedController->Set(motorSpeed);
-  Wait(delayTime);
+
+  frc::Wait(delayTime);
+
   EXPECT_TRUE(m_encoder->GetDirection() == initDirection)
       << "Inverting with Switching value does change direction";
+
   Reset();
 }
+
 INSTANTIATE_TEST_CASE_P(Test, MotorInvertingTest,
                         testing::Values(TEST_VICTOR, TEST_JAGUAR, TEST_TALON));

--- a/wpilibcIntegrationTests/src/NotifierTest.cpp
+++ b/wpilibcIntegrationTests/src/NotifierTest.cpp
@@ -12,8 +12,6 @@
 #include "gtest/gtest.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
 unsigned notifierCounter;
 
 void notifierHandler(void*) { notifierCounter++; }
@@ -25,12 +23,12 @@ TEST(NotifierTest, DISABLED_TestTimerNotifications) {
   llvm::outs() << "NotifierTest...\n";
   notifierCounter = 0;
   llvm::outs() << "notifier(notifierHandler, nullptr)...\n";
-  Notifier notifier(notifierHandler, nullptr);
+  frc::Notifier notifier(notifierHandler, nullptr);
   llvm::outs() << "Start Periodic...\n";
   notifier.StartPeriodic(1.0);
 
   llvm::outs() << "Wait...\n";
-  Wait(10.5);
+  frc::Wait(10.5);
   llvm::outs() << "...Wait\n";
 
   EXPECT_EQ(10u, notifierCounter) << "Received " << notifierCounter

--- a/wpilibcIntegrationTests/src/PCMTest.cpp
+++ b/wpilibcIntegrationTests/src/PCMTest.cpp
@@ -15,8 +15,6 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 /* The PCM switches the compressor up to a couple seconds after the pressure
         switch changes. */
 static const double kCompressorDelayTime = 3.0;
@@ -31,21 +29,21 @@ static const double kCompressorOffVoltage = 1.68;
 
 class PCMTest : public testing::Test {
  protected:
-  Compressor* m_compressor;
+  frc::Compressor* m_compressor;
 
-  DigitalOutput* m_fakePressureSwitch;
-  AnalogInput* m_fakeCompressor;
-  DoubleSolenoid* m_doubleSolenoid;
-  DigitalInput *m_fakeSolenoid1, *m_fakeSolenoid2;
+  frc::DigitalOutput* m_fakePressureSwitch;
+  frc::AnalogInput* m_fakeCompressor;
+  frc::DoubleSolenoid* m_doubleSolenoid;
+  frc::DigitalInput *m_fakeSolenoid1, *m_fakeSolenoid2;
 
   void SetUp() override {
-    m_compressor = new Compressor();
+    m_compressor = new frc::Compressor();
 
     m_fakePressureSwitch =
-        new DigitalOutput(TestBench::kFakePressureSwitchChannel);
-    m_fakeCompressor = new AnalogInput(TestBench::kFakeCompressorChannel);
-    m_fakeSolenoid1 = new DigitalInput(TestBench::kFakeSolenoid1Channel);
-    m_fakeSolenoid2 = new DigitalInput(TestBench::kFakeSolenoid2Channel);
+        new frc::DigitalOutput(TestBench::kFakePressureSwitchChannel);
+    m_fakeCompressor = new frc::AnalogInput(TestBench::kFakeCompressorChannel);
+    m_fakeSolenoid1 = new frc::DigitalInput(TestBench::kFakeSolenoid1Channel);
+    m_fakeSolenoid2 = new frc::DigitalInput(TestBench::kFakeSolenoid2Channel);
   }
 
   void TearDown() override {
@@ -72,13 +70,13 @@ TEST_F(PCMTest, PressureSwitch) {
 
   // Turn on the compressor
   m_fakePressureSwitch->Set(true);
-  Wait(kCompressorDelayTime);
+  frc::Wait(kCompressorDelayTime);
   EXPECT_NEAR(kCompressorOnVoltage, m_fakeCompressor->GetVoltage(), 0.5)
       << "Compressor did not turn on when the pressure switch turned on.";
 
   // Turn off the compressor
   m_fakePressureSwitch->Set(false);
-  Wait(kCompressorDelayTime);
+  frc::Wait(kCompressorDelayTime);
   EXPECT_NEAR(kCompressorOffVoltage, m_fakeCompressor->GetVoltage(), 0.5)
       << "Compressor did not turn off when the pressure switch turned off.";
 }
@@ -88,13 +86,13 @@ TEST_F(PCMTest, PressureSwitch) {
  */
 TEST_F(PCMTest, Solenoid) {
   Reset();
-  Solenoid solenoid1(TestBench::kSolenoidChannel1);
-  Solenoid solenoid2(TestBench::kSolenoidChannel2);
+  frc::Solenoid solenoid1(TestBench::kSolenoidChannel1);
+  frc::Solenoid solenoid2(TestBench::kSolenoidChannel2);
 
   // Turn both solenoids off
   solenoid1.Set(false);
   solenoid2.Set(false);
-  Wait(kSolenoidDelayTime);
+  frc::Wait(kSolenoidDelayTime);
   EXPECT_TRUE(m_fakeSolenoid1->Get()) << "Solenoid #1 did not turn off";
   EXPECT_TRUE(m_fakeSolenoid2->Get()) << "Solenoid #2 did not turn off";
   EXPECT_FALSE(solenoid1.Get()) << "Solenoid #1 did not read off";
@@ -103,7 +101,7 @@ TEST_F(PCMTest, Solenoid) {
   // Turn one solenoid on and one off
   solenoid1.Set(true);
   solenoid2.Set(false);
-  Wait(kSolenoidDelayTime);
+  frc::Wait(kSolenoidDelayTime);
   EXPECT_FALSE(m_fakeSolenoid1->Get()) << "Solenoid #1 did not turn on";
   EXPECT_TRUE(m_fakeSolenoid2->Get()) << "Solenoid #2 did not turn off";
   EXPECT_TRUE(solenoid1.Get()) << "Solenoid #1 did not read on";
@@ -112,7 +110,7 @@ TEST_F(PCMTest, Solenoid) {
   // Turn one solenoid on and one off
   solenoid1.Set(false);
   solenoid2.Set(true);
-  Wait(kSolenoidDelayTime);
+  frc::Wait(kSolenoidDelayTime);
   EXPECT_TRUE(m_fakeSolenoid1->Get()) << "Solenoid #1 did not turn off";
   EXPECT_FALSE(m_fakeSolenoid2->Get()) << "Solenoid #2 did not turn on";
   EXPECT_FALSE(solenoid1.Get()) << "Solenoid #1 did not read off";
@@ -121,7 +119,7 @@ TEST_F(PCMTest, Solenoid) {
   // Turn both on
   solenoid1.Set(true);
   solenoid2.Set(true);
-  Wait(kSolenoidDelayTime);
+  frc::Wait(kSolenoidDelayTime);
   EXPECT_FALSE(m_fakeSolenoid1->Get()) << "Solenoid #1 did not turn on";
   EXPECT_FALSE(m_fakeSolenoid2->Get()) << "Solenoid #2 did not turn on";
   EXPECT_TRUE(solenoid1.Get()) << "Solenoid #1 did not read on";
@@ -133,27 +131,27 @@ TEST_F(PCMTest, Solenoid) {
  * with the DoubleSolenoid class.
  */
 TEST_F(PCMTest, DoubleSolenoid) {
-  DoubleSolenoid solenoid(TestBench::kSolenoidChannel1,
-                          TestBench::kSolenoidChannel2);
+  frc::DoubleSolenoid solenoid(TestBench::kSolenoidChannel1,
+                               TestBench::kSolenoidChannel2);
 
-  solenoid.Set(DoubleSolenoid::kOff);
-  Wait(kSolenoidDelayTime);
+  solenoid.Set(frc::DoubleSolenoid::kOff);
+  frc::Wait(kSolenoidDelayTime);
   EXPECT_TRUE(m_fakeSolenoid1->Get()) << "Solenoid #1 did not turn off";
   EXPECT_TRUE(m_fakeSolenoid2->Get()) << "Solenoid #2 did not turn off";
-  EXPECT_TRUE(solenoid.Get() == DoubleSolenoid::kOff)
+  EXPECT_TRUE(solenoid.Get() == frc::DoubleSolenoid::kOff)
       << "Solenoid does not read off";
 
-  solenoid.Set(DoubleSolenoid::kForward);
-  Wait(kSolenoidDelayTime);
+  solenoid.Set(frc::DoubleSolenoid::kForward);
+  frc::Wait(kSolenoidDelayTime);
   EXPECT_FALSE(m_fakeSolenoid1->Get()) << "Solenoid #1 did not turn on";
   EXPECT_TRUE(m_fakeSolenoid2->Get()) << "Solenoid #2 did not turn off";
-  EXPECT_TRUE(solenoid.Get() == DoubleSolenoid::kForward)
+  EXPECT_TRUE(solenoid.Get() == frc::DoubleSolenoid::kForward)
       << "Solenoid does not read forward";
 
-  solenoid.Set(DoubleSolenoid::kReverse);
-  Wait(kSolenoidDelayTime);
+  solenoid.Set(frc::DoubleSolenoid::kReverse);
+  frc::Wait(kSolenoidDelayTime);
   EXPECT_TRUE(m_fakeSolenoid1->Get()) << "Solenoid #1 did not turn off";
   EXPECT_FALSE(m_fakeSolenoid2->Get()) << "Solenoid #2 did not turn on";
-  EXPECT_TRUE(solenoid.Get() == DoubleSolenoid::kReverse)
+  EXPECT_TRUE(solenoid.Get() == frc::DoubleSolenoid::kReverse)
       << "Solenoid does not read reverse";
 }

--- a/wpilibcIntegrationTests/src/PIDToleranceTest.cpp
+++ b/wpilibcIntegrationTests/src/PIDToleranceTest.cpp
@@ -12,49 +12,64 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 class PIDToleranceTest : public testing::Test {
  protected:
   const double setpoint = 50.0;
   const double range = 200;
   const double tolerance = 10.0;
-  class fakeInput : public PIDSource {
+
+  class fakeInput : public frc::PIDSource {
    public:
     double val = 0;
-    void SetPIDSourceType(PIDSourceType pidSource) {}
-    PIDSourceType GetPIDSourceType() { return PIDSourceType::kDisplacement; }
+
+    void SetPIDSourceType(frc::PIDSourceType pidSource) {}
+
+    frc::PIDSourceType GetPIDSourceType() {
+      return frc::PIDSourceType::kDisplacement;
+    }
+
     double PIDGet() { return val; }
   };
-  class fakeOutput : public PIDOutput {
+
+  class fakeOutput : public frc::PIDOutput {
     void PIDWrite(double output) {}
   };
+
   fakeInput inp;
   fakeOutput out;
-  PIDController* pid;
+  frc::PIDController* pid;
+
   void SetUp() override {
-    pid = new PIDController(0.5, 0.0, 0.0, &inp, &out);
+    pid = new frc::PIDController(0.5, 0.0, 0.0, &inp, &out);
     pid->SetInputRange(-range / 2, range / 2);
   }
+
   void TearDown() override { delete pid; }
+
   void Reset() { inp.val = 0; }
 };
 
 TEST_F(PIDToleranceTest, Absolute) {
   Reset();
+
   pid->SetAbsoluteTolerance(tolerance);
   pid->SetSetpoint(setpoint);
   pid->Enable();
+
   EXPECT_FALSE(pid->OnTarget())
       << "Error was in tolerance when it should not have been. Error was "
       << pid->GetAvgError();
+
   inp.val = setpoint + tolerance / 2;
-  Wait(1.0);
+  frc::Wait(1.0);
+
   EXPECT_TRUE(pid->OnTarget())
       << "Error was not in tolerance when it should have been. Error was "
       << pid->GetAvgError();
+
   inp.val = setpoint + 10 * tolerance;
-  Wait(1.0);
+  frc::Wait(1.0);
+
   EXPECT_FALSE(pid->OnTarget())
       << "Error was in tolerance when it should not have been. Error was "
       << pid->GetAvgError();
@@ -62,23 +77,29 @@ TEST_F(PIDToleranceTest, Absolute) {
 
 TEST_F(PIDToleranceTest, Percent) {
   Reset();
+
   pid->SetPercentTolerance(tolerance);
   pid->SetSetpoint(setpoint);
   pid->Enable();
+
   EXPECT_FALSE(pid->OnTarget())
       << "Error was in tolerance when it should not have been. Error was "
       << pid->GetAvgError();
+
   inp.val = setpoint +
             (tolerance) / 200 *
                 range;  // half of percent tolerance away from setpoint
-  Wait(1.0);
+  frc::Wait(1.0);
+
   EXPECT_TRUE(pid->OnTarget())
       << "Error was not in tolerance when it should have been. Error was "
       << pid->GetAvgError();
+
   inp.val =
       setpoint +
       (tolerance) / 50 * range;  // double percent tolerance away from setPoint
-  Wait(1.0);
+  frc::Wait(1.0);
+
   EXPECT_FALSE(pid->OnTarget())
       << "Error was in tolerance when it should not have been. Error was "
       << pid->GetAvgError();

--- a/wpilibcIntegrationTests/src/PowerDistributionPanelTest.cpp
+++ b/wpilibcIntegrationTests/src/PowerDistributionPanelTest.cpp
@@ -14,22 +14,20 @@
 #include "Victor.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 static const double kMotorTime = 0.25;
 
 class PowerDistributionPanelTest : public testing::Test {
  protected:
-  PowerDistributionPanel* m_pdp;
-  Talon* m_talon;
-  Victor* m_victor;
-  Jaguar* m_jaguar;
+  frc::PowerDistributionPanel* m_pdp;
+  frc::Talon* m_talon;
+  frc::Victor* m_victor;
+  frc::Jaguar* m_jaguar;
 
   void SetUp() override {
-    m_pdp = new PowerDistributionPanel();
-    m_talon = new Talon(TestBench::kTalonChannel);
-    m_victor = new Victor(TestBench::kVictorChannel);
-    m_jaguar = new Jaguar(TestBench::kJaguarChannel);
+    m_pdp = new frc::PowerDistributionPanel();
+    m_talon = new frc::Talon(TestBench::kTalonChannel);
+    m_victor = new frc::Victor(TestBench::kVictorChannel);
+    m_jaguar = new frc::Jaguar(TestBench::kJaguarChannel);
   }
 
   void TearDown() override {
@@ -44,7 +42,7 @@ class PowerDistributionPanelTest : public testing::Test {
  * Test if the current changes when the motor is driven using a talon
  */
 TEST_F(PowerDistributionPanelTest, CheckCurrentTalon) {
-  Wait(kMotorTime);
+  frc::Wait(kMotorTime);
 
   /* The Current should be 0 */
   EXPECT_FLOAT_EQ(0, m_pdp->GetCurrent(TestBench::kTalonPDPChannel))
@@ -52,7 +50,7 @@ TEST_F(PowerDistributionPanelTest, CheckCurrentTalon) {
 
   /* Set the motor to full forward */
   m_talon->Set(1.0);
-  Wait(kMotorTime);
+  frc::Wait(kMotorTime);
 
   /* The current should now be positive */
   ASSERT_GT(m_pdp->GetCurrent(TestBench::kTalonPDPChannel), 0)

--- a/wpilibcIntegrationTests/src/PreferencesTest.cpp
+++ b/wpilibcIntegrationTests/src/PreferencesTest.cpp
@@ -14,8 +14,6 @@
 #include "gtest/gtest.h"
 #include "ntcore.h"
 
-using namespace frc;
-
 static const char* kFileName = "networktables.ini";
 static const double kSaveTime = 1.2;
 
@@ -44,7 +42,7 @@ TEST(PreferencesTest, ReadPreferencesFromFile) {
   preferencesFile.close();
   NetworkTable::Initialize();
 
-  Preferences* preferences = Preferences::GetInstance();
+  frc::Preferences* preferences = frc::Preferences::GetInstance();
   EXPECT_EQ("Hello, preferences file",
             preferences->GetString("testFileGetString"));
   EXPECT_EQ(1, preferences->GetInt("testFileGetInt"));
@@ -61,6 +59,7 @@ TEST(PreferencesTest, ReadPreferencesFromFile) {
 TEST(PreferencesTest, WritePreferencesToFile) {
   NetworkTable::Shutdown();
   NetworkTable::GlobalDeleteAll();
+
   // persistent keys don't get deleted normally, so make remaining keys
   // non-persistent and delete them too
   for (const auto& info : nt::GetEntryInfo("", 0)) {
@@ -68,8 +67,9 @@ TEST(PreferencesTest, WritePreferencesToFile) {
   }
   NetworkTable::GlobalDeleteAll();
   std::remove(kFileName);
+
   NetworkTable::Initialize();
-  Preferences* preferences = Preferences::GetInstance();
+  frc::Preferences* preferences = frc::Preferences::GetInstance();
   preferences->PutString("testFilePutString", "Hello, preferences file");
   preferences->PutInt("testFilePutInt", 1);
   preferences->PutDouble("testFilePutDouble", 0.5);
@@ -77,7 +77,7 @@ TEST(PreferencesTest, WritePreferencesToFile) {
   preferences->PutBoolean("testFilePutBoolean", true);
   preferences->PutLong("testFilePutLong", 1000000000000000000ll);
 
-  Wait(kSaveTime);
+  frc::Wait(kSaveTime);
 
   static char const* kExpectedFileContents[] = {
       "[NetworkTables Storage 3.0]",

--- a/wpilibcIntegrationTests/src/RelayTest.cpp
+++ b/wpilibcIntegrationTests/src/RelayTest.cpp
@@ -12,20 +12,18 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 static const double kDelayTime = 0.01;
 
 class RelayTest : public testing::Test {
  protected:
-  Relay* m_relay;
-  DigitalInput* m_forward;
-  DigitalInput* m_reverse;
+  frc::Relay* m_relay;
+  frc::DigitalInput* m_forward;
+  frc::DigitalInput* m_reverse;
 
   void SetUp() override {
-    m_relay = new Relay(TestBench::kRelayChannel);
-    m_forward = new DigitalInput(TestBench::kFakeRelayForward);
-    m_reverse = new DigitalInput(TestBench::kFakeRelayReverse);
+    m_relay = new frc::Relay(TestBench::kRelayChannel);
+    m_forward = new frc::DigitalInput(TestBench::kFakeRelayForward);
+    m_reverse = new frc::DigitalInput(TestBench::kFakeRelayReverse);
   }
 
   void TearDown() override {
@@ -34,7 +32,7 @@ class RelayTest : public testing::Test {
     delete m_reverse;
   }
 
-  void Reset() { m_relay->Set(Relay::kOff); }
+  void Reset() { m_relay->Set(frc::Relay::kOff); }
 };
 
 /**
@@ -44,50 +42,50 @@ TEST_F(RelayTest, Relay) {
   Reset();
 
   // set the relay to forward
-  m_relay->Set(Relay::kForward);
-  Wait(kDelayTime);
+  m_relay->Set(frc::Relay::kForward);
+  frc::Wait(kDelayTime);
   EXPECT_TRUE(m_forward->Get()) << "Relay did not set forward";
   EXPECT_FALSE(m_reverse->Get()) << "Relay did not set forward";
-  EXPECT_EQ(m_relay->Get(), Relay::kForward);
+  EXPECT_EQ(m_relay->Get(), frc::Relay::kForward);
 
   // set the relay to reverse
-  m_relay->Set(Relay::kReverse);
-  Wait(kDelayTime);
+  m_relay->Set(frc::Relay::kReverse);
+  frc::Wait(kDelayTime);
   EXPECT_TRUE(m_reverse->Get()) << "Relay did not set reverse";
   EXPECT_FALSE(m_forward->Get()) << "Relay did not set reverse";
-  EXPECT_EQ(m_relay->Get(), Relay::kReverse);
+  EXPECT_EQ(m_relay->Get(), frc::Relay::kReverse);
 
   // set the relay to off
-  m_relay->Set(Relay::kOff);
-  Wait(kDelayTime);
+  m_relay->Set(frc::Relay::kOff);
+  frc::Wait(kDelayTime);
   EXPECT_FALSE(m_forward->Get()) << "Relay did not set off";
   EXPECT_FALSE(m_reverse->Get()) << "Relay did not set off";
-  EXPECT_EQ(m_relay->Get(), Relay::kOff);
+  EXPECT_EQ(m_relay->Get(), frc::Relay::kOff);
 
   // set the relay to on
-  m_relay->Set(Relay::kOn);
-  Wait(kDelayTime);
+  m_relay->Set(frc::Relay::kOn);
+  frc::Wait(kDelayTime);
   EXPECT_TRUE(m_forward->Get()) << "Relay did not set on";
   EXPECT_TRUE(m_reverse->Get()) << "Relay did not set on";
-  EXPECT_EQ(m_relay->Get(), Relay::kOn);
+  EXPECT_EQ(m_relay->Get(), frc::Relay::kOn);
 
   // test forward direction
   delete m_relay;
-  m_relay = new Relay(TestBench::kRelayChannel, Relay::kForwardOnly);
+  m_relay = new frc::Relay(TestBench::kRelayChannel, frc::Relay::kForwardOnly);
 
-  m_relay->Set(Relay::kOn);
-  Wait(kDelayTime);
+  m_relay->Set(frc::Relay::kOn);
+  frc::Wait(kDelayTime);
   EXPECT_TRUE(m_forward->Get()) << "Relay did not set forward";
   EXPECT_FALSE(m_reverse->Get()) << "Relay did not set forward";
-  EXPECT_EQ(m_relay->Get(), Relay::kOn);
+  EXPECT_EQ(m_relay->Get(), frc::Relay::kOn);
 
   // test reverse direction
   delete m_relay;
-  m_relay = new Relay(TestBench::kRelayChannel, Relay::kReverseOnly);
+  m_relay = new frc::Relay(TestBench::kRelayChannel, frc::Relay::kReverseOnly);
 
-  m_relay->Set(Relay::kOn);
-  Wait(kDelayTime);
+  m_relay->Set(frc::Relay::kOn);
+  frc::Wait(kDelayTime);
   EXPECT_FALSE(m_forward->Get()) << "Relay did not set reverse";
   EXPECT_TRUE(m_reverse->Get()) << "Relay did not set reverse";
-  EXPECT_EQ(m_relay->Get(), Relay::kOn);
+  EXPECT_EQ(m_relay->Get(), frc::Relay::kOn);
 }

--- a/wpilibcIntegrationTests/src/TestEnvironment.cpp
+++ b/wpilibcIntegrationTests/src/TestEnvironment.cpp
@@ -14,8 +14,6 @@
 #include "gtest/gtest.h"
 #include "llvm/raw_ostream.h"
 
-using namespace frc;
-
 class TestEnvironment : public testing::Environment {
   bool m_alreadySetUp = false;
 
@@ -36,12 +34,12 @@ class TestEnvironment : public testing::Environment {
             station returns that the robot is enabled, to ensure that tests
             will be able to run on the hardware. */
     HAL_ObserveUserProgramStarting();
-    LiveWindow::GetInstance()->SetEnabled(false);
+    frc::LiveWindow::GetInstance()->SetEnabled(false);
 
     llvm::outs() << "Waiting for enable\n";
 
-    while (!DriverStation::GetInstance().IsEnabled()) {
-      Wait(0.1);
+    while (!frc::DriverStation::GetInstance().IsEnabled()) {
+      frc::Wait(0.1);
     }
   }
 

--- a/wpilibcIntegrationTests/src/TiltPanCameraTest.cpp
+++ b/wpilibcIntegrationTests/src/TiltPanCameraTest.cpp
@@ -14,8 +14,6 @@
 #include "Timer.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 static constexpr double kServoResetTime = 2.0;
 
 static constexpr double kTestAngle = 90.0;
@@ -32,28 +30,29 @@ static constexpr double kSensitivity = 0.013;
  */
 class TiltPanCameraTest : public testing::Test {
  protected:
-  static AnalogGyro* m_gyro;
-  Servo *m_tilt, *m_pan;
-  Accelerometer* m_spiAccel;
+  static frc::AnalogGyro* m_gyro;
+  frc::Servo* m_tilt;
+  frc::Servo* m_pan;
+  frc::Accelerometer* m_spiAccel;
 
   static void SetUpTestCase() {
     // The gyro object blocks for 5 seconds in the constructor, so only
     // construct it once for the whole test case
-    m_gyro = new AnalogGyro(TestBench::kCameraGyroChannel);
+    m_gyro = new frc::AnalogGyro(TestBench::kCameraGyroChannel);
     m_gyro->SetSensitivity(kSensitivity);
   }
 
   static void TearDownTestCase() { delete m_gyro; }
 
   void SetUp() override {
-    m_tilt = new Servo(TestBench::kCameraTiltChannel);
-    m_pan = new Servo(TestBench::kCameraPanChannel);
-    m_spiAccel = new ADXL345_SPI(SPI::kOnboardCS1);
+    m_tilt = new frc::Servo(TestBench::kCameraTiltChannel);
+    m_pan = new frc::Servo(TestBench::kCameraPanChannel);
+    m_spiAccel = new frc::ADXL345_SPI(frc::SPI::kOnboardCS1);
 
     m_tilt->Set(kTiltSetpoint45);
     m_pan->SetAngle(0.0);
 
-    Wait(kServoResetTime);
+    frc::Wait(kServoResetTime);
 
     m_gyro->Reset();
   }
@@ -69,7 +68,7 @@ class TiltPanCameraTest : public testing::Test {
   }
 };
 
-AnalogGyro* TiltPanCameraTest::m_gyro = nullptr;
+frc::AnalogGyro* TiltPanCameraTest::m_gyro = nullptr;
 
 /**
  * Test if the gyro angle defaults to 0 immediately after being reset.
@@ -87,12 +86,12 @@ void TiltPanCameraTest::DefaultGyroAngle() {
 void TiltPanCameraTest::GyroAngle() {
   // Make sure that the gyro doesn't get jerked when the servo goes to zero.
   m_pan->SetAngle(0.0);
-  Wait(0.5);
+  frc::Wait(0.5);
   m_gyro->Reset();
 
   for (int32_t i = 0; i < 600; i++) {
     m_pan->Set(i / 1000.0);
-    Wait(0.001);
+    frc::Wait(0.001);
   }
 
   double gyroAngle = m_gyro->GetAngle();
@@ -111,24 +110,24 @@ void TiltPanCameraTest::GyroCalibratedParameters() {
   uint32_t cCenter = m_gyro->GetCenter();
   double cOffset = m_gyro->GetOffset();
   delete m_gyro;
-  m_gyro = new AnalogGyro(TestBench::kCameraGyroChannel, cCenter, cOffset);
+  m_gyro = new frc::AnalogGyro(TestBench::kCameraGyroChannel, cCenter, cOffset);
   m_gyro->SetSensitivity(kSensitivity);
 
   // Default gyro angle test
   // Accumulator needs a small amount of time to reset before being tested
   m_gyro->Reset();
-  Wait(0.001);
+  frc::Wait(0.001);
   EXPECT_NEAR(0.0, m_gyro->GetAngle(), 1.0);
 
   // Gyro angle test
   // Make sure that the gyro doesn't get jerked when the servo goes to zero.
   m_pan->SetAngle(0.0);
-  Wait(0.5);
+  frc::Wait(0.5);
   m_gyro->Reset();
 
   for (int32_t i = 0; i < 600; i++) {
     m_pan->Set(i / 1000.0);
-    Wait(0.001);
+    frc::Wait(0.001);
   }
 
   double gyroAngle = m_gyro->GetAngle();
@@ -153,19 +152,19 @@ TEST_F(TiltPanCameraTest, TestAllGyroTests) {
  */
 TEST_F(TiltPanCameraTest, SPIAccelerometer) {
   m_tilt->Set(kTiltSetpoint0);
-  Wait(kTiltTime);
+  frc::Wait(kTiltTime);
   EXPECT_NEAR(-1.0, m_spiAccel->GetX(), kAccelerometerTolerance);
   EXPECT_NEAR(0.0, m_spiAccel->GetY(), kAccelerometerTolerance);
   EXPECT_NEAR(0.0, m_spiAccel->GetZ(), kAccelerometerTolerance);
 
   m_tilt->Set(kTiltSetpoint45);
-  Wait(kTiltTime);
+  frc::Wait(kTiltTime);
   EXPECT_NEAR(-std::sqrt(0.5), m_spiAccel->GetX(), kAccelerometerTolerance);
   EXPECT_NEAR(0.0, m_spiAccel->GetY(), kAccelerometerTolerance);
   EXPECT_NEAR(std::sqrt(0.5), m_spiAccel->GetZ(), kAccelerometerTolerance);
 
   m_tilt->Set(kTiltSetpoint90);
-  Wait(kTiltTime);
+  frc::Wait(kTiltTime);
   EXPECT_NEAR(0.0, m_spiAccel->GetX(), kAccelerometerTolerance);
   EXPECT_NEAR(0.0, m_spiAccel->GetY(), kAccelerometerTolerance);
   EXPECT_NEAR(1.0, m_spiAccel->GetZ(), kAccelerometerTolerance);

--- a/wpilibcIntegrationTests/src/TimerTest.cpp
+++ b/wpilibcIntegrationTests/src/TimerTest.cpp
@@ -10,15 +10,13 @@
 #include "TestBench.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 static const double kWaitTime = 0.5;
 
 class TimerTest : public testing::Test {
  protected:
-  Timer* m_timer;
+  frc::Timer* m_timer;
 
-  void SetUp() override { m_timer = new Timer; }
+  void SetUp() override { m_timer = new frc::Timer; }
 
   void TearDown() override { delete m_timer; }
 
@@ -33,7 +31,7 @@ TEST_F(TimerTest, Wait) {
 
   double initialTime = m_timer->GetFPGATimestamp();
 
-  Wait(kWaitTime);
+  frc::Wait(kWaitTime);
 
   double finalTime = m_timer->GetFPGATimestamp();
 

--- a/wpilibcIntegrationTests/src/VisionTest.cpp
+++ b/wpilibcIntegrationTests/src/VisionTest.cpp
@@ -7,9 +7,7 @@
 
 #include "vision/VisionRunner.h"
 
-using namespace frc;
-
-class VisionTester : public VisionPipeline {
+class VisionTester : public frc::VisionPipeline {
  public:
   virtual ~VisionTester() = default;
   void Process(cv::Mat& mat) override {}
@@ -19,8 +17,8 @@ class VisionTester : public VisionPipeline {
 void TestVisionInitialization() {
   cs::CvSource source;
   VisionTester tester;
-  VisionRunner<VisionTester> runner(source, &tester,
-                                    [](VisionTester& t) { t.TestThing(); });
+  frc::VisionRunner<VisionTester> runner(
+      source, &tester, [](VisionTester& t) { t.TestThing(); });
 
   runner.RunOnce();
   runner.RunForever();

--- a/wpilibcIntegrationTests/src/command/CommandTest.cpp
+++ b/wpilibcIntegrationTests/src/command/CommandTest.cpp
@@ -14,13 +14,11 @@
 #include "command/MockCommand.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 class CommandTest : public testing::Test {
  protected:
   void SetUp() override {
-    RobotState::SetImplementation(DriverStation::GetInstance());
-    Scheduler::GetInstance()->SetEnabled(true);
+    frc::RobotState::SetImplementation(frc::DriverStation::GetInstance());
+    frc::Scheduler::GetInstance()->SetEnabled(true);
   }
 
   /**
@@ -32,7 +30,7 @@ class CommandTest : public testing::Test {
    * is called outside of the
    * scope of the test.
    */
-  void TeardownScheduler() { Scheduler::GetInstance()->ResetAll(); }
+  void TeardownScheduler() { frc::Scheduler::GetInstance()->ResetAll(); }
 
   void AssertCommandState(MockCommand& command, int32_t initialize,
                           int32_t execute, int32_t isFinished, int32_t end,
@@ -45,12 +43,12 @@ class CommandTest : public testing::Test {
   }
 };
 
-class ASubsystem : public Subsystem {
+class ASubsystem : public frc::Subsystem {
  private:
-  Command* m_command = nullptr;
+  frc::Command* m_command = nullptr;
 
  public:
-  explicit ASubsystem(const std::string& name) : Subsystem(name) {}
+  explicit ASubsystem(const std::string& name) : frc::Subsystem(name) {}
 
   void InitDefaultCommand() override {
     if (m_command != nullptr) {
@@ -58,14 +56,14 @@ class ASubsystem : public Subsystem {
     }
   }
 
-  void Init(Command* command) { m_command = command; }
+  void Init(frc::Command* command) { m_command = command; }
 };
 
 // CommandParallelGroupTest ported from CommandParallelGroupTest.java
 TEST_F(CommandTest, ParallelCommands) {
   MockCommand command1;
   MockCommand command2;
-  CommandGroup commandGroup;
+  frc::CommandGroup commandGroup;
 
   commandGroup.AddParallel(&command1);
   commandGroup.AddParallel(&command2);
@@ -75,24 +73,24 @@ TEST_F(CommandTest, ParallelCommands) {
   commandGroup.Start();
   AssertCommandState(command1, 0, 0, 0, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 0, 0, 0, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 1, 1, 0, 0);
   AssertCommandState(command2, 1, 1, 1, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 2, 2, 0, 0);
   AssertCommandState(command2, 1, 2, 2, 0, 0);
   command1.SetHasFinished(true);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 3, 3, 1, 0);
   AssertCommandState(command2, 1, 3, 3, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 3, 3, 1, 0);
   AssertCommandState(command2, 1, 4, 4, 0, 0);
   command2.SetHasFinished(true);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 3, 3, 1, 0);
   AssertCommandState(command2, 1, 5, 5, 1, 0);
 
@@ -105,17 +103,17 @@ TEST_F(CommandTest, RunAndTerminate) {
   MockCommand command;
   command.Start();
   AssertCommandState(command, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 1, 1, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 2, 2, 0, 0);
   command.SetHasFinished(true);
   AssertCommandState(command, 1, 2, 2, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 3, 3, 1, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 3, 3, 1, 0);
 
   TeardownScheduler();
@@ -125,19 +123,19 @@ TEST_F(CommandTest, RunAndCancel) {
   MockCommand command;
   command.Start();
   AssertCommandState(command, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 1, 1, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 2, 2, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 3, 3, 0, 0);
   command.Cancel();
   AssertCommandState(command, 1, 3, 3, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 3, 3, 0, 1);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 3, 3, 0, 1);
 
   TeardownScheduler();
@@ -154,7 +152,7 @@ TEST_F(CommandTest, ThreeCommandOnSubSystem) {
   MockCommand command3;
   command3.Requires(&subsystem);
 
-  CommandGroup commandGroup;
+  frc::CommandGroup commandGroup;
   commandGroup.AddSequential(&command1, 1.0);
   commandGroup.AddSequential(&command2, 2.0);
   commandGroup.AddSequential(&command3);
@@ -168,34 +166,34 @@ TEST_F(CommandTest, ThreeCommandOnSubSystem) {
   AssertCommandState(command2, 0, 0, 0, 0, 0);
   AssertCommandState(command3, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 0, 0, 0, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
   AssertCommandState(command3, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 1, 1, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
   AssertCommandState(command3, 0, 0, 0, 0, 0);
-  Wait(1);  // command 1 timeout
+  frc::Wait(1);  // command 1 timeout
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 1, 1, 0, 1);
   AssertCommandState(command2, 1, 1, 1, 0, 0);
   AssertCommandState(command3, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 1, 1, 0, 1);
   AssertCommandState(command2, 1, 2, 2, 0, 0);
   AssertCommandState(command3, 0, 0, 0, 0, 0);
-  Wait(2);  // command 2 timeout
+  frc::Wait(2);  // command 2 timeout
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 1, 1, 0, 1);
   AssertCommandState(command2, 1, 2, 2, 0, 1);
   AssertCommandState(command3, 1, 1, 1, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 1, 1, 0, 1);
   AssertCommandState(command2, 1, 2, 2, 0, 1);
   AssertCommandState(command3, 1, 2, 2, 0, 0);
@@ -204,12 +202,12 @@ TEST_F(CommandTest, ThreeCommandOnSubSystem) {
   AssertCommandState(command2, 1, 2, 2, 0, 1);
   AssertCommandState(command3, 1, 2, 2, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 1, 1, 0, 1);
   AssertCommandState(command2, 1, 2, 2, 0, 1);
   AssertCommandState(command3, 1, 3, 3, 1, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 1, 1, 0, 1);
   AssertCommandState(command2, 1, 2, 2, 0, 1);
   AssertCommandState(command3, 1, 3, 3, 1, 0);
@@ -233,19 +231,19 @@ TEST_F(CommandTest, OneCommandSupersedingAnotherBecauseOfDependencies) {
   AssertCommandState(command1, 0, 0, 0, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 0, 0, 0, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 1, 1, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 2, 2, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 3, 3, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
@@ -253,19 +251,19 @@ TEST_F(CommandTest, OneCommandSupersedingAnotherBecauseOfDependencies) {
   AssertCommandState(command1, 1, 3, 3, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 4, 4, 0, 1);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 4, 4, 0, 1);
   AssertCommandState(command2, 1, 1, 1, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 4, 4, 0, 1);
   AssertCommandState(command2, 1, 2, 2, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 4, 4, 0, 1);
   AssertCommandState(command2, 1, 3, 3, 0, 0);
 
@@ -290,19 +288,19 @@ TEST_F(CommandTest,
   AssertCommandState(command1, 0, 0, 0, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 0, 0, 0, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 1, 1, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 2, 2, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 3, 3, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
@@ -310,7 +308,7 @@ TEST_F(CommandTest,
   AssertCommandState(command1, 1, 3, 3, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command1, 1, 4, 4, 0, 0);
   AssertCommandState(command2, 0, 0, 0, 0, 0);
 
@@ -334,18 +332,18 @@ TEST_F(CommandTest, TwoSecondTimeout) {
 
   command.Start();
   AssertCommandState(command, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 1, 1, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 2, 2, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 3, 3, 0, 0);
-  Wait(2);
-  Scheduler::GetInstance()->Run();
+  frc::Wait(2);
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 4, 4, 1, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(command, 1, 4, 4, 1, 0);
 
   TeardownScheduler();
@@ -362,35 +360,35 @@ TEST_F(CommandTest, DefaultCommandWhereTheInteruptingCommandEndsItself) {
   subsystem.Init(&defaultCommand);
 
   AssertCommandState(defaultCommand, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 1, 1, 1, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 1, 2, 2, 0, 0);
 
   anotherCommand.Start();
   AssertCommandState(defaultCommand, 1, 2, 2, 0, 0);
   AssertCommandState(anotherCommand, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 1, 3, 3, 0, 1);
   AssertCommandState(anotherCommand, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 1, 3, 3, 0, 1);
   AssertCommandState(anotherCommand, 1, 1, 1, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 1, 3, 3, 0, 1);
   AssertCommandState(anotherCommand, 1, 2, 2, 0, 0);
   anotherCommand.SetHasFinished(true);
   AssertCommandState(defaultCommand, 1, 3, 3, 0, 1);
   AssertCommandState(anotherCommand, 1, 2, 2, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 1, 3, 3, 0, 1);
   AssertCommandState(anotherCommand, 1, 3, 3, 1, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 2, 4, 4, 0, 1);
   AssertCommandState(anotherCommand, 1, 3, 3, 1, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 2, 5, 5, 0, 1);
   AssertCommandState(anotherCommand, 1, 3, 3, 1, 0);
 
@@ -408,35 +406,35 @@ TEST_F(CommandTest, DefaultCommandsInterruptingCommandCanceled) {
   subsystem.Init(&defaultCommand);
   subsystem.InitDefaultCommand();
   AssertCommandState(defaultCommand, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 1, 1, 1, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 1, 2, 2, 0, 0);
 
   anotherCommand.Start();
   AssertCommandState(defaultCommand, 1, 2, 2, 0, 0);
   AssertCommandState(anotherCommand, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 1, 3, 3, 0, 1);
   AssertCommandState(anotherCommand, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 1, 3, 3, 0, 1);
   AssertCommandState(anotherCommand, 1, 1, 1, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 1, 3, 3, 0, 1);
   AssertCommandState(anotherCommand, 1, 2, 2, 0, 0);
   anotherCommand.Cancel();
   AssertCommandState(defaultCommand, 1, 3, 3, 0, 1);
   AssertCommandState(anotherCommand, 1, 2, 2, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 1, 3, 3, 0, 1);
   AssertCommandState(anotherCommand, 1, 2, 2, 0, 1);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 2, 4, 4, 0, 1);
   AssertCommandState(anotherCommand, 1, 2, 2, 0, 1);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(defaultCommand, 2, 5, 5, 0, 1);
   AssertCommandState(anotherCommand, 1, 2, 2, 0, 1);
 

--- a/wpilibcIntegrationTests/src/command/ConditionalCommandTest.cpp
+++ b/wpilibcIntegrationTests/src/command/ConditionalCommandTest.cpp
@@ -14,8 +14,6 @@
 #include "command/MockConditionalCommand.h"
 #include "gtest/gtest.h"
 
-using namespace frc;
-
 class ConditionalCommandTest : public testing::Test {
  public:
   MockConditionalCommand* m_command;
@@ -24,8 +22,8 @@ class ConditionalCommandTest : public testing::Test {
 
  protected:
   void SetUp() override {
-    RobotState::SetImplementation(DriverStation::GetInstance());
-    Scheduler::GetInstance()->SetEnabled(true);
+    frc::RobotState::SetImplementation(frc::DriverStation::GetInstance());
+    frc::Scheduler::GetInstance()->SetEnabled(true);
 
     m_onTrue = new MockCommand();
     m_onFalse = new MockCommand();
@@ -42,7 +40,7 @@ class ConditionalCommandTest : public testing::Test {
    * segfault). This cannot be done within the virtual void Teardown() method
    * because it is called outside of the scope of the test.
    */
-  void TeardownScheduler() { Scheduler::GetInstance()->ResetAll(); }
+  void TeardownScheduler() { frc::Scheduler::GetInstance()->ResetAll(); }
 
   void AssertCommandState(MockCommand& command, int32_t initialize,
                           int32_t execute, int32_t isFinished, int32_t end,
@@ -58,15 +56,15 @@ class ConditionalCommandTest : public testing::Test {
 TEST_F(ConditionalCommandTest, OnTrueTest) {
   m_command->SetCondition(true);
 
-  Scheduler::GetInstance()->AddCommand(m_command);
+  frc::Scheduler::GetInstance()->AddCommand(m_command);
   AssertCommandState(*m_onTrue, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();  // init command and select m_onTrue
+  frc::Scheduler::GetInstance()->Run();  // init command and select m_onTrue
   AssertCommandState(*m_onTrue, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();  // init m_onTrue
+  frc::Scheduler::GetInstance()->Run();  // init m_onTrue
   AssertCommandState(*m_onTrue, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(*m_onTrue, 1, 1, 2, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(*m_onTrue, 1, 2, 4, 0, 0);
 
   EXPECT_TRUE(m_onTrue->GetInitializeCount() > 0)
@@ -80,15 +78,15 @@ TEST_F(ConditionalCommandTest, OnTrueTest) {
 TEST_F(ConditionalCommandTest, OnFalseTest) {
   m_command->SetCondition(false);
 
-  Scheduler::GetInstance()->AddCommand(m_command);
+  frc::Scheduler::GetInstance()->AddCommand(m_command);
   AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();  // init command and select m_onTrue
+  frc::Scheduler::GetInstance()->Run();  // init command and select m_onTrue
   AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();  // init m_onTrue
+  frc::Scheduler::GetInstance()->Run();  // init m_onTrue
   AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(*m_onFalse, 1, 1, 2, 0, 0);
-  Scheduler::GetInstance()->Run();
+  frc::Scheduler::GetInstance()->Run();
   AssertCommandState(*m_onFalse, 1, 2, 4, 0, 0);
 
   EXPECT_TRUE(m_onFalse->GetInitializeCount() > 0)

--- a/wpilibcIntegrationTests/src/command/MockCommand.cpp
+++ b/wpilibcIntegrationTests/src/command/MockCommand.cpp
@@ -7,8 +7,6 @@
 
 #include "command/MockCommand.h"
 
-using namespace frc;
-
 MockCommand::MockCommand() {
   m_initializeCount = 0;
   m_executeCount = 0;

--- a/wpilibcIntegrationTests/src/command/MockConditionalCommand.cpp
+++ b/wpilibcIntegrationTests/src/command/MockConditionalCommand.cpp
@@ -7,8 +7,6 @@
 
 #include "command/MockConditionalCommand.h"
 
-using namespace frc;
-
 MockConditionalCommand::MockConditionalCommand(MockCommand* onTrue,
                                                MockCommand* onFalse)
     : ConditionalCommand(onTrue, onFalse) {}

--- a/wpilibj/src/athena/cpp/lib/AnalogGyroJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/AnalogGyroJNI.cpp
@@ -15,8 +15,6 @@
 #include "HALUtil.h"
 #include "HAL/handles/HandlesInternal.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel analogGyroJNILogLevel = logWARNING;
 
@@ -41,7 +39,7 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogGyroJNI_initializeAn
   ANALOGGYROJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGGYROJNI_LOG(logDEBUG) << "Gyro Handle = " << handle;
   // Analog input does range checking, so we don't need to do so.
-  CheckStatusForceThrow(env, status);
+  frc::CheckStatusForceThrow(env, status);
   return (jint) handle;
 }
 
@@ -57,7 +55,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogGyroJNI_setupAnalogG
   int32_t status = 0;
   HAL_SetupAnalogGyro((HAL_GyroHandle)id, &status);
   ANALOGGYROJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -84,7 +82,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogGyroJNI_setAnalogGyr
   int32_t status = 0;
   HAL_SetAnalogGyroParameters((HAL_GyroHandle)id, vPDPS, offset, center, &status);
   ANALOGGYROJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -100,7 +98,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogGyroJNI_setAnalogGyr
   int32_t status = 0;
   HAL_SetAnalogGyroVoltsPerDegreePerSecond((HAL_GyroHandle)id, vPDPS, &status);
   ANALOGGYROJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -115,7 +113,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogGyroJNI_resetAnalogG
   int32_t status = 0;
   HAL_ResetAnalogGyro((HAL_GyroHandle)id, &status);
   ANALOGGYROJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -130,7 +128,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogGyroJNI_calibrateAna
   int32_t status = 0;
   HAL_CalibrateAnalogGyro((HAL_GyroHandle)id, &status);
   ANALOGGYROJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -145,7 +143,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogGyroJNI_setAnalogGyr
   int32_t status = 0;
   HAL_SetAnalogGyroDeadband((HAL_GyroHandle)id, deadband, &status);
   ANALOGGYROJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -161,7 +159,7 @@ JNIEXPORT jdouble JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogGyroJNI_getAnalog
   jdouble value = HAL_GetAnalogGyroAngle((HAL_GyroHandle)id, &status);
   ANALOGGYROJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGGYROJNI_LOG(logDEBUG) << "Result = " << value;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return value;
 }
 
@@ -178,7 +176,7 @@ JNIEXPORT jdouble JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogGyroJNI_getAnalog
   jdouble value = HAL_GetAnalogGyroRate((HAL_GyroHandle)id, &status);
   ANALOGGYROJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGGYROJNI_LOG(logDEBUG) << "Result = " << value;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return value;
 }
 
@@ -195,7 +193,7 @@ JNIEXPORT jdouble JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogGyroJNI_getAnalog
   jdouble value = HAL_GetAnalogGyroOffset((HAL_GyroHandle)id, &status);
   ANALOGGYROJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGGYROJNI_LOG(logDEBUG) << "Result = " << value;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return value;
 }
 
@@ -212,7 +210,7 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogGyroJNI_getAnalogGyr
   jint value = HAL_GetAnalogGyroCenter((HAL_GyroHandle)id, &status);
   ANALOGGYROJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGGYROJNI_LOG(logDEBUG) << "Result = " << value;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return value;
 }
 

--- a/wpilibj/src/athena/cpp/lib/AnalogJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/AnalogJNI.cpp
@@ -19,8 +19,6 @@
 #include "HALUtil.h"
 #include "HAL/handles/HandlesInternal.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel analogJNILogLevel = logWARNING;
 
@@ -45,8 +43,8 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_initializeAnalogInputPort(
   auto analog = HAL_InitializeAnalogInputPort((HAL_PortHandle)id, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "Analog Handle = " << analog;
-  CheckStatusRange(env, status, 0, HAL_GetNumAnalogInputs(), 
-                   hal::getPortHandleChannel((HAL_PortHandle)id));
+  frc::CheckStatusRange(env, status, 0, HAL_GetNumAnalogInputs(),
+                        hal::getPortHandleChannel((HAL_PortHandle)id));
   return (jint)analog;
 }
 
@@ -75,8 +73,8 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_initializeAnalogOutputPort(
   HAL_AnalogOutputHandle analog = HAL_InitializeAnalogOutputPort((HAL_PortHandle)id, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "Analog Handle = " << analog;
-  CheckStatusRange(env, status, 0, HAL_GetNumAnalogOutputs(), 
-                   hal::getPortHandleChannel((HAL_PortHandle)id));
+  frc::CheckStatusRange(env, status, 0, HAL_GetNumAnalogOutputs(),
+                        hal::getPortHandleChannel((HAL_PortHandle)id));
   return (jlong)analog;
 }
 
@@ -149,7 +147,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogJNI_setAnalogOutput(
   ANALOGJNI_LOG(logDEBUG) << "Analog Handle = " << id;
   int32_t status = 0;
   HAL_SetAnalogOutput((HAL_AnalogOutputHandle)id, voltage, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -162,7 +160,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogOutput(
     JNIEnv *env, jclass, jint id) {
   int32_t status = 0;
   double val = HAL_GetAnalogOutput((HAL_AnalogOutputHandle)id, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -178,7 +176,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_setAnalogSampleRate(
   int32_t status = 0;
   HAL_SetAnalogSampleRate(value, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -193,7 +191,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogSampleRate(
   double returnValue = HAL_GetAnalogSampleRate(&status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "SampleRate = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -210,7 +208,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_setAnalogAverageBits(
   int32_t status = 0;
   HAL_SetAnalogAverageBits((HAL_AnalogInputHandle)id, value, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -226,7 +224,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogAverageBits(
   jint returnValue = HAL_GetAnalogAverageBits((HAL_AnalogInputHandle)id, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "AverageBits = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -243,7 +241,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_setAnalogOversampleBits(
   int32_t status = 0;
   HAL_SetAnalogOversampleBits((HAL_AnalogInputHandle)id, value, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -259,7 +257,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogOversampleBits(
   jint returnValue = HAL_GetAnalogOversampleBits((HAL_AnalogInputHandle)id, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "OversampleBits = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -276,7 +274,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogValue(
   jshort returnValue = HAL_GetAnalogValue((HAL_AnalogInputHandle)id, &status);
   // ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   // ANALOGJNI_LOG(logDEBUG) << "Value = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -293,7 +291,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogAverageValue(
   jint returnValue = HAL_GetAnalogAverageValue((HAL_AnalogInputHandle)id, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "AverageValue = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -311,7 +309,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogVoltsToValue(
   jint returnValue = HAL_GetAnalogVoltsToValue((HAL_AnalogInputHandle)id, voltageValue, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "Value = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -328,7 +326,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogVoltage(
   jdouble returnValue = HAL_GetAnalogVoltage((HAL_AnalogInputHandle)id, &status);
   // ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   // ANALOGJNI_LOG(logDEBUG) << "Voltage = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -345,7 +343,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogAverageVoltage(
   jdouble returnValue = HAL_GetAnalogAverageVoltage((HAL_AnalogInputHandle)id, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "AverageVoltage = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -363,7 +361,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogLSBWeight(
   jint returnValue = HAL_GetAnalogLSBWeight((HAL_AnalogInputHandle)id, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "AnalogLSBWeight = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -380,7 +378,7 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogOffset(
   jint returnValue = HAL_GetAnalogOffset((HAL_AnalogInputHandle)id, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "AnalogOffset = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -399,7 +397,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_isAccumulatorChannel(
   jboolean returnValue = HAL_IsAccumulatorChannel((HAL_AnalogInputHandle)id, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "AnalogOffset = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -414,7 +412,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_AnalogJNI_initAccumulator(
   int32_t status = 0;
   HAL_InitAccumulator((HAL_AnalogInputHandle)id, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -429,7 +427,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_resetAccumulator(
   int32_t status = 0;
   HAL_ResetAccumulator((HAL_AnalogInputHandle)id, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -444,7 +442,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_setAccumulatorCenter(
   int32_t status = 0;
   HAL_SetAccumulatorCenter((HAL_AnalogInputHandle)id, center, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -459,7 +457,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_setAccumulatorDeadband(
   int32_t status = 0;
   HAL_SetAccumulatorDeadband((HAL_AnalogInputHandle)id, deadband, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -475,7 +473,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAccumulatorValue(
   jlong returnValue = HAL_GetAccumulatorValue((HAL_AnalogInputHandle)id, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "AccumulatorValue = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 
   return returnValue;
 }
@@ -493,7 +491,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAccumulatorCount(
   jint returnValue = HAL_GetAccumulatorCount((HAL_AnalogInputHandle)id, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "AccumulatorCount = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -513,7 +511,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAccumulatorOutput(
   ANALOGJNI_LOG(logDEBUG) << "Value = " << *valuePtr;
   ANALOGJNI_LOG(logDEBUG) << "Count = " << *countPtr;
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -532,7 +530,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_initializeAnalogTrigger(
       HAL_InitializeAnalogTrigger((HAL_AnalogInputHandle)id, (int32_t *)indexHandle, &status);
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   ANALOGJNI_LOG(logDEBUG) << "AnalogTrigger Handle = " << analogTrigger;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return (jint)analogTrigger;
 }
 
@@ -547,7 +545,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_cleanAnalogTrigger(
   ANALOGJNI_LOG(logDEBUG) << "Analog Trigger Handle = " << (HAL_AnalogTriggerHandle)id;
   int32_t status = 0;
   HAL_CleanAnalogTrigger((HAL_AnalogTriggerHandle)id, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -561,7 +559,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_setAnalogTriggerLimitsRaw(
   ANALOGJNI_LOG(logDEBUG) << "Analog Trigger Handle = " << (HAL_AnalogTriggerHandle)id;
   int32_t status = 0;
   HAL_SetAnalogTriggerLimitsRaw((HAL_AnalogTriggerHandle)id, lower, upper, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -575,7 +573,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_setAnalogTriggerLimitsVoltage(
   ANALOGJNI_LOG(logDEBUG) << "Analog Trigger Handle = " << (HAL_AnalogTriggerHandle)id;
   int32_t status = 0;
   HAL_SetAnalogTriggerLimitsVoltage((HAL_AnalogTriggerHandle)id, lower, upper, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -589,7 +587,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_setAnalogTriggerAveraged(
   ANALOGJNI_LOG(logDEBUG) << "Analog Trigger Handle = " << (HAL_AnalogTriggerHandle)id;
   int32_t status = 0;
   HAL_SetAnalogTriggerAveraged((HAL_AnalogTriggerHandle)id, averaged, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -603,7 +601,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_setAnalogTriggerFiltered(
   ANALOGJNI_LOG(logDEBUG) << "Analog Trigger Handle = " << (HAL_AnalogTriggerHandle)id;
   int32_t status = 0;
   HAL_SetAnalogTriggerFiltered((HAL_AnalogTriggerHandle)id, filtered, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -617,7 +615,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogTriggerInWindow(
   ANALOGJNI_LOG(logDEBUG) << "Analog Trigger Handle = " << (HAL_AnalogTriggerHandle)id;
   int32_t status = 0;
   jboolean val = HAL_GetAnalogTriggerInWindow((HAL_AnalogTriggerHandle)id, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -632,7 +630,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogTriggerTriggerState(
   ANALOGJNI_LOG(logDEBUG) << "Analog Trigger Handle = " << (HAL_AnalogTriggerHandle)id;
   int32_t status = 0;
   jboolean val = HAL_GetAnalogTriggerTriggerState((HAL_AnalogTriggerHandle)id, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -648,7 +646,7 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAnalogTriggerOutput(
   int32_t status = 0;
   jboolean val =
       HAL_GetAnalogTriggerOutput((HAL_AnalogTriggerHandle)id, (HAL_AnalogTriggerType)type, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 

--- a/wpilibj/src/athena/cpp/lib/CANJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/CANJNI.cpp
@@ -18,9 +18,6 @@
 #include "llvm/raw_ostream.h"
 #include "support/jni_util.h"
 
-using namespace frc;
-using namespace wpi::java;
-
 // set the logging level
 // TLogLevel canJNILogLevel = logDEBUG;
 TLogLevel canJNILogLevel = logERROR;
@@ -45,7 +42,7 @@ Java_edu_wpi_first_wpilibj_can_CANJNI_FRCNetCommCANSessionMuxSendMessage(
   CANJNI_LOG(logDEBUG)
       << "Calling CANJNI FRCNetCommCANSessionMuxSendMessage";
 
-  JByteArrayRef dataArray{env, data};
+  wpi::java::JByteArrayRef dataArray{env, data};
 
   const uint8_t *dataBuffer = reinterpret_cast<const uint8_t*>(dataArray.array().data());
   uint8_t dataSize = dataArray.array().size();
@@ -74,7 +71,7 @@ Java_edu_wpi_first_wpilibj_can_CANJNI_FRCNetCommCANSessionMuxSendMessage(
       messageID, dataBuffer, dataSize, periodMs, &status);
 
   CANJNI_LOG(logDEBUG) << "Status: " << status;
-  CheckCANStatus(env, status, messageID);
+  frc::CheckCANStatus(env, status, messageID);
 #else
   // Noop on other platforms
 #endif
@@ -125,9 +122,10 @@ Java_edu_wpi_first_wpilibj_can_CANJNI_FRCNetCommCANSessionMuxReceiveMessage(
   CANJNI_LOG(logDEBUG) << "Timestamp: " << *timeStampPtr;
   CANJNI_LOG(logDEBUG) << "Status: " << status;
 
-  if (!CheckCANStatus(env, status, *messageIDPtr)) return nullptr;
-  return MakeJByteArray(env, llvm::StringRef{reinterpret_cast<const char*>(buffer), 
-                        static_cast<size_t>(dataSize)});
+  if (!frc::CheckCANStatus(env, status, *messageIDPtr)) return nullptr;
+  return wpi::java::MakeJByteArray(env,
+    llvm::StringRef{reinterpret_cast<const char*>(buffer),
+                    static_cast<size_t>(dataSize)});
 #else
   // Noop on other platforms. Return nullptr
   return nullptr;

--- a/wpilibj/src/athena/cpp/lib/CompressorJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/CompressorJNI.cpp
@@ -12,8 +12,6 @@
 #include "HAL/cpp/Log.h"
 #include "edu_wpi_first_wpilibj_hal_CompressorJNI.h"
 
-using namespace frc;
-
 extern "C" {
 
 /*
@@ -26,7 +24,7 @@ Java_edu_wpi_first_wpilibj_hal_CompressorJNI_initializeCompressor(
     JNIEnv *env, jclass, jbyte module) {
   int32_t status = 0;
   auto handle = HAL_InitializeCompressor(module, &status);
-  CheckStatusRange(env, status, 0, HAL_GetNumPCMModules(), module);
+  frc::CheckStatusRange(env, status, 0, HAL_GetNumPCMModules(), module);
   
   return (jint)handle;
 }
@@ -52,7 +50,7 @@ Java_edu_wpi_first_wpilibj_hal_CompressorJNI_getCompressor(
     JNIEnv *env, jclass, jint compressorHandle) {
   int32_t status = 0;
   bool val = HAL_GetCompressor((HAL_CompressorHandle)compressorHandle, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -66,7 +64,7 @@ Java_edu_wpi_first_wpilibj_hal_CompressorJNI_setCompressorClosedLoopControl(
     JNIEnv *env, jclass, jint compressorHandle, jboolean value) {
   int32_t status = 0;
   HAL_SetCompressorClosedLoopControl((HAL_CompressorHandle)compressorHandle, value, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -79,7 +77,7 @@ Java_edu_wpi_first_wpilibj_hal_CompressorJNI_getCompressorClosedLoopControl(
     JNIEnv *env, jclass, jint compressorHandle) {
   int32_t status = 0;
   bool val = HAL_GetCompressorClosedLoopControl((HAL_CompressorHandle)compressorHandle, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -93,7 +91,7 @@ Java_edu_wpi_first_wpilibj_hal_CompressorJNI_getCompressorPressureSwitch(
     JNIEnv *env, jclass, jint compressorHandle) {
   int32_t status = 0;
   bool val = HAL_GetCompressorPressureSwitch((HAL_CompressorHandle)compressorHandle, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -107,7 +105,7 @@ Java_edu_wpi_first_wpilibj_hal_CompressorJNI_getCompressorCurrent(
     JNIEnv *env, jclass, jint compressorHandle) {
   int32_t status = 0;
   double val = HAL_GetCompressorCurrent((HAL_CompressorHandle)compressorHandle, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -121,7 +119,7 @@ Java_edu_wpi_first_wpilibj_hal_CompressorJNI_getCompressorCurrentTooHighFault(
     JNIEnv *env, jclass, jint compressorHandle) {
   int32_t status = 0;
   bool val = HAL_GetCompressorCurrentTooHighFault((HAL_CompressorHandle)compressorHandle, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -136,7 +134,7 @@ Java_edu_wpi_first_wpilibj_hal_CompressorJNI_getCompressorCurrentTooHighStickyFa
   int32_t status = 0;
   bool val =
       HAL_GetCompressorCurrentTooHighStickyFault((HAL_CompressorHandle)compressorHandle, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -150,7 +148,7 @@ Java_edu_wpi_first_wpilibj_hal_CompressorJNI_getCompressorShortedStickyFault(
     JNIEnv *env, jclass, jint compressorHandle) {
   int32_t status = 0;
   bool val = HAL_GetCompressorShortedStickyFault((HAL_CompressorHandle)compressorHandle, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -164,7 +162,7 @@ Java_edu_wpi_first_wpilibj_hal_CompressorJNI_getCompressorShortedFault(
     JNIEnv *env, jclass, jint compressorHandle) {
   int32_t status = 0;
   bool val = HAL_GetCompressorShortedFault((HAL_CompressorHandle)compressorHandle, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -178,7 +176,7 @@ Java_edu_wpi_first_wpilibj_hal_CompressorJNI_getCompressorNotConnectedStickyFaul
     JNIEnv *env, jclass, jint compressorHandle) {
   int32_t status = 0;
   bool val = HAL_GetCompressorNotConnectedStickyFault((HAL_CompressorHandle)compressorHandle, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -192,7 +190,7 @@ Java_edu_wpi_first_wpilibj_hal_CompressorJNI_getCompressorNotConnectedFault(
     JNIEnv *env, jclass, jint compressorHandle) {
   int32_t status = 0;
   bool val = HAL_GetCompressorNotConnectedFault((HAL_CompressorHandle)compressorHandle, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 /*
@@ -205,7 +203,7 @@ Java_edu_wpi_first_wpilibj_hal_CompressorJNI_clearAllPCMStickyFaults(
     JNIEnv *env, jclass, jbyte module) {
   int32_t status = 0;
   HAL_ClearAllPCMStickyFaults((uint8_t)module, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 }  // extern "C"

--- a/wpilibj/src/athena/cpp/lib/ConstantsJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/ConstantsJNI.cpp
@@ -14,8 +14,6 @@
 #include "HAL/Constants.h"
 #include "HALUtil.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel constantsJNILogLevel = logWARNING;
 

--- a/wpilibj/src/athena/cpp/lib/CounterJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/CounterJNI.cpp
@@ -15,8 +15,6 @@
 #include "HAL/Errors.h"
 #include "HALUtil.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel counterJNILogLevel = logWARNING;
 
@@ -45,7 +43,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_initializeCounter(
   COUNTERJNI_LOG(logDEBUG) << "Index = " << *indexPtr;
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
   COUNTERJNI_LOG(logDEBUG) << "COUNTER Handle = " << counter;
-  CheckStatusForceThrow(env, status);
+  frc::CheckStatusForceThrow(env, status);
   return (jint)counter;
 }
 
@@ -61,7 +59,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_CounterJNI_freeCounter(
   int32_t status = 0;
   HAL_FreeCounter((HAL_CounterHandle)id, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -78,7 +76,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_setCounterAverageSize(
   int32_t status = 0;
   HAL_SetCounterAverageSize((HAL_CounterHandle)id, value, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -98,7 +96,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_setCounterUpSource(
   HAL_SetCounterUpSource((HAL_CounterHandle)id, (HAL_Handle)digitalSourceHandle, 
                      (HAL_AnalogTriggerType)analogTriggerType, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -116,7 +114,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_setCounterUpSourceEdge(
   int32_t status = 0;
   HAL_SetCounterUpSourceEdge((HAL_CounterHandle)id, valueRise, valueFall, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -132,7 +130,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_clearCounterUpSource(
   int32_t status = 0;
   HAL_ClearCounterUpSource((HAL_CounterHandle)id, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -153,12 +151,12 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_setCounterDownSource(
                        (HAL_AnalogTriggerType)analogTriggerType, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
   if (status == PARAMETER_OUT_OF_RANGE) {
-    ThrowIllegalArgumentException(env,
+    frc::ThrowIllegalArgumentException(env,
                                   "Counter only supports DownSource in "
                                   "TwoPulse and ExternalDirection modes.");
     return;
   }
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -176,7 +174,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_setCounterDownSourceEdge(
   int32_t status = 0;
   HAL_SetCounterDownSourceEdge((HAL_CounterHandle)id, valueRise, valueFall, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -192,7 +190,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_clearCounterDownSource(
   int32_t status = 0;
   HAL_ClearCounterDownSource((HAL_CounterHandle)id, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -208,7 +206,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_setCounterUpDownMode(
   int32_t status = 0;
   HAL_SetCounterUpDownMode((HAL_CounterHandle)id, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -225,7 +223,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_setCounterExternalDirectionMode(
   int32_t status = 0;
   HAL_SetCounterExternalDirectionMode((HAL_CounterHandle)id, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -242,7 +240,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_setCounterSemiPeriodMode(
   int32_t status = 0;
   HAL_SetCounterSemiPeriodMode((HAL_CounterHandle)id, value, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -259,7 +257,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_setCounterPulseLengthMode(
   int32_t status = 0;
   HAL_SetCounterPulseLengthMode((HAL_CounterHandle)id, value, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -277,7 +275,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_getCounterSamplesToAverage(
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
   COUNTERJNI_LOG(logDEBUG) << "getCounterSamplesToAverageResult = "
                            << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -296,10 +294,10 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_setCounterSamplesToAverage(
   HAL_SetCounterSamplesToAverage((HAL_CounterHandle)id, value, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
   if (status == PARAMETER_OUT_OF_RANGE) {
-    ThrowBoundaryException(env, value, 1, 127);
+    frc::ThrowBoundaryException(env, value, 1, 127);
     return;
   }
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -314,7 +312,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_CounterJNI_resetCounter(
   int32_t status = 0;
   HAL_ResetCounter((HAL_CounterHandle)id, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -330,7 +328,7 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_CounterJNI_getCounter(
   jint returnValue = HAL_GetCounter((HAL_CounterHandle)id, &status);
   // COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
   // COUNTERJNI_LOG(logDEBUG) << "getCounterResult = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -348,7 +346,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_getCounterPeriod(
   jdouble returnValue = HAL_GetCounterPeriod((HAL_CounterHandle)id, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
   COUNTERJNI_LOG(logDEBUG) << "getCounterPeriodResult = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -366,7 +364,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_setCounterMaxPeriod(
   int32_t status = 0;
   HAL_SetCounterMaxPeriod((HAL_CounterHandle)id, value, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -383,7 +381,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_setCounterUpdateWhenEmpty(
   int32_t status = 0;
   HAL_SetCounterUpdateWhenEmpty((HAL_CounterHandle)id, value, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -400,7 +398,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_getCounterStopped(
   jboolean returnValue = HAL_GetCounterStopped((HAL_CounterHandle)id, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
   COUNTERJNI_LOG(logDEBUG) << "getCounterStoppedResult = " << (jint)returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -419,7 +417,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_getCounterDirection(
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
   COUNTERJNI_LOG(logDEBUG) << "getCounterDirectionResult = "
                            << (jint)returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -437,7 +435,7 @@ Java_edu_wpi_first_wpilibj_hal_CounterJNI_setCounterReverseDirection(
   int32_t status = 0;
   HAL_SetCounterReverseDirection((HAL_CounterHandle)id, value, &status);
   COUNTERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 }  // extern "C"

--- a/wpilibj/src/athena/cpp/lib/DIOJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/DIOJNI.cpp
@@ -17,8 +17,6 @@
 #include "HAL/Ports.h"
 #include "HAL/handles/HandlesInternal.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel dioJNILogLevel = logWARNING;
 
@@ -45,8 +43,8 @@ Java_edu_wpi_first_wpilibj_hal_DIOJNI_initializeDIOPort(
   auto dio = HAL_InitializeDIOPort((HAL_PortHandle)id, (uint8_t)input, &status);
   DIOJNI_LOG(logDEBUG) << "Status = " << status;
   DIOJNI_LOG(logDEBUG) << "DIO Handle = " << dio;
-  CheckStatusRange(env, status, 0, HAL_GetNumDigitalChannels(),
-                   hal::getPortHandleChannel((HAL_PortHandle)id));
+  frc::CheckStatusRange(env, status, 0, HAL_GetNumDigitalChannels(),
+                        hal::getPortHandleChannel((HAL_PortHandle)id));
   return (jint)dio;
 }
 
@@ -87,7 +85,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_DIOJNI_setDIO(
   int32_t status = 0;
   HAL_SetDIO((HAL_DigitalHandle)id, value, &status);
   // DIOJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -103,7 +101,7 @@ Java_edu_wpi_first_wpilibj_hal_DIOJNI_getDIO(JNIEnv *env, jclass, jint id) {
   jboolean returnValue = HAL_GetDIO((HAL_DigitalHandle)id, &status);
   // DIOJNI_LOG(logDEBUG) << "Status = " << status;
   // DIOJNI_LOG(logDEBUG) << "getDIOResult = " << (jint)returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -121,7 +119,7 @@ Java_edu_wpi_first_wpilibj_hal_DIOJNI_getDIODirection(
   jboolean returnValue = HAL_GetDIODirection((HAL_DigitalHandle)id, &status);
   // DIOJNI_LOG(logDEBUG) << "Status = " << status;
   DIOJNI_LOG(logDEBUG) << "getDIODirectionResult = " << (jint)returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -138,7 +136,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_DIOJNI_pulse(
   int32_t status = 0;
   HAL_Pulse((HAL_DigitalHandle)id, value, &status);
   DIOJNI_LOG(logDEBUG) << "Did it work? Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -154,7 +152,7 @@ Java_edu_wpi_first_wpilibj_hal_DIOJNI_isPulsing(JNIEnv *env, jclass, jint id) {
   jboolean returnValue = HAL_IsPulsing((HAL_DigitalHandle)id, &status);
   // DIOJNI_LOG(logDEBUG) << "Status = " << status;
   DIOJNI_LOG(logDEBUG) << "isPulsingResult = " << (jint)returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -170,7 +168,7 @@ Java_edu_wpi_first_wpilibj_hal_DIOJNI_isAnyPulsing(JNIEnv *env, jclass) {
   jboolean returnValue = HAL_IsAnyPulsing(&status);
   // DIOJNI_LOG(logDEBUG) << "Status = " << status;
   DIOJNI_LOG(logDEBUG) << "isAnyPulsingResult = " << (jint)returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -186,7 +184,7 @@ Java_edu_wpi_first_wpilibj_hal_DIOJNI_getLoopTiming(JNIEnv *env, jclass) {
   jshort returnValue = HAL_GetLoopTiming(&status);
   DIOJNI_LOG(logDEBUG) << "Status = " << status;
   DIOJNI_LOG(logDEBUG) << "LoopTiming = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -203,7 +201,7 @@ Java_edu_wpi_first_wpilibj_hal_DIOJNI_allocateDigitalPWM(JNIEnv* env, jclass) {
   auto pwm = HAL_AllocateDigitalPWM(&status);
   DIOJNI_LOG(logDEBUG) << "Status = " << status;
   DIOJNI_LOG(logDEBUG) << "PWM Handle = " << pwm;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return (jint)pwm;
 }
 
@@ -219,7 +217,7 @@ Java_edu_wpi_first_wpilibj_hal_DIOJNI_freeDigitalPWM(JNIEnv* env, jclass, jint i
   int32_t status = 0;
   HAL_FreeDigitalPWM((HAL_DigitalPWMHandle)id, &status);
   DIOJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -234,7 +232,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_DIOJNI_setDigitalPWMRate(
   int32_t status = 0;
   HAL_SetDigitalPWMRate(value, &status);
   DIOJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -250,7 +248,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_DIOJNI_setDigitalPWMDutyCy
   int32_t status = 0;
   HAL_SetDigitalPWMDutyCycle((HAL_DigitalPWMHandle)id, value, &status);
   DIOJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -267,7 +265,7 @@ Java_edu_wpi_first_wpilibj_hal_DIOJNI_setDigitalPWMOutputChannel(
   int32_t status = 0;
   HAL_SetDigitalPWMOutputChannel((HAL_DigitalPWMHandle)id, (uint32_t)value, &status);
   DIOJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 }  // extern "C"

--- a/wpilibj/src/athena/cpp/lib/DigitalGlitchFilterJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/DigitalGlitchFilterJNI.cpp
@@ -11,8 +11,6 @@
 
 #include "edu_wpi_first_wpilibj_hal_DigitalGlitchFilterJNI.h"
 
-using namespace frc;
-
 /*
  * Class:     edu_wpi_first_wpilibj_hal_DigitalGlitchFilterJNI
  * Method:    setFilterSelect
@@ -24,7 +22,7 @@ Java_edu_wpi_first_wpilibj_hal_DigitalGlitchFilterJNI_setFilterSelect(
 
   HAL_SetFilterSelect(static_cast<HAL_DigitalHandle>(id), filter_index,
                       &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -38,7 +36,7 @@ Java_edu_wpi_first_wpilibj_hal_DigitalGlitchFilterJNI_getFilterSelect(
 
   jint result =
       HAL_GetFilterSelect(static_cast<HAL_DigitalHandle>(id), &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return result;
 }
 
@@ -52,7 +50,7 @@ Java_edu_wpi_first_wpilibj_hal_DigitalGlitchFilterJNI_setFilterPeriod(
   int32_t status = 0;
 
   HAL_SetFilterPeriod(filter_index, fpga_cycles, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -65,6 +63,6 @@ Java_edu_wpi_first_wpilibj_hal_DigitalGlitchFilterJNI_getFilterPeriod(
   int32_t status = 0;
 
   jint result = HAL_GetFilterPeriod(filter_index, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return result;
 }

--- a/wpilibj/src/athena/cpp/lib/EncoderJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/EncoderJNI.cpp
@@ -15,8 +15,6 @@
 #include "HAL/Errors.h"
 #include "HALUtil.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel encoderJNILogLevel = logWARNING;
 
@@ -55,7 +53,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_initializeEncoder(
       
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "ENCODER Handle = " << encoder;
-  CheckStatusForceThrow(env, status);
+  frc::CheckStatusForceThrow(env, status);
   return (jint)encoder;
 }
 
@@ -71,7 +69,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_EncoderJNI_freeEncoder(
   int32_t status = 0;
   HAL_FreeEncoder((HAL_EncoderHandle)id, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -87,7 +85,7 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncoder(
   jint returnValue = HAL_GetEncoder((HAL_EncoderHandle)id, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getEncoderResult = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -104,7 +102,7 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncoderRaw(
   jint returnValue = HAL_GetEncoderRaw((HAL_EncoderHandle)id, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getRawEncoderResult = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -121,7 +119,7 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncodingScal
   jint returnValue = HAL_GetEncoderEncodingScale((HAL_EncoderHandle)id, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getEncodingScaleFactorResult = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -137,7 +135,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_EncoderJNI_resetEncoder(
   int32_t status = 0;
   HAL_ResetEncoder((HAL_EncoderHandle)id, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -154,7 +152,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncoderPeriod(
   double returnValue = HAL_GetEncoderPeriod((HAL_EncoderHandle)id, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getEncoderPeriodEncoderResult = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -171,7 +169,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_setEncoderMaxPeriod(
   int32_t status = 0;
   HAL_SetEncoderMaxPeriod((HAL_EncoderHandle)id, value, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -188,7 +186,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncoderStopped(
   jboolean returnValue = HAL_GetEncoderStopped((HAL_EncoderHandle)id, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getStoppedEncoderResult = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -206,7 +204,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncoderDirection(
   jboolean returnValue = HAL_GetEncoderDirection((HAL_EncoderHandle)id, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getDirectionEncoderResult = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -224,7 +222,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncoderDistance(
   jdouble returnValue = HAL_GetEncoderDistance((HAL_EncoderHandle)id, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getDistanceEncoderResult = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -242,7 +240,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncoderRate(
   jdouble returnValue = HAL_GetEncoderRate((HAL_EncoderHandle)id, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getRateEncoderResult = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -259,7 +257,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_setEncoderMinRate(
   int32_t status = 0;
   HAL_SetEncoderMinRate((HAL_EncoderHandle)id, value, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -275,7 +273,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_setEncoderDistancePerPulse(
   int32_t status = 0;
   HAL_SetEncoderDistancePerPulse((HAL_EncoderHandle)id, value, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -291,7 +289,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_setEncoderReverseDirection(
   int32_t status = 0;
   HAL_SetEncoderReverseDirection((HAL_EncoderHandle)id, value, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -308,10 +306,10 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_setEncoderSamplesToAverage(
   HAL_SetEncoderSamplesToAverage((HAL_EncoderHandle)id, value, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   if (status == PARAMETER_OUT_OF_RANGE) {
-    ThrowBoundaryException(env, value, 1, 127);
+    frc::ThrowBoundaryException(env, value, 1, 127);
     return;
   }
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -329,7 +327,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncoderSamplesToAverage(
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getEncoderSamplesToAverageResult = "
                            << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -353,7 +351,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_setEncoderIndexSource(
                             (HAL_AnalogTriggerType)analogTriggerType, 
                             (HAL_EncoderIndexingType)type, &status);
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -371,7 +369,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncoderFPGAIndex(
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getEncoderSamplesToAverageResult = "
                            << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -390,7 +388,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncoderEncodingScale(
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getEncoderSamplesToAverageResult = "
                            << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -409,7 +407,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncoderDecodingScaleFactor(
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getEncoderSamplesToAverageResult = "
                            << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -428,7 +426,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncoderDistancePerPulse(
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getEncoderSamplesToAverageResult = "
                            << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -447,7 +445,7 @@ Java_edu_wpi_first_wpilibj_hal_EncoderJNI_getEncoderEncodingType(
   ENCODERJNI_LOG(logDEBUG) << "Status = " << status;
   ENCODERJNI_LOG(logDEBUG) << "getEncoderSamplesToAverageResult = "
                            << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 

--- a/wpilibj/src/athena/cpp/lib/HAL.cpp
+++ b/wpilibj/src/athena/cpp/lib/HAL.cpp
@@ -17,9 +17,6 @@
 #include "HALUtil.h"
 #include "support/jni_util.h"
 
-using namespace frc;
-using namespace wpi::java;
-
 // set the logging level
 static TLogLevel netCommLogLevel = logWARNING;
 
@@ -101,7 +98,7 @@ JNIEXPORT jint JNICALL
 Java_edu_wpi_first_wpilibj_hal_HAL_report(
     JNIEnv* paramEnv, jclass, jint paramResource, jint paramInstanceNumber,
     jint paramContext, jstring paramFeature) {
-  JStringRef featureStr{paramEnv, paramFeature};
+  wpi::java::JStringRef featureStr{paramEnv, paramFeature};
   NETCOMM_LOG(logDEBUG) << "Calling HAL report "
                         << "res:" << paramResource
                         << " instance:" << paramInstanceNumber
@@ -159,7 +156,7 @@ Java_edu_wpi_first_wpilibj_hal_HAL_getJoystickAxes(JNIEnv* env, jclass,
   jsize javaSize = env->GetArrayLength(axesArray);
   if (axes.count > javaSize)
   {
-    ThrowIllegalArgumentException(env, "Native array size larger then passed in java array size");
+    frc::ThrowIllegalArgumentException(env, "Native array size larger then passed in java array size");
   }
 
   env->SetFloatArrayRegion(axesArray, 0, axes.count, axes.axes);
@@ -183,7 +180,7 @@ Java_edu_wpi_first_wpilibj_hal_HAL_getJoystickPOVs(JNIEnv* env, jclass,
   jsize javaSize = env->GetArrayLength(povsArray);
   if (povs.count > javaSize)
   {
-    ThrowIllegalArgumentException(env, "Native array size larger then passed in java array size");
+    frc::ThrowIllegalArgumentException(env, "Native array size larger then passed in java array size");
   }
 
   env->SetShortArrayRegion(povsArray, 0, povs.count, povs.povs);
@@ -262,7 +259,7 @@ Java_edu_wpi_first_wpilibj_hal_HAL_getJoystickName(JNIEnv* env, jclass,
                                                    jbyte port) {
   NETCOMM_LOG(logDEBUG) << "Calling HAL_GetJoystickName";
   char *joystickName = HAL_GetJoystickName(port);
-  jstring str = MakeJString(env, joystickName);
+  jstring str = wpi::java::MakeJString(env, joystickName);
   HAL_FreeJoystickName(joystickName);
   return str;
 }
@@ -341,7 +338,7 @@ JNIEXPORT jboolean JNICALL
 Java_edu_wpi_first_wpilibj_hal_HAL_getSystemActive(JNIEnv* env, jclass) {
   int32_t status = 0;
   bool val = HAL_GetSystemActive(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -354,7 +351,7 @@ JNIEXPORT jboolean JNICALL
 Java_edu_wpi_first_wpilibj_hal_HAL_getBrownedOut(JNIEnv* env, jclass) {
   int32_t status = 0;
   bool val = HAL_GetBrownedOut(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -366,7 +363,7 @@ Java_edu_wpi_first_wpilibj_hal_HAL_getBrownedOut(JNIEnv* env, jclass) {
 JNIEXPORT jint JNICALL
 Java_edu_wpi_first_wpilibj_hal_HAL_setErrorData(JNIEnv* env, jclass,
                                                 jstring error) {
-  JStringRef errorStr{env, error};
+  wpi::java::JStringRef errorStr{env, error};
 
   NETCOMM_LOG(logDEBUG) << "Set Error: " << errorStr.c_str();
   NETCOMM_LOG(logDEBUG) << "Length: " << errorStr.size();
@@ -386,9 +383,9 @@ Java_edu_wpi_first_wpilibj_hal_HAL_sendError(JNIEnv* env, jclass,
                                              jstring location,
                                              jstring callStack,
                                              jboolean printMsg) {
-  JStringRef detailsStr{env, details};
-  JStringRef locationStr{env, location};
-  JStringRef callStackStr{env, callStack};
+  wpi::java::JStringRef detailsStr{env, details};
+  wpi::java::JStringRef locationStr{env, location};
+  wpi::java::JStringRef callStackStr{env, callStack};
 
   NETCOMM_LOG(logDEBUG) << "Send Error: " << detailsStr.c_str();
   NETCOMM_LOG(logDEBUG) << "Location: " << locationStr.c_str();

--- a/wpilibj/src/athena/cpp/lib/HALUtil.cpp
+++ b/wpilibj/src/athena/cpp/lib/HALUtil.cpp
@@ -27,8 +27,6 @@
 #include "llvm/raw_ostream.h"
 #include "support/jni_util.h"
 
-using namespace wpi::java;
-
 // set the logging level
 TLogLevel halUtilLogLevel = logWARNING;
 
@@ -46,17 +44,17 @@ TLogLevel halUtilLogLevel = logWARNING;
 #define kRIOStatusResourceNotInitialized -52010
 
 JavaVM *jvm = nullptr;
-static JException runtimeExCls;
-static JException illegalArgExCls;
-static JException boundaryExCls;
-static JException allocationExCls;
-static JException halHandleExCls;
-static JException canInvalidBufferExCls;
-static JException canMessageNotFoundExCls;
-static JException canMessageNotAllowedExCls;
-static JException canNotInitializedExCls;
-static JException uncleanStatusExCls;
-static JClass pwmConfigDataResultCls;
+static wpi::java::JException runtimeExCls;
+static wpi::java::JException illegalArgExCls;
+static wpi::java::JException boundaryExCls;
+static wpi::java::JException allocationExCls;
+static wpi::java::JException halHandleExCls;
+static wpi::java::JException canInvalidBufferExCls;
+static wpi::java::JException canMessageNotFoundExCls;
+static wpi::java::JException canMessageNotAllowedExCls;
+static wpi::java::JException canNotInitializedExCls;
+static wpi::java::JException uncleanStatusExCls;
+static wpi::java::JClass pwmConfigDataResultCls;
 
 namespace frc {
 
@@ -86,20 +84,20 @@ constexpr const char JNI_wpilibjPrefix[] = "edu.wpi.first.wpilibj";
 extern const char JNI_wpilibjPrefix[] = "edu.wpi.first.wpilibj";
 #endif
 
-void ReportError(JNIEnv *env, int32_t status, bool do_throw) {
+void ReportError(JNIEnv *env, int32_t status, bool doThrow) {
   if (status == 0) return;
   if (status == HAL_HANDLE_ERROR) {
     ThrowHalHandleException(env, status);
   }
   const char *message = HAL_GetErrorMessage(status);
-  if (do_throw && status < 0) {
+  if (doThrow && status < 0) {
     llvm::SmallString<1024> buf;
     llvm::raw_svector_ostream oss(buf);
     oss << " Code: " << status << ". " << message;
     runtimeExCls.Throw(env, buf.c_str());
   } else {
     std::string func;
-    auto stack = GetJavaStackTrace<JNI_wpilibjPrefix>(env, &func);
+    auto stack = wpi::java::GetJavaStackTrace<JNI_wpilibjPrefix>(env, &func);
     HAL_SendError(1, status, 0, message, func.c_str(), stack.c_str(), 1);
   }
 }
@@ -225,8 +223,6 @@ jobject CreatePWMConfigDataResult(JNIEnv *env, int32_t maxPwm,
 
 }  // namespace frc
 
-using namespace frc;
-
 extern "C" {
 
 //
@@ -242,37 +238,47 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
   if (vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) != JNI_OK)
     return JNI_ERR;
 
-  runtimeExCls = JException(env, "java/lang/RuntimeException");
+  runtimeExCls = wpi::java::JException(env, "java/lang/RuntimeException");
   if (!runtimeExCls) return JNI_ERR;
 
-  illegalArgExCls = JException(env, "java/lang/IllegalArgumentException");
+  illegalArgExCls =
+    wpi::java::JException(env, "java/lang/IllegalArgumentException");
   if (!illegalArgExCls) return JNI_ERR;
 
-  boundaryExCls = JException(env, "edu/wpi/first/wpilibj/util/BoundaryException");
+  boundaryExCls =
+    wpi::java::JException(env, "edu/wpi/first/wpilibj/util/BoundaryException");
   if (!boundaryExCls) return JNI_ERR;
 
-  allocationExCls = JException(env, "edu/wpi/first/wpilibj/util/AllocationException");
+  allocationExCls =
+    wpi::java::JException(env, "edu/wpi/first/wpilibj/util/AllocationException");
   if (!allocationExCls) return JNI_ERR;
 
-  halHandleExCls = JException(env, "edu/wpi/first/wpilibj/util/HalHandleException");
+  halHandleExCls =
+    wpi::java::JException(env, "edu/wpi/first/wpilibj/util/HalHandleException");
   if (!halHandleExCls) return JNI_ERR;
 
-  canInvalidBufferExCls = JException(env, "edu/wpi/first/wpilibj/can/CANInvalidBufferException");
+  canInvalidBufferExCls =
+    wpi::java::JException(env, "edu/wpi/first/wpilibj/can/CANInvalidBufferException");
   if (!canInvalidBufferExCls) return JNI_ERR;
 
-  canMessageNotFoundExCls = JException(env, "edu/wpi/first/wpilibj/can/CANMessageNotFoundException");
+  canMessageNotFoundExCls =
+    wpi::java::JException(env, "edu/wpi/first/wpilibj/can/CANMessageNotFoundException");
   if (!canMessageNotFoundExCls) return JNI_ERR;
 
-  canMessageNotAllowedExCls = JException(env, "edu/wpi/first/wpilibj/can/CANMessageNotAllowedException");
+  canMessageNotAllowedExCls =
+    wpi::java::JException(env, "edu/wpi/first/wpilibj/can/CANMessageNotAllowedException");
   if (!canMessageNotAllowedExCls) return JNI_ERR;
 
-  canNotInitializedExCls = JException(env, "edu/wpi/first/wpilibj/can/CANNotInitializedException");
+  canNotInitializedExCls =
+    wpi::java::JException(env, "edu/wpi/first/wpilibj/can/CANNotInitializedException");
   if (!canNotInitializedExCls) return JNI_ERR;
 
-  uncleanStatusExCls = JException(env,"edu/wpi/first/wpilibj/util/UncleanStatusException");
+  uncleanStatusExCls =
+    wpi::java::JException(env,"edu/wpi/first/wpilibj/util/UncleanStatusException");
   if (!uncleanStatusExCls) return JNI_ERR;
 
-  pwmConfigDataResultCls = JClass(env, "edu/wpi/first/wpilibj/PWMConfigDataResult");
+  pwmConfigDataResultCls =
+    wpi::java::JClass(env, "edu/wpi/first/wpilibj/PWMConfigDataResult");
   if (!pwmConfigDataResultCls) return JNI_ERR;
 
   return JNI_VERSION_1_6;
@@ -309,7 +315,7 @@ Java_edu_wpi_first_wpilibj_hal_HALUtil_getFPGAVersion(JNIEnv *env, jclass) {
   jshort returnValue = HAL_GetFPGAVersion(&status);
   HALUTIL_LOG(logDEBUG) << "Status = " << status;
   HALUTIL_LOG(logDEBUG) << "FPGAVersion = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -325,7 +331,7 @@ Java_edu_wpi_first_wpilibj_hal_HALUtil_getFPGARevision(JNIEnv *env, jclass) {
   jint returnValue = HAL_GetFPGARevision(&status);
   HALUTIL_LOG(logDEBUG) << "Status = " << status;
   HALUTIL_LOG(logDEBUG) << "FPGARevision = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -341,7 +347,7 @@ Java_edu_wpi_first_wpilibj_hal_HALUtil_getFPGATime(JNIEnv *env, jclass) {
   jlong returnValue = HAL_GetFPGATime(&status);
   // HALUTIL_LOG(logDEBUG) << "Status = " << status;
   // HALUTIL_LOG(logDEBUG) << "FPGATime = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -370,7 +376,7 @@ Java_edu_wpi_first_wpilibj_hal_HALUtil_getFPGAButton(JNIEnv *env, jclass) {
   jboolean returnValue = HAL_GetFPGAButton(&status);
   // HALUTIL_LOG(logDEBUG) << "Status = " << status;
   // HALUTIL_LOG(logDEBUG) << "FPGATime = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -385,7 +391,7 @@ Java_edu_wpi_first_wpilibj_hal_HALUtil_getHALErrorMessage(
   const char *msg = HAL_GetErrorMessage(paramId);
   HALUTIL_LOG(logDEBUG) << "Calling HALUtil HAL_GetErrorMessage id=" << paramId
                         << " msg=" << msg;
-  return MakeJString(paramEnv, msg);
+  return wpi::java::MakeJString(paramEnv, msg);
 }
 
 /*
@@ -408,7 +414,7 @@ JNIEXPORT jstring JNICALL Java_edu_wpi_first_wpilibj_hal_HALUtil_getHALstrerror(
   const char *msg = strerror(errno);
   HALUTIL_LOG(logDEBUG) << "Calling HALUtil getHALstrerror errorCode="
                         << errorCode << " msg=" << msg;
-  return MakeJString(env, msg);
+  return wpi::java::MakeJString(env, msg);
 }
 
 }  // extern "C"

--- a/wpilibj/src/athena/cpp/lib/HALUtil.h
+++ b/wpilibj/src/athena/cpp/lib/HALUtil.h
@@ -16,13 +16,13 @@ extern JavaVM *jvm;
 
 namespace frc {
 
-void ReportError(JNIEnv *env, int32_t status, bool do_throw = true);
-                 
+void ReportError(JNIEnv *env, int32_t status, bool doThrow = true);
+
 void ThrowError(JNIEnv *env, int32_t status, int32_t minRange, int32_t maxRange, 
                 int32_t requestedValue);
 
-inline bool CheckStatus(JNIEnv *env, int32_t status, bool do_throw = true) {
-  if (status != 0) ReportError(env, status, do_throw);
+inline bool CheckStatus(JNIEnv *env, int32_t status, bool doThrow = true) {
+  if (status != 0) ReportError(env, status, doThrow);
   return status == 0;
 }
 

--- a/wpilibj/src/athena/cpp/lib/I2CJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/I2CJNI.cpp
@@ -14,8 +14,6 @@
 #include "HAL/I2C.h"
 #include "HALUtil.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel i2cJNILogLevel = logWARNING;
 
@@ -39,7 +37,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_I2CJNI_i2CInitialize(
   int32_t status = 0;
   HAL_InitializeI2C(static_cast<HAL_I2CPort>(port), &status);
   I2CJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatusForceThrow(env, status);
+  frc::CheckStatusForceThrow(env, status);
 }
 
 /*

--- a/wpilibj/src/athena/cpp/lib/InterruptJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/InterruptJNI.cpp
@@ -18,8 +18,6 @@
 #include "edu_wpi_first_wpilibj_hal_InterruptJNI.h"
 #include "support/SafeThread.h"
 
-using namespace frc;
-
 TLogLevel interruptJNILogLevel = logERROR;
 
 #define INTERRUPTJNI_LOG(level)     \
@@ -136,7 +134,7 @@ Java_edu_wpi_first_wpilibj_hal_InterruptJNI_initializeInterrupts(
   INTERRUPTJNI_LOG(logDEBUG) << "Interrupt Handle = " << interrupt;
   INTERRUPTJNI_LOG(logDEBUG) << "Status = " << status;
 
-  CheckStatusForceThrow(env, status);
+  frc::CheckStatusForceThrow(env, status);
   return (jint)interrupt;
 }
 
@@ -177,7 +175,7 @@ Java_edu_wpi_first_wpilibj_hal_InterruptJNI_waitForInterrupt(
 
   INTERRUPTJNI_LOG(logDEBUG) << "Status = " << status;
 
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return result;
 }
 
@@ -197,7 +195,7 @@ Java_edu_wpi_first_wpilibj_hal_InterruptJNI_enableInterrupts(
 
   INTERRUPTJNI_LOG(logDEBUG) << "Status = " << status;
 
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -216,7 +214,7 @@ Java_edu_wpi_first_wpilibj_hal_InterruptJNI_disableInterrupts(
 
   INTERRUPTJNI_LOG(logDEBUG) << "Status = " << status;
 
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -234,7 +232,7 @@ Java_edu_wpi_first_wpilibj_hal_InterruptJNI_readInterruptRisingTimestamp(
   jdouble timeStamp = HAL_ReadInterruptRisingTimestamp((HAL_InterruptHandle)interruptHandle, &status);
 
   INTERRUPTJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return timeStamp;
 }
 
@@ -253,7 +251,7 @@ Java_edu_wpi_first_wpilibj_hal_InterruptJNI_readInterruptFallingTimestamp(
   jdouble timeStamp = HAL_ReadInterruptFallingTimestamp((HAL_InterruptHandle)interruptHandle, &status);
 
   INTERRUPTJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return timeStamp;
 }
 
@@ -276,7 +274,7 @@ Java_edu_wpi_first_wpilibj_hal_InterruptJNI_requestInterrupts(
                     (HAL_AnalogTriggerType)analogTriggerType, &status);
 
   INTERRUPTJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -318,7 +316,7 @@ Java_edu_wpi_first_wpilibj_hal_InterruptJNI_attachInterruptHandler(
                          &status);
 
   INTERRUPTJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -340,7 +338,7 @@ Java_edu_wpi_first_wpilibj_hal_InterruptJNI_setInterruptUpSourceEdge(
                            &status);
 
   INTERRUPTJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 }  // extern "C"

--- a/wpilibj/src/athena/cpp/lib/NotifierJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/NotifierJNI.cpp
@@ -20,8 +20,6 @@
 #include "support/SafeThread.h"
 #include "HAL/cpp/NotifierInternal.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel notifierJNILogLevel = logWARNING;
 
@@ -154,7 +152,7 @@ Java_edu_wpi_first_wpilibj_hal_NotifierJNI_initializeNotifier(
   NOTIFIERJNI_LOG(logDEBUG) << "Notifier Handle = " << notifierHandle;
   NOTIFIERJNI_LOG(logDEBUG) << "Status = " << status;
 
-  if (notifierHandle <= 0 || !CheckStatusForceThrow(env, status)) {
+  if (notifierHandle <= 0 || !frc::CheckStatusForceThrow(env, status)) {
     // something went wrong in HAL, clean up
     delete notify;
   }
@@ -178,7 +176,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_NotifierJNI_cleanNotifier(
       (NotifierJNI *)HAL_GetNotifierParam((HAL_NotifierHandle)notifierHandle, &status);
   HAL_CleanNotifier((HAL_NotifierHandle)notifierHandle, &status);
   NOTIFIERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   delete notify;
 }
 
@@ -199,7 +197,7 @@ Java_edu_wpi_first_wpilibj_hal_NotifierJNI_updateNotifierAlarm(
   int32_t status = 0;
   HAL_UpdateNotifierAlarm((HAL_NotifierHandle)notifierHandle, (uint64_t)triggerTime, &status);
   NOTIFIERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -217,7 +215,7 @@ Java_edu_wpi_first_wpilibj_hal_NotifierJNI_stopNotifierAlarm(
   int32_t status = 0;
   HAL_StopNotifierAlarm((HAL_NotifierHandle)notifierHandle, &status);
   NOTIFIERJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 }  // extern "C"

--- a/wpilibj/src/athena/cpp/lib/OSSerialPortJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/OSSerialPortJNI.cpp
@@ -14,8 +14,6 @@
 #include "HAL/OSSerialPort.h"
 #include "HALUtil.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel osserialJNILogLevel = logWARNING;
 
@@ -40,7 +38,7 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialInitializePort(
   int32_t status = 0;
   HAL_InitializeOSSerialPort(static_cast<HAL_SerialPort>(port), &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatusForceThrow(env, status);
+  frc::CheckStatusForceThrow(env, status);
 }
 
 /*
@@ -56,7 +54,7 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialSetBaudRate(
   int32_t status = 0;
   HAL_SetOSSerialBaudRate(static_cast<HAL_SerialPort>(port), rate, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -72,7 +70,7 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialSetDataBits(
   int32_t status = 0;
   HAL_SetOSSerialDataBits(static_cast<HAL_SerialPort>(port), bits, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -88,7 +86,7 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialSetParity(
   int32_t status = 0;
   HAL_SetOSSerialParity(static_cast<HAL_SerialPort>(port), parity, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -104,7 +102,7 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialSetStopBits(
   int32_t status = 0;
   HAL_SetOSSerialStopBits(static_cast<HAL_SerialPort>(port), bits, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -120,7 +118,7 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialSetWriteMode(
   int32_t status = 0;
   HAL_SetOSSerialWriteMode(static_cast<HAL_SerialPort>(port), mode, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -136,7 +134,7 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialSetFlowControl(
   int32_t status = 0;
   HAL_SetOSSerialFlowControl(static_cast<HAL_SerialPort>(port), flow, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -152,7 +150,7 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialSetTimeout(
   int32_t status = 0;
   HAL_SetOSSerialTimeout(static_cast<HAL_SerialPort>(port), timeout, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -168,7 +166,7 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialEnableTermination(
   int32_t status = 0;
   HAL_EnableOSSerialTermination(static_cast<HAL_SerialPort>(port), terminator, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -183,7 +181,7 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialDisableTermination(
   int32_t status = 0;
   HAL_DisableOSSerialTermination(static_cast<HAL_SerialPort>(port), &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -199,7 +197,7 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialSetReadBufferSize(
   int32_t status = 0;
   HAL_SetOSSerialReadBufferSize(static_cast<HAL_SerialPort>(port), size, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -215,7 +213,7 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialSetWriteBufferSize(
   int32_t status = 0;
   HAL_SetOSSerialWriteBufferSize(static_cast<HAL_SerialPort>(port), size, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -230,7 +228,7 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialGetBytesRecieved(
   int32_t status = 0;
   jint retVal = HAL_GetOSSerialBytesReceived(static_cast<HAL_SerialPort>(port), &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return retVal;
 }
 
@@ -249,7 +247,7 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialRead
                                  size, &status);
   SERIALJNI_LOG(logDEBUG) << "ReturnValue = " << retVal;
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return retVal;
 }
 
@@ -270,7 +268,7 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialWrit
                                   size, &status);
   SERIALJNI_LOG(logDEBUG) << "ReturnValue = " << retVal;
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return retVal;
 }
 
@@ -285,7 +283,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialFlus
   int32_t status = 0;
   HAL_FlushOSSerial(static_cast<HAL_SerialPort>(port), &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -299,7 +297,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialClea
   int32_t status = 0;
   HAL_ClearOSSerial(static_cast<HAL_SerialPort>(port), &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -313,7 +311,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialClos
   int32_t status = 0;
   HAL_CloseOSSerial(static_cast<HAL_SerialPort>(port), &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 }  // extern "C"

--- a/wpilibj/src/athena/cpp/lib/PDPJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/PDPJNI.cpp
@@ -10,8 +10,6 @@
 #include "HALUtil.h"
 #include "edu_wpi_first_wpilibj_hal_PDPJNI.h"
 
-using namespace frc;
-
 extern "C" {
 
 /*
@@ -23,7 +21,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_PDPJNI_initializePDP(
     JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   HAL_InitializePDP(module, &status);
-  CheckStatusRange(env, status, 0, HAL_GetNumPDPModules(), module);
+  frc::CheckStatusRange(env, status, 0, HAL_GetNumPDPModules(), module);
 }
 
 /*
@@ -56,7 +54,7 @@ Java_edu_wpi_first_wpilibj_hal_PDPJNI_getPDPTemperature(
     JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   double temperature = HAL_GetPDPTemperature(module, &status);
-  CheckStatus(env, status, false);
+  frc::CheckStatus(env, status, false);
   return temperature;
 }
 
@@ -69,7 +67,7 @@ JNIEXPORT jdouble JNICALL Java_edu_wpi_first_wpilibj_hal_PDPJNI_getPDPVoltage(
     JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   double voltage = HAL_GetPDPVoltage(module, &status);
-  CheckStatus(env, status, false);
+  frc::CheckStatus(env, status, false);
   return voltage;
 }
 
@@ -83,7 +81,7 @@ Java_edu_wpi_first_wpilibj_hal_PDPJNI_getPDPChannelCurrent(
     JNIEnv *env, jclass, jbyte channel, jint module) {
   int32_t status = 0;
   double current = HAL_GetPDPChannelCurrent(module, channel, &status);
-  CheckStatus(env, status, false);
+  frc::CheckStatus(env, status, false);
   return current;
 }
 
@@ -97,7 +95,7 @@ Java_edu_wpi_first_wpilibj_hal_PDPJNI_getPDPTotalCurrent(
     JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   double current = HAL_GetPDPTotalCurrent(module, &status);
-  CheckStatus(env, status, false);
+  frc::CheckStatus(env, status, false);
   return current;
 }
 
@@ -111,7 +109,7 @@ Java_edu_wpi_first_wpilibj_hal_PDPJNI_getPDPTotalPower(
     JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   double power = HAL_GetPDPTotalPower(module, &status);
-  CheckStatus(env, status, false);
+  frc::CheckStatus(env, status, false);
   return power;
 }
 
@@ -125,7 +123,7 @@ Java_edu_wpi_first_wpilibj_hal_PDPJNI_getPDPTotalEnergy(
     JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   double energy = HAL_GetPDPTotalEnergy(module, &status);
-  CheckStatus(env, status, false);
+  frc::CheckStatus(env, status, false);
   return energy;
 }
 
@@ -139,7 +137,7 @@ Java_edu_wpi_first_wpilibj_hal_PDPJNI_resetPDPTotalEnergy(
     JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   HAL_ResetPDPTotalEnergy(module, &status);
-  CheckStatus(env, status, false);
+  frc::CheckStatus(env, status, false);
 }
 
 /*
@@ -152,7 +150,7 @@ Java_edu_wpi_first_wpilibj_hal_PDPJNI_clearPDPStickyFaults(
     JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   HAL_ClearPDPStickyFaults(module, &status);
-  CheckStatus(env, status, false);
+  frc::CheckStatus(env, status, false);
 }
 
 }  // extern "C"

--- a/wpilibj/src/athena/cpp/lib/PWMJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/PWMJNI.cpp
@@ -17,8 +17,6 @@
 #include "HALUtil.h"
 #include "HAL/handles/HandlesInternal.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel pwmJNILogLevel = logWARNING;
 
@@ -44,8 +42,8 @@ Java_edu_wpi_first_wpilibj_hal_PWMJNI_initializePWMPort(
   auto pwm = HAL_InitializePWMPort((HAL_PortHandle)id, &status);
   PWMJNI_LOG(logDEBUG) << "Status = " << status;
   PWMJNI_LOG(logDEBUG) << "PWM Handle = " << pwm;
-  CheckStatusRange(env, status, 0, HAL_GetNumPWMChannels(),
-                   hal::getPortHandleChannel((HAL_PortHandle)id));
+  frc::CheckStatusRange(env, status, 0, HAL_GetNumPWMChannels(),
+                        hal::getPortHandleChannel((HAL_PortHandle)id));
   return (jint)pwm;
 }
 
@@ -72,7 +70,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_PWMJNI_freePWMPort(
   PWMJNI_LOG(logDEBUG) << "Port Handle = " << (HAL_DigitalHandle)id;
   int32_t status = 0;
   HAL_FreePWMPort((HAL_DigitalHandle)id, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -88,7 +86,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_PWMJNI_setPWMConfigRaw(
   int32_t status = 0;
   HAL_SetPWMConfigRaw((HAL_DigitalHandle)id, maxPwm, deadbandMaxPwm, centerPwm, 
                deadbandMinPwm, minPwm, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -104,7 +102,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_PWMJNI_setPWMConfig(
   int32_t status = 0;
   HAL_SetPWMConfig((HAL_DigitalHandle)id, maxPwm, deadbandMaxPwm, centerPwm, 
                deadbandMinPwm, minPwm, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -124,9 +122,9 @@ JNIEXPORT jobject JNICALL Java_edu_wpi_first_wpilibj_hal_PWMJNI_getPWMConfigRaw(
   int32_t minPwm = 0;
   HAL_GetPWMConfigRaw((HAL_DigitalHandle)id, &maxPwm, &deadbandMaxPwm, &centerPwm, 
                &deadbandMinPwm, &minPwm, &status);
-  CheckStatus(env, status);
-  return CreatePWMConfigDataResult(env, maxPwm, deadbandMaxPwm, centerPwm,
-                                   deadbandMinPwm, minPwm);
+  frc::CheckStatus(env, status);
+  return frc::CreatePWMConfigDataResult(env, maxPwm, deadbandMaxPwm, centerPwm,
+                                        deadbandMinPwm, minPwm);
 }
 
 /*
@@ -140,7 +138,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_PWMJNI_setPWMEliminateDead
   int32_t status = 0;
   HAL_SetPWMEliminateDeadband((HAL_DigitalHandle)id, value, &status);
   PWMJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -154,7 +152,7 @@ JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_hal_PWMJNI_getPWMEliminate
   int32_t status = 0;
   auto val = HAL_GetPWMEliminateDeadband((HAL_DigitalHandle)id, &status);
   PWMJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return (jboolean)val;
 }
 
@@ -170,7 +168,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_PWMJNI_setPWMRaw(
   int32_t status = 0;
   HAL_SetPWMRaw((HAL_DigitalHandle)id, value, &status);
   PWMJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -185,7 +183,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_PWMJNI_setPWMSpeed(
   int32_t status = 0;
   HAL_SetPWMSpeed((HAL_DigitalHandle)id, value, &status);
   PWMJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -200,7 +198,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_PWMJNI_setPWMPosition(
   int32_t status = 0;
   HAL_SetPWMPosition((HAL_DigitalHandle)id, value, &status);
   PWMJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -216,7 +214,7 @@ Java_edu_wpi_first_wpilibj_hal_PWMJNI_getPWMRaw(
   jshort returnValue = HAL_GetPWMRaw((HAL_DigitalHandle)id, &status);
   PWMJNI_LOG(logDEBUG) << "Status = " << status;
   PWMJNI_LOG(logDEBUG) << "Value = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -233,7 +231,7 @@ Java_edu_wpi_first_wpilibj_hal_PWMJNI_getPWMSpeed(
   jdouble returnValue = HAL_GetPWMSpeed((HAL_DigitalHandle)id, &status);
   PWMJNI_LOG(logDEBUG) << "Status = " << status;
   PWMJNI_LOG(logDEBUG) << "Value = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -250,7 +248,7 @@ Java_edu_wpi_first_wpilibj_hal_PWMJNI_getPWMPosition(
   jdouble returnValue = HAL_GetPWMPosition((HAL_DigitalHandle)id, &status);
   PWMJNI_LOG(logDEBUG) << "Status = " << status;
   PWMJNI_LOG(logDEBUG) << "Value = " << returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 
@@ -265,7 +263,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_PWMJNI_setPWMDisabled(
   int32_t status = 0;
   HAL_SetPWMDisabled((HAL_DigitalHandle)id, &status);
   PWMJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -279,7 +277,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_PWMJNI_latchPWMZero(
   int32_t status = 0;
   HAL_LatchPWMZero((HAL_DigitalHandle)id, &status);
   PWMJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -294,7 +292,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_PWMJNI_setPWMPeriodScale(
   int32_t status = 0;
   HAL_SetPWMPeriodScale((HAL_DigitalHandle)id, value, &status);
   PWMJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 }  // extern "C"

--- a/wpilibj/src/athena/cpp/lib/PortsJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/PortsJNI.cpp
@@ -14,8 +14,6 @@
 #include "HAL/Ports.h"
 #include "HALUtil.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel portsJNILogLevel = logWARNING;
 

--- a/wpilibj/src/athena/cpp/lib/PowerJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/PowerJNI.cpp
@@ -10,8 +10,6 @@
 #include "HALUtil.h"
 #include "edu_wpi_first_wpilibj_hal_PowerJNI.h"
 
-using namespace frc;
-
 extern "C" {
 
 /*
@@ -23,7 +21,7 @@ JNIEXPORT jdouble JNICALL
 Java_edu_wpi_first_wpilibj_hal_PowerJNI_getVinVoltage(JNIEnv* env, jclass) {
   int32_t status = 0;
   double val = HAL_GetVinVoltage(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -36,7 +34,7 @@ JNIEXPORT jdouble JNICALL
 Java_edu_wpi_first_wpilibj_hal_PowerJNI_getVinCurrent(JNIEnv* env, jclass) {
   int32_t status = 0;
   double val = HAL_GetVinCurrent(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -49,7 +47,7 @@ JNIEXPORT jdouble JNICALL
 Java_edu_wpi_first_wpilibj_hal_PowerJNI_getUserVoltage6V(JNIEnv* env, jclass) {
   int32_t status = 0;
   double val = HAL_GetUserVoltage6V(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -62,7 +60,7 @@ JNIEXPORT jdouble JNICALL
 Java_edu_wpi_first_wpilibj_hal_PowerJNI_getUserCurrent6V(JNIEnv* env, jclass) {
   int32_t status = 0;
   double val = HAL_GetUserCurrent6V(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -75,7 +73,7 @@ JNIEXPORT jboolean JNICALL
 Java_edu_wpi_first_wpilibj_hal_PowerJNI_getUserActive6V(JNIEnv* env, jclass) {
   int32_t status = 0;
   bool val = HAL_GetUserActive6V(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -89,7 +87,7 @@ Java_edu_wpi_first_wpilibj_hal_PowerJNI_getUserCurrentFaults6V(
     JNIEnv* env, jclass) {
   int32_t status = 0;
   int32_t val = HAL_GetUserCurrentFaults6V(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -102,7 +100,7 @@ JNIEXPORT jdouble JNICALL
 Java_edu_wpi_first_wpilibj_hal_PowerJNI_getUserVoltage5V(JNIEnv* env, jclass) {
   int32_t status = 0;
   double val = HAL_GetUserVoltage5V(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -115,7 +113,7 @@ JNIEXPORT jdouble JNICALL
 Java_edu_wpi_first_wpilibj_hal_PowerJNI_getUserCurrent5V(JNIEnv* env, jclass) {
   int32_t status = 0;
   double val = HAL_GetUserCurrent5V(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -128,7 +126,7 @@ JNIEXPORT jboolean JNICALL
 Java_edu_wpi_first_wpilibj_hal_PowerJNI_getUserActive5V(JNIEnv* env, jclass) {
   int32_t status = 0;
   bool val = HAL_GetUserActive5V(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -142,7 +140,7 @@ Java_edu_wpi_first_wpilibj_hal_PowerJNI_getUserCurrentFaults5V(
     JNIEnv* env, jclass) {
   int32_t status = 0;
   int32_t val = HAL_GetUserCurrentFaults5V(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -155,7 +153,7 @@ JNIEXPORT jdouble JNICALL
 Java_edu_wpi_first_wpilibj_hal_PowerJNI_getUserVoltage3V3(JNIEnv* env, jclass) {
   int32_t status = 0;
   double val = HAL_GetUserVoltage3V3(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -168,7 +166,7 @@ JNIEXPORT jdouble JNICALL
 Java_edu_wpi_first_wpilibj_hal_PowerJNI_getUserCurrent3V3(JNIEnv* env, jclass) {
   int32_t status = 0;
   double val = HAL_GetUserCurrent3V3(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -181,7 +179,7 @@ JNIEXPORT jboolean JNICALL
 Java_edu_wpi_first_wpilibj_hal_PowerJNI_getUserActive3V3(JNIEnv* env, jclass) {
   int32_t status = 0;
   bool val = HAL_GetUserActive3V3(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -195,7 +193,7 @@ Java_edu_wpi_first_wpilibj_hal_PowerJNI_getUserCurrentFaults3V3(
     JNIEnv* env, jclass) {
   int32_t status = 0;
   int32_t val = HAL_GetUserCurrentFaults3V3(&status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 

--- a/wpilibj/src/athena/cpp/lib/RelayJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/RelayJNI.cpp
@@ -16,8 +16,6 @@
 #include "HALUtil.h"
 #include "HAL/handles/HandlesInternal.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel relayJNILogLevel = logWARNING;
 
@@ -43,8 +41,8 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_RelayJNI_initializeRelayPo
   HAL_RelayHandle handle = HAL_InitializeRelayPort((HAL_PortHandle)id, (uint8_t) fwd, &status);
   RELAYJNI_LOG(logDEBUG) << "Status = " << status;
   RELAYJNI_LOG(logDEBUG) << "Relay Handle = " << handle;
-  CheckStatusRange(env, status, 0, HAL_GetNumRelayChannels(),
-                   hal::getPortHandleChannel((HAL_PortHandle)id));
+  frc::CheckStatusRange(env, status, 0, HAL_GetNumRelayChannels(),
+                        hal::getPortHandleChannel((HAL_PortHandle)id));
   return (jint) handle;
 }
 
@@ -85,7 +83,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_RelayJNI_setRelay(
   int32_t status = 0;
   HAL_SetRelay((HAL_RelayHandle)id, value, &status);
   RELAYJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -102,7 +100,7 @@ Java_edu_wpi_first_wpilibj_hal_RelayJNI_getRelay(
   jboolean returnValue = HAL_GetRelay((HAL_RelayHandle)id, &status);
   RELAYJNI_LOG(logDEBUG) << "Status = " << status;
   RELAYJNI_LOG(logDEBUG) << "getRelayResult = " << (jint)returnValue;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return returnValue;
 }
 

--- a/wpilibj/src/athena/cpp/lib/SPIJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/SPIJNI.cpp
@@ -14,8 +14,6 @@
 #include "HAL/SPI.h"
 #include "HALUtil.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel spiJNILogLevel = logWARNING;
 
@@ -39,7 +37,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_SPIJNI_spiInitialize(
   int32_t status = 0;
   HAL_InitializeSPI(static_cast<HAL_SPIPort>(port), &status);
   SPIJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatusForceThrow(env, status);
+  frc::CheckStatusForceThrow(env, status);
 }
 
 /*
@@ -158,7 +156,7 @@ Java_edu_wpi_first_wpilibj_hal_SPIJNI_spiSetChipSelectActiveHigh(
   int32_t status = 0;
   HAL_SetSPIChipSelectActiveHigh(static_cast<HAL_SPIPort>(port), &status);
   SPIJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -174,7 +172,7 @@ Java_edu_wpi_first_wpilibj_hal_SPIJNI_spiSetChipSelectActiveLow(
   int32_t status = 0;
   HAL_SetSPIChipSelectActiveLow(static_cast<HAL_SPIPort>(port), &status);
   SPIJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -201,7 +199,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_SPIJNI_spiInitAccumulator(
   HAL_InitSPIAccumulator(static_cast<HAL_SPIPort>(port), period, cmd, xferSize, validMask, validValue,
                      dataShift, dataSize, isSigned, bigEndian, &status);
   SPIJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -216,7 +214,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_SPIJNI_spiFreeAccumulator(
   int32_t status = 0;
   HAL_FreeSPIAccumulator(static_cast<HAL_SPIPort>(port), &status);
   SPIJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -232,7 +230,7 @@ Java_edu_wpi_first_wpilibj_hal_SPIJNI_spiResetAccumulator(
   int32_t status = 0;
   HAL_ResetSPIAccumulator(static_cast<HAL_SPIPort>(port), &status);
   SPIJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -249,7 +247,7 @@ Java_edu_wpi_first_wpilibj_hal_SPIJNI_spiSetAccumulatorCenter(
   int32_t status = 0;
   HAL_SetSPIAccumulatorCenter(static_cast<HAL_SPIPort>(port), center, &status);
   SPIJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -266,7 +264,7 @@ Java_edu_wpi_first_wpilibj_hal_SPIJNI_spiSetAccumulatorDeadband(
   int32_t status = 0;
   HAL_SetSPIAccumulatorDeadband(static_cast<HAL_SPIPort>(port), deadband, &status);
   SPIJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -283,7 +281,7 @@ Java_edu_wpi_first_wpilibj_hal_SPIJNI_spiGetAccumulatorLastValue(
   jint retVal = HAL_GetSPIAccumulatorLastValue(static_cast<HAL_SPIPort>(port), &status);
   SPIJNI_LOG(logDEBUG) << "Status = " << status;
   SPIJNI_LOG(logDEBUG) << "ReturnValue = " << retVal;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return retVal;
 }
 
@@ -301,7 +299,7 @@ Java_edu_wpi_first_wpilibj_hal_SPIJNI_spiGetAccumulatorValue(
   jlong retVal = HAL_GetSPIAccumulatorValue(static_cast<HAL_SPIPort>(port), &status);
   SPIJNI_LOG(logDEBUG) << "Status = " << status;
   SPIJNI_LOG(logDEBUG) << "ReturnValue = " << retVal;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return retVal;
 }
 
@@ -319,7 +317,7 @@ Java_edu_wpi_first_wpilibj_hal_SPIJNI_spiGetAccumulatorCount(
   jint retVal = HAL_GetSPIAccumulatorCount(static_cast<HAL_SPIPort>(port), &status);
   SPIJNI_LOG(logDEBUG) << "Status = " << status;
   SPIJNI_LOG(logDEBUG) << "ReturnValue = " << retVal;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return retVal;
 }
 
@@ -337,7 +335,7 @@ Java_edu_wpi_first_wpilibj_hal_SPIJNI_spiGetAccumulatorAverage(
   jdouble retVal = HAL_GetSPIAccumulatorAverage(static_cast<HAL_SPIPort>(port), &status);
   SPIJNI_LOG(logDEBUG) << "Status = " << status;
   SPIJNI_LOG(logDEBUG) << "ReturnValue = " << retVal;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return retVal;
 }
 
@@ -361,7 +359,7 @@ Java_edu_wpi_first_wpilibj_hal_SPIJNI_spiGetAccumulatorOutput(
   SPIJNI_LOG(logDEBUG) << "Status = " << status;
   SPIJNI_LOG(logDEBUG) << "Value = " << *valuePtr;
   SPIJNI_LOG(logDEBUG) << "Count = " << *countPtr;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 }  // extern "C"

--- a/wpilibj/src/athena/cpp/lib/SerialPortJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/SerialPortJNI.cpp
@@ -14,8 +14,6 @@
 #include "HAL/SerialPort.h"
 #include "HALUtil.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel serialJNILogLevel = logWARNING;
 
@@ -40,7 +38,7 @@ Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialInitializePort(
   int32_t status = 0;
   HAL_InitializeSerialPort(static_cast<HAL_SerialPort>(port), &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatusForceThrow(env, status);
+  frc::CheckStatusForceThrow(env, status);
 }
 
 /*
@@ -56,7 +54,7 @@ Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialSetBaudRate(
   int32_t status = 0;
   HAL_SetSerialBaudRate(static_cast<HAL_SerialPort>(port), rate, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -72,7 +70,7 @@ Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialSetDataBits(
   int32_t status = 0;
   HAL_SetSerialDataBits(static_cast<HAL_SerialPort>(port), bits, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -88,7 +86,7 @@ Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialSetParity(
   int32_t status = 0;
   HAL_SetSerialParity(static_cast<HAL_SerialPort>(port), parity, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -104,7 +102,7 @@ Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialSetStopBits(
   int32_t status = 0;
   HAL_SetSerialStopBits(static_cast<HAL_SerialPort>(port), bits, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -120,7 +118,7 @@ Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialSetWriteMode(
   int32_t status = 0;
   HAL_SetSerialWriteMode(static_cast<HAL_SerialPort>(port), mode, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -136,7 +134,7 @@ Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialSetFlowControl(
   int32_t status = 0;
   HAL_SetSerialFlowControl(static_cast<HAL_SerialPort>(port), flow, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -152,7 +150,7 @@ Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialSetTimeout(
   int32_t status = 0;
   HAL_SetSerialTimeout(static_cast<HAL_SerialPort>(port), timeout, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -168,7 +166,7 @@ Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialEnableTermination(
   int32_t status = 0;
   HAL_EnableSerialTermination(static_cast<HAL_SerialPort>(port), terminator, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -183,7 +181,7 @@ Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialDisableTermination(
   int32_t status = 0;
   HAL_DisableSerialTermination(static_cast<HAL_SerialPort>(port), &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -199,7 +197,7 @@ Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialSetReadBufferSize(
   int32_t status = 0;
   HAL_SetSerialReadBufferSize(static_cast<HAL_SerialPort>(port), size, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -215,7 +213,7 @@ Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialSetWriteBufferSize(
   int32_t status = 0;
   HAL_SetSerialWriteBufferSize(static_cast<HAL_SerialPort>(port), size, &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -230,7 +228,7 @@ Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialGetBytesRecieved(
   int32_t status = 0;
   jint retVal = HAL_GetSerialBytesReceived(static_cast<HAL_SerialPort>(port), &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return retVal;
 }
 
@@ -249,7 +247,7 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialRead(
                                size, &status);
   SERIALJNI_LOG(logDEBUG) << "ReturnValue = " << retVal;
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return retVal;
 }
 
@@ -270,7 +268,7 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialWrite(
                                 size, &status);
   SERIALJNI_LOG(logDEBUG) << "ReturnValue = " << retVal;
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return retVal;
 }
 
@@ -285,7 +283,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialFlush(
   int32_t status = 0;
   HAL_FlushSerial(static_cast<HAL_SerialPort>(port), &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -299,7 +297,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialClear(
   int32_t status = 0;
   HAL_ClearSerial(static_cast<HAL_SerialPort>(port), &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -313,7 +311,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_SerialPortJNI_serialClose(
   int32_t status = 0;
   HAL_CloseSerial(static_cast<HAL_SerialPort>(port), &status);
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 }  // extern "C"

--- a/wpilibj/src/athena/cpp/lib/SolenoidJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/SolenoidJNI.cpp
@@ -15,8 +15,6 @@
 
 #include "HALUtil.h"
 
-using namespace frc;
-
 TLogLevel solenoidJNILogLevel = logERROR;
 
 #define SOLENOIDJNI_LOG(level)     \
@@ -47,8 +45,8 @@ Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_initializeSolenoidPort(
   SOLENOIDJNI_LOG(logDEBUG) << "Solenoid Port Handle = " << handle;
 
   // Use solenoid channels, as we have to pick one.
-  CheckStatusRange(env, status, 0, HAL_GetNumSolenoidChannels(),
-                   hal::getPortHandleChannel((HAL_PortHandle)id));;
+  frc::CheckStatusRange(env, status, 0, HAL_GetNumSolenoidChannels(),
+                        hal::getPortHandleChannel((HAL_PortHandle)id));;
   return (jint)handle;
 }
 
@@ -104,7 +102,7 @@ JNIEXPORT void JNICALL Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_setSolenoid(
 
   int32_t status = 0;
   HAL_SetSolenoid((HAL_SolenoidHandle)solenoid_port, value, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 /*
@@ -117,7 +115,7 @@ Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getSolenoid(
     JNIEnv *env, jclass, jint solenoid_port) {
   int32_t status = 0;
   jboolean val = HAL_GetSolenoid((HAL_SolenoidHandle)solenoid_port, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -131,7 +129,7 @@ Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getAllSolenoids(
     JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   jint val = HAL_GetAllSolenoids(module, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 
@@ -145,7 +143,7 @@ Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getPCMSolenoidBlackList(
     JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   jint val = HAL_GetPCMSolenoidBlackList(module, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 /*
@@ -158,7 +156,7 @@ Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getPCMSolenoidVoltageStickyFault(
     JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   bool val = HAL_GetPCMSolenoidVoltageStickyFault(module, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 /*
@@ -171,7 +169,7 @@ Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_getPCMSolenoidVoltageFault(
     JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   bool val = HAL_GetPCMSolenoidVoltageFault(module, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return val;
 }
 /*
@@ -184,7 +182,7 @@ Java_edu_wpi_first_wpilibj_hal_SolenoidJNI_clearAllPCMStickyFaults(
     JNIEnv *env, jclass, jint module) {
   int32_t status = 0;
   HAL_ClearAllPCMStickyFaults(module, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
 }
 
 }  // extern "C"

--- a/wpilibj/src/athena/cpp/lib/ThreadsJNI.cpp
+++ b/wpilibj/src/athena/cpp/lib/ThreadsJNI.cpp
@@ -14,8 +14,6 @@
 #include "HAL/Threads.h"
 #include "HALUtil.h"
 
-using namespace frc;
-
 // set the logging level
 TLogLevel threadsJNILogLevel = logWARNING;
 
@@ -37,7 +35,7 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_ThreadsJNI_getCurrentThrea
   int32_t status = 0;
   HAL_Bool isRT = false;
   auto ret = HAL_GetCurrentThreadPriority(&isRT, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return (jint)ret;
 }
 
@@ -52,7 +50,7 @@ JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_hal_ThreadsJNI_getCurrentT
   int32_t status = 0;
   HAL_Bool isRT = false;
   HAL_GetCurrentThreadPriority(&isRT, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return (jboolean)isRT;
 }
 
@@ -66,7 +64,7 @@ JNIEXPORT jboolean JNICALL Java_edu_wpi_first_wpilibj_hal_ThreadsJNI_setCurrentT
   THREADSJNI_LOG(logDEBUG) << "Callling SetCurrentThreadPriority";
   int32_t status = 0;
   auto ret = HAL_SetCurrentThreadPriority((HAL_Bool)realTime, (int32_t)priority, &status);
-  CheckStatus(env, status);
+  frc::CheckStatus(env, status);
   return (jboolean)ret;
 }
 


### PR DESCRIPTION
Use of std::chrono_literals in TimedRobot also had its scope constrained.