### PR TITLE
[wpilib] Add FiberScheduler class

### DIFF
--- a/wpilibc/src/main/native/cpp/Fiber.cpp
+++ b/wpilibc/src/main/native/cpp/Fiber.cpp
@@ -1,0 +1,17 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/Fiber.h"
+
+using namespace frc;
+
+Fiber::Fiber(double period, std::function<void()> callback)
+    : m_period(static_cast<int64_t>(period * 1.0e6)), m_callback(callback) {}
+
+bool Fiber::operator>(const Fiber& rhs) {
+  return m_expirationTime > rhs.m_expirationTime;
+}

--- a/wpilibc/src/main/native/cpp/FiberScheduler.cpp
+++ b/wpilibc/src/main/native/cpp/FiberScheduler.cpp
@@ -1,0 +1,111 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/FiberScheduler.h"
+
+#include <hal/HALBase.h>
+#include <hal/Threads.h>
+#include <wpi/PriorityQueue.h>
+
+#include "frc/ErrorBase.h"
+#include "frc/Fiber.h"
+
+using namespace frc;
+
+class FiberScheduler::Thread : public wpi::SafeThread {
+ public:
+  template <typename T>
+  struct DerefGreater {
+    constexpr bool operator()(const T& lhs, const T& rhs) const {
+      return *lhs > *rhs;
+    }
+  };
+
+  wpi::PriorityQueue<Fiber*, std::vector<Fiber*>, DerefGreater<Fiber*>>
+      m_fibers;
+
+ private:
+  void Main() override;
+};
+
+void FiberScheduler::Thread::Main() {
+  std::unique_lock<wpi::mutex> lock(m_mutex);
+
+  while (m_active) {
+    if (m_fibers.size() > 0) {
+      if (m_cond.wait_until(lock, m_fibers.top()->m_expirationTime) ==
+          std::cv_status::timeout) {
+        if (m_fibers.size() == 0 ||
+            m_fibers.top()->m_expirationTime > hal::fpga_clock::now()) {
+          continue;
+        }
+
+        // If the condition variable timed out, a Fiber is ready to run
+        auto& fiber = *m_fibers.top();
+        m_fibers.pop();
+
+        lock.unlock();
+        fiber.m_callback();
+        lock.lock();
+
+        // Reschedule Fiber
+        fiber.m_startTime = hal::fpga_clock::now();
+        fiber.m_expirationTime = fiber.m_startTime + fiber.m_period;
+        m_fibers.emplace(&fiber);
+      }
+      // Otherwise, a Fiber removed itself from the queue (it notifies the
+      // scheduler of this) or a spurious wakeup occurred, so just rewait with
+      // the soonest watchdog timeout.
+    } else {
+      m_cond.wait(lock, [&] { return m_fibers.size() > 0 || !m_active; });
+    }
+  }
+}
+
+FiberScheduler::FiberScheduler() { m_owner.Start(); }
+
+FiberScheduler::FiberScheduler(int priority) : FiberScheduler() {
+  auto native = m_owner.GetNativeThreadHandle();
+  int32_t status = 0;
+  HAL_SetThreadPriority(&native, true, priority, &status);
+  wpi_setGlobalErrorWithContext(status, HAL_GetErrorMessage(status));
+}
+
+FiberScheduler::~FiberScheduler() {
+  {
+    // Locks mutex
+    auto thr = m_owner.GetThread();
+    if (!thr) return;
+
+    while (!thr->m_fibers.empty()) {
+      thr->m_fibers.pop();
+    }
+  }
+  m_owner.Join();
+}
+
+void FiberScheduler::Add(Fiber& fiber) {
+  fiber.m_startTime = hal::fpga_clock::now();
+
+  // Locks mutex
+  auto thr = m_owner.GetThread();
+  if (!thr) return;
+
+  thr->m_fibers.remove(&fiber);
+  fiber.m_expirationTime = fiber.m_startTime + fiber.m_period;
+  thr->m_fibers.emplace(&fiber);
+  thr->m_cond.notify_all();
+}
+
+void FiberScheduler::Remove(Fiber& fiber) {
+  // Locks mutex
+  auto thr = m_owner.GetThread();
+  if (!thr) return;
+
+  thr->m_fibers.remove(&fiber);
+  thr->m_cond.notify_all();
+}

