### PR TITLE
Fixes receive side of LabVIEW USB streams

### DIFF
--- a/cscore/src/dev/native/cpp/main.cpp
+++ b/cscore/src/dev/native/cpp/main.cpp
@@ -7,6 +7,6 @@
 
 #include <iostream>
 
-int main() {
-  std::cout << cs::GetHostname() << std::endl;
-}
+#include "cscore.h"
+
+int main() { std::cout << cs::GetHostname() << std::endl; }

--- a/cscore/src/dev/native/cpp/main.cpp
+++ b/cscore/src/dev/native/cpp/main.cpp
@@ -7,6 +7,32 @@
 
 #include <iostream>
 
+#include <opencv2/core.hpp>
+
 #include "cscore.h"
 
-int main() { std::cout << cs::GetHostname() << std::endl; }
+int main() {
+  std::cout << cs::GetHostname() << std::endl;
+  cs::UsbCamera cam{"Usb", 0};
+  cs::MjpegServer serv{"UsbS", 1181};
+  serv.SetSource(cam);
+  // cs::HttpCamera httpCamera{"Camera",
+  // "http://172.22.11.2:1181/IMAQdxStream.mjpg?name=IMAQdx%3AMicrosoft%20LifeCam%20HD-3000&fps=15&compression=30&resolution=320x240"};
+  cs::HttpCamera httpCamera{"Camera",
+                            "http://172.22.11.2:1181/"
+                            "IMAQdxStream.mjpg?name=IMAQdx%3AMicrosoft%"
+                            "20LifeCam%20HD-3000"};
+  // cs::HttpCamera httpCamera{"Camera", "http://127.0.0.1:1181/stream.mjpg"};
+  cs::CvSink sink{"Sink"};
+  sink.SetSource(httpCamera);
+
+  cv::Mat mat;
+
+  while (true) {
+    if (sink.GrabFrame(mat) != 0) {
+      std::cout << "Grabbed" << std::endl;
+    } else {
+      std::cout << "Timeout" << std::endl;
+    }
+  }
+}

--- a/cscore/src/dev/native/cpp/main.cpp
+++ b/cscore/src/dev/native/cpp/main.cpp
@@ -7,32 +7,6 @@
 
 #include <iostream>
 
-#include <opencv2/core.hpp>
-
-#include "cscore.h"
-
 int main() {
   std::cout << cs::GetHostname() << std::endl;
-  cs::UsbCamera cam{"Usb", 0};
-  cs::MjpegServer serv{"UsbS", 1181};
-  serv.SetSource(cam);
-  // cs::HttpCamera httpCamera{"Camera",
-  // "http://172.22.11.2:1181/IMAQdxStream.mjpg?name=IMAQdx%3AMicrosoft%20LifeCam%20HD-3000&fps=15&compression=30&resolution=320x240"};
-  cs::HttpCamera httpCamera{"Camera",
-                            "http://172.22.11.2:1181/"
-                            "IMAQdxStream.mjpg?name=IMAQdx%3AMicrosoft%"
-                            "20LifeCam%20HD-3000"};
-  // cs::HttpCamera httpCamera{"Camera", "http://127.0.0.1:1181/stream.mjpg"};
-  cs::CvSink sink{"Sink"};
-  sink.SetSource(httpCamera);
-
-  cv::Mat mat;
-
-  while (true) {
-    if (sink.GrabFrame(mat) != 0) {
-      std::cout << "Grabbed" << std::endl;
-    } else {
-      std::cout << "Timeout" << std::endl;
-    }
-  }
 }

