### PR TITLE
Fix missing exposure property on windows USB cameras

### DIFF
--- a/cscore/src/main/native/windows/UsbCameraImpl.cpp
+++ b/cscore/src/main/native/windows/UsbCameraImpl.cpp
@@ -488,9 +488,8 @@ bool UsbCameraImpl::CacheProperties(CS_Status* status) const {
   return true;
 }
 
-template<typename TagProperty, typename IAM>
-void UsbCameraImpl::DeviceAddProperty(const wpi::Twine& name_,
-                                      TagProperty tag,
+template <typename TagProperty, typename IAM>
+void UsbCameraImpl::DeviceAddProperty(const wpi::Twine& name_, TagProperty tag,
                                       IAM* pProcAmp) {
   // First see if properties exist
   bool isValid = false;
@@ -543,7 +542,6 @@ void UsbCameraImpl::DeviceCacheProperties() {
     pCamControl->Release();
   }
 }
-
 
 int UsbCameraImpl::RawToPercentage(const UsbCameraProperty& rawProp,
                                    int rawValue) {

--- a/cscore/src/main/native/windows/UsbCameraImpl.cpp
+++ b/cscore/src/main/native/windows/UsbCameraImpl.cpp
@@ -500,6 +500,14 @@ void UsbCameraImpl::DeviceAddProperty(const wpi::Twine& name_, TagProperty tag,
   }
 }
 
+template void UsbCameraImpl::DeviceAddProperty(const wpi::Twine& name_,
+                                               tagVideoProcAmpProperty tag,
+                                               IAMVideoProcAmp* pProcAmp);
+
+template void UsbCameraImpl::DeviceAddProperty(const wpi::Twine& name_,
+                                               tagCameraControlProperty tag,
+                                               IAMCameraControl* pProcAmp);
+
 #define CREATEPROPERTY(val) \
   DeviceAddProperty(#val, VideoProcAmp_##val, pProcAmp);
 

--- a/cscore/src/main/native/windows/UsbCameraImpl.h
+++ b/cscore/src/main/native/windows/UsbCameraImpl.h
@@ -132,11 +132,12 @@ class UsbCameraImpl : public SourceImpl,
   CS_StatusValue DeviceSetMode();
   void DeviceCacheMode();
   void DeviceCacheProperty(std::unique_ptr<UsbCameraProperty> rawProp,
-                           IAMVideoProcAmp* pProcAmp);
+                           IMFSourceReader* sourceReader);
   void DeviceCacheProperties();
   void DeviceCacheVideoModes();
-  void DeviceAddProperty(const wpi::Twine& name_, tagVideoProcAmpProperty tag,
-                         IAMVideoProcAmp* pProcAmp);
+  template<typename TagProperty, typename IAM>
+  void DeviceAddProperty(const wpi::Twine& name_, TagProperty tag,
+                         IAM* pProcAmp);
 
   ComPtr<IMFMediaType> DeviceCheckModeValid(const VideoMode& toCheck);
 

--- a/cscore/src/main/native/windows/UsbCameraImpl.h
+++ b/cscore/src/main/native/windows/UsbCameraImpl.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2016-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -135,7 +135,7 @@ class UsbCameraImpl : public SourceImpl,
                            IMFSourceReader* sourceReader);
   void DeviceCacheProperties();
   void DeviceCacheVideoModes();
-  template<typename TagProperty, typename IAM>
+  template <typename TagProperty, typename IAM>
   void DeviceAddProperty(const wpi::Twine& name_, TagProperty tag,
                          IAM* pProcAmp);
 

--- a/cscore/src/main/native/windows/UsbCameraProperty.cpp
+++ b/cscore/src/main/native/windows/UsbCameraProperty.cpp
@@ -7,13 +7,16 @@
 
 #include "UsbCameraProperty.h"
 
