### PR TITLE
Move deprecation warning for SampleRobot to constructor

### DIFF
--- a/wpilibc/src/main/native/include/frc/SampleRobot.h
+++ b/wpilibc/src/main/native/include/frc/SampleRobot.h
@@ -13,11 +13,7 @@
 
 namespace frc {
 
-class WPI_DEPRECATED(
-    "WARNING: While it may look like a good choice to use for your code if "
-    "you're inexperienced, don't. Unless you know what you are doing, complex "
-    "code will be much more difficult under this system. Use TimedRobot or "
-    "Command-Based instead.") SampleRobot : public RobotBase {
+class SampleRobot : public RobotBase {
  public:
   /**
    * Start a competition.
@@ -95,6 +91,11 @@ class WPI_DEPRECATED(
   virtual void RobotMain();
 
  protected:
+  WPI_DEPRECATED(
+      "WARNING: While it may look like a good choice to use for your code if "
+      "you're inexperienced, don't. Unless you know what you are doing, "
+      "complex code will be much more difficult under this system. Use "
+      "TimedRobot or Command-Based instead.")
   SampleRobot();
   virtual ~SampleRobot() = default;
 


### PR DESCRIPTION
This way, the warning doesn't occur when including wpilib.h

Closes #1501