### PR TITLE
Don't use symbolic path searching for USB detection

### DIFF
--- a/hal/src/main/native/athena/cpp/SerialHelper.cpp
+++ b/hal/src/main/native/athena/cpp/SerialHelper.cpp
@@ -215,9 +215,11 @@ void SerialHelper::QueryHubPaths(int32_t* status) {
     if (matchString.equals(devNameRef)) continue;
 
     // Search directories to get a list of system accessors
+    // The directories we need are not symbolic, so we can safely
+    // disable symbolic links.
     std::error_code ec;
     for (auto p = wpi::sys::fs::recursive_directory_iterator(
-             "/sys/devices/soc0", ec);
+             "/sys/devices/soc0", ec, false);
          p != wpi::sys::fs::recursive_directory_iterator(); p.increment(ec)) {
       if (ec) break;
       wpi::StringRef path{p->path()};


### PR DESCRIPTION
The USB directories we care about are not symbolic links, so we can ignore them

There was a recursive symbolic link, which was causing failure