### PR TITLE
Switch notifier command tests to be a lot more lenient.

### DIFF
--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/NotifierCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/NotifierCommandTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.condition.OS;
 
 import edu.wpi.first.wpilibj.Timer;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledOnOs(OS.MAC)
 class NotifierCommandTest extends CommandTestBase {
@@ -29,6 +29,7 @@ class NotifierCommandTest extends CommandTestBase {
     Timer.delay(.25);
     scheduler.cancel(command);
 
-    assertEquals(.25, 0.01 * counter.m_counter, .025);
+    assertTrue(counter.m_counter > 10, "Should have hit at least 10 triggers");
+    assertTrue(counter.m_counter < 100, "Shouldn't hit more then 100 triggers");
   }
 }

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/NotifierCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/NotifierCommandTest.cpp
@@ -26,5 +26,6 @@ TEST_F(NotifierCommandTest, NotifierCommandScheduleTest) {
   std::this_thread::sleep_for(std::chrono::milliseconds(250));
   scheduler.Cancel(&command);
 
-  EXPECT_NEAR(.01 * counter, .25, .025);
+  EXPECT_GT(counter, 10);
+  EXPECT_LT(counter, 100);
 }


### PR DESCRIPTION
They don't need to be testing timing, just that the command starts and stops