### PR TITLE
Add more error handling messages to RuntimeLoader failures

### DIFF
--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeLoader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeLoader.java
@@ -52,7 +52,7 @@ public final class RuntimeLoader<T> {
   }
 
   private String getLoadErrorMessage(UnsatisfiedLinkError ule) {
-    StringBuilder msg = new StringBuilder(256);
+    StringBuilder msg = new StringBuilder(512);
     msg.append(m_libraryName)
        .append(" could not be loaded from path or an embedded resource.\n"
                + "\tattempted to load for platform ")

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeLoader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeLoader.java
@@ -57,13 +57,12 @@ public final class RuntimeLoader<T> {
        .append(" could not be loaded from path or an embedded resource.\n"
                + "\tattempted to load for platform ")
        .append(RuntimeDetector.getPlatformPath())
-       .append('\n')
-       .append("Last Load Error: \n")
+       .append("\nLast Load Error: \n")
        .append(ule.getMessage())
-       .append("\n");
+       .append('\n');
     if (RuntimeDetector.isWindows()) {
-      msg.append("A common cause of this error is missing the C++ runtime.\n")
-         .append("Download the latest at https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads\n");
+      msg.append("A common cause of this error is missing the C++ runtime.\n" 
+                 + "Download the latest at https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads\n");
     }
     return msg.toString();
   }

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeLoader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeLoader.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -51,13 +51,20 @@ public final class RuntimeLoader<T> {
     m_extractionRoot = extractionRoot;
   }
 
-  private String getLoadErrorMessage() {
+  private String getLoadErrorMessage(UnsatisfiedLinkError ule) {
     StringBuilder msg = new StringBuilder(256);
     msg.append(m_libraryName)
        .append(" could not be loaded from path or an embedded resource.\n"
                + "\tattempted to load for platform ")
        .append(RuntimeDetector.getPlatformPath())
-       .append('\n');
+       .append('\n')
+       .append("Last Load Error: \n")
+       .append(ule.getMessage())
+       .append("\n");
+    if (RuntimeDetector.isWindows()) {
+      msg.append("A common cause of this error is missing the C++ runtime.\n")
+         .append("Download the latest at https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads\n");
+    }
     return msg.toString();
   }
 
@@ -75,7 +82,7 @@ public final class RuntimeLoader<T> {
       String resname = RuntimeDetector.getLibraryResource(m_libraryName);
       try (InputStream hashIs = m_loadClass.getResourceAsStream(hashName)) {
         if (hashIs == null) {
-          throw new IOException(getLoadErrorMessage());
+          throw new IOException(getLoadErrorMessage(ule));
         }
         try (Scanner scanner = new Scanner(hashIs, StandardCharsets.UTF_8.name())) {
           String hash = scanner.nextLine();
@@ -87,7 +94,7 @@ public final class RuntimeLoader<T> {
             // If extraction failed, extract
             try (InputStream resIs = m_loadClass.getResourceAsStream(resname)) {
               if (resIs == null) {
-                throw new IOException(getLoadErrorMessage());
+                throw new IOException(getLoadErrorMessage(ule));
               }
               jniLibrary.getParentFile().mkdirs();
               try (OutputStream os = Files.newOutputStream(jniLibrary.toPath())) {
@@ -120,7 +127,7 @@ public final class RuntimeLoader<T> {
       String hash = null;
       try (InputStream is = m_loadClass.getResourceAsStream(resname)) {
         if (is == null) {
-          throw new IOException(getLoadErrorMessage());
+          throw new IOException(getLoadErrorMessage(ule));
         }
         MessageDigest md = null;
         try {
@@ -152,7 +159,7 @@ public final class RuntimeLoader<T> {
         // If extraction failed, extract
         try (InputStream resIs = m_loadClass.getResourceAsStream(resname)) {
           if (resIs == null) {
-            throw new IOException(getLoadErrorMessage());
+            throw new IOException(getLoadErrorMessage(ule));
           }
           jniLibrary.getParentFile().mkdirs();
           try (OutputStream os = Files.newOutputStream(jniLibrary.toPath())) {

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeLoader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeLoader.java
@@ -61,7 +61,7 @@ public final class RuntimeLoader<T> {
        .append(ule.getMessage())
        .append('\n');
     if (RuntimeDetector.isWindows()) {
-      msg.append("A common cause of this error is missing the C++ runtime.\n" 
+      msg.append("A common cause of this error is missing the C++ runtime.\n"
                  + "Download the latest at https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads\n");
     }
     return msg.toString();


### PR DESCRIPTION
Should specify the C++ runtime is needed, along with making it easier to troubleshoot and to not lose information