### PR TITLE
wpiutil: SafeThread: join on thread exit

### DIFF
--- a/wpiutil/src/main/native/include/wpi/jni_util.h
+++ b/wpiutil/src/main/native/include/wpi/jni_util.h
@@ -479,6 +479,7 @@ class JCallbackThread : public SafeThread {
 template <typename T>
 class JCallbackManager : public SafeThreadOwner<JCallbackThread<T>> {
  public:
+  JCallbackManager() { this->SetJoinAtExit(false); }
   void SetFunc(JNIEnv* env, jobject func, jmethodID mid);
 
   template <typename... Args>


### PR DESCRIPTION
This can be conditionally disabled (for cases like JNI callbacks where the JVM
may block callbacks into it during shutdown).