### PR TITLE
Change behavior of ShuffleboardContainer#add to be repeatable

### DIFF
--- a/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTabTest.java
+++ b/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTabTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings({"PMD.TooManyMethods"})
 public class ShuffleboardTabTest {
@@ -129,12 +128,6 @@ public class ShuffleboardTabTest {
     assertAll(
         () -> assertEquals("/Shuffleboard/Tab/StringArray", entry.getName()),
         () -> assertArrayEquals(new String[]{"foo", "bar"}, entry.getValue().getStringArray()));
-  }
-
-  @Test
-  void testTitleDuplicates() {
-    m_tab.add("foo", "bar");
-    assertThrows(IllegalArgumentException.class, () -> m_tab.add("foo", "baz"));
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ContainerHelper.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ContainerHelper.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -31,6 +31,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 final class ContainerHelper {
   private final ShuffleboardContainer m_container;
   private final Set<String> m_usedTitles = new HashSet<>();
+  private final Map<String, SimpleWidget> m_simpleWidgets = new LinkedHashMap<>();
   private final List<ShuffleboardComponent<?>> m_components = new ArrayList<>();
   private final Map<String, ShuffleboardLayout> m_layouts = new LinkedHashMap<>();
 
@@ -74,15 +75,20 @@ final class ContainerHelper {
     return add(name, sendable);
   }
 
-  SimpleWidget add(String title, Object defaultValue) {
+  SimpleWidget add(String title, Object value) {
     Objects.requireNonNull(title, "Title cannot be null");
-    Objects.requireNonNull(defaultValue, "Default value cannot be null");
-    checkTitle(title);
-    checkNtType(defaultValue);
+    Objects.requireNonNull(value, "Value cannot be null");
+    // checkTitle(title); -- this is explicitly permitted to allow users to update existing values
+    checkNtType(value);
 
-    SimpleWidget widget = new SimpleWidget(m_container, title);
-    m_components.add(widget);
-    widget.getEntry().setDefaultValue(defaultValue);
+    if (!m_simpleWidgets.containsKey(title)) {
+      SimpleWidget widget = new SimpleWidget(m_container, title);
+      m_components.add(widget);
+      m_simpleWidgets.put(title, widget);
+    }
+
+    SimpleWidget widget = m_simpleWidgets.get(title);
+    widget.getEntry().setValue(value);
     return widget;
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -117,16 +117,26 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
   }
 
   /**
-   * Adds a widget to this container to display the given data.
+   * Adds a widget to this container to display the given data.  If a widget already exists with
+   * the given title, its value will be updated with the value given.
    *
-   * @param title        the title of the widget
-   * @param defaultValue the default value of the widget
+   * <p>For example:
+   * <pre>{@code
+   * public class Drivetrain extends Subsystem {
+   *   @Override
+   *   public void periodic() {
+   *     Shuffleboard.getTab("Drivetrain").add("Current Speed", myEncoder.getRate());
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param title the title of the widget
+   * @param value the  value of the widget
    * @return a widget to display the sendable data
-   * @throws IllegalArgumentException if a widget already exists in this container with the given
-   *                                  title
+   *
    * @see #addPersistent(String, Object) add(String title, Object defaultValue)
    */
-  SimpleWidget add(String title, Object defaultValue) throws IllegalArgumentException;
+  SimpleWidget add(String title, Object value);
 
   /**
    * Adds a widget to this container. The widget will display the data provided by the value

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardLayout.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardLayout.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -56,8 +56,8 @@ public class ShuffleboardLayout extends ShuffleboardComponent<ShuffleboardLayout
   }
 
   @Override
-  public SimpleWidget add(String title, Object defaultValue) throws IllegalArgumentException {
-    return m_helper.add(title, defaultValue);
+  public SimpleWidget add(String title, Object value) {
+    return m_helper.add(title, value);
   }
 
   @Override

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTab.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTab.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -68,8 +68,8 @@ public final class ShuffleboardTab implements ShuffleboardContainer {
   }
 
   @Override
-  public SimpleWidget add(String title, Object defaultValue) {
-    return m_helper.add(title, defaultValue);
+  public SimpleWidget add(String title, Object value) {
+    return m_helper.add(title, value);
   }
 
   @Override

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTest.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -7,10 +7,14 @@
 
 package edu.wpi.first.wpilibj.shuffleboard;
 
+import java.util.stream.DoubleStream;
+
 import org.junit.jupiter.api.Test;
 
 import edu.wpi.first.wpilibj.UtilityClassTest;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class ShuffleboardTest extends UtilityClassTest<Shuffleboard> {
@@ -27,4 +31,15 @@ public class ShuffleboardTest extends UtilityClassTest<Shuffleboard> {
     assertSame(tab1, tab2, "Tab objects were not cached");
   }
 
+  @Test
+  void testAddCanBeRepeated() {
+    String tabName = "Tab";
+    String title = "Title";
+    SimpleWidget widget = Shuffleboard.getTab(tabName).add(title, 0);
+    assertAll(DoubleStream.iterate(1, d -> d <= 10, d -> d + 1)
+        .mapToObj(d -> () -> {
+          Shuffleboard.getTab(tabName).add(title, d);
+          assertEquals(d, widget.getEntry().getNumber(0), "Entry was not set");
+        }));
+  }
 }


### PR DESCRIPTION
This changes the behavior of `add` where it was not allowed to be called with the same title multiple times.

Results in a similar API to `SmartDashboard.putXYZ`, and can be called in a loop.

For example:

```java
@Override
public void robotPeriodic() {
  Shuffleboard.getTab("Tab").add("Random", Math.random());
}
```