### PR TITLE
Change SmartDashboard type of PIDBase.cpp to match PIDBase.java

### DIFF
--- a/wpilibc/src/main/native/cpp/PIDBase.cpp
+++ b/wpilibc/src/main/native/cpp/PIDBase.cpp
@@ -234,7 +234,7 @@ void PIDBase::Reset() {
 void PIDBase::PIDWrite(double output) { SetSetpoint(output); }
 
 void PIDBase::InitSendable(SendableBuilder& builder) {
-  builder.SetSmartDashboardType("PIDBase");
+  builder.SetSmartDashboardType("PIDController");
   builder.SetSafeState([=]() { Reset(); });
   builder.AddDoubleProperty("p", [=]() { return GetP(); },
                             [=](double value) { SetP(value); });


### PR DESCRIPTION
Make the SmartDashboard type consistent between languages. Closes #1466.