### PR TITLE
Fix JavaDoc tag in Command

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
@@ -381,7 +381,7 @@ public abstract class Command extends SendableBase implements Sendable {
   /**
    * Returns whether the command has a parent.
    *
-   * @param True if the command has a parent.
+   * @return true if the command has a parent.
    */
   synchronized boolean isParented() {
     return m_parent != null;


### PR DESCRIPTION
The isParented method had an incorrect javadoc tag for the return value.