### PR TITLE
Deprecate old PID classes

### DIFF
--- a/wpilibc/src/main/native/include/frc/PIDBase.h
+++ b/wpilibc/src/main/native/include/frc/PIDBase.h
@@ -50,6 +50,7 @@ class PIDBase : public PIDInterface,
    * @param source The PIDSource object that is used to get values
    * @param output The PIDOutput object that is set to the output value
    */
+  WPI_DEPRECATED("All APIs which use this have been deprecated.")
   PIDBase(double p, double i, double d, PIDSource& source, PIDOutput& output);
 
   /**
@@ -61,6 +62,7 @@ class PIDBase : public PIDInterface,
    * @param source The PIDSource object that is used to get values
    * @param output The PIDOutput object that is set to the output value
    */
+  WPI_DEPRECATED("All APIs which use this have been deprecated.")
   PIDBase(double p, double i, double d, double f, PIDSource& source,
           PIDOutput& output);
 

--- a/wpilibc/src/main/native/include/frc/PIDInterface.h
+++ b/wpilibc/src/main/native/include/frc/PIDInterface.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2016-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2016-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -7,10 +7,13 @@
 
 #pragma once
 
+#include <wpi/deprecated.h>
+
 namespace frc {
 
 class PIDInterface {
  public:
+  WPI_DEPRECATED("All APIs which use this have been deprecated.")
   PIDInterface() = default;
   PIDInterface(PIDInterface&&) = default;
   PIDInterface& operator=(PIDInterface&&) = default;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
@@ -26,7 +26,10 @@ import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
  * <p>This feedback controller runs in discrete time, so time deltas are not used in the integral
  * and derivative calculations. Therefore, the sample rate affects the controller's behavior for a
  * given set of PID constants.
+ *
+ * @deprecated All APIs which use this have been deprecated.
  */
+@Deprecated(since = "2020", forRemoval = true)
 @SuppressWarnings("PMD.TooManyFields")
 public class PIDBase implements PIDInterface, PIDOutput, Sendable, AutoCloseable {
   public static final double kDefaultPeriod = 0.05;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDInterface.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PIDInterface.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2016-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2016-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -7,6 +7,7 @@
 
 package edu.wpi.first.wpilibj;
 
+@Deprecated(since = "2020", forRemoval = true)
 @SuppressWarnings("SummaryJavadoc")
 public interface PIDInterface {
   @SuppressWarnings("ParameterName")


### PR DESCRIPTION
PIDBase was only used by the old PIDController, which is deprecated.
PIDInterface is only used by PIDBase, and that's deprecated by this
commit.