### PR TITLE
[wpimath] Remove unnecessary copying in constraints

### DIFF
--- a/wpimath/src/main/native/cpp/trajectory/constraint/DifferentialDriveKinematicsConstraint.cpp
+++ b/wpimath/src/main/native/cpp/trajectory/constraint/DifferentialDriveKinematicsConstraint.cpp
@@ -10,7 +10,8 @@
 using namespace frc;
 
 DifferentialDriveKinematicsConstraint::DifferentialDriveKinematicsConstraint(
-    DifferentialDriveKinematics kinematics, units::meters_per_second_t maxSpeed)
+    const DifferentialDriveKinematics& kinematics,
+    units::meters_per_second_t maxSpeed)
     : m_kinematics(kinematics), m_maxSpeed(maxSpeed) {}
 
 units::meters_per_second_t DifferentialDriveKinematicsConstraint::MaxVelocity(

--- a/wpimath/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
+++ b/wpimath/src/main/native/cpp/trajectory/constraint/DifferentialDriveVoltageConstraint.cpp
@@ -17,8 +17,8 @@
 using namespace frc;
 
 DifferentialDriveVoltageConstraint::DifferentialDriveVoltageConstraint(
-    SimpleMotorFeedforward<units::meter> feedforward,
-    DifferentialDriveKinematics kinematics, units::volt_t maxVoltage)
+    const SimpleMotorFeedforward<units::meter>& feedforward,
+    const DifferentialDriveKinematics& kinematics, units::volt_t maxVoltage)
     : m_feedforward(feedforward),
       m_kinematics(kinematics),
       m_maxVoltage(maxVoltage) {}

--- a/wpimath/src/main/native/cpp/trajectory/constraint/MecanumDriveKinematicsConstraint.cpp
+++ b/wpimath/src/main/native/cpp/trajectory/constraint/MecanumDriveKinematicsConstraint.cpp
@@ -12,7 +12,8 @@
 using namespace frc;
 
 MecanumDriveKinematicsConstraint::MecanumDriveKinematicsConstraint(
-    MecanumDriveKinematics kinematics, units::meters_per_second_t maxSpeed)
+    const MecanumDriveKinematics& kinematics,
+    units::meters_per_second_t maxSpeed)
     : m_kinematics(kinematics), m_maxSpeed(maxSpeed) {}
 
 units::meters_per_second_t MecanumDriveKinematicsConstraint::MaxVelocity(

--- a/wpimath/src/main/native/include/frc/trajectory/constraint/DifferentialDriveKinematicsConstraint.h
+++ b/wpimath/src/main/native/include/frc/trajectory/constraint/DifferentialDriveKinematicsConstraint.h
@@ -20,8 +20,9 @@ namespace frc {
  */
 class DifferentialDriveKinematicsConstraint : public TrajectoryConstraint {
  public:
-  DifferentialDriveKinematicsConstraint(DifferentialDriveKinematics kinematics,
-                                        units::meters_per_second_t maxSpeed);
+  DifferentialDriveKinematicsConstraint(
+      const DifferentialDriveKinematics& kinematics,
+      units::meters_per_second_t maxSpeed);
 
   units::meters_per_second_t MaxVelocity(
       const Pose2d& pose, units::curvature_t curvature,
@@ -31,7 +32,7 @@ class DifferentialDriveKinematicsConstraint : public TrajectoryConstraint {
                             units::meters_per_second_t speed) const override;
 
  private:
-  DifferentialDriveKinematics m_kinematics;
+  const DifferentialDriveKinematics& m_kinematics;
   units::meters_per_second_t m_maxSpeed;
 };
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h
+++ b/wpimath/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h
@@ -33,8 +33,8 @@ class DifferentialDriveVoltageConstraint : public TrajectoryConstraint {
    * voltage (12V) to account for "voltage sag" due to current draw.
    */
   DifferentialDriveVoltageConstraint(
-      SimpleMotorFeedforward<units::meter> feedforward,
-      DifferentialDriveKinematics kinematics, units::volt_t maxVoltage);
+      const SimpleMotorFeedforward<units::meter>& feedforward,
+      const DifferentialDriveKinematics& kinematics, units::volt_t maxVoltage);
 
   units::meters_per_second_t MaxVelocity(
       const Pose2d& pose, units::curvature_t curvature,
@@ -44,8 +44,8 @@ class DifferentialDriveVoltageConstraint : public TrajectoryConstraint {
                             units::meters_per_second_t speed) const override;
 
  private:
-  SimpleMotorFeedforward<units::meter> m_feedforward;
-  DifferentialDriveKinematics m_kinematics;
+  const SimpleMotorFeedforward<units::meter>& m_feedforward;
+  const DifferentialDriveKinematics& m_kinematics;
   units::volt_t m_maxVoltage;
 };
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/trajectory/constraint/MecanumDriveKinematicsConstraint.h
+++ b/wpimath/src/main/native/include/frc/trajectory/constraint/MecanumDriveKinematicsConstraint.h
@@ -22,7 +22,7 @@ namespace frc {
  */
 class MecanumDriveKinematicsConstraint : public TrajectoryConstraint {
  public:
-  MecanumDriveKinematicsConstraint(MecanumDriveKinematics kinematics,
+  MecanumDriveKinematicsConstraint(const MecanumDriveKinematics& kinematics,
                                    units::meters_per_second_t maxSpeed);
 
   units::meters_per_second_t MaxVelocity(
@@ -33,7 +33,7 @@ class MecanumDriveKinematicsConstraint : public TrajectoryConstraint {
                             units::meters_per_second_t speed) const override;
 
  private:
-  MecanumDriveKinematics m_kinematics;
+  const MecanumDriveKinematics& m_kinematics;
   units::meters_per_second_t m_maxSpeed;
 };
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.h
+++ b/wpimath/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.h
@@ -25,7 +25,7 @@ template <size_t NumModules>
 class SwerveDriveKinematicsConstraint : public TrajectoryConstraint {
  public:
   SwerveDriveKinematicsConstraint(
-      frc::SwerveDriveKinematics<NumModules> kinematics,
+      const frc::SwerveDriveKinematics<NumModules>& kinematics,
       units::meters_per_second_t maxSpeed);
 
   units::meters_per_second_t MaxVelocity(
@@ -36,7 +36,7 @@ class SwerveDriveKinematicsConstraint : public TrajectoryConstraint {
                             units::meters_per_second_t speed) const override;
 
  private:
-  frc::SwerveDriveKinematics<NumModules> m_kinematics;
+  const frc::SwerveDriveKinematics<NumModules>& m_kinematics;
   units::meters_per_second_t m_maxSpeed;
 };
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.inc
+++ b/wpimath/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.inc
@@ -19,7 +19,7 @@ template <size_t NumModules>
  * commanded velocities of the wheels stay below a certain limit.
  */
 SwerveDriveKinematicsConstraint<NumModules>::SwerveDriveKinematicsConstraint(
-    frc::SwerveDriveKinematics<NumModules> kinematics,
+    const frc::SwerveDriveKinematics<NumModules>& kinematics,
     units::meters_per_second_t maxSpeed)
     : m_kinematics(kinematics), m_maxSpeed(maxSpeed) {}
 


### PR DESCRIPTION
We can simply use const-references instead because all the methods that we calling on kinematics and feedforward objects in the constraints are marked as const and there's no need to copy them.