### PR TITLE
Minor fixes required to enable the simulated robots to run

### DIFF
--- a/wpilibc/src/main/native/cpp/SmartDashboard/SendableChooserBase.cpp
+++ b/wpilibc/src/main/native/cpp/SmartDashboard/SendableChooserBase.cpp
@@ -9,8 +9,4 @@
 
 using namespace frc;
 
-const char* SendableChooserBase::kDefault = "default";
-const char* SendableChooserBase::kOptions = "options";
-const char* SendableChooserBase::kSelected = "selected";
-
 SendableChooserBase::SendableChooserBase() : SendableBase(false) {}

--- a/wpilibc/src/main/native/include/SmartDashboard/SendableChooserBase.h
+++ b/wpilibc/src/main/native/include/SmartDashboard/SendableChooserBase.h
@@ -27,9 +27,9 @@ class SendableChooserBase : public SendableBase {
   ~SendableChooserBase() override = default;
 
  protected:
-  static const char* kDefault;
-  static const char* kOptions;
-  static const char* kSelected;
+  static constexpr const char* kDefault = "default";
+  static constexpr const char* kOptions = "options";
+  static constexpr const char* kSelected = "selected";
 
   std::string m_defaultChoice;
   nt::NetworkTableEntry m_selectedEntry;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/subsystems/DriveTrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/subsystems/DriveTrain.java
@@ -38,7 +38,7 @@ public class DriveTrain extends Subsystem {
   private final DifferentialDrive m_drive;
   private final Encoder m_rightEncoder = new Encoder(1, 2, true, EncodingType.k4X);
   private final Encoder m_leftEncoder = new Encoder(3, 4, false, EncodingType.k4X);
-  private final AnalogGyro m_gyro = new AnalogGyro(2);
+  private final AnalogGyro m_gyro = new AnalogGyro(0);
 
   /**
    * Create a new drive train subsystem.

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/subsystems/Shooter.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/subsystems/Shooter.java
@@ -31,7 +31,7 @@ public class Shooter extends Subsystem {
   DigitalInput m_piston1ReedSwitchFront = new DigitalInput(9);
   DigitalInput m_piston1ReedSwitchBack = new DigitalInput(11);
   //NOTE: currently ignored in simulation
-  DigitalInput m_hotGoalSensor = new DigitalInput(3);
+  DigitalInput m_hotGoalSensor = new DigitalInput(7);
 
   /**
    * Create a new shooter subsystem.


### PR DESCRIPTION
With these two fixes, and a few not-suitable-for-upstream patches, I am able to operate the PacGoat robot, in simulation, both on Windows against the nt sim as well as against the gazebo simulator.

Instructions for running this are stashed in my wip6 branch here:
  https://github.com/jwhite66/allwpilib/blob/wip6/simulation/README.md

The two changes in this PR, I believe, are correct.  The other code in the wip6 branch imagines running the samples from allwpilib, when I think we eventually want to focus on using GradleRIO.  (And that code is not really correct, anyway).