### PR TITLE
ntcore: Describe RPC version 0 in spec

### DIFF
--- a/ntcore/doc/networktables3.adoc
+++ b/ntcore/doc/networktables3.adoc
@@ -748,12 +748,18 @@ the parameters defined in the corresponding RPC entry definition.
 |2 bytes, unsigned; incremented value for matching return values to call.
 
 |Parameter Value Length
-|N bytes, unsigned <<leb128>> encoded length of total number of bytes of
-parameter values in this message
+|N bytes, unsigned <<leb128>> encoded length of:
 
+RPC definition version 0: total number of raw bytes in this message
+
+RPC definition version 1: total number of bytes of parameter values in this
+message
 |Parameter Value(s)
-|Array of values; N bytes for each parameter (length dependent on the parameter
-type defined in the <<rpc-definition,RPC entry definition>>)
+|RPC definition version 0: N raw bytes.
+
+RPC definition version 1: Array of values; N bytes for each parameter (length
+dependent on the parameter type defined in the
+<<rpc-definition,RPC entry definition>>).
 |===
 
 [[msg-rpc-response]]
@@ -776,12 +782,18 @@ will respond.
 |2 bytes, unsigned; matching ID from <<msg-rpc-execute,RPC Execute>> message
 
 |Result Value Length
-|N bytes, unsigned <<leb128>> encoded length of total number of bytes of result
-values in this message
+|N bytes, unsigned <<leb128>> encoded length of:
 
+RPC definition version 0: total number of raw bytes in this message
+
+RPC definition version 1: total number of bytes of result values in this
+message
 |Result Value(s)
-|Array of values; N bytes for each result (length dependent on the result type
-defined in the <<rpc-definition,RPC entry definition>>)
+|RPC definition version 0: N raw bytes.
+
+RPC definition version 1: Array of values; N bytes for each result (length
+dependent on the result type defined in the
+<<rpc-definition,RPC entry definition>>).
 |===
 
 [[rpc-operation]]
@@ -802,7 +814,18 @@ Remote procedure calls cannot be persisted.
 [[rpc-definition]]
 === Remote Procedure Call Definition Data
 
-The data provided in the RPC definition entry consists of:
+There are currently two versions of RPC definitions: version 0 and version 1.
+Version 0 is the most straightforward: the data provided in the RPC
+definition entry consists of just a single 0 byte (indicating RPC
+definition version 0).  RPC version 0 execute and response messages do
+not contain discrete parameter and result values respectively; instead the
+entire parameter value or result value is treated as a raw byte sequence; the
+interpretation of the raw bytes is application specific--users are encouraged
+to consider using encodings such as CBOR or MessagePack for more complex
+self-describing data structures.
+
+The data provided in the RPC version 1 definition entry is more
+complex and consists of:
 
 [cols="1,3"]
 |===

--- a/ntcore/doc/networktables3.adoc
+++ b/ntcore/doc/networktables3.adoc
@@ -734,6 +734,10 @@ corresponding RPC entry definition.
 The server shall ignore any Execute RPC message whose decoding does not match
 the parameters defined in the corresponding RPC entry definition.
 
+Note that the parameter length is encoded the same way regardless of the RPC
+version and encapsulates the entirety of the parameters, so protocol layer
+decoders do not need to know the RPC details in order to process the message.
+
 [cols="1,3"]
 |===
 |Field Name |Field Type
@@ -767,6 +771,10 @@ dependent on the parameter type defined in the
 
 Return responses from a remote procedure call. Even calls with zero outputs
 will respond.
+
+Note that the result length is encoded the same way regardless of the RPC
+version and encapsulates the entirety of the result, so protocol layer decoders
+do not need to know the RPC details in order to process the message.
 
 [cols="1,3"]
 |===
@@ -815,7 +823,12 @@ Remote procedure calls cannot be persisted.
 === Remote Procedure Call Definition Data
 
 There are currently two versions of RPC definitions: version 0 and version 1.
-Version 0 is the most straightforward: the data provided in the RPC
+The first byte in the RPC definition entry determines the version.
+
+[[rpc-definition-v0]]
+==== Version 0
+
+RPC version 0 is the most straightforward: the data provided in the RPC
 definition entry consists of just a single 0 byte (indicating RPC
 definition version 0).  RPC version 0 execute and response messages do
 not contain discrete parameter and result values respectively; instead the
@@ -824,13 +837,22 @@ interpretation of the raw bytes is application specific--users are encouraged
 to consider using encodings such as CBOR or MessagePack for more complex
 self-describing data structures.
 
+[cols="1,3"]
+|===
+|RPC Definition Version
+|1 byte, unsigned; set to 0, indicating version 0
+|===
+
+[[rpc-definition-v1]]
+==== Version 1
+
 The data provided in the RPC version 1 definition entry is more
 complex and consists of:
 
 [cols="1,3"]
 |===
 |RPC Definition Version
-|1 byte, unsigned; always set to 1 for this version of the protocol.
+|1 byte, unsigned; set to 1, indicating version 1
 
 |Procedure (Entry) Name
 |<<entry-value-string,String>>


### PR DESCRIPTION
Addresses documentation gap identified in #1277.