### PR TITLE
Add communication examples

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/DigitalCommunication/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DigitalCommunication/cpp/Robot.cpp
@@ -6,8 +6,8 @@
 /*----------------------------------------------------------------------------*/
 
 #include <frc/DigitalOutput.h>
-#include <frc/TimedRobot.h>
 #include <frc/DriverStation.h>
+#include <frc/TimedRobot.h>
 
 /**
  * This is a sample program demonstrating how to communicate to a light

--- a/wpilibcExamples/src/main/cpp/examples/DigitalCommunication/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DigitalCommunication/cpp/Robot.cpp
@@ -1,0 +1,47 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <frc/DigitalOutput.h>
+#include <frc/TimedRobot.h>
+#include <frc/DriverStation.h>
+
+/**
+ * This is a sample program demonstrating how to communicate to a light
+ * controller from the robot code using the roboRIO's DIO ports.
+ */
+class Robot : public frc::TimedRobot {
+ public:
+  void RobotPeriodic() override {
+    frc::DriverStation& ds = frc::DriverStation::GetInstance();
+
+    // pull alliance port high if on red alliance, pull low if on blue alliance
+    m_allianceOutput.Set(ds.GetAlliance() == frc::DriverStation::kRed);
+
+    // pull enabled port high if enabled, low if disabled
+    m_enabledOutput.Set(ds.IsEnabled());
+
+    // pull auto port high if in autonomous, low if in teleop (or disabled)
+    m_autonomousOutput.Set(ds.IsAutonomous());
+
+    // pull alert port high if match time remaining is between 30 and 25 seconds
+    m_alertOutput.Set(ds.GetMatchTime() <= 30 && ds.GetMatchTime() >= 25);
+  }
+
+ private:
+  // define ports for communication with light controller
+  static constexpr int kAlliancePort = 0;
+  static constexpr int kEnabledPort = 1;
+  static constexpr int kAutonomousPort = 2;
+  static constexpr int kAlertPort = 3;
+
+  frc::DigitalOutput m_allianceOutput{kAlliancePort};
+  frc::DigitalOutput m_enabledOutput{kEnabledPort};
+  frc::DigitalOutput m_autonomousOutput{kAutonomousPort};
+  frc::DigitalOutput m_alertOutput{kAlertPort};
+};
+
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/examples.json
+++ b/wpilibcExamples/src/main/cpp/examples/examples.json
@@ -216,5 +216,14 @@
     ],
     "foldername": "PacGoat",
     "gradlebase": "cpp"
