### PR TITLE
ntcore: Strip whitespace from IP addresses

### DIFF
--- a/ntcore/src/main/native/cpp/Dispatcher.cpp
+++ b/ntcore/src/main/native/cpp/Dispatcher.cpp
@@ -20,19 +20,27 @@
 
 using namespace nt;
 
+std::string strip_whitespace(std::string str) {
+  str.erase(std::remove(str.begin(), str.end(), ' '), str.end());
+  return str;
+}
+
 void Dispatcher::StartServer(const Twine& persist_filename,
                              const char* listen_address, unsigned int port) {
+  std::string listen_address_copy(listen_address);
   DispatcherBase::StartServer(
       persist_filename,
       std::unique_ptr<wpi::NetworkAcceptor>(new wpi::TCPAcceptor(
-          static_cast<int>(port), listen_address, m_logger)));
+          static_cast<int>(port), strip_whitespace(listen_address_copy).c_str(),
+          m_logger)));
 }
 
 void Dispatcher::SetServer(const char* server_name, unsigned int port) {
   std::string server_name_copy(server_name);
   SetConnector([=]() -> std::unique_ptr<wpi::NetworkStream> {
-    return wpi::TCPConnector::connect(server_name_copy.c_str(),
-                                      static_cast<int>(port), m_logger, 1);
+    return wpi::TCPConnector::connect(
+        strip_whitespace(server_name_copy).c_str(), static_cast<int>(port),
+        m_logger, 1);
   });
 }
 
@@ -40,7 +48,7 @@ void Dispatcher::SetServer(
     ArrayRef<std::pair<StringRef, unsigned int>> servers) {
   wpi::SmallVector<std::pair<std::string, int>, 16> servers_copy;
   for (const auto& server : servers)
-    servers_copy.emplace_back(std::string{server.first},
+    servers_copy.emplace_back(strip_whitespace(std::string{server.first}),
                               static_cast<int>(server.second));
 
   SetConnector([=]() -> std::unique_ptr<wpi::NetworkStream> {
@@ -96,8 +104,9 @@ void Dispatcher::SetServerTeam(unsigned int team, unsigned int port) {
 void Dispatcher::SetServerOverride(const char* server_name, unsigned int port) {
   std::string server_name_copy(server_name);
   SetConnectorOverride([=]() -> std::unique_ptr<wpi::NetworkStream> {
-    return wpi::TCPConnector::connect(server_name_copy.c_str(),
-                                      static_cast<int>(port), m_logger, 1);
+    return wpi::TCPConnector::connect(
+        strip_whitespace(server_name_copy).c_str(), static_cast<int>(port),
+        m_logger, 1);
   });
 }
 

--- a/ntcore/src/test/java/edu/wpi/first/networktables/ConnectionListenerTest.java
+++ b/ntcore/src/test/java/edu/wpi/first/networktables/ConnectionListenerTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -112,16 +114,16 @@ class ConnectionListenerTest {
 
   }
 
-  @Test
-  @DisabledOnOs(OS.WINDOWS)
+  @ParameterizedTest
   @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
-  void testThreaded() {
-    m_serverInst.startServer("connectionlistenertest.ini", "127.0.0.1", 10000);
+  @ValueSource(strings = { "127.0.0.1", "127.0.0.1 ", " 1 27. 0 .0.1 " })
+  void testThreaded(String address) {
+    m_serverInst.startServer("connectionlistenertest.ini", address, 10000);
     List<ConnectionNotification> events = new ArrayList<>();
     final int handle = m_serverInst.addConnectionListener(events::add, false);
 
     // trigger a connect event
-    m_clientInst.startClient("127.0.0.1", 10000);
+    m_clientInst.startClient(address, 10000);
 
     // wait for client to report it's started, then wait another 0.1 sec
     try {


### PR DESCRIPTION
Closes https://github.com/wpilibsuite/allwpilib/issues/1514
Closes https://github.com/wpilibsuite/shuffleboard/issues/356

Connecting to "127.0.0.1", "127.0.0.1 " and " 1 27. 0 .0.1 " respectively:

| Before stripping | After stripping |
|-----------------|----------------|
| ![wo-strip](https://user-images.githubusercontent.com/10191084/50510602-33377280-0a3f-11e9-9fc5-7763d80f863d.PNG) | ![w-strip](https://user-images.githubusercontent.com/10191084/50510605-37639000-0a3f-11e9-9b99-07296f78e58c.PNG) |
