### PR TITLE
[wpiutil] Add angular acceleration units

### DIFF
--- a/wpiutil/src/main/native/include/units/angular_acceleration.h
+++ b/wpiutil/src/main/native/include/units/angular_acceleration.h
@@ -1,0 +1,35 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include "units/angular_velocity.h"
+#include "units/base.h"
+#include "units/time.h"
+
+namespace units {
+/**
+ * @namespace units::angular_acceleration
+ * @brief namespace for unit types and containers representing angular
+ *        acceleration values
+ * @details The SI unit for angular acceleration is
+ *          `radians_per_second_squared`, and the corresponding `base_unit`
+ *          category is`angular_acceleration_unit`.
+ * @anchor angularAccelerationContainers
+ * @sa See unit_t for more information on unit type containers.
+ */
+UNIT_ADD(angular_acceleration, radians_per_second_squared,
+         radians_per_second_squared, rad_per_s_sq,
+         unit<std::ratio<1>, units::category::angular_acceleration_unit>)
+UNIT_ADD(angular_acceleration, degrees_per_second_squared,
+         degrees_per_second_squared, deg_per_s_sq,
+         compound_unit<angle::degrees, inverse<squared<time::seconds>>>)
+
+UNIT_ADD_CATEGORY_TRAIT(angular_acceleration)
+
+using namespace angular_acceleration;
+}  // namespace units

--- a/wpiutil/src/main/native/include/units/base.h
+++ b/wpiutil/src/main/native/include/units/base.h
@@ -774,6 +774,7 @@ namespace units
 		typedef base_unit<detail::meter_ratio<1>,	std::ratio<0>,	std::ratio<-1>>																										velocity_unit;					///< Represents an SI derived unit of velocity
 		typedef base_unit<detail::meter_ratio<0>,	std::ratio<0>,	std::ratio<-1>,	std::ratio<1>>																						angular_velocity_unit;			///< Represents an SI derived unit of angular velocity
 		typedef base_unit<detail::meter_ratio<1>,	std::ratio<0>,	std::ratio<-2>>																										acceleration_unit;				///< Represents an SI derived unit of acceleration
+		typedef base_unit<detail::meter_ratio<0>,	std::ratio<0>,	std::ratio<-2>,	std::ratio<1>>																						angular_acceleration_unit;			///< Represents an SI derived unit of angular acceleration
 		typedef base_unit<detail::meter_ratio<1>,	std::ratio<1>,	std::ratio<-2>>																										force_unit;						///< Represents an SI derived unit of force
 		typedef base_unit<detail::meter_ratio<-1>,	std::ratio<1>,	std::ratio<-2>>																										pressure_unit;					///< Represents an SI derived unit of pressure
 		typedef base_unit<detail::meter_ratio<0>,	std::ratio<0>,	std::ratio<1>,	std::ratio<0>,	std::ratio<1>>																		charge_unit;					///< Represents an SI derived unit of charge

--- a/wpiutil/src/main/native/include/units/units.h
+++ b/wpiutil/src/main/native/include/units/units.h
@@ -18,6 +18,7 @@
 
 #include "units/acceleration.h"
 #include "units/angle.h"
+#include "units/angular_acceleration.h"
 #include "units/angular_velocity.h"
 #include "units/area.h"
 #include "units/capacitance.h"

--- a/wpiutil/src/test/native/cpp/UnitsTest.cpp
+++ b/wpiutil/src/test/native/cpp/UnitsTest.cpp
@@ -13,6 +13,7 @@
 #include "gtest/gtest.h"
 #include "units/acceleration.h"
 #include "units/angle.h"
+#include "units/angular_acceleration.h"
 #include "units/angular_velocity.h"
 #include "units/area.h"
 #include "units/capacitance.h"
@@ -52,6 +53,7 @@
 
 using namespace units::acceleration;
 using namespace units::angle;
+using namespace units::angular_acceleration;
 using namespace units::angular_velocity;
 using namespace units::area;
 using namespace units::capacitance;
@@ -1926,6 +1928,7 @@ TEST_F(UnitConversion, acceleration) {
   test = convert<standard_gravity, meters_per_second_squared>(1.0);
   EXPECT_NEAR(9.80665, test, 5.0e-10);
 }
+
 TEST_F(UnitConversion, force) {
   double test;
 


### PR DESCRIPTION
We already have predefined linear acceleration units and angular
velocity units. This makes defining acceleration constraints for angular
trapezoid profiles more convenient.

No tests were added for this because the base unit conversions are
already tested. Angular acceleration just adds another time dimension.