### PR TITLE
Adds some functionality to use the new FRC compiler define

### DIFF
--- a/hal/src/main/native/include/MockData/AccelerometerData.h
+++ b/hal/src/main/native/include/MockData/AccelerometerData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -62,4 +64,6 @@ void HALSIM_RegisterAccelerometerAllCallbacks(int32_t index,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/AnalogGyroData.h
+++ b/hal/src/main/native/include/MockData/AnalogGyroData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -44,4 +46,6 @@ void HALSIM_RegisterAnalogGyroAllCallbacks(int32_t index,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/AnalogInData.h
+++ b/hal/src/main/native/include/MockData/AnalogInData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -94,4 +96,6 @@ void HALSIM_RegisterAnalogInAllCallbacks(int32_t index,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/AnalogOutData.h
+++ b/hal/src/main/native/include/MockData/AnalogOutData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -37,4 +39,6 @@ void HALSIM_RegisterAnalogOutAllCallbacks(int32_t index,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/AnalogTriggerData.h
+++ b/hal/src/main/native/include/MockData/AnalogTriggerData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -61,4 +63,6 @@ void HALSIM_RegisterAnalogTriggerAllCallbacks(int32_t index,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/CanData.h
+++ b/hal/src/main/native/include/MockData/CanData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "HAL_Value.h"
 #include "NotifyListener.h"
@@ -71,4 +73,6 @@ void HALSIM_CancelCanGetCANStatusCallback(int32_t uid);
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/DIOData.h
+++ b/hal/src/main/native/include/MockData/DIOData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -58,4 +60,6 @@ void HALSIM_RegisterDIOAllCallbacks(int32_t index, HAL_NotifyCallback callback,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/DigitalPWMData.h
+++ b/hal/src/main/native/include/MockData/DigitalPWMData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -44,4 +46,6 @@ void HALSIM_RegisterDigitalPWMAllCallbacks(int32_t index,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/DriverStationData.h
+++ b/hal/src/main/native/include/MockData/DriverStationData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/DriverStation.h"
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
@@ -92,4 +94,6 @@ void HALSIM_RegisterDriverStationAllCallbacks(HAL_NotifyCallback callback,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/EncoderData.h
+++ b/hal/src/main/native/include/MockData/EncoderData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -84,4 +86,6 @@ void HALSIM_RegisterEncoderAllCallbacks(int32_t index,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/HAL_Value.h
+++ b/hal/src/main/native/include/MockData/HAL_Value.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/Types.h"
 
 /** HAL data types. */
@@ -65,3 +67,5 @@ inline HAL_Value MakeDouble(double v) {
   value.data.v_double = v;
   return value;
 }
+
+#endif

--- a/hal/src/main/native/include/MockData/I2CData.h
+++ b/hal/src/main/native/include/MockData/I2CData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -36,4 +38,6 @@ void HALSIM_CancelI2CWriteCallback(int32_t index, int32_t uid);
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/MockHooks.h
+++ b/hal/src/main/native/include/MockData/MockHooks.h
@@ -7,8 +7,12 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 extern "C" {
 void HALSIM_WaitForProgramStart(void);
 void HALSIM_SetProgramStarted(void);
 void HALSIM_RestartTiming(void);
 }  // extern "C"
+
+#endif

--- a/hal/src/main/native/include/MockData/NotifyCallbackHelpers.h
+++ b/hal/src/main/native/include/MockData/NotifyCallbackHelpers.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include <memory>
 
 #include "MockData/NotifyListenerVector.h"
@@ -65,3 +67,5 @@ std::shared_ptr<hal::ConstBufferListenerVector> CancelCallback(
 void InvokeCallback(
     std::shared_ptr<hal::ConstBufferListenerVector> currentVector,
     const char* name, const uint8_t* buffer, int32_t count);
+
+#endif

--- a/hal/src/main/native/include/MockData/NotifyListener.h
+++ b/hal/src/main/native/include/MockData/NotifyListener.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL_Value.h"
 
 typedef void (*HAL_NotifyCallback)(const char* name, void* param,
@@ -34,3 +36,5 @@ struct HalCallbackListener {
 };
 
 }  // namespace hal
+
+#endif

--- a/hal/src/main/native/include/MockData/NotifyListenerVector.h
+++ b/hal/src/main/native/include/MockData/NotifyListenerVector.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include <memory>
 #include <queue>
 #include <vector>
@@ -136,3 +138,5 @@ typedef HalCallbackListenerVectorImpl<HAL_ConstBufferCallback>
     ConstBufferListenerVector;
 
 }  // namespace hal
+
+#endif

--- a/hal/src/main/native/include/MockData/PCMData.h
+++ b/hal/src/main/native/include/MockData/PCMData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -86,4 +88,6 @@ void HALSIM_RegisterPCMAllSolenoidCallbacks(int32_t index, int32_t channel,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/PDPData.h
+++ b/hal/src/main/native/include/MockData/PDPData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -53,4 +55,6 @@ void HALSIM_RegisterPDPAllNonCurrentCallbacks(int32_t index, int32_t channel,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/PWMData.h
+++ b/hal/src/main/native/include/MockData/PWMData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -65,4 +67,6 @@ void HALSIM_RegisterPWMAllCallbacks(int32_t index, HAL_NotifyCallback callback,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/RelayData.h
+++ b/hal/src/main/native/include/MockData/RelayData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -53,4 +55,6 @@ void HALSIM_RegisterRelayAllCallcbaks(int32_t index,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/RoboRioData.h
+++ b/hal/src/main/native/include/MockData/RoboRioData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -139,4 +141,6 @@ void HALSIM_RegisterRoboRioAllCallbacks(int32_t index,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/SPIAccelerometerData.h
+++ b/hal/src/main/native/include/MockData/SPIAccelerometerData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -60,4 +62,6 @@ void HALSIM_RegisterSPIAccelerometerAllCallbcaks(int32_t index,
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/hal/src/main/native/include/MockData/SPIData.h
+++ b/hal/src/main/native/include/MockData/SPIData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef __FRC_ROBORIO__
+
 #include "HAL/HAL.h"
 #include "NotifyListener.h"
 
@@ -49,4 +51,6 @@ int64_t HALSIM_GetSPIGetAccumulatorValue(int32_t index);
 
 #ifdef __cplusplus
 }  // extern "C"
+#endif
+
 #endif

--- a/wpilibc/src/main/native/include/RobotBase.h
+++ b/wpilibc/src/main/native/include/RobotBase.h
@@ -52,6 +52,16 @@ class RobotBase {
   static std::thread::id GetThreadId();
   virtual void StartCompetition() = 0;
 
+  static constexpr bool IsReal() {
+#ifdef __FRC_ROBORIO__
+    return true;
+#else
+    return false;
+#endif
+  }
+
+  static constexpr bool IsSimulation() { return !IsReal(); }
+
  protected:
   RobotBase();
   virtual ~RobotBase() = default;


### PR DESCRIPTION
I want to add a few more. The current ones are removing all definitions
from the MockData headers when in simulation mode. And a constexpr
IsReal and IsSimulation in RobotBase. That's not as helpful now because
of no if constexpr, but still better then what we had, and useful for
the future.