### PR TITLE
Convert ReadInterrupt* to return int64_t time

### DIFF
--- a/hal/src/main/native/athena/Interrupts.cpp
+++ b/hal/src/main/native/athena/Interrupts.cpp
@@ -165,26 +165,26 @@ void HAL_DisableInterrupts(HAL_InterruptHandle interruptHandle,
   anInterrupt->manager->disable(status);
 }
 
-double HAL_ReadInterruptRisingTimestamp(HAL_InterruptHandle interruptHandle,
-                                        int32_t* status) {
-  auto anInterrupt = interruptHandles->Get(interruptHandle);
-  if (anInterrupt == nullptr) {
-    *status = HAL_HANDLE_ERROR;
-    return 0;
-  }
-  uint32_t timestamp = anInterrupt->anInterrupt->readRisingTimeStamp(status);
-  return timestamp * 1e-6;
-}
-
-double HAL_ReadInterruptFallingTimestamp(HAL_InterruptHandle interruptHandle,
+int64_t HAL_ReadInterruptRisingTimestamp(HAL_InterruptHandle interruptHandle,
                                          int32_t* status) {
   auto anInterrupt = interruptHandles->Get(interruptHandle);
   if (anInterrupt == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return 0;
   }
+  uint32_t timestamp = anInterrupt->anInterrupt->readRisingTimeStamp(status);
+  return timestamp;
+}
+
+int64_t HAL_ReadInterruptFallingTimestamp(HAL_InterruptHandle interruptHandle,
+                                          int32_t* status) {
+  auto anInterrupt = interruptHandles->Get(interruptHandle);
+  if (anInterrupt == nullptr) {
+    *status = HAL_HANDLE_ERROR;
+    return 0;
+  }
   uint32_t timestamp = anInterrupt->anInterrupt->readFallingTimeStamp(status);
-  return timestamp * 1e-6;
+  return timestamp;
 }
 
 void HAL_RequestInterrupts(HAL_InterruptHandle interruptHandle,

--- a/hal/src/main/native/cpp/jni/InterruptJNI.cpp
+++ b/hal/src/main/native/cpp/jni/InterruptJNI.cpp
@@ -249,7 +249,8 @@ Java_edu_wpi_first_hal_InterruptJNI_readInterruptRisingTimestamp
 
   int32_t status = 0;
   jdouble timeStamp = HAL_ReadInterruptRisingTimestamp(
-      (HAL_InterruptHandle)interruptHandle, &status);
+                          (HAL_InterruptHandle)interruptHandle, &status) *
+                      1e-6;
 
   INTERRUPTJNI_LOG(logDEBUG) << "Status = " << status;
   CheckStatus(env, status);
@@ -272,7 +273,8 @@ Java_edu_wpi_first_hal_InterruptJNI_readInterruptFallingTimestamp
 
   int32_t status = 0;
   jdouble timeStamp = HAL_ReadInterruptFallingTimestamp(
-      (HAL_InterruptHandle)interruptHandle, &status);
+                          (HAL_InterruptHandle)interruptHandle, &status) *
+                      1e-6;
 
   INTERRUPTJNI_LOG(logDEBUG) << "Status = " << status;
   CheckStatus(env, status);

--- a/hal/src/main/native/include/hal/Interrupts.h
+++ b/hal/src/main/native/include/hal/Interrupts.h
@@ -77,24 +77,28 @@ void HAL_DisableInterrupts(HAL_InterruptHandle interruptHandle,
 /**
  * Returns the timestamp for the rising interrupt that occurred most recently.
  *
- * This is in the same time domain as HAL_GetFPGATime().
+ * This is in the same time domain as HAL_GetFPGATime().  It only contains the
+ * bottom 32 bits of the timestamp.  If your robot has been running for over 1
+ * hour, you will need to fill in the upper 32 bits yourself.
  *
  * @param interruptHandle the interrupt handle
- * @return                timestamp in seconds since FPGA Initialization
+ * @return                timestamp in microseconds since FPGA Initialization
  */
-double HAL_ReadInterruptRisingTimestamp(HAL_InterruptHandle interruptHandle,
-                                        int32_t* status);
+int64_t HAL_ReadInterruptRisingTimestamp(HAL_InterruptHandle interruptHandle,
+                                         int32_t* status);
 
 /**
  * Returns the timestamp for the falling interrupt that occurred most recently.
  *
- * This is in the same time domain as HAL_GetFPGATime().
+ * This is in the same time domain as HAL_GetFPGATime().  It only contains the
+ * bottom 32 bits of the timestamp.  If your robot has been running for over 1
+ * hour, you will need to fill in the upper 32 bits yourself.
  *
  * @param interruptHandle the interrupt handle
- * @return                timestamp in seconds since FPGA Initialization
+ * @return                timestamp in microseconds since FPGA Initialization
  */
-double HAL_ReadInterruptFallingTimestamp(HAL_InterruptHandle interruptHandle,
-                                         int32_t* status);
+int64_t HAL_ReadInterruptFallingTimestamp(HAL_InterruptHandle interruptHandle,
+                                          int32_t* status);
 
 /**
  * Requests interrupts on a specific digital source.

--- a/wpilibc/src/main/native/cpp/InterruptableSensorBase.cpp
+++ b/wpilibc/src/main/native/cpp/InterruptableSensorBase.cpp
@@ -96,18 +96,18 @@ double InterruptableSensorBase::ReadRisingTimestamp() {
   if (StatusIsFatal()) return 0.0;
   wpi_assert(m_interrupt != HAL_kInvalidHandle);
   int32_t status = 0;
-  double timestamp = HAL_ReadInterruptRisingTimestamp(m_interrupt, &status);
+  int64_t timestamp = HAL_ReadInterruptRisingTimestamp(m_interrupt, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
-  return timestamp;
+  return timestamp * 1e-6;
 }
 
 double InterruptableSensorBase::ReadFallingTimestamp() {
   if (StatusIsFatal()) return 0.0;
   wpi_assert(m_interrupt != HAL_kInvalidHandle);
   int32_t status = 0;
-  double timestamp = HAL_ReadInterruptFallingTimestamp(m_interrupt, &status);
+  int64_t timestamp = HAL_ReadInterruptFallingTimestamp(m_interrupt, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
-  return timestamp;
+  return timestamp * 1e-6;
 }
 
 void InterruptableSensorBase::SetUpSourceEdge(bool risingEdge,


### PR DESCRIPTION
HAL_ReadInterruptRisingTimestamp and HAL_ReadInterruptFallingTimestamp
return time as a double.  This policy decision makes life harder for
users.  So, let's move that policy out into the C++ and Java code, not
in HAL.