### PR TITLE
Revert "Use ASAN when on Clang (#1187)"

### DIFF
--- a/shared/googletest.gradle
+++ b/shared/googletest.gradle
@@ -10,13 +10,4 @@ model {
             staticConfigs = project.staticGtestConfigs
         }
     }
-    binaries {
-        withType(GoogleTestTestSuiteBinarySpec) {
-            if (toolChain instanceof Clang) {
-                println "Clang Detected - Using ASAN"
-                cppCompiler.args << '-fsanitize=address'
-                linker.args << '-fsanitize=address'
-            }
-        }
-    }
 }


### PR DESCRIPTION
This reverts commit 340b26badaac3eddf89e39e0cc8f293e09808fc3.

closes #1232 

We are going to revert this because it broke Mac builds.  The root cause of this is a requirement that the entire application must be built with asan to link properly.  For more information about why this is please see the link below.

https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow#false-positives