### PR TITLE
Improved the portability of OpenCV Java bindings detection when using CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ option(USE_VCPKG_LIBUV "Use vcpkg libuv" OFF)
 option(USE_VCPKG_EIGEN "Use vcpkg eigen" OFF)
 option(FLAT_INSTALL_WPILIB "Use a flat install directory" OFF)
 option(WITH_SIMULATION_MODULES "build simulation modules" OFF)
+set(OPENCV_JAVA_INSTALL_DIR "" CACHE PATH "Location to search for the OpenCV jar file")
 
 if (NOT WITHOUT_JAVA AND NOT BUILD_SHARED_LIBS)
     message(FATAL_ERROR "
@@ -62,6 +63,15 @@ FATAL: Cannot build static libs with Java enabled.
        Static libs requires both BUILD_SHARED_LIBS=OFF and
        WITHOUT_JAVA=ON
 ")
+endif()
+
+if (WITHOUT_JAVA OR WITHOUT_CSCORE)
+    if(NOT OPENCV_JAVA_INSTALL_DIR EQUAL "")
+        message(WARNING "
+WARNING: OpenCV Java dir set but java is not enabled!
+It will be ignored.
+")
+    endif()
 endif()
 
 set( wpilib_dest wpilib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ FATAL: Cannot build static libs with Java enabled.
 endif()
 
 if (WITHOUT_JAVA OR WITHOUT_CSCORE)
-    if(NOT OPENCV_JAVA_INSTALL_DIR EQUAL "")
+    if(NOT "${OPENCV_JAVA_INSTALL_DIR}" STREQUAL "")
         message(WARNING "
 WARNING: OpenCV Java dir set but java is not enabled!
 It will be ignored.

--- a/README-CMAKE.md
+++ b/README-CMAKE.md
@@ -34,6 +34,8 @@ The following build options are available:
   * TODO
 * EXTERNAL_HAL_FILE
   * TODO
+* OPENCV_JAVA_INSTALL_DIR
+  * Set this option to the location of the archive of the OpenCV Java bindings (it should be called opencv-xxx.jar, with the x'es being version numbers). NOTE: set it to the LOCATION of the file, not the file itself!
 
 ## Build Setup
 

--- a/cscore/CMakeLists.txt
+++ b/cscore/CMakeLists.txt
@@ -69,7 +69,9 @@ if (NOT WITHOUT_JAVA)
 
     #find java files, copy them locally
 
-    set(OPENCV_JAVA_INSTALL_DIR ${OpenCV_INSTALL_PATH}/share/OpenCV/java/)
+    if(OPENCV_JAVA_INSTALL_DIR EQUAL "")
+        set(OPENCV_JAVA_INSTALL_DIR ${OpenCV_INSTALL_PATH}/share/OpenCV/java/)
+    endif()
 
     find_file(OPENCV_JAR_FILE NAMES opencv-${OpenCV_VERSION_MAJOR}${OpenCV_VERSION_MINOR}${OpenCV_VERSION_PATCH}.jar PATHS ${OPENCV_JAVA_INSTALL_DIR} ${OpenCV_INSTALL_PATH}/bin NO_DEFAULT_PATH)
     find_file(OPENCV_JNI_FILE NAMES libopencv_java${OpenCV_VERSION_MAJOR}${OpenCV_VERSION_MINOR}${OpenCV_VERSION_PATCH}.so

--- a/cscore/CMakeLists.txt
+++ b/cscore/CMakeLists.txt
@@ -69,7 +69,7 @@ if (NOT WITHOUT_JAVA)
 
     #find java files, copy them locally
 
-    if(OPENCV_JAVA_INSTALL_DIR EQUAL "")
+    if("${OPENCV_JAVA_INSTALL_DIR}" STREQUAL "")
         set(OPENCV_JAVA_INSTALL_DIR ${OpenCV_INSTALL_PATH}/share/OpenCV/java/)
     endif()
 


### PR DESCRIPTION
[In this issue](https://github.com/wpilibsuite/allwpilib/issues/2346#issue-561356044), the CMake build system's OpenCV Java bindings detection was shown to be flawed. On several Linux distributions, the location of the .jar file with the Java-level bindings is not located, including Arch Linux and Fedora. Since it is not possible to account for every possible system's configuration, this pull request enables the searched location to be manually set. The actual name of the .jar file cannot be configured as of now, but on all systems that I've seen it has the currently detected name. If changing it is necessary it would be possible to symlink from a directory in one's home to the correct file, and set the location there.