### PR TITLE
Added PIDController::GetAvgError() back in

### DIFF
--- a/wpilibc/src/main/native/cpp/PIDController.cpp
+++ b/wpilibc/src/main/native/cpp/PIDController.cpp
@@ -374,6 +374,16 @@ double PIDController::GetError() const {
 }
 
 /**
+ * Returns the current average of the error over the past few iterations.
+ *
+ * You can specify the number of iterations to average with SetToleranceBuffer()
+ * (defaults to 1). This is the same value that is used for OnTarget().
+ *
+ * @return the average error
+ */
+double PIDController::GetAvgError() const { return GetError(); }
+
+/**
  * Sets what type of input the PID controller will use.
  */
 void PIDController::SetPIDSourceType(PIDSourceType pidSource) {

--- a/wpilibc/src/main/native/include/PIDController.h
+++ b/wpilibc/src/main/native/include/PIDController.h
@@ -65,6 +65,9 @@ class PIDController : public LiveWindowSendable, public PIDInterface {
 
   virtual double GetError() const;
 
+  WPI_DEPRECATED("Use GetError() instead, which is now already filtered.")
+  virtual double GetAvgError() const;
+
   virtual void SetPIDSourceType(PIDSourceType pidSource);
   virtual PIDSourceType GetPIDSourceType() const;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDController.java
@@ -516,6 +516,19 @@ public class PIDController implements PIDInterface, LiveWindowSendable, Controll
   }
 
   /**
+   * Returns the current difference of the error over the past few iterations. You can specify the
+   * number of iterations to average with setToleranceBuffer() (defaults to 1). getAvgError() is
+   * used for the onTarget() function.
+   *
+   * @deprecated Use getError(), which is now already filtered.
+   * @return     the current average of the error
+   */
+  @Deprecated
+  public synchronized double getAvgError() {
+    return getError();
+  }
+
+  /**
    * Sets what type of input the PID controller will use.
    *
    * @param pidSource the type of input


### PR DESCRIPTION
It got removed during the LinearDigitalFilter change (#38) instead of deprecated
by mistake.