### PR TITLE
[wpilibc] Fix doxygen comments

### DIFF
--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveKinematicsConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/DifferentialDriveKinematicsConstraint.h
@@ -12,13 +12,13 @@
 #include "frc/kinematics/DifferentialDriveKinematics.h"
 #include "frc/trajectory/constraint/TrajectoryConstraint.h"
 
+namespace frc {
 /**
  * A class that enforces constraints on the differential drive kinematics.
  * This can be used to ensure that the trajectory is constructed so that the
  * commanded velocities for both sides of the drivetrain stay below a certain
  * limit.
  */
-namespace frc {
 class DifferentialDriveKinematicsConstraint : public TrajectoryConstraint {
  public:
   DifferentialDriveKinematicsConstraint(DifferentialDriveKinematics kinematics,

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/MecanumDriveKinematicsConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/MecanumDriveKinematicsConstraint.h
@@ -14,7 +14,6 @@
 #include "frc/kinematics/MecanumDriveKinematics.h"
 #include "frc/trajectory/constraint/TrajectoryConstraint.h"
 
-
 namespace frc {
 /**
  * A class that enforces constraints on the mecanum drive kinematics.

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/MecanumDriveKinematicsConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/MecanumDriveKinematicsConstraint.h
@@ -14,13 +14,14 @@
 #include "frc/kinematics/MecanumDriveKinematics.h"
 #include "frc/trajectory/constraint/TrajectoryConstraint.h"
 
+
+namespace frc {
 /**
- * A class that enforces constraints on the differential drive kinematics.
+ * A class that enforces constraints on the mecanum drive kinematics.
  * This can be used to ensure that the trajectory is constructed so that the
- * commanded velocities for both sides of the drivetrain stay below a certain
+ * commanded velocities for wheels of the drivetrain stay below a certain
  * limit.
  */
-namespace frc {
 class MecanumDriveKinematicsConstraint : public TrajectoryConstraint {
  public:
   MecanumDriveKinematicsConstraint(MecanumDriveKinematics kinematics,

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.h
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.h
@@ -14,15 +14,15 @@
 #include "frc/kinematics/SwerveDriveKinematics.h"
 #include "frc/trajectory/constraint/TrajectoryConstraint.h"
 
-/**
- * A class that enforces constraints on the differential drive kinematics.
- * This can be used to ensure that the trajectory is constructed so that the
- * commanded velocities for both sides of the drivetrain stay below a certain
- * limit.
- */
 namespace frc {
 
 template <size_t NumModules>
+
+/**
+ * A class that enforces constraints on the swerve drive kinematics.
+ * This can be used to ensure that the trajectory is constructed so that the
+ * commanded velocities of the wheels stay below a certain limit.
+ */
 class SwerveDriveKinematicsConstraint : public TrajectoryConstraint {
  public:
   SwerveDriveKinematicsConstraint(

--- a/wpilibc/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.inc
+++ b/wpilibc/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.inc
@@ -7,16 +7,15 @@
 
 #pragma once
 
-/**
- * A class that enforces constraints on the differential drive kinematics.
- * This can be used to ensure that the trajectory is constructed so that the
- * commanded velocities for both sides of the drivetrain stay below a certain
- * limit.
- */
-
 namespace frc {
 
 template <size_t NumModules>
+
+/**
+ * A class that enforces constraints on the swerve drive kinematics.
+ * This can be used to ensure that the trajectory is constructed so that the
+ * commanded velocities of the wheels stay below a certain limit.
+ */
 SwerveDriveKinematicsConstraint<NumModules>::SwerveDriveKinematicsConstraint(
     frc::SwerveDriveKinematics<NumModules> kinematics,
     units::meters_per_second_t maxSpeed)


### PR DESCRIPTION
Apply doxygen comments to class instead of frc namespace
Correct references to differential drive