### PR TITLE
Add a .controllable key as a standard part of Sendable

### DIFF
--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
@@ -14,6 +14,7 @@ using namespace frc;
 
 void SendableBuilderImpl::SetTable(std::shared_ptr<nt::NetworkTable> table) {
   m_table = table;
+  m_controllableEntry = table->GetEntry(".controllable");
 }
 
 std::shared_ptr<nt::NetworkTable> SendableBuilderImpl::GetTable() {
@@ -30,10 +31,12 @@ void SendableBuilderImpl::UpdateTable() {
 
 void SendableBuilderImpl::StartListeners() {
   for (auto& property : m_properties) property.StartListener();
+  m_controllableEntry.SetBoolean(true);
 }
 
 void SendableBuilderImpl::StopListeners() {
   for (auto& property : m_properties) property.StopListener();
+  m_controllableEntry.SetBoolean(false);
 }
 
 void SendableBuilderImpl::StartLiveWindowMode() {

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableBuilderImpl.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableBuilderImpl.h
@@ -187,6 +187,7 @@ class SendableBuilderImpl : public SendableBuilder {
   std::function<void()> m_safeState;
   std::function<void()> m_updateTable;
   std::shared_ptr<nt::NetworkTable> m_table;
+  nt::NetworkTableEntry m_controllableEntry;
 };
 
 }  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
@@ -57,6 +57,7 @@ public class SendableBuilderImpl implements SendableBuilder {
   private Runnable m_safeState;
   private Runnable m_updateTable;
   private NetworkTable m_table;
+  private NetworkTableEntry m_controllableEntry;
 
   /**
    * Set the network table.  Must be called prior to any Add* functions being
@@ -65,6 +66,7 @@ public class SendableBuilderImpl implements SendableBuilder {
    */
   public void setTable(NetworkTable table) {
     m_table = table;
+    m_controllableEntry = table.getEntry(".controllable");
   }
 
   /**
@@ -96,6 +98,7 @@ public class SendableBuilderImpl implements SendableBuilder {
     for (Property property : m_properties) {
       property.startListener();
     }
+    m_controllableEntry.setBoolean(true);
   }
 
   /**
@@ -105,6 +108,7 @@ public class SendableBuilderImpl implements SendableBuilder {
     for (Property property : m_properties) {
       property.stopListener();
     }
+    m_controllableEntry.setBoolean(false);
   }
 
   /**


### PR DESCRIPTION
This indicates whether or not the Sendable listeners are installed.
It is set to true when SendableBuilder.startListeners() starts the listeners,
and set to false when SendableBuilder.stopListeners() stops the listeners.

This allows dashboards to choose to change their widget display based on
whether or not the value is actually controllable.