### PR TITLE
Allow SendableCameraWrappers to take arbitrary URLs

### DIFF
--- a/wpilibc/src/main/native/cpp/shuffleboard/SendableCameraWrapper.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/SendableCameraWrapper.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -8,7 +8,12 @@
 #include "frc/shuffleboard/SendableCameraWrapper.h"
 
 #include <cscore_oo.h>
+#include <networktables/NetworkTable.h>
+#include <networktables/NetworkTableInstance.h>
+#include <ntcore.h>
+#include <wpi/ArrayRef.h>
 #include <wpi/DenseMap.h>
+#include <wpi/StringMap.h>
 
 #include "frc/smartdashboard/SendableBuilder.h"
 
@@ -16,26 +21,43 @@ using namespace frc;
 
 namespace {
 constexpr const char* kProtocol = "camera_server://";
-wpi::DenseMap<int, std::unique_ptr<SendableCameraWrapper>> wrappers;
+wpi::StringMap<std::unique_ptr<SendableCameraWrapper>> wrappers;
 }  // namespace
 
 SendableCameraWrapper& SendableCameraWrapper::Wrap(
     const cs::VideoSource& source) {
-  return Wrap(source.GetHandle());
-}
-
-SendableCameraWrapper& SendableCameraWrapper::Wrap(CS_Source source) {
-  auto& wrapper = wrappers[static_cast<int>(source)];
+  auto name = source.GetName();
+  auto& wrapper = wrappers[name];
   if (!wrapper)
-    wrapper = std::make_unique<SendableCameraWrapper>(source, private_init{});
+    wrapper = std::make_unique<SendableCameraWrapper>(name, private_init{});
   return *wrapper;
 }
 
