### PR TITLE
Clean up pidcommand

### DIFF
--- a/wpilibc/src/main/native/cpp/frc2/command/PIDCommand.cpp
+++ b/wpilibc/src/main/native/cpp/frc2/command/PIDCommand.cpp
@@ -31,15 +31,9 @@ PIDCommand::PIDCommand(PIDController controller,
 void PIDCommand::Initialize() { m_controller.Reset(); }
 
 void PIDCommand::Execute() {
-  UseOutput(m_controller.Calculate(GetMeasurement(), GetSetpoint()));
+  m_useOutput(m_controller.Calculate(m_measurement(), m_setpoint()));
 }
 
-void PIDCommand::End(bool interrupted) { UseOutput(0); }
-
-double PIDCommand::GetSetpoint() { return m_setpoint(); }
-
-double PIDCommand::GetMeasurement() { return m_measurement(); }
-
-void PIDCommand::UseOutput(double output) { m_useOutput(output); }
+void PIDCommand::End(bool interrupted) { m_useOutput(0); }
 
 PIDController& PIDCommand::getController() { return m_controller; }

--- a/wpilibc/src/main/native/cpp/frc2/command/PIDCommand.cpp
+++ b/wpilibc/src/main/native/cpp/frc2/command/PIDCommand.cpp
@@ -31,26 +31,12 @@ PIDCommand::PIDCommand(PIDController controller,
 void PIDCommand::Initialize() { m_controller.Reset(); }
 
 void PIDCommand::Execute() {
-  UseOutput(m_controller.Calculate(GetMeasurement(), m_setpoint()));
+  UseOutput(m_controller.Calculate(GetMeasurement(), GetSetpoint()));
 }
 
 void PIDCommand::End(bool interrupted) { UseOutput(0); }
 
-void PIDCommand::SetOutput(std::function<void(double)> useOutput) {
-  m_useOutput = useOutput;
-}
-
-void PIDCommand::SetSetpoint(std::function<double()> setpointSource) {
-  m_setpoint = setpointSource;
-}
-
-void PIDCommand::SetSetpoint(double setpoint) {
-  m_setpoint = [setpoint] { return setpoint; };
-}
-
-void PIDCommand::SetSetpointRelative(double relativeSetpoint) {
-  SetSetpoint(m_setpoint() + relativeSetpoint);
-}
+double PIDCommand::GetSetpoint() { return m_setpoint(); }
 
 double PIDCommand::GetMeasurement() { return m_measurement(); }
 

--- a/wpilibc/src/main/native/cpp/frc2/command/ProfiledPIDCommand.cpp
+++ b/wpilibc/src/main/native/cpp/frc2/command/ProfiledPIDCommand.cpp
@@ -54,20 +54,12 @@ ProfiledPIDCommand::ProfiledPIDCommand(
 void ProfiledPIDCommand::Initialize() { m_controller.Reset(); }
 
 void ProfiledPIDCommand::Execute() {
-  UseOutput(m_controller.Calculate(GetMeasurement(), GetGoal()),
-            m_controller.GetSetpoint());
+  m_useOutput(m_controller.Calculate(m_measurement(), m_goal()),
+              m_controller.GetSetpoint());
 }
 
 void ProfiledPIDCommand::End(bool interrupted) {
-  UseOutput(0, State{0_m, 0_mps});
-}
-
-State ProfiledPIDCommand::GetGoal() { return m_goal(); }
-
-units::meter_t ProfiledPIDCommand::GetMeasurement() { return m_measurement(); }
-
-void ProfiledPIDCommand::UseOutput(double output, State state) {
-  m_useOutput(output, state);
+  m_useOutput(0, State{0_m, 0_mps});
 }
 
 frc::ProfiledPIDController& ProfiledPIDCommand::GetController() {

--- a/wpilibc/src/main/native/cpp/frc2/command/ProfiledPIDCommand.cpp
+++ b/wpilibc/src/main/native/cpp/frc2/command/ProfiledPIDCommand.cpp
@@ -54,13 +54,15 @@ ProfiledPIDCommand::ProfiledPIDCommand(
 void ProfiledPIDCommand::Initialize() { m_controller.Reset(); }
 
 void ProfiledPIDCommand::Execute() {
-  UseOutput(m_controller.Calculate(GetMeasurement(), m_goal()),
+  UseOutput(m_controller.Calculate(GetMeasurement(), GetGoal()),
             m_controller.GetSetpoint());
 }
 
 void ProfiledPIDCommand::End(bool interrupted) {
   UseOutput(0, State{0_m, 0_mps});
 }
+
+State ProfiledPIDCommand::GetGoal() { return m_goal(); }
 
 units::meter_t ProfiledPIDCommand::GetMeasurement() { return m_measurement(); }
 

--- a/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
@@ -64,51 +64,6 @@ class PIDCommand : public CommandHelper<CommandBase, PIDCommand> {
   void End(bool interrupted) override;
 
   /**
-   * Sets the function that uses the output of the PIDController.
-   *
-   * @param useOutput The function that uses the output.
-   */
-  void SetOutput(std::function<void(double)> useOutput);
-
-  /**
-   * Sets the setpoint for the controller to track the given source.
-   *
-   * @param setpointSource The setpoint source
-   */
-  void SetSetpoint(std::function<double()> setpointSource);
-
-  /**
-   * Sets the setpoint for the controller to a constant value.
-   *
-   * @param setpoint The setpoint
-   */
-  void SetSetpoint(double setpoint);
-
-  /**
-   * Sets the setpoint for the controller to a constant value relative (i.e.
-   * added to) the current setpoint.
-   *
-   * @param relativeReference The change in setpoint
-   */
-  void SetSetpointRelative(double relativeSetpoint);
-
-  /**
-   * Gets the measurement of the process variable. Wraps the passed-in function
-   * for readability.
-   *
-   * @return The measurement of the process variable
-   */
-  virtual double GetMeasurement();
-
-  /**
-   * Gets the measurement of the process variable. Wraps the passed-in function
-   * for readability.
-   *
-   * @return The measurement of the process variable
-   */
-  virtual void UseOutput(double output);
-
-  /**
    * Returns the PIDController used by the command.
    *
    * @return The PIDController
@@ -120,5 +75,30 @@ class PIDCommand : public CommandHelper<CommandBase, PIDCommand> {
   std::function<double()> m_measurement;
   std::function<double()> m_setpoint;
   std::function<void(double)> m_useOutput;
+
+ private:
+  /**
+   * Wraps the setpoint supplier field so that changes to it are visible to the
+   * controller.
+   *
+   * @return The setpoint for the controller
+   */
+  double GetSetpoint();
+
+  /**
+   * Wraps the measurement supplier field so that changes to it are visible to
+   * the controller.
+   *
+   * @return The measurement of the process variable
+   */
+  double GetMeasurement();
+
+  /**
+   * Wraps the output consumer field so that changes to it are visible to the
+   * controller.
+   *
+   * @return The measurement of the process variable
+   */
+  void UseOutput(double output);
 };
 }  // namespace frc2

--- a/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/PIDCommand.h
@@ -75,30 +75,5 @@ class PIDCommand : public CommandHelper<CommandBase, PIDCommand> {
   std::function<double()> m_measurement;
   std::function<double()> m_setpoint;
   std::function<void(double)> m_useOutput;
-
- private:
-  /**
-   * Wraps the setpoint supplier field so that changes to it are visible to the
-   * controller.
-   *
-   * @return The setpoint for the controller
-   */
-  double GetSetpoint();
-
-  /**
-   * Wraps the measurement supplier field so that changes to it are visible to
-   * the controller.
-   *
-   * @return The measurement of the process variable
-   */
-  double GetMeasurement();
-
-  /**
-   * Wraps the output consumer field so that changes to it are visible to the
-   * controller.
-   *
-   * @return The measurement of the process variable
-   */
-  void UseOutput(double output);
 };
 }  // namespace frc2

--- a/wpilibc/src/main/native/include/frc2/command/ProfiledPIDCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/ProfiledPIDCommand.h
@@ -101,22 +101,6 @@ class ProfiledPIDCommand
   void End(bool interrupted) override;
 
   /**
-   * Gets the measurement of the process variable. Wraps the passed-in function
-   * for readability.
-   *
-   * @return The measurement of the process variable
-   */
-  virtual units::meter_t GetMeasurement();
-
-  /**
-   * Gets the measurement of the process variable. Wraps the passed-in function
-   * for readability.
-   *
-   * @return The measurement of the process variable
-   */
-  virtual void UseOutput(double output, State state);
-
-  /**
    * Returns the ProfiledPIDController used by the command.
    *
    * @return The ProfiledPIDController
@@ -128,5 +112,30 @@ class ProfiledPIDCommand
   std::function<units::meter_t()> m_measurement;
   std::function<State()> m_goal;
   std::function<void(double, State)> m_useOutput;
+
+ private:
+  /**
+   * Wraps the goal supplier field so that changes to it are visible to the
+   * controller.
+   *
+   * @return The goal for the controller
+   */
+  State GetGoal();
+
+  /**
+   * Wraps the measurement supplier field so that changes to it are visible to
+   * the controller.
+   *
+   * @return The measurement for the controller
+   */
+  units::meter_t GetMeasurement();
+
+  /**
+   * Wraps the output consumer field so that changes to it are visible to the
+   * controller.
+   *
+   * @return The output from the controller
+   */
+  void UseOutput(double output, State state);
 };
 }  // namespace frc2

--- a/wpilibc/src/main/native/include/frc2/command/ProfiledPIDCommand.h
+++ b/wpilibc/src/main/native/include/frc2/command/ProfiledPIDCommand.h
@@ -112,30 +112,5 @@ class ProfiledPIDCommand
   std::function<units::meter_t()> m_measurement;
   std::function<State()> m_goal;
   std::function<void(double, State)> m_useOutput;
-
- private:
-  /**
-   * Wraps the goal supplier field so that changes to it are visible to the
-   * controller.
-   *
-   * @return The goal for the controller
-   */
-  State GetGoal();
-
-  /**
-   * Wraps the measurement supplier field so that changes to it are visible to
-   * the controller.
-   *
-   * @return The measurement for the controller
-   */
-  units::meter_t GetMeasurement();
-
-  /**
-   * Wraps the output consumer field so that changes to it are visible to the
-   * controller.
-   *
-   * @return The output from the controller
-   */
-  void UseOutput(double output, State state);
 };
 }  // namespace frc2

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj2/command/PIDCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj2/command/PIDCommand.java
@@ -90,7 +90,7 @@ public class PIDCommand extends CommandBase {
   }
 
   /**
-   * Gets the setpoint for the controller.  Wraps the passed-in function for readability.
+   * Wraps the setpoint supplier field so that changes to it are visible to the controller.
    *
    * @return The setpoint for the controller
    */
