### PR TITLE
[wpilibj] Fix Gyro.getRotation2d() units bug

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/interfaces/Gyro.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/interfaces/Gyro.java
@@ -74,6 +74,6 @@ public interface Gyro extends AutoCloseable {
    *         {@link edu.wpi.first.wpilibj.geometry.Rotation2d}.
    */
   default Rotation2d getRotation2d() {
-    return new Rotation2d(-getAngle());
+    return Rotation2d.fromDegrees(-getAngle());
   }
 }


### PR DESCRIPTION
Closes #2593 