### PR TITLE
Update NativeUtils to not copy ni libraries to jenkins RoboRIO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'base'
     id 'edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin' version '2.2'
-    id 'edu.wpi.first.NativeUtils' version '1.7.4'
+    id 'edu.wpi.first.NativeUtils' version '1.7.5'
     id 'edu.wpi.first.GradleJni' version '0.3.0'
     id 'edu.wpi.first.GradleVsCode' version '0.4.2'
     id 'idea'

--- a/shared/nilibraries.gradle
+++ b/shared/nilibraries.gradle
@@ -19,6 +19,7 @@ model {
       version = '2018.17.1'
       sharedConfigs = chipObjectConfigs
       staticConfigs = [:]
+      compileOnlyShared = true
     }
     netcomm(DependencyConfig) {
       groupId = 'edu.wpi.first.ni-libraries'
@@ -28,6 +29,7 @@ model {
       version = '2018.17.1'
       sharedConfigs = netCommLibConfigs
       staticConfigs = [:]
+      compileOnlyShared = true
     }
   }
 }


### PR DESCRIPTION
Allows for compile only shared libraries