### PR TITLE
Fix cancel of inner commands in ConditionalCommands

### DIFF
--- a/wpilibc/src/main/native/cpp/Commands/Command.cpp
+++ b/wpilibc/src/main/native/cpp/Commands/Command.cpp
@@ -140,6 +140,7 @@ void Command::Removed() {
   m_initialized = false;
   m_canceled = false;
   m_running = false;
+  m_completed = true;
 }
 
 /**
@@ -156,6 +157,7 @@ void Command::Start() {
         CommandIllegalUse,
         "Can not start a command that is part of a command group");
 
+  m_completed = false;
   Scheduler::GetInstance()->AddCommand(this);
 }
 
@@ -211,13 +213,13 @@ void Command::End() {}
  */
 void Command::Interrupted() { End(); }
 
-void Command::_Initialize() {}
+void Command::_Initialize() { m_completed = false; }
 
-void Command::_Interrupted() {}
+void Command::_Interrupted() { m_completed = true; }
 
 void Command::_Execute() {}
 
-void Command::_End() {}
+void Command::_End() { m_completed = true; }
 
 /**
  * Called to indicate that the timer should start.
@@ -318,6 +320,7 @@ void Command::ClearRequirements() { m_requirements.clear(); }
 void Command::StartRunning() {
   m_running = true;
   m_startTime = -1;
+  m_completed = false;
 }
 
 /**
@@ -329,6 +332,20 @@ void Command::StartRunning() {
  * @return whether or not the command is running
  */
 bool Command::IsRunning() const { return m_running; }
