### PR TITLE
Add Lambda Support to InstantCommand for C++ and Java

### DIFF
--- a/wpilibc/src/main/native/cpp/commands/InstantCommand.cpp
+++ b/wpilibc/src/main/native/cpp/commands/InstantCommand.cpp
@@ -16,4 +16,30 @@ InstantCommand::InstantCommand(Subsystem& subsystem) : Command(subsystem) {}
 InstantCommand::InstantCommand(const wpi::Twine& name, Subsystem& subsystem)
     : Command(name, subsystem) {}
 
+InstantCommand::InstantCommand(std::function<void()> func) : m_func(func) {}
+
+InstantCommand::InstantCommand(Subsystem& subsystem, std::function<void()> func)
+    : InstantCommand(subsystem) {
+  m_func = func;
+}
+
+InstantCommand::InstantCommand(const wpi::Twine& name,
+                               std::function<void()> func)
+    : InstantCommand(name) {
+  m_func = func;
+}
+
+InstantCommand::InstantCommand(const wpi::Twine& name, Subsystem& subsystem,
+                               std::function<void()> func)
+    : InstantCommand(name, subsystem) {
+  m_func = func;
+}
+
+void InstantCommand::_Initialize() {
+  Command::_Initialize();
+  if (m_func) {
+    m_func();
+  }
+}
+
 bool InstantCommand::IsFinished() { return true; }

--- a/wpilibc/src/main/native/include/frc/commands/InstantCommand.h
+++ b/wpilibc/src/main/native/include/frc/commands/InstantCommand.h
@@ -7,9 +7,12 @@
 
 #pragma once
 
+#include <functional>
+
 #include <wpi/Twine.h>
 
 #include "frc/commands/Command.h"
+#include "frc/commands/Subsystem.h"
 
 namespace frc {
 
@@ -42,10 +45,45 @@ class InstantCommand : public Command {
    */
   InstantCommand(const wpi::Twine& name, Subsystem& subsystem);
 
+  /**
+   * Create a command that calls the given function when run.
+   *
+   * @param func The function to run when Initialize() is run.
+   */
+  explicit InstantCommand(std::function<void()> func);
+
+  /**
+   * Create a command that calls the given function when run.
+   *
+   * @param subsystem The subsystems that this command runs on.
+   * @param func      The function to run when Initialize() is run.
+   */
+  InstantCommand(Subsystem& subsystem, std::function<void()> func);
+
+  /**
+   * Create a command that calls the given function when run.
+   *
+   * @param name   The name of the command.
+   * @param func   The function to run when Initialize() is run.
+   */
+  InstantCommand(const wpi::Twine& name, std::function<void()> func);
+
+  /**
+   * Create a command that calls the given function when run.
+   *
+   * @param name      The name of the command.
+   * @param subsystem The subsystems that this command runs on.
+   * @param func      The function to run when Initialize() is run.
+   */
+  InstantCommand(const wpi::Twine& name, Subsystem& subsystem,
+                 std::function<void()> func);
+
   InstantCommand() = default;
   virtual ~InstantCommand() = default;
 
  protected:
+  std::function<void()> m_func = nullptr;
+  void _Initialize() override;
   bool IsFinished() override;
 };
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/InstantCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/InstantCommand.java
@@ -14,11 +14,14 @@ package edu.wpi.first.wpilibj.command;
  * {@link Command isFinished}.
  */
 public class InstantCommand extends Command {
+  private Runnable m_func;
+
   public InstantCommand() {
   }
 
   /**
    * Creates a new {@link InstantCommand InstantCommand} with the given name.
+   *
    * @param name the name for this command
    */
   public InstantCommand(String name) {
@@ -27,6 +30,7 @@ public class InstantCommand extends Command {
 
   /**
    * Creates a new {@link InstantCommand InstantCommand} with the given requirement.
+   *
    * @param subsystem the subsystem this command requires
    */
   public InstantCommand(Subsystem subsystem) {
@@ -35,6 +39,7 @@ public class InstantCommand extends Command {
 
   /**
    * Creates a new {@link InstantCommand InstantCommand} with the given name and requirement.
+   *
    * @param name      the name for this command
    * @param subsystem the subsystem this command requires
    */
@@ -42,8 +47,64 @@ public class InstantCommand extends Command {
     super(name, subsystem);
   }
 
+  /**
+   * Creates a new {@link InstantCommand InstantCommand}.
+   *
+   * @param func the function to run when {@link Command#initialize() initialize()} is run
+   */
+  public InstantCommand(Runnable func) {
+    m_func = func;
+  }
+
+  /**
+   * Creates a new {@link InstantCommand InstantCommand}.
+   *
+   * @param name the name for this command
+   * @param func the function to run when {@link Command#initialize() initialize()} is run
+   */
+  public InstantCommand(String name, Runnable func) {
+    super(name);
+    m_func = func;
+  }
+
+  /**
+   * Creates a new {@link InstantCommand InstantCommand}.
+   *
+   * @param requirement the subsystem this command requires
+   * @param func        the function to run when {@link Command#initialize() initialize()} is run
+   */
+  public InstantCommand(Subsystem requirement, Runnable func) {
+    super(requirement);
+    m_func = func;
+  }
+
+  /**
+   * Creates a new {@link InstantCommand InstantCommand}.
+   *
+   * @param name        the name for this command
+   * @param requirement the subsystem this command requires
+   * @param func        the function to run when {@link Command#initialize() initialize()} is run
+   */
+  public InstantCommand(String name, Subsystem requirement, Runnable func) {
+    super(name, requirement);
+    m_func = func;
+  }
+
   @Override
   protected boolean isFinished() {
     return true;
+  }
+
+  /**
+   * Trigger the stored function.
+   *
+   * <p>Called just before this Command runs the first time.
+   */
+  @Override
+  protected void _initialize() {
+    super._initialize();
+    if (m_func != null) {
+      m_func.run();
+    }
   }
 }


### PR DESCRIPTION
An ActionCommand is derived from a concept from the [RobotDotNet implementation of WPIlib](https://github.com/robotdotnet/WPILib/blob/master/WPILib.Extras/ActionCommand.cs). The core concept is that it "lifts" a language-native callable to become a Command.

It also is influenced by RobotDotNet's [SubsystemCommand](https://github.com/robotdotnet/WPILib/blob/master/WPILib.Extras/SubsystemCommand.cs) class, which I plan on making a PR for in the future. The rationale for this is that it allows declarative command creation, like so:

```java
    public Command closeOuter() {                                                                                                                             
        return new ActionCommand("Close Outer Manipulator", this, this::closeOuterManipulator);                         
    }
    private void closeOuterManipulator() {
        // ...
    }

    public Command openOuter() {
        return new ActionCommand("Open Outer Manipulator", this, () -> {
            // Lambdas are also accepted
        });
    }
```

This allows the same class to be used for "simple" commands as well as ones that need to require a subsystem, in a declarative syntax that allows for simpler development of "instant" commands.

I'm open to elaborate on use cases or questions if desired, as can @bot190