### PR TITLE
Use ASAN when on Clang

### DIFF
--- a/shared/googletest.gradle
+++ b/shared/googletest.gradle
@@ -10,4 +10,13 @@ model {
             staticConfigs = project.staticGtestConfigs
         }
     }
+    binaries {
+        withType(GoogleTestTestSuiteBinarySpec) {
+            if (toolChain instanceof Clang) {
+                println "Clang Detected - Using ASAN"
+                cppCompiler.args << '-fsanitize=address'
+                linker.args << '-fsanitize=address'
+            }
+        }
+    }
 }


### PR DESCRIPTION
When using the clang toolchain with GoogleTest, use the Address Sanitizer to catch memory leaks / potential memory issues. Currently will only run on macOS since we use gcc by default everywhere else. 