### PR TITLE
Make setDefaultCommand public

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Subsystem.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Subsystem.java
@@ -90,7 +90,7 @@ public abstract class Subsystem extends SendableBase implements Sendable {
    * @param command the default command (or null if there should be none)
    * @throws IllegalUseOfCommandException if the command does not require the subsystem
    */
-  protected void setDefaultCommand(Command command) {
+  public void setDefaultCommand(Command command) {
     if (command == null) {
       m_defaultCommand = null;
     } else {


### PR DESCRIPTION
It's public in C++ so I'm assuming it should be in Java as well.