### PR TITLE
Adding call to notify program started

### DIFF
--- a/hal/src/main/native/sim/DriverStation.cpp
+++ b/hal/src/main/native/sim/DriverStation.cpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "MockData/DriverStationDataInternal.h"
+#include "MockData/MockHooks.h"
 
 static std::mutex msgMutex;
 static std::condition_variable newDSDataAvailableCond;

--- a/hal/src/main/native/sim/DriverStation.cpp
+++ b/hal/src/main/native/sim/DriverStation.cpp
@@ -152,9 +152,7 @@ double HAL_GetMatchTime(int32_t* status) {
   return SimDriverStationData.GetMatchTime();
 }
 
-void HAL_ObserveUserProgramStarting(void) {
-  // TODO
-}
+void HAL_ObserveUserProgramStarting(void) { HALSIM_SetProgramStarted(); }
 
 void HAL_ObserveUserProgramDisabled(void) {
   // TODO


### PR DESCRIPTION
Causes the HALSIM_WaitForProgramStart loop to break, essentially
notifying simulators the robot is good to go.