### PR TITLE
Fix unused variable warnings in ntcore

### DIFF
--- a/ntcore/src/main/native/cpp/ConnectionNotifier.h
+++ b/ntcore/src/main/native/cpp/ConnectionNotifier.h
@@ -22,8 +22,8 @@ class ConnectionNotifierThread
  public:
   explicit ConnectionNotifierThread(int inst) : m_inst(inst) {}
 
-  bool Matches(const ListenerData& listener,
-               const ConnectionNotification& data) {
+  bool Matches(const ListenerData& /*listener*/,
+               const ConnectionNotification& /*data*/) {
     return true;
   }
 

--- a/ntcore/src/main/native/cpp/RpcServer.h
+++ b/ntcore/src/main/native/cpp/RpcServer.h
@@ -44,11 +44,12 @@ class RpcServerThread
   RpcServerThread(int inst, wpi::Logger& logger)
       : m_inst(inst), m_logger(logger) {}
 
-  bool Matches(const RpcListenerData& listener, const RpcNotifierData& data) {
+  bool Matches(const RpcListenerData& /*listener*/,
+               const RpcNotifierData& data) {
     return !data.name.empty() && data.send_response;
   }
 
-  void SetListener(RpcNotifierData* data, unsigned int listener_uid) {
+  void SetListener(RpcNotifierData* data, unsigned int /*listener_uid*/) {
     unsigned int local_id = Handle{data->entry}.GetIndex();
     unsigned int call_uid = Handle{data->call}.GetIndex();
     RpcIdPair lookup_uid{local_id, call_uid};

--- a/ntcore/src/main/native/cpp/Storage.cpp
+++ b/ntcore/src/main/native/cpp/Storage.cpp
@@ -310,7 +310,7 @@ void Storage::ProcessIncomingClearEntries(std::shared_ptr<Message> msg,
 }
 
 void Storage::ProcessIncomingExecuteRpc(
-    std::shared_ptr<Message> msg, INetworkConnection* conn,
+    std::shared_ptr<Message> msg, INetworkConnection* /*conn*/,
     std::weak_ptr<INetworkConnection> conn_weak) {
   std::unique_lock<wpi::mutex> lock(m_mutex);
   if (!m_server) return;  // only process on server
@@ -350,7 +350,7 @@ void Storage::ProcessIncomingExecuteRpc(
 }
 
 void Storage::ProcessIncomingRpcResponse(std::shared_ptr<Message> msg,
-                                         INetworkConnection* conn) {
+                                         INetworkConnection* /*conn*/) {
   std::unique_lock<wpi::mutex> lock(m_mutex);
   if (m_server) return;  // only process on client
   unsigned int id = msg->id();
@@ -387,7 +387,7 @@ void Storage::GetInitialAssignments(
 
 void Storage::ApplyInitialAssignments(
     INetworkConnection& conn, wpi::ArrayRef<std::shared_ptr<Message>> msgs,
-    bool new_server, std::vector<std::shared_ptr<Message>>* out_msgs) {
+    bool /*new_server*/, std::vector<std::shared_ptr<Message>>* out_msgs) {
   std::unique_lock<wpi::mutex> lock(m_mutex);
   if (m_server) return;  // should not do this on server
 

--- a/ntcore/src/main/native/cpp/ntcore_c.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_c.cpp
@@ -727,7 +727,7 @@ void NT_InitString(NT_String* str) {
   str->len = 0;
 }
 
-void NT_DisposeEntryArray(NT_Entry* arr, size_t count) { std::free(arr); }
+void NT_DisposeEntryArray(NT_Entry* arr, size_t /*count*/) { std::free(arr); }
 
 void NT_DisposeConnectionInfoArray(NT_ConnectionInfo* arr, size_t count) {
   for (size_t i = 0; i < count; i++) DisposeConnectionInfo(&arr[i]);


### PR DESCRIPTION
Without this, our compiler with -Werror -Wextra fails to build ntcore.