### PR TITLE
Fix recursive constructor bug

### DIFF
--- a/wpilibc/src/main/native/include/frc2/command/ParallelCommandGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelCommandGroup.h
@@ -5,8 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4521)
+#endif
+
 #pragma once
-#pragma warning(disable:4521)
 
 #include <memory>
 #include <unordered_map>
@@ -90,3 +94,7 @@ class ParallelCommandGroup
   bool isRunning = false;
 };
 }  // namespace frc2
+
+#ifdef _WIN32
+#pragma warning(pop)
+#endif

--- a/wpilibc/src/main/native/include/frc2/command/ParallelCommandGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelCommandGroup.h
@@ -5,12 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#pragma once
+
 #ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable : 4521)
 #endif
-
-#pragma once
 
 #include <memory>
 #include <unordered_map>

--- a/wpilibc/src/main/native/include/frc2/command/ParallelCommandGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelCommandGroup.h
@@ -57,7 +57,12 @@ class ParallelCommandGroup
   // No copy constructors for commandgroups
   ParallelCommandGroup(const ParallelCommandGroup&) = delete;
 
-  template <class... Types>
+  // Prevent template expansion from emulating copy ctor
+  ParallelCommandGroup(SequentialCommandGroup&) = delete;
+
+  template <class... Types,
+            typename = std::enable_if_t<std::conjunction_v<
+                std::is_base_of<Command, std::remove_reference_t<Types>>...>>>
   void AddCommands(Types&&... commands) {
     std::vector<std::unique_ptr<Command>> foo;
     ((void)foo.emplace_back(std::make_unique<std::remove_reference_t<Types>>(

--- a/wpilibc/src/main/native/include/frc2/command/ParallelCommandGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelCommandGroup.h
@@ -6,6 +6,7 @@
 /*----------------------------------------------------------------------------*/
 
 #pragma once
+#pragma warning(disable:4521)
 
 #include <memory>
 #include <unordered_map>

--- a/wpilibc/src/main/native/include/frc2/command/ParallelCommandGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelCommandGroup.h
@@ -58,7 +58,7 @@ class ParallelCommandGroup
   ParallelCommandGroup(const ParallelCommandGroup&) = delete;
 
   // Prevent template expansion from emulating copy ctor
-  ParallelCommandGroup(SequentialCommandGroup&) = delete;
+  ParallelCommandGroup(ParallelCommandGroup&) = delete;
 
   template <class... Types,
             typename = std::enable_if_t<std::conjunction_v<

--- a/wpilibc/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
@@ -65,6 +65,9 @@ class ParallelDeadlineGroup
   // No copy constructors for command groups
   ParallelDeadlineGroup(const ParallelDeadlineGroup&) = delete;
 
+  // Prevent template expansion from emulating copy ctor
+  ParallelDeadlineGroup(SequentialCommandGroup&) = delete;
+
   template <class... Types,
             typename = std::enable_if_t<std::conjunction_v<
                 std::is_base_of<Command, std::remove_reference_t<Types>>...>>>

--- a/wpilibc/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
@@ -5,12 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#pragma once
+
 #ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable : 4521)
 #endif
-
-#pragma once
 
 #include <memory>
 #include <unordered_map>

--- a/wpilibc/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
@@ -66,7 +66,7 @@ class ParallelDeadlineGroup
   ParallelDeadlineGroup(const ParallelDeadlineGroup&) = delete;
 
   // Prevent template expansion from emulating copy ctor
-  ParallelDeadlineGroup(SequentialCommandGroup&) = delete;
+  ParallelDeadlineGroup(ParallelDeadlineGroup&) = delete;
 
   template <class... Types,
             typename = std::enable_if_t<std::conjunction_v<

--- a/wpilibc/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
@@ -6,6 +6,7 @@
 /*----------------------------------------------------------------------------*/
 
 #pragma once
+#pragma warning(disable:4521)
 
 #include <memory>
 #include <unordered_map>

--- a/wpilibc/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
@@ -5,8 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4521)
+#endif
+
 #pragma once
-#pragma warning(disable:4521)
 
 #include <memory>
 #include <unordered_map>
@@ -101,3 +105,7 @@ class ParallelDeadlineGroup
   bool isRunning = false;
 };
 }  // namespace frc2
+
+#ifdef _WIN32
+#pragma warning(pop)
+#endif

--- a/wpilibc/src/main/native/include/frc2/command/ParallelRaceGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelRaceGroup.h
@@ -6,6 +6,7 @@
 /*----------------------------------------------------------------------------*/
 
 #pragma once
+#pragma warning(disable:4521)
 
 #include <memory>
 #include <set>

--- a/wpilibc/src/main/native/include/frc2/command/ParallelRaceGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelRaceGroup.h
@@ -48,6 +48,9 @@ class ParallelRaceGroup
   // No copy constructors for command groups
   ParallelRaceGroup(const ParallelRaceGroup&) = delete;
 
+  // Prevent template expansion from emulating copy ctor
+  ParallelRaceGroup(SequentialCommandGroup&) = delete;
+
   template <class... Types>
   void AddCommands(Types&&... commands) {
     std::vector<std::unique_ptr<Command>> foo;

--- a/wpilibc/src/main/native/include/frc2/command/ParallelRaceGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelRaceGroup.h
@@ -49,7 +49,7 @@ class ParallelRaceGroup
   ParallelRaceGroup(const ParallelRaceGroup&) = delete;
 
   // Prevent template expansion from emulating copy ctor
-  ParallelRaceGroup(SequentialCommandGroup&) = delete;
+  ParallelRaceGroup(ParallelRaceGroup&) = delete;
 
   template <class... Types>
   void AddCommands(Types&&... commands) {

--- a/wpilibc/src/main/native/include/frc2/command/ParallelRaceGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelRaceGroup.h
@@ -5,12 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#pragma once
+
 #ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable : 4521)
 #endif
-
-#pragma once
 
 #include <memory>
 #include <set>

--- a/wpilibc/src/main/native/include/frc2/command/ParallelRaceGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/ParallelRaceGroup.h
@@ -5,8 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4521)
+#endif
+
 #pragma once
-#pragma warning(disable:4521)
 
 #include <memory>
 #include <set>
@@ -80,3 +84,7 @@ class ParallelRaceGroup
   bool isRunning = false;
 };
 }  // namespace frc2
