### PR TITLE
[wpiutil] Restore existing dll directory when setting dll directory

### DIFF
--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/CombinedRuntimeLoader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/CombinedRuntimeLoader.java
@@ -143,8 +143,7 @@ public final class CombinedRuntimeLoader {
       throw new IOException("Could not find library " + libraryName);
     } catch (UnsatisfiedLinkError ule) {
       throw new IOException(getLoadErrorMessage(currentPath, ule));
-    }
-    finally {
+    } finally {
       if (oldDllDirectory != null) {
         setDllDirectory(oldDllDirectory);
       }


### PR DESCRIPTION
Bytedeco uses setDllDirectory as well, and we don't want to interfere with its loader.