### PR TITLE
Add tip about writeBulk() to transaction()

### DIFF
--- a/wpilibc/src/main/native/cpp/I2C.cpp
+++ b/wpilibc/src/main/native/cpp/I2C.cpp
@@ -38,7 +38,9 @@ I2C::~I2C() { HAL_CloseI2C(m_port); }
  * Generic transaction.
  *
  * This is a lower-level interface to the I2C hardware giving you more control
- * over each transaction.
+ * over each transaction. If you intend to write multiple bytes in the same
+ * transaction and do not plan to receive anything back, use writeBulk()
+ * instead. Calling this with a receiveSize of 0 will result in an error.
  *
  * @param dataToSend   Buffer of data to send as part of the transaction.
  * @param sendSize     Number of bytes to send as part of the transaction.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/I2C.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/I2C.java
@@ -63,7 +63,9 @@ public class I2C {
    * Generic transaction.
    *
    * <p>This is a lower-level interface to the I2C hardware giving you more control over each
-   * transaction.
+   * transaction. If you intend to write multiple bytes in the same transaction and do not
+   * plan to receive anything back, use writeBulk() instead. Calling this with a receiveSize
+   * of 0 will result in an error.
    *
    * @param dataToSend   Buffer of data to send as part of the transaction.
    * @param sendSize     Number of bytes to send as part of the transaction.


### PR DESCRIPTION
My team uses RobotPy.  A few days ago, we tried communicating with an Arduino over I2C.  It worked, but our code exited with an error every time we called `transaction()`. I opened [an issue](https://github.com/robotpy/robotpy-wpilib/issues/438) in the RobotPy repository, and with the help of @auscompgeek and @virtuald, I finally realized this was because we always called `transaction()` with a receiveSize of 0.  Now that I've had time to think about it more, this behavior makes sense as reading 0 bytes doesn't really work; but it could potentially be a frusterating pitfall for other teams.  I've updated the documentation to make this behavior more clear, and to suggest using `writeBulk()` instead if you want to send multiple bytes in the same transaction without receiving anything back.