### PR TITLE
Solves some safety issues with RPCs

### DIFF
--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableInstance.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableInstance.java
@@ -566,6 +566,7 @@ public final class NetworkTableInstance implements AutoCloseable {
                   + throwable.toString());
               throwable.printStackTrace();
             }
+            event.finish();
           }
         }
       }

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTablesJNI.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTablesJNI.java
@@ -139,7 +139,7 @@ public final class NetworkTablesJNI {
   public static native RpcAnswer[] pollRpcTimeout(NetworkTableInstance inst, int poller, double timeout) throws InterruptedException;
   public static native void cancelPollRpc(int poller);
   public static native boolean waitForRpcCallQueue(int inst, double timeout);
-  public static native void postRpcResponse(int entry, int call, byte[] result);
+  public static native boolean postRpcResponse(int entry, int call, byte[] result);
   public static native int callRpc(int entry, byte[] params);
   public static native byte[] getRpcResult(int entry, int call);
   public static native byte[] getRpcResult(int entry, int call, double timeout);

--- a/ntcore/src/main/native/cpp/RpcServer.cpp
+++ b/ntcore/src/main/native/cpp/RpcServer.cpp
@@ -35,14 +35,15 @@ void RpcServer::ProcessRpc(unsigned int local_id, unsigned int call_uid,
        send_response);
 }
 
-void RpcServer::PostRpcResponse(unsigned int local_id, unsigned int call_uid,
+bool RpcServer::PostRpcResponse(unsigned int local_id, unsigned int call_uid,
                                 wpi::StringRef result) {
   auto thr = GetThread();
   auto i = thr->m_response_map.find(impl::RpcIdPair{local_id, call_uid});
   if (i == thr->m_response_map.end()) {
     WARNING("posting RPC response to nonexistent call (or duplicate response)");
-    return;
+    return false;
   }
   (i->getSecond())(result);
   thr->m_response_map.erase(i);
+  return true;
 }

--- a/ntcore/src/main/native/cpp/RpcServer.h
+++ b/ntcore/src/main/native/cpp/RpcServer.h
@@ -99,7 +99,7 @@ class RpcServer : public IRpcServer,
                   SendResponseFunc send_response,
                   unsigned int rpc_uid) override;
 
-  void PostRpcResponse(unsigned int local_id, unsigned int call_uid,
+  bool PostRpcResponse(unsigned int local_id, unsigned int call_uid,
                        wpi::StringRef result);
 
  private:

--- a/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
+++ b/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
@@ -1255,17 +1255,17 @@ Java_edu_wpi_first_networktables_NetworkTablesJNI_waitForRpcCallQueue
 /*
  * Class:     edu_wpi_first_networktables_NetworkTablesJNI
  * Method:    postRpcResponse
- * Signature: (II[B)V
+ * Signature: (II[B)Z
  */
-JNIEXPORT void JNICALL
+JNIEXPORT jboolean JNICALL
 Java_edu_wpi_first_networktables_NetworkTablesJNI_postRpcResponse
   (JNIEnv* env, jclass, jint entry, jint call, jbyteArray result)
 {
   if (!result) {
     nullPointerEx.Throw(env, "result cannot be null");
-    return;
+    return false;
   }
-  nt::PostRpcResponse(entry, call, JByteArrayRef{env, result});
+  return nt::PostRpcResponse(entry, call, JByteArrayRef{env, result});
 }
 
 /*

--- a/ntcore/src/main/native/cpp/ntcore_c.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_c.cpp
@@ -431,9 +431,9 @@ NT_Bool NT_WaitForRpcCallQueue(NT_Inst inst, double timeout) {
   return nt::WaitForRpcCallQueue(inst, timeout);
 }
 
-void NT_PostRpcResponse(NT_Entry entry, NT_RpcCall call, const char* result,
-                        size_t result_len) {
-  nt::PostRpcResponse(entry, call, StringRef(result, result_len));
+NT_Bool NT_PostRpcResponse(NT_Entry entry, NT_RpcCall call, const char* result,
+                           size_t result_len) {
+  return nt::PostRpcResponse(entry, call, StringRef(result, result_len));
 }
 
 NT_RpcCall NT_CallRpc(NT_Entry entry, const char* params, size_t params_len) {

--- a/ntcore/src/main/native/cpp/ntcore_cpp.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_cpp.cpp
@@ -560,18 +560,18 @@ bool WaitForRpcCallQueue(NT_Inst inst, double timeout) {
   return ii->rpc_server.WaitForQueue(timeout);
 }
 
-void PostRpcResponse(NT_Entry entry, NT_RpcCall call, StringRef result) {
+bool PostRpcResponse(NT_Entry entry, NT_RpcCall call, StringRef result) {
   Handle handle{entry};
   int id = handle.GetTypedIndex(Handle::kEntry);
   auto ii = InstanceImpl::Get(handle.GetInst());
-  if (id < 0 || !ii) return;
+  if (id < 0 || !ii) return false;
 
   Handle chandle{call};
   int call_uid = chandle.GetTypedIndex(Handle::kRpcCall);
-  if (call_uid < 0) return;
-  if (handle.GetInst() != chandle.GetInst()) return;
+  if (call_uid < 0) return false;
+  if (handle.GetInst() != chandle.GetInst()) return false;
 
-  ii->rpc_server.PostRpcResponse(id, call_uid, result);
+  return ii->rpc_server.PostRpcResponse(id, call_uid, result);
 }
 
 NT_RpcCall CallRpc(NT_Entry entry, StringRef params) {

--- a/ntcore/src/main/native/include/ntcore_c.h
+++ b/ntcore/src/main/native/include/ntcore_c.h
@@ -851,9 +851,10 @@ NT_Bool NT_WaitForRpcCallQueue(NT_Inst inst, double timeout);
  * @param call        RPC call handle (from NT_RpcAnswer)
  * @param result      result raw data that will be provided to remote caller
  * @param result_len  length of result in bytes
+ * @return            true if the response was posted, otherwise false
  */
-void NT_PostRpcResponse(NT_Entry entry, NT_RpcCall call, const char* result,
-                        size_t result_len);
+NT_Bool NT_PostRpcResponse(NT_Entry entry, NT_RpcCall call, const char* result,
+                           size_t result_len);
 
 /**
  * Call a RPC function.  May be used on either the client or server.


### PR DESCRIPTION
Java would never properly dispose, and C++'s were easy to respond after disposing.
For C++, we now return a bool if the call was successful or not, for java we throw an exception