### PR TITLE
Notifier: properly reset HAL alarm in non-periodic case

### DIFF
--- a/wpilibc/src/main/native/cpp/Notifier.cpp
+++ b/wpilibc/src/main/native/cpp/Notifier.cpp
@@ -38,6 +38,9 @@ Notifier::Notifier(TimerEventHandler handler) {
         if (m_periodic) {
           m_expirationTime += m_period;
           UpdateAlarm();
+        } else {
+          // need to update the alarm to cause it to wait again
+          UpdateAlarm(UINT64_MAX);
         }
       }
 
@@ -87,12 +90,15 @@ void Notifier::Stop() {
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
 }
 
-void Notifier::UpdateAlarm() {
+void Notifier::UpdateAlarm(uint64_t triggerTime) {
   int32_t status = 0;
   // Return if we are being destructed, or were not created successfully
   auto notifier = m_notifier.load();
   if (notifier == 0) return;
-  HAL_UpdateNotifierAlarm(
-      notifier, static_cast<uint64_t>(m_expirationTime * 1e6), &status);
+  HAL_UpdateNotifierAlarm(notifier, triggerTime, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
+}
+
+void Notifier::UpdateAlarm() {
+  UpdateAlarm(static_cast<uint64_t>(m_expirationTime * 1e6));
 }

--- a/wpilibc/src/main/native/include/frc/Notifier.h
+++ b/wpilibc/src/main/native/include/frc/Notifier.h
@@ -88,6 +88,13 @@ class Notifier : public ErrorBase {
  private:
   /**
    * Update the HAL alarm time.
+   *
+   * @param triggerTime the time at which the next alarm will be triggered
+   */
+  void UpdateAlarm(uint64_t triggerTime);
+
+  /**
+   * Update the HAL alarm time based on m_expirationTime.
    */
   void UpdateAlarm();
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Notifier.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Notifier.java
@@ -60,13 +60,22 @@ public class Notifier implements AutoCloseable {
 
   /**
    * Update the alarm hardware to reflect the next alarm.
+   *
+   * @param triggerTime the time at which the next alarm will be triggered
    */
-  private void updateAlarm() {
+  private void updateAlarm(long triggerTime) {
     int notifier = m_notifier.get();
     if (notifier == 0) {
       return;
     }
-    NotifierJNI.updateNotifierAlarm(notifier, (long) (m_expirationTime * 1e6));
+    NotifierJNI.updateNotifierAlarm(notifier, triggerTime);
+  }
+
+  /**
+   * Update the alarm hardware to reflect the next alarm.
+   */
+  private void updateAlarm() {
+    updateAlarm((long) (m_expirationTime * 1e6));
   }
 
   /**
@@ -97,6 +106,9 @@ public class Notifier implements AutoCloseable {
           if (m_periodic) {
             m_expirationTime += m_period;
             updateAlarm();
+          } else {
+            // need to update the alarm to cause it to wait again
+            updateAlarm((long) -1);
           }
         } finally {
           m_processLock.unlock();


### PR DESCRIPTION
The loop spins otherwise.

Fixes #1294.