### PR TITLE
[build] Add PDBs to jnicvstatic archives

### DIFF
--- a/cscore/build.gradle
+++ b/cscore/build.gradle
@@ -44,7 +44,6 @@ model {
                     it.buildable = false
                     return
                 }
-                lib library: "${nativeName}", linkage: 'static'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
 
                 if (it.targetPlatform.operatingSystem.linux) {

--- a/shared/jni/publish.gradle
+++ b/shared/jni/publish.gradle
@@ -122,6 +122,12 @@ model {
                             task.from(binary.sharedLibraryFile) {
                                 into nativeUtils.getPlatformPath(binary) + '/shared'
                             }
+                            def sharedPath = binary.sharedLibraryFile.absolutePath
+                            sharedPath = sharedPath.substring(0, sharedPath.length() - 4)
+
+                            task.from(new File(sharedPath + '.pdb')) {
+                                into nativeUtils.getPlatformPath(binary) + '/shared'
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The tools plugin won't include them in the binary, but it will be easy to look them up if I need them.

Also fixes a lib link that needed to be removed, it was useless anyway.