### PR TITLE
Check for nullptr return from malloc, calloc, and realloc.

### DIFF
--- a/cscore/src/main/native/cpp/HttpCameraImpl.cpp
+++ b/cscore/src/main/native/cpp/HttpCameraImpl.cpp
@@ -9,6 +9,7 @@
 
 #include <wpi/STLExtras.h>
 #include <wpi/TCPConnector.h>
+#include <wpi/memory.h>
 #include <wpi/timestamp.h>
 
 #include "Handle.h"
@@ -574,7 +575,8 @@ void CS_SetHttpCameraUrls(CS_Source source, const char** urls, int count,
 
 char** CS_GetHttpCameraUrls(CS_Source source, int* count, CS_Status* status) {
   auto urls = cs::GetHttpCameraUrls(source, status);
-  char** out = static_cast<char**>(std::malloc(urls.size() * sizeof(char*)));
+  char** out =
+      static_cast<char**>(wpi::CheckedMalloc(urls.size() * sizeof(char*)));
   *count = urls.size();
   for (size_t i = 0; i < urls.size(); ++i) out[i] = cs::ConvertToC(urls[i]);
   return out;

--- a/cscore/src/main/native/cpp/UsbCameraImpl.cpp
+++ b/cscore/src/main/native/cpp/UsbCameraImpl.cpp
@@ -29,6 +29,7 @@
 
 #include <wpi/SmallString.h>
 #include <wpi/raw_ostream.h>
+#include <wpi/memory.h>
 #include <wpi/timestamp.h>
 
 #include "Handle.h"
@@ -1315,7 +1316,7 @@ char* CS_GetUsbCameraPath(CS_Source source, CS_Status* status) {
 CS_UsbCameraInfo* CS_EnumerateUsbCameras(int* count, CS_Status* status) {
   auto cameras = cs::EnumerateUsbCameras(status);
   CS_UsbCameraInfo* out = static_cast<CS_UsbCameraInfo*>(
-      std::malloc(cameras.size() * sizeof(CS_UsbCameraInfo)));
+      wpi::CheckedMalloc(cameras.size() * sizeof(CS_UsbCameraInfo)));
   *count = cameras.size();
   for (size_t i = 0; i < cameras.size(); ++i) {
     out[i].dev = cameras[i].dev;

--- a/cscore/src/main/native/cpp/c_util.h
+++ b/cscore/src/main/native/cpp/c_util.h
@@ -12,11 +12,12 @@
 #include <cstring>
 
 #include <wpi/StringRef.h>
+#include <wpi/memory.h>
 
 namespace cs {
 
 inline char* ConvertToC(wpi::StringRef in) {
-  char* out = static_cast<char*>(std::malloc(in.size() + 1));
+  char* out = static_cast<char*>(wpi::CheckedMalloc(in.size() + 1));
   std::memmove(out, in.data(), in.size());
   out[in.size()] = '\0';
   return out;

--- a/cscore/src/main/native/cpp/cscore_c.cpp
+++ b/cscore/src/main/native/cpp/cscore_c.cpp
@@ -12,6 +12,7 @@
 
 #include <opencv2/core/core.hpp>
 #include <wpi/SmallString.h>
+#include <wpi/memory.h>
 
 #include "c_util.h"
 #include "cscore_cpp.h"
@@ -68,7 +69,8 @@ void CS_SetStringProperty(CS_Property property, const char* value,
 char** CS_GetEnumPropertyChoices(CS_Property property, int* count,
                                  CS_Status* status) {
   auto choices = cs::GetEnumPropertyChoices(property, status);
-  char** out = static_cast<char**>(std::malloc(choices.size() * sizeof(char*)));
+  char** out =
+      static_cast<char**>(wpi::CheckedMalloc(choices.size() * sizeof(char*)));
   *count = choices.size();
   for (size_t i = 0; i < choices.size(); ++i)
     out[i] = cs::ConvertToC(choices[i]);
@@ -110,8 +112,8 @@ CS_Property* CS_EnumerateSourceProperties(CS_Source source, int* count,
                                           CS_Status* status) {
   wpi::SmallVector<CS_Property, 32> buf;
   auto vec = cs::EnumerateSourceProperties(source, buf, status);
-  CS_Property* out =
-      static_cast<CS_Property*>(std::malloc(vec.size() * sizeof(CS_Property)));
+  CS_Property* out = static_cast<CS_Property*>(
+      wpi::CheckedMalloc(vec.size() * sizeof(CS_Property)));
   *count = vec.size();
   std::copy(vec.begin(), vec.end(), out);
   return out;
@@ -162,7 +164,7 @@ CS_VideoMode* CS_EnumerateSourceVideoModes(CS_Source source, int* count,
                                            CS_Status* status) {
   auto vec = cs::EnumerateSourceVideoModes(source, status);
   CS_VideoMode* out = static_cast<CS_VideoMode*>(
-      std::malloc(vec.size() * sizeof(CS_VideoMode)));
+      wpi::CheckedMalloc(vec.size() * sizeof(CS_VideoMode)));
   *count = vec.size();
   std::copy(vec.begin(), vec.end(), out);
   return out;
@@ -172,8 +174,8 @@ CS_Sink* CS_EnumerateSourceSinks(CS_Source source, int* count,
                                  CS_Status* status) {
   wpi::SmallVector<CS_Sink, 32> buf;
   auto handles = cs::EnumerateSourceSinks(source, buf, status);
-  CS_Sink* sinks =
-      static_cast<CS_Sink*>(std::malloc(handles.size() * sizeof(CS_Sink)));
+  CS_Sink* sinks = static_cast<CS_Sink*>(
+      wpi::CheckedMalloc(handles.size() * sizeof(CS_Sink)));
   *count = handles.size();
   std::copy(handles.begin(), handles.end(), sinks);
   return sinks;
@@ -323,8 +325,8 @@ void CS_SetDefaultLogger(unsigned int min_level) {
 CS_Source* CS_EnumerateSources(int* count, CS_Status* status) {
   wpi::SmallVector<CS_Source, 32> buf;
   auto handles = cs::EnumerateSourceHandles(buf, status);
-  CS_Source* sources =
-      static_cast<CS_Source*>(std::malloc(handles.size() * sizeof(CS_Source)));
+  CS_Source* sources = static_cast<CS_Source*>(
+      wpi::CheckedMalloc(handles.size() * sizeof(CS_Source)));
   *count = handles.size();
   std::copy(handles.begin(), handles.end(), sources);
   return sources;
@@ -342,8 +344,8 @@ void CS_ReleaseEnumeratedSources(CS_Source* sources, int count) {
 CS_Sink* CS_EnumerateSinks(int* count, CS_Status* status) {
   wpi::SmallVector<CS_Sink, 32> buf;
   auto handles = cs::EnumerateSinkHandles(buf, status);
-  CS_Sink* sinks =
-      static_cast<CS_Sink*>(std::malloc(handles.size() * sizeof(CS_Sink)));
+  CS_Sink* sinks = static_cast<CS_Sink*>(
+      wpi::CheckedMalloc(handles.size() * sizeof(CS_Sink)));
   *count = handles.size();
   std::copy(handles.begin(), handles.end(), sinks);
   return sinks;
@@ -378,8 +380,8 @@ char* CS_GetHostname() { return cs::ConvertToC(cs::GetHostname()); }
 
 char** CS_GetNetworkInterfaces(int* count) {
   auto interfaces = cs::GetNetworkInterfaces();
-  char** out =
-      static_cast<char**>(std::malloc(interfaces.size() * sizeof(char*)));
+  char** out = static_cast<char**>(
+      wpi::CheckedMalloc(interfaces.size() * sizeof(char*)));
   *count = interfaces.size();
   for (size_t i = 0; i < interfaces.size(); ++i)
     out[i] = cs::ConvertToC(interfaces[i]);

--- a/ntcore/src/main/native/cpp/Value.cpp
+++ b/ntcore/src/main/native/cpp/Value.cpp
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include <wpi/memory.h>
 #include <wpi/timestamp.h>
 
 #include "Value_internal.h"
@@ -113,7 +114,7 @@ void nt::ConvertToC(const Value& in, NT_Value* out) {
     case NT_BOOLEAN_ARRAY: {
       auto v = in.GetBooleanArray();
       out->data.arr_boolean.arr =
-          static_cast<int*>(std::malloc(v.size() * sizeof(int)));
+          static_cast<int*>(wpi::CheckedMalloc(v.size() * sizeof(int)));
       out->data.arr_boolean.size = v.size();
       std::copy(v.begin(), v.end(), out->data.arr_boolean.arr);
       break;
@@ -121,15 +122,15 @@ void nt::ConvertToC(const Value& in, NT_Value* out) {
     case NT_DOUBLE_ARRAY: {
       auto v = in.GetDoubleArray();
       out->data.arr_double.arr =
-          static_cast<double*>(std::malloc(v.size() * sizeof(double)));
+          static_cast<double*>(wpi::CheckedMalloc(v.size() * sizeof(double)));
       out->data.arr_double.size = v.size();
       std::copy(v.begin(), v.end(), out->data.arr_double.arr);
       break;
     }
     case NT_STRING_ARRAY: {
       auto v = in.GetStringArray();
-      out->data.arr_string.arr =
-          static_cast<NT_String*>(std::malloc(v.size() * sizeof(NT_String)));
+      out->data.arr_string.arr = static_cast<NT_String*>(
+          wpi::CheckedMalloc(v.size() * sizeof(NT_String)));
       for (size_t i = 0; i < v.size(); ++i)
         ConvertToC(v[i], &out->data.arr_string.arr[i]);
       out->data.arr_string.size = v.size();
@@ -144,7 +145,7 @@ void nt::ConvertToC(const Value& in, NT_Value* out) {
 
 void nt::ConvertToC(wpi::StringRef in, NT_String* out) {
   out->len = in.size();
-  out->str = static_cast<char*>(std::malloc(in.size() + 1));
+  out->str = static_cast<char*>(wpi::CheckedMalloc(in.size() + 1));
   std::memcpy(out->str, in.data(), in.size());
   out->str[in.size()] = '\0';
 }

--- a/ntcore/src/main/native/cpp/WireDecoder.cpp
+++ b/ntcore/src/main/native/cpp/WireDecoder.cpp
@@ -15,6 +15,7 @@
 
 #include <wpi/MathExtras.h>
 #include <wpi/leb128.h>
+#include <wpi/memory.h>
 
 using namespace nt;
 
@@ -52,7 +53,7 @@ WireDecoder::WireDecoder(wpi::raw_istream& is, unsigned int proto_rev,
   // Start with a 1K temporary buffer.  Use malloc instead of new so we can
   // realloc.
   m_allocated = 1024;
-  m_buf = static_cast<char*>(std::malloc(m_allocated));
+  m_buf = static_cast<char*>(wpi::CheckedMalloc(m_allocated));
   m_proto_rev = proto_rev;
   m_error = nullptr;
 }
@@ -71,7 +72,7 @@ void WireDecoder::Realloc(size_t len) {
   if (m_allocated >= len) return;
   size_t newlen = m_allocated * 2;
   while (newlen < len) newlen *= 2;
-  m_buf = static_cast<char*>(std::realloc(m_buf, newlen));
+  m_buf = static_cast<char*>(wpi::CheckedRealloc(m_buf, newlen));
   m_allocated = newlen;
 }
 

--- a/ntcore/src/main/native/cpp/ntcore_test.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_test.cpp
@@ -7,12 +7,14 @@
 
 #include "ntcore_test.h"
 
+#include <wpi/memory.h>
+
 #include "Value_internal.h"
 
 extern "C" {
 struct NT_String* NT_GetStringForTesting(const char* string, int* struct_size) {
   struct NT_String* str =
-      static_cast<NT_String*>(std::calloc(1, sizeof(NT_String)));
+      static_cast<NT_String*>(wpi::CheckedCalloc(1, sizeof(NT_String)));
   nt::ConvertToC(wpi::StringRef(string), str);
   *struct_size = sizeof(NT_String);
   return str;
@@ -24,7 +26,7 @@ struct NT_EntryInfo* NT_GetEntryInfoForTesting(const char* name,
                                                uint64_t last_change,
                                                int* struct_size) {
   struct NT_EntryInfo* entry_info =
-      static_cast<NT_EntryInfo*>(std::calloc(1, sizeof(NT_EntryInfo)));
+      static_cast<NT_EntryInfo*>(wpi::CheckedCalloc(1, sizeof(NT_EntryInfo)));
   nt::ConvertToC(wpi::StringRef(name), &entry_info->name);
   entry_info->type = type;
   entry_info->flags = flags;
@@ -42,7 +44,7 @@ struct NT_ConnectionInfo* NT_GetConnectionInfoForTesting(
     const char* remote_id, const char* remote_ip, unsigned int remote_port,
     uint64_t last_update, unsigned int protocol_version, int* struct_size) {
   struct NT_ConnectionInfo* conn_info = static_cast<NT_ConnectionInfo*>(
-      std::calloc(1, sizeof(NT_ConnectionInfo)));
+      wpi::CheckedCalloc(1, sizeof(NT_ConnectionInfo)));
   nt::ConvertToC(wpi::StringRef(remote_id), &conn_info->remote_id);
   nt::ConvertToC(wpi::StringRef(remote_ip), &conn_info->remote_ip);
   conn_info->remote_port = remote_port;
@@ -61,7 +63,7 @@ void NT_FreeConnectionInfoForTesting(struct NT_ConnectionInfo* info) {
 struct NT_Value* NT_GetValueBooleanForTesting(uint64_t last_change, int val,
                                               int* struct_size) {
   struct NT_Value* value =
-      static_cast<NT_Value*>(std::calloc(1, sizeof(NT_Value)));
+      static_cast<NT_Value*>(wpi::CheckedCalloc(1, sizeof(NT_Value)));
   value->type = NT_BOOLEAN;
   value->last_change = last_change;
   value->data.v_boolean = val;
@@ -72,7 +74,7 @@ struct NT_Value* NT_GetValueBooleanForTesting(uint64_t last_change, int val,
 struct NT_Value* NT_GetValueDoubleForTesting(uint64_t last_change, double val,
                                              int* struct_size) {
   struct NT_Value* value =
-      static_cast<NT_Value*>(std::calloc(1, sizeof(NT_Value)));
+      static_cast<NT_Value*>(wpi::CheckedCalloc(1, sizeof(NT_Value)));
   value->type = NT_DOUBLE;
   value->last_change = last_change;
   value->data.v_double = val;
@@ -84,7 +86,7 @@ struct NT_Value* NT_GetValueStringForTesting(uint64_t last_change,
                                              const char* str,
                                              int* struct_size) {
   struct NT_Value* value =
-      static_cast<NT_Value*>(std::calloc(1, sizeof(NT_Value)));
+      static_cast<NT_Value*>(wpi::CheckedCalloc(1, sizeof(NT_Value)));
   value->type = NT_STRING;
   value->last_change = last_change;
   nt::ConvertToC(wpi::StringRef(str), &value->data.v_string);
@@ -95,7 +97,7 @@ struct NT_Value* NT_GetValueStringForTesting(uint64_t last_change,
 struct NT_Value* NT_GetValueRawForTesting(uint64_t last_change, const char* raw,
                                           int raw_len, int* struct_size) {
   struct NT_Value* value =
-      static_cast<NT_Value*>(std::calloc(1, sizeof(NT_Value)));
+      static_cast<NT_Value*>(wpi::CheckedCalloc(1, sizeof(NT_Value)));
   value->type = NT_RAW;
   value->last_change = last_change;
   nt::ConvertToC(wpi::StringRef(raw, raw_len), &value->data.v_string);
@@ -108,7 +110,7 @@ struct NT_Value* NT_GetValueBooleanArrayForTesting(uint64_t last_change,
                                                    size_t array_len,
                                                    int* struct_size) {
   struct NT_Value* value =
-      static_cast<NT_Value*>(std::calloc(1, sizeof(NT_Value)));
+      static_cast<NT_Value*>(wpi::CheckedCalloc(1, sizeof(NT_Value)));
   value->type = NT_BOOLEAN_ARRAY;
   value->last_change = last_change;
   value->data.arr_boolean.arr = NT_AllocateBooleanArray(array_len);
@@ -124,7 +126,7 @@ struct NT_Value* NT_GetValueDoubleArrayForTesting(uint64_t last_change,
                                                   size_t array_len,
                                                   int* struct_size) {
   struct NT_Value* value =
-      static_cast<NT_Value*>(std::calloc(1, sizeof(NT_Value)));
+      static_cast<NT_Value*>(wpi::CheckedCalloc(1, sizeof(NT_Value)));
   value->type = NT_BOOLEAN;
   value->last_change = last_change;
   value->data.arr_double.arr = NT_AllocateDoubleArray(array_len);
@@ -140,7 +142,7 @@ struct NT_Value* NT_GetValueStringArrayForTesting(uint64_t last_change,
                                                   size_t array_len,
                                                   int* struct_size) {
   struct NT_Value* value =
-      static_cast<NT_Value*>(std::calloc(1, sizeof(NT_Value)));
+      static_cast<NT_Value*>(wpi::CheckedCalloc(1, sizeof(NT_Value)));
   value->type = NT_BOOLEAN;
   value->last_change = last_change;
   value->data.arr_string.arr = NT_AllocateStringArray(array_len);
@@ -149,7 +151,7 @@ struct NT_Value* NT_GetValueStringArrayForTesting(uint64_t last_change,
     size_t len = arr[i].len;
     value->data.arr_string.arr[i].len = len;
     value->data.arr_string.arr[i].str =
-        static_cast<char*>(std::malloc(len + 1));
+        static_cast<char*>(wpi::CheckedMalloc(len + 1));
     std::memcpy(value->data.arr_string.arr[i].str, arr[i].str, len + 1);
   }
   *struct_size = sizeof(NT_Value);
@@ -171,8 +173,8 @@ static void CopyNtString(const struct NT_String* copy_from,
 struct NT_RpcParamDef* NT_GetRpcParamDefForTesting(const char* name,
                                                    const struct NT_Value* val,
                                                    int* struct_size) {
-  struct NT_RpcParamDef* def =
-      static_cast<NT_RpcParamDef*>(std::calloc(1, sizeof(NT_RpcParamDef)));
+  struct NT_RpcParamDef* def = static_cast<NT_RpcParamDef*>(
+      wpi::CheckedCalloc(1, sizeof(NT_RpcParamDef)));
   nt::ConvertToC(wpi::StringRef(name), &def->name);
   CopyNtValue(val, &def->def_value);
   *struct_size = sizeof(NT_RpcParamDef);
@@ -188,8 +190,8 @@ void NT_FreeRpcParamDefForTesting(struct NT_RpcParamDef* def) {
 struct NT_RpcResultDef* NT_GetRpcResultsDefForTesting(const char* name,
                                                       enum NT_Type type,
                                                       int* struct_size) {
-  struct NT_RpcResultDef* def =
-      static_cast<NT_RpcResultDef*>(std::calloc(1, sizeof(NT_RpcResultDef)));
+  struct NT_RpcResultDef* def = static_cast<NT_RpcResultDef*>(
+      wpi::CheckedCalloc(1, sizeof(NT_RpcResultDef)));
   nt::ConvertToC(wpi::StringRef(name), &def->name);
   def->type = type;
   *struct_size = sizeof(NT_RpcResultDef);
@@ -205,20 +207,20 @@ struct NT_RpcDefinition* NT_GetRpcDefinitionForTesting(
     unsigned int version, const char* name, size_t num_params,
     const struct NT_RpcParamDef* params, size_t num_results,
     const struct NT_RpcResultDef* results, int* struct_size) {
-  struct NT_RpcDefinition* def =
-      static_cast<NT_RpcDefinition*>(std::calloc(1, sizeof(NT_RpcDefinition)));
+  struct NT_RpcDefinition* def = static_cast<NT_RpcDefinition*>(
+      wpi::CheckedCalloc(1, sizeof(NT_RpcDefinition)));
   def->version = version;
   nt::ConvertToC(wpi::StringRef(name), &def->name);
   def->num_params = num_params;
   def->params = static_cast<NT_RpcParamDef*>(
-      std::malloc(num_params * sizeof(NT_RpcParamDef)));
+      wpi::CheckedMalloc(num_params * sizeof(NT_RpcParamDef)));
   for (size_t i = 0; i < num_params; ++i) {
     CopyNtString(&params[i].name, &def->params[i].name);
     CopyNtValue(&params[i].def_value, &def->params[i].def_value);
   }
   def->num_results = num_results;
   def->results = static_cast<NT_RpcResultDef*>(
-      std::malloc(num_results * sizeof(NT_RpcResultDef)));
+      wpi::CheckedMalloc(num_results * sizeof(NT_RpcResultDef)));
   for (size_t i = 0; i < num_results; ++i) {
     CopyNtString(&results[i].name, &def->results[i].name);
     def->results[i].type = results[i].type;
@@ -232,7 +234,7 @@ struct NT_RpcAnswer* NT_GetRpcAnswerForTesting(
     unsigned int rpc_id, unsigned int call_uid, const char* name,
     const char* params, size_t params_len, int* struct_size) {
   struct NT_RpcAnswer* info =
-      static_cast<NT_RpcAnswer*>(std::calloc(1, sizeof(NT_RpcAnswer)));
+      static_cast<NT_RpcAnswer*>(wpi::CheckedCalloc(1, sizeof(NT_RpcAnswer)));
   info->entry = rpc_id;
   info->call = call_uid;
   nt::ConvertToC(wpi::StringRef(name), &info->name);

--- a/wpiutil/src/main/native/include/wpi/memory.h
+++ b/wpiutil/src/main/native/include/wpi/memory.h
@@ -1,0 +1,64 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#ifndef WPIUTIL_SUPPORT_MEMORY_H_
+#define WPIUTIL_SUPPORT_MEMORY_H_
+
+#include <cstdlib>
+#include <exception>
+
+#include "wpi/raw_ostream.h"
+
+namespace wpi {
+
+/**
+ * Wrapper around std::calloc that calls std::terminate on out of memory.
+ * @param num number of objects to allocate
+ * @param size number of bytes per object to allocate
+ * @return Pointer to beginning of newly allocated memory.
+ */
+inline void* CheckedCalloc(size_t num, size_t size) {
+  void* p = std::calloc(num, size);
+  if (!p) {
+    errs() << "FATAL: failed to allocate " << (num * size) << " bytes\n";
+    std::terminate();
+  }
+  return p;
+}
+
+/**
+ * Wrapper around std::malloc that calls std::terminate on out of memory.
+ * @param size number of bytes to allocate
+ * @return Pointer to beginning of newly allocated memory.
+ */
+inline void* CheckedMalloc(size_t size) {
+  void* p = std::malloc(size == 0 ? 1 : size);
+  if (!p) {
+    errs() << "FATAL: failed to allocate " << size << " bytes\n";
+    std::terminate();
+  }
+  return p;
+}
+
+/**
+ * Wrapper around std::realloc that calls std::terminate on out of memory.
+ * @param ptr memory previously allocated
+ * @param size number of bytes to allocate
+ * @return Pointer to beginning of newly allocated memory.
+ */
+inline void* CheckedRealloc(void* ptr, size_t size) {
+  void* p = std::realloc(ptr, size == 0 ? 1 : size);
+  if (!p) {
+    errs() << "FATAL: failed to allocate " << size << " bytes\n";
+    std::terminate();
+  }
+  return p;
+}
+
+}  // namespace wpi
+
+#endif  // WPIUTIL_SUPPORT_MEMORY_H_


### PR DESCRIPTION
These are used in ntcore and cscore.  Add inline null-checking versions
to wpi/memory.h and use them throughout.