### PR TITLE
SendableChooser: Rename addDefault and addObject for clarity

### DIFF
--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.h
@@ -11,6 +11,7 @@
 
 #include <wpi/StringMap.h>
 #include <wpi/StringRef.h>
+#include <wpi/deprecated.h>
 
 #include "frc/smartdashboard/SendableBuilder.h"
 #include "frc/smartdashboard/SendableChooserBase.h"
@@ -46,8 +47,16 @@ class SendableChooser : public SendableChooserBase {
  public:
   ~SendableChooser() override = default;
 
-  void AddObject(wpi::StringRef name, T object);
-  void AddDefault(wpi::StringRef name, T object);
+  void AddOption(wpi::StringRef name, T object);
+  void SetDefaultOption(wpi::StringRef name, T object);
+
+  WPI_DEPRECATED("use AddOption() instead")
+  void AddObject(wpi::StringRef name, T object) { AddOption(name, object); }
+
+  WPI_DEPRECATED("use SetDefaultOption() instead")
+  void AddDefault(wpi::StringRef name, T object) {
+    SetDefaultOption(name, object);
+  }
 
   auto GetSelected() -> decltype(_unwrap_smart_ptr(m_choices[""]));
 

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.inc
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.inc
@@ -27,23 +27,23 @@ namespace frc {
  * @param object the option
  */
 template <class T>
-void SendableChooser<T>::AddObject(wpi::StringRef name, T object) {
+void SendableChooser<T>::AddOption(wpi::StringRef name, T object) {
   m_choices[name] = std::move(object);
 }
 
 /**
  * Add the given object to the list of options and marks it as the default.
  *
- * Functionally, this is very close to AddObject() except that it will use this
+ * Functionally, this is very close to AddOption() except that it will use this
  * as the default option if none other is explicitly selected.
  *
  * @param name   the name of the option
  * @param object the option
  */
 template <class T>
-void SendableChooser<T>::AddDefault(wpi::StringRef name, T object) {
+void SendableChooser<T>::SetDefaultOption(wpi::StringRef name, T object) {
   m_defaultChoice = name;
-  AddObject(name, std::move(object));
+  AddOption(name, std::move(object));
 }
 
 /**

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/Robot.cpp
@@ -29,8 +29,8 @@ void Robot::RobotInit() {
   frc::SmartDashboard::PutData(&pneumatics);
 
   // instantiate the command used for the autonomous period
-  m_autoChooser.AddDefault("Drive and Shoot", &m_driveAndShootAuto);
-  m_autoChooser.AddObject("Drive Forward", &m_driveForwardAuto);
+  m_autoChooser.SetDefaultOption("Drive and Shoot", &m_driveAndShootAuto);
+  m_autoChooser.AddOption("Drive Forward", &m_driveForwardAuto);
   frc::SmartDashboard::PutData("Auto Mode", &m_autoChooser);
 
   pneumatics.Start();  // Pressurize the pneumatics.

--- a/wpilibcExamples/src/main/cpp/templates/commandbased/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandbased/cpp/Robot.cpp
@@ -14,8 +14,8 @@ ExampleSubsystem Robot::m_subsystem;
 OI Robot::m_oi;
 
 void Robot::RobotInit() {
-  m_chooser.AddDefault("Default Auto", &m_defaultAuto);
-  m_chooser.AddObject("My Auto", &m_myAuto);
+  m_chooser.SetDefaultOption("Default Auto", &m_defaultAuto);
+  m_chooser.AddOption("My Auto", &m_myAuto);
   frc::SmartDashboard::PutData("Auto Modes", &m_chooser);
 }
 

--- a/wpilibcExamples/src/main/cpp/templates/iterative/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/iterative/cpp/Robot.cpp
@@ -12,8 +12,8 @@
 #include <frc/smartdashboard/SmartDashboard.h>
 
 void Robot::RobotInit() {
-  m_chooser.AddDefault(kAutoNameDefault, kAutoNameDefault);
-  m_chooser.AddObject(kAutoNameCustom, kAutoNameCustom);
+  m_chooser.SetDefaultOption(kAutoNameDefault, kAutoNameDefault);
+  m_chooser.AddOption(kAutoNameCustom, kAutoNameCustom);
   frc::SmartDashboard::PutData("Auto Modes", &m_chooser);
 }
 

--- a/wpilibcExamples/src/main/cpp/templates/sample/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/sample/cpp/Robot.cpp
@@ -19,8 +19,8 @@ Robot::Robot() {
 }
 
 void Robot::RobotInit() {
-  m_chooser.AddDefault(kAutoNameDefault, kAutoNameDefault);
-  m_chooser.AddObject(kAutoNameCustom, kAutoNameCustom);
+  m_chooser.SetDefaultOption(kAutoNameDefault, kAutoNameDefault);
+  m_chooser.AddOption(kAutoNameCustom, kAutoNameCustom);
   frc::SmartDashboard::PutData("Auto Modes", &m_chooser);
 }
 

--- a/wpilibcExamples/src/main/cpp/templates/timed/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/timed/cpp/Robot.cpp
@@ -12,8 +12,8 @@
 #include <frc/smartdashboard/SmartDashboard.h>
 
 void Robot::RobotInit() {
-  m_chooser.AddDefault(kAutoNameDefault, kAutoNameDefault);
-  m_chooser.AddObject(kAutoNameCustom, kAutoNameCustom);
+  m_chooser.SetDefaultOption(kAutoNameDefault, kAutoNameDefault);
+  m_chooser.AddOption(kAutoNameCustom, kAutoNameCustom);
   frc::SmartDashboard::PutData("Auto Modes", &m_chooser);
 }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
@@ -76,23 +76,49 @@ public class SendableChooser<V> extends SendableBase {
    * @param name   the name of the option
    * @param object the option
    */
-  public void addObject(String name, V object) {
+  public void addOption(String name, V object) {
     m_map.put(name, object);
   }
 
   /**
-   * Add the given object to the list of options and marks it as the default. Functionally, this is
-   * very close to {@link #addObject(String, Object)} except that it will use this as the default
+   * Adds the given object to the list of options.
+   *
+   * @deprecated Use {@link #addOption(String, Object)} instead.
+   *
+   * @param name   the name of the option
+   * @param object the option
+   */
+  @Deprecated
+  public void addObject(String name, V object) {
+    addOption(name, object);
+  }
+
+  /**
+   * Adds the given object to the list of options and marks it as the default. Functionally, this is
+   * very close to {@link #addOption(String, Object)} except that it will use this as the default
    * option if none other is explicitly selected.
    *
    * @param name   the name of the option
    * @param object the option
    */
-  public void addDefault(String name, V object) {
+  public void setDefaultOption(String name, V object) {
     requireNonNull(name, "Provided name was null");
 
     m_defaultChoice = name;
-    addObject(name, object);
+    addOption(name, object);
+  }
+
+  /**
+   * Adds the given object to the list of options and marks it as the default.
+   *
+   * @deprecated Use {@link #setDefaultOption(String, Object)} instead.
+   *
+   * @param name   the name of the option
+   * @param object the option
+   */
+  @Deprecated
+  public void addDefault(String name, V object) {
+    setDefaultOption(name, object);
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/Robot.java
@@ -62,8 +62,8 @@ public class Robot extends IterativeRobot {
 
     // instantiate the command used for the autonomous period
     m_autoChooser = new SendableChooser<Command>();
-    m_autoChooser.addDefault("Drive and Shoot", new DriveAndShootAutonomous());
-    m_autoChooser.addObject("Drive Forward", new DriveForward());
+    m_autoChooser.setDefaultOption("Drive and Shoot", new DriveAndShootAutonomous());
+    m_autoChooser.addOption("Drive Forward", new DriveForward());
     SmartDashboard.putData("Auto Mode", m_autoChooser);
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbased/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbased/Robot.java
@@ -36,8 +36,8 @@ public class Robot extends TimedRobot {
   @Override
   public void robotInit() {
     m_oi = new OI();
-    m_chooser.addDefault("Default Auto", new ExampleCommand());
-    // chooser.addObject("My Auto", new MyAutoCommand());
+    m_chooser.setDefaultOption("Default Auto", new ExampleCommand());
+    // chooser.addOption("My Auto", new MyAutoCommand());
     SmartDashboard.putData("Auto mode", m_chooser);
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/iterative/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/iterative/Robot.java
@@ -30,8 +30,8 @@ public class Robot extends IterativeRobot {
    */
   @Override
   public void robotInit() {
-    m_chooser.addDefault("Default Auto", kDefaultAuto);
-    m_chooser.addObject("My Auto", kCustomAuto);
+    m_chooser.setDefaultOption("Default Auto", kDefaultAuto);
+    m_chooser.addOption("My Auto", kCustomAuto);
     SmartDashboard.putData("Auto choices", m_chooser);
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/sample/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/sample/Robot.java
@@ -47,8 +47,8 @@ public class Robot extends SampleRobot {
 
   @Override
   public void robotInit() {
-    m_chooser.addDefault("Default Auto", kDefaultAuto);
-    m_chooser.addObject("My Auto", kCustomAuto);
+    m_chooser.setDefaultOption("Default Auto", kDefaultAuto);
+    m_chooser.addOption("My Auto", kCustomAuto);
     SmartDashboard.putData("Auto modes", m_chooser);
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/timed/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/timed/Robot.java
@@ -30,8 +30,8 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotInit() {
-    m_chooser.addDefault("Default Auto", kDefaultAuto);
-    m_chooser.addObject("My Auto", kCustomAuto);
+    m_chooser.setDefaultOption("Default Auto", kDefaultAuto);
+    m_chooser.addOption("My Auto", kCustomAuto);
     SmartDashboard.putData("Auto choices", m_chooser);
   }
 


### PR DESCRIPTION
Rename addDefault to setDefaultOption and addObject to addOption.

The old names are still available but are marked as deprecated.