### PR TITLE
Add JNI binding to suppress driver station error/warning messages

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/sim/DriverStationSim.java
+++ b/hal/src/main/java/edu/wpi/first/hal/sim/DriverStationSim.java
@@ -79,6 +79,15 @@ public class DriverStationSim {
     DriverStationDataJNI.notifyNewData();
   }
 
+  /**
+   * Toggles suppression of DriverStation.reportError and reportWarning messages.
+   * 
+   * @param shouldSend If false then messages will will be suppressed.
+   */
+  public void setSendError(boolean shouldSend) {
+    DriverStationDataJNI.setSendError(shouldSend);
+  }
+
   public void resetData() {
     DriverStationDataJNI.resetData();
   }

--- a/hal/src/main/java/edu/wpi/first/hal/sim/DriverStationSim.java
+++ b/hal/src/main/java/edu/wpi/first/hal/sim/DriverStationSim.java
@@ -81,7 +81,7 @@ public class DriverStationSim {
 
   /**
    * Toggles suppression of DriverStation.reportError and reportWarning messages.
-   * 
+   *
    * @param shouldSend If false then messages will will be suppressed.
    */
   public void setSendError(boolean shouldSend) {

--- a/hal/src/main/java/edu/wpi/first/hal/sim/mockdata/DriverStationDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/sim/mockdata/DriverStationDataJNI.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/hal/src/main/java/edu/wpi/first/hal/sim/mockdata/DriverStationDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/sim/mockdata/DriverStationDataJNI.java
@@ -49,5 +49,7 @@ public class DriverStationDataJNI extends JNIWrapper {
   public static native void registerAllCallbacks(NotifyCallback callback, boolean initialNotify);
   public static native void notifyNewData();
 
+  public static native void setSendError(boolean shouldSend);
+
   public static native void resetData();
 }

--- a/hal/src/main/native/sim/jni/DriverStationDataJNI.cpp
+++ b/hal/src/main/native/sim/jni/DriverStationDataJNI.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -462,7 +462,7 @@ Java_edu_wpi_first_hal_sim_mockdata_DriverStationDataJNI_setSendError
     HALSIM_SetSendError([](HAL_Bool isError, int32_t errorCode,
                            HAL_Bool isLVCode, const char* details,
                            const char* location, const char* callStack,
-                           HAL_Bool printMsg) {return 1;});
+                           HAL_Bool printMsg) { return 1; });
   }
 }
 

--- a/hal/src/main/native/sim/jni/DriverStationDataJNI.cpp
+++ b/hal/src/main/native/sim/jni/DriverStationDataJNI.cpp
@@ -14,6 +14,7 @@
 #include "CallbackStore.h"
 #include "edu_wpi_first_hal_sim_mockdata_DriverStationDataJNI.h"
 #include "mockdata/DriverStationData.h"
+#include "mockdata/MockHooks.h"
 
 using namespace wpi::java;
 
@@ -444,6 +445,25 @@ Java_edu_wpi_first_hal_sim_mockdata_DriverStationDataJNI_notifyNewData
   (JNIEnv*, jclass)
 {
   HALSIM_NotifyDriverStationNewData();
+}
+
+/*
+ * Class:     edu_wpi_first_hal_sim_mockdata_DriverStationDataJNI
+ * Method:    setSendError
+ * Signature: (Z)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_sim_mockdata_DriverStationDataJNI_setSendError
+  (JNIEnv*, jclass, jboolean shouldSend)
+{
+  if (shouldSend) {
+    HALSIM_SetSendError(nullptr);
+  } else {
+    HALSIM_SetSendError([](HAL_Bool isError, int32_t errorCode,
+                           HAL_Bool isLVCode, const char* details,
+                           const char* location, const char* callStack,
+                           HAL_Bool printMsg) {return 1;});
+  }
 }
 
 /*


### PR DESCRIPTION
This is to allow suppressing an ugly stack trace/error message in a unit test in #2197. It doesn't support the full `HALSIM_SetSendError` callback stuff (i.e. you can only suppress, not intercept, stack traces with this), because that was all I needed.