### PR TITLE
Make deprecations in c++ examples an error, not a warning

### DIFF
--- a/wpilibcExamples/build.gradle
+++ b/wpilibcExamples/build.gradle
@@ -30,6 +30,10 @@ templatesTree.list(new FilenameFilter() {
     templatesMap.put(it, [])
 }
 
+nativeUtils.platformConfigs.named(nativeUtils.wpi.platforms.roborio).configure {
+    cppCompiler.args.remove('-Wno-error=deprecated-declarations')
+    cppCompiler.args.add('-Werror=deprecated-declarations')
+}
 
 ext {
     sharedCvConfigs = examplesMap + templatesMap + [commands: []]


### PR DESCRIPTION
Someone will need to fix the actual errors, as I'm not sure what all needs to be changed.

Also only has errors on athena, as windows its not possible to make deprecation then be an error, but at least one platform is good anyway.