### PR TITLE
Add simulation pause/step/resume support

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/NotifierJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/NotifierJNI.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2016-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2016-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -18,6 +18,11 @@ public class NotifierJNI extends JNIWrapper {
    * Initializes the notifier.
    */
   public static native int initializeNotifier();
+
+  /**
+   * Sets the name of the notifier.
+   */
+  public static native void setNotifierName(int notifierHandle, String name);
 
   /**
    * Wakes up the waiter with time=0.  Note: after this function is called, all

--- a/hal/src/main/java/edu/wpi/first/hal/sim/NotifierSim.java
+++ b/hal/src/main/java/edu/wpi/first/hal/sim/NotifierSim.java
@@ -1,0 +1,23 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.hal.sim;
+
+import edu.wpi.first.hal.sim.mockdata.NotifierDataJNI;
+
+public final class NotifierSim {
+  private NotifierSim() {
+  }
+
+  public static long getNextTimeout() {
+    return NotifierDataJNI.getNextTimeout();
+  }
+
+  public static int getNumNotifiers() {
+    return NotifierDataJNI.getNumNotifiers();
+  }
+}

--- a/hal/src/main/java/edu/wpi/first/hal/sim/SimHooks.java
+++ b/hal/src/main/java/edu/wpi/first/hal/sim/SimHooks.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -23,5 +23,21 @@ public final class SimHooks {
 
   public static void restartTiming() {
     SimulatorJNI.restartTiming();
+  }
+
+  public static void pauseTiming() {
+    SimulatorJNI.pauseTiming();
+  }
+
+  public static void resumeTiming() {
+    SimulatorJNI.resumeTiming();
+  }
+
+  public static boolean isTimingPaused() {
+    return SimulatorJNI.isTimingPaused();
+  }
+
+  public static void stepTiming(long delta) {
+    SimulatorJNI.stepTiming(delta);
   }
 }

--- a/hal/src/main/java/edu/wpi/first/hal/sim/mockdata/NotifierDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/sim/mockdata/NotifierDataJNI.java
@@ -1,0 +1,15 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.hal.sim.mockdata;
+
+import edu.wpi.first.hal.JNIWrapper;
+
+public class NotifierDataJNI extends JNIWrapper {
+  public static native long getNextTimeout();
+  public static native int getNumNotifiers();
+}

--- a/hal/src/main/java/edu/wpi/first/hal/sim/mockdata/SimulatorJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/sim/mockdata/SimulatorJNI.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -13,5 +13,9 @@ public class SimulatorJNI extends JNIWrapper {
   public static native void waitForProgramStart();
   public static native void setProgramStarted();
   public static native void restartTiming();
+  public static native void pauseTiming();
+  public static native void resumeTiming();
+  public static native boolean isTimingPaused();
+  public static native void stepTiming(long delta);
   public static native void resetHandles();
 }

--- a/hal/src/main/native/athena/Notifier.cpp
+++ b/hal/src/main/native/athena/Notifier.cpp
@@ -139,6 +139,9 @@ HAL_NotifierHandle HAL_InitializeNotifier(int32_t* status) {
   return handle;
 }
 
+void HAL_SetNotifierName(HAL_NotifierHandle notifierHandle, const char* name,
+                         int32_t* status) {}
+
 void HAL_StopNotifier(HAL_NotifierHandle notifierHandle, int32_t* status) {
   auto notifier = notifierHandles->Get(notifierHandle);
   if (!notifier) return;

--- a/hal/src/main/native/cpp/jni/NotifierJNI.cpp
+++ b/hal/src/main/native/cpp/jni/NotifierJNI.cpp
@@ -10,6 +10,8 @@
 #include <cassert>
 #include <cstdio>
 
+#include <wpi/jni_util.h>
+
 #include "HALUtil.h"
 #include "edu_wpi_first_hal_NotifierJNI.h"
 #include "hal/Notifier.h"
@@ -35,6 +37,21 @@ Java_edu_wpi_first_hal_NotifierJNI_initializeNotifier
   }
 
   return (jint)notifierHandle;
+}
+
+/*
+ * Class:     edu_wpi_first_hal_NotifierJNI
+ * Method:    setNotifierName
+ * Signature: (ILjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_NotifierJNI_setNotifierName
+  (JNIEnv* env, jclass cls, jint notifierHandle, jstring name)
+{
+  int32_t status = 0;
+  HAL_SetNotifierName((HAL_NotifierHandle)notifierHandle,
+                      wpi::java::JStringRef{env, name}.c_str(), &status);
+  CheckStatus(env, status);
 }
 
 /*

--- a/hal/src/main/native/include/hal/Notifier.h
+++ b/hal/src/main/native/include/hal/Notifier.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2016-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2016-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -30,6 +30,15 @@ extern "C" {
  * @return the created notifier
  */
 HAL_NotifierHandle HAL_InitializeNotifier(int32_t* status);
+
+/**
+ * Sets the name of a notifier.
+ *
+ * @param notifierHandle the notifier handle
+ * @param name name
+ */
+void HAL_SetNotifierName(HAL_NotifierHandle notifierHandle, const char* name,
+                         int32_t* status);
 
 /**
  * Stops a notifier from running.

--- a/hal/src/main/native/include/mockdata/MockHooks.h
+++ b/hal/src/main/native/include/mockdata/MockHooks.h
@@ -14,6 +14,10 @@ void HALSIM_WaitForProgramStart(void);
 void HALSIM_SetProgramStarted(void);
 HAL_Bool HALSIM_GetProgramStarted(void);
 void HALSIM_RestartTiming(void);
+void HALSIM_PauseTiming(void);
+void HALSIM_ResumeTiming(void);
+HAL_Bool HALSIM_IsTimingPaused(void);
+void HALSIM_StepTiming(uint64_t delta);
 
 typedef int32_t (*HALSIM_SendErrorHandler)(
     HAL_Bool isError, int32_t errorCode, HAL_Bool isLVCode, const char* details,

--- a/hal/src/main/native/include/mockdata/NotifierData.h
+++ b/hal/src/main/native/include/mockdata/NotifierData.h
@@ -1,0 +1,38 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include "hal/Types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct HALSIM_NotifierInfo {
+  HAL_NotifierHandle handle;
+  char name[64];
+  uint64_t timeout;
+  HAL_Bool running;
+};
+
+uint64_t HALSIM_GetNextNotifierTimeout(void);
+
+int32_t HALSIM_GetNumNotifiers(void);
+
+/**
+ * Gets detailed information about each notifier.
+ *
+ * @param arr array of information to be filled
+ * @param size size of arr
+ * @return Number of notifiers; note: may be larger than passed-in size
+ */
+int32_t HALSIM_GetNotifierInfo(struct HALSIM_NotifierInfo* arr, int32_t size);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif

--- a/hal/src/main/native/sim/MockHooks.cpp
+++ b/hal/src/main/native/sim/MockHooks.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -13,10 +13,12 @@
 #include <wpi/timestamp.h>
 
 #include "MockHooksInternal.h"
+#include "NotifierInternal.h"
 
 static std::atomic<bool> programStarted{false};
 
 static std::atomic<uint64_t> programStartTime{0};
+static std::atomic<uint64_t> programPauseTime{0};
 
 namespace hal {
 namespace init {
@@ -25,12 +27,32 @@ void InitializeMockHooks() {}
 }  // namespace hal
 
 namespace hal {
-void RestartTiming() { programStartTime = wpi::Now(); }
+void RestartTiming() {
+  programStartTime = wpi::Now();
+  if (programPauseTime != 0) programPauseTime = programStartTime.load();
+}
+
+void PauseTiming() {
+  if (programPauseTime == 0) programPauseTime = wpi::Now();
+}
+
+void ResumeTiming() {
+  if (programPauseTime != 0) {
+    programStartTime += wpi::Now() - programPauseTime;
+    programPauseTime = 0;
+  }
+}
+
+bool IsTimingPaused() { return programPauseTime != 0; }
+
+void StepTiming(uint64_t delta) {
+  if (programPauseTime != 0) programPauseTime += delta;
+}
 
 int64_t GetFPGATime() {
-  auto now = wpi::Now();
-  auto currentTime = now - programStartTime;
-  return currentTime;
+  uint64_t curTime = programPauseTime;
+  if (curTime == 0) curTime = wpi::Now();
+  return curTime - programStartTime;
 }
 
 double GetFPGATimestamp() { return GetFPGATime() * 1.0e-6; }
@@ -56,4 +78,21 @@ void HALSIM_SetProgramStarted(void) { SetProgramStarted(); }
 HAL_Bool HALSIM_GetProgramStarted(void) { return GetProgramStarted(); }
 
 void HALSIM_RestartTiming(void) { RestartTiming(); }
+
+void HALSIM_PauseTiming(void) {
+  PauseTiming();
+  PauseNotifiers();
+}
+
+void HALSIM_ResumeTiming(void) {
+  ResumeTiming();
+  ResumeNotifiers();
+}
+
+HAL_Bool HALSIM_IsTimingPaused(void) { return IsTimingPaused(); }
+
+void HALSIM_StepTiming(uint64_t delta) {
+  StepTiming(delta);
+  WakeupNotifiers();
+}
 }  // extern "C"

--- a/hal/src/main/native/sim/Notifier.cpp
+++ b/hal/src/main/native/sim/Notifier.cpp
@@ -8,6 +8,7 @@
 #include "hal/Notifier.h"
 
 #include <chrono>
+#include <string>
 
 #include <wpi/condition_variable.h>
 #include <wpi/mutex.h>
@@ -20,6 +21,7 @@
 
 namespace {
 struct Notifier {
+  std::string name;
   uint64_t waitTime;
   bool updatedAlarm = false;
   bool active = true;
@@ -69,6 +71,14 @@ HAL_NotifierHandle HAL_InitializeNotifier(int32_t* status) {
     return HAL_kInvalidHandle;
   }
   return handle;
+}
+
+void HAL_SetNotifierName(HAL_NotifierHandle notifierHandle, const char* name,
+                         int32_t* status) {
+  auto notifier = notifierHandles->Get(notifierHandle);
+  if (!notifier) return;
+  std::scoped_lock lock(notifier->mutex);
+  notifier->name = name;
 }
 
 void HAL_StopNotifier(HAL_NotifierHandle notifierHandle, int32_t* status) {

--- a/hal/src/main/native/sim/NotifierInternal.h
+++ b/hal/src/main/native/sim/NotifierInternal.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -7,24 +7,8 @@
 
 #pragma once
 
-#include <stdint.h>
-
-#include "mockdata/MockHooks.h"
-
 namespace hal {
-void RestartTiming();
-
-void PauseTiming();
-
-void ResumeTiming();
-
-bool IsTimingPaused();
-
-void StepTiming(uint64_t delta);
-
-int64_t GetFPGATime();
-
-double GetFPGATimestamp();
-
-void SetProgramStarted();
+void PauseNotifiers();
+void ResumeNotifiers();
+void WakeupNotifiers();
 }  // namespace hal

--- a/hal/src/main/native/sim/jni/NotifierDataJNI.cpp
+++ b/hal/src/main/native/sim/jni/NotifierDataJNI.cpp
@@ -1,0 +1,37 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "edu_wpi_first_hal_sim_mockdata_NotifierDataJNI.h"
+#include "mockdata/NotifierData.h"
+
+extern "C" {
+
+/*
+ * Class:     edu_wpi_first_hal_sim_mockdata_NotifierDataJNI
+ * Method:    getNextTimeout
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL
+Java_edu_wpi_first_hal_sim_mockdata_NotifierDataJNI_getNextTimeout
+  (JNIEnv*, jclass)
+{
+  return HALSIM_GetNextNotifierTimeout();
+}
+
+/*
+ * Class:     edu_wpi_first_hal_sim_mockdata_NotifierDataJNI
+ * Method:    getNumNotifiers
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL
+Java_edu_wpi_first_hal_sim_mockdata_NotifierDataJNI_getNumNotifiers
+  (JNIEnv*, jclass)
+{
+  return HALSIM_GetNumNotifiers();
+}
+
+}  // extern "C"

--- a/hal/src/main/native/sim/jni/SimulatorJNI.cpp
+++ b/hal/src/main/native/sim/jni/SimulatorJNI.cpp
@@ -144,6 +144,54 @@ Java_edu_wpi_first_hal_sim_mockdata_SimulatorJNI_restartTiming
 
 /*
  * Class:     edu_wpi_first_hal_sim_mockdata_SimulatorJNI
+ * Method:    pauseTiming
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_sim_mockdata_SimulatorJNI_pauseTiming
+  (JNIEnv*, jclass)
+{
+  HALSIM_PauseTiming();
+}
+
+/*
+ * Class:     edu_wpi_first_hal_sim_mockdata_SimulatorJNI
+ * Method:    resumeTiming
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_sim_mockdata_SimulatorJNI_resumeTiming
+  (JNIEnv*, jclass)
+{
+  HALSIM_ResumeTiming();
+}
+
+/*
+ * Class:     edu_wpi_first_hal_sim_mockdata_SimulatorJNI
+ * Method:    isTimingPaused
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_hal_sim_mockdata_SimulatorJNI_isTimingPaused
+  (JNIEnv*, jclass)
+{
+  return HALSIM_IsTimingPaused();
+}
+
+/*
+ * Class:     edu_wpi_first_hal_sim_mockdata_SimulatorJNI
+ * Method:    stepTiming
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_sim_mockdata_SimulatorJNI_stepTiming
+  (JNIEnv*, jclass, jlong delta)
+{
+  HALSIM_StepTiming(delta);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_sim_mockdata_SimulatorJNI
  * Method:    resetHandles
  * Signature: ()V
  */

--- a/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
@@ -14,6 +14,7 @@
 #include <imgui.h>
 #include <imgui_internal.h>
 #include <mockdata/DriverStationData.h>
+#include <mockdata/MockHooks.h>
 #include <wpi/Format.h>
 #include <wpi/SmallString.h>
 #include <wpi/StringRef.h>
@@ -328,7 +329,7 @@ static void DriverStationExecute() {
 
   // Send new data every 20 ms (may be slower depending on GUI refresh rate)
   static double lastNewDataTime = 0.0;
-  if ((curTime - lastNewDataTime) > 0.02) {
+  if ((curTime - lastNewDataTime) > 0.02 && !HALSIM_IsTimingPaused()) {
     lastNewDataTime = curTime;
     HALSIM_NotifyDriverStationNewData();
   }
@@ -367,7 +368,7 @@ static void DisplayFMS() {
                          ImGuiInputTextFlags_EnterReturnsTrue)) {
     HALSIM_SetDriverStationMatchTime(matchTime);
     startMatchTime = curTime - matchTime;
-  } else if (!HALSIM_GetDriverStationEnabled()) {
+  } else if (!HALSIM_GetDriverStationEnabled() || HALSIM_IsTimingPaused()) {
     startMatchTime = curTime - matchTime;
   } else if (matchTimeEnabled) {
     HALSIM_SetDriverStationMatchTime(curTime - startMatchTime);

--- a/simulation/halsim_gui/src/main/native/cpp/TimingGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/TimingGui.cpp
@@ -1,0 +1,60 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "TimingGui.h"
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include <hal/HALBase.h>
+#include <imgui.h>
+#include <mockdata/MockHooks.h>
+#include <mockdata/NotifierData.h>
+
+#include "HALSimGui.h"
+
+using namespace halsimgui;
+
+static void DisplayTiming() {
+  int32_t status = 0;
+  uint64_t curTime = HAL_GetFPGATime(&status);
+
+  if (ImGui::Button("Run")) HALSIM_ResumeTiming();
+  ImGui::SameLine();
+  if (ImGui::Button("Pause")) HALSIM_PauseTiming();
+  ImGui::SameLine();
+  ImGui::PushButtonRepeat(true);
+  if (ImGui::Button("Step")) {
+    HALSIM_PauseTiming();
+    uint64_t nextTimeout = HALSIM_GetNextNotifierTimeout();
+    if (nextTimeout != UINT64_MAX) HALSIM_StepTiming(nextTimeout - curTime);
+  }
+  ImGui::PopButtonRepeat();
+  ImGui::PushItemWidth(ImGui::GetFontSize() * 4);
+  ImGui::LabelText("FPGA Time", "%.3f", curTime / 1000000.0);
+  ImGui::PopItemWidth();
+
+  static std::vector<HALSIM_NotifierInfo> notifiers;
+  int32_t num = HALSIM_GetNotifierInfo(notifiers.data(), notifiers.size());
+  if (static_cast<uint32_t>(num) > notifiers.size()) {
+    notifiers.resize(num);
+    HALSIM_GetNotifierInfo(notifiers.data(), notifiers.size());
+  }
+  if (num > 0) ImGui::Separator();
+  ImGui::PushItemWidth(ImGui::GetFontSize() * 4);
+  for (int32_t i = 0; i < num; ++i)
+    ImGui::LabelText(notifiers[i].name, "%.3f",
+                     notifiers[i].timeout / 1000000.0);
+  ImGui::PopItemWidth();
+}
+
+void TimingGui::Initialize() {
+  HALSimGui::AddWindow("Timing", DisplayTiming,
+                       ImGuiWindowFlags_AlwaysAutoResize);
+  HALSimGui::SetDefaultWindowPos("Timing", 5, 150);
+}

--- a/simulation/halsim_gui/src/main/native/cpp/TimingGui.h
+++ b/simulation/halsim_gui/src/main/native/cpp/TimingGui.h
@@ -1,0 +1,17 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+namespace halsimgui {
+
+class TimingGui {
+ public:
+  static void Initialize();
+};
+
+}  // namespace halsimgui

--- a/simulation/halsim_gui/src/main/native/cpp/main.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/main.cpp
@@ -23,6 +23,7 @@
 #include "RoboRioGui.h"
 #include "SimDeviceGui.h"
 #include "SolenoidGui.h"
+#include "TimingGui.h"
 
 using namespace halsimgui;
 
@@ -45,6 +46,7 @@ __declspec(dllexport)
   HALSimGui::Add(RoboRioGui::Initialize);
   HALSimGui::Add(SimDeviceGui::Initialize);
   HALSimGui::Add(SolenoidGui::Initialize);
+  HALSimGui::Add(TimingGui::Initialize);
 
   wpi::outs() << "Simulator GUI Initializing.\n";
   if (!HALSimGui::Initialize()) return 0;

--- a/wpilibc/src/main/native/cpp/Notifier.cpp
+++ b/wpilibc/src/main/native/cpp/Notifier.cpp
@@ -11,6 +11,7 @@
 
 #include <hal/FRCUsageReporting.h>
 #include <hal/Notifier.h>
+#include <wpi/SmallString.h>
 
 #include "frc/Timer.h"
 #include "frc/Utility.h"
@@ -89,6 +90,13 @@ Notifier& Notifier::operator=(Notifier&& rhs) {
   m_periodic = std::move(rhs.m_periodic);
 
   return *this;
+}
+
+void Notifier::SetName(const wpi::Twine& name) {
+  wpi::SmallString<64> nameBuf;
+  int32_t status = 0;
+  HAL_SetNotifierName(m_notifier,
+                      name.toNullTerminatedStringRef(nameBuf).data(), &status);
 }
 
 void Notifier::SetHandler(std::function<void()> handler) {

--- a/wpilibc/src/main/native/cpp/TimedRobot.cpp
+++ b/wpilibc/src/main/native/cpp/TimedRobot.cpp
@@ -60,6 +60,7 @@ TimedRobot::TimedRobot(units::second_t period) : IterativeRobotBase(period) {
   int32_t status = 0;
   m_notifier = HAL_InitializeNotifier(&status);
   wpi_setHALError(status);
+  HAL_SetNotifierName(m_notifier, "TimedRobot", &status);
 
   HAL_Report(HALUsageReporting::kResourceType_Framework,
              HALUsageReporting::kFramework_Timed);

--- a/wpilibc/src/main/native/include/frc/Notifier.h
+++ b/wpilibc/src/main/native/include/frc/Notifier.h
@@ -16,6 +16,7 @@
 
 #include <hal/Types.h>
 #include <units/units.h>
+#include <wpi/Twine.h>
 #include <wpi/deprecated.h>
 #include <wpi/mutex.h>
 
@@ -45,6 +46,13 @@ class Notifier : public ErrorBase {
 
   Notifier(Notifier&& rhs);
   Notifier& operator=(Notifier&& rhs);
+
+  /**
+   * Sets the name of the notifier.  Used for debugging purposes only.
+   *
+   * @param name Name
+   */
+  void SetName(const wpi::Twine& name);
 
   /**
    * Change the handler function.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Notifier.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Notifier.java
@@ -139,6 +139,16 @@ public class Notifier implements AutoCloseable {
   }
 
   /**
+   * Sets the name of the notifier.  Used for debugging purposes only.
+   *
+   * @param name Name
+   */
+  public void setName(String name) {
+    m_thread.setName(name);
+    NotifierJNI.setNotifierName(m_notifier.get(), name);
+  }
+
+  /**
    * Change the handler function.
    *
    * @param handler Handler

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/TimedRobot.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/TimedRobot.java
@@ -43,6 +43,7 @@ public class TimedRobot extends IterativeRobotBase {
    */
   protected TimedRobot(double period) {
     super(period);
+    NotifierJNI.setNotifierName(m_notifier, "TimedRobot");
 
     HAL.report(tResourceType.kResourceType_Framework, tInstances.kFramework_Timed);
   }


### PR DESCRIPTION
Calling HALSIM_PauseTiming pauses the FPGA clock and notifiers.
Calling HALSIM_ResumeTiming resumes the FPGA clock and notifiers.
Calling HALSIM_StepTiming steps the FPGA clock and runs applicable notifiers.

This will effectively pause TimedRobot and any other notifier-based events,
but of course will not pause user threads that do not use the notifier (e.g.
image processing).

The GUI also pauses DS new data notifications when paused.  This could be
done globally instead by blocking NotifyNewData at the HAL level?

Notifiers can now be named and appear in the simulation GUI.  A "Timing"
window has been added to the GUI to access this functionality.