### PR TITLE
Fixed wpilibj_frcnetcomm.py and added invocation to Travis

### DIFF
--- a/.styleguide
+++ b/.styleguide
@@ -12,11 +12,11 @@ generatedFileExclude {
   gtest/
   ni-libraries/include/
   ni-libraries/lib/
+  FRCNetComm\.java$
 }
 
 modifiableFileExclude {
   shared/arm-linux-jni/
-  \.py$
   \.so$
 }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,6 @@ cache:
 
 script:
   - python3.5 -m wpiformat -y 2018 -clang 5.0
+  - python3.5 gen/wpilibj_frcnetcomm.py
   - git --no-pager diff --exit-code HEAD  # Ensure formatter made no changes
   - ./gradlew --no-daemon --console=plain -PskipAthena :hal:halSharedLibrary :hal:halJNISharedLibrary :wpilibc:wpilibcSharedLibrary :wpilibj:jar

--- a/hal/src/main/java/edu/wpi/first/wpilibj/hal/FRCNetComm.java
+++ b/hal/src/main/java/edu/wpi/first/wpilibj/hal/FRCNetComm.java
@@ -108,6 +108,14 @@ public class FRCNetComm extends JNIWrapper {
     int kResourceType_PCM = 60;
     int kResourceType_PigeonIMU = 61;
     int kResourceType_NidecBrushless = 62;
+    int kResourceType_CANifier = 63;
+    int kResourceType_CTRE_future0 = 64;
+    int kResourceType_CTRE_future1 = 65;
+    int kResourceType_CTRE_future2 = 66;
+    int kResourceType_CTRE_future3 = 67;
+    int kResourceType_CTRE_future4 = 68;
+    int kResourceType_CTRE_future5 = 69;
+    int kResourceType_CTRE_future6 = 70;
   }
 
   /**
@@ -119,6 +127,7 @@ public class FRCNetComm extends JNIWrapper {
     int kLanguage_CPlusPlus = 2;
     int kLanguage_Java = 3;
     int kLanguage_Python = 4;
+    int kLanguage_DotNet = 5;
 
     int kCANPlugin_BlackJagBridge = 1;
     int kCANPlugin_2CAN = 2;


### PR DESCRIPTION
Making Travis run wpilibj_frcnetcomm.py will help avoid bitrot in
FRCNetComm.java in the future. Formatting was also enabled on Python
source files and FRCNetComm.java was added back to the generated files
list.