### PR TITLE
Add return-to-zero test for LinearDigitalFilter moving average

### DIFF
--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/FilterOutputTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/FilterOutputTest.java
@@ -58,7 +58,8 @@ public class FilterOutputTest extends AbstractComsSetup {
     return Arrays.asList(new FilterOutputFixture<?>[][]{
         {TestBench.getInstance().getSinglePoleIIROutputFixture()},
         {TestBench.getInstance().getHighPassOutputFixture()},
-        {TestBench.getInstance().getMovAvgOutputFixture()}});
+        {TestBench.getInstance().getMovAvgOutputFixture()},
+        {TestBench.getInstance().getPulseFixture()}});
   }
 
   @Before

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/test/TestBench.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/test/TestBench.java
@@ -387,8 +387,9 @@ public final class TestBench {
   public FilterOutputFixture<LinearDigitalFilter> getSinglePoleIIROutputFixture() {
     return new FilterOutputFixture<LinearDigitalFilter>(kSinglePoleIIRExpectedOutput) {
       @Override
-      protected LinearDigitalFilter giveFilter(PIDSource source) {
-        return LinearDigitalFilter.singlePoleIIR(source,
+      protected LinearDigitalFilter giveFilter() {
+        DataWrapper data = new DataWrapper(getData);
+        return LinearDigitalFilter.singlePoleIIR(data,
             kSinglePoleIIRTimeConstant,
             kFilterStep);
       }
@@ -403,8 +404,9 @@ public final class TestBench {
   public FilterOutputFixture<LinearDigitalFilter> getHighPassOutputFixture() {
     return new FilterOutputFixture<LinearDigitalFilter>(kHighPassExpectedOutput) {
       @Override
-      protected LinearDigitalFilter giveFilter(PIDSource source) {
-        return LinearDigitalFilter.highPass(source, kHighPassTimeConstant,
+      protected LinearDigitalFilter giveFilter() {
+        DataWrapper data = new DataWrapper(getData);
+        return LinearDigitalFilter.highPass(data, kHighPassTimeConstant,
             kFilterStep);
       }
     };
@@ -419,8 +421,25 @@ public final class TestBench {
   public FilterOutputFixture<LinearDigitalFilter> getMovAvgOutputFixture() {
     return new FilterOutputFixture<LinearDigitalFilter>(kMovAvgExpectedOutput) {
       @Override
-      protected LinearDigitalFilter giveFilter(PIDSource source) {
-        return LinearDigitalFilter.movingAverage(source, kMovAvgTaps);
+      protected LinearDigitalFilter giveFilter() {
+        DataWrapper data = new DataWrapper(getData);
+        return LinearDigitalFilter.movingAverage(data, kMovAvgTaps);
+      }
+    };
+  }
+
+  /**
+   * Constructs a new set of objects representing a moving average filter with a repeatable data
+   * source using a linear digital filter.
+   *
+   * @return a moving average filter with a repeatable data source
+   */
+  public FilterOutputFixture<LinearDigitalFilter> getPulseFixture() {
+    return new FilterOutputFixture<LinearDigitalFilter>(0.0) {
+      @Override
+      protected LinearDigitalFilter giveFilter() {
+        DataWrapper data = new DataWrapper(getPulseData);
+        return LinearDigitalFilter.movingAverage(data, kMovAvgTaps);
       }
     };
   }


### PR DESCRIPTION
Ensures LinearDigitalFilter moving average returns to zero after non-zero
values are inserted.

Tests for issue #642