### PR TITLE
cscore: Handle USB camera integer menus

### DIFF
--- a/cscore/src/main/native/linux/UsbCameraProperty.h
+++ b/cscore/src/main/native/linux/UsbCameraProperty.h
@@ -71,6 +71,9 @@ class UsbCameraProperty : public PropertyImpl {
 
   unsigned id{0};  // implementation-level id
   int type{0};     // implementation type, not CS_PropertyKind!
+
+  // If the enum property is integer rather than string
+  bool intMenu{false};
 };
 
 }  // namespace cs


### PR DESCRIPTION
The Pi Camera is one of these.  Previously, integers were just being
cast to a string instead of formatted as a string.