### PR TITLE
Fix MotorSafety deadlock

### DIFF
--- a/wpilibc/src/main/native/cpp/MotorSafety.cpp
+++ b/wpilibc/src/main/native/cpp/MotorSafety.cpp
@@ -93,7 +93,6 @@ void MotorSafety::Check() {
     return;
   }
 
-  std::lock_guard<wpi::mutex> lock(m_thisMutex);
   if (stopTime < Timer::GetFPGATimestamp()) {
     wpi::SmallString<128> buf;
     wpi::raw_svector_ostream desc(buf);


### PR DESCRIPTION
Some instances of StopMotor (most notably DifferentialDrive) call Feed(),
which deadlocks due to Check() holding the same lock.

Fixes #1525.