### PR TITLE
[WIP] [wpilibc/wpilibj] Add State-Space Control Classes

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/LTVUnicycleCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/LTVUnicycleCommand.java
@@ -1,0 +1,212 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj2.command;
+
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.controller.LTVUnicycleController;
+import edu.wpi.first.wpilibj.controller.PIDController;
+import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.trajectory.Trajectory;
+
+import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
+
+/**
+ * A command that uses a LTV (Linear Time-varying) Unicycle controller
+ * ({@link LTVUnicycleController}) to follow a trajectory {@link Trajectory} with a
+ * differential drive. Like Ramsete, the LTV Unicycle controller calculates the chassis speed
+ * command necessary to follow a trajectory, making it a drop-in replacement for Ramsete.
+ *
+ * <p>For more on the underlying math behind the controller, read
+ * https://file.tavsys.net/control/state-space-guide.pdf.
+ *
+ * <p>The command handles trajectory-following, PID calculations, and feedforwards internally.  This
+ * is intended to be a more-or-less "complete solution" that can be used by teams without a great
+ * deal of controls expertise.
+ *
+ * <p>Advanced teams seeking more flexibility (for example, those who wish to use the onboard
+ * PID functionality of a "smart" motor controller) may use the secondary constructor that omits
+ * the PID and feedforward functionality, returning only the raw wheel speeds from the unicycle
+ * controller.
+ */
+@SuppressWarnings("PMD.TooManyFields")
+public class LTVUnicycleCommand extends CommandBase {
+  private final Timer m_timer = new Timer();
+  private final boolean m_usePID;
+  private final Trajectory m_trajectory;
+  private final Supplier<Pose2d> m_pose;
+  private final LTVUnicycleController m_follower;
+  private final SimpleMotorFeedforward m_feedforward;
+  private final DifferentialDriveKinematics m_kinematics;
+  private final Supplier<DifferentialDriveWheelSpeeds> m_speeds;
+  private final PIDController m_leftController;
+  private final PIDController m_rightController;
+  private final BiConsumer<Double, Double> m_output;
+  private DifferentialDriveWheelSpeeds m_prevSpeeds;
+  private double m_prevTime;
+
+  /**
+   * Constructs a new LTVUnicycleCommand that, when executed, will follow the provided trajectory.
+   * PID control and feedforward are handled internally, and outputs are scaled -12 to 12
+   * representing units of volts.
+   *
+   * <p>Note: The controller will *not* set the outputVolts to zero upon completion of the path -
+   * this
+   * is left to the user, since it is not appropriate for paths with nonstationary endstates.
+   *
+   * @param trajectory      The trajectory to follow.
+   * @param pose            A function that supplies the robot pose - use one of
+   *                        the odometry classes to provide this.
+   * @param controller      The RAMSETE controller used to follow the trajectory.
+   * @param feedforward     The feedforward to use for the drive.
+   * @param kinematics      The kinematics for the robot drivetrain.
+   * @param wheelSpeeds     A function that supplies the speeds of the left and
+   *                        right sides of the robot drive.
+   * @param leftController  The PIDController for the left side of the robot drive.
+   * @param rightController The PIDController for the right side of the robot drive.
+   * @param outputVolts     A function that consumes the computed left and right
+   *                        outputs (in volts) for the robot drive.
+   * @param requirements    The subsystems to require.
+   */
+  @SuppressWarnings("PMD.ExcessiveParameterList")
+  public LTVUnicycleCommand(Trajectory trajectory,
+                            Supplier<Pose2d> pose,
+                            LTVUnicycleController controller,
+                            SimpleMotorFeedforward feedforward,
+                            DifferentialDriveKinematics kinematics,
+                            Supplier<DifferentialDriveWheelSpeeds> wheelSpeeds,
+                            PIDController leftController,
+                            PIDController rightController,
+                            BiConsumer<Double, Double> outputVolts,
+                            Subsystem... requirements) {
+    m_trajectory = requireNonNullParam(trajectory, "trajectory", "LTVUnicycleCommand");
+    m_pose = requireNonNullParam(pose, "pose", "LTVUnicycleCommand");
+    m_follower = requireNonNullParam(controller, "controller", "LTVUnicycleCommand");
+    m_feedforward = feedforward;
+    m_kinematics = requireNonNullParam(kinematics, "kinematics", "LTVUnicycleCommand");
+    m_speeds = requireNonNullParam(wheelSpeeds, "wheelSpeeds", "LTVUnicycleCommand");
+    m_leftController = requireNonNullParam(leftController, "leftController", "LTVUnicycleCommand");
+    m_rightController = requireNonNullParam(rightController, "rightController",
+          "LTVUnicycleCommand");
+    m_output = requireNonNullParam(outputVolts, "outputVolts", "LTVUnicycleCommand");
+
+    m_usePID = true;
+
+    addRequirements(requirements);
+  }
+
+  /**
+   * Constructs a new LTVUnicycleCommand that, when executed, will follow the provided trajectory.
+   * Performs no PID control and calculates no feedforwards; outputs are the raw wheel speeds
+   * from the LTV Unicycle controller, and will need to be converted into a usable form by the user.
+   *
+   * @param trajectory            The trajectory to follow.
+   * @param pose                  A function that supplies the robot pose - use one of
+   *                              the odometry classes to provide this.
+   * @param follower              The LTV Unicycle controller used to follow the trajectory.
+   * @param kinematics            The kinematics for the robot drivetrain.
+   * @param outputMetersPerSecond A function that consumes the computed left and right
+   *                              wheel speeds.
+   * @param requirements          The subsystems to require.
+   */
+  public LTVUnicycleCommand(Trajectory trajectory,
+                            Supplier<Pose2d> pose,
+                            LTVUnicycleController follower,
+                            DifferentialDriveKinematics kinematics,
+                            BiConsumer<Double, Double> outputMetersPerSecond,
+                            Subsystem... requirements) {
+    m_trajectory = requireNonNullParam(trajectory, "trajectory", "LTVUnicycleCommand");
+    m_pose = requireNonNullParam(pose, "pose", "LTVUnicycleCommand");
+    m_follower = requireNonNullParam(follower, "follower", "LTVUnicycleCommand");
+    m_kinematics = requireNonNullParam(kinematics, "kinematics", "LTVUnicycleCommand");
+    m_output = requireNonNullParam(outputMetersPerSecond, "output", "LTVUnicycleCommand");
+
+    m_feedforward = null;
+    m_speeds = null;
+    m_leftController = null;
+    m_rightController = null;
+
+    m_usePID = false;
+
+    addRequirements(requirements);
+  }
+
+  @Override
+  public void initialize() {
+    m_prevTime = 0;
+    var initialState = m_trajectory.sample(0);
+    m_prevSpeeds = m_kinematics.toWheelSpeeds(
+        new ChassisSpeeds(initialState.velocityMetersPerSecond,
+            0,
+            initialState.curvatureRadPerMeter
+                * initialState.velocityMetersPerSecond));
+    m_timer.reset();
+    m_timer.start();
+    if (m_usePID) {
+      m_leftController.reset();
+      m_rightController.reset();
+    }
+  }
+
+  @Override
+  public void execute() {
+    double curTime = m_timer.get();
+    double dt = curTime - m_prevTime;
+
+    var targetWheelSpeeds = m_kinematics.toWheelSpeeds(
+        m_follower.calculate(m_pose.get(), m_trajectory.sample(curTime)));
+
+    var leftSpeedSetpoint = targetWheelSpeeds.leftMetersPerSecond;
+    var rightSpeedSetpoint = targetWheelSpeeds.rightMetersPerSecond;
+
+    double leftOutput;
+    double rightOutput;
+
+    if (m_usePID) {
+      double leftFeedforward =
+          m_feedforward.calculate(leftSpeedSetpoint,
+              (leftSpeedSetpoint - m_prevSpeeds.leftMetersPerSecond) / dt);
+
+      double rightFeedforward =
+          m_feedforward.calculate(rightSpeedSetpoint,
+              (rightSpeedSetpoint - m_prevSpeeds.rightMetersPerSecond) / dt);
+
+      leftOutput = leftFeedforward
+          + m_leftController.calculate(m_speeds.get().leftMetersPerSecond,
+          leftSpeedSetpoint);
+
+      rightOutput = rightFeedforward
+          + m_rightController.calculate(m_speeds.get().rightMetersPerSecond,
+          rightSpeedSetpoint);
+    } else {
+      leftOutput = leftSpeedSetpoint;
+      rightOutput = rightSpeedSetpoint;
+    }
+
+    m_output.accept(leftOutput, rightOutput);
+
+    m_prevTime = curTime;
+    m_prevSpeeds = targetWheelSpeeds;
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    m_timer.stop();
+  }
+
+  @Override
+  public boolean isFinished() {
+    return m_timer.hasElapsed(m_trajectory.getTotalTimeSeconds());
+  }
+}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/LTVUnicycleCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/LTVUnicycleCommand.cpp
@@ -1,0 +1,142 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc2/command/LTVUnicycleCommand.h"
+
+using namespace frc2;
+using namespace units;
+
+LTVUnicycleCommand::LTVUnicycleCommand(
+    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
+    frc::LTVUnicycleController controller,
+    frc::SimpleMotorFeedforward<units::meters> feedforward,
+    frc::DifferentialDriveKinematics kinematics,
+    std::function<frc::DifferentialDriveWheelSpeeds()> wheelSpeeds,
+    frc2::PIDController leftController, frc2::PIDController rightController,
+    std::function<void(volt_t, volt_t)> output,
+    std::initializer_list<Subsystem*> requirements)
+    : m_trajectory(trajectory),
+      m_pose(pose),
+      m_controller(controller),
+      m_feedforward(feedforward),
+      m_kinematics(kinematics),
+      m_speeds(wheelSpeeds),
+      m_leftController(std::make_unique<frc2::PIDController>(leftController)),
+      m_rightController(std::make_unique<frc2::PIDController>(rightController)),
+      m_outputVolts(output),
+      m_usePID(true) {
+  AddRequirements(requirements);
+}
+
+LTVUnicycleCommand::LTVUnicycleCommand(
+    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
+    frc::LTVUnicycleController controller,
+    frc::SimpleMotorFeedforward<units::meters> feedforward,
+    frc::DifferentialDriveKinematics kinematics,
+    std::function<frc::DifferentialDriveWheelSpeeds()> wheelSpeeds,
+    frc2::PIDController leftController, frc2::PIDController rightController,
+    std::function<void(volt_t, volt_t)> output,
+    wpi::ArrayRef<Subsystem*> requirements)
+    : m_trajectory(trajectory),
+      m_pose(pose),
+      m_controller(controller),
+      m_feedforward(feedforward),
+      m_kinematics(kinematics),
+      m_speeds(wheelSpeeds),
+      m_leftController(std::make_unique<frc2::PIDController>(leftController)),
+      m_rightController(std::make_unique<frc2::PIDController>(rightController)),
+      m_outputVolts(output),
+      m_usePID(true) {
+  AddRequirements(requirements);
+}
+
+LTVUnicycleCommand::LTVUnicycleCommand(
+    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
+    frc::LTVUnicycleController controller,
+    frc::DifferentialDriveKinematics kinematics,
+    std::function<void(units::meters_per_second_t, units::meters_per_second_t)>
+        output,
+    std::initializer_list<Subsystem*> requirements)
+    : m_trajectory(trajectory),
+      m_pose(pose),
+      m_controller(controller),
+      m_kinematics(kinematics),
+      m_outputVel(output),
+      m_usePID(false) {
+  AddRequirements(requirements);
+}
+
+LTVUnicycleCommand::LTVUnicycleCommand(
+    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
+    frc::LTVUnicycleController controller,
+    frc::DifferentialDriveKinematics kinematics,
+    std::function<void(units::meters_per_second_t, units::meters_per_second_t)>
+        output,
+    wpi::ArrayRef<Subsystem*> requirements)
+    : m_trajectory(trajectory),
+      m_pose(pose),
+      m_controller(controller),
+      m_kinematics(kinematics),
+      m_outputVel(output),
+      m_usePID(false) {
+  AddRequirements(requirements);
+}
+
+void LTVUnicycleCommand::Initialize() {
+  m_prevTime = 0_s;
+  auto initialState = m_trajectory.Sample(0_s);
+  m_prevSpeeds = m_kinematics.ToWheelSpeeds(
+      frc::ChassisSpeeds{initialState.velocity, 0_mps,
+                         initialState.velocity * initialState.curvature});
+  m_timer.Reset();
+  m_timer.Start();
+  if (m_usePID) {
+    m_leftController->Reset();
+    m_rightController->Reset();
+  }
+}
+
+void LTVUnicycleCommand::Execute() {
+  auto curTime = m_timer.Get();
+  auto dt = curTime - m_prevTime;
+
+  auto targetWheelSpeeds = m_kinematics.ToWheelSpeeds(
+      m_controller.Calculate(m_pose(), m_trajectory.Sample(curTime)));
+
+  if (m_usePID) {
+    auto leftFeedforward = m_feedforward.Calculate(
+        targetWheelSpeeds.left,
+        (targetWheelSpeeds.left - m_prevSpeeds.left) / dt);
+
+    auto rightFeedforward = m_feedforward.Calculate(
+        targetWheelSpeeds.right,
+        (targetWheelSpeeds.right - m_prevSpeeds.right) / dt);
+
+    auto leftOutput = volt_t(m_leftController->Calculate(
+                          m_speeds().left.to<double>(),
+                          targetWheelSpeeds.left.to<double>())) +
+                      leftFeedforward;
+
+    auto rightOutput = volt_t(m_rightController->Calculate(
+                           m_speeds().right.to<double>(),
+                           targetWheelSpeeds.right.to<double>())) +
+                       rightFeedforward;
+
+    m_outputVolts(leftOutput, rightOutput);
+  } else {
+    m_outputVel(targetWheelSpeeds.left, targetWheelSpeeds.right);
+  }
+
+  m_prevTime = curTime;
+  m_prevSpeeds = targetWheelSpeeds;
+}
+
+void LTVUnicycleCommand::End(bool interrupted) { m_timer.Stop(); }
+
+bool LTVUnicycleCommand::IsFinished() {
+  return m_timer.HasElapsed(m_trajectory.TotalTime());
+}

--- a/wpilibNewCommands/src/main/native/include/frc2/command/LTVUnicycleCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/LTVUnicycleCommand.h
@@ -1,0 +1,206 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <functional>
+#include <initializer_list>
+#include <memory>
+
+#include <frc/controller/LTVUnicycleController.h>
+#include <frc/controller/PIDController.h>
+#include <frc/controller/SimpleMotorFeedforward.h>
+#include <frc/geometry/Pose2d.h>
+#include <frc/kinematics/DifferentialDriveKinematics.h>
+#include <frc/trajectory/Trajectory.h>
+#include <units/length.h>
+#include <units/velocity.h>
+#include <units/voltage.h>
+#include <wpi/ArrayRef.h>
+
+#include "frc2/Timer.h"
+#include "frc2/command/CommandBase.h"
+#include "frc2/command/CommandHelper.h"
+
+namespace frc2 {
+/**
+ * A command that uses a LTV (Linear Time-varying) Unicycle controller
+ * to follow a Trajectory with a
+ * differential drive. Like Ramsete, the LTV Unicycle controller calculates the
+ * chassis speed command necessary to follow a trajectory, making it a drop-in
+ * replacement for Ramsete.
+ *
+ * <p>For more on the underlying math behind the controller, read
+ * https://file.tavsys.net/control/state-space-guide.pdf.
+ *
+ * <p>The command handles trajectory-following, PID calculations, and
+ * feedforwards internally.  This is intended to be a more-or-less "complete
+ * solution" that can be used by teams without a great deal of controls
+ * expertise.
+ *
+ * <p>Advanced teams seeking more flexibility (for example, those who wish to
+ * use the onboard PID functionality of a "smart" motor controller) may use the
+ * secondary constructor that omits the PID and feedforward functionality,
+ * returning only the raw wheel speeds from the unicycle controller.
+ *
+ * @see LTVUnicycleContrller
+ * @see Trajectory
+ */
+class LTVUnicycleCommand
+    : public CommandHelper<CommandBase, LTVUnicycleCommand> {
+ public:
+  /**
+   * Constructs a new LTVUnicycleCommand that, when executed, will follow the
+   * provided trajectory. PID control and feedforward are handled internally,
+   * and outputs are scaled -12 to 12 representing units of volts.
+   *
+   * <p>Note: The controller will *not* set the outputVolts to zero upon
+   * completion of the path - this is left to the user, since it is not
+   * appropriate for paths with nonstationary endstates.
+   *
+   * @param trajectory      The trajectory to follow.
+   * @param pose            A function that supplies the robot pose - use one of
+   * the odometry classes to provide this.
+   * @param controller      The LTV Unicycle controller used to follow the
+   * trajectory.
+   * @param feedforward     A component for calculating the feedforward for the
+   * drive.
+   * @param kinematics      The kinematics for the robot drivetrain.
+   * @param wheelSpeeds     A function that supplies the speeds of the left
+   * and right sides of the robot drive.
+   * @param leftController  The PIDController for the left side of the robot
+   * drive.
+   * @param rightController The PIDController for the right side of the robot
+   * drive.
+   * @param output          A function that consumes the computed left and right
+   * outputs (in volts) for the robot drive.
+   * @param requirements    The subsystems to require.
+   */
+  LTVUnicycleCommand(
+      frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
+      frc::LTVUnicycleController controller,
+      frc::SimpleMotorFeedforward<units::meters> feedforward,
+      frc::DifferentialDriveKinematics kinematics,
+      std::function<frc::DifferentialDriveWheelSpeeds()> wheelSpeeds,
+      frc2::PIDController leftController, frc2::PIDController rightController,
+      std::function<void(units::volt_t, units::volt_t)> output,
+      std::initializer_list<Subsystem*> requirements);
+
+  /**
+   * Constructs a new LTVUnicycleCommand that, when executed, will follow the
+   * provided trajectory. PID control and feedforward are handled internally,
+   * and outputs are scaled -12 to 12 representing units of volts.
+   *
+   * <p>Note: The controller will *not* set the outputVolts to zero upon
+   * completion of the path - this is left to the user, since it is not
+   * appropriate for paths with nonstationary endstates.
+   *
+   * @param trajectory      The trajectory to follow.
+   * @param pose            A function that supplies the robot pose - use one of
+   * the odometry classes to provide this.
+   * @param controller      The LTV Unicycle controller used to follow the
+   * trajectory.
+   * @param feedforward     A component for calculating the feedforward for the
+   * drive.
+   * @param kinematics      The kinematics for the robot drivetrain.
+   * @param wheelSpeeds     A function that supplies the speeds of the left
+   * and right sides of the robot drive.
+   * @param leftController  The PIDController for the left side of the robot
+   * drive.
+   * @param rightController The PIDController for the right side of the robot
+   * drive.
+   * @param output          A function that consumes the computed left and right
+   * outputs (in volts) for the robot drive.
+   * @param requirements    The subsystems to require.
+   */
+  LTVUnicycleCommand(
+      frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
+      frc::LTVUnicycleController controller,
+      frc::SimpleMotorFeedforward<units::meters> feedforward,
+      frc::DifferentialDriveKinematics kinematics,
+      std::function<frc::DifferentialDriveWheelSpeeds()> wheelSpeeds,
+      frc2::PIDController leftController, frc2::PIDController rightController,
+      std::function<void(units::volt_t, units::volt_t)> output,
+      wpi::ArrayRef<Subsystem*> requirements = {});
+
+  /**
+   * Constructs a new LTVUnicycleCommand that, when executed, will follow the
+   * provided trajectory. Performs no PID control and calculates no
+   * feedforwards; outputs are the raw wheel speeds from the LTV Unicycle
+   * controller, and will need to be converted into a usable form by the user.
+   *
+   * @param trajectory      The trajectory to follow.
+   * @param pose            A function that supplies the robot pose - use one of
+   * the odometry classes to provide this.
+   * @param controller      The LTV Unicycle controller used to follow the
+   * trajectory.
+   * @param kinematics      The kinematics for the robot drivetrain.
+   * @param output          A function that consumes the computed left and right
+   * wheel speeds.
+   * @param requirements    The subsystems to require.
+   */
+  LTVUnicycleCommand(frc::Trajectory trajectory,
+                     std::function<frc::Pose2d()> pose,
+                     frc::LTVUnicycleController controller,
+                     frc::DifferentialDriveKinematics kinematics,
+                     std::function<void(units::meters_per_second_t,
+                                        units::meters_per_second_t)>
+                         output,
+                     std::initializer_list<Subsystem*> requirements);
+
+  /**
+   * Constructs a new LTVUnicycleCommand that, when executed, will follow the
+   * provided trajectory. Performs no PID control and calculates no
+   * feedforwards; outputs are the raw wheel speeds from the LTVUnicycle
+   * controller, and will need to be converted into a usable form by the user.
+   *
+   * @param trajectory      The trajectory to follow.
+   * @param pose            A function that supplies the robot pose - use one of
+   * the odometry classes to provide this.
+   * @param controller      The LTVUnicycle controller used to follow the
+   * trajectory.
+   * @param kinematics      The kinematics for the robot drivetrain.
+   * @param output          A function that consumes the computed left and right
+   * wheel speeds.
+   * @param requirements    The subsystems to require.
+   */
+  LTVUnicycleCommand(frc::Trajectory trajectory,
+                     std::function<frc::Pose2d()> pose,
+                     frc::LTVUnicycleController controller,
+                     frc::DifferentialDriveKinematics kinematics,
+                     std::function<void(units::meters_per_second_t,
+                                        units::meters_per_second_t)>
+                         output,
+                     wpi::ArrayRef<Subsystem*> requirements = {});
+
+  void Initialize() override;
+
+  void Execute() override;
+
+  void End(bool interrupted) override;
+
+  bool IsFinished() override;
+
+ private:
+  frc::Trajectory m_trajectory;
+  std::function<frc::Pose2d()> m_pose;
+  frc::LTVUnicycleController m_controller;
+  frc::SimpleMotorFeedforward<units::meters> m_feedforward;
+  frc::DifferentialDriveKinematics m_kinematics;
+  std::function<frc::DifferentialDriveWheelSpeeds()> m_speeds;
+  std::unique_ptr<frc2::PIDController> m_leftController;
+  std::unique_ptr<frc2::PIDController> m_rightController;
+  std::function<void(units::volt_t, units::volt_t)> m_outputVolts;
+  std::function<void(units::meters_per_second_t, units::meters_per_second_t)>
+      m_outputVel;
+
+  Timer m_timer;
+  units::second_t m_prevTime;
+  frc::DifferentialDriveWheelSpeeds m_prevSpeeds;
+  bool m_usePID;
+};
+}  // namespace frc2

--- a/wpilibc/src/main/native/cpp/controller/LTVDiffDriveController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/LTVDiffDriveController.cpp
@@ -1,0 +1,197 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/controller/LTVDiffDriveController.h"
+
+#include <cmath>
+
+#include <units/math.h>
+#include <wpi/MathExtras.h>
+#include <wpi/math>
+
+#include "frc/controller/LinearQuadraticRegulator.h"
+#include "frc/system/NumericalJacobian.h"
+
+using namespace frc;
+
+LTVDiffDriveController::LTVDiffDriveController(
+    const LinearSystem<2, 2, 2>& plant,
+    const std::array<double, 5>& controllerQ,
+    const std::array<double, 2>& controllerR,
+    const DifferentialDriveKinematics& kinematics, units::second_t dt)
+    : LTVDiffDriveController(plant, controllerQ, 1.0, controllerR, kinematics,
+                             dt) {}
+
+LTVDiffDriveController::LTVDiffDriveController(
+    const LinearSystem<2, 2, 2>& plant,
+    const std::array<double, 5>& controllerQ, const double rho,
+    const std::array<double, 2>& controllerR,
+    const DifferentialDriveKinematics& kinematics, units::second_t dt)
+    : m_plant(plant),
+      m_rb(kinematics.trackWidth / 2.0),
+      m_kinematics(kinematics) {
+  Reset();
+
+  Vector<10> x0;
+  x0.setZero();
+  x0(State::kLeftVelocity, 0) = 1e-9;
+  x0(State::kRightVelocity, 0) = 1e-9;
+
+  Vector<10> x1;
+  x1.setZero();
+  x1(State::kLeftVelocity, 0) = 1;
+  x1(State::kRightVelocity, 0) = 1;
+
+  Vector<2> u0;
+  u0.setZero();
+
+  Eigen::Matrix<double, 5, 5> A0 =
+      frc::NumericalJacobianX<10, 10, 2>(
+          [this](auto& x, auto& u) { return Dynamics(x, u); }, x0, u0)
+          .block<5, 5>(0, 0);
+  Eigen::Matrix<double, 5, 5> A1 =
+      frc::NumericalJacobianX<10, 10, 2>(
+          [this](auto& x, auto& u) { return Dynamics(x, u); }, x1, u0)
+          .block<5, 5>(0, 0);
+
+  m_B = frc::NumericalJacobianU<10, 10, 2>(
+            [this](auto& x, auto& u) { return Dynamics(x, u); }, x0, u0)
+            .block<5, 2>(0, 0);
+
+  m_K0 = frc::LinearQuadraticRegulator<5, 2>(A0, m_B, controllerQ, rho,
+                                             controllerR, dt)
+             .K();
+  m_K1 = frc::LinearQuadraticRegulator<5, 2>(A1, m_B, controllerQ, rho,
+                                             controllerR, dt)
+             .K();
+}
+
+bool LTVDiffDriveController::AtReference() const {
+  const auto& tolTranslate = m_poseTolerance.Translation();
+  const auto& tolRotate = m_poseTolerance.Rotation();
+  return std::abs(m_stateError(0)) < tolTranslate.X().to<double>() &&
+         std::abs(m_stateError(1)) < tolTranslate.Y().to<double>() &&
+         std::abs(m_stateError(2)) < tolRotate.Radians().to<double>() &&
+         std::abs(m_stateError(3)) < m_velocityTolerance.to<double>() &&
+         std::abs(m_stateError(4)) < m_velocityTolerance.to<double>();
+}
+
+const Vector<5>& LTVDiffDriveController::StateError() const {
+  return m_stateError;
+}
+
+void LTVDiffDriveController::SetTolerance(
+    const Pose2d& poseTolerance, units::meters_per_second_t velocityTolerance) {
+  m_poseTolerance = poseTolerance;
+  m_velocityTolerance = velocityTolerance;
+}
+
+const Vector<5>& LTVDiffDriveController::GetReferences() const {
+  return m_nextR;
+}
+
+const Vector<2>& LTVDiffDriveController::GetInputs() const {
+  return m_uncappedU;
+}
+
+const Vector<2>& LTVDiffDriveController::Calculate(
+    const Vector<5>& currentState, const Vector<5>& stateRef) {
+  m_nextR = stateRef;
+  m_stateError = m_nextR - currentState;
+
+  m_uncappedU = Controller(currentState, m_nextR);
+
+  return m_uncappedU;
+}
+
+const Vector<2>& LTVDiffDriveController::Calculate(
+    const Vector<5>& currentState, const Trajectory::State& desiredState) {
+  DifferentialDriveWheelSpeeds wheelVelocities = m_kinematics.ToWheelSpeeds(
+      ChassisSpeeds{desiredState.velocity, 0_mps,
+                    desiredState.velocity * desiredState.curvature});
+
+  Vector<5> stateRef;
+
+  stateRef << desiredState.pose.Translation().X().to<double>(),
+      desiredState.pose.Translation().Y().to<double>(),
+      desiredState.pose.Rotation().Radians().to<double>(),
+      wheelVelocities.left.to<double>(), wheelVelocities.right.to<double>();
+
+  return Calculate(currentState, stateRef);
+}
+
+void LTVDiffDriveController::Reset() {
+  m_nextR.setZero();
+  m_uncappedU.setZero();
+}
+
+Vector<2> LTVDiffDriveController::Controller(
+    // This implements the linear time-varying differential drive controller in
+    // theorem 8.6.2 of https://tavsys.net/controls-in-frc.
+    const Vector<5>& x, const Vector<5>& r) {
+  double kx = m_K0(0, 0);
+  double ky0 = m_K0(0, 1);
+  double kvpos0 = m_K0(0, 3);
+  double kvneg0 = m_K0(1, 3);
+  double ky1 = m_K1(0, 1);
+  double ktheta1 = m_K1(0, 2);
+  double kvpos1 = m_K1(0, 3);
+
+  double v = (x(State::kLeftVelocity, 0) + x(State::kRightVelocity, 0)) / 2.0;
+  double sqrtAbsV = std::sqrt(std::abs(v));
+
+  Eigen::Matrix<double, 2, 5> K;
+  K(0, 0) = kx;
+  K(0, 1) = (ky0 + (ky1 - ky0) * sqrtAbsV) * wpi::sgn(v);
+  K(0, 2) = ktheta1 * sqrtAbsV;
+  K(0, 3) = kvpos0 + (kvpos1 - kvpos0) * sqrtAbsV;
+  K(0, 4) = kvneg0 - (kvpos1 - kvpos0) * sqrtAbsV;
+  K(1, 0) = kx;
+  K(1, 1) = -K(0, 1);
+  K(1, 2) = -K(0, 2);
+  K(1, 3) = K(0, 4);
+  K(1, 4) = K(0, 3);
+
+  Eigen::Matrix<double, 5, 5> inRobotFrame =
+      Eigen::Matrix<double, 5, 5>::Identity();
+  inRobotFrame(0, 0) = std::cos(x(2, 0));
+  inRobotFrame(0, 1) = std::sin(x(2, 0));
+  inRobotFrame(1, 0) = -std::sin(x(2, 0));
+  inRobotFrame(1, 1) = std::cos(x(2, 0));
+
+  Eigen::Matrix<double, 5, 1> error = r - x.block<5, 1>(0, 0);
+  error(State::kHeading, 0) =
+      units::math::NormalizeAngle(units::radian_t(error(State::kHeading, 0)))
+          .to<double>();
+  return K * inRobotFrame * error;
+}
+
+Vector<10> LTVDiffDriveController::Dynamics(const Vector<10>& x,
+                                            const Vector<2>& u) {
+  Eigen::Matrix<double, 4, 2> B;
+  B.block<2, 2>(0, 0) = m_plant.B();
+  B.block<2, 2>(2, 0).setZero();
+  Eigen::Matrix<double, 4, 7> A;
+  A.block<2, 2>(0, 0) = m_plant.A();
+
+  A.block<2, 2>(2, 0).setIdentity();
+  A.block<4, 2>(0, 2).setZero();
+  A.block<4, 2>(0, 4) = B;
+  A.block<4, 1>(0, 6) << 0, 0, 1, -1;
+
+  double v = (x(State::kLeftVelocity, 0) + x(State::kRightVelocity, 0)) / 2.0;
+
+  Eigen::Matrix<double, 10, 1> result;
+  result(0, 0) = v * std::cos(x(State::kHeading, 0));
+  result(1, 0) = v * std::sin(x(State::kHeading, 0));
+  result(2, 0) = ((x(State::kRightVelocity, 0) - x(State::kLeftVelocity, 0)) /
+                  (2.0 * m_rb))
+                     .to<double>();
+  result.block<4, 1>(3, 0) = A * x.block<7, 1>(3, 0) + B * u;
+  result.block<3, 1>(7, 0).setZero();
+  return result;
+}

--- a/wpilibc/src/main/native/cpp/controller/LTVUnicycleController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/LTVUnicycleController.cpp
@@ -1,0 +1,105 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/controller/LTVUnicycleController.h"
+
+#include <cmath>
+
+#include <wpi/MathExtras.h>
+
+#include "frc/controller/LinearQuadraticRegulator.h"
+
+using namespace frc;
+
+LTVUnicycleController::LTVUnicycleController(
+    const std::array<double, 3>& Qelems, const std::array<double, 2>& Relems,
+    units::second_t dt)
+    : LTVUnicycleController(Qelems, 1.0, Relems, dt) {}
+
+LTVUnicycleController::LTVUnicycleController(
+    const std::array<double, 3>& Qelems, double rho,
+    const std::array<double, 2>& Relems, units::second_t dt) {
+  Eigen::Matrix<double, 3, 3> A0;
+  A0 << 0, 0, 0, 0, 0, 1e-9, 0, 0, 0;
+  Eigen::Matrix<double, 3, 3> A1;
+  A1 << 0, 0, 0, 0, 0, 1, 0, 0, 0;
+  Eigen::Matrix<double, 3, 2> B;
+  B << 1, 0, 0, 0, 0, 1;
+
+  std::array<double, 3> QelemsScaled = Qelems;
+
+  std::transform(QelemsScaled.begin(), QelemsScaled.end(), QelemsScaled.begin(),
+                 [&rho](auto& c) { return c * rho; });
+
+  m_K0 = LinearQuadraticRegulator<3, 2>(A0, B, QelemsScaled, Relems, dt).K();
+  m_K1 = LinearQuadraticRegulator<3, 2>(A1, B, QelemsScaled, Relems, dt).K();
+}
+
+bool LTVUnicycleController::AtReference() const {
+  const auto& eTranslate = m_poseError.Translation();
+  const auto& eRotate = m_poseError.Rotation();
+  const auto& tolTranslate = m_poseTolerance.Translation();
+  const auto& tolRotate = m_poseTolerance.Rotation();
+  return units::math::abs(eTranslate.X()) < tolTranslate.X() &&
+         units::math::abs(eTranslate.Y()) < tolTranslate.Y() &&
+         units::math::abs(eRotate.Radians()) < tolRotate.Radians();
+}
+
+void LTVUnicycleController::SetTolerance(const Pose2d& poseTolerance) {
+  m_poseTolerance = poseTolerance;
+}
+
+ChassisSpeeds LTVUnicycleController::Calculate(
+    const Pose2d& currentPose, const Pose2d& poseRef,
+    units::meters_per_second_t linearVelocityRef,
+    units::radians_per_second_t angularVelocityRef) {
+  Eigen::Matrix<double, 3, 1> x;
+  x(0, 0) = currentPose.Translation().X().to<double>();
+  x(1, 0) = currentPose.Translation().Y().to<double>();
+  x(2, 0) = currentPose.Rotation().Radians().to<double>();
+
+  Eigen::Matrix<double, 3, 1> r;
+  r(0, 0) = poseRef.Translation().X().to<double>();
+  r(1, 0) = poseRef.Translation().Y().to<double>();
+  r(2, 0) = poseRef.Rotation().Radians().to<double>();
+
+  m_poseError = poseRef.RelativeTo(currentPose);
+
+  double kx = m_K0(0, 0);
+  double ky0 = m_K0(1, 1);
+  double ky1 = m_K1(1, 1);
+  double ktheta1 = m_K1(1, 2);
+
+  double v = linearVelocityRef.to<double>();
+  double sqrtAbsV = std::sqrt(std::abs(v));
+
+  Eigen::Matrix<double, 2, 3> K;
+  K(0, 0) = kx;
+  K(0, 1) = 0;
+  K(0, 2) = 0;
+  K(1, 0) = 0;
+  K(1, 1) = (ky0 + (ky1 - ky0) * sqrtAbsV) * wpi::sgn(v);
+  K(1, 2) = ktheta1 * sqrtAbsV;
+
+  Eigen::Matrix<double, 3, 3> inRobotFrame =
+      Eigen::Matrix<double, 3, 3>::Identity();
+  inRobotFrame(0, 0) = std::cos(x(2, 0));
+  inRobotFrame(0, 1) = std::sin(x(2, 0));
+  inRobotFrame(1, 0) = -std::sin(x(2, 0));
+  inRobotFrame(1, 1) = std::cos(x(2, 0));
+  auto u = K * inRobotFrame * (r - x);
+
+  return ChassisSpeeds{
+      linearVelocityRef + units::meters_per_second_t{u(0, 0)}, 0_mps,
+      angularVelocityRef + units::radians_per_second_t{u(1, 0)}};
+}
+
+ChassisSpeeds LTVUnicycleController::Calculate(
+    const Pose2d& currentPose, const Trajectory::State& desiredState) {
+  return Calculate(currentPose, desiredState.pose, desiredState.velocity,
+                   desiredState.velocity * desiredState.curvature);
+}

--- a/wpilibc/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
+++ b/wpilibc/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
@@ -1,0 +1,135 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/estimator/DifferentialDrivePoseEstimator.h"
+
+#include "frc/StateSpaceUtil.h"
+#include "frc2/Timer.h"
+
+using namespace frc;
+
+DifferentialDrivePoseEstimator::DifferentialDrivePoseEstimator(
+    const Rotation2d& gyroAngle, const Pose2d& initialPose,
+    const Vector<5>& stateStdDevs, const Vector<3>& localMeasurementStdDevs,
+    const Vector<3>& visionMeasurmentStdDevs, units::second_t nominalDt)
+    : m_observer(
+          &DifferentialDrivePoseEstimator::F,
+          [](const Vector<5>& x, const Vector<3>& u) {
+            return frc::MakeMatrix<3, 1>(x(3, 0), x(4, 0), x(2, 0));
+          },
+          StdDevMatrixToArray<5>(stateStdDevs),
+          StdDevMatrixToArray<3>(localMeasurementStdDevs), nominalDt),
+      m_nominalDt(nominalDt) {
+  // Create R (covariances) for vision measurements.
+  Eigen::Matrix<double, 3, 3> visionContR =
+      frc::MakeCovMatrix(StdDevMatrixToArray<3>(visionMeasurmentStdDevs));
+  m_visionDiscR = frc::DiscretizeR<3>(visionContR, m_nominalDt);
+
+  // Create correction mechanism for vision measurements.
+  m_visionCorrect = [&](const Vector<3>& u, const Vector<3>& y) {
+    m_observer.Correct<3>(
+        u, y,
+        [](const Vector<5>& x, const Vector<3>&) {
+          return x.block<3, 1>(0, 0);
+        },
+        m_visionDiscR);
+  };
+
+  m_gyroOffset = initialPose.Rotation() - gyroAngle;
+  m_previousAngle = initialPose.Rotation();
+  m_observer.SetXhat(FillStateVector(initialPose, 0_m, 0_m));
+}
+
+void DifferentialDrivePoseEstimator::ResetPosition(
+    const Pose2d& pose, const Rotation2d& gyroAngle) {
+  m_previousAngle = pose.Rotation();
+  m_gyroOffset = GetEstimatedPosition().Rotation() - gyroAngle;
+  m_observer.SetXhat(FillStateVector(pose, 0_m, 0_m));
+}
+
+Pose2d DifferentialDrivePoseEstimator::GetEstimatedPosition() const {
+  return Pose2d(units::meter_t(m_observer.Xhat(0)),
+                units::meter_t(m_observer.Xhat(1)),
+                Rotation2d(units::radian_t(m_observer.Xhat(2))));
+}
+
+void DifferentialDrivePoseEstimator::AddVisionMeasurement(
+    const Pose2d& visionRobotPose, units::second_t timestamp) {
+  m_latencyCompensator.ApplyPastMeasurement<3>(&m_observer, m_nominalDt,
+                                               PoseTo3dVector(visionRobotPose),
+                                               m_visionCorrect, timestamp);
+}
+
+Pose2d DifferentialDrivePoseEstimator::Update(
+    const Rotation2d& gyroAngle,
+    const DifferentialDriveWheelSpeeds& wheelSpeeds,
+    units::meter_t leftDistance, units::meter_t rightDistance) {
+  return UpdateWithTime(frc2::Timer::GetFPGATimestamp(), gyroAngle, wheelSpeeds,
+                        leftDistance, rightDistance);
+}
+
+Pose2d DifferentialDrivePoseEstimator::UpdateWithTime(
+    units::second_t currentTime, const Rotation2d& gyroAngle,
+    const DifferentialDriveWheelSpeeds& wheelSpeeds,
+    units::meter_t leftDistance, units::meter_t rightDistance) {
+  auto dt = m_prevTime >= 0_s ? currentTime - m_prevTime : m_nominalDt;
+  m_prevTime = currentTime;
+
+  auto angle = gyroAngle + m_gyroOffset;
+  auto omega = (gyroAngle - m_previousAngle).Radians() / dt;
+
+  auto u = frc::MakeMatrix<3, 1>(
+      (wheelSpeeds.left + wheelSpeeds.right).to<double>() / 2.0, 0.0,
+      omega.to<double>());
+
+  m_previousAngle = angle;
+
+  auto localY = frc::MakeMatrix<3, 1>(leftDistance.to<double>(),
+                                      rightDistance.to<double>(),
+                                      angle.Radians().to<double>());
+
+  m_latencyCompensator.AddObserverState(m_observer, u, localY, currentTime);
+  m_observer.Predict(u, dt);
+  m_observer.Correct(u, localY);
+
+  return GetEstimatedPosition();
+}
+
+Vector<5> DifferentialDrivePoseEstimator::F(const Vector<5>& x,
+                                            const Vector<3>& u) {
+  // Apply a rotation matrix. Note that we do not add x because Runge-Kutta does
+  // that for us.
+  auto& theta = x(2, 0);
+  Eigen::Matrix<double, 5, 5> toFieldRotation = frc::MakeMatrix<5, 5>(
+      // clang-format off
+    std::cos(theta), -std::sin(theta), 0.0, 0.0, 0.0,
+    std::sin(theta), std::cos(theta), 0.0, 0.0, 0.0,
+    0.0, 0.0, 1.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 1.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 1.0);  // clang-format on
+  return toFieldRotation *
+         frc::MakeMatrix<5, 1>(u(0, 0), u(1, 0), u(2, 0), u(0, 0), u(1, 0));
+}
+
+template <int Dim>
+std::array<double, Dim> DifferentialDrivePoseEstimator::StdDevMatrixToArray(
+    const Vector<Dim>& stdDevs) {
+  std::array<double, Dim> array;
+  for (size_t i = 0; i < Dim; ++i) {
+    array[i] = stdDevs(i);
+  }
+  return array;
+}
+
+Vector<5> DifferentialDrivePoseEstimator::FillStateVector(
+    const Pose2d& pose, units::meter_t leftDistance,
+    units::meter_t rightDistance) {
+  return frc::MakeMatrix<5, 1>(
+      pose.Translation().X().to<double>(), pose.Translation().Y().to<double>(),
+      pose.Rotation().Radians().to<double>(), leftDistance.to<double>(),
+      rightDistance.to<double>());
+}

--- a/wpilibc/src/main/native/cpp/estimator/DifferentialDriveStateEstimator.cpp
+++ b/wpilibc/src/main/native/cpp/estimator/DifferentialDriveStateEstimator.cpp
@@ -1,0 +1,146 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/estimator/DifferentialDriveStateEstimator.h"
+
+#include "frc/StateSpaceUtil.h"
+#include "frc2/Timer.h"
+
+using namespace frc;
+
+DifferentialDriveStateEstimator::DifferentialDriveStateEstimator(
+    const LinearSystem<2, 2, 2>& plant, const Vector<10>& initialState,
+    const Vector<10>& stateStdDevs, const Vector<3>& localMeasurementStdDevs,
+    const Vector<3>& globalMeasurementStdDevs,
+    const DifferentialDriveKinematics& kinematics, units::second_t nominalDt)
+    : m_plant(plant),
+      m_rb(kinematics.trackWidth / 2.0),
+      m_observer([this](auto& x, auto& u) { return Dynamics(x, u); },
+                 &DifferentialDriveStateEstimator::LocalMeasurementModel,
+                 StdDevMatrixToArray<10>(stateStdDevs),
+                 StdDevMatrixToArray<3>(localMeasurementStdDevs), nominalDt),
+      m_nominalDt(nominalDt) {
+  m_localY.setZero();
+  m_globalY.setZero();
+
+  // Create R (covariances) for global measurements.
+  Eigen::Matrix<double, 3, 3> globalContR =
+      frc::MakeCovMatrix(StdDevMatrixToArray<3>(globalMeasurementStdDevs));
+
+  Eigen::Matrix<double, 3, 3> globalDiscR =
+      frc::DiscretizeR<3>(globalContR, m_nominalDt);
+
+  // Create correction mechanism for global measurements.
+  m_globalCorrect = [&](const Vector<2>& u, const Vector<3>& y) {
+    m_observer.Correct<3>(
+        u, y, &DifferentialDriveStateEstimator::GlobalMeasurementModel,
+        globalDiscR);
+  };
+
+  Reset(initialState);
+}
+
+void DifferentialDriveStateEstimator::ApplyPastGlobalMeasurement(
+    const Pose2d& visionRobotPose, units::second_t timestamp) {
+  m_latencyCompensator.ApplyPastMeasurement<3>(&m_observer, m_nominalDt,
+                                               PoseTo3dVector(visionRobotPose),
+                                               m_globalCorrect, timestamp);
+}
+
+Vector<10> DifferentialDriveStateEstimator::GetEstimatedState() const {
+  return m_observer.Xhat();
+}
+
+Vector<10> DifferentialDriveStateEstimator::Update(
+    units::radian_t heading, units::meter_t leftPosition,
+    units::meter_t rightPosition, const Vector<2>& controlInput) {
+  return UpdateWithTime(heading, leftPosition, rightPosition, controlInput,
+                        frc2::Timer::GetFPGATimestamp());
+}
+
+Vector<10> DifferentialDriveStateEstimator::UpdateWithTime(
+    units::radian_t heading, units::meter_t leftPosition,
+    units::meter_t rightPosition, const Vector<2>& controlInput,
+    units::second_t currentTime) {
+  auto dt = m_prevTime >= 0_s ? currentTime - m_prevTime : m_nominalDt;
+  m_prevTime = currentTime;
+
+  m_localY(LocalOutput::kHeading) = heading.to<double>();
+  m_localY(LocalOutput::kLeftPosition) = leftPosition.to<double>();
+  m_localY(LocalOutput::kRightPosition) = rightPosition.to<double>();
+
+  m_latencyCompensator.AddObserverState(m_observer, controlInput, m_localY,
+                                        currentTime);
+
+  m_observer.Predict(controlInput, dt);
+  m_observer.Correct(controlInput, m_localY);
+
+  return GetEstimatedState();
+}
+
+void DifferentialDriveStateEstimator::Reset(const Vector<10>& initialState) {
+  m_observer.Reset();
+
+  m_observer.SetXhat(initialState);
+}
+
+void DifferentialDriveStateEstimator::Reset() { m_observer.Reset(); }
+
+Vector<10> DifferentialDriveStateEstimator::Dynamics(const Vector<10>& x,
+                                                     const Vector<2>& u) {
+  Eigen::Matrix<double, 4, 2> B;
+  B.block<2, 2>(0, 0) = m_plant.B();
+  B.block<2, 2>(2, 0).setZero();
+  Eigen::Matrix<double, 4, 7> A;
+  A.block<2, 2>(0, 0) = m_plant.A();
+
+  A.block<2, 2>(2, 0).setIdentity();
+  A.block<4, 2>(0, 2).setZero();
+  A.block<4, 2>(0, 4) = B;
+  A.block<4, 1>(0, 6) << 0, 0, 1, -1;
+
+  double v = (x(State::kLeftVelocity, 0) + x(State::kRightVelocity, 0)) / 2.0;
+
+  Eigen::Matrix<double, 10, 1> result;
+  result(0, 0) = v * std::cos(x(State::kHeading, 0));
+  result(1, 0) = v * std::sin(x(State::kHeading, 0));
+  result(2, 0) = ((x(State::kRightVelocity, 0) - x(State::kLeftVelocity, 0)) /
+                  (2.0 * m_rb))
+                     .to<double>();
+  result.block<4, 1>(3, 0) = A * x.block<7, 1>(3, 0) + B * u;
+  result.block<3, 1>(7, 0).setZero();
+  return result;
+}
+
+Vector<3> DifferentialDriveStateEstimator::LocalMeasurementModel(
+    const Vector<10>& x, const Vector<2>& u) {
+  static_cast<void>(u);
+
+  Eigen::Matrix<double, 3, 1> y;
+  y << x(State::kHeading, 0), x(State::kLeftPosition, 0),
+      x(State::kRightPosition, 0);
+  return y;
+}
+
+Vector<3> DifferentialDriveStateEstimator::GlobalMeasurementModel(
+    const Vector<10>& x, const Vector<2>& u) {
+  static_cast<void>(u);
+
+  Eigen::Matrix<double, 3, 1> y;
+  y << x(State::kX, 0), x(State::kY, 0), x(State::kHeading, 0);
+  return y;
+}
+
+template <int Dim>
+std::array<double, Dim> DifferentialDriveStateEstimator::StdDevMatrixToArray(
+    const Vector<Dim>& stdDevs) {
+  std::array<double, Dim> array;
+  for (size_t i = 0; i < Dim; ++i) {
+    array[i] = stdDevs(i);
+  }
+  return array;
+}

--- a/wpilibc/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
+++ b/wpilibc/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
@@ -1,0 +1,122 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/estimator/MecanumDrivePoseEstimator.h"
+
+#include <limits>
+
+#include "frc/StateSpaceUtil.h"
+
+using namespace frc;
+
+frc::MecanumDrivePoseEstimator::MecanumDrivePoseEstimator(
+    const Rotation2d& gyroAngle, const Pose2d& initialPose,
+    MecanumDriveKinematics kinematics, const Vector<3>& stateStdDevs,
+    const Vector<1>& localMeasurementStdDevs,
+    const Vector<3>& visionMeasurementStdDevs, units::second_t nominalDt)
+    : m_observer(
+          &MecanumDrivePoseEstimator::F,
+          [](const Vector<4>& x, const Vector<3>& u) {
+            return x.block<2, 1>(2, 0);
+          },
+          StdDevMatrixToArray<4>(frc::MakeMatrix<4, 1>(
+              stateStdDevs(0), stateStdDevs(1), std::cos(stateStdDevs(2)),
+              std::sin(stateStdDevs(2)))),
+          StdDevMatrixToArray<2>(
+              frc::MakeMatrix<2, 1>(std::cos(localMeasurementStdDevs(0)),
+                                    std::sin(localMeasurementStdDevs(0)))),
+          nominalDt),
+      m_kinematics(kinematics),
+      m_nominalDt(nominalDt) {
+  // Construct R (covariances) matrix for vision measurements.
+  Eigen::Matrix4d visionContR =
+      frc::MakeCovMatrix<4>(StdDevMatrixToArray<4>(frc::MakeMatrix<4, 1>(
+          visionMeasurementStdDevs(0), visionMeasurementStdDevs(1),
+          std::cos(visionMeasurementStdDevs(2)),
+          std::sin(visionMeasurementStdDevs(2)))));
+
+  // Create and store discrete covariance matrix for vision measurements.
+  m_visionDiscR = frc::DiscretizeR<4>(visionContR, m_nominalDt);
+
+  // Create vision correction mechanism.
+  m_visionCorrect = [&](const Vector<3>& u, const Vector<4>& y) {
+    m_observer.Correct<4>(
+        u, y, [](const Vector<4>& x, const Vector<3>& u) { return x; },
+        m_visionDiscR);
+  };
+
+  // Set initial state.
+  m_observer.SetXhat(PoseTo4dVector(initialPose));
+
+  // Calculate offsets.
+  m_gyroOffset = initialPose.Rotation() - gyroAngle;
+  m_previousAngle = initialPose.Rotation();
+}
+
+void frc::MecanumDrivePoseEstimator::ResetPosition(
+    const Pose2d& pose, const Rotation2d& gyroAngle) {
+  // Set observer state.
+  m_observer.SetXhat(PoseTo4dVector(pose));
+
+  // Calculate offsets.
+  m_gyroOffset = pose.Rotation() - gyroAngle;
+  m_previousAngle = pose.Rotation();
+}
+
+Pose2d frc::MecanumDrivePoseEstimator::GetEstimatedPosition() const {
+  return Pose2d(m_observer.Xhat(0) * 1_m, m_observer.Xhat(1) * 1_m,
+                Rotation2d(m_observer.Xhat(2), m_observer.Xhat(3)));
+}
+
+void frc::MecanumDrivePoseEstimator::AddVisionMeasurement(
+    const Pose2d& visionRobotPose, units::second_t timestamp) {
+  m_latencyCompensator.ApplyPastMeasurement<4>(&m_observer, m_nominalDt,
+                                               PoseTo4dVector(visionRobotPose),
+                                               m_visionCorrect, timestamp);
+}
+
+Pose2d frc::MecanumDrivePoseEstimator::Update(
+    const Rotation2d& gyroAngle, const MecanumDriveWheelSpeeds& wheelSpeeds) {
+  return UpdateWithTime(frc2::Timer::GetFPGATimestamp(), gyroAngle,
+                        wheelSpeeds);
+}
+
+Pose2d frc::MecanumDrivePoseEstimator::UpdateWithTime(
+    units::second_t currentTime, const Rotation2d& gyroAngle,
+    const MecanumDriveWheelSpeeds& wheelSpeeds) {
+  auto dt = m_prevTime >= 0_s ? currentTime - m_prevTime : m_nominalDt;
+  m_prevTime = currentTime;
+
+  auto angle = gyroAngle + m_gyroOffset;
+  auto omega = (angle - m_previousAngle).Radians() / dt;
+
+  auto chassisSpeeds = m_kinematics.ToChassisSpeeds(wheelSpeeds);
+  auto fieldRelativeVelocities =
+      Translation2d(chassisSpeeds.vx * 1_s, chassisSpeeds.vy * 1_s)
+          .RotateBy(angle);
+
+  auto u = frc::MakeMatrix<3, 1>(fieldRelativeVelocities.X().to<double>(),
+                                 fieldRelativeVelocities.Y().to<double>(),
+                                 omega.to<double>());
+
+  auto localY =
+      frc::MakeMatrix<2, 1>(std::cos(angle.Radians().template to<double>()),
+                            std::sin(angle.Radians().template to<double>()));
+  m_previousAngle = angle;
+
+  m_latencyCompensator.AddObserverState(m_observer, u, localY, currentTime);
+
+  m_observer.Predict(u, dt);
+  m_observer.Correct(u, localY);
+
+  return GetEstimatedPosition();
+}
+
+Vector<4> frc::MecanumDrivePoseEstimator::F(const Vector<4>& x,
+                                            const Vector<3>& u) {
+  return frc::MakeMatrix<4, 1>(u(0), u(1), -x(3) * u(2), x(2) * u(2));
+}

--- a/wpilibc/src/main/native/cpp/simulation/ElevatorSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/ElevatorSim.cpp
@@ -1,0 +1,79 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/simulation/ElevatorSim.h"
+
+#include "frc/StateSpaceUtil.h"
+#include "frc/system/RungeKutta.h"
+#include "frc/system/plant/LinearSystemId.h"
+
+using namespace frc;
+using namespace frc::sim;
+
+ElevatorSim::ElevatorSim(const DCMotor& gearbox, units::kilogram_t carriageMass,
+                         double gearing, units::meter_t drumRadius,
+                         units::meter_t minHeight, units::meter_t maxHeight,
+                         bool addNoise,
+                         const std::array<double, 1>& m_measurementStdDevs)
+    : LinearSystemSim(LinearSystemId::ElevatorSystem(gearbox, carriageMass,
+                                                     drumRadius, gearing),
+                      addNoise, m_measurementStdDevs),
+      m_motor(gearbox),
+      m_drumRadius(drumRadius),
+      m_minHeight(minHeight),
+      m_maxHeight(maxHeight),
+      m_gearing(gearing) {}
+
+bool ElevatorSim::HasHitLowerLimit(const Eigen::Matrix<double, 2, 1>& x) const {
+  return x(0, 0) < m_minHeight.to<double>();
+}
+
+bool ElevatorSim::HasHitUpperLimit(const Eigen::Matrix<double, 2, 1>& x) const {
+  return x(0, 0) > m_maxHeight.to<double>();
+}
+
+units::meter_t ElevatorSim::GetElevatorPosition() const {
+  return units::meter_t(Y()(0, 0));
+}
+
+units::meters_per_second_t ElevatorSim::GetElevatorVelocity() const {
+  return units::meters_per_second_t(m_x(1, 0));
+}
+
+units::ampere_t ElevatorSim::GetCurrentDraw() const {
+  // I = V / R - omega / (Kv * R)
+  // Reductions are greater than 1, so a reduction of 10:1 would mean the motor
+  // is spinning 10x faster than the output.
+
+  // v = r w, so w = v / r
+  units::meters_per_second_t velocity = m_x(1, 0) * 1_mps;
+  units::radians_per_second_t motorVelocity =
+      velocity / m_drumRadius * m_gearing * 1_rad;
+
+  // Perform calculation and return.
+  return units::volt_t(m_u(0, 0)) / m_motor.R -
+         motorVelocity / (m_motor.Kv * m_motor.R);
+}
+
+Eigen::Matrix<double, 2, 1> ElevatorSim::UpdateX(
+    const Eigen::Matrix<double, 2, 1>& currentXhat,
+    const Eigen::Matrix<double, 1, 1>& u, units::second_t dt) {
+  auto updatedXhat = RungeKutta(
+      [&](const Eigen::Matrix<double, 2, 1>& x,
+          const Eigen::Matrix<double, 1, 1>& u_)
+          -> Eigen::Matrix<double, 2, 1> {
+        return m_plant.A() * x + m_plant.B() * u_ + MakeMatrix<2, 1>(0.0, -9.8);
+      },
+      currentXhat, u, dt);
+  // Check for collision after updating x-hat.
+  if (HasHitLowerLimit(updatedXhat)) {
+    return MakeMatrix<2, 1>(m_minHeight.to<double>(), 0.0);
+  } else if (HasHitUpperLimit(updatedXhat)) {
+    return MakeMatrix<2, 1>(m_maxHeight.to<double>(), 0.0);
+  }
+  return updatedXhat;
+}

--- a/wpilibc/src/main/native/cpp/simulation/FlywheelSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/FlywheelSim.cpp
@@ -1,0 +1,38 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/simulation/FlywheelSim.h"
+
+#include "frc/system/plant/LinearSystemId.h"
+
+using namespace frc;
+using namespace frc::sim;
+
+FlywheelSim::FlywheelSim(const LinearSystem<1, 1, 1>& plant,
+                         const DCMotor& gearbox, double gearing, bool addNoise,
+                         const std::array<double, 1>& measurementStdDevs)
+    : LinearSystemSim<1, 1, 1>(plant, addNoise, measurementStdDevs),
+      m_motor(gearbox),
+      m_gearing(gearing) {}
+
+FlywheelSim::FlywheelSim(const DCMotor& gearbox, double gearing,
+                         units::kilogram_square_meter_t moi, bool addNoise,
+                         const std::array<double, 1>& measurementStdDevs)
+    : FlywheelSim(LinearSystemId::FlywheelSystem(gearbox, moi, gearing),
+                  gearbox, gearing, addNoise, measurementStdDevs) {}
+
+units::radians_per_second_t FlywheelSim::GetVelocity() const {
+  return units::radians_per_second_t(Y()(0, 0));
+}
+
+units::ampere_t FlywheelSim::GetCurrentDraw() const {
+  // I = V / R - omega / (Kv * R)
+  // Reductions are greater than 1, so a reduction of 10:1 would mean the motor
+  // is spinning 10x faster than the output.
+  return units::volt_t(m_u(0, 0)) / m_motor.R -
+         GetVelocity() * m_gearing / (m_motor.Kv * m_motor.R);
+}

--- a/wpilibc/src/main/native/cpp/simulation/SingleJointedArmSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/SingleJointedArmSim.cpp
@@ -1,0 +1,91 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/simulation/SingleJointedArmSim.h"
+
+#include <cmath>
+
+#include "frc/system/RungeKutta.h"
+#include "frc/system/plant/LinearSystemId.h"
+
+using namespace frc;
+using namespace frc::sim;
+
+SingleJointedArmSim::SingleJointedArmSim(
+    const LinearSystem<2, 1, 1>& system, units::kilogram_t mass,
+    units::meter_t armLength, units::radian_t minAngle,
+    units::radian_t maxAngle, bool addNoise,
+    const std::array<double, 1>& measurementStdDevs)
+    : LinearSystemSim<2, 1, 1>(system, addNoise, measurementStdDevs),
+      m_r(armLength),
+      m_minAngle(minAngle),
+      m_maxAngle(maxAngle),
+      m_mass(mass) {}
+
+SingleJointedArmSim::SingleJointedArmSim(
+    const DCMotor& motor, units::kilogram_square_meter_t j, double G,
+    units::kilogram_t mass, units::meter_t armLength, units::radian_t minAngle,
+    units::radian_t maxAngle, bool addNoise,
+    const std::array<double, 1>& measurementStdDevs)
+    : SingleJointedArmSim(LinearSystemId::SingleJointedArmSystem(motor, j, G),
+                          mass, armLength, minAngle, maxAngle, addNoise,
+                          measurementStdDevs) {}
+
+SingleJointedArmSim::SingleJointedArmSim(
+    const DCMotor& motor, double G, units::kilogram_t mass,
+    units::meter_t armLength, units::radian_t minAngle,
+    units::radian_t maxAngle, bool addNoise,
+    const std::array<double, 1>& measurementStdDevs)
+    : SingleJointedArmSim(
+          LinearSystemId::SingleJointedArmSystem(
+              motor, 1.0 / 3.0 * mass * armLength * armLength, G),
+          mass, armLength, minAngle, maxAngle, addNoise, measurementStdDevs) {}
+
+bool SingleJointedArmSim::HasHitLowerLimit(
+    const Eigen::Matrix<double, 2, 1>& x) const {
+  return x(0, 0) < m_minAngle.to<double>();
+}
+
+bool SingleJointedArmSim::HasHitUpperLimit(
+    const Eigen::Matrix<double, 2, 1>& x) const {
+  return x(0, 0) > m_maxAngle.to<double>();
+}
+
+units::radian_t SingleJointedArmSim::GetAngle() const {
+  return units::radian_t(m_x(0, 0));
+}
+
+units::radians_per_second_t SingleJointedArmSim::GetVelocity() const {
+  return units::radians_per_second_t(m_x(1, 0));
+}
+
+Eigen::Matrix<double, 2, 1> SingleJointedArmSim::UpdateX(
+    const Eigen::Matrix<double, 2, 1>& currentXhat,
+    const Eigen::Matrix<double, 1, 1>& u, units::second_t dt) {
+  // Horizontal case:
+  // Torque = F * r = I * alpha
+  // alpha = F * r / I
+  // Since F = mg,
+  // alpha = m * g * r / I
+
+  auto updatedXhat = RungeKutta(
+      [&](const auto& x, const auto& u) -> Eigen::Matrix<double, 2, 1> {
+        return m_plant.A() * x + m_plant.B() * u +
+               MakeMatrix<2, 1>(0.0, (m_mass * m_r * -9.8 * 3.0 /
+                                      (m_mass * m_r * m_r) * std::cos(x(0, 0)))
+                                         .template to<double>());
+      },
+      currentXhat, u, dt);
+
+  // Check for collisions.
+  if (HasHitLowerLimit(updatedXhat)) {
+    return MakeMatrix<2, 1>(m_minAngle.to<double>(), 0.0);
+  } else if (HasHitUpperLimit(updatedXhat)) {
+    return MakeMatrix<2, 1>(m_maxAngle.to<double>(), 0.0);
+  }
+  return updatedXhat;
+}

--- a/wpilibc/src/main/native/cpp/simulation/SwerveDriveSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/SwerveDriveSim.cpp
@@ -1,0 +1,57 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/simulation/SwerveDriveSim.h"
+
+#include "frc/StateSpaceUtil.h"
+
+using namespace frc;
+using namespace frc::sim;
+
+SimSwerveModule::SimSwerveModule(const DCMotor& motor, double gearing,
+                                 units::meter_t wheelRadius,
+                                 const Translation2d& position,
+                                 const LinearSystem<2, 1, 1>& azimuthSystem)
+    : m_driveMotor(motor),
+      m_gearing(gearing),
+      m_wheelRadius(wheelRadius),
+      m_position(position),
+      m_azimuthSystem(azimuthSystem) {
+  m_azimuthState = Eigen::Matrix<double, 2, 1>::Zero();
+}
+
+Rotation2d SimSwerveModule::GetAzimuthAngle() const {
+  return Rotation2d{
+      units::math::NormalizeAngle(units::radian_t(m_azimuthState(0, 0)))};
+}
+
+units::newton_t SimSwerveModule::EstimateModuleForce(
+    units::meters_per_second_t wheelVelocity,
+    units::volt_t wheelVoltage) const {
+  // By the elevator equations of motion presented in Controls Engineering in
+  // FRC, F_m = (G Kt)/(R r) Voltage - (G^2 Kt)/(R r^2 Kv) velocity.
+  const auto& G = m_gearing;
+  const auto& r = m_wheelRadius;
+  const auto& m = m_driveMotor;
+
+  units::newton_t a = G * m.Kt / (m.R * r) * wheelVoltage;
+  units::newton_t b =
+      (G * G * m.Kt) / (m.R * r * r * m.Kv) * wheelVelocity * 1_rad;
+
+  return a - b;
+}
+
+Rotation2d SimSwerveModule::Update(units::volt_t azimuthVoltage,
+                                   units::second_t dt) {
+  m_azimuthState = m_azimuthSystem.CalculateX(
+      m_azimuthState, frc::MakeMatrix<1, 1>(azimuthVoltage.to<double>()), dt);
+  return Rotation2d(units::radian_t(m_azimuthState(0, 0)));
+}
+
+const Translation2d& SimSwerveModule::GetModulePosition() const {
+  return m_position;
+}

--- a/wpilibc/src/main/native/include/frc/controller/ControlAffinePlantInversionFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/ControlAffinePlantInversionFeedforward.h
@@ -1,0 +1,198 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+#include <functional>
+
+#include <Eigen/Core>
+#include <units/time.h>
+
+#include "frc/system/NumericalJacobian.h"
+
+namespace frc {
+
+template <int N>
+using Vector = Eigen::Matrix<double, N, 1>;
+
+/**
+ * Constructs a control-affine plant inversion model-based feedforward from
+ * given model dynamics.
+ *
+ * If given the vector valued function as f(x, u) where x is the state
+ * vector and u is the input vector, the B matrix(continuous input matrix)
+ * is calculated through a NumericalJacobian. In this case f has to be
+ * control-affine (of the form f(x) + Bu).
+ *
+ * The feedforward is calculated as
+ * <strong> u_ff = B<sup>+</sup> (rDot - f(x)) </strong>, where <strong>
+ * B<sup>+</sup> </strong> is the pseudoinverse of B.
+ *
+ * This feedforward does not account for a dynamic B matrix, B is either
+ * determined or supplied when the feedforward is created and remains constant.
+ *
+ * For more on the underlying math, read
+ * https://file.tavsys.net/control/controls-engineering-in-frc.pdf.
+ */
+template <int States, int Inputs>
+class ControlAffinePlantInversionFeedforward {
+ public:
+  /**
+   * Constructs a feedforward with given model dynamics as a function
+   * of state and input.
+   *
+   * @param f  A vector-valued function of x, the state, and
+   *           u, the input, that returns the derivative of
+   *           the state vector. HAS to be control-affine
+   *           (of the form f(x) + Bu).
+   * @param dt The timestep between calls of calculate().
+   */
+  ControlAffinePlantInversionFeedforward(
+      std::function<Vector<States>(const Vector<States>&,
+                                   const Vector<Inputs>&)>
+          f,
+      units::second_t dt)
+      : m_dt(dt), m_f(f) {
+    m_B = NumericalJacobianU<States, States, Inputs>(f, Vector<States>::Zero(),
+                                                     Vector<Inputs>::Zero());
+
+    m_r.setZero();
+    Reset(m_r);
+  }
+
+  /**
+   * Constructs a feedforward with given model dynamics as a function of state,
+   * and the plant's B matrix(continuous input matrix).
+   *
+   * @param f  A vector-valued function of x, the state,
+   *           that returns the derivative of the state vector.
+   * @param B  Continuous input matrix of the plant being controlled.
+   * @param dt The timestep between calls of calculate().
+   */
+  ControlAffinePlantInversionFeedforward(
+      std::function<Vector<States>(const Vector<States>&)> f,
+      const Eigen::Matrix<double, States, Inputs>& B, units::second_t dt)
+      : m_B(B), m_dt(dt) {
+    m_f = [=](const Vector<States>& x,
+              const Vector<Inputs>& u) -> Vector<States> { return f(x); };
+
+    m_r.setZero();
+    Reset(m_r);
+  }
+
+  ControlAffinePlantInversionFeedforward(
+      ControlAffinePlantInversionFeedforward&&) = default;
+  ControlAffinePlantInversionFeedforward& operator=(
+      ControlAffinePlantInversionFeedforward&&) = default;
+
+  /**
+   * Returns the previously calculated feedforward as an input vector.
+   *
+   * @return The calculated feedforward.
+   */
+  const Eigen::Matrix<double, Inputs, 1>& Uff() const { return m_uff; }
+
+  /**
+   * Returns an element of the previously calculated feedforward.
+   *
+   * @param row Row of uff.
+   *
+   * @return The row of the calculated feedforward.
+   */
+  double Uff(int i) const { return m_uff(i, 0); }
+
+  /**
+   * Returns the current reference vector r.
+   *
+   * @return The current reference vector.
+   */
+  const Eigen::Matrix<double, States, 1>& R() const { return m_r; }
+
+  /**
+   * Returns an element of the reference vector r.
+   *
+   * @param i Row of r.
+   *
+   * @return The row of the current reference vector.
+   */
+  double R(int i) const { return m_r(i, 0); }
+
+  /**
+   * Resets the feedforward with a specified initial state vector.
+   *
+   * @param initialState The initial state vector.
+   */
+  void Reset(const Eigen::Matrix<double, States, 1>& initialState) {
+    m_r = initialState;
+    m_uff.setZero();
+  }
+
+  /**
+   * Resets the feedforward with a zero initial state vector.
+   */
+  void Reset() {
+    m_r.setZero();
+    m_uff.setZero();
+  }
+
+  /**
+   * Calculate the feedforward with only the desired
+   * future reference. This uses the internally stored "current"
+   * reference.
+   *
+   * If this method is used the initial state of the system is the one
+   * set using Reset(const Eigen::Matrix<double, States, 1>&).
+   * If the initial state is not set it defaults to a zero vector.
+   *
+   * @param nextR The reference state of the future timestep (k + dt).
+   *
+   * @return The calculated feedforward.
+   */
+  Eigen::Matrix<double, Inputs, 1> Calculate(
+      const Eigen::Matrix<double, States, 1>& nextR) {
+    return Calculate(m_r, nextR);
+  }
+
+  /**
+   * Calculate the feedforward with current and future reference vectors.
+   *
+   * @param r     The reference state of the current timestep (k).
+   * @param nextR The reference state of the future timestep (k + dt).
+   *
+   * @return The calculated feedforward.
+   */
+  Eigen::Matrix<double, Inputs, 1> Calculate(
+      const Eigen::Matrix<double, States, 1>& r,
+      const Eigen::Matrix<double, States, 1>& nextR) {
+    Vector<States> rDot = (nextR - r) / m_dt.to<double>();
+
+    m_uff = m_B.householderQr().solve(rDot - m_f(r, Vector<Inputs>::Zero()));
+
+    m_r = nextR;
+    return m_uff;
+  }
+
+ private:
+  Eigen::Matrix<double, States, Inputs> m_B;
+
+  units::second_t m_dt;
+
+  /**
+   * The model dynamics.
+   */
+  std::function<Vector<States>(const Vector<States>&, const Vector<Inputs>&)>
+      m_f;
+
+  // Current reference
+  Vector<States> m_r;
+
+  // Computed feedforward
+  Vector<Inputs> m_uff;
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/LTVDiffDriveController.h
+++ b/wpilibc/src/main/native/include/frc/controller/LTVDiffDriveController.h
@@ -1,0 +1,210 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+
+#include <Eigen/Core>
+#include <units/length.h>
+#include <units/time.h>
+
+#include "frc/geometry/Pose2d.h"
+#include "frc/kinematics/DifferentialDriveKinematics.h"
+#include "frc/system/LinearSystem.h"
+#include "frc/trajectory/Trajectory.h"
+
+namespace frc {
+
+template <int N>
+using Vector = Eigen::Matrix<double, N, 1>;
+
+/**
+ * A Linear Time-Varying Differential Drive Controller for differential drive
+ * robots. This class takes in a LinearSystem of a differential drive,
+ * which can be created from known linear and angular
+ * Kv, and Ka terms with LinearSystemId::IdentifyDrivetrainSystem.
+ * This is then used to calculate the model dynamics #Dynamics.
+ *
+ * This controller is advantageous over the LTVUnicycleController
+ * due to the fact that it is easier to specify the relative weighting of
+ * state vs. input (ex. being able to have the X, Y, Theta controller
+ * have more jurisdiction over the input than the left and right velocity
+ * controller.)
+ *
+ * The current state estimate for the controller can be determined by using
+ * a DifferentialDriveStateEstimator.
+ *
+ * Our state-space system is:
+ *
+ * <strong> x = [[x, y, theta, vel_l, vel_r]]^T </strong> in the field
+ * coordinate system.
+ *
+ * <strong> u = [[voltage_l, voltage_r]]^T </strong> the control input.
+ */
+class LTVDiffDriveController {
+ public:
+  /**
+   * Construct a LTV Unicycle Controller.
+   *
+   * @param plant       A LinearSystem representing a differential
+   * drivetrain.
+   * @param controllerQ The maximum desired error tolerance for the robot's
+   * state, in the form [X, Y, Heading, leftVelocity, right Velocity]^T. Units
+   * are meters and radians for the translation and heading. 1 is a good
+   * starting value.
+   * @param controllerR The maximum desired control effort by the feedback
+   * controller, in the form [voltsLeft, voltsRight]^T. should apply on top of
+   * the trajectory feedforward.
+   * @param kinematics  A DifferentialDriveKinematics object
+   * representing the differential drivetrain's kinematics.
+   * @param dtSeconds   The nominal dt of this controller. With command based
+   * this is 0.020.
+   */
+  LTVDiffDriveController(const LinearSystem<2, 2, 2>& plant,
+                         const std::array<double, 5>& controllerQ,
+                         const std::array<double, 2>& controllerR,
+                         const DifferentialDriveKinematics& kinematics,
+                         units::second_t dt);
+
+  /**
+   * Construct a LTV Unicycle Controller.
+   *
+   * @param plant       A LinearSystem representing a differential
+   * drivetrain.
+   * @param controllerQ The maximum desired error tolerance for the robot's
+   * state, in the form [X, Y, Heading, leftVelocity, right Velocity]^T. Units
+   * are meters and radians for the translation and heading.
+   * @param rho         A weighting factor that balances control effort and
+   * state excursion. Greater values penalize state excursion more heavily. 1 is
+   * a good starting value.
+   * @param controllerR The maximum desired control effort by the feedback
+   * controller, in the form [voltsLeft, voltsRight]^T. should apply on top of
+   * the trajectory feedforward.
+   * @param kinematics  A DifferentialDriveKinematics object
+   * representing the differential drivetrain's kinematics.
+   * @param dtSeconds   The nominal dt of this controller. With command based
+   * this is 0.020.
+   */
+  LTVDiffDriveController(const LinearSystem<2, 2, 2>& plant,
+                         const std::array<double, 5>& controllerQ, double rho,
+                         const std::array<double, 2>& controllerR,
+                         const DifferentialDriveKinematics& kinematics,
+                         units::second_t dt);
+
+  /**
+   * Returns if the controller is at the reference pose on the trajectory.
+   * Note that this is different than if the robot has traversed the entire
+   * trajectory. The tolerance is set by the #SetTolerance method.
+   *
+   * @return If the robot is within the specified tolerances.
+   */
+  bool AtReference() const;
+
+  /**
+   * Set the tolerance for if the robot is #AtReference or not.
+   *
+   * @param poseTolerance The new pose tolerance.
+   * @param velocityTolerance The velocity tolerance.
+   */
+  void SetTolerance(const Pose2d& poseTolerance,
+                    units::meters_per_second_t velocityTolerance);
+
+  /**
+   * Returns the current controller reference in the form
+   * [X, Y, Heading, LeftVelocity, RightVelocity, LeftPosition].
+   *
+   * @return Matrix [5, 1] The reference.
+   */
+  const Vector<5>& GetReferences() const;
+
+  /**
+   * Returns the state error as a Vector.
+   */
+  const Vector<5>& StateError() const;
+
+  /**
+   * Returns the inputs of the controller in the form [LeftVoltage,
+   * RightVoltage].
+   *
+   * @return Matrix[2, 1] The inputs.
+   */
+  const Vector<2>& GetInputs() const;
+
+  /**
+   * Returns the uncapped control input after updating the controller with the
+   * given reference and current states.
+   *
+   * @param currentState  The current state of the robot as a vector.
+   * @param stateRef      The reference state vector.
+   * @return The control input as a matrix with motor voltages [left, right].
+   */
+  const Vector<2>& Calculate(const Vector<5>& currentState,
+                             const Vector<5>& stateRef);
+
+  /**
+   * Returns the next output of the controller.
+   *
+   * <p>The desired state should come from a Trajectory.
+   *
+   * @param currentState  The current state of the robot as a vector.
+   * @param desiredState  The desired pose, linear velocity, and angular
+   * velocity from a trajectory.
+   * @return The control input as a matrix with motor voltages [left, right].
+   */
+  const Vector<2>& Calculate(const Vector<5>& currentState,
+                             const Trajectory::State& desiredState);
+
+  /**
+   * Resets the internal state of the controller.
+   */
+  void Reset();
+
+  Vector<2> Controller(const Vector<5>& x, const Vector<5>& r);
+
+  Vector<10> Dynamics(const Vector<10>& x, const Vector<2>& u);
+
+ private:
+  LinearSystem<2, 2, 2> m_plant;
+  units::meter_t m_rb;
+
+  Vector<5> m_nextR;
+  Vector<2> m_uncappedU;
+
+  Eigen::Matrix<double, 5, 2> m_B;
+  Eigen::Matrix<double, 2, 5> m_K0;
+  Eigen::Matrix<double, 2, 5> m_K1;
+
+  Vector<5> m_stateError;
+
+  Pose2d m_poseTolerance;
+  units::meters_per_second_t m_velocityTolerance;
+
+  DifferentialDriveKinematics m_kinematics;
+
+  class State {
+   public:
+    static constexpr int kX = 0;
+    static constexpr int kY = 1;
+    static constexpr int kHeading = 2;
+    static constexpr int kLeftVelocity = 3;
+    static constexpr int kRightVelocity = 4;
+    static constexpr int kLeftPosition = 5;
+    static constexpr int kRightPosition = 6;
+    static constexpr int kLeftVoltageError = 7;
+    static constexpr int kRightVoltageError = 8;
+    static constexpr int kAngularVelocityError = 9;
+  };
+
+  class Input {
+   public:
+    static constexpr int kLeftVoltage = 0;
+    static constexpr int kRightVoltage = 1;
+  };
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/LTVUnicycleController.h
+++ b/wpilibc/src/main/native/include/frc/controller/LTVUnicycleController.h
@@ -1,0 +1,118 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+
+#include <Eigen/Core>
+#include <units/angular_velocity.h>
+#include <units/time.h>
+#include <units/velocity.h>
+
+#include "frc/geometry/Pose2d.h"
+#include "frc/kinematics/ChassisSpeeds.h"
+#include "frc/trajectory/Trajectory.h"
+
+namespace frc {
+
+/**
+ * A Linear Time-Varying Cascaded Unicycle Controller for differential drive
+ * robots. Similar to RAMSETE, this controller combines feedback and feedforward
+ * to output ChassisSpeeds to guide a robot along a trajectory. However, this
+ * controller utilizes tolerances grounded in reality to pick gains rather than
+ * magical Beta and Zeta gains.
+ */
+class LTVUnicycleController {
+ public:
+  /**
+   * Construct a LTV Unicycle Controller.
+   *
+   * @param qElms     The maximum desired error tolerance for the robot's state,
+   * in the form [X, Y, Heading]^T. Units are meters and radians.
+   * @param rElms     The maximum desired control effort by the feedback
+   * controller, in the form [vMax, wMax]^T. Units are meters per second and
+   *                  radians per second. Note that this is not the maximum
+   * speed of the robot, but rather the maximum effort the feedback controller
+   *                  should apply on top of the trajectory feedforward.
+   * @param dtSeconds The nominal dt of this controller. With command based this
+   * is 0.020.
+   */
+  LTVUnicycleController(const std::array<double, 3>& Qelems,
+                        const std::array<double, 2>& Relems,
+                        units::second_t dt);
+
+  /**
+   * Construct a LTV Unicycle Controller.
+   *
+   * @param qElms     The maximum desired error tolerance for the robot's state,
+   * in the form [X, Y, Heading]^T. Units are meters and radians.
+   * @param rho       A weighting factor that balances control effort and state
+   * excursion. Greater values penalize state excursion more heavily. 1 is a
+   * good starting value.
+   * @param rElms     The maximum desired control effort by the feedback
+   * controller, in the form [vMax, wMax]^T. Units are meters per second and
+   *                  radians per second. Note that this is not the maximum
+   * speed of the robot, but rather the maximum effort the feedback controller
+   *                  should apply on top of the trajectory feedforward.
+   * @param dtSeconds The nominal dt of this controller. With command based this
+   * is 0.020.
+   */
+  LTVUnicycleController(const std::array<double, 3>& Qelems, const double rho,
+                        const std::array<double, 2>& Relems,
+                        units::second_t dt);
+
+  /**
+   * Returns true if the pose error is within tolerance of the reference.
+   */
+  bool AtReference() const;
+
+  /**
+   * Sets the pose error which is considered tolerable for use with
+   * AtReference().
+   *
+   * @param poseTolerance Pose error which is tolerable.
+   */
+  void SetTolerance(const Pose2d& poseTolerance);
+
+  /**
+   * Returns the next output of the LTV Unicycle Controller.
+   *
+   * The reference pose, linear velocity, and angular velocity should come from
+   * a drivetrain trajectory.
+   *
+   * @param currentPose        The current pose.
+   * @param poseRef            The desired pose.
+   * @param linearVelocityRef  The desired linear velocity.
+   * @param angularVelocityRef The desired angular velocity.
+   */
+  ChassisSpeeds Calculate(const Pose2d& currentPose, const Pose2d& poseRef,
+                          units::meters_per_second_t linearVelocityRef,
+                          units::radians_per_second_t angularVelocityRef);
+
+  /**
+   * Returns the next output of the LTV Unicycle Controller.
+   *
+   * The reference pose, linear velocity, and angular velocity should come from
+   * a drivetrain trajectory.
+   *
+   * @param currentPose  The current pose.
+   * @param desiredState The desired pose, linear velocity, and angular velocity
+   *                     from a trajectory.
+   */
+  ChassisSpeeds Calculate(const Pose2d& currentPose,
+                          const Trajectory::State& desiredState);
+
+ private:
+  Eigen::Matrix<double, 2, 3> m_K0;
+  Eigen::Matrix<double, 2, 3> m_K1;
+
+  Pose2d m_poseError;
+  Pose2d m_poseTolerance;
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/controller/LinearPlantInversionFeedforward.h
+++ b/wpilibc/src/main/native/include/frc/controller/LinearPlantInversionFeedforward.h
@@ -1,0 +1,166 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+#include <functional>
+
+#include <Eigen/Core>
+#include <units/time.h>
+
+#include "frc/system/Discretization.h"
+#include "frc/system/LinearSystem.h"
+
+namespace frc {
+
+template <int N>
+using Vector = Eigen::Matrix<double, N, 1>;
+
+/**
+ * Constructs a plant inversion model-based feedforward from a LinearSystem.
+ *
+ * The feedforward is calculated as <strong> u_ff = B<sup>+</sup> (r_k+1 - A
+ * r_k) </strong>, where <strong> B<sup>+</sup> </strong> is the pseudoinverse
+ * of B.
+ *
+ * For more on the underlying math, read
+ * https://file.tavsys.net/control/controls-engineering-in-frc.pdf.
+ */
+template <int States, int Inputs>
+class LinearPlantInversionFeedforward {
+ public:
+  /**
+   * Constructs a feedforward with the given plant.
+   *
+   * @param plant     The plant being controlled.
+   * @param dtSeconds Discretization timestep.
+   */
+  template <int Outputs>
+  LinearPlantInversionFeedforward(
+      const LinearSystem<States, Inputs, Outputs>& plant, units::second_t dt)
+      : LinearPlantInversionFeedforward(plant.A(), plant.B(), dt) {}
+
+  /**
+   * Constructs a feedforward with the given coefficients.
+   *
+   * @param A         Continuous system matrix of the plant being controlled.
+   * @param B         Continuous input matrix of the plant being controlled.
+   * @param dtSeconds Discretization timestep.
+   */
+  LinearPlantInversionFeedforward(
+      const Eigen::Matrix<double, States, States>& A,
+      const Eigen::Matrix<double, States, Inputs>& B, units::second_t dt)
+      : m_dt(dt) {
+    DiscretizeAB<States, Inputs>(A, B, dt, &m_A, &m_B);
+
+    m_r.setZero();
+    Reset(m_r);
+  }
+
+  LinearPlantInversionFeedforward(LinearPlantInversionFeedforward&&) = default;
+  LinearPlantInversionFeedforward& operator=(
+      LinearPlantInversionFeedforward&&) = default;
+
+  /**
+   * Returns the previously calculated feedforward as an input vector.
+   *
+   * @return The calculated feedforward.
+   */
+  const Eigen::Matrix<double, Inputs, 1>& Uff() const { return m_uff; }
+
+  /**
+   * Returns an element of the previously calculated feedforward.
+   *
+   * @param row Row of uff.
+   *
+   * @return The row of the calculated feedforward.
+   */
+  double Uff(int i) const { return m_uff(i, 0); }
+
+  /**
+   * Returns the current reference vector r.
+   *
+   * @return The current reference vector.
+   */
+  const Eigen::Matrix<double, States, 1>& R() const { return m_r; }
+
+  /**
+   * Returns an element of the reference vector r.
+   *
+   * @param i Row of r.
+   *
+   * @return The row of the current reference vector.
+   */
+  double R(int i) const { return m_r(i, 0); }
+
+  /**
+   * Resets the feedforward with a specified initial state vector.
+   *
+   * @param initialState The initial state vector.
+   */
+  void Reset(const Eigen::Matrix<double, States, 1>& initialState) {
+    m_r = initialState;
+    m_uff.setZero();
+  }
+
+  /**
+   * Resets the feedforward with a zero initial state vector.
+   */
+  void Reset() {
+    m_r.setZero();
+    m_uff.setZero();
+  }
+
+  /**
+   * Calculate the feedforward with only the desired
+   * future reference. This uses the internally stored "current"
+   * reference.
+   *
+   * If this method is used the initial state of the system is the one
+   * set using Reset(const Eigen::Matrix<double, States, 1>&).
+   * If the initial state is not set it defaults to a zero vector.
+   *
+   * @param nextR The reference state of the future timestep (k + dt).
+   *
+   * @return The calculated feedforward.
+   */
+  Eigen::Matrix<double, Inputs, 1> Calculate(
+      const Eigen::Matrix<double, States, 1>& nextR) {
+    return Calculate(m_r, nextR);
+  }
+
+  /**
+   * Calculate the feedforward with current and future reference vectors.
+   *
+   * @param r     The reference state of the current timestep (k).
+   * @param nextR The reference state of the future timestep (k + dt).
+   *
+   * @return The calculated feedforward.
+   */
+  Eigen::Matrix<double, Inputs, 1> Calculate(
+      const Eigen::Matrix<double, States, 1>& r,
+      const Eigen::Matrix<double, States, 1>& nextR) {
+    m_uff = m_B.householderQr().solve(nextR - (m_A * r));
+    m_r = nextR;
+    return m_uff;
+  }
+
+ private:
+  Eigen::Matrix<double, States, States> m_A;
+  Eigen::Matrix<double, States, Inputs> m_B;
+
+  units::second_t m_dt;
+
+  // Current reference
+  Vector<States> m_r;
+
+  // Computed feedforward
+  Vector<Inputs> m_uff;
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/estimator/DifferentialDrivePoseEstimator.h
+++ b/wpilibc/src/main/native/include/frc/estimator/DifferentialDrivePoseEstimator.h
@@ -1,0 +1,174 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+
+#include <Eigen/Core>
+#include <units/time.h>
+
+#include "frc/estimator/ExtendedKalmanFilter.h"
+#include "frc/estimator/KalmanFilterLatencyCompensator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/geometry/Rotation2d.h"
+#include "frc/kinematics/DifferentialDriveWheelSpeeds.h"
+
+namespace frc {
+
+template <int N>
+using Vector = Eigen::Matrix<double, N, 1>;
+
+/**
+ * This class wraps an Extended Kalman Filter to fuse latency-compensated
+ * vision measurements with differential drive encoder measurements. It will
+ * correct for noisy vision measurements and encoder drift. It is intended to be
+ * an easy drop-in for DifferentialDriveOdometry. In fact, if you never call
+ * AddVisionMeasurement(), and only call Update(), this will behave exactly the
+ * same as DifferentialDriveOdometry.
+ *
+ * Update() should be called every robot loop (if your robot loops are faster or
+ * slower than the default, then you should change the nominal delta time via
+ * the constructor).
+ *
+ * AddVisionMeasurement() can be called as infrequently as you want; if you
+ * never call it, then this class will behave like regular encoder odometry.
+ *
+ * Our state-space system is:
+ *
+ * <strong> x = [[x, y, theta]]^T </strong> in the field coordinate system.
+ *
+ * <strong> u = [[d_l, d_r, dtheta]]^T </strong> (robot-relative velocities) --
+ * NB: using velocities make things considerably easier, because it means that
+ * teams don't have to worry about getting an accurate model. Basically, we
+ * suspect that it's easier for teams to get good encoder data than it is for
+ * them to perform system identification well enough to get a good model
+ *
+ * <strong> y = [[x, y, theta]]^T </strong>
+ */
+class DifferentialDrivePoseEstimator {
+ public:
+  /**
+   * Constructs a DifferentialDrivePoseEstimator.
+   *
+   * @param gyroAngle                The gyro angle of the robot.
+   * @param initialPose              The estimated initial pose.
+   * @param stateStdDevs             Standard deviations of the model states.
+   *                                 Increase these to trust your wheel speeds
+   *                                 less.
+   * @param localMeasurementStdDevs  Standard deviations of the encoder
+   *                                 measurements. Increase these to trust
+   *                                 encoder distances less.
+   * @param visionMeasurementStdDevs Standard deviations of the vision
+   *                                 measurements. Increase these to trust
+   *                                 vision less.
+   * @param nominalDt                The period of the loop calling Update().
+   */
+  DifferentialDrivePoseEstimator(const Rotation2d& gyroAngle,
+                                 const Pose2d& initialPose,
+                                 const Vector<5>& stateStdDevs,
+                                 const Vector<3>& localMeasurementStdDevs,
+                                 const Vector<3>& visionMeasurementStdDevs,
+                                 units::second_t nominalDt = 0.02_s);
+
+  /**
+   * Resets the robot's position on the field.
+   *
+   * You NEED to reset your encoders to zero when calling this method. The
+   * gyroscope angle does not need to be reset here on the user's robot code.
+   * The library automatically takes care of offsetting the gyro angle.
+   *
+   *@param pose The estimated pose of the robot on the field.
+   *@param gyroAngle The current gyro angle.
+   */
+  void ResetPosition(const Pose2d& pose, const Rotation2d& gyroAngle);
+
+  /**
+   * Returns the pose of the robot at the current time as estimated by the
+   * Extended Kalman Filter.
+   *
+   * @return The estimated robot pose.
+   */
+  Pose2d GetEstimatedPosition() const;
+
+  /**
+   * Adds a vision measurement to the Extended Kalman Filter. This will correct
+   * the odometry pose estimate while still accounting for measurement noise.
+   *
+   * This method can be called as infrequently as you want, as long as you are
+   * calling Update() every loop.
+   *
+   * @param visionRobotPose The pose of the robot as measured by the vision
+   *                        camera.
+   * @param timestamp       The timestamp of the vision measurement in seconds.
+   *                        Note that if you don't use your own time source by
+   *                        calling UpdateWithTime(), then you must use a
+   *                        timestamp with an epoch since FPGA startup (i.e. the
+   *                        epoch of this timestamp is the same epoch as
+   *                        frc2::Timer::GetFPGATimestamp(). This means that
+   *                        you should use frc2::Timer::GetFPGATimestamp() as
+   *                        your time source in this case.
+   */
+  void AddVisionMeasurement(const Pose2d& visionRobotPose,
+                            units::second_t timestamp);
+
+  /**
+   * Updates the Extended Kalman Filter using only wheel encoder information.
+   * Note that this should be called every loop iteration.
+   *
+   * @param gyroAngle     The current gyro angle.
+   * @param leftDistance  The distance traveled by the left encoder.
+   * @param rightDistance The distance traveled by the right encoder.
+   *
+   * @return The estimated pose of the robot.
+   */
+  Pose2d Update(const Rotation2d& gyroAngle,
+                const DifferentialDriveWheelSpeeds& wheelSpeeds,
+                units::meter_t leftDistance, units::meter_t rightDistance);
+
+  /**
+   * Updates the Extended Kalman Filter using only wheel encoder information.
+   * Note that this should be called every loop iteration.
+   *
+   * @param currentTime   The time at which this method was called.
+   * @param gyroAngle     The current gyro angle.
+   * @param leftDistance  The distance traveled by the left encoder.
+   * @param rightDistance The distance traveled by the right encoder.
+   *
+   * @return The estimated pose of the robot.
+   */
+  Pose2d UpdateWithTime(units::second_t currentTime,
+                        const Rotation2d& gyroAngle,
+                        const DifferentialDriveWheelSpeeds& wheelSpeeds,
+                        units::meter_t leftDistance,
+                        units::meter_t rightDistance);
+
+ private:
+  ExtendedKalmanFilter<5, 3, 3> m_observer;
+  KalmanFilterLatencyCompensator<5, 3, 3, ExtendedKalmanFilter<5, 3, 3>>
+      m_latencyCompensator;
+  std::function<void(const Vector<3>& u, const Vector<3>& y)> m_visionCorrect;
+
+  Eigen::Matrix<double, 3, 3> m_visionDiscR;
+
+  units::second_t m_nominalDt;
+  units::second_t m_prevTime = -1_s;
+
+  Rotation2d m_gyroOffset;
+  Rotation2d m_previousAngle;
+
+  template <int Dim>
+  static std::array<double, Dim> StdDevMatrixToArray(
+      const Vector<Dim>& stdDevs);
+
+  static Vector<5> F(const Vector<5>& x, const Vector<3>& u);
+  static Vector<5> FillStateVector(const Pose2d& pose,
+                                   units::meter_t leftDistance,
+                                   units::meter_t rightDistance);
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/estimator/DifferentialDriveStateEstimator.h
+++ b/wpilibc/src/main/native/include/frc/estimator/DifferentialDriveStateEstimator.h
@@ -1,0 +1,229 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+
+#include <Eigen/Core>
+#include <units/angle.h>
+#include <units/length.h>
+#include <units/time.h>
+
+#include "frc/estimator/ExtendedKalmanFilter.h"
+#include "frc/estimator/KalmanFilterLatencyCompensator.h"
+#include "frc/kinematics/DifferentialDriveKinematics.h"
+#include "frc/system/LinearSystem.h"
+
+namespace frc {
+
+template <int N>
+using Vector = Eigen::Matrix<double, N, 1>;
+
+/**
+ * This class wraps an ExtendedKalmanFilter to fuse latency-compensated
+ * global measurements(ex. vision) with differential drive encoder measurements.
+ * It will correct for noisy global measurements and encoder drift.
+ *
+ * This class is indented to be paired with a LTVDiffDriveController as it
+ * provides a 10-state estimate. This can then be trimmed into 5-state
+ * using Eigen::Matrix.block<>() with the operation
+ *
+ *     <10-stateEstimate>.block<5, 1>(0, 0)
+ *
+ * then passed into the controller as the current state estimate.
+ *
+ * DifferentialDriveStateEstimator::Update should be called every
+ * robot loop (if your robot loops are faster than the default then you should
+ * use DifferentialDriveStateEstimator::DifferentialDriveStateEstimator(const
+ * LinearSystem<2, 2, 2>&, const Vector<10>&, const Vector<10>&, const
+ * Vector<3>&, const Vector<3>&, const DifferentialDriveKinematics&,
+ * units::second_t)
+ * to change the nominal delta time.)
+ *
+ * DifferentialDriveStateEstimator::ApplyPastGlobalMeasurement can be
+ * called as infrequently as you want.
+ *
+ * Our state-space system is:
+ *
+ * <strong> x = [[x, y, theta, vel_l, vel_r, dist_l, dist_r, voltError_l,
+ * voltError_r, angularVelError]]^T </strong> in the field coordinate system
+ * (dist_* are wheel distances.)
+ *
+ * <strong> u = [[voltage_l, voltage_r]]^T </strong> This is typically the
+ * control input of the last timestep from a LTVDiffDriveController.
+ *
+ * <strong> y = [[x, y, theta]]^T </strong> from vision, or
+ * <strong> y = [[dist_l, dist_r, theta]] </strong> from encoders and gyro.
+ */
+class DifferentialDriveStateEstimator {
+ public:
+  /**
+   * Constructs a DifferentialDriveStateEstimator.
+   *
+   * @param plant                    A LinearSystem representing a
+   * differential drivetrain.
+   * @param initialState             The starting state estimate.
+   * @param stateStdDevs             Standard deviations of model states.
+   * Increase these numbers to trust your model less.
+   * @param localMeasurementStdDevs  Standard deviations of the encoder and gyro
+   * measurements. Increase these numbers to trust encoder distances and gyro
+   *                                 angle less.
+   * @param globalMeasurementStdDevs Standard deviations of the global(vision)
+   * measurements. Increase these numbers to global(vision) measurements less.
+   * @param kinematics               A link DifferentialDriveKinematics
+   * object representing the differential drivetrain's kinematics.
+   * @param nominalDtSeconds         The time in seconds between each robot
+   * loop.
+   */
+  DifferentialDriveStateEstimator(const LinearSystem<2, 2, 2>& plant,
+                                  const Vector<10>& initialState,
+                                  const Vector<10>& stateStdDevs,
+                                  const Vector<3>& localMeasurementStdDevs,
+                                  const Vector<3>& globalMeasurementStdDevs,
+                                  const DifferentialDriveKinematics& kinematics,
+                                  units::second_t nominalDt = 0.02_s);
+
+  /**
+   * Applies a global measurement with a given timestamp.
+   *
+   * @param robotPoseMeters  The measured robot pose.
+   * @param timestampSeconds The timestamp of the global measurement in seconds.
+   * Note that if you don't use your own time source by calling
+   * DifferentialDriveStateEstimator::updateWithTime then you must use a
+   * timestamp with an epoch since FPGA startup (i.e. the epoch of this
+   * timestamp is the same epoch as Timer::getFPGATimestamp.) This means that
+   * you should use Timer::getFPGATimestamp as your time source in this case.
+   */
+  void ApplyPastGlobalMeasurement(const Pose2d& visionRobotPose,
+                                  units::second_t timestamp);
+
+  /**
+   * Gets the state of the robot at the current time as estimated by the
+   * Extended Kalman Filter.
+   *
+   * @return The robot state estimate.
+   */
+  Vector<10> GetEstimatedState() const;
+
+  /**
+   * Updates the the Extended Kalman Filter using wheel encoder information,
+   * robot heading and the previous control input. The control input can be
+   * obtained from a LTVDiffDriveController.
+   * Note that this should be called every loop.
+   *
+   * @param heading       The current heading of the robot in radians.
+   * @param leftPosition  The distance traveled by the left side of the robot in
+   * meters.
+   * @param rightPosition The distance traveled by the right side of the robot
+   * in meters.
+   * @param controlInput  The control input.
+   * @return The robot state estimate.
+   */
+  Vector<10> Update(units::radian_t heading, units::meter_t leftPosition,
+                    units::meter_t rightPosition,
+                    const Vector<2>& controlInput);
+
+  /**
+   * Updates the the Extended Kalman Filter using wheel encoder information,
+   * robot heading and the previous control input. The control input can be
+   * obtained from a LTVDiffDriveController.
+   * Note that this should be called every loop.
+   *
+   * @param headingRadians     The current heading of the robot in radians.
+   * @param leftPosition       The distance traveled by the left side of the
+   * robot in meters.
+   * @param rightPosition      The distance traveled by the right side of the
+   * robot in meters.
+   * @param controlInput       The control input.
+   * @param currentTimeSeconds Time at which this method was called, in seconds.
+   * @return The robot state estimate.
+   */
+  Vector<10> UpdateWithTime(units::radian_t heading,
+                            units::meter_t leftPosition,
+                            units::meter_t rightPosition,
+                            const Vector<2>& controlInput,
+                            units::second_t currentTime);
+
+  /**
+   * Resets any internal state with a given initial state.
+   *
+   * @param initialState Initial state for state estimate.
+   */
+  void Reset(const Vector<10>& initialState);
+
+  /**
+   * Resets any internal state.
+   */
+  void Reset();
+
+  Vector<10> Dynamics(const Vector<10>& x, const Vector<2>& u);
+
+  static Vector<3> LocalMeasurementModel(const Vector<10>& x,
+                                         const Vector<2>& u);
+
+  static Vector<3> GlobalMeasurementModel(const Vector<10>& x,
+                                          const Vector<2>& u);
+
+ private:
+  LinearSystem<2, 2, 2> m_plant;
+  units::meter_t m_rb;
+
+  ExtendedKalmanFilter<10, 2, 3> m_observer;
+
+  units::second_t m_nominalDt;
+
+  KalmanFilterLatencyCompensator<10, 2, 3, ExtendedKalmanFilter<10, 2, 3>>
+      m_latencyCompensator;
+
+  std::function<void(const Vector<2>& u, const Vector<3>& y)> m_globalCorrect;
+
+  units::second_t m_prevTime = -1_s;
+
+  Vector<3> m_localY;
+  Vector<3> m_globalY;
+
+  template <int Dim>
+  static std::array<double, Dim> StdDevMatrixToArray(
+      const Vector<Dim>& stdDevs);
+
+  class State {
+   public:
+    static constexpr int kX = 0;
+    static constexpr int kY = 1;
+    static constexpr int kHeading = 2;
+    static constexpr int kLeftVelocity = 3;
+    static constexpr int kRightVelocity = 4;
+    static constexpr int kLeftPosition = 5;
+    static constexpr int kRightPosition = 6;
+    static constexpr int kLeftVoltageError = 7;
+    static constexpr int kRightVoltageError = 8;
+    static constexpr int kAngularVelocityError = 9;
+  };
+
+  class Input {
+   public:
+    static constexpr int kLeftVoltage = 0;
+    static constexpr int kRightVoltage = 1;
+  };
+
+  class LocalOutput {
+   public:
+    static constexpr int kHeading = 0;
+    static constexpr int kLeftPosition = 1;
+    static constexpr int kRightPosition = 2;
+  };
+
+  class GlobalOutput {
+   public:
+    static constexpr int kX = 0;
+    static constexpr int kY = 1;
+    static constexpr int kYHeading = 2;
+  };
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/estimator/KalmanFilterLatencyCompensator.h
+++ b/wpilibc/src/main/native/include/frc/estimator/KalmanFilterLatencyCompensator.h
@@ -1,0 +1,145 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Core>
+#include <units/time.h>
+
+namespace frc {
+
+template <int N>
+using Vector = Eigen::Matrix<double, N, 1>;
+
+template <int States, int Inputs, int Outputs, typename KalmanFilterType>
+class KalmanFilterLatencyCompensator {
+ public:
+  struct ObserverSnapshot {
+    Eigen::Matrix<double, States, 1> xHat;
+    Eigen::Matrix<double, States, States> errorCovariances;
+    Eigen::Matrix<double, Inputs, 1> inputs;
+    Eigen::Matrix<double, Outputs, 1> localMeasurements;
+
+    ObserverSnapshot(const KalmanFilterType& observer,
+                     const Eigen::Matrix<double, Inputs, 1>& u,
+                     const Eigen::Matrix<double, Outputs, 1>& localY)
+        : xHat(observer.Xhat()),
+          errorCovariances(observer.P()),
+          inputs(u),
+          localMeasurements(localY) {}
+  };
+
+  void AddObserverState(const KalmanFilterType& observer,
+                        Eigen::Matrix<double, Inputs, 1> u,
+                        Eigen::Matrix<double, Outputs, 1> localY,
+                        units::second_t timestamp) {
+    // Add the new state into the vector.
+    m_pastObserverSnapshots.emplace_back(timestamp,
+                                         ObserverSnapshot{observer, u, localY});
+
+    // Remove the oldest snapshot if the vector exceeds our maximum size.
+    if (m_pastObserverSnapshots.size() > kMaxPastObserverStates) {
+      m_pastObserverSnapshots.erase(m_pastObserverSnapshots.begin());
+    }
+  }
+
+  template <int Rows>
+  void ApplyPastMeasurement(
+      KalmanFilterType* observer, units::second_t nominalDt,
+      Eigen::Matrix<double, Rows, 1> y,
+      std::function<void(const Vector<Inputs>& u, const Vector<Rows>& y)>
+          globalMeasurementCorrect,
+      units::second_t timestamp) {
+    if (m_pastObserverSnapshots.size() == 0) {
+      // State map was empty, which means that we got a measurement right at
+      // startup. The only thing we can do is ignore the measurement.
+      return;
+    }
+
+    // We will perform a binary search to find the index of the element in the
+    // vector that has a timestamp that is equal to or greater than the vision
+    // measurement timestamp.
+
+    // This index starts at one because we use the previous state later on, and
+    // we always want to have a "previous state".
+    int low = 1;
+    int high = m_pastObserverSnapshots.size() - 1;
+
+    while (low != high) {
+      int mid = (low + high) / 2.0;
+      if (m_pastObserverSnapshots[mid].first < timestamp) {
+        // This index and everything under it are less than the requested
+        // timestamp. Therefore, we can discard them.
+        low = mid + 1;
+      } else {
+        // t is at least as large as the element at this index. This means that
+        // anything after it cannot be what we are looking for.
+        high = mid;
+      }
+    }
+
+    // We are simply assigning this index to a new variable to avoid confusion
+    // with variable names.
+    int index = low;
+
+    // High and Low should be the same. The sampled timestamp is greater than or
+    // equal to the vision pose timestamp. We will now find the entry which is
+    // closest in time to the requested timestamp.
+
+    size_t indexOfClosestEntry =
+        units::math::abs(timestamp - m_pastObserverSnapshots[index - 1].first) <
+                units::math::abs(timestamp -
+                                 m_pastObserverSnapshots[index].first)
+            ? index - 1
+            : index;
+
+    units::second_t lastTimestamp =
+        m_pastObserverSnapshots[indexOfClosestEntry].first - nominalDt;
+
+    // We will now go back in time to the state of the system at the time when
+    // the measurement was captured. We will reset the observer to that state,
+    // and apply correction based on the measurement. Then, we will go back
+    // through all observer states until the present and apply past inputs to
+    // get the present estimated state.
+    for (size_t i = indexOfClosestEntry; i < m_pastObserverSnapshots.size();
+         ++i) {
+      auto& [key, snapshot] = m_pastObserverSnapshots[i];
+
+      if (i == indexOfClosestEntry) {
+        observer->SetP(snapshot.errorCovariances);
+        observer->SetXhat(snapshot.xHat);
+      }
+
+      observer->Predict(snapshot.inputs, key - lastTimestamp);
+      observer->Correct(snapshot.inputs, snapshot.localMeasurements);
+
+      if (i == indexOfClosestEntry) {
+        // Note that the measurement is at a timestep close but probably not
+        // exactly equal to the timestep for which we called predict. This makes
+        // the assumption that the dt is small enough that the difference
+        // between the measurement time and the time that the inputs were
+        // captured at is very small.
+        globalMeasurementCorrect(snapshot.inputs, y);
+      }
+
+      lastTimestamp = key;
+      snapshot = ObserverSnapshot{*observer, snapshot.inputs,
+                                  snapshot.localMeasurements};
+    }
+  }
+
+ private:
+  static constexpr size_t kMaxPastObserverStates = 300;
+  std::vector<std::pair<units::second_t, ObserverSnapshot>>
+      m_pastObserverSnapshots;
+};
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/estimator/MecanumDrivePoseEstimator.h
+++ b/wpilibc/src/main/native/include/frc/estimator/MecanumDrivePoseEstimator.h
@@ -1,0 +1,177 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <functional>
+
+#include <Eigen/Core>
+#include <units/time.h>
+
+#include "frc/estimator/ExtendedKalmanFilter.h"
+#include "frc/estimator/KalmanFilterLatencyCompensator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/geometry/Rotation2d.h"
+#include "frc/kinematics/MecanumDriveKinematics.h"
+#include "frc2/Timer.h"
+
+namespace frc {
+
+template <int N>
+using Vector = Eigen::Matrix<double, N, 1>;
+
+/**
+ * This class wraps an ExtendedKalmanFilter to fuse latency-compensated vision
+ * measurements with mecanum drive encoder velocity measurements. It will
+ * correct for noisy measurements and encoder drift. It is intended to be an
+ * easy but more accurate drop-in for MecanumDriveOdometry.
+ *
+ * Update() should be called every robot loop. If your loops are faster or
+ * slower than the default of 0.02s, then you should change the nominal delta
+ * time by specifying it in the constructor.
+ *
+ * AddVisionMeasurement() can be called as infrequently as you want; if you
+ * never call it, then this class will behave mostly like regular encoder
+ * odometry.
+ *
+ * Our state-space system is:
+ *
+ * <strong> x = [[x, y, std::cos(theta), std::sin(theta)]]^T </strong> in the
+ * field-coordinate system.
+ *
+ * <strong> u = [[vx, vy, omega]]^T </strong> in the field-coordinate system.
+ *
+ * <strong> y = [[x, y, std::cos(theta), std::sin(theta)]]^T </strong> in field
+ * coords from vision, or <strong> y = [[cos(theta), std::sin(theta)]]^T
+ * </strong> from the gyro.
+ */
+class MecanumDrivePoseEstimator {
+ public:
+  /**
+   * Constructs a MecanumDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param kinematics               A correctly-configured kinematics object
+   *                                 for your drivetrain.
+   * @param stateStdDevs             Standard deviations of model states.
+   *                                 Increase these numbers to trust your
+   *                                 wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the gyro
+   *                                 measurement. Increase this number
+   *                                 to trust gyro angle measurements less.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder
+   *                                 measurements. Increase these numbers
+   *                                 to trust vision less.
+   * @param nominalDt                The time in seconds between each robot
+   *                                 loop.
+   */
+  MecanumDrivePoseEstimator(const Rotation2d& gyroAngle,
+                            const Pose2d& initialPose,
+                            MecanumDriveKinematics kinematics,
+                            const Vector<3>& stateStdDevs,
+                            const Vector<1>& localMeasurementStdDevs,
+                            const Vector<3>& visionMeasurementStdDevs,
+                            units::second_t nominalDt = 0.02_s);
+
+  /**
+   * Resets the robot's position on the field.
+   *
+   * <p>You NEED to reset your encoders (to zero) when calling this method.
+   *
+   * <p>The gyroscope angle does not need to be reset in the user's robot code.
+   * The library automatically takes care of offsetting the gyro angle.
+   *
+   * @param poseMeters The position on the field that your robot is at.
+   * @param gyroAngle  The angle reported by the gyroscope.
+   */
+  void ResetPosition(const Pose2d& pose, const Rotation2d& gyroAngle);
+
+  /**
+   * Gets the pose of the robot at the current time as estimated by the Extended
+   * Kalman Filter.
+   *
+   * @return The estimated robot pose in meters.
+   */
+  Pose2d GetEstimatedPosition() const;
+
+  /**
+   * Add a vision measurement to the Extended Kalman Filter. This will correct
+   * the odometry pose estimate while still accounting for measurement noise.
+   *
+   * This method can be called as infrequently as you want, as long as you are
+   * calling Update() every loop.
+   *
+   * @param visionRobotPose The pose of the robot as measured by the vision
+   *                        camera.
+   * @param timestamp       The timestamp of the vision measurement in seconds.
+   *                        Note that if you don't use your own time source by
+   *                        calling UpdateWithTime() then you must use a
+   *                        timestamp with an epoch since FPGA startup
+   *                        (i.e. the epoch of this timestamp is the same
+   *                        epoch as Timer#GetFPGATimestamp.) This means
+   *                        that you should use Timer#GetFPGATimestamp as your
+   *                        time source or sync the epochs.
+   */
+  void AddVisionMeasurement(const Pose2d& visionRobotPose,
+                            units::second_t timestamp);
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder
+   * information. This should be called every loop, and the correct loop period
+   * must be passed into the constructor of this class.
+   *
+   * @param gyroAngle   The current gyro angle.
+   * @param wheelSpeeds The current speeds of the mecanum drive wheels.
+   * @return The estimated pose of the robot in meters.
+   */
+  Pose2d Update(const Rotation2d& gyroAngle,
+                const MecanumDriveWheelSpeeds& wheelSpeeds);
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder
+   * information. This should be called every loop, and the correct loop period
+   * must be passed into the constructor of this class.
+   *
+   * @param currentTimeSeconds Time at which this method was called, in seconds.
+   * @param gyroAngle          The current gyroscope angle.
+   * @param wheelSpeeds        The current speeds of the mecanum drive wheels.
+   * @return The estimated pose of the robot in meters.
+   */
+  Pose2d UpdateWithTime(units::second_t currentTime,
+                        const Rotation2d& gyroAngle,
+                        const MecanumDriveWheelSpeeds& wheelSpeeds);
+
+ private:
+  ExtendedKalmanFilter<4, 3, 2> m_observer;
+  MecanumDriveKinematics m_kinematics;
+  KalmanFilterLatencyCompensator<4, 3, 2, ExtendedKalmanFilter<4, 3, 2>>
+      m_latencyCompensator;
+  std::function<void(const Vector<3>& u, const Vector<4>& y)> m_visionCorrect;
+
+  Eigen::Matrix4d m_visionDiscR;
+
+  units::second_t m_nominalDt;
+  units::second_t m_prevTime = -1_s;
+
+  Rotation2d m_gyroOffset;
+  Rotation2d m_previousAngle;
+
+  static Vector<4> F(const Vector<4>& x, const Vector<3>& u);
+
+  template <int Dim>
+  static std::array<double, Dim> StdDevMatrixToArray(
+      const Vector<Dim>& vector) {
+    std::array<double, Dim> array;
+    for (size_t i = 0; i < Dim; ++i) {
+      array[i] = vector(i);
+    }
+    return array;
+  }
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
+++ b/wpilibc/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
@@ -1,0 +1,269 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+#include <iostream>
+#include <limits>
+
+#include <Eigen/Core>
+#include <units/time.h>
+
+#include "frc/StateSpaceUtil.h"
+#include "frc/estimator/ExtendedKalmanFilter.h"
+#include "frc/estimator/KalmanFilterLatencyCompensator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/geometry/Rotation2d.h"
+#include "frc/kinematics/SwerveDriveKinematics.h"
+#include "frc2/Timer.h"
+
+namespace frc {
+
+template <int N>
+using Vector = Eigen::Matrix<double, N, 1>;
+
+/**
+ * This class wraps an ExtendedKalmanFilter to fuse latency-compensated vision
+ * measurements with swerve drive encoder velocity measurements. It will correct
+ * for noisy measurements and encoder drift. It is intended to be an easy but
+ * more accurate drop-in for SwerveDriveOdometry.
+ *
+ * Update() should be called every robot loop. If your loops are faster or
+ * slower than the default of 0.02s, then you should change the nominal delta
+ * time by specifying it in the constructor.
+ *
+ * AddVisionMeasurement() can be called as infrequently as you want; if you
+ * never call it, then this class will behave mostly like regular encoder
+ * odometry.
+ *
+ * Our state-space system is:
+ *
+ * <strong> x = [[x, y, std::cos(theta), std::sin(theta)]]^T </strong> in the
+ * field-coordinate system.
+ *
+ * <strong> u = [[vx, vy, omega]]^T </strong> in the field-coordinate system.
+ *
+ * <strong> y = [[x, y, std::cos(theta), std::sin(theta)]]^T </strong> in field
+ * coords from vision, or <strong> y = [[cos(theta), std::sin(theta)]]^T
+ * </strong> from the gyro.
+ */
+template <size_t NumModules>
+class SwerveDrivePoseEstimator {
+ public:
+  /**
+   * Constructs a SwerveDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param kinematics               A correctly-configured kinematics object
+   *                                 for your drivetrain.
+   * @param stateStdDevs             Standard deviations of model states.
+   *                                 Increase these numbers to trust your
+   *                                 wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the gyro
+   *                                 measurement. Increase this number to
+   *                                 trust gyro angle measurements less.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder
+   *                                 measurements. Increase these numbers to
+   *                                 trust vision less.
+   * @param nominalDt                The time in seconds between each robot
+   *                                 loop.
+   */
+  SwerveDrivePoseEstimator(const Rotation2d& gyroAngle,
+                           const Pose2d& initialPose,
+                           SwerveDriveKinematics<NumModules>& kinematics,
+                           const Vector<3>& stateStdDevs,
+                           const Vector<1>& localMeasurementStdDevs,
+                           const Vector<3>& visionMeasurementStdDevs,
+                           units::second_t nominalDt = 0.02_s)
+      : m_observer(
+            &SwerveDrivePoseEstimator::F,
+            [](const Vector<4>& x, const Vector<3>& u) {
+              return x.block<2, 1>(2, 0);
+            },
+            StdDevMatrixToArray<4>(frc::MakeMatrix<4, 1>(
+                stateStdDevs(0), stateStdDevs(1), std::cos(stateStdDevs(2)),
+                std::sin(stateStdDevs(2)))),
+            StdDevMatrixToArray<2>(
+                frc::MakeMatrix<2, 1>(std::cos(localMeasurementStdDevs(0)),
+                                      std::sin(localMeasurementStdDevs(0)))),
+            nominalDt),
+        m_kinematics(kinematics),
+        m_nominalDt(nominalDt) {
+    // Construct R (covariances) matrix for vision measurements.
+    Eigen::Matrix4d visionContR =
+        frc::MakeCovMatrix<4>(StdDevMatrixToArray<4>(frc::MakeMatrix<4, 1>(
+            visionMeasurementStdDevs(0), visionMeasurementStdDevs(1),
+            std::cos(visionMeasurementStdDevs(2)),
+            std::sin(visionMeasurementStdDevs(2)))));
+
+    // Create and store discrete covariance matrix for vision measurements.
+    m_visionDiscR = frc::DiscretizeR<4>(visionContR, m_nominalDt);
+
+    // Create correction mechanism for vision measurements.
+    m_visionCorrect = [&](const Vector<3>& u, const Vector<4>& y) {
+      m_observer.Correct<4>(
+          u, y, [](const Vector<4>& x, const Vector<3>& u) { return x; },
+          m_visionDiscR);
+    };
+
+    // Set initial state.
+    m_observer.SetXhat(PoseTo4dVector(initialPose));
+
+    // Calculate offsets.
+    m_gyroOffset = initialPose.Rotation() - gyroAngle;
+    m_previousAngle = initialPose.Rotation();
+  }
+
+  /**
+   * Resets the robot's position on the field.
+   *
+   * You NEED to reset your encoders (to zero) when calling this method.
+   *
+   * The gyroscope angle does not need to be reset in the user's robot code.
+   * The library automatically takes care of offsetting the gyro angle.
+   *
+   * @param pose      The position on the field that your robot is at.
+   * @param gyroAngle The angle reported by the gyroscope.
+   */
+  void ResetPosition(const Pose2d& pose, const Rotation2d& gyroAngle) {
+    // Set observer state.
+    m_observer.SetXhat(PoseTo4dVector(pose));
+
+    // Calculate offsets.
+    m_gyroOffset = pose.Rotation() - gyroAngle;
+    m_previousAngle = pose.Rotation();
+  }
+
+  /**
+   * Gets the pose of the robot at the current time as estimated by the Extended
+   * Kalman Filter.
+   *
+   * @return The estimated robot pose in meters.
+   */
+  Pose2d GetEstimatedPosition() const {
+    return Pose2d(m_observer.Xhat(0) * 1_m, m_observer.Xhat(1) * 1_m,
+                  Rotation2d(m_observer.Xhat(2), m_observer.Xhat(3)));
+  }
+
+  /**
+   * Add a vision measurement to the Extended Kalman Filter. This will correct
+   * the odometry pose estimate while still accounting for measurement noise.
+   *
+   * This method can be called as infrequently as you want, as long as you are
+   * calling Update() every loop.
+   *
+   * @param visionRobotPose The pose of the robot as measured by the vision
+   *                        camera.
+   * @param timestamp       The timestamp of the vision measurement in seconds.
+   *                        Note that if you don't use your own time source by
+   *                        calling UpdateWithTime() then you must use a
+   *                        timestamp with an epoch since FPGA startup
+   *                        (i.e. the epoch of this timestamp is the same
+   *                        epoch as Timer#GetFPGATimestamp.) This means
+   *                        that you should use Timer#GetFPGATimestamp as your
+   *                        time source or sync the epochs.
+   */
+  void AddVisionMeasurement(const Pose2d& visionRobotPose,
+                            units::second_t timestamp) {
+    m_latencyCompensator.ApplyPastMeasurement<4>(
+        &m_observer, m_nominalDt, PoseTo4dVector(visionRobotPose),
+        m_visionCorrect, timestamp);
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder
+   * information. This should be called every loop, and the correct loop period
+   * must be passed into the constructor of this class.
+   *
+   * @param gyroAngle    The current gyro angle.
+   * @param moduleStates The current velocities and rotations of the swerve
+   *                     modules.
+   * @return The estimated pose of the robot in meters.
+   */
+  template <typename... ModuleState>
+  Pose2d Update(const Rotation2d& gyroAngle, ModuleState&&... moduleStates) {
+    return UpdateWithTime(frc2::Timer::GetFPGATimestamp(), gyroAngle,
+                          moduleStates...);
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder
+   * information. This should be called every loop, and the correct loop period
+   * must be passed into the constructor of this class.
+   *
+   * @param currentTime  Time at which this method was called, in seconds.
+   * @param gyroAngle    The current gyroscope angle.
+   * @param moduleStates The current velocities and rotations of the swerve
+   *                     modules.
+   * @return The estimated pose of the robot in meters.
+   */
+  template <typename... ModuleState>
+  Pose2d UpdateWithTime(units::second_t currentTime,
+                        const Rotation2d& gyroAngle,
+                        ModuleState&&... moduleStates) {
+    auto dt = m_prevTime >= 0_s ? currentTime - m_prevTime : m_nominalDt;
+    m_prevTime = currentTime;
+
+    auto angle = gyroAngle + m_gyroOffset;
+    auto omega = (angle - m_previousAngle).Radians() / dt;
+
+    auto chassisSpeeds = m_kinematics.ToChassisSpeeds(moduleStates...);
+    auto fieldRelativeSpeeds =
+        Translation2d(chassisSpeeds.vx * 1_s, chassisSpeeds.vy * 1_s)
+            .RotateBy(angle);
+
+    auto u =
+        frc::MakeMatrix<3, 1>(fieldRelativeSpeeds.X().template to<double>(),
+                              fieldRelativeSpeeds.Y().template to<double>(),
+                              omega.template to<double>());
+
+    auto localY =
+        frc::MakeMatrix<2, 1>(std::cos(angle.Radians().template to<double>()),
+                              std::sin(angle.Radians().template to<double>()));
+    m_previousAngle = angle;
+
+    m_latencyCompensator.AddObserverState(m_observer, u, localY, currentTime);
+
+    m_observer.Predict(u, dt);
+    m_observer.Correct(u, localY);
+
+    return GetEstimatedPosition();
+  }
+
+ private:
+  ExtendedKalmanFilter<4, 3, 2> m_observer;
+  SwerveDriveKinematics<NumModules>& m_kinematics;
+  KalmanFilterLatencyCompensator<4, 3, 2, ExtendedKalmanFilter<4, 3, 2>>
+      m_latencyCompensator;
+  std::function<void(const Vector<3>& u, const Vector<4>& y)> m_visionCorrect;
+
+  Eigen::Matrix4d m_visionDiscR;
+
+  units::second_t m_nominalDt;
+  units::second_t m_prevTime = -1_s;
+
+  Rotation2d m_gyroOffset;
+  Rotation2d m_previousAngle;
+
+  static Vector<4> F(const Vector<4>& x, const Vector<3>& u) {
+    return frc::MakeMatrix<4, 1>(u(0), u(1), -x(3) * u(2), x(2) * u(2));
+  }
+
+  template <int Dim>
+  static std::array<double, Dim> StdDevMatrixToArray(
+      const Vector<Dim>& vector) {
+    std::array<double, Dim> array;
+    for (size_t i = 0; i < Dim; ++i) {
+      array[i] = vector(i);
+    }
+    return array;
+  }
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/simulation/ElevatorSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/ElevatorSim.h
@@ -1,0 +1,102 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+
+#include <units/length.h>
+#include <units/mass.h>
+#include <units/velocity.h>
+
+#include "frc/simulation/LinearSystemSim.h"
+#include "frc/system/plant/DCMotor.h"
+
+namespace frc {
+namespace sim {
+/**
+ * Represents a simulated elevator mechanism.
+ */
+class ElevatorSim : public LinearSystemSim<2, 1, 1> {
+ public:
+  /**
+   * Constructs a simulated elevator mechanism.
+   *
+   * @param gearbox            The type of and number of motors in your elevator
+   *                           gearbox.
+   * @param carriageMass       The mass of the elevator carriage.
+   * @param gearing            The gearing of the elevator (numbers greater than
+   *                           1 represent reductions).
+   * @param drumRadius         The radius of the drum that your cable is wrapped
+   *                           around.
+   * @param minHeight          The minimum allowed height of the elevator.
+   * @param maxHeight          The maximum allowed height of the elevator.
+   * @param addNoise           Whether the sim should automatically add some
+   *                           encoder noise.
+   * @param measurementStdDevs The standard deviation of the measurement noise.
+   */
+  ElevatorSim(const DCMotor& gearbox, units::kilogram_t carriageMass,
+              double gearing, units::meter_t drumRadius,
+              units::meter_t minHeight, units::meter_t maxHeight,
+              bool addNoise = false,
+              const std::array<double, 1>& m_measurementStdDevs = {0.0});
+
+  /**
+   * Returns whether the elevator has hit the lower limit.
+   *
+   * @param x The current elevator state.
+   * @return Whether the elevator has hit the lower limit.
+   */
+  bool HasHitLowerLimit(const Eigen::Matrix<double, 2, 1>& x) const;
+
+  /**
+   * Returns whether the elevator has hit the upper limit.
+   *
+   * @param x The current elevator state.
+   * @return Whether the elevator has hit the uppwer limit.
+   */
+  bool HasHitUpperLimit(const Eigen::Matrix<double, 2, 1>& x) const;
+
+  /**
+   * Returns the position of the elevator.
+   * @return The position of the elevator.
+   */
+  units::meter_t GetElevatorPosition() const;
+
+  /**
+   * Returns the velocity of the elevator.
+   * @return The velocity of the elevator.
+   */
+  units::meters_per_second_t GetElevatorVelocity() const;
+
+  /**
+   * Returns the elevator current draw.
+   * @return The elevator current draw.
+   */
+  units::ampere_t GetCurrentDraw() const override;
+
+ protected:
+  /**
+   * Updates the state estimate of the elevator.
+   *
+   * @param currentXhat The current state estimate.
+   * @param u           The system inputs (voltage).
+   * @param dt          The time difference between controller updates.
+   */
+  Eigen::Matrix<double, 2, 1> UpdateX(
+      const Eigen::Matrix<double, 2, 1>& currentXhat,
+      const Eigen::Matrix<double, 1, 1>& u, units::second_t dt) override;
+
+ private:
+  DCMotor m_motor;
+  units::meter_t m_drumRadius;
+  units::meter_t m_minHeight;
+  units::meter_t m_maxHeight;
+  double m_gearing;
+};
+}  // namespace sim
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/simulation/FlywheelSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/FlywheelSim.h
@@ -1,0 +1,73 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <units/angular_velocity.h>
+#include <units/moment_of_inertia.h>
+
+#include "frc/simulation/LinearSystemSim.h"
+#include "frc/system/LinearSystem.h"
+#include "frc/system/plant/DCMotor.h"
+
+namespace frc {
+namespace sim {
+/**
+ * Represents a simulated flywheel mechanism.
+ */
+class FlywheelSim : public LinearSystemSim<1, 1, 1> {
+ public:
+  /**
+   * Creates a simulated flywhel mechanism.
+   *
+   * @param plant              The linear system representing the flywheel.
+   * @param gearbox            The type of and number of motors in the flywheel
+   *                           gearbox.
+   * @param gearing            The gearing of the flywheel (numbers greater than
+   *                           1 represent reductions).
+   * @param addNoise           Whether the sim should automatically add some
+   *                           encoder noise.
+   * @param measurementStdDevs The standard deviation of the measurement noise.
+   */
+  FlywheelSim(const LinearSystem<1, 1, 1>& plant, const DCMotor& gearbox,
+              double gearing, bool addNoise = false,
+              const std::array<double, 1>& measurementStdDevs = {0.0});
+
+  /**
+   * Creates a simulated flywhel mechanism.
+   *
+   * @param gearbox            The type of and number of motors in the flywheel
+   *                           gearbox.
+   * @param gearing            The gearing of the flywheel (numbers greater than
+   *                           1 represent reductions).
+   * @param moi                The moment of inertia of the flywheel.
+   * @param addNoise           Whether the sim should automatically add some
+   *                           encoder noise.
+   * @param measurementStdDevs The standard deviation of the measurement noise.
+   */
+  FlywheelSim(const DCMotor& gearbox, double gearing,
+              units::kilogram_square_meter_t moi, bool addNoise = false,
+              const std::array<double, 1>& measurementStdDevs = {0.0});
+
+  /**
+   * Returns the flywheel velocity.
+   * @return The flywheel velocity.
+   */
+  units::radians_per_second_t GetVelocity() const;
+
+  /**
+   * Returns the flywheel current draw.
+   * @return The flywheel current draw.
+   */
+  units::ampere_t GetCurrentDraw() const override;
+
+ private:
+  DCMotor m_motor;
+  double m_gearing;
+};
+}  // namespace sim
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/simulation/LinearSystemSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/LinearSystemSim.h
@@ -1,0 +1,124 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+
+#include <Eigen/Core>
+#include <units/current.h>
+#include <units/time.h>
+
+#include "frc/StateSpaceUtil.h"
+#include "frc/system/LinearSystem.h"
+
+namespace frc {
+namespace sim {
+/**
+ * Represents a simulated generic linear system.
+ */
+template <int States, int Inputs, int Outputs>
+class LinearSystemSim {
+ public:
+  /**
+   * Creates a simulated generic linear system.
+   *
+   * @param system             The system to simulate.
+   * @param addNoise           Whether the sim should automatically add some
+   *                           measurement noise.
+   * @param measurementStdDevs The standard deviations of the measurement noise.
+   */
+  LinearSystemSim(const LinearSystem<States, Inputs, Outputs>& system,
+                  bool addNoise = false,
+                  const std::array<double, Outputs>& measurementStdDevs = {0.0})
+      : m_plant(system),
+        m_shouldAddNoise(addNoise),
+        m_measurementStdDevs(measurementStdDevs) {
+    m_x = Eigen::Matrix<double, States, 1>::Zero();
+    m_y = Eigen::Matrix<double, Outputs, 1>::Zero();
+    m_u = Eigen::Matrix<double, Inputs, 1>::Zero();
+  }
+
+  /**
+   * Returns whether the sim should add noise to the measurements.
+   * @return Whether the sim should add noise to the measurements.
+   */
+  bool ShouldAddNoise() const { return m_shouldAddNoise; }
+
+  /**
+   * Returns the current output of the plant.
+   * @return The current output of the plant.
+   */
+  const Eigen::Matrix<double, Outputs, 1>& Y() const { return m_y; }
+
+  /**
+   * Sets whether the sim should add noise to measurements.
+   * @param shouldAddNoise Whether the sim should add noise to measurements.
+   */
+  void SetShouldAddNoise(bool shouldAddNoise) {
+    m_shouldAddNoise = shouldAddNoise;
+  }
+
+  /**
+   * Updates the linear system sim.
+   * @param dt The time between updates.
+   */
+  void Update(units::second_t dt) {
+    // Update X. By default, this is the linear system dynamics X = Ax + Bu
+    m_x = UpdateX(m_x, m_u, dt);
+
+    // y = Cx + Du
+    m_y = m_plant.CalculateY(m_x, m_u);
+
+    // Add noise if needed.
+    if (m_shouldAddNoise) {
+      m_y += frc::MakeWhiteNoiseVector<Outputs>(m_measurementStdDevs);
+    }
+  }
+
+  /**
+   * Sets the system inputs (usually voltages).
+   * @param u The system inputs.
+   */
+  void SetInput(const Eigen::Matrix<double, Inputs, 1>& u) { m_u = u; }
+
+  /**
+   * Resets the system state.
+   * @param state The state to reset to.
+   */
+  void ResetState(const Eigen::Matrix<double, States, 1>& state) {
+    m_x = state;
+  }
+
+ protected:
+  /**
+   * Updates the state estimate of the system.
+   *
+   * @param currentXhat The current state estimate.
+   * @param u           The system inputs (usually voltage).
+   * @param dt          The time difference between controller updates.
+   */
+  virtual Eigen::Matrix<double, States, 1> UpdateX(
+      const Eigen::Matrix<double, States, 1>& currentXhat,
+      const Eigen::Matrix<double, Inputs, 1>& u, units::second_t dt) {
+    return m_plant.CalculateX(currentXhat, u, dt);
+  }
+
+  virtual units::ampere_t GetCurrentDraw() const {
+    return units::ampere_t(0.0);
+  }
+
+  LinearSystem<States, Inputs, Outputs> m_plant;
+  bool m_shouldAddNoise;
+
+  Eigen::Matrix<double, States, 1> m_x;
+  Eigen::Matrix<double, Outputs, 1> m_y;
+  Eigen::Matrix<double, Inputs, 1> m_u;
+  std::array<double, Outputs> m_measurementStdDevs;
+};
+}  // namespace sim
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/simulation/SimBattery.h
+++ b/wpilibc/src/main/native/include/frc/simulation/SimBattery.h
@@ -1,0 +1,58 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <numeric>
+
+#include <units/current.h>
+#include <units/impedance.h>
+#include <units/voltage.h>
+
+namespace frc {
+
+namespace sim {
+
+class SimBattery {
+ public:
+  /**
+   * Calculate the loaded battery voltage. Use this with
+   * {@link RoboRioSim#setVInVoltage(double)} to set the simulated battery
+   * voltage, which can then be retrieved with the {@link
+   * RobotController#getBatteryVoltage()} method.
+   *
+   * @param nominalVoltage The nominal battery voltage. Usually 12v.
+   * @param resistance The forward resistance of the battery. Most batteries
+   * are at or below 20 milliohms.
+   * @param currents       The currents drawn from the battery.
+   * @return The battery's voltage under load.
+   */
+  static units::volt_t Calculate(
+      units::volt_t nominalVoltage, units::ohm_t resistance,
+      std::initializer_list<units::ampere_t> currents) {
+    return nominalVoltage -
+           std::accumulate(currents.begin(), currents.end(), 0_A) * resistance;
+  }
+
+  /**
+   * Calculate the loaded battery voltage. Use this with
+   * {@link RoboRioSim#setVInVoltage(double)} to set the simulated battery
+   * voltage, which can then be retrieved with the {@link
+   * RobotController#getBatteryVoltage()} method. This function assumes a
+   * nominal voltage of 12v and a resistance of 20 milliohms (0.020 ohms)
+   *
+   * @param currents The currents drawn from the battery.
+   * @return The battery's voltage under load.
+   */
+  static units::volt_t Calculate(
+      std::initializer_list<units::ampere_t> currents) {
+    return Calculate(12_V, 0.02_Ohm, currents);
+  }
+};
+
+}  // namespace sim
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/simulation/SimDifferentialDrivetrain.h
+++ b/wpilibc/src/main/native/include/frc/simulation/SimDifferentialDrivetrain.h
@@ -1,0 +1,16 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+namespace frc {
+namespace sim {
+
+class SimDifferentialDrivetrain {};
+
+}  // namespace sim
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/simulation/SingleJointedArmSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/SingleJointedArmSim.h
@@ -1,0 +1,130 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+
+#include <units/angle.h>
+#include <units/length.h>
+#include <units/mass.h>
+#include <units/moment_of_inertia.h>
+
+#include "frc/simulation/LinearSystemSim.h"
+#include "frc/system/plant/DCMotor.h"
+
+namespace frc {
+namespace sim {
+/**
+ * Represents a simulated arm mechanism.
+ */
+class SingleJointedArmSim : public LinearSystemSim<2, 1, 1> {
+ public:
+  /**
+   * Creates a simulated arm mechanism.
+   *
+   * @param system             The system representing this arm.
+   * @param mass               The mass of the arm.
+   * @param armLength          The length of the arm.
+   * @param minAngle           The minimum allowed angle for the arm.
+   * @param maxAngle           The maximum allowed angle for the arm.
+   * @param addNoise           Whether the sim should automatically add some
+   *                           encoder noise.
+   * @param measurementStdDevs The standard deviation of the measurement noise.
+   */
+  SingleJointedArmSim(const LinearSystem<2, 1, 1>& system,
+                      units::kilogram_t mass, units::meter_t armLength,
+                      units::radian_t minAngle, units::radian_t maxAngle,
+                      bool addNoise,
+                      const std::array<double, 1>& measurementStdDevs);
+  /**
+   * Creates a simulated arm mechanism.
+   *
+   * @param motor              The type and number of motors on the arm gearbox.
+   * @param j                  The moment of inertia of the arm.
+   * @param G                  The gear ratio of the arm (numbers greater than 1
+   *                           represent reductions).
+   * @param mass               The mass of the arm.
+   * @param armLength          The length of the arm.
+   * @param minAngle           The minimum allowed angle for the arm.
+   * @param maxAngle           The maximum allowed angle for the arm.
+   * @param addNoise           Whether the sim should automatically add some
+   *                           encoder noise.
+   * @param measurementStdDevs The standard deviation of the measurement noise.
+   */
+  SingleJointedArmSim(const DCMotor& motor, units::kilogram_square_meter_t j,
+                      double G, units::kilogram_t mass,
+                      units::meter_t armLength, units::radian_t minAngle,
+                      units::radian_t maxAngle, bool addNoise,
+                      const std::array<double, 1>& measurementStdDevs);
+
+  /**
+   * Creates a simulated arm mechanism.
+   *
+   * @param motor              The type and number of motors on the arm gearbox.
+   * @param G                  The gear ratio of the arm (numbers greater than 1
+   *                           represent reductions).
+   * @param mass               The mass of the arm.
+   * @param armLength          The length of the arm.
+   * @param minAngle           The minimum allowed angle for the arm.
+   * @param maxAngle           The maximum allowed angle for the arm.
+   * @param addNoise           Whether the sim should automatically add some
+   *                           encoder noise.
+   * @param measurementStdDevs The standard deviation of the measurement noise.
+   */
+  SingleJointedArmSim(const DCMotor& motor, double G, units::kilogram_t mass,
+                      units::meter_t armLength, units::radian_t minAngle,
+                      units::radian_t maxAngle, bool addNoise,
+                      const std::array<double, 1>& measurementStdDevs);
+
+  /**
+   * Returns whether the arm has hit the lower limit.
+   *
+   * @param x The current arm state.
+   * @return Whether the arm has hit the lower limit.
+   */
+  bool HasHitLowerLimit(const Eigen::Matrix<double, 2, 1>& x) const;
+
+  /**
+   * Returns whether the arm has hit the upper limit.
+   *
+   * @param x The current arm state.
+   * @return Whether the arm has hit the upper limit.
+   */
+  bool HasHitUpperLimit(const Eigen::Matrix<double, 2, 1>& x) const;
+
+  /**
+   * Returns the current arm angle.
+   * @return The current arm angle.
+   */
+  units::radian_t GetAngle() const;
+
+  /**
+   * Returns the current arm velocity.
+   * @return The current arm velocity.
+   */
+  units::radians_per_second_t GetVelocity() const;
+
+  /**
+   * Updates the state estimate of the arm.
+   *
+   * @param currentXhat The current state estimate.
+   * @param u           The system inputs (voltage).
+   * @param dt          The time difference between controller updates.
+   */
+  Eigen::Matrix<double, 2, 1> UpdateX(
+      const Eigen::Matrix<double, 2, 1>& currentXhat,
+      const Eigen::Matrix<double, 1, 1>& u, units::second_t dt) override;
+
+ private:
+  units::meter_t m_r;
+  units::radian_t m_minAngle;
+  units::radian_t m_maxAngle;
+  units::kilogram_t m_mass;
+};
+}  // namespace sim
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/simulation/SwerveDriveSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/SwerveDriveSim.h
@@ -1,0 +1,318 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+
+#include <units/force.h>
+#include <units/length.h>
+#include <units/mass.h>
+
+#include "frc/geometry/Rotation2d.h"
+#include "frc/geometry/Translation2d.h"
+#include "frc/kinematics/ChassisSpeeds.h"
+#include "frc/kinematics/SwerveDriveKinematics.h"
+#include "frc/system/LinearSystem.h"
+#include "frc/system/RungeKutta.h"
+#include "frc/system/plant/DCMotor.h"
+
+namespace frc {
+namespace sim {
+/**
+ * Represents a simulated swerve drive module.
+ */
+class SimSwerveModule {
+ public:
+  /**
+   * Creates a simulated swerve drive module.
+   *
+   * @param motor         The drive motor on the module.
+   * @param gearing       The gearing of the drive motor (numbers greater than 1
+   *                      represent reductions).
+   * @param wheelRadius   The radius of the module wheel.
+   * @param position      The position of the module on the robot.
+   * @param azimuthSystem The linear system representing the module azimuth.
+   */
+  SimSwerveModule(const DCMotor& motor, double gearing,
+                  units::meter_t wheelRadius, const Translation2d& position,
+                  const LinearSystem<2, 1, 1>& azimuthSystem);
+
+  /**
+   * Returns the azimuth angle of the module.
+   * @return The azimuth angle of the module.
+   */
+  Rotation2d GetAzimuthAngle() const;
+
+  /**
+   * Returns the module position on the robot.
+   * @return The module position on the robot.
+   */
+  const Translation2d& GetModulePosition() const;
+
+  /**
+   * Returns an estimate of the force exerted by the module.
+   *
+   * @param wheelVelocity The velocity of the module wheel.
+   * @param wheelVoltage  The voltage applied to the module drive motor.
+   *
+   * @return An estimate of the force exerted by the module.
+   */
+  units::newton_t EstimateModuleForce(units::meters_per_second_t wheelVelocity,
+                                      units::volt_t wheelVoltage) const;
+
+  /**
+   * Updates the orientation of the module.
+   *
+   * @param azimuthVoltage The voltage applied to the azimuth motor.
+   * @param dt             The time betwee updates.
+   *
+   * @return The new azimuth angle of the module.
+   */
+  Rotation2d Update(units::volt_t azimuthVoltage, units::second_t dt);
+
+ private:
+  DCMotor m_driveMotor;
+  double m_gearing;
+  units::meter_t m_wheelRadius;
+  Translation2d m_position;
+
+  LinearSystem<2, 1, 1> m_azimuthSystem;
+  Eigen::Matrix<double, 2, 1> m_azimuthState;
+};
+
+/**
+ * Represents a simulated swerve drive robot.
+ */
+template <int NumModules>
+class SwerveDriveSim {
+ public:
+  /**
+   * Creates a simulated swerve drive robot.
+   *
+   * @param mass              The mass of the chassis.
+   * @param azimuthSystem     The linear system representing a module azimuth.
+   * @param driveMotor        The motor used for driving on each module.
+   * @param driveMotorGearing The gearing of the drive motor (numbers greater
+   *                          than 1 represent reductions).
+   * @param wheel             The location of the front left wheel.
+   * @param wheels            The locations of the other modules on the robot.
+   */
+  template <typename... Wheels>
+  SwerveDriveSim(units::kilogram_t mass,
+                 const LinearSystem<2, 1, 1>& azimuthSystem,
+                 const DCMotor& driveMotor, double driveMotorGearing,
+                 units::meter_t wheelRadius, const Translation2d& wheel,
+                 Wheels&&... wheels)
+      : m_modules(GetModulesFromInfo(azimuthSystem, driveMotor,
+                                     driveMotorGearing, wheelRadius, wheel,
+                                     wheels...)),
+        m_kinematics(GetKinematicsFromInfo(m_modules)),
+        m_mass(mass) {}
+
+  /**
+   * Creates a simulated swerve drive robot.
+   *
+   * @param mass    The mass of the chassis.
+   * @param module  The front-left module.
+   * @param modules The other modules on the drivetrain.
+   */
+  template <typename... Modules>
+  SwerveDriveSim(units::kilogram_t mass, const SimSwerveModule& module,
+                 Modules&&... modules)
+      : SwerveDriveSim{mass, {module, modules...}} {}
+
+  /**
+   * Creates a simulated swerve drive robot.
+   *
+   * @param mass    The mass of the chassis.
+   * @param modules An array of sim swerve modules on the robot.
+   */
+  SwerveDriveSim(units::kilogram_t mass,
+                 const std::array<SimSwerveModule, NumModules> modules)
+      : m_modules(modules),
+        m_kinematics(CreateKinematicsFromInfo(m_modules)),
+        m_mass(mass) {}
+
+  /**
+   * Returns a const reference to the kinematics object that represents the
+   * drivetrain.
+   * @return A const reference to the kinematics object that represents the
+   * drivetrain.
+   */
+  const SwerveDriveKinematics<NumModules>& GetKinematics() const {
+    return m_kinematics;
+  }
+
+  /**
+   * Returns the estimated speed of the chassis at this moment.
+   * @return The estimated speed of the chassis at this moment.
+   */
+  const ChassisSpeeds& GetEstimatedSpeed() const { return m_estimatedSpeed; }
+
+  /**
+   * Returns the module states that represent the chassis' motion.
+   * @return The module states that represent the chassis' motion.
+   */
+  std::array<SwerveModuleState, NumModules> GetEstimatedModuleStates() const {
+    return m_kinematics.ToSwerveModuleStates(m_estimatedSpeed);
+  }
+
+  /**
+   * Returns a const reference to the array of sim modules of this chassis.
+   * @return A const reference to the array of sim modules of this chassis.
+   */
+  const std::array<SimSwerveModule, NumModules>& GetModules() const {
+    return m_modules;
+  }
+
+  /**
+   * Returns an array of the azimuth angles of all modules.
+   * @return An array of the azimuth angles of all modules.
+   */
+  std::array<Rotation2d, NumModules> GetEstimatedModuleAngles() const {
+    std::array<Rotation2d, NumModules> angles;
+    for (size_t i = 0; i < NumModules; i++) {
+      angles[i] = m_modules[i].GetAzimuthAngle();
+    }
+    return angles;
+  }
+
+  /**
+   * Sets the module drive voltages.
+   *
+   * @param voltage  The drive voltage of the front-left module.
+   * @param voltages The drive voltages of all other modules.
+   */
+  template <typename... Voltages>
+  void SetModuleDriveVoltages(units::volt_t voltage, Voltages&&... voltages) {
+    static_assert(sizeof...(voltages) == (NumModules - 1));
+    SetModuleDriveVoltages({voltage, voltages...});
+  }
+
+  /**
+   * Sets the module drive voltages.
+   *
+   * @param voltages An array of all drive voltages.
+   */
+  void SetModuleDriveVoltages(
+      const std::array<units::volt_t, NumModules>& voltages) {
+    m_driveVoltages = voltages;
+  }
+
+  /**
+   * Sets the azimuth drive voltages.
+   *
+   * @param voltage  The azimuth voltage of the front-left module.
+   * @param voltages The azimuth voltages of all other modules.
+   */
+  template <typename... Voltages>
+  void SetModuleAzimuthVoltages(units::volt_t voltage, Voltages&&... voltages) {
+    static_assert(sizeof...(voltages) == (NumModules - 1));
+    SetModuleAzimuthVoltages({voltage, voltages...});
+  }
+
+  /**
+   * Sets the azimuth drive voltages.
+   *
+   * @param voltages An array of all azimuth voltages.
+   */
+  void SetModuleAzimuthVoltages(
+      const std::array<units::volt_t, NumModules>& voltages) {
+    m_azimuthVoltages = voltages;
+  }
+
+  /**
+   * Updates the state of the chassis.
+   *
+   * @param dt The time between updates.
+   */
+  void Update(units::second_t dt) {
+    // First, we determine the wheel speeds necessary to be at the current
+    // chassis speeds Then, we use this speed to calculate the force each module
+    // exerts on the chassis, Which we use to figure out the acceleration-ish of
+    // each wheel. We then integrate this acceleration forward with RK4, and use
+    // IK to go back to chassis speeds from our new wheel speeds.
+    auto wheelSpeeds = m_kinematics.ToSwerveModuleStates(m_estimatedSpeed);
+    std::array<SwerveModuleState, NumModules> newStates;
+
+    for (size_t i = 0; i < NumModules; ++i) {
+      auto newSpeed = RungeKutta(
+          // F = ma  <==> a = F / m
+          [&](double x, double u) {
+            return m_modules[i]
+                       .EstimateModuleForce(wheelSpeeds[i].speed,
+                                            m_driveVoltages[i])
+                       .template to<double>() /
+                   m_mass.to<double>() * NumModules;
+          },
+          wheelSpeeds[i].speed.template to<double>(),
+          m_driveVoltages[i].template to<double>(), dt);
+      Rotation2d angle = m_modules[i].Update(m_azimuthVoltages[i], dt);
+      newStates[i] =
+          SwerveModuleState{units::meters_per_second_t(newSpeed), angle};
+    }
+
+    m_estimatedSpeed = m_kinematics.ToChassisSpeeds(newStates);
+
+    // Integrate heading forward with RK4
+    m_estimatedHeading = units::radian_t(RungeKutta(
+        [&](double heading) {
+          return m_estimatedSpeed.omega.template to<double>();
+        },
+        m_estimatedHeading.Radians().template to<double>(), dt));
+  }
+
+  /**
+   * Resets the speed of the chassis.
+   *
+   * @param speeds The speed to reset to.
+   */
+  void ResetChassisSpeeds(const ChassisSpeeds& speeds) {
+    m_estimatedSpeed = speeds;
+  }
+
+ private:
+  template <typename... Wheels>
+  static std::array<SimSwerveModule, NumModules> GetModulesFromInfo(
+      const LinearSystem<2, 1, 1>& azimuthSystem, const DCMotor& driveMotor,
+      double driveMotorGearing, units::meter_t wheelRadius,
+      const Translation2d& wheel, Wheels&&... wheels) {
+    std::array<Translation2d, NumModules> locations{wheel, wheels...};
+    std::array<SimSwerveModule, NumModules> modules;
+
+    for (size_t i = 0; i < NumModules; ++i) {
+      modules[i] = SimSwerveModule(driveMotor, driveMotorGearing, wheelRadius,
+                                   locations[i], azimuthSystem);
+    }
+
+    return modules;
+  }
+
+  static SwerveDriveKinematics<NumModules> CreateKinematicsFromInfo(
+      const std::array<SimSwerveModule, NumModules>& modules) {
+    std::array<Translation2d, NumModules> locations;
+    for (size_t i = 0; i < NumModules; ++i) {
+      locations[i] = modules[i].GetModulePosition();
+    }
+    return SwerveDriveKinematics<4>(locations);
+  }
+
+  std::array<SimSwerveModule, NumModules> m_modules;
+  SwerveDriveKinematics<NumModules> m_kinematics;
+
+  units::kilogram_t m_mass;
+
+  std::array<units::volt_t, NumModules> m_driveVoltages;
+  std::array<units::volt_t, NumModules> m_azimuthVoltages;
+
+  ChassisSpeeds m_estimatedSpeed;
+  Rotation2d m_estimatedHeading;
+};  // namespace sim
+
+}  // namespace sim
+}  // namespace frc

--- a/wpilibc/src/test/native/cpp/controller/LTVDiffDriveControllerTest.cpp
+++ b/wpilibc/src/test/native/cpp/controller/LTVDiffDriveControllerTest.cpp
@@ -1,0 +1,232 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <limits>
+#include <random>
+
+#include <Eigen/Core>
+#include <units/time.h>
+#include <wpi/MathExtras.h>
+
+#include "frc/StateSpaceUtil.h"
+#include "frc/controller/ControlAffinePlantInversionFeedforward.h"
+#include "frc/controller/LTVDiffDriveController.h"
+#include "frc/estimator/DifferentialDriveStateEstimator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/geometry/Rotation2d.h"
+#include "frc/kinematics/DifferentialDriveKinematics.h"
+#include "frc/kinematics/DifferentialDriveOdometry.h"
+#include "frc/system/LinearSystem.h"
+#include "frc/system/RungeKutta.h"
+#include "frc/system/plant/LinearSystemId.h"
+#include "frc/trajectory/TrajectoryGenerator.h"
+#include "frc/trajectory/constraint/DifferentialDriveVelocitySystemConstraint.h"
+#include "frc2/Timer.h"
+#include "gtest/gtest.h"
+
+using namespace frc;
+
+void ScaleCapU(Eigen::Matrix<double, 2, 1>* u) {
+  bool outputCapped =
+      std::abs((*u)(0, 0)) > 12.0 || std::abs((*u)(1, 0)) > 12.0;
+
+  if (outputCapped) {
+    *u *= 12.0 / u->lpNorm<Eigen::Infinity>();
+  }
+}
+
+TEST(LTVDiffDriveControllerTest, TrackingTest) {
+  constexpr auto kDt = 0.02_s;
+
+  LinearSystem<2, 2, 2> plant = frc::LinearSystemId::IdentifyDrivetrainSystem(
+      3.02, 0.642, 1.382, 0.08495);
+
+  const DifferentialDriveKinematics kinematics{1_m};
+
+  LTVDiffDriveController controller{
+      plant, {0.0625, 0.125, 2.5, 0.95, 0.95}, {12.0, 12.0}, kinematics, kDt};
+
+  std::function<Eigen::Matrix<double, 10, 1>(
+      const Eigen::Matrix<double, 10, 1>&, const Eigen::Matrix<double, 2, 1>&)>
+      modelDynamics =
+          [&](auto& x, auto& u) { return controller.Dynamics(x, u); };
+
+  ControlAffinePlantInversionFeedforward<10, 2> feedforward{modelDynamics, kDt};
+
+  frc::DifferentialDriveStateEstimator estimator{
+      plant,
+      Eigen::Matrix<double, 10, 1>::Zero(),
+      frc::MakeMatrix<10, 1>(0.002, 0.002, 0.0001, 1.5, 1.5, 0.5, 0.5, 10.0,
+                             10.0, 2.0),
+      frc::MakeMatrix<3, 1>(0.0001, 0.005, 0.005),
+      frc::MakeMatrix<3, 1>(0.5, 0.5, 0.5),
+      kinematics,
+      kDt};
+
+  auto waypoints = std::vector{frc::Pose2d{0_m, 0_m, 0_rad},
+                               frc::Pose2d{4.8768_m, 2.7432_m, 0_rad}};
+
+  auto config =
+      TrajectoryConfig(12_mps / 3.02, (12_mps_sq / 0.642) - 16.5_mps_sq);
+  config.AddConstraint(
+      DifferentialDriveVelocitySystemConstraint(plant, kinematics, 8_V));
+
+  auto trajectory =
+      frc::TrajectoryGenerator::GenerateTrajectory(waypoints, config);
+
+  controller.Reset();
+  estimator.Reset();
+  controller.SetTolerance(frc::Pose2d{0.06_m, 0.06_m, 0.06_rad}, 0.3_mps);
+
+  auto t = 0.0_s;
+  auto totalTime = trajectory.TotalTime();
+
+  Eigen::Matrix<double, 10, 1> trueXhat;
+  trueXhat.setZero();
+
+  Eigen::Matrix<double, 2, 1> u;
+  u.setZero();
+
+  Eigen::Matrix<double, 5, 1> prevStateRef;
+  prevStateRef.setZero();
+
+  std::cout << "xhat x, xhat y, xhat heading, traj x, traj y, traj heading\n";
+
+  while (t <= totalTime) {
+    Eigen::Matrix<double, 3, 1> y = estimator.LocalMeasurementModel(
+        trueXhat, Eigen::Matrix<double, 2, 1>::Zero());
+
+    Eigen::Matrix<double, 10, 1> currentState = estimator.UpdateWithTime(
+        units::radian_t(y(0, 0)), units::meter_t(y(1, 0)),
+        units::meter_t(y(2, 0)), u, t);
+
+    auto desiredState = trajectory.Sample(t);
+
+    const ChassisSpeeds chassisSpeeds{
+        desiredState.velocity, 0_mps,
+        desiredState.velocity * desiredState.curvature};
+
+    auto [left, right] = kinematics.ToWheelSpeeds(chassisSpeeds);
+
+    Eigen::Matrix<double, 5, 1> stateRef;
+    stateRef << desiredState.pose.Translation().X().to<double>(),
+        desiredState.pose.Translation().Y().to<double>(),
+        desiredState.pose.Rotation().Radians().to<double>(), left.to<double>(),
+        right.to<double>();
+
+    prevStateRef = stateRef;
+
+    Eigen::Matrix<double, 10, 1> augmentedRef;
+    augmentedRef.block<5, 1>(0, 0) = stateRef;
+
+    u = controller.Calculate(currentState.block<5, 1>(0, 0), desiredState) +
+        feedforward.Calculate(augmentedRef);
+
+    ScaleCapU(&u);
+
+    t += kDt;
+
+    trueXhat = frc::RungeKutta(modelDynamics, trueXhat, u, kDt);
+    EXPECT_TRUE(controller.AtReference());
+  }
+}
+
+TEST(LTVDiffDriveControllerTest, TrackingTestNoise) {
+  constexpr auto kDt = 0.02_s;
+
+  LinearSystem<2, 2, 2> plant = frc::LinearSystemId::IdentifyDrivetrainSystem(
+      3.02, 0.642, 1.382, 0.08495);
+
+  const DifferentialDriveKinematics kinematics{1_m};
+
+  LTVDiffDriveController controller{
+      plant, {0.0625, 0.125, 2.5, 0.95, 0.95}, {12.0, 12.0}, kinematics, kDt};
+
+  std::function<Eigen::Matrix<double, 10, 1>(
+      const Eigen::Matrix<double, 10, 1>&, const Eigen::Matrix<double, 2, 1>&)>
+      controllerDynamics =
+          [&](auto& x, auto& u) { return controller.Dynamics(x, u); };
+
+  ControlAffinePlantInversionFeedforward<10, 2> feedforward{controllerDynamics,
+                                                            kDt};
+
+  frc::DifferentialDriveStateEstimator estimator{
+      plant,
+      Eigen::Matrix<double, 10, 1>::Zero(),
+      frc::MakeMatrix<10, 1>(0.002, 0.002, 0.0001, 1.5, 1.5, 0.5, 0.5, 10.0,
+                             10.0, 2.0),
+      frc::MakeMatrix<3, 1>(0.0001, 0.005, 0.005),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.01),
+      kinematics,
+      kDt};
+
+  auto waypoints = std::vector{frc::Pose2d{0_m, 0_m, 0_rad},
+                               frc::Pose2d{4.8768_m, 2.7432_m, 0_rad}};
+
+  auto config = TrajectoryConfig(12_mps / 3.02, 12_mps_sq / 0.642);
+  config.AddConstraint(
+      DifferentialDriveVelocitySystemConstraint(plant, kinematics, 8_V));
+
+  auto trajectory =
+      frc::TrajectoryGenerator::GenerateTrajectory(waypoints, config);
+
+  controller.Reset();
+  estimator.Reset();
+  controller.SetTolerance(frc::Pose2d{0.06_m, 0.06_m, 0.1_rad}, 0.5_mps);
+
+  auto t = 0.0_s;
+  auto totalTime = trajectory.TotalTime();
+
+  Eigen::Matrix<double, 10, 1> trueXhat;
+  trueXhat.setZero();
+
+  Eigen::Matrix<double, 2, 1> u;
+  u.setZero();
+
+  Eigen::Matrix<double, 5, 1> prevStateRef;
+  prevStateRef.setZero();
+
+  while (t <= totalTime) {
+    Eigen::Matrix<double, 3, 1> y = estimator.LocalMeasurementModel(
+        trueXhat, Eigen::Matrix<double, 2, 1>::Zero());
+
+    y += frc::MakeWhiteNoiseVector(0.0001, 0.005, 0.005);
+
+    Eigen::Matrix<double, 10, 1> currentState = estimator.UpdateWithTime(
+        units::radian_t(y(0, 0)), units::meter_t(y(1, 0)),
+        units::meter_t(y(2, 0)), u, t);
+
+    auto desiredState = trajectory.Sample(t);
+
+    const ChassisSpeeds chassisSpeeds{
+        desiredState.velocity, 0_mps,
+        desiredState.velocity * desiredState.curvature};
+
+    auto [left, right] = kinematics.ToWheelSpeeds(chassisSpeeds);
+
+    Eigen::Matrix<double, 5, 1> stateRef;
+    stateRef << desiredState.pose.Translation().X().to<double>(),
+        desiredState.pose.Translation().Y().to<double>(),
+        desiredState.pose.Rotation().Radians().to<double>(), left.to<double>(),
+        right.to<double>();
+
+    prevStateRef = stateRef;
+
+    Eigen::Matrix<double, 10, 1> augmentedRef;
+    augmentedRef.block<5, 1>(0, 0) = stateRef;
+
+    u = controller.Calculate(currentState.block<5, 1>(0, 0), desiredState) +
+        feedforward.Calculate(augmentedRef);
+
+    ScaleCapU(&u);
+
+    t += kDt;
+
+    trueXhat = frc::RungeKutta(controllerDynamics, trueXhat, u, kDt);
+    EXPECT_TRUE(controller.AtReference());
+  }
+}

--- a/wpilibc/src/test/native/cpp/controller/LTVUnicycleControllerTest.cpp
+++ b/wpilibc/src/test/native/cpp/controller/LTVUnicycleControllerTest.cpp
@@ -1,0 +1,44 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <Eigen/Core>
+#include <units/angle.h>
+#include <units/length.h>
+#include <units/time.h>
+#include <wpi/MathExtras.h>
+
+#include "frc/controller/LTVUnicycleController.h"
+#include "frc/trajectory/TrajectoryGenerator.h"
+#include "gtest/gtest.h"
+
+#define EXPECT_NEAR_UNITS(val1, val2, eps) \
+  EXPECT_LE(units::math::abs(val1 - val2), eps)
+
+TEST(LTVUnicycleControllerTest, ReachesReference) {
+  frc::LTVUnicycleController controller{{0.1, 0.1, 0.15}, {8.8, 4.0}, 0.02_s};
+
+  frc::Pose2d robotPose{2.7_m, 23_m, frc::Rotation2d{0_deg}};
+
+  auto waypoints = std::vector{frc::Pose2d{2.75_m, 22.521_m, 0_rad},
+                               frc::Pose2d{24.73_m, 19.68_m, 5.846_rad}};
+  auto trajectory = frc::TrajectoryGenerator::GenerateTrajectory(
+      waypoints, {8.8_mps, 0.1_mps_sq});
+
+  controller.SetTolerance(frc::Pose2d{0.01_m, 0.01_m, 0.001_rad});
+
+  constexpr auto kDt = 0.02_s;
+  auto totalTime = trajectory.TotalTime();
+  for (size_t i = 0; i < (totalTime / kDt).to<double>(); ++i) {
+    auto state = trajectory.Sample(kDt * i);
+    auto [vx, vy, omega] = controller.Calculate(robotPose, state);
+    static_cast<void>(vy);
+
+    robotPose = robotPose.Exp(frc::Twist2d{vx * kDt, 0_m, omega * kDt});
+  }
+
+  EXPECT_TRUE(controller.AtReference());
+}

--- a/wpilibc/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
+++ b/wpilibc/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
@@ -1,0 +1,110 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <limits>
+#include <random>
+
+#include <units/angle.h>
+#include <units/length.h>
+#include <units/time.h>
+
+#include "frc/StateSpaceUtil.h"
+#include "frc/estimator/DifferentialDrivePoseEstimator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/geometry/Rotation2d.h"
+#include "frc/kinematics/DifferentialDriveKinematics.h"
+#include "frc/kinematics/DifferentialDriveOdometry.h"
+#include "frc/trajectory/TrajectoryGenerator.h"
+#include "frc2/Timer.h"
+#include "gtest/gtest.h"
+
+TEST(DifferentialDrivePoseEstimatorTest, TestAccuracy) {
+  frc::DifferentialDrivePoseEstimator estimator{
+      frc::Rotation2d(), frc::Pose2d(),
+      frc::MakeMatrix<5, 1>(0.01, 0.01, 0.01, 0.01, 0.01),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1)};
+
+  frc::Trajectory trajectory = frc::TrajectoryGenerator::GenerateTrajectory(
+      std::vector{frc::Pose2d(), frc::Pose2d(20_m, 20_m, frc::Rotation2d()),
+                  frc::Pose2d(54_m, 54_m, frc::Rotation2d())},
+      frc::TrajectoryConfig(10_mps, 5.0_mps_sq));
+
+  frc::DifferentialDriveKinematics kinematics{1.0_m};
+  frc::DifferentialDriveOdometry odometry{frc::Rotation2d()};
+
+  std::default_random_engine generator;
+  std::normal_distribution<double> distribution(0.0, 1.0);
+
+  units::second_t dt = 0.02_s;
+  units::second_t t = 0.0_s;
+
+  units::meter_t leftDistance = 0_m;
+  units::meter_t rightDistance = 0_m;
+
+  units::second_t kVisionUpdateRate = 0.1_s;
+  frc::Pose2d lastVisionPose;
+  units::second_t lastVisionUpdateRealTimestamp{
+      -std::numeric_limits<double>::max()};
+  units::second_t lastVisionUpdateTime{-std::numeric_limits<double>::max()};
+
+  double maxError = -std::numeric_limits<double>::max();
+  double errorSum = 0;
+
+  while (t <= trajectory.TotalTime()) {
+    auto groundTruthState = trajectory.Sample(t);
+    auto input = kinematics.ToWheelSpeeds(
+        {groundTruthState.velocity, 0_mps,
+         groundTruthState.velocity * groundTruthState.curvature});
+
+    if (lastVisionUpdateTime + kVisionUpdateRate < t) {
+      if (lastVisionPose != frc::Pose2d()) {
+        estimator.AddVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
+      }
+      lastVisionPose =
+          groundTruthState.pose +
+          frc::Transform2d(
+              frc::Translation2d(distribution(generator) * 0.1 * 1_m,
+                                 distribution(generator) * 0.1 * 1_m),
+              frc::Rotation2d(distribution(generator) * 0.1 * 1_rad));
+
+      lastVisionUpdateRealTimestamp = frc2::Timer::GetFPGATimestamp();
+      lastVisionUpdateTime = t;
+    }
+
+    leftDistance += input.left * distribution(generator) * 0.1 * dt;
+    rightDistance += input.right * distribution(generator) * 0.1 * dt;
+
+    auto xhat = estimator.UpdateWithTime(
+        t,
+        groundTruthState.pose.Rotation() +
+            frc::Rotation2d(units::radian_t(distribution(generator) * 0.1)),
+        input, leftDistance, rightDistance);
+
+    double error = groundTruthState.pose.Translation()
+                       .Distance(xhat.Translation())
+                       .to<double>();
+
+    if (error > maxError) {
+      maxError = error;
+    }
+    errorSum += error;
+
+    t += dt;
+  }
+
+  std::cout << "error sum "
+            << errorSum /
+                   (trajectory.TotalTime().to<double>() / dt.to<double>())
+            << std::endl;
+  std::cout << "max error " << maxError << std::endl;
+
+  //  EXPECT_NEAR(0.0, errorSum / (trajectory.TotalTime().to<double>() /
+  //  dt.to<double>()),
+  //            0.2);
+  //  EXPECT_NEAR(0.0, maxError, 0.4);
+}

--- a/wpilibc/src/test/native/cpp/estimator/DifferentialDriveStateEstimatorTest.cpp
+++ b/wpilibc/src/test/native/cpp/estimator/DifferentialDriveStateEstimatorTest.cpp
@@ -1,0 +1,165 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <iostream>
+#include <limits>
+#include <random>
+
+#include <Eigen/Core>
+#include <wpi/MathExtras.h>
+
+#include "frc/StateSpaceUtil.h"
+#include "frc/controller/ControlAffinePlantInversionFeedforward.h"
+#include "frc/estimator/DifferentialDriveStateEstimator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/geometry/Rotation2d.h"
+#include "frc/kinematics/DifferentialDriveKinematics.h"
+#include "frc/kinematics/DifferentialDriveOdometry.h"
+#include "frc/system/LinearSystem.h"
+#include "frc/system/plant/LinearSystemId.h"
+#include "frc/trajectory/TrajectoryGenerator.h"
+#include "frc/trajectory/constraint/DifferentialDriveVelocitySystemConstraint.h"
+#include "frc2/Timer.h"
+#include "gtest/gtest.h"
+
+using namespace frc;
+
+void ScaleCappedU(Eigen::Matrix<double, 2, 1>* u) {
+  bool outputCapped =
+      std::abs((*u)(0, 0)) > 12.0 || std::abs((*u)(1, 0)) > 12.0;
+
+  if (outputCapped) {
+    *u *= 12.0 / u->lpNorm<Eigen::Infinity>();
+  }
+}
+
+TEST(DifferentialDriveStateEstimatorTest, TestAccuracy) {
+  constexpr auto dt = 0.00505_s;
+
+  const LinearSystem<2, 2, 2> plant =
+      frc::LinearSystemId::IdentifyDrivetrainSystem(3.02, 0.642, 1.382,
+                                                    0.08495);
+
+  const DifferentialDriveKinematics kinematics{0.990405073902434_m};
+
+  frc::DifferentialDriveStateEstimator estimator{
+      plant,
+      Eigen::Matrix<double, 10, 1>::Zero(),
+      frc::MakeMatrix<10, 1>(0.002, 0.002, 0.0001, 1.5, 1.5, 0.5, 0.5, 10.0,
+                             10.0, 2.0),
+      frc::MakeMatrix<3, 1>(0.0001, 0.005, 0.005),
+      frc::MakeMatrix<3, 1>(0.5, 0.5, 0.5),
+      kinematics,
+      dt};
+
+  std::function<Eigen::Matrix<double, 10, 1>(
+      const Eigen::Matrix<double, 10, 1>&, const Eigen::Matrix<double, 2, 1>&)>
+      modelDynamics =
+          [&](auto& x, auto& u) { return estimator.Dynamics(x, u); };
+
+  ControlAffinePlantInversionFeedforward<10, 2> feedforward{modelDynamics, dt};
+
+  auto config = TrajectoryConfig(
+      units::meters_per_second_t(12 / 3.02),
+      units::meters_per_second_squared_t(12 / 0.642) - 16.5_mps_sq);
+  config.AddConstraint(
+      DifferentialDriveVelocitySystemConstraint(plant, kinematics, 8_V));
+
+  frc::Trajectory trajectory = frc::TrajectoryGenerator::GenerateTrajectory(
+      frc::Pose2d(0_m, 0_m, 0_rad), {}, frc::Pose2d(4.8768_m, 2.7432_m, 0_rad),
+      config);
+
+  std::default_random_engine generator;
+  std::normal_distribution<double> distribution(0.0, 1.0);
+
+  units::second_t t = 0.0_s;
+
+  units::second_t kVisionUpdateRate = 0.1_s;
+  frc::Pose2d lastVisionPose;
+  units::second_t lastVisionUpdateRealTimestamp{
+      -std::numeric_limits<double>::max()};
+  units::second_t lastVisionUpdateTime{-std::numeric_limits<double>::max()};
+  units::meter_t leftDistance = 0_m;
+  units::meter_t rightDistance = 0_m;
+
+  double maxError = -std::numeric_limits<double>::max();
+  double errorSum = 0;
+
+  Eigen::Matrix<double, 2, 1> input;
+
+  while (t <= trajectory.TotalTime()) {
+    auto groundTruthState = trajectory.Sample(t);
+
+    auto wheelSpeeds = kinematics.ToWheelSpeeds(
+        {groundTruthState.velocity, 0_mps,
+         groundTruthState.velocity * groundTruthState.curvature});
+
+    Eigen::Matrix<double, 10, 1> x;
+    x << groundTruthState.pose.Translation().X().to<double>(),
+        groundTruthState.pose.Translation().Y().to<double>(),
+        groundTruthState.pose.Rotation().Radians().to<double>(),
+        wheelSpeeds.left.to<double>(), wheelSpeeds.right.to<double>(), 0.0, 0.0,
+        0.0, 0.0, 0.0;
+
+    input = feedforward.Calculate(x);
+
+    ScaleCappedU(&input);
+
+    if (lastVisionUpdateTime + kVisionUpdateRate < t) {
+      if (lastVisionPose != frc::Pose2d()) {
+        estimator.ApplyPastGlobalMeasurement(lastVisionPose,
+                                             lastVisionUpdateTime);
+      }
+      lastVisionPose =
+          groundTruthState.pose +
+          frc::Transform2d(
+              frc::Translation2d(distribution(generator) * 0.5 * 1_m,
+                                 distribution(generator) * 0.5 * 1_m),
+              frc::Rotation2d(distribution(generator) * 0.5 * 1_rad));
+
+      lastVisionUpdateRealTimestamp = frc2::Timer::GetFPGATimestamp();
+      lastVisionUpdateTime = t;
+    }
+
+    leftDistance += wheelSpeeds.left * dt;
+    rightDistance += wheelSpeeds.right * dt;
+
+    leftDistance += distribution(generator) * 0.005_m;
+    rightDistance += distribution(generator) * 0.005_m;
+
+    auto xhat = estimator.UpdateWithTime(
+        (groundTruthState.pose.Rotation() +
+         frc::Rotation2d(units::radian_t(distribution(generator) * 0.0001)))
+            .Radians(),
+        leftDistance, rightDistance, input, t);
+
+    frc::Translation2d estimatedTranslation{units::meter_t(xhat(0, 0)),
+                                            units::meter_t(xhat(1, 0))};
+
+    // std::cout << groundTruthState.pose.Translation().X().to<double>() << ","
+    //<< groundTruthState.pose.Translation().Y().to<double>() << "," <<
+    // estimatedTranslation.X().to<double>() << "," <<
+    // estimatedTranslation.Y().to<double>() << "," <<
+    // lastVisionPose.Translation().X().to<double>() << "," <<
+    // lastVisionPose.Translation().Y().to<double>() << '\n';
+
+    double error = groundTruthState.pose.Translation()
+                       .Distance(estimatedTranslation)
+                       .to<double>();
+
+    if (error > maxError) {
+      maxError = error;
+    }
+    errorSum += error;
+
+    t += dt;
+  }
+
+  EXPECT_LT(errorSum / (trajectory.TotalTime().to<double>() / dt.to<double>()),
+            0.2);
+  EXPECT_LT(maxError, 0.4);
+}

--- a/wpilibc/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
+++ b/wpilibc/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
@@ -1,0 +1,97 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <limits>
+#include <random>
+
+#include "frc/estimator/MecanumDrivePoseEstimator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/kinematics/MecanumDriveKinematics.h"
+#include "frc/kinematics/MecanumDriveOdometry.h"
+#include "frc/trajectory/TrajectoryGenerator.h"
+#include "gtest/gtest.h"
+
+TEST(MecanumDrivePoseEstimatorTest, TestAccuracy) {
+  frc::MecanumDriveKinematics kinematics{
+      frc::Translation2d{1_m, 1_m}, frc::Translation2d{1_m, -1_m},
+      frc::Translation2d{-1_m, -1_m}, frc::Translation2d{-1_m, 1_m}};
+
+  frc::MecanumDrivePoseEstimator estimator{
+      frc::Rotation2d(),
+      frc::Pose2d(),
+      kinematics,
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1),
+      frc::MakeMatrix<1, 1>(0.05),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1)};
+
+  frc::MecanumDriveOdometry odometry{kinematics, frc::Rotation2d()};
+
+  frc::Trajectory trajectory = frc::TrajectoryGenerator::GenerateTrajectory(
+      std::vector{frc::Pose2d(), frc::Pose2d(20_m, 20_m, frc::Rotation2d()),
+                  frc::Pose2d(10_m, 10_m, frc::Rotation2d(180_deg)),
+                  frc::Pose2d(30_m, 30_m, frc::Rotation2d()),
+                  frc::Pose2d(20_m, 20_m, frc::Rotation2d(180_deg)),
+                  frc::Pose2d(10_m, 10_m, frc::Rotation2d())},
+      frc::TrajectoryConfig(5.0_mps, 2.0_mps_sq));
+
+  std::default_random_engine generator;
+  std::normal_distribution<double> distribution(0.0, 1.0);
+
+  units::second_t dt = 0.02_s;
+  units::second_t t = 0_s;
+
+  units::second_t kVisionUpdateRate = 0.1_s;
+  frc::Pose2d lastVisionPose;
+  units::second_t lastVisionUpdateTime{-std::numeric_limits<double>::max()};
+
+  std::vector<frc::Pose2d> visionPoses;
+
+  double maxError = -std::numeric_limits<double>::max();
+  double errorSum = 0;
+
+  while (t < trajectory.TotalTime()) {
+    frc::Trajectory::State groundTruthState = trajectory.Sample(t);
+
+    if (lastVisionUpdateTime + kVisionUpdateRate < t) {
+      if (lastVisionPose != frc::Pose2d()) {
+        estimator.AddVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
+      }
+      lastVisionPose =
+          groundTruthState.pose +
+          frc::Transform2d(
+              frc::Translation2d(distribution(generator) * 0.1_m,
+                                 distribution(generator) * 0.1_m),
+              frc::Rotation2d(distribution(generator) * 0.1 * 1_rad));
+      visionPoses.push_back(lastVisionPose);
+      lastVisionUpdateTime = t;
+    }
+
+    auto wheelSpeeds = kinematics.ToWheelSpeeds(
+        {groundTruthState.velocity, 0_mps,
+         groundTruthState.velocity * groundTruthState.curvature});
+
+    auto xhat = estimator.UpdateWithTime(
+        t,
+        groundTruthState.pose.Rotation() +
+            frc::Rotation2d(distribution(generator) * 0.05_rad),
+        wheelSpeeds);
+    double error = groundTruthState.pose.Translation()
+                       .Distance(xhat.Translation())
+                       .to<double>();
+
+    if (error > maxError) {
+      maxError = error;
+    }
+    errorSum += error;
+
+    t += dt;
+  }
+
+  EXPECT_LT(errorSum / (trajectory.TotalTime().to<double>() / dt.to<double>()),
+            0.2);
+  EXPECT_LT(maxError, 0.4);
+}

--- a/wpilibc/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
+++ b/wpilibc/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
@@ -1,0 +1,97 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <limits>
+#include <random>
+
+#include "frc/estimator/SwerveDrivePoseEstimator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/kinematics/SwerveDriveKinematics.h"
+#include "frc/kinematics/SwerveDriveOdometry.h"
+#include "frc/trajectory/TrajectoryGenerator.h"
+#include "gtest/gtest.h"
+
+TEST(SwerveDrivePoseEstimatorTest, TestAccuracy) {
+  frc::SwerveDriveKinematics<4> kinematics{
+      frc::Translation2d{1_m, 1_m}, frc::Translation2d{1_m, -1_m},
+      frc::Translation2d{-1_m, -1_m}, frc::Translation2d{-1_m, 1_m}};
+
+  frc::SwerveDrivePoseEstimator<4> estimator{
+      frc::Rotation2d(),
+      frc::Pose2d(),
+      kinematics,
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1),
+      frc::MakeMatrix<1, 1>(0.05),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1)};
+
+  frc::SwerveDriveOdometry<4> odometry{kinematics, frc::Rotation2d()};
+
+  frc::Trajectory trajectory = frc::TrajectoryGenerator::GenerateTrajectory(
+      std::vector{frc::Pose2d(), frc::Pose2d(20_m, 20_m, frc::Rotation2d()),
+                  frc::Pose2d(10_m, 10_m, frc::Rotation2d(180_deg)),
+                  frc::Pose2d(30_m, 30_m, frc::Rotation2d()),
+                  frc::Pose2d(20_m, 20_m, frc::Rotation2d(180_deg)),
+                  frc::Pose2d(10_m, 10_m, frc::Rotation2d())},
+      frc::TrajectoryConfig(5.0_mps, 2.0_mps_sq));
+
+  std::default_random_engine generator;
+  std::normal_distribution<double> distribution(0.0, 1.0);
+
+  units::second_t dt = 0.02_s;
+  units::second_t t = 0_s;
+
+  units::second_t kVisionUpdateRate = 0.1_s;
+  frc::Pose2d lastVisionPose;
+  units::second_t lastVisionUpdateTime{-std::numeric_limits<double>::max()};
+
+  std::vector<frc::Pose2d> visionPoses;
+
+  double maxError = -std::numeric_limits<double>::max();
+  double errorSum = 0;
+
+  while (t < trajectory.TotalTime()) {
+    frc::Trajectory::State groundTruthState = trajectory.Sample(t);
+
+    if (lastVisionUpdateTime + kVisionUpdateRate < t) {
+      if (lastVisionPose != frc::Pose2d()) {
+        estimator.AddVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
+      }
+      lastVisionPose =
+          groundTruthState.pose +
+          frc::Transform2d(
+              frc::Translation2d(distribution(generator) * 0.1_m,
+                                 distribution(generator) * 0.1_m),
+              frc::Rotation2d(distribution(generator) * 0.1 * 1_rad));
+      visionPoses.push_back(lastVisionPose);
+      lastVisionUpdateTime = t;
+    }
+
+    auto moduleStates = kinematics.ToSwerveModuleStates(
+        {groundTruthState.velocity, 0_mps,
+         groundTruthState.velocity * groundTruthState.curvature});
+
+    auto xhat = estimator.UpdateWithTime(
+        t,
+        groundTruthState.pose.Rotation() +
+            frc::Rotation2d(distribution(generator) * 0.05_rad),
+        moduleStates[0], moduleStates[1], moduleStates[2], moduleStates[3]);
+    double error = groundTruthState.pose.Translation()
+                       .Distance(xhat.Translation())
+                       .to<double>();
+
+    if (error > maxError) {
+      maxError = error;
+    }
+    errorSum += error;
+
+    t += dt;
+  }
+
+  EXPECT_LT(errorSum / (trajectory.TotalTime().to<double>() / dt.to<double>()),
+            0.2);
+  EXPECT_LT(maxError, 0.4);
+}

--- a/wpilibc/src/test/native/cpp/interpolatable/TimeInterpolatableBufferTest.cpp
+++ b/wpilibc/src/test/native/cpp/interpolatable/TimeInterpolatableBufferTest.cpp
@@ -1,0 +1,24 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <units/time.h>
+
+#include "frc/geometry/Rotation2d.h"
+#include "frc/interpolatable/TimeInterpolatableBuffer.h"
+#include "gtest/gtest.h"
+
+TEST(TimeInterpolatableBufferTest, TestInterpolation) {
+  frc::TimeInterpolatableBuffer<frc::Rotation2d> buffer{};
+
+  buffer.addSample(0_s, frc::Rotation2d(0_rad));
+  EXPECT_TRUE(buffer.Sample(0_s) == frc::Rotation2d(0_rad));
+  buffer.addSample(1_s, frc::Rotation2d(1_rad));
+  EXPECT_TRUE(buffer.Sample(0.5_s) == frc::Rotation2d(0.5_rad));
+  EXPECT_TRUE(buffer.Sample(1_s) == frc::Rotation2d(1_rad));
+  buffer.addSample(3_s, frc::Rotation2d(2_rad));
+  EXPECT_TRUE(buffer.Sample(2_s) == frc::Rotation2d(1.5_rad));
+}

--- a/wpilibc/src/test/native/cpp/simulation/ElevatorSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/ElevatorSimTest.cpp
@@ -1,0 +1,70 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <iostream>
+
+#include <units/time.h>
+
+#include "frc/Encoder.h"
+#include "frc/PWMVictorSPX.h"
+#include "frc/RobotController.h"
+#include "frc/StateSpaceUtil.h"
+#include "frc/controller/PIDController.h"
+#include "frc/simulation/ElevatorSim.h"
+#include "frc/simulation/EncoderSim.h"
+#include "frc/system/plant/DCMotor.h"
+#include "frc/system/plant/LinearSystemId.h"
+#include "gtest/gtest.h"
+
+TEST(ElevatorSim, StateSpaceSim) {
+  frc::sim::ElevatorSim sim(frc::DCMotor::Vex775Pro(4), 8_kg, 13.67,
+                            units::meter_t(0.75 * 25.4 / 1000.0), 0_m, 3_m,
+                            true, {0.01});
+  frc2::PIDController controller(10, 0.0, 0.0);
+
+  frc::PWMVictorSPX motor(0);
+  frc::Encoder encoder(0, 1);
+  frc::sim::EncoderSim encoderSim(encoder);
+
+  for (size_t i = 0; i < 100; ++i) {
+    controller.SetSetpoint(2.0);
+    auto nextVoltage = controller.Calculate(encoderSim.GetDistance());
+    motor.Set(nextVoltage / frc::RobotController::GetInputVoltage());
+
+    auto u = frc::MakeMatrix<1, 1>(motor.Get() *
+                                   frc::RobotController::GetInputVoltage());
+    sim.SetInput(u);
+    sim.Update(20_ms);
+
+    const auto& y = sim.Y();
+    encoderSim.SetDistance(y(0, 0));
+  }
+
+  EXPECT_NEAR(controller.GetSetpoint(), sim.GetElevatorPosition().to<double>(),
+              0.2);
+}
+
+TEST(ElevatorSim, MinMax) {
+  frc::sim::ElevatorSim sim(frc::DCMotor::Vex775Pro(4), 8_kg, 13.67,
+                            units::meter_t(0.75 * 25.4 / 1000.0), 0_m, 1_m,
+                            true, {0.01});
+  for (size_t i = 0; i < 100; ++i) {
+    sim.SetInput(frc::MakeMatrix<1, 1>(0.0));
+    sim.Update(20_ms);
+
+    auto height = sim.GetElevatorPosition();
+    EXPECT_TRUE(height > -0.05_m);
+  }
+
+  for (size_t i = 0; i < 100; ++i) {
+    sim.SetInput(frc::MakeMatrix<1, 1>(12.0));
+    sim.Update(20_ms);
+
+    auto height = sim.GetElevatorPosition();
+    EXPECT_TRUE(height < 1.05_m);
+  }
+}

--- a/wpilibc/src/test/native/cpp/simulation/SingleJointedArmSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/SingleJointedArmSimTest.cpp
@@ -1,0 +1,25 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <wpi/math>
+
+#include "frc/simulation/SingleJointedArmSim.h"
+#include "gtest/gtest.h"
+
+TEST(SingleJointedArmTest, Disabled) {
+  frc::sim::SingleJointedArmSim sim(frc::DCMotor::Vex775Pro(2), 100, 10_kg,
+                                    9.5_in, -180_deg, 0_deg, false, {0.0});
+  sim.ResetState(frc::MakeMatrix<2, 1>(0.0, 0.0));
+
+  for (size_t i = 0; i < 12 / 0.02; ++i) {
+    sim.SetInput(frc::MakeMatrix<1, 1>(0.0));
+    sim.Update(20_ms);
+  }
+
+  // The arm should swing down.
+  EXPECT_NEAR(sim.GetAngle().to<double>(), -wpi::math::pi / 2, 0.01);
+}

--- a/wpilibc/src/test/native/cpp/simulation/StateSpaceSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/StateSpaceSimTest.cpp
@@ -1,0 +1,56 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <iostream>
+
+#include <units/angular_acceleration.h>
+#include <units/angular_velocity.h>
+
+#include "frc/Encoder.h"
+#include "frc/PWMVictorSPX.h"
+#include "frc/RobotController.h"
+#include "frc/controller/PIDController.h"
+#include "frc/controller/SimpleMotorFeedforward.h"
+#include "frc/simulation/EncoderSim.h"
+#include "frc/simulation/PWMSim.h"
+#include "frc/simulation/RoboRioSim.h"
+#include "frc/simulation/SimBattery.h"
+#include "frc/simulation/SimDifferentialDrivetrain.h"
+#include "frc/simulation/ElevatorSim.h"
+#include "frc/simulation/FlywheelSim.h"
+#include "frc/simulation/LinearSystemSim.h"
+#include "frc/simulation/SingleJointedArmSim.h"
+#include "frc/system/plant/LinearSystemId.h"
+#include "gtest/gtest.h"
+
+TEST(StateSpaceSimTest, TestFlywheelSim) {
+  const frc::LinearSystem<1, 1, 1> plant = frc::LinearSystemId::IdentifyVelocitySystem(0.02, 0.01);
+  frc::sim::FlywheelSim sim{plant, frc::DCMotor::NEO(2), 1.0};
+  frc2::PIDController controller{0.2, 0.0, 0.0};
+  frc::SimpleMotorFeedforward<units::radian> feedforward{
+      0_V, 0.02_V / 1_rad_per_s, 0.01_V / 1_rad_per_s_sq};
+  frc::Encoder encoder{0, 1};
+  frc::sim::EncoderSim encoderSim{encoder};
+  frc::PWMVictorSPX motor{0};
+
+  for (int i = 0; i < 100; i++) {
+    // RobotPeriodic runs first
+    auto voltageOut = controller.Calculate(encoder.GetRate(), 200.0);
+    motor.SetVoltage(units::volt_t(voltageOut) +
+                     feedforward.Calculate(200_rad / 1_s));
+
+    // Then, SimulationPeriodic runs
+    frc::sim::RoboRioSim::SetVInVoltage(
+        frc::sim::SimBattery::Calculate({sim.GetCurrentDraw()}).to<double>());
+    sim.SetInput(frc::MakeMatrix<1, 1>(
+        motor.Get() * frc::RobotController::GetInputVoltage()));
+    sim.Update(20_ms);
+    encoderSim.SetRate(sim.GetVelocity().to<double>());
+  }
+
+  ASSERT_TRUE(std::abs(200 - encoder.GetRate()) < 0.1);
+}

--- a/wpilibc/src/test/native/cpp/simulation/SwerveDriveSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/SwerveDriveSimTest.cpp
@@ -1,0 +1,68 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/simulation/SwerveDriveSim.h"
+#include "frc/system/plant/LinearSystemId.h"
+#include "gtest/gtest.h"
+
+frc::sim::SwerveDriveSim<4> sim{
+    50_kg,
+    frc::sim::SimSwerveModule(
+        frc::DCMotor::NEO(1), 8.0, 2_in, frc::Translation2d(1_m, 1_m),
+        frc::LinearSystemId::SingleJointedArmSystem(
+            frc::DCMotor::NEO(1), units::kilogram_square_meter_t(0.01), 10.0)),
+    frc::sim::SimSwerveModule(
+        frc::DCMotor::NEO(1), 8.0, 2_in, frc::Translation2d(1_m, -1_m),
+        frc::LinearSystemId::SingleJointedArmSystem(
+            frc::DCMotor::NEO(1), units::kilogram_square_meter_t(0.01), 10.0)),
+    frc::sim::SimSwerveModule(
+        frc::DCMotor::NEO(1), 8.0, 2_in, frc::Translation2d(-1_m, 1_m),
+        frc::LinearSystemId::SingleJointedArmSystem(
+            frc::DCMotor::NEO(1), units::kilogram_square_meter_t(0.01), 10.0)),
+    frc::sim::SimSwerveModule(
+        frc::DCMotor::NEO(1), 8.0, 2_in, frc::Translation2d(-1_m, -1_m),
+        frc::LinearSystemId::SingleJointedArmSystem(
+            frc::DCMotor::NEO(1), units::kilogram_square_meter_t(0.01), 10.0))};
+
+TEST(SwerveDriveSim, ForceCalculation) {
+  const auto& module = sim.GetModules()[0];
+  units::newton_t force = module.EstimateModuleForce(0_mps, units::volt_t(12));
+
+  // F = a when mass = 1kg
+  // xdot = [vel, accel] = 0x + B u
+  auto system =
+      frc::LinearSystemId::ElevatorSystem(frc::DCMotor::NEO(1), 1_kg, 2_in, 8);
+  auto refForce = system.B() * frc::MakeMatrix<1, 1>(12.0);
+
+  EXPECT_NEAR(refForce(1, 0), force.to<double>(), 0.02);
+}
+
+TEST(SwerveDriveSim, SimulationDrivingForward) {
+  auto desiredSpeeds =
+      sim.GetKinematics().ToSwerveModuleStates({1.0_mps, 2_mps, 0.5_rad_per_s});
+
+  // Seems like ~3.25 volts per meter per second.
+  for (size_t i = 0; i < 200; ++i) {
+    sim.SetModuleDriveVoltages(7.5_V, 7.5_V, 7.5_V, 7.5_V);
+
+    // Simple P loop on heading error.
+    std::array<units::volt_t, 4> moduleVoltages;
+    for (size_t m = 0; m < 4; ++m) {
+      const auto& module = sim.GetModules()[m];
+      const auto& ref = desiredSpeeds[m].angle;
+      const auto& angle = module.GetAzimuthAngle();
+      auto delta = ref - angle;
+      moduleVoltages[m] = units::volt_t(delta.Radians().to<double>() * 10.0);
+    }
+    sim.SetModuleAzimuthVoltages(moduleVoltages);
+    sim.Update(20_ms);
+  }
+
+  EXPECT_NEAR(1.0, sim.GetEstimatedSpeed().vx.to<double>(), 0.1);
+  EXPECT_NEAR(2.0, sim.GetEstimatedSpeed().vy.to<double>(), 0.1);
+  EXPECT_NEAR(0.5, sim.GetEstimatedSpeed().omega.to<double>(), 0.1);
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/LTVDiffDriveController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/LTVDiffDriveController.java
@@ -1,0 +1,358 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.controller;
+
+import org.ejml.simple.SimpleMatrix;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpilibj.system.NumericalJacobian;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpilibj.trajectory.Trajectory;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.MatrixUtils;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.Vector;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N10;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+import edu.wpi.first.wpiutil.math.numbers.N3;
+import edu.wpi.first.wpiutil.math.numbers.N4;
+import edu.wpi.first.wpiutil.math.numbers.N5;
+import edu.wpi.first.wpiutil.math.numbers.N7;
+
+/**
+ * A Linear Time-Varying Differential Drive Controller for differential drive
+ * robots. This class takes in a {@link LinearSystem} of a
+ * differential drive, which can be created from known linear and angular
+ * Kv, and Ka terms with {@link LinearSystemId#identifyDrivetrainSystem}.
+ * This is then used to calculate the model dynamics
+ * {@link LTVDiffDriveController#getDynamics}.
+ *
+ * <p>This controller is advantageous over the {@link LTVUnicycleController}
+ * due to the fact that it is easier to specify the relative weighting of
+ * state vs. input (ex. being able to have the X, Y, Theta controller
+ * have more jurisdiction over the input than the left and right velocity
+ * controller.)
+ *
+ * <p>The current state estimate for the controller can be determined by using
+ * a {@link edu.wpi.first.wpilibj.estimator.DifferentialDriveStateEstimator}.
+ *
+ * <p>Our state-space system is:
+ *
+ * <p><strong> x = [[x, y, theta, vel_l, vel_r]]^T </strong> in the field coordinate system.
+ *
+ * <p><strong> u = [[voltage_l, voltage_r]]^T </strong> the control input.
+ */
+@SuppressWarnings({"ParameterName", "LocalVariableName", "MemberName", "PMD.SingularField"})
+public class LTVDiffDriveController {
+  private final double m_rb;
+  private final LinearSystem<N2, N2, N2> m_plant;
+
+  private Matrix<N5, N1> m_nextR;
+  private Matrix<N2, N1> m_uncappedU;
+
+  private Matrix<N5, N2> m_B;
+  private Matrix<N2, N5> m_K0;
+  private Matrix<N2, N5> m_K1;
+
+  private Matrix<N5, N1> m_stateError;
+
+  private Pose2d m_poseTolerance;
+  private double m_velocityTolerance;
+
+  private DifferentialDriveKinematics m_kinematics;
+
+  /**
+   * Construct a LTV Unicycle Controller.
+   *
+   * @param plant       A {@link LinearSystem} representing a differential drivetrain.
+   * @param controllerQ The maximum desired error tolerance for the robot's state, in
+   *                    the form [X, Y, Heading, leftVelocity, right Velocity]^T.
+   *                    Units are meters and radians for the translation and heading.
+   *                    1 is a good starting value.
+   * @param controllerR The maximum desired control effort by the feedback controller,
+   *                    in the form [voltsLeft, voltsRight]^T.
+   *                    should apply on top of the trajectory feedforward.
+   * @param kinematics  A {@link DifferentialDriveKinematics} object representing the
+   *                    differential drivetrain's kinematics.
+   * @param dtSeconds   The nominal dt of this controller. With command based this is 0.020.
+   */
+  public LTVDiffDriveController(LinearSystem<N2, N2, N2> plant,
+                                Vector<N5> controllerQ,
+                                Vector<N2> controllerR,
+                                DifferentialDriveKinematics kinematics,
+                                double dtSeconds) {
+    this(plant, controllerQ, 1.0, controllerR, kinematics, dtSeconds);
+  }
+
+  /**
+   * Construct a LTV Unicycle Controller.
+   *
+   * @param plant       A {@link LinearSystem} representing a differential drivetrain.
+   * @param controllerQ The maximum desired error tolerance for the robot's state, in
+   *                    the form [X, Y, Heading, leftVelocity, right Velocity]^T.
+   *                    Units are meters and radians for the translation and heading.
+   * @param rho         A weighting factor that balances control effort and state excursion.
+   *                    Greater values penalize state excursion more heavily.
+   *                    1 is a good starting value.
+   * @param controllerR The maximum desired control effort by the feedback controller,
+   *                    in the form [voltsLeft, voltsRight]^T.
+   *                    should apply on top of the trajectory feedforward.
+   * @param kinematics  A {@link DifferentialDriveKinematics} object representing the
+   *                    differential drivetrain's kinematics.
+   * @param dtSeconds   The nominal dt of this controller. With command based this is 0.020.
+   */
+  public LTVDiffDriveController(LinearSystem<N2, N2, N2> plant,
+                                Vector<N5> controllerQ,
+                                double rho,
+                                Vector<N2> controllerR,
+                                DifferentialDriveKinematics kinematics,
+                                double dtSeconds) {
+    this.m_plant = plant;
+    this.m_kinematics = kinematics;
+    this.m_rb = kinematics.trackWidthMeters / 2.0;
+
+    m_poseTolerance = new Pose2d();
+    m_velocityTolerance = 0.0;
+
+    reset();
+
+    var x0 = MatrixUtils.zeros(Nat.N10());
+    x0.set(State.kLeftVelocity.value, 0, 1e-9);
+    x0.set(State.kRightVelocity.value, 0, 1e-9);
+
+    var x1 = MatrixUtils.zeros(Nat.N10());
+    x1.set(State.kLeftVelocity.value, 0, 1);
+    x1.set(State.kRightVelocity.value, 0, 1);
+
+    var u0 = new Matrix<>(Nat.N2(), Nat.N1());
+
+    var a0 = NumericalJacobian.numericalJacobianX(Nat.N10(), Nat.N10(), this::getDynamics, x0, u0)
+        .block(Nat.N5(), Nat.N5(), 0, 0);
+    var a1 = NumericalJacobian.numericalJacobianX(Nat.N10(), Nat.N10(), this::getDynamics, x1, u0)
+        .block(Nat.N5(), Nat.N5(), 0, 0);
+
+    m_B = NumericalJacobian.numericalJacobianU(Nat.N10(), Nat.N2(),
+      this::getDynamics, x0, u0).block(Nat.N5(), Nat.N2(), 0, 0);
+
+    m_K0 = new LinearQuadraticRegulator<N5, N2, N3>(a0, m_B,
+      controllerQ, rho, controllerR, dtSeconds).getK();
+    m_K1 = new LinearQuadraticRegulator<N5, N2, N3>(a1, m_B,
+      controllerQ, rho, controllerR, dtSeconds).getK();
+  }
+
+  @SuppressWarnings("JavadocMethod")
+  protected Matrix<N2, N1> getController(Matrix<N5, N1> x, Matrix<N5, N1> r) {
+    // This implements the linear time-varying differential drive controller in
+    // theorem 8.5.3 of https://tavsys.net/controls-in-frc.
+    double kx = m_K0.get(0, 0);
+    double ky0 = m_K0.get(0, 1);
+    double kvpos0 = m_K0.get(0, 3);
+    double kvneg0 = m_K0.get(1, 3);
+    double ky1 = m_K1.get(0, 1);
+    double ktheta1 = m_K1.get(0, 2);
+    double kvpos1 = m_K1.get(0, 3);
+
+    double v = (x.get(State.kLeftVelocity.value, 0) + x.get(State.kRightVelocity.value, 0)) / 2.0;
+    double sqrtAbsV = Math.sqrt(Math.abs(v));
+
+    var K = new Matrix<N2, N5>(new SimpleMatrix(2, 5));
+    K.set(0, 0, kx);
+    K.set(0, 1, (ky0 + (ky1 - ky0) * sqrtAbsV) * Math.signum(v));
+    K.set(0, 2, ktheta1 * sqrtAbsV);
+    K.set(0, 3, kvpos0 + (kvpos1 - kvpos0) * sqrtAbsV);
+    K.set(0, 4, kvneg0 - (kvpos1 - kvpos0) * sqrtAbsV);
+    K.set(1, 0, kx);
+    K.set(1, 1, -K.get(0, 1));
+    K.set(1, 2, -K.get(0, 2));
+    K.set(1, 3, K.get(0, 4));
+    K.set(1, 4, K.get(0, 3));
+
+    @SuppressWarnings("VariableDeclarationUsageDistance")
+    var inRobotFrame = new Matrix<N5, N5>(SimpleMatrix.identity(5));
+    K.set(0, 0, Math.cos(x.get(2, 0)));
+    K.set(0, 1, Math.sin(x.get(2, 0)));
+    K.set(1, 0, -Math.sin(x.get(2, 0)));
+    K.set(1, 1, Math.cos(x.get(2, 0)));
+
+    Matrix<N5, N1> error = new Matrix<>(r.getStorage().minus(
+        x.getStorage().extractMatrix(0, 5, 0, 1)));
+
+    error.set(State.kHeading.value, 0, normalizeAngle(error.get(State.kHeading.value, 0)));
+
+    return K.times(inRobotFrame).times(error);
+  }
+
+  @SuppressWarnings("JavadocMethod")
+  protected Matrix<N10, N1> getDynamics(Matrix<N10, N1> x, Matrix<N2, N1> u) {
+    Matrix<N4, N2> B = new Matrix<>(new SimpleMatrix(4, 2));
+    B.getStorage().insertIntoThis(0, 0, m_plant.getB().getStorage());
+    B.getStorage().insertIntoThis(2, 0, new SimpleMatrix(2, 2));
+
+    Matrix<N4, N7> A = new Matrix<>(new SimpleMatrix(4, 7));
+    A.getStorage().insertIntoThis(0, 0, m_plant.getA().getStorage());
+
+    A.getStorage().insertIntoThis(2, 0, SimpleMatrix.identity(2));
+    A.getStorage().insertIntoThis(0, 2, new SimpleMatrix(4, 2));
+    A.getStorage().insertIntoThis(0, 4, B.getStorage());
+    A.getStorage().setColumn(6, 0, 0, 0, 1, -1);
+
+    var v = (x.get(State.kLeftVelocity.value, 0) + x.get(State.kRightVelocity.value, 0)) / 2.0;
+
+    var result = new Matrix<N10, N1>(new SimpleMatrix(10, 1));
+    result.set(0, 0, v * Math.cos(x.get(State.kHeading.value, 0)));
+    result.set(1, 0, v * Math.sin(x.get(State.kHeading.value, 0)));
+    result.set(2, 0, (x.get(State.kRightVelocity.value, 0)
+        - x.get(State.kLeftVelocity.value, 0)) / (2.0 * m_rb));
+
+    result.getStorage().insertIntoThis(3, 0, A.times(new Matrix<N7, N1>(
+        x.getStorage().extractMatrix(3, 10, 0, 1))).plus(B.times(u)).getStorage());
+    result.getStorage().insertIntoThis(7, 0, new SimpleMatrix(3, 1));
+    return result;
+  }
+
+  /**
+   * Returns if the controller is at the reference pose on the trajectory.
+   * Note that this is different than if the robot has traversed the entire
+   * trajectory. The tolerance is set by the {@link #setTolerance(Pose2d, double)}
+   * method.
+   *
+   * @return If the robot is within the specified tolerances.
+   */
+  public boolean atReference() {
+    var tolTranslate = m_poseTolerance.getTranslation();
+    var tolRotate = m_poseTolerance.getRotation();
+    return Math.abs(m_stateError.get(0, 0)) < tolTranslate.getX()
+      && Math.abs(m_stateError.get(1, 0)) < tolTranslate.getY()
+      && Math.abs(m_stateError.get(2, 0)) < tolRotate.getRadians()
+      && Math.abs(m_stateError.get(3, 0)) < m_velocityTolerance
+      && Math.abs(m_stateError.get(4, 0)) < m_velocityTolerance;
+  }
+
+  /**
+   * Set the tolerance for if the robot is {@link #atReference()} or not.
+   *
+   * @param poseTolerance     The new pose tolerance.
+   * @param velocityTolerance The velocity tolerance.
+   */
+  public void setTolerance(final Pose2d poseTolerance, final double velocityTolerance) {
+    this.m_poseTolerance = poseTolerance;
+    this.m_velocityTolerance = velocityTolerance;
+  }
+
+  /**
+   * Returns the current controller reference in the form
+   * [X, Y, Heading, LeftVelocity, RightVelocity, LeftPosition].
+   *
+   * @return Matrix [N5, N1] The reference.
+   */
+  public Matrix<N5, N1> getReferences() {
+    return m_nextR;
+  }
+
+  /**
+   * Returns the inputs of the controller in the form [LeftVoltage, RightVoltage].
+   *
+   * @return Matrix [N2, N1] The inputs.
+   */
+  public Matrix<N2, N1> getInputs() {
+    return m_uncappedU;
+  }
+
+  public Matrix<N5, N1> getError() {
+    return m_stateError;
+  }
+
+  /**
+   * Returns the uncapped control input after updating the controller with the given
+   * reference and current states.
+   *
+   * @param currentState The current state of the robot as a vector.
+   * @param stateRef     The reference state vector.
+   * @return The control input as a matrix with motor voltages [left, right].
+   */
+  public Matrix<N2, N1> calculate(
+      Matrix<N5, N1> currentState,
+      Matrix<N5, N1> stateRef) {
+    m_nextR = stateRef;
+    m_stateError = m_nextR.minus(currentState);
+
+    m_uncappedU = getController(currentState, m_nextR);
+
+    return m_uncappedU;
+  }
+
+  /**
+   * Returns the next output of the controller.
+   *
+   * <p>The desired state should come from a {@link Trajectory}.
+   *
+   * @param currentState The current state of the robot as a vector.
+   * @param desiredState The desired pose, linear velocity, and angular velocity
+   *                     from a trajectory.
+   * @return The control input as a matrix with motor voltages [left, right].
+   */
+  public Matrix<N2, N1> calculate(Matrix<N5, N1> currentState,
+                                  Trajectory.State desiredState) {
+    var wheelVelocities = m_kinematics.toWheelSpeeds(
+        new ChassisSpeeds(desiredState.velocityMetersPerSecond,
+        0,
+        desiredState.velocityMetersPerSecond * desiredState.curvatureRadPerMeter));
+
+    Matrix<N5, N1> stateRef = VecBuilder.fill(
+        desiredState.poseMeters.getTranslation().getX(),
+        desiredState.poseMeters.getTranslation().getY(),
+        desiredState.poseMeters.getRotation().getRadians(),
+        wheelVelocities.leftMetersPerSecond,
+        wheelVelocities.rightMetersPerSecond);
+
+    return calculate(currentState, stateRef);
+  }
+
+  /**
+   * Resets the internal state of the controller.
+   */
+  public void reset() {
+    m_nextR = MatrixUtils.zeros(Nat.N5(), Nat.N1());
+    m_uncappedU = MatrixUtils.zeros(Nat.N2(), Nat.N1());
+  }
+
+  @SuppressWarnings("JavadocMethod")
+  public static double normalizeAngle(double angle) {
+    final int n_pi_pos = (int) ((angle + Math.PI) / 2.0 / Math.PI);
+    angle -= n_pi_pos * 2.0 * Math.PI;
+
+    final int n_pi_neg = (int) ((angle - Math.PI) / 2.0 / Math.PI);
+    angle -= n_pi_neg * 2.0 * Math.PI;
+
+    return angle;
+  }
+
+  private enum State {
+    kX(0),
+    kY(1),
+    kHeading(2),
+    kLeftVelocity(3),
+    kRightVelocity(4),
+    kLeftPosition(5),
+    kRightPosition(6),
+    kLeftVoltageError(7),
+    kRightVoltageError(8),
+    kAngularVelocityError(9);
+
+    private final int value;
+
+    State(int i) {
+      this.value = i;
+    }
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/LTVUnicycleController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/LTVUnicycleController.java
@@ -1,0 +1,173 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.controller;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.trajectory.Trajectory;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.Vector;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+import edu.wpi.first.wpiutil.math.numbers.N3;
+
+/**
+ * A Linear Time-Varying Cascaded Unicycle Controller for differential drive
+ * robots. Similar to RAMSETE, this controller combines feedback and feedforward
+ * to output ChassisSpeeds to guide a robot along a trajectory. However, this
+ * controller utilizes tolerances grounded in reality to pick gains rather than
+ * magical Beta and Zeta gains.
+ */
+public class LTVUnicycleController {
+  @SuppressWarnings("MemberName")
+  private final Matrix<N2, N3> m_K0;
+  @SuppressWarnings("MemberName")
+  private final Matrix<N2, N3> m_K1;
+  Pose2d m_poseError;
+  Pose2d m_poseTolerance;
+
+  /**
+   * Construct a LTV Unicycle Controller.
+   *
+   * @param qElms     The maximum desired error tolerance for the robot's state, in
+   *                  the form [X, Y, Heading]^T. Units are meters and radians.
+   * @param rElms     The maximum desired control effort by the feedback controller,
+   *                  in the form [vMax, wMax]^T. Units are meters per second and
+   *                  radians per second. Note that this is not the maximum speed of
+   *                  the robot, but rather the maximum effort the feedback controller
+   *                  should apply on top of the trajectory feedforward.
+   * @param dtSeconds The nominal dt of this controller. With command based this is 0.020.
+   */
+  @SuppressWarnings({"ParameterName", "LocalVariableName"})
+  public LTVUnicycleController(Vector<N3> qElms, Vector<N2> rElms, double dtSeconds) {
+    this(qElms, 1.0, rElms, dtSeconds);
+  }
+
+  /**
+   * Construct a LTV Unicycle Controller.
+   *
+   * @param qElms     The maximum desired error tolerance for the robot's state, in
+   *                  the form [X, Y, Heading]^T. Units are meters and radians.
+   * @param rho       A weighting factor that balances control effort and state excursion.
+   *                  Greater values penalize state excursion more heavily.
+   *                  1 is a good starting value.
+   * @param rElms     The maximum desired control effort by the feedback controller,
+   *                  in the form [vMax, wMax]^T. Units are meters per second and
+   *                  radians per second. Note that this is not the maximum speed of
+   *                  the robot, but rather the maximum effort the feedback controller
+   *                  should apply on top of the trajectory feedforward.
+   * @param dtSeconds The nominal dt of this controller. With command based this is 0.020.
+   */
+  @SuppressWarnings({"ParameterName", "LocalVariableName"})
+  public LTVUnicycleController(
+      Vector<N3> qElms,
+      double rho,
+      Vector<N2> rElms,
+      double dtSeconds) {
+
+    var a0 = new MatBuilder<>(Nat.N3(), Nat.N3()).fill(0, 0, 0, 0, 0, 1e-9, 0, 0, 0);
+    var a1 = new MatBuilder<>(Nat.N3(), Nat.N3()).fill(0, 0, 0, 0, 0, 1, 0, 0, 0);
+    var b = new MatBuilder<>(Nat.N3(), Nat.N2()).fill(1, 0, 0, 0, 0, 1);
+
+    m_K0 = new LinearQuadraticRegulator<N3, N2, N2>(
+      a0, b, qElms.times(rho), rElms, dtSeconds
+    ).getK();
+
+    m_K1 = new LinearQuadraticRegulator<N3, N2, N2>(
+      a1, b, qElms.times(rho), rElms, dtSeconds
+    ).getK();
+  }
+
+  /**
+   * Returns if the controller is at the reference pose on the trajectory.
+   * Note that this is different than if the robot has traversed the entire
+   * trajectory. The tolerance is set by the {@link #setTolerance(Pose2d)}
+   * method.
+   *
+   * @return If the robot is within the specified tolerance of the
+   */
+  public boolean atReference() {
+    var translationError = m_poseError.getTranslation();
+    var rotationError = m_poseError.getRotation();
+    var tolTranslate = m_poseTolerance.getTranslation();
+    var tolRotate = m_poseTolerance.getRotation();
+    return Math.abs(translationError.getX()) < tolTranslate.getX()
+      && Math.abs(translationError.getY()) < tolTranslate.getY()
+      && Math.abs(rotationError.getRadians()) < tolRotate.getRadians();
+  }
+
+  /**
+   * Set the tolerance for if the robot is {@link #atReference()} or not.
+   *
+   * @param poseTolerance The new pose tolerance.
+   */
+  public void setTolerance(final Pose2d poseTolerance) {
+    this.m_poseTolerance = poseTolerance;
+  }
+
+  /**
+   * Returns the next output of the controller.
+   *
+   * <p>The reference pose, linear velocity, and angular velocity should come
+   * from a {@link Trajectory}.
+   *
+   * @param currentPose                   The current position of the robot.
+   * @param poseRef                       The desired pose of the robot.
+   * @param linearVelocityRefMetersPerSec The desired linear velocity of the robot.
+   * @param angularVelocityRefRadPerSec   The desired angular velocity of the robot.
+   * @return The next calculated output.
+   */
+  public ChassisSpeeds calculate(Pose2d currentPose, Pose2d poseRef,
+                                 double linearVelocityRefMetersPerSec,
+                                 double angularVelocityRefRadPerSec) {
+
+    m_poseError = poseRef.relativeTo(currentPose);
+
+    var kx = m_K0.get(0, 0);
+    var ky0 = m_K0.get(1, 1);
+    var ky1 = m_K1.get(1, 1);
+    var ktheta1 = m_K1.get(1, 2);
+
+    var sqrtAbsV = Math.sqrt(Math.abs(linearVelocityRefMetersPerSec));
+    var gain = new MatBuilder<>(Nat.N2(), Nat.N3())
+        .fill(kx, 0, 0, 0,
+        (ky0 + (ky1 - ky0) * sqrtAbsV) * Math.signum(linearVelocityRefMetersPerSec),
+        ktheta1 * sqrtAbsV);
+
+    var error = new MatBuilder<>(Nat.N3(), Nat.N1()).fill(
+        m_poseError.getTranslation().getX(),
+        m_poseError.getTranslation().getY(),
+        m_poseError.getRotation().getRadians());
+
+    @SuppressWarnings("LocalVariableName")
+    var u = gain.times(error);
+
+    return new ChassisSpeeds(
+      linearVelocityRefMetersPerSec + u.get(0, 0),
+      0.0,
+      angularVelocityRefRadPerSec + u.get(1, 0));
+  }
+
+  /**
+   * Returns the next output of the controller.
+   *
+   * <p>The reference pose and desired state should come from a {@link Trajectory}.
+   *
+   * @param currentPose  The current pose.
+   * @param desiredState The desired pose, linear velocity, and angular velocity
+   *                     from a trajectory.
+   * @return The calculated {@link ChassisSpeeds}.
+   */
+  public ChassisSpeeds calculate(Pose2d currentPose, Trajectory.State desiredState) {
+    return calculate(currentPose, desiredState.poseMeters,
+      desiredState.velocityMetersPerSecond,
+      desiredState.velocityMetersPerSecond * desiredState.curvatureRadPerMeter);
+  }
+
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimator.java
@@ -1,0 +1,289 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.function.BiConsumer;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.math.Discretization;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N3;
+import edu.wpi.first.wpiutil.math.numbers.N5;
+
+/**
+ * This class wraps an
+ * {@link edu.wpi.first.wpilibj.estimator.ExtendedKalmanFilter Extended Kalman Filter}
+ * to fuse latency-compensated vision
+ * measurements with differential drive encoder measurements. It will correct
+ * for noisy vision measurements and encoder drift. It is intended to be an easy
+ * drop-in for
+ * {@link edu.wpi.first.wpilibj.kinematics.DifferentialDriveOdometry}; in fact,
+ * if you never call {@link DifferentialDrivePoseEstimator#addVisionMeasurement}
+ * and only call {@link DifferentialDrivePoseEstimator#update} then this will
+ * behave exactly the same as DifferentialDriveOdometry.
+ *
+ * <p>{@link DifferentialDrivePoseEstimator#update} should be called every robot
+ * loop (if your robot loops are faster than the default then you should change
+ * the {@link DifferentialDrivePoseEstimator#DifferentialDrivePoseEstimator(Rotation2d, Pose2d,
+ * Matrix, Matrix, Matrix, double) nominal delta time}.)
+ * {@link DifferentialDrivePoseEstimator#addVisionMeasurement} can be called as
+ * infrequently as you want; if you never call it then this class will behave
+ * exactly like regular encoder odometry.
+ *
+ * <p>Our state-space system is:
+ *
+ * <p><strong> x = [[x, y, theta, dist_l, dist_r]]^T </strong>
+ * in the field coordinate system (dist_* are wheel distances.)
+ *
+ * <p><strong> u = [[vx, vy, omega]]^T </strong> (robot-relative velocities)
+ *  -- NB: using velocities make things considerably easier, because it means that
+ * teams don't have to worry about getting an accurate model.
+ * Basically, we suspect that it's easier for teams to get good encoder data than it is for
+ * them to perform system identification well enough to get a good model.
+ *
+ * <p><strong>y = [[x, y, theta]]^T </strong> from vision,
+ * or <strong>y = [[dist_l, dist_r, theta]] </strong> from encoders and gyro.
+ */
+public class DifferentialDrivePoseEstimator {
+  private final ExtendedKalmanFilter<N5, N3, N3> m_observer;
+  private final BiConsumer<Matrix<N3, N1>, Matrix<N3, N1>> m_visionCorrect;
+  private final KalmanFilterLatencyCompensator<N5, N3, N3> m_latencyCompensator;
+
+  private final double m_nominalDt; // Seconds
+  private double m_prevTimeSeconds = -1.0;
+
+  private Rotation2d m_gyroOffset;
+  private Rotation2d m_previousAngle;
+
+  /**
+   * Constructs a DifferentialDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the encoder and gyro measurements.
+   *                                 Increase these numbers to trust encoder distances and gyro
+   *                                 angle less.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder measurements. Increase
+   *                                 these numbers to trust vision less.
+   */
+  public DifferentialDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters,
+          Matrix<N5, N1> stateStdDevs,
+          Matrix<N3, N1> localMeasurementStdDevs, Matrix<N3, N1> visionMeasurementStdDevs
+  ) {
+    this(gyroAngle, initialPoseMeters,
+            stateStdDevs, localMeasurementStdDevs, visionMeasurementStdDevs, 0.02);
+  }
+
+  /**
+   * Constructs a DifferentialDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the encoder and gyro measurements.
+   *                                 Increase these numbers to trust encoder distances and gyro
+   *                                 angle less.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder measurements. Increase
+   *                                 these numbers to trust vision less.
+   * @param nominalDtSeconds         The time in seconds between each robot loop.
+   */
+  @SuppressWarnings("ParameterName")
+  public DifferentialDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters,
+          Matrix<N5, N1> stateStdDevs,
+          Matrix<N3, N1> localMeasurementStdDevs, Matrix<N3, N1> visionMeasurementStdDevs,
+          double nominalDtSeconds
+  ) {
+    m_nominalDt = nominalDtSeconds;
+
+    m_observer = new ExtendedKalmanFilter<>(
+        Nat.N5(), Nat.N3(), Nat.N3(),
+        this::f,
+        (x, u) -> VecBuilder.fill(x.get(3, 0), x.get(4, 0), x.get(2, 0)),
+        stateStdDevs, localMeasurementStdDevs,
+        m_nominalDt
+    );
+    m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
+
+    var visionContR = StateSpaceUtil.makeCovarianceMatrix(Nat.N3(), visionMeasurementStdDevs);
+    var visionDiscR = Discretization.discretizeR(visionContR, m_nominalDt);
+    m_visionCorrect = (u, y) -> m_observer.correct(
+        Nat.N3(), u, y,
+        (x, u_) -> new Matrix<>(x.getStorage().extractMatrix(0, 3, 0, 1)),
+        visionDiscR
+    );
+
+    m_gyroOffset = initialPoseMeters.getRotation().minus(gyroAngle);
+    m_previousAngle = initialPoseMeters.getRotation();
+    m_observer.setXhat(fillStateVector(initialPoseMeters, 0.0, 0.0));
+  }
+
+  @SuppressWarnings({"ParameterName", "MethodName"})
+  private Matrix<N5, N1> f(Matrix<N5, N1> x, Matrix<N3, N1> u) {
+    // Apply a rotation matrix. Note that we do *not* add x--Runge-Kutta does that for us.
+    var theta = x.get(2, 0);
+    var toFieldRotation = new MatBuilder<>(Nat.N5(), Nat.N5()).fill(
+            Math.cos(theta), -Math.sin(theta), 0, 0, 0,
+            Math.sin(theta), Math.cos(theta), 0, 0, 0,
+            0, 0, 1, 0, 0,
+            0, 0, 0, 1, 0,
+            0, 0, 0, 0, 1
+    );
+    return toFieldRotation.times(VecBuilder.fill(
+            u.get(0, 0), u.get(1, 0), u.get(2, 0), u.get(0, 0), u.get(1, 0)
+    ));
+  }
+
+  /**
+   * Resets the robot's position on the field.
+   *
+   * <p>You NEED to reset your encoders (to zero) when calling this method.
+   *
+   * <p>The gyroscope angle does not need to be reset here on the user's robot code.
+   * The library automatically takes care of offsetting the gyro angle.
+   *
+   * @param poseMeters The position on the field that your robot is at.
+   * @param gyroAngle  The angle reported by the gyroscope.
+   */
+  public void resetPosition(Pose2d poseMeters, Rotation2d gyroAngle) {
+    m_previousAngle = poseMeters.getRotation();
+    m_gyroOffset = getEstimatedPosition().getRotation().minus(gyroAngle);
+    m_observer.setXhat(fillStateVector(poseMeters, 0.0, 0.0));
+  }
+
+  /**
+   * Gets the pose of the robot at the current time as estimated by the Extended Kalman Filter.
+   *
+   * @return The estimated robot pose in meters.
+   */
+  public Pose2d getEstimatedPosition() {
+    return new Pose2d(
+            m_observer.getXhat(0),
+            m_observer.getXhat(1),
+            new Rotation2d(m_observer.getXhat(2))
+    );
+  }
+
+  /**
+   * Add a vision measurement to the Extended Kalman Filter. This will correct the
+   * odometry pose estimate while still accounting for measurement noise.
+   *
+   * <p>This method can be called as infrequently as you want, as long as you are
+   * calling {@link DifferentialDrivePoseEstimator#update} every loop.
+   *
+   * @param visionRobotPoseMeters The pose of the robot as measured by the vision
+   *                              camera.
+   * @param timestampSeconds      The timestamp of the vision measurement in seconds. Note that if
+   *                              you don't use your own time source by calling
+   *                              {@link DifferentialDrivePoseEstimator#updateWithTime} then you
+   *                              must use a timestamp with an epoch since FPGA startup
+   *                              (i.e. the epoch of this timestamp is the same epoch as
+   *                              {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp
+   *                              Timer.getFPGATimestamp}.) This means that you should
+   *                              use Timer.getFPGATimestamp as your time source in
+   *                              this case.
+   */
+  public void addVisionMeasurement(Pose2d visionRobotPoseMeters, double timestampSeconds) {
+    m_latencyCompensator.applyPastGlobalMeasurement(
+            Nat.N3(),
+            m_observer, m_nominalDt,
+            StateSpaceUtil.poseTo3dVector(visionRobotPoseMeters),
+            m_visionCorrect,
+            timestampSeconds
+    );
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder information.
+   * Note that this should be called every loop.
+   *
+   * @param gyroAngle                      The current gyro angle.
+   * @param wheelVelocitiesMetersPerSecond The velocities of the wheels in meters per second.
+   * @param distanceLeftMeters             The total distance travelled by the left wheel in meters
+   *                                       since the last time you called
+   *                                       {@link DifferentialDrivePoseEstimator#resetPosition}.
+   * @param distanceRightMeters            The total distance travelled by the right wheel in meters
+   *                                       since the last time you called
+   *                                       {@link DifferentialDrivePoseEstimator#resetPosition}.
+   * @return The estimated pose of the robot in meters.
+   */
+  public Pose2d update(
+          Rotation2d gyroAngle,
+          DifferentialDriveWheelSpeeds wheelVelocitiesMetersPerSecond,
+          double distanceLeftMeters, double distanceRightMeters
+  ) {
+    return updateWithTime(
+            Timer.getFPGATimestamp(), gyroAngle, wheelVelocitiesMetersPerSecond,
+            distanceLeftMeters, distanceRightMeters
+    );
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder information.
+   * Note that this should be called every loop.
+   *
+   * @param currentTimeSeconds             Time at which this method was called, in seconds.
+   * @param gyroAngle                      The current gyro angle.
+   * @param wheelVelocitiesMetersPerSecond The velocities of the wheels in meters per second.
+   * @param distanceLeftMeters             The total distance travelled by the left wheel in meters
+   *                                       since the last time you called
+   *                                       {@link DifferentialDrivePoseEstimator#resetPosition}.
+   * @param distanceRightMeters            The total distance travelled by the right wheel in meters
+   *                                       since the last time you called
+   *                                       {@link DifferentialDrivePoseEstimator#resetPosition}.
+   * @return The estimated pose of the robot in meters.
+   */
+  @SuppressWarnings({"LocalVariableName", "ParameterName"})
+  public Pose2d updateWithTime(
+          double currentTimeSeconds, Rotation2d gyroAngle,
+          DifferentialDriveWheelSpeeds wheelVelocitiesMetersPerSecond,
+          double distanceLeftMeters, double distanceRightMeters
+  ) {
+    double dt = m_prevTimeSeconds >= 0 ? currentTimeSeconds - m_prevTimeSeconds : m_nominalDt;
+    m_prevTimeSeconds = currentTimeSeconds;
+
+    var angle = gyroAngle.plus(m_gyroOffset);
+    // Diff drive forward kinematics:
+    // v_c = (v_l + v_r) / 2
+    var wheelVels = wheelVelocitiesMetersPerSecond;
+    var u = VecBuilder.fill(
+            (wheelVels.leftMetersPerSecond + wheelVels.rightMetersPerSecond) / 2, 0,
+            angle.minus(m_previousAngle).getRadians() / dt
+    );
+    m_previousAngle = angle;
+
+    var localY = VecBuilder.fill(distanceLeftMeters, distanceRightMeters, angle.getRadians());
+    m_latencyCompensator.addObserverState(m_observer, u, localY, currentTimeSeconds);
+    m_observer.predict(u, dt);
+    m_observer.correct(u, localY);
+
+    return getEstimatedPosition();
+  }
+
+  private static Matrix<N5, N1> fillStateVector(Pose2d pose, double leftDist, double rightDist) {
+    return VecBuilder.fill(
+            pose.getTranslation().getX(),
+            pose.getTranslation().getY(),
+            pose.getRotation().getRadians(),
+            leftDist,
+            rightDist
+    );
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDriveStateEstimator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDriveStateEstimator.java
@@ -1,0 +1,358 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.function.BiConsumer;
+
+import org.ejml.simple.SimpleMatrix;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.math.Discretization;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.MatrixUtils;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N10;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+import edu.wpi.first.wpiutil.math.numbers.N3;
+import edu.wpi.first.wpiutil.math.numbers.N4;
+import edu.wpi.first.wpiutil.math.numbers.N7;
+
+/**
+ * This class wraps an
+ * {@link edu.wpi.first.wpilibj.estimator.ExtendedKalmanFilter Extended Kalman Filter}
+ * to fuse latency-compensated global measurements(ex. vision) with differential drive encoder
+ * measurements. It will correct for noisy global measurements and encoder drift.
+ *
+ * <p>This class is indented to be paired with
+ * {@link edu.wpi.first.wpilibj.controller.LTVDiffDriveController} as it provides a
+ * 10-state estimate. This can then be trimmed into 5-state using {@link Matrix#block}
+ * with the operation
+ * <code>
+ * "10-stateEstimate".block(Nat.N5(), Nat.N1(), new Pair(0, 0))
+ * </code>
+ * then passed into the controller as the current state estimate.
+ *
+ * <p>{@link DifferentialDriveStateEstimator#update} should be called every robot
+ * loop (if your robot loops are faster than the default then you should change
+ * the {@link DifferentialDriveStateEstimator#DifferentialDriveStateEstimator(LinearSystem,
+ * Matrix, Matrix, Matrix, Matrix, DifferentialDriveKinematics, double) nominal delta time}.)
+ *
+ * <p>{@link DifferentialDriveStateEstimator#applyPastGlobalMeasurement} can be called as
+ * infrequently as you want.
+ *
+ * <p>Our state-space system is:
+ *
+ * <p>x = [[x, y, theta, vel_l, vel_r, dist_l, dist_r, voltError_l, voltError_r, headingError]]^T
+ * in the field coordinate system (dist_* are wheel distances.)
+ *
+ * <p>u = [[voltage_l, voltage_r]]^T This is typically the control input of the last timestep
+ * from a {@link edu.wpi.first.wpilibj.controller.LTVDiffDriveController}.
+ *
+ * <p>y = [[x, y, theta]]^T from a global measurement source(ex. vision),
+ * or y = [[dist_l, dist_r, theta]] from encoders and gyro.
+ */
+@SuppressWarnings({"ParameterName", "LocalVariableName", "MemberName", "PMD.SingularField"})
+public class DifferentialDriveStateEstimator {
+  private final ExtendedKalmanFilter<N10, N2, N3> m_observer;
+  private final KalmanFilterLatencyCompensator<N10, N2, N3> m_latencyCompensator;
+
+  private final BiConsumer<Matrix<N2, N1>, Matrix<N3, N1>> m_globalCorrect;
+
+  private final double m_rb;
+  private final LinearSystem<N2, N2, N2> m_plant;
+
+  private final double m_nominalDt; // Seconds
+  private double m_prevTimeSeconds = -1.0;
+
+
+  private Matrix<N3, N1> m_localY;
+  private Matrix<N3, N1> m_globalY;
+
+  /**
+   * Constructs a DifferentialDriveStateEstimator.
+   *
+   * @param plant                    A {@link LinearSystem} representing a differential drivetrain.
+   * @param initialState             The starting state estimate.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your model less.
+   * @param localMeasurementStdDevs  Standard deviations of the encoder and gyro measurements.
+   *                                 Increase these numbers to trust encoder distances and gyro
+   *                                 angle less.
+   * @param globalMeasurementStdDevs Standard deviations of the global(vision) measurements.
+   *                                 Increase these numbers to global(vision) measurements less.
+   * @param kinematics               A {@link DifferentialDriveKinematics} object representing the
+   *                                 differential drivetrain's kinematics.
+   */
+  public DifferentialDriveStateEstimator(LinearSystem<N2, N2, N2> plant,
+                                        Matrix<N10, N1> initialState,
+                                        Matrix<N10, N1> stateStdDevs,
+                                        Matrix<N3, N1> localMeasurementStdDevs,
+                                        Matrix<N3, N1> globalMeasurementStdDevs,
+                                        DifferentialDriveKinematics kinematics
+  ) {
+    this(plant, initialState, stateStdDevs,
+            localMeasurementStdDevs, globalMeasurementStdDevs, kinematics, 0.02);
+  }
+
+  /**
+   * Constructs a DifferentialDriveStateEstimator.
+   *
+   * @param plant                    A {@link LinearSystem} representing a differential drivetrain.
+   * @param initialState             The starting state estimate.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the encoder and gyro measurements.
+   *                                 Increase these numbers to trust encoder distances and gyro
+   *                                 angle less.
+   * @param globalMeasurementStdDevs Standard deviations of the global(vision) measurements.
+   *                                 Increase these numbers to global(vision) measurements less.
+   * @param kinematics               A {@link DifferentialDriveKinematics} object representing the
+   *                                 differential drivetrain's kinematics.
+   * @param nominalDtSeconds         The time in seconds between each robot loop.
+   */
+  public DifferentialDriveStateEstimator(
+          LinearSystem<N2, N2, N2> plant,
+          Matrix<N10, N1> initialState,
+          Matrix<N10, N1> stateStdDevs,
+          Matrix<N3, N1> localMeasurementStdDevs,
+          Matrix<N3, N1> globalMeasurementStdDevs,
+          DifferentialDriveKinematics kinematics,
+          double nominalDtSeconds
+  ) {
+    m_nominalDt = nominalDtSeconds;
+    m_plant = plant;
+    m_rb = kinematics.trackWidthMeters / 2.0;
+
+    m_localY = MatrixUtils.zeros(Nat.N3());
+    m_globalY = MatrixUtils.zeros(Nat.N3());
+
+    // Create R (covariances) for global measurements.
+    var globalContR = StateSpaceUtil.makeCovarianceMatrix(Nat.N3(), globalMeasurementStdDevs);
+    var globalDiscR = Discretization.discretizeR(globalContR, m_nominalDt);
+
+    m_observer = new ExtendedKalmanFilter<>(
+      Nat.N10(), Nat.N2(), Nat.N3(),
+      this::getDynamics,
+      this::getLocalMeasurementModel,
+      stateStdDevs,
+      localMeasurementStdDevs,
+      nominalDtSeconds
+   );
+
+    // Create correction mechanism for global measurements.
+    m_globalCorrect = (u, y) -> m_observer.correct(
+      Nat.N3(), u, y,
+      this::getGlobalMeasurementModel,
+      globalDiscR
+    );
+    m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
+
+    reset(initialState);
+  }
+
+  @SuppressWarnings("JavadocMethod")
+  protected Matrix<N10, N1> getDynamics(Matrix<N10, N1> x, Matrix<N2, N1> u) {
+    Matrix<N4, N2> B = new Matrix<>(new SimpleMatrix(4, 2));
+    B.getStorage().insertIntoThis(0, 0, m_plant.getB().getStorage());
+    B.getStorage().insertIntoThis(2, 0, new SimpleMatrix(2, 2));
+
+    Matrix<N4, N7> A = new Matrix<>(new SimpleMatrix(4, 7));
+    A.getStorage().insertIntoThis(0, 0, m_plant.getA().getStorage());
+
+    A.getStorage().insertIntoThis(2, 0, SimpleMatrix.identity(2));
+    A.getStorage().insertIntoThis(0, 2, new SimpleMatrix(4, 2));
+    A.getStorage().insertIntoThis(0, 4, B.getStorage());
+    A.getStorage().setColumn(6, 0, 0, 0, 1, -1);
+
+    var v = (x.get(State.kLeftVelocity.value, 0) + x.get(State.kRightVelocity.value, 0)) / 2.0;
+
+    var result = new Matrix<N10, N1>(new SimpleMatrix(10, 1));
+    result.set(0, 0, v * Math.cos(x.get(State.kHeading.value, 0)));
+    result.set(1, 0, v * Math.sin(x.get(State.kHeading.value, 0)));
+    result.set(2, 0, (x.get(State.kRightVelocity.value, 0)
+            - x.get(State.kLeftVelocity.value, 0)) / (2.0 * m_rb));
+
+    result.getStorage().insertIntoThis(3, 0, A.times(new Matrix<N7, N1>(
+            x.getStorage().extractMatrix(3, 10, 0, 1))).plus(B.times(u)).getStorage());
+    result.getStorage().insertIntoThis(7, 0, new SimpleMatrix(3, 1));
+    return result;
+  }
+
+  @SuppressWarnings("JavadocMethod")
+  public Matrix<N3, N1> getLocalMeasurementModel(Matrix<N10, N1> x, Matrix<N2, N1> u) {
+    return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(x.get(State.kHeading.value, 0),
+            x.get(State.kLeftPosition.value, 0), x.get(State.kRightPosition.value, 0));
+  }
+
+  @SuppressWarnings("JavadocMethod")
+  public Matrix<N3, N1> getGlobalMeasurementModel(Matrix<N10, N1> x, Matrix<N2, N1> u) {
+    return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(
+        x.get(State.kX.value, 0),
+        x.get(State.kY.value, 0),
+        x.get(State.kHeading.value, 0)
+    );
+  }
+
+  /**
+   * Applies a global measurement with a given timestamp.
+   *
+   * @param robotPoseMeters  The measured robot pose.
+   * @param timestampSeconds The timestamp of the global measurement in seconds. Note that if
+   *                         you don't use your own time source by calling
+   *                         {@link DifferentialDriveStateEstimator#updateWithTime} then you
+   *                         must use a timestamp with an epoch since FPGA startup
+   *                         (i.e. the epoch of this timestamp is the same epoch as
+   *                         {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp
+   *                         Timer.getFPGATimestamp}.) This means that you should
+   *                         use Timer.getFPGATimestamp as your time source in
+   *                         this case.
+   */
+  public void applyPastGlobalMeasurement(Pose2d robotPoseMeters,
+                                         double timestampSeconds) {
+    m_globalY.set(GlobalOutput.kX.value, 0, robotPoseMeters.getTranslation().getX());
+    m_globalY.set(GlobalOutput.kY.value, 0, robotPoseMeters.getTranslation().getY());
+    m_globalY.set(GlobalOutput.kHeading.value, 0, robotPoseMeters.getRotation().getRadians());
+
+    m_latencyCompensator.applyPastGlobalMeasurement(
+            Nat.N3(),
+            m_observer, m_nominalDt,
+            m_globalY,
+            m_globalCorrect,
+            timestampSeconds
+    );
+  }
+
+  /**
+   * Gets the state of the robot at the current time as estimated by the Extended Kalman Filter.
+   *
+   * @return The robot state estimate.
+   */
+  public Matrix<N10, N1> getEstimatedState() {
+    return m_observer.getXhat();
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using wheel encoder information, robot heading and the
+   * previous control input. The control input can be obtained from a
+   * {@link edu.wpi.first.wpilibj.controller.LTVDiffDriveController}.
+   * Note that this should be called every loop.
+   *
+   * @param headingRadians The current heading of the robot in radians.
+   * @param leftPosition   The distance traveled by the left side of the robot in meters.
+   * @param rightPosition  The distance traveled by the right side of the robot in meters.
+   * @param controlInput   The control input from the last timestep.
+   * @return The robot state estimate.
+   */
+  public Matrix<N10, N1> update(double headingRadians, double leftPosition,
+                                double rightPosition,
+                                Matrix<N2, N1> controlInput) {
+    return updateWithTime(headingRadians,
+            leftPosition,
+            rightPosition,
+            controlInput,
+            Timer.getFPGATimestamp());
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using wheel encoder information, robot heading and the
+   * previous control input. The control input can be obtained from a
+   * {@link edu.wpi.first.wpilibj.controller.LTVDiffDriveController}.
+   * Note that this should be called every loop.
+   *
+   * @param headingRadians     The current heading of the robot in radians.
+   * @param leftPosition       The distance traveled by the left side of the robot in meters.
+   * @param rightPosition      The distance traveled by the right side of the robot in meters.
+   * @param controlInput       The control input.
+   * @param currentTimeSeconds Time at which this method was called, in seconds.
+   * @return The robot state estimate.
+   */
+  @SuppressWarnings("VariableDeclarationUsageDistance")
+  public Matrix<N10, N1> updateWithTime(double headingRadians, double leftPosition,
+                                        double rightPosition,
+                                        Matrix<N2, N1> controlInput,
+                                        double currentTimeSeconds) {
+    double dt = m_prevTimeSeconds >= 0 ? currentTimeSeconds - m_prevTimeSeconds : m_nominalDt;
+    m_prevTimeSeconds = currentTimeSeconds;
+
+    m_localY.set(LocalOutput.kHeading.value, 0, headingRadians);
+    m_localY.set(LocalOutput.kLeftPosition.value, 0, leftPosition);
+    m_localY.set(LocalOutput.kRightPosition.value, 0, rightPosition);
+
+    m_latencyCompensator.addObserverState(m_observer, controlInput, m_localY, currentTimeSeconds);
+
+    m_observer.predict(controlInput, dt);
+    m_observer.correct(controlInput, m_localY);
+
+    return getEstimatedState();
+  }
+
+  /**
+   * Resets any internal state with a given initial state.
+   *
+   * @param initialState Initial state for state estimate.
+   */
+  public void reset(Matrix<N10, N1> initialState) {
+    m_observer.reset();
+
+    m_observer.setXhat(initialState);
+  }
+
+  /**
+   * Resets any internal state.
+   */
+  public void reset() {
+    m_observer.reset();
+  }
+
+  private enum State {
+    kX(0),
+    kY(1),
+    kHeading(2),
+    kLeftVelocity(3),
+    kRightVelocity(4),
+    kLeftPosition(5),
+    kRightPosition(6),
+    kLeftVoltageError(7),
+    kRightVoltageError(8),
+    kAngularVelocityError(9);
+
+    private final int value;
+
+    State(int i) {
+      this.value = i;
+    }
+  }
+
+  private enum LocalOutput {
+    kHeading(0), kLeftPosition(1), kRightPosition(2);
+
+    private final int value;
+
+    LocalOutput(int i) {
+      this.value = i;
+    }
+  }
+
+  private enum GlobalOutput {
+    kX(0),
+    kY(1),
+    kHeading(2);
+
+    private final int value;
+
+    GlobalOutput(int i) {
+      this.value = i;
+    }
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilterLatencyCompensator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilterLatencyCompensator.java
@@ -1,0 +1,142 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.Num;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+
+public class KalmanFilterLatencyCompensator<S extends Num, I extends Num, O extends Num> {
+  private static final int k_maxPastObserverStates = 300;
+
+  private final List<Map.Entry<Double, ObserverSnapshot>> m_pastObserverSnapshots;
+
+  KalmanFilterLatencyCompensator() {
+    m_pastObserverSnapshots = new ArrayList<>();
+  }
+
+  @SuppressWarnings("ParameterName")
+  public void addObserverState(
+          KalmanTypeFilter<S, I, O> observer, Matrix<I, N1> u, Matrix<O, N1> localY,
+          double timestampSeconds
+  ) {
+    m_pastObserverSnapshots.add(Map.entry(
+            timestampSeconds, new ObserverSnapshot(observer, u, localY)
+    ));
+
+    if (m_pastObserverSnapshots.size() > k_maxPastObserverStates) {
+      m_pastObserverSnapshots.remove(0);
+    }
+  }
+
+  @SuppressWarnings({"ParameterName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  public <R extends Num> void applyPastGlobalMeasurement(
+          Nat<R> rows,
+          KalmanTypeFilter<S, I, O> observer,
+          double nominalDtSeconds,
+          Matrix<R, N1> globalMeasurement,
+          BiConsumer<Matrix<I, N1>, Matrix<R, N1>> globalMeasurementCorrect,
+          double globalMeasurementTimestampSeconds
+  ) {
+    if (m_pastObserverSnapshots.isEmpty()) {
+      // State map was empty, which means that we got a past measurement right at startup. The only
+      // thing we can really do is ignore the measurement.
+      return;
+    }
+
+    // This index starts at one because we use the previous state later on, and we always want to
+    // have a "previous state".
+    int maxIdx = m_pastObserverSnapshots.size() - 1;
+    int low = 1;
+    int high = Math.max(maxIdx, 1);
+
+    while (low != high) {
+      int mid = (low + high) / 2;
+      if (m_pastObserverSnapshots.get(mid).getKey() < globalMeasurementTimestampSeconds) {
+        // This index and everything under it are less than the requested timestamp. Therefore, we
+        // can discard them.
+        low = mid + 1;
+      } else {
+        // t is at least as large as the element at this index. This means that anything after it
+        // cannot be what we are looking for.
+        high = mid;
+      }
+    }
+
+    // We are simply assigning this index to a new variable to avoid confusion
+    // with variable names.
+    int index = low;
+    double timestamp = globalMeasurementTimestampSeconds;
+    int indexOfClosestEntry =
+        Math.abs(timestamp - m_pastObserverSnapshots.get(index - 1).getKey())
+            <= Math.abs(timestamp - m_pastObserverSnapshots.get(Math.min(index, maxIdx)).getKey())
+            ? index - 1
+            : index;
+
+    double lastTimestamp =
+            m_pastObserverSnapshots.get(indexOfClosestEntry).getKey() - nominalDtSeconds;
+
+    // We will now go back in time to the state of the system at the time when
+    // the measurement was captured. We will reset the observer to that state,
+    // and apply correction based on the measurement. Then, we will go back
+    // through all observer states until the present and apply past inputs to
+    // get the present estimated state.
+    for (int i = indexOfClosestEntry; i < m_pastObserverSnapshots.size(); i++) {
+      var key = m_pastObserverSnapshots.get(i).getKey();
+      var snapshot = m_pastObserverSnapshots.get(i).getValue();
+
+      if (i == indexOfClosestEntry) {
+        observer.setP(snapshot.errorCovariances);
+        observer.setXhat(snapshot.xHat);
+      }
+
+      observer.predict(snapshot.inputs, key - lastTimestamp);
+      observer.correct(snapshot.inputs, snapshot.localMeasurements);
+
+      if (i == indexOfClosestEntry) {
+        // Note that the measurement is at a timestep close but probably not exactly equal to the
+        // timestep for which we called predict.
+        // This makes the assumption that the dt is small enough that the difference between the
+        // measurement time and the time that the inputs were captured at is very small.
+        globalMeasurementCorrect.accept(snapshot.inputs, globalMeasurement);
+      }
+      lastTimestamp = key;
+
+      m_pastObserverSnapshots.set(i, Map.entry(key,
+              new ObserverSnapshot(observer, snapshot.inputs, snapshot.localMeasurements)));
+    }
+  }
+
+  /**
+   * This class contains all the information about our observer at a given time.
+   */
+  @SuppressWarnings("MemberName")
+  public class ObserverSnapshot {
+    public final Matrix<S, N1> xHat;
+    public final Matrix<S, S> errorCovariances;
+    public final Matrix<I, N1> inputs;
+    public final Matrix<O, N1> localMeasurements;
+
+    @SuppressWarnings("ParameterName")
+    private ObserverSnapshot(
+            KalmanTypeFilter<S, I, O> observer, Matrix<I, N1> u, Matrix<O, N1> localY
+    ) {
+      this.xHat = observer.getXhat();
+      this.errorCovariances = observer.getP();
+
+      inputs = u;
+      localMeasurements = localY;
+    }
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/MecanumDrivePoseEstimator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/MecanumDrivePoseEstimator.java
@@ -1,0 +1,259 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.function.BiConsumer;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.MecanumDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.MecanumDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.math.Discretization;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+import edu.wpi.first.wpiutil.math.numbers.N3;
+import edu.wpi.first.wpiutil.math.numbers.N4;
+
+/**
+ * This class wraps an {@link ExtendedKalmanFilter ExtendedKalmanFilter} to fuse
+ * latency-compensated vision measurements with mecanum drive encoder velocity measurements.
+ * It will correct for noisy measurements and encoder drift. It is intended to be an easy
+ * but more accurate drop-in for {@link edu.wpi.first.wpilibj.kinematics.MecanumDriveOdometry}.
+ *
+ * <p>{@link MecanumDrivePoseEstimator#update} should be called every robot loop. If
+ * your loops are faster or slower than the default of 0.02s, then you should change
+ * the nominal delta time using the secondary constructor:
+ * {@link MecanumDrivePoseEstimator#MecanumDrivePoseEstimator(Rotation2d, Pose2d,
+ * MecanumDriveKinematics, Matrix, Matrix, Matrix, double)}.
+ *
+ * <p>{@link MecanumDrivePoseEstimator#addVisionMeasurement} can be called as
+ * infrequently as you want; if you never call it, then this class will behave mostly like regular
+ * encoder odometry.
+ *
+ * <p>Our state-space system is:
+ *
+ * <p><strong> x = [[x, y, cos(theta), sin(theta)]]^T </strong> in the field-coordinate system.
+ *
+ * <p><strong> u = [[vx, vy, omega]]^T </strong> in the field-coordinate system.
+ *
+ * <p><strong> y = [[x, y, cos(theta), sin(theta)]]^T </strong> in field coords from vision,
+ * or <strong> y = [[cos(theta), sin(theta)]]^T </strong> from the gyro.
+ */
+public class MecanumDrivePoseEstimator {
+  private final ExtendedKalmanFilter<N4, N3, N2> m_observer;
+  private final MecanumDriveKinematics m_kinematics;
+  private final BiConsumer<Matrix<N3, N1>, Matrix<N4, N1>> m_visionCorrect;
+  private final KalmanFilterLatencyCompensator<N4, N3, N2> m_latencyCompensator;
+
+  private final double m_nominalDt; // Seconds
+  private double m_prevTimeSeconds = -1.0;
+
+  private Rotation2d m_gyroOffset;
+  private Rotation2d m_previousAngle;
+
+  /**
+   * Constructs a MecanumDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param kinematics               A correctly-configured kinematics object for your drivetrain.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the gyro measurement. Increase this
+   *                                 number to trust gyro angle measurements less.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder measurements. Increase
+   *                                 these numbers to trust vision less.
+   */
+  public MecanumDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters, MecanumDriveKinematics kinematics,
+          Matrix<N3, N1> stateStdDevs, Matrix<N1, N1> localMeasurementStdDevs,
+          Matrix<N3, N1> visionMeasurementStdDevs
+  ) {
+    this(gyroAngle, initialPoseMeters, kinematics, stateStdDevs, localMeasurementStdDevs,
+            visionMeasurementStdDevs, 0.02);
+  }
+
+  /**
+   * Constructs a MecanumDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param kinematics               A correctly-configured kinematics object for your drivetrain.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the gyro measurement. Increase this
+   *                                 number to trust gyro angle measurements less.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder measurements. Increase
+   *                                 these numbers to trust vision less.
+   * @param nominalDtSeconds         The time in seconds between each robot loop.
+   */
+  @SuppressWarnings("ParameterName")
+  public MecanumDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters, MecanumDriveKinematics kinematics,
+          Matrix<N3, N1> stateStdDevs, Matrix<N1, N1> localMeasurementStdDevs,
+          Matrix<N3, N1> visionMeasurementStdDevs, double nominalDtSeconds
+  ) {
+    m_nominalDt = nominalDtSeconds;
+
+    m_observer = new ExtendedKalmanFilter<>(
+        Nat.N4(), Nat.N3(), Nat.N2(),
+        this::f,
+        (x, u) -> x.block(Nat.N2(), Nat.N1(), 2, 0),
+        VecBuilder.fill(stateStdDevs.get(0, 0), stateStdDevs.get(1, 0),
+            Math.cos(stateStdDevs.get(2, 0)), Math.sin(stateStdDevs.get(2, 0))),
+        VecBuilder.fill(Math.cos(localMeasurementStdDevs.get(0, 0)),
+                Math.sin(localMeasurementStdDevs.get(0, 0))),
+        m_nominalDt
+    );
+    m_kinematics = kinematics;
+    m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
+
+    var fullVisionMeasurementStdDev = VecBuilder.fill(
+            visionMeasurementStdDevs.get(0, 0), visionMeasurementStdDevs.get(1, 0),
+            Math.cos(visionMeasurementStdDevs.get(2, 0)),
+            Math.sin(visionMeasurementStdDevs.get(2, 0))
+    );
+
+    var visionContR = StateSpaceUtil.makeCovarianceMatrix(Nat.N4(), fullVisionMeasurementStdDev);
+    var visionDiscR = Discretization.discretizeR(visionContR, m_nominalDt);
+
+    m_visionCorrect = (u, y) -> m_observer.correct(
+        Nat.N4(), u, y,
+        (x, u_) -> x,
+        visionDiscR
+    );
+
+    m_gyroOffset = initialPoseMeters.getRotation().minus(gyroAngle);
+    m_previousAngle = initialPoseMeters.getRotation();
+    m_observer.setXhat(StateSpaceUtil.poseTo4dVector(initialPoseMeters));
+  }
+
+  @SuppressWarnings({"ParameterName", "MethodName"})
+  private Matrix<N4, N1> f(Matrix<N4, N1> x, Matrix<N3, N1> u) {
+    return VecBuilder.fill(
+            u.get(0, 0), u.get(1, 0), -x.get(3, 0) * u.get(2, 0), x.get(2, 0) * u.get(2, 0)
+    );
+  }
+
+  /**
+   * Resets the robot's position on the field.
+   *
+   * <p>You NEED to reset your encoders (to zero) when calling this method.
+   *
+   * <p>The gyroscope angle does not need to be reset in the user's robot code.
+   * The library automatically takes care of offsetting the gyro angle.
+   *
+   * @param poseMeters The position on the field that your robot is at.
+   * @param gyroAngle  The angle reported by the gyroscope.
+   */
+  public void resetPosition(Pose2d poseMeters, Rotation2d gyroAngle) {
+    m_previousAngle = poseMeters.getRotation();
+    m_gyroOffset = getEstimatedPosition().getRotation().minus(gyroAngle);
+    m_observer.setXhat(StateSpaceUtil.poseTo4dVector(poseMeters));
+  }
+
+  /**
+   * Gets the pose of the robot at the current time as estimated by the Extended Kalman Filter.
+   *
+   * @return The estimated robot pose in meters.
+   */
+  public Pose2d getEstimatedPosition() {
+    return new Pose2d(
+            m_observer.getXhat(0),
+            m_observer.getXhat(1),
+            new Rotation2d(m_observer.getXhat(2), m_observer.getXhat(3))
+    );
+  }
+
+  /**
+   * Add a vision measurement to the Extended Kalman Filter. This will correct the
+   * odometry pose estimate while still accounting for measurement noise.
+   *
+   * <p>This method can be called as infrequently as you want, as long as you are
+   * calling {@link MecanumDrivePoseEstimator#update} every loop.
+   *
+   * @param visionRobotPoseMeters The pose of the robot as measured by the vision
+   *                              camera.
+   * @param timestampSeconds      The timestamp of the vision measurement in seconds. Note that if
+   *                              you don't use your own time source by calling
+   *                              {@link MecanumDrivePoseEstimator#updateWithTime} then you
+   *                              must use a timestamp with an epoch since FPGA startup
+   *                              (i.e. the epoch of this timestamp is the same epoch as
+   *                              {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp
+   *                              Timer.getFPGATimestamp}.) This means that you should
+   *                              use Timer.getFPGATimestamp as your time source
+   *                              or sync the epochs.
+   */
+  public void addVisionMeasurement(Pose2d visionRobotPoseMeters, double timestampSeconds) {
+    m_latencyCompensator.applyPastGlobalMeasurement(
+            Nat.N4(),
+            m_observer, m_nominalDt,
+            StateSpaceUtil.poseTo4dVector(visionRobotPoseMeters),
+            m_visionCorrect,
+            timestampSeconds
+    );
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder information.
+   * This should be called every loop, and the correct loop period must be passed
+   * into the constructor of this class.
+   *
+   * @param gyroAngle   The current gyro angle.
+   * @param wheelSpeeds The current speeds of the mecanum drive wheels.
+   * @return The estimated pose of the robot in meters.
+   */
+  public Pose2d update(Rotation2d gyroAngle, MecanumDriveWheelSpeeds wheelSpeeds) {
+    return updateWithTime(Timer.getFPGATimestamp(), gyroAngle, wheelSpeeds);
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder information.
+   * This should be called every loop, and the correct loop period must be passed
+   * into the constructor of this class.
+   *
+   * @param currentTimeSeconds Time at which this method was called, in seconds.
+   * @param gyroAngle          The current gyroscope angle.
+   * @param wheelSpeeds        The current speeds of the mecanum drive wheels.
+   * @return The estimated pose of the robot in meters.
+   */
+  @SuppressWarnings("LocalVariableName")
+  public Pose2d updateWithTime(double currentTimeSeconds, Rotation2d gyroAngle,
+                               MecanumDriveWheelSpeeds wheelSpeeds) {
+    double dt = m_prevTimeSeconds >= 0 ? currentTimeSeconds - m_prevTimeSeconds : m_nominalDt;
+    m_prevTimeSeconds = currentTimeSeconds;
+
+    var angle = gyroAngle.plus(m_gyroOffset);
+    var omega = angle.minus(m_previousAngle).getRadians() / dt;
+
+    var chassisSpeeds = m_kinematics.toChassisSpeeds(wheelSpeeds);
+    var fieldRelativeVelocities =
+            new Translation2d(chassisSpeeds.vxMetersPerSecond, chassisSpeeds.vyMetersPerSecond)
+                    .rotateBy(angle);
+
+    var u = VecBuilder.fill(
+            fieldRelativeVelocities.getX(),
+            fieldRelativeVelocities.getY(),
+            omega
+    );
+    m_previousAngle = angle;
+
+    var localY = VecBuilder.fill(angle.getCos(), angle.getSin());
+    m_latencyCompensator.addObserverState(m_observer, u, localY, currentTimeSeconds);
+    m_observer.predict(u, dt);
+    m_observer.correct(u, localY);
+
+    return getEstimatedPosition();
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/MerweScaledSigmaPoints.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/MerweScaledSigmaPoints.java
@@ -1,0 +1,168 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import org.ejml.simple.SimpleMatrix;
+
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.Num;
+import edu.wpi.first.wpiutil.math.SimpleMatrixUtils;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+
+/**
+ * Generates sigma points and weights according to Van der Merwe's 2004
+ * dissertation[1] for the UnscentedKalmanFilter class.
+ *
+ * <p>It parametrizes the sigma points using alpha, beta, kappa terms, and is the
+ * version seen in most publications. Unless you know better, this should be
+ * your default choice.
+ *
+ * <p>States is the dimensionality of the state. 2*States+1 weights will be
+ * generated.
+ *
+ * <p>[1] R. Van der Merwe "Sigma-Point Kalman Filters for Probabilitic
+ * Inference in Dynamic State-Space Models" (Doctoral dissertation)
+ */
+public class MerweScaledSigmaPoints<S extends Num> {
+
+  private final double m_alpha;
+  private final int m_kappa;
+  private final Nat<S> m_states;
+  private Matrix<?, N1> m_wm;
+  private Matrix<?, N1> m_wc;
+
+  /**
+   * Constructs a generator for Van der Merwe scaled sigma points.
+   *
+   * @param states an instance of Num that represents the number of states.
+   * @param alpha  Determines the spread of the sigma points around the mean.
+   *               Usually a small positive value (1e-3).
+   * @param beta   Incorporates prior knowledge of the distribution of the mean.
+   *               For Gaussian distributions, beta = 2 is optimal.
+   * @param kappa  Secondary scaling parameter usually set to 0 or 3 - States.
+   */
+  public MerweScaledSigmaPoints(Nat<S> states, double alpha, double beta, int kappa) {
+    this.m_states = states;
+    this.m_alpha = alpha;
+    this.m_kappa = kappa;
+
+    computeWeights(beta);
+  }
+
+  /**
+   * Constructs a generator for Van der Merwe scaled sigma points with default values for alpha,
+   * beta, and kappa.
+   *
+   * @param states an instance of Num that represents the number of states.
+   */
+  public MerweScaledSigmaPoints(Nat<S> states) {
+    this(states, 1e-3, 2, 3 - states.getNum());
+  }
+
+  /**
+   * Returns number of sigma points for each variable in the state x.
+   *
+   * @return The number of sigma points for each variable in the state x.
+   */
+  public int getNumSigmas() {
+    return 2 * m_states.getNum() + 1;
+  }
+
+  /**
+   * Computes the sigma points for an unscented Kalman filter given the mean
+   * (x) and covariance(P) of the filter.
+   *
+   * @param x An array of the means.
+   * @param P Covariance of the filter.
+   * @return Two dimensional array of sigma points. Each column contains all of
+   *         the sigmas for one dimension in the problem space. Ordered by
+   *         Xi_0, Xi_{1..n}, Xi_{n+1..2n}.
+   */
+  @SuppressWarnings({"ParameterName", "LocalVariableName"})
+  public Matrix<S, ?> sigmaPoints(
+          Matrix<S, N1> x,
+          Matrix<S, S> P) {
+    double lambda = Math.pow(m_alpha, 2) * (m_states.getNum() + m_kappa) - m_states.getNum();
+
+    var intermediate = P.times(lambda + m_states.getNum()).getStorage();
+    var U = SimpleMatrixUtils.lltDecompose(intermediate, true); // Lower triangular
+
+    // 2 * states + 1 by states
+    SimpleMatrix sigmas = new SimpleMatrix(m_states.getNum(), 2 * m_states.getNum() + 1);
+    sigmas.setColumn(0, 0, x.getStorage().getDDRM().getData());
+    for (int k = 0; k < m_states.getNum(); k++) {
+      var xPlusU = x.getStorage().plus(U.extractVector(false, k)).getDDRM().getData();
+      var xMinusU = x.getStorage().minus(U.extractVector(false, k)).getDDRM().getData();
+      sigmas.setColumn(k + 1, 0, xPlusU);
+      sigmas.setColumn(m_states.getNum() + k + 1, 0, xMinusU);
+    }
+
+    return new Matrix<>(sigmas);
+  }
+
+  /**
+   * Computes the weights for the scaled unscented Kalman filter.
+   *
+   * @param beta Incorporates prior knowledge of the distribution of the mean.
+   */
+  @SuppressWarnings("LocalVariableName")
+  private void computeWeights(double beta) {
+    double lambda = Math.pow(m_alpha, 2) * (m_states.getNum() + m_kappa) - m_states.getNum();
+    double c = 0.5 / (m_states.getNum() + lambda);
+
+    var wM = new SimpleMatrix(2 * m_states.getNum() + 1, 1);
+    var wC = new SimpleMatrix(2 * m_states.getNum() + 1, 1);
+    wM.fill(c);
+    wC.fill(c);
+
+    wM.set(0, 0, lambda / (m_states.getNum() + lambda));
+    wC.set(0, 0, lambda / (m_states.getNum() + lambda) + (1 - Math.pow(m_alpha, 2) + beta));
+
+    this.m_wm = new Matrix<>(wM);
+    this.m_wc = new Matrix<>(wC);
+  }
+
+  /**
+   * Returns the weight for each sigma point for the mean.
+   *
+   * @return the weight for each sigma point for the mean.
+   */
+  public Matrix<?, N1> getWm() {
+    return m_wm;
+  }
+
+  /**
+   * Returns an element of the weight for each sigma point for the mean.
+   *
+   * @param element Element of vector to return.
+   * @return the element i's weight for the mean.
+   */
+  public double getWm(int element) {
+    return m_wm.get(element, 0);
+  }
+
+  /**
+   * Returns the weight for each sigma point for the covariance.
+   *
+   * @return the weight for each sigma point for the covariance.
+   */
+  public Matrix<?, N1> getWc() {
+    return m_wc;
+  }
+
+  /**
+   * Returns an element of the weight for each sigma point for the covariance.
+   *
+   * @param element Element of vector to return.
+   * @return The element I's weight for the covariance.
+   */
+  public double getWc(int element) {
+    return m_wc.get(element, 0);
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimator.java
@@ -1,0 +1,263 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.function.BiConsumer;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.math.Discretization;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+import edu.wpi.first.wpiutil.math.numbers.N3;
+import edu.wpi.first.wpiutil.math.numbers.N4;
+
+/**
+ * This class wraps an {@link ExtendedKalmanFilter ExtendedKalmanFilter} to fuse
+ * latency-compensated vision measurements with swerve drive encoder velocity measurements.
+ * It will correct for noisy measurements and encoder drift. It is intended to be an easy
+ * but more accurate drop-in for {@link edu.wpi.first.wpilibj.kinematics.SwerveDriveOdometry}.
+ *
+ * <p>{@link SwerveDrivePoseEstimator#update} should be called every robot loop. If
+ * your loops are faster or slower than the default of 0.02s, then you should change
+ * the nominal delta time using the secondary constructor:
+ * {@link SwerveDrivePoseEstimator#SwerveDrivePoseEstimator(Rotation2d, Pose2d,
+ * SwerveDriveKinematics, Matrix, Matrix, Matrix, double)}.
+ *
+ * <p>{@link SwerveDrivePoseEstimator#addVisionMeasurement} can be called as
+ * infrequently as you want; if you never call it, then this class will behave mostly like regular
+ * encoder odometry.
+ *
+ * <p>Our state-space system is:
+ *
+ * <p><strong> x = [[x, y, cos(theta), sin(theta)]]^T </strong> in the field-coordinate system.
+ *
+ * <p><strong> u = [[vx, vy, omega]]^T </strong> in the field-coordinate system.
+ *
+ * <p><strong> y = [[x, y, cos(theta), sin(theta)]]^T </strong> in field coords from vision,
+ * or <strong> y = [[cos(theta), sin(theta)]]^T </strong> from the gyro.
+ */
+public class SwerveDrivePoseEstimator {
+  private final ExtendedKalmanFilter<N4, N3, N2> m_observer;
+  private final SwerveDriveKinematics m_kinematics;
+  private final BiConsumer<Matrix<N3, N1>, Matrix<N4, N1>> m_visionCorrect;
+  private final KalmanFilterLatencyCompensator<N4, N3, N2> m_latencyCompensator;
+
+  private final double m_nominalDt; // Seconds
+  private double m_prevTimeSeconds = -1.0;
+
+  private Rotation2d m_gyroOffset;
+  private Rotation2d m_previousAngle;
+
+  /**
+   * Constructs a SwerveDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param kinematics               A correctly-configured kinematics object for your drivetrain.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the gyro measurement. Increase this
+   *                                 number to trust gyro angle measurements less.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder measurements. Increase
+   *                                 these numbers to trust vision less.
+   */
+  public SwerveDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters, SwerveDriveKinematics kinematics,
+          Matrix<N3, N1> stateStdDevs, Matrix<N1, N1> localMeasurementStdDevs,
+          Matrix<N3, N1> visionMeasurementStdDevs
+  ) {
+    this(gyroAngle, initialPoseMeters, kinematics, stateStdDevs, localMeasurementStdDevs,
+            visionMeasurementStdDevs, 0.02);
+  }
+
+  /**
+   * Constructs a SwerveDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param kinematics               A correctly-configured kinematics object for your drivetrain.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the gyro measurement. Increase this
+   *                                 number to trust gyro angle measurements less.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder measurements. Increase
+   *                                 these numbers to trust vision less.
+   * @param nominalDtSeconds         The time in seconds between each robot loop.
+   */
+  @SuppressWarnings("ParameterName")
+  public SwerveDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters, SwerveDriveKinematics kinematics,
+          Matrix<N3, N1> stateStdDevs, Matrix<N1, N1> localMeasurementStdDevs,
+          Matrix<N3, N1> visionMeasurementStdDevs, double nominalDtSeconds
+  ) {
+    m_nominalDt = nominalDtSeconds;
+
+    m_observer = new ExtendedKalmanFilter<>(
+        Nat.N4(), Nat.N3(), Nat.N2(),
+        this::f,
+        (x, u) -> x.block(Nat.N2(), Nat.N1(), 2, 0),
+        VecBuilder.fill(stateStdDevs.get(0, 0), stateStdDevs.get(1, 0),
+            Math.cos(stateStdDevs.get(2, 0)), Math.sin(stateStdDevs.get(2, 0))),
+        VecBuilder.fill(Math.cos(localMeasurementStdDevs.get(0, 0)),
+                Math.sin(localMeasurementStdDevs.get(0, 0))),
+        m_nominalDt
+    );
+    m_kinematics = kinematics;
+    m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
+
+    var fullVisionMeasurementStdDev = VecBuilder.fill(
+            visionMeasurementStdDevs.get(0, 0), visionMeasurementStdDevs.get(1, 0),
+            Math.cos(visionMeasurementStdDevs.get(2, 0)),
+            Math.sin(visionMeasurementStdDevs.get(2, 0)));
+
+    var visionContR = StateSpaceUtil.makeCovarianceMatrix(Nat.N4(), fullVisionMeasurementStdDev);
+    var visionDiscR = Discretization.discretizeR(visionContR, m_nominalDt);
+
+    m_visionCorrect = (u, y) -> m_observer.correct(
+        Nat.N4(), u, y,
+        (x, u_) -> x,
+        visionDiscR
+    );
+
+    m_gyroOffset = initialPoseMeters.getRotation().minus(gyroAngle);
+    m_previousAngle = initialPoseMeters.getRotation();
+    m_observer.setXhat(StateSpaceUtil.poseTo4dVector(initialPoseMeters));
+  }
+
+  @SuppressWarnings({"ParameterName", "MethodName"})
+  private Matrix<N4, N1> f(Matrix<N4, N1> x, Matrix<N3, N1> u) {
+    return VecBuilder.fill(
+            u.get(0, 0), u.get(1, 0), -x.get(3, 0) * u.get(2, 0), x.get(2, 0) * u.get(2, 0)
+    );
+  }
+
+  /**
+   * Resets the robot's position on the field.
+   *
+   * <p>You NEED to reset your encoders (to zero) when calling this method.
+   *
+   * <p>The gyroscope angle does not need to be reset in the user's robot code.
+   * The library automatically takes care of offsetting the gyro angle.
+   *
+   * @param poseMeters The position on the field that your robot is at.
+   * @param gyroAngle  The angle reported by the gyroscope.
+   */
+  public void resetPosition(Pose2d poseMeters, Rotation2d gyroAngle) {
+    m_previousAngle = poseMeters.getRotation();
+    m_gyroOffset = getEstimatedPosition().getRotation().minus(gyroAngle);
+    m_observer.setXhat(StateSpaceUtil.poseTo4dVector(poseMeters));
+  }
+
+  /**
+   * Gets the pose of the robot at the current time as estimated by the Extended Kalman Filter.
+   *
+   * @return The estimated robot pose in meters.
+   */
+  public Pose2d getEstimatedPosition() {
+    return new Pose2d(
+            m_observer.getXhat(0),
+            m_observer.getXhat(1),
+            new Rotation2d(m_observer.getXhat(2), m_observer.getXhat(3))
+    );
+  }
+
+  /**
+   * Add a vision measurement to the Extended Kalman Filter. This will correct the
+   * odometry pose estimate while still accounting for measurement noise.
+   *
+   * <p>This method can be called as infrequently as you want, as long as you are
+   * calling {@link SwerveDrivePoseEstimator#update} every loop.
+   *
+   * @param visionRobotPoseMeters The pose of the robot as measured by the vision
+   *                              camera.
+   * @param timestampSeconds      The timestamp of the vision measurement in seconds. Note that if
+   *                              you don't use your own time source by calling
+   *                              {@link SwerveDrivePoseEstimator#updateWithTime} then you
+   *                              must use a timestamp with an epoch since FPGA startup
+   *                              (i.e. the epoch of this timestamp is the same epoch as
+   *                              {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp
+   *                              Timer.getFPGATimestamp}.) This means that you should
+   *                              use Timer.getFPGATimestamp as your time source or
+   *                              sync the epochs.
+   */
+  public void addVisionMeasurement(Pose2d visionRobotPoseMeters, double timestampSeconds) {
+    m_latencyCompensator.applyPastGlobalMeasurement(
+            Nat.N4(),
+            m_observer, m_nominalDt,
+            StateSpaceUtil.poseTo4dVector(visionRobotPoseMeters),
+            m_visionCorrect,
+            timestampSeconds
+    );
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder information.
+   * This should be called every loop, and the correct loop period must be passed
+   * into the constructor of this class.
+   *
+   * @param gyroAngle    The current gyro angle.
+   * @param moduleStates The current velocities and rotations of the swerve modules.
+   * @return The estimated pose of the robot in meters.
+   */
+  public Pose2d update(
+          Rotation2d gyroAngle,
+          SwerveModuleState... moduleStates
+  ) {
+    return updateWithTime(Timer.getFPGATimestamp(), gyroAngle, moduleStates);
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder information.
+   * This should be called every loop, and the correct loop period must be passed
+   * into the constructor of this class.
+   *
+   * @param currentTimeSeconds Time at which this method was called, in seconds.
+   * @param gyroAngle          The current gyroscope angle.
+   * @param moduleStates       The current velocities and rotations of the swerve modules.
+   * @return The estimated pose of the robot in meters.
+   */
+  @SuppressWarnings("LocalVariableName")
+  public Pose2d updateWithTime(
+          double currentTimeSeconds,
+          Rotation2d gyroAngle, SwerveModuleState... moduleStates
+  ) {
+    double dt = m_prevTimeSeconds >= 0 ? currentTimeSeconds - m_prevTimeSeconds : m_nominalDt;
+    m_prevTimeSeconds = currentTimeSeconds;
+
+    var angle = gyroAngle.plus(m_gyroOffset);
+    var omega = angle.minus(m_previousAngle).getRadians() / dt;
+
+    var chassisSpeeds = m_kinematics.toChassisSpeeds(moduleStates);
+    var fieldRelativeVelocities = new Translation2d(
+            chassisSpeeds.vxMetersPerSecond, chassisSpeeds.vyMetersPerSecond
+    ).rotateBy(angle);
+
+    var u = VecBuilder.fill(
+            fieldRelativeVelocities.getX(),
+            fieldRelativeVelocities.getY(),
+            omega
+    );
+    m_previousAngle = angle;
+
+    var localY = VecBuilder.fill(angle.getCos(), angle.getSin());
+    m_latencyCompensator.addObserverState(m_observer, u, localY, currentTimeSeconds);
+    m_observer.predict(u, dt);
+    m_observer.correct(u, localY);
+
+    return getEstimatedPosition();
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/BatterySim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/BatterySim.java
@@ -1,0 +1,52 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.simulation;
+
+import edu.wpi.first.wpilibj.RobotController;
+
+public final class BatterySim {
+  private BatterySim() {
+    // Utility class
+  }
+
+  /**
+   * Calculate the loaded battery voltage. Use this with
+   * {@link RoboRioSim#setVInVoltage(double)} to set the simulated battery
+   * voltage, which can then be retrieved with the {@link RobotController#getBatteryVoltage()}
+   * method.
+   *
+   * @param nominalVoltage The nominal battery voltage. Usually 12v.
+   * @param resistanceOhms The forward resistance of the battery. Most batteries are at or
+   *                       below 20 milliohms.
+   * @param currents       The currents drawn from the battery.
+   * @return The battery's voltage under load.
+   */
+  public static double calculateLoadedBatteryVoltage(double nominalVoltage,
+                                                     double resistanceOhms,
+                                                     double... currents) {
+    double retval = nominalVoltage;
+    for (var current : currents) {
+      retval -= current * resistanceOhms;
+    }
+    return retval;
+  }
+
+  /**
+   * Calculate the loaded battery voltage. Use this with
+   * {@link RoboRioSim#setVInVoltage(double)} to set the simulated battery
+   * voltage, which can then be retrieved with the {@link RobotController#getBatteryVoltage()}
+   * method. This function assumes a nominal voltage of 12v and a resistance of 20 milliohms
+   * (0.020 ohms)
+   *
+   * @param currents The currents drawn from the battery.
+   * @return The battery's voltage under load.
+   */
+  public static double calculateLoadedBatteryVoltage(double... currents) {
+    return calculateLoadedBatteryVoltage(12, 0.02, currents);
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSim.java
@@ -1,0 +1,159 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.simulation;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpilibj.system.RungeKutta;
+import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N10;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+import edu.wpi.first.wpiutil.math.numbers.N4;
+import edu.wpi.first.wpiutil.math.numbers.N7;
+import org.ejml.simple.SimpleMatrix;
+
+/**
+ * This class simulates the state of the drivetrain. In simulationPeriodic, users should first set inputs from motors with
+ * {@link #setInputs(double, double)}, call {@link #update(double)} to update the simulation,
+ * and set estimated encoder and gyro positions, as well as estimated odometry pose, . Teams can use {@link edu.wpi.first.wpilibj.simulation.Field2d} to
+ * visualize their robot on the Sim GUI's field.
+ */
+public class DifferentialDrivetrainSim {
+  private final DCMotor m_leftMotor;
+  private final DCMotor m_rightMotor;
+  private final double m_leftGearing;
+  private final double m_rightGearing;
+  @SuppressWarnings("MemberName")
+  private Matrix<N2, N1> m_u;
+  @SuppressWarnings("MemberName")
+  private Matrix<N10, N1> m_x;
+
+  private final double m_rb;
+  private final LinearSystem<N2, N2, N2> m_plant;
+
+  /**
+   * Create a SimDrivetrain.
+   *
+   * @param drivetrainPlant The {@link LinearSystem} representing the robot's drivetrain. This
+   *                        system can be created with {@link edu.wpi.first.wpilibj.system.plant.LinearSystemId#createDrivetrainVelocitySystem(DCMotor, double, double, double, double, double)}
+   *                        or {@link edu.wpi.first.wpilibj.system.plant.LinearSystemId#identifyDrivetrainSystem(double, double, double, double)}.
+   * @param kinematics      A {@link DifferentialDriveKinematics} object representing the
+   *                        differential drivetrain's kinematics.
+   */
+  public DifferentialDrivetrainSim(LinearSystem<N2, N2, N2> drivetrainPlant,
+                                   DifferentialDriveKinematics kinematics,
+                                   DCMotor leftGearbox, double leftGearing,
+                                   DCMotor rightGearbox, double rightGearing) {
+    this.m_plant = drivetrainPlant;
+    this.m_rb = kinematics.trackWidthMeters / 2.0;
+    this.m_leftMotor = leftGearbox;
+    this.m_rightMotor = rightGearbox;
+    this.m_leftGearing = leftGearing;
+    this.m_rightGearing = rightGearing;
+
+    m_x = new Matrix<>(new SimpleMatrix(10, 1));
+  }
+
+  public void setInputs(double leftVoltageVolts, double rightVoltageVolts) {
+    m_u = VecBuilder.fill(leftVoltageVolts, rightVoltageVolts);
+  }
+
+  @SuppressWarnings("LocalVariableName")
+  public void update(double dtSeconds) {
+
+    // Update state estimate with RK4
+    m_x = RungeKutta.rungeKutta(this::getDynamics, m_x, m_u, dtSeconds);
+  }
+
+  public double getState(State state) {
+    return m_x.get(state.value, 0);
+  }
+
+  public Matrix<N10, N1> getState() {
+    return m_x;
+  }
+
+  /**
+   * Get the estimated direction the robot is pointing. Note that this angle is
+   * counterclockwise-positive, while most gyros are clockwise positive.
+   */
+  public Rotation2d getHeading() {
+    return new Rotation2d(getState(State.kHeading));
+  }
+
+  public Pose2d getEstimatedPosition() {
+    return new Pose2d(m_x.get(0, 0),
+      m_x.get(1, 0),
+      new Rotation2d(m_x.get(2, 0)));
+  }
+
+  public double getCurrentDrawAmps() {
+    var loadIleft = m_leftMotor.getCurrent(
+        getState(State.kLeftVelocity) * m_leftGearing / m_rb,
+        m_u.get(0, 0)) * Math.signum(getState(State.kLeftVelocity));
+
+    var loadIright = m_rightMotor.getCurrent(
+        getState(State.kRightVelocity) * m_rightGearing / m_rb,
+        m_u.get(1, 0)) * Math.signum(getState(State.kRightVelocity));
+
+    return loadIleft + loadIright;
+  }
+
+  @SuppressWarnings({"DuplicatedCode", "LocalVariableName"})
+  protected Matrix<N10, N1> getDynamics(Matrix<N10, N1> x, Matrix<N2, N1> u) {
+    Matrix<N4, N2> B = new Matrix<>(new SimpleMatrix(4, 2));
+    B.getStorage().insertIntoThis(0, 0, m_plant.getB().getStorage());
+    B.getStorage().insertIntoThis(2, 0, new SimpleMatrix(2, 2));
+
+    Matrix<N4, N7> A = new Matrix<>(new SimpleMatrix(4, 7));
+    A.getStorage().insertIntoThis(0, 0, m_plant.getA().getStorage());
+
+    A.getStorage().insertIntoThis(2, 0, SimpleMatrix.identity(2));
+    A.getStorage().insertIntoThis(0, 2, new SimpleMatrix(4, 2));
+    A.getStorage().insertIntoThis(0, 4, B.getStorage());
+    A.getStorage().setColumn(6, 0, 0, 0, 1, -1);
+
+    var v = (x.get(State.kLeftVelocity.value, 0) + x.get(State.kRightVelocity.value, 0)) / 2.0;
+
+    var result = new Matrix<N10, N1>(new SimpleMatrix(10, 1));
+    result.set(0, 0, v * Math.cos(x.get(State.kHeading.value, 0)));
+    result.set(1, 0, v * Math.sin(x.get(State.kHeading.value, 0)));
+    result.set(2, 0, (x.get(State.kRightVelocity.value, 0)
+        - x.get(State.kLeftVelocity.value, 0)) / (2.0 * m_rb));
+
+    result.getStorage().insertIntoThis(3, 0, A.times(new Matrix<N7, N1>(
+        x.getStorage().extractMatrix(3, 10, 0, 1))).plus(B.times(u)).getStorage());
+    result.getStorage().insertIntoThis(7, 0, new SimpleMatrix(3, 1));
+    return result;
+  }
+
+  public enum State {
+    kX(0),
+    kY(1),
+    kHeading(2),
+    kLeftVelocity(3),
+    kRightVelocity(4),
+    kLeftPosition(5),
+    kRightPosition(6),
+    kLeftVoltageError(7),
+    kRightVoltageError(8),
+    kAngularVelocityError(9);
+
+    @SuppressWarnings("MemberName")
+    public final int value;
+
+    State(int i) {
+      this.value = i;
+    }
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
@@ -1,0 +1,117 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.simulation;
+
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpilibj.system.RungeKutta;
+import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+
+public class ElevatorSim extends LinearSystemSim<N2, N1, N1> {
+
+  private final DCMotor m_motor;
+  private final double m_drumRadiusMeters;
+  private double m_minHeightMeters;
+  private double m_maxHeightMeters;
+  private final double m_gearing;
+
+  /**
+   * Create a LinearSystemSimulator. This simulator uses an {@link LinearSystem} to simulate
+   * * the state of the system. In simulationPeriodic, users should first set inputs from motors, update
+   * * the simulation and write simulated outputs to sensors.
+   *
+   * @param elevatorGearbox      The {@link DCMotor} representing the elevator motor.
+   * @param carriageMassKg       The mass of the carriage.
+   * @param drumRadiusMeters     The radius of the drum driving the elevator.
+   * @param gearingReduction     The reduction between motor and drum, as output over input.
+   *                             In most cases this is greater than one.
+   * @param m_measurementStdDevs Standard deviations for position noise. Can be null
+   *                             if no added noise is desired.
+   */
+  public ElevatorSim(DCMotor elevatorGearbox, double carriageMassKg,
+                     double drumRadiusMeters, double gearingReduction,
+                     double minHeightMeters, double maxHeightMeters,
+                     Matrix<N1, N1> m_measurementStdDevs) {
+    super(LinearSystemId.createElevatorSystem(elevatorGearbox, carriageMassKg, drumRadiusMeters,
+        gearingReduction), m_measurementStdDevs);
+    this.m_motor = elevatorGearbox;
+    this.m_gearing = gearingReduction;
+    this.m_drumRadiusMeters = drumRadiusMeters;
+    this.m_minHeightMeters = minHeightMeters;
+    this.m_maxHeightMeters = maxHeightMeters;
+  }
+
+  /**
+   * Create a LinearSystemSimulator. This simulator uses an {@link LinearSystem} to simulate
+   * the state of the system. In simulationPeriodic, users should first set inputs from motors, update
+   * the simulation and write simulated outputs to sensors.
+   *
+   * @param elevatorPlant        The elevator system being controlled. This system can be created
+   *                             with {@link edu.wpi.first.wpilibj.system.plant.LinearSystemId#createElevatorSystem(DCMotor, double, double, double)}
+   *                             or {@link edu.wpi.first.wpilibj.system.plant.LinearSystemId#identifyPositionSystem(double, double)}.
+   * @param m_measurementStdDevs Standard deviations of measurements. Can be null if addNoise is false.
+   */
+  public ElevatorSim(LinearSystem<N2, N1, N1> elevatorPlant,
+                     Matrix<N1, N1> m_measurementStdDevs, DCMotor elevatorGearbox,
+                     double gearingReduction, double drumRadiusMeters,
+                     double minHeightMeters, double maxHeightMeters) {
+    super(elevatorPlant, m_measurementStdDevs);
+    this.m_motor = elevatorGearbox;
+    this.m_gearing = gearingReduction;
+    this.m_drumRadiusMeters = drumRadiusMeters;
+    this.m_minHeightMeters = minHeightMeters;
+    this.m_maxHeightMeters = maxHeightMeters;
+  }
+
+  public boolean hasHitLowerLimit(Matrix<N2, N1> x) {
+    return x.get(0, 0) < this.m_minHeightMeters;
+  }
+
+  public boolean hasHitUpperLimit(Matrix<N2, N1> x) {
+    return x.get(0, 0) > this.m_maxHeightMeters;
+  }
+
+  @Override
+  protected Matrix<N2, N1> updateX(Matrix<N2, N1> currentXhat, Matrix<N1, N1> u, double dtSeconds) {
+    var updatedXhat = RungeKutta.rungeKutta((x, u_) -> (m_plant.getA().times(x)).plus(m_plant.getB().times(u_)).plus(VecBuilder.fill(0, -9.8)),
+        currentXhat, u, dtSeconds);
+
+    // We check for collision after updating xhat
+    if (hasHitLowerLimit(updatedXhat)) {
+      return VecBuilder.fill(m_minHeightMeters, 0);
+    } else if (hasHitUpperLimit(updatedXhat)) {
+      return VecBuilder.fill(m_maxHeightMeters, 0);
+    }
+
+    return updatedXhat;
+  }
+
+  public double getElevatorPositionMeters() {
+    return getOutput(0);
+  }
+
+  public double getElevatorVelocityMetersPerSecond() {
+    return m_x.get(0, 1);
+  }
+
+  @Override
+  public double getCurrentDrawAmps() {
+    // I = V / R - omega / (Kv * R)
+    // Reductions are greater than 1, so a reduction of 10:1 would mean the motor is
+    // spinning 10x faster than the output
+    // v = r w, so w = v/r
+    double velocityMps = m_x.get(1, 0);
+    double motorVelocityRadPerSec = velocityMps / m_drumRadiusMeters * m_gearing;
+    return m_u.get(0, 0) / m_motor.m_rOhms
+          - motorVelocityRadPerSec / (m_motor.m_KvRadPerSecPerVolt * m_motor.m_rOhms);
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/FlywheelSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/FlywheelSim.java
@@ -1,0 +1,80 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.simulation;
+
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpilibj.util.Units;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+
+public class FlywheelSim extends LinearSystemSim<N1, N1, N1> {
+
+  private final DCMotor m_motor;
+  private final double m_gearing;
+
+  /**
+   * Create a LinearSystemSimulator. This simulator uses an {@link LinearSystem} to simulate
+   * the state of the system. In simulationPeriodic, users should first set inputs from motors, update
+   * the simulation and write simulated outputs to sensors.
+   *
+   * @param flywheelPlant      The flywheel system being controlled. This system can be created
+   *                           using {@link LinearSystemId#createFlywheelSystem(DCMotor, double, double)}
+   *                           or {@link LinearSystemId#identifyVelocitySystem(double, double)}
+   * @param flywheelGearbox    The DCMotor representing the motor driving the flywheel.
+   * @param gearing            The reduction between motor and drum, as output over input.
+   *                           In most cases this is greater than one.
+   * @param measurementStdDevs Standard deviations of measurements. Can be null if addNoise is false.
+   */
+  public FlywheelSim(LinearSystem<N1, N1, N1> flywheelPlant, DCMotor flywheelGearbox,
+                     double gearing, Matrix<N1, N1> measurementStdDevs) {
+    super(flywheelPlant, measurementStdDevs);
+    this.m_motor = flywheelGearbox;
+    this.m_gearing = gearing;
+  }
+
+  /**
+   * Create a LinearSystemSimulator. This simulator uses an {@link LinearSystem} to simulate
+   * the state of the system. In simulationPeriodic, users should first set inputs from motors, update
+   * the simulation and write simulated outputs to sensors.
+   *
+   * @param flywheelGearbox    The DCMotor representing the motor driving the flywheel.
+   * @param gearing            The reduction between motor and drum, as output over input.
+   *                           In most cases this is greater than one.
+   * @param moiKgMetersSquared The moment of inertia J of the flywheel. This can be
+   *                           calculated with CAD. If J is unknown, {@link #FlywheelSim(LinearSystem, DCMotor, double, Matrix)}
+   *                           using FRC-Characterization's kV and kA may be better.
+   * @param measurementStdDevs Standard deviations of measurements. Can be null if addNoise is false.
+   */
+  public FlywheelSim(DCMotor flywheelGearbox, double gearing,
+                     double moiKgMetersSquared, Matrix<N1, N1> measurementStdDevs) {
+    super(LinearSystemId.createFlywheelSystem(flywheelGearbox, moiKgMetersSquared, gearing),
+        measurementStdDevs);
+    this.m_motor = flywheelGearbox;
+    this.m_gearing = gearing;
+  }
+
+  public double getFlywheelVelocityRadPerSec() {
+    return getOutput(0);
+  }
+
+  public double getFlywheelVelocityRPM() {
+    return Units.radiansPerSecondToRotationsPerMinute(getOutput(0));
+  }
+
+  @Override
+  public double getCurrentDrawAmps() {
+    // I = V / R - omega / (Kv * R)
+    // Reductions are output over input, so a reduction of 2:1 means the motor is spinning
+    // 2x faster than the flywheel
+    return m_u.get(0, 0) / m_motor.m_rOhms
+          - getFlywheelVelocityRadPerSec() * m_gearing
+          / (m_motor.m_KvRadPerSecPerVolt * m_motor.m_rOhms);
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/LinearSystemSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/LinearSystemSim.java
@@ -1,0 +1,124 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.simulation;
+
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Num;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import org.ejml.MatrixDimensionException;
+import org.ejml.simple.SimpleMatrix;
+
+/**
+ * This class helps simulate linear systems. To use this class, do the following in the
+ * {@link edu.wpi.first.wpilibj.IterativeRobotBase#simulationPeriodic} method.
+ *
+ * <p>Call {@link #setInput(double...)} with the inputs to the system (usually voltage).
+ *
+ * <p>Call {@link #update} to update the simulation.
+ *
+ * <p>Set simulated sensor readings with the simulated positions in {@link #getOutput(int)}
+ *
+ * @param <States> The number of states of the system.
+ * @param <Inputs> The number of inputs to the system.
+ * @param <Outputs> The number of outputs of the system.
+ */
+@SuppressWarnings("ClassTypeParameterName")
+public class LinearSystemSim<States extends Num, Inputs extends Num,
+      Outputs extends Num> {
+
+  protected final LinearSystem<States, Inputs, Outputs> m_plant;
+
+  @SuppressWarnings("MemberName")
+  protected Matrix<States, N1> m_x;
+  @SuppressWarnings("MemberName")
+  protected Matrix<Outputs, N1> m_y;
+  @SuppressWarnings("MemberName")
+  protected Matrix<Inputs, N1> m_u;
+  protected final Matrix<Outputs, N1> m_measurementStdDevs;
+
+  /**
+   * Create a SimLinearSystem. This simulator uses an {@link LinearSystem} to simulate
+   * the state of the system. In simulationPeriodic, users should first set inputs from motors, update
+   * the simulation and write simulated outputs to sensors.
+   *
+   * @param system             The system being controlled.
+   * @param measurementStdDevs Standard deviations of measurements. Can be null if addNoise is false.
+   */
+  public LinearSystemSim(LinearSystem<States, Inputs, Outputs> system, Matrix<Outputs, N1> measurementStdDevs) {
+    this.m_plant = system;
+    this.m_measurementStdDevs = measurementStdDevs;
+
+    m_x = new Matrix<>(new SimpleMatrix(system.getA().getNumRows(), 1));
+    m_u = new Matrix<>(new SimpleMatrix(system.getB().getNumCols(), 1));
+    m_y = new Matrix<>(new SimpleMatrix(system.getC().getNumRows(), 1));
+  }
+
+  protected Matrix<States, N1> updateX(Matrix<States, N1> currentXhat, Matrix<Inputs, N1> u, double dtSeconds) {
+    return m_plant.calculateX(currentXhat, u, dtSeconds);
+  }
+
+  @SuppressWarnings("LocalVariableName")
+  public void update(double dtSeconds) {
+    // Update X. By default, this is the linear system dynamics X = Ax + Bu
+    m_x = updateX(m_x, m_u, dtSeconds);
+
+    // y = cx + du
+    m_y = m_plant.calculateY(m_x, m_u);
+    if (m_measurementStdDevs != null) {
+      m_y = m_y.plus(StateSpaceUtil.makeWhiteNoiseVector(m_measurementStdDevs));
+    }
+  }
+
+  public Matrix<Outputs, N1> getY() {
+    return m_y;
+  }
+
+  public double getY(int row) {
+    return m_y.get(row, 0);
+  }
+
+  public void setInput(Matrix<Inputs, N1> u) {
+    this.m_u = u;
+  }
+
+  public void setInput(int row, double value) {
+    m_u.set(row, 0, value);
+  }
+
+  public void setInput(double... u) {
+    if (u.length != m_u.getNumRows()) {
+      throw new MatrixDimensionException("Malformed input! Got " + u.length
+            + " elements instead of " + m_u.getNumRows());
+    }
+    m_u = new Matrix<>(new SimpleMatrix(m_u.getNumRows(), 1, true, u));
+  }
+
+  public Matrix<Outputs, N1> getOutput() {
+    return m_y;
+  }
+
+  public double getOutput(int row) {
+    return m_y.get(row, 0);
+  }
+
+  public void resetState(Matrix<States, N1> state) {
+    m_x = state;
+  }
+
+  /**
+   * Get the current drawn by this simulated system. Override this method to add current
+   * calculation.
+   *
+   * @return The currently drawn current.
+   */
+  public double getCurrentDrawAmps() {
+    return 0.0;
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimSwerveDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimSwerveDrive.java
@@ -1,0 +1,228 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.simulation;
+
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpilibj.system.RungeKutta;
+import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpiutil.math.MathUtil;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+import org.ejml.MatrixDimensionException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This class simulates the motion of a standard swerve drive. To use this sim, users should
+ * first call {@link #setModuleAzimuthVoltages(double...)} and {@link #setModuleDriveVoltages(double...)}
+ * in simulationPeriodic to set the currently applied voltages to the azimuth (angle) and
+ * drive motors. Next, {@link #update(double)} should be called to update the estimated system
+ * state. Finally, encoders should be updated with the {@link #getEstimatedModuleStates()} and
+ * {@link #getEstimatedChassisSpeed()}. For a full usage example, see the example project.
+ */
+public class SimSwerveDrive {
+  private final SwerveDriveKinematics m_kinematics;
+  private final double m_chassisMassKg;
+  private final SimSwerveModule[] m_modules;
+  private double[] m_moduleDriveVoltages;
+  private double[] m_moduleAzimuthVoltages;
+  private ChassisSpeeds m_estimatedSpeed = new ChassisSpeeds();
+  private Rotation2d m_estimatedHeading = new Rotation2d();
+
+  /**
+   * Create a simulated swerve drive. The azimuthSystem can be created using
+   * {@link edu.wpi.first.wpilibj.system.plant.LinearSystemId#createSingleJointedArmSystem(DCMotor, double, double)}
+   * or {@link edu.wpi.first.wpilibj.system.plant.LinearSystemId#identifyPositionSystem(double, double)}.
+   *
+   * <p>Note that with this constructor, all swerve module pods are assumed to use the same
+   * azimuth and drive motors.
+   *
+   * @param chassisMassKg          The mass of the chassis.
+   * @param azimuthSystem          A state-space system representing the
+   * @param driveMotor             The {@link DCMotor} representing a single swerve module's
+   *                               drive motor.
+   * @param driveMotorGearing      The gearing between the drive motor and the wheel, written
+   *                               as output over input. This should usually be greater than
+   *                               1.
+   * @param driveWheelRadiusMeters The radius of the drive wheel in meters.
+   * @param modulePositions        A list of {@link Translation2d}s representing the
+   *                               positions of the modules.
+   */
+  public SimSwerveDrive(double chassisMassKg, LinearSystem<N2, N1, N1> azimuthSystem,
+                        DCMotor driveMotor, double driveMotorGearing,
+                        double driveWheelRadiusMeters,
+                        Translation2d... modulePositions) {
+    this(chassisMassKg, Arrays.stream(modulePositions)
+        .map(it -> new SimSwerveModule(driveMotor, driveMotorGearing, driveWheelRadiusMeters, it, azimuthSystem))
+        .collect(Collectors.toList()).toArray(new SimSwerveModule[modulePositions.length]));
+  }
+
+  public SimSwerveDrive(double chassisMassKg, SimSwerveModule... modules) {
+    this.m_chassisMassKg = chassisMassKg;
+    this.m_modules = modules;
+
+    this.m_kinematics = new SwerveDriveKinematics(
+        Arrays.stream(modules).map(SimSwerveModule::getModulePosition).toArray(Translation2d[]::new));
+
+    m_moduleDriveVoltages = new double[m_modules.length];
+    m_moduleAzimuthVoltages = new double[m_modules.length];
+  }
+
+  public SwerveDriveKinematics getKinematics() {
+    return m_kinematics;
+  }
+
+
+  public ChassisSpeeds getEstimatedChassisSpeed() {
+    return m_estimatedSpeed;
+  }
+
+  public SwerveModuleState[] getEstimatedModuleStates() {
+    return m_kinematics.toSwerveModuleStates(getEstimatedChassisSpeed());
+  }
+
+  public SimSwerveModule[] getModules() {
+    return m_modules;
+  }
+
+  public List<Rotation2d> getEstimatedModuleAngles() {
+    return Arrays.stream(m_modules).map(SimSwerveModule::getAzimuthAngle).collect(Collectors.toList());
+  }
+
+  public void setModuleDriveVoltages(double... voltages) {
+    if (voltages.length != m_modules.length) {
+      throw new MatrixDimensionException(String.format("Got the wrong number of inputs. Got %s voltage inputs, but I have %s wheels!", voltages.length, m_modules.length));
+    }
+
+    m_moduleDriveVoltages = voltages;
+  }
+
+  public void setModuleAzimuthVoltages(double... voltages) {
+    if (voltages.length != m_modules.length) {
+      throw new MatrixDimensionException(String.format("Got the wrong number of azimuth voltages. Got %s angles, but I have %s wheels!", voltages.length, m_modules.length));
+    }
+
+    m_moduleAzimuthVoltages = voltages;
+  }
+
+  public void update(double dtSeconds) {
+    // First, we determine the wheel speeds necessary to be at the current chassis speeds
+    // Then, we use this speed to calculate the force each module exerts on the chassis,
+    // Which we use to figure out the acceleration-ish of each wheel. We then integrate this
+    // acceleration forward with RK4, and use IK to go back to chassis speeds from our new
+    // wheel speeds.
+
+    var wheelSpeeds = m_kinematics.toSwerveModuleStates(m_estimatedSpeed);
+    SwerveModuleState[] newState = new SwerveModuleState[m_modules.length];
+
+    for (int i = 0; i < m_modules.length; i++) {
+      int finalI = i;
+      var newSpeedI = RungeKutta.rungeKutta(
+          // F = ma  <==> a = F / m
+          (Double x, Double u) -> m_modules[finalI]
+              .estimateModuleForceNewtons(wheelSpeeds[finalI].speedMetersPerSecond, m_moduleDriveVoltages[finalI]) / m_chassisMassKg * m_modules.length,
+          wheelSpeeds[i].speedMetersPerSecond,
+          m_moduleDriveVoltages[i],
+          dtSeconds);
+
+      var angle = m_modules[i].update(m_moduleAzimuthVoltages[i], dtSeconds);
+      newState[i] = new SwerveModuleState(newSpeedI, angle);
+    }
+
+    this.m_estimatedSpeed = m_kinematics.toChassisSpeeds(newState);
+
+    // Integrate heading forward with RK4
+    m_estimatedHeading = new Rotation2d(RungeKutta.rungeKutta(
+        (double heading) -> this.m_estimatedSpeed.omegaRadiansPerSecond,
+        m_estimatedHeading.getRadians(), dtSeconds));
+  }
+
+  public void resetChassisSpeeds(ChassisSpeeds chassisSpeeds) {
+    this.m_estimatedSpeed = chassisSpeeds;
+  }
+
+  public Rotation2d getEstimatedHeading() {
+    return m_estimatedHeading;
+  }
+
+  public static class SimSwerveModule {
+    private final DCMotor m_driveMotor;
+    private final double m_driveMotorGearing;
+    private final double m_driveWheelRadiusMeters;
+    private final Translation2d m_position;
+
+    private final LinearSystem<N2, N1, N1> m_azimuthSystem;
+    private Matrix<N2, N1> m_azimuthState = VecBuilder.fill(0, 0);
+
+    /**
+     * Construct a SimSwerveModule. The base unit of this model must be radians. This model
+     * can be created with {@link edu.wpi.first.wpilibj.system.plant.LinearSystemId#createSingleJointedArmSystem(DCMotor, double, double)}
+     * or {@link edu.wpi.first.wpilibj.system.plant.LinearSystemId#identifyPositionSystem(double, double)}.
+     *
+     * @param driveMotor             The drive motor as a DCMotor.
+     * @param driveMotorGearing      The gearing between the drive motor and wheel. Usually greater than one.
+     * @param driveWheelRadiusMeters The radius of the wheel in meters.
+     * @param positionMeters         The locations of this wheel relative to the physical center of the
+     *                               robot.
+     */
+    public SimSwerveModule(DCMotor driveMotor, double driveMotorGearing,
+                           double driveWheelRadiusMeters, Translation2d positionMeters,
+                           LinearSystem<N2, N1, N1> azimuthSystem) {
+      this.m_driveMotor = driveMotor;
+      this.m_driveMotorGearing = driveMotorGearing;
+      this.m_driveWheelRadiusMeters = driveWheelRadiusMeters;
+      this.m_position = positionMeters;
+      this.m_azimuthSystem = azimuthSystem;
+    }
+
+    /**
+     * Update the estimated angle of the swerve module.
+     *
+     * @param azimuthVoltageVolts The voltage applied to the azimuth.
+     * @param dtSeconds           Time since last update. Usually 0.020s.
+     */
+    protected Rotation2d update(double azimuthVoltageVolts, double dtSeconds) {
+      m_azimuthState = m_azimuthSystem.calculateX(m_azimuthState, VecBuilder.fill(azimuthVoltageVolts), dtSeconds);
+      return new Rotation2d(m_azimuthState.get(0, 0));
+    }
+
+    /**
+     * Get the currently estimated angle of the swerve module.
+     */
+    public Rotation2d getAzimuthAngle() {
+      return new Rotation2d(MathUtil.normalizeAngle(m_azimuthState.get(0, 0)));
+    }
+
+    @SuppressWarnings("LocalVariableName")
+    public double estimateModuleForceNewtons(double wheelVelocityMps, double wheelVoltage) {
+      // By the elevator equations of motion presented in Controls Engineering in FRC,
+      // F_m = (G Kt)/(R r) Voltage - (G^2 Kt)/(R r^2 Kv) velocity
+      var G = m_driveMotorGearing;
+      var r = m_driveWheelRadiusMeters;
+      var m = m_driveMotor;
+
+      final var v = G * m.m_KtNMPerAmp / (m.m_rOhms * r) * wheelVoltage - (G * G * m.m_KtNMPerAmp)
+          / (m.m_rOhms * r * r * m.m_KvRadPerSecPerVolt) * wheelVelocityMps;
+      System.out.println(v);
+      return v;
+    }
+
+    public Translation2d getModulePosition() {
+      return m_position;
+    }
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
@@ -1,0 +1,126 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.simulation;
+
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpilibj.system.RungeKutta;
+import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+
+public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
+
+  @SuppressWarnings("MemberName")
+  private final double m_r;
+  private double m_maxAngleRads;
+  private double m_minAngleRads;
+  private final double m_armMass;
+
+  /**
+   * Create a LinearSystemSimulator. This simulator uses an {@link LinearSystem} to simulate
+   * the state of the system. In simulationPeriodic, users should first set inputs from motors, update
+   * the simulation and write simulated outputs to sensors.
+   *
+   * @param armSystem            The arm system being controlled.
+   * @param m_measurementStdDevs Standard deviations of measurements. Can be null if addNoise is false.
+   * @param armMassKg            The mass of the arm.
+   * @param armLengthMeters      The distance from the pivot of the arm to its center of mass.
+   *                             This number is not the same as the overall length of the arm.
+   */
+  public SingleJointedArmSim(LinearSystem<N2, N1, N1> armSystem, double armMassKg,
+                             double armLengthMeters, double minAngleRads, double maxAngleRads,
+                             Matrix<N1, N1> m_measurementStdDevs) {
+    super(armSystem, m_measurementStdDevs);
+    this.m_armMass = armMassKg;
+    this.m_r = armLengthMeters;
+    this.m_minAngleRads = minAngleRads;
+    this.m_maxAngleRads = maxAngleRads;
+  }
+
+  /**
+   * Create a LinearSystemSimulator. This simulator uses an {@link LinearSystem} to simulate
+   * the state of the system. In simulationPeriodic, users should first set inputs from motors, update
+   * the simulation and write simulated outputs to sensors.
+   *  @param armMassKg            The mass of the arm.
+   * @param armLengthMeters      The distance from the pivot of the arm to its center of mass.
+   * @param m_measurementStdDevs Standard deviations of measurements. Can be null if addNoise is false.
+   */
+  public SingleJointedArmSim(DCMotor motor, double jKgSquaredMeters,
+                             double G, double armMassKg, double armLengthMeters,
+                             double minAngleRads, double maxAngleRads,
+                             Matrix<N1, N1> m_measurementStdDevs) {
+    this(LinearSystemId.createSingleJointedArmSystem(motor, jKgSquaredMeters, G),
+        armMassKg, armLengthMeters, minAngleRads, maxAngleRads,
+        m_measurementStdDevs);
+  }
+
+  /**
+   * Create a LinearSystemSimulator. This simulator uses an {@link LinearSystem} to simulate
+   * the state of the system. In simulationPeriodic, users should first set inputs from motors, update
+   * the simulation and write simulated outputs to sensors.
+   *  @param armMassKg            The mass of the arm.
+   * @param armLengthMeters      The distance from the pivot of the arm to its center of mass.
+   * @param m_measurementStdDevs Standard deviations of measurements. Can be null if addNoise is false.
+   */
+  public SingleJointedArmSim(DCMotor motor,
+                             double G, double armMassKg, double armLengthMeters,
+                             double minAngleRads, double maxAngleRads,
+                             Matrix<N1, N1> m_measurementStdDevs) {
+    this(LinearSystemId.createSingleJointedArmSystem(motor,
+        1.0 / 3.0 * armMassKg * armLengthMeters * armLengthMeters, G),
+        armMassKg, armLengthMeters, minAngleRads, maxAngleRads,
+        m_measurementStdDevs);
+  }
+
+  public boolean hasHitLowerLimit(Matrix<N2, N1> x) {
+    return x.get(0, 0) < this.m_minAngleRads;
+  }
+
+  public boolean hasHitUpperLimit(Matrix<N2, N1> x) {
+    return x.get(0, 0) > this.m_maxAngleRads;
+  }
+
+  @Override
+  protected Matrix<N2, N1> updateX(Matrix<N2, N1> currentXhat, Matrix<N1, N1> u, double dtSeconds) {
+    /*
+    Horizontal case:
+    Torque = f * r = I * alpha
+    alpha = f * r / I
+    since f=mg,
+    alpha = m g r / I
+
+    Multiply RHS by cos(theta) to account for the arm angle
+     */
+    Matrix<N2, N1> updatedXhat = RungeKutta.rungeKutta(
+        (x, u_) -> (m_plant.getA().times(x))
+            .plus(m_plant.getB().times(u_))
+            .plus(VecBuilder.fill(0,
+                m_armMass * m_r * -9.8 * 3.0 / (m_armMass * m_r * m_r) * Math.cos(x.get(0, 0)))),
+        currentXhat, u, dtSeconds);
+
+    // We check for collision after updating xhat
+    if (hasHitLowerLimit(updatedXhat)) {
+      return VecBuilder.fill(m_minAngleRads, 0);
+    } else if (hasHitUpperLimit(updatedXhat)) {
+      return VecBuilder.fill(m_maxAngleRads, 0);
+    }
+
+    return updatedXhat;
+  }
+
+  public double getArmAngleRads() {
+    return m_x.get(0, 0);
+  }
+
+  public double getArmVelocityRadPerSec() {
+    return m_x.get(1, 0);
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/LTVDiffDriveControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/LTVDiffDriveControllerTest.java
@@ -1,0 +1,371 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.controller;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.ejml.dense.row.CommonOps_DDRM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.estimator.DifferentialDriveStateEstimator;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpilibj.system.RungeKutta;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpilibj.trajectory.Trajectory;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveVelocitySystemConstraint;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.MatrixUtils;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N10;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+import edu.wpi.first.wpiutil.math.numbers.N5;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops",
+    "MemberName", "PMD.SingularField", "PMD.ExcessiveMethodLength"})
+class LTVDiffDriveControllerTest {
+  private Matrix<N10, N1> trueXhat;
+  private Matrix<N2, N1> u;
+
+  private LinearSystem<N2, N2, N2> plant;
+
+  private LTVDiffDriveController controller;
+  private DifferentialDriveStateEstimator estimator;
+  private ControlAffinePlantInversionFeedforward<N10, N2> feedforward;
+
+  private DifferentialDriveKinematics kinematics;
+
+  private Trajectory trajectory;
+
+  private double totalTime;
+
+  @BeforeEach
+  void setUp() {
+    final double kDt = 0.02;
+
+    plant = LinearSystemId.identifyDrivetrainSystem(
+            3.02, 0.642, 1.382, 0.08495);
+
+    kinematics = new DifferentialDriveKinematics(1);
+
+    controller = new LTVDiffDriveController(
+            plant,
+            VecBuilder.fill(0.0625, 0.125, 2.5, 0.95, 0.95),
+            VecBuilder.fill(12.0, 12.0),
+            kinematics,
+            kDt);
+
+    feedforward = new ControlAffinePlantInversionFeedforward<>(
+        Nat.N10(), Nat.N2(), controller::getDynamics, kDt);
+
+    estimator = new DifferentialDriveStateEstimator(
+      plant,
+      MatrixUtils.zeros(Nat.N10()),
+      new MatBuilder<>(Nat.N10(), Nat.N1()).fill(
+        0.002, 0.002, 0.0001, 1.5, 1.5, 0.5, 0.5, 10.0, 10.0, 2.0),
+      new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.0001, 0.005, 0.005),
+      new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.5, 0.5, 0.5),
+      kinematics,
+      kDt);
+
+    final var waypoints = new ArrayList<Pose2d>();
+    waypoints.add(new Pose2d());
+    waypoints.add(new Pose2d(4.8768, 2.7432, new Rotation2d()));
+
+    var config = new TrajectoryConfig(12 / 3.02, (12 / 0.642) - 16.5);
+
+    var constraint = new DifferentialDriveVelocitySystemConstraint(plant, kinematics, 10);
+    config.addConstraint(constraint);
+
+    trajectory = TrajectoryGenerator.generateTrajectory(waypoints, config);
+    totalTime = trajectory.getTotalTimeSeconds();
+  }
+
+  @SuppressWarnings("ParameterName")
+  private Matrix<N2, N1> scaleCappedU(Matrix<N2, N1> u) {
+    boolean isOutputCapped = Math.abs(u.get(0, 0)) > 12.0 || Math.abs(u.get(1, 0)) > 12.0;
+
+    if (isOutputCapped) {
+      u = u.times(12.0 / CommonOps_DDRM.elementMaxAbs(u.getStorage().getDDRM()));
+    }
+    return u;
+  }
+
+  @Test
+  void trackingTest() {
+    controller.reset();
+    estimator.reset();
+    controller.setTolerance(new Pose2d(0.06, 0.06, new Rotation2d(0.1)), 0.5);
+
+    final double kDt = 0.02;
+
+    List<Double> time = new ArrayList<>();
+
+    List<Double> trajXs = new ArrayList<>();
+    List<Double> trajYs = new ArrayList<>();
+    List<Double> trajHeading = new ArrayList<>();
+    List<Double> trajLeftVel = new ArrayList<>();
+    List<Double> trajRightVel = new ArrayList<>();
+
+    List<Double> observerXs = new ArrayList<>();
+    List<Double> observerYs = new ArrayList<>();
+    List<Double> observerHeading = new ArrayList<>();
+    List<Double> observerLeftVel = new ArrayList<>();
+    List<Double> observerRightVel = new ArrayList<>();
+
+    trueXhat = MatrixUtils.zeros(Nat.N10(), Nat.N1());
+
+    u = MatrixUtils.zeros(Nat.N2(), Nat.N1());
+
+    var prevStateRef = MatrixUtils.zeros(Nat.N5());
+
+    double t = 0.0;
+
+    while (t <= totalTime) {
+      var y = estimator.getLocalMeasurementModel(
+          trueXhat, MatrixUtils.zeros(Nat.N2(), Nat.N1()));
+
+      var currentState = estimator.updateWithTime(
+          y.get(0, 0), y.get(1, 0), y.get(2, 0), u, t);
+
+      var desiredState = trajectory.sample(t);
+
+      var wheelVelocities = kinematics.toWheelSpeeds(
+          new ChassisSpeeds(desiredState.velocityMetersPerSecond,
+                0,
+                desiredState.velocityMetersPerSecond * desiredState.curvatureRadPerMeter));
+
+      @SuppressWarnings("VariableDeclarationUsageDistance")
+      Matrix<N5, N1> stateRef = new MatBuilder<>(Nat.N5(), Nat.N1()).fill(
+              desiredState.poseMeters.getTranslation().getX(),
+              desiredState.poseMeters.getTranslation().getY(),
+              desiredState.poseMeters.getRotation().getRadians(),
+              wheelVelocities.leftMetersPerSecond,
+              wheelVelocities.rightMetersPerSecond);
+
+      /* Logging for Graphing */
+      time.add(t);
+
+      observerXs.add(currentState.get(0, 0));
+      observerYs.add(currentState.get(1, 0));
+      observerHeading.add(currentState.get(2, 0));
+      observerLeftVel.add(currentState.get(3, 0));
+      observerRightVel.add(currentState.get(4, 0));
+
+      trajXs.add(prevStateRef.get(0, 0));
+      trajYs.add(prevStateRef.get(1, 0));
+      trajHeading.add(prevStateRef.get(2, 0));
+      trajLeftVel.add(prevStateRef.get(3, 0));
+      trajRightVel.add(prevStateRef.get(4, 0));
+
+      prevStateRef = stateRef;
+
+      var augmentedRef = MatrixUtils.zeros(Nat.N10());
+      augmentedRef.getStorage().insertIntoThis(0, 0, stateRef.getStorage());
+
+      u = controller.calculate(
+          currentState.block(Nat.N5(), Nat.N1(), 0, 0), desiredState)
+          .plus(feedforward.calculate(augmentedRef, feedforward.getR()));
+
+      u = scaleCappedU(u);
+
+      t += kDt;
+
+      trueXhat = RungeKutta.rungeKutta(controller::getDynamics, trueXhat, u, kDt);
+      assertTrue(controller.atReference());
+    }
+
+    /*
+    List<XYChart> charts = new ArrayList<XYChart>();
+
+    var chartBuilder = new XYChartBuilder();
+    chartBuilder.title = "The Magic of Sensor Fusion";
+    var chart = chartBuilder.build();
+
+    chart.addSeries("Trajectory", trajXs, trajYs);
+    chart.addSeries("xHat", observerXs, observerYs);
+    charts.add(chart);
+
+    var chartBuilderHeading = new XYChartBuilder();
+    chartBuilderHeading.title = "Heading versus Time";
+    var chartHeading = chartBuilderHeading.build();
+
+    chartHeading.addSeries("Trajectory", time, trajHeading);
+    chartHeading.addSeries("xHat", time, observerHeading);
+    charts.add(chartHeading);
+
+    var chartBuilderLeftVelocity = new XYChartBuilder();
+    chartBuilderLeftVelocity.title = "Left Velocity versus Time";
+    var chartLeftVelocity = chartBuilderLeftVelocity.build();
+
+    chartLeftVelocity.addSeries("Trajectory", time, trajLeftVel);
+    chartLeftVelocity.addSeries("xHat", time, observerLeftVel);
+    charts.add(chartLeftVelocity);
+
+    var chartBuilderRightVelocity = new XYChartBuilder();
+    chartBuilderRightVelocity.title = "Right Velocity versus Time";
+    var chartRightVelocity = chartBuilderRightVelocity.build();
+
+    chartRightVelocity.addSeries("Trajectory", time, trajRightVel);
+    chartRightVelocity.addSeries("xHat", time, observerRightVel);
+
+    charts.add(chartRightVelocity);
+
+    new SwingWrapper<>(charts).displayChartMatrix();
+    try {
+     Thread.sleep(1000000000);
+    } catch (InterruptedException e) {
+    }
+    */
+  }
+
+  @Test
+  void trackingTestNoise() {
+    controller.reset();
+    estimator.reset();
+    controller.setTolerance(new Pose2d(0.06, 0.06, new Rotation2d(0.1)), 0.5);
+
+    double kDt = 0.02;
+
+    List<Double> time = new ArrayList<>();
+
+    List<Double> trajXs = new ArrayList<>();
+    List<Double> trajYs = new ArrayList<>();
+    List<Double> trajHeading = new ArrayList<>();
+    List<Double> trajLeftVel = new ArrayList<>();
+    List<Double> trajRightVel = new ArrayList<>();
+
+    List<Double> observerXs = new ArrayList<>();
+    List<Double> observerYs = new ArrayList<>();
+    List<Double> observerHeading = new ArrayList<>();
+    List<Double> observerLeftVel = new ArrayList<>();
+    List<Double> observerRightVel = new ArrayList<>();
+
+    trueXhat = MatrixUtils.zeros(Nat.N10(), Nat.N1());
+
+    u = MatrixUtils.zeros(Nat.N2(), Nat.N1());
+
+    var prevStateRef = MatrixUtils.zeros(Nat.N5());
+
+    double t = 0.0;
+
+    while (t <= totalTime) {
+      kDt = 0.02 + StateSpaceUtil.makeWhiteNoiseVector(
+            new MatBuilder<>(Nat.N1(), Nat.N1()).fill(0.0005)).get(0, 0);
+
+      var y = estimator.getLocalMeasurementModel(trueXhat, MatrixUtils.zeros(Nat.N2(), Nat.N1()));
+
+      y = y.plus(StateSpaceUtil.makeWhiteNoiseVector(
+            new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.0001, 0.005, 0.005)));
+
+      var currentState = estimator.updateWithTime(
+          y.get(0, 0), y.get(1, 0), y.get(2, 0), u, t);
+
+      var desiredState = trajectory.sample(t);
+
+      var wheelVelocities = kinematics.toWheelSpeeds(
+          new ChassisSpeeds(desiredState.velocityMetersPerSecond,
+                0,
+                desiredState.velocityMetersPerSecond * desiredState.curvatureRadPerMeter));
+
+      @SuppressWarnings("VariableDeclarationUsageDistance")
+      Matrix<N5, N1> stateRef = new MatBuilder<>(Nat.N5(), Nat.N1()).fill(
+              desiredState.poseMeters.getTranslation().getX(),
+              desiredState.poseMeters.getTranslation().getY(),
+              desiredState.poseMeters.getRotation().getRadians(),
+              wheelVelocities.leftMetersPerSecond,
+              wheelVelocities.rightMetersPerSecond);
+
+      time.add(t);
+
+      observerXs.add(currentState.get(0, 0));
+      observerYs.add(currentState.get(1, 0));
+      observerHeading.add(currentState.get(2, 0));
+      observerLeftVel.add(currentState.get(3, 0));
+      observerRightVel.add(currentState.get(4, 0));
+
+      trajXs.add(prevStateRef.get(0, 0));
+      trajYs.add(prevStateRef.get(1, 0));
+      trajHeading.add(prevStateRef.get(2, 0));
+      trajLeftVel.add(prevStateRef.get(3, 0));
+      trajRightVel.add(prevStateRef.get(4, 0));
+
+      prevStateRef = stateRef;
+
+      var augmentedRef = MatrixUtils.zeros(Nat.N10());
+      augmentedRef.getStorage().insertIntoThis(0, 0, stateRef.getStorage());
+
+      u = controller.calculate(
+          currentState.block(Nat.N5(), Nat.N1(), 0, 0), desiredState)
+          .plus(feedforward.calculate(augmentedRef, feedforward.getR()));
+
+      u = scaleCappedU(u);
+
+      t += kDt;
+
+      trueXhat = RungeKutta.rungeKutta(controller::getDynamics, trueXhat, u, kDt);
+      assertTrue(controller.atReference());
+    }
+
+    /*
+    List<XYChart> charts = new ArrayList<XYChart>();
+
+    var chartBuilder = new XYChartBuilder();
+    chartBuilder.title = "The Magic of Sensor Fusion";
+    var chart = chartBuilder.build();
+
+    chart.addSeries("Trajectory", trajXs, trajYs);
+    chart.addSeries("xHat", observerXs, observerYs);
+    charts.add(chart);
+
+    var chartBuilderHeading = new XYChartBuilder();
+    chartBuilderHeading.title = "Heading versus Time";
+    var chartHeading = chartBuilderHeading.build();
+
+    chartHeading.addSeries("Trajectory", time, trajHeading);
+    chartHeading.addSeries("xHat", time, observerHeading);
+    charts.add(chartHeading);
+
+    var chartBuilderLeftVelocity = new XYChartBuilder();
+    chartBuilderLeftVelocity.title = "Left Velocity versus Time";
+    var chartLeftVelocity = chartBuilderLeftVelocity.build();
+
+    chartLeftVelocity.addSeries("Trajectory", time, trajLeftVel);
+    chartLeftVelocity.addSeries("xHat", time, observerLeftVel);
+    charts.add(chartLeftVelocity);
+
+    var chartBuilderRightVelocity = new XYChartBuilder();
+    chartBuilderRightVelocity.title = "Right Velocity versus Time";
+    var chartRightVelocity = chartBuilderRightVelocity.build();
+
+    chartRightVelocity.addSeries("Trajectory", time, trajRightVel);
+    chartRightVelocity.addSeries("xHat", time, observerRightVel);
+
+    charts.add(chartRightVelocity);
+
+    new SwingWrapper<>(charts).displayChartMatrix();
+    try {
+     Thread.sleep(1000000000);
+    } catch (InterruptedException e) {
+    }
+    */
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/LTVUnicycleControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/LTVUnicycleControllerTest.java
@@ -1,0 +1,104 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.controller;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Twist2d;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LTVUnicycleControllerTest {
+  @Test
+  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+  void testReachesReference() {
+    final var controller = new LTVUnicycleController(
+        VecBuilder.fill(0.1, 0.1, 0.15),
+        VecBuilder.fill(8.8, 4.0),
+        0.02
+    );
+    var robotPose = new Pose2d(2.7, 23.0, Rotation2d.fromDegrees(0.0));
+
+    final var waypoints = new ArrayList<Pose2d>();
+    waypoints.add(new Pose2d(2.75, 22.521, new Rotation2d(0)));
+    waypoints.add(new Pose2d(24.73, 19.68, new Rotation2d(5.846)));
+    var config = new TrajectoryConfig(8.8, 0.1);
+    final var trajectory = TrajectoryGenerator.generateTrajectory(waypoints, config);
+
+    controller.setTolerance(new Pose2d(0.01, 0.01, new Rotation2d(0.001)));
+
+    List<Double> time = new ArrayList<>();
+
+    List<Double> trajXs = new ArrayList<>();
+    List<Double> trajYs = new ArrayList<>();
+    List<Double> trajHeadings = new ArrayList<>();
+
+
+    List<Double> robotXs = new ArrayList<>();
+    List<Double> robotYs = new ArrayList<>();
+    List<Double> robotHeadings = new ArrayList<>();
+
+    final double kDt = 0.02;
+    final var totalTime = trajectory.getTotalTimeSeconds();
+    for (int i = 0; i < (totalTime / kDt); ++i) {
+      var state = trajectory.sample(kDt * i);
+
+      time.add(kDt * i);
+
+      trajXs.add(state.poseMeters.getTranslation().getX());
+      trajYs.add(state.poseMeters.getTranslation().getY());
+      trajHeadings.add(state.poseMeters.getRotation().getRadians());
+
+      var output = controller.calculate(robotPose, state);
+      robotPose = robotPose.exp(new Twist2d(output.vxMetersPerSecond * kDt, 0,
+          output.omegaRadiansPerSecond * kDt));
+
+      robotXs.add(robotPose.getTranslation().getX());
+      robotYs.add(robotPose.getTranslation().getY());
+      robotHeadings.add(robotPose.getRotation().getRadians());
+    }
+
+    assertTrue(controller.atReference());
+
+    // List<XYChart> charts = new ArrayList<XYChart>();
+
+    // var chartBuilder = new XYChartBuilder();
+    // chartBuilder.title = "LTV Unicycle Controller";
+    // var chart = chartBuilder.build();
+
+    // chart.addSeries("Trajectory", trajXs, trajYs);
+    // chart.addSeries("Robot", robotXs, robotYs);
+    // charts.add(chart);
+
+    // var timeChartBuilder = new XYChartBuilder();
+    // timeChartBuilder.title = "Time vs Position";
+    // var timeChart = timeChartBuilder.build();
+
+    // timeChart.addSeries("XRobot", time, robotXs);
+    // timeChart.addSeries("YRobot", time, robotYs);
+    // timeChart.addSeries("HeadingRobot", time, robotHeadings);
+    // timeChart.addSeries("XTraj", time, trajXs);
+    // timeChart.addSeries("YTraj", time, trajYs);
+    // timeChart.addSeries("HeadingTraj", time, trajHeadings);
+    // charts.add(timeChart);
+
+    // new SwingWrapper<>(charts).displayChartMatrix();
+    // try {
+    //  Thread.sleep(1000000000);
+    // } catch (InterruptedException e) {
+    // }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -1,0 +1,154 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.trajectory.Trajectory;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Nat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DifferentialDrivePoseEstimatorTest {
+  @SuppressWarnings({"LocalVariableName", "PMD.ExcessiveMethodLength",
+        "PMD.AvoidInstantiatingObjectsInLoops"})
+  @Test
+  public void testAccuracy() {
+    var estimator = new DifferentialDrivePoseEstimator(new Rotation2d(), new Pose2d(),
+            new MatBuilder<>(Nat.N5(), Nat.N1()).fill(0.02, 0.02, 0.01, 0.02, 0.02),
+            new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.02, 0.02, 0.01),
+            new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.1, 0.1, 0.01));
+
+    var traj = TrajectoryGenerator.generateTrajectory(
+            List.of(
+                    new Pose2d(),
+                    new Pose2d(20, 20, Rotation2d.fromDegrees(0)),
+                    new Pose2d(23, 23, Rotation2d.fromDegrees(173)),
+                    new Pose2d(54, 54, new Rotation2d())
+            ),
+            new TrajectoryConfig(0.5, 2));
+
+    var kinematics = new DifferentialDriveKinematics(1);
+    var rand = new Random(4915);
+
+    List<Double> trajXs = new ArrayList<>();
+    List<Double> trajYs = new ArrayList<>();
+    List<Double> observerXs = new ArrayList<>();
+    List<Double> observerYs = new ArrayList<>();
+    List<Double> visionXs = new ArrayList<>();
+    List<Double> visionYs = new ArrayList<>();
+
+    final double dt = 0.02;
+    double t = 0.0;
+
+    final double visionUpdateRate = 0.1;
+    Pose2d lastVisionPose = null;
+    double lastVisionUpdateTime = Double.NEGATIVE_INFINITY;
+
+    double distanceLeft = 0.0;
+    double distanceRight = 0.0;
+
+    double maxError = Double.NEGATIVE_INFINITY;
+    double errorSum = 0;
+    Trajectory.State groundtruthState;
+    DifferentialDriveWheelSpeeds input;
+    while (t <= traj.getTotalTimeSeconds()) {
+      groundtruthState = traj.sample(t);
+      input = kinematics.toWheelSpeeds(new ChassisSpeeds(
+              groundtruthState.velocityMetersPerSecond, 0.0,
+              // ds/dt * dtheta/ds = dtheta/dt
+              groundtruthState.velocityMetersPerSecond * groundtruthState.curvatureRadPerMeter
+      ));
+
+      if (lastVisionUpdateTime + visionUpdateRate + rand.nextGaussian() * 0.4 < t) {
+        if (lastVisionPose != null) {
+          estimator.addVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
+        }
+        var groundPose = groundtruthState.poseMeters;
+        lastVisionPose = new Pose2d(
+                new Translation2d(
+                        groundPose.getTranslation().getX() + rand.nextGaussian() * 0.1,
+                        groundPose.getTranslation().getY() + rand.nextGaussian() * 0.1
+                ),
+                new Rotation2d(rand.nextGaussian() * 0.01).plus(groundPose.getRotation())
+        );
+        lastVisionUpdateTime = t;
+
+        visionXs.add(lastVisionPose.getTranslation().getX());
+        visionYs.add(lastVisionPose.getTranslation().getY());
+      }
+
+      input.leftMetersPerSecond += rand.nextGaussian() * 0.02;
+      input.rightMetersPerSecond += rand.nextGaussian() * 0.02;
+
+      distanceLeft += input.leftMetersPerSecond * dt;
+      distanceRight += input.rightMetersPerSecond * dt;
+
+      var rotNoise = new Rotation2d(rand.nextGaussian() * 0.01);
+      var xHat = estimator.updateWithTime(
+              t,
+              groundtruthState.poseMeters.getRotation().plus(rotNoise),
+              input,
+              distanceLeft, distanceRight
+      );
+
+      double error =
+              groundtruthState.poseMeters.getTranslation().getDistance(xHat.getTranslation());
+      if (error > maxError) {
+        maxError = error;
+      }
+      errorSum += error;
+
+      trajXs.add(groundtruthState.poseMeters.getTranslation().getX());
+      trajYs.add(groundtruthState.poseMeters.getTranslation().getY());
+      observerXs.add(xHat.getTranslation().getX());
+      observerYs.add(xHat.getTranslation().getY());
+
+      t += dt;
+    }
+
+    assertEquals(
+            0.0, errorSum / (traj.getTotalTimeSeconds() / dt), 0.03,
+            "Incorrect mean error"
+    );
+    assertEquals(
+            0.0, maxError, 0.05,
+            "Incorrect max error"
+    );
+
+    //System.out.println("Mean error (meters): " + errorSum / (traj.getTotalTimeSeconds() / dt));
+    //System.out.println("Max error (meters):  " + maxError);
+
+    //var chartBuilder = new XYChartBuilder();
+    //chartBuilder.title = "The Magic of Sensor Fusion";
+    //var chart = chartBuilder.build();
+
+    //chart.addSeries("Vision", visionXs, visionYs);
+    //chart.addSeries("Trajectory", trajXs, trajYs);
+    //chart.addSeries("xHat", observerXs, observerYs);
+
+    //new SwingWrapper<>(chart).displayChart();
+    //try {
+    //  Thread.sleep(1000000000);
+    //} catch (InterruptedException e) {
+    //}
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDriveStateEstimatorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDriveStateEstimatorTest.java
@@ -1,0 +1,249 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.ejml.dense.row.CommonOps_DDRM;
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.controller.ControlAffinePlantInversionFeedforward;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpilibj.trajectory.Trajectory;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveVelocitySystemConstraint;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.MatrixUtils;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings({"PMD.AvoidInstantiatingObjectsInLoops",
+      "PMD.ExcessiveMethodLength", "ParameterName", "LocalVariableName"})
+public class DifferentialDriveStateEstimatorTest {
+  private void scaleCappedU(Matrix<N2, N1> u) {
+    boolean isOutputCapped = Math.abs(u.get(0, 0)) > 12.0 || Math.abs(u.get(1, 0)) > 12.0;
+
+    if (isOutputCapped) {
+      u.times(12.0 / CommonOps_DDRM.elementMaxAbs(u.getStorage().getDDRM()));
+    }
+  }
+
+  @Test
+  public void testAccuracy() {
+    final double dt = 0.00505;
+
+    final LinearSystem<N2, N2, N2> plant = LinearSystemId.identifyDrivetrainSystem(
+        3.02, 0.642, 1.382, 0.08495);
+    var kinematics = new DifferentialDriveKinematics(0.990405073902434);
+
+    var estimator = new DifferentialDriveStateEstimator(
+            plant,
+            MatrixUtils.zeros(Nat.N10()),
+            new MatBuilder<>(Nat.N10(), Nat.N1()).fill(
+                0.002, 0.002, 0.0001, 1.5, 1.5, 0.5, 0.5, 10.0, 10.0, 2.0),
+            new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.0001, 0.005, 0.005),
+            new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.5, 0.5, 0.5),
+            kinematics);
+
+    var feedforward = new ControlAffinePlantInversionFeedforward<>(Nat.N10(), Nat.N2(),
+        estimator::getDynamics, dt);
+
+    var config = new TrajectoryConfig(12 / 3.02, (12 / 0.642) - 16.5);
+    config.addConstraint(new DifferentialDriveVelocitySystemConstraint(plant, kinematics, 8));
+
+    var traj = TrajectoryGenerator.generateTrajectory(
+            new Pose2d(),
+            List.of(),
+            new Pose2d(4.8768, 2.7432, new Rotation2d()),
+            config);
+
+    var rand = new Random(604);
+
+    List<Double> time = new ArrayList<>();
+    List<Double> trajXs = new ArrayList<>();
+    List<Double> trajYs = new ArrayList<>();
+    List<Double> trajLeftVel = new ArrayList<>();
+    List<Double> trajRightVel = new ArrayList<>();
+    List<Double> observerXs = new ArrayList<>();
+    List<Double> observerYs = new ArrayList<>();
+    List<Double> observerLeftVelocity = new ArrayList<>();
+    List<Double> observerRightVelocity = new ArrayList<>();
+    List<Double> observerLeftVoltageError = new ArrayList<>();
+    List<Double> observerRightVoltageError = new ArrayList<>();
+    List<Double> observerAngularVelocityError = new ArrayList<>();
+    List<Double> visionXs = new ArrayList<>();
+    List<Double> visionYs = new ArrayList<>();
+
+    double t = 0.0;
+
+    final double visionUpdateRate = 0.1;
+    Pose2d lastVisionPose = null;
+    double lastVisionUpdateTime = Double.NEGATIVE_INFINITY;
+
+    double distanceLeft = 0.0;
+    double distanceRight = 0.0;
+
+    double maxError = Double.NEGATIVE_INFINITY;
+    double errorSum = 0;
+
+    Trajectory.State groundTruthState;
+
+    Matrix<N2, N1> input;
+
+    while (t <= traj.getTotalTimeSeconds()) {
+      groundTruthState = traj.sample(t);
+
+      var chassisSpeeds = new ChassisSpeeds(
+          groundTruthState.velocityMetersPerSecond, 0,
+          groundTruthState.velocityMetersPerSecond * groundTruthState.curvatureRadPerMeter
+      );
+      var wheelSpeeds = kinematics.toWheelSpeeds(chassisSpeeds);
+
+      var x = new MatBuilder<>(Nat.N10(), Nat.N1()).fill(
+              groundTruthState.poseMeters.getTranslation().getX(),
+              groundTruthState.poseMeters.getTranslation().getY(),
+              groundTruthState.poseMeters.getRotation().getRadians(),
+              wheelSpeeds.leftMetersPerSecond,
+              wheelSpeeds.rightMetersPerSecond,
+              0.0, 0.0, 0.0, 0.0, 0.0);
+
+      input = feedforward.calculate(x, feedforward.getR());
+
+      scaleCappedU(input);
+
+      if (lastVisionUpdateTime + visionUpdateRate + rand.nextGaussian() * 0.4 < t) {
+        if (lastVisionPose != null) {
+          estimator.applyPastGlobalMeasurement(
+                  lastVisionPose,
+                  lastVisionUpdateTime);
+        }
+        var groundPose = groundTruthState.poseMeters;
+        lastVisionPose = new Pose2d(
+                new Translation2d(
+                        groundPose.getTranslation().getX() + rand.nextGaussian() * 0.5,
+                        groundPose.getTranslation().getY() + rand.nextGaussian() * 0.5
+                ),
+                new Rotation2d(rand.nextGaussian() * 0.5).plus(groundPose.getRotation())
+        );
+        lastVisionUpdateTime = t;
+
+        visionXs.add(lastVisionPose.getTranslation().getX());
+        visionYs.add(lastVisionPose.getTranslation().getY());
+      }
+
+      distanceLeft += wheelSpeeds.leftMetersPerSecond * dt;
+      distanceRight += wheelSpeeds.rightMetersPerSecond * dt;
+
+      distanceLeft += rand.nextGaussian() * 0.001;
+      distanceRight += rand.nextGaussian() * 0.001;
+
+      var rotNoise = new Rotation2d(rand.nextGaussian() * 0.0001);
+
+      var xHat = estimator.updateWithTime(groundTruthState.poseMeters.getRotation()
+                      .plus(rotNoise).getRadians(),
+                      distanceLeft,
+                      distanceRight,
+                      input,
+                      t);
+
+      double error =
+              groundTruthState.poseMeters.getTranslation().getDistance(
+                      new Translation2d(xHat.get(0, 0),
+                                        xHat.get(1, 0)));
+      if (error > maxError) {
+        maxError = error;
+      }
+      errorSum += error;
+
+      time.add(t);
+
+      trajXs.add(groundTruthState.poseMeters.getTranslation().getX());
+      trajYs.add(groundTruthState.poseMeters.getTranslation().getY());
+      trajLeftVel.add(wheelSpeeds.leftMetersPerSecond);
+      trajRightVel.add(wheelSpeeds.rightMetersPerSecond);
+
+      observerXs.add(xHat.get(0, 0));
+      observerYs.add(xHat.get(1, 0));
+      observerLeftVelocity.add(xHat.get(3, 0));
+      observerRightVelocity.add(xHat.get(4, 0));
+      observerLeftVoltageError.add(xHat.get(7, 0));
+      observerRightVoltageError.add(xHat.get(8, 0));
+      observerAngularVelocityError.add(xHat.get(9, 0));
+
+      t += dt;
+    }
+
+    assertEquals(
+           0.0, errorSum / (traj.getTotalTimeSeconds() / dt), 0.3,
+           "Incorrect mean error"
+    );
+    assertEquals(
+           0.0, maxError, 0.4,
+           "Incorrect max error"
+    );
+
+    /*
+    List<XYChart> charts = new ArrayList<XYChart>();
+
+    var chartBuilder = new XYChartBuilder();
+    chartBuilder.title = "The Magic of Sensor Fusion";
+    var chart = chartBuilder.build();
+
+    chart.addSeries("Vision", visionXs, visionYs);
+    chart.addSeries("Trajectory", trajXs, trajYs);
+    chart.addSeries("xHat", observerXs, observerYs);
+    charts.add(chart);
+
+    var chartBuilderError = new XYChartBuilder();
+    chartBuilderError.title = "Error versus Time";
+    var chartError = chartBuilderError.build();
+
+    chartError.addSeries("LeftVoltage", time, observerLeftVoltageError);
+    chartError.addSeries("RightVoltage", time, observerRightVoltageError);
+    chartError.addSeries("AngularVelocity", time, observerAngularVelocityError);
+    charts.add(chartError);
+
+    var chartBuilderLeftVelocity = new XYChartBuilder();
+    chartBuilderLeftVelocity.title = "Left Velocity versus Time";
+    var chartLeftVelocity = chartBuilderLeftVelocity.build();
+
+    chartLeftVelocity.addSeries("xHat", time, observerLeftVelocity);
+    chartLeftVelocity.addSeries("Trajectory", time, trajLeftVel);
+    charts.add(chartLeftVelocity);
+
+    var chartBuilderRightVelocity = new XYChartBuilder();
+    chartBuilderRightVelocity.title = "Right Velocity versus Time";
+    var chartRightVelocity = chartBuilderRightVelocity.build();
+
+    chartRightVelocity.addSeries("xHat", time, observerRightVelocity);
+    chartRightVelocity.addSeries("Trajectory", time, trajRightVel);
+
+    charts.add(chartRightVelocity);
+
+    new SwingWrapper<>(charts).displayChartMatrix();
+    try {
+      Thread.sleep(1000000000);
+    } catch (InterruptedException e) {
+    }
+    */
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/MecanumDrivePoseEstimatorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/MecanumDrivePoseEstimatorTest.java
@@ -1,0 +1,207 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.MecanumDriveKinematics;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MecanumDrivePoseEstimatorTest {
+  @Test
+  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  public void testAccuracy() {
+    var kinematics = new MecanumDriveKinematics(
+            new Translation2d(1, 1), new Translation2d(1, -1),
+            new Translation2d(-1, -1), new Translation2d(-1, 1));
+
+    var estimator = new MecanumDrivePoseEstimator(
+            new Rotation2d(), new Pose2d(), kinematics,
+            VecBuilder.fill(0.01, 0.01, 0.01),
+            VecBuilder.fill(0.05),
+            VecBuilder.fill(0.1, 0.1, 0.1)
+    );
+
+    var trajectory = TrajectoryGenerator.generateTrajectory(
+            List.of(new Pose2d(),
+                    new Pose2d(20, 20, Rotation2d.fromDegrees(0)),
+                    new Pose2d(10, 10, Rotation2d.fromDegrees(180)),
+                    new Pose2d(30, 30, Rotation2d.fromDegrees(0)),
+                    new Pose2d(20, 20, Rotation2d.fromDegrees(180)),
+                    new Pose2d(10, 10, Rotation2d.fromDegrees(0))),
+            new TrajectoryConfig(0.5, 2)
+    );
+
+    var rand = new Random(5190);
+
+    List<Double> trajXs = new ArrayList<>();
+    List<Double> trajYs = new ArrayList<>();
+    List<Double> trajCosine = new ArrayList<>();
+    List<Double> trajSine = new ArrayList<>();
+    List<Double> trajTheta = new ArrayList<>();
+
+    List<Double> observerXs = new ArrayList<>();
+    List<Double> observerYs = new ArrayList<>();
+    List<Double> observerCosine = new ArrayList<>();
+    List<Double> observerSine = new ArrayList<>();
+    List<Double> observerTheta = new ArrayList<>();
+
+    List<Double> visionXs = new ArrayList<>();
+    List<Double> visionYs = new ArrayList<>();
+    List<Double> visionCosine = new ArrayList<>();
+    List<Double> visionSine = new ArrayList<>();
+    List<Double> visionTheta = new ArrayList<>();
+
+    List<Double> time = new ArrayList<>();
+    List<Double> visionTime = new ArrayList<>();
+
+    final double dt = 0.02;
+    double t = 0.0;
+
+    final double visionUpdateRate = 0.1;
+    Pose2d lastVisionPose = null;
+    double lastVisionUpdateTime = Double.NEGATIVE_INFINITY;
+
+    double maxError = Double.NEGATIVE_INFINITY;
+    double errorSum = 0;
+    while (t <= trajectory.getTotalTimeSeconds()) {
+      var groundTruthState = trajectory.sample(t);
+
+      if (lastVisionUpdateTime + visionUpdateRate < t) {
+        if (lastVisionPose != null) {
+          estimator.addVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
+        }
+
+        lastVisionPose = new Pose2d(
+                new Translation2d(
+                        groundTruthState.poseMeters.getTranslation().getX()
+                                + rand.nextGaussian() * 0.1,
+                        groundTruthState.poseMeters.getTranslation().getY()
+                                + rand.nextGaussian() * 0.1
+                ),
+                new Rotation2d(
+                        rand.nextGaussian() * 0.1).plus(groundTruthState.poseMeters.getRotation())
+        );
+
+        lastVisionUpdateTime = t;
+
+        visionXs.add(lastVisionPose.getTranslation().getX());
+        visionYs.add(lastVisionPose.getTranslation().getY());
+        visionTheta.add(lastVisionPose.getRotation().getDegrees());
+        visionCosine.add(lastVisionPose.getRotation().getCos());
+        visionSine.add(lastVisionPose.getRotation().getSin());
+        visionTime.add(t);
+      }
+
+      var wheelSpeeds = kinematics.toWheelSpeeds(new ChassisSpeeds(
+              groundTruthState.velocityMetersPerSecond, 0,
+              groundTruthState.velocityMetersPerSecond * groundTruthState.curvatureRadPerMeter));
+
+      wheelSpeeds.frontLeftMetersPerSecond += rand.nextGaussian() * 0.1;
+      wheelSpeeds.frontRightMetersPerSecond += rand.nextGaussian() * 0.1;
+      wheelSpeeds.rearLeftMetersPerSecond += rand.nextGaussian() * 0.1;
+      wheelSpeeds.rearRightMetersPerSecond += rand.nextGaussian() * 0.1;
+
+      var xHat = estimator.updateWithTime(t,
+              groundTruthState.poseMeters.getRotation()
+                      .plus(new Rotation2d(rand.nextGaussian() * 0.05)), wheelSpeeds);
+
+      double error =
+              groundTruthState.poseMeters.getTranslation().getDistance(xHat.getTranslation());
+      if (error > maxError) {
+        maxError = error;
+      }
+      errorSum += error;
+
+      trajXs.add(groundTruthState.poseMeters.getTranslation().getX());
+      trajYs.add(groundTruthState.poseMeters.getTranslation().getY());
+      trajTheta.add(groundTruthState.poseMeters.getRotation().getDegrees());
+      trajCosine.add(groundTruthState.poseMeters.getRotation().getCos());
+      trajSine.add(groundTruthState.poseMeters.getRotation().getSin());
+      observerXs.add(xHat.getTranslation().getX());
+      observerYs.add(xHat.getTranslation().getY());
+      observerTheta.add(xHat.getRotation().getDegrees());
+      observerCosine.add(xHat.getRotation().getCos());
+      observerSine.add(xHat.getRotation().getSin());
+      time.add(t);
+
+      t += dt;
+    }
+
+    assertEquals(
+           0.0, errorSum / (trajectory.getTotalTimeSeconds() / dt), 0.25,
+           "Incorrect mean error"
+    );
+    assertEquals(
+           0.0, maxError, 0.42,
+           "Incorrect max error"
+    );
+
+    /*
+    List<XYChart> charts = new ArrayList<XYChart>();
+
+    var chartBuilder = new XYChartBuilder();
+    chartBuilder.title = "The Magic of Sensor Fusion";
+    var chart = chartBuilder.build();
+
+    chart.addSeries("Vision", visionXs, visionYs);
+    chart.addSeries("Trajectory", trajXs, trajYs);
+    chart.addSeries("xHat", observerXs, observerYs);
+    charts.add(chart);
+
+    var chartBuilder1 = new XYChartBuilder();
+    chartBuilder1.title = "Cosine";
+    var chart1 = chartBuilder1.build();
+
+    chart1.addSeries("Vision", visionTime, visionCosine);
+    chart1.addSeries("Trajectory", time, trajCosine);
+    chart1.addSeries("xHat", time, observerCosine);
+    charts.add(chart1);
+
+    var chartBuilder2 = new XYChartBuilder();
+    chartBuilder2.title = "Sine";
+    var chart2 = chartBuilder2.build();
+
+    chart2.addSeries("Vision", visionTime, visionSine);
+    chart2.addSeries("Trajectory", time, trajSine);
+    chart2.addSeries("xHat", time, observerSine);
+
+    charts.add(chart2);
+
+    var chartBuilder3 = new XYChartBuilder();
+    chartBuilder3.title = "Degrees";
+    var chart3 = chartBuilder3.build();
+
+    chart3.addSeries("Vision", visionTime, visionTheta);
+    chart3.addSeries("Trajectory", time, trajTheta);
+    chart3.addSeries("xHat", time, observerTheta);
+    charts.add(chart3);
+
+
+
+    new SwingWrapper<>(charts).displayChartMatrix();
+    try {
+      Thread.sleep(1000000000);
+    } catch (InterruptedException e) {
+    }
+    */
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/MerweScaledSigmaPointsTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/MerweScaledSigmaPointsTest.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import org.ejml.EjmlUnitTests;
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+public class MerweScaledSigmaPointsTest {
+  @Test
+  public void testZeroMeanPoints() {
+    var merweScaledSigmaPoints = new MerweScaledSigmaPoints<>(Nat.N2());
+    var points = merweScaledSigmaPoints.sigmaPoints(VecBuilder.fill(0, 0),
+          new MatBuilder<>(Nat.N2(), Nat.N2()).fill(1, 0, 0, 1));
+
+    assertMatrixEquals(points, new MatBuilder<>(Nat.N2(), Nat.N5()).fill(
+            0.0, 0.00173205, 0.0, -0.00173205, 0.0,
+            0.0, 0.0, 0.00173205, 0.0, -0.00173205
+    ));
+  }
+
+  @Test
+  public void testNonzeroMeanPoints() {
+    var merweScaledSigmaPoints = new MerweScaledSigmaPoints<>(Nat.N2());
+    var points = merweScaledSigmaPoints.sigmaPoints(VecBuilder.fill(1, 2),
+          new MatBuilder<>(Nat.N2(), Nat.N2()).fill(1, 0, 0, 10));
+
+    assertMatrixEquals(points, new MatBuilder<>(Nat.N2(), Nat.N5()).fill(
+            1.0, 1.00173205, 1.0, 0.99826795, 1.0,
+            2.0, 2.0, 2.00547723, 2.0, 1.99452277
+    ));
+  }
+
+  @SuppressWarnings("ParameterName")
+  void assertMatrixEquals(Matrix<?, ?> a, Matrix<?, ?> b) {
+    EjmlUnitTests.assertEquals(a.getStorage().getDDRM(), b.getStorage().getDDRM());
+  }
+
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimatorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimatorTest.java
@@ -1,0 +1,213 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SwerveDrivePoseEstimatorTest {
+  @Test
+  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  public void testAccuracy() {
+    var kinematics = new SwerveDriveKinematics(
+            new Translation2d(1, 1),
+            new Translation2d(1, -1),
+            new Translation2d(-1, -1),
+            new Translation2d(-1, 1)
+    );
+    var estimator = new SwerveDrivePoseEstimator(
+            new Rotation2d(), new Pose2d(), kinematics,
+            VecBuilder.fill(0.1, 0.1, 0.1),
+            VecBuilder.fill(0.05),
+            VecBuilder.fill(0.1, 0.1, 0.1)
+    );
+
+    var trajectory = TrajectoryGenerator.generateTrajectory(
+            List.of(new Pose2d(),
+                    new Pose2d(20, 20, Rotation2d.fromDegrees(0)),
+                    new Pose2d(10, 10, Rotation2d.fromDegrees(180)),
+                    new Pose2d(30, 30, Rotation2d.fromDegrees(0)),
+                    new Pose2d(20, 20, Rotation2d.fromDegrees(180)),
+                    new Pose2d(10, 10, Rotation2d.fromDegrees(0))),
+            new TrajectoryConfig(0.5, 2)
+    );
+
+    var rand = new Random(4915);
+
+    List<Double> trajXs = new ArrayList<>();
+    List<Double> trajYs = new ArrayList<>();
+    List<Double> trajCosine = new ArrayList<>();
+    List<Double> trajSine = new ArrayList<>();
+    List<Double> trajTheta = new ArrayList<>();
+
+    List<Double> observerXs = new ArrayList<>();
+    List<Double> observerYs = new ArrayList<>();
+    List<Double> observerCosine = new ArrayList<>();
+    List<Double> observerSine = new ArrayList<>();
+    List<Double> observerTheta = new ArrayList<>();
+
+    List<Double> visionXs = new ArrayList<>();
+    List<Double> visionYs = new ArrayList<>();
+    List<Double> visionCosine = new ArrayList<>();
+    List<Double> visionSine = new ArrayList<>();
+    List<Double> visionTheta = new ArrayList<>();
+
+    List<Double> time = new ArrayList<>();
+    List<Double> visionTime = new ArrayList<>();
+
+
+    final double dt = 0.02;
+    double t = 0.0;
+
+    final double visionUpdateRate = 0.1;
+    Pose2d lastVisionPose = null;
+    double lastVisionUpdateTime = Double.NEGATIVE_INFINITY;
+
+    double maxError = Double.NEGATIVE_INFINITY;
+    double errorSum = 0;
+    while (t <= trajectory.getTotalTimeSeconds()) {
+      var groundTruthState = trajectory.sample(t);
+
+      if (lastVisionUpdateTime + visionUpdateRate < t) {
+        if (lastVisionPose != null) {
+          estimator.addVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
+        }
+
+        lastVisionPose = new Pose2d(
+                new Translation2d(
+                        groundTruthState.poseMeters.getTranslation().getX()
+                                + rand.nextGaussian() * 0.1,
+                        groundTruthState.poseMeters.getTranslation().getY()
+                                + rand.nextGaussian() * 0.1
+                ),
+                new Rotation2d(
+                        rand.nextGaussian() * 0.1).plus(groundTruthState.poseMeters.getRotation())
+        );
+
+        lastVisionUpdateTime = t;
+
+        visionXs.add(lastVisionPose.getTranslation().getX());
+        visionYs.add(lastVisionPose.getTranslation().getY());
+        visionTheta.add(lastVisionPose.getRotation().getDegrees());
+        visionCosine.add(lastVisionPose.getRotation().getCos());
+        visionSine.add(lastVisionPose.getRotation().getSin());
+        visionTime.add(t);
+      }
+
+      var moduleStates = kinematics.toSwerveModuleStates(new ChassisSpeeds(
+              groundTruthState.velocityMetersPerSecond,
+              0.0,
+              groundTruthState.velocityMetersPerSecond * groundTruthState.curvatureRadPerMeter)
+      );
+      for (var moduleState : moduleStates) {
+        moduleState.angle = moduleState.angle.plus(new Rotation2d(rand.nextGaussian() * 0.5));
+        moduleState.speedMetersPerSecond += rand.nextGaussian() * 1;
+      }
+
+      var xHat = estimator.updateWithTime(
+              t,
+              groundTruthState.poseMeters.getRotation()
+                      .plus(new Rotation2d(rand.nextGaussian() * 0.05)),
+              moduleStates);
+
+      double error =
+              groundTruthState.poseMeters.getTranslation().getDistance(xHat.getTranslation());
+      if (error > maxError) {
+        maxError = error;
+      }
+      errorSum += error;
+
+      trajXs.add(groundTruthState.poseMeters.getTranslation().getX());
+      trajYs.add(groundTruthState.poseMeters.getTranslation().getY());
+      trajTheta.add(groundTruthState.poseMeters.getRotation().getDegrees());
+      trajCosine.add(groundTruthState.poseMeters.getRotation().getCos());
+      trajSine.add(groundTruthState.poseMeters.getRotation().getSin());
+      observerXs.add(xHat.getTranslation().getX());
+      observerYs.add(xHat.getTranslation().getY());
+      observerTheta.add(xHat.getRotation().getDegrees());
+      observerCosine.add(xHat.getRotation().getCos());
+      observerSine.add(xHat.getRotation().getSin());
+      time.add(t);
+
+      t += dt;
+    }
+
+    assertEquals(
+            0.0, errorSum / (trajectory.getTotalTimeSeconds() / dt), 0.25,
+            "Incorrect mean error"
+    );
+    assertEquals(
+            0.0, maxError, 0.42,
+            "Incorrect max error"
+    );
+
+    /*
+    List<XYChart> charts = new ArrayList<XYChart>();
+
+    var chartBuilder = new XYChartBuilder();
+    chartBuilder.title = "The Magic of Sensor Fusion";
+    var chart = chartBuilder.build();
+
+    chart.addSeries("Vision", visionXs, visionYs);
+    chart.addSeries("Trajectory", trajXs, trajYs);
+    chart.addSeries("xHat", observerXs, observerYs);
+    charts.add(chart);
+
+    var chartBuilder1 = new XYChartBuilder();
+    chartBuilder1.title = "Cosine";
+    var chart1 = chartBuilder1.build();
+
+    chart1.addSeries("Vision", visionTime, visionCosine);
+    chart1.addSeries("Trajectory", time, trajCosine);
+    chart1.addSeries("xHat", time, observerCosine);
+    charts.add(chart1);
+
+    var chartBuilder2 = new XYChartBuilder();
+    chartBuilder2.title = "Sine";
+    var chart2 = chartBuilder2.build();
+
+    chart2.addSeries("Vision", visionTime, visionSine);
+    chart2.addSeries("Trajectory", time, trajSine);
+    chart2.addSeries("xHat", time, observerSine);
+
+    charts.add(chart2);
+
+    var chartBuilder3 = new XYChartBuilder();
+    chartBuilder3.title = "Degrees";
+    var chart3 = chartBuilder3.build();
+
+    chart3.addSeries("Vision", visionTime, visionTheta);
+    chart3.addSeries("Trajectory", time, trajTheta);
+    chart3.addSeries("xHat", time, observerTheta);
+    charts.add(chart3);
+
+
+
+    new SwingWrapper<>(charts).displayChartMatrix();
+    try {
+      Thread.sleep(1000000000);
+    } catch (InterruptedException e) {
+    }
+    */
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/UnscentedKalmanFilterTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/UnscentedKalmanFilterTest.java
@@ -1,0 +1,406 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.ejml.EjmlUnitTests;
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.math.Discretization;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpilibj.system.NumericalJacobian;
+import edu.wpi.first.wpilibj.system.RungeKutta;
+import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.MatrixUtils;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+import edu.wpi.first.wpiutil.math.numbers.N4;
+import edu.wpi.first.wpiutil.math.numbers.N6;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class UnscentedKalmanFilterTest {
+  @SuppressWarnings({"LocalVariableName", "ParameterName"})
+  public static Matrix<N6, N1> getDynamics(Matrix<N6, N1> x, Matrix<N2, N1> u) {
+    var motors = DCMotor.getCIM(2);
+
+    var gHigh = 7.08;
+    var rb = 0.8382 / 2.0;
+    var r = 0.0746125;
+    var m = 63.503;
+    var J = 5.6;
+
+    var C1 = -Math.pow(gHigh, 2) * motors.m_KtNMPerAmp
+          / (motors.m_KvRadPerSecPerVolt * motors.m_rOhms * r * r);
+    var C2 = gHigh * motors.m_KtNMPerAmp / (motors.m_rOhms * r);
+
+    var c = x.get(2, 0);
+    var s = x.get(3, 0);
+    var vl = x.get(4, 0);
+    var vr = x.get(5, 0);
+
+    var Vl = u.get(0, 0);
+    var Vr = u.get(1, 0);
+
+    var k1 = 1.0 / m + rb * rb / J;
+    var k2 = 1.0 / m - rb * rb / J;
+
+    var xvel = (vl + vr) / 2;
+    var w = (vr - vl) / (2.0 * rb);
+
+    return VecBuilder.fill(
+          xvel * c,
+          xvel * s,
+          -s * w,
+          c * w,
+          k1 * ((C1 * vl) + (C2 * Vl)) + k2 * ((C1 * vr) + (C2 * Vr)),
+          k2 * ((C1 * vl) + (C2 * Vl)) + k1 * ((C1 * vr) + (C2 * Vr))
+    );
+  }
+
+  @SuppressWarnings("ParameterName")
+  public static Matrix<N4, N1> getLocalMeasurementModel(Matrix<N6, N1> x, Matrix<N2, N1> u) {
+    return VecBuilder.fill(x.get(2, 0), x.get(3, 0), x.get(4, 0), x.get(5, 0));
+  }
+
+  @SuppressWarnings("ParameterName")
+  public static Matrix<N6, N1> getGlobalMeasurementModel(Matrix<N6, N1> x, Matrix<N2, N1> u) {
+    return x.copy();
+  }
+
+  @Test
+  @SuppressWarnings("LocalVariableName")
+  public void testInit() {
+    assertDoesNotThrow(() -> {
+      UnscentedKalmanFilter<N6, N2, N4> observer = new UnscentedKalmanFilter<>(
+            Nat.N6(), Nat.N4(),
+            UnscentedKalmanFilterTest::getDynamics,
+            UnscentedKalmanFilterTest::getLocalMeasurementModel,
+            VecBuilder.fill(0.5, 0.5, 0.7, 0.7, 1.0, 1.0),
+            VecBuilder.fill(0.001, 0.001, 0.5, 0.5),
+            0.00505);
+
+      var u = VecBuilder.fill(12.0, 12.0);
+      observer.predict(u, 0.00505);
+
+      var localY = getLocalMeasurementModel(observer.getXhat(), u);
+      observer.correct(u, localY);
+    });
+  }
+
+  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops",
+        "PMD.ExcessiveMethodLength"})
+  @Test
+  public void testConvergence() {
+    double dtSeconds = 0.00505;
+    double rbMeters = 0.8382 / 2.0; // Robot radius
+
+    List<Double> trajXs = new ArrayList<>();
+    List<Double> trajYs = new ArrayList<>();
+
+    List<Double> observerXs = new ArrayList<>();
+    List<Double> observerYs = new ArrayList<>();
+    List<Double> observerC = new ArrayList<>();
+    List<Double> observerS = new ArrayList<>();
+    List<Double> observervl = new ArrayList<>();
+    List<Double> observervr = new ArrayList<>();
+
+    List<Double> inputVl = new ArrayList<>();
+    List<Double> inputVr = new ArrayList<>();
+
+    List<Double> timeData = new ArrayList<>();
+    List<Matrix> rdots = new ArrayList<>();
+
+    UnscentedKalmanFilter<N6, N2, N4> observer = new UnscentedKalmanFilter<>(
+          Nat.N6(), Nat.N4(),
+          UnscentedKalmanFilterTest::getDynamics,
+          UnscentedKalmanFilterTest::getLocalMeasurementModel,
+          VecBuilder.fill(0.5, 0.5, 0.7, 0.7, 1.0, 1.0),
+          VecBuilder.fill(0.001, 0.001, 0.5, 0.5),
+          dtSeconds);
+
+    List<Pose2d> waypoints = Arrays.asList(new Pose2d(2.75, 22.521, new Rotation2d()),
+          new Pose2d(24.73, 19.68, Rotation2d.fromDegrees(5.846)));
+    var trajectory = TrajectoryGenerator.generateTrajectory(
+          waypoints,
+          new TrajectoryConfig(8.8, 0.1)
+    );
+
+    Matrix<N6, N1> nextR;
+    Matrix<N2, N1> u = MatrixUtils.zeros(Nat.N2(), Nat.N1());
+
+    var B = NumericalJacobian.numericalJacobianU(Nat.N6(), Nat.N2(),
+          UnscentedKalmanFilterTest::getDynamics, MatrixUtils.zeros(Nat.N6(), Nat.N1()), u);
+
+    observer.setXhat(VecBuilder.fill(2.75, 22.521, 1.0, 0.0, 0.0, 0.0)); // TODO not hard code this
+
+    var ref = trajectory.sample(0.0);
+
+    Matrix<N6, N1> r = VecBuilder.fill(
+          ref.poseMeters.getTranslation().getX(),
+          ref.poseMeters.getTranslation().getY(),
+          ref.poseMeters.getRotation().getCos(),
+          ref.poseMeters.getRotation().getSin(),
+          ref.velocityMetersPerSecond * (1 - (ref.curvatureRadPerMeter * rbMeters)),
+          ref.velocityMetersPerSecond * (1 + (ref.curvatureRadPerMeter * rbMeters))
+    );
+    nextR = r.copy();
+
+    var trueXhat = observer.getXhat();
+
+    double totalTime = trajectory.getTotalTimeSeconds();
+    for (int i = 0; i < (totalTime / dtSeconds); i++) {
+
+      ref = trajectory.sample(dtSeconds * i);
+      double vl = ref.velocityMetersPerSecond * (1 - (ref.curvatureRadPerMeter * rbMeters));
+      double vr = ref.velocityMetersPerSecond * (1 + (ref.curvatureRadPerMeter * rbMeters));
+
+      nextR.set(0, 0, ref.poseMeters.getTranslation().getX());
+      nextR.set(1, 0, ref.poseMeters.getTranslation().getY());
+      nextR.set(2, 0, ref.poseMeters.getRotation().getCos());
+      nextR.set(3, 0, ref.poseMeters.getRotation().getSin());
+      nextR.set(4, 0, vl);
+      nextR.set(5, 0, vr);
+
+      Matrix<N4, N1> localY =
+            getLocalMeasurementModel(trueXhat, MatrixUtils.zeros(Nat.N2(), Nat.N1()));
+      var noiseStdDev = VecBuilder.fill(0.001, 0.001, 0.5, 0.5);
+
+      observer.correct(u,
+            localY.plus(StateSpaceUtil.makeWhiteNoiseVector(
+                  noiseStdDev)));
+
+      var rdot = nextR.minus(r).div(dtSeconds);
+      u = new Matrix<>(B.getStorage()
+            .solve(rdot.minus(getDynamics(r, MatrixUtils.zeros(Nat.N2(), Nat.N1())))
+                  .getStorage()));
+
+      rdots.add(rdot);
+
+      trajXs.add(ref.poseMeters.getTranslation().getX());
+      trajYs.add(ref.poseMeters.getTranslation().getY());
+
+      observerXs.add(observer.getXhat().get(0, 0));
+      observerYs.add(observer.getXhat().get(1, 0));
+
+      observerC.add(observer.getXhat(2));
+      observerS.add(observer.getXhat(3));
+
+      observervl.add(observer.getXhat(4));
+      observervr.add(observer.getXhat(5));
+
+      inputVl.add(u.get(0, 0));
+      inputVr.add(u.get(1, 0));
+
+      timeData.add(i * dtSeconds);
+
+      r = nextR;
+      observer.predict(u, dtSeconds);
+      trueXhat = RungeKutta.rungeKutta(UnscentedKalmanFilterTest::getDynamics,
+            trueXhat, u, dtSeconds);
+    }
+
+    var localY = getLocalMeasurementModel(trueXhat, u);
+    observer.correct(u, localY);
+
+    var globalY = getGlobalMeasurementModel(trueXhat, u);
+    var R = StateSpaceUtil.makeCostMatrix(
+          VecBuilder.fill(0.01, 0.01, 0.0001, 0.0001, 0.5, 0.5));
+    observer.correct(Nat.N6(), u, globalY,
+          UnscentedKalmanFilterTest::getGlobalMeasurementModel, R);
+
+    final var finalPosition = trajectory.sample(trajectory.getTotalTimeSeconds());
+
+    //     var chartBuilder = new XYChartBuilder();
+    //     chartBuilder.title = "The Magic of Sensor Fusion, now with a "
+    //           + observer.getClass().getSimpleName();
+    //     var xyPosChart = chartBuilder.build();
+
+    //     xyPosChart.setXAxisTitle("X pos, meters");
+    //     xyPosChart.setYAxisTitle("Y pos, meters");
+    //     xyPosChart.addSeries("Trajectory", trajXs, trajYs);
+    //     xyPosChart.addSeries("xHat", observerXs, observerYs);
+
+    //     var stateChart = new XYChartBuilder()
+    //           .title("States (x-hat)").build();
+    //     stateChart.addSeries("Cos", timeData, observerC);
+    //     stateChart.addSeries("Sin", timeData, observerS);
+    //     stateChart.addSeries("vl, m/s", timeData, observervl);
+    //     stateChart.addSeries("vr, m/s", timeData, observervr);
+
+    //     var inputChart = new XYChartBuilder().title("Inputs").build();
+    //     inputChart.addSeries("Left voltage", timeData, inputVl);
+    //     inputChart.addSeries("Right voltage", timeData, inputVr);
+
+    //     var rdotChart = new XYChartBuilder().title("Rdot").build();
+    //     rdotChart.addSeries("xdot, or vx", timeData, rdots.stream().map(it -> it.get(0, 0))
+    //           .collect(Collectors.toList()));
+    //     rdotChart.addSeries("ydot, or vy", timeData, rdots.stream().map(it -> it.get(1, 0))
+    //           .collect(Collectors.toList()));
+    //     rdotChart.addSeries("cos dot", timeData, rdots.stream().map(it -> it.get(2, 0))
+    //           .collect(Collectors.toList()));
+    //     rdotChart.addSeries("sin dot", timeData, rdots.stream().map(it -> it.get(3, 0))
+    //           .collect(Collectors.toList()));
+    //     rdotChart.addSeries("vl dot, or al", timeData, rdots.stream().map(it -> it.get(4, 0))
+    //           .collect(Collectors.toList()));
+    //     rdotChart.addSeries("vr dot, or ar", timeData, rdots.stream().map(it -> it.get(5, 0))
+    //           .collect(Collectors.toList()));
+
+    //     List<XYChart> charts = new ArrayList<>();
+    //     charts.add(xyPosChart);
+    //     charts.add(stateChart);
+    //     charts.add(inputChart);
+    //     charts.add(rdotChart);
+    //     new SwingWrapper<>(charts).displayChartMatrix();
+    //     try {
+    //       Thread.sleep(1000000000);
+    //     } catch (InterruptedException ex) {
+    //       ex.printStackTrace();
+    //     }
+
+    assertEquals(finalPosition.poseMeters.getTranslation().getX(), observer.getXhat(0), 0.25);
+    assertEquals(finalPosition.poseMeters.getTranslation().getY(), observer.getXhat(1), 0.25);
+    assertEquals(finalPosition.poseMeters.getRotation().getRadians(), observer.getXhat(2), 1.0);
+    assertEquals(0.0, observer.getXhat(3), 1.0);
+    assertEquals(0.0, observer.getXhat(4), 1.0);
+  }
+
+  @Test
+  @SuppressWarnings({"LocalVariableName", "ParameterName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  public void testLinearUKF() {
+    var dt = 0.020;
+    var plant = LinearSystemId.identifyVelocitySystem(0.02, 0.006);
+    var observer = new UnscentedKalmanFilter<>(Nat.N1(), Nat.N1(),
+        (x, u) -> plant.getA().times(x).plus(plant.getB().times(u)),
+          plant::calculateY,
+          VecBuilder.fill(0.05),
+          VecBuilder.fill(1.0),
+          dt);
+
+    var time = new ArrayList<Double>();
+    var refData = new ArrayList<Double>();
+    var xhat = new ArrayList<Double>();
+    var udata = new ArrayList<Double>();
+    var xdotData = new ArrayList<Double>();
+
+    var discABPair = Discretization.discretizeAB(plant.getA(), plant.getB(), dt);
+    var discA = discABPair.getFirst();
+    var discB = discABPair.getSecond();
+
+    var ref = VecBuilder.fill(100);
+    Matrix<N1, N1> u = VecBuilder.fill(0);
+
+    Matrix<N1, N1> xdot;
+    for (int i = 0; i < (2.0 / dt); i++) {
+      observer.predict(u, dt);
+
+      u = new Matrix<>(discB.getStorage()
+            .solve((ref.minus(discA.times(ref))).getStorage()));
+
+      xdot = plant.getA().times(observer.getXhat()).plus(plant.getB().times(u));
+
+      time.add(i * dt);
+      refData.add(ref.get(0, 0));
+      xhat.add(observer.getXhat(0));
+      udata.add(u.get(0, 0));
+      xdotData.add(xdot.get(0, 0));
+    }
+
+    //    var chartBuilder = new XYChartBuilder();
+    //    chartBuilder.title = "The Magic of Sensor Fusion";
+    //    var chart = chartBuilder.build();
+
+    //    chart.addSeries("Ref", time, refData);
+    //    chart.addSeries("xHat", time, xhat);
+    //    chart.addSeries("input", time, udata);
+    ////    chart.addSeries("xdot", time, xdotData);
+
+    //    new SwingWrapper<>(chart).displayChart();
+    //    try {
+    //      Thread.sleep(1000000000);
+    //    } catch (InterruptedException e) {
+    //    }
+
+    assertEquals(ref.get(0, 0), observer.getXhat(0), 5);
+  }
+
+  @Test
+  public void testUnscentedTransform() {
+    // From FilterPy
+    var ret = UnscentedKalmanFilter.unscentedTransform(Nat.N4(), Nat.N4(),
+          new MatBuilder<>(Nat.N4(), Nat.N9()).fill(
+              -0.9, -0.822540333075852, -0.8922540333075852, -0.9,
+                  -0.9, -0.9774596669241481, -0.9077459666924148, -0.9, -0.9,
+              1.0, 1.0, 1.077459666924148, 1.0, 1.0, 1.0, 0.9225403330758519, 1.0, 1.0,
+              -0.9, -0.9, -0.9, -0.822540333075852, -0.8922540333075852, -0.9,
+                  -0.9, -0.9774596669241481, -0.9077459666924148,
+              1.0, 1.0, 1.0, 1.0, 1.077459666924148, 1.0, 1.0, 1.0, 0.9225403330758519
+          ),
+          new MatBuilder<>(Nat.N9(), Nat.N1()).fill(
+              -132.33333333,
+              16.66666667,
+              16.66666667,
+              16.66666667,
+              16.66666667,
+              16.66666667,
+              16.66666667,
+              16.66666667,
+              16.66666667
+          ),
+          new MatBuilder<>(Nat.N9(), Nat.N1()).fill(
+              -129.34333333,
+              16.66666667,
+              16.66666667,
+              16.66666667,
+              16.66666667,
+              16.66666667,
+              16.66666667,
+              16.66666667,
+              16.66666667
+          )
+    );
+
+    assertMatEqual(
+          new MatBuilder<>(Nat.N4(), Nat.N1()).fill(-0.9, 1, -0.9, 1),
+          ret.getFirst()
+    );
+
+    assertMatEqual(
+          new MatBuilder<>(Nat.N4(), Nat.N4()).fill(
+                2.02000002e-01, 2.00000500e-02, -2.69044710e-29,
+                -4.59511477e-29,
+                2.00000500e-02, 2.00001000e-01, -2.98781068e-29,
+                -5.12759588e-29,
+                -2.73372625e-29, -3.09882635e-29, 2.02000002e-01,
+                2.00000500e-02,
+                -4.67065917e-29, -5.10705197e-29, 2.00000500e-02,
+                2.00001000e-01
+          ),
+          ret.getSecond()
+    );
+  }
+
+  void assertMatEqual(Matrix<?, ?> first, Matrix<?, ?> second) {
+    EjmlUnitTests.assertEquals(first.getStorage().getDDRM(), second.getStorage().getDDRM(), 1e-5);
+  }
+
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ArmSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ArmSimTest.java
@@ -1,0 +1,39 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.simulation;
+
+import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.util.Units;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ArmSimTest {
+  SingleJointedArmSim m_sim = new SingleJointedArmSim(
+      DCMotor.getVex775Pro(2),
+      100,
+      10 / 2.2,
+      Units.inchesToMeters(19.0 / 2.0),
+      -Math.PI,
+      0.0, VecBuilder.fill(0.0)
+  );
+
+  @Test
+  public void testArmDisabled() {
+    m_sim.resetState(VecBuilder.fill(0.0, 0.0));
+
+    for (int i = 0; i < 12 / 0.02; i++) {
+      m_sim.setInput(0.0);
+      m_sim.update(0.020);
+    }
+
+    // the arm should swing down
+    assertEquals(-Math.PI / 2.0, m_sim.getArmAngleRads(), 0.1);
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ElevatorSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ElevatorSimTest.java
@@ -1,0 +1,82 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.simulation;
+
+import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.PWMVictorSPX;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.controller.PIDController;
+import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ElevatorSimTest {
+  @Test
+  @SuppressWarnings("LocalVariableName")
+  public void testStateSpaceSimWithElevator() {
+
+    var controller = new PIDController(10, 0, 0);
+
+    var sim = new ElevatorSim(DCMotor.getVex775Pro(4), 8.0, 0.75 * 25.4 / 1000.0, 14.67,
+        0.0, 3.0, VecBuilder.fill(0.01));
+
+    var motor = new PWMVictorSPX(0);
+    var encoder = new Encoder(0, 1);
+    var encoderSim = new EncoderSim(encoder);
+
+    for (int i = 0; i < 100; i++) {
+      controller.setSetpoint(2.0);
+
+      double nextVoltage = controller.calculate(encoderSim.getDistance());
+
+      double currentBatteryVoltage = RobotController.getBatteryVoltage();
+      motor.set(nextVoltage / currentBatteryVoltage);
+
+      // ------ SimulationPeriodic() happens after user code -------
+
+      var u = VecBuilder.fill(motor.get() * currentBatteryVoltage);
+      sim.setInput(u);
+      sim.update(0.020);
+      var y = sim.getOutput();
+      encoderSim.setDistance(y.get(0, 0));
+    }
+
+    assertEquals(controller.getSetpoint(), sim.getElevatorPositionMeters(), 0.2);
+  }
+
+  @Test
+  public void testMinMax() {
+    var plant = LinearSystemId.createElevatorSystem(
+        DCMotor.getVex775Pro(4),
+        8.0,
+        0.75 * 25.4 / 1000.0,
+        14.67);
+
+    var sim = new ElevatorSim(plant, VecBuilder.fill(0.01),
+        DCMotor.getVex775Pro(4),
+        14.67, 0.75 * 25.4 / 1000.0, 0.0, 1.0);
+
+    for (int i = 0; i < 100; i++) {
+      sim.setInput(VecBuilder.fill(0));
+      sim.update(0.020);
+      var height = sim.getElevatorPositionMeters();
+      assertTrue(height >= -0.05);
+    }
+
+    for (int i = 0; i < 100; i++) {
+      sim.setInput(VecBuilder.fill(12.0));
+      sim.update(0.020);
+      var height = sim.getElevatorPositionMeters();
+      assertTrue(height <= 1.05);
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/SimSwerveDriveTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/SimSwerveDriveTest.java
@@ -1,0 +1,61 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.simulation;
+
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpilibj.util.Units;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SimSwerveDriveTest {
+  private SimSwerveDrive m_sim = new SimSwerveDrive(50,
+      new SimSwerveDrive.SimSwerveModule(DCMotor.getNEO(1), 8.0,
+          Units.inchesToMeters(2.0), new Translation2d(1, 1),
+          LinearSystemId.createSingleJointedArmSystem(DCMotor.getNEO(1), 0.01, 10.0)),
+      new SimSwerveDrive.SimSwerveModule(DCMotor.getNEO(1), 8.0,
+          Units.inchesToMeters(2.0), new Translation2d(1, -1),
+          LinearSystemId.createSingleJointedArmSystem(DCMotor.getNEO(1), 0.01, 10.0)),
+      new SimSwerveDrive.SimSwerveModule(DCMotor.getNEO(1), 8.0,
+          Units.inchesToMeters(2.0), new Translation2d(-1, 1),
+          LinearSystemId.createSingleJointedArmSystem(DCMotor.getNEO(1), 0.01, 10.0)),
+      new SimSwerveDrive.SimSwerveModule(DCMotor.getNEO(1), 8.0,
+          Units.inchesToMeters(2.0), new Translation2d(-1, -1),
+          LinearSystemId.createSingleJointedArmSystem(DCMotor.getNEO(1), 0.01, 10.0)));
+
+  @Test
+  public void testDrivingForward() {
+    var desiredSpeeds =
+        m_sim.getKinematics().toSwerveModuleStates(new ChassisSpeeds(1, 2, 0.5));
+
+    // seems like ~3.25 volts per meter per second
+    for (int i = 0; i < 200; i++) {
+      m_sim.setModuleDriveVoltages(7.5, 7.5, 7.5, 7.5);
+
+      // simple P loop on heading error
+      double[] moduleVoltages = new double[m_sim.getModules().length];
+      for (int m = 0; m < m_sim.getModules().length; m++) {
+        var module = m_sim.getModules()[m];
+        var ref = desiredSpeeds[m].angle;
+        var angle = module.getAzimuthAngle();
+        var delta = ref.minus(angle);
+        moduleVoltages[m] = delta.getRadians() * 10.0;
+      }
+
+      m_sim.setModuleAzimuthVoltages(moduleVoltages);
+
+      m_sim.update(0.020);
+    }
+    assertEquals(1, m_sim.getEstimatedChassisSpeed().vxMetersPerSecond, 0.1);
+    assertEquals(2, m_sim.getEstimatedChassisSpeed().vyMetersPerSecond, 0.1);
+    assertEquals(0.5, m_sim.getEstimatedChassisSpeed().omegaRadiansPerSecond, 0.1);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armsimulation/Main.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armsimulation/Main.java
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.armsimulation;
+
+import edu.wpi.first.wpilibj.RobotBase;
+
+/**
+ * Do NOT add any static variables to this class, or any initialization at all.
+ * Unless you know what you are doing, do not modify this file except to
+ * change the parameter class to the startRobot call.
+ */
+public final class Main {
+  private Main() {
+  }
+
+  /**
+   * Main initialization function. Do not perform any initialization here.
+   *
+   * <p>If you change your main robot class, change the parameter type.
+   */
+  public static void main(String... args) {
+    RobotBase.startRobot(Robot::new);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armsimulation/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armsimulation/Robot.java
@@ -1,0 +1,95 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.armsimulation;
+
+import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.PWMVictorSPX;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj.controller.PIDController;
+import edu.wpi.first.wpilibj.simulation.EncoderSim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import edu.wpi.first.wpilibj.simulation.BatterySim;
+import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
+import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.util.Units;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+/**
+ * This is a sample program to demonstrate the use of elevator simulation with existing code.
+ */
+public class Robot extends TimedRobot {
+  private static final int kMotorPort = 0;
+  private static final int kEncoderAChannel = 0;
+  private static final int kEncoderBChannel = 1;
+  private static final int kJoystickPort = 0;
+
+  private static final double kArmKp = 5.0;
+
+  // distance per pulse = (angle per revolution) / (pulses per revolution)
+  //  = (2 * PI rads) / (4096 pulses)
+  private static final double kElevatorEncoderDistPerPulse = 2.0 * Math.PI / 4096;
+
+  private final DCMotor m_armGearbox = DCMotor.getVex775Pro(2);
+
+  // Standard classes for controlling our elevator
+  private final PIDController m_controller = new PIDController(kArmKp, 0, 0);
+  private final Encoder m_encoder = new Encoder(kEncoderAChannel, kEncoderBChannel);
+  private final PWMVictorSPX m_motor = new PWMVictorSPX(kMotorPort);
+  private final Joystick m_joystick = new Joystick(kJoystickPort);
+
+  // Simulation classes help us simulate what's going on, including gravity.
+  private final SingleJointedArmSim m_elevatorSim = new SingleJointedArmSim(m_armGearbox,
+      100.0,
+      5,
+      Units.degreesToRadians(-180),
+      Units.degreesToRadians(0),
+      Units.inchesToMeters(30),
+      VecBuilder.fill(Units.degreesToRadians(0.5))
+      );
+  private final EncoderSim m_encoderSim = new EncoderSim(m_encoder);
+
+  @Override
+  public void robotInit() {
+    m_encoder.setDistancePerPulse(kElevatorEncoderDistPerPulse);
+  }
+
+  @Override
+  public void simulationPeriodic() {
+    // In this method, we update our simulation of what our elevator is doing
+    // First, we set our "inputs" (voltages)
+    m_elevatorSim.setInput(m_motor.get() * RobotController.getBatteryVoltage());
+
+    // Next, we update it. The standard loop time is 20ms.
+    m_elevatorSim.update(0.020);
+
+    // Finally, we set our simulated encoder's readings and simulated battery voltage
+    m_encoderSim.setDistance(m_elevatorSim.getArmAngleRads());
+    // SimBattery estimates loaded battery voltages
+    RoboRioSim.setVInVoltage(BatterySim.calculateLoadedBatteryVoltage(m_elevatorSim.getCurrentDrawAmps()));
+  }
+
+  @Override
+  public void teleopPeriodic() {
+    if (m_joystick.getTrigger()) {
+      // Here, we run PID control like normal, with a constant setpoint of 30in.
+      var pidOutput = m_controller.calculate(m_encoder.getDistance(), Units.degreesToRadians(0));
+      m_motor.setVoltage(pidOutput);
+    } else {
+      // Otherwise, we disable the motor.
+      m_motor.set(0.0);
+    }
+  }
+
+  @Override
+  public void disabledInit() {
+    // This just makes sure that our simulation code knows that the motor's off.
+    m_motor.set(0.0);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/elevatorsimulation/Main.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/elevatorsimulation/Main.java
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.elevatorsimulation;
+
+import edu.wpi.first.wpilibj.RobotBase;
+
+/**
+ * Do NOT add any static variables to this class, or any initialization at all.
+ * Unless you know what you are doing, do not modify this file except to
+ * change the parameter class to the startRobot call.
+ */
+public final class Main {
+  private Main() {
+  }
+
+  /**
+   * Main initialization function. Do not perform any initialization here.
+   *
+   * <p>If you change your main robot class, change the parameter type.
+   */
+  public static void main(String... args) {
+    RobotBase.startRobot(Robot::new);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/elevatorsimulation/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/elevatorsimulation/Robot.java
@@ -1,0 +1,100 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.elevatorsimulation;
+
+import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.PWMVictorSPX;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj.controller.PIDController;
+import edu.wpi.first.wpilibj.simulation.EncoderSim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import edu.wpi.first.wpilibj.simulation.BatterySim;
+import edu.wpi.first.wpilibj.simulation.ElevatorSim;
+import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.util.Units;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+/**
+ * This is a sample program to demonstrate the use of elevator simulation with existing code.
+ */
+public class Robot extends TimedRobot {
+  private static final int kMotorPort = 0;
+  private static final int kEncoderAChannel = 0;
+  private static final int kEncoderBChannel = 1;
+  private static final int kJoystickPort = 0;
+
+  private static final double kElevatorKp = 5.0;
+  private static final double kElevatorGearing = 10.0;
+  private static final double kElevatorDrumRadius = Units.inchesToMeters(2.0);
+  private static final double kCarriageMass = 4.0; // kg
+
+  private static final double kMinElevatorHeight = 0.0;
+  private static final double kMaxElevatorHeight = Units.inchesToMeters(50);
+
+  // distance per pulse = (distance per revolution) / (pulses per revolution)
+  //  = (Pi * D) / ppr
+  private static final double kElevatorEncoderDistPerPulse = 2.0 * Math.PI * kElevatorDrumRadius / 4096;
+
+  private final DCMotor m_elevatorGearbox = DCMotor.getVex775Pro(4);
+
+  // Standard classes for controlling our elevator
+  private final PIDController m_controller = new PIDController(kElevatorKp, 0, 0);
+  private final Encoder m_encoder = new Encoder(kEncoderAChannel, kEncoderBChannel);
+  private final PWMVictorSPX m_motor = new PWMVictorSPX(kMotorPort);
+  private final Joystick m_joystick = new Joystick(kJoystickPort);
+
+  // Simulation classes help us simulate what's going on, including gravity.
+  private final ElevatorSim m_elevatorSim = new ElevatorSim(m_elevatorGearbox,
+      kCarriageMass,
+      kElevatorDrumRadius,
+      kElevatorGearing,
+      kMinElevatorHeight,
+      kMaxElevatorHeight,
+      VecBuilder.fill(0.01));
+  private final EncoderSim m_encoderSim = new EncoderSim(m_encoder);
+
+  @Override
+  public void robotInit() {
+    m_encoder.setDistancePerPulse(kElevatorEncoderDistPerPulse);
+  }
+
+  @Override
+  public void simulationPeriodic() {
+    // In this method, we update our simulation of what our elevator is doing
+    // First, we set our "inputs" (voltages)
+    m_elevatorSim.setInput(m_motor.get() * RobotController.getBatteryVoltage());
+
+    // Next, we update it. The standard loop time is 20ms.
+    m_elevatorSim.update(0.020);
+
+    // Finally, we set our simulated encoder's readings and simulated battery voltage
+    m_encoderSim.setDistance(m_elevatorSim.getElevatorPositionMeters());
+    // SimBattery estimates loaded battery voltages
+    RoboRioSim.setVInVoltage(BatterySim.calculateLoadedBatteryVoltage(m_elevatorSim.getCurrentDrawAmps()));
+  }
+
+  @Override
+  public void teleopPeriodic() {
+    if (m_joystick.getTrigger()) {
+      // Here, we run PID control like normal, with a constant setpoint of 30in.
+      var pidOutput = m_controller.calculate(m_encoder.getDistance(), Units.inchesToMeters(30));
+      m_motor.setVoltage(pidOutput);
+    } else {
+      // Otherwise, we disable the motor.
+      m_motor.set(0.0);
+    }
+  }
+
+  @Override
+  public void disabledInit() {
+    // This just makes sure that our simulation code knows that the motor's off.
+    m_motor.set(0.0);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/examples.json
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/examples.json
@@ -631,5 +631,40 @@
     "gradlebase": "java",
     "mainclass": "Main",
     "commandversion": 2
+  },
+  {
+    "name": "LTVUnicycleCommand",
+    "description": "An example command-based robot demonstrating the use of a LTV Unicycle Command to follow a pregenerated trajectory.",
+    "tags": [
+      "LTVUnicycleCommand",
+      "Drivetrain",
+      "State Space",
+      "Model",
+      "Digital",
+      "Sensors",
+      "Actuators",
+      "Trajectory"
+    ],
+    "foldername": "ltvunicyclecommand",
+    "gradlebase": "java",
+    "mainclass": "Main",
+    "commandversion": 2
+  },
+  {
+    "name": "StateSpaceSimulation",
+    "description": "An example of drivetrain simulation in combination with a RAMSETE path following controller.",
+    "tags": [
+      "Drivetrain",
+      "State space",
+      "Digital",
+      "Sensors",
+      "Actuators",
+      "Joystick",
+      "Simulation"
+    ],
+    "foldername": "statespacedifferentialdrivesimulation",
+    "gradlebase": "java",
+    "mainclass": "Main",
+    "commandversion": 2
   }
 ]

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ltvunicyclecommand/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ltvunicyclecommand/Constants.java
@@ -1,0 +1,69 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.ltvunicyclecommand;
+
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+
+/**
+ * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
+ * constants.  This class should not be used for any other purpose.  All constants should be
+ * declared globally (i.e. public static).  Do not put anything functional in this class.
+ *
+ * <p>It is advised to statically import this class (or one of its inner classes) wherever the
+ * constants are needed, to reduce verbosity.
+ */
+public final class Constants {
+  public static final class DriveConstants {
+    public static final int kLeftMotor1Port = 0;
+    public static final int kLeftMotor2Port = 1;
+    public static final int kRightMotor1Port = 2;
+    public static final int kRightMotor2Port = 3;
+
+    public static final int[] kLeftEncoderPorts = new int[]{0, 1};
+    public static final int[] kRightEncoderPorts = new int[]{2, 3};
+    public static final boolean kLeftEncoderReversed = false;
+    public static final boolean kRightEncoderReversed = true;
+
+    public static final double kTrackwidthMeters = 0.69;
+    public static final DifferentialDriveKinematics kDriveKinematics =
+        new DifferentialDriveKinematics(kTrackwidthMeters);
+
+    public static final int kEncoderCPR = 1024;
+    public static final double kWheelDiameterMeters = 0.15;
+    public static final double kEncoderDistancePerPulse =
+        // Assumes the encoders are directly mounted on the wheel shafts
+        (kWheelDiameterMeters * Math.PI) / (double) kEncoderCPR;
+
+    public static final boolean kGyroReversed = true;
+
+    // These are example values only - DO NOT USE THESE FOR YOUR OWN ROBOT!
+    // These characterization values MUST be determined either experimentally or theoretically
+    // for *your* robot's drive.
+    // The Robot Characterization Toolsuite provides a convenient tool for obtaining these
+    // values for your robot.
+    public static final double ksVolts = 0.22;
+    public static final double kvVoltSecondsPerMeter = 1.98;
+    public static final double kaVoltSecondsSquaredPerMeter = 0.2;
+
+    // Example value only - as above, this must be tuned for your drive!
+    public static final double kPDriveVel = 8.5;
+  }
+
+  public static final class OIConstants {
+    public static final int kDriverControllerPort = 1;
+  }
+
+  public static final class AutoConstants {
+    public static final double kMaxSpeedMetersPerSecond = 3;
+    public static final double kMaxAccelerationMetersPerSecondSquared = 3;
+
+    // Reasonable baseline values for a RAMSETE follower in units of meters and seconds
+    public static final double kRamseteB = 2;
+    public static final double kRamseteZeta = 0.7;
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ltvunicyclecommand/Main.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ltvunicyclecommand/Main.java
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.ltvunicyclecommand;
+
+import edu.wpi.first.wpilibj.RobotBase;
+
+/**
+ * Do NOT add any static variables to this class, or any initialization at all. Unless you know what
+ * you are doing, do not modify this file except to change the parameter class to the startRobot
+ * call.
+ */
+public final class Main {
+  private Main() {
+  }
+
+  /**
+   * Main initialization function. Do not perform any initialization here.
+   *
+   * <p>If you change your main robot class, change the parameter type.
+   */
+  public static void main(String... args) {
+    RobotBase.startRobot(Robot::new);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ltvunicyclecommand/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ltvunicyclecommand/Robot.java
@@ -1,0 +1,121 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.ltvunicyclecommand;
+
+import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+
+/**
+ * The VM is configured to automatically run this class, and to call the functions corresponding to
+ * each mode, as described in the TimedRobot documentation. If you change the name of this class or
+ * the package after creating this project, you must also update the build.gradle file in the
+ * project.
+ */
+public class Robot extends TimedRobot {
+  private Command m_autonomousCommand;
+
+  private RobotContainer m_robotContainer;
+
+  /**
+   * This function is run when the robot is first started up and should be used for any
+   * initialization code.
+   */
+  @Override
+  public void robotInit() {
+    // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
+    // autonomous chooser on the dashboard.
+    m_robotContainer = new RobotContainer();
+  }
+
+  /**
+   * This function is called every robot packet, no matter the mode. Use this for items like
+   * diagnostics that you want ran during disabled, autonomous, teleoperated and test.
+   *
+   * <p>This runs after the mode specific periodic functions, but before
+   * LiveWindow and SmartDashboard integrated updating.
+   */
+  @Override
+  public void robotPeriodic() {
+    // Runs the Scheduler.  This is responsible for polling buttons, adding newly-scheduled
+    // commands, running already-scheduled commands, removing finished or interrupted commands,
+    // and running subsystem periodic() methods.  This must be called from the robot's periodic
+    // block in order for anything in the Command-based framework to work.
+    CommandScheduler.getInstance().run();
+  }
+
+  /**
+   * This function is called once each time the robot enters Disabled mode.
+   */
+  @Override
+  public void disabledInit() {
+  }
+
+  @Override
+  public void disabledPeriodic() {
+  }
+
+  /**
+   * This autonomous runs the autonomous command selected by your {@link RobotContainer} class.
+   */
+  @Override
+  public void autonomousInit() {
+    m_autonomousCommand = m_robotContainer.getAutonomousCommand();
+
+    /*
+     * String autoSelected = SmartDashboard.getString("Auto Selector",
+     * "Default"); switch(autoSelected) { case "My Auto": autonomousCommand
+     * = new MyAutoCommand(); break; case "Default Auto": default:
+     * autonomousCommand = new ExampleCommand(); break; }
+     */
+
+    // schedule the autonomous command (example)
+    if (m_autonomousCommand != null) {
+      m_autonomousCommand.schedule();
+    }
+  }
+
+  /**
+   * This function is called periodically during autonomous.
+   */
+  @Override
+  public void autonomousPeriodic() {
+  }
+
+  @Override
+  public void teleopInit() {
+    // This makes sure that the autonomous stops running when
+    // teleop starts running. If you want the autonomous to
+    // continue until interrupted by another command, remove
+    // this line or comment it out.
+    if (m_autonomousCommand != null) {
+      m_autonomousCommand.cancel();
+    }
+  }
+
+  /**
+   * This function is called periodically during operator control.
+   */
+  @Override
+  public void teleopPeriodic() {
+
+  }
+
+  @Override
+  public void testInit() {
+    // Cancels all running commands at the start of test mode.
+    CommandScheduler.getInstance().cancelAll();
+  }
+
+  /**
+   * This function is called periodically during test mode.
+   */
+  @Override
+  public void testPeriodic() {
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ltvunicyclecommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ltvunicyclecommand/RobotContainer.java
@@ -1,0 +1,144 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.ltvunicyclecommand;
+
+import java.util.List;
+
+import edu.wpi.first.wpilibj.GenericHID;
+import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.controller.LTVUnicycleController;
+import edu.wpi.first.wpilibj.controller.PIDController;
+import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.trajectory.Trajectory;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveVoltageConstraint;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.LTVUnicycleCommand;
+import edu.wpi.first.wpilibj2.command.RunCommand;
+import edu.wpi.first.wpilibj2.command.button.JoystickButton;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+import edu.wpi.first.wpilibj.examples.ramsetecommand.Constants.AutoConstants;
+import edu.wpi.first.wpilibj.examples.ramsetecommand.Constants.DriveConstants;
+import edu.wpi.first.wpilibj.examples.ramsetecommand.Constants.OIConstants;
+import edu.wpi.first.wpilibj.examples.ramsetecommand.subsystems.DriveSubsystem;
+
+import static edu.wpi.first.wpilibj.XboxController.Button;
+
+/**
+ * This class is where the bulk of the robot should be declared.  Since Command-based is a
+ * "declarative" paradigm, very little robot logic should actually be handled in the {@link Robot}
+ * periodic methods (other than the scheduler calls).  Instead, the structure of the robot
+ * (including subsystems, commands, and button mappings) should be declared here.
+ */
+public class RobotContainer {
+  // The robot's subsystems
+  private final DriveSubsystem m_robotDrive = new DriveSubsystem();
+
+  // The driver's controller
+  XboxController m_driverController = new XboxController(OIConstants.kDriverControllerPort);
+
+  /**
+   * The container for the robot.  Contains subsystems, OI devices, and commands.
+   */
+  public RobotContainer() {
+    // Configure the button bindings
+    configureButtonBindings();
+
+    // Configure default commands
+    // Set the default drive command to split-stick arcade drive
+    m_robotDrive.setDefaultCommand(
+        // A split-stick arcade command, with forward/backward controlled by the left
+        // hand, and turning controlled by the right.
+        new RunCommand(() -> m_robotDrive
+            .arcadeDrive(m_driverController.getY(GenericHID.Hand.kLeft),
+                         m_driverController.getX(GenericHID.Hand.kRight)), m_robotDrive));
+
+  }
+
+  /**
+   * Use this method to define your button->command mappings.  Buttons can be created by
+   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then calling passing it to a
+   * {@link JoystickButton}.
+   */
+  private void configureButtonBindings() {
+    // Drive at half speed when the right bumper is held
+    new JoystickButton(m_driverController, Button.kBumperRight.value)
+        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
+        .whenReleased(() -> m_robotDrive.setMaxOutput(1));
+
+  }
+
+
+  /**
+   * Use this to pass the autonomous command to the main {@link Robot} class.
+   *
+   * @return the command to run in autonomous
+   */
+  public Command getAutonomousCommand() {
+
+    // Create a voltage constraint to ensure we don't accelerate too fast
+    var autoVoltageConstraint =
+        new DifferentialDriveVoltageConstraint(
+            new SimpleMotorFeedforward(DriveConstants.ksVolts,
+                                       DriveConstants.kvVoltSecondsPerMeter,
+                                       DriveConstants.kaVoltSecondsSquaredPerMeter),
+            DriveConstants.kDriveKinematics,
+            10);
+
+    // Create config for trajectory
+    TrajectoryConfig config =
+        new TrajectoryConfig(AutoConstants.kMaxSpeedMetersPerSecond,
+                             AutoConstants.kMaxAccelerationMetersPerSecondSquared)
+            // Add kinematics to ensure max speed is actually obeyed
+            .setKinematics(DriveConstants.kDriveKinematics)
+            // Apply the voltage constraint
+            .addConstraint(autoVoltageConstraint);
+
+    // An example trajectory to follow.  All units in meters.
+    Trajectory exampleTrajectory = TrajectoryGenerator.generateTrajectory(
+        // Start at the origin facing the +X direction
+        new Pose2d(0, 0, new Rotation2d(0)),
+        // Pass through these two interior waypoints, making an 's' curve path
+        List.of(
+            new Translation2d(1, 1),
+            new Translation2d(2, -1)
+        ),
+        // End 3 meters straight ahead of where we started, facing forward
+        new Pose2d(3, 0, new Rotation2d(0)),
+        // Pass config
+        config
+    );
+
+    // Our LTV Unicycle Controller follows our path. It takes
+
+    LTVUnicycleCommand ltvUnicycleCommand = new LTVUnicycleCommand(
+        exampleTrajectory,
+        m_robotDrive::getPose,
+        new LTVUnicycleController(VecBuilder.fill(0.1, 0.1, 10), VecBuilder.fill(3, 3), 0.020),
+        new SimpleMotorFeedforward(DriveConstants.ksVolts,
+                                   DriveConstants.kvVoltSecondsPerMeter,
+                                   DriveConstants.kaVoltSecondsSquaredPerMeter),
+        DriveConstants.kDriveKinematics,
+        m_robotDrive::getWheelSpeeds,
+        new PIDController(DriveConstants.kPDriveVel, 0, 0),
+        new PIDController(DriveConstants.kPDriveVel, 0, 0),
+        // RamseteCommand passes volts to the callback
+        m_robotDrive::tankDriveVolts,
+        m_robotDrive
+    );
+
+    // Run path following command, then stop at the end.
+    return ltvUnicycleCommand.andThen(() -> m_robotDrive.tankDriveVolts(0, 0));
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ltvunicyclecommand/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ltvunicyclecommand/subsystems/DriveSubsystem.java
@@ -1,0 +1,191 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.ltvunicyclecommand.subsystems;
+
+import edu.wpi.first.wpilibj.ADXRS450_Gyro;
+import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.PWMVictorSPX;
+import edu.wpi.first.wpilibj.SpeedControllerGroup;
+import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.interfaces.Gyro;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveOdometry;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+import static edu.wpi.first.wpilibj.examples.ltvunicyclecommand.Constants.DriveConstants;
+
+public class DriveSubsystem extends SubsystemBase {
+  // The motors on the left side of the drive.
+  private final SpeedControllerGroup m_leftMotors =
+      new SpeedControllerGroup(new PWMVictorSPX(DriveConstants.kLeftMotor1Port),
+                               new PWMVictorSPX(DriveConstants.kLeftMotor2Port));
+
+  // The motors on the right side of the drive.
+  private final SpeedControllerGroup m_rightMotors =
+      new SpeedControllerGroup(new PWMVictorSPX(DriveConstants.kRightMotor1Port),
+                               new PWMVictorSPX(DriveConstants.kRightMotor2Port));
+
+  // The robot's drive
+  private final DifferentialDrive m_drive = new DifferentialDrive(m_leftMotors, m_rightMotors);
+
+  // The left-side drive encoder
+  private final Encoder m_leftEncoder =
+      new Encoder(DriveConstants.kLeftEncoderPorts[0], DriveConstants.kLeftEncoderPorts[1],
+                  DriveConstants.kLeftEncoderReversed);
+
+  // The right-side drive encoder
+  private final Encoder m_rightEncoder =
+      new Encoder(DriveConstants.kRightEncoderPorts[0], DriveConstants.kRightEncoderPorts[1],
+                  DriveConstants.kRightEncoderReversed);
+
+  // The gyro sensor
+  private final Gyro m_gyro = new ADXRS450_Gyro();
+
+  // Odometry class for tracking robot pose
+  private final DifferentialDriveOdometry m_odometry;
+
+  /**
+   * Creates a new DriveSubsystem.
+   */
+  public DriveSubsystem() {
+    // Sets the distance per pulse for the encoders
+    m_leftEncoder.setDistancePerPulse(DriveConstants.kEncoderDistancePerPulse);
+    m_rightEncoder.setDistancePerPulse(DriveConstants.kEncoderDistancePerPulse);
+
+    resetEncoders();
+    m_odometry = new DifferentialDriveOdometry(Rotation2d.fromDegrees(getHeading()));
+  }
+
+  @Override
+  public void periodic() {
+    // Update the odometry in the periodic block
+    m_odometry.update(Rotation2d.fromDegrees(getHeading()), m_leftEncoder.getDistance(),
+                      m_rightEncoder.getDistance());
+  }
+
+  /**
+   * Returns the currently-estimated pose of the robot.
+   *
+   * @return The pose.
+   */
+  public Pose2d getPose() {
+    return m_odometry.getPoseMeters();
+  }
+
+  /**
+   * Returns the current wheel speeds of the robot.
+   *
+   * @return The current wheel speeds.
+   */
+  public DifferentialDriveWheelSpeeds getWheelSpeeds() {
+    return new DifferentialDriveWheelSpeeds(m_leftEncoder.getRate(), m_rightEncoder.getRate());
+  }
+
+  /**
+   * Resets the odometry to the specified pose.
+   *
+   * @param pose The pose to which to set the odometry.
+   */
+  public void resetOdometry(Pose2d pose) {
+    resetEncoders();
+    m_odometry.resetPosition(pose, Rotation2d.fromDegrees(getHeading()));
+  }
+
+  /**
+   * Drives the robot using arcade controls.
+   *
+   * @param fwd the commanded forward movement
+   * @param rot the commanded rotation
+   */
+  public void arcadeDrive(double fwd, double rot) {
+    m_drive.arcadeDrive(fwd, rot);
+  }
+
+  /**
+   * Controls the left and right sides of the drive directly with voltages.
+   *
+   * @param leftVolts  the commanded left output
+   * @param rightVolts the commanded right output
+   */
+  public void tankDriveVolts(double leftVolts, double rightVolts) {
+    m_leftMotors.setVoltage(leftVolts);
+    m_rightMotors.setVoltage(-rightVolts);
+    m_drive.feed();
+  }
+
+  /**
+   * Resets the drive encoders to currently read a position of 0.
+   */
+  public void resetEncoders() {
+    m_leftEncoder.reset();
+    m_rightEncoder.reset();
+  }
+
+  /**
+   * Gets the average distance of the two encoders.
+   *
+   * @return the average of the two encoder readings
+   */
+  public double getAverageEncoderDistance() {
+    return (m_leftEncoder.getDistance() + m_rightEncoder.getDistance()) / 2.0;
+  }
+
+  /**
+   * Gets the left drive encoder.
+   *
+   * @return the left drive encoder
+   */
+  public Encoder getLeftEncoder() {
+    return m_leftEncoder;
+  }
+
+  /**
+   * Gets the right drive encoder.
+   *
+   * @return the right drive encoder
+   */
+  public Encoder getRightEncoder() {
+    return m_rightEncoder;
+  }
+
+  /**
+   * Sets the max output of the drive.  Useful for scaling the drive to drive more slowly.
+   *
+   * @param maxOutput the maximum output to which the drive will be constrained
+   */
+  public void setMaxOutput(double maxOutput) {
+    m_drive.setMaxOutput(maxOutput);
+  }
+
+  /**
+   * Zeroes the heading of the robot.
+   */
+  public void zeroHeading() {
+    m_gyro.reset();
+  }
+
+  /**
+   * Returns the heading of the robot.
+   *
+   * @return the robot's heading in degrees, from -180 to 180
+   */
+  public double getHeading() {
+    return Math.IEEEremainder(m_gyro.getAngle(), 360) * (DriveConstants.kGyroReversed ? -1.0 : 1.0);
+  }
+
+  /**
+   * Returns the turn rate of the robot.
+   *
+   * @return The turn rate of the robot, in degrees per second
+   */
+  public double getTurnRate() {
+    return m_gyro.getRate() * (DriveConstants.kGyroReversed ? -1.0 : 1.0);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/Constants.java
@@ -1,0 +1,90 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.statespacedifferentialdrivesimulation;
+
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+
+/**
+ * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
+ * constants.  This class should not be used for any other purpose.  All constants should be
+ * declared globally (i.e. public static).  Do not put anything functional in this class.
+ *
+ * <p>It is advised to statically import this class (or one of its inner classes) wherever the
+ * constants are needed, to reduce verbosity.
+ */
+public final class Constants {
+  public static final class DriveConstants {
+    public static final int kLeftMotor1Port = 0;
+    public static final int kLeftMotor2Port = 1;
+    public static final int kRightMotor1Port = 2;
+    public static final int kRightMotor2Port = 3;
+
+    public static final int[] kLeftEncoderPorts = new int[]{0, 1};
+    public static final int[] kRightEncoderPorts = new int[]{2, 3};
+    public static final boolean kLeftEncoderReversed = false;
+    public static final boolean kRightEncoderReversed = true;
+
+    public static final double kTrackwidthMeters = 0.69;
+    public static final DifferentialDriveKinematics kDriveKinematics =
+          new DifferentialDriveKinematics(kTrackwidthMeters);
+
+    public static final int kEncoderCPR = 1024;
+    public static final double kWheelDiameterMeters = 0.15;
+    public static final double kEncoderDistancePerPulse =
+          // Assumes the encoders are directly mounted on the wheel shafts
+          (kWheelDiameterMeters * Math.PI) / (double) kEncoderCPR;
+
+    public static final boolean kGyroReversed = true;
+
+    // These are example values only - DO NOT USE THESE FOR YOUR OWN ROBOT!
+    // These characterization values MUST be determined either experimentally or theoretically
+    // for *your* robot's drive.
+    // The Robot Characterization Toolsuite provides a convenient tool for obtaining these
+    // values for your robot.
+    public static final double ksVolts = 0.22;
+    public static final double kvVoltSecondsPerMeter = 1.98;
+    public static final double kaVoltSecondsSquaredPerMeter = 0.2;
+
+    // These are example values only - DO NOT USE THESE FOR YOUR OWN ROBOT!
+    // These characterization values MUST be determined either experimentally or theoretically
+    // for *your* robot's drive.
+    // These two values are "angular" kV and kA
+    public static final double kvVoltSecondsPerRadian = 1.5;
+    public static final double kaVoltSecondsSquaredPerRadian = 0.3;
+
+    public static final LinearSystem<N2, N2, N2> kDrivetrainPlant =
+          LinearSystemId.identifyDrivetrainSystem(kvVoltSecondsPerMeter, kaVoltSecondsSquaredPerMeter,
+                kvVoltSecondsPerRadian, kaVoltSecondsSquaredPerRadian);
+
+    // Example values only -- use what's on your physical robot!
+    public static final DCMotor kLeftGearbox = DCMotor.getCIM(2);
+    public static final DCMotor kRightGearbox = DCMotor.getCIM(2);
+    public static final double kLeftGearing = 8;
+    public static final double kRightGearing = 8;
+
+    // Example value only - as above, this must be tuned for your drive!
+    public static final double kPDriveVel = 0.1;
+  }
+
+  public static final class OIConstants {
+    public static final int kDriverControllerPort = 0;
+  }
+
+  public static final class AutoConstants {
+    public static final double kMaxSpeedMetersPerSecond = 3;
+    public static final double kMaxAccelerationMetersPerSecondSquared = 6;
+
+    // Reasonable baseline values for a RAMSETE follower in units of meters and seconds
+    public static final double kRamseteB = 2;
+    public static final double kRamseteZeta = 0.7;
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/Main.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/Main.java
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.statespacedifferentialdrivesimulation;
+
+import edu.wpi.first.wpilibj.RobotBase;
+
+/**
+ * Do NOT add any static variables to this class, or any initialization at all.
+ * Unless you know what you are doing, do not modify this file except to
+ * change the parameter class to the startRobot call.
+ */
+public final class Main {
+  private Main() {
+  }
+
+  /**
+   * Main initialization function. Do not perform any initialization here.
+   *
+   * <p>If you change your main robot class, change the parameter type.
+   */
+  public static void main(String... args) {
+    RobotBase.startRobot(Robot::new);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/Robot.java
@@ -1,0 +1,60 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.statespacedifferentialdrivesimulation;
+
+import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import edu.wpi.first.wpilibj.simulation.BatterySim;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+
+/**
+ * This is a sample program to demonstrate the use of state-space classes in robot simulation.
+ * This robot has a flywheel, elevator, arm and differential drivetrain, and interfaces with
+ * the sim GUI's {@link edu.wpi.first.wpilibj.simulation.Field2d} class.
+ */
+public class Robot extends TimedRobot {
+  private RoboRioSim m_roborioSim;
+  private RobotContainer m_robotContainer;
+
+  /**
+   * This function is run when the robot is first started up and should be used for any
+   * initialization code.
+   */
+  @Override
+  public void robotInit() {
+    // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
+    // autonomous chooser on the dashboard.
+    m_robotContainer = new RobotContainer();
+  }
+
+  @Override
+  public void simulationPeriodic() {
+    // Here we calculate the battery voltage based on drawn current.
+    // As our robot draws more power from the battery its voltage drops.
+    // The estimated voltage is highly dependent on the battery's internal
+    // resistance.
+    var drawCurrent = m_robotContainer.getRobotDrive().getDrawnCurrentAmps();
+    var loadedVoltage = BatterySim.calculateLoadedBatteryVoltage(drawCurrent);
+    RoboRioSim.setVInVoltage(loadedVoltage);
+  }
+
+  @Override
+  public void robotPeriodic() {
+    CommandScheduler.getInstance().run();
+  }
+
+  @Override
+  public void autonomousInit() {
+    m_robotContainer.getAutonomousCommand().schedule();
+  }
+
+  @Override
+  public void disabledInit() {
+    CommandScheduler.getInstance().cancelAll();
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
@@ -1,0 +1,136 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.statespacedifferentialdrivesimulation;
+
+import edu.wpi.first.wpilibj.GenericHID;
+import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.controller.PIDController;
+import edu.wpi.first.wpilibj.controller.RamseteController;
+import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.examples.statespacedifferentialdrivesimulation.subsystems.DriveSubsystem;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.trajectory.Trajectory;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveVoltageConstraint;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.RamseteCommand;
+import edu.wpi.first.wpilibj2.command.RunCommand;
+import edu.wpi.first.wpilibj2.command.button.JoystickButton;
+
+import java.util.List;
+
+import static edu.wpi.first.wpilibj.XboxController.Button;
+
+/**
+ * This class is where the bulk of the robot should be declared.  Since Command-based is a
+ * "declarative" paradigm, very little robot logic should actually be handled in the Robot
+ * periodic methods (other than the scheduler calls).  Instead, the structure of the robot
+ * (including subsystems, commands, and button mappings) should be declared here.
+ */
+public class RobotContainer {
+  // The robot's subsystems
+  private final DriveSubsystem m_robotDrive = new DriveSubsystem();
+
+  // The driver's controller
+  XboxController m_driverController = new XboxController(Constants.OIConstants.kDriverControllerPort);
+
+  /**
+   * The container for the robot.  Contains subsystems, OI devices, and commands.
+   */
+  public RobotContainer() {
+    // Configure the button bindings
+    configureButtonBindings();
+
+    // Configure default commands
+    // Set the default drive command to split-stick arcade drive
+    m_robotDrive.setDefaultCommand(
+        // A split-stick arcade command, with forward/backward controlled by the left
+        // hand, and turning controlled by the right.
+        new RunCommand(() -> m_robotDrive
+            .arcadeDrive(-m_driverController.getY(GenericHID.Hand.kRight),
+                m_driverController.getX(GenericHID.Hand.kLeft)), m_robotDrive));
+
+  }
+
+  /**
+   * Use this method to define your button->command mappings.  Buttons can be created by
+   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then calling passing it to a
+   * {@link JoystickButton}.
+   */
+  private void configureButtonBindings() {
+    // Drive at half speed when the right bumper is held
+    new JoystickButton(m_driverController, Button.kBumperRight.value)
+        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
+        .whenReleased(() -> m_robotDrive.setMaxOutput(1));
+
+  }
+
+  public DriveSubsystem getRobotDrive() {
+    return m_robotDrive;
+  }
+
+  /**
+   * Use this to pass the autonomous command to the main {@link Robot} class.
+   *
+   * @return the command to run in autonomous
+   */
+  public Command getAutonomousCommand() {
+
+    // Create a voltage constraint to ensure we don't accelerate too fast
+    var autoVoltageConstraint =
+        new DifferentialDriveVoltageConstraint(
+            new SimpleMotorFeedforward(Constants.DriveConstants.ksVolts,
+                Constants.DriveConstants.kvVoltSecondsPerMeter,
+                Constants.DriveConstants.kaVoltSecondsSquaredPerMeter),
+            Constants.DriveConstants.kDriveKinematics,
+            7);
+
+    // Create config for trajectory
+    TrajectoryConfig config =
+        new TrajectoryConfig(Constants.AutoConstants.kMaxSpeedMetersPerSecond,
+            Constants.AutoConstants.kMaxAccelerationMetersPerSecondSquared)
+            // Add kinematics to ensure max speed is actually obeyed
+            .setKinematics(Constants.DriveConstants.kDriveKinematics)
+            // Apply the voltage constraint
+            .addConstraint(autoVoltageConstraint);
+
+    // An example trajectory to follow.  All units in meters.
+    Trajectory exampleTrajectory = TrajectoryGenerator.generateTrajectory(
+        // Start at the origin facing the +X direction
+        new Pose2d(0, 0, new Rotation2d(0)),
+        // Pass through these two interior waypoints, making an 's' curve path
+        List.of(),
+        // End 3 meters straight ahead of where we started, facing forward
+        new Pose2d(6, 6, new Rotation2d(0)),
+        // Pass config
+        config
+    );
+
+    RamseteCommand ramseteCommand = new RamseteCommand(
+        exampleTrajectory,
+        m_robotDrive::getPose,
+        new RamseteController(Constants.AutoConstants.kRamseteB, Constants.AutoConstants.kRamseteZeta),
+        new SimpleMotorFeedforward(Constants.DriveConstants.ksVolts,
+            Constants.DriveConstants.kvVoltSecondsPerMeter,
+            Constants.DriveConstants.kaVoltSecondsSquaredPerMeter),
+        Constants.DriveConstants.kDriveKinematics,
+        m_robotDrive::getWheelSpeeds,
+        new PIDController(Constants.DriveConstants.kPDriveVel, 0, 0),
+        new PIDController(Constants.DriveConstants.kPDriveVel, 0, 0),
+        // RamseteCommand passes volts to the callback
+        m_robotDrive::tankDriveVolts,
+        m_robotDrive
+    );
+
+    // Run path following command, then stop at the end.
+    return ramseteCommand.andThen(() -> m_robotDrive.tankDriveVolts(0, 0));
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/subsystems/DriveSubsystem.java
@@ -1,0 +1,258 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.statespacedifferentialdrivesimulation.subsystems;
+
+import edu.wpi.first.hal.SimDouble;
+import edu.wpi.first.wpilibj.ADXRS450_Gyro;
+import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.PWMVictorSPX;
+import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.SPI;
+import edu.wpi.first.wpilibj.SpeedControllerGroup;
+import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj.examples.statespacedifferentialdrivesimulation.Constants;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.interfaces.Gyro;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveOdometry;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.simulation.EncoderSim;
+import edu.wpi.first.wpilibj.simulation.SimDeviceSim;
+import edu.wpi.first.wpilibj.simulation.DifferentialDrivetrainSim;
+import edu.wpi.first.wpilibj.simulation.Field2d;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+public class DriveSubsystem extends SubsystemBase {
+  // The motors on the left side of the drive.
+  private final SpeedControllerGroup m_leftMotors =
+        new SpeedControllerGroup(new PWMVictorSPX(Constants.DriveConstants.kLeftMotor1Port),
+              new PWMVictorSPX(Constants.DriveConstants.kLeftMotor2Port));
+
+  // The motors on the right side of the drive.
+  private final SpeedControllerGroup m_rightMotors =
+        new SpeedControllerGroup(new PWMVictorSPX(Constants.DriveConstants.kRightMotor1Port),
+              new PWMVictorSPX(Constants.DriveConstants.kRightMotor2Port));
+
+  // The robot's drive
+  private final DifferentialDrive m_drive = new DifferentialDrive(m_leftMotors, m_rightMotors);
+
+  // The left-side drive encoder
+  private final Encoder m_leftEncoder =
+        new Encoder(Constants.DriveConstants.kLeftEncoderPorts[0],
+              Constants.DriveConstants.kLeftEncoderPorts[1],
+              Constants.DriveConstants.kLeftEncoderReversed);
+
+  // The right-side drive encoder
+  private final Encoder m_rightEncoder =
+        new Encoder(Constants.DriveConstants.kRightEncoderPorts[0],
+              Constants.DriveConstants.kRightEncoderPorts[1],
+              Constants.DriveConstants.kRightEncoderReversed);
+
+  // The gyro sensor
+  private final Gyro m_gyro = new ADXRS450_Gyro();
+
+  // Odometry class for tracking robot pose
+  private final DifferentialDriveOdometry m_odometry;
+
+  // These classes help us simulate our drivetrain
+  public DifferentialDrivetrainSim m_drivetrainSimulator;
+  private EncoderSim m_leftEncoderSim;
+  private EncoderSim m_rightEncoderSim;
+  // The Field2d class simulates the field in the sim GUI. Note that we can have only one
+  // instance!
+  private Field2d m_fieldSim;
+  private SimDouble m_gyroAngleSim;
+
+  /**
+   * Creates a new DriveSubsystem.
+   */
+  public DriveSubsystem() {
+    // Sets the distance per pulse for the encoders
+    m_leftEncoder.setDistancePerPulse(Constants.DriveConstants.kEncoderDistancePerPulse);
+    m_rightEncoder.setDistancePerPulse(Constants.DriveConstants.kEncoderDistancePerPulse);
+
+    resetEncoders();
+    m_odometry = new DifferentialDriveOdometry(Rotation2d.fromDegrees(getHeading()));
+
+    if (RobotBase.isSimulation()) { // If our robot is simulated
+      // This class simulates our drivetrain's motion around the field.
+      m_drivetrainSimulator = new DifferentialDrivetrainSim(
+            Constants.DriveConstants.kDrivetrainPlant,
+            Constants.DriveConstants.kDriveKinematics,
+            Constants.DriveConstants.kLeftGearbox,
+            Constants.DriveConstants.kLeftGearing,
+            Constants.DriveConstants.kRightGearbox,
+            Constants.DriveConstants.kRightGearing);
+
+      // The encoder and gyro angle sims let us set simulated sensor readings
+      m_leftEncoderSim = new EncoderSim(m_leftEncoder);
+      m_rightEncoderSim = new EncoderSim(m_rightEncoder);
+      m_gyroAngleSim =
+            new SimDeviceSim("ADXRS450_Gyro" + "[" + SPI.Port.kOnboardCS0.value + "]")
+                  .getDouble("Angle");
+
+      // the Field2d class lets us visualize our robot in the simulation GUI.
+      m_fieldSim = new Field2d();
+    }
+  }
+
+  @Override
+  public void periodic() {
+    // Update the odometry in the periodic block
+    m_odometry.update(Rotation2d.fromDegrees(getHeading()), m_leftEncoder.getDistance(),
+          m_rightEncoder.getDistance());
+  }
+
+  @Override
+  public void simulationPeriodic() {
+    // To update our simulation, we set motor voltage inputs, update the simulation,
+    // and write the simulated positions and velocities to our simulated encoder and gyro.
+    // We negate the right side so that positive voltages make the right side
+    // move forward.
+    m_drivetrainSimulator.setInputs(m_leftMotors.get() * RobotController.getBatteryVoltage(),
+          -m_rightMotors.get() * RobotController.getBatteryVoltage());
+    m_drivetrainSimulator.update(0.020);
+
+    m_leftEncoderSim.setDistance(m_drivetrainSimulator.getState(DifferentialDrivetrainSim.State.kLeftPosition));
+    m_leftEncoderSim.setRate(m_drivetrainSimulator.getState(DifferentialDrivetrainSim.State.kLeftVelocity));
+    m_rightEncoderSim.setDistance(m_drivetrainSimulator.getState(DifferentialDrivetrainSim.State.kRightPosition));
+    m_rightEncoderSim.setRate(m_drivetrainSimulator.getState(DifferentialDrivetrainSim.State.kRightVelocity));
+    m_gyroAngleSim.set(-m_drivetrainSimulator.getHeading().getDegrees());
+
+    m_fieldSim.setRobotPose(getPose());
+  }
+
+  /**
+   * Returns the current being drawn by the drivetrain. This works in SIMULATION ONLY!
+   * If you want it to work elsewhere, use the code in
+   * {@link DifferentialDrivetrainSim#getCurrentDrawAmps()}
+   *
+   * @return The drawn current in Amps.
+   */
+  public double getDrawnCurrentAmps() {
+    return m_drivetrainSimulator.getCurrentDrawAmps();
+  }
+
+  /**
+   * Returns the currently-estimated pose of the robot.
+   *
+   * @return The pose.
+   */
+  public Pose2d getPose() {
+    return m_odometry.getPoseMeters();
+  }
+
+  /**
+   * Returns the current wheel speeds of the robot.
+   *
+   * @return The current wheel speeds.
+   */
+  public DifferentialDriveWheelSpeeds getWheelSpeeds() {
+    return new DifferentialDriveWheelSpeeds(m_leftEncoder.getRate(), m_rightEncoder.getRate());
+  }
+
+  /**
+   * Resets the odometry to the specified pose.
+   *
+   * @param pose The pose to which to set the odometry.
+   */
+  public void resetOdometry(Pose2d pose) {
+    resetEncoders();
+    m_odometry.resetPosition(pose, Rotation2d.fromDegrees(getHeading()));
+  }
+
+  /**
+   * Drives the robot using arcade controls.
+   *
+   * @param fwd the commanded forward movement
+   * @param rot the commanded rotation
+   */
+  public void arcadeDrive(double fwd, double rot) {
+    m_drive.arcadeDrive(fwd, rot);
+  }
+
+  /**
+   * Controls the left and right sides of the drive directly with voltages.
+   *
+   * @param leftVolts  the commanded left output
+   * @param rightVolts the commanded right output
+   */
+  public void tankDriveVolts(double leftVolts, double rightVolts) {
+    var batteryVoltage = RobotController.getBatteryVoltage();
+    if (Math.max(Math.abs(leftVolts), Math.abs(rightVolts))
+          > batteryVoltage) {
+      leftVolts *= batteryVoltage / 12.0;
+      rightVolts *= batteryVoltage / 12.0;
+    }
+    m_leftMotors.setVoltage(leftVolts);
+    m_rightMotors.setVoltage(-rightVolts);
+    m_drive.feed();
+  }
+
+  /**
+   * Resets the drive encoders to currently read a position of 0.
+   */
+  public void resetEncoders() {
+    m_leftEncoder.reset();
+    m_rightEncoder.reset();
+  }
+
+  /**
+   * Gets the average distance of the two encoders.
+   *
+   * @return the average of the two encoder readings
+   */
+  public double getAverageEncoderDistance() {
+    return (m_leftEncoder.getDistance() + m_rightEncoder.getDistance()) / 2.0;
+  }
+
+  /**
+   * Gets the left drive encoder.
+   *
+   * @return the left drive encoder
+   */
+  public Encoder getLeftEncoder() {
+    return m_leftEncoder;
+  }
+
+  /**
+   * Gets the right drive encoder.
+   *
+   * @return the right drive encoder
+   */
+  public Encoder getRightEncoder() {
+    return m_rightEncoder;
+  }
+
+  /**
+   * Sets the max output of the drive.  Useful for scaling the drive to drive more slowly.
+   *
+   * @param maxOutput the maximum output to which the drive will be constrained
+   */
+  public void setMaxOutput(double maxOutput) {
+    m_drive.setMaxOutput(maxOutput);
+  }
+
+  /**
+   * Zeroes the heading of the robot.
+   */
+  public void zeroHeading() {
+    m_gyro.reset();
+  }
+
+  /**
+   * Returns the heading of the robot.
+   *
+   * @return the robot's heading in degrees, from -180 to 180
+   */
+  public double getHeading() {
+    return Math.IEEEremainder(m_gyro.getAngle(), 360) * (Constants.DriveConstants.kGyroReversed ? -1.0 : 1.0);
+  }
+
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespaceswervedrivesimulation/Main.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespaceswervedrivesimulation/Main.java
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.statespaceswervedrivesimulation;
+
+import edu.wpi.first.wpilibj.RobotBase;
+
+/**
+ * Do NOT add any static variables to this class, or any initialization at all.
+ * Unless you know what you are doing, do not modify this file except to
+ * change the parameter class to the startRobot call.
+ */
+public final class Main {
+  private Main() {
+  }
+
+  /**
+   * Main initialization function. Do not perform any initialization here.
+   *
+   * <p>If you change your main robot class, change the parameter type.
+   */
+  public static void main(String... args) {
+    RobotBase.startRobot(Robot::new);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespaceswervedrivesimulation/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespaceswervedrivesimulation/Robot.java
@@ -1,0 +1,123 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.statespaceswervedrivesimulation;
+
+import edu.wpi.first.wpilibj.*;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.SwerveDriveOdometry;
+import edu.wpi.first.wpilibj.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.simulation.Field2d;
+import edu.wpi.first.wpilibj.simulation.SimSwerveDrive;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpilibj.util.Units;
+
+import java.util.List;
+
+public class Robot extends TimedRobot {
+  private static final Translation2d m_frontLeftLocation = new Translation2d(0.381, 0.381);
+  private static final Translation2d m_frontRightLocation = new Translation2d(0.381, -0.381);
+  private static final Translation2d m_backLeftLocation = new Translation2d(-0.381, 0.381);
+  private static final Translation2d m_backRightLocation = new Translation2d(-0.381, -0.381);
+
+  SimSwerveDrive sim = new SimSwerveDrive(
+      50.0,
+      LinearSystemId.createSingleJointedArmSystem(DCMotor.getNEO(1), .0005, 10.0),
+      DCMotor.getNEO(1), 8.0, Units.inchesToMeters(2.0),
+      m_frontLeftLocation, m_frontRightLocation, m_backLeftLocation, m_backRightLocation
+  );
+
+  Field2d field = new Field2d();
+  SwerveDriveKinematics kinematics = new SwerveDriveKinematics(
+      m_frontLeftLocation, m_frontRightLocation, m_backLeftLocation, m_backRightLocation);
+  SwerveDriveOdometry odo = new SwerveDriveOdometry(kinematics, new Rotation2d());
+
+  List<SwerveModule> swerves = List.of(
+      new SwerveModule(0, new Encoder(0, 1),
+          new PWMVictorSPX(0), new PWMVictorSPX(1)),
+      new SwerveModule(1, new Encoder(2, 3),
+          new PWMVictorSPX(2), new PWMVictorSPX(3)),
+      new SwerveModule(2, new Encoder(4, 5),
+          new PWMVictorSPX(4), new PWMVictorSPX(5)),
+      new SwerveModule(3, new Encoder(6, 7),
+          new PWMVictorSPX(6), new PWMVictorSPX(7))
+  );
+
+  final XboxController controller = new XboxController(0);
+
+  @Override
+  public void robotPeriodic() {
+//    var refSpeed = ChassisSpeeds.fromFieldRelativeSpeeds(
+//        -controller.getY(GenericHID.Hand.kRight), -controller.getX(GenericHID.Hand.kRight),
+//        -controller.getX(GenericHID.Hand.kLeft), odo.getPoseMeters().getRotation());
+
+//    refSpeed = new ChassisSpeeds(1, 1, 0);
+
+    var refSpeed = new ChassisSpeeds(
+        -applyDeadband(controller.getY(GenericHID.Hand.kRight), 0.1),
+        -applyDeadband(controller.getX(GenericHID.Hand.kRight), 0.1),
+        -applyDeadband(controller.getX(GenericHID.Hand.kLeft), 0.1));
+
+
+    var refStates = kinematics.toSwerveModuleStates(refSpeed);
+    SwerveDriveKinematics.normalizeWheelSpeeds(refStates, 1.0);
+
+    for (int i = 0; i < 4; i++) {
+      var swerve = swerves.get(i);
+      swerve.distanceMotor.setVoltage(refStates[i].speedMetersPerSecond * 12);
+//      swerve.angleMotor.setVoltage(1.0 * (refStates[i].angle.minus(sim.getEstimatedModuleAngles().get(i)).getRadians()));
+      swerve.angleMotor.setVoltage(swerve.angleController.calculate(
+          swerve.getState().angle.getRadians(), refStates[i].angle.getRadians()));
+
+      SmartDashboard.putNumber("Angle" + i, sim.getEstimatedModuleAngles().get(i).getDegrees());
+    }
+
+    odo.update(sim.getEstimatedHeading(), swerves.stream().map(SwerveModule::getState).toArray(SwerveModuleState[]::new));
+  }
+
+  @Override
+  public void simulationPeriodic() {
+    sim.setModuleAzimuthVoltages(
+        swerves.get(0).angleMotor.get() * RobotController.getBatteryVoltage(),
+        swerves.get(1).angleMotor.get() * RobotController.getBatteryVoltage(),
+        swerves.get(2).angleMotor.get() * RobotController.getBatteryVoltage(),
+        swerves.get(3).angleMotor.get() * RobotController.getBatteryVoltage());
+    sim.setModuleDriveVoltages(
+        swerves.get(0).distanceMotor.get() * RobotController.getBatteryVoltage(),
+        swerves.get(1).distanceMotor.get() * RobotController.getBatteryVoltage(),
+        swerves.get(2).distanceMotor.get() * RobotController.getBatteryVoltage(),
+        swerves.get(3).distanceMotor.get() * RobotController.getBatteryVoltage()
+    );
+
+    sim.update(0.020);
+    var states = sim.getEstimatedModuleStates();
+
+    for (int i = 0; i < states.length; i++) {
+      swerves.get(i).angleEncoderSim.setPosition(states[i].angle);
+      swerves.get(i).distanceEncoderSim.setRate(states[i].speedMetersPerSecond);
+    }
+
+    field.setRobotPose(odo.getPoseMeters());
+  }
+
+  protected double applyDeadband(double value, double deadband) {
+    if (Math.abs(value) > deadband) {
+      if (value > 0.0) {
+        return (value - deadband) / (1.0 - deadband);
+      } else {
+        return (value + deadband) / (1.0 - deadband);
+      }
+    } else {
+      return 0.0;
+    }
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespaceswervedrivesimulation/SwerveModule.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespaceswervedrivesimulation/SwerveModule.java
@@ -1,0 +1,50 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.statespaceswervedrivesimulation;
+
+import edu.wpi.first.wpilibj.AnalogEncoder;
+import edu.wpi.first.wpilibj.AnalogInput;
+import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.PWMSpeedController;
+import edu.wpi.first.wpilibj.controller.PIDController;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.simulation.AnalogEncoderSim;
+import edu.wpi.first.wpilibj.simulation.EncoderSim;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+class SwerveModule {
+  final PIDController angleController;
+
+  AnalogEncoder angleEncoder;
+  AnalogEncoderSim angleEncoderSim;
+
+  Encoder distanceEncoder;
+  EncoderSim distanceEncoderSim;
+
+  PWMSpeedController angleMotor;
+  PWMSpeedController distanceMotor;
+
+  SwerveModule(int angleEncoderChannel, Encoder distanceEncoder,
+               PWMSpeedController angleMotor,
+               PWMSpeedController distanceMotor) {
+    this.angleEncoder = new AnalogEncoder(new AnalogInput(angleEncoderChannel));
+    this.angleEncoderSim = new AnalogEncoderSim(angleEncoder);
+    this.distanceEncoder = distanceEncoder;
+    this.distanceEncoderSim = new EncoderSim(distanceEncoder);
+    this.angleMotor = angleMotor;
+    this.distanceMotor = distanceMotor;
+    this.angleController = new PIDController(0.1, 0, 0);
+
+    SmartDashboard.putData("Angle controller " + angleEncoderChannel, angleController);
+  }
+
+  SwerveModuleState getState() {
+    return new SwerveModuleState(distanceEncoder.getRate(), Rotation2d.fromDegrees(angleEncoder.get() * 360.0));
+  }
+}

--- a/wpimath/src/main/java/edu/wpi/first/math/interpolation/Interpolatable.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/interpolation/Interpolatable.java
@@ -1,0 +1,26 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.math.interpolation;
+
+/**
+ * An object should extend interpolatable if you wish to linearly interpolate between a lower and
+ * upper bound, such as a robot position on the field between timesteps.
+ * @param <T> The class that is interpolatable.
+ */
+public interface Interpolatable<T> {
+
+  /**
+   * Return the interpolated value. This object is assumed to be the starting position,
+   * or lower bound.
+   * @param endValue The upper bound, or end.
+   * @param t How far between the lower and upper bound we are. This should be bounded in [0, 1].
+   * @return
+   */
+  @SuppressWarnings("ParameterName")
+  T interpolate(T endValue, double t);
+}

--- a/wpimath/src/main/java/edu/wpi/first/math/interpolation/InterpolatingDouble.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/interpolation/InterpolatingDouble.java
@@ -1,0 +1,25 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.math.interpolation;
+
+import edu.wpi.first.wpiutil.math.MathUtil;
+
+public class InterpolatingDouble implements Interpolatable<Double> {
+
+  public double m_value;
+
+  public InterpolatingDouble(double value) {
+    this.m_value = value;
+  }
+
+  @Override
+  @SuppressWarnings("ParameterName")
+  public Double interpolate(Double endValue, double t) {
+    return m_value + (endValue - m_value) * MathUtil.clamp(t, 0, 1);
+  }
+}

--- a/wpimath/src/main/java/edu/wpi/first/math/interpolation/TimeInterpolatableBuffer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/interpolation/TimeInterpolatableBuffer.java
@@ -1,0 +1,90 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.math.interpolation;
+
+import java.util.TreeMap;
+
+/**
+ * The TimeInterpolatableBuffer provides an easy way to estimate past measurements. One
+ * application might be in conjunction with the
+ * {@link edu.wpi.first.wpilibj.estimator.DifferentialDrivePoseEstimator},
+ * where knowledge of the robot pose at the time when vision or other global measurement
+ * were recorded is necessary, or for recording the past angles of mechanisms as measured
+ * by encoders. Currently, the {@link edu.wpi.first.wpilibj.geometry.Pose2d},
+ * {@link edu.wpi.first.wpilibj.geometry.Rotation2d},
+ * {@link edu.wpi.first.wpilibj.geometry.Translation2d}
+ * and {@link InterpolatingDouble} classes implement {@link Interpolatable}.
+ *
+ * @param <T> The Interpolatable stored in this buffer.
+ */
+public class TimeInterpolatableBuffer<T extends Interpolatable<T>> {
+
+  private final double m_historySize;
+  private TreeMap<Double, T> m_buffer = new TreeMap<>();
+
+  public TimeInterpolatableBuffer(double historySizeSeconds) {
+    this.m_historySize = historySizeSeconds;
+  }
+
+  public void addSample(double timeSeconds, T sample) {
+    cleanUp(timeSeconds);
+    m_buffer.put(timeSeconds, sample);
+  }
+
+  private void cleanUp(double time) {
+    while (!m_buffer.isEmpty()) {
+      var entry = m_buffer.lastEntry();
+      if (time - entry.getKey() >= m_historySize) {
+        m_buffer.remove(entry.getKey());
+      } else {
+        return;
+      }
+    }
+  }
+
+  public void clear() {
+    m_buffer.clear();
+  }
+
+  /**
+   * Sample the buffer at the given time. If the buffer is empty, this will
+   * return null.
+   *
+   * @param timeSeconds The time at which to sample.
+   * @return The interpolated value at that timestamp. Might be null.
+   */
+  public T getSample(double timeSeconds) {
+    if (m_buffer.isEmpty()) {
+      return null;
+    }
+
+    // Special case for when the requested time is the same as a sample
+    var nowEntry = m_buffer.get(timeSeconds);
+    if (nowEntry != null) {
+      return nowEntry;
+    }
+
+    var topBound = m_buffer.ceilingEntry(timeSeconds);
+    var bottomBound = m_buffer.floorEntry(timeSeconds);
+
+    // Return null if neither sample exists, and the opposite bound if the other is null
+    if (topBound == null && bottomBound == null) {
+      return null;
+    } else if (topBound == null) {
+      return bottomBound.getValue();
+    } else if (bottomBound == null) {
+      return topBound.getValue();
+    } else {
+      // Otherwise, interpolate. Because T is between [0, 1], we want the ratio of (the difference
+      // between the current time and bottom bound) and (the difference between top and bottom
+      // bounds).
+      return bottomBound.getValue().interpolate(topBound.getValue(),
+          (timeSeconds - bottomBound.getKey()) / (topBound.getKey() - bottomBound.getKey()));
+    }
+  }
+}

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/controller/ControlAffinePlantInversionFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/controller/ControlAffinePlantInversionFeedforward.java
@@ -191,18 +191,6 @@ public class ControlAffinePlantInversionFeedforward<States extends Num, Inputs e
    *
    * @return The calculated feedforward.
    */
-  public Matrix<Inputs, N1> calculate(Matrix<States, N1> nextR) {
-    return calculate(m_r, nextR);
-  }
-
-  /**
-   * Calculate the feedforward with current and future reference vectors.
-   *
-   * @param r     The reference state of the current timestep (k).
-   * @param nextR The reference state of the future timestep (k + dt).
-   *
-   * @return The calculated feedforward.
-   */
   @SuppressWarnings({"ParameterName", "LocalVariableName"})
   public Matrix<Inputs, N1> calculate(Matrix<States, N1> r, Matrix<States, N1> nextR) {
     var rDot = (nextR.minus(r)).div(m_dt);

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/controller/LinearPlantInversionFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/controller/LinearPlantInversionFeedforward.java
@@ -67,10 +67,6 @@ public class LinearPlantInversionFeedforward<States extends Num, Inputs extends 
   @SuppressWarnings({"ParameterName", "LocalVariableName"})
   public LinearPlantInversionFeedforward(Matrix<States, States> A, Matrix<States, Inputs> B,
                                          double dtSeconds) {
-    var discABPair = Discretization.discretizeAB(A, B, dtSeconds);
-    this.m_A = discABPair.getFirst();
-    this.m_B = discABPair.getSecond();
-
     m_r = new Matrix<States, N1>(new SimpleMatrix(B.getNumRows(), 1));
     m_uff = new Matrix<Inputs, N1>(new SimpleMatrix(B.getNumCols(), 1));
 

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/geometry/Pose2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/geometry/Pose2d.java
@@ -14,12 +14,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.wpi.first.math.interpolation.Interpolatable;
+
 /**
  * Represents a 2d pose containing translational and rotational elements.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
-public class Pose2d {
+public class Pose2d implements Interpolatable<Pose2d> {
   private final Translation2d m_translation;
   private final Rotation2d m_rotation;
 
@@ -248,5 +250,19 @@ public class Pose2d {
   @Override
   public int hashCode() {
     return Objects.hash(m_translation, m_rotation);
+  }
+
+  @Override
+  @SuppressWarnings("ParameterName")
+  public Pose2d interpolate(Pose2d endValue, double t) {
+    if (t < 0) {
+      return this;
+    } else if (t >= 1) {
+      return endValue;
+    } else {
+      var twist = this.log(endValue);
+      var scaledTwist = new Twist2d(twist.dx * t, twist.dy * t, twist.dtheta * t);
+      return this.exp(scaledTwist);
+    }
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/geometry/Rotation2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/geometry/Rotation2d.java
@@ -14,13 +14,16 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.wpi.first.math.interpolation.Interpolatable;
+import edu.wpi.first.wpiutil.math.MathUtil;
+
 /**
  * A rotation in a 2d coordinate frame represented a point on the unit circle
  * (cosine and sine).
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
-public class Rotation2d {
+public class Rotation2d implements Interpolatable<Rotation2d> {
   private final double m_value;
   private final double m_cos;
   private final double m_sin;
@@ -211,5 +214,11 @@ public class Rotation2d {
   @Override
   public int hashCode() {
     return Objects.hash(m_value);
+  }
+
+  @Override
+  @SuppressWarnings("ParameterName")
+  public Rotation2d interpolate(Rotation2d endValue, double t) {
+    return new Rotation2d(MathUtil.interpolate(this.getRadians(), endValue.getRadians(), t));
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/geometry/Translation2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/geometry/Translation2d.java
@@ -14,6 +14,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.wpi.first.math.interpolation.Interpolatable;
+import edu.wpi.first.wpiutil.math.MathUtil;
+
 /**
  * Represents a translation in 2d space.
  * This object can be used to represent a point or a vector.
@@ -25,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @SuppressWarnings({"ParameterName", "MemberName"})
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
-public class Translation2d {
+public class Translation2d implements Interpolatable<Translation2d> {
   private final double m_x;
   private final double m_y;
 
@@ -199,5 +202,11 @@ public class Translation2d {
   @Override
   public int hashCode() {
     return Objects.hash(m_x, m_y);
+  }
+
+  @Override
+  public Translation2d interpolate(Translation2d endValue, double t) {
+    return new Translation2d(MathUtil.interpolate(this.getX(), endValue.getX(), t),
+        MathUtil.interpolate(this.getY(), endValue.getY(), t));
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/math/StateSpaceUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/math/StateSpaceUtil.java
@@ -20,6 +20,7 @@ import edu.wpi.first.wpiutil.math.Num;
 import edu.wpi.first.wpiutil.math.VecBuilder;
 import edu.wpi.first.wpiutil.math.numbers.N1;
 import edu.wpi.first.wpiutil.math.numbers.N3;
+import edu.wpi.first.wpiutil.math.numbers.N4;
 
 @SuppressWarnings({"PMD.TooManyMethods", "ParameterName"})
 public final class StateSpaceUtil {
@@ -177,4 +178,32 @@ public final class StateSpaceUtil {
     return u;
   }
 
+  /**
+   * Convert a {@link Pose2d} to a vector of [x, y, cos(theta), sin(theta)],
+   * where theta is in radians.
+   *
+   * @param pose A pose to convert to a vector.
+   */
+  public static Matrix<N4, N1> poseTo4dVector(Pose2d pose) {
+    return VecBuilder.fill(
+      pose.getTranslation().getX(),
+      pose.getTranslation().getY(),
+      pose.getRotation().getCos(),
+      pose.getRotation().getSin()
+    );
+  }
+
+  /**
+   * Convert a {@link Pose2d} to a vector of [x, y, theta], where theta is in radians.
+   *
+   * @param pose A pose to convert to a vector.
+   * @return The given pose in vector form, with the third element, theta, in radians.
+   */
+  public static Matrix<N3, N1> poseTo3dVector(Pose2d pose) {
+    return VecBuilder.fill(
+      pose.getTranslation().getX(),
+      pose.getTranslation().getY(),
+      pose.getRotation().getRadians()
+    );
+  }
 }

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/system/LinearSystemLoop.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/system/LinearSystemLoop.java
@@ -103,8 +103,7 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num,
                           LinearQuadraticRegulator<States, Inputs, Outputs> controller,
                           LinearPlantInversionFeedforward<States, Inputs, Outputs> feedforward,
                           KalmanFilter<States, Inputs, Outputs> observer,
-                          double maxVoltageVolts
-  ) {
+                          double maxVoltageVolts) {
     this(plant, controller, feedforward,
           observer, u -> StateSpaceUtil.normalizeInputVector(u, maxVoltageVolts));
   }

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/system/plant/DCMotor.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/system/plant/DCMotor.java
@@ -48,8 +48,19 @@ public class DCMotor {
 
     this.m_rOhms = nominalVoltageVolts / stallCurrentAmps;
     this.m_KvRadPerSecPerVolt = freeSpeedRadPerSec / (nominalVoltageVolts - m_rOhms
-            * freeCurrentAmps);
+      * freeCurrentAmps);
     this.m_KtNMPerAmp = stallTorqueNewtonMeters / stallCurrentAmps;
+  }
+
+  /**
+   * Estimate the current being drawn by this motor.
+   *
+   * @param speedRadiansPerSec The speed of the rotor.
+   * @param voltageInputVolts  The input voltage.
+   */
+  public double getCurrent(double speedRadiansPerSec, double voltageInputVolts) {
+    return -1.0 / m_KvRadPerSecPerVolt / m_rOhms * speedRadiansPerSec
+      + 1.0 / m_rOhms * voltageInputVolts;
   }
 
   /**
@@ -59,8 +70,8 @@ public class DCMotor {
    */
   public static DCMotor getCIM(int numMotors) {
     return new DCMotor(12,
-            2.42 * numMotors, 133,
-            2.7, Units.rotationsPerMinuteToRadiansPerSecond(5310));
+      2.42 * numMotors, 133,
+      2.7, Units.rotationsPerMinuteToRadiansPerSecond(5310));
   }
 
   /**
@@ -70,8 +81,8 @@ public class DCMotor {
    */
   public static DCMotor getVex775Pro(int numMotors) {
     return gearbox(new DCMotor(12,
-            0.71, 134,
-            0.7, Units.rotationsPerMinuteToRadiansPerSecond(18730)), numMotors);
+      0.71, 134,
+      0.7, Units.rotationsPerMinuteToRadiansPerSecond(18730)), numMotors);
   }
 
   /**
@@ -81,7 +92,7 @@ public class DCMotor {
    */
   public static DCMotor getNEO(int numMotors) {
     return gearbox(new DCMotor(12, 2.6,
-            105, 1.8, Units.rotationsPerMinuteToRadiansPerSecond(5676)), numMotors);
+      105, 1.8, Units.rotationsPerMinuteToRadiansPerSecond(5676)), numMotors);
   }
 
   /**
@@ -91,7 +102,7 @@ public class DCMotor {
    */
   public static DCMotor getMiniCIM(int numMotors) {
     return gearbox(new DCMotor(12, 1.41, 89, 3,
-            Units.rotationsPerMinuteToRadiansPerSecond(5840)), numMotors);
+      Units.rotationsPerMinuteToRadiansPerSecond(5840)), numMotors);
   }
 
   /**
@@ -101,7 +112,7 @@ public class DCMotor {
    */
   public static DCMotor getBag(int numMotors) {
     return gearbox(new DCMotor(12, 0.43, 53, 1.8,
-            Units.rotationsPerMinuteToRadiansPerSecond(13180)), numMotors);
+      Units.rotationsPerMinuteToRadiansPerSecond(13180)), numMotors);
   }
 
   /**
@@ -111,7 +122,7 @@ public class DCMotor {
    */
   public static DCMotor getAndymarkRs775_125(int numMotors) {
     return gearbox(new DCMotor(12, 0.28, 18, 1.6,
-            Units.rotationsPerMinuteToRadiansPerSecond(5800.0)), numMotors);
+      Units.rotationsPerMinuteToRadiansPerSecond(5800.0)), numMotors);
   }
 
   /**
@@ -121,7 +132,7 @@ public class DCMotor {
    */
   public static DCMotor getBanebotsRs775(int numMotors) {
     return gearbox(new DCMotor(12, 0.72, 97, 2.7,
-            Units.rotationsPerMinuteToRadiansPerSecond(13050.0)), numMotors);
+      Units.rotationsPerMinuteToRadiansPerSecond(13050.0)), numMotors);
   }
 
   /**
@@ -131,7 +142,7 @@ public class DCMotor {
    */
   public static DCMotor getAndymark9015(int numMotors) {
     return gearbox(new DCMotor(12, 0.36, 71, 3.7,
-            Units.rotationsPerMinuteToRadiansPerSecond(14270.0)), numMotors);
+      Units.rotationsPerMinuteToRadiansPerSecond(14270.0)), numMotors);
   }
 
   /**
@@ -141,7 +152,7 @@ public class DCMotor {
    */
   public static DCMotor getBanebotsRs550(int numMotors) {
     return gearbox(new DCMotor(12, 0.38, 84, 0.4,
-            Units.rotationsPerMinuteToRadiansPerSecond(19000.0)), numMotors);
+      Units.rotationsPerMinuteToRadiansPerSecond(19000.0)), numMotors);
   }
 
   /**
@@ -151,7 +162,7 @@ public class DCMotor {
    */
   public static DCMotor getNeo550(int numMotors) {
     return gearbox(new DCMotor(12, 0.97, 100, 1.4,
-            Units.rotationsPerMinuteToRadiansPerSecond(11000.0)), numMotors);
+      Units.rotationsPerMinuteToRadiansPerSecond(11000.0)), numMotors);
   }
 
   /**
@@ -161,11 +172,11 @@ public class DCMotor {
    */
   public static DCMotor getFalcon500(int numMotors) {
     return gearbox(new DCMotor(12, 4.69, 257, 1.5,
-            Units.rotationsPerMinuteToRadiansPerSecond(6380.0)), numMotors);
+      Units.rotationsPerMinuteToRadiansPerSecond(6380.0)), numMotors);
   }
 
   private static DCMotor gearbox(DCMotor motor, double numMotors) {
     return new DCMotor(motor.m_nominalVoltageVolts, motor.m_stallTorqueNewtonMeters * numMotors,
-            motor.m_stallCurrentAmps, motor.m_freeCurrentAmps, motor.m_freeSpeedRadPerSec);
+      motor.m_stallCurrentAmps, motor.m_freeCurrentAmps, motor.m_freeSpeedRadPerSec);
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVelocitySystemConstraint.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint/DifferentialDriveVelocitySystemConstraint.java
@@ -1,0 +1,117 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.trajectory.constraint;
+
+import edu.wpi.first.wpiutil.ErrorMessages;
+import org.ejml.dense.row.CommonOps_DDRM;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+
+/**
+ * A class that enforces constraints on differential drive velocity based on
+ * a differential drive {@link LinearSystem} and the drive kinematics.
+ *
+ * <p>Ensures that the acceleration of any wheel of the robot while
+ * following the trajectory is never higher than what can be achieved with
+ * the given maximum voltage.
+ */
+@SuppressWarnings({"ParameterName", "LocalVariableName", "MemberName"})
+public class DifferentialDriveVelocitySystemConstraint implements TrajectoryConstraint {
+  private final LinearSystem<N2, N2, N2> m_system;
+  private final DifferentialDriveKinematics m_kinematics;
+  private final double m_maxVoltage;
+
+  /**
+   * Creates a new DifferentialDriveVelocitySystemConstraint.
+   *
+   * @param system     A {@link LinearSystem} representing the drivetrain..
+   * @param kinematics A kinematics component describing the drive geometry.
+   * @param maxVoltage The maximum voltage available to the motors while following the path.
+   *                   Should be somewhat less than the nominal battery voltage (12V) to account
+   *                   for "voltage sag" due to current draw.
+   */
+  public DifferentialDriveVelocitySystemConstraint(LinearSystem<N2, N2, N2> system,
+                                                   DifferentialDriveKinematics kinematics,
+                                                   double maxVoltage) {
+    m_system = ErrorMessages.requireNonNullParam(system, "system",
+      "DifferentialDriveVoltageConstraint");
+    m_kinematics = ErrorMessages.requireNonNullParam(kinematics, "kinematics",
+      "DifferentialDriveVoltageConstraint");
+    m_maxVoltage = maxVoltage;
+  }
+
+  @Override
+  public double getMaxVelocityMetersPerSecond(Pose2d poseMeters, double curvatureRadPerMeter,
+                                              double velocityMetersPerSecond) {
+    // Calculate wheel velocity states from current velocity and curvature
+    var speeds = m_kinematics.toWheelSpeeds(new ChassisSpeeds(velocityMetersPerSecond,
+        0, curvatureRadPerMeter));
+
+    Matrix<N2, N1> x = VecBuilder.fill(speeds.leftMetersPerSecond, speeds.rightMetersPerSecond);
+
+    // If either wheel velocity is greater than its maximum, normalize the wheel
+    // speeds to within an achievable range while maintaining the curvature
+    x = StateSpaceUtil.normalizeInputVector(x, velocityMetersPerSecond);
+
+    // chassis speed is average of wheel speeds
+    return (x.get(0, 0) + x.get(1, 0)) / 2.0;
+  }
+
+  @Override
+  public MinMax getMinMaxAccelerationMetersPerSecondSq(Pose2d poseMeters,
+                                                       double curvatureRadPerMeter,
+                                                       double velocityMetersPerSecond) {
+    var wheelSpeeds = m_kinematics.toWheelSpeeds(new ChassisSpeeds(velocityMetersPerSecond, 0,
+        velocityMetersPerSecond
+        * curvatureRadPerMeter));
+
+    var x = VecBuilder.fill(wheelSpeeds.leftMetersPerSecond,
+        wheelSpeeds.rightMetersPerSecond);
+
+    Matrix<N2, N1> u;
+    double minAccel;
+    double maxAccel;
+
+    u = VecBuilder.fill(wheelSpeeds.leftMetersPerSecond, wheelSpeeds.rightMetersPerSecond);
+    u = u.times(m_maxVoltage / CommonOps_DDRM.elementMaxAbs(u.getStorage().getDDRM()));
+    if (velocityMetersPerSecond > 1e-6) {
+      maxAccel = getChassisAccel(x, u);
+      minAccel = getChassisAccel(x, u.times(-1));
+    } else if (velocityMetersPerSecond < -1e-6) {
+      maxAccel = getChassisAccel(x, u.times(-1));
+      minAccel = getChassisAccel(x, u);
+    } else {
+      u = VecBuilder.fill(m_maxVoltage, m_maxVoltage);
+      maxAccel = getChassisAccel(x, u);
+      minAccel = getChassisAccel(x, u.times(-1));
+    }
+
+    //      // dx/dt for minimum u
+    //      u = VecBuilder.fill(-m_maxVoltage, -m_maxVoltage);
+    //      minAccel = getChassisAccel(x, u);
+    //
+    //      // dx/dt for maximum u
+    //      u = VecBuilder.fill(m_maxVoltage, m_maxVoltage);
+    //      maxAccel = getChassisAccel(x, u);
+
+    return new MinMax(minAccel, maxAccel);
+  }
+
+  public double getChassisAccel(Matrix<N2, N1> x, Matrix<N2, N1> u) {
+    var xDot = m_system.getA().times(x).plus(m_system.getB().times(u));
+    return (xDot.get(0, 0) + xDot.get(1, 0)) / 2.0;
+  }
+}

--- a/wpimath/src/main/java/edu/wpi/first/wpiutil/math/MathUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpiutil/math/MathUtil.java
@@ -53,4 +53,15 @@ public final class MathUtil {
 
     return theta;
   }
+
+  /**
+   * Perform linear interpolation between two values.
+   * @param startValue The value to start at.
+   * @param endValue The value to end at.
+   * @param t How far between the two values to interpolate. This is clamped to [0, 1].
+   */
+  @SuppressWarnings("ParameterName")
+  public static double interpolate(double startValue, double endValue, double t) {
+    return startValue + (endValue - startValue) * MathUtil.clamp(t, 0, 1);
+  }
 }

--- a/wpimath/src/main/java/edu/wpi/first/wpiutil/math/Matrix.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpiutil/math/Matrix.java
@@ -9,7 +9,6 @@ package edu.wpi.first.wpiutil.math;
 
 import java.util.Objects;
 
-
 import org.ejml.MatrixDimensionException;
 import org.ejml.data.DMatrixRMaj;
 import org.ejml.dense.row.CommonOps_DDRM;
@@ -22,8 +21,7 @@ import org.ejml.simple.SimpleMatrix;
 import edu.wpi.first.math.WPIMathJNI;
 import edu.wpi.first.wpiutil.math.numbers.N1;
 
-/**
- * A shape-safe wrapper over Efficient Java Matrix Library (EJML) matrices.
+/*
  *
  * <p>This class is intended to be used alongside the state space library.
  *
@@ -227,7 +225,7 @@ public class Matrix<R extends Num, C extends Num> {
    * @param value The scalar value to multiply by.
    * @return A new matrix with all the elements multiplied by the given value.
    */
-  public final Matrix<R, C> times(double value) {
+  public Matrix<R, C> times(double value) {
     return new Matrix<>(this.m_storage.scale(value));
   }
 

--- a/wpimath/src/main/java/edu/wpi/first/wpiutil/math/Vector.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpiutil/math/Vector.java
@@ -52,4 +52,9 @@ public class Vector<R extends Num> extends Matrix<R, N1> {
   public Vector(Matrix<R, N1> other) {
     super(other);
   }
+
+  @Override
+  public Vector<R> times(double value) {
+    return new Vector<>(this.m_storage.scale(value));
+  }
 }

--- a/wpimath/src/main/java/edu/wpi/first/wpiutil/math/WPIMathJNI.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpiutil/math/WPIMathJNI.java
@@ -1,0 +1,79 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpiutil.math;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import edu.wpi.first.wpiutil.RuntimeLoader;
+
+public final class WPIMathJNI {
+  static boolean libraryLoaded = false;
+  static RuntimeLoader<WPIMathJNI> loader = null;
+
+  public static class Helper {
+    private static AtomicBoolean extractOnStaticLoad = new AtomicBoolean(true);
+
+    public static boolean getExtractOnStaticLoad() {
+      return extractOnStaticLoad.get();
+    }
+
+    public static void setExtractOnStaticLoad(boolean load) {
+      extractOnStaticLoad.set(load);
+    }
+  }
+
+  static {
+    if (Helper.getExtractOnStaticLoad()) {
+      try {
+        loader = new RuntimeLoader<>("wpimathjni", RuntimeLoader.getDefaultExtractionRoot(), WPIMathJNI.class);
+        loader.loadLibrary();
+      } catch (IOException ex) {
+        ex.printStackTrace();
+        System.exit(1);
+      }
+      libraryLoaded = true;
+    }
+  }
+
+  /**
+   * Force load the library.
+   */
+  public static synchronized void forceLoad() throws IOException {
+    if (libraryLoaded) {
+      return;
+    }
+    loader = new RuntimeLoader<>("wpiutiljni", RuntimeLoader.getDefaultExtractionRoot(), WPIMathJNI.class);
+    loader.loadLibrary();
+    libraryLoaded = true;
+  }
+
+  /**
+   * Computes the matrix exp.
+   *
+   * @param src  Array of elements of the matrix to be exponentiated.
+   * @param rows how many rows there are.
+   * @param dst  Array where the result will be stored.
+   */
+  public static native void exp(double[] src, int rows, double[] dst);
+
+  /**
+   * Returns true if (A, B) is a stabilizable pair.
+   *
+   * <p>(A,B) is stabilizable if and only if the uncontrollable eigenvalues of A, if
+   * any, have absolute values less than one, where an eigenvalue is
+   * uncontrollable if rank(lambda * I - A, B) &lt; n where n is number of states.
+   *
+   * @param states the number of states of the system.
+   * @param inputs the number of inputs to the system.
+   * @param A      System matrix.
+   * @param B      Input matrix.
+   * @return If the system is stabilizable.
+   */
+  public static native boolean isStabilizable(int states, int inputs, double[] A, double[] B);
+}

--- a/wpimath/src/main/native/cpp/StateSpaceUtil.cpp
+++ b/wpimath/src/main/native/cpp/StateSpaceUtil.cpp
@@ -9,6 +9,18 @@
 
 namespace frc {
 
+Eigen::Matrix<double, 3, 1> PoseTo3dVector(const Pose2d& pose) {
+  return frc::MakeMatrix<3, 1>(pose.Translation().X().to<double>(),
+                               pose.Translation().Y().to<double>(),
+                               pose.Rotation().Radians().to<double>());
+}
+
+Eigen::Matrix<double, 4, 1> PoseTo4dVector(const Pose2d& pose) {
+  return frc::MakeMatrix<4, 1>(pose.Translation().X().to<double>(),
+                               pose.Translation().Y().to<double>(),
+                               pose.Rotation().Cos(), pose.Rotation().Sin());
+}
+
 template <>
 bool IsStabilizable<1, 1>(const Eigen::Matrix<double, 1, 1>& A,
                           const Eigen::Matrix<double, 1, 1>& B) {

--- a/wpimath/src/main/native/cpp/trajectory/Trajectory.cpp
+++ b/wpimath/src/main/native/cpp/trajectory/Trajectory.cpp
@@ -7,6 +7,7 @@
 
 #include "frc/trajectory/Trajectory.h"
 
+#include <wpi/MathExtras.h>
 #include <wpi/json.h>
 
 #include "units/math.h"
@@ -26,7 +27,7 @@ bool Trajectory::State::operator!=(const Trajectory::State& other) const {
 Trajectory::State Trajectory::State::Interpolate(State endValue,
                                                  double i) const {
   // Find the new [t] value.
-  const auto newT = Lerp(t, endValue.t, i);
+  const auto newT = wpi::Lerp(t, endValue.t, i);
 
   // Find the delta time between the current state and the interpolated state.
   const auto deltaT = newT - t;
@@ -57,8 +58,8 @@ Trajectory::State Trajectory::State::Interpolate(State endValue,
       newS / endValue.pose.Translation().Distance(pose.Translation());
 
   return {newT, newV, acceleration,
-          Lerp(pose, endValue.pose, interpolationFrac),
-          Lerp(curvature, endValue.curvature, interpolationFrac)};
+          wpi::Lerp(pose, endValue.pose, interpolationFrac),
+          wpi::Lerp(curvature, endValue.curvature, interpolationFrac)};
 }
 
 Trajectory::Trajectory(const std::vector<State>& states) : m_states(states) {

--- a/wpimath/src/main/native/cpp/trajectory/constraint/DifferentialDriveVelocitySystemConstraint.cpp
+++ b/wpimath/src/main/native/cpp/trajectory/constraint/DifferentialDriveVelocitySystemConstraint.cpp
@@ -1,0 +1,73 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/trajectory/constraint/DifferentialDriveVelocitySystemConstraint.h"
+
+#include <algorithm>
+#include <limits>
+
+#include <wpi/MathExtras.h>
+
+#include "units/velocity.h"
+
+using namespace frc;
+
+DifferentialDriveVelocitySystemConstraint::
+    DifferentialDriveVelocitySystemConstraint(
+        const LinearSystem<2, 2, 2>& system,
+        const DifferentialDriveKinematics& kinematics, units::volt_t maxVoltage)
+    : m_system(system), m_kinematics(kinematics), m_maxVoltage(maxVoltage) {}
+
+units::meters_per_second_t
+DifferentialDriveVelocitySystemConstraint::MaxVelocity(
+    const Pose2d& pose, units::curvature_t curvature,
+    units::meters_per_second_t velocity) const {
+  // Calculate wheel velocity states from current velocity and curvature
+  auto [vl, vr] =
+      m_kinematics.ToWheelSpeeds({velocity, 0_mps, velocity * curvature});
+
+  Eigen::Vector2d x;
+  x << vl.to<double>(), vr.to<double>();
+
+  // If either wheel velocity is greater than its maximum, normalize the wheel
+  // speeds to within an achievable range while maintaining the curvature
+  if (std::abs(x(0)) > velocity.to<double>() ||
+      std::abs(x(1)) > velocity.to<double>()) {
+    x *= velocity.to<double>() / x.lpNorm<Eigen::Infinity>();
+  }
+  return units::meters_per_second_t{(x(0) + x(1)) / 2.0};
+}
+
+TrajectoryConstraint::MinMax
+DifferentialDriveVelocitySystemConstraint::MinMaxAcceleration(
+    const Pose2d& pose, units::curvature_t curvature,
+    units::meters_per_second_t speed) const {
+  auto wheelSpeeds =
+      m_kinematics.ToWheelSpeeds({speed, 0_mps, speed * curvature});
+
+  Eigen::Vector2d x;
+  x << wheelSpeeds.left.to<double>(), wheelSpeeds.right.to<double>();
+
+  Eigen::Vector2d xDot;
+  Eigen::Vector2d u;
+
+  // dx/dt for minimum u
+  u << -m_maxVoltage.to<double>(), -m_maxVoltage.to<double>();
+  xDot = m_system.A() * x + m_system.B() * u;
+  units::meters_per_second_squared_t minChassisAcceleration;
+  minChassisAcceleration =
+      units::meters_per_second_squared_t((xDot(0, 0) + xDot(1, 0)) / 2.0);
+
+  // dx/dt for maximum u
+  u << m_maxVoltage.to<double>(), m_maxVoltage.to<double>();
+  xDot = m_system.A() * x + m_system.B() * u;
+  units::meters_per_second_squared_t maxChassisAcceleration;
+  maxChassisAcceleration =
+      units::meters_per_second_squared_t((xDot(0, 0) + xDot(1, 0)) / 2.0);
+
+  return {minChassisAcceleration, maxChassisAcceleration};
+}

--- a/wpimath/src/main/native/include/frc/StateSpaceUtil.h
+++ b/wpimath/src/main/native/include/frc/StateSpaceUtil.h
@@ -227,6 +227,24 @@ Eigen::Matrix<double, N, 1> MakeWhiteNoiseVector(
 }
 
 /**
+ * Converts a Pose2d into a vector of [x, y, theta].
+ *
+ * @param pose The pose that is being represented.
+ *
+ * @return The vector.
+ */
+Eigen::Matrix<double, 3, 1> PoseTo3dVector(const Pose2d& pose);
+
+/**
+ * Converts a Pose2d into a vector of [x, y, std::cos(theta), std::sin(theta)].
+ *
+ * @param pose The pose that is being represented.
+ *
+ * @return The vector.
+ */
+Eigen::Matrix<double, 4, 1> PoseTo4dVector(const Pose2d& pose);
+
+/**
  * Returns true if (A, B) is a stabilizable pair.
  *
  * (A,B) is stabilizable if and only if the uncontrollable eigenvalues of A, if

--- a/wpimath/src/main/native/include/frc/interpolatable/TimeInterpolatableBuffer.h
+++ b/wpimath/src/main/native/include/frc/interpolatable/TimeInterpolatableBuffer.h
@@ -1,0 +1,78 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+#include <utility>
+#include <vector>
+
+#include <wpi/MathExtras.h>
+
+#include "units/time.h"
+
+namespace frc {
+
+template <typename T>
+class TimeInterpolatableBuffer {
+ public:
+  void addSample(units::second_t time, T sample) {
+    // Add the new state into the vector.
+    m_pastSnapshots.emplace_back(time, sample);
+
+    // Remove the oldest snapshot if the vector exceeds our maximum size.
+    if (m_pastSnapshots.size() > kMaxPastObserverStates) {
+      m_pastSnapshots.erase(m_pastSnapshots.begin());
+    }
+  }
+
+  void Clear() { m_pastSnapshots.clear(); }
+
+  /**
+   * Sample the buffer at the given time. If there are no elements in the
+   * buffer, calling this function results in undefined behavior.
+   */
+  T Sample(units::second_t time) {
+    // We will perform a binary search to find the index of the element in the
+    // vector that has a timestamp that is equal to or greater than the vision
+    // measurement timestamp.
+
+    if (m_pastSnapshots.size() < 2) return m_pastSnapshots[0].second;
+
+    int low = 0;
+    int high = m_pastSnapshots.size() - 1;
+
+    while (low != high) {
+      int mid = (low + high) / 2.0;
+      if (m_pastSnapshots[mid].first < time) {
+        // This index and everything under it are less than the requested
+        // time. Therefore, we can discard them.
+        low = mid + 1;
+      } else {
+        // t is at least as large as the element at this index. This means that
+        // anything after it cannot be what we are looking for.
+        high = mid;
+      }
+    }
+
+    // Because low and high are now the same (both "high"), we decrement low
+    low -= 1;
+
+    std::pair<units::second_t, T> bottomBound = m_pastSnapshots[low];
+    std::pair<units::second_t, T> topBound = m_pastSnapshots[high];
+
+    return wpi::Lerp(
+        bottomBound.second, topBound.second,
+        (time - bottomBound.first) / (topBound.first - bottomBound.first));
+  }
+
+ private:
+  static constexpr size_t kMaxPastObserverStates = 300;
+  std::vector<std::pair<units::second_t, T>> m_pastSnapshots;
+};
+
+}  // namespace frc

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.h
@@ -76,6 +76,23 @@ class SwerveDriveKinematics {
         wpi::math::MathUsageId::kKinematics_SwerveDrive, 1);
   }
 
+  explicit SwerveDriveKinematics(
+      const std::array<Translation2d, NumModules>& wheels)
+      : m_modules{wheels} {
+    for (size_t i = 0; i < NumModules; i++) {
+      // clang-format off
+      m_inverseKinematics.template block<2, 3>(i * 2, 0) <<
+        1, 0, (-m_modules[i].Y()).template to<double>(),
+        0, 1, (+m_modules[i].X()).template to<double>();
+      // clang-format on
+    }
+
+    m_forwardKinematics = m_inverseKinematics.householderQr();
+
+    wpi::math::MathSharedStore::ReportUsage(
+        wpi::math::MathUsageId::kKinematics_SwerveDrive, 1);
+  }
+
   SwerveDriveKinematics(const SwerveDriveKinematics&) = default;
 
   /**

--- a/wpimath/src/main/native/include/frc/trajectory/Trajectory.h
+++ b/wpimath/src/main/native/include/frc/trajectory/Trajectory.h
@@ -148,20 +148,6 @@ class Trajectory {
  private:
   std::vector<State> m_states;
   units::second_t m_totalTime = 0_s;
-
-  /**
-   * Linearly interpolates between two values.
-   *
-   * @param startValue The start value.
-   * @param endValue The end value.
-   * @param t The fraction for interpolation.
-   *
-   * @return The interpolated value.
-   */
-  template <typename T>
-  static T Lerp(const T& startValue, const T& endValue, const double t) {
-    return startValue + (endValue - startValue) * t;
-  }
 };
 
 void to_json(wpi::json& json, const Trajectory::State& state);

--- a/wpimath/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVelocitySystemConstraint.h
+++ b/wpimath/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVelocitySystemConstraint.h
@@ -1,0 +1,50 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include "frc/kinematics/DifferentialDriveKinematics.h"
+#include "frc/system/LinearSystem.h"
+#include "frc/trajectory/constraint/TrajectoryConstraint.h"
+#include "units/voltage.h"
+
+namespace frc {
+/**
+ * A class that enforces constraints on differential drive velocity based on
+ * a differential drive {@link LinearSystem} and the drive kinematics. Ensures
+ * that the acceleration of any wheel of the robot while following the
+ * trajectory is never higher than what can be achieved with the given maximum
+ * voltage.
+ */
+class DifferentialDriveVelocitySystemConstraint : public TrajectoryConstraint {
+ public:
+  /**
+   * Creates a new DifferentialDriveVelocitySystemConstraint.
+   *
+   * @param system      A {@link LinearSystem} representing the drivetrain..
+   * @param kinematics  A kinematics component describing the drive geometry.
+   * @param maxVoltage  The maximum voltage available to the motors while
+   * following the path. Should be somewhat less than the nominal battery
+   * voltage (12V) to account for "voltage sag" due to current draw.
+   */
+  DifferentialDriveVelocitySystemConstraint(
+      const LinearSystem<2, 2, 2>& system,
+      const DifferentialDriveKinematics& kinematics, units::volt_t maxVoltage);
+
+  units::meters_per_second_t MaxVelocity(
+      const Pose2d& pose, units::curvature_t curvature,
+      units::meters_per_second_t velocity) const override;
+
+  MinMax MinMaxAcceleration(const Pose2d& pose, units::curvature_t curvature,
+                            units::meters_per_second_t speed) const override;
+
+ private:
+  const LinearSystem<2, 2, 2>& m_system;
+  const DifferentialDriveKinematics& m_kinematics;
+  units::volt_t m_maxVoltage;
+};
+}  // namespace frc

--- a/wpimath/src/test/java/edu/wpi/first/wpilibj/controller/ControlAffinePlantInversionFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/wpilibj/controller/ControlAffinePlantInversionFeedforwardTest.java
@@ -40,12 +40,11 @@ class ControlAffinePlantInversionFeedforwardTest {
     Matrix<N2, N1> B = VecBuilder.fill(0, 1);
 
     ControlAffinePlantInversionFeedforward<N2, N1> feedforward =
-            new ControlAffinePlantInversionFeedforward<N2, N1>(
-                    Nat.N2(),
-                    Nat.N1(),
-                    this::getStateDynamics,
-                    B,
-                    0.02);
+        new ControlAffinePlantInversionFeedforward<N2, N1>(
+            Nat.N2(),
+            Nat.N1(),
+            this::getDynamics,
+            0.02);
 
     assertEquals(48.0, feedforward.calculate(
             VecBuilder.fill(2, 2),

--- a/wpimath/src/test/java/edu/wpi/first/wpilibj/trajectory/DifferentialDriveVelocitySystemConstraintTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/wpilibj/trajectory/DifferentialDriveVelocitySystemConstraintTest.java
@@ -1,0 +1,186 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.trajectory;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveVelocitySystemConstraint;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveVoltageConstraint;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class DifferentialDriveVelocitySystemConstraintTest {
+  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  @Test
+  void testDifferentialDriveVelocitySystemConstraint() {
+    double maxVoltage = 10;
+
+    // Pick an unreasonably large kA to ensure the constraint has to do some work
+    var system = LinearSystemId.identifyDrivetrainSystem(1, 3, 1, 3);
+    var kinematics = new DifferentialDriveKinematics(0.5);
+    //    var constraint = new DifferentialDriveVelocitySystemConstraint(system,
+    //          kinematics,
+    //          maxVoltage);
+
+    var constraint = new DifferentialDriveVoltageConstraint(
+        new SimpleMotorFeedforward(0, 1, 3), kinematics, 10);
+
+    Trajectory trajectory = TrajectoryGeneratorTest.getTrajectory(
+          Collections.singletonList(constraint));
+    //    Trajectory trajectory = TrajectoryGenerator.generateTrajectory(
+    //      List.of(new Pose2d(), new Pose2d(new Translation2d(10, 10),
+    //          Rotation2d.fromDegrees(90))),
+    //      new TrajectoryConfig(300000000000.0, 300000000000.00).addConstraint(constraint)
+    //    );
+
+    var duration = trajectory.getTotalTimeSeconds();
+    var t = 0.0;
+    var dt = 0.02;
+    var previousSpeeds = new DifferentialDriveWheelSpeeds(0, 0);
+
+    List<Double> vleft = new ArrayList<>();
+    List<Double> vright = new ArrayList<>();
+
+    System.out.println("time, uleft, uright, vleft, vright, vx, max_vleft, curvature");
+
+    while (t < duration) {
+      var point = trajectory.sample(t);
+      var chassisSpeeds = new ChassisSpeeds(
+            point.velocityMetersPerSecond, 0,
+            point.velocityMetersPerSecond * point.curvatureRadPerMeter
+      );
+
+      var wheelSpeeds = kinematics.toWheelSpeeds(chassisSpeeds);
+
+      var x = new MatBuilder<>(Nat.N2(), Nat.N1()).fill(wheelSpeeds.leftMetersPerSecond,
+            wheelSpeeds.rightMetersPerSecond);
+
+      var leftAccel = (wheelSpeeds.leftMetersPerSecond - previousSpeeds.leftMetersPerSecond) / dt;
+      var rightAccel = (wheelSpeeds.rightMetersPerSecond
+            - previousSpeeds.rightMetersPerSecond) / dt;
+      var xDot = VecBuilder.fill(leftAccel, rightAccel);
+
+      var u = (system.getB().inv()).times(xDot.minus(system.getA().times(x)));
+
+      double left = u.get(0, 0);
+      double right = u.get(1, 0);
+
+      vleft.add(left);
+      vright.add(right);
+
+      t += dt;
+      previousSpeeds = wheelSpeeds;
+
+      System.out.println(String.format("%s, %s, %s, %s, %s, %s, %s, %s", t, u.get(0, 0),
+          u.get(1, 0),
+          wheelSpeeds.leftMetersPerSecond, wheelSpeeds.rightMetersPerSecond,
+          chassisSpeeds.vxMetersPerSecond, constraint
+          .getMaxVelocityMetersPerSecond(point.poseMeters, point.curvatureRadPerMeter,
+          point.velocityMetersPerSecond), point.curvatureRadPerMeter));
+
+      //      System.out.println(left + ", " + right);
+      //      assertTrue((-10.1 <= left) && (left <= 10.1));
+      //      assertTrue((-10.1 <= right) && (right <= 10.1));
+
+    }
+    //var c = new XYChartBuilder().build();
+    //c.addSeries("left voltage", vleft);
+    //c.addSeries("right voltage", vright);
+    // new SwingWrapper<>(c).displayChart();
+    // try {
+    //  Thread.sleep(1000000000);
+    // } catch (InterruptedException e) {
+    // }
+  }
+
+  @Test
+  void testEndpointHighCurvature() {
+    double maxVoltage = 10;
+
+    var system = LinearSystemId.identifyDrivetrainSystem(1, 3, 1, 3);
+
+    // Large trackwidth - need to test with radius of curvature less than half of trackwidth
+    var kinematics = new DifferentialDriveKinematics(3);
+    var constraint = new DifferentialDriveVelocitySystemConstraint(system,
+          kinematics,
+          maxVoltage);
+
+    var config = new TrajectoryConfig(12, 12).addConstraint(constraint);
+
+    // Radius of curvature should be ~1 meter.
+    assertDoesNotThrow(() -> TrajectoryGenerator.generateTrajectory(
+          new Pose2d(1, 0, Rotation2d.fromDegrees(90)),
+          new ArrayList<Translation2d>(),
+          new Pose2d(0, 1, Rotation2d.fromDegrees(180)),
+          config));
+
+    assertDoesNotThrow(() -> TrajectoryGenerator.generateTrajectory(
+          new Pose2d(0, 1, Rotation2d.fromDegrees(180)),
+          new ArrayList<Translation2d>(),
+          new Pose2d(1, 0, Rotation2d.fromDegrees(90)),
+          config.setReversed(true)));
+
+  }
+
+  @Test
+  @SuppressWarnings("LocalVariableName")
+  void testGraph() throws IOException {
+    double maxVoltage = 10;
+
+    // Pick an unreasonably large kA to ensure the constraint has to do some work
+    var system = LinearSystemId.identifyDrivetrainSystem(1, 3, 1, 3);
+    var kinematics = new DifferentialDriveKinematics(0.5);
+
+    var constraint = new DifferentialDriveVelocitySystemConstraint(system, kinematics, maxVoltage);
+
+    var velocity = 12.0;
+    var curvature = 10.0;
+
+    var wheelSpeeds = kinematics.toWheelSpeeds(new ChassisSpeeds(velocity, 0,
+        velocity
+        * curvature));
+
+    var x = VecBuilder.fill(wheelSpeeds.leftMetersPerSecond,
+        wheelSpeeds.rightMetersPerSecond);
+
+    var writer = new BufferedWriter(new FileWriter(Path.of("D:\\Documents\\out.csv").toString()));
+
+    System.out.println(x);
+
+    // iterate by steps of 1 over the voltage range
+    for (int uLeft = -10; uLeft <= 10; uLeft++) {
+      for (int uRight = -10; uRight <= 10; uRight++) {
+        var u = VecBuilder.fill(uLeft, uRight);
+        var xdot = system.getA().times(x).plus(system.getB().times(u));
+        writer.write(String.format("%s,%s,%s", uLeft, uRight, (xdot.get(0, 0)
+            + xdot.get(1, 0)) / 2.0));
+        writer.newLine();
+        writer.flush();
+      }
+    }
+  }
+}

--- a/wpimath/src/test/native/cpp/system/LinearSystemIDTest.cpp
+++ b/wpimath/src/test/native/cpp/system/LinearSystemIDTest.cpp
@@ -70,8 +70,6 @@ TEST(LinearSystemIDTest, IdentifyVelocitySystem) {
   double ka = 0.5;
   auto model = frc::LinearSystemId::IdentifyVelocitySystem(kv, ka);
 
-  std::cout << model.A() << std::endl << model.B() << std::endl;
-
   ASSERT_TRUE(model.A().isApprox(frc::MakeMatrix<1, 1>(-kv / ka), 0.001));
   ASSERT_TRUE(model.B().isApprox(frc::MakeMatrix<1, 1>(1.0 / ka), 0.001));
 }

--- a/wpimath/src/test/native/cpp/trajectory/DifferentialDriveVelocitySystemTest.cpp
+++ b/wpimath/src/test/native/cpp/trajectory/DifferentialDriveVelocitySystemTest.cpp
@@ -1,0 +1,90 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <iostream>
+#include <memory>
+#include <vector>
+
+#include <wpi/MathExtras.h>
+
+#include "frc/geometry/Pose2d.h"
+#include "frc/system/LinearSystem.h"
+#include "frc/system/plant/LinearSystemId.h"
+#include "frc/trajectory/TrajectoryGenerator.h"
+#include "frc/trajectory/constraint/DifferentialDriveVelocitySystemConstraint.h"
+#include "gtest/gtest.h"
+#include "trajectory/TestTrajectory.h"
+#include "units/length.h"
+
+using namespace frc;
+
+TEST(DifferentialDriveVelocitySystemTest, Constraint) {
+  const auto maxVoltage = 10_V;
+
+  // Pick an unreasonably large kA to ensure the constraint has to do some work
+  const LinearSystem<2, 2, 2> system =
+      frc::LinearSystemId::IdentifyDrivetrainSystem(1.0, 3.0, 1.0, 3.0);
+  const DifferentialDriveKinematics kinematics{0.5_m};
+  auto config = TrajectoryConfig(12_mps, 12_mps_sq);
+  config.AddConstraint(DifferentialDriveVelocitySystemConstraint(
+      system, kinematics, maxVoltage));
+
+  auto trajectory = TestTrajectory::GetTrajectory(config);
+
+  units::second_t time = 0_s;
+  units::second_t dt = 20_ms;
+  units::second_t duration = trajectory.TotalTime();
+
+  while (time < duration) {
+    const Trajectory::State point = trajectory.Sample(time);
+    time += dt;
+
+    const ChassisSpeeds chassisSpeeds{point.velocity, 0_mps,
+                                      point.velocity * point.curvature};
+
+    auto [left, right] = kinematics.ToWheelSpeeds(chassisSpeeds);
+
+    auto x = frc::MakeMatrix<2, 1>(left.to<double>(), right.to<double>());
+
+    // Not really a strictly-correct test as we're using the chassis accel
+    // instead of the wheel accel, but much easier than doing it "properly" and
+    // a reasonable check anyway
+    auto xDot = frc::MakeMatrix<2, 1>(point.acceleration.to<double>(),
+                                      point.acceleration.to<double>());
+
+    auto u = system.B().inverse() * (xDot - (system.A() * x));
+
+    EXPECT_TRUE(((-maxVoltage.to<double>() - 0.5) <= u(0)) &&
+                (u(0) <= (maxVoltage.to<double>() + 0.5)));
+    EXPECT_TRUE(((-maxVoltage.to<double>() - 0.5) <= u(1)) &&
+                (u(1) <= (maxVoltage.to<double>() + 0.5)));
+  }
+}
+
+TEST(DifferentialDriveVelocitySystemTest, HighCurvature) {
+  const auto maxVoltage = 10_V;
+
+  const LinearSystem<2, 2, 2> system =
+      frc::LinearSystemId::IdentifyDrivetrainSystem(1.0, 3.0, 1.0, 3.0);
+  // Large trackwidth - need to test with radius of curvature less than half of
+  // trackwidth
+  const DifferentialDriveKinematics kinematics{3_m};
+
+  auto config = TrajectoryConfig(12_fps, 12_fps_sq);
+  config.AddConstraint(DifferentialDriveVelocitySystemConstraint(
+      system, kinematics, maxVoltage));
+
+  EXPECT_NO_FATAL_FAILURE(TrajectoryGenerator::GenerateTrajectory(
+      Pose2d{1_m, 0_m, Rotation2d{90_deg}}, std::vector<Translation2d>{},
+      Pose2d{0_m, 1_m, Rotation2d{180_deg}}, config));
+
+  config.SetReversed(true);
+
+  EXPECT_NO_FATAL_FAILURE(TrajectoryGenerator::GenerateTrajectory(
+      Pose2d{0_m, 1_m, Rotation2d{180_deg}}, std::vector<Translation2d>{},
+      Pose2d{1_m, 0_m, Rotation2d{90_deg}}, config));
+}

--- a/wpiutil/src/main/native/include/wpi/MathExtras.h
+++ b/wpiutil/src/main/native/include/wpi/MathExtras.h
@@ -845,6 +845,20 @@ constexpr int sgn(T val) {
   return (T(0) < val) - (val < T(0));
 }
 
+/**
+ * Linearly interpolates between two values.
+ *
+ * @param startValue The start value.
+ * @param endValue The end value.
+ * @param t The fraction for interpolation.
+ *
+ * @return The interpolated value.
+ */
+template <typename T>
+static T Lerp(const T& startValue, const T& endValue, const double t) {
+  return startValue + (endValue - startValue) * t;
+}
+
 } // namespace wpi
 
 #endif


### PR DESCRIPTION
This PR supersedes #2468 , #1832 and #990

Adds state-space control classes to WPILib. We utilize the DARE solver from MIT's DRAKE library in order to solve the DARE on the RoboRIO, rather than generating it using python as previous PRs did. 

The state-space classes added fit into one of the following catagories
- State-space systems, in the `LinearSystem` class. C++ and Java include factory methods to identify state-space systems of common frc mechanisms like drivetrains, arms and elevators. Also included are factory methods that use the `kV` and `kA` calculated by frc-characterization.
- Model-based estimators, in the `KalmanFilter`, `ExtendedKalmanFilter` and `UnscentedKalmanFilter` classes
  - These are wrapped for Swerve, Mecanum and Differential Drive classes to fuse odometry and external measurements such as vision in the Pose Estimator classes
- Controllers. The main class is the `LinearQuadraticRegulator`, but we will be splitting that into a `PlantInversionFeedforward` class and a LQR class instead. 
  - Also LTV Unicycle and LTV Diff Drive controllers, which are similar to RAMSETE but have superior performance.

Currently underway is a rewrite of LTV unicycle and diff drive controllers to recompute a LQR at every timestep rather than using an approximation.

Things we still have to do:

- [x] Resolve bug in Java UnscentedKalmanFilter
- [x] Resolve bug in DifferentialDriveStateEstimator
- [x] Split LQR
- [x] Add LTV Diff Drive controller (There's a PR for this open to my branch that we're going to be merging soon)
- [x] Add more examples to Java and C++
- [ ] Fix failing C++ tests
- [ ] Write C++/Java simulation code
- [ ] Write C++/Java sim code examples
- [ ] Autotuning support in the `PIDController` class?
- [ ] Square root UKF changes
- [x] Add simulation periodic method to command-based subsystems
- [ ] Add simulation physics objects