### PR TITLE
Update auto SPI for timestamp changes

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/SPIJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/SPIJNI.java
@@ -57,7 +57,7 @@ public class SPIJNI extends JNIWrapper {
   public static native int spiReadAutoReceivedData(int port, ByteBuffer buffer, int numToRead,
                                                    double timeout);
 
-  public static native int spiReadAutoReceivedData(int port, byte[] buffer, int numToRead,
+  public static native int spiReadAutoReceivedData(int port, int[] buffer, int numToRead,
                                                    double timeout);
 
   public static native int spiGetAutoDroppedCount(int port);

--- a/hal/src/main/java/edu/wpi/first/hal/sim/SpiReadAutoReceiveBufferCallback.java
+++ b/hal/src/main/java/edu/wpi/first/hal/sim/SpiReadAutoReceiveBufferCallback.java
@@ -8,5 +8,5 @@
 package edu.wpi.first.hal.sim;
 
 public interface SpiReadAutoReceiveBufferCallback {
-  int callback(String name, byte[] buffer, int numToRead);
+  int callback(String name, int[] buffer, int numToRead);
 }

--- a/hal/src/main/native/athena/SPI.cpp
+++ b/hal/src/main/native/athena/SPI.cpp
@@ -604,7 +604,7 @@ void HAL_ForceSPIAutoRead(HAL_SPIPort port, int32_t* status) {
   spiSystem->strobeAutoForceOne(status);
 }
 
-int32_t HAL_ReadSPIAutoReceivedData(HAL_SPIPort port, uint8_t* buffer,
+int32_t HAL_ReadSPIAutoReceivedData(HAL_SPIPort port, uint32_t* buffer,
                                     int32_t numToRead, double timeout,
                                     int32_t* status) {
   std::lock_guard<wpi::mutex> lock(spiAutoMutex);

--- a/hal/src/main/native/cpp/jni/SPIJNI.cpp
+++ b/hal/src/main/native/cpp/jni/SPIJNI.cpp
@@ -436,8 +436,8 @@ Java_edu_wpi_first_hal_SPIJNI_spiReadAutoReceivedData__ILjava_nio_ByteBuffer_2ID
   SPIJNI_LOG(logDEBUG) << "Port = " << port;
   SPIJNI_LOG(logDEBUG) << "NumToRead = " << numToRead;
   SPIJNI_LOG(logDEBUG) << "Timeout = " << timeout;
-  uint8_t* recvBuf =
-      reinterpret_cast<uint8_t*>(env->GetDirectBufferAddress(buffer));
+  uint32_t* recvBuf =
+      reinterpret_cast<uint32_t*>(env->GetDirectBufferAddress(buffer));
   int32_t status = 0;
   jint retval = HAL_ReadSPIAutoReceivedData(
       static_cast<HAL_SPIPort>(port), recvBuf, numToRead, timeout, &status);
@@ -450,18 +450,18 @@ Java_edu_wpi_first_hal_SPIJNI_spiReadAutoReceivedData__ILjava_nio_ByteBuffer_2ID
 /*
  * Class:     edu_wpi_first_hal_SPIJNI
  * Method:    spiReadAutoReceivedData
- * Signature: (I[BID)I
+ * Signature: (I[IID)I
  */
 JNIEXPORT jint JNICALL
-Java_edu_wpi_first_hal_SPIJNI_spiReadAutoReceivedData__I_3BID
-  (JNIEnv* env, jclass, jint port, jbyteArray buffer, jint numToRead,
+Java_edu_wpi_first_hal_SPIJNI_spiReadAutoReceivedData__I_3IID
+  (JNIEnv* env, jclass, jint port, jintArray buffer, jint numToRead,
    jdouble timeout)
 {
   SPIJNI_LOG(logDEBUG) << "Calling SPIJNI spiReadAutoReceivedData";
   SPIJNI_LOG(logDEBUG) << "Port = " << port;
   SPIJNI_LOG(logDEBUG) << "NumToRead = " << numToRead;
   SPIJNI_LOG(logDEBUG) << "Timeout = " << timeout;
-  wpi::SmallVector<uint8_t, 128> recvBuf;
+  wpi::SmallVector<uint32_t, 128> recvBuf;
   recvBuf.resize(numToRead);
   int32_t status = 0;
   jint retval =
@@ -471,8 +471,8 @@ Java_edu_wpi_first_hal_SPIJNI_spiReadAutoReceivedData__I_3BID
   SPIJNI_LOG(logDEBUG) << "Return = " << retval;
   if (!CheckStatus(env, status)) return retval;
   if (numToRead > 0) {
-    env->SetByteArrayRegion(buffer, 0, numToRead,
-                            reinterpret_cast<const jbyte*>(recvBuf.data()));
+    env->SetIntArrayRegion(buffer, 0, numToRead,
+                           reinterpret_cast<const jint*>(recvBuf.data()));
   }
   return retval;
 }

--- a/hal/src/main/native/include/hal/SPI.h
+++ b/hal/src/main/native/include/hal/SPI.h
@@ -218,16 +218,20 @@ void HAL_SetSPIAutoTransmitData(HAL_SPIPort port, const uint8_t* dataToSend,
 void HAL_ForceSPIAutoRead(HAL_SPIPort port, int32_t* status);
 
 /**
- * Reads data received by the SPI accumulator.
+ * Reads data received by the SPI accumulator.  Each received data sequence
+ * consists of a timestamp followed by the received data bytes, one byte per
+ * word (in the least significant byte).  The length of each received data
+ * sequence is the same as the combined dataSize + zeroSize set in
+ * HAL_SetSPIAutoTransmitData.
  *
  * @param port      The number of the port to use. 0-3 for Onboard CS0-CS2, 4
  * for MXP.
  * @param buffer    The buffer to store the data into.
- * @param numToRead The number of bytes to read.
+ * @param numToRead The number of words to read.
  * @param timeout   The read timeout (in seconds).
- * @return          The number of bytes actually read.
+ * @return          The number of words actually read.
  */
-int32_t HAL_ReadSPIAutoReceivedData(HAL_SPIPort port, uint8_t* buffer,
+int32_t HAL_ReadSPIAutoReceivedData(HAL_SPIPort port, uint32_t* buffer,
                                     int32_t numToRead, double timeout,
                                     int32_t* status);
 

--- a/hal/src/main/native/include/mockdata/SPIData.h
+++ b/hal/src/main/native/include/mockdata/SPIData.h
@@ -14,7 +14,7 @@
 
 typedef void (*HAL_SpiReadAutoReceiveBufferCallback)(const char* name,
                                                      void* param,
-                                                     unsigned char* buffer,
+                                                     uint32_t* buffer,
                                                      int32_t numToRead,
                                                      int32_t* outputCount);
 

--- a/hal/src/main/native/sim/SPI.cpp
+++ b/hal/src/main/native/sim/SPI.cpp
@@ -54,7 +54,7 @@ void HAL_SetSPIAutoTransmitData(HAL_SPIPort port, const uint8_t* dataToSend,
                                 int32_t dataSize, int32_t zeroSize,
                                 int32_t* status) {}
 void HAL_ForceSPIAutoRead(HAL_SPIPort port, int32_t* status) {}
-int32_t HAL_ReadSPIAutoReceivedData(HAL_SPIPort port, uint8_t* buffer,
+int32_t HAL_ReadSPIAutoReceivedData(HAL_SPIPort port, uint32_t* buffer,
                                     int32_t numToRead, double timeout,
                                     int32_t* status) {
   return SimSPIData[port].ReadAutoReceivedData(buffer, numToRead, timeout,

--- a/hal/src/main/native/sim/jni/SimulatorJNI.cpp
+++ b/hal/src/main/native/sim/jni/SimulatorJNI.cpp
@@ -69,7 +69,7 @@ jint SimOnLoad(JavaVM* vm, void* reserved) {
 
   spiReadAutoReceiveBufferCallbackCallback =
       env->GetMethodID(spiReadAutoReceiveBufferCallbackCls, "callback",
-                       "(Ljava/lang/String;[BI)I");
+                       "(Ljava/lang/String;[II)I");
   if (!spiReadAutoReceiveBufferCallbackCallback) return JNI_ERR;
 
   InitializeStore();

--- a/hal/src/main/native/sim/jni/SpiReadAutoReceiveBufferCallbackStore.h
+++ b/hal/src/main/native/sim/jni/SpiReadAutoReceiveBufferCallbackStore.h
@@ -22,7 +22,7 @@ namespace sim {
 class SpiReadAutoReceiveBufferCallbackStore {
  public:
   void create(JNIEnv* env, jobject obj);
-  int32_t performCallback(const char* name, unsigned char* buffer,
+  int32_t performCallback(const char* name, uint32_t* buffer,
                           int32_t numToRead);
   void free(JNIEnv* env);
   void setCallbackId(int32_t id) { callbackId = id; }

--- a/hal/src/main/native/sim/mockdata/SPIData.cpp
+++ b/hal/src/main/native/sim/mockdata/SPIData.cpp
@@ -46,7 +46,7 @@ int32_t SPIData::Transaction(const uint8_t* dataToSend, uint8_t* dataReceived,
   return size;
 }
 
-int32_t SPIData::ReadAutoReceivedData(uint8_t* buffer, int32_t numToRead,
+int32_t SPIData::ReadAutoReceivedData(uint32_t* buffer, int32_t numToRead,
                                       double timeout, int32_t* status) {
   int32_t outputCount = 0;
   autoReceivedData(buffer, numToRead, &outputCount);

--- a/hal/src/main/native/sim/mockdata/SPIDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/SPIDataInternal.h
@@ -24,7 +24,7 @@ class SPIData {
   int32_t Write(const uint8_t* dataToSend, int32_t sendSize);
   int32_t Transaction(const uint8_t* dataToSend, uint8_t* dataReceived,
                       int32_t size);
-  int32_t ReadAutoReceivedData(uint8_t* buffer, int32_t numToRead,
+  int32_t ReadAutoReceivedData(uint32_t* buffer, int32_t numToRead,
                                double timeout, int32_t* status);
 
   SimDataValue<HAL_Bool, MakeBoolean, GetInitializedName> initialized{false};

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXRS450_SpiGyroWrapperData.cpp
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/cpp/ADXRS450_SpiGyroWrapperData.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstring>
 
+#include <hal/HALBase.h>
 #include <mockdata/SPIData.h>
 
 #ifdef _WIN32
@@ -22,9 +23,11 @@
 
 using namespace hal;
 
-const double ADXRS450_SpiGyroWrapper::kAngleLsb = 1 / 0.0125 / 0.0005;
+static constexpr double kSamplePeriod = 0.0005;
+
+const double ADXRS450_SpiGyroWrapper::kAngleLsb = 1 / 0.0125 / kSamplePeriod;
 const double ADXRS450_SpiGyroWrapper::kMaxAngleDeltaPerMessage = 0.1875;
-const int ADXRS450_SpiGyroWrapper::kPacketSize = 4;
+const int ADXRS450_SpiGyroWrapper::kPacketSize = 4 + 1;  // +1 for timestamp
 
 template <class T>
 constexpr const T& clamp(const T& value, const T& low, const T& high) {
@@ -38,7 +41,8 @@ static void ADXRS450SPI_ReadBufferCallback(const char* name, void* param,
 }
 
 static void ADXRS450SPI_ReadAutoReceivedData(const char* name, void* param,
-                                             uint8_t* buffer, int32_t numToRead,
+                                             uint32_t* buffer,
+                                             int32_t numToRead,
                                              int32_t* outputCount) {
   auto sim = static_cast<ADXRS450_SpiGyroWrapper*>(param);
   sim->HandleAutoReceiveData(buffer, numToRead, *outputCount);
@@ -71,13 +75,14 @@ void ADXRS450_SpiGyroWrapper::HandleRead(uint8_t* buffer, uint32_t count) {
   std::memcpy(&buffer[0], &returnCode, sizeof(returnCode));
 }
 
-void ADXRS450_SpiGyroWrapper::HandleAutoReceiveData(uint8_t* buffer,
+void ADXRS450_SpiGyroWrapper::HandleAutoReceiveData(uint32_t* buffer,
                                                     int32_t numToRead,
                                                     int32_t& outputCount) {
   std::lock_guard<wpi::recursive_spinlock> lock(m_angle.GetMutex());
-  int32_t messagesToSend = std::abs(
-      m_angleDiff > 0 ? std::ceil(m_angleDiff / kMaxAngleDeltaPerMessage)
-                      : std::floor(m_angleDiff / kMaxAngleDeltaPerMessage));
+  int32_t messagesToSend =
+      1 + std::abs(m_angleDiff > 0
+                       ? std::ceil(m_angleDiff / kMaxAngleDeltaPerMessage)
+                       : std::floor(m_angleDiff / kMaxAngleDeltaPerMessage));
 
   // Zero gets passed in during the "How much data do I need to read" step.
   // Else it is actually reading the accumulator
@@ -87,24 +92,34 @@ void ADXRS450_SpiGyroWrapper::HandleAutoReceiveData(uint8_t* buffer,
   }
 
   int valuesToRead = numToRead / kPacketSize;
-  std::memset(&buffer[0], 0, numToRead);
+  std::memset(&buffer[0], 0, numToRead * sizeof(uint32_t));
 
-  int msgCtr = 0;
+  int32_t status = 0;
+  uint32_t timestamp = HAL_GetFPGATime(&status);
 
-  while (msgCtr < valuesToRead) {
-    double cappedDiff =
-        clamp(m_angleDiff, -kMaxAngleDeltaPerMessage, kMaxAngleDeltaPerMessage);
+  for (int msgCtr = 0; msgCtr < valuesToRead; ++msgCtr) {
+    // force the first message to be a rate of 0 to init the timestamp
+    double cappedDiff = (msgCtr == 0)
+                            ? 0
+                            : clamp(m_angleDiff, -kMaxAngleDeltaPerMessage,
+                                    kMaxAngleDeltaPerMessage);
+
+    // first word is timestamp
+    buffer[msgCtr * kPacketSize] = timestamp;
 
     int32_t valueToSend =
         ((static_cast<int32_t>(cappedDiff * kAngleLsb) << 10) & (~0x0C00000E)) |
         0x04000000;
-    valueToSend = ntohl(valueToSend);
 
-    std::memcpy(&buffer[msgCtr * kPacketSize], &valueToSend,
-                sizeof(valueToSend));
+    // following words have byte in LSB, in big endian order
+    for (int i = 4; i >= 1; --i) {
+      buffer[msgCtr * kPacketSize + i] =
+          static_cast<uint32_t>(valueToSend) & 0xffu;
+      valueToSend >>= 8;
+    }
 
     m_angleDiff -= cappedDiff;
-    msgCtr += 1;
+    timestamp += kSamplePeriod * 1e6;  // fpga time is in us
   }
 }
 

--- a/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXRS450_SpiGyroWrapperData.h
+++ b/simulation/halsim_adx_gyro_accelerometer/src/main/native/include/ADXRS450_SpiGyroWrapperData.h
@@ -18,7 +18,7 @@ class ADXRS450_SpiGyroWrapper {
   bool GetInitialized() const;
 
   void HandleRead(uint8_t* buffer, uint32_t count);
-  void HandleAutoReceiveData(uint8_t* buffer, int32_t numToRead,
+  void HandleAutoReceiveData(uint32_t* buffer, int32_t numToRead,
                              int32_t& outputCount);
 
   int32_t RegisterAngleCallback(HAL_NotifyCallback callback, void* param,

--- a/wpilibc/src/main/native/cpp/ADXRS450_Gyro.cpp
+++ b/wpilibc/src/main/native/cpp/ADXRS450_Gyro.cpp
@@ -86,7 +86,7 @@ uint16_t ADXRS450_Gyro::ReadRegister(int reg) {
 }
 
 double ADXRS450_Gyro::GetAngle() const {
-  return m_spi.GetAccumulatorValue() * kDegreePerSecondPerLSB * kSamplePeriod;
+  return m_spi.GetAccumulatorIntegratedValue() * kDegreePerSecondPerLSB;
 }
 
 double ADXRS450_Gyro::GetRate() const {
@@ -99,11 +99,11 @@ void ADXRS450_Gyro::Reset() { m_spi.ResetAccumulator(); }
 void ADXRS450_Gyro::Calibrate() {
   Wait(0.1);
 
-  m_spi.SetAccumulatorCenter(0);
+  m_spi.SetAccumulatorIntegratedCenter(0);
   m_spi.ResetAccumulator();
 
   Wait(kCalibrationSampleTime);
 
-  m_spi.SetAccumulatorCenter(static_cast<int>(m_spi.GetAccumulatorAverage()));
+  m_spi.SetAccumulatorIntegratedCenter(m_spi.GetAccumulatorIntegratedAverage());
   m_spi.ResetAccumulator();
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.java
@@ -92,12 +92,12 @@ public class ADXRS450_Gyro extends GyroBase implements Gyro, PIDSource, Sendable
 
     Timer.delay(0.1);
 
-    m_spi.setAccumulatorCenter(0);
+    m_spi.setAccumulatorIntegratedCenter(0);
     m_spi.resetAccumulator();
 
     Timer.delay(kCalibrationSampleTime);
 
-    m_spi.setAccumulatorCenter((int) m_spi.getAccumulatorAverage());
+    m_spi.setAccumulatorIntegratedCenter(m_spi.getAccumulatorIntegratedAverage());
     m_spi.resetAccumulator();
   }
 
@@ -154,7 +154,7 @@ public class ADXRS450_Gyro extends GyroBase implements Gyro, PIDSource, Sendable
     if (m_spi == null) {
       return 0.0;
     }
-    return m_spi.getAccumulatorValue() * kDegreePerSecondPerLSB * kSamplePeriod;
+    return m_spi.getAccumulatorIntegratedValue() * kDegreePerSecondPerLSB;
   }
 
   @Override


### PR DESCRIPTION
The 2019 FPGA image switched the output of auto SPI from plain bytes to pairs
of 32-bit words (timestamp, 1-byte value in least significant byte).

In addition to changing the HAL and simulators to reflect this, add piecewise
integration support to wpilibc/wpilibj SPI to take advantage of the timestamps
and use it in the ADXRS450 gyro.