### PR TITLE
[hal] Use std::thread for Notifier thread on Rio

### DIFF
--- a/hal/src/main/native/athena/Notifier.cpp
+++ b/hal/src/main/native/athena/Notifier.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2016-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2016-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/hal/src/main/native/athena/Notifier.cpp
+++ b/hal/src/main/native/athena/Notifier.cpp
@@ -10,10 +10,10 @@
 #include <atomic>
 #include <cstdlib>  // For std::atexit()
 #include <memory>
+#include <thread>
 
 #include <wpi/condition_variable.h>
 #include <wpi/mutex.h>
-#include <thread>
 
 #include "HALInitializer.h"
 #include "HALInternal.h"


### PR DESCRIPTION
Will depend on a new image, but puts us in control of the thread that is used. 