### PR TITLE
Fix C++ floating point literal formatting

### DIFF
--- a/hal/src/main/native/athena/AnalogGyro.cpp
+++ b/hal/src/main/native/athena/AnalogGyro.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2016-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2016-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -181,7 +181,7 @@ void HAL_CalibrateAnalogGyro(HAL_GyroHandle handle, int32_t* status) {
   if (*status != 0) return;
 
   gyro->center = static_cast<int32_t>(
-      static_cast<double>(value) / static_cast<double>(count) + .5);
+      static_cast<double>(value) / static_cast<double>(count) + 0.5);
 
   gyro->offset = static_cast<double>(value) / static_cast<double>(count) -
                  static_cast<double>(gyro->center);

--- a/hal/src/main/native/athena/DigitalInternal.cpp
+++ b/hal/src/main/native/athena/DigitalInternal.cpp
@@ -103,9 +103,9 @@ void initializeDigital(int32_t* status) {
                     (kSystemClockTicksPerMicrosecond * 1e3);
 
   pwmSystem->writeConfig_Period(
-      static_cast<uint16_t>(kDefaultPwmPeriod / loopTime + .5), status);
+      static_cast<uint16_t>(kDefaultPwmPeriod / loopTime + 0.5), status);
   uint16_t minHigh = static_cast<uint16_t>(
-      (kDefaultPwmCenter - kDefaultPwmStepsDown * loopTime) / loopTime + .5);
+      (kDefaultPwmCenter - kDefaultPwmStepsDown * loopTime) / loopTime + 0.5);
   pwmSystem->writeConfig_MinHigh(minHigh, status);
   // Ensure that PWM output values are set to OFF
   for (uint8_t pwmIndex = 0; pwmIndex < kNumPWMChannels; pwmIndex++) {

--- a/hal/src/main/native/athena/Encoder.cpp
+++ b/hal/src/main/native/athena/Encoder.cpp
@@ -35,7 +35,7 @@ Encoder::Encoder(HAL_Handle digitalSourceHandleA,
         return;
       }
       m_counter = HAL_kInvalidHandle;
-      SetMaxPeriod(.5, status);
+      SetMaxPeriod(0.5, status);
       break;
     }
     case HAL_Encoder_k1X:

