### PR TITLE
Fix visibility of ControlVectorList in TrajectoryGenerator

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
@@ -8,6 +8,7 @@
 package edu.wpi.first.wpilibj.trajectory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import edu.wpi.first.wpilibj.geometry.Pose2d;
@@ -160,8 +161,7 @@ public final class TrajectoryGenerator {
   @SuppressWarnings("LocalVariableName")
   public static Trajectory generateTrajectory(List<Pose2d> waypoints, TrajectoryConfig config) {
     var originalList = SplineHelper.getQuinticControlVectorsFromWaypoints(waypoints);
-    var newList = new ControlVectorList();
-    newList.addAll(originalList);
+    var newList = new ControlVectorList(originalList);
     return generateTrajectory(newList, config);
   }
 
@@ -194,6 +194,17 @@ public final class TrajectoryGenerator {
   }
 
   // Work around type erasure signatures
-  private static class ControlVectorList extends ArrayList<Spline.ControlVector> {
+  public static class ControlVectorList extends ArrayList<Spline.ControlVector> {
+    public ControlVectorList(int initialCapacity) {
+      super(initialCapacity);
+    }
+
+    public ControlVectorList() {
+      super();
+    }
+
+    public ControlVectorList(Collection<? extends Spline.ControlVector> c) {
+      super(c);
+    }
   }
 }


### PR DESCRIPTION
Although I would much prefer these functions having different names, the implementation as-is is currently broken because ControlVectorList was private. I've made it public and added the proper constructors for it to actually be useful.