### PR TITLE
Remove sendables from SendableRegistry when close() is called

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_I2C.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_I2C.java
@@ -113,6 +113,7 @@ public class ADXL345_I2C implements Accelerometer, Sendable, AutoCloseable {
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     if (m_i2c != null) {
       m_i2c.close();
       m_i2c = null;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_SPI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_SPI.java
@@ -98,6 +98,7 @@ public class ADXL345_SPI implements Accelerometer, Sendable, AutoCloseable {
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     if (m_spi != null) {
       m_spi.close();
       m_spi = null;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL362.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL362.java
@@ -135,6 +135,7 @@ public class ADXL362 implements Accelerometer, Sendable, AutoCloseable {
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     if (m_spi != null) {
       m_spi.close();
       m_spi = null;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.java
@@ -175,6 +175,7 @@ public class ADXRS450_Gyro extends GyroBase implements Gyro, PIDSource, Sendable
    */
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     if (m_spi != null) {
       m_spi.close();
       m_spi = null;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogAccelerometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogAccelerometer.java
@@ -71,6 +71,7 @@ public class AnalogAccelerometer implements PIDSource, Sendable, AutoCloseable {
    */
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     if (m_analogChannel != null && m_allocatedChannel) {
       m_analogChannel.close();
     }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogGyro.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogGyro.java
@@ -121,6 +121,7 @@ public class AnalogGyro extends GyroBase implements Gyro, PIDSource, Sendable, A
    */
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     if (m_analog != null && m_channelAllocated) {
       m_analog.close();
     }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogInput.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogInput.java
@@ -55,6 +55,7 @@ public class AnalogInput implements PIDSource, Sendable, AutoCloseable {
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     AnalogJNI.freeAnalogInputPort(m_port);
     m_port = 0;
     m_channel = 0;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogOutput.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogOutput.java
@@ -39,6 +39,7 @@ public class AnalogOutput implements Sendable, AutoCloseable {
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     AnalogJNI.freeAnalogOutputPort(m_port);
     m_port = 0;
     m_channel = 0;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
@@ -157,6 +157,7 @@ public class AnalogPotentiometer implements Potentiometer, Sendable, AutoCloseab
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     if (m_initAnalogInput) {
       m_analogInput.close();
       m_analogInput = null;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogTrigger.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogTrigger.java
@@ -78,6 +78,7 @@ public class AnalogTrigger implements Sendable, AutoCloseable {
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     AnalogJNI.cleanAnalogTrigger(m_port);
     m_port = 0;
     if (m_ownsAnalog && m_analogInput != null) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/BuiltInAccelerometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/BuiltInAccelerometer.java
@@ -20,7 +20,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  *
  * <p>This class allows access to the roboRIO's internal accelerometer.
  */
-public class BuiltInAccelerometer implements Accelerometer, Sendable {
+public class BuiltInAccelerometer implements Accelerometer, Sendable, AutoCloseable {
   /**
    * Constructor.
    *
@@ -37,6 +37,11 @@ public class BuiltInAccelerometer implements Accelerometer, Sendable {
    */
   public BuiltInAccelerometer() {
     this(Range.k8G);
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   @Override

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
@@ -24,7 +24,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * the safety provided by using the pressure switch and closed loop control. You can only turn off
  * closed loop control, thereby stopping the compressor from operating.
  */
-public class Compressor implements Sendable {
+public class Compressor implements Sendable, AutoCloseable {
   private int m_compressorHandle;
   private byte m_module;
 
@@ -51,6 +51,11 @@ public class Compressor implements Sendable {
    */
   public Compressor() {
     this(SensorUtil.getDefaultSolenoidModule());
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Counter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Counter.java
@@ -183,6 +183,8 @@ public class Counter implements CounterBase, PIDSource, Sendable, AutoCloseable 
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
+
     setUpdateWhenEmpty(true);
 
     clearUpSource();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalGlitchFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalGlitchFilter.java
@@ -43,6 +43,7 @@ public class DigitalGlitchFilter implements Sendable, AutoCloseable {
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     if (m_channelIndex >= 0) {
       synchronized (m_mutex) {
         m_filterAllocated[m_channelIndex] = false;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalInput.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalInput.java
@@ -42,6 +42,7 @@ public class DigitalInput extends DigitalSource implements Sendable, AutoCloseab
   @Override
   public void close() {
     super.close();
+    SendableRegistry.remove(this);
     if (m_interrupt != 0) {
       cancelInterrupts();
     }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalOutput.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalOutput.java
@@ -44,6 +44,7 @@ public class DigitalOutput implements Sendable, AutoCloseable {
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     // Disable the pwm only if we have allocated it
     if (m_pwmGenerator != invalidPwmGenerator) {
       disablePWM();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DoubleSolenoid.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DoubleSolenoid.java
@@ -86,6 +86,7 @@ public class DoubleSolenoid extends SolenoidBase implements Sendable, AutoClosea
 
   @Override
   public synchronized void close() {
+    SendableRegistry.remove(this);
     SolenoidJNI.freeSolenoidPort(m_forwardHandle);
     SolenoidJNI.freeSolenoidPort(m_reverseHandle);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Encoder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Encoder.java
@@ -294,6 +294,7 @@ public class Encoder implements CounterBase, PIDSource, Sendable, AutoCloseable 
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     if (m_aSource != null && m_allocatedA) {
       m_aSource.close();
       m_allocatedA = false;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/NidecBrushless.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/NidecBrushless.java
@@ -50,6 +50,7 @@ public class NidecBrushless extends MotorSafety implements SpeedController, Send
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     m_dio.close();
     m_pwm.close();
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
@@ -28,7 +28,7 @@ import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
  * given set of PID constants.
  */
 @SuppressWarnings("PMD.TooManyFields")
-public class PIDBase implements PIDInterface, PIDOutput, Sendable {
+public class PIDBase implements PIDInterface, PIDOutput, Sendable, AutoCloseable {
   public static final double kDefaultPeriod = 0.05;
   private static int instances;
 
@@ -189,6 +189,11 @@ public class PIDBase implements PIDInterface, PIDOutput, Sendable {
   @SuppressWarnings("ParameterName")
   public PIDBase(double Kp, double Ki, double Kd, PIDSource source, PIDOutput output) {
     this(Kp, Ki, Kd, 0.0, source, output);
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWM.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWM.java
@@ -74,6 +74,7 @@ public class PWM extends MotorSafety implements Sendable, AutoCloseable {
    */
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     if (m_handle == 0) {
       return;
     }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistributionPanel.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistributionPanel.java
@@ -17,7 +17,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * Class for getting voltage, current, temperature, power and energy from the Power Distribution
  * Panel over CAN.
  */
-public class PowerDistributionPanel implements Sendable {
+public class PowerDistributionPanel implements Sendable, AutoCloseable {
   private final int m_handle;
 
   /**
@@ -38,6 +38,11 @@ public class PowerDistributionPanel implements Sendable {
    */
   public PowerDistributionPanel() {
     this(0);
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Relay.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Relay.java
@@ -141,6 +141,7 @@ public class Relay extends MotorSafety implements Sendable, AutoCloseable {
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     freeRelay();
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SendableBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SendableBase.java
@@ -37,5 +37,7 @@ public abstract class SendableBase implements Sendable, AutoCloseable {
   }
 
   @Override
-  public void close() {}
+  public void close() {
+    SendableRegistry.remove(this);
+  }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Solenoid.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Solenoid.java
@@ -54,6 +54,7 @@ public class Solenoid extends SolenoidBase implements Sendable, AutoCloseable {
 
   @Override
   public void close() {
+    SendableRegistry.remove(this);
     SolenoidJNI.freeSolenoidPort(m_solenoidHandle);
     m_solenoidHandle = 0;
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SpeedControllerGroup.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SpeedControllerGroup.java
@@ -13,7 +13,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 /**
  * Allows multiple {@link SpeedController} objects to be linked together.
  */
-public class SpeedControllerGroup implements SpeedController, Sendable {
+public class SpeedControllerGroup implements SpeedController, Sendable, AutoCloseable {
   private boolean m_isInverted;
   private final SpeedController[] m_speedControllers;
   private static int instances;
@@ -35,6 +35,11 @@ public class SpeedControllerGroup implements SpeedController, Sendable {
     }
     instances++;
     SendableRegistry.addLW(this, "tSpeedControllerGroup", instances);
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   @Override

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Ultrasonic.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Ultrasonic.java
@@ -206,6 +206,7 @@ public class Ultrasonic implements PIDSource, Sendable, AutoCloseable {
    */
   @Override
   public synchronized void close() {
+    SendableRegistry.remove(this);
     final boolean wasAutomaticMode = m_automaticEnabled;
     setAutomaticMode(false);
     if (m_allocatedChannels) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Command.java
@@ -41,7 +41,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * @see IllegalUseOfCommandException
  */
 @SuppressWarnings("PMD.TooManyMethods")
-public abstract class Command implements Sendable {
+public abstract class Command implements Sendable, AutoCloseable {
   /**
    * The time since this command was initialized.
    */
@@ -202,6 +202,11 @@ public abstract class Command implements Sendable {
   public Command(String name, double timeout, Subsystem subsystem) {
     this(name, timeout);
     requires(subsystem);
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Scheduler.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Scheduler.java
@@ -32,7 +32,8 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  *
  * @see Command
  */
-public final class Scheduler implements Sendable {
+@SuppressWarnings("PMD.TooManyMethods")
+public final class Scheduler implements Sendable, AutoCloseable {
   /**
    * The Singleton Instance.
    */
@@ -97,6 +98,11 @@ public final class Scheduler implements Sendable {
   private Scheduler() {
     HAL.report(tResourceType.kResourceType_Command, tInstances.kCommand_Scheduler);
     SendableRegistry.addLW(this, "Scheduler");
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Subsystem.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/command/Subsystem.java
@@ -27,7 +27,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  *
  * @see Command
  */
-public abstract class Subsystem implements Sendable {
+public abstract class Subsystem implements Sendable, AutoCloseable {
   /**
    * Whether or not getDefaultCommand() was called.
    */
@@ -62,6 +62,11 @@ public abstract class Subsystem implements Sendable {
     SendableRegistry.addLW(this, name, name);
     Scheduler.getInstance().registerSubsystem(this);
     m_currentCommandChanged = true;
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
@@ -18,7 +18,7 @@ import edu.wpi.first.wpiutil.math.MathUtils;
  * Implements a PID control loop.
  */
 @SuppressWarnings("PMD.TooManyFields")
-public class PIDController implements Sendable {
+public class PIDController implements Sendable, AutoCloseable {
   private static int instances;
 
   // Factor for "proportional" control
@@ -101,6 +101,11 @@ public class PIDController implements Sendable {
     SendableRegistry.addLW(this, "PIDController", instances);
 
     HAL.report(tResourceType.kResourceType_PIDController, instances);
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -96,7 +96,7 @@ import edu.wpi.first.wpiutil.math.MathUtils;
  * {@link edu.wpi.first.wpilibj.RobotDrive#drive(double, double)} with the addition of a quick turn
  * mode. However, it is not designed to give exactly the same response.
  */
-public class DifferentialDrive extends RobotDriveBase implements Sendable {
+public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoCloseable {
   public static final double kDefaultQuickStopThreshold = 0.2;
   public static final double kDefaultQuickStopAlpha = 0.1;
 
@@ -125,6 +125,11 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable {
     SendableRegistry.addChild(this, m_rightMotor);
     instances++;
     SendableRegistry.addLW(this, "DifferentialDrive", instances);
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
@@ -42,7 +42,7 @@ import edu.wpi.first.wpiutil.math.MathUtils;
  * points down. Rotations follow the right-hand rule, so clockwise rotation around the Z axis is
  * positive.
  */
-public class KilloughDrive extends RobotDriveBase implements Sendable {
+public class KilloughDrive extends RobotDriveBase implements Sendable, AutoCloseable {
   public static final double kDefaultLeftMotorAngle = 60.0;
   public static final double kDefaultRightMotorAngle = 120.0;
   public static final double kDefaultBackMotorAngle = 270.0;
@@ -107,6 +107,11 @@ public class KilloughDrive extends RobotDriveBase implements Sendable {
     SendableRegistry.addChild(this, m_backMotor);
     instances++;
     SendableRegistry.addLW(this, "KilloughDrive", instances);
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
@@ -61,7 +61,7 @@ import edu.wpi.first.wpiutil.math.MathUtils;
  * {@link edu.wpi.first.wpilibj.RobotDrive#mecanumDrive_Polar(double, double, double)} if a
  * deadband of 0 is used.
  */
-public class MecanumDrive extends RobotDriveBase implements Sendable {
+public class MecanumDrive extends RobotDriveBase implements Sendable, AutoCloseable {
   private static int instances;
 
   private final SpeedController m_frontLeftMotor;
@@ -90,6 +90,11 @@ public class MecanumDrive extends RobotDriveBase implements Sendable {
     SendableRegistry.addChild(this, m_rearRightMotor);
     instances++;
     SendableRegistry.addLW(this, "MecanumDrive", instances);
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/SendableCameraWrapper.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/SendableCameraWrapper.java
@@ -18,7 +18,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 /**
  * A wrapper to make video sources sendable and usable from Shuffleboard.
  */
-public final class SendableCameraWrapper implements Sendable {
+public final class SendableCameraWrapper implements Sendable, AutoCloseable {
   private static final String kProtocol = "camera_server://";
 
   private static Map<VideoSource, SendableCameraWrapper> m_wrappers = new WeakHashMap<>();
@@ -35,6 +35,11 @@ public final class SendableCameraWrapper implements Sendable {
     String name = source.getName();
     SendableRegistry.add(this, name);
     m_uri = kProtocol + name;
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
@@ -32,7 +32,7 @@ import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
  *
  * @param <V> The type of the values to be stored
  */
-public class SendableChooser<V> implements Sendable {
+public class SendableChooser<V> implements Sendable, AutoCloseable {
   /**
    * The key for the default value.
    */
@@ -67,6 +67,11 @@ public class SendableChooser<V> implements Sendable {
   public SendableChooser() {
     m_instance = s_instances.getAndIncrement();
     SendableRegistry.add(this, "SendableChooser", m_instance);
+  }
+
+  @Override
+  public void close() {
+    SendableRegistry.remove(this);
   }
 
   /**


### PR DESCRIPTION
This only affected Java (C++ RAII doesn't have the same problem).

Needed to add close/AutoCloseable to several classes to add this behavior.

Fixes #1916.