### PR TITLE
Replace typedefs in C++ source with using declarations

### DIFF
--- a/cscore/src/main/native/cpp/Frame.h
+++ b/cscore/src/main/native/cpp/Frame.h
@@ -29,7 +29,7 @@ class Frame {
   friend class SourceImpl;
 
  public:
-  typedef uint64_t Time;
+  using Time = uint64_t;
 
  private:
   struct Impl {

--- a/cscore/src/main/native/cpp/Notifier.cpp
+++ b/cscore/src/main/native/cpp/Notifier.cpp
@@ -24,7 +24,7 @@ namespace {
 template <typename T>
 class UidVector {
  public:
-  typedef typename std::vector<T>::size_type size_type;
+  using size_type = typename std::vector<T>::size_type;
 
   size_type size() const { return m_vector.size(); }
   T& operator[](size_type i) { return m_vector[i]; }

--- a/cscore/src/main/native/cpp/default_init_allocator.h
+++ b/cscore/src/main/native/cpp/default_init_allocator.h
@@ -14,7 +14,7 @@ namespace cs {
 // convert value initialization into default initialization.
 template <typename T, typename A = std::allocator<T>>
 class default_init_allocator : public A {
-  typedef std::allocator_traits<A> a_t;
+  using a_t = std::allocator_traits<A>;
 
  public:
   template <typename U>

--- a/cscore/src/main/native/include/cscore_cpp.h
+++ b/cscore/src/main/native/include/cscore_cpp.h
@@ -371,9 +371,8 @@ double GetTelemetryAverageValue(CS_Handle handle, CS_TelemetryKind kind,
  * @defgroup cscore_logging_func Logging Functions
  * @{
  */
-typedef std::function<void(unsigned int level, const char* file,
-                           unsigned int line, const char* msg)>
-    LogFunc;
+using LogFunc = std::function<void(unsigned int level, const char* file,
+                                   unsigned int line, const char* msg)>;
 void SetLogger(LogFunc func, unsigned int min_level);
 void SetDefaultLogger(unsigned int min_level);
 /** @} */

--- a/hal/src/main/native/include/hal/cpp/Log.h
+++ b/hal/src/main/native/include/hal/cpp/Log.h
@@ -90,7 +90,7 @@ inline TLogLevel Log::FromString(const std::string& level) {
   return logINFO;
 }
 
-typedef Log FILELog;
+using FILELog = Log;  // NOLINT
 
 #define FILE_LOG(level)                  \
   if (level > FILELog::ReportingLevel()) \

--- a/hal/src/main/native/include/hal/cpp/fpga_clock.h
+++ b/hal/src/main/native/include/hal/cpp/fpga_clock.h
@@ -18,10 +18,10 @@ namespace hal {
  */
 class fpga_clock {
  public:
-  typedef std::chrono::microseconds::rep rep;
-  typedef std::chrono::microseconds::period period;
-  typedef std::chrono::microseconds duration;
-  typedef std::chrono::time_point<fpga_clock> time_point;
+  using rep = std::chrono::microseconds::rep;
+  using period = std::chrono::microseconds::period;
+  using duration = std::chrono::microseconds;
+  using time_point = std::chrono::time_point<fpga_clock>;
 
   static fpga_clock::time_point now() noexcept;
   static constexpr bool is_steady = true;

--- a/wpilibc/src/main/native/cpp/commands/Scheduler.cpp
+++ b/wpilibc/src/main/native/cpp/commands/Scheduler.cpp
@@ -28,15 +28,15 @@ struct Scheduler::Impl {
   void Remove(Command* command);
   void ProcessCommandAddition(Command* command);
 
-  typedef std::set<Subsystem*> SubsystemSet;
+  using SubsystemSet = std::set<Subsystem*>;
   SubsystemSet subsystems;
   wpi::mutex buttonsMutex;
-  typedef std::vector<std::unique_ptr<ButtonScheduler>> ButtonVector;
+  using ButtonVector = std::vector<std::unique_ptr<ButtonScheduler>>;
   ButtonVector buttons;
-  typedef std::vector<Command*> CommandVector;
+  using CommandVector = std::vector<Command*>;
   wpi::mutex additionsMutex;
   CommandVector additions;
-  typedef std::set<Command*> CommandSet;
+  using CommandSet = std::set<Command*>;
   CommandSet commands;
   bool adding = false;
   bool enabled = true;

--- a/wpilibc/src/main/native/include/frc/Error.h
+++ b/wpilibc/src/main/native/include/frc/Error.h
@@ -31,7 +31,7 @@ class ErrorBase;
  */
 class Error {
  public:
-  typedef int Code;
+  using Code = int;
 
   Error() = default;
   Error(Code code, const wpi::Twine& contextMessage, wpi::StringRef filename,

--- a/wpilibc/src/main/native/include/frc/Notifier.h
+++ b/wpilibc/src/main/native/include/frc/Notifier.h
@@ -21,7 +21,7 @@
 
 namespace frc {
 
-typedef std::function<void()> TimerEventHandler;
+using TimerEventHandler = std::function<void()>;
 
 class Notifier : public ErrorBase {
  public:

--- a/wpilibc/src/main/native/include/frc/Timer.h
+++ b/wpilibc/src/main/native/include/frc/Timer.h
@@ -14,7 +14,7 @@
 
 namespace frc {
 
-typedef void (*TimerInterruptHandler)(void* param);
+using TimerInterruptHandler = void (*)(void* param);
 
 /**
  * Pause the task for a specified time.

--- a/wpilibc/src/main/native/include/frc/circular_buffer.h
+++ b/wpilibc/src/main/native/include/frc/circular_buffer.h
@@ -21,13 +21,13 @@ class circular_buffer {
  public:
   explicit circular_buffer(size_t size);
 
-  typedef T value_type;
-  typedef value_type& reference;
-  typedef const value_type& const_reference;
-  typedef value_type* pointer;
-  typedef size_t size_type;
-  typedef std::forward_iterator_tag iterator_category;
-  typedef std::ptrdiff_t difference_type;
+  using value_type = T;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = value_type*;
+  using size_type = size_t;
+  using iterator_category = std::forward_iterator_tag;
+  using difference_type = std::ptrdiff_t;
 
   size_type size() const;
   T& front();

--- a/wpilibc/src/main/native/include/frc/commands/Command.h
+++ b/wpilibc/src/main/native/include/frc/commands/Command.h
@@ -221,7 +221,7 @@ class Command : public ErrorBase, public SendableBase {
    */
   bool DoesRequire(Subsystem* subsystem) const;
 
-  typedef wpi::SmallPtrSetImpl<Subsystem*> SubsystemSet;
+  using SubsystemSet = wpi::SmallPtrSetImpl<Subsystem*>;
 
   /**
    * Returns the requirements (as an std::set of Subsystem pointers) of this

--- a/wpilibc/src/main/native/include/frc/commands/CommandGroupEntry.h
+++ b/wpilibc/src/main/native/include/frc/commands/CommandGroupEntry.h
@@ -13,11 +13,11 @@ class Command;
 
 class CommandGroupEntry {
  public:
-  typedef enum {
+  enum Sequence {
     kSequence_InSequence,
     kSequence_BranchPeer,
     kSequence_BranchChild
-  } Sequence;
+  };
 
   CommandGroupEntry() = default;
   CommandGroupEntry(Command* command, Sequence state, double timeout = -1.0);

--- a/wpiutil/src/main/native/include/wpi/Logger.h
+++ b/wpiutil/src/main/native/include/wpi/Logger.h
@@ -29,9 +29,8 @@ enum LogLevel {
 
 class Logger {
  public:
-  typedef std::function<void(unsigned int level, const char* file,
-                             unsigned int line, const char* msg)>
-      LogFunc;
+  using LogFunc = std::function<void(unsigned int level, const char* file,
+                                     unsigned int line, const char* msg)>;
 
   Logger() = default;
   explicit Logger(const LogFunc& func) : m_func(func) {}

--- a/wpiutil/src/main/native/include/wpi/priority_mutex.h
+++ b/wpiutil/src/main/native/include/wpi/priority_mutex.h
@@ -26,7 +26,7 @@ namespace wpi {
 
 class priority_recursive_mutex {
  public:
-  typedef pthread_mutex_t* native_handle_type;
+  using native_handle_type = pthread_mutex_t*;
 
   constexpr priority_recursive_mutex() noexcept = default;
   priority_recursive_mutex(const priority_recursive_mutex&) = delete;
@@ -57,7 +57,7 @@ class priority_recursive_mutex {
 
 class priority_mutex {
  public:
-  typedef pthread_mutex_t* native_handle_type;
+  using native_handle_type = pthread_mutex_t*;
 
   constexpr priority_mutex() noexcept = default;
   priority_mutex(const priority_mutex&) = delete;


### PR DESCRIPTION
These are more readable than typedefs. C headers were left alone.