### PR TITLE
Remove percent tolerance from PID controller

### DIFF
--- a/wpilibc/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/PIDController.cpp
@@ -64,9 +64,10 @@ void PIDController::EnableContinuousInput(double minimumInput,
 
 void PIDController::DisableContinuousInput() { m_continuous = false; }
 
-void PIDController::SetOutputRange(double minimumOutput, double maximumOutput) {
-  m_minimumOutput = minimumOutput;
-  m_maximumOutput = maximumOutput;
+void PIDController::SetIntegratorRange(double minimumIntegral,
+                                       double maximumIntegral) {
+  m_minimumIntegral = minimumIntegral;
+  m_maximumIntegral = maximumIntegral;
 }
 
 void PIDController::SetTolerance(double positionTolerance,
@@ -89,12 +90,10 @@ double PIDController::Calculate(double measurement) {
   if (m_Ki != 0) {
     m_totalError =
         std::clamp(m_totalError + m_positionError * m_period.to<double>(),
-                   m_minimumOutput / m_Ki, m_maximumOutput / m_Ki);
+                   m_minimumIntegral / m_Ki, m_maximumIntegral / m_Ki);
   }
 
-  return std::clamp(
-      m_Kp * m_positionError + m_Ki * m_totalError + m_Kd * m_velocityError,
-      m_minimumOutput, m_maximumOutput);
+  return m_Kp * m_positionError + m_Ki * m_totalError + m_Kd * m_velocityError;
 }
 
 double PIDController::Calculate(double measurement, double setpoint) {

--- a/wpilibc/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/PIDController.cpp
@@ -51,31 +51,9 @@ void PIDController::SetSetpoint(double setpoint) {
 
 double PIDController::GetSetpoint() const { return m_setpoint; }
 
-bool PIDController::AtSetpoint(double positionTolerance,
-                               double velocityTolerance,
-                               Tolerance toleranceType) const {
-  if (m_toleranceType == Tolerance::kPercent) {
-    return std::abs(m_positionError) < positionTolerance / 100 * m_inputRange &&
-           std::abs(m_velocityError) < velocityTolerance / 100 * m_inputRange;
-  } else {
-    return std::abs(m_positionError) < positionTolerance &&
-           std::abs(m_velocityError) < velocityTolerance;
-  }
-}
-
 bool PIDController::AtSetpoint() const {
-  return AtSetpoint(m_positionTolerance, m_velocityTolerance);
-}
-
-void PIDController::SetInputRange(double minimumInput, double maximumInput) {
-  m_minimumInput = minimumInput;
-  m_maximumInput = maximumInput;
-  m_inputRange = maximumInput - minimumInput;
-
-  // Clamp setpoint to new input range
-  if (m_maximumInput > m_minimumInput) {
-    m_setpoint = std::clamp(m_setpoint, m_minimumInput, m_maximumInput);
-  }
+  return std::abs(m_positionError) < m_positionTolerance &&
+         std::abs(m_velocityError) < m_velocityTolerance;
 }
 
 void PIDController::EnableContinuousInput(double minimumInput,
@@ -91,16 +69,8 @@ void PIDController::SetOutputRange(double minimumOutput, double maximumOutput) {
   m_maximumOutput = maximumOutput;
 }
 
-void PIDController::SetAbsoluteTolerance(double positionTolerance,
-                                         double velocityTolerance) {
-  m_toleranceType = Tolerance::kAbsolute;
-  m_positionTolerance = positionTolerance;
-  m_velocityTolerance = velocityTolerance;
-}
-
-void PIDController::SetPercentTolerance(double positionTolerance,
-                                        double velocityTolerance) {
-  m_toleranceType = Tolerance::kPercent;
+void PIDController::SetTolerance(double positionTolerance,
+                                 double velocityTolerance) {
   m_positionTolerance = positionTolerance;
   m_velocityTolerance = velocityTolerance;
 }
@@ -163,4 +133,15 @@ double PIDController::GetContinuousError(double error) const {
   }
 
   return error;
+}
+
+void PIDController::SetInputRange(double minimumInput, double maximumInput) {
+  m_minimumInput = minimumInput;
+  m_maximumInput = maximumInput;
+  m_inputRange = maximumInput - minimumInput;
+
+  // Clamp setpoint to new input range
+  if (m_maximumInput > m_minimumInput) {
+    m_setpoint = std::clamp(m_setpoint, m_minimumInput, m_maximumInput);
+  }
 }

--- a/wpilibc/src/main/native/cpp/controller/ProfiledPIDController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/ProfiledPIDController.cpp
@@ -69,9 +69,9 @@ void ProfiledPIDController::DisableContinuousInput() {
   m_controller.DisableContinuousInput();
 }
 
-void ProfiledPIDController::SetOutputRange(double minimumOutput,
-                                           double maximumOutput) {
-  m_controller.SetOutputRange(minimumOutput, maximumOutput);
+void ProfiledPIDController::SetIntegratorRange(double minimumIntegral,
+                                               double maximumIntegral) {
+  m_controller.SetIntegratorRange(minimumIntegral, maximumIntegral);
 }
 
 void ProfiledPIDController::SetTolerance(double positionTolerance,

--- a/wpilibc/src/main/native/cpp/controller/ProfiledPIDController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/ProfiledPIDController.cpp
@@ -43,13 +43,6 @@ units::meter_t ProfiledPIDController::GetGoal() const {
   return m_goal.position;
 }
 
-bool ProfiledPIDController::AtGoal(
-    double positionTolerance, double velocityTolerance,
-    frc2::PIDController::Tolerance toleranceType) const {
-  return AtSetpoint(positionTolerance, velocityTolerance, toleranceType) &&
-         m_goal == m_setpoint;
-}
-
 bool ProfiledPIDController::AtGoal() const {
   return AtSetpoint() && m_goal == m_setpoint;
 }
@@ -63,20 +56,8 @@ double ProfiledPIDController::GetSetpoint() const {
   return m_controller.GetSetpoint();
 }
 
-bool ProfiledPIDController::AtSetpoint(
-    double positionTolerance, double velocityTolerance,
-    frc2::PIDController::Tolerance toleranceType) const {
-  return m_controller.AtSetpoint(positionTolerance, velocityTolerance,
-                                 toleranceType);
-}
-
 bool ProfiledPIDController::AtSetpoint() const {
   return m_controller.AtSetpoint();
-}
-
-void ProfiledPIDController::SetInputRange(double minimumInput,
-                                          double maximumInput) {
-  m_controller.SetInputRange(minimumInput, maximumInput);
 }
 
 void ProfiledPIDController::EnableContinuousInput(double minimumInput,
@@ -93,14 +74,9 @@ void ProfiledPIDController::SetOutputRange(double minimumOutput,
   m_controller.SetOutputRange(minimumOutput, maximumOutput);
 }
 
-void ProfiledPIDController::SetAbsoluteTolerance(double positionTolerance,
-                                                 double velocityTolerance) {
-  m_controller.SetAbsoluteTolerance(positionTolerance, velocityTolerance);
-}
-
-void ProfiledPIDController::SetPercentTolerance(double positionTolerance,
-                                                double velocityTolerance) {
-  m_controller.SetPercentTolerance(positionTolerance, velocityTolerance);
+void ProfiledPIDController::SetTolerance(double positionTolerance,
+                                         double velocityTolerance) {
+  m_controller.SetTolerance(positionTolerance, velocityTolerance);
 }
 
 double ProfiledPIDController::GetPositionError() const {

--- a/wpilibc/src/main/native/include/frc/controller/PIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/PIDController.h
@@ -139,12 +139,15 @@ class PIDController : public frc::SendableBase {
   void DisableContinuousInput();
 
   /**
-   * Sets the minimum and maximum values to write.
+   * Sets the minimum and maximum values for the integrator.
    *
-   * @param minimumOutput the minimum value to write to the output
-   * @param maximumOutput the maximum value to write to the output
+   * When the cap is reached, the integrator value is added to the controller
+   * output rather than the integrator value times the integral gain.
+   *
+   * @param minimumIntegral The minimum value of the integrator.
+   * @param maximumIntegral The maximum value of the integrator.
    */
-  void SetOutputRange(double minimumOutput, double maximumOutput);
+  void SetIntegratorRange(double minimumIntegral, double maximumIntegral);
 
   /**
    * Sets the error which is considered tolerable for use with AtSetpoint().
@@ -211,11 +214,9 @@ class PIDController : public frc::SendableBase {
   // The period (in seconds) of the control loop running this controller
   units::second_t m_period;
 
-  // |maximum output|
-  double m_maximumOutput = 1.0;
+  double m_maximumIntegral = 1.0;
 
-  // |minimum output|
-  double m_minimumOutput = -1.0;
+  double m_minimumIntegral = -1.0;
 
   // Maximum input - limit setpoint to this
   double m_maximumInput = 0;

--- a/wpilibc/src/main/native/include/frc/controller/PIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/PIDController.h
@@ -21,8 +21,6 @@ namespace frc2 {
  */
 class PIDController : public frc::SendableBase {
  public:
-  enum class Tolerance { kAbsolute, kPercent };
-
   /**
    * Allocates a PIDController with the given constants for Kp, Ki, and Kd.
    *
@@ -117,33 +115,11 @@ class PIDController : public frc::SendableBase {
   double GetSetpoint() const;
 
   /**
-   * Returns true if the error is within tolerance of the setpoint.
-   *
-   * This will return false until at least one input value has been computed.
-   *
-   * @param positionTolerance The maximum allowable position error.
-   * @param velocityTolerance The maximum allowable velocity error.
-   * @param toleranceType     The type of tolerance specified.
-   */
-  bool AtSetpoint(
-      double positionTolerance,
-      double velocityTolerance = std::numeric_limits<double>::infinity(),
-      Tolerance toleranceType = Tolerance::kAbsolute) const;
-
-  /**
    * Returns true if the error is within the tolerance of the error.
    *
    * This will return false until at least one input value has been computed.
    */
   bool AtSetpoint() const;
-
-  /**
-   * Sets the minimum and maximum values expected from the input.
-   *
-   * @param minimumInput The minimum value expected from the input.
-   * @param maximumInput The maximum value expected from the input.
-   */
-  void SetInputRange(double minimumInput, double maximumInput);
 
   /**
    * Enables continuous input.
@@ -171,24 +147,12 @@ class PIDController : public frc::SendableBase {
   void SetOutputRange(double minimumOutput, double maximumOutput);
 
   /**
-   * Sets the absolute error which is considered tolerable for use with
-   * AtSetpoint().
+   * Sets the error which is considered tolerable for use with AtSetpoint().
    *
    * @param positionTolerance Position error which is tolerable.
    * @param velociytTolerance Velocity error which is tolerable.
    */
-  void SetAbsoluteTolerance(
-      double positionTolerance,
-      double velocityTolerance = std::numeric_limits<double>::infinity());
-
-  /**
-   * Sets the percent error which is considered tolerable for use with
-   * AtSetpoint().
-   *
-   * @param positionTolerance Position error which is tolerable.
-   * @param velociytTolerance Velocity error which is tolerable.
-   */
-  void SetPercentTolerance(
+  void SetTolerance(
       double positionTolerance,
       double velocityTolerance = std::numeric_limits<double>::infinity());
 
@@ -276,13 +240,19 @@ class PIDController : public frc::SendableBase {
   // The sum of the errors for use in the integral calc
   double m_totalError = 0;
 
-  Tolerance m_toleranceType = Tolerance::kAbsolute;
-
   // The error that is considered at setpoint.
   double m_positionTolerance = 0.05;
   double m_velocityTolerance = std::numeric_limits<double>::infinity();
 
   double m_setpoint = 0;
+
+  /**
+   * Sets the minimum and maximum values expected from the input.
+   *
+   * @param minimumInput The minimum value expected from the input.
+   * @param maximumInput The maximum value expected from the input.
+   */
+  void SetInputRange(double minimumInput, double maximumInput);
 };
 
 }  // namespace frc2

--- a/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -168,12 +168,15 @@ class ProfiledPIDController : public SendableBase {
   void DisableContinuousInput();
 
   /**
-   * Sets the minimum and maximum values to write.
+   * Sets the minimum and maximum values for the integrator.
    *
-   * @param minimumOutput the minimum value to write to the output
-   * @param maximumOutput the maximum value to write to the output
+   * When the cap is reached, the integrator value is added to the controller
+   * output rather than the integrator value times the integral gain.
+   *
+   * @param minimumIntegral The minimum value of the integrator.
+   * @param maximumIntegral The maximum value of the integrator.
    */
-  void SetOutputRange(double minimumOutput, double maximumOutput);
+  void SetIntegratorRange(double minimumIntegral, double maximumIntegral);
 
   /**
    * Sets the error which is considered tolerable for use with

--- a/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -119,21 +119,6 @@ class ProfiledPIDController : public SendableBase {
   units::meter_t GetGoal() const;
 
   /**
-   * Returns true if the error is within tolerance of the setpoint.
-   *
-   * This will return false until at least one input value has been computed.
-   *
-   * @param positionTolerance The maximum allowable position error.
-   * @param velocityTolerance The maximum allowable velocity error.
-   * @param toleranceType     The type of tolerance specified.
-   */
-  bool AtGoal(
-      double positionTolerance,
-      double velocityTolerance = std::numeric_limits<double>::infinity(),
-      frc2::PIDController::Tolerance toleranceType =
-          frc2::PIDController::Tolerance::kAbsolute) const;
-
-  /**
    * Returns true if the error is within the tolerance of the error.
    *
    * This will return false until at least one input value has been computed.
@@ -155,21 +140,6 @@ class ProfiledPIDController : public SendableBase {
   double GetSetpoint() const;
 
   /**
-   * Returns true if the error is within tolerance of the setpoint.
-   *
-   * This will return false until at least one input value has been computed.
-   *
-   * @param positionTolerance The maximum allowable position error.
-   * @param velocityTolerance The maximum allowable velocity error.
-   * @param toleranceType     The type of tolerance specified.
-   */
-  bool AtSetpoint(
-      double positionTolerance,
-      double velocityTolerance = std::numeric_limits<double>::infinity(),
-      frc2::PIDController::Tolerance toleranceType =
-          frc2::PIDController::Tolerance::kAbsolute) const;
-
-  /**
    * Returns true if the error is within the tolerance of the error.
    *
    * Currently this just reports on target as the actual value passes through
@@ -179,14 +149,6 @@ class ProfiledPIDController : public SendableBase {
    * This will return false until at least one input value has been computed.
    */
   bool AtSetpoint() const;
-
-  /**
-   * Sets the minimum and maximum values expected from the input.
-   *
-   * @param minimumInput The minimum value expected from the input.
-   * @param maximumInput The maximum value expected from the input.
-   */
-  void SetInputRange(double minimumInput, double maximumInput);
 
   /**
    * Enables continuous input.
@@ -214,24 +176,13 @@ class ProfiledPIDController : public SendableBase {
   void SetOutputRange(double minimumOutput, double maximumOutput);
 
   /**
-   * Sets the absolute error which is considered tolerable for use with
+   * Sets the error which is considered tolerable for use with
    * AtSetpoint().
    *
    * @param positionTolerance Position error which is tolerable.
    * @param velocityTolerance Velocity error which is tolerable.
    */
-  void SetAbsoluteTolerance(
-      double positionTolerance,
-      double velocityTolerance = std::numeric_limits<double>::infinity());
-
-  /**
-   * Sets the percent error which is considered tolerable for use with
-   * AtSetpoint().
-   *
-   * @param positionTolerance Position error which is tolerable.
-   * @param velocityTolerance Velocity error which is tolerable.
-   */
-  void SetPercentTolerance(
+  void SetTolerance(
       double positionTolerance,
       double velocityTolerance = std::numeric_limits<double>::infinity());
 

--- a/wpilibc/src/test/native/cpp/controller/PIDInputOutputTest.cpp
+++ b/wpilibc/src/test/native/cpp/controller/PIDInputOutputTest.cpp
@@ -17,14 +17,6 @@ class PIDInputOutputTest : public testing::Test {
   void TearDown() override { delete controller; }
 };
 
-TEST_F(PIDInputOutputTest, OutputRangeTest) {
-  controller->SetP(1);
-  controller->SetOutputRange(-50, 50);
-
-  EXPECT_DOUBLE_EQ(-50, controller->Calculate(100, 0));
-  EXPECT_DOUBLE_EQ(50, controller->Calculate(0, 100));
-}
-
 TEST_F(PIDInputOutputTest, ContinuousInputTest) {
   controller->SetP(1);
   controller->EnableContinuousInput(-180, 180);

--- a/wpilibc/src/test/native/cpp/controller/PIDInputOutputTest.cpp
+++ b/wpilibc/src/test/native/cpp/controller/PIDInputOutputTest.cpp
@@ -25,15 +25,6 @@ TEST_F(PIDInputOutputTest, OutputRangeTest) {
   EXPECT_DOUBLE_EQ(50, controller->Calculate(0, 100));
 }
 
-TEST_F(PIDInputOutputTest, InputRangeTest) {
-  controller->SetP(1);
-  controller->SetOutputRange(-1000, 1000);
-  controller->SetInputRange(-50, 50);
-
-  EXPECT_DOUBLE_EQ(-100, controller->Calculate(100, 0));
-  EXPECT_DOUBLE_EQ(50, controller->Calculate(0, 100));
-}
-
 TEST_F(PIDInputOutputTest, ContinuousInputTest) {
   controller->SetP(1);
   controller->EnableContinuousInput(-180, 180);

--- a/wpilibc/src/test/native/cpp/controller/PIDToleranceTest.cpp
+++ b/wpilibc/src/test/native/cpp/controller/PIDToleranceTest.cpp
@@ -8,68 +8,39 @@
 #include "frc/controller/PIDController.h"
 #include "gtest/gtest.h"
 
-class PIDToleranceTest : public testing::Test {
- protected:
-  static constexpr double kSetpoint = 50.0;
-  static constexpr double kRange = 200;
-  static constexpr double kTolerance = 10.0;
+static constexpr double kSetpoint = 50.0;
+static constexpr double kRange = 200;
+static constexpr double kTolerance = 10.0;
 
-  frc2::PIDController* pidController;
+TEST(PIDToleranceTest, InitialTolerance) {
+  frc2::PIDController controller{0.5, 0.0, 0.0};
+  controller.EnableContinuousInput(-kRange / 2, kRange / 2);
 
-  void SetUp() override {
-    pidController = new frc2::PIDController(0.5, 0.0, 0.0);
-    pidController->SetInputRange(-kRange / 2, kRange / 2);
-  }
-
-  void TearDown() override { delete pidController; }
-};
-
-TEST_F(PIDToleranceTest, Initial) { EXPECT_TRUE(pidController->AtSetpoint()); }
-
-TEST_F(PIDToleranceTest, Absolute) {
-  pidController->SetAbsoluteTolerance(kTolerance);
-  pidController->SetSetpoint(kSetpoint);
-
-  pidController->Calculate(0.0);
-
-  EXPECT_FALSE(pidController->AtSetpoint())
-      << "Error was in tolerance when it should not have been. Error was "
-      << pidController->GetPositionError();
-
-  pidController->Calculate(kSetpoint + kTolerance / 2);
-
-  EXPECT_TRUE(pidController->AtSetpoint())
-      << "Error was not in tolerance when it should have been. Error was "
-      << pidController->GetPositionError();
-
-  pidController->Calculate(kSetpoint + 10 * kTolerance);
-
-  EXPECT_FALSE(pidController->AtSetpoint())
-      << "Error was in tolerance when it should not have been. Error was "
-      << pidController->GetPositionError();
+  EXPECT_TRUE(controller.AtSetpoint());
 }
 
-TEST_F(PIDToleranceTest, Percent) {
-  pidController->SetPercentTolerance(kTolerance);
-  pidController->SetSetpoint(kSetpoint);
+TEST(PIDToleranceTest, AbsoluteTolerance) {
+  frc2::PIDController controller{0.5, 0.0, 0.0};
+  controller.EnableContinuousInput(-kRange / 2, kRange / 2);
 
-  pidController->Calculate(0.0);
+  controller.SetTolerance(kTolerance);
+  controller.SetSetpoint(kSetpoint);
 
-  EXPECT_FALSE(pidController->AtSetpoint())
+  controller.Calculate(0.0);
+
+  EXPECT_FALSE(controller.AtSetpoint())
       << "Error was in tolerance when it should not have been. Error was "
-      << pidController->GetPositionError();
+      << controller.GetPositionError();
 
-  // Half of percent tolerance away from setpoint
-  pidController->Calculate(kSetpoint + (kTolerance / 2) / 100 * kRange);
+  controller.Calculate(kSetpoint + kTolerance / 2);
 
-  EXPECT_TRUE(pidController->AtSetpoint())
+  EXPECT_TRUE(controller.AtSetpoint())
       << "Error was not in tolerance when it should have been. Error was "
-      << pidController->GetPositionError();
+      << controller.GetPositionError();
 
-  // Double percent tolerance away from setpoint
-  pidController->Calculate(kSetpoint + (kTolerance * 2) / 100 * kRange);
+  controller.Calculate(kSetpoint + 10 * kTolerance);
 
-  EXPECT_FALSE(pidController->AtSetpoint())
+  EXPECT_FALSE(controller.AtSetpoint())
       << "Error was in tolerance when it should not have been. Error was "
-      << pidController->GetPositionError();
+      << controller.GetPositionError();
 }

--- a/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/subsystems/ShooterSubsystem.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/subsystems/ShooterSubsystem.cpp
@@ -18,7 +18,7 @@ ShooterSubsystem::ShooterSubsystem()
       m_shooterMotor(kShooterMotorPort),
       m_feederMotor(kFeederMotorPort),
       m_shooterEncoder(kEncoderPorts[0], kEncoderPorts[1]) {
-  m_controller.SetAbsoluteTolerance(kShooterToleranceRPS);
+  m_controller.SetTolerance(kShooterToleranceRPS);
   m_shooterEncoder.SetDistancePerPulse(kEncoderDistancePerPulse);
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/DriveStraight.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/DriveStraight.cpp
@@ -18,7 +18,7 @@ DriveStraight::DriveStraight(double distance, DriveTrain* drivetrain)
           [this](double output) { m_drivetrain->Drive(output, output); },
           {drivetrain}),
       m_drivetrain(drivetrain) {
-  m_controller.SetAbsoluteTolerance(0.01);
+  m_controller.SetTolerance(0.01);
 }
 
 // Called just before this Command runs the first time

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetDistanceToBox.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetDistanceToBox.cpp
@@ -18,7 +18,7 @@ SetDistanceToBox::SetDistanceToBox(double distance, DriveTrain* drivetrain)
           [this](double output) { m_drivetrain->Drive(output, output); },
           {drivetrain}),
       m_drivetrain(drivetrain) {
-  m_controller.SetAbsoluteTolerance(0.01);
+  m_controller.SetTolerance(0.01);
 }
 
 // Called just before this Command runs the first time

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Elevator.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Elevator.cpp
@@ -16,7 +16,7 @@ Elevator::Elevator()
 #ifdef SIMULATION  // Check for simulation and update PID values
   GetPIDController()->SetPID(kP_simulation, kI_simulation, 0, 0);
 #endif
-  m_controller.SetAbsoluteTolerance(0.005);
+  m_controller.SetTolerance(0.005);
 
   SetName("Elevator");
   // Let's show everything on the LiveWindow

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Wrist.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Wrist.cpp
@@ -14,7 +14,7 @@ Wrist::Wrist() : frc2::PIDSubsystem(frc2::PIDController(kP_real, 0, 0)) {
 #ifdef SIMULATION  // Check for simulation and update PID values
   GetPIDController()->SetPID(kP_simulation, 0, 0, 0);
 #endif
-  m_controller.SetAbsoluteTolerance(2.5);
+  m_controller.SetTolerance(2.5);
 
   SetName("Wrist");
   // Let's show everything on the LiveWindow

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/commands/TurnToAngle.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/commands/TurnToAngle.cpp
@@ -26,8 +26,7 @@ TurnToAngle::TurnToAngle(double targetAngleDegrees, DriveSubsystem* drive)
   // Set the controller tolerance - the delta tolerance ensures the robot is
   // stationary at the setpoint before it is considered as having reached the
   // reference
-  m_controller.SetAbsoluteTolerance(kTurnToleranceDeg,
-                                    kTurnRateToleranceDegPerS);
+  m_controller.SetTolerance(kTurnToleranceDeg, kTurnRateToleranceDegPerS);
 
   AddRequirements({drive});
 }

--- a/wpilibcExamples/src/main/cpp/examples/PotentiometerPID/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PotentiometerPID/cpp/Robot.cpp
@@ -20,8 +20,6 @@
  */
 class Robot : public frc::TimedRobot {
  public:
-  void RobotInit() override { m_pidController.SetInputRange(0, 5); }
-
   void TeleopPeriodic() override {
     // When the button is pressed once, the selected elevator setpoint is
     // incremented.

--- a/wpilibcExamples/src/main/cpp/examples/UltrasonicPID/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/UltrasonicPID/cpp/Robot.cpp
@@ -22,10 +22,6 @@ class Robot : public frc::TimedRobot {
    * ultrasonic sensor.
    */
   void TeleopInit() override {
-    // Set expected range to 0-24 inches; e.g. at 24 inches from object go full
-    // forward, at 0 inches from object go full backward.
-    m_pidController.SetInputRange(0, 24 * kValueToInches);
-
     // Set setpoint of the PID Controller
     m_pidController.SetSetpoint(kHoldDistance * kValueToInches);
   }

--- a/wpilibcIntegrationTests/src/main/native/cpp/MotorEncoderTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/MotorEncoderTest.cpp
@@ -141,7 +141,7 @@ TEST_P(MotorEncoderTest, PositionPIDController) {
   double goal = 1000;
   frc2::PIDController pidController(0.001, 0.01, 0.0);
   pidController.SetTolerance(50.0);
-  pidController.SetOutputRange(-0.2, 0.2);
+  pidController.SetIntegratorRange(-0.2, 0.2);
   pidController.SetSetpoint(goal);
 
   /* 10 seconds should be plenty time to get to the reference */
@@ -167,7 +167,6 @@ TEST_P(MotorEncoderTest, VelocityPIDController) {
 
   frc2::PIDController pidController(1e-5, 0.0, 0.0006);
   pidController.SetTolerance(200.0);
-  pidController.SetOutputRange(-0.3, 0.3);
   pidController.SetSetpoint(600);
 
   /* 10 seconds should be plenty time to get to the reference */

--- a/wpilibcIntegrationTests/src/main/native/cpp/MotorEncoderTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/MotorEncoderTest.cpp
@@ -140,7 +140,7 @@ TEST_P(MotorEncoderTest, PositionPIDController) {
   Reset();
   double goal = 1000;
   frc2::PIDController pidController(0.001, 0.01, 0.0);
-  pidController.SetAbsoluteTolerance(50.0);
+  pidController.SetTolerance(50.0);
   pidController.SetOutputRange(-0.2, 0.2);
   pidController.SetSetpoint(goal);
 
@@ -166,7 +166,7 @@ TEST_P(MotorEncoderTest, VelocityPIDController) {
   Reset();
 
   frc2::PIDController pidController(1e-5, 0.0, 0.0006);
-  pidController.SetAbsoluteTolerance(200.0);
+  pidController.SetTolerance(200.0);
   pidController.SetOutputRange(-0.3, 0.3);
   pidController.SetSetpoint(600);
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
@@ -63,12 +63,6 @@ public class PIDController extends SendableBase {
   // The sum of the errors for use in the integral calc
   private double m_totalError;
 
-  enum Tolerance {
-    kAbsolute, kPercent
-  }
-
-  private Tolerance m_toleranceType = Tolerance.kAbsolute;
-
   // The percentage or absolute error that is considered at setpoint.
   private double m_positionTolerance = 0.05;
   private double m_velocityTolerance = Double.POSITIVE_INFINITY;
@@ -223,43 +217,8 @@ public class PIDController extends SendableBase {
    * @return Whether the error is within the acceptable bounds.
    */
   public boolean atSetpoint() {
-    return atSetpoint(m_positionTolerance, m_velocityTolerance, m_toleranceType);
-  }
-
-  /**
-   * Returns true if the error and change in error are below the specified tolerances.
-   *
-   * @param positionTolerance The maximum allowable position error.
-   * @param velocityTolerance The maximum allowable velocity error.
-   * @param toleranceType     The type of tolerance specified.
-   * @return Whether the error is within the acceptable bounds.
-   */
-  public boolean atSetpoint(double positionTolerance, double velocityTolerance,
-      Tolerance toleranceType) {
-    if (toleranceType == Tolerance.kPercent) {
-      return Math.abs(m_positionError) < positionTolerance / 100 * m_inputRange
-          && Math.abs(m_velocityError) < velocityTolerance / 100 * m_inputRange;
-    } else {
-      return Math.abs(m_positionError) < positionTolerance
-          && Math.abs(m_velocityError) < velocityTolerance;
-    }
-  }
-
-  /**
-   * Sets the minimum and maximum values expected from the input.
-   *
-   * @param minimumInput The minimum value expected from the input.
-   * @param maximumInput The maximum value expected from the input.
-   */
-  public void setInputRange(double minimumInput, double maximumInput) {
-    m_minimumInput = minimumInput;
-    m_maximumInput = maximumInput;
-    m_inputRange = maximumInput - minimumInput;
-
-    // Clamp setpoint to new input
-    if (m_maximumInput > m_minimumInput) {
-      m_setpoint = MathUtils.clamp(m_setpoint, m_minimumInput, m_maximumInput);
-    }
+    return Math.abs(m_positionError) < m_positionTolerance
+        && Math.abs(m_velocityError) < m_velocityTolerance;
   }
 
   /**
@@ -296,43 +255,21 @@ public class PIDController extends SendableBase {
   }
 
   /**
-   * Sets the absolute error which is considered tolerable for use with atSetpoint().
+   * Sets the error which is considered tolerable for use with atSetpoint().
    *
    * @param positionTolerance Position error which is tolerable.
    */
-  public void setAbsoluteTolerance(double positionTolerance) {
-    setAbsoluteTolerance(positionTolerance, Double.POSITIVE_INFINITY);
+  public void setTolerance(double positionTolerance) {
+    setTolerance(positionTolerance, Double.POSITIVE_INFINITY);
   }
 
   /**
-   * Sets the absolute error which is considered tolerable for use with atSetpoint().
+   * Sets the error which is considered tolerable for use with atSetpoint().
    *
    * @param positionTolerance Position error which is tolerable.
    * @param velocityTolerance Velocity error which is tolerable.
    */
-  public void setAbsoluteTolerance(double positionTolerance, double velocityTolerance) {
-    m_toleranceType = Tolerance.kAbsolute;
-    m_positionTolerance = positionTolerance;
-    m_velocityTolerance = velocityTolerance;
-  }
-
-  /**
-   * Sets the percent error which is considered tolerable for use with atSetpoint().
-   *
-   * @param positionTolerance Position error which is tolerable.
-   */
-  public void setPercentTolerance(double positionTolerance) {
-    setPercentTolerance(positionTolerance, Double.POSITIVE_INFINITY);
-  }
-
-  /**
-   * Sets the percent error which is considered tolerable for use with atSetpoint().
-   *
-   * @param positionTolerance Position error which is tolerable.
-   * @param velocityTolerance Velocity error which is tolerable.
-   */
-  public void setPercentTolerance(double positionTolerance, double velocityTolerance) {
-    m_toleranceType = Tolerance.kPercent;
+  public void setTolerance(double positionTolerance, double velocityTolerance) {
     m_positionTolerance = positionTolerance;
     m_velocityTolerance = velocityTolerance;
   }
@@ -421,5 +358,22 @@ public class PIDController extends SendableBase {
       }
     }
     return error;
+  }
+
+  /**
+   * Sets the minimum and maximum values expected from the input.
+   *
+   * @param minimumInput The minimum value expected from the input.
+   * @param maximumInput The maximum value expected from the input.
+   */
+  private void setInputRange(double minimumInput, double maximumInput) {
+    m_minimumInput = minimumInput;
+    m_maximumInput = maximumInput;
+    m_inputRange = maximumInput - minimumInput;
+
+    // Clamp setpoint to new input
+    if (m_maximumInput > m_minimumInput) {
+      m_setpoint = MathUtils.clamp(m_setpoint, m_minimumInput, m_maximumInput);
+    }
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
@@ -35,11 +35,9 @@ public class PIDController extends SendableBase {
   // The period (in seconds) of the loop that calls the controller
   private final double m_period;
 
-  // |maximum output|
-  private double m_maximumOutput = 1.0;
+  private double m_maximumIntegral = 1.0;
 
-  // |minimum output|
-  private double m_minimumOutput = -1.0;
+  private double m_minimumIntegral = -1.0;
 
   // Maximum input - limit setpoint to this
   private double m_maximumInput;
@@ -244,14 +242,17 @@ public class PIDController extends SendableBase {
   }
 
   /**
-   * Sets the minimum and maximum values to write.
+   * Sets the minimum and maximum values for the integrator.
    *
-   * @param minimumOutput the minimum value to write to the output
-   * @param maximumOutput the maximum value to write to the output
+   * <p>When the cap is reached, the integrator value is added to the controller
+   * output rather than the integrator value times the integral gain.
+   *
+   * @param minimumIntegral The minimum value of the integrator.
+   * @param maximumIntegral The maximum value of the integrator.
    */
-  public void setOutputRange(double minimumOutput, double maximumOutput) {
-    m_minimumOutput = minimumOutput;
-    m_maximumOutput = maximumOutput;
+  public void setIntegratorRange(double minimumIntegral, double maximumIntegral) {
+    m_minimumIntegral = minimumIntegral;
+    m_maximumIntegral = maximumIntegral;
   }
 
   /**
@@ -314,12 +315,10 @@ public class PIDController extends SendableBase {
 
     if (m_Ki != 0) {
       m_totalError = MathUtils.clamp(m_totalError + m_positionError * m_period,
-          m_minimumOutput / m_Ki, m_maximumOutput / m_Ki);
+          m_minimumIntegral / m_Ki, m_maximumIntegral / m_Ki);
     }
 
-    return MathUtils.clamp(
-        m_Kp * m_positionError + m_Ki * m_totalError + m_Kd * m_velocityError,
-        m_minimumOutput, m_maximumOutput);
+    return m_Kp * m_positionError + m_Ki * m_totalError + m_Kd * m_velocityError;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
@@ -153,46 +153,6 @@ public class ProfiledPIDController extends SendableBase {
   }
 
   /**
-   * Returns true if the error is within tolerance of the setpoint.
-   *
-   * <p>This will return false until at least one input value has been computed.
-   *
-   * @param positionTolerance The maximum allowable position error.
-   */
-  public boolean atGoal(double positionTolerance) {
-    return atGoal(positionTolerance, Double.POSITIVE_INFINITY, PIDController.Tolerance.kAbsolute);
-  }
-
-  /**
-   * Returns true if the error is within tolerance of the setpoint.
-   *
-   * <p>This will return false until at least one input value has been computed.
-   *
-   * @param positionTolerance The maximum allowable position error.
-   * @param velocityTolerance The maximum allowable velocity error.
-   */
-  public boolean atGoal(double positionTolerance, double velocityTolerance) {
-    return atGoal(positionTolerance, velocityTolerance, PIDController.Tolerance.kAbsolute);
-  }
-
-  /**
-   * Returns true if the error is within tolerance of the setpoint.
-   *
-   * <p>This will return false until at least one input value has been computed.
-   *
-   * @param positionTolerance The maximum allowable position error.
-   * @param velocityTolerance The maximum allowable velocity error.
-   * @param toleranceType     The type of tolerance specified.
-   */
-  public boolean atGoal(
-      double positionTolerance,
-      double velocityTolerance,
-      PIDController.Tolerance toleranceType) {
-    return atSetpoint(positionTolerance, velocityTolerance, toleranceType)
-        && m_goal.equals(m_setpoint);
-  }
-
-  /**
    * Returns true if the error is within the tolerance of the error.
    *
    * <p>This will return false until at least one input value has been computed.
@@ -220,62 +180,12 @@ public class ProfiledPIDController extends SendableBase {
   }
 
   /**
-   * Returns true if the error is within tolerance of the setpoint.
-   *
-   * <p>This will return false until at least one input value has been computed.
-   *
-   * @param positionTolerance The maximum allowable position error.
-   */
-  public boolean atSetpoint(double positionTolerance) {
-    return atSetpoint(positionTolerance, Double.POSITIVE_INFINITY,
-        PIDController.Tolerance.kAbsolute);
-  }
-
-  /**
-   * Returns true if the error is within tolerance of the setpoint.
-   *
-   * <p>This will return false until at least one input value has been computed.
-   *
-   * @param positionTolerance The maximum allowable position error.
-   * @param velocityTolerance The maximum allowable velocity error.
-   */
-  public boolean atSetpoint(double positionTolerance, double velocityTolerance) {
-    return atSetpoint(positionTolerance, velocityTolerance, PIDController.Tolerance.kAbsolute);
-  }
-
-  /**
-   * Returns true if the error is within tolerance of the setpoint.
-   *
-   * <p>This will return false until at least one input value has been computed.
-   *
-   * @param positionTolerance The maximum allowable position error.
-   * @param velocityTolerance The maximum allowable velocity error.
-   * @param toleranceType     The type of tolerance specified.
-   */
-  public boolean atSetpoint(
-      double positionTolerance,
-      double velocityTolerance,
-      PIDController.Tolerance toleranceType) {
-    return m_controller.atSetpoint(positionTolerance, velocityTolerance, toleranceType);
-  }
-
-  /**
    * Returns true if the error is within the tolerance of the error.
    *
    * <p>This will return false until at least one input value has been computed.
    */
   public boolean atSetpoint() {
     return m_controller.atSetpoint();
-  }
-
-  /**
-   * Sets the minimum and maximum values expected from the input.
-   *
-   * @param minimumInput The minimum value expected from the input.
-   * @param maximumInput The maximum value expected from the input.
-   */
-  public void setInputRange(double minimumInput, double maximumInput) {
-    m_controller.setInputRange(minimumInput, maximumInput);
   }
 
   /**
@@ -310,47 +220,22 @@ public class ProfiledPIDController extends SendableBase {
   }
 
   /**
-   * Sets the absolute error which is considered tolerable for use with
-   * atSetpoint().
+   * Sets the error which is considered tolerable for use with atSetpoint().
    *
    * @param positionTolerance Position error which is tolerable.
    */
-  public void setAbsoluteTolerance(double positionTolerance) {
-    setAbsoluteTolerance(positionTolerance, Double.POSITIVE_INFINITY);
+  public void setTolerance(double positionTolerance) {
+    setTolerance(positionTolerance, Double.POSITIVE_INFINITY);
   }
 
   /**
-   * Sets the absolute error which is considered tolerable for use with
-   * atSetpoint().
+   * Sets the error which is considered tolerable for use with atSetpoint().
    *
    * @param positionTolerance Position error which is tolerable.
    * @param velocityTolerance Velocity error which is tolerable.
    */
-  public void setAbsoluteTolerance(double positionTolerance, double velocityTolerance) {
-    m_controller.setAbsoluteTolerance(positionTolerance, velocityTolerance);
-  }
-
-  /**
-   * Sets the percent error which is considered tolerable for use with
-   * atSetpoint().
-   *
-   * @param positionTolerance Position error which is tolerable.
-   */
-  public void setPercentTolerance(double positionTolerance) {
-    m_controller.setPercentTolerance(positionTolerance, Double.POSITIVE_INFINITY);
-  }
-
-  /**
-   * Sets the percent error which is considered tolerable for use with
-   * atSetpoint().
-   *
-   * @param positionTolerance Position error which is tolerable.
-   * @param velocityTolerance Velocity error which is tolerable.
-   */
-  public void setPercentTolerance(
-      double positionTolerance,
-      double velocityTolerance) {
-    m_controller.setPercentTolerance(positionTolerance, velocityTolerance);
+  public void setTolerance(double positionTolerance, double velocityTolerance) {
+    m_controller.setTolerance(positionTolerance, velocityTolerance);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
@@ -210,13 +210,16 @@ public class ProfiledPIDController extends SendableBase {
   }
 
   /**
-   * Sets the minimum and maximum values to write.
+   * Sets the minimum and maximum values for the integrator.
    *
-   * @param minimumOutput the minimum value to write to the output
-   * @param maximumOutput the maximum value to write to the output
+   * <p>When the cap is reached, the integrator value is added to the controller
+   * output rather than the integrator value times the integral gain.
+   *
+   * @param minimumIntegral The minimum value of the integrator.
+   * @param maximumIntegral The maximum value of the integrator.
    */
-  public void setOutputRange(double minimumOutput, double maximumOutput) {
-    m_controller.setOutputRange(minimumOutput, maximumOutput);
+  public void setIntegratorRange(double minimumIntegral, double maximumIntegral) {
+    m_controller.setIntegratorRange(minimumIntegral, maximumIntegral);
   }
 
   /**

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/PIDInputOutputTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/PIDInputOutputTest.java
@@ -34,18 +34,6 @@ class PIDInputOutputTest {
   }
 
   @Test
-  void inputRangeTest() {
-    m_controller.setP(1);
-    m_controller.setOutputRange(-1000, 1000);
-    m_controller.setInputRange(-50, 50);
-
-    assertAll(
-        () -> assertEquals(-100, m_controller.calculate(100, 0), 1e-5),
-        () -> assertEquals(50, m_controller.calculate(0, 100), 1e-5)
-    );
-  }
-
-  @Test
   void continuousInputTest() {
     m_controller.setP(1);
     m_controller.enableContinuousInput(-180, 180);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/PIDInputOutputTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/PIDInputOutputTest.java
@@ -10,7 +10,6 @@ package edu.wpi.first.wpilibj.controller;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -20,17 +19,6 @@ class PIDInputOutputTest {
   @BeforeEach
   void setUp() {
     m_controller = new PIDController(0, 0, 0);
-  }
-
-  @Test
-  void outputRangeTest() {
-    m_controller.setP(1);
-    m_controller.setOutputRange(-50, 50);
-
-    assertAll(
-        () -> assertEquals(-50, m_controller.calculate(100, 0), 1e-5),
-        () -> assertEquals(50, m_controller.calculate(0, 100), 1e-5)
-    );
   }
 
   @Test

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/PIDToleranceTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/PIDToleranceTest.java
@@ -7,83 +7,48 @@
 
 package edu.wpi.first.wpilibj.controller;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PIDToleranceTest {
-  private PIDController m_pidController;
   private static final double kSetpoint = 50.0;
   private static final double kTolerance = 10.0;
   private static final double kRange = 200;
 
-  @BeforeEach
-  void setUp() {
-    m_pidController = new PIDController(0.05, 0.0, 0.0);
-    m_pidController.setInputRange(-kRange / 2, kRange / 2);
-  }
-
-  @AfterEach
-  void tearDown() {
-    m_pidController.close();
-    m_pidController = null;
-  }
-
   @Test
   void initialToleranceTest() {
-    assertTrue(m_pidController.atSetpoint());
+    var controller = new PIDController(0.05, 0.0, 0.0);
+    controller.enableContinuousInput(-kRange / 2, kRange / 2);
+
+    assertTrue(controller.atSetpoint());
   }
 
   @Test
   void absoluteToleranceTest() {
-    m_pidController.setAbsoluteTolerance(kTolerance);
-    m_pidController.setSetpoint(kSetpoint);
+    var controller = new PIDController(0.05, 0.0, 0.0);
+    controller.enableContinuousInput(-kRange / 2, kRange / 2);
 
-    m_pidController.calculate(0.0);
+    controller.setTolerance(kTolerance);
+    controller.setSetpoint(kSetpoint);
 
-    assertFalse(m_pidController.atSetpoint(),
-        "Error was in tolerance when it should not have been. Error was " + m_pidController
+    controller.calculate(0.0);
+
+    assertFalse(controller.atSetpoint(),
+        "Error was in tolerance when it should not have been. Error was " + controller
             .getPositionError());
 
-    m_pidController.calculate(kSetpoint + kTolerance / 2);
+    controller.calculate(kSetpoint + kTolerance / 2);
 
-    assertTrue(m_pidController.atSetpoint(),
-        "Error was not in tolerance when it should have been. Error was " + m_pidController
+    assertTrue(controller.atSetpoint(),
+        "Error was not in tolerance when it should have been. Error was " + controller
             .getPositionError());
 
-    m_pidController.calculate(kSetpoint + 10 * kTolerance);
+    controller.calculate(kSetpoint + 10 * kTolerance);
 
-    assertFalse(m_pidController.atSetpoint(),
-        "Error was in tolerance when it should not have been. Error was " + m_pidController
-            .getPositionError());
-  }
-
-  @Test
-  void percentToleranceTest() {
-    m_pidController.setPercentTolerance(kTolerance);
-    m_pidController.setSetpoint(kSetpoint);
-
-    m_pidController.calculate(0.0);
-
-    assertFalse(m_pidController.atSetpoint(),
-        "Error was in tolerance when it should not have been. Error was " + m_pidController
-            .getPositionError());
-
-    // Half of percent tolerance away from setpoint
-    m_pidController.calculate(kSetpoint + (kTolerance / 2) / 100 * kRange);
-
-    assertTrue(m_pidController.atSetpoint(),
-        "Error was not in tolerance when it should have been. Error was " + m_pidController
-            .getPositionError());
-
-    // Double percent tolerance away from setpoint
-    m_pidController.calculate(kSetpoint + (kTolerance * 2) / 100 * kRange);
-
-    assertFalse(m_pidController.atSetpoint(),
-        "Error was in tolerance when it should not have been. Error was " + m_pidController
+    assertFalse(controller.atSetpoint(),
+        "Error was in tolerance when it should not have been. Error was " + controller
             .getPositionError());
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/subsystems/ShooterSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/subsystems/ShooterSubsystem.java
@@ -37,7 +37,7 @@ public class ShooterSubsystem extends PIDSubsystem {
    */
   public ShooterSubsystem() {
     super(new PIDController(kP, kI, kD));
-    getController().setAbsoluteTolerance(kShooterToleranceRPS);
+    getController().setTolerance(kShooterToleranceRPS);
     m_shooterEncoder.setDistancePerPulse(kEncoderDistancePerPulse);
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
@@ -34,7 +34,7 @@ public class DriveStraight extends PIDCommand {
     m_drivetrain = drivetrain;
     addRequirements(m_drivetrain);
 
-    getController().setAbsoluteTolerance(0.01);
+    getController().setTolerance(0.01);
   }
 
   // Called just before this Command runs the first time

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/SetDistanceToBox.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/SetDistanceToBox.java
@@ -35,7 +35,7 @@ public class SetDistanceToBox extends PIDCommand {
     m_drivetrain = drivetrain;
     addRequirements(m_drivetrain);
 
-    getController().setAbsoluteTolerance(0.01);
+    getController().setTolerance(0.01);
   }
 
   // Called just before this Command runs the first time

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
@@ -37,7 +37,7 @@ public class Elevator extends PIDSubsystem {
     if (Robot.isSimulation()) { // Check for simulation and update PID values
       getController().setPID(kP_simulation, kI_simulation, 0);
     }
-    getController().setAbsoluteTolerance(0.005);
+    getController().setTolerance(0.005);
 
     m_motor = new Victor(5);
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Wrist.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Wrist.java
@@ -34,7 +34,7 @@ public class Wrist extends PIDSubsystem {
     if (Robot.isSimulation()) { // Check for simulation and update PID values
       getController().setPID(kP_simulation, 0, 0);
     }
-    getController().setAbsoluteTolerance(2.5);
+    getController().setTolerance(2.5);
 
     m_motor = new Victor(6);
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/commands/TurnToAngle.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/commands/TurnToAngle.java
@@ -43,7 +43,7 @@ public class TurnToAngle extends PIDCommand {
     getController().enableContinuousInput(-180, 180);
     // Set the controller tolerance - the delta tolerance ensures the robot is stationary at the
     // setpoint before it is considered as having reached the reference
-    getController().setAbsoluteTolerance(kTurnToleranceDeg, kTurnRateToleranceDegPerS);
+    getController().setTolerance(kTurnToleranceDeg, kTurnRateToleranceDegPerS);
   }
 
   @Override

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/potentiometerpid/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/potentiometerpid/Robot.java
@@ -50,7 +50,6 @@ public class Robot extends TimedRobot {
     m_joystick = new Joystick(kJoystickChannel);
 
     m_pidController = new PIDController(kP, kI, kD);
-    m_pidController.setInputRange(0, 5);
   }
 
   @Override

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ultrasonicpid/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ultrasonicpid/Robot.java
@@ -21,9 +21,6 @@ public class Robot extends TimedRobot {
   // distance in inches the robot wants to stay from an object
   private static final double kHoldDistance = 12.0;
 
-  // maximum distance in inches we expect the robot to see
-  private static final double kMaxDistance = 24.0;
-
   // factor to convert sensor values to a distance in inches
   private static final double kValueToInches = 0.125;
 
@@ -45,13 +42,6 @@ public class Robot extends TimedRobot {
       = new DifferentialDrive(new PWMVictorSPX(kLeftMotorPort),
       new PWMVictorSPX(kRightMotorPort));
   private final PIDController m_pidController = new PIDController(kP, kI, kD);
-
-  @Override
-  public void robotInit() {
-    // Set expected range to 0-24 inches; e.g. at 24 inches from object go
-    // full forward, at 0 inches from object go full backward.
-    m_pidController.setInputRange(0, kMaxDistance * kValueToInches);
-  }
 
   @Override
   public void teleopInit() {

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/MotorEncoderTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/MotorEncoderTest.java
@@ -178,7 +178,7 @@ public class MotorEncoderTest extends AbstractComsSetup {
   public void testPositionPIDController() {
     PIDController pidController = new PIDController(0.001, 0.0005, 0);
     pidController.setTolerance(50.0);
-    pidController.setOutputRange(-0.2, 0.2);
+    pidController.setIntegratorRange(-0.2, 0.2);
     pidController.setSetpoint(1000);
 
     Notifier pidRunner = new Notifier(
@@ -200,7 +200,6 @@ public class MotorEncoderTest extends AbstractComsSetup {
     LinearFilter filter = LinearFilter.movingAverage(50);
     PIDController pidController = new PIDController(1e-5, 0.0, 0.0006);
     pidController.setTolerance(200);
-    pidController.setOutputRange(-0.3, 0.3);
     pidController.setSetpoint(600);
 
     Notifier pidRunner =

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/MotorEncoderTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/MotorEncoderTest.java
@@ -177,7 +177,7 @@ public class MotorEncoderTest extends AbstractComsSetup {
   @Test
   public void testPositionPIDController() {
     PIDController pidController = new PIDController(0.001, 0.0005, 0);
-    pidController.setAbsoluteTolerance(50.0);
+    pidController.setTolerance(50.0);
     pidController.setOutputRange(-0.2, 0.2);
     pidController.setSetpoint(1000);
 
@@ -199,7 +199,7 @@ public class MotorEncoderTest extends AbstractComsSetup {
   public void testVelocityPIDController() {
     LinearFilter filter = LinearFilter.movingAverage(50);
     PIDController pidController = new PIDController(1e-5, 0.0, 0.0006);
-    pidController.setAbsoluteTolerance(200);
+    pidController.setTolerance(200);
     pidController.setOutputRange(-0.3, 0.3);
     pidController.setSetpoint(600);
 

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PIDTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PIDTest.java
@@ -45,7 +45,7 @@ public class PIDTest extends AbstractComsSetup {
   private SendableBuilderImpl m_builder;
 
   private static final double absoluteTolerance = 50;
-  private static final double outputRange = 0.25;
+  private static final double integratorRange = 0.25;
 
   private PIDController m_controller = null;
   private static MotorEncoderFixture me = null;
@@ -121,14 +121,14 @@ public class PIDTest extends AbstractComsSetup {
     m_controller.setTolerance(absoluteTolerance);
   }
 
-  private void setupOutputRange() {
-    m_controller.setOutputRange(-outputRange, outputRange);
+  private void setupIntegratorRange() {
+    m_controller.setIntegratorRange(-integratorRange, integratorRange);
   }
 
   @Test
   public void testInitialSettings() {
     setupTolerance();
-    setupOutputRange();
+    setupIntegratorRange();
     double reference = 2500.0;
     m_controller.setSetpoint(reference);
     assertEquals("PID.getPositionError() did not start at " + reference,
@@ -144,7 +144,7 @@ public class PIDTest extends AbstractComsSetup {
   @Test
   public void testSetSetpoint() {
     setupTolerance();
-    setupOutputRange();
+    setupIntegratorRange();
     double reference = 2500.0;
     m_controller.setSetpoint(reference);
     assertEquals("Did not correctly set reference", reference, m_controller.getSetpoint(), 1e-3);
@@ -153,7 +153,7 @@ public class PIDTest extends AbstractComsSetup {
   @Test(timeout = 10000)
   public void testRotateToTarget() {
     setupTolerance();
-    setupOutputRange();
+    setupIntegratorRange();
     double reference = 1000.0;
     assertEquals(pidData() + "did not start at 0", 0, me.getMotor().get(), 0);
     m_controller.setSetpoint(reference);
@@ -176,7 +176,7 @@ public class PIDTest extends AbstractComsSetup {
 
   @Test(expected = RuntimeException.class)
   public void testOnTargetNoToleranceSet() {
-    setupOutputRange();
+    setupIntegratorRange();
     m_controller.atSetpoint();
   }
 }

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PIDTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PIDTest.java
@@ -117,8 +117,8 @@ public class PIDTest extends AbstractComsSetup {
     me.reset();
   }
 
-  private void setupAbsoluteTolerance() {
-    m_controller.setAbsoluteTolerance(absoluteTolerance);
+  private void setupTolerance() {
+    m_controller.setTolerance(absoluteTolerance);
   }
 
   private void setupOutputRange() {
@@ -127,7 +127,7 @@ public class PIDTest extends AbstractComsSetup {
 
   @Test
   public void testInitialSettings() {
-    setupAbsoluteTolerance();
+    setupTolerance();
     setupOutputRange();
     double reference = 2500.0;
     m_controller.setSetpoint(reference);
@@ -143,7 +143,7 @@ public class PIDTest extends AbstractComsSetup {
 
   @Test
   public void testSetSetpoint() {
-    setupAbsoluteTolerance();
+    setupTolerance();
     setupOutputRange();
     double reference = 2500.0;
     m_controller.setSetpoint(reference);
@@ -152,7 +152,7 @@ public class PIDTest extends AbstractComsSetup {
 
   @Test(timeout = 10000)
   public void testRotateToTarget() {
-    setupAbsoluteTolerance();
+    setupTolerance();
     setupOutputRange();
     double reference = 1000.0;
     assertEquals(pidData() + "did not start at 0", 0, me.getMotor().get(), 0);


### PR DESCRIPTION
It breaks the unit system badly; the tolerance member variable has
different units depending on percent vs absolute. Absolute tolerance is
a lot more natural than percent tolerance anyway.