### PR TITLE
Fix google test not being disabled for cross compilers

### DIFF
--- a/buildSrc/src/main/groovy/MultiBuilds.groovy
+++ b/buildSrc/src/main/groovy/MultiBuilds.groovy
@@ -9,7 +9,9 @@ import org.gradle.language.base.internal.ProjectLayout;
 import org.gradle.language.base.plugins.ComponentModelBasePlugin;
 import org.gradle.language.nativeplatform.tasks.AbstractNativeSourceCompileTask;
 import org.gradle.model.ModelMap;
+import edu.wpi.first.toolchain.ToolchainExtension
 import org.gradle.model.Mutate;
+import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.nativeplatform.test.googletest.GoogleTestTestSuiteBinarySpec;
 import org.gradle.model.RuleSource;
 import org.gradle.model.Validate;
@@ -51,6 +53,20 @@ class MultiBuilds implements Plugin<Project> {
     private static void setBuildableFalseDynamically(NativeBinarySpec binary) {
         binary.buildable = false
     }
+
+    @Validate
+    @CompileStatic
+    // TODO: Move this to tc plugin
+    void disableCrossTests(BinaryContainer binaries, ExtensionContainer extContainer) {
+        final ToolchainExtension ext = extContainer.getByType(ToolchainExtension.class);
+
+        for (GoogleTestTestSuiteBinarySpec binary : binaries.withType(GoogleTestTestSuiteBinarySpec.class)) {
+            if (ext.getCrossCompilers().findByName(binary.getTargetPlatform().getName()) != null) {
+              setBuildableFalseDynamically(binary)
+            }
+        }
+    }
+
 
     @Mutate
     @CompileStatic

--- a/shared/javacpp/setupBuild.gradle
+++ b/shared/javacpp/setupBuild.gradle
@@ -103,11 +103,7 @@ model {
     }
     binaries {
         withType(GoogleTestTestSuiteBinarySpec) {
-            if (!project.hasProperty('onlylinuxathena') && !project.hasProperty('onlylinuxraspbian')) {
-                lib library: nativeName, linkage: 'shared'
-            } else {
-                it.buildable = false
-            }
+            lib library: nativeName, linkage: 'shared'
         }
     }
     tasks {

--- a/shared/jni/setupBuild.gradle
+++ b/shared/jni/setupBuild.gradle
@@ -232,12 +232,8 @@ model {
     }
     binaries {
         withType(GoogleTestTestSuiteBinarySpec) {
-            if (!project.hasProperty('onlylinuxathena') && !project.hasProperty('onlylinuxraspbian')) {
-                lib library: nativeName, linkage: 'shared'
-                lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-            } else {
-                it.buildable = false
-            }
+            lib library: nativeName, linkage: 'shared'
+            lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
         }
     }
     tasks {

--- a/wpilibc/build.gradle
+++ b/wpilibc/build.gradle
@@ -203,16 +203,12 @@ model {
             }
         }
         withType(GoogleTestTestSuiteBinarySpec) {
-            if (!project.hasProperty('onlylinuxathena') && !project.hasProperty('onlylinuxraspbian')) {
-                lib project: ':ntcore', library: 'ntcore', linkage: 'shared'
-                lib project: ':cscore', library: 'cscore', linkage: 'shared'
-                project(':hal').addHalDependency(it, 'shared')
-                lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-                lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
-                lib library: nativeName, linkage: 'shared'
-            } else {
-                it.buildable = false
-            }
+            lib project: ':ntcore', library: 'ntcore', linkage: 'shared'
+            lib project: ':cscore', library: 'cscore', linkage: 'shared'
+            project(':hal').addHalDependency(it, 'shared')
+            lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
+            lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
+            lib library: nativeName, linkage: 'shared'
         }
     }
     tasks {


### PR DESCRIPTION
Removes checks for onlyathena and onlyraspbian, and just disables gtest for cross compilers. That way azure will detect a failure in the future