### PR TITLE
Silence DriverStation Joystick Unplugged Warnings. Closes #962 - WIP

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -174,7 +174,7 @@ public class DriverStation {
   private final ControlWord m_controlWordCache;
   private long m_lastControlWordUpdate;
 
-  private static boolean m_silenceJoystickWarnings = false;
+  private boolean m_silenceJoystickWarnings = false;
 
   /**
    * Gets an instance of the DriverStation.
@@ -278,10 +278,7 @@ public class DriverStation {
   }
 
   private static void reportErrorImpl(boolean isError, int code, String error,
-      boolean printTrace, StackTraceElement[] stackTrace, int stackTraceFirst) {
-    if(m_silenceJoystickWarnings) {
-      return;
-    }
+                                      boolean printTrace, StackTraceElement[] stackTrace, int stackTraceFirst) {
     String locString;
     if (stackTrace.length >= stackTraceFirst + 1) {
       locString = stackTrace[stackTraceFirst].toString();
@@ -1111,14 +1108,19 @@ public class DriverStation {
    */
   private void reportJoystickUnpluggedWarning(String message) {
     double currentTime = Timer.getFPGATimestamp();
-    if (!m_silenceJoystickWarnings && currentTime > m_nextMessageTime ) {
+    if (currentTime > m_nextMessageTime) {
       reportWarning(message, false);
+      if (m_silenceJoystickWarnings) {
+        m_nextMessageTime = Double.POSITIVE_INFINITY;
+        return;
+      }
       m_nextMessageTime = currentTime + JOYSTICK_UNPLUGGED_MESSAGE_INTERVAL;
     }
   }
 
   /**
    * Sets whether to silence the DriverStation warning prints when a Joystick is unplugged.
+   *
    * @param silenced true to enable, false to disable silencing.
    */
   public void silenceJoystickUnplugged(boolean silenced) {
@@ -1126,17 +1128,18 @@ public class DriverStation {
   }
 
   /**
-   * Silence the DriverStation warning prints when a Joystick is unplugged.
+   * Silences the DriverStation warning prints when a Joystick is unplugged.
    */
   public void silenceJoystickUnplugged() {
     m_silenceJoystickWarnings = true;
   }
 
   /**
-   * Get whether the Joystick warnings are silenced.
+   * Gets whether the Joystick warnings are silenced.
+   *
    * @return true for silenced, false for printing.
    */
-  public boolean getJoystickWarnings() {
+  public boolean isJoystickUnplugSuppressed() {
     return m_silenceJoystickWarnings;
   }
 


### PR DESCRIPTION
Only suppressed the reportJoystickUnpluggedWarning because the Error counterpart is used to alert for the index error. Something that could be a legitimate issue.

I put it into the time check condition, but put it first so it can short circuit faster if enabled.

silenceJoystickUnplugged(boolean silenced) allows a toggling as needed (for example, teams having a debugging controller that prints certain messages)

silenceJoystickUnplugged() enables silencing.

getJoystickWarngins() - Get whether the warnings are suppressed.
I couldn't think of a good name for this, as the others I had in mind were either cumbersome or not grammatically correct.

Currently working on a unit test for this, will squash when the unit test is added.