### PR TITLE
TimedRobot.cpp: Fix deprecation warning

### DIFF
--- a/wpilibc/src/main/native/cpp/IterativeRobotBase.cpp
+++ b/wpilibc/src/main/native/cpp/IterativeRobotBase.cpp
@@ -24,8 +24,7 @@
 using namespace frc;
 
 IterativeRobotBase::IterativeRobotBase(double period)
-    : m_period(period),
-      m_watchdog(period, [this] { PrintLoopOverrunMessage(); }) {}
+    : IterativeRobotBase(units::second_t(period)) {}
 
 IterativeRobotBase::IterativeRobotBase(units::second_t period)
     : m_period(period.to<double>()),

--- a/wpilibc/src/main/native/cpp/TimedRobot.cpp
+++ b/wpilibc/src/main/native/cpp/TimedRobot.cpp
@@ -47,14 +47,7 @@ units::second_t TimedRobot::GetPeriod() const {
   return units::second_t(m_period);
 }
 
-TimedRobot::TimedRobot(double period) : IterativeRobotBase(period) {
-  int32_t status = 0;
-  m_notifier = HAL_InitializeNotifier(&status);
-  wpi_setErrorWithContext(status, HAL_GetErrorMessage(status));
-
-  HAL_Report(HALUsageReporting::kResourceType_Framework,
-             HALUsageReporting::kFramework_Timed);
-}
+TimedRobot::TimedRobot(double period) : TimedRobot(units::second_t(period)) {}
 
 TimedRobot::TimedRobot(units::second_t period) : IterativeRobotBase(period) {
   int32_t status = 0;


### PR DESCRIPTION
For both TimedRobot and IterativeRobotBase, use delegating constructors
to reduce code duplication.