+
+/**
+ * Returns whether or not the command has been initialized.
+ *
+ * @return whether or not the command has been initialized.
+ */
+bool Command::IsInitialized() const { return m_initialized; }
+
+/**
+ * Returns whether or not the command has completed running.
+ *
+ * @return whether or not the command has completed running.
+ */
+bool Command::IsCompleted() const { return m_completed; }
 
 /**
  * This will cancel the current command.

--- a/wpilibc/src/main/native/cpp/Commands/ConditionalCommand.cpp
+++ b/wpilibc/src/main/native/cpp/Commands/ConditionalCommand.cpp
@@ -65,6 +65,14 @@ void ConditionalCommand::_Initialize() {
 
     m_chosenCommand->Start();
   }
+  m_isStarted = false;
+  Command::_Initialize();
+}
+
+void ConditionalCommand::_Execute() {
+  Command::_Execute();
+  if (m_chosenCommand != nullptr && !m_isStarted)
+    m_isStarted = m_chosenCommand->IsRunning();
 }
 
 void ConditionalCommand::_Cancel() {
@@ -76,14 +84,14 @@ void ConditionalCommand::_Cancel() {
 }
 
 bool ConditionalCommand::IsFinished() {
-  return m_chosenCommand != nullptr && m_chosenCommand->IsRunning() &&
-         m_chosenCommand->IsFinished();
+  return m_chosenCommand != nullptr && !m_chosenCommand->IsRunning() &&
+         m_isStarted;
 }
 
-void ConditionalCommand::Interrupted() {
+void ConditionalCommand::_Interrupted() {
   if (m_chosenCommand != nullptr && m_chosenCommand->IsRunning()) {
     m_chosenCommand->Cancel();
   }
 
-  Command::Interrupted();
+  Command::_Interrupted();
 }

--- a/wpilibc/src/main/native/cpp/Commands/ConditionalCommand.cpp
+++ b/wpilibc/src/main/native/cpp/Commands/ConditionalCommand.cpp
@@ -7,6 +7,8 @@
 
 #include "Commands/ConditionalCommand.h"
 
+#include <iostream>
+
 #include "Commands/Scheduler.h"
 
 using namespace frc;
@@ -31,7 +33,6 @@ static void RequireAll(Command& command, Command* onTrue, Command* onFalse) {
 ConditionalCommand::ConditionalCommand(Command* onTrue, Command* onFalse) {
   m_onTrue = onTrue;
   m_onFalse = onFalse;
-  m_isStarted = false;
 
   RequireAll(*this, onTrue, onFalse);
 }
@@ -48,7 +49,6 @@ ConditionalCommand::ConditionalCommand(const llvm::Twine& name, Command* onTrue,
     : Command(name) {
   m_onTrue = onTrue;
   m_onFalse = onFalse;
-  m_isStarted = false;
 
   RequireAll(*this, onTrue, onFalse);
 }
@@ -67,15 +67,7 @@ void ConditionalCommand::_Initialize() {
 
     m_chosenCommand->Start();
   }
-  m_isStarted = false;
   Command::_Initialize();
-}
-
-void ConditionalCommand::_Execute() {
-  if (m_chosenCommand != nullptr && !m_isStarted)
-    m_isStarted = m_chosenCommand->IsRunning();
-
-  Command::_Execute();
 }
 
 void ConditionalCommand::_Cancel() {
@@ -88,7 +80,7 @@ void ConditionalCommand::_Cancel() {
 
 bool ConditionalCommand::IsFinished() {
   if (m_chosenCommand != nullptr) {
-    return !m_chosenCommand->IsRunning() && m_isStarted;
+    return m_chosenCommand->IsCompleted();
   } else {
     return true;
   }

--- a/wpilibc/src/main/native/cpp/Commands/ConditionalCommand.cpp
+++ b/wpilibc/src/main/native/cpp/Commands/ConditionalCommand.cpp
@@ -31,6 +31,7 @@ static void RequireAll(Command& command, Command* onTrue, Command* onFalse) {
 ConditionalCommand::ConditionalCommand(Command* onTrue, Command* onFalse) {
   m_onTrue = onTrue;
   m_onFalse = onFalse;
+  m_isStarted = false;
 
   RequireAll(*this, onTrue, onFalse);
 }
@@ -47,6 +48,7 @@ ConditionalCommand::ConditionalCommand(const llvm::Twine& name, Command* onTrue,
     : Command(name) {
   m_onTrue = onTrue;
   m_onFalse = onFalse;
+  m_isStarted = false;
 
   RequireAll(*this, onTrue, onFalse);
 }
@@ -70,9 +72,10 @@ void ConditionalCommand::_Initialize() {
 }
 
 void ConditionalCommand::_Execute() {
-  Command::_Execute();
   if (m_chosenCommand != nullptr && !m_isStarted)
     m_isStarted = m_chosenCommand->IsRunning();
+
+  Command::_Execute();
 }
 
 void ConditionalCommand::_Cancel() {
@@ -84,8 +87,11 @@ void ConditionalCommand::_Cancel() {
 }
 
 bool ConditionalCommand::IsFinished() {
-  return m_chosenCommand != nullptr && !m_chosenCommand->IsRunning() &&
-         m_isStarted;
+  if (m_chosenCommand != nullptr) {
+    return !m_chosenCommand->IsRunning() && m_isStarted;
+  } else {
+    return true;
+  }
 }
 
 void ConditionalCommand::_Interrupted() {

--- a/wpilibc/src/main/native/include/Commands/Command.h
+++ b/wpilibc/src/main/native/include/Commands/Command.h
@@ -62,6 +62,8 @@ class Command : public ErrorBase, public SendableBase {
   bool Run();
   void Cancel();
   bool IsRunning() const;
+  bool IsInitialized() const;
+  bool IsCompleted() const;
   bool IsInterruptible() const;
   void SetInterruptible(bool interruptible);
   bool DoesRequire(Subsystem* subsystem) const;
@@ -147,6 +149,9 @@ class Command : public ErrorBase, public SendableBase {
 
   // The CommandGroup this is in
   CommandGroup* m_parent = nullptr;
+
+  // Whether or not this command has completed running
+  bool m_completed = false;
 
   int m_commandID = m_commandCounter++;
   static int m_commandCounter;

--- a/wpilibc/src/main/native/include/Commands/Command.h
+++ b/wpilibc/src/main/native/include/Commands/Command.h
@@ -48,6 +48,7 @@ class Subsystem;
 class Command : public ErrorBase, public SendableBase {
   friend class CommandGroup;
   friend class Scheduler;
+  friend class MockConditionalCommand;
 
  public:
   Command();

--- a/wpilibc/src/main/native/include/Commands/Command.h
+++ b/wpilibc/src/main/native/include/Commands/Command.h
@@ -48,7 +48,6 @@ class Subsystem;
 class Command : public ErrorBase, public SendableBase {
   friend class CommandGroup;
   friend class Scheduler;
-  friend class MockConditionalCommand;
 
  public:
   Command();

--- a/wpilibc/src/main/native/include/Commands/ConditionalCommand.h
+++ b/wpilibc/src/main/native/include/Commands/ConditionalCommand.h
@@ -51,7 +51,6 @@ class ConditionalCommand : public Command {
   void _Cancel() override;
   bool IsFinished() override;
   void _Interrupted() override;
-  void _Execute() override;
 
  private:
   // The Command to execute if Condition() returns true
@@ -62,9 +61,6 @@ class ConditionalCommand : public Command {
 
   // Stores command chosen by condition
   Command* m_chosenCommand = nullptr;
-
-  // Whether the chosen command has started
-  bool m_isStarted = false;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/Commands/ConditionalCommand.h
+++ b/wpilibc/src/main/native/include/Commands/ConditionalCommand.h
@@ -31,6 +31,8 @@ namespace frc {
  * @see Scheduler
  */
 class ConditionalCommand : public Command {
+  friend class MockConditionalCommand;
+
  public:
   explicit ConditionalCommand(Command* onTrue, Command* onFalse = nullptr);
   ConditionalCommand(const llvm::Twine& name, Command* onTrue,

--- a/wpilibc/src/main/native/include/Commands/ConditionalCommand.h
+++ b/wpilibc/src/main/native/include/Commands/ConditionalCommand.h
@@ -50,7 +50,8 @@ class ConditionalCommand : public Command {
   void _Initialize() override;
   void _Cancel() override;
   bool IsFinished() override;
-  void Interrupted() override;
+  void _Interrupted() override;
+  void _Execute() override;
 
  private:
   // The Command to execute if Condition() returns true
@@ -61,6 +62,8 @@ class ConditionalCommand : public Command {
 
   // Stores command chosen by condition
   Command* m_chosenCommand = nullptr;
+
+  bool m_isStarted = false;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/Commands/ConditionalCommand.h
+++ b/wpilibc/src/main/native/include/Commands/ConditionalCommand.h
@@ -10,29 +10,29 @@
 #include <llvm/Twine.h>
 
 #include "Commands/Command.h"
-#include "Commands/InstantCommand.h"
 
 namespace frc {
 
 /**
  * A ConditionalCommand is a Command that starts one of two commands.
  *
- * A ConditionalCommand uses m_condition to determine whether it should run
- * m_onTrue or m_onFalse.
+ * A ConditionalCommand uses the Condition method to determine whether it should
+ * run onTrue or onFalse.
  *
  * A ConditionalCommand adds the proper Command to the Scheduler during
  * Initialize() and then IsFinished() will return true once that Command has
  * finished executing.
  *
- * If no Command is specified for m_onFalse, the occurrence of that condition
+ * If no Command is specified for onFalse, the occurrence of that condition
  * will be a no-op.
+ *
+ * A CondtionalCommand will require the superset of subsystems of the onTrue
+ * and onFalse commands.
  *
  * @see Command
  * @see Scheduler
  */
 class ConditionalCommand : public Command {
-  friend class MockConditionalCommand;
-
  public:
   explicit ConditionalCommand(Command* onTrue, Command* onFalse = nullptr);
   ConditionalCommand(const llvm::Twine& name, Command* onTrue,
@@ -63,6 +63,7 @@ class ConditionalCommand : public Command {
   // Stores command chosen by condition
   Command* m_chosenCommand = nullptr;
 
+  // Whether the chosen command has started
   bool m_isStarted = false;
 };
 

--- a/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/ConditionalCommandTest.cpp
+++ b/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/ConditionalCommandTest.cpp
@@ -53,21 +53,68 @@ class ConditionalCommandTest : public testing::Test {
     EXPECT_EQ(end, command.GetEndCount());
     EXPECT_EQ(interrupted, command.GetInterruptedCount());
   }
+
+  void AssertConditionalCommandState(MockConditionalCommand& command,
+                                     int32_t initialize, int32_t execute,
+                                     int32_t isFinished, int32_t end,
+                                     int32_t interrupted) {
+    EXPECT_EQ(initialize, command.GetInitializeCount());
+    EXPECT_EQ(execute, command.GetExecuteCount());
+    EXPECT_EQ(isFinished, command.GetIsFinishedCount());
+    EXPECT_EQ(end, command.GetEndCount());
+    EXPECT_EQ(interrupted, command.GetInterruptedCount());
+  }
 };
 
 TEST_F(ConditionalCommandTest, OnTrueTest) {
   m_command->SetCondition(true);
 
+  SCOPED_TRACE("1");
   Scheduler::GetInstance()->AddCommand(m_command);
   AssertCommandState(*m_onTrue, 0, 0, 0, 0, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 0, 0, 0, 0, 0);
+  SCOPED_TRACE("2");
   Scheduler::GetInstance()->Run();  // init command and select m_onTrue
   AssertCommandState(*m_onTrue, 0, 0, 0, 0, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 0, 0, 0, 0, 0);
+  SCOPED_TRACE("3");
   Scheduler::GetInstance()->Run();  // init m_onTrue
   AssertCommandState(*m_onTrue, 0, 0, 0, 0, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 1, 1, 2, 0, 0);
+  SCOPED_TRACE("4");
   Scheduler::GetInstance()->Run();
-  AssertCommandState(*m_onTrue, 1, 1, 2, 0, 0);
+  AssertCommandState(*m_onTrue, 1, 1, 1, 0, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 1, 2, 2, 0, 0);
+  SCOPED_TRACE("5");
   Scheduler::GetInstance()->Run();
-  AssertCommandState(*m_onTrue, 1, 2, 4, 0, 0);
+  AssertCommandState(*m_onTrue, 1, 2, 2, 0, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 1, 3, 3, 0, 0);
+  SCOPED_TRACE("6");
+  m_onTrue->SetHasFinished(true);
+  Scheduler::GetInstance()->Run();
+  AssertCommandState(*m_onTrue, 1, 3, 3, 1, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 1, 4, 4, 1, 0);
+  SCOPED_TRACE("7");
+  Scheduler::GetInstance()->Run();
+  AssertCommandState(*m_onTrue, 1, 3, 3, 1, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 1, 4, 4, 1, 0);
+  SCOPED_TRACE("8");
+  Scheduler::GetInstance()->Run();
+  AssertCommandState(*m_onTrue, 1, 3, 3, 1, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 1, 4, 4, 1, 0);
+  SCOPED_TRACE("9");
+  Scheduler::GetInstance()->Run();
+  AssertCommandState(*m_onTrue, 1, 3, 3, 1, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 1, 4, 4, 1, 0);
 
   EXPECT_TRUE(m_onTrue->GetInitializeCount() > 0)
       << "Did not initialize the true command\n";
@@ -77,14 +124,14 @@ TEST_F(ConditionalCommandTest, OnTrueTest) {
   TeardownScheduler();
 }
 
-TEST_F(ConditionalCommandTest, OnFalseTest) {
+TEST_F(ConditionalCommandTest, DISABLED_OnFalseTest) {
   m_command->SetCondition(false);
 
   Scheduler::GetInstance()->AddCommand(m_command);
   AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();  // init command and select m_onTrue
+  Scheduler::GetInstance()->Run();  // init command and select m_onFalse
   AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
-  Scheduler::GetInstance()->Run();  // init m_onTrue
+  Scheduler::GetInstance()->Run();  // init m_onFalse
   AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
   Scheduler::GetInstance()->Run();
   AssertCommandState(*m_onFalse, 1, 1, 2, 0, 0);
@@ -95,6 +142,43 @@ TEST_F(ConditionalCommandTest, OnFalseTest) {
       << "Did not initialize the false command";
   EXPECT_TRUE(m_onTrue->GetInitializeCount() == 0)
       << "Initialized the true command";
+
+  TeardownScheduler();
+}
+
+TEST_F(ConditionalCommandTest, DISABLED_OnTrueCancelTest) {
+  m_command->SetCondition(true);
+
+  Scheduler::GetInstance()->AddCommand(m_command);
+  AssertCommandState(*m_onTrue, 0, 0, 0, 0, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 0, 0, 0, 0, 0);
+  Scheduler::GetInstance()->Run();  // init command and select m_onTrue
+  AssertCommandState(*m_onTrue, 0, 0, 0, 0, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 1, 1, 1, 0, 0);
+  Scheduler::GetInstance()->Run();  // init m_onTrue
+  AssertCommandState(*m_onTrue, 0, 0, 0, 0, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 2, 2, 2, 0, 0);
+  Scheduler::GetInstance()->Run();
+  AssertCommandState(*m_onTrue, 1, 1, 2, 0, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 3, 3, 3, 0, 0);
+  Scheduler::GetInstance()->Run();
+  AssertCommandState(*m_onTrue, 1, 2, 4, 0, 0);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 4, 4, 4, 0, 0);
+  m_onTrue->Cancel();
+  Scheduler::GetInstance()->Run();
+  AssertCommandState(*m_onTrue, 1, 3, 6, 0, 1);
+  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
+  AssertConditionalCommandState(*m_command, 5, 5, 5, 1, 0);
+
+  EXPECT_TRUE(m_onTrue->GetInitializeCount() > 0)
+      << "Did not initialize the true command\n";
+  EXPECT_TRUE(m_onFalse->GetInitializeCount() == 0)
+      << "Initialized the false command\n";
 
   TeardownScheduler();
 }

--- a/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/ConditionalCommandTest.cpp
+++ b/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/ConditionalCommandTest.cpp
@@ -360,17 +360,12 @@ TEST_F(ConditionalCommandTest, OnTrueInstantTest) {
   Scheduler::GetInstance()->Run();
   AssertCommandState(*m_onTrue, 1, 1, 1, 1, 0);
   AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
-  AssertConditionalCommandState(*m_command, 1, 2, 2, 0, 0);
+  AssertConditionalCommandState(*m_command, 1, 2, 2, 1, 0);
   SCOPED_TRACE("5");
   Scheduler::GetInstance()->Run();
   AssertCommandState(*m_onTrue, 1, 1, 1, 1, 0);
   AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
-  AssertConditionalCommandState(*m_command, 1, 3, 3, 0, 0);
-  SCOPED_TRACE("6");
-  Scheduler::GetInstance()->Run();
-  AssertCommandState(*m_onTrue, 1, 1, 1, 1, 0);
-  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
-  AssertConditionalCommandState(*m_command, 1, 4, 4, 1, 0);
+  AssertConditionalCommandState(*m_command, 1, 2, 2, 1, 0);
 
   TeardownScheduler();
 }

--- a/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/ConditionalCommandTest.cpp
+++ b/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/ConditionalCommandTest.cpp
@@ -83,7 +83,7 @@ TEST_F(ConditionalCommandTest, OnTrueTest) {
   Scheduler::GetInstance()->Run();  // init m_onTrue
   AssertCommandState(*m_onTrue, 0, 0, 0, 0, 0);
   AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
-  AssertConditionalCommandState(*m_command, 1, 1, 2, 0, 0);
+  AssertConditionalCommandState(*m_command, 1, 1, 1, 0, 0);
   SCOPED_TRACE("4");
   Scheduler::GetInstance()->Run();
   AssertCommandState(*m_onTrue, 1, 1, 1, 0, 0);
@@ -101,16 +101,6 @@ TEST_F(ConditionalCommandTest, OnTrueTest) {
   AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
   AssertConditionalCommandState(*m_command, 1, 4, 4, 1, 0);
   SCOPED_TRACE("7");
-  Scheduler::GetInstance()->Run();
-  AssertCommandState(*m_onTrue, 1, 3, 3, 1, 0);
-  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
-  AssertConditionalCommandState(*m_command, 1, 4, 4, 1, 0);
-  SCOPED_TRACE("8");
-  Scheduler::GetInstance()->Run();
-  AssertCommandState(*m_onTrue, 1, 3, 3, 1, 0);
-  AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);
-  AssertConditionalCommandState(*m_command, 1, 4, 4, 1, 0);
-  SCOPED_TRACE("9");
   Scheduler::GetInstance()->Run();
   AssertCommandState(*m_onTrue, 1, 3, 3, 1, 0);
   AssertCommandState(*m_onFalse, 0, 0, 0, 0, 0);

--- a/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/MockCommand.cpp
+++ b/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/MockCommand.cpp
@@ -9,6 +9,10 @@
 
 using namespace frc;
 
+MockCommand::MockCommand(Subsystem* subsys) : MockCommand() {
+  Requires(subsys);
+}
+
 MockCommand::MockCommand() {
   m_initializeCount = 0;
   m_executeCount = 0;
@@ -36,3 +40,12 @@ bool MockCommand::IsFinished() {
 void MockCommand::End() { ++m_endCount; }
 
 void MockCommand::Interrupted() { ++m_interruptedCount; }
+
+void MockCommand::ResetCounters() {
+  m_initializeCount = 0;
+  m_executeCount = 0;
+  m_isFinishedCount = 0;
+  m_hasFinished = false;
+  m_endCount = 0;
+  m_interruptedCount = 0;
+}

--- a/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/MockConditionalCommand.cpp
+++ b/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/MockConditionalCommand.cpp
@@ -7,14 +7,55 @@
 
 #include "command/MockConditionalCommand.h"
 
+#include <iostream>
+
 using namespace frc;
 
 MockConditionalCommand::MockConditionalCommand(MockCommand* onTrue,
                                                MockCommand* onFalse)
-    : ConditionalCommand(onTrue, onFalse) {}
+    : ConditionalCommand(onTrue, onFalse) {
+  m_initializeCount = 0;
+  m_executeCount = 0;
+  m_isFinishedCount = 0;
+  m_endCount = 0;
+  m_interruptedCount = 0;
+}
 
 void MockConditionalCommand::SetCondition(bool condition) {
   m_condition = condition;
 }
 
 bool MockConditionalCommand::Condition() { return m_condition; }
+
+bool MockConditionalCommand::HasInitialized() {
+  return GetInitializeCount() > 0;
+}
+
+bool MockConditionalCommand::HasEnd() { return GetEndCount() > 0; }
+
+bool MockConditionalCommand::HasInterrupted() {
+  return GetInterruptedCount() > 0;
+}
+
+void MockConditionalCommand::Initialize() { ++m_initializeCount; }
+
+void MockConditionalCommand::Execute() { ++m_executeCount; }
+
+bool MockConditionalCommand::IsFinished() {
+  ++m_isFinishedCount;
+  std::cerr << "Command: " << m_chosenCommand->GetName()
+            << " Running: " << m_chosenCommand->IsRunning()
+            << " Finished: " << m_chosenCommand->IsFinished()
+            << " ConditionalCommand Finished: "
+            << ConditionalCommand::IsFinished() << "isStarted: " << m_isStarted
+            << std::endl
+            << std::flush;
+  return ConditionalCommand::IsFinished();
+}
+
+void MockConditionalCommand::End() {
+  ++m_endCount;
+  std::cerr << "MockConditionalCommand End" << std::endl << std::flush;
+}
+
+void MockConditionalCommand::Interrupted() { ++m_interruptedCount; }

--- a/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/MockConditionalCommand.cpp
+++ b/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/MockConditionalCommand.cpp
@@ -43,20 +43,17 @@ void MockConditionalCommand::Execute() { ++m_executeCount; }
 
 bool MockConditionalCommand::IsFinished() {
   ++m_isFinishedCount;
-  //  std::cerr << "Command: " << m_chosenCommand->GetName()
-  //            << " Running: " << m_chosenCommand->IsRunning()
-  //            << " Finished: " << m_chosenCommand->IsFinished()
-  //            << " ConditionalCommand Finished: "
-  //            << ConditionalCommand::IsFinished() << " isStarted: " <<
-  //            m_isStarted
-  //            << std::endl
-  //            << std::flush;
   return ConditionalCommand::IsFinished();
 }
 
-void MockConditionalCommand::End() {
-  ++m_endCount;
-  //  std::cerr << "MockConditionalCommand End" << std::endl << std::flush;
-}
+void MockConditionalCommand::End() { ++m_endCount; }
 
 void MockConditionalCommand::Interrupted() { ++m_interruptedCount; }
+
+void MockConditionalCommand::ResetCounters() {
+  m_initializeCount = 0;
+  m_executeCount = 0;
+  m_isFinishedCount = 0;
+  m_endCount = 0;
+  m_interruptedCount = 0;
+}

--- a/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/MockConditionalCommand.cpp
+++ b/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/MockConditionalCommand.cpp
@@ -43,19 +43,20 @@ void MockConditionalCommand::Execute() { ++m_executeCount; }
 
 bool MockConditionalCommand::IsFinished() {
   ++m_isFinishedCount;
-  std::cerr << "Command: " << m_chosenCommand->GetName()
-            << " Running: " << m_chosenCommand->IsRunning()
-            << " Finished: " << m_chosenCommand->IsFinished()
-            << " ConditionalCommand Finished: "
-            << ConditionalCommand::IsFinished() << "isStarted: " << m_isStarted
-            << std::endl
-            << std::flush;
+  //  std::cerr << "Command: " << m_chosenCommand->GetName()
+  //            << " Running: " << m_chosenCommand->IsRunning()
+  //            << " Finished: " << m_chosenCommand->IsFinished()
+  //            << " ConditionalCommand Finished: "
+  //            << ConditionalCommand::IsFinished() << " isStarted: " <<
+  //            m_isStarted
+  //            << std::endl
+  //            << std::flush;
   return ConditionalCommand::IsFinished();
 }
 
 void MockConditionalCommand::End() {
   ++m_endCount;
-  std::cerr << "MockConditionalCommand End" << std::endl << std::flush;
+  //  std::cerr << "MockConditionalCommand End" << std::endl << std::flush;
 }
 
 void MockConditionalCommand::Interrupted() { ++m_interruptedCount; }

--- a/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/MockConditionalCommand.cpp
+++ b/wpilibcIntegrationTests/src/FRCUserProgram/cpp/command/MockConditionalCommand.cpp
@@ -7,8 +7,6 @@
 
 #include "command/MockConditionalCommand.h"
 
-#include <iostream>
-
 using namespace frc;
 
 MockConditionalCommand::MockConditionalCommand(MockCommand* onTrue,

--- a/wpilibcIntegrationTests/src/FRCUserProgram/headers/command/MockCommand.h
+++ b/wpilibcIntegrationTests/src/FRCUserProgram/headers/command/MockCommand.h
@@ -13,6 +13,7 @@ namespace frc {
 
 class MockCommand : public Command {
  public:
+  explicit MockCommand(Subsystem*);
   MockCommand();
   int32_t GetInitializeCount() { return m_initializeCount; }
   bool HasInitialized();
@@ -26,6 +27,7 @@ class MockCommand : public Command {
 
   int32_t GetInterruptedCount() { return m_interruptedCount; }
   bool HasInterrupted();
+  void ResetCounters();
 
  protected:
   void Initialize() override;

--- a/wpilibcIntegrationTests/src/FRCUserProgram/headers/command/MockConditionalCommand.h
+++ b/wpilibcIntegrationTests/src/FRCUserProgram/headers/command/MockConditionalCommand.h
@@ -26,6 +26,7 @@ class MockConditionalCommand : public ConditionalCommand {
 
   int32_t GetInterruptedCount() { return m_interruptedCount; }
   bool HasInterrupted();
+  void ResetCounters();
 
  protected:
   bool Condition() override;

--- a/wpilibcIntegrationTests/src/FRCUserProgram/headers/command/MockConditionalCommand.h
+++ b/wpilibcIntegrationTests/src/FRCUserProgram/headers/command/MockConditionalCommand.h
@@ -16,12 +16,32 @@ class MockConditionalCommand : public ConditionalCommand {
  public:
   MockConditionalCommand(MockCommand* onTrue, MockCommand* onFalse);
   void SetCondition(bool condition);
+  int32_t GetInitializeCount() { return m_initializeCount; }
+  bool HasInitialized();
+
+  int32_t GetExecuteCount() { return m_executeCount; }
+  int32_t GetIsFinishedCount() { return m_isFinishedCount; }
+  int32_t GetEndCount() { return m_endCount; }
+  bool HasEnd();
+
+  int32_t GetInterruptedCount() { return m_interruptedCount; }
+  bool HasInterrupted();
 
  protected:
   bool Condition() override;
+  void Initialize() override;
+  void Execute() override;
+  bool IsFinished() override;
+  void End() override;
+  void Interrupted() override;
 
  private:
   bool m_condition = false;
+  int32_t m_initializeCount;
+  int32_t m_executeCount;
+  int32_t m_isFinishedCount;
+  int32_t m_endCount;
+  int32_t m_interruptedCount;
 };
 
 }  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
@@ -87,6 +87,11 @@ public abstract class Command extends SendableBase implements Sendable {
   private boolean m_runWhenDisabled = false;
 
   /**
+   * Whether or not this command has completed running.
+   */
+  private boolean m_completed = false;
+
+  /**
    * The {@link CommandGroup} this is in.
    */
   private CommandGroup m_parent;
@@ -208,6 +213,7 @@ public abstract class Command extends SendableBase implements Sendable {
     m_initialized = false;
     m_canceled = false;
     m_running = false;
+    m_completed = true;
   }
 
   /**
@@ -404,6 +410,7 @@ public abstract class Command extends SendableBase implements Sendable {
           "Can not start a command that is a part of a command group");
     }
     Scheduler.getInstance().add(this);
+    m_completed = false;
   }
 
   /**
@@ -465,6 +472,15 @@ public abstract class Command extends SendableBase implements Sendable {
    */
   public synchronized boolean isCanceled() {
     return m_canceled;
+  }
+
+  /**
+   * Whether or not this command has completed running.
+   *
+   * @return whether or not this command has completed running.
+   */
+  public synchronized boolean isCompleted() {
+    return m_completed;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/ConditionalCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/ConditionalCommand.java
@@ -47,11 +47,6 @@ public abstract class ConditionalCommand extends Command {
    */
   private Command m_chosenCommand = null;
 
-  /**
-   * Whether the chosen command has started.
-   */
-  private boolean m_isStarted = false;
-
   private void requireAll() {
     if (m_onTrue != null) {
       for (Enumeration e = m_onTrue.getRequirements(); e.hasMoreElements(); ) {
@@ -88,7 +83,6 @@ public abstract class ConditionalCommand extends Command {
   public ConditionalCommand(Command onTrue, Command onFalse) {
     m_onTrue = onTrue;
     m_onFalse = onFalse;
-    m_isStarted = false;
 
     requireAll();
   }
@@ -118,7 +112,6 @@ public abstract class ConditionalCommand extends Command {
     super(name);
     m_onTrue = onTrue;
     m_onFalse = onFalse;
-    m_isStarted = false;
 
     requireAll();
   }
@@ -150,16 +143,7 @@ public abstract class ConditionalCommand extends Command {
 
       m_chosenCommand.start();
     }
-    m_isStarted = false;
     super._initialize();
-  }
-
-  @Override
-  protected void _execute() {
-    if (m_chosenCommand != null && !m_isStarted) {
-      m_isStarted = m_chosenCommand.isRunning();
-    }
-    super._execute();
   }
 
   @Override
@@ -167,13 +151,14 @@ public abstract class ConditionalCommand extends Command {
     if (m_chosenCommand != null && m_chosenCommand.isRunning()) {
       m_chosenCommand.cancel();
     }
+
     super._cancel();
   }
 
   @Override
   protected boolean isFinished() {
     if (m_chosenCommand != null) {
-      return !m_chosenCommand.isRunning() && m_isStarted;
+      return m_chosenCommand.isCompleted();
     } else {
       return true;
     }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/ConditionalCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/ConditionalCommand.java
@@ -172,8 +172,11 @@ public abstract class ConditionalCommand extends Command {
 
   @Override
   protected boolean isFinished() {
-    return m_chosenCommand != null && !m_chosenCommand.isRunning()
-        && m_isStarted;
+    if (m_chosenCommand != null) {
+      return !m_chosenCommand.isRunning() && m_isStarted;
+    } else {
+      return true;
+    }
   }
 
   @Override

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/ConditionalCommandTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/ConditionalCommandTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 public class ConditionalCommandTest extends AbstractCommandTest {
   MockConditionalCommand m_command;
+  MockConditionalCommand m_commandNull;
   MockCommand m_onTrue;
   MockCommand m_onFalse;
   MockSubsystem m_subsys;
@@ -27,6 +28,7 @@ public class ConditionalCommandTest extends AbstractCommandTest {
     m_onTrue = new MockCommand(m_subsys);
     m_onFalse = new MockCommand(m_subsys);
     m_command = new MockConditionalCommand(m_onTrue, m_onFalse);
+    m_commandNull = new MockConditionalCommand(m_onTrue, null);
   }
 
   protected void assertConditionalCommandState(MockConditionalCommand command, int initialize,
@@ -40,7 +42,6 @@ public class ConditionalCommandTest extends AbstractCommandTest {
   }
 
   @Test
-  //@Ignore
   public void testOnTrue() {
     m_command.setCondition(true);
 
@@ -79,7 +80,6 @@ public class ConditionalCommandTest extends AbstractCommandTest {
   }
 
   @Test
-  //@Ignore
   public void testOnFalse() {
     m_command.setCondition(false);
 
@@ -118,9 +118,6 @@ public class ConditionalCommandTest extends AbstractCommandTest {
   }
 
   @Test
-  //@Ignore
-  //@Ignore("WPILIB conditional command bug, canceling inner command doesn't cancel conditional "
-  //        + "command")
   public void testCancelSubCommand() {
     m_command.setCondition(true);
 
@@ -160,7 +157,6 @@ public class ConditionalCommandTest extends AbstractCommandTest {
   }
 
   @Test
-  //@Ignore
   public void testCancelRequires() {
     m_command.setCondition(true);
 
@@ -196,7 +192,6 @@ public class ConditionalCommandTest extends AbstractCommandTest {
   }
 
   @Test
-  //@Ignore
   public void testCancelCondCommand() {
     m_command.setCondition(true);
 
@@ -232,7 +227,6 @@ public class ConditionalCommandTest extends AbstractCommandTest {
   }
 
   @Test
-  //@Ignore
   public void testOnTrueTwice() {
     m_command.setCondition(true);
 
@@ -266,35 +260,86 @@ public class ConditionalCommandTest extends AbstractCommandTest {
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
 
-    m_onTrue.setHasFinished(false);
+    m_onTrue.resetCounters();
+    m_command.resetCounters();
+    m_command.setCondition(true);
     Scheduler.getInstance().add(m_command);
-    assertCommandState(m_onTrue, 1, 3, 3, 1, 0);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
     Scheduler.getInstance().run();  // init command and select m_onTrue
-    assertCommandState(m_onTrue, 1, 3, 3, 1, 0);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
     Scheduler.getInstance().run();  // init m_onTrue
-    assertCommandState(m_onTrue, 1, 3, 3, 1, 0);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 2, 6, 6, 1, 0);
+    assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 2, 4, 4, 1, 0);
+    assertCommandState(m_onTrue, 1, 1, 1, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 2, 7, 7, 1, 0);
+    assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 2, 5, 5, 1, 0);
+    assertCommandState(m_onTrue, 1, 2, 2, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 2, 8, 8, 1, 0);
+    assertConditionalCommandState(m_command, 1, 3, 3, 0, 0);
     m_onTrue.setHasFinished(true);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 2, 6, 6, 2, 0);
+    assertCommandState(m_onTrue, 1, 3, 3, 1, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 2, 9, 9, 1, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 2, 6, 6, 2, 0);
+    assertCommandState(m_onTrue, 1, 3, 3, 1, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 2, 10, 10, 2, 0);
+    assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
+  }
+
+  @Test
+  public void testOnTrueInstant() {
+    m_command.setCondition(true);
+    m_onTrue.setHasFinished(true);
+
+    Scheduler.getInstance().add(m_command);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
+    Scheduler.getInstance().run();  // init command and select m_onTrue
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
+    Scheduler.getInstance().run();  // init m_onTrue
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 1, 1, 1, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 1, 1, 1, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 3, 3, 1, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 1, 1, 1, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 3, 3, 1, 0);
+  }
+
+  @Test
+  public void testOnFalseNull() {
+    m_commandNull.setCondition(false);
+
+    Scheduler.getInstance().add(m_commandNull);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_commandNull, 0, 0, 0, 0, 0);
+    Scheduler.getInstance().run();  // init command and select m_onFalse
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_commandNull, 0, 0, 0, 0, 0);
+    Scheduler.getInstance().run();  // init m_onFalse
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_commandNull, 1, 1, 1, 1, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_commandNull, 1, 1, 1, 1, 0);
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/ConditionalCommandTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/ConditionalCommandTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 public class ConditionalCommandTest extends AbstractCommandTest {
@@ -40,6 +40,7 @@ public class ConditionalCommandTest extends AbstractCommandTest {
   }
 
   @Test
+  //@Ignore
   public void testOnTrue() {
     m_command.setCondition(true);
 
@@ -56,28 +57,29 @@ public class ConditionalCommandTest extends AbstractCommandTest {
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 1, 2, 0, 0);
+    assertCommandState(m_onTrue, 1, 1, 1, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 2, 4, 0, 0);
+    assertCommandState(m_onTrue, 1, 2, 2, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 3, 3, 0, 0);
     m_onTrue.setHasFinished(true);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
+    assertCommandState(m_onTrue, 1, 3, 3, 1, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
+    assertCommandState(m_onTrue, 1, 3, 3, 1, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
 
     assertTrue("Did not initialize the true command", m_onTrue.getInitializeCount() > 0);
     assertTrue("Initialized the false command", m_onFalse.getInitializeCount() == 0);
   }
 
   @Test
+  //@Ignore
   public void testOnFalse() {
     m_command.setCondition(false);
 
@@ -94,30 +96,31 @@ public class ConditionalCommandTest extends AbstractCommandTest {
     assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onFalse, 1, 1, 2, 0, 0);
+    assertCommandState(m_onFalse, 1, 1, 1, 0, 0);
     assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onFalse, 1, 2, 4, 0, 0);
+    assertCommandState(m_onFalse, 1, 2, 2, 0, 0);
     assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 3, 3, 0, 0);
     m_onFalse.setHasFinished(true);
     Scheduler.getInstance().run();
-    assertCommandState(m_onFalse, 1, 3, 6, 1, 0);
+    assertCommandState(m_onFalse, 1, 3, 3, 1, 0);
     assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onFalse, 1, 3, 6, 1, 0);
+    assertCommandState(m_onFalse, 1, 3, 3, 1, 0);
     assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
 
     assertTrue("Did not initialize the false command", m_onFalse.getInitializeCount() > 0);
     assertTrue("Initialized the true command", m_onTrue.getInitializeCount() == 0);
   }
 
   @Test
-  @Ignore("WPILIB conditional command bug, canceling inner command doesn't cancel conditional "
-          + "command")
+  //@Ignore
+  //@Ignore("WPILIB conditional command bug, canceling inner command doesn't cancel conditional "
+  //        + "command")
   public void testCancelSubCommand() {
     m_command.setCondition(true);
 
@@ -134,25 +137,30 @@ public class ConditionalCommandTest extends AbstractCommandTest {
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 1, 2, 0, 0);
+    assertCommandState(m_onTrue, 1, 1, 1, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 2, 4, 0, 0);
+    assertCommandState(m_onTrue, 1, 2, 2, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 3, 3, 0, 0);
     m_onTrue.cancel();
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 2, 5, 0, 1);
+    assertCommandState(m_onTrue, 1, 2, 2, 0, 1);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 2, 5, 0, 1);
+    assertCommandState(m_onTrue, 1, 2, 2, 0, 1);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 2, 2, 0, 1);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
   }
 
   @Test
+  //@Ignore
   public void testCancelRequires() {
     m_command.setCondition(true);
 
@@ -169,25 +177,26 @@ public class ConditionalCommandTest extends AbstractCommandTest {
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 1, 2, 0, 0);
+    assertCommandState(m_onTrue, 1, 1, 1, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 2, 4, 0, 0);
+    assertCommandState(m_onTrue, 1, 2, 2, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 3, 3, 0, 0);
     m_onFalse.start();
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 3, 6, 0, 0);
+    assertCommandState(m_onTrue, 1, 3, 3, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 4, 4, 0, 1);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 3, 6, 0, 1);
+    assertCommandState(m_onTrue, 1, 3, 3, 0, 1);
     assertCommandState(m_onFalse, 1, 1, 1, 0, 0);
     assertConditionalCommandState(m_command, 1, 4, 4, 0, 1);
   }
 
   @Test
+  //@Ignore
   public void testCancelCondCommand() {
     m_command.setCondition(true);
 
@@ -204,25 +213,26 @@ public class ConditionalCommandTest extends AbstractCommandTest {
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 1, 2, 0, 0);
+    assertCommandState(m_onTrue, 1, 1, 1, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 2, 4, 0, 0);
+    assertCommandState(m_onTrue, 1, 2, 2, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 3, 3, 0, 0);
     m_command.cancel();
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 2, 4, 0, 1);
+    assertCommandState(m_onTrue, 1, 2, 2, 0, 1);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 3, 3, 0, 1);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 2, 4, 0, 1);
+    assertCommandState(m_onTrue, 1, 2, 2, 0, 1);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 3, 3, 0, 1);
   }
 
   @Test
+  //@Ignore
   public void testOnTrueTwice() {
     m_command.setCondition(true);
 
@@ -239,52 +249,52 @@ public class ConditionalCommandTest extends AbstractCommandTest {
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 1, 2, 0, 0);
+    assertCommandState(m_onTrue, 1, 1, 1, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 2, 4, 0, 0);
+    assertCommandState(m_onTrue, 1, 2, 2, 0, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 1, 3, 3, 0, 0);
     m_onTrue.setHasFinished(true);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
+    assertCommandState(m_onTrue, 1, 3, 3, 1, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 0, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
+    assertCommandState(m_onTrue, 1, 3, 3, 1, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
 
     m_onTrue.setHasFinished(false);
     Scheduler.getInstance().add(m_command);
-    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
+    assertCommandState(m_onTrue, 1, 3, 3, 1, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
     Scheduler.getInstance().run();  // init command and select m_onTrue
-    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
+    assertCommandState(m_onTrue, 1, 3, 3, 1, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
     Scheduler.getInstance().run();  // init m_onTrue
-    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
-    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 2, 5, 5, 1, 0);
-    Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 2, 4, 8, 1, 0);
+    assertCommandState(m_onTrue, 1, 3, 3, 1, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 2, 6, 6, 1, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 2, 5, 10, 1, 0);
+    assertCommandState(m_onTrue, 2, 4, 4, 1, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
     assertConditionalCommandState(m_command, 2, 7, 7, 1, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 2, 5, 5, 1, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 2, 8, 8, 1, 0);
     m_onTrue.setHasFinished(true);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 2, 6, 12, 2, 0);
+    assertCommandState(m_onTrue, 2, 6, 6, 2, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 2, 8, 8, 2, 0);
+    assertConditionalCommandState(m_command, 2, 9, 9, 1, 0);
     Scheduler.getInstance().run();
-    assertCommandState(m_onTrue, 2, 6, 12, 2, 0);
+    assertCommandState(m_onTrue, 2, 6, 6, 2, 0);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
-    assertConditionalCommandState(m_command, 2, 8, 8, 2, 0);
+    assertConditionalCommandState(m_command, 2, 10, 10, 2, 0);
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/ConditionalCommandTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/ConditionalCommandTest.java
@@ -7,22 +7,36 @@
 
 package edu.wpi.first.wpilibj.command;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class ConditionalCommandTest extends AbstractCommandTest {
   MockConditionalCommand m_command;
   MockCommand m_onTrue;
   MockCommand m_onFalse;
+  MockSubsystem m_subsys;
   Boolean m_condition;
 
   @Before
   public void initCommands() {
-    m_onTrue = new MockCommand();
-    m_onFalse = new MockCommand();
+    m_subsys = new MockSubsystem();
+    m_onTrue = new MockCommand(m_subsys);
+    m_onFalse = new MockCommand(m_subsys);
     m_command = new MockConditionalCommand(m_onTrue, m_onFalse);
+  }
+
+  protected void assertConditionalCommandState(MockConditionalCommand command, int initialize,
+                                               int execute, int isFinished, int end,
+                                               int interrupted) {
+    assertEquals(initialize, command.getInitializeCount());
+    assertEquals(execute, command.getExecuteCount());
+    assertEquals(isFinished, command.getIsFinishedCount());
+    assertEquals(end, command.getEndCount());
+    assertEquals(interrupted, command.getInterruptedCount());
   }
 
   @Test
@@ -31,14 +45,33 @@ public class ConditionalCommandTest extends AbstractCommandTest {
 
     Scheduler.getInstance().add(m_command);
     assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
     Scheduler.getInstance().run();  // init command and select m_onTrue
     assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
     Scheduler.getInstance().run();  // init m_onTrue
     assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
     Scheduler.getInstance().run();
     assertCommandState(m_onTrue, 1, 1, 2, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
     Scheduler.getInstance().run();
     assertCommandState(m_onTrue, 1, 2, 4, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 3, 3, 0, 0);
+    m_onTrue.setHasFinished(true);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
 
     assertTrue("Did not initialize the true command", m_onTrue.getInitializeCount() > 0);
     assertTrue("Initialized the false command", m_onFalse.getInitializeCount() == 0);
@@ -50,16 +83,208 @@ public class ConditionalCommandTest extends AbstractCommandTest {
 
     Scheduler.getInstance().add(m_command);
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
     Scheduler.getInstance().run();  // init command and select m_onFalse
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
     Scheduler.getInstance().run();  // init m_onFalse
     assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
     Scheduler.getInstance().run();
     assertCommandState(m_onFalse, 1, 1, 2, 0, 0);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
     Scheduler.getInstance().run();
     assertCommandState(m_onFalse, 1, 2, 4, 0, 0);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 3, 3, 0, 0);
+    m_onFalse.setHasFinished(true);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onFalse, 1, 3, 6, 1, 0);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onFalse, 1, 3, 6, 1, 0);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
 
     assertTrue("Did not initialize the false command", m_onFalse.getInitializeCount() > 0);
     assertTrue("Initialized the true command", m_onTrue.getInitializeCount() == 0);
+  }
+
+  @Test
+  @Ignore("WPILIB conditional command bug, canceling inner command doesn't cancel conditional "
+          + "command")
+  public void testCancelSubCommand() {
+    m_command.setCondition(true);
+
+    Scheduler.getInstance().add(m_command);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
+    Scheduler.getInstance().run();  // init command and select m_onTrue
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
+    Scheduler.getInstance().run();  // init m_onTrue
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 1, 2, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 2, 4, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 3, 3, 0, 0);
+    m_onTrue.cancel();
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 2, 5, 0, 1);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 2, 5, 0, 1);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
+  }
+
+  @Test
+  public void testCancelRequires() {
+    m_command.setCondition(true);
+
+    Scheduler.getInstance().add(m_command);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
+    Scheduler.getInstance().run();  // init command and select m_onTrue
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
+    Scheduler.getInstance().run();  // init m_onTrue
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 1, 2, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 2, 4, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 3, 3, 0, 0);
+    m_onFalse.start();
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 3, 6, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 0, 1);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 3, 6, 0, 1);
+    assertCommandState(m_onFalse, 1, 1, 1, 0, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 0, 1);
+  }
+
+  @Test
+  public void testCancelCondCommand() {
+    m_command.setCondition(true);
+
+    Scheduler.getInstance().add(m_command);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
+    Scheduler.getInstance().run();  // init command and select m_onTrue
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
+    Scheduler.getInstance().run();  // init m_onTrue
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 1, 2, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 2, 4, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 3, 3, 0, 0);
+    m_command.cancel();
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 2, 4, 0, 1);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 3, 3, 0, 1);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 2, 4, 0, 1);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 3, 3, 0, 1);
+  }
+
+  @Test
+  public void testOnTrueTwice() {
+    m_command.setCondition(true);
+
+    Scheduler.getInstance().add(m_command);
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
+    Scheduler.getInstance().run();  // init command and select m_onTrue
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 0, 0, 0, 0, 0);
+    Scheduler.getInstance().run();  // init m_onTrue
+    assertCommandState(m_onTrue, 0, 0, 0, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 1, 1, 0, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 1, 2, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 2, 2, 0, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 2, 4, 0, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 3, 3, 0, 0);
+    m_onTrue.setHasFinished(true);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+
+    m_onTrue.setHasFinished(false);
+    Scheduler.getInstance().add(m_command);
+    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    Scheduler.getInstance().run();  // init command and select m_onTrue
+    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 1, 4, 4, 1, 0);
+    Scheduler.getInstance().run();  // init m_onTrue
+    assertCommandState(m_onTrue, 1, 3, 6, 1, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 2, 5, 5, 1, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 2, 4, 8, 1, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 2, 6, 6, 1, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 2, 5, 10, 1, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 2, 7, 7, 1, 0);
+    m_onTrue.setHasFinished(true);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 2, 6, 12, 2, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 2, 8, 8, 2, 0);
+    Scheduler.getInstance().run();
+    assertCommandState(m_onTrue, 2, 6, 12, 2, 0);
+    assertCommandState(m_onFalse, 0, 0, 0, 0, 0);
+    assertConditionalCommandState(m_command, 2, 8, 8, 2, 0);
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockCommand.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockCommand.java
@@ -8,7 +8,7 @@
 package edu.wpi.first.wpilibj.command;
 
 /**
- * A class to simulate a simple command The command keeps track of how many times each method was
+ * A class to simulate a simple command. The command keeps track of how many times each method was
  * called.
  */
 public class MockCommand extends Command {
@@ -18,6 +18,15 @@ public class MockCommand extends Command {
   private boolean m_hasFinished = false;
   private int m_endCount = 0;
   private int m_interruptedCount = 0;
+
+  public MockCommand(Subsystem subsys) {
+    super();
+    requires(subsys);
+  }
+
+  public MockCommand() {
+    super();
+  }
 
   protected void initialize() {
     ++m_initializeCount;

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockCommand.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockCommand.java
@@ -124,4 +124,16 @@ public class MockCommand extends Command {
     return getInterruptedCount() > 0;
   }
 
+  /**
+   * Reset internal counters.
+   */
+  public void resetCounters() {
+    m_initializeCount = 0;
+    m_executeCount = 0;
+    m_isFinishedCount = 0;
+    m_hasFinished = false;
+    m_endCount = 0;
+    m_interruptedCount = 0;
+  }
+
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockConditionalCommand.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockConditionalCommand.java
@@ -9,6 +9,11 @@ package edu.wpi.first.wpilibj.command;
 
 public class MockConditionalCommand extends ConditionalCommand {
   private boolean m_condition = false;
+  private int m_initializeCount = 0;
+  private int m_executeCount = 0;
+  private int m_isFinishedCount = 0;
+  private int m_endCount = 0;
+  private int m_interruptedCount = 0;
 
   public MockConditionalCommand(MockCommand onTrue, MockCommand onFalse) {
     super(onTrue, onFalse);
@@ -21,5 +26,83 @@ public class MockConditionalCommand extends ConditionalCommand {
 
   public void setCondition(boolean condition) {
     this.m_condition = condition;
+  }
+
+  protected void initialize() {
+    ++m_initializeCount;
+  }
+
+  protected void execute() {
+    ++m_executeCount;
+  }
+
+  protected boolean isFinished() {
+    ++m_isFinishedCount;
+    return super.isFinished();
+  }
+
+  protected void end() {
+    ++m_endCount;
+  }
+
+  protected void interrupted() {
+    ++m_interruptedCount;
+  }
+
+
+  /**
+   * How many times the initialize method has been called.
+   */
+  public int getInitializeCount() {
+    return m_initializeCount;
+  }
+
+  /**
+   * If the initialize method has been called at least once.
+   */
+  public boolean hasInitialized() {
+    return getInitializeCount() > 0;
+  }
+
+  /**
+   * How many time the execute method has been called.
+   */
+  public int getExecuteCount() {
+    return m_executeCount;
+  }
+
+  /**
+   * How many times the isFinished method has been called.
+   */
+  public int getIsFinishedCount() {
+    return m_isFinishedCount;
+  }
+
+  /**
+   * How many times the end method has been called.
+   */
+  public int getEndCount() {
+    return m_endCount;
+  }
+
+  /**
+   * If the end method has been called at least once.
+   */
+  public boolean hasEnd() {
+    return getEndCount() > 0;
+  }
+
+  /**
+   * How many times the interrupted method has been called.
+   */
+  public int getInterruptedCount() {
+    return m_interruptedCount;
+  }
+
+  /**
+   * If the interrupted method has been called at least once.
+   */
+  public boolean hasInterrupted() {
+    return getInterruptedCount() > 0;
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockConditionalCommand.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockConditionalCommand.java
@@ -105,4 +105,16 @@ public class MockConditionalCommand extends ConditionalCommand {
   public boolean hasInterrupted() {
     return getInterruptedCount() > 0;
   }
+
+  /**
+   * Reset internal counters.
+   */
+  public void resetCounters() {
+    m_condition = false;
+    m_initializeCount = 0;
+    m_executeCount = 0;
+    m_isFinishedCount = 0;
+    m_endCount = 0;
+    m_interruptedCount = 0;
+  }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockSubsystem.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockSubsystem.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockSubsystem.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockSubsystem.java
@@ -1,0 +1,15 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.command;
+
+/**
+ * A class to simulate a simple subsystem.
+ */
+public class MockSubsystem extends Subsystem {
+  protected void initDefaultCommand() {}
+}


### PR DESCRIPTION
Make sure ConditonalCommand ends if a null command is chosen.
Don't call chosen command's isFinished twice.
Add additional tests for ConditionalCommand.
This does the same thing as #690 but less intrusive.
  