### PR TITLE
Adds way to explicitly initialize and shut down cscore

### DIFF
--- a/cscore/src/main/native/cpp/Instance.cpp
+++ b/cscore/src/main/native/cpp/Instance.cpp
@@ -69,15 +69,21 @@ std::pair<CS_Sink, std::shared_ptr<SinkData>> Instance::FindSink(
 }
 
 namespace cs {
-
 void Shutdown() {
-  auto tmp = instance.exchange(nullptr);
-  if (tmp) {
-    delete instance;
+  auto& instance = Instance::GetInstance();
+  instance.notifier.Stop();
+  instance.network_listener.Stop();
+  auto loop = instance.event_loop.GetLoop();
+  if (loop) {
+    loop->Stop();
   }
+  instance.sources.ClearAll();
+  instance.sinks.ClearAll();
 }
-}  // namespace cs
+}
 
 extern "C" {
-void CS_Shutdown(void) { cs::Shutdown(); }
-}  // extern "C"
+void CS_Shutdown(void) {
+  cs::Shutdown();
+}
+}

--- a/cscore/src/main/native/cpp/Instance.cpp
+++ b/cscore/src/main/native/cpp/Instance.cpp
@@ -7,16 +7,12 @@
 
 #include "Instance.h"
 
-#include <atomic>
-
 #include <wpi/Path.h>
 #include <wpi/SmallString.h>
 #include <wpi/StringRef.h>
 #include <wpi/raw_ostream.h>
 
 using namespace cs;
-
-static std::atomic<Instance*> instance{nullptr};
 
 static void def_log_func(unsigned int level, const char* file,
                          unsigned int line, const char* msg) {
@@ -43,7 +39,6 @@ static void def_log_func(unsigned int level, const char* file,
 }
 
 Instance::Instance() : telemetry(notifier), network_listener(logger, notifier) {
-  instance = this;
   SetDefaultLogger();
 }
 
@@ -80,10 +75,8 @@ void Shutdown() {
   instance.sources.ClearAll();
   instance.sinks.ClearAll();
 }
-}
+}  // namespace cs
 
 extern "C" {
-void CS_Shutdown(void) {
-  cs::Shutdown();
-}
-}
+void CS_Shutdown(void) { cs::Shutdown(); }
+}  // extern "C"

