### PR TITLE
[wpilib] Throw separate exception for constraint misbehavior

### DIFF
--- a/wpilibc/src/main/native/cpp/trajectory/TrajectoryParameterizer.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/TrajectoryParameterizer.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibc/src/main/native/cpp/trajectory/TrajectoryParameterizer.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/TrajectoryParameterizer.cpp
@@ -31,6 +31,8 @@
 
 #include "frc/trajectory/TrajectoryParameterizer.h"
 
+#include <string>
+
 using namespace frc;
 
 Trajectory TrajectoryParameterizer::TimeParameterizeTrajectory(
@@ -186,7 +188,8 @@ Trajectory TrajectoryParameterizer::TimeParameterizeTrajectory(
         // delta_x = v * t
         dt = ds / v;
       } else {
-        throw std::runtime_error("Something went wrong at iteration" + i +
+        throw std::runtime_error("Something went wrong at iteration" +
+                                 std::to_string(i) +
                                  " of time parameterization.");
       }
     }

--- a/wpilibc/src/main/native/cpp/trajectory/TrajectoryParameterizer.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/TrajectoryParameterizer.cpp
@@ -213,6 +213,14 @@ void TrajectoryParameterizer::EnforceAccelerationLimits(
     auto minMaxAccel = constraint->MinMaxAcceleration(
         state->pose.first, state->pose.second, state->maxVelocity * factor);
 
+    if (minMaxAccel.minAcceleration > minMaxAccel.maxAcceleration) {
+      throw std::runtime_error(
+          "The constraint's min acceleration was greater than its max "
+          "acceleration. To debug this, remove all constraints from the config "
+          "and add each one individually. If the offending constraint was "
+          "packaged with WPILib, please file a bug report.");
+    }
+
     state->minAcceleration = units::math::max(
         state->minAcceleration,
         reverse ? -minMaxAccel.maxAcceleration : minMaxAccel.minAcceleration);

--- a/wpilibc/src/main/native/cpp/trajectory/TrajectoryParameterizer.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/TrajectoryParameterizer.cpp
@@ -186,8 +186,8 @@ Trajectory TrajectoryParameterizer::TimeParameterizeTrajectory(
         // delta_x = v * t
         dt = ds / v;
       } else {
-        throw std::runtime_error(
-            "Something went wrong during trajectory generation.");
+        throw std::runtime_error("Something went wrong at iteration" + i +
+                                 " of time parameterization.");
       }
     }
 

--- a/wpilibc/src/main/native/cpp/trajectory/TrajectoryParameterizer.cpp
+++ b/wpilibc/src/main/native/cpp/trajectory/TrajectoryParameterizer.cpp
@@ -188,7 +188,7 @@ Trajectory TrajectoryParameterizer::TimeParameterizeTrajectory(
         // delta_x = v * t
         dt = ds / v;
       } else {
-        throw std::runtime_error("Something went wrong at iteration" +
+        throw std::runtime_error("Something went wrong at iteration " +
                                  std::to_string(i) +
                                  " of time parameterization.");
       }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
@@ -266,6 +266,13 @@ public final class TrajectoryParameterizer {
           state.pose.poseMeters, state.pose.curvatureRadPerMeter,
           state.maxVelocityMetersPerSecond * factor);
 
+      if (minMaxAccel.minAccelerationMetersPerSecondSq
+          > minMaxAccel.maxAccelerationMetersPerSecondSq) {
+        throw new RuntimeException("The constraint's min acceleration was greater than its" +
+            "max acceleration. \n Offending Constraint: " + constraint.getClass().getName() +
+            "\n If the offending constraint was packaged with WPILib, please file a bug report.");
+      }
+
       state.minAccelerationMetersPerSecondSq = Math.max(state.minAccelerationMetersPerSecondSq,
           reverse ? -minMaxAccel.maxAccelerationMetersPerSecondSq
               : minMaxAccel.minAccelerationMetersPerSecondSq);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
@@ -236,7 +236,8 @@ public final class TrajectoryParameterizer {
           // delta_x = v * t
           dt = ds / velocityMetersPerSecond;
         } else {
-          throw new RuntimeException("Something went wrong");
+          throw new RuntimeException("Something went wrong at iteration " + i
+              + " of time parameterization.");
         }
       }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
@@ -269,8 +269,8 @@ public final class TrajectoryParameterizer {
 
       if (minMaxAccel.minAccelerationMetersPerSecondSq
           > minMaxAccel.maxAccelerationMetersPerSecondSq) {
-        throw new RuntimeException("The constraint's min acceleration was greater than its" +
-            "max acceleration. \n Offending Constraint: " + constraint.getClass().getName() +
+        throw new RuntimeException("The constraint's min acceleration was greater than its " +
+            "max acceleration.\n Offending Constraint: " + constraint.getClass().getName() +
             "\n If the offending constraint was packaged with WPILib, please file a bug report.");
       }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
@@ -69,8 +69,7 @@ public final class TrajectoryParameterizer {
    * @return The trajectory.
    */
   @SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.CyclomaticComplexity",
-      "PMD.NPathComplexity", "PMD.AvoidInstantiatingObjectsInLoops",
-      "PMD.AvoidThrowingRawExceptionTypes"})
+      "PMD.NPathComplexity", "PMD.AvoidInstantiatingObjectsInLoops"})
   public static Trajectory timeParameterizeTrajectory(
       List<PoseWithCurvature> points,
       List<TrajectoryConstraint> constraints,
@@ -236,7 +235,7 @@ public final class TrajectoryParameterizer {
           // delta_x = v * t
           dt = ds / velocityMetersPerSecond;
         } else {
-          throw new RuntimeException("Something went wrong at iteration " + i
+          throw new TrajectoryGenerationException("Something went wrong at iteration " + i
               + " of time parameterization.");
         }
       }
@@ -257,7 +256,6 @@ public final class TrajectoryParameterizer {
     return new Trajectory(states);
   }
 
-  @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
   private static void enforceAccelerationLimits(boolean reverse,
                                                 List<TrajectoryConstraint> constraints,
                                                 ConstrainedState state) {
@@ -270,8 +268,9 @@ public final class TrajectoryParameterizer {
 
       if (minMaxAccel.minAccelerationMetersPerSecondSq
           > minMaxAccel.maxAccelerationMetersPerSecondSq) {
-        throw new RuntimeException("The constraint's min acceleration was greater than its "
-            + "max acceleration.\n Offending Constraint: " + constraint.getClass().getName()
+        throw new TrajectoryGenerationException("The constraint's min acceleration "
+            + "was greater than its max acceleration.\n Offending Constraint: "
+            + constraint.getClass().getName()
             + "\n If the offending constraint was packaged with WPILib, please file a bug report.");
       }
 
@@ -307,6 +306,12 @@ public final class TrajectoryParameterizer {
 
     ConstrainedState() {
       pose = new PoseWithCurvature();
+    }
+  }
+
+  public static class TrajectoryGenerationException extends RuntimeException {
+    public TrajectoryGenerationException(String message) {
+      super(message);
     }
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
@@ -257,6 +257,7 @@ public final class TrajectoryParameterizer {
     return new Trajectory(states);
   }
 
+  @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
   private static void enforceAccelerationLimits(boolean reverse,
                                                 List<TrajectoryConstraint> constraints,
                                                 ConstrainedState state) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/TrajectoryParameterizer.java
@@ -269,9 +269,9 @@ public final class TrajectoryParameterizer {
 
       if (minMaxAccel.minAccelerationMetersPerSecondSq
           > minMaxAccel.maxAccelerationMetersPerSecondSq) {
-        throw new RuntimeException("The constraint's min acceleration was greater than its " +
-            "max acceleration.\n Offending Constraint: " + constraint.getClass().getName() +
-            "\n If the offending constraint was packaged with WPILib, please file a bug report.");
+        throw new RuntimeException("The constraint's min acceleration was greater than its "
+            + "max acceleration.\n Offending Constraint: " + constraint.getClass().getName()
+            + "\n If the offending constraint was packaged with WPILib, please file a bug report.");
       }
 
       state.minAccelerationMetersPerSecondSq = Math.max(state.minAccelerationMetersPerSecondSq,


### PR DESCRIPTION
The most common mistake users (including contributors to WPILib) seem to make while creating new constraints is ignoring some sort of edge case that causes the calculated minimum acceleration to be greater than the calculated maximum acceleration.

This specialized exception, with its detailed error message, should make it easier and quicker for said users to debug and fix bugs within their constraints.