### PR TITLE
Add dependency injection of Subsystems to commands

### DIFF
--- a/wpilibc/src/main/native/cpp/commands/Command.cpp
+++ b/wpilibc/src/main/native/cpp/commands/Command.cpp
@@ -27,6 +27,10 @@ Command::Command(const wpi::Twine& name) : Command(name, -1.0) {}
 
 Command::Command(double timeout) : Command("", timeout) {}
 
+Command::Command(Subsystem& requirement) : Command("", -1.0) {
+  Requires(requirement);
+}
+
 Command::Command(const wpi::Twine& name, double timeout) : SendableBase(false) {
   // We use -1.0 to indicate no timeout.
   if (timeout < 0.0 && timeout != -1.0)
@@ -41,6 +45,21 @@ Command::Command(const wpi::Twine& name, double timeout) : SendableBase(false) {
   } else {
     SetName(name);
   }
+}
+
+Command::Command(const wpi::Twine& name, Subsystem& requirement)
+    : Command(name, -1.0) {
+  Requires(requirement);
+}
+
+Command::Command(double timeout, Subsystem& requirement)
+    : Command("", timeout) {
+  Requires(requirement);
+}
+
+Command::Command(const wpi::Twine& name, double timeout, Subsystem& requirement)
+    : Command(name, timeout) {
+  Requires(requirement);
 }
 
 double Command::TimeSinceInitialized() const {

--- a/wpilibc/src/main/native/cpp/commands/Command.cpp
+++ b/wpilibc/src/main/native/cpp/commands/Command.cpp
@@ -28,7 +28,7 @@ Command::Command(const wpi::Twine& name) : Command(name, -1.0) {}
 Command::Command(double timeout) : Command("", timeout) {}
 
 Command::Command(Subsystem& requirement) : Command("", -1.0) {
-  Requires(requirement);
+  Requires(&requirement);
 }
 
 Command::Command(const wpi::Twine& name, double timeout) : SendableBase(false) {
@@ -49,17 +49,17 @@ Command::Command(const wpi::Twine& name, double timeout) : SendableBase(false) {
 
 Command::Command(const wpi::Twine& name, Subsystem& requirement)
     : Command(name, -1.0) {
-  Requires(requirement);
+  Requires(&requirement);
 }
 
 Command::Command(double timeout, Subsystem& requirement)
     : Command("", timeout) {
-  Requires(requirement);
+  Requires(&requirement);
 }
 
 Command::Command(const wpi::Twine& name, double timeout, Subsystem& requirement)
     : Command(name, timeout) {
-  Requires(requirement);
+  Requires(&requirement);
 }
 
 double Command::TimeSinceInitialized() const {

--- a/wpilibc/src/main/native/cpp/commands/InstantCommand.cpp
+++ b/wpilibc/src/main/native/cpp/commands/InstantCommand.cpp
@@ -11,4 +11,7 @@ using namespace frc;
 
 InstantCommand::InstantCommand(const wpi::Twine& name) : Command(name) {}
 
+InstantCommand::InstantCommand(const wpi::Twine& name, Subsystem& subsystem)
+    : Command(name, subsystem) {}
+
 bool InstantCommand::IsFinished() { return true; }

--- a/wpilibc/src/main/native/cpp/commands/PIDCommand.cpp
+++ b/wpilibc/src/main/native/cpp/commands/PIDCommand.cpp
@@ -41,6 +41,39 @@ PIDCommand::PIDCommand(double p, double i, double d, double period) {
   m_controller = std::make_shared<PIDController>(p, i, d, this, this, period);
 }
 
+PIDCommand::PIDCommand(const wpi::Twine& name, double p, double i, double d,
+                       double f, double period, Subsystem& requirement)
+    : Command(name, requirement) {
+  m_controller = std::make_shared<PIDController>(p, i, d, this, this, period);
+}
+
+PIDCommand::PIDCommand(double p, double i, double d, double f, double period,
+                       Subsystem& requirement) {
+  m_controller =
+      std::make_shared<PIDController>(p, i, d, f, this, this, period);
+}
+
+PIDCommand::PIDCommand(const wpi::Twine& name, double p, double i, double d,
+                       Subsystem& requirement)
+    : Command(name) {
+  m_controller = std::make_shared<PIDController>(p, i, d, this, this);
+}
+
+PIDCommand::PIDCommand(const wpi::Twine& name, double p, double i, double d,
+                       double period, Subsystem& requirement)
+    : Command(name) {
+  m_controller = std::make_shared<PIDController>(p, i, d, this, this, period);
+}
+
+PIDCommand::PIDCommand(double p, double i, double d, Subsystem& requirement) {
+  m_controller = std::make_shared<PIDController>(p, i, d, this, this);
+}
+
+PIDCommand::PIDCommand(double p, double i, double d, double period,
+                       Subsystem& requirement) {
+  m_controller = std::make_shared<PIDController>(p, i, d, this, this, period);
+}
+
 void PIDCommand::_Initialize() { m_controller->Enable(); }
 
 void PIDCommand::_End() { m_controller->Disable(); }

--- a/wpilibc/src/main/native/cpp/commands/TimedCommand.cpp
+++ b/wpilibc/src/main/native/cpp/commands/TimedCommand.cpp
@@ -14,4 +14,11 @@ TimedCommand::TimedCommand(const wpi::Twine& name, double timeout)
 
 TimedCommand::TimedCommand(double timeout) : Command(timeout) {}
 
+TimedCommand::TimedCommand(const wpi::Twine& name, double timeout,
+                           Subsystem& requirement)
+    : Command(name, timeout, requirement) {}
+
+TimedCommand::TimedCommand(double timeout, Subsystem& requirement)
+    : Command(timeout, requirement) {}
+
 bool TimedCommand::IsFinished() { return IsTimedOut(); }

--- a/wpilibc/src/main/native/include/frc/commands/Command.h
+++ b/wpilibc/src/main/native/include/frc/commands/Command.h
@@ -73,6 +73,13 @@ class Command : public ErrorBase, public SendableBase {
   explicit Command(double timeout);
 
   /**
+   * Creates a new command with the given timeout and a default name.
+   *
+   * @param requirement the subsystem that the command requires
+   */
+  explicit Command(Subsystem& requirement);
+
+  /**
    * Creates a new command with the given name and timeout.
    *
    * @param name    the name of the command
@@ -80,6 +87,33 @@ class Command : public ErrorBase, public SendableBase {
    * @see IsTimedOut()
    */
   Command(const wpi::Twine& name, double timeout);
+
+  /**
+   * Creates a new command with the given name and timeout.
+   *
+   * @param name        the name of the command
+   * @param requirement the subsystem that the command requires
+   */
+  Command(const wpi::Twine& name, Subsystem& requirement);
+
+  /**
+   * Creates a new command with the given name and timeout.
+   *
+   * @param timeout     the time (in seconds) before this command "times out"
+   * @param requirement the subsystem that the command requires
+   * @see IsTimedOut()
+   */
+  Command(double timeout, Subsystem& requirement);
+
+  /**
+   * Creates a new command with the given name and timeout.
+   *
+   * @param name        the name of the command
+   * @param timeout     the time (in seconds) before this command "times out"
+   * @param requirement the subsystem that the command requires
+   * @see IsTimedOut()
+   */
+  Command(const wpi::Twine& name, double timeout, Subsystem& requirement);
 
   ~Command() override = default;
 

--- a/wpilibc/src/main/native/include/frc/commands/InstantCommand.h
+++ b/wpilibc/src/main/native/include/frc/commands/InstantCommand.h
@@ -27,6 +27,14 @@ class InstantCommand : public Command {
    */
   explicit InstantCommand(const wpi::Twine& name);
 
+  /**
+   * Creates a new InstantCommand with the given name.
+   *
+   * @param name        The name for this command
+   * @param requirement The subsystem that the command requires
+   */
+  InstantCommand(const wpi::Twine& name, Subsystem& requirement);
+
   InstantCommand() = default;
   virtual ~InstantCommand() = default;
 

--- a/wpilibc/src/main/native/include/frc/commands/PIDCommand.h
+++ b/wpilibc/src/main/native/include/frc/commands/PIDCommand.h
@@ -28,6 +28,17 @@ class PIDCommand : public Command, public PIDOutput, public PIDSource {
   PIDCommand(double p, double i, double d);
   PIDCommand(double p, double i, double d, double period);
   PIDCommand(double p, double i, double d, double f, double period);
+  PIDCommand(const wpi::Twine& name, double p, double i, double d,
+             Subsystem& requirement);
+  PIDCommand(const wpi::Twine& name, double p, double i, double d,
+             double period, Subsystem& requirement);
+  PIDCommand(const wpi::Twine& name, double p, double i, double d, double f,
+             double period, Subsystem& requirement);
+  PIDCommand(double p, double i, double d, Subsystem& requirement);
+  PIDCommand(double p, double i, double d, double period,
+             Subsystem& requirement);
+  PIDCommand(double p, double i, double d, double f, double period,
+             Subsystem& requirement);
   virtual ~PIDCommand() = default;
 
   void SetSetpointRelative(double deltaSetpoint);

--- a/wpilibc/src/main/native/include/frc/commands/TimedCommand.h
+++ b/wpilibc/src/main/native/include/frc/commands/TimedCommand.h
@@ -35,6 +35,23 @@ class TimedCommand : public Command {
    */
   explicit TimedCommand(double timeout);
 
+  /**
+   * Creates a new TimedCommand with the given name and timeout.
+   *
+   * @param name        the name of the command
+   * @param timeout     the time (in seconds) before this command "times out"
+   * @param requirement the subsystem that the command requires
+   */
+  TimedCommand(const wpi::Twine& name, double timeout, Subsystem& requirement);
+
+  /**
+   * Creates a new WaitCommand with the given timeout.
+   *
+   * @param timeout     the time (in seconds) before this command "times out"
+   * @param requirement the subsystem that the command requires
+   */
+  TimedCommand(double timeout, Subsystem& requirement);
+
   virtual ~TimedCommand() = default;
 
  protected:

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
@@ -136,6 +136,24 @@ public abstract class Command extends SendableBase {
   }
 
   /**
+   * Creates a new command with the given timeout and a default name. The default name is the name
+   * of the class.
+   *
+   * @param timeout     the time (in seconds) before this command "times out"
+   * @param requirement the subsystem that this command requires
+   * @throws IllegalArgumentException if given a negative timeout
+   * @see Command#isTimedOut() isTimedOut()
+   */
+  public Command(double timeout, Subsystem requirement) {
+    this();
+    if (timeout < 0) {
+      throw new IllegalArgumentException("Timeout must not be negative.  Given:" + timeout);
+    }
+    m_timeout = timeout;
+    requires(requirement);
+  }
+
+  /**
    * Creates a new command with the given name and timeout.
    *
    * @param name    the name of the command
@@ -149,6 +167,25 @@ public abstract class Command extends SendableBase {
       throw new IllegalArgumentException("Timeout must not be negative.  Given:" + timeout);
     }
     m_timeout = timeout;
+  }
+
+  /**
+   * Creates a new command with the given name and timeout.
+   *
+   * @param name    the name of the command
+   * @param timeout the time (in seconds) before this command "times out"
+   * @param requirement the subsystem that this command requires
+   * @throws IllegalArgumentException if given a negative timeout
+   * @throws IllegalArgumentException if given a negative timeout or name was null.
+   * @see Command#isTimedOut() isTimedOut()
+   */
+  public Command(String name, double timeout, Subsystem requirement) {
+    this(name);
+    if (timeout < 0) {
+      throw new IllegalArgumentException("Timeout must not be negative.  Given:" + timeout);
+    }
+    m_timeout = timeout;
+    requires(requirement);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
@@ -139,6 +139,35 @@ public abstract class Command extends SendableBase {
    * Creates a new command with the given timeout and a default name. The default name is the name
    * of the class.
    *
+   * @param requirement the subsystem that this command requires
+   * @throws IllegalArgumentException if given a negative timeout
+   * @see Command#isTimedOut() isTimedOut()
+   */
+  public Command(Subsystem requirement) {
+    this();
+    requires(requirement);
+  }
+
+  /**
+   * Creates a new command with the given name.
+   *
+   * @param name        the name for this command
+   * @param requirement the subsystem that this command requires
+   * @throws IllegalArgumentException if name is null
+   */
+  public Command(String name, Subsystem requirement) {
+    super(false);
+    if (name == null) {
+      throw new IllegalArgumentException("Name must not be null.");
+    }
+    setName(name);
+    requires(requirement);
+  }
+
+  /**
+   * Creates a new command with the given timeout and a default name. The default name is the name
+   * of the class.
+   *
    * @param timeout     the time (in seconds) before this command "times out"
    * @param requirement the subsystem that this command requires
    * @throws IllegalArgumentException if given a negative timeout

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
@@ -156,11 +156,7 @@ public abstract class Command extends SendableBase {
    * @throws IllegalArgumentException if name is null
    */
   public Command(String name, Subsystem requirement) {
-    super(false);
-    if (name == null) {
-      throw new IllegalArgumentException("Name must not be null.");
-    }
-    setName(name);
+    this(name);
     requires(requirement);
   }
 
@@ -174,11 +170,7 @@ public abstract class Command extends SendableBase {
    * @see Command#isTimedOut() isTimedOut()
    */
   public Command(double timeout, Subsystem requirement) {
-    this();
-    if (timeout < 0) {
-      throw new IllegalArgumentException("Timeout must not be negative.  Given:" + timeout);
-    }
-    m_timeout = timeout;
+    this(timeout);
     requires(requirement);
   }
 
@@ -201,19 +193,15 @@ public abstract class Command extends SendableBase {
   /**
    * Creates a new command with the given name and timeout.
    *
-   * @param name    the name of the command
-   * @param timeout the time (in seconds) before this command "times out"
+   * @param name        the name of the command
+   * @param timeout     the time (in seconds) before this command "times out"
    * @param requirement the subsystem that this command requires
    * @throws IllegalArgumentException if given a negative timeout
    * @throws IllegalArgumentException if given a negative timeout or name was null.
    * @see Command#isTimedOut() isTimedOut()
    */
   public Command(String name, double timeout, Subsystem requirement) {
-    this(name);
-    if (timeout < 0) {
-      throw new IllegalArgumentException("Timeout must not be negative.  Given:" + timeout);
-    }
-    m_timeout = timeout;
+    this(name, timeout);
     requires(requirement);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/InstantCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/InstantCommand.java
@@ -30,7 +30,7 @@ public class InstantCommand extends Command {
    * @param requirement the subsystem this command requires
    */
   public InstantCommand(Subsystem requirement) {
-      super(requirement);
+    super(requirement);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/InstantCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/InstantCommand.java
@@ -25,6 +25,23 @@ public class InstantCommand extends Command {
     super(name);
   }
 
+  /**
+   * Creates a new {@link InstantCommand InstantCommand} with the given requirement.
+   * @param requirement the subsystem this command requires
+   */
+  public InstantCommand(Subsystem requirement) {
+      super(requirement);
+  }
+
+  /**
+   * Creates a new {@link InstantCommand InstantCommand} with the given name and requirement.
+   * @param name        the name for this command
+   * @param requirement the subsystem this command requires
+   */
+  public InstantCommand(String name, Subsystem requirement) {
+    super(name, requirement);
+  }
+
   @Override
   protected boolean isFinished() {
     return true;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/PIDCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/PIDCommand.java
@@ -133,7 +133,8 @@ public abstract class PIDCommand extends Command {
    * @param requirement the subsystem that this command requires
    */
   @SuppressWarnings("ParameterName")
-  public PIDCommand(String name, double p, double i, double d, double period, Subsystem requirement) {
+  public PIDCommand(String name, double p, double i, double d, double period,
+                    Subsystem requirement) {
     super(name, requirement);
     m_controller = new PIDController(p, i, d, m_source, m_output, period);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/PIDCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/PIDCommand.java
@@ -93,7 +93,7 @@ public abstract class PIDCommand extends Command {
 
   /**
    * Instantiates a {@link PIDCommand} that will use the given p, i and d values. It will use the
-   * class name as its name.. It will also space the time between PID loop calculations to be equal
+   * class name as its name. It will also space the time between PID loop calculations to be equal
    * to the given period.
    *
    * @param p      the proportional value
@@ -103,6 +103,70 @@ public abstract class PIDCommand extends Command {
    */
   @SuppressWarnings("ParameterName")
   public PIDCommand(double p, double i, double d, double period) {
+    m_controller = new PIDController(p, i, d, m_source, m_output, period);
+  }
+
+  /**
+   * Instantiates a {@link PIDCommand} that will use the given p, i and d values.
+   *
+   * @param name        the name of the command
+   * @param p           the proportional value
+   * @param i           the integral value
+   * @param d           the derivative value
+   * @param requirement the subsystem that this command requires
+   */
+  @SuppressWarnings("ParameterName")
+  public PIDCommand(String name, double p, double i, double d, Subsystem requirement) {
+    super(name, requirement);
+    m_controller = new PIDController(p, i, d, m_source, m_output);
+  }
+
+  /**
+   * Instantiates a {@link PIDCommand} that will use the given p, i and d values. It will also space
+   * the time between PID loop calculations to be equal to the given period.
+   *
+   * @param name        the name
+   * @param p           the proportional value
+   * @param i           the integral value
+   * @param d           the derivative value
+   * @param period      the time (in seconds) between calculations
+   * @param requirement the subsystem that this command requires
+   */
+  @SuppressWarnings("ParameterName")
+  public PIDCommand(String name, double p, double i, double d, double period, Subsystem requirement) {
+    super(name, requirement);
+    m_controller = new PIDController(p, i, d, m_source, m_output, period);
+  }
+
+  /**
+   * Instantiates a {@link PIDCommand} that will use the given p, i and d values. It will use the
+   * class name as its name.
+   *
+   * @param p           the proportional value
+   * @param i           the integral value
+   * @param d           the derivative value
+   * @param requirement the subsystem that this command requires
+   */
+  @SuppressWarnings("ParameterName")
+  public PIDCommand(double p, double i, double d, Subsystem requirement) {
+    super(requirement);
+    m_controller = new PIDController(p, i, d, m_source, m_output);
+  }
+
+  /**
+   * Instantiates a {@link PIDCommand} that will use the given p, i and d values. It will use the
+   * class name as its name. It will also space the time between PID loop calculations to be equal
+   * to the given period.
+   *
+   * @param p           the proportional value
+   * @param i           the integral value
+   * @param d           the derivative value
+   * @param period      the time (in seconds) between calculations
+   * @param requirement the subsystem that this command requires
+   */
+  @SuppressWarnings("ParameterName")
+  public PIDCommand(double p, double i, double d, double period, Subsystem requirement) {
+    super(requirement);
     m_controller = new PIDController(p, i, d, m_source, m_output, period);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/TimedCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/TimedCommand.java
@@ -19,7 +19,7 @@ public class TimedCommand extends Command {
    * @param timeout the time the command takes to run (seconds)
    */
   public TimedCommand(String name, double timeout) {
-    super(name, timeout, requirement);
+    super(name, timeout);
   }
 
   /**
@@ -28,7 +28,7 @@ public class TimedCommand extends Command {
    * @param timeout the time the command takes to run (seconds)
    */
   public TimedCommand(double timeout) {
-    super(timeout, requirement);
+    super(timeout);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/TimedCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/TimedCommand.java
@@ -15,11 +15,11 @@ public class TimedCommand extends Command {
   /**
    * Instantiates a TimedCommand with the given name and timeout.
    *
-   * @param name the name of the command
+   * @param name    the name of the command
    * @param timeout the time the command takes to run (seconds)
    */
   public TimedCommand(String name, double timeout) {
-    super(name, timeout);
+    super(name, timeout, requirement);
   }
 
   /**
@@ -28,7 +28,28 @@ public class TimedCommand extends Command {
    * @param timeout the time the command takes to run (seconds)
    */
   public TimedCommand(double timeout) {
-    super(timeout);
+    super(timeout, requirement);
+  }
+
+  /**
+   * Instantiates a TimedCommand with the given name and timeout.
+   *
+   * @param name        the name of the command
+   * @param timeout     the time the command takes to run (seconds)
+   * @param requirement the subsystem that this command requires
+   */
+  public TimedCommand(String name, double timeout, Subsystem requirement) {
+    super(name, timeout, requirement);
+  }
+
+  /**
+   * Instantiates a TimedCommand with the given timeout.
+   *
+   * @param timeout     the time the command takes to run (seconds)
+   * @param requirement the subsystem that this command requires
+   */
+  public TimedCommand(double timeout, Subsystem requirement) {
+    super(timeout, requirement);
   }
 
   /**


### PR DESCRIPTION
Per discussion on #1262 this adds a single optional Subsystem parameter that is automatically marked as `requires()`.