### PR TITLE
Make one-arg Rotation2d constructor implicit

### DIFF
--- a/wpilibc/src/main/native/include/frc/geometry/Rotation2d.h
+++ b/wpilibc/src/main/native/include/frc/geometry/Rotation2d.h
@@ -28,7 +28,7 @@ class Rotation2d {
    *
    * @param value The value of the angle in radians.
    */
-  explicit Rotation2d(units::radian_t value);
+  Rotation2d(units::radian_t value);  // NOLINT(runtime/explicit)
 
   /**
    * Constructs a Rotation2d with the given x and y (cosine and sine)


### PR DESCRIPTION
Since a value in radians is always a rotation, it makes sense to provide
an implicit constructor for this for convenience with Pose2d's
constructor.