### PR TITLE
libuv: Use WPI (FPGA) clock on roboRio

### DIFF
--- a/wpiutil/src/main/native/libuv/unix/internal.h
+++ b/wpiutil/src/main/native/libuv/unix/internal.h
@@ -60,10 +60,6 @@
 # include <AvailabilityMacros.h>
 #endif
 
-#ifdef __FRC_ROBORIO__
-#include "wpi/timestamp.h"
-#endif
-
 #if defined(__ANDROID__)
 int uv__pthread_sigmask(int how, const sigset_t* set, sigset_t* oset);
 # ifdef pthread_sigmask
@@ -341,11 +337,7 @@ static const int kFSEventStreamEventFlagItemIsSymlink = 0x00040000;
 UV_UNUSED(static void uv__update_time(uv_loop_t* loop)) {
   /* Use a fast time source if available.  We only need millisecond precision.
    */
-#ifdef __FRC_ROBORIO__
-  loop->time = wpi::Now() / 1000;
-#else
   loop->time = uv__hrtime(UV_CLOCK_FAST) / 1000000;
-#endif
 }
 
 UV_UNUSED(static const char* uv__basename_r(const char* path)) {

--- a/wpiutil/src/main/native/libuv/unix/internal.h
+++ b/wpiutil/src/main/native/libuv/unix/internal.h
@@ -60,6 +60,10 @@
 # include <AvailabilityMacros.h>
 #endif
 
+#ifdef __FRC_ROBORIO__
+#include "wpi/timestamp.h"
+#endif
+
 #if defined(__ANDROID__)
 int uv__pthread_sigmask(int how, const sigset_t* set, sigset_t* oset);
 # ifdef pthread_sigmask
@@ -337,7 +341,11 @@ static const int kFSEventStreamEventFlagItemIsSymlink = 0x00040000;
 UV_UNUSED(static void uv__update_time(uv_loop_t* loop)) {
   /* Use a fast time source if available.  We only need millisecond precision.
    */
+#ifdef __FRC_ROBORIO__
+  loop->time = wpi::Now() / 1000;
+#else
   loop->time = uv__hrtime(UV_CLOCK_FAST) / 1000000;
+#endif
 }
 
 UV_UNUSED(static const char* uv__basename_r(const char* path)) {

--- a/wpiutil/src/main/native/libuv/unix/linux-core.cpp
+++ b/wpiutil/src/main/native/libuv/unix/linux-core.cpp
@@ -65,6 +65,10 @@
 # define CLOCK_MONOTONIC_COARSE 6
 #endif
 
+#ifdef __FRC_ROBORIO__
+#include "wpi/timestamp.h"
+#endif
+
 /* This is rather annoying: CLOCK_BOOTTIME lives in <linux/time.h> but we can't
  * include that file because it conflicts with <time.h>. We'll just have to
  * define it ourselves.
@@ -441,6 +445,9 @@ update_timeout:
 
 
 uint64_t uv__hrtime(uv_clocktype_t type) {
+#ifdef __FRC_ROBORIO__
+  return wpi::Now() * 1000u;
+#else
   static clock_t fast_clock_id = -1;
   struct timespec t;
   clock_t clock_id;
@@ -470,6 +477,7 @@ uint64_t uv__hrtime(uv_clocktype_t type) {
     return 0;  /* Not really possible. */
 
   return t.tv_sec * (uint64_t) 1e9 + t.tv_nsec;
+#endif
 }
 
 


### PR DESCRIPTION
This is set to the FPGA clock by HAL_Initialize.  Note this change means
that libuv loops should not be started until after HAL_Initialize is called.