### PR TITLE
Add getters for pose in odometry classes

### DIFF
--- a/wpilibc/src/main/native/include/frc/kinematics/DifferentialDriveOdometry.h
+++ b/wpilibc/src/main/native/include/frc/kinematics/DifferentialDriveOdometry.h
@@ -48,6 +48,12 @@ class DifferentialDriveOdometry {
   }
 
   /**
+   * Returns the position of the robot on the field.
+   * @return The pose of the robot.
+   */
+  const Pose2d& GetPose() const { return m_pose; }
+
+  /**
    * Updates the robot's position on the field using forward kinematics and
    * integration of the pose over time. This method takes in the current time as
    * a parameter to calculate period (difference between two timestamps). The

--- a/wpilibc/src/main/native/include/frc/kinematics/MecanumDriveOdometry.h
+++ b/wpilibc/src/main/native/include/frc/kinematics/MecanumDriveOdometry.h
@@ -46,6 +46,12 @@ class MecanumDriveOdometry {
   }
 
   /**
+   * Returns the position of the robot on the field.
+   * @return The pose of the robot.
+   */
+  const Pose2d& GetPose() const { return m_pose; }
+
+  /**
    * Updates the robot's position on the field using forward kinematics and
    * integration of the pose over time. This method takes in the current time as
    * a parameter to calculate period (difference between two timestamps). The

--- a/wpilibc/src/main/native/include/frc/kinematics/SwerveDriveOdometry.h
+++ b/wpilibc/src/main/native/include/frc/kinematics/SwerveDriveOdometry.h
@@ -51,6 +51,12 @@ class SwerveDriveOdometry {
   }
 
   /**
+   * Returns the position of the robot on the field.
+   * @return The pose of the robot.
+   */
+  const Pose2d& GetPose() const { return m_pose; }
+
+  /**
    * Updates the robot's position on the field using forward kinematics and
    * integration of the pose over time. This method takes in the current time as
    * a parameter to calculate period (difference between two timestamps). The

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/kinematics/DifferentialDriveOdometry.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/kinematics/DifferentialDriveOdometry.java
@@ -65,6 +65,14 @@ public class DifferentialDriveOdometry {
   }
 
   /**
+   * Returns the position of the robot on the field.
+   * @return The pose of the robot (x and y are in meters).
+   */
+  public Pose2d getPoseMeters() {
+    return m_poseMeters;
+  }
+
+  /**
    * Updates the robot's position on the field using forward kinematics and
    * integration of the pose over time. This method takes in the current time as
    * a parameter to calculate period (difference between two timestamps). The

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/kinematics/MecanumDriveOdometry.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/kinematics/MecanumDriveOdometry.java
@@ -59,6 +59,14 @@ public class MecanumDriveOdometry {
   }
 
   /**
+   * Returns the position of the robot on the field.
+   * @return The pose of the robot (x and y are in meters).
+   */
+  public Pose2d getPoseMeters() {
+    return m_poseMeters;
+  }
+
+  /**
    * Updates the robot's position on the field using forward kinematics and
    * integration of the pose over time. This method takes in the current time as
    * a parameter to calculate period (difference between two timestamps). The

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/kinematics/SwerveDriveOdometry.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/kinematics/SwerveDriveOdometry.java
@@ -59,6 +59,14 @@ public class SwerveDriveOdometry {
   }
 
   /**
+   * Returns the position of the robot on the field.
+   * @return The pose of the robot (x and y are in meters).
+   */
+  public Pose2d getPoseMeters() {
+    return m_poseMeters;
+  }
+
+  /**
    * Updates the robot's position on the field using forward kinematics and
    * integration of the pose over time. This method takes in the current time as
    * a parameter to calculate period (difference between two timestamps). The


### PR DESCRIPTION
Previously, the only way to get the updated robot pose was by storing the return value of `update`. This PR makes it possible to get the current pose without needing to call `update` with new information. 