### PR TITLE
cscore: Add JSON for source settings

### DIFF
--- a/cscore/src/main/java/edu/wpi/cscore/CameraServerJNI.java
+++ b/cscore/src/main/java/edu/wpi/cscore/CameraServerJNI.java
@@ -89,6 +89,8 @@ public class CameraServerJNI {
   public static native boolean setSourcePixelFormat(int source, int pixelFormat);
   public static native boolean setSourceResolution(int source, int width, int height);
   public static native boolean setSourceFPS(int source, int fps);
+  public static native boolean setSourceConfigJson(int source, String config);
+  public static native String getSourceConfigJson(int source);
   public static native VideoMode[] enumerateSourceVideoModes(int source);
   public static native int[] enumerateSourceSinks(int source);
   public static native int copySource(int source);

--- a/cscore/src/main/java/edu/wpi/cscore/VideoSource.java
+++ b/cscore/src/main/java/edu/wpi/cscore/VideoSource.java
@@ -271,6 +271,45 @@ public class VideoSource implements AutoCloseable {
   }
 
   /**
+   * Set video mode and properties from a JSON configuration string.
+   *
+   * <p>The format of the JSON input is:
+   *
+   * <pre>
+   * {
+   *     "pixel format": "MJPEG", "YUYV", etc
+   *     "width": video mode width
+   *     "height": video mode height
+   *     "fps": video mode fps
+   *     "brightness": percentage brightness
+   *     "white balance": "auto", "hold", or value
+   *     "exposure": "auto", "hold", or value
+   *     "properties": [
+   *         {
+   *             "name": property name
+   *             "value": property value
+   *         }
+   *     ]
+   * }
+   * </pre>
+   *
+   * @param config configuration
+   * @return True if set successfully
+   */
+  public boolean setConfigJson(String config) {
+    return CameraServerJNI.setSourceConfigJson(m_handle, config);
+  }
+
+  /**
+   * Get a JSON configuration string.
+   *
+   * @return JSON configuration string
+   */
+  public String getConfigJson() {
+    return CameraServerJNI.getSourceConfigJson(m_handle);
+  }
+
+  /**
    * Get the actual FPS.
    *
    * <p>CameraServerJNI#setTelemetryPeriod() must be called for this to be valid

--- a/cscore/src/main/native/cpp/MjpegServerImpl.cpp
+++ b/cscore/src/main/native/cpp/MjpegServerImpl.cpp
@@ -341,7 +341,7 @@ void MjpegServerImpl::ConnThread::SendHTMLHeadTitle(
 // Send the root html file with controls for all the settable properties.
 void MjpegServerImpl::ConnThread::SendHTML(wpi::raw_ostream& os,
                                            SourceImpl& source, bool header) {
-  if (header) SendHeader(os, 200, "OK", "application/x-javascript");
+  if (header) SendHeader(os, 200, "OK", "text/html");
 
   SendHTMLHeadTitle(os);
   os << startRootPage;
@@ -454,7 +454,7 @@ void MjpegServerImpl::ConnThread::SendHTML(wpi::raw_ostream& os,
 // Send a JSON file which is contains information about the source parameters.
 void MjpegServerImpl::ConnThread::SendJSON(wpi::raw_ostream& os,
                                            SourceImpl& source, bool header) {
-  if (header) SendHeader(os, 200, "OK", "application/x-javascript");
+  if (header) SendHeader(os, 200, "OK", "application/json");
 
   os << "{\n\"controls\": [\n";
   wpi::SmallVector<int, 32> properties_vec;
@@ -813,7 +813,7 @@ void MjpegServerImpl::ConnThread::ProcessRequest() {
     case kGetSourceConfig:
       SDEBUG("request for JSON file");
       if (auto source = GetSource()) {
-        SendHeader(os, 200, "OK", "application/x-javascript");
+        SendHeader(os, 200, "OK", "application/json");
         CS_Status status = CS_OK;
         os << source->GetConfigJson(&status);
         os.flush();

--- a/cscore/src/main/native/cpp/MjpegServerImpl.cpp
+++ b/cscore/src/main/native/cpp/MjpegServerImpl.cpp
@@ -817,8 +817,9 @@ void MjpegServerImpl::ConnThread::ProcessRequest() {
         CS_Status status = CS_OK;
         os << source->GetConfigJson(&status);
         os.flush();
-      } else
+      } else {
         SendError(os, 404, "Resource not found");
+      }
       break;
     case kRootPage:
       SDEBUG("request for root page");

--- a/cscore/src/main/native/cpp/SourceImpl.cpp
+++ b/cscore/src/main/native/cpp/SourceImpl.cpp
@@ -12,6 +12,7 @@
 
 #include <wpi/STLExtras.h>
 #include <wpi/timestamp.h>
+#include <wpi/json.h>
 
 #include "Log.h"
 #include "Notifier.h"
@@ -159,6 +160,272 @@ bool SourceImpl::SetFPS(int fps, CS_Status* status) {
   if (!mode) return false;
   mode.fps = fps;
   return SetVideoMode(mode, status);
+}
+
+bool SourceImpl::SetConfigJson(wpi::StringRef config, CS_Status* status) {
+  wpi::json j;
+  try {
+    j = wpi::json::parse(config);
+  } catch (wpi::json::parse_error e) {
+    SWARNING("SetConfigJson: parse error at byte " << e.byte << ": "
+                                                   << e.what());
+    *status = CS_PROPERTY_WRITE_FAILED;
+    return false;
+  }
+  return SetConfigJson(j, status);
+}
+
+bool SourceImpl::SetConfigJson(const wpi::json& config, CS_Status* status) {
+  VideoMode mode;
+
+  // pixel format
+  if (config.count("pixel format") != 0) {
+    try {
+      auto str = config.at("pixel format").get<std::string>();
+      wpi::StringRef s(str);
+      if (s.equals_lower("mjpeg"))
+        mode.pixelFormat = cs::VideoMode::kMJPEG;
+      else if (s.equals_lower("yuyv"))
+        mode.pixelFormat = cs::VideoMode::kYUYV;
+      else if (s.equals_lower("rgb565"))
+        mode.pixelFormat = cs::VideoMode::kRGB565;
+      else if (s.equals_lower("bgr"))
+        mode.pixelFormat = cs::VideoMode::kBGR;
+      else if (s.equals_lower("gray"))
+        mode.pixelFormat = cs::VideoMode::kGray;
+      else {
+        SWARNING("SetConfigJson: could not understand pixel format value '"
+                 << str << '\'');
+      }
+    } catch (wpi::json::exception e) {
+      SWARNING("SetConfigJson: could not read pixel format: " << e.what());
+    }
+  }
+
+  // width
+  if (config.count("width") != 0) {
+    try {
+      mode.width = config.at("width").get<unsigned int>();
+    } catch (wpi::json::exception e) {
+      SWARNING("SetConfigJson: could not read width: " << e.what());
+    }
+  }
+
+  // height
+  if (config.count("height") != 0) {
+    try {
+      mode.height = config.at("height").get<unsigned int>();
+    } catch (wpi::json::exception e) {
+      SWARNING("SetConfigJson: could not read height: " << e.what());
+    }
+  }
+
+  // fps
+  if (config.count("fps") != 0) {
+    try {
+      mode.fps = config.at("fps").get<unsigned int>();
+    } catch (wpi::json::exception e) {
+      SWARNING("SetConfigJson: could not read fps: " << e.what());
+    }
+  }
+
+  // if all of video mode is set, use SetVideoMode, otherwise piecemeal it
+  if (mode.pixelFormat != VideoMode::kUnknown && mode.width != 0 &&
+      mode.height != 0 && mode.fps != 0) {
+    SINFO("SetConfigJson: setting video mode to pixelFormat "
+          << mode.pixelFormat << ", width " << mode.width << ", height "
+          << mode.height << ", fps " << mode.fps);
+    SetVideoMode(mode, status);
+  } else {
+    if (mode.pixelFormat != cs::VideoMode::kUnknown) {
+      SINFO("SetConfigJson: setting pixelFormat " << mode.pixelFormat);
+      SetPixelFormat(static_cast<cs::VideoMode::PixelFormat>(mode.pixelFormat),
+                     status);
+    }
+    if (mode.width != 0 && mode.height != 0) {
+      SINFO("SetConfigJson: setting width " << mode.width << ", height "
+                                            << mode.height);
+      SetResolution(mode.width, mode.height, status);
+    }
+    if (mode.fps != 0) {
+      SINFO("SetConfigJson: setting fps " << mode.fps);
+      SetFPS(mode.fps, status);
+    }
+  }
+
+  // brightness
+  if (config.count("brightness") != 0) {
+    try {
+      int val = config.at("brightness").get<int>();
+      SINFO("SetConfigJson: setting brightness to " << val);
+      SetBrightness(val, status);
+    } catch (wpi::json::exception e) {
+      SWARNING("SetConfigJson: could not read brightness: " << e.what());
+    }
+  }
+
+  // white balance
+  if (config.count("white balance") != 0) {
+    try {
+      auto& setting = config.at("white balance");
+      if (setting.is_string()) {
+        auto str = setting.get<std::string>();
+        wpi::StringRef s(str);
+        if (s.equals_lower("auto")) {
+          SINFO("SetConfigJson: setting white balance to auto");
+          SetWhiteBalanceAuto(status);
+        } else if (s.equals_lower("hold")) {
+          SINFO("SetConfigJson: setting white balance to hold current");
+          SetWhiteBalanceHoldCurrent(status);
+        } else {
+          SWARNING("SetConfigJson: could not understand white balance value '"
+                   << str << '\'');
+        }
+      } else {
+        int val = setting.get<int>();
+        SINFO("SetConfigJson: setting white balance to " << val);
+        SetWhiteBalanceManual(val, status);
+      }
+    } catch (wpi::json::exception e) {
+      SWARNING("SetConfigJson: could not read white balance: " << e.what());
+    }
+  }
+
+  // exposure
+  if (config.count("exposure") != 0) {
+    try {
+      auto& setting = config.at("exposure");
+      if (setting.is_string()) {
+        auto str = setting.get<std::string>();
+        wpi::StringRef s(str);
+        if (s.equals_lower("auto")) {
+          SINFO("SetConfigJson: setting exposure to auto");
+          SetExposureAuto(status);
+        } else if (s.equals_lower("hold")) {
+          SINFO("SetConfigJson: setting exposure to hold current");
+          SetExposureHoldCurrent(status);
+        } else {
+          SWARNING("SetConfigJson: could not understand exposure value '"
+                   << str << '\'');
+        }
+      } else {
+        int val = setting.get<int>();
+        SINFO("SetConfigJson: setting exposure to " << val);
+        SetExposureManual(val, status);
+      }
+    } catch (wpi::json::exception e) {
+      SWARNING("SetConfigJson: could not read exposure: " << e.what());
+    }
+  }
+
+  // properties
+  if (config.count("properties") != 0) {
+    for (auto&& prop : config.at("properties")) {
+      std::string name;
+      try {
+        name = prop.at("name").get<std::string>();
+      } catch (wpi::json::exception e) {
+        SWARNING("SetConfigJson: could not read property name: " << e.what());
+        continue;
+      }
+      int n = GetPropertyIndex(name);
+      try {
+        auto& v = prop.at("value");
+        if (v.is_string()) {
+          std::string val = v.get<std::string>();
+          SINFO("SetConfigJson: setting property '" << name << "' to '" << val
+                                                    << '\'');
+          SetStringProperty(n, val, status);
+        } else if (v.is_boolean()) {
+          bool val = v.get<bool>();
+          SINFO("SetConfigJson: setting property '" << name << "' to " << val);
+          SetProperty(n, val, status);
+        } else {
+          int val = v.get<int>();
+          SINFO("SetConfigJson: setting property '" << name << "' to " << val);
+          SetProperty(n, val, status);
+        }
+      } catch (wpi::json::exception e) {
+        SWARNING("SetConfigJson: could not read property value: " << e.what());
+        continue;
+      }
+    }
+  }
+
+  return true;
+}
+
+std::string SourceImpl::GetConfigJson(CS_Status* status) {
+  std::string rv;
+  wpi::raw_string_ostream os(rv);
+  GetConfigJsonObject(status).dump(os, 4);
+  os.flush();
+  return rv;
+}
+
+wpi::json SourceImpl::GetConfigJsonObject(CS_Status* status) {
+  wpi::json j;
+
+  // pixel format
+  wpi::StringRef pixelFormat;
+  switch (m_mode.pixelFormat) {
+    case VideoMode::kMJPEG:
+      pixelFormat = "mjpeg";
+      break;
+    case VideoMode::kYUYV:
+      pixelFormat = "yuyv";
+      break;
+    case VideoMode::kRGB565:
+      pixelFormat = "rgb565";
+      break;
+    case VideoMode::kBGR:
+      pixelFormat = "bgr";
+      break;
+    case VideoMode::kGray:
+      pixelFormat = "gray";
+      break;
+    default:
+      break;
+  }
+  if (!pixelFormat.empty()) j.emplace("pixel format", pixelFormat);
+
+  // width
+  if (m_mode.width != 0) j.emplace("width", m_mode.width);
+
+  // height
+  if (m_mode.height != 0) j.emplace("height", m_mode.height);
+
+  // fps
+  if (m_mode.fps != 0) j.emplace("fps", m_mode.fps);
+
+  // TODO: output brightness, white balance, and exposure?
+
+  // properties
+  wpi::json props;
+  wpi::SmallVector<int, 32> propVec;
+  for (int p : EnumerateProperties(propVec, status)) {
+    wpi::json prop;
+    wpi::SmallString<128> strBuf;
+    prop.emplace("name", GetPropertyName(p, strBuf, status));
+    switch (GetPropertyKind(p)) {
+      case CS_PROP_BOOLEAN:
+        prop.emplace("value", static_cast<bool>(GetProperty(p, status)));
+        break;
+      case CS_PROP_INTEGER:
+      case CS_PROP_ENUM:
+        prop.emplace("value", GetProperty(p, status));
+        break;
+      case CS_PROP_STRING:
+        prop.emplace("value", GetStringProperty(p, strBuf, status));
+        break;
+      default:
+        continue;
+    }
+    props.emplace_back(prop);
+  }
+  if (props.is_array()) j.emplace("properties", props);
+
+  return j;
 }
 
 std::vector<VideoMode> SourceImpl::EnumerateVideoModes(

--- a/cscore/src/main/native/cpp/SourceImpl.cpp
+++ b/cscore/src/main/native/cpp/SourceImpl.cpp
@@ -11,8 +11,8 @@
 #include <cstring>
 
 #include <wpi/STLExtras.h>
-#include <wpi/timestamp.h>
 #include <wpi/json.h>
+#include <wpi/timestamp.h>
 
 #include "Log.h"
 #include "Notifier.h"

--- a/cscore/src/main/native/cpp/SourceImpl.cpp
+++ b/cscore/src/main/native/cpp/SourceImpl.cpp
@@ -183,17 +183,17 @@ bool SourceImpl::SetConfigJson(const wpi::json& config, CS_Status* status) {
     try {
       auto str = config.at("pixel format").get<std::string>();
       wpi::StringRef s(str);
-      if (s.equals_lower("mjpeg"))
+      if (s.equals_lower("mjpeg")) {
         mode.pixelFormat = cs::VideoMode::kMJPEG;
-      else if (s.equals_lower("yuyv"))
+      } else if (s.equals_lower("yuyv")) {
         mode.pixelFormat = cs::VideoMode::kYUYV;
-      else if (s.equals_lower("rgb565"))
+      } else if (s.equals_lower("rgb565")) {
         mode.pixelFormat = cs::VideoMode::kRGB565;
-      else if (s.equals_lower("bgr"))
+      } else if (s.equals_lower("bgr")) {
         mode.pixelFormat = cs::VideoMode::kBGR;
-      else if (s.equals_lower("gray"))
+      } else if (s.equals_lower("gray")) {
         mode.pixelFormat = cs::VideoMode::kGray;
-      else {
+      } else {
         SWARNING("SetConfigJson: could not understand pixel format value '"
                  << str << '\'');
       }

--- a/cscore/src/main/native/cpp/SourceImpl.h
+++ b/cscore/src/main/native/cpp/SourceImpl.h
@@ -27,6 +27,10 @@
 #include "PropertyContainer.h"
 #include "cscore_cpp.h"
 
+namespace wpi {
+class json;
+}  // namespace wpi
+
 namespace cs {
 
 class Notifier;
@@ -126,6 +130,11 @@ class SourceImpl : public PropertyContainer {
                               CS_Status* status);
   virtual bool SetResolution(int width, int height, CS_Status* status);
   virtual bool SetFPS(int fps, CS_Status* status);
+
+  bool SetConfigJson(wpi::StringRef config, CS_Status* status);
+  virtual bool SetConfigJson(const wpi::json& config, CS_Status* status);
+  std::string GetConfigJson(CS_Status* status);
+  virtual wpi::json GetConfigJsonObject(CS_Status* status);
 
   std::vector<VideoMode> EnumerateVideoModes(CS_Status* status) const;
 

--- a/cscore/src/main/native/cpp/cscore_c.cpp
+++ b/cscore/src/main/native/cpp/cscore_c.cpp
@@ -170,6 +170,15 @@ CS_Bool CS_SetSourceFPS(CS_Source source, int fps, CS_Status* status) {
   return cs::SetSourceFPS(source, fps, status);
 }
 
+CS_Bool CS_SetSourceConfigJson(CS_Source source, const char* config,
+                               CS_Status* status) {
+  return cs::SetSourceConfigJson(source, config, status);
+}
+
+char* CS_GetSourceConfigJson(CS_Source source, CS_Status* status) {
+  return cs::ConvertToC(cs::GetSourceConfigJson(source, status));
+}
+
 CS_VideoMode* CS_EnumerateSourceVideoModes(CS_Source source, int* count,
                                            CS_Status* status) {
   auto vec = cs::EnumerateSourceVideoModes(source, status);

--- a/cscore/src/main/native/cpp/cscore_cpp.cpp
+++ b/cscore/src/main/native/cpp/cscore_cpp.cpp
@@ -9,6 +9,7 @@
 
 #include <wpi/SmallString.h>
 #include <wpi/hostname.h>
+#include <wpi/json.h>
 
 #include "Handle.h"
 #include "Instance.h"
@@ -322,6 +323,44 @@ bool SetSourceFPS(CS_Source source, int fps, CS_Status* status) {
     return false;
   }
   return data->source->SetFPS(fps, status);
+}
+
+bool SetSourceConfigJson(CS_Source source, wpi::StringRef config,
+                         CS_Status* status) {
+  auto data = Instance::GetInstance().GetSource(source);
+  if (!data) {
+    *status = CS_INVALID_HANDLE;
+    return false;
+  }
+  return data->source->SetConfigJson(config, status);
+}
+
+bool SetSourceConfigJson(CS_Source source, const wpi::json& config,
+                         CS_Status* status) {
+  auto data = Instance::GetInstance().GetSource(source);
+  if (!data) {
+    *status = CS_INVALID_HANDLE;
+    return false;
+  }
+  return data->source->SetConfigJson(config, status);
+}
+
+std::string GetSourceConfigJson(CS_Source source, CS_Status* status) {
+  auto data = Instance::GetInstance().GetSource(source);
+  if (!data) {
+    *status = CS_INVALID_HANDLE;
+    return std::string{};
+  }
+  return data->source->GetConfigJson(status);
+}
+
+wpi::json GetSourceConfigJsonObject(CS_Source source, CS_Status* status) {
+  auto data = Instance::GetInstance().GetSource(source);
+  if (!data) {
+    *status = CS_INVALID_HANDLE;
+    return wpi::json{};
+  }
+  return data->source->GetConfigJsonObject(status);
 }
 
 std::vector<VideoMode> EnumerateSourceVideoModes(CS_Source source,

--- a/cscore/src/main/native/cpp/cscore_oo.cpp
+++ b/cscore/src/main/native/cpp/cscore_oo.cpp
@@ -7,7 +7,14 @@
 
 #include "cscore_oo.h"
 
+#include <wpi/json.h>
+
 using namespace cs;
+
+wpi::json VideoSource::GetConfigJsonObject() const {
+  m_status = 0;
+  return GetSourceConfigJsonObject(m_handle, &m_status);
+}
 
 std::vector<VideoProperty> VideoSource::EnumerateProperties() const {
   wpi::SmallVector<CS_Property, 32> handles_buf;

--- a/cscore/src/main/native/cpp/jni/CameraServerJNI.cpp
+++ b/cscore/src/main/native/cpp/jni/CameraServerJNI.cpp
@@ -753,6 +753,36 @@ Java_edu_wpi_cscore_CameraServerJNI_setSourceFPS
 
 /*
  * Class:     edu_wpi_cscore_CameraServerJNI
+ * Method:    setSourceConfigJson
+ * Signature: (ILjava/lang/String;)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_cscore_CameraServerJNI_setSourceConfigJson
+  (JNIEnv* env, jclass, jint source, jstring config)
+{
+  CS_Status status = 0;
+  auto val = cs::SetSourceConfigJson(source, JStringRef{env, config}, &status);
+  CheckStatus(env, status);
+  return val;
+}
+
+/*
+ * Class:     edu_wpi_cscore_CameraServerJNI
+ * Method:    getSourceConfigJson
+ * Signature: (I)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_cscore_CameraServerJNI_getSourceConfigJson
+  (JNIEnv* env, jclass, jint source)
+{
+  CS_Status status = 0;
+  auto val = cs::GetSourceConfigJson(source, &status);
+  CheckStatus(env, status);
+  return MakeJString(env, val);
+}
+
+/*
+ * Class:     edu_wpi_cscore_CameraServerJNI
  * Method:    enumerateSourceVideoModes
  * Signature: (I)[Ljava/lang/Object;
  */

--- a/cscore/src/main/native/include/cscore_c.h
+++ b/cscore/src/main/native/include/cscore_c.h
@@ -289,6 +289,9 @@ CS_Bool CS_SetSourcePixelFormat(CS_Source source,
 CS_Bool CS_SetSourceResolution(CS_Source source, int width, int height,
                                CS_Status* status);
 CS_Bool CS_SetSourceFPS(CS_Source source, int fps, CS_Status* status);
+CS_Bool CS_SetSourceConfigJson(CS_Source source, const char* config,
+                               CS_Status* status);
+char* CS_GetSourceConfigJson(CS_Source source, CS_Status* status);
 CS_VideoMode* CS_EnumerateSourceVideoModes(CS_Source source, int* count,
                                            CS_Status* status);
 CS_Sink* CS_EnumerateSourceSinks(CS_Source source, int* count,

--- a/cscore/src/main/native/include/cscore_cpp.h
+++ b/cscore/src/main/native/include/cscore_cpp.h
@@ -25,6 +25,10 @@ namespace cv {
 class Mat;
 }  // namespace cv
 
+namespace wpi {
+class json;
+}  // namespace wpi
+
 /** CameraServer (cscore) namespace */
 namespace cs {
 
@@ -221,6 +225,12 @@ bool SetSourcePixelFormat(CS_Source source, VideoMode::PixelFormat pixelFormat,
 bool SetSourceResolution(CS_Source source, int width, int height,
                          CS_Status* status);
 bool SetSourceFPS(CS_Source source, int fps, CS_Status* status);
+bool SetSourceConfigJson(CS_Source source, wpi::StringRef config,
+                         CS_Status* status);
+bool SetSourceConfigJson(CS_Source source, const wpi::json& config,
+                         CS_Status* status);
+std::string GetSourceConfigJson(CS_Source source, CS_Status* status);
+wpi::json GetSourceConfigJsonObject(CS_Source source, CS_Status* status);
 std::vector<VideoMode> EnumerateSourceVideoModes(CS_Source source,
                                                  CS_Status* status);
 wpi::ArrayRef<CS_Sink> EnumerateSourceSinks(CS_Source source,

--- a/cscore/src/main/native/include/cscore_oo.h
+++ b/cscore/src/main/native/include/cscore_oo.h
@@ -254,6 +254,56 @@ class VideoSource {
   bool SetFPS(int fps);
 
   /**
+   * Set video mode and properties from a JSON configuration string.
+   *
+   * The format of the JSON input is:
+   *
+   * <pre>
+   * {
+   *     "pixel format": "MJPEG", "YUYV", etc
+   *     "width": video mode width
+   *     "height": video mode height
+   *     "fps": video mode fps
+   *     "brightness": percentage brightness
+   *     "white balance": "auto", "hold", or value
+   *     "exposure": "auto", "hold", or value
+   *     "properties": [
+   *         {
+   *             "name": property name
+   *             "value": property value
+   *         }
+   *     ]
+   * }
+   * </pre>
+   *
+   * @param config configuration
+   * @return True if set successfully
+   */
+  bool SetConfigJson(wpi::StringRef config);
+
+  /**
+   * Set video mode and properties from a JSON configuration object.
+   *
+   * @param config configuration
+   * @return True if set successfully
+   */
+  bool SetConfigJson(const wpi::json& config);
+
+  /**
+   * Get a JSON configuration string.
+   *
+   * @return JSON configuration string
+   */
+  std::string GetConfigJson() const;
+
+  /**
+   * Get a JSON configuration object.
+   *
+   * @return JSON configuration object
+   */
+  wpi::json GetConfigJsonObject() const;
+
+  /**
    * Get the actual FPS.
    *
    * <p>SetTelemetryPeriod() must be called for this to be valid.

--- a/cscore/src/main/native/include/cscore_oo.inl
+++ b/cscore/src/main/native/include/cscore_oo.inl
@@ -170,6 +170,21 @@ inline bool VideoSource::SetFPS(int fps) {
   return SetSourceFPS(m_handle, fps, &m_status);
 }
 
+inline bool VideoSource::SetConfigJson(wpi::StringRef config) {
+  m_status = 0;
+  return SetSourceConfigJson(m_handle, config, &m_status);
+}
+
+inline bool VideoSource::SetConfigJson(const wpi::json& config) {
+  m_status = 0;
+  return SetSourceConfigJson(m_handle, config, &m_status);
+}
+
+inline std::string VideoSource::GetConfigJson() const {
+  m_status = 0;
+  return GetSourceConfigJson(m_handle, &m_status);
+}
+
 inline double VideoSource::GetActualFPS() const {
   m_status = 0;
   return cs::GetTelemetryAverageValue(m_handle, CS_SOURCE_FRAMES_RECEIVED,

--- a/wpiutil/src/main/native/include/wpi/Logger.h
+++ b/wpiutil/src/main/native/include/wpi/Logger.h
@@ -58,7 +58,8 @@ class Logger {
 #define WPI_LOG(logger_inst, level, x)                                 \
   do {                                                                 \
     ::wpi::Logger& WPI_logger_ = logger_inst;                          \
-    if (WPI_logger_.min_level() <= level && WPI_logger_.HasLogger()) { \
+    if (WPI_logger_.min_level() <= static_cast<unsigned int>(level) && \
+        WPI_logger_.HasLogger()) {                                     \
       ::wpi::SmallString<128> log_buf_;                                \
       ::wpi::raw_svector_ostream log_os_{log_buf_};                    \
       log_os_ << x;                                                    \


### PR DESCRIPTION
This allows save and restore of camera settings.  The restore is a bit
smarter than the save.