### PR TITLE
Don't use static for raw_ostream outs/errs

### DIFF
--- a/wpiutil/src/main/native/cpp/llvm/raw_ostream.cpp
+++ b/wpiutil/src/main/native/cpp/llvm/raw_ostream.cpp
@@ -675,23 +675,23 @@ void raw_fd_ostream::anchor() {}
 raw_ostream &wpi::outs() {
   // Set buffer settings to model stdout behavior.
   std::error_code EC;
-  static raw_fd_ostream S("-", EC, sys::fs::F_None);
+  static raw_fd_ostream* S = new raw_fd_ostream("-", EC, sys::fs::F_None);
   assert(!EC);
-  return S;
+  return *S;
 }
 
 /// errs() - This returns a reference to a raw_ostream for standard error.
 /// Use it like: errs() << "foo" << "bar";
 raw_ostream &wpi::errs() {
   // Set standard error to be unbuffered by default.
-  static raw_fd_ostream S(STDERR_FILENO, false, true);
-  return S;
+  static raw_fd_ostream* S = new raw_fd_ostream(STDERR_FILENO, false, true);
+  return *S;
 }
 
 /// nulls() - This returns a reference to a raw_ostream which discards output.
 raw_ostream &wpi::nulls() {
-  static raw_null_ostream S;
-  return S;
+  static raw_null_ostream* S = new raw_null_ostream;
+  return *S;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Static destruction order is not well defined, so it was possible for outs()
or errs() return value to be destroyed even while other code was running,
resulting in a crash.  Instead dynamically allocate the static so the
destructor never runs.  While this technically leaks, valgrind generally
supresses such leaks as the data is still "reachable" from the static pointer.