### PR TITLE
Make HAL headers C-compatible

### DIFF
--- a/hal/src/main/native/athena/FRCDriverStation.cpp
+++ b/hal/src/main/native/athena/FRCDriverStation.cpp
@@ -307,7 +307,7 @@ void HAL_ObserveUserProgramTest(void) {
   FRC_NetworkCommunication_observeUserProgramTest();
 }
 
-bool HAL_IsNewControlData(void) {
+HAL_Bool HAL_IsNewControlData(void) {
   // There is a rollover error condition here. At Packet# = n * (uintmax), this
   // will return false when instead it should return true. However, this at a
   // 20ms rate occurs once every 2.7 years of DS connected runtime, so not

--- a/hal/src/main/native/include/HAL/Accelerometer.h
+++ b/hal/src/main/native/include/HAL/Accelerometer.h
@@ -12,7 +12,7 @@
 /**
  * The acceptable accelerometer ranges.
  */
-enum HAL_AccelerometerRange : int32_t {
+HAL_ENUM(HAL_AccelerometerRange) {
   HAL_AccelerometerRange_k2G = 0,
   HAL_AccelerometerRange_k4G = 1,
   HAL_AccelerometerRange_k8G = 2,

--- a/hal/src/main/native/include/HAL/Accelerometer.h
+++ b/hal/src/main/native/include/HAL/Accelerometer.h
@@ -9,6 +9,7 @@
 
 #include "HAL/Types.h"
 
+// clang-format off
 /**
  * The acceptable accelerometer ranges.
  */
@@ -17,6 +18,7 @@ HAL_ENUM(HAL_AccelerometerRange) {
   HAL_AccelerometerRange_k4G = 1,
   HAL_AccelerometerRange_k8G = 2,
 };
+// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/AnalogTrigger.h
+++ b/hal/src/main/native/include/HAL/AnalogTrigger.h
@@ -11,6 +11,7 @@
 
 #include "HAL/Types.h"
 
+// clang-format off
 /**
  * The type of analog trigger to trigger on.
  */
@@ -20,6 +21,7 @@ HAL_ENUM(HAL_AnalogTriggerType) {
   HAL_Trigger_kRisingPulse = 2,
   HAL_Trigger_kFallingPulse = 3
 };
+// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/AnalogTrigger.h
+++ b/hal/src/main/native/include/HAL/AnalogTrigger.h
@@ -14,7 +14,7 @@
 /**
  * The type of analog trigger to trigger on.
  */
-enum HAL_AnalogTriggerType : int32_t {
+HAL_ENUM(HAL_AnalogTriggerType) {
   HAL_Trigger_kInWindow = 0,
   HAL_Trigger_kState = 1,
   HAL_Trigger_kRisingPulse = 2,

--- a/hal/src/main/native/include/HAL/CANAPI.h
+++ b/hal/src/main/native/include/HAL/CANAPI.h
@@ -16,7 +16,7 @@
  *
  * Teams should use HAL_CAN_Dev_kMiscellaneous
  */
-enum HAL_CANDeviceType : int32_t {
+HAL_ENUM(HAL_CANDeviceType) {
   HAL_CAN_Dev_kBroadcast = 0,
   HAL_CAN_Dev_kRobotController = 1,
   HAL_CAN_Dev_kMotorController = 2,
@@ -36,7 +36,7 @@ enum HAL_CANDeviceType : int32_t {
  *
  * Teams should use HAL_CAN_Man_kTeamUse.
  */
-enum HAL_CANManufacturer : int32_t {
+HAL_ENUM(HAL_CANManufacturer) {
   HAL_CAN_Man_kBroadcast = 0,
   HAL_CAN_Man_kNI = 1,
   HAL_CAN_Man_kLM = 2,

--- a/hal/src/main/native/include/HAL/CANAPI.h
+++ b/hal/src/main/native/include/HAL/CANAPI.h
@@ -11,6 +11,7 @@
 
 #include "HAL/Types.h"
 
+// clang-format off
 /**
  * The CAN device type.
  *
@@ -45,6 +46,7 @@ HAL_ENUM(HAL_CANManufacturer) {
   HAL_CAN_Man_kMS = 7,
   HAL_CAN_Man_kTeamUse = 8,
 };
+// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/Counter.h
+++ b/hal/src/main/native/include/HAL/Counter.h
@@ -15,7 +15,7 @@
 /**
  * The counter mode.
  */
-enum HAL_Counter_Mode : int32_t {
+HAL_ENUM(HAL_Counter_Mode) {
   HAL_Counter_kTwoPulse = 0,
   HAL_Counter_kSemiperiod = 1,
   HAL_Counter_kPulseLength = 2,

--- a/hal/src/main/native/include/HAL/Counter.h
+++ b/hal/src/main/native/include/HAL/Counter.h
@@ -12,6 +12,7 @@
 #include "HAL/AnalogTrigger.h"
 #include "HAL/Types.h"
 
+// clang-format off
 /**
  * The counter mode.
  */
@@ -21,6 +22,7 @@ HAL_ENUM(HAL_Counter_Mode) {
   HAL_Counter_kPulseLength = 2,
   HAL_Counter_kExternalDirection = 3
 };
+// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/DriverStation.h
+++ b/hal/src/main/native/include/HAL/DriverStation.h
@@ -290,7 +290,7 @@ void HAL_ReleaseDSMutex(void);
  *
  * @return true if the control data has been updated since the last call
  */
-bool HAL_IsNewControlData(void);
+HAL_Bool HAL_IsNewControlData(void);
 
 /**
  * Waits for the newest DS packet to arrive. Note that this is a blocking call.

--- a/hal/src/main/native/include/HAL/DriverStation.h
+++ b/hal/src/main/native/include/HAL/DriverStation.h
@@ -9,8 +9,6 @@
 
 #include <stdint.h>
 
-#include <cstddef>
-
 #include "HAL/Types.h"
 
 #define HAL_IO_CONFIG_DATA_SIZE 32

--- a/hal/src/main/native/include/HAL/DriverStation.h
+++ b/hal/src/main/native/include/HAL/DriverStation.h
@@ -36,7 +36,7 @@ struct HAL_ControlWord {
   uint32_t control_reserved : 26;
 };
 
-enum HAL_AllianceStationID : int32_t {
+HAL_ENUM(HAL_AllianceStationID) {
   HAL_AllianceStationID_kRed1,
   HAL_AllianceStationID_kRed2,
   HAL_AllianceStationID_kRed3,
@@ -45,7 +45,7 @@ enum HAL_AllianceStationID : int32_t {
   HAL_AllianceStationID_kBlue3,
 };
 
-enum HAL_MatchType {
+HAL_ENUM(HAL_MatchType) {
   HAL_kMatchType_none,
   HAL_kMatchType_practice,
   HAL_kMatchType_qualification,

--- a/hal/src/main/native/include/HAL/DriverStation.h
+++ b/hal/src/main/native/include/HAL/DriverStation.h
@@ -37,6 +37,7 @@ struct HAL_ControlWord {
 };
 typedef struct HAL_ControlWord HAL_ControlWord;
 
+// clang-format off
 HAL_ENUM(HAL_AllianceStationID) {
   HAL_AllianceStationID_kRed1,
   HAL_AllianceStationID_kRed2,
@@ -52,6 +53,7 @@ HAL_ENUM(HAL_MatchType) {
   HAL_kMatchType_qualification,
   HAL_kMatchType_elimination,
 };
+// clang-format on
 
 /* The maximum number of axes that will be stored in a single HALJoystickAxes
  * struct. This is used for allocating buffers, not bounds checking, since

--- a/hal/src/main/native/include/HAL/DriverStation.h
+++ b/hal/src/main/native/include/HAL/DriverStation.h
@@ -35,6 +35,7 @@ struct HAL_ControlWord {
   uint32_t dsAttached : 1;
   uint32_t control_reserved : 26;
 };
+typedef struct HAL_ControlWord HAL_ControlWord;
 
 HAL_ENUM(HAL_AllianceStationID) {
   HAL_AllianceStationID_kRed1,
@@ -63,16 +64,19 @@ struct HAL_JoystickAxes {
   int16_t count;
   float axes[HAL_kMaxJoystickAxes];
 };
+typedef struct HAL_JoystickAxes HAL_JoystickAxes;
 
 struct HAL_JoystickPOVs {
   int16_t count;
   int16_t povs[HAL_kMaxJoystickPOVs];
 };
+typedef struct HAL_JoystickPOVs HAL_JoystickPOVs;
 
 struct HAL_JoystickButtons {
   uint32_t buttons;
   uint8_t count;
 };
+typedef struct HAL_JoystickButtons HAL_JoystickButtons;
 
 struct HAL_JoystickDescriptor {
   uint8_t isXbox;
@@ -83,6 +87,7 @@ struct HAL_JoystickDescriptor {
   uint8_t buttonCount;
   uint8_t povCount;
 };
+typedef struct HAL_JoystickDescriptor HAL_JoystickDescriptor;
 
 struct HAL_MatchInfo {
   char* eventName;
@@ -91,6 +96,7 @@ struct HAL_MatchInfo {
   uint8_t replayNumber;
   char* gameSpecificMessage;
 };
+typedef struct HAL_MatchInfo HAL_MatchInfo;
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/Encoder.h
+++ b/hal/src/main/native/include/HAL/Encoder.h
@@ -12,6 +12,7 @@
 #include "HAL/AnalogTrigger.h"
 #include "HAL/Types.h"
 
+// clang-format off
 /**
  * The type of index pulse for the encoder.
  */
@@ -30,6 +31,7 @@ HAL_ENUM(HAL_EncoderEncodingType) {
   HAL_Encoder_k2X,
   HAL_Encoder_k4X
 };
+// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/Encoder.h
+++ b/hal/src/main/native/include/HAL/Encoder.h
@@ -15,7 +15,7 @@
 /**
  * The type of index pulse for the encoder.
  */
-enum HAL_EncoderIndexingType : int32_t {
+HAL_ENUM(HAL_EncoderIndexingType) {
   HAL_kResetWhileHigh,
   HAL_kResetWhileLow,
   HAL_kResetOnFallingEdge,
@@ -25,7 +25,7 @@ enum HAL_EncoderIndexingType : int32_t {
 /**
  * The encoding scaling of the encoder.
  */
-enum HAL_EncoderEncodingType : int32_t {
+HAL_ENUM(HAL_EncoderEncodingType) {
   HAL_Encoder_k1X,
   HAL_Encoder_k2X,
   HAL_Encoder_k4X

--- a/hal/src/main/native/include/HAL/HAL.h
+++ b/hal/src/main/native/include/HAL/HAL.h
@@ -40,9 +40,11 @@
 
 #include "HAL/Types.h"
 
+#ifdef __cplusplus
 #include "UsageReporting.h"
 
 namespace HALUsageReporting = nUsageReporting;
+#endif
 
 HAL_ENUM(HAL_RuntimeType) { HAL_Athena, HAL_Mock };
 

--- a/hal/src/main/native/include/HAL/HAL.h
+++ b/hal/src/main/native/include/HAL/HAL.h
@@ -39,11 +39,12 @@
 #endif  // HAL_USE_LABVIEW
 
 #include "HAL/Types.h"
+
 #include "UsageReporting.h"
 
 namespace HALUsageReporting = nUsageReporting;
 
-enum HAL_RuntimeType : int32_t { HAL_Athena, HAL_Mock };
+HAL_ENUM(HAL_RuntimeType) { HAL_Athena, HAL_Mock };
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/HAL.h
+++ b/hal/src/main/native/include/HAL/HAL.h
@@ -46,7 +46,9 @@
 namespace HALUsageReporting = nUsageReporting;
 #endif
 
+// clang-format off
 HAL_ENUM(HAL_RuntimeType) { HAL_Athena, HAL_Mock };
+// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/I2C.h
+++ b/hal/src/main/native/include/HAL/I2C.h
@@ -11,7 +11,9 @@
 
 #include "HAL/Types.h"
 
+// clang-format off
 HAL_ENUM(HAL_I2CPort) { HAL_I2C_kOnboard = 0, HAL_I2C_kMXP };
+// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/I2C.h
+++ b/hal/src/main/native/include/HAL/I2C.h
@@ -9,7 +9,9 @@
 
 #include <stdint.h>
 
-enum HAL_I2CPort : int32_t { HAL_I2C_kOnboard = 0, HAL_I2C_kMXP };
+#include "HAL/Types.h"
+
+HAL_ENUM(HAL_I2CPort) { HAL_I2C_kOnboard = 0, HAL_I2C_kMXP };
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/SPI.h
+++ b/hal/src/main/native/include/HAL/SPI.h
@@ -12,6 +12,7 @@
 #include "HAL/AnalogTrigger.h"
 #include "HAL/Types.h"
 
+// clang-format off
 HAL_ENUM(HAL_SPIPort) {
   HAL_SPI_kOnboardCS0 = 0,
   HAL_SPI_kOnboardCS1,
@@ -19,6 +20,7 @@ HAL_ENUM(HAL_SPIPort) {
   HAL_SPI_kOnboardCS3,
   HAL_SPI_kMXP
 };
+// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/SPI.h
+++ b/hal/src/main/native/include/HAL/SPI.h
@@ -12,7 +12,7 @@
 #include "HAL/AnalogTrigger.h"
 #include "HAL/Types.h"
 
-enum HAL_SPIPort : int32_t {
+HAL_ENUM(HAL_SPIPort) {
   HAL_SPI_kOnboardCS0 = 0,
   HAL_SPI_kOnboardCS1,
   HAL_SPI_kOnboardCS2,

--- a/hal/src/main/native/include/HAL/SerialPort.h
+++ b/hal/src/main/native/include/HAL/SerialPort.h
@@ -9,7 +9,9 @@
 
 #include <stdint.h>
 
-enum HAL_SerialPort : int32_t {
+#include "HAL/Types.h"
+
+HAL_ENUM(HAL_SerialPort) {
   HAL_SerialPort_Onboard = 0,
   HAL_SerialPort_MXP = 1,
   HAL_SerialPort_USB1 = 2,

--- a/hal/src/main/native/include/HAL/SerialPort.h
+++ b/hal/src/main/native/include/HAL/SerialPort.h
@@ -11,12 +11,14 @@
 
 #include "HAL/Types.h"
 
+// clang-format off
 HAL_ENUM(HAL_SerialPort) {
   HAL_SerialPort_Onboard = 0,
   HAL_SerialPort_MXP = 1,
   HAL_SerialPort_USB1 = 2,
   HAL_SerialPort_USB2 = 3
 };
+// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/HAL/Types.h
+++ b/hal/src/main/native/include/HAL/Types.h
@@ -48,3 +48,9 @@ typedef HAL_Handle HAL_CANHandle;
 typedef HAL_CANHandle HAL_PDPHandle;
 
 typedef int32_t HAL_Bool;
+
+#ifdef __cplusplus
+#define HAL_ENUM(name) enum name : int32_t
+#else
+#define HAL_ENUM(name) typedef int32_t name; enum name
+#endif

--- a/hal/src/main/native/include/HAL/Types.h
+++ b/hal/src/main/native/include/HAL/Types.h
@@ -52,5 +52,7 @@ typedef int32_t HAL_Bool;
 #ifdef __cplusplus
 #define HAL_ENUM(name) enum name : int32_t
 #else
-#define HAL_ENUM(name) typedef int32_t name; enum name
+#define HAL_ENUM(name)  \
+  typedef int32_t name; \
+  enum name
 #endif

--- a/hal/src/main/native/sim/DriverStation.cpp
+++ b/hal/src/main/native/sim/DriverStation.cpp
@@ -204,7 +204,7 @@ static void InitLastCountKey(void) {
 }
 #endif
 
-bool HAL_IsNewControlData(void) {
+HAL_Bool HAL_IsNewControlData(void) {
 #ifdef __APPLE__
   pthread_once(&lastCountKeyOnce, InitLastCountKey);
   int* lastCountPtr = static_cast<int*>(pthread_getspecific(lastCountKey));


### PR DESCRIPTION
This also fixes the return type of `HAL_IsNewControlData()` and `HAL_MatchType`'s type.

Since UsageReporting is intended to be namespaced, I've hidden that when this is being used in C.

Fixes: #476
Closes: #535
Ref: #1122