### PR TITLE
PIDController now supports composition

### DIFF
--- a/wpilibc/src/main/native/cpp/PIDBase.cpp
+++ b/wpilibc/src/main/native/cpp/PIDBase.cpp
@@ -528,6 +528,18 @@ void PIDBase::Reset() {
   m_result = 0;
 }
 
+/**
+ * Passes the output directly to SetSetpoint().
+ *
+ * PIDControllers can be nested by passing a PIDController as another
+ * PIDController's output. In that case, the output of the parent controller
+ * becomes the input (i.e., the reference) of the child.
+ *
+ * It is the caller's responsibility to put the data into a valid form for
+ * SetSetpoint().
+ */
+void PIDBase::PIDWrite(double output) { SetSetpoint(output); }
+
 void PIDBase::InitSendable(SendableBuilder& builder) {
   builder.SetSmartDashboardType("PIDBase");
   builder.SetSafeState([=]() { Reset(); });

--- a/wpilibc/src/main/native/include/PIDBase.h
+++ b/wpilibc/src/main/native/include/PIDBase.h
@@ -16,13 +16,12 @@
 #include "Base.h"
 #include "Filters/LinearDigitalFilter.h"
 #include "PIDInterface.h"
+#include "PIDOutput.h"
 #include "PIDSource.h"
 #include "SmartDashboard/SendableBase.h"
 #include "Timer.h"
 
 namespace frc {
-
-class PIDOutput;
 
 /**
  * Class implements a PID Control Loop.
@@ -34,7 +33,7 @@ class PIDOutput;
  * in the integral and derivative calculations. Therefore, the sample rate
  * affects the controller's behavior for a given set of PID constants.
  */
-class PIDBase : public SendableBase, public PIDInterface {
+class PIDBase : public SendableBase, public PIDInterface, public PIDOutput {
  public:
   PIDBase(double p, double i, double d, PIDSource& source, PIDOutput& output);
   PIDBase(double p, double i, double d, double f, PIDSource& source,
@@ -82,6 +81,8 @@ class PIDBase : public SendableBase, public PIDInterface {
   virtual bool OnTarget() const;
 
   void Reset() override;
+
+  void PIDWrite(double output) override;
 
   void InitSendable(SendableBuilder& builder) override;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
  * and derivative calculations. Therefore, the sample rate affects the controller's behavior for a
  * given set of PID constants.
  */
-public class PIDBase extends SendableBase implements PIDInterface {
+public class PIDBase extends SendableBase implements PIDInterface, PIDOutput {
   public static final double kDefaultPeriod = 0.05;
   private static int instances = 0;
 
@@ -763,6 +763,20 @@ public class PIDBase extends SendableBase implements PIDInterface {
     } finally {
       m_thisMutex.unlock();
     }
+  }
+
+  /**
+   * Passes the output directly to setSetpoint().
+   *
+   * <p>PIDControllers can be nested by passing a PIDController as another PIDController's output.
+   * In that case, the output of the parent controller becomes the input (i.e., the reference) of
+   * the child.
+   *
+   * <p>It is the caller's responsibility to put the data into a valid form for setSetpoint().
+   */
+  @Override
+  public void pidWrite(double output) {
+    setSetpoint(output);
   }
 
   @Override


### PR DESCRIPTION
For example, an outer position feedback controller can now drive the
reference of an inner velocity feedback controller.