### PR TITLE
Invert when getting motor speed in SpeedControllerGroup

### DIFF
--- a/wpilibc/src/main/native/cpp/SpeedControllerGroup.cpp
+++ b/wpilibc/src/main/native/cpp/SpeedControllerGroup.cpp
@@ -19,7 +19,7 @@ void SpeedControllerGroup::Set(double speed) {
 
 double SpeedControllerGroup::Get() const {
   if (!m_speedControllers.empty()) {
-    return m_speedControllers.front().get().Get();
+    return m_speedControllers.front().get().Get() * (m_isInverted ? -1 : 1);
   }
   return 0.0;
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SpeedControllerGroup.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SpeedControllerGroup.java
@@ -45,7 +45,7 @@ public class SpeedControllerGroup extends SendableBase implements SpeedControlle
   @Override
   public double get() {
     if (m_speedControllers.length > 0) {
-      return m_speedControllers[0].get();
+      return m_speedControllers[0].get() * (m_isInverted ? -1 : 1);
     }
     return 0.0;
   }


### PR DESCRIPTION
Previously, `setInverted` would cause the sign of the speed to be flipped *only when setting*. Now, the sign is flipped (if the SpeedControllerGroup is inverted) when getting as well.