### PR TITLE
Header cleanup

### DIFF
--- a/cameraserver/src/main/native/include/cameraserver/CameraServer.h
+++ b/cameraserver/src/main/native/include/cameraserver/CameraServer.h
@@ -9,16 +9,11 @@
 
 #include <stdint.h>
 
-#include <atomic>
 #include <memory>
 #include <string>
-#include <vector>
 
-#include <networktables/NetworkTable.h>
-#include <wpi/DenseMap.h>
-#include <wpi/StringMap.h>
+#include <wpi/ArrayRef.h>
 #include <wpi/StringRef.h>
-#include <wpi/mutex.h>
 
 #include "cscore.h"
 
@@ -285,25 +280,10 @@ class CameraServer {
 
  private:
   CameraServer();
+  ~CameraServer();
 
-  std::shared_ptr<nt::NetworkTable> GetSourceTable(CS_Source source);
-  std::vector<std::string> GetSinkStreamValues(CS_Sink sink);
-  std::vector<std::string> GetSourceStreamValues(CS_Source source);
-  void UpdateStreamValues();
-
-  static constexpr char const* kPublishName = "/CameraPublisher";
-
-  wpi::mutex m_mutex;
-  std::atomic<int> m_defaultUsbDevice;
-  std::string m_primarySourceName;
-  wpi::StringMap<cs::VideoSource> m_sources;
-  wpi::StringMap<cs::VideoSink> m_sinks;
-  wpi::DenseMap<CS_Source, std::shared_ptr<nt::NetworkTable>> m_tables;
-  std::shared_ptr<nt::NetworkTable> m_publishTable;
-  cs::VideoListener m_videoListener;
-  int m_tableListener;
-  int m_nextPort;
-  std::vector<std::string> m_addresses;
+  struct Impl;
+  std::unique_ptr<Impl> m_impl;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/cpp/MotorSafetyHelper.cpp
+++ b/wpilibc/src/main/native/cpp/MotorSafetyHelper.cpp
@@ -7,6 +7,7 @@
 
 #include "frc/MotorSafetyHelper.h"
 
+#include <wpi/SmallPtrSet.h>
 #include <wpi/SmallString.h>
 #include <wpi/raw_ostream.h>
 
@@ -17,8 +18,8 @@
 
 using namespace frc;
 
-std::set<MotorSafetyHelper*> MotorSafetyHelper::m_helperList;
-wpi::mutex MotorSafetyHelper::m_listMutex;
+static wpi::SmallPtrSet<MotorSafetyHelper*, 32> helperList;
+static wpi::mutex listMutex;
 
 MotorSafetyHelper::MotorSafetyHelper(MotorSafety* safeObject)
     : m_safeObject(safeObject) {
@@ -26,13 +27,13 @@ MotorSafetyHelper::MotorSafetyHelper(MotorSafety* safeObject)
   m_expiration = DEFAULT_SAFETY_EXPIRATION;
   m_stopTime = Timer::GetFPGATimestamp();
 
-  std::lock_guard<wpi::mutex> lock(m_listMutex);
-  m_helperList.insert(this);
+  std::lock_guard<wpi::mutex> lock(listMutex);
+  helperList.insert(this);
 }
 
 MotorSafetyHelper::~MotorSafetyHelper() {
-  std::lock_guard<wpi::mutex> lock(m_listMutex);
-  m_helperList.erase(this);
+  std::lock_guard<wpi::mutex> lock(listMutex);
+  helperList.erase(this);
 }
 
 void MotorSafetyHelper::Feed() {
@@ -89,8 +90,8 @@ bool MotorSafetyHelper::IsSafetyEnabled() const {
 }
 
 void MotorSafetyHelper::CheckMotors() {
-  std::lock_guard<wpi::mutex> lock(m_listMutex);
-  for (auto elem : m_helperList) {
+  std::lock_guard<wpi::mutex> lock(listMutex);
+  for (auto elem : helperList) {
     elem->Check();
   }
 }

--- a/wpilibc/src/main/native/cpp/commands/CommandGroup.cpp
+++ b/wpilibc/src/main/native/cpp/commands/CommandGroup.cpp
@@ -26,7 +26,7 @@ void CommandGroup::AddSequential(Command* command) {
 
   // Iterate through command->GetRequirements() and call Requires() on each
   // required subsystem
-  for (auto& requirement : command->GetRequirements()) Requires(requirement);
+  for (auto&& requirement : command->GetRequirements()) Requires(requirement);
 }
 
 void CommandGroup::AddSequential(Command* command, double timeout) {
@@ -47,7 +47,7 @@ void CommandGroup::AddSequential(Command* command, double timeout) {
 
   // Iterate through command->GetRequirements() and call Requires() on each
   // required subsystem
-  for (auto& requirement : command->GetRequirements()) Requires(requirement);
+  for (auto&& requirement : command->GetRequirements()) Requires(requirement);
 }
 
 void CommandGroup::AddParallel(Command* command) {
@@ -63,7 +63,7 @@ void CommandGroup::AddParallel(Command* command) {
 
   // Iterate through command->GetRequirements() and call Requires() on each
   // required subsystem
-  for (auto& requirement : command->GetRequirements()) Requires(requirement);
+  for (auto&& requirement : command->GetRequirements()) Requires(requirement);
 }
 
 void CommandGroup::AddParallel(Command* command, double timeout) {
@@ -84,7 +84,7 @@ void CommandGroup::AddParallel(Command* command, double timeout) {
 
   // Iterate through command->GetRequirements() and call Requires() on each
   // required subsystem
-  for (auto& requirement : command->GetRequirements()) Requires(requirement);
+  for (auto&& requirement : command->GetRequirements()) Requires(requirement);
 }
 
 bool CommandGroup::IsInterruptible() const {
@@ -229,7 +229,7 @@ void CommandGroup::CancelConflicts(Command* command) {
     Command* child = (*childIter)->m_command;
     bool erased = false;
 
-    for (auto& requirement : command->GetRequirements()) {
+    for (auto&& requirement : command->GetRequirements()) {
       if (child->DoesRequire(requirement)) {
         child->_Cancel();
         child->Removed();

--- a/wpilibc/src/main/native/cpp/commands/ConditionalCommand.cpp
+++ b/wpilibc/src/main/native/cpp/commands/ConditionalCommand.cpp
@@ -7,8 +7,6 @@
 
 #include "frc/commands/ConditionalCommand.h"
 
-#include <iostream>
-
 #include "frc/commands/Scheduler.h"
 
 using namespace frc;

--- a/wpilibc/src/main/native/cpp/commands/Scheduler.cpp
+++ b/wpilibc/src/main/native/cpp/commands/Scheduler.cpp
@@ -8,7 +8,6 @@
 #include "frc/commands/Scheduler.h"
 
 #include <algorithm>
-#include <set>
 
 #include <hal/HAL.h>
 
@@ -100,7 +99,7 @@ void Scheduler::Remove(Command* command) {
 
   if (!m_commands.erase(command)) return;
 
-  for (auto& requirement : command->GetRequirements()) {
+  for (auto&& requirement : command->GetRequirements()) {
     requirement->SetCurrentCommand(nullptr);
   }
 
@@ -186,7 +185,7 @@ void Scheduler::ProcessCommandAddition(Command* command) {
   auto found = m_commands.find(command);
   if (found == m_commands.end()) {
     // Check that the requirements can be had
-    Command::SubsystemSet requirements = command->GetRequirements();
+    const auto& requirements = command->GetRequirements();
     for (const auto& requirement : requirements) {
       if (requirement->GetCurrentCommand() != nullptr &&
           !requirement->GetCurrentCommand()->IsInterruptible())
@@ -195,7 +194,7 @@ void Scheduler::ProcessCommandAddition(Command* command) {
 
     // Give it the requirements
     m_adding = true;
-    for (auto& requirement : requirements) {
+    for (auto&& requirement : requirements) {
       if (requirement->GetCurrentCommand() != nullptr) {
         requirement->GetCurrentCommand()->Cancel();
         Remove(requirement->GetCurrentCommand());

--- a/wpilibc/src/main/native/cpp/commands/Scheduler.cpp
+++ b/wpilibc/src/main/native/cpp/commands/Scheduler.cpp
@@ -8,15 +8,42 @@
 #include "frc/commands/Scheduler.h"
 
 #include <algorithm>
+#include <set>
+#include <string>
+#include <vector>
 
 #include <hal/HAL.h>
+#include <networktables/NetworkTableEntry.h>
+#include <wpi/mutex.h>
 
 #include "frc/WPIErrors.h"
 #include "frc/buttons/ButtonScheduler.h"
+#include "frc/commands/Command.h"
 #include "frc/commands/Subsystem.h"
 #include "frc/smartdashboard/SendableBuilder.h"
 
 using namespace frc;
+
+struct Scheduler::Impl {
+  void Remove(Command* command);
+  void ProcessCommandAddition(Command* command);
+
+  typedef std::set<Subsystem*> SubsystemSet;
+  SubsystemSet subsystems;
+  wpi::mutex buttonsMutex;
+  typedef std::vector<std::unique_ptr<ButtonScheduler>> ButtonVector;
+  ButtonVector buttons;
+  typedef std::vector<Command*> CommandVector;
+  wpi::mutex additionsMutex;
+  CommandVector additions;
+  typedef std::set<Command*> CommandSet;
+  CommandSet commands;
+  bool adding = false;
+  bool enabled = true;
+  std::vector<std::string> commandsBuf;
+  std::vector<double> idsBuf;
+  bool runningCommandsChanged = false;
+};
 
 Scheduler* Scheduler::GetInstance() {
   static Scheduler instance;
@@ -24,16 +51,16 @@ Scheduler* Scheduler::GetInstance() {
 }
 
 void Scheduler::AddCommand(Command* command) {
-  std::lock_guard<wpi::mutex> lock(m_additionsMutex);
-  if (std::find(m_additions.begin(), m_additions.end(), command) !=
-      m_additions.end())
+  std::lock_guard<wpi::mutex> lock(m_impl->additionsMutex);
+  if (std::find(m_impl->additions.begin(), m_impl->additions.end(), command) !=
+      m_impl->additions.end())
     return;
-  m_additions.push_back(command);
+  m_impl->additions.push_back(command);
 }
 
 void Scheduler::AddButton(ButtonScheduler* button) {
-  std::lock_guard<wpi::mutex> lock(m_buttonsMutex);
-  m_buttons.emplace_back(button);
+  std::lock_guard<wpi::mutex> lock(m_impl->buttonsMutex);
+  m_impl->buttons.emplace_back(button);
 }
 
 void Scheduler::RegisterSubsystem(Subsystem* subsystem) {
@@ -41,51 +68,63 @@ void Scheduler::RegisterSubsystem(Subsystem* subsystem) {
     wpi_setWPIErrorWithContext(NullParameter, "subsystem");
     return;
   }
-  m_subsystems.insert(subsystem);
+  m_impl->subsystems.insert(subsystem);
 }
 
 void Scheduler::Run() {
   // Get button input (going backwards preserves button priority)
   {
-    if (!m_enabled) return;
+    if (!m_impl->enabled) return;
 
-    std::lock_guard<wpi::mutex> lock(m_buttonsMutex);
-    for (auto& button : m_buttons) {
+    std::lock_guard<wpi::mutex> lock(m_impl->buttonsMutex);
+    for (auto& button : m_impl->buttons) {
       button->Execute();
     }
   }
 
   // Call every subsystem's periodic method
-  for (auto& subsystem : m_subsystems) {
+  for (auto& subsystem : m_impl->subsystems) {
     subsystem->Periodic();
   }
 
-  m_runningCommandsChanged = false;
+  m_impl->runningCommandsChanged = false;
 
   // Loop through the commands
-  for (auto cmdIter = m_commands.begin(); cmdIter != m_commands.end();) {
+  for (auto cmdIter = m_impl->commands.begin();
+       cmdIter != m_impl->commands.end();) {
     Command* command = *cmdIter;
     // Increment before potentially removing to keep the iterator valid
     ++cmdIter;
     if (!command->Run()) {
       Remove(command);
-      m_runningCommandsChanged = true;
+      m_impl->runningCommandsChanged = true;
     }
   }
 
   // Add the new things
   {
-    std::lock_guard<wpi::mutex> lock(m_additionsMutex);
-    for (auto& addition : m_additions) {
-      ProcessCommandAddition(addition);
+    std::lock_guard<wpi::mutex> lock(m_impl->additionsMutex);
+    for (auto& addition : m_impl->additions) {
+      // Check to make sure no adding during adding
+      if (m_impl->adding) {
+        wpi_setWPIErrorWithContext(IncompatibleState,
+                                   "Can not start command from cancel method");
+      } else {
+        m_impl->ProcessCommandAddition(addition);
+      }
     }
-    m_additions.clear();
+    m_impl->additions.clear();
   }
 
   // Add in the defaults
-  for (auto& subsystem : m_subsystems) {
+  for (auto& subsystem : m_impl->subsystems) {
     if (subsystem->GetCurrentCommand() == nullptr) {
-      ProcessCommandAddition(subsystem->GetDefaultCommand());
+      if (m_impl->adding) {
+        wpi_setWPIErrorWithContext(IncompatibleState,
+                                   "Can not start command from cancel method");
+      } else {
+        m_impl->ProcessCommandAddition(subsystem->GetDefaultCommand());
+      }
     }
     subsystem->ConfirmCommand();
   }
@@ -97,7 +136,72 @@ void Scheduler::Remove(Command* command) {
     return;
   }
 
-  if (!m_commands.erase(command)) return;
+  m_impl->Remove(command);
+}
+
+void Scheduler::RemoveAll() {
+  while (m_impl->commands.size() > 0) {
+    Remove(*m_impl->commands.begin());
+  }
+}
+
+void Scheduler::ResetAll() {
+  RemoveAll();
+  m_impl->subsystems.clear();
+  m_impl->buttons.clear();
+  m_impl->additions.clear();
+  m_impl->commands.clear();
+}
+
+void Scheduler::SetEnabled(bool enabled) { m_impl->enabled = enabled; }
+
+void Scheduler::InitSendable(SendableBuilder& builder) {
+  builder.SetSmartDashboardType("Scheduler");
+  auto namesEntry = builder.GetEntry("Names");
+  auto idsEntry = builder.GetEntry("Ids");
+  auto cancelEntry = builder.GetEntry("Cancel");
+  builder.SetUpdateTable([=]() {
+    // Get the list of possible commands to cancel
+    auto new_toCancel = cancelEntry.GetValue();
+    wpi::ArrayRef<double> toCancel;
+    if (new_toCancel) toCancel = new_toCancel->GetDoubleArray();
+
+    // Cancel commands whose cancel buttons were pressed on the SmartDashboard
+    if (!toCancel.empty()) {
+      for (auto& command : m_impl->commands) {
+        for (const auto& cancelled : toCancel) {
+          if (command->GetID() == cancelled) {
+            command->Cancel();
+          }
+        }
+      }
+      nt::NetworkTableEntry(cancelEntry).SetDoubleArray({});
+    }
+
+    // Set the running commands
+    if (m_impl->runningCommandsChanged) {
+      m_impl->commandsBuf.resize(0);
+      m_impl->idsBuf.resize(0);
+      for (const auto& command : m_impl->commands) {
+        m_impl->commandsBuf.emplace_back(command->GetName());
+        m_impl->idsBuf.emplace_back(command->GetID());
+      }
+      nt::NetworkTableEntry(namesEntry).SetStringArray(m_impl->commandsBuf);
+      nt::NetworkTableEntry(idsEntry).SetDoubleArray(m_impl->idsBuf);
+    }
+  });
+}
+
+Scheduler::Scheduler() : m_impl(new Impl) {
+  HAL_Report(HALUsageReporting::kResourceType_Command,
+             HALUsageReporting::kCommand_Scheduler);
+  SetName("Scheduler");
+}
+
+Scheduler::~Scheduler() {}
+
+void Scheduler::Impl::Remove(Command* command) {
+  if (!commands.erase(command)) return;
 
   for (auto&& requirement : command->GetRequirements()) {
     requirement->SetCurrentCommand(nullptr);
@@ -106,84 +210,12 @@ void Scheduler::Remove(Command* command) {
   command->Removed();
 }
 
-void Scheduler::RemoveAll() {
-  while (m_commands.size() > 0) {
-    Remove(*m_commands.begin());
-  }
-}
-
-void Scheduler::ResetAll() {
-  RemoveAll();
-  m_subsystems.clear();
-  m_buttons.clear();
-  m_additions.clear();
-  m_commands.clear();
-  m_namesEntry = nt::NetworkTableEntry();
-  m_idsEntry = nt::NetworkTableEntry();
-  m_cancelEntry = nt::NetworkTableEntry();
-}
-
-void Scheduler::SetEnabled(bool enabled) { m_enabled = enabled; }
-
-void Scheduler::InitSendable(SendableBuilder& builder) {
-  builder.SetSmartDashboardType("Scheduler");
-  m_namesEntry = builder.GetEntry("Names");
-  m_idsEntry = builder.GetEntry("Ids");
-  m_cancelEntry = builder.GetEntry("Cancel");
-  builder.SetUpdateTable([=]() {
-    // Get the list of possible commands to cancel
-    auto new_toCancel = m_cancelEntry.GetValue();
-    if (new_toCancel)
-      toCancel = new_toCancel->GetDoubleArray();
-    else
-      toCancel.resize(0);
-
-    // Cancel commands whose cancel buttons were pressed on the SmartDashboard
-    if (!toCancel.empty()) {
-      for (auto& command : m_commands) {
-        for (const auto& cancelled : toCancel) {
-          if (command->GetID() == cancelled) {
-            command->Cancel();
-          }
-        }
-      }
-      toCancel.resize(0);
-      m_cancelEntry.SetDoubleArray(toCancel);
-    }
-
-    // Set the running commands
-    if (m_runningCommandsChanged) {
-      commands.resize(0);
-      ids.resize(0);
-      for (const auto& command : m_commands) {
-        commands.emplace_back(command->GetName());
-        ids.emplace_back(command->GetID());
-      }
-      m_namesEntry.SetStringArray(commands);
-      m_idsEntry.SetDoubleArray(ids);
-    }
-  });
-}
-
-Scheduler::Scheduler() {
-  HAL_Report(HALUsageReporting::kResourceType_Command,
-             HALUsageReporting::kCommand_Scheduler);
-  SetName("Scheduler");
-}
-
-void Scheduler::ProcessCommandAddition(Command* command) {
+void Scheduler::Impl::ProcessCommandAddition(Command* command) {
   if (command == nullptr) return;
 
-  // Check to make sure no adding during adding
-  if (m_adding) {
-    wpi_setWPIErrorWithContext(IncompatibleState,
-                               "Can not start command from cancel method");
-    return;
-  }
-
   // Only add if not already in
-  auto found = m_commands.find(command);
-  if (found == m_commands.end()) {
+  auto found = commands.find(command);
+  if (found == commands.end()) {
     // Check that the requirements can be had
     const auto& requirements = command->GetRequirements();
     for (const auto& requirement : requirements) {
@@ -193,7 +225,7 @@ void Scheduler::ProcessCommandAddition(Command* command) {
     }
 
     // Give it the requirements
-    m_adding = true;
+    adding = true;
     for (auto&& requirement : requirements) {
       if (requirement->GetCurrentCommand() != nullptr) {
         requirement->GetCurrentCommand()->Cancel();
@@ -201,11 +233,11 @@ void Scheduler::ProcessCommandAddition(Command* command) {
       }
       requirement->SetCurrentCommand(command);
     }
-    m_adding = false;
+    adding = false;
 
-    m_commands.insert(command);
+    commands.insert(command);
 
     command->StartRunning();
-    m_runningCommandsChanged = true;
+    runningCommandsChanged = true;
   }
 }

--- a/wpilibc/src/main/native/include/frc/MotorSafetyHelper.h
+++ b/wpilibc/src/main/native/include/frc/MotorSafetyHelper.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <set>
-
 #include <wpi/mutex.h>
 
 #include "frc/ErrorBase.h"
@@ -114,12 +112,6 @@ class MotorSafetyHelper : public ErrorBase {
 
   // The object that is using the helper
   MotorSafety* m_safeObject;
-
-  // List of all existing MotorSafetyHelper objects.
-  static std::set<MotorSafetyHelper*> m_helperList;
-
-  // Protect accesses to the list of helpers
-  static wpi::mutex m_listMutex;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/commands/Command.h
+++ b/wpilibc/src/main/native/include/frc/commands/Command.h
@@ -8,18 +8,18 @@
 #pragma once
 
 #include <memory>
-#include <set>
 #include <string>
 
+#include <wpi/SmallPtrSet.h>
 #include <wpi/Twine.h>
 
 #include "frc/ErrorBase.h"
+#include "frc/commands/Subsystem.h"
 #include "frc/smartdashboard/SendableBase.h"
 
 namespace frc {
 
 class CommandGroup;
-class Subsystem;
 
 /**
  * The Command class is at the very core of the entire command framework.
@@ -186,7 +186,7 @@ class Command : public ErrorBase, public SendableBase {
    */
   bool DoesRequire(Subsystem* subsystem) const;
 
-  typedef std::set<Subsystem*> SubsystemSet;
+  typedef wpi::SmallPtrSetImpl<Subsystem*> SubsystemSet;
 
   /**
    * Returns the requirements (as an std::set of Subsystem pointers) of this
@@ -393,7 +393,7 @@ class Command : public ErrorBase, public SendableBase {
   bool m_initialized = false;
 
   // The requirements (or null if no requirements)
-  SubsystemSet m_requirements;
+  wpi::SmallPtrSet<Subsystem*, 4> m_requirements;
 
   // Whether or not it is running
   bool m_running = false;

--- a/wpilibc/src/main/native/include/frc/commands/Scheduler.h
+++ b/wpilibc/src/main/native/include/frc/commands/Scheduler.h
@@ -8,20 +8,14 @@
 #pragma once
 
 #include <memory>
-#include <set>
-#include <string>
-#include <vector>
-
-#include <networktables/NetworkTableEntry.h>
-#include <wpi/mutex.h>
 
 #include "frc/ErrorBase.h"
-#include "frc/commands/Command.h"
 #include "frc/smartdashboard/SendableBase.h"
 
 namespace frc {
 
 class ButtonScheduler;
+class Command;
 class Subsystem;
 
 class Scheduler : public ErrorBase, public SendableBase {
@@ -91,29 +85,10 @@ class Scheduler : public ErrorBase, public SendableBase {
 
  private:
   Scheduler();
-  ~Scheduler() override = default;
+  ~Scheduler() override;
 
-  void ProcessCommandAddition(Command* command);
-
-  typedef std::set<Subsystem*> SubsystemSet;
-  SubsystemSet m_subsystems;
-  wpi::mutex m_buttonsMutex;
-  typedef std::vector<std::unique_ptr<ButtonScheduler>> ButtonVector;
-  ButtonVector m_buttons;
-  typedef std::vector<Command*> CommandVector;
-  wpi::mutex m_additionsMutex;
-  CommandVector m_additions;
-  typedef std::set<Command*> CommandSet;
-  CommandSet m_commands;
-  bool m_adding = false;
-  bool m_enabled = true;
-  std::vector<std::string> commands;
-  std::vector<double> ids;
-  std::vector<double> toCancel;
-  nt::NetworkTableEntry m_namesEntry;
-  nt::NetworkTableEntry m_idsEntry;
-  nt::NetworkTableEntry m_cancelEntry;
-  bool m_runningCommandsChanged = false;
+  struct Impl;
+  std::unique_ptr<Impl> m_impl;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/commands/Scheduler.h
+++ b/wpilibc/src/main/native/include/frc/commands/Scheduler.h
@@ -95,7 +95,8 @@ class Scheduler : public ErrorBase, public SendableBase {
 
   void ProcessCommandAddition(Command* command);
 
-  Command::SubsystemSet m_subsystems;
+  typedef std::set<Subsystem*> SubsystemSet;
+  SubsystemSet m_subsystems;
   wpi::mutex m_buttonsMutex;
   typedef std::vector<std::unique_ptr<ButtonScheduler>> ButtonVector;
   ButtonVector m_buttons;

--- a/wpiutil/src/main/native/include/wpi/SmallPtrSet.h
+++ b/wpiutil/src/main/native/include/wpi/SmallPtrSet.h
@@ -383,7 +383,7 @@ public:
 private:
   /// Create an iterator that dereferences to same place as the given pointer.
   iterator makeIterator(const void *const *P) const {
-    return iterator(P, EndPointer(), *this);
+    return iterator(P, EndPointer());
   }
 };
 


### PR DESCRIPTION
Remove a number of header dependencies by replacing std::set with wpi::SmallPtrSet and using the Pimpl idiom for Scheduler and CameraServer.

Fixes #414.