### PR TITLE
PIDOutputs can now be superimposed

### DIFF
--- a/wpilibc/src/main/native/cpp/PIDOutputBuffer.cpp
+++ b/wpilibc/src/main/native/cpp/PIDOutputBuffer.cpp
@@ -1,0 +1,14 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "PIDOutputBuffer.h"
+
+using namespace frc;
+
+void PIDOutputBuffer::PIDWrite(double output) { m_output = output; }
+
+double PIDOutputBuffer::GetOutput() const { return m_output; }

--- a/wpilibc/src/main/native/cpp/PIDOutputSummer.cpp
+++ b/wpilibc/src/main/native/cpp/PIDOutputSummer.cpp
@@ -1,0 +1,46 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "PIDOutputSummer.h"
+
+using namespace frc;
+
+/**
+ * Appends buffer and associated sign to array.
+ *
+ * @param output The output for the sum.
+ */
+PIDOutputSummer::PIDOutputSummer(PIDOutput& output) : m_output(output) {}
+
+/**
+ * Starts periodic output.
+ *
+ * @param period The loop time for doing calculations in seconds. The default
+ *               period is 50ms.
+ */
+void PIDOutputSummer::Enable(double period) {
+  m_notifier.StartPeriodic(period);
+}
+
+/**
+ * Stops periodic output.
+ */
+void PIDOutputSummer::Disable() { m_notifier.Stop(); }
+
+void PIDOutputSummer::SetOutput() {
+  double sum = 0.0;
+
+  for (auto& buffer : m_buffers) {
+    if (buffer.second) {
+      sum += buffer.first.GetOutput();
+    } else {
+      sum -= buffer.first.GetOutput();
+    }
+  }
+
+  m_output.PIDWrite(sum);
+}

--- a/wpilibc/src/main/native/include/PIDOutputBuffer.h
+++ b/wpilibc/src/main/native/include/PIDOutputBuffer.h
@@ -1,0 +1,26 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <atomic>
+
+#include "PIDOutput.h"
+
+namespace frc {
+
+class PIDOutputBuffer : public PIDOutput {
+ public:
+  void PIDWrite(double output) override;
+
+  double GetOutput() const;
+
+ private:
+  std::atomic<double> m_output{0.0};
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/PIDOutputSummer.h
+++ b/wpilibc/src/main/native/include/PIDOutputSummer.h
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "Notifier.h"
+#include "PIDOutput.h"
+#include "PIDOutputBuffer.h"
+
+namespace frc {
+
+/**
+ * Takes an arbitrary list of PIDOutputBuffers and outputs the sum of their
+ * outputs to a PIDOutput.
+ */
+class PIDOutputSummer {
+ public:
+  template <class... PIDOutputBuffers>
+  PIDOutputSummer(PIDOutput& output, PIDOutputBuffer& buffer, bool positive,
+                  PIDOutputBuffers&&... buffers);
+  explicit PIDOutputSummer(PIDOutput& output);
+
+  void Enable(double period = 0.05);
+  void Disable();
+
+ private:
+  /**
+   * First argument is buffer.
+   * Second argument is whether to add or subtract its output.
+   */
+  std::vector<std::pair<PIDOutputBuffer&, bool>> m_buffers;
+
+  PIDOutput& m_output;
+  Notifier m_notifier{&PIDOutputSummer::SetOutput, this};
+
+  void SetOutput();
+};
+
+}  // namespace frc
+
+#include "PIDOutputSummer.inc"

--- a/wpilibc/src/main/native/include/PIDOutputSummer.inc
+++ b/wpilibc/src/main/native/include/PIDOutputSummer.inc
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+namespace frc {
+
+/**
+ * Appends buffer and associated sign to array.
+ *
+ * @param output   The output for the sum.
+ * @param buffer   The PIDOutputBuffer object to add to the array for round
+ *                 robin.
+ * @param positive If true, adds buffer output; otherwise, subtracts buffer
+ *                 output.
+ * @param buffers  The other PIDOutputBuffer objects and bools.
+ */
+template <class... PIDOutputBuffers>
+PIDOutputSummer::PIDOutputSummer(PIDOutput& output, PIDOutputBuffer& buffer,
+                                 bool positive, PIDOutputBuffers&&... buffers)
+    : PIDOutputSummer(output, buffers...) {
+  m_buffers.emplace_back(buffer, positive);
+}
+
+}  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDOutputBuffer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDOutputBuffer.java
@@ -1,0 +1,21 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj;
+
+public class PIDOutputBuffer implements PIDOutput {
+  private volatile double m_output = 0.0;
+
+  @Override
+  public void pidWrite(double output) {
+    m_output = output;
+  }
+
+  public double getOutput() {
+    return m_output;
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDOutputSummer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDOutputSummer.java
@@ -1,0 +1,88 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj;
+
+/**
+ * Takes an arbitrary list of PIDOutputBuffers and outputs the sum of their outputs to a PIDOutput.
+ */
+public class PIDOutputSummer {
+  private Buffer[] m_buffers;
+
+  private PIDOutput m_output;
+  private Notifier m_notifier = new Notifier(this::setOutput);
+
+  private class Buffer {
+    public PIDOutputBuffer m_buffer;
+    public boolean m_positive;
+
+    Buffer(PIDOutputBuffer buffer, boolean positive) {
+      m_buffer = buffer;
+      m_positive = positive;
+    }
+  }
+
+  /**
+   * Appends buffer and associated sign to array.
+   *
+   * @param output   The output for the sum.
+   * @param buffer   The PIDOutputBuffer object to add to the array for round
+   *                 robin.
+   * @param positive If true, adds buffer output; otherwise, subtracts buffer
+   *                 output.
+   * @param buffers  The other PIDOutputBuffer objects and bools.
+   */
+  public PIDOutputSummer(PIDOutput output, PIDOutputBuffer buffer, boolean positive,
+      Object... buffers) {
+    m_output = output;
+
+    m_buffers = new Buffer[1 + buffers.length / 2];
+
+    m_buffers[0] = new Buffer(buffer, positive);
+    for (int i = 0; i < buffers.length; i += 2) {
+      m_buffers[1 + i / 2] = new Buffer((PIDOutputBuffer) buffers[i], (boolean) buffers[i + 1]);
+    }
+  }
+
+  /**
+   * Starts periodic output.
+   *
+   * @param period The loop time for doing calculations in seconds. The default
+   *               period is 50ms.
+   */
+  public void enable(double period) {
+    m_notifier.startPeriodic(period);
+  }
+
+  /**
+   * Starts periodic output.
+   */
+  public void enable() {
+    m_notifier.startPeriodic(0.05);
+  }
+
+  /**
+   * Stops periodic output.
+   */
+  public void disable() {
+    m_notifier.stop();
+  }
+
+  private void setOutput() {
+    double sum = 0.0;
+
+    for (Buffer buffer : m_buffers) {
+      if (buffer.m_positive) {
+        sum += buffer.m_buffer.getOutput();
+      } else {
+        sum -= buffer.m_buffer.getOutput();
+      }
+    }
+
+    m_output.pidWrite(sum);
+  }
+}


### PR DESCRIPTION
PIDOutputs can be summed to drive one actuator. This allows, for example,
position and heading controllers that drive the same drivetrain.

Fixes #977.