### PR TITLE
Fixed the names of the arguments to some C++ drive classes

### DIFF
--- a/wpilibc/src/main/native/cpp/Drive/KilloughDrive.cpp
+++ b/wpilibc/src/main/native/cpp/Drive/KilloughDrive.cpp
@@ -132,7 +132,7 @@ void KilloughDrive::DriveCartesian(double ySpeed, double xSpeed,
  *                  Clockwise is positive.
  */
 void KilloughDrive::DrivePolar(double magnitude, double angle,
-                               double rotation) {
+                               double zRotation) {
   if (!reported) {
     // HAL_Report(HALUsageReporting::kResourceType_RobotDrive, 3,
     //            HALUsageReporting::kRobotDrive_KilloughPolar);
@@ -140,7 +140,7 @@ void KilloughDrive::DrivePolar(double magnitude, double angle,
   }
 
   DriveCartesian(magnitude * std::sin(angle * (kPi / 180.0)),
-                 magnitude * std::cos(angle * (kPi / 180.0)), rotation, 0.0);
+                 magnitude * std::cos(angle * (kPi / 180.0)), zRotation, 0.0);
 }
 
 void KilloughDrive::StopMotor() {

--- a/wpilibc/src/main/native/include/Drive/MecanumDrive.h
+++ b/wpilibc/src/main/native/include/Drive/MecanumDrive.h
@@ -72,9 +72,9 @@ class MecanumDrive : public RobotDriveBase {
   MecanumDrive(const MecanumDrive&) = delete;
   MecanumDrive& operator=(const MecanumDrive&) = delete;
 
-  void DriveCartesian(double x, double y, double rotation,
+  void DriveCartesian(double ySpeed, double xSpeed, double zRotation,
                       double gyroAngle = 0.0);
-  void DrivePolar(double magnitude, double angle, double rotation);
+  void DrivePolar(double magnitude, double angle, double zRotation);
 
   void StopMotor() override;
   void GetDescription(wpi::raw_ostream& desc) const override;


### PR DESCRIPTION
The docs already have the correct name, but some headers and sources
weren't updated. Java doesn't have this mistake.