### PR TITLE
cscore: set charset of displayed pages

### DIFF
--- a/cscore/src/main/native/cpp/MjpegServerImpl.cpp
+++ b/cscore/src/main/native/cpp/MjpegServerImpl.cpp
@@ -335,7 +335,8 @@ bool MjpegServerImpl::ConnThread::ProcessCommand(wpi::raw_ostream& os,
 
 void MjpegServerImpl::ConnThread::SendHTMLHeadTitle(
     wpi::raw_ostream& os) const {
-  os << "<html><head><title>" << m_name << " CameraServer</title>";
+  os << "<html><head><title>" << m_name << " CameraServer</title>"
+     << "<meta charset=\"UTF-8\">";
 }
 
 // Send the root html file with controls for all the settable properties.


### PR DESCRIPTION
* All of our strings are UTF-8, but the default charset for HTML<5 was ISO-8859-1