### PR TITLE
Enable HTML5 javadocs

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -100,6 +100,7 @@ task generateJavaDocs(type: Javadoc) {
     options.links("https://docs.oracle.com/javase/8/docs/api/")
     options.addStringOption "tag", "pre:a:Pre-Condition"
     options.addStringOption('Xdoclint:accessibility,html,missing,reference,syntax')
+    options.addBooleanOption('html5', true)
     dependsOn project(':wpilibj').generateJavaVersion
     dependsOn project(':hal').generateUsageReporting
     source project(':hal').sourceSets.main.java


### PR DESCRIPTION
This will suppress the following warning during build:

>javadoc: warning - You have not specified the version of HTML to use.
The default is currently HTML 4.01, but this will change to HTML5
in a future release. To suppress this warning, please specify the
version of HTML used in your documentation comments and to be
generated by this doclet, using the -html4 or -html5 options.