### PR TITLE
Fix trapezoidal profile PID controller setpoint bug

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDCommand.java
@@ -113,7 +113,7 @@ public class ProfiledPIDCommand extends CommandBase {
 
   @Override
   public void initialize() {
-    m_controller.reset();
+    m_controller.reset(m_measurement.getAsDouble());
   }
 
   @Override

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDSubsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDSubsystem.java
@@ -93,7 +93,7 @@ public abstract class ProfiledPIDSubsystem extends SubsystemBase {
    */
   public void enable() {
     m_enabled = true;
-    m_controller.reset();
+    m_controller.reset(getMeasurement());
   }
 
   /**

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ProfiledPIDCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ProfiledPIDCommand.h
@@ -118,7 +118,7 @@ class ProfiledPIDCommand
 
   ProfiledPIDCommand(const ProfiledPIDCommand& other) = default;
 
-  void Initialize() override { m_controller.Reset(); }
+  void Initialize() override { m_controller.Reset(m_measurement()); }
 
   void Execute() override {
     m_useOutput(m_controller.Calculate(m_measurement(), m_goal()),

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ProfiledPIDSubsystem.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ProfiledPIDSubsystem.h
@@ -62,10 +62,10 @@ class ProfiledPIDSubsystem : public SubsystemBase {
   void SetGoal(Distance_t goal) { m_goal = State{goal, Velocity_t(0)}; }
 
   /**
-   * Enables the PID control.  Resets the controller.
+   * Enables the PID control. Resets the controller.
    */
   virtual void Enable() {
-    m_controller.Reset();
+    m_controller.Reset(GetMeasurement());
     m_enabled = true;
   }
 

--- a/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -312,7 +312,7 @@ class ProfiledPIDController
 
   /**
    * Reset the previous error and the integral term.
-   * @param measuredPosition the current measured position of the system. The 
+   * @param measuredPosition the current measured position of the system. The
    * velocity is assumed to be zero.
    */
   void Reset(Distance_t measuredPosition) {

--- a/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -294,7 +294,7 @@ class ProfiledPIDController
 
   /**
    * Reset the previous error and the integral term.
-   * 
+   *
    * @param measurement The current measured State of the system.
    */
   void Reset(const State measurement) {
@@ -304,7 +304,7 @@ class ProfiledPIDController
 
   /**
    * Reset the previous error and the integral term.
-   * 
+   *
    * @param measuredPosition The current measured position of the system.
    * @param measuredVelocity The current measured velocity of the system.
    */
@@ -314,7 +314,7 @@ class ProfiledPIDController
 
   /**
    * Reset the previous error and the integral term.
-   * 
+   *
    * @param measuredPosition The current measured position of the system. The
    * velocity is assumed to be zero.
    */

--- a/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -296,8 +296,8 @@ class ProfiledPIDController
    * Reset the previous error and the integral term.
    * @param measurement the current measured State of the system.
    */
-  void Reset(State measurement) { 
-    m_controller.Reset(); 
+  void Reset(State measurement) {
+    m_controller.Reset();
     m_setpoint = measurement;
   }
 
@@ -312,8 +312,8 @@ class ProfiledPIDController
 
   /**
    * Reset the previous error and the integral term.
-   * @param measuredPosition the current measured position of the system. The velocity is
-   *     assumed to be zero.
+   * @param measuredPosition the current measured position of the system. The 
+   * velocity is assumed to be zero.
    */
   void Reset(Distance_t measuredPosition) {
     Reset(measuredPosition, Velocity_t(0));

--- a/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -46,7 +46,8 @@ class ProfiledPIDController
  public:
   /**
    * Allocates a ProfiledPIDController with the given constants for Kp, Ki, and
-   * Kd.
+   * Kd. Users should call reset() when they first start running the controller
+   * to avoid unwanted behavior.
    *
    * @param Kp          The proportional coefficient.
    * @param Ki          The integral coefficient.
@@ -292,9 +293,31 @@ class ProfiledPIDController
   }
 
   /**
-   * Reset the previous error, the integral term, and disable the controller.
+   * Reset the previous error and the integral term.
+   * @param measurement the current measured State of the system.
    */
-  void Reset() { m_controller.Reset(); }
+  void Reset(State measurement) { 
+    m_controller.Reset(); 
+    m_setpoint = measurement;
+  }
+
+  /**
+   * Reset the previous error and the integral term.
+   * @param measuredPosition the current measured position of the system.
+   * @param measuredVelocity the current measured velocity of the system.
+   */
+  void Reset(Distance_t measuredPosition, Velocity_t measuredVelocity) {
+    Reset(State{measuredPosition, measuredVelocity});
+  }
+
+  /**
+   * Reset the previous error and the integral term.
+   * @param measuredPosition the current measured position of the system. The velocity is
+   *     assumed to be zero.
+   */
+  void Reset(Distance_t measuredPosition) {
+    Reset(measuredPosition, Velocity_t(0));
+  }
 
   void InitSendable(frc::SendableBuilder& builder) override {
     builder.SetSmartDashboardType("ProfiledPIDController");

--- a/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -297,7 +297,7 @@ class ProfiledPIDController
    *
    * @param measurement The current measured State of the system.
    */
-  void Reset(const State measurement) {
+  void Reset(const State& measurement) {
     m_controller.Reset();
     m_setpoint = measurement;
   }

--- a/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -294,17 +294,19 @@ class ProfiledPIDController
 
   /**
    * Reset the previous error and the integral term.
-   * @param measurement the current measured State of the system.
+   * 
+   * @param measurement The current measured State of the system.
    */
-  void Reset(State measurement) {
+  void Reset(const State measurement) {
     m_controller.Reset();
     m_setpoint = measurement;
   }
 
   /**
    * Reset the previous error and the integral term.
-   * @param measuredPosition the current measured position of the system.
-   * @param measuredVelocity the current measured velocity of the system.
+   * 
+   * @param measuredPosition The current measured position of the system.
+   * @param measuredVelocity The current measured velocity of the system.
    */
   void Reset(Distance_t measuredPosition, Velocity_t measuredVelocity) {
     Reset(State{measuredPosition, measuredVelocity});
@@ -312,7 +314,8 @@ class ProfiledPIDController
 
   /**
    * Reset the previous error and the integral term.
-   * @param measuredPosition the current measured position of the system. The
+   * 
+   * @param measuredPosition The current measured position of the system. The
    * velocity is assumed to be zero.
    */
   void Reset(Distance_t measuredPosition) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
@@ -328,7 +328,7 @@ public class PIDController implements Sendable, AutoCloseable {
   }
 
   /**
-   * Resets the previous error and the integral term. Also disables the controller.
+   * Resets the previous error and the integral term.
    */
   public void reset() {
     m_prevError = 0;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
@@ -321,7 +321,8 @@ public class ProfiledPIDController implements Sendable {
 
   /**
    * Reset the previous error and the integral term.
-   * @param measurement the current measured State of the system.
+   * 
+   * @param measurement The current measured State of the system.
    */
   public void reset(TrapezoidProfile.State measurement) {
     m_controller.reset();
@@ -330,8 +331,9 @@ public class ProfiledPIDController implements Sendable {
 
   /**
    * Reset the previous error and the integral term.
-   * @param measuredPosition the current measured position of the system.
-   * @param measuredVelocity the current measured velocity of the system.
+   * 
+   * @param measuredPosition The current measured position of the system.
+   * @param measuredVelocity The current measured velocity of the system.
    */
   public void reset(double measuredPosition, double measuredVelocity) {
     reset(new TrapezoidProfile.State(measuredPosition, measuredVelocity));
@@ -339,7 +341,8 @@ public class ProfiledPIDController implements Sendable {
 
   /**
    * Reset the previous error and the integral term.
-   * @param measuredPosition the current measured position of the system. The velocity is
+   * 
+   * @param measuredPosition The current measured position of the system. The velocity is
    *     assumed to be zero.
    */
   public void reset(double measuredPosition) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
@@ -15,7 +15,8 @@ import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile;
 
 /**
  * Implements a PID control loop whose setpoint is constrained by a trapezoid
- * profile.
+ * profile. Users should call reset() when they first start running the controller
+ * to avoid unwanted behavior.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public class ProfiledPIDController implements Sendable {
@@ -319,10 +320,30 @@ public class ProfiledPIDController implements Sendable {
   }
 
   /**
-   * Reset the previous error, the integral term, and disable the controller.
+   * Reset the previous error and the integral term.
+   * @param measurement the current measured State of the system.
    */
-  public void reset() {
+  public void reset(TrapezoidProfile.State measurement) {
     m_controller.reset();
+    m_setpoint = measurement;
+  }
+
+  /**
+   * Reset the previous error and the integral term.
+   * @param measuredPosition the current measured position of the system.
+   * @param measuredVelocity the current measured velocity of the system.
+   */
+  public void reset(double measuredPosition, double measuredVelocity) {
+    reset(new TrapezoidProfile.State(measuredPosition, measuredVelocity));
+  }
+
+  /**
+   * Reset the previous error and the integral term.
+   * @param measuredPosition the current measured position of the system. The velocity is
+   *     assumed to be zero.
+   */
+  public void reset(double measuredPosition) {
+    reset(measuredPosition, 0.0);
   }
 
   @Override

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -321,7 +321,7 @@ public class ProfiledPIDController implements Sendable {
 
   /**
    * Reset the previous error and the integral term.
-   * 
+   *
    * @param measurement The current measured State of the system.
    */
   public void reset(TrapezoidProfile.State measurement) {
@@ -331,7 +331,7 @@ public class ProfiledPIDController implements Sendable {
 
   /**
    * Reset the previous error and the integral term.
-   * 
+   *
    * @param measuredPosition The current measured position of the system.
    * @param measuredVelocity The current measured velocity of the system.
    */
@@ -341,7 +341,7 @@ public class ProfiledPIDController implements Sendable {
 
   /**
    * Reset the previous error and the integral term.
-   * 
+   *
    * @param measuredPosition The current measured position of the system. The velocity is
    *     assumed to be zero.
    */

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/ProfiledPIDControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/ProfiledPIDControllerTest.java
@@ -15,7 +15,7 @@ import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile;
 public class ProfiledPIDControllerTest {
   @Test
   @SuppressWarnings("PMD")
-  public void testStartFromNonZeroPosition() {
+ void testStartFromNonZeroPosition() {
     ProfiledPIDController controller = new ProfiledPIDController(1.0, 0.0, 0.0,
         new TrapezoidProfile.Constraints(1.0, 1.0));
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/ProfiledPIDControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/ProfiledPIDControllerTest.java
@@ -1,3 +1,10 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
 package edu.wpi.first.wpilibj.controller;
 
 import org.junit.jupiter.api.Assertions;
@@ -6,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile;
 
 public class ProfiledPIDControllerTest {
-
   @Test
   @SuppressWarnings("PMD")
   public void testStartFromNonZeroPosition() {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/ProfiledPIDControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/ProfiledPIDControllerTest.java
@@ -1,0 +1,21 @@
+package edu.wpi.first.wpilibj.controller;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile;
+
+public class ProfiledPIDControllerTest {
+
+  @Test
+  @SuppressWarnings("PMD")
+  public void testStartFromNonZeroPosition() {
+    ProfiledPIDController controller = new ProfiledPIDController(1.0, 0.0, 0.0,
+        new TrapezoidProfile.Constraints(1.0, 1.0));
+
+    controller.reset(20);
+
+    Assertions.assertEquals(0.0, controller.calculate(20), 0.05);
+  }
+
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/ProfiledPIDControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/ProfiledPIDControllerTest.java
@@ -23,5 +23,4 @@ class ProfiledPIDControllerTest {
 
     assertEquals(0.0, controller.calculate(20), 0.05);
   }
-
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/ProfiledPIDControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/ProfiledPIDControllerTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile;
 
-public class ProfiledPIDControllerTest {
+class ProfiledPIDControllerTest {
   @Test
   @SuppressWarnings("PMD")
  void testStartFromNonZeroPosition() {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/ProfiledPIDControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/ProfiledPIDControllerTest.java
@@ -7,21 +7,21 @@
 
 package edu.wpi.first.wpilibj.controller;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 class ProfiledPIDControllerTest {
   @Test
-  @SuppressWarnings("PMD")
- void testStartFromNonZeroPosition() {
+  void testStartFromNonZeroPosition() {
     ProfiledPIDController controller = new ProfiledPIDController(1.0, 0.0, 0.0,
         new TrapezoidProfile.Constraints(1.0, 1.0));
 
     controller.reset(20);
 
-    Assertions.assertEquals(0.0, controller.calculate(20), 0.05);
+    assertEquals(0.0, controller.calculate(20), 0.05);
   }
 
 }


### PR DESCRIPTION
Currently, the profiled PID Controller's m_setpoint starts at (0,0). This changes the reset() method to set m_setpoint to the current state of the system.