### PR TITLE
Fix LiveWindow attempting to start listeners on uninitialized sendables

### DIFF
--- a/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
+++ b/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
@@ -175,7 +175,10 @@ void LiveWindow::SetEnabled(bool enabled) {
   std::lock_guard<wpi::mutex> lock(m_impl->mutex);
   if (m_impl->liveWindowEnabled == enabled) return;
   Scheduler* scheduler = Scheduler::GetInstance();
-  UpdateValues(); // Force table generation now to make sure everything is defined
+  m_impl->startLiveWindow = enabled;
+  m_impl->liveWindowEnabled = enabled;
+  // Force table generation now to make sure everything is defined
+  UpdateValues();
   if (enabled) {
     scheduler->SetEnabled(false);
     scheduler->RemoveAll();
@@ -185,8 +188,6 @@ void LiveWindow::SetEnabled(bool enabled) {
     }
     scheduler->SetEnabled(true);
   }
-  m_impl->startLiveWindow = enabled;
-  m_impl->liveWindowEnabled = enabled;
   m_impl->enabledEntry.SetBoolean(enabled);
 }
 

--- a/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
+++ b/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
@@ -172,13 +172,15 @@ bool LiveWindow::IsEnabled() const {
 }
 
 void LiveWindow::SetEnabled(bool enabled) {
-  std::lock_guard<wpi::mutex> lock(m_impl->mutex);
+  std::unique_lock<wpi::mutex> lock(m_impl->mutex);
   if (m_impl->liveWindowEnabled == enabled) return;
   Scheduler* scheduler = Scheduler::GetInstance();
   m_impl->startLiveWindow = enabled;
   m_impl->liveWindowEnabled = enabled;
+  lock.unlock();
   // Force table generation now to make sure everything is defined
   UpdateValues();
+  lock.lock();
   if (enabled) {
     scheduler->SetEnabled(false);
     scheduler->RemoveAll();

--- a/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
+++ b/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
@@ -175,6 +175,7 @@ void LiveWindow::SetEnabled(bool enabled) {
   std::lock_guard<wpi::mutex> lock(m_impl->mutex);
   if (m_impl->liveWindowEnabled == enabled) return;
   Scheduler* scheduler = Scheduler::GetInstance();
+  UpdateValues(); // Force table generation now to make sure everything is defined
   if (enabled) {
     scheduler->SetEnabled(false);
     scheduler->RemoveAll();

--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
@@ -33,12 +33,12 @@ void SendableBuilderImpl::UpdateTable() {
 
 void SendableBuilderImpl::StartListeners() {
   for (auto& property : m_properties) property.StartListener();
-  m_controllableEntry.SetBoolean(true);
+  if (m_controllableEntry) m_controllableEntry.SetBoolean(true);
 }
 
 void SendableBuilderImpl::StopListeners() {
   for (auto& property : m_properties) property.StopListener();
-  m_controllableEntry.SetBoolean(false);
+  if (m_controllableEntry) m_controllableEntry.SetBoolean(false);
 }
 
 void SendableBuilderImpl::StartLiveWindowMode() {

--- a/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
+++ b/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
@@ -208,6 +208,11 @@ class LiveWindow {
 
   struct Impl;
   std::unique_ptr<Impl> m_impl;
+
+  /**
+   * Updates the entries, without using a mutex or lock.
+   */
+  void UpdateValuesUnsafe();
 };
 
 }  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -65,6 +65,8 @@ public class LiveWindow {
    */
   public static synchronized void setEnabled(boolean enabled) {
     if (liveWindowEnabled != enabled) {
+      startLiveWindow = enabled;
+      liveWindowEnabled = enabled;
       updateValues(); // Force table generation now to make sure everything is defined
       Scheduler scheduler = Scheduler.getInstance();
       if (enabled) {
@@ -78,8 +80,6 @@ public class LiveWindow {
         }
         scheduler.enable();
       }
-      startLiveWindow = enabled;
-      liveWindowEnabled = enabled;
       enabledEntry.setBoolean(enabled);
     }
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -65,6 +65,7 @@ public class LiveWindow {
    */
   public static synchronized void setEnabled(boolean enabled) {
     if (liveWindowEnabled != enabled) {
+      updateValues(); // Force table generation now to make sure everything is defined
       Scheduler scheduler = Scheduler.getInstance();
       if (enabled) {
         System.out.println("Starting live window mode.");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
@@ -107,7 +107,9 @@ public class SendableBuilderImpl implements SendableBuilder {
     for (Property property : m_properties) {
       property.startListener();
     }
-    m_controllableEntry.setBoolean(true);
+    if (m_controllableEntry != null) {
+      m_controllableEntry.setBoolean(true);
+    }
   }
 
   /**
@@ -117,7 +119,9 @@ public class SendableBuilderImpl implements SendableBuilder {
     for (Property property : m_properties) {
       property.stopListener();
     }
-    m_controllableEntry.setBoolean(false);
+    if (m_controllableEntry != null) {
+      m_controllableEntry.setBoolean(false);
+    }
   }
 
   /**


### PR DESCRIPTION
Additionally adds a defensive check in SendableBuilderImpl to avoid the NPE

Fixes #1446