### PR TITLE
Only generate passthrough URLs for RoboRIO

### DIFF
--- a/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
+++ b/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
@@ -149,7 +149,8 @@ public final class CameraServer {
         int sink = i.getHandle();
         int sinkSource = CameraServerJNI.getSinkSource(sink);
         if (source == sinkSource
-            && VideoSink.getKindFromInt(CameraServerJNI.getSinkKind(sink)) == VideoSink.Kind.kMjpeg) {
+            && VideoSink.getKindFromInt(CameraServerJNI.getSinkKind(sink))
+            == VideoSink.Kind.kMjpeg) {
           // Add USB-only passthrough
           String[] finalValues = Arrays.copyOf(values, values.length + 1);
           int port = CameraServerJNI.getMjpegServerPort(sink);

--- a/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
+++ b/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
@@ -142,17 +142,20 @@ public final class CameraServer {
       values[j] = "mjpg:" + values[j];
     }
 
-    // Look to see if we have a passthrough server for this source
-    for (VideoSink i : m_sinks.values()) {
-      int sink = i.getHandle();
-      int sinkSource = CameraServerJNI.getSinkSource(sink);
-      if (source == sinkSource
-          && VideoSink.getKindFromInt(CameraServerJNI.getSinkKind(sink)) == VideoSink.Kind.kMjpeg) {
-        // Add USB-only passthrough
-        String[] finalValues = Arrays.copyOf(values, values.length + 1);
-        int port = CameraServerJNI.getMjpegServerPort(sink);
-        finalValues[values.length] = makeStreamValue("172.22.11.2", port);
-        return finalValues;
+    if (CameraServerSharedStore.getCameraServerShared().isRoboRIO()) {
+      // Look to see if we have a passthrough server for this source
+      // Only do this on the roboRIO
+      for (VideoSink i : m_sinks.values()) {
+        int sink = i.getHandle();
+        int sinkSource = CameraServerJNI.getSinkSource(sink);
+        if (source == sinkSource
+            && VideoSink.getKindFromInt(CameraServerJNI.getSinkKind(sink)) == VideoSink.Kind.kMjpeg) {
+          // Add USB-only passthrough
+          String[] finalValues = Arrays.copyOf(values, values.length + 1);
+          int port = CameraServerJNI.getMjpegServerPort(sink);
+          finalValues[values.length] = makeStreamValue("172.22.11.2", port);
+          return finalValues;
+        }
       }
     }
 

--- a/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServerShared.java
+++ b/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServerShared.java
@@ -43,4 +43,13 @@ public interface CameraServerShared {
    * @param id the usage id
    */
   void reportAxisCamera(int id);
+
+  /**
+   * Get if running on a roboRIO.
+   *
+   * @return true if on roboRIO
+   */
+  default boolean isRoboRIO() {
+    return false;
+  }
 }

--- a/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
+++ b/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
@@ -132,7 +132,9 @@ std::vector<std::string> CameraServer::Impl::GetSourceStreamValues(
   auto values = cs::GetHttpCameraUrls(source, &status);
   for (auto& value : values) value = "mjpg:" + value;
 
+#ifdef __FRC_ROBORIO__
   // Look to see if we have a passthrough server for this source
+  // Only do this on the roboRIO
   for (const auto& i : m_sinks) {
     CS_Sink sink = i.second.GetHandle();
     CS_Source sinkSource = cs::GetSinkSource(sink, &status);
@@ -144,6 +146,7 @@ std::vector<std::string> CameraServer::Impl::GetSourceStreamValues(
       break;
     }
   }
+#endif
 
   // Set table value
   return values;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/CameraServer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/CameraServer.java
@@ -153,7 +153,8 @@ public final class CameraServer {
         int sink = i.getHandle();
         int sinkSource = CameraServerJNI.getSinkSource(sink);
         if (source == sinkSource
-            && VideoSink.getKindFromInt(CameraServerJNI.getSinkKind(sink)) == VideoSink.Kind.kMjpeg) {
+            && VideoSink.getKindFromInt(CameraServerJNI.getSinkKind(sink))
+            == VideoSink.Kind.kMjpeg) {
           // Add USB-only passthrough
           String[] finalValues = Arrays.copyOf(values, values.length + 1);
           int port = CameraServerJNI.getMjpegServerPort(sink);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/CameraServer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/CameraServer.java
@@ -146,17 +146,20 @@ public final class CameraServer {
       values[j] = "mjpg:" + values[j];
     }
 
-    // Look to see if we have a passthrough server for this source
-    for (VideoSink i : m_sinks.values()) {
-      int sink = i.getHandle();
-      int sinkSource = CameraServerJNI.getSinkSource(sink);
-      if (source == sinkSource
-          && VideoSink.getKindFromInt(CameraServerJNI.getSinkKind(sink)) == VideoSink.Kind.kMjpeg) {
-        // Add USB-only passthrough
-        String[] finalValues = Arrays.copyOf(values, values.length + 1);
-        int port = CameraServerJNI.getMjpegServerPort(sink);
-        finalValues[values.length] = makeStreamValue("172.22.11.2", port);
-        return finalValues;
+    if (CameraServerSharedStore.getCameraServerShared().isRoboRIO()) {
+      // Look to see if we have a passthrough server for this source
+      // Only do this on the roboRIO
+      for (VideoSink i : m_sinks.values()) {
+        int sink = i.getHandle();
+        int sinkSource = CameraServerJNI.getSinkSource(sink);
+        if (source == sinkSource
+            && VideoSink.getKindFromInt(CameraServerJNI.getSinkKind(sink)) == VideoSink.Kind.kMjpeg) {
+          // Add USB-only passthrough
+          String[] finalValues = Arrays.copyOf(values, values.length + 1);
+          int port = CameraServerJNI.getMjpegServerPort(sink);
+          finalValues[values.length] = makeStreamValue("172.22.11.2", port);
+          return finalValues;
+        }
       }
     }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -67,6 +67,11 @@ public abstract class RobotBase implements AutoCloseable {
       public Long getRobotMainThreadId() {
         return MAIN_THREAD_ID;
       }
+
+      @Override
+      public boolean isRoboRIO() {
+        return RobotBase.isReal();
+      }
     };
 
     CameraServerSharedStore.setCameraServerShared(shared);


### PR DESCRIPTION
Otherwise accidentally, a race could occur between coprocessors and rio

Java was done in both old and new locations as its a race