### PR TITLE
Move curvature_t to units namespace

### DIFF
--- a/wpilibc/src/main/native/cpp/trajectory/Trajectory.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/Trajectory.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/cpp/trajectory/Trajectory.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/Trajectory.cpp
@@ -149,5 +149,5 @@ void frc::from_json(const wpi::json& json, Trajectory::State& state) {
       units::meters_per_second_t{json.at("velocity").get<double>()};
   state.acceleration =
       units::meters_per_second_squared_t{json.at("acceleration").get<double>()};
-  state.curvature = frc::curvature_t{json.at("curvature").get<double>()};
+  state.curvature = units::curvature_t{json.at("curvature").get<double>()};
 }

--- a/wpilibc/src/main/native/cpp/trajectory/constraint/CentripetalAccelerationConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/CentripetalAccelerationConstraint.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/cpp/trajectory/constraint/CentripetalAccelerationConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/CentripetalAccelerationConstraint.cpp
@@ -14,7 +14,7 @@ CentripetalAccelerationConstraint::CentripetalAccelerationConstraint(
     : m_maxCentripetalAcceleration(maxCentripetalAcceleration) {}
 
 units::meters_per_second_t CentripetalAccelerationConstraint::MaxVelocity(
-    const Pose2d& pose, curvature_t curvature,
+    const Pose2d& pose, units::curvature_t curvature,
     units::meters_per_second_t velocity) {
   // ac = v^2 / r
   // k (curvature) = 1 / r
@@ -32,7 +32,7 @@ units::meters_per_second_t CentripetalAccelerationConstraint::MaxVelocity(
 
 TrajectoryConstraint::MinMax
 CentripetalAccelerationConstraint::MinMaxAcceleration(
-    const Pose2d& pose, curvature_t curvature,
+    const Pose2d& pose, units::curvature_t curvature,
     units::meters_per_second_t speed) {
   // The acceleration of the robot has no impact on the centripetal acceleration
   // of the robot.

--- a/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveKinematicsConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveKinematicsConstraint.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveKinematicsConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveKinematicsConstraint.cpp
@@ -14,7 +14,7 @@ DifferentialDriveKinematicsConstraint::DifferentialDriveKinematicsConstraint(
     : m_kinematics(kinematics), m_maxSpeed(maxSpeed) {}
 
 units::meters_per_second_t DifferentialDriveKinematicsConstraint::MaxVelocity(
-    const Pose2d& pose, curvature_t curvature,
+    const Pose2d& pose, units::curvature_t curvature,
     units::meters_per_second_t velocity) {
   auto wheelSpeeds =
       m_kinematics.ToWheelSpeeds({velocity, 0_mps, velocity * curvature});
@@ -25,7 +25,7 @@ units::meters_per_second_t DifferentialDriveKinematicsConstraint::MaxVelocity(
 
 TrajectoryConstraint::MinMax
 DifferentialDriveKinematicsConstraint::MinMaxAcceleration(
-    const Pose2d& pose, curvature_t curvature,
+    const Pose2d& pose, units::curvature_t curvature,
     units::meters_per_second_t speed) {
   return {};
 }

--- a/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
@@ -22,14 +22,14 @@ DifferentialDriveVoltageConstraint::DifferentialDriveVoltageConstraint(
       m_maxVoltage(maxVoltage) {}
 
 units::meters_per_second_t DifferentialDriveVoltageConstraint::MaxVelocity(
-    const Pose2d& pose, curvature_t curvature,
+    const Pose2d& pose, units::curvature_t curvature,
     units::meters_per_second_t velocity) {
   return units::meters_per_second_t(std::numeric_limits<double>::max());
 }
 
 TrajectoryConstraint::MinMax
 DifferentialDriveVoltageConstraint::MinMaxAcceleration(
-    const Pose2d& pose, curvature_t curvature,
+    const Pose2d& pose, units::curvature_t curvature,
     units::meters_per_second_t speed) {
   auto wheelSpeeds =
       m_kinematics.ToWheelSpeeds({speed, 0_mps, speed * curvature});

--- a/wpilibc/src/main/native/cpp/trajectory/constraint/MecanumDriveKinematicsConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/MecanumDriveKinematicsConstraint.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/cpp/trajectory/constraint/MecanumDriveKinematicsConstraint.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/constraint/MecanumDriveKinematicsConstraint.cpp
@@ -14,7 +14,7 @@ MecanumDriveKinematicsConstraint::MecanumDriveKinematicsConstraint(
     : m_kinematics(kinematics), m_maxSpeed(maxSpeed) {}
 
 units::meters_per_second_t MecanumDriveKinematicsConstraint::MaxVelocity(
-    const Pose2d& pose, curvature_t curvature,
+    const Pose2d& pose, units::curvature_t curvature,
     units::meters_per_second_t velocity) {
   auto xVelocity = velocity * pose.Rotation().Cos();
   auto yVelocity = velocity * pose.Rotation().Sin();
@@ -29,7 +29,7 @@ units::meters_per_second_t MecanumDriveKinematicsConstraint::MaxVelocity(
 
 TrajectoryConstraint::MinMax
 MecanumDriveKinematicsConstraint::MinMaxAcceleration(
-    const Pose2d& pose, curvature_t curvature,
+    const Pose2d& pose, units::curvature_t curvature,
     units::meters_per_second_t speed) {
   return {};
 }

--- a/wpilibc/src/main/native/include/frc/spline/Spline.h
+++ b/wpilibc/src/main/native/include/frc/spline/Spline.h
@@ -10,19 +10,15 @@
 #include <array>
 #include <utility>
 #include <vector>
+#include <units/units.h>
+
+#include <wpi/deprecated.h>
 
 #include <Eigen/Core>
 
 #include "frc/geometry/Pose2d.h"
 
 namespace frc {
-
-/**
- * Define a unit for curvature.
- */
-using curvature_t = units::unit_t<
-    units::compound_unit<units::radian, units::inverse<units::meter>>>;
-
 /**
  * Represents a two-dimensional parametric spline that interpolates between two
  * points.
@@ -32,7 +28,7 @@ using curvature_t = units::unit_t<
 template <int Degree>
 class Spline {
  public:
-  using PoseWithCurvature = std::pair<Pose2d, curvature_t>;
+  using PoseWithCurvature = std::pair<Pose2d, units::curvature_t>;
 
   Spline() = default;
 
@@ -99,7 +95,7 @@ class Spline {
 
     return {
         {FromVector(combined.template block<2, 1>(0, 0)), Rotation2d(dx, dy)},
-        curvature_t(curvature)};
+        units::curvature_t(curvature)};
   }
 
  protected:

--- a/wpilibc/src/main/native/include/frc/spline/Spline.h
+++ b/wpilibc/src/main/native/include/frc/spline/Spline.h
@@ -13,7 +13,6 @@
 
 #include <Eigen/Core>
 #include <units/units.h>
-#include <wpi/deprecated.h>
 
 #include "frc/geometry/Pose2d.h"
 

--- a/wpilibc/src/main/native/include/frc/spline/Spline.h
+++ b/wpilibc/src/main/native/include/frc/spline/Spline.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -10,11 +10,10 @@
 #include <array>
 #include <utility>
 #include <vector>
-#include <units/units.h>
-
-#include <wpi/deprecated.h>
 
 #include <Eigen/Core>
+#include <units/units.h>
+#include <wpi/deprecated.h>
 
 #include "frc/geometry/Pose2d.h"
 

--- a/wpilibc/src/main/native/include/frc/spline/SplineParameterizer.h
+++ b/wpilibc/src/main/native/include/frc/spline/SplineParameterizer.h
@@ -48,7 +48,7 @@ namespace frc {
  */
 class SplineParameterizer {
  public:
-  using PoseWithCurvature = std::pair<Pose2d, curvature_t>;
+  using PoseWithCurvature = std::pair<Pose2d, units::curvature_t>;
 
   struct MalformedSplineException : public std::runtime_error {
     explicit MalformedSplineException(const char* what_arg)

--- a/wpilibc/src/main/native/include/frc/trajectory/Trajectory.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/Trajectory.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include <units/units.h>
-#include <wpi/deprecated.h>
 
 #include "frc/geometry/Pose2d.h"
 #include "frc/geometry/Transform2d.h"

--- a/wpilibc/src/main/native/include/frc/trajectory/Trajectory.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/Trajectory.h
@@ -11,6 +11,8 @@
 
 #include <units/units.h>
 
+#include <wpi/deprecated.h>
+
 #include "frc/geometry/Pose2d.h"
 #include "frc/geometry/Transform2d.h"
 
@@ -19,13 +21,6 @@ class json;
 }  // namespace wpi
 
 namespace frc {
-
-/**
- * Define a unit for curvature.
- */
-using curvature_t = units::unit_t<
-    units::compound_unit<units::radian, units::inverse<units::meter>>>;
-
 /**
  * Represents a time-parameterized trajectory. The trajectory contains of
  * various States that represent the pose, curvature, time elapsed, velocity,
@@ -50,7 +45,7 @@ class Trajectory {
     Pose2d pose;
 
     // The curvature at that point of the trajectory.
-    curvature_t curvature{0.0};
+    units::curvature_t curvature{0.0};
 
     /**
      * Checks equality between this State and another object.

--- a/wpilibc/src/main/native/include/frc/trajectory/Trajectory.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/Trajectory.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include <units/units.h>
-
 #include <wpi/deprecated.h>
 
 #include "frc/geometry/Pose2d.h"

--- a/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
@@ -24,7 +24,7 @@ namespace frc {
  */
 class TrajectoryGenerator {
  public:
-  using PoseWithCurvature = std::pair<Pose2d, curvature_t>;
+  using PoseWithCurvature = std::pair<Pose2d, units::curvature_t>;
 
   /**
    * Generates a trajectory from the given control vectors and config. This

--- a/wpilibc/src/main/native/include/frc/trajectory/TrajectoryParameterizer.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/TrajectoryParameterizer.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/include/frc/trajectory/TrajectoryParameterizer.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/TrajectoryParameterizer.h
@@ -44,7 +44,7 @@ namespace frc {
  */
 class TrajectoryParameterizer {
  public:
-  using PoseWithCurvature = std::pair<Pose2d, curvature_t>;
+  using PoseWithCurvature = std::pair<Pose2d, units::curvature_t>;
 
   /**
    * Parameterize the trajectory by time. This is where the velocity profile is
@@ -82,7 +82,7 @@ class TrajectoryParameterizer {
    * the trajectory, max velocity, min acceleration and max acceleration.
    */
   struct ConstrainedState {
-    PoseWithCurvature pose = {Pose2d(), curvature_t(0.0)};
+    PoseWithCurvature pose = {Pose2d(), units::curvature_t(0.0)};
     units::meter_t distance = 0_m;
     units::meters_per_second_t maxVelocity = 0_mps;
     units::meters_per_second_squared_t minAcceleration = 0_mps_sq;

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/CentripetalAccelerationConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/CentripetalAccelerationConstraint.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/CentripetalAccelerationConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/CentripetalAccelerationConstraint.h
@@ -28,10 +28,10 @@ class CentripetalAccelerationConstraint : public TrajectoryConstraint {
       units::meters_per_second_squared_t maxCentripetalAcceleration);
 
   units::meters_per_second_t MaxVelocity(
-      const Pose2d& pose, curvature_t curvature,
+      const Pose2d& pose, units::curvature_t curvature,
       units::meters_per_second_t velocity) override;
 
-  MinMax MinMaxAcceleration(const Pose2d& pose, curvature_t curvature,
+  MinMax MinMaxAcceleration(const Pose2d& pose, units::curvature_t curvature,
                             units::meters_per_second_t speed) override;
 
  private:

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveKinematicsConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveKinematicsConstraint.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveKinematicsConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveKinematicsConstraint.h
@@ -25,10 +25,10 @@ class DifferentialDriveKinematicsConstraint : public TrajectoryConstraint {
                                         units::meters_per_second_t maxSpeed);
 
   units::meters_per_second_t MaxVelocity(
-      const Pose2d& pose, curvature_t curvature,
+      const Pose2d& pose, units::curvature_t curvature,
       units::meters_per_second_t velocity) override;
 
-  MinMax MinMaxAcceleration(const Pose2d& pose, curvature_t curvature,
+  MinMax MinMaxAcceleration(const Pose2d& pose, units::curvature_t curvature,
                             units::meters_per_second_t speed) override;
 
  private:

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h
@@ -37,10 +37,10 @@ class DifferentialDriveVoltageConstraint : public TrajectoryConstraint {
       DifferentialDriveKinematics kinematics, units::volt_t maxVoltage);
 
   units::meters_per_second_t MaxVelocity(
-      const Pose2d& pose, curvature_t curvature,
+      const Pose2d& pose, units::curvature_t curvature,
       units::meters_per_second_t velocity) override;
 
-  MinMax MinMaxAcceleration(const Pose2d& pose, curvature_t curvature,
+  MinMax MinMaxAcceleration(const Pose2d& pose, units::curvature_t curvature,
                             units::meters_per_second_t speed) override;
 
  private:

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/MecanumDriveKinematicsConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/MecanumDriveKinematicsConstraint.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/MecanumDriveKinematicsConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/MecanumDriveKinematicsConstraint.h
@@ -27,10 +27,10 @@ class MecanumDriveKinematicsConstraint : public TrajectoryConstraint {
                                    units::meters_per_second_t maxSpeed);
 
   units::meters_per_second_t MaxVelocity(
-      const Pose2d& pose, curvature_t curvature,
+      const Pose2d& pose, units::curvature_t curvature,
       units::meters_per_second_t velocity) override;
 
-  MinMax MinMaxAcceleration(const Pose2d& pose, curvature_t curvature,
+  MinMax MinMaxAcceleration(const Pose2d& pose, units::curvature_t curvature,
                             units::meters_per_second_t speed) override;
 
  private:

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.h
@@ -30,10 +30,10 @@ class SwerveDriveKinematicsConstraint : public TrajectoryConstraint {
       units::meters_per_second_t maxSpeed);
 
   units::meters_per_second_t MaxVelocity(
-      const Pose2d& pose, curvature_t curvature,
+      const Pose2d& pose, units::curvature_t curvature,
       units::meters_per_second_t velocity) override;
 
-  MinMax MinMaxAcceleration(const Pose2d& pose, curvature_t curvature,
+  MinMax MinMaxAcceleration(const Pose2d& pose, units::curvature_t curvature,
                             units::meters_per_second_t speed) override;
 
  private:

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.inc
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.inc
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.inc
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.inc
@@ -25,7 +25,7 @@ SwerveDriveKinematicsConstraint<NumModules>::SwerveDriveKinematicsConstraint(
 template <size_t NumModules>
 units::meters_per_second_t
 SwerveDriveKinematicsConstraint<NumModules>::MaxVelocity(
-    const Pose2d& pose, curvature_t curvature,
+    const Pose2d& pose, units::curvature_t curvature,
     units::meters_per_second_t velocity) {
   auto xVelocity = velocity * pose.Rotation().Cos();
   auto yVelocity = velocity * pose.Rotation().Sin();
@@ -41,7 +41,7 @@ SwerveDriveKinematicsConstraint<NumModules>::MaxVelocity(
 template <size_t NumModules>
 TrajectoryConstraint::MinMax
 SwerveDriveKinematicsConstraint<NumModules>::MinMaxAcceleration(
-    const Pose2d& pose, curvature_t curvature,
+    const Pose2d& pose, units::curvature_t curvature,
     units::meters_per_second_t speed) {
   return {};
 }

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/TrajectoryConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/TrajectoryConstraint.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -72,7 +72,8 @@ class TrajectoryConstraint {
    *
    * @return The min and max acceleration bounds.
    */
-  virtual MinMax MinMaxAcceleration(const Pose2d& pose, units::curvature_t curvature,
+  virtual MinMax MinMaxAcceleration(const Pose2d& pose,
+                                    units::curvature_t curvature,
                                     units::meters_per_second_t speed) = 0;
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/TrajectoryConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/TrajectoryConstraint.h
@@ -59,7 +59,7 @@ class TrajectoryConstraint {
    * @return The absolute maximum velocity.
    */
   virtual units::meters_per_second_t MaxVelocity(
-      const Pose2d& pose, curvature_t curvature,
+      const Pose2d& pose, units::curvature_t curvature,
       units::meters_per_second_t velocity) = 0;
 
   /**
@@ -72,7 +72,7 @@ class TrajectoryConstraint {
    *
    * @return The min and max acceleration bounds.
    */
-  virtual MinMax MinMaxAcceleration(const Pose2d& pose, curvature_t curvature,
+  virtual MinMax MinMaxAcceleration(const Pose2d& pose, units::curvature_t curvature,
                                     units::meters_per_second_t speed) = 0;
 };
 }  // namespace frc

--- a/wpiutil/src/main/native/include/units/units.h
+++ b/wpiutil/src/main/native/include/units/units.h
@@ -4855,6 +4855,12 @@ using namespace acceleration;
 using namespace angle;
 using namespace voltage;
 
+/**
+ * Define a unit for curvature.
+ */
+using curvature_t = units::unit_t<
+    units::compound_unit<units::radian, units::inverse<units::meter>>>;
+
 using dimensionless::scalar;
 using dimensionless::scalar_t;
 using dimensionless::dimensionless_t;


### PR DESCRIPTION
Closes #2335 
This is a breaking change; however, I do not think that many users would have used the `curvature_t` type in their robot projects.