### PR TITLE
Remove CameraServer and CS Core from wpilibc

### DIFF
--- a/cameraserver/src/main/native/cpp/cameraserver/CameraServerShared.cpp
+++ b/cameraserver/src/main/native/cpp/cameraserver/CameraServerShared.cpp
@@ -24,15 +24,10 @@ class DefaultCameraServerShared : public frc::CameraServerShared {
 };
 }  // namespace
 
-namespace frc {
-
-static std::unique_ptr<CameraServerShared> cameraServerShared = nullptr;
+static std::unique_ptr<frc::CameraServerShared> cameraServerShared = nullptr;
 static wpi::mutex setLock;
 
-void SetCameraServerShared(std::unique_ptr<CameraServerShared> shared) {
-  std::unique_lock lock(setLock);
-  cameraServerShared = std::move(shared);
-}
+namespace frc {
 CameraServerShared* GetCameraServerShared() {
   std::unique_lock lock(setLock);
   if (!cameraServerShared) {
@@ -41,3 +36,10 @@ CameraServerShared* GetCameraServerShared() {
   return cameraServerShared.get();
 }
 }  // namespace frc
+
+extern "C" {
+void CameraServer_SetCameraServerShared(frc::CameraServerShared* shared) {
+  std::unique_lock lock(setLock);
+  cameraServerShared.reset(shared);
+}
+}  // extern "C"

--- a/cameraserver/src/main/native/include/cameraserver/CameraServerShared.h
+++ b/cameraserver/src/main/native/include/cameraserver/CameraServerShared.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -26,6 +26,10 @@ class CameraServerShared {
   virtual std::pair<std::thread::id, bool> GetRobotMainThreadId() const = 0;
 };
 
-void SetCameraServerShared(std::unique_ptr<CameraServerShared> shared);
 CameraServerShared* GetCameraServerShared();
 }  // namespace frc
+
+extern "C" {
+// Takes ownership
+void CameraServer_SetCameraServerShared(frc::CameraServerShared* shared);
+}  // extern "C"

--- a/wpilibc/CMakeLists.txt
+++ b/wpilibc/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package( OpenCV REQUIRED )
 configure_file(src/generate/WPILibVersion.cpp.in WPILibVersion.cpp)
 
 file(GLOB_RECURSE
-    wpilibc_native_src src/main/native/cpp/*.cpp)
+    wpilibc_native_src src/main/native/cpp/*.cpp src/main/native/cppcs/*.cpp)
 
 add_library(wpilibc ${wpilibc_native_src} ${CMAKE_CURRENT_BINARY_DIR}/WPILibVersion.cpp)
 set_target_properties(wpilibc PROPERTIES DEBUG_POSTFIX "d")

--- a/wpilibc/build.gradle
+++ b/wpilibc/build.gradle
@@ -116,31 +116,39 @@ model {
                     it.buildable = false
                     return
                 }
+                cppCompiler.define 'DYNAMIC_CAMERA_SERVER'
                 lib project: ':ntcore', library: 'ntcore', linkage: 'shared'
-                lib project: ':cscore', library: 'cscore', linkage: 'shared'
                 project(':hal').addHalDependency(it, 'shared')
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-                lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
             }
         }
         "${nativeName}"(NativeLibrarySpec) {
             sources {
                 cpp {
                     source {
-                        srcDirs "${rootDir}/shared/singlelib"
+                        srcDirs "src/main/native/cppcs"
                         include '**/*.cpp'
                     }
                     exportedHeaders {
-                        srcDirs 'src/main/native/include'
+                        srcDirs 'src/main/native/include', '../cameraserver/src/main/native/include'
                     }
                 }
             }
             binaries.all {
                 lib project: ':ntcore', library: 'ntcore', linkage: 'shared'
-                lib project: ':cscore', library: 'cscore', linkage: 'shared'
                 project(':hal').addHalDependency(it, 'shared')
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-                lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
+
+                if (it instanceof SharedLibraryBinarySpec) {
+                    cppCompiler.define 'DYNAMIC_CAMERA_SERVER'
+                    if (buildType == buildTypes.debug) {
+                        cppCompiler.define 'DYNAMIC_CAMERA_SERVER_DEBUG'
+                    }
+                } else {
+                    lib project: ':cscore', library: 'cscore', linkage: 'shared'
+                    lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
+                }
+
             }
             appendDebugPathToBinaries(binaries)
         }

--- a/wpilibc/src/main/native/cpp/shuffleboard/SendableCameraWrapper.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/SendableCameraWrapper.cpp
@@ -5,6 +5,8 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#include "frc/shuffleboard/SendableCameraWrapper.h"
+
 #include <functional>
 #include <memory>
 #include <string>
