### PR TITLE
ntcore: Change params in Java RpcAnswer from String to byte[]

### DIFF
--- a/ntcore/src/main/java/edu/wpi/first/networktables/RpcAnswer.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/RpcAnswer.java
@@ -25,7 +25,7 @@ public final class RpcAnswer {
 
   /** Call raw parameters. */
   @SuppressWarnings("MemberName")
-  public final String params;
+  public final byte[] params;
 
   /** Connection that called the RPC. */
   @SuppressWarnings("MemberName")
@@ -41,7 +41,7 @@ public final class RpcAnswer {
    * @param params Call raw parameters
    * @param conn Connection info
    */
-  public RpcAnswer(NetworkTableInstance inst, int entry, int call, String name, String params,
+  public RpcAnswer(NetworkTableInstance inst, int entry, int call, String name, byte[] params,
                    ConnectionInfo conn) {
     this.m_inst = inst;
     this.entry = entry;

--- a/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
+++ b/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
@@ -270,10 +270,10 @@ static jobject MakeJObject(JNIEnv* env, jobject inst,
   static jmethodID constructor =
       env->GetMethodID(rpcAnswerCls, "<init>",
                        "(Ledu/wpi/first/networktables/"
-                       "NetworkTableInstance;IILjava/lang/String;Ljava/lang/"
-                       "String;Ledu/wpi/first/networktables/ConnectionInfo;)V");
+                       "NetworkTableInstance;IILjava/lang/String;[B"
+                       "Ledu/wpi/first/networktables/ConnectionInfo;)V");
   JLocal<jstring> name{env, MakeJString(env, answer.name)};
-  JLocal<jstring> params{env, MakeJString(env, answer.params)};
+  JLocal<jbyteArray> params{env, MakeJByteArray(env, answer.params)};
   JLocal<jobject> conn{env, MakeJObject(env, answer.conn)};
   return env->NewObject(rpcAnswerCls, constructor, inst, (jint)answer.entry,
                         (jint)answer.call, name.obj(), params.obj(),


### PR DESCRIPTION
The underlying protocol uses raw bytes, so they should not be required to be
a valid string.