### PR TITLE
Adds a HAL wrapper around the CAN API's

### DIFF
--- a/hal/src/main/native/athena/CAN.cpp
+++ b/hal/src/main/native/athena/CAN.cpp
@@ -1,0 +1,49 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2016-2017 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "HAL/CAN.h"
+
+#include <FRC_NetworkCommunication/CANSessionMux.h>
+
+extern "C" {
+
+void HAL_CAN_SendMessage(uint32_t messageID, const uint8_t* data,
+                         uint8_t dataSize, int32_t periodMs, int32_t* status) {
+  FRC_NetworkCommunication_CANSessionMux_sendMessage(messageID, data, dataSize,
+                                                     periodMs, status);
+}
+void HAL_CAN_ReceiveMessage(uint32_t* messageID, uint32_t messageIDMask,
+                            uint8_t* data, uint8_t* dataSize,
+                            uint32_t* timeStamp, int32_t* status) {
+  FRC_NetworkCommunication_CANSessionMux_receiveMessage(
+      messageID, messageIDMask, data, dataSize, timeStamp, status);
+}
+void HAL_CAN_OpenStreamSession(uint32_t* sessionHandle, uint32_t messageID,
+                               uint32_t messageIDMask, uint32_t maxMessages,
+                               int32_t* status) {
+  FRC_NetworkCommunication_CANSessionMux_openStreamSession(
+      sessionHandle, messageID, messageIDMask, maxMessages, status);
+}
+void HAL_CAN_CloseStreamSession(uint32_t sessionHandle) {
+  FRC_NetworkCommunication_CANSessionMux_closeStreamSession(sessionHandle);
+}
+void HAL_CAN_ReadStreamSession(uint32_t sessionHandle,
+                               struct HAL_CANStreamMessage* messages,
+                               uint32_t messagesToRead, uint32_t* messagesRead,
+                               int32_t* status) {
+  FRC_NetworkCommunication_CANSessionMux_readStreamSession(
+      sessionHandle, reinterpret_cast<tCANStreamMessage*>(messages),
+      messagesToRead, messagesRead, status);
+}
+void HAL_CAN_GetCANStatus(float* percentBusUtilization, uint32_t* busOffCount,
+                          uint32_t* txFullCount, uint32_t* receiveErrorCount,
+                          uint32_t* transmitErrorCount, int32_t* status) {
+  FRC_NetworkCommunication_CANSessionMux_getCANStatus(
+      percentBusUtilization, busOffCount, txFullCount, receiveErrorCount,
+      transmitErrorCount, status);
+}
+}

--- a/hal/src/main/native/athena/HAL.cpp
+++ b/hal/src/main/native/athena/HAL.cpp
@@ -17,7 +17,6 @@
 #include <mutex>
 #include <thread>
 
-#include <FRC_NetworkCommunication/CANSessionMux.h>
 #include <FRC_NetworkCommunication/FRCComm.h>
 #include <FRC_NetworkCommunication/LoadOut.h>
 #include <llvm/raw_ostream.h>
