### PR TITLE
Deprecate IterativeRobot in favor of TimedRobot

### DIFF
--- a/wpilibc/src/main/native/include/frc/IterativeRobot.h
+++ b/wpilibc/src/main/native/include/frc/IterativeRobot.h
@@ -22,6 +22,9 @@ namespace frc {
  */
 class IterativeRobot : public IterativeRobotBase {
  public:
+  WPI_DEPRECATED(
+      "Use TimedRobot instead. It's a drop-in replacement that provides more "
+      "regular execution periods.")
   IterativeRobot();
   virtual ~IterativeRobot() = default;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobot.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobot.java
@@ -18,7 +18,11 @@ import edu.wpi.first.hal.HAL;
  *
  * <p>periodic() functions from the base class are called each time a new packet is received from
  * the driver station.
+ *
+ * @deprecated Use TimedRobot instead. It's a drop-in replacement that provides more regular
+ *     execution periods.
  */
+@Deprecated
 public class IterativeRobot extends IterativeRobotBase {
   private static final double kPacketPeriod = 0.02;
 


### PR DESCRIPTION
Since https://github.com/wpilibsuite/allwpilib/issues/786 has been
closed as not a legitimate concern, there is now no reason to use
IterativeRobot over TimedRobot. It's a drop-in replacement that's
strictly an improvement in terms of execution jitter.

To migrate, one simply has to replace the IterativeRobot subclass in
their robot code with TimedRobot.