### PR TITLE
Accelerometer and Potentiometer base classes

### DIFF
--- a/wpilibc/src/main/native/cpp/AccelerometerBase.cpp
+++ b/wpilibc/src/main/native/cpp/AccelerometerBase.cpp
@@ -1,0 +1,19 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/AccelerometerBase.h"
+
+#include "frc/smartdashboard/SendableBuilder.h"
+
+using namespace frc;
+
+void AccelerometerBase::InitSendable(SendableBuilder& builder) {
+  builder.SetSmartDashboardType("3AxisAccelerometer");
+  builder.AddDoubleProperty("X", [=]() { return GetX(); }, nullptr);
+  builder.AddDoubleProperty("Y", [=]() { return GetY(); }, nullptr);
+  builder.AddDoubleProperty("Z", [=]() { return GetZ(); }, nullptr);
+}

--- a/wpilibc/src/main/native/cpp/BuiltInAccelerometer.cpp
+++ b/wpilibc/src/main/native/cpp/BuiltInAccelerometer.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2014-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2014-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -11,7 +11,6 @@
 #include <hal/HAL.h>
 
 #include "frc/WPIErrors.h"
-#include "frc/smartdashboard/SendableBuilder.h"
 
 using namespace frc;
 
@@ -39,10 +38,3 @@ double BuiltInAccelerometer::GetX() { return HAL_GetAccelerometerX(); }
 double BuiltInAccelerometer::GetY() { return HAL_GetAccelerometerY(); }
 
 double BuiltInAccelerometer::GetZ() { return HAL_GetAccelerometerZ(); }
-
-void BuiltInAccelerometer::InitSendable(SendableBuilder& builder) {
-  builder.SetSmartDashboardType("3AxisAccelerometer");
-  builder.AddDoubleProperty("X", [=]() { return GetX(); }, nullptr);
-  builder.AddDoubleProperty("Y", [=]() { return GetY(); }, nullptr);
-  builder.AddDoubleProperty("Z", [=]() { return GetZ(); }, nullptr);
-}

--- a/wpilibc/src/main/native/include/frc/ADXL345_I2C.h
+++ b/wpilibc/src/main/native/include/frc/ADXL345_I2C.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -7,10 +7,9 @@
 
 #pragma once
 
+#include "frc/AccelerometerBase.h"
 #include "frc/ErrorBase.h"
 #include "frc/I2C.h"
