### PR TITLE
Fix "'dimensionless' ambiguous symbol" error

### DIFF
--- a/wpiutil/src/main/native/include/units/units.h
+++ b/wpiutil/src/main/native/include/units/units.h
@@ -4854,5 +4854,8 @@ using namespace velocity;
 using namespace acceleration;
 using namespace angle;
 using namespace voltage;
-using namespace dimensionless;
+
+using dimensionless::scalar;
+using dimensionless::scalar_t;
+using dimensionless::dimensionless_t;
 }  // namespace units


### PR DESCRIPTION
A typedef for units::dimensionless::dimensionless is defined, which
conflicted with the namespace when we added "using namespace
dimensionless". This patch reverts the "using namespace" directive.
"using" directives were added to pull three of the four relevant
typedefs but avoid the "dimensionless" type conflict.

This issue was first introduced in #2301.