### PR TITLE
Fix null pointer dereference in C++ CommandScheduler

### DIFF
--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -174,7 +174,7 @@ void CommandScheduler::Run() {
   // Add default commands for un-required registered subsystems.
   for (auto&& subsystem : m_subsystems) {
     auto s = m_requirements.find(subsystem.getFirst());
-    if (s == m_requirements.end()) {
+    if (s == m_requirements.end() && subsystem.getSecond()) {
       Schedule({subsystem.getSecond().get()});
     }
   }


### PR DESCRIPTION
Java has a null check that was missing in C++ when adding default commands.