### PR TITLE
Directly construct PWM port from HAL, avoid wpilib PWM object

### DIFF
--- a/wpilibc/src/main/native/cpp/AddressableLED.cpp
+++ b/wpilibc/src/main/native/cpp/AddressableLED.cpp
@@ -8,44 +8,34 @@
 #include "frc/AddressableLED.h"
 
 #include <hal/AddressableLED.h>
+#include <hal/HALBase.h>
+#include <hal/PWM.h>
+#include <hal/Ports.h>
 
-#include "frc/PWM.h"
 #include "frc/WPIErrors.h"
 
 using namespace frc;
 
-AddressableLED::AddressableLED(PWM& output)
-    : m_pwmOutput{&output, NullDeleter<PWM>()} {
-  Init();
-}
-
-AddressableLED::AddressableLED(PWM* output)
-    : m_pwmOutput{output, NullDeleter<PWM>()} {
-  if (m_pwmOutput == nullptr) {
-    wpi_setWPIError(NullParameter);
-  } else {
-    Init();
-  }
-}
-
-AddressableLED::AddressableLED(std::shared_ptr<PWM> output)
-    : m_pwmOutput{std::move(output)} {
-  Init();
-}
-
-AddressableLED::AddressableLED(int port)
-    : m_pwmOutput{std::make_shared<PWM>(port)} {
-  if (!m_pwmOutput->StatusIsFatal()) {
-    Init();
-  }
-}
-
-AddressableLED::~AddressableLED() { HAL_FreeAddressableLED(m_handle); }
-
-void AddressableLED::Init() {
+AddressableLED::AddressableLED(int port) {
   int32_t status = 0;
-  m_handle = HAL_InitializeAddressableLED(m_pwmOutput->m_handle, &status);
+
+  m_pwmHandle = HAL_InitializePWMPort(HAL_GetPort(port), &status);
+  wpi_setHALErrorWithRange(status, 0, HAL_GetNumPWMChannels(), port);
+  if (m_pwmHandle == HAL_kInvalidHandle) {
+    return;
+  }
+
+  m_handle = HAL_InitializeAddressableLED(m_pwmHandle, &status);
   wpi_setHALError(status);
+  if (m_handle == HAL_kInvalidHandle) {
+    HAL_FreePWMPort(m_pwmHandle, &status);
+  }
+}
+
+AddressableLED::~AddressableLED() {
+  HAL_FreeAddressableLED(m_handle);
+  int32_t status = 0;
+  HAL_FreePWMPort(m_pwmHandle, &status);
 }
 
 void AddressableLED::SetLength(int length) {

--- a/wpilibc/src/main/native/include/frc/AddressableLED.h
+++ b/wpilibc/src/main/native/include/frc/AddressableLED.h
@@ -17,7 +17,6 @@
 #include "frc/ErrorBase.h"
 
 namespace frc {
-class PWM;
 
 /**
  * A class for driving addressable LEDs, such as WS2812s and NeoPixels.
@@ -43,27 +42,6 @@ class AddressableLED : public ErrorBase {
       this->b = b;
     }
   };
-
-  /**
-   * Constructs a new driver from a PWM output.
-   *
-   * @param output the pwm output to use
-   */
-  explicit AddressableLED(PWM& output);
-
-  /**
-   * Constructs a new driver from a PWM output.
-   *
-   * @param output the pwm output to use
-   */
-  explicit AddressableLED(PWM* output);
-
-  /**
-   * Constructs a new driver from a PWM output.
-   *
-   * @param output the pwm output to use
-   */
-  explicit AddressableLED(std::shared_ptr<PWM> output);
 
   /**
    * Constructs a new driver for a specific port.
@@ -142,9 +120,7 @@ class AddressableLED : public ErrorBase {
   void Stop();
 
  private:
-  void Init();
-
-  std::shared_ptr<PWM> m_pwmOutput;
+  hal::Handle<HAL_DigitalHandle> m_pwmHandle;
   hal::Handle<HAL_AddressableLEDHandle> m_handle;
 };
 }  // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AddressableLED.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AddressableLED.java
@@ -8,25 +8,15 @@
 package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.AddressableLEDJNI;
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.hal.PWMJNI;
 
 /**
  * A class for driving addressable LEDs, such as WS2812s and NeoPixels.
  */
 public class AddressableLED implements AutoCloseable {
-  private final PWM m_pwmOutput;
-  private int m_handle;
-  private final boolean m_ownsPwm;
-
-  /**
-   * Constructs a new driver from a PWM output.
-   *
-   * @param output the pwm output to use
-   */
-  public AddressableLED(PWM output) {
-    m_pwmOutput = output;
-    m_ownsPwm = false;
-    init();
-  }
+  private final int m_pwmHandle;
+  private final int m_handle;
 
   /**
    * Constructs a new driver for a specific port.
@@ -34,13 +24,8 @@ public class AddressableLED implements AutoCloseable {
    * @param port the output port to use (Must be a PWM port)
    */
   public AddressableLED(int port) {
-    m_pwmOutput = new PWM(port);
-    m_ownsPwm = true;
-    init();
-  }
-
-  private void init() {
-    m_handle = AddressableLEDJNI.initialize(m_pwmOutput.m_handle);
+    m_pwmHandle = PWMJNI.initializePWMPort(HAL.getPort((byte) port));
+    m_handle = AddressableLEDJNI.initialize(m_pwmHandle);
   }
 
   @Override
@@ -48,8 +33,8 @@ public class AddressableLED implements AutoCloseable {
     if (m_handle != 0) {
       AddressableLEDJNI.free(m_handle);
     }
-    if (m_ownsPwm) {
-      m_pwmOutput.close();
+    if (m_pwmHandle != 0) {
+      PWMJNI.freePWMPort(m_pwmHandle);
     }
   }
 


### PR DESCRIPTION
The PWM object really shouldn't be used anymore.