### PR TITLE
Fix stringop truncation warning from GCC 8.2

### DIFF
--- a/hal/src/main/native/sim/DriverStation.cpp
+++ b/hal/src/main/native/sim/DriverStation.cpp
@@ -149,8 +149,7 @@ char* HAL_GetJoystickName(int32_t joystickNum) {
   SimDriverStationData->GetJoystickDescriptor(joystickNum, &desc);
   size_t len = std::strlen(desc.name);
   char* name = static_cast<char*>(std::malloc(len + 1));
-  std::strncpy(name, desc.name, len);
-  name[len] = '\0';
+  std::memcpy(name, desc.name, len + 1);
   return name;
 }
 


### PR DESCRIPTION
/home/tav/frc/wpilib/allwpilib/hal/src/main/native/sim/DriverStation.cpp: In function 'char* HAL_GetJoystickName(int32_t)':
/home/tav/frc/wpilib/allwpilib/hal/src/main/native/sim/DriverStation.cpp:152:15: error: 'char* strncpy(char*, const char*, size_t)' output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
  std::strncpy(name, desc.name, len);
  ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
/home/tav/frc/wpilib/allwpilib/hal/src/main/native/sim/DriverStation.cpp:150:27: note: length computed here
  size_t len = std::strlen(desc.name);
               ~~~~~~~~~~~^~~~~~~~~~~

The next line adds a null terminator, but it's cleaner to just do a
std::memcpy() since the code already assumes a null terminator exists in
the source string.