### PR TITLE
wpiutil spinlock.h: Include STL mutex for convenience

### DIFF
--- a/wpiutil/src/main/native/include/wpi/spinlock.h
+++ b/wpiutil/src/main/native/include/wpi/spinlock.h
@@ -9,6 +9,7 @@
 
 #include <atomic>
 #include <cassert>
+#include <mutex>
 #include <thread>
 
 #include "Compiler.h"


### PR DESCRIPTION
The STL mutex header defines classes like lock_guard and unique_lock.