### PR TITLE
Fix PIDControllerRunner member destruction order

### DIFF
--- a/wpilibc/src/main/native/include/frc/controller/PIDControllerRunner.h
+++ b/wpilibc/src/main/native/include/frc/controller/PIDControllerRunner.h
@@ -55,7 +55,6 @@ class PIDControllerRunner : SendableBase {
   void InitSendable(SendableBuilder& builder) override;
 
  private:
-  Notifier m_notifier{&PIDControllerRunner::Run, this};
   frc2::PIDController& m_controller;
   std::function<double(void)> m_measurementSource;
   std::function<void(double)> m_controllerOutput;
@@ -66,6 +65,12 @@ class PIDControllerRunner : SendableBase {
   // Ensures when Disable() is called, m_controllerOutput() won't run if
   // Controller::Update() is already running at that time.
   mutable wpi::mutex m_outputMutex;
+
+  // This is declared after all other member variables so that during
+  // PIDControllerRunner destruction, the Notifier is stopped before any member
+  // variables its callable uses are destructed. This avoids use-after-free
+  // bugs like crashes when locking is attempted on deallocated mutexes.
+  Notifier m_notifier{&PIDControllerRunner::Run, this};
 
   void Run();
 };

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDControllerRunner.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDControllerRunner.java
@@ -16,7 +16,6 @@ import edu.wpi.first.wpilibj.SendableBase;
 import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 
 public class PIDControllerRunner extends SendableBase {
-  private final Notifier m_notifier = new Notifier(this::run);
   private final PIDController m_controller;
   private final DoubleConsumer m_controllerOutput;
   private final DoubleSupplier m_measurementSource;
@@ -27,6 +26,12 @@ public class PIDControllerRunner extends SendableBase {
   // Ensures when disable() is called, m_controllerOutput() won't run if
   // Controller.update() is already running at that time.
   private final ReentrantLock m_outputMutex = new ReentrantLock();
+
+  // This is declared after all other member variables so that during
+  // PIDControllerRunner destruction, the Notifier is stopped before any member
+  // variables its callable uses are destructed. This avoids use-after-free
+  // bugs like crashes when locking is attempted on deallocated mutexes.
+  private final Notifier m_notifier = new Notifier(this::run);
 
   /**
    * Allocates a PIDControllerRunner.


### PR DESCRIPTION
The mutexes in PIDControllerRunner are declared after the Notifier, and
we don't stop the Notifier in `~PIDControllerRunner()`; we call
`PIDControllerRunner::Disable()`, but that doesn't actually stop the
Notifier. It still calls this:

```
void PIDControllerRunner::Run() {
  // Ensures m_enabled check and m_controllerOutput() call occur atomically
  std::scoped_lock outputLock(m_outputMutex);
  std::unique_lock mainLock(m_thisMutex);
  if (m_enabled) {
    // Don't block other PIDControllerRunner operations on output
    mainLock.unlock();

    m_controllerOutput(m_controller.Calculate(m_measurementSource()));
  }
}
```

When we call `PIDControllerRunner::Disable()`, the Notifier is still
running, locking the mutexes, and accessing `m_enabled`. When the
PIDControllerRunner object is destructed, the PIDControllerRunner
destructor runs, then the member object destructors are called in the
reverse order in which they are declared. The mutexes are destructed
first, then the Notifier destructor is called which stops the Notifier.
There's a window between those destructor calls during which the
Notifier can run the callable and attempt to lock a mutex that no longer
exists.

To fix this, we can either call `Notifier::Disable()` in
`~PIDControllerRunner()` so the Notifier won't be running during that
destruction window, or we can declare the Notifier after all the
variables its callable uses. I opted for the latter since it's
RAII-correct.