### PR TITLE
Replaced the START_ROBOT_CLASS() macro with a template function

### DIFF
--- a/myRobot/src/main/native/cpp/MyRobot.cpp
+++ b/myRobot/src/main/native/cpp/MyRobot.cpp
@@ -45,4 +45,4 @@ class MyRobot : public frc::IterativeRobot {
   void RobotPeriodic() override {}
 };
 
-START_ROBOT_CLASS(MyRobot)
+int main() { return frc::StartRobot<MyRobot>(); }

--- a/wpilibc/src/main/native/include/RobotBase.h
+++ b/wpilibc/src/main/native/include/RobotBase.h
@@ -18,18 +18,27 @@ namespace frc {
 
 class DriverStation;
 
-#define START_ROBOT_CLASS(_ClassName_)                                 \
-  int main() {                                                         \
-    if (!HAL_Initialize(500, 0)) {                                     \
-      wpi::errs() << "FATAL ERROR: HAL could not be initialized\n";    \
-      return -1;                                                       \
-    }                                                                  \
-    HAL_Report(HALUsageReporting::kResourceType_Language,              \
-               HALUsageReporting::kLanguage_CPlusPlus);                \
-    wpi::outs() << "\n********** Robot program starting **********\n"; \
-    static _ClassName_ robot;                                          \
-    robot.StartCompetition();                                          \
+template <class Robot>
+int StartRobot() {
+  if (!HAL_Initialize(500, 0)) {
+    wpi::errs() << "FATAL ERROR: HAL could not be initialized\n";
+    return -1;
   }
+  HAL_Report(HALUsageReporting::kResourceType_Language,
+             HALUsageReporting::kLanguage_CPlusPlus);
+  wpi::outs() << "\n********** Robot program starting **********\n";
+  static Robot robot;
+  robot.StartCompetition();
+
+  return 0;
+}
+
+#define START_ROBOT_CLASS(_ClassName_)                                 \
+  WPI_DEPRECATED("Call frc::StartRobot<" #_ClassName_                  \
+                 ">() in your own main() instead of using the "        \
+                 "START_ROBOT_CLASS(" #_ClassName_ ") macro.")         \
+  int StartRobotClassImpl() { return frc::StartRobot<_ClassName_>(); } \
+  int main() { return StartRobotClassImpl(); }
 
 /**
  * Implement a Robot Program framework.

--- a/wpilibcExamples/src/main/cpp/examples/ArcadeDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArcadeDrive/cpp/Robot.cpp
@@ -27,4 +27,4 @@ class Robot : public frc::IterativeRobot {
   }
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/AxisCameraSample/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/AxisCameraSample/cpp/Robot.cpp
@@ -60,4 +60,4 @@ class Robot : public frc::IterativeRobot {
   }
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/CANPDP/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/CANPDP/cpp/Robot.cpp
@@ -37,4 +37,4 @@ class Robot : public frc::IterativeRobot {
   frc::PowerDistributionPanel m_pdp;
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/Encoder/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Encoder/cpp/Robot.cpp
@@ -80,4 +80,4 @@ class Robot : public frc::IterativeRobot {
   frc::Encoder m_encoder{1, 2, false, Encoder::k4X};
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/Robot.cpp
@@ -42,4 +42,4 @@ void Robot::TeleopPeriodic() { frc::Scheduler::GetInstance()->Run(); }
 
 void Robot::TestPeriodic() {}
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
@@ -55,4 +55,4 @@ class Robot : public frc::IterativeRobot {
   frc::Timer m_timer;
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/Gyro/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Gyro/cpp/Robot.cpp
@@ -55,4 +55,4 @@ class Robot : public frc::IterativeRobot {
   frc::Joystick m_joystick{kJoystickPort};
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/GyroMecanum/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GyroMecanum/cpp/Robot.cpp
@@ -58,4 +58,4 @@ class Robot : public frc::IterativeRobot {
   frc::Joystick m_joystick{kJoystickPort};
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/IntermediateVision/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/IntermediateVision/cpp/Robot.cpp
@@ -72,4 +72,4 @@ class Robot : public frc::IterativeRobot {
   }
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/MecanumDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumDrive/cpp/Robot.cpp
@@ -48,4 +48,4 @@ class Robot : public frc::IterativeRobot {
   frc::Joystick m_stick{kJoystickChannel};
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/MotorControl/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MotorControl/cpp/Robot.cpp
@@ -26,4 +26,4 @@ class Robot : public frc::IterativeRobot {
   frc::Spark m_motor{0};
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/Robot.cpp
@@ -80,4 +80,4 @@ void Robot::Log() {
                                  drivetrain.GetRightEncoder().GetDistance());
 }
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/PotentiometerPID/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PotentiometerPID/cpp/Robot.cpp
@@ -73,4 +73,4 @@ class Robot : public frc::IterativeRobot {
 
 constexpr std::array<double, 3> Robot::kSetPoints;
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/QuickVision/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/QuickVision/cpp/Robot.cpp
@@ -27,4 +27,4 @@ class Robot : public frc::IterativeRobot {
   }
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/Relay/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Relay/cpp/Robot.cpp
@@ -55,4 +55,4 @@ class Robot : public frc::IterativeRobot {
   static constexpr int kRelayReverseButton = 2;
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/Solenoid/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Solenoid/cpp/Robot.cpp
@@ -67,4 +67,4 @@ class Robot : public frc::IterativeRobot {
   static constexpr int kDoubleSolenoidReverse = 3;
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/Ultrasonic/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Ultrasonic/cpp/Robot.cpp
@@ -50,4 +50,4 @@ class Robot : public frc::IterativeRobot {
   frc::DifferentialDrive m_robotDrive{m_left, m_right};
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/UltrasonicPID/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/UltrasonicPID/cpp/Robot.cpp
@@ -80,4 +80,4 @@ class Robot : public frc::IterativeRobot {
   frc::PIDController m_pidController{kP, kI, kD, m_ultrasonic, m_pidOutput};
 };
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/templates/commandbased/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandbased/cpp/Robot.cpp
@@ -72,4 +72,4 @@ void Robot::TeleopPeriodic() { frc::Scheduler::GetInstance()->Run(); }
 
 void Robot::TestPeriodic() {}
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/templates/iterative/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/iterative/cpp/Robot.cpp
@@ -55,4 +55,4 @@ void Robot::TeleopPeriodic() {}
 
 void Robot::TestPeriodic() {}
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/templates/sample/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/sample/cpp/Robot.cpp
@@ -87,4 +87,4 @@ void Robot::OperatorControl() {
  */
 void Robot::Test() {}
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/templates/timed/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/timed/cpp/Robot.cpp
@@ -55,4 +55,4 @@ void Robot::TeleopPeriodic() {}
 
 void Robot::TestPeriodic() {}
 
-START_ROBOT_CLASS(Robot)
+int main() { return frc::StartRobot<Robot>(); }


### PR DESCRIPTION
The START_ROBOT_CLASS() macro's main() now calls this function through a
deprecated proxy function to encourage users to switch.