### PR TITLE
Created C++ ShuffleBoard example

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/ShuffleBoard/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ShuffleBoard/cpp/Robot.cpp
@@ -1,0 +1,82 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <frc/AnalogPotentiometer.h>
+#include <frc/Encoder.h>
+#include <frc/Joystick.h>
+#include <frc/Spark.h>
+#include <frc/TimedRobot.h>
+#include <frc/drive/DifferentialDrive.h>
+#include <frc/shuffleboard/Shuffleboard.h>
+#include <frc/shuffleboard/ShuffleboardLayout.h>
+#include <frc/shuffleboard/ShuffleboardTab.h>
+#include <networktables/NetworkTableEntry.h>
+#include <networktables/NetworkTableInstance.h>
+
+/**
+ * This sample program provides an example for ShuffleBoard, an alternative
+ * to SmartDashboard for displaying values and properties of different robot
+ * parts.
+ *
+ * ShuffleBoard can use pre-programmed widgets to display various values, such
+ * as Boolean Boxes, Sliders, Graphs, and more. In addition, they can display
+ * things in various Tabs.
+ *
+ * For more information on how to create personal layouts and more in
+ * ShuffleBoard, feel free to reference the official FIRST WPILib documentation
+ * online.
+ */
+class Robot : public frc::TimedRobot {
+ public:
+  void RobotInit() override {
+    // Add a widget titled 'Max Speed' with a number slider.
+    m_maxSpeed = frc::Shuffleboard::GetTab("Configuration")
+                     .Add("Max Speed", 1)
+                     .WithWidget("Number Slider")
+                     .GetEntry();
+
+    // Create a 'DriveBase' tab and add the drivetrain object to it.
+    frc::ShuffleboardTab& driveBaseTab = frc::Shuffleboard::GetTab("DriveBase");
+    driveBaseTab.Add("TankDrive", m_robotDrive);
+
+    // Put encoders in a list layout.
+    frc::ShuffleboardLayout& encoders =
+        driveBaseTab.GetLayout("List Layout", "Encoders")
+            .WithPosition(0, 0)
+            .WithSize(2, 2);
+    encoders.Add("Left Encoder", m_leftEncoder);
+    encoders.Add("Right Encoder", m_rightEncoder);
+
+    // Create a 'Elevator' tab and add the potentiometer and elevator motor to
+    // it.
+    frc::ShuffleboardTab& elevatorTab = frc::Shuffleboard::GetTab("Elevator");
+    elevatorTab.Add("Motor", m_elevatorMotor);
+    elevatorTab.Add("Potentiometer", m_ElevatorPot);
+  }
+
+  void AutonomousInit() override {
+    // Update the Max Output for the drivetrain.
+    m_robotDrive.SetMaxOutput(m_maxSpeed.GetDouble(1.0));
+  }
+
+ private:
+  frc::Spark m_left{0};
+  frc::Spark m_right{1};
+  frc::Spark m_elevatorMotor{2};
+
+  frc::DifferentialDrive m_robotDrive{m_left, m_right};
+
+  frc::Joystick m_stick{0};
+
+  frc::Encoder m_leftEncoder{0, 1};
+  frc::Encoder m_rightEncoder{2, 3};
+  frc::AnalogPotentiometer m_ElevatorPot{0};
+
+  nt::NetworkTableEntry m_maxSpeed;
+};
+
+int main() { return frc::StartRobot<Robot>(); }

--- a/wpilibcExamples/src/main/cpp/examples/examples.json
+++ b/wpilibcExamples/src/main/cpp/examples/examples.json
@@ -234,5 +234,14 @@
     ],
     "foldername": "HAL",
     "gradlebase": "c"
+  },
+  {
+    "name": "ShuffleBoard",
+    "description": "An example program that uses ShuffleBoard with its Widgets and Tabs.",
+    "tags": [
+      "ShuffleBoard"
+    ],
+    "foldername": "ShuffleBoard",
+    "gradlebase": "cpp"
   }
 ]


### PR DESCRIPTION
I ported over the Java ShuffleBoard example to C++ as referenced in Issue #1428. (I updated the `examples.json` file with this example.

I was not able to completely copy it because adding the methods `WithPosition` and `WithSize` to did not work.
[Snippet #1]( https://github.com/Tyler-Duckworth/allwpilib/blob/d4f7db0db782582360962ae50c266d73a1a0d0db/wpilibcExamples/src/main/cpp/examples/ShuffleBoard/cpp/Robot.cpp#L40-L44)

For comparison, here is the same lines in Java: 
[Snippet #2](https://github.com/Tyler-Duckworth/allwpilib/blob/d4f7db0db782582360962ae50c266d73a1a0d0db/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/shuffleboard/Robot.java#L31-L38)
