### PR TITLE
Correctly report -1 for POV on disconnected joystick

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -53,6 +53,9 @@ public class DriverStation {
 
     HALJoystickPOVs(int count) {
       m_povs = new short[count];
+      for (int i = 0; i < count; i++) {
+        m_povs[i] = -1;
+      }
     }
   }
 
@@ -461,6 +464,7 @@ public class DriverStation {
         m_cacheDataMutex.unlock();
         reportJoystickUnpluggedWarning("Joystick POV " + pov + " on port " + stick
             + " not available, check if controller is plugged in");
+        return -1;
       }
     } finally {
       if (m_cacheDataMutex.isHeldByCurrentThread()) {


### PR DESCRIPTION
Fixes #1642.

C++ behavior was correct.