### PR TITLE
wpiutil: Change future to C++ P1054R0 executor style

### DIFF
--- a/wpiutil/src/main/native/cpp/WorkerThread.cpp
+++ b/wpiutil/src/main/native/cpp/WorkerThread.cpp
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "wpi/WorkerThread.h"
+
+using namespace wpi;
+
+void detail::WorkerThreadThread::Main() {
+  std::vector<Entry> queue;
+  while (m_active) {
+    std::unique_lock<wpi::mutex> lock(m_mutex);
+    m_cond.wait(lock, [&] { return !m_active || !m_queue.empty(); });
+    if (!m_active) break;
+
+    // don't want to hold the lock while executing the callbacks
+    queue.swap(m_queue);
+    lock.unlock();
+
+    for (auto&& entry : queue) {
+      if (!m_active) break;  // requests may be long-running
+      entry.func(entry.factory, entry.req);
+    }
+    queue.clear();
+  }
+}

--- a/wpiutil/src/main/native/cpp/uv/AsyncExecutor.cpp
+++ b/wpiutil/src/main/native/cpp/uv/AsyncExecutor.cpp
@@ -1,0 +1,46 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "wpi/uv/AsyncExecutor.h"
+
+namespace wpi {
+namespace uv {
+namespace detail {
+
+AsyncExecutorHandle::~AsyncExecutorHandle() noexcept {
+  if (auto loop = m_loop.lock())
+    this->Close();
+  else
+    this->ForceClosed();
+}
+
+std::shared_ptr<AsyncExecutorHandle> AsyncExecutorHandle::Create(
+    const std::shared_ptr<Loop>& loop) {
+  auto h = std::make_shared<AsyncExecutorHandle>(loop, private_init{});
+  int err = uv_async_init(loop->GetRaw(), h->GetRaw(), [](uv_async_t* handle) {
+    auto& h = *static_cast<AsyncExecutorHandle*>(handle->data);
+    std::unique_lock<wpi::mutex> lock(h.m_mutex);
+
+    for (size_t i = 0; i < h.m_queue.size(); ++i) {
+      auto v = h.m_queue[i];
+      lock.unlock();
+      v.func(v.factory, v.req);
+      lock.lock();
+    }
+    h.m_queue.clear();
+  });
+  if (err < 0) {
+    loop->ReportError(err);
+    return nullptr;
+  }
+  h->Keep();
+  return h;
+}
+
+}  // namespace detail
+}  // namespace uv
+}  // namespace wpi

