### PR TITLE
Use an explicit stack instead of recursion when parameterizing splines

### DIFF
--- a/wpilibc/src/main/native/cpp/trajectory/TrajectoryGenerator.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/TrajectoryGenerator.cpp
@@ -9,12 +9,15 @@
 
 #include <utility>
 
-#include "frc/spline/SplineHelper.h"
-#include "frc/trajectory/TrajectoryParameterizer.h"
-#include "frc/spline/SplineParameterizer.h"
 #include "frc/DriverStation.h"
+#include "frc/spline/SplineHelper.h"
+#include "frc/spline/SplineParameterizer.h"
+#include "frc/trajectory/TrajectoryParameterizer.h"
 
 using namespace frc;
+
+const Trajectory TrajectoryGenerator::kDoNothingTrajectory(
+    std::vector<Trajectory::State>{Trajectory::State()});
 
 Trajectory TrajectoryGenerator::GenerateTrajectory(
     Spline<3>::ControlVector initial,
@@ -33,8 +36,9 @@ Trajectory TrajectoryGenerator::GenerateTrajectory(
 
   std::vector<frc::SplineParameterizer::PoseWithCurvature> points;
   try {
-      points = SplinePointsFromSplines(SplineHelper::CubicSplinesFromControlVectors(
-          initial, interiorWaypoints, end));
+    points =
+        SplinePointsFromSplines(SplineHelper::CubicSplinesFromControlVectors(
+            initial, interiorWaypoints, end));
   } catch (SplineParameterizer::MalformedSplineException& e) {
     DriverStation::ReportError(e.what());
     return kDoNothingTrajectory;

--- a/wpilibc/src/main/native/cpp/trajectory/TrajectoryGenerator.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/TrajectoryGenerator.cpp
@@ -33,7 +33,7 @@ Trajectory TrajectoryGenerator::GenerateTrajectory(
 
   std::vector<frc::SplineParameterizer::PoseWithCurvature> points;
   try {
-      SplinePointsFromSplines(SplineHelper::CubicSplinesFromControlVectors(
+      points = SplinePointsFromSplines(SplineHelper::CubicSplinesFromControlVectors(
           initial, interiorWaypoints, end));
   } catch (SplineParameterizer::MalformedSplineException& e) {
     DriverStation::ReportError(e.what());
@@ -77,7 +77,7 @@ Trajectory TrajectoryGenerator::GenerateTrajectory(
 
   std::vector<frc::SplineParameterizer::PoseWithCurvature> points;
   try {
-    SplinePointsFromSplines(
+    points = SplinePointsFromSplines(
         SplineHelper::QuinticSplinesFromControlVectors(controlVectors));
   } catch (SplineParameterizer::MalformedSplineException& e) {
     DriverStation::ReportError(e.what());

--- a/wpilibc/src/main/native/cpp/trajectory/TrajectoryGenerator.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/TrajectoryGenerator.cpp
@@ -11,6 +11,8 @@
 
 #include "frc/spline/SplineHelper.h"
 #include "frc/trajectory/TrajectoryParameterizer.h"
+#include "frc/spline/SplineParameterizer.h"
+#include "frc/DriverStation.h"
 
 using namespace frc;
 
@@ -29,9 +31,14 @@ Trajectory TrajectoryGenerator::GenerateTrajectory(
     end.y[1] *= -1;
   }
 
-  auto points =
+  std::vector<frc::SplineParameterizer::PoseWithCurvature> points;
+  try {
       SplinePointsFromSplines(SplineHelper::CubicSplinesFromControlVectors(
           initial, interiorWaypoints, end));
+  } catch (SplineParameterizer::MalformedSplineException& e) {
+    DriverStation::ReportError(e.what());
+    return kDoNothingTrajectory;
+  }
 
   // After trajectory generation, flip theta back so it's relative to the
   // field. Also fix curvature.
@@ -68,8 +75,14 @@ Trajectory TrajectoryGenerator::GenerateTrajectory(
     }
   }
 
-  auto points = SplinePointsFromSplines(
-      SplineHelper::QuinticSplinesFromControlVectors(controlVectors));
+  std::vector<frc::SplineParameterizer::PoseWithCurvature> points;
+  try {
+    SplinePointsFromSplines(
+        SplineHelper::QuinticSplinesFromControlVectors(controlVectors));
+  } catch (SplineParameterizer::MalformedSplineException& e) {
+    DriverStation::ReportError(e.what());
+    return kDoNothingTrajectory;
+  }
 
   // After trajectory generation, flip theta back so it's relative to the
   // field. Also fix curvature.

--- a/wpilibc/src/main/native/include/frc/spline/SplineParameterizer.h
+++ b/wpilibc/src/main/native/include/frc/spline/SplineParameterizer.h
@@ -35,8 +35,10 @@
 
 #include <utility>
 #include <vector>
+#include <stack>
 
 #include <units/units.h>
+#include <wpi/Twine.h>
 
 namespace frc {
 
@@ -46,6 +48,10 @@ namespace frc {
 class SplineParameterizer {
  public:
   using PoseWithCurvature = std::pair<Pose2d, curvature_t>;
+
+  struct MalformedSplineException : public std::runtime_error {
+    MalformedSplineException(const std::string& what_arg) : runtime_error(what_arg) {}
+  };
 
   /**
    * Parameterizes the spline. This method breaks up the spline into various
@@ -64,14 +70,49 @@ class SplineParameterizer {
   static std::vector<PoseWithCurvature> Parameterize(const Spline<Dim>& spline,
                                                      double t0 = 0.0,
                                                      double t1 = 1.0) {
-    std::vector<PoseWithCurvature> arr;
+    std::vector<PoseWithCurvature> splinePoints;
 
-    // The parameterization does not add the first initial point. Let's add
-    // that.
-    arr.push_back(spline.GetPoint(t0));
+    // The parameterization does not add the initial point. Let's add that.
+    splinePoints.push_back(spline.GetPoint(t0));
 
-    GetSegmentArc(spline, &arr, t0, t1);
-    return arr;
+    // We use an "explicit stack" to simulate recursion, instead of a recursive function call
+    // This give us greater control, instead of a stack overflow
+    std::stack<StackContents> stack;
+    stack.emplace(StackContents{t0, t1});
+
+    StackContents current;
+    PoseWithCurvature start;
+    PoseWithCurvature end;
+    int iterations = 0;
+
+    while (!stack.empty()) {
+      current = stack.top();
+      start = spline.GetPoint(current.t0);
+      end = spline.GetPoint(current.t1);
+
+      const auto twist = start.first.Log(end.first);
+
+      if (units::math::abs(twist.dy) > kMaxDy ||
+          units::math::abs(twist.dx) > kMaxDx ||
+          units::math::abs(twist.dtheta) > kMaxDtheta) {
+        stack.emplace(StackContents{(current.t0 + current.t1) / 2, current.t1});
+        stack.emplace(StackContents{current.t0, (current.t0 + current.t1) / 2});
+      } else {
+        splinePoints.push_back(spline.GetPoint(current.t1));
+      }
+
+      if (iterations++ >= kMaxIterations) {
+        throw MalformedSplineException(
+            (wpi::Twine{"Could not parameterize a malformed spline. "}
+            + "This means that you probably had two or more adjacent waypoints "
+            + "that were very close together with headings in opposing directions.").str()
+          );
+      }
+
+      stack.pop();
+    }
+
+    return splinePoints;
   }
 
  private:
@@ -80,33 +121,19 @@ class SplineParameterizer {
   static constexpr units::meter_t kMaxDy = 0.05_in;
   static constexpr units::radian_t kMaxDtheta = 0.0872_rad;
 
+  struct StackContents {
+    double t1;
+    double t0;
+  };
+
   /**
-   * Breaks up the spline into arcs until the dx, dy, and theta of each arc is
-   * within tolerance.
-   *
-   * @param spline The spline to parameterize.
-   * @param vector Pointer to vector of poses.
-   * @param t0 Starting point for arc.
-   * @param t1 Ending point for arc.
+   * A malformed spline does not actually explode the LIFO stack size. Instead,
+   * the stack size stays at a relatively small number (e.g. 30) and never
+   * decreases. Because of this, we must count iterations. Even long, complex
+   * paths don't usually go over 300 iterations, so hitting this maximum should
+   * definitely indicate something has gone wrong.
    */
-  template <int Dim>
-  static void GetSegmentArc(const Spline<Dim>& spline,
-                            std::vector<PoseWithCurvature>* vector, double t0,
-                            double t1) {
-    const auto start = spline.GetPoint(t0);
-    const auto end = spline.GetPoint(t1);
-
-    const auto twist = start.first.Log(end.first);
-
-    if (units::math::abs(twist.dy) > kMaxDy ||
-        units::math::abs(twist.dx) > kMaxDx ||
-        units::math::abs(twist.dtheta) > kMaxDtheta) {
-      GetSegmentArc(spline, vector, t0, (t0 + t1) / 2);
-      GetSegmentArc(spline, vector, (t0 + t1) / 2, t1);
-    } else {
-      vector->push_back(spline.GetPoint(t1));
-    }
-  }
+  static constexpr int kMaxIterations = 5000;
 
   friend class CubicHermiteSplineTest;
   friend class QuinticHermiteSplineTest;

--- a/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
@@ -113,5 +113,9 @@ class TrajectoryGenerator {
     }
     return splinePoints;
   }
+
+  private:
+    static const Trajectory kDoNothingTrajectory;
 };
+const Trajectory TrajectoryGenerator::kDoNothingTrajectory(std::vector<Trajectory::State>{Trajectory::State()});
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
@@ -114,8 +114,7 @@ class TrajectoryGenerator {
     return splinePoints;
   }
 
-  private:
-    static const Trajectory kDoNothingTrajectory;
+ private:
+  static const Trajectory kDoNothingTrajectory;
 };
-const Trajectory TrajectoryGenerator::kDoNothingTrajectory(std::vector<Trajectory::State>{Trajectory::State()});
 }  // namespace frc

--- a/wpilibc/src/test/native/cpp/spline/CubicHermiteSplineTest.cpp
+++ b/wpilibc/src/test/native/cpp/spline/CubicHermiteSplineTest.cpp
@@ -120,3 +120,16 @@ TEST_F(CubicHermiteSplineTest, OneInterior) {
   Pose2d end{4_m, 0_m, 0_rad};
   Run(start, waypoints, end);
 }
+
+TEST_F(CubicHermiteSplineTest, Malformed) {
+  EXPECT_THROW(Run(
+    Pose2d{0_m, 0_m, Rotation2d(0_deg)},
+    std::vector<Translation2d>{},
+    Pose2d{1_m, 0_m, Rotation2d(180_deg)}
+  ), SplineParameterizer::MalformedSplineException);
+  EXPECT_THROW(Run(
+    Pose2d{10_m, 10_m, Rotation2d(90_deg)},
+    std::vector<Translation2d>{},
+    Pose2d{10_m, 11_m, Rotation2d(-90_deg)}
+  ), SplineParameterizer::MalformedSplineException);
+}

--- a/wpilibc/src/test/native/cpp/spline/CubicHermiteSplineTest.cpp
+++ b/wpilibc/src/test/native/cpp/spline/CubicHermiteSplineTest.cpp
@@ -121,15 +121,13 @@ TEST_F(CubicHermiteSplineTest, OneInterior) {
   Run(start, waypoints, end);
 }
 
-TEST_F(CubicHermiteSplineTest, Malformed) {
-  EXPECT_THROW(Run(
-    Pose2d{0_m, 0_m, Rotation2d(0_deg)},
-    std::vector<Translation2d>{},
-    Pose2d{1_m, 0_m, Rotation2d(180_deg)}
-  ), SplineParameterizer::MalformedSplineException);
-  EXPECT_THROW(Run(
-    Pose2d{10_m, 10_m, Rotation2d(90_deg)},
-    std::vector<Translation2d>{},
-    Pose2d{10_m, 11_m, Rotation2d(-90_deg)}
-  ), SplineParameterizer::MalformedSplineException);
+TEST_F(CubicHermiteSplineTest, ThrowsOnMalformed) {
+  EXPECT_THROW(
+      Run(Pose2d{0_m, 0_m, Rotation2d(0_deg)}, std::vector<Translation2d>{},
+          Pose2d{1_m, 0_m, Rotation2d(180_deg)}),
+      SplineParameterizer::MalformedSplineException);
+  EXPECT_THROW(
+      Run(Pose2d{10_m, 10_m, Rotation2d(90_deg)}, std::vector<Translation2d>{},
+          Pose2d{10_m, 11_m, Rotation2d(-90_deg)}),
+      SplineParameterizer::MalformedSplineException);
 }

--- a/wpilibc/src/test/native/cpp/spline/QuinticHermiteSplineTest.cpp
+++ b/wpilibc/src/test/native/cpp/spline/QuinticHermiteSplineTest.cpp
@@ -85,3 +85,12 @@ TEST_F(QuinticHermiteSplineTest, SquigglyCurve) {
   Run(Pose2d(0_m, 0_m, Rotation2d(90_deg)),
       Pose2d(-1_m, 0_m, Rotation2d(90_deg)));
 }
+
+TEST_F(QuinticHermiteSplineTest, ThrowsOnMalformed) {
+  EXPECT_THROW(Run(Pose2d(0_m, 0_m, Rotation2d(0_deg)),
+                   Pose2d(1_m, 0_m, Rotation2d(180_deg))),
+               SplineParameterizer::MalformedSplineException);
+  EXPECT_THROW(Run(Pose2d(10_m, 10_m, Rotation2d(90_deg)),
+                   Pose2d(10_m, 11_m, Rotation2d(-90_deg))),
+               SplineParameterizer::MalformedSplineException);
+}

--- a/wpilibc/src/test/native/cpp/trajectory/TrajectoryGeneratorTest.cpp
+++ b/wpilibc/src/test/native/cpp/trajectory/TrajectoryGeneratorTest.cpp
@@ -33,3 +33,13 @@ TEST(TrajectoryGenerationTest, ObeysConstraints) {
                 12_fps_sq + 0.01_fps_sq);
   }
 }
+
+TEST(TrajectoryGenertionTest, ReturnsEmptyOnMalformed) {
+  const auto t = TrajectoryGenerator::GenerateTrajectory(
+      std::vector<Pose2d>{Pose2d(0_m, 0_m, Rotation2d(0_deg)),
+                          Pose2d(1_m, 0_m, Rotation2d(180_deg))},
+      TrajectoryConfig(12_fps, 12_fps_sq));
+
+  ASSERT_EQ(t.States().size(), 1u);
+  ASSERT_EQ(t.TotalTime(), 0_s);
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/spline/SplineParameterizer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/spline/SplineParameterizer.java
@@ -35,8 +35,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 
-import edu.wpi.first.wpilibj.DriverStation;
-
 /**
  * Class used to parameterize a spline by its arc length.
  */
@@ -49,7 +47,7 @@ public final class SplineParameterizer {
    * A malformed spline does not actually explode the LIFO stack size. Instead, the stack size
    * stays at a relatively small number (e.g. 30) and never decreases. Because of this, we must
    * count iterations. Even long, complex paths don't usually go over 300 iterations, so hitting
-   * this maximum should definitely indicate something has gone wrong. 
+   * this maximum should definitely indicate something has gone wrong.
    */
   private static final int kMaxIterations = 5000;
 
@@ -87,7 +85,8 @@ public final class SplineParameterizer {
    *
    * @param spline The spline to parameterize.
    * @return A list of poses and curvatures that represents various points on the spline.
-   * @throws MalformedSplineException
+   * @throws MalformedSplineException When the spline is malformed (e.g. has close adjacent points
+   *                                  with approximately opposing headings)
    */
   public static List<PoseWithCurvature> parameterize(Spline spline) {
     return parameterize(spline, 0.0, 1.0);
@@ -101,7 +100,8 @@ public final class SplineParameterizer {
    * @param t0     Starting internal spline parameter. It is recommended to use 0.0.
    * @param t1     Ending internal spline parameter. It is recommended to use 1.0.
    * @return       A list of poses and curvatures that represents various points on the spline.
-   * @throws MalformedSplineException
+   * @throws MalformedSplineException When the spline is malformed (e.g. has close adjacent points
+   *                                  with approximately opposing headings)
    */
   public static List<PoseWithCurvature> parameterize(Spline spline, double t0, double t1) {
     var splinePoints = new ArrayList<PoseWithCurvature>();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/spline/SplineParameterizer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/spline/SplineParameterizer.java
@@ -31,8 +31,11 @@
 
 package edu.wpi.first.wpilibj.spline;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
+
+import edu.wpi.first.wpilibj.DriverStation;
 
 /**
  * Class used to parameterize a spline by its arc length.
@@ -41,6 +44,36 @@ public final class SplineParameterizer {
   private static final double kMaxDx = 0.127;
   private static final double kMaxDy = 0.00127;
   private static final double kMaxDtheta = 0.0872;
+
+  /**
+   * A malformed spline does not actually explode the LIFO stack size. Instead, the stack size
+   * stays at a relatively small number (e.g. 30) and never decreases. Because of this, we must
+   * count iterations. Even long, complex paths don't usually go over 300 iterations, so hitting
+   * this maximum should definitely indicate something has gone wrong. 
+   */
+  private static final int kMaxIterations = 5000;
+
+  @SuppressWarnings("MemberName")
+  private static class StackContents {
+    final double t1;
+    final double t0;
+
+    StackContents(double t0, double t1) {
+      this.t0 = t0;
+      this.t1 = t1;
+    }
+  }
+
+  public static class MalformedSplineException extends RuntimeException {
+    /**
+     * Create a new exception with the given message.
+     *
+     * @param message the message to pass with the exception
+     */
+    private MalformedSplineException(String message) {
+      super(message);
+    }
+  }
 
   /**
    * Private constructor because this is a utility class.
@@ -53,7 +86,8 @@ public final class SplineParameterizer {
    * arcs until their dx, dy, and dtheta are within specific tolerances.
    *
    * @param spline The spline to parameterize.
-   * @return A vector of poses and curvatures that represents various points on the spline.
+   * @return A list of poses and curvatures that represents various points on the spline.
+   * @throws MalformedSplineException
    */
   public static List<PoseWithCurvature> parameterize(Spline spline) {
     return parameterize(spline, 0.0, 1.0);
@@ -66,41 +100,51 @@ public final class SplineParameterizer {
    * @param spline The spline to parameterize.
    * @param t0     Starting internal spline parameter. It is recommended to use 0.0.
    * @param t1     Ending internal spline parameter. It is recommended to use 1.0.
-   * @return A vector of poses and curvatures that represents various points on the spline.
+   * @return       A list of poses and curvatures that represents various points on the spline.
+   * @throws MalformedSplineException
    */
   public static List<PoseWithCurvature> parameterize(Spline spline, double t0, double t1) {
-    var arr = new ArrayList<PoseWithCurvature>();
+    var splinePoints = new ArrayList<PoseWithCurvature>();
 
-    // The parameterization does not add the first initial point. Let's add
-    // that.
-    arr.add(spline.getPoint(t0));
+    // The parameterization does not add the initial point. Let's add that.
+    splinePoints.add(spline.getPoint(t0));
 
-    getSegmentArc(spline, arr, t0, t1);
-    return arr;
-  }
+    // We use an "explicit stack" to simulate recursion, instead of a recursive function call
+    // This give us greater control, instead of a stack overflow
+    var stack = new ArrayDeque<StackContents>();
+    stack.push(new StackContents(t0, t1));
 
-  /**
-   * Breaks up the spline into arcs until the dx, dy, and theta of each arc is
-   * within tolerance.
-   *
-   * @param spline The spline to parameterize.
-   * @param vector Pointer to vector of poses.
-   * @param t0     Starting point for arc.
-   * @param t1     Ending point for arc.
-   */
-  private static void getSegmentArc(Spline spline, List<PoseWithCurvature> vector,
-                                    double t0, double t1) {
-    final var start = spline.getPoint(t0);
-    final var end = spline.getPoint(t1);
+    StackContents current;
+    PoseWithCurvature start;
+    PoseWithCurvature end;
+    int iterations = 0;
 
-    final var twist = start.poseMeters.log(end.poseMeters);
+    while (!stack.isEmpty()) {
+      current = stack.removeFirst();
+      start = spline.getPoint(current.t0);
+      end = spline.getPoint(current.t1);
 
-    if (Math.abs(twist.dy) > kMaxDy || Math.abs(twist.dx) > kMaxDx
-        || Math.abs(twist.dtheta) > kMaxDtheta) {
-      getSegmentArc(spline, vector, t0, (t0 + t1) / 2);
-      getSegmentArc(spline, vector, (t0 + t1) / 2, t1);
-    } else {
-      vector.add(spline.getPoint(t1));
+      final var twist = start.poseMeters.log(end.poseMeters);
+      if (
+          Math.abs(twist.dy) > kMaxDy
+          || Math.abs(twist.dx) > kMaxDx
+          || Math.abs(twist.dtheta) > kMaxDtheta
+      ) {
+        stack.addFirst(new StackContents((current.t0 + current.t1) / 2, current.t1));
+        stack.addFirst(new StackContents(current.t0, (current.t0 + current.t1) / 2));
+      } else {
+        splinePoints.add(spline.getPoint(current.t1));
+      }
+
+      if (iterations++ >= kMaxIterations) {
+        throw new MalformedSplineException(
+          "Could not parameterize a malformed spline. "
+          + "This means that you probably had two or more adjacent waypoints that were very close "
+          + "together with headings in opposing directions."
+        );
+      }
     }
+
+    return splinePoints;
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/spline/SplineParameterizer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/spline/SplineParameterizer.java
@@ -103,6 +103,7 @@ public final class SplineParameterizer {
    * @throws MalformedSplineException When the spline is malformed (e.g. has close adjacent points
    *                                  with approximately opposing headings)
    */
+  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   public static List<PoseWithCurvature> parameterize(Spline spline, double t0, double t1) {
     var splinePoints = new ArrayList<PoseWithCurvature>();
 
@@ -136,7 +137,8 @@ public final class SplineParameterizer {
         splinePoints.add(spline.getPoint(current.t1));
       }
 
-      if (iterations++ >= kMaxIterations) {
+      iterations++;
+      if (iterations >= kMaxIterations) {
         throw new MalformedSplineException(
           "Could not parameterize a malformed spline. "
           + "This means that you probably had two or more adjacent waypoints that were very close "

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
@@ -26,7 +26,7 @@ import edu.wpi.first.wpilibj.spline.SplineParameterizer.MalformedSplineException
 public final class TrajectoryGenerator {
   private static final Trajectory kDoNothingTrajectory =
       new Trajectory(Arrays.asList(new Trajectory.State()));
-  
+
   /**
    * Private constructor because this is a utility class.
    */
@@ -70,10 +70,9 @@ public final class TrajectoryGenerator {
     try {
       points = splinePointsFromSplines(SplineHelper.getCubicSplinesFromControlVectors(newInitial,
           interiorWaypoints.toArray(new Translation2d[0]), newEnd));
-    } catch (MalformedSplineException e) {
-      DriverStation.reportError(e.getMessage(), e.getStackTrace());
+    } catch (MalformedSplineException ex) {
+      DriverStation.reportError(ex.getMessage(), ex.getStackTrace());
       return kDoNothingTrajectory;
-      // return kEmptyTrajectory.transformBy(new Transform2d(new Translation2d(initial.x[0], initial.y[0]), Rotation2d.fromDegrees(Math.atan2(initial.y[1], initial.x[1]))));
     }
 
     // Change the points back to their original orientation.
@@ -147,8 +146,8 @@ public final class TrajectoryGenerator {
       points = splinePointsFromSplines(SplineHelper.getQuinticSplinesFromControlVectors(
           newControlVectors.toArray(new Spline.ControlVector[]{})
       ));
-    } catch (MalformedSplineException e) {
-      DriverStation.reportError(e.getMessage(), e.getStackTrace());
+    } catch (MalformedSplineException ex) {
+      DriverStation.reportError(ex.getMessage(), ex.getStackTrace());
       return kDoNothingTrajectory;
     }
 
@@ -189,7 +188,8 @@ public final class TrajectoryGenerator {
    *
    * @param splines The splines to parameterize.
    * @return The spline points for use in time parameterization of a trajectory.
-   * @throws MalformedSplineException
+   * @throws MalformedSplineException When the spline is malformed (e.g. has close adjacent points
+   *                                  with approximately opposing headings)
    */
   public static List<PoseWithCurvature> splinePointsFromSplines(
       Spline[] splines) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/spline/CubicHermiteSplineTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/spline/CubicHermiteSplineTest.java
@@ -149,19 +149,14 @@ class CubicHermiteSplineTest {
     run(start, waypoints, end);
   }
 
-    @Test
+  @Test
   void testMalformed() {
-    assertAll(
-      () -> assertThrows(MalformedSplineException.class,
-            () -> run(
-              new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
-              new ArrayList<>(),
-              new Pose2d(1, 0, Rotation2d.fromDegrees(180)))),
-      () -> assertThrows(MalformedSplineException.class, 
-            () -> run(
-              new Pose2d(10, 10, Rotation2d.fromDegrees(90)),
-              Arrays.asList(new Translation2d(10, 10.5)),
-              new Pose2d(10, 11, Rotation2d.fromDegrees(-90))))
-    );
+    assertThrows(MalformedSplineException.class, () -> run(
+        new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
+        new ArrayList<>(), new Pose2d(1, 0, Rotation2d.fromDegrees(180))));
+    assertThrows(MalformedSplineException.class, () -> run(
+        new Pose2d(10, 10, Rotation2d.fromDegrees(90)),
+        Arrays.asList(new Translation2d(10, 10.5)),
+        new Pose2d(10, 11, Rotation2d.fromDegrees(-90))));
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/spline/CubicHermiteSplineTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/spline/CubicHermiteSplineTest.java
@@ -8,6 +8,7 @@
 package edu.wpi.first.wpilibj.spline;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -15,9 +16,11 @@ import org.junit.jupiter.api.Test;
 import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.spline.SplineParameterizer.MalformedSplineException;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -144,5 +147,21 @@ class CubicHermiteSplineTest {
     final var end = new Pose2d(3.0, 0.0, Rotation2d.fromDegrees(0.0));
 
     run(start, waypoints, end);
+  }
+
+    @Test
+  void testMalformed() {
+    assertAll(
+      () -> assertThrows(MalformedSplineException.class,
+            () -> run(
+              new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
+              new ArrayList<>(),
+              new Pose2d(1, 0, Rotation2d.fromDegrees(180)))),
+      () -> assertThrows(MalformedSplineException.class, 
+            () -> run(
+              new Pose2d(10, 10, Rotation2d.fromDegrees(90)),
+              Arrays.asList(new Translation2d(10, 10.5)),
+              new Pose2d(10, 11, Rotation2d.fromDegrees(-90))))
+    );
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/spline/QuinticHermiteSplineTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/spline/QuinticHermiteSplineTest.java
@@ -13,9 +13,11 @@ import org.junit.jupiter.api.Test;
 
 import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.spline.SplineParameterizer.MalformedSplineException;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class QuinticHermiteSplineTest {
@@ -23,15 +25,15 @@ class QuinticHermiteSplineTest {
   private static final double kMaxDy = 0.00127;
   private static final double kMaxDtheta = 0.0872;
 
-  @SuppressWarnings({"ParameterName", "PMD.UnusedLocalVariable"})
+  @SuppressWarnings({ "ParameterName", "PMD.UnusedLocalVariable" })
   private void run(Pose2d a, Pose2d b) {
     // Start the timer.
     var start = System.nanoTime();
 
     // Generate and parameterize the spline.
     var controlVectors = SplineHelper.getQuinticControlVectorsFromWaypoints(List.of(a, b));
-    var spline = SplineHelper.getQuinticSplinesFromControlVectors(
-        controlVectors.toArray(new Spline.ControlVector[0]))[0];
+    var spline = SplineHelper
+        .getQuinticSplinesFromControlVectors(controlVectors.toArray(new Spline.ControlVector[0]))[0];
     var poses = SplineParameterizer.parameterize(spline);
 
     // End the timer.
@@ -46,32 +48,23 @@ class QuinticHermiteSplineTest {
 
       // Make sure the twist is under the tolerance defined by the Spline class.
       var twist = p0.poseMeters.log(p1.poseMeters);
-      assertAll(
-          () -> assertTrue(Math.abs(twist.dx) < kMaxDx),
-          () -> assertTrue(Math.abs(twist.dy) < kMaxDy),
-          () -> assertTrue(Math.abs(twist.dtheta) < kMaxDtheta)
-      );
+      assertAll(() -> assertTrue(Math.abs(twist.dx) < kMaxDx), () -> assertTrue(Math.abs(twist.dy) < kMaxDy),
+          () -> assertTrue(Math.abs(twist.dtheta) < kMaxDtheta));
     }
 
     // Check first point
-    assertAll(
-        () -> assertEquals(a.getTranslation().getX(),
-            poses.get(0).poseMeters.getTranslation().getX(), 1E-9),
-        () -> assertEquals(a.getTranslation().getY(),
-            poses.get(0).poseMeters.getTranslation().getY(), 1E-9),
-        () -> assertEquals(a.getRotation().getRadians(),
-            poses.get(0).poseMeters.getRotation().getRadians(), 1E-9)
-    );
+    assertAll(() -> assertEquals(a.getTranslation().getX(), poses.get(0).poseMeters.getTranslation().getX(), 1E-9),
+        () -> assertEquals(a.getTranslation().getY(), poses.get(0).poseMeters.getTranslation().getY(), 1E-9),
+        () -> assertEquals(a.getRotation().getRadians(), poses.get(0).poseMeters.getRotation().getRadians(), 1E-9));
 
     // Check last point
     assertAll(
-        () -> assertEquals(b.getTranslation().getX(),
-            poses.get(poses.size() - 1).poseMeters.getTranslation().getX(), 1E-9),
-        () -> assertEquals(b.getTranslation().getY(),
-            poses.get(poses.size() - 1).poseMeters.getTranslation().getY(), 1E-9),
+        () -> assertEquals(b.getTranslation().getX(), poses.get(poses.size() - 1).poseMeters.getTranslation().getX(),
+            1E-9),
+        () -> assertEquals(b.getTranslation().getY(), poses.get(poses.size() - 1).poseMeters.getTranslation().getY(),
+            1E-9),
         () -> assertEquals(b.getRotation().getRadians(),
-            poses.get(poses.size() - 1).poseMeters.getRotation().getRadians(), 1E-9)
-    );
+            poses.get(poses.size() - 1).poseMeters.getRotation().getRadians(), 1E-9));
   }
 
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
@@ -89,7 +82,20 @@ class QuinticHermiteSplineTest {
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @Test
   void testSquiggly() {
-    run(new Pose2d(0, 0, Rotation2d.fromDegrees(90)),
-        new Pose2d(-1, 0, Rotation2d.fromDegrees(90)));
+    run(new Pose2d(0, 0, Rotation2d.fromDegrees(90)), new Pose2d(-1, 0, Rotation2d.fromDegrees(90)));
+  }
+
+  @Test
+  void testMalformed() {
+    assertAll(
+      () -> assertThrows(MalformedSplineException.class,
+            () -> run(
+              new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
+              new Pose2d(1, 0, Rotation2d.fromDegrees(180)))),
+      () -> assertThrows(MalformedSplineException.class, 
+            () -> run(
+              new Pose2d(10, 10, Rotation2d.fromDegrees(90)),
+              new Pose2d(10, 11, Rotation2d.fromDegrees(-90))))
+    );
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/spline/QuinticHermiteSplineTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/spline/QuinticHermiteSplineTest.java
@@ -32,8 +32,8 @@ class QuinticHermiteSplineTest {
 
     // Generate and parameterize the spline.
     var controlVectors = SplineHelper.getQuinticControlVectorsFromWaypoints(List.of(a, b));
-    var spline = SplineHelper
-        .getQuinticSplinesFromControlVectors(controlVectors.toArray(new Spline.ControlVector[0]))[0];
+    var spline = SplineHelper.getQuinticSplinesFromControlVectors(
+        controlVectors.toArray(new Spline.ControlVector[0]))[0];
     var poses = SplineParameterizer.parameterize(spline);
 
     // End the timer.
@@ -48,21 +48,28 @@ class QuinticHermiteSplineTest {
 
       // Make sure the twist is under the tolerance defined by the Spline class.
       var twist = p0.poseMeters.log(p1.poseMeters);
-      assertAll(() -> assertTrue(Math.abs(twist.dx) < kMaxDx), () -> assertTrue(Math.abs(twist.dy) < kMaxDy),
+      assertAll(
+          () -> assertTrue(Math.abs(twist.dx) < kMaxDx),
+          () -> assertTrue(Math.abs(twist.dy) < kMaxDy),
           () -> assertTrue(Math.abs(twist.dtheta) < kMaxDtheta));
     }
 
     // Check first point
-    assertAll(() -> assertEquals(a.getTranslation().getX(), poses.get(0).poseMeters.getTranslation().getX(), 1E-9),
-        () -> assertEquals(a.getTranslation().getY(), poses.get(0).poseMeters.getTranslation().getY(), 1E-9),
-        () -> assertEquals(a.getRotation().getRadians(), poses.get(0).poseMeters.getRotation().getRadians(), 1E-9));
+    assertAll(
+        () -> assertEquals(
+            a.getTranslation().getX(), poses.get(0).poseMeters.getTranslation().getX(), 1E-9),
+        () -> assertEquals(
+            a.getTranslation().getY(), poses.get(0).poseMeters.getTranslation().getY(), 1E-9),
+        () -> assertEquals(
+            a.getRotation().getRadians(), poses.get(0).poseMeters.getRotation().getRadians(),
+            1E-9));
 
     // Check last point
     assertAll(
-        () -> assertEquals(b.getTranslation().getX(), poses.get(poses.size() - 1).poseMeters.getTranslation().getX(),
-            1E-9),
-        () -> assertEquals(b.getTranslation().getY(), poses.get(poses.size() - 1).poseMeters.getTranslation().getY(),
-            1E-9),
+        () -> assertEquals(b.getTranslation().getX(), poses.get(poses.size() - 1)
+            .poseMeters.getTranslation().getX(), 1E-9),
+        () -> assertEquals(b.getTranslation().getY(), poses.get(poses.size() - 1)
+            .poseMeters.getTranslation().getY(), 1E-9),
         () -> assertEquals(b.getRotation().getRadians(),
             poses.get(poses.size() - 1).poseMeters.getRotation().getRadians(), 1E-9));
   }
@@ -82,20 +89,20 @@ class QuinticHermiteSplineTest {
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @Test
   void testSquiggly() {
-    run(new Pose2d(0, 0, Rotation2d.fromDegrees(90)), new Pose2d(-1, 0, Rotation2d.fromDegrees(90)));
+    run(
+        new Pose2d(0, 0, Rotation2d.fromDegrees(90)),
+        new Pose2d(-1, 0, Rotation2d.fromDegrees(90)));
   }
 
   @Test
   void testMalformed() {
-    assertAll(
-      () -> assertThrows(MalformedSplineException.class,
-            () -> run(
-              new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
-              new Pose2d(1, 0, Rotation2d.fromDegrees(180)))),
-      () -> assertThrows(MalformedSplineException.class, 
-            () -> run(
-              new Pose2d(10, 10, Rotation2d.fromDegrees(90)),
-              new Pose2d(10, 11, Rotation2d.fromDegrees(-90))))
-    );
+    assertThrows(MalformedSplineException.class,
+        () -> run(
+          new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
+          new Pose2d(1, 0, Rotation2d.fromDegrees(180))));
+    assertThrows(MalformedSplineException.class,
+        () -> run(
+          new Pose2d(10, 10, Rotation2d.fromDegrees(90)),
+          new Pose2d(10, 11, Rotation2d.fromDegrees(-90))));
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGeneratorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGeneratorTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import edu.wpi.first.hal.sim.DriverStationSim;
 import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.geometry.Transform2d;
@@ -74,8 +75,9 @@ class TrajectoryGeneratorTest {
 
   @Test
   void testMalformedTrajectory() {
-    // TODO (for review): this spews an ugly stack trace into test stdout
-    // Should I add bindings to HALSIM_SetSendError?
+    var dsSim = new DriverStationSim();
+    dsSim.setSendError(false);
+
     var traj =
         TrajectoryGenerator.generateTrajectory(
           Arrays.asList(
@@ -87,5 +89,7 @@ class TrajectoryGeneratorTest {
 
     assertEquals(traj.getStates().size(), 1);
     assertEquals(traj.getTotalTimeSeconds(), 0);
+
+    dsSim.setSendError(true);
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGeneratorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGeneratorTest.java
@@ -7,16 +7,12 @@
 
 package edu.wpi.first.wpilibj.trajectory;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.geometry.Transform2d;
@@ -80,14 +76,16 @@ class TrajectoryGeneratorTest {
   void testMalformedTrajectory() {
     // TODO (for review): this spews an ugly stack trace into test stdout
     // Should I add bindings to HALSIM_SetSendError?
-    var initial = new Pose2d(0, 0, Rotation2d.fromDegrees(0));
-    var t =
+    var traj =
         TrajectoryGenerator.generateTrajectory(
-          Arrays.asList(initial, new Pose2d(1, 0, Rotation2d.fromDegrees(180))),
+          Arrays.asList(
+            new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
+            new Pose2d(1, 0, Rotation2d.fromDegrees(180))
+          ),
           new TrajectoryConfig(feetToMeters(12), feetToMeters(12))
         );
 
-    assertEquals(t.getStates().size(), 1);
-    assertEquals(t.getTotalTimeSeconds(), 0);
+    assertEquals(traj.getStates().size(), 1);
+    assertEquals(traj.getTotalTimeSeconds(), 0);
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGeneratorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGeneratorTest.java
@@ -7,11 +7,14 @@
 
 package edu.wpi.first.wpilibj.trajectory;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.geometry.Pose2d;
@@ -75,12 +78,15 @@ class TrajectoryGeneratorTest {
 
   @Test
   void testMalformedTrajectory() {
+    // TODO (for review): this spews an ugly stack trace into test stdout
+    // Should I add bindings to HALSIM_SetSendError?
     var initial = new Pose2d(0, 0, Rotation2d.fromDegrees(0));
     var t =
         TrajectoryGenerator.generateTrajectory(
           Arrays.asList(initial, new Pose2d(1, 0, Rotation2d.fromDegrees(180))),
           new TrajectoryConfig(feetToMeters(12), feetToMeters(12))
         );
+
     assertEquals(t.getStates().size(), 1);
     assertEquals(t.getTotalTimeSeconds(), 0);
   }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGeneratorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGeneratorTest.java
@@ -8,10 +8,12 @@
 package edu.wpi.first.wpilibj.trajectory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.geometry.Transform2d;
@@ -20,6 +22,7 @@ import edu.wpi.first.wpilibj.trajectory.constraint.TrajectoryConstraint;
 
 import static edu.wpi.first.wpilibj.util.Units.feetToMeters;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TrajectoryGeneratorTest {
@@ -68,5 +71,17 @@ class TrajectoryGeneratorTest {
               + 0.05)
       );
     }
+  }
+
+  @Test
+  void testMalformedTrajectory() {
+    var initial = new Pose2d(0, 0, Rotation2d.fromDegrees(0));
+    var t =
+        TrajectoryGenerator.generateTrajectory(
+          Arrays.asList(initial, new Pose2d(1, 0, Rotation2d.fromDegrees(180))),
+          new TrajectoryConfig(feetToMeters(12), feetToMeters(12))
+        );
+    assertEquals(t.getStates().size(), 1);
+    assertEquals(t.getTotalTimeSeconds(), 0);
   }
 }


### PR DESCRIPTION
This PR changes the spline parameterizer to use an explicit stack instead of recursion. This is motivated by the fact that splines with adjacent waypoints with approximately opposite headings will never parameterize. In this case the parameterizer subdivides these malformed splines fine for a while, and then gets stuck parameterizing infinitely on some interval. In the recursive approach, this would lead to a stack overflow. We could implement a recursion depth counter (this is what my team did on our similar trajectory code last season), but it's hard to choose a good number for max depth because the initial amount of stack used varies based on how the user calls `Parameterize`.

A good solution for this is converting the recursion to an "explicit stack," which basically simulates recursion, but allows us to have a much larger maximum stack size. Because we avoid the stack overflow, we can instead throws a more informative `MalformedSplineException`. If the user is using the `TrajectoryGenerator` instead of the `SplineParameterizer` directly then the `TrajectoryGenerator` will go ahead and catch the exception, return a harmless empty trajectory, and report and error to the driver station.

Everything is finished with this PR, except that reporting an error to the driver station spews a stack trace in the Java unit test, which is rather confusing. Java does not have a binding to `HALSIM_SetSendError`, so I can't suppress the stack trace and error message... I'm planning to PR a binding, so I'm marking this PR as a draft until the dependent PR gets merged. **There are no substantive changes remaining, however, so it should be fine to start reviewing this.**