### PR TITLE
Enable timeout message suppression in C++ MotorSafety class

### DIFF
--- a/wpilibc/src/main/native/cpp/MotorSafety.cpp
+++ b/wpilibc/src/main/native/cpp/MotorSafety.cpp
@@ -16,6 +16,8 @@
 
 using namespace frc;
 
+MotorSafety::MotorSafety() { m_watchdog.SuppressTimeoutMessage(true); }
+
 MotorSafety::MotorSafety(MotorSafety&& rhs)
     : ErrorBase(std::move(rhs)), m_enabled(std::move(rhs.m_enabled)) {
   m_watchdog = Watchdog(rhs.m_watchdog.GetTimeout(), [this] { TimeoutFunc(); });

--- a/wpilibc/src/main/native/include/frc/MotorSafety.h
+++ b/wpilibc/src/main/native/include/frc/MotorSafety.h
@@ -25,7 +25,7 @@ namespace frc {
  */
 class MotorSafety : public ErrorBase {
  public:
-  MotorSafety() = default;
+  MotorSafety();
   virtual ~MotorSafety() = default;
 
   MotorSafety(MotorSafety&& rhs);


### PR DESCRIPTION
wpilibj's default constructor is already correct.