### PR TITLE
C++ SPI: Fix SetClockRate to take int

### DIFF
--- a/wpilibc/src/main/native/cpp/SPI.cpp
+++ b/wpilibc/src/main/native/cpp/SPI.cpp
@@ -183,7 +183,7 @@ SPI& SPI::operator=(SPI&& rhs) {
   return *this;
 }
 
-void SPI::SetClockRate(double hz) { HAL_SetSPISpeed(m_port, hz); }
+void SPI::SetClockRate(int hz) { HAL_SetSPISpeed(m_port, hz); }
 
 void SPI::SetMSBFirst() {
   m_msbFirst = true;

--- a/wpilibc/src/main/native/include/frc/SPI.h
+++ b/wpilibc/src/main/native/include/frc/SPI.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -52,7 +52,7 @@ class SPI : public ErrorBase {
    *
    * @param hz The clock rate in Hertz.
    */
-  void SetClockRate(double hz);
+  void SetClockRate(int hz);
 
   /**
    * Configure the order that bits are sent and received on the wire


### PR DESCRIPTION
The Java version takes an int, and `HAL_SetSPISpeed` takes an int as well.