### PR TITLE
Add confirmation to SendableChooser

### DIFF
--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableChooserBase.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableChooserBase.cpp
@@ -9,4 +9,7 @@
 
 using namespace frc;
 
-SendableChooserBase::SendableChooserBase() : SendableBase(false) {}
+std::atomic_int SendableChooserBase::s_instances{0};
+
+SendableChooserBase::SendableChooserBase()
+    : SendableBase(false), m_instance{s_instances++} {}

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.inc
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.inc
@@ -75,6 +75,7 @@ auto SendableChooser<T>::GetSelected()
 template <class T>
 void SendableChooser<T>::InitSendable(SendableBuilder& builder) {
   builder.SetSmartDashboardType("String Chooser");
+  builder.GetEntry(kInstance).SetDouble(m_instance);
   builder.AddStringArrayProperty(kOptions,
                                  [=]() {
                                    std::vector<std::string> keys;

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.inc
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.inc
@@ -61,8 +61,9 @@ template <class T>
 auto SendableChooser<T>::GetSelected()
     -> decltype(_unwrap_smart_ptr(m_choices[""])) {
   std::string selected = m_defaultChoice;
-  if (m_selectedEntry) {
-    selected = m_selectedEntry.GetString(m_defaultChoice);
+  {
+    std::lock_guard<wpi::mutex> lock(m_mutex);
+    if (m_haveSelected) selected = m_selected;
   }
   if (selected.empty()) {
     return decltype(_unwrap_smart_ptr(m_choices[""])){};
@@ -90,11 +91,32 @@ void SendableChooser<T>::InitSendable(SendableBuilder& builder) {
                                  nullptr);
   builder.AddSmallStringProperty(
       kDefault,
-      [=](const wpi::SmallVectorImpl<char>&) -> wpi::StringRef {
+      [=](wpi::SmallVectorImpl<char>&) -> wpi::StringRef {
         return m_defaultChoice;
       },
       nullptr);
-  m_selectedEntry = builder.GetEntry(kSelected);
+  builder.AddSmallStringProperty(
+      kActive,
+      [=](wpi::SmallVectorImpl<char>& buf) -> wpi::StringRef {
+        std::lock_guard<wpi::mutex> lock(m_mutex);
+        if (m_haveSelected) {
+          buf.assign(m_selected.begin(), m_selected.end());
+          return wpi::StringRef(buf.data(), buf.size());
+        } else {
+          return m_defaultChoice;
+        }
+      },
+      nullptr);
+  {
+    std::lock_guard<wpi::mutex> lock(m_mutex);
+    m_activeEntries.emplace_back(builder.GetEntry(kActive));
+  }
+  builder.AddStringProperty(kSelected, nullptr, [=](wpi::StringRef val) {
+    std::lock_guard<wpi::mutex> lock(m_mutex);
+    m_haveSelected = true;
+    m_selected = val;
+    for (auto& entry : m_activeEntries) entry.SetString(val);
+  });
 }
 
 template <class T>

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooserBase.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooserBase.h
@@ -10,6 +10,8 @@
 #include <string>
 
 #include <networktables/NetworkTableEntry.h>
+#include <wpi/SmallVector.h>
+#include <wpi/mutex.h>
 
 #include "frc/smartdashboard/SendableBase.h"
 
@@ -30,9 +32,13 @@ class SendableChooserBase : public SendableBase {
   static constexpr const char* kDefault = "default";
   static constexpr const char* kOptions = "options";
   static constexpr const char* kSelected = "selected";
+  static constexpr const char* kActive = "active";
 
   std::string m_defaultChoice;
-  nt::NetworkTableEntry m_selectedEntry;
+  std::string m_selected;
+  bool m_haveSelected = false;
+  wpi::SmallVector<nt::NetworkTableEntry, 2> m_activeEntries;
+  wpi::mutex m_mutex;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooserBase.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooserBase.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <string>
 
 #include <networktables/NetworkTableEntry.h>
@@ -33,12 +34,15 @@ class SendableChooserBase : public SendableBase {
   static constexpr const char* kOptions = "options";
   static constexpr const char* kSelected = "selected";
   static constexpr const char* kActive = "active";
+  static constexpr const char* kInstance = ".instance";
 
   std::string m_defaultChoice;
   std::string m_selected;
   bool m_haveSelected = false;
   wpi::SmallVector<nt::NetworkTableEntry, 2> m_activeEntries;
   wpi::mutex m_mutex;
+  int m_instance;
+  static std::atomic_int s_instances;
 };
 
 }  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
@@ -10,6 +10,7 @@ package edu.wpi.first.wpilibj.smartdashboard;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
 import edu.wpi.first.networktables.NetworkTableEntry;
@@ -48,17 +49,24 @@ public class SendableChooser<V> extends SendableBase {
    */
   private static final String OPTIONS = "options";
   /**
+   * The key for the instance number.
+   */
+  private static final String INSTANCE = ".instance";
+  /**
    * A map linking strings to the objects the represent.
    */
   @SuppressWarnings("PMD.LooseCoupling")
   private final LinkedHashMap<String, V> m_map = new LinkedHashMap<>();
   private String m_defaultChoice = "";
+  private final int m_instance;
+  private static final AtomicInteger s_instances = new AtomicInteger();
 
   /**
    * Instantiates a {@link SendableChooser}.
    */
   public SendableChooser() {
     super(false);
+    m_instance = s_instances.getAndIncrement();
   }
 
   /**
@@ -113,6 +121,7 @@ public class SendableChooser<V> extends SendableBase {
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("String Chooser");
+    builder.getEntry(INSTANCE).setDouble(m_instance);
     builder.addStringProperty(DEFAULT, () -> {
       return m_defaultChoice;
     }, null);


### PR DESCRIPTION
This echos back the "selected" value to the "active" key to enable dashboards
to display positive feedback to the user that the value is actually set on
the robot side.

Also fixes SendableChooser so it can be safely added to multiple tables.
Changes to "selected" in any table will result in all "active" values being
updated.