### PR TITLE
Deprecate GearTooth class for removal

### DIFF
--- a/wpilibc/src/main/native/include/frc/GearTooth.h
+++ b/wpilibc/src/main/native/include/frc/GearTooth.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -9,6 +9,8 @@
 
 #include <memory>
 #include <string>
+
+#include <wpi/deprecated.h>
 
 #include "frc/Counter.h"
 
@@ -34,6 +36,9 @@ class GearTooth : public Counter {
    * @param directionSensitive True to enable the pulse length decoding in
    *                           hardware to specify count direction.
    */
+  WPI_DEPRECATED(
+      "The only sensor this works with is no longer available and no teams use "
+      "it according to FMS usage reporting.")
   explicit GearTooth(int channel, bool directionSensitive = false);
 
   /**
@@ -46,6 +51,9 @@ class GearTooth : public Counter {
    * @param directionSensitive True to enable the pulse length decoding in
    *                           hardware to specify count direction.
    */
+  WPI_DEPRECATED(
+      "The only sensor this works with is no longer available and no teams use "
+      "it according to FMS usage reporting.")
   explicit GearTooth(DigitalSource* source, bool directionSensitive = false);
 
   /**
@@ -58,6 +66,9 @@ class GearTooth : public Counter {
    * @param directionSensitive True to enable the pulse length decoding in
    *                           hardware to specify count direction.
    */
+  WPI_DEPRECATED(
+      "The only sensor this works with is no longer available and no teams use "
+      "it according to FMS usage reporting.")
   explicit GearTooth(std::shared_ptr<DigitalSource> source,
                      bool directionSensitive = false);
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/GearTooth.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/GearTooth.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -15,7 +15,11 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
  * Alias for counter class. Implement the gear tooth sensor supplied by FIRST. Currently there is no
  * reverse sensing on the gear tooth sensor, but in future versions we might implement the necessary
  * timing in the FPGA to sense direction.
+ *
+ * @deprecated The only sensor this works with is no longer available and no teams use it according
+ *             to FMS usage reporting.
  */
+@Deprecated(since = "2020", forRemoval = true)
 public class GearTooth extends Counter {
   private static final double kGearToothThreshold = 55e-6;
 


### PR DESCRIPTION
It only works with a specific sensor that isn't available anymore, the
class is a trivial wrapper around a Counter, and no one uses this class
according to FMS usage reporting.