### PR TITLE
Add methods to change the selected tab in the Shuffleboard app

### DIFF
--- a/wpilibc/src/main/native/cpp/shuffleboard/Shuffleboard.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/Shuffleboard.cpp
@@ -19,9 +19,7 @@ ShuffleboardTab& Shuffleboard::GetTab(wpi::StringRef title) {
   return GetInstance().GetTab(title);
 }
 
-void Shuffleboard::SelectTab(int index) {
-  GetInstance().SelectTab(index);
-}
+void Shuffleboard::SelectTab(int index) { GetInstance().SelectTab(index); }
 
 void Shuffleboard::SelectTab(wpi::StringRef title) {
   GetInstance().SelectTab(title);

--- a/wpilibc/src/main/native/cpp/shuffleboard/Shuffleboard.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/Shuffleboard.cpp
@@ -19,6 +19,14 @@ ShuffleboardTab& Shuffleboard::GetTab(wpi::StringRef title) {
   return GetInstance().GetTab(title);
 }
 
+void Shuffleboard::SelectTab(int index) {
+  GetInstance().SelectTab(index);
+}
+
+void Shuffleboard::SelectTab(wpi::StringRef title) {
+  GetInstance().SelectTab(title);
+}
+
 void Shuffleboard::EnableActuatorWidgets() {
   GetInstance().EnableActuatorWidgets();
 }

--- a/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
@@ -72,3 +72,11 @@ void ShuffleboardInstance::DisableActuatorWidgets() {
     }
   }
 }
+
+void ShuffleboardInstance::SelectTab(int index) {
+  m_impl->rootMetaTable->GetEntry("Selected").ForceSetDouble(index);
+}
+
+void ShuffleboardInstance::SelectTab(wpi::StringRef title) {
+  m_impl->rootMetaTable->GetEntry("Selected").ForceSetString(title);
+}

