### PR TITLE
cscore: Support multiple levels of JPEG compression

### DIFF
--- a/cscore/src/main/native/cpp/Image.h
+++ b/cscore/src/main/native/cpp/Image.h
@@ -79,6 +79,14 @@ class Image {
   bool Is(int width_, int height_, VideoMode::PixelFormat pixelFormat_) {
     return width == width_ && height == height_ && pixelFormat == pixelFormat_;
   }
+  bool Is(int width_, int height_, VideoMode::PixelFormat pixelFormat_,
+          int jpegQuality_) {
+    // Consider +/-5 on JPEG quality to be "close enough"
+    return width == width_ && height == height_ &&
+           pixelFormat == pixelFormat_ &&
+           (pixelFormat != VideoMode::kMJPEG || jpegQuality_ == -1 ||
+            (jpegQuality != -1 && std::abs(jpegQuality - jpegQuality_) <= 5));
+  }
   bool IsLarger(int width_, int height_) {
     return width >= width_ && height >= height_;
   }
@@ -95,6 +103,7 @@ class Image {
   VideoMode::PixelFormat pixelFormat{VideoMode::kUnknown};
   int width{0};
   int height{0};
+  int jpegQuality{-1};
 };
 
 }  // namespace cs

--- a/cscore/src/main/native/cpp/MjpegServerImpl.cpp
+++ b/cscore/src/main/native/cpp/MjpegServerImpl.cpp
@@ -114,7 +114,7 @@ class MjpegServerImpl::ConnThread : public wpi::SafeThread {
 
   int m_width{0};
   int m_height{0};
-  int m_compression{80};
+  int m_compression{-1};
   int m_fps{0};
 };
 
@@ -635,8 +635,8 @@ void MjpegServerImpl::ConnThread::SendStream(wpi::raw_socket_ostream& os) {
 
     int width = m_width != 0 ? m_width : frame.GetOriginalWidth();
     int height = m_height != 0 ? m_height : frame.GetOriginalHeight();
-    Image* image =
-        frame.GetImage(width, height, VideoMode::kMJPEG, m_compression);
+    Image* image = frame.GetImageMJPEG(
+        width, height, m_compression, m_compression == -1 ? 80 : m_compression);
     if (!image) {
       // Shouldn't happen, but just in case...
       std::this_thread::sleep_for(std::chrono::milliseconds(20));
@@ -695,7 +695,7 @@ void MjpegServerImpl::ConnThread::ProcessRequest() {
   // Reset per-request settings
   m_width = 0;
   m_height = 0;
-  m_compression = 80;
+  m_compression = -1;
   m_fps = 0;
 
   // Read the request string from the stream


### PR DESCRIPTION
This allows two streams with different compression levels, and also allows
a stream to receive a different compression level than provided by a JPEG
camera (decompress and recompress).