### PR TITLE
Fix cscore build with OpenCV 4

### DIFF
--- a/cscore/src/main/native/cpp/CvSinkImpl.cpp
+++ b/cscore/src/main/native/cpp/CvSinkImpl.cpp
@@ -217,6 +217,7 @@ void CS_SetSinkDescription(CS_Sink sink, const char* description,
   return cs::SetSinkDescription(sink, description, status);
 }
 
+#if CV_VERSION_MAJOR < 4
 uint64_t CS_GrabSinkFrame(CS_Sink sink, struct CvMat* image,
                           CS_Status* status) {
   auto mat = cv::cvarrToMat(image);
@@ -228,6 +229,7 @@ uint64_t CS_GrabSinkFrameTimeout(CS_Sink sink, struct CvMat* image,
   auto mat = cv::cvarrToMat(image);
   return cs::GrabSinkFrameTimeout(sink, mat, timeout, status);
 }
+#endif  // CV_VERSION_MAJOR < 4
 
 uint64_t CS_GrabSinkFrameCpp(CS_Sink sink, cv::Mat* image, CS_Status* status) {
   return cs::GrabSinkFrame(sink, *image, status);

--- a/cscore/src/main/native/cpp/CvSourceImpl.cpp
+++ b/cscore/src/main/native/cpp/CvSourceImpl.cpp
@@ -178,11 +178,13 @@ CS_Source CS_CreateCvSource(const char* name, const CS_VideoMode* mode,
                             status);
 }
 
+#if CV_VERSION_MAJOR < 4
 void CS_PutSourceFrame(CS_Source source, struct CvMat* image,
                        CS_Status* status) {
   auto mat = cv::cvarrToMat(image);
   return cs::PutSourceFrame(source, mat, status);
 }
+#endif  // CV_VERSION_MAJOR < 4
 
 void CS_PutSourceFrameCpp(CS_Source source, cv::Mat* image, CS_Status* status) {
   return cs::PutSourceFrame(source, *image, status);

--- a/cscore/src/main/native/cpp/Frame.cpp
+++ b/cscore/src/main/native/cpp/Frame.cpp
@@ -397,7 +397,7 @@ Image* Frame::ConvertBGRToMJPEG(Image* image, int quality) {
 
   // Compress
   if (m_impl->compressionParams.empty()) {
-    m_impl->compressionParams.push_back(CV_IMWRITE_JPEG_QUALITY);
+    m_impl->compressionParams.push_back(cv::IMWRITE_JPEG_QUALITY);
     m_impl->compressionParams.push_back(quality);
   } else {
     m_impl->compressionParams[1] = quality;
@@ -428,7 +428,7 @@ Image* Frame::ConvertGrayToMJPEG(Image* image, int quality) {
 
   // Compress
   if (m_impl->compressionParams.empty()) {
-    m_impl->compressionParams.push_back(CV_IMWRITE_JPEG_QUALITY);
+    m_impl->compressionParams.push_back(cv::IMWRITE_JPEG_QUALITY);
     m_impl->compressionParams.push_back(quality);
   } else {
     m_impl->compressionParams[1] = quality;

--- a/cscore/src/main/native/include/cscore_cv.h
+++ b/cscore/src/main/native/include/cscore_cv.h
@@ -19,6 +19,8 @@
 
 #endif
 
+#if CV_VERSION_MAJOR < 4
+
 #ifdef __cplusplus
 extern "C" {  // NOLINT(build/include_order)
 #endif
@@ -35,6 +37,8 @@ uint64_t CS_GrabSinkFrameTimeout(CS_Sink sink, struct CvMat* image,
 #ifdef __cplusplus
 }  // extern "C"
 #endif
+
+#endif  // CV_VERSION_MAJOR < 4
 
 #ifdef __cplusplus
 


### PR DESCRIPTION
The main change in OpenCV 4 was removing its C APIs from OpenCV 1. If
the user has OpenCV 4, they have no way of obtaining the correct
arguments for cscore functions that require the C API. Therefore, we can
fix the build by just not compiling in functions reliant on the C API if
OpenCV 4 is being used.

OpenCV 3 builds should continue to work with this change.