### PR TITLE
Java number formatting

### DIFF
--- a/styleguide/checkstyle.xml
+++ b/styleguide/checkstyle.xml
@@ -51,6 +51,26 @@ module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
       <property name="message"
                 value="Avoid using corresponding octal or Unicode escape." />
     </module>
+    <module name="IllegalTokenText">
+      <property name="tokens"
+                value="NUM_INT,NUM_LONG"/>
+      <property name="format"
+                value="^0[^lx]"/>
+      <property name="ignoreCase"
+                value="true"/>
+      <property name="message"
+                value="Forbid leading zeros in an integer literal, other than zero and a hex literal." />
+    </module>
+    <module name="IllegalTokenText">
+      <property name="tokens"
+                value="NUM_DOUBLE,NUM_FLOAT"/>
+      <property name="format"
+                value="(^\.|\.$)"/>
+      <property name="ignoreCase"
+                value="true"/>
+      <property name="message"
+                value="Must use leading and trailing zero in floating point numbers." />
+    </module>
     <module name="AvoidEscapedUnicodeCharacters">
       <property name="allowEscapesForControlCharacters"
                 value="true" />

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDCommand.java
@@ -124,7 +124,7 @@ public class ProfiledPIDCommand extends CommandBase {
 
   @Override
   public void end(boolean interrupted) {
-    m_useOutput.accept(0., new State());
+    m_useOutput.accept(0.0, new State());
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/TrapezoidProfileSubsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/TrapezoidProfileSubsystem.java
@@ -30,7 +30,7 @@ public abstract class TrapezoidProfileSubsystem extends SubsystemBase {
                                    double initialPosition) {
     m_constraints = constraints;
     m_state = new TrapezoidProfile.State(initialPosition, 0);
-    m_period = .02;
+    m_period = 0.02;
   }
 
   /**

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/NotifierCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/NotifierCommandTest.java
@@ -23,10 +23,10 @@ class NotifierCommandTest extends CommandTestBase {
 
     Counter counter = new Counter();
 
-    NotifierCommand command = new NotifierCommand(counter::increment, .01);
+    NotifierCommand command = new NotifierCommand(counter::increment, 0.01);
 
     scheduler.schedule(command);
-    Timer.delay(.25);
+    Timer.delay(0.25);
     scheduler.cancel(command);
 
     assertTrue(counter.m_counter > 10, "Should have hit at least 10 triggers");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Counter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Counter.java
@@ -84,7 +84,7 @@ public class Counter implements CounterBase, PIDSource, Sendable, AutoCloseable 
     m_upSource = null;
     m_downSource = null;
 
-    setMaxPeriod(.5);
+    setMaxPeriod(0.5);
 
     HAL.report(tResourceType.kResourceType_Counter, m_index + 1, mode.value + 1);
     SendableRegistry.addLW(this, "Counter", m_index);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DMC60.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DMC60.java
@@ -38,7 +38,7 @@ public class DMC60 extends PWMSpeedController {
   public DMC60(final int channel) {
     super(channel);
 
-    setBounds(2.004, 1.52, 1.50, 1.48, .997);
+    setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
     setPeriodMultiplier(PeriodMultiplier.k1X);
     setSpeed(0.0);
     setZeroLatch();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Jaguar.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Jaguar.java
@@ -38,7 +38,7 @@ public class Jaguar extends PWMSpeedController {
   public Jaguar(final int channel) {
     super(channel);
 
-    setBounds(2.31, 1.55, 1.507, 1.454, .697);
+    setBounds(2.31, 1.55, 1.507, 1.454, 0.697);
     setPeriodMultiplier(PeriodMultiplier.k1X);
     setSpeed(0.0);
     setZeroLatch();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
@@ -36,7 +36,7 @@ public class PWMSparkMax extends PWMSpeedController {
   public PWMSparkMax(final int channel) {
     super(channel);
 
-    setBounds(2.003, 1.55, 1.50, 1.46, .999);
+    setBounds(2.003, 1.55, 1.50, 1.46, 0.999);
     setPeriodMultiplier(PeriodMultiplier.k1X);
     setSpeed(0.0);
     setZeroLatch();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonSRX.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonSRX.java
@@ -38,7 +38,7 @@ public class PWMTalonSRX extends PWMSpeedController {
   public PWMTalonSRX(final int channel) {
     super(channel);
 
-    setBounds(2.004, 1.52, 1.50, 1.48, .997);
+    setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
     setPeriodMultiplier(PeriodMultiplier.k1X);
     setSpeed(0.0);
     setZeroLatch();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMVictorSPX.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMVictorSPX.java
@@ -38,7 +38,7 @@ public class PWMVictorSPX extends PWMSpeedController {
   public PWMVictorSPX(final int channel) {
     super(channel);
 
-    setBounds(2.004, 1.52, 1.50, 1.48, .997);
+    setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
     setPeriodMultiplier(PeriodMultiplier.k1X);
     setSpeed(0.0);
     setZeroLatch();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotDrive.java
@@ -178,7 +178,7 @@ public class RobotDrive extends MotorSafety implements AutoCloseable {
       double value = Math.log(-curve);
       double ratio = (value - m_sensitivity) / (value + m_sensitivity);
       if (ratio == 0) {
-        ratio = .0000000001;
+        ratio = 0.0000000001;
       }
       leftOutput = outputMagnitude / ratio;
       rightOutput = outputMagnitude;
@@ -186,7 +186,7 @@ public class RobotDrive extends MotorSafety implements AutoCloseable {
       double value = Math.log(curve);
       double ratio = (value - m_sensitivity) / (value + m_sensitivity);
       if (ratio == 0) {
-        ratio = .0000000001;
+        ratio = 0.0000000001;
       }
       leftOutput = outputMagnitude;
       rightOutput = outputMagnitude / ratio;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SD540.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SD540.java
@@ -33,7 +33,7 @@ public class SD540 extends PWMSpeedController {
    * Common initialization code called by all constructors.
    */
   protected void initSD540() {
-    setBounds(2.05, 1.55, 1.50, 1.44, .94);
+    setBounds(2.05, 1.55, 1.50, 1.44, 0.94);
     setPeriodMultiplier(PeriodMultiplier.k1X);
     setSpeed(0.0);
     setZeroLatch();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Servo.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Servo.java
@@ -23,7 +23,7 @@ public class Servo extends PWM {
   private static final double kMinServoAngle = 0.0;
 
   protected static final double kDefaultMaxServoPWM = 2.4;
-  protected static final double kDefaultMinServoPWM = .6;
+  protected static final double kDefaultMinServoPWM = 0.6;
 
   /**
    * Constructor.<br>

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Spark.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Spark.java
@@ -33,7 +33,7 @@ public class Spark extends PWMSpeedController {
    * Common initialization code called by all constructors.
    */
   protected void initSpark() {
-    setBounds(2.003, 1.55, 1.50, 1.46, .999);
+    setBounds(2.003, 1.55, 1.50, 1.46, 0.999);
     setPeriodMultiplier(PeriodMultiplier.k1X);
     setSpeed(0.0);
     setZeroLatch();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Talon.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Talon.java
@@ -38,7 +38,7 @@ public class Talon extends PWMSpeedController {
   public Talon(final int channel) {
     super(channel);
 
-    setBounds(2.037, 1.539, 1.513, 1.487, .989);
+    setBounds(2.037, 1.539, 1.513, 1.487, 0.989);
     setPeriodMultiplier(PeriodMultiplier.k1X);
     setSpeed(0.0);
     setZeroLatch();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/VictorSP.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/VictorSP.java
@@ -38,7 +38,7 @@ public class VictorSP extends PWMSpeedController {
   public VictorSP(final int channel) {
     super(channel);
 
-    setBounds(2.004, 1.52, 1.50, 1.48, .997);
+    setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
     setPeriodMultiplier(PeriodMultiplier.k1X);
     setSpeed(0.0);
     setZeroLatch();

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/PIDInputOutputTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/PIDInputOutputTest.java
@@ -43,7 +43,7 @@ class PIDInputOutputTest {
     double out = 0;
 
     for (int i = 0; i < 5; i++) {
-      out = m_controller.calculate(.025, 0);
+      out = m_controller.calculate(0.025, 0);
     }
 
     assertEquals(-0.5 * m_controller.getPeriod(), out, 1e-5);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/Constants.java
@@ -40,7 +40,7 @@ public final class Constants {
     public static final int kEncoderCPR = 1024;
     public static final double kEncoderDistancePerPulse =
         // Distance units will be rotations
-        1. / (double) kEncoderCPR;
+        1.0 / (double) kEncoderCPR;
 
     public static final int kShooterMotorPort = 4;
     public static final int kFeederMotorPort = 5;
@@ -56,12 +56,12 @@ public final class Constants {
 
     // On a real robot the feedforward constants should be empirically determined; these are
     // reasonable guesses.
-    public static final double kSVolts = .05;
+    public static final double kSVolts = 0.05;
     public static final double kVVoltSecondsPerRotation =
         // Should have value 12V at free speed...
-        12. / kShooterFreeRPS;
+        12.0 / kShooterFreeRPS;
 
-    public static final double kFeederSpeed = .5;
+    public static final double kFeederSpeed = 0.5;
   }
 
   public static final class AutoConstants {

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/RobotContainer.java
@@ -103,7 +103,7 @@ public class RobotContainer {
 
     // Drive at half speed when the bumper is held
     new JoystickButton(m_driverController, Button.kBumperRight.value)
-        .whenPressed(() -> m_robotDrive.setMaxOutput(.5))
+        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
         .whenReleased(() -> m_robotDrive.setMaxOutput(1));
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/subsystems/DriveSubsystem.java
@@ -78,7 +78,7 @@ public class DriveSubsystem extends SubsystemBase {
    * @return the average of the two encoder readings
    */
   public double getAverageEncoderDistance() {
-    return (m_leftEncoder.getDistance() + m_rightEncoder.getDistance()) / 2.;
+    return (m_leftEncoder.getDistance() + m_rightEncoder.getDistance()) / 2.0;
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/Constants.java
@@ -36,7 +36,7 @@ public final class Constants {
     public static final boolean kGyroReversed = false;
 
     public static final double kStabilizationP = 1;
-    public static final double kStabilizationI = .5;
+    public static final double kStabilizationI = 0.5;
     public static final double kStabilizationD = 0;
 
     public static final double kTurnP = 1;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/RobotContainer.java
@@ -65,7 +65,7 @@ public class RobotContainer {
   private void configureButtonBindings() {
     // Drive at half speed when the right bumper is held
     new JoystickButton(m_driverController, Button.kBumperRight.value)
-        .whenPressed(() -> m_robotDrive.setMaxOutput(.5))
+        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
         .whenReleased(() -> m_robotDrive.setMaxOutput(1));
 
     // Stabilize robot to drive straight with gyro when left bumper is held

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/subsystems/DriveSubsystem.java
@@ -84,7 +84,7 @@ public class DriveSubsystem extends SubsystemBase {
    * @return the average of the two encoder readings
    */
   public double getAverageEncoderDistance() {
-    return (m_leftEncoder.getDistance() + m_rightEncoder.getDistance()) / 2.;
+    return (m_leftEncoder.getDistance() + m_rightEncoder.getDistance()) / 2.0;
   }
 
   /**
@@ -127,7 +127,7 @@ public class DriveSubsystem extends SubsystemBase {
    * @return the robot's heading in degrees, from 180 to 180
    */
   public double getHeading() {
-    return Math.IEEEremainder(m_gyro.getAngle(), 360) * (kGyroReversed ? -1. : 1.);
+    return Math.IEEEremainder(m_gyro.getAngle(), 360) * (kGyroReversed ? -1.0 : 1.0);
   }
 
   /**
@@ -136,6 +136,6 @@ public class DriveSubsystem extends SubsystemBase {
    * @return The turn rate of the robot, in degrees per second
    */
   public double getTurnRate() {
-    return m_gyro.getRate() * (kGyroReversed ? -1. : 1.);
+    return m_gyro.getRate() * (kGyroReversed ? -1.0 : 1.0);
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/Constants.java
@@ -42,7 +42,7 @@ public final class Constants {
   public static final class AutoConstants {
     public static final double kAutoDriveDistanceInches = 60;
     public static final double kAutoBackupDistanceInches = 20;
-    public static final double kAutoDriveSpeed = .5;
+    public static final double kAutoDriveSpeed = 0.5;
   }
 
   public static final class OIConstants {

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
@@ -105,7 +105,7 @@ public class RobotContainer {
         .whenPressed(new InstantCommand(m_hatchSubsystem::releaseHatch, m_hatchSubsystem));
     // While holding the shoulder button, drive at half speed
     new JoystickButton(m_driverController, Button.kBumperRight.value)
-        .whenPressed(() -> m_robotDrive.setMaxOutput(.5))
+        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
         .whenReleased(() -> m_robotDrive.setMaxOutput(1));
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/subsystems/DriveSubsystem.java
@@ -78,7 +78,7 @@ public class DriveSubsystem extends SubsystemBase {
    * @return the average of the TWO encoder readings
    */
   public double getAverageEncoderDistance() {
-    return (m_leftEncoder.getDistance() + m_rightEncoder.getDistance()) / 2.;
+    return (m_leftEncoder.getDistance() + m_rightEncoder.getDistance()) / 2.0;
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/Constants.java
@@ -42,7 +42,7 @@ public final class Constants {
   public static final class AutoConstants {
     public static final double kAutoDriveDistanceInches = 60;
     public static final double kAutoBackupDistanceInches = 20;
-    public static final double kAutoDriveSpeed = .5;
+    public static final double kAutoDriveSpeed = 0.5;
   }
 
   public static final class OIConstants {

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/commands/HalveDriveSpeed.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/commands/HalveDriveSpeed.java
@@ -20,7 +20,7 @@ public class HalveDriveSpeed extends CommandBase {
 
   @Override
   public void initialize() {
-    m_drive.setMaxOutput(.5);
+    m_drive.setMaxOutput(0.5);
   }
 
   @Override

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/subsystems/DriveSubsystem.java
@@ -78,7 +78,7 @@ public class DriveSubsystem extends SubsystemBase {
    * @return the average of the TWO encoder readings
    */
   public double getAverageEncoderDistance() {
-    return (m_leftEncoder.getDistance() + m_rightEncoder.getDistance()) / 2.;
+    return (m_leftEncoder.getDistance() + m_rightEncoder.getDistance()) / 2.0;
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/Constants.java
@@ -30,12 +30,12 @@ public final class Constants {
     public static final boolean kLeftEncoderReversed = false;
     public static final boolean kRightEncoderReversed = true;
 
-    public static final double kTrackwidthMeters = .6;
+    public static final double kTrackwidthMeters = 0.6;
     public static final DifferentialDriveKinematics kDriveKinematics =
         new DifferentialDriveKinematics(kTrackwidthMeters);
 
     public static final int kEncoderCPR = 1024;
-    public static final double kWheelDiameterMeters = .15;
+    public static final double kWheelDiameterMeters = 0.15;
     public static final double kEncoderDistancePerPulse =
         // Assumes the encoders are directly mounted on the wheel shafts
         (kWheelDiameterMeters * Math.PI) / (double) kEncoderCPR;
@@ -48,11 +48,11 @@ public final class Constants {
     // The RobotPy Characterization Toolsuite provides a convenient tool for obtaining these
     // values for your robot.
     public static final double ksVolts = 1;
-    public static final double kvVoltSecondsPerMeter = .8;
-    public static final double kaVoltSecondsSquaredPerMeter = .15;
+    public static final double kvVoltSecondsPerMeter = 0.8;
+    public static final double kaVoltSecondsSquaredPerMeter = 0.15;
 
     // Example value only - as above, this must be tuned for your drive!
-    public static final double kPDriveVel = .5;
+    public static final double kPDriveVel = 0.5;
   }
 
   public static final class OIConstants {
@@ -69,6 +69,6 @@ public final class Constants {
 
     // Reasonable baseline values for a RAMSETE follower in units of meters and seconds
     public static final double kRamseteB = 2;
-    public static final double kRamseteZeta = .7;
+    public static final double kRamseteZeta = 0.7;
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
@@ -79,7 +79,7 @@ public class RobotContainer {
   private void configureButtonBindings() {
     // Drive at half speed when the right bumper is held
     new JoystickButton(m_driverController, Button.kBumperRight.value)
-        .whenPressed(() -> m_robotDrive.setMaxOutput(.5))
+        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
         .whenReleased(() -> m_robotDrive.setMaxOutput(1));
 
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/subsystems/DriveSubsystem.java
@@ -137,7 +137,7 @@ public class DriveSubsystem extends SubsystemBase {
    * @return the average of the two encoder readings
    */
   public double getAverageEncoderDistance() {
-    return (m_leftEncoder.getDistance() + m_rightEncoder.getDistance()) / 2.;
+    return (m_leftEncoder.getDistance() + m_rightEncoder.getDistance()) / 2.0;
   }
 
   /**
@@ -180,7 +180,7 @@ public class DriveSubsystem extends SubsystemBase {
    * @return the robot's heading in degrees, from 180 to 180
    */
   public double getHeading() {
-    return Math.IEEEremainder(m_gyro.getAngle(), 360) * (kGyroReversed ? -1. : 1.);
+    return Math.IEEEremainder(m_gyro.getAngle(), 360) * (kGyroReversed ? -1.0 : 1.0);
   }
 
   /**
@@ -189,6 +189,6 @@ public class DriveSubsystem extends SubsystemBase {
    * @return The turn rate of the robot, in degrees per second
    */
   public double getTurnRate() {
-    return m_gyro.getRate() * (kGyroReversed ? -1. : 1.);
+    return m_gyro.getRate() * (kGyroReversed ? -1.0 : 1.0);
   }
 }

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/AbstractInterruptTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/AbstractInterruptTest.java
@@ -137,7 +137,7 @@ public abstract class AbstractInterruptTest extends AbstractComsSetup {
 
     // Delay until the interrupt is complete
     while (!function.m_interruptComplete.get()) {
-      Timer.delay(.005);
+      Timer.delay(0.005);
     }
 
 
@@ -176,7 +176,7 @@ public abstract class AbstractInterruptTest extends AbstractComsSetup {
       setInterruptHigh();
       // Wait for the interrupt to complete before moving on
       while (!function.m_interruptComplete.getAndSet(false)) {
-        Timer.delay(.005);
+        Timer.delay(0.005);
       }
     }
     // Then
@@ -194,7 +194,7 @@ public abstract class AbstractInterruptTest extends AbstractComsSetup {
     // Given
     getInterruptable().requestInterrupts();
 
-    final double synchronousDelay = synchronousTimeout / 2.;
+    final double synchronousDelay = synchronousTimeout / 2.0;
     final Runnable runnable = () -> {
       Timer.delay(synchronousDelay);
       setInterruptLow();
@@ -215,7 +215,7 @@ public abstract class AbstractInterruptTest extends AbstractComsSetup {
     // The test will not have timed out and:
     final double interruptRunTime = (stopTimeStamp - startTimeStamp) * 1e-6;
     assertEquals("The interrupt did not run for the expected amount of time (units in seconds)",
-        synchronousDelay, interruptRunTime, .1);
+        synchronousDelay, interruptRunTime, 0.1);
   }
 
   @Test(timeout = (long) (synchronousTimeout * 1e3))
@@ -236,7 +236,7 @@ public abstract class AbstractInterruptTest extends AbstractComsSetup {
     // Given
     getInterruptable().requestInterrupts();
 
-    final double synchronousDelay = synchronousTimeout / 2.;
+    final double synchronousDelay = synchronousTimeout / 2.0;
     final Runnable runnable = () -> {
       Timer.delay(synchronousDelay);
       setInterruptLow();
@@ -258,7 +258,7 @@ public abstract class AbstractInterruptTest extends AbstractComsSetup {
     getInterruptable().requestInterrupts();
     getInterruptable().setUpSourceEdge(false, true);
 
-    final double synchronousDelay = synchronousTimeout / 2.;
+    final double synchronousDelay = synchronousTimeout / 2.0;
     final Runnable runnable = () -> {
       Timer.delay(synchronousDelay);
       setInterruptHigh();
@@ -290,7 +290,7 @@ public abstract class AbstractInterruptTest extends AbstractComsSetup {
       setInterruptHigh();
       // Wait for the interrupt to complete before moving on
       while (!function.m_interruptComplete.getAndSet(false)) {
-        Timer.delay(.005);
+        Timer.delay(0.005);
       }
     }
     getInterruptable().disableInterrupts();
@@ -300,7 +300,7 @@ public abstract class AbstractInterruptTest extends AbstractComsSetup {
       setInterruptLow();
       setInterruptHigh();
       // Just wait because the interrupt should not fire
-      Timer.delay(.005);
+      Timer.delay(0.005);
     }
 
     // Then

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometerTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometerTest.java
@@ -61,7 +61,7 @@ public class AnalogPotentiometerTest extends AbstractComsSetup {
     for (double i = 0.0; i < 360.0; i = i + 1.0) {
       m_potSource.setAngle(i);
       m_potSource.setMaxVoltage(RobotController.getVoltage5V());
-      Timer.delay(.02);
+      Timer.delay(0.02);
       assertEquals(i, m_pot.get(), DOUBLE_COMPARISON_DELTA);
     }
   }

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/DIOCrossConnectTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/DIOCrossConnectTest.java
@@ -87,7 +87,7 @@ public class DIOCrossConnectTest extends AbstractInterruptTest {
   public void testSetHigh() {
     dio.getOutput().set(true);
     assertTrue("DIO Not High after no delay", dio.getInput().get());
-    Timer.delay(.02);
+    Timer.delay(0.02);
     assertTrue("DIO Not High after .05s delay", dio.getInput().get());
   }
 
@@ -98,7 +98,7 @@ public class DIOCrossConnectTest extends AbstractInterruptTest {
   public void testSetLow() {
     dio.getOutput().set(false);
     assertFalse("DIO Not Low after no delay", dio.getInput().get());
-    Timer.delay(.02);
+    Timer.delay(0.02);
     assertFalse("DIO Not Low after .05s delay", dio.getInput().get());
   }
 

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/GyroTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/GyroTest.java
@@ -56,7 +56,7 @@ public class GyroTest extends AbstractComsSetup {
 
   public void testInitial(AnalogGyro gyro) {
     double angle = gyro.getAngle();
-    assertEquals(errorMessage(angle, 0), 0, angle, .5);
+    assertEquals(errorMessage(angle, 0), 0, angle, 0.5);
   }
 
   /**
@@ -68,7 +68,7 @@ public class GyroTest extends AbstractComsSetup {
     // Set angle
     for (int i = 0; i < 5; i++) {
       m_tpcam.getPan().set(0);
-      Timer.delay(.1);
+      Timer.delay(0.1);
     }
 
     Timer.delay(0.5);
@@ -99,7 +99,7 @@ public class GyroTest extends AbstractComsSetup {
     gyro.reset();
     Timer.delay(0.25);
     double angle = gyro.getAngle();
-    assertEquals(errorMessage(angle, 0), 0, angle, .5);
+    assertEquals(errorMessage(angle, 0), 0, angle, 0.5);
     Timer.delay(5);
     angle = gyro.getAngle();
     assertEquals("After 5 seconds " + errorMessage(angle, 0), 0, angle, 2.0);

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/MotorEncoderTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/MotorEncoderTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 public class MotorEncoderTest extends AbstractComsSetup {
   private static final Logger logger = Logger.getLogger(MotorEncoderTest.class.getName());
 
-  private static final double MOTOR_RUNTIME = .25;
+  private static final double MOTOR_RUNTIME = 0.25;
 
   // private static final List<MotorEncoderFixture> pairs = new
   // ArrayList<MotorEncoderFixture>();
@@ -108,7 +108,7 @@ public class MotorEncoderTest extends AbstractComsSetup {
   public void testIncrement() {
     int startValue = me.getEncoder().get();
 
-    me.getMotor().set(.2);
+    me.getMotor().set(0.2);
     Timer.delay(MOTOR_RUNTIME);
     int currentValue = me.getEncoder().get();
     assertTrue(me.getType() + " Encoder not incremented: start: " + startValue + "; current: "
@@ -124,7 +124,7 @@ public class MotorEncoderTest extends AbstractComsSetup {
   public void testDecrement() {
     int startValue = me.getEncoder().get();
 
-    me.getMotor().set(-.2);
+    me.getMotor().set(-0.2);
     Timer.delay(MOTOR_RUNTIME);
     int currentValue = me.getEncoder().get();
     assertTrue(me.getType() + " Encoder not decremented: start: " + startValue + "; current: "
@@ -139,7 +139,7 @@ public class MotorEncoderTest extends AbstractComsSetup {
     final int counter1Start = me.getCounters()[0].get();
     final int counter2Start = me.getCounters()[1].get();
 
-    me.getMotor().set(.75);
+    me.getMotor().set(0.75);
     Timer.delay(MOTOR_RUNTIME);
     int counter1End = me.getCounters()[0].get();
     int counter2End = me.getCounters()[1].get();

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/mockhardware/FakeCounterSource.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/mockhardware/FakeCounterSource.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2014-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2014-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/mockhardware/FakeCounterSource.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/mockhardware/FakeCounterSource.java
@@ -107,7 +107,7 @@ public class FakeCounterSource implements AutoCloseable {
       Thread.currentThread().interrupt();
     }
     m_task = new EncoderThread(this);
-    Timer.delay(.01);
+    Timer.delay(0.01);
   }
 
   /**

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/mockhardware/FakeEncoderSource.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/mockhardware/FakeEncoderSource.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2014-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2014-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/mockhardware/FakeEncoderSource.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/mockhardware/FakeEncoderSource.java
@@ -131,7 +131,7 @@ public class FakeEncoderSource implements AutoCloseable {
       Thread.currentThread().interrupt();
     }
     m_task = new QuadEncoderThread(this);
-    Timer.delay(.01);
+    Timer.delay(0.01);
   }
 
   /**

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/test/AbstractComsSetup.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/test/AbstractComsSetup.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/test/AbstractComsSetup.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/test/AbstractComsSetup.java
@@ -232,14 +232,14 @@ public abstract class AbstractComsSetup {
     // reached then continue to run this loop
     for (timeoutIndex = 0; timeoutIndex < (timeout * 100) && !correctState.getAsBoolean();
          timeoutIndex++) {
-      Timer.delay(.01);
+      Timer.delay(0.01);
     }
     if (correctState.getAsBoolean()) {
-      simpleLog(level, message + " took " + (timeoutIndex * .01) + " seconds");
+      simpleLog(level, message + " took " + (timeoutIndex * 0.01) + " seconds");
     } else {
-      simpleLog(level, message + " timed out after " + (timeoutIndex * .01) + " seconds");
+      simpleLog(level, message + " timed out after " + (timeoutIndex * 0.01) + " seconds");
     }
-    return timeoutIndex * .01;
+    return timeoutIndex * 0.01;
   }
 
 }


### PR DESCRIPTION
Enforce that integer literals must not have leading zeros and that floating point literals must have leading or trailing zeros in Java.