### PR TITLE
Remove appveyor artifacts, and only build 64 bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ branches:
   only:
   - master
 platform:
-- x86
 - x64
 shallow_clone: true
 init:
@@ -40,8 +39,3 @@ build_script:
 
     ./gradlew --stop
 test: off
-artifacts:
-- path: '**/allOutputs/*'
-  name: AllOutputs
-- path: '**/test-results/**/*'
-  name: TestResults


### PR DESCRIPTION
There is a limit on artifacts, and doing both builds gains little  and doubles build time