### PR TITLE
Add deprecated shims for LiveWindowSendable and NamedSendable.

### DIFF
--- a/wpilibc/src/main/native/cpp/LiveWindow/LiveWindowSendable.cpp
+++ b/wpilibc/src/main/native/cpp/LiveWindow/LiveWindowSendable.cpp
@@ -1,0 +1,24 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "LiveWindow/LiveWindowSendable.h"
+
+#include "SmartDashboard/SendableBuilder.h"
+
+using namespace frc;
+
+std::string LiveWindowSendable::GetName() const { return std::string(); }
+
+void LiveWindowSendable::SetName(const llvm::Twine&) {}
+
+std::string LiveWindowSendable::GetSubsystem() const { return std::string(); }
+
+void LiveWindowSendable::SetSubsystem(const llvm::Twine&) {}
+
+void LiveWindowSendable::InitSendable(SendableBuilder& builder) {
+  builder.SetUpdateTable([=]() { UpdateTable(); });
+}

--- a/wpilibc/src/main/native/cpp/SmartDashboard/NamedSendable.cpp
+++ b/wpilibc/src/main/native/cpp/SmartDashboard/NamedSendable.cpp
@@ -1,0 +1,18 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "SmartDashboard/NamedSendable.h"
+
+using namespace frc;
+
+void NamedSendable::SetName(const llvm::Twine&) {}
+
+std::string NamedSendable::GetSubsystem() const { return std::string(); }
+
+void NamedSendable::SetSubsystem(const llvm::Twine&) {}
+
+void NamedSendable::InitSendable(SendableBuilder&) {}

--- a/wpilibc/src/main/native/include/LiveWindow/LiveWindowSendable.h
+++ b/wpilibc/src/main/native/include/LiveWindow/LiveWindowSendable.h
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2012-2017 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <string>
+
+#include <support/deprecated.h>
+
+#include "SmartDashboard/Sendable.h"
+
+namespace frc {
+
+/**
+ * Live Window Sendable is a special type of object sendable to the live window.
+ * @deprecated Use Sendable directly instead
+ */
+class WPI_DEPRECATED("use Sendable directly instead") LiveWindowSendable
+    : public Sendable {
+ public:
+  /**
+   * Update the table for this sendable object with the latest values.
+   */
+  virtual void UpdateTable() = 0;
+
+  /**
+   * Start having this sendable object automatically respond to value changes
+   * reflect the value on the table.
+   */
+  virtual void StartLiveWindowMode() = 0;
+
+  /**
+   * Stop having this sendable object automatically respond to value changes.
+   */
+  virtual void StopLiveWindowMode() = 0;
+
+  std::string GetName() const override;
+  void SetName(const llvm::Twine& name) override;
+  std::string GetSubsystem() const override;
+  void SetSubsystem(const llvm::Twine& subsystem) override;
+  void InitSendable(SendableBuilder& builder) override;
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/SmartDashboard/NamedSendable.h
+++ b/wpilibc/src/main/native/include/SmartDashboard/NamedSendable.h
@@ -1,0 +1,32 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2012-2017 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <string>
+
+#include <support/deprecated.h>
+
+#include "SmartDashboard/Sendable.h"
+
+namespace frc {
+
+/**
+ * The interface for sendable objects that gives the sendable a default name in
+ * the Smart Dashboard.
+ * @deprecated Use Sendable directly instead
+ */
+class WPI_DEPRECATED("use Sendable directly instead") NamedSendable
+    : public Sendable {
+ public:
+  void SetName(const llvm::Twine& name) override;
+  std::string GetSubsystem() const override;
+  void SetSubsystem(const llvm::Twine& subsystem) override;
+  void InitSendable(SendableBuilder& builder) override;
+};
+
+}  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/NamedSendable.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/NamedSendable.java
@@ -1,0 +1,43 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2016-2017 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj;
+
+import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+
+/**
+ * The interface for sendable objects that gives the sendable a default name in the Smart
+ * Dashboard.
+ * @deprecated Use Sendable directly instead
+ */
+@Deprecated
+public interface NamedSendable extends Sendable {
+
+  /**
+   * The name of the subtable.
+   *
+   * @return the name of the subtable of SmartDashboard that the Sendable object will use.
+   */
+  String getName();
+
+  @Override
+  default void setName(String name) {
+  }
+
+  @Override
+  default String getSubsystem() {
+    return "";
+  }
+
+  @Override
+  default void setSubsystem(String subsystem) {
+  }
+
+  @Override
+  default void initSendable(SendableBuilder builder) {
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindowSendable.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindowSendable.java
@@ -1,0 +1,57 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2008-2017 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.livewindow;
+
+import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+import edu.wpi.first.wpilibj.Sendable;
+
+/**
+ * Live Window Sendable is a special type of object sendable to the live window.
+ * @deprecated Use Sendable directly instead
+ */
+@Deprecated
+public interface LiveWindowSendable extends Sendable {
+  /**
+   * Update the table for this sendable object with the latest values.
+   */
+  void updateTable();
+
+  /**
+   * Start having this sendable object automatically respond to value changes reflect the value on
+   * the table.
+   */
+  void startLiveWindowMode();
+
+  /**
+   * Stop having this sendable object automatically respond to value changes.
+   */
+  void stopLiveWindowMode();
+
+  @Override
+  default String getName() {
+    return "";
+  }
+
+  @Override
+  default void setName(String name) {
+  }
+
+  @Override
+  default String getSubsystem() {
+    return "";
+  }
+
+  @Override
+  default void setSubsystem(String subsystem) {
+  }
+
+  @Override
+  default void initSendable(SendableBuilder builder) {
+    builder.setUpdateTable(this::updateTable);
+  }
+}


### PR DESCRIPTION
This will help prevent old code from breaking (not all cases, but should help).