### PR TITLE
Added PIDSourceWrapper for wrapping function calls in a PIDSource object

### DIFF
--- a/wpilibc/src/main/native/cpp/PIDSourceWrapper.cpp
+++ b/wpilibc/src/main/native/cpp/PIDSourceWrapper.cpp
@@ -1,0 +1,16 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "PIDSourceWrapper.h"
+
+using namespace frc;
+
+PIDSourceWrapper::PIDSourceWrapper(std::function<double()> func) {
+  m_func = func;
+}
+
+double PIDSourceWrapper::PIDGet() { return m_func(); }

--- a/wpilibc/src/main/native/include/PIDSourceWrapper.h
+++ b/wpilibc/src/main/native/include/PIDSourceWrapper.h
@@ -1,0 +1,26 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <functional>
+
+#include "PIDSource.h"
+
+namespace frc {
+
+class PIDSourceWrapper : public PIDSource {
+ public:
+  PIDSourceWrapper(std::function<double()> func);  // NOLINT(runtime/explicit)
+
+  double PIDGet() override;
+
+ private:
+  std::function<double()> m_func;
+};
+
+}  // namespace frc


### PR DESCRIPTION
Wrapping a PIDSource object around an arbitrary function call is necessary
for writing PIDControllers that use feedback values that cannot implement
PIDSource easily (e.g., the difference between the output of two PIDSource
objects). Java's lambdas provide a terse syntax for implementing a function
from an arbitrary base class, but C++ does not provide something similar as
a language feature. PIDSourceWrapper provides this functionality for
PIDSource.