### PR TITLE
Set the llvm standard output stream to be unbuffered.

### DIFF
--- a/hal/src/main/native/athena/HAL.cpp
+++ b/hal/src/main/native/athena/HAL.cpp
@@ -342,6 +342,7 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
 
   setlinebuf(stdin);
   setlinebuf(stdout);
+  llvm::outs().SetUnbuffered();
 
   prctl(PR_SET_PDEATHSIG, SIGTERM);
 

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -7,6 +7,8 @@
 
 #include "HAL/HAL.h"
 
+#include <llvm/raw_ostream.h>
+
 #include "ErrorsInternal.h"
 #include "HAL/DriverStation.h"
 #include "HAL/Errors.h"
@@ -204,6 +206,7 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
   // Second check in case another thread was waiting
   if (initialized) return true;
 
+  llvm::outs().SetUnbuffered();
   if (HAL_LoadExtensions() < 0) return false;
   hal::RestartTiming();
   HAL_InitializeDriverStation();


### PR DESCRIPTION
This is particularly useful for the simulation when invoked
inside Eclipse.  Otherwise, you won't see the robot starting
message.

I have tested this on both Linux and Windows with the simulator.  I am currently unable to test this on Athena as I don't have ready access to a Rio.