### PR TITLE
remove unnecessary synchronization from SendableBase

### DIFF
--- a/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
+++ b/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
@@ -81,9 +81,9 @@ void LiveWindow::AddChild(Sendable* parent, void* child) {
   comp.telemetryEnabled = false;
 }
 
-void LiveWindow::Remove(Sendable* sendable) {
+bool LiveWindow::Remove(Sendable* sendable) {
   std::scoped_lock lock(m_impl->mutex);
-  m_impl->components.erase(sendable);
+  return m_impl->components.erase(sendable);
 }
 
 void LiveWindow::EnableTelemetry(Sendable* sendable) {

--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableBase.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableBase.cpp
@@ -19,17 +19,11 @@ SendableBase::SendableBase(bool addLiveWindow) {
 
 SendableBase::~SendableBase() { LiveWindow::GetInstance()->Remove(this); }
 
-std::string SendableBase::GetName() const {
-  return m_name;
-}
+std::string SendableBase::GetName() const { return m_name; }
 
-void SendableBase::SetName(const wpi::Twine& name) {
-  m_name = name.str();
-}
+void SendableBase::SetName(const wpi::Twine& name) { m_name = name.str(); }
 
-std::string SendableBase::GetSubsystem() const {
-  return m_subsystem;
-}
+std::string SendableBase::GetSubsystem() const { return m_subsystem; }
 
 void SendableBase::SetSubsystem(const wpi::Twine& subsystem) {
   m_subsystem = subsystem.str();

--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableBase.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableBase.cpp
@@ -17,17 +17,22 @@ SendableBase::SendableBase(bool addLiveWindow) {
   if (addLiveWindow) LiveWindow::GetInstance()->Add(this);
 }
 
-SendableBase::SendableBase(SendableBase&& other) {
-  LiveWindow::GetInstance()->Remove(&other);
-  LiveWindow::GetInstance()->Add(this);
+SendableBase::SendableBase(SendableBase&& other)
+    : m_name(other.m_name), m_subsystem(other.m_subsystem) {
+  auto&& lw = LiveWindow::GetInstance();
+  if (lw->Remove(&other)) {
+    lw->Add(this);
+  }
 }
 
 SendableBase& SendableBase::operator=(SendableBase&& other) {
   m_name = other.m_name;
   m_subsystem = other.m_subsystem;
-  LiveWindow::GetInstance()->Remove(&other);
-  LiveWindow::GetInstance()->Add(this);
-  
+  auto&& lw = LiveWindow::GetInstance();
+  if (lw->Remove(&other)) {
+    lw->Add(this);
+  }
+
   return *this;
 }
 

--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableBase.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableBase.cpp
@@ -18,7 +18,8 @@ SendableBase::SendableBase(bool addLiveWindow) {
 }
 
 SendableBase::SendableBase(SendableBase&& other)
-    : m_name(other.m_name), m_subsystem(other.m_subsystem) {
+    : m_name(std::move(other.m_name)),
+      m_subsystem(std::move(other.m_subsystem)) {
   auto&& lw = LiveWindow::GetInstance();
   if (lw->Remove(&other)) {
     lw->Add(this);
@@ -26,8 +27,8 @@ SendableBase::SendableBase(SendableBase&& other)
 }
 
 SendableBase& SendableBase::operator=(SendableBase&& other) {
-  m_name = other.m_name;
-  m_subsystem = other.m_subsystem;
+  m_name = std::move(other.m_name);
+  m_subsystem = std::move(other.m_subsystem);
   auto&& lw = LiveWindow::GetInstance();
   if (lw->Remove(&other)) {
     lw->Add(this);

--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableBase.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableBase.cpp
@@ -19,37 +19,19 @@ SendableBase::SendableBase(bool addLiveWindow) {
 
 SendableBase::~SendableBase() { LiveWindow::GetInstance()->Remove(this); }
 
-SendableBase::SendableBase(SendableBase&& rhs) {
-  m_name = std::move(rhs.m_name);
-  m_subsystem = std::move(rhs.m_subsystem);
-}
-
-SendableBase& SendableBase::operator=(SendableBase&& rhs) {
-  Sendable::operator=(std::move(rhs));
-
-  m_name = std::move(rhs.m_name);
-  m_subsystem = std::move(rhs.m_subsystem);
-
-  return *this;
-}
-
 std::string SendableBase::GetName() const {
-  std::scoped_lock lock(m_mutex);
   return m_name;
 }
 
 void SendableBase::SetName(const wpi::Twine& name) {
-  std::scoped_lock lock(m_mutex);
   m_name = name.str();
 }
 
 std::string SendableBase::GetSubsystem() const {
-  std::scoped_lock lock(m_mutex);
   return m_subsystem;
 }
 
 void SendableBase::SetSubsystem(const wpi::Twine& subsystem) {
-  std::scoped_lock lock(m_mutex);
   m_subsystem = subsystem.str();
 }
 

--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableBase.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableBase.cpp
@@ -17,6 +17,20 @@ SendableBase::SendableBase(bool addLiveWindow) {
   if (addLiveWindow) LiveWindow::GetInstance()->Add(this);
 }
 
+SendableBase::SendableBase(SendableBase&& other) {
+  LiveWindow::GetInstance()->Remove(&other);
+  LiveWindow::GetInstance()->Add(this);
+}
+
+SendableBase& SendableBase::operator=(SendableBase&& other) {
+  m_name = other.m_name;
+  m_subsystem = other.m_subsystem;
+  LiveWindow::GetInstance()->Remove(&other);
+  LiveWindow::GetInstance()->Add(this);
+  
+  return *this;
+}
+
 SendableBase::~SendableBase() { LiveWindow::GetInstance()->Remove(this); }
 
 std::string SendableBase::GetName() const { return m_name; }

--- a/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
+++ b/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
@@ -68,7 +68,7 @@ class LiveWindow {
    *
    * @param sendable component to remove
    */
-  void Remove(Sendable* component);
+  bool Remove(Sendable* component);
 
   /**
    * Enable telemetry for a single component.

--- a/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
+++ b/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
@@ -67,6 +67,7 @@ class LiveWindow {
    * Remove the component from the LiveWindow.
    *
    * @param sendable component to remove
+   * @return true if the component was removed; false if it was not present
    */
   bool Remove(Sendable* component);
 

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableBase.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableBase.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableBase.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableBase.h
@@ -10,8 +10,6 @@
 #include <memory>
 #include <string>
 
-#include <wpi/mutex.h>
-
 #include "frc/smartdashboard/Sendable.h"
 
 namespace frc {

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableBase.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableBase.h
@@ -27,8 +27,8 @@ class SendableBase : public Sendable {
 
   SendableBase(const SendableBase&) = default;
   SendableBase& operator=(const SendableBase&) = default;
-  SendableBase(SendableBase&&) = default;
-  SendableBase& operator=(SendableBase&&) = default;
+  SendableBase(SendableBase&&);
+  SendableBase& operator=(SendableBase&&);
 
   using Sendable::SetName;
 

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableBase.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableBase.h
@@ -27,8 +27,10 @@ class SendableBase : public Sendable {
 
   ~SendableBase() override;
 
-  SendableBase(SendableBase&& rhs);
-  SendableBase& operator=(SendableBase&& rhs);
+  SendableBase(const SendableBase&) = default;
+  SendableBase& operator=(const SendableBase&) = default;
+  SendableBase(SendableBase&&) = default;
+  SendableBase& operator=(SendableBase&&) = default;
 
   using Sendable::SetName;
 
@@ -73,7 +75,6 @@ class SendableBase : public Sendable {
   void SetName(const wpi::Twine& moduleType, int moduleNumber, int channel);
 
  private:
-  mutable wpi::mutex m_mutex;
   std::string m_name;
   std::string m_subsystem = "Ungrouped";
 };

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SendableBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SendableBase.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SendableBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SendableBase.java
@@ -46,12 +46,12 @@ public abstract class SendableBase implements Sendable, AutoCloseable {
   }
 
   @Override
-  public final synchronized String getName() {
+  public final String getName() {
     return m_name;
   }
 
   @Override
-  public final synchronized void setName(String name) {
+  public final void setName(String name) {
     m_name = name;
   }
 
@@ -77,12 +77,12 @@ public abstract class SendableBase implements Sendable, AutoCloseable {
   }
 
   @Override
-  public final synchronized String getSubsystem() {
+  public final String getSubsystem() {
     return m_subsystem;
   }
 
   @Override
-  public final synchronized void setSubsystem(String subsystem) {
+  public final void setSubsystem(String subsystem) {
     m_subsystem = subsystem;
   }
 


### PR DESCRIPTION
The mutexes in SendableBase are unnecessary, as the methods are never used asynchronously.  These were preventing the class from having default copy/move constructors, which would be very handy.