### PR TITLE
Fixing bug in min axis count

### DIFF
--- a/wpilibc/src/main/native/include/Joystick.h
+++ b/wpilibc/src/main/native/include/Joystick.h
@@ -30,7 +30,7 @@ class Joystick : public GenericHID {
   static constexpr int kDefaultZAxis = 2;
   static constexpr int kDefaultTwistAxis = 2;
   static constexpr int kDefaultThrottleAxis = 3;
-  static constexpr int kMinNumAxes = 4;
+  static constexpr int kMinNumAxes = 5;
 
   enum AxisType { kXAxis, kYAxis, kZAxis, kTwistAxis, kThrottleAxis };
   enum ButtonType { kTriggerButton, kTopButton };

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
@@ -23,7 +23,7 @@ public class Joystick extends GenericHID {
   static final byte kDefaultZAxis = 2;
   static final byte kDefaultTwistAxis = 2;
   static final byte kDefaultThrottleAxis = 3;
-  static final byte kMinNumAxes = 4;
+  static final byte kMinNumAxes = 5;
 
   /**
    * Represents an analog axis on a joystick.


### PR DESCRIPTION
Looks like an off by one error.  Throws in
index out of bounds.