+
+#ifdef _WIN32
+#pragma warning(pop)
+#endif

--- a/wpilibc/src/main/native/include/frc2/command/PerpetualCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/PerpetualCommand.h
@@ -55,7 +55,7 @@ class PerpetualCommand : public CommandHelper<CommandBase, PerpetualCommand> {
   PerpetualCommand(const PerpetualCommand& other) = delete;
 
   // Prevent template expansion from emulating copy ctor
-  PerpetualCommand(SequentialCommandGroup&) = delete;
+  PerpetualCommand(PerpetualCommand&) = delete;
 
   void Initialize() override;
 

--- a/wpilibc/src/main/native/include/frc2/command/PerpetualCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/PerpetualCommand.h
@@ -6,6 +6,7 @@
 /*----------------------------------------------------------------------------*/
 
 #pragma once
+#pragma warning(disable:4521)
 
 #include <memory>
 #include <utility>

--- a/wpilibc/src/main/native/include/frc2/command/PerpetualCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/PerpetualCommand.h
@@ -5,12 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#pragma once
+
 #ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable : 4521)
 #endif
-
-#pragma once
 
 #include <memory>
 #include <utility>

--- a/wpilibc/src/main/native/include/frc2/command/PerpetualCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/PerpetualCommand.h
@@ -54,6 +54,9 @@ class PerpetualCommand : public CommandHelper<CommandBase, PerpetualCommand> {
   // No copy constructors for command groups
   PerpetualCommand(const PerpetualCommand& other) = delete;
 
+  // Prevent template expansion from emulating copy ctor
+  PerpetualCommand(SequentialCommandGroup&) = delete;
+
   void Initialize() override;
 
   void Execute() override;

--- a/wpilibc/src/main/native/include/frc2/command/PerpetualCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/PerpetualCommand.h
@@ -5,8 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4521)
+#endif
+
 #pragma once
-#pragma warning(disable:4521)
 
 #include <memory>
 #include <utility>
@@ -68,3 +72,7 @@ class PerpetualCommand : public CommandHelper<CommandBase, PerpetualCommand> {
   std::unique_ptr<Command> m_command;
 };
 }  // namespace frc2
+
+#ifdef _WIN32
+#pragma warning(pop)
+#endif

