### PR TITLE
Java 11 Static Analysis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,7 @@ plugins {
     id 'edu.wpi.first.GradleVsCode' version '0.4.2'
     id 'idea'
     id 'com.gradle.build-scan' version '1.15.1'
-    id 'net.ltgt.errorprone' version '0.0.15' apply false // For Java 8
-    id 'net.ltgt.errorprone-javacplugin' version '0.3' apply false // For Java 9+
+    id 'net.ltgt.errorprone' version '0.6'
 }
 
 repositories {

--- a/ntcore/src/test/java/edu/wpi/first/networktables/ConnectionListenerTest.java
+++ b/ntcore/src/test/java/edu/wpi/first/networktables/ConnectionListenerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.condition.OS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -65,9 +66,9 @@ class ConnectionListenerTest {
   void testJNI() {
     // set up the poller
     int poller = NetworkTablesJNI.createConnectionListenerPoller(m_serverInst.getHandle());
-    assertTrue(poller != 0, "bad poller handle");
+    assertNotSame(poller, 0, "bad poller handle");
     int handle = NetworkTablesJNI.addPolledConnectionListener(poller, false);
-    assertTrue(handle != 0, "bad listener handle");
+    assertNotSame(handle, 0, "bad listener handle");
 
     // trigger a connect event
     connect();

--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -113,6 +113,7 @@ dependencies {
     devCompile sourceSets.main.output
 
     errorprone 'com.google.errorprone:error_prone_core:2.3.2-SNAPSHOT'
+    errorproneJavac 'com.google.errorprone:error_prone_core:2.3.1'
 }
 
 task run(type: JavaExec) {

--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -1,11 +1,6 @@
 apply plugin: 'maven-publish'
 apply plugin: 'java'
-
-if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
-    apply plugin: 'net.ltgt.errorprone'
-} else {
-    apply plugin: 'net.ltgt.errorprone-javacplugin'
-}
+apply plugin: 'net.ltgt.errorprone'
 
 def pubVersion
 if (project.hasProperty("publishVersion")) {
@@ -98,6 +93,7 @@ if (project.hasProperty('onlyAthena')) {
 
 repositories {
     mavenCentral()
+    maven.url "https://oss.sonatype.org/content/repositories/snapshots/"
 }
 
 sourceSets {
@@ -116,7 +112,7 @@ dependencies {
 
     devCompile sourceSets.main.output
 
-    errorprone 'com.google.errorprone:error_prone_core:2.3.1'
+    errorprone 'com.google.errorprone:error_prone_core:2.3.2-SNAPSHOT'
 }
 
 task run(type: JavaExec) {

--- a/shared/java/javastyle.gradle
+++ b/shared/java/javastyle.gradle
@@ -9,7 +9,7 @@ checkstyle {
 }
 
 pmd {
-    toolVersion = '6.3.0'
+    toolVersion = '6.7.0'
     consoleOutput = true
     reportsDir = file("$project.buildDir/reports/pmd")
     ruleSetFiles = files(new File(rootDir, "styleguide/pmd-ruleset.xml"))

--- a/shared/java/javastyle.gradle
+++ b/shared/java/javastyle.gradle
@@ -3,8 +3,9 @@ apply plugin: 'checkstyle'
 apply plugin: 'pmd'
 
 checkstyle {
-    toolVersion = "8.10"
-    configFile = new File(rootDir, "styleguide/checkstyle.xml")
+    toolVersion = "8.12"
+    configDir = file("${project.rootDir}/styleguide")
+    config = resources.text.fromFile(new File(configDir, "checkstyle.xml"))
 }
 
 pmd {

--- a/styleguide/checkstyle.xml
+++ b/styleguide/checkstyle.xml
@@ -20,7 +20,7 @@ module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
             value="error" />
   <module name="SuppressionFilter">
     <property name="file"
-              value="styleguide/suppressions.xml" />
+              value="${config_loc}/suppressions.xml" />
   </module>
   <property name="fileExtensions"
             value="java, properties, xml" />

--- a/styleguide/pmd-ruleset.xml
+++ b/styleguide/pmd-ruleset.xml
@@ -50,6 +50,7 @@
     <exclude name="DataflowAnomalyAnalysis" />
     <exclude name="DoNotCallSystemExit" />
     <exclude name="FinalizeDoesNotCallSuperFinalize" />
+    <exclude name="MissingSerialVersionUID" />
     <exclude name="NullAssignment" />
   </rule>
 

--- a/styleguide/pmd-ruleset.xml
+++ b/styleguide/pmd-ruleset.xml
@@ -50,6 +50,7 @@
     <exclude name="DataflowAnomalyAnalysis" />
     <exclude name="DoNotCallSystemExit" />
     <exclude name="FinalizeDoesNotCallSuperFinalize" />
+    <exclude name="JUnitSpelling" />
     <exclude name="MissingSerialVersionUID" />
     <exclude name="NullAssignment" />
   </rule>

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/ConditionalCommandTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/ConditionalCommandTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ConditionalCommandTest extends AbstractCommandTest {
@@ -75,7 +76,7 @@ class ConditionalCommandTest extends AbstractCommandTest {
     assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
 
     assertTrue(m_onTrue.getInitializeCount() > 0, "Did not initialize the true command");
-    assertTrue(m_onFalse.getInitializeCount() == 0, "Initialized the false command");
+    assertSame(m_onFalse.getInitializeCount(), 0, "Initialized the false command");
   }
 
   @Test
@@ -113,7 +114,7 @@ class ConditionalCommandTest extends AbstractCommandTest {
     assertConditionalCommandState(m_command, 1, 5, 5, 1, 0);
 
     assertTrue(m_onFalse.getInitializeCount() > 0, "Did not initialize the false command");
-    assertTrue(m_onTrue.getInitializeCount() == 0, "Initialized the true command");
+    assertSame(m_onTrue.getInitializeCount(), 0, "Initialized the true command");
   }
 
   @Test


### PR DESCRIPTION
This updates our static analysis tools so they work on Java 11.

We cannot merge this until https://github.com/google/error-prone/issues/1127 is closed and the PR is updated to use the release version of error prone.