### PR TITLE
Add kInvalid value to HAL_I2CPort and HAL_SPIPort

### DIFF
--- a/hal/src/main/native/athena/I2C.cpp
+++ b/hal/src/main/native/athena/I2C.cpp
@@ -46,12 +46,12 @@ void HAL_InitializeI2C(HAL_I2CPort port, int32_t* status) {
   initializeDigital(status);
   if (*status != 0) return;
 
-  if (port > 1) {
+  if (port < 0 || port > 1) {
     // Set port out of range error here
     return;
   }
 
-  if (port == 0) {
+  if (port == HAL_I2C_kOnboard) {
     std::lock_guard<wpi::mutex> lock(digitalI2COnBoardMutex);
     i2COnboardObjCount++;
     if (i2COnboardObjCount > 1) return;
@@ -88,7 +88,7 @@ void HAL_InitializeI2C(HAL_I2CPort port, int32_t* status) {
 int32_t HAL_TransactionI2C(HAL_I2CPort port, int32_t deviceAddress,
                            const uint8_t* dataToSend, int32_t sendSize,
                            uint8_t* dataReceived, int32_t receiveSize) {
-  if (port > 1) {
+  if (port < 0 || port > 1) {
     // Set port out of range error here
     return -1;
   }
@@ -107,7 +107,7 @@ int32_t HAL_TransactionI2C(HAL_I2CPort port, int32_t deviceAddress,
   rdwr.msgs = msgs;
   rdwr.nmsgs = 2;
 
-  if (port == 0) {
+  if (port == HAL_I2C_kOnboard) {
     std::lock_guard<wpi::mutex> lock(digitalI2COnBoardMutex);
     return ioctl(i2COnBoardHandle, I2C_RDWR, &rdwr);
   } else {
@@ -118,7 +118,7 @@ int32_t HAL_TransactionI2C(HAL_I2CPort port, int32_t deviceAddress,
 
 int32_t HAL_WriteI2C(HAL_I2CPort port, int32_t deviceAddress,
                      const uint8_t* dataToSend, int32_t sendSize) {
-  if (port > 1) {
+  if (port < 0 || port > 1) {
     // Set port out of range error here
     return -1;
   }
@@ -133,7 +133,7 @@ int32_t HAL_WriteI2C(HAL_I2CPort port, int32_t deviceAddress,
   rdwr.msgs = &msg;
   rdwr.nmsgs = 1;
 
-  if (port == 0) {
+  if (port == HAL_I2C_kOnboard) {
     std::lock_guard<wpi::mutex> lock(digitalI2COnBoardMutex);
     return ioctl(i2COnBoardHandle, I2C_RDWR, &rdwr);
   } else {
@@ -144,7 +144,7 @@ int32_t HAL_WriteI2C(HAL_I2CPort port, int32_t deviceAddress,
 
 int32_t HAL_ReadI2C(HAL_I2CPort port, int32_t deviceAddress, uint8_t* buffer,
                     int32_t count) {
-  if (port > 1) {
+  if (port < 0 || port > 1) {
     // Set port out of range error here
     return -1;
   }
@@ -159,7 +159,7 @@ int32_t HAL_ReadI2C(HAL_I2CPort port, int32_t deviceAddress, uint8_t* buffer,
   rdwr.msgs = &msg;
   rdwr.nmsgs = 1;
 
-  if (port == 0) {
+  if (port == HAL_I2C_kOnboard) {
     std::lock_guard<wpi::mutex> lock(digitalI2COnBoardMutex);
     return ioctl(i2COnBoardHandle, I2C_RDWR, &rdwr);
   } else {
@@ -169,12 +169,12 @@ int32_t HAL_ReadI2C(HAL_I2CPort port, int32_t deviceAddress, uint8_t* buffer,
 }
 
 void HAL_CloseI2C(HAL_I2CPort port) {
-  if (port > 1) {
+  if (port < 0 || port > 1) {
     // Set port out of range error here
     return;
   }
 
-  if (port == 0) {
+  if (port == HAL_I2C_kOnboard) {
     std::lock_guard<wpi::mutex> lock(digitalI2COnBoardMutex);
     if (i2COnboardObjCount-- == 0) {
       close(i2COnBoardHandle);

--- a/hal/src/main/native/athena/SPI.cpp
+++ b/hal/src/main/native/athena/SPI.cpp
@@ -110,7 +110,7 @@ void HAL_InitializeSPI(HAL_SPIPort port, int32_t* status) {
   int handle;
   if (HAL_GetSPIHandle(port) != 0) return;
   switch (port) {
-    case 0:
+    case HAL_SPI_kOnboardCS0:
       CommonSPIPortInit(status);
       if (*status != 0) return;
       // CS0 is not a DIO port, so nothing to allocate
@@ -123,7 +123,7 @@ void HAL_InitializeSPI(HAL_SPIPort port, int32_t* status) {
       }
       HAL_SetSPIHandle(HAL_SPI_kOnboardCS0, handle);
       break;
-    case 1:
+    case HAL_SPI_kOnboardCS1:
       CommonSPIPortInit(status);
       if (*status != 0) return;
       // CS1, Allocate
@@ -144,7 +144,7 @@ void HAL_InitializeSPI(HAL_SPIPort port, int32_t* status) {
       }
       HAL_SetSPIHandle(HAL_SPI_kOnboardCS1, handle);
       break;
-    case 2:
+    case HAL_SPI_kOnboardCS2:
       CommonSPIPortInit(status);
       if (*status != 0) return;
       // CS2, Allocate
@@ -165,7 +165,7 @@ void HAL_InitializeSPI(HAL_SPIPort port, int32_t* status) {
       }
       HAL_SetSPIHandle(HAL_SPI_kOnboardCS2, handle);
       break;
-    case 3:
+    case HAL_SPI_kOnboardCS3:
       CommonSPIPortInit(status);
       if (*status != 0) return;
       // CS3, Allocate
@@ -186,7 +186,7 @@ void HAL_InitializeSPI(HAL_SPIPort port, int32_t* status) {
       }
       HAL_SetSPIHandle(HAL_SPI_kOnboardCS3, handle);
       break;
-    case 4:
+    case HAL_SPI_kMXP:
       initializeDigital(status);
       if (*status != 0) return;
       if ((digitalHandles[5] = HAL_InitializeDIOPort(createPortHandleForSPI(14),

--- a/hal/src/main/native/include/hal/I2C.h
+++ b/hal/src/main/native/include/hal/I2C.h
@@ -18,7 +18,7 @@
  */
 
 // clang-format off
-HAL_ENUM(HAL_I2CPort) { HAL_I2C_kOnboard = 0, HAL_I2C_kMXP };
+HAL_ENUM(HAL_I2CPort) { HAL_I2C_kInvalid = -1, HAL_I2C_kOnboard, HAL_I2C_kMXP };
 // clang-format on
 
 #ifdef __cplusplus

--- a/hal/src/main/native/include/hal/SPI.h
+++ b/hal/src/main/native/include/hal/SPI.h
@@ -20,7 +20,8 @@
 
 // clang-format off
 HAL_ENUM(HAL_SPIPort) {
-  HAL_SPI_kOnboardCS0 = 0,
+  HAL_SPI_kInvalid = -1,
+  HAL_SPI_kOnboardCS0,
   HAL_SPI_kOnboardCS1,
   HAL_SPI_kOnboardCS2,
   HAL_SPI_kOnboardCS3,

--- a/wpilibc/src/main/native/include/frc/I2C.h
+++ b/wpilibc/src/main/native/include/frc/I2C.h
@@ -9,9 +9,9 @@
 
 #include <stdint.h>
 
-#include "frc/ErrorBase.h"
+#include <hal/I2C.h>
 
-enum HAL_I2CPort : int32_t;
+#include "frc/ErrorBase.h"
 
 namespace frc {
 
@@ -135,7 +135,7 @@ class I2C : public ErrorBase {
   bool VerifySensor(int registerAddress, int count, const uint8_t* expected);
 
  private:
-  HAL_I2CPort m_port;
+  HAL_I2CPort m_port = HAL_I2C_kInvalid;
   int m_deviceAddress;
 };
 

--- a/wpilibc/src/main/native/include/frc/SPI.h
+++ b/wpilibc/src/main/native/include/frc/SPI.h
@@ -11,12 +11,11 @@
 
 #include <memory>
 
+#include <hal/SPI.h>
 #include <wpi/ArrayRef.h>
 #include <wpi/deprecated.h>
 
 #include "frc/ErrorBase.h"
-
-enum HAL_SPIPort : int32_t;
 
 namespace frc {
 
@@ -315,7 +314,7 @@ class SPI : public ErrorBase {
   void GetAccumulatorOutput(int64_t& value, int64_t& count) const;
 
  protected:
-  HAL_SPIPort m_port;
+  HAL_SPIPort m_port = HAL_SPI_kInvalid;
   bool m_msbFirst = false;          // Default little-endian
   bool m_sampleOnTrailing = false;  // Default data updated on falling edge
   bool m_clockIdleHigh = false;     // Default clock active high


### PR DESCRIPTION
This allows HAL_CloseI2C() and HAL_CloseSPI() to be noops, which makes
enabling move semantics in the I2C and SPI wpilibc classes easier and
cleaner.

Fixes #1328.