### PR TITLE
Fixes phase lag in PIDController caused by LinearDigitalFilter

### DIFF
--- a/wpilibc/src/main/native/include/PIDController.h
+++ b/wpilibc/src/main/native/include/PIDController.h
@@ -160,7 +160,6 @@ class PIDController : public SendableBase, public PIDInterface {
   double m_result = 0;
   double m_period;
 
-  std::shared_ptr<PIDSource> m_origSource;
   LinearDigitalFilter m_filter{nullptr, {}, {}};
 
   mutable wpi::mutex m_thisMutex;


### PR DESCRIPTION
The tolerance buffer LDF implementation (which is still deprecated) now matches
the original implementation.

Fixes #901.