### PR TITLE
Correct C++ DifferentialDrive::ArcadeDrive() xSpeed param documentation

### DIFF
--- a/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -121,7 +121,7 @@ class DifferentialDrive : public RobotDriveBase {
    * by negating the value passed for rotation.
    *
    * @param xSpeed        The speed at which the robot should drive along the X
-   *                      axis [-1.0..1.0]. Forward is negative.
+   *                      axis [-1.0..1.0]. Forward is positive.
    * @param zRotation     The rotation rate of the robot around the Z axis
    *                      [-1.0..1.0]. Clockwise is positive.
    * @param squareInputs If set, decreases the input sensitivity at low speeds.


### PR DESCRIPTION
Forward is positive for xSpeed. Java is already correct.

https://github.com/wpilibsuite/allwpilib/blob/a60f312d19ee3a38df4318e1fec86c6789ef667a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java#L166
https://github.com/wpilibsuite/allwpilib/blob/a60f312d19ee3a38df4318e1fec86c6789ef667a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java#L231