### PR TITLE
[wpilibc] Remove incorrect timer rollover

### DIFF
--- a/wpilibc/src/main/native/cpp/Timer.cpp
+++ b/wpilibc/src/main/native/cpp/Timer.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -24,8 +24,6 @@ double GetTime() { return frc2::GetTime().to<double>(); }
 }  // namespace frc
 
 using namespace frc;
-
-const double Timer::kRolloverTime = frc2::Timer::kRolloverTime.to<double>();
 
 Timer::Timer() { Reset(); }
 

--- a/wpilibc/src/main/native/cpp/frc2/Timer.cpp
+++ b/wpilibc/src/main/native/cpp/frc2/Timer.cpp
@@ -36,9 +36,6 @@ units::second_t GetTime() {
 
 using namespace frc2;
 
-// for compatibility with msvc12--see C2864
-const units::second_t Timer::kRolloverTime = units::second_t((1ll << 32) / 1e6);
-
 Timer::Timer() { Reset(); }
 
 Timer::Timer(const Timer& rhs)
@@ -77,13 +74,6 @@ units::second_t Timer::Get() const {
 
   std::scoped_lock lock(m_mutex);
   if (m_running) {
-    // If the current time is before the start time, then the FPGA clock rolled
-    // over. Compensate by adding the ~71 minutes that it takes to roll over to
-    // the current time.
-    if (currentTime < m_startTime) {
-      currentTime += kRolloverTime;
-    }
-
     result = (currentTime - m_startTime) + m_accumulatedTime;
   } else {
     result = m_accumulatedTime;

--- a/wpilibc/src/main/native/include/frc/Timer.h
+++ b/wpilibc/src/main/native/include/frc/Timer.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2008-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2008-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -131,9 +131,6 @@ class Timer {
    * @return Time remaining in current match period (auto or teleop)
    */
   static double GetMatchTime();
-
-  // The time, in seconds, at which the 32-bit FPGA timestamp rolls over to 0
-  static const double kRolloverTime;
 
  private:
   frc2::Timer m_timer;

--- a/wpilibc/src/main/native/include/frc2/Timer.h
+++ b/wpilibc/src/main/native/include/frc2/Timer.h
@@ -144,9 +144,6 @@ class Timer {
    */
   static units::second_t GetMatchTime();
 
-  // The time, in seconds, at which the 32-bit FPGA timestamp rolls over to 0
-  static const units::second_t kRolloverTime;
-
  private:
   units::second_t m_startTime = 0_s;
   units::second_t m_accumulatedTime = 0_s;


### PR DESCRIPTION
If the 64 bit FPGA timer rolls over, a 32 bit value is added for the rollover, an artifact of when it was a 32 bit timer. The 64 bit microsecond timer won't rollover for 500k years so remove the check for simplicity.
Fixes #2504