### PR TITLE
Fix CAN API's timing out incorrectly

### DIFF
--- a/hal/src/main/native/athena/CANAPI.cpp
+++ b/hal/src/main/native/athena/CANAPI.cpp
@@ -22,7 +22,7 @@ using namespace hal;
 
 namespace {
 struct Receives {
-  uint64_t lastTimeStamp;
+  uint32_t lastTimeStamp;
   uint8_t data[8];
   uint8_t length;
 };
@@ -40,30 +40,13 @@ struct CANStorage {
 static UnlimitedHandleResource<HAL_CANHandle, CANStorage, HAL_HandleEnum::CAN>*
     canHandles;
 
-static std::atomic_bool HasFixedTime{false};
-static uint64_t timeSpanDiff;
-
-static void CheckDeltaTime() {
-  if (HasFixedTime) return;
-  HasFixedTime = true;
-
-  // TODO: Fix locking
+static uint32_t GetPacketBaseTime() {
   timespec t;
   clock_gettime(CLOCK_MONOTONIC, &t);
 
-  int32_t status = 0;
-  uint64_t fpgaTime = HAL_GetFPGATime(&status);
-
-  // Convert t to microseconds
-  uint64_t us = t.tv_sec * 1000000ull + t.tv_nsec / 1000ull;
-
-  timeSpanDiff =
-      us - fpgaTime;  // This assumes CLOCK_MONOTONIC is greater then FPGA Time.
-}
-
-static inline uint64_t ConvertToFPGATime(uint32_t canMs) {
-  uint64_t canMsToUs = canMs * 1000ull;
-  return canMsToUs - timeSpanDiff;
+  // Convert t to milliseconds
+  uint64_t ms = t.tv_sec * 1000ull + t.tv_nsec / 1000000ull;
+  return ms & 0xFFFFFFFF;
 }
 
 namespace hal {
@@ -89,7 +72,6 @@ HAL_CANHandle HAL_InitializeCAN(HAL_CANManufacturer manufacturer,
                                 int32_t deviceId, HAL_CANDeviceType deviceType,
                                 int32_t* status) {
   hal::init::CheckInit();
-  CheckDeltaTime();
   auto can = std::make_shared<CANStorage>();
 
   auto handle = canHandles->Allocate(can);
@@ -189,18 +171,16 @@ void HAL_ReadCANPacketNew(HAL_CANHandle handle, int32_t apiId, uint8_t* data,
   uint32_t ts = 0;
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
-  uint64_t timestamp = ConvertToFPGATime(ts);
-
   if (*status == 0) {
     std::lock_guard<wpi::mutex> lock(can->mapMutex);
     auto& msg = can->receives[messageId];
     msg.length = dataSize;
-    msg.lastTimeStamp = timestamp;
+    msg.lastTimeStamp = ts;
     // The NetComm call placed in data, copy into the msg
     std::memcpy(msg.data, data, dataSize);
   }
   *length = dataSize;
-  *receivedTimestamp = timestamp;
+  *receivedTimestamp = ts;
 }
 
 void HAL_ReadCANPacketLatest(HAL_CANHandle handle, int32_t apiId, uint8_t* data,
@@ -217,16 +197,14 @@ void HAL_ReadCANPacketLatest(HAL_CANHandle handle, int32_t apiId, uint8_t* data,
   uint32_t ts = 0;
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
-  uint64_t timestamp = ConvertToFPGATime(ts);
-
   std::lock_guard<wpi::mutex> lock(can->mapMutex);
   if (*status == 0) {
     // fresh update
     auto& msg = can->receives[messageId];
     msg.length = dataSize;
     *length = dataSize;
-    msg.lastTimeStamp = timestamp;
-    *receivedTimestamp = timestamp;
+    msg.lastTimeStamp = ts;
+    *receivedTimestamp = ts;
     // The NetComm call placed in data, copy into the msg
     std::memcpy(msg.data, data, dataSize);
   } else {
@@ -256,26 +234,22 @@ void HAL_ReadCANPacketTimeout(HAL_CANHandle handle, int32_t apiId,
   uint32_t ts = 0;
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
-  uint64_t timestamp = ConvertToFPGATime(ts);
-
   std::lock_guard<wpi::mutex> lock(can->mapMutex);
   if (*status == 0) {
     // fresh update
     auto& msg = can->receives[messageId];
     msg.length = dataSize;
     *length = dataSize;
-    msg.lastTimeStamp = timestamp;
-    *receivedTimestamp = timestamp;
+    msg.lastTimeStamp = ts;
+    *receivedTimestamp = ts;
     // The NetComm call placed in data, copy into the msg
     std::memcpy(msg.data, data, dataSize);
   } else {
     auto i = can->receives.find(messageId);
     if (i != can->receives.end()) {
       // Found, check if new enough
-      *status = 0;
-      uint64_t now = HAL_GetFPGATime(status);
-      if (now - i->second.lastTimeStamp >
-          static_cast<uint64_t>(timeoutMs) * 1000) {
+      uint32_t now = GetPacketBaseTime();
+      if (now - i->second.lastTimeStamp > timeoutMs) {
         // Timeout, return bad status
         *status = HAL_CAN_TIMEOUT;
         return;
@@ -305,11 +279,9 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
     std::lock_guard<wpi::mutex> lock(can->mapMutex);
     auto i = can->receives.find(messageId);
     if (i != can->receives.end()) {
-      *status = 0;
-      uint64_t now = HAL_GetFPGATime(status);
       // Found, check if new enough
-      if (now - i->second.lastTimeStamp <
-          static_cast<uint64_t>(periodMs) * 1000) {
+      uint32_t now = GetPacketBaseTime();
+      if (now - i->second.lastTimeStamp > timeoutMs) {
         *status = 0;
         // Read the data from the stored message into the output
         std::memcpy(data, i->second.data, i->second.length);
@@ -324,26 +296,22 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
   uint32_t ts = 0;
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
-  uint64_t timestamp = ConvertToFPGATime(ts);
-
   std::lock_guard<wpi::mutex> lock(can->mapMutex);
   if (*status == 0) {
     // fresh update
     auto& msg = can->receives[messageId];
     msg.length = dataSize;
     *length = dataSize;
-    msg.lastTimeStamp = timestamp;
-    *receivedTimestamp = timestamp;
+    msg.lastTimeStamp = ts;
+    *receivedTimestamp = ts;
     // The NetComm call placed in data, copy into the msg
     std::memcpy(msg.data, data, dataSize);
   } else {
     auto i = can->receives.find(messageId);
     if (i != can->receives.end()) {
       // Found, check if new enough
-      *status = 0;
-      uint64_t now = HAL_GetFPGATime(status);
-      if (now - i->second.lastTimeStamp >
-          static_cast<uint64_t>(timeoutMs) * 1000) {
+      uint32_t now = GetPacketBaseTime();
+      if (now - i->second.lastTimeStamp > timeoutMs) {
         // Timeout, return bad status
         *status = HAL_CAN_TIMEOUT;
         return;

--- a/hal/src/main/native/athena/CANAPI.cpp
+++ b/hal/src/main/native/athena/CANAPI.cpp
@@ -249,7 +249,7 @@ void HAL_ReadCANPacketTimeout(HAL_CANHandle handle, int32_t apiId,
     if (i != can->receives.end()) {
       // Found, check if new enough
       uint32_t now = GetPacketBaseTime();
-      if (now - i->second.lastTimeStamp > timeoutMs) {
+      if (now - i->second.lastTimeStamp > static_cast<uint32_t>(timeoutMs)) {
         // Timeout, return bad status
         *status = HAL_CAN_TIMEOUT;
         return;
@@ -281,12 +281,12 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
     if (i != can->receives.end()) {
       // Found, check if new enough
       uint32_t now = GetPacketBaseTime();
-      if (now - i->second.lastTimeStamp > timeoutMs) {
-        *status = 0;
+      if (now - i->second.lastTimeStamp > static_cast<uint32_t>(periodMs)) {
         // Read the data from the stored message into the output
         std::memcpy(data, i->second.data, i->second.length);
         *length = i->second.length;
         *receivedTimestamp = i->second.lastTimeStamp;
+        *status = 0;
         return;
       }
     }
@@ -311,7 +311,7 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
     if (i != can->receives.end()) {
       // Found, check if new enough
       uint32_t now = GetPacketBaseTime();
-      if (now - i->second.lastTimeStamp > timeoutMs) {
+      if (now - i->second.lastTimeStamp > static_cast<uint32_t>(timeoutMs)) {
         // Timeout, return bad status
         *status = HAL_CAN_TIMEOUT;
         return;

--- a/hal/src/main/native/athena/CANAPI.cpp
+++ b/hal/src/main/native/athena/CANAPI.cpp
@@ -55,14 +55,14 @@ static void CheckDeltaTime() {
   uint64_t fpgaTime = HAL_GetFPGATime(&status);
 
   // Convert t to microseconds
-  uint64_t us = t.tv_sec * 1000000 + t.tv_nsec / 1000;
+  uint64_t us = t.tv_sec * 1000000ull + t.tv_nsec / 1000ull;
 
   timeSpanDiff =
       us - fpgaTime;  // This assumes CLOCK_MONOTONIC is greater then FPGA Time.
 }
 
 static inline uint64_t ConvertToFPGATime(uint32_t canMs) {
-  uint64_t canMsToUs = canMs * 1000;
+  uint64_t canMsToUs = canMs * 1000ull;
   return canMsToUs - timeSpanDiff;
 }
 

--- a/hal/src/main/native/athena/CANAPI.cpp
+++ b/hal/src/main/native/athena/CANAPI.cpp
@@ -272,6 +272,7 @@ void HAL_ReadCANPacketTimeout(HAL_CANHandle handle, int32_t apiId,
     auto i = can->receives.find(messageId);
     if (i != can->receives.end()) {
       // Found, check if new enough
+      *status = 0;
       uint64_t now = HAL_GetFPGATime(status);
       if (now - i->second.lastTimeStamp >
           static_cast<uint64_t>(timeoutMs) * 1000) {
@@ -304,6 +305,7 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
     std::lock_guard<wpi::mutex> lock(can->mapMutex);
     auto i = can->receives.find(messageId);
     if (i != can->receives.end()) {
+      *status = 0;
       uint64_t now = HAL_GetFPGATime(status);
       // Found, check if new enough
       if (now - i->second.lastTimeStamp <
@@ -338,6 +340,7 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
     auto i = can->receives.find(messageId);
     if (i != can->receives.end()) {
       // Found, check if new enough
+      *status = 0;
       uint64_t now = HAL_GetFPGATime(status);
       if (now - i->second.lastTimeStamp >
           static_cast<uint64_t>(timeoutMs) * 1000) {

--- a/hal/src/main/native/athena/CANAPI.cpp
+++ b/hal/src/main/native/athena/CANAPI.cpp
@@ -281,7 +281,7 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
     if (i != can->receives.end()) {
       // Found, check if new enough
       uint32_t now = GetPacketBaseTime();
-      if (now - i->second.lastTimeStamp > static_cast<uint32_t>(periodMs)) {
+      if (now - i->second.lastTimeStamp < static_cast<uint32_t>(periodMs)) {
         // Read the data from the stored message into the output
         std::memcpy(data, i->second.data, i->second.length);
         *length = i->second.length;

--- a/hal/src/main/native/athena/HAL.cpp
+++ b/hal/src/main/native/athena/HAL.cpp
@@ -239,7 +239,7 @@ uint64_t HAL_GetFPGATime(int32_t* status) {
     *status = NiFpga_Status_ResourceNotInitialized;
     return 0;
   }
-
+  *status = 0;
   uint64_t upper1 = global->readLocalTimeUpper(status);
   uint32_t lower = global->readLocalTime(status);
   uint64_t upper2 = global->readLocalTimeUpper(status);

--- a/hal/src/main/native/athena/PDP.cpp
+++ b/hal/src/main/native/athena/PDP.cpp
@@ -31,7 +31,7 @@ static constexpr int32_t StatusEnergy = 0x5D;
 
 static constexpr int32_t Control1 = 0x70;
 
-static constexpr int32_t TimeoutMs = 50;
+static constexpr int32_t TimeoutMs = 255;
 static constexpr int32_t StatusPeriodMs = 25;
 
 /* encoder/decoders */

--- a/hal/src/main/native/athena/PDP.cpp
+++ b/hal/src/main/native/athena/PDP.cpp
@@ -31,7 +31,7 @@ static constexpr int32_t StatusEnergy = 0x5D;
 
 static constexpr int32_t Control1 = 0x70;
 
-static constexpr int32_t TimeoutMs = 255;
+static constexpr int32_t TimeoutMs = 100;
 static constexpr int32_t StatusPeriodMs = 25;
 
 /* encoder/decoders */

--- a/hal/src/main/native/sim/CANAPI.cpp
+++ b/hal/src/main/native/sim/CANAPI.cpp
@@ -258,7 +258,7 @@ void HAL_ReadCANPacketTimeout(HAL_CANHandle handle, int32_t apiId,
     if (i != can->receives.end()) {
       // Found, check if new enough
       uint32_t now = GetPacketBaseTime();
-      if (now - i->second.lastTimeStamp > timeoutMs) {
+      if (now - i->second.lastTimeStamp > static_cast<uint32_t>(timeoutMs)) {
         // Timeout, return bad status
         *status = HAL_CAN_TIMEOUT;
         return;
@@ -290,7 +290,7 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
     if (i != can->receives.end()) {
       // Found, check if new enough
       uint32_t now = GetPacketBaseTime();
-      if (now - i->second.lastTimeStamp > timeoutMs) {
+      if (now - i->second.lastTimeStamp > static_cast<uint32_t>(periodMs)) {
         *status = 0;
         // Read the data from the stored message into the output
         std::memcpy(data, i->second.data, i->second.length);
@@ -320,7 +320,7 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
     if (i != can->receives.end()) {
       // Found, check if new enough
       uint32_t now = GetPacketBaseTime();
-      if (now - i->second.lastTimeStamp > timeoutMs) {
+      if (now - i->second.lastTimeStamp > static_cast<uint32_t>(timeoutMs)) {
         // Timeout, return bad status
         *status = HAL_CAN_TIMEOUT;
         return;

--- a/hal/src/main/native/sim/CANAPI.cpp
+++ b/hal/src/main/native/sim/CANAPI.cpp
@@ -41,13 +41,11 @@ struct CANStorage {
 static UnlimitedHandleResource<HAL_CANHandle, CANStorage, HAL_HandleEnum::CAN>*
     canHandles;
 
-static void CheckDeltaTime() {
-  // Noop on sim
-}
-
-static inline uint64_t ConvertToFPGATime(uint32_t canMs) {
-  uint64_t canMsToUs = canMs * 1000;
-  return canMsToUs;
+static uint32_t GetPacketBaseTime() {
+  int status = 0;
+  auto basetime = HAL_GetFPGATime(&status);
+  // us to ms
+  return (status / 1000ull) & 0xFFFFFFFF;
 }
 
 namespace hal {
@@ -83,7 +81,6 @@ HAL_CANHandle HAL_InitializeCAN(HAL_CANManufacturer manufacturer,
                                 int32_t deviceId, HAL_CANDeviceType deviceType,
                                 int32_t* status) {
   hal::init::CheckInit();
-  CheckDeltaTime();
   auto can = std::make_shared<CANStorage>();
 
   auto handle = canHandles->Allocate(can);
@@ -183,18 +180,16 @@ void HAL_ReadCANPacketNew(HAL_CANHandle handle, int32_t apiId, uint8_t* data,
   uint32_t ts = 0;
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
-  uint64_t timestamp = ConvertToFPGATime(ts);
-
   if (*status == 0) {
     std::lock_guard<wpi::mutex> lock(can->mapMutex);
     auto& msg = can->receives[messageId];
     msg.length = dataSize;
-    msg.lastTimeStamp = timestamp;
+    msg.lastTimeStamp = ts;
     // The NetComm call placed in data, copy into the msg
     std::memcpy(msg.data, data, dataSize);
   }
   *length = dataSize;
-  *receivedTimestamp = timestamp;
+  *receivedTimestamp = ts;
 }
 
 void HAL_ReadCANPacketLatest(HAL_CANHandle handle, int32_t apiId, uint8_t* data,
@@ -211,16 +206,14 @@ void HAL_ReadCANPacketLatest(HAL_CANHandle handle, int32_t apiId, uint8_t* data,
   uint32_t ts = 0;
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
-  uint64_t timestamp = ConvertToFPGATime(ts);
-
   std::lock_guard<wpi::mutex> lock(can->mapMutex);
   if (*status == 0) {
     // fresh update
     auto& msg = can->receives[messageId];
     msg.length = dataSize;
     *length = dataSize;
-    msg.lastTimeStamp = timestamp;
-    *receivedTimestamp = timestamp;
+    msg.lastTimeStamp = ts;
+    *receivedTimestamp = ts;
     // The NetComm call placed in data, copy into the msg
     std::memcpy(msg.data, data, dataSize);
   } else {
@@ -250,26 +243,22 @@ void HAL_ReadCANPacketTimeout(HAL_CANHandle handle, int32_t apiId,
   uint32_t ts = 0;
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
-  uint64_t timestamp = ConvertToFPGATime(ts);
-
   std::lock_guard<wpi::mutex> lock(can->mapMutex);
   if (*status == 0) {
     // fresh update
     auto& msg = can->receives[messageId];
     msg.length = dataSize;
     *length = dataSize;
-    msg.lastTimeStamp = timestamp;
-    *receivedTimestamp = timestamp;
+    msg.lastTimeStamp = ts;
+    *receivedTimestamp = ts;
     // The NetComm call placed in data, copy into the msg
     std::memcpy(msg.data, data, dataSize);
   } else {
     auto i = can->receives.find(messageId);
     if (i != can->receives.end()) {
       // Found, check if new enough
-      *status = 0;
-      uint64_t now = HAL_GetFPGATime(status);
-      if (now - i->second.lastTimeStamp >
-          static_cast<uint64_t>(timeoutMs) * 1000) {
+      uint32_t now = GetPacketBaseTime();
+      if (now - i->second.lastTimeStamp > timeoutMs) {
         // Timeout, return bad status
         *status = HAL_CAN_TIMEOUT;
         return;
@@ -299,11 +288,9 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
     std::lock_guard<wpi::mutex> lock(can->mapMutex);
     auto i = can->receives.find(messageId);
     if (i != can->receives.end()) {
-      *status = 0;
-      uint64_t now = HAL_GetFPGATime(status);
       // Found, check if new enough
-      if (now - i->second.lastTimeStamp <
-          static_cast<uint64_t>(periodMs) * 1000) {
+      uint32_t now = GetPacketBaseTime();
+      if (now - i->second.lastTimeStamp > timeoutMs) {
         *status = 0;
         // Read the data from the stored message into the output
         std::memcpy(data, i->second.data, i->second.length);
@@ -318,26 +305,22 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
   uint32_t ts = 0;
   HAL_CAN_ReceiveMessage(&messageId, 0x1FFFFFFF, data, &dataSize, &ts, status);
 
-  uint64_t timestamp = ConvertToFPGATime(ts);
-
   std::lock_guard<wpi::mutex> lock(can->mapMutex);
   if (*status == 0) {
     // fresh update
     auto& msg = can->receives[messageId];
     msg.length = dataSize;
     *length = dataSize;
-    msg.lastTimeStamp = timestamp;
-    *receivedTimestamp = timestamp;
+    msg.lastTimeStamp = ts;
+    *receivedTimestamp = ts;
     // The NetComm call placed in data, copy into the msg
     std::memcpy(msg.data, data, dataSize);
   } else {
     auto i = can->receives.find(messageId);
     if (i != can->receives.end()) {
       // Found, check if new enough
-      *status = 0;
-      uint64_t now = HAL_GetFPGATime(status);
-      if (now - i->second.lastTimeStamp >
-          static_cast<uint64_t>(timeoutMs) * 1000) {
+      uint32_t now = GetPacketBaseTime();
+      if (now - i->second.lastTimeStamp > timeoutMs) {
         // Timeout, return bad status
         *status = HAL_CAN_TIMEOUT;
         return;

--- a/hal/src/main/native/sim/CANAPI.cpp
+++ b/hal/src/main/native/sim/CANAPI.cpp
@@ -266,6 +266,7 @@ void HAL_ReadCANPacketTimeout(HAL_CANHandle handle, int32_t apiId,
     auto i = can->receives.find(messageId);
     if (i != can->receives.end()) {
       // Found, check if new enough
+      *status = 0;
       uint64_t now = HAL_GetFPGATime(status);
       if (now - i->second.lastTimeStamp >
           static_cast<uint64_t>(timeoutMs) * 1000) {
@@ -298,6 +299,7 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
     std::lock_guard<wpi::mutex> lock(can->mapMutex);
     auto i = can->receives.find(messageId);
     if (i != can->receives.end()) {
+      *status = 0;
       uint64_t now = HAL_GetFPGATime(status);
       // Found, check if new enough
       if (now - i->second.lastTimeStamp <
@@ -332,6 +334,7 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
     auto i = can->receives.find(messageId);
     if (i != can->receives.end()) {
       // Found, check if new enough
+      *status = 0;
       uint64_t now = HAL_GetFPGATime(status);
       if (now - i->second.lastTimeStamp >
           static_cast<uint64_t>(timeoutMs) * 1000) {

--- a/hal/src/main/native/sim/CANAPI.cpp
+++ b/hal/src/main/native/sim/CANAPI.cpp
@@ -45,7 +45,7 @@ static uint32_t GetPacketBaseTime() {
   int status = 0;
   auto basetime = HAL_GetFPGATime(&status);
   // us to ms
-  return (status / 1000ull) & 0xFFFFFFFF;
+  return (basetime / 1000ull) & 0xFFFFFFFF;
 }
 
 namespace hal {

--- a/hal/src/main/native/sim/CANAPI.cpp
+++ b/hal/src/main/native/sim/CANAPI.cpp
@@ -290,7 +290,7 @@ void HAL_ReadCANPeriodicPacket(HAL_CANHandle handle, int32_t apiId,
     if (i != can->receives.end()) {
       // Found, check if new enough
       uint32_t now = GetPacketBaseTime();
-      if (now - i->second.lastTimeStamp > static_cast<uint32_t>(periodMs)) {
+      if (now - i->second.lastTimeStamp < static_cast<uint32_t>(periodMs)) {
         *status = 0;
         // Read the data from the stored message into the output
         std::memcpy(data, i->second.data, i->second.length);

--- a/wpilibcIntegrationTests/src/main/native/cpp/PowerDistributionPanelTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/PowerDistributionPanelTest.cpp
@@ -12,6 +12,7 @@
 #include "frc/Talon.h"
 #include "frc/Timer.h"
 #include "frc/Victor.h"
+#include "hal/Ports.h"
 #include "gtest/gtest.h"
 
 using namespace frc;
@@ -39,6 +40,20 @@ class PowerDistributionPanelTest : public testing::Test {
     delete m_jaguar;
   }
 };
+
+TEST_F(PowerDistributionPanelTest, CheckRepeatedCalls) {
+  auto numChannels = HAL_GetNumPDPChannels();
+  // 1 second
+  for (int i = 0; i < 50; i++) {
+    for (int j = 0; j < numChannels; j++) {
+      m_pdp->GetCurrent(j);
+      ASSERT_TRUE(m_pdp->GetError().GetCode() == 0);
+    }
+    m_pdp->GetVoltage();
+    ASSERT_TRUE(m_pdp->GetError().GetCode() == 0);
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+}
 
 /**
  * Test if the current changes when the motor is driven using a talon

--- a/wpilibcIntegrationTests/src/main/native/cpp/PowerDistributionPanelTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/PowerDistributionPanelTest.cpp
@@ -7,12 +7,13 @@
 
 #include "frc/PowerDistributionPanel.h"  // NOLINT(build/include_order)
 
+#include <hal/Ports.h>
+
 #include "TestBench.h"
 #include "frc/Jaguar.h"
 #include "frc/Talon.h"
 #include "frc/Timer.h"
 #include "frc/Victor.h"
-#include "hal/Ports.h"
 #include "gtest/gtest.h"
 
 using namespace frc;


### PR DESCRIPTION
HAL_GetFPGATime returns 0 if it starts with a non zero status