### PR TITLE
C++ CameraServer: initialize default Usb camera device number

### DIFF
--- a/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
+++ b/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
@@ -33,7 +33,7 @@ struct CameraServer::Impl {
   void UpdateStreamValues();
 
   wpi::mutex m_mutex;
-  std::atomic<int> m_defaultUsbDevice;
+  std::atomic<int> m_defaultUsbDevice{0};
   std::string m_primarySourceName;
   wpi::StringMap<cs::VideoSource> m_sources;
   wpi::StringMap<cs::VideoSink> m_sinks;


### PR DESCRIPTION
Otherwise just plain StartAutomaticCapture() starts with random number.