### PR TITLE
[hal] Cache solenoid bits

### DIFF
--- a/hal/src/main/native/athena/ctre/PCM.h
+++ b/hal/src/main/native/athena/ctre/PCM.h
@@ -194,6 +194,8 @@ public:
      */
     CTR_Code SetOneShotDurationMs(UINT8 idx,uint32_t durMs);
 
+  private:
+    unsigned m_cachedSolenoidBits = 0;
 };
 //------------------ C interface --------------------------------------------//
 extern "C" {


### PR DESCRIPTION
The CAN Rx path is potentially blocking.  Instead of doing a Rx when
reading solenoid values, cache the set values and use them instead.

The cache is also updated when doing other receive processing.