### PR TITLE
Add state-space controller

### DIFF
--- a/wpilibc/src/main/native/include/frc/controller/PeriodVariantController.h
+++ b/wpilibc/src/main/native/include/frc/controller/PeriodVariantController.h
@@ -1,0 +1,184 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <vector>
+
+#include <Eigen/Core>
+
+#include "frc/controller/PeriodVariantPlant.h"
+#include "frc/controller/StateSpaceControllerCoeffs.h"
+
+namespace frc {
+
+/**
+ * Contains the controller coefficients and logic for a state-space controller.
+ *
+ * State-space controllers generally use the control law u = -Kx. The
+ * feedforward used is u_ff = K_ff * (r_k+1 - A * r_k).
+ *
+ * For more on the underlying math, read
+ * https://file.tavsys.net/control/state-space-guide.pdf.
+ */
+template <int States, int Inputs, int Outputs>
+class PeriodVariantController {
+ public:
+  /**
+   * Constructs a controller with the given coefficients and plant.
+   *
+   * @param controllerCoeffs Controller coefficients.
+   * @param plant            The plant used for the feedforward calculation.
+   */
+  PeriodVariantController(const StateSpaceControllerCoeffs<
+                              States, Inputs, Outputs>& controllerCoeffs,
+                          PeriodVariantPlant<States, Inputs, Outputs>& plant);
+
+  PeriodVariantController(PeriodVariantController&&) = default;
+  PeriodVariantController& operator=(PeriodVariantController&&) = default;
+
+  /**
+   * Enables controller.
+   */
+  void Enable();
+
+  /**
+   * Disables controller, zeroing controller output U.
+   */
+  void Disable();
+
+  /**
+   * Returns the controller matrix K.
+   */
+  const Eigen::Matrix<double, Inputs, States>& K() const;
+
+  /**
+   * Returns an element of the controller matrix K.
+   *
+   * @param i Row of K.
+   * @param j Column of K.
+   */
+  double K(int i, int j) const;
+
+  /**
+   * Returns the feedforward controller matrix Kff.
+   */
+  const Eigen::Matrix<double, Inputs, States>& Kff() const;
+
+  /**
+   * Returns an element of the feedforward controller matrix Kff.
+   *
+   * @param i Row of Kff.
+   * @param j Column of Kff.
+   */
+  double Kff(int i, int j) const;
+
+  /**
+   * Returns the reference vector r.
+   */
+  const Eigen::Matrix<double, States, 1>& R() const;
+
+  /**
+   * Returns an element of the reference vector r.
+   *
+   * @param i Row of r.
+   */
+  double R(int i) const;
+
+  /**
+   * Returns the control input vector u.
+   */
+  const Eigen::Matrix<double, Inputs, 1>& U() const;
+
+  /**
+   * Returns an element of the control input vector u.
+   *
+   * @param i Row of u.
+   */
+  double U(int i) const;
+
+  /**
+   * Resets the controller.
+   */
+  void Reset();
+
+  /**
+   * Update controller without setting a new reference.
+   *
+   * @param x The current state x.
+   */
+  void Update(const Eigen::Matrix<double, States, 1>& x);
+
+  /**
+   * Set a new reference and update the controller.
+   *
+   * @param x     The current state x.
+   * @param nextR The next reference vector r.
+   */
+  void Update(const Eigen::Matrix<double, States, 1>& x,
+              const Eigen::Matrix<double, States, 1>& nextR);
+
+  /**
+   * Adds the given coefficients to the controller for gain scheduling.
+   *
+   * @param coefficients Controller coefficients.
+   */
+  void AddCoefficients(
+      const StateSpaceControllerCoeffs<States, Inputs, Outputs>& coefficients);
+
+  /**
+   * Returns the controller coefficients with the given index.
+   *
+   * @param index Index of coefficients.
+   */
+  const StateSpaceControllerCoeffs<States, Inputs, Outputs>& GetCoefficients(
+      int index) const;
+
+  /**
+   * Returns the current controller coefficients.
+   */
+  const StateSpaceControllerCoeffs<States, Inputs, Outputs>& GetCoefficients()
+      const;
+
+  /**
+   * Sets the current controller to be "index", clamped to be within range. This
+   * can be used for gain scheduling.
+   *
+   * @param index The controller index.
+   */
+  void SetIndex(int index);
+
+  /**
+   * Returns the current controller index.
+   */
+  int GetIndex() const;
+
+ private:
+  PeriodVariantPlant<States, Inputs, Outputs>* m_plant;
+
+  bool m_enabled = false;
+
+  /**
+   * Current reference.
+   */
+  Eigen::Matrix<double, States, 1> m_r;
+
+  /**
+   * Computed controller output after being capped.
+   */
+  Eigen::Matrix<double, Inputs, 1> m_u;
+
+  std::vector<StateSpaceControllerCoeffs<States, Inputs, Outputs>>
+      m_coefficients;
+  int m_index = 0;
+
+  void CapU();
+};
+
+}  // namespace frc
+
+#include "frc/controller/PeriodVariantController.inc"

