### PR TITLE
CameraServer: Add switched camera support

### DIFF
--- a/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
+++ b/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
@@ -37,6 +37,7 @@ struct CameraServer::Impl {
   std::string m_primarySourceName;
   wpi::StringMap<cs::VideoSource> m_sources;
   wpi::StringMap<cs::VideoSink> m_sinks;
+  wpi::DenseMap<CS_Sink, CS_Source> m_fixedSources;
   wpi::DenseMap<CS_Source, std::shared_ptr<nt::NetworkTable>> m_tables;
   std::shared_ptr<nt::NetworkTable> m_publishTable;
   cs::VideoListener m_videoListener;
@@ -156,7 +157,8 @@ void CameraServer::Impl::UpdateStreamValues() {
     CS_Sink sink = i.second.GetHandle();
 
     // Get the source's subtable (if none exists, we're done)
-    CS_Source source = cs::GetSinkSource(sink, &status);
+    CS_Source source = m_fixedSources.lookup(sink);
+    if (source == 0) source = cs::GetSinkSource(sink, &status);
     if (source == 0) continue;
     auto table = m_tables.lookup(source);
     if (table) {
@@ -536,6 +538,15 @@ cs::AxisCamera CameraServer::AddAxisCamera(const wpi::Twine& name,
   auto csShared = GetCameraServerShared();
   csShared->ReportAxisCamera(camera.GetHandle());
   return camera;
+}
+
+cs::MjpegServer CameraServer::AddSwitchedCamera(const wpi::Twine& name) {
+  // create a dummy CvSource
+  cs::CvSource source{name, cs::VideoMode::PixelFormat::kMJPEG, 160, 120, 30};
+  cs::MjpegServer server = StartAutomaticCapture(source);
+  m_impl->m_fixedSources[server.GetHandle()] = source.GetHandle();
+
+  return server;
 }
 
 cs::MjpegServer CameraServer::StartAutomaticCapture(

--- a/cameraserver/src/main/native/include/cameraserver/CameraServer.h
+++ b/cameraserver/src/main/native/include/cameraserver/CameraServer.h
@@ -174,6 +174,14 @@ class CameraServer {
                                std::initializer_list<T> hosts);
 
   /**
+   * Adds a virtual camera for switching between two streams.  Unlike the
+   * other addCamera methods, this returns a VideoSink rather than a
+   * VideoSource.  Calling SetSource() on the returned object can be used
+   * to switch the actual source of the stream.
+   */
+  cs::MjpegServer AddSwitchedCamera(const wpi::Twine& name);
+
+  /**
    * Get OpenCV access to the primary camera feed.  This allows you to
    * get images from the camera for image processing on the roboRIO.
    *


### PR DESCRIPTION
This adds a new function "addSwitchedCamera" that creates and publishes a
virtual camera where the published stream information is consistent even if
the mjpeg server source is switched to a different camera.

Previously, changing the source of the mjpeg server resulted in updating the
stream information published for that source.