### PR TITLE
Disable watchdog test on mac

### DIFF
--- a/wpilibc/src/test/native/cpp/WatchdogTest.cpp
+++ b/wpilibc/src/test/native/cpp/WatchdogTest.cpp
@@ -118,7 +118,11 @@ TEST(WatchdogTest, Epochs) {
   EXPECT_EQ(0u, watchdogCounter) << "Watchdog triggered early";
 }
 
+#ifdef __APPLE__
+TEST(WatchdogTest, DISABLED_MultiWatchdog) {
+#else
 TEST(WatchdogTest, MultiWatchdog) {
+#endif
   uint32_t watchdogCounter1 = 0;
   uint32_t watchdogCounter2 = 0;
 


### PR DESCRIPTION
It can't be held property on the asure test system