### PR TITLE
Remove wpi::ArrayRef std::initializer_list constructor

### DIFF
--- a/ntcore/src/main/native/include/networktables/NetworkTableEntry.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableEntry.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 
+#include <initializer_list>
 #include <memory>
 #include <string>
 #include <vector>
@@ -177,6 +178,23 @@ class NetworkTableEntry final {
   std::vector<int> GetBooleanArray(ArrayRef<int> defaultValue) const;
 
   /**
+   * Gets the entry's value as a boolean array. If the entry does not exist
+   * or is of different type, it will return the default value.
+   *
+   * @param defaultValue the value to be returned if no value is found
+   * @return the entry's value or the given default value
+   *
+   * @note This makes a copy of the array.  If the overhead of this is a
+   *       concern, use GetValue() instead.
+   *
+   * @note The returned array is std::vector<int> instead of std::vector<bool>
+   *       because std::vector<bool> is special-cased in C++.  0 is false, any
+   *       non-zero value is true.
+   */
+  std::vector<int> GetBooleanArray(
+      std::initializer_list<int> defaultValue) const;
+
+  /**
    * Gets the entry's value as a double array. If the entry does not exist
    * or is of different type, it will return the default value.
    *
@@ -187,6 +205,19 @@ class NetworkTableEntry final {
    *       concern, use GetValue() instead.
    */
   std::vector<double> GetDoubleArray(ArrayRef<double> defaultValue) const;
+
+  /**
+   * Gets the entry's value as a double array. If the entry does not exist
+   * or is of different type, it will return the default value.
+   *
+   * @param defaultValue the value to be returned if no value is found
+   * @return the entry's value or the given default value
+   *
+   * @note This makes a copy of the array.  If the overhead of this is a
+   *       concern, use GetValue() instead.
+   */
+  std::vector<double> GetDoubleArray(
+      std::initializer_list<double> defaultValue) const;
 
   /**
    * Gets the entry's value as a string array. If the entry does not exist
@@ -200,6 +231,19 @@ class NetworkTableEntry final {
    */
   std::vector<std::string> GetStringArray(
       ArrayRef<std::string> defaultValue) const;
+
+  /**
+   * Gets the entry's value as a string array. If the entry does not exist
+   * or is of different type, it will return the default value.
+   *
+   * @param defaultValue the value to be returned if no value is found
+   * @return the entry's value or the given default value
+   *
+   * @note This makes a copy of the array.  If the overhead of this is a
+   *       concern, use GetValue() instead.
+   */
+  std::vector<std::string> GetStringArray(
+      std::initializer_list<std::string> defaultValue) const;
 
   /**
    * Sets the entry's value if it does not exist.
@@ -255,6 +299,14 @@ class NetworkTableEntry final {
    * @param defaultValue the default value to set
    * @return False if the entry exists with a different type
    */
+  bool SetDefaultBooleanArray(std::initializer_list<int> defaultValue);
+
+  /**
+   * Sets the entry's value if it does not exist.
+   *
+   * @param defaultValue the default value to set
+   * @return False if the entry exists with a different type
+   */
   bool SetDefaultDoubleArray(ArrayRef<double> defaultValue);
 
   /**
@@ -263,7 +315,23 @@ class NetworkTableEntry final {
    * @param defaultValue the default value to set
    * @return False if the entry exists with a different type
    */
+  bool SetDefaultDoubleArray(std::initializer_list<double> defaultValue);
+
+  /**
+   * Sets the entry's value if it does not exist.
+   *
+   * @param defaultValue the default value to set
+   * @return False if the entry exists with a different type
+   */
   bool SetDefaultStringArray(ArrayRef<std::string> defaultValue);
+
+  /**
+   * Sets the entry's value if it does not exist.
+   *
+   * @param defaultValue the default value to set
+   * @return False if the entry exists with a different type
+   */
+  bool SetDefaultStringArray(std::initializer_list<std::string> defaultValue);
 
   /**
    * Sets the entry's value.
@@ -311,7 +379,31 @@ class NetworkTableEntry final {
    * @param value the value to set
    * @return False if the entry exists with a different type
    */
+  bool SetBooleanArray(ArrayRef<bool> value);
+
+  /**
+   * Sets the entry's value.
+   *
+   * @param value the value to set
+   * @return False if the entry exists with a different type
+   */
+  bool SetBooleanArray(std::initializer_list<bool> value);
+
+  /**
+   * Sets the entry's value.
+   *
+   * @param value the value to set
+   * @return False if the entry exists with a different type
+   */
   bool SetBooleanArray(ArrayRef<int> value);
+
+  /**
+   * Sets the entry's value.
+   *
+   * @param value the value to set
+   * @return False if the entry exists with a different type
+   */
+  bool SetBooleanArray(std::initializer_list<int> value);
 
   /**
    * Sets the entry's value.
@@ -327,7 +419,23 @@ class NetworkTableEntry final {
    * @param value the value to set
    * @return False if the entry exists with a different type
    */
+  bool SetDoubleArray(std::initializer_list<double> value);
+
+  /**
+   * Sets the entry's value.
+   *
+   * @param value the value to set
+   * @return False if the entry exists with a different type
+   */
   bool SetStringArray(ArrayRef<std::string> value);
+
+  /**
+   * Sets the entry's value.
+   *
+   * @param value the value to set
+   * @return False if the entry exists with a different type
+   */
+  bool SetStringArray(std::initializer_list<std::string> value);
 
   /**
    * Sets the entry's value.  If the value is of different type, the type is
@@ -375,7 +483,31 @@ class NetworkTableEntry final {
    *
    * @param value the value to set
    */
+  void ForceSetBooleanArray(ArrayRef<bool> value);
+
+  /**
+   * Sets the entry's value.  If the value is of different type, the type is
+   * changed to match the new value.
+   *
+   * @param value the value to set
+   */
+  void ForceSetBooleanArray(std::initializer_list<bool> value);
+
+  /**
+   * Sets the entry's value.  If the value is of different type, the type is
+   * changed to match the new value.
+   *
+   * @param value the value to set
+   */
   void ForceSetBooleanArray(ArrayRef<int> value);
+
+  /**
+   * Sets the entry's value.  If the value is of different type, the type is
+   * changed to match the new value.
+   *
+   * @param value the value to set
+   */
+  void ForceSetBooleanArray(std::initializer_list<int> value);
 
   /**
    * Sets the entry's value.  If the value is of different type, the type is
@@ -391,7 +523,23 @@ class NetworkTableEntry final {
    *
    * @param value the value to set
    */
+  void ForceSetDoubleArray(std::initializer_list<double> value);
+
+  /**
+   * Sets the entry's value.  If the value is of different type, the type is
+   * changed to match the new value.
+   *
+   * @param value the value to set
+   */
   void ForceSetStringArray(ArrayRef<std::string> value);
+
+  /**
+   * Sets the entry's value.  If the value is of different type, the type is
+   * changed to match the new value.
+   *
+   * @param value the value to set
+   */
+  void ForceSetStringArray(std::initializer_list<std::string> value);
 
   /**
    * Sets flags.

--- a/ntcore/src/main/native/include/networktables/NetworkTableEntry.inl
+++ b/ntcore/src/main/native/include/networktables/NetworkTableEntry.inl
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) FIRST 2017. All Rights Reserved.                             */
+/* Copyright (c) FIRST 2017-2019. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -76,6 +76,12 @@ inline std::vector<int> NetworkTableEntry::GetBooleanArray(
   return value->GetBooleanArray();
 }
 
+inline std::vector<int> NetworkTableEntry::GetBooleanArray(
+    std::initializer_list<int> defaultValue) const {
+  return GetBooleanArray(
+      wpi::makeArrayRef(defaultValue.begin(), defaultValue.end()));
+}
+
 inline std::vector<double> NetworkTableEntry::GetDoubleArray(
     ArrayRef<double> defaultValue) const {
   auto value = GetEntryValue(m_handle);
@@ -83,11 +89,23 @@ inline std::vector<double> NetworkTableEntry::GetDoubleArray(
   return value->GetDoubleArray();
 }
 
+inline std::vector<double> NetworkTableEntry::GetDoubleArray(
+    std::initializer_list<double> defaultValue) const {
+  return GetDoubleArray(
+      wpi::makeArrayRef(defaultValue.begin(), defaultValue.end()));
+}
+
 inline std::vector<std::string> NetworkTableEntry::GetStringArray(
     ArrayRef<std::string> defaultValue) const {
   auto value = GetEntryValue(m_handle);
   if (!value || value->type() != NT_STRING_ARRAY) return defaultValue;
   return value->GetStringArray();
+}
+
+inline std::vector<std::string> NetworkTableEntry::GetStringArray(
+    std::initializer_list<std::string> defaultValue) const {
+  return GetStringArray(
+      wpi::makeArrayRef(defaultValue.begin(), defaultValue.end()));
 }
 
 inline bool NetworkTableEntry::SetDefaultValue(std::shared_ptr<Value> value) {
@@ -145,7 +163,21 @@ inline bool NetworkTableEntry::SetRaw(StringRef value) {
   return SetEntryValue(m_handle, Value::MakeRaw(value));
 }
 
+inline bool NetworkTableEntry::SetBooleanArray(ArrayRef<bool> value) {
+  return SetEntryValue(m_handle, Value::MakeBooleanArray(value));
+}
+
+inline bool NetworkTableEntry::SetBooleanArray(
+    std::initializer_list<bool> value) {
+  return SetEntryValue(m_handle, Value::MakeBooleanArray(value));
+}
+
 inline bool NetworkTableEntry::SetBooleanArray(ArrayRef<int> value) {
+  return SetEntryValue(m_handle, Value::MakeBooleanArray(value));
+}
+
+inline bool NetworkTableEntry::SetBooleanArray(
+    std::initializer_list<int> value) {
   return SetEntryValue(m_handle, Value::MakeBooleanArray(value));
 }
 
@@ -153,7 +185,17 @@ inline bool NetworkTableEntry::SetDoubleArray(ArrayRef<double> value) {
   return SetEntryValue(m_handle, Value::MakeDoubleArray(value));
 }
 
+inline bool NetworkTableEntry::SetDoubleArray(
+    std::initializer_list<double> value) {
+  return SetEntryValue(m_handle, Value::MakeDoubleArray(value));
+}
+
 inline bool NetworkTableEntry::SetStringArray(ArrayRef<std::string> value) {
+  return SetEntryValue(m_handle, Value::MakeStringArray(value));
+}
+
+inline bool NetworkTableEntry::SetStringArray(
+    std::initializer_list<std::string> value) {
   return SetEntryValue(m_handle, Value::MakeStringArray(value));
 }
 
@@ -177,7 +219,21 @@ inline void NetworkTableEntry::ForceSetRaw(StringRef value) {
   SetEntryTypeValue(m_handle, Value::MakeRaw(value));
 }
 
+inline void NetworkTableEntry::ForceSetBooleanArray(ArrayRef<bool> value) {
+  SetEntryTypeValue(m_handle, Value::MakeBooleanArray(value));
+}
+
+inline void NetworkTableEntry::ForceSetBooleanArray(
+    std::initializer_list<bool> value) {
+  SetEntryTypeValue(m_handle, Value::MakeBooleanArray(value));
+}
+
 inline void NetworkTableEntry::ForceSetBooleanArray(ArrayRef<int> value) {
+  SetEntryTypeValue(m_handle, Value::MakeBooleanArray(value));
+}
+
+inline void NetworkTableEntry::ForceSetBooleanArray(
+    std::initializer_list<int> value) {
   SetEntryTypeValue(m_handle, Value::MakeBooleanArray(value));
 }
 
@@ -185,8 +241,18 @@ inline void NetworkTableEntry::ForceSetDoubleArray(ArrayRef<double> value) {
   SetEntryTypeValue(m_handle, Value::MakeDoubleArray(value));
 }
 
+inline void NetworkTableEntry::ForceSetDoubleArray(
+    std::initializer_list<double> value) {
+  SetEntryTypeValue(m_handle, Value::MakeDoubleArray(value));
+}
+
 inline void NetworkTableEntry::ForceSetStringArray(
     ArrayRef<std::string> value) {
+  SetEntryTypeValue(m_handle, Value::MakeStringArray(value));
+}
+
+inline void NetworkTableEntry::ForceSetStringArray(
+    std::initializer_list<std::string> value) {
   SetEntryTypeValue(m_handle, Value::MakeStringArray(value));
 }
 

--- a/ntcore/src/main/native/include/networktables/NetworkTableValue.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableValue.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include <cassert>
+#include <initializer_list>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -382,8 +383,36 @@ class Value final {
    *             time)
    * @return The entry value
    */
+  static std::shared_ptr<Value> MakeBooleanArray(
+      std::initializer_list<bool> value, uint64_t time = 0) {
+    return MakeBooleanArray(wpi::makeArrayRef(value.begin(), value.end()),
+                            time);
+  }
+
+  /**
+   * Creates a boolean array entry value.
+   *
+   * @param value the value
+   * @param time if nonzero, the creation time to use (instead of the current
+   *             time)
+   * @return The entry value
+   */
   static std::shared_ptr<Value> MakeBooleanArray(ArrayRef<int> value,
                                                  uint64_t time = 0);
+
+  /**
+   * Creates a boolean array entry value.
+   *
+   * @param value the value
+   * @param time if nonzero, the creation time to use (instead of the current
+   *             time)
+   * @return The entry value
+   */
+  static std::shared_ptr<Value> MakeBooleanArray(
+      std::initializer_list<int> value, uint64_t time = 0) {
+    return MakeBooleanArray(wpi::makeArrayRef(value.begin(), value.end()),
+                            time);
+  }
 
   /**
    * Creates a double array entry value.
@@ -397,6 +426,19 @@ class Value final {
                                                 uint64_t time = 0);
 
   /**
+   * Creates a double array entry value.
+   *
+   * @param value the value
+   * @param time if nonzero, the creation time to use (instead of the current
+   *             time)
+   * @return The entry value
+   */
+  static std::shared_ptr<Value> MakeDoubleArray(
+      std::initializer_list<double> value, uint64_t time = 0) {
+    return MakeDoubleArray(wpi::makeArrayRef(value.begin(), value.end()), time);
+  }
+
+  /**
    * Creates a string array entry value.
    *
    * @param value the value
@@ -406,6 +448,19 @@ class Value final {
    */
   static std::shared_ptr<Value> MakeStringArray(ArrayRef<std::string> value,
                                                 uint64_t time = 0);
+
+  /**
+   * Creates a string array entry value.
+   *
+   * @param value the value
+   * @param time if nonzero, the creation time to use (instead of the current
+   *             time)
+   * @return The entry value
+   */
+  static std::shared_ptr<Value> MakeStringArray(
+      std::initializer_list<std::string> value, uint64_t time = 0) {
+    return MakeStringArray(wpi::makeArrayRef(value.begin(), value.end()), time);
+  }
 
   /**
    * Creates a string array entry value.

--- a/wpilibc/src/main/native/cpp/LinearFilter.cpp
+++ b/wpilibc/src/main/native/cpp/LinearFilter.cpp
@@ -26,8 +26,7 @@ LinearFilter LinearFilter::SinglePoleIIR(double timeConstant, double period) {
 
 LinearFilter LinearFilter::HighPass(double timeConstant, double period) {
   double gain = std::exp(-period / timeConstant);
-  const double ffGains[] = {gain, -gain};
-  return LinearFilter(ffGains, -gain);
+  return LinearFilter({gain, -gain}, {-gain});
 }
 
 LinearFilter LinearFilter::MovingAverage(int taps) {

--- a/wpilibc/src/main/native/cpp/filters/LinearDigitalFilter.cpp
+++ b/wpilibc/src/main/native/cpp/filters/LinearDigitalFilter.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2015-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2015-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -27,6 +27,13 @@ LinearDigitalFilter::LinearDigitalFilter(PIDSource& source,
   HAL_Report(HALUsageReporting::kResourceType_LinearFilter, instances);
 }
 
+LinearDigitalFilter::LinearDigitalFilter(PIDSource& source,
+                                         std::initializer_list<double> ffGains,
+                                         std::initializer_list<double> fbGains)
+    : LinearDigitalFilter(source,
+                          wpi::makeArrayRef(ffGains.begin(), ffGains.end()),
+                          wpi::makeArrayRef(fbGains.begin(), fbGains.end())) {}
+
 LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
                                          wpi::ArrayRef<double> ffGains,
                                          wpi::ArrayRef<double> fbGains)
@@ -39,6 +46,13 @@ LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
   instances++;
   HAL_Report(HALUsageReporting::kResourceType_LinearFilter, instances);
 }
+
+LinearDigitalFilter::LinearDigitalFilter(std::shared_ptr<PIDSource> source,
+                                         std::initializer_list<double> ffGains,
+                                         std::initializer_list<double> fbGains)
+    : LinearDigitalFilter(source,
+                          wpi::makeArrayRef(ffGains.begin(), ffGains.end()),
+                          wpi::makeArrayRef(fbGains.begin(), fbGains.end())) {}
 
 LinearDigitalFilter LinearDigitalFilter::SinglePoleIIR(PIDSource& source,
                                                        double timeConstant,

--- a/wpilibc/src/main/native/cpp/shuffleboard/RecordingController.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/RecordingController.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -44,7 +44,6 @@ void RecordingController::AddEventMarker(
     DriverStation::ReportError("Shuffleboard event name was not specified");
     return;
   }
-  auto arr = wpi::ArrayRef<std::string>{
-      description, ShuffleboardEventImportanceName(importance)};
-  m_eventsTable->GetSubTable(name)->GetEntry("Info").SetStringArray(arr);
+  m_eventsTable->GetSubTable(name)->GetEntry("Info").SetStringArray(
+      {description, ShuffleboardEventImportanceName(importance)});
 }

--- a/wpilibc/src/main/native/include/frc/LinearFilter.h
+++ b/wpilibc/src/main/native/include/frc/LinearFilter.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <initializer_list>
 #include <vector>
 
 #include <wpi/ArrayRef.h>
@@ -74,6 +75,17 @@ class LinearFilter {
    * @param fbGains The "feed back" or IIR gains.
    */
   LinearFilter(wpi::ArrayRef<double> ffGains, wpi::ArrayRef<double> fbGains);
+
+  /**
+   * Create a linear FIR or IIR filter.
+   *
+   * @param ffGains The "feed forward" or FIR gains.
+   * @param fbGains The "feed back" or IIR gains.
+   */
+  LinearFilter(std::initializer_list<double> ffGains,
+               std::initializer_list<double> fbGains)
+      : LinearFilter(wpi::makeArrayRef(ffGains.begin(), ffGains.end()),
+                     wpi::makeArrayRef(fbGains.begin(), fbGains.end())) {}
 
   LinearFilter(LinearFilter&&) = default;
   LinearFilter& operator=(LinearFilter&&) = default;

--- a/wpilibc/src/main/native/include/frc/filters/LinearDigitalFilter.h
+++ b/wpilibc/src/main/native/include/frc/filters/LinearDigitalFilter.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <initializer_list>
 #include <memory>
 #include <vector>
 
@@ -89,9 +90,32 @@ class LinearDigitalFilter : public Filter {
    * @param fbGains The "feed back" or IIR gains
    */
   WPI_DEPRECATED("Use LinearFilter class instead.")
+  LinearDigitalFilter(PIDSource& source, std::initializer_list<double> ffGains,
+                      std::initializer_list<double> fbGains);
+
+  /**
+   * Create a linear FIR or IIR filter.
+   *
+   * @param source  The PIDSource object that is used to get values
+   * @param ffGains The "feed forward" or FIR gains
+   * @param fbGains The "feed back" or IIR gains
+   */
+  WPI_DEPRECATED("Use LinearFilter class instead.")
   LinearDigitalFilter(std::shared_ptr<PIDSource> source,
                       wpi::ArrayRef<double> ffGains,
                       wpi::ArrayRef<double> fbGains);
+
+  /**
+   * Create a linear FIR or IIR filter.
+   *
+   * @param source  The PIDSource object that is used to get values
+   * @param ffGains The "feed forward" or FIR gains
+   * @param fbGains The "feed back" or IIR gains
+   */
+  WPI_DEPRECATED("Use LinearFilter class instead.")
+  LinearDigitalFilter(std::shared_ptr<PIDSource> source,
+                      std::initializer_list<double> ffGains,
+                      std::initializer_list<double> fbGains);
 
   LinearDigitalFilter(LinearDigitalFilter&&) = default;
   LinearDigitalFilter& operator=(LinearDigitalFilter&&) = default;

--- a/wpiutil/src/main/native/cpp/WebSocket.cpp
+++ b/wpiutil/src/main/native/cpp/WebSocket.cpp
@@ -286,8 +286,9 @@ void WebSocket::SendClose(uint16_t code, const Twine& reason) {
   SmallVector<uv::Buffer, 4> bufs;
   if (code != 1005) {
     raw_uv_ostream os{bufs, 4096};
-    os << ArrayRef<uint8_t>{static_cast<uint8_t>((code >> 8) & 0xff),
-                            static_cast<uint8_t>(code & 0xff)};
+    const uint8_t codeMsb[] = {static_cast<uint8_t>((code >> 8) & 0xff),
+                               static_cast<uint8_t>(code & 0xff)};
+    os << ArrayRef<uint8_t>(codeMsb);
     reason.print(os);
   }
   Send(kFlagFin | kOpClose, bufs, [](auto bufs, uv::Error) {
@@ -520,18 +521,20 @@ void WebSocket::Send(
     os << static_cast<unsigned char>((m_server ? 0x00 : kFlagMasking) | size);
   } else if (size <= 0xffff) {
     os << static_cast<unsigned char>((m_server ? 0x00 : kFlagMasking) | 126);
-    os << ArrayRef<uint8_t>{static_cast<uint8_t>((size >> 8) & 0xff),
-                            static_cast<uint8_t>(size & 0xff)};
+    const uint8_t sizeMsb[] = {static_cast<uint8_t>((size >> 8) & 0xff),
+                               static_cast<uint8_t>(size & 0xff)};
+    os << ArrayRef<uint8_t>(sizeMsb);
   } else {
     os << static_cast<unsigned char>((m_server ? 0x00 : kFlagMasking) | 127);
-    os << ArrayRef<uint8_t>{static_cast<uint8_t>((size >> 56) & 0xff),
-                            static_cast<uint8_t>((size >> 48) & 0xff),
-                            static_cast<uint8_t>((size >> 40) & 0xff),
-                            static_cast<uint8_t>((size >> 32) & 0xff),
-                            static_cast<uint8_t>((size >> 24) & 0xff),
-                            static_cast<uint8_t>((size >> 16) & 0xff),
-                            static_cast<uint8_t>((size >> 8) & 0xff),
-                            static_cast<uint8_t>(size & 0xff)};
+    const uint8_t sizeMsb[] = {static_cast<uint8_t>((size >> 56) & 0xff),
+                               static_cast<uint8_t>((size >> 48) & 0xff),
+                               static_cast<uint8_t>((size >> 40) & 0xff),
+                               static_cast<uint8_t>((size >> 32) & 0xff),
+                               static_cast<uint8_t>((size >> 24) & 0xff),
+                               static_cast<uint8_t>((size >> 16) & 0xff),
+                               static_cast<uint8_t>((size >> 8) & 0xff),
+                               static_cast<uint8_t>(size & 0xff)};
+    os << ArrayRef<uint8_t>(sizeMsb);
   }
 
   // clients need to mask the input data

--- a/wpiutil/src/main/native/include/wpi/ArrayRef.h
+++ b/wpiutil/src/main/native/include/wpi/ArrayRef.h
@@ -98,11 +98,6 @@ namespace wpi {
     template <size_t N>
     /*implicit*/ constexpr ArrayRef(const T (&Arr)[N]) : Data(Arr), Length(N) {}
 
-    /// Construct an ArrayRef from a std::initializer_list.
-    /*implicit*/ ArrayRef(const std::initializer_list<T> &Vec)
-    : Data(Vec.begin() == Vec.end() ? (T*)nullptr : Vec.begin()),
-      Length(Vec.size()) {}
-
     /// Construct an ArrayRef<const T*> from ArrayRef<T*>. This uses SFINAE to
     /// ensure that only ArrayRefs of pointers can be converted.
     template <typename U>

--- a/wpiutil/src/main/native/include/wpi/WebSocket.h
+++ b/wpiutil/src/main/native/include/wpi/WebSocket.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include <functional>
+#include <initializer_list>
 #include <memory>
 #include <string>
 #include <utility>
@@ -98,6 +99,25 @@ class WebSocket : public std::enable_shared_from_this<WebSocket> {
       uv::Stream& stream, const Twine& uri, const Twine& host,
       ArrayRef<StringRef> protocols = ArrayRef<StringRef>{},
       const ClientOptions& options = ClientOptions{});
+
+  /**
+   * Starts a client connection by performing the initial client handshake.
+   * An open event is emitted when the handshake completes.
+   * This sets the stream user data to the websocket.
+   * @param stream Connection stream
+   * @param uri The Request-URI to send
+   * @param host The host or host:port to send
+   * @param protocols The list of subprotocols
+   * @param options Handshake options
+   */
+  static std::shared_ptr<WebSocket> CreateClient(
+      uv::Stream& stream, const Twine& uri, const Twine& host,
+      std::initializer_list<StringRef> protocols,
+      const ClientOptions& options = ClientOptions{}) {
+    return CreateClient(stream, uri, host,
+                        makeArrayRef(protocols.begin(), protocols.end()),
+                        options);
+  }
 
   /**
    * Starts a server connection by performing the initial server side handshake.

--- a/wpiutil/src/main/native/include/wpi/WebSocketServer.h
+++ b/wpiutil/src/main/native/include/wpi/WebSocketServer.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -9,6 +9,7 @@
 #define WPIUTIL_WPI_WEBSOCKETSERVER_H_
 
 #include <functional>
+#include <initializer_list>
 #include <memory>
 #include <string>
 #include <utility>
@@ -55,6 +56,20 @@ class WebSocketServerHelper {
    *         is empty.
    */
   std::pair<bool, StringRef> MatchProtocol(ArrayRef<StringRef> protocols);
+
+  /**
+   * Try to find a match to the list of sub-protocols provided by the client.
+   * The list is priority ordered, so the first match wins.
+   * Only valid during and after the upgrade event.
+   * @param protocols Acceptable protocols
+   * @return Pair; first item is true if a match was made, false if not.
+   *         Second item is the matched protocol if a match was made, otherwise
+   *         is empty.
+   */
+  std::pair<bool, StringRef> MatchProtocol(
+      std::initializer_list<StringRef> protocols) {
+    return MatchProtocol(makeArrayRef(protocols.begin(), protocols.end()));
+  }
 
   /**
    * Accept the upgrade.  Disconnect other readers (such as the HttpParser
@@ -124,6 +139,22 @@ class WebSocketServer : public std::enable_shared_from_this<WebSocketServer> {
   static std::shared_ptr<WebSocketServer> Create(
       uv::Stream& stream, ArrayRef<StringRef> protocols = ArrayRef<StringRef>{},
       const ServerOptions& options = ServerOptions{});
+
+  /**
+   * Starts a dedicated WebSocket server on the provided connection.  The
+   * connection should be an accepted client stream.
+   * This also sets the stream user data to the socket server.
+   * A connected event is emitted when the connection is opened.
+   * @param stream Connection stream
+   * @param protocols Acceptable subprotocols
+   * @param options Handshake options
+   */
+  static std::shared_ptr<WebSocketServer> Create(
+      uv::Stream& stream, std::initializer_list<StringRef> protocols,
+      const ServerOptions& options = ServerOptions{}) {
+    return Create(stream, makeArrayRef(protocols.begin(), protocols.end()),
+                  options);
+  }
 
   /**
    * Connected event.  First parameter is the URL, second is the websocket.

--- a/wpiutil/src/netconsoleServer/native/cpp/main.cpp
+++ b/wpiutil/src/netconsoleServer/native/cpp/main.cpp
@@ -48,14 +48,16 @@ static bool NewlineBuffer(std::string& rem, uv::Buffer& buf, size_t len,
     // Header is 2 byte len, 1 byte type, 4 byte timestamp, 2 byte sequence num
     uint32_t ts = wpi::FloatToBits((wpi::Now() - startTime) * 1.0e-6);
     uint16_t len = rem.size() + toCopy.size() + 1 + 4 + 2;
-    out << wpi::ArrayRef<uint8_t>({static_cast<uint8_t>((len >> 8) & 0xff),
-                                   static_cast<uint8_t>(len & 0xff), 12,
-                                   static_cast<uint8_t>((ts >> 24) & 0xff),
-                                   static_cast<uint8_t>((ts >> 16) & 0xff),
-                                   static_cast<uint8_t>((ts >> 8) & 0xff),
-                                   static_cast<uint8_t>(ts & 0xff),
-                                   static_cast<uint8_t>((tcpSeq >> 8) & 0xff),
-                                   static_cast<uint8_t>(tcpSeq & 0xff)});
+    const uint8_t header[] = {static_cast<uint8_t>((len >> 8) & 0xff),
+                              static_cast<uint8_t>(len & 0xff),
+                              12,
+                              static_cast<uint8_t>((ts >> 24) & 0xff),
+                              static_cast<uint8_t>((ts >> 16) & 0xff),
+                              static_cast<uint8_t>((ts >> 8) & 0xff),
+                              static_cast<uint8_t>(ts & 0xff),
+                              static_cast<uint8_t>((tcpSeq >> 8) & 0xff),
+                              static_cast<uint8_t>(tcpSeq & 0xff)};
+    out << wpi::ArrayRef<uint8_t>(header);
   }
   out << rem << toCopy;
 

--- a/wpiutil/src/netconsoleTee/native/cpp/main.cpp
+++ b/wpiutil/src/netconsoleTee/native/cpp/main.cpp
@@ -39,14 +39,16 @@ static bool NewlineBuffer(std::string& rem, uv::Buffer& buf, size_t len,
     // Header is 2 byte len, 1 byte type, 4 byte timestamp, 2 byte sequence num
     uint32_t ts = wpi::FloatToBits((wpi::Now() - startTime) * 1.0e-6);
     uint16_t len = rem.size() + toCopy.size() + 1 + 4 + 2;
-    out << wpi::ArrayRef<uint8_t>({static_cast<uint8_t>((len >> 8) & 0xff),
-                                   static_cast<uint8_t>(len & 0xff), 12,
-                                   static_cast<uint8_t>((ts >> 24) & 0xff),
-                                   static_cast<uint8_t>((ts >> 16) & 0xff),
-                                   static_cast<uint8_t>((ts >> 8) & 0xff),
-                                   static_cast<uint8_t>(ts & 0xff),
-                                   static_cast<uint8_t>((tcpSeq >> 8) & 0xff),
-                                   static_cast<uint8_t>(tcpSeq & 0xff)});
+    const uint8_t header[] = {static_cast<uint8_t>((len >> 8) & 0xff),
+                              static_cast<uint8_t>(len & 0xff),
+                              12,
+                              static_cast<uint8_t>((ts >> 24) & 0xff),
+                              static_cast<uint8_t>((ts >> 16) & 0xff),
+                              static_cast<uint8_t>((ts >> 8) & 0xff),
+                              static_cast<uint8_t>(ts & 0xff),
+                              static_cast<uint8_t>((tcpSeq >> 8) & 0xff),
+                              static_cast<uint8_t>(tcpSeq & 0xff)};
+    out << wpi::ArrayRef<uint8_t>(header);
   }
   out << rem << toCopy;
 

--- a/wpiutil/src/test/native/cpp/WebSocketClientTest.cpp
+++ b/wpiutil/src/test/native/cpp/WebSocketClientTest.cpp
@@ -135,9 +135,8 @@ TEST_F(WebSocketClientTest, ProtocolGood) {
   mockProtocol = "myProtocol";
 
   clientPipe->Connect(pipeName, [&] {
-    auto ws = WebSocket::CreateClient(
-        *clientPipe, "/test", pipeName,
-        ArrayRef<StringRef>{"myProtocol", "myProtocol2"});
+    auto ws = WebSocket::CreateClient(*clientPipe, "/test", pipeName,
+                                      {"myProtocol", "myProtocol2"});
     ws->closed.connect([&](uint16_t code, StringRef msg) {
       Finish();
       if (code != 1005 && code != 1006)

--- a/wpiutil/src/test/native/cpp/WebSocketServerTest.cpp
+++ b/wpiutil/src/test/native/cpp/WebSocketServerTest.cpp
@@ -141,14 +141,15 @@ TEST_F(WebSocketServerTest, CloseCode) {
     });
   };
   // need to respond with close for server to finish shutdown
-  auto message = BuildMessage(0x08, true, true, {0x03u, 0xe8u});
+  const uint8_t contents[] = {0x03u, 0xe8u};
+  auto message = BuildMessage(0x08, true, true, contents);
   handleData = [&](StringRef) {
     clientPipe->Write(uv::Buffer(message), [&](auto bufs, uv::Error) {});
   };
 
   loop->Run();
 
-  auto expectData = BuildMessage(0x08, true, false, {0x03u, 0xe8u});
+  auto expectData = BuildMessage(0x08, true, false, contents);
   ASSERT_EQ(wireData, expectData);
   ASSERT_EQ(gotClosed, 1);
 }
@@ -164,16 +165,15 @@ TEST_F(WebSocketServerTest, CloseReason) {
     });
   };
   // need to respond with close for server to finish shutdown
-  auto message = BuildMessage(0x08, true, true,
-                              {0x03u, 0xe8u, 'h', 'a', 'n', 'g', 'u', 'p'});
+  const uint8_t contents[] = {0x03u, 0xe8u, 'h', 'a', 'n', 'g', 'u', 'p'};
+  auto message = BuildMessage(0x08, true, true, contents);
   handleData = [&](StringRef) {
     clientPipe->Write(uv::Buffer(message), [&](auto bufs, uv::Error) {});
   };
 
   loop->Run();
 
-  auto expectData = BuildMessage(0x08, true, false,
-                                 {0x03u, 0xe8u, 'h', 'a', 'n', 'g', 'u', 'p'});
+  auto expectData = BuildMessage(0x08, true, false, contents);
   ASSERT_EQ(wireData, expectData);
   ASSERT_EQ(gotClosed, 1);
 }
@@ -211,7 +211,8 @@ TEST_F(WebSocketServerTest, ReceiveCloseCode) {
       ASSERT_EQ(code, 1000) << "reason: " << reason;
     });
   };
-  auto message = BuildMessage(0x08, true, true, {0x03u, 0xe8u});
+  const uint8_t contents[] = {0x03u, 0xe8u};
+  auto message = BuildMessage(0x08, true, true, contents);
   resp.headersComplete.connect([&](bool) {
     clientPipe->Write(uv::Buffer(message), [&](auto bufs, uv::Error) {});
   });
@@ -219,7 +220,7 @@ TEST_F(WebSocketServerTest, ReceiveCloseCode) {
   loop->Run();
 
   // the endpoint should echo the message
-  auto expectData = BuildMessage(0x08, true, false, {0x03u, 0xe8u});
+  auto expectData = BuildMessage(0x08, true, false, contents);
   ASSERT_EQ(wireData, expectData);
   ASSERT_EQ(gotClosed, 1);
 }
@@ -233,8 +234,8 @@ TEST_F(WebSocketServerTest, ReceiveCloseReason) {
       ASSERT_EQ(reason, "hangup");
     });
   };
-  auto message = BuildMessage(0x08, true, true,
-                              {0x03u, 0xe8u, 'h', 'a', 'n', 'g', 'u', 'p'});
+  const uint8_t contents[] = {0x03u, 0xe8u, 'h', 'a', 'n', 'g', 'u', 'p'};
+  auto message = BuildMessage(0x08, true, true, contents);
   resp.headersComplete.connect([&](bool) {
     clientPipe->Write(uv::Buffer(message), [&](auto bufs, uv::Error) {});
   });
@@ -242,8 +243,7 @@ TEST_F(WebSocketServerTest, ReceiveCloseReason) {
   loop->Run();
 
   // the endpoint should echo the message
-  auto expectData = BuildMessage(0x08, true, false,
-                                 {0x03u, 0xe8u, 'h', 'a', 'n', 'g', 'u', 'p'});
+  auto expectData = BuildMessage(0x08, true, false, contents);
   ASSERT_EQ(wireData, expectData);
   ASSERT_EQ(gotClosed, 1);
 }


### PR DESCRIPTION
This can be dangerous as it refers to a temporary, and GCC 9.0 warns about
its use.  Instead add std::initializer_list overloads to common places it
was used in an initializer_list sense.