### PR TITLE
Switch JNI interfaces from ByteBuffer to byte[]

### DIFF
--- a/hal/src/main/native/athena/I2C.cpp
+++ b/hal/src/main/native/athena/I2C.cpp
@@ -95,7 +95,7 @@ void HAL_InitializeI2C(HAL_I2CPort port, int32_t* status) {
  * @return >= 0 on success or -1 on transfer abort.
  */
 int32_t HAL_TransactionI2C(HAL_I2CPort port, int32_t deviceAddress,
-                           uint8_t* dataToSend, int32_t sendSize,
+                           const uint8_t* dataToSend, int32_t sendSize,
                            uint8_t* dataReceived, int32_t receiveSize) {
   if (port > 1) {
     // Set port out of range error here
@@ -106,7 +106,7 @@ int32_t HAL_TransactionI2C(HAL_I2CPort port, int32_t deviceAddress,
   msgs[0].addr = deviceAddress;
   msgs[0].flags = 0;
   msgs[0].len = sendSize;
-  msgs[0].buf = dataToSend;
+  msgs[0].buf = const_cast<uint8_t*>(dataToSend);
   msgs[1].addr = deviceAddress;
   msgs[1].flags = I2C_M_RD;
   msgs[1].len = receiveSize;
@@ -137,7 +137,7 @@ int32_t HAL_TransactionI2C(HAL_I2CPort port, int32_t deviceAddress,
  * @return >= 0 on success or -1 on transfer abort.
  */
 int32_t HAL_WriteI2C(HAL_I2CPort port, int32_t deviceAddress,
-                     uint8_t* dataToSend, int32_t sendSize) {
+                     const uint8_t* dataToSend, int32_t sendSize) {
   if (port > 1) {
     // Set port out of range error here
     return -1;
@@ -147,7 +147,7 @@ int32_t HAL_WriteI2C(HAL_I2CPort port, int32_t deviceAddress,
   msg.addr = deviceAddress;
   msg.flags = 0;
   msg.len = sendSize;
-  msg.buf = dataToSend;
+  msg.buf = const_cast<uint8_t*>(dataToSend);
 
   struct i2c_rdwr_ioctl_data rdwr;
   rdwr.msgs = &msg;

--- a/hal/src/main/native/athena/SPI.cpp
+++ b/hal/src/main/native/athena/SPI.cpp
@@ -260,7 +260,7 @@ void HAL_InitializeSPI(HAL_SPIPort port, int32_t* status) {
  * @param size Number of bytes to transfer. [0..7]
  * @return Number of bytes transferred, -1 for error
  */
-int32_t HAL_TransactionSPI(HAL_SPIPort port, uint8_t* dataToSend,
+int32_t HAL_TransactionSPI(HAL_SPIPort port, const uint8_t* dataToSend,
                            uint8_t* dataReceived, int32_t size) {
   if (port < 0 || port >= kSpiMaxHandles) {
     return -1;
@@ -286,7 +286,8 @@ int32_t HAL_TransactionSPI(HAL_SPIPort port, uint8_t* dataToSend,
  * @param sendSize The number of bytes to be written
  * @return The number of bytes written. -1 for an error
  */
-int32_t HAL_WriteSPI(HAL_SPIPort port, uint8_t* dataToSend, int32_t sendSize) {
+int32_t HAL_WriteSPI(HAL_SPIPort port, const uint8_t* dataToSend,
+                     int32_t sendSize) {
   if (port < 0 || port >= kSpiMaxHandles) {
     return -1;
   }

--- a/hal/src/main/native/include/HAL/I2C.h
+++ b/hal/src/main/native/include/HAL/I2C.h
@@ -17,10 +17,10 @@ extern "C" {
 
 void HAL_InitializeI2C(HAL_I2CPort port, int32_t* status);
 int32_t HAL_TransactionI2C(HAL_I2CPort port, int32_t deviceAddress,
-                           uint8_t* dataToSend, int32_t sendSize,
+                           const uint8_t* dataToSend, int32_t sendSize,
                            uint8_t* dataReceived, int32_t receiveSize);
 int32_t HAL_WriteI2C(HAL_I2CPort port, int32_t deviceAddress,
-                     uint8_t* dataToSend, int32_t sendSize);
+                     const uint8_t* dataToSend, int32_t sendSize);
 int32_t HAL_ReadI2C(HAL_I2CPort port, int32_t deviceAddress, uint8_t* buffer,
                     int32_t count);
 void HAL_CloseI2C(HAL_I2CPort port);

--- a/hal/src/main/native/include/HAL/SPI.h
+++ b/hal/src/main/native/include/HAL/SPI.h
@@ -24,9 +24,10 @@ extern "C" {
 #endif
 
 void HAL_InitializeSPI(HAL_SPIPort port, int32_t* status);
-int32_t HAL_TransactionSPI(HAL_SPIPort port, uint8_t* dataToSend,
+int32_t HAL_TransactionSPI(HAL_SPIPort port, const uint8_t* dataToSend,
                            uint8_t* dataReceived, int32_t size);
-int32_t HAL_WriteSPI(HAL_SPIPort port, uint8_t* dataToSend, int32_t sendSize);
+int32_t HAL_WriteSPI(HAL_SPIPort port, const uint8_t* dataToSend,
+                     int32_t sendSize);
 int32_t HAL_ReadSPI(HAL_SPIPort port, uint8_t* buffer, int32_t count);
 void HAL_CloseSPI(HAL_SPIPort port);
 void HAL_SetSPISpeed(HAL_SPIPort port, int32_t speed);

--- a/hal/src/main/native/sim/I2C.cpp
+++ b/hal/src/main/native/sim/I2C.cpp
@@ -16,14 +16,14 @@ void HAL_InitializeI2C(HAL_I2CPort port, int32_t* status) {
   SimI2CData[port].SetInitialized(true);
 }
 int32_t HAL_TransactionI2C(HAL_I2CPort port, int32_t deviceAddress,
-                           uint8_t* dataToSend, int32_t sendSize,
+                           const uint8_t* dataToSend, int32_t sendSize,
                            uint8_t* dataReceived, int32_t receiveSize) {
   SimI2CData[port].Write(deviceAddress, dataToSend, sendSize);
   SimI2CData[port].Read(deviceAddress, dataReceived, receiveSize);
   return 0;
 }
 int32_t HAL_WriteI2C(HAL_I2CPort port, int32_t deviceAddress,
-                     uint8_t* dataToSend, int32_t sendSize) {
+                     const uint8_t* dataToSend, int32_t sendSize) {
   SimI2CData[port].Write(deviceAddress, dataToSend, sendSize);
   return 0;
 }

--- a/hal/src/main/native/sim/MockData/I2CData.cpp
+++ b/hal/src/main/native/sim/MockData/I2CData.cpp
@@ -97,10 +97,11 @@ void I2CData::CancelWriteCallback(int32_t uid) {
   m_writeCallbacks = CancelCallback(m_writeCallbacks, uid);
 }
 
-void I2CData::Write(int32_t deviceAddress, uint8_t* dataToSend,
+void I2CData::Write(int32_t deviceAddress, const uint8_t* dataToSend,
                     int32_t sendSize) {
   std::lock_guard<wpi::mutex> lock(m_dataMutex);
-  InvokeCallback(m_writeCallbacks, "Write", dataToSend, sendSize);
+  InvokeCallback(m_writeCallbacks, "Write", const_cast<uint8_t*>(dataToSend),
+                 sendSize);
 }
 void I2CData::Read(int32_t deviceAddress, uint8_t* buffer, int32_t count) {
   std::lock_guard<wpi::mutex> lock(m_dataMutex);

--- a/hal/src/main/native/sim/MockData/I2CDataInternal.h
+++ b/hal/src/main/native/sim/MockData/I2CDataInternal.h
@@ -35,7 +35,8 @@ class I2CData {
   int32_t RegisterWriteCallback(HAL_BufferCallback callback, void* param);
   void CancelWriteCallback(int32_t uid);
 
-  void Write(int32_t deviceAddress, uint8_t* dataToSend, int32_t sendSize);
+  void Write(int32_t deviceAddress, const uint8_t* dataToSend,
+             int32_t sendSize);
   void Read(int32_t deviceAddress, uint8_t* buffer, int32_t count);
 
   void ResetData();

--- a/hal/src/main/native/sim/MockData/SPIData.cpp
+++ b/hal/src/main/native/sim/MockData/SPIData.cpp
@@ -167,14 +167,15 @@ int32_t SPIData::Read(uint8_t* buffer, int32_t count) {
   return count;
 }
 
-int32_t SPIData::Write(uint8_t* dataToSend, int32_t sendSize) {
+int32_t SPIData::Write(const uint8_t* dataToSend, int32_t sendSize) {
   std::lock_guard<wpi::mutex> lock(m_dataMutex);
-  InvokeCallback(m_writeCallbacks, "Write", dataToSend, sendSize);
+  InvokeCallback(m_writeCallbacks, "Write", const_cast<uint8_t*>(dataToSend),
+                 sendSize);
 
   return sendSize;
 }
 
-int32_t SPIData::Transaction(uint8_t* dataToSend, uint8_t* dataReceived,
+int32_t SPIData::Transaction(const uint8_t* dataToSend, uint8_t* dataReceived,
                              int32_t size) {
   std::lock_guard<wpi::mutex> lock(m_dataMutex);
   return size;

--- a/hal/src/main/native/sim/MockData/SPIDataInternal.h
+++ b/hal/src/main/native/sim/MockData/SPIDataInternal.h
@@ -47,8 +47,9 @@ class SPIData {
   int64_t GetAccumulatorValue();
 
   int32_t Read(uint8_t* buffer, int32_t count);
-  int32_t Write(uint8_t* dataToSend, int32_t sendSize);
-  int32_t Transaction(uint8_t* dataToSend, uint8_t* dataReceived, int32_t size);
+  int32_t Write(const uint8_t* dataToSend, int32_t sendSize);
+  int32_t Transaction(const uint8_t* dataToSend, uint8_t* dataReceived,
+                      int32_t size);
   void ResetAccumulator();
 
   void ResetData();

--- a/hal/src/main/native/sim/SPI.cpp
+++ b/hal/src/main/native/sim/SPI.cpp
@@ -14,11 +14,12 @@ using namespace hal;
 void HAL_InitializeSPI(HAL_SPIPort port, int32_t* status) {
   SimSPIData[port].SetInitialized(true);
 }
-int32_t HAL_TransactionSPI(HAL_SPIPort port, uint8_t* dataToSend,
+int32_t HAL_TransactionSPI(HAL_SPIPort port, const uint8_t* dataToSend,
                            uint8_t* dataReceived, int32_t size) {
   return SimSPIData[port].Transaction(dataToSend, dataReceived, size);
 }
-int32_t HAL_WriteSPI(HAL_SPIPort port, uint8_t* dataToSend, int32_t sendSize) {
+int32_t HAL_WriteSPI(HAL_SPIPort port, const uint8_t* dataToSend,
+                     int32_t sendSize) {
   return SimSPIData[port].Write(dataToSend, sendSize);
 }
 int32_t HAL_ReadSPI(HAL_SPIPort port, uint8_t* buffer, int32_t count) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_I2C.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_I2C.java
@@ -144,7 +144,7 @@ public class ADXL345_I2C extends SensorBase implements Accelerometer, LiveWindow
    * @return Acceleration of the ADXL345 in Gs.
    */
   public double getAcceleration(Axes axis) {
-    ByteBuffer rawAccel = ByteBuffer.allocateDirect(2);
+    ByteBuffer rawAccel = ByteBuffer.allocate(2);
     m_i2c.read(kDataRegister + axis.value, 2, rawAccel);
 
     // Sensor is little endian... swap bytes
@@ -159,7 +159,7 @@ public class ADXL345_I2C extends SensorBase implements Accelerometer, LiveWindow
    */
   public AllAxes getAccelerations() {
     AllAxes data = new AllAxes();
-    ByteBuffer rawData = ByteBuffer.allocateDirect(6);
+    ByteBuffer rawData = ByteBuffer.allocate(6);
     m_i2c.read(kDataRegister, 6, rawData);
 
     // Sensor is little endian... swap bytes

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_SPI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_SPI.java
@@ -156,7 +156,7 @@ public class ADXL345_SPI extends SensorBase implements Accelerometer, LiveWindow
    * @return Acceleration of the ADXL345 in Gs.
    */
   public double getAcceleration(ADXL345_SPI.Axes axis) {
-    ByteBuffer transferBuffer = ByteBuffer.allocateDirect(3);
+    ByteBuffer transferBuffer = ByteBuffer.allocate(3);
     transferBuffer.put(0,
         (byte) ((kAddress_Read | kAddress_MultiByte | kDataRegister) + axis.value));
     m_spi.transaction(transferBuffer, transferBuffer, 3);
@@ -174,7 +174,7 @@ public class ADXL345_SPI extends SensorBase implements Accelerometer, LiveWindow
   public ADXL345_SPI.AllAxes getAccelerations() {
     ADXL345_SPI.AllAxes data = new ADXL345_SPI.AllAxes();
     if (m_spi != null) {
-      ByteBuffer dataBuffer = ByteBuffer.allocateDirect(7);
+      ByteBuffer dataBuffer = ByteBuffer.allocate(7);
       // Select the data address.
       dataBuffer.put(0, (byte) (kAddress_Read | kAddress_MultiByte | kDataRegister));
       m_spi.transaction(dataBuffer, dataBuffer, 7);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL362.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL362.java
@@ -89,7 +89,7 @@ public class ADXL362 extends SensorBase implements Accelerometer, LiveWindowSend
     m_spi.setChipSelectActiveLow();
 
     // Validate the part ID
-    ByteBuffer transferBuffer = ByteBuffer.allocateDirect(3);
+    ByteBuffer transferBuffer = ByteBuffer.allocate(3);
     transferBuffer.put(0, kRegRead);
     transferBuffer.put(1, kPartIdRegister);
     m_spi.transaction(transferBuffer, transferBuffer, 3);
@@ -171,7 +171,7 @@ public class ADXL362 extends SensorBase implements Accelerometer, LiveWindowSend
     if (m_spi == null) {
       return 0.0;
     }
-    ByteBuffer transferBuffer = ByteBuffer.allocateDirect(4);
+    ByteBuffer transferBuffer = ByteBuffer.allocate(4);
     transferBuffer.put(0, kRegRead);
     transferBuffer.put(1, (byte) (kDataRegister + axis.value));
     m_spi.transaction(transferBuffer, transferBuffer, 4);
@@ -189,7 +189,7 @@ public class ADXL362 extends SensorBase implements Accelerometer, LiveWindowSend
   public ADXL362.AllAxes getAccelerations() {
     ADXL362.AllAxes data = new ADXL362.AllAxes();
     if (m_spi != null) {
-      ByteBuffer dataBuffer = ByteBuffer.allocateDirect(8);
+      ByteBuffer dataBuffer = ByteBuffer.allocate(8);
       // Select the data address.
       dataBuffer.put(0, kRegRead);
       dataBuffer.put(1, kDataRegister);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.java
@@ -111,7 +111,7 @@ public class ADXRS450_Gyro extends GyroBase implements Gyro, PIDSource, LiveWind
     int cmdhi = 0x8000 | (reg << 1);
     boolean parity = calcParity(cmdhi);
 
-    ByteBuffer buf = ByteBuffer.allocateDirect(4);
+    ByteBuffer buf = ByteBuffer.allocate(4);
     buf.order(ByteOrder.BIG_ENDIAN);
     buf.put(0, (byte) (cmdhi >> 8));
     buf.put(1, (byte) (cmdhi & 0xff));

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AccumulatorResult.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AccumulatorResult.java
@@ -22,4 +22,12 @@ public class AccumulatorResult {
    */
   @SuppressWarnings("MemberName")
   public long count;
+
+  /**
+   * Set the value and count.
+   */
+  public void set(long value, long count) {
+    this.value = value;
+    this.count = count;
+  }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogInput.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogInput.java
@@ -7,9 +7,6 @@
 
 package edu.wpi.first.wpilibj;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.wpilibj.hal.AnalogJNI;
@@ -289,15 +286,8 @@ public class AnalogInput extends SensorBase implements PIDSource, LiveWindowSend
       throw new IllegalArgumentException(
           "Channel " + m_channel + " is not an accumulator channel.");
     }
-    ByteBuffer value = ByteBuffer.allocateDirect(8);
-    // set the byte order
-    value.order(ByteOrder.LITTLE_ENDIAN);
-    ByteBuffer count = ByteBuffer.allocateDirect(8);
-    // set the byte order
-    count.order(ByteOrder.LITTLE_ENDIAN);
-    AnalogJNI.getAccumulatorOutput(m_port, value.asLongBuffer(), count.asLongBuffer());
-    result.value = value.asLongBuffer().get(0) + m_accumulatorOffset;
-    result.count = count.asLongBuffer().get(0);
+    AnalogJNI.getAccumulatorOutput(m_port, result);
+    result.value += m_accumulatorOffset;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/I2C.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/I2C.java
@@ -72,20 +72,15 @@ public class I2C extends SensorBase {
    */
   public synchronized boolean transaction(byte[] dataToSend, int sendSize,
                                           byte[] dataReceived, int receiveSize) {
-    final int status;
-
-    ByteBuffer dataToSendBuffer = ByteBuffer.allocateDirect(sendSize);
-    if (sendSize > 0 && dataToSend != null) {
-      dataToSendBuffer.put(dataToSend);
+    if (dataToSend.length < sendSize) {
+      throw new IllegalArgumentException("dataToSend is too small, must be at least " + sendSize);
     }
-    ByteBuffer dataReceivedBuffer = ByteBuffer.allocateDirect(receiveSize);
-
-    status = I2CJNI.i2CTransaction(m_port, (byte) m_deviceAddress, dataToSendBuffer,
-                                   (byte) sendSize, dataReceivedBuffer, (byte) receiveSize);
-    if (receiveSize > 0 && dataReceived != null) {
-      dataReceivedBuffer.get(dataReceived, 0, receiveSize);
+    if (dataReceived.length < receiveSize) {
+      throw new IllegalArgumentException(
+          "dataReceived is too small, must be at least " + receiveSize);
     }
-    return status < 0;
+    return I2CJNI.i2CTransactionB(m_port, (byte) m_deviceAddress, dataToSend,
+                                  (byte) sendSize, dataReceived, (byte) receiveSize) < 0;
   }
 
   /**
@@ -94,16 +89,17 @@ public class I2C extends SensorBase {
    * <p>This is a lower-level interface to the I2C hardware giving you more control over each
    * transaction.
    *
-   * @param dataToSend   Buffer of data to send as part of the transaction. Must be allocated using
-   *                     ByteBuffer.allocateDirect().
+   * @param dataToSend   Buffer of data to send as part of the transaction.
    * @param sendSize     Number of bytes to send as part of the transaction.
-   * @param dataReceived Buffer to read data into. Must be allocated using {@link
-   *                     ByteBuffer#allocateDirect(int)}.
+   * @param dataReceived Buffer to read data into.
    * @param receiveSize  Number of bytes to read from the device.
    * @return Transfer Aborted... false for success, true for aborted.
    */
   public synchronized boolean transaction(ByteBuffer dataToSend, int sendSize,
                                           ByteBuffer dataReceived, int receiveSize) {
+    if (dataToSend.hasArray() && dataReceived.hasArray()) {
+      return transaction(dataToSend.array(), sendSize, dataReceived.array(), receiveSize);
+    }
     if (!dataToSend.isDirect()) {
       throw new IllegalArgumentException("dataToSend must be a direct buffer");
     }
@@ -131,7 +127,7 @@ public class I2C extends SensorBase {
    * @return Transfer Aborted... false for success, true for aborted.
    */
   public boolean addressOnly() {
-    return transaction((byte[]) null, (byte) 0, null, (byte) 0);
+    return transaction(new byte[0], (byte) 0, new byte[0], (byte) 0);
   }
 
   /**
@@ -147,12 +143,8 @@ public class I2C extends SensorBase {
     byte[] buffer = new byte[2];
     buffer[0] = (byte) registerAddress;
     buffer[1] = (byte) data;
-
-    ByteBuffer dataToSendBuffer = ByteBuffer.allocateDirect(2);
-    dataToSendBuffer.put(buffer);
-
-    return I2CJNI.i2CWrite(m_port, (byte) m_deviceAddress, dataToSendBuffer,
-                           (byte) buffer.length) < 0;
+    return I2CJNI.i2CWriteB(m_port, (byte) m_deviceAddress, buffer,
+                            (byte) buffer.length) < 0;
   }
 
   /**
@@ -164,11 +156,7 @@ public class I2C extends SensorBase {
    * @return Transfer Aborted... false for success, true for aborted.
    */
   public synchronized boolean writeBulk(byte[] data) {
-    ByteBuffer dataToSendBuffer = ByteBuffer.allocateDirect(data.length);
-    dataToSendBuffer.put(data);
-
-    return I2CJNI.i2CWrite(m_port, (byte) m_deviceAddress, dataToSendBuffer,
-                           (byte) data.length) < 0;
+    return writeBulk(data, data.length);
   }
 
   /**
@@ -176,10 +164,31 @@ public class I2C extends SensorBase {
    *
    * <p>Write multiple bytes to a register on a device and wait until the transaction is complete.
    *
-   * @param data The data to write to the device. Must be created using ByteBuffer.allocateDirect().
+   * @param data The data to write to the device.
+   * @param size The number of data bytes to write.
+   * @return Transfer Aborted... false for success, true for aborted.
+   */
+  public synchronized boolean writeBulk(byte[] data, int size) {
+    if (data.length < size) {
+      throw new IllegalArgumentException(
+          "buffer is too small, must be at least " + size);
+    }
+    return I2CJNI.i2CWriteB(m_port, (byte) m_deviceAddress, data, (byte) size) < 0;
+  }
+
+  /**
+   * Execute a write transaction with the device.
+   *
+   * <p>Write multiple bytes to a register on a device and wait until the transaction is complete.
+   *
+   * @param data The data to write to the device.
+   * @param size The number of data bytes to write.
    * @return Transfer Aborted... false for success, true for aborted.
    */
   public synchronized boolean writeBulk(ByteBuffer data, int size) {
+    if (data.hasArray()) {
+      return writeBulk(data.array(), size);
+    }
     if (!data.isDirect()) {
       throw new IllegalArgumentException("must be a direct buffer");
     }
@@ -208,12 +217,17 @@ public class I2C extends SensorBase {
     if (count < 1) {
       throw new BoundaryException("Value must be at least 1, " + count + " given");
     }
+    if (buffer.length < count) {
+      throw new IllegalArgumentException("buffer is too small, must be at least " + count);
+    }
 
     byte[] registerAddressArray = new byte[1];
     registerAddressArray[0] = (byte) registerAddress;
 
     return transaction(registerAddressArray, registerAddressArray.length, buffer, count);
   }
+
+  private ByteBuffer m_readDataToSendBuffer = null;
 
   /**
    * Execute a read transaction with the device.
@@ -223,13 +237,16 @@ public class I2C extends SensorBase {
    *
    * @param registerAddress The register to read first in the transaction.
    * @param count           The number of bytes to read in the transaction.
-   * @param buffer          A buffer to store the data read from the device. Must be created using
-   *                        ByteBuffer.allocateDirect().
+   * @param buffer          A buffer to store the data read from the device.
    * @return Transfer Aborted... false for success, true for aborted.
    */
   public boolean read(int registerAddress, int count, ByteBuffer buffer) {
     if (count < 1) {
       throw new BoundaryException("Value must be at least 1, " + count + " given");
+    }
+
+    if (buffer.hasArray()) {
+      return read(registerAddress, count, buffer.array());
     }
 
     if (!buffer.isDirect()) {
@@ -239,10 +256,14 @@ public class I2C extends SensorBase {
       throw new IllegalArgumentException("buffer is too small, must be at least " + count);
     }
 
-    ByteBuffer dataToSendBuffer = ByteBuffer.allocateDirect(1);
-    dataToSendBuffer.put(0, (byte) registerAddress);
+    synchronized (this) {
+      if (m_readDataToSendBuffer == null) {
+        m_readDataToSendBuffer = ByteBuffer.allocateDirect(1);
+      }
+      m_readDataToSendBuffer.put(0, (byte) registerAddress);
 
-    return transaction(dataToSendBuffer, 1, buffer, count);
+      return transaction(m_readDataToSendBuffer, 1, buffer, count);
+    }
   }
 
   /**
@@ -259,13 +280,12 @@ public class I2C extends SensorBase {
     if (count < 1) {
       throw new BoundaryException("Value must be at least 1, " + count + " given");
     }
+    if (buffer.length < count) {
+      throw new IllegalArgumentException("buffer is too small, must be at least " + count);
+    }
 
-    ByteBuffer dataReceivedBuffer = ByteBuffer.allocateDirect(count);
-
-    int retVal = I2CJNI.i2CRead(m_port, (byte) m_deviceAddress, dataReceivedBuffer,
-                                (byte) count);
-    dataReceivedBuffer.get(buffer);
-    return retVal < 0;
+    return I2CJNI.i2CReadB(m_port, (byte) m_deviceAddress, buffer,
+                           (byte) count) < 0;
   }
 
   /**
@@ -273,8 +293,7 @@ public class I2C extends SensorBase {
    *
    * <p>Read bytes from a device. This method does not write any data to prompt the device.
    *
-   * @param buffer A pointer to the array of bytes to store the data read from the device. Must be
-   *               created using ByteBuffer.allocateDirect().
+   * @param buffer A pointer to the array of bytes to store the data read from the device.
    * @param count  The number of bytes to read in the transaction.
    * @return Transfer Aborted... false for success, true for aborted.
    */
@@ -282,6 +301,10 @@ public class I2C extends SensorBase {
     if (count < 1) {
       throw new BoundaryException("Value must be at least 1, " + count
           + " given");
+    }
+
+    if (buffer.hasArray()) {
+      return readOnly(buffer.array(), count);
     }
 
     if (!buffer.isDirect()) {
@@ -322,21 +345,21 @@ public class I2C extends SensorBase {
   public boolean verifySensor(int registerAddress, int count,
                               byte[] expected) {
     // TODO: Make use of all 7 read bytes
-    ByteBuffer dataToSendBuffer = ByteBuffer.allocateDirect(1);
+    byte[] dataToSend = new byte[1];
 
-    ByteBuffer deviceData = ByteBuffer.allocateDirect(4);
+    byte[] deviceData = new byte[4];
     for (int i = 0, curRegisterAddress = registerAddress;
          i < count; i += 4, curRegisterAddress += 4) {
       int toRead = count - i < 4 ? count - i : 4;
       // Read the chunk of data. Return false if the sensor does not
       // respond.
-      dataToSendBuffer.put(0, (byte) curRegisterAddress);
-      if (transaction(dataToSendBuffer, 1, deviceData, toRead)) {
+      dataToSend[0] = (byte) curRegisterAddress;
+      if (transaction(dataToSend, 1, deviceData, toRead)) {
         return false;
       }
 
       for (byte j = 0; j < toRead; j++) {
-        if (deviceData.get(j) != expected[i + j]) {
+        if (deviceData[j] != expected[i + j]) {
           return false;
         }
       }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SPI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SPI.java
@@ -8,7 +8,6 @@
 package edu.wpi.first.wpilibj;
 
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 import edu.wpi.first.wpilibj.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.wpilibj.hal.HAL;
@@ -141,9 +140,10 @@ public class SPI extends SensorBase {
    * the transfer into the receive FIFO.
    */
   public int write(byte[] dataToSend, int size) {
-    ByteBuffer dataToSendBuffer = ByteBuffer.allocateDirect(size);
-    dataToSendBuffer.put(dataToSend);
-    return SPIJNI.spiWrite(m_port, dataToSendBuffer, (byte) size);
+    if (dataToSend.length < size) {
+      throw new IllegalArgumentException("buffer is too small, must be at least " + size);
+    }
+    return SPIJNI.spiWriteB(m_port, dataToSend, (byte) size);
   }
 
   /**
@@ -152,10 +152,12 @@ public class SPI extends SensorBase {
    * <p>If not running in output only mode, also saves the data received on the MISO input during
    * the transfer into the receive FIFO.
    *
-   * @param dataToSend The buffer containing the data to send. Must be created using
-   *                   ByteBuffer.allocateDirect().
+   * @param dataToSend The buffer containing the data to send.
    */
   public int write(ByteBuffer dataToSend, int size) {
+    if (dataToSend.hasArray()) {
+      return write(dataToSend.array(), size);
+    }
     if (!dataToSend.isDirect()) {
       throw new IllegalArgumentException("must be a direct buffer");
     }
@@ -177,16 +179,10 @@ public class SPI extends SensorBase {
    *                 FIFO from a previous write.
    */
   public int read(boolean initiate, byte[] dataReceived, int size) {
-    final int retVal;
-    ByteBuffer dataReceivedBuffer = ByteBuffer.allocateDirect(size);
-    ByteBuffer dataToSendBuffer = ByteBuffer.allocateDirect(size);
-    if (initiate) {
-      retVal = SPIJNI.spiTransaction(m_port, dataToSendBuffer, dataReceivedBuffer, (byte) size);
-    } else {
-      retVal = SPIJNI.spiRead(m_port, dataReceivedBuffer, (byte) size);
+    if (dataReceived.length < size) {
+      throw new IllegalArgumentException("buffer is too small, must be at least " + size);
     }
-    dataReceivedBuffer.get(dataReceived);
-    return retVal;
+    return SPIJNI.spiReadB(m_port, initiate, dataReceived, (byte) size);
   }
 
   /**
@@ -199,22 +195,20 @@ public class SPI extends SensorBase {
    * @param initiate     If true, this function pushes "0" into the transmit buffer and initiates
    *                     a transfer. If false, this function assumes that data is already in the
    *                     receive FIFO from a previous write.
-   * @param dataReceived The buffer to be filled with the received data. Must be created using
-   *                     ByteBuffer.allocateDirect().
+   * @param dataReceived The buffer to be filled with the received data.
    * @param size         The length of the transaction, in bytes
    */
   public int read(boolean initiate, ByteBuffer dataReceived, int size) {
+    if (dataReceived.hasArray()) {
+      return read(initiate, dataReceived.array(), size);
+    }
     if (!dataReceived.isDirect()) {
       throw new IllegalArgumentException("must be a direct buffer");
     }
     if (dataReceived.capacity() < size) {
       throw new IllegalArgumentException("buffer is too small, must be at least " + size);
     }
-    if (initiate) {
-      ByteBuffer dataToSendBuffer = ByteBuffer.allocateDirect(size);
-      return SPIJNI.spiTransaction(m_port, dataToSendBuffer, dataReceived, (byte) size);
-    }
-    return SPIJNI.spiRead(m_port, dataReceived, (byte) size);
+    return SPIJNI.spiRead(m_port, initiate, dataReceived, (byte) size);
   }
 
   /**
@@ -225,24 +219,26 @@ public class SPI extends SensorBase {
    * @param size         The length of the transaction, in bytes
    */
   public int transaction(byte[] dataToSend, byte[] dataReceived, int size) {
-    ByteBuffer dataToSendBuffer = ByteBuffer.allocateDirect(size);
-    dataToSendBuffer.put(dataToSend);
-    ByteBuffer dataReceivedBuffer = ByteBuffer.allocateDirect(size);
-    int retVal = SPIJNI.spiTransaction(m_port, dataToSendBuffer, dataReceivedBuffer, (byte) size);
-    dataReceivedBuffer.get(dataReceived);
-    return retVal;
+    if (dataToSend.length < size) {
+      throw new IllegalArgumentException("dataToSend is too small, must be at least " + size);
+    }
+    if (dataReceived.length < size) {
+      throw new IllegalArgumentException("dataReceived is too small, must be at least " + size);
+    }
+    return SPIJNI.spiTransactionB(m_port, dataToSend, dataReceived, (byte) size);
   }
 
   /**
    * Perform a simultaneous read/write transaction with the device.
    *
-   * @param dataToSend   The data to be written out to the device. Must be created using
-   *                     ByteBuffer.allocateDirect().
-   * @param dataReceived Buffer to receive data from the device. Must be created using
-   *                     ByteBuffer.allocateDirect().
+   * @param dataToSend   The data to be written out to the device.
+   * @param dataReceived Buffer to receive data from the device.
    * @param size         The length of the transaction, in bytes
    */
   public int transaction(ByteBuffer dataToSend, ByteBuffer dataReceived, int size) {
+    if (dataToSend.hasArray() && dataReceived.hasArray()) {
+      return transaction(dataToSend.array(), dataReceived.array(), size);
+    }
     if (!dataToSend.isDirect()) {
       throw new IllegalArgumentException("dataToSend must be a direct buffer");
     }
@@ -359,14 +355,6 @@ public class SPI extends SensorBase {
     if (result == null) {
       throw new IllegalArgumentException("Null parameter `result'");
     }
-    ByteBuffer value = ByteBuffer.allocateDirect(8);
-    // set the byte order
-    value.order(ByteOrder.LITTLE_ENDIAN);
-    ByteBuffer count = ByteBuffer.allocateDirect(8);
-    // set the byte order
-    count.order(ByteOrder.LITTLE_ENDIAN);
-    SPIJNI.spiGetAccumulatorOutput(m_port, value.asLongBuffer(), count.asLongBuffer());
-    result.value = value.asLongBuffer().get(0);
-    result.count = count.asLongBuffer().get(0);
+    SPIJNI.spiGetAccumulatorOutput(m_port, result);
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SerialPort.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SerialPort.java
@@ -8,7 +8,6 @@
 package edu.wpi.first.wpilibj;
 
 import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
 
 import edu.wpi.first.wpilibj.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.wpilibj.hal.HAL;
@@ -252,10 +251,13 @@ public class SerialPort {
    * @return An array of the read bytes
    */
   public byte[] read(final int count) {
-    ByteBuffer dataReceivedBuffer = ByteBuffer.allocateDirect(count);
+    byte[] dataReceivedBuffer = new byte[count];
     int gotten = SerialPortJNI.serialRead(m_port, dataReceivedBuffer, count);
+    if (gotten == count) {
+      return dataReceivedBuffer;
+    }
     byte[] retVal = new byte[gotten];
-    dataReceivedBuffer.get(retVal);
+    System.arraycopy(dataReceivedBuffer, 0, retVal, 0, gotten);
     return retVal;
   }
 
@@ -267,9 +269,10 @@ public class SerialPort {
    * @return The number of bytes actually written into the port.
    */
   public int write(byte[] buffer, int count) {
-    ByteBuffer dataToSendBuffer = ByteBuffer.allocateDirect(count);
-    dataToSendBuffer.put(buffer, 0, count);
-    return SerialPortJNI.serialWrite(m_port, dataToSendBuffer, count);
+    if (buffer.length < count) {
+      throw new IllegalArgumentException("buffer is too small, must be at least " + count);
+    }
+    return SerialPortJNI.serialWrite(m_port, buffer, count);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/hal/AnalogJNI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/hal/AnalogJNI.java
@@ -7,8 +7,8 @@
 
 package edu.wpi.first.wpilibj.hal;
 
+import edu.wpi.first.wpilibj.AccumulatorResult;
 import java.nio.IntBuffer;
-import java.nio.LongBuffer;
 
 public class AnalogJNI extends JNIWrapper {
   /**
@@ -91,8 +91,7 @@ public class AnalogJNI extends JNIWrapper {
 
   public static native int getAccumulatorCount(int analogPortHandle);
 
-  public static native void getAccumulatorOutput(int analogPortHandle, LongBuffer value,
-                                                 LongBuffer count);
+  public static native void getAccumulatorOutput(int analogPortHandle, AccumulatorResult result);
 
   public static native int initializeAnalogTrigger(int analogInputHandle, IntBuffer index);
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/hal/I2CJNI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/hal/I2CJNI.java
@@ -16,10 +16,18 @@ public class I2CJNI extends JNIWrapper {
   public static native int i2CTransaction(int port, byte address, ByteBuffer dataToSend,
                                           byte sendSize, ByteBuffer dataReceived, byte receiveSize);
 
+  public static native int i2CTransactionB(int port, byte address, byte[] dataToSend,
+                                           byte sendSize, byte[] dataReceived, byte receiveSize);
+
   public static native int i2CWrite(int port, byte address, ByteBuffer dataToSend, byte sendSize);
+
+  public static native int i2CWriteB(int port, byte address, byte[] dataToSend, byte sendSize);
 
   public static native int i2CRead(int port, byte address, ByteBuffer dataReceived,
                                    byte receiveSize);
+
+  public static native int i2CReadB(int port, byte address, byte[] dataReceived,
+                                    byte receiveSize);
 
   public static native void i2CClose(int port);
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/hal/OSSerialPortJNI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/hal/OSSerialPortJNI.java
@@ -7,8 +7,6 @@
 
 package edu.wpi.first.wpilibj.hal;
 
-import java.nio.ByteBuffer;
-
 public class OSSerialPortJNI extends JNIWrapper {
   public static native void serialInitializePort(byte port);
 
@@ -36,9 +34,9 @@ public class OSSerialPortJNI extends JNIWrapper {
 
   public static native int serialGetBytesReceived(byte port);
 
-  public static native int serialRead(byte port, ByteBuffer buffer, int count);
+  public static native int serialRead(byte port, byte[] buffer, int count);
 
-  public static native int serialWrite(byte port, ByteBuffer buffer, int count);
+  public static native int serialWrite(byte port, byte[] buffer, int count);
 
   public static native void serialFlush(byte port);
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/hal/SPIJNI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/hal/SPIJNI.java
@@ -7,8 +7,8 @@
 
 package edu.wpi.first.wpilibj.hal;
 
+import edu.wpi.first.wpilibj.AccumulatorResult;
 import java.nio.ByteBuffer;
-import java.nio.LongBuffer;
 
 @SuppressWarnings("AbbreviationAsWordInName")
 public class SPIJNI extends JNIWrapper {
@@ -17,9 +17,16 @@ public class SPIJNI extends JNIWrapper {
   public static native int spiTransaction(int port, ByteBuffer dataToSend,
                                           ByteBuffer dataReceived, byte size);
 
+  public static native int spiTransactionB(int port, byte[] dataToSend,
+                                           byte[] dataReceived, byte size);
+
   public static native int spiWrite(int port, ByteBuffer dataToSend, byte sendSize);
 
-  public static native int spiRead(int port, ByteBuffer dataReceived, byte size);
+  public static native int spiWriteB(int port, byte[] dataToSend, byte sendSize);
+
+  public static native int spiRead(int port, boolean initiate, ByteBuffer dataReceived, byte size);
+
+  public static native int spiReadB(int port, boolean initiate, byte[] dataReceived, byte size);
 
   public static native void spiClose(int port);
 
@@ -52,6 +59,5 @@ public class SPIJNI extends JNIWrapper {
 
   public static native double spiGetAccumulatorAverage(int port);
 
-  public static native void spiGetAccumulatorOutput(int port, LongBuffer value,
-                                                    LongBuffer count);
+  public static native void spiGetAccumulatorOutput(int port, AccumulatorResult result);
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/hal/SerialPortJNI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/hal/SerialPortJNI.java
@@ -7,8 +7,6 @@
 
 package edu.wpi.first.wpilibj.hal;
 
-import java.nio.ByteBuffer;
-
 public class SerialPortJNI extends JNIWrapper {
   public static native void serialInitializePort(byte port);
 
@@ -36,9 +34,9 @@ public class SerialPortJNI extends JNIWrapper {
 
   public static native int serialGetBytesReceived(byte port);
 
-  public static native int serialRead(byte port, ByteBuffer buffer, int count);
+  public static native int serialRead(byte port, byte[] buffer, int count);
 
-  public static native int serialWrite(byte port, ByteBuffer buffer, int count);
+  public static native int serialWrite(byte port, byte[] buffer, int count);
 
   public static native void serialFlush(byte port);
 

--- a/wpilibj/src/main/native/cpp/AnalogJNI.cpp
+++ b/wpilibj/src/main/native/cpp/AnalogJNI.cpp
@@ -500,22 +500,19 @@ Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAccumulatorCount(
 /*
  * Class:     edu_wpi_first_wpilibj_hal_AnalogJNI
  * Method:    getAccumulatorOutput
- * Signature: (ILjava/nio/LongBuffer;Ljava/nio/LongBuffer;)V
+ * Signature: (ILedu/wpi/first/wpilibj/AccumulatorResult;)V
  */
 JNIEXPORT void JNICALL
 Java_edu_wpi_first_wpilibj_hal_AnalogJNI_getAccumulatorOutput(
-    JNIEnv *env, jclass, jint id, jobject value, jobject count) {
+    JNIEnv *env, jclass, jint id, jobject accumulatorResult) {
   ANALOGJNI_LOG(logDEBUG) << "Analog Handle = " << (HAL_AnalogInputHandle)id;
   int32_t status = 0;
-  jlong *valuePtr = (jlong *)env->GetDirectBufferAddress(value);
-  jlong *countPtr = (jlong *)env->GetDirectBufferAddress(count);
-  int64_t valueInt64;
-  int64_t countInt64;
-  HAL_GetAccumulatorOutput((HAL_AnalogInputHandle)id, &valueInt64, &countInt64, &status);
-  *valuePtr = valueInt64;
-  *countPtr = countInt64;
-  ANALOGJNI_LOG(logDEBUG) << "Value = " << *valuePtr;
-  ANALOGJNI_LOG(logDEBUG) << "Count = " << *countPtr;
+  int64_t value = 0;
+  int64_t count = 0;
+  HAL_GetAccumulatorOutput((HAL_AnalogInputHandle)id, &value, &count, &status);
+  SetAccumulatorResultObject(env, accumulatorResult, value, count);
+  ANALOGJNI_LOG(logDEBUG) << "Value = " << value;
+  ANALOGJNI_LOG(logDEBUG) << "Count = " << count;
   ANALOGJNI_LOG(logDEBUG) << "Status = " << status;
   CheckStatus(env, status);
 }

--- a/wpilibj/src/main/native/cpp/HALUtil.cpp
+++ b/wpilibj/src/main/native/cpp/HALUtil.cpp
@@ -57,6 +57,7 @@ static JException uncleanStatusExCls;
 static JClass pwmConfigDataResultCls;
 static JClass canStatusCls;
 static JClass matchInfoDataCls;
+static JClass accumulatorResultCls;
 
 namespace frc {
 
@@ -234,6 +235,14 @@ void SetMatchInfoObject(JNIEnv* env, jobject matchStatus,
       (jint)matchInfo.matchType);
 }
 
+void SetAccumulatorResultObject(JNIEnv* env, jobject accumulatorResult,
+                                int64_t value, int64_t count) {
+  static jmethodID func = env->GetMethodID(accumulatorResultCls, "set",
+      "(JJ)V");
+
+  env->CallObjectMethod(accumulatorResult, func, (jlong)value, (jlong)count);
+}
+
 }  // namespace frc
 
 using namespace frc;
@@ -291,6 +300,9 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
 
   matchInfoDataCls = JClass(env, "edu/wpi/first/wpilibj/hal/MatchInfoData");
   if (!matchInfoDataCls) return JNI_ERR;
+
+  accumulatorResultCls = JClass(env, "edu/wpi/first/wpilibj/AccumulatorResult");
+  if (!accumulatorResultCls) return JNI_ERR;
 
   return JNI_VERSION_1_6;
 }

--- a/wpilibj/src/main/native/cpp/HALUtil.h
+++ b/wpilibj/src/main/native/cpp/HALUtil.h
@@ -63,6 +63,9 @@ void SetCanStatusObject(JNIEnv *env, jobject canStatus,
 void SetMatchInfoObject(JNIEnv* env, jobject matchStatus,
                         const HAL_MatchInfo& matchInfo);
 
+void SetAccumulatorResultObject(JNIEnv* env, jobject accumulatorResult,
+                                int64_t value, int64_t count);
+
 }  // namespace frc
 
 #endif  // HALUTIL_H

--- a/wpilibj/src/main/native/cpp/I2CJNI.cpp
+++ b/wpilibj/src/main/native/cpp/I2CJNI.cpp
@@ -13,8 +13,10 @@
 
 #include "HAL/I2C.h"
 #include "HALUtil.h"
+#include "support/jni_util.h"
 
 using namespace frc;
+using namespace wpi::java;
 
 // set the logging level
 TLogLevel i2cJNILogLevel = logWARNING;
@@ -71,6 +73,32 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_I2CJNI_i2CTransaction(
 
 /*
  * Class:     edu_wpi_first_wpilibj_hal_I2CJNI
+ * Method:    i2CTransactionB
+ * Signature: (IB[BB[BB)I
+ */
+JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_I2CJNI_i2CTransactionB(
+    JNIEnv* env, jclass, jint port, jbyte address, jbyteArray dataToSend,
+    jbyte sendSize, jbyteArray dataReceived, jbyte receiveSize) {
+  I2CJNI_LOG(logDEBUG) << "Calling I2CJNI i2CTransactionB";
+  I2CJNI_LOG(logDEBUG) << "Port = " << port;
+  I2CJNI_LOG(logDEBUG) << "Address = " << (jint)address;
+  I2CJNI_LOG(logDEBUG) << "SendSize = " << (jint)sendSize;
+  llvm::SmallVector<uint8_t, 128> recvBuf;
+  recvBuf.resize(receiveSize);
+  I2CJNI_LOG(logDEBUG) << "ReceiveSize = " << (jint)receiveSize;
+  jint returnValue =
+      HAL_TransactionI2C(static_cast<HAL_I2CPort>(port), address,
+                         reinterpret_cast<const uint8_t *>(
+                             JByteArrayRef(env, dataToSend).array().data()),
+                         sendSize, recvBuf.data(), receiveSize);
+  env->SetByteArrayRegion(dataReceived, 0, receiveSize,
+                          reinterpret_cast<const jbyte *>(recvBuf.data()));
+  I2CJNI_LOG(logDEBUG) << "ReturnValue = " << returnValue;
+  return returnValue;
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_hal_I2CJNI
  * Method:    i2CWrite
  * Signature: (IBLjava/nio/ByteBuffer;B)I
  */
@@ -94,6 +122,27 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_I2CJNI_i2CWrite(
 
 /*
  * Class:     edu_wpi_first_wpilibj_hal_I2CJNI
+ * Method:    i2CWriteB
+ * Signature: (IB[BB)I
+ */
+JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_I2CJNI_i2CWriteB(
+    JNIEnv* env, jclass, jint port, jbyte address, jbyteArray dataToSend,
+    jbyte sendSize) {
+  I2CJNI_LOG(logDEBUG) << "Calling I2CJNI i2CWrite";
+  I2CJNI_LOG(logDEBUG) << "Port = " << port;
+  I2CJNI_LOG(logDEBUG) << "Address = " << (jint)address;
+  I2CJNI_LOG(logDEBUG) << "SendSize = " << (jint)sendSize;
+  jint returnValue =
+      HAL_WriteI2C(static_cast<HAL_I2CPort>(port), address,
+                   reinterpret_cast<const uint8_t *>(
+                       JByteArrayRef(env, dataToSend).array().data()),
+                   sendSize);
+  I2CJNI_LOG(logDEBUG) << "ReturnValue = " << (jint)returnValue;
+  return returnValue;
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_hal_I2CJNI
  * Method:    i2CRead
  * Signature: (IBLjava/nio/ByteBuffer;B)I
  */
@@ -108,6 +157,27 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_I2CJNI_i2CRead(
   I2CJNI_LOG(logDEBUG) << "DataReceivedPtr = " << dataReceivedPtr;
   I2CJNI_LOG(logDEBUG) << "ReceiveSize = " << receiveSize;
   jint returnValue = HAL_ReadI2C(static_cast<HAL_I2CPort>(port), address, dataReceivedPtr, receiveSize);
+  I2CJNI_LOG(logDEBUG) << "ReturnValue = " << returnValue;
+  return returnValue;
+}
+
+/*
+ * Class:     edu_wpi_first_wpilibj_hal_I2CJNI
+ * Method:    i2CReadB
+ * Signature: (IB[BB)I
+ */
+JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_I2CJNI_i2CReadB(
+    JNIEnv* env, jclass, jint port, jbyte address, jbyteArray dataReceived,
+    jbyte receiveSize) {
+  I2CJNI_LOG(logDEBUG) << "Calling I2CJNI i2CRead";
+  I2CJNI_LOG(logDEBUG) << "Port = " << port;
+  I2CJNI_LOG(logDEBUG) << "Address = " << address;
+  I2CJNI_LOG(logDEBUG) << "ReceiveSize = " << receiveSize;
+  llvm::SmallVector<uint8_t, 128> recvBuf;
+  recvBuf.resize(receiveSize);
+  jint returnValue = HAL_ReadI2C(static_cast<HAL_I2CPort>(port), address, recvBuf.data(), receiveSize);
+  env->SetByteArrayRegion(dataReceived, 0, receiveSize,
+                          reinterpret_cast<const jbyte *>(recvBuf.data()));
   I2CJNI_LOG(logDEBUG) << "ReturnValue = " << returnValue;
   return returnValue;
 }

--- a/wpilibj/src/main/native/cpp/OSSerialPortJNI.cpp
+++ b/wpilibj/src/main/native/cpp/OSSerialPortJNI.cpp
@@ -13,8 +13,10 @@
 
 #include "HAL/OSSerialPort.h"
 #include "HALUtil.h"
+#include "support/jni_util.h"
 
 using namespace frc;
+using namespace wpi::java;
 
 // set the logging level
 TLogLevel osserialJNILogLevel = logWARNING;
@@ -237,16 +239,18 @@ Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialGetBytesReceived(
 /*
  * Class:     edu_wpi_first_wpilibj_hal_OSSerialPortJNI
  * Method:    serialRead
- * Signature: (BLjava/nio/ByteBuffer;I)I
+ * Signature: (B[BI)I
  */
 JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialRead(
-    JNIEnv* env, jclass, jbyte port, jobject dataReceived, jint size) {
+    JNIEnv* env, jclass, jbyte port, jbyteArray dataReceived, jint size) {
   SERIALJNI_LOG(logDEBUG) << "Serial Read";
-  jbyte* dataReceivedPtr = nullptr;
-  dataReceivedPtr = (jbyte*)env->GetDirectBufferAddress(dataReceived);
+  llvm::SmallVector<char, 128> recvBuf;
+  recvBuf.resize(size);
   int32_t status = 0;
-  jint retVal = HAL_ReadOSSerial(static_cast<HAL_SerialPort>(port), reinterpret_cast<char*>(dataReceivedPtr), 
+  jint retVal = HAL_ReadOSSerial(static_cast<HAL_SerialPort>(port), recvBuf.data(), 
                                  size, &status);
+  env->SetByteArrayRegion(dataReceived, 0, size,
+                          reinterpret_cast<const jbyte *>(recvBuf.data()));
   SERIALJNI_LOG(logDEBUG) << "ReturnValue = " << retVal;
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
   CheckStatus(env, status);
@@ -256,18 +260,17 @@ JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialRead
 /*
  * Class:     edu_wpi_first_wpilibj_hal_OSSerialPortJNI
  * Method:    serialWrite
- * Signature: (BLjava/nio/ByteBuffer;I)I
+ * Signature: (B[BI)I
  */
 JNIEXPORT jint JNICALL Java_edu_wpi_first_wpilibj_hal_OSSerialPortJNI_serialWrite(
-    JNIEnv* env, jclass, jbyte port, jobject dataToSend, jint size) {
+    JNIEnv* env, jclass, jbyte port, jbyteArray dataToSend, jint size) {
   SERIALJNI_LOG(logDEBUG) << "Serial Write";
-  jbyte* dataToSendPtr = nullptr;
-  if (dataToSend != 0) {
-    dataToSendPtr = (jbyte*)env->GetDirectBufferAddress(dataToSend);
-  }
   int32_t status = 0;
-  jint retVal = HAL_WriteOSSerial(static_cast<HAL_SerialPort>(port), reinterpret_cast<char*>(dataToSendPtr), 
-                                  size, &status);
+  jint retVal =
+      HAL_WriteOSSerial(static_cast<HAL_SerialPort>(port),
+                        reinterpret_cast<const char *>(
+                            JByteArrayRef(env, dataToSend).array().data()),
+                        size, &status);
   SERIALJNI_LOG(logDEBUG) << "ReturnValue = " << retVal;
   SERIALJNI_LOG(logDEBUG) << "Status = " << status;
   CheckStatus(env, status);


### PR DESCRIPTION
This avoids a direct byte buffer allocation on every read/write/transaction
for the byte[] variants.

Also change spiGetAccumulatorOutput() to directly set the AccumulatorResult
object, avoiding a ByteBuffer allocation.

Changes HAL SPI interfaces to use const for dataToSend.

Fixes #733.