### PR TITLE
Various simulation GUI fixes

### DIFF
--- a/hal/src/main/native/sim/mockdata/SimDeviceData.cpp
+++ b/hal/src/main/native/sim/mockdata/SimDeviceData.cpp
@@ -37,6 +37,7 @@ SimDeviceData::Value* SimDeviceData::LookupValue(HAL_SimValueHandle handle) {
 
   // look up device
   Device* deviceImpl = LookupDevice(handle >> 16);
+  if (!deviceImpl) return nullptr;
 
   // look up value
   handle &= 0xffff;

--- a/imgui/CMakeLists.txt
+++ b/imgui/CMakeLists.txt
@@ -14,6 +14,24 @@ if(result)
   message(FATAL_ERROR "Build step for imgui failed: ${result}")
 endif()
 
+# Build font
+add_executable(imgui_font_bin2c ${CMAKE_CURRENT_BINARY_DIR}/imgui-src/misc/fonts/binary_to_compressed_c.cpp)
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/ProggyDotted.inc
+  COMMAND imgui_font_bin2c
+  ARGS "${CMAKE_CURRENT_BINARY_DIR}/proggyfonts-src/ProggyDotted/ProggyDotted Regular.ttf" ProggyDotted > ${CMAKE_CURRENT_BINARY_DIR}/ProggyDotted.inc
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  MAIN_DEPENDENCY "${CMAKE_CURRENT_BINARY_DIR}/proggyfonts-src/ProggyDotted/ProggyDotted Regular.ttf"
+  VERBATIM
+)
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/imgui_ProggyDotted.cpp
+    CONTENT "#include \"imgui_ProggyDotted.h\"\n#include \"ProggyDotted.inc\"\nImFont* ImGui::AddFontProggyDotted(ImGuiIO& io, float size_pixels, const ImFontConfig* font_cfg, const ImWchar* glyph_ranges) {\n  return io.Fonts->AddFontFromMemoryCompressedTTF(ProggyDotted_compressed_data, ProggyDotted_compressed_size, size_pixels, font_cfg, glyph_ranges);\n}\n"
+)
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/imgui_ProggyDotted.h
+    CONTENT "#pragma once\n#include \"imgui.h\"\nnamespace ImGui {\nImFont* AddFontProggyDotted(ImGuiIO& io, float size_pixels, const ImFontConfig* font_cfg = nullptr, const ImWchar* glyph_ranges = nullptr);\n}\n"
+)
+set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/imgui_ProggyDotted.cpp
+    PROPERTIES OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ProggyDotted.inc)
+
 # Add imgui directly to our build.
 set(SAVE_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
@@ -28,8 +46,8 @@ add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/gl3w-src
 
 set(imgui_srcdir ${CMAKE_CURRENT_BINARY_DIR}/imgui-src)
 file(GLOB imgui_sources ${imgui_srcdir}/*.cpp)
-add_library(imgui STATIC ${imgui_sources} ${imgui_srcdir}/examples/imgui_impl_glfw.cpp ${imgui_srcdir}/examples/imgui_impl_opengl3.cpp)
+add_library(imgui STATIC ${imgui_sources} ${imgui_srcdir}/examples/imgui_impl_glfw.cpp ${imgui_srcdir}/examples/imgui_impl_opengl3.cpp ${CMAKE_CURRENT_BINARY_DIR}/imgui_ProggyDotted.cpp)
 target_link_libraries(imgui PUBLIC gl3w glfw)
-target_include_directories(imgui PUBLIC "$<BUILD_INTERFACE:${imgui_srcdir}>" "$<BUILD_INTERFACE:${imgui_srcdir}/examples>")
+target_include_directories(imgui PUBLIC "$<BUILD_INTERFACE:${imgui_srcdir}>" "$<BUILD_INTERFACE:${imgui_srcdir}/examples>" "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
 
 set_property(TARGET imgui PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/imgui/CMakeLists.txt.in
+++ b/imgui/CMakeLists.txt.in
@@ -31,3 +31,13 @@ ExternalProject_Add(imgui
   INSTALL_COMMAND   ""
   TEST_COMMAND      ""
 )
+ExternalProject_Add(proggyfonts
+  GIT_REPOSITORY    https://github.com/bluescan/proggyfonts.git
+  GIT_TAG           v1.1.5
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/proggyfonts-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/proggyfonts-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -11,7 +11,7 @@ nativeUtils {
       niLibVersion = "2020.4.1"
       opencvVersion = "3.4.7-1"
       googleTestVersion = "1.9.0-3-437e100"
-      imguiVersion = "1.72b-1"
+      imguiVersion = "1.72b-2"
     }
   }
 }

--- a/simulation/halsim_gui/src/main/native/cpp/CompressorGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/CompressorGui.cpp
@@ -14,6 +14,7 @@
 #include <imgui.h>
 #include <mockdata/PCMData.h>
 
+#include "HALSimGui.h"
 #include "SimDeviceGui.h"
 
 using namespace halsimgui;
@@ -28,7 +29,10 @@ static void DisplayCompressors() {
       HAL_Value value;
 
       // enabled
-      value = HAL_MakeBoolean(HALSIM_GetPCMCompressorOn(i));
+      if (HALSimGui::AreOutputsDisabled())
+        value = HAL_MakeBoolean(false);
+      else
+        value = HAL_MakeBoolean(HALSIM_GetPCMCompressorOn(i));
       if (SimDeviceGui::DisplayValue("Running", false, &value))
         HALSIM_SetPCMCompressorOn(i, value.data.v_boolean);
 

--- a/simulation/halsim_gui/src/main/native/cpp/DIOGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/DIOGui.cpp
@@ -56,7 +56,7 @@ static void DisplayDIO() {
     }
   }
 
-  ImGui::PushItemWidth(100);
+  ImGui::PushItemWidth(ImGui::GetFontSize() * 8);
   for (int i = 0; i < numDIO; ++i) {
     if (HALSIM_GetDIOInitialized(i)) {
       hasAny = true;

--- a/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
@@ -211,7 +211,12 @@ void RobotJoystick::Update() {
   const unsigned char* sysButtons;
   if (sys->isGamepad && useGamepad) {
     sysAxes = sys->gamepadState.axes;
+    // don't remap on windows
+#ifdef _WIN32
+    sysButtons = sys->buttons;
+#else
     sysButtons = sys->gamepadState.buttons;
+#endif
   } else {
     sysAxes = sys->axes;
     sysButtons = sys->buttons;
@@ -226,12 +231,32 @@ void RobotJoystick::Update() {
   desc.buttonCount = (std::min)(sys->buttonCount, 32);
   desc.povCount = (std::min)(sys->hatCount, HAL_kMaxJoystickPOVs);
 
-  axes.count = desc.axisCount;
-  std::memcpy(axes.axes, sysAxes, axes.count * sizeof(&axes.axes[0]));
-
   buttons.count = desc.buttonCount;
   for (int j = 0; j < buttons.count; ++j)
     buttons.buttons |= (sysButtons[j] ? 1u : 0u) << j;
+
+  axes.count = desc.axisCount;
+  if (sys->isGamepad && useGamepad) {
+    // the FRC DriverStation maps gamepad (XInput) trigger values to 0-1 range
+    // on axis 2 and 3.
+    axes.axes[0] = sysAxes[0];
+    axes.axes[1] = sysAxes[1];
+    axes.axes[2] = 0.5 + sysAxes[4] / 2.0;
+    axes.axes[3] = 0.5 + sysAxes[5] / 2.0;
+    axes.axes[4] = sysAxes[2];
+    axes.axes[5] = sysAxes[3];
+
+    // the start button for gamepads is not mapped on the FRC DriverStation
+    // platforms, so remove it if present
+    if (buttons.count == 11) {
+      --desc.buttonCount;
+      --buttons.count;
+      buttons.buttons =
+          (buttons.buttons & 0xff) | ((buttons.buttons >> 1) & 0x300);
+    }
+  } else {
+    std::memcpy(axes.axes, sysAxes, axes.count * sizeof(&axes.axes[0]));
+  }
 
   povs.count = desc.povCount;
   for (int j = 0; j < povs.count; ++j) povs.povs[j] = HatToAngle(sys->hats[j]);

--- a/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
@@ -351,7 +351,7 @@ static void DisplayFMS() {
   static const char* stations[] = {"Red 1",  "Red 2",  "Red 3",
                                    "Blue 1", "Blue 2", "Blue 3"};
   int allianceStationId = HALSIM_GetDriverStationAllianceStationId();
-  ImGui::SetNextItemWidth(100);
+  ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8);
   if (ImGui::Combo("Alliance Station", &allianceStationId, stations, 6))
     HALSIM_SetDriverStationAllianceStationId(
         static_cast<HAL_AllianceStationID>(allianceStationId));
@@ -362,7 +362,7 @@ static void DisplayFMS() {
 
   static double startMatchTime = 0.0;
   double matchTime = HALSIM_GetDriverStationMatchTime();
-  ImGui::SetNextItemWidth(100);
+  ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8);
   if (ImGui::InputDouble("Match Time", &matchTime, 0, 0, "%.1f",
                          ImGuiInputTextFlags_EnterReturnsTrue)) {
     HALSIM_SetDriverStationMatchTime(matchTime);
@@ -380,7 +380,7 @@ static void DisplayFMS() {
 
   // Game Specific Message
   static HAL_MatchInfo matchInfo;
-  ImGui::SetNextItemWidth(100);
+  ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8);
   if (ImGui::InputText("Game Specific",
                        reinterpret_cast<char*>(matchInfo.gameSpecificMessage),
                        sizeof(matchInfo.gameSpecificMessage),
@@ -420,7 +420,7 @@ static void DisplaySystemJoysticks() {
 
 static void DisplayJoysticks() {
   // imgui doesn't size columns properly with autoresize, so force it
-  ImGui::Dummy(ImVec2(14.0 * 9 * HAL_kMaxJoysticks, 0));
+  ImGui::Dummy(ImVec2(ImGui::GetFontSize() * 10 * HAL_kMaxJoysticks, 0));
 
   ImGui::Columns(HAL_kMaxJoysticks, "Joysticks", false);
   for (int i = 0; i < HAL_kMaxJoysticks; ++i) {

--- a/simulation/halsim_gui/src/main/native/cpp/EncoderGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/EncoderGui.cpp
@@ -54,7 +54,7 @@ static void EncodersWriteAll(ImGuiContext* ctx, ImGuiSettingsHandler* handler,
 static void DisplayEncoders() {
   bool hasAny = false;
   static int numEncoder = HAL_GetNumEncoders();
-  ImGui::PushItemWidth(100);
+  ImGui::PushItemWidth(ImGui::GetFontSize() * 8);
   for (int i = 0; i < numEncoder; ++i) {
     if (HALSIM_GetEncoderInitialized(i)) {
       hasAny = true;

--- a/simulation/halsim_gui/src/main/native/cpp/ExtraGuiWidgets.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/ExtraGuiWidgets.cpp
@@ -12,6 +12,8 @@ namespace halsimgui {
 void DrawLEDs(int* values, int numValues, int cols, const ImU32* colors,
               float size, float spacing) {
   if (numValues == 0) return;
+  if (size == 0) size = ImGui::GetFontSize() / 2.0;
+  if (spacing == 0) spacing = ImGui::GetFontSize() / 3.0;
 
   ImDrawList* drawList = ImGui::GetWindowDrawList();
   const ImVec2 p = ImGui::GetCursorScreenPos();

--- a/simulation/halsim_gui/src/main/native/cpp/PDPGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/PDPGui.cpp
@@ -21,7 +21,7 @@ static void DisplayPDP() {
   bool hasAny = false;
   static int numPDP = HAL_GetNumPDPModules();
   static int numChannels = HAL_GetNumPDPChannels();
-  ImGui::PushItemWidth(150);
+  ImGui::PushItemWidth(ImGui::GetFontSize() * 13);
   for (int i = 0; i < numPDP; ++i) {
     if (HALSIM_GetPDPInitialized(i)) {
       hasAny = true;

--- a/simulation/halsim_gui/src/main/native/cpp/PWMGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/PWMGui.cpp
@@ -42,7 +42,7 @@ static void DisplayPWMs() {
 
       char name[32];
       std::snprintf(name, sizeof(name), "PWM[%d]", i);
-      float val = HALSIM_GetPWMSpeed(i);
+      float val = HALSimGui::AreOutputsDisabled() ? 0 : HALSIM_GetPWMSpeed(i);
       ImGui::Value(name, val, "%0.3f");
 
       // lazily build history storage

--- a/simulation/halsim_gui/src/main/native/cpp/RelayGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/RelayGui.cpp
@@ -35,8 +35,12 @@ static void DisplayRelays() {
       else
         first = false;
 
-      bool forward = HALSIM_GetRelayForward(i);
-      bool reverse = HALSIM_GetRelayReverse(i);
+      bool forward = false;
+      bool reverse = false;
+      if (!HALSimGui::AreOutputsDisabled()) {
+        reverse = HALSIM_GetRelayReverse(i);
+        forward = HALSIM_GetRelayForward(i);
+      }
 
       ImGui::Text("Relay[%d]", i);
       ImGui::SameLine();

--- a/simulation/halsim_gui/src/main/native/cpp/RoboRioGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/RoboRioGui.cpp
@@ -18,7 +18,7 @@ static void DisplayRoboRio() {
   ImGui::Button("User Button");
   HALSIM_SetRoboRioFPGAButton(0, ImGui::IsItemActive());
 
-  ImGui::PushItemWidth(100);
+  ImGui::PushItemWidth(ImGui::GetFontSize() * 8);
 
   if (ImGui::CollapsingHeader("RoboRIO Input")) {
     {

--- a/simulation/halsim_gui/src/main/native/cpp/SolenoidGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/SolenoidGui.cpp
@@ -31,7 +31,10 @@ static void DisplaySolenoids() {
     for (int j = 0; j < numChannels; ++j) {
       if (HALSIM_GetPCMSolenoidInitialized(i, j)) {
         anyInit = true;
-        channels[j] = HALSIM_GetPCMSolenoidOutput(i, j) ? 1 : -1;
+        channels[j] = (!HALSimGui::AreOutputsDisabled() &&
+                       HALSIM_GetPCMSolenoidOutput(i, j))
+                          ? 1
+                          : -1;
       } else {
         channels[j] = -2;
       }

--- a/simulation/halsim_gui/src/main/native/include/ExtraGuiWidgets.h
+++ b/simulation/halsim_gui/src/main/native/include/ExtraGuiWidgets.h
@@ -23,10 +23,12 @@ namespace halsimgui {
  * @param numValues size of values array
  * @param cols number of columns
  * @param colors colors array
- * @param size size of each LED (both horizontal and vertical)
- * @param spacing spacing between each LED (both horizontal and vertical)
+ * @param size size of each LED (both horizontal and vertical);
+ *             if 0, defaults to 1/2 of font size
+ * @param spacing spacing between each LED (both horizontal and vertical);
+ *                if 0, defaults to 1/3 of font size
  */
 void DrawLEDs(int* values, int numValues, int cols, const ImU32* colors,
-              float size = 8.0f, float spacing = 6.0f);
+              float size = 0.0f, float spacing = 0.0f);
 
 }  // namespace halsimgui

--- a/simulation/halsim_gui/src/main/native/include/HALSimGui.h
+++ b/simulation/halsim_gui/src/main/native/include/HALSimGui.h
@@ -23,6 +23,7 @@ void HALSIMGUI_SetWindowVisibility(const char* name, int32_t visibility);
 void HALSIMGUI_SetDefaultWindowPos(const char* name, float x, float y);
 void HALSIMGUI_SetDefaultWindowSize(const char* name, float width,
                                     float height);
+int HALSIMGUI_AreOutputsDisabled(void);
 
 }  // extern "C"
 
@@ -125,6 +126,13 @@ class HALSimGui {
    * @param height height
    */
   static void SetDefaultWindowSize(const char* name, float width, float height);
+
+  /**
+   * Returns true if outputs are disabled.
+   *
+   * @return true if outputs are disabled, false otherwise.
+   */
+  static bool AreOutputsDisabled();
 };
 
 }  // namespace halsimgui


### PR DESCRIPTION
- Map gamepad the same way as DS
- Support high DPI monitors (fixes #1919)
- Handle low resolution monitors (fixes #1928)
- Disable outputs on DS disable (fixes #1927)