### PR TITLE
Add IDEA plugin to root project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ test-reports
 
 # IntelliJ
 *.iml
+*.ipr
+*.iws
 .idea/
 
 # Created by http://www.gitignore.io

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 plugins {
     id 'net.ltgt.errorprone' version '0.0.10'
     id 'edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin' version '2.0'
-	id 'idea'
+    id 'idea'
 }
 
 ext.licenseFile = file("$rootDir/LICENSE.txt")

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 plugins {
     id 'net.ltgt.errorprone' version '0.0.10'
     id 'edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin' version '2.0'
+	id 'idea'
 }
 
 ext.licenseFile = file("$rootDir/LICENSE.txt")


### PR DESCRIPTION
As the title implies. Adding to the root project allows for an intellij project file to be created, since the individual sub-project 'module' files are pretty useless without a linking, parent idea project.