### PR TITLE
Bump Native Utils and OpenCV dependencies

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,5 +5,5 @@ repositories {
     }
 }
 dependencies {
-    compile "edu.wpi.first:native-utils:2020.1.2"
+    compile "edu.wpi.first:native-utils:2020.1.4"
 }

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -9,7 +9,7 @@ nativeUtils {
     configureDependencies {
       wpiVersion = "-1"
       niLibVersion = "2020.5.1"
-      opencvVersion = "3.4.7-1"
+      opencvVersion = "3.4.7-2"
       googleTestVersion = "1.9.0-3-437e100"
       imguiVersion = "1.72b-2"
     }

--- a/shared/opencv.gradle
+++ b/shared/opencv.gradle
@@ -1,4 +1,4 @@
-def opencvVersion = '3.4.7-1'
+def opencvVersion = '3.4.7-2'
 
 if (project.hasProperty('useCpp') && project.useCpp) {
     model {


### PR DESCRIPTION
OpenCV doesn't change anything other then the hash file. NativeUtils is needed to get the newest compiler