### PR TITLE
Update HAL GetStackTrace to properly report user errors

### DIFF
--- a/hal/src/main/native/cpp/jni/HALUtil.cpp
+++ b/hal/src/main/native/cpp/jni/HALUtil.cpp
@@ -127,7 +127,7 @@ void ReportError(JNIEnv* env, int32_t status, bool doThrow) {
     ThrowUncleanStatusException(env, buf.c_str(), status);
   } else {
     std::string func;
-    auto stack = GetJavaStackTrace(env, &func, "edu.wpi.first.wpilibj");
+    auto stack = GetJavaStackTrace(env, &func, "edu.wpi.first");
     HAL_SendError(1, status, 0, message, func.c_str(), stack.c_str(), 1);
   }
 }


### PR DESCRIPTION
With the move of the HAL, the old value no longer worked, as the JNI call is in a different namespace