### PR TITLE
TrajectoryGenerator: Allow replacement of error reporting function

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
@@ -27,7 +27,7 @@ import edu.wpi.first.wpilibj.spline.SplineParameterizer.MalformedSplineException
 public final class TrajectoryGenerator {
   private static final Trajectory kDoNothingTrajectory =
       new Trajectory(Arrays.asList(new Trajectory.State()));
-  private static BiConsumer<String, StackTraceElement[]> errorFunc = null;
+  private static BiConsumer<String, StackTraceElement[]> errorFunc;
 
   /**
    * Private constructor because this is a utility class.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryGenerator.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.geometry.Pose2d;
@@ -26,11 +27,29 @@ import edu.wpi.first.wpilibj.spline.SplineParameterizer.MalformedSplineException
 public final class TrajectoryGenerator {
   private static final Trajectory kDoNothingTrajectory =
       new Trajectory(Arrays.asList(new Trajectory.State()));
+  private static BiConsumer<String, StackTraceElement[]> errorFunc = null;
 
   /**
    * Private constructor because this is a utility class.
    */
   private TrajectoryGenerator() {
+  }
+
+  private static void reportError(String error, StackTraceElement[] stackTrace) {
+    if (errorFunc != null) {
+      errorFunc.accept(error, stackTrace);
+    } else {
+      DriverStation.reportError(error, stackTrace);
+    }
+  }
+
+  /**
+   * Set error reporting function. By default, DriverStation.reportError() is used.
+   *
+   * @param func Error reporting function, arguments are error and stackTrace.
+   */
+  public static void setErrorHandler(BiConsumer<String, StackTraceElement[]> func) {
+    errorFunc = func;
   }
 
   /**
@@ -71,7 +90,7 @@ public final class TrajectoryGenerator {
       points = splinePointsFromSplines(SplineHelper.getCubicSplinesFromControlVectors(newInitial,
           interiorWaypoints.toArray(new Translation2d[0]), newEnd));
     } catch (MalformedSplineException ex) {
-      DriverStation.reportError(ex.getMessage(), ex.getStackTrace());
+      reportError(ex.getMessage(), ex.getStackTrace());
       return kDoNothingTrajectory;
     }
 
@@ -147,7 +166,7 @@ public final class TrajectoryGenerator {
           newControlVectors.toArray(new Spline.ControlVector[]{})
       ));
     } catch (MalformedSplineException ex) {
-      DriverStation.reportError(ex.getMessage(), ex.getStackTrace());
+      reportError(ex.getMessage(), ex.getStackTrace());
       return kDoNothingTrajectory;
     }
 


### PR DESCRIPTION
This is needed to avoid use of DriverStation if used from desktop applications
such as PathWeaver.