### PR TITLE
[build] Fix Gradle build on macOS 11.0 Big Sur

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,5 +5,5 @@ repositories {
     }
 }
 dependencies {
-    implementation "edu.wpi.first:native-utils:2020.8.0"
+    implementation "edu.wpi.first:native-utils:2020.10.0"
 }

--- a/wpilibOldCommands/src/main/native/cpp/commands/Scheduler.cpp
+++ b/wpilibOldCommands/src/main/native/cpp/commands/Scheduler.cpp
@@ -232,7 +232,7 @@ void Scheduler::Impl::ProcessCommandAddition(Command* command) {
   if (found == commands.end()) {
     // Check that the requirements can be had
     const auto& requirements = command->GetRequirements();
-    for (const auto& requirement : requirements) {
+    for (const auto requirement : requirements) {
       if (requirement->GetCurrentCommand() != nullptr &&
           !requirement->GetCurrentCommand()->IsInterruptible())
         return;

--- a/wpiutil/src/main/native/cpp/json_serializer.h
+++ b/wpiutil/src/main/native/cpp/json_serializer.h
@@ -36,6 +36,7 @@ SOFTWARE.
 #include <clocale> // lconv, localeconv
 #include <cmath>  // labs, isfinite, isnan, signbit, ldexp
 #include <locale> // locale
+#include <type_traits>
 
 #include "wpi/raw_ostream.h"
 
@@ -99,6 +100,18 @@ class json::serializer
     */
     void dump_escaped(StringRef s, const bool ensure_ascii);
 
+    template <typename NumberType,
+              detail::enable_if_t<std::is_same_v<NumberType, uint64_t>, int> = 0>
+    bool is_negative_integer(NumberType x) {
+      return false;
+    }
+
+    template <typename NumberType,
+              detail::enable_if_t<std::is_same_v<NumberType, int64_t>, int> = 0>
+    bool is_negative_integer(NumberType x) {
+      return x < 0;
+    }
+
     /*!
     @brief dump an integer
 
@@ -121,7 +134,7 @@ class json::serializer
             return;
         }
 
-        const bool is_negative = (x <= 0) and (x != 0);  // see issue #755
+        const bool is_negative = is_negative_integer(x);  // see issue #755
         std::size_t i = 0;
 
         while (x != 0)


### PR DESCRIPTION
The beta of macOS 11.0 Big Sur comes with AppleClang 12.0, which catches some more warnings with C++ code when building. Because `-Werror` is turned on, this inevitably leads to build failures. There were three main build failures that I've categorized below:

 * `wpiutil` - `tautological-overlap-compare`
     - The build log for this error can be found here: https://scans.gradle.com/s/omj24fccxybfg
     - The fix was in this commit: https://github.com/wpilibsuite/allwpilib/commit/9cf79189fcd461d63844e500b01d3974ef06ab73
 * `opencv` - `c11-extensions`
     - The build log for this type of error can be found here: https://gradle.com/s/4bndkaxghnipk
     - The fix was to compile with `Wno-error=c11-extensions` on macOS. I had to add this everywhere that OpenCV headers were included.

 * `wpilibOldCommands` - `range-loop-analysis`
    - The error was as follows (fixed by replacing `const auto&` with `const auto`:
```
wpi::SmallPtrSetImpl<frc::Subsystem *>' does not return a reference [-Werror,-Wrange-loop-analysis]
    for (const auto& requirement : requirements) {
                     ^
/Users/prateekma/Documents/Dev/allwpilib/wpilibOldCommands/src/main/native/cpp/commands/Scheduler.cpp:235:10: note: use non-reference type 'frc::Subsystem *'
    for (const auto& requirement : requirements) {
         ^~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

This was the build log after everything was fixed: https://gradle.com/s/hl3d6oryvnzzq