### PR TITLE
Change ButtonScheduler scope start method to public. Closes #765

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/Trigger.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/Trigger.java
@@ -175,7 +175,7 @@ public abstract class Trigger extends SendableBase {
   public abstract static class ButtonScheduler {
     public abstract void execute();
 
-    protected void start() {
+    public void start() {
       Scheduler.getInstance().addButton(this);
     }
   }


### PR DESCRIPTION
Change's the scope. 

