### PR TITLE
Removes close() explicitly from Gryo interface

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/interfaces/Gyro.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/interfaces/Gyro.java
@@ -54,10 +54,4 @@ public interface Gyro extends AutoCloseable {
    */
   @Deprecated
   void free();
-
-  /**
-   * Free the resources used by the gyro.
-   */
-  @Override
-  void close();
 }


### PR DESCRIPTION
Its not needed, as the extending AutoClosable is enough.

Should we remove free() from the contract? The implementations would still be freeable, but the interface doesn't need to be explicitly freeable I don't think.