### PR TITLE
Disable extraneous data warnings in libjpeg

### DIFF
--- a/shared/opencv.gradle
+++ b/shared/opencv.gradle
@@ -1,4 +1,4 @@
-def opencvVersion = '3.4.4-4'
+def opencvVersion = '3.4.4-5'
 
 if (project.hasProperty('useCpp') && project.useCpp) {
     model {


### PR DESCRIPTION
These are common with USB cameras.