### PR TITLE
Limit length of message sent to DS SendError call

### DIFF
--- a/hal/src/main/native/athena/FRCDriverStation.cpp
+++ b/hal/src/main/native/athena/FRCDriverStation.cpp
@@ -325,8 +325,9 @@ int32_t HAL_SendError(HAL_Bool isError, int32_t errorCode, HAL_Bool isLVCode,
       // Stack too long
       auto newLen = 65536 - baseLength - detailsRef.size() - locationRef.size();
       std::string newCallStack{callStack, newLen};
-      retval = FRC_NetworkCommunication_sendError(
-          isError, errorCode, isLVCode, details, location, newCallStack.c_str());
+      retval = FRC_NetworkCommunication_sendError(isError, errorCode, isLVCode,
+                                                  details, location,
+                                                  newCallStack.c_str());
     }
     if (printMsg) {
       if (location && location[0] != '\0') {

--- a/hal/src/main/native/athena/FRCDriverStation.cpp
+++ b/hal/src/main/native/athena/FRCDriverStation.cpp
@@ -310,31 +310,23 @@ int32_t HAL_SendError(HAL_Bool isError, int32_t errorCode, HAL_Bool isLVCode,
     } else if (baseLength + detailsRef.size() > 65536) {
       // Details too long, cut both location and stack
       auto newLen = 65536 - baseLength;
-      std::unique_ptr<char[]> newDetails = std::make_unique<char[]>(newLen + 1);
-      std::strncpy(newDetails.get(), detailsRef.data(), newLen);
-      newDetails[newLen] = '\0';
+      std::string newDetails{details, newLen};
       char empty = '\0';
       retval = FRC_NetworkCommunication_sendError(
-          isError, errorCode, isLVCode, newDetails.get(), &empty, &empty);
+          isError, errorCode, isLVCode, newDetails.c_str(), &empty, &empty);
     } else if (baseLength + detailsRef.size() + locationRef.size() > 65536) {
       // Location too long, cut stack
       auto newLen = 65536 - baseLength - detailsRef.size();
-      std::unique_ptr<char[]> newLocation =
-          std::make_unique<char[]>(newLen + 1);
-      std::strncpy(newLocation.get(), locationRef.data(), newLen);
-      newLocation[newLen] = '\0';
+      std::string newLocation{location, newLen};
       char empty = '\0';
       retval = FRC_NetworkCommunication_sendError(
-          isError, errorCode, isLVCode, details, newLocation.get(), &empty);
+          isError, errorCode, isLVCode, details, newLocation.c_str(), &empty);
     } else {
       // Stack too long
       auto newLen = 65536 - baseLength - detailsRef.size() - locationRef.size();
-      std::unique_ptr<char[]> newCallStack =
-          std::make_unique<char[]>(newLen + 1);
-      std::strncpy(newCallStack.get(), locationRef.data(), newLen);
-      newCallStack[newLen] = '\0';
+      std::string newCallStack{callStack, newLen};
       retval = FRC_NetworkCommunication_sendError(
-          isError, errorCode, isLVCode, details, location, newCallStack.get());
+          isError, errorCode, isLVCode, details, location, newCallStack.c_str());
     }
     if (printMsg) {
       if (location && location[0] != '\0') {

--- a/hal/src/main/native/athena/FRCDriverStation.cpp
+++ b/hal/src/main/native/athena/FRCDriverStation.cpp
@@ -298,7 +298,8 @@ int32_t HAL_SendError(HAL_Bool isError, int32_t errorCode, HAL_Bool isLVCode,
 
     // 1 tag, 4 timestamp, 2 seqnum
     // 2 numOccur, 4 error code, 1 flags, 6 strlen
-    size_t baseLength = 20;
+    // 1 extra needed for padding on Netcomm end.
+    size_t baseLength = 21;
 
     if (baseLength + detailsRef.size() + locationRef.size() +
             callStackRef.size() <=

--- a/hal/src/main/native/athena/FRCDriverStation.cpp
+++ b/hal/src/main/native/athena/FRCDriverStation.cpp
@@ -332,7 +332,6 @@ int32_t HAL_SendError(HAL_Bool isError, int32_t errorCode, HAL_Bool isLVCode,
           std::make_unique<char[]>(newLen + 1);
       std::strncpy(newCallStack.get(), locationRef.data(), newLen);
       newCallStack[newLen] = '\0';
-      char empty = '\0';
       retval = FRC_NetworkCommunication_sendError(
           isError, errorCode, isLVCode, details, location, newCallStack.get());
     }


### PR DESCRIPTION
If total length is over 65536, the packet will get thrown own. This becomes a problem in stackoverflow cases