### PR TITLE
Deprecated PIDController::SetTolerance()

### DIFF
--- a/wpilibc/src/main/native/include/PIDController.h
+++ b/wpilibc/src/main/native/include/PIDController.h
@@ -75,6 +75,7 @@ class PIDController : public LiveWindowSendable, public PIDInterface {
   virtual void SetPIDSourceType(PIDSourceType pidSource);
   virtual PIDSourceType GetPIDSourceType() const;
 
+  WPI_DEPRECATED("Use SetPercentTolerance() instead.")
   virtual void SetTolerance(double percent);
   virtual void SetAbsoluteTolerance(double absValue);
   virtual void SetPercentTolerance(double percentValue);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDController.java
@@ -552,9 +552,11 @@ public class PIDController implements PIDInterface, LiveWindowSendable, Controll
    * object. Use it by creating the type of tolerance that you want to use: setTolerance(new
    * PIDController.AbsoluteTolerance(0.1))
    *
-   * @param tolerance a tolerance object of the right type, e.g. PercentTolerance or
+   * @deprecated      Use setPercentTolerance() instead.
+   * @param tolerance A tolerance object of the right type, e.g. PercentTolerance or
    *                  AbsoluteTolerance
    */
+  @Deprecated
   public void setTolerance(Tolerance tolerance) {
     m_tolerance = tolerance;
   }


### PR DESCRIPTION
PIDController::SetPercentTolerance() behaves identically to it, so removing
SetTolerance() leaves one obvious way to do absolute or percent tolerance.