### PR TITLE
fix missing default name in java pidcontroller

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
@@ -108,6 +108,8 @@ public class PIDController extends SendableBase {
     m_period = period;
 
     instances++;
+    setName("PIDController", instances);
+
     HAL.report(tResourceType.kResourceType_PIDController, instances);
   }
 


### PR DESCRIPTION
Java PIDController was missing a default sendable name.