### PR TITLE
Remove HAL Base Initialize

### DIFF
--- a/hal/src/main/native/athena/HAL.cpp
+++ b/hal/src/main/native/athena/HAL.cpp
@@ -350,7 +350,7 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
     setNewDataSem(nullptr);
   });
 
-    // image 4; Fixes errors caused by multiple processes. Talk to NI about this
+  // image 4; Fixes errors caused by multiple processes. Talk to NI about this
   nFPGA::nRoboRIO_FPGANamespace::g_currentTargetClass =
       nLoadOut::kTargetClass_RoboRIO;
 

--- a/hal/src/main/native/athena/HAL.cpp
+++ b/hal/src/main/native/athena/HAL.cpp
@@ -277,24 +277,6 @@ HAL_Bool HAL_GetBrownedOut(int32_t* status) {
   return !(watchdog->readStatus_PowerAlive(status));
 }
 
-void HAL_BaseInitialize(int32_t* status) {
-  static std::atomic_bool initialized{false};
-  static wpi::mutex initializeMutex;
-  // Initial check, as if it's true initialization has finished
-  if (initialized) return;
-
-  std::scoped_lock lock(initializeMutex);
-  // Second check in case another thread was waiting
-  if (initialized) return;
-  // image 4; Fixes errors caused by multiple processes. Talk to NI about this
-  nFPGA::nRoboRIO_FPGANamespace::g_currentTargetClass =
-      nLoadOut::kTargetClass_RoboRIO;
-
-  global.reset(tGlobal::create(status));
-  watchdog.reset(tSysWatchdog::create(status));
-  initialized = true;
-}
-
 static bool killExistingProgram(int timeout, int mode) {
   // Kill any previous robot programs
   std::fstream fs;
@@ -368,8 +350,14 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
     setNewDataSem(nullptr);
   });
 
+    // image 4; Fixes errors caused by multiple processes. Talk to NI about this
+  nFPGA::nRoboRIO_FPGANamespace::g_currentTargetClass =
+      nLoadOut::kTargetClass_RoboRIO;
+
   int32_t status = 0;
-  HAL_BaseInitialize(&status);
+  global.reset(tGlobal::create(&status));
+  watchdog.reset(tSysWatchdog::create(&status));
+
   if (status != 0) return false;
 
   HAL_InitializeDriverStation();

--- a/hal/src/main/native/include/hal/HALBase.h
+++ b/hal/src/main/native/include/hal/HALBase.h
@@ -78,16 +78,6 @@ HAL_Bool HAL_GetSystemActive(int32_t* status);
 HAL_Bool HAL_GetBrownedOut(int32_t* status);
 
 /**
- * The base HAL initialize function. Useful if you need to ensure the DS and
- * base HAL functions (the ones above this declaration in HAL.h) are properly
- * initialized. For normal programs and executables, please use HAL_Initialize.
- *
- * This is mainly expected to be use from libraries that are expected to be used
- * from LabVIEW, as it handles its own initialization for objects.
- */
-void HAL_BaseInitialize(int32_t* status);
-
-/**
  * Gets a port handle for a specific channel.
  *
  * The created handle does not need to be freed.


### PR DESCRIPTION
Because of the DS changes we made, we cannot support this anymore. Therefore it can be removed.