### PR TITLE
Fixes JNI files not getting cleaned on rebuild

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "base"
     id 'edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin' version '2.0'
     id 'edu.wpi.first.NativeUtils' version '1.6.7'
-    id "edu.wpi.first.GradleJni" version "0.1.5"
+    id "edu.wpi.first.GradleJni" version "0.2.2"
     id 'idea'
     id 'com.gradle.build-scan' version '1.13.1'
 }


### PR DESCRIPTION
If a JNI file was added then removed without a clean (like a branch change)
The symbol check would fail because extra headers wouldnt get removed.