### PR TITLE
Only write version information on real robot

### DIFF
--- a/wpilibc/src/main/native/cpp/RobotBase.cpp
+++ b/wpilibc/src/main/native/cpp/RobotBase.cpp
@@ -98,13 +98,15 @@ RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
 
   SmartDashboard::init();
 
-  std::FILE* file = nullptr;
-  file = std::fopen("/tmp/frc_versions/FRC_Lib_Version.ini", "w");
+  if (IsReal()) {
+    std::FILE* file = nullptr;
+    file = std::fopen("/tmp/frc_versions/FRC_Lib_Version.ini", "w");
 
-  if (file != nullptr) {
-    std::fputs("C++ ", file);
-    std::fputs(GetWPILibVersion(), file);
-    std::fclose(file);
+    if (file != nullptr) {
+      std::fputs("C++ ", file);
+      std::fputs(GetWPILibVersion(), file);
+      std::fclose(file);
+    }
   }
 
   // First and one-time initialization

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -237,23 +237,25 @@ public abstract class RobotBase implements AutoCloseable {
       return;
     }
 
-    try {
-      final File file = new File("/tmp/frc_versions/FRC_Lib_Version.ini");
+    if (isReal()) {
+      try {
+        final File file = new File("/tmp/frc_versions/FRC_Lib_Version.ini");
 
-      if (file.exists()) {
-        file.delete();
+        if (file.exists()) {
+          file.delete();
+        }
+
+        file.createNewFile();
+
+        try (OutputStream output = Files.newOutputStream(file.toPath())) {
+          output.write("Java ".getBytes(StandardCharsets.UTF_8));
+          output.write(WPILibVersion.Version.getBytes(StandardCharsets.UTF_8));
+        }
+
+      } catch (IOException ex) {
+        DriverStation.reportError("Could not write FRC_Lib_Version.ini: " + ex.toString(),
+                ex.getStackTrace());
       }
-
-      file.createNewFile();
-
-      try (OutputStream output = Files.newOutputStream(file.toPath())) {
-        output.write("Java ".getBytes(StandardCharsets.UTF_8));
-        output.write(WPILibVersion.Version.getBytes(StandardCharsets.UTF_8));
-      }
-
-    } catch (IOException ex) {
-      DriverStation.reportError("Could not write FRC_Lib_Version.ini: " + ex.toString(),
-          ex.getStackTrace());
     }
 
     boolean errorOnExit = false;


### PR DESCRIPTION
Writing to the versions file throws an exception while simulating on Windows and might write weird files on Linux.

Fixes https://github.com/wpilibsuite/allwpilib/issues/1455