### PR TITLE
[wpilibc] Add implicit conversion from degree_t to Rotation2d

### DIFF
--- a/wpilibc/src/main/native/cpp/geometry/Rotation2d.cpp
+++ b/wpilibc/src/main/native/cpp/geometry/Rotation2d.cpp
@@ -19,6 +19,11 @@ Rotation2d::Rotation2d(units::radian_t value)
       m_cos(units::math::cos(value)),
       m_sin(units::math::sin(value)) {}
 
+Rotation2d::Rotation2d(units::degree_t value)
+    : m_value(value),
+      m_cos(units::math::cos(value)),
+      m_sin(units::math::sin(value)) {}
+
 Rotation2d::Rotation2d(double x, double y) {
   const auto magnitude = std::hypot(x, y);
   if (magnitude > 1e-6) {

--- a/wpilibc/src/main/native/include/frc/geometry/Rotation2d.h
+++ b/wpilibc/src/main/native/include/frc/geometry/Rotation2d.h
@@ -34,6 +34,13 @@ class Rotation2d {
   Rotation2d(units::radian_t value);  // NOLINT(runtime/explicit)
 
   /**
+   * Constructs a Rotation2d with the given degree value.
+   *
+   * @param value The value of the angle in degrees.
+   */
+  Rotation2d(units::degree_t value);  // NOLINT(runtime/explicit)
+
+  /**
    * Constructs a Rotation2d with the given x and y (cosine and sine)
    * components. The x and y don't have to be normalized.
    *
@@ -174,7 +181,7 @@ class Rotation2d {
   double Tan() const { return m_sin / m_cos; }
 
  private:
-  units::radian_t m_value = 0_deg;
+  units::radian_t m_value = 0_rad;
   double m_cos = 1;
   double m_sin = 0;
 };


### PR DESCRIPTION
There's already an implicit conversion for radian_t, but there's no
implicit conversion from degree_t to radian_t.