### PR TITLE
Update Ultrasonic.java

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Ultrasonic.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Ultrasonic.java
@@ -78,18 +78,14 @@ public class Ultrasonic extends SendableBase implements PIDSource {
           if (m_sensors.isEmpty()) {
             return;
           }
-          if (sensorIndex >= m_sensors.size()) {
-            sensorIndex = m_sensors.size() - 1;
-          }
           ultrasonic = m_sensors.get(sensorIndex);
         }
         if (ultrasonic.isEnabled()) {
           // Do the ping
           ultrasonic.m_pingChannel.pulse(kPingTime);
         }
-        if (sensorIndex < m_sensors.size()) {
-          sensorIndex++;
-        } else {
+        sensorIndex++;
+        if (sensorIndex >= m_sensors.size()) {
           sensorIndex = 0;
         }
 


### PR DESCRIPTION
When there is more than one ultrasonic sensor, only the last sensor instantiated works.
In the loop above, sensorIndex starts from 0 but once it reaches the max, it toggles between max - 1 and max. 
The changes submitted here fixes that.
We've tested it.