### PR TITLE
Revert "Clean up edge detection logic in ButtonScheduler subclasses (#1340)

### DIFF
--- a/wpilibc/src/main/native/cpp/buttons/CancelButtonScheduler.cpp
+++ b/wpilibc/src/main/native/cpp/buttons/CancelButtonScheduler.cpp
@@ -14,14 +14,17 @@ using namespace frc;
 
 CancelButtonScheduler::CancelButtonScheduler(bool last, Trigger* button,
                                              Command* orders)
-    : ButtonScheduler(last, button, orders) {}
+    : ButtonScheduler(last, button, orders) {
+  pressedLast = m_button->Grab();
+}
 
 void CancelButtonScheduler::Execute() {
-  bool pressed = m_button->Grab();
-
-  if (!m_pressedLast && pressed) {
-    m_command->Cancel();
+  if (m_button->Grab()) {
+    if (!pressedLast) {
+      pressedLast = true;
+      m_command->Cancel();
+    }
+  } else {
+    pressedLast = false;
   }
-
-  m_pressedLast = pressed;
 }

--- a/wpilibc/src/main/native/cpp/buttons/HeldButtonScheduler.cpp
+++ b/wpilibc/src/main/native/cpp/buttons/HeldButtonScheduler.cpp
@@ -17,13 +17,13 @@ HeldButtonScheduler::HeldButtonScheduler(bool last, Trigger* button,
     : ButtonScheduler(last, button, orders) {}
 
 void HeldButtonScheduler::Execute() {
-  bool pressed = m_button->Grab();
-
-  if (!m_pressedLast && pressed) {
+  if (m_button->Grab()) {
+    m_pressedLast = true;
     m_command->Start();
-  } else if (m_pressedLast && !pressed) {
-    m_command->Cancel();
+  } else {
+    if (m_pressedLast) {
+      m_pressedLast = false;
+      m_command->Cancel();
+    }
   }
-
-  m_pressedLast = pressed;
 }

--- a/wpilibc/src/main/native/cpp/buttons/PressedButtonScheduler.cpp
+++ b/wpilibc/src/main/native/cpp/buttons/PressedButtonScheduler.cpp
@@ -17,11 +17,12 @@ PressedButtonScheduler::PressedButtonScheduler(bool last, Trigger* button,
     : ButtonScheduler(last, button, orders) {}
 
 void PressedButtonScheduler::Execute() {
-  bool pressed = m_button->Grab();
-
-  if (!m_pressedLast && pressed) {
-    m_command->Start();
+  if (m_button->Grab()) {
+    if (!m_pressedLast) {
+      m_pressedLast = true;
+      m_command->Start();
+    }
+  } else {
+    m_pressedLast = false;
   }
-
-  m_pressedLast = pressed;
 }

--- a/wpilibc/src/main/native/cpp/buttons/ReleasedButtonScheduler.cpp
+++ b/wpilibc/src/main/native/cpp/buttons/ReleasedButtonScheduler.cpp
@@ -17,11 +17,12 @@ ReleasedButtonScheduler::ReleasedButtonScheduler(bool last, Trigger* button,
     : ButtonScheduler(last, button, orders) {}
 
 void ReleasedButtonScheduler::Execute() {
-  bool pressed = m_button->Grab();
-
-  if (m_pressedLast && !pressed) {
-    m_command->Start();
+  if (m_button->Grab()) {
+    m_pressedLast = true;
+  } else {
+    if (m_pressedLast) {
+      m_pressedLast = false;
+      m_command->Start();
+    }
   }
-
-  m_pressedLast = pressed;
 }

--- a/wpilibc/src/main/native/cpp/buttons/ToggleButtonScheduler.cpp
+++ b/wpilibc/src/main/native/cpp/buttons/ToggleButtonScheduler.cpp
@@ -14,18 +14,21 @@ using namespace frc;
 
 ToggleButtonScheduler::ToggleButtonScheduler(bool last, Trigger* button,
                                              Command* orders)
-    : ButtonScheduler(last, button, orders) {}
+    : ButtonScheduler(last, button, orders) {
+  pressedLast = m_button->Grab();
+}
 
 void ToggleButtonScheduler::Execute() {
-  bool pressed = m_button->Grab();
-
-  if (!m_pressedLast && pressed) {
-    if (m_command->IsRunning()) {
-      m_command->Cancel();
-    } else {
-      m_command->Start();
+  if (m_button->Grab()) {
+    if (!pressedLast) {
+      pressedLast = true;
+      if (m_command->IsRunning()) {
+        m_command->Cancel();
+      } else {
+        m_command->Start();
+      }
     }
+  } else {
+    pressedLast = false;
   }
-
-  m_pressedLast = pressed;
 }

--- a/wpilibc/src/main/native/include/frc/buttons/CancelButtonScheduler.h
+++ b/wpilibc/src/main/native/include/frc/buttons/CancelButtonScheduler.h
@@ -23,6 +23,9 @@ class CancelButtonScheduler : public ButtonScheduler {
   CancelButtonScheduler& operator=(CancelButtonScheduler&&) = default;
 
   virtual void Execute();
+
+ private:
+  bool pressedLast;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/buttons/ToggleButtonScheduler.h
+++ b/wpilibc/src/main/native/include/frc/buttons/ToggleButtonScheduler.h
@@ -23,6 +23,9 @@ class ToggleButtonScheduler : public ButtonScheduler {
   ToggleButtonScheduler& operator=(ToggleButtonScheduler&&) = default;
 
   virtual void Execute();
+
+ private:
+  bool pressedLast;
 };
 
 }  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/Trigger.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/buttons/Trigger.java
@@ -56,13 +56,14 @@ public abstract class Trigger extends SendableBase {
 
       @Override
       public void execute() {
-        boolean pressed = grab();
-
-        if (!m_pressedLast && pressed) {
-          command.start();
+        if (grab()) {
+          if (!m_pressedLast) {
+            m_pressedLast = true;
+            command.start();
+          }
+        } else {
+          m_pressedLast = false;
         }
-
-        m_pressedLast = pressed;
       }
     }.start();
   }
@@ -81,15 +82,15 @@ public abstract class Trigger extends SendableBase {
 
       @Override
       public void execute() {
-        boolean pressed = grab();
-
-        if (!m_pressedLast && pressed) {
+        if (grab()) {
+          m_pressedLast = true;
           command.start();
-        } else if (m_pressedLast && !pressed) {
-          command.cancel();
+        } else {
+          if (m_pressedLast) {
+            m_pressedLast = false;
+            command.cancel();
+          }
         }
-
-        m_pressedLast = pressed;
       }
     }.start();
   }
@@ -105,13 +106,14 @@ public abstract class Trigger extends SendableBase {
 
       @Override
       public void execute() {
-        boolean pressed = grab();
-
-        if (m_pressedLast && !pressed) {
-          command.start();
+        if (grab()) {
+          m_pressedLast = true;
+        } else {
+          if (m_pressedLast) {
+            m_pressedLast = false;
+            command.start();
+          }
         }
-
-        m_pressedLast = pressed;
       }
     }.start();
   }
@@ -127,17 +129,18 @@ public abstract class Trigger extends SendableBase {
 
       @Override
       public void execute() {
-        boolean pressed = grab();
-
-        if (!m_pressedLast && pressed) {
-          if (command.isRunning()) {
-            command.cancel();
-          } else {
-            command.start();
+        if (grab()) {
+          if (!m_pressedLast) {
+            m_pressedLast = true;
+            if (command.isRunning()) {
+              command.cancel();
+            } else {
+              command.start();
+            }
           }
+        } else {
+          m_pressedLast = false;
         }
-
-        m_pressedLast = pressed;
       }
     }.start();
   }
@@ -153,13 +156,14 @@ public abstract class Trigger extends SendableBase {
 
       @Override
       public void execute() {
-        boolean pressed = grab();
-
-        if (!m_pressedLast && pressed) {
-          command.cancel();
+        if (grab()) {
+          if (!m_pressedLast) {
+            m_pressedLast = true;
+            command.cancel();
+          }
+        } else {
+          m_pressedLast = false;
         }
-
-        m_pressedLast = pressed;
       }
     }.start();
   }


### PR DESCRIPTION
This reverts commit a732854866926a18794db2343711e433c7eadab7.

See #1376.  This should instead be done as new methods instead of silently changing current behavior (or at least needs to be done in stages to avoid silent breakage).