-SendableCameraWrapper::SendableCameraWrapper(CS_Source source,
-                                             const private_init&)
-    : SendableBase(false), m_uri(kProtocol) {
+SendableCameraWrapper& SendableCameraWrapper::Wrap(CS_Source source) {
   CS_Status status = 0;
   auto name = cs::GetSourceName(source, &status);
+  auto& wrapper = wrappers[name];
+  if (!wrapper)
+    wrapper = std::make_unique<SendableCameraWrapper>(name, private_init{});
+  return *wrapper;
+}
+
+SendableCameraWrapper& SendableCameraWrapper::Wrap(
+    std::string cameraName, wpi::ArrayRef<std::string> cameraUrls) {
+  auto& wrapper = wrappers[cameraName];
+  if (!wrapper) {
+    wrapper =
+        std::make_unique<SendableCameraWrapper>(cameraName, private_init{});
+    std::string streams = "/CameraPublisher/" + cameraName + "/streams";
+    nt::NetworkTableInstance::GetDefault().GetEntry(streams).SetStringArray(
+        cameraUrls);
+  }
+  return *wrapper;
+}
+
+SendableCameraWrapper::SendableCameraWrapper(std::string name,
+                                             const private_init&)
+    : SendableBase(false), m_uri(kProtocol) {
   SetName(name);
   m_uri += name;
 }

--- a/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardContainer.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardContainer.cpp
@@ -79,7 +79,7 @@ ComplexWidget& ShuffleboardContainer::Add(const wpi::Twine& title,
   return Add(title, SendableCameraWrapper::Wrap(video));
 }
 
-ComplexWidget& ShuffleboardContainer::Add(
+ComplexWidget& ShuffleboardContainer::AddCamera(
     const wpi::Twine& title, const std::string cameraName,
     wpi::ArrayRef<std::string> cameraUrls) {
   return Add(title, SendableCameraWrapper::Wrap(cameraName, cameraUrls));

--- a/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardContainer.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardContainer.cpp
@@ -79,6 +79,12 @@ ComplexWidget& ShuffleboardContainer::Add(const wpi::Twine& title,
   return Add(title, SendableCameraWrapper::Wrap(video));
 }
 
+ComplexWidget& ShuffleboardContainer::Add(
+    const wpi::Twine& title, const std::string cameraName,
+    wpi::ArrayRef<std::string> cameraUrls) {
+  return Add(title, SendableCameraWrapper::Wrap(cameraName, cameraUrls));
+}
+
 ComplexWidget& ShuffleboardContainer::Add(Sendable& sendable) {
   if (sendable.GetName().empty()) {
     wpi::outs() << "Sendable must have a name\n";

--- a/wpilibc/src/main/native/include/frc/shuffleboard/SendableCameraWrapper.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/SendableCameraWrapper.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -10,6 +10,8 @@
 #include <string>
 
 #include <cscore_c.h>
+#include <wpi/ArrayRef.h>
+#include <wpi/StringMap.h>
 
 #include "frc/smartdashboard/SendableBase.h"
 
@@ -31,9 +33,9 @@ class SendableCameraWrapper : public SendableBase {
    * Creates a new sendable wrapper. Private constructor to avoid direct
    * instantiation with multiple wrappers floating around for the same camera.
    *
-   * @param source the source to wrap
+   * @param cameraName the name of the camera to wrap
    */
-  SendableCameraWrapper(CS_Source source, const private_init&);
+  SendableCameraWrapper(std::string cameraName, const private_init&);
 
   /**
    * Gets a sendable wrapper object for the given video source, creating the
@@ -45,6 +47,9 @@ class SendableCameraWrapper : public SendableBase {
    */
   static SendableCameraWrapper& Wrap(const cs::VideoSource& source);
   static SendableCameraWrapper& Wrap(CS_Source source);
+
+  static SendableCameraWrapper& Wrap(std::string cameraName,
+                                     wpi::ArrayRef<std::string> cameraUrls);
 
   void InitSendable(SendableBuilder& builder) override;
 

--- a/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardContainer.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardContainer.h
@@ -133,6 +133,18 @@ class ShuffleboardContainer : public virtual ShuffleboardValue,
   ComplexWidget& Add(const wpi::Twine& title, const cs::VideoSource& video);
 
   /**
+   * Adds a widget to this container to display a video stream.
+   *
+   * @param title      the title of the widget
+   * @param cameraName the name of the streamed camera
+   * @param cameraUrls the URLs with which the dashboard can access the camera
+   * stream
+   * @return a widget to display the camera stream
+   */
+  ComplexWidget& Add(const wpi::Twine& title, const std::string cameraName,
+                     wpi::ArrayRef<std::string> cameraUrls);
+
+  /**
    * Adds a widget to this container to display the given sendable.
    *
    * @param sendable the sendable to display

--- a/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardContainer.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardContainer.h
@@ -141,8 +141,9 @@ class ShuffleboardContainer : public virtual ShuffleboardValue,
    * stream
    * @return a widget to display the camera stream
    */
-  ComplexWidget& Add(const wpi::Twine& title, const std::string cameraName,
-                     wpi::ArrayRef<std::string> cameraUrls);
+  ComplexWidget& AddCamera(const wpi::Twine& title,
+                           const std::string cameraName,
+                           wpi::ArrayRef<std::string> cameraUrls);
 
   /**
    * Adds a widget to this container to display the given sendable.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
@@ -95,6 +95,20 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
   }
 
   /**
+   * Adds a widget to this container to display a video stream.
+   *
+   * @param title      the title of the widget
+   * @param cameraName the name of the streamed camera
+   * @param cameraUrls the URLs with which the dashboard can access the camera stream
+   * @return a widget to display the camera stream
+   * @throws IllegalArgumentException if a widget already exists in this container with the given
+   *                                  title
+   */
+  default ComplexWidget add(String title, String cameraName, String... cameraUrls) {
+    return add(title, SendableCameraWrapper.wrap(cameraName, cameraUrls));
+  }
+
+  /**
    * Adds a widget to this container to display the given sendable.
    *
    * @param sendable the sendable to display

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
@@ -95,20 +95,6 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
   }
 
   /**
-   * Adds a widget to this container to display a video stream.
-   *
-   * @param title      the title of the widget
-   * @param cameraName the name of the streamed camera
-   * @param cameraUrls the URLs with which the dashboard can access the camera stream
-   * @return a widget to display the camera stream
-   * @throws IllegalArgumentException if a widget already exists in this container with the given
-   *                                  title
-   */
-  default ComplexWidget add(String title, String cameraName, String... cameraUrls) {
-    return add(title, SendableCameraWrapper.wrap(cameraName, cameraUrls));
-  }
-
-  /**
    * Adds a widget to this container to display the given sendable.
    *
    * @param sendable the sendable to display
@@ -141,6 +127,20 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
    * @see #addPersistent(String, Object) add(String title, Object defaultValue)
    */
   SimpleWidget add(String title, Object defaultValue) throws IllegalArgumentException;
+
+  /**
+   * Adds a widget to this container to display a video stream.
+   *
+   * @param title      the title of the widget
+   * @param cameraName the name of the streamed camera
+   * @param cameraUrls the URLs with which the dashboard can access the camera stream
+   * @return a widget to display the camera stream
+   * @throws IllegalArgumentException if a widget already exists in this container with the given
+   *                                  title
+   */
+  default ComplexWidget addCamera(String title, String cameraName, String... cameraUrls) {
+    return add(title, SendableCameraWrapper.wrap(cameraName, cameraUrls));
+  }
 
   /**
    * Adds a widget to this container. The widget will display the data provided by the value

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/SendableCameraWrapperTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/SendableCameraWrapperTest.java
@@ -1,0 +1,70 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.shuffleboard;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.networktables.NetworkTableInstance;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SendableCameraWrapperTest {
+  @BeforeEach
+  void setup() {
+    NetworkTableInstance.getDefault().deleteAllEntries();
+    SendableCameraWrapper.clearWrappers();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    NetworkTableInstance.getDefault().deleteAllEntries();
+  }
+
+  @Test
+  void testNullCameraName() {
+    assertThrows(NullPointerException.class,
+        () -> SendableCameraWrapper.wrap(null, ""));
+  }
+
+  @Test
+  void testEmptyCameraName() {
+    assertThrows(IllegalArgumentException.class,
+        () -> SendableCameraWrapper.wrap("", ""));
+  }
+
+  @Test
+  void testNullUrlArray() {
+    assertThrows(NullPointerException.class,
+        () -> SendableCameraWrapper.wrap("name", (String[]) null));
+  }
+
+  @Test
+  void testNullUrlInArray() {
+    assertThrows(NullPointerException.class,
+        () -> SendableCameraWrapper.wrap("name", "url", null));
+  }
+
+  @Test
+  void testEmptyUrlArray() {
+    assertThrows(IllegalArgumentException.class,
+        () -> SendableCameraWrapper.wrap("name"));
+  }
+
+  @Test
+  void testUrlsAddedToNt() {
+    SendableCameraWrapper.wrap("name", "url1", "url2");
+    assertArrayEquals(
+        new String[]{"url1", "url2"},
+        NetworkTableInstance.getDefault()
+            .getEntry("/CameraPublisher/name/streams").getValue().getStringArray()
+    );
+  }
+}


### PR DESCRIPTION
Useful for adding cameras that are streamed from a coprocessor

#### Usage

**Java**
```java
Shuffleboard.getTab("Tab")
  .add("My Camera", "Camera Name", "url1", "url2);
```

**C++**
```c++
Shuffleboard::GetTab("Tab)
  .Add("My Camera", "Camera Name", wpi::ArrayRef<std::string>{"url1", "url2"});
```

Closes https://github.com/wpilibsuite/shuffleboard/issues/582
Closes https://github.com/wpilibsuite/shuffleboard/issues/598
Closes #1587