### PR TITLE
HttpParser: Add Reset() function

### DIFF
--- a/wpiutil/src/main/native/cpp/HttpParser.cpp
+++ b/wpiutil/src/main/native/cpp/HttpParser.cpp
@@ -162,3 +162,15 @@ HttpParser::HttpParser(Type type) {
     return self.m_aborted;
   };
 }
+
+void HttpParser::Reset(Type type) {
+  http_parser_init(&m_parser,
+                   static_cast<http_parser_type>(static_cast<int>(type)));
+  m_parser.data = this;
+  m_maxLength = 1024;
+  m_state = kStart;
+  m_urlBuf.clear();
+  m_fieldBuf.clear();
+  m_valueBuf.clear();
+  m_aborted = false;
+}

--- a/wpiutil/src/main/native/include/wpi/HttpParser.h
+++ b/wpiutil/src/main/native/include/wpi/HttpParser.h
@@ -36,7 +36,18 @@ class HttpParser {
    */
   static uint32_t GetParserVersion();
 
+  /**
+   * Constructor.
+   * @param type Type of parser (request or response or both)
+   */
   explicit HttpParser(Type type);
+
+  /**
+   * Reset the parser to initial state.
+   * This allows reusing the same parser object from request to request.
+   * @param type Type of parser (request or response or both)
+   */
+  void Reset(Type type);
 
   /**
    * Set the maximum accepted length for URLs, field names, and field values.

--- a/wpiutil/src/test/native/cpp/HttpParserTest.cpp
+++ b/wpiutil/src/test/native/cpp/HttpParserTest.cpp
@@ -190,4 +190,20 @@ TEST(HttpParserTest, HeadersCompleteUpgrade) {
   ASSERT_FALSE(p.HasError());
 }
 
+TEST(HttpParserTest, Reset) {
+  HttpParser p{HttpParser::kRequest};
+  int callbacks = 0;
+  p.headersComplete.connect([&](bool) { ++callbacks; });
+  p.Execute("GET / HTTP/1.1\r\n");
+  ASSERT_EQ(callbacks, 0);
+  p.Execute("\r\n");
+  ASSERT_EQ(callbacks, 1);
+  p.Reset(HttpParser::kRequest);
+  p.Execute("GET / HTTP/1.1\r\n");
+  ASSERT_EQ(callbacks, 1);
+  p.Execute("\r\n");
+  ASSERT_EQ(callbacks, 2);
+  ASSERT_FALSE(p.HasError());
+}
+
 }  // namespace wpi


### PR DESCRIPTION
This allows reuse of the HttpParser object for multiple requests.