### PR TITLE
Add sim names

### DIFF
--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXL345_I2CAccelerometerData.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXL345_I2CAccelerometerData.cpp
@@ -40,6 +40,10 @@ ADXL345_I2CData::~ADXL345_I2CData() {
   HALSIM_CancelI2CWriteCallback(m_port, m_writeCallbackId);
 }
 
+bool ADXL345_I2CData::GetInitialized() {
+  return HALSIM_GetI2CInitialized(m_port);
+}
+
 void ADXL345_I2CData::ADXL345_I2CData::HandleWrite(const uint8_t* buffer,
                                                    uint32_t count) {
   m_lastWriteAddress = buffer[0];

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXL345_I2CAccelerometerData.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXL345_I2CAccelerometerData.cpp
@@ -40,7 +40,7 @@ ADXL345_I2CData::~ADXL345_I2CData() {
   HALSIM_CancelI2CWriteCallback(m_port, m_writeCallbackId);
 }
 
-bool ADXL345_I2CData::GetInitialized() {
+bool ADXL345_I2CData::GetInitialized() const {
   return HALSIM_GetI2CInitialized(m_port);
 }
 

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXL345_SpiAccelerometerData.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXL345_SpiAccelerometerData.cpp
@@ -40,7 +40,7 @@ ADXL345_SpiAccelerometer::~ADXL345_SpiAccelerometer() {
   HALSIM_CancelSPIWriteCallback(m_port, m_writeCallbackId);
 }
 
-bool ADXL345_SpiAccelerometer::GetInitialized() {
+bool ADXL345_SpiAccelerometer::GetInitialized() const {
   return HALSIM_GetSPIInitialized(m_port);
 }
 

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXL345_SpiAccelerometerData.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXL345_SpiAccelerometerData.cpp
@@ -40,6 +40,10 @@ ADXL345_SpiAccelerometer::~ADXL345_SpiAccelerometer() {
   HALSIM_CancelSPIWriteCallback(m_port, m_writeCallbackId);
 }
 
+bool ADXL345_SpiAccelerometer::GetInitialized() {
+  return HALSIM_GetSPIInitialized(m_port);
+}
+
 void ADXL345_SpiAccelerometer::HandleWrite(const uint8_t* buffer,
                                            uint32_t count) {
   m_lastWriteAddress = buffer[0] & 0xF;

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXL362_SpiAccelerometerData.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXL362_SpiAccelerometerData.cpp
@@ -39,6 +39,9 @@ ADXL362_SpiAccelerometer::~ADXL362_SpiAccelerometer() {
   HALSIM_CancelSPIReadCallback(m_port, m_readCallbackId);
   HALSIM_CancelSPIWriteCallback(m_port, m_writeCallbackId);
 }
+bool ADXL362_SpiAccelerometer::GetInitialized() {
+  return HALSIM_GetSPIInitialized(m_port);
+}
 
 void ADXL362_SpiAccelerometer::HandleWrite(const uint8_t* buffer,
                                            uint32_t count) {

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXL362_SpiAccelerometerData.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXL362_SpiAccelerometerData.cpp
@@ -39,7 +39,7 @@ ADXL362_SpiAccelerometer::~ADXL362_SpiAccelerometer() {
   HALSIM_CancelSPIReadCallback(m_port, m_readCallbackId);
   HALSIM_CancelSPIWriteCallback(m_port, m_writeCallbackId);
 }
-bool ADXL362_SpiAccelerometer::GetInitialized() {
+bool ADXL362_SpiAccelerometer::GetInitialized() const {
   return HALSIM_GetSPIInitialized(m_port);
 }
 

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXRS450_SpiGyroWrapperData.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXRS450_SpiGyroWrapperData.cpp
@@ -57,7 +57,7 @@ ADXRS450_SpiGyroWrapper::~ADXRS450_SpiGyroWrapper() {
   HALSIM_CancelSPIReadAutoReceivedDataCallback(m_port,
                                                m_autoReceiveReadCallbackId);
 }
-bool ADXRS450_SpiGyroWrapper::GetInitialized() {
+bool ADXRS450_SpiGyroWrapper::GetInitialized() const {
   return HALSIM_GetSPIInitialized(m_port);
 }
 

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXRS450_SpiGyroWrapperData.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXRS450_SpiGyroWrapperData.cpp
@@ -57,6 +57,9 @@ ADXRS450_SpiGyroWrapper::~ADXRS450_SpiGyroWrapper() {
   HALSIM_CancelSPIReadAutoReceivedDataCallback(m_port,
                                                m_autoReceiveReadCallbackId);
 }
+bool ADXRS450_SpiGyroWrapper::GetInitialized() {
+  return HALSIM_GetSPIInitialized(m_port);
+}
 
 void ADXRS450_SpiGyroWrapper::ResetData() {
   std::lock_guard<wpi::mutex> lock(m_dataMutex);

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXL345_I2CAccelerometerData.h
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXL345_I2CAccelerometerData.h
@@ -15,6 +15,8 @@ class ADXL345_I2CData : public ThreeAxisAccelerometerData {
   explicit ADXL345_I2CData(int port);
   virtual ~ADXL345_I2CData();
 
+  bool GetInitialized() override;
+
   void HandleWrite(const uint8_t* buffer, uint32_t count);
   void HandleRead(uint8_t* buffer, uint32_t count);
 

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXL345_I2CAccelerometerData.h
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXL345_I2CAccelerometerData.h
@@ -15,7 +15,7 @@ class ADXL345_I2CData : public ThreeAxisAccelerometerData {
   explicit ADXL345_I2CData(int port);
   virtual ~ADXL345_I2CData();
 
-  bool GetInitialized() override;
+  bool GetInitialized() const override;
 
   void HandleWrite(const uint8_t* buffer, uint32_t count);
   void HandleRead(uint8_t* buffer, uint32_t count);

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXL345_SpiAccelerometerData.h
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXL345_SpiAccelerometerData.h
@@ -15,7 +15,7 @@ class ADXL345_SpiAccelerometer : public ThreeAxisAccelerometerData {
   explicit ADXL345_SpiAccelerometer(int port);
   virtual ~ADXL345_SpiAccelerometer();
 
-  bool GetInitialized() override;
+  bool GetInitialized() const override;
 
   void HandleWrite(const uint8_t* buffer, uint32_t count);
   void HandleRead(uint8_t* buffer, uint32_t count);

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXL345_SpiAccelerometerData.h
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXL345_SpiAccelerometerData.h
@@ -15,6 +15,8 @@ class ADXL345_SpiAccelerometer : public ThreeAxisAccelerometerData {
   explicit ADXL345_SpiAccelerometer(int port);
   virtual ~ADXL345_SpiAccelerometer();
 
+  bool GetInitialized() override;
+
   void HandleWrite(const uint8_t* buffer, uint32_t count);
   void HandleRead(uint8_t* buffer, uint32_t count);
 

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXL362_SpiAccelerometerData.h
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXL362_SpiAccelerometerData.h
@@ -15,7 +15,7 @@ class ADXL362_SpiAccelerometer : public ThreeAxisAccelerometerData {
   explicit ADXL362_SpiAccelerometer(int port);
   virtual ~ADXL362_SpiAccelerometer();
 
-  bool GetInitialized() override;
+  bool GetInitialized() const override;
 
   void HandleWrite(const uint8_t* buffer, uint32_t count);
   void HandleRead(uint8_t* buffer, uint32_t count);

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXL362_SpiAccelerometerData.h
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXL362_SpiAccelerometerData.h
@@ -15,6 +15,8 @@ class ADXL362_SpiAccelerometer : public ThreeAxisAccelerometerData {
   explicit ADXL362_SpiAccelerometer(int port);
   virtual ~ADXL362_SpiAccelerometer();
 
+  bool GetInitialized() override;
+
   void HandleWrite(const uint8_t* buffer, uint32_t count);
   void HandleRead(uint8_t* buffer, uint32_t count);
 

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXRS450_SpiGyroWrapperData.h
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXRS450_SpiGyroWrapperData.h
@@ -19,6 +19,8 @@ class ADXRS450_SpiGyroWrapper {
   explicit ADXRS450_SpiGyroWrapper(int port);
   virtual ~ADXRS450_SpiGyroWrapper();
 
+  bool GetInitialized();
+
   void HandleRead(uint8_t* buffer, uint32_t count);
   void HandleAutoReceiveData(uint8_t* buffer, int32_t numToRead,
                              int32_t& outputCount);

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXRS450_SpiGyroWrapperData.h
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXRS450_SpiGyroWrapperData.h
@@ -19,7 +19,7 @@ class ADXRS450_SpiGyroWrapper {
   explicit ADXRS450_SpiGyroWrapper(int port);
   virtual ~ADXRS450_SpiGyroWrapper();
 
-  bool GetInitialized();
+  bool GetInitialized() const;
 
   void HandleRead(uint8_t* buffer, uint32_t count);
   void HandleAutoReceiveData(uint8_t* buffer, int32_t numToRead,

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ThreeAxisAccelerometerData.h
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ThreeAxisAccelerometerData.h
@@ -19,7 +19,7 @@ class ThreeAxisAccelerometerData {
   ThreeAxisAccelerometerData();
   virtual ~ThreeAxisAccelerometerData();
 
-  virtual bool GetInitialized() = 0;
+  virtual bool GetInitialized() const = 0;
 
   int32_t RegisterXCallback(HAL_NotifyCallback callback, void* param,
                             HAL_Bool initialNotify);

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ThreeAxisAccelerometerData.h
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ThreeAxisAccelerometerData.h
@@ -19,6 +19,8 @@ class ThreeAxisAccelerometerData {
   ThreeAxisAccelerometerData();
   virtual ~ThreeAxisAccelerometerData();
 
+  virtual bool GetInitialized() = 0;
+
   int32_t RegisterXCallback(HAL_NotifyCallback callback, void* param,
                             HAL_Bool initialNotify);
   void CancelXCallback(int32_t uid);

--- a/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/SimulatorComponentBase.cpp
+++ b/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/SimulatorComponentBase.cpp
@@ -11,7 +11,9 @@ namespace frc {
 namespace sim {
 namespace lowfi {
 
-const std::string& SimulatorComponentBase::GetDisplayName() const { return m_name; }
+const std::string& SimulatorComponentBase::GetDisplayName() const {
+  return m_name;
+}
 
 void SimulatorComponentBase::SetDisplayName(const std::string& displayName) {
   m_name = displayName;

--- a/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/SimulatorComponentBase.cpp
+++ b/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/SimulatorComponentBase.cpp
@@ -5,25 +5,14 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-/*
- * SimulatorComponentBase.cpp
- *
- *  Created on: Aug 12, 2018
- *      Author: PJ
- */
-
 #include "lowfisim/SimulatorComponentBase.h"
 
 namespace frc {
 namespace sim {
 namespace lowfi {
-SimulatorComponentBase::SimulatorComponentBase() {
-  // TODO Auto-generated constructor stub
-}
+SimulatorComponentBase::SimulatorComponentBase() {}
 
-SimulatorComponentBase::~SimulatorComponentBase() {
-  // TODO Auto-generated destructor stub
-}
+SimulatorComponentBase::~SimulatorComponentBase() {}
 
 const std::string& SimulatorComponentBase::GetDisplayName() { return m_name; }
 

--- a/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/SimulatorComponentBase.cpp
+++ b/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/SimulatorComponentBase.cpp
@@ -5,25 +5,30 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-#include "lowfisim/wpisimulators/WpiEncoderSim.h"
+/*
+ * SimulatorComponentBase.cpp
+ *
+ *  Created on: Aug 12, 2018
+ *      Author: PJ
+ */
+
+#include "lowfisim/SimulatorComponentBase.h"
 
 namespace frc {
 namespace sim {
 namespace lowfi {
-
-WpiEncoderSim::WpiEncoderSim(int index) : m_encoderSimulator(index) {}
-
-bool WpiEncoderSim::IsWrapperInitialized() {
-  return m_encoderSimulator.GetInitialized();
+SimulatorComponentBase::SimulatorComponentBase() {
+  // TODO Auto-generated constructor stub
 }
 
-void WpiEncoderSim::SetPosition(double position) {
-  m_encoderSimulator.SetCount(
-      static_cast<int>(position / m_encoderSimulator.GetDistancePerPulse()));
+SimulatorComponentBase::~SimulatorComponentBase() {
+  // TODO Auto-generated destructor stub
 }
 
-void WpiEncoderSim::SetVelocity(double velocity) {
-  m_encoderSimulator.SetPeriod(1.0 / velocity);
+const std::string& SimulatorComponentBase::GetDisplayName() { return m_name; }
+
+void SimulatorComponentBase::SetDisplayName(const std::string& displayName) {
+  m_name = displayName;
 }
 
 }  // namespace lowfi

--- a/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/SimulatorComponentBase.cpp
+++ b/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/SimulatorComponentBase.cpp
@@ -10,11 +10,8 @@
 namespace frc {
 namespace sim {
 namespace lowfi {
-SimulatorComponentBase::SimulatorComponentBase() {}
 
-SimulatorComponentBase::~SimulatorComponentBase() {}
-
-const std::string& SimulatorComponentBase::GetDisplayName() { return m_name; }
+const std::string& SimulatorComponentBase::GetDisplayName() const { return m_name; }
 
 void SimulatorComponentBase::SetDisplayName(const std::string& displayName) {
   m_name = displayName;

--- a/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/ADXLThreeAxisAccelerometerSim.cpp
+++ b/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/ADXLThreeAxisAccelerometerSim.cpp
@@ -14,21 +14,30 @@ namespace lowfi {
 ADXLThreeAxisAccelerometerSim::ADXLThreeAxisAccelerometerSim(
     hal::ThreeAxisAccelerometerData& accelerometerWrapper)
     : m_accelerometerWrapper(accelerometerWrapper),
-      m_xWrapper(std::function<void(double)>(
+      m_xWrapper(std::function<bool(void)>(
+                     std::bind(&hal::ThreeAxisAccelerometerData::GetInitialized,
+                               &m_accelerometerWrapper)),
+                 std::function<void(double)>(
                      std::bind(&hal::ThreeAxisAccelerometerData::SetX,
                                &m_accelerometerWrapper, std::placeholders::_1)),
                  std::function<double(void)>(
                      std::bind(&hal::ThreeAxisAccelerometerData::GetX,
                                &m_accelerometerWrapper))),
 
-      m_yWrapper(std::function<void(double)>(
+      m_yWrapper(std::function<bool(void)>(
+                     std::bind(&hal::ThreeAxisAccelerometerData::GetInitialized,
+                               &m_accelerometerWrapper)),
+                 std::function<void(double)>(
                      std::bind(&hal::ThreeAxisAccelerometerData::SetY,
                                &m_accelerometerWrapper, std::placeholders::_1)),
                  std::function<double(void)>(
                      std::bind(&hal::ThreeAxisAccelerometerData::GetY,
                                &m_accelerometerWrapper))),
 
-      m_zWrapper(std::function<void(double)>(
+      m_zWrapper(std::function<bool(void)>(
+                     std::bind(&hal::ThreeAxisAccelerometerData::GetInitialized,
+                               &m_accelerometerWrapper)),
+                 std::function<void(double)>(
                      std::bind(&hal::ThreeAxisAccelerometerData::SetZ,
                                &m_accelerometerWrapper, std::placeholders::_1)),
                  std::function<double(void)>(

--- a/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/ADXRS450_SpiGyroSim.cpp
+++ b/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/ADXRS450_SpiGyroSim.cpp
@@ -14,7 +14,7 @@ namespace lowfi {
 ADXRS450_SpiGyroSim::ADXRS450_SpiGyroSim(int spiPort)
     : m_gyroWrapper(spiPort) {}
 
-bool ADXRS450_SpiGyroSim::IsWrapperInitialized() {
+bool ADXRS450_SpiGyroSim::IsWrapperInitialized() const {
   return m_gyroWrapper.GetInitialized();
 }
 

--- a/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/ADXRS450_SpiGyroSim.cpp
+++ b/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/ADXRS450_SpiGyroSim.cpp
@@ -14,6 +14,10 @@ namespace lowfi {
 ADXRS450_SpiGyroSim::ADXRS450_SpiGyroSim(int spiPort)
     : m_gyroWrapper(spiPort) {}
 
+bool ADXRS450_SpiGyroSim::IsWrapperInitialized() {
+  return m_gyroWrapper.GetInitialized();
+}
+
 void ADXRS450_SpiGyroSim::SetAngle(double angle) {
   m_gyroWrapper.SetAngle(angle);
 }

--- a/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/WpiAnalogGyroSim.cpp
+++ b/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/WpiAnalogGyroSim.cpp
@@ -13,7 +13,7 @@ namespace lowfi {
 
 WpiAnalogGyroSim::WpiAnalogGyroSim(int index) : m_gyroSimulator(index) {}
 
-bool WpiAnalogGyroSim::IsWrapperInitialized() {
+bool WpiAnalogGyroSim::IsWrapperInitialized() const {
   return m_gyroSimulator.GetInitialized();
 }
 

--- a/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/WpiAnalogGyroSim.cpp
+++ b/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/WpiAnalogGyroSim.cpp
@@ -13,6 +13,10 @@ namespace lowfi {
 
 WpiAnalogGyroSim::WpiAnalogGyroSim(int index) : m_gyroSimulator(index) {}
 
+bool WpiAnalogGyroSim::IsWrapperInitialized() {
+  return m_gyroSimulator.GetInitialized();
+}
+
 void WpiAnalogGyroSim::SetAngle(double angle) {
   m_gyroSimulator.SetAngle(angle);
 }

--- a/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/WpiEncoderSim.cpp
+++ b/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/WpiEncoderSim.cpp
@@ -13,7 +13,7 @@ namespace lowfi {
 
 WpiEncoderSim::WpiEncoderSim(int index) : m_encoderSimulator(index) {}
 
-bool WpiEncoderSim::IsWrapperInitialized() {
+bool WpiEncoderSim::IsWrapperInitialized() const {
   return m_encoderSimulator.GetInitialized();
 }
 

--- a/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/WpiMotorSim.cpp
+++ b/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/WpiMotorSim.cpp
@@ -20,6 +20,10 @@ void WpiMotorSim::Update(double elapsedTime) {
   m_motorModelSimulation.Update(elapsedTime);
 }
 
+bool WpiMotorSim::IsWrapperInitialized() {
+  return m_pwmSimulator.GetInitialized();
+}
+
 double WpiMotorSim::GetPosition() const {
   return m_motorModelSimulation.GetPosition();
 }

--- a/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/WpiMotorSim.cpp
+++ b/simulation/lowfi_simulation/src/main/native/cpp/lowfisim/wpisimulators/WpiMotorSim.cpp
@@ -20,7 +20,7 @@ void WpiMotorSim::Update(double elapsedTime) {
   m_motorModelSimulation.Update(elapsedTime);
 }
 
-bool WpiMotorSim::IsWrapperInitialized() {
+bool WpiMotorSim::IsWrapperInitialized() const {
   return m_pwmSimulator.GetInitialized();
 }
 

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/AccelerometerSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/AccelerometerSim.h
@@ -7,11 +7,13 @@
 
 #pragma once
 
+#include "lowfisim/SimulatorComponent.h"
+
 namespace frc {
 namespace sim {
 namespace lowfi {
 
-class AccelerometerSim {
+class AccelerometerSim : public virtual SimulatorComponent {
  public:
   virtual double GetAcceleration() = 0;
   virtual void SetAcceleration(double acceleration) = 0;

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/EncoderSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/EncoderSim.h
@@ -7,11 +7,13 @@
 
 #pragma once
 
+#include "lowfisim/SimulatorComponent.h"
+
 namespace frc {
 namespace sim {
 namespace lowfi {
 
-class EncoderSim {
+class EncoderSim : public virtual SimulatorComponent {
  public:
   virtual void SetPosition(double position) = 0;
   virtual void SetVelocity(double velocity) = 0;

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/GyroSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/GyroSim.h
@@ -7,11 +7,13 @@
 
 #pragma once
 
+#include "lowfisim/SimulatorComponent.h"
+
 namespace frc {
 namespace sim {
 namespace lowfi {
 
-class GyroSim {
+class GyroSim : public virtual SimulatorComponent {
  public:
   virtual void SetAngle(double angle) = 0;
   virtual double GetAngle() = 0;

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/MotorSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/MotorSim.h
@@ -7,11 +7,13 @@
 
 #pragma once
 
+#include "lowfisim/SimulatorComponent.h"
+
 namespace frc {
 namespace sim {
 namespace lowfi {
 
-class MotorSim {
+class MotorSim : public virtual SimulatorComponent {
  public:
   virtual double GetPosition() const = 0;
   virtual double GetVelocity() const = 0;

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimpleAccelerometerSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimpleAccelerometerSim.h
@@ -33,7 +33,7 @@ class SimpleAccelerometerSim : public SimulatorComponentBase,
     m_setAccelerationFunction(acceleration);
   }
 
-  bool IsWrapperInitialized() override { return m_isInitializedFunction(); }
+  bool IsWrapperInitialized() const override { return m_isInitializedFunction(); }
 
  private:
   std::function<bool(void)> m_isInitializedFunction;

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimpleAccelerometerSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimpleAccelerometerSim.h
@@ -33,7 +33,9 @@ class SimpleAccelerometerSim : public SimulatorComponentBase,
     m_setAccelerationFunction(acceleration);
   }
 
-  bool IsWrapperInitialized() const override { return m_isInitializedFunction(); }
+  bool IsWrapperInitialized() const override {
+    return m_isInitializedFunction();
+  }
 
  private:
   std::function<bool(void)> m_isInitializedFunction;

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimpleAccelerometerSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimpleAccelerometerSim.h
@@ -10,16 +10,22 @@
 #include <functional>
 
 #include "lowfisim/AccelerometerSim.h"
+#include "lowfisim/SimulatorComponentBase.h"
 
 namespace frc {
 namespace sim {
 namespace lowfi {
 
-class SimpleAccelerometerSim : public AccelerometerSim {
+class SimpleAccelerometerSim : public SimulatorComponentBase,
+                               public AccelerometerSim {
  public:
-  SimpleAccelerometerSim(const std::function<void(double)>& setterFunction,
+  using SimulatorComponentBase::GetDisplayName;
+
+  SimpleAccelerometerSim(const std::function<bool(void)>& initializedFunction,
+                         const std::function<void(double)>& setterFunction,
                          const std::function<double(void)>& getterFunction)
-      : m_setAccelerationFunction(setterFunction),
+      : m_isInitializedFunction(initializedFunction),
+        m_setAccelerationFunction(setterFunction),
         m_getAccelerationFunction(getterFunction) {}
   double GetAcceleration() override { return m_getAccelerationFunction(); }
 
@@ -27,7 +33,10 @@ class SimpleAccelerometerSim : public AccelerometerSim {
     m_setAccelerationFunction(acceleration);
   }
 
+  bool IsWrapperInitialized() override { return m_isInitializedFunction(); }
+
  private:
+  std::function<bool(void)> m_isInitializedFunction;
   std::function<void(double)> m_setAccelerationFunction;
   std::function<double(void)> m_getAccelerationFunction;
 };

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponent.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponent.h
@@ -5,13 +5,6 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-/*
- * SimulatorComponent.h
- *
- *  Created on: Aug 12, 2018
- *      Author: PJ
- */
-
 #ifndef WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENT_H_
 #define WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENT_H_
 

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponent.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponent.h
@@ -15,11 +15,11 @@ namespace lowfi {
 
 class SimulatorComponent {
  public:
-  virtual ~SimulatorComponent() {}
+  virtual ~SimulatorComponent() = default;
 
   virtual bool IsWrapperInitialized() = 0;
 
-  virtual const std::string& GetDisplayName() = 0;
+  virtual const std::string& GetDisplayName() const = 0;
 
   virtual void SetDisplayName(const std::string& displayName) = 0;
 };

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponent.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponent.h
@@ -17,7 +17,7 @@ class SimulatorComponent {
  public:
   virtual ~SimulatorComponent() = default;
 
-  virtual bool IsWrapperInitialized() = 0;
+  virtual bool IsWrapperInitialized() const = 0;
 
   virtual const std::string& GetDisplayName() const = 0;
 

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponent.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponent.h
@@ -1,0 +1,39 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+/*
+ * SimulatorComponent.h
+ *
+ *  Created on: Aug 12, 2018
+ *      Author: PJ
+ */
+
+#ifndef WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENT_H_
+#define WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENT_H_
+
+#include <string>
+
+namespace frc {
+namespace sim {
+namespace lowfi {
+
+class SimulatorComponent {
+ public:
+  virtual ~SimulatorComponent() {}
+
+  virtual bool IsWrapperInitialized() = 0;
+
+  virtual const std::string& GetDisplayName() = 0;
+
+  virtual void SetDisplayName(const std::string& displayName) = 0;
+};
+
+}  // namespace lowfi
+}  // namespace sim
+}  // namespace frc
+
+#endif  // WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENT_H_

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponent.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponent.h
@@ -5,8 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-#ifndef WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENT_H_
-#define WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENT_H_
+#pragma once
 
 #include <string>
 
@@ -28,5 +27,3 @@ class SimulatorComponent {
 }  // namespace lowfi
 }  // namespace sim
 }  // namespace frc
-
-#endif  // WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENT_H_

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponentBase.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponentBase.h
@@ -5,15 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-/*
- * SimulatorComponentBase.h
- *
- *  Created on: Aug 12, 2018
- *      Author: PJ
- */
-
-#ifndef WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENTBASE_H_
-#define WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENTBASE_H_
+#pragma once
 
 #include <string>
 
@@ -39,5 +31,3 @@ class SimulatorComponentBase : public virtual SimulatorComponent {
 }  // namespace lowfi
 }  // namespace sim
 }  // namespace frc
-
-#endif  // WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENTBASE_H_

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponentBase.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponentBase.h
@@ -17,10 +17,10 @@ namespace lowfi {
 
 class SimulatorComponentBase : public virtual SimulatorComponent {
  public:
-  SimulatorComponentBase();
-  virtual ~SimulatorComponentBase();
+  SimulatorComponentBase() = default;
+  virtual ~SimulatorComponentBase() = default;
 
-  const std::string& GetDisplayName() override;
+  const std::string& GetDisplayName() const override;
 
   void SetDisplayName(const std::string& displayName) override;
 

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponentBase.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/SimulatorComponentBase.h
@@ -1,0 +1,43 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+/*
+ * SimulatorComponentBase.h
+ *
+ *  Created on: Aug 12, 2018
+ *      Author: PJ
+ */
+
+#ifndef WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENTBASE_H_
+#define WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENTBASE_H_
+
+#include <string>
+
+#include "lowfisim/SimulatorComponent.h"
+
+namespace frc {
+namespace sim {
+namespace lowfi {
+
+class SimulatorComponentBase : public virtual SimulatorComponent {
+ public:
+  SimulatorComponentBase();
+  virtual ~SimulatorComponentBase();
+
+  const std::string& GetDisplayName() override;
+
+  void SetDisplayName(const std::string& displayName) override;
+
+ private:
+  std::string m_name;
+};
+
+}  // namespace lowfi
+}  // namespace sim
+}  // namespace frc
+
+#endif  // WPILIB_SIMULATION_LOWFI_SIMULATION_SRC_MAIN_NATIVE_INCLUDE_LOWFISIM_SIMULATORCOMPONENTBASE_H_

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/ADXRS450_SpiGyroSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/ADXRS450_SpiGyroSim.h
@@ -9,14 +9,17 @@
 
 #include "ADXRS450_SpiGyroWrapperData.h"
 #include "lowfisim/GyroSim.h"
+#include "lowfisim/SimulatorComponentBase.h"
 
 namespace frc {
 namespace sim {
 namespace lowfi {
 
-class ADXRS450_SpiGyroSim : public GyroSim {
+class ADXRS450_SpiGyroSim : public SimulatorComponentBase, public GyroSim {
  public:
   explicit ADXRS450_SpiGyroSim(int spiPort);
+
+  bool IsWrapperInitialized() override;
 
   void SetAngle(double angle) override;
   double GetAngle() override;

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/ADXRS450_SpiGyroSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/ADXRS450_SpiGyroSim.h
@@ -19,7 +19,7 @@ class ADXRS450_SpiGyroSim : public SimulatorComponentBase, public GyroSim {
  public:
   explicit ADXRS450_SpiGyroSim(int spiPort);
 
-  bool IsWrapperInitialized() override;
+  bool IsWrapperInitialized() const override;
 
   void SetAngle(double angle) override;
   double GetAngle() override;

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/WpiAnalogGyroSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/WpiAnalogGyroSim.h
@@ -8,15 +8,18 @@
 #pragma once
 
 #include "lowfisim/GyroSim.h"
+#include "lowfisim/SimulatorComponentBase.h"
 #include "simulation/AnalogGyroSim.h"
 
 namespace frc {
 namespace sim {
 namespace lowfi {
 
-class WpiAnalogGyroSim : public GyroSim {
+class WpiAnalogGyroSim : public SimulatorComponentBase, public GyroSim {
  public:
   explicit WpiAnalogGyroSim(int index);
+
+  bool IsWrapperInitialized() override;
 
   void SetAngle(double angle) override;
   double GetAngle() override;

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/WpiAnalogGyroSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/WpiAnalogGyroSim.h
@@ -19,7 +19,7 @@ class WpiAnalogGyroSim : public SimulatorComponentBase, public GyroSim {
  public:
   explicit WpiAnalogGyroSim(int index);
 
-  bool IsWrapperInitialized() override;
+  bool IsWrapperInitialized() const override;
 
   void SetAngle(double angle) override;
   double GetAngle() override;

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/WpiEncoderSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/WpiEncoderSim.h
@@ -18,7 +18,7 @@ namespace lowfi {
 class WpiEncoderSim : public SimulatorComponentBase, public EncoderSim {
  public:
   explicit WpiEncoderSim(int index);
-  bool IsWrapperInitialized() override;
+  bool IsWrapperInitialized() const override;
 
   void SetPosition(double position) override;
   void SetVelocity(double velocity) override;

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/WpiEncoderSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/WpiEncoderSim.h
@@ -8,15 +8,17 @@
 #pragma once
 
 #include "lowfisim/EncoderSim.h"
+#include "lowfisim/SimulatorComponentBase.h"
 #include "simulation/EncoderSim.h"
 
 namespace frc {
 namespace sim {
 namespace lowfi {
 
-class WpiEncoderSim : public EncoderSim {
+class WpiEncoderSim : public SimulatorComponentBase, public EncoderSim {
  public:
   explicit WpiEncoderSim(int index);
+  bool IsWrapperInitialized() override;
 
   void SetPosition(double position) override;
   void SetVelocity(double velocity) override;

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/WpiMotorSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/WpiMotorSim.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "lowfisim/MotorSim.h"
+#include "lowfisim/SimulatorComponentBase.h"
 #include "lowfisim/motormodel/MotorModel.h"
 #include "simulation/PWMSim.h"
 
@@ -15,9 +16,10 @@ namespace frc {
 namespace sim {
 namespace lowfi {
 
-class WpiMotorSim : public MotorSim {
+class WpiMotorSim : public SimulatorComponentBase, public MotorSim {
  public:
   explicit WpiMotorSim(int index, MotorModel& motorModelSimulator);
+  bool IsWrapperInitialized() override;
 
   void Update(double elapsedTime);
   double GetPosition() const override;

--- a/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/WpiMotorSim.h
+++ b/simulation/lowfi_simulation/src/main/native/include/lowfisim/wpisimulators/WpiMotorSim.h
@@ -19,7 +19,7 @@ namespace lowfi {
 class WpiMotorSim : public SimulatorComponentBase, public MotorSim {
  public:
   explicit WpiMotorSim(int index, MotorModel& motorModelSimulator);
-  bool IsWrapperInitialized() override;
+  bool IsWrapperInitialized() const override;
 
   void Update(double elapsedTime);
   double GetPosition() const override;

--- a/simulation/lowfi_simulation/src/test/native/cpp/lowfisim/AccelerometerSimulatorTest.cpp
+++ b/simulation/lowfi_simulation/src/test/native/cpp/lowfisim/AccelerometerSimulatorTest.cpp
@@ -15,17 +15,22 @@ TEST(AccelerometerTests, TestADXL345_I2CAccelerometerWrapper) {
 
   frc::I2C::Port port = frc::I2C::kOnboard;
 
-  frc::ADXL345_I2C accel{port};
-
-  EXPECT_NEAR(0, accel.GetX(), EPSILON);
-  EXPECT_NEAR(0, accel.GetY(), EPSILON);
-  EXPECT_NEAR(0, accel.GetZ(), EPSILON);
-
   hal::ADXL345_I2CData rawAdxSim(port);
   frc::sim::lowfi::ADXLThreeAxisAccelerometerSim accelerometerSim(rawAdxSim);
   frc::sim::lowfi::AccelerometerSim& xWrapper = accelerometerSim.GetXWrapper();
   frc::sim::lowfi::AccelerometerSim& yWrapper = accelerometerSim.GetYWrapper();
   frc::sim::lowfi::AccelerometerSim& zWrapper = accelerometerSim.GetZWrapper();
+  EXPECT_FALSE(xWrapper.IsWrapperInitialized());
+  EXPECT_FALSE(yWrapper.IsWrapperInitialized());
+  EXPECT_FALSE(zWrapper.IsWrapperInitialized());
+
+  frc::ADXL345_I2C accel{port};
+  EXPECT_NEAR(0, accel.GetX(), EPSILON);
+  EXPECT_NEAR(0, accel.GetY(), EPSILON);
+  EXPECT_NEAR(0, accel.GetZ(), EPSILON);
+  EXPECT_TRUE(xWrapper.IsWrapperInitialized());
+  EXPECT_TRUE(yWrapper.IsWrapperInitialized());
+  EXPECT_TRUE(zWrapper.IsWrapperInitialized());
 
   xWrapper.SetAcceleration(1.45);
   EXPECT_NEAR(1.45, accel.GetX(), EPSILON);

--- a/simulation/lowfi_simulation/src/test/native/cpp/lowfisim/GyroSimulatorTest.cpp
+++ b/simulation/lowfi_simulation/src/test/native/cpp/lowfisim/GyroSimulatorTest.cpp
@@ -25,16 +25,23 @@ void TestGyro(frc::sim::lowfi::GyroSim& sim, frc::Gyro& gyro) {
 
 TEST(GyroSimulatorTests, TestAnalogGyro) {
   int port = 1;
-  frc::AnalogGyro gyro{port};
   frc::sim::lowfi::WpiAnalogGyroSim sim{port};
+  EXPECT_FALSE(sim.IsWrapperInitialized());
+
+  frc::AnalogGyro gyro{port};
+  EXPECT_TRUE(sim.IsWrapperInitialized());
 
   TestGyro(sim, gyro);
 }
 
 TEST(GyroSimulatorTests, TestSpiGyro) {
   frc::SPI::Port port = frc::SPI::kOnboardCS0;
+
   frc::sim::lowfi::ADXRS450_SpiGyroSim sim{port};
+  EXPECT_FALSE(sim.IsWrapperInitialized());
+
   frc::ADXRS450_Gyro gyro{port};
+  EXPECT_TRUE(sim.IsWrapperInitialized());
 
   TestGyro(sim, gyro);
 }

--- a/simulation/lowfi_simulation/src/test/native/cpp/lowfisim/MotorEncoderSimulatorTest.cpp
+++ b/simulation/lowfi_simulation/src/test/native/cpp/lowfisim/MotorEncoderSimulatorTest.cpp
@@ -14,13 +14,17 @@
 #include "lowfisim/wpisimulators/WpiMotorSim.h"
 
 TEST(MotorEncoderConnectorTest, TestWithoutDistancePerPulseFullSpeed) {
-  frc::Talon talon{3};
-  frc::Encoder encoder{3, 1};
-
   frc::sim::lowfi::SimpleMotorModel motorModelSim(6000);
   frc::sim::lowfi::WpiMotorSim motorSim(3, motorModelSim);
   frc::sim::lowfi::WpiEncoderSim encoderSim(0);
   frc::sim::lowfi::MotorEncoderConnector connector(motorSim, encoderSim);
+
+  EXPECT_FALSE(motorSim.IsWrapperInitialized());
+  EXPECT_FALSE(encoderSim.IsWrapperInitialized());
+  frc::Talon talon{3};
+  frc::Encoder encoder{3, 1};
+  EXPECT_TRUE(motorSim.IsWrapperInitialized());
+  EXPECT_TRUE(encoderSim.IsWrapperInitialized());
 
   talon.Set(-1);
   motorSim.Update(1);

--- a/simulation/lowfi_simulation/src/test/native/cpp/main.cpp
+++ b/simulation/lowfi_simulation/src/test/native/cpp/main.cpp
@@ -5,9 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#include <hal/HAL.h>
+
 #include "gtest/gtest.h"
 
 int main(int argc, char** argv) {
+  HAL_Initialize(500, 0);
   ::testing::InitGoogleTest(&argc, argv);
   int ret = RUN_ALL_TESTS();
   return ret;

--- a/wpilibcExamples/src/main/cpp/examples/IntermediateVision/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/IntermediateVision/cpp/Robot.cpp
@@ -61,8 +61,8 @@ class Robot : public frc::IterativeRobot {
 #endif
 
   void RobotInit() override {
-    // We need to run our vision program in a separate thread. If not, our robot
-    // program will not run.
+  // We need to run our vision program in a separate thread. If not, our robot
+  // program will not run.
 #if defined(__linux__)
     std::thread visionThread(VisionThread);
     visionThread.detach();

--- a/wpilibcExamples/src/main/cpp/examples/IntermediateVision/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/IntermediateVision/cpp/Robot.cpp
@@ -61,8 +61,8 @@ class Robot : public frc::IterativeRobot {
 #endif
 
   void RobotInit() override {
-  // We need to run our vision program in a separate thread. If not, our robot
-  // program will not run.
+    // We need to run our vision program in a separate thread. If not, our robot
+    // program will not run.
 #if defined(__linux__)
     std::thread visionThread(VisionThread);
     visionThread.detach();

--- a/wpiutil/src/main/native/include/wpi/jni_util.h
+++ b/wpiutil/src/main/native/include/wpi/jni_util.h
@@ -419,7 +419,7 @@ inline jbooleanArray MakeJBooleanArray(JNIEnv* env, ArrayRef<bool> arr) {
   return jarr;
 }
 
-  // Other MakeJ*Array conversions.
+// Other MakeJ*Array conversions.
 
 #define WPI_JNI_MAKEJARRAY(T, F)                                  \
   inline T##Array MakeJ##F##Array(JNIEnv* env, ArrayRef<T> arr) { \

--- a/wpiutil/src/main/native/include/wpi/jni_util.h
+++ b/wpiutil/src/main/native/include/wpi/jni_util.h
@@ -419,7 +419,7 @@ inline jbooleanArray MakeJBooleanArray(JNIEnv* env, ArrayRef<bool> arr) {
   return jarr;
 }
 
-// Other MakeJ*Array conversions.
+  // Other MakeJ*Array conversions.
 
 #define WPI_JNI_MAKEJARRAY(T, F)                                  \
   inline T##Array MakeJ##F##Array(JNIEnv* env, ArrayRef<T> arr) { \


### PR DESCRIPTION
This is a feature in SnobotSim. Allows users to set a display name for the simulator so it is clearer what shows up as opposed to just having a port displayed. Also added an accessor for checking if the thing wrapped has been initialized. Allows simulators to be created a priori, but can still run a check on everything to see if the thing it was hooked up to was removed from the robot code.