### PR TITLE
Add hidden functions to get the SPI system and SPI DMA

### DIFF
--- a/hal/src/main/native/athena/SPI.cpp
+++ b/hal/src/main/native/athena/SPI.cpp
@@ -635,12 +635,8 @@ int32_t HAL_GetSPIAutoDroppedCount(HAL_SPIPort port, int32_t* status) {
 // can be tested. How they're used is not very clear
 // but I want them to be testable so we can add an impl.
 // We will not be including these in the headers
-void* HAL_GetSPIDMAManager() {
-  return spiAutoDMA.get();
-}
+void* HAL_GetSPIDMAManager() { return spiAutoDMA.get(); }
 
-void* HAL_GetSPISystem() {
-  return spiSystem.get();
-}
+void* HAL_GetSPISystem() { return spiSystem.get(); }
 
 }  // extern "C"

--- a/hal/src/main/native/athena/SPI.cpp
+++ b/hal/src/main/native/athena/SPI.cpp
@@ -631,4 +631,16 @@ int32_t HAL_GetSPIAutoDroppedCount(HAL_SPIPort port, int32_t* status) {
   return spiSystem->readTransferSkippedFullCount(status);
 }
 
+// These 2 functions are so the new stall functionality
+// can be tested. How they're used is not very clear
+// but I want them to be testable so we can add an impl.
+// We will not be including these in the headers
+void* HAL_GetSPIDMAManager() {
+  return spiAutoDMA.get();
+}
+
+void* HAL_GetSPISystem() {
+  return spiSystem.get();
+}
+
 }  // extern "C"


### PR DESCRIPTION
With the addition of stall configuration, its not very clear how it works, and seems like it would be different
per use. So adding ways to manually get them, so the functionality can be figured out how to be used.