### PR TITLE
Remove unnecessary constructor arg for LinearFilter's circular buffers

### DIFF
--- a/wpilibc/src/main/native/include/frc/LinearFilter.h
+++ b/wpilibc/src/main/native/include/frc/LinearFilter.h
@@ -141,8 +141,8 @@ class LinearFilter {
   double Calculate(double input);
 
  private:
-  wpi::circular_buffer<double> m_inputs{0};
-  wpi::circular_buffer<double> m_outputs{0};
+  wpi::circular_buffer<double> m_inputs;
+  wpi::circular_buffer<double> m_outputs;
   std::vector<double> m_inputGains;
   std::vector<double> m_outputGains;
 };


### PR DESCRIPTION
They are initialized in LinearFilter's constructor, so the default is
never used.