### PR TITLE
wpiutil: WebSocket: Fix Sec-Websocket-Accept computation

### DIFF
--- a/wpiutil/src/main/native/cpp/WebSocket.cpp
+++ b/wpiutil/src/main/native/cpp/WebSocket.cpp
@@ -71,7 +71,7 @@ static StringRef AcceptHash(StringRef key, SmallVectorImpl<char>& buf) {
   hash.Update(key);
   hash.Update("258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
   SmallString<64> hashBuf;
-  return Base64Encode(hash.Final(hashBuf), buf);
+  return Base64Encode(hash.RawFinal(hashBuf), buf);
 }
 
 WebSocket::WebSocket(uv::Stream& stream, bool server, const private_init&)

--- a/wpiutil/src/main/native/include/wpi/sha1.h
+++ b/wpiutil/src/main/native/include/wpi/sha1.h
@@ -38,6 +38,7 @@ class SHA1 {
   void Update(raw_istream& is);
   std::string Final();
   StringRef Final(SmallVectorImpl<char>& buf);
+  StringRef RawFinal(SmallVectorImpl<char>& buf);
   static std::string FromFile(StringRef filename);
 
  private:

--- a/wpiutil/src/test/native/cpp/WebSocketClientTest.cpp
+++ b/wpiutil/src/test/native/cpp/WebSocketClientTest.cpp
@@ -40,7 +40,7 @@ class WebSocketClientTest : public WebSocketTest {
       SmallString<64> hashBuf;
       SmallString<64> acceptBuf;
       os << "Sec-WebSocket-Accept: "
-         << Base64Encode(hash.Final(hashBuf), acceptBuf) << "\r\n";
+         << Base64Encode(hash.RawFinal(hashBuf), acceptBuf) << "\r\n";
 
       if (!mockProtocol.empty())
         os << "Sec-WebSocket-Protocol: " << mockProtocol << "\r\n";

--- a/wpiutil/src/test/native/cpp/WebSocketTest.cpp
+++ b/wpiutil/src/test/native/cpp/WebSocketTest.cpp
@@ -223,6 +223,7 @@ TEST_F(WebSocketTest, CreateServerBasic) {
       ASSERT_EQ(value, "Upgrade");
       ++gotConnection;
     } else if (name.equals_lower("sec-websocket-accept")) {
+      ASSERT_EQ(value, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
       ++gotAccept;
     } else {
       FAIL() << "unexpected header " << name.str();
@@ -232,7 +233,7 @@ TEST_F(WebSocketTest, CreateServerBasic) {
 
   serverPipe->Listen([&]() {
     auto conn = serverPipe->Accept();
-    auto ws = WebSocket::CreateServer(*conn, "foo", "13");
+    auto ws = WebSocket::CreateServer(*conn, "dGhlIHNhbXBsZSBub25jZQ==", "13");
     ws->open.connect([&](StringRef protocol) {
       ++gotOpen;
       ASSERT_TRUE(protocol.empty());


### PR DESCRIPTION
It needs to use the raw SHA1 bytes, not the hex-decoded text.