### PR TITLE
Fix some move constructors

### DIFF
--- a/wpilibc/src/main/native/cpp/MotorSafety.cpp
+++ b/wpilibc/src/main/native/cpp/MotorSafety.cpp
@@ -39,6 +39,8 @@ MotorSafety::MotorSafety(MotorSafety&& rhs)
       m_stopTime(std::move(rhs.m_stopTime)) {}
 
 MotorSafety& MotorSafety::operator=(MotorSafety&& rhs) {
+  std::scoped_lock lock(m_thisMutex, rhs.m_thisMutex);
+
   ErrorBase::operator=(std::move(rhs));
 
   m_expiration = std::move(rhs.m_expiration);

--- a/wpilibc/src/main/native/cpp/Timer.cpp
+++ b/wpilibc/src/main/native/cpp/Timer.cpp
@@ -39,6 +39,21 @@ const double Timer::kRolloverTime = (1ll << 32) / 1e6;
 
 Timer::Timer() { Reset(); }
 
+Timer::Timer(Timer&& rhs)
+    : m_startTime(std::move(rhs.m_startTime)),
+      m_accumulatedTime(std::move(rhs.m_accumulatedTime)),
+      m_running(std::move(rhs.m_running)) {}
+
+Timer& Timer::operator=(Timer&& rhs) {
+  std::scoped_lock lock(m_mutex, rhs.m_mutex);
+
+  m_startTime = std::move(rhs.m_startTime);
+  m_accumulatedTime = std::move(rhs.m_accumulatedTime);
+  m_running = std::move(rhs.m_running);
+
+  return *this;
+}
+
 double Timer::Get() const {
   double result;
   double currentTime = GetFPGATimestamp();

--- a/wpilibc/src/main/native/include/frc/Timer.h
+++ b/wpilibc/src/main/native/include/frc/Timer.h
@@ -56,8 +56,8 @@ class Timer {
 
   virtual ~Timer() = default;
 
-  Timer(Timer&&) = default;
-  Timer& operator=(Timer&&) = default;
+  Timer(Timer&& rhs);
+  Timer& operator=(Timer&& rhs);
 
   /**
    * Get the current time from the timer. If the clock is running it is derived


### PR DESCRIPTION
Timer didn't have working move semantics because mutexes aren't moveable,
meaning the default implementations were ill-formed. MotorSafety wasn't
locking its mutex.