### PR TITLE
Remove MSVC 2013 and GCC 4 workarounds

### DIFF
--- a/wpilibc/src/main/native/include/Base.h
+++ b/wpilibc/src/main/native/include/Base.h
@@ -13,39 +13,13 @@ static_assert(0,
               "update to the 2018 toolchains.");
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER < 1900
+static_assert(0, "Visual Studio 2015 or greater required.");
+#endif
+
 #include <HAL/cpp/make_unique.h>
 
-// MSVC 2013 doesn't allow "= default" on move constructors, but since we are
-// (currently) only actually using the move constructors in non-MSVC situations
-// (ie, wpilibC++Devices), we can just ignore it in MSVC.
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define DEFAULT_MOVE_CONSTRUCTOR(ClassName)
-#else
 #define DEFAULT_MOVE_CONSTRUCTOR(ClassName) ClassName(ClassName&&) = default
-#endif
-
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define constexpr const
-#endif
-
-#if (__cplusplus < 201103L) && !defined(_MSC_VER)
-#define nullptr NULL
-#endif
-
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define noexcept throw()
-#endif
-
-// Provide std::decay_t when using GCC < 4.9
-#if defined(__GNUC__)
-#if __GNUC__ == 4 && __GNUC_MINOR__ < 9
-#include <type_traits>
-namespace std {
-template <class T>
-using decay_t = typename decay<T>::type;
-}  // namespace std
-#endif
-#endif
 
 namespace frc {
 


### PR DESCRIPTION
No longer necessary in wpilibc. Also force MSVC 2015 or greater.