### PR TITLE
wpiutil: Signal: make operator() const

### DIFF
--- a/wpiutil/src/main/native/include/wpi/Signal.h
+++ b/wpiutil/src/main/native/include/wpi/Signal.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -570,7 +570,7 @@ public:
      * @param a... arguments to emit
      */
     template <typename... A>
-    void operator()(A && ... a) {
+    void operator()(A && ... a) const {
         lock_type lock(m_mutex);
         if (!m_block && m_func) m_func(std::forward<A>(a)...);
     }
@@ -799,7 +799,7 @@ private:
 
 private:
     std::function<void(T...)> m_func;
-    Lockable m_mutex;
+    mutable Lockable m_mutex;
     std::atomic<bool> m_block;
 };
 

--- a/wpiutil/src/main/native/include/wpi/uv/Handle.h
+++ b/wpiutil/src/main/native/include/wpi/uv/Handle.h
@@ -235,7 +235,7 @@ class Handle : public std::enable_shared_from_this<Handle> {
    * Report an error.
    * @param err Error code
    */
-  void ReportError(int err) { error(Error(err)); }
+  void ReportError(int err) const { error(Error(err)); }
 
  protected:
   explicit Handle(uv_handle_t* uv_handle) : m_uv_handle{uv_handle} {
@@ -250,7 +250,7 @@ class Handle : public std::enable_shared_from_this<Handle> {
   static void DefaultFreeBuf(Buffer& buf);
 
   template <typename F, typename... Args>
-  bool Invoke(F&& f, Args&&... args) {
+  bool Invoke(F&& f, Args&&... args) const {
     auto err = std::forward<F>(f)(std::forward<Args>(args)...);
     if (err < 0) ReportError(err);
     return err == 0;


### PR DESCRIPTION
This enables const-ness in uv::Handle ReportError() and Invoke() as well.