### PR TITLE
[WIP] Implement XboxControllerButton

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/XboxControllerButton.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/XboxControllerButton.java
@@ -60,45 +60,91 @@ public class XboxControllerButton extends Button {
   }
 
   /**
-   * TODO: Finish javadocs.
-   * TODO: Use Hand for left/right, possibly.
+   * Create an Xbox Controller button on the left bumper.
+   *
+   * @param controller The XboxController object that has the button
    */
   public static XboxControllerButton getBumperLeftButton(XboxController controller) {
     return new XboxControllerButton(controller, Button.kBumperLeft);
   }
 
+  /**
+   * Create an Xbox Controller button on the right bumper.
+   *
+   * @param controller The XboxController object that has the button
+   */
   public static XboxControllerButton getBumperRightButton(XboxController controller) {
     return new XboxControllerButton(controller, Button.kBumperRight);
   }
 
+  /**
+   * Create an Xbox Controller button on the left stick.
+   *
+   * @param controller The XboxController object that has the button
+   */
   public static XboxControllerButton getStickLeftButton(XboxController controller) {
     return new XboxControllerButton(controller, Button.kStickLeft);
   }
 
+  /**
+   * Create an Xbox Controller button on the right stick.
+   *
+   * @param controller The XboxController object that has the button
+   */
   public static XboxControllerButton getStickRightButton(XboxController controller) {
     return new XboxControllerButton(controller, Button.kStickRight);
   }
 
+  /**
+   * Create an Xbox Controller button on the A button.
+   *
+   * @param controller The XboxController object that has the button
+   */
   public static XboxControllerButton getAButton(XboxController controller) {
     return new XboxControllerButton(controller, Button.kA);
   }
 
+  /**
+   * Create an Xbox Controller button on the B button.
+   *
+   * @param controller The XboxController object that has the button
+   */
   public static XboxControllerButton getBButton(XboxController controller) {
     return new XboxControllerButton(controller, Button.kB);
   }
 
+  /**
+   * Create an Xbox Controller button on the X button.
+   *
+   * @param controller The XboxController object that has the button
+   */
   public static XboxControllerButton getXButton(XboxController controller) {
     return new XboxControllerButton(controller, Button.kX);
   }
 
+  /**
+   * Create an Xbox Controller button on the Y button.
+   *
+   * @param controller The XboxController object that has the button
+   */
   public static XboxControllerButton getYButton(XboxController controller) {
     return new XboxControllerButton(controller, Button.kY);
   }
 
+  /**
+   * Create an Xbox Controller button on the Back button.
+   *
+   * @param controller The XboxController object that has the button
+   */
   public static XboxControllerButton getBackButton(XboxController controller) {
     return new XboxControllerButton(controller, Button.kBack);
   }
 
