### PR TITLE
fix slicing of copyable superclasses

### DIFF
--- a/wpilibc/src/main/native/include/frc2/command/Command.h
+++ b/wpilibc/src/main/native/include/frc2/command/Command.h
@@ -51,13 +51,7 @@ class ProxyScheduleCommand;
  */
 class Command : public frc::ErrorBase {
  public:
-  Command() = default;
   virtual ~Command();
-
-  Command(const Command&);
-  Command& operator=(const Command&);
-  Command(Command&&) = default;
-  Command& operator=(Command&&) = default;
 
   /**
    * The initial subroutine of a command.  Called once when the command is
@@ -222,6 +216,12 @@ class Command : public frc::ErrorBase {
   virtual std::string GetName() const;
 
  protected:
+  Command() = default;
+  Command(const Command&);
+  Command& operator=(const Command&);
+  Command(Command&&) = default;
+  Command& operator=(Command&&) = default;
+
   /**
    * Transfers ownership of this command to a unique pointer.  Used for
    * decorator methods.

--- a/wpilibc/src/main/native/include/frc2/command/CommandBase.h
+++ b/wpilibc/src/main/native/include/frc2/command/CommandBase.h
@@ -68,6 +68,11 @@ class CommandBase : public Command,
 
  protected:
   CommandBase();
+  CommandBase(const CommandBase&) = default;
+  CommandBase& operator=(const CommandBase&) = default;
+  CommandBase(CommandBase&&) = default;
+  CommandBase& operator=(CommandBase&&) = default;
+
   wpi::SmallSet<Subsystem*, 4> m_requirements;
 };
 }  // namespace frc2

--- a/wpilibc/src/main/native/include/frc2/command/CommandGroupBase.h
+++ b/wpilibc/src/main/native/include/frc2/command/CommandGroupBase.h
@@ -22,7 +22,7 @@ namespace frc2 {
  * allocated to groups to ensure those commands are not also used independently,
  * which can result in inconsistent command state and unpredictable execution.
  */
-class CommandGroupBase : public CommandBase { 
+class CommandGroupBase : public CommandBase {
  public:
   /**
    * Requires that the specified command not have been already allocated to a

--- a/wpilibc/src/main/native/include/frc2/command/CommandGroupBase.h
+++ b/wpilibc/src/main/native/include/frc2/command/CommandGroupBase.h
@@ -22,7 +22,7 @@ namespace frc2 {
  * allocated to groups to ensure those commands are not also used independently,
  * which can result in inconsistent command state and unpredictable execution.
  */
-class CommandGroupBase : public CommandBase {
+class CommandGroupBase : public CommandBase { 
  public:
   /**
    * Requires that the specified command not have been already allocated to a
@@ -58,5 +58,12 @@ class CommandGroupBase : public CommandBase {
    */
   virtual void AddCommands(
       std::vector<std::unique_ptr<Command>>&& commands) = 0;
+
+ protected:
+  CommandGroupBase() = default;
+  CommandGroupBase(const CommandGroupBase&) = default;
+  CommandGroupBase& operator=(const CommandGroupBase&) = default;
+  CommandGroupBase(CommandGroupBase&&) = default;
+  CommandGroupBase& operator=(CommandGroupBase&&) = default;
 };
 }  // namespace frc2

--- a/wpilibc/src/main/native/include/frc2/command/CommandHelper.h
+++ b/wpilibc/src/main/native/include/frc2/command/CommandHelper.h
@@ -26,10 +26,13 @@ template <typename Base, typename CRTP,
 class CommandHelper : public Base {
   using Base::Base;
 
- public:
-  CommandHelper() = default;
-
  protected:
+  CommandHelper() = default;
+  CommandHelper(const CommandHelper&) = default;
+  CommandHelper& operator=(const CommandHelper&) = default;
+  CommandHelper(CommandHelper&&) = default;
+  CommandHelper& operator=(CommandHelper&&) = default;
+
   std::unique_ptr<Command> TransferOwnership() && override {
     return std::make_unique<CRTP>(std::move(*static_cast<CRTP*>(this)));
   }


### PR DESCRIPTION
C++ type inference allowed compilation of invalid code when a non-copyable command was passed to a command group by lvalue reference, because the type would be inferred as a copyable superclass.  This would cause a segfault at runtime when the nonexistent subclass methods are called, when it should cause a compile error.

Moving all the constructors in abstract superclasses to `protected` solves this problem, without sacrificing any functionality.