### PR TITLE
[sim] Add support for disabling SimDevices

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/simulation/SimDeviceDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/SimDeviceDataJNI.java
@@ -11,6 +11,9 @@ import edu.wpi.first.hal.HALValue;
 import edu.wpi.first.hal.JNIWrapper;
 
 public class SimDeviceDataJNI extends JNIWrapper {
+  public static native void setSimDeviceEnabled(String prefix, boolean enabled);
+  public static native boolean isSimDeviceEnabled(String name);
+
   public static native int registerSimDeviceCreatedCallback(String prefix, SimDeviceCallback callback, boolean initialNotify);
   public static native void cancelSimDeviceCreatedCallback(int uid);
 

--- a/hal/src/main/native/include/hal/simulation/SimDeviceData.h
+++ b/hal/src/main/native/include/hal/simulation/SimDeviceData.h
@@ -23,6 +23,9 @@ typedef void (*HALSIM_SimValueCallback)(const char* name, void* param,
 extern "C" {
 #endif
 
+void HALSIM_SetSimDeviceEnabled(const char* prefix, HAL_Bool enabled);
+HAL_Bool HALSIM_IsSimDeviceEnabled(const char* name);
+
 int32_t HALSIM_RegisterSimDeviceCreatedCallback(
     const char* prefix, void* param, HALSIM_SimDeviceCallback callback,
     HAL_Bool initialNotify);

--- a/hal/src/main/native/sim/jni/SimDeviceDataJNI.cpp
+++ b/hal/src/main/native/sim/jni/SimDeviceDataJNI.cpp
@@ -305,6 +305,30 @@ extern "C" {
 
 /*
  * Class:     edu_wpi_first_hal_simulation_SimDeviceDataJNI
+ * Method:    setSimDeviceEnabled
+ * Signature: (Ljava/lang/String;Z)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_simulation_SimDeviceDataJNI_setSimDeviceEnabled
+  (JNIEnv* env, jclass, jstring prefix, jboolean enabled)
+{
+  HALSIM_SetSimDeviceEnabled(JStringRef{env, prefix}.c_str(), enabled);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_SimDeviceDataJNI
+ * Method:    isSimDeviceEnabled
+ * Signature: (Ljava/lang/String;)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_edu_wpi_first_hal_simulation_SimDeviceDataJNI_isSimDeviceEnabled
+  (JNIEnv* env, jclass, jstring name)
+{
+  return HALSIM_IsSimDeviceEnabled(JStringRef{env, name}.c_str());
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_SimDeviceDataJNI
  * Method:    registerSimDeviceCreatedCallback
  * Signature: (Ljava/lang/String;Ljava/lang/Object;Z)I
  */

--- a/hal/src/main/native/sim/mockdata/SimDeviceDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/SimDeviceDataInternal.h
@@ -150,6 +150,7 @@ class SimDeviceData {
 
   wpi::UidVector<std::shared_ptr<Device>, 4> m_devices;
   wpi::StringMap<std::weak_ptr<Device>> m_deviceMap;
+  std::vector<std::pair<std::string, bool>> m_prefixEnabled;
 
   wpi::recursive_spinlock m_mutex;
 
@@ -161,6 +162,9 @@ class SimDeviceData {
   Value* LookupValue(HAL_SimValueHandle handle);
 
  public:
+  void SetDeviceEnabled(const char* prefix, bool enabled);
+  bool IsDeviceEnabled(const char* name);
+
   HAL_SimDeviceHandle CreateDevice(const char* name);
   void FreeDevice(HAL_SimDeviceHandle handle);
   HAL_SimValueHandle CreateValue(HAL_SimDeviceHandle device, const char* name,

--- a/hal/src/test/native/cpp/mockdata/SimDeviceDataTests.cpp
+++ b/hal/src/test/native/cpp/mockdata/SimDeviceDataTests.cpp
@@ -1,0 +1,25 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "gtest/gtest.h"
+#include "hal/SimDevice.h"
+#include "hal/simulation/SimDeviceData.h"
+
+namespace hal {
+
+TEST(SimDeviceSimTests, TestEnabled) {
+  ASSERT_TRUE(HALSIM_IsSimDeviceEnabled("foo"));
+  HALSIM_SetSimDeviceEnabled("f", false);
+  HALSIM_SetSimDeviceEnabled("foob", true);
+  ASSERT_FALSE(HALSIM_IsSimDeviceEnabled("foo"));
+  ASSERT_TRUE(HALSIM_IsSimDeviceEnabled("foobar"));
+  ASSERT_TRUE(HALSIM_IsSimDeviceEnabled("bar"));
+
+  ASSERT_EQ(HAL_CreateSimDevice("foo"), 0);
+}
+
+}  // namespace hal


### PR DESCRIPTION
This allows disabling/enabling SimDevices via prefix matching.  This can be
used to force devices that normally use SimDevice in simulation mode to
instead talk directly to the hardware as in normal operation.