### PR TITLE
Standardize documentation of Speed Controllers bounds.

### DIFF
--- a/wpilibc/src/main/native/cpp/DMC60.cpp
+++ b/wpilibc/src/main/native/cpp/DMC60.cpp
@@ -14,20 +14,6 @@
 using namespace frc;
 
 DMC60::DMC60(int channel) : PWMSpeedController(channel) {
-  /*
-   * Note that the DMC 60 uses the following bounds for PWM values. These
-   * values should work reasonably well for most controllers, but if users
-   * experience issues such as asymmetric behavior around the deadband or
-   * inability to saturate the controller in either direction, calibration is
-   * recommended. The calibration procedure can be found in the DMC 60 User
-   * Manual available from Digilent.
-   *
-   *   2.004ms = full "forward"
-   *   1.52ms = the "high end" of the deadband range
-   *   1.50ms = center of the deadband range (off)
-   *   1.48ms = the "low end" of the deadband range
-   *   0.997ms = full "reverse"
-   */
   SetBounds(2.004, 1.52, 1.50, 1.48, .997);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);

--- a/wpilibc/src/main/native/cpp/Jaguar.cpp
+++ b/wpilibc/src/main/native/cpp/Jaguar.cpp
@@ -14,14 +14,6 @@
 using namespace frc;
 
 Jaguar::Jaguar(int channel) : PWMSpeedController(channel) {
-  /* Input profile defined by Luminary Micro.
-   *
-   * Full reverse ranges from 0.671325ms to 0.6972211ms
-   * Proportional reverse ranges from 0.6972211ms to 1.4482078ms
-   * Neutral ranges from 1.4482078ms to 1.5517922ms
-   * Proportional forward ranges from 1.5517922ms to 2.3027789ms
-   * Full forward ranges from 2.3027789ms to 2.328675ms
-   */
   SetBounds(2.31, 1.55, 1.507, 1.454, .697);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);

--- a/wpilibc/src/main/native/cpp/PWMSparkMax.cpp
+++ b/wpilibc/src/main/native/cpp/PWMSparkMax.cpp
@@ -14,14 +14,6 @@
 using namespace frc;
 
 PWMSparkMax::PWMSparkMax(int channel) : PWMSpeedController(channel) {
-  /* Note that the SparkMax uses the following bounds for PWM values.
-   *
-   *   2.003ms = full "forward"
-   *   1.55ms = the "high end" of the deadband range
-   *   1.50ms = center of the deadband range (off)
-   *   1.46ms = the "low end" of the deadband range
-   *   0.999ms = full "reverse"
-   */
   SetBounds(2.003, 1.55, 1.50, 1.46, .999);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);

--- a/wpilibc/src/main/native/cpp/PWMTalonSRX.cpp
+++ b/wpilibc/src/main/native/cpp/PWMTalonSRX.cpp
@@ -14,18 +14,6 @@
 using namespace frc;
 
 PWMTalonSRX::PWMTalonSRX(int channel) : PWMSpeedController(channel) {
-  /* Note that the PWMTalonSRX uses the following bounds for PWM values. These
-   * values should work reasonably well for most controllers, but if users
-   * experience issues such as asymmetric behavior around the deadband or
-   * inability to saturate the controller in either direction, calibration is
-   * recommended. The calibration procedure can be found in the TalonSRX User
-   * Manual available from Cross The Road Electronics.
-   *   2.004ms = full "forward"
-   *   1.52ms = the "high end" of the deadband range
-   *   1.50ms = center of the deadband range (off)
-   *   1.48ms = the "low end" of the deadband range
-   *   0.997ms = full "reverse"
-   */
   SetBounds(2.004, 1.52, 1.50, 1.48, .997);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);

--- a/wpilibc/src/main/native/cpp/PWMVictorSPX.cpp
+++ b/wpilibc/src/main/native/cpp/PWMVictorSPX.cpp
@@ -14,18 +14,6 @@
 using namespace frc;
 
 PWMVictorSPX::PWMVictorSPX(int channel) : PWMSpeedController(channel) {
-  /* Note that the PWMVictorSPX uses the following bounds for PWM values. These
-   * values should work reasonably well for most controllers, but if users
-   * experience issues such as asymmetric behavior around the deadband or
-   * inability to saturate the controller in either direction, calibration is
-   * recommended. The calibration procedure can be found in the VictorSPX User
-   * Manual available from Cross The Road Electronics.
-   *   2.004ms = full "forward"
-   *   1.52ms = the "high end" of the deadband range
-   *   1.50ms = center of the deadband range (off)
-   *   1.48ms = the "low end" of the deadband range
-   *   0.997ms = full "reverse"
-   */
   SetBounds(2.004, 1.52, 1.50, 1.48, .997);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);

--- a/wpilibc/src/main/native/cpp/SD540.cpp
+++ b/wpilibc/src/main/native/cpp/SD540.cpp
@@ -14,19 +14,6 @@
 using namespace frc;
 
 SD540::SD540(int channel) : PWMSpeedController(channel) {
-  /* Note that the SD540 uses the following bounds for PWM values. These values
-   * should work reasonably well for most controllers, but if users experience
-   * issues such as asymmetric behavior around the deadband or inability to
-   * saturate the controller in either direction, calibration is recommended.
-   * The calibration procedure can be found in the SD540 User Manual available
-   * from Mindsensors.
-   *
-   *   2.05ms = full "forward"
-   *   1.55ms = the "high end" of the deadband range
-   *   1.50ms = center of the deadband range (off)
-   *   1.44ms = the "low end" of the deadband range
-   *   0.94ms = full "reverse"
-   */
   SetBounds(2.05, 1.55, 1.50, 1.44, .94);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);

--- a/wpilibc/src/main/native/cpp/Spark.cpp
+++ b/wpilibc/src/main/native/cpp/Spark.cpp
@@ -14,19 +14,6 @@
 using namespace frc;
 
 Spark::Spark(int channel) : PWMSpeedController(channel) {
-  /* Note that the Spark uses the following bounds for PWM values. These values
-   * should work reasonably well for most controllers, but if users experience
-   * issues such as asymmetric behavior around the deadband or inability to
-   * saturate the controller in either direction, calibration is recommended.
-   * The calibration procedure can be found in the Spark User Manual available
-   * from REV Robotics.
-   *
-   *   2.003ms = full "forward"
-   *   1.55ms = the "high end" of the deadband range
-   *   1.50ms = center of the deadband range (off)
-   *   1.46ms = the "low end" of the deadband range
-   *   0.999ms = full "reverse"
-   */
   SetBounds(2.003, 1.55, 1.50, 1.46, .999);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);

