### PR TITLE
Remove TimerEventHandler typedef from Notifier class

### DIFF
--- a/wpilibc/src/main/native/cpp/Notifier.cpp
+++ b/wpilibc/src/main/native/cpp/Notifier.cpp
@@ -17,7 +17,7 @@
 
 using namespace frc;
 
-Notifier::Notifier(TimerEventHandler handler) {
+Notifier::Notifier(std::function<void()> handler) {
   if (handler == nullptr)
     wpi_setWPIErrorWithContext(NullParameter, "handler must not be nullptr");
   m_handler = handler;
@@ -33,7 +33,7 @@ Notifier::Notifier(TimerEventHandler handler) {
       uint64_t curTime = HAL_WaitForNotifierAlarm(notifier, &status);
       if (curTime == 0 || status != 0) break;
 
-      TimerEventHandler handler;
+      std::function<void()> handler;
       {
         std::scoped_lock lock(m_processMutex);
         handler = m_handler;
@@ -90,7 +90,7 @@ Notifier& Notifier::operator=(Notifier&& rhs) {
   return *this;
 }
 
-void Notifier::SetHandler(TimerEventHandler handler) {
+void Notifier::SetHandler(std::function<void()> handler) {
   std::scoped_lock lock(m_processMutex);
   m_handler = handler;
 }

--- a/wpilibc/src/main/native/include/frc/Notifier.h
+++ b/wpilibc/src/main/native/include/frc/Notifier.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -21,8 +21,6 @@
 
 namespace frc {
 
-using TimerEventHandler = std::function<void()>;
-
 class Notifier : public ErrorBase {
  public:
   /**
@@ -31,7 +29,7 @@ class Notifier : public ErrorBase {
    * @param handler The handler is called at the notification time which is set
    *                using StartSingle or StartPeriodic.
    */
-  explicit Notifier(TimerEventHandler handler);
+  explicit Notifier(std::function<void()> handler);
 
   template <typename Callable, typename Arg, typename... Args>
   Notifier(Callable&& f, Arg&& arg, Args&&... args)
@@ -51,7 +49,7 @@ class Notifier : public ErrorBase {
    *
    * @param handler Handler
    */
-  void SetHandler(TimerEventHandler handler);
+  void SetHandler(std::function<void()> handler);
 
   /**
    * Register for single event notification.
@@ -108,7 +106,7 @@ class Notifier : public ErrorBase {
   std::atomic<HAL_NotifierHandle> m_notifier{0};
 
   // Address of the handler
-  TimerEventHandler m_handler;
+  std::function<void()> m_handler;
 
   // The absolute expiration time
   double m_expirationTime = 0;


### PR DESCRIPTION
Using std::function<void()> directly makes it much clearer to the user
what kind of function Notifier expects. The Doxygen comments already say
what the function is used for, so the typedef just discards useful
information.