### PR TITLE
Fix hal header zip task dependencies

### DIFF
--- a/hal/build.gradle
+++ b/hal/build.gradle
@@ -116,6 +116,7 @@ cppSourcesZip {
 }
 
 cppHeadersZip {
+    dependsOn generateUsageReporting
     from(generatedHeaders) {
         into '/'
     }


### PR DESCRIPTION
Sometimes wouldn't include generated header file