@@ -130,15 +129,15 @@ const char* HAL_GetErrorMessage(int32_t code) {
       return PARAMETER_OUT_OF_RANGE_MESSAGE;
     case HAL_COUNTER_NOT_SUPPORTED:
       return HAL_COUNTER_NOT_SUPPORTED_MESSAGE;
-    case ERR_CANSessionMux_InvalidBuffer:
+    case HAL_ERR_CANSessionMux_InvalidBuffer:
       return ERR_CANSessionMux_InvalidBuffer_MESSAGE;
-    case ERR_CANSessionMux_MessageNotFound:
+    case HAL_ERR_CANSessionMux_MessageNotFound:
       return ERR_CANSessionMux_MessageNotFound_MESSAGE;
-    case WARN_CANSessionMux_NoToken:
+    case HAL_WARN_CANSessionMux_NoToken:
       return WARN_CANSessionMux_NoToken_MESSAGE;
-    case ERR_CANSessionMux_NotAllowed:
+    case HAL_ERR_CANSessionMux_NotAllowed:
       return ERR_CANSessionMux_NotAllowed_MESSAGE;
-    case ERR_CANSessionMux_NotInitialized:
+    case HAL_ERR_CANSessionMux_NotInitialized:
       return ERR_CANSessionMux_NotInitialized_MESSAGE;
     case VI_ERROR_SYSTEM_ERROR:
       return VI_ERROR_SYSTEM_ERROR_MESSAGE;

--- a/hal/src/main/native/include/HAL/CAN.h
+++ b/hal/src/main/native/include/HAL/CAN.h
@@ -1,0 +1,60 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2016-2017 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <stdint.h>
+
+#include "HAL/Types.h"
+
+// These are copies of defines located in CANSessionMux.h prepended with HAL_
+
+#define HAL_CAN_SEND_PERIOD_NO_REPEAT 0
+#define HAL_CAN_SEND_PERIOD_STOP_REPEATING -1
+
+/* Flags in the upper bits of the messageID */
+#define HAL_CAN_IS_FRAME_REMOTE 0x80000000
+#define HAL_CAN_IS_FRAME_11BIT 0x40000000
+
+#define HAL_ERR_CANSessionMux_InvalidBuffer -44086
+#define HAL_ERR_CANSessionMux_MessageNotFound -44087
+#define HAL_WARN_CANSessionMux_NoToken 44087
+#define HAL_ERR_CANSessionMux_NotAllowed -44088
+#define HAL_ERR_CANSessionMux_NotInitialized -44089
+#define HAL_ERR_CANSessionMux_SessionOverrun 44050
+
+struct HAL_CANStreamMessage {
+  uint32_t messageID;
+  uint32_t timeStamp;
+  uint8_t data[8];
+  uint8_t dataSize;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void HAL_CAN_SendMessage(uint32_t messageID, const uint8_t* data,
+                         uint8_t dataSize, int32_t periodMs, int32_t* status);
+void HAL_CAN_ReceiveMessage(uint32_t* messageID, uint32_t messageIDMask,
+                            uint8_t* data, uint8_t* dataSize,
+                            uint32_t* timeStamp, int32_t* status);
+void HAL_CAN_OpenStreamSession(uint32_t* sessionHandle, uint32_t messageID,
+                               uint32_t messageIDMask, uint32_t maxMessages,
+                               int32_t* status);
+void HAL_CAN_CloseStreamSession(uint32_t sessionHandle);
+void HAL_CAN_ReadStreamSession(uint32_t sessionHandle,
+                               struct HAL_CANStreamMessage* messages,
+                               uint32_t messagesToRead, uint32_t* messagesRead,
+                               int32_t* status);
+void HAL_CAN_GetCANStatus(float* percentBusUtilization, uint32_t* busOffCount,
+                          uint32_t* txFullCount, uint32_t* receiveErrorCount,
+                          uint32_t* transmitErrorCount, int32_t* status);
+
+#ifdef __cplusplus
+}
+#endif

--- a/hal/src/main/native/include/HAL/HAL.h
+++ b/hal/src/main/native/include/HAL/HAL.h
@@ -17,6 +17,7 @@
 #include "HAL/AnalogInput.h"
 #include "HAL/AnalogOutput.h"
 #include "HAL/AnalogTrigger.h"
+#include "HAL/CAN.h"
 #include "HAL/Compressor.h"
 #include "HAL/Constants.h"
 #include "HAL/Counter.h"

--- a/hal/src/main/native/sim/CAN.cpp
+++ b/hal/src/main/native/sim/CAN.cpp
@@ -1,0 +1,28 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2016-2017 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "HAL/CAN.h"
+
+extern "C" {
+
+void HAL_CAN_SendMessage(uint32_t messageID, const uint8_t* data,
+                         uint8_t dataSize, int32_t periodMs, int32_t* status) {}
+void HAL_CAN_ReceiveMessage(uint32_t* messageID, uint32_t messageIDMask,
+                            uint8_t* data, uint8_t* dataSize,
+                            uint32_t* timeStamp, int32_t* status) {}
+void HAL_CAN_OpenStreamSession(uint32_t* sessionHandle, uint32_t messageID,
+                               uint32_t messageIDMask, uint32_t maxMessages,
+                               int32_t* status) {}
+void HAL_CAN_CloseStreamSession(uint32_t sessionHandle) {}
+void HAL_CAN_ReadStreamSession(uint32_t sessionHandle,
+                               struct HAL_CANStreamMessage* messages,
+                               uint32_t messagesToRead, uint32_t* messagesRead,
+                               int32_t* status) {}
+void HAL_CAN_GetCANStatus(float* percentBusUtilization, uint32_t* busOffCount,
+                          uint32_t* txFullCount, uint32_t* receiveErrorCount,
+                          uint32_t* transmitErrorCount, int32_t* status) {}
+}

--- a/hal/src/main/native/sim/ErrorsInternal.h
+++ b/hal/src/main/native/sim/ErrorsInternal.h
@@ -20,15 +20,6 @@ typedef enum {
                    // full.
 } CTR_Code;
 
-// CAN Errors
-
-#define ERR_CANSessionMux_InvalidBuffer -44086
-#define ERR_CANSessionMux_MessageNotFound -44087
-#define WARN_CANSessionMux_NoToken 44087
-#define ERR_CANSessionMux_NotAllowed -44088
-#define ERR_CANSessionMux_NotInitialized -44089
-#define ERR_CANSessionMux_SessionOverrun 44050
-
 // VISA Error
 #define _VI_ERROR (-2147483647L - 1)
 #define VI_ERROR_SYSTEM_ERROR (_VI_ERROR + 0x3FFF0000L)

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -102,15 +102,15 @@ const char* HAL_GetErrorMessage(int32_t code) {
       return PARAMETER_OUT_OF_RANGE_MESSAGE;
     case HAL_COUNTER_NOT_SUPPORTED:
       return HAL_COUNTER_NOT_SUPPORTED_MESSAGE;
-    case ERR_CANSessionMux_InvalidBuffer:
+    case HAL_ERR_CANSessionMux_InvalidBuffer:
       return ERR_CANSessionMux_InvalidBuffer_MESSAGE;
-    case ERR_CANSessionMux_MessageNotFound:
+    case HAL_ERR_CANSessionMux_MessageNotFound:
       return ERR_CANSessionMux_MessageNotFound_MESSAGE;
-    case WARN_CANSessionMux_NoToken:
+    case HAL_WARN_CANSessionMux_NoToken:
       return WARN_CANSessionMux_NoToken_MESSAGE;
-    case ERR_CANSessionMux_NotAllowed:
+    case HAL_ERR_CANSessionMux_NotAllowed:
       return ERR_CANSessionMux_NotAllowed_MESSAGE;
-    case ERR_CANSessionMux_NotInitialized:
+    case HAL_ERR_CANSessionMux_NotInitialized:
       return ERR_CANSessionMux_NotInitialized_MESSAGE;
     case VI_ERROR_SYSTEM_ERROR:
       return VI_ERROR_SYSTEM_ERROR_MESSAGE;


### PR DESCRIPTION
Can someday be added to the simulator. Removes the last use case for the
ni headers directly.