### PR TITLE
Add a way to indicate a Sendable is an actuator

### DIFF
--- a/wpilibc/src/main/native/cpp/DoubleSolenoid.cpp
+++ b/wpilibc/src/main/native/cpp/DoubleSolenoid.cpp
@@ -136,6 +136,7 @@ bool DoubleSolenoid::IsRevSolenoidBlackListed() const {
 
 void DoubleSolenoid::InitSendable(SendableBuilder& builder) {
   builder.SetSmartDashboardType("Double Solenoid");
+  builder.SetActuator(true);
   builder.SetSafeState([=]() { Set(kOff); });
   builder.AddSmallStringProperty(
       "Value",

--- a/wpilibc/src/main/native/cpp/NidecBrushless.cpp
+++ b/wpilibc/src/main/native/cpp/NidecBrushless.cpp
@@ -84,6 +84,7 @@ int NidecBrushless::GetChannel() const { return m_pwm.GetChannel(); }
 
 void NidecBrushless::InitSendable(SendableBuilder& builder) {
   builder.SetSmartDashboardType("Nidec Brushless");
+  builder.SetActuator(true);
   builder.SetSafeState([=]() { StopMotor(); });
   builder.AddDoubleProperty("Value", [=]() { return Get(); },
                             [=](double value) { Set(value); });

--- a/wpilibc/src/main/native/cpp/PWM.cpp
+++ b/wpilibc/src/main/native/cpp/PWM.cpp
@@ -184,6 +184,7 @@ int PWM::GetChannel() const { return m_channel; }
 
 void PWM::InitSendable(SendableBuilder& builder) {
   builder.SetSmartDashboardType("PWM");
+  builder.SetActuator(true);
   builder.SetSafeState([=]() { SetDisabled(); });
   builder.AddDoubleProperty("Value", [=]() { return GetRaw(); },
                             [=](double value) { SetRaw(value); });

--- a/wpilibc/src/main/native/cpp/PWMSpeedController.cpp
+++ b/wpilibc/src/main/native/cpp/PWMSpeedController.cpp
@@ -33,6 +33,7 @@ PWMSpeedController::PWMSpeedController(int channel) : SafePWM(channel) {}
 
 void PWMSpeedController::InitSendable(SendableBuilder& builder) {
   builder.SetSmartDashboardType("Speed Controller");
+  builder.SetActuator(true);
   builder.SetSafeState([=]() { SetDisabled(); });
   builder.AddDoubleProperty("Value", [=]() { return GetSpeed(); },
                             [=](double value) { SetSpeed(value); });

--- a/wpilibc/src/main/native/cpp/Relay.cpp
+++ b/wpilibc/src/main/native/cpp/Relay.cpp
@@ -201,6 +201,7 @@ void Relay::GetDescription(wpi::raw_ostream& desc) const {
 
 void Relay::InitSendable(SendableBuilder& builder) {
   builder.SetSmartDashboardType("Relay");
+  builder.SetActuator(true);
   builder.SetSafeState([=]() { Set(kOff); });
   builder.AddSmallStringProperty(
       "Value",

--- a/wpilibc/src/main/native/cpp/Solenoid.cpp
+++ b/wpilibc/src/main/native/cpp/Solenoid.cpp
@@ -87,6 +87,7 @@ void Solenoid::StartPulse() {
 
 void Solenoid::InitSendable(SendableBuilder& builder) {
   builder.SetSmartDashboardType("Solenoid");
+  builder.SetActuator(true);
   builder.SetSafeState([=]() { Set(false); });
   builder.AddBooleanProperty("Value", [=]() { return Get(); },
                              [=](bool value) { Set(value); });

--- a/wpilibc/src/main/native/cpp/SpeedControllerGroup.cpp
+++ b/wpilibc/src/main/native/cpp/SpeedControllerGroup.cpp
@@ -46,6 +46,7 @@ void SpeedControllerGroup::PIDWrite(double output) { Set(output); }
 
 void SpeedControllerGroup::InitSendable(SendableBuilder& builder) {
   builder.SetSmartDashboardType("Speed Controller");
+  builder.SetActuator(true);
   builder.SetSafeState([=]() { StopMotor(); });
   builder.AddDoubleProperty("Value", [=]() { return Get(); },
                             [=](double value) { Set(value); });

--- a/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
@@ -211,6 +211,8 @@ void DifferentialDrive::GetDescription(wpi::raw_ostream& desc) const {
 
 void DifferentialDrive::InitSendable(SendableBuilder& builder) {
   builder.SetSmartDashboardType("DifferentialDrive");
+  builder.SetActuator(true);
+  builder.SetSafeState([=] { StopMotor(); });
   builder.AddDoubleProperty("Left Motor Speed",
                             [=]() { return m_leftMotor.Get(); },
                             [=](double value) { m_leftMotor.Set(value); });

--- a/wpilibc/src/main/native/cpp/drive/KilloughDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/KilloughDrive.cpp
@@ -101,6 +101,8 @@ void KilloughDrive::GetDescription(wpi::raw_ostream& desc) const {
 
 void KilloughDrive::InitSendable(SendableBuilder& builder) {
   builder.SetSmartDashboardType("KilloughDrive");
+  builder.SetActuator(true);
+  builder.SetSafeState([=] { StopMotor(); });
   builder.AddDoubleProperty("Left Motor Speed",
                             [=]() { return m_leftMotor.Get(); },
                             [=](double value) { m_leftMotor.Set(value); });

--- a/wpilibc/src/main/native/cpp/drive/MecanumDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/MecanumDrive.cpp
@@ -107,6 +107,8 @@ void MecanumDrive::GetDescription(wpi::raw_ostream& desc) const {
 
 void MecanumDrive::InitSendable(SendableBuilder& builder) {
   builder.SetSmartDashboardType("MecanumDrive");
+  builder.SetActuator(true);
+  builder.SetSafeState([=] { StopMotor(); });
   builder.AddDoubleProperty("Front Left Motor Speed",
                             [=]() { return m_frontLeftMotor.Get(); },
                             [=](double value) { m_frontLeftMotor.Set(value); });

--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
@@ -21,6 +21,8 @@ std::shared_ptr<nt::NetworkTable> SendableBuilderImpl::GetTable() {
   return m_table;
 }
 
+bool SendableBuilderImpl::IsActuator() const { return m_actuator; }
+
 void SendableBuilderImpl::UpdateTable() {
   uint64_t time = nt::Now();
   for (auto& property : m_properties) {
@@ -51,6 +53,11 @@ void SendableBuilderImpl::StopLiveWindowMode() {
 
 void SendableBuilderImpl::SetSmartDashboardType(const wpi::Twine& type) {
   m_table->GetEntry(".type").SetString(type);
+}
+
+void SendableBuilderImpl::SetActuator(bool value) {
+  m_table->GetEntry(".actuator").SetBoolean(value);
+  m_actuator = value;
 }
 
 void SendableBuilderImpl::SetSafeState(std::function<void()> func) {

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableBuilder.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableBuilder.h
@@ -33,6 +33,14 @@ class SendableBuilder {
   virtual void SetSmartDashboardType(const wpi::Twine& type) = 0;
 
   /**
+   * Set a flag indicating if this sendable should be treated as an actuator.
+   * By default this flag is false.
+   *
+   * @param value   true if actuator, false if not
+   */
+  virtual void SetActuator(bool value) = 0;
+
+  /**
    * Set the function that should be called to set the Sendable into a safe
    * state.  This is called when entering and exiting Live Window mode.
    *

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableBuilderImpl.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableBuilderImpl.h
@@ -47,6 +47,12 @@ class SendableBuilderImpl : public SendableBuilder {
   std::shared_ptr<nt::NetworkTable> GetTable();
 
   /**
+   * Return whether this sendable should be treated as an actuator.
+   * @return True if actuator, false if not.
+   */
+  bool IsActuator() const;
+
+  /**
    * Update the network table values by calling the getters for all properties.
    */
   void UpdateTable();
@@ -74,6 +80,7 @@ class SendableBuilderImpl : public SendableBuilder {
   void StopLiveWindowMode();
 
   void SetSmartDashboardType(const wpi::Twine& type) override;
+  void SetActuator(bool value) override;
   void SetSafeState(std::function<void()> func) override;
   void SetUpdateTable(std::function<void()> func) override;
   nt::NetworkTableEntry GetEntry(const wpi::Twine& key) override;
@@ -188,6 +195,7 @@ class SendableBuilderImpl : public SendableBuilder {
   std::function<void()> m_updateTable;
   std::shared_ptr<nt::NetworkTable> m_table;
   nt::NetworkTableEntry m_controllableEntry;
+  bool m_actuator = false;
 };
 
 }  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DoubleSolenoid.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DoubleSolenoid.java
@@ -166,6 +166,7 @@ public class DoubleSolenoid extends SolenoidBase {
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("Double Solenoid");
+    builder.setActuator(true);
     builder.setSafeState(() -> set(Value.kOff));
     builder.addStringProperty("Value", () -> get().name().substring(1), value -> {
       if ("Forward".equals(value)) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/NidecBrushless.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/NidecBrushless.java
@@ -196,6 +196,7 @@ public class NidecBrushless extends SendableBase implements SpeedController, Mot
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("Nidec Brushless");
+    builder.setActuator(true);
     builder.setSafeState(this::stopMotor);
     builder.addDoubleProperty("Value", this::get, this::set);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWM.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWM.java
@@ -242,6 +242,7 @@ public class PWM extends SendableBase {
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("PWM");
+    builder.setActuator(true);
     builder.setSafeState(this::setDisabled);
     builder.addDoubleProperty("Value", this::getRaw, value -> setRaw((int) value));
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSpeedController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSpeedController.java
@@ -77,6 +77,7 @@ public abstract class PWMSpeedController extends SafePWM implements SpeedControl
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("Speed Controller");
+    builder.setActuator(true);
     builder.setSafeState(this::setDisabled);
     builder.addDoubleProperty("Value", this::getSpeed, this::setSpeed);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Relay.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Relay.java
@@ -334,6 +334,7 @@ public class Relay extends SendableBase implements MotorSafety {
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("Relay");
+    builder.setActuator(true);
     builder.setSafeState(() -> set(Value.kOff));
     builder.addStringProperty("Value", () -> get().getPrettyValue(),
         value -> set(Value.getValueOf(value).orElse(Value.kOff)));

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Solenoid.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Solenoid.java
@@ -115,6 +115,7 @@ public class Solenoid extends SolenoidBase {
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("Solenoid");
+    builder.setActuator(true);
     builder.setSafeState(() -> set(false));
     builder.addBooleanProperty("Value", this::get, this::set);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SpeedControllerGroup.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SpeedControllerGroup.java
@@ -83,6 +83,7 @@ public class SpeedControllerGroup extends SendableBase implements SpeedControlle
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("Speed Controller");
+    builder.setActuator(true);
     builder.setSafeState(this::stopMotor);
     builder.addDoubleProperty("Value", this::get, this::set);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -390,6 +390,8 @@ public class DifferentialDrive extends RobotDriveBase {
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("DifferentialDrive");
+    builder.setActuator(true);
+    builder.setSafeState(this::stopMotor);
     builder.addDoubleProperty("Left Motor Speed", m_leftMotor::get, m_leftMotor::set);
     builder.addDoubleProperty(
         "Right Motor Speed",

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
@@ -204,6 +204,8 @@ public class KilloughDrive extends RobotDriveBase {
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("KilloughDrive");
+    builder.setActuator(true);
+    builder.setSafeState(this::stopMotor);
     builder.addDoubleProperty("Left Motor Speed", m_leftMotor::get, m_leftMotor::set);
     builder.addDoubleProperty("Right Motor Speed", m_rightMotor::get, m_rightMotor::set);
     builder.addDoubleProperty("Back Motor Speed", m_backMotor::get, m_backMotor::set);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
@@ -208,6 +208,8 @@ public class MecanumDrive extends RobotDriveBase {
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("MecanumDrive");
+    builder.setActuator(true);
+    builder.setSafeState(this::stopMotor);
     builder.addDoubleProperty("Front Left Motor Speed",
         m_frontLeftMotor::get,
         m_frontLeftMotor::set);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilder.java
@@ -26,6 +26,14 @@ public interface SendableBuilder {
   void setSmartDashboardType(String type);
 
   /**
+   * Set a flag indicating if this sendable should be treated as an actuator.
+   * By default this flag is false.
+   *
+   * @param value   true if actuator, false if not
+   */
+  void setActuator(boolean value);
+
+  /**
    * Set the function that should be called to set the Sendable into a safe
    * state.  This is called when entering and exiting Live Window mode.
    *

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
@@ -58,6 +58,7 @@ public class SendableBuilderImpl implements SendableBuilder {
   private Runnable m_updateTable;
   private NetworkTable m_table;
   private NetworkTableEntry m_controllableEntry;
+  private boolean m_actuator;
 
   /**
    * Set the network table.  Must be called prior to any Add* functions being
@@ -75,6 +76,14 @@ public class SendableBuilderImpl implements SendableBuilder {
    */
   public NetworkTable getTable() {
     return m_table;
+  }
+
+  /**
+   * Return whether this sendable should be treated as an actuator.
+   * @return True if actuator, false if not.
+   */
+  public boolean isActuator() {
+    return m_actuator;
   }
 
   /**
@@ -142,6 +151,18 @@ public class SendableBuilderImpl implements SendableBuilder {
   @Override
   public void setSmartDashboardType(String type) {
     m_table.getEntry(".type").setString(type);
+  }
+
+  /**
+   * Set a flag indicating if this sendable should be treated as an actuator.
+   * By default this flag is false.
+   *
+   * @param value   true if actuator, false if not
+   */
+  @Override
+  public void setActuator(boolean value) {
+    m_table.getEntry(".actuator").setBoolean(value);
+    m_actuator = value;
   }
 
   /**


### PR DESCRIPTION
SendableBuilder.setActuator() sets the .actuator key in the network table
so dashboards can change behavior on the client side if desired, and also
sets a local flag (retrievable via isActuator()).