### PR TITLE
Refactor HAL handle move construction/assignment

### DIFF
--- a/hal/src/main/native/include/hal/I2CTypes.h
+++ b/hal/src/main/native/include/hal/I2CTypes.h
@@ -28,30 +28,7 @@ namespace hal {
  * A move-only C++ wrapper around HAL_I2CPort.
  * Does not ensure destruction.
  */
-class I2CPort {
- public:
-  I2CPort() = default;
-  /*implicit*/ I2CPort(HAL_I2CPort val)  // NOLINT(runtime/explicit)
-      : m_value(val) {}
-
-  I2CPort(const I2CPort&) = delete;
-  I2CPort& operator=(const I2CPort&) = delete;
-
-  I2CPort(I2CPort&& rhs) : m_value(rhs.m_value) {
-    rhs.m_value = HAL_I2C_kInvalid;
-  }
-
-  I2CPort& operator=(I2CPort&& rhs) {
-    m_value = rhs.m_value;
-    rhs.m_value = HAL_I2C_kInvalid;
-    return *this;
-  }
-
-  operator HAL_I2CPort() const { return m_value; }
-
- private:
-  HAL_I2CPort m_value = HAL_I2C_kInvalid;
-};
+using I2CPort = Handle<HAL_I2CPort, HAL_I2C_kInvalid>;
 
 }  // namespace hal
 #endif

--- a/hal/src/main/native/include/hal/I2CTypes.h
+++ b/hal/src/main/native/include/hal/I2CTypes.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -21,4 +21,38 @@
 HAL_ENUM(HAL_I2CPort) { HAL_I2C_kInvalid = -1, HAL_I2C_kOnboard, HAL_I2C_kMXP };
 // clang-format on
 
+#ifdef __cplusplus
+namespace hal {
+
+/**
+ * A move-only C++ wrapper around HAL_I2CPort.
+ * Does not ensure destruction.
+ */
+class I2CPort {
+ public:
+  I2CPort() = default;
+  /*implicit*/ I2CPort(HAL_I2CPort val)  // NOLINT(runtime/explicit)
+      : m_value(val) {}
+
+  I2CPort(const I2CPort&) = delete;
+  I2CPort& operator=(const I2CPort&) = delete;
+
+  I2CPort(I2CPort&& rhs) : m_value(rhs.m_value) {
+    rhs.m_value = HAL_I2C_kInvalid;
+  }
+
+  I2CPort& operator=(I2CPort&& rhs) {
+    m_value = rhs.m_value;
+    rhs.m_value = HAL_I2C_kInvalid;
+    return *this;
+  }
+
+  operator HAL_I2CPort() const { return m_value; }
+
+ private:
+  HAL_I2CPort m_value = HAL_I2C_kInvalid;
+};
+
+}  // namespace hal
+#endif
 /** @} */

--- a/hal/src/main/native/include/hal/SPITypes.h
+++ b/hal/src/main/native/include/hal/SPITypes.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -27,4 +27,39 @@ HAL_ENUM(HAL_SPIPort) {
   HAL_SPI_kMXP
 };
 // clang-format on
+
+#ifdef __cplusplus
+namespace hal {
+
+/**
+ * A move-only C++ wrapper around HAL_SPIPort.
+ * Does not ensure destruction.
+ */
+class SPIPort {
+ public:
+  SPIPort() = default;
+  /*implicit*/ SPIPort(HAL_SPIPort val)  // NOLINT(runtime/explicit)
+      : m_value(val) {}
+
+  SPIPort(const SPIPort&) = delete;
+  SPIPort& operator=(const SPIPort&) = delete;
+
+  SPIPort(SPIPort&& rhs) : m_value(rhs.m_value) {
+    rhs.m_value = HAL_SPI_kInvalid;
+  }
+
+  SPIPort& operator=(SPIPort&& rhs) {
+    m_value = rhs.m_value;
+    rhs.m_value = HAL_SPI_kInvalid;
+    return *this;
+  }
+
+  operator HAL_SPIPort() const { return m_value; }
+
+ private:
+  HAL_SPIPort m_value = HAL_SPI_kInvalid;
+};
+
+}  // namespace hal
+#endif
 /** @} */

--- a/hal/src/main/native/include/hal/SPITypes.h
+++ b/hal/src/main/native/include/hal/SPITypes.h
@@ -35,30 +35,7 @@ namespace hal {
  * A move-only C++ wrapper around HAL_SPIPort.
  * Does not ensure destruction.
  */
-class SPIPort {
- public:
-  SPIPort() = default;
-  /*implicit*/ SPIPort(HAL_SPIPort val)  // NOLINT(runtime/explicit)
-      : m_value(val) {}
-
-  SPIPort(const SPIPort&) = delete;
-  SPIPort& operator=(const SPIPort&) = delete;
-
-  SPIPort(SPIPort&& rhs) : m_value(rhs.m_value) {
-    rhs.m_value = HAL_SPI_kInvalid;
-  }
-
-  SPIPort& operator=(SPIPort&& rhs) {
-    m_value = rhs.m_value;
-    rhs.m_value = HAL_SPI_kInvalid;
-    return *this;
-  }
-
-  operator HAL_SPIPort() const { return m_value; }
-
- private:
-  HAL_SPIPort m_value = HAL_SPI_kInvalid;
-};
+using SPIPort = Handle<HAL_SPIPort, HAL_SPI_kInvalid>;
 
 }  // namespace hal
 #endif

