### PR TITLE
wpiutil: Signal: Don't use std::forward when calling

### DIFF
--- a/wpiutil/src/main/native/include/wpi/Signal.h
+++ b/wpiutil/src/main/native/include/wpi/Signal.h
@@ -511,7 +511,7 @@ class SignalBase {
                 // call non blocked, non connected slots
                 if ((*curr)->connected()) {
                     if (!m_base.m_block && !(*curr)->blocked())
-                        (*curr)->operator()(std::forward<A>(a)...);
+                        (*curr)->operator()(a...);
                     prev = curr;
                     curr = (*curr)->next ? &((*curr)->next) : nullptr;
                 }


### PR DESCRIPTION
This causes a std::move of objects that are both moveable and copyable.