### PR TITLE
[sim] Change StepTiming to wait for notifiers

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/simulation/SimulatorJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/SimulatorJNI.java
@@ -19,5 +19,6 @@ public class SimulatorJNI extends JNIWrapper {
   public static native void resumeTiming();
   public static native boolean isTimingPaused();
   public static native void stepTiming(long delta);
+  public static native void stepTimingAsync(long delta);
   public static native void resetHandles();
 }

--- a/hal/src/main/native/athena/mockdata/MockHooks.cpp
+++ b/hal/src/main/native/athena/mockdata/MockHooks.cpp
@@ -27,6 +27,8 @@ HAL_Bool HALSIM_IsTimingPaused(void) { return false; }
 
 void HALSIM_StepTiming(uint64_t delta) {}
 
+void HALSIM_StepTimingAsync(uint64_t delta) {}
+
 void HALSIM_SetSendError(HALSIM_SendErrorHandler handler) {}
 
 void HALSIM_SetSendConsoleLine(HALSIM_SendConsoleLineHandler handler) {}

--- a/hal/src/main/native/cpp/jni/simulation/SimulatorJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/SimulatorJNI.cpp
@@ -220,6 +220,18 @@ Java_edu_wpi_first_hal_simulation_SimulatorJNI_stepTiming
 
 /*
  * Class:     edu_wpi_first_hal_simulation_SimulatorJNI
+ * Method:    stepTimingAsync
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_simulation_SimulatorJNI_stepTimingAsync
+  (JNIEnv*, jclass, jlong delta)
+{
+  HALSIM_StepTimingAsync(delta);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_SimulatorJNI
  * Method:    resetHandles
  * Signature: ()V
  */

--- a/hal/src/main/native/include/hal/simulation/MockHooks.h
+++ b/hal/src/main/native/include/hal/simulation/MockHooks.h
@@ -20,6 +20,7 @@ void HALSIM_PauseTiming(void);
 void HALSIM_ResumeTiming(void);
 HAL_Bool HALSIM_IsTimingPaused(void);
 void HALSIM_StepTiming(uint64_t delta);
+void HALSIM_StepTimingAsync(uint64_t delta);
 
 typedef int32_t (*HALSIM_SendErrorHandler)(
     HAL_Bool isError, int32_t errorCode, HAL_Bool isLVCode, const char* details,

--- a/hal/src/main/native/sim/MockHooks.cpp
+++ b/hal/src/main/native/sim/MockHooks.cpp
@@ -93,6 +93,11 @@ HAL_Bool HALSIM_IsTimingPaused(void) { return IsTimingPaused(); }
 
 void HALSIM_StepTiming(uint64_t delta) {
   StepTiming(delta);
+  WakeupWaitNotifiers();
+}
+
+void HALSIM_StepTimingAsync(uint64_t delta) {
+  StepTiming(delta);
   WakeupNotifiers();
 }
 }  // extern "C"

--- a/hal/src/main/native/sim/NotifierInternal.h
+++ b/hal/src/main/native/sim/NotifierInternal.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -11,4 +11,5 @@ namespace hal {
 void PauseNotifiers();
 void ResumeNotifiers();
 void WakeupNotifiers();
+void WakeupWaitNotifiers();
 }  // namespace hal

