### PR TITLE
Add reference constructors/factory methods to LinearDigitalFilter

### DIFF
--- a/wpilibc/src/main/native/cpp/Filters/Filter.cpp
+++ b/wpilibc/src/main/native/cpp/Filters/Filter.cpp
@@ -7,9 +7,15 @@
 
 #include "Filters/Filter.h"
 
+#include "Base.h"
+
 using namespace frc;
 
-Filter::Filter(std::shared_ptr<PIDSource> source) { m_source = source; }
+Filter::Filter(PIDSource& source)
+    : m_source(std::shared_ptr<PIDSource>(&source, NullDeleter<PIDSource>())) {}
+
+Filter::Filter(std::shared_ptr<PIDSource> source)
+    : m_source(std::move(source)) {}
 
 void Filter::SetPIDSourceType(PIDSourceType pidSource) {
   m_source->SetPIDSourceType(pidSource);

--- a/wpilibc/src/main/native/include/Filters/Filter.h
+++ b/wpilibc/src/main/native/include/Filters/Filter.h
@@ -18,6 +18,7 @@ namespace frc {
  */
 class Filter : public PIDSource {
  public:
+  explicit Filter(PIDSource& source);
   explicit Filter(std::shared_ptr<PIDSource> source);
   virtual ~Filter() = default;
 

--- a/wpilibc/src/main/native/include/Filters/LinearDigitalFilter.h
+++ b/wpilibc/src/main/native/include/Filters/LinearDigitalFilter.h
@@ -69,11 +69,18 @@ namespace frc {
  */
 class LinearDigitalFilter : public Filter {
  public:
+  LinearDigitalFilter(PIDSource& source, llvm::ArrayRef<double> ffGains,
+                      llvm::ArrayRef<double> fbGains);
   LinearDigitalFilter(std::shared_ptr<PIDSource> source,
                       llvm::ArrayRef<double> ffGains,
                       llvm::ArrayRef<double> fbGains);
 
   // Static methods to create commonly used filters
+  static LinearDigitalFilter SinglePoleIIR(PIDSource& source,
+                                           double timeConstant, double period);
+  static LinearDigitalFilter HighPass(PIDSource& source, double timeConstant,
+                                      double period);
+  static LinearDigitalFilter MovingAverage(PIDSource& source, int taps);
   static LinearDigitalFilter SinglePoleIIR(std::shared_ptr<PIDSource> source,
                                            double timeConstant, double period);
   static LinearDigitalFilter HighPass(std::shared_ptr<PIDSource> source,


### PR DESCRIPTION
Composition is less verbose with references than with smart pointers.