--- a/wpilibc/src/main/native/include/frc/Fiber.h
+++ b/wpilibc/src/main/native/include/frc/Fiber.h
@@ -1,0 +1,56 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <utility>
+
+#include <hal/cpp/fpga_clock.h>
+
+namespace frc {
+
+class FiberScheduler;
+
+/**
+ * A wrapper around a callable object with an execution period.
+ *
+ * FiberScheduler can be used to run it periodically.
+ */
+class Fiber {
+ public:
+  /**
+   * Fiber constructor.
+   *
+   * @param period   The period between callback invocations in seconds with
+   *                 microsecond resolution.
+   * @param callback The function to call every period.
+   */
+  Fiber(double period, std::function<void()> callback);
+
+  template <typename Callable, typename Arg, typename... Args>
+  Fiber(double period, Callable&& f, Arg&& arg, Args&&... args)
+      : Fiber(period,
+              std::bind(std::forward<Callable>(f), std::forward<Arg>(arg),
+                        std::forward<Args>(args)...)) {}
+
+  Fiber(Fiber&&) = default;
+  Fiber& operator=(Fiber&&) = default;
+
+ private:
+  hal::fpga_clock::time_point m_startTime;
+  std::chrono::microseconds m_period;
+  hal::fpga_clock::time_point m_expirationTime;
+  std::function<void()> m_callback;
+
+  bool operator>(const Fiber& rhs);
+
+  friend class FiberScheduler;
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/Fiber.h
+++ b/wpilibc/src/main/native/include/frc/Fiber.h
@@ -43,7 +43,6 @@ class Fiber {
   Fiber& operator=(Fiber&&) = default;
 
  private:
-  hal::fpga_clock::time_point m_startTime;
   std::chrono::microseconds m_period;
   hal::fpga_clock::time_point m_expirationTime;
   std::function<void()> m_callback;

--- a/wpilibc/src/main/native/include/frc/FiberScheduler.h
+++ b/wpilibc/src/main/native/include/frc/FiberScheduler.h
@@ -1,0 +1,67 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <wpi/SafeThread.h>
+
+namespace frc {
+
+class Fiber;
+
+/**
+ * A class for that schedules Fibers to run on an internal thread.
+ */
+class FiberScheduler {
+ public:
+  /**
+   * FiberScheduler constructor.
+   *
+   * Constructs a non-real-time thread on which to run scheduled fibers.
+   */
+  FiberScheduler();
+
+  /**
+   * FiberScheduler constructor.
+   *
+   * Constructs a real-time thread on which to run scheduled fibers.
+   *
+   * @param priority The priority at which to run the internal thread (1..99
+   *                 where 1 is highest priority).
+   */
+  explicit FiberScheduler(int priority);
+
+  ~FiberScheduler();
+
+  FiberScheduler(FiberScheduler&&) = default;
+  FiberScheduler& operator=(FiberScheduler&&) = default;
+
+  /**
+   * Add a fiber to the scheduler.
+   *
+   * The fiber will automaticaly start running after its period has elapsed.
+   *
+   * @param fiber The fiber to add.
+   */
+  void Add(Fiber& fiber);
+
+  /**
+   * Remove a fiber from the scheduler.
+   *
+   * This will wait until the current fiber has stopped running, then remove
+   * the given fiber from the scheduler.
+   *
+   * @param fiber The fiber to remove.
+   */
+  void Remove(Fiber& fiber);
+
+ private:
+  class Thread;
+  wpi::SafeThreadOwner<Thread> m_owner;
+};
+
+}  // namespace frc

--- a/wpilibc/src/test/native/cpp/FiberSchedulerTest.cpp
+++ b/wpilibc/src/test/native/cpp/FiberSchedulerTest.cpp
@@ -1,0 +1,81 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/FiberScheduler.h"  // NOLINT(build/include_order)
+
+#include "frc/Fiber.h"  // NOLINT(build/include_order)
+
+#include <stdint.h>
+
+#include <thread>
+
+#include <wpi/raw_ostream.h>
+
+#include "gtest/gtest.h"
+
+using namespace frc;
+
+TEST(FiberSchedulerTest, AddRemove) {
+  uint32_t fiberCounter = 0;
+
+  FiberScheduler scheduler;
+  Fiber fiber(0.4, [&] { fiberCounter++; });
+
+  wpi::outs() << "Run 1\n";
+  scheduler.Add(fiber);
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  scheduler.Remove(fiber);
+
+  EXPECT_EQ(0u, fiberCounter) << "Fiber triggered early";
+
+  wpi::outs() << "Run 2\n";
+  fiberCounter = 0;
+  scheduler.Add(fiber);
+  std::this_thread::sleep_for(std::chrono::milliseconds(600));
+  scheduler.Remove(fiber);
+
+  EXPECT_EQ(1u, fiberCounter)
+      << "Fiber either didn't trigger or triggered more than once";
+
+  wpi::outs() << "Run 3\n";
+  fiberCounter = 0;
+  scheduler.Add(fiber);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  scheduler.Remove(fiber);
+
+  // Fiber scheduled every 400ms runs twice in 1000ms
+  EXPECT_EQ(2u, fiberCounter)
+      << "Fiber either didn't trigger or triggered more than once";
+}
+
+#ifdef __APPLE__
+TEST(FiberSchedulerTest, DISABLED_MultiFiber) {
+#else
+TEST(FiberSchedulerTest, MultiFiber) {
+#endif
+  uint32_t fiberCounter1 = 0;
+  uint32_t fiberCounter2 = 0;
+
+  FiberScheduler scheduler;
+  Fiber fiber1(0.2, [&] { fiberCounter1++; });
+  Fiber fiber2(0.6, [&] { fiberCounter2++; });
+
+  scheduler.Add(fiber2);
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_EQ(0u, fiberCounter1) << "Fiber triggered early";
+  EXPECT_EQ(0u, fiberCounter2) << "Fiber triggered early";
+
+  // Sleep enough such that only the fiber enabled later times out first
+  scheduler.Add(fiber1);
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  scheduler.Remove(fiber1);
+  scheduler.Remove(fiber2);
+
+  EXPECT_EQ(1u, fiberCounter1)
+      << "Fiber either didn't trigger or triggered more than once";
+  EXPECT_EQ(0u, fiberCounter2) << "Fiber triggered early";
+}

--- a/wpilibcIntegrationTests/src/main/native/cpp/FiberSchedulerTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/FiberSchedulerTest.cpp
@@ -1,0 +1,80 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/FiberScheduler.h"  // NOLINT(build/include_order)
+
+#include "frc/Fiber.h"  // NOLINT(build/include_order)
+
+#include <stdint.h>
+
+#include <thread>
+
+#include <wpi/raw_ostream.h>
+
+#include "gtest/gtest.h"
+
+using namespace frc;
+
+TEST(FiberSchedulerTest, RtAddRemove) {
+  uint32_t fiberCounter = 0;
+
+  FiberScheduler scheduler{60};
+  Fiber fiber(0.4, [&] { fiberCounter++; });
+
+  wpi::outs() << "Run 1\n";
+  scheduler.Add(fiber);
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  scheduler.Remove(fiber);
+
+  EXPECT_EQ(0u, fiberCounter) << "Fiber triggered early";
+
+  wpi::outs() << "Run 2\n";
+  fiberCounter = 0;
+  scheduler.Add(fiber);
+  std::this_thread::sleep_for(std::chrono::milliseconds(600));
+  scheduler.Remove(fiber);
+
+  EXPECT_EQ(1u, fiberCounter)
+      << "Fiber either didn't trigger or triggered more than once";
+
+  wpi::outs() << "Run 3\n";
+  fiberCounter = 0;
+  scheduler.Add(fiber);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  scheduler.Remove(fiber);
+
+  EXPECT_EQ(1u, fiberCounter)
+      << "Fiber either didn't trigger or triggered more than once";
+}
+
+#ifdef __APPLE__
+TEST(FiberSchedulerTest, DISABLED_RtMultiFiber) {
+#else
+TEST(FiberSchedulerTest, RtMultiFiber) {
+#endif
+  uint32_t fiberCounter1 = 0;
+  uint32_t fiberCounter2 = 0;
+
+  FiberScheduler scheduler{60};
+  Fiber fiber1(0.2, [&] { fiberCounter1++; });
+  Fiber fiber2(0.6, [&] { fiberCounter2++; });
+
+  scheduler.Add(fiber2);
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_EQ(0u, fiberCounter1) << "Fiber triggered early";
+  EXPECT_EQ(0u, fiberCounter2) << "Fiber triggered early";
+
+  // Sleep enough such that only the fiber enabled later times out first
+  scheduler.Add(fiber1);
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  scheduler.Remove(fiber1);
+  scheduler.Remove(fiber2);
+
+  EXPECT_EQ(1u, fiberCounter1)
+      << "Fiber either didn't trigger or triggered more than once";
+  EXPECT_EQ(0u, fiberCounter2) << "Fiber triggered early";
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Fiber.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Fiber.java
@@ -1,0 +1,45 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj;
+
+/**
+ * A wrapper around a callable object with an execution period.
+ *
+ * <p>FiberScheduler can be used to run it periodically.
+ */
+public class Fiber implements Comparable<Fiber> {
+  long m_startTime; // us
+  long m_period; // us
+  long m_expirationTime; // us
+  final Runnable m_callback;
+
+  /**
+   * Fiber constructor.
+   *
+   * @param period   The period between callback invocations in seconds with
+   *                 microsecond resolution.
+   * @param callback The function to call every period.
+   */
+  public Fiber(double period, Runnable callback) {
+    m_period = (long) (period * 1.0e6);
+    m_callback = callback;
+  }
+
+  @Override
+  public int compareTo(Fiber rhs) {
+    // Elements with sooner expiration times are sorted as lesser. The head of
+    // Java's PriorityQueue is the least element.
+    if (m_expirationTime < rhs.m_expirationTime) {
+      return -1;
+    } else if (m_expirationTime > rhs.m_expirationTime) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Fiber.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Fiber.java
@@ -13,7 +13,6 @@ package edu.wpi.first.wpilibj;
  * <p>FiberScheduler can be used to run it periodically.
  */
 public class Fiber implements Comparable<Fiber> {
-  long m_startTime; // us
   long m_period; // us
   long m_expirationTime; // us
   final Runnable m_callback;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/FiberScheduler.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/FiberScheduler.java
@@ -1,0 +1,170 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj;
+
+import java.io.Closeable;
+import java.util.PriorityQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A class for that schedules Fibers to run on an internal thread.
+ */
+public class FiberScheduler implements Closeable {
+  private final Thread m_thread;
+  private boolean m_running;
+
+  private final PriorityQueue<Fiber> m_fibers = new PriorityQueue<>();
+  private final ReentrantLock m_queueMutex = new ReentrantLock();
+  private final Condition m_schedulerWaiter = m_queueMutex.newCondition();
+
+  /**
+   * FiberScheduler constructor.
+   *
+   * <p>Constructs a non-real-time thread on which to run scheduled fibers.
+   */
+  public FiberScheduler() {
+    m_thread = new Thread(() -> schedulerFunc());
+    m_running = true;
+    m_thread.start();
+  }
+
+  /**
+   * FiberScheduler constructor.
+   *
+   * <p>Constructs a real-time thread on which to run scheduled fibers.
+   *
+   * @param priority The priority at which to run the internal thread (1..99
+   *                 where 1 is highest priority).
+   */
+  public FiberScheduler(int priority) {
+    m_thread = new Thread(() -> {
+      Threads.setCurrentThreadPriority(true, priority);
+      schedulerFunc();
+    });
+    m_running = true;
+    m_thread.start();
+  }
+
+  @Override
+  public void close() {
+    m_queueMutex.lock();
+    try {
+      m_fibers.clear();
+      m_running = false;
+      m_schedulerWaiter.signalAll();
+    } finally {
+      m_queueMutex.unlock();
+    }
+
+    try {
+      m_thread.join();
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      ex.printStackTrace();
+    }
+  }
+
+  /**
+   * Add a fiber to the scheduler.
+   *
+   * <p>The fiber will automaticaly start running after its period has elapsed.
+   *
+   * @param fiber The fiber to add.
+   */
+  public void add(Fiber fiber) {
+    fiber.m_startTime = RobotController.getFPGATime();
+
+    m_queueMutex.lock();
+    try {
+      m_fibers.remove(fiber);
+      fiber.m_expirationTime = fiber.m_startTime + fiber.m_period;
+      m_fibers.add(fiber);
+      m_schedulerWaiter.signalAll();
+    } finally {
+      m_queueMutex.unlock();
+    }
+  }
+
+  /**
+   * Remove a fiber from the scheduler.
+   *
+   * <p>This will wait until the current fiber has stopped running, then remove
+   * the given fiber from the scheduler.
+   *
+   * @param fiber The fiber to remove.
+   */
+  public void remove(Fiber fiber) {
+    m_queueMutex.lock();
+    try {
+      m_fibers.remove(this);
+      m_schedulerWaiter.signalAll();
+    } finally {
+      m_queueMutex.unlock();
+    }
+  }
+
+  private void schedulerFunc() {
+    m_queueMutex.lock();
+
+    try {
+      while (m_running) {
+        if (m_fibers.size() > 0) {
+          boolean timedOut = !awaitUntil(m_schedulerWaiter, m_fibers.peek().m_expirationTime);
+          if (timedOut) {
+            if (m_fibers.size() == 0 || m_fibers.peek().m_expirationTime
+                > RobotController.getFPGATime()) {
+              continue;
+            }
+
+            // If the condition variable timed out, a Fiber is ready to run
+            Fiber fiber = m_fibers.poll();
+
+            m_queueMutex.unlock();
+            fiber.m_callback.run();
+            m_queueMutex.lock();
+
+            // Reschedule Fiber
+            fiber.m_startTime = RobotController.getFPGATime();
+            fiber.m_expirationTime = fiber.m_startTime + fiber.m_period;
+            m_fibers.add(fiber);
+          }
+          // Otherwise, a Fiber removed itself from the queue (it notifies the
+          // scheduler of this) or a spurious wakeup occurred, so just rewait
+          // with the soonest watchdog timeout.
+        } else {
+          while (m_fibers.size() == 0) {
+            m_schedulerWaiter.awaitUninterruptibly();
+          }
+        }
+      }
+    } finally {
+      m_queueMutex.unlock();
+    }
+  }
+
+  /**
+   * Wrapper emulating functionality of C++'s std::condition_variable::wait_until().
+   *
+   * @param cond The condition variable on which to wait.
+   * @param time The time at which to stop waiting.
+   * @return False if the deadline has elapsed upon return, else true.
+   */
+  private static boolean awaitUntil(Condition cond, long time) {
+    long delta = time - RobotController.getFPGATime();
+    try {
+      return cond.await(delta, TimeUnit.MICROSECONDS);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      ex.printStackTrace();
+    }
+
+    return true;
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/FiberScheduler.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/FiberScheduler.java
@@ -79,12 +79,12 @@ public class FiberScheduler implements Closeable {
    * @param fiber The fiber to add.
    */
   public void add(Fiber fiber) {
-    fiber.m_startTime = RobotController.getFPGATime();
+    long startTime = RobotController.getFPGATime();
 
     m_queueMutex.lock();
     try {
       m_fibers.remove(fiber);
-      fiber.m_expirationTime = fiber.m_startTime + fiber.m_period;
+      fiber.m_expirationTime = startTime + fiber.m_period;
       m_fibers.add(fiber);
       m_schedulerWaiter.signalAll();
     } finally {
@@ -131,8 +131,7 @@ public class FiberScheduler implements Closeable {
             m_queueMutex.lock();
 
             // Reschedule Fiber
-            fiber.m_startTime = RobotController.getFPGATime();
-            fiber.m_expirationTime = fiber.m_startTime + fiber.m_period;
+            fiber.m_expirationTime = RobotController.getFPGATime() + fiber.m_period;
             m_fibers.add(fiber);
           }
           // Otherwise, a Fiber removed itself from the queue (it notifies the

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/FiberSchedulerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/FiberSchedulerTest.java
@@ -1,0 +1,101 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FiberSchedulerTest {
+  @Test
+  void addRemoveTest() {
+    final AtomicInteger fiberCounter = new AtomicInteger(0);
+
+    final FiberScheduler scheduler = new FiberScheduler();
+    final Fiber fiber = new Fiber(0.4, () -> {
+      fiberCounter.addAndGet(1);
+    });
+
+    System.out.println("Run 1");
+    scheduler.add(fiber);
+    try {
+      Thread.sleep(200);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+    }
+    scheduler.remove(fiber);
+
+    assertEquals(0, fiberCounter.get(), "FiberScheduler triggered early");
+
+    System.out.println("Run 2");
+    fiberCounter.set(0);
+    scheduler.add(fiber);
+    try {
+      Thread.sleep(600);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+    }
+    scheduler.remove(fiber);
+
+    assertEquals(1, fiberCounter.get(),
+        "FiberScheduler either didn't trigger or triggered more than once");
+
+    // Run 3
+    fiberCounter.set(0);
+    scheduler.add(fiber);
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+    }
+    scheduler.remove(fiber);
+
+    // Fiber scheduled every 400ms runs twice in 1000ms
+    assertEquals(2, fiberCounter.get(),
+        "FiberScheduler either didn't trigger or triggered more than once");
+  }
+
+  @Test
+  void multiFiberTest() {
+    final AtomicInteger fiberCounter1 = new AtomicInteger(0);
+    final AtomicInteger fiberCounter2 = new AtomicInteger(0);
+
+    final FiberScheduler scheduler = new FiberScheduler();
+    final Fiber fiber1 = new Fiber(0.2, () -> {
+      fiberCounter1.addAndGet(1);
+    });
+    final Fiber fiber2 = new Fiber(0.6, () -> {
+      fiberCounter2.addAndGet(1);
+    });
+
+    scheduler.add(fiber2);
+    try {
+      Thread.sleep(200);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+    }
+    assertEquals(0, fiberCounter1.get(), "FiberScheduler triggered early");
+    assertEquals(0, fiberCounter2.get(), "FiberScheduler triggered early");
+
+    // Sleep enough such that only the fiber enabled later times out first
+    scheduler.add(fiber1);
+    try {
+      Thread.sleep(300);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+    }
+    scheduler.remove(fiber1);
+    scheduler.remove(fiber2);
+
+    assertEquals(1, fiberCounter1.get(),
+        "FiberScheduler either didn't trigger or triggered more than once");
+    assertEquals(0, fiberCounter2.get(), "FiberScheduler triggered early");
+  }
+}


### PR DESCRIPTION
FiberScheduler provides a way of running arbitrary functions at desired
periods on a single optionally RT thread. This reduces context switch
overhead from using Notifiers, which each have their own thread and
condition variable.

The scheduling logic is based on the Watchdog class.