### PR TITLE
Change metadata format to dotfile, make certain entries metadata

### DIFF
--- a/wpilibc/src/main/native/cpp/Commands/Command.cpp
+++ b/wpilibc/src/main/native/cpp/Commands/Command.cpp
@@ -17,9 +17,9 @@
 
 using namespace frc;
 
-static const std::string kName = "name";
+static const std::string kName = ".name";
 static const std::string kRunning = "running";
-static const std::string kIsParented = "isParented";
+static const std::string kIsParented = ".isParented";
 
 int Command::m_commandCounter = 0;
 

--- a/wpilibc/src/main/native/cpp/LiveWindow/LiveWindow.cpp
+++ b/wpilibc/src/main/native/cpp/LiveWindow/LiveWindow.cpp
@@ -36,7 +36,7 @@ LiveWindow* LiveWindow::GetInstance() {
 LiveWindow::LiveWindow() : m_scheduler(Scheduler::GetInstance()) {
   m_liveWindowTable =
       nt::NetworkTableInstance::GetDefault().GetTable("LiveWindow");
-  m_statusTable = m_liveWindowTable->GetSubTable("~STATUS~");
+  m_statusTable = m_liveWindowTable->GetSubTable(".status");
   m_enabledEntry = m_statusTable->GetEntry("LW Enabled");
 }
 
@@ -231,12 +231,12 @@ void LiveWindow::InitializeLiveWindowComponents() {
     LiveWindowComponent c = elem.second;
     std::string subsystem = c.subsystem;
     std::string name = c.name;
-    m_liveWindowTable->GetSubTable(subsystem)->GetEntry("~TYPE~").SetString(
+    m_liveWindowTable->GetSubTable(subsystem)->GetEntry(".type").SetString(
         "LW Subsystem");
     std::shared_ptr<NetworkTable> table(
         m_liveWindowTable->GetSubTable(subsystem)->GetSubTable(name));
-    table->GetEntry("~TYPE~").SetString(component->GetSmartDashboardType());
-    table->GetEntry("Name").SetString(name);
+    table->GetEntry(".type").SetString(component->GetSmartDashboardType());
+    table->GetEntry(".name").SetString(name);
     table->GetEntry("Subsystem").SetString(subsystem);
     component->InitTable(table);
     if (c.isSensor) {

--- a/wpilibc/src/main/native/cpp/RobotBase.cpp
+++ b/wpilibc/src/main/native/cpp/RobotBase.cpp
@@ -59,7 +59,7 @@ RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
 
   // First and one-time initialization
   inst.GetTable("LiveWindow")
-      ->GetSubTable("~STATUS~")
+      ->GetSubTable(".status")
       ->GetEntry("LW Enabled")
       .SetBoolean(false);
 

--- a/wpilibc/src/main/native/cpp/SmartDashboard/SmartDashboard.cpp
+++ b/wpilibc/src/main/native/cpp/SmartDashboard/SmartDashboard.cpp
@@ -127,7 +127,7 @@ void SmartDashboard::PutData(llvm::StringRef key, Sendable* data) {
     return;
   }
   std::shared_ptr<nt::NetworkTable> dataTable(s_table->GetSubTable(key));
-  dataTable->GetEntry("~TYPE~").SetString(data->GetSmartDashboardType());
+  dataTable->GetEntry(".type").SetString(data->GetSmartDashboardType());
   data->InitTable(dataTable);
   s_tablesToData[dataTable] = data;
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -61,7 +61,7 @@ public abstract class RobotBase {
     inst.setNetworkIdentity("Robot");
     inst.startServer("/home/lvuser/networktables.ini");
     m_ds = DriverStation.getInstance();
-    inst.getTable("LiveWindow").getSubTable("~STATUS~").getEntry("LW Enabled").setBoolean(false);
+    inst.getTable("LiveWindow").getSubTable(".status").getEntry("LW Enabled").setBoolean(false);
 
     LiveWindow.setEnabled(false);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
@@ -575,8 +575,8 @@ public abstract class Command implements NamedSendable {
     }
     if (table != null) {
       m_runningEntry = table.getEntry("running");
-      m_isParentedEntry = table.getEntry("isParented");
-      table.getEntry("name").setString(getName());
+      m_isParentedEntry = table.getEntry(".isParented");
+      table.getEntry(".name").setString(getName());
       m_runningEntry.setBoolean(isRunning());
       m_isParentedEntry.setBoolean(m_parent != null);
       m_runningListener = m_runningEntry.addListener((event) -> {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -41,7 +41,7 @@ public class LiveWindow {
   private static void initializeLiveWindowComponents() {
     System.out.println("Initializing the components first time");
     livewindowTable = NetworkTableInstance.getDefault().getTable("LiveWindow");
-    statusTable = livewindowTable.getSubTable("~STATUS~");
+    statusTable = livewindowTable.getSubTable(".status");
     enabledEntry = statusTable.getEntry("LW Enabled");
     for (Enumeration e = components.keys(); e.hasMoreElements(); ) {
       LiveWindowSendable component = (LiveWindowSendable) e.nextElement();
@@ -49,11 +49,11 @@ public class LiveWindow {
       String subsystem = liveWindowComponent.getSubsystem();
       String name = liveWindowComponent.getName();
       System.out.println("Initializing table for '" + subsystem + "' '" + name + "'");
-      livewindowTable.getSubTable(subsystem).getEntry("~TYPE~").setString("LW Subsystem");
+      livewindowTable.getSubTable(subsystem).getEntry(".type").setString("LW Subsystem");
       NetworkTable table = livewindowTable.getSubTable(subsystem).getSubTable(name);
-      table.getEntry("~TYPE~").setString(component.getSmartDashboardType());
-      table.getEntry("Name").setString(name);
-      table.getEntry("Subsystem").setString(subsystem);
+      table.getEntry(".type").setString(component.getSmartDashboardType());
+      table.getEntry(".name").setString(name);
+      table.getEntry(".subsystem").setString(subsystem);
       component.initTable(table);
       if (liveWindowComponent.isSensor()) {
         sensors.addElement(component);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
@@ -51,7 +51,7 @@ public class SmartDashboard {
    */
   public static void putData(String key, Sendable data) {
     NetworkTable dataTable = table.getSubTable(key);
-    dataTable.getEntry("~TYPE~").setString(data.getSmartDashboardType());
+    dataTable.getEntry(".type").setString(data.getSmartDashboardType());
     data.initTable(dataTable);
     tablesToData.put(dataTable, data);
   }


### PR DESCRIPTION
Closes #548 

Changed to dotfile format from tildes: `~TYPE~`, `~STATUS~` => `.type`, `.status`

Keys that are now metadata:

| Component | Old key | New key |
|---|---|---|
| Sendable (in LiveWindow) | `"Name"` | `".name"` |
|  | `"Subsystem"` | `".subsystem"` |
| Command | `"name"` | `".name"`
|  | `"isParented"` | `".isParented"`

These keys are now metadata to reduce clutter in dashboards and table viewers

Supersedes and closes #600 due to many merge conflicts in that PR

Smartdashboard currently uses the dotfile format so this is required for beta. Shuffleboard and OutlineViewer are both backwards compatible.