### PR TITLE
Try catch around task dependancies

### DIFF
--- a/myRobot/build.gradle
+++ b/myRobot/build.gradle
@@ -86,18 +86,27 @@ deploy {
 }
 
 tasks.register('deployJava') {
-    dependsOn tasks.named('deployJreRoborio')
-    dependsOn tasks.named('deployMyRobotJavaRoborio')
-    dependsOn tasks.named('deployMyRobotCppLibrariesRoborio')
+    try {
+        dependsOn tasks.named('deployJreRoborio')
+        dependsOn tasks.named('deployMyRobotJavaRoborio')
+        dependsOn tasks.named('deployMyRobotCppLibrariesRoborio')
+    } catch (ignored) {
+    }
 }
 
 tasks.register('deployShared') {
-    dependsOn tasks.named('deployMyRobotCppLibrariesRoborio')
-    dependsOn tasks.named('deployMyRobotCppRoborio')
+    try {
+        dependsOn tasks.named('deployMyRobotCppLibrariesRoborio')
+        dependsOn tasks.named('deployMyRobotCppRoborio')
+    } catch (ignored) {
+    }
 }
 
 tasks.register('deployStatic') {
-    dependsOn tasks.named('deployMyRobotCppStaticRoborio')
+    try {
+        dependsOn tasks.named('deployMyRobotCppStaticRoborio')
+    } catch (ignored) {
+    }
 }
 
 mainClassName = 'Main'


### PR DESCRIPTION
```
<ij_msg_gr>Gradle import errors<ij_msg_gr><ij_nav>/Users/austinshalit/git/allwpilib/myRobot/build.gradle<ij_nav><i><b>project ':myRobot': Unable to build Kotlin project configuration</b><eol>Details: org.gradle.api.internal.tasks.DefaultTaskContainer$TaskCreationException: Could not create task ':myRobot:deployJava'.<eol>Caused by: org.gradle.api.UnknownTaskException: Task with name 'deployMyRobotCppLibrariesRoborio' not found in project ':myRobot'.</i>
<ij_msg_gr>Project resolve errors<ij_msg_gr><ij_nav>/Users/austinshalit/git/allwpilib/build.gradle<ij_nav><i><b>root project 'allwpilib': Unable to resolve additional project configuration.</b><eol>Details: org.gradle.api.internal.tasks.DefaultTaskContainer$TaskCreationException: Could not create task ':myRobot:deployShared'.<eol>Caused by: org.gradle.api.UnknownTaskException: Task with name 'deployMyRobotCppLibrariesRoborio' not found in project ':myRobot'.</i>
```


>Those might need to be surrounded by a try catch Austin
>Builds are fine, but intellij must attempt to actually resolve all tasks
>Gradle only does it if you actually call the tasks
>In build.gradle for myrobot, in the custom deploys added, surround their internals with try catch