### PR TITLE
Fix cmake hal sim build

### DIFF
--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -26,7 +26,7 @@ file(GLOB
     hal_shared_native_src src/main/native/cpp/cpp/*.cpp
     hal_shared_native_src src/main/native/cpp/handles/*.cpp
     hal_sim_native_src src/main/native/sim/*.cpp
-    hal_sim_native_src src/main/native/sim/MockData/*.cpp)
+    hal_sim_native_src src/main/native/sim/mockdata/*.cpp)
 add_library(hal ${hal_shared_native_src})
 set_target_properties(hal PROPERTIES DEBUG_POSTFIX "d")
 


### PR DESCRIPTION
A source directory was named incorrectly in CamelCase.