### PR TITLE
Unconditionally disable 4996 (Deprecation warnings) on windows

### DIFF
--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -1,7 +1,7 @@
 import edu.wpi.first.nativeutils.*
 import org.gradle.internal.os.OperatingSystem
 
-def windowsCompilerArgs = ['/EHsc', '/D_CRT_SECURE_NO_WARNINGS', '/Zi', '/FS', '/Zc:inline', '/MP4', '/W3', '/wd4244', '/wd4267', '/wd4146', '/std:c++17', '/permissive-', '/WX']
+def windowsCompilerArgs = ['/EHsc', '/D_CRT_SECURE_NO_WARNINGS', '/Zi', '/FS', '/Zc:inline', '/MP4', '/W3', '/wd4244', '/wd4267', '/wd4146', '/wd4996', '/std:c++17', '/permissive-', '/WX']
 def windowsCCompilerArgs = ['/Zi', '/FS', '/Zc:inline', '/W3', '/WX']
 def windowsReleaseCompilerArgs = ['/O2', '/MD']
 def windowsDebugCompilerArgs = ['/Od', '/MDd']

--- a/wpiutil/CMakeLists.txt
+++ b/wpiutil/CMakeLists.txt
@@ -80,7 +80,7 @@ set_property(TARGET wpiutil PROPERTY FOLDER "libraries")
 if (NOT MSVC)
     target_compile_options(wpiutil PUBLIC -std=c++14 -Wall -pedantic -Wextra -Wno-unused-parameter)
 else()
-    target_compile_options(wpiutil PUBLIC /wd4244 /wd4267 /wd4146 /WX /permissive- /std:c++17)
+    target_compile_options(wpiutil PUBLIC /wd4244 /wd4267 /wd4146 /wd4996 /WX /permissive- /std:c++17)
     target_compile_options(wpiutil PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 


### PR DESCRIPTION
No way to turn the level down, so the only option is to disable