@@ -15,20 +17,20 @@
 #include "frc/smartdashboard/SendableRegistry.h"
 
 namespace frc {
-class SendableCameraWrapper;
 namespace detail {
-std::shared_ptr<SendableCameraWrapper>& GetSendableCameraWrapper(int source) {
+std::shared_ptr<SendableCameraWrapper>& GetSendableCameraWrapper(
+    CS_Source source) {
   static wpi::DenseMap<int, std::shared_ptr<SendableCameraWrapper>> wrappers;
-  return wrappers[source];
-}
-
-void CreateSendableCameraWrapperSendable(std::function<std::string()> urlGetter,
-                                         SendableBuilder& builder) {
-  builder.AddStringProperty(".ShuffleboardURI", std::move(urlGetter), nullptr);
+  return wrappers[static_cast<int>(source)];
 }
 
 void AddToSendableRegistry(frc::Sendable* sendable, std::string name) {
   SendableRegistry::GetInstance().Add(sendable, name);
 }
 }  // namespace detail
+
+void SendableCameraWrapper::InitSendable(SendableBuilder& builder) {
+  builder.AddStringProperty(".ShuffleboardURI", [this] { return m_uri; },
+                            nullptr);
+}
 }  // namespace frc

--- a/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardContainer.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardContainer.cpp
@@ -11,7 +11,6 @@
 #include <wpi/raw_ostream.h>
 
 #include "frc/shuffleboard/ComplexWidget.h"
-#include "frc/shuffleboard/SendableCameraWrapper.h"
 #include "frc/shuffleboard/ShuffleboardComponent.h"
 #include "frc/shuffleboard/ShuffleboardLayout.h"
 #include "frc/shuffleboard/SimpleWidget.h"
@@ -75,21 +74,12 @@ ComplexWidget& ShuffleboardContainer::Add(const wpi::Twine& title,
   return *ptr;
 }
 
-ComplexWidget& ShuffleboardContainer::Add(const wpi::Twine& title,
-                                          const cs::VideoSource& video) {
-  return Add(title, SendableCameraWrapper::Wrap(video));
-}
-
 ComplexWidget& ShuffleboardContainer::Add(Sendable& sendable) {
   auto name = SendableRegistry::GetInstance().GetName(&sendable);
   if (name.empty()) {
     wpi::outs() << "Sendable must have a name\n";
   }
   return Add(name, sendable);
-}
-
-ComplexWidget& ShuffleboardContainer::Add(const cs::VideoSource& video) {
-  return Add(SendableCameraWrapper::Wrap(video));
 }
 
 SimpleWidget& ShuffleboardContainer::Add(

--- a/wpilibc/src/main/native/cppcs/RobotBase.cpp
+++ b/wpilibc/src/main/native/cppcs/RobotBase.cpp
@@ -94,7 +94,7 @@ static void SetupCameraServerShared() {
     wpi::outs().flush();
   }
 #else
-  SetCameraServerShared(new WPILibCameraServerShared{});
+  CameraServer_SetCameraServerShared(new WPILibCameraServerShared{});
 #endif
 #else
   wpi::outs() << "Not loading CameraServerShared\n";

--- a/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardContainer.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardContainer.h
@@ -501,3 +501,17 @@ class ShuffleboardContainer : public virtual ShuffleboardValue,
 #include "frc/shuffleboard/ComplexWidget.h"
 #include "frc/shuffleboard/ShuffleboardLayout.h"
 #include "frc/shuffleboard/SimpleWidget.h"
+
+#ifndef DYNAMIC_CAMERA_SERVER
+#include "frc/shuffleboard/SendableCameraWrapper.h"
+
+inline frc::ComplexWidget& frc::ShuffleboardContainer::Add(
+    const cs::VideoSource& video) {
+  return Add(frc::SendableCameraWrapper::Wrap(video));
+}
+
+inline frc::ComplexWidget& frc::ShuffleboardContainer::Add(
+    const wpi::Twine& title, const cs::VideoSource& video) {
+  return Add(title, frc::SendableCameraWrapper::Wrap(video));
+}
+#endif

--- a/wpiutil/src/main/native/windows/StackWalker.cpp
+++ b/wpiutil/src/main/native/windows/StackWalker.cpp
@@ -88,6 +88,7 @@
 #include <stdlib.h>
 #include <tchar.h>
 #pragma comment(lib, "version.lib") // for "VerQueryValue"
+#pragma comment(lib, "Advapi32.lib") // for "GetUserName"
 #pragma warning(disable : 4826)
 
 #ifdef UNICODE
@@ -484,8 +485,8 @@ private:
       if (hToolhelp == NULL)
         continue;
       createToolhelp32Snapshot = (tCT32S)GetProcAddress(hToolhelp, "CreateToolhelp32Snapshot");
-      module32First = (tM32F)GetProcAddress(hToolhelp, strModule32First);  
-      module32Next = (tM32N)GetProcAddress(hToolhelp, strModule32Next); 
+      module32First = (tM32F)GetProcAddress(hToolhelp, strModule32First);
+      module32Next = (tM32N)GetProcAddress(hToolhelp, strModule32Next);
       if ((createToolhelp32Snapshot != NULL) && (module32First != NULL) && (module32Next != NULL))
         break; // found the functions!
       FreeLibrary(hToolhelp);


### PR DESCRIPTION
Will help make linking easier, and there is VERY little that uses it. One piece of shuffleboard functionality is missing. However I might solve that by making it entirely header only. Will hurt compile times for that file, but thats OK.