### PR TITLE
Make usage reporting enums type match

### DIFF
--- a/hal/src/generate/FRCUsageReporting.h.in
+++ b/hal/src/generate/FRCUsageReporting.h.in
@@ -43,10 +43,10 @@ int64_t HAL_Report(int32_t resource, int32_t instanceNumber, int32_t context,
  */
 
 namespace HALUsageReporting {
-  typedef enum {
+  enum tResourceType : int32_t {
 ${usage_reporting_types_cpp}
-  } tResourceType;
-  typedef enum {
+  };
+  enum tInstances : int32_t {
 ${usage_reporting_instances_cpp}
-  } tInstances;
+  };
 }


### PR DESCRIPTION
This changes the C++ HALUsageReporting enums to have an
explicit type which matches the HAL_Report parameter
types.  In practice this shouldn't change much except
for tooling that might be parsing this header.