### PR TITLE
wpiutil: Fix resources build

### DIFF
--- a/wpiutil/build.gradle
+++ b/wpiutil/build.gradle
@@ -20,7 +20,7 @@ ext {
             }
             resourcesCpp(CppSourceSet) {
                 source {
-                    srcDirs "$buildDir/generated/main/cpp"
+                    srcDirs "$buildDir/generated/main/cpp", "$rootDir/shared/singlelib"
                     include '*.cpp'
                 }
                 exportedHeaders {


### PR DESCRIPTION
#1433 didn't properly include the resources in the build as the source set was empty during configuration.