### PR TITLE
Bail out of the integration tests if enable fails

### DIFF
--- a/wpilibcIntegrationTests/src/FRCUserProgram/cpp/TestEnvironment.cpp
+++ b/wpilibcIntegrationTests/src/FRCUserProgram/cpp/TestEnvironment.cpp
@@ -43,10 +43,20 @@ class TestEnvironment : public testing::Environment {
     HAL_ObserveUserProgramStarting();
     LiveWindow::GetInstance()->SetEnabled(false);
 
-    llvm::outs() << "Waiting for enable\n";
+    llvm::outs() << "Started coms\n";
 
+    int enableCounter = 0;
     while (!DriverStation::GetInstance().IsEnabled()) {
+      if (enableCounter > 50) {
+        // Robot did not enable properly after 5 seconds.
+        // Force exit
+        llvm::errs() << " Failed to enable. Aborting\n";
+        std::terminate();
+      }
+
       Wait(0.1);
+
+      llvm::outs() << "Waiting for enable: " << enableCounter++ << "\n";
     }
   }
 

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/test/AbstractComsSetup.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/test/AbstractComsSetup.java
@@ -66,6 +66,12 @@ public abstract class AbstractComsSetup {
       // Wait until the robot is enabled before starting the tests
       int enableCounter = 0;
       while (!DriverStation.getInstance().isEnabled()) {
+        if (enableCounter > 50) {
+          // Robot did not enable properly after 5 seconds.
+          // Force exit
+          TestBench.err().println("Failed to enable. Aborting");
+          System.exit(1);
+        }
         try {
           Thread.sleep(100);
         } catch (InterruptedException ex) {


### PR DESCRIPTION
A failure is much better then an infinite loop.