### PR TITLE
[wpilibc] Output Tracer to DriverStation by default

### DIFF
--- a/wpilibc/src/main/native/cpp/Tracer.cpp
+++ b/wpilibc/src/main/native/cpp/Tracer.cpp
@@ -8,7 +8,10 @@
 #include "frc/Tracer.h"
 
 #include <wpi/Format.h>
+#include <wpi/SmallString.h>
 #include <wpi/raw_ostream.h>
+
+#include "frc/DriverStation.h"
 
 using namespace frc;
 
@@ -28,6 +31,13 @@ void Tracer::AddEpoch(wpi::StringRef epochName) {
 }
 
 void Tracer::PrintEpochs() {
+  wpi::SmallString<128> buf;
+  wpi::raw_svector_ostream os(buf);
+  PrintEpochs(os);
+  if (!buf.empty()) DriverStation::ReportWarning(buf);
+}
+
+void Tracer::PrintEpochs(wpi::raw_ostream& os) {
   using std::chrono::duration_cast;
   using std::chrono::microseconds;
 
@@ -35,12 +45,11 @@ void Tracer::PrintEpochs() {
   if (now - m_lastEpochsPrintTime > kMinPrintPeriod) {
     m_lastEpochsPrintTime = now;
     for (const auto& epoch : m_epochs) {
-      wpi::outs() << '\t' << epoch.getKey() << ": "
-                  << wpi::format(
-                         "%.6f",
-                         duration_cast<microseconds>(epoch.getValue()).count() /
-                             1.0e6)
-                  << "s\n";
+      os << '\t' << epoch.getKey() << ": "
+         << wpi::format(
+                "%.6f",
+                duration_cast<microseconds>(epoch.getValue()).count() / 1.0e6)
+         << "s\n";
     }
   }
 }

--- a/wpilibc/src/main/native/include/frc/Tracer.h
+++ b/wpilibc/src/main/native/include/frc/Tracer.h
@@ -14,6 +14,10 @@
 #include <wpi/StringMap.h>
 #include <wpi/StringRef.h>
 
+namespace wpi {
+class raw_ostream;
+}  // namespace wpi
+
 namespace frc {
 /**
  * A class for keeping track of how much time it takes for different parts of
@@ -51,9 +55,16 @@ class Tracer {
   void AddEpoch(wpi::StringRef epochName);
 
   /**
-   * Prints list of epochs added so far and their times.
+   * Prints list of epochs added so far and their times to the DriverStation.
    */
   void PrintEpochs();
+
+  /**
+   * Prints list of epochs added so far and their times to a stream.
+   *
+   * @param os output stream
+   */
+  void PrintEpochs(wpi::raw_ostream& os);
 
  private:
   static constexpr std::chrono::milliseconds kMinPrintPeriod{1000};

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
@@ -83,13 +83,15 @@ public class Tracer {
    */
   public void printEpochs(Consumer<String> output) {
     long now = RobotController.getFPGATime();
-    StringBuilder sb = new StringBuilder();
-    if (now  - m_lastEpochsPrintTime > kMinPrintPeriod) {
+    if (now - m_lastEpochsPrintTime > kMinPrintPeriod) {
+      StringBuilder sb = new StringBuilder();
       m_lastEpochsPrintTime = now;
       m_epochs.forEach((key, value) -> {
         sb.append(String.format("\t%s: %.6fs\n", key, value / 1.0e6));
       });
+      if (sb.length() > 0) {
+        output.accept(sb.toString());
+      }
     }
-    output.accept(sb.toString());
   }
 }


### PR DESCRIPTION
This matches the Java behavior.

Also optimizes Java to only create a StringBuffer and call
DriverStation.reportWarning if there is data to output.