### PR TITLE
Remove unused import from rumble example

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/HidRumble/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HidRumble/cpp/Robot.cpp
@@ -6,7 +6,6 @@
 /*----------------------------------------------------------------------------*/
 
 #include <frc/GenericHID.h>
-#include <frc/Joystick.h>
 #include <frc/TimedRobot.h>
 #include <frc/XboxController.h>
 


### PR DESCRIPTION
This is a nit that we missed on #1394 