### PR TITLE
Remove pre-C++17 shims

### DIFF
--- a/cscore/src/main/native/cpp/ConfigurableSourceImpl.cpp
+++ b/cscore/src/main/native/cpp/ConfigurableSourceImpl.cpp
@@ -64,7 +64,7 @@ int ConfigurableSourceImpl::CreateProperty(const wpi::Twine& name,
   std::lock_guard<wpi::mutex> lock(m_mutex);
   int ndx = CreateOrUpdateProperty(name,
                                    [=] {
-                                     return wpi::make_unique<PropertyImpl>(
+                                     return std::make_unique<PropertyImpl>(
                                          name, kind, minimum, maximum, step,
                                          defaultValue, value);
                                    },

--- a/cscore/src/main/native/cpp/HttpCameraImpl.cpp
+++ b/cscore/src/main/native/cpp/HttpCameraImpl.cpp
@@ -8,7 +8,6 @@
 #include "HttpCameraImpl.h"
 
 #include <wpi/MemAlloc.h>
-#include <wpi/STLExtras.h>
 #include <wpi/TCPConnector.h>
 #include <wpi/timestamp.h>
 
@@ -149,7 +148,7 @@ wpi::HttpConnection* HttpCameraImpl::DeviceStreamConnect(
 
   if (!m_active || !stream) return nullptr;
 
-  auto connPtr = wpi::make_unique<wpi::HttpConnection>(std::move(stream), 1);
+  auto connPtr = std::make_unique<wpi::HttpConnection>(std::move(stream), 1);
   wpi::HttpConnection* conn = connPtr.get();
 
   // update m_streamConn
@@ -322,7 +321,7 @@ void HttpCameraImpl::DeviceSendSettings(wpi::HttpRequest& req) {
 
   if (!m_active || !stream) return;
 
-  auto connPtr = wpi::make_unique<wpi::HttpConnection>(std::move(stream), 1);
+  auto connPtr = std::make_unique<wpi::HttpConnection>(std::move(stream), 1);
   wpi::HttpConnection* conn = connPtr.get();
 
   // update m_settingsConn
@@ -377,7 +376,7 @@ void HttpCameraImpl::CreateProperty(const wpi::Twine& name,
                                     int minimum, int maximum, int step,
                                     int defaultValue, int value) const {
   std::lock_guard<wpi::mutex> lock(m_mutex);
-  m_propertyData.emplace_back(wpi::make_unique<PropertyData>(
+  m_propertyData.emplace_back(std::make_unique<PropertyData>(
       name, httpParam, viaSettings, kind, minimum, maximum, step, defaultValue,
       value));
 
@@ -391,7 +390,7 @@ void HttpCameraImpl::CreateEnumProperty(
     const wpi::Twine& name, const wpi::Twine& httpParam, bool viaSettings,
     int defaultValue, int value, std::initializer_list<T> choices) const {
   std::lock_guard<wpi::mutex> lock(m_mutex);
-  m_propertyData.emplace_back(wpi::make_unique<PropertyData>(
+  m_propertyData.emplace_back(std::make_unique<PropertyData>(
       name, httpParam, viaSettings, CS_PROP_ENUM, 0, choices.size() - 1, 1,
       defaultValue, value));
 
@@ -409,7 +408,7 @@ void HttpCameraImpl::CreateEnumProperty(
 
 std::unique_ptr<PropertyImpl> HttpCameraImpl::CreateEmptyProperty(
     const wpi::Twine& name) const {
-  return wpi::make_unique<PropertyData>(name);
+  return std::make_unique<PropertyData>(name);
 }
 
 bool HttpCameraImpl::CacheProperties(CS_Status* status) const {

--- a/cscore/src/main/native/cpp/PropertyContainer.cpp
+++ b/cscore/src/main/native/cpp/PropertyContainer.cpp
@@ -201,7 +201,7 @@ std::vector<std::string> PropertyContainer::GetEnumPropertyChoices(
 
 std::unique_ptr<PropertyImpl> PropertyContainer::CreateEmptyProperty(
     const wpi::Twine& name) const {
-  return wpi::make_unique<PropertyImpl>(name);
+  return std::make_unique<PropertyImpl>(name);
 }
 
 bool PropertyContainer::CacheProperties(CS_Status* status) const {

--- a/cscore/src/main/native/cpp/SourceImpl.cpp
+++ b/cscore/src/main/native/cpp/SourceImpl.cpp
@@ -10,7 +10,6 @@
 #include <algorithm>
 #include <cstring>
 
-#include <wpi/STLExtras.h>
 #include <wpi/json.h>
 #include <wpi/timestamp.h>
 
@@ -514,7 +513,7 @@ void SourceImpl::ReleaseImage(std::unique_ptr<Image> image) {
 std::unique_ptr<Frame::Impl> SourceImpl::AllocFrameImpl() {
   std::lock_guard<wpi::mutex> lock{m_poolMutex};
 
-  if (m_framesAvail.empty()) return wpi::make_unique<Frame::Impl>(*this);
+  if (m_framesAvail.empty()) return std::make_unique<Frame::Impl>(*this);
 
   auto impl = std::move(m_framesAvail.back());
   m_framesAvail.pop_back();

--- a/cscore/src/main/native/linux/UsbCameraImpl.cpp
+++ b/cscore/src/main/native/linux/UsbCameraImpl.cpp
@@ -907,7 +907,7 @@ void UsbCameraImpl::DeviceCacheProperty(
   std::unique_ptr<UsbCameraProperty> perProp;
   if (IsPercentageProperty(rawProp->name)) {
     perProp =
-        wpi::make_unique<UsbCameraProperty>(rawProp->name, 0, *rawProp, 0, 0);
+        std::make_unique<UsbCameraProperty>(rawProp->name, 0, *rawProp, 0, 0);
     rawProp->name = "raw_" + perProp->name;
   }
 
@@ -1130,7 +1130,7 @@ void UsbCameraImpl::Send(Message&& msg) const {
 
 std::unique_ptr<PropertyImpl> UsbCameraImpl::CreateEmptyProperty(
     const wpi::Twine& name) const {
-  return wpi::make_unique<UsbCameraProperty>(name);
+  return std::make_unique<UsbCameraProperty>(name);
 }
 
 bool UsbCameraImpl::CacheProperties(CS_Status* status) const {

--- a/cscore/src/main/native/linux/UsbCameraProperty.cpp
+++ b/cscore/src/main/native/linux/UsbCameraProperty.cpp
@@ -7,7 +7,6 @@
 
 #include "UsbCameraProperty.h"
 
-#include <wpi/STLExtras.h>
 #include <wpi/SmallString.h>
 #include <wpi/raw_ostream.h>
 
@@ -224,7 +223,7 @@ std::unique_ptr<UsbCameraProperty> UsbCameraProperty::DeviceQuery(int fd,
     *id = qc_ext.id;  // copy back
     // We don't support array types
     if (qc_ext.elems > 1 || qc_ext.nr_of_dims > 0) return nullptr;
-    prop = wpi::make_unique<UsbCameraProperty>(qc_ext);
+    prop = std::make_unique<UsbCameraProperty>(qc_ext);
   }
 #endif
   if (!prop) {
@@ -235,7 +234,7 @@ std::unique_ptr<UsbCameraProperty> UsbCameraProperty::DeviceQuery(int fd,
     rc = TryIoctl(fd, VIDIOC_QUERYCTRL, &qc);
     *id = qc.id;  // copy back
     if (rc != 0) return nullptr;
-    prop = wpi::make_unique<UsbCameraProperty>(qc);
+    prop = std::make_unique<UsbCameraProperty>(qc);
   }
 
   // Cache enum property choices

--- a/cscore/src/main/native/windows/UsbCameraImpl.cpp
+++ b/cscore/src/main/native/windows/UsbCameraImpl.cpp
@@ -595,7 +595,7 @@ void UsbCameraImpl::DeviceCacheProperty(
   std::unique_ptr<UsbCameraProperty> perProp;
   if (IsPercentageProperty(rawProp->name)) {
     perProp =
-        wpi::make_unique<UsbCameraProperty>(rawProp->name, 0, *rawProp, 0, 0);
+        std::make_unique<UsbCameraProperty>(rawProp->name, 0, *rawProp, 0, 0);
     rawProp->name = "raw_" + perProp->name;
   }
 

--- a/wpiutil/src/main/native/cpp/llvm/Error.cpp
+++ b/wpiutil/src/main/native/cpp/llvm/Error.cpp
@@ -88,7 +88,7 @@ std::error_code FileError::convertToErrorCode() const {
 Error errorCodeToError(std::error_code EC) {
   if (!EC)
     return Error::success();
-  return Error(wpi::make_unique<ECError>(ECError(EC)));
+  return Error(std::make_unique<ECError>(ECError(EC)));
 }
 
 std::error_code errorToErrorCode(Error Err) {

--- a/wpiutil/src/main/native/include/wpi/Error.h
+++ b/wpiutil/src/main/native/include/wpi/Error.h
@@ -298,7 +298,7 @@ inline ErrorSuccess Error::success() { return ErrorSuccess(); }
 /// Make a Error instance representing failure using the given error info
 /// type.
 template <typename ErrT, typename... ArgTs> Error make_error(ArgTs &&... Args) {
-  return Error(wpi::make_unique<ErrT>(std::forward<ArgTs>(Args)...));
+  return Error(std::make_unique<ErrT>(std::forward<ArgTs>(Args)...));
 }
 
 /// Base class for user error types. Users should declare their error types

--- a/wpiutil/src/main/native/include/wpi/Format.h
+++ b/wpiutil/src/main/native/include/wpi/Format.h
@@ -24,13 +24,13 @@
 #define WPIUTIL_WPI_FORMAT_H
 
 #include "wpi/ArrayRef.h"
-#include "wpi/STLExtras.h"
 #include "wpi/StringRef.h"
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
 #include <optional>
 #include <tuple>
+#include <utility>
 
 namespace wpi {
 
@@ -93,7 +93,7 @@ class format_object final : public format_object_base {
 
   template <std::size_t... Is>
   int snprint_tuple(char *Buffer, unsigned BufferSize,
-                    index_sequence<Is...>) const {
+                    std::index_sequence<Is...>) const {
 #ifdef _MSC_VER
     return _snprintf_s(Buffer, BufferSize, BufferSize, Fmt, std::get<Is>(Vals)...);
 #else
@@ -115,7 +115,7 @@ public:
   }
 
   int snprint(char *Buffer, unsigned BufferSize) const override {
-    return snprint_tuple(Buffer, BufferSize, index_sequence_for<Ts...>());
+    return snprint_tuple(Buffer, BufferSize, std::index_sequence_for<Ts...>());
   }
 };
 

--- a/wpiutil/src/main/native/include/wpi/WorkerThread.h
+++ b/wpiutil/src/main/native/include/wpi/WorkerThread.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -14,7 +14,6 @@
 #include <utility>
 #include <vector>
 
-#include "wpi/STLExtras.h"
 #include "wpi/SafeThread.h"
 #include "wpi/future.h"
 #include "wpi/uv/Async.h"
@@ -107,7 +106,7 @@ class WorkerThreadThread : public SafeThread {
 template <typename R, typename... T>
 void RunWorkerThreadRequest(WorkerThreadThread<R, T...>& thr,
                             WorkerThreadRequest<R, T...>& req) {
-  R result = apply_tuple(req.work, std::move(req.params));
+  R result = std::apply(req.work, std::move(req.params));
   if (req.afterWork) {
     if (auto async = thr.m_async.m_async.lock())
       async->Send(std::move(req.afterWork), std::move(result));
@@ -119,7 +118,7 @@ void RunWorkerThreadRequest(WorkerThreadThread<R, T...>& thr,
 template <typename... T>
 void RunWorkerThreadRequest(WorkerThreadThread<void, T...>& thr,
                             WorkerThreadRequest<void, T...>& req) {
-  apply_tuple(req.work, req.params);
+  std::apply(req.work, req.params);
   if (req.afterWork) {
     if (auto async = thr.m_async.m_async.lock())
       async->Send(std::move(req.afterWork));

--- a/wpiutil/src/main/native/include/wpi/deprecated.h
+++ b/wpiutil/src/main/native/include/wpi/deprecated.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2015-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2015-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -8,26 +8,8 @@
 #ifndef WPIUTIL_WPI_DEPRECATED_H_
 #define WPIUTIL_WPI_DEPRECATED_H_
 
-// [[deprecated(msg)]] is a C++14 feature not supported by MSVC or GCC < 4.9.
-// We provide an equivalent warning implementation for those compilers here.
 #ifndef WPI_DEPRECATED
-#if defined(_MSC_VER)
-#define WPI_DEPRECATED(msg) __declspec(deprecated(msg))
-#elif defined(__GNUC__)
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 8)
-#if __cplusplus > 201103L
 #define WPI_DEPRECATED(msg) [[deprecated(msg)]]
-#else
-#define WPI_DEPRECATED(msg) [[gnu::deprecated(msg)]]
-#endif
-#else
-#define WPI_DEPRECATED(msg) __attribute__((deprecated(msg)))
-#endif
-#elif __cplusplus > 201103L
-#define WPI_DEPRECATED(msg) [[deprecated(msg)]]
-#else
-#define WPI_DEPRECATED(msg) /*nothing*/
-#endif
 #endif
 
 #endif  // WPIUTIL_WPI_DEPRECATED_H_

--- a/wpiutil/src/main/native/include/wpi/json.h
+++ b/wpiutil/src/main/native/include/wpi/json.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Modifications Copyright (c) 2017-2018 FIRST. All Rights Reserved.          */
+/* Modifications Copyright (c) 2017-2019 FIRST. All Rights Reserved.          */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -163,14 +163,6 @@ class json;
     #define JSON_UNLIKELY(x)    x
 #endif
 
-// C++ language standard detection
-#if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_HAS_CXX17) && _HAS_CXX17 == 1) // fix for issue #464
-    #define JSON_HAS_CPP_17
-    #define JSON_HAS_CPP_14
-#elif (defined(__cplusplus) && __cplusplus >= 201402L) || (defined(_HAS_CXX14) && _HAS_CXX14 == 1)
-    #define JSON_HAS_CPP_14
-#endif
-
 /*!
 @brief Helper to determine whether there's a key_type for T.
 
@@ -219,57 +211,6 @@ using enable_if_t = typename std::enable_if<B, T>::type;
 template<typename T>
 using uncvref_t = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
 
-// implementation of C++14 index_sequence and affiliates
-// source: https://stackoverflow.com/a/32223343
-template<std::size_t... Ints>
-struct index_sequence
-{
-    using type = index_sequence;
-    using value_type = std::size_t;
-    static constexpr std::size_t size() noexcept
-    {
-        return sizeof...(Ints);
-    }
-};
-
-template<class Sequence1, class Sequence2>
-struct merge_and_renumber;
-
-template<std::size_t... I1, std::size_t... I2>
-struct merge_and_renumber<index_sequence<I1...>, index_sequence<I2...>>
-        : index_sequence < I1..., (sizeof...(I1) + I2)... > {};
-
-template<std::size_t N>
-struct make_index_sequence
-    : merge_and_renumber < typename make_index_sequence < N / 2 >::type,
-      typename make_index_sequence < N - N / 2 >::type > {};
-
-template<> struct make_index_sequence<0> : index_sequence<> {};
-template<> struct make_index_sequence<1> : index_sequence<0> {};
-
-template<typename... Ts>
-using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
-
-/*
-Implementation of two C++17 constructs: conjunction, negation. This is needed
-to avoid evaluating all the traits in a condition
-
-For example: not std::is_same<void, T>::value and has_value_type<T>::value
-will not compile when T = void (on MSVC at least). Whereas
-conjunction<negation<std::is_same<void, T>>, has_value_type<T>>::value will
-stop evaluating if negation<...>::value == false
-
-Please note that those constructs must be used with caution, since symbols can
-become very long quickly (which can slow down compilation and cause MSVC
-internal compiler errors). Only use it when you have to (see example ahead).
-*/
-template<class...> struct conjunction : std::true_type {};
-template<class B1> struct conjunction<B1> : B1 {};
-template<class B1, class... Bn>
-struct conjunction<B1, Bn...> : std::conditional<bool(B1::value), conjunction<Bn...>, B1>::type {};
-
-template<class B> struct negation : std::integral_constant<bool, not B::value> {};
-
 // dispatch utility (taken from ranges-v3)
 template<unsigned N> struct priority_tag : priority_tag < N - 1 > {};
 template<> struct priority_tag<0> {};
@@ -306,7 +247,7 @@ template<class BasicJsonType, class CompatibleObjectType>
 struct is_compatible_object_type
 {
     static auto constexpr value = is_compatible_object_type_impl <
-                                  conjunction<negation<std::is_same<void, CompatibleObjectType>>,
+                                  std::conjunction<std::negation<std::is_same<void, CompatibleObjectType>>,
                                   has_mapped_type<CompatibleObjectType>,
                                   has_key_type<CompatibleObjectType>>::value,
                                   typename BasicJsonType::object_t, CompatibleObjectType >::value;
@@ -325,12 +266,12 @@ template<class BasicJsonType, class CompatibleArrayType>
 struct is_compatible_array_type
 {
     static auto constexpr value =
-        conjunction<negation<std::is_same<void, CompatibleArrayType>>,
-        negation<is_compatible_object_type<
+        std::conjunction<std::negation<std::is_same<void, CompatibleArrayType>>,
+        std::negation<is_compatible_object_type<
         BasicJsonType, CompatibleArrayType>>,
-        negation<std::is_constructible<StringRef,
+        std::negation<std::is_constructible<StringRef,
         CompatibleArrayType>>,
-        negation<is_json_nested_type<BasicJsonType, CompatibleArrayType>>,
+        std::negation<is_json_nested_type<BasicJsonType, CompatibleArrayType>>,
         has_value_type<CompatibleArrayType>,
         has_iterator<CompatibleArrayType>>::value;
 };
@@ -422,7 +363,7 @@ struct is_compatible_complete_type
 
 template <typename BasicJsonType, typename CompatibleType>
 struct is_compatible_type
-    : conjunction<is_complete_type<CompatibleType>,
+    : std::conjunction<is_complete_type<CompatibleType>,
       is_compatible_complete_type<BasicJsonType, CompatibleType>>
 {
 };
@@ -1035,7 +976,7 @@ void from_json(const BasicJsonType& j, std::pair<A1, A2>& p)
 }
 
 template<typename BasicJsonType, typename Tuple, std::size_t... Idx>
-void from_json_tuple_impl(const BasicJsonType& j, Tuple& t, index_sequence<Idx...>)
+void from_json_tuple_impl(const BasicJsonType& j, Tuple& t, std::index_sequence<Idx...>)
 {
     t = std::make_tuple(j.at(Idx).template get<typename std::tuple_element<Idx, Tuple>::type>()...);
 }
@@ -1043,7 +984,7 @@ void from_json_tuple_impl(const BasicJsonType& j, Tuple& t, index_sequence<Idx..
 template<typename BasicJsonType, typename... Args>
 void from_json(const BasicJsonType& j, std::tuple<Args...>& t)
 {
-    from_json_tuple_impl(j, t, index_sequence_for<Args...> {});
+    from_json_tuple_impl(j, t, std::index_sequence_for<Args...> {});
 }
 
 struct from_json_fn
@@ -1355,7 +1296,7 @@ void to_json(BasicJsonType& j, const std::pair<Args...>& p)
 }
 
 template<typename BasicJsonType, typename Tuple, std::size_t... Idx>
-void to_json_tuple_impl(BasicJsonType& j, const Tuple& t, index_sequence<Idx...>)
+void to_json_tuple_impl(BasicJsonType& j, const Tuple& t, std::index_sequence<Idx...>)
 {
     j = {std::get<Idx>(t)...};
 }
@@ -1363,7 +1304,7 @@ void to_json_tuple_impl(BasicJsonType& j, const Tuple& t, index_sequence<Idx...>
 template<typename BasicJsonType, typename... Args>
 void to_json(BasicJsonType& j, const std::tuple<Args...>& t)
 {
-    to_json_tuple_impl(j, t, index_sequence_for<Args...> {});
+    to_json_tuple_impl(j, t, std::index_sequence_for<Args...> {});
 }
 
 struct to_json_fn
@@ -2860,13 +2801,9 @@ class json
     /// the template arguments passed to class @ref json.
     /// @{
 
-#if defined(JSON_HAS_CPP_14)
     // Use transparent comparator if possible, combined with perfect forwarding
     // on find() and count() calls prevents unnecessary string construction.
     using object_comparator_t = std::less<>;
-#else
-    using object_comparator_t = std::less<std::string>;
-#endif
 
     /*!
     @brief a type for an object
@@ -4674,9 +4611,7 @@ class json
 #ifndef _MSC_VER  // fix for issue #167 operator<< ambiguity under VS2015
                    and not std::is_same<ValueType, std::initializer_list<std::string::value_type>>::value
 #endif
-#if defined(JSON_HAS_CPP_17)
                    and not std::is_same<ValueType, typename std::string_view>::value
-#endif
                    , int >::type = 0 >
     operator ValueType() const
     {
@@ -8176,8 +8111,6 @@ inline wpi::json::json_pointer operator "" _json_pointer(const char* s, std::siz
 #undef JSON_TRY
 #undef JSON_LIKELY
 #undef JSON_UNLIKELY
-#undef JSON_HAS_CPP_14
-#undef JSON_HAS_CPP_17
 #undef NLOHMANN_BASIC_JSON_TPL_DECLARATION
 #undef NLOHMANN_BASIC_JSON_TPL
 #undef NLOHMANN_JSON_HAS_HELPER

--- a/wpiutil/src/main/native/include/wpi/uv/Async.h
+++ b/wpiutil/src/main/native/include/wpi/uv/Async.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpiutil/src/main/native/include/wpi/uv/Async.h
+++ b/wpiutil/src/main/native/include/wpi/uv/Async.h
@@ -16,7 +16,6 @@
 #include <utility>
 #include <vector>
 
-#include "wpi/STLExtras.h"
 #include "wpi/Signal.h"
 #include "wpi/mutex.h"
 #include "wpi/uv/Handle.h"
@@ -70,7 +69,7 @@ class Async final : public HandleImpl<Async<T...>, uv_async_t> {
         uv_async_init(loop->GetRaw(), h->GetRaw(), [](uv_async_t* handle) {
           auto& h = *static_cast<Async*>(handle->data);
           std::lock_guard<wpi::mutex> lock(h.m_mutex);
-          for (auto&& v : h.m_data) apply_tuple(h.wakeup, v);
+          for (auto&& v : h.m_data) std::apply(h.wakeup, v);
           h.m_data.clear();
         });
     if (err < 0) {

--- a/wpiutil/src/main/native/include/wpi/uv/AsyncFunction.h
+++ b/wpiutil/src/main/native/include/wpi/uv/AsyncFunction.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -18,7 +18,6 @@
 #include <utility>
 #include <vector>
 
-#include "wpi/STLExtras.h"
 #include "wpi/future.h"
 #include "wpi/mutex.h"
 #include "wpi/uv/Handle.h"
@@ -91,9 +90,9 @@ class AsyncFunction<R(T...)> final
             for (auto&& v : h.m_params) {
               auto p = h.m_promises.CreatePromise(v.first);
               if (h.wakeup)
-                apply_tuple(h.wakeup,
-                            std::tuple_cat(std::make_tuple(std::move(p)),
-                                           std::move(v.second)));
+                std::apply(h.wakeup,
+                           std::tuple_cat(std::make_tuple(std::move(p)),
+                                          std::move(v.second)));
             }
             h.m_params.clear();
             // wake up any threads that might be waiting for the result


### PR DESCRIPTION
Now that all compilers support C++17, remove some old C++14/C++17 shims.

WPI_DEPRECATED macro can't be removed because clang-format formatting of [[deprecated]] is terrible.