### PR TITLE
[cscore] Add new jnicvstatic artifact type

### DIFF
--- a/cscore/build.gradle
+++ b/cscore/build.gradle
@@ -15,15 +15,54 @@ ext {
 
 apply from: "${rootDir}/shared/jni/setupBuild.gradle"
 
+model {
+    components {
+        cscoreJNICvStatic(JniNativeLibrarySpec) {
+            baseName = 'cscore-jnicvstatic'
+
+            enableCheckTask true
+            javaCompileTasks << compileJava
+            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.roborio)
+            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.raspbian)
+            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.aarch64bionic)
+
+            sources {
+                cpp {
+                    source {
+                        srcDirs 'src/main/native/cpp'
+                        include '**/jni/*.cpp'
+                    }
+                    exportedHeaders {
+                        srcDir 'src/main/native/include'
+                        include '**/*.h'
+                    }
+
+                }
+            }
+            binaries.all {
+                if (it instanceof StaticLibraryBinarySpec) {
+                    it.buildable = false
+                    return
+                }
+                lib library: "${nativeName}", linkage: 'shared'
+                lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
+            }
+        }
+    }
+}
+
+
 ext {
     sharedCvConfigs = [cscore    : [],
                        cscoreBase: [],
                        cscoreDev : [],
                        cscoreTest: [],
                        cscoreJNIShared: []]
-    staticCvConfigs = [cscoreJNI: []]
+    staticCvConfigs = [cscoreJNI: [],
+                       cscoreJNICvStatic: []]
     useJava = true
     useCpp = true
+    cvStaticBuild = true
     splitSetup = {
         if (it.targetPlatform.operatingSystem.isMacOsX()) {
             it.sources {
@@ -105,6 +144,14 @@ nativeUtils.exportsConfigs {
                             '_TI3?AVout_of_range', '_CT??_R0?AVbad_cast']
     }
     cscoreJNI {
+        x86SymbolFilter = { symbols ->
+            symbols.removeIf({ !it.startsWith('CS_') })
+        }
+        x64SymbolFilter = { symbols ->
+            symbols.removeIf({ !it.startsWith('CS_') })
+        }
+    }
+    cscoreJNICvStatic {
         x86SymbolFilter = { symbols ->
             symbols.removeIf({ !it.startsWith('CS_') })
         }

--- a/shared/jni/publish.gradle
+++ b/shared/jni/publish.gradle
@@ -7,6 +7,7 @@ def baseArtifactId = nativeName
 def artifactGroupId = "edu.wpi.first.${nativeName}"
 def zipBaseName = "_GROUP_edu_wpi_first_${nativeName}_ID_${nativeName}-cpp_CLS"
 def jniBaseName = "_GROUP_edu_wpi_first_${nativeName}_ID_${nativeName}-jni_CLS"
+def jniCvStaticBaseName = "_GROUP_edu_wpi_first_${nativeName}_ID_${nativeName}-jnicvstatic_CLS"
 
 def licenseFile = file("$rootDir/license.md")
 
@@ -108,6 +109,34 @@ model {
                 artifactId = "${baseArtifactId}-jni"
                 groupId artifactGroupId
                 version wpilibVersioning.version.get()
+            }
+        }
+
+        if (project.hasProperty('cvStaticBuild') && project.getProperty('cvStaticBuild') == true) {
+            def jniCvTaskList = createComponentZipTasks($.components, ["${nativeName}JNICvStatic"], jniCvStaticBaseName, Jar, project, { task, value ->
+                value.each { binary ->
+                    if (binary.buildable) {
+                        if (binary instanceof SharedLibraryBinarySpec) {
+                            task.dependsOn binary.tasks.link
+                            task.inputs.file(binary.sharedLibraryFile)
+                            task.from(binary.sharedLibraryFile) {
+                                into nativeUtils.getPlatformPath(binary) + '/shared'
+                            }
+                        }
+                    }
+                }
+            })
+
+            publications {
+                jniCvStatic(MavenPublication) {
+                    jniCvTaskList.each {
+                        artifact it
+                    }
+
+                    artifactId = "${baseArtifactId}-jnicvstatic"
+                    groupId artifactGroupId
+                    version wpilibVersioning.version.get()
+                }
             }
         }
     }


### PR DESCRIPTION
With the new extraction method, we would need to provide an opencv. However, all of our tools that use opencv use an alternate version of OpenCV, so that would interfere.

This adds an artifact where opencv is statically linked into cscore, but wpiutil is a shared dependency. This solves some shared state hacks, and the extraction works so much better, so its worth making this change to allow that