### PR TITLE
[build] Update to latest native utils

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,5 +5,5 @@ repositories {
     }
 }
 dependencies {
-    implementation "edu.wpi.first:native-utils:2020.7.3"
+    implementation "edu.wpi.first:native-utils:2020.8.0"
 }

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -18,6 +18,7 @@ nativeUtils {
 
 nativeUtils.wpi.addWarnings()
 nativeUtils.wpi.addWarningsAsErrors()
+nativeUtils.wpi.addReleaseSymbolGeneration()
 
 nativeUtils.setSinglePrintPerPlatform()
 


### PR DESCRIPTION
By default, release projects do not include symbols in the new version. This updates that to work correctly now