### PR TITLE
Update jni library, fix cross builds of the jni symbol check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'base'
     id 'edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin' version '2.3'
     id 'edu.wpi.first.NativeUtils' apply false
-    id 'edu.wpi.first.GradleJni' version '0.4.1'
+    id 'edu.wpi.first.GradleJni' version '0.9.0'
     id 'edu.wpi.first.GradleVsCode' version '0.8.0'
     id 'idea'
     id 'visual-studio'

--- a/shared/jni/setupBuild.gradle
+++ b/shared/jni/setupBuild.gradle
@@ -104,11 +104,8 @@ model {
             } else {
                 baseName = nativeName + 'jni'
             }
-            if (project.hasProperty('skipJniCheck')) {
-                enableCheckTask false
-            } else {
-                enableCheckTask true
-            }
+
+            enableCheckTask true
             javaCompileTasks << compileJava
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.roborio)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.raspbian)
@@ -146,11 +143,8 @@ model {
             } else {
                 baseName = nativeName + 'jni'
             }
-            if (project.hasProperty('skipJniCheck')) {
-                enableCheckTask false
-            } else {
-                enableCheckTask true
-            }
+
+            enableCheckTask true
             javaCompileTasks << compileJava
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.roborio)
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.raspbian)


### PR DESCRIPTION
This uses jelf now to parse the jni symbols.