### PR TITLE
Old C++ Command: Make GetName et al public

### DIFF
--- a/wpilibOldCommands/src/main/native/include/frc/commands/Command.h
+++ b/wpilibOldCommands/src/main/native/include/frc/commands/Command.h
@@ -388,6 +388,7 @@ class Command : public ErrorBase,
 
   friend class ConditionalCommand;
 
+ public:
   /**
    * Gets the name of this Command.
    *


### PR DESCRIPTION
These used to be effectively public due to SendableBase, and are public
in the Java version.