### PR TITLE
Deprecated internal filter of PID controller

### DIFF
--- a/config.gradle
+++ b/config.gradle
@@ -8,7 +8,7 @@ def windowsLinkerArgs = [ '/DEBUG:FULL' ]
 def windowsReleaseLinkerArgs = [ '/OPT:REF', '/OPT:ICF' ]
 
 def linuxCompilerArgs = ['-std=c++1y', '-Wformat=2', '-Wall', '-Wextra', '-Werror', '-pedantic', '-Wno-psabi', '-g',
-                         '-Wno-unused-parameter', '-fPIC', '-rdynamic', '-pthread']
+                         '-Wno-unused-parameter', '-Wno-error=deprecated-declarations', '-fPIC', '-rdynamic', '-pthread']
 def linuxLinkerArgs = ['-rdynamic', '-pthread']
 def linuxReleaseCompilerArgs = ['-O2']
 def linuxDebugCompilerArgs = ['-O0']

--- a/wpilibc/src/main/native/include/PIDController.h
+++ b/wpilibc/src/main/native/include/PIDController.h
@@ -69,7 +69,7 @@ class PIDController : public LiveWindowSendable, public PIDInterface {
 
   virtual double GetError() const;
 
-  WPI_DEPRECATED("Use GetError() instead, which is now already filtered.")
+  WPI_DEPRECATED("Use a LinearDigitalFilter as the input and GetError().")
   virtual double GetAvgError() const;
 
   virtual void SetPIDSourceType(PIDSourceType pidSource);
@@ -79,7 +79,10 @@ class PIDController : public LiveWindowSendable, public PIDInterface {
   virtual void SetTolerance(double percent);
   virtual void SetAbsoluteTolerance(double absValue);
   virtual void SetPercentTolerance(double percentValue);
+
+  WPI_DEPRECATED("Use a LinearDigitalFilter as the input.")
   virtual void SetToleranceBuffer(int buf = 1);
+
   virtual bool OnTarget() const;
 
   void Enable() override;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDController.java
@@ -589,8 +589,10 @@ public class PIDController implements PIDInterface, LiveWindowSendable, Controll
    * erroneous measurements when the mechanism is on target. However, the mechanism will not
    * register as on target for at least the specified bufLength cycles.
    *
+   * @deprecated      Use a LinearDigitalFilter as the input.
    * @param bufLength Number of previous cycles to average.
    */
+  @Deprecated
   public synchronized void setToleranceBuffer(int bufLength) {
     m_filter = LinearDigitalFilter.movingAverage(m_origSource, bufLength);
     m_pidInput = m_filter;

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/MotorEncoderTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/MotorEncoderTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.logging.Logger;
 
+import edu.wpi.first.wpilibj.filters.LinearDigitalFilter;
 import edu.wpi.first.wpilibj.fixtures.MotorEncoderFixture;
 import edu.wpi.first.wpilibj.test.AbstractComsSetup;
 import edu.wpi.first.wpilibj.test.TestBench;
@@ -194,10 +195,10 @@ public class MotorEncoderTest extends AbstractComsSetup {
   @Test
   public void testVelocityPIDController() {
     me.getEncoder().setPIDSourceType(PIDSourceType.kRate);
+    LinearDigitalFilter filter = LinearDigitalFilter.movingAverage(me.getEncoder(), 50);
     PIDController pid =
-        new PIDController(1e-5, 0.0, 3e-5, 8e-5, me.getEncoder(), me.getMotor());
+        new PIDController(1e-5, 0.0, 3e-5, 8e-5, filter, me.getMotor());
     pid.setAbsoluteTolerance(200);
-    pid.setToleranceBuffer(50);
     pid.setOutputRange(-0.3, 0.3);
     pid.setSetpoint(600);
 


### PR DESCRIPTION
This was replaced with an external LinearDigitalFilter. To reduce boilerplate,
constructor overloads that take references were added to LinearDigitalFilter.
External ownership is now expected rather than shared ownership.