--- a/wpilibc/src/main/native/include/frc2/command/SelectCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/SelectCommand.h
@@ -5,12 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#pragma once
+
 #ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable : 4521)
 #endif
-
-#pragma once
 
 #include <memory>
 #include <unordered_map>

--- a/wpilibc/src/main/native/include/frc2/command/SelectCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/SelectCommand.h
@@ -6,6 +6,7 @@
 /*----------------------------------------------------------------------------*/
 
 #pragma once
+#pragma warning(disable:4521)
 
 #include <memory>
 #include <unordered_map>

--- a/wpilibc/src/main/native/include/frc2/command/SelectCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/SelectCommand.h
@@ -89,7 +89,7 @@ class SelectCommand : public CommandHelper<CommandBase, SelectCommand<Key>> {
   SelectCommand(const SelectCommand& other) = delete;
 
   // Prevent template expansion from emulating copy ctor
-  SelectCommand(SequentialCommandGroup&) = delete;
+  SelectCommand(SelectCommand&) = delete;
 
   /**
    * Creates a new selectcommand.

--- a/wpilibc/src/main/native/include/frc2/command/SelectCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/SelectCommand.h
@@ -88,6 +88,9 @@ class SelectCommand : public CommandHelper<CommandBase, SelectCommand<Key>> {
   // No copy constructors for command groups
   SelectCommand(const SelectCommand& other) = delete;
 
+  // Prevent template expansion from emulating copy ctor
+  SelectCommand(SequentialCommandGroup&) = delete;
+
   /**
    * Creates a new selectcommand.
    *

--- a/wpilibc/src/main/native/include/frc2/command/SelectCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/SelectCommand.h
@@ -5,8 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4521)
+#endif
+
 #pragma once
-#pragma warning(disable:4521)
 
 #include <memory>
 #include <unordered_map>
@@ -143,3 +147,7 @@ void SelectCommand<T>::Initialize() {
 }
 
 }  // namespace frc2
+
+#ifdef _WIN32
+#pragma warning(pop)
+#endif

--- a/wpilibc/src/main/native/include/frc2/command/SequentialCommandGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/SequentialCommandGroup.h
@@ -61,6 +61,9 @@ class SequentialCommandGroup
   // No copy constructors for command groups
   SequentialCommandGroup(const SequentialCommandGroup&) = delete;
 
+  // Prevent template expansion from emulating copy ctor
+  SequentialCommandGroup(SequentialCommandGroup&) = delete;
+
   template <class... Types,
             typename = std::enable_if_t<std::conjunction_v<
                 std::is_base_of<Command, std::remove_reference_t<Types>>...>>>

--- a/wpilibc/src/main/native/include/frc2/command/SequentialCommandGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/SequentialCommandGroup.h
@@ -5,8 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4521)
+#endif
+
 #pragma once
-#pragma warning(disable:4521)
 
 #include <limits>
 #include <memory>
@@ -94,3 +98,7 @@ class SequentialCommandGroup
   bool m_runWhenDisabled{true};
 };
 }  // namespace frc2
+
+#ifdef _WIN32
+#pragma warning(pop)
+#endif

--- a/wpilibc/src/main/native/include/frc2/command/SequentialCommandGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/SequentialCommandGroup.h
@@ -6,6 +6,7 @@
 /*----------------------------------------------------------------------------*/
 
 #pragma once
+#pragma warning(disable:4521)
 
 #include <limits>
 #include <memory>

--- a/wpilibc/src/main/native/include/frc2/command/SequentialCommandGroup.h
+++ b/wpilibc/src/main/native/include/frc2/command/SequentialCommandGroup.h
@@ -5,12 +5,12 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#pragma once
+
 #ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable : 4521)
 #endif
-
-#pragma once
 
 #include <limits>
 #include <memory>


### PR DESCRIPTION
Passing command groups as lvalue-references to other command groups should be illegal, as their copy constructors have been deleted.  However, copy constructors are const-qualified.  This led to a very obscure bug where passing a command group by lvalue to another command group would result in a valid template expansion 'looking like' a copy constructor, and being *preferred* to the deleted copy constructor.  This would result in constructor recursion (the expanded constructor would, in an attempt to call the copy constructor, call itself), and an eventual segfault when the stack inevitably overflowed.

This fixes the problem by explicitly deleting the problematic constructor signature - attempting to do this now (correctly) generates a compilation error.