### PR TITLE
Add high speed data logging

### DIFF
--- a/wpiutil/CMakeLists.txt
+++ b/wpiutil/CMakeLists.txt
@@ -5,7 +5,7 @@ include(GenResources)
 include(CompileWarnings)
 include(AddTest)
 
-file(GLOB wpiutil_jni_src src/main/native/cpp/jni/WPIUtilJNI.cpp)
+file(GLOB wpiutil_jni_src src/main/native/cpp/jni/WPIUtilJNI.cpp src/main/native/cpp/jni/DataLogJNI.cpp)
 
 # Java bindings
 if (WITH_JAVA)

--- a/wpiutil/examples/printlog/printlog.cpp
+++ b/wpiutil/examples/printlog/printlog.cpp
@@ -19,8 +19,9 @@ int main() {
       wpi::errs() << "log is not a double log\n";
       return EXIT_FAILURE;
     }
-    for (auto&& p : *log)
+    for (auto&& p : *log) {
       wpi::outs() << "TS=" << p.first << " Value=" << p.second << '\n';
+    }
 
     {
       auto it = log->find(600000);
@@ -53,8 +54,9 @@ int main() {
       wpi::errs() << "could not open log\n";
       return EXIT_FAILURE;
     }
-    for (auto&& p : *log)
+    for (auto&& p : *log) {
       wpi::outs() << "TS=" << p.first << " Value=" << p.second << '\n';
+    }
   }
   {
     auto log = wpi::log::DoubleArrayLog::Open("test-double-array.log",

--- a/wpiutil/examples/printlog/printlog.cpp
+++ b/wpiutil/examples/printlog/printlog.cpp
@@ -1,0 +1,93 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "wpi/DataLog.h"
+
+int main() {
+  {
+    auto log1 = wpi::log::DataLog::Open("test.log");
+    if (!log1) {
+      wpi::errs() << "could not open log\n";
+      return EXIT_FAILURE;
+    }
+    auto log = wpi::log::DoubleLog::Wrap(*log1);
+    if (!log) {
+      wpi::errs() << "log is not a double log\n";
+      return EXIT_FAILURE;
+    }
+    for (auto&& p : *log)
+      wpi::outs() << "TS=" << p.first << " Value=" << p.second << '\n';
+
+    {
+      auto it = log->find(600000);
+      wpi::outs() << "found 600000: TS=" << it->first << " Value=" << it->second
+                  << '\n';
+    }
+
+    {
+      auto it = log->find(600001);
+      wpi::outs() << "found 600001: TS=" << it->first << " Value=" << it->second
+                  << '\n';
+    }
+
+    {
+      auto it = log->find(599999);
+      wpi::outs() << "found 599999: TS=" << it->first << " Value=" << it->second
+                  << '\n';
+    }
+
+    {
+      auto it = log->find(120001, log->begin() + 2, log->begin() + 20);
+      wpi::outs() << "found 120001: TS=" << it->first << " Value=" << it->second
+                  << '\n';
+    }
+  }
+  {
+    auto log =
+        wpi::log::StringLog::Open("test-string.log", wpi::log::CD_OpenExisting);
+    if (!log) {
+      wpi::errs() << "could not open log\n";
+      return EXIT_FAILURE;
+    }
+    for (auto&& p : *log)
+      wpi::outs() << "TS=" << p.first << " Value=" << p.second << '\n';
+  }
+  {
+    auto log = wpi::log::DoubleArrayLog::Open("test-double-array.log",
+                                              wpi::log::CD_OpenExisting);
+    if (!log) {
+      wpi::errs() << "could not open log\n";
+      return EXIT_FAILURE;
+    }
+    for (auto&& p : *log) {
+      wpi::outs() << "TS=" << p.first << " Value Len=" << p.second.size()
+                  << '\n';
+      for (auto&& v : p.second) {
+        wpi::outs() << "  " << v << '\n';
+      }
+    }
+  }
+  {
+    auto log = wpi::log::StringArrayLog::Open("test-string-array.log",
+                                              wpi::log::CD_OpenExisting);
+    if (!log) {
+      wpi::errs() << "could not open log\n";
+      return EXIT_FAILURE;
+    }
+    for (auto&& p : *log) {
+      wpi::outs() << "TS=" << p.first << " Value Len=" << p.second.size()
+                  << '\n';
+      for (auto&& v : p.second) {
+        wpi::outs() << " " << v << '\n';
+      }
+    }
+    wpi::SmallVector<wpi::StringRef, 4> buf;
+    for (auto&& v : log->Get(0, buf).second) {
+      wpi::outs() << " " << v << '\n';
+    }
+  }
+}

--- a/wpiutil/examples/writelog/writelog.cpp
+++ b/wpiutil/examples/writelog/writelog.cpp
@@ -21,8 +21,9 @@ int main(int argc, char** argv) {
 
   int kNumRuns = 10;
 
-  if (argc == 2)
+  if (argc == 2) {
     kNumRuns = std::stoi(argv[1]);
+  }
 
   auto testVec = std::vector<std::pair<std::string, void (*)()>>();
 
@@ -30,10 +31,13 @@ int main(int argc, char** argv) {
     auto log =
         wpi::log::DoubleLog::Open("test.log", wpi::log::CD_CreateAlways);
 
-    if (!log)
+    if (!log) {
       throw std::runtime_error("Could not open log");
+    }
 
-    for (int i = 0; i < 50; ++i) log->Append(20000 * i, 1.3 * i);
+    for (int i = 0; i < 50; ++i) {
+      log->Append(20000 * i, 1.3 * i);
+    }
   }});
 
   testVec.push_back({"500k double append (test2.log)", []{
@@ -42,10 +46,13 @@ int main(int argc, char** argv) {
     auto log =
         wpi::log::DoubleLog::Open("test2.log", wpi::log::CD_CreateAlways);
 
-    if (!log)
+    if (!log) {
       throw std::runtime_error("Could not open log");
+    }
 
-    for (uint64_t i = 0; i < 500000; ++i) log->Append(20000 * i, 1.3 * i);
+    for (uint64_t i = 0; i < 500000; ++i) {
+      log->Append(20000 * i, 1.3 * i);
+    }
   }});
 
   /*
@@ -63,17 +70,21 @@ int main(int argc, char** argv) {
   testVec.push_back({"50 string append (test-string.log)", []{
     auto log = wpi::log::StringLog::Open("test-string.log",
                                          wpi::log::CD_CreateAlways);
-    if (!log)
+    if (!log) {
       throw std::runtime_error("Could not open log");
+    }
 
-    for (int i = 0; i < 50; ++i) log->Append(20000 * i, "hello");
+    for (int i = 0; i < 50; ++i) {
+      log->Append(20000 * i, "hello");
+    }
   }});
 
   testVec.push_back({"Double array append (test-double-array.log)", []{
     auto log = wpi::log::DoubleArrayLog::Open("test-double-array.log",
                                               wpi::log::CD_CreateAlways);
-    if (!log)
+    if (!log) {
       throw std::runtime_error("Could not open log");
+    }
 
     log->Append(20000, {1, 2, 3});
     log->Append(30000, {4, 5});
@@ -82,8 +93,9 @@ int main(int argc, char** argv) {
   testVec.push_back({"String array append (test-string-array.log)", []{
     auto log = wpi::log::StringArrayLog::Open("test-string-array.log",
                                               wpi::log::CD_CreateAlways);
-    if (!log)
+    if (!log) {
       throw std::runtime_error("Could not open log");
+    }
 
     log->Append(20000, {"Hello", "World"});
     log->Append(30000, {"This", "Is", "Fun"});

--- a/wpiutil/examples/writelog/writelog.cpp
+++ b/wpiutil/examples/writelog/writelog.cpp
@@ -1,0 +1,107 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <chrono>
+#include <iostream>
+#include <vector>
+#include <array>
+#include <string>
+#include <numeric>
+
+#include "wpi/DataLog.h"
+
+int main(int argc, char** argv) {
+  using std::chrono::duration_cast;
+  using std::chrono::high_resolution_clock;
+  using std::chrono::microseconds;
+
+  int kNumRuns = 10;
+
+  if (argc == 2)
+    kNumRuns = std::stoi(argv[1]);
+
+  auto testVec = std::vector<std::pair<std::string, void (*)()>>();
+
+  testVec.push_back({"50 double append (test.log)", []{
+    auto log =
+        wpi::log::DoubleLog::Open("test.log", wpi::log::CD_CreateAlways);
+
+    if (!log)
+      throw std::runtime_error("Could not open log");
+
+    for (int i = 0; i < 50; ++i) log->Append(20000 * i, 1.3 * i);
+  }});
+
+  testVec.push_back({"500k double append (test2.log)", []{
+    wpi::log::DoubleLog::Config config;
+    config.periodicFlush = 1000;
+    auto log =
+        wpi::log::DoubleLog::Open("test2.log", wpi::log::CD_CreateAlways);
+
+    if (!log)
+      throw std::runtime_error("Could not open log");
+
+    for (uint64_t i = 0; i < 500000; ++i) log->Append(20000 * i, 1.3 * i);
+  }});
+
+  /*
+  testVec.push_back("Int array append (test2.log)", []{
+    auto data = std::vector<uint8_t>(5000);
+    auto log = wpi::log::DataLog::Open("test2.log", "image", "image", 0,
+                                       wpi::log::CD_OpenAlways);
+    if (!log)
+      throw std::runtime_error("Could not open log");
+    
+    for (int i = 0; i < 1000; ++i) log->Append(20000 * i, data);
+  }
+  */
+
+  testVec.push_back({"50 string append (test-string.log)", []{
+    auto log = wpi::log::StringLog::Open("test-string.log",
+                                         wpi::log::CD_CreateAlways);
+    if (!log)
+      throw std::runtime_error("Could not open log");
+
+    for (int i = 0; i < 50; ++i) log->Append(20000 * i, "hello");
+  }});
+
+  testVec.push_back({"Double array append (test-double-array.log)", []{
+    auto log = wpi::log::DoubleArrayLog::Open("test-double-array.log",
+                                              wpi::log::CD_CreateAlways);
+    if (!log)
+      throw std::runtime_error("Could not open log");
+
+    log->Append(20000, {1, 2, 3});
+    log->Append(30000, {4, 5});
+  }});
+
+  testVec.push_back({"String array append (test-string-array.log)", []{
+    auto log = wpi::log::StringArrayLog::Open("test-string-array.log",
+                                              wpi::log::CD_CreateAlways);
+    if (!log)
+      throw std::runtime_error("Could not open log");
+
+    log->Append(20000, {"Hello", "World"});
+    log->Append(30000, {"This", "Is", "Fun"});
+  }});
+
+  for (const auto& [name, fn] : testVec) {
+    auto resVec = std::vector<microseconds::rep>();
+    std::cout << name << ": ";
+
+    for (int i = 0; i < kNumRuns; ++i) {
+      auto start = high_resolution_clock::now();
+      fn();
+      auto stop = high_resolution_clock::now();
+      resVec.push_back(duration_cast<microseconds>(stop - start).count());
+    }
+
+    std::cout << std::accumulate(resVec.begin(), resVec.end(), 0)/kNumRuns << "us\n";
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/WPIUtilJNI.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/WPIUtilJNI.java
@@ -7,7 +7,7 @@ package edu.wpi.first.wpiutil;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public final class WPIUtilJNI {
+public class WPIUtilJNI {
   static boolean libraryLoaded = false;
   static RuntimeLoader<WPIUtilJNI> loader = null;
 

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/BooleanArrayLog.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/BooleanArrayLog.java
@@ -1,0 +1,34 @@
+package edu.wpi.first.wpiutil.datalog;
+
+public class BooleanArrayLog extends DataLog {
+  //explicitly package-private, object should be created via factory method
+  BooleanArrayLog(long impl) {
+    super(impl);
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param value Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendBooleanArray(boolean[] value) {
+    return DataLogJNI.appendBooleanArray(m_impl, value);
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param timestamp Time stamp
+   * @param value     Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendBooleanArrayTime(long timestamp, boolean[] value) {
+    return DataLogJNI.appendBooleanArrayTime(m_impl, timestamp, value);
+  }
+
+}

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/BooleanLog.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/BooleanLog.java
@@ -1,0 +1,33 @@
+package edu.wpi.first.wpiutil.datalog;
+
+public class BooleanLog extends DataLog {
+  //explicitly package-private, object should be created via factory method
+  BooleanLog(long impl) {
+    super(impl);
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param value Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendBoolean(boolean value) {
+    return DataLogJNI.appendBoolean(m_impl, value);
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param timestamp Time stamp
+   * @param value     Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendBooleanTime(long timestamp, boolean value) {
+    return DataLogJNI.appendBooleanTime(m_impl, timestamp, value);
+  }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/DataLog.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/DataLog.java
@@ -1,0 +1,424 @@
+package edu.wpi.first.wpiutil.datalog;
+
+/**
+ * <b>DATA STORAGE FORMAT</b>
+ *
+ * <p><b>**Timestamp File**</b>
+ *
+ * <p>Timestamp file (named whatever the user provides as filename) consists of:
+ *
+ * <p>- 4KiB header
+ *
+ * <p>- 0 or more fixed-size records
+ *
+ * <p>The timestamp file header contains 0-padded JSON data containing at least
+ * the following fields:
+ *
+ * <pre><code>{{@literal
+ *  "dataLayout": <string>,
+ *  "dataType": <string>,
+ *  "dataWritePos": <integer>,
+ *  "fixedSize": <boolean>,
+ *  "gapData": <string>,
+ *  "recordSize": <integer>,
+ *  "timeWritePos": <integer>
+ * }}</code></pre>
+ *
+ * <p>{@code dataLayout} : user-defined string that describes the detailed layout
+ * of the data.
+ *
+ * <p>{@code dataType} : user-defined string, typically used to make sure there's not
+ * a data type conflict when reading the file, or knowing what type of data
+ * is stored when opening an arbitrary file.  Suggestions: make this java-style
+ * (com.foo.bar) or MIME type.
+ *
+ * <p>{@code dataWritePos} : next byte write position in the data file
+ *
+ * <p>{@code fixedSize} : true if each record is fixed size (in which case there will not
+ * be a data file), false if the records are variable size
+ *
+ * <p>{@code gapData} : user-defined string that contains the data that should be written
+ * between each record's data in the data file.  Unused if fixedSize is true.
+ *
+ * <p>{@code recordSize} : the size of each record (including timestamp) in the timestamp
+ * file, in bytes
+ *
+ * <p>{@code timeWritePos} : next byte write position in the timestamp file
+ *
+ * <p><b> **Timestamp File Records** </b>
+ *
+ * <p>Each record in the timestamp file starts with a 64-bit timestamp.  The
+ * epoch and resolution of the timestamp is unspecified, but most files
+ * use microsecond resolution. The timestamps must be monotonically
+ * increasing for the find function to work.
+ *
+ * <p>If {@code fixedSize=true}, the rest of the record contains the user data.
+ *
+ * <p>If {@code fixedSize=false}, the rest of the record contains the offset and size
+ * (in that order) of the data contents in the data file.  The offset
+ * and size can either be 32-bit or 64-bit (as determined by recordSize, so
+ * {@code recordSize=16} if 32-bit offset+size, {@code recordSize=24} if 64-bit offset+size).
+ *
+ * <p><b> **Data File** </b>
+ *
+ * <p>Used only for variable-sized data ({@code fixedSize=false}).  File is named with
+ * {@code .data} suffix to whatever the user provided as a filename.
+ *
+ * <p>Contains continuous data contents, potentially with gaps between each
+ * record (as configured by gapData).
+ */
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.ExcessivePublicCount"})
+public class DataLog {
+  protected final long m_impl;
+
+  //explicitly package-private so inheritors can call it
+  DataLog(long impl) {
+    m_impl = impl;
+  }
+
+  /**
+   * Opens a log file.  Returns log object.
+   *
+   * @param filename Filename to open
+   * @param disp     Creation disposition (e.g. open or create)
+   * @param config   Implementation configuration
+   * @return Log object
+   */
+  public static DataLog open(String filename, String dataType, String dataLayout, int recordSize,
+                             CreationDisposition disp, DataLogConfig config) {
+    return new DataLog(DataLogJNI.open(filename, dataType, dataLayout,
+            recordSize, disp.m_id, config));
+  }
+
+  /**
+   * Opens a log file.  Returns log object.
+   *
+   * @param filename Filename to open
+   * @param config   Implementation configuration
+   * @return Log object
+   */
+  public static DataLog openRaw(String filename, DataLogConfig config) {
+    return new DataLog(DataLogJNI.openRaw(filename, config));
+  }
+
+  /**
+   * Opens a log file.  Returns log object.
+   *
+   * @param filename Filename to open
+   * @param disp     Creation disposition (e.g. open or create)
+   * @param config   Implementation configuration
+   * @return Log object
+   */
+  public static DataLog openBoolean(String filename, CreationDisposition disp,
+                                    DataLogConfig config) {
+    return new BooleanLog(DataLogJNI.openBoolean(filename, disp.m_id, config));
+  }
+
+  /**
+   * Opens a log file.  Returns log object.
+   *
+   * @param filename Filename to open
+   * @param disp     Creation disposition (e.g. open or create)
+   * @param config   Implementation configuration
+   * @return Log object
+   */
+  public static DataLog openDouble(String filename, CreationDisposition disp,
+                                   DataLogConfig config) {
+    return new DoubleLog(DataLogJNI.openDouble(filename, disp.m_id, config));
+  }
+
+  /**
+   * Opens a log file.  Returns log object.
+   *
+   * @param filename Filename to open
+   * @param disp     Creation disposition (e.g. open or create)
+   * @param config   Implementation configuration
+   * @return Log object
+   */
+  public static DataLog openString(String filename, CreationDisposition disp,
+                                   DataLogConfig config) {
+    return new StringLog(DataLogJNI.openString(filename, disp.m_id, config));
+  }
+
+  /**
+   * Opens a log file.  Returns log object, or error if file does not exist.
+   *
+   * @param filename Filename to open
+   * @param disp     Creation disposition (e.g. open or create)
+   * @param config   Implementation configuration
+   * @return Log object (or error)
+   */
+  public static DataLog openBooleanArray(String filename, CreationDisposition disp,
+                                         DataLogConfig config) {
+    return new BooleanArrayLog(DataLogJNI.openBooleanArray(filename, disp.m_id, config));
+  }
+
+  /**
+   * Opens a log file.  Returns log object.
+   *
+   * @param filename Filename to open
+   * @param disp     Creation disposition (e.g. open or create)
+   * @param config   Implementation configuration
+   * @return Log object
+   */
+  public static DataLog openDoubleArray(String filename, CreationDisposition disp,
+                                        DataLogConfig config) {
+    return new DoubleArrayLog(DataLogJNI.openDoubleArray(filename, disp.m_id, config));
+  }
+
+  /**
+   * Opens a log file.  Returns log object.
+   *
+   * @param filename Filename to open
+   * @param disp     Creation disposition (e.g. open or create)
+   * @param config   Implementation configuration
+   * @return Log object
+   */
+  public static DataLog openStringArray(String filename, CreationDisposition disp,
+                                        DataLogConfig config) {
+    return new StringArrayLog(DataLogJNI.openStringArray(filename, disp.m_id, config));
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param data Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendRaw(byte[] data) {
+    return DataLogJNI.appendRaw(m_impl, data);
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param timestamp Time stamp
+   * @param data      Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendRawTime(long timestamp, byte[] data) {
+    return DataLogJNI.appendRawTime(m_impl, timestamp, data);
+  }
+
+  /**
+   * Flushes the log data to disk.
+   */
+  public void flush() {
+    DataLogJNI.flush(m_impl);
+  }
+
+  public String getDataType() {
+    return DataLogJNI.getDataType(m_impl);
+  }
+
+  public String getDataLayout() {
+    return DataLogJNI.getDataLayout(m_impl);
+  }
+
+  public int getRecordSize() {
+    return DataLogJNI.getRecordSize(m_impl);
+  }
+
+  public boolean isFixedSize() {
+    return DataLogJNI.isFixedSize(m_impl);
+  }
+
+  public int getSize() {
+    return DataLogJNI.getSize(m_impl);
+  }
+
+  /**
+   * Finds the first record with timestamp greater than or equal to the
+   * provided time.
+   *
+   * @param timestamp Time stamp
+   * @param first     index of first record
+   * @return Index of record
+   */
+  public int find(long timestamp, int first) {
+    return DataLogJNI.find(m_impl, timestamp, first);
+  }
+
+  /**
+   * Finds the first record with timestamp greater than or equal to the
+   * provided time.
+   *
+   * @param timestamp Time stamp
+   * @param first     index of first record
+   * @param last      index of last record
+   * @return Index of record
+   */
+  public int find(long timestamp, int first, int last) {
+    return DataLogJNI.find(m_impl, timestamp, first, last);
+  }
+
+  /**
+   * Checks the currently opened log file header.
+   *
+   * @param dataType    Data type
+   * @param recordSize  Record size; 0 indicates variable data size
+   * @param checkType   Check data type matches
+   * @param checkLayout Check data layout matches
+   * @param checkSize   Check size matches
+   * @return True if successful
+   */
+  public boolean check(String dataType, int recordSize, boolean checkType, boolean checkLayout,
+                       boolean checkSize) {
+    return DataLogJNI.check(m_impl, dataType, recordSize, checkType, checkLayout, checkSize);
+
+  }
+
+  public void close() {
+    DataLogJNI.close(m_impl);
+  }
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @param index Log index
+   * @return Pair of timestamp and reference to raw stored data
+   */
+  public DataLogEntry readRaw(int index) {
+    return new DataLogEntry(0L, DataLogJNI.readRaw(m_impl, index));
+  }
+
+
+  public static final class DataLogEntry {
+    private long m_timestamp;
+    private byte[] m_data;
+
+    private DataLogEntry(long timestamp, byte[] data) {
+      m_timestamp = timestamp;
+      setData(data);
+    }
+
+    public long getTimestamp() {
+      return m_timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+      m_timestamp = timestamp;
+    }
+
+    public byte[] getData() {
+      return m_data.clone();
+    }
+
+    public void setData(byte[] data) {
+      m_data = data.clone();
+    }
+
+  }
+
+  /**
+   * Creation disposition.
+   */
+  public enum CreationDisposition {
+    /// CD_CreateAlways - When opening a file:
+    ///   * If it already exists, truncate it.
+    ///   * If it does not already exist, create a new file.
+    CreateAlways(0),
+
+    /// CD_CreateNew - When opening a file:
+    ///   * If it already exists, fail.
+    ///   * If it does not already exist, create a new file.
+    CreateNew(1),
+
+    /// CD_OpenExisting - When opening a file:
+    ///   * If it already exists, open the file.
+    ///   * If it does not already exist, fail.
+    OpenExisting(2),
+
+    /// CD_OpenAlways - When opening a file:
+    ///   * If it already exists, open the file.
+    ///   * If it does not already exist, create a new file.
+    OpenAlways(3);
+
+    final int m_id;
+
+    CreationDisposition(int id) {
+      m_id = id;
+    }
+  }
+
+  public static final class DataLogConfig {
+    /**
+     * Start out timestamp file with space for this many records.  Note the
+     * actual file size will start out this big, but it's a sparse file.
+     */
+    public int m_initialSize = 1000;
+
+    /**
+     * Once size has reached this size, grow by this number of records each
+     * time.  Prior to it reaching this size, the space is doubled.
+     */
+    public int m_maxGrowSize = 60000;
+
+    /**
+     * Maximum map window size.  Larger is more efficient, but may have
+     * issues on 32-bit systems.  Defaults to unlimited.
+     */
+    public int m_maxMapSize;
+
+    /**
+     * Periodic flush setting.  Flushes log to disk every N appends.
+     * Defaults to no periodic flush.
+     */
+    public int m_periodicFlush;
+
+    /**
+     * Start out data file with space for this many bytes.  Note the
+     * actual file size will start out this big, but it's a sparse file.
+     */
+    public long m_initialDataSize = 100000;
+
+    /**
+     * Once data file has reached this size, grow by this number of bytes each
+     * time.  Prior to it reaching this size, the space is doubled.
+     */
+    public long m_maxDataGrowSize = 1024 * 1024;
+
+    /**
+     * Use large (e.g. 64-bit) variable-sized data files when creating a new
+     * log.  The default is to use 32-bit sizes for the variable-sized data.
+     */
+    public boolean m_largeData;
+
+    /**
+     * Fill data to put in between each record of variable-sized data in data
+     * file.  Useful for e.g. making strings null terminated.  Defaults to
+     * nothing.
+     */
+    public String m_gapData;
+
+    /**
+     * Check data type when opening existing file.  Defaults to checking.
+     */
+    public boolean m_checkType = true;
+
+    /**
+     * Check record size when opening existing file.  Defaults to checking.
+     */
+    public boolean m_checkSize = true;
+
+    /**
+     * Check data layout when opening existing file.  Defaults to checking.
+     */
+    public boolean m_checkLayout = true;
+
+    /**
+     * Check timestamp is monotonically increasing and don't save the value if
+     * timestamp decreased.  Defaults to true.
+     */
+    public boolean m_checkMonotonic = true;
+
+    /**
+     * Open file in read-only mode.
+     */
+    public boolean m_readOnly;
+  }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/DataLogJNI.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/DataLogJNI.java
@@ -1,0 +1,59 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpiutil.datalog;
+
+import edu.wpi.first.wpiutil.WPIUtilJNI;
+import edu.wpi.first.wpiutil.datalog.DataLog.DataLogConfig;
+
+public class DataLogJNI extends WPIUtilJNI {
+  public static native String getDataType(long impl);
+  public static native String getDataLayout(long impl);
+  public static native int getRecordSize(long impl);
+  public static native boolean isFixedSize(long impl);
+  public static native void flush(long impl);
+
+  public static native int getSize(long impl);
+
+  public static native int find(long impl, long timestamp, int first);
+  public static native int find(long impl, long timestamp, int first, int last);
+
+  public static native boolean check(long impl, String dataType, int recordSize, boolean checkType, boolean checkLayout, boolean checkSize);
+
+  public static native void close(long impl);
+
+  public static native long open(String filename, String dataType, String dataLayout, int recordSize, int disp, DataLogConfig config);
+
+  public static native long openRaw(String filename, DataLogConfig config);
+  public static native boolean appendRaw(long impl, byte[] data);
+  public static native boolean appendRawTime(long impl, long timestamp, byte[] data);
+  public static native byte[] readRaw(long impl, int n);
+
+  public static native long openBoolean(String filename, int disp, DataLogConfig config);
+  public static native boolean appendBoolean(long impl, boolean value);
+  public static native boolean appendBooleanTime(long impl, long timestamp, boolean value);
+
+  public static native long openDouble(String filename, int disp, DataLogConfig config);
+  public static native boolean appendDouble(long impl, double value);
+  public static native boolean appendDoubleTime(long impl, long timestamp, double value);
+
+  public static native long openString(String filename, int disp, DataLogConfig config);
+  public static native boolean appendString(long impl, String value);
+  public static native boolean appendStringTime(long impl, long timestamp, String value);
+
+  public static native long openBooleanArray(String filename, int disp, DataLogConfig config);
+  public static native boolean appendBooleanArray(long impl, boolean[] value);
+  public static native boolean appendBooleanArrayTime(long impl, long timestamp, boolean[] value);
+
+  public static native long openDoubleArray(String filename, int disp, DataLogConfig config);
+  public static native boolean appendDoubleArray(long impl, double[] value);
+  public static native boolean appendDoubleArrayTime(long impl, long timestamp, double[] value);
+
+  public static native long openStringArray(String filename, int disp, DataLogConfig config);
+  public static native boolean appendStringArray(long impl, String[] value);
+  public static native boolean appendStringArrayTime(long impl, long timestamp, String[] value);
+}

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/DoubleArrayLog.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/DoubleArrayLog.java
@@ -1,0 +1,34 @@
+package edu.wpi.first.wpiutil.datalog;
+
+
+public class DoubleArrayLog extends DataLog {
+  //explicitly package-private, object should be created via factory method
+  DoubleArrayLog(long impl) {
+    super(impl);
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param value Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendDoubleArray(double[] value) {
+    return DataLogJNI.appendDoubleArray(m_impl, value);
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param timestamp Time stamp
+   * @param value     Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendDoubleArrayTime(long timestamp, double[] value) {
+    return DataLogJNI.appendDoubleArrayTime(m_impl, timestamp, value);
+  }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/DoubleLog.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/DoubleLog.java
@@ -1,0 +1,34 @@
+package edu.wpi.first.wpiutil.datalog;
+
+public class DoubleLog extends DataLog {
+  //explicitly package-private, object should be created via factory method
+  DoubleLog(long impl) {
+    super(impl);
+  }
+
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param value Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendDouble(double value) {
+    return DataLogJNI.appendDouble(m_impl, value);
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param timestamp Time stamp
+   * @param value     Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendDoubleTime(long timestamp, double value) {
+    return DataLogJNI.appendDoubleTime(m_impl, timestamp, value);
+  }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/StringArrayLog.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/StringArrayLog.java
@@ -1,0 +1,33 @@
+package edu.wpi.first.wpiutil.datalog;
+
+public class StringArrayLog extends DataLog {
+  //explicitly package-private, object should be created via factory method
+  StringArrayLog(long impl) {
+    super(impl);
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param value Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendStringArray(String[] value) {
+    return DataLogJNI.appendStringArray(m_impl, value);
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param timestamp Time stamp
+   * @param value     Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendStringArrayTime(long timestamp, String[] value) {
+    return DataLogJNI.appendStringArrayTime(m_impl, timestamp, value);
+  }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/StringLog.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/datalog/StringLog.java
@@ -1,0 +1,34 @@
+package edu.wpi.first.wpiutil.datalog;
+
+public class StringLog extends DataLog {
+  //explicitly package-private, object should be created via factory method
+  StringLog(long impl) {
+    super(impl);
+  }
+
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param value Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendString(String value) {
+    return DataLogJNI.appendString(m_impl, value);
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param timestamp Time stamp
+   * @param value     Data to record
+   * @return True if successful, false on failure
+   */
+  public boolean appendStringTime(long timestamp, String value) {
+    return DataLogJNI.appendStringTime(m_impl, timestamp, value);
+  }
+}

--- a/wpiutil/src/main/native/cpp/DataLog.cpp
+++ b/wpiutil/src/main/native/cpp/DataLog.cpp
@@ -1,0 +1,739 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "wpi/DataLog.h"
+
+#include <sys/types.h>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>  // NOLINT(build/include_order)
+
+#include <memoryapi.h>
+
+#else  // _WIN32
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#endif  // _WIN32
+
+#ifdef _MSC_VER
+#include <io.h>
+#endif
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <system_error>
+
+#include <wpi/Endian.h>
+#include <wpi/FileSystem.h>
+#include <wpi/MathExtras.h>
+#ifdef _WIN32
+#include <wpi/WindowsError.h>
+#endif
+#include <wpi/json.h>
+#include <wpi/raw_istream.h>
+
+/*
+ * DATA STORAGE FORMAT
+ *
+ * **Timestamp File**
+ *
+ * Timestamp file (named whatever the user provides as filename) consists of:
+ * - 4KiB header
+ * - 0 or more fixed-size records
+ *
+ * The timestamp file header contains 0-padded JSON data containing at least
+ * the following fields:
+ *
+ * {
+ *  "dataLayout": <string>,
+ *  "dataType": <string>,
+ *  "dataWritePos": <integer>,
+ *  "fixedSize": <boolean>,
+ *  "gapData": <string>,
+ *  "recordSize": <integer>,
+ *  "timeWritePos": <integer>
+ * }
+ *
+ * dataLayout: user-defined string that describes the detailed layout
+ * of the data.
+ *
+ * dataType: user-defined string, typically used to make sure there's not
+ * a data type conflict when reading the file, or knowing what type of data
+ * is stored when opening an arbitrary file.  Suggestions: make this java-style
+ * (com.foo.bar) or MIME type.
+ *
+ * dataWritePos: next byte write position in the data file
+ *
+ * fixedSize: true if each record is fixed size (in which case there will not
+ * be a data file), false if the records are variable size
+ *
+ * gapData: user-defined string that contains the data that should be written
+ * between each record's data in the data file.  Unused if fixedSize is true.
+ *
+ * recordSize: the size of each record (including timestamp) in the timestamp
+ * file, in bytes
+ *
+ * timeWritePos: next byte write position in the timestamp file
+ *
+ * **Timestamp File Records**
+ *
+ * Each record in the timestamp file starts with a 64-bit timestamp.  The
+ * epoch and resolution of the timestamp is unspecified, but most files
+ * use microsecond resolution.  The timestamps must be monotonically
+ * increasing for the find function to work.
+ *
+ * If fixedSize=true, the rest of the record contains the user data.
+ *
+ * If fixedSize=false, the rest of the record contains the offset and size
+ * (in that order) of the data contents in the data file.  The offset
+ * and size can either be 32-bit or 64-bit (as determined by recordSize, so
+ * recordSize=16 if 32-bit offset+size, recordSize=24 if 64-bit offset+size).
+ *
+ * **Data File**
+ *
+ * Used only for variable-sized data (fixedSize=false).  File is named with
+ * ".data" suffix to whatever the user provided as a filename.
+ *
+ * Contains continuous data contents, potentially with gaps between each
+ * record (as configured by gapData).
+ */
+
+using namespace wpi::log;
+
+static constexpr size_t kLargePointerRecordSize =
+    DataLogImpl::kTimestampSize + 8 * 2;
+static constexpr size_t kSmallPointerRecordSize =
+    DataLogImpl::kTimestampSize + 4 * 2;
+
+static uint64_t GetFileSize(int fd) {
+#ifdef _WIN32
+  uint64_t size = ::_lseeki64(fd, 0, SEEK_END);
+  ::_lseeki64(fd, 0, SEEK_SET);
+#else
+  uint64_t size = ::lseek(fd, 0, SEEK_END);
+  ::lseek(fd, 0, SEEK_SET);
+#endif
+  return size;
+}
+
+MappedFile::MappedFile(int fd, size_t length, uint64_t offset, bool readOnly,
+                       std::error_code& ec)
+    : m_size(length) {
+#ifdef _WIN32
+  HANDLE origFileHandle = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
+  if (origFileHandle == INVALID_HANDLE_VALUE) {
+    ec = std::make_error_code(std::errc::bad_file_descriptor);
+    return;
+  }
+
+  HANDLE fileMappingHandle = ::CreateFileMappingW(
+      origFileHandle, 0, readOnly ? PAGE_READONLY : PAGE_READWRITE,
+      Hi_32(length), Lo_32(length), 0);
+  if (fileMappingHandle == nullptr) {
+    ec = wpi::mapWindowsError(GetLastError());
+    return;
+  }
+
+  m_mapping = ::MapViewOfFile(fileMappingHandle, FILE_MAP_WRITE, offset >> 32,
+                              offset & 0xffffffff, length);
+  if (m_mapping == nullptr) {
+    ec = wpi::mapWindowsError(GetLastError());
+    ::CloseHandle(fileMappingHandle);
+    return;
+  }
+
+  // Close the file mapping handle, as it's kept alive by the file mapping. But
+  // neither the file mapping nor the file mapping handle keep the file handle
+  // alive, so we need to keep a reference to the file in case all other handles
+  // are closed and the file is deleted, which may cause invalid data to be read
+  // from the file.
+  ::CloseHandle(fileMappingHandle);
+  if (!::DuplicateHandle(::GetCurrentProcess(), origFileHandle,
+                         ::GetCurrentProcess(), &m_fileHandle, 0, 0,
+                         DUPLICATE_SAME_ACCESS)) {
+    ec = wpi::mapWindowsError(GetLastError());
+    ::UnmapViewOfFile(m_mapping);
+    m_mapping = nullptr;
+    return;
+  }
+#else
+  m_mapping =
+      ::mmap(nullptr, length, readOnly ? PROT_READ : (PROT_READ | PROT_WRITE),
+             MAP_SHARED, fd, offset);
+  if (m_mapping == MAP_FAILED) {
+    ec = std::error_code(errno, std::generic_category());
+    m_mapping = nullptr;
+  }
+#endif
+}
+
+void MappedFile::Flush() {
+#ifdef _WIN32
+  ::FlushViewOfFile(m_mapping, 0);
+  ::FlushFileBuffers(m_fileHandle);
+#else
+  ::msync(m_mapping, m_size, MS_ASYNC);
+#endif
+}
+
+void MappedFile::Unmap() {
+  if (!m_mapping) return;
+#ifdef _WIN32
+  ::UnmapViewOfFile(m_mapping);
+  ::CloseHandle(m_fileHandle);
+#else
+  ::munmap(m_mapping, m_size);
+#endif
+  m_mapping = nullptr;
+}
+
+std::pair<uint64_t, wpi::ArrayRef<uint8_t>> DataLogImpl::ReadRaw(
+    size_t n) const {
+  auto raw = m_time.Read(kHeaderSize + n * m_recordSize, m_recordSize);
+  if (raw.size() < m_recordSize || raw.size() < kTimestampSize) return {0, {}};
+  uint64_t ts = wpi::support::endian::read64le(raw.data());
+  if (m_fixedSize) {
+    return {ts, raw.slice(kTimestampSize)};
+  } else if (m_recordSize == kLargePointerRecordSize) {
+    // use data offset and size to read data file
+    return {ts, m_data.Read(
+                    wpi::support::endian::read64le(raw.data() + kTimestampSize),
+                    wpi::support::endian::read64le(raw.data() + kTimestampSize +
+                                                   8))};
+  } else {
+    // use data offset and size to read data file
+    return {ts, m_data.Read(
+                    wpi::support::endian::read32le(raw.data() + kTimestampSize),
+                    wpi::support::endian::read32le(raw.data() + kTimestampSize +
+                                                   4))};
+  }
+}
+
+void DataLogImpl::Flush() {
+  WriteHeader();
+  if (m_time.map && !m_time.readOnly) m_time.map.Flush();
+  if (m_data.map && !m_data.readOnly) m_data.map.Flush();
+}
+
+DataLogImpl::DataLogImpl() {}
+
+DataLogImpl::~DataLogImpl() { WriteHeader(); }
+
+bool DataLogImpl::AppendRaw(uint64_t timestamp, wpi::ArrayRef<uint8_t> data) {
+  size_t size = data.size();
+  uint8_t* out = AppendRawStart(timestamp, size);
+  if (!out) return false;
+  std::memcpy(out, data.data(), size);
+  AppendRawFinish(size);
+  return true;
+}
+
+uint8_t* DataLogImpl::AppendRawStart(uint64_t timestamp, uint64_t size) {
+  // check monotonic (if checking enabled)
+  if (m_checkMonotonic && timestamp <= m_lastTimestamp) return nullptr;
+
+  // check read-only
+  if (m_time.readOnly) return nullptr;
+
+  std::error_code ec;
+  size_t off = m_time.GetMappedOffset(m_time.writePos, m_recordSize, ec);
+  if (ec) return nullptr;
+
+  // write timestamp
+  uint8_t* timeBuf = m_time.map.data() + off;
+  wpi::support::endian::write64le(timeBuf, timestamp);
+
+  if (m_fixedSize) {
+    m_lastTimestamp = timestamp;
+    return timeBuf + kTimestampSize;
+  }
+
+  // write data to data file
+  if (m_recordSize == kLargePointerRecordSize) {
+    wpi::support::endian::write64le(timeBuf + kTimestampSize, m_data.writePos);
+    wpi::support::endian::write64le(timeBuf + kTimestampSize + 8, size);
+  } else {
+    wpi::support::endian::write32le(timeBuf + kTimestampSize, m_data.writePos);
+    wpi::support::endian::write32le(timeBuf + kTimestampSize + 4, size);
+  }
+
+  off = m_data.GetMappedOffset(m_data.writePos, size, ec);
+  if (ec) return nullptr;
+  m_lastTimestamp = timestamp;
+  return m_data.map.data() + off;
+}
+
+void DataLogImpl::AppendRawFinish(uint64_t size) {
+  if (!m_fixedSize) {
+    m_data.writePos += size;
+
+    // write gap data (if any)
+    if (!m_gapData.empty()) {
+      m_data.Write(
+          m_data.writePos,
+          wpi::makeArrayRef(reinterpret_cast<const uint8_t*>(m_gapData.data()),
+                            m_gapData.size()));
+      m_data.writePos += m_gapData.size();
+    }
+  }
+
+  m_time.writePos += m_recordSize;
+
+  // periodic flush (if enabled)
+  if (m_periodicFlush != 0 && ++m_periodicFlushCount >= m_periodicFlush) {
+    Flush();
+    m_periodicFlushCount = 0;
+  }
+}
+
+size_t DataLogImpl::FindImpl(uint64_t timestamp, size_t first,
+                             size_t last) const {
+  size_t it = 0;
+  size_t count = (std::min)(size(), last) - first;
+  while (count > 0) {
+    it = first;
+    size_t step = count / 2;
+    it += step;
+    if (ReadRaw(it).first < timestamp) {
+      first = ++it;
+      count -= step + 1;
+    } else {
+      count = step;
+    }
+  }
+  return first;
+}
+
+wpi::Error DataLogImpl::Check(const wpi::Twine& dataType,
+                              const wpi::Twine& dataLayout,
+                              unsigned int recordSize, bool checkType,
+                              bool checkLayout, bool checkSize) const {
+  wpi::SmallString<128> dataTypeBuf;
+  wpi::SmallString<128> dataLayoutBuf;
+  if ((checkType && m_dataType != dataType.toStringRef(dataTypeBuf)) ||
+      (checkLayout && m_dataLayout != dataLayout.toStringRef(dataLayoutBuf)) ||
+      (checkSize &&
+       ((recordSize != 0 && (!m_fixedSize || m_recordSize != recordSize)) ||
+        (recordSize == 0 &&
+         (m_fixedSize || (m_recordSize != kLargePointerRecordSize &&
+                          m_recordSize != kSmallPointerRecordSize))))))
+    return wpi::errorCodeToError(
+        std::make_error_code(std::errc::wrong_protocol_type));
+  else
+    return wpi::Error::success();
+}
+
+wpi::Error DataLogImpl::DoOpen(const wpi::Twine& filename,
+                               const wpi::Twine& dataType,
+                               const wpi::Twine& dataLayout,
+                               unsigned int recordSize,
+                               CreationDisposition disp, const Config& config) {
+  // open the time file
+  std::error_code ec = m_time.Open(filename, disp, config.readOnly);
+  if (ec) return wpi::errorCodeToError(ec);
+  m_time.fileSize = GetFileSize(m_time.fd);
+
+  if (disp == CD_OpenExisting ||
+      (disp == CD_OpenAlways && m_time.fileSize > 0)) {
+    if (wpi::Error e = ReadHeader()) {
+      return e;
+    }
+
+    // check configuration
+    if (wpi::Error e = Check(dataType, dataLayout, recordSize, config.checkType,
+                             config.checkLayout, config.checkSize)) {
+      return e;
+    }
+  } else {
+    m_dataType = dataType.str();
+    m_dataLayout = dataLayout.str();
+    m_fixedSize = recordSize != 0;
+    m_recordSize = m_fixedSize ? recordSize
+                               : (config.largeData ? kLargePointerRecordSize
+                                                   : kSmallPointerRecordSize);
+    m_gapData = config.gapData;
+    m_time.writePos = kHeaderSize;
+  }
+
+  // set configuration
+  m_periodicFlush = config.periodicFlush;
+  m_checkMonotonic = config.checkMonotonic;
+
+  m_time.maxGrowSize = config.maxGrowSize * m_recordSize;
+  m_time.mapGrowSize = config.initialSize * m_recordSize;
+  m_time.maxMapSize = config.maxMapSize;
+
+  m_data.maxGrowSize = config.maxDataGrowSize;
+  m_data.mapGrowSize = config.initialDataSize;
+  m_data.maxMapSize = config.maxMapSize;
+
+  // set up the time file for writing
+  if (m_time.writePos > (kHeaderSize + m_recordSize)) {
+    // Read last timestamp
+    size_t off = m_time.GetMappedOffset(m_time.writePos - m_recordSize,
+                                        m_recordSize * 2, ec);
+    if (ec) return wpi::errorCodeToError(ec);
+    m_lastTimestamp =
+        wpi::support::endian::read64le(m_time.map.const_data() + off);
+  } else {
+    m_time.GetMappedOffset(m_time.writePos, m_recordSize, ec);
+    if (ec) return wpi::errorCodeToError(ec);
+  }
+
+  if (!m_fixedSize) {
+    // open the data file
+    ec = m_data.Open(filename + ".data", disp, config.readOnly);
+    if (ec) return wpi::errorCodeToError(ec);
+    m_data.fileSize = GetFileSize(m_data.fd);
+    m_data.GetMappedOffset(m_data.writePos, 1024, ec);
+    if (ec) return wpi::errorCodeToError(ec);
+  }
+
+  return wpi::Error::success();
+}
+
+wpi::Error DataLogImpl::ReadHeader() {
+  // don't use memory map for this; it doesn't exist yet
+  wpi::raw_fd_istream is(m_time.fd, false);
+  wpi::json j;
+  try {
+    j = wpi::json::parse(is);
+  } catch (const wpi::json::parse_error&) {
+    return wpi::errorCodeToError(
+        std::make_error_code(std::errc::wrong_protocol_type));
+  }
+  if (!j.is_object())
+    return wpi::errorCodeToError(
+        std::make_error_code(std::errc::wrong_protocol_type));
+  try {
+    m_dataType = j.at("dataType").get<std::string>();
+    m_dataLayout = j.at("dataLayout").get<std::string>();
+    m_recordSize = j.at("recordSize").get<unsigned int>();
+    m_fixedSize = j.at("fixedSize").get<bool>();
+    m_gapData = j.at("gapData").get<std::string>();
+    m_time.writePos = j.at("timeWritePos").get<uint64_t>();
+    m_data.writePos = j.at("dataWritePos").get<uint64_t>();
+  } catch (const wpi::json::exception&) {
+    return wpi::errorCodeToError(
+        std::make_error_code(std::errc::wrong_protocol_type));
+  }
+  return wpi::Error::success();
+}
+
+void DataLogImpl::WriteHeader() {
+  if (!m_time.map || m_time.readOnly) return;
+  wpi::json j = {{"dataType", m_dataType},
+                 {"dataLayout", m_dataLayout},
+                 {"recordSize", m_recordSize},
+                 {"fixedSize", m_fixedSize},
+                 {"gapData", m_gapData},
+                 {"timeWritePos", m_time.mapOffset + m_time.writePos},
+                 {"dataWritePos", m_data.mapOffset + m_data.writePos}};
+  std::vector<uint8_t> buf;
+  wpi::raw_uvector_ostream os(buf);
+  j.dump(os, 1);
+  os << '\n';
+  buf.resize(kHeaderSize);
+  m_time.Write(0, buf);
+}
+
+std::error_code DataLogImpl::FileInfo::Open(const wpi::Twine& filename,
+                                            CreationDisposition disp, bool ro) {
+  readOnly = ro;
+  return wpi::sys::fs::openFile(
+      filename, fd, static_cast<wpi::sys::fs::CreationDisposition>(disp),
+      ro ? wpi::sys::fs::FA_Read
+         : (wpi::sys::fs::FA_Read | wpi::sys::fs::FA_Write),
+      wpi::sys::fs::OF_None);
+}
+
+void DataLogImpl::FileInfo::Close() {
+  map.Unmap();
+  if (fd != -1 && writePos != 0 && !readOnly) {
+#ifdef _WIN32
+    _chsize_s(fd, writePos);
+#else
+    if (::ftruncate(fd, writePos) == -1)
+      std::perror("could not truncate during close");
+#endif
+  }
+  if (fd != -1) ::close(fd);
+  fd = -1;
+}
+
+size_t DataLogImpl::FileInfo::GetMappedOffset(uint64_t pos, size_t len,
+                                              std::error_code& ec) const {
+  // TODO: handle smaller mapping window (instead of entire file)
+
+  // easy case: already in mapped window
+  if (map && pos >= mapOffset && (pos + len - mapOffset) <= map.size())
+    return pos - mapOffset;
+
+  if (!readOnly) {
+    // round up to multiple of mapGrowSize
+    uint64_t size = ((pos + len + mapGrowSize - 1) / mapGrowSize) * mapGrowSize;
+    if (size > fileSize) fileSize = size;
+
+    // scale up mapGrowSize until it gets to maxGrowSize
+    if (mapGrowSize < maxGrowSize) {
+      mapGrowSize *= 2;
+      if (mapGrowSize > maxGrowSize) mapGrowSize = maxGrowSize;
+    }
+
+    // update file size
+#ifdef _WIN32
+    _chsize_s(fd, fileSize);
+#else
+    if (::ftruncate(fd, fileSize) == -1)
+      std::perror("could not update file size");
+#endif
+  }
+
+  // update map
+  map.Unmap();
+  map = MappedFile(fd, fileSize, 0, readOnly, ec);
+  if (ec) return SIZE_MAX;
+
+  return pos - mapOffset;
+}
+
+wpi::ArrayRef<uint8_t> DataLogImpl::FileInfo::Read(uint64_t pos,
+                                                   size_t len) const {
+  std::error_code ec;
+  size_t off = GetMappedOffset(pos, len, ec);
+  if (ec) return {};
+  return wpi::makeArrayRef(map.const_data() + off, len);
+}
+
+void DataLogImpl::FileInfo::Write(uint64_t pos, wpi::ArrayRef<uint8_t> data) {
+  std::error_code ec;
+  size_t off = GetMappedOffset(pos, data.size(), ec);
+  if (ec) return;
+  std::memcpy(map.data() + off, data.data(), data.size());
+}
+
+wpi::Expected<DataLog> DataLog::Open(const wpi::Twine& filename,
+                                     const Config& config) {
+  Config configCopy = config;
+  configCopy.checkType = false;
+  configCopy.checkSize = false;
+  configCopy.checkLayout = false;
+  return Open(filename, "", "", 0, CD_OpenExisting, configCopy);
+}
+
+wpi::Expected<DataLog> DataLog::Open(const wpi::Twine& filename,
+                                     const wpi::Twine& dataType,
+                                     const wpi::Twine& dataLayout,
+                                     unsigned int recordSize,
+                                     CreationDisposition disp,
+                                     const Config& config) {
+  DataLog log(new DataLogImpl, true);
+
+  if (wpi::Error e = log.m_impl->DoOpen(filename, dataType, dataLayout,
+                                        recordSize, disp, config))
+    return wpi::Expected<DataLog>{std::move(e)};
+  return wpi::Expected<DataLog>{std::move(log)};
+}
+
+bool DoubleLog::Append(uint64_t timestamp, double value) {
+  uint8_t buf[8];
+  wpi::support::endian::write64le(buf, wpi::DoubleToBits(value));
+  return m_impl->AppendRaw(timestamp, buf);
+}
+
+std::pair<uint64_t, double> DoubleLog::operator[](size_t n) const {
+  auto [ts, arr] = m_impl->ReadRaw(n);
+  return {ts, wpi::BitsToDouble(wpi::support::endian::read64le(arr.data()))};
+}
+
+bool BooleanArrayLog::Append(uint64_t timestamp, wpi::ArrayRef<bool> arr) {
+  uint8_t* out = m_impl->AppendRawStart(timestamp, arr.size());
+  if (!out) return false;
+  for (bool value : arr) *out++ = value ? 1 : 0;
+  m_impl->AppendRawFinish(arr.size());
+  return true;
+}
+
+bool BooleanArrayLog::Append(uint64_t timestamp, wpi::ArrayRef<int> arr) {
+  uint8_t* out = m_impl->AppendRawStart(timestamp, arr.size());
+  if (!out) return false;
+  for (int value : arr) *out++ = value ? 1 : 0;
+  m_impl->AppendRawFinish(arr.size());
+  return true;
+}
+
+std::pair<uint64_t, wpi::ArrayRef<bool>> BooleanArrayLog::Get(
+    size_t n, wpi::SmallVectorImpl<bool>& buf) const {
+  auto [ts, arr] = m_impl->ReadRaw(n);
+  buf.clear();
+  buf.reserve(arr.size());
+  for (uint8_t value : arr) buf.emplace_back(value != 0);
+  return {ts, wpi::makeArrayRef(buf.data(), buf.size())};
+}
+
+std::pair<uint64_t, wpi::ArrayRef<int>> BooleanArrayLog::Get(
+    size_t n, wpi::SmallVectorImpl<int>& buf) const {
+  auto [ts, arr] = m_impl->ReadRaw(n);
+  buf.clear();
+  buf.reserve(arr.size());
+  for (uint8_t value : arr) buf.emplace_back(value != 0 ? 1 : 0);
+  return {ts, wpi::makeArrayRef(buf.data(), buf.size())};
+}
+
+double DoubleArrayLogArrayProxy::operator[](size_t n) const {
+  return wpi::BitsToDouble(
+      wpi::support::endian::read64le(m_data.data() + n * 8));
+}
+
+bool DoubleArrayLog::Append(uint64_t timestamp, wpi::ArrayRef<double> arr) {
+  uint8_t* out = m_impl->AppendRawStart(timestamp, arr.size() * 8);
+  if (!out) return false;
+  for (double value : arr) {
+    wpi::support::endian::write64le(out, wpi::DoubleToBits(value));
+    out += 8;
+  }
+  m_impl->AppendRawFinish(arr.size() * 8);
+  return true;
+}
+
+std::pair<uint64_t, wpi::ArrayRef<double>> DoubleArrayLog::Get(
+    size_t n, wpi::SmallVectorImpl<double>& buf) const {
+  auto [ts, arr] = m_impl->ReadRaw(n);
+  buf.clear();
+  buf.reserve(arr.size() / 8);
+  for (size_t i = 0; i < arr.size() / 8; ++i)
+    buf.emplace_back(
+        wpi::BitsToDouble(wpi::support::endian::read64le(arr.data() + i * 8)));
+  return {ts, wpi::makeArrayRef(buf.data(), buf.size())};
+}
+
+wpi::StringRef StringArrayLogArrayProxy::operator[](size_t n) const {
+  const uint8_t* ptrRec = m_data.slice(4 + n * 8, 8).data();
+  uint32_t off = wpi::support::endian::read32le(ptrRec);
+  uint32_t size = wpi::support::endian::read32le(ptrRec + 4);
+  return wpi::StringRef(
+      reinterpret_cast<const char*>(m_data.slice(off, size).data()), size);
+}
+
+bool StringArrayLog::Append(uint64_t timestamp,
+                            wpi::ArrayRef<std::string> arr) {
+  // calculate size
+  uint32_t off = 4 + 8 * arr.size();
+  uint32_t size = off;
+  for (auto&& value : arr) size += value.size() + 1;
+
+  uint8_t* out = m_impl->AppendRawStart(timestamp, size);
+  if (!out) return false;
+
+  // number of strings
+  wpi::support::endian::write32le(out, arr.size());
+  out += 4;
+
+  // offset, length for each string
+  for (auto&& value : arr) {
+    wpi::support::endian::write32le(out, off);
+    wpi::support::endian::write32le(out, value.size());
+    off += value.size() + 1;
+    out += 8;
+  }
+
+  // string data, null terminate after each string
+  for (auto&& value : arr) {
+    std::memcpy(out, value.data(), value.size());
+    out += value.size();
+    *out++ = '\0';
+  }
+
+  m_impl->AppendRawFinish(size);
+  return true;
+}
+
+bool StringArrayLog::Append(uint64_t timestamp,
+                            wpi::ArrayRef<wpi::StringRef> arr) {
+  // calculate size
+  uint32_t off = 4 + 8 * arr.size();
+  uint32_t size = off;
+  for (auto&& value : arr) size += value.size() + 1;
+
+  uint8_t* out = m_impl->AppendRawStart(timestamp, size);
+  if (!out) return false;
+
+  // number of strings
+  wpi::support::endian::write32le(out, arr.size());
+  out += 4;
+
+  // offset, length for each string
+  for (auto&& value : arr) {
+    wpi::support::endian::write32le(out, off);
+    out += 4;
+    wpi::support::endian::write32le(out, value.size());
+    out += 4;
+    off += value.size() + 1;
+  }
+
+  // string data, null terminate after each string
+  for (auto&& value : arr) {
+    std::memcpy(out, value.data(), value.size());
+    out += value.size();
+    *out++ = '\0';
+  }
+
+  m_impl->AppendRawFinish(size);
+  return true;
+}
+
+std::pair<uint64_t, wpi::ArrayRef<std::string>> StringArrayLog::Get(
+    size_t n, wpi::SmallVectorImpl<std::string>& buf) const {
+  auto [ts, arr] = m_impl->ReadRaw(n);
+
+  // number of strings
+  uint32_t num = wpi::support::endian::read32le(arr.data());
+
+  buf.clear();
+  buf.reserve(num);
+  for (uint32_t i = 0; i < num; ++i) {
+    const uint8_t* ptrRec = arr.slice(4 + i * 8, 8).data();
+    uint32_t off = wpi::support::endian::read32le(ptrRec);
+    uint32_t size = wpi::support::endian::read32le(ptrRec + 4);
+    buf.emplace_back(reinterpret_cast<const char*>(arr.slice(off, size).data()),
+                     size);
+  }
+  return {ts, wpi::makeArrayRef(buf.data(), buf.size())};
+}
+
+std::pair<uint64_t, wpi::ArrayRef<wpi::StringRef>> StringArrayLog::Get(
+    size_t n, wpi::SmallVectorImpl<wpi::StringRef>& buf) const {
+  auto [ts, arr] = m_impl->ReadRaw(n);
+
+  // number of strings
+  uint32_t num = wpi::support::endian::read32le(arr.data());
+
+  buf.clear();
+  buf.reserve(num);
+  for (uint32_t i = 0; i < num; ++i) {
+    const uint8_t* ptrRec = arr.slice(4 + i * 8, 8).data();
+    uint32_t off = wpi::support::endian::read32le(ptrRec);
+    uint32_t size = wpi::support::endian::read32le(ptrRec + 4);
+    buf.emplace_back(reinterpret_cast<const char*>(arr.slice(off, size).data()),
+                     size);
+  }
+  return {ts, wpi::makeArrayRef(buf.data(), buf.size())};
+}
+
+std::pair<uint64_t, StringArrayLogArrayProxy> StringArrayLog::operator[](
+    size_t n) const {
+  auto [ts, arr] = m_impl->ReadRaw(n);
+  return {ts, StringArrayLogArrayProxy(
+                  wpi::support::endian::read32le(arr.data()), arr)};
+}

--- a/wpiutil/src/main/native/cpp/jni/DataLogJNI.cpp
+++ b/wpiutil/src/main/native/cpp/jni/DataLogJNI.cpp
@@ -1,0 +1,416 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <jni.h>
+
+#include "edu_wpi_first_wpiutil_datalog_DataLogJNI.h"
+#include "wpi/DataLog.h"
+#include "wpi/jni_util.h"
+
+using namespace wpi::java;
+using namespace wpi::log;
+
+extern "C" {
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    getDataType
+ * Signature: (J)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_getDataType
+  (JNIEnv* env, jclass, jlong impl)
+{
+  return MakeJString(env,
+                     reinterpret_cast<const DataLogImpl*>(impl)->m_dataType);
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    getDataLayout
+ * Signature: (J)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_getDataLayout
+  (JNIEnv*, jclass, jlong)
+{
+  return nullptr;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    getRecordSize
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_getRecordSize
+  (JNIEnv*, jclass, jlong)
+{
+  return 0;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    isFixedSize
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_isFixedSize
+  (JNIEnv*, jclass, jlong)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    flush
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_flush
+  (JNIEnv*, jclass, jlong)
+{
+  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    getSize
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_getSize
+  (JNIEnv*, jclass, jlong)
+{
+  return 0;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    find
+ * Signature: (JJI)I
+ */
+JNIEXPORT jint JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_find__JJI
+  (JNIEnv*, jclass, jlong, jlong, jint)
+{
+  return 0;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    find
+ * Signature: (JJII)I
+ */
+JNIEXPORT jint JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_find__JJII
+  (JNIEnv*, jclass, jlong, jlong, jint, jint)
+{
+  return 0;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    check
+ * Signature: (JLjava/lang/String;IZZZ)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_check
+  (JNIEnv*, jclass, jlong, jstring, jint, jboolean, jboolean, jboolean)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    close
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_close
+  (JNIEnv*, jclass, jlong)
+{
+  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    open
+ * Signature: (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)J
+ */
+JNIEXPORT jlong JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_open
+  (JNIEnv*, jclass, jstring, jstring, jstring, jint, jint, jobject)
+{
+  return 0;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    openRaw
+ * Signature: (Ljava/lang/String;Ljava/lang/Object;)J
+ */
+JNIEXPORT jlong JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_openRaw
+  (JNIEnv*, jclass, jstring, jobject)
+{
+  return 0;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendRaw
+ * Signature: (J[B)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendRaw
+  (JNIEnv*, jclass, jlong, jbyteArray)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendRawTime
+ * Signature: (JJ[B)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendRawTime
+  (JNIEnv*, jclass, jlong, jlong, jbyteArray)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    readRaw
+ * Signature: (JI)[B
+ */
+JNIEXPORT jbyteArray JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_readRaw
+  (JNIEnv*, jclass, jlong, jint)
+{
+  return nullptr;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    openBoolean
+ * Signature: (Ljava/lang/String;ILjava/lang/Object;)J
+ */
+JNIEXPORT jlong JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_openBoolean
+  (JNIEnv*, jclass, jstring, jint, jobject)
+{
+  return 0;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendBoolean
+ * Signature: (JZ)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendBoolean
+  (JNIEnv*, jclass, jlong, jboolean)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendBooleanTime
+ * Signature: (JJZ)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendBooleanTime
+  (JNIEnv*, jclass, jlong, jlong, jboolean)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    openDouble
+ * Signature: (Ljava/lang/String;ILjava/lang/Object;)J
+ */
+JNIEXPORT jlong JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_openDouble
+  (JNIEnv*, jclass, jstring, jint, jobject)
+{
+  return 0;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendDouble
+ * Signature: (JD)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendDouble
+  (JNIEnv*, jclass, jlong, jdouble)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendDoubleTime
+ * Signature: (JJD)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendDoubleTime
+  (JNIEnv*, jclass, jlong, jlong, jdouble)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    openString
+ * Signature: (Ljava/lang/String;ILjava/lang/Object;)J
+ */
+JNIEXPORT jlong JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_openString
+  (JNIEnv*, jclass, jstring, jint, jobject)
+{
+  return 0;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendString
+ * Signature: (JLjava/lang/String;)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendString
+  (JNIEnv*, jclass, jlong, jstring)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendStringTime
+ * Signature: (JJLjava/lang/String;)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendStringTime
+  (JNIEnv*, jclass, jlong, jlong, jstring)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    openBooleanArray
+ * Signature: (Ljava/lang/String;ILjava/lang/Object;)J
+ */
+JNIEXPORT jlong JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_openBooleanArray
+  (JNIEnv*, jclass, jstring, jint, jobject)
+{
+  return 0;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendBooleanArray
+ * Signature: (J[Z)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendBooleanArray
+  (JNIEnv*, jclass, jlong, jbooleanArray)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendBooleanArrayTime
+ * Signature: (JJ[Z)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendBooleanArrayTime
+  (JNIEnv*, jclass, jlong, jlong, jbooleanArray)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    openDoubleArray
+ * Signature: (Ljava/lang/String;ILjava/lang/Object;)J
+ */
+JNIEXPORT jlong JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_openDoubleArray
+  (JNIEnv*, jclass, jstring, jint, jobject)
+{
+  return 0;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendDoubleArray
+ * Signature: (J[D)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendDoubleArray
+  (JNIEnv*, jclass, jlong, jdoubleArray)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendDoubleArrayTime
+ * Signature: (JJ[D)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendDoubleArrayTime
+  (JNIEnv*, jclass, jlong, jlong, jdoubleArray)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    openStringArray
+ * Signature: (Ljava/lang/String;ILjava/lang/Object;)J
+ */
+JNIEXPORT jlong JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_openStringArray
+  (JNIEnv*, jclass, jstring, jint, jobject)
+{
+  return 0;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendStringArray
+ * Signature: (J[Ljava/lang/Object;)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendStringArray
+  (JNIEnv*, jclass, jlong, jobjectArray)
+{
+  return JNI_FALSE;  // TODO
+}
+
+/*
+ * Class:     edu_wpi_first_wpiutil_datalog_DataLogJNI
+ * Method:    appendStringArrayTime
+ * Signature: (JJ[Ljava/lang/Object;)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_wpiutil_datalog_DataLogJNI_appendStringArrayTime
+  (JNIEnv*, jclass, jlong, jlong, jobjectArray)
+{
+  return JNI_FALSE;  // TODO
+}
+
+}  // extern "C"

--- a/wpiutil/src/main/native/include/wpi/DataLog.h
+++ b/wpiutil/src/main/native/include/wpi/DataLog.h
@@ -1,0 +1,1191 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <stdint.h>
+
+#include <iterator>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <utility>
+
+#include "wpi/ArrayRef.h"
+#include "wpi/Error.h"
+#include "wpi/StringRef.h"
+#include "wpi/Twine.h"
+
+namespace wpi {
+template <typename T>
+class SmallVectorImpl;
+}  // namespace wpi
+
+namespace wpi {
+namespace log {
+
+template <typename T>
+struct DataLogInfo {
+  // static T Read(wpi::ArrayRef<uint8_t> data);
+  // static bool Append(DataLogImpl& impl, uint64_t timestamp, T val);
+};
+
+// Common iterator bits
+template <typename Container, typename Value>
+class ConstArrayIterator {
+ public:
+  using iterator_category = std::random_access_iterator_tag;
+  using value_type = Value;
+  using difference_type = std::ptrdiff_t;
+  using pointer = const value_type*;
+  using reference = const value_type&;
+
+ private:
+  /// A proxy object for computing a reference via indirecting a copy of an
+  /// iterator. This is used in APIs which need to produce a reference via
+  /// indirection but for which the iterator object might be a temporary. The
+  /// proxy preserves the iterator internally and exposes the indirected
+  /// reference via a conversion operator.
+  class ReferenceProxy {
+    friend ConstArrayIterator;
+
+    ConstArrayIterator it;
+
+    explicit ReferenceProxy(ConstArrayIterator it) : it(std::move(it)) {}
+
+   public:
+    operator reference() const { return *it; }
+  };
+
+ public:
+  ConstArrayIterator(const Container* container, size_t n)
+      : m_container(container), m_index(n) {}
+
+  bool operator==(const ConstArrayIterator& oth) const {
+    return m_container == oth.m_container && m_index == oth.m_index;
+  }
+  bool operator!=(const ConstArrayIterator& oth) const {
+    return !this->operator==(oth);
+  }
+
+  bool operator<(const ConstArrayIterator& oth) const {
+    return m_index < oth.m_index;
+  }
+  bool operator>(const ConstArrayIterator& oth) const {
+    return !this->operator<(oth) && !this->operator==(oth);
+  }
+  bool operator<=(const ConstArrayIterator& oth) const {
+    return !this->operator>(oth);
+  }
+  bool operator>=(const ConstArrayIterator& oth) const {
+    return !this->operator<(oth);
+  }
+
+  std::ptrdiff_t operator-(const ConstArrayIterator& oth) const {
+    return oth.m_index - m_index;
+  }
+
+  ConstArrayIterator& operator+=(difference_type n) {
+    m_index += n;
+    m_validValue = false;
+    return *this;
+  }
+
+  ConstArrayIterator& operator-=(difference_type n) {
+    m_index -= n;
+    m_validValue = false;
+    return *this;
+  }
+
+  ConstArrayIterator operator+(difference_type n) const {
+    ConstArrayIterator tmp = *this;
+    tmp += n;
+    return tmp;
+  }
+
+  friend ConstArrayIterator operator+(difference_type n,
+                                      const ConstArrayIterator& i) {
+    return i + n;
+  }
+
+  ConstArrayIterator operator-(difference_type n) const {
+    ConstArrayIterator tmp = *this;
+    tmp -= n;
+    return tmp;
+  }
+
+  ConstArrayIterator& operator++() { return this->operator+=(1); }
+
+  ConstArrayIterator operator++(int) {
+    ConstArrayIterator tmp = *this;
+    ++*this;
+    return tmp;
+  }
+
+  ConstArrayIterator& operator--() { return this->operator-=(1); }
+
+  ConstArrayIterator operator--(int) {
+    ConstArrayIterator tmp = *this;
+    --*this;
+    return tmp;
+  }
+
+  reference operator*() const {
+    if (!m_validValue) {
+      m_value = m_container->operator[](m_index);
+      m_validValue = true;
+    }
+    return m_value;
+  }
+
+  pointer operator->() const { return &this->operator*(); }
+
+  ReferenceProxy operator[](difference_type n) const {
+    return ReferenceProxy(this->operator+(n));
+  }
+
+ private:
+  const Container* m_container;
+  size_t m_index;
+  mutable bool m_validValue = false;
+  mutable Value m_value;
+};
+
+class MappedFile {
+ public:
+  MappedFile() = default;
+  MappedFile(int fd, size_t length, uint64_t offset, bool readOnly,
+             std::error_code& ec);
+  ~MappedFile() { Unmap(); }
+
+  MappedFile(const MappedFile&) = delete;
+  MappedFile& operator=(const MappedFile&) = delete;
+
+  MappedFile(MappedFile&& rhs) : m_size(rhs.m_size), m_mapping(rhs.m_mapping) {
+    rhs.m_mapping = nullptr;
+#ifdef _WIN32
+    m_fileHandle = rhs.m_fileHandle;
+    rhs.m_fileHandle = nullptr;
+#endif
+  }
+
+  MappedFile& operator=(MappedFile&& rhs) {
+    if (m_mapping) Unmap();
+    m_size = rhs.m_size;
+    m_mapping = rhs.m_mapping;
+    rhs.m_mapping = nullptr;
+#ifdef _WIN32
+    m_fileHandle = rhs.m_fileHandle;
+    rhs.m_fileHandle = nullptr;
+#endif
+    return *this;
+  }
+
+  explicit operator bool() const { return m_mapping != nullptr; }
+
+  void Flush();
+  void Unmap();
+
+  size_t size() const { return m_size; }
+  uint8_t* data() const { return static_cast<uint8_t*>(m_mapping); }
+  const uint8_t* const_data() const {
+    return static_cast<const uint8_t*>(m_mapping);
+  }
+
+ private:
+  size_t m_size = 0;
+  void* m_mapping = nullptr;
+#ifdef _WIN32
+  void* m_fileHandle = nullptr;
+#endif
+};
+
+/**
+ * Creation disposition.  Identical to wpi::sys::fs::CreationDisposition
+ * but declared here to avoid header dependency.
+ */
+enum CreationDisposition : unsigned {
+  /// CD_CreateAlways - When opening a file:
+  ///   * If it already exists, truncate it.
+  ///   * If it does not already exist, create a new file.
+  CD_CreateAlways = 0,
+
+  /// CD_CreateNew - When opening a file:
+  ///   * If it already exists, fail.
+  ///   * If it does not already exist, create a new file.
+  CD_CreateNew = 1,
+
+  /// CD_OpenExisting - When opening a file:
+  ///   * If it already exists, open the file.
+  ///   * If it does not already exist, fail.
+  CD_OpenExisting = 2,
+
+  /// CD_OpenAlways - When opening a file:
+  ///   * If it already exists, open the file.
+  ///   * If it does not already exist, create a new file.
+  CD_OpenAlways = 3,
+};
+
+// Common log bits
+class DataLogImpl {
+ public:
+  DataLogImpl();
+  ~DataLogImpl();
+  DataLogImpl(const DataLogImpl&) = delete;
+  DataLogImpl& operator=(const DataLogImpl&) = delete;
+
+  /**
+   * Log implementation configuration.  These can have substantial performance
+   * impacts.  The defaults should be good for desktop applications.
+   */
+  struct Config {
+    /**
+     * Start out timestamp file with space for this many records.  Note the
+     * actual file size will start out this big, but it's a sparse file.
+     */
+    size_t initialSize = 1000;
+
+    /**
+     * Once size has reached this size, grow by this number of records each
+     * time.  Prior to it reaching this size, the space is doubled.
+     */
+    size_t maxGrowSize = 60000;
+
+    /**
+     * Maximum map window size.  Larger is more efficient, but may have
+     * issues on 32-bit systems.  Defaults to unlimited.
+     */
+    size_t maxMapSize = 0;
+
+    /**
+     * Periodic flush setting.  Flushes log to disk every N appends.
+     * Defaults to no periodic flush.
+     */
+    size_t periodicFlush = 0;
+
+    /**
+     * Start out data file with space for this many bytes.  Note the
+     * actual file size will start out this big, but it's a sparse file.
+     */
+    uint64_t initialDataSize = 100000;
+
+    /**
+     * Once data file has reached this size, grow by this number of bytes each
+     * time.  Prior to it reaching this size, the space is doubled.
+     */
+    uint64_t maxDataGrowSize = 1024 * 1024;
+
+    /**
+     * Use large (e.g. 64-bit) variable-sized data files when creating a new
+     * log.  The default is to use 32-bit sizes for the variable-sized data.
+     */
+    bool largeData = false;
+
+    /**
+     * Fill data to put in between each record of variable-sized data in data
+     * file.  Useful for e.g. making strings null terminated.  Defaults to
+     * nothing.
+     */
+    wpi::StringRef gapData;
+
+    /**
+     * Check data type when opening existing file.  Defaults to checking.
+     */
+    bool checkType = true;
+
+    /**
+     * Check record size when opening existing file.  Defaults to checking.
+     */
+    bool checkSize = true;
+
+    /**
+     * Check data layout when opening existing file.  Defaults to checking.
+     */
+    bool checkLayout = true;
+
+    /**
+     * Check timestamp is monotonically increasing and don't save the value if
+     * timestamp decreased.  Defaults to true.
+     */
+    bool checkMonotonic = true;
+
+    /**
+     * Open file in read-only mode.
+     */
+    bool readOnly = false;
+  };
+
+  /**
+   * Returns the number of records stored in the log.
+   *
+   * @return Size of the log, in records
+   */
+  size_t size() const { return (m_time.writePos - kHeaderSize) / m_recordSize; }
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @note The returned reference may be invalidated when log records are
+   *       appended.
+   *
+   * @param n Log index
+   * @return Pair of timestamp and reference to raw stored data
+   */
+  std::pair<uint64_t, wpi::ArrayRef<uint8_t>> ReadRaw(size_t n) const;
+
+  /**
+   * Flushes the log data to disk.
+   */
+  void Flush();
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.  If it is not, and the configuration
+   * has checkMonotonic true, this function will return false.
+   *
+   * @param timestamp Time stamp
+   * @param data Data to record
+   * @return True if successful, false on failure
+   */
+  bool AppendRaw(uint64_t timestamp, wpi::ArrayRef<uint8_t> data);
+
+  /**
+   * Starts appending a record to the log.  This allows more complex write
+   * logic than AppendRaw() without having to copy the data into a temporary
+   * buffer.  As with AppendRaw(), the timestamp must be monotonically
+   * increasing if checkMonotonic is true (if it is not, nullptr is returned).
+   *
+   * AppendRawFinish MUST be called (if this function does not return nullptr)
+   * for the data to actually be preserved.
+   *
+   * @param timestamp Time stamp
+   * @param size length of data to record (ignored if records are fixed size)
+   * @return Pointer to start of writable data region, or nullptr if error
+   */
+  uint8_t* AppendRawStart(uint64_t timestamp, uint64_t size);
+
+  /**
+   * Finishes appending a record to the log started with AppendRawStart().
+   * Size must be the same as the size passed to AppendRawStart().
+   *
+   * @param size length of data recorded (ignored if records are fixed size)
+   */
+  void AppendRawFinish(uint64_t size);
+
+  /**
+   * Finds the first record with timestamp greater than or equal to the
+   * provided time.
+   *
+   * @param timestamp Time stamp
+   * @param first index of first record
+   * @param last index of last record
+   * @return Index of record
+   */
+  size_t FindImpl(uint64_t timestamp, size_t first = 0,
+                  size_t last = SIZE_MAX) const;
+
+  /**
+   * Checks the currently opened log file header.
+   *
+   * @param dataType Data type
+   * @param dataLayout Data layout
+   * @param recordSize Record size; 0 indicates variable data size
+   * @param checkType Check data type matches
+   * @param checkLayout Check data layout matches
+   * @param checkSize Check size matches
+   * @return Error if mismatch, wpi::Error::success() if no error
+   */
+  wpi::Error Check(const wpi::Twine& dataType, const wpi::Twine& dataLayout,
+                   unsigned int recordSize, bool checkType, bool checkLayout,
+                   bool checkSize) const;
+
+  /**
+   * Opens or creates a log file.  If file exists, returns error if file header
+   * does not match the dataType, dataLayout, and/or recordSize specified
+   * (if these checks are enabled in the config parameter).
+   *
+   * @param filename Filename to open
+   * @param dataType Data type
+   * @param dataLayout Data layout
+   * @param recordSize Record size; 0 indicates variable data size.
+   * @param disp Creation disposition (e.g. open or create)
+   * @param config Implementation configuration
+   * @return Error (wpi::Error::success() if no error)
+   */
+  wpi::Error DoOpen(const wpi::Twine& filename, const wpi::Twine& dataType,
+                    const wpi::Twine& dataLayout, unsigned int recordSize,
+                    CreationDisposition disp, const Config& config);
+
+  std::string m_dataType;
+  std::string m_dataLayout;
+  unsigned int m_recordSize = 0;
+  bool m_fixedSize = false;
+  size_t m_periodicFlush = 0;
+  size_t m_periodicFlushCount = 0;
+  std::string m_gapData;
+  bool m_checkMonotonic = true;
+  uint64_t m_lastTimestamp = 0;
+
+  static constexpr size_t kTimestampSize = 8;
+
+ private:
+  wpi::Error ReadHeader();
+  void WriteHeader();
+
+  static constexpr size_t kHeaderSize = 4096;
+
+  struct FileInfo {
+    FileInfo() = default;
+    FileInfo(const FileInfo&) = delete;
+    FileInfo& operator=(const FileInfo&) = delete;
+    ~FileInfo() { Close(); }
+
+    std::error_code Open(const wpi::Twine& filename, CreationDisposition disp,
+                         bool ro);
+    void Close();
+
+    // this remaps the map if necessary
+    size_t GetMappedOffset(uint64_t pos, size_t len, std::error_code& ec) const;
+
+    wpi::ArrayRef<uint8_t> Read(uint64_t pos, size_t len) const;
+    void Write(uint64_t pos, wpi::ArrayRef<uint8_t> data);
+
+    int fd = -1;
+
+    mutable MappedFile map;
+    mutable uint64_t mapOffset = 0;
+    uint64_t maxGrowSize = 0;
+    mutable uint64_t mapGrowSize = 0;
+    size_t maxMapSize = 0;
+    mutable uint64_t fileSize = 0;
+    uint64_t writePos = 0;
+    bool readOnly = false;
+  };
+
+  FileInfo m_time;
+  FileInfo m_data;
+};
+
+/**
+ * CRTP base class for data log classes.
+ *
+ * Derived classes need to implement operator[] and should implement an
+ * appropriate Append() function.
+ */
+template <typename Derived, typename Value>
+class DataLogBase {
+ public:
+  DataLogBase() = default;
+  DataLogBase(const DataLogBase&) = delete;
+  DataLogBase& operator=(const DataLogBase&) = delete;
+  DataLogBase(DataLogBase&& rhs) : m_impl(rhs.m_impl), m_owned(rhs.m_owned) {
+    rhs.m_impl = nullptr;
+  }
+  DataLogBase& operator=(DataLogBase&& rhs) {
+    m_impl = rhs.m_impl;
+    m_owned = rhs.m_owned;
+    rhs.m_impl = nullptr;
+  }
+  ~DataLogBase() {
+    if (m_owned) delete m_impl;
+  }
+
+  explicit operator bool() const { return m_impl != nullptr; }
+
+  using Config = DataLogImpl::Config;
+
+  using iterator = ConstArrayIterator<Derived, std::pair<uint64_t, Value>>;
+
+  /**
+   * Gets the data type string.  This is persistent and saved as part of the
+   * file header.
+   *
+   * @return Data type
+   */
+  wpi::StringRef GetDataType() const { return m_impl->m_dataType; }
+
+  /**
+   * Gets the data layout string.  This is persistent and saved as part of the
+   * file header.
+   *
+   * @return Data layout
+   */
+  wpi::StringRef GetDataLayout() const { return m_impl->m_dataLayout; }
+
+  /**
+   * Gets the record size.  Note this returns a non-zero value even if the
+   * stored data is of variable length.  The record size includes the
+   * timestamp.
+   *
+   * @return Record size, in bytes
+   */
+  unsigned int GetRecordSize() const { return m_impl->m_recordSize; }
+
+  /**
+   * Returns whether the stored data is fixed length.
+   *
+   * @return True if fixed length, false if variable length.
+   */
+  bool IsFixedSize() const { return m_impl->m_fixedSize; }
+
+  /**
+   * Flushes the log data to disk.
+   */
+  void Flush() { m_impl->Flush(); }
+
+  DataLogImpl* GetImpl() { return m_impl; }
+  const DataLogImpl* GetImpl() const { return m_impl; }
+
+  bool empty() const { return m_impl->size() == 0; }
+
+  /**
+   * Returns the number of records stored in the log.
+   *
+   * @return Size of the log, in records
+   */
+  size_t size() const { return m_impl->size(); }
+
+  std::pair<uint64_t, Value> front() const {
+    return static_cast<const Derived*>(this)->operator[](0);
+  }
+
+  std::pair<uint64_t, Value> back() const {
+    return static_cast<const Derived*>(this)->operator[](m_impl->size() - 1);
+  }
+
+  iterator begin() const {
+    return iterator(static_cast<const Derived*>(this), 0);
+  }
+
+  iterator end() const {
+    return iterator(static_cast<const Derived*>(this), m_impl->size());
+  }
+
+  iterator find(uint64_t timestamp) const {
+    return iterator(static_cast<const Derived*>(this),
+                    m_impl->FindImpl(timestamp));
+  }
+
+  iterator find(uint64_t timestamp, iterator first, iterator last) const {
+    iterator b = begin();
+    return iterator(static_cast<const Derived*>(this),
+                    m_impl->FindImpl(timestamp, first - b, last - b));
+  }
+
+ protected:
+  DataLogBase(DataLogImpl* impl, bool owned) : m_impl(impl), m_owned(owned) {}
+
+  DataLogImpl* m_impl = nullptr;
+  bool m_owned = true;
+
+  static constexpr unsigned int kTimestampSize = DataLogImpl::kTimestampSize;
+};
+
+/**
+ * Log arbitrary byte data.
+ */
+class DataLog : public DataLogBase<DataLog, wpi::ArrayRef<uint8_t>> {
+ public:
+  DataLog() = default;
+
+  /**
+   * Opens a log file.  Fails if file does not exist.  Does not check dataType,
+   * dataLayout, or recordSize of opened file.
+   *
+   * @param filename Filename to open
+   * @param config Implementation configuration
+   * @return Log object (or error)
+   */
+  static wpi::Expected<DataLog> Open(const wpi::Twine& filename,
+                                     const Config& config = {});
+
+  /**
+   * Opens or creates a log file.  If file exists, returns error if file header
+   * does not match the dataType, dataLayout, and/or recordSize specified
+   * (if these checks are enabled in the config parameter).
+   *
+   * @param filename Filename to open
+   * @param dataType Data type
+   * @param dataLayout Data layout
+   * @param recordSize Record size; 0 indicates variable data size
+   * @param disp Creation disposition (e.g. open or create)
+   * @param config Implementation configuration
+   * @return Log object (or error)
+   */
+  static wpi::Expected<DataLog> Open(const wpi::Twine& filename,
+                                     const wpi::Twine& dataType,
+                                     const wpi::Twine& dataLayout,
+                                     unsigned int recordSize,
+                                     CreationDisposition disp,
+                                     const Config& config = {});
+
+  /**
+   * Makes a reference to the log.  Named WrapUnsafe for compatibility with
+   * specific log types.
+   *
+   * @note Keeps a reference to passed-in object.  Lifetime of datalog must
+   *       extend past the lifetime of return value.
+   *
+   * @param datalog data log object
+   * @return Log object
+   */
+  static DataLog WrapUnsafe(DataLog& datalog) {
+    return DataLog(datalog.GetImpl(), false);
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.
+   *
+   * @param timestamp Time stamp
+   * @param data Data to record
+   * @return True if successful, false on failure
+   */
+  bool Append(uint64_t timestamp, wpi::ArrayRef<uint8_t> data) {
+    return m_impl->AppendRaw(timestamp, data);
+  }
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @note The returned reference may be invalidated when log records are
+   *       appended.
+   *
+   * @param n Log index
+   * @return Pair of timestamp and reference to raw stored data
+   */
+  std::pair<uint64_t, wpi::ArrayRef<uint8_t>> operator[](size_t n) const {
+    return m_impl->ReadRaw(n);
+  }
+
+ protected:
+  DataLog(DataLogImpl* ptr, bool owned) : DataLogBase(ptr, owned) {}
+};
+
+template <typename Derived>
+class DataLogStaticMixin {
+ public:
+  /**
+   * Wraps a generic data log.  Returns log object, or error if log is
+   * not a log of this type.
+   *
+   * @note Keeps a reference to passed-in object.  Lifetime of datalog must
+   *       extend past the lifetime of return value.
+   *
+   * @param datalog data log object
+   * @param layout check layout matches
+   * @return Log object (or error)
+   */
+  static wpi::Expected<Derived> Wrap(DataLog& datalog,
+                                     bool checkLayout = false) {
+    auto impl = datalog.GetImpl();
+    if (wpi::Error e =
+            impl->Check(Derived::kDataType, Derived::kDataLayout,
+                        Derived::kRecordSize, true, checkLayout, true))
+      return wpi::Expected<Derived>{std::move(e)};
+    return Derived(impl, false);
+  }
+
+  /**
+   * Wraps a generic data log without doing format checks.
+   *
+   * @note Keeps a reference to passed-in object.  Lifetime of datalog must
+   *       extend past the lifetime of return value.
+   *
+   * @param datalog data log object
+   * @return Log object
+   */
+  static Derived WrapUnsafe(DataLog& datalog) {
+    return Derived(datalog.GetImpl(), false);
+  }
+
+  /**
+   * Opens a log file.  Returns log object, or error if file does not exist.
+   *
+   * @param filename Filename to open
+   * @param disp Creation disposition (e.g. open or create)
+   * @param config Implementation configuration
+   * @return Log object (or error)
+   */
+  static wpi::Expected<Derived> Open(const wpi::Twine& filename,
+                                     CreationDisposition disp,
+                                     const DataLogImpl::Config& config = {}) {
+    Derived log(new DataLogImpl, true);
+    if (wpi::Error e = log.GetImpl()->DoOpen(
+            filename, Derived::kDataType, Derived::kDataLayout,
+            Derived::kRecordSize, disp, config))
+      return wpi::Expected<Derived>{std::move(e)};
+    return wpi::Expected<Derived>{std::move(log)};
+
+  }
+};
+
+/**
+ * Log boolean values.
+ */
+class BooleanLog : public DataLogBase<BooleanLog, bool>,
+                   public DataLogStaticMixin<BooleanLog> {
+  friend class DataLogStaticMixin<BooleanLog>;
+
+ public:
+  static constexpr const char* kDataType = "boolean";
+  static constexpr const char* kDataLayout = "byte";
+  static constexpr unsigned int kRecordSize = kTimestampSize + 1;
+
+  BooleanLog() = default;
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.
+   *
+   * @param timestamp Time stamp
+   * @param value Value to record
+   * @return True if successful, false on failure
+   */
+  bool Append(uint64_t timestamp, bool value) {
+    uint8_t buf[1];
+    buf[0] = value ? 1 : 0;
+    return m_impl->AppendRaw(timestamp, buf);
+  }
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @param n Log index
+   * @return Pair of timestamp and double value
+   */
+  std::pair<uint64_t, bool> operator[](size_t n) const {
+    auto [ts, arr] = m_impl->ReadRaw(n);
+    return {ts, arr[0] != 0};
+  }
+
+ protected:
+  BooleanLog(DataLogImpl* ptr, bool owned) : DataLogBase(ptr, owned) {}
+};
+
+/**
+ * Log double values.
+ */
+class DoubleLog : public DataLogBase<DoubleLog, double>,
+                  public DataLogStaticMixin<DoubleLog> {
+  friend class DataLogStaticMixin<DoubleLog>;
+
+ public:
+  static constexpr const char* kDataType = "double";
+  static constexpr const char* kDataLayout = "float64";
+  static constexpr unsigned int kRecordSize = kTimestampSize + 8;
+
+  DoubleLog() = default;
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.
+   *
+   * @param timestamp Time stamp
+   * @param value Value to record
+   * @return True if successful, false on failure
+   */
+  bool Append(uint64_t timestamp, double value);
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @param n Log index
+   * @return Pair of timestamp and double value
+   */
+  std::pair<uint64_t, double> operator[](size_t n) const;
+
+ protected:
+  DoubleLog(DataLogImpl* ptr, bool owned) : DataLogBase(ptr, owned) {}
+};
+
+/**
+ * Log string values.
+ */
+class StringLog : public DataLogBase<StringLog, wpi::StringRef>,
+                  public DataLogStaticMixin<StringLog> {
+  friend class DataLogStaticMixin<StringLog>;
+
+ public:
+  static constexpr const char* kDataType = "string";
+  static constexpr const char* kDataLayout = "utf8";
+  static constexpr unsigned int kRecordSize = 0;
+
+  StringLog() = default;
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.
+   *
+   * @param timestamp Time stamp
+   * @param value Value to record
+   * @return True if successful, false on failure
+   */
+  bool Append(uint64_t timestamp, wpi::StringRef value) {
+    return m_impl->AppendRaw(
+        timestamp,
+        wpi::makeArrayRef(reinterpret_cast<const uint8_t*>(value.data()),
+                          value.size()));
+  }
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @note The returned reference may be invalidated when log records are
+   *       appended.
+   *
+   * @param n Log index
+   * @return Pair of timestamp and string value
+   */
+  std::pair<uint64_t, wpi::StringRef> operator[](size_t n) const {
+    auto [ts, arr] = m_impl->ReadRaw(n);
+    return {ts, wpi::StringRef(reinterpret_cast<const char*>(arr.data()),
+                               arr.size())};
+  }
+
+ protected:
+  StringLog(DataLogImpl* ptr, bool owned) : DataLogBase(ptr, owned) {}
+};
+
+/**
+ * Proxy object for boolean array log access.
+ */
+class BooleanArrayLogArrayProxy {
+  friend class BooleanArrayLog;
+
+ public:
+  BooleanArrayLogArrayProxy() = default;
+
+  using iterator = ConstArrayIterator<BooleanArrayLogArrayProxy, bool>;
+
+  iterator begin() const { return iterator(this, 0); }
+  iterator end() const { return iterator(this, size()); }
+
+  size_t size() const { return m_data.size(); }
+
+  bool operator[](size_t n) const { return m_data[n] != 0; }
+
+ private:
+  explicit BooleanArrayLogArrayProxy(wpi::ArrayRef<uint8_t> data)
+      : m_data(data) {}
+
+  wpi::ArrayRef<uint8_t> m_data;
+};
+
+/**
+ * Log array of boolean values.
+ */
+class BooleanArrayLog
+    : public DataLogBase<BooleanArrayLog, BooleanArrayLogArrayProxy>,
+      public DataLogStaticMixin<BooleanArrayLog> {
+  friend class DataLogStaticMixin<BooleanArrayLog>;
+
+ public:
+  static constexpr const char* kDataType = "boolean[]";
+  static constexpr const char* kDataLayout = "byte[]";
+  static constexpr unsigned int kRecordSize = 0;
+
+  BooleanArrayLog() = default;
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.
+   *
+   * @param timestamp Time stamp
+   * @param arr Values to record
+   * @return True if successful, false on failure
+   */
+  bool Append(uint64_t timestamp, wpi::ArrayRef<bool> arr);
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.
+   *
+   * @param timestamp Time stamp
+   * @param arr Values to record
+   * @return True if successful, false on failure
+   */
+  bool Append(uint64_t timestamp, std::initializer_list<bool> arr) {
+    return Append(timestamp, wpi::makeArrayRef(arr.begin(), arr.end()));
+  }
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.
+   *
+   * @param timestamp Time stamp
+   * @param arr Values to record
+   * @return True if successful, false on failure
+   */
+  bool Append(uint64_t timestamp, wpi::ArrayRef<int> arr);
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.
+   *
+   * @param timestamp Time stamp
+   * @param arr Values to record
+   * @return True if successful, false on failure
+   */
+  bool Append(uint64_t timestamp, std::initializer_list<int> arr) {
+    return Append(timestamp, wpi::makeArrayRef(arr.begin(), arr.end()));
+  }
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @note The returned reference may be invalidated when log records are
+   *       appended.
+   *
+   * @param n Log index
+   * @param buf Buffer for stored data
+   * @return Pair of timestamp and boolean array value
+   */
+  std::pair<uint64_t, wpi::ArrayRef<bool>> Get(
+      size_t n, wpi::SmallVectorImpl<bool>& buf) const;
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @note The returned reference may be invalidated when log records are
+   *       appended.
+   *
+   * @param n Log index
+   * @param buf Buffer for stored data
+   * @return Pair of timestamp and boolean array value
+   */
+  std::pair<uint64_t, wpi::ArrayRef<int>> Get(
+      size_t n, wpi::SmallVectorImpl<int>& buf) const;
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @note The returned reference may be invalidated when log records are
+   *       appended.
+   *
+   * @param n Log index
+   * @return Pair of timestamp and boolean array value
+   */
+  std::pair<uint64_t, BooleanArrayLogArrayProxy> operator[](size_t n) const {
+    auto [ts, arr] = m_impl->ReadRaw(n);
+    return {ts, BooleanArrayLogArrayProxy(arr)};
+  }
+
+ protected:
+  BooleanArrayLog(DataLogImpl* ptr, bool owned) : DataLogBase(ptr, owned) {}
+};
+
+/**
+ * Proxy object for double array log access.
+ */
+class DoubleArrayLogArrayProxy {
+  friend class DoubleArrayLog;
+
+ public:
+  DoubleArrayLogArrayProxy() = default;
+
+  using iterator = ConstArrayIterator<DoubleArrayLogArrayProxy, double>;
+
+  iterator begin() const { return iterator(this, 0); }
+  iterator end() const { return iterator(this, size()); }
+
+  size_t size() const { return m_data.size() / 8; }
+
+  double operator[](size_t n) const;
+
+ private:
+  explicit DoubleArrayLogArrayProxy(wpi::ArrayRef<uint8_t> data)
+      : m_data(data) {}
+
+  wpi::ArrayRef<uint8_t> m_data;
+};
+
+/**
+ * Log array of double values.
+ */
+class DoubleArrayLog
+    : public DataLogBase<DoubleArrayLog, DoubleArrayLogArrayProxy>,
+      public DataLogStaticMixin<DoubleArrayLog> {
+  friend class DataLogStaticMixin<DoubleArrayLog>;
+
+ public:
+  static constexpr const char* kDataType = "double[]";
+  static constexpr const char* kDataLayout = "float64[]";
+  static constexpr unsigned int kRecordSize = 0;
+
+  DoubleArrayLog() = default;
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.
+   *
+   * @param timestamp Time stamp
+   * @param arr Values to record
+   * @return True if successful, false on failure
+   */
+  bool Append(uint64_t timestamp, wpi::ArrayRef<double> arr);
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.
+   *
+   * @param timestamp Time stamp
+   * @param arr Values to record
+   * @return True if successful, false on failure
+   */
+  bool Append(uint64_t timestamp, std::initializer_list<double> arr) {
+    return Append(timestamp, wpi::makeArrayRef(arr.begin(), arr.end()));
+  }
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @note The returned reference may be invalidated when log records are
+   *       appended.
+   *
+   * @param n Log index
+   * @param buf Buffer for stored data
+   * @return Pair of timestamp and double array value
+   */
+  std::pair<uint64_t, wpi::ArrayRef<double>> Get(
+      size_t n, wpi::SmallVectorImpl<double>& buf) const;
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @note The returned reference may be invalidated when log records are
+   *       appended.
+   *
+   * @param n Log index
+   * @return Pair of timestamp and double array value
+   */
+  std::pair<uint64_t, DoubleArrayLogArrayProxy> operator[](size_t n) const {
+    auto [ts, arr] = m_impl->ReadRaw(n);
+    return {ts, DoubleArrayLogArrayProxy(arr)};
+  }
+
+ protected:
+  DoubleArrayLog(DataLogImpl* ptr, bool owned) : DataLogBase(ptr, owned) {}
+};
+
+/**
+ * Proxy object for string array log access.
+ */
+class StringArrayLogArrayProxy {
+  friend class StringArrayLog;
+
+ public:
+  StringArrayLogArrayProxy() = default;
+
+  using iterator = ConstArrayIterator<StringArrayLogArrayProxy, wpi::StringRef>;
+
+  iterator begin() const { return iterator(this, 0); }
+  iterator end() const { return iterator(this, size()); }
+
+  size_t size() const { return m_size; }
+
+  wpi::StringRef operator[](size_t n) const;
+
+ private:
+  explicit StringArrayLogArrayProxy(uint32_t size, wpi::ArrayRef<uint8_t> data)
+      : m_size(size), m_data(data) {}
+
+  uint32_t m_size;
+  wpi::ArrayRef<uint8_t> m_data;
+};
+
+/**
+ * Log array of double values.
+ */
+class StringArrayLog
+    : public DataLogBase<StringArrayLog, StringArrayLogArrayProxy>,
+      public DataLogStaticMixin<StringArrayLog> {
+  friend class DataLogStaticMixin<StringArrayLog>;
+
+ public:
+  static constexpr const char* kDataType = "string[]";
+  static constexpr const char* kDataLayout =
+      "u32 n,{u32 off,u32 size}[],utf8[]";
+  static constexpr unsigned int kRecordSize = 0;
+
+  StringArrayLog() = default;
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.
+   *
+   * @param timestamp Time stamp
+   * @param arr Values to record
+   * @return True if successful, false on failure
+   */
+  bool Append(uint64_t timestamp, wpi::ArrayRef<std::string> arr);
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.
+   *
+   * @param timestamp Time stamp
+   * @param arr Values to record
+   * @return True if successful, false on failure
+   */
+  bool Append(uint64_t timestamp, wpi::ArrayRef<wpi::StringRef> arr);
+
+  /**
+   * Appends a record to the log.  For find functions to work, timestamp
+   * must be monotonically increasing.
+   *
+   * @param timestamp Time stamp
+   * @param arr Values to record
+   * @return True if successful, false on failure
+   */
+  bool Append(uint64_t timestamp, std::initializer_list<wpi::StringRef> arr) {
+    return Append(timestamp, wpi::makeArrayRef(arr.begin(), arr.end()));
+  }
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @note The returned reference may be invalidated when log records are
+   *       appended.
+   *
+   * @param n Log index
+   * @param buf Buffer for stored data
+   * @return Pair of timestamp and string array value
+   */
+  std::pair<uint64_t, wpi::ArrayRef<std::string>> Get(
+      size_t n, wpi::SmallVectorImpl<std::string>& buf) const;
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @note The returned reference may be invalidated when log records are
+   *       appended.
+   *
+   * @param n Log index
+   * @param buf Buffer for stored data
+   * @return Pair of timestamp and string array value
+   */
+  std::pair<uint64_t, wpi::ArrayRef<wpi::StringRef>> Get(
+      size_t n, wpi::SmallVectorImpl<wpi::StringRef>& buf) const;
+
+  /**
+   * Reads the raw stored data.
+   *
+   * @note The returned reference may be invalidated when log records are
+   *       appended.
+   *
+   * @param n Log index
+   * @return Pair of timestamp and string array value
+   */
+  std::pair<uint64_t, StringArrayLogArrayProxy> operator[](size_t n) const;
+
+ protected:
+  StringArrayLog(DataLogImpl* ptr, bool owned) : DataLogBase(ptr, owned) {}
+};
+
+}  // namespace log
+}  // namespace wpi

--- a/wpiutil/src/main/native/include/wpi/DataLog.h
+++ b/wpiutil/src/main/native/include/wpi/DataLog.h
@@ -174,7 +174,9 @@ class MappedFile {
   }
 
   MappedFile& operator=(MappedFile&& rhs) {
-    if (m_mapping) Unmap();
+    if (m_mapping) {
+      Unmap();
+    }
     m_size = rhs.m_size;
     m_mapping = rhs.m_mapping;
     rhs.m_mapping = nullptr;
@@ -491,7 +493,9 @@ class DataLogBase {
     rhs.m_impl = nullptr;
   }
   ~DataLogBase() {
-    if (m_owned) delete m_impl;
+    if (m_owned) {
+      delete m_impl;
+    }
   }
 
   explicit operator bool() const { return m_impl != nullptr; }
@@ -685,8 +689,9 @@ class DataLogStaticMixin {
     auto impl = datalog.GetImpl();
     if (wpi::Error e =
             impl->Check(Derived::kDataType, Derived::kDataLayout,
-                        Derived::kRecordSize, true, checkLayout, true))
-      return wpi::Expected<Derived>{std::move(e)};
+                        Derived::kRecordSize, true, checkLayout, true)) {
+      return wpi::Expected<Derived> { std::move(e) }
+    };
     return Derived(impl, false);
   }
 
@@ -717,8 +722,9 @@ class DataLogStaticMixin {
     Derived log(new DataLogImpl, true);
     if (wpi::Error e = log.GetImpl()->DoOpen(
             filename, Derived::kDataType, Derived::kDataLayout,
-            Derived::kRecordSize, disp, config))
-      return wpi::Expected<Derived>{std::move(e)};
+            Derived::kRecordSize, disp, config)) {
+      return wpi::Expected<Derived> { std::move(e) }
+    };
     return wpi::Expected<Derived>{std::move(log)};
 
   }


### PR DESCRIPTION
These use memory-mapped buffers to memory mapped files for very high speed
reading and writing.  The data storage format is binary, either one or two
files per value being logged.

C++ only at present; JNI wrappers still need to be written.