### PR TITLE
Replace std::is_pod_v with std::is_standard_layout_v

### DIFF
--- a/hal/src/main/native/athena/DMA.cpp
+++ b/hal/src/main/native/athena/DMA.cpp
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstring>
 #include <memory>
+#include <type_traits>
 
 #include "AnalogInternal.h"
 #include "DigitalInternal.h"
@@ -28,7 +29,8 @@
 
 using namespace hal;
 
-static_assert(std::is_pod_v<HAL_DMASample>, "DMA Sample must be POD");
+static_assert(std::is_standard_layout_v<HAL_DMASample>,
+              "HAL_DMASample must have standard layout");
 
 namespace {
 

--- a/wpilibc/src/main/native/include/frc/DMASample.h
+++ b/wpilibc/src/main/native/include/frc/DMASample.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <hal/AnalogInput.h>
 #include <hal/DMA.h>
 #include <units/units.h>
@@ -104,5 +106,6 @@ class DMASample : public HAL_DMASample {
   }
 };
 
-static_assert(std::is_pod_v<frc::DMASample>, "DMA Sample MUST Be POD");
+static_assert(std::is_standard_layout_v<frc::DMASample>,
+              "frc::DMASample must have standard layout");
 }  // namespace frc


### PR DESCRIPTION
The former is deprecated in C++20.