@@ -99,7 +99,7 @@ public class PIDCommand extends CommandBase {
   }
 
   /**
-   * Gets the measurement of the process variable. Wraps the passed-in function for readability.
+   * Wraps the measurement supplier field so that changes to it are visible to the controller.
    *
    * @return The measurement of the process variable
    */
@@ -108,7 +108,7 @@ public class PIDCommand extends CommandBase {
   }
 
   /**
-   * Uses the output of the controller.  Wraps the passed-in function for readability.
+   * Wraps the output consumer field so that changes to it are visible to the controller.
    *
    * @param output The output value to use
    */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj2/command/PIDCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj2/command/PIDCommand.java
@@ -110,7 +110,7 @@ public class PIDCommand extends CommandBase {
   /**
    * Wraps the output consumer field so that changes to it are visible to the controller.
    *
-   * @param output The output value to use
+   * @param output The output from the controller
    */
   private void useOutput(double output) {
     m_useOutput.accept(output);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj2/command/PIDCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj2/command/PIDCommand.java
@@ -72,12 +72,13 @@ public class PIDCommand extends CommandBase {
 
   @Override
   public void execute() {
-    useOutput(m_controller.calculate(getMeasurement(), getSetpoint()));
+    m_useOutput.accept(m_controller.calculate(m_measurement.getAsDouble(),
+                                              m_setpoint.getAsDouble()));
   }
 
   @Override
   public void end(boolean interrupted) {
-    useOutput(0);
+    m_useOutput.accept(0);
   }
 
   /**
@@ -87,32 +88,5 @@ public class PIDCommand extends CommandBase {
    */
   public PIDController getController() {
     return m_controller;
-  }
-
-  /**
-   * Wraps the setpoint supplier field so that changes to it are visible to the controller.
-   *
-   * @return The setpoint for the controller
-   */
-  private double getSetpoint() {
-    return m_setpoint.getAsDouble();
-  }
-
-  /**
-   * Wraps the measurement supplier field so that changes to it are visible to the controller.
-   *
-   * @return The measurement of the process variable
-   */
-  private double getMeasurement() {
-    return m_measurement.getAsDouble();
-  }
-
-  /**
-   * Wraps the output consumer field so that changes to it are visible to the controller.
-   *
-   * @param output The output from the controller
-   */
-  private void useOutput(double output) {
-    m_useOutput.accept(output);
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDCommand.java
@@ -118,12 +118,13 @@ public class ProfiledPIDCommand extends CommandBase {
 
   @Override
   public void execute() {
-    useOutput(m_controller.calculate(getMeasurement(), getGoal()), m_controller.getSetpoint());
+    m_useOutput.accept(m_controller.calculate(m_measurement.getAsDouble(), m_goal.get()),
+                       m_controller.getSetpoint());
   }
 
   @Override
   public void end(boolean interrupted) {
-    useOutput(0, new State());
+    m_useOutput.accept(0., new State());
   }
 
   /**
@@ -133,32 +134,5 @@ public class ProfiledPIDCommand extends CommandBase {
    */
   public ProfiledPIDController getController() {
     return m_controller;
-  }
-
-  /**
-   * Wraps the goal supplier field so that changes to it are visible to the controller.
-   *
-   * @return The goal for the controller
-   */
-  private State getGoal() {
-    return m_goal.get();
-  }
-
-  /**
-   * Wraps the measurement supplier field so that changes to it are visible to the controller.
-   *
-   * @return The measurement of the process variable
-   */
-  private double getMeasurement() {
-    return m_measurement.getAsDouble();
-  }
-
-  /**
-   * Wraps the output consumer field so that changes to it are visible to the controller.
-   *
-   * @param output The output from the controller
-   */
-  private void useOutput(double output, State state) {
-    m_useOutput.accept(output, state);
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDCommand.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDCommand.java
@@ -136,7 +136,7 @@ public class ProfiledPIDCommand extends CommandBase {
   }
 
   /**
-   * Gets the goal for the controller.  Wraps the passed-in function for readability.
+   * Wraps the goal supplier field so that changes to it are visible to the controller.
    *
    * @return The goal for the controller
    */
@@ -145,7 +145,7 @@ public class ProfiledPIDCommand extends CommandBase {
   }
 
   /**
-   * Gets the measurement of the process variable. Wraps the passed-in function for readability.
+   * Wraps the measurement supplier field so that changes to it are visible to the controller.
    *
    * @return The measurement of the process variable
    */
@@ -154,9 +154,9 @@ public class ProfiledPIDCommand extends CommandBase {
   }
 
   /**
-   * Uses the output of the controller.  Wraps the passed-in function for readability.
+   * Wraps the output consumer field so that changes to it are visible to the controller.
    *
-   * @param output The output value to use
+   * @param output The output from the controller
    */
   private void useOutput(double output, State state) {
     m_useOutput.accept(output, state);


### PR DESCRIPTION
Assorted clean-ups for pidcommands.  Wrapper methods are no longer needed now that PIDController does not take the lambdas as parameters.