### PR TITLE
NidecBrushless: Have disable() call PWM.setDisabled().

### DIFF
--- a/wpilibc/src/main/native/include/NidecBrushless.h
+++ b/wpilibc/src/main/native/include/NidecBrushless.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -38,6 +39,8 @@ class NidecBrushless : public SpeedController,
   void Disable() override;
   void StopMotor() override;
 
+  void Enable();
+
   // PIDOutput interface
   void PIDWrite(double output) override;
 
@@ -63,6 +66,7 @@ class NidecBrushless : public SpeedController,
  private:
   MotorSafetyHelper m_safetyHelper;
   bool m_isInverted = false;
+  std::atomic_bool m_disabled{false};
   DigitalOutput m_dio;
   PWM m_pwm;
   double m_speed = 0.0;


### PR DESCRIPTION
This provides a way to stop motor operation even if the DIO is disconnected.

Also change Set() to enable the PWM instead of having the constructor do it.

Provide an explicit Enable() call to re-enable after Disable() is called.
This is different from the other motor controllers (which automatically
re-enable when Set() is called) due to the dual-wiring of this motor
controller.

Motor safety results in disabling the motor only until the next Set() call.