### PR TITLE
Adds CAN API constructor that takes explicit manufacturer and device type

### DIFF
--- a/wpilibc/src/main/native/cpp/CAN.cpp
+++ b/wpilibc/src/main/native/cpp/CAN.cpp
@@ -24,6 +24,20 @@ CAN::CAN(int deviceId) {
   HAL_Report(HALUsageReporting::kResourceType_CAN, deviceId);
 }
 
+CAN::CAN(int deviceId, int deviceManufacturer, int deviceType) {
+  int32_t status = 0;
+  m_handle = HAL_InitializeCAN(
+      static_cast<HAL_CANManufacturer>(deviceManufacturer), deviceId,
+      static_cast<HAL_CANDeviceType>(deviceType), &status);
+  if (status != 0) {
+    wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
+    m_handle = HAL_kInvalidHandle;
+    return;
+  }
+
+  HAL_Report(HALUsageReporting::kResourceType_CAN, deviceId);
+}
+
 CAN::~CAN() {
   if (StatusIsFatal()) return;
   if (m_handle != HAL_kInvalidHandle) {

--- a/wpilibc/src/main/native/include/frc/CAN.h
+++ b/wpilibc/src/main/native/include/frc/CAN.h
@@ -35,9 +35,23 @@ class CAN : public ErrorBase {
  public:
   /**
    * Create a new CAN communication interface with the specific device ID.
+   * This uses the team manufacturer and device types.
    * The device ID is 6 bits (0-63)
+   *
+   * @param deviceId The device id
    */
   explicit CAN(int deviceId);
+
+  /**
+   * Create a new CAN communication interface with a specific device ID,
+   * manufacturer and device type. The device ID is 6 bits, the
+   * manufacturer is 8 bits, and the device type is 5 bits.
+   *
+   * @param deviceId           The device ID
+   * @param deviceManufacturer The device manufacturer
+   * @param deviceType         The device type
+   */
+  CAN(int deviceId, int deviceManufacturer, int deviceType);
 
   /**
    * Closes the CAN communication.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/CAN.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/CAN.java
@@ -32,10 +32,27 @@ public class CAN implements Closeable {
 
   /**
    * Create a new CAN communication interface with the specific device ID.
-   * The device ID is 6 bits (0-63)
+   * This uses the team manufacturer and device types.
+   * The device ID is 6 bits (0-63).
+   *
+   * @param deviceId The device id
    */
   public CAN(int deviceId) {
     m_handle = CANAPIJNI.initializeCAN(kTeamManufacturer, deviceId, kTeamDeviceType);
+    HAL.report(tResourceType.kResourceType_CAN, deviceId);
+  }
+
+  /**
+   * Create a new CAN communication interface with a specific device ID,
+   * manufacturer and device type. The device ID is 6 bits, the
+   * manufacturer is 8 bits, and the device type is 5 bits.
+   *
+   * @param deviceId           The device ID
+   * @param deviceManufacturer The device manufacturer
+   * @param deviceType         The device type
+   */
+  public CAN(int deviceId, int deviceManufacturer, int deviceType) {
+    m_handle = CANAPIJNI.initializeCAN(deviceManufacturer, deviceId, deviceType);
     HAL.report(tResourceType.kResourceType_CAN, deviceId);
   }
 


### PR DESCRIPTION
Useful by vendors wanting to use the API, and make their own device parameters