### PR TITLE
Add sockaddr_in overloads for uv::Tcp and uv::Udp

### DIFF
--- a/wpiutil/src/main/native/include/wpi/uv/Tcp.h
+++ b/wpiutil/src/main/native/include/wpi/uv/Tcp.h
@@ -154,6 +154,14 @@ class Tcp final : public NetworkStreamImpl<Tcp, uv_tcp_t> {
     Invoke(&uv_tcp_bind, GetRaw(), &addr, flags);
   }
 
+  void Bind(const sockaddr_in& addr, unsigned int flags = 0) {
+    Bind(reinterpret_cast<const sockaddr&>(addr), flags);
+  }
+
+  void Bind(const sockaddr_in6& addr, unsigned int flags = 0) {
+    Bind(reinterpret_cast<const sockaddr&>(addr), flags);
+  }
+
   /**
    * Bind the handle to an IPv4 address and port.
    *
@@ -215,6 +223,16 @@ class Tcp final : public NetworkStreamImpl<Tcp, uv_tcp_t> {
    */
   void Connect(const sockaddr& addr, const std::shared_ptr<TcpConnectReq>& req);
 
+  void Connect(const sockaddr_in& addr,
+               const std::shared_ptr<TcpConnectReq>& req) {
+    Connect(reinterpret_cast<const sockaddr&>(addr), req);
+  }
+
+  void Connect(const sockaddr_in6& addr,
+               const std::shared_ptr<TcpConnectReq>& req) {
+    Connect(reinterpret_cast<const sockaddr&>(addr), req);
+  }
+
   /**
    * Establish an IPv4 or IPv6 TCP connection.
    *
@@ -229,6 +247,14 @@ class Tcp final : public NetworkStreamImpl<Tcp, uv_tcp_t> {
    * @param callback Callback function to call when connection established
    */
   void Connect(const sockaddr& addr, std::function<void()> callback);
+
+  void Connect(const sockaddr_in& addr, std::function<void()> callback) {
+    Connect(reinterpret_cast<const sockaddr&>(addr), callback);
+  }
+
+  void Connect(const sockaddr_in6& addr, std::function<void()> callback) {
+    Connect(reinterpret_cast<const sockaddr&>(addr), callback);
+  }
 
   /**
    * Establish an IPv4 TCP connection.

--- a/wpiutil/src/main/native/include/wpi/uv/Udp.h
+++ b/wpiutil/src/main/native/include/wpi/uv/Udp.h
@@ -89,6 +89,14 @@ class Udp final : public HandleImpl<Udp, uv_udp_t> {
     Invoke(&uv_udp_bind, GetRaw(), &addr, flags);
   }
 
+  void Bind(const sockaddr_in& addr, unsigned int flags = 0) {
+    Bind(reinterpret_cast<const sockaddr&>(addr), flags);
+  }
+
+  void Bind(const sockaddr_in6& addr, unsigned int flags = 0) {
+    Bind(reinterpret_cast<const sockaddr&>(addr), flags);
+  }
+
   /**
    * Bind the handle to an IPv4 address and port.
    *
@@ -186,6 +194,16 @@ class Udp final : public HandleImpl<Udp, uv_udp_t> {
   void Send(const sockaddr& addr, ArrayRef<Buffer> bufs,
             const std::shared_ptr<UdpSendReq>& req);
 
+  void Send(const sockaddr_in& addr, ArrayRef<Buffer> bufs,
+            const std::shared_ptr<UdpSendReq>& req) {
+    Send(reinterpret_cast<const sockaddr&>(addr), bufs, req);
+  }
+
+  void Send(const sockaddr_in6& addr, ArrayRef<Buffer> bufs,
+            const std::shared_ptr<UdpSendReq>& req) {
+    Send(reinterpret_cast<const sockaddr&>(addr), bufs, req);
+  }
+
   /**
    * Send data over the UDP socket.  If the socket has not previously been bound
    * with Bind() it will be bound to 0.0.0.0 (the "all interfaces" IPv4 address)
@@ -206,6 +224,16 @@ class Udp final : public HandleImpl<Udp, uv_udp_t> {
   void Send(const sockaddr& addr, ArrayRef<Buffer> bufs,
             std::function<void(MutableArrayRef<Buffer>, Error)> callback);
 
+  void Send(const sockaddr_in& addr, ArrayRef<Buffer> bufs,
+            std::function<void(MutableArrayRef<Buffer>, Error)> callback) {
+    Send(reinterpret_cast<const sockaddr&>(addr), bufs, callback);
+  }
+
+  void Send(const sockaddr_in6& addr, ArrayRef<Buffer> bufs,
+            std::function<void(MutableArrayRef<Buffer>, Error)> callback) {
+    Send(reinterpret_cast<const sockaddr&>(addr), bufs, callback);
+  }
+
   /**
    * Same as Send(), but won't queue a send request if it can't be completed
    * immediately.
@@ -222,6 +250,14 @@ class Udp final : public HandleImpl<Udp, uv_udp_t> {
       return 0;
     }
     return val;
+  }
+
+  int TrySend(const sockaddr_in& addr, ArrayRef<Buffer> bufs) {
+    return TrySend(reinterpret_cast<const sockaddr&>(addr), bufs);
+  }
+
+  int TrySend(const sockaddr_in6& addr, ArrayRef<Buffer> bufs) {
+    return TrySend(reinterpret_cast<const sockaddr&>(addr), bufs);
   }
 
   /**


### PR DESCRIPTION
These help avoid the need for reinterpret_casts in common use cases.