-#include "frc/interfaces/Accelerometer.h"
-#include "frc/smartdashboard/SendableBase.h"
 
 namespace frc {
 
@@ -21,9 +20,7 @@ namespace frc {
  * an I2C bus. This class assumes the default (not alternate) sensor address of
  * 0x1D (7-bit address).
  */
-class ADXL345_I2C : public ErrorBase,
-                    public SendableBase,
-                    public Accelerometer {
+class ADXL345_I2C : public ErrorBase, public AccelerometerBase {
  public:
   enum Axes { kAxis_X = 0x00, kAxis_Y = 0x02, kAxis_Z = 0x04 };
 

--- a/wpilibc/src/main/native/include/frc/ADXL345_SPI.h
+++ b/wpilibc/src/main/native/include/frc/ADXL345_SPI.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -7,10 +7,9 @@
 
 #pragma once
 
+#include "frc/AccelerometerBase.h"
 #include "frc/ErrorBase.h"
 #include "frc/SPI.h"
-#include "frc/interfaces/Accelerometer.h"
-#include "frc/smartdashboard/SendableBase.h"
 
 namespace frc {
 
@@ -20,9 +19,7 @@ namespace frc {
  * This class allows access to an Analog Devices ADXL345 3-axis accelerometer
  * via SPI. This class assumes the sensor is wired in 4-wire SPI mode.
  */
-class ADXL345_SPI : public ErrorBase,
-                    public SendableBase,
-                    public Accelerometer {
+class ADXL345_SPI : public ErrorBase, public AccelerometerBase {
  public:
   enum Axes { kAxis_X = 0x00, kAxis_Y = 0x02, kAxis_Z = 0x04 };
 

--- a/wpilibc/src/main/native/include/frc/ADXL362.h
+++ b/wpilibc/src/main/native/include/frc/ADXL362.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -7,10 +7,9 @@
 
 #pragma once
 
+#include "frc/AccelerometerBase.h"
 #include "frc/ErrorBase.h"
 #include "frc/SPI.h"
-#include "frc/interfaces/Accelerometer.h"
-#include "frc/smartdashboard/SendableBase.h"
 
 namespace frc {
 
@@ -19,7 +18,7 @@ namespace frc {
  *
  * This class allows access to an Analog Devices ADXL362 3-axis accelerometer.
  */
-class ADXL362 : public ErrorBase, public SendableBase, public Accelerometer {
+class ADXL362 : public ErrorBase, public AccelerometerBase {
  public:
   enum Axes { kAxis_X = 0x00, kAxis_Y = 0x02, kAxis_Z = 0x04 };
   struct AllAxes {

--- a/wpilibc/src/main/native/include/frc/AccelerometerBase.h
+++ b/wpilibc/src/main/native/include/frc/AccelerometerBase.h
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include "frc/interfaces/Accelerometer.h"
+#include "frc/smartdashboard/SendableBase.h"
+
+namespace frc {
+
+/**
+ * Interface for 3-axis accelerometers.
+ */
+class AccelerometerBase : public Accelerometer, public SendableBase {
+ public:
+  AccelerometerBase() = default;
+  virtual ~AccelerometerBase() = default;
+
+  AccelerometerBase(AccelerometerBase&&) = default;
+  AccelerometerBase& operator=(AccelerometerBase&&) = default;
+
+  void InitSendable(SendableBuilder& builder) override;
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/AnalogPotentiometer.h
+++ b/wpilibc/src/main/native/include/frc/AnalogPotentiometer.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2016-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2016-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -11,8 +11,7 @@
 
 #include "frc/AnalogInput.h"
 #include "frc/ErrorBase.h"
-#include "frc/interfaces/Potentiometer.h"
-#include "frc/smartdashboard/SendableBase.h"
+#include "frc/PotentiometerBase.h"
 
 namespace frc {
 
@@ -22,9 +21,7 @@ namespace frc {
  * units you choose, by way of the scaling and offset constants passed to the
  * constructor.
  */
-class AnalogPotentiometer : public ErrorBase,
-                            public SendableBase,
-                            public Potentiometer {
+class AnalogPotentiometer : public ErrorBase, public PotentiometerBase {
  public:
   /**
    * Construct an Analog Potentiometer object from a channel number.

--- a/wpilibc/src/main/native/include/frc/BuiltInAccelerometer.h
+++ b/wpilibc/src/main/native/include/frc/BuiltInAccelerometer.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2014-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2014-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -7,9 +7,8 @@
 
 #pragma once
 
+#include "frc/AccelerometerBase.h"
 #include "frc/ErrorBase.h"
-#include "frc/interfaces/Accelerometer.h"
-#include "frc/smartdashboard/SendableBase.h"
 
 namespace frc {
 
@@ -18,9 +17,7 @@ namespace frc {
  *
  * This class allows access to the roboRIO's internal accelerometer.
  */
-class BuiltInAccelerometer : public ErrorBase,
-                             public SendableBase,
-                             public Accelerometer {
+class BuiltInAccelerometer : public ErrorBase, public AccelerometerBase {
  public:
   /**
    * Constructor.
@@ -56,8 +53,6 @@ class BuiltInAccelerometer : public ErrorBase,
    * @return The acceleration of the roboRIO along the Z axis in g-forces
    */
   double GetZ() override;
-
-  void InitSendable(SendableBuilder& builder) override;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/PotentiometerBase.h
+++ b/wpilibc/src/main/native/include/frc/PotentiometerBase.h
@@ -1,0 +1,27 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include "frc/interfaces/Potentiometer.h"
+#include "frc/smartdashboard/SendableBase.h"
+
+namespace frc {
+
+/**
+ * Interface for potentiometers that can be displayed on a dashboard.
+ */
+class PotentiometerBase : public Potentiometer, public SendableBase {
+ public:
+  PotentiometerBase() = default;
+  virtual ~PotentiometerBase() = default;
+
+  PotentiometerBase(PotentiometerBase&&) = default;
+  PotentiometerBase& operator=(PotentiometerBase&&) = default;
+};
+
+}  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_I2C.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_I2C.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -14,14 +14,13 @@ import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.networktables.NetworkTableEntry;
-import edu.wpi.first.wpilibj.interfaces.Accelerometer;
 import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 
 /**
  * ADXL345 I2C Accelerometer.
  */
 @SuppressWarnings({"TypeName", "PMD.UnusedPrivateField"})
-public class ADXL345_I2C extends SendableBase implements Accelerometer {
+public class ADXL345_I2C extends AccelerometerBase {
   private static final byte kAddress = 0x1D;
   private static final byte kPowerCtlRegister = 0x2D;
   private static final byte kDataFormatRegister = 0x31;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_SPI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_SPI.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -14,14 +14,13 @@ import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.networktables.NetworkTableEntry;
-import edu.wpi.first.wpilibj.interfaces.Accelerometer;
 import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 
 /**
  * ADXL345 SPI Accelerometer.
  */
 @SuppressWarnings({"TypeName", "PMD.UnusedPrivateField"})
-public class ADXL345_SPI extends SendableBase implements Accelerometer {
+public class ADXL345_SPI extends AccelerometerBase {
   private static final int kPowerCtlRegister = 0x2D;
   private static final int kDataFormatRegister = 0x31;
   private static final int kDataRegister = 0x32;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL362.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL362.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -13,7 +13,6 @@ import java.nio.ByteOrder;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.networktables.NetworkTableEntry;
-import edu.wpi.first.wpilibj.interfaces.Accelerometer;
 import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 
 /**
@@ -22,7 +21,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
  * <p>This class allows access to an Analog Devices ADXL362 3-axis accelerometer.
  */
 @SuppressWarnings("PMD.UnusedPrivateField")
-public class ADXL362 extends SendableBase implements Accelerometer {
+public class ADXL362 extends AccelerometerBase {
   private static final byte kRegWrite = 0x0A;
   private static final byte kRegRead = 0x0B;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AccelerometerBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AccelerometerBase.java
@@ -1,0 +1,24 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj;
+
+import edu.wpi.first.wpilibj.interfaces.Accelerometer;
+import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+
+/**
+ * Interface for 3-axis accelerometers that can be displayed.
+ */
+public abstract class AccelerometerBase extends SendableBase implements Accelerometer {
+  @Override
+  public void initSendable(SendableBuilder builder) {
+    builder.setSmartDashboardType("3AxisAccelerometer");
+    builder.addDoubleProperty("X", this::getX, null);
+    builder.addDoubleProperty("Y", this::getY, null);
+    builder.addDoubleProperty("Z", this::getZ, null);
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -7,7 +7,6 @@
 
 package edu.wpi.first.wpilibj;
 
-import edu.wpi.first.wpilibj.interfaces.Potentiometer;
 import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 
 /**
@@ -15,7 +14,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
  * corresponds to a position. The position is in whichever units you choose, by way of the scaling
  * and offset constants passed to the constructor.
  */
-public class AnalogPotentiometer extends SendableBase implements Potentiometer {
+public class AnalogPotentiometer extends PotentiometerBase {
   private AnalogInput m_analogInput;
   private boolean m_initAnalogInput;
   private double m_fullRange;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/BuiltInAccelerometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/BuiltInAccelerometer.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2014-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2014-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -11,15 +11,13 @@ import edu.wpi.first.hal.AccelerometerJNI;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.sim.AccelerometerSim;
-import edu.wpi.first.wpilibj.interfaces.Accelerometer;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 
 /**
  * Built-in accelerometer.
  *
  * <p>This class allows access to the roboRIO's internal accelerometer.
  */
-public class BuiltInAccelerometer extends SendableBase implements Accelerometer {
+public class BuiltInAccelerometer extends AccelerometerBase {
   /**
    * Constructor.
    *
@@ -89,14 +87,6 @@ public class BuiltInAccelerometer extends SendableBase implements Accelerometer 
   @Override
   public double getZ() {
     return AccelerometerJNI.getAccelerometerZ();
-  }
-
-  @Override
-  public void initSendable(SendableBuilder builder) {
-    builder.setSmartDashboardType("3AxisAccelerometer");
-    builder.addDoubleProperty("X", this::getX, null);
-    builder.addDoubleProperty("Y", this::getY, null);
-    builder.addDoubleProperty("Z", this::getZ, null);
   }
 
   public AccelerometerSim getSimObject() {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PotentiometerBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PotentiometerBase.java
@@ -1,0 +1,19 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj;
+
+import edu.wpi.first.wpilibj.interfaces.Potentiometer;
+import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+
+/**
+ * Interface for a Potentiometer that can be displayed on a dashboard.
+ */
+public abstract class PotentiometerBase extends SendableBase implements Potentiometer {
+  @Override
+  public abstract void initSendable(SendableBuilder builder);
+}


### PR DESCRIPTION
Inspired by the work in #1567, creates `AccelerometerBase` and `PotentiometerBase` that are the same as their associated interfaces, but also inherit from `SendableBase`. This is to help create more testable objects/mock objects.