### PR TITLE
Improved Command-based examples

### DIFF
--- a/wpilibcExamples/src/main/cpp/templates/commandbased/Commands/ExampleCommand.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandbased/Commands/ExampleCommand.cpp
@@ -7,9 +7,11 @@
 
 #include "ExampleCommand.h"
 
+#include "../Robot.h"
+
 ExampleCommand::ExampleCommand() {
 	// Use Requires() here to declare subsystem dependencies
-	// eg. Requires(&Robot::chassis);
+	Requires(&Robot::m_subsystem);
 }
 
 // Called just before this Command runs the first time

--- a/wpilibcExamples/src/main/cpp/templates/commandbased/Commands/MyAutoCommand.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandbased/Commands/MyAutoCommand.cpp
@@ -7,9 +7,11 @@
 
 #include "MyAutoCommand.h"
 
+#include "../Robot.h"
+
 MyAutoCommand::MyAutoCommand() {
 	// Use Requires() here to declare subsystem dependencies
-	// eg. Requires(&Robot::chassis);
+	Requires(&Robot::m_subsystem);
 }
 
 // Called just before this Command runs the first time

--- a/wpilibcExamples/src/main/cpp/templates/commandbased/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandbased/Robot.cpp
@@ -5,93 +5,77 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-#include <Commands/Command.h>
+#include "Robot.h"
+
 #include <Commands/Scheduler.h>
-#include <LiveWindow/LiveWindow.h>
-#include <SmartDashboard/SendableChooser.h>
 #include <SmartDashboard/SmartDashboard.h>
-#include <TimedRobot.h>
 
-#include "Commands/ExampleCommand.h"
-#include "Commands/MyAutoCommand.h"
+ExampleSubsystem Robot::m_subsystem;
+OI Robot::m_oi;
 
