### PR TITLE
Add .type metadata to preferences table

### DIFF
--- a/wpilibc/src/main/native/cpp/Preferences.cpp
+++ b/wpilibc/src/main/native/cpp/Preferences.cpp
@@ -22,6 +22,7 @@ static llvm::StringRef kTableName{"Preferences"};
 
 Preferences::Preferences()
     : m_table(nt::NetworkTableInstance::GetDefault().GetTable(kTableName)) {
+  m_table->GetEntry(".type").SetString("RobotPreferences");
   m_listener = m_table->AddEntryListener(
       [=](nt::NetworkTable* table, llvm::StringRef name,
           nt::NetworkTableEntry entry, std::shared_ptr<nt::Value> value,

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Preferences.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Preferences.java
@@ -63,6 +63,7 @@ public class Preferences {
    */
   private Preferences() {
     m_table = NetworkTableInstance.getDefault().getTable(TABLE_NAME);
+    m_table.getEntry(".type").setString("RobotPreferences");
     // Listener to set all Preferences values to persistent
     // (for backwards compatibility with old dashboards).
     m_table.addEntryListener(


### PR DESCRIPTION
Allows shuffleboard to automatically discover the type, instead of inflexibly hardcoding it

This also puts it in line with "sendable" components