### PR TITLE
Only disable execution of cross compile google tests

### DIFF
--- a/buildSrc/src/main/groovy/DisableBuildingGTest.groovy
+++ b/buildSrc/src/main/groovy/DisableBuildingGTest.groovy
@@ -1,0 +1,70 @@
+
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.language.base.internal.ProjectLayout;
+import org.gradle.language.base.plugins.ComponentModelBasePlugin;
+import org.gradle.language.nativeplatform.tasks.AbstractNativeSourceCompileTask;
+import org.gradle.model.ModelMap;
+import edu.wpi.first.toolchain.ToolchainExtension
+import org.gradle.model.Mutate;
+import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.nativeplatform.test.googletest.GoogleTestTestSuiteBinarySpec;
+import org.gradle.model.RuleSource;
+import org.gradle.model.Validate;
+import org.gradle.nativeplatform.NativeExecutableBinarySpec
+import org.gradle.nativeplatform.NativeBinarySpec;
+import org.gradle.nativeplatform.NativeComponentSpec;
+import org.gradle.nativeplatform.NativeLibrarySpec;
+import org.gradle.nativeplatform.SharedLibraryBinarySpec;
+import org.gradle.nativeplatform.StaticLibraryBinarySpec;
+import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
+import org.gradle.nativeplatform.toolchain.NativeToolChain;
+import org.gradle.nativeplatform.toolchain.NativeToolChainRegistry;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
+import org.gradle.nativeplatform.toolchain.internal.ToolType;
+import org.gradle.nativeplatform.toolchain.internal.gcc.AbstractGccCompatibleToolChain;
+import org.gradle.nativeplatform.toolchain.internal.msvcpp.VisualCppToolChain;
+import org.gradle.nativeplatform.toolchain.internal.tools.ToolRegistry;
+import org.gradle.platform.base.BinarySpec;
+import org.gradle.platform.base.ComponentSpec;
+import org.gradle.platform.base.ComponentSpecContainer;
+import org.gradle.platform.base.BinaryContainer;
+import org.gradle.platform.base.ComponentType;
+import org.gradle.platform.base.TypeBuilder;
+import org.gradle.nativeplatform.tasks.ObjectFilesToBinary;
+import groovy.transform.CompileStatic;
+import groovy.transform.CompileDynamic
+import org.gradle.nativeplatform.BuildTypeContainer
+
+@CompileStatic
+class DisableBuildingGTest implements Plugin<Project> {
+  @CompileStatic
+  public void apply(Project project) {
+
+  }
+
+  @CompileStatic
+  static class Rules extends RuleSource {
+    @CompileDynamic
+    private static void setBuildableFalseDynamically(NativeBinarySpec binary) {
+        binary.buildable = false
+    }
+
+    @Validate
+    @CompileStatic
+    // TODO: Move this to tc plugin
+    void disableCrossTests(BinaryContainer binaries, ExtensionContainer extContainer) {
+        final ToolchainExtension ext = extContainer.getByType(ToolchainExtension.class);
+
+        for (GoogleTestTestSuiteBinarySpec binary : binaries.withType(GoogleTestTestSuiteBinarySpec.class)) {
+            if (ext.getCrossCompilers().findByName(binary.getTargetPlatform().getName()) != null) {
+              setBuildableFalseDynamically(binary)
+            }
+        }
+    }
+  }
+}

--- a/buildSrc/src/main/groovy/MultiBuilds.groovy
+++ b/buildSrc/src/main/groovy/MultiBuilds.groovy
@@ -15,6 +15,7 @@ import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.nativeplatform.test.googletest.GoogleTestTestSuiteBinarySpec;
 import org.gradle.model.RuleSource;
 import org.gradle.model.Validate;
+import org.gradle.nativeplatform.test.tasks.RunTestExecutable
 import org.gradle.nativeplatform.NativeExecutableBinarySpec
 import org.gradle.nativeplatform.NativeBinarySpec;
 import org.gradle.nativeplatform.NativeComponentSpec;
@@ -62,7 +63,9 @@ class MultiBuilds implements Plugin<Project> {
 
         for (GoogleTestTestSuiteBinarySpec binary : binaries.withType(GoogleTestTestSuiteBinarySpec.class)) {
             if (ext.getCrossCompilers().findByName(binary.getTargetPlatform().getName()) != null) {
-              setBuildableFalseDynamically(binary)
+              binary.tasks.withType(RunTestExecutable).each {
+                it.onlyIf { false }
+              }
             }
         }
     }
@@ -81,21 +84,6 @@ class MultiBuilds implements Plugin<Project> {
           Rules.setBuildableFalseDynamically(spec)
         }
       }
-        // def crossCompileConfigs = []
-        // for (BuildConfig config : configs) {
-        //     if (!BuildConfigRulesBase.isCrossCompile(config)) {
-        //         continue
-        //     }
-        //     crossCompileConfigs << config.architecture
-        // }
-        // if (!crossCompileConfigs.empty) {
-        //     binaries.withType(GoogleTestTestSuiteBinarySpec) { oSpec ->
-        //         GoogleTestTestSuiteBinarySpec spec = (GoogleTestTestSuiteBinarySpec) oSpec
-        //         if (crossCompileConfigs.contains(spec.targetPlatform.architecture.name)) {
-        //             setBuildableFalseDynamically(spec)
-        //         }
-        //     }
-        // }
     }
   }
 }

--- a/hal/build.gradle
+++ b/hal/build.gradle
@@ -43,6 +43,8 @@ def generateUsageReporting = tasks.register('generateUsageReporting') {
     }
 }
 
+apply plugin: DisableBuildingGTest
+
 ext {
     addHalDependency = { binary, shared->
         binary.tasks.withType(AbstractNativeSourceCompileTask) {

--- a/shared/googletest.gradle
+++ b/shared/googletest.gradle
@@ -1,7 +1,6 @@
 model {
     binaries {
         withType(GoogleTestTestSuiteBinarySpec).all {
-            if (it.targetPlatform.name != nativeUtils.wpi.platforms.raspbian)
             nativeUtils.useRequiredLibrary(it, 'googletest_static')
         }
     }

--- a/wpilibc/build.gradle
+++ b/wpilibc/build.gradle
@@ -81,6 +81,8 @@ ext {
 
 apply from: "${rootDir}/shared/nilibraries.gradle"
 
+apply plugin: DisableBuildingGTest
+
 nativeUtils.exportsConfigs {
     wpilibc {
         x86ExcludeSymbols = ['_CT??_R0?AV_System_error', '_CT??_R0?AVexception', '_CT??_R0?AVfailure',


### PR DESCRIPTION
Still build them and link them, just don't execute them