### PR TITLE
Add differentialdrive voltage constraint

### DIFF
--- a/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
@@ -46,7 +46,7 @@ DifferentialDriveVoltageConstraint::MinMaxAcceleration(
 
   // Robot chassis turning on radius = 1/|curvature|.  Outer wheel has radius
   // increased by half of the trackwidth T.  Inner wheel has radius decreased
-  // by half of the wheelbase.  Achassis / radius = Aouter / (radius + T/2), so
+  // by half of the trackwidth.  Achassis / radius = Aouter / (radius + T/2), so
   // Achassis = Aouter * radius / (radius + T/2) = Aouter / (1 + |curvature|T/2)
   // Inner wheel is similar.
 

--- a/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
@@ -1,0 +1,62 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h"
+
+#include <algorithm>
+#include <limits>
+
+#include <wpi/MathExtras.h>
+
+using namespace frc;
+
+DifferentialDriveVoltageConstraint::DifferentialDriveVoltageConstraint(
+    SimpleMotorFeedforward<units::meter> feedforward,
+    DifferentialDriveKinematics kinematics, units::volt_t maxVoltage)
+    : m_feedforward(feedforward),
+      m_kinematics(kinematics),
+      m_maxVoltage(maxVoltage) {}
+
+units::meters_per_second_t DifferentialDriveVoltageConstraint::MaxVelocity(
+    const Pose2d& pose, curvature_t curvature,
+    units::meters_per_second_t velocity) {
+  return units::meters_per_second_t(std::numeric_limits<double>::max());
+}
+
+TrajectoryConstraint::MinMax
+DifferentialDriveVoltageConstraint::MinMaxAcceleration(
+    const Pose2d& pose, curvature_t curvature,
+    units::meters_per_second_t speed) {
+  auto wheelSpeeds =
+      m_kinematics.ToWheelSpeeds({speed, 0_mps, speed * curvature});
+
+  auto maxWheelSpeed = std::max(wheelSpeeds.left, wheelSpeeds.right);
+  auto minWheelSpeed = std::min(wheelSpeeds.left, wheelSpeeds.right);
+
+  auto maxWheelAcceleration =
+      (m_maxVoltage - m_feedforward.kS * wpi::sgn(maxWheelSpeed) -
+       m_feedforward.kV * maxWheelSpeed) /
+      m_feedforward.kA;
+  auto minWheelAcceleration =
+      (-m_maxVoltage - m_feedforward.kS * wpi::sgn(minWheelSpeed) -
+       m_feedforward.kV * minWheelSpeed) /
+      m_feedforward.kA;
+
+  // If moving forward, max acceleration constraint corresponds to wheel on
+  // outside of turn If moving backward, max acceleration constraint corresponds
+  // to wheel on inside of turn
+  auto maxChassisAcceleration =
+      maxWheelAcceleration /
+      (1 + m_kinematics.trackWidth * units::math::abs(curvature) *
+               wpi::sgn(speed) / (2_rad));
+  auto minChassisAcceleration =
+      minWheelAcceleration /
+      (1 - m_kinematics.trackWidth * units::math::abs(curvature) *
+               wpi::sgn(speed) / (2_rad));
+
+  return {minChassisAcceleration, maxChassisAcceleration};
+}

--- a/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
@@ -58,5 +58,10 @@ DifferentialDriveVoltageConstraint::MinMaxAcceleration(
       (1 - m_kinematics.trackWidth * units::math::abs(curvature) *
                wpi::sgn(speed) / (2_rad));
 
+  // Negate min chassis acceleration if center of turn is inside of wheelbase
+  if ((m_kinematics.trackWidth / 2) > 1_rad / units::math::abs(curvature)) {
+    minChassisAcceleration = -minChassisAcceleration;
+  }
+
   return {minChassisAcceleration, maxChassisAcceleration};
 }

--- a/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
@@ -44,10 +44,11 @@ DifferentialDriveVoltageConstraint::MinMaxAcceleration(
   auto minWheelAcceleration =
       m_feedforward.MinAchievableAcceleration(m_maxVoltage, minWheelSpeed);
 
-  // Robot chassis turning on radius 1/|curvature|.  Outer wheel has radius
-  // increased by half of the wheelbase.  Inner wheel has radius decreased
-  // by half of the wheelbase.  Solve resulting equations, and you get
-  // the implementation below.
+  // Robot chassis turning on radius = 1/|curvature|.  Outer wheel has radius
+  // increased by half of the trackwidth T.  Inner wheel has radius decreased
+  // by half of the wheelbase.  Achassis / radius = Aouter / (radius + T/2), so
+  // Achassis = Aouter * radius / (radius + T/2) = Aouter / (1 + |curvature|T/2)
+  // Inner wheel is similar.
 
   // sgn(speed) term added to correctly account for which wheel is on
   // outside of turn:

--- a/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
@@ -40,13 +40,9 @@ DifferentialDriveVoltageConstraint::MinMaxAcceleration(
   // Calculate maximum/minimum possible accelerations from motor dynamics
   // and max/min wheel speeds
   auto maxWheelAcceleration =
-      (m_maxVoltage - m_feedforward.kS * wpi::sgn(maxWheelSpeed) -
-       m_feedforward.kV * maxWheelSpeed) /
-      m_feedforward.kA;
+      m_feedforward.MaxAchievableAcceleration(m_maxVoltage, maxWheelSpeed);
   auto minWheelAcceleration =
-      (-m_maxVoltage - m_feedforward.kS * wpi::sgn(minWheelSpeed) -
-       m_feedforward.kV * minWheelSpeed) /
-      m_feedforward.kA;
+      m_feedforward.MinAchievableAcceleration(m_maxVoltage, minWheelSpeed);
 
   // Robot chassis turning on radius 1/|curvature|.  Outer wheel has radius
   // increased by half of the wheelbase.  Inner wheel has radius decreased
@@ -71,7 +67,7 @@ DifferentialDriveVoltageConstraint::MinMaxAcceleration(
   // Negate acceleration corresponding to wheel on inside of turn
   // if center of turn is inside of wheelbase
   if ((m_kinematics.trackWidth / 2) > 1_rad / units::math::abs(curvature)) {
-    if (velocity > 0) {
+    if (speed > 0_mps) {
       minChassisAcceleration = -minChassisAcceleration;
     } else {
       maxChassisAcceleration = -maxChassisAcceleration;

--- a/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
@@ -73,8 +73,7 @@ DifferentialDriveVoltageConstraint::MinMaxAcceleration(
   if ((m_kinematics.trackWidth / 2) > 1_rad / units::math::abs(curvature)) {
     if (velocity > 0) {
       minChassisAcceleration = -minChassisAcceleration;
-    }
-    else {
+    } else {
       maxChassisAcceleration = -maxChassisAcceleration;
     }
   }

--- a/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
@@ -58,9 +58,15 @@ DifferentialDriveVoltageConstraint::MinMaxAcceleration(
       (1 - m_kinematics.trackWidth * units::math::abs(curvature) *
                wpi::sgn(speed) / (2_rad));
 
-  // Negate min chassis acceleration if center of turn is inside of wheelbase
+  // Negate acceleration of wheel on inside of turn
+  // if center of turn is inside of wheelbase
   if ((m_kinematics.trackWidth / 2) > 1_rad / units::math::abs(curvature)) {
-    minChassisAcceleration = -minChassisAcceleration;
+    if (velocity > 0) {
+      minChassisAcceleration = -minChassisAcceleration;
+    }
+    else {
+      maxChassisAcceleration = -maxChassisAcceleration;
+    }
   }
 
   return {minChassisAcceleration, maxChassisAcceleration};

--- a/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
@@ -58,10 +58,9 @@ class ArmFeedforward {
            m_kV * velocity + m_kA * acceleration;
   }
 
- private:
-  units::volt_t m_kS{0};
-  units::volt_t m_kCos{0};
-  units::unit_t<kv_unit> m_kV{0};
-  units::unit_t<ka_unit> m_kA{0};
+  units::volt_t kS{0};
+  units::volt_t kCos{0};
+  units::unit_t<kv_unit> kV{0};
+  units::unit_t<ka_unit> kA{0};
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
@@ -58,6 +58,9 @@ class ArmFeedforward {
            kV * velocity + kA * acceleration;
   }
 
+  // Rearranging the main equation from the calculate() method yields the
+  // formulas for the methods below:
+
   /**
    * Calculates the maximum achievable velocity given a maximum voltage supply,
    * a position, and an acceleration.

--- a/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
@@ -40,7 +40,7 @@ class ArmFeedforward {
   constexpr ArmFeedforward(
       units::volt_t kS, units::volt_t kCos, units::unit_t<kv_unit> kV,
       units::unit_t<ka_unit> kA = units::unit_t<ka_unit>(0))
-      : m_kS(kS), m_kCos(kCos), m_kV(kV), m_kA(kA) {}
+      : kS(kS), kCos(kCos), kV(kV), kA(kA) {}
 
   /**
    * Calculates the feedforward from the gains and setpoints.
@@ -54,8 +54,8 @@ class ArmFeedforward {
                           units::unit_t<Velocity> velocity,
                           units::unit_t<Acceleration> acceleration =
                               units::unit_t<Acceleration>(0)) const {
-    return m_kS * wpi::sgn(velocity) + m_kCos * units::math::cos(angle) +
-           m_kV * velocity + m_kA * acceleration;
+    return kS * wpi::sgn(velocity) + kCos * units::math::cos(angle) +
+           kV * velocity + kA * acceleration;
   }
 
   units::volt_t kS{0};

--- a/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
@@ -63,7 +63,10 @@ class ArmFeedforward {
 
   /**
    * Calculates the maximum achievable velocity given a maximum voltage supply,
-   * a position, and an acceleration.
+   * a position, and an acceleration.  Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the acceleration constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the arm.
    * @param angle The angle of the arm
@@ -81,7 +84,10 @@ class ArmFeedforward {
 
   /**
    * Calculates the minimum achievable velocity given a maximum voltage supply,
-   * a position, and an acceleration.
+   * a position, and an acceleration.  Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the acceleration constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the arm.
    * @param angle The angle of the arm
@@ -99,7 +105,10 @@ class ArmFeedforward {
 
   /**
    * Calculates the maximum achievable acceleration given a maximum voltage
-   * supply, a position, and a velocity.
+   * supply, a position, and a velocity. Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the velocity constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the arm.
    * @param angle The angle of the arm
@@ -115,7 +124,10 @@ class ArmFeedforward {
 
   /**
    * Calculates the minimum achievable acceleration given a maximum voltage
-   * supply, a position and a velocity.
+   * supply, a position, and a velocity. Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the velocity constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the arm.
    * @param angle The angle of the arm

--- a/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
@@ -108,7 +108,7 @@ class ArmFeedforward {
    * supply, a position, and a velocity. Useful for ensuring that velocity and
    * acceleration constraints for a trapezoidal profile are simultaneously
    * achievable - enter the velocity constraint, and this will give you
-   * a simultaneously-achievable velocity constraint.
+   * a simultaneously-achievable acceleration constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the arm.
    * @param angle The angle of the arm
@@ -127,7 +127,7 @@ class ArmFeedforward {
    * supply, a position, and a velocity. Useful for ensuring that velocity and
    * acceleration constraints for a trapezoidal profile are simultaneously
    * achievable - enter the velocity constraint, and this will give you
-   * a simultaneously-achievable velocity constraint.
+   * a simultaneously-achievable acceleration constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the arm.
    * @param angle The angle of the arm

--- a/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
@@ -58,6 +58,70 @@ class ArmFeedforward {
            kV * velocity + kA * acceleration;
   }
 
+  /**
+   * Calculates the maximum achievable velocity given a maximum voltage supply,
+   * a position, and an acceleration.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the arm.
+   * @param angle The angle of the arm
+   * @param acceleration The acceleration of the arm.
+   * @return The maximum possible velocity at the given acceleration and angle.
+   */
+  units::unit_t<Velocity> MaxAchievableVelocity(
+      units::volt_t maxVoltage, Angle angle,
+      units::unit_t<Acceleration> acceleration) {
+    return (maxVoltage - kS - kCos * units::math::cos(angle) -
+            kA * acceleration) /
+           kV;
+  }
+
+  /**
+   * Calculates the minimum achievable velocity given a maximum voltage supply,
+   * a position, and an acceleration.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the arm.
+   * @param angle The angle of the arm
+   * @param acceleration The acceleration of the arm.
+   * @return The minimum possible velocity at the given acceleration and angle.
+   */
+  units::unit_t<Velocity> MinAchievableVelocity(
+      units::volt_t maxVoltage, Angle angle,
+      units::unit_t<Acceleration> acceleration) {
+    return (-maxVoltage + kS - kCos * units::math::cos(angle) -
+            kA * acceleration) /
+           kV;
+  }
+
+  /**
+   * Calculates the maximum achievable acceleration given a maximum voltage
+   * supply, a position, and a velocity.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the arm.
+   * @param angle The angle of the arm
+   * @param velocity The velocity of the arm.
+   * @return The maximum possible acceleration at the given velocity and angle.
+   */
+  units::unit_t<Acceleration> MaxAchievableAcceleration(
+      units::volt_t maxVoltage, Angle angle, units::unit_t<Velocity> velocity) {
+    return (maxVoltage - kS * wpi::sgn(velocity) -
+            kCos * units::math::cos(angle) - kV * velocity) /
+           kA;
+  }
+
+  /**
+   * Calculates the minimum achievable acceleration given a maximum voltage
+   * supply, a position and a velocity.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the arm.
+   * @param angle The angle of the arm
+   * @param velocity The velocity of the arm.
+   * @return The minimum possible acceleration at the given velocity and angle.
+   */
+  units::unit_t<Acceleration> MinAchievableAcceleration(
+      units::volt_t maxVoltage, Angle angle, units::unit_t<Velocity> velocity) {
+    return MaxAchievableAcceleration(-maxVoltage, angle, velocity);
+  }
+
   units::volt_t kS{0};
   units::volt_t kCos{0};
   units::unit_t<kv_unit> kV{0};

--- a/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ArmFeedforward.h
@@ -73,6 +73,7 @@ class ArmFeedforward {
   units::unit_t<Velocity> MaxAchievableVelocity(
       units::volt_t maxVoltage, Angle angle,
       units::unit_t<Acceleration> acceleration) {
+    // Assume max velocity is positive
     return (maxVoltage - kS - kCos * units::math::cos(angle) -
             kA * acceleration) /
            kV;
@@ -90,6 +91,7 @@ class ArmFeedforward {
   units::unit_t<Velocity> MinAchievableVelocity(
       units::volt_t maxVoltage, Angle angle,
       units::unit_t<Acceleration> acceleration) {
+    // Assume min velocity is negative, ks flips sign
     return (-maxVoltage + kS - kCos * units::math::cos(angle) -
             kA * acceleration) /
            kV;

--- a/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
@@ -36,9 +36,9 @@ class ElevatorFeedforward {
    * @param kV The velocity gain, in volt seconds per distance.
    * @param kA The acceleration gain, in volt seconds^2 per distance.
    */
-  constexpr ElevatorFeedforward(units::volt_t kS, units::volt_t kG,
-                      units::unit_t<kv_unit> kV,
-                      units::unit_t<ka_unit> kA = units::unit_t<ka_unit>(0))
+  constexpr ElevatorFeedforward(
+      units::volt_t kS, units::volt_t kG, units::unit_t<kv_unit> kV,
+      units::unit_t<ka_unit> kA = units::unit_t<ka_unit>(0))
       : kS(kS), kG(kG), kV(kV), kA(kA) {}
 
   /**
@@ -49,8 +49,8 @@ class ElevatorFeedforward {
    * @return The computed feedforward, in volts.
    */
   constexpr units::volt_t Calculate(units::unit_t<Velocity> velocity,
-                          units::unit_t<Acceleration> acceleration =
-                              units::unit_t<Acceleration>(0)) {
+                                    units::unit_t<Acceleration> acceleration =
+                                        units::unit_t<Acceleration>(0)) {
     return kS * wpi::sgn(velocity) + kG + kV * velocity + kA * acceleration;
   }
 

--- a/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
@@ -26,7 +26,7 @@ class ElevatorFeedforward {
       units::compound_unit<units::volts, units::inverse<Acceleration>>;
 
  public:
-  constexpr ElevatorFeedforward() = default;
+  ElevatorFeedforward() = default;
 
   /**
    * Creates a new ElevatorFeedforward with the specified gains.
@@ -36,10 +36,10 @@ class ElevatorFeedforward {
    * @param kV The velocity gain, in volt seconds per distance.
    * @param kA The acceleration gain, in volt seconds^2 per distance.
    */
-  constexpr ElevatorFeedforward(
-      units::volt_t kS, units::volt_t kG, units::unit_t<kv_unit> kV,
-      units::unit_t<ka_unit> kA = units::unit_t<ka_unit>(0))
-      : m_kS(kS), m_kG(kG), m_kV(kV), m_kA(kA) {}
+  constexpr ElevatorFeedforward(units::volt_t kS, units::volt_t kG,
+                      units::unit_t<kv_unit> kV,
+                      units::unit_t<ka_unit> kA = units::unit_t<ka_unit>(0))
+      : kS(kS), kG(kG), kV(kV), kA(kA) {}
 
   /**
    * Calculates the feedforward from the gains and setpoints.
@@ -49,16 +49,15 @@ class ElevatorFeedforward {
    * @return The computed feedforward, in volts.
    */
   constexpr units::volt_t Calculate(units::unit_t<Velocity> velocity,
-                                    units::unit_t<Acceleration> acceleration =
-                                        units::unit_t<Acceleration>(0)) const {
-    return m_kS * wpi::sgn(velocity) + m_kG + m_kV * velocity +
-           m_kA * acceleration;
+                          units::unit_t<Acceleration> acceleration =
+                              units::unit_t<Acceleration>(0)) {
+    return kS * wpi::sgn(velocity) + kG + kV * velocity +
+           kA * acceleration;
   }
 
- private:
-  units::volt_t m_kS{0};
-  units::volt_t m_kG{0};
-  units::unit_t<kv_unit> m_kV{0};
-  units::unit_t<ka_unit> m_kA{0};
+  units::volt_t kS{0};
+  units::volt_t kG{0};
+  units::unit_t<kv_unit> kV{0};
+  units::unit_t<ka_unit> kA{0};
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
@@ -59,7 +59,10 @@ class ElevatorFeedforward {
 
   /**
    * Calculates the maximum achievable velocity given a maximum voltage supply
-   * and an acceleration.
+   * and an acceleration.  Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the acceleration constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the elevator.
    * @param acceleration The acceleration of the elevator.
@@ -73,7 +76,10 @@ class ElevatorFeedforward {
 
   /**
    * Calculates the minimum achievable velocity given a maximum voltage supply
-   * and an acceleration.
+   * and an acceleration.  Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the acceleration constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the elevator.
    * @param acceleration The acceleration of the elevator.
@@ -87,7 +93,10 @@ class ElevatorFeedforward {
 
   /**
    * Calculates the maximum achievable acceleration given a maximum voltage
-   * supply and a velocity.
+   * supply and a velocity. Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the velocity constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the elevator.
    * @param velocity The velocity of the elevator.
@@ -100,7 +109,10 @@ class ElevatorFeedforward {
 
   /**
    * Calculates the minimum achievable acceleration given a maximum voltage
-   * supply and a velocity.
+   * supply and a velocity. Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the velocity constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the elevator.
    * @param velocity The velocity of the elevator.

--- a/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
@@ -54,6 +54,58 @@ class ElevatorFeedforward {
     return kS * wpi::sgn(velocity) + kG + kV * velocity + kA * acceleration;
   }
 
+  /**
+   * Calculates the maximum achievable velocity given a maximum voltage supply
+   * and an acceleration.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the elevator.
+   * @param acceleration The acceleration of the elevator.
+   * @return The maximum possible velocity at the given acceleration.
+   */
+  constexpr units::unit_t<Velocity> MaxAchievableVelocity(
+      units::volt_t maxVoltage, units::unit_t<Acceleration> acceleration) {
+    return (maxVoltage - kS - kG - kA * acceleration) / kV;
+  }
+
+  /**
+   * Calculates the minimum achievable velocity given a maximum voltage supply
+   * and an acceleration.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the elevator.
+   * @param acceleration The acceleration of the elevator.
+   * @return The minimum possible velocity at the given acceleration.
+   */
+  constexpr units::unit_t<Velocity> MinAchievableVelocity(
+      units::volt_t maxVoltage, units::unit_t<Acceleration> acceleration) {
+    return (-maxVoltage + kS - kG - kA * acceleration) / kV;
+  }
+
+  /**
+   * Calculates the maximum achievable acceleration given a maximum voltage
+   * supply and a velocity.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the elevator.
+   * @param velocity The velocity of the elevator.
+   * @return The maximum possible acceleration at the given velocity.
+   */
+  constexpr units::unit_t<Acceleration> MaxAchievableAcceleration(
+      units::volt_t maxVoltage, units::unit_t<Velocity> velocity) {
+    return (maxVoltage - kS * wpi::sgn(velocity) - kG - kV * velocity) / kA;
+  }
+
+  /**
+   * Calculates the minimum achievable acceleration given a maximum voltage
+   * supply and a velocity.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the elevator.
+   * @param velocity The velocity of the elevator.
+   * @return The minimum possible acceleration at the given velocity.
+   */
+  constexpr units::unit_t<Acceleration> MinAchievableAcceleration(
+      units::volt_t maxVoltage, units::unit_t<Velocity> velocity) {
+    return MaxAchievableAcceleration(-maxVoltage, velocity);
+  }
+
   units::volt_t kS{0};
   units::volt_t kG{0};
   units::unit_t<kv_unit> kV{0};

--- a/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
@@ -54,6 +54,9 @@ class ElevatorFeedforward {
     return kS * wpi::sgn(velocity) + kG + kV * velocity + kA * acceleration;
   }
 
+  // Rearranging the main equation from the calculate() method yields the
+  // formulas for the methods below:
+
   /**
    * Calculates the maximum achievable velocity given a maximum voltage supply
    * and an acceleration.

--- a/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
@@ -67,6 +67,7 @@ class ElevatorFeedforward {
    */
   constexpr units::unit_t<Velocity> MaxAchievableVelocity(
       units::volt_t maxVoltage, units::unit_t<Acceleration> acceleration) {
+    // Assume max velocity is positive
     return (maxVoltage - kS - kG - kA * acceleration) / kV;
   }
 
@@ -80,6 +81,7 @@ class ElevatorFeedforward {
    */
   constexpr units::unit_t<Velocity> MinAchievableVelocity(
       units::volt_t maxVoltage, units::unit_t<Acceleration> acceleration) {
+    // Assume min velocity is negative, ks flips sign
     return (-maxVoltage + kS - kG - kA * acceleration) / kV;
   }
 

--- a/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
@@ -96,7 +96,7 @@ class ElevatorFeedforward {
    * supply and a velocity. Useful for ensuring that velocity and
    * acceleration constraints for a trapezoidal profile are simultaneously
    * achievable - enter the velocity constraint, and this will give you
-   * a simultaneously-achievable velocity constraint.
+   * a simultaneously-achievable acceleration constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the elevator.
    * @param velocity The velocity of the elevator.
@@ -112,7 +112,7 @@ class ElevatorFeedforward {
    * supply and a velocity. Useful for ensuring that velocity and
    * acceleration constraints for a trapezoidal profile are simultaneously
    * achievable - enter the velocity constraint, and this will give you
-   * a simultaneously-achievable velocity constraint.
+   * a simultaneously-achievable acceleration constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the elevator.
    * @param velocity The velocity of the elevator.

--- a/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ElevatorFeedforward.h
@@ -51,8 +51,7 @@ class ElevatorFeedforward {
   constexpr units::volt_t Calculate(units::unit_t<Velocity> velocity,
                           units::unit_t<Acceleration> acceleration =
                               units::unit_t<Acceleration>(0)) {
-    return kS * wpi::sgn(velocity) + kG + kV * velocity +
-           kA * acceleration;
+    return kS * wpi::sgn(velocity) + kG + kV * velocity + kA * acceleration;
   }
 
   units::volt_t kS{0};

--- a/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
@@ -35,10 +35,9 @@ class SimpleMotorFeedforward {
    * @param kV The velocity gain, in volt seconds per distance.
    * @param kA The acceleration gain, in volt seconds^2 per distance.
    */
-  constexpr SimpleMotorFeedforward(
-      units::volt_t kS, units::unit_t<kv_unit> kV,
-      units::unit_t<ka_unit> kA = units::unit_t<ka_unit>(0))
-      : m_kS(kS), m_kV(kV), m_kA(kA) {}
+  constexpr SimpleMotorFeedforward(units::volt_t kS, units::unit_t<kv_unit> kV,
+                         units::unit_t<ka_unit> kA = units::unit_t<ka_unit>(0))
+      : kS(kS), kV(kV), kA(kA) {}
 
   /**
    * Calculates the feedforward from the gains and setpoints.
@@ -50,12 +49,10 @@ class SimpleMotorFeedforward {
   constexpr units::volt_t Calculate(units::unit_t<Velocity> velocity,
                                     units::unit_t<Acceleration> acceleration =
                                         units::unit_t<Acceleration>(0)) const {
-    return m_kS * wpi::sgn(velocity) + m_kV * velocity + m_kA * acceleration;
-  }
+    return kS * wpi::sgn(velocity) + kV * velocity + kA * acceleration;
 
- private:
-  units::volt_t m_kS{0};
-  units::unit_t<kv_unit> m_kV{0};
-  units::unit_t<ka_unit> m_kA{0};
+  units::volt_t kS{0};
+  units::unit_t<kv_unit> kV{0};
+  units::unit_t<ka_unit> kA{0};
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
@@ -55,5 +55,6 @@ class SimpleMotorFeedforward {
     units::volt_t kS{0};
     units::unit_t<kv_unit> kV{0};
     units::unit_t<ka_unit> kA{0};
-  };
+  }
+};
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
@@ -51,10 +51,62 @@ class SimpleMotorFeedforward {
                                     units::unit_t<Acceleration> acceleration =
                                         units::unit_t<Acceleration>(0)) const {
     return kS * wpi::sgn(velocity) + kV * velocity + kA * acceleration;
-
-    units::volt_t kS{0};
-    units::unit_t<kv_unit> kV{0};
-    units::unit_t<ka_unit> kA{0};
   }
+
+  /**
+   * Calculates the maximum achievable velocity given a maximum voltage supply
+   * and an acceleration.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the motor.
+   * @param acceleration The acceleration of the motor.
+   * @return The maximum possible velocity at the given acceleration.
+   */
+  constexpr units::unit_t<Velocity> MaxAchievableVelocity(
+      units::volt_t maxVoltage, units::unit_t<Acceleration> acceleration) {
+    return (maxVoltage - kS - kA * acceleration) / kV;
+  }
+
+  /**
+   * Calculates the minimum achievable velocity given a maximum voltage supply
+   * and an acceleration.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the motor.
+   * @param acceleration The acceleration of the motor.
+   * @return The minimum possible velocity at the given acceleration.
+   */
+  constexpr units::unit_t<Velocity> MinAchievableVelocity(
+      units::volt_t maxVoltage, units::unit_t<Acceleration> acceleration) {
+    return (-maxVoltage + kS - kA * acceleration) / kV;
+  }
+
+  /**
+   * Calculates the maximum achievable acceleration given a maximum voltage
+   * supply and a velocity.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the motor.
+   * @param velocity The velocity of the motor.
+   * @return The maximum possible acceleration at the given velocity.
+   */
+  constexpr units::unit_t<Acceleration> MaxAchievableAcceleration(
+      units::volt_t maxVoltage, units::unit_t<Velocity> velocity) {
+    return (maxVoltage - kS * wpi::sgn(velocity) - kV * velocity) / kA;
+  }
+
+  /**
+   * Calculates the minimum achievable acceleration given a maximum voltage
+   * supply and a velocity.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the motor.
+   * @param velocity The velocity of the motor.
+   * @return The minimum possible acceleration at the given velocity.
+   */
+  constexpr units::unit_t<Acceleration> MinAchievableAcceleration(
+      units::volt_t maxVoltage, units::unit_t<Velocity> velocity) {
+    return MaxAchievableAcceleration(-maxVoltage, velocity);
+  }
+
+  units::volt_t kS{0};
+  units::unit_t<kv_unit> kV{0};
+  units::unit_t<ka_unit> kA{0};
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
@@ -53,6 +53,9 @@ class SimpleMotorFeedforward {
     return kS * wpi::sgn(velocity) + kV * velocity + kA * acceleration;
   }
 
+  // Rearranging the main equation from the calculate() method yields the
+  // formulas for the methods below:
+
   /**
    * Calculates the maximum achievable velocity given a maximum voltage supply
    * and an acceleration.

--- a/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
@@ -66,6 +66,7 @@ class SimpleMotorFeedforward {
    */
   constexpr units::unit_t<Velocity> MaxAchievableVelocity(
       units::volt_t maxVoltage, units::unit_t<Acceleration> acceleration) {
+    // Assume max velocity is positive
     return (maxVoltage - kS - kA * acceleration) / kV;
   }
 
@@ -79,6 +80,7 @@ class SimpleMotorFeedforward {
    */
   constexpr units::unit_t<Velocity> MinAchievableVelocity(
       units::volt_t maxVoltage, units::unit_t<Acceleration> acceleration) {
+    // Assume min velocity is positive, ks flips sign
     return (-maxVoltage + kS - kA * acceleration) / kV;
   }
 

--- a/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
@@ -95,7 +95,7 @@ class SimpleMotorFeedforward {
    * supply and a velocity. Useful for ensuring that velocity and
    * acceleration constraints for a trapezoidal profile are simultaneously
    * achievable - enter the velocity constraint, and this will give you
-   * a simultaneously-achievable velocity constraint.
+   * a simultaneously-achievable acceleration constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the motor.
    * @param velocity The velocity of the motor.
@@ -111,7 +111,7 @@ class SimpleMotorFeedforward {
    * supply and a velocity. Useful for ensuring that velocity and
    * acceleration constraints for a trapezoidal profile are simultaneously
    * achievable - enter the velocity constraint, and this will give you
-   * a simultaneously-achievable velocity constraint..
+   * a simultaneously-achievable acceleration constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the motor.
    * @param velocity The velocity of the motor.

--- a/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
@@ -35,8 +35,9 @@ class SimpleMotorFeedforward {
    * @param kV The velocity gain, in volt seconds per distance.
    * @param kA The acceleration gain, in volt seconds^2 per distance.
    */
-  constexpr SimpleMotorFeedforward(units::volt_t kS, units::unit_t<kv_unit> kV,
-                         units::unit_t<ka_unit> kA = units::unit_t<ka_unit>(0))
+  constexpr SimpleMotorFeedforward(
+      units::volt_t kS, units::unit_t<kv_unit> kV,
+      units::unit_t<ka_unit> kA = units::unit_t<ka_unit>(0))
       : kS(kS), kV(kV), kA(kA) {}
 
   /**
@@ -51,8 +52,8 @@ class SimpleMotorFeedforward {
                                         units::unit_t<Acceleration>(0)) const {
     return kS * wpi::sgn(velocity) + kV * velocity + kA * acceleration;
 
-  units::volt_t kS{0};
-  units::unit_t<kv_unit> kV{0};
-  units::unit_t<ka_unit> kA{0};
-};
+    units::volt_t kS{0};
+    units::unit_t<kv_unit> kV{0};
+    units::unit_t<ka_unit> kA{0};
+  };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/SimpleMotorFeedforward.h
@@ -58,7 +58,10 @@ class SimpleMotorFeedforward {
 
   /**
    * Calculates the maximum achievable velocity given a maximum voltage supply
-   * and an acceleration.
+   * and an acceleration.  Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the acceleration constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the motor.
    * @param acceleration The acceleration of the motor.
@@ -72,7 +75,10 @@ class SimpleMotorFeedforward {
 
   /**
    * Calculates the minimum achievable velocity given a maximum voltage supply
-   * and an acceleration.
+   * and an acceleration.  Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the acceleration constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the motor.
    * @param acceleration The acceleration of the motor.
@@ -86,7 +92,10 @@ class SimpleMotorFeedforward {
 
   /**
    * Calculates the maximum achievable acceleration given a maximum voltage
-   * supply and a velocity.
+   * supply and a velocity. Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the velocity constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the motor.
    * @param velocity The velocity of the motor.
@@ -99,7 +108,10 @@ class SimpleMotorFeedforward {
 
   /**
    * Calculates the minimum achievable acceleration given a maximum voltage
-   * supply and a velocity.
+   * supply and a velocity. Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the velocity constraint, and this will give you
+   * a simultaneously-achievable velocity constraint..
    *
    * @param maxVoltage The maximum voltage that can be supplied to the motor.
    * @param velocity The velocity of the motor.

--- a/wpilibc/src/main/native/include/frc/kinematics/DifferentialDriveKinematics.h
+++ b/wpilibc/src/main/native/include/frc/kinematics/DifferentialDriveKinematics.h
@@ -32,7 +32,7 @@ class DifferentialDriveKinematics {
    * scrubbing effects.
    */
   constexpr explicit DifferentialDriveKinematics(units::meter_t trackWidth)
-      : m_trackWidth(trackWidth) {}
+      : trackWidth(trackWidth) {}
 
   /**
    * Returns a chassis speed from left and right component velocities using
@@ -44,7 +44,7 @@ class DifferentialDriveKinematics {
   constexpr ChassisSpeeds ToChassisSpeeds(
       const DifferentialDriveWheelSpeeds& wheelSpeeds) const {
     return {(wheelSpeeds.left + wheelSpeeds.right) / 2.0, 0_mps,
-            (wheelSpeeds.right - wheelSpeeds.left) / m_trackWidth * 1_rad};
+            (wheelSpeeds.right - wheelSpeeds.left) / trackWidth * 1_rad};
   }
 
   /**
@@ -57,11 +57,10 @@ class DifferentialDriveKinematics {
    */
   constexpr DifferentialDriveWheelSpeeds ToWheelSpeeds(
       const ChassisSpeeds& chassisSpeeds) const {
-    return {chassisSpeeds.vx - m_trackWidth / 2 * chassisSpeeds.omega / 1_rad,
-            chassisSpeeds.vx + m_trackWidth / 2 * chassisSpeeds.omega / 1_rad};
+    return {chassisSpeeds.vx - trackWidth / 2 * chassisSpeeds.omega / 1_rad,
+            chassisSpeeds.vx + trackWidth / 2 * chassisSpeeds.omega / 1_rad};
   }
 
- private:
-  units::meter_t m_trackWidth;
+  units::meter_t trackWidth;
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h
@@ -13,15 +13,25 @@
 #include "frc/kinematics/DifferentialDriveKinematics.h"
 #include "frc/trajectory/constraint/TrajectoryConstraint.h"
 
-/**
- * A class that enforces constraints on the differential drive kinematics.
- * This can be used to ensure that the trajectory is constructed so that the
- * commanded velocities for both sides of the drivetrain stay below a certain
- * limit.
- */
 namespace frc {
+/**
+ * A class that enforces constraints on differential drive voltage expenditure
+ * based on the motor dynamics and the drive kinematics.  Ensures that the
+ * acceleration of any wheel of the robot while following the trajectory is
+ * never higher than what can be achieved with the given maximum voltage.
+ */
 class DifferentialDriveVoltageConstraint : public TrajectoryConstraint {
  public:
+  /**
+   * Creates a new DifferentialDriveVoltageConstraint.
+   *
+   * @param feedforward A feedforward component describing the behavior of the
+   * drive.
+   * @param kinematics  A kinematics component describing the drive geometry.
+   * @param maxVoltage  The maximum voltage available to the motors while
+   * following the path. Should be somewhat less than the nominal battery
+   * voltage (12V) to account for "voltage sag" due to current draw.
+   */
   DifferentialDriveVoltageConstraint(
       SimpleMotorFeedforward<units::meter> feedforward,
       DifferentialDriveKinematics kinematics, units::volt_t maxVoltage);

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h
@@ -1,0 +1,41 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <units/units.h>
+
+#include "frc/controller/SimpleMotorFeedforward.h"
+#include "frc/kinematics/DifferentialDriveKinematics.h"
+#include "frc/trajectory/constraint/TrajectoryConstraint.h"
+
+/**
+ * A class that enforces constraints on the differential drive kinematics.
+ * This can be used to ensure that the trajectory is constructed so that the
+ * commanded velocities for both sides of the drivetrain stay below a certain
+ * limit.
+ */
+namespace frc {
+class DifferentialDriveVoltageConstraint : public TrajectoryConstraint {
+ public:
+  DifferentialDriveVoltageConstraint(
+      SimpleMotorFeedforward<units::meter> feedforward,
+      DifferentialDriveKinematics kinematics, units::volt_t maxVoltage);
+
+  units::meters_per_second_t MaxVelocity(
+      const Pose2d& pose, curvature_t curvature,
+      units::meters_per_second_t velocity) override;
+
+  MinMax MinMaxAcceleration(const Pose2d& pose, curvature_t curvature,
+                            units::meters_per_second_t speed) override;
+
+ private:
+  SimpleMotorFeedforward<units::meter> m_feedforward;
+  DifferentialDriveKinematics m_kinematics;
+  units::volt_t m_maxVoltage;
+};
+}  // namespace frc

--- a/wpilibc/src/test/native/cpp/trajectory/DifferentialDriveVoltageTest.cpp
+++ b/wpilibc/src/test/native/cpp/trajectory/DifferentialDriveVoltageTest.cpp
@@ -1,0 +1,59 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <iostream>
+#include <memory>
+#include <vector>
+
+#include <units/units.h>
+
+#include "frc/kinematics/DifferentialDriveKinematics.h"
+#include "frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h"
+#include "gtest/gtest.h"
+#include "trajectory/TestTrajectory.h"
+
+using namespace frc;
+
+TEST(DifferentialDriveVoltageConstraintTest, Constraint) {
+  // Pick an unreasonably large kA to ensure the constraint has to do some work
+  SimpleMotorFeedforward<units::meter> feedforward{1_V, 1_V / 1_mps,
+                                                   3_V / 1_mps_sq};
+  const DifferentialDriveKinematics kinematics{0.5_m};
+  const auto maxVoltage = 10_V;
+
+  auto config = TrajectoryConfig(12_fps, 12_fps_sq);
+  config.AddConstraint(
+      DifferentialDriveVoltageConstraint(feedforward, kinematics, maxVoltage));
+
+  auto trajectory = TestTrajectory::GetTrajectory(config);
+
+  units::second_t time = 0_s;
+  units::second_t dt = 20_ms;
+  units::second_t duration = trajectory.TotalTime();
+
+  while (time < duration) {
+    const Trajectory::State point = trajectory.Sample(time);
+    time += dt;
+
+    const ChassisSpeeds chassisSpeeds{point.velocity, 0_mps,
+                                      point.velocity * point.curvature};
+
+    auto [left, right] = kinematics.ToWheelSpeeds(chassisSpeeds);
+
+    // Not really a strictly-correct test as we're using the chassis accel
+    // instead of the wheel accel, but much easier than doing it "properly" and
+    // a reasonable check anyway
+    EXPECT_TRUE(feedforward.Calculate(left, point.acceleration) <
+                maxVoltage + 0.05_V);
+    EXPECT_TRUE(feedforward.Calculate(left, point.acceleration) >
+                -maxVoltage - 0.05_V);
+    EXPECT_TRUE(feedforward.Calculate(right, point.acceleration) <
+                maxVoltage + 0.05_V);
+    EXPECT_TRUE(feedforward.Calculate(right, point.acceleration) >
+                -maxVoltage - 0.05_V);
+  }
+}

--- a/wpilibcExamples/src/main/cpp/examples/RamseteCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RamseteCommand/cpp/RobotContainer.cpp
@@ -12,7 +12,7 @@
 #include <frc/shuffleboard/Shuffleboard.h>
 #include <frc/trajectory/Trajectory.h>
 #include <frc/trajectory/TrajectoryGenerator.h>
-#include <frc/trajectory/constraint/DifferentialDriveKinematicsConstraint.h>
+#include <frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h>
 #include <frc2/command/InstantCommand.h>
 #include <frc2/command/RamseteCommand.h>
 #include <frc2/command/SequentialCommandGroup.h>
@@ -44,11 +44,19 @@ void RobotContainer::ConfigureButtonBindings() {
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {
+  // Create a voltage constraint to ensure we don't accelerate too fast
+  frc::DifferentialDriveVoltageConstraint autoVoltageConstraint(
+      frc::SimpleMotorFeedforward<units::meters>(
+          DriveConstants::ks, DriveConstants::kv, DriveConstants::ka),
+      DriveConstants::kDriveKinematics, 10_V);
+
   // Set up config for trajectory
   frc::TrajectoryConfig config(AutoConstants::kMaxSpeed,
                                AutoConstants::kMaxAcceleration);
   // Add kinematics to ensure max speed is actually obeyed
   config.SetKinematics(DriveConstants::kDriveKinematics);
+  // Apply the voltage constraint
+  config.AddConstraint(autoVoltageConstraint);
 
   // An example trajectory to follow.  All units in meters.
   auto exampleTrajectory = frc::TrajectoryGenerator::GenerateTrajectory(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ArmFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ArmFeedforward.java
@@ -113,7 +113,7 @@ public class ArmFeedforward {
    * supply, a position, and a velocity. Useful for ensuring that velocity and
    * acceleration constraints for a trapezoidal profile are simultaneously
    * achievable - enter the velocity constraint, and this will give you
-   * a simultaneously-achievable velocity constraint.
+   * a simultaneously-achievable acceleration constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the arm.
    * @param angle The angle of the arm.
@@ -129,7 +129,7 @@ public class ArmFeedforward {
    * supply, a position, and a velocity. Useful for ensuring that velocity and
    * acceleration constraints for a trapezoidal profile are simultaneously
    * achievable - enter the velocity constraint, and this will give you
-   * a simultaneously-achievable velocity constraint.
+   * a simultaneously-achievable acceleration constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the arm.
    * @param angle The angle of the arm.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ArmFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ArmFeedforward.java
@@ -11,11 +11,12 @@ package edu.wpi.first.wpilibj.controller;
  * A helper class that computes feedforward outputs for a simple arm (modeled as a motor
  * acting against the force of gravity on a beam suspended at an angle).
  */
+@SuppressWarnings("MemberName")
 public class ArmFeedforward {
-  private final double m_ks;
-  private final double m_kcos;
-  private final double m_kv;
-  private final double m_ka;
+  public final double ks;
+  public final double kcos;
+  public final double kv;
+  public final double ka;
 
   /**
    * Creates a new ArmFeedforward with the specified gains.  Units of the gain values
@@ -27,10 +28,10 @@ public class ArmFeedforward {
    * @param ka   The acceleration gain.
    */
   public ArmFeedforward(double ks, double kcos, double kv, double ka) {
-    m_ks = ks;
-    m_kcos = kcos;
-    m_kv = kv;
-    m_ka = ka;
+    this.ks = ks;
+    this.kcos = kcos;
+    this.kv = kv;
+    this.ka = ka;
   }
 
   /**
@@ -54,9 +55,9 @@ public class ArmFeedforward {
    */
   public double calculate(double positionRadians, double velocityRadPerSec,
                           double accelRadPerSecSquared) {
-    return m_ks * Math.signum(velocityRadPerSec) + m_kcos * Math.cos(positionRadians)
-        + m_kv * velocityRadPerSec
-        + m_ka * accelRadPerSecSquared;
+    return ks * Math.signum(velocityRadPerSec) + kcos * Math.cos(positionRadians)
+        + kv * velocityRadPerSec
+        + ka * accelRadPerSecSquared;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ArmFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ArmFeedforward.java
@@ -60,6 +60,9 @@ public class ArmFeedforward {
         + ka * accelRadPerSecSquared;
   }
 
+  // Rearranging the main equation from the calculate() method yields the
+  // formulas for the methods below:
+
   /**
    * Calculates the feedforward from the gains and velocity setpoint (acceleration is assumed to
    * be zero).

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ArmFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ArmFeedforward.java
@@ -70,4 +70,56 @@ public class ArmFeedforward {
   public double calculate(double positionRadians, double velocity) {
     return calculate(positionRadians, velocity, 0);
   }
+
+  /**
+   * Calculates the maximum achievable velocity given a maximum voltage supply, a position, and an
+   * acceleration.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the arm.
+   * @param angle The angle of the arm.
+   * @param acceleration The acceleration of the arm.
+   * @return The maximum possible velocity at the given acceleration and angle.
+   */
+  public double maxAchievableVelocity(double maxVoltage, double angle, double acceleration) {
+    return (maxVoltage - ks - Math.cos(angle) * kcos - acceleration * ka) / kv;
+  }
+
+  /**
+   * Calculates the minimum achievable velocity given a maximum voltage supply, a position, and an
+   * acceleration.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the arm.
+   * @param angle The angle of the arm.
+   * @param acceleration The acceleration of the arm.
+   * @return The minimum possible velocity at the given acceleration and angle.
+   */
+  public double minAchievableVelocity(double maxVoltage, double angle, double acceleration) {
+    return (-maxVoltage + ks - Math.cos(angle) * kcos - acceleration * ka) / kv;
+  }
+
+  /**
+   * Calculates the maximum achievable acceleration given a maximum voltage supply, a position,
+   * and a velocity.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the arm.
+   * @param angle The angle of the arm.
+   * @param velocity The velocity of the arm.
+   * @return The maximum possible acceleration at the given velocity.
+   */
+  public double maxAchievableAcceleration(double maxVoltage, double angle, double velocity) {
+    return (maxVoltage - ks * Math.signum(velocity) - Math.cos(angle) * kcos - velocity * kv) / ka;
+  }
+
+  /**
+   * Calculates the minimum achievable acceleration given a maximum voltage supply, a position,
+   * and a velocity.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the arm.
+   * @param angle The angle of the arm.
+   * @param velocity The velocity of the arm.
+   * @return The minimum possible acceleration at the given velocity.
+   */
+  public double minAchievableAcceleration(double maxVoltage, double angle, double velocity) {
+    return maxAchievableAcceleration(-maxVoltage, angle, velocity);
+  }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ArmFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ArmFeedforward.java
@@ -75,8 +75,11 @@ public class ArmFeedforward {
   // formulas for the methods below:
 
   /**
-   * Calculates the maximum achievable velocity given a maximum voltage supply, a position, and an
-   * acceleration.
+   * Calculates the maximum achievable velocity given a maximum voltage supply,
+   * a position, and an acceleration.  Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the acceleration constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the arm.
    * @param angle The angle of the arm.
@@ -89,8 +92,11 @@ public class ArmFeedforward {
   }
 
   /**
-   * Calculates the minimum achievable velocity given a maximum voltage supply, a position, and an
-   * acceleration.
+   * Calculates the minimum achievable velocity given a maximum voltage supply,
+   * a position, and an acceleration.  Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the acceleration constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the arm.
    * @param angle The angle of the arm.
@@ -103,8 +109,11 @@ public class ArmFeedforward {
   }
 
   /**
-   * Calculates the maximum achievable acceleration given a maximum voltage supply, a position,
-   * and a velocity.
+   * Calculates the maximum achievable acceleration given a maximum voltage
+   * supply, a position, and a velocity. Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the velocity constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the arm.
    * @param angle The angle of the arm.
@@ -116,8 +125,11 @@ public class ArmFeedforward {
   }
 
   /**
-   * Calculates the minimum achievable acceleration given a maximum voltage supply, a position,
-   * and a velocity.
+   * Calculates the minimum achievable acceleration given a maximum voltage
+   * supply, a position, and a velocity. Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the velocity constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the arm.
    * @param angle The angle of the arm.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ArmFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ArmFeedforward.java
@@ -60,9 +60,6 @@ public class ArmFeedforward {
         + ka * accelRadPerSecSquared;
   }
 
-  // Rearranging the main equation from the calculate() method yields the
-  // formulas for the methods below:
-
   /**
    * Calculates the feedforward from the gains and velocity setpoint (acceleration is assumed to
    * be zero).
@@ -74,6 +71,9 @@ public class ArmFeedforward {
     return calculate(positionRadians, velocity, 0);
   }
 
+  // Rearranging the main equation from the calculate() method yields the
+  // formulas for the methods below:
+
   /**
    * Calculates the maximum achievable velocity given a maximum voltage supply, a position, and an
    * acceleration.
@@ -84,6 +84,7 @@ public class ArmFeedforward {
    * @return The maximum possible velocity at the given acceleration and angle.
    */
   public double maxAchievableVelocity(double maxVoltage, double angle, double acceleration) {
+    // Assume max velocity is positive
     return (maxVoltage - ks - Math.cos(angle) * kcos - acceleration * ka) / kv;
   }
 
@@ -97,6 +98,7 @@ public class ArmFeedforward {
    * @return The minimum possible velocity at the given acceleration and angle.
    */
   public double minAchievableVelocity(double maxVoltage, double angle, double acceleration) {
+    // Assume min velocity is negative, ks flips sign
     return (-maxVoltage + ks - Math.cos(angle) * kcos - acceleration * ka) / kv;
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ElevatorFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ElevatorFeedforward.java
@@ -11,11 +11,12 @@ package edu.wpi.first.wpilibj.controller;
  * A helper class that computes feedforward outputs for a simple elevator (modeled as a motor
  * acting against the force of gravity).
  */
+@SuppressWarnings("MemberName")
 public class ElevatorFeedforward {
-  private final double m_ks;
-  private final double m_kg;
-  private final double m_kv;
-  private final double m_ka;
+  public final double ks;
+  public final double kg;
+  public final double kv;
+  public final double ka;
 
   /**
    * Creates a new ElevatorFeedforward with the specified gains.  Units of the gain values
@@ -27,10 +28,10 @@ public class ElevatorFeedforward {
    * @param ka The acceleration gain.
    */
   public ElevatorFeedforward(double ks, double kg, double kv, double ka) {
-    m_ks = ks;
-    m_kg = kg;
-    m_kv = kv;
-    m_ka = ka;
+    this.ks = ks;
+    this.kg = kg;
+    this.kv = kv;
+    this.ka = ka;
   }
 
   /**
@@ -53,7 +54,7 @@ public class ElevatorFeedforward {
    * @return The computed feedforward.
    */
   public double calculate(double velocity, double acceleration) {
-    return m_ks * Math.signum(velocity) + m_kg + m_kv * velocity + m_ka * acceleration;
+    return ks * Math.signum(velocity) + kg + kv * velocity + ka * acceleration;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ElevatorFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ElevatorFeedforward.java
@@ -67,4 +67,48 @@ public class ElevatorFeedforward {
   public double calculate(double velocity) {
     return calculate(velocity, 0);
   }
+
+  /**
+   * Calculates the maximum achievable velocity given a maximum voltage supply and an acceleration.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the elevator.
+   * @param acceleration The acceleration of the elevator.
+   * @return The maximum possible velocity at the given acceleration.
+   */
+  public double maxAchievableVelocity(double maxVoltage, double acceleration) {
+    return (maxVoltage - ks - kg - acceleration * ka) / kv;
+  }
+
+  /**
+   * Calculates the minimum achievable velocity given a maximum voltage supply and an acceleration.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the elevator.
+   * @param acceleration The acceleration of the elevator.
+   * @return The minimum possible velocity at the given acceleration.
+   */
+  public double minAchievableVelocity(double maxVoltage, double acceleration) {
+    return (-maxVoltage + ks - kg - acceleration * ka) / kv;
+  }
+
+  /**
+   * Calculates the maximum achievable acceleration given a maximum voltage supply and a velocity.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the elevator.
+   * @param velocity The velocity of the elevator.
+   * @return The maximum possible acceleration at the given velocity.
+   */
+  public double maxAchievableAcceleration(double maxVoltage, double velocity) {
+    return (maxVoltage - ks * Math.signum(velocity) - kg - velocity * kv) / ka;
+  }
+
+  /**
+   * Calculates the minimum achievable acceleration given a maximum voltage supply and a velocity.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the elevator.
+   * @param velocity The velocity of the elevator.
+   * @return The minimum possible acceleration at the given velocity.
+   */
+  public double minAchievableAcceleration(double maxVoltage, double velocity) {
+    return maxAchievableAcceleration(-maxVoltage, velocity);
+  }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ElevatorFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ElevatorFeedforward.java
@@ -57,9 +57,6 @@ public class ElevatorFeedforward {
     return ks * Math.signum(velocity) + kg + kv * velocity + ka * acceleration;
   }
 
-  // Rearranging the main equation from the calculate() method yields the
-  // formulas for the methods below:
-
   /**
    * Calculates the feedforward from the gains and velocity setpoint (acceleration is assumed to
    * be zero).
@@ -71,6 +68,9 @@ public class ElevatorFeedforward {
     return calculate(velocity, 0);
   }
 
+  // Rearranging the main equation from the calculate() method yields the
+  // formulas for the methods below:
+
   /**
    * Calculates the maximum achievable velocity given a maximum voltage supply and an acceleration.
    *
@@ -79,6 +79,7 @@ public class ElevatorFeedforward {
    * @return The maximum possible velocity at the given acceleration.
    */
   public double maxAchievableVelocity(double maxVoltage, double acceleration) {
+    // Assume max velocity is positive
     return (maxVoltage - ks - kg - acceleration * ka) / kv;
   }
 
@@ -90,6 +91,7 @@ public class ElevatorFeedforward {
    * @return The minimum possible velocity at the given acceleration.
    */
   public double minAchievableVelocity(double maxVoltage, double acceleration) {
+    // Assume min velocity is negative, ks flips sign
     return (-maxVoltage + ks - kg - acceleration * ka) / kv;
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ElevatorFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ElevatorFeedforward.java
@@ -72,7 +72,11 @@ public class ElevatorFeedforward {
   // formulas for the methods below:
 
   /**
-   * Calculates the maximum achievable velocity given a maximum voltage supply and an acceleration.
+   * Calculates the maximum achievable velocity given a maximum voltage supply
+   * and an acceleration.  Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the acceleration constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the elevator.
    * @param acceleration The acceleration of the elevator.
@@ -84,7 +88,11 @@ public class ElevatorFeedforward {
   }
 
   /**
-   * Calculates the minimum achievable velocity given a maximum voltage supply and an acceleration.
+   * Calculates the minimum achievable velocity given a maximum voltage supply
+   * and an acceleration.  Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the acceleration constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the elevator.
    * @param acceleration The acceleration of the elevator.
@@ -96,7 +104,11 @@ public class ElevatorFeedforward {
   }
 
   /**
-   * Calculates the maximum achievable acceleration given a maximum voltage supply and a velocity.
+   * Calculates the maximum achievable acceleration given a maximum voltage
+   * supply and a velocity. Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the velocity constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the elevator.
    * @param velocity The velocity of the elevator.
@@ -107,7 +119,11 @@ public class ElevatorFeedforward {
   }
 
   /**
-   * Calculates the minimum achievable acceleration given a maximum voltage supply and a velocity.
+   * Calculates the minimum achievable acceleration given a maximum voltage
+   * supply and a velocity. Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the velocity constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the elevator.
    * @param velocity The velocity of the elevator.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ElevatorFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ElevatorFeedforward.java
@@ -57,6 +57,9 @@ public class ElevatorFeedforward {
     return ks * Math.signum(velocity) + kg + kv * velocity + ka * acceleration;
   }
 
+  // Rearranging the main equation from the calculate() method yields the
+  // formulas for the methods below:
+
   /**
    * Calculates the feedforward from the gains and velocity setpoint (acceleration is assumed to
    * be zero).

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ElevatorFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ElevatorFeedforward.java
@@ -108,7 +108,7 @@ public class ElevatorFeedforward {
    * supply and a velocity. Useful for ensuring that velocity and
    * acceleration constraints for a trapezoidal profile are simultaneously
    * achievable - enter the velocity constraint, and this will give you
-   * a simultaneously-achievable velocity constraint.
+   * a simultaneously-achievable acceleration constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the elevator.
    * @param velocity The velocity of the elevator.
@@ -123,7 +123,7 @@ public class ElevatorFeedforward {
    * supply and a velocity. Useful for ensuring that velocity and
    * acceleration constraints for a trapezoidal profile are simultaneously
    * achievable - enter the velocity constraint, and this will give you
-   * a simultaneously-achievable velocity constraint.
+   * a simultaneously-achievable acceleration constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the elevator.
    * @param velocity The velocity of the elevator.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
@@ -103,7 +103,7 @@ public class SimpleMotorFeedforward {
    * supply and a velocity. Useful for ensuring that velocity and
    * acceleration constraints for a trapezoidal profile are simultaneously
    * achievable - enter the velocity constraint, and this will give you
-   * a simultaneously-achievable velocity constraint.
+   * a simultaneously-achievable acceleration constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the motor.
    * @param velocity The velocity of the motor.
@@ -118,7 +118,7 @@ public class SimpleMotorFeedforward {
    * supply and a velocity. Useful for ensuring that velocity and
    * acceleration constraints for a trapezoidal profile are simultaneously
    * achievable - enter the velocity constraint, and this will give you
-   * a simultaneously-achievable velocity constraint.
+   * a simultaneously-achievable acceleration constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the motor.
    * @param velocity The velocity of the motor.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
@@ -74,6 +74,7 @@ public class SimpleMotorFeedforward {
    * @return The maximum possible velocity at the given acceleration.
    */
   public double maxAchievableVelocity(double maxVoltage, double acceleration) {
+    // Assume max velocity is positive
     return (maxVoltage - ks - acceleration * ka) / kv;
   }
 
@@ -85,6 +86,7 @@ public class SimpleMotorFeedforward {
    * @return The minimum possible velocity at the given acceleration.
    */
   public double minAchievableVelocity(double maxVoltage, double acceleration) {
+    // Assume min velocity is negative, ks flips sign
     return (-maxVoltage + ks - acceleration * ka) / kv;
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
@@ -52,6 +52,9 @@ public class SimpleMotorFeedforward {
     return ks * Math.signum(velocity) + kv * velocity + ka * acceleration;
   }
 
+  // Rearranging the main equation from the calculate() method yields the
+  // formulas for the methods below:
+
   /**
    * Calculates the feedforward from the gains and velocity setpoint (acceleration is assumed to
    * be zero).

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
@@ -10,7 +10,7 @@ package edu.wpi.first.wpilibj.controller;
 /**
  * A helper class that computes feedforward outputs for a simple permanent-magnet DC motor.
  */
-@SuppressWarnings("MemberNames")
+@SuppressWarnings("MemberName")
 public class SimpleMotorFeedforward {
   public final double ks;
   public final double kv;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
@@ -10,10 +10,11 @@ package edu.wpi.first.wpilibj.controller;
 /**
  * A helper class that computes feedforward outputs for a simple permanent-magnet DC motor.
  */
+@SuppressWarnings("MemberNames")
 public class SimpleMotorFeedforward {
-  private final double m_ks;
-  private final double m_kv;
-  private final double m_ka;
+  public final double ks;
+  public final double kv;
+  public final double ka;
 
   /**
    * Creates a new SimpleMotorFeedforward with the specified gains.  Units of the gain values
@@ -24,9 +25,9 @@ public class SimpleMotorFeedforward {
    * @param ka The acceleration gain.
    */
   public SimpleMotorFeedforward(double ks, double kv, double ka) {
-    m_ks = ks;
-    m_kv = kv;
-    m_ka = ka;
+    this.ks = ks;
+    this.kv = kv;
+    this.ka = ka;
   }
 
   /**
@@ -48,7 +49,7 @@ public class SimpleMotorFeedforward {
    * @return The computed feedforward.
    */
   public double calculate(double velocity, double acceleration) {
-    return m_ks * Math.signum(velocity) + m_kv * velocity + m_ka * acceleration;
+    return ks * Math.signum(velocity) + kv * velocity + ka * acceleration;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
@@ -62,4 +62,48 @@ public class SimpleMotorFeedforward {
   public double calculate(double velocity) {
     return calculate(velocity, 0);
   }
+
+  /**
+   * Calculates the maximum achievable velocity given a maximum voltage supply and an acceleration.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the motor.
+   * @param acceleration The acceleration of the motor.
+   * @return The maximum possible velocity at the given acceleration.
+   */
+  public double maxAchievableVelocity(double maxVoltage, double acceleration) {
+    return (maxVoltage - ks - acceleration * ka) / kv;
+  }
+
+  /**
+   * Calculates the minimum achievable velocity given a maximum voltage supply and an acceleration.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the motor.
+   * @param acceleration The acceleration of the motor.
+   * @return The minimum possible velocity at the given acceleration.
+   */
+  public double minAchievableVelocity(double maxVoltage, double acceleration) {
+    return (-maxVoltage + ks - acceleration * ka) / kv;
+  }
+
+  /**
+   * Calculates the maximum achievable acceleration given a maximum voltage supply and a velocity.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the motor.
+   * @param velocity The velocity of the motor.
+   * @return The maximum possible acceleration at the given velocity.
+   */
+  public double maxAchievableAcceleration(double maxVoltage, double velocity) {
+    return (maxVoltage - ks * Math.signum(velocity) - velocity * kv) / ka;
+  }
+
+  /**
+   * Calculates the minimum achievable acceleration given a maximum voltage supply and a velocity.
+   *
+   * @param maxVoltage The maximum voltage that can be supplied to the motor.
+   * @param velocity The velocity of the motor.
+   * @return The minimum possible acceleration at the given velocity.
+   */
+  public double minAchievableAcceleration(double maxVoltage, double velocity) {
+    return maxAchievableAcceleration(-maxVoltage, velocity);
+  }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/SimpleMotorFeedforward.java
@@ -67,7 +67,11 @@ public class SimpleMotorFeedforward {
   }
 
   /**
-   * Calculates the maximum achievable velocity given a maximum voltage supply and an acceleration.
+   * Calculates the maximum achievable velocity given a maximum voltage supply
+   * and an acceleration.  Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the acceleration constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the motor.
    * @param acceleration The acceleration of the motor.
@@ -79,7 +83,11 @@ public class SimpleMotorFeedforward {
   }
 
   /**
-   * Calculates the minimum achievable velocity given a maximum voltage supply and an acceleration.
+   * Calculates the minimum achievable velocity given a maximum voltage supply
+   * and an acceleration.  Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the acceleration constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the motor.
    * @param acceleration The acceleration of the motor.
@@ -91,7 +99,11 @@ public class SimpleMotorFeedforward {
   }
 
   /**
-   * Calculates the maximum achievable acceleration given a maximum voltage supply and a velocity.
+   * Calculates the maximum achievable acceleration given a maximum voltage
+   * supply and a velocity. Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the velocity constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the motor.
    * @param velocity The velocity of the motor.
@@ -102,7 +114,11 @@ public class SimpleMotorFeedforward {
   }
 
   /**
-   * Calculates the minimum achievable acceleration given a maximum voltage supply and a velocity.
+   * Calculates the maximum achievable acceleration given a maximum voltage
+   * supply and a velocity. Useful for ensuring that velocity and
+   * acceleration constraints for a trapezoidal profile are simultaneously
+   * achievable - enter the velocity constraint, and this will give you
+   * a simultaneously-achievable velocity constraint.
    *
    * @param maxVoltage The maximum voltage that can be supplied to the motor.
    * @param velocity The velocity of the motor.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/kinematics/DifferentialDriveKinematics.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/kinematics/DifferentialDriveKinematics.java
@@ -15,8 +15,9 @@ package edu.wpi.first.wpilibj.kinematics;
  * velocity components whereas forward kinematics converts left and right
  * component velocities into a linear and angular chassis speed.
  */
+@SuppressWarnings("MemberNames")
 public class DifferentialDriveKinematics {
-  private final double m_trackWidthMeters;
+  public final double trackWidthMeters;
 
   /**
    * Constructs a differential drive kinematics object.
@@ -27,7 +28,7 @@ public class DifferentialDriveKinematics {
    *                         measured value due to scrubbing effects.
    */
   public DifferentialDriveKinematics(double trackWidthMeters) {
-    m_trackWidthMeters = trackWidthMeters;
+    this.trackWidthMeters = trackWidthMeters;
   }
 
   /**
@@ -41,7 +42,7 @@ public class DifferentialDriveKinematics {
     return new ChassisSpeeds(
         (wheelSpeeds.leftMetersPerSecond + wheelSpeeds.rightMetersPerSecond) / 2, 0,
         (wheelSpeeds.rightMetersPerSecond - wheelSpeeds.leftMetersPerSecond)
-            / m_trackWidthMeters
+            / trackWidthMeters
     );
   }
 
@@ -55,9 +56,9 @@ public class DifferentialDriveKinematics {
    */
   public DifferentialDriveWheelSpeeds toWheelSpeeds(ChassisSpeeds chassisSpeeds) {
     return new DifferentialDriveWheelSpeeds(
-        chassisSpeeds.vxMetersPerSecond - m_trackWidthMeters / 2
+        chassisSpeeds.vxMetersPerSecond - trackWidthMeters / 2
           * chassisSpeeds.omegaRadiansPerSecond,
-        chassisSpeeds.vxMetersPerSecond + m_trackWidthMeters / 2
+        chassisSpeeds.vxMetersPerSecond + trackWidthMeters / 2
           * chassisSpeeds.omegaRadiansPerSecond
     );
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/kinematics/DifferentialDriveKinematics.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/kinematics/DifferentialDriveKinematics.java
@@ -15,7 +15,7 @@ package edu.wpi.first.wpilibj.kinematics;
  * velocity components whereas forward kinematics converts left and right
  * component velocities into a linear and angular chassis speed.
  */
-@SuppressWarnings("MemberNames")
+@SuppressWarnings("MemberName")
 public class DifferentialDriveKinematics {
   public final double trackWidthMeters;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveKinematicsConstraint.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveKinematicsConstraint.java
@@ -24,6 +24,7 @@ public class DifferentialDriveKinematicsConstraint implements TrajectoryConstrai
   /**
    * Constructs a differential drive dynamics constraint.
    *
+   * @param kinematics A kinematics component describing the drive geometry.
    * @param maxSpeedMetersPerSecond The max speed that a side of the robot can travel at.
    */
   public DifferentialDriveKinematicsConstraint(final DifferentialDriveKinematics kinematics,

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
@@ -78,13 +78,18 @@ public class DifferentialDriveVoltageConstraint implements TrajectoryConstraint 
             / (1 + m_kinematics.trackWidthMeters * Math.abs(curvatureRadPerMeter)
             * Math.signum(velocityMetersPerSecond) / 2);
     double minChassisAcceleration =
-          minWheelAcceleration
-              / (1 - m_kinematics.trackWidthMeters * Math.abs(curvatureRadPerMeter)
-              * Math.signum(velocityMetersPerSecond) / 2);
+        minWheelAcceleration
+            / (1 - m_kinematics.trackWidthMeters * Math.abs(curvatureRadPerMeter)
+            * Math.signum(velocityMetersPerSecond) / 2);
 
-    // Negate min chassis acceleration if center of turn is inside of wheelbase
-    if((m_kinematics.trackWidthMeters / 2) > (1 / Math.abs(curvatureRadPerMeter))) {
-      minChassisAcceleration = -minChassisAcceleration;
+    // Negate acceleration of wheel on inside of turn if center of turn is inside of wheelbase
+    if ((m_kinematics.trackWidthMeters / 2) > (1 / Math.abs(curvatureRadPerMeter))) {
+      if (velocityMetersPerSecond > 0) {
+        minChassisAcceleration = -minChassisAcceleration;
+      }
+      else {
+        maxChassisAcceleration = -maxChassisAcceleration;
+      }
     }
 
     return new MinMax(minChassisAcceleration, maxChassisAcceleration);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
@@ -73,7 +73,7 @@ public class DifferentialDriveVoltageConstraint implements TrajectoryConstraint 
 
     // Robot chassis turning on radius = 1/|curvature|.  Outer wheel has radius
     // increased by half of the trackwidth T.  Inner wheel has radius decreased
-    // by half of the wheelbase.  Achassis / radius = Aouter / (radius + T/2), so
+    // by half of the trackwidth.  Achassis / radius = Aouter / (radius + T/2), so
     // Achassis = Aouter * radius / (radius + T/2) = Aouter / (1 + |curvature|T/2).
     // Inner wheel is similar.
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
@@ -94,8 +94,7 @@ public class DifferentialDriveVoltageConstraint implements TrajectoryConstraint 
     if ((m_kinematics.trackWidthMeters / 2) > (1 / Math.abs(curvatureRadPerMeter))) {
       if (velocityMetersPerSecond > 0) {
         minChassisAcceleration = -minChassisAcceleration;
-      }
-      else {
+      } else {
         maxChassisAcceleration = -maxChassisAcceleration;
       }
     }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
@@ -1,0 +1,61 @@
+package edu.wpi.first.wpilibj.trajectory.constraint;
+
+import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+
+import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
+
+/**
+ * A class that enforces constraints on differential drive voltage expenditure based on the motor
+ * dynamics and the drive kinematics.  Ensures that the acceleration of any wheel of the robot
+ * while following the trajectory is never higher than what can be achieved with the given
+ * maximum voltage.
+ */
+public class DifferentialDriveVoltageConstraint implements TrajectoryConstraint {
+  private final SimpleMotorFeedforward m_feedforward;
+  private final DifferentialDriveKinematics m_kinematics;
+  private final double m_maxVoltage;
+
+  /**
+   * Creates a new DifferentialDriveVoltageConstraint.
+   *
+   * @param feedforward A feedforward component describing the behavior of the drive.
+   * @param kinematics A kinematics component describing the drive geometry.
+   * @param maxVoltage The maximum voltage available to the motors while following the path.
+   *                   Should be somewhat less than the nominal battery voltage (12V) to account
+   *                   for "voltage sag" due to current draw.
+   */
+  public DifferentialDriveVoltageConstraint(SimpleMotorFeedforward feedforward,
+                                            DifferentialDriveKinematics kinematics,
+                                            double maxVoltage) {
+    m_feedforward = requireNonNullParam(feedforward, "feedforward",
+                                        "DifferentialDriveVoltageConstraint");
+    m_kinematics = requireNonNullParam(kinematics, "kinematics",
+                                       "DifferentialDriveVoltageConstraint");
+    m_maxVoltage = maxVoltage;
+  }
+
+  @Override
+  public double getMaxVelocityMetersPerSecond(Pose2d poseMeters, double curvatureRadPerMeter,
+                                              double velocityMetersPerSecond) {
+    return Double.POSITIVE_INFINITY;
+  }
+
+  @Override
+  public MinMax getMinMaxAccelerationMetersPerSecondSq(Pose2d poseMeters,
+                                                       double curvatureRadPerMeter,
+                                                       double velocityMetersPerSecond) {
+    var wheelSpeeds = m_kinematics.toWheelSpeeds(new ChassisSpeeds(velocityMetersPerSecond, 0,
+                                                                   velocityMetersPerSecond *
+                                                                       curvatureRadPerMeter));
+    double maxWheelSpeed = Math.max(Math.abs(wheelSpeeds.leftMetersPerSecond),
+                                    Math.abs(wheelSpeeds.rightMetersPerSecond));
+    double maxWheelAcceleration =
+        (m_maxVoltage - m_feedforward.ks - m_feedforward.kv * maxWheelSpeed) / m_feedforward.ka;
+    double maxChassisAcceleration =
+        maxWheelAcceleration / (1 + m_kinematics.trackWidthMeters * curvatureRadPerMeter / 2);
+    return new MinMax(-maxChassisAcceleration, maxChassisAcceleration);
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
@@ -64,6 +64,8 @@ public class DifferentialDriveVoltageConstraint implements TrajectoryConstraint 
     double minWheelSpeed = Math.min(wheelSpeeds.leftMetersPerSecond,
                                     wheelSpeeds.rightMetersPerSecond);
 
+    // Calculate maximum/minimum possible accelerations from motor dynamics
+    // and max/min wheel speeds
     double maxWheelAcceleration =
         (m_maxVoltage - m_feedforward.ks * Math.signum(maxWheelSpeed)
             - m_feedforward.kv * maxWheelSpeed) / m_feedforward.ka;
@@ -71,8 +73,16 @@ public class DifferentialDriveVoltageConstraint implements TrajectoryConstraint 
         (-m_maxVoltage - m_feedforward.ks * Math.signum(minWheelSpeed)
             - m_feedforward.kv * minWheelSpeed) / m_feedforward.ka;
 
+    // Robot chassis turning on radius 1/|curvature|.  Outer wheel has radius
+    // increased by half of the wheelbase.  Inner wheel has radius decreased
+    // by half of the wheelbase.  Solve resulting equations, and you get
+    // the implementation below.
+
+    // sgn(speed) term added to correctly account for which wheel is on
+    // outside of turn:
     // If moving forward, max acceleration constraint corresponds to wheel on outside of turn
     // If moving backward, max acceleration constraint corresponds to wheel on inside of turn
+
     double maxChassisAcceleration =
         maxWheelAcceleration
             / (1 + m_kinematics.trackWidthMeters * Math.abs(curvatureRadPerMeter)

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
@@ -67,11 +67,9 @@ public class DifferentialDriveVoltageConstraint implements TrajectoryConstraint 
     // Calculate maximum/minimum possible accelerations from motor dynamics
     // and max/min wheel speeds
     double maxWheelAcceleration =
-        (m_maxVoltage - m_feedforward.ks * Math.signum(maxWheelSpeed)
-            - m_feedforward.kv * maxWheelSpeed) / m_feedforward.ka;
+        m_feedforward.maxAchievableAcceleration(m_maxVoltage, maxWheelSpeed);
     double minWheelAcceleration =
-        (-m_maxVoltage - m_feedforward.ks * Math.signum(minWheelSpeed)
-            - m_feedforward.kv * minWheelSpeed) / m_feedforward.ka;
+        m_feedforward.minAchievableAcceleration(m_maxVoltage, minWheelSpeed);
 
     // Robot chassis turning on radius 1/|curvature|.  Outer wheel has radius
     // increased by half of the wheelbase.  Inner wheel has radius decreased

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
@@ -1,3 +1,10 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
 package edu.wpi.first.wpilibj.trajectory.constraint;
 
 import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
@@ -47,9 +54,11 @@ public class DifferentialDriveVoltageConstraint implements TrajectoryConstraint 
   public MinMax getMinMaxAccelerationMetersPerSecondSq(Pose2d poseMeters,
                                                        double curvatureRadPerMeter,
                                                        double velocityMetersPerSecond) {
+
     var wheelSpeeds = m_kinematics.toWheelSpeeds(new ChassisSpeeds(velocityMetersPerSecond, 0,
                                                                    velocityMetersPerSecond *
                                                                        curvatureRadPerMeter));
+
     double maxWheelSpeed = Math.max(wheelSpeeds.leftMetersPerSecond,
                                     wheelSpeeds.rightMetersPerSecond);
     double minWheelSpeed = Math.min(wheelSpeeds.leftMetersPerSecond,

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
@@ -76,11 +76,16 @@ public class DifferentialDriveVoltageConstraint implements TrajectoryConstraint 
     double maxChassisAcceleration =
         maxWheelAcceleration
             / (1 + m_kinematics.trackWidthMeters * Math.abs(curvatureRadPerMeter)
-                * Math.signum(velocityMetersPerSecond) / 2);
+            * Math.signum(velocityMetersPerSecond) / 2);
     double minChassisAcceleration =
-        minWheelAcceleration
-            / (1 - m_kinematics.trackWidthMeters * Math.abs(curvatureRadPerMeter)
-                * Math.signum(velocityMetersPerSecond) / 2);
+          minWheelAcceleration
+              / (1 - m_kinematics.trackWidthMeters * Math.abs(curvatureRadPerMeter)
+              * Math.signum(velocityMetersPerSecond) / 2);
+
+    // Negate min chassis acceleration if center of turn is inside of wheelbase
+    if((m_kinematics.trackWidthMeters / 2) > (1 / Math.abs(curvatureRadPerMeter))) {
+      minChassisAcceleration = -minChassisAcceleration;
+    }
 
     return new MinMax(minChassisAcceleration, maxChassisAcceleration);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
@@ -71,10 +71,11 @@ public class DifferentialDriveVoltageConstraint implements TrajectoryConstraint 
     double minWheelAcceleration =
         m_feedforward.minAchievableAcceleration(m_maxVoltage, minWheelSpeed);
 
-    // Robot chassis turning on radius 1/|curvature|.  Outer wheel has radius
-    // increased by half of the wheelbase.  Inner wheel has radius decreased
-    // by half of the wheelbase.  Solve resulting equations, and you get
-    // the implementation below.
+    // Robot chassis turning on radius = 1/|curvature|.  Outer wheel has radius
+    // increased by half of the trackwidth T.  Inner wheel has radius decreased
+    // by half of the wheelbase.  Achassis / radius = Aouter / (radius + T/2), so
+    // Achassis = Aouter * radius / (radius + T/2) = Aouter / (1 + |curvature|T/2).
+    // Inner wheel is similar.
 
     // sgn(speed) term added to correctly account for which wheel is on
     // outside of turn:

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVoltageConstraint.java
@@ -56,8 +56,8 @@ public class DifferentialDriveVoltageConstraint implements TrajectoryConstraint 
                                                        double velocityMetersPerSecond) {
 
     var wheelSpeeds = m_kinematics.toWheelSpeeds(new ChassisSpeeds(velocityMetersPerSecond, 0,
-                                                                   velocityMetersPerSecond *
-                                                                       curvatureRadPerMeter));
+                                                                   velocityMetersPerSecond
+                                                                       * curvatureRadPerMeter));
 
     double maxWheelSpeed = Math.max(wheelSpeeds.leftMetersPerSecond,
                                     wheelSpeeds.rightMetersPerSecond);
@@ -65,22 +65,22 @@ public class DifferentialDriveVoltageConstraint implements TrajectoryConstraint 
                                     wheelSpeeds.rightMetersPerSecond);
 
     double maxWheelAcceleration =
-        (m_maxVoltage - m_feedforward.ks * Math.signum(maxWheelSpeed) -
-            m_feedforward.kv * maxWheelSpeed) / m_feedforward.ka;
+        (m_maxVoltage - m_feedforward.ks * Math.signum(maxWheelSpeed)
+            - m_feedforward.kv * maxWheelSpeed) / m_feedforward.ka;
     double minWheelAcceleration =
-        (-m_maxVoltage - m_feedforward.ks * Math.signum(minWheelSpeed) -
-            m_feedforward.kv * minWheelSpeed) / m_feedforward.ka;
+        (-m_maxVoltage - m_feedforward.ks * Math.signum(minWheelSpeed)
+            - m_feedforward.kv * minWheelSpeed) / m_feedforward.ka;
 
     // If moving forward, max acceleration constraint corresponds to wheel on outside of turn
     // If moving backward, max acceleration constraint corresponds to wheel on inside of turn
     double maxChassisAcceleration =
-        maxWheelAcceleration /
-            (1 + m_kinematics.trackWidthMeters * Math.abs(curvatureRadPerMeter) *
-                Math.signum(velocityMetersPerSecond) / 2);
+        maxWheelAcceleration
+            / (1 + m_kinematics.trackWidthMeters * Math.abs(curvatureRadPerMeter)
+                * Math.signum(velocityMetersPerSecond) / 2);
     double minChassisAcceleration =
-        minWheelAcceleration /
-            (1 - m_kinematics.trackWidthMeters * Math.abs(curvatureRadPerMeter) *
-                Math.signum(velocityMetersPerSecond) / 2);
+        minWheelAcceleration
+            / (1 - m_kinematics.trackWidthMeters * Math.abs(curvatureRadPerMeter)
+                * Math.signum(velocityMetersPerSecond) / 2);
 
     return new MinMax(minChassisAcceleration, maxChassisAcceleration);
   }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/trajectory/DifferentialDriveVoltageConstraintTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/trajectory/DifferentialDriveVoltageConstraintTest.java
@@ -1,0 +1,70 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.trajectory;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveVoltageConstraint;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DifferentialDriveVoltageConstraintTest {
+  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  @Test
+  void testDifferentialDriveVoltageConstraint() {
+    // Pick an unreasonably large kA to ensure the constraint has to do some work
+    var feedforward = new SimpleMotorFeedforward(1, 1, 3);
+    var kinematics = new DifferentialDriveKinematics(.5);
+    double maxVoltage = 10;
+    var constraint = new DifferentialDriveVoltageConstraint(feedforward,
+                                                            kinematics,
+                                                            maxVoltage);
+
+    Trajectory trajectory = TrajectoryGeneratorTest.getTrajectory(
+        Collections.singletonList(constraint));
+
+    var duration = trajectory.getTotalTimeSeconds();
+    var t = 0.0;
+    var dt = 0.02;
+
+    while (t < duration) {
+      var point = trajectory.sample(t);
+      var chassisSpeeds = new ChassisSpeeds(
+          point.velocityMetersPerSecond, 0,
+          point.velocityMetersPerSecond * point.curvatureRadPerMeter
+      );
+
+      var wheelSpeeds = kinematics.toWheelSpeeds(chassisSpeeds);
+
+      t += dt;
+
+      // Not really a strictly-correct test as we're using the chassis accel instead of the
+      // wheel accel, but much easier than doing it "properly" and a reasonable check anyway
+      assertAll(
+          () -> assertTrue(feedforward.calculate(wheelSpeeds.leftMetersPerSecond,
+                                                 point.accelerationMetersPerSecondSq)
+                               <= maxVoltage + 0.05),
+          () -> assertTrue(feedforward.calculate(wheelSpeeds.leftMetersPerSecond,
+                                                 point.accelerationMetersPerSecondSq)
+                               >= -maxVoltage - 0.05),
+          () -> assertTrue(feedforward.calculate(wheelSpeeds.rightMetersPerSecond,
+                                                 point.accelerationMetersPerSecondSq)
+                               <= maxVoltage + 0.05),
+          () -> assertTrue(feedforward.calculate(wheelSpeeds.rightMetersPerSecond,
+                                                 point.accelerationMetersPerSecondSq)
+                               >= -maxVoltage - 0.05)
+      );
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/trajectory/DifferentialDriveVoltageConstraintTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/trajectory/DifferentialDriveVoltageConstraintTest.java
@@ -25,7 +25,7 @@ class DifferentialDriveVoltageConstraintTest {
   void testDifferentialDriveVoltageConstraint() {
     // Pick an unreasonably large kA to ensure the constraint has to do some work
     var feedforward = new SimpleMotorFeedforward(1, 1, 3);
-    var kinematics = new DifferentialDriveKinematics(.5);
+    var kinematics = new DifferentialDriveKinematics(0.5);
     double maxVoltage = 10;
     var constraint = new DifferentialDriveVoltageConstraint(feedforward,
                                                             kinematics,

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/Constants.java
@@ -8,7 +8,6 @@
 package edu.wpi.first.wpilibj.examples.ramsetecommand;
 
 import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
-import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveKinematicsConstraint;
 
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/Constants.java
@@ -8,7 +8,6 @@
 package edu.wpi.first.wpilibj.examples.ramsetecommand;
 
 import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
-import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveKinematicsConstraint;
 
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
@@ -62,10 +61,6 @@ public final class Constants {
   public static final class AutoConstants {
     public static final double kMaxSpeedMetersPerSecond = 3;
     public static final double kMaxAccelerationMetersPerSecondSquared = 3;
-
-    public static final DifferentialDriveKinematicsConstraint kAutoPathConstraints =
-        new DifferentialDriveKinematicsConstraint(DriveConstants.kDriveKinematics,
-                                                  kMaxSpeedMetersPerSecond);
 
     // Reasonable baseline values for a RAMSETE follower in units of meters and seconds
     public static final double kRamseteB = 2;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/Constants.java
@@ -8,6 +8,7 @@
 package edu.wpi.first.wpilibj.examples.ramsetecommand;
 
 import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveKinematicsConstraint;
 
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/Constants.java
@@ -67,7 +67,7 @@ public final class Constants {
         new DifferentialDriveKinematicsConstraint(DriveConstants.kDriveKinematics,
                                                   kMaxSpeedMetersPerSecond);
 
-    // Reasonable baseline values for a RAMSETE Controller in units of meters and seconds
+    // Reasonable baseline values for a RAMSETE follower in units of meters and seconds
     public static final double kRamseteB = 2;
     public static final double kRamseteZeta = 0.7;
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
@@ -14,7 +14,6 @@ import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.controller.PIDController;
 import edu.wpi.first.wpilibj.controller.RamseteController;
 import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
-import edu.wpi.first.wpilibj.examples.ramsetecommand.subsystems.DriveSubsystem;
 import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.geometry.Translation2d;
@@ -26,6 +25,8 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.RamseteCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
+
+import edu.wpi.first.wpilibj.examples.ramsetecommand.subsystems.DriveSubsystem;
 
 import static edu.wpi.first.wpilibj.XboxController.Button;
 import static edu.wpi.first.wpilibj.examples.ramsetecommand.Constants.AutoConstants.kMaxAccelerationMetersPerSecondSquared;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
@@ -20,6 +20,8 @@ import edu.wpi.first.wpilibj.geometry.Translation2d;
 import edu.wpi.first.wpilibj.trajectory.Trajectory;
 import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
 import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveKinematicsConstraint;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveVoltageConstraint;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.RamseteCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
@@ -91,11 +93,23 @@ public class RobotContainer {
    * @return the command to run in autonomous
    */
   public Command getAutonomousCommand() {
+
+    // Create a voltage constraint to ensure we don't accelerate too fast
+    var autoVoltageConstraint =
+        new DifferentialDriveVoltageConstraint(
+            new SimpleMotorFeedforward(ksVolts,
+                                       kvVoltSecondsPerMeter,
+                                       kaVoltSecondsSquaredPerMeter),
+            kDriveKinematics,
+            10);
+
     // Create config for trajectory
     TrajectoryConfig config =
         new TrajectoryConfig(kMaxSpeedMetersPerSecond, kMaxAccelerationMetersPerSecondSquared)
             // Add kinematics to ensure max speed is actually obeyed
-            .setKinematics(kDriveKinematics);
+            .setKinematics(kDriveKinematics)
+            // Apply the voltage constraint
+            .addConstraint(autoVoltageConstraint);
 
     // An example trajectory to follow.  All units in meters.
     Trajectory exampleTrajectory = TrajectoryGenerator.generateTrajectory(

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
@@ -14,20 +14,18 @@ import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.controller.PIDController;
 import edu.wpi.first.wpilibj.controller.RamseteController;
 import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.examples.ramsetecommand.subsystems.DriveSubsystem;
 import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.geometry.Translation2d;
 import edu.wpi.first.wpilibj.trajectory.Trajectory;
 import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
 import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
-import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveKinematicsConstraint;
 import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveVoltageConstraint;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.RamseteCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
-
-import edu.wpi.first.wpilibj.examples.ramsetecommand.subsystems.DriveSubsystem;
 
 import static edu.wpi.first.wpilibj.XboxController.Button;
 import static edu.wpi.first.wpilibj.examples.ramsetecommand.Constants.AutoConstants.kMaxAccelerationMetersPerSecondSquared;


### PR DESCRIPTION
Adds a constraint that ensures that a trajectory never accelerates faster than a differential drive is capable of achieving given a max voltage and a set of drive characterization parameters.