-class Robot : public frc::TimedRobot {
-public:
-	void RobotInit() override {
-		m_chooser.AddDefault("Default Auto", &m_defaultAuto);
-		m_chooser.AddObject("My Auto", &m_myAuto);
-		frc::SmartDashboard::PutData("Auto Modes", &m_chooser);
+void Robot::RobotInit() {
+	m_chooser.AddDefault("Default Auto", &m_defaultAuto);
+	m_chooser.AddObject("My Auto", &m_myAuto);
+	frc::SmartDashboard::PutData("Auto Modes", &m_chooser);
+}
+
+/**
+ * This function is called once each time the robot enters Disabled mode. You
+ * can use it to reset any subsystem information you want to clear when the
+ * robot is disabled.
+ */
+void Robot::DisabledInit() {}
+
+void Robot::DisabledPeriodic() {
+	frc::Scheduler::GetInstance()->Run();
+}
+
+/**
+ * This autonomous (along with the chooser code above) shows how to select
+ * between different autonomous modes using the dashboard. The sendable chooser
+ * code works with the Java SmartDashboard. If you prefer the LabVIEW Dashboard,
+ * remove all of the chooser code and uncomment the GetString code to get the
+ * auto name from the text box below the Gyro.
+ *
+ * You can add additional auto modes by adding additional commands to the
+ * chooser code above (like the commented example) or additional comparisons to
+ * the if-else structure below with additional strings & commands.
+ */
+void Robot::AutonomousInit() {
+	// std::string autoSelected = frc::SmartDashboard::GetString(
+	// 		"Auto Selector", "Default");
+	// if (autoSelected == "My Auto") {
+	// 	m_autonomousCommand = &m_myAuto;
+	// } else {
+	// 	m_autonomousCommand = &m_defaultAuto;
+	// }
+
+	m_autonomousCommand = m_chooser.GetSelected();
+
+	if (m_autonomousCommand != nullptr) {
+		m_autonomousCommand->Start();
 	}
+}
 
-	/**
-	 * This function is called once each time the robot enters Disabled
-	 * mode.
-	 * You can use it to reset any subsystem information you want to clear
-	 * when
-	 * the robot is disabled.
-	 */
-	void DisabledInit() override {}
+void Robot::AutonomousPeriodic() {
+	frc::Scheduler::GetInstance()->Run();
+}
 
-	void DisabledPeriodic() override {
-		frc::Scheduler::GetInstance()->Run();
+void Robot::TeleopInit() {
+	// This makes sure that the autonomous stops running when
+	// teleop starts running. If you want the autonomous to
+	// continue until interrupted by another command, remove
+	// this line or comment it out.
+	if (m_autonomousCommand != nullptr) {
+		m_autonomousCommand->Cancel();
+		m_autonomousCommand = nullptr;
 	}
+}
 
-	/**
-	 * This autonomous (along with the chooser code above) shows how to
-	 * select
-	 * between different autonomous modes using the dashboard. The sendable
-	 * chooser code works with the Java SmartDashboard. If you prefer the
-	 * LabVIEW Dashboard, remove all of the chooser code and uncomment the
-	 * GetString code to get the auto name from the text box below the Gyro.
-	 *
-	 * You can add additional auto modes by adding additional commands to
-	 * the
-	 * chooser code above (like the commented example) or additional
-	 * comparisons
-	 * to the if-else structure below with additional strings & commands.
-	 */
-	void AutonomousInit() override {
-		std::string autoSelected = frc::SmartDashboard::GetString(
-				"Auto Selector", "Default");
-		if (autoSelected == "My Auto") {
-			m_autonomousCommand = &m_myAuto;
-		} else {
-			m_autonomousCommand = &m_defaultAuto;
-		}
+void Robot::TeleopPeriodic() {
+	frc::Scheduler::GetInstance()->Run();
+}
 
-		m_autonomousCommand = m_chooser.GetSelected();
-
-		if (m_autonomousCommand != nullptr) {
-			m_autonomousCommand->Start();
-		}
-	}
-
-	void AutonomousPeriodic() override {
-		frc::Scheduler::GetInstance()->Run();
-	}
-
-	void TeleopInit() override {
-		// This makes sure that the autonomous stops running when
-		// teleop starts running. If you want the autonomous to
-		// continue until interrupted by another command, remove
-		// this line or comment it out.
-		if (m_autonomousCommand != nullptr) {
-			m_autonomousCommand->Cancel();
-			m_autonomousCommand = nullptr;
-		}
-	}
-
-	void TeleopPeriodic() override { frc::Scheduler::GetInstance()->Run(); }
-
-	void TestPeriodic() override {}
-
-private:
-	// Have it null by default so that if testing teleop it
-	// doesn't have undefined behavior and potentially crash.
-	frc::Command* m_autonomousCommand = nullptr;
-	ExampleCommand m_defaultAuto;
-	MyAutoCommand m_myAuto;
-	frc::SendableChooser<frc::Command*> m_chooser;
-};
+void Robot::TestPeriodic() {}
 
 START_ROBOT_CLASS(Robot)

--- a/wpilibcExamples/src/main/cpp/templates/commandbased/Robot.h
+++ b/wpilibcExamples/src/main/cpp/templates/commandbased/Robot.h
@@ -1,0 +1,40 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Commands/Command.h>
+#include <SmartDashboard/SendableChooser.h>
+#include <TimedRobot.h>
+
+#include "Commands/ExampleCommand.h"
+#include "Commands/MyAutoCommand.h"
+#include "OI.h"
+#include "Subsystems/ExampleSubsystem.h"
+
+class Robot : public frc::TimedRobot {
+public:
+	static ExampleSubsystem m_subsystem;
+	static OI m_oi;
+
+	void RobotInit() override;
+	void DisabledInit() override;
+	void DisabledPeriodic() override;
+	void AutonomousInit() override;
+	void AutonomousPeriodic() override;
+	void TeleopInit() override;
+	void TeleopPeriodic() override;
+	void TestPeriodic() override;
+
+private:
+	// Have it null by default so that if testing teleop it
+	// doesn't have undefined behavior and potentially crash.
+	frc::Command* m_autonomousCommand = nullptr;
+	ExampleCommand m_defaultAuto;
+	MyAutoCommand m_myAuto;
+	frc::SendableChooser<frc::Command*> m_chooser;
+};

--- a/wpilibcExamples/src/main/cpp/templates/iterative/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/iterative/Robot.cpp
@@ -5,69 +5,54 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-#include <iostream>
-#include <string>
+#include "Robot.h"
 
-#include <IterativeRobot.h>
-#include <LiveWindow/LiveWindow.h>
-#include <SmartDashboard/SendableChooser.h>
+#include <iostream>
+
 #include <SmartDashboard/SmartDashboard.h>
 
-class Robot : public frc::IterativeRobot {
-public:
-	void RobotInit() {
-		m_chooser.AddDefault(kAutoNameDefault, kAutoNameDefault);
-		m_chooser.AddObject(kAutoNameCustom, kAutoNameCustom);
-		frc::SmartDashboard::PutData("Auto Modes", &m_chooser);
+void Robot::RobotInit() {
+	m_chooser.AddDefault(kAutoNameDefault, kAutoNameDefault);
+	m_chooser.AddObject(kAutoNameCustom, kAutoNameCustom);
+	frc::SmartDashboard::PutData("Auto Modes", &m_chooser);
+}
+
+/**
+ * This autonomous (along with the chooser code above) shows how to select
+ * between different autonomous modes using the dashboard. The sendable chooser
+ * code works with the Java SmartDashboard. If you prefer the LabVIEW Dashboard,
+ * remove all of the chooser code and uncomment the GetString line to get the
+ * auto name from the text box below the Gyro.
+ *
+ * You can add additional auto modes by adding additional comparisons to the
+ * if-else structure below with additional strings. If using the SendableChooser
+ * make sure to add them to the chooser code above as well.
+ */
+void Robot::AutonomousInit() {
+	m_autoSelected = m_chooser.GetSelected();
+	// m_autoSelected = SmartDashboard::GetString(
+	// 		"Auto Selector", kAutoNameDefault);
+	std::cout << "Auto selected: " << m_autoSelected << std::endl;
+
+	if (m_autoSelected == kAutoNameCustom) {
+		// Custom Auto goes here
+	} else {
+		// Default Auto goes here
 	}
+}
 
-	/*
-	 * This autonomous (along with the chooser code above) shows how to
-	 * select
-	 * between different autonomous modes using the dashboard. The sendable
-	 * chooser code works with the Java SmartDashboard. If you prefer the
-	 * LabVIEW Dashboard, remove all of the chooser code and uncomment the
-	 * GetString line to get the auto name from the text box below the Gyro.
-	 *
-	 * You can add additional auto modes by adding additional comparisons to
-	 * the
-	 * if-else structure below with additional strings. If using the
-	 * SendableChooser make sure to add them to the chooser code above as
-	 * well.
-	 */
-	void AutonomousInit() override {
-		m_autoSelected = m_chooser.GetSelected();
-		// m_autoSelected = SmartDashboard::GetString(
-		// 		"Auto Selector", kAutoNameDefault);
-		std::cout << "Auto selected: " << m_autoSelected << std::endl;
-
-		if (m_autoSelected == kAutoNameCustom) {
-			// Custom Auto goes here
-		} else {
-			// Default Auto goes here
-		}
+void Robot::AutonomousPeriodic() {
+	if (m_autoSelected == kAutoNameCustom) {
+		// Custom Auto goes here
+	} else {
+		// Default Auto goes here
 	}
+}
 
-	void AutonomousPeriodic() {
-		if (m_autoSelected == kAutoNameCustom) {
-			// Custom Auto goes here
-		} else {
-			// Default Auto goes here
-		}
-	}
+void Robot::TeleopInit() {}
 
-	void TeleopInit() {}
+void Robot::TeleopPeriodic() {}
 
-	void TeleopPeriodic() {}
-
-	void TestPeriodic() {}
-
-private:
-	frc::LiveWindow& m_lw = *LiveWindow::GetInstance();
-	frc::SendableChooser<std::string> m_chooser;
-	const std::string kAutoNameDefault = "Default";
-	const std::string kAutoNameCustom = "My Auto";
-	std::string m_autoSelected;
-};
+void Robot::TestPeriodic() {}
 
 START_ROBOT_CLASS(Robot)

--- a/wpilibcExamples/src/main/cpp/templates/iterative/Robot.h
+++ b/wpilibcExamples/src/main/cpp/templates/iterative/Robot.h
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <string>
+
+#include <IterativeRobot.h>
+#include <SmartDashboard/SendableChooser.h>
+
+class Robot : public frc::IterativeRobot {
+public:
+	void RobotInit() override;
+	void AutonomousInit() override;
+	void AutonomousPeriodic() override;
+	void TeleopInit() override;
+	void TeleopPeriodic() override;
+	void TestPeriodic() override;
+
+private:
+	frc::SendableChooser<std::string> m_chooser;
+	const std::string kAutoNameDefault = "Default";
+	const std::string kAutoNameCustom = "My Auto";
+	std::string m_autoSelected;
+};

--- a/wpilibcExamples/src/main/cpp/templates/sample/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/sample/Robot.cpp
@@ -5,121 +5,87 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-#include <iostream>
-#include <string>
+#include "Robot.h"
 
-#include <Drive/DifferentialDrive.h>
-#include <Joystick.h>
-#include <SampleRobot.h>
-#include <SmartDashboard/SendableChooser.h>
+#include <iostream>
+
 #include <SmartDashboard/SmartDashboard.h>
-#include <Spark.h>
 #include <Timer.h>
 
+Robot::Robot() {
+	// Note SmartDashboard is not initialized here, wait until
+	// RobotInit to make SmartDashboard calls
+	m_robotDrive.SetExpiration(0.1);
+}
+
+void Robot::RobotInit() {
+	m_chooser.AddDefault(kAutoNameDefault, kAutoNameDefault);
+	m_chooser.AddObject(kAutoNameCustom, kAutoNameCustom);
+	frc::SmartDashboard::PutData("Auto Modes", &m_chooser);
+}
+
 /**
- * This is a demo program showing the use of the DifferentialDrive class.
- * The SampleRobot class is the base of a robot application that will
- * automatically call your Autonomous and OperatorControl methods at the right
- * time as controlled by the switches on the driver station or the field
- * controls.
+ * This autonomous (along with the chooser code above) shows how to select
+ * between different autonomous modes using the dashboard. The sendable chooser
+ * code works with the Java SmartDashboard. If you prefer the LabVIEW Dashboard,
+ * remove all of the chooser code and uncomment the GetString line to get the
+ * auto name from the text box below the Gyro.
  *
- * WARNING: While it may look like a good choice to use for your code if you're
- * inexperienced, don't. Unless you know what you are doing, complex code will
- * be much more difficult under this system. Use IterativeRobot or Command-Based
- * instead if you're new.
+ * You can add additional auto modes by adding additional comparisons to the
+ * if-else structure below with additional strings. If using the SendableChooser
+ * make sure to add them to the chooser code above as well.
  */
-class Robot : public frc::SampleRobot {
-public:
-	Robot() {
-		// Note SmartDashboard is not initialized here, wait until
-		// RobotInit to make SmartDashboard calls
-		m_robotDrive.SetExpiration(0.1);
+void Robot::Autonomous() {
+	std::string autoSelected = m_chooser.GetSelected();
+	// std::string autoSelected = frc::SmartDashboard::GetString(
+	// "Auto Selector", kAutoNameDefault);
+	std::cout << "Auto selected: " << autoSelected << std::endl;
+
+	// MotorSafety improves safety when motors are updated in loops
+	// but is disabled here because motor updates are not looped in
+	// this autonomous mode.
+	m_robotDrive.SetSafetyEnabled(false);
+
+	if (autoSelected == kAutoNameCustom) {
+		// Custom Auto goes here
+		std::cout << "Running custom Autonomous" << std::endl;
+
+		// Spin at half speed for two seconds
+		m_robotDrive.ArcadeDrive(0.0, 0.5);
+		frc::Wait(2.0);
+
+		// Stop robot
+		m_robotDrive.ArcadeDrive(0.0, 0.0);
+	} else {
+		// Default Auto goes here
+		std::cout << "Running default Autonomous" << std::endl;
+
+		// Drive forwards at half speed for two seconds
+		m_robotDrive.ArcadeDrive(-0.5, 0.0);
+		frc::Wait(2.0);
+
+		// Stop robot
+		m_robotDrive.ArcadeDrive(0.0, 0.0);
 	}
+}
 
-	void RobotInit() {
-		m_chooser.AddDefault(kAutoNameDefault, kAutoNameDefault);
-		m_chooser.AddObject(kAutoNameCustom, kAutoNameCustom);
-		frc::SmartDashboard::PutData("Auto Modes", &m_chooser);
+/**
+ * Runs the motors with arcade steering.
+ */
+void Robot::OperatorControl() {
+	m_robotDrive.SetSafetyEnabled(true);
+	while (IsOperatorControl() && IsEnabled()) {
+		// Drive with arcade style (use right stick)
+		m_robotDrive.ArcadeDrive(-m_stick.GetY(), m_stick.GetX());
+
+		// The motors will be updated every 5ms
+		frc::Wait(0.005);
 	}
+}
 
-	/*
-	 * This autonomous (along with the chooser code above) shows how to
-	 * select between different autonomous modes using the dashboard. The
-	 * sendable chooser code works with the Java SmartDashboard. If you
-	 * prefer the LabVIEW Dashboard, remove all of the chooser code and
-	 * uncomment the GetString line to get the auto name from the text box
-	 * below the Gyro.
-	 *
-	 * You can add additional auto modes by adding additional comparisons to
-	 * the if-else structure below with additional strings. If using the
-	 * SendableChooser make sure to add them to the chooser code above as
-	 * well.
-	 */
-	void Autonomous() {
-		std::string autoSelected = m_chooser.GetSelected();
-		// std::string autoSelected = frc::SmartDashboard::GetString(
-		// "Auto Selector", kAutoNameDefault);
-		std::cout << "Auto selected: " << autoSelected << std::endl;
-
-		// MotorSafety improves safety when motors are updated in loops
-		// but is disabled here because motor updates are not looped in
-		// this autonomous mode.
-		m_robotDrive.SetSafetyEnabled(false);
-
-		if (autoSelected == kAutoNameCustom) {
-			// Custom Auto goes here
-			std::cout << "Running custom Autonomous" << std::endl;
-
-			// Spin at half speed for two seconds
-			m_robotDrive.ArcadeDrive(0.0, 0.5);
-			frc::Wait(2.0);
-
-			// Stop robot
-			m_robotDrive.ArcadeDrive(0.0, 0.0);
-		} else {
-			// Default Auto goes here
-			std::cout << "Running default Autonomous" << std::endl;
-
-			// Drive forwards at half speed for two seconds
-			m_robotDrive.ArcadeDrive(-0.5, 0.0);
-			frc::Wait(2.0);
-
-			// Stop robot
-			m_robotDrive.ArcadeDrive(0.0, 0.0);
-		}
-	}
-
-	/*
-	 * Runs the motors with arcade steering.
-	 */
-	void OperatorControl() override {
-		m_robotDrive.SetSafetyEnabled(true);
-		while (IsOperatorControl() && IsEnabled()) {
-			// Drive with arcade style (use right stick)
-			m_robotDrive.ArcadeDrive(
-					-m_stick.GetY(), m_stick.GetX());
-
-			// The motors will be updated every 5ms
-			frc::Wait(0.005);
-		}
-	}
-
-	/*
-	 * Runs during test mode
-	 */
-	void Test() override {}
-
-private:
-	// Robot drive system
-	frc::Spark m_leftMotor{0};
-	frc::Spark m_rightMotor{1};
-	frc::DifferentialDrive m_robotDrive{m_leftMotor, m_rightMotor};
-
-	frc::Joystick m_stick{0};
-
-	frc::SendableChooser<std::string> m_chooser;
-	const std::string kAutoNameDefault = "Default";
-	const std::string kAutoNameCustom = "My Auto";
-};
+/**
+ * Runs during test mode
+ */
+void Robot::Test() {}
 
 START_ROBOT_CLASS(Robot)

--- a/wpilibcExamples/src/main/cpp/templates/sample/Robot.h
+++ b/wpilibcExamples/src/main/cpp/templates/sample/Robot.h
@@ -1,0 +1,50 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <string>
+
+#include <Drive/DifferentialDrive.h>
+#include <Joystick.h>
+#include <SampleRobot.h>
+#include <SmartDashboard/SendableChooser.h>
+#include <Spark.h>
+
+/**
+ * This is a demo program showing the use of the DifferentialDrive class.
+ * The SampleRobot class is the base of a robot application that will
+ * automatically call your Autonomous and OperatorControl methods at the right
+ * time as controlled by the switches on the driver station or the field
+ * controls.
+ *
+ * WARNING: While it may look like a good choice to use for your code if you're
+ * inexperienced, don't. Unless you know what you are doing, complex code will
+ * be much more difficult under this system. Use IterativeRobot or Command-Based
+ * instead if you're new.
+ */
+class Robot : public frc::SampleRobot {
+public:
+	Robot();
+
+	void RobotInit() override;
+	void Autonomous() override;
+	void OperatorControl() override;
+	void Test() override;
+
+private:
+	// Robot drive system
+	frc::Spark m_leftMotor{0};
+	frc::Spark m_rightMotor{1};
+	frc::DifferentialDrive m_robotDrive{m_leftMotor, m_rightMotor};
+
+	frc::Joystick m_stick{0};
+
+	frc::SendableChooser<std::string> m_chooser;
+	const std::string kAutoNameDefault = "Default";
+	const std::string kAutoNameCustom = "My Auto";
+};

--- a/wpilibcExamples/src/main/cpp/templates/timed/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/timed/Robot.cpp
@@ -5,68 +5,54 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#include "Robot.h"
+
 #include <iostream>
-#include <string>
 
-#include <LiveWindow/LiveWindow.h>
-#include <SmartDashboard/SendableChooser.h>
 #include <SmartDashboard/SmartDashboard.h>
-#include <TimedRobot.h>
 
-class Robot : public frc::TimedRobot {
-public:
-	void RobotInit() {
-		m_chooser.AddDefault(kAutoNameDefault, kAutoNameDefault);
-		m_chooser.AddObject(kAutoNameCustom, kAutoNameCustom);
-		frc::SmartDashboard::PutData("Auto Modes", &m_chooser);
+void Robot::RobotInit() {
+	m_chooser.AddDefault(kAutoNameDefault, kAutoNameDefault);
+	m_chooser.AddObject(kAutoNameCustom, kAutoNameCustom);
+	frc::SmartDashboard::PutData("Auto Modes", &m_chooser);
+}
+
+/**
+ * This autonomous (along with the chooser code above) shows how to select
+ * between different autonomous modes using the dashboard. The sendable chooser
+ * code works with the Java SmartDashboard. If you prefer the LabVIEW Dashboard,
+ * remove all of the chooser code and uncomment the GetString line to get the
+ * auto name from the text box below the Gyro.
+ *
+ * You can add additional auto modes by adding additional comparisons to the
+ * if-else structure below with additional strings. If using the SendableChooser
+ * make sure to add them to the chooser code above as well.
+ */
+void Robot::AutonomousInit() {
+	m_autoSelected = m_chooser.GetSelected();
+	// m_autoSelected = SmartDashboard::GetString("Auto Selector",
+	//		 kAutoNameDefault);
+	std::cout << "Auto selected: " << m_autoSelected << std::endl;
+
+	if (m_autoSelected == kAutoNameCustom) {
+		// Custom Auto goes here
+	} else {
+		// Default Auto goes here
 	}
+}
 
-	/*
-	 * This autonomous (along with the chooser code above) shows how to
-	 * select between different autonomous modes using the dashboard. The
-	 * sendable chooser code works with the Java SmartDashboard. If you
-	 * prefer the LabVIEW Dashboard, remove all of the chooser code and
-	 * uncomment the GetString line to get the auto name from the text box
-	 * below the Gyro.
-	 *
-	 * You can add additional auto modes by adding additional comparisons to
-	 * the if-else structure below with additional strings. If using the
-	 * SendableChooser make sure to add them to the chooser code above as
-	 * well.
-	 */
-	void AutonomousInit() override {
-		m_autoSelected = m_chooser.GetSelected();
-		// m_autoSelected = SmartDashboard::GetString("Auto Selector",
-		//		 kAutoNameDefault);
-		std::cout << "Auto selected: " << m_autoSelected << std::endl;
-
-		if (m_autoSelected == kAutoNameCustom) {
-			// Custom Auto goes here
-		} else {
-			// Default Auto goes here
-		}
+void Robot::AutonomousPeriodic() {
+	if (m_autoSelected == kAutoNameCustom) {
+		// Custom Auto goes here
+	} else {
+		// Default Auto goes here
 	}
+}
 
-	void AutonomousPeriodic() {
-		if (m_autoSelected == kAutoNameCustom) {
-			// Custom Auto goes here
-		} else {
-			// Default Auto goes here
-		}
-	}
+void Robot::TeleopInit() {}
 
-	void TeleopInit() {}
+void Robot::TeleopPeriodic() {}
 
-	void TeleopPeriodic() {}
-
-	void TestPeriodic() {}
-
-private:
-	frc::LiveWindow& m_lw = *LiveWindow::GetInstance();
-	frc::SendableChooser<std::string> m_chooser;
-	const std::string kAutoNameDefault = "Default";
-	const std::string kAutoNameCustom = "My Auto";
-	std::string m_autoSelected;
-};
+void Robot::TestPeriodic() {}
 
 START_ROBOT_CLASS(Robot)

--- a/wpilibcExamples/src/main/cpp/templates/timed/Robot.h
+++ b/wpilibcExamples/src/main/cpp/templates/timed/Robot.h
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <string>
+
+#include <SmartDashboard/SendableChooser.h>
+#include <TimedRobot.h>
+
+class Robot : public frc::TimedRobot {
+public:
+	void RobotInit() override;
+	void AutonomousInit() override;
+	void AutonomousPeriodic() override;
+	void TeleopInit() override;
+	void TeleopPeriodic() override;
+	void TestPeriodic() override;
+
+private:
+	frc::SendableChooser<std::string> m_chooser;
+	const std::string kAutoNameDefault = "Default";
+	const std::string kAutoNameCustom = "My Auto";
+	std::string m_autoSelected;
+};

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbased/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbased/Robot.java
@@ -23,8 +23,7 @@ import edu.wpi.first.wpilibj.templates.commandbased.subsystems.ExampleSubsystem;
  * project.
  */
 public class Robot extends TimedRobot {
-	public static final ExampleSubsystem kExampleSubsystem
-			= new ExampleSubsystem();
+	public static ExampleSubsystem m_subsystem = new ExampleSubsystem();
 	public static OI m_oi;
 
 	Command m_autonomousCommand;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbased/commands/ExampleCommand.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbased/commands/ExampleCommand.java
@@ -16,7 +16,7 @@ import edu.wpi.first.wpilibj.templates.commandbased.Robot;
 public class ExampleCommand extends Command {
 	public ExampleCommand() {
 		// Use requires() here to declare subsystem dependencies
-		requires(Robot.kExampleSubsystem);
+		requires(Robot.m_subsystem);
 	}
 
 	// Called just before this Command runs the first time


### PR DESCRIPTION
Robot.cpp has been split into header-source pairs and the Command-based
examples now define an example subsystem in the Robot class.