### PR TITLE
Replaced extra constructors in LinearDigitalFilter with llvm::ArrayRef<>

### DIFF
--- a/wpilibc/src/main/native/cpp/Filters/LinearDigitalFilter.cpp
+++ b/wpilibc/src/main/native/cpp/Filters/LinearDigitalFilter.cpp
@@ -20,56 +20,8 @@ using namespace frc;
  * @param fbGains The "feed back" or IIR gains
  */
 LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
-                                         std::initializer_list<double> ffGains,
-                                         std::initializer_list<double> fbGains)
-    : Filter(source),
-      m_inputs(ffGains.size()),
-      m_outputs(fbGains.size()),
-      m_inputGains(ffGains),
-      m_outputGains(fbGains) {}
-
-/**
- * Create a linear FIR or IIR filter.
- *
- * @param source  The PIDSource object that is used to get values
- * @param ffGains The "feed forward" or FIR gains
- * @param fbGains The "feed back" or IIR gains
- */
-LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
-                                         std::initializer_list<double> ffGains,
-                                         const std::vector<double>& fbGains)
-    : Filter(source),
-      m_inputs(ffGains.size()),
-      m_outputs(fbGains.size()),
-      m_inputGains(ffGains),
-      m_outputGains(fbGains) {}
-
-/**
- * Create a linear FIR or IIR filter.
- *
- * @param source  The PIDSource object that is used to get values
- * @param ffGains The "feed forward" or FIR gains
- * @param fbGains The "feed back" or IIR gains
- */
-LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
-                                         const std::vector<double>& ffGains,
-                                         std::initializer_list<double> fbGains)
-    : Filter(source),
-      m_inputs(ffGains.size()),
-      m_outputs(fbGains.size()),
-      m_inputGains(ffGains),
-      m_outputGains(fbGains) {}
-
-/**
- * Create a linear FIR or IIR filter.
- *
- * @param source  The PIDSource object that is used to get values
- * @param ffGains The "feed forward" or FIR gains
- * @param fbGains The "feed back" or IIR gains
- */
-LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
-                                         const std::vector<double>& ffGains,
-                                         const std::vector<double>& fbGains)
+                                         llvm::ArrayRef<double> ffGains,
+                                         llvm::ArrayRef<double> fbGains)
     : Filter(source),
       m_inputs(ffGains.size()),
       m_outputs(fbGains.size()),

--- a/wpilibc/src/main/native/include/Filters/LinearDigitalFilter.h
+++ b/wpilibc/src/main/native/include/Filters/LinearDigitalFilter.h
@@ -7,9 +7,10 @@
 
 #pragma once
 
-#include <initializer_list>
 #include <memory>
 #include <vector>
+
+#include <llvm/ArrayRef.h>
 
 #include "CircularBuffer.h"
 #include "Filter.h"
@@ -69,17 +70,8 @@ namespace frc {
 class LinearDigitalFilter : public Filter {
  public:
   LinearDigitalFilter(std::shared_ptr<PIDSource> source,
-                      std::initializer_list<double> ffGains,
-                      std::initializer_list<double> fbGains);
-  LinearDigitalFilter(std::shared_ptr<PIDSource> source,
-                      std::initializer_list<double> ffGains,
-                      const std::vector<double>& fbGains);
-  LinearDigitalFilter(std::shared_ptr<PIDSource> source,
-                      const std::vector<double>& ffGains,
-                      std::initializer_list<double> fbGains);
-  LinearDigitalFilter(std::shared_ptr<PIDSource> source,
-                      const std::vector<double>& ffGains,
-                      const std::vector<double>& fbGains);
+                      llvm::ArrayRef<double> ffGains,
+                      llvm::ArrayRef<double> fbGains);
 
   // Static methods to create commonly used filters
   static LinearDigitalFilter SinglePoleIIR(std::shared_ptr<PIDSource> source,


### PR DESCRIPTION
llvm::ArrayRef<> replaces both the std::initializer_list<> and std::vector<>
constructor overloads.