### PR TITLE
Use base azure image for primary wpilib build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,7 @@ stages:
     pool:
       vmImage: 'Ubuntu 16.04'
 
-    container: wpilib2020
+    container: ubuntu
 
     steps:
       - task: Gradle@2
@@ -78,7 +78,6 @@ stages:
           publishJUnitResults: true
           testResultsFiles: '**/TEST-*.xml'
           tasks: 'build'
-          options: '-Pskiplinuxathena -Pskiplinuxraspbian'
           # checkStyleRunAnalysis: true
           # pmdRunAnalysis: true
 


### PR DESCRIPTION
This will ensure everything works with no flags, even without a rio or raspbian compiler