### PR TITLE
VisionRunner: Add stop() function to stop a runForever() loop.

### DIFF
--- a/wpilibc/src/main/native/cpp/vision/VisionRunner.cpp
+++ b/wpilibc/src/main/native/cpp/vision/VisionRunner.cpp
@@ -21,7 +21,9 @@ using namespace frc;
  * @param videoSource the video source to use to supply images for the pipeline
  */
 VisionRunnerBase::VisionRunnerBase(cs::VideoSource videoSource)
-    : m_image(std::make_unique<cv::Mat>()), m_cvSink("VisionRunner CvSink") {
+    : m_image(std::make_unique<cv::Mat>()),
+      m_cvSink("VisionRunner CvSink"),
+      m_enabled(true) {
   m_cvSink.SetSource(videoSource);
 }
 
@@ -70,7 +72,12 @@ void VisionRunnerBase::RunForever() {
         "thread");
     return;
   }
-  while (true) {
+  while (m_enabled) {
     RunOnce();
   }
 }
+
+/**
+ * Stop a RunForever() loop.
+ */
+void VisionRunnerBase::Stop() { m_enabled = false; }

--- a/wpilibc/src/main/native/include/vision/VisionRunner.h
+++ b/wpilibc/src/main/native/include/vision/VisionRunner.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <memory>
 
@@ -31,12 +32,15 @@ class VisionRunnerBase : public ErrorBase {
 
   void RunForever();
 
+  void Stop();
+
  protected:
   virtual void DoProcess(cv::Mat& image) = 0;
 
  private:
   std::unique_ptr<cv::Mat> m_image;
   cs::CvSink m_cvSink;
+  std::atomic_bool m_enabled;
 };
 
 /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/vision/VisionRunner.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/vision/VisionRunner.java
@@ -28,6 +28,7 @@ public class VisionRunner<P extends VisionPipeline> {
   private final P m_pipeline;
   private final Mat m_image = new Mat();
   private final Listener<? super P> m_listener;
+  private volatile boolean m_enabled = true;
 
   /**
    * Listener interface for a callback that should run after a pipeline has processed its input.
@@ -107,9 +108,15 @@ public class VisionRunner<P extends VisionPipeline> {
       throw new IllegalStateException(
           "VisionRunner.runForever() cannot be called from the main robot thread");
     }
-    while (!Thread.interrupted()) {
+    while (m_enabled && !Thread.interrupted()) {
       runOnce();
     }
   }
 
+  /**
+   * Stop a RunForever() loop.
+   */
+  public void stop() {
+    m_enabled = false;
+  }
 }


### PR DESCRIPTION
This was previously possible in Java with Thread.interrupt(), but provide
the same function in both C++ and Java.

Fixes #444.