### PR TITLE
Fixes JNI symbol check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'gradle.plugin.edu.wpi.first:native-utils:1.5.0'
+        classpath 'gradle.plugin.edu.wpi.first:native-utils:1.5.1'
     }
 }
 

--- a/wpilibj/build.gradle
+++ b/wpilibj/build.gradle
@@ -12,6 +12,7 @@ apply plugin: 'edu.wpi.first.NativeUtils'
 apply plugin: 'java'
 apply plugin: 'net.ltgt.errorprone'
 apply plugin: 'pmd'
+apply plugin: TestingModelBasePlugin
 
 configurations.errorprone {
     resolutionStrategy.force 'com.google.errorprone:error_prone_core:2.0.9'

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/hal/HAL.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/hal/HAL.java
@@ -120,8 +120,6 @@ public class HAL extends JNIWrapper {
 
   public static native int getMatchInfo(MatchInfoData info);
 
-  public static native int setErrorData(String error);
-
   public static native int sendError(boolean isError, int errorCode, boolean isLVCode,
                                      String details, String location, String callStack,
                                      boolean printMsg);


### PR DESCRIPTION
setErrorData symbol was missing. However, its been deprecated at the
netcomm level for years, and wasn't exposed in wpilibj. And it would
have been crashing since forever, so safe to remove.