### PR TITLE
Interface out IterativeBase

### DIFF
--- a/wpilibc/src/main/native/include/IterativeBase.h
+++ b/wpilibc/src/main/native/include/IterativeBase.h
@@ -7,42 +7,44 @@
 
 #pragma once
 
+namespace frc {
 
 /**
-* IterativeBase provides methods that are to be used when code is designed to be aware of
-* robot state. These are provided as 'init' functions and 'periodic' functions.
-*
-* Init() functions -- each of the following functions is called once when the
-*					  appropriate mode is entered:
+ * IterativeBase provides methods that are to be used when code is designed to
+ be aware of
+ * robot state. These are provided as 'init' functions and 'periodic' functions.
+ *
+ * Init() functions -- each of the following functions is called once when the
+ *					  appropriate mode is entered:
 
-*   - DisabledInit()   -- called only when first disabled
-*   - AutonomousInit() -- called each and every time autonomous is entered from
-*                         another mode
-*   - TeleopInit()     -- called each and every time teleop is entered from
-*                         another mode
-*   - TestInit()       -- called each and every time test is entered from
-*                         another mode
-*
-* Periodic() functions -- each of these functions is called on an interval:
+ *   - DisabledInit()   -- called only when first disabled
+ *   - AutonomousInit() -- called each and every time autonomous is entered from
+ *                         another mode
+ *   - TeleopInit()     -- called each and every time teleop is entered from
+ *                         another mode
+ *   - TestInit()       -- called each and every time test is entered from
+ *                         another mode
+ *
+ * Periodic() functions -- each of these functions is called on an interval:
 
-*   - RobotPeriodic()
-*   - DisabledPeriodic()
-*   - AutonomousPeriodic()
-*   - TeleopPeriodic()
-*   - TestPeriodic()
-*/
-namespace frc {
+ *   - RobotPeriodic()
+ *   - DisabledPeriodic()
+ *   - AutonomousPeriodic()
+ *   - TeleopPeriodic()
+ *   - TestPeriodic()
+ */
 class IterativeBase {
-  public:
-	virtual void DisabledInit() = 0;
-	virtual void AutonomousInit() = 0;
-	virtual void TeleopInit() = 0;
-	virtual void TestInit() = 0;
+ public:
+  virtual void DisabledInit() = 0;
+  virtual void AutonomousInit() = 0;
+  virtual void TeleopInit() = 0;
+  virtual void TestInit() = 0;
 
-	virtual void RobotPeriodic() = 0;
-	virtual void DisabledPeriodic() = 0;
-	virtual void AutonomousPeriodic() = 0;
-	virtual void TeleopPeriodic() = 0;
-	virtual void TestPeriodic() = 0;
+  virtual void RobotPeriodic() = 0;
+  virtual void DisabledPeriodic() = 0;
+  virtual void AutonomousPeriodic() = 0;
+  virtual void TeleopPeriodic() = 0;
+  virtual void TestPeriodic() = 0;
 };
+
 }  // namespace frc

--- a/wpilibc/src/main/native/include/IterativeBase.h
+++ b/wpilibc/src/main/native/include/IterativeBase.h
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+
+/**
+* IterativeBase provides methods that are to be used when code is designed to be aware of
+* robot state. These are provided as 'init' functions and 'periodic' functions.
+*
+* Init() functions -- each of the following functions is called once when the
+*					  appropriate mode is entered:
+
+*   - DisabledInit()   -- called only when first disabled
+*   - AutonomousInit() -- called each and every time autonomous is entered from
+*                         another mode
+*   - TeleopInit()     -- called each and every time teleop is entered from
+*                         another mode
+*   - TestInit()       -- called each and every time test is entered from
+*                         another mode
+*
+* Periodic() functions -- each of these functions is called on an interval:
+
+*   - RobotPeriodic()
+*   - DisabledPeriodic()
+*   - AutonomousPeriodic()
+*   - TeleopPeriodic()
+*   - TestPeriodic()
+*/
+namespace frc {
+class IterativeBase {
+  public:
+	virtual void DisabledInit() = 0;
+	virtual void AutonomousInit() = 0;
+	virtual void TeleopInit() = 0;
+	virtual void TestInit() = 0;
+
+	virtual void RobotPeriodic() = 0;
+	virtual void DisabledPeriodic() = 0;
+	virtual void AutonomousPeriodic() = 0;
+	virtual void TeleopPeriodic() = 0;
+	virtual void TestPeriodic() = 0;
+};
+}  // namespace frc

--- a/wpilibc/src/main/native/include/IterativeRobotBase.h
+++ b/wpilibc/src/main/native/include/IterativeRobotBase.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include "RobotBase.h"
 #include "IterativeBase.h"
+#include "RobotBase.h"
 
 namespace frc {
 
@@ -24,36 +24,22 @@ namespace frc {
  *
  * RobotInit() -- provide for initialization at robot power-on
  *
- * Init() functions -- each of the following functions is called once when the
- *                     appropriate mode is entered:
- *   - DisabledInit()   -- called only when first disabled
- *   - AutonomousInit() -- called each and every time autonomous is entered from
- *                         another mode
- *   - TeleopInit()     -- called each and every time teleop is entered from
- *                         another mode
- *   - TestInit()       -- called each and every time test is entered from
- *                         another mode
- *
- * Periodic() functions -- each of these functions is called on an interval:
- *   - RobotPeriodic()
- *   - DisabledPeriodic()
- *   - AutonomousPeriodic()
- *   - TeleopPeriodic()
- *   - TestPeriodic()
+ * Init() and Periodic() functions are implemented from, and documented within,
+ * IterativeBase.
  */
 class IterativeRobotBase : public RobotBase, public IterativeBase {
  public:
-  virtual void RobotInit();
-  virtual void DisabledInit();
-  virtual void AutonomousInit();
-  virtual void TeleopInit();
-  virtual void TestInit();
+  void RobotInit() override;
+  void DisabledInit() override;
+  void AutonomousInit() override;
+  void TeleopInit() override;
+  void TestInit() override;
 
-  virtual void RobotPeriodic();
-  virtual void DisabledPeriodic();
-  virtual void AutonomousPeriodic();
-  virtual void TeleopPeriodic();
-  virtual void TestPeriodic();
+  void RobotPeriodic() override;
+  void DisabledPeriodic() override;
+  void AutonomousPeriodic() override;
+  void TeleopPeriodic() override;
+  void TestPeriodic() override;
 
  protected:
   virtual ~IterativeRobotBase() = default;

--- a/wpilibc/src/main/native/include/IterativeRobotBase.h
+++ b/wpilibc/src/main/native/include/IterativeRobotBase.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "RobotBase.h"
+#include "IterativeBase.h"
 
 namespace frc {
 
@@ -40,7 +41,7 @@ namespace frc {
  *   - TeleopPeriodic()
  *   - TestPeriodic()
  */
-class IterativeRobotBase : public RobotBase {
+class IterativeRobotBase : public RobotBase, public IterativeBase {
  public:
   virtual void RobotInit();
   virtual void DisabledInit();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeBase.java
@@ -1,0 +1,77 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj;
+
+/**
+ * IterativeBase provides methods that are to be used when code is designed to be aware of
+ * robot state. These are provided as 'init' functions and 'periodic' functions.
+ *
+ * <p>init() functions -- each of the following functions is called once when the
+ * appropriate mode is entered:
+ *   - disabledInit()   -- called only when first disabled
+ *   - autonomousInit() -- called each and every time autonomous is entered from
+ *                         another mode
+ *   - teleopInit()     -- called each and every time teleop is entered from
+ *                         another mode
+ *   - testInit()       -- called each and every time test is entered from
+ *                         another mode
+ *
+ * <p>periodic() functions -- each of these functions is called on an interval:
+ *   - robotPeriodic()
+ *   - disabledPeriodic()
+ *   - autonomousPeriodic()
+ *   - teleopPeriodic()
+ *   - testPeriodic()
+ */
+public interface IterativeBase {
+
+    /**
+     * Initialization code for disabled mode should go here.
+     */
+    public void disabledInit();
+
+    /**
+     * Initialization code for autonomous mode should go here.
+     */
+    public void autonomousInit();
+
+    /**
+     * Initialization code for teleop mode should go here.
+     */
+    public void teleopInit();
+
+    /**
+     * Initialization code for test mode should go here.
+     */
+    public void testInit();
+
+    /**
+     * Periodic code for all robot modes should go here.
+     */
+    public void robotPeriodic();
+
+    /**
+     * Periodic code for disabled mode should go here.
+     */
+    public void disabledPeriodic();
+
+    /**
+     * Periodic code for autonomous mode should go here.
+     */
+    public void autonomousPeriodic();
+
+    /**
+     * Periodic code for teleop mode should go here.
+     */
+    public void teleopPeriodic();
+
+    /**
+     * Periodic code for test mode should go here.
+     */
+    public void testPeriodic();
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -77,6 +77,7 @@ public abstract class IterativeRobotBase extends RobotBase implements IterativeB
    * <p>Users should override this method for initialization code which will be called each time the
    * robot enters disabled mode.
    */
+  @Override
   public void disabledInit() {
     System.out.println("Default disabledInit() method... Overload me!");
   }
@@ -87,6 +88,7 @@ public abstract class IterativeRobotBase extends RobotBase implements IterativeB
    * <p>Users should override this method for initialization code which will be called each time the
    * robot enters autonomous mode.
    */
+  @Override
   public void autonomousInit() {
     System.out.println("Default autonomousInit() method... Overload me!");
   }
@@ -97,6 +99,7 @@ public abstract class IterativeRobotBase extends RobotBase implements IterativeB
    * <p>Users should override this method for initialization code which will be called each time the
    * robot enters teleop mode.
    */
+  @Override
   public void teleopInit() {
     System.out.println("Default teleopInit() method... Overload me!");
   }
@@ -108,6 +111,7 @@ public abstract class IterativeRobotBase extends RobotBase implements IterativeB
    * robot enters test mode.
    */
   @SuppressWarnings("PMD.JUnit4TestShouldUseTestAnnotation")
+  @Override
   public void testInit() {
     System.out.println("Default testInit() method... Overload me!");
   }
@@ -119,6 +123,7 @@ public abstract class IterativeRobotBase extends RobotBase implements IterativeB
   /**
    * Periodic code for all robot modes should go here.
    */
+  @Override
   public void robotPeriodic() {
     if (m_rpFirstRun) {
       System.out.println("Default robotPeriodic() method... Overload me!");
@@ -131,6 +136,7 @@ public abstract class IterativeRobotBase extends RobotBase implements IterativeB
   /**
    * Periodic code for disabled mode should go here.
    */
+  @Override
   public void disabledPeriodic() {
     if (m_dpFirstRun) {
       System.out.println("Default disabledPeriodic() method... Overload me!");
@@ -143,6 +149,7 @@ public abstract class IterativeRobotBase extends RobotBase implements IterativeB
   /**
    * Periodic code for autonomous mode should go here.
    */
+  @Override
   public void autonomousPeriodic() {
     if (m_apFirstRun) {
       System.out.println("Default autonomousPeriodic() method... Overload me!");
@@ -155,6 +162,7 @@ public abstract class IterativeRobotBase extends RobotBase implements IterativeB
   /**
    * Periodic code for teleop mode should go here.
    */
+  @Override
   public void teleopPeriodic() {
     if (m_tpFirstRun) {
       System.out.println("Default teleopPeriodic() method... Overload me!");
@@ -168,6 +176,7 @@ public abstract class IterativeRobotBase extends RobotBase implements IterativeB
    * Periodic code for test mode should go here.
    */
   @SuppressWarnings("PMD.JUnit4TestShouldUseTestAnnotation")
+  @Override
   public void testPeriodic() {
     if (m_tmpFirstRun) {
       System.out.println("Default testPeriodic() method... Overload me!");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -39,7 +39,7 @@ import edu.wpi.first.wpilibj.livewindow.LiveWindow;
  *   - teleopPeriodic()
  *   - testPeriodic()
  */
-public abstract class IterativeRobotBase extends RobotBase {
+public abstract class IterativeRobotBase extends RobotBase implements IterativeBase {
   private enum Mode {
     kNone,
     kDisabled,


### PR DESCRIPTION
Pulls out the init and periodic functions into an interface. Primarily intended to be used in non-robot-main classes that still want to be state-aware. 

RobotInit() was not included as for non-robot-main classes its fairly useless since it's only called once. 