### PR TITLE
Add missing driver station documentation

### DIFF
--- a/wpilibc/src/main/native/include/frc/DriverStation.h
+++ b/wpilibc/src/main/native/include/frc/DriverStation.h
@@ -295,7 +295,7 @@ class DriverStation : public ErrorBase {
   int GetMatchNumber() const;
 
   /**
-   * Returns the number or times the current match has been replayed from the
+   * Returns the number of times the current match has been replayed from the
    * FMS.
    *
    * @return The number of replays

--- a/wpilibc/src/main/native/include/frc/DriverStation.h
+++ b/wpilibc/src/main/native/include/frc/DriverStation.h
@@ -289,7 +289,7 @@ class DriverStation : public ErrorBase {
   int GetMatchNumber() const;
 
   /**
-   * Returns The number or times the current match has been replayed.
+   * Returns the number or times the current match has been replayed.
    *
    * @return The number of replays
    */

--- a/wpilibc/src/main/native/include/frc/DriverStation.h
+++ b/wpilibc/src/main/native/include/frc/DriverStation.h
@@ -266,9 +266,33 @@ class DriverStation : public ErrorBase {
   bool IsBrownedOut() const;
 
   std::string GetGameSpecificMessage() const;
+  /**
+   * Returns the name of the competition event from the FMS.
+   *
+   * @return An std::string containing the event name
+   */
   std::string GetEventName() const;
+
+  /**
+   * Return the type of match being played from the FMS.
+   *
+   * @return The match type enum (kNone, kPractice, kQualification,
+   * kElimination)
+   */
   MatchType GetMatchType() const;
+
+  /**
+   * Return the match number from the FMS.
+   *
+   * @return The number of the match
+   */
   int GetMatchNumber() const;
+
+  /**
+   * Returns The number or times the current match has been replayed.
+   *
+   * @return The number of replays
+   */
   int GetReplayNumber() const;
 
   /**

--- a/wpilibc/src/main/native/include/frc/DriverStation.h
+++ b/wpilibc/src/main/native/include/frc/DriverStation.h
@@ -277,7 +277,7 @@ class DriverStation : public ErrorBase {
    * Return the type of match being played from the FMS.
    *
    * @return The match type enum (kNone, kPractice, kQualification,
-   * kElimination)
+   *         kElimination)
    */
   MatchType GetMatchType() const;
 

--- a/wpilibc/src/main/native/include/frc/DriverStation.h
+++ b/wpilibc/src/main/native/include/frc/DriverStation.h
@@ -269,7 +269,7 @@ class DriverStation : public ErrorBase {
   /**
    * Returns the name of the competition event from the FMS.
    *
-   * @return An std::string containing the event name
+   * @return A string containing the event name
    */
   std::string GetEventName() const;
 

--- a/wpilibc/src/main/native/include/frc/DriverStation.h
+++ b/wpilibc/src/main/native/include/frc/DriverStation.h
@@ -267,7 +267,7 @@ class DriverStation : public ErrorBase {
 
   std::string GetGameSpecificMessage() const;
   /**
-   * Returns the name of the competition event from the FMS.
+   * Returns the name of the competition event provided by FMS.
    *
    * @return A string containing the event name
    */

--- a/wpilibc/src/main/native/include/frc/DriverStation.h
+++ b/wpilibc/src/main/native/include/frc/DriverStation.h
@@ -266,21 +266,21 @@ class DriverStation : public ErrorBase {
   bool IsBrownedOut() const;
 
   /**
-   * Returns the game specific message provided by FMS.
-   * 
+   * Returns the game specific message provided by the FMS.
+   *
    * @return A string containing the game specific message.
    */
   std::string GetGameSpecificMessage() const;
 
   /**
-   * Returns the name of the competition event provided by FMS.
+   * Returns the name of the competition event provided by the FMS.
    *
    * @return A string containing the event name
    */
   std::string GetEventName() const;
 
   /**
-   * Returns the type of match being played provided by FMS.
+   * Returns the type of match being played provided by the FMS.
    *
    * @return The match type enum (kNone, kPractice, kQualification,
    *         kElimination)
@@ -288,14 +288,15 @@ class DriverStation : public ErrorBase {
   MatchType GetMatchType() const;
 
   /**
-   * Returns the match number provided by FMS.
+   * Returns the match number provided by the FMS.
    *
    * @return The number of the match
    */
   int GetMatchNumber() const;
 
   /**
-   * Returns the number or times the current match has been replayed.
+   * Returns the number or times the current match has been replayed from the
+   * FMS.
    *
    * @return The number of replays
    */

--- a/wpilibc/src/main/native/include/frc/DriverStation.h
+++ b/wpilibc/src/main/native/include/frc/DriverStation.h
@@ -282,7 +282,7 @@ class DriverStation : public ErrorBase {
   MatchType GetMatchType() const;
 
   /**
-   * Return the match number from the FMS.
+   * Returns the match number provided by FMS.
    *
    * @return The number of the match
    */

--- a/wpilibc/src/main/native/include/frc/DriverStation.h
+++ b/wpilibc/src/main/native/include/frc/DriverStation.h
@@ -274,7 +274,7 @@ class DriverStation : public ErrorBase {
   std::string GetEventName() const;
 
   /**
-   * Return the type of match being played from the FMS.
+   * Returns the type of match being played provided by FMS.
    *
    * @return The match type enum (kNone, kPractice, kQualification,
    *         kElimination)

--- a/wpilibc/src/main/native/include/frc/DriverStation.h
+++ b/wpilibc/src/main/native/include/frc/DriverStation.h
@@ -265,7 +265,13 @@ class DriverStation : public ErrorBase {
   WPI_DEPRECATED("Use RobotController static class method")
   bool IsBrownedOut() const;
 
+  /**
+   * Returns the game specific message provided by FMS.
+   * 
+   * @return A string containing the game specific message.
+   */
   std::string GetGameSpecificMessage() const;
+
   /**
    * Returns the name of the competition event provided by FMS.
    *


### PR DESCRIPTION
in reference to #1257

I wasn't sure exactly what `GetGameSpecificMessage` gets, but I'll add it if someone explains.