### PR TITLE
Make HAL headers C-compatible for FFIs

### DIFF
--- a/hal/src/main/native/include/HAL/Accelerometer.h
+++ b/hal/src/main/native/include/HAL/Accelerometer.h
@@ -9,11 +9,12 @@
 
 #include "HAL/Types.h"
 
-enum HAL_AccelerometerRange : int32_t {
+HAL_ENUM_I32_START(HAL_AccelerometerRange) {
   HAL_AccelerometerRange_k2G = 0,
   HAL_AccelerometerRange_k4G = 1,
   HAL_AccelerometerRange_k8G = 2,
-};
+}
+HAL_ENUM_I32_END(HAL_AccelerometerRange)
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/AnalogTrigger.h
+++ b/hal/src/main/native/include/HAL/AnalogTrigger.h
@@ -11,12 +11,14 @@
 
 #include "HAL/Types.h"
 
-enum HAL_AnalogTriggerType : int32_t {
+
+HAL_ENUM_I32_START(HAL_AnalogTriggerType) {
   HAL_Trigger_kInWindow = 0,
   HAL_Trigger_kState = 1,
   HAL_Trigger_kRisingPulse = 2,
   HAL_Trigger_kFallingPulse = 3
-};
+}
+HAL_ENUM_I32_END(HAL_AnalogTriggerType)
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/CAN.h
+++ b/hal/src/main/native/include/HAL/CAN.h
@@ -33,6 +33,7 @@ struct HAL_CANStreamMessage {
   uint8_t data[8];
   uint8_t dataSize;
 };
+typedef struct HAL_CANStreamMessage HAL_CANStreamMessage;
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/CANAPI.h
+++ b/hal/src/main/native/include/HAL/CANAPI.h
@@ -11,7 +11,7 @@
 
 #include "HAL/Types.h"
 
