### PR TITLE
Adding null check around reset

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.java
@@ -80,6 +80,10 @@ public class ADXRS450_Gyro extends GyroBase implements Gyro, PIDSource, Sendable
     setName("ADXRS450_Gyro", port.value);
   }
 
+  public boolean isConnected() {
+    return m_spi != null;
+  }
+
   @Override
   public void calibrate() {
     if (m_spi == null) {
@@ -128,7 +132,9 @@ public class ADXRS450_Gyro extends GyroBase implements Gyro, PIDSource, Sendable
 
   @Override
   public void reset() {
-    m_spi.resetAccumulator();
+    if (m_spi != null) {
+      m_spi.resetAccumulator();
+    }
   }
 
   /**


### PR DESCRIPTION
```Reset()``` is the only function without a null check around it.  We call the function on startup, which means if it is unplugged the robot crashes.  I noticed null'ing it out is not what is done in C++, don't know why they are different.

Also added an accessor for checking if it is connected, as some teams (us) would like to handle the case where it was not connected on startup.