### PR TITLE
[WIP] Add toggleBetweenWhenActive to Trigger

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/Button.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/Button.java
@@ -60,6 +60,17 @@ public abstract class Button extends Trigger {
   }
 
   /**
+   * Toggles between two commands whenever the button is pressed (i.e. starts the first command
+   * and cancels the second, then cancels the first and starts the second).
+   *
+   * @param commandOne the first command
+   * @param commandTwo the second command
+   */
+  public void toggleBetweenWhenPressed(final Command commandOne, final Command commandTwo) {
+    toggleBetweenWhenActive(commandOne, commandTwo);
+  }
+
+  /**
    * Cancel the command when the button is pressed.
    *
    * @param command the command to start

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/Trigger.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/Trigger.java
@@ -150,6 +150,37 @@ public abstract class Trigger extends SendableBase {
   }
 
   /**
+   * Toggles between two commands when the trigger becomes active.
+   *
+   * @param commandOne the first command to toggle between
+   * @param commandTwo the second command to toggle between
+   */
+  public void toggleBetweenWhenActive(final Command commandOne, final Command commandTwo) {
+    new ButtonScheduler() {
+
+    private boolean m_pressedLast = grab();
+
+      @Override
+      public void execute() {
+        if (grab()) {
+          if (!m_pressedLast) {
+            m_pressedLast = true;
+            if (commandOne.isRunning()) {
+              commandOne.cancel();
+              commandTwo.start();
+            } else { // either Two is running, or neither are running (initial press)
+              commandOne.start();
+              commandTwo.cancel();
+            }
+          }
+        } else {
+          m_pressedLast = false;
+        }
+      }
+    }.start();
+  }
+
+  /**
    * Cancels a command when the trigger becomes active.
    *
    * @param command the command to cancel


### PR DESCRIPTION
Oftentimes, it is useful for teams to be able to toggle between two states on a subsystem. This is currently *partially* possible via `toggleWhenActive()`. For example, it works well in situations like:

```
toggleWhenActive(new SetIntakeCommand(0.8)) // set intake to 80% power
...
setDefaultCommand(new SetIntakeCommand(0)) // set intake to 0% power
```

...where there is a default command set in the subsystem which sets the subsystem back to a different state. However, it doesn't really allow toggling *between* two different states (that aren't the defaults), and I've noticed some teams having to write boilerplate Commands which store a state and simply toggle between two different commands (such as setting a Solenoid state or switching a motor from forward to reverse, where there isn't really a clear "default"). 

This PR aims to fix that by adding a method to both Trigger and Button to handle this for them, e.g.:

```
toggleBetweenWhenActive(new SetIntakeCommand(0.5), new SetIntakeCommand(-0.5))
```

Right now, this is only the Java implementation - if we think it's worthwihle I'll add it to C++ too.