### PR TITLE
[wpilib] Clean up drive class implementations

### DIFF
--- a/wpilibc/src/main/native/cpp/GenericHID.cpp
+++ b/wpilibc/src/main/native/cpp/GenericHID.cpp
@@ -4,6 +4,8 @@
 
 #include "frc/GenericHID.h"
 
+#include <cmath>
+
 #include <hal/DriverStation.h>
 
 #include "frc/DriverStation.h"
@@ -31,7 +33,7 @@ bool GenericHID::GetRawButtonReleased(int button) {
 }
 
 double GenericHID::GetRawAxis(int axis) const {
-  return m_ds->GetStickAxis(m_port, axis);
+  return ApplyDeadband(m_ds->GetStickAxis(m_port, axis), m_deadband);
 }
 
 int GenericHID::GetPOV(int pov) const {
@@ -94,4 +96,20 @@ void GenericHID::SetRumble(RumbleType type, double value) {
     m_rightRumble = value * 65535;
   }
   HAL_SetJoystickOutputs(m_port, m_outputs, m_leftRumble, m_rightRumble);
+}
+
+void GenericHID::SetAxisDeadband(double deadband) {
+  m_deadband = deadband;
+}
+
+double GenericHID::ApplyDeadband(double value, double deadband) {
+  if (std::abs(value) > deadband) {
+    if (value > 0.0) {
+      return (value - deadband) / (1.0 - deadband);
+    } else {
+      return (value + deadband) / (1.0 - deadband);
+    }
+  } else {
+    return 0.0;
+  }
 }

--- a/wpilibc/src/main/native/cpp/frc2/drive/DifferentialDrive.cpp
+++ b/wpilibc/src/main/native/cpp/frc2/drive/DifferentialDrive.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc2/drive/DifferentialDrive.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <hal/HAL.h>
+
+#include "frc/SpeedController.h"
+#include "frc/smartdashboard/SendableBuilder.h"
+#include "frc/smartdashboard/SendableRegistry.h"
+
+using namespace frc2;
+
+DifferentialDrive::DifferentialDrive(frc::SpeedController& leftMotor,
+                                     frc::SpeedController& rightMotor)
+    : m_leftMotor(&leftMotor), m_rightMotor(&rightMotor) {
+  auto& registry = frc::SendableRegistry::GetInstance();
+  registry.AddChild(this, m_leftMotor);
+  registry.AddChild(this, m_rightMotor);
+  static int instances = 0;
+  ++instances;
+  registry.AddLW(this, "DifferentialDrive", instances);
+}
+
+void DifferentialDrive::ArcadeDrive(double xSpeed, double zRotation,
+                                    bool squareInputs) {
+  static bool reported = false;
+  if (!reported) {
+    HAL_Report(HALUsageReporting::kResourceType_RobotDrive, 2,
+               HALUsageReporting::kRobotDrive2_DifferentialArcade);
+    reported = true;
+  }
+
+  xSpeed = std::clamp(xSpeed, -1.0, 1.0);
+  zRotation = std::clamp(zRotation, -1.0, 1.0);
+
+  // Square the inputs (while preserving the sign) to increase fine control
+  // while permitting full power.
+  if (squareInputs) {
+    xSpeed = std::copysign(xSpeed * xSpeed, xSpeed);
+    zRotation = std::copysign(zRotation * zRotation, zRotation);
+  }
+
+  double leftSpeed = xSpeed + zRotation;
+  double rightSpeed = xSpeed - zRotation;
+
+  // Normalize wheel speeds
+  double maxMagnitude = std::max(std::abs(leftSpeed), std::abs(rightSpeed));
+  if (maxMagnitude > 1.0) {
+    leftSpeed /= maxMagnitude;
+    rightSpeed /= maxMagnitude;
+  }
+
+  m_leftMotor->Set(leftSpeed * m_maxOutput);
+  m_rightMotor->Set(rightSpeed * m_maxOutput);
+}
+
+void DifferentialDrive::CurvatureDrive(double xSpeed, double zRotation,
+                                       bool allowTurnInPlace) {
+  static bool reported = false;
+  if (!reported) {
+    HAL_Report(HALUsageReporting::kResourceType_RobotDrive, 2,
+               HALUsageReporting::kRobotDrive2_DifferentialCurvature);
+    reported = true;
+  }
+
+  xSpeed = std::clamp(xSpeed, -1.0, 1.0);
+  zRotation = std::clamp(zRotation, -1.0, 1.0);
+
+  double leftSpeed = 0.0;
+  double rightSpeed = 0.0;
+
+  if (allowTurnInPlace) {
+    leftSpeed = xSpeed + zRotation;
+    rightSpeed = xSpeed - zRotation;
+  } else {
+    leftSpeed = xSpeed + std::abs(xSpeed) * zRotation;
+    rightSpeed = xSpeed - std::abs(xSpeed) * zRotation;
+  }
+
+  // Normalize wheel speeds
+  double maxMagnitude = std::max(std::abs(leftSpeed), std::abs(rightSpeed));
+  if (maxMagnitude > 1.0) {
+    leftSpeed /= maxMagnitude;
+    rightSpeed /= maxMagnitude;
+  }
+
+  m_leftMotor->Set(leftSpeed * m_maxOutput);
+  m_rightMotor->Set(rightSpeed * m_maxOutput);
+}
+
+void DifferentialDrive::TankDrive(double leftSpeed, double rightSpeed,
+                                  bool squareInputs) {
+  static bool reported = false;
+  if (!reported) {
+    HAL_Report(HALUsageReporting::kResourceType_RobotDrive, 2,
+               HALUsageReporting::kRobotDrive2_DifferentialTank);
+    reported = true;
+  }
+
+  leftSpeed = std::clamp(leftSpeed, -1.0, 1.0);
+  rightSpeed = std::clamp(rightSpeed, -1.0, 1.0);
+
+  // Square the inputs (while preserving the sign) to increase fine control
+  // while permitting full power.
+  if (squareInputs) {
+    leftSpeed = std::copysign(leftSpeed * leftSpeed, leftSpeed);
+    rightSpeed = std::copysign(rightSpeed * rightSpeed, rightSpeed);
+  }
+
+  m_leftMotor->Set(leftSpeed * m_maxOutput);
+  m_rightMotor->Set(rightSpeed * m_maxOutput);
+}
+
+void DifferentialDrive::InitSendable(frc::SendableBuilder& builder) {
+  builder.SetSmartDashboardType("DifferentialDrive");
+  builder.SetActuator(true);
+  builder.AddDoubleProperty(
+      "Left Motor Speed", [=]() { return m_leftMotor->Get(); },
+      [=](double value) { m_leftMotor->Set(value); });
+  builder.AddDoubleProperty(
+      "Right Motor Speed", [=]() { return m_rightMotor->Get(); },
+      [=](double value) { m_rightMotor->Set(value); });
+}

--- a/wpilibc/src/main/native/cpp/frc2/drive/KilloughDrive.cpp
+++ b/wpilibc/src/main/native/cpp/frc2/drive/KilloughDrive.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc2/drive/KilloughDrive.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <hal/HAL.h>
+#include <wpi/math>
+
+#include "frc/SpeedController.h"
+#include "frc/smartdashboard/SendableBuilder.h"
+#include "frc/smartdashboard/SendableRegistry.h"
+
+using namespace frc2;
+
+KilloughDrive::KilloughDrive(frc::SpeedController& leftMotor,
+                             frc::SpeedController& rightMotor,
+                             frc::SpeedController& backMotor)
+    : KilloughDrive(leftMotor, rightMotor, backMotor, kDefaultLeftMotorAngle,
+                    kDefaultRightMotorAngle, kDefaultBackMotorAngle) {}
+
+KilloughDrive::KilloughDrive(frc::SpeedController& leftMotor,
+                             frc::SpeedController& rightMotor,
+                             frc::SpeedController& backMotor,
+                             double leftMotorAngle, double rightMotorAngle,
+                             double backMotorAngle)
+    : m_leftMotor(&leftMotor),
+      m_rightMotor(&rightMotor),
+      m_backMotor(&backMotor) {
+  m_leftVec = {std::cos(leftMotorAngle * (wpi::math::pi / 180.0)),
+               std::sin(leftMotorAngle * (wpi::math::pi / 180.0))};
+  m_rightVec = {std::cos(rightMotorAngle * (wpi::math::pi / 180.0)),
+                std::sin(rightMotorAngle * (wpi::math::pi / 180.0))};
+  m_backVec = {std::cos(backMotorAngle * (wpi::math::pi / 180.0)),
+               std::sin(backMotorAngle * (wpi::math::pi / 180.0))};
+  auto& registry = frc::SendableRegistry::GetInstance();
+  registry.AddChild(this, m_leftMotor);
+  registry.AddChild(this, m_rightMotor);
+  registry.AddChild(this, m_backMotor);
+  static int instances = 0;
+  ++instances;
+  registry.AddLW(this, "KilloughDrive", instances);
+}
+
+void KilloughDrive::DriveCartesian(double ySpeed, double xSpeed,
+                                   double zRotation, double gyroAngle) {
+  if (!reported) {
+    HAL_Report(HALUsageReporting::kResourceType_RobotDrive, 3,
+               HALUsageReporting::kRobotDrive2_KilloughCartesian);
+    reported = true;
+  }
+
+  ySpeed = std::clamp(ySpeed, -1.0, 1.0);
+  xSpeed = std::clamp(xSpeed, -1.0, 1.0);
+
+  // Compensate for gyro angle.
+  frc::Vector2d input{ySpeed, xSpeed};
+  input.Rotate(-gyroAngle);
+
+  double wheelSpeeds[3];
+  wheelSpeeds[kLeft] = input.ScalarProject(m_leftVec) + zRotation;
+  wheelSpeeds[kRight] = input.ScalarProject(m_rightVec) + zRotation;
+  wheelSpeeds[kBack] = input.ScalarProject(m_backVec) + zRotation;
+
+  Normalize(wheelSpeeds);
+
+  m_leftMotor->Set(wheelSpeeds[kLeft] * m_maxOutput);
+  m_rightMotor->Set(wheelSpeeds[kRight] * m_maxOutput);
+  m_backMotor->Set(wheelSpeeds[kBack] * m_maxOutput);
+}
+
+void KilloughDrive::DrivePolar(double magnitude, double angle,
+                               double zRotation) {
+  if (!reported) {
+    HAL_Report(HALUsageReporting::kResourceType_RobotDrive, 3,
+               HALUsageReporting::kRobotDrive2_KilloughPolar);
+    reported = true;
+  }
+
+  DriveCartesian(magnitude * std::sin(angle * (wpi::math::pi / 180.0)),
+                 magnitude * std::cos(angle * (wpi::math::pi / 180.0)),
+                 zRotation, 0.0);
+}
+
+void KilloughDrive::InitSendable(frc::SendableBuilder& builder) {
+  builder.SetSmartDashboardType("KilloughDrive");
+  builder.SetActuator(true);
+  builder.AddDoubleProperty(
+      "Left Motor Speed", [=]() { return m_leftMotor->Get(); },
+      [=](double value) { m_leftMotor->Set(value); });
+  builder.AddDoubleProperty(
+      "Right Motor Speed", [=]() { return m_rightMotor->Get(); },
+      [=](double value) { m_rightMotor->Set(value); });
+  builder.AddDoubleProperty(
+      "Back Motor Speed", [=]() { return m_backMotor->Get(); },
+      [=](double value) { m_backMotor->Set(value); });
+}

--- a/wpilibc/src/main/native/cpp/frc2/drive/MecanumDrive.cpp
+++ b/wpilibc/src/main/native/cpp/frc2/drive/MecanumDrive.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc2/drive/MecanumDrive.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <hal/HAL.h>
+#include <wpi/math>
+
+#include "frc/SpeedController.h"
+#include "frc/drive/Vector2d.h"
+#include "frc/smartdashboard/SendableBuilder.h"
+#include "frc/smartdashboard/SendableRegistry.h"
+
+using namespace frc2;
+
+MecanumDrive::MecanumDrive(frc::SpeedController& frontLeftMotor,
+                           frc::SpeedController& rearLeftMotor,
+                           frc::SpeedController& frontRightMotor,
+                           frc::SpeedController& rearRightMotor)
+    : m_frontLeftMotor(&frontLeftMotor),
+      m_rearLeftMotor(&rearLeftMotor),
+      m_frontRightMotor(&frontRightMotor),
+      m_rearRightMotor(&rearRightMotor) {
+  auto& registry = frc::SendableRegistry::GetInstance();
+  registry.AddChild(this, m_frontLeftMotor);
+  registry.AddChild(this, m_rearLeftMotor);
+  registry.AddChild(this, m_frontRightMotor);
+  registry.AddChild(this, m_rearRightMotor);
+  static int instances = 0;
+  ++instances;
+  registry.AddLW(this, "MecanumDrive", instances);
+}
+
+void MecanumDrive::DriveCartesian(double ySpeed, double xSpeed,
+                                  double zRotation, double gyroAngle) {
+  if (!reported) {
+    HAL_Report(HALUsageReporting::kResourceType_RobotDrive, 4,
+               HALUsageReporting::kRobotDrive2_MecanumCartesian);
+    reported = true;
+  }
+
+  ySpeed = std::clamp(ySpeed, -1.0, 1.0);
+  xSpeed = std::clamp(xSpeed, -1.0, 1.0);
+
+  // Compensate for gyro angle.
+  frc::Vector2d input{ySpeed, xSpeed};
+  input.Rotate(-gyroAngle);
+
+  double wheelSpeeds[4];
+  wheelSpeeds[kFrontLeft] = input.x + input.y + zRotation;
+  wheelSpeeds[kFrontRight] = input.x - input.y - zRotation;
+  wheelSpeeds[kRearLeft] = input.x - input.y + zRotation;
+  wheelSpeeds[kRearRight] = input.x + input.y - zRotation;
+
+  Normalize(wheelSpeeds);
+
+  m_frontLeftMotor->Set(wheelSpeeds[kFrontLeft] * m_maxOutput);
+  m_frontRightMotor->Set(wheelSpeeds[kFrontRight] * m_maxOutput);
+  m_rearLeftMotor->Set(wheelSpeeds[kRearLeft] * m_maxOutput);
+  m_rearRightMotor->Set(wheelSpeeds[kRearRight] * m_maxOutput);
+}
+
+void MecanumDrive::DrivePolar(double magnitude, double angle,
+                              double zRotation) {
+  if (!reported) {
+    HAL_Report(HALUsageReporting::kResourceType_RobotDrive, 4,
+               HALUsageReporting::kRobotDrive2_MecanumPolar);
+    reported = true;
+  }
+
+  DriveCartesian(magnitude * std::cos(angle * (wpi::math::pi / 180.0)),
+                 magnitude * std::sin(angle * (wpi::math::pi / 180.0)),
+                 zRotation, 0.0);
+}
+
+void MecanumDrive::InitSendable(frc::SendableBuilder& builder) {
+  builder.SetSmartDashboardType("MecanumDrive");
+  builder.SetActuator(true);
+  builder.AddDoubleProperty(
+      "Front Left Motor Speed", [=]() { return m_frontLeftMotor->Get(); },
+      [=](double value) { m_frontLeftMotor->Set(value); });
+  builder.AddDoubleProperty(
+      "Front Right Motor Speed", [=]() { return m_frontRightMotor->Get(); },
+      [=](double value) { m_frontRightMotor->Set(value); });
+  builder.AddDoubleProperty(
+      "Rear Left Motor Speed", [=]() { return m_rearLeftMotor->Get(); },
+      [=](double value) { m_rearLeftMotor->Set(value); });
+  builder.AddDoubleProperty(
+      "Rear Right Motor Speed", [=]() { return m_rearRightMotor->Get(); },
+      [=](double value) { m_rearRightMotor->Set(value); });
+}

