### PR TITLE
Use dotfile naming format for LiveWindow metadata

### DIFF
--- a/wpilibc/athena/src/RobotBase.cpp
+++ b/wpilibc/athena/src/RobotBase.cpp
@@ -57,7 +57,7 @@ RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
 
   // First and one-time initialization
   NetworkTable::GetTable("LiveWindow")
-      ->GetSubTable("~STATUS~")
+      ->GetSubTable(".status")
       ->PutBoolean("LW Enabled", false);
 
   LiveWindow::GetInstance()->SetEnabled(false);

--- a/wpilibc/shared/src/LiveWindow/LiveWindow.cpp
+++ b/wpilibc/shared/src/LiveWindow/LiveWindow.cpp
@@ -33,7 +33,7 @@ LiveWindow* LiveWindow::GetInstance() {
  */
 LiveWindow::LiveWindow() : m_scheduler(Scheduler::GetInstance()) {
   m_liveWindowTable = NetworkTable::GetTable("LiveWindow");
-  m_statusTable = m_liveWindowTable->GetSubTable("~STATUS~");
+  m_statusTable = m_liveWindowTable->GetSubTable(".status");
 }
 
 /**
@@ -227,11 +227,11 @@ void LiveWindow::InitializeLiveWindowComponents() {
     LiveWindowComponent c = elem.second;
     std::string subsystem = c.subsystem;
     std::string name = c.name;
-    m_liveWindowTable->GetSubTable(subsystem)->PutString("~TYPE~",
+    m_liveWindowTable->GetSubTable(subsystem)->PutString(".type",
                                                          "LW Subsystem");
     std::shared_ptr<ITable> table(
         m_liveWindowTable->GetSubTable(subsystem)->GetSubTable(name));
-    table->PutString("~TYPE~", component->GetSmartDashboardType());
+    table->PutString(".type", component->GetSmartDashboardType());
     table->PutString("Name", name);
     table->PutString("Subsystem", subsystem);
     component->InitTable(table);

--- a/wpilibc/shared/src/SmartDashboard/SmartDashboard.cpp
+++ b/wpilibc/shared/src/SmartDashboard/SmartDashboard.cpp
@@ -124,7 +124,7 @@ void SmartDashboard::PutData(llvm::StringRef key, Sendable* data) {
     return;
   }
   std::shared_ptr<ITable> dataTable(m_table->GetSubTable(key));
-  dataTable->PutString("~TYPE~", data->GetSmartDashboardType());
+  dataTable->PutString(".type", data->GetSmartDashboardType());
   data->InitTable(dataTable);
   m_tablesToData[dataTable] = data;
 }

--- a/wpilibc/sim/src/IterativeRobot.cpp
+++ b/wpilibc/sim/src/IterativeRobot.cpp
@@ -31,7 +31,7 @@ void IterativeRobot::StartCompetition() {
   LiveWindow* lw = LiveWindow::GetInstance();
   // first and one-time initialization
   NetworkTable::GetTable("LiveWindow")
-      ->GetSubTable("~STATUS~")
+      ->GetSubTable(".status")
       ->PutBoolean("LW Enabled", false);
   RobotInit();
 

--- a/wpilibc/sim/src/SampleRobot.cpp
+++ b/wpilibc/sim/src/SampleRobot.cpp
@@ -104,7 +104,7 @@ void SampleRobot::StartCompetition() {
   LiveWindow* lw = LiveWindow::GetInstance();
 
   NetworkTable::GetTable("LiveWindow")
-      ->GetSubTable("~STATUS~")
+      ->GetSubTable(".status")
       ->PutBoolean("LW Enabled", false);
 
   RobotMain();

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/CANSpeedController.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/CANSpeedController.java
@@ -145,7 +145,7 @@ public interface CANSpeedController extends SpeedController, PIDInterface, LiveW
   default void updateTable() {
     ITable table = getTable();
     if (table != null) {
-      table.putString("~TYPE~", SMART_DASHBOARD_TYPE);
+      table.putString(".type", SMART_DASHBOARD_TYPE);
       table.putString("Type", getClass().getSimpleName());
       table.putNumber("Mode", getControlMode().getValue());
       if (getControlMode().isPID()) {

--- a/wpilibj/src/athena/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/athena/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -61,7 +61,7 @@ public abstract class RobotBase {
     NetworkTable.setServerMode(); // must be before b
     m_ds = DriverStation.getInstance();
     NetworkTable.getTable(""); // forces network tables to initialize
-    NetworkTable.getTable("LiveWindow").getSubTable("~STATUS~").putBoolean("LW Enabled", false);
+    NetworkTable.getTable("LiveWindow").getSubTable(".status").putBoolean("LW Enabled", false);
 
     LiveWindow.setEnabled(false);
   }

--- a/wpilibj/src/shared/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+++ b/wpilibj/src/shared/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -39,16 +39,16 @@ public class LiveWindow {
   private static void initializeLiveWindowComponents() {
     System.out.println("Initializing the components first time");
     livewindowTable = NetworkTable.getTable("LiveWindow");
-    statusTable = livewindowTable.getSubTable("~STATUS~");
+    statusTable = livewindowTable.getSubTable(".status");
     for (Enumeration e = components.keys(); e.hasMoreElements(); ) {
       LiveWindowSendable component = (LiveWindowSendable) e.nextElement();
       LiveWindowComponent liveWindowComponent = components.get(component);
       String subsystem = liveWindowComponent.getSubsystem();
       String name = liveWindowComponent.getName();
       System.out.println("Initializing table for '" + subsystem + "' '" + name + "'");
-      livewindowTable.getSubTable(subsystem).putString("~TYPE~", "LW Subsystem");
+      livewindowTable.getSubTable(subsystem).putString(".type", "LW Subsystem");
       ITable table = livewindowTable.getSubTable(subsystem).getSubTable(name);
-      table.putString("~TYPE~", component.getSmartDashboardType());
+      table.putString(".type", component.getSmartDashboardType());
       table.putString("Name", name);
       table.putString("Subsystem", subsystem);
       component.initTable(table);

--- a/wpilibj/src/shared/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
+++ b/wpilibj/src/shared/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
@@ -49,7 +49,7 @@ public class SmartDashboard {
    */
   public static void putData(String key, Sendable data) {
     ITable dataTable = table.getSubTable(key);
-    dataTable.putString("~TYPE~", data.getSmartDashboardType());
+    dataTable.putString(".type", data.getSmartDashboardType());
     data.initTable(dataTable);
     tablesToData.put(dataTable, data);
   }

--- a/wpilibj/src/sim/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/sim/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -55,7 +55,7 @@ public abstract class RobotBase {
     NetworkTable.setServerMode();//must be before b
     m_ds = DriverStation.getInstance();
     NetworkTable.getTable("");  // forces network tables to initialize
-    NetworkTable.getTable("LiveWindow").getSubTable("~STATUS~").putBoolean("LW Enabled", false);
+    NetworkTable.getTable("LiveWindow").getSubTable(".status").putBoolean("LW Enabled", false);
   }
 
   /**


### PR DESCRIPTION
Closes #548 

This breaks SmartDashboard/SFX/Swing OutlineViewer. Shuffleboard and JavaFX OutlineViewer already support this format

I'm going to open a PR later for adding more data to the livewindow and generally improve key naming