### PR TITLE
Java: Fix Timer.get() handling of accumulated time

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Timer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Timer.java
@@ -70,7 +70,7 @@ public class Timer {
    */
   public synchronized double get() {
     if (m_running) {
-      return ((getMsClock() - m_startTime) + m_accumulatedTime) / 1000.0;
+      return m_accumulatedTime + (getMsClock() - m_startTime) / 1000.0;
     } else {
       return m_accumulatedTime;
     }


### PR DESCRIPTION
It was incorrectly treating accumulated time as being in milliseconds instead of seconds.

Fixes #1530.