### PR TITLE
Fix JavaDoc generation

### DIFF
--- a/cameraserver/src/main/java/edu/wpi/first/wpilibj/vision/VisionRunner.java
+++ b/cameraserver/src/main/java/edu/wpi/first/wpilibj/vision/VisionRunner.java
@@ -20,7 +20,7 @@ import edu.wpi.first.wpilibj.CameraServerSharedStore;
  *
  * @see VisionPipeline
  * @see VisionThread
- * @see edu.wpi.first.wpilibj.vision
+ * @see <a href="package-summary.html">vision</a>
  */
 public class VisionRunner<P extends VisionPipeline> {
   private final CvSink m_cvSink = new CvSink("VisionRunner CvSink");

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -96,9 +96,9 @@ ext {
 apply from: "${rootDir}/shared/opencv.gradle"
 
 task generateJavaDocs(type: Javadoc) {
-    javadoc.options.links("http://docs.oracle.com/javase/8/docs/api/")
+    options.links("https://docs.oracle.com/javase/8/docs/api/")
     options.addStringOption "tag", "pre:a:Pre-Condition"
-    options.addStringOption('Xdoclint:accessibility,syntax,html', '-quiet')
+    options.addStringOption('Xdoclint:accessibility,html,missing,reference,syntax')
     dependsOn project(':wpilibj').generateJavaVersion
     source project(':hal').sourceSets.main.java
     source project(':wpiutil').sourceSets.main.java


### PR DESCRIPTION
JavaDoc cannot handle redirects so HTTP link does not work anymore.  It also looks like javadoc.options was the wrong thing to set.  Options properly connects external docs to ours.  I also reenabled warnings so these things will pop out if they turn up again.

closes #1233 