### PR TITLE
Synchronous Sendable listeners

### DIFF
--- a/wpilibc/src/main/native/cpp/smartdashboard/ListenerExecutor.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/ListenerExecutor.cpp
@@ -1,0 +1,27 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/smartdashboard/ListenerExecutor.h"
+
+using namespace frc;
+
+void ListenerExecutor::Execute(std::function<void()> task) {
+  std::scoped_lock lock(m_lock);
+  m_tasks.emplace_back(task);
+}
+
+void ListenerExecutor::RunListenerTasks() {
+  // Locally copy tasks from internal list; minimizes blocking time
+  m_lock.lock();
+  std::vector<std::function<void()>> tasks(m_tasks);
+  m_tasks.clear();
+  m_lock.unlock();
+
+  for (auto&& task : tasks) {
+    task();
+  }
+}

--- a/wpilibc/src/main/native/cpp/smartdashboard/ListenerExecutor.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/ListenerExecutor.cpp
@@ -7,7 +7,7 @@
 
 #include "frc/smartdashboard/ListenerExecutor.h"
 
-using namespace frc;
+using namespace frc::detail;
 
 void ListenerExecutor::Execute(std::function<void()> task) {
   std::scoped_lock lock(m_lock);

--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
@@ -91,7 +91,7 @@ void SendableBuilderImpl::AddBooleanProperty(const wpi::Twine& key,
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsBoolean()) return;
             SmartDashboard::PostListenerTask(
-                [&setter, &event] { setter(event.value->GetBoolean()); });
+                [=] { setter(event.value->GetBoolean()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -115,7 +115,7 @@ void SendableBuilderImpl::AddDoubleProperty(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsDouble()) return;
             SmartDashboard::PostListenerTask(
-                [&setter, &event] { setter(event.value->GetDouble()); });
+                [=] { setter(event.value->GetDouble()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -139,7 +139,7 @@ void SendableBuilderImpl::AddStringProperty(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsString()) return;
             SmartDashboard::PostListenerTask(
-                [&setter, &event] { setter(event.value->GetString()); });
+                [=] { setter(event.value->GetString()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -163,7 +163,7 @@ void SendableBuilderImpl::AddBooleanArrayProperty(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsBooleanArray()) return;
             SmartDashboard::PostListenerTask(
-                [&setter, &event] { setter(event.value->GetBooleanArray()); });
+                [=] { setter(event.value->GetBooleanArray()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -187,7 +187,7 @@ void SendableBuilderImpl::AddDoubleArrayProperty(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsDoubleArray()) return;
             SmartDashboard::PostListenerTask(
-                [&setter, &event] { setter(event.value->GetDoubleArray()); });
+                [=] { setter(event.value->GetDoubleArray()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -211,7 +211,7 @@ void SendableBuilderImpl::AddStringArrayProperty(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsStringArray()) return;
             SmartDashboard::PostListenerTask(
-                [&setter, &event] { setter(event.value->GetStringArray()); });
+                [=] { setter(event.value->GetStringArray()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -235,7 +235,7 @@ void SendableBuilderImpl::AddRawProperty(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsRaw()) return;
             SmartDashboard::PostListenerTask(
-                [&setter, &event] { setter(event.value->GetRaw()); });
+                [=] { setter(event.value->GetRaw()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -257,8 +257,7 @@ void SendableBuilderImpl::AddValueProperty(
         [=](nt::NetworkTableEntry entry) -> NT_EntryListener {
       return entry.AddListener(
           [=](const nt::EntryNotification& event) {
-            SmartDashboard::PostListenerTask(
-                [&setter, &event] { setter(event.value); });
+            SmartDashboard::PostListenerTask([=] { setter(event.value); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -284,7 +283,7 @@ void SendableBuilderImpl::AddSmallStringProperty(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsString()) return;
             SmartDashboard::PostListenerTask(
-                [&setter, &event] { setter(event.value->GetString()); });
+                [=] { setter(event.value->GetString()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -310,7 +309,7 @@ void SendableBuilderImpl::AddSmallBooleanArrayProperty(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsBooleanArray()) return;
             SmartDashboard::PostListenerTask(
-                [&setter, &event] { setter(event.value->GetBooleanArray()); });
+                [=] { setter(event.value->GetBooleanArray()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -337,7 +336,7 @@ void SendableBuilderImpl::AddSmallDoubleArrayProperty(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsDoubleArray()) return;
             SmartDashboard::PostListenerTask(
-                [&setter, &event] { setter(event.value->GetDoubleArray()); });
+                [=] { setter(event.value->GetDoubleArray()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -365,7 +364,7 @@ void SendableBuilderImpl::AddSmallStringArrayProperty(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsStringArray()) return;
             SmartDashboard::PostListenerTask(
-                [&setter, &event] { setter(event.value->GetStringArray()); });
+                [=] { setter(event.value->GetStringArray()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -391,7 +390,7 @@ void SendableBuilderImpl::AddSmallRawProperty(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsRaw()) return;
             SmartDashboard::PostListenerTask(
-                [&setter, &event] { setter(event.value->GetRaw()); });
+                [=] { setter(event.value->GetRaw()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };

--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
@@ -10,6 +10,8 @@
 #include <ntcore_cpp.h>
 #include <wpi/SmallString.h>
 
+#include "frc/smartdashboard/SmartDashboard.h"
+
 using namespace frc;
 
 void SendableBuilderImpl::SetTable(std::shared_ptr<nt::NetworkTable> table) {
@@ -88,7 +90,8 @@ void SendableBuilderImpl::AddBooleanProperty(const wpi::Twine& key,
       return entry.AddListener(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsBoolean()) return;
-            setter(event.value->GetBoolean());
+            SmartDashboard::PostListenerTask(
+                [&setter, &event] { setter(event.value->GetBoolean()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -111,7 +114,8 @@ void SendableBuilderImpl::AddDoubleProperty(
       return entry.AddListener(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsDouble()) return;
-            setter(event.value->GetDouble());
+            SmartDashboard::PostListenerTask(
+                [&setter, &event] { setter(event.value->GetDouble()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -134,7 +138,8 @@ void SendableBuilderImpl::AddStringProperty(
       return entry.AddListener(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsString()) return;
-            setter(event.value->GetString());
+            SmartDashboard::PostListenerTask(
+                [&setter, &event] { setter(event.value->GetString()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -157,7 +162,8 @@ void SendableBuilderImpl::AddBooleanArrayProperty(
       return entry.AddListener(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsBooleanArray()) return;
-            setter(event.value->GetBooleanArray());
+            SmartDashboard::PostListenerTask(
+                [&setter, &event] { setter(event.value->GetBooleanArray()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -180,7 +186,8 @@ void SendableBuilderImpl::AddDoubleArrayProperty(
       return entry.AddListener(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsDoubleArray()) return;
-            setter(event.value->GetDoubleArray());
+            SmartDashboard::PostListenerTask(
+                [&setter, &event] { setter(event.value->GetDoubleArray()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -203,7 +210,8 @@ void SendableBuilderImpl::AddStringArrayProperty(
       return entry.AddListener(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsStringArray()) return;
-            setter(event.value->GetStringArray());
+            SmartDashboard::PostListenerTask(
+                [&setter, &event] { setter(event.value->GetStringArray()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -226,7 +234,8 @@ void SendableBuilderImpl::AddRawProperty(
       return entry.AddListener(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsRaw()) return;
-            setter(event.value->GetRaw());
+            SmartDashboard::PostListenerTask(
+                [&setter, &event] { setter(event.value->GetRaw()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -247,7 +256,10 @@ void SendableBuilderImpl::AddValueProperty(
     m_properties.back().createListener =
         [=](nt::NetworkTableEntry entry) -> NT_EntryListener {
       return entry.AddListener(
-          [=](const nt::EntryNotification& event) { setter(event.value); },
+          [=](const nt::EntryNotification& event) {
+            SmartDashboard::PostListenerTask(
+                [&setter, &event] { setter(event.value); });
+          },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
   }
@@ -271,7 +283,8 @@ void SendableBuilderImpl::AddSmallStringProperty(
       return entry.AddListener(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsString()) return;
-            setter(event.value->GetString());
+            SmartDashboard::PostListenerTask(
+                [&setter, &event] { setter(event.value->GetString()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -296,7 +309,8 @@ void SendableBuilderImpl::AddSmallBooleanArrayProperty(
       return entry.AddListener(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsBooleanArray()) return;
-            setter(event.value->GetBooleanArray());
+            SmartDashboard::PostListenerTask(
+                [&setter, &event] { setter(event.value->GetBooleanArray()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -322,7 +336,8 @@ void SendableBuilderImpl::AddSmallDoubleArrayProperty(
       return entry.AddListener(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsDoubleArray()) return;
-            setter(event.value->GetDoubleArray());
+            SmartDashboard::PostListenerTask(
+                [&setter, &event] { setter(event.value->GetDoubleArray()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -349,7 +364,8 @@ void SendableBuilderImpl::AddSmallStringArrayProperty(
       return entry.AddListener(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsStringArray()) return;
-            setter(event.value->GetStringArray());
+            SmartDashboard::PostListenerTask(
+                [&setter, &event] { setter(event.value->GetStringArray()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };
@@ -374,7 +390,8 @@ void SendableBuilderImpl::AddSmallRawProperty(
       return entry.AddListener(
           [=](const nt::EntryNotification& event) {
             if (!event.value->IsRaw()) return;
-            setter(event.value->GetRaw());
+            SmartDashboard::PostListenerTask(
+                [&setter, &event] { setter(event.value->GetRaw()); });
           },
           NT_NOTIFY_IMMEDIATE | NT_NOTIFY_NEW | NT_NOTIFY_UPDATE);
     };

--- a/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
@@ -254,7 +254,7 @@ std::shared_ptr<nt::Value> SmartDashboard::GetValue(wpi::StringRef keyName) {
   return Singleton::GetInstance().table->GetEntry(keyName).GetValue();
 }
 
-ListenerExecutor SmartDashboard::listenerExecutor;
+detail::ListenerExecutor SmartDashboard::listenerExecutor;
 
 void SmartDashboard::PostListenerTask(std::function<void()> task) {
   listenerExecutor.Execute(task);

--- a/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
@@ -254,10 +254,17 @@ std::shared_ptr<nt::Value> SmartDashboard::GetValue(wpi::StringRef keyName) {
   return Singleton::GetInstance().table->GetEntry(keyName).GetValue();
 }
 
+ListenerExecutor SmartDashboard::listenerExecutor;
+
+void SmartDashboard::PostListenerTask(std::function<void()> task) {
+  listenerExecutor.Execute(task);
+}
+
 void SmartDashboard::UpdateValues() {
   auto& inst = Singleton::GetInstance();
   std::scoped_lock lock(inst.tablesToDataMutex);
   for (auto& i : inst.tablesToData) {
     i.getValue().builder.UpdateTable();
   }
+  listenerExecutor.RunListenerTasks();
 }

--- a/wpilibc/src/main/native/include/frc/smartdashboard/ListenerExecutor.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/ListenerExecutor.h
@@ -12,7 +12,7 @@
 
 #include <wpi/mutex.h>
 
-namespace frc {
+namespace frc::detail {
 /**
  * An executor for running listener tasks posted by Sendable listeners
  * synchronously from the main application thread.
@@ -38,4 +38,4 @@ class ListenerExecutor {
   std::vector<std::function<void()>> m_runningTasks;
   wpi::mutex m_lock;
 };
-}  // namespace frc
+}  // namespace frc::detail

--- a/wpilibc/src/main/native/include/frc/smartdashboard/ListenerExecutor.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/ListenerExecutor.h
@@ -11,13 +11,13 @@
 #include <mutex>
 #include <vector>
 
+namespace frc {
 /**
  * An executor for running listener tasks posted by Sendable listeners
  * synchronously from the main application thread.
  *
  * @see Sendable
  */
-namespace frc {
 class ListenerExecutor {
  public:
   /**

--- a/wpilibc/src/main/native/include/frc/smartdashboard/ListenerExecutor.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/ListenerExecutor.h
@@ -9,6 +9,7 @@
 
 #include <functional>
 #include <vector>
+
 #include <wpi/mutex.h>
 
 namespace frc {

--- a/wpilibc/src/main/native/include/frc/smartdashboard/ListenerExecutor.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/ListenerExecutor.h
@@ -34,6 +34,7 @@ class ListenerExecutor {
 
  private:
   std::vector<std::function<void()>> m_tasks;
+  std::vector<std::function<void()>> m_runningTasks;
   std::mutex m_lock;
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/smartdashboard/ListenerExecutor.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/ListenerExecutor.h
@@ -1,0 +1,39 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <functional>
+#include <mutex>
+#include <vector>
+
+/**
+ * An executor for running listener tasks posted by Sendable listeners
+ * synchronously from the main application thread.
+ *
+ * @see Sendable
+ */
+namespace frc {
+class ListenerExecutor {
+ public:
+  /**
+   * Posts a task to the executor to be run synchronously from the main thread.
+   *
+   * @param task The task to run synchronously from the main thread.
+   */
+  void Execute(std::function<void()> task);
+
+  /**
+   * Runs all posted tasks.  Called periodically from main thread.
+   */
+  void RunListenerTasks();
+
+ private:
+  std::vector<std::function<void()>> m_tasks;
+  std::mutex m_lock;
+};
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/smartdashboard/ListenerExecutor.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/ListenerExecutor.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <functional>
-#include <mutex>
 #include <vector>
+#include <wpi/mutex.h>
 
 namespace frc {
 /**
@@ -35,6 +35,6 @@ class ListenerExecutor {
  private:
   std::vector<std::function<void()>> m_tasks;
   std::vector<std::function<void()>> m_runningTasks;
-  std::mutex m_lock;
+  wpi::mutex m_lock;
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2011-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2011-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
@@ -14,6 +14,7 @@
 #include <networktables/NetworkTableValue.h>
 
 #include "frc/ErrorBase.h"
+#include "frc/smartdashboard/ListenerExecutor.h"
 #include "frc/smartdashboard/SendableBase.h"
 
 namespace frc {
@@ -402,12 +403,23 @@ class SmartDashboard : public ErrorBase, public SendableBase {
   static std::shared_ptr<nt::Value> GetValue(wpi::StringRef keyName);
 
   /**
+   * Posts a task from a listener to the ListenerExecutor, so that it can be run
+   * synchronously from the main loop on the next call to {@link
+   * SmartDashboard#updateValues()}.
+   *
+   * @param task The task to run synchronously from the main thread.
+   */
+  static void PostListenerTask(std::function<void()> task);
+
+  /**
    * Puts all sendable data to the dashboard.
    */
   static void UpdateValues();
 
  private:
   virtual ~SmartDashboard() = default;
+
+  static ListenerExecutor listenerExecutor;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
@@ -419,7 +419,7 @@ class SmartDashboard : public ErrorBase, public SendableBase {
  private:
   virtual ~SmartDashboard() = default;
 
-  static ListenerExecutor listenerExecutor;
+  static detail::ListenerExecutor listenerExecutor;
 };
 
 }  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/ListenerExecutor.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/ListenerExecutor.java
@@ -1,4 +1,50 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
 package edu.wpi.first.wpilibj.smartdashboard;
 
-public class ListenerExecutor {
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.Executor;
+
+/**
+ * An executor for running listener tasks posted by {@link edu.wpi.first.wpilibj.Sendable} listeners
+ * synchronously from the main application thread.
+ */
+class ListenerExecutor implements Executor {
+  private final Collection<Runnable> m_tasks = new ArrayList<>();
+  private final Object m_lock = new Object();
+
+  /**
+   * Posts a task to the executor to be run synchronously from the main thread.
+   *
+   * @param task The task to run synchronously from the main thread.
+   */
+  @Override
+  public void execute(Runnable task) {
+    synchronized (m_lock) {
+      m_tasks.add(task);
+    }
+  }
+
+  /**
+   * Runs all posted tasks.  Called periodically from main thread.
+   */
+  public void runListenerTasks() {
+    // Locally copy tasks from internal list; minimizes blocking time
+    Collection<Runnable> tasks = new ArrayList<>();
+    synchronized (m_lock) {
+      tasks.addAll(m_tasks);
+      m_tasks.clear();
+    }
+
+    // Run all tasks
+    for (Runnable task : tasks) {
+      task.run();
+    }
+  }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/ListenerExecutor.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/ListenerExecutor.java
@@ -1,0 +1,4 @@
+package edu.wpi.first.wpilibj.smartdashboard;
+
+public class ListenerExecutor {
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
@@ -61,8 +61,8 @@ public class SendableBuilderImpl implements SendableBuilder {
   private boolean m_actuator;
 
   /**
-   * Set the network table.  Must be called prior to any Add* functions being
-   * called.
+   * Set the network table.  Must be called prior to any Add* functions being called.
+   *
    * @param table Network table
    */
   public void setTable(NetworkTable table) {
@@ -72,6 +72,7 @@ public class SendableBuilderImpl implements SendableBuilder {
 
   /**
    * Get the network table.
+   *
    * @return The network table
    */
   public NetworkTable getTable() {
@@ -80,6 +81,7 @@ public class SendableBuilderImpl implements SendableBuilder {
 
   /**
    * Return whether this sendable should be treated as an actuator.
+   *
    * @return True if actuator, false if not.
    */
   public boolean isActuator() {
@@ -125,8 +127,8 @@ public class SendableBuilderImpl implements SendableBuilder {
   }
 
   /**
-   * Start LiveWindow mode by hooking the setters for all properties.  Also
-   * calls the safeState function if one was provided.
+   * Start LiveWindow mode by hooking the setters for all properties.  Also calls the safeState
+   * function if one was provided.
    */
   public void startLiveWindowMode() {
     if (m_safeState != null) {
@@ -136,8 +138,8 @@ public class SendableBuilderImpl implements SendableBuilder {
   }
 
   /**
-   * Stop LiveWindow mode by unhooking the setters for all properties.  Also
-   * calls the safeState function if one was provided.
+   * Stop LiveWindow mode by unhooking the setters for all properties.  Also calls the safeState
+   * function if one was provided.
    */
   public void stopLiveWindowMode() {
     stopListeners();
@@ -147,10 +149,10 @@ public class SendableBuilderImpl implements SendableBuilder {
   }
 
   /**
-   * Set the string representation of the named data type that will be used
-   * by the smart dashboard for this sendable.
+   * Set the string representation of the named data type that will be used by the smart dashboard
+   * for this sendable.
    *
-   * @param type    data type
+   * @param type data type
    */
   @Override
   public void setSmartDashboardType(String type) {
@@ -158,10 +160,10 @@ public class SendableBuilderImpl implements SendableBuilder {
   }
 
   /**
-   * Set a flag indicating if this sendable should be treated as an actuator.
-   * By default this flag is false.
+   * Set a flag indicating if this sendable should be treated as an actuator. By default this flag
+   * is false.
    *
-   * @param value   true if actuator, false if not
+   * @param value true if actuator, false if not
    */
   @Override
   public void setActuator(boolean value) {
@@ -170,10 +172,10 @@ public class SendableBuilderImpl implements SendableBuilder {
   }
 
   /**
-   * Set the function that should be called to set the Sendable into a safe
-   * state.  This is called when entering and exiting Live Window mode.
+   * Set the function that should be called to set the Sendable into a safe state.  This is called
+   * when entering and exiting Live Window mode.
    *
-   * @param func    function
+   * @param func function
    */
   @Override
   public void setSafeState(Runnable func) {
@@ -181,12 +183,11 @@ public class SendableBuilderImpl implements SendableBuilder {
   }
 
   /**
-   * Set the function that should be called to update the network table
-   * for things other than properties.  Note this function is not passed
-   * the network table object; instead it should use the entry handles
-   * returned by getEntry().
+   * Set the function that should be called to update the network table for things other than
+   * properties.  Note this function is not passed the network table object; instead it should use
+   * the entry handles returned by getEntry().
    *
-   * @param func    function
+   * @param func function
    */
   @Override
   public void setUpdateTable(Runnable func) {
@@ -194,10 +195,10 @@ public class SendableBuilderImpl implements SendableBuilder {
   }
 
   /**
-   * Add a property without getters or setters.  This can be used to get
-   * entry handles for the function called by setUpdateTable().
+   * Add a property without getters or setters.  This can be used to get entry handles for the
+   * function called by setUpdateTable().
    *
-   * @param key   property name
+   * @param key property name
    * @return Network table entry
    */
   @Override
@@ -208,9 +209,9 @@ public class SendableBuilderImpl implements SendableBuilder {
   /**
    * Add a boolean property.
    *
-   * @param key     property name
-   * @param getter  getter function (returns current value)
-   * @param setter  setter function (sets new value)
+   * @param key    property name
+   * @param getter getter function (returns current value)
+   * @param setter setter function (sets new value)
    */
   @Override
   public void addBooleanProperty(String key, BooleanSupplier getter, BooleanConsumer setter) {
@@ -221,7 +222,7 @@ public class SendableBuilderImpl implements SendableBuilder {
     if (setter != null) {
       property.m_createListener = entry -> entry.addListener(event -> {
         if (event.value.isBoolean()) {
-          setter.accept(event.value.getBoolean());
+          SmartDashboard.postListenerTask(() -> setter.accept(event.value.getBoolean()));
         }
       }, EntryListenerFlags.kImmediate | EntryListenerFlags.kNew | EntryListenerFlags.kUpdate);
     }
@@ -231,9 +232,9 @@ public class SendableBuilderImpl implements SendableBuilder {
   /**
    * Add a double property.
    *
-   * @param key     property name
-   * @param getter  getter function (returns current value)
-   * @param setter  setter function (sets new value)
+   * @param key    property name
+   * @param getter getter function (returns current value)
+   * @param setter setter function (sets new value)
    */
   @Override
   public void addDoubleProperty(String key, DoubleSupplier getter, DoubleConsumer setter) {
@@ -244,7 +245,7 @@ public class SendableBuilderImpl implements SendableBuilder {
     if (setter != null) {
       property.m_createListener = entry -> entry.addListener(event -> {
         if (event.value.isDouble()) {
-          setter.accept(event.value.getDouble());
+          SmartDashboard.postListenerTask(() -> setter.accept(event.value.getDouble()));
         }
       }, EntryListenerFlags.kImmediate | EntryListenerFlags.kNew | EntryListenerFlags.kUpdate);
     }
@@ -254,9 +255,9 @@ public class SendableBuilderImpl implements SendableBuilder {
   /**
    * Add a string property.
    *
-   * @param key     property name
-   * @param getter  getter function (returns current value)
-   * @param setter  setter function (sets new value)
+   * @param key    property name
+   * @param getter getter function (returns current value)
+   * @param setter setter function (sets new value)
    */
   @Override
   public void addStringProperty(String key, Supplier<String> getter, Consumer<String> setter) {
@@ -267,7 +268,7 @@ public class SendableBuilderImpl implements SendableBuilder {
     if (setter != null) {
       property.m_createListener = entry -> entry.addListener(event -> {
         if (event.value.isString()) {
-          setter.accept(event.value.getString());
+          SmartDashboard.postListenerTask(() -> setter.accept(event.value.getString()));
         }
       }, EntryListenerFlags.kImmediate | EntryListenerFlags.kNew | EntryListenerFlags.kUpdate);
     }
@@ -277,9 +278,9 @@ public class SendableBuilderImpl implements SendableBuilder {
   /**
    * Add a boolean array property.
    *
-   * @param key     property name
-   * @param getter  getter function (returns current value)
-   * @param setter  setter function (sets new value)
+   * @param key    property name
+   * @param getter getter function (returns current value)
+   * @param setter setter function (sets new value)
    */
   @Override
   public void addBooleanArrayProperty(String key, Supplier<boolean[]> getter,
@@ -291,7 +292,7 @@ public class SendableBuilderImpl implements SendableBuilder {
     if (setter != null) {
       property.m_createListener = entry -> entry.addListener(event -> {
         if (event.value.isBooleanArray()) {
-          setter.accept(event.value.getBooleanArray());
+          SmartDashboard.postListenerTask(() -> setter.accept(event.value.getBooleanArray()));
         }
       }, EntryListenerFlags.kImmediate | EntryListenerFlags.kNew | EntryListenerFlags.kUpdate);
     }
@@ -301,9 +302,9 @@ public class SendableBuilderImpl implements SendableBuilder {
   /**
    * Add a double array property.
    *
-   * @param key     property name
-   * @param getter  getter function (returns current value)
-   * @param setter  setter function (sets new value)
+   * @param key    property name
+   * @param getter getter function (returns current value)
+   * @param setter setter function (sets new value)
    */
   @Override
   public void addDoubleArrayProperty(String key, Supplier<double[]> getter,
@@ -315,7 +316,7 @@ public class SendableBuilderImpl implements SendableBuilder {
     if (setter != null) {
       property.m_createListener = entry -> entry.addListener(event -> {
         if (event.value.isDoubleArray()) {
-          setter.accept(event.value.getDoubleArray());
+          SmartDashboard.postListenerTask(() -> setter.accept(event.value.getDoubleArray()));
         }
       }, EntryListenerFlags.kImmediate | EntryListenerFlags.kNew | EntryListenerFlags.kUpdate);
     }
@@ -325,9 +326,9 @@ public class SendableBuilderImpl implements SendableBuilder {
   /**
    * Add a string array property.
    *
-   * @param key     property name
-   * @param getter  getter function (returns current value)
-   * @param setter  setter function (sets new value)
+   * @param key    property name
+   * @param getter getter function (returns current value)
+   * @param setter setter function (sets new value)
    */
   @Override
   public void addStringArrayProperty(String key, Supplier<String[]> getter,
@@ -339,7 +340,7 @@ public class SendableBuilderImpl implements SendableBuilder {
     if (setter != null) {
       property.m_createListener = entry -> entry.addListener(event -> {
         if (event.value.isStringArray()) {
-          setter.accept(event.value.getStringArray());
+          SmartDashboard.postListenerTask(() -> setter.accept(event.value.getStringArray()));
         }
       }, EntryListenerFlags.kImmediate | EntryListenerFlags.kNew | EntryListenerFlags.kUpdate);
     }
@@ -349,9 +350,9 @@ public class SendableBuilderImpl implements SendableBuilder {
   /**
    * Add a raw property.
    *
-   * @param key     property name
-   * @param getter  getter function (returns current value)
-   * @param setter  setter function (sets new value)
+   * @param key    property name
+   * @param getter getter function (returns current value)
+   * @param setter setter function (sets new value)
    */
   @Override
   public void addRawProperty(String key, Supplier<byte[]> getter, Consumer<byte[]> setter) {
@@ -362,7 +363,7 @@ public class SendableBuilderImpl implements SendableBuilder {
     if (setter != null) {
       property.m_createListener = entry -> entry.addListener(event -> {
         if (event.value.isRaw()) {
-          setter.accept(event.value.getRaw());
+          SmartDashboard.postListenerTask(() -> setter.accept(event.value.getRaw()));
         }
       }, EntryListenerFlags.kImmediate | EntryListenerFlags.kNew | EntryListenerFlags.kUpdate);
     }
@@ -372,9 +373,9 @@ public class SendableBuilderImpl implements SendableBuilder {
   /**
    * Add a NetworkTableValue property.
    *
-   * @param key     property name
-   * @param getter  getter function (returns current value)
-   * @param setter  setter function (sets new value)
+   * @param key    property name
+   * @param getter getter function (returns current value)
+   * @param setter setter function (sets new value)
    */
   @Override
   public void addValueProperty(String key, Supplier<NetworkTableValue> getter,
@@ -385,7 +386,7 @@ public class SendableBuilderImpl implements SendableBuilder {
     }
     if (setter != null) {
       property.m_createListener = entry -> entry.addListener(event -> {
-        setter.accept(event.value);
+        SmartDashboard.postListenerTask(() -> setter.accept(event.value));
       }, EntryListenerFlags.kImmediate | EntryListenerFlags.kNew | EntryListenerFlags.kUpdate);
     }
     m_properties.add(property);


### PR DESCRIPTION
Previously, the listeners on `Sendable` objects called the passed-in setters asynchronously.  This is a large potential source of bugs, forces a lot of locking logic into other classes, and is not necessarily obvious to users.

This adds a synchronous executor to which setter calls can be posted asynchronously, so that they are all called synchronously from the main loop (namely, from the `SmartDashboard.updateValues()` method).