### PR TITLE
Added delta tolerance term to PIDController's SetTolerance()

### DIFF
--- a/wpilibc/src/main/native/cpp/PIDController.cpp
+++ b/wpilibc/src/main/native/cpp/PIDController.cpp
@@ -22,7 +22,7 @@ using namespace frc;
  * @param source The PIDSource object that is used to get values
  * @param output The PIDOutput object that is set to the output value
  * @param period the loop time for doing calculations. This particularly
- *               effects calculations of the integral and differental terms.
+ *               affects calculations of the integral and differental terms.
  *               The default is 50ms.
  */
 PIDController::PIDController(double Kp, double Ki, double Kd, PIDSource* source,
@@ -38,7 +38,7 @@ PIDController::PIDController(double Kp, double Ki, double Kd, PIDSource* source,
  * @param source The PIDSource object that is used to get values
  * @param output The PIDOutput object that is set to the output value
  * @param period the loop time for doing calculations. This particularly
- *               effects calculations of the integral and differental terms.
+ *               affects calculations of the integral and differental terms.
  *               The default is 50ms.
  */
 PIDController::PIDController(double Kp, double Ki, double Kd, double Kf,
@@ -55,7 +55,7 @@ PIDController::PIDController(double Kp, double Ki, double Kd, double Kf,
  * @param source The PIDSource object that is used to get values
  * @param output The PIDOutput object that is set to the output value
  * @param period the loop time for doing calculations. This particularly
- *               effects calculations of the integral and differental terms.
+ *               affects calculations of the integral and differental terms.
  *               The default is 50ms.
  */
 PIDController::PIDController(double Kp, double Ki, double Kd, PIDSource& source,
@@ -71,13 +71,13 @@ PIDController::PIDController(double Kp, double Ki, double Kd, PIDSource& source,
  * @param source The PIDSource object that is used to get values
  * @param output The PIDOutput object that is set to the output value
  * @param period the loop time for doing calculations. This particularly
- *               effects calculations of the integral and differental terms.
+ *               affects calculations of the integral and differental terms.
  *               The default is 50ms.
  */
 PIDController::PIDController(double Kp, double Ki, double Kd, double Kf,
                              PIDSource& source, PIDOutput& output,
                              double period)
-    : PIDBase(Kp, Ki, Kd, Kf, source, output) {
+    : PIDBase(Kp, Ki, Kd, Kf, source, output, period) {
   m_controlLoop = std::make_unique<Notifier>(&PIDController::Calculate, this);
   m_controlLoop->StartPeriodic(period);
 }

--- a/wpilibc/src/main/native/cpp/SynchronousPID.cpp
+++ b/wpilibc/src/main/native/cpp/SynchronousPID.cpp
@@ -17,10 +17,14 @@ using namespace frc;
  * @param Kd     the derivative coefficient
  * @param source The PIDSource object that is used to get values
  * @param output The PIDOutput object that is set to the output percentage
+ * @param period The loop time for doing calculations. This particularly
+ *               affects calculations of the integral and differential terms.
+ *               The default is 50ms.
  */
 SynchronousPID::SynchronousPID(double Kp, double Ki, double Kd,
-                               PIDSource& source, PIDOutput& output)
-    : SynchronousPID(Kp, Ki, Kd, 0.0, source, output) {}
+                               PIDSource& source, PIDOutput& output,
+                               double period)
+    : SynchronousPID(Kp, Ki, Kd, 0.0, source, output, period) {}
 
 /**
  * Allocate a PID object with the given constants for P, I, and D.
@@ -31,10 +35,14 @@ SynchronousPID::SynchronousPID(double Kp, double Ki, double Kd,
  * @param Kf     the feed forward term
  * @param source The PIDSource object that is used to get values
  * @param output The PIDOutput object that is set to the output percentage
+ * @param period The loop time for doing calculations. This particularly
+ *               affects calculations of the integral and differential terms.
+ *               The default is 50ms.
  */
 SynchronousPID::SynchronousPID(double Kp, double Ki, double Kd, double Kf,
-                               PIDSource& source, PIDOutput& output)
-    : PIDBase(Kp, Ki, Kd, Kf, source, output) {
+                               PIDSource& source, PIDOutput& output,
+                               double period)
+    : PIDBase(Kp, Ki, Kd, Kf, source, output, period) {
   m_enabled = true;
 }
 

--- a/wpilibc/src/main/native/include/PIDBase.h
+++ b/wpilibc/src/main/native/include/PIDBase.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <limits>
 #include <memory>
 #include <string>
 
@@ -18,7 +19,6 @@
 #include "PIDInterface.h"
 #include "PIDSource.h"
 #include "SmartDashboard/SendableBase.h"
-#include "Timer.h"
 
 namespace frc {
 
@@ -36,9 +36,10 @@ class PIDOutput;
  */
 class PIDBase : public SendableBase, public PIDInterface {
  public:
-  PIDBase(double p, double i, double d, PIDSource& source, PIDOutput& output);
+  PIDBase(double p, double i, double d, PIDSource& source, PIDOutput& output,
+          double period);
   PIDBase(double p, double i, double d, double f, PIDSource& source,
-          PIDOutput& output);
+          PIDOutput& output, double period);
   ~PIDBase() override = default;
 
   PIDBase(const PIDBase&) = delete;
@@ -64,6 +65,7 @@ class PIDBase : public SendableBase, public PIDInterface {
   double GetDeltaSetpoint() const;
 
   virtual double GetError() const;
+  double GetDeltaError() const;
 
   WPI_DEPRECATED("Use a LinearDigitalFilter as the input and GetError().")
   virtual double GetAvgError() const;
@@ -72,9 +74,15 @@ class PIDBase : public SendableBase, public PIDInterface {
   virtual PIDSourceType GetPIDSourceType() const;
 
   WPI_DEPRECATED("Use SetPercentTolerance() instead.")
-  virtual void SetTolerance(double percent);
-  virtual void SetAbsoluteTolerance(double absValue);
-  virtual void SetPercentTolerance(double percentValue);
+  virtual void SetTolerance(
+      double tolerance,
+      double deltaTolerance = std::numeric_limits<double>::infinity());
+  virtual void SetAbsoluteTolerance(
+      double tolerance,
+      double deltaTolerance = std::numeric_limits<double>::infinity());
+  virtual void SetPercentTolerance(
+      double tolerance,
+      double deltaTolerance = std::numeric_limits<double>::infinity());
 
   WPI_DEPRECATED("Use a LinearDigitalFilter as the input.")
   virtual void SetToleranceBuffer(int buf = 1);
@@ -97,7 +105,7 @@ class PIDBase : public SendableBase, public PIDInterface {
 
   PIDSource* m_pidInput;
   PIDOutput* m_pidOutput;
-  Timer m_setpointTimer;
+  double m_period;
 
   virtual void Calculate();
   virtual double CalculateFeedForward();
@@ -148,6 +156,7 @@ class PIDBase : public SendableBase, public PIDInterface {
 
   // The percetage or absolute error that is considered on target.
   double m_tolerance = 0.05;
+  double m_deltaTolerance = std::numeric_limits<double>::infinity();
 
   double m_setpoint = 0;
   double m_prevSetpoint = 0;

--- a/wpilibc/src/main/native/include/SynchronousPID.h
+++ b/wpilibc/src/main/native/include/SynchronousPID.h
@@ -20,9 +20,9 @@ namespace frc {
 class SynchronousPID : public PIDBase {
  public:
   SynchronousPID(double Kp, double Ki, double Kd, PIDSource& source,
-                 PIDOutput& output);
+                 PIDOutput& output, double period = 0.05);
   SynchronousPID(double Kp, double Ki, double Kd, double Kf, PIDSource& source,
-                 PIDOutput& output);
+                 PIDOutput& output, double period = 0.05);
 
   SynchronousPID(const SynchronousPID&) = delete;
   SynchronousPID& operator=(const SynchronousPID) = delete;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDController.java
@@ -31,13 +31,13 @@ public class PIDController extends PIDBase implements Controller {
    * @param Kf     the feed forward term
    * @param source The PIDSource object that is used to get values
    * @param output The PIDOutput object that is set to the output percentage
-   * @param period the loop time for doing calculations. This particularly effects calculations of
+   * @param period The loop time for doing calculations. This particularly affects calculations of
    *               the integral and differential terms. The default is 50ms.
    */
   @SuppressWarnings("ParameterName")
   public PIDController(double Kp, double Ki, double Kd, double Kf, PIDSource source,
                        PIDOutput output, double period) {
-    super(Kp, Ki, Kd, Kf, source, output);
+    super(Kp, Ki, Kd, Kf, source, output, period);
     m_controlLoop.startPeriodic(period);
   }
 
@@ -49,7 +49,7 @@ public class PIDController extends PIDBase implements Controller {
    * @param Kd     the derivative coefficient
    * @param source the PIDSource object that is used to get values
    * @param output the PIDOutput object that is set to the output percentage
-   * @param period the loop time for doing calculations. This particularly effects calculations of
+   * @param period The loop time for doing calculations. This particularly affects calculations of
    *               the integral and differential terms. The default is 50ms.
    */
   @SuppressWarnings("ParameterName")

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SynchronousPID.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SynchronousPID.java
@@ -21,10 +21,13 @@ public class SynchronousPID extends PIDBase {
    * @param Kd     the derivative coefficient
    * @param source The PIDSource object that is used to get values
    * @param output The PIDOutput object that is set to the output percentage
+   * @param period The loop time for doing calculations. This particularly affects calculations of
+   *               the integral and differential terms. The default is 50ms.
    */
   @SuppressWarnings("ParameterName")
-  public SynchronousPID(double Kp, double Ki, double Kd, PIDSource source, PIDOutput output) {
-    this(Kp, Ki, Kd, 0.0, source, output);
+  public SynchronousPID(double Kp, double Ki, double Kd, PIDSource source, PIDOutput output,
+                        double period) {
+    this(Kp, Ki, Kd, 0.0, source, output, period);
   }
 
   /**
@@ -36,11 +39,13 @@ public class SynchronousPID extends PIDBase {
    * @param Kf     the feed forward term
    * @param source The PIDSource object that is used to get values
    * @param output The PIDOutput object that is set to the output percentage
+   * @param period The loop time for doing calculations. This particularly affects calculations of
+   *               the integral and differential terms. The default is 50ms.
    */
   @SuppressWarnings("ParameterName")
   public SynchronousPID(double Kp, double Ki, double Kd, double Kf, PIDSource source,
-                        PIDOutput output) {
-    super(Kp, Ki, Kd, Kf, source, output);
+                        PIDOutput output, double period) {
+    super(Kp, Ki, Kd, Kf, source, output, period);
 
     m_enabled = true;
   }


### PR DESCRIPTION
PIDController returns true from OnTarget() when the output is passing through
the reference, not only when the output has settled. To compensate for this,
teams have been using the tolerance buffer to lag the OnTarget() calculation
until the oscillations have settled. This is obviously not the intended use for
the tolerance buffer.

This patch adds a defaulted argument to SetTolerance() for the change in error
between samples. This delta tolerance term ensures the controller is not
considered to be at the reference when oscillating around it at large
frequencies.