### PR TITLE
Make MotorEncoderTest use LinearFilter

### DIFF
--- a/wpilibcIntegrationTests/src/main/native/cpp/MotorEncoderTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/MotorEncoderTest.cpp
@@ -8,12 +8,12 @@
 #include "TestBench.h"
 #include "frc/Encoder.h"
 #include "frc/Jaguar.h"
+#include "frc/LinearFilter.h"
 #include "frc/Talon.h"
 #include "frc/Timer.h"
 #include "frc/Victor.h"
 #include "frc/controller/PIDController.h"
 #include "frc/controller/PIDControllerRunner.h"
-#include "frc/LinearFilter.h"
 #include "gtest/gtest.h"
 
 using namespace frc;

--- a/wpilibcIntegrationTests/src/main/native/cpp/MotorEncoderTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/MotorEncoderTest.cpp
@@ -13,7 +13,7 @@
 #include "frc/Victor.h"
 #include "frc/controller/PIDController.h"
 #include "frc/controller/PIDControllerRunner.h"
-#include "frc/filters/LinearFilter.h"
+#include "frc/LinearFilter.h"
 #include "gtest/gtest.h"
 
 using namespace frc;
@@ -68,8 +68,7 @@ class MotorEncoderTest : public testing::TestWithParam<MotorEncoderTestType> {
                                 TestBench::kTalonEncoderChannelB);
         break;
     }
-    m_filter = new LinearFilter(
-        LinearFilter::MovingAverage(50));
+    m_filter = new LinearFilter(LinearFilter::MovingAverage(50));
   }
 
   void TearDown() override {

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/MotorEncoderTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/MotorEncoderTest.java
@@ -21,7 +21,6 @@ import org.junit.runners.Parameterized.Parameters;
 
 import edu.wpi.first.wpilibj.controller.PIDController;
 import edu.wpi.first.wpilibj.controller.PIDControllerRunner;
-import edu.wpi.first.wpilibj.filters.LinearDigitalFilter;
 import edu.wpi.first.wpilibj.fixtures.MotorEncoderFixture;
 import edu.wpi.first.wpilibj.test.AbstractComsSetup;
 import edu.wpi.first.wpilibj.test.TestBench;
@@ -197,15 +196,16 @@ public class MotorEncoderTest extends AbstractComsSetup {
 
   @Test
   public void testVelocityPIDController() {
-    me.getEncoder().setPIDSourceType(PIDSourceType.kRate);
-    LinearDigitalFilter filter = LinearDigitalFilter.movingAverage(me.getEncoder(), 50);
+    LinearFilter filter = LinearFilter.movingAverage(50);
     PIDController pidController = new PIDController(1e-5, 0.0, 0.0006);
     pidController.setAbsoluteTolerance(200);
     pidController.setOutputRange(-0.3, 0.3);
     pidController.setSetpoint(600);
 
-    PIDControllerRunner pidRunner = new PIDControllerRunner(pidController, filter::pidGet,
+    PIDControllerRunner pidRunner = new PIDControllerRunner(pidController,
+        () -> filter.calculate(me.getEncoder().getRate()),
         output -> me.getMotor().set(output + 8e-5));
+
     pidRunner.enable();
     Timer.delay(10.0);
     pidRunner.disable();


### PR DESCRIPTION
Closes #1774 
This also eliminates the call to the deprecated `setPIDSourceType` method.