### PR TITLE
Fix race conditions in command tests by increasing the delay time

### DIFF
--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/CommandSequentialGroupTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/CommandSequentialGroupTest.java
@@ -56,7 +56,7 @@ class CommandSequentialGroupTest extends AbstractCommandTest {
     assertCommandState(command1, 1, 1, 1, 0, 0);
     assertCommandState(command2, 0, 0, 0, 0, 0);
     assertCommandState(command3, 0, 0, 0, 0, 0);
-    sleep(1000); // command 1 timeout
+    sleep(1250); // command 1 timeout
     Scheduler.getInstance().run();
     assertCommandState(command1, 1, 1, 1, 0, 1);
     assertCommandState(command2, 1, 1, 1, 0, 0);
@@ -66,7 +66,7 @@ class CommandSequentialGroupTest extends AbstractCommandTest {
     assertCommandState(command1, 1, 1, 1, 0, 1);
     assertCommandState(command2, 1, 2, 2, 0, 0);
     assertCommandState(command3, 0, 0, 0, 0, 0);
-    sleep(2000); // command 2 timeout
+    sleep(2500); // command 2 timeout
     Scheduler.getInstance().run();
     assertCommandState(command1, 1, 1, 1, 0, 1);
     assertCommandState(command2, 1, 2, 2, 0, 1);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/CommandTimeoutTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/CommandTimeoutTest.java
@@ -38,7 +38,7 @@ class CommandTimeoutTest extends AbstractCommandTest {
     assertCommandState(command, 1, 2, 2, 0, 0);
     Scheduler.getInstance().run();
     assertCommandState(command, 1, 3, 3, 0, 0);
-    sleep(2000);
+    sleep(2500);
     Scheduler.getInstance().run();
     assertCommandState(command, 1, 4, 4, 1, 0);
     Scheduler.getInstance().run();


### PR DESCRIPTION
Fix these random failures: http://imacjenkins.dyn.wpi.edu/job/WPILib/job/WPILib%20Windows%20-%20PR/29/consoleFull

