### PR TITLE
[wpilibj] Move button tests to button package

### DIFF
--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandTestBase.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandTestBase.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
  * Basic setup for all {@link Command tests}."
  */
 @SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
-abstract class CommandTestBase {
+public abstract class CommandTestBase {
   @BeforeEach
   void commandSetup() {
     CommandScheduler.getInstance().cancelAll();
@@ -32,7 +32,7 @@ abstract class CommandTestBase {
     setDSEnabled(true);
   }
 
-  void setDSEnabled(boolean enabled) {
+  public void setDSEnabled(boolean enabled) {
     DriverStationSim sim = new DriverStationSim();
     sim.setDsAttached(true);
 
@@ -48,44 +48,44 @@ abstract class CommandTestBase {
     }
   }
 
-  class TestSubsystem extends SubsystemBase {
+  public class TestSubsystem extends SubsystemBase {
   }
 
-  protected class MockCommandHolder {
+  public class MockCommandHolder {
     private final Command m_mockCommand = mock(Command.class);
 
-    MockCommandHolder(boolean runWhenDisabled, Subsystem... requirements) {
+    public MockCommandHolder(boolean runWhenDisabled, Subsystem... requirements) {
       when(m_mockCommand.getRequirements()).thenReturn(Set.of(requirements));
       when(m_mockCommand.isFinished()).thenReturn(false);
       when(m_mockCommand.runsWhenDisabled()).thenReturn(runWhenDisabled);
     }
 
-    Command getMock() {
+    public Command getMock() {
       return m_mockCommand;
     }
 
-    void setFinished(boolean finished) {
+    public void setFinished(boolean finished) {
       when(m_mockCommand.isFinished()).thenReturn(finished);
     }
 
   }
 
-  protected class Counter {
-    int m_counter;
+  public class Counter {
+    public int m_counter;
 
-    void increment() {
+    public void increment() {
       m_counter++;
     }
   }
 
-  protected class ConditionHolder {
+  public class ConditionHolder {
     private boolean m_condition;
 
-    void setCondition(boolean condition) {
+    public void setCondition(boolean condition) {
       m_condition = condition;
     }
 
-    boolean getCondition() {
+    public boolean getCondition() {
       return m_condition;
     }
   }

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/ButtonTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/ButtonTest.java
@@ -1,15 +1,17 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package edu.wpi.first.wpilibj2.command;
+package edu.wpi.first.wpilibj2.command.button;
 
 import org.junit.jupiter.api.Test;
 
-import edu.wpi.first.wpilibj2.command.button.InternalButton;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import edu.wpi.first.wpilibj2.command.CommandTestBase;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;


### PR DESCRIPTION
Also make CommandTestBase public to facilitate

As suggested here: https://github.com/wpilibsuite/allwpilib/pull/2373/files#r403770017
