### PR TITLE
[sim] Move HAL_LoadExtensions to end of HAL_Initialize

### DIFF
--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -284,8 +284,6 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
 
   hal::init::HAL_IsInitialized.store(true);
 
-  wpi::outs().SetUnbuffered();
-  if (HAL_LoadExtensions() < 0) return false;
   hal::RestartTiming();
   HAL_InitializeDriverStation();
 
@@ -306,6 +304,9 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
     });
   }
 #endif  // _WIN32
+
+  wpi::outs().SetUnbuffered();
+  if (HAL_LoadExtensions() < 0) return false;
 
   return true;  // Add initialization if we need to at a later point
 }


### PR DESCRIPTION
Previously, HAL_InitializeDriverStation would reset any callbacks set in
extensions during load.