### PR TITLE
Fix cmake Eigen include directory

### DIFF
--- a/wpiutil/CMakeLists.txt
+++ b/wpiutil/CMakeLists.txt
@@ -126,7 +126,7 @@ target_link_libraries(wpiutil Threads::Threads ${CMAKE_DL_LIBS} ${ATOMIC})
 if (NOT USE_VCPKG_EIGEN)
     install(DIRECTORY src/main/native/eigen/ DESTINATION "${include_dest}/wpiutil")
     target_include_directories(wpiutil PUBLIC
-                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/eigen>
+                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/eigeninclude>
                             $<INSTALL_INTERFACE:${include_dest}/wpiutil>)
 else()
     find_package(Eigen3 CONFIG REQUIRED)


### PR DESCRIPTION
This currently only breaks when cmake is configured with WITH_TESTS but
ultimately this would have affected wpilibc builds too.