--- a/hal/src/main/native/athena/PDP.cpp
+++ b/hal/src/main/native/athena/PDP.cpp
@@ -308,54 +308,54 @@ void HAL_GetPDPAllChannelCurrents(HAL_PDPHandle handle, double* currents,
 
   currents[0] = ((static_cast<uint32_t>(pdpStatus.bits.chan1_h8) << 2) |
                  pdpStatus.bits.chan1_l2) *
-                .125;
+                0.125;
   currents[1] = ((static_cast<uint32_t>(pdpStatus.bits.chan2_h6) << 4) |
                  pdpStatus.bits.chan2_l4) *
-                .125;
+                0.125;
   currents[2] = ((static_cast<uint32_t>(pdpStatus.bits.chan3_h4) << 6) |
                  pdpStatus.bits.chan3_l6) *
-                .125;
+                0.125;
   currents[3] = ((static_cast<uint32_t>(pdpStatus.bits.chan4_h2) << 8) |
                  pdpStatus.bits.chan4_l8) *
-                .125;
+                0.125;
   currents[4] = ((static_cast<uint32_t>(pdpStatus.bits.chan5_h8) << 2) |
                  pdpStatus.bits.chan5_l2) *
-                .125;
+                0.125;
   currents[5] = ((static_cast<uint32_t>(pdpStatus.bits.chan6_h6) << 4) |
                  pdpStatus.bits.chan6_l4) *
-                .125;
+                0.125;
 
   currents[6] = ((static_cast<uint32_t>(pdpStatus2.bits.chan7_h8) << 2) |
                  pdpStatus2.bits.chan7_l2) *
-                .125;
+                0.125;
   currents[7] = ((static_cast<uint32_t>(pdpStatus2.bits.chan8_h6) << 4) |
                  pdpStatus2.bits.chan8_l4) *
-                .125;
+                0.125;
   currents[8] = ((static_cast<uint32_t>(pdpStatus2.bits.chan9_h4) << 6) |
                  pdpStatus2.bits.chan9_l6) *
-                .125;
+                0.125;
   currents[9] = ((static_cast<uint32_t>(pdpStatus2.bits.chan10_h2) << 8) |
                  pdpStatus2.bits.chan10_l8) *
-                .125;
+                0.125;
   currents[10] = ((static_cast<uint32_t>(pdpStatus2.bits.chan11_h8) << 2) |
                   pdpStatus2.bits.chan11_l2) *
-                 .125;
+                 0.125;
   currents[11] = ((static_cast<uint32_t>(pdpStatus2.bits.chan12_h6) << 4) |
                   pdpStatus2.bits.chan12_l4) *
-                 .125;
+                 0.125;
 
   currents[12] = ((static_cast<uint32_t>(pdpStatus3.bits.chan13_h8) << 2) |
                   pdpStatus3.bits.chan13_l2) *
-                 .125;
+                 0.125;
   currents[13] = ((static_cast<uint32_t>(pdpStatus3.bits.chan14_h6) << 4) |
                   pdpStatus3.bits.chan14_l4) *
-                 .125;
+                 0.125;
   currents[14] = ((static_cast<uint32_t>(pdpStatus3.bits.chan15_h4) << 6) |
                   pdpStatus3.bits.chan15_l6) *
-                 .125;
+                 0.125;
   currents[15] = ((static_cast<uint32_t>(pdpStatus3.bits.chan16_h2) << 8) |
                   pdpStatus3.bits.chan16_l8) *
-                 .125;
+                 0.125;
 }
 
 double HAL_GetPDPTotalCurrent(HAL_PDPHandle handle, int32_t* status) {

--- a/hal/src/test/native/cpp/mockdata/DriverStationDataTests.cpp
+++ b/hal/src/test/native/cpp/mockdata/DriverStationDataTests.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2015-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2015-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -50,7 +50,7 @@ TEST(DriverStationTests, JoystickTests) {
   int joystickUnderTest = 4;
   set_axes.count = 5;
   for (int i = 0; i < set_axes.count; ++i) {
-    set_axes.axes[i] = i * .125;
+    set_axes.axes[i] = i * 0.125;
   }
 
   set_povs.count = 3;

--- a/simulation/lowfi_simulation/src/test/native/cpp/lowfisim/MotorEncoderSimulatorTest.cpp
+++ b/simulation/lowfi_simulation/src/test/native/cpp/lowfisim/MotorEncoderSimulatorTest.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -49,7 +49,7 @@ TEST(MotorEncoderConnectorTest, TestWithoutDistancePerPulseRealisitcUpdate) {
   frc::sim::lowfi::MotorEncoderConnector connector(motorSim, encoderSim);
 
   talon.Set(0.5);
-  motorSim.Update(.02);
+  motorSim.Update(0.02);
   connector.Update();
 
   // Position
@@ -64,7 +64,7 @@ TEST(MotorEncoderConnectorTest, TestWithoutDistancePerPulseRealisitcUpdate) {
 TEST(MotorEncoderConnectorTest, TestWithDistancePerPulseFullSpeed) {
   frc::Talon talon{3};
   frc::Encoder encoder{3, 1};
-  encoder.SetDistancePerPulse(.001);
+  encoder.SetDistancePerPulse(0.001);
 
   frc::sim::lowfi::SimpleMotorModel motorModelSim(6000);
   frc::sim::lowfi::WpiMotorSim motorSim(3, motorModelSim);
@@ -88,7 +88,7 @@ TEST(MotorEncoderConnectorTest, TestWithDistancePerPulseFullSpeed) {
 TEST(MotorEncoderConnectorTest, TestWithDistancePerPulseRealistic) {
   frc::Talon talon{3};
   frc::Encoder encoder{3, 1};
-  encoder.SetDistancePerPulse(.001);
+  encoder.SetDistancePerPulse(0.001);
 
   frc::sim::lowfi::SimpleMotorModel motorModelSim(6000);
   frc::sim::lowfi::WpiMotorSim motorSim(3, motorModelSim);
@@ -97,7 +97,7 @@ TEST(MotorEncoderConnectorTest, TestWithDistancePerPulseRealistic) {
 
   talon.Set(0.5);
 
-  motorSim.Update(.02);
+  motorSim.Update(0.02);
   connector.Update();
 
   // Position

--- a/simulation/lowfi_simulation/src/test/native/cpp/lowfisim/motormodel/SimpleMotorModelSimulationTest.cpp
+++ b/simulation/lowfi_simulation/src/test/native/cpp/lowfisim/motormodel/SimpleMotorModelSimulationTest.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -13,7 +13,7 @@ TEST(SimpleMotorModelSimulationTest, TestSimpleModel) {
 
   // Test forward voltage
   motorModelSim.SetVoltage(6);
-  motorModelSim.Update(.5);
+  motorModelSim.Update(0.5);
 
   EXPECT_DOUBLE_EQ(50, motorModelSim.GetPosition());
   EXPECT_DOUBLE_EQ(100, motorModelSim.GetVelocity());
@@ -26,7 +26,7 @@ TEST(SimpleMotorModelSimulationTest, TestSimpleModel) {
   // Test negative voltage
   motorModelSim.Reset();
   motorModelSim.SetVoltage(-3);
-  motorModelSim.Update(.06);
+  motorModelSim.Update(0.06);
 
   EXPECT_DOUBLE_EQ(-3, motorModelSim.GetPosition());
   EXPECT_DOUBLE_EQ(-50, motorModelSim.GetVelocity());

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
@@ -18,7 +18,7 @@ class CommandDecoratorTest : public CommandTestBase {};
 TEST_F(CommandDecoratorTest, WithTimeoutTest) {
   CommandScheduler scheduler = GetScheduler();
 
-  auto command = RunCommand([] {}, {}).WithTimeout(.1_s);
+  auto command = RunCommand([] {}, {}).WithTimeout(100_ms);
 
   scheduler.Schedule(&command);
 

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/WaitCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/WaitCommandTest.cpp
@@ -15,7 +15,7 @@ class WaitCommandTest : public CommandTestBase {};
 TEST_F(WaitCommandTest, WaitCommandScheduleTest) {
   CommandScheduler scheduler = GetScheduler();
 
-  WaitCommand command(.1_s);
+  WaitCommand command(100_ms);
 
   scheduler.Schedule(&command);
   scheduler.Run();

--- a/wpilibc/src/main/native/cpp/Counter.cpp
+++ b/wpilibc/src/main/native/cpp/Counter.cpp
@@ -25,7 +25,7 @@ Counter::Counter(Mode mode) {
   m_counter = HAL_InitializeCounter((HAL_Counter_Mode)mode, &m_index, &status);
   wpi_setHALError(status);
 
-  SetMaxPeriod(.5);
+  SetMaxPeriod(0.5);
 
   HAL_Report(HALUsageReporting::kResourceType_Counter, m_index + 1, mode + 1);
   SendableRegistry::GetInstance().AddLW(this, "Counter", m_index);

--- a/wpilibc/src/main/native/cpp/DMC60.cpp
+++ b/wpilibc/src/main/native/cpp/DMC60.cpp
@@ -14,7 +14,7 @@
 using namespace frc;
 
 DMC60::DMC60(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.004, 1.52, 1.50, 1.48, .997);
+  SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);
   SetZeroLatch();

--- a/wpilibc/src/main/native/cpp/Jaguar.cpp
+++ b/wpilibc/src/main/native/cpp/Jaguar.cpp
@@ -14,7 +14,7 @@
 using namespace frc;
 
 Jaguar::Jaguar(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.31, 1.55, 1.507, 1.454, .697);
+  SetBounds(2.31, 1.55, 1.507, 1.454, 0.697);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);
   SetZeroLatch();

--- a/wpilibc/src/main/native/cpp/PWMSparkMax.cpp
+++ b/wpilibc/src/main/native/cpp/PWMSparkMax.cpp
@@ -14,7 +14,7 @@
 using namespace frc;
 
 PWMSparkMax::PWMSparkMax(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.003, 1.55, 1.50, 1.46, .999);
+  SetBounds(2.003, 1.55, 1.50, 1.46, 0.999);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);
   SetZeroLatch();

--- a/wpilibc/src/main/native/cpp/PWMTalonSRX.cpp
+++ b/wpilibc/src/main/native/cpp/PWMTalonSRX.cpp
@@ -14,7 +14,7 @@
 using namespace frc;
 
 PWMTalonSRX::PWMTalonSRX(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.004, 1.52, 1.50, 1.48, .997);
+  SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);
   SetZeroLatch();

--- a/wpilibc/src/main/native/cpp/PWMVictorSPX.cpp
+++ b/wpilibc/src/main/native/cpp/PWMVictorSPX.cpp
@@ -14,7 +14,7 @@
 using namespace frc;
 
 PWMVictorSPX::PWMVictorSPX(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.004, 1.52, 1.50, 1.48, .997);
+  SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);
   SetZeroLatch();

--- a/wpilibc/src/main/native/cpp/RobotDrive.cpp
+++ b/wpilibc/src/main/native/cpp/RobotDrive.cpp
@@ -128,13 +128,13 @@ void RobotDrive::Drive(double outputMagnitude, double curve) {
   if (curve < 0) {
     double value = std::log(-curve);
     double ratio = (value - m_sensitivity) / (value + m_sensitivity);
-    if (ratio == 0) ratio = .0000000001;
+    if (ratio == 0) ratio = 0.0000000001;
     leftOutput = outputMagnitude / ratio;
     rightOutput = outputMagnitude;
   } else if (curve > 0) {
     double value = std::log(curve);
     double ratio = (value - m_sensitivity) / (value + m_sensitivity);
-    if (ratio == 0) ratio = .0000000001;
+    if (ratio == 0) ratio = 0.0000000001;
     leftOutput = outputMagnitude;
     rightOutput = outputMagnitude / ratio;
   } else {

--- a/wpilibc/src/main/native/cpp/SD540.cpp
+++ b/wpilibc/src/main/native/cpp/SD540.cpp
@@ -14,7 +14,7 @@
 using namespace frc;
 
 SD540::SD540(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.05, 1.55, 1.50, 1.44, .94);
+  SetBounds(2.05, 1.55, 1.50, 1.44, 0.94);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);
   SetZeroLatch();

--- a/wpilibc/src/main/native/cpp/Spark.cpp
+++ b/wpilibc/src/main/native/cpp/Spark.cpp
@@ -14,7 +14,7 @@
 using namespace frc;
 
 Spark::Spark(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.003, 1.55, 1.50, 1.46, .999);
+  SetBounds(2.003, 1.55, 1.50, 1.46, 0.999);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);
   SetZeroLatch();

--- a/wpilibc/src/main/native/cpp/Talon.cpp
+++ b/wpilibc/src/main/native/cpp/Talon.cpp
@@ -14,7 +14,7 @@
 using namespace frc;
 
 Talon::Talon(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.037, 1.539, 1.513, 1.487, .989);
+  SetBounds(2.037, 1.539, 1.513, 1.487, 0.989);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);
   SetZeroLatch();

--- a/wpilibc/src/main/native/cpp/VictorSP.cpp
+++ b/wpilibc/src/main/native/cpp/VictorSP.cpp
@@ -14,7 +14,7 @@
 using namespace frc;
 
 VictorSP::VictorSP(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.004, 1.52, 1.50, 1.48, .997);
+  SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
   SetPeriodMultiplier(kPeriodMultiplier_1X);
   SetSpeed(0.0);
   SetZeroLatch();

--- a/wpilibc/src/main/native/include/frc/PWM.h
+++ b/wpilibc/src/main/native/include/frc/PWM.h
@@ -34,7 +34,7 @@ class SendableBuilder;
  *   - 1999 to 1001 = linear scaling from "full forward" to "center"
  *   - 1000 = center value
  *   - 999 to 2 = linear scaling from "center" to "full reverse"
- *   - 1 = minimum pulse width (currently .5ms)
+ *   - 1 = minimum pulse width (currently 0.5ms)
  *   - 0 = disabled (i.e. PWM output is held low)
  */
 class PWM : public MotorSafety, public Sendable, public SendableHelper<PWM> {

--- a/wpilibc/src/main/native/include/frc/Servo.h
+++ b/wpilibc/src/main/native/include/frc/Servo.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -105,7 +105,7 @@ class Servo : public PWM {
   static constexpr double kMinServoAngle = 0.0;
 
   static constexpr double kDefaultMaxServoPWM = 2.4;
-  static constexpr double kDefaultMinServoPWM = .6;
+  static constexpr double kDefaultMinServoPWM = 0.6;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/geometry/Pose2d.h
+++ b/wpilibc/src/main/native/include/frc/geometry/Pose2d.h
@@ -150,8 +150,8 @@ class Pose2d {
    *
    * @param twist The change in pose in the robot's coordinate frame since the
    * previous pose update. For example, if a non-holonomic robot moves forward
-   * 0.01 meters and changes angle by .5 degrees since the previous pose update,
-   * the twist would be Twist2d{0.01, 0.0, toRadians(0.5)}
+   * 0.01 meters and changes angle by 0.5 degrees since the previous pose
+   * update, the twist would be Twist2d{0.01, 0.0, toRadians(0.5)}
    *
    * @return The new pose of the robot.
    */

--- a/wpilibc/src/test/native/cpp/controller/PIDInputOutputTest.cpp
+++ b/wpilibc/src/test/native/cpp/controller/PIDInputOutputTest.cpp
@@ -27,7 +27,7 @@ TEST_F(PIDInputOutputTest, ContinuousInputTest) {
 TEST_F(PIDInputOutputTest, ProportionalGainOutputTest) {
   controller->SetP(4);
 
-  EXPECT_DOUBLE_EQ(-.1, controller->Calculate(.025, 0));
+  EXPECT_DOUBLE_EQ(-0.1, controller->Calculate(0.025, 0));
 }
 
 TEST_F(PIDInputOutputTest, IntegralGainOutputTest) {
@@ -36,10 +36,10 @@ TEST_F(PIDInputOutputTest, IntegralGainOutputTest) {
   double out = 0;
 
   for (int i = 0; i < 5; i++) {
-    out = controller->Calculate(.025, 0);
+    out = controller->Calculate(0.025, 0);
   }
 
-  EXPECT_DOUBLE_EQ(-.5 * controller->GetPeriod().to<double>(), out);
+  EXPECT_DOUBLE_EQ(-0.5 * controller->GetPeriod().to<double>(), out);
 }
 
 TEST_F(PIDInputOutputTest, DerivativeGainOutputTest) {
@@ -47,6 +47,6 @@ TEST_F(PIDInputOutputTest, DerivativeGainOutputTest) {
 
   controller->Calculate(0, 0);
 
-  EXPECT_DOUBLE_EQ(-.01_s / controller->GetPeriod(),
-                   controller->Calculate(.0025, 0));
+  EXPECT_DOUBLE_EQ(-10_ms / controller->GetPeriod(),
+                   controller->Calculate(0.0025, 0));
 }

--- a/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/subsystems/DriveSubsystem.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/subsystems/DriveSubsystem.cpp
@@ -35,7 +35,7 @@ void DriveSubsystem::ResetEncoders() {
 }
 
 double DriveSubsystem::GetAverageEncoderDistance() {
-  return (m_leftEncoder.GetDistance() + m_rightEncoder.GetDistance()) / 2.;
+  return (m_leftEncoder.GetDistance() + m_rightEncoder.GetDistance()) / 2.0;
 }
 
 frc::Encoder& DriveSubsystem::GetLeftEncoder() { return m_leftEncoder; }

--- a/wpilibcExamples/src/main/cpp/examples/Frisbeebot/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/Frisbeebot/include/Constants.h
@@ -43,7 +43,7 @@ constexpr bool kEncoderReversed = false;
 constexpr int kEncoderCPR = 1024;
 constexpr double kEncoderDistancePerPulse =
     // Distance units will be rotations
-    1. / static_cast<double>(kEncoderCPR);
+    1.0 / static_cast<double>(kEncoderCPR);
 
 constexpr int kShooterMotorPort = 4;
 constexpr int kFeederMotorPort = 5;
@@ -58,12 +58,12 @@ constexpr double kD = 0;
 
 // On a real robot the feedforward constants should be empirically determined;
 // these are reasonable guesses.
-constexpr auto kS = .05_V;
+constexpr auto kS = 0.05_V;
 constexpr auto kV =
     // Should have value 12V at free speed...
     12_V / kShooterFreeRPS;
 
-constexpr double kFeederSpeed = .5;
+constexpr double kFeederSpeed = 0.5;
 }  // namespace ShooterConstants
 
 namespace AutoConstants {

--- a/wpilibcExamples/src/main/cpp/examples/Frisbeebot/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/Frisbeebot/include/RobotContainer.h
@@ -90,7 +90,7 @@ class RobotContainer {
   frc2::InstantCommand m_stopFeeder{[this] { m_shooter.StopFeeder(); },
                                     {&m_shooter}};
 
-  frc2::InstantCommand m_driveHalfSpeed{[this] { m_drive.SetMaxOutput(.5); },
+  frc2::InstantCommand m_driveHalfSpeed{[this] { m_drive.SetMaxOutput(0.5); },
                                         {}};
   frc2::InstantCommand m_driveFullSpeed{[this] { m_drive.SetMaxOutput(1); },
                                         {}};

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/subsystems/DriveSubsystem.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/subsystems/DriveSubsystem.cpp
@@ -35,7 +35,7 @@ void DriveSubsystem::ResetEncoders() {
 }
 
 double DriveSubsystem::GetAverageEncoderDistance() {
-  return (m_leftEncoder.GetDistance() + m_rightEncoder.GetDistance()) / 2.;
+  return (m_leftEncoder.GetDistance() + m_rightEncoder.GetDistance()) / 2.0;
 }
 
 frc::Encoder& DriveSubsystem::GetLeftEncoder() { return m_leftEncoder; }
@@ -47,9 +47,9 @@ void DriveSubsystem::SetMaxOutput(double maxOutput) {
 }
 
 double DriveSubsystem::GetHeading() {
-  return std::remainder(m_gyro.GetAngle(), 360) * (kGyroReversed ? -1. : 1.);
+  return std::remainder(m_gyro.GetAngle(), 360) * (kGyroReversed ? -1.0 : 1.0);
 }
 
 double DriveSubsystem::GetTurnRate() {
-  return m_gyro.GetRate() * (kGyroReversed ? -1. : 1.);
+  return m_gyro.GetRate() * (kGyroReversed ? -1.0 : 1.0);
 }

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/include/Constants.h
@@ -38,7 +38,7 @@ constexpr double kEncoderDistancePerPulse =
 constexpr bool kGyroReversed = true;
 
 constexpr double kStabilizationP = 1;
-constexpr double kStabilizationI = .5;
+constexpr double kStabilizationI = 0.5;
 constexpr double kStabilizationD = 0;
 
 constexpr double kTurnP = 1;
@@ -52,7 +52,7 @@ constexpr double kTurnRateToleranceDegPerS = 10;  // degrees per second
 namespace AutoConstants {
 constexpr double kAutoDriveDistanceInches = 60;
 constexpr double kAutoBackupDistanceInches = 20;
-constexpr double kAutoDriveSpeed = .5;
+constexpr double kAutoDriveSpeed = 0.5;
 }  // namespace AutoConstants
 
 namespace OIConstants {

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/include/RobotContainer.h
@@ -68,7 +68,7 @@ class RobotContainer {
       // Require the robot drive
       {&m_drive}};
 
-  frc2::InstantCommand m_driveHalfSpeed{[this] { m_drive.SetMaxOutput(.5); },
+  frc2::InstantCommand m_driveHalfSpeed{[this] { m_drive.SetMaxOutput(0.5); },
                                         {}};
   frc2::InstantCommand m_driveFullSpeed{[this] { m_drive.SetMaxOutput(1); },
                                         {}};

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/subsystems/DriveSubsystem.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/subsystems/DriveSubsystem.cpp
@@ -35,7 +35,7 @@ void DriveSubsystem::ResetEncoders() {
 }
 
 double DriveSubsystem::GetAverageEncoderDistance() {
-  return (m_leftEncoder.GetDistance() + m_rightEncoder.GetDistance()) / 2.;
+  return (m_leftEncoder.GetDistance() + m_rightEncoder.GetDistance()) / 2.0;
 }
 
 frc::Encoder& DriveSubsystem::GetLeftEncoder() { return m_leftEncoder; }

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/Constants.h
@@ -44,7 +44,7 @@ constexpr int kHatchSolenoidPorts[]{0, 1};
 namespace AutoConstants {
 constexpr double kAutoDriveDistanceInches = 60;
 constexpr double kAutoBackupDistanceInches = 20;
-constexpr double kAutoDriveSpeed = .5;
+constexpr double kAutoDriveSpeed = 0.5;
 }  // namespace AutoConstants
 
 namespace OIConstants {

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/RobotContainer.h
@@ -63,7 +63,7 @@ class RobotContainer {
   frc2::InstantCommand m_grabHatch{[this] { m_hatch.GrabHatch(); }, {&m_hatch}};
   frc2::InstantCommand m_releaseHatch{[this] { m_hatch.ReleaseHatch(); },
                                       {&m_hatch}};
-  frc2::InstantCommand m_driveHalfSpeed{[this] { m_drive.SetMaxOutput(.5); },
+  frc2::InstantCommand m_driveHalfSpeed{[this] { m_drive.SetMaxOutput(0.5); },
                                         {}};
   frc2::InstantCommand m_driveFullSpeed{[this] { m_drive.SetMaxOutput(1); },
                                         {}};

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/commands/HalveDriveSpeed.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/commands/HalveDriveSpeed.cpp
@@ -10,6 +10,6 @@
 HalveDriveSpeed::HalveDriveSpeed(DriveSubsystem* subsystem)
     : m_drive(subsystem) {}
 
-void HalveDriveSpeed::Initialize() { m_drive->SetMaxOutput(.5); }
+void HalveDriveSpeed::Initialize() { m_drive->SetMaxOutput(0.5); }
 
 void HalveDriveSpeed::End(bool interrupted) { m_drive->SetMaxOutput(1); }

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/subsystems/DriveSubsystem.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/subsystems/DriveSubsystem.cpp
@@ -35,7 +35,7 @@ void DriveSubsystem::ResetEncoders() {
 }
 
 double DriveSubsystem::GetAverageEncoderDistance() {
-  return (m_leftEncoder.GetDistance() + m_rightEncoder.GetDistance()) / 2.;
+  return (m_leftEncoder.GetDistance() + m_rightEncoder.GetDistance()) / 2.0;
 }
 
 frc::Encoder& DriveSubsystem::GetLeftEncoder() { return m_leftEncoder; }

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/include/Constants.h
@@ -44,7 +44,7 @@ constexpr int kHatchSolenoidPorts[]{0, 1};
 namespace AutoConstants {
 constexpr double kAutoDriveDistanceInches = 60;
 constexpr double kAutoBackupDistanceInches = 20;
-constexpr double kAutoDriveSpeed = .5;
+constexpr double kAutoDriveSpeed = 0.5;
 }  // namespace AutoConstants
 
 namespace OIConstants {

--- a/wpilibcExamples/src/main/cpp/examples/RamseteCommand/cpp/subsystems/DriveSubsystem.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RamseteCommand/cpp/subsystems/DriveSubsystem.cpp
@@ -47,7 +47,7 @@ void DriveSubsystem::ResetEncoders() {
 }
 
 double DriveSubsystem::GetAverageEncoderDistance() {
-  return (m_leftEncoder.GetDistance() + m_rightEncoder.GetDistance()) / 2.;
+  return (m_leftEncoder.GetDistance() + m_rightEncoder.GetDistance()) / 2.0;
 }
 
 frc::Encoder& DriveSubsystem::GetLeftEncoder() { return m_leftEncoder; }
@@ -59,11 +59,11 @@ void DriveSubsystem::SetMaxOutput(double maxOutput) {
 }
 
 double DriveSubsystem::GetHeading() {
-  return std::remainder(m_gyro.GetAngle(), 360) * (kGyroReversed ? -1. : 1.);
+  return std::remainder(m_gyro.GetAngle(), 360) * (kGyroReversed ? -1.0 : 1.0);
 }
 
 double DriveSubsystem::GetTurnRate() {
-  return m_gyro.GetRate() * (kGyroReversed ? -1. : 1.);
+  return m_gyro.GetRate() * (kGyroReversed ? -1.0 : 1.0);
 }
 
 frc::Pose2d DriveSubsystem::GetPose() { return m_odometry.GetPose(); }

--- a/wpilibcExamples/src/main/cpp/examples/RamseteCommand/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/RamseteCommand/include/Constants.h
@@ -32,7 +32,7 @@ constexpr int kRightEncoderPorts[]{2, 3};
 constexpr bool kLeftEncoderReversed = false;
 constexpr bool kRightEncoderReversed = true;
 
-constexpr auto kTrackwidth = .6_m;
+constexpr auto kTrackwidth = 0.6_m;
 constexpr frc::DifferentialDriveKinematics kDriveKinematics(kTrackwidth);
 
 constexpr int kEncoderCPR = 1024;
@@ -49,11 +49,11 @@ constexpr bool kGyroReversed = true;
 // Toolsuite provides a convenient tool for obtaining these values for your
 // robot.
 constexpr auto ks = 1_V;
-constexpr auto kv = .8 * 1_V * 1_s / 1_m;
-constexpr auto ka = .15 * 1_V * 1_s * 1_s / 1_m;
+constexpr auto kv = 0.8 * 1_V * 1_s / 1_m;
+constexpr auto ka = 0.15 * 1_V * 1_s * 1_s / 1_m;
 
 // Example value only - as above, this must be tuned for your drive!
-constexpr double kPDriveVel = .5;
+constexpr double kPDriveVel = 0.5;
 }  // namespace DriveConstants
 
 namespace AutoConstants {
@@ -63,7 +63,7 @@ constexpr auto kMaxAcceleration = 3_mps_sq;
 // Reasonable baseline values for a RAMSETE follower in units of meters and
 // seconds
 constexpr double kRamseteB = 2;
-constexpr double kRamseteZeta = .7;
+constexpr double kRamseteZeta = 0.7;
 }  // namespace AutoConstants
 
 namespace OIConstants {

--- a/wpilibcExamples/src/main/cpp/examples/RamseteCommand/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/RamseteCommand/include/RobotContainer.h
@@ -41,7 +41,7 @@ class RobotContainer {
   // The robot's subsystems
   DriveSubsystem m_drive;
 
-  frc2::InstantCommand m_driveHalfSpeed{[this] { m_drive.SetMaxOutput(.5); },
+  frc2::InstantCommand m_driveHalfSpeed{[this] { m_drive.SetMaxOutput(0.5); },
                                         {}};
   frc2::InstantCommand m_driveFullSpeed{[this] { m_drive.SetMaxOutput(1); },
                                         {}};

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/geometry/Pose2d.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/geometry/Pose2d.java
@@ -154,7 +154,7 @@ public class Pose2d {
    *
    * @param twist The change in pose in the robot's coordinate frame since the
    *              previous pose update. For example, if a non-holonomic robot moves forward
-   *              0.01 meters and changes angle by .5 degrees since the previous pose update,
+   *              0.01 meters and changes angle by 0.5 degrees since the previous pose update,
    *              the twist would be Twist2d{0.01, 0.0, toRadians(0.5)}
    * @return The new pose of the robot.
    */


### PR DESCRIPTION
I found formatting errors with this regex
`"([^a-z0-9\.]\.[0-9]|[^a-z0-9\.][0-9]\.[^a-z0-9\.])"` and ignored false
positives.

Fixes #2112.