### PR TITLE
Fixes halsim_print to not try and build when the 'onlyAthena' flag has been set

### DIFF
--- a/simulation/halsim_print/build.gradle
+++ b/simulation/halsim_print/build.gradle
@@ -3,24 +3,26 @@ description = "A simulation shared object that simply prints robot behaviors"
 apply plugin: 'edu.wpi.first.NativeUtils'
 apply plugin: 'cpp'
 
-ext.skipAthena = true
+if (!project.hasProperty('onlyAthena')) {
+    ext.skipAthena = true
 
-apply from: "../../config.gradle"
+    apply from: "../../config.gradle"
 
 
-model {
-    components {
-        halsim_print(NativeLibrarySpec)
-    }
-
-    binaries {
-        all {
-            project(':hal').addHalCompilerArguments(it)
-            project(':hal').addHalToLinker(it)
+    model {
+        components {
+            halsim_print(NativeLibrarySpec)
         }
-        withType(StaticLibraryBinarySpec) {
-            it.buildable = false
+
+        binaries {
+            all {
+                project(':hal').addHalCompilerArguments(it)
+                project(':hal').addHalToLinker(it)
+            }
+            withType(StaticLibraryBinarySpec) {
+                it.buildable = false
+            }
         }
     }
+    apply from: 'publish.gradle'
 }
-apply from: 'publish.gradle'


### PR DESCRIPTION
Building a non-athena library in athena only is not possible.