--- a/cscore/src/main/native/cpp/HttpCameraImpl.cpp
+++ b/cscore/src/main/native/cpp/HttpCameraImpl.cpp
@@ -149,7 +149,7 @@ wpi::HttpConnection* HttpCameraImpl::DeviceStreamConnect(
 
   if (!m_active || !stream) return nullptr;
 
-  auto connPtr = wpi::make_unique<wpi::HttpConnection>(std::move(stream), 1);
+  auto connPtr = wpi::make_unique<wpi::HttpConnection>(std::move(stream), 2);
   wpi::HttpConnection* conn = connPtr.get();
 
   // update m_streamConn
@@ -189,6 +189,9 @@ wpi::HttpConnection* HttpCameraImpl::DeviceStreamConnect(
     std::tie(key, value) = keyvalue.split('=');
     if (key.trim() == "boundary") {
       value = value.trim().trim('"');  // value may be quoted
+      if (value.startswith("--")) {
+        value = value.slice(2, wpi::StringRef::npos);
+	  }
       boundary.append(value.begin(), value.end());
     }
   }
@@ -219,11 +222,16 @@ void HttpCameraImpl::DeviceStream(wpi::raw_istream& is,
     if (!FindMultipartBoundary(is, boundary, nullptr)) break;
 
     // Read the next two characters after the boundary (normally \r\n)
+	// Handle just \n for LabVIEW however
     char eol[2];
-    is.read(eol, 2);
+    is.read(eol, 1);
     if (!m_active || is.has_error()) break;
-    // End-of-stream is indicated with trailing --
-    if (eol[0] == '-' && eol[1] == '-') break;
+    if (eol[0] != '\n') {
+      is.read(eol + 1, 1);
+      if (!m_active || is.has_error()) break;
+      // End-of-stream is indicated with trailing --
+      if (eol[0] == '-' && eol[1] == '-') break;
+    }
 
     if (!DeviceStreamFrame(is, imageBuf))
       ++numErrors;

--- a/cscore/src/main/native/cpp/HttpCameraImpl.cpp
+++ b/cscore/src/main/native/cpp/HttpCameraImpl.cpp
@@ -190,8 +190,8 @@ wpi::HttpConnection* HttpCameraImpl::DeviceStreamConnect(
     if (key.trim() == "boundary") {
       value = value.trim().trim('"');  // value may be quoted
       if (value.startswith("--")) {
-        value = value.slice(2, wpi::StringRef::npos);
-	  }
+        value = value.substr(2);
+      }
       boundary.append(value.begin(), value.end());
     }
   }
@@ -222,7 +222,7 @@ void HttpCameraImpl::DeviceStream(wpi::raw_istream& is,
     if (!FindMultipartBoundary(is, boundary, nullptr)) break;
 
     // Read the next two characters after the boundary (normally \r\n)
-	// Handle just \n for LabVIEW however
+    // Handle just \n for LabVIEW however
     char eol[2];
     is.read(eol, 1);
     if (!m_active || is.has_error()) break;

--- a/cscore/src/main/native/cpp/HttpCameraImpl.cpp
+++ b/cscore/src/main/native/cpp/HttpCameraImpl.cpp
@@ -149,7 +149,7 @@ wpi::HttpConnection* HttpCameraImpl::DeviceStreamConnect(
 
   if (!m_active || !stream) return nullptr;
 
-  auto connPtr = wpi::make_unique<wpi::HttpConnection>(std::move(stream), 2);
+  auto connPtr = wpi::make_unique<wpi::HttpConnection>(std::move(stream), 1);
   wpi::HttpConnection* conn = connPtr.get();
 
   // update m_streamConn

--- a/wpiutil/src/main/native/include/wpi/HttpUtil.inl
+++ b/wpiutil/src/main/native/include/wpi/HttpUtil.inl
@@ -36,9 +36,9 @@ void HttpRequest::SetPath(StringRef path_, const T& params) {
       pathOs << '&';
     }
     SmallString<64> escapeBuf;
-    pathOs << EscapeURI(GetFirst(param), escapeBuf);
+    pathOs << EscapeURI(GetFirst(param), escapeBuf, false);
     if (!GetSecond(param).empty()) {
-      pathOs << '=' << EscapeURI(GetSecond(param), escapeBuf);
+      pathOs << '=' << EscapeURI(GetSecond(param), escapeBuf, false);
     }
   }
 }


### PR DESCRIPTION
They only accept %20 instead of + for parameters, they only send '\n' at the boundaries,
And they include the -- when sending the initial boundary.  This solves those parts.

This is not fully enough to fix shuffleboard and others, as the NT format for paths is not the correct path