### PR TITLE
Fix C++ SendableRegistry::AddChild()

### DIFF
--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableRegistry.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableRegistry.h
@@ -125,6 +125,15 @@ class SendableRegistry {
    * @param parent parent object
    * @param child child object
    */
+  void AddChild(Sendable* parent, Sendable* child);
+
+  /**
+   * Adds a child object to an object.  Adds the child object to the registry
+   * if it's not already present.
+   *
+   * @param parent parent object
+   * @param child child object
+   */
   void AddChild(Sendable* parent, void* child);
 
   /**


### PR DESCRIPTION
Add a Sendable* overload so pointers to sendable objects work appropriately.
Otherwise an AddLW(this) in a child (which is a Sendable*) could be a
different pointer than a void* to the same object.

For example:
  AnalogInput constructor calls AddLW(this)
  AnalogPotentiometer constructor calls AddChild(analog input pointer)

Also add handling for the child object moving (if it's Sendable).