### PR TITLE
Remove wildcard dep version from gazebo msg

### DIFF
--- a/simulation/gz_msgs/build.gradle
+++ b/simulation/gz_msgs/build.gradle
@@ -1,26 +1,14 @@
-description = "A C++ and Java library to pass FRC Simulation Messages in and out of Gazebo."
+plugins {
+    id 'cpp'
+    id 'java'
+    id 'com.google.protobuf' version '0.8.6'
+    id 'edu.wpi.first.NativeUtils'
+}
 
-apply plugin: 'cpp'
-apply plugin: 'java'
-apply plugin: 'com.google.protobuf'
-apply plugin: 'edu.wpi.first.NativeUtils'
+description = "A C++ and Java library to pass FRC Simulation Messages in and out of Gazebo."
 
 /* The simulation does not run on real hardware; so we always skip Athena */
 ext.skipAthena = true
-
-repositories {
-      mavenCentral()
-}
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:+'
-    }
-}
-
 
 /* Use a sort of poor man's autoconf to find the protobuf development
    files; on Debian, those are supplied by libprotobuf-dev.


### PR DESCRIPTION
We don't want any wildcards in allwpilib. Also uses plugin repo for protobuf rather then mavenCentral.