--- a/simulation/halsim_gui/src/main/native/cpp/TimingGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/TimingGui.cpp
@@ -32,7 +32,8 @@ static void DisplayTiming() {
   if (ImGui::Button("Step")) {
     HALSIM_PauseTiming();
     uint64_t nextTimeout = HALSIM_GetNextNotifierTimeout();
-    if (nextTimeout != UINT64_MAX) HALSIM_StepTiming(nextTimeout - curTime);
+    if (nextTimeout != UINT64_MAX)
+      HALSIM_StepTimingAsync(nextTimeout - curTime);
   }
   ImGui::PopButtonRepeat();
   ImGui::PushItemWidth(ImGui::GetFontSize() * 4);

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
@@ -8,15 +8,20 @@
 package edu.wpi.first.wpilibj2.command;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
-import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.simulation.SimHooks;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CommandDecoratorTest extends CommandTestBase {
   @Test
+  @ResourceLock("timing")
   void withTimeoutTest() {
+    HAL.initialize(500, 0);
+    SimHooks.pauseTiming();
     try (CommandScheduler scheduler = new CommandScheduler()) {
       Command command1 = new WaitCommand(10);
 
@@ -28,10 +33,12 @@ class CommandDecoratorTest extends CommandTestBase {
       assertFalse(scheduler.isScheduled(command1));
       assertTrue(scheduler.isScheduled(timeout));
 
-      Timer.delay(3);
+      SimHooks.stepTiming(3);
       scheduler.run();
 
       assertFalse(scheduler.isScheduled(timeout));
+    } finally {
+      SimHooks.resumeTiming();
     }
   }
 

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommandTest.java
@@ -9,10 +9,12 @@ package edu.wpi.first.wpilibj2.command;
 
 import java.util.ArrayList;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+import edu.wpi.first.hal.HAL;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.controller.PIDController;
 import edu.wpi.first.wpilibj.controller.ProfiledPIDController;
@@ -31,13 +33,14 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MecanumControllerCommandTest {
-  @BeforeAll
-  static void setupAll() {
+  @BeforeEach
+  void setupAll() {
+    HAL.initialize(500, 0);
     SimHooks.pauseTiming();
   }
 
-  @AfterAll
-  static void cleanupAll() {
+  @AfterEach
+  void cleanupAll() {
     SimHooks.resumeTiming();
   }
 
@@ -86,6 +89,7 @@ class MecanumControllerCommandTest {
   }
 
   @Test
+  @ResourceLock("timing")
   @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   void testReachesReference() {
     final var subsystem = new Subsystem() {};

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommandTest.java
@@ -9,10 +9,12 @@ package edu.wpi.first.wpilibj2.command;
 
 import java.util.ArrayList;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+import edu.wpi.first.hal.HAL;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.controller.PIDController;
 import edu.wpi.first.wpilibj.controller.ProfiledPIDController;
@@ -31,13 +33,14 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SwerveControllerCommandTest {
-  @BeforeAll
-  static void setupAll() {
+  @BeforeEach
+  void setup() {
+    HAL.initialize(500, 0);
     SimHooks.pauseTiming();
   }
 
-  @AfterAll
-  static void cleanupAll() {
+  @AfterEach
+  void cleanup() {
     SimHooks.resumeTiming();
   }
 
@@ -80,6 +83,7 @@ class SwerveControllerCommandTest {
   }
 
   @Test
+  @ResourceLock("timing")
   @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   void testReachesReference() {
     final var subsystem = new Subsystem() {};

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
@@ -1,9 +1,11 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
+
+#include <frc/simulation/SimHooks.h>
 
 #include "CommandTestBase.h"
 #include "frc2/command/InstantCommand.h"
@@ -18,6 +20,8 @@ class CommandDecoratorTest : public CommandTestBase {};
 TEST_F(CommandDecoratorTest, WithTimeoutTest) {
   CommandScheduler scheduler = GetScheduler();
 
+  frc::sim::PauseTiming();
+
   auto command = RunCommand([] {}, {}).WithTimeout(100_ms);
 
   scheduler.Schedule(&command);
@@ -25,10 +29,12 @@ TEST_F(CommandDecoratorTest, WithTimeoutTest) {
   scheduler.Run();
   EXPECT_TRUE(scheduler.IsScheduled(&command));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  frc::sim::StepTiming(150_ms);
 
   scheduler.Run();
   EXPECT_FALSE(scheduler.IsScheduled(&command));
+
+  frc::sim::ResumeTiming();
 }
 
 TEST_F(CommandDecoratorTest, WithInterruptTest) {

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.cpp
@@ -18,12 +18,7 @@ CommandTestBase::CommandTestBase() {
 
 CommandScheduler CommandTestBase::GetScheduler() { return CommandScheduler(); }
 
-void CommandTestBase::SetUp() {
-  frc::sim::DriverStationSim::SetEnabled(true);
-  while (!frc::sim::DriverStationSim::GetEnabled()) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  }
-}
+void CommandTestBase::SetUp() { frc::sim::DriverStationSim::SetEnabled(true); }
 
 void CommandTestBase::TearDown() {
   CommandScheduler::GetInstance().ClearButtons();
@@ -31,7 +26,4 @@ void CommandTestBase::TearDown() {
 
 void CommandTestBase::SetDSEnabled(bool enabled) {
   frc::sim::DriverStationSim::SetEnabled(enabled);
-  while (frc::sim::DriverStationSim::GetEnabled() != enabled) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  }
 }

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/NotifierCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/NotifierCommandTest.cpp
@@ -1,31 +1,35 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
+#include <frc/simulation/SimHooks.h>
+
 #include "CommandTestBase.h"
 #include "frc2/command/NotifierCommand.h"
 
 using namespace frc2;
+using namespace std::chrono_literals;
+
 class NotifierCommandTest : public CommandTestBase {};
 
-#ifdef __APPLE__
-TEST_F(NotifierCommandTest, DISABLED_NotifierCommandScheduleTest) {
-#else
 TEST_F(NotifierCommandTest, NotifierCommandScheduleTest) {
-#endif
   CommandScheduler scheduler = GetScheduler();
 
-  int counter = 0;
+  frc::sim::PauseTiming();
 
-  NotifierCommand command([&counter] { counter++; }, 0.01_s, {});
+  int counter = 0;
+  NotifierCommand command([&] { counter++; }, 0.01_s, {});
 
   scheduler.Schedule(&command);
-  std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  for (int i = 0; i < 5; ++i) {
+    frc::sim::StepTiming(0.005_s);
+  }
   scheduler.Cancel(&command);
 
-  EXPECT_GT(counter, 10);
-  EXPECT_LT(counter, 100);
+  frc::sim::ResumeTiming();
+
+  EXPECT_EQ(counter, 2);
 }

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/WaitCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/WaitCommandTest.cpp
@@ -1,9 +1,11 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
+
+#include <frc/simulation/SimHooks.h>
 
 #include "CommandTestBase.h"
 #include "frc2/command/WaitCommand.h"
@@ -13,6 +15,8 @@ using namespace frc2;
 class WaitCommandTest : public CommandTestBase {};
 
 TEST_F(WaitCommandTest, WaitCommandScheduleTest) {
+  frc::sim::PauseTiming();
+
   CommandScheduler scheduler = GetScheduler();
 
   WaitCommand command(100_ms);
@@ -20,7 +24,9 @@ TEST_F(WaitCommandTest, WaitCommandScheduleTest) {
   scheduler.Schedule(&command);
   scheduler.Run();
   EXPECT_TRUE(scheduler.IsScheduled(&command));
-  std::this_thread::sleep_for(std::chrono::milliseconds(110));
+  frc::sim::StepTiming(110_ms);
   scheduler.Run();
   EXPECT_FALSE(scheduler.IsScheduled(&command));
+
+  frc::sim::ResumeTiming();
 }

--- a/wpilibc/src/main/native/cpp/simulation/SimHooks.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/SimHooks.cpp
@@ -32,5 +32,9 @@ void StepTiming(units::second_t delta) {
   HALSIM_StepTiming(static_cast<uint64_t>(delta.to<double>() * 1e6));
 }
 
+void StepTimingAsync(units::second_t delta) {
+  HALSIM_StepTimingAsync(static_cast<uint64_t>(delta.to<double>() * 1e6));
+}
+
 }  // namespace sim
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/simulation/SimHooks.h
+++ b/wpilibc/src/main/native/include/frc/simulation/SimHooks.h
@@ -33,5 +33,7 @@ bool IsTimingPaused();
 
 void StepTiming(units::second_t delta);
 
+void StepTimingAsync(units::second_t delta);
+
 }  // namespace sim
 }  // namespace frc

--- a/wpilibc/src/test/native/cpp/SlewRateLimiterTest.cpp
+++ b/wpilibc/src/test/native/cpp/SlewRateLimiterTest.cpp
@@ -12,12 +12,13 @@
 #include <units/velocity.h>
 
 #include "frc/SlewRateLimiter.h"
+#include "frc/simulation/SimHooks.h"
 #include "gtest/gtest.h"
 
 TEST(SlewRateLimiterTest, SlewRateLimitTest) {
   frc::SlewRateLimiter<units::meters> limiter(1_mps);
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  frc::sim::StepTiming(1.0_s);
 
   EXPECT_TRUE(limiter.Calculate(2_m) < 2_m);
 }
@@ -25,7 +26,7 @@ TEST(SlewRateLimiterTest, SlewRateLimitTest) {
 TEST(SlewRateLimiterTest, SlewRateNoLimitTest) {
   frc::SlewRateLimiter<units::meters> limiter(1_mps);
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  frc::sim::StepTiming(1.0_s);
 
   EXPECT_EQ(limiter.Calculate(0.5_m), 0.5_m);
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimHooks.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimHooks.java
@@ -48,4 +48,8 @@ public final class SimHooks {
   public static void stepTiming(double deltaSeconds) {
     SimulatorJNI.stepTiming((long) (deltaSeconds * 1e6));
   }
+
+  public static void stepTimingAsync(double deltaSeconds) {
+    SimulatorJNI.stepTimingAsync((long) (deltaSeconds * 1e6));
+  }
 }


### PR DESCRIPTION
Old behavior is available via StepTimingAsync.

This makes it significantly easier to use simulation timing with notifiers.

Also update tests to use simulation framework.  This also speeds up the
timing-dependent tests by using simulation timing.  ResourceLock is used
in the Java tests to prevent parallel execution.

While we're here, tweak HAL Notifier implementation:
- Use wait_for instead of wait_until in WaitForNotifierAlarm
- Check for triggerTime = UINT64_MAX in UpdateNotifierAlarm