### PR TITLE
Improve requirements APIs

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
@@ -112,11 +112,12 @@ public interface Command {
    * {@link CommandGroupBase#clearGroupedCommand(Command)}.  The decorated command can, however, be
    * further decorated without issue.
    *
-   * @param toRun the Runnable to run
+   * @param toRun        the Runnable to run
+   * @param requirements the required subsystems
    * @return the decorated command
    */
-  default SequentialCommandGroup beforeStarting(Runnable toRun) {
-    return new SequentialCommandGroup(new InstantCommand(toRun), this);
+  default SequentialCommandGroup beforeStarting(Runnable toRun, Subsystem... requirements) {
+    return new SequentialCommandGroup(new InstantCommand(toRun, requirements), this);
   }
 
   /**
@@ -128,11 +129,12 @@ public interface Command {
    * {@link CommandGroupBase#clearGroupedCommand(Command)}.  The decorated command can, however, be
    * further decorated without issue.
    *
-   * @param toRun the Runnable to run
+   * @param toRun        the Runnable to run
+   * @param requirements the required subsystems
    * @return the decorated command
    */
-  default SequentialCommandGroup andThen(Runnable toRun) {
-    return new SequentialCommandGroup(this, new InstantCommand(toRun));
+  default SequentialCommandGroup andThen(Runnable toRun, Subsystem... requirements) {
+    return new SequentialCommandGroup(this, new InstantCommand(toRun, requirements));
   }
 
   /**
@@ -279,7 +281,7 @@ public interface Command {
    * Whether the command requires a given subsystem.  Named "hasRequirement" rather than "requires"
    * to avoid confusion with
    * {@link edu.wpi.first.wpilibj.command.Command#requires(edu.wpi.first.wpilibj.command.Subsystem)}
-   *  - this may be able to be changed in a few years.
+   * - this may be able to be changed in a few years.
    *
    * @param requirement the subsystem to inquire about
    * @return whether the subsystem is required

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Button.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Button.java
@@ -10,6 +10,7 @@ package edu.wpi.first.wpilibj2.command.button;
 import java.util.function.BooleanSupplier;
 
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Subsystem;
 
 /**
  * This class provides an easy way to link commands to OI inputs.
@@ -66,11 +67,12 @@ public abstract class Button extends Trigger {
   /**
    * Runs the given runnable whenever the button is newly pressed.
    *
-   * @param toRun the runnable to run
+   * @param toRun        the runnable to run
+   * @param requirements the required subsystems
    * @return this button, so calls can be chained
    */
-  public Button whenPressed(final Runnable toRun) {
-    whenActive(toRun);
+  public Button whenPressed(final Runnable toRun, Subsystem... requirements) {
+    whenActive(toRun, requirements);
     return this;
   }
 
@@ -106,11 +108,12 @@ public abstract class Button extends Trigger {
   /**
    * Constantly runs the given runnable while the button is held.
    *
-   * @param toRun the runnable to run
+   * @param toRun        the runnable to run
+   * @param requirements the required subsystems
    * @return this button, so calls can be chained
    */
-  public Button whileHeld(final Runnable toRun) {
-    whileActiveContinuous(toRun);
+  public Button whileHeld(final Runnable toRun, Subsystem... requirements) {
+    whileActiveContinuous(toRun, requirements);
     return this;
   }
 
@@ -167,11 +170,12 @@ public abstract class Button extends Trigger {
   /**
    * Runs the given runnable when the button is released.
    *
-   * @param toRun the runnable to run
+   * @param toRun        the runnable to run
+   * @param requirements the required subsystems
    * @return this button, so calls can be chained
    */
-  public Button whenReleased(final Runnable toRun) {
-    whenInactive(toRun);
+  public Button whenReleased(final Runnable toRun, Subsystem... requirements) {
+    whenInactive(toRun, requirements);
     return this;
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
@@ -12,6 +12,7 @@ import java.util.function.BooleanSupplier;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.Subsystem;
 
 import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
 
@@ -100,11 +101,12 @@ public class Trigger {
   /**
    * Runs the given runnable whenever the trigger just becomes active.
    *
-   * @param toRun the runnable to run
+   * @param toRun        the runnable to run
+   * @param requirements the required subsystems
    * @return this trigger, so calls can be chained
    */
-  public Trigger whenActive(final Runnable toRun) {
-    return whenActive(new InstantCommand(toRun));
+  public Trigger whenActive(final Runnable toRun, Subsystem... requirements) {
+    return whenActive(new InstantCommand(toRun, requirements));
   }
 
   /**
@@ -155,11 +157,12 @@ public class Trigger {
   /**
    * Constantly runs the given runnable while the button is held.
    *
-   * @param toRun the runnable to run
+   * @param toRun        the runnable to run
+   * @param requirements the required subsystems
    * @return this trigger, so calls can be chained
    */
-  public Trigger whileActiveContinuous(final Runnable toRun) {
-    return whileActiveContinuous(new InstantCommand(toRun));
+  public Trigger whileActiveContinuous(final Runnable toRun, Subsystem... requirements) {
+    return whileActiveContinuous(new InstantCommand(toRun, requirements));
   }
 
   /**
@@ -243,11 +246,12 @@ public class Trigger {
   /**
    * Runs the given runnable when the trigger becomes inactive.
    *
-   * @param toRun the runnable to run
+   * @param toRun        the runnable to run
+   * @param requirements the required subsystems
    * @return this trigger, so calls can be chained
    */
-  public Trigger whenInactive(final Runnable toRun) {
-    return whenInactive(new InstantCommand(toRun));
+  public Trigger whenInactive(final Runnable toRun, Subsystem... requirements) {
+    return whenInactive(new InstantCommand(toRun, requirements));
   }
 
   /**

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -48,19 +48,21 @@ ParallelRaceGroup Command::WithInterrupt(std::function<bool()> condition) && {
   return ParallelRaceGroup(std::move(temp));
 }
 
-SequentialCommandGroup Command::BeforeStarting(std::function<void()> toRun) && {
+SequentialCommandGroup Command::BeforeStarting(std::function<void()> toRun,
+                                               std::initializer_list<Subsystem*> requirements) && {
   std::vector<std::unique_ptr<Command>> temp;
   temp.emplace_back(std::make_unique<InstantCommand>(
-      std::move(toRun), std::initializer_list<Subsystem*>{}));
+      std::move(toRun), requirements));
   temp.emplace_back(std::move(*this).TransferOwnership());
   return SequentialCommandGroup(std::move(temp));
 }
 
-SequentialCommandGroup Command::AndThen(std::function<void()> toRun) && {
+SequentialCommandGroup Command::AndThen(std::function<void()> toRun,
+                                        std::initializer_list<Subsystem*> requirements) && {
   std::vector<std::unique_ptr<Command>> temp;
   temp.emplace_back(std::move(*this).TransferOwnership());
   temp.emplace_back(std::make_unique<InstantCommand>(
-      std::move(toRun), std::initializer_list<Subsystem*>{}));
+      std::move(toRun), requirements));
   return SequentialCommandGroup(std::move(temp));
 }
 

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/FunctionalCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/FunctionalCommand.cpp
@@ -12,11 +12,14 @@ using namespace frc2;
 FunctionalCommand::FunctionalCommand(std::function<void()> onInit,
                                      std::function<void()> onExecute,
                                      std::function<void(bool)> onEnd,
-                                     std::function<bool()> isFinished)
+                                     std::function<bool()> isFinished,
+                                     std::initializer_list<Subsystem*> requirements)
     : m_onInit{std::move(onInit)},
       m_onExecute{std::move(onExecute)},
       m_onEnd{std::move(onEnd)},
-      m_isFinished{std::move(isFinished)} {}
+      m_isFinished{std::move(isFinished)} {
+  AddRequirements(requirements);
+}
 
 void FunctionalCommand::Initialize() { m_onInit(); }
 

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Button.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Button.cpp
@@ -16,8 +16,9 @@ Button Button::WhenPressed(Command* command, bool interruptible) {
   return *this;
 }
 
-Button Button::WhenPressed(std::function<void()> toRun) {
-  WhenActive(std::move(toRun));
+Button Button::WhenPressed(std::function<void()> toRun,
+                           std::initializer_list<Subsystem*> requirements) {
+  WhenActive(std::move(toRun), requirements);
   return *this;
 }
 
@@ -26,8 +27,9 @@ Button Button::WhileHeld(Command* command, bool interruptible) {
   return *this;
 }
 
-Button Button::WhileHeld(std::function<void()> toRun) {
-  WhileActiveContinous(std::move(toRun));
+Button Button::WhileHeld(std::function<void()> toRun,
+                         std::initializer_list<Subsystem*> requirements) {
+  WhileActiveContinous(std::move(toRun), requirements);
   return *this;
 }
 
@@ -41,8 +43,9 @@ Button Button::WhenReleased(Command* command, bool interruptible) {
   return *this;
 }
 
-Button Button::WhenReleased(std::function<void()> toRun) {
-  WhenInactive(std::move(toRun));
+Button Button::WhenReleased(std::function<void()> toRun,
+                            std::initializer_list<Subsystem*> requirements) {
+  WhenInactive(std::move(toRun), requirements);
   return *this;
 }
 

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
@@ -28,8 +28,9 @@ Trigger Trigger::WhenActive(Command* command, bool interruptible) {
   return *this;
 }
 
-Trigger Trigger::WhenActive(std::function<void()> toRun) {
-  return WhenActive(InstantCommand(std::move(toRun), {}));
+Trigger Trigger::WhenActive(std::function<void()> toRun,
+                            std::initializer_list<Subsystem*> requirements) {
+  return WhenActive(InstantCommand(std::move(toRun), requirements));
 }
 
 Trigger Trigger::WhileActiveContinous(Command* command, bool interruptible) {
@@ -48,8 +49,9 @@ Trigger Trigger::WhileActiveContinous(Command* command, bool interruptible) {
   return *this;
 }
 
-Trigger Trigger::WhileActiveContinous(std::function<void()> toRun) {
-  return WhileActiveContinous(InstantCommand(std::move(toRun), {}));
+Trigger Trigger::WhileActiveContinous(std::function<void()> toRun,
+                                      std::initializer_list<Subsystem*> requirements) {
+  return WhileActiveContinous(InstantCommand(std::move(toRun), requirements));
 }
 
 Trigger Trigger::WhileActiveOnce(Command* command, bool interruptible) {
@@ -82,8 +84,9 @@ Trigger Trigger::WhenInactive(Command* command, bool interruptible) {
   return *this;
 }
 
-Trigger Trigger::WhenInactive(std::function<void()> toRun) {
-  return WhenInactive(InstantCommand(std::move(toRun), {}));
+Trigger Trigger::WhenInactive(std::function<void()> toRun,
+                              std::initializer_list<Subsystem*> requirements) {
+  return WhenInactive(InstantCommand(std::move(toRun), requirements));
 }
 
 Trigger Trigger::ToggleWhenActive(Command* command, bool interruptible) {

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -127,17 +127,21 @@ class Command : public frc::ErrorBase {
    * Decorates this command with a runnable to run before this command starts.
    *
    * @param toRun the Runnable to run
+   * @param requirements the required subsystems
    * @return the decorated command
    */
-  SequentialCommandGroup BeforeStarting(std::function<void()> toRun) &&;
+  SequentialCommandGroup BeforeStarting(std::function<void()> toRun,
+                                        std::initializer_list<Subsystem*> requirements = {}) &&;
 
   /**
    * Decorates this command with a runnable to run after the command finishes.
    *
    * @param toRun the Runnable to run
+   * @param requirements the required subsystems
    * @return the decorated command
    */
-  SequentialCommandGroup AndThen(std::function<void()> toRun) &&;
+  SequentialCommandGroup AndThen(std::function<void()> toRun,
+                                 std::initializer_list<Subsystem*> requirements = {}) &&;
 
   /**
    * Decorates this command to run perpetually, ignoring its ordinary end

--- a/wpilibNewCommands/src/main/native/include/frc2/command/FunctionalCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/FunctionalCommand.h
@@ -35,7 +35,8 @@ class FunctionalCommand : public CommandHelper<CommandBase, FunctionalCommand> {
   FunctionalCommand(std::function<void()> onInit,
                     std::function<void()> onExecute,
                     std::function<void(bool)> onEnd,
-                    std::function<bool()> isFinished);
+                    std::function<bool()> isFinished,
+                    std::initializer_list<Subsystem*> requirements = {});
 
   FunctionalCommand(FunctionalCommand&& other) = default;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/InstantCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/InstantCommand.h
@@ -29,7 +29,7 @@ class InstantCommand : public CommandHelper<CommandBase, InstantCommand> {
    * @param requirements the subsystems required by this command
    */
   InstantCommand(std::function<void()> toRun,
-                 std::initializer_list<Subsystem*> requirements);
+                 std::initializer_list<Subsystem*> requirements = {});
 
   InstantCommand(InstantCommand&& other) = default;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/NotifierCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/NotifierCommand.h
@@ -37,7 +37,7 @@ class NotifierCommand : public CommandHelper<CommandBase, NotifierCommand> {
    * @param requirements the subsystems required by this command
    */
   NotifierCommand(std::function<void()> toRun, units::second_t period,
-                  std::initializer_list<Subsystem*> requirements);
+                  std::initializer_list<Subsystem*> requirements = {});
 
   NotifierCommand(NotifierCommand&& other);
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/PIDCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/PIDCommand.h
@@ -40,7 +40,7 @@ class PIDCommand : public CommandHelper<CommandBase, PIDCommand> {
              std::function<double()> measurementSource,
              std::function<double()> setpointSource,
              std::function<void(double)> useOutput,
-             std::initializer_list<Subsystem*> requirements);
+             std::initializer_list<Subsystem*> requirements = {});
 
   /**
    * Creates a new PIDCommand, which controls the given output with a

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ProfiledPIDCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ProfiledPIDCommand.h
@@ -44,7 +44,7 @@ class ProfiledPIDCommand
                      std::function<units::meter_t()> measurementSource,
                      std::function<State()> goalSource,
                      std::function<void(double, State)> useOutput,
-                     std::initializer_list<Subsystem*> requirements);
+                     std::initializer_list<Subsystem*> requirements = {});
 
   /**
    * Creates a new PIDCommand, which controls the given output with a

--- a/wpilibNewCommands/src/main/native/include/frc2/command/RamseteCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/RamseteCommand.h
@@ -91,7 +91,7 @@ class RamseteCommand : public CommandHelper<CommandBase, RamseteCommand> {
                  frc2::PIDController leftController,
                  frc2::PIDController rightController,
                  std::function<void(units::volt_t, units::volt_t)> output,
-                 std::initializer_list<Subsystem*> requirements);
+                 std::initializer_list<Subsystem*> requirements = {});
 
   /**
    * Constructs a new RamseteCommand that, when executed, will follow the

--- a/wpilibNewCommands/src/main/native/include/frc2/command/RunCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/RunCommand.h
@@ -30,7 +30,7 @@ class RunCommand : public CommandHelper<CommandBase, RunCommand> {
    * @param requirements the subsystems to require
    */
   RunCommand(std::function<void()> toRun,
-             std::initializer_list<Subsystem*> requirements);
+             std::initializer_list<Subsystem*> requirements = {});
 
   RunCommand(RunCommand&& other) = default;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/StartEndCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/StartEndCommand.h
@@ -32,7 +32,7 @@ class StartEndCommand : public CommandHelper<CommandBase, StartEndCommand> {
    * @param requirements the subsystems required by this command
    */
   StartEndCommand(std::function<void()> onInit, std::function<void()> onEnd,
-                  std::initializer_list<Subsystem*> requirements);
+                  std::initializer_list<Subsystem*> requirements = {});
 
   StartEndCommand(StartEndCommand&& other) = default;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Button.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Button.h
@@ -65,8 +65,10 @@ class Button : public Trigger {
    * Binds a runnable to execute when the button is pressed.
    *
    * @param toRun the runnable to execute.
+   * @param requirements the required subsystems.
    */
-  Button WhenPressed(std::function<void()> toRun);
+  Button WhenPressed(std::function<void()> toRun,
+                     std::initializer_list<Subsystem*> requirements = {});
 
   /**
    * Binds a command to be started repeatedly while the button is pressed, and
@@ -100,8 +102,10 @@ class Button : public Trigger {
    * Binds a runnable to execute repeatedly while the button is pressed.
    *
    * @param toRun the runnable to execute.
+   * @param requirements the required subsystems.
    */
-  Button WhileHeld(std::function<void()> toRun);
+  Button WhileHeld(std::function<void()> toRun,
+                   std::initializer_list<Subsystem*> requirements = {});
 
   /**
    * Binds a command to be started when the button is pressed, and cancelled
@@ -163,8 +167,10 @@ class Button : public Trigger {
    * Binds a runnable to execute when the button is released.
    *
    * @param toRun the runnable to execute.
+   * @param requirements the required subsystems.
    */
-  Button WhenReleased(std::function<void()> toRun);
+  Button WhenReleased(std::function<void()> toRun,
+                      std::initializer_list<Subsystem*> requirements = {});
 
   /**
    * Binds a command to start when the button is pressed, and be cancelled when

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
@@ -96,8 +96,10 @@ class Trigger {
    * Binds a runnable to execute when the trigger becomes active.
    *
    * @param toRun the runnable to execute.
+   * @paaram requirements the required subsystems.
    */
-  Trigger WhenActive(std::function<void()> toRun);
+  Trigger WhenActive(std::function<void()> toRun,
+                     std::initializer_list<Subsystem*> requirements = {});
 
   /**
    * Binds a command to be started repeatedly while the trigger is active, and
@@ -145,8 +147,10 @@ class Trigger {
    * Binds a runnable to execute repeatedly while the trigger is active.
    *
    * @param toRun the runnable to execute.
+   * @param requirements the required subsystems.
    */
-  Trigger WhileActiveContinous(std::function<void()> toRun);
+  Trigger WhileActiveContinous(std::function<void()> toRun,
+                               std::initializer_list<Subsystem*> requirements = {});
 
   /**
    * Binds a command to be started when the trigger becomes active, and
@@ -234,8 +238,10 @@ class Trigger {
    * Binds a runnable to execute when the trigger becomes inactive.
    *
    * @param toRun the runnable to execute.
+   * @param requirements the required subsystems.
    */
-  Trigger WhenInactive(std::function<void()> toRun);
+  Trigger WhenInactive(std::function<void()> toRun,
+                       std::initializer_list<Subsystem*> requirements = {});
 
   /**
    * Binds a command to start when the trigger becomes active, and be cancelled


### PR DESCRIPTION
Assorted improvements to the ergonomics of declaring requirements in the new command framework.  C++ requirements list parameters have been defaulted to an empty list, some missing C++ requirements list parameters have been added, and both C++ and Java have been given requirements list params in various `InstantCommand` wrapper methods (https://github.com/wpilibsuite/allwpilib/issues/2049), whose value is forwarded to the command.