### PR TITLE
SafeThread: Avoid use-after-free risk in thread shutdown

### DIFF
--- a/cscore/src/main/native/cpp/MjpegServerImpl.cpp
+++ b/cscore/src/main/native/cpp/MjpegServerImpl.cpp
@@ -865,10 +865,7 @@ void MjpegServerImpl::ServerThreadMain() {
     }
 
     // Start it if not already started
-    {
-      auto thr = it->GetThread();
-      if (!thr) it->Start(new ConnThread{GetName()});
-    }
+    it->Start(GetName());
 
     auto nstreams =
         std::count_if(m_connThreads.begin(), m_connThreads.end(),

--- a/cscore/src/main/native/cpp/Notifier.cpp
+++ b/cscore/src/main/native/cpp/Notifier.cpp
@@ -94,10 +94,7 @@ Notifier::Notifier() { s_destroyed = false; }
 
 Notifier::~Notifier() { s_destroyed = true; }
 
-void Notifier::Start() {
-  auto thr = m_owner.GetThread();
-  if (!thr) m_owner.Start(new Thread(m_on_start, m_on_exit));
-}
+void Notifier::Start() { m_owner.Start(m_on_start, m_on_exit); }
 
 void Notifier::Stop() { m_owner.Stop(); }
 

--- a/cscore/src/main/native/cpp/Telemetry.cpp
+++ b/cscore/src/main/native/cpp/Telemetry.cpp
@@ -45,10 +45,7 @@ Telemetry::Telemetry() {}
 
 Telemetry::~Telemetry() {}
 
-void Telemetry::Start() {
-  auto thr = m_owner.GetThread();
-  if (!thr) m_owner.Start(new Thread);
-}
+void Telemetry::Start() { m_owner.Start(); }
 
 void Telemetry::Stop() { m_owner.Stop(); }
 

--- a/ntcore/src/main/native/cpp/CallbackManager.h
+++ b/ntcore/src/main/native/cpp/CallbackManager.h
@@ -294,8 +294,7 @@ class CallbackManager {
  protected:
   template <typename... Args>
   void DoStart(Args&&... args) {
-    auto thr = m_owner.GetThread();
-    if (!thr) m_owner.Start(new Thread(std::forward<Args>(args)...));
+    m_owner.Start(std::forward<Args>(args)...);
   }
 
   template <typename... Args>

--- a/ntcore/src/main/native/cpp/DsClient.cpp
+++ b/ntcore/src/main/native/cpp/DsClient.cpp
@@ -36,7 +36,7 @@ DsClient::DsClient(Dispatcher& dispatcher, wpi::Logger& logger)
 void DsClient::Start(unsigned int port) {
   auto thr = m_owner.GetThread();
   if (!thr)
-    m_owner.Start(new Thread(m_dispatcher, m_logger, port));
+    m_owner.Start(m_dispatcher, m_logger, port);
   else
     thr->m_port = port;
 }

--- a/wpiutil/src/main/native/cpp/EventLoopRunner.cpp
+++ b/wpiutil/src/main/native/cpp/EventLoopRunner.cpp
@@ -39,7 +39,7 @@ class EventLoopRunner::Thread : public SafeThread {
   std::weak_ptr<UvExecFunc> m_doExec;
 };
 
-EventLoopRunner::EventLoopRunner() { m_owner.Start(new Thread); }
+EventLoopRunner::EventLoopRunner() { m_owner.Start(); }
 
 EventLoopRunner::~EventLoopRunner() {
   ExecAsync([](uv::Loop& loop) {

--- a/wpiutil/src/main/native/cpp/SafeThread.cpp
+++ b/wpiutil/src/main/native/cpp/SafeThread.cpp
@@ -1,0 +1,65 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2015-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "wpi/SafeThread.h"
+
+using namespace wpi;
+
+detail::SafeThreadProxyBase::SafeThreadProxyBase(
+    std::shared_ptr<SafeThread> thr)
+    : m_thread(std::move(thr)) {
+  if (!m_thread) return;
+  m_lock = std::unique_lock<wpi::mutex>(m_thread->m_mutex);
+  if (!m_thread->m_active) {
+    m_lock.unlock();
+    m_thread = nullptr;
+    return;
+  }
+}
+
+void detail::SafeThreadOwnerBase::Start(std::shared_ptr<SafeThread> thr) {
+  std::lock_guard<wpi::mutex> lock(m_mutex);
+  if (auto thr = m_thread.lock()) return;
+  std::thread stdThread([=] { thr->Main(); });
+  m_thread = thr;
+  m_nativeHandle = stdThread.native_handle();
+  stdThread.detach();
+}
+
+void detail::SafeThreadOwnerBase::Stop() {
+  std::lock_guard<wpi::mutex> lock(m_mutex);
+  if (auto thr = m_thread.lock()) {
+    thr->m_active = false;
+    thr->m_cond.notify_one();
+  }
+}
+
+void detail::swap(SafeThreadOwnerBase& lhs, SafeThreadOwnerBase& rhs) noexcept {
+  using std::swap;
+  if (&lhs == &rhs) return;
+  std::lock(lhs.m_mutex, rhs.m_mutex);
+  std::lock_guard<wpi::mutex> lock_lhs(lhs.m_mutex, std::adopt_lock);
+  std::lock_guard<wpi::mutex> lock_rhs(rhs.m_mutex, std::adopt_lock);
+  std::swap(lhs.m_thread, rhs.m_thread);
+  std::swap(lhs.m_nativeHandle, rhs.m_nativeHandle);
+}
+
+detail::SafeThreadOwnerBase::operator bool() const {
+  std::lock_guard<wpi::mutex> lock(m_mutex);
+  return !m_thread.expired();
+}
+
+std::thread::native_handle_type
+detail::SafeThreadOwnerBase::GetNativeThreadHandle() const {
+  std::lock_guard<wpi::mutex> lock(m_mutex);
+  return m_nativeHandle;
+}
+
+std::shared_ptr<SafeThread> detail::SafeThreadOwnerBase::GetThread() const {
+  std::lock_guard<wpi::mutex> lock(m_mutex);
+  return m_thread.lock();
+}


### PR DESCRIPTION
Use shared_ptr to keep data alive until the thread has terminated.