### PR TITLE
Utility class tests

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotController.java
@@ -18,6 +18,7 @@ import edu.wpi.first.wpilibj.hal.PowerJNI;
  */
 public final class RobotController {
   private RobotController() {
+    throw new UnsupportedOperationException("This is a utility class!");
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -45,6 +45,10 @@ public class LiveWindow {
   private static boolean liveWindowEnabled = false;
   private static boolean telemetryEnabled = true;
 
+  private LiveWindow() {
+    throw new UnsupportedOperationException("This is a utility class!");
+  }
+
   public static synchronized boolean isEnabled() {
     return liveWindowEnabled;
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
@@ -51,6 +51,10 @@ public class SmartDashboard {
     HLUsageReporting.reportSmartDashboard();
   }
 
+  private SmartDashboard() {
+    throw new UnsupportedOperationException("This is a utility class!");
+  }
+
   /**
    * Maps the specified key to the specified value in this table. The key can not be null. The value
    * can be retrieved by calling the get method with a key that is equal to the original key.

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/RobotControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/RobotControllerTest.java
@@ -8,7 +8,6 @@
 package edu.wpi.first.wpilibj;
 
 public class RobotControllerTest extends UtilityClassTest {
-
   public RobotControllerTest() {
     super(RobotController.class);
   }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/RobotControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/RobotControllerTest.java
@@ -1,3 +1,10 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
 package edu.wpi.first.wpilibj;
 
 public class RobotControllerTest extends UtilityClassTest {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/RobotControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/RobotControllerTest.java
@@ -1,0 +1,9 @@
+package edu.wpi.first.wpilibj;
+
+public class RobotControllerTest extends UtilityClassTest {
+
+  public RobotControllerTest() {
+    super(RobotController.class);
+  }
+
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
@@ -1,5 +1,13 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
 package edu.wpi.first.wpilibj;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
@@ -15,22 +23,28 @@ import org.junit.Test;
 @SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
 public abstract class UtilityClassTest {
 
-  private final Class clazz;
+  private final Class m_clazz;
 
   UtilityClassTest(Class clazz) {
-    this.clazz = clazz;
+    m_clazz = clazz;
+  }
+
+  @Test
+  public void testSingleConstructor() {
+    assertEquals("More than one constructor defined", 1,
+        m_clazz.getDeclaredConstructors().length);
   }
 
   @Test
   public void testConstructorPrivate() {
-    Constructor constructor = clazz.getDeclaredConstructors()[0];
+    Constructor constructor = m_clazz.getDeclaredConstructors()[0];
 
-    assertFalse(constructor.isAccessible());
+    assertFalse("Constructor is not private", constructor.isAccessible());
   }
 
   @Test(expected = InvocationTargetException.class)
   public void testConstructorReflection() throws Throwable {
-    Constructor constructor = clazz.getDeclaredConstructors()[0];
+    Constructor constructor = m_clazz.getDeclaredConstructors()[0];
     constructor.setAccessible(true);
     constructor.newInstance();
   }
@@ -38,7 +52,7 @@ public abstract class UtilityClassTest {
   @Test
   public void testPublicMethodsStatic() {
     List<String> failures = new ArrayList<>();
-    for (Method method : clazz.getDeclaredMethods()) {
+    for (Method method : m_clazz.getDeclaredMethods()) {
       int modifiers = method.getModifiers();
       if (Modifier.isPublic(modifiers) && !Modifier.isStatic(modifiers)) {
         failures.add(method.toString());

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
@@ -7,10 +7,6 @@
 
 package edu.wpi.first.wpilibj;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -18,7 +14,12 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
 public abstract class UtilityClassTest {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -23,6 +24,11 @@ import static org.junit.Assert.fail;
 
 @SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
 public abstract class UtilityClassTest {
+  @Before
+  public void setup() {
+    UnitTestUtility.setupMockBase();
+  }
+
   private final Class m_clazz;
 
   protected UtilityClassTest(Class clazz) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
@@ -1,0 +1,53 @@
+package edu.wpi.first.wpilibj;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
+public abstract class UtilityClassTest {
+
+  private final Class clazz;
+
+  UtilityClassTest(Class clazz) {
+    this.clazz = clazz;
+  }
+
+  @Test
+  public void testConstructorPrivate() {
+    Constructor constructor = clazz.getDeclaredConstructors()[0];
+
+    assertFalse(constructor.isAccessible());
+  }
+
+  @Test(expected = InvocationTargetException.class)
+  public void testConstructorReflection() throws Throwable {
+    Constructor constructor = clazz.getDeclaredConstructors()[0];
+    constructor.setAccessible(true);
+    constructor.newInstance();
+  }
+
+  @Test
+  public void testPublicMethodsStatic() {
+    List<String> failures = new ArrayList<>();
+    for (Method method : clazz.getDeclaredMethods()) {
+      int modifiers = method.getModifiers();
+      if (Modifier.isPublic(modifiers) && !Modifier.isStatic(modifiers)) {
+        failures.add(method.toString());
+      }
+    }
+
+    if (!failures.isEmpty()) {
+      fail("Found public methods that are not static: "
+          + Arrays.toString(failures.toArray()));
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 public abstract class UtilityClassTest {
   private final Class m_clazz;
 
-  UtilityClassTest(Class clazz) {
+  protected UtilityClassTest(Class clazz) {
     m_clazz = clazz;
   }
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 @SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
 public abstract class UtilityClassTest {
-
   private final Class m_clazz;
 
   UtilityClassTest(Class clazz) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/livewindow/LiveWindowTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/livewindow/LiveWindowTest.java
@@ -5,10 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package edu.wpi.first.wpilibj;
+package edu.wpi.first.wpilibj.livewindow;
 
-public class RobotControllerTest extends UtilityClassTest {
-  public RobotControllerTest() {
-    super(RobotController.class);
+import edu.wpi.first.wpilibj.UtilityClassTest;
+
+public class LiveWindowTest extends UtilityClassTest {
+  public LiveWindowTest() {
+    super(LiveWindow.class);
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboardTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboardTest.java
@@ -5,10 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package edu.wpi.first.wpilibj;
+package edu.wpi.first.wpilibj.smartdashboard;
 
-public class RobotControllerTest extends UtilityClassTest {
-  public RobotControllerTest() {
-    super(RobotController.class);
+import edu.wpi.first.wpilibj.UtilityClassTest;
+
+public class SmartDashboardTest extends UtilityClassTest {
+  public SmartDashboardTest() {
+    super(SmartDashboard.class);
   }
 }


### PR DESCRIPTION
Add tests to ensure utility classes have private constructors and all public methods are static.

Should prevent issues like #870 