### PR TITLE
Only returns lower 32 bits of FPGA time

### DIFF
--- a/hal/src/main/native/athena/HAL.cpp
+++ b/hal/src/main/native/athena/HAL.cpp
@@ -219,6 +219,9 @@ uint64_t HAL_GetFPGATime(int32_t* status) {
     *status = NiFpga_Status_ResourceNotInitialized;
     return 0;
   }
+  // Because of a bug in FPGA image 10, just return the lower 32 bits of time.
+  return global->readLocalTime(status);
+
   uint64_t upper1 = global->readLocalTimeUpper(status);
   uint32_t lower = global->readLocalTime(status);
   uint64_t upper2 = global->readLocalTimeUpper(status);

--- a/hal/src/main/native/athena/PWM.cpp
+++ b/hal/src/main/native/athena/PWM.cpp
@@ -473,6 +473,10 @@ int32_t HAL_GetPWMLoopTiming(int32_t* status) {
 uint64_t HAL_GetPWMCycleStartTime(int32_t* status) {
   initializeDigital(status);
   if (*status != 0) return 0;
+  // Because of a bug in FPGA image 10, just return the lower 32 bits of cycle
+  // time.
+  return pwmSystem->readCycleStartTime(status);
+
   uint64_t upper1 = pwmSystem->readCycleStartTimeUpper(status);
   uint32_t lower = pwmSystem->readCycleStartTime(status);
   uint64_t upper2 = pwmSystem->readCycleStartTimeUpper(status);


### PR DESCRIPTION
Works around an NI bug in image 10.