### PR TITLE
AxisCamera constructor: add StringRef overload

### DIFF
--- a/cscore/src/main/native/include/cscore_oo.h
+++ b/cscore/src/main/native/include/cscore_oo.h
@@ -586,6 +586,15 @@ class AxisCamera : public HttpCamera {
    * Create a source for an Axis IP camera.
    *
    * @param name Source name (arbitrary unique identifier)
+   * @param host Camera host IP or DNS name (e.g. "10.x.y.11")
+   * @param kind Camera kind (e.g. kAxis)
+   */
+  AxisCamera(const wpi::Twine& name, wpi::StringRef host);
+
+  /**
+   * Create a source for an Axis IP camera.
+   *
+   * @param name Source name (arbitrary unique identifier)
    * @param hosts Array of Camera host IPs/DNS names
    * @param kind Camera kind (e.g. kAxis)
    */

--- a/cscore/src/main/native/include/cscore_oo.inl
+++ b/cscore/src/main/native/include/cscore_oo.inl
@@ -361,6 +361,9 @@ inline AxisCamera::AxisCamera(const wpi::Twine& name, const char* host)
 inline AxisCamera::AxisCamera(const wpi::Twine& name, const std::string& host)
     : HttpCamera(name, HostToUrl(wpi::Twine{host}), kAxis) {}
 
+inline AxisCamera::AxisCamera(const wpi::Twine& name, wpi::StringRef host)
+    : HttpCamera(name, HostToUrl(host), kAxis) {}
+
 inline AxisCamera::AxisCamera(const wpi::Twine& name,
                               wpi::ArrayRef<std::string> hosts)
     : HttpCamera(name, HostToUrl(hosts), kAxis) {}


### PR DESCRIPTION
This avoids a conversion ambiguity when StringRef is passed.