### PR TITLE
Performed cleanup of Timer's free functions

### DIFF
--- a/wpilibc/src/main/native/cpp/Notifier.cpp
+++ b/wpilibc/src/main/native/cpp/Notifier.cpp
@@ -103,7 +103,7 @@ void Notifier::StartSingle(double delay) {
   std::lock_guard<wpi::mutex> lock(m_processMutex);
   m_periodic = false;
   m_period = delay;
-  m_expirationTime = GetClock() + m_period;
+  m_expirationTime = Timer::GetFPGATimestamp() + m_period;
   UpdateAlarm();
 }
 
@@ -121,7 +121,7 @@ void Notifier::StartPeriodic(double period) {
   std::lock_guard<wpi::mutex> lock(m_processMutex);
   m_periodic = true;
   m_period = period;
-  m_expirationTime = GetClock() + m_period;
+  m_expirationTime = Timer::GetFPGATimestamp() + m_period;
   UpdateAlarm();
 }
 

--- a/wpilibc/src/main/native/cpp/Timer.cpp
+++ b/wpilibc/src/main/native/cpp/Timer.cpp
@@ -28,7 +28,6 @@ namespace frc {
  * @param seconds Length of time to pause, in seconds.
  */
 void Wait(double seconds) {
-  if (seconds < 0.0) return;
   std::this_thread::sleep_for(std::chrono::duration<double>(seconds));
 }
 

--- a/wpilibc/src/main/native/include/Timer.h
+++ b/wpilibc/src/main/native/include/Timer.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <support/deprecated.h>
 #include <support/mutex.h>
 
 #include "Base.h"
@@ -16,6 +17,7 @@ namespace frc {
 typedef void (*TimerInterruptHandler)(void* param);
 
 void Wait(double seconds);
+WPI_DEPRECATED("Use Timer::GetFPGATimestamp() instead.")
 double GetClock();
 double GetTime();
 
@@ -43,7 +45,6 @@ class Timer {
   bool HasPeriodPassed(double period);
 
   static double GetFPGATimestamp();
-  static double GetPPCTimestamp();
   static double GetMatchTime();
 
   // The time, in seconds, at which the 32-bit FPGA timestamp rolls over to 0


### PR DESCRIPTION
* GetClock() is now officially deprecated since its comment already informally
  did so and the function just forwards to Timer::GetFPGATimestamp().
* The declaration of GetPPCTimestamp() is missing a definition and has been
  removed.
* std::this_thread::sleep_for() returns immediately when given a negative
  duration, so the check for that was removed from Wait().