### PR TITLE
Move published wpilibj JNI shared artifact into shared/ subfolder

### DIFF
--- a/wpilibj/publish.gradle
+++ b/wpilibj/publish.gradle
@@ -97,7 +97,7 @@ model {
                     if (binary instanceof SharedLibraryBinarySpec) {
                         task.dependsOn binary.buildTask
                         task.from (binary.sharedLibraryFile) {
-                            into getPlatformPath(binary)
+                            into getPlatformPath(binary) + '/shared'
                         }
                     }
                 }


### PR DESCRIPTION
Makes eclipse easier.