### PR TITLE
ntcore: Add support for local-only operation

### DIFF
--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableInstance.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableInstance.java
@@ -44,7 +44,7 @@ public final class NetworkTableInstance implements AutoCloseable {
   public static final int kNetModeClient = 0x02;
   public static final int kNetModeStarting = 0x04;
   public static final int kNetModeFailure = 0x08;
-  public static final int kNetModeDisabled = 0x10;
+  public static final int kNetModeLocal = 0x10;
 
   /**
    * The default port that network tables operates on.
@@ -677,20 +677,20 @@ public final class NetworkTableInstance implements AutoCloseable {
   }
 
   /**
-   * Disables networking.  Prevents calls to startServer or startClient
+   * Starts local-only operation.  Prevents calls to startServer or startClient
    * from taking effect.  Has no effect if startServer or startClient
    * has already been called.
    */
-  public void disableNetwork() {
-    NetworkTablesJNI.disableNetwork(m_handle);
+  public void startLocal() {
+    NetworkTablesJNI.startLocal(m_handle);
   }
 
   /**
-   * Enables networking.  startServer or startClient can be called after
-   * this call to start a server or client.  By default, networking is enabled.
+   * Stops local-only operation.  startServer or startClient can be called after
+   * this call to start a server or client.
    */
-  public void enableNetwork() {
-    NetworkTablesJNI.enableNetwork(m_handle);
+  public void stopLocal() {
+    NetworkTablesJNI.stopLocal(m_handle);
   }
 
   /**

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableInstance.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableInstance.java
@@ -44,6 +44,7 @@ public final class NetworkTableInstance implements AutoCloseable {
   public static final int kNetModeClient = 0x02;
   public static final int kNetModeStarting = 0x04;
   public static final int kNetModeFailure = 0x08;
+  public static final int kNetModeDisabled = 0x10;
 
   /**
    * The default port that network tables operates on.
@@ -673,6 +674,23 @@ public final class NetworkTableInstance implements AutoCloseable {
    */
   public int getNetworkMode() {
     return NetworkTablesJNI.getNetworkMode(m_handle);
+  }
+
+  /**
+   * Disables networking.  Prevents calls to startServer or startClient
+   * from taking effect.  Has no effect if startServer or startClient
+   * has already been called.
+   */
+  public void disableNetwork() {
+    NetworkTablesJNI.disableNetwork(m_handle);
+  }
+
+  /**
+   * Enables networking.  startServer or startClient can be called after
+   * this call to start a server or client.  By default, networking is enabled.
+   */
+  public void enableNetwork() {
+    NetworkTablesJNI.enableNetwork(m_handle);
   }
 
   /**

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTablesJNI.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTablesJNI.java
@@ -139,6 +139,8 @@ public final class NetworkTablesJNI {
 
   public static native void setNetworkIdentity(int inst, String name);
   public static native int getNetworkMode(int inst);
+  public static native void disableNetwork(int inst);
+  public static native void enableNetwork(int inst);
   public static native void startServer(int inst, String persistFilename, String listenAddress, int port);
   public static native void stopServer(int inst);
   public static native void startClient(int inst);

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTablesJNI.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTablesJNI.java
@@ -139,8 +139,8 @@ public final class NetworkTablesJNI {
 
   public static native void setNetworkIdentity(int inst, String name);
   public static native int getNetworkMode(int inst);
-  public static native void disableNetwork(int inst);
-  public static native void enableNetwork(int inst);
+  public static native void startLocal(int inst);
+  public static native void stopLocal(int inst);
   public static native void startServer(int inst, String persistFilename, String listenAddress, int port);
   public static native void stopServer(int inst);
   public static native void startClient(int inst);

--- a/ntcore/src/main/native/cpp/Dispatcher.cpp
+++ b/ntcore/src/main/native/cpp/Dispatcher.cpp
@@ -115,6 +115,16 @@ DispatcherBase::~DispatcherBase() { Stop(); }
 
 unsigned int DispatcherBase::GetNetworkMode() const { return m_networkMode; }
 
+void DispatcherBase::StartNoNetwork() {
+  {
+    std::scoped_lock lock(m_user_mutex);
+    if (m_active) return;
+    m_active = true;
+  }
+  m_networkMode = NT_NET_MODE_DISABLED;
+  m_storage.SetDispatcher(this, false);
+}
+
 void DispatcherBase::StartServer(
     const Twine& persist_filename,
     std::unique_ptr<wpi::NetworkAcceptor> acceptor) {

--- a/ntcore/src/main/native/cpp/Dispatcher.cpp
+++ b/ntcore/src/main/native/cpp/Dispatcher.cpp
@@ -115,13 +115,13 @@ DispatcherBase::~DispatcherBase() { Stop(); }
 
 unsigned int DispatcherBase::GetNetworkMode() const { return m_networkMode; }
 
-void DispatcherBase::StartNoNetwork() {
+void DispatcherBase::StartLocal() {
   {
     std::scoped_lock lock(m_user_mutex);
     if (m_active) return;
     m_active = true;
   }
-  m_networkMode = NT_NET_MODE_DISABLED;
+  m_networkMode = NT_NET_MODE_LOCAL;
   m_storage.SetDispatcher(this, false);
 }
 

--- a/ntcore/src/main/native/cpp/Dispatcher.h
+++ b/ntcore/src/main/native/cpp/Dispatcher.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2015-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2015-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/ntcore/src/main/native/cpp/Dispatcher.h
+++ b/ntcore/src/main/native/cpp/Dispatcher.h
@@ -48,6 +48,7 @@ class DispatcherBase : public IDispatcher {
   virtual ~DispatcherBase();
 
   unsigned int GetNetworkMode() const;
+  void StartNoNetwork();
   void StartServer(const Twine& persist_filename,
                    std::unique_ptr<wpi::NetworkAcceptor> acceptor);
   void StartClient();

--- a/ntcore/src/main/native/cpp/Dispatcher.h
+++ b/ntcore/src/main/native/cpp/Dispatcher.h
@@ -48,7 +48,7 @@ class DispatcherBase : public IDispatcher {
   virtual ~DispatcherBase();
 
   unsigned int GetNetworkMode() const;
-  void StartNoNetwork();
+  void StartLocal();
   void StartServer(const Twine& persist_filename,
                    std::unique_ptr<wpi::NetworkAcceptor> acceptor);
   void StartClient();

--- a/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
+++ b/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
+++ b/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
@@ -1370,26 +1370,26 @@ Java_edu_wpi_first_networktables_NetworkTablesJNI_getNetworkMode
 
 /*
  * Class:     edu_wpi_first_networktables_NetworkTablesJNI
- * Method:    disableNetwork
+ * Method:    startLocal
  * Signature: (I)V
  */
 JNIEXPORT void JNICALL
-Java_edu_wpi_first_networktables_NetworkTablesJNI_disableNetwork
+Java_edu_wpi_first_networktables_NetworkTablesJNI_startLocal
   (JNIEnv*, jclass, jint inst)
 {
-  nt::DisableNetwork(inst);
+  nt::StartLocal(inst);
 }
 
 /*
  * Class:     edu_wpi_first_networktables_NetworkTablesJNI
- * Method:    enableNetwork
+ * Method:    stopLocal
  * Signature: (I)V
  */
 JNIEXPORT void JNICALL
-Java_edu_wpi_first_networktables_NetworkTablesJNI_enableNetwork
+Java_edu_wpi_first_networktables_NetworkTablesJNI_stopLocal
   (JNIEnv*, jclass, jint inst)
 {
-  nt::EnableNetwork(inst);
+  nt::StopLocal(inst);
 }
 
 /*

--- a/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
+++ b/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
@@ -1370,6 +1370,30 @@ Java_edu_wpi_first_networktables_NetworkTablesJNI_getNetworkMode
 
 /*
  * Class:     edu_wpi_first_networktables_NetworkTablesJNI
+ * Method:    disableNetwork
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_networktables_NetworkTablesJNI_disableNetwork
+  (JNIEnv*, jclass, jint inst)
+{
+  nt::DisableNetwork(inst);
+}
+
+/*
+ * Class:     edu_wpi_first_networktables_NetworkTablesJNI
+ * Method:    enableNetwork
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_networktables_NetworkTablesJNI_enableNetwork
+  (JNIEnv*, jclass, jint inst)
+{
+  nt::EnableNetwork(inst);
+}
+
+/*
+ * Class:     edu_wpi_first_networktables_NetworkTablesJNI
  * Method:    startServer
  * Signature: (ILjava/lang/String;Ljava/lang/String;I)V
  */

--- a/ntcore/src/main/native/cpp/ntcore_c.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_c.cpp
@@ -539,6 +539,10 @@ unsigned int NT_GetNetworkMode(NT_Inst inst) {
   return nt::GetNetworkMode(inst);
 }
 
+void NT_DisableNetwork(NT_Inst inst) { nt::DisableNetwork(inst); }
+
+void NT_EnableNetwork(NT_Inst inst) { nt::EnableNetwork(inst); }
+
 void NT_StartServer(NT_Inst inst, const char* persist_filename,
                     const char* listen_address, unsigned int port) {
   nt::StartServer(inst, persist_filename, listen_address, port);

--- a/ntcore/src/main/native/cpp/ntcore_c.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_c.cpp
@@ -539,9 +539,9 @@ unsigned int NT_GetNetworkMode(NT_Inst inst) {
   return nt::GetNetworkMode(inst);
 }
 
-void NT_DisableNetwork(NT_Inst inst) { nt::DisableNetwork(inst); }
+void NT_StartLocal(NT_Inst inst) { nt::StartLocal(inst); }
 
-void NT_EnableNetwork(NT_Inst inst) { nt::EnableNetwork(inst); }
+void NT_StopLocal(NT_Inst inst) { nt::StopLocal(inst); }
 
 void NT_StartServer(NT_Inst inst, const char* persist_filename,
                     const char* listen_address, unsigned int port) {

--- a/ntcore/src/main/native/cpp/ntcore_cpp.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_cpp.cpp
@@ -742,14 +742,14 @@ unsigned int GetNetworkMode(NT_Inst inst) {
   return ii->dispatcher.GetNetworkMode();
 }
 
-void DisableNetwork(NT_Inst inst) {
+void StartLocal(NT_Inst inst) {
   auto ii = InstanceImpl::Get(Handle{inst}.GetTypedInst(Handle::kInstance));
   if (!ii) return;
 
-  ii->dispatcher.StartNoNetwork();
+  ii->dispatcher.StartLocal();
 }
 
-void EnableNetwork(NT_Inst inst) {
+void StopLocal(NT_Inst inst) {
   auto ii = InstanceImpl::Get(Handle{inst}.GetTypedInst(Handle::kInstance));
   if (!ii) return;
 

--- a/ntcore/src/main/native/cpp/ntcore_cpp.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_cpp.cpp
@@ -742,6 +742,20 @@ unsigned int GetNetworkMode(NT_Inst inst) {
   return ii->dispatcher.GetNetworkMode();
 }
 
+void DisableNetwork(NT_Inst inst) {
+  auto ii = InstanceImpl::Get(Handle{inst}.GetTypedInst(Handle::kInstance));
+  if (!ii) return;
+
+  ii->dispatcher.StartNoNetwork();
+}
+
+void EnableNetwork(NT_Inst inst) {
+  auto ii = InstanceImpl::Get(Handle{inst}.GetTypedInst(Handle::kInstance));
+  if (!ii) return;
+
+  ii->dispatcher.Stop();
+}
+
 void StartServer(StringRef persist_filename, const char* listen_address,
                  unsigned int port) {
   auto ii = InstanceImpl::GetDefault();

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
@@ -61,7 +61,8 @@ class NetworkTableInstance final {
     kNetModeServer = NT_NET_MODE_SERVER,
     kNetModeClient = NT_NET_MODE_CLIENT,
     kNetModeStarting = NT_NET_MODE_STARTING,
-    kNetModeFailure = NT_NET_MODE_FAILURE
+    kNetModeFailure = NT_NET_MODE_FAILURE,
+    kNetModeLocal = NT_NET_MODE_LOCAL
   };
 
   /**
@@ -299,17 +300,17 @@ class NetworkTableInstance final {
   unsigned int GetNetworkMode() const;
 
   /**
-   * Disables networking.  Prevents calls to StartServer or StartClient
+   * Starts local-only operation.  Prevents calls to StartServer or StartClient
    * from taking effect.  Has no effect if StartServer or StartClient
    * has already been called.
    */
-  void DisableNetwork();
+  void StartLocal();
 
   /**
-   * Enables networking.  StartServer or StartClient can be called after
-   * this call to start a server or client.  By default, networking is enabled.
+   * Stops local-only operation.  StartServer or StartClient can be called after
+   * this call to start a server or client.
    */
-  void EnableNetwork();
+  void StopLocal();
 
   /**
    * Starts a server using the specified filename, listening address, and port.

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
@@ -299,6 +299,19 @@ class NetworkTableInstance final {
   unsigned int GetNetworkMode() const;
 
   /**
+   * Disables networking.  Prevents calls to StartServer or StartClient
+   * from taking effect.  Has no effect if StartServer or StartClient
+   * has already been called.
+   */
+  void DisableNetwork();
+
+  /**
+   * Enables networking.  StartServer or StartClient can be called after
+   * this call to start a server or client.  By default, networking is enabled.
+   */
+  void EnableNetwork();
+
+  /**
    * Starts a server using the specified filename, listening address, and port.
    *
    * @param persist_filename  the name of the persist file to use (UTF-8 string,

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.inl
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.inl
@@ -81,6 +81,14 @@ inline unsigned int NetworkTableInstance::GetNetworkMode() const {
   return ::nt::GetNetworkMode(m_handle);
 }
 
+inline void NetworkTableInstance::DisableNetwork() {
+  ::nt::DisableNetwork(m_handle);
+}
+
+inline void NetworkTableInstance::EnableNetwork() {
+  ::nt::EnableNetwork(m_handle);
+}
+
 inline void NetworkTableInstance::StartServer(const Twine& persist_filename,
                                               const char* listen_address,
                                               unsigned int port) {

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.inl
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.inl
@@ -81,13 +81,9 @@ inline unsigned int NetworkTableInstance::GetNetworkMode() const {
   return ::nt::GetNetworkMode(m_handle);
 }
 
-inline void NetworkTableInstance::DisableNetwork() {
-  ::nt::DisableNetwork(m_handle);
-}
+inline void NetworkTableInstance::StartLocal() { ::nt::StartLocal(m_handle); }
 
-inline void NetworkTableInstance::EnableNetwork() {
-  ::nt::EnableNetwork(m_handle);
-}
+inline void NetworkTableInstance::StopLocal() { ::nt::StopLocal(m_handle); }
 
 inline void NetworkTableInstance::StartServer(const Twine& persist_filename,
                                               const char* listen_address,

--- a/ntcore/src/main/native/include/ntcore_c.h
+++ b/ntcore/src/main/native/include/ntcore_c.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2015-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2015-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/ntcore/src/main/native/include/ntcore_c.h
+++ b/ntcore/src/main/native/include/ntcore_c.h
@@ -95,7 +95,7 @@ enum NT_NetworkMode {
   NT_NET_MODE_CLIENT = 0x02,   /* running in client mode */
   NT_NET_MODE_STARTING = 0x04, /* flag for starting (either client or server) */
   NT_NET_MODE_FAILURE = 0x08,  /* flag for failure (either client or server) */
-  NT_NET_MODE_DISABLED = 0x10, /* network disabled */
+  NT_NET_MODE_LOCAL = 0x10,    /* running in local-only mode */
 };
 
 /*
@@ -1039,17 +1039,17 @@ void NT_SetNetworkIdentity(NT_Inst inst, const char* name, size_t name_len);
 unsigned int NT_GetNetworkMode(NT_Inst inst);
 
 /**
- * Disables networking.  Prevents calls to NT_StartServer or NT_StartClient
- * from taking effect.  Has no effect if NT_StartServer or NT_StartClient
- * has already been called.
+ * Starts local-only operation.  Prevents calls to NT_StartServer or
+ * NT_StartClient from taking effect.  Has no effect if NT_StartServer or
+ * NT_StartClient has already been called.
  */
-void NT_DisableNetwork(NT_Inst inst);
+void NT_StartLocal(NT_Inst inst);
 
 /**
- * Enables networking.  NT_StartServer or NT_StartClient can be called after
- * this call to start a server or client.  By default, networking is enabled.
+ * Stops local-only operation.  NT_StartServer or NT_StartClient can be called
+ * after this call to start a server or client.
  */
-void NT_EnableNetwork(NT_Inst inst);
+void NT_StopLocal(NT_Inst inst);
 
 /**
  * Starts a server using the specified filename, listening address, and port.

--- a/ntcore/src/main/native/include/ntcore_c.h
+++ b/ntcore/src/main/native/include/ntcore_c.h
@@ -95,6 +95,7 @@ enum NT_NetworkMode {
   NT_NET_MODE_CLIENT = 0x02,   /* running in client mode */
   NT_NET_MODE_STARTING = 0x04, /* flag for starting (either client or server) */
   NT_NET_MODE_FAILURE = 0x08,  /* flag for failure (either client or server) */
+  NT_NET_MODE_DISABLED = 0x10, /* network disabled */
 };
 
 /*
@@ -1036,6 +1037,19 @@ void NT_SetNetworkIdentity(NT_Inst inst, const char* name, size_t name_len);
  * @return Bitmask of NT_NetworkMode.
  */
 unsigned int NT_GetNetworkMode(NT_Inst inst);
+
+/**
+ * Disables networking.  Prevents calls to NT_StartServer or NT_StartClient
+ * from taking effect.  Has no effect if NT_StartServer or NT_StartClient
+ * has already been called.
+ */
+void NT_DisableNetwork(NT_Inst inst);
+
+/**
+ * Enables networking.  NT_StartServer or NT_StartClient can be called after
+ * this call to start a server or client.  By default, networking is enabled.
+ */
+void NT_EnableNetwork(NT_Inst inst);
 
 /**
  * Starts a server using the specified filename, listening address, and port.

--- a/ntcore/src/main/native/include/ntcore_cpp.h
+++ b/ntcore/src/main/native/include/ntcore_cpp.h
@@ -1131,6 +1131,19 @@ unsigned int GetNetworkMode();
 unsigned int GetNetworkMode(NT_Inst inst);
 
 /**
+ * Disables networking.  Prevents calls to StartServer or StartClient
+ * from taking effect.  Has no effect if StartServer or StartClient
+ * has already been called.
+ */
+void DisableNetwork(NT_Inst inst);
+
+/**
+ * Enables networking.  StartServer or StartClient can be called after
+ * this call to start a server or client.  By default, networking is enabled.
+ */
+void EnableNetwork(NT_Inst inst);
+
+/**
  * Starts a server using the specified filename, listening address, and port.
  *
  * @param persist_filename  the name of the persist file to use (UTF-8 string,

--- a/ntcore/src/main/native/include/ntcore_cpp.h
+++ b/ntcore/src/main/native/include/ntcore_cpp.h
@@ -1131,17 +1131,17 @@ unsigned int GetNetworkMode();
 unsigned int GetNetworkMode(NT_Inst inst);
 
 /**
- * Disables networking.  Prevents calls to StartServer or StartClient
+ * Starts local-only operation.  Prevents calls to StartServer or StartClient
  * from taking effect.  Has no effect if StartServer or StartClient
  * has already been called.
  */
-void DisableNetwork(NT_Inst inst);
+void StartLocal(NT_Inst inst);
 
 /**
- * Enables networking.  StartServer or StartClient can be called after
- * this call to start a server or client.  By default, networking is enabled.
+ * Stops local-only operation.  StartServer or StartClient can be called after
+ * this call to start a server or client.
  */
-void EnableNetwork(NT_Inst inst);
+void StopLocal(NT_Inst inst);
 
 /**
  * Starts a server using the specified filename, listening address, and port.


### PR DESCRIPTION
StartLocal() causes future calls to StartServer() or StartClient() to have
no effect.  StopLocal() re-enables these calls.