+  },
+  {
+    "name": "Digital Communication Sample",
+    "description": "An example program that communicates with external devices (such as an Arduino) using the roboRIO's DIO",
+    "tags": [
+      "Digital"
+    ],
+    "foldername": "DigitalCommunication",
+    "gradlebase": "cpp"
   }
 ]

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/digitalcommunication/Main.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/digitalcommunication/Main.java
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.digitalcommunication;
+
+import edu.wpi.first.wpilibj.RobotBase;
+
+/**
+ * Do NOT add any static variables to this class, or any initialization at all.
+ * Unless you know what you are doing, do not modify this file except to
+ * change the parameter class to the startRobot call.
+ */
+public final class Main {
+  private Main() {
+  }
+
+  /**
+   * Main initialization function. Do not perform any initialization here.
+   *
+   * <p>If you change your main robot class, change the parameter type.
+   */
+  public static void main(String... args) {
+    RobotBase.startRobot(Robot::new);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/digitalcommunication/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/digitalcommunication/Robot.java
@@ -1,0 +1,46 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.digitalcommunication;
+
+import edu.wpi.first.wpilibj.DigitalOutput;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.TimedRobot;
+
+/**
+ * This is a sample program demonstrating how to communicate to a light
+ * controller from the robot code using the roboRIO's DIO ports.
+ */
+public class Robot extends TimedRobot {
+  // define ports for digitalcommunication with light controller
+  private static final int kAlliancePort = 0;
+  private static final int kEnabledPort = 1;
+  private static final int kAutonomousPort = 2;
+  private static final int kAlertPort = 3;
+
+  private final DigitalOutput m_allianceOutput = new DigitalOutput(kAlliancePort);
+  private final DigitalOutput m_enabledOutput = new DigitalOutput(kEnabledPort);
+  private final DigitalOutput m_autonomousOutput = new DigitalOutput(kAutonomousPort);
+  private final DigitalOutput m_alertOutput = new DigitalOutput(kAlertPort);
+
+  @Override
+  public void robotPeriodic() {
+    DriverStation driverStation = DriverStation.getInstance();
+
+    // pull alliance port high if on red alliance, pull low if on blue alliance
+    m_allianceOutput.set(driverStation.getAlliance() == DriverStation.Alliance.Red);
+
+    // pull enabled port high if enabled, low if disabled
+    m_enabledOutput.set(driverStation.isEnabled());
+
+    // pull auto port high if in autonomous, low if in teleop (or disabled)
+    m_autonomousOutput.set(driverStation.isAutonomous());
+
+    // pull alert port high if match time remaining is between 30 and 25 seconds
+    m_alertOutput.set(driverStation.getMatchTime() <= 30 && driverStation.getMatchTime() >= 25);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/examples.json
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/examples.json
@@ -187,5 +187,15 @@
     "foldername": "shuffleboard",
     "gradlebase": "java",
     "mainclass": "Main"
+  },
+  {
+    "name": "Digital Communication Sample",
+    "description": "An example program that communicates with external devices (such as an Arduino) using the roboRIO's DIO",
+    "tags": [
+      "Digital"
+    ],
+    "foldername": "digitalcommunication",
+    "gradlebase": "java",
+    "mainclass": "Main"
   }
 ]

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/examples.json
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/examples.json
@@ -197,5 +197,15 @@
     "foldername": "digitalcommunication",
     "gradlebase": "java",
     "mainclass": "Main"
+  },
+  {
+    "name": "I2C Communication Sample",
+    "description": "An example program that communicates with external devices (such as an Arduino) using the roboRIO's I2C port",
+    "tags": [
+      "I2C"
+    ],
+    "foldername": "i2ccommunication",
+    "gradlebase": "java",
+    "mainclass": "Main"
   }
 ]

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/i2ccommunication/Main.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/i2ccommunication/Main.java
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.i2ccommunication;
+
+import edu.wpi.first.wpilibj.RobotBase;
+
+/**
+ * Do NOT add any static variables to this class, or any initialization at all.
+ * Unless you know what you are doing, do not modify this file except to
+ * change the parameter class to the startRobot call.
+ */
+public final class Main {
+  private Main() {
+  }
+
+  /**
+   * Main initialization function. Do not perform any initialization here.
+   *
+   * <p>If you change your main robot class, change the parameter type.
+   */
+  public static void main(String... args) {
+    RobotBase.startRobot(Robot::new);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/i2ccommunication/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/i2ccommunication/Robot.java
@@ -1,0 +1,62 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.i2ccommunication;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.I2C;
+import edu.wpi.first.wpilibj.TimedRobot;
+
+/**
+ * This is a sample program demonstrating how to communicate to a light
+ * controller from the robot code using the roboRIO's I2C port.
+ */
+public class Robot extends TimedRobot {
+  private static int kDeviceAddress = 4;
+
+  private static I2C m_arduino = new I2C(I2C.Port.kOnboard, kDeviceAddress);
+
+  private void writeString(String input) {
+    // Creates a char array from the input string
+    char[] chars = input.toCharArray();
+
+    // Creates a byte array from the char array
+    byte[] data = new byte[chars.length];
+
+    // Adds each character
+    for (int i = 0; i < chars.length; i++) {
+      data[i] = (byte) chars[i];
+    }
+
+    // Writes bytes over I2C
+    m_arduino.transaction(data, data.length, null, 0);
+  }
+
+  @Override
+  public void robotPeriodic() {
+    DriverStation driverStation = DriverStation.getInstance();
+
+    // Creates a string to hold current robot state information, including
+    // alliance, enabled state, operation mode, and match time. The message
+    // is sent in format "AEM###" where A is the alliance color, (R)ed or
+    // (B)lue, E is the enabled state, (E)nabled or (D)isabled, M is the
+    // operation mode, (A)utonomous or (T)eleop, and ### is the zero-padded
+    // time remaining in the match.
+    //
+    // For example, "RET043" would indicate that the robot is on the red
+    // alliance, enabled in teleop mode, with 43 seconds left in the match.
+    StringBuilder stateMessage = new StringBuilder(6);
+
+    stateMessage
+            .append(driverStation.getAlliance() == DriverStation.Alliance.Red ? "R" : "B")
+            .append(driverStation.isEnabled() ? "E" : "D")
+            .append(driverStation.isAutonomous() ? "A" : "T")
+            .append(String.format("%03d" , (int) driverStation.getMatchTime()));
+
+    writeString(stateMessage.toString());
+  }
+}


### PR DESCRIPTION
Closes https://github.com/wpilibsuite/allwpilib/issues/1038

This adds various Java/C++ communication samples, including DigitalOutput and I2C.

I can whip up some sample Arduino code to consume the data being sent, but that likely falls outside the scope of this repo. Maybe just providing a link to a Gist with a minimal working example would suffice? Open to ideas.

Also, if anyone has any additional related sample ideas they'd like me to throw in this PR, I'd be more than happy to!