### PR TITLE
CameraServer: Change opencv sources to publish "cv:" type

### DIFF
--- a/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
+++ b/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
@@ -85,9 +85,7 @@ public final class CameraServer {
         }
       }
       case kCv:
-        // FIXME: Should be "cv:", but LabVIEW dashboard requires "usb:".
-        // https://github.com/wpilibsuite/allwpilib/issues/407
-        return "usb:";
+        return "cv:";
       default:
         return "unknown:";
     }

--- a/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
+++ b/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
@@ -72,9 +72,7 @@ static wpi::StringRef MakeSourceValue(CS_Source source,
       break;
     }
     case cs::VideoSource::kCv:
-      // FIXME: Should be "cv:", but LabVIEW dashboard requires "usb:".
-      // https://github.com/wpilibsuite/allwpilib/issues/407
-      return "usb:";
+      return "cv:";
     default:
       return "unknown:";
   }


### PR DESCRIPTION
The LabVIEW dashboard has been fixed to understand this prefix.

Fixes #407.