--- a/wpilibc/src/main/native/cpp/frc2/drive/RobotDriveBase.cpp
+++ b/wpilibc/src/main/native/cpp/frc2/drive/RobotDriveBase.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc2/drive/RobotDriveBase.h"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace frc2;
+
+void RobotDriveBase::SetMaxOutput(double maxOutput) {
+  m_maxOutput = maxOutput;
+}
+
+void RobotDriveBase::Normalize(wpi::MutableArrayRef<double> wheelSpeeds) {
+  double maxMagnitude = std::abs(wheelSpeeds[0]);
+  for (size_t i = 1; i < wheelSpeeds.size(); i++) {
+    double temp = std::abs(wheelSpeeds[i]);
+    if (maxMagnitude < temp) {
+      maxMagnitude = temp;
+    }
+  }
+  if (maxMagnitude > 1.0) {
+    for (size_t i = 0; i < wheelSpeeds.size(); i++) {
+      wheelSpeeds[i] = wheelSpeeds[i] / maxMagnitude;
+    }
+  }
+}

--- a/wpilibc/src/main/native/include/frc/GenericHID.h
+++ b/wpilibc/src/main/native/include/frc/GenericHID.h
@@ -193,12 +193,32 @@ class GenericHID : public ErrorBase {
    */
   void SetRumble(RumbleType type, double value);
 
+  /**
+   * Sets the deadband applied to the joystick axes.
+   *
+   * Inputs smaller than the deadband are set to 0.0 while inputs larger than
+   * the deadband are scaled from 0.0 to 1.0. The default deadband is 0.0.
+   *
+   * @param deadband The deadband to set.
+   */
+  void SetAxisDeadband(double deadband);
+
  private:
   DriverStation* m_ds;
   int m_port;
   int m_outputs = 0;
   uint16_t m_leftRumble = 0;
   uint16_t m_rightRumble = 0;
+  double m_deadband = 0.0;
+
+  /**
+   * Returns 0.0 if the given value is within the specified range around zero.
+   * The remaining range between the deadband and 1.0 is scaled from 0.0 to 1.0.
+   *
+   * @param value    Value to clip.
+   * @param deadband Range around zero.
+   */
+  static double ApplyDeadband(double value, double deadband);
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc2/drive/DifferentialDrive.h
+++ b/wpilibc/src/main/native/include/frc2/drive/DifferentialDrive.h
@@ -1,0 +1,157 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <wpi/raw_ostream.h>
+
+#include "frc/smartdashboard/Sendable.h"
+#include "frc/smartdashboard/SendableHelper.h"
+#include "frc2/drive/RobotDriveBase.h"
+
+namespace frc {
+class SpeedController;
+}  // namespace frc
+
+namespace frc2 {
+
+/**
+ * A class for driving differential drive/skid-steer drive platforms such as
+ * the Kit of Parts drive base, "tank drive", or West Coast Drive.
+ *
+ * These drive bases typically have drop-center / skid-steer with two or more
+ * wheels per side (e.g., 6WD or 8WD). This class takes a SpeedController per
+ * side. For four and six motor drivetrains, construct and pass in
+ * SpeedControllerGroup instances as follows.
+ *
+ * Four motor drivetrain:
+ * @code{.cpp}
+ * class Robot {
+ *  public:
+ *   frc::Spark m_frontLeft{1};
+ *   frc::Spark m_rearLeft{2};
+ *   frc::SpeedControllerGroup m_left{m_frontLeft, m_rearLeft};
+ *
+ *   frc::Spark m_frontRight{3};
+ *   frc::Spark m_rearRight{4};
+ *   frc::SpeedControllerGroup m_right{m_frontRight, m_rearRight};
+ *
+ *   frc::DifferentialDrive m_drive{m_left, m_right};
+ * };
+ * @endcode
+ *
+ * Six motor drivetrain:
+ * @code{.cpp}
+ * class Robot {
+ *  public:
+ *   frc::Spark m_frontLeft{1};
+ *   frc::Spark m_midLeft{2};
+ *   frc::Spark m_rearLeft{3};
+ *   frc::SpeedControllerGroup m_left{m_frontLeft, m_midLeft, m_rearLeft};
+ *
+ *   frc::Spark m_frontRight{4};
+ *   frc::Spark m_midRight{5};
+ *   frc::Spark m_rearRight{6};
+ *   frc::SpeedControllerGroup m_right{m_frontRight, m_midRight, m_rearRight};
+ *
+ *   frc::DifferentialDrive m_drive{m_left, m_right};
+ * };
+ * @endcode
+ *
+ * A differential drive robot has left and right wheels separated by an
+ * arbitrary width.
+ *
+ * Drive base diagram:
+ * <pre>
+ * |_______|
+ * | |   | |
+ *   |   |
+ * |_|___|_|
+ * |       |
+ * </pre>
+ *
+ * Each Drive() function provides different inverse kinematic relations for a
+ * differential drive robot. Note that motor direction inversion by the user is
+ * usually unnecessary.
+ *
+ * This library uses the NED axes convention (North-East-Down as external
+ * reference in the world frame):
+ * http://www.nuclearprojects.com/ins/images/axis_big.png.
+ *
+ * The positive X axis points ahead, the positive Y axis points to the right,
+ * and the positive Z axis points down. Rotations follow the right-hand rule, so
+ * clockwise rotation around the Z axis is positive.
+ */
+class DifferentialDrive : public RobotDriveBase,
+                          public frc::Sendable,
+                          public frc::SendableHelper<DifferentialDrive> {
+ public:
+  /**
+   * Construct a DifferentialDrive.
+   *
+   * To pass multiple motors per side, use a SpeedControllerGroup. If a motor
+   * needs to be inverted, do so before passing it in.
+   *
+   * @param leftMotor Left motor.
+   * @param rightMotor Right motor.
+   */
+  DifferentialDrive(frc::SpeedController& leftMotor,
+                    frc::SpeedController& rightMotor);
+
+  ~DifferentialDrive() override = default;
+
+  DifferentialDrive(DifferentialDrive&&) = default;
+  DifferentialDrive& operator=(DifferentialDrive&&) = default;
+
+  /**
+   * Arcade drive method for differential drive platform.
+   *
+   * Note: Some drivers may prefer inverted rotation controls. This can be done
+   * by negating the value passed for rotation.
+   *
+   * @param xSpeed       The speed at which the robot should drive along the X
+   *                     axis [-1.0..1.0]. Forward is positive.
+   * @param zRotation    The rotation rate of the robot around the Z axis
+   * @param squareInputs If set, decreases the input sensitivity at low speeds.
+   *                     [-1.0..1.0]. Clockwise is positive.
+   */
+  void ArcadeDrive(double xSpeed, double zRotation, bool squareInputs = true);
+
+  /**
+   * Curvature drive method for differential drive platform.
+   *
+   * The rotation argument controls the curvature of the robot's path rather
+   * than its rate of heading change. This makes the robot more controllable at
+   * high speeds. Constant-curvature turning can be overridden for turn-in-place
+   * maneuvers.
+   *
+   * @param xSpeed           The robot's speed along the X axis [-1.0..1.0].
+   *                         Forward is positive.
+   * @param zRotation        The robot's rotation rate around the Z axis
+   *                         [-1.0..1.0]. Clockwise is positive.
+   * @param allowTurnInPlace If set, overrides constant-curvature turning for
+   *                         turn-in-place maneuvers.
+   */
+  void CurvatureDrive(double xSpeed, double zRotation, bool allowTurnInPlace);
+
+  /**
+   * Tank drive method for differential drive platform.
+   *
+   * @param leftSpeed     The robot left side's speed along the X axis
+   *                      [-1.0..1.0]. Forward is positive.
+   * @param rightSpeed    The robot right side's speed along the X axis
+   *                      [-1.0..1.0]. Forward is positive.
+   * @param squareInputs If set, decreases the input sensitivity at low speeds.
+   *                     [-1.0..1.0]. Clockwise is positive.
+   */
+  void TankDrive(double leftSpeed, double rightSpeed, bool squareInputs = true);
+
+  void InitSendable(frc::SendableBuilder& builder) override;
+
+ private:
+  frc::SpeedController* m_leftMotor;
+  frc::SpeedController* m_rightMotor;
+};
+
+}  // namespace frc2

--- a/wpilibc/src/main/native/include/frc2/drive/KilloughDrive.h
+++ b/wpilibc/src/main/native/include/frc2/drive/KilloughDrive.h
@@ -1,0 +1,144 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <memory>
+
+#include <wpi/raw_ostream.h>
+
+#include "frc/drive/Vector2d.h"
+#include "frc/smartdashboard/Sendable.h"
+#include "frc/smartdashboard/SendableHelper.h"
+#include "frc2/drive/RobotDriveBase.h"
+
+namespace frc {
+class SpeedController;
+}  // namespace frc
+
+namespace frc2 {
+
+/**
+ * A class for driving Killough drive platforms.
+ *
+ * Killough drives are triangular with one omni wheel on each corner.
+ *
+ * Drive base diagram:
+ * <pre>
+ *  /_____\
+ * / \   / \
+ *    \ /
+ *    ---
+ * </pre>
+ *
+ * Each Drive() function provides different inverse kinematic relations for a
+ * Killough drive. The default wheel vectors are parallel to their respective
+ * opposite sides, but can be overridden. See the constructor for more
+ * information.
+ *
+ * This library uses the NED axes convention (North-East-Down as external
+ * reference in the world frame):
+ * http://www.nuclearprojects.com/ins/images/axis_big.png.
+ *
+ * The positive X axis points ahead, the positive Y axis points right, and the
+ * and the positive Z axis points down. Rotations follow the right-hand rule, so
+ * clockwise rotation around the Z axis is positive.
+ */
+class KilloughDrive : public RobotDriveBase,
+                      public frc::Sendable,
+                      public frc::SendableHelper<KilloughDrive> {
+ public:
+  static constexpr double kDefaultLeftMotorAngle = 60.0;
+  static constexpr double kDefaultRightMotorAngle = 120.0;
+  static constexpr double kDefaultBackMotorAngle = 270.0;
+
+  /**
+   * Construct a Killough drive with the given motors and default motor angles.
+   *
+   * The default motor angles make the wheels on each corner parallel to their
+   * respective opposite sides.
+   *
+   * If a motor needs to be inverted, do so before passing it in.
+   *
+   * @param leftMotor  The motor on the left corner.
+   * @param rightMotor The motor on the right corner.
+   * @param backMotor  The motor on the back corner.
+   */
+  KilloughDrive(frc::SpeedController& leftMotor,
+                frc::SpeedController& rightMotor,
+                frc::SpeedController& backMotor);
+
+  /**
+   * Construct a Killough drive with the given motors.
+   *
+   * Angles are measured in degrees clockwise from the positive X axis.
+   *
+   * @param leftMotor       The motor on the left corner.
+   * @param rightMotor      The motor on the right corner.
+   * @param backMotor       The motor on the back corner.
+   * @param leftMotorAngle  The angle of the left wheel's forward direction of
+   *                        travel.
+   * @param rightMotorAngle The angle of the right wheel's forward direction of
+   *                        travel.
+   * @param backMotorAngle  The angle of the back wheel's forward direction of
+   *                        travel.
+   */
+  KilloughDrive(frc::SpeedController& leftMotor,
+                frc::SpeedController& rightMotor,
+                frc::SpeedController& backMotor, double leftMotorAngle,
+                double rightMotorAngle, double backMotorAngle);
+
+  ~KilloughDrive() override = default;
+
+  KilloughDrive(KilloughDrive&&) = default;
+  KilloughDrive& operator=(KilloughDrive&&) = default;
+
+  /**
+   * Drive method for Killough platform.
+   *
+   * Angles are measured clockwise from the positive X axis. The robot's speed
+   * is independent from its angle or rotation rate.
+   *
+   * @param ySpeed    The robot's speed along the Y axis [-1.0..1.0]. Right is
+   *                  positive.
+   * @param xSpeed    The robot's speed along the X axis [-1.0..1.0]. Forward is
+   *                  positive.
+   * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0].
+   *                  Clockwise is positive.
+   * @param gyroAngle The current angle reading from the gyro in degrees around
+   *                  the Z axis. Use this to implement field-oriented controls.
+   */
+  void DriveCartesian(double ySpeed, double xSpeed, double zRotation,
+                      double gyroAngle = 0.0);
+
+  /**
+   * Drive method for Killough platform.
+   *
+   * Angles are measured clockwise from the positive X axis. The robot's speed
+   * is independent from its angle or rotation rate.
+   *
+   * @param magnitude The robot's speed at a given angle [-1.0..1.0]. Forward is
+   *                  positive.
+   * @param angle     The angle around the Z axis at which the robot drives in
+   *                  degrees [-180..180].
+   * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0].
+   *                  Clockwise is positive.
+   */
+  void DrivePolar(double magnitude, double angle, double zRotation);
+
+  void InitSendable(frc::SendableBuilder& builder) override;
+
+ private:
+  frc::SpeedController* m_leftMotor;
+  frc::SpeedController* m_rightMotor;
+  frc::SpeedController* m_backMotor;
+
+  frc::Vector2d m_leftVec;
+  frc::Vector2d m_rightVec;
+  frc::Vector2d m_backVec;
+
+  bool reported = false;
+};
+
+}  // namespace frc2

--- a/wpilibc/src/main/native/include/frc2/drive/MecanumDrive.h
+++ b/wpilibc/src/main/native/include/frc2/drive/MecanumDrive.h
@@ -1,0 +1,121 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <memory>
+
+#include <wpi/raw_ostream.h>
+
+#include "frc/smartdashboard/Sendable.h"
+#include "frc/smartdashboard/SendableHelper.h"
+#include "frc2/drive/RobotDriveBase.h"
+
+namespace frc {
+class SpeedController;
+}  // namespace frc
+
+namespace frc2 {
+
+/**
+ * A class for driving Mecanum drive platforms.
+ *
+ * Mecanum drives are rectangular with one wheel on each corner. Each wheel has
+ * rollers toed in 45 degrees toward the front or back. When looking at the
+ * wheels from the top, the roller axles should form an X across the robot.
+ *
+ * Drive base diagram:
+ * <pre>
+ * \\_______/
+ * \\ |   | /
+ *   |   |
+ * /_|___|_\\
+ * /       \\
+ * </pre>
+ *
+ * Each Drive() function provides different inverse kinematic relations for a
+ * Mecanum drive robot. Note that so motor direction inversion by the user is
+ * usually unnecessary.
+ *
+ * This library uses the NED axes convention (North-East-Down as external
+ * reference in the world frame):
+ * http://www.nuclearprojects.com/ins/images/axis_big.png.
+ *
+ * The positive X axis points ahead, the positive Y axis points to the right,
+ * and the positive Z axis points down. Rotations follow the right-hand rule, so
+ * clockwise rotation around the Z axis is positive.
+ *
+ * Inputs smaller then 0.02 will be set to 0, and larger values will be scaled
+ * so that the full range is still used. This deadband value can be changed
+ * with SetDeadband().
+ */
+class MecanumDrive : public RobotDriveBase,
+                     public frc::Sendable,
+                     public frc::SendableHelper<MecanumDrive> {
+ public:
+  /**
+   * Construct a MecanumDrive.
+   *
+   * If a motor needs to be inverted, do so before passing it in.
+   *
+   * @param frontLeftMotor The motor on the front-left corner.
+   * @param rearLeftMotor The motor on the rear-left corner.
+   * @param frontRightMotor The motor on the front-right corner.
+   * @param rearRightMotor The motor on the rear-right corner.
+   */
+  MecanumDrive(frc::SpeedController& frontLeftMotor,
+               frc::SpeedController& rearLeftMotor,
+               frc::SpeedController& frontRightMotor,
+               frc::SpeedController& rearRightMotor);
+
+  ~MecanumDrive() override = default;
+
+  MecanumDrive(MecanumDrive&&) = default;
+  MecanumDrive& operator=(MecanumDrive&&) = default;
+
+  /**
+   * Drive method for Mecanum platform.
+   *
+   * Angles are measured clockwise from the positive X axis. The robot's speed
+   * is independent from its angle or rotation rate.
+   *
+   * @param ySpeed    The robot's speed along the Y axis [-1.0..1.0]. Right is
+   *                  positive.
+   * @param xSpeed    The robot's speed along the X axis [-1.0..1.0]. Forward is
+   *                  positive.
+   * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0].
+   *                  Clockwise is positive.
+   * @param gyroAngle The current angle reading from the gyro in degrees around
+   *                  the Z axis. Use this to implement field-oriented controls.
+   */
+  void DriveCartesian(double ySpeed, double xSpeed, double zRotation,
+                      double gyroAngle = 0.0);
+
+  /**
+   * Drive method for Mecanum platform.
+   *
+   * Angles are measured clockwise from the positive X axis. The robot's speed
+   * is independent from its angle or rotation rate.
+   *
+   * @param magnitude The robot's speed at a given angle [-1.0..1.0]. Forward is
+   *                  positive.
+   * @param angle     The angle around the Z axis at which the robot drives in
+   *                  degrees [-180..180].
+   * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0].
+   *                  Clockwise is positive.
+   */
+  void DrivePolar(double magnitude, double angle, double zRotation);
+
+  void InitSendable(frc::SendableBuilder& builder) override;
+
+ private:
+  frc::SpeedController* m_frontLeftMotor;
+  frc::SpeedController* m_rearLeftMotor;
+  frc::SpeedController* m_frontRightMotor;
+  frc::SpeedController* m_rearRightMotor;
+
+  bool reported = false;
+};
+
+}  // namespace frc2

--- a/wpilibc/src/main/native/include/frc2/drive/RobotDriveBase.h
+++ b/wpilibc/src/main/native/include/frc2/drive/RobotDriveBase.h
@@ -1,0 +1,57 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <memory>
+
+#include <wpi/ArrayRef.h>
+
+namespace frc2 {
+
+/**
+ * Common base class for drive platforms.
+ */
+class RobotDriveBase {
+ public:
+  RobotDriveBase() = default;
+
+  RobotDriveBase(RobotDriveBase&&) = default;
+  RobotDriveBase& operator=(RobotDriveBase&&) = default;
+
+  /**
+   * Configure the scaling factor for using RobotDrive with motor controllers in
+   * a mode other than PercentVbus or to limit the maximum output.
+   *
+   * @param maxOutput Multiplied with the output percentage computed by the
+   *                  drive functions.
+   */
+  void SetMaxOutput(double maxOutput);
+
+ protected:
+  /**
+   * The location of a motor on the robot for the purpose of driving.
+   */
+  enum MotorType {
+    kFrontLeft = 0,
+    kFrontRight = 1,
+    kRearLeft = 2,
+    kRearRight = 3,
+    kLeft = 0,
+    kRight = 1,
+    kBack = 2
+  };
+
+  /**
+   * Normalize all wheel speeds if the magnitude of any wheel is greater than
+   * 1.0.
+   *
+   * @param wheelSpeeds Array of wheel speeds.
+   */
+  static void Normalize(wpi::MutableArrayRef<double> wheelSpeeds);
+
+  double m_maxOutput = 1.0;
+};
+
+}  // namespace frc2

--- a/wpilibc/src/test/native/cpp/frc2/drive/DifferentialDriveTest.cpp
+++ b/wpilibc/src/test/native/cpp/frc2/drive/DifferentialDriveTest.cpp
@@ -1,0 +1,223 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "MockSpeedController.h"
+#include "frc2/drive/DifferentialDrive.h"
+#include "gtest/gtest.h"
+
+TEST(DifferentialDriveTest, ArcadeDrive) {
+  frc::MockSpeedController left;
+  frc::MockSpeedController right;
+  frc2::DifferentialDrive drive{left, right};
+
+  // Forward
+  drive.ArcadeDrive(1.0, 0.0, false);
+  EXPECT_DOUBLE_EQ(1.0, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+
+  // Forward left turn
+  drive.ArcadeDrive(0.5, -0.5, false);
+  EXPECT_DOUBLE_EQ(0.0, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+
+  // Forward right turn
+  drive.ArcadeDrive(0.5, 0.5, false);
+  EXPECT_DOUBLE_EQ(1.0, left.Get());
+  EXPECT_DOUBLE_EQ(0.0, right.Get());
+
+  // Backward
+  drive.ArcadeDrive(-1.0, 0.0, false);
+  EXPECT_DOUBLE_EQ(-1.0, left.Get());
+  EXPECT_DOUBLE_EQ(-1.0, right.Get());
+
+  // Backward left turn
+  drive.ArcadeDrive(-0.5, -0.5, false);
+  EXPECT_DOUBLE_EQ(-1.0, left.Get());
+  EXPECT_DOUBLE_EQ(0.0, right.Get());
+
+  // Backward right turn
+  drive.ArcadeDrive(-0.5, 0.5, false);
+  EXPECT_DOUBLE_EQ(0.0, left.Get());
+  EXPECT_DOUBLE_EQ(-1.0, right.Get());
+}
+
+TEST(DifferentialDriveTest, ArcadeDriveSquared) {
+  frc::MockSpeedController left;
+  frc::MockSpeedController right;
+  frc2::DifferentialDrive drive{left, right};
+
+  // Forward
+  drive.ArcadeDrive(1.0, 0.0, true);
+  EXPECT_DOUBLE_EQ(1.0, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+
+  // Forward left turn
+  drive.ArcadeDrive(0.5, -0.5, true);
+  EXPECT_DOUBLE_EQ(0.0, left.Get());
+  EXPECT_DOUBLE_EQ(0.5, right.Get());
+
+  // Forward right turn
+  drive.ArcadeDrive(0.5, 0.5, true);
+  EXPECT_DOUBLE_EQ(0.5, left.Get());
+  EXPECT_DOUBLE_EQ(0.0, right.Get());
+
+  // Backward
+  drive.ArcadeDrive(-1.0, 0.0, true);
+  EXPECT_DOUBLE_EQ(-1.0, left.Get());
+  EXPECT_DOUBLE_EQ(-1.0, right.Get());
+
+  // Backward left turn
+  drive.ArcadeDrive(-0.5, -0.5, true);
+  EXPECT_DOUBLE_EQ(-0.5, left.Get());
+  EXPECT_DOUBLE_EQ(0.0, right.Get());
+
+  // Backward right turn
+  drive.ArcadeDrive(-0.5, 0.5, true);
+  EXPECT_DOUBLE_EQ(0.0, left.Get());
+  EXPECT_DOUBLE_EQ(-0.5, right.Get());
+}
+
+TEST(DifferentialDriveTest, CurvatureDrive) {
+  frc::MockSpeedController left;
+  frc::MockSpeedController right;
+  frc2::DifferentialDrive drive{left, right};
+
+  // Forward
+  drive.CurvatureDrive(1.0, 0.0, false);
+  EXPECT_DOUBLE_EQ(1.0, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+
+  // Forward left turn
+  drive.CurvatureDrive(0.5, -0.5, false);
+  EXPECT_DOUBLE_EQ(0.25, left.Get());
+  EXPECT_DOUBLE_EQ(0.75, right.Get());
+
+  // Forward right turn
+  drive.CurvatureDrive(0.5, 0.5, false);
+  EXPECT_DOUBLE_EQ(0.75, left.Get());
+  EXPECT_DOUBLE_EQ(0.25, right.Get());
+
+  // Backward
+  drive.CurvatureDrive(-1.0, 0.0, false);
+  EXPECT_DOUBLE_EQ(-1.0, left.Get());
+  EXPECT_DOUBLE_EQ(-1.0, right.Get());
+
+  // Backward left turn
+  drive.CurvatureDrive(-0.5, -0.5, false);
+  EXPECT_DOUBLE_EQ(-0.75, left.Get());
+  EXPECT_DOUBLE_EQ(-0.25, right.Get());
+
+  // Backward right turn
+  drive.CurvatureDrive(-0.5, 0.5, false);
+  EXPECT_DOUBLE_EQ(-0.25, left.Get());
+  EXPECT_DOUBLE_EQ(-0.75, right.Get());
+}
+
+TEST(DifferentialDriveTest, CurvatureDriveTurnInPlace) {
+  frc::MockSpeedController left;
+  frc::MockSpeedController right;
+  frc2::DifferentialDrive drive{left, right};
+
+  // Forward
+  drive.CurvatureDrive(1.0, 0.0, true);
+  EXPECT_DOUBLE_EQ(1.0, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+
+  // Forward left turn
+  drive.CurvatureDrive(0.5, -0.5, true);
+  EXPECT_DOUBLE_EQ(0.0, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+
+  // Forward right turn
+  drive.CurvatureDrive(0.5, 0.5, true);
+  EXPECT_DOUBLE_EQ(1.0, left.Get());
+  EXPECT_DOUBLE_EQ(0.0, right.Get());
+
+  // Backward
+  drive.CurvatureDrive(-1.0, 0.0, true);
+  EXPECT_DOUBLE_EQ(-1.0, left.Get());
+  EXPECT_DOUBLE_EQ(-1.0, right.Get());
+
+  // Backward left turn
+  drive.CurvatureDrive(-0.5, -0.5, true);
+  EXPECT_DOUBLE_EQ(-1.0, left.Get());
+  EXPECT_DOUBLE_EQ(0.0, right.Get());
+
+  // Backward right turn
+  drive.CurvatureDrive(-0.5, 0.5, true);
+  EXPECT_DOUBLE_EQ(0.0, left.Get());
+  EXPECT_DOUBLE_EQ(-1.0, right.Get());
+}
+
+TEST(DifferentialDriveTest, TankDrive) {
+  frc::MockSpeedController left;
+  frc::MockSpeedController right;
+  frc2::DifferentialDrive drive{left, right};
+
+  // Forward
+  drive.TankDrive(1.0, 1.0, false);
+  EXPECT_DOUBLE_EQ(1.0, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+
+  // Forward left turn
+  drive.TankDrive(0.5, 1.0, false);
+  EXPECT_DOUBLE_EQ(0.5, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+
+  // Forward right turn
+  drive.TankDrive(1.0, 0.5, false);
+  EXPECT_DOUBLE_EQ(1.0, left.Get());
+  EXPECT_DOUBLE_EQ(0.5, right.Get());
+
+  // Backward
+  drive.TankDrive(-1.0, -1.0, false);
+  EXPECT_DOUBLE_EQ(-1.0, left.Get());
+  EXPECT_DOUBLE_EQ(-1.0, right.Get());
+
+  // Backward left turn
+  drive.TankDrive(-0.5, -1.0, false);
+  EXPECT_DOUBLE_EQ(-0.5, left.Get());
+  EXPECT_DOUBLE_EQ(-1.0, right.Get());
+
+  // Backward right turn
+  drive.TankDrive(-0.5, 1.0, false);
+  EXPECT_DOUBLE_EQ(-0.5, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+}
+
+TEST(DifferentialDriveTest, TankDriveSquared) {
+  frc::MockSpeedController left;
+  frc::MockSpeedController right;
+  frc2::DifferentialDrive drive{left, right};
+
+  // Forward
+  drive.TankDrive(1.0, 1.0, true);
+  EXPECT_DOUBLE_EQ(1.0, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+
+  // Forward left turn
+  drive.TankDrive(0.5, 1.0, true);
+  EXPECT_DOUBLE_EQ(0.25, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+
+  // Forward right turn
+  drive.TankDrive(1.0, 0.5, true);
+  EXPECT_DOUBLE_EQ(1.0, left.Get());
+  EXPECT_DOUBLE_EQ(0.25, right.Get());
+
+  // Backward
+  drive.TankDrive(-1.0, -1.0, true);
+  EXPECT_DOUBLE_EQ(-1.0, left.Get());
+  EXPECT_DOUBLE_EQ(-1.0, right.Get());
+
+  // Backward left turn
+  drive.TankDrive(-0.5, -1.0, true);
+  EXPECT_DOUBLE_EQ(-0.25, left.Get());
+  EXPECT_DOUBLE_EQ(-1.0, right.Get());
+
+  // Backward right turn
+  drive.TankDrive(-1.0, -0.5, true);
+  EXPECT_DOUBLE_EQ(-1.0, left.Get());
+  EXPECT_DOUBLE_EQ(-0.25, right.Get());
+}

--- a/wpilibc/src/test/native/cpp/frc2/drive/KilloughDriveTest.cpp
+++ b/wpilibc/src/test/native/cpp/frc2/drive/KilloughDriveTest.cpp
@@ -1,0 +1,120 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <cmath>
+
+#include "MockSpeedController.h"
+#include "frc2/drive/KilloughDrive.h"
+#include "gtest/gtest.h"
+
+TEST(KilloughDriveTest, Cartesian) {
+  frc::MockSpeedController left;
+  frc::MockSpeedController right;
+  frc::MockSpeedController back;
+  frc2::KilloughDrive drive{left, right, back};
+
+  // Forward
+  drive.DriveCartesian(1.0, 0.0, 0.0);
+  EXPECT_DOUBLE_EQ(0.5, left.Get());
+  EXPECT_DOUBLE_EQ(-0.5, right.Get());
+  EXPECT_NEAR(0.0, back.Get(), 1e-9);
+
+  // Left
+  drive.DriveCartesian(0.0, -1.0, 0.0);
+  EXPECT_DOUBLE_EQ(-std::sqrt(3) / 2, left.Get());
+  EXPECT_DOUBLE_EQ(-std::sqrt(3) / 2, right.Get());
+  EXPECT_DOUBLE_EQ(1.0, back.Get());
+
+  // Right
+  drive.DriveCartesian(0.0, 1.0, 0.0);
+  EXPECT_DOUBLE_EQ(std::sqrt(3) / 2, left.Get());
+  EXPECT_DOUBLE_EQ(std::sqrt(3) / 2, right.Get());
+  EXPECT_DOUBLE_EQ(-1.0, back.Get());
+
+  // Rotate CCW
+  drive.DriveCartesian(0.0, 0.0, -1.0);
+  EXPECT_DOUBLE_EQ(-1.0, left.Get());
+  EXPECT_DOUBLE_EQ(-1.0, right.Get());
+  EXPECT_DOUBLE_EQ(-1.0, back.Get());
+
+  // Rotate CW
+  drive.DriveCartesian(0.0, 0.0, 1.0);
+  EXPECT_DOUBLE_EQ(1.0, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+  EXPECT_DOUBLE_EQ(1.0, back.Get());
+}
+
+TEST(KilloughDriveTest, CartesianGyro90CW) {
+  frc::MockSpeedController left;
+  frc::MockSpeedController right;
+  frc::MockSpeedController back;
+  frc2::KilloughDrive drive{left, right, back};
+
+  // Forward in global frame; left in robot frame
+  drive.DriveCartesian(1.0, 0.0, 0.0, 90.0);
+  EXPECT_DOUBLE_EQ(-std::sqrt(3) / 2, left.Get());
+  EXPECT_DOUBLE_EQ(-std::sqrt(3) / 2, right.Get());
+  EXPECT_DOUBLE_EQ(1.0, back.Get());
+
+  // Left in global frame; backward in robot frame
+  drive.DriveCartesian(0.0, -1.0, 0.0, 90.0);
+  EXPECT_DOUBLE_EQ(-0.5, left.Get());
+  EXPECT_NEAR(0.5, right.Get(), 1e-9);
+  EXPECT_NEAR(0.0, back.Get(), 1e-9);
+
+  // Right in global frame; forward in robot frame
+  drive.DriveCartesian(0.0, 1.0, 0.0, 90.0);
+  EXPECT_DOUBLE_EQ(0.5, left.Get());
+  EXPECT_NEAR(-0.5, right.Get(), 1e-9);
+  EXPECT_NEAR(0.0, back.Get(), 1e-9);
+
+  // Rotate CCW
+  drive.DriveCartesian(0.0, 0.0, -1.0, 90.0);
+  EXPECT_DOUBLE_EQ(-1.0, left.Get());
+  EXPECT_DOUBLE_EQ(-1.0, right.Get());
+  EXPECT_DOUBLE_EQ(-1.0, back.Get());
+
+  // Rotate CW
+  drive.DriveCartesian(0.0, 0.0, 1.0, 90.0);
+  EXPECT_DOUBLE_EQ(1.0, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+  EXPECT_DOUBLE_EQ(1.0, back.Get());
+}
+
+TEST(KilloughDriveTest, Polar) {
+  frc::MockSpeedController left;
+  frc::MockSpeedController right;
+  frc::MockSpeedController back;
+  frc2::KilloughDrive drive{left, right, back};
+
+  // Forward
+  drive.DrivePolar(1.0, 0.0, 0.0);
+  EXPECT_DOUBLE_EQ(std::sqrt(3) / 2, left.Get());
+  EXPECT_DOUBLE_EQ(std::sqrt(3) / 2, right.Get());
+  EXPECT_DOUBLE_EQ(-1.0, back.Get());
+
+  // Left
+  drive.DrivePolar(1.0, -90.0, 0.0);
+  EXPECT_DOUBLE_EQ(-0.5, left.Get());
+  EXPECT_DOUBLE_EQ(0.5, right.Get());
+  EXPECT_NEAR(0.0, back.Get(), 1e-9);
+
+  // Right
+  drive.DrivePolar(1.0, 90.0, 0.0);
+  EXPECT_DOUBLE_EQ(0.5, left.Get());
+  EXPECT_NEAR(-0.5, right.Get(), 1e-9);
+  EXPECT_NEAR(0.0, back.Get(), 1e-9);
+
+  // Rotate CCW
+  drive.DrivePolar(0.0, 0.0, -1.0);
+  EXPECT_DOUBLE_EQ(-1.0, left.Get());
+  EXPECT_DOUBLE_EQ(-1.0, right.Get());
+  EXPECT_DOUBLE_EQ(-1.0, back.Get());
+
+  // Rotate CW
+  drive.DrivePolar(0.0, 0.0, 1.0);
+  EXPECT_DOUBLE_EQ(1.0, left.Get());
+  EXPECT_DOUBLE_EQ(1.0, right.Get());
+  EXPECT_DOUBLE_EQ(1.0, back.Get());
+}

--- a/wpilibc/src/test/native/cpp/frc2/drive/MecanumDriveTest.cpp
+++ b/wpilibc/src/test/native/cpp/frc2/drive/MecanumDriveTest.cpp
@@ -1,0 +1,136 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "MockSpeedController.h"
+#include "frc2/drive/MecanumDrive.h"
+#include "gtest/gtest.h"
+
+TEST(MecanumDriveTest, Cartesian) {
+  frc::MockSpeedController fl;
+  frc::MockSpeedController fr;
+  frc::MockSpeedController rl;
+  frc::MockSpeedController rr;
+  frc2::MecanumDrive drive{fl, fr, rl, rr};
+
+  // Forward
+  drive.DriveCartesian(1.0, 0.0, 0.0);
+  EXPECT_DOUBLE_EQ(1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(1.0, rr.Get());
+
+  // Left
+  drive.DriveCartesian(0.0, -1.0, 0.0);
+  EXPECT_DOUBLE_EQ(-1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(-1.0, rr.Get());
+
+  // Right
+  drive.DriveCartesian(0.0, 1.0, 0.0);
+  EXPECT_DOUBLE_EQ(1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(-1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(-1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(1.0, rr.Get());
+
+  // Rotate CCW
+  drive.DriveCartesian(0.0, 0.0, -1.0);
+  EXPECT_DOUBLE_EQ(-1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(-1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(1.0, rr.Get());
+
+  // Rotate CW
+  drive.DriveCartesian(0.0, 0.0, 1.0);
+  EXPECT_DOUBLE_EQ(1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(-1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(-1.0, rr.Get());
+}
+
+TEST(MecanumDriveTest, CartesianGyro90CW) {
+  frc::MockSpeedController fl;
+  frc::MockSpeedController fr;
+  frc::MockSpeedController rl;
+  frc::MockSpeedController rr;
+  frc2::MecanumDrive drive{fl, fr, rl, rr};
+
+  // Forward in global frame; left in robot frame
+  drive.DriveCartesian(1.0, 0.0, 0.0, 90.0);
+  EXPECT_DOUBLE_EQ(-1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(-1.0, rr.Get());
+
+  // Left in global frame; backward in robot frame
+  drive.DriveCartesian(0.0, -1.0, 0.0, 90.0);
+  EXPECT_DOUBLE_EQ(-1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(-1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(-1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(-1.0, rr.Get());
+
+  // Right in global frame; forward in robot frame
+  drive.DriveCartesian(0.0, 1.0, 0.0, 90.0);
+  EXPECT_DOUBLE_EQ(1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(1.0, rr.Get());
+
+  // Rotate CCW
+  drive.DriveCartesian(0.0, 0.0, -1.0, 90.0);
+  EXPECT_DOUBLE_EQ(-1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(-1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(1.0, rr.Get());
+
+  // Rotate CW
+  drive.DriveCartesian(0.0, 0.0, 1.0, 90.0);
+  EXPECT_DOUBLE_EQ(1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(-1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(-1.0, rr.Get());
+}
+
+TEST(MecanumDriveTest, Polar) {
+  frc::MockSpeedController fl;
+  frc::MockSpeedController fr;
+  frc::MockSpeedController rl;
+  frc::MockSpeedController rr;
+  frc2::MecanumDrive drive{fl, fr, rl, rr};
+
+  // Forward
+  drive.DrivePolar(1.0, 0.0, 0.0);
+  EXPECT_DOUBLE_EQ(1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(1.0, rr.Get());
+
+  // Left
+  drive.DrivePolar(1.0, -90.0, 0.0);
+  EXPECT_DOUBLE_EQ(-1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(-1.0, rr.Get());
+
+  // Right
+  drive.DrivePolar(1.0, 90.0, 0.0);
+  EXPECT_DOUBLE_EQ(1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(-1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(-1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(1.0, rr.Get());
+
+  // Rotate CCW
+  drive.DrivePolar(0.0, 0.0, -1.0);
+  EXPECT_DOUBLE_EQ(-1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(-1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(1.0, rr.Get());
+
+  // Rotate CW
+  drive.DrivePolar(0.0, 0.0, 1.0);
+  EXPECT_DOUBLE_EQ(1.0, fl.Get());
+  EXPECT_DOUBLE_EQ(1.0, fr.Get());
+  EXPECT_DOUBLE_EQ(-1.0, rl.Get());
+  EXPECT_DOUBLE_EQ(-1.0, rr.Get());
+}

--- a/wpilibcExamples/src/main/cpp/examples/ArcadeDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArcadeDrive/cpp/Robot.cpp
@@ -5,7 +5,7 @@
 #include <frc/Joystick.h>
 #include <frc/PWMSparkMax.h>
 #include <frc/TimedRobot.h>
-#include <frc/drive/DifferentialDrive.h>
+#include <frc2/drive/DifferentialDrive.h>
 
 /**
  * This is a demo program showing the use of the DifferentialDrive class.
@@ -14,7 +14,7 @@
 class Robot : public frc::TimedRobot {
   frc::PWMSparkMax m_leftMotor{0};
   frc::PWMSparkMax m_rightMotor{1};
-  frc::DifferentialDrive m_robotDrive{m_leftMotor, m_rightMotor};
+  frc2::DifferentialDrive m_robotDrive{m_leftMotor, m_rightMotor};
   frc::Joystick m_stick{0};
 
  public:

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/DriveTrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/DriveTrain.h
@@ -9,8 +9,8 @@
 #include <frc/Encoder.h>
 #include <frc/PWMSparkMax.h>
 #include <frc/SpeedControllerGroup.h>
-#include <frc/drive/DifferentialDrive.h>
 #include <frc2/command/SubsystemBase.h>
+#include <frc2/drive/DifferentialDrive.h>
 
 namespace frc {
 class Joystick;
@@ -72,7 +72,7 @@ class DriveTrain : public frc2::SubsystemBase {
   frc::PWMSparkMax m_rearRight{4};
   frc::SpeedControllerGroup m_right{m_frontRight, m_rearRight};
 
-  frc::DifferentialDrive m_robotDrive{m_left, m_right};
+  frc2::DifferentialDrive m_robotDrive{m_left, m_right};
 
   frc::Encoder m_leftEncoder{1, 2};
   frc::Encoder m_rightEncoder{3, 4};

--- a/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
@@ -6,15 +6,12 @@
 #include <frc/PWMSparkMax.h>
 #include <frc/TimedRobot.h>
 #include <frc/Timer.h>
-#include <frc/drive/DifferentialDrive.h>
 #include <frc/livewindow/LiveWindow.h>
+#include <frc2/drive/DifferentialDrive.h>
 
 class Robot : public frc::TimedRobot {
  public:
-  Robot() {
-    m_robotDrive.SetExpiration(0.1);
-    m_timer.Start();
-  }
+  Robot() { m_timer.Start(); }
 
   void AutonomousInit() override {
     m_timer.Reset();
@@ -47,7 +44,7 @@ class Robot : public frc::TimedRobot {
   // Robot drive system
   frc::PWMSparkMax m_left{0};
   frc::PWMSparkMax m_right{1};
-  frc::DifferentialDrive m_robotDrive{m_left, m_right};
+  frc2::DifferentialDrive m_robotDrive{m_left, m_right};
 
   frc::Joystick m_stick{0};
   frc::LiveWindow& m_lw = frc::LiveWindow::GetInstance();

--- a/wpilibcExamples/src/main/cpp/examples/Gyro/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Gyro/cpp/Robot.cpp
@@ -8,7 +8,7 @@
 #include <frc/Joystick.h>
 #include <frc/PWMSparkMax.h>
 #include <frc/TimedRobot.h>
-#include <frc/drive/DifferentialDrive.h>
+#include <frc2/drive/DifferentialDrive.h>
 
 /**
  * This is a sample program to demonstrate how to use a gyro sensor to make a
@@ -46,7 +46,7 @@ class Robot : public frc::TimedRobot {
 
   frc::PWMSparkMax m_left{kLeftMotorPort};
   frc::PWMSparkMax m_right{kRightMotorPort};
-  frc::DifferentialDrive m_robotDrive{m_left, m_right};
+  frc2::DifferentialDrive m_robotDrive{m_left, m_right};
 
   frc::AnalogGyro m_gyro{kGyroPort};
   frc::Joystick m_joystick{kJoystickPort};

--- a/wpilibcExamples/src/main/cpp/examples/GyroMecanum/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GyroMecanum/cpp/Robot.cpp
@@ -6,7 +6,7 @@
 #include <frc/Joystick.h>
 #include <frc/PWMSparkMax.h>
 #include <frc/TimedRobot.h>
-#include <frc/drive/MecanumDrive.h>
+#include <frc2/drive/MecanumDrive.h>
 
 /**
  * This is a sample program that uses mecanum drive with a gyro sensor to
@@ -48,8 +48,8 @@ class Robot : public frc::TimedRobot {
   frc::PWMSparkMax m_rearLeft{kRearLeftMotorPort};
   frc::PWMSparkMax m_frontRight{kFrontRightMotorPort};
   frc::PWMSparkMax m_rearRight{kRearRightMotorPort};
-  frc::MecanumDrive m_robotDrive{m_frontLeft, m_rearLeft, m_frontRight,
-                                 m_rearRight};
+  frc2::MecanumDrive m_robotDrive{m_frontLeft, m_rearLeft, m_frontRight,
+                                  m_rearRight};
 
   frc::AnalogGyro m_gyro{kGyroPort};
   frc::Joystick m_joystick{kJoystickPort};

--- a/wpilibcExamples/src/main/cpp/examples/MecanumDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumDrive/cpp/Robot.cpp
@@ -5,7 +5,7 @@
 #include <frc/Joystick.h>
 #include <frc/PWMSparkMax.h>
 #include <frc/TimedRobot.h>
-#include <frc/drive/MecanumDrive.h>
+#include <frc2/drive/MecanumDrive.h>
 
 /**
  * This is a demo program showing how to use Mecanum control with the
@@ -39,8 +39,8 @@ class Robot : public frc::TimedRobot {
   frc::PWMSparkMax m_rearLeft{kRearLeftChannel};
   frc::PWMSparkMax m_frontRight{kFrontRightChannel};
   frc::PWMSparkMax m_rearRight{kRearRightChannel};
-  frc::MecanumDrive m_robotDrive{m_frontLeft, m_rearLeft, m_frontRight,
-                                 m_rearRight};
+  frc2::MecanumDrive m_robotDrive{m_frontLeft, m_rearLeft, m_frontRight,
+                                  m_rearRight};
 
   frc::Joystick m_stick{kJoystickChannel};
 };

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/subsystems/DriveTrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/subsystems/DriveTrain.cpp
@@ -18,8 +18,10 @@ DriveTrain::DriveTrain() : frc::Subsystem("DriveTrain") {
 
   // Configure the DifferentialDrive to reflect the fact that all our
   // motors are wired backwards and our drivers sensitivity preferences.
-  m_robotDrive.SetSafetyEnabled(false);
-  m_robotDrive.SetExpiration(0.1);
+  m_frontLeftCIM.SetSafetyEnabled(false);
+  m_rearLeftCIM.SetSafetyEnabled(false);
+  m_frontRightCIM.SetSafetyEnabled(false);
+  m_rearRightCIM.SetSafetyEnabled(false);
   m_robotDrive.SetMaxOutput(1.0);
   m_leftCIMs.SetInverted(true);
   m_rightCIMs.SetInverted(true);

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/include/subsystems/DriveTrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/include/subsystems/DriveTrain.h
@@ -9,7 +9,7 @@
 #include <frc/PWMSparkMax.h>
 #include <frc/SpeedControllerGroup.h>
 #include <frc/commands/Subsystem.h>
-#include <frc/drive/DifferentialDrive.h>
+#include <frc2/drive/DifferentialDrive.h>
 
 namespace frc {
 class Joystick;
@@ -68,7 +68,7 @@ class DriveTrain : public frc::Subsystem {
   frc::PWMSparkMax m_rearRightCIM{4};
   frc::SpeedControllerGroup m_rightCIMs{m_frontRightCIM, m_rearRightCIM};
 
-  frc::DifferentialDrive m_robotDrive{m_leftCIMs, m_rightCIMs};
+  frc2::DifferentialDrive m_robotDrive{m_leftCIMs, m_rightCIMs};
 
   frc::Encoder m_rightEncoder{1, 2, true, frc::Encoder::k4X};
   frc::Encoder m_leftEncoder{3, 4, false, frc::Encoder::k4X};

--- a/wpilibcExamples/src/main/cpp/examples/ShuffleBoard/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ShuffleBoard/cpp/Robot.cpp
@@ -7,10 +7,10 @@
 #include <frc/Joystick.h>
 #include <frc/PWMSparkMax.h>
 #include <frc/TimedRobot.h>
-#include <frc/drive/DifferentialDrive.h>
 #include <frc/shuffleboard/Shuffleboard.h>
 #include <frc/shuffleboard/ShuffleboardLayout.h>
 #include <frc/shuffleboard/ShuffleboardTab.h>
+#include <frc2/drive/DifferentialDrive.h>
 #include <networktables/NetworkTableEntry.h>
 #include <networktables/NetworkTableInstance.h>
 
@@ -65,7 +65,7 @@ class Robot : public frc::TimedRobot {
   frc::PWMSparkMax m_right{1};
   frc::PWMSparkMax m_elevatorMotor{2};
 
-  frc::DifferentialDrive m_robotDrive{m_left, m_right};
+  frc2::DifferentialDrive m_robotDrive{m_left, m_right};
 
   frc::Joystick m_stick{0};
 

--- a/wpilibcExamples/src/main/cpp/examples/Ultrasonic/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Ultrasonic/cpp/Robot.cpp
@@ -6,7 +6,7 @@
 #include <frc/MedianFilter.h>
 #include <frc/PWMSparkMax.h>
 #include <frc/TimedRobot.h>
-#include <frc/drive/DifferentialDrive.h>
+#include <frc2/drive/DifferentialDrive.h>
 
 /**
  * This is a sample program demonstrating how to use an ultrasonic sensor and
@@ -51,7 +51,7 @@ class Robot : public frc::TimedRobot {
 
   frc::PWMSparkMax m_left{kLeftMotorPort};
   frc::PWMSparkMax m_right{kRightMotorPort};
-  frc::DifferentialDrive m_robotDrive{m_left, m_right};
+  frc2::DifferentialDrive m_robotDrive{m_left, m_right};
 };
 
 #ifndef RUNNING_FRC_TESTS

--- a/wpilibcExamples/src/main/cpp/examples/UltrasonicPID/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/UltrasonicPID/cpp/Robot.cpp
@@ -7,7 +7,7 @@
 #include <frc/PWMSparkMax.h>
 #include <frc/TimedRobot.h>
 #include <frc/controller/PIDController.h>
-#include <frc/drive/DifferentialDrive.h>
+#include <frc2/drive/DifferentialDrive.h>
 
 /**
  * This is a sample program demonstrating how to use an ultrasonic sensor and
@@ -57,7 +57,7 @@ class Robot : public frc::TimedRobot {
 
   frc::PWMSparkMax m_left{kLeftMotorPort};
   frc::PWMSparkMax m_right{kRightMotorPort};
-  frc::DifferentialDrive m_robotDrive{m_left, m_right};
+  frc2::DifferentialDrive m_robotDrive{m_left, m_right};
 
   frc2::PIDController m_pidController{kP, kI, kD};
 };

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj2/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj2/drive/DifferentialDrive.java
@@ -2,7 +2,7 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package edu.wpi.first.wpilibj.drive;
+package edu.wpi.first.wpilibj2.drive;
 
 import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
@@ -28,12 +28,12 @@ import java.util.StringJoiner;
  *
  * <pre><code>
  * public class Robot {
- *   SpeedController m_frontLeft = new PWMVictorSPX(1);
- *   SpeedController m_rearLeft = new PWMVictorSPX(2);
+ *   Spark m_frontLeft = new Spark(1);
+ *   Spark m_rearLeft = new Spark(2);
  *   SpeedControllerGroup m_left = new SpeedControllerGroup(m_frontLeft, m_rearLeft);
  *
- *   SpeedController m_frontRight = new PWMVictorSPX(3);
- *   SpeedController m_rearRight = new PWMVictorSPX(4);
+ *   Spark m_frontRight = new Spark(3);
+ *   Spark m_rearRight = new Spark(4);
  *   SpeedControllerGroup m_right = new SpeedControllerGroup(m_frontRight, m_rearRight);
  *
  *   DifferentialDrive m_drive = new DifferentialDrive(m_left, m_right);
@@ -44,14 +44,14 @@ import java.util.StringJoiner;
  *
  * <pre><code>
  * public class Robot {
- *   SpeedController m_frontLeft = new PWMVictorSPX(1);
- *   SpeedController m_midLeft = new PWMVictorSPX(2);
- *   SpeedController m_rearLeft = new PWMVictorSPX(3);
+ *   Spark m_frontLeft = new Spark(1);
+ *   Spark m_midLeft = new Spark(2);
+ *   Spark m_rearLeft = new Spark(3);
  *   SpeedControllerGroup m_left = new SpeedControllerGroup(m_frontLeft, m_midLeft, m_rearLeft);
  *
- *   SpeedController m_frontRight = new PWMVictorSPX(4);
- *   SpeedController m_midRight = new PWMVictorSPX(5);
- *   SpeedController m_rearRight = new PWMVictorSPX(6);
+ *   Spark m_frontRight = new Spark(4);
+ *   Spark m_midRight = new Spark(5);
+ *   Spark m_rearRight = new Spark(6);
  *   SpeedControllerGroup m_right = new SpeedControllerGroup(m_frontRight, m_midRight, m_rearRight);
  *
  *   DifferentialDrive m_drive = new DifferentialDrive(m_left, m_right);
@@ -71,8 +71,7 @@ import java.util.StringJoiner;
  * </pre>
  *
  * <p>Each drive() function provides different inverse kinematic relations for a differential drive
- * robot. Motor outputs for the right side are negated, so motor direction inversion by the user is
- * usually unnecessary.
+ * robot. Note that motor direction inversion by the user is usually unnecessary.
  *
  * <p>This library uses the NED axes convention (North-East-Down as external reference in the world
  * frame): http://www.nuclearprojects.com/ins/images/axis_big.png.
@@ -80,24 +79,13 @@ import java.util.StringJoiner;
  * <p>The positive X axis points ahead, the positive Y axis points right, and the positive Z axis
  * points down. Rotations follow the right-hand rule, so clockwise rotation around the Z axis is
  * positive.
- *
- * <p>Inputs smaller then {@value edu.wpi.first.wpilibj.drive.RobotDriveBase#kDefaultDeadband} will
- * be set to 0, and larger values will be scaled so that the full range is still used. This deadband
- * value can be changed with {@link #setDeadband}.
  */
-public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoCloseable {
-  public static final double kDefaultQuickStopThreshold = 0.2;
-  public static final double kDefaultQuickStopAlpha = 0.1;
-
+public class DifferentialDrive extends RobotDriveBase implements Sendable {
   private static int instances;
 
   private final SpeedController m_leftMotor;
   private final SpeedController m_rightMotor;
 
-  private double m_quickStopThreshold = kDefaultQuickStopThreshold;
-  private double m_quickStopAlpha = kDefaultQuickStopAlpha;
-  private double m_quickStopAccumulator;
-  private double m_rightSideInvertMultiplier = -1.0;
   private boolean m_reported;
 
   /**
@@ -105,6 +93,9 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    *
    * <p>To pass multiple motors per side, use a {@link SpeedControllerGroup}. If a motor needs to be
    * inverted, do so before passing it in.
+   *
+   * @param leftMotor Left motor.
+   * @param rightMotor Right motor.
    */
   public DifferentialDrive(SpeedController leftMotor, SpeedController rightMotor) {
     verify(leftMotor, rightMotor);
@@ -114,11 +105,6 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
     SendableRegistry.addChild(this, m_rightMotor);
     instances++;
     SendableRegistry.addLW(this, "DifferentialDrive", instances);
-  }
-
-  @Override
-  public void close() {
-    SendableRegistry.remove(this);
   }
 
   /**
@@ -169,15 +155,12 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
   public void arcadeDrive(double xSpeed, double zRotation, boolean squareInputs) {
     if (!m_reported) {
       HAL.report(
-          tResourceType.kResourceType_RobotDrive, tInstances.kRobotDrive2_DifferentialArcade, 2);
+          tResourceType.kResourceType_RobotDrive, 2, tInstances.kRobotDrive2_DifferentialArcade);
       m_reported = true;
     }
 
     xSpeed = MathUtil.clamp(xSpeed, -1.0, 1.0);
-    xSpeed = applyDeadband(xSpeed, m_deadband);
-
     zRotation = MathUtil.clamp(zRotation, -1.0, 1.0);
-    zRotation = applyDeadband(zRotation, m_deadband);
 
     // Square the inputs (while preserving the sign) to increase fine control
     // while permitting full power.
@@ -186,120 +169,64 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
       zRotation = Math.copySign(zRotation * zRotation, zRotation);
     }
 
-    double leftMotorOutput;
-    double rightMotorOutput;
+    double leftSpeed = xSpeed + zRotation;
+    double rightSpeed = xSpeed - zRotation;
 
-    double maxInput = Math.copySign(Math.max(Math.abs(xSpeed), Math.abs(zRotation)), xSpeed);
-
-    if (xSpeed >= 0.0) {
-      // First quadrant, else second quadrant
-      if (zRotation >= 0.0) {
-        leftMotorOutput = maxInput;
-        rightMotorOutput = xSpeed - zRotation;
-      } else {
-        leftMotorOutput = xSpeed + zRotation;
-        rightMotorOutput = maxInput;
-      }
-    } else {
-      // Third quadrant, else fourth quadrant
-      if (zRotation >= 0.0) {
-        leftMotorOutput = xSpeed + zRotation;
-        rightMotorOutput = maxInput;
-      } else {
-        leftMotorOutput = maxInput;
-        rightMotorOutput = xSpeed - zRotation;
-      }
+    // Normalize wheel speeds
+    double maxMagnitude = Math.max(Math.abs(leftSpeed), Math.abs(rightSpeed));
+    if (maxMagnitude > 1.0) {
+      leftSpeed /= maxMagnitude;
+      rightSpeed /= maxMagnitude;
     }
 
-    m_leftMotor.set(MathUtil.clamp(leftMotorOutput, -1.0, 1.0) * m_maxOutput);
-    double maxOutput = m_maxOutput * m_rightSideInvertMultiplier;
-    m_rightMotor.set(MathUtil.clamp(rightMotorOutput, -1.0, 1.0) * maxOutput);
-
-    feed();
+    m_leftMotor.set(leftSpeed * m_maxOutput);
+    m_rightMotor.set(rightSpeed * m_maxOutput);
   }
 
   /**
    * Curvature drive method for differential drive platform.
    *
    * <p>The rotation argument controls the curvature of the robot's path rather than its rate of
-   * heading change. This makes the robot more controllable at high speeds. Also handles the robot's
-   * quick turn functionality - "quick turn" overrides constant-curvature turning for turn-in-place
-   * maneuvers.
+   * heading change. This makes the robot more controllable at high speeds. Constant-curvature
+   * turning can be overridden for turn-in-place maneuvers.
    *
    * @param xSpeed The robot's speed along the X axis [-1.0..1.0]. Forward is positive.
    * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
    *     positive.
-   * @param isQuickTurn If set, overrides constant-curvature turning for turn-in-place maneuvers.
+   * @param allowTurnInPlace If set, overrides constant-curvature turning for turn-in-place
+   *     maneuvers.
    */
   @SuppressWarnings({"ParameterName", "PMD.CyclomaticComplexity"})
-  public void curvatureDrive(double xSpeed, double zRotation, boolean isQuickTurn) {
+  public void curvatureDrive(double xSpeed, double zRotation, boolean allowTurnInPlace) {
     if (!m_reported) {
       HAL.report(
-          tResourceType.kResourceType_RobotDrive, tInstances.kRobotDrive2_DifferentialCurvature, 2);
+          tResourceType.kResourceType_RobotDrive, 2, tInstances.kRobotDrive2_DifferentialCurvature);
       m_reported = true;
     }
 
     xSpeed = MathUtil.clamp(xSpeed, -1.0, 1.0);
-    xSpeed = applyDeadband(xSpeed, m_deadband);
-
     zRotation = MathUtil.clamp(zRotation, -1.0, 1.0);
-    zRotation = applyDeadband(zRotation, m_deadband);
 
-    double angularPower;
-    boolean overPower;
+    double leftSpeed = 0.0;
+    double rightSpeed = 0.0;
 
-    if (isQuickTurn) {
-      if (Math.abs(xSpeed) < m_quickStopThreshold) {
-        m_quickStopAccumulator =
-            (1 - m_quickStopAlpha) * m_quickStopAccumulator
-                + m_quickStopAlpha * MathUtil.clamp(zRotation, -1.0, 1.0) * 2;
-      }
-      overPower = true;
-      angularPower = zRotation;
+    if (allowTurnInPlace) {
+      leftSpeed = xSpeed + zRotation;
+      rightSpeed = xSpeed - zRotation;
     } else {
-      overPower = false;
-      angularPower = Math.abs(xSpeed) * zRotation - m_quickStopAccumulator;
-
-      if (m_quickStopAccumulator > 1) {
-        m_quickStopAccumulator -= 1;
-      } else if (m_quickStopAccumulator < -1) {
-        m_quickStopAccumulator += 1;
-      } else {
-        m_quickStopAccumulator = 0.0;
-      }
+      leftSpeed = xSpeed + Math.abs(xSpeed) * zRotation;
+      rightSpeed = xSpeed - Math.abs(xSpeed) * zRotation;
     }
 
-    double leftMotorOutput = xSpeed + angularPower;
-    double rightMotorOutput = xSpeed - angularPower;
-
-    // If rotation is overpowered, reduce both outputs to within acceptable range
-    if (overPower) {
-      if (leftMotorOutput > 1.0) {
-        rightMotorOutput -= leftMotorOutput - 1.0;
-        leftMotorOutput = 1.0;
-      } else if (rightMotorOutput > 1.0) {
-        leftMotorOutput -= rightMotorOutput - 1.0;
-        rightMotorOutput = 1.0;
-      } else if (leftMotorOutput < -1.0) {
-        rightMotorOutput -= leftMotorOutput + 1.0;
-        leftMotorOutput = -1.0;
-      } else if (rightMotorOutput < -1.0) {
-        leftMotorOutput -= rightMotorOutput + 1.0;
-        rightMotorOutput = -1.0;
-      }
-    }
-
-    // Normalize the wheel speeds
-    double maxMagnitude = Math.max(Math.abs(leftMotorOutput), Math.abs(rightMotorOutput));
+    // Normalize wheel speeds
+    double maxMagnitude = Math.max(Math.abs(leftSpeed), Math.abs(rightSpeed));
     if (maxMagnitude > 1.0) {
-      leftMotorOutput /= maxMagnitude;
-      rightMotorOutput /= maxMagnitude;
+      leftSpeed /= maxMagnitude;
+      rightSpeed /= maxMagnitude;
     }
 
-    m_leftMotor.set(leftMotorOutput * m_maxOutput);
-    m_rightMotor.set(rightMotorOutput * m_maxOutput * m_rightSideInvertMultiplier);
-
-    feed();
+    m_leftMotor.set(leftSpeed * m_maxOutput);
+    m_rightMotor.set(rightSpeed * m_maxOutput);
   }
 
   /**
@@ -325,15 +252,12 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
   public void tankDrive(double leftSpeed, double rightSpeed, boolean squareInputs) {
     if (!m_reported) {
       HAL.report(
-          tResourceType.kResourceType_RobotDrive, tInstances.kRobotDrive2_DifferentialTank, 2);
+          tResourceType.kResourceType_RobotDrive, 2, tInstances.kRobotDrive2_DifferentialTank);
       m_reported = true;
     }
 
     leftSpeed = MathUtil.clamp(leftSpeed, -1.0, 1.0);
-    leftSpeed = applyDeadband(leftSpeed, m_deadband);
-
     rightSpeed = MathUtil.clamp(rightSpeed, -1.0, 1.0);
-    rightSpeed = applyDeadband(rightSpeed, m_deadband);
 
     // Square the inputs (while preserving the sign) to increase fine control
     // while permitting full power.
@@ -343,81 +267,14 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
     }
 
     m_leftMotor.set(leftSpeed * m_maxOutput);
-    m_rightMotor.set(rightSpeed * m_maxOutput * m_rightSideInvertMultiplier);
-
-    feed();
-  }
-
-  /**
-   * Sets the QuickStop speed threshold in curvature drive.
-   *
-   * <p>QuickStop compensates for the robot's moment of inertia when stopping after a QuickTurn.
-   *
-   * <p>While QuickTurn is enabled, the QuickStop accumulator takes on the rotation rate value
-   * outputted by the low-pass filter when the robot's speed along the X axis is below the
-   * threshold. When QuickTurn is disabled, the accumulator's value is applied against the computed
-   * angular power request to slow the robot's rotation.
-   *
-   * @param threshold X speed below which quick stop accumulator will receive rotation rate values
-   *     [0..1.0].
-   */
-  public void setQuickStopThreshold(double threshold) {
-    m_quickStopThreshold = threshold;
-  }
-
-  /**
-   * Sets the low-pass filter gain for QuickStop in curvature drive.
-   *
-   * <p>The low-pass filter filters incoming rotation rate commands to smooth out high frequency
-   * changes.
-   *
-   * @param alpha Low-pass filter gain [0.0..2.0]. Smaller values result in slower output changes.
-   *     Values between 1.0 and 2.0 result in output oscillation. Values below 0.0 and above 2.0 are
-   *     unstable.
-   */
-  public void setQuickStopAlpha(double alpha) {
-    m_quickStopAlpha = alpha;
-  }
-
-  /**
-   * Gets if the power sent to the right side of the drivetrain is multiplied by -1.
-   *
-   * @return true if the right side is inverted
-   */
-  public boolean isRightSideInverted() {
-    return m_rightSideInvertMultiplier == -1.0;
-  }
-
-  /**
-   * Sets if the power sent to the right side of the drivetrain should be multiplied by -1.
-   *
-   * @param rightSideInverted true if right side power should be multiplied by -1
-   */
-  public void setRightSideInverted(boolean rightSideInverted) {
-    m_rightSideInvertMultiplier = rightSideInverted ? -1.0 : 1.0;
-  }
-
-  @Override
-  public void stopMotor() {
-    m_leftMotor.stopMotor();
-    m_rightMotor.stopMotor();
-    feed();
-  }
-
-  @Override
-  public String getDescription() {
-    return "DifferentialDrive";
+    m_rightMotor.set(rightSpeed * m_maxOutput);
   }
 
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("DifferentialDrive");
     builder.setActuator(true);
-    builder.setSafeState(this::stopMotor);
     builder.addDoubleProperty("Left Motor Speed", m_leftMotor::get, m_leftMotor::set);
-    builder.addDoubleProperty(
-        "Right Motor Speed",
-        () -> m_rightMotor.get() * m_rightSideInvertMultiplier,
-        x -> m_rightMotor.set(x * m_rightSideInvertMultiplier));
+    builder.addDoubleProperty("Right Motor Speed", m_rightMotor::get, m_rightMotor::set);
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj2/drive/KilloughDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj2/drive/KilloughDrive.java
@@ -1,0 +1,241 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj2.drive;
+
+import edu.wpi.first.hal.FRCNetComm.tInstances;
+import edu.wpi.first.hal.FRCNetComm.tResourceType;
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.wpilibj.SpeedController;
+import edu.wpi.first.wpilibj.drive.Vector2d;
+import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.wpiutil.math.MathUtil;
+import java.util.StringJoiner;
+
+/**
+ * A class for driving Killough drive platforms.
+ *
+ * <p>Killough drives are triangular with one omni wheel on each corner.
+ *
+ * <p>Drive base diagram:
+ *
+ * <pre>
+ *  /_____\
+ * / \   / \
+ *    \ /
+ *    ---
+ * </pre>
+ *
+ * <p>Each drive() function provides different inverse kinematic relations for a Killough drive. The
+ * default wheel vectors are parallel to their respective opposite sides, but can be overridden. See
+ * the constructor for more information.
+ *
+ * <p>This library uses the NED axes convention (North-East-Down as external reference in the world
+ * frame): http://www.nuclearprojects.com/ins/images/axis_big.png.
+ *
+ * <p>The positive X axis points ahead, the positive Y axis points right, and the positive Z axis
+ * points down. Rotations follow the right-hand rule, so clockwise rotation around the Z axis is
+ * positive.
+ */
+public class KilloughDrive extends RobotDriveBase implements Sendable {
+  public static final double kDefaultLeftMotorAngle = 60.0;
+  public static final double kDefaultRightMotorAngle = 120.0;
+  public static final double kDefaultBackMotorAngle = 270.0;
+
+  private static int instances;
+
+  private SpeedController m_leftMotor;
+  private SpeedController m_rightMotor;
+  private SpeedController m_backMotor;
+
+  private Vector2d m_leftVec;
+  private Vector2d m_rightVec;
+  private Vector2d m_backVec;
+
+  private boolean m_reported;
+
+  /**
+   * Construct a Killough drive with the given motors and default motor angles.
+   *
+   * <p>The default motor angles make the wheels on each corner parallel to their respective
+   * opposite sides.
+   *
+   * <p>If a motor needs to be inverted, do so before passing it in.
+   *
+   * @param leftMotor The motor on the left corner.
+   * @param rightMotor The motor on the right corner.
+   * @param backMotor The motor on the back corner.
+   */
+  public KilloughDrive(
+      SpeedController leftMotor, SpeedController rightMotor, SpeedController backMotor) {
+    this(
+        leftMotor,
+        rightMotor,
+        backMotor,
+        kDefaultLeftMotorAngle,
+        kDefaultRightMotorAngle,
+        kDefaultBackMotorAngle);
+  }
+
+  /**
+   * Construct a Killough drive with the given motors.
+   *
+   * <p>Angles are measured in degrees clockwise from the positive X axis.
+   *
+   * @param leftMotor The motor on the left corner.
+   * @param rightMotor The motor on the right corner.
+   * @param backMotor The motor on the back corner.
+   * @param leftMotorAngle The angle of the left wheel's forward direction of travel.
+   * @param rightMotorAngle The angle of the right wheel's forward direction of travel.
+   * @param backMotorAngle The angle of the back wheel's forward direction of travel.
+   */
+  public KilloughDrive(
+      SpeedController leftMotor,
+      SpeedController rightMotor,
+      SpeedController backMotor,
+      double leftMotorAngle,
+      double rightMotorAngle,
+      double backMotorAngle) {
+    verify(leftMotor, rightMotor, backMotor);
+    m_leftMotor = leftMotor;
+    m_rightMotor = rightMotor;
+    m_backMotor = backMotor;
+    m_leftVec =
+        new Vector2d(
+            Math.cos(leftMotorAngle * (Math.PI / 180.0)),
+            Math.sin(leftMotorAngle * (Math.PI / 180.0)));
+    m_rightVec =
+        new Vector2d(
+            Math.cos(rightMotorAngle * (Math.PI / 180.0)),
+            Math.sin(rightMotorAngle * (Math.PI / 180.0)));
+    m_backVec =
+        new Vector2d(
+            Math.cos(backMotorAngle * (Math.PI / 180.0)),
+            Math.sin(backMotorAngle * (Math.PI / 180.0)));
+    SendableRegistry.addChild(this, m_leftMotor);
+    SendableRegistry.addChild(this, m_rightMotor);
+    SendableRegistry.addChild(this, m_backMotor);
+    instances++;
+    SendableRegistry.addLW(this, "KilloughDrive", instances);
+  }
+
+  /**
+   * Verifies that all motors are nonnull, throwing a NullPointerException if any of them are. The
+   * exception's error message will specify all null motors, e.g. {@code
+   * NullPointerException("leftMotor, rightMotor")}, to give as much information as possible to the
+   * programmer.
+   *
+   * @throws NullPointerException if any of the given motors are null
+   */
+  @SuppressWarnings("PMD.AvoidThrowingNullPointerException")
+  private void verify(
+      SpeedController leftMotor, SpeedController rightMotor, SpeedController backMotor) {
+    if (leftMotor != null && rightMotor != null && backMotor != null) {
+      return;
+    }
+    StringJoiner joiner = new StringJoiner(", ");
+    if (leftMotor == null) {
+      joiner.add("leftMotor");
+    }
+    if (rightMotor == null) {
+      joiner.add("rightMotor");
+    }
+    if (backMotor == null) {
+      joiner.add("backMotor");
+    }
+    throw new NullPointerException(joiner.toString());
+  }
+
+  /**
+   * Drive method for Killough platform.
+   *
+   * <p>Angles are measured clockwise from the positive X axis. The robot's speed is independent
+   * from its angle or rotation rate.
+   *
+   * @param ySpeed The robot's speed along the Y axis [-1.0..1.0]. Right is positive.
+   * @param xSpeed The robot's speed along the X axis [-1.0..1.0]. Forward is positive.
+   * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
+   *     positive.
+   */
+  @SuppressWarnings("ParameterName")
+  public void driveCartesian(double ySpeed, double xSpeed, double zRotation) {
+    driveCartesian(ySpeed, xSpeed, zRotation, 0.0);
+  }
+
+  /**
+   * Drive method for Killough platform.
+   *
+   * <p>Angles are measured clockwise from the positive X axis. The robot's speed is independent
+   * from its angle or rotation rate.
+   *
+   * @param ySpeed The robot's speed along the Y axis [-1.0..1.0]. Right is positive.
+   * @param xSpeed The robot's speed along the X axis [-1.0..1.0]. Forward is positive.
+   * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
+   *     positive.
+   * @param gyroAngle The current angle reading from the gyro in degrees around the Z axis. Use this
+   *     to implement field-oriented controls.
+   */
+  @SuppressWarnings("ParameterName")
+  public void driveCartesian(double ySpeed, double xSpeed, double zRotation, double gyroAngle) {
+    if (!m_reported) {
+      HAL.report(
+          tResourceType.kResourceType_RobotDrive, 3, tInstances.kRobotDrive2_KilloughCartesian);
+      m_reported = true;
+    }
+
+    ySpeed = MathUtil.clamp(ySpeed, -1.0, 1.0);
+    xSpeed = MathUtil.clamp(xSpeed, -1.0, 1.0);
+
+    // Compensate for gyro angle.
+    Vector2d input = new Vector2d(ySpeed, xSpeed);
+    input.rotate(-gyroAngle);
+
+    double[] wheelSpeeds = new double[3];
+    wheelSpeeds[MotorType.kLeft.value] = input.scalarProject(m_leftVec) + zRotation;
+    wheelSpeeds[MotorType.kRight.value] = input.scalarProject(m_rightVec) + zRotation;
+    wheelSpeeds[MotorType.kBack.value] = input.scalarProject(m_backVec) + zRotation;
+
+    normalize(wheelSpeeds);
+
+    m_leftMotor.set(wheelSpeeds[MotorType.kLeft.value] * m_maxOutput);
+    m_rightMotor.set(wheelSpeeds[MotorType.kRight.value] * m_maxOutput);
+    m_backMotor.set(wheelSpeeds[MotorType.kBack.value] * m_maxOutput);
+  }
+
+  /**
+   * Drive method for Killough platform.
+   *
+   * <p>Angles are measured counter-clockwise from straight ahead. The speed at which the robot
+   * drives (translation) is independent from its angle or rotation rate.
+   *
+   * @param magnitude The robot's speed at a given angle [-1.0..1.0]. Forward is positive.
+   * @param angle The angle around the Z axis at which the robot drives in degrees [-180..180].
+   * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
+   *     positive.
+   */
+  @SuppressWarnings("ParameterName")
+  public void drivePolar(double magnitude, double angle, double zRotation) {
+    if (!m_reported) {
+      HAL.report(tResourceType.kResourceType_RobotDrive, 3, tInstances.kRobotDrive2_KilloughPolar);
+      m_reported = true;
+    }
+
+    driveCartesian(
+        magnitude * Math.sin(angle * (Math.PI / 180.0)),
+        magnitude * Math.cos(angle * (Math.PI / 180.0)),
+        zRotation,
+        0.0);
+  }
+
+  @Override
+  public void initSendable(SendableBuilder builder) {
+    builder.setSmartDashboardType("KilloughDrive");
+    builder.setActuator(true);
+    builder.addDoubleProperty("Left Motor Speed", m_leftMotor::get, m_leftMotor::set);
+    builder.addDoubleProperty("Right Motor Speed", m_rightMotor::get, m_rightMotor::set);
+    builder.addDoubleProperty("Back Motor Speed", m_backMotor::get, m_backMotor::set);
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj2/drive/RobotDriveBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj2/drive/RobotDriveBase.java
@@ -1,0 +1,65 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj2.drive;
+
+/** Common base class for drive platforms. */
+public class RobotDriveBase {
+  public static final double kDefaultMaxOutput = 1.0;
+
+  protected double m_maxOutput = kDefaultMaxOutput;
+
+  /** The location of a motor on the robot for the purpose of driving. */
+  public enum MotorType {
+    kFrontLeft(0),
+    kFrontRight(1),
+    kRearLeft(2),
+    kRearRight(3),
+    kLeft(0),
+    kRight(1),
+    kBack(2);
+
+    @SuppressWarnings("MemberName")
+    public final int value;
+
+    MotorType(int value) {
+      this.value = value;
+    }
+  }
+
+  /** RobotDriveBase constructor. */
+  protected RobotDriveBase() {}
+
+  /**
+   * Configure the scaling factor for using drive methods with motor controllers in a mode other
+   * than PercentVbus or to limit the maximum output.
+   *
+   * <p>The default value is {@value #kDefaultMaxOutput}.
+   *
+   * @param maxOutput Multiplied with the output percentage computed by the drive functions.
+   */
+  public void setMaxOutput(double maxOutput) {
+    m_maxOutput = maxOutput;
+  }
+
+  /**
+   * Normalize all wheel speeds if the magnitude of any wheel is greater than 1.0.
+   *
+   * @param wheelSpeeds Array of wheel speeds.
+   */
+  protected static void normalize(double[] wheelSpeeds) {
+    double maxMagnitude = Math.abs(wheelSpeeds[0]);
+    for (int i = 1; i < wheelSpeeds.length; i++) {
+      double temp = Math.abs(wheelSpeeds[i]);
+      if (maxMagnitude < temp) {
+        maxMagnitude = temp;
+      }
+    }
+    if (maxMagnitude > 1.0) {
+      for (int i = 0; i < wheelSpeeds.length; i++) {
+        wheelSpeeds[i] = wheelSpeeds[i] / maxMagnitude;
+      }
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj2/drive/DifferentialDriveTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj2/drive/DifferentialDriveTest.java
@@ -1,0 +1,234 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj2.drive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.wpilibj.MockSpeedController;
+import org.junit.jupiter.api.Test;
+
+class DifferentialDriveTest {
+  @Test
+  void testArcadeDrive() {
+    var left = new MockSpeedController();
+    var right = new MockSpeedController();
+    var drive = new DifferentialDrive(left, right);
+
+    // Forward
+    drive.arcadeDrive(1.0, 0.0, false);
+    assertEquals(1.0, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+
+    // Forward left turn
+    drive.arcadeDrive(0.5, -0.5, false);
+    assertEquals(0.0, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+
+    // Forward right turn
+    drive.arcadeDrive(0.5, 0.5, false);
+    assertEquals(1.0, left.get(), 1e-9);
+    assertEquals(0.0, right.get(), 1e-9);
+
+    // Backward
+    drive.arcadeDrive(-1.0, 0.0, false);
+    assertEquals(-1.0, left.get(), 1e-9);
+    assertEquals(-1.0, right.get(), 1e-9);
+
+    // Backward left turn
+    drive.arcadeDrive(-0.5, -0.5, false);
+    assertEquals(-1.0, left.get(), 1e-9);
+    assertEquals(0.0, right.get(), 1e-9);
+
+    // Backward right turn
+    drive.arcadeDrive(-0.5, 0.5, false);
+    assertEquals(0.0, left.get(), 1e-9);
+    assertEquals(-1.0, right.get(), 1e-9);
+  }
+
+  @Test
+  void testArcadeDriveSquared() {
+    var left = new MockSpeedController();
+    var right = new MockSpeedController();
+    var drive = new DifferentialDrive(left, right);
+
+    // Forward
+    drive.arcadeDrive(1.0, 0.0, true);
+    assertEquals(1.0, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+
+    // Forward left turn
+    drive.arcadeDrive(0.5, -0.5, true);
+    assertEquals(0.0, left.get(), 1e-9);
+    assertEquals(0.5, right.get(), 1e-9);
+
+    // Forward right turn
+    drive.arcadeDrive(0.5, 0.5, true);
+    assertEquals(0.5, left.get(), 1e-9);
+    assertEquals(0.0, right.get(), 1e-9);
+
+    // Backward
+    drive.arcadeDrive(-1.0, 0.0, true);
+    assertEquals(-1.0, left.get(), 1e-9);
+    assertEquals(-1.0, right.get(), 1e-9);
+
+    // Backward left turn
+    drive.arcadeDrive(-0.5, -0.5, true);
+    assertEquals(-0.5, left.get(), 1e-9);
+    assertEquals(0.0, right.get(), 1e-9);
+
+    // Backward right turn
+    drive.arcadeDrive(-0.5, 0.5, true);
+    assertEquals(0.0, left.get(), 1e-9);
+    assertEquals(-0.5, right.get(), 1e-9);
+  }
+
+  @Test
+  void testCurvatureDrive() {
+    var left = new MockSpeedController();
+    var right = new MockSpeedController();
+    var drive = new DifferentialDrive(left, right);
+
+    // Forward
+    drive.curvatureDrive(1.0, 0.0, false);
+    assertEquals(1.0, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+
+    // Forward left turn
+    drive.curvatureDrive(0.5, -0.5, false);
+    assertEquals(0.25, left.get(), 1e-9);
+    assertEquals(0.75, right.get(), 1e-9);
+
+    // Forward right turn
+    drive.curvatureDrive(0.5, 0.5, false);
+    assertEquals(0.75, left.get(), 1e-9);
+    assertEquals(0.25, right.get(), 1e-9);
+
+    // Backward
+    drive.curvatureDrive(-1.0, 0.0, false);
+    assertEquals(-1.0, left.get(), 1e-9);
+    assertEquals(-1.0, right.get(), 1e-9);
+
+    // Backward left turn
+    drive.curvatureDrive(-0.5, -0.5, false);
+    assertEquals(-0.75, left.get(), 1e-9);
+    assertEquals(-0.25, right.get(), 1e-9);
+
+    // Backward right turn
+    drive.curvatureDrive(-0.5, 0.5, false);
+    assertEquals(-0.25, left.get(), 1e-9);
+    assertEquals(-0.75, right.get(), 1e-9);
+  }
+
+  @Test
+  void testCurvatureDriveTurnInPlace() {
+    var left = new MockSpeedController();
+    var right = new MockSpeedController();
+    var drive = new DifferentialDrive(left, right);
+
+    // Forward
+    drive.curvatureDrive(1.0, 0.0, true);
+    assertEquals(1.0, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+
+    // Forward left turn
+    drive.curvatureDrive(0.5, -0.5, true);
+    assertEquals(0.0, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+
+    // Forward right turn
+    drive.curvatureDrive(0.5, 0.5, true);
+    assertEquals(1.0, left.get(), 1e-9);
+    assertEquals(0.0, right.get(), 1e-9);
+
+    // Backward
+    drive.curvatureDrive(-1.0, 0.0, true);
+    assertEquals(-1.0, left.get(), 1e-9);
+    assertEquals(-1.0, right.get(), 1e-9);
+
+    // Backward left turn
+    drive.curvatureDrive(-0.5, -0.5, true);
+    assertEquals(-1.0, left.get(), 1e-9);
+    assertEquals(0.0, right.get(), 1e-9);
+
+    // Backward right turn
+    drive.curvatureDrive(-0.5, 0.5, true);
+    assertEquals(0.0, left.get(), 1e-9);
+    assertEquals(-1.0, right.get(), 1e-9);
+  }
+
+  @Test
+  void testTankDrive() {
+    var left = new MockSpeedController();
+    var right = new MockSpeedController();
+    var drive = new DifferentialDrive(left, right);
+
+    // Forward
+    drive.tankDrive(1.0, 1.0, false);
+    assertEquals(1.0, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+
+    // Forward left turn
+    drive.tankDrive(0.5, 1.0, false);
+    assertEquals(0.5, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+
+    // Forward right turn
+    drive.tankDrive(1.0, 0.5, false);
+    assertEquals(1.0, left.get(), 1e-9);
+    assertEquals(0.5, right.get(), 1e-9);
+
+    // Backward
+    drive.tankDrive(-1.0, -1.0, false);
+    assertEquals(-1.0, left.get(), 1e-9);
+    assertEquals(-1.0, right.get(), 1e-9);
+
+    // Backward left turn
+    drive.tankDrive(-0.5, -1.0, false);
+    assertEquals(-0.5, left.get(), 1e-9);
+    assertEquals(-1.0, right.get(), 1e-9);
+
+    // Backward right turn
+    drive.tankDrive(-0.5, 1.0, false);
+    assertEquals(-0.5, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+  }
+
+  @Test
+  void testTankDriveSquared() {
+    var left = new MockSpeedController();
+    var right = new MockSpeedController();
+    var drive = new DifferentialDrive(left, right);
+
+    // Forward
+    drive.tankDrive(1.0, 1.0, true);
+    assertEquals(1.0, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+
+    // Forward left turn
+    drive.tankDrive(0.5, 1.0, true);
+    assertEquals(0.25, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+
+    // Forward right turn
+    drive.tankDrive(1.0, 0.5, true);
+    assertEquals(1.0, left.get(), 1e-9);
+    assertEquals(0.25, right.get(), 1e-9);
+
+    // Backward
+    drive.tankDrive(-1.0, -1.0, true);
+    assertEquals(-1.0, left.get(), 1e-9);
+    assertEquals(-1.0, right.get(), 1e-9);
+
+    // Backward left turn
+    drive.tankDrive(-0.5, -1.0, true);
+    assertEquals(-0.25, left.get(), 1e-9);
+    assertEquals(-1.0, right.get(), 1e-9);
+
+    // Backward right turn
+    drive.tankDrive(-1.0, -0.5, true);
+    assertEquals(-1.0, left.get(), 1e-9);
+    assertEquals(-0.25, right.get(), 1e-9);
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj2/drive/KilloughDriveTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj2/drive/KilloughDriveTest.java
@@ -1,0 +1,126 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj2.drive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.wpilibj.MockSpeedController;
+import org.junit.jupiter.api.Test;
+
+class KilloughDriveTest {
+  @Test
+  void testCartesian() {
+    var left = new MockSpeedController();
+    var right = new MockSpeedController();
+    var back = new MockSpeedController();
+    var drive = new KilloughDrive(left, right, back);
+
+    // Forward
+    drive.driveCartesian(1.0, 0.0, 0.0);
+    assertEquals(0.5, left.get(), 1e-9);
+    assertEquals(-0.5, right.get(), 1e-9);
+    assertEquals(0.0, back.get(), 1e-9);
+
+    // Left
+    drive.driveCartesian(0.0, -1.0, 0.0);
+    assertEquals(-Math.sqrt(3) / 2, left.get(), 1e-9);
+    assertEquals(-Math.sqrt(3) / 2, right.get(), 1e-9);
+    assertEquals(1.0, back.get(), 1e-9);
+
+    // Right
+    drive.driveCartesian(0.0, 1.0, 0.0);
+    assertEquals(Math.sqrt(3) / 2, left.get(), 1e-9);
+    assertEquals(Math.sqrt(3) / 2, right.get(), 1e-9);
+    assertEquals(-1.0, back.get(), 1e-9);
+
+    // Rotate CCW
+    drive.driveCartesian(0.0, 0.0, -1.0);
+    assertEquals(-1.0, left.get(), 1e-9);
+    assertEquals(-1.0, right.get(), 1e-9);
+    assertEquals(-1.0, back.get(), 1e-9);
+
+    // Rotate CW
+    drive.driveCartesian(0.0, 0.0, 1.0);
+    assertEquals(1.0, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+    assertEquals(1.0, back.get(), 1e-9);
+  }
+
+  @Test
+  void testCartesiangyro90CW() {
+    var left = new MockSpeedController();
+    var right = new MockSpeedController();
+    var back = new MockSpeedController();
+    var drive = new KilloughDrive(left, right, back);
+
+    // Forward in global frame; left in robot frame
+    drive.driveCartesian(1.0, 0.0, 0.0, 90.0);
+    assertEquals(-Math.sqrt(3) / 2, left.get(), 1e-9);
+    assertEquals(-Math.sqrt(3) / 2, right.get(), 1e-9);
+    assertEquals(1.0, back.get(), 1e-9);
+
+    // Left in global frame; backward in robot frame
+    drive.driveCartesian(0.0, -1.0, 0.0, 90.0);
+    assertEquals(-0.5, left.get(), 1e-9);
+    assertEquals(0.5, right.get(), 1e-9);
+    assertEquals(0.0, back.get(), 1e-9);
+
+    // Right in global frame; forward in robot frame
+    drive.driveCartesian(0.0, 1.0, 0.0, 90.0);
+    assertEquals(0.5, left.get(), 1e-9);
+    assertEquals(-0.5, right.get(), 1e-9);
+    assertEquals(0.0, back.get(), 1e-9);
+
+    // Rotate CCW
+    drive.driveCartesian(0.0, 0.0, -1.0, 90.0);
+    assertEquals(-1.0, left.get(), 1e-9);
+    assertEquals(-1.0, right.get(), 1e-9);
+    assertEquals(-1.0, back.get(), 1e-9);
+
+    // Rotate CW
+    drive.driveCartesian(0.0, 0.0, 1.0, 90.0);
+    assertEquals(1.0, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+    assertEquals(1.0, back.get(), 1e-9);
+  }
+
+  @Test
+  void testPolar() {
+    var left = new MockSpeedController();
+    var right = new MockSpeedController();
+    var back = new MockSpeedController();
+    var drive = new KilloughDrive(left, right, back);
+
+    // Forward
+    drive.drivePolar(1.0, 0.0, 0.0);
+    assertEquals(Math.sqrt(3) / 2, left.get(), 1e-9);
+    assertEquals(Math.sqrt(3) / 2, right.get(), 1e-9);
+    assertEquals(-1.0, back.get(), 1e-9);
+
+    // Left
+    drive.drivePolar(1.0, -90.0, 0.0);
+    assertEquals(-0.5, left.get(), 1e-9);
+    assertEquals(0.5, right.get(), 1e-9);
+    assertEquals(0.0, back.get(), 1e-9);
+
+    // Right
+    drive.drivePolar(1.0, 90.0, 0.0);
+    assertEquals(0.5, left.get(), 1e-9);
+    assertEquals(-0.5, right.get(), 1e-9);
+    assertEquals(0.0, back.get(), 1e-9);
+
+    // Rotate CCW
+    drive.drivePolar(0.0, 0.0, -1.0);
+    assertEquals(-1.0, left.get(), 1e-9);
+    assertEquals(-1.0, right.get(), 1e-9);
+    assertEquals(-1.0, back.get(), 1e-9);
+
+    // Rotate CW
+    drive.drivePolar(0.0, 0.0, 1.0);
+    assertEquals(1.0, left.get(), 1e-9);
+    assertEquals(1.0, right.get(), 1e-9);
+    assertEquals(1.0, back.get(), 1e-9);
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj2/drive/MecanumDriveTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj2/drive/MecanumDriveTest.java
@@ -1,0 +1,144 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj2.drive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.wpilibj.MockSpeedController;
+import org.junit.jupiter.api.Test;
+
+class MecanumDriveTest {
+  @Test
+  void testCartesian() {
+    var fl = new MockSpeedController();
+    var fr = new MockSpeedController();
+    var rl = new MockSpeedController();
+    var rr = new MockSpeedController();
+    var drive = new MecanumDrive(fl, fr, rl, rr);
+
+    // Forward
+    drive.driveCartesian(1.0, 0.0, 0.0);
+    assertEquals(1.0, fl.get(), 1e-9);
+    assertEquals(1.0, fr.get(), 1e-9);
+    assertEquals(1.0, rl.get(), 1e-9);
+    assertEquals(1.0, rr.get(), 1e-9);
+
+    // Left
+    drive.driveCartesian(0.0, -1.0, 0.0);
+    assertEquals(-1.0, fl.get(), 1e-9);
+    assertEquals(1.0, fr.get(), 1e-9);
+    assertEquals(1.0, rl.get(), 1e-9);
+    assertEquals(-1.0, rr.get(), 1e-9);
+
+    // Right
+    drive.driveCartesian(0.0, 1.0, 0.0);
+    assertEquals(1.0, fl.get(), 1e-9);
+    assertEquals(-1.0, fr.get(), 1e-9);
+    assertEquals(-1.0, rl.get(), 1e-9);
+    assertEquals(1.0, rr.get(), 1e-9);
+
+    // Rotate CCW
+    drive.driveCartesian(0.0, 0.0, -1.0);
+    assertEquals(-1.0, fl.get(), 1e-9);
+    assertEquals(-1.0, fr.get(), 1e-9);
+    assertEquals(1.0, rl.get(), 1e-9);
+    assertEquals(1.0, rr.get(), 1e-9);
+
+    // Rotate CW
+    drive.driveCartesian(0.0, 0.0, 1.0);
+    assertEquals(1.0, fl.get(), 1e-9);
+    assertEquals(1.0, fr.get(), 1e-9);
+    assertEquals(-1.0, rl.get(), 1e-9);
+    assertEquals(-1.0, rr.get(), 1e-9);
+  }
+
+  @Test
+  void testCartesiangyro90CW() {
+    var fl = new MockSpeedController();
+    var fr = new MockSpeedController();
+    var rl = new MockSpeedController();
+    var rr = new MockSpeedController();
+    var drive = new MecanumDrive(fl, fr, rl, rr);
+
+    // Forward in global frame; left in robot frame
+    drive.driveCartesian(1.0, 0.0, 0.0, 90.0);
+    assertEquals(-1.0, fl.get(), 1e-9);
+    assertEquals(1.0, fr.get(), 1e-9);
+    assertEquals(1.0, rl.get(), 1e-9);
+    assertEquals(-1.0, rr.get(), 1e-9);
+
+    // Left in global frame; backward in robot frame
+    drive.driveCartesian(0.0, -1.0, 0.0, 90.0);
+    assertEquals(-1.0, fl.get(), 1e-9);
+    assertEquals(-1.0, fr.get(), 1e-9);
+    assertEquals(-1.0, rl.get(), 1e-9);
+    assertEquals(-1.0, rr.get(), 1e-9);
+
+    // Right in global frame; forward in robot frame
+    drive.driveCartesian(0.0, 1.0, 0.0, 90.0);
+    assertEquals(1.0, fl.get(), 1e-9);
+    assertEquals(1.0, fr.get(), 1e-9);
+    assertEquals(1.0, rl.get(), 1e-9);
+    assertEquals(1.0, rr.get(), 1e-9);
+
+    // Rotate CCW
+    drive.driveCartesian(0.0, 0.0, -1.0, 90.0);
+    assertEquals(-1.0, fl.get(), 1e-9);
+    assertEquals(-1.0, fr.get(), 1e-9);
+    assertEquals(1.0, rl.get(), 1e-9);
+    assertEquals(1.0, rr.get(), 1e-9);
+
+    // Rotate CW
+    drive.driveCartesian(0.0, 0.0, 1.0, 90.0);
+    assertEquals(1.0, fl.get(), 1e-9);
+    assertEquals(1.0, fr.get(), 1e-9);
+    assertEquals(-1.0, rl.get(), 1e-9);
+    assertEquals(-1.0, rr.get(), 1e-9);
+  }
+
+  @Test
+  void testPolar() {
+    var fl = new MockSpeedController();
+    var fr = new MockSpeedController();
+    var rl = new MockSpeedController();
+    var rr = new MockSpeedController();
+    var drive = new MecanumDrive(fl, fr, rl, rr);
+
+    // Forward
+    drive.drivePolar(1.0, 0.0, 0.0);
+    assertEquals(1.0, fl.get(), 1e-9);
+    assertEquals(1.0, fr.get(), 1e-9);
+    assertEquals(1.0, rl.get(), 1e-9);
+    assertEquals(1.0, rr.get(), 1e-9);
+
+    // Left
+    drive.drivePolar(1.0, -90.0, 0.0);
+    assertEquals(-1.0, fl.get(), 1e-9);
+    assertEquals(1.0, fr.get(), 1e-9);
+    assertEquals(1.0, rl.get(), 1e-9);
+    assertEquals(-1.0, rr.get(), 1e-9);
+
+    // Right
+    drive.drivePolar(1.0, 90.0, 0.0);
+    assertEquals(1.0, fl.get(), 1e-9);
+    assertEquals(-1.0, fr.get(), 1e-9);
+    assertEquals(-1.0, rl.get(), 1e-9);
+    assertEquals(1.0, rr.get(), 1e-9);
+
+    // Rotate CCW
+    drive.drivePolar(0.0, 0.0, -1.0);
+    assertEquals(-1.0, fl.get(), 1e-9);
+    assertEquals(-1.0, fr.get(), 1e-9);
+    assertEquals(1.0, rl.get(), 1e-9);
+    assertEquals(1.0, rr.get(), 1e-9);
+
+    // Rotate CW
+    drive.drivePolar(0.0, 0.0, 1.0);
+    assertEquals(1.0, fl.get(), 1e-9);
+    assertEquals(1.0, fr.get(), 1e-9);
+    assertEquals(-1.0, rl.get(), 1e-9);
+    assertEquals(-1.0, rr.get(), 1e-9);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/arcadedrive/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/arcadedrive/Robot.java
@@ -7,7 +7,7 @@ package edu.wpi.first.wpilibj.examples.arcadedrive;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj2.drive.DifferentialDrive;
 
 /**
  * This is a demo program showing the use of the DifferentialDrive class. Runs the motors with

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/subsystems/DriveSubsystem.java
@@ -7,9 +7,9 @@ package edu.wpi.first.wpilibj.examples.frisbeebot.subsystems;
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.SpeedControllerGroup;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.examples.frisbeebot.Constants.DriveConstants;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.drive.DifferentialDrive;
 
 public class DriveSubsystem extends SubsystemBase {
   // The motors on the left side of the drive.

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/DriveTrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/DriveTrain.java
@@ -10,10 +10,10 @@ import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.SpeedController;
 import edu.wpi.first.wpilibj.SpeedControllerGroup;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.examples.gearsbot.Robot;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.drive.DifferentialDrive;
 
 public class DriveTrain extends SubsystemBase {
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gettingstarted/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gettingstarted/Robot.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj2.drive.DifferentialDrive;
 
 /**
  * The VM is configured to automatically run this class, and to call the functions corresponding to
@@ -41,9 +41,11 @@ public class Robot extends TimedRobot {
   public void autonomousPeriodic() {
     // Drive for 2 seconds
     if (m_timer.get() < 2.0) {
-      m_robotDrive.arcadeDrive(0.5, 0.0); // drive forwards half speed
+      // Drive forwards half speed
+      m_robotDrive.arcadeDrive(0.5, 0.0);
     } else {
-      m_robotDrive.stopMotor(); // stop robot
+      // Stop robot
+      m_robotDrive.arcadeDrive(0.0, 0.0);
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyro/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyro/Robot.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj.AnalogGyro;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj2.drive.DifferentialDrive;
 
 /**
  * This is a sample program to demonstrate how to use a gyro sensor to make a robot drive straight.

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/subsystems/DriveSubsystem.java
@@ -8,10 +8,10 @@ import edu.wpi.first.wpilibj.ADXRS450_Gyro;
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.SpeedControllerGroup;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.examples.gyrodrivecommands.Constants.DriveConstants;
 import edu.wpi.first.wpilibj.interfaces.Gyro;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.drive.DifferentialDrive;
 
 public class DriveSubsystem extends SubsystemBase {
   // The motors on the left side of the drive.

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyromecanum/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyromecanum/Robot.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj.AnalogGyro;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj.drive.MecanumDrive;
+import edu.wpi.first.wpilibj2.drive.MecanumDrive;
 
 /**
  * This is a sample program that uses mecanum drive with a gyro sensor to maintain rotation

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/subsystems/DriveSubsystem.java
@@ -7,9 +7,9 @@ package edu.wpi.first.wpilibj.examples.hatchbotinlined.subsystems;
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.SpeedControllerGroup;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.examples.hatchbotinlined.Constants.DriveConstants;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.drive.DifferentialDrive;
 
 public class DriveSubsystem extends SubsystemBase {
   // The motors on the left side of the drive.

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/subsystems/DriveSubsystem.java
@@ -7,9 +7,9 @@ package edu.wpi.first.wpilibj.examples.hatchbottraditional.subsystems;
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.SpeedControllerGroup;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.examples.hatchbottraditional.Constants.DriveConstants;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.drive.DifferentialDrive;
 
 public class DriveSubsystem extends SubsystemBase {
   // The motors on the left side of the drive.

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdrive/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdrive/Robot.java
@@ -7,7 +7,7 @@ package edu.wpi.first.wpilibj.examples.mecanumdrive;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj.drive.MecanumDrive;
+import edu.wpi.first.wpilibj2.drive.MecanumDrive;
 
 /** This is a demo program showing how to use Mecanum control with the MecanumDrive class. */
 public class Robot extends TimedRobot {

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/subsystems/DriveTrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/subsystems/DriveTrain.java
@@ -8,13 +8,12 @@ import edu.wpi.first.wpilibj.AnalogGyro;
 import edu.wpi.first.wpilibj.CounterBase.EncodingType;
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.Joystick;
-import edu.wpi.first.wpilibj.SpeedController;
 import edu.wpi.first.wpilibj.SpeedControllerGroup;
 import edu.wpi.first.wpilibj.Victor;
 import edu.wpi.first.wpilibj.command.Subsystem;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.examples.pacgoat.Robot;
 import edu.wpi.first.wpilibj.examples.pacgoat.commands.DriveWithJoystick;
+import edu.wpi.first.wpilibj2.drive.DifferentialDrive;
 
 /**
  * The DriveTrain subsystem controls the robot's chassis and reads in information about it's speed
@@ -22,10 +21,10 @@ import edu.wpi.first.wpilibj.examples.pacgoat.commands.DriveWithJoystick;
  */
 public class DriveTrain extends Subsystem {
   // Subsystem devices
-  private final SpeedController m_frontLeftCIM = new Victor(1);
-  private final SpeedController m_frontRightCIM = new Victor(2);
-  private final SpeedController m_rearLeftCIM = new Victor(3);
-  private final SpeedController m_rearRightCIM = new Victor(4);
+  private final Victor m_frontLeftCIM = new Victor(1);
+  private final Victor m_frontRightCIM = new Victor(2);
+  private final Victor m_rearLeftCIM = new Victor(3);
+  private final Victor m_rearRightCIM = new Victor(4);
   private final SpeedControllerGroup m_leftCIMs =
       new SpeedControllerGroup(m_frontLeftCIM, m_rearLeftCIM);
   private final SpeedControllerGroup m_rightCIMs =
@@ -46,9 +45,12 @@ public class DriveTrain extends Subsystem {
     // Configure the DifferentialDrive to reflect the fact that all motors
     // are wired backwards (right is inverted in DifferentialDrive).
     m_leftCIMs.setInverted(true);
+    m_rightCIMs.setInverted(true);
+    m_frontLeftCIM.setSafetyEnabled(false);
+    m_frontRightCIM.setSafetyEnabled(false);
+    m_rearLeftCIM.setSafetyEnabled(false);
+    m_rearRightCIM.setSafetyEnabled(false);
     m_drive = new DifferentialDrive(m_leftCIMs, m_rightCIMs);
-    m_drive.setSafetyEnabled(true);
-    m_drive.setExpiration(0.1);
     m_drive.setMaxOutput(1.0);
 
     if (Robot.isReal()) { // Converts to feet

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/shuffleboard/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/shuffleboard/Robot.java
@@ -9,10 +9,10 @@ import edu.wpi.first.wpilibj.AnalogPotentiometer;
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardLayout;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj2.drive.DifferentialDrive;
 
 public class Robot extends TimedRobot {
   private final DifferentialDrive m_tankDrive =

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/tankdrive/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/tankdrive/Robot.java
@@ -7,7 +7,7 @@ package edu.wpi.first.wpilibj.examples.tankdrive;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj2.drive.DifferentialDrive;
 
 /**
  * This is a demo program showing the use of the DifferentialDrive class, specifically it contains

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ultrasonic/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ultrasonic/Robot.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj.AnalogInput;
 import edu.wpi.first.wpilibj.MedianFilter;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj2.drive.DifferentialDrive;
 
 /**
  * This is a sample program demonstrating how to use an ultrasonic sensor and proportional control

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ultrasonicpid/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ultrasonicpid/Robot.java
@@ -9,7 +9,7 @@ import edu.wpi.first.wpilibj.MedianFilter;
 import edu.wpi.first.wpilibj.PWMSparkMax;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.controller.PIDController;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj2.drive.DifferentialDrive;
 
 /**
  * This is a sample program to demonstrate the use of a PIDController with an ultrasonic sensor to


### PR DESCRIPTION
These return the inverse kinematic values, so they can be composed with
feedback controllers. The internal implementation for DifferentialDrive
was massively simplified as well.

Input limits were removed since the normalization takes care of that.
The deadband functionality was moved to GenericHID::GetRawAxis class
since the deadband is generally applied to joystick axes.

MotorSafety was removed since that's handled by the drivetrain's motor
controllers already.