### PR TITLE
Deprecate frc/WPILib.h

### DIFF
--- a/wpilibc/src/main/native/include/frc/WPILib.h
+++ b/wpilibc/src/main/native/include/frc/WPILib.h
@@ -7,8 +7,14 @@
 
 #pragma once
 
-#pragma warning( \
-    "Including this header drastically increases compilation times and is bad style. Include only what you use instead.")
+// clang-format off
+#ifdef _MSC_VER
+#pragma message "warning: Including this header drastically increases compilation times and is bad style. Include only what you use instead."
+#else
+#warning "Including this header drastically increases compilation times and is bad style. Include only what you use instead."
+#endif
+
+// clang-format on
 
 #include <cameraserver/CameraServer.h>
 #include <vision/VisionRunner.h>

--- a/wpilibc/src/main/native/include/frc/WPILib.h
+++ b/wpilibc/src/main/native/include/frc/WPILib.h
@@ -7,6 +7,9 @@
 
 #pragma once
 
+#pragma warning( \
+    "Including this header drastically increases compilation times and is bad style. Include only what you use instead.")
+
 #include <cameraserver/CameraServer.h>
 #include <vision/VisionRunner.h>
 

--- a/wpilibcExamples/src/main/cpp/templates/commandbased/cpp/OI.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/commandbased/cpp/OI.cpp
@@ -1,13 +1,11 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
 #include "OI.h"
-
-#include <frc/WPILib.h>
 
 OI::OI() {
   // Process operator interface input here.


### PR DESCRIPTION
It drastically increases compile times and is bad style. C++ users
should be including what they use. We don't necessarily have to remove
WPILib.h, but it should at least be deprecated.