### PR TITLE
Added output normalization to DifferentialDrive::CurvatureDrive()

### DIFF
--- a/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp
+++ b/wpilibc/src/main/native/cpp/Drive/DifferentialDrive.cpp
@@ -7,6 +7,7 @@
 
 #include "Drive/DifferentialDrive.h"
 
+#include <algorithm>
 #include <cmath>
 
 #include <HAL/HAL.h>
@@ -169,6 +170,14 @@ void DifferentialDrive::CurvatureDrive(double xSpeed, double zRotation,
       leftMotorOutput -= rightMotorOutput + 1.0;
       rightMotorOutput = -1.0;
     }
+  }
+
+  // Normalize the wheel speeds
+  double maxMagnitude =
+      std::max(std::abs(leftMotorOutput), std::abs(rightMotorOutput));
+  if (maxMagnitude > 1.0) {
+    leftMotorOutput /= maxMagnitude;
+    rightMotorOutput /= maxMagnitude;
   }
 
   m_leftMotor.Set(leftMotorOutput * m_maxOutput);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -261,6 +261,13 @@ public class DifferentialDrive extends RobotDriveBase {
       }
     }
 
+    // Normalize the wheel speeds
+    double maxMagnitude = Math.max(Math.abs(leftMotorOutput), Math.abs(rightMotorOutput));
+    if (maxMagnitude > 1.0) {
+      leftMotorOutput /= maxMagnitude;
+      rightMotorOutput /= maxMagnitude;
+    }
+
     m_leftMotor.set(leftMotorOutput * m_maxOutput);
     m_rightMotor.set(-rightMotorOutput * m_maxOutput);
 


### PR DESCRIPTION
This normalizes within -1..1 to avoid clipping and maintain the ratio between
wheel speeds, since that ratio determines the center of rotation.

Fixes #923.