### PR TITLE
Fix Watchdog epoch prints being off by three orders of magnitude

### DIFF
--- a/wpilibc/src/main/native/cpp/Watchdog.cpp
+++ b/wpilibc/src/main/native/cpp/Watchdog.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -134,12 +134,18 @@ void Watchdog::AddEpoch(wpi::StringRef epochName) {
 }
 
 void Watchdog::PrintEpochs() {
+  using std::chrono::duration_cast;
+  using std::chrono::microseconds;
+
   auto now = hal::fpga_clock::now();
   if (now - m_lastEpochsPrintTime > kMinPrintPeriod) {
     m_lastEpochsPrintTime = now;
     for (const auto& epoch : m_epochs) {
       wpi::outs() << '\t' << epoch.getKey() << ": "
-                  << wpi::format("%.6f", epoch.getValue().count() / 1.0e6)
+                  << wpi::format(
+                         "%.6f",
+                         duration_cast<microseconds>(epoch.getValue()).count() /
+                             1.0e6)
                   << "s\n";
     }
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -26,17 +26,17 @@ import java.util.concurrent.locks.ReentrantLock;
 @SuppressWarnings("PMD.TooManyMethods")
 public class Watchdog implements Closeable, Comparable<Watchdog> {
   // Used for timeout print rate-limiting
-  private static final long kMinPrintPeriod = 1000000; // us
+  private static final long kMinPrintPeriod = 1000000; // microseconds
 
-  private long m_startTime; // us
-  private long m_timeout; // us
-  private long m_expirationTime; // us
+  private long m_startTime; // microseconds
+  private long m_timeout; // microseconds
+  private long m_expirationTime; // microseconds
   private final Runnable m_callback;
-  private long m_lastTimeoutPrintTime; // us
-  private long m_lastEpochsPrintTime; // us
+  private long m_lastTimeoutPrintTime; // microseconds
+  private long m_lastEpochsPrintTime; // microseconds
 
   @SuppressWarnings("PMD.UseConcurrentHashMap")
-  private final Map<String, Long> m_epochs = new HashMap<>();
+  private final Map<String, Long> m_epochs = new HashMap<>(); // microseconds
   boolean m_isExpired;
 
   boolean m_suppressTimeoutMessage;


### PR DESCRIPTION
This was caused by m_epochs storing the timestamps as nanoseconds while
the epoch printing code expects microseconds. Adding a duration cast
fixes this.

Java stores the epoch timestamps in a double as microseconds, so it
doesn't exhibit this bug. The comments were updated to make this more
obvious.

Fixes #2392.