### PR TITLE
Add command loop timing telemetry

### DIFF
--- a/wpilibc/src/main/native/include/frc/commands/Command.h
+++ b/wpilibc/src/main/native/include/frc/commands/Command.h
@@ -243,6 +243,22 @@ class Command : public ErrorBase, public SendableBase {
   CommandGroup* GetGroup() const;
 
   /**
+   * Returns the amount of time taken to initialize this command. If the command
+   * is not yet initialized, returns -1.
+   *
+   * @return the amount of time taken to initialize this command
+   */
+  double GetInitializeTime() const;
+
+  /**
+   * Returns the amount of time taken to run the execute method. If the command
+   * has not yet been started, returns -1.
+   *
+   * @return the amount of time taken to execute this command
+   */
+  double GetExecuteTime() const;
+
+  /**
    * Sets whether or not this Command should run when the robot is disabled.
    *
    * By default a command will not run when the robot is disabled, and will in
@@ -423,6 +439,12 @@ class Command : public ErrorBase, public SendableBase {
 
   // The time (in seconds) before this command "times out" (-1 if no timeout)
   double m_timeout;
+
+  // The time (in seconds) taken for the command to initialize.
+  double m_initializeTime = -1;
+
+  // The time (in seconds) taken for the previous execute method to run.
+  double m_executeTime = -1;
 
   // Whether or not this command has been initialized
   bool m_initialized = false;

--- a/wpilibcIntegrationTests/src/main/native/cpp/command/CommandTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/command/CommandTest.cpp
@@ -40,6 +40,10 @@ class CommandTest : public testing::Test {
     EXPECT_EQ(end, command->GetEndCount());
     EXPECT_EQ(interrupted, command->GetInterruptedCount());
   }
+
+  void AssertBetween(double value, double lower, double upper) {
+    EXPECT_TRUE(value >= lower && value <= upper);
+  }
 };
 
 class ASubsystem : public Subsystem {

--- a/wpilibcIntegrationTests/src/main/native/cpp/command/MockCommand.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/command/MockCommand.cpp
@@ -7,6 +7,9 @@
 
 #include "command/MockCommand.h"
 
+#include <chrono>
+#include <thread>
+
 using namespace frc;
 
 MockCommand::MockCommand(Subsystem* subsys) : MockCommand() {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/CommandTimingTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/CommandTimingTest.java
@@ -1,0 +1,122 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.command;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test the timing telemetry of a {@link Command}.
+ */
+class CommandTimingTest extends AbstractCommandTest {
+  /**
+   * Test timing telemetry of a short delay in initialization.
+   */
+  @Test
+  void initializeTimingTest() {
+    final MockCommand command = new MockCommand() {
+      @Override
+      public void initialize() {
+        ++m_initializeCount;
+        sleep(50);
+      }
+
+      @Override
+      public void execute() {
+        ++m_executeCount;
+        sleep(10);
+      }
+    };
+
+    command.start();
+    assertCommandState(command, 0, 0, 0, 0, 0);
+    assertEquals(command.getInitializeTime(), -1);
+    Scheduler.getInstance().run();
+    assertCommandState(command, 0, 0, 0, 0, 0);
+    assertEquals(command.getInitializeTime(), -1);
+    Scheduler.getInstance().run();
+    assertCommandState(command, 1, 1, 1, 0, 0);
+    assertApprox(command.getInitializeTime(), 0.05);
+    Scheduler.getInstance().run();
+    assertCommandState(command, 1, 2, 2, 0, 0);
+    assertApprox(command.getInitializeTime(), 0.05);
+  }
+
+  /**
+   * Test timing telemetry of a short delay in execution.
+   */
+  @Test
+  void executeTimingTest() {
+    final MockCommand command = new MockCommand() {
+      @Override
+      public void execute() {
+        ++m_executeCount;
+        sleep(100);
+      }
+    };
+
+    command.start();
+    assertCommandState(command, 0, 0, 0, 0, 0);
+    assertEquals(command.getExecuteTime(), -1);
+    Scheduler.getInstance().run();
+    assertCommandState(command, 0, 0, 0, 0, 0);
+    assertEquals(command.getExecuteTime(), -1);
+    Scheduler.getInstance().run();
+    assertCommandState(command, 1, 1, 1, 0, 0);
+    assertApprox(command.getExecuteTime(), 0.1);
+    Scheduler.getInstance().run();
+    assertCommandState(command, 1, 2, 2, 0, 0);
+    assertApprox(command.getExecuteTime(), 0.1);
+  }
+
+  /**
+   * Test timing telemetry of a long delay in initialization and execution.
+   */
+  @Test
+  void longTimingTest() {
+    final MockCommand command = new MockCommand() {
+      @Override
+      public void initialize() {
+        ++m_initializeCount;
+        sleep(500);
+      }
+
+      @Override
+      public void execute() {
+        ++m_executeCount;
+        sleep(2500);
+      }
+    };
+
+    command.start();
+    assertCommandState(command, 0, 0, 0, 0, 0);
+    assertEquals(command.getInitializeTime(), -1);
+    assertEquals(command.getExecuteTime(), -1);
+    Scheduler.getInstance().run();
+    assertCommandState(command, 0, 0, 0, 0, 0);
+    assertEquals(command.getInitializeTime(), -1);
+    assertEquals(command.getExecuteTime(), -1);
+    Scheduler.getInstance().run();
+    assertCommandState(command, 1, 1, 1, 0, 0);
+    assertApprox(command.getInitializeTime(), 0.5);
+    assertApprox(command.getExecuteTime(), 2.5);
+    Scheduler.getInstance().run();
+    assertCommandState(command, 1, 2, 2, 0, 0);
+    assertApprox(command.getInitializeTime(), 0.5);
+    assertApprox(command.getExecuteTime(), 2.5);
+  }
+
+  void assertApprox(double value, double real) {
+    double lower = real * 0.9;
+    double upper = real * 1.1;
+
+    assertTrue(value >= lower && value <= upper);
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockCommand.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/command/MockCommand.java
@@ -12,12 +12,12 @@ package edu.wpi.first.wpilibj.command;
  * called.
  */
 public class MockCommand extends Command {
-  private int m_initializeCount;
-  private int m_executeCount;
-  private int m_isFinishedCount;
-  private boolean m_hasFinished;
-  private int m_endCount;
-  private int m_interruptedCount;
+  protected int m_initializeCount;
+  protected int m_executeCount;
+  protected int m_isFinishedCount;
+  protected boolean m_hasFinished;
+  protected int m_endCount;
+  protected int m_interruptedCount;
 
   public MockCommand(Subsystem subsys) {
     super();


### PR DESCRIPTION
This starts to add basic loop timing telemetry to commands. Adds `executeTime` and `initializeTime` to the command's Sendable. Also opens the gate for some cool Shuffleboard integration.

Closes https://github.com/wpilibsuite/allwpilib/issues/609