### PR TITLE
Remove functions in LiveWindow deprecated since 2018

### DIFF
--- a/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
+++ b/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2012-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2012-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -58,66 +58,6 @@ LiveWindow::Impl::Impl()
 LiveWindow* LiveWindow::GetInstance() {
   static LiveWindow instance;
   return &instance;
-}
-
-void LiveWindow::Run() { UpdateValues(); }
-
-void LiveWindow::AddSensor(const wpi::Twine& subsystem, const wpi::Twine& name,
-                           Sendable* component) {
-  Add(component);
-  component->SetName(subsystem, name);
-}
-
-void LiveWindow::AddSensor(const wpi::Twine& subsystem, const wpi::Twine& name,
-                           Sendable& component) {
-  Add(&component);
-  component.SetName(subsystem, name);
-}
-
-void LiveWindow::AddSensor(const wpi::Twine& subsystem, const wpi::Twine& name,
-                           std::shared_ptr<Sendable> component) {
-  Add(component);
-  component->SetName(subsystem, name);
-}
-
-void LiveWindow::AddActuator(const wpi::Twine& subsystem,
-                             const wpi::Twine& name, Sendable* component) {
-  Add(component);
-  component->SetName(subsystem, name);
-}
-
-void LiveWindow::AddActuator(const wpi::Twine& subsystem,
-                             const wpi::Twine& name, Sendable& component) {
-  Add(&component);
-  component.SetName(subsystem, name);
-}
-
-void LiveWindow::AddActuator(const wpi::Twine& subsystem,
-                             const wpi::Twine& name,
-                             std::shared_ptr<Sendable> component) {
-  Add(component);
-  component->SetName(subsystem, name);
-}
-
-void LiveWindow::AddSensor(const wpi::Twine& type, int channel,
-                           Sendable* component) {
-  Add(component);
-  component->SetName("Ungrouped",
-                     type + Twine('[') + Twine(channel) + Twine(']'));
-}
-
-void LiveWindow::AddActuator(const wpi::Twine& type, int channel,
-                             Sendable* component) {
-  Add(component);
-  component->SetName("Ungrouped",
-                     type + Twine('[') + Twine(channel) + Twine(']'));
-}
-
-void LiveWindow::AddActuator(const wpi::Twine& type, int module, int channel,
-                             Sendable* component) {
-  Add(component);
-  component->SetName("Ungrouped", type + Twine('[') + Twine(module) +
-                                      Twine(',') + Twine(channel) + Twine(']'));
 }
 
 void LiveWindow::Add(std::shared_ptr<Sendable> sendable) {

--- a/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
+++ b/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2012-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2012-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -32,103 +32,6 @@ class LiveWindow {
    * regardless of how many times GetInstance is called.
    */
   static LiveWindow* GetInstance();
-
-  WPI_DEPRECATED("no longer required")
-  void Run();
-
-  /**
-   * Add a Sensor associated with the subsystem and call it by the given name.
-   *
-   * @param subsystem The subsystem this component is part of.
-   * @param name      The name of this component.
-   * @param component A Sendable component that represents a sensor.
-   */
-  WPI_DEPRECATED("use Sendable::SetName() instead")
-  void AddSensor(const wpi::Twine& subsystem, const wpi::Twine& name,
-                 Sendable* component);
-
-  /**
-   * Add a Sensor associated with the subsystem and call it by the given name.
-   *
-   * @param subsystem The subsystem this component is part of.
-   * @param name      The name of this component.
-   * @param component A Sendable component that represents a sensor.
-   */
-  WPI_DEPRECATED("use Sendable::SetName() instead")
-  void AddSensor(const wpi::Twine& subsystem, const wpi::Twine& name,
-                 Sendable& component);
-
-  /**
-   * Add a Sensor associated with the subsystem and call it by the given name.
-   *
-   * @param subsystem The subsystem this component is part of.
-   * @param name      The name of this component.
-   * @param component A Sendable component that represents a sensor.
-   */
-  WPI_DEPRECATED("use Sendable::SetName() instead")
-  void AddSensor(const wpi::Twine& subsystem, const wpi::Twine& name,
-                 std::shared_ptr<Sendable> component);
-
-  /**
-   * Add an Actuator associated with the subsystem and call it by the given
-   * name.
-   *
-   * @param subsystem The subsystem this component is part of.
-   * @param name      The name of this component.
-   * @param component A Sendable component that represents a actuator.
-   */
-  WPI_DEPRECATED("use Sendable::SetName() instead")
-  void AddActuator(const wpi::Twine& subsystem, const wpi::Twine& name,
-                   Sendable* component);
-
-  /**
-   * Add an Actuator associated with the subsystem and call it by the given
-   * name.
-   *
-   * @param subsystem The subsystem this component is part of.
-   * @param name      The name of this component.
-   * @param component A Sendable component that represents a actuator.
-   */
-  WPI_DEPRECATED("use Sendable::SetName() instead")
-  void AddActuator(const wpi::Twine& subsystem, const wpi::Twine& name,
-                   Sendable& component);
-
-  /**
-   * Add an Actuator associated with the subsystem and call it by the given
-   * name.
-   *
-   * @param subsystem The subsystem this component is part of.
-   * @param name      The name of this component.
-   * @param component A Sendable component that represents a actuator.
-   */
-  WPI_DEPRECATED("use Sendable::SetName() instead")
-  void AddActuator(const wpi::Twine& subsystem, const wpi::Twine& name,
-                   std::shared_ptr<Sendable> component);
-
-  /**
-   * Meant for internal use in other WPILib classes.
-   *
-   * @deprecated Use SendableBase::SetName() instead.
-   */
-  WPI_DEPRECATED("use SensorUtil::SetName() instead")
-  void AddSensor(const wpi::Twine& type, int channel, Sendable* component);
-
-  /**
-   * Meant for internal use in other WPILib classes.
-   *
-   * @deprecated Use SendableBase::SetName() instead.
-   */
-  WPI_DEPRECATED("use SensorUtil::SetName() instead")
-  void AddActuator(const wpi::Twine& type, int channel, Sendable* component);
-
-  /**
-   * Meant for internal use in other WPILib classes.
-   *
-   * @deprecated Use SendableBase::SetName() instead.
-   */
-  WPI_DEPRECATED("use SensorUtil::SetName() instead")
-  void AddActuator(const wpi::Twine& type, int module, int channel,
-                   Sendable* component);
 
   /**
    * Add a component to the LiveWindow.


### PR DESCRIPTION
The Java versions were already accidentally removed in #1059.