### PR TITLE
Add missing SubTableListener methods to C++ NetworkTable

### DIFF
--- a/ntcore/src/main/native/include/networktables/NetworkTable.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTable.h
@@ -338,7 +338,7 @@ class NetworkTable final : public ITable {
    * @return Listener handle
    */
   NT_EntryListener AddSubTableListener(TableListener listener,
-                                       bool localNotify = false) const;
+                                       bool localNotify = false);
 
   /**
    * Remove a sub-table listener.

--- a/ntcore/src/main/native/include/networktables/TableListener.h
+++ b/ntcore/src/main/native/include/networktables/TableListener.h
@@ -31,7 +31,7 @@ using wpi::StringRef;
  * @ingroup ntcore_cpp_api
  */
 typedef std::function<void(NetworkTable* parent, StringRef name,
-                           NetworkTable* table)>
+                           std::shared_ptr<NetworkTable> table)>
     TableListener;
 
 }  // namespace nt


### PR DESCRIPTION
Since we received the subtable as a shared_ptr, I figured we should send that through the event handler (This was the only function that implemented that event, and since it wasn't implemented in the past, this is not a breaking change).

The const had to be removed otherwise the `this`  became const, which couldn't be passed to the callback.

Closes #1464 

WIP, as I noticed a bug when creating this PR.