### PR TITLE
DutyCycleEncoder: Fix simulation support

### DIFF
--- a/wpilibc/src/main/native/include/frc/DutyCycleEncoder.h
+++ b/wpilibc/src/main/native/include/frc/DutyCycleEncoder.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -160,8 +160,8 @@ class DutyCycleEncoder : public ErrorBase,
   void Init();
 
   std::shared_ptr<DutyCycle> m_dutyCycle;
-  AnalogTrigger m_analogTrigger;
-  Counter m_counter;
+  std::unique_ptr<AnalogTrigger> m_analogTrigger;
+  std::unique_ptr<Counter> m_counter;
   int m_frequencyThreshold = 100;
   double m_positionOffset = 0;
   double m_distancePerRotation = 1.0;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycleEncoder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycleEncoder.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -65,19 +65,18 @@ public class DutyCycleEncoder implements Sendable, AutoCloseable {
   }
 
   private void init() {
-    m_analogTrigger = new AnalogTrigger(m_dutyCycle);
-    m_counter = new Counter();
-
     m_simDevice = SimDevice.create("DutyCycleEncoder", m_dutyCycle.getFPGAIndex());
 
     if (m_simDevice != null) {
       m_simPosition = m_simDevice.createDouble("Position", false, 0.0);
       m_simIsConnected = m_simDevice.createBoolean("Connected", false, true);
+    } else {
+      m_counter = new Counter();
+      m_analogTrigger = new AnalogTrigger(m_dutyCycle);
+      m_analogTrigger.setLimitsDutyCycle(0.25, 0.75);
+      m_counter.setUpSource(m_analogTrigger, AnalogTriggerType.kRisingPulse);
+      m_counter.setDownSource(m_analogTrigger, AnalogTriggerType.kFallingPulse);
     }
-
-    m_analogTrigger.setLimitsDutyCycle(0.25, 0.75);
-    m_counter.setUpSource(m_analogTrigger, AnalogTriggerType.kRisingPulse);
-    m_counter.setDownSource(m_analogTrigger, AnalogTriggerType.kFallingPulse);
 
     SendableRegistry.addLW(this, "DutyCycle Encoder", m_dutyCycle.getSourceChannel());
   }
@@ -173,7 +172,9 @@ public class DutyCycleEncoder implements Sendable, AutoCloseable {
    * Reset the Encoder distance to zero.
    */
   public void reset() {
-    m_counter.reset();
+    if (m_counter != null) {
+      m_counter.reset();
+    }
     m_positionOffset = m_dutyCycle.getOutput();
   }
 
@@ -209,8 +210,12 @@ public class DutyCycleEncoder implements Sendable, AutoCloseable {
 
   @Override
   public void close() {
-    m_counter.close();
-    m_analogTrigger.close();
+    if (m_counter != null) {
+      m_counter.close();
+    }
+    if (m_analogTrigger != null) {
+      m_analogTrigger.close();
+    }
     if (m_ownsDutyCycle) {
       m_dutyCycle.close();
     }


### PR DESCRIPTION
The DutyCycleEncoder class initializes `AnalogTrigger` even while using `simulateJava`. When initializing `AnalogTrigger` an exception is thrown as described here: https://github.com/wpilibsuite/allwpilib/issues/2367

This PR fixes the Java version by not using AnalogTrigger (or Counter) while simulating DutyCycleEncoder. I believe the CPP version also needs the same fix.