### PR TITLE
Add generateTrajectory overload

### DIFF
--- a/wpilibc/src/main/native/cpp/trajectory/TrajectoryGenerator.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/TrajectoryGenerator.cpp
@@ -75,3 +75,34 @@ Trajectory TrajectoryGenerator::GenerateTrajectory(
       points, std::move(constraints), startVelocity, endVelocity, maxVelocity,
       maxAcceleration, reversed);
 }
+
+Trajectory TrajectoryGenerator::GenerateTrajectory(
+    const std::vector<Pose2d>& waypoints,
+    const DifferentialDriveKinematics& differentialDriveKinematics,
+    units::meters_per_second_t startVelocity,
+    units::meters_per_second_t endVelocity,
+    units::meters_per_second_t maxVelocity,
+    units::meters_per_second_squared_t maxAcceleration, bool reversed) {
+  std::vector<TrajectoryConstraint> constraints{
+      std::make_unique<DifferentialDriveKinematicsConstraint>(
+          differentialDriveKinematics, maxVelocity)};
+  return GenerateTrajectory(waypoints, std::move(constraints), startVelocity,
+                            endVelocity, maxVelocity, maxAcceleration,
+                            reversed);
+}
+
+Trajectory TrajectoryGenerator::GenerateTrajectory(
+    const Pose2d& start, const std::vector<Translation2d>& waypoints,
+    const Pose2d& end,
+    const DifferentialDriveKinematics& differentialDriveKinematics,
+    units::meters_per_second_t startVelocity,
+    units::meters_per_second_t endVelocity,
+    units::meters_per_second_t maxVelocity,
+    units::meters_per_second_squared_t maxAcceleration, bool reversed) {
+  std::vector<TrajectoryConstraint> constraints{
+      std::make_unique<DifferentialDriveKinematicsConstraint>(
+          differentialDriveKinematics, maxVelocity)};
+  return GenerateTrajectory(start, waypoints, end, std::move(constraints),
+                            startVelocity, endVelocity, maxVelocity,
+                            maxAcceleration, reversed);
+}

--- a/wpilibc/src/main/native/cpp/trajectory/TrajectoryGenerator.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/TrajectoryGenerator.cpp
@@ -83,9 +83,11 @@ Trajectory TrajectoryGenerator::GenerateTrajectory(
     units::meters_per_second_t endVelocity,
     units::meters_per_second_t maxVelocity,
     units::meters_per_second_squared_t maxAcceleration, bool reversed) {
-  std::vector<TrajectoryConstraint> constraints{
+  std::vector<std::unique_ptr<TrajectoryConstraint>> constraints;
+  constraints.emplace_back(
       std::make_unique<DifferentialDriveKinematicsConstraint>(
-          differentialDriveKinematics, maxVelocity)};
+          differentialDriveKinematics, maxVelocity));
+
   return GenerateTrajectory(waypoints, std::move(constraints), startVelocity,
                             endVelocity, maxVelocity, maxAcceleration,
                             reversed);
@@ -99,9 +101,11 @@ Trajectory TrajectoryGenerator::GenerateTrajectory(
     units::meters_per_second_t endVelocity,
     units::meters_per_second_t maxVelocity,
     units::meters_per_second_squared_t maxAcceleration, bool reversed) {
-  std::vector<TrajectoryConstraint> constraints{
+  std::vector<std::unique_ptr<TrajectoryConstraint>> constraints;
+  constraints.emplace_back(
       std::make_unique<DifferentialDriveKinematicsConstraint>(
-          differentialDriveKinematics, maxVelocity)};
+          differentialDriveKinematics, maxVelocity));
+
   return GenerateTrajectory(start, waypoints, end, std::move(constraints),
                             startVelocity, endVelocity, maxVelocity,
                             maxAcceleration, reversed);

--- a/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
@@ -13,6 +13,7 @@
 
 #include "frc/spline/SplineParameterizer.h"
 #include "frc/trajectory/Trajectory.h"