--- a/wpilibc/src/main/native/include/frc/shuffleboard/Shuffleboard.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/Shuffleboard.h
@@ -83,8 +83,9 @@ class Shuffleboard final {
   static ShuffleboardTab& GetTab(wpi::StringRef title);
 
   /**
-   * Selects the tab in the dashboard with the given index in the range [0..n-1], where <i>n</i>
-   * is the number of tabs in the dashboard at the time this method is called.
+   * Selects the tab in the dashboard with the given index in the range
+   * [0..n-1], where <i>n</i> is the number of tabs in the dashboard at the time
+   * this method is called.
    *
    * @param index the index of the tab to select
    */

--- a/wpilibc/src/main/native/include/frc/shuffleboard/Shuffleboard.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/Shuffleboard.h
@@ -83,6 +83,21 @@ class Shuffleboard final {
   static ShuffleboardTab& GetTab(wpi::StringRef title);
 
   /**
+   * Selects the tab in the dashboard with the given index in the range [0..n-1], where <i>n</i>
+   * is the number of tabs in the dashboard at the time this method is called.
+   *
+   * @param index the index of the tab to select
+   */
+  static void SelectTab(int index);
+
+  /**
+   * Selects the tab in the dashboard with the given title.
+   *
+   * @param title the title of the tab to select
+   */
+  static void SelectTab(wpi::StringRef title);
+
+  /**
    * Enables user control of widgets containing actuators: speed controllers,
    * relays, etc. This should only be used when the robot is in test mode.
    * IterativeRobotBase and SampleRobot are both configured to call this method

--- a/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardInstance.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardInstance.h
@@ -28,6 +28,10 @@ class ShuffleboardInstance final : public ShuffleboardRoot {
 
   void DisableActuatorWidgets() override;
 
+  void SelectTab(int index) override;
+
+  void SelectTab(wpi::StringRef) override;
+
  private:
   struct Impl;
   std::unique_ptr<Impl> m_impl;

--- a/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardRoot.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardRoot.h
@@ -45,6 +45,22 @@ class ShuffleboardRoot {
    * actuators.
    */
   virtual void DisableActuatorWidgets() = 0;
+
+  /**
+   * Selects the tab in the dashboard with the given index in the range [0..n-1], where <i>n</i>
+   * is the number of tabs in the dashboard at the time this method is called.
+   *
+   * @param index the index of the tab to select
+   */
+  virtual void SelectTab(int index) = 0;
+
+  /**
+   * Selects the tab in the dashboard with the given title.
+   *
+   * @param title the title of the tab to select
+   */
+  virtual void SelectTab(wpi::StringRef title) = 0;
+
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardRoot.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardRoot.h
@@ -47,8 +47,9 @@ class ShuffleboardRoot {
   virtual void DisableActuatorWidgets() = 0;
 
   /**
-   * Selects the tab in the dashboard with the given index in the range [0..n-1], where <i>n</i>
-   * is the number of tabs in the dashboard at the time this method is called.
+   * Selects the tab in the dashboard with the given index in the range
+   * [0..n-1], where <i>n</i> is the number of tabs in the dashboard at the time
+   * this method is called.
    *
    * @param index the index of the tab to select
    */
@@ -60,7 +61,6 @@ class ShuffleboardRoot {
    * @param title the title of the tab to select
    */
   virtual void SelectTab(wpi::StringRef title) = 0;
-
 };
 
 }  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/Shuffleboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/Shuffleboard.java
@@ -83,6 +83,25 @@ public final class Shuffleboard {
   }
 
   /**
+   * Selects the tab in the dashboard with the given index in the range [0..n-1], where <i>n</i>
+   * is the number of tabs in the dashboard at the time this method is called.
+   *
+   * @param index the index of the tab to select
+   */
+  public static void selectTab(int index) {
+    root.selectTab(index);
+  }
+
+  /**
+   * Selects the tab in the dashboard with the given title.
+   *
+   * @param title the title of the tab to select
+   */
+  public static void selectTab(String title) {
+    root.selectTab(title);
+  }
+
+  /**
    * Enables user control of widgets containing actuators: speed controllers, relays, etc. This
    * should only be used when the robot is in test mode. IterativeRobotBase and SampleRobot are
    * both configured to call this method when entering test mode; most users should not need to use

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
 
 final class ShuffleboardInstance implements ShuffleboardRoot {
@@ -21,11 +22,13 @@ final class ShuffleboardInstance implements ShuffleboardRoot {
   private boolean m_tabsChanged = false; // NOPMD redundant field initializer
   private final NetworkTable m_rootTable;
   private final NetworkTable m_rootMetaTable;
+  private final NetworkTableEntry m_selectedTabEntry;
 
   ShuffleboardInstance(NetworkTableInstance ntInstance) {
     Objects.requireNonNull(ntInstance, "NetworkTable instance cannot be null");
     m_rootTable = ntInstance.getTable(Shuffleboard.kBaseTableName);
     m_rootMetaTable = m_rootTable.getSubTable(".metadata");
+    m_selectedTabEntry = m_rootMetaTable.getEntry("Selected");
   }
 
   @Override
@@ -62,6 +65,16 @@ final class ShuffleboardInstance implements ShuffleboardRoot {
   @Override
   public void disableActuatorWidgets() {
     applyToAllComplexWidgets(ComplexWidget::disableIfActuator);
+  }
+
+  @Override
+  public void selectTab(int index) {
+    m_selectedTabEntry.forceSetDouble(index);
+  }
+
+  @Override
+  public void selectTab(String title) {
+    m_selectedTabEntry.forceSetString(title);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardRoot.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardRoot.java
@@ -38,4 +38,19 @@ interface ShuffleboardRoot {
    */
   void disableActuatorWidgets();
 
+  /**
+   * Selects the tab in the dashboard with the given index in the range [0..n-1], where <i>n</i>
+   * is the number of tabs in the dashboard at the time this method is called.
+   *
+   * @param index the index of the tab to select
+   */
+  void selectTab(int index);
+
+  /**
+   * Selects the tab in the dashboard with the given title.
+   *
+   * @param title the title of the tab to select
+   */
+  void selectTab(String title);
+
 }


### PR DESCRIPTION
One possible usecase would be to switch between context-specific tabs as the match transitions between states (e.g. a `Preround` tab used before the start of the match with choosers, an `Autonomous` tab that might display robot location or the running commands, a `Teleop` tab for drivers, etc.)