### PR TITLE
Make splinePointsFromSplines public

### DIFF
--- a/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
@@ -136,7 +136,7 @@ class TrajectoryGenerator {
    *
    * @param splines The splines to parameterize.
    *
-   * @return The spline points.
+   * @return The spline points for use in time parametrization of a trajectory.
    */
   template <typename Spline>
   static std::vector<PoseWithCurvature> SplinePointsFromSplines(

--- a/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
@@ -136,7 +136,7 @@ class TrajectoryGenerator {
    *
    * @param splines The splines to parameterize.
    *
-   * @return The spline points for use in time parametrization of a trajectory.
+   * @return The spline points for use in time parameterization of a trajectory.
    */
   template <typename Spline>
   static std::vector<PoseWithCurvature> SplinePointsFromSplines(

--- a/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
@@ -130,7 +130,6 @@ class TrajectoryGenerator {
       units::meters_per_second_t maxVelocity,
       units::meters_per_second_squared_t maxAcceleration, bool reversed);
 
- private:
   /**
    * Generate spline points from a vector of splines by parameterizing the
    * splines.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
@@ -223,7 +223,7 @@ public final class TrajectoryGenerator {
    *
    * @param splines The splines to parameterize.
    *
-   * @return The spline points for use in time parametrization of a trajectory.
+   * @return The spline points for use in time parameterization of a trajectory.
    */
   public static List<PoseWithCurvature> splinePointsFromSplines(
       Spline[] splines) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
@@ -217,7 +217,7 @@ public final class TrajectoryGenerator {
     );
   }
 
-  private static List<PoseWithCurvature> splinePointsFromSplines(
+  public static List<PoseWithCurvature> splinePointsFromSplines(
       Spline[] splines) {
     // Create the vector of spline points.
     var splinePoints = new ArrayList<PoseWithCurvature>();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
@@ -217,6 +217,14 @@ public final class TrajectoryGenerator {
     );
   }
 
+  /**
+   * Generate spline points from a vector of splines by parameterizing the
+   * splines.
+   *
+   * @param splines The splines to parameterize.
+   *
+   * @return The spline points for use in time parametrization of a trajectory.
+   */
   public static List<PoseWithCurvature> splinePointsFromSplines(
       Spline[] splines) {
     // Create the vector of spline points.


### PR DESCRIPTION
This utility function is made public in both the Java and C++ libraries. This utility function allows a user to turn an array of splines (generated individually perhaps), into the splinePoints needed to time parameterize.

The real world use case is my current work on Pathweaver, where I generate each spline separately for display, and then time parameterize them at the end when exporting.