--- a/cscore/src/main/native/cpp/Instance.cpp
+++ b/cscore/src/main/native/cpp/Instance.cpp
@@ -44,8 +44,10 @@ Instance::Instance() : telemetry(notifier), network_listener(logger, notifier) {
 
 Instance::~Instance() {}
 
-Instance& Instance::GetInstance() {
-  static Instance inst;
+Instance& Instance::GetInstance() { return *Instance::GetInstancePtr(); }
+
+Instance* Instance::GetInstancePtr() {
+  static Instance* inst = new Instance();
   return inst;
 }
 
@@ -62,3 +64,17 @@ std::pair<CS_Sink, std::shared_ptr<SinkData>> Instance::FindSink(
   return sinks.FindIf(
       [&](const SinkData& data) { return data.sink.get() == &sink; });
 }
+
+namespace cs {
+void Initialize() { Instance::GetInstancePtr(); }
+
+void Shutdown() {
+  Instance* ptr = Instance::GetInstancePtr();
+  delete ptr;
+}
+}  // namespace cs
+
+extern "C" {
+void CS_Initialize(void) { cs::Initialize(); }
+void CS_Shutdown(void) { cs::Shutdown(); }
+}  // extern "C"

--- a/cscore/src/main/native/cpp/Instance.cpp
+++ b/cscore/src/main/native/cpp/Instance.cpp
@@ -66,14 +66,19 @@ std::pair<CS_Sink, std::shared_ptr<SinkData>> Instance::FindSink(
 namespace cs {
 void Shutdown() {
   auto& instance = Instance::GetInstance();
-  instance.notifier.Stop();
-  instance.network_listener.Stop();
+
   auto loop = instance.event_loop.GetLoop();
   if (loop) {
     loop->Stop();
   }
-  instance.sources.ClearAll();
+
+  instance.notifier.Stop();
+  instance.telemetry.Stop();
+  instance.network_listener.Stop();
+
   instance.sinks.ClearAll();
+  instance.sources.ClearAll();
+
 }
 }  // namespace cs
 

--- a/cscore/src/main/native/cpp/Instance.h
+++ b/cscore/src/main/native/cpp/Instance.h
@@ -50,6 +50,7 @@ class Instance {
   ~Instance();
 
   static Instance& GetInstance();
+  static Instance* GetInstancePtr();
 
   UnlimitedHandleResource<Handle, SourceData, Handle::kSource> sources;
   UnlimitedHandleResource<Handle, SinkData, Handle::kSink> sinks;

--- a/cscore/src/main/native/cpp/Instance.h
+++ b/cscore/src/main/native/cpp/Instance.h
@@ -50,7 +50,6 @@ class Instance {
   ~Instance();
 
   static Instance& GetInstance();
-  static Instance* GetInstancePtr();
 
   UnlimitedHandleResource<Handle, SourceData, Handle::kSource> sources;
   UnlimitedHandleResource<Handle, SinkData, Handle::kSink> sinks;

--- a/cscore/src/main/native/cpp/UnlimitedHandleResource.h
+++ b/cscore/src/main/native/cpp/UnlimitedHandleResource.h
@@ -63,6 +63,8 @@ class UnlimitedHandleResource {
   template <typename F>
   std::pair<THandle, std::shared_ptr<TStruct>> FindIf(F func);
 
+  void ClearAll();
+
  private:
   THandle MakeHandle(size_t i) {
     return THandle{static_cast<int>(i),
@@ -71,6 +73,16 @@ class UnlimitedHandleResource {
   std::vector<std::shared_ptr<TStruct>> m_structures;
   TMutex m_handleMutex;
 };
+
+template <typename THandle, typename TStruct, int typeValue, typename TMutex>
+void UnlimitedHandleResource<THandle, TStruct, typeValue, TMutex>::ClearAll() {
+  std::unique_lock<TMutex> sync(m_handleMutex);
+  for (int index = 0; index < m_structures.size(); index++) {
+    sync.unlock();
+    m_structures[index].reset();
+    sync.lock();
+  }
+}
 
 template <typename THandle, typename TStruct, int typeValue, typename TMutex>
 template <typename... Args>

--- a/cscore/src/main/native/cpp/jni/CameraServerJNI.cpp
+++ b/cscore/src/main/native/cpp/jni/CameraServerJNI.cpp
@@ -82,11 +82,14 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
   // Initial configuration of listener start/exit
   cs::SetListenerOnStart(ListenerOnStart);
   cs::SetListenerOnExit(ListenerOnExit);
+  cs::Initialize();
 
   return JNI_VERSION_1_6;
 }
 
 JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void* reserved) {
+  cs::Shutdown();
+
   JNIEnv* env;
   if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK)
     return;

--- a/cscore/src/main/native/cpp/jni/CameraServerJNI.cpp
+++ b/cscore/src/main/native/cpp/jni/CameraServerJNI.cpp
@@ -82,7 +82,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
   // Initial configuration of listener start/exit
   cs::SetListenerOnStart(ListenerOnStart);
   cs::SetListenerOnExit(ListenerOnExit);
-  cs::Initialize();
 
   return JNI_VERSION_1_6;
 }

--- a/cscore/src/main/native/include/cscore_c.h
+++ b/cscore/src/main/native/include/cscore_c.h
@@ -441,6 +441,14 @@ void CS_SetDefaultLogger(unsigned int min_level);
 /** @} */
 
 /**
+ * @defgroup cscore_init_cfunc Library Initialization Functions
+ * @{
+ */
+void CS_Initialize(void);
+void CS_Shutdown(void);
+/** @} */
+
+/**
  * @defgroup cscore_utility_cfunc Utility Functions
  * @{
  */

--- a/cscore/src/main/native/include/cscore_c.h
+++ b/cscore/src/main/native/include/cscore_c.h
@@ -441,10 +441,9 @@ void CS_SetDefaultLogger(unsigned int min_level);
 /** @} */
 
 /**
- * @defgroup cscore_init_cfunc Library Initialization Functions
+ * @defgroup cscore_shutdown_cfunc Library Shutdown Function
  * @{
  */
-void CS_Initialize(void);
 void CS_Shutdown(void);
 /** @} */
 

--- a/cscore/src/main/native/include/cscore_c.h
+++ b/cscore/src/main/native/include/cscore_c.h
@@ -440,8 +440,6 @@ void CS_SetLogger(CS_LogFunc func, unsigned int min_level);
 void CS_SetDefaultLogger(unsigned int min_level);
 /** @} */
 
-void CS_Shutdown(void);
-
 /**
  * @defgroup cscore_shutdown_cfunc Library Shutdown Function
  * @{

--- a/cscore/src/main/native/include/cscore_c.h
+++ b/cscore/src/main/native/include/cscore_c.h
@@ -440,6 +440,8 @@ void CS_SetLogger(CS_LogFunc func, unsigned int min_level);
 void CS_SetDefaultLogger(unsigned int min_level);
 /** @} */
 
+void CS_Shutdown(void);
+
 /**
  * @defgroup cscore_shutdown_cfunc Library Shutdown Function
  * @{

--- a/cscore/src/main/native/include/cscore_cpp.h
+++ b/cscore/src/main/native/include/cscore_cpp.h
@@ -377,6 +377,8 @@ void SetLogger(LogFunc func, unsigned int min_level);
 void SetDefaultLogger(unsigned int min_level);
 /** @} */
 
+void Shutdown();
+
 /**
  * @defgroup cscore_shutdown_func Library Shutdown Function
  * @{

--- a/cscore/src/main/native/include/cscore_cpp.h
+++ b/cscore/src/main/native/include/cscore_cpp.h
@@ -377,8 +377,6 @@ void SetLogger(LogFunc func, unsigned int min_level);
 void SetDefaultLogger(unsigned int min_level);
 /** @} */
 
-void Shutdown();
-
 /**
  * @defgroup cscore_shutdown_func Library Shutdown Function
  * @{

--- a/cscore/src/main/native/include/cscore_cpp.h
+++ b/cscore/src/main/native/include/cscore_cpp.h
@@ -378,6 +378,14 @@ void SetDefaultLogger(unsigned int min_level);
 /** @} */
 
 /**
+ * @defgroup cscore_init_func Library Initialization Functions
+ * @{
+ */
+void Initialize();
+void Shutdown();
+/** @} */
+
+/**
  * @defgroup cscore_utility_func Utility Functions
  * @{
  */

--- a/cscore/src/main/native/include/cscore_cpp.h
+++ b/cscore/src/main/native/include/cscore_cpp.h
@@ -378,10 +378,9 @@ void SetDefaultLogger(unsigned int min_level);
 /** @} */
 
 /**
- * @defgroup cscore_init_func Library Initialization Functions
+ * @defgroup cscore_shutdown_func Library Shutdown Function
  * @{
  */
-void Initialize();
 void Shutdown();
 /** @} */
 

--- a/wpilibc/src/main/native/cpp/RobotBase.cpp
+++ b/wpilibc/src/main/native/cpp/RobotBase.cpp
@@ -92,8 +92,6 @@ RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
 
   SetupCameraServerShared();
 
-  cs::Initialize();
-
   auto inst = nt::NetworkTableInstance::GetDefault();
   inst.SetNetworkIdentity("Robot");
   inst.StartServer("/home/lvuser/networktables.ini");

--- a/wpilibc/src/main/native/cpp/RobotBase.cpp
+++ b/wpilibc/src/main/native/cpp/RobotBase.cpp
@@ -10,6 +10,7 @@
 #include <cstdio>
 
 #include <cameraserver/CameraServerShared.h>
+#include <cscore.h>
 #include <hal/HAL.h>
 #include <networktables/NetworkTableInstance.h>
 
@@ -91,6 +92,8 @@ RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
 
   SetupCameraServerShared();
 
+  cs::Initialize();
+
   auto inst = nt::NetworkTableInstance::GetDefault();
   inst.SetNetworkIdentity("Robot");
   inst.StartServer("/home/lvuser/networktables.ini");
@@ -116,5 +119,7 @@ RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
 }
 
 RobotBase::RobotBase(RobotBase&&) : m_ds(DriverStation::GetInstance()) {}
+
+RobotBase::~RobotBase() { cs::Shutdown(); }
 
 RobotBase& RobotBase::operator=(RobotBase&&) { return *this; }

--- a/wpilibc/src/main/native/include/frc/RobotBase.h
+++ b/wpilibc/src/main/native/include/frc/RobotBase.h
@@ -127,7 +127,7 @@ class RobotBase {
    */
   RobotBase();
 
-  virtual ~RobotBase() = default;
+  virtual ~RobotBase();
 
   // m_ds isn't moved in these because DriverStation is a singleton; every
   // instance of RobotBase has a reference to the same object.


### PR DESCRIPTION
In JNI, this is done in the OnLoad and OnUnload functions. In C++, this will need to be done user side
for non robot programs.

Robot programs handle this correctly.