### PR TITLE
wpiutil: Add inja, a template engine

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -38,6 +38,7 @@ CoreUI                wpiutil/src/main/native/resources/coreui-*
 Feather Icons         wpiutil/src/main/native/resources/feather-*
 jQuery                wpiutil/src/main/native/resources/jquery-*
 popper.js             wpiutil/src/main/native/resources/popper-*
+Inja                  wpiutil/src/test/native/cpp/inja/
 
 
 ==============================================================================
@@ -370,4 +371,28 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+==============================================================================
+Inja License
+==============================================================================
+Copyright (c) 2017-2018 Pantor <https://github.com/pantor>.
+
+Permission is hereby  granted, free of charge, to any  person obtaining a copy
+of this software and associated  documentation files (the "Software"), to deal
+in the Software  without restriction, including without  limitation the rights
+to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.

--- a/wpiutil/.styleguide
+++ b/wpiutil/.styleguide
@@ -68,6 +68,7 @@ licenseUpdateExclude {
   src/main/native/include/wpi/TCPAcceptor\.h$
   src/main/native/include/wpi/TCPConnector\.h$
   src/main/native/include/wpi/TCPStream\.h$
+  src/test/native/cpp/inja/
 }
 
 repoRootNameOverride {
@@ -78,4 +79,5 @@ includeGuardRoots {
   wpiutil/src/main/native/cpp/
   wpiutil/src/main/native/include/
   wpiutil/src/test/native/cpp/
+  wpiutil/src/test/native/include/
 }

--- a/wpiutil/src/main/native/cpp/inja.cpp
+++ b/wpiutil/src/main/native/cpp/inja.cpp
@@ -1,0 +1,150 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "wpi/inja.h"
+
+#include "inja_internal.h"
+#include "inja_parser.h"
+#include "inja_renderer.h"
+#include "wpi/FileSystem.h"
+#include "wpi/SmallString.h"
+#include "wpi/raw_ostream.h"
+
+using namespace wpi;
+using namespace wpi::inja;
+
+void inja::inja_throw(const Twine& type, const Twine& message) {
+  throw std::runtime_error(("[inja.exception." + type + "] " + message).str());
+}
+
+class Environment::Impl {
+ public:
+  std::string path;
+
+  FunctionStorage callbacks;
+
+  LexerConfig lexerConfig;
+  ParserConfig parserConfig;
+
+  TemplateStorage includedTemplates;
+};
+
+Template::Template() {}
+
+Template::~Template() {}
+
+Template::Template(const Template& oth)
+    : bytecodes(oth.bytecodes), contents(oth.contents) {}
+
+Template::Template(Template&& oth)
+    : bytecodes(std::move(oth.bytecodes)), contents(std::move(oth.contents)) {}
+
+Template& Template::operator=(const Template& oth) {
+  bytecodes = oth.bytecodes;
+  contents = oth.contents;
+  return *this;
+}
+
+Template& Template::operator=(Template&& oth) {
+  bytecodes = std::move(oth.bytecodes);
+  contents = std::move(oth.contents);
+  return *this;
+}
+
+Environment::Environment() : Environment("./") {}
+
+Environment::Environment(const Twine& path) : m_impl(std::make_unique<Impl>()) {
+  m_impl->path = path.str();
+}
+
+Environment::~Environment() {}
+
+void Environment::SetStatement(const Twine& open, const Twine& close) {
+  m_impl->lexerConfig.statementOpen = open.str();
+  m_impl->lexerConfig.statementClose = close.str();
+  m_impl->lexerConfig.UpdateOpenChars();
+}
+
+void Environment::SetLineStatement(const Twine& open) {
+  m_impl->lexerConfig.lineStatement = open.str();
+  m_impl->lexerConfig.UpdateOpenChars();
+}
+
+void Environment::SetExpression(const Twine& open, const Twine& close) {
+  m_impl->lexerConfig.expressionOpen = open.str();
+  m_impl->lexerConfig.expressionClose = close.str();
+  m_impl->lexerConfig.UpdateOpenChars();
+}
+
+void Environment::SetComment(const Twine& open, const Twine& close) {
+  m_impl->lexerConfig.commentOpen = open.str();
+  m_impl->lexerConfig.commentClose = close.str();
+  m_impl->lexerConfig.UpdateOpenChars();
+}
+
+void Environment::SetElementNotation(ElementNotation notation) {
+  m_impl->parserConfig.notation = notation;
+}
+
+void Environment::SetLoadFile(std::function<std::string(StringRef)> loadFile) {
+  m_impl->parserConfig.loadFile = loadFile;
+}
+
+Template Environment::Parse(StringRef input) {
+  Parser parser(m_impl->parserConfig, m_impl->lexerConfig,
+                m_impl->includedTemplates);
+  return parser.Parse(input);
+}
+
+std::string Environment::Render(StringRef input, const json& data) {
+  return Render(Parse(input), data);
+}
+
+std::string Environment::Render(const Template& tmpl, const json& data) {
+  std::string s;
+  raw_string_ostream os(s);
+  RenderTo(os, tmpl, data);
+  return os.str();
+}
+
+raw_ostream& Environment::RenderTo(raw_ostream& os, const Template& tmpl,
+                                   const json& data) {
+  Renderer(m_impl->includedTemplates, m_impl->callbacks)
+      .RenderTo(os, tmpl, data);
+  return os;
+}
+
+void Environment::AddCallback(StringRef name, unsigned int numArgs,
+                              const CallbackFunction& callback) {
+  m_impl->callbacks.AddCallback(name, numArgs, callback);
+}
+
+void Environment::IncludeTemplate(const Twine& name, const Template& tmpl) {
+  SmallString<64> buf;
+  m_impl->includedTemplates[name.toStringRef(buf)] = tmpl;
+}
+
+FunctionStorage::FunctionData& FunctionStorage::GetOrNew(StringRef name,
+                                                         unsigned int numArgs) {
+  auto& vec = m_map[name];
+  for (auto& i : vec) {
+    if (i.numArgs == numArgs) return i;
+  }
+  vec.emplace_back();
+  vec.back().numArgs = numArgs;
+  return vec.back();
+}
+
+const FunctionStorage::FunctionData* FunctionStorage::Get(
+    StringRef name, unsigned int numArgs) const {
+  auto it = m_map.find(name);
+  if (it == m_map.end()) return nullptr;
+  for (auto&& i : it->second) {
+    if (i.numArgs == numArgs) return &i;
+  }
+  return nullptr;
+}

--- a/wpiutil/src/main/native/cpp/inja_internal.h
+++ b/wpiutil/src/main/native/cpp/inja_internal.h
@@ -1,0 +1,189 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#ifndef WPIUTIL_INJA_INTERNAL_H_
+#define WPIUTIL_INJA_INTERNAL_H_
+
+#include <stdint.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "wpi/SmallVector.h"
+#include "wpi/StringMap.h"
+#include "wpi/StringRef.h"
+#include "wpi/Twine.h"
+#include "wpi/inja.h"
+#include "wpi/json.h"
+
+namespace wpi {
+namespace inja {
+
+void inja_throw(const Twine& type, const Twine& message);
+
+class Bytecode {
+ public:
+  enum class Op : uint8_t {
+    Nop,
+    // print StringRef (always immediate)
+    PrintText,
+    // print value
+    PrintValue,
+    // push value onto stack (always immediate)
+    Push,
+
+    // builtin functions
+    // result is pushed to stack
+    // args specify number of arguments
+    // all functions can take their "last" argument either immediate
+    // or popped off stack (e.g. if immediate, it's like the immediate was
+    // just pushed to the stack)
+    Not,
+    And,
+    Or,
+    In,
+    Equal,
+    Greater,
+    GreaterEqual,
+    Less,
+    LessEqual,
+    Different,
+    DivisibleBy,
+    Even,
+    First,
+    Float,
+    Int,
+    Last,
+    Length,
+    Lower,
+    Max,
+    Min,
+    Odd,
+    Range,
+    Result,
+    Round,
+    Sort,
+    Upper,
+    Exists,
+    ExistsInObject,
+    IsBoolean,
+    IsNumber,
+    IsInteger,
+    IsFloat,
+    IsObject,
+    IsArray,
+    IsString,
+    Default,
+
+    // include another template
+    // value is the template name
+    Include,
+
+    // callback function
+    // str is the function name (this means it cannot be a lookup)
+    // args specify number of arguments
+    // as with builtin functions, "last" argument can be immediate
+    Callback,
+
+    // unconditional jump
+    // args is the index of the bytecode to jump to.
+    Jump,
+
+    // conditional jump
+    // value popped off stack is checked for truthyness
+    // if false, args is the index of the bytecode to jump to.
+    // if true, no action is taken (falls through)
+    ConditionalJump,
+
+    // start loop
+    // value popped off stack is what is iterated over
+    // args is index of bytecode after end loop (jumped to if iterable is
+    // empty)
+    // immediate value is key name (for maps)
+    // str is value name
+    StartLoop,
+
+    // end a loop
+    // args is index of the first bytecode in the loop body
+    EndLoop
+  };
+
+  enum Flag {
+    // location of value for value-taking ops (mask)
+    kFlagValueMask = 0x03,
+    // pop value off stack
+    kFlagValuePop = 0x00,
+    // value is immediate rather than on stack
+    kFlagValueImmediate = 0x01,
+    // lookup immediate str (dot notation)
+    kFlagValueLookupDot = 0x02,
+    // lookup immediate str (json pointer notation)
+    kFlagValueLookupPointer = 0x03
+  };
+
+  Op op = Op::Nop;
+  uint32_t args : 30;
+  uint32_t flags : 2;
+
+  json value;
+  StringRef str;
+
+  Bytecode() : args(0), flags(0) {}
+  explicit Bytecode(Op op, unsigned int args = 0)
+      : op(op), args(args), flags(0) {}
+  Bytecode(Op op, StringRef str, unsigned int flags)
+      : op(op), args(0), flags(flags), str(str) {}
+  Bytecode(Op op, json&& value, unsigned int flags)
+      : op(op), args(0), flags(flags), value(std::move(value)) {}
+};
+
+class FunctionStorage {
+ public:
+  void AddBuiltin(StringRef name, unsigned int numArgs, Bytecode::Op op) {
+    auto& data = GetOrNew(name, numArgs);
+    data.op = op;
+  }
+  void AddCallback(StringRef name, unsigned int numArgs,
+                   const CallbackFunction& function) {
+    auto& data = GetOrNew(name, numArgs);
+    data.function = function;
+  }
+
+  Bytecode::Op FindBuiltin(StringRef name, unsigned int numArgs) const {
+    if (auto ptr = Get(name, numArgs))
+      return ptr->op;
+    else
+      return Bytecode::Op::Nop;
+  }
+
+  CallbackFunction FindCallback(StringRef name, unsigned int numArgs) const {
+    if (auto ptr = Get(name, numArgs))
+      return ptr->function;
+    else
+      return nullptr;
+  }
+
+ private:
+  struct FunctionData {
+    unsigned int numArgs = 0;
+    Bytecode::Op op = Bytecode::Op::Nop;  // for builtins
+    CallbackFunction function;  // for callbacks
+  };
+
+  FunctionData& GetOrNew(StringRef name, unsigned int numArgs);
+  const FunctionData* Get(StringRef name, unsigned int numArgs) const;
+
+  StringMap<SmallVector<FunctionData, 1>> m_map;
+};
+
+using TemplateStorage = StringMap<Template>;
+
+}  // namespace inja
+}  // namespace wpi
+
+#endif  // WPIUTIL_INJA_INTERNAL_H_

--- a/wpiutil/src/main/native/cpp/inja_parser.cpp
+++ b/wpiutil/src/main/native/cpp/inja_parser.cpp
@@ -7,6 +7,8 @@
 
 #include "inja_parser.h"
 
+#include <cctype>
+
 #include "wpi/Path.h"
 #include "wpi/SmallString.h"
 #include "wpi/raw_istream.h"

--- a/wpiutil/src/main/native/cpp/inja_parser.cpp
+++ b/wpiutil/src/main/native/cpp/inja_parser.cpp
@@ -1,0 +1,751 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "inja_parser.h"
+
+#include "wpi/Path.h"
+#include "wpi/SmallString.h"
+#include "wpi/raw_istream.h"
+
+using namespace wpi;
+using namespace wpi::inja;
+
+StringRef Token::Describe() const {
+  switch (kind) {
+    case kText:
+      return "<text>";
+    case kExpressionOpen:
+      return "{{";
+    case kExpressionClose:
+      return "}}";
+    case kLineStatementOpen:
+      return "##";
+    case kLineStatementClose:
+      return "<eol>";
+    case kStatementOpen:
+      return "{%";
+    case kStatementClose:
+      return "%}";
+    case kCommentOpen:
+      return "{#";
+    case kCommentClose:
+      return "#}";
+    case kEof:
+      return "<eof>";
+    default:
+      return text;
+  }
+}
+
+void LexerConfig::UpdateOpenChars() {
+  openChars = "\n";
+  if (openChars.find(statementOpen[0]) == std::string::npos)
+    openChars += statementOpen[0];
+  if (openChars.find(expressionOpen[0]) == std::string::npos)
+    openChars += expressionOpen[0];
+  if (openChars.find(commentOpen[0]) == std::string::npos)
+    openChars += commentOpen[0];
+}
+
+void Lexer::Start(StringRef in) {
+  m_in = in;
+  m_tokStart = 0;
+  m_pos = 0;
+  m_state = State::Text;
+}
+
+Token Lexer::Scan() {
+  m_tokStart = m_pos;
+
+again:
+  if (m_tokStart >= m_in.size()) return MakeToken(Token::kEof);
+
+  switch (m_state) {
+    default:
+    case State::Text: {
+      // fast-scan to first open character
+      size_t openStart = m_in.substr(m_pos).find_first_of(m_config.openChars);
+      if (openStart == StringRef::npos) {
+        // didn't find open, return remaining text as text token
+        m_pos = m_in.size();
+        return MakeToken(Token::kText);
+      }
+      m_pos += openStart;
+
+      // try to match one of the opening sequences, and get the close
+      StringRef openStr = m_in.substr(m_pos);
+      if (openStr.startswith(m_config.expressionOpen)) {
+        m_state = State::ExpressionStart;
+      } else if (openStr.startswith(m_config.statementOpen)) {
+        m_state = State::StatementStart;
+      } else if (openStr.startswith(m_config.commentOpen)) {
+        m_state = State::CommentStart;
+      } else if ((m_pos == 0 || m_in[m_pos - 1] == '\n') &&
+                 openStr.startswith(m_config.lineStatement)) {
+        m_state = State::LineStart;
+      } else {
+        ++m_pos; // wasn't actually an opening sequence
+        goto again;
+      }
+      if (m_pos == m_tokStart) goto again;  // don't generate empty token
+      return MakeToken(Token::kText);
+    }
+    case State::ExpressionStart: {
+      m_state = State::ExpressionBody;
+      m_pos += m_config.expressionOpen.size();
+      return MakeToken(Token::kExpressionOpen);
+    }
+    case State::LineStart: {
+      m_state = State::LineBody;
+      m_pos += m_config.lineStatement.size();
+      return MakeToken(Token::kLineStatementOpen);
+    }
+    case State::StatementStart: {
+      m_state = State::StatementBody;
+      m_pos += m_config.statementOpen.size();
+      return MakeToken(Token::kStatementOpen);
+    }
+    case State::CommentStart: {
+      m_state = State::CommentBody;
+      m_pos += m_config.commentOpen.size();
+      return MakeToken(Token::kCommentOpen);
+    }
+    case State::ExpressionBody:
+      return ScanBody(m_config.expressionClose, Token::kExpressionClose);
+    case State::LineBody:
+      return ScanBody("\n", Token::kLineStatementClose);
+    case State::StatementBody:
+      return ScanBody(m_config.statementClose, Token::kStatementClose);
+    case State::CommentBody: {
+      // fast-scan to comment close
+      size_t end = m_in.substr(m_pos).find(m_config.commentClose);
+      if (end == StringRef::npos) {
+        m_pos = m_in.size();
+        return MakeToken(Token::kEof);
+      }
+      // return the entire comment in the close token
+      m_state = State::Text;
+      m_pos += end + m_config.commentClose.size();
+      return MakeToken(Token::kCommentClose);
+    }
+  }
+}
+
+Token Lexer::ScanBody(StringRef close, Token::Kind closeKind) {
+again:
+  // skip whitespace (except for \n as it might be a close)
+  if (m_tokStart >= m_in.size()) return MakeToken(Token::kEof);
+  char ch = m_in[m_tokStart];
+  if (ch == ' ' || ch == '\t' || ch == '\r') {
+    ++m_tokStart;
+    goto again;
+  }
+
+  // check for close
+  if (m_in.substr(m_tokStart).startswith(close)) {
+    m_state = State::Text;
+    m_pos = m_tokStart + close.size();
+    return MakeToken(closeKind);
+  }
+
+  // skip \n
+  if (ch == '\n') {
+    ++m_tokStart;
+    goto again;
+  }
+
+  m_pos = m_tokStart + 1;
+  if (std::isalpha(ch)) return ScanId();
+  switch (ch) {
+    case ',':
+      return MakeToken(Token::kComma);
+    case ':':
+      return MakeToken(Token::kColon);
+    case '(':
+      return MakeToken(Token::kLeftParen);
+    case ')':
+      return MakeToken(Token::kRightParen);
+    case '[':
+      return MakeToken(Token::kLeftBracket);
+    case ']':
+      return MakeToken(Token::kRightBracket);
+    case '{':
+      return MakeToken(Token::kLeftBrace);
+    case '}':
+      return MakeToken(Token::kRightBrace);
+    case '>':
+      if (m_pos < m_in.size() && m_in[m_pos] == '=') {
+        ++m_pos;
+        return MakeToken(Token::kGreaterEqual);
+      }
+      return MakeToken(Token::kGreaterThan);
+    case '<':
+      if (m_pos < m_in.size() && m_in[m_pos] == '=') {
+        ++m_pos;
+        return MakeToken(Token::kLessEqual);
+      }
+      return MakeToken(Token::kLessThan);
+    case '=':
+      if (m_pos < m_in.size() && m_in[m_pos] == '=') {
+        ++m_pos;
+        return MakeToken(Token::kEqual);
+      }
+      return MakeToken(Token::kUnknown);
+    case '!':
+      if (m_pos < m_in.size() && m_in[m_pos] == '=') {
+        ++m_pos;
+        return MakeToken(Token::kNotEqual);
+      }
+      return MakeToken(Token::kUnknown);
+    case '\"':
+      return ScanString();
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case '-':
+      return ScanNumber();
+    case '_':
+      return ScanId();
+    default:
+      return MakeToken(Token::kUnknown);
+  }
+}
+
+Token Lexer::ScanId() {
+  for (;;) {
+    if (m_pos >= m_in.size()) break;
+    char ch = m_in[m_pos];
+    if (!isalnum(ch) && ch != '.' && ch != '/' && ch != '_' && ch != '-') break;
+    ++m_pos;
+  }
+  return MakeToken(Token::kId);
+}
+
+Token Lexer::ScanNumber() {
+  for (;;) {
+    if (m_pos >= m_in.size()) break;
+    char ch = m_in[m_pos];
+    // be very permissive in lexer (we'll catch errors when conversion happens)
+    if (!isdigit(ch) && ch != '.' && ch != 'e' && ch != 'E' && ch != '+' &&
+        ch != '-')
+      break;
+    ++m_pos;
+  }
+  return MakeToken(Token::kNumber);
+}
+
+Token Lexer::ScanString() {
+  bool escape = false;
+  for (;;) {
+    if (m_pos >= m_in.size()) break;
+    char ch = m_in[m_pos++];
+    if (ch == '\\')
+      escape = true;
+    else if (!escape && ch == m_in[m_tokStart])
+      break;
+    else
+      escape = false;
+  }
+  return MakeToken(Token::kString);
+}
+
+const ParserStatic& ParserStatic::GetInstance() {
+  static ParserStatic inst;
+  return inst;
+}
+
+ParserStatic::ParserStatic() {
+  functions.AddBuiltin("default", 2, Bytecode::Op::Default);
+  functions.AddBuiltin("divisibleBy", 2, Bytecode::Op::DivisibleBy);
+  functions.AddBuiltin("even", 1, Bytecode::Op::Even);
+  functions.AddBuiltin("first", 1, Bytecode::Op::First);
+  functions.AddBuiltin("float", 1, Bytecode::Op::Float);
+  functions.AddBuiltin("int", 1, Bytecode::Op::Int);
+  functions.AddBuiltin("last", 1, Bytecode::Op::Last);
+  functions.AddBuiltin("length", 1, Bytecode::Op::Length);
+  functions.AddBuiltin("lower", 1, Bytecode::Op::Lower);
+  functions.AddBuiltin("max", 1, Bytecode::Op::Max);
+  functions.AddBuiltin("min", 1, Bytecode::Op::Min);
+  functions.AddBuiltin("odd", 1, Bytecode::Op::Odd);
+  functions.AddBuiltin("range", 1, Bytecode::Op::Range);
+  functions.AddBuiltin("round", 2, Bytecode::Op::Round);
+  functions.AddBuiltin("sort", 1, Bytecode::Op::Sort);
+  functions.AddBuiltin("upper", 1, Bytecode::Op::Upper);
+  functions.AddBuiltin("exists", 1, Bytecode::Op::Exists);
+  functions.AddBuiltin("existsIn", 2, Bytecode::Op::ExistsInObject);
+  functions.AddBuiltin("isBoolean", 1, Bytecode::Op::IsBoolean);
+  functions.AddBuiltin("isNumber", 1, Bytecode::Op::IsNumber);
+  functions.AddBuiltin("isInteger", 1, Bytecode::Op::IsInteger);
+  functions.AddBuiltin("isFloat", 1, Bytecode::Op::IsFloat);
+  functions.AddBuiltin("isObject", 1, Bytecode::Op::IsObject);
+  functions.AddBuiltin("isArray", 1, Bytecode::Op::IsArray);
+  functions.AddBuiltin("isString", 1, Bytecode::Op::IsString);
+}
+
+Parser::Parser(const ParserConfig& parserConfig, const LexerConfig& lexerConfig,
+               TemplateStorage& includedTemplates)
+    : m_config(parserConfig),
+      m_lexer(lexerConfig),
+      m_includedTemplates(includedTemplates),
+      m_static(ParserStatic::GetInstance()) {}
+
+bool Parser::ParseExpression(Template& tmpl) {
+  if (!ParseExpressionAnd(tmpl)) return false;
+  if (m_tok.kind != Token::kId || m_tok.text != "or") return true;
+  GetNextToken();
+  if (!ParseExpressionAnd(tmpl)) return false;
+  AppendFunction(tmpl, Bytecode::Op::Or, 2);
+  return true;
+}
+
+bool Parser::ParseExpressionAnd(Template& tmpl) {
+  if (!ParseExpressionNot(tmpl)) return false;
+  if (m_tok.kind != Token::kId || m_tok.text != "and") return true;
+  GetNextToken();
+  if (!ParseExpressionNot(tmpl)) return false;
+  AppendFunction(tmpl, Bytecode::Op::And, 2);
+  return true;
+}
+
+bool Parser::ParseExpressionNot(Template& tmpl) {
+  if (m_tok.kind == Token::kId && m_tok.text == "not") {
+    GetNextToken();
+    if (!ParseExpressionNot(tmpl)) return false;
+    AppendFunction(tmpl, Bytecode::Op::Not, 1);
+    return true;
+  } else {
+    return ParseExpressionComparison(tmpl);
+  }
+}
+
+bool Parser::ParseExpressionComparison(Template& tmpl) {
+  if (!ParseExpressionDatum(tmpl)) return false;
+  Bytecode::Op op;
+  switch (m_tok.kind) {
+    case Token::kId:
+      if (m_tok.text == "in")
+        op = Bytecode::Op::In;
+      else
+        return true;
+      break;
+    case Token::kEqual:
+      op = Bytecode::Op::Equal;
+      break;
+    case Token::kGreaterThan:
+      op = Bytecode::Op::Greater;
+      break;
+    case Token::kLessThan:
+      op = Bytecode::Op::Less;
+      break;
+    case Token::kLessEqual:
+      op = Bytecode::Op::LessEqual;
+      break;
+    case Token::kGreaterEqual:
+      op = Bytecode::Op::GreaterEqual;
+      break;
+    case Token::kNotEqual:
+      op = Bytecode::Op::Different;
+      break;
+    default:
+      return true;
+  }
+  GetNextToken();
+  if (!ParseExpressionDatum(tmpl)) return false;
+  AppendFunction(tmpl, op, 2);
+  return true;
+}
+
+bool Parser::ParseExpressionDatum(Template& tmpl) {
+  StringRef jsonFirst;
+  size_t bracketLevel = 0;
+  size_t braceLevel = 0;
+
+  for (;;) {
+    switch (m_tok.kind) {
+      case Token::kLeftParen: {
+        GetNextToken();
+        if (!ParseExpression(tmpl)) return false;
+        if (m_tok.kind != Token::kRightParen) {
+          inja_throw("parser_error", "unmatched '('");
+        }
+        GetNextToken();
+        return true;
+      }
+      case Token::kId:
+        GetPeekToken();
+        if (m_peekTok.kind == Token::kLeftParen) {
+          // function call, parse arguments
+          Token funcTok = m_tok;
+          GetNextToken();  // id
+          GetNextToken();  // leftParen
+          unsigned int numArgs = 0;
+          if (m_tok.kind == Token::kRightParen) {
+            // no args
+            GetNextToken();
+          } else {
+            for (;;) {
+              if (!ParseExpression(tmpl)) {
+                inja_throw("parser_error", Twine("expected expression, got '") +
+                                               m_tok.Describe() + "'");
+              }
+              ++numArgs;
+              if (m_tok.kind == Token::kRightParen) {
+                GetNextToken();
+                break;
+              }
+              if (m_tok.kind != Token::kComma) {
+                inja_throw("parser_error", Twine("expected ')' or ',', got '") +
+                                               m_tok.Describe() + "'");
+              }
+              GetNextToken();
+            }
+          }
+
+          auto op = m_static.functions.FindBuiltin(funcTok.text, numArgs);
+          if (op != Bytecode::Op::Nop) {
+            // swap arguments for default(); see comment in RenderTo()
+            if (op == Bytecode::Op::Default)
+              std::swap(tmpl.bytecodes.back(), *(tmpl.bytecodes.rbegin() + 1));
+            AppendFunction(tmpl, op, numArgs);
+            return true;
+          } else {
+            AppendCallback(tmpl, funcTok.text, numArgs);
+            return true;
+          }
+        } else if (m_tok.text == "true" || m_tok.text == "false" ||
+                   m_tok.text == "null") {
+          // true, false, null are json literals
+          if (braceLevel == 0 && bracketLevel == 0) {
+            jsonFirst = m_tok.text;
+            goto returnJson;
+          }
+          break;
+        } else {
+          // normal literal (json read)
+          tmpl.bytecodes.emplace_back(
+              Bytecode::Op::Push, m_tok.text,
+              m_config.notation == ElementNotation::Pointer
+                  ? Bytecode::kFlagValueLookupPointer
+                  : Bytecode::kFlagValueLookupDot);
+          GetNextToken();
+          return true;
+        }
+      /* json passthrough */
+      case Token::kNumber:
+      case Token::kString:
+        if (braceLevel == 0 && bracketLevel == 0) {
+          jsonFirst = m_tok.text;
+          goto returnJson;
+        }
+        break;
+      case Token::kComma:
+      case Token::kColon:
+        if (braceLevel == 0 && bracketLevel == 0) {
+          inja_throw("parser_error",
+                     Twine("unexpected token '") + m_tok.Describe() + "'");
+        }
+        break;
+      case Token::kLeftBracket:
+        if (braceLevel == 0 && bracketLevel == 0) jsonFirst = m_tok.text;
+        ++bracketLevel;
+        break;
+      case Token::kLeftBrace:
+        if (braceLevel == 0 && bracketLevel == 0) jsonFirst = m_tok.text;
+        ++braceLevel;
+        break;
+      case Token::kRightBracket:
+        if (bracketLevel == 0) {
+          inja_throw("parser_error", "unexpected ']'");
+        }
+        --bracketLevel;
+        if (braceLevel == 0 && bracketLevel == 0) goto returnJson;
+        break;
+      case Token::kRightBrace:
+        if (braceLevel == 0) {
+          inja_throw("parser_error", "unexpected '}'");
+        }
+        --braceLevel;
+        if (braceLevel == 0 && bracketLevel == 0) goto returnJson;
+        break;
+      default:
+        if (braceLevel != 0) {
+          inja_throw("parser_error", "unmatched '{'");
+        }
+        if (bracketLevel != 0) {
+          inja_throw("parser_error", "unmatched '['");
+        }
+        return false;
+    }
+
+    GetNextToken();
+  }
+
+returnJson:
+  // bridge across all intermediate tokens
+  StringRef jsonText(
+      jsonFirst.data(),
+      m_tok.text.data() - jsonFirst.data() + m_tok.text.size());
+
+  tmpl.bytecodes.emplace_back(Bytecode::Op::Push, json::parse(jsonText),
+                              Bytecode::kFlagValueImmediate);
+  GetNextToken();
+  return true;
+}
+
+bool Parser::ParseStatement(Template& tmpl, StringRef path) {
+  if (m_tok.kind != Token::kId) return false;
+
+  if (m_tok.text == "if") {
+    GetNextToken();
+
+    // evaluate expression
+    if (!ParseExpression(tmpl)) return false;
+
+    // start a new if block on if stack
+    m_ifStack.emplace_back(tmpl.bytecodes.size());
+
+    // conditional jump; destination will be filled in by else or endif
+    tmpl.bytecodes.emplace_back(Bytecode::Op::ConditionalJump);
+  } else if (m_tok.text == "endif") {
+    if (m_ifStack.empty())
+      inja_throw("parser_error", "endif without matching if");
+    auto& ifData = m_ifStack.back();
+    GetNextToken();
+
+    // previous conditional jump jumps here
+    if (ifData.prevCondJump != UINT_MAX)
+      tmpl.bytecodes[ifData.prevCondJump].args = tmpl.bytecodes.size();
+
+    // update all previous unconditional jumps to here
+    for (unsigned int i : ifData.uncondJumps)
+      tmpl.bytecodes[i].args = tmpl.bytecodes.size();
+
+    // pop if stack
+    m_ifStack.pop_back();
+  } else if (m_tok.text == "else") {
+    if (m_ifStack.empty())
+      inja_throw("parser_error", "else without matching if");
+    auto& ifData = m_ifStack.back();
+    GetNextToken();
+
+    // end previous block with unconditional jump to endif; destination will be
+    // filled in by endif
+    ifData.uncondJumps.push_back(tmpl.bytecodes.size());
+    tmpl.bytecodes.emplace_back(Bytecode::Op::Jump);
+
+    // previous conditional jump jumps here
+    tmpl.bytecodes[ifData.prevCondJump].args = tmpl.bytecodes.size();
+    ifData.prevCondJump = UINT_MAX;
+
+    // chained else if
+    if (m_tok.kind == Token::kId && m_tok.text == "if") {
+      GetNextToken();
+
+      // evaluate expression
+      if (!ParseExpression(tmpl)) return false;
+
+      // update "previous jump"
+      ifData.prevCondJump = tmpl.bytecodes.size();
+
+      // conditional jump; destination will be filled in by else or endif
+      tmpl.bytecodes.emplace_back(Bytecode::Op::ConditionalJump);
+    }
+  } else if (m_tok.text == "for") {
+    GetNextToken();
+
+    // options: for a in arr; for a, b in obj
+    if (m_tok.kind != Token::kId)
+      inja_throw("parser_error",
+                 Twine("expected id, got '") + m_tok.Describe() + "'");
+    Token valueTok = m_tok;
+    GetNextToken();
+
+    Token keyTok;
+    if (m_tok.kind == Token::kComma) {
+      GetNextToken();
+      if (m_tok.kind != Token::kId)
+        inja_throw("parser_error",
+                   Twine("expected id, got '") + m_tok.Describe() + "'");
+      keyTok = std::move(valueTok);
+      valueTok = m_tok;
+      GetNextToken();
+    }
+
+    if (m_tok.kind != Token::kId || m_tok.text != "in")
+      inja_throw("parser_error",
+                 Twine("expected 'in', got '") + m_tok.Describe() + "'");
+    GetNextToken();
+
+    if (!ParseExpression(tmpl)) return false;
+
+    m_loopStack.push_back(tmpl.bytecodes.size());
+
+    tmpl.bytecodes.emplace_back(Bytecode::Op::StartLoop);
+    if (!keyTok.text.empty()) tmpl.bytecodes.back().value = keyTok.text;
+    tmpl.bytecodes.back().str = valueTok.text;
+  } else if (m_tok.text == "endfor") {
+    GetNextToken();
+    if (m_loopStack.empty())
+      inja_throw("parser_error", "endfor without matching for");
+
+    // update loop with EndLoop index (for empty case)
+    tmpl.bytecodes[m_loopStack.back()].args = tmpl.bytecodes.size();
+
+    tmpl.bytecodes.emplace_back(Bytecode::Op::EndLoop);
+    tmpl.bytecodes.back().args = m_loopStack.back() + 1;  // loop body
+    m_loopStack.pop_back();
+  } else if (m_tok.text == "include") {
+    GetNextToken();
+
+    if (m_tok.kind != Token::kString)
+      inja_throw("parser_error",
+                 Twine("expected string, got '") + m_tok.Describe() + "'");
+
+    // build the relative path
+    json jsonName = json::parse(m_tok.text);
+    SmallString<128> pathname = path;
+    pathname += jsonName.get_ref<const std::string&>();
+    sys::path::remove_dots(pathname, true, sys::path::Style::posix);
+
+    // parse it only if it's new
+    StringMap<Template>::iterator included;
+    bool isNew;
+    std::tie(included, isNew) = m_includedTemplates.try_emplace(pathname);
+    if (isNew) included->second = ParseTemplate(pathname);
+
+    // generate a reference bytecode
+    tmpl.bytecodes.emplace_back(Bytecode::Op::Include, json(pathname),
+                                Bytecode::kFlagValueImmediate);
+
+    GetNextToken();
+  } else {
+    return false;
+  }
+  return true;
+}
+
+void Parser::AppendFunction(Template& tmpl, Bytecode::Op op,
+                            unsigned int numArgs) {
+  // we can merge with back-to-back push
+  if (!tmpl.bytecodes.empty()) {
+    Bytecode& last = tmpl.bytecodes.back();
+    if (last.op == Bytecode::Op::Push) {
+      last.op = op;
+      last.args = numArgs;
+      return;
+    }
+  }
+
+  // otherwise just add it to the end
+  tmpl.bytecodes.emplace_back(op, numArgs);
+}
+
+void Parser::AppendCallback(Template& tmpl, StringRef name,
+                            unsigned int numArgs) {
+  // we can merge with back-to-back push value (not lookup)
+  if (!tmpl.bytecodes.empty()) {
+    Bytecode& last = tmpl.bytecodes.back();
+    if (last.op == Bytecode::Op::Push &&
+        (last.flags & Bytecode::kFlagValueMask) ==
+            Bytecode::kFlagValueImmediate) {
+      last.op = Bytecode::Op::Callback;
+      last.args = numArgs;
+      last.str = name;
+      return;
+    }
+  }
+
+  // otherwise just add it to the end
+  tmpl.bytecodes.emplace_back(Bytecode::Op::Callback, numArgs);
+  tmpl.bytecodes.back().str = name;
+}
+
+void Parser::ParseInto(Template& tmpl, StringRef path) {
+  m_lexer.Start(tmpl.contents);
+
+  for (;;) {
+    GetNextToken();
+    switch (m_tok.kind) {
+      case Token::kEof:
+        if (!m_ifStack.empty()) inja_throw("parser_error", "unmatched if");
+        if (!m_loopStack.empty()) inja_throw("parser_error", "unmatched for");
+        return;
+      case Token::kText:
+        tmpl.bytecodes.emplace_back(Bytecode::Op::PrintText, m_tok.text, 0u);
+        break;
+      case Token::kStatementOpen:
+        GetNextToken();
+        if (!ParseStatement(tmpl, path)) {
+          inja_throw("parser_error", Twine("expected statement, got '") +
+                                         m_tok.Describe() + "'");
+        }
+        if (m_tok.kind != Token::kStatementClose) {
+          inja_throw("parser_error", Twine("expected statement close, got '") +
+                                         m_tok.Describe() + "'");
+        }
+        break;
+      case Token::kLineStatementOpen:
+        GetNextToken();
+        ParseStatement(tmpl, path);
+        if (m_tok.kind != Token::kLineStatementClose &&
+            m_tok.kind != Token::kEof) {
+          inja_throw("parser_error",
+                     Twine("expected line statement close, got '") +
+                         m_tok.Describe() + "'");
+        }
+        break;
+      case Token::kExpressionOpen:
+        GetNextToken();
+        if (!ParseExpression(tmpl)) {
+          inja_throw("parser_error", Twine("expected expression, got '") +
+                                         m_tok.Describe() + "'");
+        }
+        AppendFunction(tmpl, Bytecode::Op::PrintValue, 1);
+        if (m_tok.kind != Token::kExpressionClose) {
+          inja_throw("parser_error", Twine("expected expression close, got '") +
+                                         m_tok.Describe() + "'");
+        }
+        break;
+      case Token::kCommentOpen:
+        GetNextToken();
+        if (m_tok.kind != Token::kCommentClose) {
+          inja_throw("parser_error", Twine("expected comment close, got '") +
+                                         m_tok.Describe() + "'");
+        }
+        break;
+      default:
+        inja_throw("parser_error",
+                   Twine("unexpected token '") + m_tok.Describe() + "'");
+        break;
+    }
+  }
+}
+
+Template Parser::Parse(StringRef input, StringRef path) {
+  Template result;
+  result.contents = input;
+  ParseInto(result, path);
+  return result;
+}
+
+Template Parser::ParseTemplate(StringRef filename) {
+  Template result;
+  if (m_config.loadFile) {
+    result.contents = m_config.loadFile(filename);
+    StringRef path = sys::path::parent_path(filename);
+    Parser(m_config, m_lexer.GetConfig(), m_includedTemplates)
+        .ParseInto(result, path);
+  }
+  return result;
+}

--- a/wpiutil/src/main/native/cpp/inja_parser.h
+++ b/wpiutil/src/main/native/cpp/inja_parser.h
@@ -1,0 +1,181 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#ifndef WPIUTIL_INJA_PARSER_H_
+#define WPIUTIL_INJA_PARSER_H_
+
+#include "inja_internal.h"
+#include "wpi/SmallString.h"
+#include "wpi/StringRef.h"
+#include "wpi/Twine.h"
+#include "wpi/inja.h"
+
+namespace wpi {
+namespace inja {
+
+class ParserStatic {
+ public:
+  ParserStatic(const ParserStatic&) = delete;
+  ParserStatic& operator=(const ParserStatic&) = delete;
+
+  static const ParserStatic& GetInstance();
+
+  FunctionStorage functions;
+
+ private:
+  ParserStatic();
+};
+
+struct Token {
+  enum Kind {
+    kText,
+    kExpressionOpen,      // {{
+    kExpressionClose,     // }}
+    kLineStatementOpen,   // ##
+    kLineStatementClose,  // \n
+    kStatementOpen,       // {%
+    kStatementClose,      // %}
+    kCommentOpen,         // {#
+    kCommentClose,        // #}
+    kId,                  // this, this.foo
+    kNumber,              // 1, 2, -1, 5.2, -5.3
+    kString,              // "this"
+    kComma,               // ,
+    kColon,               // :
+    kLeftParen,           // (
+    kRightParen,          // )
+    kLeftBracket,         // [
+    kRightBracket,        // ]
+    kLeftBrace,           // {
+    kRightBrace,          // }
+    kEqual,               // ==
+    kGreaterThan,         // >
+    kLessThan,            // <
+    kLessEqual,           // <=
+    kGreaterEqual,        // >=
+    kNotEqual,            // !=
+    kUnknown,
+    kEof
+  };
+  Kind kind = kUnknown;
+  StringRef text;
+
+  Token() = default;
+  constexpr Token(Kind kind, StringRef text) : kind(kind), text(text) {}
+  StringRef Describe() const;
+};
+
+struct LexerConfig {
+  SmallString<4> statementOpen{"{%"};
+  SmallString<4> statementClose{"%}"};
+  SmallString<4> lineStatement{"##"};
+  SmallString<4> expressionOpen{"{{"};
+  SmallString<4> expressionClose{"}}"};
+  SmallString<4> commentOpen{"{#"};
+  SmallString<4> commentClose{"#}"};
+  SmallString<4> openChars{"#{"};
+
+  void UpdateOpenChars();
+};
+
+class Lexer {
+ public:
+  explicit Lexer(const LexerConfig& config) : m_config(config) {}
+
+  void Start(StringRef in);
+  Token Scan();
+
+  const LexerConfig& GetConfig() const { return m_config; }
+
+ private:
+  Token ScanBody(StringRef close, Token::Kind closeKind);
+  Token ScanId();
+  Token ScanNumber();
+  Token ScanString();
+  Token MakeToken(Token::Kind kind) const {
+    return Token(kind, m_in.slice(m_tokStart, m_pos));
+  }
+
+  const LexerConfig& m_config;
+  StringRef m_in;
+  size_t m_tokStart;
+  size_t m_pos;
+  enum class State {
+    Text,
+    ExpressionStart,
+    ExpressionBody,
+    LineStart,
+    LineBody,
+    StatementStart,
+    StatementBody,
+    CommentStart,
+    CommentBody
+  };
+  State m_state;
+};
+
+struct ParserConfig {
+  ElementNotation notation = ElementNotation::Pointer;
+  std::function<std::string(StringRef filename)> loadFile;
+};
+
+class Parser {
+ public:
+  Parser(const ParserConfig& parserConfig, const LexerConfig& lexerConfig,
+         TemplateStorage& includedTemplates);
+
+  bool ParseExpression(Template& tmpl);
+  bool ParseExpressionAnd(Template& tmpl);
+  bool ParseExpressionNot(Template& tmpl);
+  bool ParseExpressionComparison(Template& tmpl);
+  bool ParseExpressionDatum(Template& tmpl);
+  bool ParseStatement(Template& tmpl, StringRef path);
+  void AppendFunction(Template& tmpl, Bytecode::Op op, unsigned int numArgs);
+  void AppendCallback(Template& tmpl, StringRef name, unsigned int numArgs);
+  void ParseInto(Template& tmpl, StringRef path);
+
+  Template Parse(StringRef input, StringRef path = "./");
+  Template ParseTemplate(StringRef filename);
+
+ private:
+  const ParserConfig& m_config;
+  Lexer m_lexer;
+  Token m_tok;
+  Token m_peekTok;
+  bool m_havePeekTok = false;
+  TemplateStorage& m_includedTemplates;
+  const ParserStatic& m_static;
+  struct IfData {
+    unsigned int prevCondJump;
+    SmallVector<unsigned int, 4> uncondJumps;
+
+    explicit IfData(unsigned int condJump) : prevCondJump(condJump) {}
+  };
+  SmallVector<IfData, 4> m_ifStack;
+  SmallVector<unsigned int, 4> m_loopStack;
+
+  void GetNextToken() {
+    if (m_havePeekTok) {
+      m_tok = m_peekTok;
+      m_havePeekTok = false;
+    } else {
+      m_tok = m_lexer.Scan();
+    }
+  }
+
+  void GetPeekToken() {
+    if (!m_havePeekTok) {
+      m_peekTok = m_lexer.Scan();
+      m_havePeekTok = true;
+    }
+  }
+};
+
+}  // namespace inja
+}  // namespace wpi
+
+#endif  // WPIUTIL_INJA_PARSER_H_

--- a/wpiutil/src/main/native/cpp/inja_renderer.cpp
+++ b/wpiutil/src/main/native/cpp/inja_renderer.cpp
@@ -1,0 +1,502 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "inja_renderer.h"
+
+#include <algorithm>
+#include <numeric>
+
+#include "inja_internal.h"
+#include "wpi/SmallString.h"
+#include "wpi/inja.h"
+#include "wpi/raw_ostream.h"
+
+using namespace wpi;
+using namespace wpi::inja;
+
+static bool Truthy(const json& var) {
+  if (var.empty()) {
+    return false;
+  } else if (var.is_number()) {
+    return (var != 0);
+  } else if (var.is_string()) {
+    return !var.empty();
+  }
+  try {
+    return var.get<bool>();
+  } catch (json::type_error& e) {
+    inja_throw("json_error", e.what());
+    throw;
+  }
+}
+
+StringRef inja::ConvertDotToJsonPointer(StringRef dot,
+                                        SmallVectorImpl<char>& out) {
+  out.clear();
+  do {
+    StringRef part;
+    std::tie(part, dot) = dot.split('.');
+    out.push_back('/');
+    out.append(part.begin(), part.end());
+  } while (!dot.empty());
+  return StringRef(out.data(), out.size());
+}
+
+void Renderer::RenderTo(raw_ostream& os, const Template& tmpl,
+                        const json& data) {
+  m_data = &data;
+
+  for (size_t i = 0; i < tmpl.bytecodes.size(); ++i) {
+    const auto& bc = tmpl.bytecodes[i];
+
+    switch (bc.op) {
+      case Bytecode::Op::Nop:
+        break;
+      case Bytecode::Op::PrintText:
+        os << bc.str;
+        break;
+      case Bytecode::Op::PrintValue: {
+        const json& val = *GetArgs(bc)[0];
+        if (val.is_string())
+          os << val.get_ref<const std::string&>();
+        else
+          val.dump(os);
+        PopArgs(bc);
+        break;
+      }
+      case Bytecode::Op::Push:
+        m_stack.emplace_back(*GetImm(bc));
+        break;
+      case Bytecode::Op::Upper: {
+        auto result = GetArgs(bc)[0]->get<std::string>();
+        std::transform(result.begin(), result.end(), result.begin(), ::toupper);
+        PopArgs(bc);
+        m_stack.emplace_back(std::move(result));
+        break;
+      }
+      case Bytecode::Op::Lower: {
+        auto result = GetArgs(bc)[0]->get<std::string>();
+        std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+        PopArgs(bc);
+        m_stack.emplace_back(std::move(result));
+        break;
+      }
+      case Bytecode::Op::Range: {
+        int number = GetArgs(bc)[0]->get<int>();
+        std::vector<int> result(number);
+        std::iota(std::begin(result), std::end(result), 0);
+        PopArgs(bc);
+        m_stack.emplace_back(std::move(result));
+        break;
+      }
+      case Bytecode::Op::Length: {
+        auto result = GetArgs(bc)[0]->size();
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::Sort: {
+        auto result = GetArgs(bc)[0]->get<std::vector<json>>();
+        std::sort(result.begin(), result.end());
+        PopArgs(bc);
+        m_stack.emplace_back(std::move(result));
+        break;
+      }
+      case Bytecode::Op::First: {
+        auto result = GetArgs(bc)[0]->front();
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::Last: {
+        auto result = GetArgs(bc)[0]->back();
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::Round: {
+        auto args = GetArgs(bc);
+        double number = args[0]->get<double>();
+        int precision = args[1]->get<int>();
+        PopArgs(bc);
+        m_stack.emplace_back(std::round(number * std::pow(10.0, precision)) /
+                             std::pow(10.0, precision));
+        break;
+      }
+      case Bytecode::Op::DivisibleBy: {
+        auto args = GetArgs(bc);
+        int number = args[0]->get<int>();
+        int divisor = args[1]->get<int>();
+        PopArgs(bc);
+        m_stack.emplace_back((divisor != 0) && (number % divisor == 0));
+        break;
+      }
+      case Bytecode::Op::Odd: {
+        int number = GetArgs(bc)[0]->get<int>();
+        PopArgs(bc);
+        m_stack.emplace_back(number % 2 != 0);
+        break;
+      }
+      case Bytecode::Op::Even: {
+        int number = GetArgs(bc)[0]->get<int>();
+        PopArgs(bc);
+        m_stack.emplace_back(number % 2 == 0);
+        break;
+      }
+      case Bytecode::Op::Max: {
+        auto args = GetArgs(bc);
+        auto result = *std::max_element(args[0]->begin(), args[0]->end());
+        PopArgs(bc);
+        m_stack.emplace_back(std::move(result));
+        break;
+      }
+      case Bytecode::Op::Min: {
+        auto args = GetArgs(bc);
+        auto result = *std::min_element(args[0]->begin(), args[0]->end());
+        PopArgs(bc);
+        m_stack.emplace_back(std::move(result));
+        break;
+      }
+      case Bytecode::Op::Not: {
+        bool result = !Truthy(*GetArgs(bc)[0]);
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::And: {
+        auto args = GetArgs(bc);
+        bool result = Truthy(*args[0]) && Truthy(*args[1]);
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::Or: {
+        auto args = GetArgs(bc);
+        bool result = Truthy(*args[0]) || Truthy(*args[1]);
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::In: {
+        auto args = GetArgs(bc);
+        bool result = std::find(args[1]->begin(), args[1]->end(), *args[0]) !=
+                      args[1]->end();
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::Equal: {
+        auto args = GetArgs(bc);
+        bool result = (*args[0] == *args[1]);
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::Greater: {
+        auto args = GetArgs(bc);
+        bool result = (*args[0] > *args[1]);
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::Less: {
+        auto args = GetArgs(bc);
+        bool result = (*args[0] < *args[1]);
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::GreaterEqual: {
+        auto args = GetArgs(bc);
+        bool result = (*args[0] >= *args[1]);
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::LessEqual: {
+        auto args = GetArgs(bc);
+        bool result = (*args[0] <= *args[1]);
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::Different: {
+        auto args = GetArgs(bc);
+        bool result = (*args[0] != *args[1]);
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::Float: {
+        double result =
+            std::stod(GetArgs(bc)[0]->get_ref<const std::string&>());
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::Int: {
+        int result = std::stoi(GetArgs(bc)[0]->get_ref<const std::string&>());
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::Exists: {
+        auto&& name = GetArgs(bc)[0]->get_ref<const std::string&>();
+        bool result = (data.find(name) != data.end());
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::ExistsInObject: {
+        auto args = GetArgs(bc);
+        auto&& name = args[1]->get_ref<const std::string&>();
+        bool result = (args[0]->find(name) != args[0]->end());
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::IsBoolean: {
+        bool result = GetArgs(bc)[0]->is_boolean();
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::IsNumber: {
+        bool result = GetArgs(bc)[0]->is_number();
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::IsInteger: {
+        bool result = GetArgs(bc)[0]->is_number_integer();
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::IsFloat: {
+        bool result = GetArgs(bc)[0]->is_number_float();
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::IsObject: {
+        bool result = GetArgs(bc)[0]->is_object();
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::IsArray: {
+        bool result = GetArgs(bc)[0]->is_array();
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::IsString: {
+        bool result = GetArgs(bc)[0]->is_string();
+        PopArgs(bc);
+        m_stack.emplace_back(result);
+        break;
+      }
+      case Bytecode::Op::Default: {
+        // default needs to be a bit "magic"; we can't evaluate the first
+        // argument during the push operation, so we swap the arguments during
+        // the parse phase so the second argument is pushed on the stack and
+        // the first argument is in the immediate
+        try {
+          const json* imm = GetImm(bc);
+          // if no exception was raised, replace the stack value with it
+          m_stack.back() = *imm;
+        } catch (std::exception&) {
+          // couldn't read immediate, just leave the stack as is
+        }
+        break;
+      }
+      case Bytecode::Op::Include:
+        Renderer(m_includedTemplates, m_callbacks)
+            .RenderTo(os,
+                      m_includedTemplates.lookup(
+                          GetImm(bc)->get_ref<const std::string&>()),
+                      data);
+        break;
+      case Bytecode::Op::Callback: {
+        auto cb = m_callbacks.FindCallback(bc.str, bc.args);
+        if (!cb)
+          inja_throw("render_error",
+                     Twine("function '") + bc.str + "' (" +
+                         Twine(static_cast<unsigned int>(bc.args)) +
+                         ") not found");
+        json result = cb(GetArgs(bc), data);
+        PopArgs(bc);
+        m_stack.emplace_back(std::move(result));
+        break;
+      }
+      case Bytecode::Op::Jump:
+        i = bc.args - 1;  // -1 due to ++i in loop
+        break;
+      case Bytecode::Op::ConditionalJump: {
+        if (!Truthy(m_stack.back()))
+          i = bc.args - 1;  // -1 due to ++i in loop
+        m_stack.pop_back();
+        break;
+      }
+      case Bytecode::Op::StartLoop: {
+        // jump past loop body if empty
+        if (m_stack.back().empty()) {
+          m_stack.pop_back();
+          i = bc.args;  // ++i in loop will take it past EndLoop
+          break;
+        }
+
+        m_loopStack.emplace_back();
+        LoopLevel& level = m_loopStack.back();
+        level.valueName = bc.str;
+        level.values = std::move(m_stack.back());
+        level.data = data;
+        m_stack.pop_back();
+
+        if (bc.value.is_string()) {
+          // map iterator
+          if (!level.values.is_object()) {
+            m_loopStack.pop_back();
+            inja_throw("render_error", "for key, value requires object");
+          }
+          level.keyName = bc.value.get_ref<const std::string&>();
+
+          // sort by key
+          for (auto it = level.values.begin(), end = level.values.end();
+               it != end; ++it)
+            level.mapValues.emplace_back(it.key(), &it.value());
+          std::sort(
+              level.mapValues.begin(), level.mapValues.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+          level.mapIt = level.mapValues.begin();
+        } else {
+          // list iterator
+          level.it = level.values.begin();
+          level.index = 0;
+          level.size = level.values.size();
+        }
+
+        // provide parent access in nested loop
+        auto parentLoopIt = level.data.find("loop");
+        if (parentLoopIt != level.data.end()) {
+          json loopCopy = *parentLoopIt;
+          (*parentLoopIt)["parent"] = std::move(loopCopy);
+        }
+
+        // set "current" data to loop data
+        m_data = &level.data;
+        UpdateLoopData();
+        break;
+      }
+      case Bytecode::Op::EndLoop: {
+        if (m_loopStack.empty())
+          inja_throw("render_error", "unexpected state in renderer");
+        LoopLevel& level = m_loopStack.back();
+
+        bool done;
+        if (level.keyName.empty()) {
+          ++level.it;
+          ++level.index;
+          done = (level.it == level.values.end());
+        } else {
+          ++level.mapIt;
+          done = (level.mapIt == level.mapValues.end());
+        }
+
+        if (done) {
+          m_loopStack.pop_back();
+          // set "current" data to outer loop data or main data as appropriate
+          if (!m_loopStack.empty())
+            m_data = &m_loopStack.back().data;
+          else
+            m_data = &data;
+          break;
+        }
+
+        UpdateLoopData();
+
+        // jump back to start of loop
+        i = bc.args - 1;  // -1 due to ++i in loop
+        break;
+      }
+      default:
+        inja_throw("render_error", "unknown op in renderer: " +
+                                       Twine(static_cast<unsigned int>(bc.op)));
+    }
+  }
+}
+
+void Renderer::UpdateLoopData() {
+  LoopLevel& level = m_loopStack.back();
+  if (level.keyName.empty()) {
+    level.data[level.valueName] = *level.it;
+    auto& loopData = level.data["loop"];
+    loopData["index"] = level.index;
+    loopData["index1"] = level.index + 1;
+    loopData["is_first"] = (level.index == 0);
+    loopData["is_last"] = (level.index == level.size - 1);
+  } else {
+    level.data[level.keyName] = level.mapIt->first;
+    level.data[level.valueName] = *level.mapIt->second;
+  }
+}
+
+ArrayRef<const json*> Renderer::GetArgs(const Bytecode& bc) {
+  m_tmpArgs.clear();
+
+  bool hasImm =
+      ((bc.flags & Bytecode::kFlagValueMask) != Bytecode::kFlagValuePop);
+
+  // get args from stack
+  unsigned int popArgs = bc.args;
+  if (hasImm) --popArgs;
+  for (auto&& i : makeArrayRef(m_stack).take_back(popArgs))
+    m_tmpArgs.push_back(&i);
+
+  // get immediate arg
+  if (hasImm) m_tmpArgs.push_back(GetImm(bc));
+
+  return m_tmpArgs;
+}
+
+void Renderer::PopArgs(const Bytecode& bc) {
+  unsigned int popArgs = bc.args;
+  if ((bc.flags & Bytecode::kFlagValueMask) != Bytecode::kFlagValuePop)
+    --popArgs;
+  for (unsigned int i = 0; i < popArgs; ++i) m_stack.pop_back();
+}
+
+const json* Renderer::GetImm(const Bytecode& bc) {
+  SmallString<64> ptrBuf;
+  StringRef ptr;
+  switch (bc.flags & Bytecode::kFlagValueMask) {
+    case Bytecode::kFlagValuePop:
+      return nullptr;
+    case Bytecode::kFlagValueImmediate:
+      return &bc.value;
+    case Bytecode::kFlagValueLookupDot:
+      ptr = ConvertDotToJsonPointer(bc.str, ptrBuf);
+      break;
+    case Bytecode::kFlagValueLookupPointer:
+      ptrBuf += '/';
+      ptrBuf += bc.str;
+      ptr = ptrBuf;
+      break;
+  }
+  try {
+    return &m_data->at(json::json_pointer(ptr));
+  } catch (std::exception&) {
+    // try to evaluate as a no-argument callback
+    if (auto cb = m_callbacks.FindCallback(bc.str, 0)) {
+      m_tmpVal = cb(ArrayRef<const json*>{}, *m_data);
+      return &m_tmpVal;
+    }
+    inja_throw("render_error", Twine("variable '") + bc.str + "' not found");
+    return nullptr;
+  }
+}

--- a/wpiutil/src/main/native/cpp/inja_renderer.h
+++ b/wpiutil/src/main/native/cpp/inja_renderer.h
@@ -1,0 +1,75 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#ifndef WPIUTIL_INJA_RENDERER_H_
+#define WPIUTIL_INJA_RENDERER_H_
+
+#include <vector>
+
+#include "inja_internal.h"
+#include "wpi/ArrayRef.h"
+#include "wpi/SmallVector.h"
+#include "wpi/StringRef.h"
+#include "wpi/inja.h"
+#include "wpi/json.h"
+
+namespace wpi {
+
+class raw_ostream;
+
+namespace inja {
+
+StringRef ConvertDotToJsonPointer(StringRef dot, SmallVectorImpl<char>& out);
+
+class Renderer {
+ public:
+  Renderer(const TemplateStorage& includedTemplates,
+           const FunctionStorage& callbacks)
+      : m_includedTemplates(includedTemplates), m_callbacks(callbacks) {}
+
+  void RenderTo(raw_ostream& os, const Template& tmpl, const json& data);
+
+ private:
+  ArrayRef<const json*> GetArgs(const Bytecode& bc);
+  void PopArgs(const Bytecode& bc);
+  const json* GetImm(const Bytecode& bc);
+  void UpdateLoopData();
+
+  const TemplateStorage& m_includedTemplates;
+  const FunctionStorage& m_callbacks;
+
+  SmallVector<json, 16> m_stack;
+
+  struct LoopLevel {
+    StringRef keyName;              // variable name for keys
+    StringRef valueName;            // variable name for values
+    json data;                      // data with loop info added
+
+    json values;                    // values to iterate over
+
+    // loop over list
+    json::iterator it;              // iterator over values
+    size_t index;                   // current list index
+    size_t size;                    // length of list
+
+    // loop over map
+    using KeyValue = std::pair<StringRef, json*>;
+    using MapValues = std::vector<KeyValue>;
+    MapValues mapValues;            // values to iterate over
+    MapValues::iterator mapIt;      // iterator over values
+  };
+  SmallVector<LoopLevel, 0> m_loopStack;
+  const json* m_data;
+
+  SmallVector<const json*, 4> m_tmpArgs;
+  json m_tmpVal;
+};
+
+}  // namespace inja
+}  // namespace wpi
+
+#endif  // WPIUTIL_INJA_RENDERER_H_

--- a/wpiutil/src/main/native/include/wpi/inja.h
+++ b/wpiutil/src/main/native/include/wpi/inja.h
@@ -1,0 +1,104 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#ifndef WPIUTIL_WPI_INJA_H_
+#define WPIUTIL_WPI_INJA_H_
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "wpi/ArrayRef.h"
+#include "wpi/StringRef.h"
+#include "wpi/Twine.h"
+#include "wpi/json.h"
+
+namespace wpi {
+
+class raw_ostream;
+
+namespace inja {
+
+class Bytecode;
+class Parser;
+class Renderer;
+
+using CallbackFunction =
+    std::function<json(ArrayRef<const json*> args, const json& data)>;
+
+class Template {
+  friend class Parser;
+  friend class Renderer;
+
+ public:
+  // These must be out of line because Bytecode is forward declared
+  Template();
+  ~Template();
+  Template(const Template&);
+  Template(Template&& oth);
+  Template& operator=(const Template&);
+  Template& operator=(Template&&);
+
+ private:
+  std::vector<Bytecode> bytecodes;
+  std::string contents;
+};
+
+enum class ElementNotation {
+  Dot,
+  Pointer
+};
+
+class Environment {
+ public:
+  Environment();
+  explicit Environment(const Twine& path);
+  ~Environment();
+
+  void SetStatement(const Twine& open, const Twine& close);
+
+  void SetLineStatement(const Twine& open);
+
+  void SetExpression(const Twine& open, const Twine& close);
+
+  void SetComment(const Twine& open, const Twine& close);
+
+  void SetElementNotation(ElementNotation notation);
+
+  void SetLoadFile(std::function<std::string(StringRef)> loadFile);
+
+  Template Parse(StringRef input);
+
+  std::string Render(StringRef input, const json& data);
+
+  std::string Render(const Template& tmpl, const json& data);
+
+  raw_ostream& RenderTo(raw_ostream& os, const Template& tmpl,
+                        const json& data);
+
+  void AddCallback(StringRef name, unsigned int numArgs,
+                   const CallbackFunction& callback);
+
+  void IncludeTemplate(const Twine& name, const Template& tmpl);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> m_impl;
+};
+
+/*!
+@brief render with default settings
+*/
+inline std::string Render(StringRef input, const json& data) {
+  return Environment().Render(input, data);
+}
+
+}  // namespace inja
+}  // namespace wpi
+
+#endif  // WPIUTIL_WPI_INJA_H_

--- a/wpiutil/src/test/native/cpp/inja/unit-renderer.cpp
+++ b/wpiutil/src/test/native/cpp/inja/unit-renderer.cpp
@@ -1,0 +1,522 @@
+/*----------------------------------------------------------------------------*/
+/* Modifications Copyright (c) 2018 FIRST. All Rights Reserved.               */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+/*
+Inja - A Template Engine for Modern C++
+version 1.1.0
+https://github.com/pantor/inja
+
+Licensed under the MIT License <https://opensource.org/licenses/MIT>.
+Copyright (c) 2017-2018 Pantor <https://github.com/pantor>.
+
+Permission is hereby  granted, free of charge, to any  person obtaining a copy
+of this software and associated  documentation files (the "Software"), to deal
+in the Software  without restriction, including without  limitation the rights
+to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#include "TestThrow.h"
+#include "gtest/gtest.h"
+#include "inja_renderer.h"
+#include "wpi/SmallString.h"
+#include "wpi/inja.h"
+
+using namespace wpi;
+
+TEST(InjaDotToPointer, Case) {
+  SmallString<64> buf;
+  EXPECT_EQ(inja::ConvertDotToJsonPointer("person.names.surname", buf),
+            "/person/names/surname");
+  EXPECT_EQ(inja::ConvertDotToJsonPointer("guests.2", buf), "/guests/2");
+}
+
+class InjaTypesTest : public ::testing::Test {
+ public:
+  inja::Environment env;
+  json data;
+
+  InjaTypesTest() {
+    data["name"] = "Peter";
+    data["city"] = "Brunswick";
+    data["age"] = 29;
+    data["names"] = {"Jeff", "Seb"};
+    data["brother"]["name"] = "Chris";
+    data["brother"]["daughters"] = {"Maria", "Helen"};
+    data["brother"]["daughter0"] = { { "name", "Maria" } };
+    data["is_happy"] = true;
+    data["is_sad"] = false;
+    data["relatives"]["mother"] = "Maria";
+    data["relatives"]["brother"] = "Chris";
+    data["relatives"]["sister"] = "Jenny";
+    data["vars"] = {2, 3, 4, 0, -1, -2, -3};
+  }
+};
+
+TEST_F(InjaTypesTest, Basic) {
+  EXPECT_EQ(env.Render("", data), "");
+  EXPECT_EQ(env.Render("Hello World!", data), "Hello World!");
+}
+
+TEST_F(InjaTypesTest, Variables) {
+  EXPECT_EQ(env.Render("Hello {{ name }}!", data), "Hello Peter!");
+  EXPECT_EQ(env.Render("{{ name }}", data), "Peter");
+  EXPECT_EQ(env.Render("{{name}}", data), "Peter");
+  EXPECT_EQ(env.Render("{{ name }} is {{ age }} years old.", data),
+            "Peter is 29 years old.");
+  EXPECT_EQ(env.Render("{{name}}{{age}}", data), "Peter29");
+  EXPECT_EQ(env.Render("Hello {{ name }}! I come from {{ city }}.", data),
+            "Hello Peter! I come from Brunswick.");
+  EXPECT_EQ(env.Render("Hello {{ names/1 }}!", data), "Hello Seb!");
+  EXPECT_EQ(env.Render("Hello {{ brother/name }}!", data), "Hello Chris!");
+  EXPECT_EQ(env.Render("Hello {{ brother/daughter0/name }}!", data),
+            "Hello Maria!");
+
+  EXPECT_THROW_MSG(
+      env.Render("{{unknown}}", data), std::runtime_error,
+      "[inja.exception.render_error] variable 'unknown' not found");
+}
+
+TEST_F(InjaTypesTest, Comments) {
+  EXPECT_EQ(env.Render("Hello{# This is a comment #}!", data), "Hello!");
+  EXPECT_EQ(env.Render("{# --- #Todo --- #}", data), "");
+}
+
+TEST_F(InjaTypesTest, Loops) {
+  EXPECT_EQ(env.Render("{% for name in names %}a{% endfor %}", data), "aa");
+  EXPECT_EQ(
+      env.Render("Hello {% for name in names %}{{ name }} {% endfor %}!", data),
+      "Hello Jeff Seb !");
+  EXPECT_EQ(env.Render("Hello {% for name in names %}{{ loop/index }}: {{ name "
+                       "}}, {% endfor %}!",
+                       data),
+            "Hello 0: Jeff, 1: Seb, !");
+  EXPECT_EQ(env.Render("{% for type, name in relatives %}{{ type }}: {{ name "
+                       "}}, {% endfor %}",
+                       data),
+            "brother: Chris, mother: Maria, sister: Jenny, ");
+  EXPECT_EQ(
+      env.Render("{% for v in vars %}{% if v > 0 %}+{% endif %}{% endfor %}",
+                 data),
+      "+++");
+  EXPECT_EQ(env.Render("{% for name in names %}{{ loop/index }}: {{ name }}{% "
+                       "if not loop/is_last %}, {% endif %}{% endfor %}!",
+                       data),
+            "0: Jeff, 1: Seb!");
+  EXPECT_EQ(env.Render("{% for name in names %}{{ loop/index }}: {{ name }}{% "
+                       "if loop/is_last == false %}, {% endif %}{% endfor %}!",
+                       data),
+            "0: Jeff, 1: Seb!");
+
+  data["empty_loop"] = {};
+  EXPECT_EQ(env.Render("{% for name in empty_loop %}a{% endfor %}", data), "");
+  EXPECT_EQ(env.Render("{% for name in {} %}a{% endfor %}", data), "");
+
+  EXPECT_THROW_MSG(env.Render("{% for name ins names %}a{% endfor %}", data),
+                   std::runtime_error,
+                   "[inja.exception.parser_error] expected 'in', got 'ins'");
+  // CHECK_THROWS_WITH( env.Render("{% for name in relatives %}{{ name }}{%
+  // endfor %}", data), "[inja.exception.json_error]
+  // [json.exception.type_error.302] type must be array, but is object" );
+}
+
+TEST_F(InjaTypesTest, Conditionals) {
+  EXPECT_EQ(env.Render("{% if is_happy %}Yeah!{% endif %}", data), "Yeah!");
+  EXPECT_EQ(env.Render("{% if is_sad %}Yeah!{% endif %}", data), "");
+  EXPECT_EQ(
+      env.Render("{% if is_sad %}Yeah!{% else %}Nooo...{% endif %}", data),
+      "Nooo...");
+  EXPECT_EQ(
+      env.Render("{% if age == 29 %}Right{% else %}Wrong{% endif %}", data),
+      "Right");
+  EXPECT_EQ(
+      env.Render("{% if age > 29 %}Right{% else %}Wrong{% endif %}", data),
+      "Wrong");
+  EXPECT_EQ(
+      env.Render("{% if age <= 29 %}Right{% else %}Wrong{% endif %}", data),
+      "Right");
+  EXPECT_EQ(
+      env.Render("{% if age != 28 %}Right{% else %}Wrong{% endif %}", data),
+      "Right");
+  EXPECT_EQ(
+      env.Render("{% if age >= 30 %}Right{% else %}Wrong{% endif %}", data),
+      "Wrong");
+  EXPECT_EQ(env.Render("{% if age in [28, 29, 30] %}True{% endif %}", data),
+            "True");
+  EXPECT_EQ(
+      env.Render("{% if age == 28 %}28{% else if age == 29 %}29{% endif %}",
+                 data),
+      "29");
+  EXPECT_EQ(env.Render("{% if age == 26 %}26{% else if age == 27 %}27{% else "
+                       "if age == 28 %}28{% else %}29{% endif %}",
+                       data),
+            "29");
+  EXPECT_EQ(env.Render("{% if age == 25 %}+{% endif %}{% if age == 29 %}+{% "
+                       "else %}-{% endif %}",
+                       data),
+            "+");
+
+  EXPECT_THROW_MSG(
+      env.Render("{% if is_happy %}{% if is_happy %}{% endif %}", data),
+      std::runtime_error, "[inja.exception.parser_error] unmatched if");
+  //EXPECT_THROW_MSG(
+  //    env.Render("{% if is_happy %}{% else if is_happy %}{% end if %}", data),
+  //    std::runtime_error,
+  //    "[inja.exception.parser_error] misordered if statement");
+}
+
+TEST_F(InjaTypesTest, LineStatements) {
+  EXPECT_EQ(env.Render("## if is_happy\nYeah!\n## endif", data), "Yeah!\n");
+
+  EXPECT_EQ(
+      env.Render("## if is_happy\n## if is_happy\nYeah!\n## endif\n## endif",
+                 data),
+      "Yeah!\n");
+}
+
+class InjaFunctionsTest : public ::testing::Test {
+ public:
+  inja::Environment env;
+  json data;
+
+  InjaFunctionsTest() {
+    data["name"] = "Peter";
+    data["city"] = "New York";
+    data["names"] = {"Jeff", "Seb", "Peter", "Tom"};
+    data["temperature"] = 25.6789;
+    data["brother"]["name"] = "Chris";
+    data["brother"]["daughters"] = {"Maria", "Helen"};
+    data["property"] = "name";
+    data["age"] = 29;
+    data["is_happy"] = true;
+    data["is_sad"] = false;
+    data["vars"] = {2, 3, 4, 0, -1, -2, -3};
+  }
+};
+
+TEST_F(InjaFunctionsTest, Upper) {
+  EXPECT_EQ(env.Render("{{ upper(name) }}", data), "PETER");
+  EXPECT_EQ(env.Render("{{ upper(  name  ) }}", data), "PETER");
+  EXPECT_EQ(env.Render("{{ upper(city) }}", data), "NEW YORK");
+  EXPECT_EQ(env.Render("{{ upper(upper(name)) }}", data), "PETER");
+  // CHECK_THROWS_WITH( env.Render("{{ upper(5) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // string, but is number" ); CHECK_THROWS_WITH( env.Render("{{ upper(true)
+  // }}", data), "[inja.exception.json_error] [json.exception.type_error.302]
+  // type must be string, but is boolean" );
+}
+
+TEST_F(InjaFunctionsTest, Lower) {
+  EXPECT_EQ(env.Render("{{ lower(name) }}", data), "peter");
+  EXPECT_EQ(env.Render("{{ lower(city) }}", data), "new york");
+  // CHECK_THROWS_WITH( env.Render("{{ lower(5.45) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // string, but is number" );
+}
+
+TEST_F(InjaFunctionsTest, Range) {
+  EXPECT_EQ(env.Render("{{ range(2) }}", data), "[0,1]");
+  EXPECT_EQ(env.Render("{{ range(4) }}", data), "[0,1,2,3]");
+  // CHECK_THROWS_WITH( env.Render("{{ range(name) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // number, but is string" );
+}
+
+TEST_F(InjaFunctionsTest, Length) {
+  EXPECT_EQ(env.Render("{{ length(names) }}", data), "4");
+  // CHECK_THROWS_WITH( env.Render("{{ length(5) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // array, but is number" );
+}
+
+TEST_F(InjaFunctionsTest, Sort) {
+  EXPECT_EQ(env.Render("{{ sort([3, 2, 1]) }}", data), "[1,2,3]");
+  EXPECT_EQ(env.Render("{{ sort([\"bob\", \"charlie\", \"alice\"]) }}", data),
+            "[\"alice\",\"bob\",\"charlie\"]");
+  // CHECK_THROWS_WITH( env.Render("{{ sort(5) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // array, but is number" );
+}
+
+TEST_F(InjaFunctionsTest, First) {
+  EXPECT_EQ(env.Render("{{ first(names) }}", data), "Jeff");
+  // CHECK_THROWS_WITH( env.Render("{{ first(5) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // array, but is number" );
+}
+
+TEST_F(InjaFunctionsTest, Last) {
+  EXPECT_EQ(env.Render("{{ last(names) }}", data), "Tom");
+  // CHECK_THROWS_WITH( env.Render("{{ last(5) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // array, but is number" );
+}
+
+TEST_F(InjaFunctionsTest, Round) {
+  EXPECT_EQ(env.Render("{{ round(4, 0) }}", data), "4.0");
+  EXPECT_EQ(env.Render("{{ round(temperature, 2) }}", data), "25.68");
+  // CHECK_THROWS_WITH( env.Render("{{ round(name, 2) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // number, but is string" );
+}
+
+TEST_F(InjaFunctionsTest, DivisibleBy) {
+  EXPECT_EQ(env.Render("{{ divisibleBy(50, 5) }}", data), "true");
+  EXPECT_EQ(env.Render("{{ divisibleBy(12, 3) }}", data), "true");
+  EXPECT_EQ(env.Render("{{ divisibleBy(11, 3) }}", data), "false");
+  // CHECK_THROWS_WITH( env.Render("{{ divisibleBy(name, 2) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // number, but is string" );
+}
+
+TEST_F(InjaFunctionsTest, Odd) {
+  EXPECT_EQ(env.Render("{{ odd(11) }}", data), "true");
+  EXPECT_EQ(env.Render("{{ odd(12) }}", data), "false");
+  // CHECK_THROWS_WITH( env.Render("{{ odd(name) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // number, but is string" );
+}
+
+TEST_F(InjaFunctionsTest, Even) {
+  EXPECT_EQ(env.Render("{{ even(11) }}", data), "false");
+  EXPECT_EQ(env.Render("{{ even(12) }}", data), "true");
+  // CHECK_THROWS_WITH( env.Render("{{ even(name) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // number, but is string" );
+}
+
+TEST_F(InjaFunctionsTest, Max) {
+  EXPECT_EQ(env.Render("{{ max([1, 2, 3]) }}", data), "3");
+  EXPECT_EQ(env.Render("{{ max([-5.2, 100.2, 2.4]) }}", data), "100.2");
+  // CHECK_THROWS_WITH( env.Render("{{ max(name) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // array, but is string" );
+}
+
+TEST_F(InjaFunctionsTest, Min) {
+  EXPECT_EQ(env.Render("{{ min([1, 2, 3]) }}", data), "1");
+  EXPECT_EQ(env.Render("{{ min([-5.2, 100.2, 2.4]) }}", data), "-5.2");
+  // CHECK_THROWS_WITH( env.Render("{{ min(name) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // array, but is string" );
+}
+
+TEST_F(InjaFunctionsTest, Float) {
+  EXPECT_EQ(env.Render("{{ float(\"2.2\") == 2.2 }}", data), "true");
+  EXPECT_EQ(env.Render("{{ float(\"-1.25\") == -1.25 }}", data), "true");
+  // CHECK_THROWS_WITH( env.Render("{{ max(name) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // array, but is string" );
+}
+
+TEST_F(InjaFunctionsTest, Int) {
+  EXPECT_EQ(env.Render("{{ int(\"2\") == 2 }}", data), "true");
+  EXPECT_EQ(env.Render("{{ int(\"-1.25\") == -1 }}", data), "true");
+  // CHECK_THROWS_WITH( env.Render("{{ max(name) }}", data),
+  // "[inja.exception.json_error] [json.exception.type_error.302] type must be
+  // array, but is string" );
+}
+
+TEST_F(InjaFunctionsTest, Default) {
+  EXPECT_EQ(env.Render("{{ default(11, 0) }}", data), "11");
+  EXPECT_EQ(env.Render("{{ default(nothing, 0) }}", data), "0");
+  EXPECT_EQ(env.Render("{{ default(name, \"nobody\") }}", data), "Peter");
+  EXPECT_EQ(env.Render("{{ default(surname, \"nobody\") }}", data), "nobody");
+  EXPECT_THROW_MSG(
+      env.Render("{{ default(surname, lastname) }}", data), std::runtime_error,
+      "[inja.exception.render_error] variable 'lastname' not found");
+}
+
+TEST_F(InjaFunctionsTest, Exists) {
+  EXPECT_EQ(env.Render("{{ exists(\"name\") }}", data), "true");
+  EXPECT_EQ(env.Render("{{ exists(\"zipcode\") }}", data), "false");
+  EXPECT_EQ(env.Render("{{ exists(name) }}", data), "false");
+  EXPECT_EQ(env.Render("{{ exists(property) }}", data), "true");
+}
+
+TEST_F(InjaFunctionsTest, ExistsIn) {
+  EXPECT_EQ(env.Render("{{ existsIn(brother, \"name\") }}", data), "true");
+  EXPECT_EQ(env.Render("{{ existsIn(brother, \"parents\") }}", data), "false");
+  EXPECT_EQ(env.Render("{{ existsIn(brother, property) }}", data), "true");
+  EXPECT_EQ(env.Render("{{ existsIn(brother, name) }}", data), "false");
+  EXPECT_THROW_MSG(
+      env.Render("{{ existsIn(sister, \"lastname\") }}", data),
+      std::runtime_error,
+      "[inja.exception.render_error] variable 'sister' not found");
+  EXPECT_THROW_MSG(
+      env.Render("{{ existsIn(brother, sister) }}", data), std::runtime_error,
+      "[inja.exception.render_error] variable 'sister' not found");
+}
+
+TEST_F(InjaFunctionsTest, IsType) {
+  EXPECT_EQ(env.Render("{{ isBoolean(is_happy) }}", data), "true");
+  EXPECT_EQ(env.Render("{{ isBoolean(vars) }}", data), "false");
+  EXPECT_EQ(env.Render("{{ isNumber(age) }}", data), "true");
+  EXPECT_EQ(env.Render("{{ isNumber(name) }}", data), "false");
+  EXPECT_EQ(env.Render("{{ isInteger(age) }}", data), "true");
+  EXPECT_EQ(env.Render("{{ isInteger(is_happy) }}", data), "false");
+  EXPECT_EQ(env.Render("{{ isFloat(temperature) }}", data), "true");
+  EXPECT_EQ(env.Render("{{ isFloat(age) }}", data), "false");
+  EXPECT_EQ(env.Render("{{ isObject(brother) }}", data), "true");
+  EXPECT_EQ(env.Render("{{ isObject(vars) }}", data), "false");
+  EXPECT_EQ(env.Render("{{ isArray(vars) }}", data), "true");
+  EXPECT_EQ(env.Render("{{ isArray(name) }}", data), "false");
+  EXPECT_EQ(env.Render("{{ isString(name) }}", data), "true");
+  EXPECT_EQ(env.Render("{{ isString(names) }}", data), "false");
+}
+
+TEST(InjaCallbacksTest, Case) {
+  inja::Environment env;
+  json data;
+  data["age"] = 28;
+
+  env.AddCallback("double", 1,
+                  [](ArrayRef<const json*> args, const json& data) {
+                    int number = args[0]->get<double>();
+                    return 2 * number;
+                  });
+
+  env.AddCallback("half", 1, [](ArrayRef<const json*> args, const json& data) {
+    int number = args[0]->get<double>();
+    return number / 2;
+  });
+
+  std::string greet = "Hello";
+  env.AddCallback("double-greetings", 0, [greet](auto, const json&) {
+    return greet + " " + greet + "!";
+  });
+
+  env.AddCallback("multiply", 2,
+                  [](ArrayRef<const json*> args, const json& data) {
+                    auto number1 = args[0]->get<double>();
+                    auto number2 = args[1]->get<double>();
+                    return number1 * number2;
+                  });
+
+  env.AddCallback("multiply", 3,
+                  [](ArrayRef<const json*> args, const json& data) {
+                    double number1 = args[0]->get<double>();
+                    double number2 = args[1]->get<double>();
+                    double number3 = args[2]->get<double>();
+                    return number1 * number2 * number3;
+                  });
+
+  env.AddCallback("multiply", 0, [](auto, const json&) { return 1.0; });
+
+  EXPECT_EQ( env.Render("{{ double(age) }}", data), "56" );
+  EXPECT_EQ( env.Render("{{ half(age) }}", data), "14" );
+  EXPECT_EQ( env.Render("{{ double-greetings }}", data), "Hello Hello!" );
+  EXPECT_EQ( env.Render("{{ double-greetings() }}", data), "Hello Hello!" );
+  EXPECT_EQ( env.Render("{{ multiply(4, 5) }}", data), "20.0" );
+  EXPECT_EQ( env.Render("{{ multiply(3, 4, 5) }}", data), "60.0" );
+  EXPECT_EQ( env.Render("{{ multiply }}", data), "1.0" );
+}
+
+TEST(InjaCombinationsTest, Case) {
+  inja::Environment env;
+  json data;
+  data["name"] = "Peter";
+  data["city"] = "Brunswick";
+  data["age"] = 29;
+  data["names"] = {"Jeff", "Seb"};
+  data["brother"]["name"] = "Chris";
+  data["brother"]["daughters"] = {"Maria", "Helen"};
+  data["brother"]["daughter0"] = { { "name", "Maria" } };
+  data["is_happy"] = true;
+
+  EXPECT_EQ( env.Render("{% if upper(\"Peter\") == \"PETER\" %}TRUE{% endif %}", data), "TRUE" );
+  EXPECT_EQ( env.Render("{% if lower(upper(name)) == \"peter\" %}TRUE{% endif %}", data), "TRUE" );
+  EXPECT_EQ( env.Render("{% for i in range(4) %}{{ loop/index1 }}{% endfor %}", data), "1234" );
+}
+
+class InjaTemplatesTest : public ::testing::Test {
+ public:
+  inja::Environment env;
+  json data;
+
+  InjaTemplatesTest() {
+    data["name"] = "Peter";
+    data["city"] = "Brunswick";
+    data["is_happy"] = true;
+  }
+};
+
+TEST_F(InjaTemplatesTest, Reuse) {
+  inja::Template temp =
+      env.Parse("{% if is_happy %}{{ name }}{% else %}{{ city }}{% endif %}");
+
+  EXPECT_EQ(env.Render(temp, data), "Peter");
+
+  data["is_happy"] = false;
+
+  EXPECT_EQ(env.Render(temp, data), "Brunswick");
+}
+
+TEST_F(InjaTemplatesTest, Include) {
+  inja::Template t1 = env.Parse("Hello {{ name }}");
+  env.IncludeTemplate("greeting", t1);
+
+  inja::Template t2 = env.Parse("{% include \"greeting\" %}!");
+  EXPECT_EQ(env.Render(t2, data), "Hello Peter!");
+}
+
+class InjaOtherSyntaxTest : public ::testing::Test {
+ public:
+  inja::Environment env;
+  json data;
+
+  InjaOtherSyntaxTest() {
+    data["name"] = "Peter";
+    data["city"] = "Brunswick";
+    data["age"] = 29;
+    data["names"] = {"Jeff", "Seb"};
+    data["brother"]["name"] = "Chris";
+    data["brother"]["daughters"] = {"Maria", "Helen"};
+    data["brother"]["daughter0"] = { { "name", "Maria" } };
+    data["is_happy"] = true;
+  }
+};
+
+TEST_F(InjaOtherSyntaxTest, Variables) {
+  env.SetElementNotation(inja::ElementNotation::Dot);
+
+  EXPECT_EQ(env.Render("{{ name }}", data), "Peter");
+  EXPECT_EQ(env.Render("Hello {{ names.1 }}!", data), "Hello Seb!");
+  EXPECT_EQ(env.Render("Hello {{ brother.name }}!", data), "Hello Chris!");
+  EXPECT_EQ(env.Render("Hello {{ brother.daughter0.name }}!", data),
+            "Hello Maria!");
+
+  EXPECT_THROW_MSG(
+      env.Render("{{unknown.name}}", data), std::runtime_error,
+      "[inja.exception.render_error] variable 'unknown.name' not found");
+}
+
+TEST_F(InjaOtherSyntaxTest, OtherExpressionSyntax) {
+  EXPECT_EQ(env.Render("Hello {{ name }}!", data), "Hello Peter!");
+
+  env.SetExpression("(&", "&)");
+
+  EXPECT_EQ(env.Render("Hello {{ name }}!", data), "Hello {{ name }}!");
+  EXPECT_EQ(env.Render("Hello (& name &)!", data), "Hello Peter!");
+}
+
+TEST_F(InjaOtherSyntaxTest, OtherCommentSyntax) {
+  env.SetComment("(&", "&)");
+
+  EXPECT_EQ(env.Render("Hello {# Test #}", data), "Hello {# Test #}");
+  EXPECT_EQ(env.Render("Hello (& Test &)", data), "Hello ");
+}

--- a/wpiutil/src/test/native/cpp/json/unit-json.h
+++ b/wpiutil/src/test/native/cpp/json/unit-json.h
@@ -3,12 +3,15 @@
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
-/*----------------------------------------------------------------------------*/#ifndef UNIT_JSON_H_
+/*----------------------------------------------------------------------------*/
+#ifndef UNIT_JSON_H_
 #define UNIT_JSON_H_
 
 #include <ostream>
 
 #include "wpi/json.h"
+
+#include "TestThrow.h"
 
 namespace wpi {
 
@@ -37,52 +40,5 @@ class JsonTest {
 };
 
 }  // namespace wpi
-
-// clang warns on TEST_THROW_MSG(x == y, ...) saying the result is unused.
-// suppress this warning.
-#if defined(__clang__)
-#pragma GCC diagnostic ignored "-Wunused-comparison"
-#endif
-
-// variant of GTEST_TEST_THROW_ that also checks the exception's message.
-#define TEST_THROW_MSG(statement, expected_exception, expected_msg, fail) \
-  GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
-  if (::testing::internal::ConstCharPtr gtest_msg = "") { \
-    bool gtest_caught_expected = false; \
-    try { \
-      GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement); \
-    } \
-    catch (expected_exception const& gtest_ex) { \
-      gtest_caught_expected = true; \
-      if (::std::string(gtest_ex.what()) != expected_msg) { \
-        ::testing::AssertionResult gtest_ar = ::testing::AssertionFailure(); \
-        gtest_ar \
-            << "Expected: " #statement " throws an exception with message \"" \
-            << expected_msg "\".\n  Actual: it throws message \"" \
-            << gtest_ex.what() << "\"."; \
-        fail(gtest_ar.failure_message()); \
-      } \
-    } \
-    catch (...) { \
-      gtest_msg.value = \
-          "Expected: " #statement " throws an exception of type " \
-          #expected_exception ".\n  Actual: it throws a different type."; \
-      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
-    } \
-    if (!gtest_caught_expected) { \
-      gtest_msg.value = \
-          "Expected: " #statement " throws an exception of type " \
-          #expected_exception ".\n  Actual: it throws nothing."; \
-      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
-    } \
-  } else \
-    GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__): \
-      fail(gtest_msg.value)
-
-#define EXPECT_THROW_MSG(statement, expected_exception, expected_msg) \
-  TEST_THROW_MSG(statement, expected_exception, expected_msg, GTEST_NONFATAL_FAILURE_)
-
-#define ASSERT_THROW_MSG(statement, expected_exception, expected_msg) \
-  TEST_THROW_MSG(statement, expected_exception, expected_msg, GTEST_FATAL_FAILURE_)
 
 #endif

--- a/wpiutil/src/test/native/include/TestThrow.h
+++ b/wpiutil/src/test/native/include/TestThrow.h
@@ -1,0 +1,58 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#ifndef WPIUTIL_TESTTHROW_H_
+#define WPIUTIL_TESTTHROW_H_
+
+// clang warns on TEST_THROW_MSG(x == y, ...) saying the result is unused.
+// suppress this warning.
+#if defined(__clang__)
+#pragma GCC diagnostic ignored "-Wunused-comparison"
+#endif
+
+// variant of GTEST_TEST_THROW_ that also checks the exception's message.
+#define TEST_THROW_MSG(statement, expected_exception, expected_msg, fail) \
+  GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
+  if (::testing::internal::ConstCharPtr gtest_msg = "") { \
+    bool gtest_caught_expected = false; \
+    try { \
+      GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement); \
+    } \
+    catch (expected_exception const& gtest_ex) { \
+      gtest_caught_expected = true; \
+      if (::std::string(gtest_ex.what()) != expected_msg) { \
+        ::testing::AssertionResult gtest_ar = ::testing::AssertionFailure(); \
+        gtest_ar \
+            << "Expected: " #statement " throws an exception with message \"" \
+            << expected_msg "\".\n  Actual: it throws message \"" \
+            << gtest_ex.what() << "\"."; \
+        fail(gtest_ar.failure_message()); \
+      } \
+    } \
+    catch (...) { \
+      gtest_msg.value = \
+          "Expected: " #statement " throws an exception of type " \
+          #expected_exception ".\n  Actual: it throws a different type."; \
+      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
+    } \
+    if (!gtest_caught_expected) { \
+      gtest_msg.value = \
+          "Expected: " #statement " throws an exception of type " \
+          #expected_exception ".\n  Actual: it throws nothing."; \
+      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
+    } \
+  } else \
+    GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__): \
+      fail(gtest_msg.value)
+
+#define EXPECT_THROW_MSG(statement, expected_exception, expected_msg) \
+  TEST_THROW_MSG(statement, expected_exception, expected_msg, GTEST_NONFATAL_FAILURE_)
+
+#define ASSERT_THROW_MSG(statement, expected_exception, expected_msg) \
+  TEST_THROW_MSG(statement, expected_exception, expected_msg, GTEST_FATAL_FAILURE_)
+
+#endif  // WPIUTIL_TESTTHROW_H_


### PR DESCRIPTION
The supported syntax is identical to https://github.com/pantor/inja, and the
user API is similar, but the internals are a from-scratch rewrite with a
handwritten lexer, recursive descent parser, and stack-based machine executor.