### PR TITLE
Default to DS attached to true in sim

### DIFF
--- a/hal/src/main/native/sim/mockdata/DriverStationData.cpp
+++ b/hal/src/main/native/sim/mockdata/DriverStationData.cpp
@@ -41,7 +41,7 @@ void DriverStationData::ResetData() {
   test.Reset(false);
   eStop.Reset(false);
   fmsAttached.Reset(false);
-  dsAttached.Reset(false);
+  dsAttached.Reset(true);
   allianceStationId.Reset(static_cast<HAL_AllianceStationID>(0));
   matchTime.Reset(0.0);
 

--- a/hal/src/main/native/sim/mockdata/DriverStationDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/DriverStationDataInternal.h
@@ -63,7 +63,7 @@ class DriverStationData {
   SimDataValue<HAL_Bool, MakeBoolean, GetTestName> test{false};
   SimDataValue<HAL_Bool, MakeBoolean, GetEStopName> eStop{false};
   SimDataValue<HAL_Bool, MakeBoolean, GetFmsAttachedName> fmsAttached{false};
-  SimDataValue<HAL_Bool, MakeBoolean, GetDsAttachedName> dsAttached{false};
+  SimDataValue<HAL_Bool, MakeBoolean, GetDsAttachedName> dsAttached{true};
   SimDataValue<HAL_AllianceStationID, MakeAllianceStationIdValue,
                GetAllianceStationIdName>
       allianceStationId{static_cast<HAL_AllianceStationID>(0)};


### PR DESCRIPTION
Otherwise, it is required to be set manually, which isn't obvious.

This is because the HighLevel DS classes check that the ds is attached before enabling