### PR TITLE
Move deprecated message in C++ from class level to constructor

### DIFF
--- a/wpilibc/src/main/native/include/frc/GamepadBase.h
+++ b/wpilibc/src/main/native/include/frc/GamepadBase.h
@@ -16,9 +16,9 @@ namespace frc {
 /**
  * Gamepad Interface.
  */
-class WPI_DEPRECATED("Inherit directly from GenericHID instead.") GamepadBase
-    : public GenericHID {
+class GamepadBase : public GenericHID {
  public:
+  WPI_DEPRECATED("Inherit directly from GenericHID instead.")
   explicit GamepadBase(int port);
   virtual ~GamepadBase() = default;
 

--- a/wpilibc/src/main/native/include/frc/JoystickBase.h
+++ b/wpilibc/src/main/native/include/frc/JoystickBase.h
@@ -16,9 +16,9 @@ namespace frc {
 /**
  * Joystick Interface.
  */
-class WPI_DEPRECATED("Inherit directly from GenericHID instead.") JoystickBase
-    : public GenericHID {
+class JoystickBase : public GenericHID {
  public:
+  WPI_DEPRECATED("Inherit directly from GenericHID instead.")
   explicit JoystickBase(int port);
   virtual ~JoystickBase() = default;
 

--- a/wpilibc/src/main/native/include/frc/livewindow/LiveWindowSendable.h
+++ b/wpilibc/src/main/native/include/frc/livewindow/LiveWindowSendable.h
@@ -19,9 +19,9 @@ namespace frc {
  * Live Window Sendable is a special type of object sendable to the live window.
  * @deprecated Use Sendable directly instead
  */
-class WPI_DEPRECATED("use Sendable directly instead") LiveWindowSendable
-    : public Sendable {
+class LiveWindowSendable : public Sendable {
  public:
+  WPI_DEPRECATED("use Sendable directly instead")
   LiveWindowSendable() = default;
   LiveWindowSendable(LiveWindowSendable&&) = default;
   LiveWindowSendable& operator=(LiveWindowSendable&&) = default;

--- a/wpilibc/src/main/native/include/frc/smartdashboard/NamedSendable.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/NamedSendable.h
@@ -20,9 +20,11 @@ namespace frc {
  * the Smart Dashboard.
  * @deprecated Use Sendable directly instead
  */
-class WPI_DEPRECATED("use Sendable directly instead") NamedSendable
-    : public Sendable {
+class NamedSendable : public Sendable {
  public:
+  WPI_DEPRECATED("use Sendable directly instead")
+  NamedSendable() = default;
+
   void SetName(const wpi::Twine& name) override;
   std::string GetSubsystem() const override;
   void SetSubsystem(const wpi::Twine& subsystem) override;


### PR DESCRIPTION
This prevents deprecation messages when including a header but not
instantiating the class. SampleRobot was addressed by #1503.