### PR TITLE
Adds support for unit testing from GradleRIO for C++ projects

### DIFF
--- a/wpilibcExamples/src/main/cpp/templates/commandbased/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandbased/cpp/Robot.cpp
@@ -72,4 +72,6 @@ void Robot::TeleopPeriodic() { frc::Scheduler::GetInstance()->Run(); }
 
 void Robot::TestPeriodic() {}
 
+#ifndef RUNNING_FRC_TESTS
 int main() { return frc::StartRobot<Robot>(); }
+#endif

--- a/wpilibcExamples/src/main/cpp/templates/iterative/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/iterative/cpp/Robot.cpp
@@ -55,4 +55,6 @@ void Robot::TeleopPeriodic() {}
 
 void Robot::TestPeriodic() {}
 
+#ifndef RUNNING_FRC_TESTS
 int main() { return frc::StartRobot<Robot>(); }
+#endif

--- a/wpilibcExamples/src/main/cpp/templates/sample/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/sample/cpp/Robot.cpp
@@ -87,4 +87,6 @@ void Robot::OperatorControl() {
  */
 void Robot::Test() {}
 
+#ifndef RUNNING_FRC_TESTS
 int main() { return frc::StartRobot<Robot>(); }
+#endif

--- a/wpilibcExamples/src/main/cpp/templates/timed/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/timed/cpp/Robot.cpp
@@ -55,4 +55,6 @@ void Robot::TeleopPeriodic() {}
 
 void Robot::TestPeriodic() {}
 
+#ifndef RUNNING_FRC_TESTS
 int main() { return frc::StartRobot<Robot>(); }
+#endif


### PR DESCRIPTION
In order for this to properly work, we need to remove the main code.
Then the test component will actually have the main in it.  Example tests will be added later.