### PR TITLE
Fix javadoc 'undefined' issue

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -106,6 +106,7 @@ task generateJavaDocs(type: Javadoc) {
     options.addStringOption "tag", "pre:a:Pre-Condition"
     options.addBooleanOption "Xdoclint:html,missing,reference,syntax", true
     options.addBooleanOption('html5', true)
+    options.addBooleanOption "-no-module-directories", true
     dependsOn project(':wpilibj').generateJavaVersion
     dependsOn project(':hal').generateUsageReporting
     source project(':hal').sourceSets.main.java


### PR DESCRIPTION
There is a known issue with javadoc generation in Gradle where, when the option `-no-module-directories` is not set to `true`, the search functionality is broken, and will bring you to a 404 page. This PR adds the option to the build.gradle

This issue is specifically caused by a Javascript function returning `undefined`, and causing the URL to become `https://first.wpi.edu/FRC/roborio/release/docs/java/undefined/...` instead of `https://first.wpi.edu/FRC/roborio/release/docs/java/...`