### PR TITLE
Fixed crash in wpilibj SampleRobot

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SampleRobot.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SampleRobot.java
@@ -31,11 +31,6 @@ public class SampleRobot extends RobotBase {
    * Create a new SampleRobot.
    */
   public SampleRobot() {
-    robotInit();
-
-    // Tell the DS that the robot is ready to be enabled
-    HAL.observeUserProgramStarting();
-
     HAL.report(tResourceType.kResourceType_Framework, tInstances.kFramework_Simple);
   }
 
@@ -115,7 +110,13 @@ public class SampleRobot extends RobotBase {
    * for the robot to be enabled again.
    */
   public void startCompetition() {
+    robotInit();
+
+    // Tell the DS that the robot is ready to be enabled
+    HAL.observeUserProgramStarting();
+
     robotMain();
+
     if (!m_robotMainOverridden) {
       while (true) {
         if (isDisabled()) {


### PR DESCRIPTION
robotInit() and HAL.observeUserProgramStarting() should be called in
startCompetition() rather than the constructor.