### PR TITLE
Add getter for initial pose in Trajectory

### DIFF
--- a/wpilibc/src/main/native/include/frc/trajectory/Trajectory.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/Trajectory.h
@@ -110,7 +110,7 @@ class Trajectory {
    *
    * @return The initial pose of the trajectory.
    */
-  const Pose2d& InitialPose() const { return Sample(0_s).pose; }
+  Pose2d InitialPose() const { return Sample(0_s).pose; }
 
  private:
   std::vector<State> m_states;

--- a/wpilibc/src/main/native/include/frc/trajectory/Trajectory.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/Trajectory.h
@@ -105,6 +105,13 @@ class Trajectory {
    */
   State Sample(units::second_t t) const;
 
+  /**
+   * Returns the initial pose of the trajectory.
+   *
+   * @return The initial pose of the trajectory.
+   */
+  const Pose2d& InitialPose() const { return Sample(0_s).pose; }
+
  private:
   std::vector<State> m_states;
   units::second_t m_totalTime;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/Trajectory.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/Trajectory.java
@@ -66,7 +66,7 @@ public class Trajectory {
    * @return The initial pose of the trajectory.
    */
   public Pose2d getInitialPose() {
-      return sample(0).poseMeters;
+    return sample(0).poseMeters;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/Trajectory.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/Trajectory.java
@@ -59,7 +59,7 @@ public class Trajectory {
   private static Pose2d lerp(Pose2d startValue, Pose2d endValue, double t) {
     return startValue.plus((endValue.minus(startValue)).times(t));
   }
-  
+
   /**
    * Returns the initial pose of the trajectory.
    *

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/Trajectory.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/Trajectory.java
@@ -59,6 +59,15 @@ public class Trajectory {
   private static Pose2d lerp(Pose2d startValue, Pose2d endValue, double t) {
     return startValue.plus((endValue.minus(startValue)).times(t));
   }
+  
+  /**
+   * Returns the initial pose of the trajectory.
+   *
+   * @return The initial pose of the trajectory.
+   */
+  public Pose2d getInitialPose() {
+      return sample(0).poseMeters;
+  }
 
   /**
    * Returns the overall duration of the trajectory.


### PR DESCRIPTION
This is useful for teams who want to reset their odometry to the initial pose of the trajectory before traversing it.

Example usage:
`m_odometry.resetPose(trajectory.getInitialPose()` or `m_odometry.ResetPose(trajectory.InitialPose())`