### PR TITLE
Remove some usages of windows.h

### DIFF
--- a/hal/src/main/native/athena/Threads.cpp
+++ b/hal/src/main/native/athena/Threads.cpp
@@ -24,7 +24,8 @@ int32_t HAL_GetThreadPriority(NativeThreadHandle handle, HAL_Bool* isRealTime,
                               int32_t* status) {
   sched_param sch;
   int policy;
-  int success = pthread_getschedparam(*reinterpret_cast<const pthread_t*>(handle), &policy, &sch);
+  int success = pthread_getschedparam(
+      *reinterpret_cast<const pthread_t*>(handle), &policy, &sch);
   if (success == 0) {
     *status = 0;
   } else {
@@ -66,13 +67,15 @@ HAL_Bool HAL_SetThreadPriority(NativeThreadHandle handle, HAL_Bool realTime,
 
   sched_param sch;
   int policy;
-  pthread_getschedparam(*reinterpret_cast<const pthread_t*>(handle), &policy, &sch);
+  pthread_getschedparam(*reinterpret_cast<const pthread_t*>(handle), &policy,
+                        &sch);
   if (scheduler == SCHED_FIFO || scheduler == SCHED_RR)
     sch.sched_priority = priority;
   else
     // Only need to set 0 priority for non RT thread
     sch.sched_priority = 0;
-  if (pthread_setschedparam(*reinterpret_cast<const pthread_t*>(handle), scheduler, &sch)) {
+  if (pthread_setschedparam(*reinterpret_cast<const pthread_t*>(handle),
+                            scheduler, &sch)) {
     *status = HAL_THREAD_PRIORITY_ERROR;
     return false;
   } else {

--- a/hal/src/main/native/athena/Threads.cpp
+++ b/hal/src/main/native/athena/Threads.cpp
@@ -24,7 +24,7 @@ int32_t HAL_GetThreadPriority(NativeThreadHandle handle, HAL_Bool* isRealTime,
                               int32_t* status) {
   sched_param sch;
   int policy;
-  int success = pthread_getschedparam(*handle, &policy, &sch);
+  int success = pthread_getschedparam(*reinterpret_cast<const pthread_t*>(handle), &policy, &sch);
   if (success == 0) {
     *status = 0;
   } else {
@@ -66,13 +66,13 @@ HAL_Bool HAL_SetThreadPriority(NativeThreadHandle handle, HAL_Bool realTime,
 
   sched_param sch;
   int policy;
-  pthread_getschedparam(*handle, &policy, &sch);
+  pthread_getschedparam(*reinterpret_cast<const pthread_t*>(handle), &policy, &sch);
   if (scheduler == SCHED_FIFO || scheduler == SCHED_RR)
     sch.sched_priority = priority;
   else
     // Only need to set 0 priority for non RT thread
     sch.sched_priority = 0;
-  if (pthread_setschedparam(*handle, scheduler, &sch)) {
+  if (pthread_setschedparam(*reinterpret_cast<const pthread_t*>(handle), scheduler, &sch)) {
     *status = HAL_THREAD_PRIORITY_ERROR;
     return false;
   } else {

--- a/hal/src/main/native/include/hal/Threads.h
+++ b/hal/src/main/native/include/hal/Threads.h
@@ -7,13 +7,7 @@
 
 #pragma once
 
-#ifdef _WIN32
-#include <windows.h>
-#define NativeThreadHandle const HANDLE*
-#else
-#include <pthread.h>
-#define NativeThreadHandle const pthread_t*
-#endif
+#define NativeThreadHandle const void*
 
 #include "hal/Types.h"
 

--- a/wpilibc/src/main/native/include/frc/Error.h
+++ b/wpilibc/src/main/native/include/frc/Error.h
@@ -15,8 +15,7 @@
 #include <wpi/Twine.h>
 
 #ifdef _WIN32
-#include <Windows.h>
-// Windows.h defines #define GetMessage GetMessageW, which we don't want.
+#pragma push_macro("GetMessage")
 #undef GetMessage
 #endif
 
@@ -65,3 +64,7 @@ class Error {
 };
 
 }  // namespace frc
+
+#ifdef _WIN32
+#pragma pop_macro("GetMessage")
+#endif


### PR DESCRIPTION
For HAL and wpilib, we don't need them, especially in where they were used.