### PR TITLE
Simulation Model Framework

### DIFF
--- a/wpilibc/build.gradle
+++ b/wpilibc/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'edu.wpi.first.NativeUtils'
 apply from: '../config.gradle'
 
 ext.addWpilibCCompilerArguments = { binary->
-	if (binary.targetPlatform.architecture.name == 'athena') {
+    if (binary.targetPlatform.architecture.name == 'athena') {
         tasks.withType(CppCompile) {
             binary.cppCompiler.args "-DCONFIG_ATHENA"
         }

--- a/wpilibc/build.gradle
+++ b/wpilibc/build.gradle
@@ -6,6 +6,11 @@ apply plugin: 'edu.wpi.first.NativeUtils'
 apply from: '../config.gradle'
 
 ext.addWpilibCCompilerArguments = { binary->
+	if (binary.targetPlatform.architecture.name == 'athena') {
+        tasks.withType(CppCompile) {
+            binary.cppCompiler.args "-DCONFIG_ATHENA"
+        }
+    }
     tasks.withType(CppCompile) {
         binary.cppCompiler.args "-DNAMESPACED_WPILib"
     }

--- a/wpilibc/src/main/native/cpp/Simulation/Data/PWMData.cpp
+++ b/wpilibc/src/main/native/cpp/Simulation/Data/PWMData.cpp
@@ -1,0 +1,30 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2016-2017 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "Simulation/Data/PWMData.h"
+#include "HAL/HAL.h"
+#include "MockData/PWMData.h"
+
+int frc::sim::GetNumPWM() {
+	return HAL_GetNumPWMChannels();
+}
+
+frc::sim::PWMData frc::sim::GetPWMData(int index) {
+#ifndef CONFIG_ATHENA
+	PWMData data = {
+		HALSIM_GetPWMInitialized(index),		// initialized
+		HALSIM_GetPWMRawValue(index),			// raw
+		HALSIM_GetPWMSpeed(index),				// speed
+		HALSIM_GetPWMPosition(index),			// position
+		HALSIM_GetPWMPeriodScale(index),		// period scale
+		HALSIM_GetPWMZeroLatch(index)			// zero latch
+	};
+	return data;
+#else
+	return {};
+#endif
+}

--- a/wpilibc/src/main/native/include/Simulation/Data/PWMData.h
+++ b/wpilibc/src/main/native/include/Simulation/Data/PWMData.h
@@ -1,0 +1,39 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2016-2017 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <cinttypes>
+
+namespace frc {
+namespace sim {
+
+	/** 
+	 * PWM Data structure, containing data for each of the PWM Channels.
+	 * This is intended to be used in a Model instance.
+	 */
+	typedef struct PWMData_ {
+		bool initialized;
+		int32_t raw;
+		double speed;
+		double position;
+		int32_t periodScale;
+		bool zeroLatch;
+	} PWMData;
+	
+	/**
+	 * Get the number of available PWM Channels (both onboard + MXP)
+	 */
+	int GetNumPWM();
+
+	/**
+	 * Get PWM Data for a specific channel. This only works in simulation.
+	 */
+	PWMData GetPWMData(int index);
+
+} // namespace sim
+} // namespace frc

--- a/wpilibc/src/main/native/include/Simulation/Model.h
+++ b/wpilibc/src/main/native/include/Simulation/Model.h
@@ -1,0 +1,41 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2016-2017 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+namespace frc {
+namespace sim {
+
+	/**
+	 * The Model class is an interface used to represent a physical system during simulation.
+	 * This interface is to be used with a known 'state', containing all the instance-relevant 
+	 * information (like speed, position, etc), and a 'data' instance containing immutable information
+	 * about the robot (like PWM channel values).
+	 *
+	 * Each Model instance represents a type of mechanism or device (like a motor), but not necessarily
+	 * one instance per device on the robot. Instead, each physical device has its own state instance
+	 * that is passed to this class. 
+	 *
+	 * This class is intended to be pure with no side effects. All mutable data should be handled in the
+	 * state instance exposed by the class template.
+	 */
+	template<typename STATE, typename DATA>
+	class Model {
+	public:
+		virtual ~Model() = default;
+
+		/**
+		 * Calculate the state for the model using the last known state, immutable data, as well as 
+		 * the time difference between when the last state was recorded. This function is pure, with
+		 * no side effects.
+		 *
+		 * The state parameter should not be modified outside of this function.
+		 */
+		virtual STATE calculate(STATE state, const DATA data, const double dt) const = 0;
+	};
+} // namespace sim
+} // namespace frc

--- a/wpilibc/src/main/native/include/Simulation/Mutator.h
+++ b/wpilibc/src/main/native/include/Simulation/Mutator.h
@@ -1,0 +1,33 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2016-2017 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+namespace frc {
+namespace sim {
+
+	/**
+	 * The Mutator interface is the last stage of a simulation pipeline. 
+	 * A Mutator is designed to take a (now-immutable) state from Model instances
+	 * and set some form of (now-mutable) data with it. For example, it may take in
+	 * the state of a Motor, and set the data of an Encoder channel with it.
+	 */
+	template<typename STATE, typename DATA>
+	class Mutator {
+	public:
+		virtual ~Mutator() = default;
+
+		/**
+		 * Mutate the data given an immutable state. This function should not modify the state (or any
+		 * external values), and should modify only the passed data instance.
+		 *
+		 * The passed data instance may not be reallocated, only modified.
+		 */
+		virtual void mutate(STATE const state, DATA &data) const = 0;
+	};
+} // namespace sim
+} // namespace frc


### PR DESCRIPTION
This PR adds a basic framework for physical models of parts of a robot, intended to be used with the new additions to the HAL for simulation.

`Model` is an interface class to repesent a change of 'state' of a device on the robot, taking in immutable data (e.g. for a motor, state = speed, data = pwm values).

`Mutator` is an interface for setting values inside of WPILib (like encoder readings) based on (a now immutable) state (e.g., for an encoder, state = motor readings, data = encoder status).

A single, `PWMData` file has been added that puts the data from `MockData/PWMData` (in the hal) into a more user-friendly format. More will be added at a later date.

I've made a quick skeleton of an implementation [in this gist](https://gist.github.com/JacisNonsense/fd57993badf02858dfcdb79148dfb1b7). This is a very messy implementation since more infrastructure will have to be added before this is fleshed out to users, so this is very much a work in progress. I'm submitting the PR now so we can start deciding how this should look when it's fully fleshed out. For that same reason, there is a lot missing from this PR (framework, more data providers, boilerplate models, etc).