### PR TITLE
Fix "'dimensionless' ambiguous symbol" error

### DIFF
--- a/wpiutil/src/main/native/include/units/units.h
+++ b/wpiutil/src/main/native/include/units/units.h
@@ -2462,7 +2462,6 @@ namespace units
 	namespace dimensionless
 	{
 		typedef unit<std::ratio<1>, units::category::scalar_unit> scalar;
-		typedef unit<std::ratio<1>, units::category::dimensionless_unit> dimensionless;
 
 		typedef unit_t<scalar> scalar_t;
 		typedef scalar_t dimensionless_t;


### PR DESCRIPTION
A typedef for units::dimensionless::dimensionless is defined, which
conflicted with the namespace when we added "using namespace
dimensionless". This patch removes the typedef. Teams should use
units::scalar instead.

This issue was first introduced in #2301.