### PR TITLE
SendableChooser: Do not automatically add to LiveWindow.

### DIFF
--- a/wpilibc/src/main/native/cpp/SmartDashboard/SendableChooserBase.cpp
+++ b/wpilibc/src/main/native/cpp/SmartDashboard/SendableChooserBase.cpp
@@ -12,3 +12,8 @@ using namespace frc;
 const char* SendableChooserBase::kDefault = "default";
 const char* SendableChooserBase::kOptions = "options";
 const char* SendableChooserBase::kSelected = "selected";
+
+/**
+ * Instantiates a SendableChooser.
+ */
+SendableChooserBase::SendableChooserBase() : SendableBase(false) {}

--- a/wpilibc/src/main/native/include/SmartDashboard/SendableChooserBase.h
+++ b/wpilibc/src/main/native/include/SmartDashboard/SendableChooserBase.h
@@ -23,6 +23,7 @@ namespace frc {
  */
 class SendableChooserBase : public SendableBase {
  public:
+  SendableChooserBase();
   ~SendableChooserBase() override = default;
 
  protected:

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
@@ -51,6 +51,7 @@ public class SendableChooser<V> extends SendableBase implements Sendable {
    * Instantiates a {@link SendableChooser}.
    */
   public SendableChooser() {
+    super(false);
   }
 
   /**


### PR DESCRIPTION
SendableChooser::InitSendable() is written such that it saves the table
being used in an instance variable.  This doesn't work if the chooser is
added to both LiveWindow and SmartDashboard.  Normally it is not added to
LiveWindow because the name is empty, but if setName() is called this could
still happen.  Note adding the same SendableChooser to SmartDashboard with
two different names is also not currently supported, for the same reason.

The correct solution will be to remove the instance variable, but this is
too high risk to implement mid-season, so instead just remove from LiveWindow.