--- a/wpiutil/src/main/native/include/wpi/EventLoopRunner.h
+++ b/wpiutil/src/main/native/include/wpi/EventLoopRunner.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -54,6 +54,12 @@ class EventLoopRunner {
    * @return The loop
    */
   std::shared_ptr<uv::Loop> GetLoop();
+
+  /**
+   * Get an asynchronous executor for use with wpi::async() or
+   * wpi::future::via() to run a continuation on the event loop.
+   */
+  uv::AsyncExecutor GetExecutor();
 
  private:
   class Thread;

--- a/wpiutil/src/main/native/include/wpi/ThreadedExecutorBase.h
+++ b/wpiutil/src/main/native/include/wpi/ThreadedExecutorBase.h
@@ -1,0 +1,245 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#ifndef WPIUTIL_WPI_THREADEDEXECUTORBASE_H_
+#define WPIUTIL_WPI_THREADEDEXECUTORBASE_H_
+
+#include <stdint.h>
+
+#include <functional>
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "wpi/future.h"
+#include "wpi/mutex.h"
+
+namespace wpi {
+
+template <typename Derived, typename Handle>
+class ThreadedExecutorBase;
+
+/**
+ * Executor handle base class to use as a basis for threaded executors.
+ */
+class ThreadedExecutorBaseHandle {
+  template <typename D, typename H>
+  friend class ThreadedExecutorBase;
+
+ protected:
+  // type-erase the PromiseFactory via lambda capture, but put the req in the
+  // vector to reduce the capture size enough to avoid a memory allocation in
+  // std::function
+  struct Entry {
+    template <typename F>
+    Entry(void* factory_, uint64_t req_, F&& func_)
+        : factory(factory_), req(req_), func(std::forward<F>(func_)) {}
+    void* factory;
+    uint64_t req;
+    std::function<void(void*, uint64_t)> func;
+  };
+  std::vector<Entry> m_queue;
+};
+
+/**
+ * Executor base class to use as a basis for threaded executors.
+ * Uses CTRP.
+ * Handle class must define a Signal() function to signal the thread and a
+ * GetThreadId() function to get the thread id (not the current thread id),
+ * and must also provide a mutex named m_mutex.
+ */
+template <typename Derived, typename Handle>
+class ThreadedExecutorBase {
+ public:
+  ThreadedExecutorBase() = default;
+  explicit ThreadedExecutorBase(std::shared_ptr<Handle> handle)
+      : m_handle(std::move(handle)) {}
+
+  template <typename F>
+  void execute(F&& func) const;
+
+  template <typename F,
+            typename R = typename std::result_of_t<std::decay_t<F>()>>
+  future<R> twoway_execute(F&& func) const;
+
+  template <typename R, typename F, typename Future>
+  continuable_future<R, Derived> then_execute(F&& func, Future&& pred) const;
+
+ private:
+  std::shared_ptr<Handle> m_handle;
+};
+
+template <typename Derived, typename Handle>
+template <typename F>
+void ThreadedExecutorBase<Derived, Handle>::execute(F&& func) const {
+  if (!m_handle) return;
+  if (m_handle->GetThreadId() == std::this_thread::get_id()) {
+    // called from within the loop, just call the function directly
+    func();
+    return;
+  }
+
+  // add to the input queue
+  {
+    std::scoped_lock lock(m_handle->m_mutex);
+    m_handle->m_queue.emplace_back(
+        nullptr, 0, [fun = std::forward<F>(func)](void*, uint64_t) { fun(); });
+  }
+
+  m_handle->Signal();
+}
+
+template <typename Derived, typename Handle>
+template <typename F, typename R>
+future<R> ThreadedExecutorBase<Derived, Handle>::twoway_execute(
+    F&& func) const {
+  if (!m_handle) {
+    if constexpr (std::is_void_v<R>) {
+      return make_ready_future();
+    } else {
+      return make_ready_future<R>(R());
+    }
+  }
+  if (m_handle->GetThreadId() == std::this_thread::get_id()) {
+    // called from within the loop, just call the function directly
+    if constexpr (std::is_void_v<R>) {
+      func();
+      return make_ready_future();
+    } else {
+      return make_ready_future(func());
+    }
+  }
+
+  // create the future
+  using Factory = PromiseFactory<R>;
+  auto& factory = Factory::GetInstance();
+  uint64_t req = factory.CreateRequest();
+
+  // add to the input queue
+  {
+    std::scoped_lock lock(m_handle->m_mutex);
+    if constexpr (std::is_void_v<R>) {
+      m_handle->m_queue.emplace_back(&factory, req,
+                                     [func](void* f, uint64_t r) {
+                                       func();
+                                       static_cast<Factory*>(f)->SetValue(r);
+                                     });
+    } else {
+      m_handle->m_queue.emplace_back(
+          &factory, req, [func](void* f, uint64_t r) {
+            static_cast<Factory*>(f)->SetValue(r, func());
+          });
+    }
+  }
+
+  m_handle->Signal();
+
+  // return future
+  return factory.CreateFuture(req);
+}
+
+template <typename Derived, typename Handle>
+template <typename R, typename F, typename Future>
+continuable_future<R, Derived>
+ThreadedExecutorBase<Derived, Handle>::then_execute(F&& func,
+                                                    Future&& pred) const {
+  // create the future
+  auto [predFactory, predRequest] = std::move(pred).ToFactory();
+  using Factory = PromiseFactory<R>;
+  auto& factory = Factory::GetInstance();
+
+  uint64_t req = factory.CreateRequest();
+  if constexpr (std::is_void_v<typename Future::value_type>) {
+    if constexpr (std::is_void_v<R>) {
+      predFactory->SetThen(
+          predRequest, &factory, req, m_handle,
+          [func](void* f, uint64_t r, std::shared_ptr<void> e) {
+            auto handle = static_cast<Handle*>(e.get());
+            if (handle->GetThreadId() == std::this_thread::get_id()) {
+              // called from within the loop, just call the function directly
+              func();
+              static_cast<Factory*>(f)->SetValue(r);
+              return;
+            }
+            // add to the input queue
+            std::scoped_lock lock(handle->m_mutex);
+            handle->m_queue.emplace_back(f, r, [func](void* f2, uint64_t r2) {
+              func();
+              static_cast<Factory*>(f2)->SetValue(r2);
+            });
+            handle->Signal();
+          });
+    } else {
+      predFactory->SetThen(
+          predRequest, &factory, req, m_handle,
+          [func](void* f, uint64_t r, std::shared_ptr<void> e) {
+            auto handle = static_cast<Handle*>(e.get());
+            if (handle->GetThreadId() == std::this_thread::get_id()) {
+              // called from within the loop, just call the function directly
+              static_cast<Factory*>(f)->SetValue(r, func());
+              return;
+            }
+            // add to the input queue
+            std::scoped_lock lock(handle->m_mutex);
+            handle->m_queue.emplace_back(f, r, [func](void* f2, uint64_t r2) {
+              static_cast<Factory*>(f2)->SetValue(r2, func());
+            });
+            handle->Signal();
+          });
+    }
+  } else {
+    if constexpr (std::is_void_v<R>) {
+      predFactory->SetThen(
+          predRequest, &factory, req, m_handle,
+          [func](void* f, uint64_t r, std::shared_ptr<void> e,
+                 typename Future::value_type value) {
+            auto handle = static_cast<Handle*>(e.get());
+            if (handle->GetThreadId() == std::this_thread::get_id()) {
+              // called from within the loop, just call the function directly
+              func(std::move(value));
+              static_cast<Factory*>(f)->SetValue(r);
+              return;
+            }
+            // add to the input queue
+            std::scoped_lock lock(handle->m_mutex);
+            handle->m_queue.emplace_back(
+                f, r, [func, v = std::move(value)](void* f2, uint64_t r2) {
+                  func(std::move(v));
+                  static_cast<Factory*>(f2)->SetValue(r2);
+                });
+            handle->Signal();
+          });
+    } else {
+      predFactory->SetThen(
+          predRequest, &factory, req, m_handle,
+          [func](void* f, uint64_t r, std::shared_ptr<void> e,
+                 typename Future::value_type value) {
+            auto handle = static_cast<Handle*>(e.get());
+            if (handle->GetThreadId() == std::this_thread::get_id()) {
+              // called from within the loop, just call the function directly
+              static_cast<Factory*>(f)->SetValue(r, func(std::move(value)));
+              return;
+            }
+            // add to the input queue
+            std::scoped_lock lock(handle->m_mutex);
+            handle->m_queue.emplace_back(
+                f, r, [func, v = std::move(value)](void* f2, uint64_t r2) {
+                  static_cast<Factory*>(f2)->SetValue(r2, func(std::move(v)));
+                });
+            handle->Signal();
+          });
+    }
+  }
+
+  return factory.CreateContinuableFuture(req,
+                                         *static_cast<const Derived*>(this));
+}
+
+}  // namespace wpi
+
+#endif  // WPIUTIL_WPI_THREADEDEXECUTORBASE_H_

--- a/wpiutil/src/main/native/include/wpi/WorkerThread.h
+++ b/wpiutil/src/main/native/include/wpi/WorkerThread.h
@@ -8,267 +8,55 @@
 #ifndef WPIUTIL_WPI_WORKERTHREAD_H_
 #define WPIUTIL_WPI_WORKERTHREAD_H_
 
-#include <functional>
 #include <memory>
-#include <tuple>
 #include <utility>
-#include <vector>
 
 #include "wpi/SafeThread.h"
-#include "wpi/future.h"
-#include "wpi/uv/Async.h"
+#include "wpi/ThreadedExecutorBase.h"
 
 namespace wpi {
 
+class WorkerThreadExecutor;
+
 namespace detail {
 
-template <typename R>
-struct WorkerThreadAsync {
-  using AfterWorkFunction = std::function<void(R)>;
+class WorkerThreadThread : public SafeThread,
+                           public ThreadedExecutorBaseHandle {
+  friend class ThreadedExecutorBase<WorkerThreadExecutor, WorkerThreadThread>;
 
-  ~WorkerThreadAsync() { UnsetLoop(); }
-
-  void SetLoop(uv::Loop& loop) {
-    auto async = uv::Async<AfterWorkFunction, R>::Create(loop);
-    async->wakeup.connect(
-        [](AfterWorkFunction func, R result) { func(result); });
-    m_async = async;
-  }
-
-  void UnsetLoop() {
-    if (auto async = m_async.lock()) {
-      async->Close();
-      m_async.reset();
-    }
-  }
-
-  std::weak_ptr<uv::Async<AfterWorkFunction, R>> m_async;
-};
-
-template <>
-struct WorkerThreadAsync<void> {
-  using AfterWorkFunction = std::function<void()>;
-
-  ~WorkerThreadAsync() { RemoveLoop(); }
-
-  void SetLoop(uv::Loop& loop) {
-    auto async = uv::Async<AfterWorkFunction>::Create(loop);
-    async->wakeup.connect([](AfterWorkFunction func) { func(); });
-    m_async = async;
-  }
-
-  void RemoveLoop() {
-    if (auto async = m_async.lock()) {
-      async->Close();
-      m_async.reset();
-    }
-  }
-
-  std::weak_ptr<uv::Async<AfterWorkFunction>> m_async;
-};
-
-template <typename R, typename... T>
-struct WorkerThreadRequest {
-  using WorkFunction = std::function<R(T...)>;
-  using AfterWorkFunction = typename WorkerThreadAsync<R>::AfterWorkFunction;
-
-  WorkerThreadRequest() = default;
-  WorkerThreadRequest(uint64_t promiseId_, WorkFunction work_,
-                      std::tuple<T...> params_)
-      : promiseId(promiseId_),
-        work(std::move(work_)),
-        params(std::move(params_)) {}
-  WorkerThreadRequest(WorkFunction work_, AfterWorkFunction afterWork_,
-                      std::tuple<T...> params_)
-      : promiseId(0),
-        work(std::move(work_)),
-        afterWork(std::move(afterWork_)),
-        params(std::move(params_)) {}
-
-  uint64_t promiseId;
-  WorkFunction work;
-  AfterWorkFunction afterWork;
-  std::tuple<T...> params;
-};
-
-template <typename R, typename... T>
-class WorkerThreadThread : public SafeThread {
  public:
-  using Request = WorkerThreadRequest<R, T...>;
-
   void Main() override;
 
-  std::vector<Request> m_requests;
-  PromiseFactory<R> m_promises;
-  detail::WorkerThreadAsync<R> m_async;
+ private:
+  void Signal() { m_cond.notify_one(); }
+  std::thread::id GetThreadId() { return m_threadId; }
 };
-
-template <typename R, typename... T>
-void RunWorkerThreadRequest(WorkerThreadThread<R, T...>& thr,
-                            WorkerThreadRequest<R, T...>& req) {
-  R result = std::apply(req.work, std::move(req.params));
-  if (req.afterWork) {
-    if (auto async = thr.m_async.m_async.lock())
-      async->Send(std::move(req.afterWork), std::move(result));
-  } else {
-    thr.m_promises.SetValue(req.promiseId, std::move(result));
-  }
-}
-
-template <typename... T>
-void RunWorkerThreadRequest(WorkerThreadThread<void, T...>& thr,
-                            WorkerThreadRequest<void, T...>& req) {
-  std::apply(req.work, req.params);
-  if (req.afterWork) {
-    if (auto async = thr.m_async.m_async.lock())
-      async->Send(std::move(req.afterWork));
-  } else {
-    thr.m_promises.SetValue(req.promiseId);
-  }
-}
-
-template <typename R, typename... T>
-void WorkerThreadThread<R, T...>::Main() {
-  std::vector<Request> requests;
-  while (m_active) {
-    std::unique_lock lock(m_mutex);
-    m_cond.wait(lock, [&] { return !m_active || !m_requests.empty(); });
-    if (!m_active) break;
-
-    // don't want to hold the lock while executing the callbacks
-    requests.swap(m_requests);
-    lock.unlock();
-
-    for (auto&& req : requests) {
-      if (!m_active) break;  // requests may be long-running
-      RunWorkerThreadRequest(*this, req);
-    }
-    requests.clear();
-    m_promises.Notify();
-  }
-}
 
 }  // namespace detail
 
-template <typename T>
-class WorkerThread;
-
-template <typename R, typename... T>
-class WorkerThread<R(T...)> final {
-  using Thread = detail::WorkerThreadThread<R, T...>;
-
+class WorkerThread final {
  public:
-  using WorkFunction = std::function<R(T...)>;
-  using AfterWorkFunction =
-      typename detail::WorkerThreadAsync<R>::AfterWorkFunction;
-
   WorkerThread() { m_owner.Start(); }
 
-  /**
-   * Set the loop.  This must be called from the loop thread.
-   * Subsequent calls to QueueWorkThen will run afterWork on the provided
-   * loop (via an async handle).
-   *
-   * @param loop the loop to use for running afterWork routines
-   */
-  void SetLoop(uv::Loop& loop) {
-    if (auto thr = m_owner.GetThread()) thr->m_async.SetLoop(loop);
-  }
-
-  /**
-   * Set the loop.  This must be called from the loop thread.
-   * Subsequent calls to QueueWorkThen will run afterWork on the provided
-   * loop (via an async handle).
-   *
-   * @param loop the loop to use for running afterWork routines
-   */
-  void SetLoop(std::shared_ptr<uv::Loop> loop) { SetLoop(*loop); }
-
-  /**
-   * Unset the loop.  This must be called from the loop thread.
-   * Subsequent calls to QueueWorkThen will no longer run afterWork.
-   */
-  void UnsetLoop() {
-    if (auto thr = m_owner.GetThread()) thr->m_async.UnsetLoop();
-  }
-
-  /**
-   * Get the handle used by QueueWorkThen() to run afterWork.
-   * This handle is set by SetLoop().
-   * Calling Close() on this handle is the same as calling UnsetLoop().
-   *
-   * @return The handle (if nullptr, no handle is set)
-   */
-  std::shared_ptr<uv::Handle> GetHandle() const {
-    if (auto thr = m_owner.GetThread())
-      return thr->m_async.m_async.lock();
-    else
-      return nullptr;
-  }
-
-  /**
-   * Wakeup the worker thread, call the work function, and return a future for
-   * the result.
-   *
-   * It’s safe to call this function from any thread.
-   * The work function will be called on the worker thread.
-   *
-   * The future will return a default-constructed result if this class is
-   * destroyed while waiting for a result.
-   *
-   * @param work Work function (called on worker thread)
-   */
-  template <typename... U>
-  future<R> QueueWork(WorkFunction work, U&&... u) {
-    if (auto thr = m_owner.GetThread()) {
-      // create the future
-      uint64_t req = thr->m_promises.CreateRequest();
-
-      // add the parameters to the input queue
-      thr->m_requests.emplace_back(
-          req, std::move(work), std::forward_as_tuple(std::forward<U>(u)...));
-
-      // signal the thread
-      thr->m_cond.notify_one();
-
-      // return future
-      return thr->m_promises.CreateFuture(req);
-    }
-
-    // XXX: is this the right thing to do?
-    return future<R>();
-  }
-
-  /**
-   * Wakeup the worker thread, call the work function, and call the afterWork
-   * function with the result on the loop set by SetLoop().
-   *
-   * It’s safe to call this function from any thread.
-   * The work function will be called on the worker thread, and the afterWork
-   * function will be called on the loop thread.
-   *
-   * SetLoop() must be called prior to calling this function for afterWork to
-   * be called.
-   *
-   * @param work Work function (called on worker thread)
-   * @param afterWork After work function (called on loop thread)
-   */
-  template <typename... U>
-  void QueueWorkThen(WorkFunction work, AfterWorkFunction afterWork, U&&... u) {
-    if (auto thr = m_owner.GetThread()) {
-      // add the parameters to the input queue
-      thr->m_requests.emplace_back(
-          std::move(work), std::move(afterWork),
-          std::forward_as_tuple(std::forward<U>(u)...));
-
-      // signal the thread
-      thr->m_cond.notify_one();
-    }
-  }
+  WorkerThreadExecutor GetExecutor();
 
  private:
-  SafeThreadOwner<Thread> m_owner;
+  SafeThreadOwner<detail::WorkerThreadThread> m_owner;
 };
+
+class WorkerThreadExecutor final
+    : public ThreadedExecutorBase<WorkerThreadExecutor,
+                                  detail::WorkerThreadThread> {
+ public:
+  WorkerThreadExecutor() = default;
+  explicit WorkerThreadExecutor(
+      std::shared_ptr<detail::WorkerThreadThread> handle)
+      : ThreadedExecutorBase(std::move(handle)) {}
+};
+
+inline WorkerThreadExecutor WorkerThread::GetExecutor() {
+  return WorkerThreadExecutor{m_owner.GetThreadSharedPtr()};
+}
 
 }  // namespace wpi
 

--- a/wpiutil/src/main/native/include/wpi/future.h
+++ b/wpiutil/src/main/native/include/wpi/future.h
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -26,13 +27,13 @@ namespace wpi {
 template <typename T>
 class PromiseFactory;
 
+template <typename T, class E>
+class continuable_future;
 template <typename T>
 class future;
 
 template <typename T>
 class promise;
-template <>
-class promise<void>;
 
 namespace detail {
 
@@ -78,35 +79,56 @@ class PromiseFactoryBase {
   std::vector<uint64_t> m_requests;
 };
 
-template <typename To, typename From>
-struct FutureThen {
-  template <typename F>
-  static future<To> Create(PromiseFactory<From>& fromFactory, uint64_t request,
-                           PromiseFactory<To>& factory, F&& func);
+/**
+ * If U is std::future<T>, provides the member constant value equal to true.
+ * Otherwise value is false.
+ */
+template <typename U>
+struct is_future : std::false_type {};
+template <typename T>
+struct is_future<future<T>> : std::true_type {};
+
+/**
+ * Helper variable template for is_future<U>.
+ */
+template <typename U>
+inline constexpr bool is_future_v = is_future<U>::value;
+
+/**
+ * If U is a continuable_future<T, E>, provides T as the member type.
+ * Otherwise provides U as the member type.
+ */
+template <typename U>
+struct cont_future_unwrap {
+  using type = U;
+};
+template <typename T, typename E>
+struct cont_future_unwrap<continuable_future<T, E>> {
+  using type = T;
 };
 
-template <typename From>
-struct FutureThen<void, From> {
-  template <typename F>
-  static future<void> Create(PromiseFactory<From>& fromFactory,
-                             uint64_t request, PromiseFactory<void>& factory,
-                             F&& func);
+/**
+ * Helper type template for cont_future_unwrap<U>.
+ */
+template <typename U>
+using cont_future_unwrap_t = typename cont_future_unwrap<U>::type;
+
+/**
+ * If U is a future<T>, provides T as the member type.
+ * Otherwise the member type is not defined.
+ */
+template <typename U>
+struct future_unwrap {};
+template <typename T>
+struct future_unwrap<future<T>> {
+  using type = T;
 };
 
-template <typename To>
-struct FutureThen<To, void> {
-  template <typename F>
-  static future<To> Create(PromiseFactory<void>& fromFactory, uint64_t request,
-                           PromiseFactory<To>& factory, F&& func);
-};
-
-template <>
-struct FutureThen<void, void> {
-  template <typename F>
-  static future<void> Create(PromiseFactory<void>& fromFactory,
-                             uint64_t request, PromiseFactory<void>& factory,
-                             F&& func);
-};
+/**
+ * Helper type template for future_unwrap<U>.
+ */
+template <typename U>
+using future_unwrap_t = typename future_unwrap<U>::type;
 
 }  // namespace detail
 
@@ -128,7 +150,8 @@ class PromiseFactory final : public detail::PromiseFactoryBase {
 
  public:
   using detail::PromiseFactoryBase::Notify;
-  using ThenFunction = std::function<void(uint64_t, T)>;
+  using ThenFunction =
+      std::function<void(void*, uint64_t, std::shared_ptr<void>, T)>;
 
   /**
    * Creates a future.
@@ -137,6 +160,17 @@ class PromiseFactory final : public detail::PromiseFactoryBase {
    * @return the future
    */
   future<T> CreateFuture(uint64_t request);
+
+  /**
+   * Creates a continuable_future.
+   *
+   * @param request the request id returned by CreateRequest()
+   * @param exe the executor
+   * @return the future
+   */
+  template <typename E>
+  continuable_future<T, E> CreateContinuableFuture(uint64_t request,
+                                                   const E& exe);
 
   /**
    * Creates a future and makes it immediately ready.
@@ -171,7 +205,8 @@ class PromiseFactory final : public detail::PromiseFactoryBase {
    */
   void SetValue(uint64_t request, T&& value);
 
-  void SetThen(uint64_t request, uint64_t outRequest, ThenFunction func);
+  void SetThen(uint64_t request, void* outFactory, uint64_t outRequest,
+               std::shared_ptr<void> executor, ThenFunction func);
 
   bool IsReady(uint64_t request) noexcept;
   T GetResult(uint64_t request);
@@ -185,10 +220,18 @@ class PromiseFactory final : public detail::PromiseFactoryBase {
 
  private:
   struct Then {
-    Then(uint64_t request_, uint64_t outRequest_, ThenFunction func_)
-        : request(request_), outRequest(outRequest_), func(std::move(func_)) {}
+    template <typename F>
+    Then(uint64_t request_, void* outFactory_, uint64_t outRequest_,
+         std::shared_ptr<void> executor_, F&& func_)
+        : request(request_),
+          outRequest(outRequest_),
+          outFactory(outFactory_),
+          executor(std::move(executor_)),
+          func(std::forward<F>(func_)) {}
     uint64_t request;
     uint64_t outRequest;
+    void* outFactory;
+    std::shared_ptr<void> executor;
     ThenFunction func;
   };
 
@@ -205,7 +248,8 @@ class PromiseFactory<void> final : public detail::PromiseFactoryBase {
 
  public:
   using detail::PromiseFactoryBase::Notify;
-  using ThenFunction = std::function<void(uint64_t)>;
+  using ThenFunction =
+      std::function<void(void*, uint64_t, std::shared_ptr<void>)>;
 
   /**
    * Creates a future.
@@ -214,6 +258,17 @@ class PromiseFactory<void> final : public detail::PromiseFactoryBase {
    * @return std::pair of the future and the request id
    */
   future<void> CreateFuture(uint64_t request);
+
+  /**
+   * Creates a continuable_future.
+   *
+   * @param request the request id returned by CreateRequest()
+   * @param exe the executor
+   * @return the future
+   */
+  template <typename E>
+  continuable_future<void, E> CreateContinuableFuture(uint64_t request,
+                                                      const E& exe);
 
   /**
    * Creates a future and makes it immediately ready.
@@ -238,7 +293,8 @@ class PromiseFactory<void> final : public detail::PromiseFactoryBase {
    */
   void SetValue(uint64_t request);
 
-  void SetThen(uint64_t request, uint64_t outRequest, ThenFunction func);
+  void SetThen(uint64_t request, void* outFactory, uint64_t outRequest,
+               std::shared_ptr<void> executor, ThenFunction func);
 
   bool IsReady(uint64_t request) noexcept;
   void GetResult(uint64_t request);
@@ -252,10 +308,18 @@ class PromiseFactory<void> final : public detail::PromiseFactoryBase {
 
  private:
   struct Then {
-    Then(uint64_t request_, uint64_t outRequest_, ThenFunction func_)
-        : request(request_), outRequest(outRequest_), func(std::move(func_)) {}
+    template <typename F>
+    Then(uint64_t request_, void* outFactory_, uint64_t outRequest_,
+         std::shared_ptr<void> executor_, F&& func_)
+        : request(request_),
+          outRequest(outRequest_),
+          outFactory(outFactory_),
+          executor(std::move(executor_)),
+          func(std::forward<F>(func_)) {}
     uint64_t request;
     uint64_t outRequest;
+    void* outFactory;
+    std::shared_ptr<void> executor;
     ThenFunction func;
   };
 
@@ -264,18 +328,21 @@ class PromiseFactory<void> final : public detail::PromiseFactoryBase {
 };
 
 /**
- * A lightweight version of std::future.
+ * A lightweight variant of std::execution::semi_future.
+ * This can be used directly or bound to an executor using the via() function
+ * to produce a continuable_future.
  *
- * Use either promise::get_future() or PromiseFactory::CreateFuture() to create.
+ * Use make_promise_contract() or PromiseFactory::CreateFuture() to create.
  *
  * @tparam T the "return" type
  */
 template <typename T>
 class future final {
   friend class PromiseFactory<T>;
-  friend class promise<T>;
 
  public:
+  using value_type = T;
+
   /**
    * Constructs an empty (invalid) future.
    */
@@ -289,9 +356,31 @@ class future final {
   }
   future(const future&) = delete;
 
-  template <typename R>
-  future(future<R>&& oth) noexcept
-      : future(oth.then([](R&& val) -> T { return val; })) {}
+  /**
+   * Conversion constructor from continuable_future<T, E> when T is the same
+   * type as this class' T.
+   */
+  template <typename E>
+  future(continuable_future<T, E>&& oth) noexcept {  // NOLINT: runtime/explicit
+    std::tie(m_promises, m_request) = std::move(oth).ToFactory();
+  }
+
+  /**
+   * Conversion constructor from continuable_future<T, E> when T is a different
+   * type than this class' T.
+   */
+  template <typename R, typename E,
+            typename = std::enable_if_t<!std::is_same<T, R>::value>>
+  future(continuable_future<R, E>&& oth) {  // NOLINT: runtime/explicit
+    std::tie(m_promises, m_request) =
+        std::move(oth).then([](R&& val) -> T { return val; }).ToFactory();
+  }
+
+  /**
+   * Unwrapping constructor from continuable_future<future<T>, E>.
+   */
+  template <typename E>
+  future(continuable_future<future<T>, E>&& oth);  // NOLINT: runtime/explicit
 
   /**
    * Ignores the result of the future if it has not been retrieved.
@@ -310,35 +399,11 @@ class future final {
   future& operator=(const future&) = delete;
 
   /**
-   * Gets the value.  Calls wait() if the value is not yet available.
-   * Can only be called once.  The future will be marked invalid after the call.
+   * Checks if the future is ready.
    *
-   * @return The value provided by the corresponding promise.set_value().
+   * @return True if get() will return a value immediately, false if it will
+   * block.
    */
-  T get() {
-    if (m_promises)
-      return m_promises->GetResult(m_request);
-    else
-      return T();
-  }
-
-  template <typename R, typename F>
-  future<R> then(PromiseFactory<R>& factory, F&& func) {
-    if (m_promises) {
-      auto promises = m_promises;
-      m_promises = nullptr;
-      return detail::FutureThen<R, T>::Create(*promises, m_request, factory,
-                                              func);
-    } else {
-      return future<R>();
-    }
-  }
-
-  template <typename F, typename R = typename std::result_of<F && (T &&)>::type>
-  future<R> then(F&& func) {
-    return then(PromiseFactory<R>::GetInstance(), std::forward<F>(func));
-  }
-
   bool is_ready() const noexcept {
     return m_promises && m_promises->IsReady(m_request);
   }
@@ -352,37 +417,30 @@ class future final {
   bool valid() const noexcept { return m_promises; }
 
   /**
-   * Waits for the promise to provide a value.
-   * Does not return until the value is available or the promise is destroyed
-   * (in which case a default-constructed value is "returned").
-   * If the value has already been provided, returns immediately.
+   * Bind to an executor to make a continuable_future.
    */
-  void wait() const {
-    if (m_promises) m_promises->WaitResult(m_request);
+  template <class E>
+  continuable_future<T, E> via(E exe) && {
+    if (!m_promises) return continuable_future<T, E>{};
+    auto rv = m_promises->CreateContinuableFuture(m_request, exe);
+    m_promises = nullptr;
+    m_request = 0;
+    return rv;
   }
 
   /**
-   * Waits for the promise to provide a value, or the specified time has been
-   * reached.
-   *
-   * @return True if the promise provided a value, false if timed out.
+   * Get the PromiseFactory and request ID for this future.
+   * This is a move operation (the future is left in an invalid state).
    */
-  template <class Clock, class Duration>
-  bool wait_until(
-      const std::chrono::time_point<Clock, Duration>& timeout_time) const {
-    return m_promises && m_promises->WaitResultUntil(m_request, timeout_time);
+  std::pair<PromiseFactory<T>*, uint64_t> ToFactory() && noexcept {
+    auto rv = GetFactory();
+    m_promises = nullptr;
+    m_request = 0;
+    return rv;
   }
 
-  /**
-   * Waits for the promise to provide a value, or the specified amount of time
-   * has elapsed.
-   *
-   * @return True if the promise provided a value, false if timed out.
-   */
-  template <class Rep, class Period>
-  bool wait_for(
-      const std::chrono::duration<Rep, Period>& timeout_duration) const {
-    return wait_until(std::chrono::steady_clock::now() + timeout_duration);
+  std::pair<PromiseFactory<T>*, uint64_t> GetFactory() const noexcept {
+    return std::make_pair(m_promises, m_request);
   }
 
  private:
@@ -394,68 +452,88 @@ class future final {
 };
 
 /**
- * Explicit specialization for future<void>.
+ * A lightweight variant of std::execution::continuable_future.
+ * This is a future that is bound to an executor and can have continuations
+ * attached to it.
+ *
+ * Use make_promise_contract(Executor) or
+ * PromiseFactory::CreateContinuableFuture() to create.
+ *
+ * @tparam T the "return" type
  */
-template <>
-class future<void> final {
-  friend class PromiseFactory<void>;
-  friend class promise<void>;
+template <typename T, typename E>
+class continuable_future final {
+  friend class PromiseFactory<T>;
+  friend class future<T>;
+  template <typename T2, typename E2>
+  friend class continuable_future;
 
  public:
+  using value_type = T;
+  using executor_type = E;
+  using future_type = future<T>;
+
   /**
    * Constructs an empty (invalid) future.
    */
-  future() noexcept = default;
+  continuable_future() noexcept = default;
 
-  future(future&& oth) noexcept {
-    m_request = oth.m_request;
-    m_promises = oth.m_promises;
+  continuable_future(continuable_future&& oth) noexcept {
+    this->m_request = oth.m_request;
+    this->m_promises = oth.m_promises;
+    this->m_executor = oth.m_executor;
     oth.m_request = 0;
     oth.m_promises = nullptr;
   }
-  future(const future&) = delete;
+  continuable_future(const continuable_future&) = delete;
+
+  /**
+   * Conversion constructor from continuable_future<T, E>; both T and E can
+   * be different types than this class' T and E.
+   */
+  template <typename R, typename EI,
+            typename = std::enable_if_t<!std::is_same<T, R>::value>>
+  continuable_future(continuable_future<R, EI>&& oth)
+      : continuable_future(
+            std::move(oth).then([](R&& val) -> T { return val; })) {}
+
+  /**
+   * Unwrapping constructor from continuable_future<continuable_future<T, E2>,
+   * E>.
+   */
+  template <typename E2>
+  continuable_future(continuable_future<continuable_future<T, E2>, E>&&
+                         oth);  // NOLINT: runtime/explicit
+
+  continuable_future(PromiseFactory<T>* promises, uint64_t request,
+                     E executor) noexcept
+      : m_request(request),
+        m_promises(promises),
+        m_executor(std::move(executor)) {}
 
   /**
    * Ignores the result of the future if it has not been retrieved.
    */
-  ~future() {
+  ~continuable_future() {
     if (m_promises) m_promises->IgnoreResult(m_request);
   }
 
-  future& operator=(future&& oth) noexcept {
-    m_request = oth.m_request;
-    m_promises = oth.m_promises;
+  continuable_future& operator=(continuable_future&& oth) noexcept {
+    this->m_request = oth.m_request;
+    this->m_promises = oth.m_promises;
+    this->m_executor = oth.m_executor;
     oth.m_request = 0;
     oth.m_promises = nullptr;
     return *this;
   }
-  future& operator=(const future&) = delete;
+  continuable_future& operator=(const continuable_future&) = delete;
 
   /**
-   * Gets the value.  Calls wait() if the value is not yet available.
-   * Can only be called once.  The future will be marked invalid after the call.
+   * Checks if the future is ready.
+   *
+   * @return True if get() will return a value immediately, false if it will
+   * block.
    */
-  void get() {
-    if (m_promises) m_promises->GetResult(m_request);
-  }
-
-  template <typename R, typename F>
-  future<R> then(PromiseFactory<R>& factory, F&& func) {
-    if (m_promises) {
-      auto promises = m_promises;
-      m_promises = nullptr;
-      return detail::FutureThen<R, void>::Create(*promises, m_request, factory,
-                                                 func);
-    } else {
-      return future<R>();
-    }
-  }
-
-  template <typename F, typename R = typename std::result_of<F && ()>::type>
-  future<R> then(F&& func) {
-    return then(PromiseFactory<R>::GetInstance(), std::forward<F>(func));
-  }
-
   bool is_ready() const noexcept {
     return m_promises && m_promises->IsReady(m_request);
   }
@@ -469,50 +547,251 @@ class future<void> final {
   bool valid() const noexcept { return m_promises; }
 
   /**
-   * Waits for the promise to provide a value.
-   * Does not return until the value is available or the promise is destroyed
-   * If the value has already been provided, returns immediately.
+   * Link a continuation functor to this future.  The functor will get executed
+   * with the result of this future when it is made ready.  A continuable_future
+   * is returned that represents the future value of the return value of the
+   * functor.  The returned continuable_future is bound to the same executor as
+   * this continuable_future.
+   *
+   * Automatic unwrapping is performed if the functor returns a wpi::future or
+   * wpi::continuable_future.  This variant of the function handles normal and
+   * wpi::continuable_future functor return values.
    */
-  void wait() const {
-    if (m_promises) m_promises->WaitResult(m_request);
+  template <typename F,
+            std::enable_if_t<
+                !detail::is_future_v<std::result_of_t<std::decay_t<F>(T&&)>>,
+                int> = 0>
+  continuable_future<
+      detail::cont_future_unwrap_t<std::result_of_t<std::decay_t<F>(T&&)>>, E>
+  then(F&& func) && {
+    return m_executor
+        .template then_execute<std::result_of_t<std::decay_t<F>(T &&)>>(
+            func, std::move(*this));
   }
 
   /**
-   * Waits for the promise to provide a value, or the specified time has been
-   * reached.
-   *
-   * @return True if the promise provided a value, false if timed out.
+   * This variant of then() handles wpi::future functor return values.
    */
-  template <class Clock, class Duration>
-  bool wait_until(
-      const std::chrono::time_point<Clock, Duration>& timeout_time) const {
-    return m_promises && m_promises->WaitResultUntil(m_request, timeout_time);
+  template <typename F>
+  continuable_future<
+      detail::future_unwrap_t<std::result_of_t<std::decay_t<F>(T&&)>>, E>
+  then(F&& func) && {
+    return future<detail::future_unwrap_t<
+        std::result_of_t<std::decay_t<F>(T &&)>>>(
+               m_executor.template then_execute<
+                   std::result_of_t<std::decay_t<F>(T &&)>>(func,
+                                                            std::move(*this)))
+        .via(m_executor);
   }
 
   /**
-   * Waits for the promise to provide a value, or the specified amount of time
-   * has elapsed.
-   *
-   * @return True if the promise provided a value, false if timed out.
+   * Bind to a different executor.
    */
-  template <class Rep, class Period>
-  bool wait_for(
-      const std::chrono::duration<Rep, Period>& timeout_duration) const {
-    return wait_until(std::chrono::steady_clock::now() + timeout_duration);
+  template <typename EI>
+  continuable_future<T, EI> via(EI exe) && {
+    auto h = std::move(*this).ToFactory();
+    return continuable_future<T, EI>(h.first, h.second, exe);
+  }
+
+  /**
+   * Get the executor bound to this future.
+   */
+  E get_executor() const noexcept { return m_executor; }
+
+  /**
+   * Get the unbound future for this future.
+   */
+  future<T> semi() && noexcept { return future<T>(std::move(*this)); }
+
+  /**
+   * Get the PromiseFactory and request ID for this future.
+   * This is a move operation (the future is left in an invalid state).
+   */
+  std::pair<PromiseFactory<T>*, uint64_t> ToFactory() && noexcept {
+    auto rv = GetFactory();
+    m_promises = nullptr;
+    m_request = 0;
+    return rv;
+  }
+
+  std::pair<PromiseFactory<T>*, uint64_t> GetFactory() const noexcept {
+    return std::make_pair(m_promises, m_request);
   }
 
  private:
-  future(PromiseFactory<void>* promises, uint64_t request) noexcept
-      : m_request(request), m_promises(promises) {}
-
   uint64_t m_request = 0;
-  PromiseFactory<void>* m_promises = nullptr;
+  PromiseFactory<T>* m_promises = nullptr;
+  E m_executor;
 };
 
 /**
- * A lightweight version of std::promise.
+ * Explicit specialization for continuable_future<void, E>.
+ */
+template <typename E>
+class continuable_future<void, E> final {
+  friend class PromiseFactory<void>;
+  friend class future<void>;
+  template <typename T2, typename E2>
+  friend class continuable_future;
+
+ public:
+  using value_type = void;
+  using executor_type = E;
+  using future_type = future<void>;
+
+  /**
+   * Constructs an empty (invalid) future.
+   */
+  continuable_future() noexcept = default;
+
+  continuable_future(continuable_future&& oth) noexcept {
+    this->m_request = oth.m_request;
+    this->m_promises = oth.m_promises;
+    this->m_executor = oth.m_executor;
+    oth.m_request = 0;
+    oth.m_promises = nullptr;
+  }
+  continuable_future(const continuable_future&) = delete;
+
+  /**
+   * Conversion constructor from continuable_future<T, E>; both T and E can
+   * be different types than this class' T and E.
+   */
+  template <typename R, typename EI,
+            typename = std::enable_if_t<!std::is_void_v<R>>>
+  continuable_future(continuable_future<R, EI>&& oth)
+      : continuable_future(std::move(oth).then([](R&& val) {})) {}
+
+  /**
+   * Unwrapping constructor from continuable_future<continuable_future<T, E2>,
+   * E>.
+   */
+  template <typename E2>
+  continuable_future(continuable_future<continuable_future<void, E2>, E>&&
+                         oth);  // NOLINT: runtime/explicit
+
+  /**
+   * Ignores the result of the future if it has not been retrieved.
+   */
+  ~continuable_future() {
+    if (m_promises) m_promises->IgnoreResult(m_request);
+  }
+
+  continuable_future& operator=(continuable_future&& oth) noexcept {
+    this->m_request = oth.m_request;
+    this->m_promises = oth.m_promises;
+    this->m_executor = oth.m_executor;
+    oth.m_request = 0;
+    oth.m_promises = nullptr;
+    return *this;
+  }
+  continuable_future& operator=(const continuable_future&) = delete;
+
+  /**
+   * Checks if the future is ready.
+   *
+   * @return True if get() will return a value immediately, false if it will
+   * block.
+   */
+  bool is_ready() const noexcept {
+    return m_promises && m_promises->IsReady(m_request);
+  }
+
+  /**
+   * Checks if the future is valid.
+   * A default-constructed future or one where get() has been called is invalid.
+   *
+   * @return True if valid
+   */
+  bool valid() const noexcept { return m_promises; }
+
+  /**
+   * Link a continuation functor to this future.  The functor will get executed
+   * with the result of this future when it is made ready.  A continuable_future
+   * is returned that represents the future value of the return value of the
+   * functor.  The returned continuable_future is bound to the same executor as
+   * this continuable_future.
+   *
+   * Automatic unwrapping is performed if the functor returns a wpi::future or
+   * wpi::continuable_future.  This variant of the function handles normal and
+   * wpi::continuable_future functor return values.
+   */
+  template <
+      typename F,
+      std::enable_if_t<
+          !detail::is_future_v<std::result_of_t<std::decay_t<F>()>>, int> = 0>
+  continuable_future<
+      detail::cont_future_unwrap_t<std::result_of_t<std::decay_t<F>()>>, E>
+  then(F&& func) && {
+    return m_executor
+        .template then_execute<std::result_of_t<std::decay_t<F>()>>(
+            func, std::move(*this));
+  }
+
+  /**
+   * This variant of then() handles wpi::future functor return values.
+   */
+  template <typename F>
+  continuable_future<
+      detail::future_unwrap_t<std::result_of_t<std::decay_t<F>()>>, E>
+  then(F&& func) && {
+    return future<detail::future_unwrap_t<std::result_of_t<std::decay_t<F>()>>>(
+               m_executor
+                   .template then_execute<std::result_of_t<std::decay_t<F>()>>(
+                       func, std::move(*this)))
+        .via(m_executor);
+  }
+
+  /**
+   * Bind to a different executor.
+   */
+  template <typename EI>
+  continuable_future<void, EI> via(EI exe) && {
+    auto h = std::move(*this).ToFactory();
+    return continuable_future<void, EI>(h.first, h.second, exe);
+  }
+
+  /**
+   * Get the executor bound to this future.
+   */
+  E get_executor() const noexcept { return m_executor; }
+
+  /**
+   * Get the unbound future for this future.
+   */
+  future<void> semi() && noexcept { return future<void>(std::move(*this)); }
+
+  /**
+   * Get the PromiseFactory and request ID for this future.
+   * This is a move operation (the future is left in an invalid state).
+   */
+  std::pair<PromiseFactory<void>*, uint64_t> ToFactory() && noexcept {
+    auto rv = GetFactory();
+    m_promises = nullptr;
+    m_request = 0;
+    return rv;
+  }
+
+  std::pair<PromiseFactory<void>*, uint64_t> GetFactory() const noexcept {
+    return std::make_pair(m_promises, m_request);
+  }
+
+ private:
+  continuable_future(PromiseFactory<void>* promises, uint64_t request,
+                     E executor) noexcept
+      : m_request(request),
+        m_promises(promises),
+        m_executor(std::move(executor)) {}
+
+  uint64_t m_request = 0;
+  PromiseFactory<void>* m_promises = nullptr;
+  E m_executor;
+};
+
+/**
+ * A lightweight variant of std::execution::promise.
  *
- * Use PromiseFactory::CreatePromise() to create.
+ * Use make_promise_contract() or PromiseFactory::CreatePromise() to create.
  *
  * @tparam T the "return" type
  */
@@ -524,9 +803,7 @@ class promise final {
   /**
    * Constructs an empty promise.
    */
-  promise() : m_promises(&PromiseFactory<T>::GetInstance()) {
-    m_request = m_promises->CreateRequest();
-  }
+  promise() noexcept = default;
 
   promise(promise&& oth) noexcept
       : m_request(oth.m_request), m_promises(oth.m_promises) {
@@ -562,19 +839,12 @@ class promise final {
   }
 
   /**
-   * Gets a future for this promise.
-   *
-   * @return The future
-   */
-  future<T> get_future() noexcept { return future<T>(m_promises, m_request); }
-
-  /**
    * Sets the promised value.
    * Only effective once (subsequent calls will be ignored).
    *
    * @param value The value to provide to the waiting future
    */
-  void set_value(const T& value) {
+  void set_value(const T& value) && {
     if (m_promises) m_promises->SetValue(m_request, value);
     m_promises = nullptr;
   }
@@ -585,10 +855,14 @@ class promise final {
    *
    * @param value The value to provide to the waiting future
    */
-  void set_value(T&& value) {
+  void set_value(T&& value) && {
     if (m_promises) m_promises->SetValue(m_request, std::move(value));
     m_promises = nullptr;
   }
+
+  bool valid() const noexcept { return m_promises != nullptr; }
+
+  explicit operator bool() const noexcept { return valid(); }
 
  private:
   promise(PromiseFactory<T>* promises, uint64_t request) noexcept
@@ -609,9 +883,7 @@ class promise<void> final {
   /**
    * Constructs an empty promise.
    */
-  promise() : m_promises(&PromiseFactory<void>::GetInstance()) {
-    m_request = m_promises->CreateRequest();
-  }
+  promise() noexcept = default;
 
   promise(promise&& oth) noexcept
       : m_request(oth.m_request), m_promises(oth.m_promises) {
@@ -647,22 +919,17 @@ class promise<void> final {
   }
 
   /**
-   * Gets a future for this promise.
-   *
-   * @return The future
-   */
-  future<void> get_future() noexcept {
-    return future<void>(m_promises, m_request);
-  }
-
-  /**
    * Sets the promised value.
    * Only effective once (subsequent calls will be ignored).
    */
-  void set_value() {
+  void set_value() && {
     if (m_promises) m_promises->SetValue(m_request);
     m_promises = nullptr;
   }
+
+  bool valid() const noexcept { return m_promises != nullptr; }
+
+  explicit operator bool() const noexcept { return valid(); }
 
  private:
   promise(PromiseFactory<void>* promises, uint64_t request) noexcept
@@ -670,6 +937,40 @@ class promise<void> final {
 
   uint64_t m_request = 0;
   PromiseFactory<void>* m_promises = nullptr;
+};
+
+/**
+ * An executor that supports inline (e.g. in the same thread) execution of
+ * futures/promises.
+ */
+class inline_executor final {
+ public:
+  /**
+   * One-way execution: calls the function.
+   */
+  template <typename F>
+  void execute(F&& func) const {
+    func();
+  }
+
+  /**
+   * Two-way execution: returns a future for the result of the function.  For
+   * this executor, the function is called immediately and the returned future
+   * is immediately ready.
+   */
+  template <typename F,
+            typename R = typename std::result_of_t<std::decay_t<F>()>>
+  future<R> twoway_execute(F&& func) const;
+
+  /**
+   * Continuation (then) execution: returns a future for the result of the
+   * function; the function is called after the passed predicate future is made
+   * ready.  For this executor, the function is called in the same thread as the
+   * predicate future.
+   */
+  template <typename R, typename F, typename Future>
+  continuable_future<R, inline_executor> then_execute(F&& func,
+                                                      Future&& pred) const;
 };
 
 /**
@@ -688,220 +989,117 @@ inline future<void> make_ready_future() {
   return PromiseFactory<void>::GetInstance().MakeReadyFuture();
 }
 
+/**
+ * Constructs a promise/future pair.
+ */
 template <typename T>
-inline future<T> PromiseFactory<T>::CreateFuture(uint64_t request) {
-  return future<T>{this, request};
+inline std::pair<promise<T>, future<T>> make_promise_contract() {
+  auto& factory = PromiseFactory<T>::GetInstance();
+  uint64_t request = factory.CreateRequest();
+  return std::pair(factory.CreatePromise(request),
+                   factory.CreateFuture(request));
 }
 
-template <typename T>
-future<T> PromiseFactory<T>::MakeReadyFuture(T&& value) {
-  std::unique_lock lock(GetResultMutex());
-  uint64_t req = CreateErasedRequest();
-  m_results.emplace_back(std::piecewise_construct, std::forward_as_tuple(req),
-                         std::forward_as_tuple(std::move(value)));
-  return future<T>{this, req};
+/**
+ * Constructs a promise/continuable_future pair from an executor.
+ */
+template <typename T, typename Executor>
+inline std::pair<promise<T>, continuable_future<T, std::decay_t<Executor>>>
+make_promise_contract(const Executor& exe) {
+  auto& factory = PromiseFactory<T>::GetInstance();
+  uint64_t request = factory.CreateRequest();
+  return std::pair(factory.CreatePromise(request),
+                   factory.CreateContinuableFuture(request, exe));
 }
 
-template <typename T>
-inline promise<T> PromiseFactory<T>::CreatePromise(uint64_t request) {
-  return promise<T>{this, request};
+/**
+ * Gets the value of a future.  Calls future_wait() if the value is not yet
+ * available. Can only be called once.  The future will be marked invalid after
+ * the call.
+ *
+ * @return The value provided by the corresponding promise.set_value().
+ */
+template <typename Future>
+inline typename Future::value_type future_get(Future&& f) {
+  auto h = std::move(f).ToFactory();
+  if (h.first)
+    return h.first->GetResult(h.second);
+  else
+    return typename Future::value_type();
 }
 
-template <typename T>
-void PromiseFactory<T>::SetValue(uint64_t request, const T& value) {
-  std::unique_lock lock(GetResultMutex());
-  if (!EraseRequest(request)) return;
-  auto it = std::find_if(m_thens.begin(), m_thens.end(),
-                         [=](const auto& x) { return x.request == request; });
-  if (it != m_thens.end()) {
-    uint64_t outRequest = it->outRequest;
-    ThenFunction func = std::move(it->func);
-    m_thens.erase(it);
-    lock.unlock();
-    return func(outRequest, value);
-  }
-  m_results.emplace_back(std::piecewise_construct,
-                         std::forward_as_tuple(request),
-                         std::forward_as_tuple(value));
-  Notify();
+template <typename Future, std::enable_if_t<Future::value_type, void> = 0>
+inline void future_get(Future&& f) {
+  auto h = std::move(f).ToFactory();
+  if (h.first) h.first->GetResult(h.second);
 }
 
-template <typename T>
-void PromiseFactory<T>::SetValue(uint64_t request, T&& value) {
-  std::unique_lock lock(GetResultMutex());
-  if (!EraseRequest(request)) return;
-  auto it = std::find_if(m_thens.begin(), m_thens.end(),
-                         [=](const auto& x) { return x.request == request; });
-  if (it != m_thens.end()) {
-    uint64_t outRequest = it->outRequest;
-    ThenFunction func = std::move(it->func);
-    m_thens.erase(it);
-    lock.unlock();
-    return func(outRequest, std::move(value));
-  }
-  m_results.emplace_back(std::piecewise_construct,
-                         std::forward_as_tuple(request),
-                         std::forward_as_tuple(std::move(value)));
-  Notify();
+/**
+ * Waits for the promise to provide a value.
+ * Does not return until the value is available or the promise is destroyed
+ * (in which case a default-constructed value is "returned").
+ * If the value has already been provided, returns immediately.
+ */
+template <typename Future>
+inline void future_wait(Future& f) {
+  auto h = f.GetFactory();
+  if (h.first) h.first->WaitResult(h.second);
 }
 
-template <typename T>
-void PromiseFactory<T>::SetThen(uint64_t request, uint64_t outRequest,
-                                ThenFunction func) {
-  std::unique_lock lock(GetResultMutex());
-  auto it = std::find_if(m_results.begin(), m_results.end(),
-                         [=](const auto& r) { return r.first == request; });
-  if (it != m_results.end()) {
-    auto val = std::move(it->second);
-    m_results.erase(it);
-    lock.unlock();
-    return func(outRequest, std::move(val));
-  }
-  m_thens.emplace_back(request, outRequest, func);
+/**
+ * Waits for the promise to provide a value, or the specified time has been
+ * reached.
+ *
+ * @return True if the promise provided a value, false if timed out.
+ */
+template <typename Future, class Clock, class Duration>
+inline bool future_wait_until(
+    Future& f, const std::chrono::time_point<Clock, Duration>& timeout_time) {
+  auto h = f.GetFactory();
+  return h.first && h.first->WaitResultUntil(h.second, timeout_time);
 }
 
-template <typename T>
-bool PromiseFactory<T>::IsReady(uint64_t request) noexcept {
-  std::unique_lock lock(GetResultMutex());
-  auto it = std::find_if(m_results.begin(), m_results.end(),
-                         [=](const auto& r) { return r.first == request; });
-  return it != m_results.end();
+/**
+ * Waits for the promise to provide a value, or the specified amount of time
+ * has elapsed.
+ *
+ * @return True if the promise provided a value, false if timed out.
+ */
+template <typename Future, class Rep, class Period>
+inline bool future_wait_for(
+    Future& f, const std::chrono::duration<Rep, Period>& timeout_duration) {
+  return future_wait_until(f,
+                           std::chrono::steady_clock::now() + timeout_duration);
 }
 
-template <typename T>
-T PromiseFactory<T>::GetResult(uint64_t request) {
-  // wait for response
-  std::unique_lock lock(GetResultMutex());
-  while (IsActive()) {
-    // Did we get a response to *our* request?
-    auto it = std::find_if(m_results.begin(), m_results.end(),
-                           [=](const auto& r) { return r.first == request; });
-    if (it != m_results.end()) {
-      // Yes, remove it from the vector and we're done.
-      auto rv = std::move(it->second);
-      m_results.erase(it);
-      return rv;
-    }
-    // No, keep waiting for a response
-    Wait(lock);
-  }
-  return T();
+/**
+ * Execute a function asynchronously on an executor, returning a std::future
+ * for the return value of the function.
+ *
+ * Automatic unwrapping is performed if the functor returns a wpi::future or
+ * wpi::continuable_future.  This variant of the function handles normal and
+ * wpi::continuable_future functor return values.
+ */
+template <
+    typename Executor, typename F,
+    std::enable_if_t<!detail::is_future_v<std::result_of_t<std::decay_t<F>()>>,
+                     int> = 0>
+inline future<std::result_of_t<std::decay_t<F>()>> async(const Executor& exe,
+                                                         F&& func) {
+  return exe.twoway_execute(std::forward<F>(func));
 }
 
-template <typename T>
-void PromiseFactory<T>::WaitResult(uint64_t request) {
-  // wait for response
-  std::unique_lock lock(GetResultMutex());
-  while (IsActive()) {
-    // Did we get a response to *our* request?
-    auto it = std::find_if(m_results.begin(), m_results.end(),
-                           [=](const auto& r) { return r.first == request; });
-    if (it != m_results.end()) return;
-    // No, keep waiting for a response
-    Wait(lock);
-  }
-}
-
-template <typename T>
-template <class Clock, class Duration>
-bool PromiseFactory<T>::WaitResultUntil(
-    uint64_t request,
-    const std::chrono::time_point<Clock, Duration>& timeout_time) {
-  std::unique_lock lock(GetResultMutex());
-  bool timeout = false;
-  while (IsActive()) {
-    // Did we get a response to *our* request?
-    auto it = std::find_if(m_results.begin(), m_results.end(),
-                           [=](const auto& r) { return r.first == request; });
-    if (it != m_results.end()) return true;
-    if (timeout) break;
-    // No, keep waiting for a response
-    if (!WaitUntil(lock, timeout_time)) timeout = true;
-  }
-  return false;
-}
-
-template <typename T>
-PromiseFactory<T>& PromiseFactory<T>::GetInstance() {
-  static PromiseFactory inst;
-  return inst;
-}
-
-inline future<void> PromiseFactory<void>::CreateFuture(uint64_t request) {
-  return future<void>{this, request};
-}
-
-inline promise<void> PromiseFactory<void>::CreatePromise(uint64_t request) {
-  return promise<void>{this, request};
-}
-
-template <class Clock, class Duration>
-bool PromiseFactory<void>::WaitResultUntil(
-    uint64_t request,
-    const std::chrono::time_point<Clock, Duration>& timeout_time) {
-  std::unique_lock lock(GetResultMutex());
-  bool timeout = false;
-  while (IsActive()) {
-    // Did we get a response to *our* request?
-    auto it = std::find_if(m_results.begin(), m_results.end(),
-                           [=](const auto& r) { return r == request; });
-    if (it != m_results.end()) return true;
-    if (timeout) break;
-    // No, keep waiting for a response
-    if (!WaitUntil(lock, timeout_time)) timeout = true;
-  }
-  return false;
-}
-
-template <typename To, typename From>
-template <typename F>
-future<To> detail::FutureThen<To, From>::Create(
-    PromiseFactory<From>& fromFactory, uint64_t request,
-    PromiseFactory<To>& factory, F&& func) {
-  uint64_t req = factory.CreateRequest();
-  fromFactory.SetThen(request, req, [&factory, func](uint64_t r, From value) {
-    factory.SetValue(r, func(std::move(value)));
-  });
-  return factory.CreateFuture(req);
-}
-
-template <typename From>
-template <typename F>
-future<void> detail::FutureThen<void, From>::Create(
-    PromiseFactory<From>& fromFactory, uint64_t request,
-    PromiseFactory<void>& factory, F&& func) {
-  uint64_t req = factory.CreateRequest();
-  fromFactory.SetThen(request, req, [&factory, func](uint64_t r, From value) {
-    func(std::move(value));
-    factory.SetValue(r);
-  });
-  return factory.CreateFuture(req);
-}
-
-template <typename To>
-template <typename F>
-future<To> detail::FutureThen<To, void>::Create(
-    PromiseFactory<void>& fromFactory, uint64_t request,
-    PromiseFactory<To>& factory, F&& func) {
-  uint64_t req = factory.CreateRequest();
-  fromFactory.SetThen(request, req, [&factory, func](uint64_t r) {
-    factory.SetValue(r, func());
-  });
-  return factory.CreateFuture(req);
-}
-
-template <typename F>
-future<void> detail::FutureThen<void, void>::Create(
-    PromiseFactory<void>& fromFactory, uint64_t request,
-    PromiseFactory<void>& factory, F&& func) {
-  uint64_t req = factory.CreateRequest();
-  fromFactory.SetThen(request, req, [&factory, func](uint64_t r) {
-    func();
-    factory.SetValue(r);
-  });
-  return factory.CreateFuture(req);
+/**
+ * This variant of async() handles wpi::future functor return values.
+ */
+template <typename Executor, typename F>
+inline future<detail::future_unwrap_t<std::result_of_t<std::decay_t<F>()>>>
+async(const Executor& exe, F&& func) {
+  return exe.twoway_execute(std::forward<F>(func)).via(exe);
 }
 
 }  // namespace wpi
+
+#include "future.inl"
 
 #endif  // WPIUTIL_WPI_FUTURE_H_

--- a/wpiutil/src/main/native/include/wpi/future.inl
+++ b/wpiutil/src/main/native/include/wpi/future.inl
@@ -1,0 +1,312 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#ifndef WPIUTIL_WPI_FUTURE_INL_
+#define WPIUTIL_WPI_FUTURE_INL_
+
+namespace wpi {
+
+template <typename T>
+inline future<T> PromiseFactory<T>::CreateFuture(uint64_t request) {
+  return future<T>{this, request};
+}
+
+template <typename T>
+template <typename E>
+inline continuable_future<T, E> PromiseFactory<T>::CreateContinuableFuture(
+    uint64_t request, const E& exe) {
+  return continuable_future<T, E>{this, request, exe};
+}
+
+template <typename T>
+future<T> PromiseFactory<T>::MakeReadyFuture(T&& value) {
+  std::unique_lock lock(GetResultMutex());
+  uint64_t req = CreateErasedRequest();
+  m_results.emplace_back(std::piecewise_construct, std::forward_as_tuple(req),
+                         std::forward_as_tuple(std::move(value)));
+  return future<T>{this, req};
+}
+
+template <typename T>
+inline promise<T> PromiseFactory<T>::CreatePromise(uint64_t request) {
+  return promise<T>{this, request};
+}
+
+template <typename T>
+void PromiseFactory<T>::SetValue(uint64_t request, const T& value) {
+  std::unique_lock lock(GetResultMutex());
+  if (!EraseRequest(request)) return;
+  auto it = std::find_if(m_thens.begin(), m_thens.end(),
+                         [=](const auto& x) { return x.request == request; });
+  if (it != m_thens.end()) {
+    uint64_t outRequest = it->outRequest;
+    ThenFunction func = std::move(it->func);
+    m_thens.erase(it);
+    lock.unlock();
+    return func(outRequest, value);
+  }
+  m_results.emplace_back(std::piecewise_construct,
+                         std::forward_as_tuple(request),
+                         std::forward_as_tuple(value));
+  Notify();
+}
+
+template <typename T>
+void PromiseFactory<T>::SetValue(uint64_t request, T&& value) {
+  std::unique_lock lock(GetResultMutex());
+  if (!EraseRequest(request)) return;
+  auto it = std::find_if(m_thens.begin(), m_thens.end(),
+                         [=](const auto& x) { return x.request == request; });
+  if (it != m_thens.end()) {
+    void* outFactory = it->outFactory;
+    uint64_t outRequest = it->outRequest;
+    std::shared_ptr<void> executor = std::move(it->executor);
+    ThenFunction func = std::move(it->func);
+    m_thens.erase(it);
+    lock.unlock();
+    return func(outFactory, outRequest, std::move(executor), std::move(value));
+  }
+  m_results.emplace_back(std::piecewise_construct,
+                         std::forward_as_tuple(request),
+                         std::forward_as_tuple(std::move(value)));
+  Notify();
+}
+
+template <typename T>
+void PromiseFactory<T>::SetThen(uint64_t request, void* outFactory,
+                                uint64_t outRequest,
+                                std::shared_ptr<void> executor,
+                                ThenFunction func) {
+  std::unique_lock lock(GetResultMutex());
+  auto it = std::find_if(m_results.begin(), m_results.end(),
+                         [=](const auto& r) { return r.first == request; });
+  if (it != m_results.end()) {
+    auto val = std::move(it->second);
+    m_results.erase(it);
+    lock.unlock();
+    return func(outFactory, outRequest, std::move(executor), std::move(val));
+  }
+  m_thens.emplace_back(request, outFactory, outRequest, std::move(executor),
+                       std::move(func));
+}
+
+template <typename T>
+bool PromiseFactory<T>::IsReady(uint64_t request) noexcept {
+  std::unique_lock lock(GetResultMutex());
+  auto it = std::find_if(m_results.begin(), m_results.end(),
+                         [=](const auto& r) { return r.first == request; });
+  return it != m_results.end();
+}
+
+template <typename T>
+T PromiseFactory<T>::GetResult(uint64_t request) {
+  // wait for response
+  std::unique_lock lock(GetResultMutex());
+  while (IsActive()) {
+    // Did we get a response to *our* request?
+    auto it = std::find_if(m_results.begin(), m_results.end(),
+                           [=](const auto& r) { return r.first == request; });
+    if (it != m_results.end()) {
+      // Yes, remove it from the vector and we're done.
+      auto rv = std::move(it->second);
+      m_results.erase(it);
+      return rv;
+    }
+    // No, keep waiting for a response
+    Wait(lock);
+  }
+  return T();
+}
+
+template <typename T>
+void PromiseFactory<T>::WaitResult(uint64_t request) {
+  // wait for response
+  std::unique_lock lock(GetResultMutex());
+  while (IsActive()) {
+    // Did we get a response to *our* request?
+    auto it = std::find_if(m_results.begin(), m_results.end(),
+                           [=](const auto& r) { return r.first == request; });
+    if (it != m_results.end()) return;
+    // No, keep waiting for a response
+    Wait(lock);
+  }
+}
+
+template <typename T>
+template <class Clock, class Duration>
+bool PromiseFactory<T>::WaitResultUntil(
+    uint64_t request,
+    const std::chrono::time_point<Clock, Duration>& timeout_time) {
+  std::unique_lock lock(GetResultMutex());
+  bool timeout = false;
+  while (IsActive()) {
+    // Did we get a response to *our* request?
+    auto it = std::find_if(m_results.begin(), m_results.end(),
+                           [=](const auto& r) { return r.first == request; });
+    if (it != m_results.end()) return true;
+    if (timeout) break;
+    // No, keep waiting for a response
+    if (!WaitUntil(lock, timeout_time)) timeout = true;
+  }
+  return false;
+}
+
+template <typename T>
+PromiseFactory<T>& PromiseFactory<T>::GetInstance() {
+  static PromiseFactory inst;
+  return inst;
+}
+
+inline future<void> PromiseFactory<void>::CreateFuture(uint64_t request) {
+  return future<void>{this, request};
+}
+
+template <typename E>
+inline continuable_future<void, E>
+PromiseFactory<void>::CreateContinuableFuture(uint64_t request, const E& exe) {
+  return continuable_future<void, E>{this, request, exe};
+}
+
+inline promise<void> PromiseFactory<void>::CreatePromise(uint64_t request) {
+  return promise<void>{this, request};
+}
+
+template <class Clock, class Duration>
+bool PromiseFactory<void>::WaitResultUntil(
+    uint64_t request,
+    const std::chrono::time_point<Clock, Duration>& timeout_time) {
+  std::unique_lock lock(GetResultMutex());
+  bool timeout = false;
+  while (IsActive()) {
+    // Did we get a response to *our* request?
+    auto it = std::find_if(m_results.begin(), m_results.end(),
+                           [=](const auto& r) { return r == request; });
+    if (it != m_results.end()) return true;
+    if (timeout) break;
+    // No, keep waiting for a response
+    if (!WaitUntil(lock, timeout_time)) timeout = true;
+  }
+  return false;
+}
+
+template <typename T>
+template <typename E>
+future<T>::future(continuable_future<future<T>, E>&& oth) {
+  using Factory = PromiseFactory<T>;
+  this->m_promises = &Factory::GetInstance();
+  this->m_request = this->m_promises->CreateRequest();
+
+  std::move(oth).then([req = this->m_request](auto&& f) {
+    auto [predFactory, predRequest] = std::move(f).ToFactory();
+    auto& factory = Factory::GetInstance();
+    if constexpr (std::is_same_v<T, void>) {
+      predFactory->SetThen(predRequest, &factory, req, nullptr,
+                           [](void* fac, uint64_t r, std::shared_ptr<void>) {
+                             static_cast<Factory*>(fac)->SetValue(r);
+                           });
+    } else {
+      predFactory->SetThen(
+          predRequest, &factory, req, nullptr,
+          [](void* fac, uint64_t r, std::shared_ptr<void>, T&& value) {
+            static_cast<Factory*>(fac)->SetValue(r, std::move(value));
+          });
+    }
+  });
+}
+
+template <typename T, typename E>
+template <typename E2>
+continuable_future<T, E>::continuable_future(
+    continuable_future<continuable_future<T, E2>, E>&& oth) {
+  using Factory = PromiseFactory<T>;
+  this->m_promises = &Factory::GetInstance();
+  this->m_request = this->m_promises->CreateRequest();
+  this->m_executor = oth.m_executor;
+
+  std::move(oth).then([req = this->m_request](auto&& f) {
+    auto [predFactory, predRequest] = std::move(f).ToFactory();
+    auto& factory = Factory::GetInstance();
+    predFactory->SetThen(
+        predRequest, &factory, req, nullptr,
+        [](void* fac, uint64_t r, std::shared_ptr<void>, T&& value) {
+          static_cast<Factory*>(fac)->SetValue(r, std::move(value));
+        });
+  });
+}
+
+template <typename E>
+template <typename E2>
+continuable_future<void, E>::continuable_future(
+    continuable_future<continuable_future<void, E2>, E>&& oth) {
+  using Factory = PromiseFactory<void>;
+  this->m_promises = &Factory::GetInstance();
+  this->m_request = this->m_promises->CreateRequest();
+  this->m_executor = oth.m_executor;
+
+  std::move(oth).then([req = this->m_request](auto&& f) {
+    auto [predFactory, predRequest] = std::move(f).ToFactory();
+    auto& factory = Factory::GetInstance();
+    predFactory->SetThen(predRequest, &factory, req, nullptr,
+                         [](void* fac, uint64_t r, std::shared_ptr<void>) {
+                           static_cast<Factory*>(fac)->SetValue(r);
+                         });
+  });
+}
+
+template <typename F, typename R>
+inline future<R> inline_executor::twoway_execute(F&& func) const {
+  if constexpr (std::is_void_v<R>) {
+    func();
+    return make_ready_future();
+  } else {
+    return make_ready_future(func());
+  }
+}
+
+template <typename R, typename F, typename Future>
+continuable_future<R, inline_executor> inline_executor::then_execute(
+    F&& func, Future&& pred) const {
+  auto [predFactory, predRequest] = std::move(pred).ToFactory();
+  using Factory = PromiseFactory<R>;
+  auto& factory = Factory::GetInstance();
+  uint64_t req = factory.CreateRequest();
+  if constexpr (std::is_void_v<typename Future::value_type>) {
+    if constexpr (std::is_void_v<R>) {
+      predFactory->SetThen(predRequest, &factory, req, nullptr,
+                           [func](void* f, uint64_t r, std::shared_ptr<void>) {
+                             func();
+                             static_cast<Factory*>(f)->SetValue(r);
+                           });
+    } else {
+      predFactory->SetThen(predRequest, &factory, req, nullptr,
+                           [func](void* f, uint64_t r, std::shared_ptr<void>) {
+                             static_cast<Factory*>(f)->SetValue(r, func());
+                           });
+    }
+  } else {
+    if constexpr (std::is_void_v<R>) {
+      predFactory->SetThen(predRequest, &factory, req, nullptr,
+                           [func](void* f, uint64_t r, std::shared_ptr<void>,
+                                  typename Future::value_type value) {
+                             func(std::move(value));
+                             static_cast<Factory*>(f)->SetValue(r);
+                           });
+    } else {
+      predFactory->SetThen(predRequest, &factory, req, nullptr,
+                           [func](void* f, uint64_t r, std::shared_ptr<void>,
+                                  typename Future::value_type value) {
+                             static_cast<Factory*>(f)->SetValue(
+                                 r, func(std::move(value)));
+                           });
+    }
+  }
+  return factory.CreateContinuableFuture(req, *this);
+}
+
+}  // namespace wpi
+
+#endif  // WPIUTIL_WPI_FUTURE_INL_

--- a/wpiutil/src/main/native/include/wpi/uv/AsyncExecutor.h
+++ b/wpiutil/src/main/native/include/wpi/uv/AsyncExecutor.h
@@ -1,0 +1,97 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#ifndef WPIUTIL_WPI_UV_ASYNCEXECUTOR_H_
+#define WPIUTIL_WPI_UV_ASYNCEXECUTOR_H_
+
+#include <uv.h>
+
+#include <memory>
+#include <thread>
+#include <utility>
+
+#include "wpi/ThreadedExecutorBase.h"
+#include "wpi/uv/Handle.h"
+#include "wpi/uv/Loop.h"
+
+namespace wpi {
+namespace uv {
+
+class AsyncExecutor;
+
+namespace detail {
+
+/**
+ * Async executor handle.
+ * Async handles allow the user to "wakeup" the event loop and have a function
+ * called from another thread that returns a result to the calling thread.
+ */
+class AsyncExecutorHandle final
+    : public ThreadedExecutorBaseHandle,
+      public HandleImpl<AsyncExecutorHandle, uv_async_t> {
+  struct private_init {};
+  friend class ::wpi::uv::AsyncExecutor;
+  friend class ThreadedExecutorBase<AsyncExecutor, AsyncExecutorHandle>;
+
+ public:
+  AsyncExecutorHandle(const std::shared_ptr<Loop>& loop, const private_init&)
+      : m_loop{loop} {}
+  ~AsyncExecutorHandle() noexcept override;
+
+  /**
+   * Create an async handle.
+   *
+   * @param loop Loop object where this handle runs.
+   */
+  static std::shared_ptr<AsyncExecutorHandle> Create(Loop& loop) {
+    return Create(loop.shared_from_this());
+  }
+
+  /**
+   * Create an async handle.
+   *
+   * @param loop Loop object where this handle runs.
+   */
+  static std::shared_ptr<AsyncExecutorHandle> Create(
+      const std::shared_ptr<Loop>& loop);
+
+  AsyncExecutor GetExecutor();
+
+ private:
+  void Signal() {
+    if (auto loop = m_loop.lock()) Invoke(&uv_async_send, GetRaw());
+  }
+
+  std::thread::id GetThreadId() {
+    if (auto loop = m_loop.lock())
+      return loop->GetThreadId();
+    else
+      return std::thread::id{};
+  }
+
+  wpi::mutex m_mutex;
+  std::weak_ptr<Loop> m_loop;
+};
+
+}  // namespace detail
+
+class AsyncExecutor final
+    : public ThreadedExecutorBase<AsyncExecutor, detail::AsyncExecutorHandle> {
+ public:
+  AsyncExecutor() = default;
+  explicit AsyncExecutor(std::shared_ptr<detail::AsyncExecutorHandle> handle)
+      : ThreadedExecutorBase(std::move(handle)) {}
+};
+
+inline AsyncExecutor detail::AsyncExecutorHandle::GetExecutor() {
+  return AsyncExecutor{shared_from_this()};
+}
+
+}  // namespace uv
+}  // namespace wpi
+
+#endif  // WPIUTIL_WPI_UV_ASYNCEXECUTOR_H_

--- a/wpiutil/src/main/native/include/wpi/uv/Loop.h
+++ b/wpiutil/src/main/native/include/wpi/uv/Loop.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -18,11 +18,17 @@
 #include <utility>
 
 #include "wpi/Signal.h"
+#include "wpi/mutex.h"
 #include "wpi/uv/Error.h"
 
 namespace wpi {
 namespace uv {
 
+namespace detail {
+class AsyncExecutorHandle;
+}  // namespace detail
+
+class AsyncExecutor;
 class Handle;
 
 /**
@@ -206,6 +212,12 @@ class Loop final : public std::enable_shared_from_this<Loop> {
   void Fork();
 
   /**
+   * Get an asynchronous executor for use with wpi::async() or
+   * wpi::future::via() to run a continuation on the event loop.
+   */
+  AsyncExecutor GetExecutor();
+
+  /**
    * Get the underlying event loop data structure.
    *
    * @return The underlying event loop data structure.
@@ -249,6 +261,9 @@ class Loop final : public std::enable_shared_from_this<Loop> {
   uv_loop_t* m_loop;
   uv_loop_t m_loopStruct;
   std::atomic<std::thread::id> m_tid;
+  wpi::mutex m_executorMutex;
+  std::shared_ptr<detail::AsyncExecutorHandle> m_execHandle;
+  std::unique_ptr<AsyncExecutor> m_executor;
 };
 
 }  // namespace uv

--- a/wpiutil/src/test/native/cpp/WorkerThreadTest.cpp
+++ b/wpiutil/src/test/native/cpp/WorkerThreadTest.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -11,63 +11,147 @@
 
 #include <thread>
 
-#include "wpi/uv/Loop.h"
-
 namespace wpi {
 
-TEST(WorkerThread, Future) {
-  WorkerThread<int(bool)> worker;
-  future<int> f =
-      worker.QueueWork([](bool v) -> int { return v ? 1 : 2; }, true);
-  ASSERT_EQ(f.get(), 1);
+TEST(WorkerThread, Test) {
+  WorkerThread worker;
+  auto exe = worker.GetExecutor();
+  int cb_called[4] = {0, 0, 0, 0};
+  auto outer_tid = std::this_thread::get_id();
+
+  exe.execute([&] {
+    ++cb_called[0];
+    EXPECT_NE(std::this_thread::get_id(), outer_tid);
+  });
+  auto call0 = async(exe, [&] {
+    ++cb_called[1];
+    EXPECT_EQ(cb_called[0], 1);
+    EXPECT_NE(std::this_thread::get_id(), outer_tid);
+    return 1;
+  });
+  auto call1 = exe.twoway_execute([&] {
+    ++cb_called[2];
+    EXPECT_EQ(cb_called[0], 1);
+    EXPECT_EQ(cb_called[1], 1);
+    EXPECT_NE(std::this_thread::get_id(), outer_tid);
+    return 2;
+  });
+  auto call2 = async(exe, [&] {
+    ++cb_called[3];
+    EXPECT_EQ(cb_called[0], 1);
+    EXPECT_EQ(cb_called[1], 1);
+    EXPECT_EQ(cb_called[2], 1);
+    EXPECT_NE(std::this_thread::get_id(), outer_tid);
+  });
+
+  ASSERT_EQ(future_get(std::move(call0)), 1);
+  ASSERT_EQ(future_get(std::move(call1)), 2);
+  future_get(std::move(call2));
+
+  ASSERT_EQ(cb_called[0], 1);
+  ASSERT_EQ(cb_called[1], 1);
+  ASSERT_EQ(cb_called[2], 1);
+  ASSERT_EQ(cb_called[3], 1);
 }
 
-TEST(WorkerThread, FutureVoid) {
-  int callbacks = 0;
-  WorkerThread<void(int)> worker;
-  future<void> f = worker.QueueWork(
-      [&](int v) {
-        ++callbacks;
-        ASSERT_EQ(v, 3);
-      },
-      3);
-  f.get();
-  ASSERT_EQ(callbacks, 1);
+TEST(WorkerThread, TestThen) {
+  int cb_called[4] = {0, 0, 0, 0};
+
+  WorkerThread worker1;
+  auto exe1 = worker1.GetExecutor();
+  WorkerThread worker2;
+  auto exe2 = worker2.GetExecutor();
+
+  auto outer_tid = std::this_thread::get_id();
+  std::thread::id thread1_tid;
+
+  inline_executor imm_exe;
+  auto call = async(imm_exe,
+                    [&] {
+                      ++cb_called[0];
+                      EXPECT_EQ(std::this_thread::get_id(), outer_tid);
+                      return 1;
+                    })
+                  .via(exe1)
+                  .then([&](int v) {
+                    ++cb_called[1];
+                    thread1_tid = std::this_thread::get_id();
+                    EXPECT_NE(thread1_tid, outer_tid);
+                    EXPECT_EQ(v, 1);
+                    return v + 1;
+                  })
+                  .then([&](int v) {
+                    ++cb_called[2];
+                    EXPECT_EQ(std::this_thread::get_id(), thread1_tid);
+                    EXPECT_EQ(v, 2);
+                  })
+                  .via(exe2)
+                  .then([&] {
+                    ++cb_called[3];
+                    EXPECT_NE(std::this_thread::get_id(), outer_tid);
+                    EXPECT_NE(std::this_thread::get_id(), thread1_tid);
+                  });
+  future_get(std::move(call));
+
+  ASSERT_EQ(cb_called[0], 1);
+  ASSERT_EQ(cb_called[1], 1);
+  ASSERT_EQ(cb_called[2], 1);
+  ASSERT_EQ(cb_called[3], 1);
 }
 
-TEST(WorkerThread, Loop) {
-  int callbacks = 0;
-  WorkerThread<int(bool)> worker;
-  auto loop = uv::Loop::Create();
-  worker.SetLoop(*loop);
-  worker.QueueWorkThen([](bool v) -> int { return v ? 1 : 2; },
-                       [&](int v2) {
-                         ++callbacks;
-                         loop->Stop();
-                         ASSERT_EQ(v2, 1);
-                       },
-                       true);
-  auto f = worker.QueueWork([](bool) -> int { return 2; }, true);
-  ASSERT_EQ(f.get(), 2);
-  loop->Run();
-  ASSERT_EQ(callbacks, 1);
+TEST(WorkerThread, ReadyThen) {
+  int cb_called[4] = {0, 0, 0, 0};
+
+  WorkerThread worker1;
+  auto exe = worker1.GetExecutor();
+  auto call =
+      wpi::make_ready_future(1).via(exe).then([&](int v) { ++cb_called[0]; });
+  future_get(std::move(call));
+
+  ASSERT_EQ(cb_called[0], 1);
 }
 
-TEST(WorkerThread, LoopVoid) {
-  int callbacks = 0;
-  WorkerThread<void(bool)> worker;
-  auto loop = uv::Loop::Create();
-  worker.SetLoop(*loop);
-  worker.QueueWorkThen([](bool) {},
-                       [&]() {
-                         ++callbacks;
-                         loop->Stop();
-                       },
-                       true);
-  auto f = worker.QueueWork([](bool) {}, true);
-  f.get();
-  loop->Run();
-  ASSERT_EQ(callbacks, 1);
+TEST(WorkerThread, Continuation) {
+  int cb_called[4] = {0, 0, 0, 0};
+
+  inline_executor exe;
+  WorkerThread worker1, worker2;
+  auto w1exe = worker1.GetExecutor();
+  auto w2exe = worker2.GetExecutor();
+
+  wpi::mutex m;
+  wpi::condition_variable cv;
+  bool ready = false;
+
+  auto [inPromise, inFuture] = make_promise_contract<void>(exe);
+
+  future<void> outFuture = std::move(inFuture)
+                               .then([&] {
+                                 ++cb_called[0];
+                                 return wpi::async(w1exe, [&] {
+                                   ++cb_called[1];
+                                   std::unique_lock<wpi::mutex> lock(m);
+                                   cv.wait(lock, [&] { return ready; });
+                                   ++cb_called[2];
+                                 });
+                               })
+                               .via(w2exe)
+                               .then([&] { ++cb_called[3]; });
+
+  std::move(inPromise).set_value();
+  ASSERT_FALSE(outFuture.is_ready());
+  ASSERT_EQ(cb_called[0], 1);
+
+  {
+    std::scoped_lock lock(m);
+    ready = true;
+  }
+  cv.notify_one();
+
+  wpi::future_get(std::move(outFuture));
+  ASSERT_EQ(cb_called[1], 1);
+  ASSERT_EQ(cb_called[2], 1);
+  ASSERT_EQ(cb_called[3], 1);
 }
 
 }  // namespace wpi

--- a/wpiutil/src/test/native/cpp/uv/UvAsyncExecutorTest.cpp
+++ b/wpiutil/src/test/native/cpp/uv/UvAsyncExecutorTest.cpp
@@ -1,0 +1,200 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "wpi/uv/AsyncExecutor.h"  // NOLINT(build/include_order)
+
+#include "gtest/gtest.h"  // NOLINT(build/include_order)
+
+#include <thread>
+
+#include "wpi/WorkerThread.h"
+#include "wpi/uv/Loop.h"
+#include "wpi/uv/Prepare.h"
+
+namespace wpi {
+namespace uv {
+
+TEST(UvAsyncExecutor, Test) {
+  int prepare_cb_called = 0;
+  int async_cb_called[4] = {0, 0, 0, 0};
+
+  std::thread theThread;
+
+  auto loop = Loop::Create();
+  auto exe = loop->GetExecutor();
+  auto prepare = Prepare::Create(loop);
+  auto loop_tid = std::this_thread::get_id();
+
+  loop->error.connect([](Error e) { FAIL(); });
+
+  prepare->error.connect([](Error) { FAIL(); });
+  prepare->prepare.connect([&] {
+    if (prepare_cb_called++) return;
+    theThread = std::thread([&] {
+      exe.execute([&] {
+        ++async_cb_called[0];
+        EXPECT_EQ(std::this_thread::get_id(), loop_tid);
+      });
+      auto call0 = async(exe, [&] {
+        ++async_cb_called[1];
+        EXPECT_EQ(async_cb_called[0], 1);
+        EXPECT_EQ(std::this_thread::get_id(), loop_tid);
+        return 1;
+      });
+      auto call1 = exe.twoway_execute([&] {
+        ++async_cb_called[2];
+        EXPECT_EQ(async_cb_called[0], 1);
+        EXPECT_EQ(async_cb_called[1], 1);
+        EXPECT_EQ(std::this_thread::get_id(), loop_tid);
+        return 2;
+      });
+      auto call2 = async(exe, [&] {
+        ++async_cb_called[3];
+        EXPECT_EQ(async_cb_called[0], 1);
+        EXPECT_EQ(async_cb_called[1], 1);
+        EXPECT_EQ(async_cb_called[2], 1);
+        EXPECT_EQ(std::this_thread::get_id(), loop_tid);
+      });
+      exe.execute([&] { prepare->Close(); });
+      ASSERT_EQ(future_get(std::move(call0)), 1);
+      ASSERT_EQ(future_get(std::move(call1)), 2);
+      future_get(std::move(call2));
+    });
+  });
+  prepare->Start();
+
+  loop->Run();
+
+  ASSERT_GE(prepare_cb_called, 1);
+  ASSERT_EQ(async_cb_called[0], 1);
+  ASSERT_EQ(async_cb_called[1], 1);
+  ASSERT_EQ(async_cb_called[2], 1);
+  ASSERT_EQ(async_cb_called[3], 1);
+
+  if (theThread.joinable()) theThread.join();
+}
+
+TEST(UvAsyncExecutor, TestThen) {
+  int prepare_cb_called = 0;
+  int async_cb_called[4] = {0, 0, 0, 0};
+
+  std::thread theThread;
+
+  auto loop = Loop::Create();
+  auto exe = loop->GetExecutor();
+  auto prepare = Prepare::Create(loop);
+  auto loop_tid = std::this_thread::get_id();
+
+  loop->error.connect([](Error e) { FAIL(); });
+
+  prepare->error.connect([](Error) { FAIL(); });
+  prepare->prepare.connect([&] {
+    if (prepare_cb_called++) return;
+    theThread = std::thread([&] {
+      auto thread_tid = std::this_thread::get_id();
+      inline_executor imm_exe;
+      auto call = async(imm_exe,
+                        [&] {
+                          ++async_cb_called[0];
+                          EXPECT_EQ(std::this_thread::get_id(), thread_tid);
+                          return 1;
+                        })
+                      .via(exe)
+                      .then([&](int v) {
+                        ++async_cb_called[1];
+                        EXPECT_EQ(std::this_thread::get_id(), loop_tid);
+                        EXPECT_EQ(v, 1);
+                        return v + 1;
+                      })
+                      .then([&](int v) {
+                        ++async_cb_called[2];
+                        EXPECT_EQ(std::this_thread::get_id(), loop_tid);
+                        EXPECT_EQ(v, 2);
+                      })
+                      .then([&] {
+                        ++async_cb_called[3];
+                        EXPECT_EQ(std::this_thread::get_id(), loop_tid);
+                        prepare->Close();
+                      });
+      future_get(std::move(call));
+    });
+  });
+  prepare->Start();
+
+  loop->Run();
+
+  ASSERT_GE(prepare_cb_called, 1);
+  ASSERT_EQ(async_cb_called[0], 1);
+  ASSERT_EQ(async_cb_called[1], 1);
+  ASSERT_EQ(async_cb_called[2], 1);
+  ASSERT_EQ(async_cb_called[3], 1);
+
+  if (theThread.joinable()) theThread.join();
+}
+
+TEST(UvAsyncExecutor, TestWorker) {
+  int prepare_cb_called = 0;
+  int async_cb_called[4] = {0, 0, 0, 0};
+
+  std::thread theThread;
+
+  auto loop = Loop::Create();
+  auto loopExe = loop->GetExecutor();
+  WorkerThread worker;
+  auto workerExe = worker.GetExecutor();
+
+  auto prepare = Prepare::Create(loop);
+  auto loop_tid = std::this_thread::get_id();
+
+  loop->error.connect([](Error e) { FAIL(); });
+
+  prepare->error.connect([](Error) { FAIL(); });
+  prepare->prepare.connect([&] {
+    if (prepare_cb_called++) return;
+    theThread = std::thread([&] {
+      auto call = async(loopExe,
+                        [&] {
+                          ++async_cb_called[0];
+                          EXPECT_EQ(std::this_thread::get_id(), loop_tid);
+                          return 1;
+                        })
+                      .via(workerExe)
+                      .then([&](int v) {
+                        ++async_cb_called[1];
+                        EXPECT_NE(std::this_thread::get_id(), loop_tid);
+                        EXPECT_EQ(v, 1);
+                        return v + 1;
+                      })
+                      .via(loopExe)
+                      .then([&](int v) {
+                        ++async_cb_called[2];
+                        EXPECT_EQ(std::this_thread::get_id(), loop_tid);
+                        EXPECT_EQ(v, 2);
+                      })
+                      .then([&] {
+                        ++async_cb_called[3];
+                        EXPECT_EQ(std::this_thread::get_id(), loop_tid);
+                        prepare->Close();
+                      });
+      future_get(std::move(call));
+    });
+  });
+  prepare->Start();
+
+  loop->Run();
+
+  ASSERT_GE(prepare_cb_called, 1);
+  ASSERT_EQ(async_cb_called[0], 1);
+  ASSERT_EQ(async_cb_called[1], 1);
+  ASSERT_EQ(async_cb_called[2], 1);
+  ASSERT_EQ(async_cb_called[3], 1);
+
+  if (theThread.joinable()) theThread.join();
+}
+
+}  // namespace uv
+}  // namespace wpi

--- a/wpiutil/src/test/native/cpp/uv/UvAsyncFunctionTest.cpp
+++ b/wpiutil/src/test/native/cpp/uv/UvAsyncFunctionTest.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -36,8 +36,8 @@ TEST(UvAsyncFunction, Test) {
     theThread = std::thread([&] {
       auto call0 = async->Call(0);
       auto call1 = async->Call(1);
-      ASSERT_EQ(call0.get(), 1);
-      ASSERT_EQ(call1.get(), 2);
+      ASSERT_EQ(future_get(std::move(call0)), 1);
+      ASSERT_EQ(future_get(std::move(call1)), 2);
     });
   });
   prepare->Start();
@@ -50,7 +50,7 @@ TEST(UvAsyncFunction, Test) {
       async->Close();
       prepare->Close();
     }
-    out.set_value(v + 1);
+    std::move(out).set_value(v + 1);
   };
 
   loop->Run();
@@ -74,7 +74,8 @@ TEST(UvAsyncFunction, Ref) {
 
   prepare->prepare.connect([&] {
     if (prepare_cb_called++) return;
-    theThread = std::thread([&] { ASSERT_EQ(async->Call(1, val).get(), 2); });
+    theThread =
+        std::thread([&] { ASSERT_EQ(future_get(async->Call(1, val)), 2); });
   });
   prepare->Start();
 
@@ -82,7 +83,7 @@ TEST(UvAsyncFunction, Ref) {
     r = v;
     async->Close();
     prepare->Close();
-    out.set_value(v + 1);
+    std::move(out).set_value(v + 1);
   };
 
   loop->Run();
@@ -106,7 +107,7 @@ TEST(UvAsyncFunction, Movable) {
     if (prepare_cb_called++) return;
     theThread = std::thread([&] {
       auto val = std::make_unique<int>(1);
-      auto val2 = async->Call(std::move(val)).get();
+      auto val2 = future_get(async->Call(std::move(val)));
       ASSERT_NE(val2, nullptr);
       ASSERT_EQ(*val2, 1);
     });
@@ -117,7 +118,7 @@ TEST(UvAsyncFunction, Movable) {
                       std::unique_ptr<int> v) {
     async->Close();
     prepare->Close();
-    out.set_value(std::move(v));
+    std::move(out).set_value(std::move(v));
   };
 
   loop->Run();
@@ -145,7 +146,7 @@ TEST(UvAsyncFunction, CallIgnoreResult) {
                       std::unique_ptr<int> v) {
     async->Close();
     prepare->Close();
-    out.set_value(std::move(v));
+    std::move(out).set_value(std::move(v));
   };
 
   loop->Run();
@@ -171,7 +172,7 @@ TEST(UvAsyncFunction, VoidCall) {
   async->wakeup = [&](promise<void> out) {
     async->Close();
     prepare->Close();
-    out.set_value();
+    std::move(out).set_value();
   };
 
   loop->Run();
@@ -191,7 +192,8 @@ TEST(UvAsyncFunction, WaitFor) {
   prepare->prepare.connect([&] {
     if (prepare_cb_called++) return;
     theThread = std::thread([&] {
-      ASSERT_FALSE(async->Call().wait_for(std::chrono::milliseconds(10)));
+      auto f = async->Call();
+      ASSERT_FALSE(future_wait_for(f, std::chrono::milliseconds(10)));
     });
   });
   prepare->Start();
@@ -200,7 +202,7 @@ TEST(UvAsyncFunction, WaitFor) {
     async->Close();
     prepare->Close();
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    out.set_value(1);
+    std::move(out).set_value(1);
   };
 
   loop->Run();
@@ -220,7 +222,8 @@ TEST(UvAsyncFunction, VoidWaitFor) {
   prepare->prepare.connect([&] {
     if (prepare_cb_called++) return;
     theThread = std::thread([&] {
-      ASSERT_FALSE(async->Call().wait_for(std::chrono::milliseconds(10)));
+      auto f = async->Call();
+      ASSERT_FALSE(future_wait_for(f, std::chrono::milliseconds(10)));
     });
   });
   prepare->Start();
@@ -229,7 +232,7 @@ TEST(UvAsyncFunction, VoidWaitFor) {
     async->Close();
     prepare->Close();
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    out.set_value();
+    std::move(out).set_value();
   };
 
   loop->Run();


### PR DESCRIPTION
These are modeled after P1054R0 with some changes and simplifications.

- future is now more like P1054R0 semi_future
- future::get() and wait() have been moved to free functions (future_get())
- Move then() to continuable_future
- then() supports true continuations with future unwrapping
- Rewrite WorkerThread to use executors
- Add UvAsyncExecutor for libuv async execution