--- a/wpilibc/src/main/native/include/frc/controller/PeriodVariantController.inc
+++ b/wpilibc/src/main/native/include/frc/controller/PeriodVariantController.inc
@@ -1,0 +1,148 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs>
+PeriodVariantController<States, Inputs, Outputs>::PeriodVariantController(
+    const StateSpaceControllerCoeffs<States, Inputs, Outputs>& controllerCoeffs,
+    PeriodVariantPlant<States, Inputs, Outputs>& plant)
+    : m_plant(&plant) {
+  AddCoefficients(controllerCoeffs);
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantController<States, Inputs, Outputs>::Enable() {
+  m_enabled = true;
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantController<States, Inputs, Outputs>::Disable() {
+  m_enabled = false;
+  m_u.setZero();
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Inputs, States>&
+PeriodVariantController<States, Inputs, Outputs>::K() const {
+  return GetCoefficients().K;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantController<States, Inputs, Outputs>::K(int i, int j) const {
+  return K()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Inputs, States>&
+PeriodVariantController<States, Inputs, Outputs>::Kff() const {
+  return GetCoefficients().Kff;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantController<States, Inputs, Outputs>::Kff(int i,
+                                                             int j) const {
+  return Kff()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, 1>&
+PeriodVariantController<States, Inputs, Outputs>::R() const {
+  return m_r;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantController<States, Inputs, Outputs>::R(int i) const {
+  return R()(i, 0);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Inputs, 1>&
+PeriodVariantController<States, Inputs, Outputs>::U() const {
+  return m_u;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantController<States, Inputs, Outputs>::U(int i) const {
+  return U()(i, 0);
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantController<States, Inputs, Outputs>::Reset() {
+  m_r.setZero();
+  m_u.setZero();
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantController<States, Inputs, Outputs>::Update(
+    const Eigen::Matrix<double, States, 1>& x) {
+  if (m_enabled) {
+    m_u = K() * (m_r - x) + Kff() * (m_r - m_plant->A() * m_r);
+    CapU();
+  }
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantController<States, Inputs, Outputs>::Update(
+    const Eigen::Matrix<double, States, 1>& x,
+    const Eigen::Matrix<double, States, 1>& nextR) {
+  if (m_enabled) {
+    m_u = K() * (m_r - x) + Kff() * (nextR - m_plant->A() * m_r);
+    CapU();
+    m_r = nextR;
+  }
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantController<States, Inputs, Outputs>::CapU() {
+  for (int i = 0; i < Inputs; ++i) {
+    if (U(i) > GetCoefficients().Umax(i)) {
+      m_u(i, 0) = GetCoefficients().Umax(i);
+    } else if (U(i) < GetCoefficients().Umin(i)) {
+      m_u(i, 0) = GetCoefficients().Umin(i);
+    }
+  }
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantController<States, Inputs, Outputs>::AddCoefficients(
+    const StateSpaceControllerCoeffs<States, Inputs, Outputs>& coefficients) {
+  m_coefficients.emplace_back(coefficients);
+}
+
+template <int States, int Inputs, int Outputs>
+const StateSpaceControllerCoeffs<States, Inputs, Outputs>&
+PeriodVariantController<States, Inputs, Outputs>::GetCoefficients(
+    int index) const {
+  return m_coefficients[index];
+}
+
+template <int States, int Inputs, int Outputs>
+const StateSpaceControllerCoeffs<States, Inputs, Outputs>&
+PeriodVariantController<States, Inputs, Outputs>::GetCoefficients() const {
+  return m_coefficients[m_index];
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantController<States, Inputs, Outputs>::SetIndex(int index) {
+  if (index < 0) {
+    m_index = 0;
+  } else if (index >= static_cast<int>(m_coefficients.size())) {
+    m_index = static_cast<int>(m_coefficients.size()) - 1;
+  } else {
+    m_index = index;
+  }
+}
+
+template <int States, int Inputs, int Outputs>
+int PeriodVariantController<States, Inputs, Outputs>::GetIndex() const {
+  return m_index;
+}
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/PeriodVariantLoop.h
+++ b/wpilibc/src/main/native/include/frc/controller/PeriodVariantLoop.h
@@ -1,0 +1,209 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+#include <units/units.h>
+
+#include "frc/controller/PeriodVariantController.h"
+#include "frc/controller/PeriodVariantObserver.h"
+#include "frc/controller/PeriodVariantPlant.h"
+
+namespace frc {
+
+/**
+ * Combines a plant, controller, and observer for controlling a mechanism with
+ * full state feedback.
+ *
+ * For everything in this file, "inputs" and "outputs" are defined from the
+ * perspective of the plant. This means U is an input and Y is an output
+ * (because you give the plant U (powers) and it gives you back a Y (sensor
+ * values). This is the opposite of what they mean from the perspective of the
+ * controller (U is an output because that's what goes to the motors and Y is an
+ * input because that's what comes back from the sensors).
+ *
+ * For more on the underlying math, read
+ * https://file.tavsys.net/control/state-space-guide.pdf.
+ */
+template <int States, int Inputs, int Outputs>
+class PeriodVariantLoop {
+ public:
+  /**
+   * A convenience constructor for constructing a period-variant loop with the
+   * given plant, controller, and observer coefficients.
+   *
+   * @param plantCoeffs      Period-variant plant coefficients.
+   * @param controllerCoeffs Period-variant controller coefficients.
+   * @param observerCoeffs   Period-variant observer coefficients.
+   */
+  PeriodVariantLoop(
+      const PeriodVariantPlantCoeffs<States, Inputs, Outputs>& plantCoeffs,
+      const StateSpaceControllerCoeffs<States, Inputs, Outputs>&
+          controllerCoeffs,
+      const PeriodVariantObserverCoeffs<States, Inputs, Outputs>&
+          observerCoeffs);
+  /**
+   * Constructs a period-variant loop with the given plant, controller, and
+   * observer.
+   *
+   * @param plant      Period-variant plant.
+   * @param controller Period-variant controller.
+   * @param observer   Period-variant observer.
+   */
+  PeriodVariantLoop(
+      PeriodVariantPlant<States, Inputs, Outputs>&& plant,
+      PeriodVariantController<States, Inputs, Outputs>&& controller,
+      PeriodVariantObserver<States, Inputs, Outputs>&& observer);
+
+  virtual ~PeriodVariantLoop() = default;
+
+  PeriodVariantLoop(PeriodVariantLoop&&) = default;
+  PeriodVariantLoop& operator=(PeriodVariantLoop&&) = default;
+
+  /**
+   * Enables the controller.
+   */
+  void Enable();
+
+  /**
+   * Disables the controller and zeros the control input.
+   */
+  void Disable();
+
+  /**
+   * Returns the observer's state estimate x-hat.
+   */
+  const Eigen::Matrix<double, States, 1>& Xhat() const;
+
+  /**
+   * Returns an element of the observer's state estimate x-hat.
+   *
+   * @param i Row of x-hat.
+   */
+  double Xhat(int i) const;
+
+  /**
+   * Returns the controller's next reference r.
+   */
+  const Eigen::Matrix<double, States, 1>& NextR() const;
+
+  /**
+   * Returns an element of the controller's next reference r.
+   *
+   * @param i Row of r.
+   */
+  double NextR(int i) const;
+
+  /**
+   * Returns the controller's calculated control input u.
+   */
+  const Eigen::Matrix<double, Inputs, 1>& U() const;
+
+  /**
+   * Returns an element of the controller's calculated control input u.
+   *
+   * @param i Row of u.
+   */
+  double U(int i) const;
+
+  /**
+   * Set the initial state estimate x-hat.
+   *
+   * @param xHat The initial state estimate x-hat.
+   */
+  void SetXhat(const Eigen::Matrix<double, States, 1>& xHat);
+
+  /**
+   * Set an element of the initial state estimate x-hat.
+   *
+   * @param i     Row of x-hat.
+   * @param value Value for element of x-hat.
+   */
+  void SetXhat(int i, double value);
+
+  /**
+   * Set the next reference r.
+   *
+   * @param nextR Next reference.
+   */
+  void SetNextR(const Eigen::Matrix<double, States, 1>& nextR);
+
+  /**
+   * Return the plant used internally.
+   */
+  const PeriodVariantPlant<States, Inputs, Outputs>& GetPlant() const;
+
+  /**
+   * Return the controller used internally.
+   */
+  const PeriodVariantController<States, Inputs, Outputs>& GetController() const;
+
+  /**
+   * Return the observer used internally.
+   */
+  const PeriodVariantObserver<States, Inputs, Outputs>& GetObserver() const;
+
+  /**
+   * Zeroes reference r, controller output u, plant output y, and state estimate
+   * x-hat.
+   */
+  void Reset();
+
+  /**
+   * Returns difference between reference r and x-hat.
+   */
+  const Eigen::Matrix<double, States, 1> Error() const;
+
+  /**
+   * Correct the state estimate x-hat using the measurements in y.
+   *
+   * @param y Measurement vector.
+   */
+  void Correct(const Eigen::Matrix<double, Outputs, 1>& y);
+
+  /**
+   * Sets new controller output, projects model forward, and runs observer
+   * prediction.
+   *
+   * After calling this, the user should send the elements of u to the
+   * actuators.
+   *
+   * @param dt Timestep for prediction.
+   */
+  void Predict(units::second_t dt = 5_ms);
+
+  /**
+   * Sets the current controller to be "index". This can be used for gain
+   * scheduling.
+   *
+   * @param index The controller index.
+   */
+  void SetIndex(int index);
+
+  /**
+   * Returns the current controller index.
+   */
+  int GetIndex() const;
+
+ protected:
+  PeriodVariantPlant<States, Inputs, Outputs> m_plant;
+  PeriodVariantController<States, Inputs, Outputs> m_controller;
+  PeriodVariantObserver<States, Inputs, Outputs> m_observer;
+
+  // Reference to go to in the next cycle (used by feedforward controller).
+  Eigen::Matrix<double, States, 1> m_nextR;
+
+  // These are accessible from non-templated subclasses.
+  static constexpr int kStates = States;
+  static constexpr int kInputs = Inputs;
+  static constexpr int kOutputs = Outputs;
+};
+
+}  // namespace frc
+
+#include "frc/controller/PeriodVariantLoop.inc"

--- a/wpilibc/src/main/native/include/frc/controller/PeriodVariantLoop.inc
+++ b/wpilibc/src/main/native/include/frc/controller/PeriodVariantLoop.inc
@@ -1,0 +1,152 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <utility>
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs>
+PeriodVariantLoop<States, Inputs, Outputs>::PeriodVariantLoop(
+    const PeriodVariantPlantCoeffs<States, Inputs, Outputs>& plantCoeffs,
+    const StateSpaceControllerCoeffs<States, Inputs, Outputs>& controllerCoeffs,
+    const PeriodVariantObserverCoeffs<States, Inputs, Outputs>& observerCoeffs)
+    : m_plant(plantCoeffs),
+      m_controller(controllerCoeffs, m_plant),
+      m_observer(observerCoeffs, m_plant) {
+  Reset();
+}
+
+template <int States, int Inputs, int Outputs>
+PeriodVariantLoop<States, Inputs, Outputs>::PeriodVariantLoop(
+    PeriodVariantPlant<States, Inputs, Outputs>&& plant,
+    PeriodVariantController<States, Inputs, Outputs>&& controller,
+    PeriodVariantObserver<States, Inputs, Outputs>&& observer)
+    : m_plant(std::move(plant)),
+      m_controller(std::move(controller)),
+      m_observer(std::move(observer)) {
+  Reset();
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantLoop<States, Inputs, Outputs>::Enable() {
+  m_controller.Enable();
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantLoop<States, Inputs, Outputs>::Disable() {
+  m_controller.Disable();
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, 1>&
+PeriodVariantLoop<States, Inputs, Outputs>::Xhat() const {
+  return GetObserver().Xhat();
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantLoop<States, Inputs, Outputs>::Xhat(int i) const {
+  return GetObserver().Xhat(i);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, 1>&
+PeriodVariantLoop<States, Inputs, Outputs>::NextR() const {
+  return m_nextR;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantLoop<States, Inputs, Outputs>::NextR(int i) const {
+  return NextR()(i, 0);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Inputs, 1>&
+PeriodVariantLoop<States, Inputs, Outputs>::U() const {
+  return m_controller.U();
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantLoop<States, Inputs, Outputs>::U(int i) const {
+  return m_controller.U(i);
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantLoop<States, Inputs, Outputs>::SetXhat(
+    const Eigen::Matrix<double, States, 1>& xHat) {
+  m_observer.SetXhat(xHat);
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantLoop<States, Inputs, Outputs>::SetXhat(int i, double value) {
+  m_observer.SetXhat(i, value);
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantLoop<States, Inputs, Outputs>::SetNextR(
+    const Eigen::Matrix<double, States, 1>& nextR) {
+  m_nextR = nextR;
+}
+
+template <int States, int Inputs, int Outputs>
+const PeriodVariantPlant<States, Inputs, Outputs>&
+PeriodVariantLoop<States, Inputs, Outputs>::GetPlant() const {
+  return m_plant;
+}
+
+template <int States, int Inputs, int Outputs>
+const PeriodVariantController<States, Inputs, Outputs>&
+PeriodVariantLoop<States, Inputs, Outputs>::GetController() const {
+  return m_controller;
+}
+
+template <int States, int Inputs, int Outputs>
+const PeriodVariantObserver<States, Inputs, Outputs>&
+PeriodVariantLoop<States, Inputs, Outputs>::GetObserver() const {
+  return m_observer;
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantLoop<States, Inputs, Outputs>::Reset() {
+  m_plant.Reset();
+  m_controller.Reset();
+  m_observer.Reset();
+  m_nextR.setZero();
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, 1>
+PeriodVariantLoop<States, Inputs, Outputs>::Error() const {
+  return m_controller.R() - m_observer.Xhat();
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantLoop<States, Inputs, Outputs>::Correct(
+    const Eigen::Matrix<double, Outputs, 1>& y) {
+  m_observer.Correct(m_controller.U(), y);
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantLoop<States, Inputs, Outputs>::Predict(units::second_t dt) {
+  m_controller.Update(m_observer.Xhat(), m_nextR);
+  m_observer.Predict(m_controller.U(), dt);
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantLoop<States, Inputs, Outputs>::SetIndex(int index) {
+  m_plant.SetIndex(index);
+  m_controller.SetIndex(index);
+  m_observer.SetIndex(index);
+}
+
+template <int States, int Inputs, int Outputs>
+int PeriodVariantLoop<States, Inputs, Outputs>::GetIndex() const {
+  return m_plant.GetIndex();
+}
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/PeriodVariantObserver.h
+++ b/wpilibc/src/main/native/include/frc/controller/PeriodVariantObserver.h
@@ -1,0 +1,219 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <vector>
+
+#include <Eigen/Core>
+#include <units/units.h>
+
+#include "frc/controller/PeriodVariantObserverCoeffs.h"
+#include "frc/controller/PeriodVariantPlant.h"
+
+namespace frc {
+
+/**
+ * A Kalman filter that discretizes its model and covariance matrices after
+ * every sample period.
+ *
+ * Typical discrete state feedback implementations discretize with a nominal
+ * sample period offline. If the real system doesn't maintain this period, this
+ * nonlinearity can negatively affect the state estimate. This class discretizes
+ * the continuous model after each measurement based on the measured sample
+ * period.
+ *
+ * Since the sample period changes during runtime, the process and measurement
+ * noise covariance matrices as well as the true steady state error covariance
+ * change as well. During runtime, the error covariance matrix is initialized
+ * with the discrete steady state value, but is updated during runtime as well.
+ *
+ * For more on the underlying math, read
+ * https://file.tavsys.net/control/state-space-guide.pdf.
+ */
+template <int States, int Inputs, int Outputs>
+class PeriodVariantObserver {
+ public:
+  /**
+   * Constructs a Kalman filter with the given coefficients and plant.
+   *
+   * @param observerCoeffs      Observer coefficients.
+   * @param plant               The plant used for the prediction step.
+   * @param nominalSamplePeriod The nominal period at which the control loop
+   *                            will run.
+   */
+  PeriodVariantObserver(const PeriodVariantObserverCoeffs<
+                            States, Inputs, Outputs>& observerCoeffs,
+                        PeriodVariantPlant<States, Inputs, Outputs>& plant,
+                        const units::second_t nominalSamplePeriod = 5_ms);
+
+  PeriodVariantObserver(PeriodVariantObserver&&) = default;
+  PeriodVariantObserver& operator=(PeriodVariantObserver&&) = default;
+
+  /**
+   * Returns the discretized process noise covariance matrix.
+   */
+  const Eigen::Matrix<double, States, States>& Q() const;
+
+  /**
+   * Returns an element of the discretized process noise covariance matrix.
+   *
+   * @param i Row in Q.
+   * @param j Column in Q.
+   */
+  double Q(int i, int j) const;
+
+  /**
+   * Returns the discretized measurement noise covariance matrix.
+   */
+  const Eigen::Matrix<double, Outputs, Outputs>& R() const;
+
+  /**
+   * Returns an element of the discretized measurement noise covariance matrix.
+   *
+   * @param i Row of R.
+   * @param j Column of R.
+   */
+  double R(int i, int j) const;
+
+  /**
+   * Returns the discretized error covariance matrix.
+   */
+  const Eigen::Matrix<double, States, States>& P() const;
+
+  /**
+   * Returns an element of the discretized error covariance matrix.
+   *
+   * @param i Row of P.
+   * @param j Column of P.
+   */
+  double P(int i, int j) const;
+
+  /**
+   * Returns the state estimate x-hat.
+   */
+  const Eigen::Matrix<double, States, 1>& Xhat() const;
+
+  /**
+   * Returns an element of the state estimate x-hat.
+   *
+   * @param i Row of x-hat.
+   */
+  double Xhat(int i) const;
+
+  /**
+   * Set initial state estimate x-hat.
+   *
+   * @param xHat The state estimate x-hat.
+   */
+  void SetXhat(const Eigen::Matrix<double, States, 1>& xHat);
+
+  /**
+   * Set an element of the initial state estimate x-hat.
+   *
+   * @param i     Row of x-hat.
+   * @param value Value for element of x-hat.
+   */
+  void SetXhat(int i, double value);
+
+  /**
+   * Resets the observer.
+   */
+  void Reset();
+
+  /**
+   * Project the model into the future with a new control input u.
+   *
+   * @param newU New control input from controller.
+   * @param dt   Timestep for prediction.
+   */
+  void Predict(const Eigen::Matrix<double, Inputs, 1>& newU,
+               units::second_t dt);
+
+  /**
+   * Correct the state estimate x-hat using the measurements in y.
+   *
+   * @param u Same control input used in the predict step.
+   * @param y Measurement vector.
+   */
+  void Correct(const Eigen::Matrix<double, Inputs, 1>& u,
+               const Eigen::Matrix<double, Outputs, 1>& y);
+
+  /**
+   * Adds the given coefficients to the observer for gain scheduling.
+   *
+   * @param coefficients Observer coefficients.
+   */
+  void AddCoefficients(
+      const PeriodVariantObserverCoeffs<States, Inputs, Outputs>& coefficients);
+
+  /**
+   * Returns the observer coefficients with the given index.
+   *
+   * @param index Index of coefficients.
+   */
+  const PeriodVariantObserverCoeffs<States, Inputs, Outputs>& GetCoefficients(
+      int index) const;
+
+  /**
+   * Returns the current observer coefficients.
+   */
+  const PeriodVariantObserverCoeffs<States, Inputs, Outputs>& GetCoefficients()
+      const;
+
+  /**
+   * Sets the current observer to be "index", clamped to be within range. This
+   * can be used for gain scheduling.
+   *
+   * @param index The controller index.
+   */
+  void SetIndex(int index);
+
+  /**
+   * Returns the current observer index.
+   */
+  int GetIndex() const;
+
+ private:
+  /**
+   * Rediscretizes Q and R with the provided timestep.
+   *
+   * @param dt Discretization timestep.
+   */
+  void UpdateQR(units::second_t dt);
+
+  PeriodVariantPlant<States, Inputs, Outputs>* m_plant;
+  const units::second_t m_nominalSamplePeriod;
+
+  /**
+   * Internal state estimate.
+   */
+  Eigen::Matrix<double, States, 1> m_Xhat;
+
+  /**
+   * Internal error covariance estimate.
+   */
+  Eigen::Matrix<double, States, States> m_P;
+
+  /**
+   * Discretized process noise covariance matrix.
+   */
+  Eigen::Matrix<double, States, States> m_Q;
+
+  /**
+   * Discretized measurement noise covariance matrix.
+   */
+  Eigen::Matrix<double, Outputs, Outputs> m_R;
+
+  std::vector<PeriodVariantObserverCoeffs<States, Inputs, Outputs>>
+      m_coefficients;
+  int m_index = 0;
+};
+
+}  // namespace frc
+
+#include "frc/controller/PeriodVariantObserver.inc"

--- a/wpilibc/src/main/native/include/frc/controller/PeriodVariantObserver.inc
+++ b/wpilibc/src/main/native/include/frc/controller/PeriodVariantObserver.inc
@@ -1,0 +1,200 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <unsupported/Eigen/MatrixFunctions>
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs>
+PeriodVariantObserver<States, Inputs, Outputs>::PeriodVariantObserver(
+    const PeriodVariantObserverCoeffs<States, Inputs, Outputs>& observerCoeffs,
+    PeriodVariantPlant<States, Inputs, Outputs>& plant,
+    const units::second_t nominalSamplePeriod)
+    : m_plant(&plant), m_nominalSamplePeriod(nominalSamplePeriod) {
+  AddCoefficients(observerCoeffs);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, States>&
+PeriodVariantObserver<States, Inputs, Outputs>::Q() const {
+  return m_Q;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantObserver<States, Inputs, Outputs>::Q(int i, int j) const {
+  return Q()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Outputs, Outputs>&
+PeriodVariantObserver<States, Inputs, Outputs>::R() const {
+  return m_R;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantObserver<States, Inputs, Outputs>::R(int i, int j) const {
+  return R()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, States>&
+PeriodVariantObserver<States, Inputs, Outputs>::P() const {
+  return m_P;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantObserver<States, Inputs, Outputs>::P(int i, int j) const {
+  return P()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, 1>&
+PeriodVariantObserver<States, Inputs, Outputs>::Xhat() const {
+  return m_Xhat;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantObserver<States, Inputs, Outputs>::Xhat(int i) const {
+  return Xhat()(i, 0);
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantObserver<States, Inputs, Outputs>::SetXhat(
+    const Eigen::Matrix<double, States, 1>& xHat) {
+  m_Xhat = xHat;
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantObserver<States, Inputs, Outputs>::SetXhat(int i,
+                                                             double value) {
+  m_Xhat(i, 0) = value;
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantObserver<States, Inputs, Outputs>::Reset() {
+  m_Xhat.setZero();
+  m_P = GetCoefficients().PsteadyState;
+  UpdateQR(m_nominalSamplePeriod);
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantObserver<States, Inputs, Outputs>::Predict(
+    const Eigen::Matrix<double, Inputs, 1>& newU, units::second_t dt) {
+  // Trigger the predict step. This will update A() and B() in the plant.
+  m_Xhat = m_plant->CalculateX(Xhat(), newU, dt);
+
+  UpdateQR(dt);
+  m_P = m_plant->A() * P() * m_plant->A().transpose() + Q();
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantObserver<States, Inputs, Outputs>::Correct(
+    const Eigen::Matrix<double, Inputs, 1>& u,
+    const Eigen::Matrix<double, Outputs, 1>& y) {
+  Eigen::Matrix<double, Outputs, 1> yBar = y - m_plant->CalculateY(Xhat(), u);
+  Eigen::Matrix<double, Outputs, Outputs> S =
+      m_plant->C() * P() * m_plant->C().transpose() + R();
+
+  // We want to put K = PC^T S^-1 into Ax = b form so we can solve it more
+  // efficiently.
+  //
+  // K = PC^T S^-1
+  // KS = PC^T
+  // (KS)^T = (PC^T)^T
+  // S^T K^T = CP^T
+  //
+  // The solution of Ax = b can be found via x = A.solve(b).
+  //
+  // K^T = S^T.solve(CP^T)
+  // K = (S^T.solve(CP^T))^T
+  Eigen::Matrix<double, States, Outputs> kalmanGain =
+      S.transpose().ldlt().solve(m_plant->C() * P().transpose()).transpose();
+  m_Xhat = Xhat() + kalmanGain * yBar;
+  m_P = (m_plant->GetCoefficients().Acontinuous.Identity() -
+         kalmanGain * m_plant->C()) *
+        P();
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantObserver<States, Inputs, Outputs>::AddCoefficients(
+    const PeriodVariantObserverCoeffs<States, Inputs, Outputs>& coefficients) {
+  m_coefficients.emplace_back(coefficients);
+}
+
+template <int States, int Inputs, int Outputs>
+const PeriodVariantObserverCoeffs<States, Inputs, Outputs>&
+PeriodVariantObserver<States, Inputs, Outputs>::GetCoefficients(
+    int index) const {
+  return m_coefficients[index];
+}
+
+template <int States, int Inputs, int Outputs>
+const PeriodVariantObserverCoeffs<States, Inputs, Outputs>&
+PeriodVariantObserver<States, Inputs, Outputs>::GetCoefficients() const {
+  return m_coefficients[m_index];
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantObserver<States, Inputs, Outputs>::SetIndex(int index) {
+  if (index < 0) {
+    m_index = 0;
+  } else if (index >= static_cast<int>(m_coefficients.size())) {
+    m_index = static_cast<int>(m_coefficients.size()) - 1;
+  } else {
+    m_index = index;
+  }
+}
+
+template <int States, int Inputs, int Outputs>
+int PeriodVariantObserver<States, Inputs, Outputs>::GetIndex() const {
+  return m_index;
+}
+
+/**
+ * Rediscretizes Q and R matrices based on provided period.
+ */
+template <int States, int Inputs, int Outputs>
+void PeriodVariantObserver<States, Inputs, Outputs>::UpdateQR(
+    units::second_t dt) {
+  // Now, compute the discrete time Q and R coefficients.
+  Eigen::Matrix<double, States, States> Qtemp =
+      (GetCoefficients().Qcontinuous +
+       GetCoefficients().Qcontinuous.transpose()) /
+      2.0;
+  Eigen::Matrix<double, Outputs, Outputs> Rtemp =
+      (GetCoefficients().Rcontinuous +
+       GetCoefficients().Rcontinuous.transpose()) /
+      2.0;
+
+  Eigen::Matrix<double, 2 * States, 2 * States> Mgain;
+  Mgain.setZero();
+
+  // Set up the matrix M = [[-A, Q], [0, A.T]]
+  Mgain.template block<States, States>(0, 0) =
+      -m_plant->GetCoefficients().Acontinuous;
+  Mgain.template block<States, States>(0, States) = Qtemp;
+  Mgain.template block<States, States>(States, States) =
+      m_plant->GetCoefficients().Acontinuous.transpose();
+
+  Eigen::Matrix<double, 2 * States, 2 * States> phi =
+      (Mgain * dt.to<double>()).exp();
+
+  // Phi12 = phi[0:States,        States:2*States]
+  // Phi22 = phi[States:2*States, States:2*States]
+  Eigen::Matrix<double, States, States> phi12 =
+      phi.block(0, States, States, States);
+  Eigen::Matrix<double, States, States> phi22 =
+      phi.block(States, States, States, States);
+
+  m_Q = phi22.transpose() * phi12;
+  m_Q = (m_Q + m_Q.transpose()) / 2.0;
+  m_R = Rtemp / dt.to<double>();
+}
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/PeriodVariantObserverCoeffs.h
+++ b/wpilibc/src/main/native/include/frc/controller/PeriodVariantObserverCoeffs.h
@@ -1,0 +1,49 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+
+namespace frc {
+
+/**
+ * A container for all the observer coefficients.
+ */
+template <int States, int Inputs, int Outputs>
+struct PeriodVariantObserverCoeffs final {
+  /**
+   * The continuous process noise covariance matrix.
+   */
+  Eigen::Matrix<double, States, States> Qcontinuous;
+
+  /**
+   * The continuous measurement noise covariance matrix.
+   */
+  Eigen::Matrix<double, Outputs, Outputs> Rcontinuous;
+
+  /**
+   * The steady-state error covariance matrix.
+   */
+  Eigen::Matrix<double, States, States> PsteadyState;
+
+  /**
+   * Construct the container for the observer coefficients.
+   *
+   * @param Qcontinuous The continuous process noise covariance matrix.
+   * @param Rcontinuous The continuous measurement noise covariance matrix.
+   * @param PsteadyState The steady-state error covariance matrix.
+   */
+  PeriodVariantObserverCoeffs(
+      const Eigen::Matrix<double, States, States>& Qcontinuous,
+      const Eigen::Matrix<double, Outputs, Outputs>& Rcontinuous,
+      const Eigen::Matrix<double, States, States>& PsteadyState);
+};
+
+}  // namespace frc
+
+#include "frc/controller/PeriodVariantObserverCoeffs.inc"

--- a/wpilibc/src/main/native/include/frc/controller/PeriodVariantObserverCoeffs.inc
+++ b/wpilibc/src/main/native/include/frc/controller/PeriodVariantObserverCoeffs.inc
@@ -1,0 +1,24 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include "frc/controller/PeriodVariantObserverCoeffs.h"
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs>
+PeriodVariantObserverCoeffs<States, Inputs, Outputs>::
+    PeriodVariantObserverCoeffs(
+        const Eigen::Matrix<double, States, States>& Qcontinuous,
+        const Eigen::Matrix<double, Outputs, Outputs>& Rcontinuous,
+        const Eigen::Matrix<double, States, States>& PsteadyState)
+    : Qcontinuous(Qcontinuous),
+      Rcontinuous(Rcontinuous),
+      PsteadyState(PsteadyState) {}
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/PeriodVariantPlant.h
+++ b/wpilibc/src/main/native/include/frc/controller/PeriodVariantPlant.h
@@ -1,0 +1,279 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <vector>
+
+#include <Eigen/Core>
+#include <units/units.h>
+
+#include "frc/controller/PeriodVariantPlantCoeffs.h"
+
+namespace frc {
+
+/**
+ * A plant which discretizes its model after every sample period.
+ *
+ * Typical discrete state feedback implementations discretize with a nominal
+ * sample period offline. If the real system doesn't maintain this period, this
+ * nonlinearity can negatively affect the state estimate. This class discretizes
+ * the continuous model after each measurement based on the measured sample
+ * period.
+ *
+ * For more on the underlying math, read
+ * https://file.tavsys.net/control/state-space-guide.pdf.
+ */
+template <int States, int Inputs, int Outputs>
+class PeriodVariantPlant {
+ public:
+  /**
+   * Constructs a plant with the given coefficients.
+   *
+   * @param plantCoeffs         Plant coefficients.
+   * @param nominalSamplePeriod The nominal period at which the control loop
+   *                            will run.
+   */
+  explicit PeriodVariantPlant(
+      const PeriodVariantPlantCoeffs<States, Inputs, Outputs>& plantCoeffs,
+      const units::second_t nominalSamplePeriod = 5_ms);
+
+  virtual ~PeriodVariantPlant() = default;
+
+  PeriodVariantPlant(PeriodVariantPlant&&) = default;
+  PeriodVariantPlant& operator=(PeriodVariantPlant&&) = default;
+
+  /**
+   * Returns the system matrix A.
+   */
+  const Eigen::Matrix<double, States, States>& A() const;
+
+  /**
+   * Returns an element of the system matrix A.
+   *
+   * @param i Row of A.
+   * @param j Column of A.
+   */
+  double A(int i, int j) const;
+
+  /**
+   * Returns the input matrix B.
+   */
+  const Eigen::Matrix<double, States, Inputs>& B() const;
+
+  /**
+   * Returns an element of the input matrix B.
+   *
+   * @param i Row of B.
+   * @param j Column of B.
+   */
+  double B(int i, int j) const;
+
+  /**
+   * Returns the output matrix C.
+   */
+  const Eigen::Matrix<double, Outputs, States>& C() const;
+
+  /**
+   * Returns an element of the output matrix C.
+   *
+   * @param i Row of C.
+   * @param j Column of C.
+   */
+  double C(int i, int j) const;
+
+  /**
+   * Returns the feedthrough matrix D.
+   */
+  const Eigen::Matrix<double, Outputs, Inputs>& D() const;
+
+  /**
+   * Returns an element of the feedthrough matrix D.
+   *
+   * @param i Row of D.
+   * @param j Column of D.
+   */
+  double D(int i, int j) const;
+
+  /**
+   * Returns the current state X.
+   */
+  const Eigen::Matrix<double, States, 1>& X() const;
+
+  /**
+   * Returns an element of the current state x.
+   *
+   * @param i Row of x.
+   */
+  double X(int i) const;
+
+  /**
+   * Returns the current measurement vector y.
+   */
+  const Eigen::Matrix<double, Outputs, 1>& Y() const;
+
+  /**
+   * Returns an element of the current measurement vector y.
+   *
+   * @param i Row of y.
+   */
+  double Y(int i) const;
+
+  /**
+   * Set the initial state x.
+   *
+   * @param x The initial state.
+   */
+  void SetX(const Eigen::Matrix<double, States, 1>& x);
+
+  /**
+   * Set an element of the initial state x.
+   *
+   * @param i     Row of x.
+   * @param value Value of element of x.
+   */
+  void SetX(int i, double value);
+
+  /**
+   * Set the current measurement y.
+   *
+   * @param y The current measurement.
+   */
+  void SetY(const Eigen::Matrix<double, Outputs, 1>& y);
+
+  /**
+   * Set an element of the current measurement y.
+   *
+   * @param i     Row of y.
+   * @param value Value of element of y.
+   */
+  void SetY(int i, double value);
+
+  /**
+   * Adds the given coefficients to the plant for gain scheduling.
+   *
+   * @param coefficients Plant coefficients.
+   */
+  void AddCoefficients(
+      const PeriodVariantPlantCoeffs<States, Inputs, Outputs>& coefficients);
+
+  /**
+   * Returns the plant coefficients with the given index.
+   *
+   * @param index Index of coefficients.
+   */
+  const PeriodVariantPlantCoeffs<States, Inputs, Outputs>& GetCoefficients(
+      int index) const;
+
+  /**
+   * Returns the current plant coefficients.
+   */
+  const PeriodVariantPlantCoeffs<States, Inputs, Outputs>& GetCoefficients()
+      const;
+
+  /**
+   * Sets the current plant to be "index", clamped to be within range. This can
+   * be used for gain scheduling to make the current model match changed plant
+   * behavior.
+   *
+   * @param index The plant index.
+   */
+  void SetIndex(int index);
+
+  /**
+   * Returns the current plant index.
+   */
+  int GetIndex() const;
+
+  /**
+   * Resets the plant.
+   */
+  void Reset();
+
+  /**
+   * Computes the new x and y given the control input.
+   *
+   * @param u  The control input.
+   * @param dt The timestep.
+   */
+  void Update(const Eigen::Matrix<double, Inputs, 1>& u, units::second_t dt);
+
+  /**
+   * Computes the new x given the old x and the control input.
+   *
+   * This is used by state observers directly to run updates based on state
+   * estimate.
+   *
+   * @param x  The current state.
+   * @param u  The control input.
+   * @param dt The timestep.
+   */
+  Eigen::Matrix<double, States, 1> CalculateX(
+      const Eigen::Matrix<double, States, 1>& x,
+      const Eigen::Matrix<double, Inputs, 1>& u, units::second_t dt);
+
+  /**
+   * Computes the new y given the control input.
+   *
+   * This is used by state observers directly to run updates based on state
+   * estimate.
+   *
+   * @param x The current state.
+   * @param u The control input.
+   */
+  Eigen::Matrix<double, Outputs, 1> CalculateY(
+      const Eigen::Matrix<double, States, 1>& x,
+      const Eigen::Matrix<double, Inputs, 1>& u) const;
+
+ protected:
+  // These are accessible from non-templated subclasses.
+  static const int kStates = States;
+  static const int kInputs = Inputs;
+  static const int kOutputs = Outputs;
+
+ private:
+  /**
+   * Rediscretize the plant with the given timestep.
+   *
+   * @param dt Timestep.
+   */
+  void UpdateAB(units::second_t dt);
+
+  const units::second_t m_nominalSamplePeriod;
+
+  /**
+   * Current state.
+   */
+  Eigen::Matrix<double, States, 1> m_X;
+
+  /**
+   * Current output.
+   */
+  Eigen::Matrix<double, Outputs, 1> m_Y;
+
+  /**
+   * Discrete system matrix.
+   */
+  Eigen::Matrix<double, States, States> m_A;
+
+  /**
+   * Discrete input matrix.
+   */
+  Eigen::Matrix<double, States, Inputs> m_B;
+
+  /**
+   * Delayed u since predict and correct steps are run in reverse.
+   */
+  Eigen::Matrix<double, Inputs, 1> m_delayedU;
+
+  std::vector<PeriodVariantPlantCoeffs<States, Inputs, Outputs>> m_coefficients;
+  int m_index = 0;
+};
+
+}  // namespace frc
+
+#include "frc/controller/PeriodVariantPlant.inc"

--- a/wpilibc/src/main/native/include/frc/controller/PeriodVariantPlant.inc
+++ b/wpilibc/src/main/native/include/frc/controller/PeriodVariantPlant.inc
@@ -1,0 +1,194 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <cassert>
+
+#include <unsupported/Eigen/MatrixFunctions>
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs>
+PeriodVariantPlant<States, Inputs, Outputs>::PeriodVariantPlant(
+    const PeriodVariantPlantCoeffs<States, Inputs, Outputs>& plantCoeffs,
+    const units::second_t nominalSamplePeriod)
+    : m_nominalSamplePeriod(nominalSamplePeriod) {
+  AddCoefficients(plantCoeffs);
+  Reset();
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, States>&
+PeriodVariantPlant<States, Inputs, Outputs>::A() const {
+  return m_A;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantPlant<States, Inputs, Outputs>::A(int i, int j) const {
+  return A()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, Inputs>&
+PeriodVariantPlant<States, Inputs, Outputs>::B() const {
+  return m_B;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantPlant<States, Inputs, Outputs>::B(int i, int j) const {
+  return B()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Outputs, States>&
+PeriodVariantPlant<States, Inputs, Outputs>::C() const {
+  return GetCoefficients().C;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantPlant<States, Inputs, Outputs>::C(int i, int j) const {
+  return C()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Outputs, Inputs>&
+PeriodVariantPlant<States, Inputs, Outputs>::D() const {
+  return GetCoefficients().D;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantPlant<States, Inputs, Outputs>::D(int i, int j) const {
+  return D()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, 1>&
+PeriodVariantPlant<States, Inputs, Outputs>::X() const {
+  return m_X;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantPlant<States, Inputs, Outputs>::X(int i) const {
+  return X()(i, 0);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Outputs, 1>&
+PeriodVariantPlant<States, Inputs, Outputs>::Y() const {
+  return m_Y;
+}
+
+template <int States, int Inputs, int Outputs>
+double PeriodVariantPlant<States, Inputs, Outputs>::Y(int i) const {
+  return Y()(i, 0);
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantPlant<States, Inputs, Outputs>::SetX(
+    const Eigen::Matrix<double, States, 1>& x) {
+  m_X = x;
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantPlant<States, Inputs, Outputs>::SetX(int i, double value) {
+  m_X(i, 0) = value;
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantPlant<States, Inputs, Outputs>::SetY(
+    const Eigen::Matrix<double, Outputs, 1>& y) {
+  m_Y = y;
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantPlant<States, Inputs, Outputs>::SetY(int i, double value) {
+  m_Y(i, 0) = value;
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantPlant<States, Inputs, Outputs>::AddCoefficients(
+    const PeriodVariantPlantCoeffs<States, Inputs, Outputs>& coefficients) {
+  m_coefficients.emplace_back(coefficients);
+}
+
+template <int States, int Inputs, int Outputs>
+const PeriodVariantPlantCoeffs<States, Inputs, Outputs>&
+PeriodVariantPlant<States, Inputs, Outputs>::GetCoefficients(int index) const {
+  return m_coefficients[index];
+}
+
+template <int States, int Inputs, int Outputs>
+const PeriodVariantPlantCoeffs<States, Inputs, Outputs>&
+PeriodVariantPlant<States, Inputs, Outputs>::GetCoefficients() const {
+  return m_coefficients[m_index];
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantPlant<States, Inputs, Outputs>::SetIndex(int index) {
+  assert(index >= 0);
+  assert(index < static_cast<int>(m_coefficients.size()));
+  m_index = index;
+}
+
+template <int States, int Inputs, int Outputs>
+int PeriodVariantPlant<States, Inputs, Outputs>::GetIndex() const {
+  return m_index;
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantPlant<States, Inputs, Outputs>::Reset() {
+  m_X.setZero();
+  m_Y.setZero();
+  m_A.setZero();
+  m_B.setZero();
+  m_delayedU.setZero();
+  UpdateAB(m_nominalSamplePeriod);
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantPlant<States, Inputs, Outputs>::Update(
+    const Eigen::Matrix<double, Inputs, 1>& u, units::second_t dt) {
+  m_X = CalculateX(X(), m_delayedU);
+  m_Y = CalculateY(X(), m_delayedU);
+  m_delayedU = u;
+}
+
+template <int States, int Inputs, int Outputs>
+Eigen::Matrix<double, States, 1>
+PeriodVariantPlant<States, Inputs, Outputs>::CalculateX(
+    const Eigen::Matrix<double, States, 1>& x,
+    const Eigen::Matrix<double, Inputs, 1>& u, units::second_t dt) {
+  UpdateAB(dt);
+  return A() * x + B() * u;
+}
+
+template <int States, int Inputs, int Outputs>
+Eigen::Matrix<double, Outputs, 1>
+PeriodVariantPlant<States, Inputs, Outputs>::CalculateY(
+    const Eigen::Matrix<double, States, 1>& x,
+    const Eigen::Matrix<double, Inputs, 1>& u) const {
+  return C() * x + D() * u;
+}
+
+template <int States, int Inputs, int Outputs>
+void PeriodVariantPlant<States, Inputs, Outputs>::UpdateAB(units::second_t dt) {
+  // Matrices are blocked here to minimize matrix exponentiation calculations.
+  Eigen::Matrix<double, States + Inputs, States + Inputs> MstateContinuous;
+  MstateContinuous.setZero();
+  MstateContinuous.template block<States, States>(0, 0) =
+      GetCoefficients().Acontinuous * dt.to<double>();
+  MstateContinuous.template block<States, Inputs>(0, States) =
+      GetCoefficients().Bcontinuous * dt.to<double>();
+
+  Eigen::Matrix<double, States + Inputs, States + Inputs> Mstate =
+      MstateContinuous.exp();
+  m_A = Mstate.template block<States, States>(0, 0);
+  m_B = Mstate.template block<States, Inputs>(0, States);
+}
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/PeriodVariantPlantCoeffs.h
+++ b/wpilibc/src/main/native/include/frc/controller/PeriodVariantPlantCoeffs.h
@@ -1,0 +1,56 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+
+namespace frc {
+
+/**
+ * A container for all the period-variant plant coefficients.
+ */
+template <int States, int Inputs, int Outputs>
+struct PeriodVariantPlantCoeffs final {
+  /**
+   * Continuous system matrix.
+   */
+  const Eigen::Matrix<double, States, States> Acontinuous;
+
+  /**
+   * Continuous input matrix.
+   */
+  const Eigen::Matrix<double, States, Inputs> Bcontinuous;
+
+  /**
+   * Output matrix.
+   */
+  const Eigen::Matrix<double, Outputs, States> C;
+
+  /**
+   * Feedthrough matrix.
+   */
+  const Eigen::Matrix<double, Outputs, Inputs> D;
+
+  /**
+   * Construct the container for the period-variant plant coefficients.
+   *
+   * @param Acontinuous Continuous system matrix.
+   * @param Bcontinuous Continuous input matrix.
+   * @param C           Output matrix.
+   * @param D           Feedthrough matrix.
+   */
+  PeriodVariantPlantCoeffs(
+      const Eigen::Matrix<double, States, States>& Acontinuous,
+      const Eigen::Matrix<double, States, Inputs>& Bcontinuous,
+      const Eigen::Matrix<double, Outputs, States>& C,
+      const Eigen::Matrix<double, Outputs, Inputs>& D);
+};
+
+}  // namespace frc
+
+#include "frc/controller/PeriodVariantPlantCoeffs.inc"

--- a/wpilibc/src/main/native/include/frc/controller/PeriodVariantPlantCoeffs.inc
+++ b/wpilibc/src/main/native/include/frc/controller/PeriodVariantPlantCoeffs.inc
@@ -1,0 +1,20 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs>
+PeriodVariantPlantCoeffs<States, Inputs, Outputs>::PeriodVariantPlantCoeffs(
+    const Eigen::Matrix<double, States, States>& Acontinuous,
+    const Eigen::Matrix<double, States, Inputs>& Bcontinuous,
+    const Eigen::Matrix<double, Outputs, States>& C,
+    const Eigen::Matrix<double, Outputs, Inputs>& D)
+    : Acontinuous(Acontinuous), Bcontinuous(Bcontinuous), C(C), D(D) {}
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/StateSpaceController.h
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpaceController.h
@@ -1,0 +1,178 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <vector>
+
+#include <Eigen/Core>
+
+#include "frc/controller/StateSpaceControllerCoeffs.h"
+#include "frc/controller/StateSpacePlant.h"
+
+namespace frc {
+
+/**
+ * Contains the controller coefficients and logic for a state-space controller.
+ *
+ * State-space controllers generally use the control law u = -Kx. The
+ * feedforward used is u_ff = K_ff * (r_k+1 - A * r_k).
+ *
+ * For more on the underlying math, read
+ * https://file.tavsys.net/control/state-space-guide.pdf.
+ */
+template <int States, int Inputs, int Outputs>
+class StateSpaceController {
+ public:
+  /**
+   * Constructs a controller with the given coefficients and plant.
+   *
+   * @param controllerCoeffs Controller coefficients.
+   * @param plant            The plant used for the feedforward calculation.
+   */
+  StateSpaceController(const StateSpaceControllerCoeffs<
+                           States, Inputs, Outputs>& controllerCoeffs,
+                       StateSpacePlant<States, Inputs, Outputs>& plant);
+
+  StateSpaceController(StateSpaceController&&) = default;
+  StateSpaceController& operator=(StateSpaceController&&) = default;
+
+  /**
+   * Enables controller.
+   */
+  void Enable();
+
+  /**
+   * Disables controller, zeroing controller output U.
+   */
+  void Disable();
+
+  /**
+   * Returns the controller matrix K.
+   */
+  const Eigen::Matrix<double, Inputs, States>& K() const;
+
+  /**
+   * Returns an element of the controller matrix K.
+   *
+   * @param i Row of K.
+   * @param j Column of K.
+   */
+  double K(int i, int j) const;
+
+  /**
+   * Returns the feedforward controller matrix Kff.
+   */
+  const Eigen::Matrix<double, Inputs, States>& Kff() const;
+
+  /**
+   * Returns an element of the feedforward controller matrix Kff.
+   *
+   * @param i Row of Kff.
+   * @param j Column of Kff.
+   */
+  double Kff(int i, int j) const;
+
+  /**
+   * Returns the reference vector r.
+   */
+  const Eigen::Matrix<double, States, 1>& R() const;
+
+  /**
+   * Returns an element of the reference vector r.
+   *
+   * @param i Row of r.
+   */
+  double R(int i) const;
+
+  /**
+   * Returns the control input vector u.
+   */
+  const Eigen::Matrix<double, Inputs, 1>& U() const;
+
+  /**
+   * Returns an element of the control input vector u.
+   *
+   * @param i Row of u.
+   */
+  double U(int i) const;
+
+  /**
+   * Resets the controller.
+   */
+  void Reset();
+
+  /**
+   * Update controller without setting a new reference.
+   *
+   * @param x The current state x.
+   */
+  void Update(const Eigen::Matrix<double, States, 1>& x);
+
+  /**
+   * Set a new reference and update the controller.
+   *
+   * @param x     The current state x.
+   * @param nextR The next reference vector r.
+   */
+  void Update(const Eigen::Matrix<double, States, 1>& x,
+              const Eigen::Matrix<double, States, 1>& nextR);
+
+  /**
+   * Sets the current controller to be "index", clamped to be within range. This
+   * can be used for gain scheduling.
+   *
+   * @param index The controller index.
+   */
+  void SetIndex(int index);
+
+  /**
+   * Returns the currnet controller index.
+   */
+  int GetIndex() const;
+
+  /**
+   * Adds the given coefficients to the controller for gain scheduling.
+   */
+  void AddCoefficients(
+      const StateSpaceControllerCoeffs<States, Inputs, Outputs>& coefficients);
+
+  /**
+   * Returns the controller coefficients with the given index.
+   *
+   * @param index Index of coefficients.
+   */
+  const StateSpaceControllerCoeffs<States, Inputs, Outputs>& GetCoefficients(
+      int index) const;
+
+  /**
+   * Returns the current controller coefficients.
+   */
+  const StateSpaceControllerCoeffs<States, Inputs, Outputs>& GetCoefficients()
+      const;
+
+ private:
+  StateSpacePlant<States, Inputs, Outputs>* m_plant;
+
+  bool m_enabled = false;
+
+  // Current reference.
+  Eigen::Matrix<double, States, 1> m_r;
+
+  // Computed controller output after being capped.
+  Eigen::Matrix<double, Inputs, 1> m_u;
+
+  std::vector<StateSpaceControllerCoeffs<States, Inputs, Outputs>>
+      m_coefficients;
+  int m_index = 0;
+
+  void CapU();
+};
+
+}  // namespace frc
+
+#include "frc/controller/StateSpaceController.inc"

--- a/wpilibc/src/main/native/include/frc/controller/StateSpaceController.inc
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpaceController.inc
@@ -1,0 +1,147 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs>
+StateSpaceController<States, Inputs, Outputs>::StateSpaceController(
+    const StateSpaceControllerCoeffs<States, Inputs, Outputs>& controllerCoeffs,
+    StateSpacePlant<States, Inputs, Outputs>& plant)
+    : m_plant(&plant) {
+  AddCoefficients(controllerCoeffs);
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceController<States, Inputs, Outputs>::Enable() {
+  m_enabled = true;
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceController<States, Inputs, Outputs>::Disable() {
+  m_enabled = false;
+  m_u.setZero();
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Inputs, States>&
+StateSpaceController<States, Inputs, Outputs>::K() const {
+  return GetCoefficients().K;
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpaceController<States, Inputs, Outputs>::K(int i, int j) const {
+  return K()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Inputs, States>&
+StateSpaceController<States, Inputs, Outputs>::Kff() const {
+  return GetCoefficients().Kff;
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpaceController<States, Inputs, Outputs>::Kff(int i, int j) const {
+  return Kff()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, 1>&
+StateSpaceController<States, Inputs, Outputs>::R() const {
+  return m_r;
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpaceController<States, Inputs, Outputs>::R(int i) const {
+  return R()(i, 0);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Inputs, 1>&
+StateSpaceController<States, Inputs, Outputs>::U() const {
+  return m_u;
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpaceController<States, Inputs, Outputs>::U(int i) const {
+  return U()(i, 0);
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceController<States, Inputs, Outputs>::Reset() {
+  m_r.setZero();
+  m_u.setZero();
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceController<States, Inputs, Outputs>::Update(
+    const Eigen::Matrix<double, States, 1>& x) {
+  if (m_enabled) {
+    m_u = K() * (m_r - x) + Kff() * (m_r - m_plant->A() * m_r);
+    CapU();
+  }
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceController<States, Inputs, Outputs>::Update(
+    const Eigen::Matrix<double, States, 1>& x,
+    const Eigen::Matrix<double, States, 1>& nextR) {
+  if (m_enabled) {
+    m_u = K() * (m_r - x) + Kff() * (nextR - m_plant->A() * m_r);
+    CapU();
+    m_r = nextR;
+  }
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceController<States, Inputs, Outputs>::CapU() {
+  for (int i = 0; i < Inputs; ++i) {
+    if (U(i) > GetCoefficients().Umax(i)) {
+      m_u(i, 0) = GetCoefficients().Umax(i);
+    } else if (U(i) < GetCoefficients().Umin(i)) {
+      m_u(i, 0) = GetCoefficients().Umin(i);
+    }
+  }
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceController<States, Inputs, Outputs>::AddCoefficients(
+    const StateSpaceControllerCoeffs<States, Inputs, Outputs>& coefficients) {
+  m_coefficients.emplace_back(coefficients);
+}
+
+template <int States, int Inputs, int Outputs>
+const StateSpaceControllerCoeffs<States, Inputs, Outputs>&
+StateSpaceController<States, Inputs, Outputs>::GetCoefficients(
+    int index) const {
+  return m_coefficients[index];
+}
+
+template <int States, int Inputs, int Outputs>
+const StateSpaceControllerCoeffs<States, Inputs, Outputs>&
+StateSpaceController<States, Inputs, Outputs>::GetCoefficients() const {
+  return m_coefficients[m_index];
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceController<States, Inputs, Outputs>::SetIndex(int index) {
+  if (index < 0) {
+    m_index = 0;
+  } else if (index >= static_cast<int>(m_coefficients.size())) {
+    m_index = static_cast<int>(m_coefficients.size()) - 1;
+  } else {
+    m_index = index;
+  }
+}
+
+template <int States, int Inputs, int Outputs>
+int StateSpaceController<States, Inputs, Outputs>::GetIndex() const {
+  return m_index;
+}
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/StateSpaceControllerCoeffs.h
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpaceControllerCoeffs.h
@@ -1,0 +1,55 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+
+namespace frc {
+
+/**
+ * A container for all the state-space controller coefficients.
+ */
+template <int States, int Inputs, int Outputs>
+struct StateSpaceControllerCoeffs final {
+  /**
+   * Controller gain matrix.
+   */
+  const Eigen::Matrix<double, Inputs, States> K;
+
+  /**
+   * Controller feedforward gain matrix.
+   */
+  const Eigen::Matrix<double, Inputs, States> Kff;
+
+  /**
+   * Minimum control input.
+   */
+  const Eigen::Matrix<double, Inputs, 1> Umin;
+
+  /**
+   * Maximum control input.
+   */
+  const Eigen::Matrix<double, Inputs, 1> Umax;
+
+  /**
+   * Construct the container for the controller coefficients.
+   *
+   * @param K    Controller gain matrix.
+   * @param Kff  Controller feedforward gain matrix.
+   * @param Umin Minimum control input.
+   * @param Umax Maximum control input.
+   */
+  StateSpaceControllerCoeffs(const Eigen::Matrix<double, Inputs, States>& K,
+                             const Eigen::Matrix<double, Inputs, States>& Kff,
+                             const Eigen::Matrix<double, Inputs, 1>& Umin,
+                             const Eigen::Matrix<double, Inputs, 1>& Umax);
+};
+
+}  // namespace frc
+
+#include "frc/controller/StateSpaceControllerCoeffs.inc"

--- a/wpilibc/src/main/native/include/frc/controller/StateSpaceControllerCoeffs.inc
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpaceControllerCoeffs.inc
@@ -1,0 +1,20 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs>
+StateSpaceControllerCoeffs<States, Inputs, Outputs>::StateSpaceControllerCoeffs(
+    const Eigen::Matrix<double, Inputs, States>& K,
+    const Eigen::Matrix<double, Inputs, States>& Kff,
+    const Eigen::Matrix<double, Inputs, 1>& Umin,
+    const Eigen::Matrix<double, Inputs, 1>& Umax)
+    : K(K), Kff(Kff), Umin(Umin), Umax(Umax) {}
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/StateSpaceLoop.h
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpaceLoop.h
@@ -1,0 +1,205 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+
+#include "frc/controller/StateSpaceController.h"
+#include "frc/controller/StateSpaceObserver.h"
+#include "frc/controller/StateSpacePlant.h"
+
+namespace frc {
+
+/**
+ * Combines a plant, controller, and observer for controlling a mechanism with
+ * full state feedback.
+ *
+ * For everything in this file, "inputs" and "outputs" are defined from the
+ * perspective of the plant. This means U is an input and Y is an output
+ * (because you give the plant U (powers) and it gives you back a Y (sensor
+ * values). This is the opposite of what they mean from the perspective of the
+ * controller (U is an output because that's what goes to the motors and Y is an
+ * input because that's what comes back from the sensors).
+ *
+ * For more on the underlying math, read
+ * https://file.tavsys.net/control/state-space-guide.pdf.
+ */
+template <int States, int Inputs, int Outputs>
+class StateSpaceLoop {
+ public:
+  /**
+   * A convenience constructor for constructing a state-space loop with the
+   * given plant, controller, and observer coefficients.
+   *
+   * @param plantCoeffs      State-space plant coefficients.
+   * @param controllerCoeffs State-space controller coefficients.
+   * @param observerCoeffs   State-space observer coefficients.
+   */
+  StateSpaceLoop(
+      const StateSpacePlantCoeffs<States, Inputs, Outputs>& plantCoeffs,
+      const StateSpaceControllerCoeffs<States, Inputs, Outputs>&
+          controllerCoeffs,
+      const StateSpaceObserverCoeffs<States, Inputs, Outputs>& observerCoeffs);
+
+  /**
+   * Constructs a state-space loop with the given plant, controller, and
+   * observer.
+   *
+   * @param plant      State-space plant.
+   * @param controller State-space controller.
+   * @param observer   State-space observer.
+   */
+  StateSpaceLoop(StateSpacePlant<States, Inputs, Outputs>&& plant,
+                 StateSpaceController<States, Inputs, Outputs>&& controller,
+                 StateSpaceObserver<States, Inputs, Outputs>&& observer);
+
+  virtual ~StateSpaceLoop() = default;
+
+  StateSpaceLoop(StateSpaceLoop&&) = default;
+  StateSpaceLoop& operator=(StateSpaceLoop&&) = default;
+
+  /**
+   * Enables the controller.
+   */
+  void Enable();
+
+  /**
+   * Disables the controller and zeros the control input.
+   */
+  void Disable();
+
+  /**
+   * Returns the observer's state estimate x-hat.
+   */
+  const Eigen::Matrix<double, States, 1>& Xhat() const;
+
+  /**
+   * Returns an element of the observer's state estimate x-hat.
+   *
+   * @param i Row of x-hat.
+   */
+  double Xhat(int i) const;
+
+  /**
+   * Returns the controller's next reference r.
+   */
+  const Eigen::Matrix<double, States, 1>& NextR() const;
+
+  /**
+   * Returns an element of the controller's next reference r.
+   *
+   * @param i Row of r.
+   */
+  double NextR(int i) const;
+
+  /**
+   * Returns the controller's calculated control input u.
+   */
+  const Eigen::Matrix<double, Inputs, 1>& U() const;
+
+  /**
+   * Returns an element of the controller's calculated control input u.
+   *
+   * @param i Row of u.
+   */
+  double U(int i) const;
+
+  /**
+   * Set the initial state estimate x-hat.
+   *
+   * @param xHat The initial state estimate x-hat.
+   */
+  void SetXhat(const Eigen::Matrix<double, States, 1>& xHat);
+
+  /**
+   * Set an element of the initial state estimate x-hat.
+   *
+   * @param i     Row of x-hat.
+   * @param value Value for element of x-hat.
+   */
+  void SetXhat(int i, double value);
+
+  /**
+   * Set the next reference r.
+   *
+   * @param nextR Next reference.
+   */
+  void SetNextR(const Eigen::Matrix<double, States, 1>& nextR);
+
+  /**
+   * Return the plant used internally.
+   */
+  const StateSpacePlant<States, Inputs, Outputs>& GetPlant() const;
+
+  /**
+   * Return the controller used internally.
+   */
+  const StateSpaceController<States, Inputs, Outputs>& GetController() const;
+
+  /**
+   * Return the observer used internally.
+   */
+  const StateSpaceObserver<States, Inputs, Outputs>& GetObserver() const;
+
+  /**
+   * Zeroes reference r, controller output u, plant output y, and state estimate
+   * x-hat.
+   */
+  void Reset();
+
+  /**
+   * Returns difference between reference r and x-hat.
+   */
+  const Eigen::Matrix<double, States, 1> Error() const;
+
+  /**
+   * Correct the state estimate x-hat using the measurements in y.
+   *
+   * @param y Measurement vector.
+   */
+  void Correct(const Eigen::Matrix<double, Outputs, 1>& y);
+
+  /**
+   * Sets new controller output, projects model forward, and runs observer
+   * prediction.
+   *
+   * After calling this, the user should send the elements of u to the
+   * actuators.
+   */
+  void Predict();
+
+  /**
+   * Sets the current controller to be "index". This can be used for gain
+   * scheduling.
+   *
+   * @param index The controller index.
+   */
+  void SetIndex(int index);
+
+  /**
+   * Returns the current controller index.
+   */
+  int GetIndex() const;
+
+ protected:
+  StateSpacePlant<States, Inputs, Outputs> m_plant;
+  StateSpaceController<States, Inputs, Outputs> m_controller;
+  StateSpaceObserver<States, Inputs, Outputs> m_observer;
+
+  // Reference to go to in the next cycle (used by feedforward controller).
+  Eigen::Matrix<double, States, 1> m_nextR;
+
+  // These are accessible from non-templated subclasses.
+  static constexpr int kStates = States;
+  static constexpr int kInputs = Inputs;
+  static constexpr int kOutputs = Outputs;
+};
+
+}  // namespace frc
+
+#include "frc/controller/StateSpaceLoop.inc"

--- a/wpilibc/src/main/native/include/frc/controller/StateSpaceLoop.inc
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpaceLoop.inc
@@ -1,0 +1,152 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <utility>
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs>
+StateSpaceLoop<States, Inputs, Outputs>::StateSpaceLoop(
+    const StateSpacePlantCoeffs<States, Inputs, Outputs>& plantCoeffs,
+    const StateSpaceControllerCoeffs<States, Inputs, Outputs>& controllerCoeffs,
+    const StateSpaceObserverCoeffs<States, Inputs, Outputs>& observerCoeffs)
+    : m_plant(plantCoeffs),
+      m_controller(controllerCoeffs, m_plant),
+      m_observer(observerCoeffs, m_plant) {
+  Reset();
+}
+
+template <int States, int Inputs, int Outputs>
+StateSpaceLoop<States, Inputs, Outputs>::StateSpaceLoop(
+    StateSpacePlant<States, Inputs, Outputs>&& plant,
+    StateSpaceController<States, Inputs, Outputs>&& controller,
+    StateSpaceObserver<States, Inputs, Outputs>&& observer)
+    : m_plant(std::move(plant)),
+      m_controller(std::move(controller)),
+      m_observer(std::move(observer)) {
+  Reset();
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceLoop<States, Inputs, Outputs>::Enable() {
+  m_controller.Enable();
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceLoop<States, Inputs, Outputs>::Disable() {
+  m_controller.Disable();
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, 1>&
+StateSpaceLoop<States, Inputs, Outputs>::Xhat() const {
+  return m_observer.Xhat();
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpaceLoop<States, Inputs, Outputs>::Xhat(int i) const {
+  return m_observer.Xhat(i);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, 1>&
+StateSpaceLoop<States, Inputs, Outputs>::NextR() const {
+  return m_nextR;
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpaceLoop<States, Inputs, Outputs>::NextR(int i) const {
+  return NextR()(i, 0);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Inputs, 1>&
+StateSpaceLoop<States, Inputs, Outputs>::U() const {
+  return m_controller.U();
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpaceLoop<States, Inputs, Outputs>::U(int i) const {
+  return m_controller.U(i);
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceLoop<States, Inputs, Outputs>::SetXhat(
+    const Eigen::Matrix<double, States, 1>& xHat) {
+  m_observer.SetXhat(xHat);
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceLoop<States, Inputs, Outputs>::SetXhat(int i, double value) {
+  m_observer.SetXhat(i, value);
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceLoop<States, Inputs, Outputs>::SetNextR(
+    const Eigen::Matrix<double, States, 1>& nextR) {
+  m_nextR = nextR;
+}
+
+template <int States, int Inputs, int Outputs>
+const StateSpacePlant<States, Inputs, Outputs>&
+StateSpaceLoop<States, Inputs, Outputs>::GetPlant() const {
+  return m_plant;
+}
+
+template <int States, int Inputs, int Outputs>
+const StateSpaceController<States, Inputs, Outputs>&
+StateSpaceLoop<States, Inputs, Outputs>::GetController() const {
+  return m_controller;
+}
+
+template <int States, int Inputs, int Outputs>
+const StateSpaceObserver<States, Inputs, Outputs>&
+StateSpaceLoop<States, Inputs, Outputs>::GetObserver() const {
+  return m_observer;
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceLoop<States, Inputs, Outputs>::Reset() {
+  m_plant.Reset();
+  m_controller.Reset();
+  m_observer.Reset();
+  m_nextR.setZero();
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, 1>
+StateSpaceLoop<States, Inputs, Outputs>::Error() const {
+  return m_controller.R() - m_observer.Xhat();
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceLoop<States, Inputs, Outputs>::Correct(
+    const Eigen::Matrix<double, Outputs, 1>& y) {
+  m_observer.Correct(m_controller.U(), y);
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceLoop<States, Inputs, Outputs>::Predict() {
+  m_controller.Update(m_observer.Xhat(), m_nextR);
+  m_observer.Predict(m_controller.U());
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceLoop<States, Inputs, Outputs>::SetIndex(int index) {
+  m_plant.SetIndex(index);
+  m_controller.SetIndex(index);
+  m_observer.SetIndex(index);
+}
+
+template <int States, int Inputs, int Outputs>
+int StateSpaceLoop<States, Inputs, Outputs>::GetIndex() const {
+  return m_plant.GetIndex();
+}
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/StateSpaceObserver.h
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpaceObserver.h
@@ -1,0 +1,164 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <vector>
+
+#include <Eigen/Core>
+
+#include "frc/controller/StateSpaceObserverCoeffs.h"
+#include "frc/controller/StateSpacePlant.h"
+
+namespace frc {
+
+/**
+ * Luenberger observers combine predictions from a model and measurements to
+ * give an estimate of the true system state.
+ *
+ * Luenberger observers use an L gain matrix to determine whether to trust the
+ * model or measurements more. Kalman filter theory uses statistics to compute
+ * an optimal L gain (alternatively called the Kalman gain, K) which minimizes
+ * the sum of squares error in the state estimate.
+ *
+ * Luenberger observers run the prediction and correction steps simultaneously
+ * while Kalman filters run them sequentially. To implement a discrete-time
+ * Kalman filter as a Luenberger observer, use the following mapping:
+ * <pre>C = H, L = A * K</pre>
+ * (H is the measurement matrix).
+ *
+ * For more on the underlying math, read
+ * https://file.tavsys.net/control/state-space-guide.pdf.
+ */
+template <int States, int Inputs, int Outputs>
+class StateSpaceObserver {
+ public:
+  /**
+   * Constructs a state-space observer with the given coefficients and plant.
+   *
+   * @param observerCoeffs Observer coefficients.
+   * @param plant          The plant used for the prediction step.
+   */
+  StateSpaceObserver(
+      const StateSpaceObserverCoeffs<States, Inputs, Outputs>& observerCoeffs,
+      StateSpacePlant<States, Inputs, Outputs>& plant);
+
+  StateSpaceObserver(StateSpaceObserver&&) = default;
+  StateSpaceObserver& operator=(StateSpaceObserver&&) = default;
+
+  /**
+   * Returns the Kalman gain matrix K.
+   */
+  const Eigen::Matrix<double, States, Outputs>& K() const;
+
+  /**
+   * Returns an element of the Kalman gain matrix K.
+   *
+   * @param i Row of K.
+   * @param j Column of K.
+   */
+  double K(int i, int j) const;
+
+  /**
+   * Returns the state estimate x-hat.
+   */
+  const Eigen::Matrix<double, States, 1>& Xhat() const;
+
+  /**
+   * Returns an element of the state estimate x-hat.
+   *
+   * @param i Row of x-hat.
+   */
+  double Xhat(int i) const;
+
+  /**
+   * Set initial state estimate x-hat.
+   *
+   * @param xHat The state estimate x-hat.
+   */
+  void SetXhat(const Eigen::Matrix<double, States, 1>& xHat);
+
+  /**
+   * Set an element of the initial state estimate x-hat.
+   *
+   * @param i     Row of x-hat.
+   * @param value Value for element of x-hat.
+   */
+  void SetXhat(int i, double value);
+
+  /**
+   * Resets the observer.
+   */
+  void Reset();
+
+  /**
+   * Project the model into the future with a new control input u.
+   *
+   * @param newU New control input from controller.
+   * @param dt   Timestep for prediction.
+   */
+  void Predict(const Eigen::Matrix<double, Inputs, 1>& newU);
+
+  /**
+   * Correct the state estimate x-hat using the measurements in y.
+   *
+   * @param u Same control input used in the predict step.
+   * @param y Measurement vector.
+   */
+  void Correct(const Eigen::Matrix<double, Inputs, 1>& u,
+               const Eigen::Matrix<double, Outputs, 1>& y);
+
+  /**
+   * Adds the given coefficients to the observer for gain scheduling.
+   *
+   * @param coefficients Observer coefficients.
+   */
+  void AddCoefficients(
+      const StateSpaceObserverCoeffs<States, Inputs, Outputs>& coefficients);
+
+  /**
+   * Returns the observer coefficients with the given index.
+   *
+   * @param index Index of coefficients.
+   */
+  const StateSpaceObserverCoeffs<States, Inputs, Outputs>& GetCoefficients(
+      int index) const;
+
+  /**
+   * Returns the current observer coefficients.
+   */
+  const StateSpaceObserverCoeffs<States, Inputs, Outputs>& GetCoefficients()
+      const;
+
+  /**
+   * Sets the current observer to be "index", clamped to be within range. This
+   * can be used for gain scheduling.
+   *
+   * @param index The controller index.
+   */
+  void SetIndex(int index);
+
+  /**
+   * Returns the current observer index.
+   */
+  int GetIndex() const;
+
+ private:
+  StateSpacePlant<States, Inputs, Outputs>* m_plant;
+
+  /**
+   * Internal state estimate.
+   */
+  Eigen::Matrix<double, States, 1> m_Xhat;
+
+  std::vector<StateSpaceObserverCoeffs<States, Inputs, Outputs>> m_coefficients;
+  int m_index = 0;
+};
+
+}  // namespace frc
+
+#include "frc/controller/StateSpaceObserver.inc"

--- a/wpilibc/src/main/native/include/frc/controller/StateSpaceObserver.inc
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpaceObserver.inc
@@ -1,0 +1,105 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs>
+StateSpaceObserver<States, Inputs, Outputs>::StateSpaceObserver(
+    const StateSpaceObserverCoeffs<States, Inputs, Outputs>& observerCoeffs,
+    StateSpacePlant<States, Inputs, Outputs>& plant)
+    : m_plant(&plant) {
+  AddCoefficients(observerCoeffs);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, Outputs>&
+StateSpaceObserver<States, Inputs, Outputs>::K() const {
+  return GetCoefficients().K;
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpaceObserver<States, Inputs, Outputs>::K(int i, int j) const {
+  return K()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, 1>&
+StateSpaceObserver<States, Inputs, Outputs>::Xhat() const {
+  return m_Xhat;
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpaceObserver<States, Inputs, Outputs>::Xhat(int i) const {
+  return Xhat()(i, 0);
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceObserver<States, Inputs, Outputs>::SetXhat(
+    const Eigen::Matrix<double, States, 1>& xHat) {
+  m_Xhat = xHat;
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceObserver<States, Inputs, Outputs>::SetXhat(int i, double value) {
+  m_Xhat(i, 0) = value;
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceObserver<States, Inputs, Outputs>::Reset() {
+  m_Xhat.setZero();
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceObserver<States, Inputs, Outputs>::Predict(
+    const Eigen::Matrix<double, Inputs, 1>& newU) {
+  m_Xhat = m_plant->CalculateX(Xhat(), newU);
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceObserver<States, Inputs, Outputs>::Correct(
+    const Eigen::Matrix<double, Inputs, 1>& u,
+    const Eigen::Matrix<double, Outputs, 1>& y) {
+  m_Xhat += K() * (y - m_plant->CalculateY(Xhat(), u));
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceObserver<States, Inputs, Outputs>::AddCoefficients(
+    const StateSpaceObserverCoeffs<States, Inputs, Outputs>& coefficients) {
+  m_coefficients.emplace_back(coefficients);
+}
+
+template <int States, int Inputs, int Outputs>
+const StateSpaceObserverCoeffs<States, Inputs, Outputs>&
+StateSpaceObserver<States, Inputs, Outputs>::GetCoefficients(int index) const {
+  return m_coefficients[index];
+}
+
+template <int States, int Inputs, int Outputs>
+const StateSpaceObserverCoeffs<States, Inputs, Outputs>&
+StateSpaceObserver<States, Inputs, Outputs>::GetCoefficients() const {
+  return m_coefficients[m_index];
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpaceObserver<States, Inputs, Outputs>::SetIndex(int index) {
+  if (index < 0) {
+    m_index = 0;
+  } else if (index >= static_cast<int>(m_coefficients.size())) {
+    m_index = static_cast<int>(m_coefficients.size()) - 1;
+  } else {
+    m_index = index;
+  }
+}
+
+template <int States, int Inputs, int Outputs>
+int StateSpaceObserver<States, Inputs, Outputs>::GetIndex() const {
+  return m_index;
+}
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/StateSpaceObserverCoeffs.h
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpaceObserverCoeffs.h
@@ -1,0 +1,35 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+
+namespace frc {
+
+/**
+ * A container for all the observer coefficients.
+ */
+template <int States, int Inputs, int Outputs>
+struct StateSpaceObserverCoeffs final {
+  /**
+   * Estimator gain matrix.
+   */
+  const Eigen::Matrix<double, States, Outputs> K;
+
+  /**
+   * Construct the container for the observer coefficients.
+   *
+   * @param K The Kalman gain matrix.
+   */
+  explicit StateSpaceObserverCoeffs(
+      const Eigen::Matrix<double, States, Outputs>& K);
+};
+
+}  // namespace frc
+
+#include "frc/controller/StateSpaceObserverCoeffs.inc"

--- a/wpilibc/src/main/native/include/frc/controller/StateSpaceObserverCoeffs.inc
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpaceObserverCoeffs.inc
@@ -1,0 +1,17 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs>
+StateSpaceObserverCoeffs<States, Inputs, Outputs>::StateSpaceObserverCoeffs(
+    const Eigen::Matrix<double, States, Outputs>& K)
+    : K(K) {}
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/StateSpacePlant.h
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpacePlant.h
@@ -1,0 +1,239 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <vector>
+
+#include <Eigen/Core>
+
+#include "frc/controller/StateSpacePlantCoeffs.h"
+
+namespace frc {
+
+/**
+ * A plant defined using state-space notation.
+ *
+ * A plant is a mathematical model of a system's dynamics.
+ *
+ * For more on the underlying math, read
+ * https://file.tavsys.net/control/state-space-guide.pdf.
+ */
+template <int States, int Inputs, int Outputs>
+class StateSpacePlant {
+ public:
+  /**
+   * Constructs a plant with the given coefficients.
+   *
+   * @param plantCoeffs Plant coefficients.
+   */
+  explicit StateSpacePlant(
+      const StateSpacePlantCoeffs<States, Inputs, Outputs>& plantCoeffs);
+
+  virtual ~StateSpacePlant() = default;
+
+  StateSpacePlant(StateSpacePlant&&) = default;
+  StateSpacePlant& operator=(StateSpacePlant&&) = default;
+
+  /**
+   * Returns the system matrix A.
+   */
+  const Eigen::Matrix<double, States, States>& A() const;
+
+  /**
+   * Returns an element of the system matrix A.
+   *
+   * @param i Row of A.
+   * @param j Column of A.
+   */
+  double A(int i, int j) const;
+
+  /**
+   * Returns the input matrix B.
+   */
+  const Eigen::Matrix<double, States, Inputs>& B() const;
+
+  /**
+   * Returns an element of the input matrix B.
+   *
+   * @param i Row of B.
+   * @param j Column of B.
+   */
+  double B(int i, int j) const;
+
+  /**
+   * Returns the output matrix C.
+   */
+  const Eigen::Matrix<double, Outputs, States>& C() const;
+
+  /**
+   * Returns an element of the output matrix C.
+   *
+   * @param i Row of C.
+   * @param j Column of C.
+   */
+  double C(int i, int j) const;
+
+  /**
+   * Returns the feedthrough matrix D.
+   */
+  const Eigen::Matrix<double, Outputs, Inputs>& D() const;
+
+  /**
+   * Returns an element of the feedthrough matrix D.
+   *
+   * @param i Row of D.
+   * @param j Column of D.
+   */
+  double D(int i, int j) const;
+
+  /**
+   * Returns the current state X.
+   */
+  const Eigen::Matrix<double, States, 1>& X() const;
+
+  /**
+   * Returns an element of the current state x.
+   *
+   * @param i Row of x.
+   */
+  double X(int i) const;
+
+  /**
+   * Returns the current measurement vector y.
+   */
+  const Eigen::Matrix<double, Outputs, 1>& Y() const;
+
+  /**
+   * Returns an element of the current measurement vector y.
+   *
+   * @param i Row of y.
+   */
+  double Y(int i) const;
+
+  /**
+   * Set the initial state x.
+   *
+   * @param x The initial state.
+   */
+  void SetX(const Eigen::Matrix<double, States, 1>& x);
+
+  /**
+   * Set an element of the initial state x.
+   *
+   * @param i     Row of x.
+   * @param value Value of element of x.
+   */
+  void SetX(int i, double value);
+
+  /**
+   * Set the current measurement y.
+   *
+   * @param y The current measurement.
+   */
+  void SetY(const Eigen::Matrix<double, Outputs, 1>& y);
+
+  /**
+   * Set an element of the current measurement y.
+   *
+   * @param i     Row of y.
+   * @param value Value of element of y.
+   */
+  void SetY(int i, double value);
+
+  /**
+   * Adds the given coefficients to the plant for gain scheduling.
+   *
+   * @param coefficients Plant coefficients.
+   */
+  void AddCoefficients(
+      const StateSpacePlantCoeffs<States, Inputs, Outputs>& coefficients);
+
+  /**
+   * Returns the plant coefficients with the given index.
+   *
+   * @param index Index of coefficients.
+   */
+  const StateSpacePlantCoeffs<States, Inputs, Outputs>& GetCoefficients(
+      int index) const;
+
+  /**
+   * Returns the current plant coefficients.
+   */
+  const StateSpacePlantCoeffs<States, Inputs, Outputs>& GetCoefficients() const;
+
+  /**
+   * Sets the current plant to be "index", clamped to be within range. This can
+   * be used for gain scheduling to make the current model match changed plant
+   * behavior.
+   *
+   * @param index The plant index.
+   */
+  void SetIndex(int index);
+
+  /**
+   * Returns the current plant index.
+   */
+  int GetIndex() const;
+
+  /**
+   * Resets the plant.
+   */
+  void Reset();
+
+  /**
+   * Computes the new x and y given the control input.
+   *
+   * @param x The current state.
+   * @param u The control input.
+   */
+  void Update(const Eigen::Matrix<double, States, 1>& x,
+              const Eigen::Matrix<double, Inputs, 1>& u);
+
+  /**
+   * Computes the new x given the old x and the control input.
+   *
+   * This is used by state observers directly to run updates based on state
+   * estimate.
+   *
+   * @param x The current state.
+   * @param u The control input.
+   */
+  Eigen::Matrix<double, States, 1> CalculateX(
+      const Eigen::Matrix<double, States, 1>& x,
+      const Eigen::Matrix<double, Inputs, 1>& u) const;
+
+  /**
+   * Computes the new y given the control input.
+   *
+   * This is used by state observers directly to run updates based on state
+   * estimate.
+   *
+   * @param x The current state.
+   * @param u The control input.
+   */
+  Eigen::Matrix<double, Outputs, 1> CalculateY(
+      const Eigen::Matrix<double, States, 1>& x,
+      const Eigen::Matrix<double, Inputs, 1>& u) const;
+
+ protected:
+  // These are accessible from non-templated subclasses.
+  static constexpr int kStates = States;
+  static constexpr int kInputs = Inputs;
+  static constexpr int kOutputs = Outputs;
+
+ private:
+  Eigen::Matrix<double, States, 1> m_X;
+  Eigen::Matrix<double, Outputs, 1> m_Y;
+
+  std::vector<StateSpacePlantCoeffs<States, Inputs, Outputs>> m_coefficients;
+  int m_index = 0;
+};
+
+}  // namespace frc
+
+#include "frc/controller/StateSpacePlant.inc"

--- a/wpilibc/src/main/native/include/frc/controller/StateSpacePlant.inc
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpacePlant.inc
@@ -1,0 +1,169 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <cassert>
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs>
+StateSpacePlant<States, Inputs, Outputs>::StateSpacePlant(
+    const StateSpacePlantCoeffs<States, Inputs, Outputs>& plantCoeffs) {
+  AddCoefficients(plantCoeffs);
+  Reset();
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, States>&
+StateSpacePlant<States, Inputs, Outputs>::A() const {
+  return GetCoefficients().A;
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpacePlant<States, Inputs, Outputs>::A(int i, int j) const {
+  return A()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, Inputs>&
+StateSpacePlant<States, Inputs, Outputs>::B() const {
+  return GetCoefficients().B;
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpacePlant<States, Inputs, Outputs>::B(int i, int j) const {
+  return B()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Outputs, States>&
+StateSpacePlant<States, Inputs, Outputs>::C() const {
+  return GetCoefficients().C;
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpacePlant<States, Inputs, Outputs>::C(int i, int j) const {
+  return C()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Outputs, Inputs>&
+StateSpacePlant<States, Inputs, Outputs>::D() const {
+  return GetCoefficients().D;
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpacePlant<States, Inputs, Outputs>::D(int i, int j) const {
+  return D()(i, j);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, States, 1>&
+StateSpacePlant<States, Inputs, Outputs>::X() const {
+  return m_X;
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpacePlant<States, Inputs, Outputs>::X(int i) const {
+  return X()(i, 0);
+}
+
+template <int States, int Inputs, int Outputs>
+const Eigen::Matrix<double, Outputs, 1>&
+StateSpacePlant<States, Inputs, Outputs>::Y() const {
+  return m_Y;
+}
+
+template <int States, int Inputs, int Outputs>
+double StateSpacePlant<States, Inputs, Outputs>::Y(int i) const {
+  return Y()(i, 0);
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpacePlant<States, Inputs, Outputs>::SetX(
+    const Eigen::Matrix<double, States, 1>& x) {
+  m_X = x;
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpacePlant<States, Inputs, Outputs>::SetX(int i, double value) {
+  m_X(i, 0) = value;
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpacePlant<States, Inputs, Outputs>::SetY(
+    const Eigen::Matrix<double, Outputs, 1>& y) {
+  m_Y = y;
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpacePlant<States, Inputs, Outputs>::SetY(int i, double value) {
+  m_Y(i, 0) = value;
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpacePlant<States, Inputs, Outputs>::AddCoefficients(
+    const StateSpacePlantCoeffs<States, Inputs, Outputs>& coefficients) {
+  m_coefficients.emplace_back(coefficients);
+}
+
+template <int States, int Inputs, int Outputs>
+const StateSpacePlantCoeffs<States, Inputs, Outputs>&
+StateSpacePlant<States, Inputs, Outputs>::GetCoefficients(int index) const {
+  return m_coefficients[index];
+}
+
+template <int States, int Inputs, int Outputs>
+const StateSpacePlantCoeffs<States, Inputs, Outputs>&
+StateSpacePlant<States, Inputs, Outputs>::GetCoefficients() const {
+  return m_coefficients[m_index];
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpacePlant<States, Inputs, Outputs>::SetIndex(int index) {
+  assert(index >= 0);
+  assert(index < static_cast<int>(m_coefficients.size()));
+  m_index = index;
+}
+
+template <int States, int Inputs, int Outputs>
+int StateSpacePlant<States, Inputs, Outputs>::GetIndex() const {
+  return m_index;
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpacePlant<States, Inputs, Outputs>::Reset() {
+  m_X.setZero();
+  m_Y.setZero();
+}
+
+template <int States, int Inputs, int Outputs>
+void StateSpacePlant<States, Inputs, Outputs>::Update(
+    const Eigen::Matrix<double, States, 1>& x,
+    const Eigen::Matrix<double, Inputs, 1>& u) {
+  m_X = CalculateX(x, u);
+  m_Y = CalculateY(x, u);
+}
+
+template <int States, int Inputs, int Outputs>
+Eigen::Matrix<double, States, 1>
+StateSpacePlant<States, Inputs, Outputs>::CalculateX(
+    const Eigen::Matrix<double, States, 1>& x,
+    const Eigen::Matrix<double, Inputs, 1>& u) const {
+  return A() * x + B() * u;
+}
+
+template <int States, int Inputs, int Outputs>
+Eigen::Matrix<double, Outputs, 1>
+StateSpacePlant<States, Inputs, Outputs>::CalculateY(
+    const Eigen::Matrix<double, States, 1>& x,
+    const Eigen::Matrix<double, Inputs, 1>& u) const {
+  return C() * x + D() * u;
+}
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/StateSpacePlantCoeffs.h
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpacePlantCoeffs.h
@@ -1,0 +1,55 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+
+namespace frc {
+
+/**
+ * A container for all the state-space plant coefficients.
+ */
+template <int States, int Inputs, int Outputs>
+struct StateSpacePlantCoeffs final {
+  /**
+   * System matrix.
+   */
+  const Eigen::Matrix<double, States, States> A;
+
+  /**
+   * Input matrix.
+   */
+  const Eigen::Matrix<double, States, Inputs> B;
+
+  /**
+   * Output matrix.
+   */
+  const Eigen::Matrix<double, Outputs, States> C;
+
+  /**
+   * Feedthrough matrix.
+   */
+  const Eigen::Matrix<double, Outputs, Inputs> D;
+
+  /**
+   * Construct the container for the state-space plant coefficients.
+   *
+   * @param A System matrix.
+   * @param B Input matrix.
+   * @param C Output matrix.
+   * @param D Feedthrough matrix.
+   */
+  StateSpacePlantCoeffs(const Eigen::Matrix<double, States, States>& A,
+                        const Eigen::Matrix<double, States, Inputs>& B,
+                        const Eigen::Matrix<double, Outputs, States>& C,
+                        const Eigen::Matrix<double, Outputs, Inputs>& D);
+};
+
+}  // namespace frc
+
+#include "frc/controller/StateSpacePlantCoeffs.inc"

--- a/wpilibc/src/main/native/include/frc/controller/StateSpacePlantCoeffs.inc
+++ b/wpilibc/src/main/native/include/frc/controller/StateSpacePlantCoeffs.inc
@@ -1,0 +1,20 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs>
+StateSpacePlantCoeffs<States, Inputs, Outputs>::StateSpacePlantCoeffs(
+    const Eigen::Matrix<double, States, States>& A,
+    const Eigen::Matrix<double, States, Inputs>& B,
+    const Eigen::Matrix<double, Outputs, States>& C,
+    const Eigen::Matrix<double, Outputs, Inputs>& D)
+    : A(A), B(B), C(C), D(D) {}
+
+}  // namespace frc

--- a/wpilibc/src/test/native/cpp/control/PeriodVariant/ElevatorCoeffs.cpp
+++ b/wpilibc/src/test/native/cpp/control/PeriodVariant/ElevatorCoeffs.cpp
@@ -1,0 +1,64 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "control/PeriodVariant/ElevatorCoeffs.h"
+
+#include <Eigen/Core>
+
+frc::PeriodVariantPlantCoeffs<2, 1, 1> MakeElevatorPVPlantCoeffs() {
+  Eigen::Matrix<double, 2, 2> Acontinuous;
+  Acontinuous(0, 0) = 0.0;
+  Acontinuous(0, 1) = 1.0;
+  Acontinuous(1, 0) = 0.0;
+  Acontinuous(1, 1) = -164.20904979369794;
+  Eigen::Matrix<double, 2, 1> Bcontinuous;
+  Bcontinuous(0, 0) = 0.0;
+  Bcontinuous(1, 0) = 21.457377744727182;
+  Eigen::Matrix<double, 1, 2> C;
+  C(0, 0) = 1.0;
+  C(0, 1) = 0.0;
+  Eigen::Matrix<double, 1, 1> D;
+  D(0, 0) = 0.0;
+  return frc::PeriodVariantPlantCoeffs<2, 1, 1>(Acontinuous, Bcontinuous, C, D);
+}
+
+frc::StateSpaceControllerCoeffs<2, 1, 1> MakeElevatorPVControllerCoeffs() {
+  Eigen::Matrix<double, 1, 2> K;
+  K(0, 0) = 232.76812610676956;
+  K(0, 1) = 5.540693882702349;
+  Eigen::Matrix<double, 1, 2> Kff;
+  Kff(0, 0) = 12.902151500051774;
+  Kff(0, 1) = 11.23863895630079;
+  Eigen::Matrix<double, 1, 1> Umin;
+  Umin(0, 0) = -12.0;
+  Eigen::Matrix<double, 1, 1> Umax;
+  Umax(0, 0) = 12.0;
+  return frc::StateSpaceControllerCoeffs<2, 1, 1>(K, Kff, Umin, Umax);
+}
+
+frc::PeriodVariantObserverCoeffs<2, 1, 1> MakeElevatorPVObserverCoeffs() {
+  Eigen::Matrix<double, 2, 2> Qcontinuous;
+  Qcontinuous(0, 0) = 0.0025000000000000005;
+  Qcontinuous(0, 1) = 0.0;
+  Qcontinuous(1, 0) = 0.0;
+  Qcontinuous(1, 1) = 1.0;
+  Eigen::Matrix<double, 1, 1> Rcontinuous;
+  Rcontinuous(0, 0) = 1e-08;
+  Eigen::Matrix<double, 2, 2> PsteadyState;
+  PsteadyState(0, 0) = 9.99996023173184e-09;
+  PsteadyState(0, 1) = 7.34757941922686e-09;
+  PsteadyState(1, 0) = 7.347579419241315e-09;
+  PsteadyState(1, 1) = 1.2335349474145199;
+  return frc::PeriodVariantObserverCoeffs<2, 1, 1>(Qcontinuous, Rcontinuous,
+                                                   PsteadyState);
+}
+
+frc::PeriodVariantLoop<2, 1, 1> MakeElevatorPVLoop() {
+  return frc::PeriodVariantLoop<2, 1, 1>(MakeElevatorPVPlantCoeffs(),
+                                         MakeElevatorPVControllerCoeffs(),
+                                         MakeElevatorPVObserverCoeffs());
+}

--- a/wpilibc/src/test/native/cpp/control/PeriodVariantTest.cpp
+++ b/wpilibc/src/test/native/cpp/control/PeriodVariantTest.cpp
@@ -1,0 +1,73 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <control/PeriodVariant/ElevatorCoeffs.h>
+#include <frc/controller/PeriodVariantLoop.h>
+
+#include <cmath>
+#include <random>
+
+#include <Eigen/Core>
+
+#include "gtest/gtest.h"
+
+using namespace frc;
+
+constexpr double kNominalDt = 0.005;
+constexpr double kPositionStddev = 0.0001;
+
+void update(PeriodVariantLoop<2, 1, 1>& loop, double dt, double yNoise) {
+  Eigen::Matrix<double, 1, 1> y =
+      loop.GetPlant().CalculateY(loop.Xhat(), loop.U()) +
+      Eigen::Matrix<double, 1, 1>(yNoise);
+
+  loop.Correct(y);
+  loop.Predict(units::second_t{dt});
+}
+
+TEST(PeriodVariant, TestEnabled) {
+  PeriodVariantLoop<2, 1, 1> m_loop{MakeElevatorPVLoop()};
+  std::default_random_engine generator;
+  std::normal_distribution<double> dist;
+
+  Eigen::Matrix<double, 2, 1> references;
+  references << 2.0, 0.0;
+  m_loop.SetNextR(references);
+
+  m_loop.Enable();
+
+  for (int i = 0; i < 350; i++) {
+    double dtNoise = dist(generator);
+    double dt = std::abs(kNominalDt + (dtNoise * 0.02));
+    double yNoise = dist(generator) * (kPositionStddev / kNominalDt) * dt;
+    update(m_loop, dt, yNoise);
+    EXPECT_GE(m_loop.U(0), -12.0);
+    EXPECT_LE(m_loop.U(0), 12.0);
+  }
+
+  EXPECT_LT(std::abs(m_loop.Xhat(0) - 2.0), 0.05);
+  EXPECT_LT(std::abs(m_loop.Xhat(1) - 0.0), 0.5);
+}
+
+TEST(PeriodVariant, TestDisabled) {
+  PeriodVariantLoop<2, 1, 1> m_loop{MakeElevatorPVLoop()};
+
+  Eigen::Matrix<double, 2, 1> references;
+  references << 2.0, 0.0;
+
+  m_loop.SetNextR(references);
+
+  for (int i = 0; i < 100; i++) {
+    update(m_loop, 0.0, 0.0);
+  }
+
+  auto position = m_loop.Xhat(0);
+  auto velocity = m_loop.Xhat(1);
+
+  EXPECT_LT(std::abs(position), 1E-9);
+  EXPECT_LT(std::abs(velocity), 1E-9);
+}

--- a/wpilibc/src/test/native/cpp/control/StateSpace/ElevatorCoeffs.cpp
+++ b/wpilibc/src/test/native/cpp/control/StateSpace/ElevatorCoeffs.cpp
@@ -1,0 +1,54 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "control/StateSpace/ElevatorCoeffs.h"
+
+#include <Eigen/Core>
+
+frc::StateSpacePlantCoeffs<2, 1, 1> MakeElevatorPlantCoeffs() {
+  Eigen::Matrix<double, 2, 2> A;
+  A(0, 0) = 1.0;
+  A(0, 1) = 0.0034323689390278016;
+  A(1, 0) = 0.0;
+  A(1, 1) = 0.4363739579808415;
+  Eigen::Matrix<double, 2, 1> B;
+  B(0, 0) = 0.00021137763582757403;
+  B(1, 0) = 0.07364963688398798;
+  Eigen::Matrix<double, 1, 2> C;
+  C(0, 0) = 1.0;
+  C(0, 1) = 0.0;
+  Eigen::Matrix<double, 1, 1> D;
+  D(0, 0) = 0.0;
+  return frc::StateSpacePlantCoeffs<2, 1, 1>(A, B, C, D);
+}
+
+frc::StateSpaceControllerCoeffs<2, 1, 1> MakeElevatorControllerCoeffs() {
+  Eigen::Matrix<double, 1, 2> K;
+  K(0, 0) = 232.76812610676956;
+  K(0, 1) = 5.540693882702349;
+  Eigen::Matrix<double, 1, 2> Kff;
+  Kff(0, 0) = 12.902151500051774;
+  Kff(0, 1) = 11.23863895630079;
+  Eigen::Matrix<double, 1, 1> Umin;
+  Umin(0, 0) = -12.0;
+  Eigen::Matrix<double, 1, 1> Umax;
+  Umax(0, 0) = 12.0;
+  return frc::StateSpaceControllerCoeffs<2, 1, 1>(K, Kff, Umin, Umax);
+}
+
+frc::StateSpaceObserverCoeffs<2, 1, 1> MakeElevatorObserverCoeffs() {
+  Eigen::Matrix<double, 2, 1> K;
+  K(0, 0) = 0.9999960231492777;
+  K(1, 0) = 0.7347579419051207;
+  return frc::StateSpaceObserverCoeffs<2, 1, 1>(K);
+}
+
+frc::StateSpaceLoop<2, 1, 1> MakeElevatorLoop() {
+  return frc::StateSpaceLoop<2, 1, 1>(MakeElevatorPlantCoeffs(),
+                                      MakeElevatorControllerCoeffs(),
+                                      MakeElevatorObserverCoeffs());
+}

--- a/wpilibc/src/test/native/cpp/control/StateSpaceTest.cpp
+++ b/wpilibc/src/test/native/cpp/control/StateSpaceTest.cpp
@@ -1,0 +1,67 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <control/StateSpace/ElevatorCoeffs.h>
+#include <frc/controller/StateSpaceLoop.h>
+
+#include <cmath>
+#include <random>
+
+#include <Eigen/Core>
+
+#include "gtest/gtest.h"
+
+using namespace frc;
+
+constexpr double kPositionStddev = 0.0001;
+
+void update(StateSpaceLoop<2, 1, 1>& loop, double noise) {
+  Eigen::Matrix<double, 1, 1> y =
+      loop.GetPlant().CalculateY(loop.Xhat(), loop.U()) +
+      Eigen::Matrix<double, 1, 1>(noise);
+  loop.Correct(y);
+  loop.Predict();
+}
+
+TEST(StateSpace, TestEnabled) {
+  std::default_random_engine generator;
+  std::normal_distribution<double> dist{0.0, kPositionStddev};
+
+  StateSpaceLoop<2, 1, 1> m_loop{MakeElevatorLoop()};
+
+  Eigen::Matrix<double, 2, 1> references;
+  references << 2.0, 0.0;
+  m_loop.SetNextR(references);
+
+  m_loop.Enable();
+
+  for (int i = 0; i < 350; i++) {
+    update(m_loop, dist(generator));
+    EXPECT_TRUE(m_loop.U(0) >= -12.0 && m_loop.U(0) <= 12.0);
+  }
+
+  EXPECT_LT(std::abs(m_loop.Xhat(0) - 2.0), 0.05);
+  EXPECT_LT(std::abs(m_loop.Xhat(1) - 0.0), 0.5);
+}
+
+TEST(StateSpace, TestDisabled) {
+  StateSpaceLoop<2, 1, 1> m_loop{MakeElevatorLoop()};
+
+  Eigen::Matrix<double, 2, 1> references;
+  references << 2.0, 0.0;
+  m_loop.SetNextR(references);
+
+  EXPECT_DOUBLE_EQ(m_loop.Xhat(0), 0.0);
+  EXPECT_DOUBLE_EQ(m_loop.Xhat(1), 0.0);
+
+  for (int i = 0; i < 100; i++) {
+    update(m_loop, 0.0);
+  }
+
+  EXPECT_LT(std::abs(m_loop.Xhat(0)), 1E-9);
+  EXPECT_LT(std::abs(m_loop.Xhat(1)), 1E-9);
+}

--- a/wpilibc/src/test/native/include/control/PeriodVariant/ElevatorCoeffs.h
+++ b/wpilibc/src/test/native/include/control/PeriodVariant/ElevatorCoeffs.h
@@ -1,0 +1,18 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/controller/PeriodVariantLoop.h>
+#include <frc/controller/PeriodVariantObserverCoeffs.h>
+#include <frc/controller/PeriodVariantPlantCoeffs.h>
+#include <frc/controller/StateSpaceControllerCoeffs.h>
+
+frc::PeriodVariantPlantCoeffs<2, 1, 1> MakeElevatorPVPlantCoeffs();
+frc::StateSpaceControllerCoeffs<2, 1, 1> MakeElevatorPVControllerCoeffs();
+frc::PeriodVariantObserverCoeffs<2, 1, 1> MakeElevatorPVObserverCoeffs();
+frc::PeriodVariantLoop<2, 1, 1> MakeElevatorPVLoop();

--- a/wpilibc/src/test/native/include/control/StateSpace/ElevatorCoeffs.h
+++ b/wpilibc/src/test/native/include/control/StateSpace/ElevatorCoeffs.h
@@ -1,0 +1,18 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/controller/StateSpaceControllerCoeffs.h>
+#include <frc/controller/StateSpaceLoop.h>
+#include <frc/controller/StateSpaceObserverCoeffs.h>
+#include <frc/controller/StateSpacePlantCoeffs.h>
+
+frc::StateSpacePlantCoeffs<2, 1, 1> MakeElevatorPlantCoeffs();
+frc::StateSpaceControllerCoeffs<2, 1, 1> MakeElevatorControllerCoeffs();
+frc::StateSpaceObserverCoeffs<2, 1, 1> MakeElevatorObserverCoeffs();
+frc::StateSpaceLoop<2, 1, 1> MakeElevatorLoop();

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/cpp/Robot.cpp
@@ -1,0 +1,12 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "Robot.h"
+
+Drivetrain Robot::m_drivetrain;
+
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/cpp/subsystems/DifferentialDriveCoeffs.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/cpp/subsystems/DifferentialDriveCoeffs.cpp
@@ -1,0 +1,135 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/DifferentialDriveCoeffs.h"
+
+#include <Eigen/Core>
+
+frc::PeriodVariantPlantCoeffs<4, 2, 2> MakeDifferentialDrivePlantCoeffs() {
+  Eigen::Matrix<double, 4, 4> Acontinuous;
+  Acontinuous(0, 0) = 0.0;
+  Acontinuous(0, 1) = 1.0;
+  Acontinuous(0, 2) = 0.0;
+  Acontinuous(0, 3) = 0.0;
+  Acontinuous(1, 0) = 0.0;
+  Acontinuous(1, 1) = -5.027892724619944;
+  Acontinuous(1, 2) = 0.0;
+  Acontinuous(1, 3) = -0.6998646867368526;
+  Acontinuous(2, 0) = 0.0;
+  Acontinuous(2, 1) = 0.0;
+  Acontinuous(2, 2) = 0.0;
+  Acontinuous(2, 3) = 1.0;
+  Acontinuous(3, 0) = 0.0;
+  Acontinuous(3, 1) = -0.6998646867368526;
+  Acontinuous(3, 2) = 0.0;
+  Acontinuous(3, 3) = -5.027892724619944;
+  Eigen::Matrix<double, 4, 2> Bcontinuous;
+  Bcontinuous(0, 0) = 0.0;
+  Bcontinuous(0, 1) = 0.0;
+  Bcontinuous(1, 0) = 1.7995488399804316;
+  Bcontinuous(1, 1) = 0.25049076305735457;
+  Bcontinuous(2, 0) = 0.0;
+  Bcontinuous(2, 1) = 0.0;
+  Bcontinuous(3, 0) = 0.25049076305735457;
+  Bcontinuous(3, 1) = 1.7995488399804316;
+  Eigen::Matrix<double, 2, 4> C;
+  C(0, 0) = 1.0;
+  C(0, 1) = 0.0;
+  C(0, 2) = 0.0;
+  C(0, 3) = 0.0;
+  C(1, 0) = 0.0;
+  C(1, 1) = 0.0;
+  C(1, 2) = 1.0;
+  C(1, 3) = 0.0;
+  Eigen::Matrix<double, 2, 2> D;
+  D(0, 0) = 0.0;
+  D(0, 1) = 0.0;
+  D(1, 0) = 0.0;
+  D(1, 1) = 0.0;
+  return frc::PeriodVariantPlantCoeffs<4, 2, 2>(Acontinuous, Bcontinuous, C, D);
+}
+
+frc::StateSpaceControllerCoeffs<4, 2, 2>
+MakeDifferentialDriveControllerCoeffs() {
+  Eigen::Matrix<double, 2, 4> K;
+  K(0, 0) = 80.65341818675051;
+  K(0, 1) = 12.71586889712588;
+  K(0, 2) = -0.5333100328369462;
+  K(0, 3) = -0.4931520992908445;
+  K(1, 0) = -0.5333100328373179;
+  K(1, 1) = -0.4931520992908412;
+  K(1, 2) = 80.65341818675063;
+  K(1, 3) = 12.715868897125851;
+  Eigen::Matrix<double, 2, 4> Kff;
+  Kff(0, 0) = 129.05358519143596;
+  Kff(0, 1) = 1.272274192517092;
+  Kff(0, 2) = 17.31489107452048;
+  Kff(0, 3) = 0.16996589760178937;
+  Kff(1, 0) = 17.314891074520485;
+  Kff(1, 1) = 0.16996589760178946;
+  Kff(1, 2) = 129.053585191436;
+  Kff(1, 3) = 1.2722741925170924;
+  Eigen::Matrix<double, 2, 1> Umin;
+  Umin(0, 0) = -12.0;
+  Umin(1, 0) = -12.0;
+  Eigen::Matrix<double, 2, 1> Umax;
+  Umax(0, 0) = 12.0;
+  Umax(1, 0) = 12.0;
+  return frc::StateSpaceControllerCoeffs<4, 2, 2>(K, Kff, Umin, Umax);
+}
+
+frc::PeriodVariantObserverCoeffs<4, 2, 2>
+MakeDifferentialDriveObserverCoeffs() {
+  Eigen::Matrix<double, 4, 4> Qcontinuous;
+  Qcontinuous(0, 0) = 0.0025000000000000005;
+  Qcontinuous(0, 1) = 0.0;
+  Qcontinuous(0, 2) = 0.0;
+  Qcontinuous(0, 3) = 0.0;
+  Qcontinuous(1, 0) = 0.0;
+  Qcontinuous(1, 1) = 1.0;
+  Qcontinuous(1, 2) = 0.0;
+  Qcontinuous(1, 3) = 0.0;
+  Qcontinuous(2, 0) = 0.0;
+  Qcontinuous(2, 1) = 0.0;
+  Qcontinuous(2, 2) = 0.0025000000000000005;
+  Qcontinuous(2, 3) = 0.0;
+  Qcontinuous(3, 0) = 0.0;
+  Qcontinuous(3, 1) = 0.0;
+  Qcontinuous(3, 2) = 0.0;
+  Qcontinuous(3, 3) = 1.0;
+  Eigen::Matrix<double, 2, 2> Rcontinuous;
+  Rcontinuous(0, 0) = 1e-08;
+  Rcontinuous(0, 1) = 0.0;
+  Rcontinuous(1, 0) = 0.0;
+  Rcontinuous(1, 1) = 1e-08;
+  Eigen::Matrix<double, 4, 4> PsteadyState;
+  PsteadyState(0, 0) = 9.999963029693557e-09;
+  PsteadyState(0, 1) = 1.4808967508114098e-07;
+  PsteadyState(0, 2) = -9.883671001894896e-17;
+  PsteadyState(0, 3) = -5.0939159960507185e-09;
+  PsteadyState(1, 0) = 1.4808967507921014e-07;
+  PsteadyState(1, 1) = 8.238974828958986;
+  PsteadyState(1, 2) = -5.093915996150815e-09;
+  PsteadyState(1, 3) = -0.26183323515195367;
+  PsteadyState(2, 0) = -9.883769833075987e-17;
+  PsteadyState(2, 1) = -5.093915996217903e-09;
+  PsteadyState(2, 2) = 9.999963029993743e-09;
+  PsteadyState(2, 3) = 1.480896750855879e-07;
+  PsteadyState(3, 0) = -5.093915996044057e-09;
+  PsteadyState(3, 1) = -0.26183323515195367;
+  PsteadyState(3, 2) = 1.4808967508522786e-07;
+  PsteadyState(3, 3) = 8.238974828958877;
+  return frc::PeriodVariantObserverCoeffs<4, 2, 2>(Qcontinuous, Rcontinuous,
+                                                   PsteadyState);
+}
+
+frc::PeriodVariantLoop<4, 2, 2> MakeDifferentialDriveLoop() {
+  return frc::PeriodVariantLoop<4, 2, 2>(
+      MakeDifferentialDrivePlantCoeffs(),
+      MakeDifferentialDriveControllerCoeffs(),
+      MakeDifferentialDriveObserverCoeffs());
+}

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/cpp/subsystems/DifferentialDriveController.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/cpp/subsystems/DifferentialDriveController.cpp
@@ -1,0 +1,88 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/DifferentialDriveController.h"
+
+#include <cmath>
+
+DifferentialDriveController::DifferentialDriveController() { m_Y.setZero(); }
+
+void DifferentialDriveController::Enable() { m_loop.Enable(); }
+
+void DifferentialDriveController::Disable() { m_loop.Disable(); }
+
+void DifferentialDriveController::SetReferences(double leftPosition,
+                                                double leftVelocity,
+                                                double rightPosition,
+                                                double rightVelocity) {
+  Eigen::Matrix<double, 4, 1> nextR;
+  nextR << leftPosition, leftVelocity, rightPosition, rightVelocity;
+  m_loop.SetNextR(nextR);
+}
+
+bool DifferentialDriveController::AtReferences() const {
+  return m_atReferences;
+}
+
+void DifferentialDriveController::SetMeasuredStates(double leftPosition,
+                                                    double rightPosition) {
+  m_Y << leftPosition, rightPosition;
+}
+
+double DifferentialDriveController::ControllerLeftVoltage() const {
+  return m_loop.U(0);
+}
+
+double DifferentialDriveController::ControllerRightVoltage() const {
+  return m_loop.U(1);
+}
+
+double DifferentialDriveController::EstimatedLeftPosition() const {
+  return m_loop.Xhat(0);
+}
+
+double DifferentialDriveController::EstimatedLeftVelocity() const {
+  return m_loop.Xhat(1);
+}
+
+double DifferentialDriveController::EstimatedRightPosition() const {
+  return m_loop.Xhat(2);
+}
+
+double DifferentialDriveController::EstimatedRightVelocity() const {
+  return m_loop.Xhat(3);
+}
+
+double DifferentialDriveController::LeftPositionError() const {
+  return m_loop.Error()(0, 0);
+}
+
+double DifferentialDriveController::LeftVelocityError() const {
+  return m_loop.Error()(1, 0);
+}
+
+double DifferentialDriveController::RightPositionError() const {
+  return m_loop.Error()(2, 0);
+}
+
+double DifferentialDriveController::RightVelocityError() const {
+  return m_loop.Error()(3, 0);
+}
+
+void DifferentialDriveController::Update(std::chrono::nanoseconds dt) {
+  m_loop.Correct(m_Y);
+
+  auto error = m_loop.Error();
+  m_atReferences = std::abs(error(0, 0)) < kPositionTolerance &&
+                   std::abs(error(1, 0)) < kVelocityTolerance &&
+                   std::abs(error(2, 0)) < kPositionTolerance &&
+                   std::abs(error(3, 0)) < kVelocityTolerance;
+
+  m_loop.Predict(dt);
+}
+
+void DifferentialDriveController::Reset() { m_loop.Reset(); }

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/cpp/subsystems/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/cpp/subsystems/Drivetrain.cpp
@@ -1,0 +1,69 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/Drivetrain.h"
+
+#include <chrono>
+
+#include <frc/DriverStation.h>
+
+constexpr double kPi = 3.14159265358979323846;
+
+Drivetrain::Drivetrain() {
+  // Set radians of encoder shaft per encoder pulse using pulses per revolution
+  m_leftEncoder.SetDistancePerPulse(2.0 * kPi / 360.0);
+  m_rightEncoder.SetDistancePerPulse(2.0 * kPi / 360.0);
+}
+
+void Drivetrain::Enable() {
+  m_drivetrain.Enable();
+  m_thread.StartPeriodic(5_ms);
+}
+
+void Drivetrain::Disable() {
+  m_drivetrain.Disable();
+  m_thread.Stop();
+}
+
+void Drivetrain::SetReferences(double leftPosition, double leftVelocity,
+                               double rightPosition, double rightVelocity) {
+  m_drivetrain.SetReferences(leftPosition, leftVelocity, rightPosition,
+                             rightVelocity);
+}
+
+void Drivetrain::Iterate() {
+  m_drivetrain.SetMeasuredStates(m_leftEncoder.GetDistance(),
+                                 m_rightEncoder.GetDistance());
+
+  // Run controller update
+  auto now = std::chrono::steady_clock::now();
+  if (m_lastTime != std::chrono::steady_clock::time_point::min()) {
+    m_drivetrain.Update(now - m_lastTime);
+  } else {
+    m_drivetrain.Update();
+  }
+
+  // Set motor inputs
+  double batteryVoltage = frc::DriverStation::GetInstance().GetBatteryVoltage();
+  m_left.Set(m_drivetrain.ControllerLeftVoltage() / batteryVoltage);
+  m_right.Set(m_drivetrain.ControllerRightVoltage() / batteryVoltage);
+
+  m_lastTime = now;
+}
+
+double Drivetrain::ControllerLeftVoltage() const {
+  return m_drivetrain.ControllerLeftVoltage();
+}
+
+double Drivetrain::ControllerRightVoltage() const {
+  return m_drivetrain.ControllerRightVoltage();
+}
+
+void Drivetrain::Reset() {
+  m_drivetrain.Reset();
+  m_lastTime = std::chrono::steady_clock::time_point::min();
+}

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/differential_drive.py
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/differential_drive.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+# Avoid needing display if plots aren't being shown
+import os
+import sys
+
+if "--noninteractive" in sys.argv:
+    import matplotlib as mpl
+
+    mpl.use("svg")
+
+import frccontrol as fct
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+class DifferentialDrive(fct.System):
+
+    def __init__(self, dt):
+        """DifferentialDrive subsystem.
+
+        Keyword arguments:
+        dt -- time between model/controller updates
+        """
+        state_labels = [
+            ("Left position", "m"),
+            ("Left velocity", "m/s"),
+            ("Right position", "m"),
+            ("Right velocity", "m/s"),
+        ]
+        u_labels = [("Left voltage", "V"), ("Right voltage", "V")]
+        self.set_plot_labels(state_labels, u_labels)
+
+        u_min = np.array([[-12.0], [-12.0]])
+        u_max = np.array([[12.0], [12.0]])
+        fct.System.__init__(self, np.zeros((4, 1)), u_min, u_max, dt)
+
+    def create_model(self, states):
+        self.in_low_gear = False
+
+        # Number of motors per side
+        num_motors = 2.0
+
+        # High and low gear ratios of differential drive
+        Glow = 60.0 / 11.0
+        Ghigh = 60.0 / 11.0
+
+        # Drivetrain mass in kg
+        m = 52
+        # Radius of wheels in meters
+        r = 0.08255 / 2.0
+        # Radius of robot in meters
+        rb = 0.59055 / 2.0
+        # Moment of inertia of the differential drive in kg-m^2
+        J = 6.0
+
+        # Gear ratios of left and right sides of differential drive respectively
+        if self.in_low_gear:
+            Gl = Glow
+            Gr = Glow
+        else:
+            Gl = Ghigh
+            Gr = Ghigh
+
+        return fct.models.differential_drive(fct.models.MOTOR_CIM, num_motors,
+                                             m, r, rb, J, Gl, Gr)
+
+    def design_controller_observer(self):
+        if self.in_low_gear:
+            q_pos = 0.12
+            q_vel = 1.0
+        else:
+            q_pos = 0.14
+            q_vel = 0.95
+
+        q = [q_pos, q_vel, q_pos, q_vel]
+        r = [12.0, 12.0]
+        self.design_lqr(q, r)
+
+        qff_pos = 0.005
+        qff_vel = 1.0
+        self.design_two_state_feedforward([qff_pos, qff_vel, qff_pos, qff_vel],
+                                          [12.0, 12.0])
+
+        q_pos = 0.05
+        q_vel = 1.0
+        q_voltage = 10.0
+        q_encoder_uncertainty = 2.0
+        r_pos = 0.0001
+        r_gyro = 0.000001
+        self.design_kalman_filter([q_pos, q_vel, q_pos, q_vel], [r_pos, r_pos])
+
+
+def main():
+    dt = 0.00505
+    diff_drive = DifferentialDrive(dt)
+    diff_drive.export_cpp_coeffs("DifferentialDrive", "subsystems/", "h", True)
+    os.rename("DifferentialDriveCoeffs.cpp",
+              "cpp/subsystems/DifferentialDriveCoeffs.cpp")
+    os.rename("DifferentialDriveCoeffs.h",
+              "include/subsystems/DifferentialDriveCoeffs.h")
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        try:
+            import slycot
+
+            plt.figure(1)
+            diff_drive.plot_pzmaps()
+        except ImportError:  # Slycot unavailable. Can't show pzmaps.
+            pass
+    if "--save-plots" in sys.argv:
+        plt.savefig("differential_drive_pzmaps.svg")
+
+    t, xprof, vprof, aprof = fct.generate_s_curve_profile(max_v=4.0,
+                                                          max_a=3.5,
+                                                          time_to_max_a=1.0,
+                                                          dt=dt,
+                                                          goal=50.0)
+
+    # Generate references for simulation
+    refs = []
+    for i in range(len(t)):
+        r = np.array([[xprof[i]], [vprof[i]], [xprof[i]], [vprof[i]]])
+        refs.append(r)
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        plt.figure(2)
+        x_rec, ref_rec, u_rec = diff_drive.generate_time_responses(t, refs)
+        diff_drive.plot_time_responses(t, x_rec, ref_rec, u_rec)
+    if "--save-plots" in sys.argv:
+        plt.savefig("differential_drive_response.svg")
+    if "--noninteractive" not in sys.argv:
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/include/Robot.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/include/Robot.h
@@ -1,0 +1,17 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/TimedRobot.h>
+
+#include "subsystems/Drivetrain.h"
+
+class Robot : public frc::TimedRobot {
+ public:
+  static Drivetrain m_drivetrain;
+};

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/include/subsystems/DifferentialDriveCoeffs.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/include/subsystems/DifferentialDriveCoeffs.h
@@ -1,0 +1,19 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/controller/PeriodVariantLoop.h>
+#include <frc/controller/PeriodVariantObserverCoeffs.h>
+#include <frc/controller/PeriodVariantPlantCoeffs.h>
+#include <frc/controller/StateSpaceControllerCoeffs.h>
+
+frc::PeriodVariantPlantCoeffs<4, 2, 2> MakeDifferentialDrivePlantCoeffs();
+frc::StateSpaceControllerCoeffs<4, 2, 2>
+MakeDifferentialDriveControllerCoeffs();
+frc::PeriodVariantObserverCoeffs<4, 2, 2> MakeDifferentialDriveObserverCoeffs();
+frc::PeriodVariantLoop<4, 2, 2> MakeDifferentialDriveLoop();

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/include/subsystems/DifferentialDriveController.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/include/subsystems/DifferentialDriveController.h
@@ -1,0 +1,127 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <chrono>
+
+#include <Eigen/Core>
+#include <frc/controller/PeriodVariantLoop.h>
+
+#include "subsystems/DifferentialDriveCoeffs.h"
+
+class DifferentialDriveController {
+ public:
+  // State tolerances in meters and meters/sec respectively.
+  static constexpr double kPositionTolerance = 0.05;
+  static constexpr double kVelocityTolerance = 2.0;
+
+  DifferentialDriveController();
+
+  DifferentialDriveController(DifferentialDriveController&&) = default;
+  DifferentialDriveController& operator=(DifferentialDriveController&&) =
+      default;
+
+  void Enable();
+  void Disable();
+
+  /**
+   * Sets the references.
+   *
+   * @param leftPosition  Position of left side in meters.
+   * @param leftVelocity  Velocity of left side in meters per second.
+   * @param rightPosition Position of right side in meters.
+   * @param rightVelocity Velocity of right side in meters per second.
+   */
+  void SetReferences(double leftPosition, double leftVelocity,
+                     double rightPosition, double rightVelocity);
+
+  bool AtReferences() const;
+
+  /**
+   * Sets the current encoder measurements.
+   *
+   * @param leftPosition  Position of left side in meters.
+   * @param rightPosition Position of right side in meters.
+   */
+  void SetMeasuredStates(double leftPosition, double rightPosition);
+
+  /**
+   * Returns the control loop calculated voltage for the left side.
+   */
+  double ControllerLeftVoltage() const;
+
+  /**
+   * Returns the control loop calculated voltage for the left side.
+   */
+  double ControllerRightVoltage() const;
+
+  /**
+   * Returns the estimated left position.
+   */
+  double EstimatedLeftPosition() const;
+
+  /**
+   * Returns the estimated left velocity.
+   */
+  double EstimatedLeftVelocity() const;
+
+  /**
+   * Returns the estimated right position.
+   */
+  double EstimatedRightPosition() const;
+
+  /**
+   * Returns the estimated right velocity.
+   */
+  double EstimatedRightVelocity() const;
+
+  /**
+   * Returns the error between the left position reference and the left position
+   * estimate.
+   */
+  double LeftPositionError() const;
+
+  /**
+   * Returns the error between the left velocity reference and the left velocity
+   * estimate.
+   */
+  double LeftVelocityError() const;
+
+  /**
+   * Returns the error between the right position reference and the right
+   * position estimate.
+   */
+  double RightPositionError() const;
+
+  /**
+   * Returns the error between the right velocity reference and the right
+   * velocity estimate.
+   */
+  double RightVelocityError() const;
+
+  /**
+   * Executes the control loop for a cycle.
+   *
+   * @param dt Measured time since the last controller update.
+   */
+  void Update(std::chrono::nanoseconds dt = std::chrono::milliseconds(5));
+
+  /**
+   * Resets any internal state.
+   */
+  void Reset();
+
+ private:
+  // The current sensor measurements.
+  Eigen::Matrix<double, 2, 1> m_Y;
+
+  // The control loop.
+  frc::PeriodVariantLoop<4, 2, 2> m_loop{MakeDifferentialDriveLoop()};
+
+  bool m_atReferences = false;
+};

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/include/subsystems/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantDifferentialDrive/include/subsystems/Drivetrain.h
@@ -1,0 +1,83 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+#include <frc/Encoder.h>
+#include <frc/Notifier.h>
+#include <frc/Spark.h>
+#include <frc/SpeedControllerGroup.h>
+#include <frc/drive/DifferentialDrive.h>
+
+#include "subsystems/DifferentialDriveController.h"
+
+class Drivetrain {
+ public:
+  Drivetrain();
+
+  Drivetrain(const Drivetrain&) = delete;
+  Drivetrain& operator=(const Drivetrain&) = delete;
+
+  /**
+   * Enable controller.
+   */
+  void Enable();
+
+  /**
+   * Disable controller.
+   */
+  void Disable();
+
+  /**
+   * Sets the references.
+   *
+   * @param leftPosition  Position of left side in meters.
+   * @param leftVelocity  Velocity of left side in meters per second.
+   * @param rightPosition Position of right side in meters.
+   * @param rightVelocity Velocity of right side in meters per second.
+   */
+  void SetReferences(double leftPosition, double leftVelocity,
+                     double rightPosition, double rightVelocity);
+
+  bool AtReference() const;
+
+  /**
+   * Iterates the drivetrain control loop one cycle.
+   */
+  void Iterate();
+
+  /**
+   * Returns controller output for left side.
+   */
+  double ControllerLeftVoltage() const;
+
+  /**
+   * Returns controller output for right side.
+   */
+  double ControllerRightVoltage() const;
+
+  void Reset();
+
+ private:
+  frc::Spark m_leftFront{1};
+  frc::Spark m_leftRear{2};
+  frc::SpeedControllerGroup m_left{m_leftFront, m_leftRear};
+  frc::Encoder m_leftEncoder{1, 2};
+
+  frc::Spark m_rightFront{3};
+  frc::Spark m_rightRear{4};
+  frc::SpeedControllerGroup m_right{m_rightFront, m_rightRear};
+  frc::Encoder m_rightEncoder{1, 2};
+
+  frc::DifferentialDrive m_drive{m_left, m_right};
+
+  DifferentialDriveController m_drivetrain;
+  frc::Notifier m_thread{&Drivetrain::Iterate, this};
+  std::chrono::steady_clock::time_point m_lastTime =
+      std::chrono::steady_clock::time_point::min();
+};

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/cpp/Robot.cpp
@@ -1,0 +1,12 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "Robot.h"
+
+Elevator Robot::m_elevator;
+
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/cpp/subsystems/Elevator.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/cpp/subsystems/Elevator.cpp
@@ -1,0 +1,60 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/Elevator.h"
+
+#include <chrono>
+
+#include <frc/DriverStation.h>
+
+constexpr double kPi = 3.14159265358979323846;
+
+Elevator::Elevator() {
+  // Set radians of encoder shaft per encoder pulse using pulses per revolution
+  m_encoder.SetDistancePerPulse(2.0 * kPi / 360.0);
+}
+
+void Elevator::Enable() {
+  m_elevator.Enable();
+  m_thread.StartPeriodic(5_ms);
+}
+
+void Elevator::Disable() {
+  m_elevator.Disable();
+  m_thread.Stop();
+}
+
+void Elevator::SetReferences(double position, double velocity) {
+  m_elevator.SetReferences(position, velocity);
+}
+
+void Elevator::Iterate() {
+  m_elevator.SetMeasuredPosition(m_encoder.GetDistance());
+
+  // Run controller update
+  auto now = std::chrono::steady_clock::now();
+  if (m_lastTime != std::chrono::steady_clock::time_point::min()) {
+    m_elevator.Update(now - m_lastTime);
+  } else {
+    m_elevator.Update();
+  }
+
+  // Set motor input
+  double batteryVoltage = frc::DriverStation::GetInstance().GetBatteryVoltage();
+  m_motor.Set(m_elevator.ControllerVoltage() / batteryVoltage);
+
+  m_lastTime = now;
+}
+
+double Elevator::ControllerVoltage() const {
+  return m_elevator.ControllerVoltage();
+}
+
+void Elevator::Reset() {
+  m_elevator.Reset();
+  m_lastTime = std::chrono::steady_clock::time_point::min();
+}

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/cpp/subsystems/ElevatorCoeffs.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/cpp/subsystems/ElevatorCoeffs.cpp
@@ -1,0 +1,64 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/ElevatorCoeffs.h"
+
+#include <Eigen/Core>
+
+frc::PeriodVariantPlantCoeffs<2, 1, 1> MakeElevatorPlantCoeffs() {
+  Eigen::Matrix<double, 2, 2> Acontinuous;
+  Acontinuous(0, 0) = 0.0;
+  Acontinuous(0, 1) = 1.0;
+  Acontinuous(1, 0) = 0.0;
+  Acontinuous(1, 1) = -164.20904979369794;
+  Eigen::Matrix<double, 2, 1> Bcontinuous;
+  Bcontinuous(0, 0) = 0.0;
+  Bcontinuous(1, 0) = 21.457377744727182;
+  Eigen::Matrix<double, 1, 2> C;
+  C(0, 0) = 1.0;
+  C(0, 1) = 0.0;
+  Eigen::Matrix<double, 1, 1> D;
+  D(0, 0) = 0.0;
+  return frc::PeriodVariantPlantCoeffs<2, 1, 1>(Acontinuous, Bcontinuous, C, D);
+}
+
+frc::StateSpaceControllerCoeffs<2, 1, 1> MakeElevatorControllerCoeffs() {
+  Eigen::Matrix<double, 1, 2> K;
+  K(0, 0) = 232.76812610676956;
+  K(0, 1) = 5.540693882702349;
+  Eigen::Matrix<double, 1, 2> Kff;
+  Kff(0, 0) = 12.902151500051774;
+  Kff(0, 1) = 11.23863895630079;
+  Eigen::Matrix<double, 1, 1> Umin;
+  Umin(0, 0) = -12.0;
+  Eigen::Matrix<double, 1, 1> Umax;
+  Umax(0, 0) = 12.0;
+  return frc::StateSpaceControllerCoeffs<2, 1, 1>(K, Kff, Umin, Umax);
+}
+
+frc::PeriodVariantObserverCoeffs<2, 1, 1> MakeElevatorObserverCoeffs() {
+  Eigen::Matrix<double, 2, 2> Qcontinuous;
+  Qcontinuous(0, 0) = 0.0025000000000000005;
+  Qcontinuous(0, 1) = 0.0;
+  Qcontinuous(1, 0) = 0.0;
+  Qcontinuous(1, 1) = 1.0;
+  Eigen::Matrix<double, 1, 1> Rcontinuous;
+  Rcontinuous(0, 0) = 1e-08;
+  Eigen::Matrix<double, 2, 2> PsteadyState;
+  PsteadyState(0, 0) = 9.99996023173184e-09;
+  PsteadyState(0, 1) = 7.34757941922686e-09;
+  PsteadyState(1, 0) = 7.347579419241315e-09;
+  PsteadyState(1, 1) = 1.2335349474145199;
+  return frc::PeriodVariantObserverCoeffs<2, 1, 1>(Qcontinuous, Rcontinuous,
+                                                   PsteadyState);
+}
+
+frc::PeriodVariantLoop<2, 1, 1> MakeElevatorLoop() {
+  return frc::PeriodVariantLoop<2, 1, 1>(MakeElevatorPlantCoeffs(),
+                                         MakeElevatorControllerCoeffs(),
+                                         MakeElevatorObserverCoeffs());
+}

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/cpp/subsystems/ElevatorController.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/cpp/subsystems/ElevatorController.cpp
@@ -1,0 +1,54 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <cmath>
+
+#include "subsystems/Elevator.h"
+
+ElevatorController::ElevatorController() { m_Y.setZero(); }
+
+void ElevatorController::Enable() { m_loop.Enable(); }
+
+void ElevatorController::Disable() { m_loop.Disable(); }
+
+void ElevatorController::SetReferences(double position, double velocity) {
+  Eigen::Matrix<double, 2, 1> nextR;
+  nextR << position, velocity;
+  m_loop.SetNextR(nextR);
+}
+
+bool ElevatorController::AtReferences() const { return m_atReferences; }
+
+void ElevatorController::SetMeasuredPosition(double measuredPosition) {
+  m_Y << measuredPosition;
+}
+
+double ElevatorController::ControllerVoltage() const { return m_loop.U(0); }
+
+double ElevatorController::EstimatedPosition() const { return m_loop.Xhat(0); }
+
+double ElevatorController::EstimatedVelocity() const { return m_loop.Xhat(1); }
+
+double ElevatorController::PositionError() const {
+  return m_loop.Error()(0, 0);
+}
+
+double ElevatorController::VelocityError() const {
+  return m_loop.Error()(1, 0);
+}
+
+void ElevatorController::Update(std::chrono::nanoseconds dt) {
+  m_loop.Correct(m_Y);
+
+  auto error = m_loop.Error();
+  m_atReferences = std::abs(error(0, 0)) < kPositionTolerance &&
+                   std::abs(error(1, 0)) < kVelocityTolerance;
+
+  m_loop.Predict(dt);
+}
+
+void ElevatorController::Reset() { m_loop.Reset(); }

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/elevator.py
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/elevator.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+# Avoid needing display if plots aren't being shown
+import os
+import sys
+
+if "--noninteractive" in sys.argv:
+    import matplotlib as mpl
+
+    mpl.use("svg")
+
+import frccontrol as fct
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+class Elevator(fct.System):
+
+    def __init__(self, dt):
+        """Elevator subsystem.
+
+        Keyword arguments:
+        dt -- time between model/controller updates
+        """
+        state_labels = [("Position", "m"), ("Velocity", "m/s")]
+        u_labels = [("Voltage", "V")]
+        self.set_plot_labels(state_labels, u_labels)
+
+        fct.System.__init__(self, np.zeros((2, 1)), np.array([[-12.0]]),
+                            np.array([[12.0]]), dt)
+
+    def create_model(self, states):
+        # Number of motors
+        num_motors = 2.0
+        # Elevator carriage mass in kg
+        m = 6.803886
+        # Radius of pulley in meters
+        r = 0.02762679089
+        # Gear ratio
+        G = 42.0 / 12.0 * 40.0 / 14.0
+
+        return fct.models.elevator(fct.models.MOTOR_CIM, num_motors, m, r, G)
+
+    def design_controller_observer(self):
+        q = [0.02, 0.4]
+        r = [12.0]
+        self.design_lqr(q, r)
+        self.design_two_state_feedforward(q, r)
+
+        q_pos = 0.05
+        q_vel = 1.0
+        r_pos = 0.0001
+        self.design_kalman_filter([q_pos, q_vel], [r_pos])
+
+
+def main():
+    dt = 0.00505
+    elevator = Elevator(dt)
+    elevator.export_cpp_coeffs("Elevator", "subsystems/", "h", True)
+    os.rename("ElevatorCoeffs.cpp", "cpp/subsystems/ElevatorCoeffs.cpp")
+    os.rename("ElevatorCoeffs.h", "include/subsystems/ElevatorCoeffs.h")
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        try:
+            import slycot
+
+            plt.figure(1)
+            elevator.plot_pzmaps()
+        except ImportError:  # Slycot unavailable. Can't show pzmaps.
+            pass
+    if "--save-plots" in sys.argv:
+        plt.savefig("elevator_pzmaps.svg")
+
+    # Set up graphing
+    l0 = 0.1
+    l1 = l0 + 5.0
+    l2 = l1 + 0.1
+    t = np.arange(0, l2 + 5.0, dt)
+
+    refs = []
+
+    # Generate references for simulation
+    for i in range(len(t)):
+        if t[i] < l0:
+            r = np.array([[0.0], [0.0]])
+        elif t[i] < l1:
+            r = np.array([[1.524], [0.0]])
+        else:
+            r = np.array([[0.0], [0.0]])
+        refs.append(r)
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        plt.figure(2)
+        x_rec, ref_rec, u_rec = elevator.generate_time_responses(t, refs)
+        elevator.plot_time_responses(t, x_rec, ref_rec, u_rec)
+    if "--save-plots" in sys.argv:
+        plt.savefig("elevator_response.svg")
+    if "--noninteractive" not in sys.argv:
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/include/Robot.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/include/Robot.h
@@ -1,0 +1,17 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/TimedRobot.h>
+
+#include "subsystems/Elevator.h"
+
+class Robot : public frc::TimedRobot {
+ public:
+  static Elevator m_elevator;
+};

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/include/subsystems/Elevator.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/include/subsystems/Elevator.h
@@ -1,0 +1,59 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <chrono>
+
+#include <Eigen/Core>
+#include <frc/Encoder.h>
+#include <frc/Notifier.h>
+#include <frc/Spark.h>
+
+#include "subsystems/ElevatorController.h"
+
+class Elevator {
+ public:
+  Elevator();
+
+  Elevator(const Elevator&) = delete;
+  Elevator& operator=(const Elevator&) = delete;
+
+  void Enable();
+  void Disable();
+
+  /**
+   * Sets the references.
+   *
+   * @param position Position of the carriage in meters.
+   * @param velocity Velocity of the carriage in meters per second.
+   */
+  void SetReferences(double position, double velocity);
+
+  bool AtReference() const;
+
+  /**
+   * Iterates the elevator control loop one cycle.
+   */
+  void Iterate();
+
+  /**
+   * Returns controller output.
+   */
+  double ControllerVoltage() const;
+
+  void Reset();
+
+ private:
+  frc::Spark m_motor{1};
+  frc::Encoder m_encoder{1, 2};
+
+  ElevatorController m_elevator;
+  frc::Notifier m_thread{&Elevator::Iterate, this};
+  std::chrono::steady_clock::time_point m_lastTime =
+      std::chrono::steady_clock::time_point::min();
+};

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/include/subsystems/ElevatorCoeffs.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/include/subsystems/ElevatorCoeffs.h
@@ -1,0 +1,18 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/controller/PeriodVariantLoop.h>
+#include <frc/controller/PeriodVariantObserverCoeffs.h>
+#include <frc/controller/PeriodVariantPlantCoeffs.h>
+#include <frc/controller/StateSpaceControllerCoeffs.h>
+
+frc::PeriodVariantPlantCoeffs<2, 1, 1> MakeElevatorPlantCoeffs();
+frc::StateSpaceControllerCoeffs<2, 1, 1> MakeElevatorControllerCoeffs();
+frc::PeriodVariantObserverCoeffs<2, 1, 1> MakeElevatorObserverCoeffs();
+frc::PeriodVariantLoop<2, 1, 1> MakeElevatorLoop();

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/include/subsystems/ElevatorController.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantElevator/include/subsystems/ElevatorController.h
@@ -1,0 +1,93 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <chrono>
+
+#include <Eigen/Core>
+#include <frc/controller/PeriodVariantLoop.h>
+
+#include "subsystems/ElevatorCoeffs.h"
+
+class ElevatorController {
+ public:
+  // State tolerances in meters and meters/sec respectively.
+  static constexpr double kPositionTolerance = 0.05;
+  static constexpr double kVelocityTolerance = 2.0;
+
+  ElevatorController();
+
+  ElevatorController(ElevatorController&&) = default;
+  ElevatorController& operator=(ElevatorController&&) = default;
+
+  void Enable();
+  void Disable();
+
+  /**
+   * Sets the references.
+   *
+   * @param position Position of the carriage in meters.
+   * @param velocity Velocity of the carriage in meters per second.
+   */
+  void SetReferences(double position, double velocity);
+
+  bool AtReferences() const;
+
+  /**
+   * Sets the current encoder measurement.
+   *
+   * @param measuredPosition Position of the carriage in meters.
+   */
+  void SetMeasuredPosition(double measuredPosition);
+
+  /**
+   * Returns the control loop calculated voltage.
+   */
+  double ControllerVoltage() const;
+
+  /**
+   * Returns the estimated position.
+   */
+  double EstimatedPosition() const;
+
+  /**
+   * Returns the estimated velocity.
+   */
+  double EstimatedVelocity() const;
+
+  /**
+   * Returns the error between the position reference and the position estimate.
+   */
+  double PositionError() const;
+
+  /**
+   * Returns the error between the velocity reference and the velocity estimate.
+   */
+  double VelocityError() const;
+
+  /**
+   * Executes the control loop for a cycle.
+   *
+   * @param dt Measured time since the last controller update.
+   */
+  void Update(std::chrono::nanoseconds dt = std::chrono::milliseconds(5));
+
+  /**
+   * Resets any internal state.
+   */
+  void Reset();
+
+ private:
+  // The current sensor measurement.
+  Eigen::Matrix<double, 1, 1> m_Y;
+
+  // The control loop.
+  frc::PeriodVariantLoop<2, 1, 1> m_loop{MakeElevatorLoop()};
+
+  bool m_atReferences = false;
+};

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/cpp/Robot.cpp
@@ -1,0 +1,12 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "Robot.h"
+
+Flywheel Robot::m_flywheel;
+
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/cpp/subsystems/Flywheel.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/cpp/subsystems/Flywheel.cpp
@@ -1,0 +1,56 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/Flywheel.h"
+
+#include <chrono>
+
+#include <frc/DriverStation.h>
+
+constexpr double kPi = 3.14159265358979323846;
+
+Flywheel::Flywheel() {
+  // Set radians of encoder shaft per encoder pulse using pulses per revolution
+  m_encoder.SetDistancePerPulse(2.0 * kPi / 360.0);
+}
+
+void Flywheel::Enable() {
+  m_wheel.Enable();
+  m_thread.StartPeriodic(5_ms);
+}
+
+void Flywheel::Disable() {
+  m_wheel.Disable();
+  m_thread.Stop();
+}
+
+void Flywheel::SetReference(double angularVelocity) {
+  m_wheel.SetVelocityReference(angularVelocity);
+}
+
+void Flywheel::Iterate() {
+  m_wheel.SetMeasuredVelocity(m_encoder.GetRate());
+
+  // Run controller update
+  auto now = std::chrono::steady_clock::now();
+  if (m_lastTime != std::chrono::steady_clock::time_point::min()) {
+    m_wheel.Update(now - m_lastTime);
+  } else {
+    m_wheel.Update();
+  }
+
+  // Set motor input
+  double batteryVoltage = frc::DriverStation::GetInstance().GetBatteryVoltage();
+  m_motor.Set(m_wheel.ControllerVoltage() / batteryVoltage);
+
+  m_lastTime = now;
+}
+
+void Flywheel::Reset() {
+  m_wheel.Reset();
+  m_lastTime = std::chrono::steady_clock::time_point::min();
+}

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/cpp/subsystems/FlywheelCoeffs.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/cpp/subsystems/FlywheelCoeffs.cpp
@@ -1,0 +1,51 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/FlywheelCoeffs.h"
+
+#include <Eigen/Core>
+
+frc::PeriodVariantPlantCoeffs<1, 1, 1> MakeFlywheelPlantCoeffs() {
+  Eigen::Matrix<double, 1, 1> Acontinuous;
+  Acontinuous(0, 0) = -0.5001321900589898;
+  Eigen::Matrix<double, 1, 1> Bcontinuous;
+  Bcontinuous(0, 0) = 123.26388888888889;
+  Eigen::Matrix<double, 1, 1> C;
+  C(0, 0) = 1.0;
+  Eigen::Matrix<double, 1, 1> D;
+  D(0, 0) = 0.0;
+  return frc::PeriodVariantPlantCoeffs<1, 1, 1>(Acontinuous, Bcontinuous, C, D);
+}
+
+frc::StateSpaceControllerCoeffs<1, 1, 1> MakeFlywheelControllerCoeffs() {
+  Eigen::Matrix<double, 1, 1> K;
+  K(0, 0) = 0.8623214751211266;
+  Eigen::Matrix<double, 1, 1> Kff;
+  Kff(0, 0) = 0.6200031001383457;
+  Eigen::Matrix<double, 1, 1> Umin;
+  Umin(0, 0) = -12.0;
+  Eigen::Matrix<double, 1, 1> Umax;
+  Umax(0, 0) = 12.0;
+  return frc::StateSpaceControllerCoeffs<1, 1, 1>(K, Kff, Umin, Umax);
+}
+
+frc::PeriodVariantObserverCoeffs<1, 1, 1> MakeFlywheelObserverCoeffs() {
+  Eigen::Matrix<double, 1, 1> Qcontinuous;
+  Qcontinuous(0, 0) = 1.0;
+  Eigen::Matrix<double, 1, 1> Rcontinuous;
+  Rcontinuous(0, 0) = 0.0001;
+  Eigen::Matrix<double, 1, 1> PsteadyState;
+  PsteadyState(0, 0) = 9.999000199441811e-05;
+  return frc::PeriodVariantObserverCoeffs<1, 1, 1>(Qcontinuous, Rcontinuous,
+                                                   PsteadyState);
+}
+
+frc::PeriodVariantLoop<1, 1, 1> MakeFlywheelLoop() {
+  return frc::PeriodVariantLoop<1, 1, 1>(MakeFlywheelPlantCoeffs(),
+                                         MakeFlywheelControllerCoeffs(),
+                                         MakeFlywheelObserverCoeffs());
+}

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/cpp/subsystems/FlywheelController.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/cpp/subsystems/FlywheelController.cpp
@@ -1,0 +1,52 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <cmath>
+
+#include "subsystems/Flywheel.h"
+
+FlywheelController::FlywheelController() { m_Y.setZero(); }
+
+void FlywheelController::Enable() { m_loop.Enable(); }
+
+void FlywheelController::Disable() { m_loop.Disable(); }
+
+void FlywheelController::SetVelocityReference(double angularVelocity) {
+  Eigen::Matrix<double, 1, 1> nextR;
+  nextR << angularVelocity;
+  m_loop.SetNextR(nextR);
+}
+
+bool FlywheelController::AtReference() const { return m_atReference; }
+
+void FlywheelController::SetMeasuredVelocity(double angularVelocity) {
+  // Update angular velocity in the model.
+  m_Y << angularVelocity;
+}
+
+double FlywheelController::ControllerVoltage() const { return m_loop.U(0); }
+
+double FlywheelController::GetEstimatedVelocity() const {
+  return m_loop.Xhat(0);
+}
+
+double FlywheelController::Error() const { return m_loop.Error()(0, 0); }
+
+void FlywheelController::Update(std::chrono::nanoseconds dt) {
+  if (std::abs(m_loop.NextR(0)) < 1.0) {
+    // Kill power at low angular velocities.
+    m_loop.Disable();
+  }
+
+  m_loop.Correct(m_Y);
+
+  m_atReference = std::abs(Error()) < kTolerance && m_loop.NextR(0) > 1.0;
+
+  m_loop.Predict(dt);
+}
+
+void FlywheelController::Reset() { m_loop.Reset(); }

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/flywheel.py
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/flywheel.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+# Avoid needing display if plots aren't being shown
+import os
+import sys
+
+if "--noninteractive" in sys.argv:
+    import matplotlib as mpl
+
+    mpl.use("svg")
+
+import frccontrol as fct
+import math
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+class Flywheel(fct.System):
+
+    def __init__(self, dt):
+        """Flywheel subsystem.
+
+        Keyword arguments:
+        dt -- time between model/controller updates
+        """
+        state_labels = [("Angular velocity", "rad/s")]
+        u_labels = [("Voltage", "V")]
+        self.set_plot_labels(state_labels, u_labels)
+
+        fct.System.__init__(self, np.array([[0.0]]), np.array([[-12.0]]),
+                            np.array([[12.0]]), dt)
+
+    def create_model(self, states):
+        # Number of motors
+        num_motors = 1.0
+        # Flywheel moment of inertia in kg-m^2
+        J = 0.00032
+        # Gear ratio
+        G = 12.0 / 18.0
+
+        return fct.models.flywheel(fct.models.MOTOR_775PRO, num_motors, J, G)
+
+    def design_controller_observer(self):
+        q = [9.42]
+        r = [12.0]
+        self.design_lqr(q, r)
+        # self.place_controller_poles([0.87])
+        self.design_two_state_feedforward(q, r)
+
+        q_vel = 1.0
+        r_vel = 0.01
+        self.design_kalman_filter([q_vel], [r_vel])
+        # self.place_observer_poles([0.3])
+
+
+def main():
+    dt = 0.00505
+    flywheel = Flywheel(dt)
+    flywheel.export_cpp_coeffs("Flywheel", "subsystems/", "h", True)
+    os.rename("FlywheelCoeffs.cpp", "cpp/subsystems/FlywheelCoeffs.cpp")
+    os.rename("FlywheelCoeffs.h", "include/subsystems/FlywheelCoeffs.h")
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        plt.figure(1)
+        flywheel.plot_pzmaps()
+    if "--save-plots" in sys.argv:
+        plt.savefig("flywheel_pzmaps.svg")
+
+    # Set up graphing
+    l0 = 0.1
+    l1 = l0 + 5.0
+    l2 = l1 + 0.1
+    t = np.arange(0, l2 + 5.0, dt)
+
+    refs = []
+
+    # Generate references for simulation
+    for i in range(len(t)):
+        if t[i] < l0:
+            r = np.array([[0]])
+        elif t[i] < l1:
+            r = np.array([[9000 / 60 * 2 * math.pi]])
+        else:
+            r = np.array([[0]])
+        refs.append(r)
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        plt.figure(2)
+        x_rec, ref_rec, u_rec = flywheel.generate_time_responses(t, refs)
+        flywheel.plot_time_responses(t, x_rec, ref_rec, u_rec)
+    if "--save-plots" in sys.argv:
+        plt.savefig("flywheel_response.svg")
+    if "--noninteractive" not in sys.argv:
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/include/Robot.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/include/Robot.h
@@ -1,0 +1,17 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/TimedRobot.h>
+
+#include "subsystems/Flywheel.h"
+
+class Robot : public frc::TimedRobot {
+ public:
+  static Flywheel m_flywheel;
+};

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/include/subsystems/Flywheel.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/include/subsystems/Flywheel.h
@@ -1,0 +1,55 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <chrono>
+
+#include <Eigen/Core>
+#include <frc/Encoder.h>
+#include <frc/Notifier.h>
+#include <frc/Spark.h>
+
+#include "subsystems/FlywheelController.h"
+
+class Flywheel {
+ public:
+  Flywheel();
+
+  Flywheel(const Flywheel&) = delete;
+  Flywheel& operator=(const Flywheel&) = delete;
+
+  /**
+   * Enable controller.
+   */
+  void Enable();
+
+  /**
+   * Disable controller.
+   */
+  void Disable();
+
+  void SetReference(double angularVelocity);
+
+  bool AtReference() const;
+
+  /**
+   * Iterates the shooter control loop one cycle.
+   */
+  void Iterate();
+
+  void Reset();
+
+ private:
+  frc::Spark m_motor{1};
+  frc::Encoder m_encoder{1, 2};
+
+  FlywheelController m_wheel;
+  frc::Notifier m_thread{&Flywheel::Iterate, this};
+  std::chrono::steady_clock::time_point m_lastTime =
+      std::chrono::steady_clock::time_point::min();
+};

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/include/subsystems/FlywheelCoeffs.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/include/subsystems/FlywheelCoeffs.h
@@ -1,0 +1,18 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/controller/PeriodVariantLoop.h>
+#include <frc/controller/PeriodVariantObserverCoeffs.h>
+#include <frc/controller/PeriodVariantPlantCoeffs.h>
+#include <frc/controller/StateSpaceControllerCoeffs.h>
+
+frc::PeriodVariantPlantCoeffs<1, 1, 1> MakeFlywheelPlantCoeffs();
+frc::StateSpaceControllerCoeffs<1, 1, 1> MakeFlywheelControllerCoeffs();
+frc::PeriodVariantObserverCoeffs<1, 1, 1> MakeFlywheelObserverCoeffs();
+frc::PeriodVariantLoop<1, 1, 1> MakeFlywheelLoop();

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/include/subsystems/FlywheelController.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantFlywheel/include/subsystems/FlywheelController.h
@@ -1,0 +1,78 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <chrono>
+
+#include <Eigen/Core>
+#include <frc/controller/PeriodVariantLoop.h>
+
+#include "subsystems/FlywheelCoeffs.h"
+
+class FlywheelController {
+ public:
+  // Angular velocity tolerance in radians/sec.
+  static constexpr double kTolerance = 10.0;
+
+  FlywheelController();
+
+  FlywheelController(FlywheelController&&) = default;
+  FlywheelController& operator=(FlywheelController&&) = default;
+
+  void Enable();
+  void Disable();
+
+  /**
+   * Sets the velocity reference in radians/sec.
+   */
+  void SetVelocityReference(double angularVelocity);
+
+  bool AtReference() const;
+
+  /**
+   * Sets the current encoder velocity in radians/sec.
+   */
+  void SetMeasuredVelocity(double angularVelocity);
+
+  /**
+   * Returns the control loop calculated voltage.
+   */
+  double ControllerVoltage() const;
+
+  /**
+   * Returns the instantaneous velocity.
+   */
+  double GetEstimatedVelocity() const;
+
+  /**
+   * Returns the error between the angular velocity reference and angular
+   * velocity estimate.
+   */
+  double Error() const;
+
+  /**
+   * Executes the control loop for a cycle.
+   *
+   * @param dt Measured time since the last controller update.
+   */
+  void Update(std::chrono::nanoseconds dt = std::chrono::milliseconds(5));
+
+  /**
+   * Resets any internal state.
+   */
+  void Reset();
+
+ private:
+  // The current sensor measurement.
+  Eigen::Matrix<double, 1, 1> m_Y;
+
+  // The control loop.
+  frc::PeriodVariantLoop<1, 1, 1> m_loop{MakeFlywheelLoop()};
+
+  bool m_atReference = false;
+};

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/cpp/Robot.cpp
@@ -1,0 +1,12 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "Robot.h"
+
+SingleJointedArm Robot::m_singleJointedArm;
+
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/cpp/subsystems/SingleJointedArm.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/cpp/subsystems/SingleJointedArm.cpp
@@ -1,0 +1,60 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/SingleJointedArm.h"
+
+#include <chrono>
+
+#include <frc/DriverStation.h>
+
+constexpr double kPi = 3.14159265358979323846;
+
+SingleJointedArm::SingleJointedArm() {
+  // Set radians of encoder shaft per encoder pulse using pulses per revolution
+  m_encoder.SetDistancePerPulse(2.0 * kPi / 360.0);
+}
+
+void SingleJointedArm::Enable() {
+  m_singleJointedArm.Enable();
+  m_thread.StartPeriodic(5_ms);
+}
+
+void SingleJointedArm::Disable() {
+  m_singleJointedArm.Disable();
+  m_thread.Stop();
+}
+
+void SingleJointedArm::SetReferences(double angle, double angularVelocity) {
+  m_singleJointedArm.SetReferences(angle, angularVelocity);
+}
+
+void SingleJointedArm::Iterate() {
+  m_singleJointedArm.SetMeasuredAngle(m_encoder.GetDistance());
+
+  // Run controller update
+  auto now = std::chrono::steady_clock::now();
+  if (m_lastTime != std::chrono::steady_clock::time_point::min()) {
+    m_singleJointedArm.Update(now - m_lastTime);
+  } else {
+    m_singleJointedArm.Update();
+  }
+
+  // Set motor input
+  double batteryVoltage = frc::DriverStation::GetInstance().GetBatteryVoltage();
+  m_motor.Set(m_singleJointedArm.ControllerVoltage() / batteryVoltage);
+
+  m_lastTime = now;
+}
+
+double SingleJointedArm::ControllerVoltage() const {
+  return m_singleJointedArm.ControllerVoltage();
+}
+
+void SingleJointedArm::Reset() {
+  m_singleJointedArm.Reset();
+  m_lastTime = std::chrono::steady_clock::time_point::min();
+}

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/cpp/subsystems/SingleJointedArmCoeffs.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/cpp/subsystems/SingleJointedArmCoeffs.cpp
@@ -1,0 +1,65 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/SingleJointedArmCoeffs.h"
+
+#include <Eigen/Core>
+
+frc::PeriodVariantPlantCoeffs<2, 1, 1> MakeSingleJointedArmPlantCoeffs() {
+  Eigen::Matrix<double, 2, 2> Acontinuous;
+  Acontinuous(0, 0) = 0.0;
+  Acontinuous(0, 1) = 1.0;
+  Acontinuous(1, 0) = 0.0;
+  Acontinuous(1, 1) = -0.000948744041441224;
+  Eigen::Matrix<double, 2, 1> Bcontinuous;
+  Bcontinuous(0, 0) = 0.0;
+  Bcontinuous(1, 0) = 0.08974870179312819;
+  Eigen::Matrix<double, 1, 2> C;
+  C(0, 0) = 1.0;
+  C(0, 1) = 0.0;
+  Eigen::Matrix<double, 1, 1> D;
+  D(0, 0) = 0.0;
+  return frc::PeriodVariantPlantCoeffs<2, 1, 1>(Acontinuous, Bcontinuous, C, D);
+}
+
+frc::StateSpaceControllerCoeffs<2, 1, 1>
+MakeSingleJointedArmControllerCoeffs() {
+  Eigen::Matrix<double, 1, 2> K;
+  K(0, 0) = 659.4457876860411;
+  K(0, 1) = 179.11558938712352;
+  Eigen::Matrix<double, 1, 2> Kff;
+  Kff(0, 0) = 0.5390980036447967;
+  Kff(0, 1) = 8.538202281633405;
+  Eigen::Matrix<double, 1, 1> Umin;
+  Umin(0, 0) = -12.0;
+  Eigen::Matrix<double, 1, 1> Umax;
+  Umax(0, 0) = 12.0;
+  return frc::StateSpaceControllerCoeffs<2, 1, 1>(K, Kff, Umin, Umax);
+}
+
+frc::PeriodVariantObserverCoeffs<2, 1, 1> MakeSingleJointedArmObserverCoeffs() {
+  Eigen::Matrix<double, 2, 2> Qcontinuous;
+  Qcontinuous(0, 0) = 0.0003045025;
+  Qcontinuous(0, 1) = 0.0;
+  Qcontinuous(1, 0) = 0.0;
+  Qcontinuous(1, 1) = 0.030461733182409998;
+  Eigen::Matrix<double, 1, 1> Rcontinuous;
+  Rcontinuous(0, 0) = 0.0001;
+  Eigen::Matrix<double, 2, 2> PsteadyState;
+  PsteadyState(0, 0) = 8.033915976431203e-05;
+  PsteadyState(0, 1) = 0.0007738121910642457;
+  PsteadyState(1, 0) = 0.000773812191064246;
+  PsteadyState(1, 1) = 0.62614228094563;
+  return frc::PeriodVariantObserverCoeffs<2, 1, 1>(Qcontinuous, Rcontinuous,
+                                                   PsteadyState);
+}
+
+frc::PeriodVariantLoop<2, 1, 1> MakeSingleJointedArmLoop() {
+  return frc::PeriodVariantLoop<2, 1, 1>(MakeSingleJointedArmPlantCoeffs(),
+                                         MakeSingleJointedArmControllerCoeffs(),
+                                         MakeSingleJointedArmObserverCoeffs());
+}

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/cpp/subsystems/SingleJointedArmController.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/cpp/subsystems/SingleJointedArmController.cpp
@@ -1,0 +1,61 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <cmath>
+
+#include "subsystems/SingleJointedArm.h"
+
+SingleJointedArmController::SingleJointedArmController() { m_Y.setZero(); }
+
+void SingleJointedArmController::Enable() { m_loop.Enable(); }
+
+void SingleJointedArmController::Disable() { m_loop.Disable(); }
+
+void SingleJointedArmController::SetReferences(double angle,
+                                               double angularVelocity) {
+  Eigen::Matrix<double, 2, 1> nextR;
+  nextR << angle, angularVelocity;
+  m_loop.SetNextR(nextR);
+}
+
+bool SingleJointedArmController::AtReferences() const { return m_atReferences; }
+
+void SingleJointedArmController::SetMeasuredAngle(double measuredAngle) {
+  m_Y << measuredAngle;
+}
+
+double SingleJointedArmController::ControllerVoltage() const {
+  return m_loop.U(0);
+}
+
+double SingleJointedArmController::EstimatedAngle() const {
+  return m_loop.Xhat(0);
+}
+
+double SingleJointedArmController::EstimatedAngularVelocity() const {
+  return m_loop.Xhat(1);
+}
+
+double SingleJointedArmController::AngleError() const {
+  return m_loop.Error()(0, 0);
+}
+
+double SingleJointedArmController::AngularVelocityError() const {
+  return m_loop.Error()(1, 0);
+}
+
+void SingleJointedArmController::Update(std::chrono::nanoseconds dt) {
+  m_loop.Correct(m_Y);
+
+  auto error = m_loop.Error();
+  m_atReferences = std::abs(error(0, 0)) < kAngleTolerance &&
+                   std::abs(error(1, 0)) < kAngularVelocityTolerance;
+
+  m_loop.Predict(dt);
+}
+
+void SingleJointedArmController::Reset() { m_loop.Reset(); }

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/include/Robot.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/include/Robot.h
@@ -1,0 +1,17 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/TimedRobot.h>
+
+#include "subsystems/SingleJointedArm.h"
+
+class Robot : public frc::TimedRobot {
+ public:
+  static SingleJointedArm m_singleJointedArm;
+};

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/include/subsystems/SingleJointedArm.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/include/subsystems/SingleJointedArm.h
@@ -1,0 +1,59 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <chrono>
+
+#include <Eigen/Core>
+#include <frc/Encoder.h>
+#include <frc/Notifier.h>
+#include <frc/Spark.h>
+
+#include "subsystems/SingleJointedArmController.h"
+
+class SingleJointedArm {
+ public:
+  SingleJointedArm();
+
+  SingleJointedArm(const SingleJointedArm&) = delete;
+  SingleJointedArm& operator=(const SingleJointedArm&) = delete;
+
+  void Enable();
+  void Disable();
+
+  /**
+   * Sets the references.
+   *
+   * @param angle           Angle of arm in radians.
+   * @param angularVelocity Velocity of arm in radians per second.
+   */
+  void SetReferences(double angle, double angularVelocity);
+
+  bool AtReference() const;
+
+  /**
+   * Iterates the elevator control loop one cycle.
+   */
+  void Iterate();
+
+  /**
+   * Returns controller output.
+   */
+  double ControllerVoltage() const;
+
+  void Reset();
+
+ private:
+  frc::Spark m_motor{1};
+  frc::Encoder m_encoder{1, 2};
+
+  SingleJointedArmController m_singleJointedArm;
+  frc::Notifier m_thread{&SingleJointedArm::Iterate, this};
+  std::chrono::steady_clock::time_point m_lastTime =
+      std::chrono::steady_clock::time_point::min();
+};

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/include/subsystems/SingleJointedArmCoeffs.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/include/subsystems/SingleJointedArmCoeffs.h
@@ -1,0 +1,18 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/controller/PeriodVariantLoop.h>
+#include <frc/controller/PeriodVariantObserverCoeffs.h>
+#include <frc/controller/PeriodVariantPlantCoeffs.h>
+#include <frc/controller/StateSpaceControllerCoeffs.h>
+
+frc::PeriodVariantPlantCoeffs<2, 1, 1> MakeSingleJointedArmPlantCoeffs();
+frc::StateSpaceControllerCoeffs<2, 1, 1> MakeSingleJointedArmControllerCoeffs();
+frc::PeriodVariantObserverCoeffs<2, 1, 1> MakeSingleJointedArmObserverCoeffs();
+frc::PeriodVariantLoop<2, 1, 1> MakeSingleJointedArmLoop();

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/include/subsystems/SingleJointedArmController.h
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/include/subsystems/SingleJointedArmController.h
@@ -1,0 +1,94 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <chrono>
+
+#include <Eigen/Core>
+#include <frc/controller/PeriodVariantLoop.h>
+
+#include "subsystems/SingleJointedArmCoeffs.h"
+
+class SingleJointedArmController {
+ public:
+  // State tolerances in meters and meters/sec respectively.
+  static constexpr double kAngleTolerance = 0.05;
+  static constexpr double kAngularVelocityTolerance = 2.0;
+
+  SingleJointedArmController();
+
+  SingleJointedArmController(SingleJointedArmController&&) = default;
+  SingleJointedArmController& operator=(SingleJointedArmController&&) = default;
+
+  void Enable();
+  void Disable();
+
+  /**
+   * Sets the references.
+   *
+   * @param angle           Angle of arm in radians.
+   * @param angularVelocity Angular velocity of arm in radians per second.
+   */
+  void SetReferences(double angle, double angularVelocity);
+
+  bool AtReferences() const;
+
+  /**
+   * Sets the current encoder measurement.
+   *
+   * @param measuredAngle Angle of arm in radians.
+   */
+  void SetMeasuredAngle(double measuredAngle);
+
+  /**
+   * Returns the control loop calculated voltage.
+   */
+  double ControllerVoltage() const;
+
+  /**
+   * Returns the estimated angle.
+   */
+  double EstimatedAngle() const;
+
+  /**
+   * Returns the estimated angular velocity.
+   */
+  double EstimatedAngularVelocity() const;
+
+  /**
+   * Returns the error between the angle reference and the angle estimate.
+   */
+  double AngleError() const;
+
+  /**
+   * Returns the error between the angular velocity reference and the angular
+   * velocity estimate.
+   */
+  double AngularVelocityError() const;
+
+  /**
+   * Executes the control loop for a cycle.
+   *
+   * @param dt Measured time since the last controller update.
+   */
+  void Update(std::chrono::nanoseconds dt = std::chrono::milliseconds(5));
+
+  /**
+   * Resets any internal state.
+   */
+  void Reset();
+
+ private:
+  // The current sensor measurement.
+  Eigen::Matrix<double, 1, 1> m_Y;
+
+  // The control loop.
+  frc::PeriodVariantLoop<2, 1, 1> m_loop{MakeSingleJointedArmLoop()};
+
+  bool m_atReferences = false;
+};

--- a/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/single_jointed_arm.py
+++ b/wpilibcExamples/src/main/cpp/examples/PeriodVariantSingleJointedArm/single_jointed_arm.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+# Avoid needing display if plots aren't being shown
+import os
+import sys
+
+if "--noninteractive" in sys.argv:
+    import matplotlib as mpl
+
+    mpl.use("svg")
+
+import frccontrol as fct
+import math
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+class SingleJointedArm(fct.System):
+
+    def __init__(self, dt):
+        """Single-jointed arm subsystem.
+
+        Keyword arguments:
+        dt -- time between model/controller updates
+        """
+        state_labels = [("Angle", "rad"), ("Angular velocity", "rad/s")]
+        u_labels = [("Voltage", "V")]
+        self.set_plot_labels(state_labels, u_labels)
+
+        fct.System.__init__(self, np.zeros((2, 1)), np.array([[-12.0]]),
+                            np.array([[12.0]]), dt)
+
+    def create_model(self, states):
+        # Number of motors
+        num_motors = 1.0
+        # Mass of arm in kg
+        m = 2.2675
+        # Length of arm in m
+        l = 1.2192
+        # Arm moment of inertia in kg-m^2
+        J = 1 / 3 * m * l**2
+        # Gear ratio
+        G = 1.0 / 2.0
+
+        return fct.models.single_jointed_arm(fct.models.MOTOR_CIM, num_motors,
+                                             J, G)
+
+    def design_controller_observer(self):
+        q_pos = 0.01745
+        q_vel = 0.08726
+        self.design_lqr([q_pos, q_vel], [12.0])
+        self.design_two_state_feedforward([q_pos, q_vel], [12.0])
+
+        q_pos = 0.01745
+        q_vel = 0.1745329
+        r_pos = 0.01
+        r_vel = 0.01
+        self.design_kalman_filter([q_pos, q_vel], [r_pos])
+
+
+def main():
+    dt = 0.00505
+    single_jointed_arm = SingleJointedArm(dt)
+    single_jointed_arm.export_cpp_coeffs("SingleJointedArm", "subsystems/", "h",
+                                         True)
+    os.rename("SingleJointedArmCoeffs.cpp",
+              "cpp/subsystems/SingleJointedArmCoeffs.cpp")
+    os.rename("SingleJointedArmCoeffs.h",
+              "include/subsystems/SingleJointedArmCoeffs.h")
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        try:
+            import slycot
+
+            plt.figure(1)
+            single_jointed_arm.plot_pzmaps()
+        except ImportError:  # Slycot unavailable. Can't show pzmaps.
+            pass
+    if "--save-plots" in sys.argv:
+        plt.savefig("single_jointed_arm_pzmaps.svg")
+
+    t, xprof, vprof, aprof = fct.generate_s_curve_profile(max_v=0.5,
+                                                          max_a=1,
+                                                          time_to_max_a=0.5,
+                                                          dt=dt,
+                                                          goal=1.04)
+
+    # Generate references for simulation
+    refs = []
+    for i in range(len(t)):
+        r = np.array([[xprof[i]], [vprof[i]]])
+        refs.append(r)
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        plt.figure(2)
+        x_rec, ref_rec, u_rec = single_jointed_arm.generate_time_responses(
+            t, refs)
+        single_jointed_arm.plot_time_responses(t, x_rec, ref_rec, u_rec)
+    if "--save-plots" in sys.argv:
+        plt.savefig("single_jointed_arm_response.svg")
+    if "--noninteractive" not in sys.argv:
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/cpp/Robot.cpp
@@ -1,0 +1,12 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "Robot.h"
+
+Drivetrain Robot::m_drivetrain;
+
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/cpp/subsystems/DifferentialDriveCoeffs.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/cpp/subsystems/DifferentialDriveCoeffs.cpp
@@ -1,0 +1,102 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/DifferentialDriveCoeffs.h"
+
+#include <Eigen/Core>
+
+frc::StateSpacePlantCoeffs<4, 2, 2> MakeDifferentialDrivePlantCoeffs() {
+  Eigen::Matrix<double, 4, 4> A;
+  A(0, 0) = 1.0;
+  A(0, 1) = 0.004986437590193592;
+  A(0, 2) = 0.0;
+  A(0, 3) = -8.774526130757167e-06;
+  A(1, 0) = 0.0;
+  A(1, 1) = 0.974934867699476;
+  A(1, 2) = 0.0;
+  A(1, 3) = -0.003445714205898883;
+  A(2, 0) = 0.0;
+  A(2, 1) = -8.774526130757165e-06;
+  A(2, 2) = 1.0;
+  A(2, 3) = 0.004986437590193592;
+  A(3, 0) = 0.0;
+  A(3, 1) = -0.003445714205898883;
+  A(3, 2) = 0.0;
+  A(3, 3) = 0.974934867699476;
+  Eigen::Matrix<double, 4, 2> B;
+  B(0, 0) = 2.2749821266747515e-05;
+  B(0, 1) = 3.1405181424541263e-06;
+  B(1, 0) = 0.008971140043321736;
+  B(1, 1) = 0.001233266368585487;
+  B(2, 0) = 3.140518142454126e-06;
+  B(2, 1) = 2.274982126674752e-05;
+  B(3, 0) = 0.0012332663685854868;
+  B(3, 1) = 0.008971140043321736;
+  Eigen::Matrix<double, 2, 4> C;
+  C(0, 0) = 1.0;
+  C(0, 1) = 0.0;
+  C(0, 2) = 0.0;
+  C(0, 3) = 0.0;
+  C(1, 0) = 0.0;
+  C(1, 1) = 0.0;
+  C(1, 2) = 1.0;
+  C(1, 3) = 0.0;
+  Eigen::Matrix<double, 2, 2> D;
+  D(0, 0) = 0.0;
+  D(0, 1) = 0.0;
+  D(1, 0) = 0.0;
+  D(1, 1) = 0.0;
+  return frc::StateSpacePlantCoeffs<4, 2, 2>(A, B, C, D);
+}
+
+frc::StateSpaceControllerCoeffs<4, 2, 2>
+MakeDifferentialDriveControllerCoeffs() {
+  Eigen::Matrix<double, 2, 4> K;
+  K(0, 0) = 80.65341818675051;
+  K(0, 1) = 12.71586889712588;
+  K(0, 2) = -0.5333100328369462;
+  K(0, 3) = -0.4931520992908445;
+  K(1, 0) = -0.5333100328373179;
+  K(1, 1) = -0.4931520992908412;
+  K(1, 2) = 80.65341818675063;
+  K(1, 3) = 12.715868897125851;
+  Eigen::Matrix<double, 2, 4> Kff;
+  Kff(0, 0) = 129.05358519143596;
+  Kff(0, 1) = 1.272274192517092;
+  Kff(0, 2) = 17.31489107452048;
+  Kff(0, 3) = 0.16996589760178937;
+  Kff(1, 0) = 17.314891074520485;
+  Kff(1, 1) = 0.16996589760178946;
+  Kff(1, 2) = 129.053585191436;
+  Kff(1, 3) = 1.2722741925170924;
+  Eigen::Matrix<double, 2, 1> Umin;
+  Umin(0, 0) = -12.0;
+  Umin(1, 0) = -12.0;
+  Eigen::Matrix<double, 2, 1> Umax;
+  Umax(0, 0) = 12.0;
+  Umax(1, 0) = 12.0;
+  return frc::StateSpaceControllerCoeffs<4, 2, 2>(K, Kff, Umin, Umax);
+}
+
+frc::StateSpaceObserverCoeffs<4, 2, 2> MakeDifferentialDriveObserverCoeffs() {
+  Eigen::Matrix<double, 4, 2> K;
+  K(0, 0) = 0.999996302984025;
+  K(0, 1) = -9.883770254956401e-09;
+  K(1, 0) = 14.808967508331385;
+  K(1, 1) = -0.5093915996139777;
+  K(2, 0) = -9.883770254887717e-09;
+  K(2, 1) = 0.9999963029840249;
+  K(3, 0) = -0.5093915996140141;
+  K(3, 1) = 14.808967508331481;
+  return frc::StateSpaceObserverCoeffs<4, 2, 2>(K);
+}
+
+frc::StateSpaceLoop<4, 2, 2> MakeDifferentialDriveLoop() {
+  return frc::StateSpaceLoop<4, 2, 2>(MakeDifferentialDrivePlantCoeffs(),
+                                      MakeDifferentialDriveControllerCoeffs(),
+                                      MakeDifferentialDriveObserverCoeffs());
+}

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/cpp/subsystems/DifferentialDriveController.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/cpp/subsystems/DifferentialDriveController.cpp
@@ -1,0 +1,88 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/DifferentialDriveController.h"
+
+#include <cmath>
+
+DifferentialDriveController::DifferentialDriveController() { m_Y.setZero(); }
+
+void DifferentialDriveController::Enable() { m_loop.Enable(); }
+
+void DifferentialDriveController::Disable() { m_loop.Disable(); }
+
+void DifferentialDriveController::SetReferences(double leftPosition,
+                                                double leftVelocity,
+                                                double rightPosition,
+                                                double rightVelocity) {
+  Eigen::Matrix<double, 4, 1> nextR;
+  nextR << leftPosition, leftVelocity, rightPosition, rightVelocity;
+  m_loop.SetNextR(nextR);
+}
+
+bool DifferentialDriveController::AtReferences() const {
+  return m_atReferences;
+}
+
+void DifferentialDriveController::SetMeasuredStates(double leftPosition,
+                                                    double rightPosition) {
+  m_Y << leftPosition, rightPosition;
+}
+
+double DifferentialDriveController::ControllerLeftVoltage() const {
+  return m_loop.U(0);
+}
+
+double DifferentialDriveController::ControllerRightVoltage() const {
+  return m_loop.U(1);
+}
+
+double DifferentialDriveController::EstimatedLeftPosition() const {
+  return m_loop.Xhat(0);
+}
+
+double DifferentialDriveController::EstimatedLeftVelocity() const {
+  return m_loop.Xhat(1);
+}
+
+double DifferentialDriveController::EstimatedRightPosition() const {
+  return m_loop.Xhat(2);
+}
+
+double DifferentialDriveController::EstimatedRightVelocity() const {
+  return m_loop.Xhat(3);
+}
+
+double DifferentialDriveController::LeftPositionError() const {
+  return m_loop.Error()(0, 0);
+}
+
+double DifferentialDriveController::LeftVelocityError() const {
+  return m_loop.Error()(1, 0);
+}
+
+double DifferentialDriveController::RightPositionError() const {
+  return m_loop.Error()(2, 0);
+}
+
+double DifferentialDriveController::RightVelocityError() const {
+  return m_loop.Error()(3, 0);
+}
+
+void DifferentialDriveController::Update() {
+  m_loop.Correct(m_Y);
+
+  auto error = m_loop.Error();
+  m_atReferences = std::abs(error(0, 0)) < kPositionTolerance &&
+                   std::abs(error(1, 0)) < kVelocityTolerance &&
+                   std::abs(error(2, 0)) < kPositionTolerance &&
+                   std::abs(error(3, 0)) < kVelocityTolerance;
+
+  m_loop.Predict();
+}
+
+void DifferentialDriveController::Reset() { m_loop.Reset(); }

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/cpp/subsystems/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/cpp/subsystems/Drivetrain.cpp
@@ -1,0 +1,55 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/Drivetrain.h"
+
+#include <frc/DriverStation.h>
+
+constexpr double kPi = 3.14159265358979323846;
+
+Drivetrain::Drivetrain() {
+  // Set radians of encoder shaft per encoder pulse using pulses per revolution
+  m_leftEncoder.SetDistancePerPulse(2.0 * kPi / 360.0);
+  m_rightEncoder.SetDistancePerPulse(2.0 * kPi / 360.0);
+}
+
+void Drivetrain::Enable() {
+  m_drivetrain.Enable();
+  m_thread.StartPeriodic(0.005);
+}
+
+void Drivetrain::Disable() {
+  m_drivetrain.Disable();
+  m_thread.Stop();
+}
+
+void Drivetrain::SetReferences(double leftPosition, double leftVelocity,
+                               double rightPosition, double rightVelocity) {
+  m_drivetrain.SetReferences(leftPosition, leftVelocity, rightPosition,
+                             rightVelocity);
+}
+
+void Drivetrain::Iterate() {
+  m_drivetrain.SetMeasuredStates(m_leftEncoder.GetDistance(),
+                                 m_rightEncoder.GetDistance());
+  m_drivetrain.Update();
+
+  // Set motor inputs
+  double batteryVoltage = frc::DriverStation::GetInstance().GetBatteryVoltage();
+  m_left.Set(m_drivetrain.ControllerLeftVoltage() / batteryVoltage);
+  m_right.Set(m_drivetrain.ControllerRightVoltage() / batteryVoltage);
+}
+
+double Drivetrain::ControllerLeftVoltage() const {
+  return m_drivetrain.ControllerLeftVoltage();
+}
+
+double Drivetrain::ControllerRightVoltage() const {
+  return m_drivetrain.ControllerRightVoltage();
+}
+
+void Drivetrain::Reset() { m_drivetrain.Reset(); }

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/differential_drive.py
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/differential_drive.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+# Avoid needing display if plots aren't being shown
+import os
+import sys
+
+if "--noninteractive" in sys.argv:
+    import matplotlib as mpl
+
+    mpl.use("svg")
+
+import frccontrol as fct
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+class DifferentialDrive(fct.System):
+
+    def __init__(self, dt):
+        """DifferentialDrive subsystem.
+
+        Keyword arguments:
+        dt -- time between model/controller updates
+        """
+        state_labels = [
+            ("Left position", "m"),
+            ("Left velocity", "m/s"),
+            ("Right position", "m"),
+            ("Right velocity", "m/s"),
+        ]
+        u_labels = [("Left voltage", "V"), ("Right voltage", "V")]
+        self.set_plot_labels(state_labels, u_labels)
+
+        u_min = np.array([[-12.0], [-12.0]])
+        u_max = np.array([[12.0], [12.0]])
+        fct.System.__init__(self, np.zeros((4, 1)), u_min, u_max, dt)
+
+    def create_model(self, states):
+        self.in_low_gear = False
+
+        # Number of motors per side
+        num_motors = 2.0
+
+        # High and low gear ratios of differential drive
+        Glow = 60.0 / 11.0
+        Ghigh = 60.0 / 11.0
+
+        # Drivetrain mass in kg
+        m = 52
+        # Radius of wheels in meters
+        r = 0.08255 / 2.0
+        # Radius of robot in meters
+        rb = 0.59055 / 2.0
+        # Moment of inertia of the differential drive in kg-m^2
+        J = 6.0
+
+        # Gear ratios of left and right sides of differential drive respectively
+        if self.in_low_gear:
+            Gl = Glow
+            Gr = Glow
+        else:
+            Gl = Ghigh
+            Gr = Ghigh
+
+        return fct.models.differential_drive(fct.models.MOTOR_CIM, num_motors,
+                                             m, r, rb, J, Gl, Gr)
+
+    def design_controller_observer(self):
+        if self.in_low_gear:
+            q_pos = 0.12
+            q_vel = 1.0
+        else:
+            q_pos = 0.14
+            q_vel = 0.95
+
+        q = [q_pos, q_vel, q_pos, q_vel]
+        r = [12.0, 12.0]
+        self.design_lqr(q, r)
+
+        qff_pos = 0.005
+        qff_vel = 1.0
+        self.design_two_state_feedforward([qff_pos, qff_vel, qff_pos, qff_vel],
+                                          [12.0, 12.0])
+
+        q_pos = 0.05
+        q_vel = 1.0
+        q_voltage = 10.0
+        q_encoder_uncertainty = 2.0
+        r_pos = 0.0001
+        r_gyro = 0.000001
+        self.design_kalman_filter([q_pos, q_vel, q_pos, q_vel], [r_pos, r_pos])
+
+
+def main():
+    dt = 0.00505
+    diff_drive = DifferentialDrive(dt)
+    diff_drive.export_cpp_coeffs("DifferentialDrive", "subsystems/", "h")
+    os.rename("DifferentialDriveCoeffs.cpp",
+              "cpp/subsystems/DifferentialDriveCoeffs.cpp")
+    os.rename("DifferentialDriveCoeffs.h",
+              "include/subsystems/DifferentialDriveCoeffs.h")
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        try:
+            import slycot
+
+            plt.figure(1)
+            diff_drive.plot_pzmaps()
+        except ImportError:  # Slycot unavailable. Can't show pzmaps.
+            pass
+    if "--save-plots" in sys.argv:
+        plt.savefig("differential_drive_pzmaps.svg")
+
+    t, xprof, vprof, aprof = fct.generate_s_curve_profile(max_v=4.0,
+                                                          max_a=3.5,
+                                                          time_to_max_a=1.0,
+                                                          dt=dt,
+                                                          goal=50.0)
+
+    # Generate references for simulation
+    refs = []
+    for i in range(len(t)):
+        r = np.array([[xprof[i]], [vprof[i]], [xprof[i]], [vprof[i]]])
+        refs.append(r)
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        plt.figure(2)
+        x_rec, ref_rec, u_rec = diff_drive.generate_time_responses(t, refs)
+        diff_drive.plot_time_responses(t, x_rec, ref_rec, u_rec)
+    if "--save-plots" in sys.argv:
+        plt.savefig("differential_drive_response.svg")
+    if "--noninteractive" not in sys.argv:
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/include/Robot.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/include/Robot.h
@@ -1,0 +1,17 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/TimedRobot.h>
+
+#include "subsystems/Drivetrain.h"
+
+class Robot : public frc::TimedRobot {
+ public:
+  static Drivetrain m_drivetrain;
+};

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/include/subsystems/DifferentialDriveCoeffs.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/include/subsystems/DifferentialDriveCoeffs.h
@@ -1,0 +1,19 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/controller/StateSpaceControllerCoeffs.h>
+#include <frc/controller/StateSpaceLoop.h>
+#include <frc/controller/StateSpaceObserverCoeffs.h>
+#include <frc/controller/StateSpacePlantCoeffs.h>
+
+frc::StateSpacePlantCoeffs<4, 2, 2> MakeDifferentialDrivePlantCoeffs();
+frc::StateSpaceControllerCoeffs<4, 2, 2>
+MakeDifferentialDriveControllerCoeffs();
+frc::StateSpaceObserverCoeffs<4, 2, 2> MakeDifferentialDriveObserverCoeffs();
+frc::StateSpaceLoop<4, 2, 2> MakeDifferentialDriveLoop();

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/include/subsystems/DifferentialDriveController.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/include/subsystems/DifferentialDriveController.h
@@ -1,0 +1,123 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+#include <frc/controller/StateSpaceLoop.h>
+
+#include "subsystems/DifferentialDriveCoeffs.h"
+
+class DifferentialDriveController {
+ public:
+  // State tolerances in meters and meters/sec respectively.
+  static constexpr double kPositionTolerance = 0.05;
+  static constexpr double kVelocityTolerance = 2.0;
+
+  DifferentialDriveController();
+
+  DifferentialDriveController(DifferentialDriveController&&) = default;
+  DifferentialDriveController& operator=(DifferentialDriveController&&) =
+      default;
+
+  void Enable();
+  void Disable();
+
+  /**
+   * Sets the references.
+   *
+   * @param leftPosition  Position of left side in meters.
+   * @param leftVelocity  Velocity of left side in meters per second.
+   * @param rightPosition Position of right side in meters.
+   * @param rightVelocity Velocity of right side in meters per second.
+   */
+  void SetReferences(double leftPosition, double leftVelocity,
+                     double rightPosition, double rightVelocity);
+
+  bool AtReferences() const;
+
+  /**
+   * Sets the current encoder measurements.
+   *
+   * @param leftPosition  Position of left side in meters.
+   * @param rightPosition Position of right side in meters.
+   */
+  void SetMeasuredStates(double leftPosition, double rightPosition);
+
+  /**
+   * Returns the control loop calculated voltage for the left side.
+   */
+  double ControllerLeftVoltage() const;
+
+  /**
+   * Returns the control loop calculated voltage for the left side.
+   */
+  double ControllerRightVoltage() const;
+
+  /**
+   * Returns the estimated left position.
+   */
+  double EstimatedLeftPosition() const;
+
+  /**
+   * Returns the estimated left velocity.
+   */
+  double EstimatedLeftVelocity() const;
+
+  /**
+   * Returns the estimated right position.
+   */
+  double EstimatedRightPosition() const;
+
+  /**
+   * Returns the estimated right velocity.
+   */
+  double EstimatedRightVelocity() const;
+
+  /**
+   * Returns the error between the left position reference and the left position
+   * estimate.
+   */
+  double LeftPositionError() const;
+
+  /**
+   * Returns the error between the left velocity reference and the left velocity
+   * estimate.
+   */
+  double LeftVelocityError() const;
+
+  /**
+   * Returns the error between the right position reference and the right
+   * position estimate.
+   */
+  double RightPositionError() const;
+
+  /**
+   * Returns the error between the right velocity reference and the right
+   * velocity estimate.
+   */
+  double RightVelocityError() const;
+
+  /**
+   * Executes the control loop for a cycle.
+   */
+  void Update();
+
+  /**
+   * Resets any internal state.
+   */
+  void Reset();
+
+ private:
+  // The current sensor measurements.
+  Eigen::Matrix<double, 2, 1> m_Y;
+
+  // The control loop.
+  frc::StateSpaceLoop<4, 2, 2> m_loop{MakeDifferentialDriveLoop()};
+
+  bool m_atReferences = false;
+};

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/include/subsystems/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDrive/include/subsystems/Drivetrain.h
@@ -1,0 +1,81 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+#include <frc/Encoder.h>
+#include <frc/Notifier.h>
+#include <frc/Spark.h>
+#include <frc/SpeedControllerGroup.h>
+#include <frc/drive/DifferentialDrive.h>
+
+#include "subsystems/DifferentialDriveController.h"
+
+class Drivetrain {
+ public:
+  Drivetrain();
+
+  Drivetrain(const Drivetrain&) = delete;
+  Drivetrain& operator=(const Drivetrain&) = delete;
+
+  /**
+   * Enable controller.
+   */
+  void Enable();
+
+  /**
+   * Disable controller.
+   */
+  void Disable();
+
+  /**
+   * Sets the references.
+   *
+   * @param leftPosition  Position of left side in meters.
+   * @param leftVelocity  Velocity of left side in meters per second.
+   * @param rightPosition Position of right side in meters.
+   * @param rightVelocity Velocity of right side in meters per second.
+   */
+  void SetReferences(double leftPosition, double leftVelocity,
+                     double rightPosition, double rightVelocity);
+
+  bool AtReference() const;
+
+  /**
+   * Iterates the drivetrain control loop one cycle.
+   */
+  void Iterate();
+
+  /**
+   * Returns controller output for left side.
+   */
+  double ControllerLeftVoltage() const;
+
+  /**
+   * Returns controller output for right side.
+   */
+  double ControllerRightVoltage() const;
+
+  void Reset();
+
+ private:
+  frc::Spark m_leftFront{1};
+  frc::Spark m_leftRear{2};
+  frc::SpeedControllerGroup m_left{m_leftFront, m_leftRear};
+  frc::Encoder m_leftEncoder{1, 2};
+
+  frc::Spark m_rightFront{3};
+  frc::Spark m_rightRear{4};
+  frc::SpeedControllerGroup m_right{m_rightFront, m_rightRear};
+  frc::Encoder m_rightEncoder{1, 2};
+
+  frc::DifferentialDrive m_drive{m_left, m_right};
+
+  DifferentialDriveController m_drivetrain;
+  frc::Notifier m_thread{&Drivetrain::Iterate, this};
+};

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/cpp/Robot.cpp
@@ -1,0 +1,12 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "Robot.h"
+
+Elevator Robot::m_elevator;
+
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/cpp/subsystems/Elevator.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/cpp/subsystems/Elevator.cpp
@@ -1,0 +1,46 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/Elevator.h"
+
+#include <frc/DriverStation.h>
+
+constexpr double kPi = 3.14159265358979323846;
+
+Elevator::Elevator() {
+  // Set radians of encoder shaft per encoder pulse using pulses per revolution
+  m_encoder.SetDistancePerPulse(2.0 * kPi / 360.0);
+}
+
+void Elevator::Enable() {
+  m_elevator.Enable();
+  m_thread.StartPeriodic(0.005);
+}
+
+void Elevator::Disable() {
+  m_elevator.Disable();
+  m_thread.Stop();
+}
+
+void Elevator::SetReferences(double position, double velocity) {
+  m_elevator.SetReferences(position, velocity);
+}
+
+void Elevator::Iterate() {
+  m_elevator.SetMeasuredPosition(m_encoder.GetDistance());
+  m_elevator.Update();
+
+  // Set motor input
+  double batteryVoltage = frc::DriverStation::GetInstance().GetBatteryVoltage();
+  m_motor.Set(m_elevator.ControllerVoltage() / batteryVoltage);
+}
+
+double Elevator::ControllerVoltage() const {
+  return m_elevator.ControllerVoltage();
+}
+
+void Elevator::Reset() { m_elevator.Reset(); }

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/cpp/subsystems/ElevatorCoeffs.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/cpp/subsystems/ElevatorCoeffs.cpp
@@ -1,0 +1,54 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/ElevatorCoeffs.h"
+
+#include <Eigen/Core>
+
+frc::StateSpacePlantCoeffs<2, 1, 1> MakeElevatorPlantCoeffs() {
+  Eigen::Matrix<double, 2, 2> A;
+  A(0, 0) = 1.0;
+  A(0, 1) = 0.0034323689390278016;
+  A(1, 0) = 0.0;
+  A(1, 1) = 0.4363739579808415;
+  Eigen::Matrix<double, 2, 1> B;
+  B(0, 0) = 0.00021137763582757403;
+  B(1, 0) = 0.07364963688398798;
+  Eigen::Matrix<double, 1, 2> C;
+  C(0, 0) = 1.0;
+  C(0, 1) = 0.0;
+  Eigen::Matrix<double, 1, 1> D;
+  D(0, 0) = 0.0;
+  return frc::StateSpacePlantCoeffs<2, 1, 1>(A, B, C, D);
+}
+
+frc::StateSpaceControllerCoeffs<2, 1, 1> MakeElevatorControllerCoeffs() {
+  Eigen::Matrix<double, 1, 2> K;
+  K(0, 0) = 232.76812610676956;
+  K(0, 1) = 5.540693882702349;
+  Eigen::Matrix<double, 1, 2> Kff;
+  Kff(0, 0) = 12.902151500051774;
+  Kff(0, 1) = 11.23863895630079;
+  Eigen::Matrix<double, 1, 1> Umin;
+  Umin(0, 0) = -12.0;
+  Eigen::Matrix<double, 1, 1> Umax;
+  Umax(0, 0) = 12.0;
+  return frc::StateSpaceControllerCoeffs<2, 1, 1>(K, Kff, Umin, Umax);
+}
+
+frc::StateSpaceObserverCoeffs<2, 1, 1> MakeElevatorObserverCoeffs() {
+  Eigen::Matrix<double, 2, 1> K;
+  K(0, 0) = 0.9999960231492777;
+  K(1, 0) = 0.7347579419051207;
+  return frc::StateSpaceObserverCoeffs<2, 1, 1>(K);
+}
+
+frc::StateSpaceLoop<2, 1, 1> MakeElevatorLoop() {
+  return frc::StateSpaceLoop<2, 1, 1>(MakeElevatorPlantCoeffs(),
+                                      MakeElevatorControllerCoeffs(),
+                                      MakeElevatorObserverCoeffs());
+}

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/cpp/subsystems/ElevatorController.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/cpp/subsystems/ElevatorController.cpp
@@ -1,0 +1,54 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <cmath>
+
+#include "subsystems/Elevator.h"
+
+ElevatorController::ElevatorController() { m_Y.setZero(); }
+
+void ElevatorController::Enable() { m_loop.Enable(); }
+
+void ElevatorController::Disable() { m_loop.Disable(); }
+
+void ElevatorController::SetReferences(double position, double velocity) {
+  Eigen::Matrix<double, 2, 1> nextR;
+  nextR << position, velocity;
+  m_loop.SetNextR(nextR);
+}
+
+bool ElevatorController::AtReferences() const { return m_atReferences; }
+
+void ElevatorController::SetMeasuredPosition(double measuredPosition) {
+  m_Y << measuredPosition;
+}
+
+double ElevatorController::ControllerVoltage() const { return m_loop.U(0); }
+
+double ElevatorController::EstimatedPosition() const { return m_loop.Xhat(0); }
+
+double ElevatorController::EstimatedVelocity() const { return m_loop.Xhat(1); }
+
+double ElevatorController::PositionError() const {
+  return m_loop.Error()(0, 0);
+}
+
+double ElevatorController::VelocityError() const {
+  return m_loop.Error()(1, 0);
+}
+
+void ElevatorController::Update() {
+  m_loop.Correct(m_Y);
+
+  auto error = m_loop.Error();
+  m_atReferences = std::abs(error(0, 0)) < kPositionTolerance &&
+                   std::abs(error(1, 0)) < kVelocityTolerance;
+
+  m_loop.Predict();
+}
+
+void ElevatorController::Reset() { m_loop.Reset(); }

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/elevator.py
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/elevator.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+# Avoid needing display if plots aren't being shown
+import os
+import sys
+
+if "--noninteractive" in sys.argv:
+    import matplotlib as mpl
+
+    mpl.use("svg")
+
+import frccontrol as fct
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+class Elevator(fct.System):
+
+    def __init__(self, dt):
+        """Elevator subsystem.
+
+        Keyword arguments:
+        dt -- time between model/controller updates
+        """
+        state_labels = [("Position", "m"), ("Velocity", "m/s")]
+        u_labels = [("Voltage", "V")]
+        self.set_plot_labels(state_labels, u_labels)
+
+        fct.System.__init__(self, np.zeros((2, 1)), np.array([[-12.0]]),
+                            np.array([[12.0]]), dt)
+
+    def create_model(self, states):
+        # Number of motors
+        num_motors = 2.0
+        # Elevator carriage mass in kg
+        m = 6.803886
+        # Radius of pulley in meters
+        r = 0.02762679089
+        # Gear ratio
+        G = 42.0 / 12.0 * 40.0 / 14.0
+
+        return fct.models.elevator(fct.models.MOTOR_CIM, num_motors, m, r, G)
+
+    def design_controller_observer(self):
+        q = [0.02, 0.4]
+        r = [12.0]
+        self.design_lqr(q, r)
+        self.design_two_state_feedforward(q, r)
+
+        q_pos = 0.05
+        q_vel = 1.0
+        r_pos = 0.0001
+        self.design_kalman_filter([q_pos, q_vel], [r_pos])
+
+
+def main():
+    dt = 0.00505
+    elevator = Elevator(dt)
+    elevator.export_cpp_coeffs("Elevator", "subsystems/", "h")
+    os.rename("ElevatorCoeffs.cpp", "cpp/subsystems/ElevatorCoeffs.cpp")
+    os.rename("ElevatorCoeffs.h", "include/subsystems/ElevatorCoeffs.h")
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        try:
+            import slycot
+
+            plt.figure(1)
+            elevator.plot_pzmaps()
+        except ImportError:  # Slycot unavailable. Can't show pzmaps.
+            pass
+    if "--save-plots" in sys.argv:
+        plt.savefig("elevator_pzmaps.svg")
+
+    # Set up graphing
+    l0 = 0.1
+    l1 = l0 + 5.0
+    l2 = l1 + 0.1
+    t = np.arange(0, l2 + 5.0, dt)
+
+    refs = []
+
+    # Generate references for simulation
+    for i in range(len(t)):
+        if t[i] < l0:
+            r = np.array([[0.0], [0.0]])
+        elif t[i] < l1:
+            r = np.array([[1.524], [0.0]])
+        else:
+            r = np.array([[0.0], [0.0]])
+        refs.append(r)
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        plt.figure(2)
+        x_rec, ref_rec, u_rec = elevator.generate_time_responses(t, refs)
+        elevator.plot_time_responses(t, x_rec, ref_rec, u_rec)
+    if "--save-plots" in sys.argv:
+        plt.savefig("elevator_response.svg")
+    if "--noninteractive" not in sys.argv:
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/include/Robot.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/include/Robot.h
@@ -1,0 +1,17 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/TimedRobot.h>
+
+#include "subsystems/Elevator.h"
+
+class Robot : public frc::TimedRobot {
+ public:
+  static Elevator m_elevator;
+};

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/include/subsystems/Elevator.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/include/subsystems/Elevator.h
@@ -1,0 +1,55 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+#include <frc/Encoder.h>
+#include <frc/Notifier.h>
+#include <frc/Spark.h>
+
+#include "subsystems/ElevatorController.h"
+
+class Elevator {
+ public:
+  Elevator();
+
+  Elevator(const Elevator&) = delete;
+  Elevator& operator=(const Elevator&) = delete;
+
+  void Enable();
+  void Disable();
+
+  /**
+   * Sets the references.
+   *
+   * @param position Position of the carriage in meters.
+   * @param velocity Velocity of the carriage in meters per second.
+   */
+  void SetReferences(double position, double velocity);
+
+  bool AtReference() const;
+
+  /**
+   * Iterates the elevator control loop one cycle.
+   */
+  void Iterate();
+
+  /**
+   * Returns controller output.
+   */
+  double ControllerVoltage() const;
+
+  void Reset();
+
+ private:
+  frc::Spark m_motor{1};
+  frc::Encoder m_encoder{1, 2};
+
+  ElevatorController m_elevator;
+  frc::Notifier m_thread{&Elevator::Iterate, this};
+};

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/include/subsystems/ElevatorCoeffs.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/include/subsystems/ElevatorCoeffs.h
@@ -1,0 +1,18 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/controller/StateSpaceControllerCoeffs.h>
+#include <frc/controller/StateSpaceLoop.h>
+#include <frc/controller/StateSpaceObserverCoeffs.h>
+#include <frc/controller/StateSpacePlantCoeffs.h>
+
+frc::StateSpacePlantCoeffs<2, 1, 1> MakeElevatorPlantCoeffs();
+frc::StateSpaceControllerCoeffs<2, 1, 1> MakeElevatorControllerCoeffs();
+frc::StateSpaceObserverCoeffs<2, 1, 1> MakeElevatorObserverCoeffs();
+frc::StateSpaceLoop<2, 1, 1> MakeElevatorLoop();

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/include/subsystems/ElevatorController.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/include/subsystems/ElevatorController.h
@@ -1,0 +1,89 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+#include <frc/controller/StateSpaceLoop.h>
+
+#include "subsystems/ElevatorCoeffs.h"
+
+class ElevatorController {
+ public:
+  // State tolerances in meters and meters/sec respectively.
+  static constexpr double kPositionTolerance = 0.05;
+  static constexpr double kVelocityTolerance = 2.0;
+
+  ElevatorController();
+
+  ElevatorController(ElevatorController&&) noexcept = default;
+  ElevatorController& operator=(ElevatorController&&) noexcept = default;
+
+  void Enable();
+  void Disable();
+
+  /**
+   * Sets the references.
+   *
+   * @param position Position of the carriage in meters.
+   * @param velocity Velocity of the carriage in meters per second.
+   */
+  void SetReferences(double position, double velocity);
+
+  bool AtReferences() const;
+
+  /**
+   * Sets the current encoder measurement.
+   *
+   * @param measuredPosition Position of the carriage in meters.
+   */
+  void SetMeasuredPosition(double measuredPosition);
+
+  /**
+   * Returns the control loop calculated voltage.
+   */
+  double ControllerVoltage() const;
+
+  /**
+   * Returns the estimated position.
+   */
+  double EstimatedPosition() const;
+
+  /**
+   * Returns the estimated velocity.
+   */
+  double EstimatedVelocity() const;
+
+  /**
+   * Returns the error between the position reference and the position estimate.
+   */
+  double PositionError() const;
+
+  /**
+   * Returns the error between the velocity reference and the velocity estimate.
+   */
+  double VelocityError() const;
+
+  /**
+   * Executes the control loop for a cycle.
+   */
+  void Update();
+
+  /**
+   * Resets any internal state.
+   */
+  void Reset();
+
+ private:
+  // The current sensor measurement.
+  Eigen::Matrix<double, 1, 1> m_Y;
+
+  // The control loop.
+  frc::StateSpaceLoop<2, 1, 1> m_loop{MakeElevatorLoop()};
+
+  bool m_atReferences = false;
+};

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/cpp/Robot.cpp
@@ -1,0 +1,12 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "Robot.h"
+
+Flywheel Robot::m_flywheel;
+
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/cpp/subsystems/Flywheel.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/cpp/subsystems/Flywheel.cpp
@@ -1,0 +1,42 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/Flywheel.h"
+
+#include <frc/DriverStation.h>
+
+constexpr double kPi = 3.14159265358979323846;
+
+Flywheel::Flywheel() {
+  // Set radians of encoder shaft per encoder pulse using pulses per revolution
+  m_encoder.SetDistancePerPulse(2.0 * kPi / 360.0);
+}
+
+void Flywheel::Enable() {
+  m_wheel.Enable();
+  m_thread.StartPeriodic(0.005);
+}
+
+void Flywheel::Disable() {
+  m_wheel.Disable();
+  m_thread.Stop();
+}
+
+void Flywheel::SetReference(double angularVelocity) {
+  m_wheel.SetVelocityReference(angularVelocity);
+}
+
+void Flywheel::Iterate() {
+  m_wheel.SetMeasuredVelocity(m_encoder.GetRate());
+  m_wheel.Update();
+
+  // Set motor input
+  double batteryVoltage = frc::DriverStation::GetInstance().GetBatteryVoltage();
+  m_motor.Set(m_wheel.ControllerVoltage() / batteryVoltage);
+}
+
+void Flywheel::Reset() { m_wheel.Reset(); }

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/cpp/subsystems/FlywheelCoeffs.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/cpp/subsystems/FlywheelCoeffs.cpp
@@ -1,0 +1,46 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/FlywheelCoeffs.h"
+
+#include <Eigen/Core>
+
+frc::StateSpacePlantCoeffs<1, 1, 1> MakeFlywheelPlantCoeffs() {
+  Eigen::Matrix<double, 1, 1> A;
+  A(0, 0) = 0.9974775192550039;
+  Eigen::Matrix<double, 1, 1> B;
+  B(0, 0) = 0.6216972081698791;
+  Eigen::Matrix<double, 1, 1> C;
+  C(0, 0) = 1.0;
+  Eigen::Matrix<double, 1, 1> D;
+  D(0, 0) = 0.0;
+  return frc::StateSpacePlantCoeffs<1, 1, 1>(A, B, C, D);
+}
+
+frc::StateSpaceControllerCoeffs<1, 1, 1> MakeFlywheelControllerCoeffs() {
+  Eigen::Matrix<double, 1, 1> K;
+  K(0, 0) = 0.8623214751211266;
+  Eigen::Matrix<double, 1, 1> Kff;
+  Kff(0, 0) = 0.6200031001383457;
+  Eigen::Matrix<double, 1, 1> Umin;
+  Umin(0, 0) = -12.0;
+  Eigen::Matrix<double, 1, 1> Umax;
+  Umax(0, 0) = 12.0;
+  return frc::StateSpaceControllerCoeffs<1, 1, 1>(K, Kff, Umin, Umax);
+}
+
+frc::StateSpaceObserverCoeffs<1, 1, 1> MakeFlywheelObserverCoeffs() {
+  Eigen::Matrix<double, 1, 1> K;
+  K(0, 0) = 0.9999000199446406;
+  return frc::StateSpaceObserverCoeffs<1, 1, 1>(K);
+}
+
+frc::StateSpaceLoop<1, 1, 1> MakeFlywheelLoop() {
+  return frc::StateSpaceLoop<1, 1, 1>(MakeFlywheelPlantCoeffs(),
+                                      MakeFlywheelControllerCoeffs(),
+                                      MakeFlywheelObserverCoeffs());
+}

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/cpp/subsystems/FlywheelController.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/cpp/subsystems/FlywheelController.cpp
@@ -1,0 +1,52 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <cmath>
+
+#include "subsystems/Flywheel.h"
+
+FlywheelController::FlywheelController() { m_Y.setZero(); }
+
+void FlywheelController::Enable() { m_loop.Enable(); }
+
+void FlywheelController::Disable() { m_loop.Disable(); }
+
+void FlywheelController::SetVelocityReference(double angularVelocity) {
+  Eigen::Matrix<double, 1, 1> nextR;
+  nextR << angularVelocity;
+  m_loop.SetNextR(nextR);
+}
+
+bool FlywheelController::AtReference() const { return m_atReference; }
+
+void FlywheelController::SetMeasuredVelocity(double angularVelocity) {
+  // Update angular velocity in the model.
+  m_Y << angularVelocity;
+}
+
+double FlywheelController::ControllerVoltage() const { return m_loop.U(0); }
+
+double FlywheelController::GetEstimatedVelocity() const {
+  return m_loop.Xhat(0);
+}
+
+double FlywheelController::Error() const { return m_loop.Error()(0, 0); }
+
+void FlywheelController::Update() {
+  if (std::abs(m_loop.NextR(0)) < 1.0) {
+    // Kill power at low angular velocities.
+    m_loop.Disable();
+  }
+
+  m_loop.Correct(m_Y);
+
+  m_atReference = std::abs(Error()) < kTolerance && m_loop.NextR(0) > 1.0;
+
+  m_loop.Predict();
+}
+
+void FlywheelController::Reset() { m_loop.Reset(); }

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/flywheel.py
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/flywheel.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+# Avoid needing display if plots aren't being shown
+import os
+import sys
+
+if "--noninteractive" in sys.argv:
+    import matplotlib as mpl
+
+    mpl.use("svg")
+
+import frccontrol as fct
+import math
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+class Flywheel(fct.System):
+
+    def __init__(self, dt):
+        """Flywheel subsystem.
+
+        Keyword arguments:
+        dt -- time between model/controller updates
+        """
+        state_labels = [("Angular velocity", "rad/s")]
+        u_labels = [("Voltage", "V")]
+        self.set_plot_labels(state_labels, u_labels)
+
+        fct.System.__init__(self, np.array([[0.0]]), np.array([[-12.0]]),
+                            np.array([[12.0]]), dt)
+
+    def create_model(self, states):
+        # Number of motors
+        num_motors = 1.0
+        # Flywheel moment of inertia in kg-m^2
+        J = 0.00032
+        # Gear ratio
+        G = 12.0 / 18.0
+
+        return fct.models.flywheel(fct.models.MOTOR_775PRO, num_motors, J, G)
+
+    def design_controller_observer(self):
+        q = [9.42]
+        r = [12.0]
+        self.design_lqr(q, r)
+        # self.place_controller_poles([0.87])
+        self.design_two_state_feedforward(q, r)
+
+        q_vel = 1.0
+        r_vel = 0.01
+        self.design_kalman_filter([q_vel], [r_vel])
+        # self.place_observer_poles([0.3])
+
+
+def main():
+    dt = 0.00505
+    flywheel = Flywheel(dt)
+    flywheel.export_cpp_coeffs("Flywheel", "subsystems/", "h")
+    os.rename("FlywheelCoeffs.cpp", "cpp/subsystems/FlywheelCoeffs.cpp")
+    os.rename("FlywheelCoeffs.h", "include/subsystems/FlywheelCoeffs.h")
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        plt.figure(1)
+        flywheel.plot_pzmaps()
+    if "--save-plots" in sys.argv:
+        plt.savefig("flywheel_pzmaps.svg")
+
+    # Set up graphing
+    l0 = 0.1
+    l1 = l0 + 5.0
+    l2 = l1 + 0.1
+    t = np.arange(0, l2 + 5.0, dt)
+
+    refs = []
+
+    # Generate references for simulation
+    for i in range(len(t)):
+        if t[i] < l0:
+            r = np.array([[0]])
+        elif t[i] < l1:
+            r = np.array([[9000 / 60 * 2 * math.pi]])
+        else:
+            r = np.array([[0]])
+        refs.append(r)
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        plt.figure(2)
+        x_rec, ref_rec, u_rec = flywheel.generate_time_responses(t, refs)
+        flywheel.plot_time_responses(t, x_rec, ref_rec, u_rec)
+    if "--save-plots" in sys.argv:
+        plt.savefig("flywheel_response.svg")
+    if "--noninteractive" not in sys.argv:
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/include/Robot.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/include/Robot.h
@@ -1,0 +1,17 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/TimedRobot.h>
+
+#include "subsystems/Flywheel.h"
+
+class Robot : public frc::TimedRobot {
+ public:
+  static Flywheel m_flywheel;
+};

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/include/subsystems/Flywheel.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/include/subsystems/Flywheel.h
@@ -1,0 +1,51 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+#include <frc/Encoder.h>
+#include <frc/Notifier.h>
+#include <frc/Spark.h>
+
+#include "subsystems/FlywheelController.h"
+
+class Flywheel {
+ public:
+  Flywheel();
+
+  Flywheel(const Flywheel&) = delete;
+  Flywheel& operator=(const Flywheel&) = delete;
+
+  /**
+   * Enable controller.
+   */
+  void Enable();
+
+  /**
+   * Disable controller.
+   */
+  void Disable();
+
+  void SetReference(double angularVelocity);
+
+  bool AtReference() const;
+
+  /**
+   * Iterates the shooter control loop one cycle.
+   */
+  void Iterate();
+
+  void Reset();
+
+ private:
+  frc::Spark m_motor{1};
+  frc::Encoder m_encoder{1, 2};
+
+  FlywheelController m_wheel;
+  frc::Notifier m_thread{&Flywheel::Iterate, this};
+};

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/include/subsystems/FlywheelCoeffs.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/include/subsystems/FlywheelCoeffs.h
@@ -1,0 +1,18 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/controller/StateSpaceControllerCoeffs.h>
+#include <frc/controller/StateSpaceLoop.h>
+#include <frc/controller/StateSpaceObserverCoeffs.h>
+#include <frc/controller/StateSpacePlantCoeffs.h>
+
+frc::StateSpacePlantCoeffs<1, 1, 1> MakeFlywheelPlantCoeffs();
+frc::StateSpaceControllerCoeffs<1, 1, 1> MakeFlywheelControllerCoeffs();
+frc::StateSpaceObserverCoeffs<1, 1, 1> MakeFlywheelObserverCoeffs();
+frc::StateSpaceLoop<1, 1, 1> MakeFlywheelLoop();

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/include/subsystems/FlywheelController.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/include/subsystems/FlywheelController.h
@@ -1,0 +1,74 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+#include <frc/controller/StateSpaceLoop.h>
+
+#include "subsystems/FlywheelCoeffs.h"
+
+class FlywheelController {
+ public:
+  // Angular velocity tolerance in radians/sec.
+  static constexpr double kTolerance = 10.0;
+
+  FlywheelController();
+
+  FlywheelController(FlywheelController&&) = default;
+  FlywheelController& operator=(FlywheelController&&) = default;
+
+  void Enable();
+  void Disable();
+
+  /**
+   * Sets the velocity reference in radians/sec.
+   */
+  void SetVelocityReference(double angularVelocity);
+
+  bool AtReference() const;
+
+  /**
+   * Sets the current encoder velocity in radians/sec.
+   */
+  void SetMeasuredVelocity(double angularVelocity);
+
+  /**
+   * Returns the control loop calculated voltage.
+   */
+  double ControllerVoltage() const;
+
+  /**
+   * Returns the instantaneous velocity.
+   */
+  double GetEstimatedVelocity() const;
+
+  /**
+   * Returns the error between the angular velocity reference and angular
+   * velocity estimate.
+   */
+  double Error() const;
+
+  /**
+   * Executes the control loop for a cycle.
+   */
+  void Update();
+
+  /**
+   * Resets any internal state.
+   */
+  void Reset();
+
+ private:
+  // The current sensor measurement.
+  Eigen::Matrix<double, 1, 1> m_Y;
+
+  // The control loop.
+  frc::StateSpaceLoop<1, 1, 1> m_loop{MakeFlywheelLoop()};
+
+  bool m_atReference = false;
+};

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/cpp/Robot.cpp
@@ -1,0 +1,12 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "Robot.h"
+
+SingleJointedArm Robot::m_singleJointedArm;
+
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/cpp/subsystems/SingleJointedArm.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/cpp/subsystems/SingleJointedArm.cpp
@@ -1,0 +1,46 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/SingleJointedArm.h"
+
+#include <frc/DriverStation.h>
+
+constexpr double kPi = 3.14159265358979323846;
+
+SingleJointedArm::SingleJointedArm() {
+  // Set radians of encoder shaft per encoder pulse using pulses per revolution
+  m_encoder.SetDistancePerPulse(2.0 * kPi / 360.0);
+}
+
+void SingleJointedArm::Enable() {
+  m_singleJointedArm.Enable();
+  m_thread.StartPeriodic(0.05);
+}
+
+void SingleJointedArm::Disable() {
+  m_singleJointedArm.Disable();
+  m_thread.Stop();
+}
+
+void SingleJointedArm::SetReferences(double angle, double angularVelocity) {
+  m_singleJointedArm.SetReferences(angle, angularVelocity);
+}
+
+void SingleJointedArm::Iterate() {
+  m_singleJointedArm.SetMeasuredAngle(m_encoder.GetDistance());
+  m_singleJointedArm.Update();
+
+  // Set motor input
+  double batteryVoltage = frc::DriverStation::GetInstance().GetBatteryVoltage();
+  m_motor.Set(m_singleJointedArm.ControllerVoltage() / batteryVoltage);
+}
+
+double SingleJointedArm::ControllerVoltage() const {
+  return m_singleJointedArm.ControllerVoltage();
+}
+
+void SingleJointedArm::Reset() { m_singleJointedArm.Reset(); }

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/cpp/subsystems/SingleJointedArmCoeffs.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/cpp/subsystems/SingleJointedArmCoeffs.cpp
@@ -1,0 +1,55 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "subsystems/SingleJointedArmCoeffs.h"
+
+#include <Eigen/Core>
+
+frc::StateSpacePlantCoeffs<2, 1, 1> MakeSingleJointedArmPlantCoeffs() {
+  Eigen::Matrix<double, 2, 2> A;
+  A(0, 0) = 1.0;
+  A(0, 1) = 0.005049987902346862;
+  A(1, 0) = 0.0;
+  A(1, 1) = 0.9999952088540683;
+  Eigen::Matrix<double, 2, 1> B;
+  B(0, 0) = 1.1444063060619785e-06;
+  B(1, 0) = 0.0004532298583066335;
+  Eigen::Matrix<double, 1, 2> C;
+  C(0, 0) = 1.0;
+  C(0, 1) = 0.0;
+  Eigen::Matrix<double, 1, 1> D;
+  D(0, 0) = 0.0;
+  return frc::StateSpacePlantCoeffs<2, 1, 1>(A, B, C, D);
+}
+
+frc::StateSpaceControllerCoeffs<2, 1, 1>
+MakeSingleJointedArmControllerCoeffs() {
+  Eigen::Matrix<double, 1, 2> K;
+  K(0, 0) = 659.4457876860411;
+  K(0, 1) = 179.11558938712352;
+  Eigen::Matrix<double, 1, 2> Kff;
+  Kff(0, 0) = 0.5390980036447967;
+  Kff(0, 1) = 8.538202281633405;
+  Eigen::Matrix<double, 1, 1> Umin;
+  Umin(0, 0) = -12.0;
+  Eigen::Matrix<double, 1, 1> Umax;
+  Umax(0, 0) = 12.0;
+  return frc::StateSpaceControllerCoeffs<2, 1, 1>(K, Kff, Umin, Umax);
+}
+
+frc::StateSpaceObserverCoeffs<2, 1, 1> MakeSingleJointedArmObserverCoeffs() {
+  Eigen::Matrix<double, 2, 1> K;
+  K(0, 0) = 0.8033915976431203;
+  K(1, 0) = 7.738121910642457;
+  return frc::StateSpaceObserverCoeffs<2, 1, 1>(K);
+}
+
+frc::StateSpaceLoop<2, 1, 1> MakeSingleJointedArmLoop() {
+  return frc::StateSpaceLoop<2, 1, 1>(MakeSingleJointedArmPlantCoeffs(),
+                                      MakeSingleJointedArmControllerCoeffs(),
+                                      MakeSingleJointedArmObserverCoeffs());
+}

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/cpp/subsystems/SingleJointedArmController.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/cpp/subsystems/SingleJointedArmController.cpp
@@ -1,0 +1,61 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <cmath>
+
+#include "subsystems/SingleJointedArm.h"
+
+SingleJointedArmController::SingleJointedArmController() { m_Y.setZero(); }
+
+void SingleJointedArmController::Enable() { m_loop.Enable(); }
+
+void SingleJointedArmController::Disable() { m_loop.Disable(); }
+
+void SingleJointedArmController::SetReferences(double angle,
+                                               double angularVelocity) {
+  Eigen::Matrix<double, 2, 1> nextR;
+  nextR << angle, angularVelocity;
+  m_loop.SetNextR(nextR);
+}
+
+bool SingleJointedArmController::AtReferences() const { return m_atReferences; }
+
+void SingleJointedArmController::SetMeasuredAngle(double measuredAngle) {
+  m_Y << measuredAngle;
+}
+
+double SingleJointedArmController::ControllerVoltage() const {
+  return m_loop.U(0);
+}
+
+double SingleJointedArmController::EstimatedAngle() const {
+  return m_loop.Xhat(0);
+}
+
+double SingleJointedArmController::EstimatedAngularVelocity() const {
+  return m_loop.Xhat(1);
+}
+
+double SingleJointedArmController::AngleError() const {
+  return m_loop.Error()(0, 0);
+}
+
+double SingleJointedArmController::AngularVelocityError() const {
+  return m_loop.Error()(1, 0);
+}
+
+void SingleJointedArmController::Update() {
+  m_loop.Correct(m_Y);
+
+  auto error = m_loop.Error();
+  m_atReferences = std::abs(error(0, 0)) < kAngleTolerance &&
+                   std::abs(error(1, 0)) < kAngularVelocityTolerance;
+
+  m_loop.Predict();
+}
+
+void SingleJointedArmController::Reset() { m_loop.Reset(); }

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/include/Robot.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/include/Robot.h
@@ -1,0 +1,17 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/TimedRobot.h>
+
+#include "subsystems/SingleJointedArm.h"
+
+class Robot : public frc::TimedRobot {
+ public:
+  static SingleJointedArm m_singleJointedArm;
+};

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/include/subsystems/SingleJointedArm.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/include/subsystems/SingleJointedArm.h
@@ -1,0 +1,55 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+#include <frc/Encoder.h>
+#include <frc/Notifier.h>
+#include <frc/Spark.h>
+
+#include "subsystems/SingleJointedArmController.h"
+
+class SingleJointedArm {
+ public:
+  SingleJointedArm();
+
+  SingleJointedArm(const SingleJointedArm&) = delete;
+  SingleJointedArm& operator=(const SingleJointedArm&) = delete;
+
+  void Enable();
+  void Disable();
+
+  /**
+   * Sets the references.
+   *
+   * @param angle           Angle of arm in radians.
+   * @param angularVelocity Velocity of arm in radians per second.
+   */
+  void SetReferences(double angle, double angularVelocity);
+
+  bool AtReference() const;
+
+  /**
+   * Iterates the elevator control loop one cycle.
+   */
+  void Iterate();
+
+  /**
+   * Returns controller output.
+   */
+  double ControllerVoltage() const;
+
+  void Reset();
+
+ private:
+  frc::Spark m_motor{1};
+  frc::Encoder m_encoder{1, 2};
+
+  SingleJointedArmController m_singleJointedArm;
+  frc::Notifier m_thread{&SingleJointedArm::Iterate, this};
+};

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/include/subsystems/SingleJointedArmCoeffs.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/include/subsystems/SingleJointedArmCoeffs.h
@@ -1,0 +1,18 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/controller/StateSpaceControllerCoeffs.h>
+#include <frc/controller/StateSpaceLoop.h>
+#include <frc/controller/StateSpaceObserverCoeffs.h>
+#include <frc/controller/StateSpacePlantCoeffs.h>
+
+frc::StateSpacePlantCoeffs<2, 1, 1> MakeSingleJointedArmPlantCoeffs();
+frc::StateSpaceControllerCoeffs<2, 1, 1> MakeSingleJointedArmControllerCoeffs();
+frc::StateSpaceObserverCoeffs<2, 1, 1> MakeSingleJointedArmObserverCoeffs();
+frc::StateSpaceLoop<2, 1, 1> MakeSingleJointedArmLoop();

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/include/subsystems/SingleJointedArmController.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/include/subsystems/SingleJointedArmController.h
@@ -1,0 +1,90 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <Eigen/Core>
+#include <frc/controller/StateSpaceLoop.h>
+
+#include "subsystems/SingleJointedArmCoeffs.h"
+
+class SingleJointedArmController {
+ public:
+  // State tolerances in meters and meters/sec respectively.
+  static constexpr double kAngleTolerance = 0.05;
+  static constexpr double kAngularVelocityTolerance = 2.0;
+
+  SingleJointedArmController();
+
+  SingleJointedArmController(SingleJointedArmController&&) = default;
+  SingleJointedArmController& operator=(SingleJointedArmController&&) = default;
+
+  void Enable();
+  void Disable();
+
+  /**
+   * Sets the references.
+   *
+   * @param angle           Angle of arm in radians.
+   * @param angularVelocity Angular velocity of arm in radians per second.
+   */
+  void SetReferences(double angle, double angularVelocity);
+
+  bool AtReferences() const;
+
+  /**
+   * Sets the current encoder measurement.
+   *
+   * @param measuredAngle Angle of arm in radians.
+   */
+  void SetMeasuredAngle(double measuredAngle);
+
+  /**
+   * Returns the control loop calculated voltage.
+   */
+  double ControllerVoltage() const;
+
+  /**
+   * Returns the estimated angle.
+   */
+  double EstimatedAngle() const;
+
+  /**
+   * Returns the estimated angular velocity.
+   */
+  double EstimatedAngularVelocity() const;
+
+  /**
+   * Returns the error between the angle reference and the angle estimate.
+   */
+  double AngleError() const;
+
+  /**
+   * Returns the error between the angular velocity reference and the angular
+   * velocity estimate.
+   */
+  double AngularVelocityError() const;
+
+  /**
+   * Executes the control loop for a cycle.
+   */
+  void Update();
+
+  /**
+   * Resets any internal state.
+   */
+  void Reset();
+
+ private:
+  // The current sensor measurement.
+  Eigen::Matrix<double, 1, 1> m_Y;
+
+  // The control loop.
+  frc::StateSpaceLoop<2, 1, 1> m_loop{MakeSingleJointedArmLoop()};
+
+  bool m_atReferences = false;
+};

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/single_jointed_arm.py
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceSingleJointedArm/single_jointed_arm.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+# Avoid needing display if plots aren't being shown
+import os
+import sys
+
+if "--noninteractive" in sys.argv:
+    import matplotlib as mpl
+
+    mpl.use("svg")
+
+import frccontrol as fct
+import math
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+class SingleJointedArm(fct.System):
+
+    def __init__(self, dt):
+        """Single-jointed arm subsystem.
+
+        Keyword arguments:
+        dt -- time between model/controller updates
+        """
+        state_labels = [("Angle", "rad"), ("Angular velocity", "rad/s")]
+        u_labels = [("Voltage", "V")]
+        self.set_plot_labels(state_labels, u_labels)
+
+        fct.System.__init__(self, np.zeros((2, 1)), np.array([[-12.0]]),
+                            np.array([[12.0]]), dt)
+
+    def create_model(self, states):
+        # Number of motors
+        num_motors = 1.0
+        # Mass of arm in kg
+        m = 2.2675
+        # Length of arm in m
+        l = 1.2192
+        # Arm moment of inertia in kg-m^2
+        J = 1 / 3 * m * l**2
+        # Gear ratio
+        G = 1.0 / 2.0
+
+        return fct.models.single_jointed_arm(fct.models.MOTOR_CIM, num_motors,
+                                             J, G)
+
+    def design_controller_observer(self):
+        q_pos = 0.01745
+        q_vel = 0.08726
+        self.design_lqr([q_pos, q_vel], [12.0])
+        self.design_two_state_feedforward([q_pos, q_vel], [12.0])
+
+        q_pos = 0.01745
+        q_vel = 0.1745329
+        r_pos = 0.01
+        r_vel = 0.01
+        self.design_kalman_filter([q_pos, q_vel], [r_pos])
+
+
+def main():
+    dt = 0.00505
+    single_jointed_arm = SingleJointedArm(dt)
+    single_jointed_arm.export_cpp_coeffs("SingleJointedArm", "subsystems/", "h")
+    os.rename("SingleJointedArmCoeffs.cpp",
+              "cpp/subsystems/SingleJointedArmCoeffs.cpp")
+    os.rename("SingleJointedArmCoeffs.h",
+              "include/subsystems/SingleJointedArmCoeffs.h")
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        try:
+            import slycot
+
+            plt.figure(1)
+            single_jointed_arm.plot_pzmaps()
+        except ImportError:  # Slycot unavailable. Can't show pzmaps.
+            pass
+    if "--save-plots" in sys.argv:
+        plt.savefig("single_jointed_arm_pzmaps.svg")
+
+    t, xprof, vprof, aprof = fct.generate_s_curve_profile(max_v=0.5,
+                                                          max_a=1,
+                                                          time_to_max_a=0.5,
+                                                          dt=dt,
+                                                          goal=1.04)
+
+    # Generate references for simulation
+    refs = []
+    for i in range(len(t)):
+        r = np.array([[xprof[i]], [vprof[i]]])
+        refs.append(r)
+
+    if "--save-plots" in sys.argv or "--noninteractive" not in sys.argv:
+        plt.figure(2)
+        x_rec, ref_rec, u_rec = single_jointed_arm.generate_time_responses(
+            t, refs)
+        single_jointed_arm.plot_time_responses(t, x_rec, ref_rec, u_rec)
+    if "--save-plots" in sys.argv:
+        plt.savefig("single_jointed_arm_response.svg")
+    if "--noninteractive" not in sys.argv:
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/wpilibcExamples/src/main/cpp/examples/examples.json
+++ b/wpilibcExamples/src/main/cpp/examples/examples.json
@@ -531,6 +531,87 @@
     ],
     "foldername": "DriveDistanceOffboard",
     "gradlebase": "cpp",
-    "commandversion": 2
+    "commandversion": 2,
+    "gradlebase": "cpp"
+  },
+  {
+    "name": "StateSpaceDifferentialDrive",
+    "description": "An example that demonstates a state-space controller for a differential drive.",
+    "tags": [
+      "State-space",
+      "Complete List"
+    ],
+    "foldername": "StateSpaceDifferentialDrive",
+    "gradlebase": "cpp"
+  },
+  {
+    "name": "StateSpaceElevator",
+    "description": "An example that demonstates a state-space controller for an elevator.",
+    "tags": [
+      "State-space",
+      "Complete List"
+    ],
+    "foldername": "StateSpaceElevator",
+    "gradlebase": "cpp"
+  },
+  {
+    "name": "StateSpaceFlywheel",
+    "description": "An example that demonstates a state-space controller for a flywheel.",
+    "tags": [
+      "State-space",
+      "Complete List"
+    ],
+    "foldername": "StateSpaceFlywheel",
+    "gradlebase": "cpp"
+  },
+  {
+    "name": "StateSpaceSingleJointedArm",
+    "description": "An example that demonstates a state-space controller for a single-jointed arm.",
+    "tags": [
+      "State-space",
+      "Complete List"
+    ],
+    "foldername": "StateSpaceSingleJointedArm",
+    "gradlebase": "cpp"
+  },
+  {
+    "name": "PeriodVariantDifferentialDrive",
+    "description": "An example that demonstates a period-variant state-space controller for a differential drive.",
+    "tags": [
+      "State-space",
+      "Complete List"
+    ],
+    "foldername": "PeriodVariantDifferentialDrive",
+    "gradlebase": "cpp"
+  },
+  {
+    "name": "PeriodVariantElevator",
+    "description": "An example that demonstates a period-variant state-space controller for an elevator.",
+    "tags": [
+      "State-space",
+      "Complete List"
+    ],
+    "foldername": "PeriodVariantElevator",
+    "gradlebase": "cpp"
+  },
+  {
+    "name": "PeriodVariantFlywheel",
+    "description": "An example that demonstates a period-variant state-space controller for a flywheel.",
+    "tags": [
+      "State-space",
+      "Complete List"
+    ],
+    "foldername": "PeriodVariantFlywheel",
+    "gradlebase": "cpp"
+  },
+  {
+    "name": "PeriodVariantSingleJointedArm",
+    "description": "An example that demonstates a period-variant state-space controller for a single-jointed arm.",
+    "tags": [
+      "State-space",
+      "Complete List"
+    ],
+    "foldername": "PeriodVariantSingleJointedArm",
+    "gradlebase": "cpp"
   }
 ]


### PR DESCRIPTION
This supports two types: StateSpace and PeriodVariant. The latter allows
the user to specify a dt between controller updates to make the model
more accurate.
    
Examples for a drivetrain, elevator, flywheel, and single-jointed arm
are in the examples folders.