### PR TITLE
add GetMeasurement() to PIDCommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,5 +214,10 @@ ipch/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+
+# compile_commands
 compile_commands.json
-.clangd
+
+# clang configuration and clangd cache
+.clang
+.clangd/

--- a/.gitignore
+++ b/.gitignore
@@ -214,10 +214,5 @@ ipch/
 
 # Visual Studio 2015 cache/options directory
 .vs/
-
-# compile_commands
 compile_commands.json
-
-# clang configuration and clangd cache
-.clang
-.clangd/
+.clangd

--- a/wpilibc/src/main/native/cpp/frc2/command/PIDCommand.cpp
+++ b/wpilibc/src/main/native/cpp/frc2/command/PIDCommand.cpp
@@ -54,4 +54,6 @@ void PIDCommand::SetSetpointRelative(double relativeSetpoint) {
 
 double PIDCommand::GetMeasurement() { return m_measurement(); }
 
+void PIDCommand::UseOutput(double output) { m_useOutput(output); }
+
 PIDController& PIDCommand::getController() { return m_controller; }

--- a/wpilibc/src/main/native/cpp/frc2/command/PIDCommand.cpp
+++ b/wpilibc/src/main/native/cpp/frc2/command/PIDCommand.cpp
@@ -31,7 +31,7 @@ PIDCommand::PIDCommand(PIDController controller,
 void PIDCommand::Initialize() { m_controller.Reset(); }
 
 void PIDCommand::Execute() {
-  m_useOutput(m_controller.Calculate(m_measurement(), m_setpoint()));
+  m_useOutput(m_controller.Calculate(GetMeasurement(), m_setpoint()));
 }
 
 void PIDCommand::End(bool interrupted) { m_useOutput(0); }
@@ -50,6 +50,10 @@ void PIDCommand::SetSetpoint(double setpoint) {
 
 void PIDCommand::SetSetpointRelative(double relativeSetpoint) {
   SetSetpoint(m_setpoint() + relativeSetpoint);
+}
+
+double PIDCommand::GetMeasurement() {
+  return m_measurement();
 }
 
 PIDController& PIDCommand::getController() { return m_controller; }

--- a/wpilibc/src/main/native/cpp/frc2/command/PIDCommand.cpp
+++ b/wpilibc/src/main/native/cpp/frc2/command/PIDCommand.cpp
@@ -52,8 +52,6 @@ void PIDCommand::SetSetpointRelative(double relativeSetpoint) {
   SetSetpoint(m_setpoint() + relativeSetpoint);
 }
 
-double PIDCommand::GetMeasurement() {
-  return m_measurement();
-}
+double PIDCommand::GetMeasurement() { return m_measurement(); }
 
 PIDController& PIDCommand::getController() { return m_controller; }

--- a/wpilibc/src/main/native/cpp/frc2/command/PIDCommand.cpp
+++ b/wpilibc/src/main/native/cpp/frc2/command/PIDCommand.cpp
@@ -31,10 +31,10 @@ PIDCommand::PIDCommand(PIDController controller,
 void PIDCommand::Initialize() { m_controller.Reset(); }
 
 void PIDCommand::Execute() {
-  m_useOutput(m_controller.Calculate(GetMeasurement(), m_setpoint()));
+  UseOutput(m_controller.Calculate(GetMeasurement(), m_setpoint()));
 }
 
-void PIDCommand::End(bool interrupted) { m_useOutput(0); }
+void PIDCommand::End(bool interrupted) { UseOutput(0); }
 
 void PIDCommand::SetOutput(std::function<void(double)> useOutput) {
   m_useOutput = useOutput;

--- a/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
@@ -101,7 +101,7 @@ class PIDCommand : public CommandHelper<CommandBase, PIDCommand> {
   virtual double GetMeasurement();
 
   /**
-   * Gets the measurement of the process variable. Wraps the passed-in function 
+   * Gets the measurement of the process variable. Wraps the passed-in function
    * for readability.
    *
    * @return The measurement of the process variable

--- a/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
@@ -101,7 +101,8 @@ class PIDCommand : public CommandHelper<CommandBase, PIDCommand> {
   virtual double GetMeasurement();
 
   /**
-   * Gets the measurement of the process variable. Wraps the passed-in function for readability.
+   * Gets the measurement of the process variable. Wraps the passed-in function 
+   * for readability.
    *
    * @return The measurement of the process variable
    */

--- a/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
@@ -93,7 +93,8 @@ class PIDCommand : public CommandHelper<CommandBase, PIDCommand> {
   void SetSetpointRelative(double relativeSetpoint);
 
   /**
-   * Gets the measurement of the process variable. Wraps the passed-in function for readability.
+   * Gets the measurement of the process variable. Wraps the passed-in function
+   * for readability.
    *
    * @return The measurement of the process variable
    */

--- a/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
@@ -68,7 +68,7 @@ class PIDCommand : public CommandHelper<CommandBase, PIDCommand> {
    *
    * @param useOutput The function that uses the output.
    */
-  virtual void SetOutput(std::function<void(double)> useOutput);
+  void SetOutput(std::function<void(double)> useOutput);
 
   /**
    * Sets the setpoint for the controller to track the given source.
@@ -99,6 +99,13 @@ class PIDCommand : public CommandHelper<CommandBase, PIDCommand> {
    * @return The measurement of the process variable
    */
   virtual double GetMeasurement();
+
+  /**
+   * Gets the measurement of the process variable. Wraps the passed-in function for readability.
+   *
+   * @return The measurement of the process variable
+   */
+  virtual void UseOutput(double output);
 
   /**
    * Returns the PIDController used by the command.

--- a/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
@@ -68,7 +68,7 @@ class PIDCommand : public CommandHelper<CommandBase, PIDCommand> {
    *
    * @param useOutput The function that uses the output.
    */
-  void SetOutput(std::function<void(double)> useOutput);
+  virtual void SetOutput(std::function<void(double)> useOutput);
 
   /**
    * Sets the setpoint for the controller to track the given source.
@@ -91,6 +91,13 @@ class PIDCommand : public CommandHelper<CommandBase, PIDCommand> {
    * @param relativeReference The change in setpoint
    */
   void SetSetpointRelative(double relativeSetpoint);
+
+  /**
+   * Gets the measurement of the process variable. Wraps the passed-in function for readability.
+   *
+   * @return The measurement of the process variable
+   */
+  virtual double GetMeasurement();
 
   /**
    * Returns the PIDController used by the command.


### PR DESCRIPTION
Fixes a small inconsistency between the Java and C++ PIDCommands.