### PR TITLE
PIDController move/copy ctor/assignment fix

### DIFF
--- a/wpilibc/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/PIDController.cpp
@@ -24,9 +24,11 @@ PIDController::PIDController(double Kp, double Ki, double Kd, double period)
   SetName("PIDController", instances);
 }
 
-PIDController::PIDController(PIDController&& rhs) : PIDController(std::move(rhs), std::scoped_lock(rhs.m_thisMutex)) {}
+PIDController::PIDController(PIDController&& rhs)
+    : PIDController(std::move(rhs), std::scoped_lock(rhs.m_thisMutex)) {}
 
-PIDController::PIDController(PIDController&& rhs, std::scoped_lock<wpi::mutex> lock)
+PIDController::PIDController(PIDController&& rhs,
+                             std::scoped_lock<wpi::mutex> lock)
     : SendableBase(std::move(rhs)),
       m_Kp(std::move(rhs.m_Kp)),
       m_Ki(std::move(rhs.m_Ki)),
@@ -47,9 +49,11 @@ PIDController::PIDController(PIDController&& rhs, std::scoped_lock<wpi::mutex> l
       m_setpoint(std::move(rhs.m_setpoint)),
       m_output(std::move(rhs.m_output)) {}
 
-PIDController::PIDController(const PIDController& other) : PIDController(other, std::scoped_lock(other.m_thisMutex)) {}
+PIDController::PIDController(const PIDController& other)
+    : PIDController(other, std::scoped_lock(other.m_thisMutex)) {}
 
-PIDController::PIDController(const PIDController& other, std::scoped_lock<wpi::mutex> lock)
+PIDController::PIDController(const PIDController& other,
+                             std::scoped_lock<wpi::mutex> lock)
     : PIDController(other.m_Kp, other.m_Ki, other.m_Kd, other.m_period) {
   m_maximumInput = other.m_maximumInput;
   m_minimumInput = other.m_minimumInput;

--- a/wpilibc/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/PIDController.cpp
@@ -24,7 +24,9 @@ PIDController::PIDController(double Kp, double Ki, double Kd, double period)
   SetName("PIDController", instances);
 }
 
-PIDController::PIDController(PIDController&& rhs)
+PIDController::PIDController(PIDController&& rhs) : PIDController(std::move(rhs), std::scoped_lock(rhs.m_thisMutex)) {}
+
+PIDController::PIDController(PIDController&& rhs, std::scoped_lock<wpi::mutex> lock)
     : SendableBase(std::move(rhs)),
       m_Kp(std::move(rhs.m_Kp)),
       m_Ki(std::move(rhs.m_Ki)),
@@ -44,6 +46,23 @@ PIDController::PIDController(PIDController&& rhs)
       m_deltaTolerance(std::move(rhs.m_deltaTolerance)),
       m_setpoint(std::move(rhs.m_setpoint)),
       m_output(std::move(rhs.m_output)) {}
+
+PIDController::PIDController(const PIDController& other) : PIDController(other, std::scoped_lock(other.m_thisMutex)) {}
+
+PIDController::PIDController(const PIDController& other, std::scoped_lock<wpi::mutex> lock)
+    : PIDController(other.m_Kp, other.m_Ki, other.m_Kd, other.m_period) {
+  m_maximumInput = other.m_maximumInput;
+  m_minimumInput = other.m_minimumInput;
+  m_maximumOutput = other.m_maximumOutput;
+  m_minimumOutput = other.m_minimumOutput;
+  m_inputRange = other.m_inputRange;
+  m_continuous = other.m_continuous;
+  m_tolerance = other.m_tolerance;
+  m_toleranceType = other.m_toleranceType;
+  m_deltaTolerance = other.m_deltaTolerance;
+  m_setpoint = other.m_setpoint;
+  m_output = other.m_output;
+}
 
 PIDController& PIDController::operator=(PIDController&& rhs) {
   std::scoped_lock lock(m_thisMutex, rhs.m_thisMutex);
@@ -68,6 +87,28 @@ PIDController& PIDController::operator=(PIDController&& rhs) {
   m_deltaTolerance = std::move(rhs.m_deltaTolerance);
   m_setpoint = std::move(rhs.m_setpoint);
   m_output = std::move(rhs.m_output);
+
+  return *this;
+}
+
+PIDController& PIDController::operator=(const PIDController& other) {
+  std::scoped_lock lock(m_thisMutex, other.m_thisMutex);
+
+  m_Kp = other.m_Kp;
+  m_Ki = other.m_Ki;
+  m_Kd = other.m_Kd;
+  m_period = other.m_period;
+  m_maximumInput = other.m_maximumInput;
+  m_minimumInput = other.m_minimumInput;
+  m_maximumOutput = other.m_maximumOutput;
+  m_minimumOutput = other.m_minimumOutput;
+  m_inputRange = other.m_inputRange;
+  m_continuous = other.m_continuous;
+  m_tolerance = other.m_tolerance;
+  m_toleranceType = other.m_toleranceType;
+  m_deltaTolerance = other.m_deltaTolerance;
+  m_setpoint = other.m_setpoint;
+  m_output = other.m_output;
 
   return *this;
 }

--- a/wpilibc/src/main/native/cpp/controller/PIDControllerRunner.cpp
+++ b/wpilibc/src/main/native/cpp/controller/PIDControllerRunner.cpp
@@ -24,24 +24,29 @@ PIDControllerRunner::PIDControllerRunner(
 
 PIDControllerRunner::~PIDControllerRunner() { Disable(); }
 
-PIDControllerRunner::PIDControllerRunner(PIDControllerRunner&& rhs) : PIDControllerRunner(std::move(rhs), std::scoped_lock(rhs.m_thisMutex, rhs.m_outputMutex)) {}
+PIDControllerRunner::PIDControllerRunner(PIDControllerRunner&& rhs)
+    : PIDControllerRunner(std::move(rhs), std::scoped_lock(rhs.m_thisMutex,
+                                                           rhs.m_outputMutex)) {
+}
 
-PIDControllerRunner::PIDControllerRunner(PIDControllerRunner&& rhs, std::scoped_lock<wpi::mutex, wpi::mutex> lock) :
-  SendableBase(std::move(rhs)),
-  m_controller(std::move(rhs.m_controller)),
-  m_measurementSource(std::move(rhs.m_measurementSource)),
-  m_controllerOutput(std::move(rhs.m_controllerOutput)),
-  m_enabled(std::move(m_enabled)) {};
+PIDControllerRunner::PIDControllerRunner(
+    PIDControllerRunner&& rhs, std::scoped_lock<wpi::mutex, wpi::mutex> lock)
+    : SendableBase(std::move(rhs)),
+      m_controller(std::move(rhs.m_controller)),
+      m_measurementSource(std::move(rhs.m_measurementSource)),
+      m_controllerOutput(std::move(rhs.m_controllerOutput)),
+      m_enabled(std::move(rhs.m_enabled)) {}
 
 PIDControllerRunner& PIDControllerRunner::operator=(PIDControllerRunner&& rhs) {
-  std::scoped_lock lock(m_thisMutex, m_outputMutex, rhs.m_thisMutex, rhs.m_outputMutex);
+  std::scoped_lock lock(m_thisMutex, m_outputMutex, rhs.m_thisMutex,
+                        rhs.m_outputMutex);
 
   SendableBase::operator=(std::move(rhs));
 
   m_controller = std::move(rhs.m_controller);
   m_measurementSource = std::move(rhs.m_measurementSource);
   m_controllerOutput = std::move(rhs.m_controllerOutput);
-  m_enabled = std::move(m_enabled);
+  m_enabled = std::move(rhs.m_enabled);
 
   return *this;
 }

--- a/wpilibc/src/main/native/include/frc/controller/PIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/PIDController.h
@@ -33,11 +33,13 @@ class PIDController : public frc::SendableBase {
    *               default is 0.02 seconds.
    */
   PIDController(double Kp, double Ki, double Kd, double period = 0.02);
-
   ~PIDController() override = default;
 
   PIDController(PIDController&& rhs);
   PIDController& operator=(PIDController&& rhs);
+
+  PIDController(const PIDController& other);
+  PIDController& operator=(const PIDController& other);
 
   /**
    * Sets the PID Controller gain parameters.
@@ -234,6 +236,8 @@ class PIDController : public frc::SendableBase {
 
  protected:
   mutable wpi::mutex m_thisMutex;
+  PIDController(PIDController&& rhs, std::scoped_lock<wpi::mutex> lock);
+  PIDController(const PIDController& rhs, std::scoped_lock<wpi::mutex> lock);
 
   /**
    * Wraps error around for continuous inputs. The original error is returned if

--- a/wpilibc/src/main/native/include/frc/controller/PIDControllerRunner.h
+++ b/wpilibc/src/main/native/include/frc/controller/PIDControllerRunner.h
@@ -32,8 +32,8 @@ class PIDControllerRunner : SendableBase {
 
   ~PIDControllerRunner();
 
-  PIDControllerRunner(PIDControllerRunner&&) = default;
-  PIDControllerRunner& operator=(PIDControllerRunner&&) = default;
+  PIDControllerRunner(PIDControllerRunner&& rhs);
+  PIDControllerRunner& operator=(PIDControllerRunner&& rhs);
 
   /**
    * Begins running the controller.
@@ -54,9 +54,12 @@ class PIDControllerRunner : SendableBase {
 
   void InitSendable(SendableBuilder& builder) override;
 
+ protected:
+  PIDControllerRunner(PIDControllerRunner&& rhs, std::scoped_lock<wpi::mutex, wpi::mutex> lock);
+
  private:
   Notifier m_notifier{&PIDControllerRunner::Run, this};
-  frc2::PIDController& m_controller;
+  frc2::PIDController* m_controller;
   std::function<double(void)> m_measurementSource;
   std::function<void(double)> m_controllerOutput;
   bool m_enabled = false;

--- a/wpilibc/src/main/native/include/frc/controller/PIDControllerRunner.h
+++ b/wpilibc/src/main/native/include/frc/controller/PIDControllerRunner.h
@@ -55,7 +55,8 @@ class PIDControllerRunner : SendableBase {
   void InitSendable(SendableBuilder& builder) override;
 
  protected:
-  PIDControllerRunner(PIDControllerRunner&& rhs, std::scoped_lock<wpi::mutex, wpi::mutex> lock);
+  PIDControllerRunner(PIDControllerRunner&& rhs,
+                      std::scoped_lock<wpi::mutex, wpi::mutex> lock);
 
  private:
   Notifier m_notifier{&PIDControllerRunner::Run, this};

--- a/wpilibc/src/test/native/cpp/PIDCopyMoveTest.cpp
+++ b/wpilibc/src/test/native/cpp/PIDCopyMoveTest.cpp
@@ -1,0 +1,20 @@
+#include "frc/controller/PIDController.h"
+#include "gtest/gtest.h"
+
+using namespace frc2;
+
+TEST(PIDCopyMoveTest, CopyConstructible) {
+  EXPECT_TRUE(std::is_copy_constructible_v<PIDController>);
+}
+
+TEST(PIDCopyMoveTest, MoveConstructible) {
+  EXPECT_TRUE(std::is_move_constructible_v<PIDController>);
+}
+
+TEST(PIDCopyMoveTest, CopyAssignable) {
+  EXPECT_TRUE(std::is_copy_assignable_v<PIDController>);
+}
+
+TEST(PIDCopyMoveTest, MoveAssignable) {
+  EXPECT_TRUE(std::is_move_assignable_v<PIDController>);
+}

--- a/wpilibc/src/test/native/cpp/PIDCopyMoveTest.cpp
+++ b/wpilibc/src/test/native/cpp/PIDCopyMoveTest.cpp
@@ -1,3 +1,10 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
 #include "frc/controller/PIDController.h"
 #include "frc/controller/PIDControllerRunner.h"
 #include "gtest/gtest.h"

--- a/wpilibc/src/test/native/cpp/PIDCopyMoveTest.cpp
+++ b/wpilibc/src/test/native/cpp/PIDCopyMoveTest.cpp
@@ -1,20 +1,30 @@
 #include "frc/controller/PIDController.h"
+#include "frc/controller/PIDControllerRunner.h"
 #include "gtest/gtest.h"
 
 using namespace frc2;
+using namespace frc;
 
-TEST(PIDCopyMoveTest, CopyConstructible) {
+TEST(PIDCopyMoveTest, ControllerCopyConstructible) {
   EXPECT_TRUE(std::is_copy_constructible_v<PIDController>);
 }
 
-TEST(PIDCopyMoveTest, MoveConstructible) {
+TEST(PIDCopyMoveTest, ControllerMoveConstructible) {
   EXPECT_TRUE(std::is_move_constructible_v<PIDController>);
 }
 
-TEST(PIDCopyMoveTest, CopyAssignable) {
+TEST(PIDCopyMoveTest, ControllerCopyAssignable) {
   EXPECT_TRUE(std::is_copy_assignable_v<PIDController>);
 }
 
-TEST(PIDCopyMoveTest, MoveAssignable) {
+TEST(PIDCopyMoveTest, ControllerMoveAssignable) {
   EXPECT_TRUE(std::is_move_assignable_v<PIDController>);
+}
+
+TEST(PIDCopyMoveTest, RunnerMoveConstructible) {
+  EXPECT_TRUE(std::is_move_constructible_v<PIDControllerRunner>);
+}
+
+TEST(PIDCopyMoveTest, RunnerMoveAssignable) {
+  EXPECT_TRUE(std::is_move_assignable_v<PIDControllerRunner>);
 }


### PR DESCRIPTION
This commit fixes the invalid (previously-defaulted) move and copy constructors for PIDController and PIDControllerRunner. This constructors delegate to another constructor that takes in a scoped_lock. Assignment operators were done to the best of my ability, and tests have been done.