+  /**
+   * Create an Xbox Controller button on the Start button.
+   *
+   * @param controller The XboxController object that has the button
+   */
   public static XboxControllerButton getStartButton(XboxController controller) {
     return new XboxControllerButton(controller, Button.kStart);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/XboxControllerButton.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/XboxControllerButton.java
@@ -16,7 +16,7 @@ public class XboxControllerButton extends Button {
   /**
    * Represents a digital button on an XboxController.
    */
-  public enum Button {
+  private enum Button {
     kBumperLeft(5),
     kBumperRight(6),
     kStickLeft(9),
@@ -45,7 +45,7 @@ public class XboxControllerButton extends Button {
    * @param controller   The XboxController object that has the button
    * @param button       The button to use (see {@link XboxControllerButton.Button}
    */
-  public XboxControllerButton(XboxController controller, XboxControllerButton.Button button) {
+  private XboxControllerButton(XboxController controller, XboxControllerButton.Button button) {
     m_controller = controller;
     m_buttonNumber = button.value;
   }
@@ -57,5 +57,49 @@ public class XboxControllerButton extends Button {
    */
   public boolean get() {
     return m_controller.getRawButton(m_buttonNumber);
+  }
+
+  /**
+   * TODO: Finish javadocs.
+   * TODO: Use Hand for left/right, possibly.
+   */
+  public static XboxControllerButton getBumperLeftButton(XboxController controller) {
+    return new XboxControllerButton(controller, Button.kBumperLeft);
+  }
+
+  public static XboxControllerButton getBumperRightButton(XboxController controller) {
+    return new XboxControllerButton(controller, Button.kBumperRight);
+  }
+
+  public static XboxControllerButton getStickLeftButton(XboxController controller) {
+    return new XboxControllerButton(controller, Button.kStickLeft);
+  }
+
+  public static XboxControllerButton getStickRightButton(XboxController controller) {
+    return new XboxControllerButton(controller, Button.kStickRight);
+  }
+
+  public static XboxControllerButton getAButton(XboxController controller) {
+    return new XboxControllerButton(controller, Button.kA);
+  }
+
+  public static XboxControllerButton getBButton(XboxController controller) {
+    return new XboxControllerButton(controller, Button.kB);
+  }
+
+  public static XboxControllerButton getXButton(XboxController controller) {
+    return new XboxControllerButton(controller, Button.kX);
+  }
+
+  public static XboxControllerButton getYButton(XboxController controller) {
+    return new XboxControllerButton(controller, Button.kY);
+  }
+
+  public static XboxControllerButton getBackButton(XboxController controller) {
+    return new XboxControllerButton(controller, Button.kBack);
+  }
+
+  public static XboxControllerButton getStartButton(XboxController controller) {
+    return new XboxControllerButton(controller, Button.kStart);
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/XboxControllerButton.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/XboxControllerButton.java
@@ -36,26 +36,26 @@ public class XboxControllerButton extends Button {
     }
   }
 
-  private final XboxController m_joystick;
+  private final XboxController m_controller;
   private final int m_buttonNumber;
 
   /**
-   * Create a joystick button for triggering commands.
+   * Create an Xbox Controller button for triggering commands.
    *
-   * @param joystick     The XboxController object that has the button
-   * @param button The button to use (see {@link XboxControllerButton.Button}
+   * @param controller   The XboxController object that has the button
+   * @param button       The button to use (see {@link XboxControllerButton.Button}
    */
-  public XboxControllerButton(XboxController joystick, XboxControllerButton.Button button) {
-    m_joystick = joystick;
+  public XboxControllerButton(XboxController controller, XboxControllerButton.Button button) {
+    m_controller = controller;
     m_buttonNumber = button.value;
   }
 
   /**
-   * Gets the value of the joystick button.
+   * Gets the value of the controller button.
    *
-   * @return The value of the joystick button
+   * @return The value of the controller button
    */
   public boolean get() {
-    return m_joystick.getRawButton(m_buttonNumber);
+    return m_controller.getRawButton(m_buttonNumber);
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/XboxControllerButton.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/XboxControllerButton.java
@@ -1,0 +1,61 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2008-2017 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.buttons;
+
+import edu.wpi.first.wpilibj.XboxController;
+
+/**
+ * A {@link Button} that gets its state from an {@link XboxController}.
+ */
+public class XboxControllerButton extends Button {
+  /**
+   * Represents a digital button on an XboxController.
+   */
+  public enum Button {
+    kBumperLeft(5),
+    kBumperRight(6),
+    kStickLeft(9),
+    kStickRight(10),
+    kA(1),
+    kB(2),
+    kX(3),
+    kY(4),
+    kBack(7),
+    kStart(8);
+
+    @SuppressWarnings("MemberName")
+    private int value;
+
+    Button(int value) {
+      this.value = value;
+    }
+  }
+
+  private final XboxController m_joystick;
+  private final int m_buttonNumber;
+
+  /**
+   * Create a joystick button for triggering commands.
+   *
+   * @param joystick     The XboxController object that has the button
+   * @param button The button to use (see {@link XboxControllerButton.Button}
+   */
+  public XboxControllerButton(XboxController joystick, XboxControllerButton.Button button) {
+    m_joystick = joystick;
+    m_buttonNumber = button.value;
+  }
+
+  /**
+   * Gets the value of the joystick button.
+   *
+   * @return The value of the joystick button
+   */
+  public boolean get() {
+    return m_joystick.getRawButton(m_buttonNumber);
+  }
+}


### PR DESCRIPTION
Closes #787 

Right now I've only implemented the Java side of things - I'd like some design feedback before I add the C++ code. 

I have a couple alternative branches to this one:

**Public Enums**

Two branches, [here](https://github.com/karagenit/allwpilib/tree/xbox-controller-button-public) and [here](https://github.com/karagenit/allwpilib/tree/xbox-controller-button-enum), expose public `enum`s to be passed to the constructor of `XboxControllerButton`. (The first makes XboxController.Button public, the second one adds a new duplicate enum to XboxControllerButton itself).

Because of the trend away from requiring `enum`s as arguments, this branch opts to use a number of static methods which internally call the (private) constructor with the `enum`, but the other code's there if you'd like to look at it.

**Switch in Get()**

This code can be seen [here](https://github.com/karagenit/allwpilib/tree/xbox-controller-button-enum-switch). Instead of passing the button's port number (stored in the `enum`) straight to `getRawButton()`, it uses a switch statement based on the `enum` value to call the corresponding button getter in `XboxController`. This means that a change to the button numbers in XboxController.Button won't affect this class, but has the disadvantage of adding more complex logic and of being less performant (to use the `enum` in a switch we have to store the full `enum` and not just its `int` value, plus more comparisons & method calls). 

Again, I don't think this addition is worthwhile (the likelihood of the button numbers changes is slim to none, and we can always just update both `enum`s), but its a thought.