### PR TITLE
Fixed wpilibj GenericHID.getType()

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
@@ -8,6 +8,8 @@
 package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.wpilibj.hal.HAL;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * GenericHID Interface.
@@ -41,9 +43,20 @@ public abstract class GenericHID {
 
     @SuppressWarnings("MemberName")
     public final int value;
+    private static final Map<Integer, HIDType> map = new HashMap<>();
 
     HIDType(int value) {
       this.value = value;
+    }
+
+    static {
+      for (HIDType hidType : HIDType.values()) {
+        map.put(hidType.value, hidType);
+      }
+    }
+
+    public static HIDType of(int value) {
+      return (HIDType) map.get(value);
     }
   }
 
@@ -197,7 +210,7 @@ public abstract class GenericHID {
    * @return the type of the HID.
    */
   public HIDType getType() {
-    return HIDType.values()[m_ds.getJoystickType(m_port)];
+    return HIDType.of(m_ds.getJoystickType(m_port));
   }
 
   /**


### PR DESCRIPTION
It was using array indexing to map the return value of
DriverStation.getJoystickType() to HIDType when the enum should instead be
constructed from the int value. C++ already does this.

Fixes #968.