--- a/hal/src/main/native/include/hal/Types.h
+++ b/hal/src/main/native/include/hal/Types.h
@@ -79,9 +79,7 @@ class Handle {
   Handle(const Handle&) = delete;
   Handle& operator=(const Handle&) = delete;
 
-  Handle(Handle&& rhs) : m_handle(rhs.m_handle) {
-    rhs.m_handle = CInvalid;
-  }
+  Handle(Handle&& rhs) : m_handle(rhs.m_handle) { rhs.m_handle = CInvalid; }
 
   Handle& operator=(Handle&& rhs) {
     m_handle = rhs.m_handle;

--- a/hal/src/main/native/include/hal/Types.h
+++ b/hal/src/main/native/include/hal/Types.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2016-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2016-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -61,5 +61,40 @@ typedef int32_t HAL_Bool;
 #define HAL_ENUM(name)  \
   typedef int32_t name; \
   enum name
+#endif
+
+#ifdef __cplusplus
+namespace hal {
+
+/**
+ * A move-only C++ wrapper around a HAL handle.
+ * Does not ensure destruction.
+ */
+template <typename CType>
+class Handle {
+ public:
+  Handle() = default;
+  /*implicit*/ Handle(CType val) : m_handle(val) {}  // NOLINT(runtime/explicit)
+
+  Handle(const Handle&) = delete;
+  Handle& operator=(const Handle&) = delete;
+
+  Handle(Handle&& rhs) : m_handle(rhs.m_handle) {
+    rhs.m_handle = HAL_kInvalidHandle;
+  }
+
+  Handle& operator=(Handle&& rhs) {
+    m_handle = rhs.m_handle;
+    rhs.m_handle = HAL_kInvalidHandle;
+    return *this;
+  }
+
+  operator CType() const { return m_handle; }
+
+ private:
+  CType m_handle = HAL_kInvalidHandle;
+};
+
+}  // namespace hal
 #endif
 /** @} */

--- a/hal/src/main/native/include/hal/Types.h
+++ b/hal/src/main/native/include/hal/Types.h
@@ -70,7 +70,7 @@ namespace hal {
  * A move-only C++ wrapper around a HAL handle.
  * Does not ensure destruction.
  */
-template <typename CType>
+template <typename CType, int32_t CInvalid = HAL_kInvalidHandle>
 class Handle {
  public:
   Handle() = default;
@@ -80,19 +80,19 @@ class Handle {
   Handle& operator=(const Handle&) = delete;
 
   Handle(Handle&& rhs) : m_handle(rhs.m_handle) {
-    rhs.m_handle = HAL_kInvalidHandle;
+    rhs.m_handle = CInvalid;
   }
 
   Handle& operator=(Handle&& rhs) {
     m_handle = rhs.m_handle;
-    rhs.m_handle = HAL_kInvalidHandle;
+    rhs.m_handle = CInvalid;
     return *this;
   }
 
   operator CType() const { return m_handle; }
 
  private:
-  CType m_handle = HAL_kInvalidHandle;
+  CType m_handle = CInvalid;
 };
 
 }  // namespace hal

--- a/wpilibc/src/main/native/cpp/AnalogGyro.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogGyro.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -64,20 +64,6 @@ AnalogGyro::AnalogGyro(std::shared_ptr<AnalogInput> channel, int center,
 }
 
 AnalogGyro::~AnalogGyro() { HAL_FreeAnalogGyro(m_gyroHandle); }
-
-AnalogGyro::AnalogGyro(AnalogGyro&& rhs)
-    : GyroBase(std::move(rhs)), m_analog(std::move(rhs.m_analog)) {
-  std::swap(m_gyroHandle, rhs.m_gyroHandle);
-}
-
-AnalogGyro& AnalogGyro::operator=(AnalogGyro&& rhs) {
-  GyroBase::operator=(std::move(rhs));
-
-  m_analog = std::move(rhs.m_analog);
-  std::swap(m_gyroHandle, rhs.m_gyroHandle);
-
-  return *this;
-}
 
 double AnalogGyro::GetAngle() const {
   if (StatusIsFatal()) return 0.0;

--- a/wpilibc/src/main/native/cpp/AnalogInput.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogInput.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -46,27 +46,6 @@ AnalogInput::AnalogInput(int channel) {
 }
 
 AnalogInput::~AnalogInput() { HAL_FreeAnalogInputPort(m_port); }
-
-AnalogInput::AnalogInput(AnalogInput&& rhs)
-    : ErrorBase(std::move(rhs)),
-      SendableBase(std::move(rhs)),
-      PIDSource(std::move(rhs)),
-      m_channel(std::move(rhs.m_channel)),
-      m_accumulatorOffset(std::move(rhs.m_accumulatorOffset)) {
-  std::swap(m_port, rhs.m_port);
-}
-
-AnalogInput& AnalogInput::operator=(AnalogInput&& rhs) {
-  ErrorBase::operator=(std::move(rhs));
-  SendableBase::operator=(std::move(rhs));
-  PIDSource::operator=(std::move(rhs));
-
-  m_channel = std::move(rhs.m_channel);
-  std::swap(m_port, rhs.m_port);
-  m_accumulatorOffset = std::move(rhs.m_accumulatorOffset);
-
-  return *this;
-}
 
 int AnalogInput::GetValue() const {
   if (StatusIsFatal()) return 0;

--- a/wpilibc/src/main/native/cpp/AnalogOutput.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogOutput.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2014-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2014-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -46,23 +46,6 @@ AnalogOutput::AnalogOutput(int channel) {
 }
 
 AnalogOutput::~AnalogOutput() { HAL_FreeAnalogOutputPort(m_port); }
-
-AnalogOutput::AnalogOutput(AnalogOutput&& rhs)
-    : ErrorBase(std::move(rhs)),
-      SendableBase(std::move(rhs)),
-      m_channel(std::move(rhs.m_channel)) {
-  std::swap(m_port, rhs.m_port);
-}
-
-AnalogOutput& AnalogOutput::operator=(AnalogOutput&& rhs) {
-  ErrorBase::operator=(std::move(rhs));
-  SendableBase::operator=(std::move(rhs));
-
-  m_channel = std::move(rhs.m_channel);
-  std::swap(m_port, rhs.m_port);
-
-  return *this;
-}
 
 void AnalogOutput::SetVoltage(double voltage) {
   int32_t status = 0;

--- a/wpilibc/src/main/native/cpp/AnalogTrigger.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogTrigger.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -51,8 +51,8 @@ AnalogTrigger::~AnalogTrigger() {
 AnalogTrigger::AnalogTrigger(AnalogTrigger&& rhs)
     : ErrorBase(std::move(rhs)),
       SendableBase(std::move(rhs)),
-      m_index(std::move(rhs.m_index)) {
-  std::swap(m_trigger, rhs.m_trigger);
+      m_index(std::move(rhs.m_index)),
+      m_trigger(std::move(rhs.m_trigger)) {
   std::swap(m_analogInput, rhs.m_analogInput);
   std::swap(m_ownsAnalog, rhs.m_ownsAnalog);
 }
@@ -62,7 +62,7 @@ AnalogTrigger& AnalogTrigger::operator=(AnalogTrigger&& rhs) {
   SendableBase::operator=(std::move(rhs));
 
   m_index = std::move(rhs.m_index);
-  std::swap(m_trigger, rhs.m_trigger);
+  m_trigger = std::move(rhs.m_trigger);
   std::swap(m_analogInput, rhs.m_analogInput);
   std::swap(m_ownsAnalog, rhs.m_ownsAnalog);
 

--- a/wpilibc/src/main/native/cpp/AnalogTriggerOutput.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogTriggerOutput.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -14,26 +14,17 @@
 
 using namespace frc;
 
-AnalogTriggerOutput::~AnalogTriggerOutput() {
-  if (m_interrupt != HAL_kInvalidHandle) {
-    int32_t status = 0;
-    HAL_CleanInterrupts(m_interrupt, &status);
-    // ignore status, as an invalid handle just needs to be ignored.
-    m_interrupt = HAL_kInvalidHandle;
-  }
-}
-
 bool AnalogTriggerOutput::Get() const {
   int32_t status = 0;
   bool result = HAL_GetAnalogTriggerOutput(
-      m_trigger.m_trigger, static_cast<HAL_AnalogTriggerType>(m_outputType),
+      m_trigger->m_trigger, static_cast<HAL_AnalogTriggerType>(m_outputType),
       &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
   return result;
 }
 
 HAL_Handle AnalogTriggerOutput::GetPortHandleForRouting() const {
-  return m_trigger.m_trigger;
+  return m_trigger->m_trigger;
 }
 
 AnalogTriggerType AnalogTriggerOutput::GetAnalogTriggerTypeForRouting() const {
@@ -42,13 +33,13 @@ AnalogTriggerType AnalogTriggerOutput::GetAnalogTriggerTypeForRouting() const {
 
 bool AnalogTriggerOutput::IsAnalogTrigger() const { return true; }
 
-int AnalogTriggerOutput::GetChannel() const { return m_trigger.m_index; }
+int AnalogTriggerOutput::GetChannel() const { return m_trigger->m_index; }
 
 void AnalogTriggerOutput::InitSendable(SendableBuilder&) {}
 
 AnalogTriggerOutput::AnalogTriggerOutput(const AnalogTrigger& trigger,
                                          AnalogTriggerType outputType)
-    : m_trigger(trigger), m_outputType(outputType) {
+    : m_trigger(&trigger), m_outputType(outputType) {
   HAL_Report(HALUsageReporting::kResourceType_AnalogTriggerOutput,
              trigger.GetIndex(), static_cast<uint8_t>(outputType));
 }

--- a/wpilibc/src/main/native/cpp/CAN.cpp
+++ b/wpilibc/src/main/native/cpp/CAN.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -50,18 +50,6 @@ CAN::~CAN() {
     HAL_CleanCAN(m_handle);
     m_handle = HAL_kInvalidHandle;
   }
-}
-
-CAN::CAN(CAN&& rhs) : ErrorBase(std::move(rhs)) {
-  std::swap(m_handle, rhs.m_handle);
-}
-
-CAN& CAN::operator=(CAN&& rhs) {
-  ErrorBase::operator=(std::move(rhs));
-
-  std::swap(m_handle, rhs.m_handle);
-
-  return *this;
 }
 
 void CAN::WritePacket(const uint8_t* data, int length, int apiId) {

--- a/wpilibc/src/main/native/cpp/Counter.cpp
+++ b/wpilibc/src/main/native/cpp/Counter.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -90,30 +90,6 @@ Counter::~Counter() {
   int32_t status = 0;
   HAL_FreeCounter(m_counter, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
-  m_counter = HAL_kInvalidHandle;
-}
-
-Counter::Counter(Counter&& rhs)
-    : ErrorBase(std::move(rhs)),
-      SendableBase(std::move(rhs)),
-      CounterBase(std::move(rhs)),
-      m_upSource(std::move(rhs.m_upSource)),
-      m_downSource(std::move(rhs.m_downSource)),
-      m_index(std::move(rhs.m_index)) {
-  std::swap(m_counter, rhs.m_counter);
-}
-
-Counter& Counter::operator=(Counter&& rhs) {
-  ErrorBase::operator=(std::move(rhs));
-  SendableBase::operator=(std::move(rhs));
-  CounterBase::operator=(std::move(rhs));
-
-  m_upSource = std::move(rhs.m_upSource);
-  m_downSource = std::move(rhs.m_downSource);
-  std::swap(m_counter, rhs.m_counter);
-  m_index = std::move(rhs.m_index);
-
-  return *this;
 }
 
 void Counter::SetUpSource(int channel) {

--- a/wpilibc/src/main/native/cpp/DigitalInput.cpp
+++ b/wpilibc/src/main/native/cpp/DigitalInput.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -45,28 +45,7 @@ DigitalInput::DigitalInput(int channel) {
 
 DigitalInput::~DigitalInput() {
   if (StatusIsFatal()) return;
-  if (m_interrupt != HAL_kInvalidHandle) {
-    int32_t status = 0;
-    HAL_CleanInterrupts(m_interrupt, &status);
-    // Ignore status, as an invalid handle just needs to be ignored.
-    m_interrupt = HAL_kInvalidHandle;
-  }
-
   HAL_FreeDIOPort(m_handle);
-}
-
-DigitalInput::DigitalInput(DigitalInput&& rhs)
-    : DigitalSource(std::move(rhs)), m_channel(std::move(rhs.m_channel)) {
-  std::swap(m_handle, rhs.m_handle);
-}
-
-DigitalInput& DigitalInput::operator=(DigitalInput&& rhs) {
-  DigitalSource::operator=(std::move(rhs));
-
-  m_channel = std::move(rhs.m_channel);
-  std::swap(m_handle, rhs.m_handle);
-
-  return *this;
 }
 
 bool DigitalInput::Get() const {

--- a/wpilibc/src/main/native/cpp/DigitalOutput.cpp
+++ b/wpilibc/src/main/native/cpp/DigitalOutput.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -50,25 +50,6 @@ DigitalOutput::~DigitalOutput() {
   DisablePWM();
 
   HAL_FreeDIOPort(m_handle);
-}
-
-DigitalOutput::DigitalOutput(DigitalOutput&& rhs)
-    : ErrorBase(std::move(rhs)),
-      SendableBase(std::move(rhs)),
-      m_channel(std::move(rhs.m_channel)),
-      m_pwmGenerator(std::move(rhs.m_pwmGenerator)) {
-  std::swap(m_handle, rhs.m_handle);
-}
-
-DigitalOutput& DigitalOutput::operator=(DigitalOutput&& rhs) {
-  ErrorBase::operator=(std::move(rhs));
-  SendableBase::operator=(std::move(rhs));
-
-  m_channel = std::move(rhs.m_channel);
-  std::swap(m_handle, rhs.m_handle);
-  m_pwmGenerator = std::move(rhs.m_pwmGenerator);
-
-  return *this;
 }
 
 void DigitalOutput::Set(bool value) {

--- a/wpilibc/src/main/native/cpp/DoubleSolenoid.cpp
+++ b/wpilibc/src/main/native/cpp/DoubleSolenoid.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -81,29 +81,6 @@ DoubleSolenoid::DoubleSolenoid(int moduleNumber, int forwardChannel,
 DoubleSolenoid::~DoubleSolenoid() {
   HAL_FreeSolenoidPort(m_forwardHandle);
   HAL_FreeSolenoidPort(m_reverseHandle);
-}
-
-DoubleSolenoid::DoubleSolenoid(DoubleSolenoid&& rhs)
-    : SolenoidBase(std::move(rhs)),
-      m_forwardChannel(std::move(rhs.m_forwardChannel)),
-      m_reverseChannel(std::move(rhs.m_reverseChannel)),
-      m_forwardMask(std::move(rhs.m_forwardMask)),
-      m_reverseMask(std::move(rhs.m_reverseMask)) {
-  std::swap(m_forwardHandle, rhs.m_forwardHandle);
-  std::swap(m_reverseHandle, rhs.m_reverseHandle);
-}
-
-DoubleSolenoid& DoubleSolenoid::operator=(DoubleSolenoid&& rhs) {
-  SolenoidBase::operator=(std::move(rhs));
-
-  m_forwardChannel = std::move(rhs.m_forwardChannel);
-  m_reverseChannel = std::move(rhs.m_reverseChannel);
-  m_forwardMask = std::move(rhs.m_forwardMask);
-  m_reverseMask = std::move(rhs.m_reverseMask);
-  std::swap(m_forwardHandle, rhs.m_forwardHandle);
-  std::swap(m_reverseHandle, rhs.m_reverseHandle);
-
-  return *this;
 }
 
 void DoubleSolenoid::Set(Value value) {

--- a/wpilibc/src/main/native/cpp/Encoder.cpp
+++ b/wpilibc/src/main/native/cpp/Encoder.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -59,31 +59,6 @@ Encoder::~Encoder() {
   int32_t status = 0;
   HAL_FreeEncoder(m_encoder, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
-}
-
-Encoder::Encoder(Encoder&& rhs)
-    : ErrorBase(std::move(rhs)),
-      SendableBase(std::move(rhs)),
-      CounterBase(std::move(rhs)),
-      PIDSource(std::move(rhs)),
-      m_aSource(std::move(rhs.m_aSource)),
-      m_bSource(std::move(rhs.m_bSource)),
-      m_indexSource(std::move(rhs.m_indexSource)) {
-  std::swap(m_encoder, rhs.m_encoder);
-}
-
-Encoder& Encoder::operator=(Encoder&& rhs) {
-  ErrorBase::operator=(std::move(rhs));
-  SendableBase::operator=(std::move(rhs));
-  CounterBase::operator=(std::move(rhs));
-  PIDSource::operator=(std::move(rhs));
-
-  m_aSource = std::move(rhs.m_aSource);
-  m_bSource = std::move(rhs.m_bSource);
-  m_indexSource = std::move(rhs.m_indexSource);
-  std::swap(m_encoder, rhs.m_encoder);
-
-  return *this;
 }
 
 int Encoder::Get() const {

--- a/wpilibc/src/main/native/cpp/I2C.cpp
+++ b/wpilibc/src/main/native/cpp/I2C.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -26,21 +26,6 @@ I2C::I2C(Port port, int deviceAddress)
 }
 
 I2C::~I2C() { HAL_CloseI2C(m_port); }
-
-I2C::I2C(I2C&& rhs)
-    : ErrorBase(std::move(rhs)),
-      m_deviceAddress(std::move(rhs.m_deviceAddress)) {
-  std::swap(m_port, rhs.m_port);
-}
-
-I2C& I2C::operator=(I2C&& rhs) {
-  ErrorBase::operator=(std::move(rhs));
-
-  std::swap(m_port, rhs.m_port);
-  m_deviceAddress = std::move(rhs.m_deviceAddress);
-
-  return *this;
-}
 
 bool I2C::Transaction(uint8_t* dataToSend, int sendSize, uint8_t* dataReceived,
                       int receiveSize) {

--- a/wpilibc/src/main/native/cpp/InterruptableSensorBase.cpp
+++ b/wpilibc/src/main/native/cpp/InterruptableSensorBase.cpp
@@ -21,26 +21,6 @@ InterruptableSensorBase::~InterruptableSensorBase() {
   // Ignore status, as an invalid handle just needs to be ignored.
 }
 
-InterruptableSensorBase::InterruptableSensorBase(InterruptableSensorBase&& rhs)
-    : ErrorBase(std::move(rhs)),
-      m_interrupt(rhs.m_interrupt),
-      m_interruptHandler{std::move(rhs.m_interruptHandler)} {
-  rhs.m_interrupt = HAL_kInvalidHandle;
-  rhs.m_interruptHandler = nullptr;
-}
-
-InterruptableSensorBase& InterruptableSensorBase::operator=(
-    InterruptableSensorBase&& rhs) {
-  ErrorBase::operator=(std::move(rhs));
-
-  m_interrupt = rhs.m_interrupt;
-  m_interruptHandler = std::move(rhs.m_interruptHandler);
-  rhs.m_interrupt = HAL_kInvalidHandle;
-  rhs.m_interruptHandler = nullptr;
-
-  return *this;
-}
-
 void InterruptableSensorBase::RequestInterrupts(
     HAL_InterruptHandlerFunction handler, void* param) {
   if (StatusIsFatal()) return;

--- a/wpilibc/src/main/native/cpp/PWM.cpp
+++ b/wpilibc/src/main/native/cpp/PWM.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -59,23 +59,6 @@ PWM::~PWM() {
 
   HAL_FreePWMPort(m_handle, &status);
   wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
-}
-
-PWM::PWM(PWM&& rhs)
-    : MotorSafety(std::move(rhs)),
-      SendableBase(std::move(rhs)),
-      m_channel(std::move(rhs.m_channel)) {
-  std::swap(m_handle, rhs.m_handle);
-}
-
-PWM& PWM::operator=(PWM&& rhs) {
-  ErrorBase::operator=(std::move(rhs));
-  SendableBase::operator=(std::move(rhs));
-
-  m_channel = std::move(rhs.m_channel);
-  std::swap(m_handle, rhs.m_handle);
-
-  return *this;
 }
 
 void PWM::StopMotor() { SetDisabled(); }

--- a/wpilibc/src/main/native/cpp/Relay.cpp
+++ b/wpilibc/src/main/native/cpp/Relay.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -86,27 +86,6 @@ Relay::~Relay() {
   // ignore errors, as we want to make sure a free happens.
   if (m_forwardHandle != HAL_kInvalidHandle) HAL_FreeRelayPort(m_forwardHandle);
   if (m_reverseHandle != HAL_kInvalidHandle) HAL_FreeRelayPort(m_reverseHandle);
-}
-
-Relay::Relay(Relay&& rhs)
-    : MotorSafety(std::move(rhs)),
-      SendableBase(std::move(rhs)),
-      m_channel(std::move(rhs.m_channel)),
-      m_direction(std::move(rhs.m_direction)) {
-  std::swap(m_forwardHandle, rhs.m_forwardHandle);
-  std::swap(m_reverseHandle, rhs.m_reverseHandle);
-}
-
-Relay& Relay::operator=(Relay&& rhs) {
-  MotorSafety::operator=(std::move(rhs));
-  SendableBase::operator=(std::move(rhs));
-
-  m_channel = std::move(rhs.m_channel);
-  m_direction = std::move(rhs.m_direction);
-  std::swap(m_forwardHandle, rhs.m_forwardHandle);
-  std::swap(m_reverseHandle, rhs.m_reverseHandle);
-
-  return *this;
 }
 
 void Relay::Set(Relay::Value value) {

--- a/wpilibc/src/main/native/cpp/SPI.cpp
+++ b/wpilibc/src/main/native/cpp/SPI.cpp
@@ -162,27 +162,6 @@ SPI::SPI(Port port) : m_port(static_cast<HAL_SPIPort>(port)) {
 
 SPI::~SPI() { HAL_CloseSPI(m_port); }
 
-SPI::SPI(SPI&& rhs)
-    : ErrorBase(std::move(rhs)),
-      m_msbFirst(std::move(rhs.m_msbFirst)),
-      m_sampleOnTrailing(std::move(rhs.m_sampleOnTrailing)),
-      m_clockIdleHigh(std::move(rhs.m_clockIdleHigh)),
-      m_accum(std::move(rhs.m_accum)) {
-  std::swap(m_port, rhs.m_port);
-}
-
-SPI& SPI::operator=(SPI&& rhs) {
-  ErrorBase::operator=(std::move(rhs));
-
-  std::swap(m_port, rhs.m_port);
-  m_msbFirst = std::move(rhs.m_msbFirst);
-  m_sampleOnTrailing = std::move(rhs.m_sampleOnTrailing);
-  m_clockIdleHigh = std::move(rhs.m_clockIdleHigh);
-  m_accum = std::move(rhs.m_accum);
-
-  return *this;
-}
-
 void SPI::SetClockRate(int hz) { HAL_SetSPISpeed(m_port, hz); }
 
 void SPI::SetMSBFirst() {

--- a/wpilibc/src/main/native/cpp/Solenoid.cpp
+++ b/wpilibc/src/main/native/cpp/Solenoid.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -51,20 +51,6 @@ Solenoid::Solenoid(int moduleNumber, int channel)
 }
 
 Solenoid::~Solenoid() { HAL_FreeSolenoidPort(m_solenoidHandle); }
-
-Solenoid::Solenoid(Solenoid&& rhs)
-    : SolenoidBase(std::move(rhs)), m_channel(std::move(rhs.m_channel)) {
-  std::swap(m_solenoidHandle, rhs.m_solenoidHandle);
-}
-
-Solenoid& Solenoid::operator=(Solenoid&& rhs) {
-  SolenoidBase::operator=(std::move(rhs));
-
-  std::swap(m_solenoidHandle, rhs.m_solenoidHandle);
-  m_channel = std::move(rhs.m_channel);
-
-  return *this;
-}
 
 void Solenoid::Set(bool on) {
   if (StatusIsFatal()) return;

--- a/wpilibc/src/main/native/cpp/TimedRobot.cpp
+++ b/wpilibc/src/main/native/cpp/TimedRobot.cpp
@@ -67,22 +67,6 @@ TimedRobot::~TimedRobot() {
   HAL_CleanNotifier(m_notifier, &status);
 }
 
-TimedRobot::TimedRobot(TimedRobot&& rhs)
-    : IterativeRobotBase(std::move(rhs)),
-      m_expirationTime(std::move(rhs.m_expirationTime)) {
-  std::swap(m_notifier, rhs.m_notifier);
-}
-
-TimedRobot& TimedRobot::operator=(TimedRobot&& rhs) {
-  IterativeRobotBase::operator=(std::move(rhs));
-  ErrorBase::operator=(std::move(rhs));
-
-  std::swap(m_notifier, rhs.m_notifier);
-  m_expirationTime = std::move(rhs.m_expirationTime);
-
-  return *this;
-}
-
 void TimedRobot::UpdateAlarm() {
   int32_t status = 0;
   HAL_UpdateNotifierAlarm(

--- a/wpilibc/src/main/native/include/frc/AnalogGyro.h
+++ b/wpilibc/src/main/native/include/frc/AnalogGyro.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -188,7 +188,7 @@ class AnalogGyro : public GyroBase {
   std::shared_ptr<AnalogInput> m_analog;
 
  private:
-  HAL_GyroHandle m_gyroHandle = HAL_kInvalidHandle;
+  hal::Handle<HAL_GyroHandle> m_gyroHandle;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/AnalogInput.h
+++ b/wpilibc/src/main/native/include/frc/AnalogInput.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -48,8 +48,8 @@ class AnalogInput : public ErrorBase, public SendableBase, public PIDSource {
 
   ~AnalogInput() override;
 
-  AnalogInput(AnalogInput&& rhs);
-  AnalogInput& operator=(AnalogInput&& rhs);
+  AnalogInput(AnalogInput&&) = default;
+  AnalogInput& operator=(AnalogInput&&) = default;
 
   /**
    * Get a sample straight from this channel.
@@ -284,7 +284,7 @@ class AnalogInput : public ErrorBase, public SendableBase, public PIDSource {
 
  private:
   int m_channel;
-  HAL_AnalogInputHandle m_port = HAL_kInvalidHandle;
+  hal::Handle<HAL_AnalogInputHandle> m_port;
   int64_t m_accumulatorOffset;
 };
 

--- a/wpilibc/src/main/native/include/frc/AnalogOutput.h
+++ b/wpilibc/src/main/native/include/frc/AnalogOutput.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2014-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2014-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -30,8 +30,8 @@ class AnalogOutput : public ErrorBase, public SendableBase {
 
   ~AnalogOutput() override;
 
-  AnalogOutput(AnalogOutput&& rhs);
-  AnalogOutput& operator=(AnalogOutput&& rhs);
+  AnalogOutput(AnalogOutput&&) = default;
+  AnalogOutput& operator=(AnalogOutput&&) = default;
 
   /**
    * Set the value of the analog output.
@@ -56,7 +56,7 @@ class AnalogOutput : public ErrorBase, public SendableBase {
 
  protected:
   int m_channel;
-  HAL_AnalogOutputHandle m_port = HAL_kInvalidHandle;
+  hal::Handle<HAL_AnalogOutputHandle> m_port;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/AnalogTrigger.h
+++ b/wpilibc/src/main/native/include/frc/AnalogTrigger.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -136,7 +136,7 @@ class AnalogTrigger : public ErrorBase, public SendableBase {
 
  private:
   int m_index;
-  HAL_AnalogTriggerHandle m_trigger = HAL_kInvalidHandle;
+  hal::Handle<HAL_AnalogTriggerHandle> m_trigger;
   AnalogInput* m_analogInput = nullptr;
   bool m_ownsAnalog = false;
 };

--- a/wpilibc/src/main/native/include/frc/AnalogTriggerOutput.h
+++ b/wpilibc/src/main/native/include/frc/AnalogTriggerOutput.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -48,11 +48,6 @@ class AnalogTriggerOutput : public DigitalSource {
   friend class AnalogTrigger;
 
  public:
-  ~AnalogTriggerOutput() override;
-
-  AnalogTriggerOutput(AnalogTriggerOutput&&) = default;
-  AnalogTriggerOutput& operator=(AnalogTriggerOutput&&) = default;
-
   /**
    * Get the state of the analog trigger output.
    *
@@ -99,10 +94,10 @@ class AnalogTriggerOutput : public DigitalSource {
                       AnalogTriggerType outputType);
 
  private:
-  // Uses reference rather than smart pointer because a user can not construct
+  // Uses pointer rather than smart pointer because a user can not construct
   // an AnalogTriggerOutput themselves and because the AnalogTriggerOutput
   // should always be in scope at the same time as an AnalogTrigger.
-  const AnalogTrigger& m_trigger;
+  const AnalogTrigger* m_trigger;
   AnalogTriggerType m_outputType;
 };
 

--- a/wpilibc/src/main/native/include/frc/CAN.h
+++ b/wpilibc/src/main/native/include/frc/CAN.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -58,8 +58,8 @@ class CAN : public ErrorBase {
    */
   ~CAN() override;
 
-  CAN(CAN&& rhs);
-  CAN& operator=(CAN&& rhs);
+  CAN(CAN&&) = default;
+  CAN& operator=(CAN&&) = default;
 
   /**
    * Write a packet to the CAN device with a specific ID. This ID is 10 bits.
@@ -144,6 +144,6 @@ class CAN : public ErrorBase {
       HAL_CAN_Dev_kMiscellaneous;
 
  private:
-  HAL_CANHandle m_handle = HAL_kInvalidHandle;
+  hal::Handle<HAL_CANHandle> m_handle;
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/Compressor.h
+++ b/wpilibc/src/main/native/include/frc/Compressor.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2014-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2014-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -169,7 +169,7 @@ class Compressor : public ErrorBase, public SendableBase {
   void InitSendable(SendableBuilder& builder) override;
 
  protected:
-  HAL_CompressorHandle m_compressorHandle = HAL_kInvalidHandle;
+  hal::Handle<HAL_CompressorHandle> m_compressorHandle;
 
  private:
   void SetCompressor(bool on);

--- a/wpilibc/src/main/native/include/frc/Counter.h
+++ b/wpilibc/src/main/native/include/frc/Counter.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -139,8 +139,8 @@ class Counter : public ErrorBase, public SendableBase, public CounterBase {
 
   ~Counter() override;
 
-  Counter(Counter&& rhs);
-  Counter& operator=(Counter&& rhs);
+  Counter(Counter&&) = default;
+  Counter& operator=(Counter&&) = default;
 
   /**
    * Set the upsource for the counter as a digital input channel.
@@ -425,7 +425,7 @@ class Counter : public ErrorBase, public SendableBase, public CounterBase {
   std::shared_ptr<DigitalSource> m_downSource;
 
   // The FPGA counter object
-  HAL_CounterHandle m_counter = HAL_kInvalidHandle;
+  hal::Handle<HAL_CounterHandle> m_counter;
 
  private:
   int m_index = 0;  // The index of this counter.

--- a/wpilibc/src/main/native/include/frc/DigitalInput.h
+++ b/wpilibc/src/main/native/include/frc/DigitalInput.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -35,8 +35,8 @@ class DigitalInput : public DigitalSource {
 
   ~DigitalInput() override;
 
-  DigitalInput(DigitalInput&& rhs);
-  DigitalInput& operator=(DigitalInput&& rhs);
+  DigitalInput(DigitalInput&&) = default;
+  DigitalInput& operator=(DigitalInput&&) = default;
 
   /**
    * Get the value from a digital input channel.
@@ -70,7 +70,7 @@ class DigitalInput : public DigitalSource {
 
  private:
   int m_channel;
-  HAL_DigitalHandle m_handle = HAL_kInvalidHandle;
+  hal::Handle<HAL_DigitalHandle> m_handle;
 
   friend class DigitalGlitchFilter;
 };

--- a/wpilibc/src/main/native/include/frc/DigitalOutput.h
+++ b/wpilibc/src/main/native/include/frc/DigitalOutput.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -35,8 +35,8 @@ class DigitalOutput : public ErrorBase, public SendableBase {
 
   ~DigitalOutput() override;
 
-  DigitalOutput(DigitalOutput&& rhs);
-  DigitalOutput& operator=(DigitalOutput&& rhs);
+  DigitalOutput(DigitalOutput&&) = default;
+  DigitalOutput& operator=(DigitalOutput&&) = default;
 
   /**
    * Set the value of a digital output.
@@ -124,8 +124,8 @@ class DigitalOutput : public ErrorBase, public SendableBase {
 
  private:
   int m_channel;
-  HAL_DigitalHandle m_handle = HAL_kInvalidHandle;
-  HAL_DigitalPWMHandle m_pwmGenerator = HAL_kInvalidHandle;
+  hal::Handle<HAL_DigitalHandle> m_handle;
+  hal::Handle<HAL_DigitalPWMHandle> m_pwmGenerator;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/DoubleSolenoid.h
+++ b/wpilibc/src/main/native/include/frc/DoubleSolenoid.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -45,8 +45,8 @@ class DoubleSolenoid : public SolenoidBase {
 
   ~DoubleSolenoid() override;
 
-  DoubleSolenoid(DoubleSolenoid&& rhs);
-  DoubleSolenoid& operator=(DoubleSolenoid&& rhs);
+  DoubleSolenoid(DoubleSolenoid&&) = default;
+  DoubleSolenoid& operator=(DoubleSolenoid&&) = default;
 
   /**
    * Set the value of a solenoid.
@@ -91,8 +91,8 @@ class DoubleSolenoid : public SolenoidBase {
   int m_reverseChannel;  // The reverse channel on the module to control.
   int m_forwardMask;     // The mask for the forward channel.
   int m_reverseMask;     // The mask for the reverse channel.
-  HAL_SolenoidHandle m_forwardHandle = HAL_kInvalidHandle;
-  HAL_SolenoidHandle m_reverseHandle = HAL_kInvalidHandle;
+  hal::Handle<HAL_SolenoidHandle> m_forwardHandle;
+  hal::Handle<HAL_SolenoidHandle> m_reverseHandle;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/Encoder.h
+++ b/wpilibc/src/main/native/include/frc/Encoder.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -133,8 +133,8 @@ class Encoder : public ErrorBase,
 
   ~Encoder() override;
 
-  Encoder(Encoder&& rhs);
-  Encoder& operator=(Encoder&& rhs);
+  Encoder(Encoder&&) = default;
+  Encoder& operator=(Encoder&&) = default;
 
   // CounterBase interface
   /**
@@ -362,7 +362,7 @@ class Encoder : public ErrorBase,
   std::shared_ptr<DigitalSource> m_aSource;  // The A phase of the quad encoder
   std::shared_ptr<DigitalSource> m_bSource;  // The B phase of the quad encoder
   std::shared_ptr<DigitalSource> m_indexSource = nullptr;
-  HAL_EncoderHandle m_encoder = HAL_kInvalidHandle;
+  hal::Handle<HAL_EncoderHandle> m_encoder;
 
   friend class DigitalGlitchFilter;
 };

--- a/wpilibc/src/main/native/include/frc/I2C.h
+++ b/wpilibc/src/main/native/include/frc/I2C.h
@@ -35,8 +35,8 @@ class I2C : public ErrorBase {
 
   ~I2C() override;
 
-  I2C(I2C&& rhs);
-  I2C& operator=(I2C&& rhs);
+  I2C(I2C&&) = default;
+  I2C& operator=(I2C&&) = default;
 
   /**
    * Generic transaction.
@@ -137,7 +137,7 @@ class I2C : public ErrorBase {
   bool VerifySensor(int registerAddress, int count, const uint8_t* expected);
 
  private:
-  HAL_I2CPort m_port = HAL_I2C_kInvalid;
+  hal::I2CPort m_port;
   int m_deviceAddress;
 };
 

--- a/wpilibc/src/main/native/include/frc/InterruptableSensorBase.h
+++ b/wpilibc/src/main/native/include/frc/InterruptableSensorBase.h
@@ -41,8 +41,8 @@ class InterruptableSensorBase : public ErrorBase, public SendableBase {
    */
   virtual ~InterruptableSensorBase();
 
-  InterruptableSensorBase(InterruptableSensorBase&&);
-  InterruptableSensorBase& operator=(InterruptableSensorBase&&);
+  InterruptableSensorBase(InterruptableSensorBase&&) = default;
+  InterruptableSensorBase& operator=(InterruptableSensorBase&&) = default;
 
   virtual HAL_Handle GetPortHandleForRouting() const = 0;
   virtual AnalogTriggerType GetAnalogTriggerTypeForRouting() const = 0;
@@ -144,7 +144,7 @@ class InterruptableSensorBase : public ErrorBase, public SendableBase {
   virtual void SetUpSourceEdge(bool risingEdge, bool fallingEdge);
 
  protected:
-  HAL_InterruptHandle m_interrupt{HAL_kInvalidHandle};
+  hal::Handle<HAL_InterruptHandle> m_interrupt;
   std::unique_ptr<InterruptEventHandler> m_interruptHandler{nullptr};
 
   void AllocateInterrupts(bool watcher);

--- a/wpilibc/src/main/native/include/frc/PWM.h
+++ b/wpilibc/src/main/native/include/frc/PWM.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -73,8 +73,8 @@ class PWM : public MotorSafety, public SendableBase {
    */
   ~PWM() override;
 
-  PWM(PWM&& rhs);
-  PWM& operator=(PWM&& rhs);
+  PWM(PWM&&) = default;
+  PWM& operator=(PWM&&) = default;
 
   // MotorSafety interface
   void StopMotor() override;
@@ -231,7 +231,7 @@ class PWM : public MotorSafety, public SendableBase {
 
  private:
   int m_channel;
-  HAL_DigitalHandle m_handle = HAL_kInvalidHandle;
+  hal::Handle<HAL_DigitalHandle> m_handle;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/PowerDistributionPanel.h
+++ b/wpilibc/src/main/native/include/frc/PowerDistributionPanel.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2014-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2014-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -83,7 +83,7 @@ class PowerDistributionPanel : public ErrorBase, public SendableBase {
   void InitSendable(SendableBuilder& builder) override;
 
  private:
-  HAL_PDPHandle m_handle = HAL_kInvalidHandle;
+  hal::Handle<HAL_PDPHandle> m_handle;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/Relay.h
+++ b/wpilibc/src/main/native/include/frc/Relay.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -53,8 +53,8 @@ class Relay : public MotorSafety, public SendableBase {
    */
   ~Relay() override;
 
-  Relay(Relay&& rhs);
-  Relay& operator=(Relay&& rhs);
+  Relay(Relay&&) = default;
+  Relay& operator=(Relay&&) = default;
 
   /**
    * Set the relay state.
@@ -98,8 +98,8 @@ class Relay : public MotorSafety, public SendableBase {
   int m_channel;
   Direction m_direction;
 
-  HAL_RelayHandle m_forwardHandle = HAL_kInvalidHandle;
-  HAL_RelayHandle m_reverseHandle = HAL_kInvalidHandle;
+  hal::Handle<HAL_RelayHandle> m_forwardHandle;
+  hal::Handle<HAL_RelayHandle> m_reverseHandle;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/SPI.h
+++ b/wpilibc/src/main/native/include/frc/SPI.h
@@ -41,8 +41,8 @@ class SPI : public ErrorBase {
 
   ~SPI() override;
 
-  SPI(SPI&& rhs);
-  SPI& operator=(SPI&& rhs);
+  SPI(SPI&&) = default;
+  SPI& operator=(SPI&&) = default;
 
   /**
    * Configure the rate of the generated clock signal.
@@ -345,7 +345,7 @@ class SPI : public ErrorBase {
   double GetAccumulatorIntegratedAverage() const;
 
  protected:
-  HAL_SPIPort m_port = HAL_SPI_kInvalid;
+  hal::SPIPort m_port;
   bool m_msbFirst = false;          // Default little-endian
   bool m_sampleOnTrailing = false;  // Default data updated on falling edge
   bool m_clockIdleHigh = false;     // Default clock active high

--- a/wpilibc/src/main/native/include/frc/Solenoid.h
+++ b/wpilibc/src/main/native/include/frc/Solenoid.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -38,8 +38,8 @@ class Solenoid : public SolenoidBase {
 
   ~Solenoid() override;
 
-  Solenoid(Solenoid&& rhs);
-  Solenoid& operator=(Solenoid&& rhs);
+  Solenoid(Solenoid&&) = default;
+  Solenoid& operator=(Solenoid&&) = default;
 
   /**
    * Set the value of a solenoid.
@@ -90,7 +90,7 @@ class Solenoid : public SolenoidBase {
   void InitSendable(SendableBuilder& builder) override;
 
  private:
-  HAL_SolenoidHandle m_solenoidHandle = HAL_kInvalidHandle;
+  hal::Handle<HAL_SolenoidHandle> m_solenoidHandle;
   int m_channel;  // The channel on the module to control
 };
 

--- a/wpilibc/src/main/native/include/frc/TimedRobot.h
+++ b/wpilibc/src/main/native/include/frc/TimedRobot.h
@@ -56,11 +56,11 @@ class TimedRobot : public IterativeRobotBase, public ErrorBase {
 
   ~TimedRobot() override;
 
-  TimedRobot(TimedRobot&& rhs);
-  TimedRobot& operator=(TimedRobot&& rhs);
+  TimedRobot(TimedRobot&&) = default;
+  TimedRobot& operator=(TimedRobot&&) = default;
 
  private:
-  HAL_NotifierHandle m_notifier{0};
+  hal::Handle<HAL_NotifierHandle> m_notifier;
 
   // The absolute expiration time
   double m_expirationTime = 0;


### PR DESCRIPTION
A templated hal::Handle class is used to wrap handles to make them move-only.
This eliminates a lot of boilerplate move constructor/assignment code
in the main WPILib classes.  HAL_SPIPort and HAL_I2CPort are also wrapped.

The wrapper class does not implement destruction.  This would require the
wrapper class to be handle-specific (rather than generic) and would result
in more code added than it removed, plus would add header dependencies on
more HAL headers.