+#include "ComPtr.h"
+
 using namespace cs;
 
 UsbCameraProperty::UsbCameraProperty(const wpi::Twine& name_,
                                      tagVideoProcAmpProperty tag, bool autoProp,
                                      IAMVideoProcAmp* pProcAmp, bool* isValid)
     : PropertyImpl{autoProp ? name_ + "_auto" : name_} {
-  this->tag = tag;
+  this->tagVideoProc = tag;
+  this->isControlProperty = false;
   this->isAutoProp = autoProp;
   long paramVal, paramFlag;  // NOLINT(runtime/int)
   HRESULT hr;
@@ -42,7 +45,7 @@ bool UsbCameraProperty::DeviceGet(std::unique_lock<wpi::mutex>& lock,
 
   lock.unlock();
   long newValue = 0, paramFlag = 0;  // NOLINT(runtime/int)
-  if (SUCCEEDED(pProcAmp->Get(tag, &newValue, &paramFlag))) {
+  if (SUCCEEDED(pProcAmp->Get(tagVideoProc, &newValue, &paramFlag))) {
     lock.lock();
     value = newValue;
     return true;
@@ -60,10 +63,127 @@ bool UsbCameraProperty::DeviceSet(std::unique_lock<wpi::mutex>& lock,
   if (!pProcAmp) return true;
 
   lock.unlock();
-  if (SUCCEEDED(pProcAmp->Set(tag, newValue, VideoProcAmp_Flags_Manual))) {
+  if (SUCCEEDED(
+          pProcAmp->Set(tagVideoProc, newValue, VideoProcAmp_Flags_Manual))) {
     lock.lock();
     return true;
   }
 
   return false;
+}
+
+UsbCameraProperty::UsbCameraProperty(const wpi::Twine& name_,
+                                     tagCameraControlProperty tag,
+                                     bool autoProp, IAMCameraControl* pProcAmp,
+                                     bool* isValid)
+    : PropertyImpl{autoProp ? name_ + "_auto" : name_} {
+  this->tagCameraControl = tag;
+  this->isControlProperty = true;
+  this->isAutoProp = autoProp;
+  long paramVal, paramFlag;  // NOLINT(runtime/int)
+  HRESULT hr;
+  long minVal, maxVal, stepVal;  // NOLINT(runtime/int)
+  hr = pProcAmp->GetRange(tag, &minVal, &maxVal, &stepVal, &paramVal,
+                          &paramFlag);  // Unable to get the property, trying to
+                                        // return default value
+  if (SUCCEEDED(hr)) {
+    minimum = minVal;
+    maximum = maxVal;
+    hasMaximum = true;
+    hasMinimum = true;
+    defaultValue = paramVal;
+    step = stepVal;
+    value = paramVal;
+    propKind = CS_PropertyKind::CS_PROP_INTEGER;
+    *isValid = true;
+  } else {
+    *isValid = false;
+  }
+}
+
+bool UsbCameraProperty::DeviceGet(std::unique_lock<wpi::mutex>& lock,
+                                  IAMCameraControl* pProcAmp) {
+  if (!pProcAmp) return true;
+
+  lock.unlock();
+  long newValue = 0, paramFlag = 0;  // NOLINT(runtime/int)
+  if (SUCCEEDED(pProcAmp->Get(tagCameraControl, &newValue, &paramFlag))) {
+    lock.lock();
+    value = newValue;
+    return true;
+  }
+
+  return false;
+}
+bool UsbCameraProperty::DeviceSet(std::unique_lock<wpi::mutex>& lock,
+                                  IAMCameraControl* pProcAmp) const {
+  return DeviceSet(lock, pProcAmp, value);
+}
+bool UsbCameraProperty::DeviceSet(std::unique_lock<wpi::mutex>& lock,
+                                  IAMCameraControl* pProcAmp,
+                                  int newValue) const {
+  if (!pProcAmp) return true;
+
+  lock.unlock();
+  if (SUCCEEDED(pProcAmp->Set(tagCameraControl, newValue,
+                              CameraControl_Flags_Manual))) {
+    lock.lock();
+    return true;
+  }
+
+  return false;
+}
+
+bool UsbCameraProperty::DeviceGet(std::unique_lock<wpi::mutex>& lock,
+                                  IMFSourceReader* sourceReader) {
+  if (!sourceReader) return true;
+
+  if (isControlProperty) {
+    ComPtr<IAMCameraControl> pProcAmp;
+    if (SUCCEEDED(sourceReader->GetServiceForStream(
+            (DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL,
+            IID_PPV_ARGS(pProcAmp.GetAddressOf())))) {
+      return DeviceGet(lock, pProcAmp.Get());
+    } else {
+      return false;
+    }
+  } else {
+    ComPtr<IAMVideoProcAmp> pProcAmp;
+    if (SUCCEEDED(sourceReader->GetServiceForStream(
+            (DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL,
+            IID_PPV_ARGS(pProcAmp.GetAddressOf())))) {
+      return DeviceGet(lock, pProcAmp.Get());
+    } else {
+      return false;
+    }
+  }
+}
+bool UsbCameraProperty::DeviceSet(std::unique_lock<wpi::mutex>& lock,
+                                  IMFSourceReader* sourceReader) const {
+  return DeviceSet(lock, sourceReader, value);
+}
+bool UsbCameraProperty::DeviceSet(std::unique_lock<wpi::mutex>& lock,
+                                  IMFSourceReader* sourceReader,
+                                  int newValue) const {
+  if (!sourceReader) return true;
+
+  if (isControlProperty) {
+    ComPtr<IAMCameraControl> pProcAmp;
+    if (SUCCEEDED(sourceReader->GetServiceForStream(
+            (DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL,
+            IID_PPV_ARGS(pProcAmp.GetAddressOf())))) {
+      return DeviceSet(lock, pProcAmp.Get(), newValue);
+    } else {
+      return false;
+    }
+  } else {
+    ComPtr<IAMVideoProcAmp> pProcAmp;
+    if (SUCCEEDED(sourceReader->GetServiceForStream(
+            (DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL,
+            IID_PPV_ARGS(pProcAmp.GetAddressOf())))) {
+      return DeviceSet(lock, pProcAmp.Get(), newValue);
+    } else {
+      return false;
+    }
+  }
 }

--- a/cscore/src/main/native/windows/UsbCameraProperty.h
+++ b/cscore/src/main/native/windows/UsbCameraProperty.h
@@ -9,6 +9,11 @@
 
 #include <memory>
 
+#include <mfapi.h>
+#include <mfidl.h>
+#include <mfreadwrite.h>
+
+
 #include <Dshow.h>
 #include <wpi/mutex.h>
 
@@ -49,16 +54,22 @@ class UsbCameraProperty : public PropertyImpl {
   UsbCameraProperty(const wpi::Twine& name_, tagVideoProcAmpProperty tag,
                     bool autoProp, IAMVideoProcAmp* pProcAmp, bool* isValid);
 
-  bool DeviceGet(std::unique_lock<wpi::mutex>& lock, IAMVideoProcAmp* pProcAmp);
+  UsbCameraProperty(const wpi::Twine& name_, tagCameraControlProperty tag,
+                    bool autoProp, IAMCameraControl* pProcAmp, bool* isValid);
+
+  bool DeviceGet(std::unique_lock<wpi::mutex>& lock, IMFSourceReader* sourceReader);
   bool DeviceSet(std::unique_lock<wpi::mutex>& lock,
-                 IAMVideoProcAmp* pProcAmp) const;
-  bool DeviceSet(std::unique_lock<wpi::mutex>& lock, IAMVideoProcAmp* pProcAmp,
+                 IMFSourceReader* sourceReader) const;
+  bool DeviceSet(std::unique_lock<wpi::mutex>& lock, IMFSourceReader* sourceReader,
                  int newValue) const;
 
   // If this is a device (rather than software) property
   bool device{true};
   bool isAutoProp{true};
-  tagVideoProcAmpProperty tag;
+
+  bool isControlProperty{false};
+  tagVideoProcAmpProperty tagVideoProc;
+  tagCameraControlProperty tagCameraControl;
 
   // If this is a percentage (rather than raw) property
   bool percentage{false};
@@ -68,5 +79,19 @@ class UsbCameraProperty : public PropertyImpl {
 
   unsigned id{0};  // implementation-level id
   int type{0};     // implementation type, not CS_PropertyKind!
+
+ private:
+  bool DeviceGet(std::unique_lock<wpi::mutex>& lock, IAMCameraControl* pProcAmp);
+  bool DeviceSet(std::unique_lock<wpi::mutex>& lock,
+                 IAMCameraControl* pProcAmp) const;
+  bool DeviceSet(std::unique_lock<wpi::mutex>& lock, IAMCameraControl* pProcAmp,
+                 int newValue) const;
+
+  bool DeviceGet(std::unique_lock<wpi::mutex>& lock, IAMVideoProcAmp* pProcAmp);
+  bool DeviceSet(std::unique_lock<wpi::mutex>& lock,
+                 IAMVideoProcAmp* pProcAmp) const;
+  bool DeviceSet(std::unique_lock<wpi::mutex>& lock, IAMVideoProcAmp* pProcAmp,
+                 int newValue) const;
+
 };
 }  // namespace cs

--- a/cscore/src/main/native/windows/UsbCameraProperty.h
+++ b/cscore/src/main/native/windows/UsbCameraProperty.h
@@ -7,12 +7,11 @@
 
 #pragma once
 
-#include <memory>
-
 #include <mfapi.h>
 #include <mfidl.h>
 #include <mfreadwrite.h>
 
+#include <memory>
 
 #include <Dshow.h>
 #include <wpi/mutex.h>
@@ -57,11 +56,12 @@ class UsbCameraProperty : public PropertyImpl {
   UsbCameraProperty(const wpi::Twine& name_, tagCameraControlProperty tag,
                     bool autoProp, IAMCameraControl* pProcAmp, bool* isValid);
 
-  bool DeviceGet(std::unique_lock<wpi::mutex>& lock, IMFSourceReader* sourceReader);
+  bool DeviceGet(std::unique_lock<wpi::mutex>& lock,
+                 IMFSourceReader* sourceReader);
   bool DeviceSet(std::unique_lock<wpi::mutex>& lock,
                  IMFSourceReader* sourceReader) const;
-  bool DeviceSet(std::unique_lock<wpi::mutex>& lock, IMFSourceReader* sourceReader,
-                 int newValue) const;
+  bool DeviceSet(std::unique_lock<wpi::mutex>& lock,
+                 IMFSourceReader* sourceReader, int newValue) const;
 
   // If this is a device (rather than software) property
   bool device{true};
@@ -81,7 +81,8 @@ class UsbCameraProperty : public PropertyImpl {
   int type{0};     // implementation type, not CS_PropertyKind!
 
  private:
-  bool DeviceGet(std::unique_lock<wpi::mutex>& lock, IAMCameraControl* pProcAmp);
+  bool DeviceGet(std::unique_lock<wpi::mutex>& lock,
+                 IAMCameraControl* pProcAmp);
   bool DeviceSet(std::unique_lock<wpi::mutex>& lock,
                  IAMCameraControl* pProcAmp) const;
   bool DeviceSet(std::unique_lock<wpi::mutex>& lock, IAMCameraControl* pProcAmp,
@@ -92,6 +93,5 @@ class UsbCameraProperty : public PropertyImpl {
                  IAMVideoProcAmp* pProcAmp) const;
   bool DeviceSet(std::unique_lock<wpi::mutex>& lock, IAMVideoProcAmp* pProcAmp,
                  int newValue) const;
-
 };
 }  // namespace cs


### PR DESCRIPTION
They're controlled from a separate interface