### PR TITLE
Fix javadoc in SwerveDriveKinematicsConstraint.

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/SwerveDriveKinematicsConstraint.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/SwerveDriveKinematicsConstraint.java
@@ -22,7 +22,7 @@ public class SwerveDriveKinematicsConstraint implements TrajectoryConstraint {
   private final SwerveDriveKinematics m_kinematics;
 
   /**
-   * Constructs a mecanum drive dynamics constraint.
+   * Constructs a swerve drive dynamics constraint.
    *
    * @param maxSpeedMetersPerSecond The max speed that a side of the robot can travel at.
    */


### PR DESCRIPTION
Fix a javadoc in SwerveDriveKinematicsConstraint that says 

> Constructs a mecanum drive dynamics constraint.