--- a/wpilibc/src/main/native/cpp/Talon.cpp
+++ b/wpilibc/src/main/native/cpp/Talon.cpp
@@ -14,19 +14,6 @@
 using namespace frc;
 
 Talon::Talon(int channel) : PWMSpeedController(channel) {
-  /* Note that the Talon uses the following bounds for PWM values. These values
-   * should work reasonably well for most controllers, but if users experience
-   * issues such as asymmetric behavior around the deadband or inability to
-   * saturate the controller in either direction, calibration is recommended.
-   * The calibration procedure can be found in the Talon User Manual available
-   * from CTRE.
-   *
-   *   2.037ms = full "forward"
-   *   1.539ms = the "high end" of the deadband range
-   *   1.513ms = center of the deadband range (off)
-   *   1.487ms = the "low end" of the deadband range
-   *   0.989ms = full "reverse"
-   */
   SetBounds(2.037, 1.539, 1.513, 1.487, .989);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);

--- a/wpilibc/src/main/native/cpp/Victor.cpp
+++ b/wpilibc/src/main/native/cpp/Victor.cpp
@@ -14,20 +14,6 @@
 using namespace frc;
 
 Victor::Victor(int channel) : PWMSpeedController(channel) {
-  /* Note that the Victor uses the following bounds for PWM values.  These
-   * values were determined empirically and optimized for the Victor 888. These
-   * values should work reasonably well for Victor 884 controllers as well but
-   * if users experience issues such as asymmetric behaviour around the deadband
-   * or inability to saturate the controller in either direction, calibration is
-   * recommended. The calibration procedure can be found in the Victor 884 User
-   * Manual available from IFI.
-   *
-   *   2.027ms = full "forward"
-   *   1.525ms = the "high end" of the deadband range
-   *   1.507ms = center of the deadband range (off)
-   *   1.49ms = the "low end" of the deadband range
-   *   1.026ms = full "reverse"
-   */
   SetBounds(2.027, 1.525, 1.507, 1.49, 1.026);
   SetPeriodMultiplier(kPeriodMultiplier_2X);
   SetSpeed(0.0);

--- a/wpilibc/src/main/native/cpp/VictorSP.cpp
+++ b/wpilibc/src/main/native/cpp/VictorSP.cpp
@@ -14,19 +14,6 @@
 using namespace frc;
 
 VictorSP::VictorSP(int channel) : PWMSpeedController(channel) {
-  /* Note that the VictorSP uses the following bounds for PWM values. These
-   * values should work reasonably well for most controllers, but if users
-   * experience issues such as asymmetric behavior around the deadband or
-   * inability to saturate the controller in either direction, calibration is
-   * recommended. The calibration procedure can be found in the VictorSP User
-   * Manual available from Vex.
-   *
-   *   2.004ms = full "forward"
-   *   1.52ms = the "high end" of the deadband range
-   *   1.50ms = center of the deadband range (off)
-   *   1.48ms = the "low end" of the deadband range
-   *   0.997ms = full "reverse"
-   */
   SetBounds(2.004, 1.52, 1.50, 1.48, .997);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);

--- a/wpilibc/src/main/native/include/frc/DMC60.h
+++ b/wpilibc/src/main/native/include/frc/DMC60.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/include/frc/DMC60.h
+++ b/wpilibc/src/main/native/include/frc/DMC60.h
@@ -22,9 +22,9 @@ namespace frc {
  * Manual available from Digilent.
  *
  * \li 2.004ms = full "forward"
- * \li 1.52ms = the "high end" of the deadband range
- * \li 1.50ms = center of the deadband range (off)
- * \li 1.48ms = the "low end" of the deadband range
+ * \li 1.520ms = the "high end" of the deadband range
+ * \li 1.500ms = center of the deadband range (off)
+ * \li 1.480ms = the "low end" of the deadband range
  * \li 0.997ms = full "reverse"
  */
 class DMC60 : public PWMSpeedController {

--- a/wpilibc/src/main/native/include/frc/DMC60.h
+++ b/wpilibc/src/main/native/include/frc/DMC60.h
@@ -13,6 +13,19 @@ namespace frc {
 
 /**
  * Digilent DMC 60 Speed Controller.
+ *
+ * Note that the DMC 60 uses the following bounds for PWM values. These
+ * values should work reasonably well for most controllers, but if users
+ * experience issues such as asymmetric behavior around the deadband or
+ * inability to saturate the controller in either direction, calibration is
+ * recommended. The calibration procedure can be found in the DMC 60 User
+ * Manual available from Digilent.
+ *
+ * \li 2.004ms = full "forward"
+ * \li 1.52ms = the "high end" of the deadband range
+ * \li 1.50ms = center of the deadband range (off)
+ * \li 1.48ms = the "low end" of the deadband range
+ * \li 0.997ms = full "reverse"
  */
 class DMC60 : public PWMSpeedController {
  public:

--- a/wpilibc/src/main/native/include/frc/Jaguar.h
+++ b/wpilibc/src/main/native/include/frc/Jaguar.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/include/frc/Jaguar.h
+++ b/wpilibc/src/main/native/include/frc/Jaguar.h
@@ -21,10 +21,10 @@ namespace frc {
  * calibration procedure can be found in the Jaguar User Manual available from
  * Vex.
  *
- * \li 2.31ms = full "forward"
- * \li 1.55ms = the "high end" of the deadband range
+ * \li 2.310ms = full "forward"
+ * \li 1.550ms = the "high end" of the deadband range
  * \li 1.507ms = center of the deadband range (off)
- * \li 1.454s = the "low end" of the deadband range
+ * \li 1.454ms = the "low end" of the deadband range
  * \li 0.697ms = full "reverse"
  */
 class Jaguar : public PWMSpeedController {

--- a/wpilibc/src/main/native/include/frc/Jaguar.h
+++ b/wpilibc/src/main/native/include/frc/Jaguar.h
@@ -13,6 +13,19 @@ namespace frc {
 
 /**
  * Luminary Micro / Vex Robotics Jaguar Speed Controller with PWM control.
+ *
+ * Note that the Jaguar uses the following bounds for PWM values. These values
+ * should work reasonably well for most controllers, but if users experience
+ * issues such as asymmetric behavior around the deadband or inability to
+ * saturate the controller in either direction, calibration is recommended. The
+ * calibration procedure can be found in the Jaguar User Manual available from
+ * Vex.
+ *
+ * \li 2.31ms = full "forward"
+ * \li 1.55ms = the "high end" of the deadband range
+ * \li 1.507ms = center of the deadband range (off)
+ * \li 1.454s = the "low end" of the deadband range
+ * \li 0.697ms = full "reverse"
  */
 class Jaguar : public PWMSpeedController {
  public:

--- a/wpilibc/src/main/native/include/frc/PWMSparkMax.h
+++ b/wpilibc/src/main/native/include/frc/PWMSparkMax.h
@@ -22,9 +22,9 @@ namespace frc {
  * Manual available from REV Robotics.
  *
  * \li 2.003ms = full "forward"
- * \li 1.55ms = the "high end" of the deadband range
- * \li 1.50ms = center of the deadband range (off)
- * \li 1.46ms = the "low end" of the deadband range
+ * \li 1.550ms = the "high end" of the deadband range
+ * \li 1.500ms = center of the deadband range (off)
+ * \li 1.460ms = the "low end" of the deadband range
  * \li 0.999ms = full "reverse"
  */
 class PWMSparkMax : public PWMSpeedController {

--- a/wpilibc/src/main/native/include/frc/PWMSparkMax.h
+++ b/wpilibc/src/main/native/include/frc/PWMSparkMax.h
@@ -13,6 +13,19 @@ namespace frc {
 
 /**
  * REV Robotics SparkMax Speed Controller.
+ *
+ * Note that the SPARK Max uses the following bounds for PWM values. These
+ * values should work reasonably well for most controllers, but if users
+ * experience issues such as asymmetric behavior around the deadband or
+ * inability to saturate the controller in either direction, calibration is
+ * recommended. The calibration procedure can be found in the Spark Max User
+ * Manual available from REV Robotics.
+ *
+ * \li 2.003ms = full "forward"
+ * \li 1.55ms = the "high end" of the deadband range
+ * \li 1.50ms = center of the deadband range (off)
+ * \li 1.46ms = the "low end" of the deadband range
+ * \li 0.999ms = full "reverse"
  */
 class PWMSparkMax : public PWMSpeedController {
  public:

--- a/wpilibc/src/main/native/include/frc/PWMSparkMax.h
+++ b/wpilibc/src/main/native/include/frc/PWMSparkMax.h
@@ -12,13 +12,13 @@
 namespace frc {
 
 /**
- * REV Robotics SparkMax Speed Controller.
+ * REV Robotics SPARK MAX Speed Controller.
  *
- * Note that the SPARK Max uses the following bounds for PWM values. These
+ * Note that the SPARK MAX uses the following bounds for PWM values. These
  * values should work reasonably well for most controllers, but if users
  * experience issues such as asymmetric behavior around the deadband or
  * inability to saturate the controller in either direction, calibration is
- * recommended. The calibration procedure can be found in the Spark Max User
+ * recommended. The calibration procedure can be found in the SPARK MAX User
  * Manual available from REV Robotics.
  *
  * \li 2.003ms = full "forward"
@@ -30,9 +30,9 @@ namespace frc {
 class PWMSparkMax : public PWMSpeedController {
  public:
   /**
-   * Constructor for a SparkMax.
+   * Constructor for a SPARK MAX.
    *
-   * @param channel The PWM channel that the Spark is attached to. 0-9 are
+   * @param channel The PWM channel that the SPARK MAX is attached to. 0-9 are
    *                on-board, 10-19 are on the MXP port
    */
   explicit PWMSparkMax(int channel);

--- a/wpilibc/src/main/native/include/frc/PWMTalonSRX.h
+++ b/wpilibc/src/main/native/include/frc/PWMTalonSRX.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/include/frc/PWMTalonSRX.h
+++ b/wpilibc/src/main/native/include/frc/PWMTalonSRX.h
@@ -14,13 +14,26 @@ namespace frc {
 /**
  * Cross the Road Electronics (CTRE) Talon SRX Speed Controller with PWM
  * control.
+ *
+ * Note that the Talon SRX uses the following bounds for PWM values. These
+ * values should work reasonably well for most controllers, but if users
+ * experience issues such as asymmetric behavior around the deadband or
+ * inability to saturate the controller in either direction, calibration is
+ * recommended. The calibration procedure can be found in the Talon SRX User
+ * Manual available from Cross The Road Electronics.
+ *
+ * \li 2.004ms = full "forward"
+ * \li 1.520ms = the "high end" of the deadband range
+ * \li 1.500ms = center of the deadband range (off)
+ * \li 1.480ms = the "low end" of the deadband range
+ * \li 0.997ms = full "reverse"
  */
 class PWMTalonSRX : public PWMSpeedController {
  public:
   /**
-   * Construct a PWMTalonSRX connected via PWM.
+   * Construct a Talon SRX connected via PWM.
    *
-   * @param channel The PWM channel that the PWMTalonSRX is attached to. 0-9 are
+   * @param channel The PWM channel that the Talon SRX is attached to. 0-9 are
    *                on-board, 10-19 are on the MXP port
    */
   explicit PWMTalonSRX(int channel);

--- a/wpilibc/src/main/native/include/frc/PWMVictorSPX.h
+++ b/wpilibc/src/main/native/include/frc/PWMVictorSPX.h
@@ -21,6 +21,7 @@ namespace frc {
  * inability to saturate the controller in either direction, calibration is
  * recommended. The calibration procedure can be found in the Victor SPX User
  * Manual available from Cross The Road Electronics.
+ *
  * \li 2.004ms = full "forward"
  * \li 1.520ms = the "high end" of the deadband range
  * \li 1.500ms = center of the deadband range (off)

--- a/wpilibc/src/main/native/include/frc/PWMVictorSPX.h
+++ b/wpilibc/src/main/native/include/frc/PWMVictorSPX.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -14,13 +14,25 @@ namespace frc {
 /**
  * Cross the Road Electronics (CTRE) Victor SPX Speed Controller with PWM
  * control.
+ *
+ * Note that the Victor SPX uses the following bounds for PWM values. These
+ * values should work reasonably well for most controllers, but if users
+ * experience issues such as asymmetric behavior around the deadband or
+ * inability to saturate the controller in either direction, calibration is
+ * recommended. The calibration procedure can be found in the Victor SPX User
+ * Manual available from Cross The Road Electronics.
+ * \li 2.004ms = full "forward"
+ * \li 1.520ms = the "high end" of the deadband range
+ * \li 1.500ms = center of the deadband range (off)
+ * \li 1.480ms = the "low end" of the deadband range
+ * \li 0.997ms = full "reverse"
  */
 class PWMVictorSPX : public PWMSpeedController {
  public:
   /**
-   * Construct a PWMVictorSPX connected via PWM.
+   * Construct a Victor SPX connected via PWM.
    *
-   * @param channel The PWM channel that the PWMVictorSPX is attached to. 0-9
+   * @param channel The PWM channel that the Victor SPX is attached to. 0-9
    *                are on-board, 10-19 are on the MXP port
    */
   explicit PWMVictorSPX(int channel);

--- a/wpilibc/src/main/native/include/frc/SD540.h
+++ b/wpilibc/src/main/native/include/frc/SD540.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -13,6 +13,19 @@ namespace frc {
 
 /**
  * Mindsensors SD540 Speed Controller.
+ *
+ * Note that the SD540 uses the following bounds for PWM values. These values
+ * should work reasonably well for most controllers, but if users experience
+ * issues such as asymmetric behavior around the deadband or inability to
+ * saturate the controller in either direction, calibration is recommended.
+ * The calibration procedure can be found in the SD540 User Manual available
+ * from Mindsensors.
+ *
+ * \li 2.05ms = full "forward"
+ * \li 1.55ms = the "high end" of the deadband range
+ * \li 1.50ms = center of the deadband range (off)
+ * \li 1.44ms = the "low end" of the deadband range
+ * \li 0.94ms = full "reverse"
  */
 class SD540 : public PWMSpeedController {
  public:

--- a/wpilibc/src/main/native/include/frc/Spark.h
+++ b/wpilibc/src/main/native/include/frc/Spark.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -12,7 +12,20 @@
 namespace frc {
 
 /**
- * REV Robotics Speed Controller.
+ * REV Robotics Spark Speed Controller.
+ *
+ * Note that the Spark uses the following bounds for PWM values. These values
+ * should work reasonably well for most controllers, but if users experience
+ * issues such as asymmetric behavior around the deadband or inability to
+ * saturate the controller in either direction, calibration is recommended.
+ * The calibration procedure can be found in the Spark User Manual available
+ * from REV Robotics.
+ *
+ * \li 2.003ms = full "forward"
+ * \li 1.550ms = the "high end" of the deadband range
+ * \li 1.500ms = center of the deadband range (off)
+ * \li 1.460ms = the "low end" of the deadband range
+ * \li 0.999ms = full "reverse"
  */
 class Spark : public PWMSpeedController {
  public:

--- a/wpilibc/src/main/native/include/frc/Spark.h
+++ b/wpilibc/src/main/native/include/frc/Spark.h
@@ -12,13 +12,13 @@
 namespace frc {
 
 /**
- * REV Robotics Spark Speed Controller.
+ * REV Robotics SPARK Speed Controller.
  *
- * Note that the Spark uses the following bounds for PWM values. These values
+ * Note that the SPARK uses the following bounds for PWM values. These values
  * should work reasonably well for most controllers, but if users experience
  * issues such as asymmetric behavior around the deadband or inability to
  * saturate the controller in either direction, calibration is recommended.
- * The calibration procedure can be found in the Spark User Manual available
+ * The calibration procedure can be found in the SPARK User Manual available
  * from REV Robotics.
  *
  * \li 2.003ms = full "forward"
@@ -30,9 +30,9 @@ namespace frc {
 class Spark : public PWMSpeedController {
  public:
   /**
-   * Constructor for a Spark.
+   * Constructor for a SPARK.
    *
-   * @param channel The PWM channel that the Spark is attached to. 0-9 are
+   * @param channel The PWM channel that the SPARK is attached to. 0-9 are
    *                on-board, 10-19 are on the MXP port
    */
   explicit Spark(int channel);

--- a/wpilibc/src/main/native/include/frc/Talon.h
+++ b/wpilibc/src/main/native/include/frc/Talon.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -13,6 +13,19 @@ namespace frc {
 
 /**
  * Cross the Road Electronics (CTRE) Talon and Talon SR Speed Controller.
+ *
+ * Note that the Talon uses the following bounds for PWM values. These values
+ * should work reasonably well for most controllers, but if users experience
+ * issues such as asymmetric behavior around the deadband or inability to
+ * saturate the controller in either direction, calibration is recommended.
+ * The calibration procedure can be found in the Talon User Manual available
+ * from CTRE.
+ *
+ * \li 2.037ms = full "forward"
+ * \li 1.539ms = the "high end" of the deadband range
+ * \li 1.513ms = center of the deadband range (off)
+ * \li 1.487ms = the "low end" of the deadband range
+ * \li 0.989ms = full "reverse"
  */
 class Talon : public PWMSpeedController {
  public:

--- a/wpilibc/src/main/native/include/frc/Victor.h
+++ b/wpilibc/src/main/native/include/frc/Victor.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/include/frc/Victor.h
+++ b/wpilibc/src/main/native/include/frc/Victor.h
@@ -23,7 +23,7 @@ namespace frc {
  * if users experience issues such as asymmetric behavior around the deadband
  * or inability to saturate the controller in either direction, calibration is
  * recommended. The calibration procedure can be found in the Victor 884 User
- * Manual available from IFI.
+ * Manual available from Vex.
  *
  * \li 2.027ms = full "forward"
  * \li 1.525ms = the "high end" of the deadband range

--- a/wpilibc/src/main/native/include/frc/Victor.h
+++ b/wpilibc/src/main/native/include/frc/Victor.h
@@ -16,6 +16,20 @@ namespace frc {
  *
  * The Vex Robotics Victor 884 Speed Controller can also be used with this
  * class but may need to be calibrated per the Victor 884 user manual.
+ *
+ * Note that the Victor uses the following bounds for PWM values.  These
+ * values were determined empirically and optimized for the Victor 888. These
+ * values should work reasonably well for Victor 884 controllers as well but
+ * if users experience issues such as asymmetric behavior around the deadband
+ * or inability to saturate the controller in either direction, calibration is
+ * recommended. The calibration procedure can be found in the Victor 884 User
+ * Manual available from IFI.
+ *
+ * \li 2.027ms = full "forward"
+ * \li 1.525ms = the "high end" of the deadband range
+ * \li 1.507ms = center of the deadband range (off)
+ * \li 1.490ms = the "low end" of the deadband range
+ * \li 1.026ms = full "reverse"
  */
 class Victor : public PWMSpeedController {
  public:

--- a/wpilibc/src/main/native/include/frc/VictorSP.h
+++ b/wpilibc/src/main/native/include/frc/VictorSP.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -13,11 +13,24 @@ namespace frc {
 
 /**
  * Vex Robotics Victor SP Speed Controller.
+ *
+ * Note that the VictorSP uses the following bounds for PWM values. These
+ * values should work reasonably well for most controllers, but if users
+ * experience issues such as asymmetric behavior around the deadband or
+ * inability to saturate the controller in either direction, calibration is
+ * recommended. The calibration procedure can be found in the VictorSP User
+ * Manual available from Vex.
+ *
+ * \li 2.004ms = full "forward"
+ * \li 1.520ms = the "high end" of the deadband range
+ * \li 1.500ms = center of the deadband range (off)
+ * \li 1.480ms = the "low end" of the deadband range
+ * \li 0.997ms = full "reverse"
  */
 class VictorSP : public PWMSpeedController {
  public:
   /**
-   * Constructor for a VictorSP.
+   * Constructor for a Victor SP.
    *
    * @param channel The PWM channel that the VictorSP is attached to. 0-9 are
    *                on-board, 10-19 are on the MXP port

--- a/wpilibc/src/main/native/include/frc/VictorSP.h
+++ b/wpilibc/src/main/native/include/frc/VictorSP.h
@@ -14,11 +14,11 @@ namespace frc {
 /**
  * Vex Robotics Victor SP Speed Controller.
  *
- * Note that the VictorSP uses the following bounds for PWM values. These
+ * Note that the Victor SP uses the following bounds for PWM values. These
  * values should work reasonably well for most controllers, but if users
  * experience issues such as asymmetric behavior around the deadband or
  * inability to saturate the controller in either direction, calibration is
- * recommended. The calibration procedure can be found in the VictorSP User
+ * recommended. The calibration procedure can be found in the Victor SP User
  * Manual available from Vex.
  *
  * \li 2.004ms = full "forward"

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DMC60.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DMC60.java
@@ -19,10 +19,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the DMC 60 User Manual
  * available from Digilent
- *
- * <p>- 2.004ms = full "forward" - 1.52ms = the "high end" of the deadband range - 1.50ms =
- * center of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms =
- * full "reverse"
+ * <p><ul>
+ * <li>2.004ms = full "forward"
+ * <li>1.520ms = the "high end" of the deadband range
+ * <li>1.500ms = center of the deadband range (off)
+ * <li>1.480ms = the "low end" of the deadband range
+ * <li>0.997ms = full "reverse"
+ * </ul>
  */
 public class DMC60 extends PWMSpeedController {
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DMC60.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DMC60.java
@@ -18,7 +18,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * reasonably well for most controllers, but if users experience issues such as asymmetric
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the DMC 60 User Manual
- * available from Digilent
+ * available from Digilent.
  *
  * <p><ul>
  * <li>2.004ms = full "forward"

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DMC60.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DMC60.java
@@ -13,20 +13,20 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Digilent DMC 60 Speed Controller.
+ *
+ * <p>Note that the DMC uses the following bounds for PWM values. These values should work
+ * reasonably well for most controllers, but if users experience issues such as asymmetric
+ * behavior around the deadband or inability to saturate the controller in either direction,
+ * calibration is recommended. The calibration procedure can be found in the DMC 60 User Manual
+ * available from Digilent
+ *
+ * <p>- 2.004ms = full "forward" - 1.52ms = the "high end" of the deadband range - 1.50ms =
+ * center of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms =
+ * full "reverse"
  */
 public class DMC60 extends PWMSpeedController {
   /**
    * Constructor.
-   *
-   * <p>Note that the DMC uses the following bounds for PWM values. These values should work
-   * reasonably well for most controllers, but if users experience issues such as asymmetric
-   * behavior around the deadband or inability to saturate the controller in either direction,
-   * calibration is recommended. The calibration procedure can be found in the DMC 60 User Manual
-   * available from Digilent
-   *
-   * <p>- 2.004ms = full "forward" - 1.52ms = the "high end" of the deadband range - 1.50ms =
-   * center of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms =
-   * full "reverse"
    *
    * @param channel The PWM channel that the DMC60 is attached to. 0-9 are
    *        on-board, 10-19 are on the MXP port

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DMC60.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DMC60.java
@@ -19,6 +19,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the DMC 60 User Manual
  * available from Digilent
+ *
  * <p><ul>
  * <li>2.004ms = full "forward"
  * <li>1.520ms = the "high end" of the deadband range

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Jaguar.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Jaguar.java
@@ -13,6 +13,16 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Texas Instruments / Vex Robotics Jaguar Speed Controller as a PWM device.
+ *
+ * <p>Note that the Jaguar uses the following bounds for PWM values. These values should work
+ * reasonably well for most controllers, but if users experience issues such as asymmetric
+ * behavior around the deadband or inability to saturate the controller in either direction,
+ * calibration is recommended. The calibration procedure can be found in the Jaguar User Manual
+ * available from Vex.
+ *
+ * <p>- 2.31ms = full "forward" - 1.55ms = the "high end" of the deadband range - 1.507ms =
+ * center of the deadband range (off) - 1.454ms = the "low end" of the deadband range - 0.697ms =
+ * full "reverse"
  */
 public class Jaguar extends PWMSpeedController {
   /**
@@ -24,14 +34,6 @@ public class Jaguar extends PWMSpeedController {
   public Jaguar(final int channel) {
     super(channel);
 
-    /*
-     * Input profile defined by Luminary Micro.
-     *
-     * Full reverse ranges from 0.671325ms to 0.6972211ms Proportional reverse
-     * ranges from 0.6972211ms to 1.4482078ms Neutral ranges from 1.4482078ms to
-     * 1.5517922ms Proportional forward ranges from 1.5517922ms to 2.3027789ms
-     * Full forward ranges from 2.3027789ms to 2.328675ms
-     */
     setBounds(2.31, 1.55, 1.507, 1.454, .697);
     setPeriodMultiplier(PeriodMultiplier.k1X);
     setSpeed(0.0);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Jaguar.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Jaguar.java
@@ -19,10 +19,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the Jaguar User Manual
  * available from Vex.
- *
- * <p>- 2.31ms = full "forward" - 1.55ms = the "high end" of the deadband range - 1.507ms =
- * center of the deadband range (off) - 1.454ms = the "low end" of the deadband range - 0.697ms =
- * full "reverse"
+ * <p><ul>
+ * <li>2.310ms = full "forward"
+ * <li>1.550ms = the "high end" of the deadband range
+ * <li>1.507ms = center of the deadband range (off)
+ * <li>1.454ms = the "low end" of the deadband range
+ * <li>0.697ms = full "reverse"
+ * </ul>
  */
 public class Jaguar extends PWMSpeedController {
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Jaguar.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Jaguar.java
@@ -19,6 +19,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the Jaguar User Manual
  * available from Vex.
+ *
  * <p><ul>
  * <li>2.310ms = full "forward"
  * <li>1.550ms = the "high end" of the deadband range

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
@@ -13,20 +13,21 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * REV Robotics SparkMax Speed Controller.
+ *
+ * <p>Note that the SPARK uses the following bounds for PWM values. These values should work
+ * reasonably well for most controllers, but if users experience issues such as asymmetric
+ * behavior around the deadband or inability to saturate the controller in either direction,
+ * calibration is recommended. The calibration procedure can be found in the Spark User Manual
+ * available from REV Robotics.
+ *
+ * <p>- 2.003ms = full "forward" - 1.55ms = the "high end" of the deadband range - 1.50ms =
+ * center of the deadband range (off) - 1.46ms = the "low end" of the deadband range - .999ms =
+ * full "reverse"
  */
 public class PWMSparkMax extends PWMSpeedController {
   /**
    * Common initialization code called by all constructors.
    *
-   * <p>Note that the SPARK uses the following bounds for PWM values. These values should work
-   * reasonably well for most controllers, but if users experience issues such as asymmetric
-   * behavior around the deadband or inability to saturate the controller in either direction,
-   * calibration is recommended. The calibration procedure can be found in the Spark User Manual
-   * available from REV Robotics.
-   *
-   * <p>- 2.003ms = full "forward" - 1.55ms = the "high end" of the deadband range - 1.50ms =
-   * center of the deadband range (off) - 1.46ms = the "low end" of the deadband range - .999ms =
-   * full "reverse"
    */
   public PWMSparkMax(final int channel) {
     super(channel);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
@@ -19,6 +19,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the Spark Max User Manual
  * available from REV Robotics.
+ *
  * <p><ul>
  * <li> 2.003ms = full "forward"
  * <li> 1.550ms = the "high end" of the deadband range

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
@@ -14,17 +14,17 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 /**
  * REV Robotics SparkMax Speed Controller.
  *
- * Note that the SPARK Max uses the following bounds for PWM values. These values should work
+ * <P>Note that the SPARK Max uses the following bounds for PWM values. These values should work
  * reasonably well for most controllers, but if users experience issues such as asymmetric
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the Spark Max User Manual
  * available from REV Robotics.
  * <p><ul>
  * <li> 2.003ms = full "forward"
- * <li> 1.55ms = the "high end" of the deadband range
- * <li> 1.50ms = center of the deadband range (off)
- * <li> 1.46ms = the "low end" of the deadband range
- * <li> .999ms = full "reverse"
+ * <li> 1.550ms = the "high end" of the deadband range
+ * <li> 1.500ms = center of the deadband range (off)
+ * <li> 1.460ms = the "low end" of the deadband range
+ * <li> 0.999ms = full "reverse"
  * </ul>
  */
 public class PWMSparkMax extends PWMSpeedController {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
@@ -14,15 +14,18 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 /**
  * REV Robotics SparkMax Speed Controller.
  *
- * <p>Note that the SPARK uses the following bounds for PWM values. These values should work
+ * Note that the SPARK Max uses the following bounds for PWM values. These values should work
  * reasonably well for most controllers, but if users experience issues such as asymmetric
  * behavior around the deadband or inability to saturate the controller in either direction,
- * calibration is recommended. The calibration procedure can be found in the Spark User Manual
+ * calibration is recommended. The calibration procedure can be found in the Spark Max User Manual
  * available from REV Robotics.
- *
- * <p>- 2.003ms = full "forward" - 1.55ms = the "high end" of the deadband range - 1.50ms =
- * center of the deadband range (off) - 1.46ms = the "low end" of the deadband range - .999ms =
- * full "reverse"
+ * <p><ul>
+ * <li> 2.003ms = full "forward"
+ * <li> 1.55ms = the "high end" of the deadband range
+ * <li> 1.50ms = center of the deadband range (off)
+ * <li> 1.46ms = the "low end" of the deadband range
+ * <li> .999ms = full "reverse"
+ * </ul>
  */
 public class PWMSparkMax extends PWMSpeedController {
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
@@ -12,12 +12,12 @@ import edu.wpi.first.hal.HAL;
 import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
- * REV Robotics SparkMax Speed Controller.
+ * REV Robotics SPARK MAX Speed Controller with PWM control.
  *
- * <P>Note that the SPARK Max uses the following bounds for PWM values. These values should work
+ * <P>Note that the SPARK MAX uses the following bounds for PWM values. These values should work
  * reasonably well for most controllers, but if users experience issues such as asymmetric
  * behavior around the deadband or inability to saturate the controller in either direction,
- * calibration is recommended. The calibration procedure can be found in the Spark Max User Manual
+ * calibration is recommended. The calibration procedure can be found in the SPARK MAX User Manual
  * available from REV Robotics.
  *
  * <p><ul>

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonSRX.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonSRX.java
@@ -19,10 +19,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the TalonSRX User Manual
  * available from CTRE.
- *
- * <p>- 2.004ms = full "forward" - 1.52ms = the "high end" of the deadband range - 1.50ms =
- * center of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms =
- * full "reverse"
+ * <p><ul>
+ * <li>2.004ms = full "forward"
+ * <li>1.520ms = the "high end" of the deadband range
+ * <li>1.500ms = center of the deadband range (off)
+ * <li>1.480ms = the "low end" of the deadband range
+ * <li>0.997ms = full "reverse"
+ * </ul>
  */
 public class PWMTalonSRX extends PWMSpeedController {
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonSRX.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonSRX.java
@@ -19,6 +19,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the TalonSRX User Manual
  * available from CTRE.
+ *
  * <p><ul>
  * <li>2.004ms = full "forward"
  * <li>1.520ms = the "high end" of the deadband range

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonSRX.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonSRX.java
@@ -21,7 +21,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * available from CTRE.
  *
  * <p>- 2.004ms = full "forward" - 1.52ms = the "high end" of the deadband range - 1.50ms =
- * center of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms = 
+ * center of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms =
  * full "reverse"
  */
 public class PWMTalonSRX extends PWMSpeedController {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonSRX.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonSRX.java
@@ -13,23 +13,22 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Cross the Road Electronics (CTRE) Talon SRX Speed Controller with PWM control.
+ *
+ * <p>Note that the TalonSRX uses the following bounds for PWM values. These values should work
+ * reasonably well for most controllers, but if users experience issues such as asymmetric
+ * behavior around the deadband or inability to saturate the controller in either direction,
+ * calibration is recommended. The calibration procedure can be found in the TalonSRX User Manual
+ * available from CTRE.
+ *
+ * <p>- 2.004ms = full "forward" - 1.52ms = the "high end" of the deadband range - 1.50ms =
+ * center of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms = 
+ * full "reverse"
  */
 public class PWMTalonSRX extends PWMSpeedController {
   /**
-   * Constructor for a PWMTalonSRX connected via PWM.
+   * Constructor for a TalonSRX connected via PWM.
    *
-   * <p>Note that the PWMTalonSRX uses the following bounds for PWM values. These values should work
-   * reasonably well for most controllers, but if users experience issues such as asymmetric
-   * behavior around the deadband or inability to saturate the controller in either direction,
-   * calibration is recommended. The calibration procedure can be found in the TalonSRX User Manual
-   * available from CTRE.
-   *
-   * <p>- 2.0004ms = full "forward" - 1.52ms = the "high end" of the deadband range - 1.50ms =
-   * center
-   * of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms = full
-   * "reverse"
-   *
-   * @param channel The PWM channel that the PWMTalonSRX is attached to. 0-9 are on-board, 10-19 are
+   * @param channel The PWM channel that the Talon SRX is attached to. 0-9 are on-board, 10-19 are
    *                on the MXP port
    */
   public PWMTalonSRX(final int channel) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMVictorSPX.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMVictorSPX.java
@@ -19,10 +19,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the Victor SPX User
  * Manual available from CTRE.
- *
- * <p>- 2.004ms = full "forward" - 1.52ms = the "high end" of the deadband range - 1.50ms =
- * center of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms =
- * full "reverse"
+ * <p><ul>
+ * <li>2.004ms = full "forward"
+ * <li>1.520ms = the "high end" of the deadband range
+ * <li>1.500ms = center of the deadband range (off)
+ * <li>1.480ms = the "low end" of the deadband range
+ * <li>0.997ms = full "reverse"
+ * </ul>
  */
 public class PWMVictorSPX extends PWMSpeedController {
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMVictorSPX.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMVictorSPX.java
@@ -13,21 +13,20 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Cross the Road Electronics (CTRE) Victor SPX Speed Controller with PWM control.
+ *
+ * <p>Note that the Victor SPX uses the following bounds for PWM values. These values should
+ * work reasonably well for most controllers, but if users experience issues such as asymmetric
+ * behavior around the deadband or inability to saturate the controller in either direction,
+ * calibration is recommended. The calibration procedure can be found in the Victor SPX User
+ * Manual available from CTRE.
+ *
+ * <p>- 2.004ms = full "forward" - 1.52ms = the "high end" of the deadband range - 1.50ms =
+ * center of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms =
+ * full "reverse"
  */
 public class PWMVictorSPX extends PWMSpeedController {
   /**
-   * Constructor for a PWMVictorSPX connected via PWM.
-   *
-   * <p>Note that the PWMVictorSPX uses the following bounds for PWM values. These values should
-   *  work reasonably well for most controllers, but if users experience issues such as asymmetric
-   * behavior around the deadband or inability to saturate the controller in either direction,
-   * calibration is recommended. The calibration procedure can be found in the VictorSPX User
-   * Manual available from CTRE.
-   *
-   * <p>- 2.0004ms = full "forward" - 1.52ms = the "high end" of the deadband range - 1.50ms =
-   * center
-   * of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms = full
-   * "reverse"
+   * Constructor for a Victor SPX connected via PWM.
    *
    * @param channel The PWM channel that the PWMVictorSPX is attached to. 0-9 are on-board, 10-19
    *                are on the MXP port

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMVictorSPX.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMVictorSPX.java
@@ -19,6 +19,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the Victor SPX User
  * Manual available from CTRE.
+ *
  * <p><ul>
  * <li>2.004ms = full "forward"
  * <li>1.520ms = the "high end" of the deadband range

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SD540.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SD540.java
@@ -13,20 +13,20 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Mindsensors SD540 Speed Controller.
+ *
+ * <p>Note that the SD540 uses the following bounds for PWM values. These values should work
+ * reasonably well for most controllers, but if users experience issues such as asymmetric
+ * behavior around the deadband or inability to saturate the controller in either direction,
+ * calibration is recommended. The calibration procedure can be found in the SD540 User Manual
+ * available from Mindsensors.
+ *
+ * <p>- 2.05ms = full "forward" - 1.55ms = the "high end" of the deadband range - 1.50ms = center
+ * of the deadband range (off) - 1.44ms = the "low end" of the deadband range - 0.94ms = full
+ * "reverse"
  */
 public class SD540 extends PWMSpeedController {
   /**
    * Common initialization code called by all constructors.
-   *
-   * <p>Note that the SD540 uses the following bounds for PWM values. These values should work
-   * reasonably well for most controllers, but if users experience issues such as asymmetric
-   * behavior around the deadband or inability to saturate the controller in either direction,
-   * calibration is recommended. The calibration procedure can be found in the SD540 User Manual
-   * available from Mindsensors.
-   *
-   * <p>- 2.05ms = full "forward" - 1.55ms = the "high end" of the deadband range - 1.50ms = center
-   * of the deadband range (off) - 1.44ms = the "low end" of the deadband range - .94ms = full
-   * "reverse"
    */
   protected void initSD540() {
     setBounds(2.05, 1.55, 1.50, 1.44, .94);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SD540.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SD540.java
@@ -19,10 +19,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the SD540 User Manual
  * available from Mindsensors.
- *
- * <p>- 2.05ms = full "forward" - 1.55ms = the "high end" of the deadband range - 1.50ms = center
- * of the deadband range (off) - 1.44ms = the "low end" of the deadband range - 0.94ms = full
- * "reverse"
+ * <p><ul>
+ * <li>2.05ms = full "forward"
+ * <li>1.55ms = the "high end" of the deadband range
+ * <li>1.50ms = center of the deadband range (off)
+ * <li>1.44ms = the "low end" of the deadband range
+ * <li>0.94ms = full "reverse"
+ * </ul>
  */
 public class SD540 extends PWMSpeedController {
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SD540.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SD540.java
@@ -19,6 +19,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the SD540 User Manual
  * available from Mindsensors.
+ *
  * <p><ul>
  * <li>2.05ms = full "forward"
  * <li>1.55ms = the "high end" of the deadband range

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Spark.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Spark.java
@@ -19,10 +19,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the Spark User Manual
  * available from REV Robotics.
- *
- * <p>- 2.003ms = full "forward" - 1.55ms = the "high end" of the deadband range - 1.50ms =
- * center of the deadband range (off) - 1.46ms = the "low end" of the deadband range - .999ms =
- * full "reverse"
+ * <p><ul>
+ * <li>2.003ms = full "forward"
+ * <li>1.550ms = the "high end" of the deadband range
+ * <li>1.500ms = center of the deadband range (off)
+ * <li>1.460ms = the "low end" of the deadband range
+ * <li>0.999ms = full "reverse"
+ * </ul>
  */
 public class Spark extends PWMSpeedController {
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Spark.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Spark.java
@@ -13,20 +13,20 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * REV Robotics SPARK Speed Controller.
+ *
+ * <p>Note that the SPARK uses the following bounds for PWM values. These values should work
+ * reasonably well for most controllers, but if users experience issues such as asymmetric
+ * behavior around the deadband or inability to saturate the controller in either direction,
+ * calibration is recommended. The calibration procedure can be found in the Spark User Manual
+ * available from REV Robotics.
+ *
+ * <p>- 2.003ms = full "forward" - 1.55ms = the "high end" of the deadband range - 1.50ms =
+ * center of the deadband range (off) - 1.46ms = the "low end" of the deadband range - .999ms =
+ * full "reverse"
  */
 public class Spark extends PWMSpeedController {
   /**
    * Common initialization code called by all constructors.
-   *
-   * <p>Note that the SPARK uses the following bounds for PWM values. These values should work
-   * reasonably well for most controllers, but if users experience issues such as asymmetric
-   * behavior around the deadband or inability to saturate the controller in either direction,
-   * calibration is recommended. The calibration procedure can be found in the Spark User Manual
-   * available from REV Robotics.
-   *
-   * <p>- 2.003ms = full "forward" - 1.55ms = the "high end" of the deadband range - 1.50ms =
-   * center of the deadband range (off) - 1.46ms = the "low end" of the deadband range - .999ms =
-   * full "reverse"
    */
   protected void initSpark() {
     setBounds(2.003, 1.55, 1.50, 1.46, .999);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Spark.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Spark.java
@@ -19,6 +19,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the Spark User Manual
  * available from REV Robotics.
+ *
  * <p><ul>
  * <li>2.003ms = full "forward"
  * <li>1.550ms = the "high end" of the deadband range

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Talon.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Talon.java
@@ -13,20 +13,20 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Cross the Road Electronics (CTRE) Talon and Talon SR Speed Controller.
+ *
+ * <p>Note that the Talon uses the following bounds for PWM values. These values should work
+ * reasonably well for most controllers, but if users experience issues such as asymmetric
+ * behavior around the deadband or inability to saturate the controller in either direction,
+ * calibration is recommended. The calibration procedure can be found in the Talon User Manual
+ * available from CTRE.
+ *
+ * <p>- 2.037ms = full "forward" - 1.539ms = the "high end" of the deadband range - 1.513ms =
+ * center of the deadband range (off) - 1.487ms = the "low end" of the deadband range - .989ms
+ * = full "reverse"
  */
 public class Talon extends PWMSpeedController {
   /**
    * Constructor for a Talon (original or Talon SR).
-   *
-   * <p>Note that the Talon uses the following bounds for PWM values. These values should work
-   * reasonably well for most controllers, but if users experience issues such as asymmetric
-   * behavior around the deadband or inability to saturate the controller in either direction,
-   * calibration is recommended. The calibration procedure can be found in the Talon User Manual
-   * available from CTRE.
-   *
-   * <p>- 2.037ms = full "forward" - 1.539ms = the "high end" of the deadband range - 1.513ms =
-   * center of the deadband range (off) - 1.487ms = the "low end" of the deadband range - .989ms
-   * = full "reverse"
    *
    * @param channel The PWM channel that the Talon is attached to. 0-9 are on-board, 10-19 are on
    *                the MXP port

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Talon.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Talon.java
@@ -19,10 +19,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the Talon User Manual
  * available from CTRE.
- *
- * <p>- 2.037ms = full "forward" - 1.539ms = the "high end" of the deadband range - 1.513ms =
- * center of the deadband range (off) - 1.487ms = the "low end" of the deadband range - .989ms
- * = full "reverse"
+ * <p><ul>
+ * <li>2.037ms = full "forward"
+ * <li>1.539ms = the "high end" of the deadband range
+ * <li>1.513ms = center of the deadband range (off)
+ * <li>1.487ms = the "low end" of the deadband range
+ * <li>0.989ms = full "reverse"
+ * </ul>
  */
 public class Talon extends PWMSpeedController {
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Talon.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Talon.java
@@ -19,6 +19,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the Talon User Manual
  * available from CTRE.
+ *
  * <p><ul>
  * <li>2.037ms = full "forward"
  * <li>1.539ms = the "high end" of the deadband range

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Victor.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Victor.java
@@ -14,21 +14,21 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 /**
  * VEX Robotics Victor 888 Speed Controller The Vex Robotics Victor 884 Speed Controller can also
  * be used with this class but may need to be calibrated per the Victor 884 user manual.
+ *
+ * <p>Note that the Victor uses the following bounds for PWM values. These values were determined
+ * empirically and optimized for the Victor 888. These values should work reasonably well for
+ * Victor 884 controllers also but if users experience issues such as asymmetric behaviour around
+ * the deadband or inability to saturate the controller in either direction, calibration is
+ * recommended. The calibration procedure can be found in the Victor 884 User Manual available
+ * from VEX Robotics: http://content.vexrobotics.com/docs/ifi-v884-users-manual-9-25-06.pdf
+ *
+ * <p>- 2.027ms = full "forward" - 1.525ms = the "high end" of the deadband range - 1.507ms =
+ * center of the deadband range (off) - 1.49ms = the "low end" of the deadband range - 1.026ms =
+ * full "reverse"
  */
 public class Victor extends PWMSpeedController {
   /**
    * Constructor.
-   *
-   * <p>Note that the Victor uses the following bounds for PWM values. These values were determined
-   * empirically and optimized for the Victor 888. These values should work reasonably well for
-   * Victor 884 controllers also but if users experience issues such as asymmetric behaviour around
-   * the deadband or inability to saturate the controller in either direction, calibration is
-   * recommended. The calibration procedure can be found in the Victor 884 User Manual available
-   * from VEX Robotics: http://content.vexrobotics.com/docs/ifi-v884-users-manual-9-25-06.pdf
-   *
-   * <p>- 2.027ms = full "forward" - 1.525ms = the "high end" of the deadband range - 1.507ms =
-   * center of the deadband range (off) - 1.49ms = the "low end" of the deadband range - 1.026ms =
-   * full "reverse"
    *
    * @param channel The PWM channel that the Victor is attached to. 0-9 are
    *        on-board, 10-19 are on the MXP port

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Victor.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Victor.java
@@ -21,10 +21,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * the deadband or inability to saturate the controller in either direction, calibration is
  * recommended. The calibration procedure can be found in the Victor 884 User Manual available
  * from VEX Robotics: http://content.vexrobotics.com/docs/ifi-v884-users-manual-9-25-06.pdf
- *
- * <p>- 2.027ms = full "forward" - 1.525ms = the "high end" of the deadband range - 1.507ms =
- * center of the deadband range (off) - 1.49ms = the "low end" of the deadband range - 1.026ms =
- * full "reverse"
+ * <p><ul>
+ * <li>2.027ms = full "forward"
+ * <li>1.525ms = the "high end" of the deadband range
+ * <li>1.507ms = center of the deadband range (off)
+ * <li>1.490ms = the "low end" of the deadband range
+ * <li>1.026ms = full "reverse"
+ * </ul>
  */
 public class Victor extends PWMSpeedController {
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Victor.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Victor.java
@@ -21,6 +21,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * the deadband or inability to saturate the controller in either direction, calibration is
  * recommended. The calibration procedure can be found in the Victor 884 User Manual available
  * from VEX Robotics: http://content.vexrobotics.com/docs/ifi-v884-users-manual-9-25-06.pdf
+ *
  * <p><ul>
  * <li>2.027ms = full "forward"
  * <li>1.525ms = the "high end" of the deadband range

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/VictorSP.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/VictorSP.java
@@ -19,10 +19,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the VictorSP User Manual
  * available from CTRE.
- *
- * <p>- 2.004ms = full "forward" - 1.52ms = the "high end" of the deadband range - 1.50ms =
- * center of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms =
- * full "reverse"
+ * <p><ul>
+ * <li>2.004ms = full "forward"
+ * <li>1.520ms = the "high end" of the deadband range
+ * <li>1.500ms = center of the deadband range (off)
+ * <li>1.480ms = the "low end" of the deadband range
+ * <li>0.997ms = full "reverse"
+ * </ul>
  */
 public class VictorSP extends PWMSpeedController {
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/VictorSP.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/VictorSP.java
@@ -13,20 +13,20 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * VEX Robotics Victor SP Speed Controller.
+ *
+ * <p>Note that the VictorSP uses the following bounds for PWM values. These values should work
+ * reasonably well for most controllers, but if users experience issues such as asymmetric
+ * behavior around the deadband or inability to saturate the controller in either direction,
+ * calibration is recommended. The calibration procedure can be found in the VictorSP User Manual
+ * available from CTRE.
+ *
+ * <p>- 2.004ms = full "forward" - 1.52ms = the "high end" of the deadband range - 1.50ms =
+ * center of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms =
+ * full "reverse"
  */
 public class VictorSP extends PWMSpeedController {
   /**
    * Constructor.
-   *
-   * <p>Note that the VictorSP uses the following bounds for PWM values. These values should work
-   * reasonably well for most controllers, but if users experience issues such as asymmetric
-   * behavior around the deadband or inability to saturate the controller in either direction,
-   * calibration is recommended. The calibration procedure can be found in the VictorSP User Manual
-   * available from CTRE.
-   *
-   * <p>- 2.004ms = full "forward" - 1.52ms = the "high end" of the deadband range - 1.50ms =
-   * center of the deadband range (off) - 1.48ms = the "low end" of the deadband range - .997ms =
-   * full "reverse"
    *
    * @param channel The PWM channel that the VictorSP is attached to. 0-9 are
    *        on-board, 10-19 are on the MXP port

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/VictorSP.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/VictorSP.java
@@ -19,6 +19,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * behavior around the deadband or inability to saturate the controller in either direction,
  * calibration is recommended. The calibration procedure can be found in the VictorSP User Manual
  * available from CTRE.
+ *
  * <p><ul>
  * <li>2.004ms = full "forward"
  * <li>1.520ms = the "high end" of the deadband range


### PR DESCRIPTION
Some were in constructor docs, some in init function docs, and some
inline in code. Move them all to class docs and improve formatting