### PR TITLE
Fix linker errors with free functions in Threads.h

### DIFF
--- a/wpilibc/src/main/native/cpp/Threads.cpp
+++ b/wpilibc/src/main/native/cpp/Threads.cpp
@@ -12,7 +12,7 @@
 
 #include "frc/ErrorBase.h"
 
-using namespace frc;
+namespace frc {
 
 int GetThreadPriority(std::thread& thread, bool* isRealTime) {
   int32_t status = 0;
@@ -47,3 +47,5 @@ bool SetCurrentThreadPriority(bool realTime, int priority) {
   wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
   return ret;
 }
+
+}  // namespace frc


### PR DESCRIPTION
The functions in Threads.h are in the frc namespace. `using namespace frc;` in
Threads.cpp doesn't put their implementations in the frc namespace, so linker
errors occur when attempting to use them in robot programs.

To fix this, one can either wrap them in a namespace block or prepend
`frc::` to the implementation's signature. Based on past discussion, I
opted for the namespace block.