### PR TITLE
Add StartWhileActive() method in Trigger and Button

### DIFF
--- a/wpilibc/src/main/native/cpp/buttons/StartWhilePressedButtonScheduler.cpp
+++ b/wpilibc/src/main/native/cpp/buttons/StartWhilePressedButtonScheduler.cpp
@@ -12,8 +12,8 @@
 
 using namespace frc;
 
-StartWhilePressedButtonScheduler::StartWhilePressedButtonScheduler(bool last, Trigger* button,
-                                                                  Command* orders)
+StartWhilePressedButtonScheduler::StartWhilePressedButtonScheduler(
+    bool last, Trigger* button, Command* orders)
     : ButtonScheduler(last, button, orders) {}
 
 void StartWhilePressedButtonScheduler::Execute() {

--- a/wpilibc/src/main/native/cpp/buttons/StartWhilePressedButtonScheduler.cpp
+++ b/wpilibc/src/main/native/cpp/buttons/StartWhilePressedButtonScheduler.cpp
@@ -5,18 +5,23 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#include "frc/buttons/StartWhilePressedButtonScheduler.h"
+
 #include "frc/buttons/Button.h"
+#include "frc/commands/Command.h"
 
 using namespace frc;
 
-void Button::WhenPressed(Command* command) { WhenActive(command); }
+StartWhilePressedButtonScheduler::StartWhilePressedButtonScheduler(bool last, Trigger* button,
+                                                                  Command* orders)
+    : ButtonScheduler(last, button, orders) {}
 
-void Button::WhileHeld(Command* command) { WhileActive(command); }
+void StartWhilePressedButtonScheduler::Execute() {
+  bool pressed = m_button->Grab();
 
-void Button::StartWhileHeld(Command* command) { StartWhileActive(command); }
+  if (pressed) {
+    m_command->Start();
+  }
 
-void Button::WhenReleased(Command* command) { WhenInactive(command); }
-
-void Button::CancelWhenPressed(Command* command) { CancelWhenActive(command); }
-
-void Button::ToggleWhenPressed(Command* command) { ToggleWhenActive(command); }
+  m_pressedLast = pressed;
+}

--- a/wpilibc/src/main/native/cpp/buttons/Trigger.cpp
+++ b/wpilibc/src/main/native/cpp/buttons/Trigger.cpp
@@ -10,8 +10,8 @@
 #include "frc/buttons/HeldButtonScheduler.h"
 #include "frc/buttons/PressedButtonScheduler.h"
 #include "frc/buttons/ReleasedButtonScheduler.h"
-#include "frc/buttons/ToggleButtonScheduler.h"
 #include "frc/buttons/StartWhilePressedButtonScheduler.h"
+#include "frc/buttons/ToggleButtonScheduler.h"
 #include "frc/smartdashboard/SendableBuilder.h"
 
 using namespace frc;

--- a/wpilibc/src/main/native/cpp/buttons/Trigger.cpp
+++ b/wpilibc/src/main/native/cpp/buttons/Trigger.cpp
@@ -8,6 +8,7 @@
 #include "frc/buttons/Button.h"
 #include "frc/buttons/CancelButtonScheduler.h"
 #include "frc/buttons/HeldButtonScheduler.h"
+#include "frc/buttons/StartWhilePressedButtonScheduler.h"
 #include "frc/buttons/PressedButtonScheduler.h"
 #include "frc/buttons/ReleasedButtonScheduler.h"
 #include "frc/buttons/ToggleButtonScheduler.h"
@@ -24,6 +25,11 @@ void Trigger::WhenActive(Command* command) {
 
 void Trigger::WhileActive(Command* command) {
   auto hbs = new HeldButtonScheduler(Grab(), this, command);
+  hbs->Start();
+}
+
+void Trigger::StartWhileActive(Command* command) {
+  auto hbs = new StartWhilePressedButtonScheduler(Grab(), this, command);
   hbs->Start();
 }
 

--- a/wpilibc/src/main/native/cpp/buttons/Trigger.cpp
+++ b/wpilibc/src/main/native/cpp/buttons/Trigger.cpp
@@ -8,10 +8,10 @@
 #include "frc/buttons/Button.h"
 #include "frc/buttons/CancelButtonScheduler.h"
 #include "frc/buttons/HeldButtonScheduler.h"
-#include "frc/buttons/StartWhilePressedButtonScheduler.h"
 #include "frc/buttons/PressedButtonScheduler.h"
 #include "frc/buttons/ReleasedButtonScheduler.h"
 #include "frc/buttons/ToggleButtonScheduler.h"
+#include "frc/buttons/StartWhilePressedButtonScheduler.h"
 #include "frc/smartdashboard/SendableBuilder.h"
 
 using namespace frc;

--- a/wpilibc/src/main/native/include/frc/buttons/Button.h
+++ b/wpilibc/src/main/native/include/frc/buttons/Button.h
@@ -47,6 +47,16 @@ class Button : public Trigger {
   virtual void WhileHeld(Command* command);
 
   /**
+   * Specifies the command to run when a button is pressed.
+   *
+   * The command will be scheduled repeatedly while the button is pressed and
+   * will not be canceled until the command finishes .
+   *
+   * @param command The pointer to the command to run
+   */
+  virtual void StartWhileHeld(Command* command);
+
+  /**
    * Specifies the command to run when the button is released.
    *
    * The command will be scheduled a single time.

--- a/wpilibc/src/main/native/include/frc/buttons/StartWhilePressedButtonScheduler.h
+++ b/wpilibc/src/main/native/include/frc/buttons/StartWhilePressedButtonScheduler.h
@@ -19,8 +19,10 @@ class StartWhilePressedButtonScheduler : public ButtonScheduler {
   StartWhilePressedButtonScheduler(bool last, Trigger* button, Command* orders);
   virtual ~StartWhilePressedButtonScheduler() = default;
 
-  StartWhilePressedButtonScheduler(StartWhilePressedButtonScheduler&&) = default;
-  StartWhilePressedButtonScheduler& operator=(StartWhilePressedButtonScheduler&&) = default;
+  StartWhilePressedButtonScheduler(StartWhilePressedButtonScheduler&&) =
+      default;
+  StartWhilePressedButtonScheduler& operator=(
+      StartWhilePressedButtonScheduler&&) = default;
 
   virtual void Execute();
 };

--- a/wpilibc/src/main/native/include/frc/buttons/StartWhilePressedButtonScheduler.h
+++ b/wpilibc/src/main/native/include/frc/buttons/StartWhilePressedButtonScheduler.h
@@ -1,0 +1,28 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2011-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include "frc/buttons/ButtonScheduler.h"
+
+namespace frc {
+
+class Trigger;
+class Command;
+
+class StartWhilePressedButtonScheduler : public ButtonScheduler {
+ public:
+  StartWhilePressedButtonScheduler(bool last, Trigger* button, Command* orders);
+  virtual ~StartWhilePressedButtonScheduler() = default;
+
+  StartWhilePressedButtonScheduler(StartWhilePressedButtonScheduler&&) = default;
+  StartWhilePressedButtonScheduler& operator=(StartWhilePressedButtonScheduler&&) = default;
+
+  virtual void Execute();
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/buttons/Trigger.h
+++ b/wpilibc/src/main/native/include/frc/buttons/Trigger.h
@@ -40,6 +40,7 @@ class Trigger : public SendableBase {
   virtual bool Get() = 0;
   void WhenActive(Command* command);
   void WhileActive(Command* command);
+  void StartWhileActive(Command* command);
   void WhenInactive(Command* command);
   void CancelWhenActive(Command* command);
   void ToggleWhenActive(Command* command);


### PR DESCRIPTION
### Changes
- Add StartWhilePressedButtonScheduler class
- Add StartWhileActive() method in Trigger class
- Add StartWhileHeld() method in Button class

### Description
The command passed as argument in both methods will be scheduled repeatedly while the button is pressed. This behaviour is similar to the WhileActive() or WhileHeld() methods.
However, unlike both of these methods, the command will not be cancelled until it finishes.

This is a mix of WhenActive() and WhileActive() methods.

### Example
An example of using this feature would be a TimedCommand x that rotates the wheels of an intake for 3 seconds :
- If WhenActive is used, the command will stop after 3 seconds even if the pilot keeps pressing the button.
- If WhileActive is used, the command will stop as soon as the pilot releases the button.

StartWhileActive would allow the command to run as long as the pilot presses the button and continue 3 seconds after he releases.

### Other
I don't know if this is the right way to do it and I have not tested it, so tell me if I am completely wrong.
I have no Java knowledge, that why I only add the C++ version of the feature to begin.