### PR TITLE
Rewrites ConditionalCommand

### DIFF
--- a/wpilibc/src/main/native/cpp/Commands/CommandGroup.cpp
+++ b/wpilibc/src/main/native/cpp/Commands/CommandGroup.cpp
@@ -311,4 +311,19 @@ void CommandGroup::CancelConflicts(Command* command) {
   }
 }
 
+void CommandGroup::SetCommands(std::vector<CommandGroupEntry> cmds) {
+  for (auto& entry : cmds) {
+    auto requirements = entry.m_command->GetRequirements();
+    for (auto subsystem : requirements) {
+      if (!DoesRequire(subsystem)) {
+        wpi_setWPIErrorWithContext(
+            CommandIllegalUse,
+            "Command set does not match CommandGroup requirements");
+        return;
+      }
+    }
+    m_commands = cmds;
+  }
+}
+
 int CommandGroup::GetSize() const { return m_children.size(); }

--- a/wpilibc/src/main/native/include/Commands/CommandGroup.h
+++ b/wpilibc/src/main/native/include/Commands/CommandGroup.h
@@ -58,6 +58,8 @@ class CommandGroup : public Command {
   virtual void _Execute();
   virtual void _End();
 
+  virtual void SetCommands(std::vector<CommandGroupEntry> cmds);
+
  private:
   void CancelConflicts(Command* command);
 

--- a/wpilibc/src/main/native/include/Commands/ConditionalCommand.h
+++ b/wpilibc/src/main/native/include/Commands/ConditionalCommand.h
@@ -7,10 +7,11 @@
 
 #pragma once
 
+#include <vector>
+
 #include <llvm/Twine.h>
 
-#include "Commands/Command.h"
-#include "Commands/InstantCommand.h"
+#include "Commands/CommandGroup.h"
 
 namespace frc {
 
@@ -30,7 +31,7 @@ namespace frc {
  * @see Command
  * @see Scheduler
  */
-class ConditionalCommand : public Command {
+class ConditionalCommand : public CommandGroup {
  public:
   explicit ConditionalCommand(Command* onTrue, Command* onFalse = nullptr);
   ConditionalCommand(const llvm::Twine& name, Command* onTrue,
@@ -46,19 +47,15 @@ class ConditionalCommand : public Command {
   virtual bool Condition() = 0;
 
   void _Initialize() override;
-  void _Cancel() override;
-  bool IsFinished() override;
-  void Interrupted() override;
 
  private:
-  // The Command to execute if Condition() returns true
-  Command* m_onTrue;
+  // Commands to execute if Condition() returns true
+  std::vector<CommandGroupEntry> m_onTrue;
 
-  // The Command to execute if Condition() returns false
-  Command* m_onFalse;
+  // Commands to execute if Condition() returns false
+  std::vector<CommandGroupEntry> m_onFalse;
 
-  // Stores command chosen by condition
-  Command* m_chosenCommand = nullptr;
+  std::vector<CommandGroupEntry> ProcessCommand(Command* cmd);
 };
 
 }  // namespace frc


### PR DESCRIPTION
The current version of `ConditionalCommand` has several problems:

1. It assumes that `IsFinished` does not have any side effects. While that is generally good practice, that is not guaranteed. Since `IsFinished` is now being called by the `Scheduler` and by `ConditionalCommand`, any side effect is running twice as often. A simple example would be a counter, that would be incremented twice as quickly if it used as a branch in a `ConditionalCommand`. Even worse, if that counter expects to stop at an exact value, it might skip that value when the `Scheduler` calls it, meaning the `Command` would never end.
2. Even with a properly written `IsFinished` it is possible that the `ConditionalCommand` will never end. If `IsFinished` is called by the `Scheduler` first, then `IsRunning` will be false, which means that `ConditionalCommand`'s `IsFinished` method never returns true.
3. Since `ConditionalCommand` does not parent its branch commands, it is possible to call `Cancel` on a branch. This will also cause the ConditionalCommand to never end, since it does not detect that a branch was ended any other way than `IsFinished` returning true.

We ran into problems with `ConditionalCommand` hanging in certain situations in our autonomous program, and after trying to tweak the logic, we eventually realized that the best way to make `ConditionalCommand` behave correctly was to inherit from `CommandGroup`. This necessitated a change to the `CommandGroup` class in C++ so that `ConditionalCommand` could update its list of `Commands` in a safe manner.

Our team switched to Python last year, so this C++ is our best guess at how it could be implemented. You can see our team's Python implementation in [our GitHub account](https://github.com/FRC2539/pybot/blob/steamworks/commands/conditionalcommand.py).