### PR TITLE
PIDController now supports Kv and Ka feedforward terms

### DIFF
--- a/wpilibc/src/main/native/include/PIDBase.h
+++ b/wpilibc/src/main/native/include/PIDBase.h
@@ -36,9 +36,12 @@ class PIDOutput;
  */
 class PIDBase : public SendableBase, public PIDInterface {
  public:
-  PIDBase(double p, double i, double d, PIDSource& source, PIDOutput& output);
-  PIDBase(double p, double i, double d, double f, PIDSource& source,
+  PIDBase(double Kp, double Ki, double Kd, PIDSource& source,
           PIDOutput& output);
+  PIDBase(double Kp, double Ki, double Kd, double Kv, PIDSource& source,
+          PIDOutput& output);
+  PIDBase(double Kp, double Ki, double Kd, double Kv, double Ka,
+          PIDSource& source, PIDOutput& output);
   ~PIDBase() override = default;
 
   PIDBase(const PIDBase&) = delete;
@@ -48,16 +51,18 @@ class PIDBase : public SendableBase, public PIDInterface {
   virtual void SetContinuous(bool continuous = true);
   virtual void SetInputRange(double minimumInput, double maximumInput);
   virtual void SetOutputRange(double minimumOutput, double maximumOutput);
-  void SetPID(double p, double i, double d) override;
-  virtual void SetPID(double p, double i, double d, double f);
-  void SetP(double p);
-  void SetI(double i);
-  void SetD(double d);
-  void SetF(double f);
+  void SetPID(double Kp, double Ki, double Kd) override;
+  void SetPID(double Kp, double Ki, double Kd, double Kv, double Ka = 0.0);
+  void SetP(double Kp);
+  void SetI(double Ki);
+  void SetD(double Kd);
+  void SetV(double Kv);
+  void SetA(double Ka);
   double GetP() const override;
   double GetI() const override;
   double GetD() const override;
-  virtual double GetF() const;
+  virtual double GetV() const;
+  virtual double GetA() const;
 
   void SetSetpoint(double setpoint) override;
   double GetSetpoint() const override;
@@ -97,6 +102,8 @@ class PIDBase : public SendableBase, public PIDInterface {
 
   PIDSource* m_pidInput;
   PIDOutput* m_pidOutput;
+  double m_prevSetpoint = 0;
+  double m_prevDeltaSetpoint = 0;
   Timer m_setpointTimer;
 
   virtual void Calculate();
@@ -113,8 +120,11 @@ class PIDBase : public SendableBase, public PIDInterface {
   // Factor for "derivative" control
   double m_D;
 
-  // Factor for "feed forward" control
-  double m_F;
+  // Factor for "velocity feedforward" control
+  double m_V;
+
+  // Factor for "acceleration feedforward" control
+  double m_A;
 
   // |maximum output|
   double m_maximumOutput = 1.0;
@@ -150,7 +160,6 @@ class PIDBase : public SendableBase, public PIDInterface {
   double m_tolerance = 0.05;
 
   double m_setpoint = 0;
-  double m_prevSetpoint = 0;
   double m_error = 0;
   double m_result = 0;
 

--- a/wpilibc/src/main/native/include/PIDController.h
+++ b/wpilibc/src/main/native/include/PIDController.h
@@ -37,14 +37,18 @@ class PIDOutput;
  */
 class PIDController : public PIDBase, public Controller {
  public:
-  PIDController(double p, double i, double d, PIDSource* source,
+  PIDController(double Kp, double Ki, double Kd, PIDSource* source,
                 PIDOutput* output, double period = 0.05);
-  PIDController(double p, double i, double d, double f, PIDSource* source,
+  PIDController(double Kp, double Ki, double Kd, double Kv, PIDSource* source,
                 PIDOutput* output, double period = 0.05);
-  PIDController(double p, double i, double d, PIDSource& source,
+  PIDController(double Kp, double Ki, double Kd, double Kv, double Ka,
+                PIDSource* source, PIDOutput* output, double period = 0.05);
+  PIDController(double Kp, double Ki, double Kd, PIDSource& source,
                 PIDOutput& output, double period = 0.05);
-  PIDController(double p, double i, double d, double f, PIDSource& source,
+  PIDController(double Kp, double Ki, double Kd, double Kv, PIDSource& source,
                 PIDOutput& output, double period = 0.05);
+  PIDController(double Kp, double Ki, double Kd, double Kv, double Ka,
+                PIDSource& source, PIDOutput& output, double period = 0.05);
   ~PIDController() override;
 
   PIDController(const PIDController&) = delete;
@@ -55,12 +59,15 @@ class PIDController : public PIDBase, public Controller {
   void SetEnabled(bool enable);
   bool IsEnabled() const;
 
+  double CalculateFeedForward() override;
+
   void Reset() override;
 
   void InitSendable(SendableBuilder& builder) override;
 
  private:
   std::unique_ptr<Notifier> m_controlLoop;
+  double m_period;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/PIDInterface.h
+++ b/wpilibc/src/main/native/include/PIDInterface.h
@@ -10,7 +10,7 @@
 namespace frc {
 
 class PIDInterface {
-  virtual void SetPID(double p, double i, double d) = 0;
+  virtual void SetPID(double Kp, double Ki, double Kd) = 0;
   virtual double GetP() const = 0;
   virtual double GetI() const = 0;
   virtual double GetD() const = 0;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDController.java
@@ -20,29 +20,49 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
  * given set of PID constants.
  */
 public class PIDController extends PIDBase implements Controller {
-  Notifier m_controlLoop = new Notifier(this::calculate);
+  private Notifier m_controlLoop = new Notifier(this::calculate);
+  private double m_period;
 
   /**
-   * Allocate a PID object with the given constants for P, I, D, and F.
+   * Allocate a PID object with the given constants for Kp, Ki, Kd, and Kv.
    *
    * @param Kp     the proportional coefficient
    * @param Ki     the integral coefficient
    * @param Kd     the derivative coefficient
-   * @param Kf     the feed forward term
+   * @param Kv     the velocity feedforward term
    * @param source The PIDSource object that is used to get values
    * @param output The PIDOutput object that is set to the output percentage
    * @param period the loop time for doing calculations. This particularly effects calculations of
    *               the integral and differential terms. The default is 50ms.
    */
   @SuppressWarnings("ParameterName")
-  public PIDController(double Kp, double Ki, double Kd, double Kf, PIDSource source,
+  public PIDController(double Kp, double Ki, double Kd, double Kv, PIDSource source,
                        PIDOutput output, double period) {
-    super(Kp, Ki, Kd, Kf, source, output);
+    this(Kp, Ki, Kd, Kv, 0.0, source, output, period);
+  }
+
+  /**
+   * Allocate a PID object with the given constants for Kp, Ki, Kd, Kv, and Ka.
+   *
+   * @param Kp     the proportional coefficient
+   * @param Ki     the integral coefficient
+   * @param Kd     the derivative coefficient
+   * @param Kv     the velocity feedforward term
+   * @param Ka     the acceleration feedforward term
+   * @param source The PIDSource object that is used to get values
+   * @param output The PIDOutput object that is set to the output percentage
+   * @param period the loop time for doing calculations. This particularly effects calculations of
+   *               the integral and differential terms. The default is 50ms.
+   */
+  @SuppressWarnings("ParameterName")
+  public PIDController(double Kp, double Ki, double Kd, double Kv, double Ka, PIDSource source,
+                       PIDOutput output, double period) {
+    super(Kp, Ki, Kd, Kv, Ka, source, output);
     m_controlLoop.startPeriodic(period);
   }
 
   /**
-   * Allocate a PID object with the given constants for P, I, D and period.
+   * Allocate a PID object with the given constants for Kp, Ki, Kd, and period.
    *
    * @param Kp     the proportional coefficient
    * @param Ki     the integral coefficient
@@ -55,11 +75,11 @@ public class PIDController extends PIDBase implements Controller {
   @SuppressWarnings("ParameterName")
   public PIDController(double Kp, double Ki, double Kd, PIDSource source, PIDOutput output,
                        double period) {
-    this(Kp, Ki, Kd, 0.0, source, output, period);
+    this(Kp, Ki, Kd, 0.0, 0.0, source, output, period);
   }
 
   /**
-   * Allocate a PID object with the given constants for P, I, D, using a 50ms period.
+   * Allocate a PID object with the given constants for Kp, Ki, and Kd using a 50ms period.
    *
    * @param Kp     the proportional coefficient
    * @param Ki     the integral coefficient
@@ -73,19 +93,36 @@ public class PIDController extends PIDBase implements Controller {
   }
 
   /**
-   * Allocate a PID object with the given constants for P, I, D, using a 50ms period.
+   * Allocate a PID object with the given constants for Kp, Ki, Kd, and Kv using a 50ms period.
    *
    * @param Kp     the proportional coefficient
    * @param Ki     the integral coefficient
    * @param Kd     the derivative coefficient
-   * @param Kf     the feed forward term
+   * @param Kv     the velocity feedforward term
    * @param source The PIDSource object that is used to get values
    * @param output The PIDOutput object that is set to the output percentage
    */
   @SuppressWarnings("ParameterName")
-  public PIDController(double Kp, double Ki, double Kd, double Kf, PIDSource source,
+  public PIDController(double Kp, double Ki, double Kd, double Kv, PIDSource source,
                        PIDOutput output) {
-    this(Kp, Ki, Kd, Kf, source, output, kDefaultPeriod);
+    this(Kp, Ki, Kd, Kv, source, output, kDefaultPeriod);
+  }
+
+  /**
+   * Allocate a PID object with the given constants for Kp, Ki, Ki, Kv, and Ka using a 50ms period.
+   *
+   * @param Kp     the proportional coefficient
+   * @param Ki     the integral coefficient
+   * @param Kd     the derivative coefficient
+   * @param Kv     the velocity feedforward term
+   * @param Ka     the acceleration feedforward term
+   * @param source The PIDSource object that is used to get values
+   * @param output The PIDOutput object that is set to the output percentage
+   */
+  @SuppressWarnings("ParameterName")
+  public PIDController(double Kp, double Ki, double Kd, double Kv, double Ka, PIDSource source,
+                       PIDOutput output) {
+    this(Kp, Ki, Kd, Kv, Ka, source, output, kDefaultPeriod);
   }
 
   /**
@@ -159,6 +196,32 @@ public class PIDController extends PIDBase implements Controller {
       return m_enabled;
     } finally {
       m_thisMutex.unlock();
+    }
+  }
+
+  /**
+   * Calculate the feed forward term.
+   *
+   * <p>Both of the provided feed forward calculations are velocity feed forwards. If a different
+   * feed forward calculation is desired, the user can override this function and provide his or
+   * her own. This function  does no synchronization because the PIDController class only calls it
+   * in synchronized code, so be careful if calling it oneself.
+   *
+   * <p>If a velocity PID controller is being used, the Kv term should be set to 1 over the maximum
+   * setpoint for the output. If a position PID controller is being used, the Kv term should be set
+   * to 1 over the maximum speed for the output measured in setpoint units per second.
+   */
+  @Override
+  protected double calculateFeedForward() {
+    if (m_pidInput.getPIDSourceType().equals(PIDSourceType.kRate)) {
+      return (getV() * getSetpoint() + getA() * getDeltaSetpoint()) * m_period;
+    } else {
+      final double deltaSetpoint = getDeltaSetpoint();
+      final double output = getV() * deltaSetpoint + getA() * (deltaSetpoint - m_prevDeltaSetpoint);
+      m_prevSetpoint = getSetpoint();
+      m_prevDeltaSetpoint = deltaSetpoint;
+      m_setpointTimer.reset();
+      return output * m_period;
     }
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDInterface.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDInterface.java
@@ -10,7 +10,7 @@ package edu.wpi.first.wpilibj;
 @SuppressWarnings("SummaryJavadoc")
 public interface PIDInterface {
   @SuppressWarnings("ParameterName")
-  void setPID(double p, double i, double d);
+  void setPID(double Kp, double Ki, double Kd);
 
   double getP();
 


### PR DESCRIPTION
PIDController now supports Kv and Ka for position control instead of Kff.
Kff is just another name for Kv at this point because that's the behavior it
exhibits by default. The acceleration for Ka is estimated using a
m_prevDeltaSetpoint variable.