### PR TITLE
SPI: Report port as instance for usage reporting

### DIFF
--- a/wpilibc/src/main/native/cpp/SPI.cpp
+++ b/wpilibc/src/main/native/cpp/SPI.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/cpp/SPI.cpp
+++ b/wpilibc/src/main/native/cpp/SPI.cpp
@@ -157,9 +157,7 @@ SPI::SPI(Port port) : m_port(static_cast<HAL_SPIPort>(port)) {
   HAL_InitializeSPI(m_port, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
 
-  static int instances = 0;
-  instances++;
-  HAL_Report(HALUsageReporting::kResourceType_SPI, instances);
+  HAL_Report(HALUsageReporting::kResourceType_SPI, port);
 }
 
 SPI::~SPI() { HAL_CloseSPI(m_port); }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SPI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SPI.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2016-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2016-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SPI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SPI.java
@@ -32,8 +32,6 @@ public class SPI implements AutoCloseable {
     }
   }
 
-  private static int devices;
-
   private int m_port;
   private int m_msbFirst;
   private int m_clockIdleHigh;
@@ -46,11 +44,10 @@ public class SPI implements AutoCloseable {
    */
   public SPI(Port port) {
     m_port = (byte) port.value;
-    devices++;
 
     SPIJNI.spiInitialize(m_port);
 
-    HAL.report(tResourceType.kResourceType_SPI, devices);
+    HAL.report(tResourceType.kResourceType_SPI, port.value);
   }
 
 


### PR DESCRIPTION
I would like to propose for SPI usage reporting to use the port ID as its instance numbers.

There are a few advantages to this:

- This eliminates a static variable (which are not so fun in other languages).
- This allows whoever is looking at the raw usage reporting data to differentiate between usage of the MXP and onboard ports (which may be useful in designing/selecting a roboRIO replacement in future).