-enum HAL_CANDeviceType : int32_t {
+HAL_ENUM_I32_START(HAL_CANDeviceType) {
   HAL_CAN_Dev_kBroadcast = 0,
   HAL_CAN_Dev_kRobotController = 1,
   HAL_CAN_Dev_kMotorController = 2,
@@ -24,9 +24,9 @@ enum HAL_CANDeviceType : int32_t {
   HAL_CAN_Dev_kPneumatics = 9,
   HAL_CAN_Dev_kMiscellaneous = 10,
   HAL_CAN_Dev_kFirmwareUpdate = 31
-};
+} HAL_ENUM_I32_END(HAL_CANDeviceType)
 
-enum HAL_CANManufacturer : int32_t {
+HAL_ENUM_I32_START(HAL_CANManufacturer) {
   HAL_CAN_Man_kBroadcast = 0,
   HAL_CAN_Man_kNI = 1,
   HAL_CAN_Man_kLM = 2,
@@ -34,7 +34,7 @@ enum HAL_CANManufacturer : int32_t {
   HAL_CAN_Man_kCTRE = 4,
   HAL_CAN_Man_kMS = 7,
   HAL_CAN_Man_kTeamUse = 8,
-};
+} HAL_ENUM_I32_END(HAL_CANManufacturer)
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/Counter.h
+++ b/hal/src/main/native/include/HAL/Counter.h
@@ -12,12 +12,13 @@
 #include "HAL/AnalogTrigger.h"
 #include "HAL/Types.h"
 
-enum HAL_Counter_Mode : int32_t {
+HAL_ENUM_I32_START(HAL_Counter_Mode) {
   HAL_Counter_kTwoPulse = 0,
   HAL_Counter_kSemiperiod = 1,
   HAL_Counter_kPulseLength = 2,
   HAL_Counter_kExternalDirection = 3
-};
+}
+HAL_ENUM_I32_END(HAL_Counter_Mode)
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/DriverStation.h
+++ b/hal/src/main/native/include/HAL/DriverStation.h
@@ -9,7 +9,10 @@
 
 #include <stdint.h>
 
-#include <cstddef>
+#include <stddef.h>
+
+//maybe ifndef __cplusplus
+#include <stdbool.h>
 
 #include "HAL/Types.h"
 
@@ -37,15 +40,17 @@ struct HAL_ControlWord {
   uint32_t dsAttached : 1;
   uint32_t control_reserved : 26;
 };
+typedef struct HAL_ControlWord HAL_ControlWord;
 
-enum HAL_AllianceStationID : int32_t {
+HAL_ENUM_I32_START(HAL_AllianceStationID) {
   HAL_AllianceStationID_kRed1,
   HAL_AllianceStationID_kRed2,
   HAL_AllianceStationID_kRed3,
   HAL_AllianceStationID_kBlue1,
   HAL_AllianceStationID_kBlue2,
   HAL_AllianceStationID_kBlue3,
-};
+}
+HAL_ENUM_I32_END(HAL_AllianceStationID)
 
 enum HAL_MatchType {
   HAL_kMatchType_none,
@@ -53,6 +58,7 @@ enum HAL_MatchType {
   HAL_kMatchType_qualification,
   HAL_kMatchType_elimination,
 };
+typedef enum HAL_MatchType HAL_MatchType;
 
 /* The maximum number of axes that will be stored in a single HALJoystickAxes
  * struct. This is used for allocating buffers, not bounds checking, since
@@ -65,16 +71,19 @@ struct HAL_JoystickAxes {
   int16_t count;
   float axes[HAL_kMaxJoystickAxes];
 };
+typedef struct HAL_JoystickAxes HAL_JoystickAxes;
 
 struct HAL_JoystickPOVs {
   int16_t count;
   int16_t povs[HAL_kMaxJoystickPOVs];
 };
+typedef struct HAL_JoystickPOVs HAL_JoystickPOVs;
 
 struct HAL_JoystickButtons {
   uint32_t buttons;
   uint8_t count;
 };
+typedef struct HAL_JoystickButtons HAL_JoystickButtons;
 
 struct HAL_JoystickDescriptor {
   uint8_t isXbox;
@@ -85,6 +94,7 @@ struct HAL_JoystickDescriptor {
   uint8_t buttonCount;
   uint8_t povCount;
 };
+typedef struct HAL_JoystickDescriptor HAL_JoystickDescriptor;
 
 struct HAL_MatchInfo {
   char* eventName;
@@ -93,6 +103,7 @@ struct HAL_MatchInfo {
   uint8_t replayNumber;
   char* gameSpecificMessage;
 };
+typedef struct HAL_MatchInfo HAL_MatchInfo;
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/HAL.h
+++ b/hal/src/main/native/include/HAL/HAL.h
@@ -18,6 +18,7 @@
 #include "HAL/AnalogOutput.h"
 #include "HAL/AnalogTrigger.h"
 #include "HAL/CAN.h"
+#include "HAL/CANAPI.h"
 #include "HAL/Compressor.h"
 #include "HAL/Constants.h"
 #include "HAL/Counter.h"
@@ -41,9 +42,14 @@
 #include "HAL/Types.h"
 #include "UsageReporting.h"
 
+#ifdef __cplusplus
 namespace HALUsageReporting = nUsageReporting;
+#endif
 
-enum HAL_RuntimeType : int32_t { HAL_Athena, HAL_Mock };
+HAL_ENUM_I32_START(HAL_RuntimeType) {
+    HAL_Athena, HAL_Mock
+}
+HAL_ENUM_I32_END(HAL_RuntimeType)
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/I2C.h
+++ b/hal/src/main/native/include/HAL/I2C.h
@@ -8,8 +8,13 @@
 #pragma once
 
 #include <stdint.h>
+#include <HAL/Types.h>
 
-enum HAL_I2CPort : int32_t { HAL_I2C_kOnboard = 0, HAL_I2C_kMXP };
+HAL_ENUM_I32_START(HAL_I2CPort) {
+    HAL_I2C_kOnboard = 0,
+    HAL_I2C_kMXP
+}
+HAL_ENUM_I32_END(HAL_I2CPort)
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/SPI.h
+++ b/hal/src/main/native/include/HAL/SPI.h
@@ -12,13 +12,14 @@
 #include "HAL/AnalogTrigger.h"
 #include "HAL/Types.h"
 
-enum HAL_SPIPort : int32_t {
+HAL_ENUM_I32_START(HAL_SPIPort) {
   HAL_SPI_kOnboardCS0 = 0,
   HAL_SPI_kOnboardCS1,
   HAL_SPI_kOnboardCS2,
   HAL_SPI_kOnboardCS3,
   HAL_SPI_kMXP
-};
+}
+HAL_ENUM_I32_END(HAL_SPIPort)
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/SerialPort.h
+++ b/hal/src/main/native/include/HAL/SerialPort.h
@@ -8,13 +8,15 @@
 #pragma once
 
 #include <stdint.h>
+#include "HAL/Types.h"
 
-enum HAL_SerialPort : int32_t {
+HAL_ENUM_I32_START(HAL_SerialPort) {
   HAL_SerialPort_Onboard = 0,
   HAL_SerialPort_MXP = 1,
   HAL_SerialPort_USB1 = 2,
   HAL_SerialPort_USB2 = 3
-};
+}
+HAL_ENUM_I32_END(HAL_SerialPort)
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/Types.h
+++ b/hal/src/main/native/include/HAL/Types.h
@@ -46,3 +46,70 @@ typedef HAL_Handle HAL_SolenoidHandle;
 typedef HAL_Handle HAL_CANHandle;
 
 typedef int32_t HAL_Bool;
+
+// credit to czipperz on GitHub for the idea
+/** @def HAL_ENUM_START(name, type)
+ *
+ * This macro is used before the start of a typed enum declaration:
+@code{.cpp}
+HAL_ENUM_START(HAL_AccelerometerRange, int32_t) {
+    HAL_AccelerometerRange_k2G = 0,
+    HAL_AccelerometerRange_k4G = 1,
+    HAL_AccelerometerRange_k8G = 2
+}
+HAL_ENUM_END(HAL_AccelerometerRange, int32_t)
+@endcode
+ * In C this evaluates to:
+@code{.c}
+typedef enum {
+    HAL_AccelerometerRange_k2G = 0,
+    HAL_AccelerometerRange_k4G = 1,
+    HAL_AccelerometerRange_k8G = 2
+} HAL_AccelerometerRange;
+@endcode
+ * While in C++ this evaluates to:
+@code{.cpp}
+enum HAL_AccelerometerRange : int32_t {
+    HAL_AccelerometerRange_k2G = 0,
+    HAL_AccelerometerRange_k4G = 1,
+    HAL_AccelerometerRange_k8G = 2
+};
+@endcode
+ * This defines the constants @c HAL_AccelerometerRange_k2G,
+ * @c HAL_AccelerometerRange_k4G, and @c HAL_AccelerometerRange_k8G to @c 0,
+ * @c 1, and @c 2, respectively.  It also makes a 32 bit signed integer type
+ * called @c HAL_AccelerometerRange.
+ *
+ * In C, enums are basically macros for integral types. This means that the width
+ * of the integer backing the enum doesn't matter, as long as the integral 
+ * conversion works crossing a function barrier.
+ * 
+ * The C++ code has to name the enumeration in order to use it as a
+ * namespace, for example @c HAL_AccelerometerRange::HAL_AccelerometerRange_k2G
+ * is used in code and therefore it must remain backwards compatible.
+ */
+/** @def HAL_ENUM_END(name, type)
+ *
+ * This macro is used after the body of a typed enum declaration.
+ *
+ * For more documentation see @link HAL_ENUM_START @endlink.
+ */
+
+#ifdef __cplusplus
+#define HAL_ENUM_START(name, type) enum name : type
+#define HAL_ENUM_END(name, type) ; // NOLINT
+#else
+#define HAL_ENUM_START(name, type) typedef enum
+#define HAL_ENUM_END(name, type) name;
+#endif
+
+/** @def HAL_ENUM_I32_START(name)
+ *
+ * @link HAL_ENUM_START @endlink but uses @c int32_t as the type.
+ */
+/** @def HAL_ENUM_I32_END(name)
+ *
+ * @link HAL_ENUM_END @endlink but uses @c int32_t as the type.
+ */
+#define HAL_ENUM_I32_START(name) HAL_ENUM_START(name, int32_t)
+#define HAL_ENUM_I32_END(name) HAL_ENUM_END(name, int32_t)

--- a/hal/src/main/native/include/HAL/UsageReporting.h
+++ b/hal/src/main/native/include/HAL/UsageReporting.h
@@ -16,8 +16,10 @@
 
 #define kUsageReporting_version 1
 
+#ifdef __cplusplus
 namespace nUsageReporting
 {
+#endif
     typedef enum
     {
         kResourceType_Controller,
@@ -138,7 +140,7 @@ namespace nUsageReporting
 
         kSmartDashboard_Instance = 1,
     } tInstances;
-
+#ifdef __cplusplus // No FFI code should call this, use HAL_Report instead
     /**
      * Report the usage of a resource of interest.
      *
@@ -149,6 +151,7 @@ namespace nUsageReporting
      */
     uint32_t EXPORT_FUNC report(tResourceType resource, uint8_t instanceNumber, uint8_t context = 0, const char *feature = NULL);
 }
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Allows for easy FFI's from other languages.
Overrides #535 
Solves #476 