### PR TITLE
Fix Watchdog incorrectly resetting expiration flag upon disable

### DIFF
--- a/wpilibc/src/main/native/cpp/Watchdog.cpp
+++ b/wpilibc/src/main/native/cpp/Watchdog.cpp
@@ -160,8 +160,6 @@ void Watchdog::Disable() {
   auto thr = m_owner->GetThread();
   if (!thr) return;
 
-  m_isExpired = false;
-
   thr->m_watchdogs.remove(this);
   thr->m_cond.notify_all();
 }

--- a/wpilibc/src/test/native/cpp/WatchdogTest.cpp
+++ b/wpilibc/src/test/native/cpp/WatchdogTest.cpp
@@ -83,11 +83,18 @@ TEST(WatchdogTest, SetTimeout) {
 
 TEST(WatchdogTest, IsExpired) {
   Watchdog watchdog(0.2, [] {});
+  EXPECT_FALSE(watchdog.IsExpired());
   watchdog.Enable();
 
   EXPECT_FALSE(watchdog.IsExpired());
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
   EXPECT_TRUE(watchdog.IsExpired());
+
+  watchdog.Disable();
+  EXPECT_TRUE(watchdog.IsExpired());
+
+  watchdog.Reset();
+  EXPECT_FALSE(watchdog.IsExpired());
 }
 
 TEST(WatchdogTest, Epochs) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -195,8 +195,6 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
   public void disable() {
     m_queueMutex.lock();
     try {
-      m_isExpired = false;
-
       m_watchdogs.remove(this);
       m_schedulerWaiter.signalAll();
     } finally {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/WatchdogTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/WatchdogTest.java
@@ -121,6 +121,7 @@ class WatchdogTest {
   void isExpiredTest() {
     final Watchdog watchdog = new Watchdog(0.2, () -> {
     });
+    assertFalse(watchdog.isExpired());
     watchdog.enable();
 
     assertFalse(watchdog.isExpired());
@@ -130,6 +131,12 @@ class WatchdogTest {
       Thread.currentThread().interrupt();
     }
     assertTrue(watchdog.isExpired());
+
+    watchdog.disable();
+    assertTrue(watchdog.isExpired());
+
+    watchdog.reset();
+    assertFalse(watchdog.isExpired());
   }
 
   @Test


### PR DESCRIPTION
Resetting the flag should only occur in Enable() and Reset().
IterativeRobotBase needs the flag to remain set to print epochs after
disabling the Watchdog.