### PR TITLE
Remove -no-module-directories flag from javadoc build

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -125,7 +125,6 @@ task generateJavaDocs(type: Javadoc) {
     ext.entryPoint = "$destinationDir/index.html"
 
     if (JavaVersion.current().isJava11Compatible()) {
-        options.addBooleanOption('-no-module-directories', true)
         doLast {
             // This is a work-around for https://bugs.openjdk.java.net/browse/JDK-8211194. Can be removed once that issue is fixed on JDK's side
             // Since JDK 11, package-list is missing from javadoc output files and superseded by element-list file, but a lot of external tools still need it


### PR DESCRIPTION
Closes #2177 