### PR TITLE
Removes OpenCV dependency from wpilibJNI

### DIFF
--- a/wpilibj/build.gradle
+++ b/wpilibj/build.gradle
@@ -224,15 +224,6 @@ model {
             sharedConfigs = [ wpilibJNIShared: [] ]
             staticConfigs = [ wpilibJNIStatic: [] ]
         }
-        opencv(DependencyConfig) {
-            groupId = 'org.opencv'
-            artifactId = 'opencv-cpp'
-            headerClassifier = 'headers'
-            ext = 'zip'
-            version = '3.2.0'
-            sharedConfigs = [ wpilibJNIShared: [] ]
-            staticConfigs = [ wpilibJNIStatic: [] ]
-        }
     }
     components {
         wpilibJNIStatic(NativeLibrarySpec) {


### PR DESCRIPTION
Not exactly sure why it was there in the first place. Closes #664