### PR TITLE
Don't allow rising and falling values to be read from AnalogTrigger

### DIFF
--- a/hal/src/main/native/athena/AnalogTrigger.cpp
+++ b/hal/src/main/native/athena/AnalogTrigger.cpp
@@ -254,10 +254,9 @@ HAL_Bool HAL_GetAnalogTriggerOutput(HAL_AnalogTriggerHandle analogTriggerHandle,
       result = trigger->trigger->readOutput_OverLimit(trigger->index, status);
       break;
     case HAL_Trigger_kRisingPulse:
-      result = trigger->trigger->readOutput_Rising(trigger->index, status);
-      break;
     case HAL_Trigger_kFallingPulse:
-      result = trigger->trigger->readOutput_Falling(trigger->index, status);
+      *status = ANALOG_TRIGGER_PULSE_OUTPUT_ERROR;
+      return false;
       break;
   }
   return result;


### PR DESCRIPTION
They can't be caught from user code