### PR TITLE
Removes custom CONFIG_ATHENA compiler directive

### DIFF
--- a/hal/build.gradle
+++ b/hal/build.gradle
@@ -5,17 +5,6 @@ apply plugin: 'edu.wpi.first.NativeUtils'
 
 apply from: '../config.gradle'
 
-ext.addHalCompilerArguments = { binary->
-    if (binary.targetPlatform.architecture.name == 'athena') {
-        tasks.withType(CppCompile) {
-            binary.cppCompiler.args "-DCONFIG_ATHENA"
-        }
-    }
-    tasks.withType(CppCompile) {
-        binary.cppCompiler.args "-DNAMESPACED_PRIORITY"
-    }
-}
-
 ext.addHalToLinker = { binary->
     if (binary.targetPlatform.architecture.name == 'athena') {
         binary.lib project: ':hal', library: 'halAthena', linkage: 'shared'
@@ -172,7 +161,6 @@ model {
     }
     binaries {
         all {
-            project.addHalCompilerArguments(it)
             project(':ni-libraries').addNiLibrariesToLinker(it)
         }
         withType(GoogleTestTestSuiteBinarySpec) {

--- a/hal/src/main/native/include/HAL/handles/HandlesInternal.h
+++ b/hal/src/main/native/include/HAL/handles/HandlesInternal.h
@@ -77,7 +77,7 @@ static inline int16_t getHandleTypedIndex(HAL_Handle handle,
                                           HAL_HandleEnum enumType,
                                           int16_t version) {
   if (!isHandleType(handle, enumType)) return InvalidHandleIndex;
-#if !defined(CONFIG_ATHENA)
+#if !defined(__FRC_ROBORIO__)
   if (!isHandleCorrectVersion(handle, version)) return InvalidHandleIndex;
 #endif
   return getHandleIndex(handle);

--- a/myRobot/build.gradle
+++ b/myRobot/build.gradle
@@ -66,7 +66,6 @@ model {
             }
             binaries.all { binary->
                 project(':ni-libraries').addNiLibrariesToLinker(binary)
-                project(':hal').addHalCompilerArguments(binary)
                 project(':hal').addHalToLinker(binary)
                 project(':wpilibc').addWpilibCCompilerArguments(binary)
                 project(':wpilibc').addWpilibCToLinker(binary)

--- a/myRobot/src/main/native/cpp/MyRobot.cpp
+++ b/myRobot/src/main/native/cpp/MyRobot.cpp
@@ -7,7 +7,7 @@
 
 #include "IterativeRobot.h"
 
-class MyRobot : public IterativeRobot {
+class MyRobot : public frc::IterativeRobot {
   /**
    * This function is run when the robot is first started up and should be
    * used for any initialization code.

--- a/simulation/adx_gyro_accelerometer/build.gradle
+++ b/simulation/adx_gyro_accelerometer/build.gradle
@@ -51,7 +51,6 @@ if (!project.hasProperty('onlyAthena')) {
 
         binaries {
             all {
-                project(':hal').addHalCompilerArguments(it)
                 project(':hal').addHalToLinker(it)
             }
         }

--- a/simulation/halsim_print/build.gradle
+++ b/simulation/halsim_print/build.gradle
@@ -28,7 +28,6 @@ if (!project.hasProperty('onlyAthena')) {
 
         binaries {
             all {
-                project(':hal').addHalCompilerArguments(it)
                 project(':hal').addHalToLinker(it)
             }
             withType(StaticLibraryBinarySpec) {

--- a/wpilibc/build.gradle
+++ b/wpilibc/build.gradle
@@ -6,8 +6,8 @@ apply plugin: 'edu.wpi.first.NativeUtils'
 apply from: '../config.gradle'
 
 ext.addWpilibCCompilerArguments = { binary->
-    tasks.withType(CppCompile) {
-        binary.cppCompiler.args "-DNAMESPACED_WPILib"
+    binary.tasks.withType(CppCompile) {
+        binary.cppCompiler.args "-DNAMESPACED_WPILIB"
     }
 }
 
@@ -170,7 +170,6 @@ model {
             tasks.withType(CppCompile) {
                 dependsOn generateCppVersion
             }
-            project(':hal').addHalCompilerArguments(it)
             project(':ni-libraries').addNiLibrariesToLinker(it)
             project(':hal').addHalToLinker(it)
             project.addWpilibCCompilerArguments(it)

--- a/wpilibcIntegrationTests/build.gradle
+++ b/wpilibcIntegrationTests/build.gradle
@@ -68,7 +68,6 @@ if (!project.hasProperty('skipAthena')) {
                             cppCompiler.args "-Wno-error=deprecated-declarations"
                         }
                         project(':ni-libraries').addNiLibrariesToLinker(binary)
-                        project(':hal').addHalCompilerArguments(binary)
                         project(':hal').addHalToLinker(binary)
                         project(':wpilibc').addWpilibCCompilerArguments(binary)
                         project(':wpilibc').addWpilibCToLinker(binary)

--- a/wpilibj/build.gradle
+++ b/wpilibj/build.gradle
@@ -266,7 +266,6 @@ model {
     }
     binaries {
         withType(NativeBinarySpec) {
-            project(':hal').addHalCompilerArguments(it)
             project(':ni-libraries').addNiLibrariesToLinker(it)
         }
         withType(StaticLibraryBinarySpec) {


### PR DESCRIPTION
In roborio GCC 5.5, __FRC_ROBORIO__ has been added directly to the
compiler. So we can instead use that to detect if we are build for the
roborio, and in a much more reliable way.