### PR TITLE
Use ManagedStatic for CameraServer

### DIFF
--- a/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
+++ b/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
@@ -52,7 +52,7 @@ CameraServer* CameraServer::GetInstance() {
     static void* call() { return new CameraServer{}; }
   };
   struct Deleter {
-    static void call(void* ptr) { delete reinterpret_cast<CameraServer*>(ptr); }
+    static void call(void* ptr) { delete static_cast<CameraServer*>(ptr); }
   };
   static wpi::ManagedStatic<CameraServer, Creator, Deleter> instance;
   return &(*instance);

--- a/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
+++ b/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
@@ -13,6 +13,7 @@
 #include <networktables/NetworkTable.h>
 #include <networktables/NetworkTableInstance.h>
 #include <wpi/DenseMap.h>
+#include <wpi/ManagedStatic.h>
 #include <wpi/SmallString.h>
 #include <wpi/StringMap.h>
 #include <wpi/mutex.h>
@@ -47,8 +48,14 @@ struct CameraServer::Impl {
 };
 
 CameraServer* CameraServer::GetInstance() {
-  static CameraServer instance;
-  return &instance;
+  struct Creator {
+    static void* call() { return new CameraServer{}; }
+  };
+  struct Deleter {
+    static void call(void* ptr) { delete reinterpret_cast<CameraServer*>(ptr); }
+  };
+  static wpi::ManagedStatic<CameraServer, Creator, Deleter> instance;
+  return &(*instance);
 }
 
 static wpi::StringRef MakeSourceValue(CS_Source source,


### PR DESCRIPTION
Closes #1666 

On Windows, as soon as Main ends, you cannot access any libraries, and all threads are dead. This causes USB Cameras on windows to crash hard on shutdown.