### PR TITLE
Replacing FRC_NetworkCommunication in wpilibj with the HAL CAN code to maintain consistency

### DIFF
--- a/wpilibj/src/main/native/cpp/CANJNI.cpp
+++ b/wpilibj/src/main/native/cpp/CANJNI.cpp
@@ -8,10 +8,8 @@
 #include <assert.h>
 #include <jni.h>
 
-#ifdef CONFIG_ATHENA
-#include "FRC_NetworkCommunication/CANSessionMux.h"
-#endif
 #include "HAL/cpp/Log.h"
+#include "HAL/CAN.h"
 #include "HALUtil.h"
 #include "edu_wpi_first_wpilibj_can_CANJNI.h"
 #include "llvm/SmallString.h"
@@ -41,7 +39,7 @@ extern "C" {
 JNIEXPORT void JNICALL
 Java_edu_wpi_first_wpilibj_can_CANJNI_FRCNetCommCANSessionMuxSendMessage(
     JNIEnv *env, jclass, jint messageID, jbyteArray data, jint periodMs) {
-#ifdef CONFIG_ATHENA
+
   CANJNI_LOG(logDEBUG)
       << "Calling CANJNI FRCNetCommCANSessionMuxSendMessage";
 
@@ -70,14 +68,11 @@ Java_edu_wpi_first_wpilibj_can_CANJNI_FRCNetCommCANSessionMuxSendMessage(
   CANJNI_LOG(logDEBUG) << "Period: " << periodMs;
 
   int32_t status = 0;
-  FRC_NetworkCommunication_CANSessionMux_sendMessage(
+  HAL_CAN_SendMessage(
       messageID, dataBuffer, dataSize, periodMs, &status);
 
   CANJNI_LOG(logDEBUG) << "Status: " << status;
   CheckCANStatus(env, status, messageID);
-#else
-  // Noop on other platforms
-#endif
 }
 
 /*
@@ -89,7 +84,7 @@ JNIEXPORT jbyteArray JNICALL
 Java_edu_wpi_first_wpilibj_can_CANJNI_FRCNetCommCANSessionMuxReceiveMessage(
     JNIEnv *env, jclass, jobject messageID, jint messageIDMask,
     jobject timeStamp) {
-#ifdef CONFIG_ATHENA
+
   CANJNI_LOG(logDEBUG)
       << "Calling CANJNI FRCNetCommCANSessionMuxReceiveMessage";
 
@@ -100,7 +95,7 @@ Java_edu_wpi_first_wpilibj_can_CANJNI_FRCNetCommCANSessionMuxReceiveMessage(
   uint8_t buffer[8];
 
   int32_t status = 0;
-  FRC_NetworkCommunication_CANSessionMux_receiveMessage(
+  HAL_CAN_ReceiveMessage(
       messageIDPtr, messageIDMask, buffer, &dataSize, timeStampPtr, &status);
 
   CANJNI_LOG(logDEBUG) << "Message ID ";
@@ -128,10 +123,6 @@ Java_edu_wpi_first_wpilibj_can_CANJNI_FRCNetCommCANSessionMuxReceiveMessage(
   if (!CheckCANStatus(env, status, *messageIDPtr)) return nullptr;
   return MakeJByteArray(env, llvm::StringRef{reinterpret_cast<const char*>(buffer), 
                         static_cast<size_t>(dataSize)});
-#else
-  // Noop on other platforms. Return nullptr
-  return nullptr;
-#endif
 }
 
 }  // extern "C"

--- a/wpilibj/src/main/native/cpp/HALUtil.cpp
+++ b/wpilibj/src/main/native/cpp/HALUtil.cpp
@@ -15,9 +15,7 @@
 #include <cstring>
 #include <string>
 
-#ifdef CONFIG_ATHENA
-#include "FRC_NetworkCommunication/CANSessionMux.h"
-#endif
+#include "HAL/CAN.h"
 #include "HAL/HAL.h"
 #include "HAL/DriverStation.h"
 #include "HAL/Errors.h"
@@ -122,9 +120,7 @@ void ReportCANError(JNIEnv *env, int32_t status, int message_id) {
     case kRioStatusSuccess:
       // Everything is ok... don't throw.
       break;
-#ifdef CONFIG_ATHENA
-    case ERR_CANSessionMux_InvalidBuffer:
-#endif
+    case HAL_ERR_CANSessionMux_InvalidBuffer:
     case kRIOStatusBufferInvalidSize: {
       static jmethodID invalidBufConstruct = nullptr;
       if (!invalidBufConstruct)
@@ -135,9 +131,7 @@ void ReportCANError(JNIEnv *env, int32_t status, int message_id) {
       env->Throw(static_cast<jthrowable>(exception));
       break;
     }
-#ifdef CONFIG_ATHENA
-    case ERR_CANSessionMux_MessageNotFound:
-#endif
+    case HAL_ERR_CANSessionMux_MessageNotFound:
     case kRIOStatusOperationTimedOut: {
       static jmethodID messageNotFoundConstruct = nullptr;
       if (!messageNotFoundConstruct)
@@ -148,9 +142,7 @@ void ReportCANError(JNIEnv *env, int32_t status, int message_id) {
       env->Throw(static_cast<jthrowable>(exception));
       break;
     }
-#ifdef CONFIG_ATHENA
-    case ERR_CANSessionMux_NotAllowed:
-#endif
+    case HAL_ERR_CANSessionMux_NotAllowed:
     case kRIOStatusFeatureNotSupported: {
       llvm::SmallString<100> buf;
       llvm::raw_svector_ostream oss(buf);
@@ -158,9 +150,7 @@ void ReportCANError(JNIEnv *env, int32_t status, int message_id) {
       canMessageNotAllowedExCls.Throw(env, buf.c_str());
       break;
     }
-#ifdef CONFIG_ATHENA
-    case ERR_CANSessionMux_NotInitialized:
-#endif
+    case HAL_ERR_CANSessionMux_NotInitialized:
     case kRIOStatusResourceNotInitialized: {
       static jmethodID notInitConstruct = nullptr;
       if (!notInitConstruct)


### PR DESCRIPTION
Keep that header and the ifdefs out of wpilibj libraray.  Based on #623 