### PR TITLE
Fix hal cmake generated code install

### DIFF
--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -57,7 +57,7 @@ set_property(TARGET hal PROPERTY FOLDER "libraries")
 
 install(TARGETS hal EXPORT hal DESTINATION "${main_lib_dest}")
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/hal")
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gen DESTINATION "${include_dest}/hal")
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gen/ DESTINATION "${include_dest}/hal")
 
 if (MSVC OR FLAT_INSTALL_WPILIB)
     set (hal_config_dir ${wpilib_dest})


### PR DESCRIPTION
Previously the cmake for hal would install the entire `gen` folder into `wpilib\include\hal`, but now it will correctly copy only the contents. See [this SO answer](https://stackoverflow.com/a/23766303) for details.

For example
`wpilib\include\hal\gen\hal\FRCUsageReporting.h`
now becomes
`wpilib\include\hal\hal\FRCUsageReporting.h`