### PR TITLE
cscore: Add connection strategy to sources

### DIFF
--- a/cscore/src/main/java/edu/wpi/cscore/CameraServerJNI.java
+++ b/cscore/src/main/java/edu/wpi/cscore/CameraServerJNI.java
@@ -79,7 +79,9 @@ public class CameraServerJNI {
   public static native String getSourceName(int source);
   public static native String getSourceDescription(int source);
   public static native long getSourceLastFrameTime(int source);
+  public static native void setSourceConnectionStrategy(int source, int strategy);
   public static native boolean isSourceConnected(int source);
+  public static native boolean isSourceEnabled(int source);
   public static native int getSourceProperty(int source, String name);
   public static native int[] enumerateSourceProperties(int source);
   public static native VideoMode getSourceVideoMode(int source);

--- a/cscore/src/main/java/edu/wpi/cscore/VideoSource.java
+++ b/cscore/src/main/java/edu/wpi/cscore/VideoSource.java
@@ -153,11 +153,12 @@ public class VideoSource implements AutoCloseable {
   }
 
   /**
-   * Set the connection strategy.  By default, the source will automatically
+   * Sets the connection strategy.  By default, the source will automatically
    * connect or disconnect based on whether any sinks are connected.
    *
    * <p>This function is non-blocking; look for either a connection open or
-   * close event or call IsConnected() to determine the connection state.
+   * close event or call {@link #isConnected()} to determine the connection
+   * state.
    *
    * @param strategy connection strategy (auto, keep open, or force close)
    */
@@ -173,7 +174,7 @@ public class VideoSource implements AutoCloseable {
   }
 
   /**
-   * Get source enable status.  This is determined with a combination of
+   * Gets source enable status.  This is determined with a combination of
    * connection strategy and the number of sinks connected.
    *
    * @return True if enabled, false otherwise.

--- a/cscore/src/main/java/edu/wpi/cscore/VideoSource.java
+++ b/cscore/src/main/java/edu/wpi/cscore/VideoSource.java
@@ -29,6 +29,40 @@ public class VideoSource implements AutoCloseable {
   }
 
   /**
+   * Connection strategy.
+   */
+  public enum ConnectionStrategy {
+    /**
+     * Automatically connect or disconnect based on whether any sinks are
+     * connected to this source.  This is the default behavior.
+     */
+    kAutoManage(0),
+
+    /**
+     * Try to keep the connection open regardless of whether any sinks are
+     * connected.
+     */
+    kKeepOpen(1),
+
+    /**
+     * Never open the connection.  If this is set when the connection is open,
+     * close the connection.
+     */
+    kForceClose(2);
+
+    @SuppressWarnings("MemberName")
+    private final int value;
+
+    ConnectionStrategy(int value) {
+      this.value = value;
+    }
+
+    public int getValue() {
+      return value;
+    }
+  }
+
+  /**
    * Convert from the numerical representation of kind to an enum type.
    *
    * @param kind The numerical representation of kind
@@ -119,10 +153,33 @@ public class VideoSource implements AutoCloseable {
   }
 
   /**
+   * Set the connection strategy.  By default, the source will automatically
+   * connect or disconnect based on whether any sinks are connected.
+   *
+   * <p>This function is non-blocking; look for either a connection open or
+   * close event or call IsConnected() to determine the connection state.
+   *
+   * @param strategy connection strategy (auto, keep open, or force close)
+   */
+  public void setConnectionStrategy(ConnectionStrategy strategy) {
+    CameraServerJNI.setSourceConnectionStrategy(m_handle, strategy.getValue());
+  }
+
+  /**
    * Returns if the source currently connected to whatever is providing the images.
    */
   public boolean isConnected() {
     return CameraServerJNI.isSourceConnected(m_handle);
+  }
+
+  /**
+   * Get source enable status.  This is determined with a combination of
+   * connection strategy and the number of sinks connected.
+   *
+   * @return True if enabled, false otherwise.
+   */
+  public boolean isEnabled() {
+    return CameraServerJNI.isSourceEnabled(m_handle);
   }
 
   /**

--- a/cscore/src/main/native/cpp/SourceImpl.h
+++ b/cscore/src/main/native/cpp/SourceImpl.h
@@ -41,6 +41,15 @@ class SourceImpl : public PropertyContainer {
   void SetDescription(const wpi::Twine& description);
   wpi::StringRef GetDescription(wpi::SmallVectorImpl<char>& buf) const;
 
+  void SetConnectionStrategy(CS_ConnectionStrategy strategy) {
+    m_strategy = static_cast<int>(strategy);
+  }
+  bool IsEnabled() const {
+    return m_strategy == CS_CONNECTION_KEEP_OPEN ||
+           (m_strategy == CS_CONNECTION_AUTO_MANAGE && m_numSinksEnabled > 0);
+  }
+
+  // User-visible connection status
   void SetConnected(bool connected);
   bool IsConnected() const { return m_connected; }
 
@@ -130,7 +139,6 @@ class SourceImpl : public PropertyContainer {
   virtual void NumSinksEnabledChanged() = 0;
 
   std::atomic_int m_numSinks{0};
-  std::atomic_int m_numSinksEnabled{0};
 
  protected:
   // Cached video modes (protected with m_mutex)
@@ -145,6 +153,9 @@ class SourceImpl : public PropertyContainer {
 
   std::string m_name;
   std::string m_description;
+
+  std::atomic_int m_strategy{CS_CONNECTION_AUTO_MANAGE};
+  std::atomic_int m_numSinksEnabled{0};
 
   wpi::mutex m_frameMutex;
   wpi::condition_variable m_frameCv;

--- a/cscore/src/main/native/cpp/UsbCameraImpl.cpp
+++ b/cscore/src/main/native/cpp/UsbCameraImpl.cpp
@@ -309,10 +309,10 @@ void UsbCameraImpl::CameraThreadMain() {
       }
     }
 
-    // Turn off streaming if no one is listening, and turn it on if there is.
-    if (m_streaming && m_numSinksEnabled == 0) {
+    // Turn off streaming if not enabled, and turn it on if enabled
+    if (m_streaming && !IsEnabled()) {
       DeviceStreamOff();
-    } else if (!m_streaming && m_numSinksEnabled > 0) {
+    } else if (!m_streaming && IsEnabled()) {
       DeviceStreamOn();
     }
 

--- a/cscore/src/main/native/cpp/cscore_c.cpp
+++ b/cscore/src/main/native/cpp/cscore_c.cpp
@@ -99,8 +99,18 @@ uint64_t CS_GetSourceLastFrameTime(CS_Source source, CS_Status* status) {
   return cs::GetSourceLastFrameTime(source, status);
 }
 
+void CS_SetSourceConnectionStrategy(CS_Source source,
+                                    CS_ConnectionStrategy strategy,
+                                    CS_Status* status) {
+  cs::SetSourceConnectionStrategy(source, strategy, status);
+}
+
 CS_Bool CS_IsSourceConnected(CS_Source source, CS_Status* status) {
   return cs::IsSourceConnected(source, status);
+}
+
+CS_Bool CS_IsSourceEnabled(CS_Source source, CS_Status* status) {
+  return cs::IsSourceEnabled(source, status);
 }
 
 CS_Property CS_GetSourceProperty(CS_Source source, const char* name,

--- a/cscore/src/main/native/cpp/cscore_cpp.cpp
+++ b/cscore/src/main/native/cpp/cscore_cpp.cpp
@@ -222,6 +222,17 @@ uint64_t GetSourceLastFrameTime(CS_Source source, CS_Status* status) {
   return data->source->GetCurFrameTime();
 }
 
+void SetSourceConnectionStrategy(CS_Source source,
+                                 CS_ConnectionStrategy strategy,
+                                 CS_Status* status) {
+  auto data = Sources::GetInstance().Get(source);
+  if (!data) {
+    *status = CS_INVALID_HANDLE;
+    return;
+  }
+  data->source->SetConnectionStrategy(strategy);
+}
+
 bool IsSourceConnected(CS_Source source, CS_Status* status) {
   auto data = Sources::GetInstance().Get(source);
   if (!data) {
@@ -229,6 +240,15 @@ bool IsSourceConnected(CS_Source source, CS_Status* status) {
     return false;
   }
   return data->source->IsConnected();
+}
+
+bool IsSourceEnabled(CS_Source source, CS_Status* status) {
+  auto data = Sources::GetInstance().Get(source);
+  if (!data) {
+    *status = CS_INVALID_HANDLE;
+    return false;
+  }
+  return data->source->IsEnabled();
 }
 
 CS_Property GetSourceProperty(CS_Source source, const wpi::Twine& name,

--- a/cscore/src/main/native/cpp/jni/CameraServerJNI.cpp
+++ b/cscore/src/main/native/cpp/jni/CameraServerJNI.cpp
@@ -601,6 +601,21 @@ Java_edu_wpi_cscore_CameraServerJNI_getSourceLastFrameTime
 
 /*
  * Class:     edu_wpi_cscore_CameraServerJNI
+ * Method:    setSourceConnectionStrategy
+ * Signature: (II)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_cscore_CameraServerJNI_setSourceConnectionStrategy
+  (JNIEnv* env, jclass, jint source, jint strategy)
+{
+  CS_Status status = 0;
+  cs::SetSourceConnectionStrategy(
+      source, static_cast<CS_ConnectionStrategy>(strategy), &status);
+  CheckStatus(env, status);
+}
+
+/*
+ * Class:     edu_wpi_cscore_CameraServerJNI
  * Method:    isSourceConnected
  * Signature: (I)Z
  */
@@ -610,6 +625,21 @@ Java_edu_wpi_cscore_CameraServerJNI_isSourceConnected
 {
   CS_Status status = 0;
   auto val = cs::IsSourceConnected(source, &status);
+  CheckStatus(env, status);
+  return val;
+}
+
+/*
+ * Class:     edu_wpi_cscore_CameraServerJNI
+ * Method:    isSourceEnabled
+ * Signature: (I)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_cscore_CameraServerJNI_isSourceEnabled
+  (JNIEnv* env, jclass, jint source)
+{
+  CS_Status status = 0;
+  auto val = cs::IsSourceEnabled(source, &status);
   CheckStatus(env, status);
   return val;
 }

--- a/cscore/src/main/native/include/cscore_c.h
+++ b/cscore/src/main/native/include/cscore_c.h
@@ -178,6 +178,27 @@ enum CS_TelemetryKind {
   CS_SOURCE_FRAMES_RECEIVED = 2
 };
 
+/** Connection strategy */
+enum CS_ConnectionStrategy {
+  /**
+   * Automatically connect or disconnect based on whether any sinks are
+   * connected to this source.  This is the default behavior.
+   */
+  CS_CONNECTION_AUTO_MANAGE = 0,
+
+  /**
+   * Try to keep the connection open regardless of whether any sinks are
+   * connected.
+   */
+  CS_CONNECTION_KEEP_OPEN,
+
+  /**
+   * Never open the connection.  If this is set when the connection is open,
+   * close the connection.
+   */
+  CS_CONNECTION_FORCE_CLOSE
+};
+
 /**
  * Listener event
  */
@@ -245,7 +266,11 @@ enum CS_SourceKind CS_GetSourceKind(CS_Source source, CS_Status* status);
 char* CS_GetSourceName(CS_Source source, CS_Status* status);
 char* CS_GetSourceDescription(CS_Source source, CS_Status* status);
 uint64_t CS_GetSourceLastFrameTime(CS_Source source, CS_Status* status);
+void CS_SetSourceConnectionStrategy(CS_Source source,
+                                    enum CS_ConnectionStrategy strategy,
+                                    CS_Status* status);
 CS_Bool CS_IsSourceConnected(CS_Source source, CS_Status* status);
+CS_Bool CS_IsSourceEnabled(CS_Source source, CS_Status* status);
 CS_Property CS_GetSourceProperty(CS_Source source, const char* name,
                                  CS_Status* status);
 CS_Property* CS_EnumerateSourceProperties(CS_Source source, int* count,

--- a/cscore/src/main/native/include/cscore_cpp.h
+++ b/cscore/src/main/native/include/cscore_cpp.h
@@ -203,7 +203,11 @@ wpi::StringRef GetSourceDescription(CS_Source source,
                                     wpi::SmallVectorImpl<char>& buf,
                                     CS_Status* status);
 uint64_t GetSourceLastFrameTime(CS_Source source, CS_Status* status);
+void SetSourceConnectionStrategy(CS_Source source,
+                                 CS_ConnectionStrategy strategy,
+                                 CS_Status* status);
 bool IsSourceConnected(CS_Source source, CS_Status* status);
+bool IsSourceEnabled(CS_Source source, CS_Status* status);
 CS_Property GetSourceProperty(CS_Source source, const wpi::Twine& name,
                               CS_Status* status);
 wpi::ArrayRef<CS_Property> EnumerateSourceProperties(

--- a/cscore/src/main/native/include/cscore_oo.h
+++ b/cscore/src/main/native/include/cscore_oo.h
@@ -168,7 +168,7 @@ class VideoSource {
   uint64_t GetLastFrameTime() const;
 
   /**
-   * Set the connection strategy.  By default, the source will automatically
+   * Sets the connection strategy.  By default, the source will automatically
    * connect or disconnect based on whether any sinks are connected.
    *
    * <p>This function is non-blocking; look for either a connection open or
@@ -184,7 +184,7 @@ class VideoSource {
   bool IsConnected() const;
 
   /**
-   * Get source enable status.  This is determined with a combination of
+   * Gets source enable status.  This is determined with a combination of
    * connection strategy and the number of sinks connected.
    *
    * @return True if enabled, false otherwise.

--- a/cscore/src/main/native/include/cscore_oo.h
+++ b/cscore/src/main/native/include/cscore_oo.h
@@ -106,6 +106,27 @@ class VideoSource {
     kCv = CS_SOURCE_CV
   };
 
+  /** Connection strategy.  Used for SetConnectionStrategy(). */
+  enum ConnectionStrategy {
+    /**
+     * Automatically connect or disconnect based on whether any sinks are
+     * connected to this source.  This is the default behavior.
+     */
+    kConnectionAutoManage = CS_CONNECTION_AUTO_MANAGE,
+
+    /**
+     * Try to keep the connection open regardless of whether any sinks are
+     * connected.
+     */
+    kConnectionKeepOpen = CS_CONNECTION_KEEP_OPEN,
+
+    /**
+     * Never open the connection.  If this is set when the connection is open,
+     * close the connection.
+     */
+    kConnectionForceClose = CS_CONNECTION_FORCE_CLOSE
+  };
+
   VideoSource() noexcept : m_handle(0) {}
   VideoSource(const VideoSource& source);
   VideoSource(VideoSource&& other) noexcept;
@@ -147,9 +168,28 @@ class VideoSource {
   uint64_t GetLastFrameTime() const;
 
   /**
+   * Set the connection strategy.  By default, the source will automatically
+   * connect or disconnect based on whether any sinks are connected.
+   *
+   * <p>This function is non-blocking; look for either a connection open or
+   * close event or call IsConnected() to determine the connection state.
+   *
+   * @param strategy connection strategy (auto, keep open, or force close)
+   */
+  void SetConnectionStrategy(ConnectionStrategy strategy);
+
+  /**
    * Is the source currently connected to whatever is providing the images?
    */
   bool IsConnected() const;
+
+  /**
+   * Get source enable status.  This is determined with a combination of
+   * connection strategy and the number of sinks connected.
+   *
+   * @return True if enabled, false otherwise.
+   */
+  bool IsEnabled() const;
 
   /** Get a property.
    *

--- a/cscore/src/main/native/include/cscore_oo.inl
+++ b/cscore/src/main/native/include/cscore_oo.inl
@@ -116,9 +116,21 @@ inline uint64_t VideoSource::GetLastFrameTime() const {
   return GetSourceLastFrameTime(m_handle, &m_status);
 }
 
+inline void VideoSource::SetConnectionStrategy(ConnectionStrategy strategy) {
+  m_status = 0;
+  SetSourceConnectionStrategy(
+      m_handle, static_cast<CS_ConnectionStrategy>(static_cast<int>(strategy)),
+      &m_status);
+}
+
 inline bool VideoSource::IsConnected() const {
   m_status = 0;
   return IsSourceConnected(m_handle, &m_status);
+}
+
+inline bool VideoSource::IsEnabled() const {
+  m_status = 0;
+  return IsSourceEnabled(m_handle, &m_status);
 }
 
 inline VideoProperty VideoSource::GetProperty(const wpi::Twine& name) {


### PR DESCRIPTION
By default, sources automatically manage their connection based on whether
any sinks are connected.  This change allows the user to keep a connection
open or force it closed regardless of the number of connected sinks.