### PR TITLE
[command] Speed up MecanumControllerCommand and SwerveControllerCommand tests

### DIFF
--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommandTest.java
@@ -9,6 +9,8 @@ package edu.wpi.first.wpilibj2.command;
 
 import java.util.ArrayList;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import edu.wpi.first.wpilibj.Timer;
@@ -20,6 +22,7 @@ import edu.wpi.first.wpilibj.geometry.Translation2d;
 import edu.wpi.first.wpilibj.kinematics.MecanumDriveKinematics;
 import edu.wpi.first.wpilibj.kinematics.MecanumDriveOdometry;
 import edu.wpi.first.wpilibj.kinematics.MecanumDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.simulation.SimHooks;
 import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
 import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
 import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile;
@@ -28,6 +31,16 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MecanumControllerCommandTest {
+  @BeforeAll
+  static void setupAll() {
+    SimHooks.pauseTiming();
+  }
+
+  @AfterAll
+  static void cleanupAll() {
+    SimHooks.resumeTiming();
+  }
+
   private final Timer m_timer = new Timer();
   private Rotation2d m_angle = new Rotation2d(0);
 
@@ -102,6 +115,7 @@ class MecanumControllerCommandTest {
     while (!command.isFinished()) {
       command.execute();
       m_angle = trajectory.sample(m_timer.get()).poseMeters.getRotation();
+      SimHooks.stepTiming(0.005);
     }
     m_timer.stop();
     command.end(true);

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommandTest.java
@@ -9,6 +9,8 @@ package edu.wpi.first.wpilibj2.command;
 
 import java.util.ArrayList;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import edu.wpi.first.wpilibj.Timer;
@@ -20,6 +22,7 @@ import edu.wpi.first.wpilibj.geometry.Translation2d;
 import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.wpilibj.kinematics.SwerveDriveOdometry;
 import edu.wpi.first.wpilibj.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.simulation.SimHooks;
 import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
 import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
 import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile;
@@ -28,6 +31,16 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SwerveControllerCommandTest {
+  @BeforeAll
+  static void setupAll() {
+    SimHooks.pauseTiming();
+  }
+
+  @AfterAll
+  static void cleanupAll() {
+    SimHooks.resumeTiming();
+  }
+
   private final Timer m_timer = new Timer();
   private Rotation2d m_angle = new Rotation2d(0);
 
@@ -95,6 +108,7 @@ class SwerveControllerCommandTest {
     while (!command.isFinished()) {
       command.execute();
       m_angle = trajectory.sample(m_timer.get()).poseMeters.getRotation();
+      SimHooks.stepTiming(0.005);
     }
     m_timer.stop();
     command.end(true);


### PR DESCRIPTION
Currently, these two tests take several seconds to complete and fail
intermittently in Windows CI. This is caused by relying on wall clock
time.

Sampling the trajectory with wall clock time means the simulation must
run for several seconds to reach the end of the trajectory. Also, the
controller can become unstable when Windows CI experiences process
scheduling delays of several hundred milliseconds. Feedback controllers
don't cope well with large delays on systems with fast dynamics.

This patch uses the mocking functionality of frc::Timer to advance the
clock by 5ms at every timestep instead of using the wall clock time.
This has two benefits:

1. The tests complete much faster because the simulation can step
   forward faster than real time.
2. The controller is more stable because the sample period is uniform,
   which should fix the occasional failures.