### PR TITLE
Default to requiring frc namespace for wpilibc.

### DIFF
--- a/wpilibc/src/main/native/include/Base.h
+++ b/wpilibc/src/main/native/include/Base.h
@@ -52,6 +52,6 @@ struct HasBeenMoved {
 }  // namespace frc
 
 // For backwards compatibility
-#ifndef NAMESPACED_WPILIB
+#ifdef NO_NAMESPACED_WPILIB
 using namespace frc;  // NOLINT
 #endif

--- a/wpilibcExamples/src/main/cpp/examples/AxisCameraSample/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/AxisCameraSample/cpp/Robot.cpp
@@ -22,15 +22,15 @@ class Robot : public frc::IterativeRobot {
   static void VisionThread() {
     // Get the Axis camera from CameraServer
     cs::AxisCamera camera =
-        CameraServer::GetInstance()->AddAxisCamera("axis-camera.local");
+        frc::CameraServer::GetInstance()->AddAxisCamera("axis-camera.local");
     // Set the resolution
     camera.SetResolution(640, 480);
 
     // Get a CvSink. This will capture Mats from the Camera
-    cs::CvSink cvSink = CameraServer::GetInstance()->GetVideo();
+    cs::CvSink cvSink = frc::CameraServer::GetInstance()->GetVideo();
     // Setup a CvSource. This will send images back to the Dashboard
     cs::CvSource outputStream =
-        CameraServer::GetInstance()->PutVideo("Rectangle", 640, 480);
+        frc::CameraServer::GetInstance()->PutVideo("Rectangle", 640, 480);
 
     // Mats are very memory expensive. Lets reuse this Mat.
     cv::Mat mat;

--- a/wpilibcExamples/src/main/cpp/examples/Encoder/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Encoder/cpp/Robot.cpp
@@ -77,7 +77,7 @@ class Robot : public frc::IterativeRobot {
    * and defaults to k4X. Faster (k4X) encoding gives greater positional
    * precision but more noise in the rate.
    */
-  frc::Encoder m_encoder{1, 2, false, Encoder::k4X};
+  frc::Encoder m_encoder{1, 2, false, frc::Encoder::k4X};
 };
 
 int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/Subsystems/Wrist.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/Subsystems/Wrist.h
@@ -15,7 +15,7 @@
  * The wrist subsystem is like the elevator, but with a rotational joint instead
  * of a linear joint.
  */
-class Wrist : public PIDSubsystem {
+class Wrist : public frc::PIDSubsystem {
  public:
   Wrist();
 

--- a/wpilibcExamples/src/main/cpp/examples/IntermediateVision/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/IntermediateVision/cpp/Robot.cpp
@@ -26,15 +26,16 @@ class Robot : public frc::IterativeRobot {
  private:
   static void VisionThread() {
     // Get the USB camera from CameraServer
-    cs::UsbCamera camera = CameraServer::GetInstance()->StartAutomaticCapture();
+    cs::UsbCamera camera =
+        frc::CameraServer::GetInstance()->StartAutomaticCapture();
     // Set the resolution
     camera.SetResolution(640, 480);
 
     // Get a CvSink. This will capture Mats from the Camera
-    cs::CvSink cvSink = CameraServer::GetInstance()->GetVideo();
+    cs::CvSink cvSink = frc::CameraServer::GetInstance()->GetVideo();
     // Setup a CvSource. This will send images back to the Dashboard
     cs::CvSource outputStream =
-        CameraServer::GetInstance()->PutVideo("Rectangle", 640, 480);
+        frc::CameraServer::GetInstance()->PutVideo("Rectangle", 640, 480);
 
     // Mats are very memory expensive. Lets reuse this Mat.
     cv::Mat mat;

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/Subsystems/DriveTrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/Subsystems/DriveTrain.cpp
@@ -28,8 +28,8 @@ DriveTrain::DriveTrain() : frc::Subsystem("DriveTrain") {
   m_rightCIMs.SetInverted(true);
 
   // Configure encoders
-  m_rightEncoder.SetPIDSourceType(PIDSourceType::kDisplacement);
-  m_leftEncoder.SetPIDSourceType(PIDSourceType::kDisplacement);
+  m_rightEncoder.SetPIDSourceType(frc::PIDSourceType::kDisplacement);
+  m_leftEncoder.SetPIDSourceType(frc::PIDSourceType::kDisplacement);
 
 #ifndef SIMULATION
   // Converts to feet
@@ -63,8 +63,8 @@ void DriveTrain::TankDrive(double leftAxis, double rightAxis) {
 
 void DriveTrain::Stop() { m_robotDrive.TankDrive(0.0, 0.0); }
 
-Encoder& DriveTrain::GetLeftEncoder() { return m_leftEncoder; }
+frc::Encoder& DriveTrain::GetLeftEncoder() { return m_leftEncoder; }
 
-Encoder& DriveTrain::GetRightEncoder() { return m_rightEncoder; }
+frc::Encoder& DriveTrain::GetRightEncoder() { return m_rightEncoder; }
 
 double DriveTrain::GetAngle() { return m_gyro.GetAngle(); }

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/include/Robot.h
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/include/Robot.h
@@ -20,7 +20,7 @@
 #include "Subsystems/Pneumatics.h"
 #include "Subsystems/Shooter.h"
 
-class Robot : public IterativeRobot {
+class Robot : public frc::IterativeRobot {
  public:
   static DriveTrain drivetrain;
   static Pivot pivot;
@@ -33,7 +33,7 @@ class Robot : public IterativeRobot {
   frc::Command* m_autonomousCommand = nullptr;
   DriveAndShootAutonomous m_driveAndShootAuto;
   DriveForward m_driveForwardAuto;
-  SendableChooser<frc::Command*> m_autoChooser;
+  frc::SendableChooser<frc::Command*> m_autoChooser;
 
   void RobotInit() override;
   void AutonomousInit() override;

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/include/Subsystems/DriveTrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/include/Subsystems/DriveTrain.h
@@ -48,13 +48,13 @@ class DriveTrain : public frc::Subsystem {
    * @return The encoder getting the distance and speed of left side of
    * the drivetrain.
    */
-  Encoder& GetLeftEncoder();
+  frc::Encoder& GetLeftEncoder();
 
   /**
    * @return The encoder getting the distance and speed of right side of
    * the drivetrain.
    */
-  Encoder& GetRightEncoder();
+  frc::Encoder& GetRightEncoder();
 
   /**
    * @return The current angle of the drivetrain.
@@ -73,7 +73,7 @@ class DriveTrain : public frc::Subsystem {
 
   frc::DifferentialDrive m_robotDrive{m_leftCIMs, m_rightCIMs};
 
-  frc::Encoder m_rightEncoder{1, 2, true, Encoder::k4X};
-  frc::Encoder m_leftEncoder{3, 4, false, Encoder::k4X};
+  frc::Encoder m_rightEncoder{1, 2, true, frc::Encoder::k4X};
+  frc::Encoder m_leftEncoder{3, 4, false, frc::Encoder::k4X};
   frc::AnalogGyro m_gyro{0};
 };

--- a/wpilibcExamples/src/main/cpp/examples/QuickVision/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/QuickVision/cpp/Robot.cpp
@@ -19,7 +19,7 @@ class Robot : public frc::IterativeRobot {
  public:
   void RobotInit() override {
 #if defined(__linux__)
-    CameraServer::GetInstance()->StartAutomaticCapture();
+    frc::CameraServer::GetInstance()->StartAutomaticCapture();
 #else
     wpi::errs() << "Vision only available on Linux.\n";
     wpi::errs().flush();

--- a/wpilibcExamples/src/main/cpp/examples/Relay/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Relay/cpp/Robot.cpp
@@ -37,13 +37,13 @@ class Robot : public frc::IterativeRobot {
      * kReverse sets reverse to 12V and forward to 0V.
      */
     if (forward && reverse) {
-      m_relay.Set(Relay::kOn);
+      m_relay.Set(frc::Relay::kOn);
     } else if (forward) {
-      m_relay.Set(Relay::kForward);
+      m_relay.Set(frc::Relay::kForward);
     } else if (reverse) {
-      m_relay.Set(Relay::kReverse);
+      m_relay.Set(frc::Relay::kReverse);
     } else {
-      m_relay.Set(Relay::kOff);
+      m_relay.Set(frc::Relay::kOff);
     }
   }
 


### PR DESCRIPTION
Instead of defining NAMESPACED_WPILIB to remove the "using namespace frc"
shim in Base.h, instead require NO_NAMESPACED_WPILIB be defined to add it.

Fix up various examples to use correct namespacing.