### PR TITLE
[cscore] Fix jnicvstatic classifier

### DIFF
--- a/cscore/build.gradle
+++ b/cscore/build.gradle
@@ -44,7 +44,7 @@ model {
                     it.buildable = false
                     return
                 }
-                lib library: "${nativeName}", linkage: 'shared'
+                lib library: "${nativeName}", linkage: 'static'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
             }
         }

--- a/shared/jni/publish.gradle
+++ b/shared/jni/publish.gradle
@@ -113,7 +113,7 @@ model {
         }
 
         if (project.hasProperty('cvStaticBuild') && project.getProperty('cvStaticBuild') == true) {
-            def jniCvTaskList = createComponentZipTasks($.components, ["${nativeName}JNICvStatic"], jniCvStaticBaseName, Jar, project, { task, value ->
+            def jniCvTaskList = createComponentZipTasks($.components, ["${nativeName}JNICvStatic"], jniCvStaticBaseName, Zip, project, { task, value ->
                 value.each { binary ->
                     if (binary.buildable) {
                         if (binary instanceof SharedLibraryBinarySpec) {


### PR DESCRIPTION
The archive needed to be zip, additionally the library needed to statically link to cscore. All better now