### PR TITLE
[sim] Provide method to set the runtime type

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/sim/SimHooks.java
+++ b/hal/src/main/java/edu/wpi/first/hal/sim/SimHooks.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -11,6 +11,10 @@ import edu.wpi.first.hal.sim.mockdata.SimulatorJNI;
 
 public final class SimHooks {
   private SimHooks() {
+  }
+
+  public static void setHALRuntimeType(int type) {
+    SimulatorJNI.setRuntimeType(type);
   }
 
   public static void waitForProgramStart() {

--- a/hal/src/main/java/edu/wpi/first/hal/sim/mockdata/SimulatorJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/sim/mockdata/SimulatorJNI.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -10,6 +10,7 @@ package edu.wpi.first.hal.sim.mockdata;
 import edu.wpi.first.hal.JNIWrapper;
 
 public class SimulatorJNI extends JNIWrapper {
+  public static native void setRuntimeType(int type);
   public static native void waitForProgramStart();
   public static native void setProgramStarted();
   public static native void restartTiming();

--- a/hal/src/main/native/include/mockdata/MockHooks.h
+++ b/hal/src/main/native/include/mockdata/MockHooks.h
@@ -7,9 +7,11 @@
 
 #pragma once
 
+#include "hal/HALBase.h"
 #include "hal/Types.h"
 
 extern "C" {
+void HALSIM_SetRuntimeType(HAL_RuntimeType type);
 void HALSIM_WaitForProgramStart(void);
 void HALSIM_SetProgramStarted(void);
 HAL_Bool HALSIM_GetProgramStarted(void);

--- a/hal/src/main/native/include/simulation/SimHooks.h
+++ b/hal/src/main/native/include/simulation/SimHooks.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -11,6 +11,8 @@
 
 namespace frc {
 namespace sim {
+
+void SetRuntimeType(HAL_RuntimeType type) { HALSIM_SetRuntimeType(type); }
 
 void WaitForProgramStart() { HALSIM_WaitForProgramStart(); }
 

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -22,6 +22,8 @@
 
 using namespace hal;
 
+static HAL_RuntimeType runtimeType{HAL_Mock};
+
 namespace hal {
 namespace init {
 void InitializeHAL() {
@@ -215,7 +217,9 @@ const char* HAL_GetErrorMessage(int32_t code) {
   }
 }
 
-HAL_RuntimeType HAL_GetRuntimeType(void) { return HAL_Mock; }
+HAL_RuntimeType HAL_GetRuntimeType(void) { return runtimeType; }
+
+void HALSIM_SetRuntimeType(HAL_RuntimeType type) { runtimeType = type; }
 
 int32_t HAL_GetFPGAVersion(int32_t* status) {
   return 2018;  // Automatically script this at some point

--- a/hal/src/main/native/sim/jni/SimulatorJNI.cpp
+++ b/hal/src/main/native/sim/jni/SimulatorJNI.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -106,6 +106,18 @@ jmethodID GetSpiReadAutoReceiveBufferCallback() {
 }  // namespace sim
 
 extern "C" {
+/*
+ * Class:     edu_wpi_first_hal_sim_mockdata_SimulatorJNI
+ * Method:    setRuntimeType
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_sim_mockdata_SimulatorJNI_setRuntimeType
+  (JNIEnv*, jclass, jint type)
+{
+  HALSIM_SetRuntimeType(static_cast<HAL_RuntimeType>(type));
+}
+
 /*
  * Class:     edu_wpi_first_hal_sim_mockdata_SimulatorJNI
  * Method:    waitForProgramStart


### PR DESCRIPTION
This is needed for extensions that effectively access real hardware and
want to disable the "simulation" parts of user code.