### PR TITLE
Derivative filter

### DIFF
--- a/wpilibc/src/main/native/include/frc/Derivative.h
+++ b/wpilibc/src/main/native/include/frc/Derivative.h
@@ -1,0 +1,41 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <cassert>
+#include <type_traits>
+
+#include <units/units.h>
+#include <wpi/circular_buffer.h>
+
+namespace frc {
+template <class Unit>
+class Derivative {
+ public:
+  using Unit_t = units::unit_t<Unit>;
+  using Velocity = units::compound_unit<Unit, units::inverse<units::seconds>>;
+  using Velocity_t = units::unit_t<Velocity>;
+
+  Derivative(size_t taps, units::second_t period)
+      : m_buffer(taps), m_taps(taps), m_period(period) {
+    assert(taps >= 2);
+  }
+
+  Velocity_t Calculate(Unit_t input) {
+    m_buffer.push_front(input);
+    return (m_buffer.front() - m_buffer.back()) / ((m_taps - 1) * m_period);
+  }
+
+  void Reset() { m_buffer.Reset(); }
+
+ private:
+  wpi::circular_buffer<Unit_t> m_buffer;
+  size_t m_taps;
+  units::second_t m_period;
+};
+}  // namespace frc

--- a/wpilibc/src/test/native/cpp/DerivativeTest.cpp
+++ b/wpilibc/src/test/native/cpp/DerivativeTest.cpp
@@ -1,0 +1,32 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <units/units.h>
+
+#include "frc/Derivative.h"
+#include "gtest/gtest.h"
+
+using namespace frc;
+
+TEST(DerivativeTest, DerivativeTest) {
+  Derivative<units::meter> twoSampleDerivative{2, 0.02_s};
+  Derivative<units::meter> fiveSampleDerivative{5, 0.02_s};
+
+  // Input stream; increases by 1 every 20ms, derivative should be 50.
+  units::meter_t input[] = {0_m, 1_m, 2_m, 3_m, 4_m, 5_m, 6_m, 7_m, 8_m, 9_m};
+
+  units::meters_per_second_t twoSampleOutput = 0_mps;
+  units::meters_per_second_t fiveSampleOutput = 0_mps;
+
+  for (auto value : input) {
+    twoSampleOutput = twoSampleDerivative.Calculate(value);
+    fiveSampleOutput = fiveSampleDerivative.Calculate(value);
+  }
+
+  EXPECT_EQ(twoSampleOutput, 50_mps);
+  EXPECT_EQ(fiveSampleOutput, 50_mps);
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/LinearFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/LinearFilter.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2015-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2015-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -125,9 +125,30 @@ public class LinearFilter {
     }
 
     double[] ffGains = new double[taps];
-    for (int i = 0; i < ffGains.length; i++) {
-      ffGains[i] = 1.0 / taps;
+    Arrays.fill(ffGains, 1.0 / taps);
+
+    double[] fbGains = new double[0];
+
+    return new LinearFilter(ffGains, fbGains);
+  }
+
+  /**
+   * Creates a K-tap numerical derivative filter (i.e. slope of the secant line over the past K
+   * samples).
+   *
+   * @param taps The number of samples over which to compute the derivative.
+   * @param period The period between samples, in seconds.
+   * @throws IllegalArgumentException if number of taps is less than 2.
+   */
+  public static LinearFilter derivative(int taps, double period) {
+    if (taps < 2) {
+      throw new IllegalArgumentException("Number of taps was not at least 1");
     }
+
+    double[] ffGains = new double[taps];
+    Arrays.fill(ffGains, 0);
+    ffGains[0] = 1.0 / ((taps - 1) * period);
+    ffGains[taps - 1] = -1.0 / ((taps - 1) * period);
 
     double[] fbGains = new double[0];
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/LinearFilterTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/LinearFilterTest.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2015-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2015-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -112,5 +112,25 @@ class LinearFilterTest {
             (DoubleFunction<Double>) LinearFilterTest::getPulseData,
             0.0)
     );
+  }
+
+  @Test
+  void derivativeFilterTest() {
+    var twoSampleDerivative = LinearFilter.derivative(2, .02);
+    var fiveSampleDerivative = LinearFilter.derivative(5, .02);
+
+    // Input stream; increases by 1 every 20ms, derivative should be 50.
+    double[] input = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    double twoSampleOutput = 0;
+    double fiveSampleOutput = 0;
+
+    for (var value : input) {
+      twoSampleOutput = twoSampleDerivative.calculate(value);
+      fiveSampleOutput = fiveSampleDerivative.calculate(value);
+    }
+
+    assertEquals(50, twoSampleOutput);
+    assertEquals(50, fiveSampleOutput);
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/LinearFilterTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/LinearFilterTest.java
@@ -116,8 +116,8 @@ class LinearFilterTest {
 
   @Test
   void derivativeFilterTest() {
-    var twoSampleDerivative = LinearFilter.derivative(2, .02);
-    var fiveSampleDerivative = LinearFilter.derivative(5, .02);
+    var twoSampleDerivative = LinearFilter.derivative(2, 0.02);
+    var fiveSampleDerivative = LinearFilter.derivative(5, 0.02);
 
     // Input stream; increases by 1 every 20ms, derivative should be 50.
     double[] input = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};


### PR DESCRIPTION
Adds a derivative calculator.  In java, this is implemented as a static factory for `LinearFilter`, which is highly convenient.  In C++, this cannot be done due to units, and it is a separate class.

This also partially fixes an issue with `CircularBuffer` where it would not work with any type not implicitly-convertible from `int`, including all unit types.  It is not fully fixed - I have opened an issue for the remaining problem.