### PR TITLE
Rename Joystick default channel constants

### DIFF
--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -8,7 +8,8 @@ def windowsLinkerArgs = ['/DEBUG:FULL']
 def windowsReleaseLinkerArgs = ['/OPT:REF', '/OPT:ICF']
 
 def linuxCompilerArgs = ['-std=c++14', '-Wformat=2', '-Wall', '-Wextra', '-Werror', '-pedantic', '-Wno-psabi', '-g',
-                         '-Wno-unused-parameter', '-fPIC', '-rdynamic', '-pthread']
+                         '-Wno-unused-parameter', '-Wno-error=deprecated-declarations', '-fPIC', '-rdynamic',
+                         '-pthread']
 def linuxCCompilerArgs = ['-Wformat=2', '-Wall', '-Wextra', '-Werror', '-pedantic', '-Wno-psabi', '-g',
                           '-Wno-unused-parameter', '-fPIC', '-rdynamic', '-pthread']
 def linuxLinkerArgs = ['-rdynamic', '-pthread', '-ldl']
@@ -17,8 +18,8 @@ def linuxDebugCompilerArgs = ['-O0']
 def linux32BitArg = '-m32'
 
 def macCompilerArgs = ['-std=c++14', '-Wall', '-Wextra', '-Werror', '-pedantic-errors', '-fPIC', '-g',
-                       '-Wno-unused-parameter', '-Wno-missing-field-initializers', '-Wno-unused-private-field',
-                       '-Wno-unused-const-variable', '-pthread']
+                       '-Wno-unused-parameter', '-Wno-error=deprecated-declarations', '-Wno-missing-field-initializers',
+                       '-Wno-unused-private-field', '-Wno-unused-const-variable', '-pthread']
 def macCCompilerArgs = ['-Wall', '-Wextra', '-Werror', '-pedantic-errors', '-fPIC', '-g',
                         '-Wno-unused-parameter', '-Wno-missing-field-initializers', '-Wno-unused-private-field']
 def macObjCLinkerArgs = ['-std=c++14', '-stdlib=libc++','-fobjc-arc', '-g', '-fPIC', '-Wall', '-Wextra', '-Werror']

--- a/wpilibc/src/main/native/cpp/Joystick.cpp
+++ b/wpilibc/src/main/native/cpp/Joystick.cpp
@@ -27,11 +27,11 @@ constexpr double kPi = 3.14159265358979323846;
  *             (0-5).
  */
 Joystick::Joystick(int port) : GenericHID(port) {
-  m_axes[Axis::kX] = kDefaultXAxis;
-  m_axes[Axis::kY] = kDefaultYAxis;
-  m_axes[Axis::kZ] = kDefaultZAxis;
-  m_axes[Axis::kTwist] = kDefaultTwistAxis;
-  m_axes[Axis::kThrottle] = kDefaultThrottleAxis;
+  m_axes[Axis::kX] = kDefaultXChannel;
+  m_axes[Axis::kY] = kDefaultYChannel;
+  m_axes[Axis::kZ] = kDefaultZChannel;
+  m_axes[Axis::kTwist] = kDefaultTwistChannel;
+  m_axes[Axis::kThrottle] = kDefaultThrottleChannel;
 
   HAL_Report(HALUsageReporting::kResourceType_Joystick, port);
 }

--- a/wpilibc/src/main/native/include/Joystick.h
+++ b/wpilibc/src/main/native/include/Joystick.h
@@ -25,10 +25,21 @@ namespace frc {
  */
 class Joystick : public GenericHID {
  public:
+  static constexpr int kDefaultXChannel = 0;
+  static constexpr int kDefaultYChannel = 1;
+  static constexpr int kDefaultZChannel = 2;
+  static constexpr int kDefaultTwistChannel = 2;
+  static constexpr int kDefaultThrottleChannel = 3;
+
+  WPI_DEPRECATED("Use kDefaultXChannel instead.")
   static constexpr int kDefaultXAxis = 0;
+  WPI_DEPRECATED("Use kDefaultYChannel instead.")
   static constexpr int kDefaultYAxis = 1;
+  WPI_DEPRECATED("Use kDefaultZChannel instead.")
   static constexpr int kDefaultZAxis = 2;
+  WPI_DEPRECATED("Use kDefaultTwistChannel instead.")
   static constexpr int kDefaultTwistAxis = 2;
+  WPI_DEPRECATED("Use kDefaultThrottleChannel instead.")
   static constexpr int kDefaultThrottleAxis = 3;
 
   enum AxisType { kXAxis, kYAxis, kZAxis, kTwistAxis, kThrottleAxis };

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
@@ -18,10 +18,21 @@ import edu.wpi.first.wpilibj.hal.HAL;
  * and the mapping of ports to hardware buttons depends on the code in the Driver Station.
  */
 public class Joystick extends GenericHID {
+  static final byte kDefaultXChannel = 0;
+  static final byte kDefaultYChannel = 1;
+  static final byte kDefaultZChannel = 2;
+  static final byte kDefaultTwistChannel = 2;
+  static final byte kDefaultThrottleChannel = 3;
+
+  @Deprecated
   static final byte kDefaultXAxis = 0;
+  @Deprecated
   static final byte kDefaultYAxis = 1;
+  @Deprecated
   static final byte kDefaultZAxis = 2;
+  @Deprecated
   static final byte kDefaultTwistAxis = 2;
+  @Deprecated
   static final byte kDefaultThrottleAxis = 3;
 
   /**
@@ -91,11 +102,11 @@ public class Joystick extends GenericHID {
   public Joystick(final int port) {
     super(port);
 
-    m_axes[Axis.kX.value] = kDefaultXAxis;
-    m_axes[Axis.kY.value] = kDefaultYAxis;
-    m_axes[Axis.kZ.value] = kDefaultZAxis;
-    m_axes[Axis.kTwist.value] = kDefaultTwistAxis;
-    m_axes[Axis.kThrottle.value] = kDefaultThrottleAxis;
+    m_axes[Axis.kX.value] = kDefaultXChannel;
+    m_axes[Axis.kY.value] = kDefaultYChannel;
+    m_axes[Axis.kZ.value] = kDefaultZChannel;
+    m_axes[Axis.kTwist.value] = kDefaultTwistChannel;
+    m_axes[Axis.kThrottle.value] = kDefaultThrottleChannel;
 
     HAL.report(tResourceType.kResourceType_Joystick, port);
   }


### PR DESCRIPTION
The new naming makes it more clear that the constants are intended to be used
with the channel setters.