### PR TITLE
cscore: Move CvSourceImpl placeholders into SourceImpl

### DIFF
--- a/cscore/src/main/native/cpp/CvSourceImpl.cpp
+++ b/cscore/src/main/native/cpp/CvSourceImpl.cpp
@@ -31,41 +31,6 @@ CvSourceImpl::~CvSourceImpl() {}
 
 void CvSourceImpl::Start() {}
 
-// These are only valid for cameras (should never get called)
-
-void CvSourceImpl::SetBrightness(int brightness, CS_Status* status) {
-  *status = CS_INVALID_HANDLE;
-}
-
-int CvSourceImpl::GetBrightness(CS_Status* status) const {
-  *status = CS_INVALID_HANDLE;
-  return 0;
-}
-
-void CvSourceImpl::SetWhiteBalanceAuto(CS_Status* status) {
-  *status = CS_INVALID_HANDLE;
-}
-
-void CvSourceImpl::SetWhiteBalanceHoldCurrent(CS_Status* status) {
-  *status = CS_INVALID_HANDLE;
-}
-
-void CvSourceImpl::SetWhiteBalanceManual(int value, CS_Status* status) {
-  *status = CS_INVALID_HANDLE;
-}
-
-void CvSourceImpl::SetExposureAuto(CS_Status* status) {
-  *status = CS_INVALID_HANDLE;
-}
-
-void CvSourceImpl::SetExposureHoldCurrent(CS_Status* status) {
-  *status = CS_INVALID_HANDLE;
-}
-
-void CvSourceImpl::SetExposureManual(int value, CS_Status* status) {
-  *status = CS_INVALID_HANDLE;
-}
-
 bool CvSourceImpl::SetVideoMode(const VideoMode& mode, CS_Status* status) {
   {
     std::lock_guard<wpi::mutex> lock(m_mutex);

--- a/cscore/src/main/native/cpp/CvSourceImpl.h
+++ b/cscore/src/main/native/cpp/CvSourceImpl.h
@@ -25,16 +25,6 @@ class CvSourceImpl : public SourceImpl {
 
   void Start();
 
-  // Standard common camera properties
-  void SetBrightness(int brightness, CS_Status* status) override;
-  int GetBrightness(CS_Status* status) const override;
-  void SetWhiteBalanceAuto(CS_Status* status) override;
-  void SetWhiteBalanceHoldCurrent(CS_Status* status) override;
-  void SetWhiteBalanceManual(int value, CS_Status* status) override;
-  void SetExposureAuto(CS_Status* status) override;
-  void SetExposureHoldCurrent(CS_Status* status) override;
-  void SetExposureManual(int value, CS_Status* status) override;
-
   bool SetVideoMode(const VideoMode& mode, CS_Status* status) override;
 
   void NumSinksChanged() override;

--- a/cscore/src/main/native/cpp/SourceImpl.cpp
+++ b/cscore/src/main/native/cpp/SourceImpl.cpp
@@ -94,6 +94,39 @@ void SourceImpl::Wakeup() {
   m_frameCv.notify_all();
 }
 
+void SourceImpl::SetBrightness(int brightness, CS_Status* status) {
+  *status = CS_INVALID_HANDLE;
+}
+
+int SourceImpl::GetBrightness(CS_Status* status) const {
+  *status = CS_INVALID_HANDLE;
+  return 0;
+}
+
+void SourceImpl::SetWhiteBalanceAuto(CS_Status* status) {
+  *status = CS_INVALID_HANDLE;
+}
+
+void SourceImpl::SetWhiteBalanceHoldCurrent(CS_Status* status) {
+  *status = CS_INVALID_HANDLE;
+}
+
+void SourceImpl::SetWhiteBalanceManual(int value, CS_Status* status) {
+  *status = CS_INVALID_HANDLE;
+}
+
+void SourceImpl::SetExposureAuto(CS_Status* status) {
+  *status = CS_INVALID_HANDLE;
+}
+
+void SourceImpl::SetExposureHoldCurrent(CS_Status* status) {
+  *status = CS_INVALID_HANDLE;
+}
+
+void SourceImpl::SetExposureManual(int value, CS_Status* status) {
+  *status = CS_INVALID_HANDLE;
+}
+
 VideoMode SourceImpl::GetVideoMode(CS_Status* status) const {
   if (!m_properties_cached && !CacheProperties(status)) return VideoMode{};
   std::lock_guard<wpi::mutex> lock(m_mutex);

--- a/cscore/src/main/native/cpp/SourceImpl.h
+++ b/cscore/src/main/native/cpp/SourceImpl.h
@@ -89,14 +89,14 @@ class SourceImpl : public PropertyContainer {
   void Wakeup();
 
   // Standard common camera properties
-  virtual void SetBrightness(int brightness, CS_Status* status) = 0;
-  virtual int GetBrightness(CS_Status* status) const = 0;
-  virtual void SetWhiteBalanceAuto(CS_Status* status) = 0;
-  virtual void SetWhiteBalanceHoldCurrent(CS_Status* status) = 0;
-  virtual void SetWhiteBalanceManual(int value, CS_Status* status) = 0;
-  virtual void SetExposureAuto(CS_Status* status) = 0;
-  virtual void SetExposureHoldCurrent(CS_Status* status) = 0;
-  virtual void SetExposureManual(int value, CS_Status* status) = 0;
+  virtual void SetBrightness(int brightness, CS_Status* status);
+  virtual int GetBrightness(CS_Status* status) const;
+  virtual void SetWhiteBalanceAuto(CS_Status* status);
+  virtual void SetWhiteBalanceHoldCurrent(CS_Status* status);
+  virtual void SetWhiteBalanceManual(int value, CS_Status* status);
+  virtual void SetExposureAuto(CS_Status* status);
+  virtual void SetExposureHoldCurrent(CS_Status* status);
+  virtual void SetExposureManual(int value, CS_Status* status);
 
   // Video mode functions
   VideoMode GetVideoMode(CS_Status* status) const;


### PR DESCRIPTION
This makes it easier to implement new non-camera Sources.