### PR TITLE
Remove line ending requirements from spotless

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,26 +1,15 @@
 plugins {
     id 'net.ltgt.errorprone' version '0.0.13'
+    id "base"
     id 'edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin' version '2.0'
     id 'edu.wpi.first.NativeUtils' version '1.6.2'
     id "edu.wpi.first.GradleJni" version "0.1.4"
-    id "com.diffplug.gradle.spotless" version "3.10.0"
     id 'idea'
     id 'com.gradle.build-scan' version '1.13.1'
 }
 
 repositories {
     mavenCentral()
-}
-
-spotless {
-    format 'misc', {
-        target '**/*.gradle', '**/*.md', '**/.gitignore', '**/*.yml', '**/*.sh', 'styleguide/*.xml'
-        lineEndings 'UNIX'
-
-        trimTrailingWhitespace()
-        indentWithSpaces()
-        endWithNewline()
-    }
 }
 
 buildScan {
@@ -69,11 +58,6 @@ task outputVersions() {
 task libraryBuild() {}
 
 build.dependsOn outputVersions
-
-task cleanBuildDir(type: Delete) {
-    delete buildDir
-}
-clean.dependsOn cleanBuildDir
 
 task copyAllOutputs(type: Copy) {
     destinationDir outputsFolder


### PR DESCRIPTION
Has issues with some git configs, and shouldn't be an absolute build requirement. We need to fix the issue with gitattributes instead.