+#include "frc/trajectory/constraint/DifferentialDriveKinematicsConstraint.h"
 #include "frc/trajectory/constraint/TrajectoryConstraint.h"
 
 namespace frc {
@@ -68,6 +69,62 @@ class TrajectoryGenerator {
       const Pose2d& start, const std::vector<Translation2d>& waypoints,
       const Pose2d& end,
       std::vector<std::unique_ptr<TrajectoryConstraint>>&& constraints,
+      units::meters_per_second_t startVelocity,
+      units::meters_per_second_t endVelocity,
+      units::meters_per_second_t maxVelocity,
+      units::meters_per_second_squared_t maxAcceleration, bool reversed);
+
+  /**
+   * Generates a trajectory with the given waypoints and differential drive
+   * constraints. Use this method if you just want a constraint such that none
+   * of the wheels on your differential drive exceed the specified max velocity.
+   * If you desire to impose more constraints, please use the other overloads.
+   *
+   * @param waypoints A vector of points that the trajectory must go through.
+   * @param differentialDriveKinematics The DifferentialDriveKinematics
+   * object that represents your drivetrain.
+   * @param startVelocity The start velocity for the trajectory.
+   * @param endVelocity The end velocity for the trajectory.
+   * @param maxVelocity The max velocity for the trajectory.
+   * @param maxAcceleration The max acceleration for the trajectory.
+   * @param reversed Whether the robot should move backwards. Note that the
+   * robot will still move from a -> b -> ... -> z as defined in the waypoints.
+   *
+   * @return The trajectory.
+   */
+  static Trajectory GenerateTrajectory(
+      const std::vector<Pose2d>& waypoints,
+      const DifferentialDriveKinematics& differentialDriveKinematics,
+      units::meters_per_second_t startVelocity,
+      units::meters_per_second_t endVelocity,
+      units::meters_per_second_t maxVelocity,
+      units::meters_per_second_squared_t maxAcceleration, bool reversed);
+
+  /**
+   * Generates a trajectory with the given waypoints and differential drive
+   * constraints. Use this method if you just want a constraint such that none
+   * of the wheels on your differential drive exceed the specified max velocity.
+   * If you desire to impose more constraints, please use the other overloads.
+   *
+   * @param start The starting pose for the trajectory.
+   * @param waypoints The interior waypoints for the trajectory. The headings
+   * will be determined automatically to ensure continuous curvature.
+   * @param end The ending pose for the trajectory.
+   * @param differentialDriveKinematics The DifferentialDriveKinematics
+   * object that represents your drivetrain.
+   * @param startVelocity The start velocity for the trajectory.
+   * @param endVelocity The end velocity for the trajectory.
+   * @param maxVelocity The max velocity for the trajectory.
+   * @param maxAcceleration The max acceleration for the trajectory.
+   * @param reversed Whether the robot should move backwards. Note that the
+   * robot will still move from a -> b -> ... -> z as defined in the waypoints.
+   *
+   * @return The trajectory.
+   */
+  static Trajectory GenerateTrajectory(
+      const Pose2d& start, const std::vector<Translation2d>& waypoints,
+      const Pose2d& end,
+      const DifferentialDriveKinematics& differentialDriveKinematics,
       units::meters_per_second_t startVelocity,
       units::meters_per_second_t endVelocity,
       units::meters_per_second_t maxVelocity,

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
@@ -14,10 +14,12 @@ import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.geometry.Transform2d;
 import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
 import edu.wpi.first.wpilibj.spline.PoseWithCurvature;
 import edu.wpi.first.wpilibj.spline.Spline;
 import edu.wpi.first.wpilibj.spline.SplineHelper;
 import edu.wpi.first.wpilibj.spline.SplineParameterizer;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveKinematicsConstraint;
 import edu.wpi.first.wpilibj.trajectory.constraint.TrajectoryConstraint;
 
 public final class TrajectoryGenerator {
@@ -129,6 +131,90 @@ public final class TrajectoryGenerator {
     return TrajectoryParameterizer.timeParameterizeTrajectory(points, constraints,
         startVelocityMetersPerSecond, endVelocityMetersPerSecond, maxVelocityMetersPerSecond,
         maxAccelerationMetersPerSecondSq, reversed);
+  }
+
+  /**
+   * Generates a trajectory with the given waypoints and differential drive constraints. Use
+   * this method if you just want a constraint such that none of the wheels on your differential
+   * drive exceed the specified max velocity. If you desire to impose more constraints, please
+   * use the other overloads.
+   *
+   * @param waypoints                        A vector of points that the trajectory must go through.
+   * @param differentialDriveKinematics      The DifferentialDriveKinematics object that represents
+   *                                         your drivetrain.
+   * @param startVelocityMetersPerSecond     The start velocity for the trajectory.
+   * @param endVelocityMetersPerSecond       The end velocity for the trajectory.
+   * @param maxVelocityMetersPerSecond       The max velocity for the trajectory.
+   * @param maxAccelerationMetersPerSecondSq The max acceleration for the trajectory.
+   * @param reversed                         Whether the robot should move backwards. Note that the
+   *                                         robot will still move from a -&gt; b -&gt; ... -&gt; z
+   *                                         as defined in the waypoints.
+   * @return The trajectory.
+   */
+  public static Trajectory generateTrajectory(
+    List<Pose2d> waypoints,
+    DifferentialDriveKinematics differentialDriveKinematics,
+    double startVelocityMetersPerSecond,
+    double endVelocityMetersPerSecond,
+    double maxVelocityMetersPerSecond,
+    double maxAccelerationMetersPerSecondSq,
+    boolean reversed
+  ) {
+    return generateTrajectory(
+      waypoints,
+      List.of(new DifferentialDriveKinematicsConstraint(differentialDriveKinematics,
+        maxVelocityMetersPerSecond)),
+      startVelocityMetersPerSecond,
+      endVelocityMetersPerSecond,
+      maxVelocityMetersPerSecond,
+      maxAccelerationMetersPerSecondSq,
+      reversed
+    );
+  }
+
+  /**
+   * Generates a trajectory with the given waypoints and differential drive constraints. Use
+   * this method if you just want a constraint such that none of the wheels on your differential
+   * drive exceed the specified max velocity. If you desire to impose more constraints, please
+   * use the other overloads.
+   *
+   * @param start                            The starting pose for the trajectory.
+   * @param waypoints                        The interior waypoints for the trajectory. The headings
+   *                                         will be determined automatically to ensure continuous
+   *                                         curvature.
+   * @param end                              The ending pose for the trajectory.
+   * @param differentialDriveKinematics      The DifferentialDriveKinematics object that represents
+   *                                         your drivetrain.
+   * @param startVelocityMetersPerSecond     The start velocity for the trajectory.
+   * @param endVelocityMetersPerSecond       The end velocity for the trajectory.
+   * @param maxVelocityMetersPerSecond       The max velocity for the trajectory.
+   * @param maxAccelerationMetersPerSecondSq The max acceleration for the trajectory.
+   * @param reversed                         Whether the robot should move backwards. Note that the
+   *                                         robot will still move from a -&gt; b -&gt; ... -&gt; z
+   *                                         as defined in the waypoints.
+   * @return The trajectory.
+   */
+  public static Trajectory generateTrajectory(
+    Pose2d start,
+    List<Translation2d> waypoints,
+    Pose2d end,
+    DifferentialDriveKinematics differentialDriveKinematics,
+    double startVelocityMetersPerSecond,
+    double endVelocityMetersPerSecond,
+    double maxVelocityMetersPerSecond,
+    double maxAccelerationMetersPerSecondSq,
+    boolean reversed
+  ) {
+    return generateTrajectory(
+      start, waypoints, end,
+      List.of(new DifferentialDriveKinematicsConstraint(differentialDriveKinematics,
+        maxVelocityMetersPerSecond)),
+      startVelocityMetersPerSecond,
+      endVelocityMetersPerSecond,
+      maxVelocityMetersPerSecond,
+      maxAccelerationMetersPerSecondSq,
+      reversed
+    );
   }
 
   private static List<PoseWithCurvature> splinePointsFromSplines(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
@@ -152,23 +152,23 @@ public final class TrajectoryGenerator {
    * @return The trajectory.
    */
   public static Trajectory generateTrajectory(
-    List<Pose2d> waypoints,
-    DifferentialDriveKinematics differentialDriveKinematics,
-    double startVelocityMetersPerSecond,
-    double endVelocityMetersPerSecond,
-    double maxVelocityMetersPerSecond,
-    double maxAccelerationMetersPerSecondSq,
-    boolean reversed
+      List<Pose2d> waypoints,
+      DifferentialDriveKinematics differentialDriveKinematics,
+      double startVelocityMetersPerSecond,
+      double endVelocityMetersPerSecond,
+      double maxVelocityMetersPerSecond,
+      double maxAccelerationMetersPerSecondSq,
+      boolean reversed
   ) {
     return generateTrajectory(
-      waypoints,
-      List.of(new DifferentialDriveKinematicsConstraint(differentialDriveKinematics,
-        maxVelocityMetersPerSecond)),
-      startVelocityMetersPerSecond,
-      endVelocityMetersPerSecond,
-      maxVelocityMetersPerSecond,
-      maxAccelerationMetersPerSecondSq,
-      reversed
+        waypoints,
+        List.of(new DifferentialDriveKinematicsConstraint(differentialDriveKinematics,
+            maxVelocityMetersPerSecond)),
+        startVelocityMetersPerSecond,
+        endVelocityMetersPerSecond,
+        maxVelocityMetersPerSecond,
+        maxAccelerationMetersPerSecondSq,
+        reversed
     );
   }
 
@@ -195,25 +195,25 @@ public final class TrajectoryGenerator {
    * @return The trajectory.
    */
   public static Trajectory generateTrajectory(
-    Pose2d start,
-    List<Translation2d> waypoints,
-    Pose2d end,
-    DifferentialDriveKinematics differentialDriveKinematics,
-    double startVelocityMetersPerSecond,
-    double endVelocityMetersPerSecond,
-    double maxVelocityMetersPerSecond,
-    double maxAccelerationMetersPerSecondSq,
-    boolean reversed
+      Pose2d start,
+      List<Translation2d> waypoints,
+      Pose2d end,
+      DifferentialDriveKinematics differentialDriveKinematics,
+      double startVelocityMetersPerSecond,
+      double endVelocityMetersPerSecond,
+      double maxVelocityMetersPerSecond,
+      double maxAccelerationMetersPerSecondSq,
+      boolean reversed
   ) {
     return generateTrajectory(
-      start, waypoints, end,
-      List.of(new DifferentialDriveKinematicsConstraint(differentialDriveKinematics,
-        maxVelocityMetersPerSecond)),
-      startVelocityMetersPerSecond,
-      endVelocityMetersPerSecond,
-      maxVelocityMetersPerSecond,
-      maxAccelerationMetersPerSecondSq,
-      reversed
+        start, waypoints, end,
+        List.of(new DifferentialDriveKinematicsConstraint(differentialDriveKinematics,
+            maxVelocityMetersPerSecond)),
+        startVelocityMetersPerSecond,
+        endVelocityMetersPerSecond,
+        maxVelocityMetersPerSecond,
+        maxAccelerationMetersPerSecondSq,
+        reversed
     );
   }
 


### PR DESCRIPTION
Per @Oblarg's request, I added an overload for the `generateTrajectory` method that accepts a `DifferentialDriveKinematics` instance instead of a list of constraints. This instance is used to automatically create a `DifferentialDriveKinematicsConstraint` behind the scenes, saving the user some verbosity.