### PR TITLE
WIP Add support for deadzones on old / faulty controllers

### DIFF
--- a/wpilibc/src/main/native/cpp/XboxController.cpp
+++ b/wpilibc/src/main/native/cpp/XboxController.cpp
@@ -21,6 +21,7 @@ double XboxController::GetAxisAfterDeadzone(int axis){
   } else {
     return 0.00;
   }
+}
 
 void XboxController::SetDeadzone(bool deadzone){
   this->deadzone = deadzone;

--- a/wpilibc/src/main/native/cpp/XboxController.cpp
+++ b/wpilibc/src/main/native/cpp/XboxController.cpp
@@ -15,19 +15,30 @@ XboxController::XboxController(int port) : GenericHID(port) {
   HAL_Report(HALUsageReporting::kResourceType_XboxController, port);
 }
 
+double XboxController::GetAxisAfterDeadzone(int axis){
+  if(GetRawAxis(axis) > this->deadzone || GetRawAxis(axis) < (this->deadzone * -1)){
+    return GetRawAxis(axis);
+  } else {
+    return 0.00;
+  }
+
+void XboxController::SetDeadzone(bool deadzone){
+  this->deadzone = deadzone;
+}
+
 double XboxController::GetX(JoystickHand hand) const {
   if (hand == kLeftHand) {
-    return GetRawAxis(0);
+    return GetAxisAfterDeadzone(0);
   } else {
-    return GetRawAxis(4);
+    return GetAxisAfterDeadzone(4);
   }
 }
 
 double XboxController::GetY(JoystickHand hand) const {
   if (hand == kLeftHand) {
-    return GetRawAxis(1);
+    return GetAxisAfterDeadzone(1);
   } else {
-    return GetRawAxis(5);
+    return GetAxisAfterDeadzone(5);
   }
 }
 

--- a/wpilibc/src/main/native/include/frc/XboxController.h
+++ b/wpilibc/src/main/native/include/frc/XboxController.h
@@ -36,6 +36,20 @@ class XboxController : public GenericHID {
 
   XboxController(const XboxController&) = delete;
   XboxController& operator=(const XboxController&) = delete;
+  
+  /**
+   * Get a raw axis readint after checking if it is in the deadzone or not.
+   *
+   * @param axis id to check
+   */
+  double GetAxisAfterDeadzone(int axis);
+  
+  /**
+   * Set controller's joystick deadzone.
+   *
+   * @param Deadzone amount as bool
+   */
+  void SetDeadzone(bool deadzone);
 
   /**
    * Get the X axis value of the controller.
@@ -233,6 +247,9 @@ class XboxController : public GenericHID {
   bool GetStartButtonReleased();
 
  private:
+  // The deadzone of the two joysticks
+  double deadzone = 0.00;
+
   enum class Button {
     kBumperLeft = 5,
     kBumperRight = 6,


### PR DESCRIPTION
Many older Xbox controllers' joysticks have a habit of "drifting around" when they are supposed to be in the centre. This can cause drivers to loose some precision when driving slowly or doing other tasks that involve the joystick.

This pr adds a new function `SetDeadzone()` that can be used to set a deadzone on that drifting (for example, if your controller drifts around from -10 to 10, you could set the deadzone to 11 or 12, and the robot would no longer be affected by these small changes,

This function can also be completely ignored, and the controller will function as normal.

I have not yet added this to wpilibj. I am working on a separate pr for that right now.