### PR TITLE
InstantCommand.perpetually() now runs perpetually

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -127,16 +127,15 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
    * @param requirements  The command requirements
    */
   private void initCommand(Command command, boolean interruptible, Set<Subsystem> requirements) {
+    command.initialize();
     CommandState scheduledCommand = new CommandState(interruptible);
     m_scheduledCommands.put(command, scheduledCommand);
-    command.initialize();
-    for (Subsystem requirement : requirements) {
-      m_requirements.put(requirement, command);
-    }
     for (Consumer<Command> action : m_initActions) {
       action.accept(command);
     }
-
+    for (Subsystem requirement : requirements) {
+      m_requirements.put(requirement, command);
+    }
   }
 
   /**
@@ -356,10 +355,9 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   }
 
   /**
-   * Cancels commands. The scheduler will only call {@link Command#end(boolean)} method of the canceled command
-   * with {@code true}, indicating they were canceled (as opposed to finishing normally).
-   *
-   * <p>Commands will be canceled even if they are not scheduled as interruptible.
+   * Cancels commands.  The scheduler will only call the interrupted method of a canceled command,
+   * not the end method (though the interrupted method may itself call the end method).  Commands
+   * will be canceled even if they are not scheduled as interruptible.
    *
    * @param commands the commands to cancel
    */

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -127,15 +127,16 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
    * @param requirements  The command requirements
    */
   private void initCommand(Command command, boolean interruptible, Set<Subsystem> requirements) {
-    command.initialize();
     CommandState scheduledCommand = new CommandState(interruptible);
     m_scheduledCommands.put(command, scheduledCommand);
-    for (Consumer<Command> action : m_initActions) {
-      action.accept(command);
-    }
+    command.initialize();
     for (Subsystem requirement : requirements) {
       m_requirements.put(requirement, command);
     }
+    for (Consumer<Command> action : m_initActions) {
+      action.accept(command);
+    }
+
   }
 
   /**
@@ -355,9 +356,10 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   }
 
   /**
-   * Cancels commands.  The scheduler will only call the interrupted method of a canceled command,
-   * not the end method (though the interrupted method may itself call the end method).  Commands
-   * will be canceled even if they are not scheduled as interruptible.
+   * Cancels commands. The scheduler will only call {@link Command#end(boolean)} method of the canceled command
+   * with {@code true}, indicating they were canceled (as opposed to finishing normally).
+   *
+   * <p>Commands will be canceled even if they are not scheduled as interruptible.
    *
    * @param commands the commands to cancel
    */

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/InstantCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/InstantCommand.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/InstantCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/InstantCommand.java
@@ -47,4 +47,22 @@ public class InstantCommand extends CommandBase {
   public final boolean isFinished() {
     return true;
   }
+
+  /**
+   * Decorates this command to run perpetually, ignoring its ordinary end conditions.  The decorated
+   * command can still be interrupted or canceled.
+   *
+   * <p>Note: This decorator works by composing this command within a CommandGroup.  The command
+   * cannot be used independently after being decorated, or be re-decorated with a different
+   * decorator, unless it is manually cleared from the list of grouped commands with
+   * {@link CommandGroupBase#clearGroupedCommand(Command)}.  The decorated command can, however, be
+   * further decorated without issue.
+   *
+   * @return the decorated command
+   */
+  @Override
+  public PerpetualCommand perpetually() {
+    return new PerpetualCommand(new RunCommand(m_toRun,
+            getRequirements().toArray(Subsystem[]::new)));
+  }
 }


### PR DESCRIPTION
java fix #2302