### PR TITLE
Fixes gradle wpilibj classpath for editors

### DIFF
--- a/wpilibj/build.gradle
+++ b/wpilibj/build.gradle
@@ -48,30 +48,10 @@ gradle.taskGraph.addTaskExecutionGraphListener { graph ->
     }
 }
 
-sourceSets {
-    generated {
-        java.srcDir "${buildDir}/generated/java/"
-    }
-}
-
-compileGeneratedJava {
-    dependsOn generateJavaVersion
-    classpath = configurations.compile
-}
+sourceSets.main.java.srcDir "${buildDir}/generated/java/"
 
 compileJava {
-    dependsOn compileGeneratedJava
-    source += sourceSets.generated.java
-}
-
-classes.dependsOn generateJavaVersion
-
-sourcesJar {
-    from sourceSets.generated.allSource
-}
-
-outputSourcesJar {
-    from sourceSets.generated.allSource
+    dependsOn generateJavaVersion
 }
 
 dependencies {


### PR DESCRIPTION
Fixes #1039 

Previously, gradle didn't properly output the classpath for the version file, so editors would not see the file and continuously report and error. This fixes that, and cleans up the build slightly as well.