### PR TITLE
[wpilibc] Fix uninitialized variable in Trajectory class

### DIFF
--- a/wpilibc/src/main/native/include/frc/trajectory/Trajectory.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/Trajectory.h
@@ -129,7 +129,7 @@ class Trajectory {
 
  private:
   std::vector<State> m_states;
-  units::second_t m_totalTime;
+  units::second_t m_totalTime = 0_s;
 
   /**
    * Linearly interpolates between two values.


### PR DESCRIPTION
Valgrind caught this one. If you default initialize a Trajectory, it
doesn't initialize m_totalTime. This means a subsequent call to
Trajectory::TotalTime() returns the value of an uninitialized variable.
3512's software was using 0_s as a sentinel value for when a trajectory
was empty. We didn't notice a problem before because Linux zero-inits
memory.