### PR TITLE
Waits 10 seconds between running the C++ and Java test

### DIFF
--- a/test-scripts/jenkins-run-tests-get-results.sh
+++ b/test-scripts/jenkins-run-tests-get-results.sh
@@ -51,6 +51,8 @@ else
 	eval ${SCP_GET_CPP_TEST_RESULT}
 fi
 
+sleep 10
+
 # Run the Java Tests
 ./deploy-and-run-test-on-robot.sh java
 


### PR DESCRIPTION
Potentially will fix java tests not enabling.