### PR TITLE
 Update ADX Simulators

### DIFF
--- a/shared/plugins/publish.gradle
+++ b/shared/plugins/publish.gradle
@@ -55,9 +55,8 @@ addTaskToCopyAllOutputs(cppSourcesZip)
 addTaskToCopyAllOutputs(cppHeadersZip)
 
 
-model {
-    publishing {
-        def pluginTaskList = createComponentZipTasks($.components, pluginName, zipBaseName, Zip, project, { task, value ->
+if (!project.hasProperty('publishZipFunction')) {
+	ext.publishZipFunction = { task, value ->
             value.each { binary ->
                 if (binary.buildable) {
                     if (binary instanceof SharedLibraryBinarySpec) {
@@ -68,7 +67,14 @@ model {
                     }
                 }
             }
-        })
+        }
+}
+
+
+
+model {
+    publishing {
+        def pluginTaskList = createComponentZipTasks($.components, pluginName, zipBaseName, Zip, project, publishZipFunction)
 
         def allTask
         if (!project.hasProperty('jenkinsBuild')) {

--- a/simulation/halsim_adx_gyro_accelerometer/build.gradle
+++ b/simulation/halsim_adx_gyro_accelerometer/build.gradle
@@ -6,6 +6,9 @@ ext {
 }
 
 apply from: "${rootDir}/shared/plugins/setupBuild.gradle"
+ext {
+	publishZipFunction = includeStandardZipFormat
+}
 
 
 if (!project.hasProperty('onlyAthena')) {
@@ -23,4 +26,68 @@ if (!project.hasProperty('onlyAthena')) {
             }
         }
     }
+}
+
+
+
+apply plugin: 'google-test-test-suite'
+
+ext {
+	sharedCvConfigs = [halsim_adx_gyro_accelerometerTest: []]
+	staticCvConfigs = [:]
+	useJava = false
+	useCpp = true
+}
+apply from: "${rootDir}/shared/opencv.gradle"
+
+ext {
+	staticGtestConfigs = [:]
+}
+
+staticGtestConfigs["${pluginName}Test"] = []
+apply from: "${rootDir}/shared/googletest.gradle"
+
+model {
+	
+	testSuites {
+		"${pluginName}Test"(GoogleTestTestSuiteSpec) {
+		for(NativeComponentSpec c : $.components) {
+			if (c.name == pluginName) {
+				testing c
+				break
+			}
+		}
+			sources {
+				cpp {
+					source {
+						srcDirs 'src/test/native/cpp'
+						include '**/*.cpp'
+					}
+					exportedHeaders {
+						srcDirs 'src/test/native/include', 'src/main/native/cpp'
+					}
+				}
+			}
+		}
+	}
+	binaries {
+		withType(GoogleTestTestSuiteBinarySpec) {
+			if (!project.hasProperty('onlyAthena')) {
+				lib project: ':ntcore', library: 'ntcore', linkage: 'shared'
+				lib project: ':cscore', library: 'cscore', linkage: 'shared'
+				lib project: ':hal', library: 'hal', linkage: 'shared'
+				lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
+				lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
+				lib project: ':wpilibc', library: 'wpilibc', linkage: 'shared'
+				lib library: pluginName, linkage: 'shared'
+			} else {
+				it.buildable = false
+			}
+		}
+	}
+}
+
+tasks.withType(RunTestExecutable) {
+	args "--gtest_output=xml:test_detail.xml"
+	outputs.dir outputDir
 }

--- a/simulation/halsim_adx_gyro_accelerometer/build.gradle
+++ b/simulation/halsim_adx_gyro_accelerometer/build.gradle
@@ -48,7 +48,7 @@ staticGtestConfigs["${pluginName}Test"] = []
 apply from: "${rootDir}/shared/googletest.gradle"
 
 model {
-	
+
 	testSuites {
 		"${pluginName}Test"(GoogleTestTestSuiteSpec) {
 		for(NativeComponentSpec c : $.components) {

--- a/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXL345_I2CAccelerometerTest.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXL345_I2CAccelerometerTest.cpp
@@ -1,43 +1,47 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
 
 #include "ADXL345_I2C.h"
 #include "ADXL345_I2CAccelerometerData.h"
 #include "Talon.h"
 #include "gtest/gtest.h"
 
-class ADXL345_I2CAccelerometerTest : public ::testing::TestWithParam<frc::I2C::Port> {
-
-};
+class ADXL345_I2CAccelerometerTest
+    : public ::testing::TestWithParam<frc::I2C::Port> {};
 
 TEST_P(ADXL345_I2CAccelerometerTest, TestAccelerometer) {
+  const double EPSILON = 1 / 256.0;
 
-	const double EPSILON = 1 / 256.0;
+  frc::I2C::Port port = GetParam();
 
-	frc::I2C::Port port = GetParam();
+  hal::ADXL345_I2CData sim{port};
+  frc::ADXL345_I2C accel{port};
 
-	hal::ADXL345_I2CData sim{port};
-	frc::ADXL345_I2C accel{port};
+  EXPECT_NEAR(0, sim.GetX(), EPSILON);
+  EXPECT_NEAR(0, sim.GetY(), EPSILON);
+  EXPECT_NEAR(0, sim.GetZ(), EPSILON);
 
-	EXPECT_NEAR(0, sim.GetX(), EPSILON);
-	EXPECT_NEAR(0, sim.GetY(), EPSILON);
-	EXPECT_NEAR(0, sim.GetZ(), EPSILON);
+  EXPECT_NEAR(0, accel.GetX(), EPSILON);
+  EXPECT_NEAR(0, accel.GetY(), EPSILON);
+  EXPECT_NEAR(0, accel.GetZ(), EPSILON);
 
-	EXPECT_NEAR(0, accel.GetX(), EPSILON);
-	EXPECT_NEAR(0, accel.GetY(), EPSILON);
-	EXPECT_NEAR(0, accel.GetZ(), EPSILON);
+  sim.SetX(1.56);
+  sim.SetY(-.653);
+  sim.SetZ(0.11);
 
-	sim.SetX(1.56);
-	sim.SetY(-.653);
-	sim.SetZ(0.11);
+  EXPECT_NEAR(1.56, sim.GetX(), EPSILON);
+  EXPECT_NEAR(-.653, sim.GetY(), EPSILON);
+  EXPECT_NEAR(0.11, sim.GetZ(), EPSILON);
 
-	EXPECT_NEAR(1.56, sim.GetX(), EPSILON);
-	EXPECT_NEAR(-.653, sim.GetY(), EPSILON);
-	EXPECT_NEAR(0.11, sim.GetZ(), EPSILON);
-
-	EXPECT_NEAR(1.56, accel.GetX(), EPSILON);
-	EXPECT_NEAR(-.653, accel.GetY(), EPSILON);
-	EXPECT_NEAR(0.11, accel.GetZ(), EPSILON);
+  EXPECT_NEAR(1.56, accel.GetX(), EPSILON);
+  EXPECT_NEAR(-.653, accel.GetY(), EPSILON);
+  EXPECT_NEAR(0.11, accel.GetZ(), EPSILON);
 }
 
 INSTANTIATE_TEST_CASE_P(ADXL345_I2CAccelerometerTest,
-		ADXL345_I2CAccelerometerTest,
+                        ADXL345_I2CAccelerometerTest,
                         ::testing::Values(frc::I2C::kOnboard, frc::I2C::kMXP));

--- a/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXL345_I2CAccelerometerTest.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXL345_I2CAccelerometerTest.cpp
@@ -1,0 +1,43 @@
+
+#include "ADXL345_I2C.h"
+#include "ADXL345_I2CAccelerometerData.h"
+#include "Talon.h"
+#include "gtest/gtest.h"
+
+class ADXL345_I2CAccelerometerTest : public ::testing::TestWithParam<frc::I2C::Port> {
+
+};
+
+TEST_P(ADXL345_I2CAccelerometerTest, TestAccelerometer) {
+
+	const double EPSILON = 1 / 256.0;
+
+	frc::I2C::Port port = GetParam();
+
+	hal::ADXL345_I2CData sim{port};
+	frc::ADXL345_I2C accel{port};
+
+	EXPECT_NEAR(0, sim.GetX(), EPSILON);
+	EXPECT_NEAR(0, sim.GetY(), EPSILON);
+	EXPECT_NEAR(0, sim.GetZ(), EPSILON);
+
+	EXPECT_NEAR(0, accel.GetX(), EPSILON);
+	EXPECT_NEAR(0, accel.GetY(), EPSILON);
+	EXPECT_NEAR(0, accel.GetZ(), EPSILON);
+
+	sim.SetX(1.56);
+	sim.SetY(-.653);
+	sim.SetZ(0.11);
+
+	EXPECT_NEAR(1.56, sim.GetX(), EPSILON);
+	EXPECT_NEAR(-.653, sim.GetY(), EPSILON);
+	EXPECT_NEAR(0.11, sim.GetZ(), EPSILON);
+
+	EXPECT_NEAR(1.56, accel.GetX(), EPSILON);
+	EXPECT_NEAR(-.653, accel.GetY(), EPSILON);
+	EXPECT_NEAR(0.11, accel.GetZ(), EPSILON);
+}
+
+INSTANTIATE_TEST_CASE_P(ADXL345_I2CAccelerometerTest,
+		ADXL345_I2CAccelerometerTest,
+                        ::testing::Values(frc::I2C::kOnboard, frc::I2C::kMXP));

--- a/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXL345_SpiAccelerometerTest.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXL345_SpiAccelerometerTest.cpp
@@ -1,0 +1,49 @@
+
+#include "ADXL345_SPI.h"
+#include "ADXL345_SpiAccelerometerData.h"
+#include "Talon.h"
+#include "gtest/gtest.h"
+
+class ADXL345_SpiAccelerometerTest : public ::testing::TestWithParam<frc::SPI::Port> {
+
+};
+
+TEST_P(ADXL345_SpiAccelerometerTest, TestAccelerometer) {
+
+	const double EPSILON = 1 / 256.0;
+
+	frc::SPI::Port port = GetParam();
+
+	hal::ADXL345_SpiAccelerometer sim{port};
+	frc::ADXL345_SPI accel{port};
+
+	EXPECT_NEAR(0, sim.GetX(), EPSILON);
+	EXPECT_NEAR(0, sim.GetY(), EPSILON);
+	EXPECT_NEAR(0, sim.GetZ(), EPSILON);
+
+	EXPECT_NEAR(0, accel.GetX(), EPSILON);
+	EXPECT_NEAR(0, accel.GetY(), EPSILON);
+	EXPECT_NEAR(0, accel.GetZ(), EPSILON);
+
+	sim.SetX(1.56);
+	sim.SetY(-.653);
+	sim.SetZ(0.11);
+
+	EXPECT_NEAR(1.56, sim.GetX(), EPSILON);
+	EXPECT_NEAR(-.653, sim.GetY(), EPSILON);
+	EXPECT_NEAR(0.11, sim.GetZ(), EPSILON);
+
+	EXPECT_NEAR(1.56, accel.GetX(), EPSILON);
+	EXPECT_NEAR(-.653, accel.GetY(), EPSILON);
+	EXPECT_NEAR(0.11, accel.GetZ(), EPSILON);
+}
+
+
+INSTANTIATE_TEST_CASE_P(ADXL345_SpiAccelerometerTest,
+		ADXL345_SpiAccelerometerTest,
+                        ::testing::Values(
+                        		frc::SPI::kOnboardCS0,
+                        		frc::SPI::kOnboardCS1,
+                        		frc::SPI::kOnboardCS2,
+                        		frc::SPI::kOnboardCS3,
+								frc::SPI::kMXP));

--- a/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXL345_SpiAccelerometerTest.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXL345_SpiAccelerometerTest.cpp
@@ -1,49 +1,49 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
 
 #include "ADXL345_SPI.h"
 #include "ADXL345_SpiAccelerometerData.h"
 #include "Talon.h"
 #include "gtest/gtest.h"
 
-class ADXL345_SpiAccelerometerTest : public ::testing::TestWithParam<frc::SPI::Port> {
-
-};
+class ADXL345_SpiAccelerometerTest
+    : public ::testing::TestWithParam<frc::SPI::Port> {};
 
 TEST_P(ADXL345_SpiAccelerometerTest, TestAccelerometer) {
+  const double EPSILON = 1 / 256.0;
 
-	const double EPSILON = 1 / 256.0;
+  frc::SPI::Port port = GetParam();
 
-	frc::SPI::Port port = GetParam();
+  hal::ADXL345_SpiAccelerometer sim{port};
+  frc::ADXL345_SPI accel{port};
 
-	hal::ADXL345_SpiAccelerometer sim{port};
-	frc::ADXL345_SPI accel{port};
+  EXPECT_NEAR(0, sim.GetX(), EPSILON);
+  EXPECT_NEAR(0, sim.GetY(), EPSILON);
+  EXPECT_NEAR(0, sim.GetZ(), EPSILON);
 
-	EXPECT_NEAR(0, sim.GetX(), EPSILON);
-	EXPECT_NEAR(0, sim.GetY(), EPSILON);
-	EXPECT_NEAR(0, sim.GetZ(), EPSILON);
+  EXPECT_NEAR(0, accel.GetX(), EPSILON);
+  EXPECT_NEAR(0, accel.GetY(), EPSILON);
+  EXPECT_NEAR(0, accel.GetZ(), EPSILON);
 
-	EXPECT_NEAR(0, accel.GetX(), EPSILON);
-	EXPECT_NEAR(0, accel.GetY(), EPSILON);
-	EXPECT_NEAR(0, accel.GetZ(), EPSILON);
+  sim.SetX(1.56);
+  sim.SetY(-.653);
+  sim.SetZ(0.11);
 
-	sim.SetX(1.56);
-	sim.SetY(-.653);
-	sim.SetZ(0.11);
+  EXPECT_NEAR(1.56, sim.GetX(), EPSILON);
+  EXPECT_NEAR(-.653, sim.GetY(), EPSILON);
+  EXPECT_NEAR(0.11, sim.GetZ(), EPSILON);
 
-	EXPECT_NEAR(1.56, sim.GetX(), EPSILON);
-	EXPECT_NEAR(-.653, sim.GetY(), EPSILON);
-	EXPECT_NEAR(0.11, sim.GetZ(), EPSILON);
-
-	EXPECT_NEAR(1.56, accel.GetX(), EPSILON);
-	EXPECT_NEAR(-.653, accel.GetY(), EPSILON);
-	EXPECT_NEAR(0.11, accel.GetZ(), EPSILON);
+  EXPECT_NEAR(1.56, accel.GetX(), EPSILON);
+  EXPECT_NEAR(-.653, accel.GetY(), EPSILON);
+  EXPECT_NEAR(0.11, accel.GetZ(), EPSILON);
 }
 
-
-INSTANTIATE_TEST_CASE_P(ADXL345_SpiAccelerometerTest,
-		ADXL345_SpiAccelerometerTest,
-                        ::testing::Values(
-                        		frc::SPI::kOnboardCS0,
-                        		frc::SPI::kOnboardCS1,
-                        		frc::SPI::kOnboardCS2,
-                        		frc::SPI::kOnboardCS3,
-								frc::SPI::kMXP));
+INSTANTIATE_TEST_CASE_P(
+    ADXL345_SpiAccelerometerTest, ADXL345_SpiAccelerometerTest,
+    ::testing::Values(frc::SPI::kOnboardCS0, frc::SPI::kOnboardCS1,
+                      frc::SPI::kOnboardCS2, frc::SPI::kOnboardCS3,
+                      frc::SPI::kMXP));

--- a/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXL362_SpiAccelerometerTest.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXL362_SpiAccelerometerTest.cpp
@@ -1,0 +1,49 @@
+
+#include "ADXL362.h"
+#include "ADXL362_SpiAccelerometerData.h"
+#include "Talon.h"
+#include "gtest/gtest.h"
+
+class ADXL362_SpiAccelerometerTest : public ::testing::TestWithParam<frc::SPI::Port> {
+
+};
+
+TEST_P(ADXL362_SpiAccelerometerTest, TestAccelerometer) {
+
+	const double EPSILON = 1 / 256.0;
+
+	frc::SPI::Port port = GetParam();
+
+	hal::ADXL362_SpiAccelerometer sim{port};
+	frc::ADXL362 accel{port};
+
+	EXPECT_NEAR(0, sim.GetX(), EPSILON);
+	EXPECT_NEAR(0, sim.GetY(), EPSILON);
+	EXPECT_NEAR(0, sim.GetZ(), EPSILON);
+
+	EXPECT_NEAR(0, accel.GetX(), EPSILON);
+	EXPECT_NEAR(0, accel.GetY(), EPSILON);
+	EXPECT_NEAR(0, accel.GetZ(), EPSILON);
+
+	sim.SetX(1.56);
+	sim.SetY(-.653);
+	sim.SetZ(0.11);
+
+	EXPECT_NEAR(1.56, sim.GetX(), EPSILON);
+	EXPECT_NEAR(-.653, sim.GetY(), EPSILON);
+	EXPECT_NEAR(0.11, sim.GetZ(), EPSILON);
+
+	EXPECT_NEAR(1.56, accel.GetX(), EPSILON);
+	EXPECT_NEAR(-.653, accel.GetY(), EPSILON);
+	EXPECT_NEAR(0.11, accel.GetZ(), EPSILON);
+}
+
+
+INSTANTIATE_TEST_CASE_P(ADXL362_SpiAccelerometerTest,
+		ADXL362_SpiAccelerometerTest,
+                        ::testing::Values(
+                        		frc::SPI::kOnboardCS0,
+                        		frc::SPI::kOnboardCS1,
+                        		frc::SPI::kOnboardCS2,
+                        		frc::SPI::kOnboardCS3,
+								frc::SPI::kMXP));

--- a/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXL362_SpiAccelerometerTest.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXL362_SpiAccelerometerTest.cpp
@@ -1,49 +1,49 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
 
 #include "ADXL362.h"
 #include "ADXL362_SpiAccelerometerData.h"
 #include "Talon.h"
 #include "gtest/gtest.h"
 
-class ADXL362_SpiAccelerometerTest : public ::testing::TestWithParam<frc::SPI::Port> {
-
-};
+class ADXL362_SpiAccelerometerTest
+    : public ::testing::TestWithParam<frc::SPI::Port> {};
 
 TEST_P(ADXL362_SpiAccelerometerTest, TestAccelerometer) {
+  const double EPSILON = 1 / 256.0;
 
-	const double EPSILON = 1 / 256.0;
+  frc::SPI::Port port = GetParam();
 
-	frc::SPI::Port port = GetParam();
+  hal::ADXL362_SpiAccelerometer sim{port};
+  frc::ADXL362 accel{port};
 
-	hal::ADXL362_SpiAccelerometer sim{port};
-	frc::ADXL362 accel{port};
+  EXPECT_NEAR(0, sim.GetX(), EPSILON);
+  EXPECT_NEAR(0, sim.GetY(), EPSILON);
+  EXPECT_NEAR(0, sim.GetZ(), EPSILON);
 
-	EXPECT_NEAR(0, sim.GetX(), EPSILON);
-	EXPECT_NEAR(0, sim.GetY(), EPSILON);
-	EXPECT_NEAR(0, sim.GetZ(), EPSILON);
+  EXPECT_NEAR(0, accel.GetX(), EPSILON);
+  EXPECT_NEAR(0, accel.GetY(), EPSILON);
+  EXPECT_NEAR(0, accel.GetZ(), EPSILON);
 
-	EXPECT_NEAR(0, accel.GetX(), EPSILON);
-	EXPECT_NEAR(0, accel.GetY(), EPSILON);
-	EXPECT_NEAR(0, accel.GetZ(), EPSILON);
+  sim.SetX(1.56);
+  sim.SetY(-.653);
+  sim.SetZ(0.11);
 
-	sim.SetX(1.56);
-	sim.SetY(-.653);
-	sim.SetZ(0.11);
+  EXPECT_NEAR(1.56, sim.GetX(), EPSILON);
+  EXPECT_NEAR(-.653, sim.GetY(), EPSILON);
+  EXPECT_NEAR(0.11, sim.GetZ(), EPSILON);
 
-	EXPECT_NEAR(1.56, sim.GetX(), EPSILON);
-	EXPECT_NEAR(-.653, sim.GetY(), EPSILON);
-	EXPECT_NEAR(0.11, sim.GetZ(), EPSILON);
-
-	EXPECT_NEAR(1.56, accel.GetX(), EPSILON);
-	EXPECT_NEAR(-.653, accel.GetY(), EPSILON);
-	EXPECT_NEAR(0.11, accel.GetZ(), EPSILON);
+  EXPECT_NEAR(1.56, accel.GetX(), EPSILON);
+  EXPECT_NEAR(-.653, accel.GetY(), EPSILON);
+  EXPECT_NEAR(0.11, accel.GetZ(), EPSILON);
 }
 
-
-INSTANTIATE_TEST_CASE_P(ADXL362_SpiAccelerometerTest,
-		ADXL362_SpiAccelerometerTest,
-                        ::testing::Values(
-                        		frc::SPI::kOnboardCS0,
-                        		frc::SPI::kOnboardCS1,
-                        		frc::SPI::kOnboardCS2,
-                        		frc::SPI::kOnboardCS3,
-								frc::SPI::kMXP));
+INSTANTIATE_TEST_CASE_P(
+    ADXL362_SpiAccelerometerTest, ADXL362_SpiAccelerometerTest,
+    ::testing::Values(frc::SPI::kOnboardCS0, frc::SPI::kOnboardCS1,
+                      frc::SPI::kOnboardCS2, frc::SPI::kOnboardCS3,
+                      frc::SPI::kMXP));

--- a/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXRS450_SpiGyroWrapperTest.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXRS450_SpiGyroWrapperTest.cpp
@@ -1,0 +1,36 @@
+
+#include "ADXRS450_Gyro.h"
+#include "ADXRS450_SpiGyroWrapperData.h"
+#include "Talon.h"
+#include "gtest/gtest.h"
+
+class ADXRS450_SpiGyroWrapperTest : public ::testing::TestWithParam<frc::SPI::Port> {
+
+};
+
+TEST_P(ADXRS450_SpiGyroWrapperTest, TestAccelerometer) {
+
+	const double EPSILON = .000001;
+
+	frc::SPI::Port port = GetParam();
+
+	hal::ADXRS450_SpiGyroWrapper sim{port};
+	frc::ADXRS450_Gyro gyro{port};
+
+	EXPECT_NEAR(0, sim.GetAngle(), EPSILON);
+	EXPECT_NEAR(0, gyro.GetAngle(), EPSILON);
+
+	sim.SetAngle(32.56);
+	EXPECT_NEAR(32.56, sim.GetAngle(), EPSILON);
+	EXPECT_NEAR(32.56, gyro.GetAngle(), EPSILON);
+}
+
+
+INSTANTIATE_TEST_CASE_P(ADXRS450_SpiGyroWrapperTest,
+		ADXRS450_SpiGyroWrapperTest,
+                        ::testing::Values(
+                        		frc::SPI::kOnboardCS0,
+                        		frc::SPI::kOnboardCS1,
+                        		frc::SPI::kOnboardCS2,
+                        		frc::SPI::kOnboardCS3,
+								frc::SPI::kMXP));

--- a/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXRS450_SpiGyroWrapperTest.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/ADXRS450_SpiGyroWrapperTest.cpp
@@ -1,36 +1,36 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
 
 #include "ADXRS450_Gyro.h"
 #include "ADXRS450_SpiGyroWrapperData.h"
 #include "Talon.h"
 #include "gtest/gtest.h"
 
-class ADXRS450_SpiGyroWrapperTest : public ::testing::TestWithParam<frc::SPI::Port> {
-
-};
+class ADXRS450_SpiGyroWrapperTest
+    : public ::testing::TestWithParam<frc::SPI::Port> {};
 
 TEST_P(ADXRS450_SpiGyroWrapperTest, TestAccelerometer) {
+  const double EPSILON = .000001;
 
-	const double EPSILON = .000001;
+  frc::SPI::Port port = GetParam();
 
-	frc::SPI::Port port = GetParam();
+  hal::ADXRS450_SpiGyroWrapper sim{port};
+  frc::ADXRS450_Gyro gyro{port};
 
-	hal::ADXRS450_SpiGyroWrapper sim{port};
-	frc::ADXRS450_Gyro gyro{port};
+  EXPECT_NEAR(0, sim.GetAngle(), EPSILON);
+  EXPECT_NEAR(0, gyro.GetAngle(), EPSILON);
 
-	EXPECT_NEAR(0, sim.GetAngle(), EPSILON);
-	EXPECT_NEAR(0, gyro.GetAngle(), EPSILON);
-
-	sim.SetAngle(32.56);
-	EXPECT_NEAR(32.56, sim.GetAngle(), EPSILON);
-	EXPECT_NEAR(32.56, gyro.GetAngle(), EPSILON);
+  sim.SetAngle(32.56);
+  EXPECT_NEAR(32.56, sim.GetAngle(), EPSILON);
+  EXPECT_NEAR(32.56, gyro.GetAngle(), EPSILON);
 }
 
-
-INSTANTIATE_TEST_CASE_P(ADXRS450_SpiGyroWrapperTest,
-		ADXRS450_SpiGyroWrapperTest,
-                        ::testing::Values(
-                        		frc::SPI::kOnboardCS0,
-                        		frc::SPI::kOnboardCS1,
-                        		frc::SPI::kOnboardCS2,
-                        		frc::SPI::kOnboardCS3,
-								frc::SPI::kMXP));
+INSTANTIATE_TEST_CASE_P(
+    ADXRS450_SpiGyroWrapperTest, ADXRS450_SpiGyroWrapperTest,
+    ::testing::Values(frc::SPI::kOnboardCS0, frc::SPI::kOnboardCS1,
+                      frc::SPI::kOnboardCS2, frc::SPI::kOnboardCS3,
+                      frc::SPI::kMXP));

--- a/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/main.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/main.cpp
@@ -1,0 +1,16 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2015-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "HAL/HAL.h"
+#include "gtest/gtest.h"
+
+int main(int argc, char** argv) {
+	  HAL_Initialize(500, 0);
+  ::testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+  return ret;
+}

--- a/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/main.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/test/native/cpp/main.cpp
@@ -5,11 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-#include "HAL/HAL.h"
+#include <HAL/HAL.h>
+
 #include "gtest/gtest.h"
 
 int main(int argc, char** argv) {
-	  HAL_Initialize(500, 0);
+  HAL_Initialize(500, 0);
   ::testing::InitGoogleTest(&argc, argv);
   int ret = RUN_ALL_TESTS();
   return ret;

--- a/wpilibc/src/main/native/cpp/ADXRS450_Gyro.cpp
+++ b/wpilibc/src/main/native/cpp/ADXRS450_Gyro.cpp
@@ -6,11 +6,11 @@
 /*----------------------------------------------------------------------------*/
 
 #include "ADXRS450_Gyro.h"
-#include "RobotBase.h"
 
 #include <HAL/HAL.h>
 
 #include "DriverStation.h"
+#include "RobotBase.h"
 #include "Timer.h"
 
 using namespace frc;
@@ -103,9 +103,8 @@ void ADXRS450_Gyro::Calibrate() {
   m_spi.SetAccumulatorCenter(0);
   m_spi.ResetAccumulator();
 
-  if(RobotBase::IsReal())
-  {
-     Wait(kCalibrationSampleTime);
+  if (RobotBase::IsReal()) {
+    Wait(kCalibrationSampleTime);
   }
 
   m_spi.SetAccumulatorCenter(static_cast<int>(m_spi.GetAccumulatorAverage()));

--- a/wpilibc/src/main/native/cpp/ADXRS450_Gyro.cpp
+++ b/wpilibc/src/main/native/cpp/ADXRS450_Gyro.cpp
@@ -6,6 +6,7 @@
 /*----------------------------------------------------------------------------*/
 
 #include "ADXRS450_Gyro.h"
+#include "RobotBase.h"
 
 #include <HAL/HAL.h>
 
@@ -102,7 +103,10 @@ void ADXRS450_Gyro::Calibrate() {
   m_spi.SetAccumulatorCenter(0);
   m_spi.ResetAccumulator();
 
-  Wait(kCalibrationSampleTime);
+  if(RobotBase::IsReal())
+  {
+     Wait(kCalibrationSampleTime);
+  }
 
   m_spi.SetAccumulatorCenter(static_cast<int>(m_spi.GetAccumulatorAverage()));
   m_spi.ResetAccumulator();


### PR DESCRIPTION
- Added unit tests
- Modified plugin publishing so you can create different zip files. I need the .lib in my downstream simluation branch, so I need it published.  Alternatively this could be a library rather than a plugin
- Don't do the cal time for the gyro if you are simulating.  Adds 5 seconds for no gain