### PR TITLE
WIP Make Shuffleboard classes public

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/RecordingController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/RecordingController.java
@@ -15,20 +15,34 @@ import edu.wpi.first.wpilibj.DriverStation;
 /**
  * Controls Shuffleboard recordings via NetworkTables.
  */
-final class RecordingController {
+public final class RecordingController {
   private static final String kRecordingTableName = "/Shuffleboard/.recording/";
   private static final String kRecordingControlKey = kRecordingTableName + "RecordData";
   private static final String kRecordingFileNameFormatKey = kRecordingTableName + "FileNameFormat";
   private static final String kEventMarkerTableName = kRecordingTableName + "events";
 
+  private static RecordingController s_defaultInstance;
+
   private final NetworkTableEntry m_recordingControlEntry;
   private final NetworkTableEntry m_recordingFileNameFormatEntry;
   private final NetworkTable m_eventsTable;
 
-  RecordingController(NetworkTableInstance ntInstance) {
+  public RecordingController(NetworkTableInstance ntInstance) {
     m_recordingControlEntry = ntInstance.getEntry(kRecordingControlKey);
     m_recordingFileNameFormatEntry = ntInstance.getEntry(kRecordingFileNameFormatKey);
     m_eventsTable = ntInstance.getTable(kEventMarkerTableName);
+  }
+
+  /**
+   * Get global default instance.
+   *
+   * @return Global default instance
+   */
+  public static synchronized RecordingController getDefault() {
+    if (s_defaultInstance == null) {
+      s_defaultInstance = new RecordingController(NetworkTableInstance.getDefault());
+    }
+    return s_defaultInstance;
   }
 
   public void startRecording() {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/RecordingController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/RecordingController.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -27,6 +27,11 @@ public final class RecordingController {
   private final NetworkTableEntry m_recordingFileNameFormatEntry;
   private final NetworkTable m_eventsTable;
 
+  /**
+   * Creates a new RecordingController instance
+   *
+   * @param ntInstance the NetworkTables instance to use
+   */
   public RecordingController(NetworkTableInstance ntInstance) {
     m_recordingControlEntry = ntInstance.getEntry(kRecordingControlKey);
     m_recordingFileNameFormatEntry = ntInstance.getEntry(kRecordingFileNameFormatKey);
@@ -45,22 +50,64 @@ public final class RecordingController {
     return s_defaultInstance;
   }
 
+  /**
+   * Starts data recording on the dashboard. Has no effect if recording is already in progress.
+   *
+   * @see #stopRecording()
+   */
   public void startRecording() {
     m_recordingControlEntry.setBoolean(true);
   }
 
+  /**
+   * Stops data recording on the dashboard. Has no effect if no recording is in progress.
+   *
+   * @see #startRecording()
+   */
   public void stopRecording() {
     m_recordingControlEntry.setBoolean(false);
   }
 
+  /**
+   * Sets the file name format for new recording files to use. If recording is in progress when this
+   * method is called, it will continue to use the same file. New recordings will use the format.
+   *
+   * <p>To avoid recording files overwriting each other, make sure to use unique recording file
+   * names. File name formats accept templates for inserting the date and time when the recording
+   * started with the {@code ${date}} and {@code ${time}} templates, respectively. For example,
+   * the default format is {@code "recording-${time}"} and recording files created with it will have
+   * names like {@code "recording-2018.01.15.sbr"}. Users are <strong>strongly</strong> recommended
+   * to use the {@code ${time}} template to ensure unique file names.
+   * </p>
+   *
+   * @param format the format for the
+   * @see #clearRecordingFileNameFormat()
+   */
   public void setRecordingFileNameFormat(String format) {
     m_recordingFileNameFormatEntry.setString(format);
   }
 
+  /**
+   * Clears the custom name format for recording files. New recordings will use the default format.
+   *
+   * @see #setRecordingFileNameFormat(String)
+   */
   public void clearRecordingFileNameFormat() {
     m_recordingFileNameFormatEntry.delete();
   }
 
+  /**
+   * Notifies Shuffleboard of an event. Events can range from as trivial as a change in a command
+   * state to as critical as a total power loss or component failure. If Shuffleboard is recording,
+   * the event will also be recorded.
+   *
+   * <p>If {@code name} is {@code null} or empty, or {@code importance} is {@code null}, then
+   * no event will be sent and an error will be printed to the driver station.
+   *
+   * @param name        the name of the event
+   * @param description a description of the event
+   * @param importance  the importance of the event
+   */
   public void addEventMarker(String name, String description, EventImportance importance) {
     if (name == null || name.isEmpty()) {
       DriverStation.reportError(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/Shuffleboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/Shuffleboard.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -51,10 +51,8 @@ public final class Shuffleboard {
    */
   public static final String kBaseTableName = "/Shuffleboard";
 
-  private static final ShuffleboardRoot root =
-      new ShuffleboardInstance(NetworkTableInstance.getDefault());
-  private static final RecordingController recordingController =
-      new RecordingController(NetworkTableInstance.getDefault());
+  private static final ShuffleboardRoot root = ShuffleboardInstance.getDefault();
+  private static final RecordingController recordingController = RecordingController.getDefault();
 
   private Shuffleboard() {
     throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/Shuffleboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/Shuffleboard.java
@@ -7,8 +7,6 @@
 
 package edu.wpi.first.wpilibj.shuffleboard;
 
-import edu.wpi.first.networktables.NetworkTableInstance;
-
 /**
  * The Shuffleboard class provides a mechanism with which data can be added and laid out in the
  * Shuffleboard dashboard application from a robot program. Tabs and layouts can be specified, as

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -41,6 +41,7 @@ public final class ShuffleboardInstance implements ShuffleboardRoot {
     m_selectedTabEntry = m_rootMetaTable.getEntry("Selected");
     HAL.report(tResourceType.kResourceType_Shuffleboard, 0);
   }
+
   /**
    * Get global default instance.
    *

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
@@ -19,7 +19,9 @@ import edu.wpi.first.networktables.NetworkTableInstance;
 
 import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
 
-final class ShuffleboardInstance implements ShuffleboardRoot {
+public final class ShuffleboardInstance implements ShuffleboardRoot {
+  private static ShuffleboardInstance s_defaultInstance;
+
   private final Map<String, ShuffleboardTab> m_tabs = new LinkedHashMap<>();
 
   private boolean m_tabsChanged = false; // NOPMD redundant field initializer
@@ -32,12 +34,23 @@ final class ShuffleboardInstance implements ShuffleboardRoot {
    *
    * @param ntInstance the NetworkTables instance to use
    */
-  ShuffleboardInstance(NetworkTableInstance ntInstance) {
+  public ShuffleboardInstance(NetworkTableInstance ntInstance) {
     requireNonNullParam(ntInstance, "ntInstance", "ShuffleboardInstance");
     m_rootTable = ntInstance.getTable(Shuffleboard.kBaseTableName);
     m_rootMetaTable = m_rootTable.getSubTable(".metadata");
     m_selectedTabEntry = m_rootMetaTable.getEntry("Selected");
     HAL.report(tResourceType.kResourceType_Shuffleboard, 0);
+  }
+  /**
+   * Get global default instance.
+   *
+   * @return Global default instance
+   */
+  public static synchronized ShuffleboardInstance getDefault() {
+    if (s_defaultInstance == null) {
+      s_defaultInstance = new ShuffleboardInstance(NetworkTableInstance.getDefault());
+    }
+    return s_defaultInstance;
   }
 
   @Override

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardRoot.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardRoot.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -10,8 +10,6 @@ package edu.wpi.first.wpilibj.shuffleboard;
 /**
  * The root of the data placed in Shuffleboard. It contains the tabs, but no data is placed
  * directly in the root.
- *
- * <p>This class is package-private to minimize API surface area.
  */
 public interface ShuffleboardRoot {
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardRoot.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardRoot.java
@@ -13,7 +13,7 @@ package edu.wpi.first.wpilibj.shuffleboard;
  *
  * <p>This class is package-private to minimize API surface area.
  */
-interface ShuffleboardRoot {
+public interface ShuffleboardRoot {
 
   /**
    * Gets the tab with the given title, creating it if it does not already exist.


### PR DESCRIPTION
WIP

These are some changes that make parts of the Shuffleboard API more similar to the NetworkTableInstance class with `getDefault()` methods. This issue was brought up in https://github.com/wpilibsuite/allwpilib/issues/2365.

I'm probably going to make Shuffleboard's state able to be reset as well, but for now this just makes a few classes public. I'm not sure what the best way is to be able to reset ShuffleboardInstance's state. Probably add a method in ShuffleboardRoot and have the implementation in ShuffleboardInstance clear the tabs map and possibly delete all entries on one of the network tables.