### PR TITLE
[wpilib] Add state-space pose & state estimators

### DIFF
--- a/wpilibc/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
+++ b/wpilibc/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
@@ -1,0 +1,135 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/estimator/DifferentialDrivePoseEstimator.h"
+
+#include "frc/StateSpaceUtil.h"
+#include "frc2/Timer.h"
+
+using namespace frc;
+
+DifferentialDrivePoseEstimator::DifferentialDrivePoseEstimator(
+    const Rotation2d& gyroAngle, const Pose2d& initialPose,
+    const Vector<5>& stateStdDevs, const Vector<3>& localMeasurementStdDevs,
+    const Vector<3>& visionMeasurmentStdDevs, units::second_t nominalDt)
+    : m_observer(
+          &DifferentialDrivePoseEstimator::F,
+          [](const Vector<5>& x, const Vector<3>& u) {
+            return frc::MakeMatrix<3, 1>(x(3, 0), x(4, 0), x(2, 0));
+          },
+          StdDevMatrixToArray<5>(stateStdDevs),
+          StdDevMatrixToArray<3>(localMeasurementStdDevs), nominalDt),
+      m_nominalDt(nominalDt) {
+  // Create R (covariances) for vision measurements.
+  Eigen::Matrix<double, 3, 3> visionContR =
+      frc::MakeCovMatrix(StdDevMatrixToArray<3>(visionMeasurmentStdDevs));
+  m_visionDiscR = frc::DiscretizeR<3>(visionContR, m_nominalDt);
+
+  // Create correction mechanism for vision measurements.
+  m_visionCorrect = [&](const Vector<3>& u, const Vector<3>& y) {
+    m_observer.Correct<3>(
+        u, y,
+        [](const Vector<5>& x, const Vector<3>&) {
+          return x.block<3, 1>(0, 0);
+        },
+        m_visionDiscR);
+  };
+
+  m_gyroOffset = initialPose.Rotation() - gyroAngle;
+  m_previousAngle = initialPose.Rotation();
+  m_observer.SetXhat(FillStateVector(initialPose, 0_m, 0_m));
+}
+
+void DifferentialDrivePoseEstimator::ResetPosition(
+    const Pose2d& pose, const Rotation2d& gyroAngle) {
+  m_previousAngle = pose.Rotation();
+  m_gyroOffset = GetEstimatedPosition().Rotation() - gyroAngle;
+  m_observer.SetXhat(FillStateVector(pose, 0_m, 0_m));
+}
+
+Pose2d DifferentialDrivePoseEstimator::GetEstimatedPosition() const {
+  return Pose2d(units::meter_t(m_observer.Xhat(0)),
+                units::meter_t(m_observer.Xhat(1)),
+                Rotation2d(units::radian_t(m_observer.Xhat(2))));
+}
+
+void DifferentialDrivePoseEstimator::AddVisionMeasurement(
+    const Pose2d& visionRobotPose, units::second_t timestamp) {
+  m_latencyCompensator.ApplyPastMeasurement<3>(&m_observer, m_nominalDt,
+                                               PoseTo3dVector(visionRobotPose),
+                                               m_visionCorrect, timestamp);
+}
+
+Pose2d DifferentialDrivePoseEstimator::Update(
+    const Rotation2d& gyroAngle,
+    const DifferentialDriveWheelSpeeds& wheelSpeeds,
+    units::meter_t leftDistance, units::meter_t rightDistance) {
+  return UpdateWithTime(frc2::Timer::GetFPGATimestamp(), gyroAngle, wheelSpeeds,
+                        leftDistance, rightDistance);
+}
+
+Pose2d DifferentialDrivePoseEstimator::UpdateWithTime(
+    units::second_t currentTime, const Rotation2d& gyroAngle,
+    const DifferentialDriveWheelSpeeds& wheelSpeeds,
+    units::meter_t leftDistance, units::meter_t rightDistance) {
+  auto dt = m_prevTime >= 0_s ? currentTime - m_prevTime : m_nominalDt;
+  m_prevTime = currentTime;
+
+  auto angle = gyroAngle + m_gyroOffset;
+  auto omega = (gyroAngle - m_previousAngle).Radians() / dt;
+
+  auto u = frc::MakeMatrix<3, 1>(
+      (wheelSpeeds.left + wheelSpeeds.right).to<double>() / 2.0, 0.0,
+      omega.to<double>());
+
+  m_previousAngle = angle;
+
+  auto localY = frc::MakeMatrix<3, 1>(leftDistance.to<double>(),
+                                      rightDistance.to<double>(),
+                                      angle.Radians().to<double>());
+
+  m_latencyCompensator.AddObserverState(m_observer, u, localY, currentTime);
+  m_observer.Predict(u, dt);
+  m_observer.Correct(u, localY);
+
+  return GetEstimatedPosition();
+}
+
+Vector<5> DifferentialDrivePoseEstimator::F(const Vector<5>& x,
+                                            const Vector<3>& u) {
+  // Apply a rotation matrix. Note that we do not add x because Runge-Kutta does
+  // that for us.
+  auto& theta = x(2, 0);
+  Eigen::Matrix<double, 5, 5> toFieldRotation = frc::MakeMatrix<5, 5>(
+      // clang-format off
+    std::cos(theta), -std::sin(theta), 0.0, 0.0, 0.0,
+    std::sin(theta), std::cos(theta), 0.0, 0.0, 0.0,
+    0.0, 0.0, 1.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 1.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 1.0);  // clang-format on
+  return toFieldRotation *
+         frc::MakeMatrix<5, 1>(u(0, 0), u(1, 0), u(2, 0), u(0, 0), u(1, 0));
+}
+
+template <int Dim>
+std::array<double, Dim> DifferentialDrivePoseEstimator::StdDevMatrixToArray(
+    const Vector<Dim>& stdDevs) {
+  std::array<double, Dim> array;
+  for (size_t i = 0; i < Dim; ++i) {
+    array[i] = stdDevs(i);
+  }
+  return array;
+}
+
+Vector<5> DifferentialDrivePoseEstimator::FillStateVector(
+    const Pose2d& pose, units::meter_t leftDistance,
+    units::meter_t rightDistance) {
+  return frc::MakeMatrix<5, 1>(
+      pose.Translation().X().to<double>(), pose.Translation().Y().to<double>(),
+      pose.Rotation().Radians().to<double>(), leftDistance.to<double>(),
+      rightDistance.to<double>());
+}

--- a/wpilibc/src/main/native/cpp/estimator/DifferentialDriveStateEstimator.cpp
+++ b/wpilibc/src/main/native/cpp/estimator/DifferentialDriveStateEstimator.cpp
@@ -1,0 +1,154 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/estimator/DifferentialDriveStateEstimator.h"
+
+#include "frc/StateSpaceUtil.h"
+#include "frc2/Timer.h"
+
+using namespace frc;
+
+DifferentialDriveStateEstimator::DifferentialDriveStateEstimator(
+    const LinearSystem<2, 2, 2>& plant, const Eigen::Matrix<double, 10, 1>& initialState,
+    const Eigen::Matrix<double, 10, 1>& stateStdDevs, const Eigen::Matrix<double, 3, 1>& localMeasurementStdDevs,
+    const Eigen::Matrix<double, 3, 1>& globalMeasurementStdDevs,
+    const DifferentialDriveKinematics& kinematics, units::second_t nominalDt)
+    : m_plant(plant),
+      m_rb(kinematics.trackWidth / 2.0),
+      m_observer([this](auto& x, auto& u) { return Dynamics(x, u); },
+                 &DifferentialDriveStateEstimator::LocalMeasurementModel,
+                 StdDevMatrixToArray<10>(stateStdDevs),
+                 StdDevMatrixToArray<3>(localMeasurementStdDevs), nominalDt),
+      m_nominalDt(nominalDt) {
+  m_localY.setZero();
+  m_globalY.setZero();
+
+  // Create R (covariances) for global measurements.
+  Eigen::Matrix<double, 3, 3> globalContR =
+      frc::MakeCovMatrix(StdDevMatrixToArray<3>(globalMeasurementStdDevs));
+
+  Eigen::Matrix<double, 3, 3> globalDiscR =
+      frc::DiscretizeR<3>(globalContR, m_nominalDt);
+
+  // Create correction mechanism for global measurements.
+  m_globalCorrect = [&](const Eigen::Matrix<double, 2, 1>& u, const Eigen::Matrix<double, 3, 1>& y) {
+    m_observer.Correct<3>(
+        u, y, &DifferentialDriveStateEstimator::GlobalMeasurementModel,
+        globalDiscR);
+  };
+
+  Reset(initialState);
+}
+
+void DifferentialDriveStateEstimator::ApplyPastGlobalMeasurement(
+    const Pose2d& visionRobotPose, units::second_t timestamp) {
+  m_latencyCompensator.ApplyPastMeasurement<3>(&m_observer, m_nominalDt,
+                                               PoseTo3dVector(visionRobotPose),
+                                               m_globalCorrect, timestamp);
+}
+
+Vector<10> DifferentialDriveStateEstimator::GetEstimatedState() const {
+  return m_observer.Xhat();
+}
+
+frc::Pose2d DifferentialDriveStateEstimator::GetEstimatedPosition() {
+  Vector<10> xHat = GetEstimatedState();
+  return frc::Pose2d(
+    units::meter_t(xHat(State::kX, 0)),
+    units::meter_t(xHat(State::kY, 0)),
+    frc::Rotation2d(units::radian_t(xHat(State::kHeading, 0))));
+}
+
+Vector<10> DifferentialDriveStateEstimator::Update(
+    units::radian_t heading, units::meter_t leftPosition,
+    units::meter_t rightPosition, const Eigen::Matrix<double, 2, 1>& controlInput) {
+  return UpdateWithTime(heading, leftPosition, rightPosition, controlInput,
+                        frc2::Timer::GetFPGATimestamp());
+}
+
+Vector<10> DifferentialDriveStateEstimator::UpdateWithTime(
+    units::radian_t heading, units::meter_t leftPosition,
+    units::meter_t rightPosition, const Eigen::Matrix<double, 2, 1>& controlInput,
+    units::second_t currentTime) {
+  auto dt = m_prevTime >= 0_s ? currentTime - m_prevTime : m_nominalDt;
+  m_prevTime = currentTime;
+
+  m_localY(LocalOutput::kHeading) = heading.to<double>();
+  m_localY(LocalOutput::kLeftPosition) = leftPosition.to<double>();
+  m_localY(LocalOutput::kRightPosition) = rightPosition.to<double>();
+
+  m_latencyCompensator.AddObserverState(m_observer, controlInput, m_localY,
+                                        currentTime);
+
+  m_observer.Predict(controlInput, dt);
+  m_observer.Correct(controlInput, m_localY);
+
+  return GetEstimatedState();
+}
+
+void DifferentialDriveStateEstimator::Reset(const Eigen::Matrix<double, 10, 1>& initialState) {
+  m_observer.Reset();
+
+  m_observer.SetXhat(initialState);
+}
+
+void DifferentialDriveStateEstimator::Reset() { m_observer.Reset(); }
+
+Vector<10> DifferentialDriveStateEstimator::Dynamics(const Eigen::Matrix<double, 10, 1>& x,
+                                                     const Eigen::Matrix<double, 2, 1>& u) {
+  Eigen::Matrix<double, 4, 2> B;
+  B.block<2, 2>(0, 0) = m_plant.B();
+  B.block<2, 2>(2, 0).setZero();
+  Eigen::Matrix<double, 4, 7> A;
+  A.block<2, 2>(0, 0) = m_plant.A();
+
+  A.block<2, 2>(2, 0).setIdentity();
+  A.block<4, 2>(0, 2).setZero();
+  A.block<4, 2>(0, 4) = B;
+  A.block<4, 1>(0, 6) << 0, 0, 1, -1;
+
+  double v = (x(State::kLeftVelocity, 0) + x(State::kRightVelocity, 0)) / 2.0;
+
+  Eigen::Matrix<double, 10, 1> result;
+  result(0, 0) = v * std::cos(x(State::kHeading, 0));
+  result(1, 0) = v * std::sin(x(State::kHeading, 0));
+  result(2, 0) = ((x(State::kRightVelocity, 0) - x(State::kLeftVelocity, 0)) /
+                  (2.0 * m_rb))
+                     .to<double>();
+  result.block<4, 1>(3, 0) = A * x.block<7, 1>(3, 0) + B * u;
+  result.block<3, 1>(7, 0).setZero();
+  return result;
+}
+
+Vector<3> DifferentialDriveStateEstimator::LocalMeasurementModel(
+    const Eigen::Matrix<double, 10, 1>& x, const Eigen::Matrix<double, 2, 1>& u) {
+  static_cast<void>(u);
+
+  Eigen::Matrix<double, 3, 1> y;
+  y << x(State::kHeading, 0), x(State::kLeftPosition, 0),
+      x(State::kRightPosition, 0);
+  return y;
+}
+
+Vector<3> DifferentialDriveStateEstimator::GlobalMeasurementModel(
+    const Eigen::Matrix<double, 10, 1>& x, const Eigen::Matrix<double, 2, 1>& u) {
+  static_cast<void>(u);
+
+  Eigen::Matrix<double, 3, 1> y;
+  y << x(State::kX, 0), x(State::kY, 0), x(State::kHeading, 0);
+  return y;
+}
+
+template <int Dim>
+std::array<double, Dim> DifferentialDriveStateEstimator::StdDevMatrixToArray(
+    const Eigen::Matrix<double, Dim, 1>& stdDevs) {
+  std::array<double, Dim> array;
+  for (size_t i = 0; i < Dim; ++i) {
+    array[i] = stdDevs(i);
+  }
+  return array;
+}

--- a/wpilibc/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
+++ b/wpilibc/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
@@ -1,0 +1,122 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "frc/estimator/MecanumDrivePoseEstimator.h"
+
+#include <limits>
+
+#include "frc/StateSpaceUtil.h"
+
+using namespace frc;
+
+frc::MecanumDrivePoseEstimator::MecanumDrivePoseEstimator(
+    const Rotation2d& gyroAngle, const Pose2d& initialPose,
+    MecanumDriveKinematics kinematics, const Vector<3>& stateStdDevs,
+    const Vector<1>& localMeasurementStdDevs,
+    const Vector<3>& visionMeasurementStdDevs, units::second_t nominalDt)
+    : m_observer(
+          &MecanumDrivePoseEstimator::F,
+          [](const Vector<4>& x, const Vector<3>& u) {
+            return x.block<2, 1>(2, 0);
+          },
+          StdDevMatrixToArray<4>(frc::MakeMatrix<4, 1>(
+              stateStdDevs(0), stateStdDevs(1), std::cos(stateStdDevs(2)),
+              std::sin(stateStdDevs(2)))),
+          StdDevMatrixToArray<2>(
+              frc::MakeMatrix<2, 1>(std::cos(localMeasurementStdDevs(0)),
+                                    std::sin(localMeasurementStdDevs(0)))),
+          nominalDt),
+      m_kinematics(kinematics),
+      m_nominalDt(nominalDt) {
+  // Construct R (covariances) matrix for vision measurements.
+  Eigen::Matrix4d visionContR =
+      frc::MakeCovMatrix<4>(StdDevMatrixToArray<4>(frc::MakeMatrix<4, 1>(
+          visionMeasurementStdDevs(0), visionMeasurementStdDevs(1),
+          std::cos(visionMeasurementStdDevs(2)),
+          std::sin(visionMeasurementStdDevs(2)))));
+
+  // Create and store discrete covariance matrix for vision measurements.
+  m_visionDiscR = frc::DiscretizeR<4>(visionContR, m_nominalDt);
+
+  // Create vision correction mechanism.
+  m_visionCorrect = [&](const Vector<3>& u, const Vector<4>& y) {
+    m_observer.Correct<4>(
+        u, y, [](const Vector<4>& x, const Vector<3>& u) { return x; },
+        m_visionDiscR);
+  };
+
+  // Set initial state.
+  m_observer.SetXhat(PoseTo4dVector(initialPose));
+
+  // Calculate offsets.
+  m_gyroOffset = initialPose.Rotation() - gyroAngle;
+  m_previousAngle = initialPose.Rotation();
+}
+
+void frc::MecanumDrivePoseEstimator::ResetPosition(
+    const Pose2d& pose, const Rotation2d& gyroAngle) {
+  // Set observer state.
+  m_observer.SetXhat(PoseTo4dVector(pose));
+
+  // Calculate offsets.
+  m_gyroOffset = pose.Rotation() - gyroAngle;
+  m_previousAngle = pose.Rotation();
+}
+
+Pose2d frc::MecanumDrivePoseEstimator::GetEstimatedPosition() const {
+  return Pose2d(m_observer.Xhat(0) * 1_m, m_observer.Xhat(1) * 1_m,
+                Rotation2d(m_observer.Xhat(2), m_observer.Xhat(3)));
+}
+
+void frc::MecanumDrivePoseEstimator::AddVisionMeasurement(
+    const Pose2d& visionRobotPose, units::second_t timestamp) {
+  m_latencyCompensator.ApplyPastMeasurement<4>(&m_observer, m_nominalDt,
+                                               PoseTo4dVector(visionRobotPose),
+                                               m_visionCorrect, timestamp);
+}
+
+Pose2d frc::MecanumDrivePoseEstimator::Update(
+    const Rotation2d& gyroAngle, const MecanumDriveWheelSpeeds& wheelSpeeds) {
+  return UpdateWithTime(frc2::Timer::GetFPGATimestamp(), gyroAngle,
+                        wheelSpeeds);
+}
+
+Pose2d frc::MecanumDrivePoseEstimator::UpdateWithTime(
+    units::second_t currentTime, const Rotation2d& gyroAngle,
+    const MecanumDriveWheelSpeeds& wheelSpeeds) {
+  auto dt = m_prevTime >= 0_s ? currentTime - m_prevTime : m_nominalDt;
+  m_prevTime = currentTime;
+
+  auto angle = gyroAngle + m_gyroOffset;
+  auto omega = (angle - m_previousAngle).Radians() / dt;
+
+  auto chassisSpeeds = m_kinematics.ToChassisSpeeds(wheelSpeeds);
+  auto fieldRelativeVelocities =
+      Translation2d(chassisSpeeds.vx * 1_s, chassisSpeeds.vy * 1_s)
+          .RotateBy(angle);
+
+  auto u = frc::MakeMatrix<3, 1>(fieldRelativeVelocities.X().to<double>(),
+                                 fieldRelativeVelocities.Y().to<double>(),
+                                 omega.to<double>());
+
+  auto localY =
+      frc::MakeMatrix<2, 1>(std::cos(angle.Radians().template to<double>()),
+                            std::sin(angle.Radians().template to<double>()));
+  m_previousAngle = angle;
+
+  m_latencyCompensator.AddObserverState(m_observer, u, localY, currentTime);
+
+  m_observer.Predict(u, dt);
+  m_observer.Correct(u, localY);
+
+  return GetEstimatedPosition();
+}
+
+Vector<4> frc::MecanumDrivePoseEstimator::F(const Vector<4>& x,
+                                            const Vector<3>& u) {
+  return frc::MakeMatrix<4, 1>(u(0), u(1), -x(3) * u(2), x(2) * u(2));
+}

--- a/wpilibc/src/main/native/include/frc/estimator/DifferentialDrivePoseEstimator.h
+++ b/wpilibc/src/main/native/include/frc/estimator/DifferentialDrivePoseEstimator.h
@@ -1,0 +1,174 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+
+#include <Eigen/Core>
+#include <units/time.h>
+
+#include "frc/estimator/ExtendedKalmanFilter.h"
+#include "frc/estimator/KalmanFilterLatencyCompensator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/geometry/Rotation2d.h"
+#include "frc/kinematics/DifferentialDriveWheelSpeeds.h"
+
+namespace frc {
+
+template <int N>
+using Vector = Eigen::Matrix<double, N, 1>;
+
+/**
+ * This class wraps an Extended Kalman Filter to fuse latency-compensated
+ * vision measurements with differential drive encoder measurements. It will
+ * correct for noisy vision measurements and encoder drift. It is intended to be
+ * an easy drop-in for DifferentialDriveOdometry. In fact, if you never call
+ * AddVisionMeasurement(), and only call Update(), this will behave exactly the
+ * same as DifferentialDriveOdometry.
+ *
+ * Update() should be called every robot loop (if your robot loops are faster or
+ * slower than the default, then you should change the nominal delta time via
+ * the constructor).
+ *
+ * AddVisionMeasurement() can be called as infrequently as you want; if you
+ * never call it, then this class will behave like regular encoder odometry.
+ *
+ * Our state-space system is:
+ *
+ * <strong> x = [[x, y, theta]]^T </strong> in the field coordinate system.
+ *
+ * <strong> u = [[d_l, d_r, dtheta]]^T </strong> (robot-relative velocities) --
+ * NB: using velocities make things considerably easier, because it means that
+ * teams don't have to worry about getting an accurate model. Basically, we
+ * suspect that it's easier for teams to get good encoder data than it is for
+ * them to perform system identification well enough to get a good model
+ *
+ * <strong> y = [[x, y, theta]]^T </strong>
+ */
+class DifferentialDrivePoseEstimator {
+ public:
+  /**
+   * Constructs a DifferentialDrivePoseEstimator.
+   *
+   * @param gyroAngle                The gyro angle of the robot.
+   * @param initialPose              The estimated initial pose.
+   * @param stateStdDevs             Standard deviations of the model states.
+   *                                 Increase these to trust your wheel speeds
+   *                                 less.
+   * @param localMeasurementStdDevs  Standard deviations of the encoder
+   *                                 measurements. Increase these to trust
+   *                                 encoder distances less.
+   * @param visionMeasurementStdDevs Standard deviations of the vision
+   *                                 measurements. Increase these to trust
+   *                                 vision less.
+   * @param nominalDt                The period of the loop calling Update().
+   */
+  DifferentialDrivePoseEstimator(const Rotation2d& gyroAngle,
+                                 const Pose2d& initialPose,
+                                 const Vector<5>& stateStdDevs,
+                                 const Vector<3>& localMeasurementStdDevs,
+                                 const Vector<3>& visionMeasurementStdDevs,
+                                 units::second_t nominalDt = 0.02_s);
+
+  /**
+   * Resets the robot's position on the field.
+   *
+   * You NEED to reset your encoders to zero when calling this method. The
+   * gyroscope angle does not need to be reset here on the user's robot code.
+   * The library automatically takes care of offsetting the gyro angle.
+   *
+   *@param pose The estimated pose of the robot on the field.
+   *@param gyroAngle The current gyro angle.
+   */
+  void ResetPosition(const Pose2d& pose, const Rotation2d& gyroAngle);
+
+  /**
+   * Returns the pose of the robot at the current time as estimated by the
+   * Extended Kalman Filter.
+   *
+   * @return The estimated robot pose.
+   */
+  Pose2d GetEstimatedPosition() const;
+
+  /**
+   * Adds a vision measurement to the Extended Kalman Filter. This will correct
+   * the odometry pose estimate while still accounting for measurement noise.
+   *
+   * This method can be called as infrequently as you want, as long as you are
+   * calling Update() every loop.
+   *
+   * @param visionRobotPose The pose of the robot as measured by the vision
+   *                        camera.
+   * @param timestamp       The timestamp of the vision measurement in seconds.
+   *                        Note that if you don't use your own time source by
+   *                        calling UpdateWithTime(), then you must use a
+   *                        timestamp with an epoch since FPGA startup (i.e. the
+   *                        epoch of this timestamp is the same epoch as
+   *                        frc2::Timer::GetFPGATimestamp(). This means that
+   *                        you should use frc2::Timer::GetFPGATimestamp() as
+   *                        your time source in this case.
+   */
+  void AddVisionMeasurement(const Pose2d& visionRobotPose,
+                            units::second_t timestamp);
+
+  /**
+   * Updates the Extended Kalman Filter using only wheel encoder information.
+   * Note that this should be called every loop iteration.
+   *
+   * @param gyroAngle     The current gyro angle.
+   * @param leftDistance  The distance traveled by the left encoder.
+   * @param rightDistance The distance traveled by the right encoder.
+   *
+   * @return The estimated pose of the robot.
+   */
+  Pose2d Update(const Rotation2d& gyroAngle,
+                const DifferentialDriveWheelSpeeds& wheelSpeeds,
+                units::meter_t leftDistance, units::meter_t rightDistance);
+
+  /**
+   * Updates the Extended Kalman Filter using only wheel encoder information.
+   * Note that this should be called every loop iteration.
+   *
+   * @param currentTime   The time at which this method was called.
+   * @param gyroAngle     The current gyro angle.
+   * @param leftDistance  The distance traveled by the left encoder.
+   * @param rightDistance The distance traveled by the right encoder.
+   *
+   * @return The estimated pose of the robot.
+   */
+  Pose2d UpdateWithTime(units::second_t currentTime,
+                        const Rotation2d& gyroAngle,
+                        const DifferentialDriveWheelSpeeds& wheelSpeeds,
+                        units::meter_t leftDistance,
+                        units::meter_t rightDistance);
+
+ private:
+  ExtendedKalmanFilter<5, 3, 3> m_observer;
+  KalmanFilterLatencyCompensator<5, 3, 3, ExtendedKalmanFilter<5, 3, 3>>
+      m_latencyCompensator;
+  std::function<void(const Vector<3>& u, const Vector<3>& y)> m_visionCorrect;
+
+  Eigen::Matrix<double, 3, 3> m_visionDiscR;
+
+  units::second_t m_nominalDt;
+  units::second_t m_prevTime = -1_s;
+
+  Rotation2d m_gyroOffset;
+  Rotation2d m_previousAngle;
+
+  template <int Dim>
+  static std::array<double, Dim> StdDevMatrixToArray(
+      const Vector<Dim>& stdDevs);
+
+  static Vector<5> F(const Vector<5>& x, const Vector<3>& u);
+  static Vector<5> FillStateVector(const Pose2d& pose,
+                                   units::meter_t leftDistance,
+                                   units::meter_t rightDistance);
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/estimator/DifferentialDriveStateEstimator.h
+++ b/wpilibc/src/main/native/include/frc/estimator/DifferentialDriveStateEstimator.h
@@ -1,0 +1,236 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+
+#include <Eigen/Core>
+#include <units/angle.h>
+#include <units/length.h>
+#include <units/time.h>
+
+#include "frc/estimator/ExtendedKalmanFilter.h"
+#include "frc/estimator/KalmanFilterLatencyCompensator.h"
+#include "frc/kinematics/DifferentialDriveKinematics.h"
+#include "frc/system/LinearSystem.h"
+
+namespace frc {
+
+template <int N>
+using Vector = Eigen::Matrix<double, N, 1>;
+
+/**
+ * This class wraps an ExtendedKalmanFilter to fuse latency-compensated
+ * global measurements(ex. vision) with differential drive encoder measurements.
+ * It will correct for noisy global measurements and encoder drift.
+ *
+ * This class is indented to be paired with a LTVDiffDriveController as it
+ * provides a 10-state estimate. This can then be trimmed into 5-state
+ * using Eigen::Matrix.block<>() with the operation
+ *
+ *     <10-stateEstimate>.block<5, 1>(0, 0)
+ *
+ * then passed into the controller as the current state estimate.
+ *
+ * DifferentialDriveStateEstimator::Update should be called every
+ * robot loop (if your robot loops are faster than the default then you should
+ * use DifferentialDriveStateEstimator::DifferentialDriveStateEstimator(const
+ * LinearSystem<2, 2, 2>&, const Eigen::Matrix<double, 10, 1>&, const Eigen::Matrix<double, 10, 1>&, const
+ * Vector<3>&, const Eigen::Matrix<double, 3, 1>&, const DifferentialDriveKinematics&,
+ * units::second_t)
+ * to change the nominal delta time.)
+ *
+ * DifferentialDriveStateEstimator::ApplyPastGlobalMeasurement can be
+ * called as infrequently as you want.
+ *
+ * Our state-space system is:
+ *
+ * <strong> x = [[x, y, theta, vel_l, vel_r, dist_l, dist_r, voltError_l,
+ * voltError_r, angularVelError]]^T </strong> in the field coordinate system
+ * (dist_* are wheel distances.)
+ *
+ * <strong> u = [[voltage_l, voltage_r]]^T </strong> This is typically the
+ * control input of the last timestep from a LTVDiffDriveController.
+ *
+ * <strong> y = [[x, y, theta]]^T </strong> from vision, or
+ * <strong> y = [[dist_l, dist_r, theta]] </strong> from encoders and gyro.
+ */
+class DifferentialDriveStateEstimator {
+ public:
+  /**
+   * Constructs a DifferentialDriveStateEstimator.
+   *
+   * @param plant                    A LinearSystem representing a
+   * differential drivetrain.
+   * @param initialState             The starting state estimate.
+   * @param stateStdDevs             Standard deviations of model states.
+   * Increase these numbers to trust your model less.
+   * @param localMeasurementStdDevs  Standard deviations of the encoder and gyro
+   * measurements. Increase these numbers to trust encoder distances and gyro
+   *                                 angle less.
+   * @param globalMeasurementStdDevs Standard deviations of the global(vision)
+   * measurements. Increase these numbers to global(vision) measurements less.
+   * @param kinematics               A link DifferentialDriveKinematics
+   * object representing the differential drivetrain's kinematics.
+   * @param nominalDtSeconds         The time in seconds between each robot
+   * loop.
+   */
+  DifferentialDriveStateEstimator(const LinearSystem<2, 2, 2>& plant,
+                                  const Eigen::Matrix<double, 10, 1>& initialState,
+                                  const Eigen::Matrix<double, 10, 1>& stateStdDevs,
+                                  const Eigen::Matrix<double, 3, 1>& localMeasurementStdDevs,
+                                  const Eigen::Matrix<double, 3, 1>& globalMeasurementStdDevs,
+                                  const DifferentialDriveKinematics& kinematics,
+                                  units::second_t nominalDt = 0.02_s);
+
+  /**
+   * Applies a global measurement with a given timestamp.
+   *
+   * @param robotPoseMeters  The measured robot pose.
+   * @param timestampSeconds The timestamp of the global measurement in seconds.
+   * Note that if you don't use your own time source by calling
+   * DifferentialDriveStateEstimator::updateWithTime then you must use a
+   * timestamp with an epoch since FPGA startup (i.e. the epoch of this
+   * timestamp is the same epoch as Timer::getFPGATimestamp.) This means that
+   * you should use Timer::getFPGATimestamp as your time source in this case.
+   */
+  void ApplyPastGlobalMeasurement(const Pose2d& visionRobotPose,
+                                  units::second_t timestamp);
+
+  /**
+   * Gets the state of the robot at the current time as estimated by the
+   * Extended Kalman Filter.
+   *
+   * @return The robot state estimate.
+   */
+  Vector<10> GetEstimatedState() const;
+
+  /**
+   * Gets the state of the robot at the current time as estimated by the Extended Kalman Filter.
+   *
+   * @return The robot state estimate.
+   */
+  frc::Pose2d GetEstimatedPosition();
+
+  /**
+   * Updates the the Extended Kalman Filter using wheel encoder information,
+   * robot heading and the previous control input. The control input can be
+   * obtained from a LTVDiffDriveController.
+   * Note that this should be called every loop.
+   *
+   * @param heading       The current heading of the robot in radians.
+   * @param leftPosition  The distance traveled by the left side of the robot in
+   * meters.
+   * @param rightPosition The distance traveled by the right side of the robot
+   * in meters.
+   * @param controlInput  The control input.
+   * @return The robot state estimate.
+   */
+  Vector<10> Update(units::radian_t heading, units::meter_t leftPosition,
+                    units::meter_t rightPosition,
+                    const Eigen::Matrix<double, 2, 1>& controlInput);
+
+  /**
+   * Updates the the Extended Kalman Filter using wheel encoder information,
+   * robot heading and the previous control input. The control input can be
+   * obtained from a LTVDiffDriveController.
+   * Note that this should be called every loop.
+   *
+   * @param headingRadians     The current heading of the robot in radians.
+   * @param leftPosition       The distance traveled by the left side of the
+   * robot in meters.
+   * @param rightPosition      The distance traveled by the right side of the
+   * robot in meters.
+   * @param controlInput       The control input.
+   * @param currentTimeSeconds Time at which this method was called, in seconds.
+   * @return The robot state estimate.
+   */
+  Vector<10> UpdateWithTime(units::radian_t heading,
+                            units::meter_t leftPosition,
+                            units::meter_t rightPosition,
+                            const Eigen::Matrix<double, 2, 1>& controlInput,
+                            units::second_t currentTime);
+
+  /**
+   * Resets any internal state with a given initial state.
+   *
+   * @param initialState Initial state for state estimate.
+   */
+  void Reset(const Eigen::Matrix<double, 10, 1>& initialState);
+
+  /**
+   * Resets any internal state.
+   */
+  void Reset();
+
+  Vector<10> Dynamics(const Eigen::Matrix<double, 10, 1>& x, const Eigen::Matrix<double, 2, 1>& u);
+
+  static Vector<3> LocalMeasurementModel(const Eigen::Matrix<double, 10, 1>& x,
+                                         const Eigen::Matrix<double, 2, 1>& u);
+
+  static Vector<3> GlobalMeasurementModel(const Eigen::Matrix<double, 10, 1>& x,
+                                          const Eigen::Matrix<double, 2, 1>& u);
+
+ private:
+  LinearSystem<2, 2, 2> m_plant;
+  units::meter_t m_rb;
+
+  ExtendedKalmanFilter<10, 2, 3> m_observer;
+
+  units::second_t m_nominalDt;
+
+  KalmanFilterLatencyCompensator<10, 2, 3, ExtendedKalmanFilter<10, 2, 3>>
+      m_latencyCompensator;
+
+  std::function<void(const Eigen::Matrix<double, 2, 1>& u, const Eigen::Matrix<double, 3, 1>& y)> m_globalCorrect;
+
+  units::second_t m_prevTime = -1_s;
+
+  Vector<3> m_localY;
+  Vector<3> m_globalY;
+
+  template <int Dim>
+  static std::array<double, Dim> StdDevMatrixToArray(
+      const Vector<Dim>& stdDevs);
+
+  class State {
+   public:
+    static constexpr int kX = 0;
+    static constexpr int kY = 1;
+    static constexpr int kHeading = 2;
+    static constexpr int kLeftVelocity = 3;
+    static constexpr int kRightVelocity = 4;
+    static constexpr int kLeftPosition = 5;
+    static constexpr int kRightPosition = 6;
+    static constexpr int kLeftVoltageError = 7;
+    static constexpr int kRightVoltageError = 8;
+    static constexpr int kAngularVelocityError = 9;
+  };
+
+  class Input {
+   public:
+    static constexpr int kLeftVoltage = 0;
+    static constexpr int kRightVoltage = 1;
+  };
+
+  class LocalOutput {
+   public:
+    static constexpr int kHeading = 0;
+    static constexpr int kLeftPosition = 1;
+    static constexpr int kRightPosition = 2;
+  };
+
+  class GlobalOutput {
+   public:
+    static constexpr int kX = 0;
+    static constexpr int kY = 1;
+    static constexpr int kYHeading = 2;
+  };
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/estimator/KalmanFilterLatencyCompensator.h
+++ b/wpilibc/src/main/native/include/frc/estimator/KalmanFilterLatencyCompensator.h
@@ -1,0 +1,142 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Core>
+#include <units/time.h>
+
+namespace frc {
+
+template <int States, int Inputs, int Outputs, typename KalmanFilterType>
+class KalmanFilterLatencyCompensator {
+ public:
+  struct ObserverSnapshot {
+    Eigen::Matrix<double, States, 1> xHat;
+    Eigen::Matrix<double, States, States> errorCovariances;
+    Eigen::Matrix<double, Inputs, 1> inputs;
+    Eigen::Matrix<double, Outputs, 1> localMeasurements;
+
+    ObserverSnapshot(const KalmanFilterType& observer,
+                     const Eigen::Matrix<double, Inputs, 1>& u,
+                     const Eigen::Matrix<double, Outputs, 1>& localY)
+        : xHat(observer.Xhat()),
+          errorCovariances(observer.P()),
+          inputs(u),
+          localMeasurements(localY) {}
+  };
+
+  void AddObserverState(const KalmanFilterType& observer,
+                        Eigen::Matrix<double, Inputs, 1> u,
+                        Eigen::Matrix<double, Outputs, 1> localY,
+                        units::second_t timestamp) {
+    // Add the new state into the vector.
+    m_pastObserverSnapshots.emplace_back(timestamp,
+                                         ObserverSnapshot{observer, u, localY});
+
+    // Remove the oldest snapshot if the vector exceeds our maximum size.
+    if (m_pastObserverSnapshots.size() > kMaxPastObserverStates) {
+      m_pastObserverSnapshots.erase(m_pastObserverSnapshots.begin());
+    }
+  }
+
+  template <int Rows>
+  void ApplyPastMeasurement(
+      KalmanFilterType* observer, units::second_t nominalDt,
+      Eigen::Matrix<double, Rows, 1> y,
+      std::function<void(const Eigen::Matrix<double, Inputs, 1>& u, const Eigen::Matrix<double, Rows, 1>& y)>
+          globalMeasurementCorrect,
+      units::second_t timestamp) {
+    if (m_pastObserverSnapshots.size() == 0) {
+      // State map was empty, which means that we got a measurement right at
+      // startup. The only thing we can do is ignore the measurement.
+      return;
+    }
+
+    // We will perform a binary search to find the index of the element in the
+    // vector that has a timestamp that is equal to or greater than the vision
+    // measurement timestamp.
+
+    // This index starts at one because we use the previous state later on, and
+    // we always want to have a "previous state".
+    int low = 1;
+    int high = m_pastObserverSnapshots.size() - 1;
+
+    while (low != high) {
+      int mid = (low + high) / 2.0;
+      if (m_pastObserverSnapshots[mid].first < timestamp) {
+        // This index and everything under it are less than the requested
+        // timestamp. Therefore, we can discard them.
+        low = mid + 1;
+      } else {
+        // t is at least as large as the element at this index. This means that
+        // anything after it cannot be what we are looking for.
+        high = mid;
+      }
+    }
+
+    // We are simply assigning this index to a new variable to avoid confusion
+    // with variable names.
+    int index = low;
+
+    // High and Low should be the same. The sampled timestamp is greater than or
+    // equal to the vision pose timestamp. We will now find the entry which is
+    // closest in time to the requested timestamp.
+
+    size_t indexOfClosestEntry =
+        units::math::abs(timestamp - m_pastObserverSnapshots[index - 1].first) <
+                units::math::abs(timestamp -
+                                 m_pastObserverSnapshots[index].first)
+            ? index - 1
+            : index;
+
+    units::second_t lastTimestamp =
+        m_pastObserverSnapshots[indexOfClosestEntry].first - nominalDt;
+
+    // We will now go back in time to the state of the system at the time when
+    // the measurement was captured. We will reset the observer to that state,
+    // and apply correction based on the measurement. Then, we will go back
+    // through all observer states until the present and apply past inputs to
+    // get the present estimated state.
+    for (size_t i = indexOfClosestEntry; i < m_pastObserverSnapshots.size();
+         ++i) {
+      auto& [key, snapshot] = m_pastObserverSnapshots[i];
+
+      if (i == indexOfClosestEntry) {
+        observer->SetP(snapshot.errorCovariances);
+        observer->SetXhat(snapshot.xHat);
+      }
+
+      observer->Predict(snapshot.inputs, key - lastTimestamp);
+      observer->Correct(snapshot.inputs, snapshot.localMeasurements);
+
+      if (i == indexOfClosestEntry) {
+        // Note that the measurement is at a timestep close but probably not
+        // exactly equal to the timestep for which we called predict. This makes
+        // the assumption that the dt is small enough that the difference
+        // between the measurement time and the time that the inputs were
+        // captured at is very small.
+        globalMeasurementCorrect(snapshot.inputs, y);
+      }
+
+      lastTimestamp = key;
+      snapshot = ObserverSnapshot{*observer, snapshot.inputs,
+                                  snapshot.localMeasurements};
+    }
+  }
+
+ private:
+  static constexpr size_t kMaxPastObserverStates = 300;
+  std::vector<std::pair<units::second_t, ObserverSnapshot>>
+      m_pastObserverSnapshots;
+};
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/estimator/MecanumDrivePoseEstimator.h
+++ b/wpilibc/src/main/native/include/frc/estimator/MecanumDrivePoseEstimator.h
@@ -1,0 +1,177 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <functional>
+
+#include <Eigen/Core>
+#include <units/time.h>
+
+#include "frc/estimator/ExtendedKalmanFilter.h"
+#include "frc/estimator/KalmanFilterLatencyCompensator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/geometry/Rotation2d.h"
+#include "frc/kinematics/MecanumDriveKinematics.h"
+#include "frc2/Timer.h"
+
+namespace frc {
+
+template <int N>
+using Vector = Eigen::Matrix<double, N, 1>;
+
+/**
+ * This class wraps an ExtendedKalmanFilter to fuse latency-compensated vision
+ * measurements with mecanum drive encoder velocity measurements. It will
+ * correct for noisy measurements and encoder drift. It is intended to be an
+ * easy but more accurate drop-in for MecanumDriveOdometry.
+ *
+ * Update() should be called every robot loop. If your loops are faster or
+ * slower than the default of 0.02s, then you should change the nominal delta
+ * time by specifying it in the constructor.
+ *
+ * AddVisionMeasurement() can be called as infrequently as you want; if you
+ * never call it, then this class will behave mostly like regular encoder
+ * odometry.
+ *
+ * Our state-space system is:
+ *
+ * <strong> x = [[x, y, std::cos(theta), std::sin(theta)]]^T </strong> in the
+ * field-coordinate system.
+ *
+ * <strong> u = [[vx, vy, omega]]^T </strong> in the field-coordinate system.
+ *
+ * <strong> y = [[x, y, std::cos(theta), std::sin(theta)]]^T </strong> in field
+ * coords from vision, or <strong> y = [[cos(theta), std::sin(theta)]]^T
+ * </strong> from the gyro.
+ */
+class MecanumDrivePoseEstimator {
+ public:
+  /**
+   * Constructs a MecanumDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param kinematics               A correctly-configured kinematics object
+   *                                 for your drivetrain.
+   * @param stateStdDevs             Standard deviations of model states.
+   *                                 Increase these numbers to trust your
+   *                                 wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the gyro
+   *                                 measurement. Increase this number
+   *                                 to trust gyro angle measurements less.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder
+   *                                 measurements. Increase these numbers
+   *                                 to trust vision less.
+   * @param nominalDt                The time in seconds between each robot
+   *                                 loop.
+   */
+  MecanumDrivePoseEstimator(const Rotation2d& gyroAngle,
+                            const Pose2d& initialPose,
+                            MecanumDriveKinematics kinematics,
+                            const Vector<3>& stateStdDevs,
+                            const Vector<1>& localMeasurementStdDevs,
+                            const Vector<3>& visionMeasurementStdDevs,
+                            units::second_t nominalDt = 0.02_s);
+
+  /**
+   * Resets the robot's position on the field.
+   *
+   * <p>You NEED to reset your encoders (to zero) when calling this method.
+   *
+   * <p>The gyroscope angle does not need to be reset in the user's robot code.
+   * The library automatically takes care of offsetting the gyro angle.
+   *
+   * @param poseMeters The position on the field that your robot is at.
+   * @param gyroAngle  The angle reported by the gyroscope.
+   */
+  void ResetPosition(const Pose2d& pose, const Rotation2d& gyroAngle);
+
+  /**
+   * Gets the pose of the robot at the current time as estimated by the Extended
+   * Kalman Filter.
+   *
+   * @return The estimated robot pose in meters.
+   */
+  Pose2d GetEstimatedPosition() const;
+
+  /**
+   * Add a vision measurement to the Extended Kalman Filter. This will correct
+   * the odometry pose estimate while still accounting for measurement noise.
+   *
+   * This method can be called as infrequently as you want, as long as you are
+   * calling Update() every loop.
+   *
+   * @param visionRobotPose The pose of the robot as measured by the vision
+   *                        camera.
+   * @param timestamp       The timestamp of the vision measurement in seconds.
+   *                        Note that if you don't use your own time source by
+   *                        calling UpdateWithTime() then you must use a
+   *                        timestamp with an epoch since FPGA startup
+   *                        (i.e. the epoch of this timestamp is the same
+   *                        epoch as Timer#GetFPGATimestamp.) This means
+   *                        that you should use Timer#GetFPGATimestamp as your
+   *                        time source or sync the epochs.
+   */
+  void AddVisionMeasurement(const Pose2d& visionRobotPose,
+                            units::second_t timestamp);
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder
+   * information. This should be called every loop, and the correct loop period
+   * must be passed into the constructor of this class.
+   *
+   * @param gyroAngle   The current gyro angle.
+   * @param wheelSpeeds The current speeds of the mecanum drive wheels.
+   * @return The estimated pose of the robot in meters.
+   */
+  Pose2d Update(const Rotation2d& gyroAngle,
+                const MecanumDriveWheelSpeeds& wheelSpeeds);
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder
+   * information. This should be called every loop, and the correct loop period
+   * must be passed into the constructor of this class.
+   *
+   * @param currentTimeSeconds Time at which this method was called, in seconds.
+   * @param gyroAngle          The current gyroscope angle.
+   * @param wheelSpeeds        The current speeds of the mecanum drive wheels.
+   * @return The estimated pose of the robot in meters.
+   */
+  Pose2d UpdateWithTime(units::second_t currentTime,
+                        const Rotation2d& gyroAngle,
+                        const MecanumDriveWheelSpeeds& wheelSpeeds);
+
+ private:
+  ExtendedKalmanFilter<4, 3, 2> m_observer;
+  MecanumDriveKinematics m_kinematics;
+  KalmanFilterLatencyCompensator<4, 3, 2, ExtendedKalmanFilter<4, 3, 2>>
+      m_latencyCompensator;
+  std::function<void(const Vector<3>& u, const Vector<4>& y)> m_visionCorrect;
+
+  Eigen::Matrix4d m_visionDiscR;
+
+  units::second_t m_nominalDt;
+  units::second_t m_prevTime = -1_s;
+
+  Rotation2d m_gyroOffset;
+  Rotation2d m_previousAngle;
+
+  static Vector<4> F(const Vector<4>& x, const Vector<3>& u);
+
+  template <int Dim>
+  static std::array<double, Dim> StdDevMatrixToArray(
+      const Vector<Dim>& vector) {
+    std::array<double, Dim> array;
+    for (size_t i = 0; i < Dim; ++i) {
+      array[i] = vector(i);
+    }
+    return array;
+  }
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
+++ b/wpilibc/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
@@ -1,0 +1,269 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <array>
+#include <iostream>
+#include <limits>
+
+#include <Eigen/Core>
+#include <units/time.h>
+
+#include "frc/StateSpaceUtil.h"
+#include "frc/estimator/ExtendedKalmanFilter.h"
+#include "frc/estimator/KalmanFilterLatencyCompensator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/geometry/Rotation2d.h"
+#include "frc/kinematics/SwerveDriveKinematics.h"
+#include "frc2/Timer.h"
+
+namespace frc {
+
+template <int N>
+using Vector = Eigen::Matrix<double, N, 1>;
+
+/**
+ * This class wraps an ExtendedKalmanFilter to fuse latency-compensated vision
+ * measurements with swerve drive encoder velocity measurements. It will correct
+ * for noisy measurements and encoder drift. It is intended to be an easy but
+ * more accurate drop-in for SwerveDriveOdometry.
+ *
+ * Update() should be called every robot loop. If your loops are faster or
+ * slower than the default of 0.02s, then you should change the nominal delta
+ * time by specifying it in the constructor.
+ *
+ * AddVisionMeasurement() can be called as infrequently as you want; if you
+ * never call it, then this class will behave mostly like regular encoder
+ * odometry.
+ *
+ * Our state-space system is:
+ *
+ * <strong> x = [[x, y, std::cos(theta), std::sin(theta)]]^T </strong> in the
+ * field-coordinate system.
+ *
+ * <strong> u = [[vx, vy, omega]]^T </strong> in the field-coordinate system.
+ *
+ * <strong> y = [[x, y, std::cos(theta), std::sin(theta)]]^T </strong> in field
+ * coords from vision, or <strong> y = [[cos(theta), std::sin(theta)]]^T
+ * </strong> from the gyro.
+ */
+template <size_t NumModules>
+class SwerveDrivePoseEstimator {
+ public:
+  /**
+   * Constructs a SwerveDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param kinematics               A correctly-configured kinematics object
+   *                                 for your drivetrain.
+   * @param stateStdDevs             Standard deviations of model states.
+   *                                 Increase these numbers to trust your
+   *                                 wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the gyro
+   *                                 measurement. Increase this number to
+   *                                 trust gyro angle measurements less.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder
+   *                                 measurements. Increase these numbers to
+   *                                 trust vision less.
+   * @param nominalDt                The time in seconds between each robot
+   *                                 loop.
+   */
+  SwerveDrivePoseEstimator(const Rotation2d& gyroAngle,
+                           const Pose2d& initialPose,
+                           SwerveDriveKinematics<NumModules>& kinematics,
+                           const Vector<3>& stateStdDevs,
+                           const Vector<1>& localMeasurementStdDevs,
+                           const Vector<3>& visionMeasurementStdDevs,
+                           units::second_t nominalDt = 0.02_s)
+      : m_observer(
+            &SwerveDrivePoseEstimator::F,
+            [](const Vector<4>& x, const Vector<3>& u) {
+              return x.block<2, 1>(2, 0);
+            },
+            StdDevMatrixToArray<4>(frc::MakeMatrix<4, 1>(
+                stateStdDevs(0), stateStdDevs(1), std::cos(stateStdDevs(2)),
+                std::sin(stateStdDevs(2)))),
+            StdDevMatrixToArray<2>(
+                frc::MakeMatrix<2, 1>(std::cos(localMeasurementStdDevs(0)),
+                                      std::sin(localMeasurementStdDevs(0)))),
+            nominalDt),
+        m_kinematics(kinematics),
+        m_nominalDt(nominalDt) {
+    // Construct R (covariances) matrix for vision measurements.
+    Eigen::Matrix4d visionContR =
+        frc::MakeCovMatrix<4>(StdDevMatrixToArray<4>(frc::MakeMatrix<4, 1>(
+            visionMeasurementStdDevs(0), visionMeasurementStdDevs(1),
+            std::cos(visionMeasurementStdDevs(2)),
+            std::sin(visionMeasurementStdDevs(2)))));
+
+    // Create and store discrete covariance matrix for vision measurements.
+    m_visionDiscR = frc::DiscretizeR<4>(visionContR, m_nominalDt);
+
+    // Create correction mechanism for vision measurements.
+    m_visionCorrect = [&](const Vector<3>& u, const Vector<4>& y) {
+      m_observer.Correct<4>(
+          u, y, [](const Vector<4>& x, const Vector<3>& u) { return x; },
+          m_visionDiscR);
+    };
+
+    // Set initial state.
+    m_observer.SetXhat(PoseTo4dVector(initialPose));
+
+    // Calculate offsets.
+    m_gyroOffset = initialPose.Rotation() - gyroAngle;
+    m_previousAngle = initialPose.Rotation();
+  }
+
+  /**
+   * Resets the robot's position on the field.
+   *
+   * You NEED to reset your encoders (to zero) when calling this method.
+   *
+   * The gyroscope angle does not need to be reset in the user's robot code.
+   * The library automatically takes care of offsetting the gyro angle.
+   *
+   * @param pose      The position on the field that your robot is at.
+   * @param gyroAngle The angle reported by the gyroscope.
+   */
+  void ResetPosition(const Pose2d& pose, const Rotation2d& gyroAngle) {
+    // Set observer state.
+    m_observer.SetXhat(PoseTo4dVector(pose));
+
+    // Calculate offsets.
+    m_gyroOffset = pose.Rotation() - gyroAngle;
+    m_previousAngle = pose.Rotation();
+  }
+
+  /**
+   * Gets the pose of the robot at the current time as estimated by the Extended
+   * Kalman Filter.
+   *
+   * @return The estimated robot pose in meters.
+   */
+  Pose2d GetEstimatedPosition() const {
+    return Pose2d(m_observer.Xhat(0) * 1_m, m_observer.Xhat(1) * 1_m,
+                  Rotation2d(m_observer.Xhat(2), m_observer.Xhat(3)));
+  }
+
+  /**
+   * Add a vision measurement to the Extended Kalman Filter. This will correct
+   * the odometry pose estimate while still accounting for measurement noise.
+   *
+   * This method can be called as infrequently as you want, as long as you are
+   * calling Update() every loop.
+   *
+   * @param visionRobotPose The pose of the robot as measured by the vision
+   *                        camera.
+   * @param timestamp       The timestamp of the vision measurement in seconds.
+   *                        Note that if you don't use your own time source by
+   *                        calling UpdateWithTime() then you must use a
+   *                        timestamp with an epoch since FPGA startup
+   *                        (i.e. the epoch of this timestamp is the same
+   *                        epoch as Timer#GetFPGATimestamp.) This means
+   *                        that you should use Timer#GetFPGATimestamp as your
+   *                        time source or sync the epochs.
+   */
+  void AddVisionMeasurement(const Pose2d& visionRobotPose,
+                            units::second_t timestamp) {
+    m_latencyCompensator.ApplyPastMeasurement<4>(
+        &m_observer, m_nominalDt, PoseTo4dVector(visionRobotPose),
+        m_visionCorrect, timestamp);
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder
+   * information. This should be called every loop, and the correct loop period
+   * must be passed into the constructor of this class.
+   *
+   * @param gyroAngle    The current gyro angle.
+   * @param moduleStates The current velocities and rotations of the swerve
+   *                     modules.
+   * @return The estimated pose of the robot in meters.
+   */
+  template <typename... ModuleState>
+  Pose2d Update(const Rotation2d& gyroAngle, ModuleState&&... moduleStates) {
+    return UpdateWithTime(frc2::Timer::GetFPGATimestamp(), gyroAngle,
+                          moduleStates...);
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder
+   * information. This should be called every loop, and the correct loop period
+   * must be passed into the constructor of this class.
+   *
+   * @param currentTime  Time at which this method was called, in seconds.
+   * @param gyroAngle    The current gyroscope angle.
+   * @param moduleStates The current velocities and rotations of the swerve
+   *                     modules.
+   * @return The estimated pose of the robot in meters.
+   */
+  template <typename... ModuleState>
+  Pose2d UpdateWithTime(units::second_t currentTime,
+                        const Rotation2d& gyroAngle,
+                        ModuleState&&... moduleStates) {
+    auto dt = m_prevTime >= 0_s ? currentTime - m_prevTime : m_nominalDt;
+    m_prevTime = currentTime;
+
+    auto angle = gyroAngle + m_gyroOffset;
+    auto omega = (angle - m_previousAngle).Radians() / dt;
+
+    auto chassisSpeeds = m_kinematics.ToChassisSpeeds(moduleStates...);
+    auto fieldRelativeSpeeds =
+        Translation2d(chassisSpeeds.vx * 1_s, chassisSpeeds.vy * 1_s)
+            .RotateBy(angle);
+
+    auto u =
+        frc::MakeMatrix<3, 1>(fieldRelativeSpeeds.X().template to<double>(),
+                              fieldRelativeSpeeds.Y().template to<double>(),
+                              omega.template to<double>());
+
+    auto localY =
+        frc::MakeMatrix<2, 1>(std::cos(angle.Radians().template to<double>()),
+                              std::sin(angle.Radians().template to<double>()));
+    m_previousAngle = angle;
+
+    m_latencyCompensator.AddObserverState(m_observer, u, localY, currentTime);
+
+    m_observer.Predict(u, dt);
+    m_observer.Correct(u, localY);
+
+    return GetEstimatedPosition();
+  }
+
+ private:
+  ExtendedKalmanFilter<4, 3, 2> m_observer;
+  SwerveDriveKinematics<NumModules>& m_kinematics;
+  KalmanFilterLatencyCompensator<4, 3, 2, ExtendedKalmanFilter<4, 3, 2>>
+      m_latencyCompensator;
+  std::function<void(const Vector<3>& u, const Vector<4>& y)> m_visionCorrect;
+
+  Eigen::Matrix4d m_visionDiscR;
+
+  units::second_t m_nominalDt;
+  units::second_t m_prevTime = -1_s;
+
+  Rotation2d m_gyroOffset;
+  Rotation2d m_previousAngle;
+
+  static Vector<4> F(const Vector<4>& x, const Vector<3>& u) {
+    return frc::MakeMatrix<4, 1>(u(0), u(1), -x(3) * u(2), x(2) * u(2));
+  }
+
+  template <int Dim>
+  static std::array<double, Dim> StdDevMatrixToArray(
+      const Vector<Dim>& vector) {
+    std::array<double, Dim> array;
+    for (size_t i = 0; i < Dim; ++i) {
+      array[i] = vector(i);
+    }
+    return array;
+  }
+};
+
+}  // namespace frc

--- a/wpilibc/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
+++ b/wpilibc/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
@@ -1,0 +1,110 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <limits>
+#include <random>
+
+#include <units/angle.h>
+#include <units/length.h>
+#include <units/time.h>
+
+#include "frc/StateSpaceUtil.h"
+#include "frc/estimator/DifferentialDrivePoseEstimator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/geometry/Rotation2d.h"
+#include "frc/kinematics/DifferentialDriveKinematics.h"
+#include "frc/kinematics/DifferentialDriveOdometry.h"
+#include "frc/trajectory/TrajectoryGenerator.h"
+#include "frc2/Timer.h"
+#include "gtest/gtest.h"
+
+TEST(DifferentialDrivePoseEstimatorTest, TestAccuracy) {
+  frc::DifferentialDrivePoseEstimator estimator{
+      frc::Rotation2d(), frc::Pose2d(),
+      frc::MakeMatrix<5, 1>(0.01, 0.01, 0.01, 0.01, 0.01),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1)};
+
+  frc::Trajectory trajectory = frc::TrajectoryGenerator::GenerateTrajectory(
+      std::vector{frc::Pose2d(), frc::Pose2d(20_m, 20_m, frc::Rotation2d()),
+                  frc::Pose2d(54_m, 54_m, frc::Rotation2d())},
+      frc::TrajectoryConfig(10_mps, 5.0_mps_sq));
+
+  frc::DifferentialDriveKinematics kinematics{1.0_m};
+  frc::DifferentialDriveOdometry odometry{frc::Rotation2d()};
+
+  std::default_random_engine generator;
+  std::normal_distribution<double> distribution(0.0, 1.0);
+
+  units::second_t dt = 0.02_s;
+  units::second_t t = 0.0_s;
+
+  units::meter_t leftDistance = 0_m;
+  units::meter_t rightDistance = 0_m;
+
+  units::second_t kVisionUpdateRate = 0.1_s;
+  frc::Pose2d lastVisionPose;
+  units::second_t lastVisionUpdateRealTimestamp{
+      -std::numeric_limits<double>::max()};
+  units::second_t lastVisionUpdateTime{-std::numeric_limits<double>::max()};
+
+  double maxError = -std::numeric_limits<double>::max();
+  double errorSum = 0;
+
+  while (t <= trajectory.TotalTime()) {
+    auto groundTruthState = trajectory.Sample(t);
+    auto input = kinematics.ToWheelSpeeds(
+        {groundTruthState.velocity, 0_mps,
+         groundTruthState.velocity * groundTruthState.curvature});
+
+    if (lastVisionUpdateTime + kVisionUpdateRate < t) {
+      if (lastVisionPose != frc::Pose2d()) {
+        estimator.AddVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
+      }
+      lastVisionPose =
+          groundTruthState.pose +
+          frc::Transform2d(
+              frc::Translation2d(distribution(generator) * 0.1 * 1_m,
+                                 distribution(generator) * 0.1 * 1_m),
+              frc::Rotation2d(distribution(generator) * 0.1 * 1_rad));
+
+      lastVisionUpdateRealTimestamp = frc2::Timer::GetFPGATimestamp();
+      lastVisionUpdateTime = t;
+    }
+
+    leftDistance += input.left * distribution(generator) * 0.1 * dt;
+    rightDistance += input.right * distribution(generator) * 0.1 * dt;
+
+    auto xhat = estimator.UpdateWithTime(
+        t,
+        groundTruthState.pose.Rotation() +
+            frc::Rotation2d(units::radian_t(distribution(generator) * 0.1)),
+        input, leftDistance, rightDistance);
+
+    double error = groundTruthState.pose.Translation()
+                       .Distance(xhat.Translation())
+                       .to<double>();
+
+    if (error > maxError) {
+      maxError = error;
+    }
+    errorSum += error;
+
+    t += dt;
+  }
+
+  std::cout << "error sum "
+            << errorSum /
+                   (trajectory.TotalTime().to<double>() / dt.to<double>())
+            << std::endl;
+  std::cout << "max error " << maxError << std::endl;
+
+  //  EXPECT_NEAR(0.0, errorSum / (trajectory.TotalTime().to<double>() /
+  //  dt.to<double>()),
+  //            0.2);
+  //  EXPECT_NEAR(0.0, maxError, 0.4);
+}

--- a/wpilibc/src/test/native/cpp/estimator/DifferentialDriveStateEstimatorTest.cpp
+++ b/wpilibc/src/test/native/cpp/estimator/DifferentialDriveStateEstimatorTest.cpp
@@ -1,0 +1,161 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <iostream>
+#include <limits>
+#include <random>
+
+#include <Eigen/Core>
+#include <wpi/MathExtras.h>
+
+#include "frc/StateSpaceUtil.h"
+#include "frc/controller/ControlAffinePlantInversionFeedforward.h"
+#include "frc/estimator/DifferentialDriveStateEstimator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/geometry/Rotation2d.h"
+#include "frc/kinematics/DifferentialDriveKinematics.h"
+#include "frc/kinematics/DifferentialDriveOdometry.h"
+#include "frc/system/LinearSystem.h"
+#include "frc/system/plant/LinearSystemId.h"
+#include "frc/trajectory/TrajectoryGenerator.h"
+#include "frc2/Timer.h"
+#include "gtest/gtest.h"
+
+using namespace frc;
+
+void ScaleCappedU(Eigen::Matrix<double, 2, 1>* u) {
+  bool outputCapped =
+      std::abs((*u)(0, 0)) > 12.0 || std::abs((*u)(1, 0)) > 12.0;
+
+  if (outputCapped) {
+    *u *= 12.0 / u->lpNorm<Eigen::Infinity>();
+  }
+}
+
+TEST(DifferentialDriveStateEstimatorTest, TestAccuracy) {
+  constexpr auto dt = 0.00505_s;
+
+  const LinearSystem<2, 2, 2> plant =
+      frc::LinearSystemId::IdentifyDrivetrainSystem(3.02, 0.642, 1.382,
+                                                    0.08495);
+
+  const DifferentialDriveKinematics kinematics{0.990405073902434_m};
+
+  frc::DifferentialDriveStateEstimator estimator{
+      plant,
+      Eigen::Matrix<double, 10, 1>::Zero(),
+      frc::MakeMatrix<10, 1>(0.002, 0.002, 0.0001, 1.5, 1.5, 0.5, 0.5, 10.0,
+                             10.0, 2.0),
+      frc::MakeMatrix<3, 1>(0.0001, 0.005, 0.005),
+      frc::MakeMatrix<3, 1>(0.5, 0.5, 0.5),
+      kinematics,
+      dt};
+
+  std::function<Eigen::Matrix<double, 10, 1>(
+      const Eigen::Matrix<double, 10, 1>&, const Eigen::Matrix<double, 2, 1>&)>
+      modelDynamics =
+          [&](auto& x, auto& u) { return estimator.Dynamics(x, u); };
+
+  ControlAffinePlantInversionFeedforward<10, 2> feedforward{modelDynamics, dt};
+
+  auto config = TrajectoryConfig(
+      units::meters_per_second_t(12 / 3.5),
+      units::meters_per_second_squared_t(12 / 0.642) - 17.5_mps_sq);
+
+  frc::Trajectory trajectory = frc::TrajectoryGenerator::GenerateTrajectory(
+      frc::Pose2d(0_m, 0_m, 0_rad), {}, frc::Pose2d(4.8768_m, 2.7432_m, 0_rad),
+      config);
+
+  std::default_random_engine generator;
+  std::normal_distribution<double> distribution(0.0, 1.0);
+
+  units::second_t t = 0.0_s;
+
+  units::second_t kVisionUpdateRate = 0.1_s;
+  frc::Pose2d lastVisionPose;
+  units::second_t lastVisionUpdateRealTimestamp{
+      -std::numeric_limits<double>::max()};
+  units::second_t lastVisionUpdateTime{-std::numeric_limits<double>::max()};
+  units::meter_t leftDistance = 0_m;
+  units::meter_t rightDistance = 0_m;
+
+  double maxError = -std::numeric_limits<double>::max();
+  double errorSum = 0;
+
+  Eigen::Matrix<double, 2, 1> input;
+
+  while (t <= trajectory.TotalTime()) {
+    auto groundTruthState = trajectory.Sample(t);
+
+    auto wheelSpeeds = kinematics.ToWheelSpeeds(
+        {groundTruthState.velocity, 0_mps,
+         groundTruthState.velocity * groundTruthState.curvature});
+
+    Eigen::Matrix<double, 10, 1> x;
+    x << groundTruthState.pose.Translation().X().to<double>(),
+        groundTruthState.pose.Translation().Y().to<double>(),
+        groundTruthState.pose.Rotation().Radians().to<double>(),
+        wheelSpeeds.left.to<double>(), wheelSpeeds.right.to<double>(), 0.0, 0.0,
+        0.0, 0.0, 0.0;
+
+    input = feedforward.Calculate(x);
+
+    ScaleCappedU(&input);
+
+    if (lastVisionUpdateTime + kVisionUpdateRate < t) {
+      if (lastVisionPose != frc::Pose2d()) {
+        estimator.ApplyPastGlobalMeasurement(lastVisionPose,
+                                             lastVisionUpdateTime);
+      }
+      lastVisionPose =
+          groundTruthState.pose +
+          frc::Transform2d(
+              frc::Translation2d(distribution(generator) * 0.5 * 1_m,
+                                 distribution(generator) * 0.5 * 1_m),
+              frc::Rotation2d(distribution(generator) * 0.5 * 1_rad));
+
+      lastVisionUpdateRealTimestamp = frc2::Timer::GetFPGATimestamp();
+      lastVisionUpdateTime = t;
+    }
+
+    leftDistance += wheelSpeeds.left * dt;
+    rightDistance += wheelSpeeds.right * dt;
+
+    leftDistance += distribution(generator) * 0.005_m;
+    rightDistance += distribution(generator) * 0.005_m;
+
+    auto xhat = estimator.UpdateWithTime(
+        (groundTruthState.pose.Rotation() +
+         frc::Rotation2d(units::radian_t(distribution(generator) * 0.0001)))
+            .Radians(),
+        leftDistance, rightDistance, input, t);
+
+    frc::Translation2d estimatedTranslation{units::meter_t(xhat(0, 0)),
+                                            units::meter_t(xhat(1, 0))};
+
+    double error = groundTruthState.pose.Translation()
+                       .Distance(estimatedTranslation)
+                       .to<double>();
+    if (error > maxError) {
+      maxError = error;
+    }
+    errorSum += error;
+
+    std::cout << groundTruthState.pose.Translation().X().to<double>() 
+      << "," << groundTruthState.pose.Translation().Y().to<double>() 
+      << "," << estimatedTranslation.X().to<double>() << ","
+      << estimatedTranslation.Y().to<double>() << "," << error << "\n";
+
+    t += dt;
+  }
+
+  EXPECT_LT(errorSum / (trajectory.TotalTime().to<double>() / dt.to<double>()),
+            0.2);
+  EXPECT_LT(maxError, 0.4);
+
+  std::cout << "Sum over time: " << errorSum / (trajectory.TotalTime().to<double>() / dt.to<double>()) << " max error " << maxError << "\n"; 
+}

--- a/wpilibc/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
+++ b/wpilibc/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
@@ -1,0 +1,97 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <limits>
+#include <random>
+
+#include "frc/estimator/MecanumDrivePoseEstimator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/kinematics/MecanumDriveKinematics.h"
+#include "frc/kinematics/MecanumDriveOdometry.h"
+#include "frc/trajectory/TrajectoryGenerator.h"
+#include "gtest/gtest.h"
+
+TEST(MecanumDrivePoseEstimatorTest, TestAccuracy) {
+  frc::MecanumDriveKinematics kinematics{
+      frc::Translation2d{1_m, 1_m}, frc::Translation2d{1_m, -1_m},
+      frc::Translation2d{-1_m, -1_m}, frc::Translation2d{-1_m, 1_m}};
+
+  frc::MecanumDrivePoseEstimator estimator{
+      frc::Rotation2d(),
+      frc::Pose2d(),
+      kinematics,
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1),
+      frc::MakeMatrix<1, 1>(0.05),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1)};
+
+  frc::MecanumDriveOdometry odometry{kinematics, frc::Rotation2d()};
+
+  frc::Trajectory trajectory = frc::TrajectoryGenerator::GenerateTrajectory(
+      std::vector{frc::Pose2d(), frc::Pose2d(20_m, 20_m, frc::Rotation2d()),
+                  frc::Pose2d(10_m, 10_m, frc::Rotation2d(180_deg)),
+                  frc::Pose2d(30_m, 30_m, frc::Rotation2d()),
+                  frc::Pose2d(20_m, 20_m, frc::Rotation2d(180_deg)),
+                  frc::Pose2d(10_m, 10_m, frc::Rotation2d())},
+      frc::TrajectoryConfig(5.0_mps, 2.0_mps_sq));
+
+  std::default_random_engine generator;
+  std::normal_distribution<double> distribution(0.0, 1.0);
+
+  units::second_t dt = 0.02_s;
+  units::second_t t = 0_s;
+
+  units::second_t kVisionUpdateRate = 0.1_s;
+  frc::Pose2d lastVisionPose;
+  units::second_t lastVisionUpdateTime{-std::numeric_limits<double>::max()};
+
+  std::vector<frc::Pose2d> visionPoses;
+
+  double maxError = -std::numeric_limits<double>::max();
+  double errorSum = 0;
+
+  while (t < trajectory.TotalTime()) {
+    frc::Trajectory::State groundTruthState = trajectory.Sample(t);
+
+    if (lastVisionUpdateTime + kVisionUpdateRate < t) {
+      if (lastVisionPose != frc::Pose2d()) {
+        estimator.AddVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
+      }
+      lastVisionPose =
+          groundTruthState.pose +
+          frc::Transform2d(
+              frc::Translation2d(distribution(generator) * 0.1_m,
+                                 distribution(generator) * 0.1_m),
+              frc::Rotation2d(distribution(generator) * 0.1 * 1_rad));
+      visionPoses.push_back(lastVisionPose);
+      lastVisionUpdateTime = t;
+    }
+
+    auto wheelSpeeds = kinematics.ToWheelSpeeds(
+        {groundTruthState.velocity, 0_mps,
+         groundTruthState.velocity * groundTruthState.curvature});
+
+    auto xhat = estimator.UpdateWithTime(
+        t,
+        groundTruthState.pose.Rotation() +
+            frc::Rotation2d(distribution(generator) * 0.05_rad),
+        wheelSpeeds);
+    double error = groundTruthState.pose.Translation()
+                       .Distance(xhat.Translation())
+                       .to<double>();
+
+    if (error > maxError) {
+      maxError = error;
+    }
+    errorSum += error;
+
+    t += dt;
+  }
+
+  EXPECT_LT(errorSum / (trajectory.TotalTime().to<double>() / dt.to<double>()),
+            0.2);
+  EXPECT_LT(maxError, 0.4);
+}

--- a/wpilibc/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
+++ b/wpilibc/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
@@ -1,0 +1,97 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <limits>
+#include <random>
+
+#include "frc/estimator/SwerveDrivePoseEstimator.h"
+#include "frc/geometry/Pose2d.h"
+#include "frc/kinematics/SwerveDriveKinematics.h"
+#include "frc/kinematics/SwerveDriveOdometry.h"
+#include "frc/trajectory/TrajectoryGenerator.h"
+#include "gtest/gtest.h"
+
+TEST(SwerveDrivePoseEstimatorTest, TestAccuracy) {
+  frc::SwerveDriveKinematics<4> kinematics{
+      frc::Translation2d{1_m, 1_m}, frc::Translation2d{1_m, -1_m},
+      frc::Translation2d{-1_m, -1_m}, frc::Translation2d{-1_m, 1_m}};
+
+  frc::SwerveDrivePoseEstimator<4> estimator{
+      frc::Rotation2d(),
+      frc::Pose2d(),
+      kinematics,
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1),
+      frc::MakeMatrix<1, 1>(0.05),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1)};
+
+  frc::SwerveDriveOdometry<4> odometry{kinematics, frc::Rotation2d()};
+
+  frc::Trajectory trajectory = frc::TrajectoryGenerator::GenerateTrajectory(
+      std::vector{frc::Pose2d(), frc::Pose2d(20_m, 20_m, frc::Rotation2d()),
+                  frc::Pose2d(10_m, 10_m, frc::Rotation2d(180_deg)),
+                  frc::Pose2d(30_m, 30_m, frc::Rotation2d()),
+                  frc::Pose2d(20_m, 20_m, frc::Rotation2d(180_deg)),
+                  frc::Pose2d(10_m, 10_m, frc::Rotation2d())},
+      frc::TrajectoryConfig(5.0_mps, 2.0_mps_sq));
+
+  std::default_random_engine generator;
+  std::normal_distribution<double> distribution(0.0, 1.0);
+
+  units::second_t dt = 0.02_s;
+  units::second_t t = 0_s;
+
+  units::second_t kVisionUpdateRate = 0.1_s;
+  frc::Pose2d lastVisionPose;
+  units::second_t lastVisionUpdateTime{-std::numeric_limits<double>::max()};
+
+  std::vector<frc::Pose2d> visionPoses;
+
+  double maxError = -std::numeric_limits<double>::max();
+  double errorSum = 0;
+
+  while (t < trajectory.TotalTime()) {
+    frc::Trajectory::State groundTruthState = trajectory.Sample(t);
+
+    if (lastVisionUpdateTime + kVisionUpdateRate < t) {
+      if (lastVisionPose != frc::Pose2d()) {
+        estimator.AddVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
+      }
+      lastVisionPose =
+          groundTruthState.pose +
+          frc::Transform2d(
+              frc::Translation2d(distribution(generator) * 0.1_m,
+                                 distribution(generator) * 0.1_m),
+              frc::Rotation2d(distribution(generator) * 0.1 * 1_rad));
+      visionPoses.push_back(lastVisionPose);
+      lastVisionUpdateTime = t;
+    }
+
+    auto moduleStates = kinematics.ToSwerveModuleStates(
+        {groundTruthState.velocity, 0_mps,
+         groundTruthState.velocity * groundTruthState.curvature});
+
+    auto xhat = estimator.UpdateWithTime(
+        t,
+        groundTruthState.pose.Rotation() +
+            frc::Rotation2d(distribution(generator) * 0.05_rad),
+        moduleStates[0], moduleStates[1], moduleStates[2], moduleStates[3]);
+    double error = groundTruthState.pose.Translation()
+                       .Distance(xhat.Translation())
+                       .to<double>();
+
+    if (error > maxError) {
+      maxError = error;
+    }
+    errorSum += error;
+
+    t += dt;
+  }
+
+  EXPECT_LT(errorSum / (trajectory.TotalTime().to<double>() / dt.to<double>()),
+            0.2);
+  EXPECT_LT(maxError, 0.4);
+}

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/cpp/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/cpp/Drivetrain.cpp
@@ -1,0 +1,45 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "Drivetrain.h"
+
+#include <frc/Timer.h>
+
+#include "ExampleGlobalMeasurementSensor.h"
+
+void Drivetrain::SetSpeeds(const frc::DifferentialDriveWheelSpeeds& speeds) {
+  const auto leftFeedforward = m_feedforward.Calculate(speeds.left);
+  const auto rightFeedforward = m_feedforward.Calculate(speeds.right);
+  const double leftOutput = m_leftPIDController.Calculate(
+      m_leftEncoder.GetRate(), speeds.left.to<double>());
+  const double rightOutput = m_rightPIDController.Calculate(
+      m_rightEncoder.GetRate(), speeds.right.to<double>());
+
+  m_leftGroup.SetVoltage(units::volt_t{leftOutput} + leftFeedforward);
+  m_rightGroup.SetVoltage(units::volt_t{rightOutput} + rightFeedforward);
+}
+
+void Drivetrain::Drive(units::meters_per_second_t xSpeed,
+                       units::radians_per_second_t rot) {
+  SetSpeeds(m_kinematics.ToWheelSpeeds({xSpeed, 0_mps, rot}));
+}
+
+void Drivetrain::UpdateOdometry() {
+  m_poseEstimator.Update(m_gyro.GetRotation2d(),
+                         {units::meters_per_second_t(m_leftEncoder.GetRate()),
+                          units::meters_per_second_t(m_rightEncoder.GetRate())},
+                         units::meter_t(m_leftEncoder.GetDistance()),
+                         units::meter_t(m_rightEncoder.GetDistance()));
+
+  // Also apply vision measurements. We use 0.3 seconds in the past as an
+  // example -- on a real robot, this must be calculated based either on latency
+  // or timestamps.
+  m_poseEstimator.AddVisionMeasurement(
+      ExampleGlobalMeasurementSensor::GetEstimatedGlobalPose(
+          m_poseEstimator.GetEstimatedPosition()),
+      units::second_t{frc::Timer::GetFPGATimestamp() - 0.3});
+}

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/cpp/Robot.cpp
@@ -1,0 +1,52 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <frc/SlewRateLimiter.h>
+#include <frc/TimedRobot.h>
+#include <frc/XboxController.h>
+
+#include "Drivetrain.h"
+
+class Robot : public frc::TimedRobot {
+ public:
+  void AutonomousPeriodic() override {
+    TeleopPeriodic();
+    m_drive.UpdateOdometry();
+  }
+
+  void TeleopPeriodic() override {
+    // Get the x speed. We are inverting this because Xbox controllers return
+    // negative values when we push forward.
+    const auto xSpeed = -m_speedLimiter.Calculate(
+                            m_controller.GetY(frc::GenericHID::kLeftHand)) *
+                        Drivetrain::kMaxSpeed;
+
+    // Get the rate of angular rotation. We are inverting this because we want a
+    // positive value when we pull to the left (remember, CCW is positive in
+    // mathematics). Xbox controllers return positive values when you pull to
+    // the right by default.
+    const auto rot = -m_rotLimiter.Calculate(
+                         m_controller.GetX(frc::GenericHID::kRightHand)) *
+                     Drivetrain::kMaxAngularSpeed;
+
+    m_drive.Drive(xSpeed, rot);
+  }
+
+ private:
+  frc::XboxController m_controller{0};
+
+  // Slew rate limiters to make joystick inputs more gentle; 1/3 sec from 0
+  // to 1.
+  frc::SlewRateLimiter<units::scalar> m_speedLimiter{3 / 1_s};
+  frc::SlewRateLimiter<units::scalar> m_rotLimiter{3 / 1_s};
+
+  Drivetrain m_drive;
+};
+
+#ifndef RUNNING_FRC_TESTS
+int main() { return frc::StartRobot<Robot>(); }
+#endif

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/include/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/include/Drivetrain.h
@@ -1,0 +1,87 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/AnalogGyro.h>
+#include <frc/Encoder.h>
+#include <frc/PWMVictorSPX.h>
+#include <frc/SpeedControllerGroup.h>
+#include <frc/controller/PIDController.h>
+#include <frc/controller/SimpleMotorFeedforward.h>
+#include <frc/estimator/DifferentialDrivePoseEstimator.h>
+#include <frc/kinematics/DifferentialDriveKinematics.h>
+#include <units/angle.h>
+#include <units/angular_velocity.h>
+#include <units/length.h>
+#include <units/velocity.h>
+#include <wpi/math>
+
+/**
+ * Represents a differential drive style drivetrain.
+ */
+class Drivetrain {
+ public:
+  Drivetrain() {
+    m_gyro.Reset();
+    // Set the distance per pulse for the drive encoders. We can simply use the
+    // distance traveled for one rotation of the wheel divided by the encoder
+    // resolution.
+    m_leftEncoder.SetDistancePerPulse(2 * wpi::math::pi * kWheelRadius /
+                                      kEncoderResolution);
+    m_rightEncoder.SetDistancePerPulse(2 * wpi::math::pi * kWheelRadius /
+                                       kEncoderResolution);
+
+    m_leftEncoder.Reset();
+    m_rightEncoder.Reset();
+  }
+
+  static constexpr units::meters_per_second_t kMaxSpeed =
+      3.0_mps;  // 3 meters per second
+  static constexpr units::radians_per_second_t kMaxAngularSpeed{
+      wpi::math::pi};  // 1/2 rotation per second
+
+  void SetSpeeds(const frc::DifferentialDriveWheelSpeeds& speeds);
+  void Drive(units::meters_per_second_t xSpeed,
+             units::radians_per_second_t rot);
+  void UpdateOdometry();
+
+ private:
+  static constexpr units::meter_t kTrackWidth = 0.381_m * 2;
+  static constexpr double kWheelRadius = 0.0508;  // meters
+  static constexpr int kEncoderResolution = 4096;
+
+  frc::PWMVictorSPX m_leftLeader{1};
+  frc::PWMVictorSPX m_leftFollower{2};
+  frc::PWMVictorSPX m_rightLeader{3};
+  frc::PWMVictorSPX m_rightFollower{4};
+
+  frc::SpeedControllerGroup m_leftGroup{m_leftLeader, m_leftFollower};
+  frc::SpeedControllerGroup m_rightGroup{m_rightLeader, m_rightFollower};
+
+  frc::Encoder m_leftEncoder{0, 1};
+  frc::Encoder m_rightEncoder{2, 3};
+
+  frc2::PIDController m_leftPIDController{1.0, 0.0, 0.0};
+  frc2::PIDController m_rightPIDController{1.0, 0.0, 0.0};
+
+  frc::AnalogGyro m_gyro{0};
+
+  frc::DifferentialDriveKinematics m_kinematics{kTrackWidth};
+
+  // Gains are for example purposes only - must be determined for your own
+  // robot!
+  frc::DifferentialDrivePoseEstimator m_poseEstimator{
+      frc::Rotation2d(), frc::Pose2d(),
+      frc::MakeMatrix<5, 1>(0.01, 0.01, 0.01, 0.01, 0.01),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1)};
+
+  // Gains are for example purposes only - must be determined for your own
+  // robot!
+  frc::SimpleMotorFeedforward<units::meters> m_feedforward{1_V, 3_V / 1_mps};
+};

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/include/ExampleGlobalMeasurementSensor.h
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/include/ExampleGlobalMeasurementSensor.h
@@ -1,0 +1,26 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/StateSpaceUtil.h>
+#include <frc/geometry/Pose2d.h>
+
+/**
+ * This dummy class represents a global measurement sensor, such as a computer
+ * vision solution.
+ */
+class ExampleGlobalMeasurementSensor {
+ public:
+  static frc::Pose2d GetEstimatedGlobalPose(frc::Pose2d estimatedRobotPose) {
+    auto randVec = frc::MakeWhiteNoiseVector(0.1, 0.1, 0.1);
+    return frc::Pose2d(estimatedRobotPose.X() + units::meter_t(randVec(0)),
+                       estimatedRobotPose.Y() + units::meter_t(randVec(1)),
+                       estimatedRobotPose.Rotation() +
+                           frc::Rotation2d(units::radian_t(randVec(3))));
+  }
+};

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDriveStateEstimator/cpp/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDriveStateEstimator/cpp/Drivetrain.cpp
@@ -1,0 +1,46 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "Drivetrain.h"
+
+#include <frc/Timer.h>
+#include <frc/RobotController.h>
+
+#include "ExampleGlobalMeasurementSensor.h"
+
+void Drivetrain::SetSpeeds(const frc::DifferentialDriveWheelSpeeds& speeds) {
+  const auto leftFeedforward = m_feedforward.Calculate(speeds.left);
+  const auto rightFeedforward = m_feedforward.Calculate(speeds.right);
+  const double leftOutput = m_leftPIDController.Calculate(
+      m_leftEncoder.GetRate(), speeds.left.to<double>());
+  const double rightOutput = m_rightPIDController.Calculate(
+      m_rightEncoder.GetRate(), speeds.right.to<double>());
+
+  m_leftGroup.SetVoltage(units::volt_t{leftOutput} + leftFeedforward);
+  m_rightGroup.SetVoltage(units::volt_t{rightOutput} + rightFeedforward);
+}
+
+void Drivetrain::Drive(units::meters_per_second_t xSpeed,
+                       units::radians_per_second_t rot) {
+  SetSpeeds(m_kinematics.ToWheelSpeeds({xSpeed, 0_mps, rot}));
+}
+
+void Drivetrain::UpdateOdometry() {
+  m_stateEstimator.Update(m_gyro.GetRotation2d().Radians(),
+                         units::meter_t(m_leftEncoder.GetDistance()),
+                         units::meter_t(m_rightEncoder.GetDistance()),
+                         frc::MakeMatrix<2, 1>(m_leftLeader.Get() * frc::RobotController::GetInputVoltage(),
+                          -m_rightLeader.Get() * frc::RobotController::GetInputVoltage()));
+
+  // Also apply vision measurements. We use 0.3 seconds in the past as an
+  // example -- on a real robot, this must be calculated based either on latency
+  // or timestamps.
+  m_stateEstimator.ApplyPastGlobalMeasurement(
+      ExampleGlobalMeasurementSensor::GetEstimatedGlobalPose(
+          m_stateEstimator.GetEstimatedPosition()),
+      units::second_t{frc::Timer::GetFPGATimestamp() - 0.3});
+}

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDriveStateEstimator/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDriveStateEstimator/cpp/Robot.cpp
@@ -1,0 +1,52 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <frc/SlewRateLimiter.h>
+#include <frc/TimedRobot.h>
+#include <frc/XboxController.h>
+
+#include "Drivetrain.h"
+
+class Robot : public frc::TimedRobot {
+ public:
+  void AutonomousPeriodic() override {
+    TeleopPeriodic();
+    m_drive.UpdateOdometry();
+  }
+
+  void TeleopPeriodic() override {
+    // Get the x speed. We are inverting this because Xbox controllers return
+    // negative values when we push forward.
+    const auto xSpeed = -m_speedLimiter.Calculate(
+                            m_controller.GetY(frc::GenericHID::kLeftHand)) *
+                        Drivetrain::kMaxSpeed;
+
+    // Get the rate of angular rotation. We are inverting this because we want a
+    // positive value when we pull to the left (remember, CCW is positive in
+    // mathematics). Xbox controllers return positive values when you pull to
+    // the right by default.
+    const auto rot = -m_rotLimiter.Calculate(
+                         m_controller.GetX(frc::GenericHID::kRightHand)) *
+                     Drivetrain::kMaxAngularSpeed;
+
+    m_drive.Drive(xSpeed, rot);
+  }
+
+ private:
+  frc::XboxController m_controller{0};
+
+  // Slew rate limiters to make joystick inputs more gentle; 1/3 sec from 0
+  // to 1.
+  frc::SlewRateLimiter<units::scalar> m_speedLimiter{3 / 1_s};
+  frc::SlewRateLimiter<units::scalar> m_rotLimiter{3 / 1_s};
+
+  Drivetrain m_drive;
+};
+
+#ifndef RUNNING_FRC_TESTS
+int main() { return frc::StartRobot<Robot>(); }
+#endif

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDriveStateEstimator/include/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDriveStateEstimator/include/Drivetrain.h
@@ -1,0 +1,96 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/AnalogGyro.h>
+#include <frc/Encoder.h>
+#include <frc/PWMVictorSPX.h>
+#include <frc/SpeedControllerGroup.h>
+#include <frc/controller/PIDController.h>
+#include <frc/controller/SimpleMotorFeedforward.h>
+#include <frc/estimator/DifferentialDriveStateEstimator.h>
+#include <frc/system/plant/LinearSystemId.h>
+#include <frc/kinematics/DifferentialDriveKinematics.h>
+#include <units/angle.h>
+#include <units/angular_velocity.h>
+#include <units/length.h>
+#include <units/velocity.h>
+#include <wpi/math>
+
+/**
+ * Represents a differential drive style drivetrain.
+ */
+class Drivetrain {
+ public:
+  Drivetrain() {
+    m_gyro.Reset();
+    // Set the distance per pulse for the drive encoders. We can simply use the
+    // distance traveled for one rotation of the wheel divided by the encoder
+    // resolution.
+    m_leftEncoder.SetDistancePerPulse(2 * wpi::math::pi * kWheelRadius /
+                                      kEncoderResolution);
+    m_rightEncoder.SetDistancePerPulse(2 * wpi::math::pi * kWheelRadius /
+                                       kEncoderResolution);
+
+    m_leftEncoder.Reset();
+    m_rightEncoder.Reset();
+  }
+
+  static constexpr units::meters_per_second_t kMaxSpeed =
+      3.0_mps;  // 3 meters per second
+  static constexpr units::radians_per_second_t kMaxAngularSpeed{
+      wpi::math::pi};  // 1/2 rotation per second
+
+  void SetSpeeds(const frc::DifferentialDriveWheelSpeeds& speeds);
+  void Drive(units::meters_per_second_t xSpeed,
+             units::radians_per_second_t rot);
+  void UpdateOdometry();
+
+ private:
+  static constexpr units::meter_t kTrackWidth = 0.381_m * 2;
+  static constexpr double kWheelRadius = 0.0508;  // meters
+  static constexpr int kEncoderResolution = 4096;
+
+  frc::PWMVictorSPX m_leftLeader{1};
+  frc::PWMVictorSPX m_leftFollower{2};
+  frc::PWMVictorSPX m_rightLeader{3};
+  frc::PWMVictorSPX m_rightFollower{4};
+
+  frc::SpeedControllerGroup m_leftGroup{m_leftLeader, m_leftFollower};
+  frc::SpeedControllerGroup m_rightGroup{m_rightLeader, m_rightFollower};
+
+  frc::Encoder m_leftEncoder{0, 1};
+  frc::Encoder m_rightEncoder{2, 3};
+
+  frc2::PIDController m_leftPIDController{1.0, 0.0, 0.0};
+  frc2::PIDController m_rightPIDController{1.0, 0.0, 0.0};
+
+  frc::AnalogGyro m_gyro{0};
+
+  frc::DifferentialDriveKinematics m_kinematics{kTrackWidth};
+
+  // Gains are for example purposes only - must be determined for your own
+  // robot!
+  frc::LinearSystem<2, 2, 2> m_drivetrainSystem = frc::LinearSystemId::IdentifyDrivetrainSystem(3, 4, 1, 2);
+
+  // Gains are for example purposes only - must be determined for your own
+  // robot!
+  frc::DifferentialDriveStateEstimator m_stateEstimator{
+      m_drivetrainSystem,
+      Eigen::Matrix<double, 10, 1>::Zero(),
+      frc::MakeMatrix<10, 1>(0.002, 0.002, 0.0001, 1.5, 1.5, 0.5, 0.5, 10.0,
+                             10.0, 2.0),
+      frc::MakeMatrix<3, 1>(0.0001, 0.005, 0.005),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1),
+      m_kinematics,
+      20_ms};
+
+  // Gains are for example purposes only - must be determined for your own
+  // robot!
+  frc::SimpleMotorFeedforward<units::meters> m_feedforward{1_V, 3_V / 1_mps};
+};

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDriveStateEstimator/include/ExampleGlobalMeasurementSensor.h
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDriveStateEstimator/include/ExampleGlobalMeasurementSensor.h
@@ -1,0 +1,26 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/StateSpaceUtil.h>
+#include <frc/geometry/Pose2d.h>
+
+/**
+ * This dummy class represents a global measurement sensor, such as a computer
+ * vision solution.
+ */
+class ExampleGlobalMeasurementSensor {
+ public:
+  static frc::Pose2d GetEstimatedGlobalPose(frc::Pose2d estimatedRobotPose) {
+    auto randVec = frc::MakeWhiteNoiseVector(0.1, 0.1, 0.1);
+    return frc::Pose2d(estimatedRobotPose.X() + units::meter_t(randVec(0)),
+                       estimatedRobotPose.Y() + units::meter_t(randVec(1)),
+                       estimatedRobotPose.Rotation() +
+                           frc::Rotation2d(units::radian_t(randVec(3))));
+  }
+};

--- a/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/cpp/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/cpp/Drivetrain.cpp
@@ -1,0 +1,68 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "Drivetrain.h"
+#include "ExampleGlobalMeasurementSensor.h"
+
+frc::MecanumDriveWheelSpeeds Drivetrain::GetCurrentState() const {
+  return {units::meters_per_second_t(m_frontLeftEncoder.GetRate()),
+          units::meters_per_second_t(m_frontRightEncoder.GetRate()),
+          units::meters_per_second_t(m_backLeftEncoder.GetRate()),
+          units::meters_per_second_t(m_backRightEncoder.GetRate())};
+}
+
+void Drivetrain::SetSpeeds(const frc::MecanumDriveWheelSpeeds& wheelSpeeds) {
+  const auto frontLeftFeedforward =
+      m_feedforward.Calculate(wheelSpeeds.frontLeft);
+  const auto frontRightFeedforward =
+      m_feedforward.Calculate(wheelSpeeds.frontRight);
+  const auto backLeftFeedforward =
+      m_feedforward.Calculate(wheelSpeeds.rearLeft);
+  const auto backRightFeedforward =
+      m_feedforward.Calculate(wheelSpeeds.rearRight);
+
+  const double frontLeftOutput = m_frontLeftPIDController.Calculate(
+      m_frontLeftEncoder.GetRate(), wheelSpeeds.frontLeft.to<double>());
+  const double frontRightOutput = m_frontRightPIDController.Calculate(
+      m_frontRightEncoder.GetRate(), wheelSpeeds.frontRight.to<double>());
+  const double backLeftOutput = m_backLeftPIDController.Calculate(
+      m_backLeftEncoder.GetRate(), wheelSpeeds.rearLeft.to<double>());
+  const double backRightOutput = m_backRightPIDController.Calculate(
+      m_backRightEncoder.GetRate(), wheelSpeeds.rearRight.to<double>());
+
+  m_frontLeftMotor.SetVoltage(units::volt_t{frontLeftOutput} +
+                              frontLeftFeedforward);
+  m_frontRightMotor.SetVoltage(units::volt_t{frontRightOutput} +
+                               frontRightFeedforward);
+  m_backLeftMotor.SetVoltage(units::volt_t{backLeftOutput} +
+                             backLeftFeedforward);
+  m_backRightMotor.SetVoltage(units::volt_t{backRightOutput} +
+                              backRightFeedforward);
+}
+
+void Drivetrain::Drive(units::meters_per_second_t xSpeed,
+                       units::meters_per_second_t ySpeed,
+                       units::radians_per_second_t rot, bool fieldRelative) {
+  auto wheelSpeeds = m_kinematics.ToWheelSpeeds(
+      fieldRelative ? frc::ChassisSpeeds::FromFieldRelativeSpeeds(
+                          xSpeed, ySpeed, rot, m_gyro.GetRotation2d())
+                    : frc::ChassisSpeeds{xSpeed, ySpeed, rot});
+  wheelSpeeds.Normalize(kMaxSpeed);
+  SetSpeeds(wheelSpeeds);
+}
+
+void Drivetrain::UpdateOdometry() {
+  m_poseEstimator.Update(m_gyro.GetRotation2d(), GetCurrentState());
+
+  // Also apply vision measurements. We use 0.3 seconds in the past as an
+  // example -- on a real robot, this must be calculated based either on latency
+  // or timestamps.
+  m_poseEstimator.AddVisionMeasurement(
+      ExampleGlobalMeasurementSensor::GetEstimatedGlobalPose(
+          m_poseEstimator.GetEstimatedPosition()),
+      units::second_t{frc::Timer::GetFPGATimestamp() - 0.3});
+}

--- a/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/cpp/Robot.cpp
@@ -1,0 +1,61 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <frc/SlewRateLimiter.h>
+#include <frc/TimedRobot.h>
+#include <frc/XboxController.h>
+
+#include "Drivetrain.h"
+
+class Robot : public frc::TimedRobot {
+ public:
+  void AutonomousPeriodic() override {
+    DriveWithJoystick(false);
+    m_mecanum.UpdateOdometry();
+  }
+
+  void TeleopPeriodic() override { DriveWithJoystick(true); }
+
+ private:
+  frc::XboxController m_controller{0};
+  Drivetrain m_mecanum;
+
+  // Slew rate limiters to make joystick inputs more gentle; 1/3 sec from 0
+  // to 1.
+  frc::SlewRateLimiter<units::scalar> m_xspeedLimiter{3 / 1_s};
+  frc::SlewRateLimiter<units::scalar> m_yspeedLimiter{3 / 1_s};
+  frc::SlewRateLimiter<units::scalar> m_rotLimiter{3 / 1_s};
+
+  void DriveWithJoystick(bool fieldRelative) {
+    // Get the x speed. We are inverting this because Xbox controllers return
+    // negative values when we push forward.
+    const auto xSpeed = -m_xspeedLimiter.Calculate(
+                            m_controller.GetY(frc::GenericHID::kLeftHand)) *
+                        Drivetrain::kMaxSpeed;
+
+    // Get the y speed or sideways/strafe speed. We are inverting this because
+    // we want a positive value when we pull to the left. Xbox controllers
+    // return positive values when you pull to the right by default.
+    const auto ySpeed = -m_yspeedLimiter.Calculate(
+                            m_controller.GetX(frc::GenericHID::kLeftHand)) *
+                        Drivetrain::kMaxSpeed;
+
+    // Get the rate of angular rotation. We are inverting this because we want a
+    // positive value when we pull to the left (remember, CCW is positive in
+    // mathematics). Xbox controllers return positive values when you pull to
+    // the right by default.
+    const auto rot = -m_rotLimiter.Calculate(
+                         m_controller.GetX(frc::GenericHID::kRightHand)) *
+                     Drivetrain::kMaxAngularSpeed;
+
+    m_mecanum.Drive(xSpeed, ySpeed, rot, fieldRelative);
+  }
+};
+
+#ifndef RUNNING_FRC_TESTS
+int main() { return frc::StartRobot<Robot>(); }
+#endif

--- a/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/include/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/include/Drivetrain.h
@@ -1,0 +1,81 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/AnalogGyro.h>
+#include <frc/Encoder.h>
+#include <frc/PWMVictorSPX.h>
+#include <frc/controller/PIDController.h>
+#include <frc/controller/SimpleMotorFeedforward.h>
+#include <frc/geometry/Translation2d.h>
+#include <frc/kinematics/MecanumDriveKinematics.h>
+#include <frc/kinematics/MecanumDriveOdometry.h>
+#include <frc/kinematics/MecanumDriveWheelSpeeds.h>
+#include <wpi/math>
+#include <frc/estimator/MecanumDrivePoseEstimator.h>
+
+/**
+ * Represents a mecanum drive style drivetrain.
+ */
+class Drivetrain {
+ public:
+  Drivetrain() { m_gyro.Reset(); }
+
+  frc::MecanumDriveWheelSpeeds GetCurrentState() const;
+  void SetSpeeds(const frc::MecanumDriveWheelSpeeds& wheelSpeeds);
+  void Drive(units::meters_per_second_t xSpeed,
+             units::meters_per_second_t ySpeed, units::radians_per_second_t rot,
+             bool fieldRelative);
+  void UpdateOdometry();
+
+  static constexpr units::meters_per_second_t kMaxSpeed =
+      3.0_mps;  // 3 meters per second
+  static constexpr units::radians_per_second_t kMaxAngularSpeed{
+      wpi::math::pi};  // 1/2 rotation per second
+
+ private:
+  frc::PWMVictorSPX m_frontLeftMotor{1};
+  frc::PWMVictorSPX m_frontRightMotor{2};
+  frc::PWMVictorSPX m_backLeftMotor{3};
+  frc::PWMVictorSPX m_backRightMotor{4};
+
+  frc::Encoder m_frontLeftEncoder{0, 1};
+  frc::Encoder m_frontRightEncoder{2, 3};
+  frc::Encoder m_backLeftEncoder{4, 5};
+  frc::Encoder m_backRightEncoder{6, 7};
+
+  frc::Translation2d m_frontLeftLocation{0.381_m, 0.381_m};
+  frc::Translation2d m_frontRightLocation{0.381_m, -0.381_m};
+  frc::Translation2d m_backLeftLocation{-0.381_m, 0.381_m};
+  frc::Translation2d m_backRightLocation{-0.381_m, -0.381_m};
+
+  frc2::PIDController m_frontLeftPIDController{1.0, 0.0, 0.0};
+  frc2::PIDController m_frontRightPIDController{1.0, 0.0, 0.0};
+  frc2::PIDController m_backLeftPIDController{1.0, 0.0, 0.0};
+  frc2::PIDController m_backRightPIDController{1.0, 0.0, 0.0};
+
+  frc::AnalogGyro m_gyro{0};
+
+  frc::MecanumDriveKinematics m_kinematics{
+      m_frontLeftLocation, m_frontRightLocation, m_backLeftLocation,
+      m_backRightLocation};
+
+  // Gains are for example purposes only - must be determined for your own
+  // robot!
+  frc::SimpleMotorFeedforward<units::meters> m_feedforward{1_V, 3_V / 1_mps};
+
+  // Gains are for example purposes only - must be determined for your own
+  // robot!
+  frc::MecanumDrivePoseEstimator m_poseEstimator{
+      frc::Rotation2d(),
+      frc::Pose2d(),
+      m_kinematics,
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1),
+      frc::MakeMatrix<1, 1>(0.05),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1)};
+};

--- a/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/include/ExampleGlobalMeasurementSensor.h
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/include/ExampleGlobalMeasurementSensor.h
@@ -1,0 +1,26 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/StateSpaceUtil.h>
+#include <frc/geometry/Pose2d.h>
+
+/**
+ * This dummy class represents a global measurement sensor, such as a computer
+ * vision solution.
+ */
+class ExampleGlobalMeasurementSensor {
+ public:
+  static frc::Pose2d GetEstimatedGlobalPose(frc::Pose2d estimatedRobotPose) {
+    auto randVec = frc::MakeWhiteNoiseVector(0.1, 0.1, 0.1);
+    return frc::Pose2d(estimatedRobotPose.X() + units::meter_t(randVec(0)),
+                       estimatedRobotPose.Y() + units::meter_t(randVec(1)),
+                       estimatedRobotPose.Rotation() +
+                           frc::Rotation2d(units::radian_t(randVec(3))));
+  }
+};

--- a/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/cpp/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/cpp/Drivetrain.cpp
@@ -1,0 +1,42 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "Drivetrain.h"
+#include "ExampleGlobalMeasurementSensor.h"
+
+void Drivetrain::Drive(units::meters_per_second_t xSpeed,
+                       units::meters_per_second_t ySpeed,
+                       units::radians_per_second_t rot, bool fieldRelative) {
+  auto states = m_kinematics.ToSwerveModuleStates(
+      fieldRelative ? frc::ChassisSpeeds::FromFieldRelativeSpeeds(
+                          xSpeed, ySpeed, rot, m_gyro.GetRotation2d())
+                    : frc::ChassisSpeeds{xSpeed, ySpeed, rot});
+
+  m_kinematics.NormalizeWheelSpeeds(&states, kMaxSpeed);
+
+  auto [fl, fr, bl, br] = states;
+
+  m_frontLeft.SetDesiredState(fl);
+  m_frontRight.SetDesiredState(fr);
+  m_backLeft.SetDesiredState(bl);
+  m_backRight.SetDesiredState(br);
+}
+
+void Drivetrain::UpdateOdometry() {
+  m_poseEstimator.Update(m_gyro.GetRotation2d(), m_frontLeft.GetState(),
+                    m_frontRight.GetState(), m_backLeft.GetState(),
+                    m_backRight.GetState());
+
+
+  // Also apply vision measurements. We use 0.3 seconds in the past as an
+  // example -- on a real robot, this must be calculated based either on latency
+  // or timestamps.
+  m_poseEstimator.AddVisionMeasurement(
+      ExampleGlobalMeasurementSensor::GetEstimatedGlobalPose(
+          m_poseEstimator.GetEstimatedPosition()),
+      units::second_t{frc::Timer::GetFPGATimestamp() - 0.3});
+}

--- a/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/cpp/Robot.cpp
@@ -1,0 +1,61 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include <frc/SlewRateLimiter.h>
+#include <frc/TimedRobot.h>
+#include <frc/XboxController.h>
+
+#include "Drivetrain.h"
+
+class Robot : public frc::TimedRobot {
+ public:
+  void AutonomousPeriodic() override {
+    DriveWithJoystick(false);
+    m_swerve.UpdateOdometry();
+  }
+
+  void TeleopPeriodic() override { DriveWithJoystick(true); }
+
+ private:
+  frc::XboxController m_controller{0};
+  Drivetrain m_swerve;
+
+  // Slew rate limiters to make joystick inputs more gentle; 1/3 sec from 0
+  // to 1.
+  frc::SlewRateLimiter<units::scalar> m_xspeedLimiter{3 / 1_s};
+  frc::SlewRateLimiter<units::scalar> m_yspeedLimiter{3 / 1_s};
+  frc::SlewRateLimiter<units::scalar> m_rotLimiter{3 / 1_s};
+
+  void DriveWithJoystick(bool fieldRelative) {
+    // Get the x speed. We are inverting this because Xbox controllers return
+    // negative values when we push forward.
+    const auto xSpeed = -m_xspeedLimiter.Calculate(
+                            m_controller.GetY(frc::GenericHID::kLeftHand)) *
+                        Drivetrain::kMaxSpeed;
+
+    // Get the y speed or sideways/strafe speed. We are inverting this because
+    // we want a positive value when we pull to the left. Xbox controllers
+    // return positive values when you pull to the right by default.
+    const auto ySpeed = -m_yspeedLimiter.Calculate(
+                            m_controller.GetX(frc::GenericHID::kLeftHand)) *
+                        Drivetrain::kMaxSpeed;
+
+    // Get the rate of angular rotation. We are inverting this because we want a
+    // positive value when we pull to the left (remember, CCW is positive in
+    // mathematics). Xbox controllers return positive values when you pull to
+    // the right by default.
+    const auto rot = -m_rotLimiter.Calculate(
+                         m_controller.GetX(frc::GenericHID::kRightHand)) *
+                     Drivetrain::kMaxAngularSpeed;
+
+    m_swerve.Drive(xSpeed, ySpeed, rot, fieldRelative);
+  }
+};
+
+#ifndef RUNNING_FRC_TESTS
+int main() { return frc::StartRobot<Robot>(); }
+#endif

--- a/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/cpp/SwerveModule.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/cpp/SwerveModule.cpp
@@ -1,0 +1,55 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "SwerveModule.h"
+
+#include <frc/geometry/Rotation2d.h>
+#include <wpi/math>
+
+SwerveModule::SwerveModule(const int driveMotorChannel,
+                           const int turningMotorChannel)
+    : m_driveMotor(driveMotorChannel), m_turningMotor(turningMotorChannel) {
+  // Set the distance per pulse for the drive encoder. We can simply use the
+  // distance traveled for one rotation of the wheel divided by the encoder
+  // resolution.
+  m_driveEncoder.SetDistancePerPulse(2 * wpi::math::pi * kWheelRadius /
+                                     kEncoderResolution);
+
+  // Set the distance (in this case, angle) per pulse for the turning encoder.
+  // This is the the angle through an entire rotation (2 * wpi::math::pi)
+  // divided by the encoder resolution.
+  m_turningEncoder.SetDistancePerPulse(2 * wpi::math::pi / kEncoderResolution);
+
+  // Limit the PID Controller's input range between -pi and pi and set the input
+  // to be continuous.
+  m_turningPIDController.EnableContinuousInput(-units::radian_t(wpi::math::pi),
+                                               units::radian_t(wpi::math::pi));
+}
+
+frc::SwerveModuleState SwerveModule::GetState() const {
+  return {units::meters_per_second_t{m_driveEncoder.GetRate()},
+          frc::Rotation2d(units::radian_t(m_turningEncoder.Get()))};
+}
+
+void SwerveModule::SetDesiredState(const frc::SwerveModuleState& state) {
+  // Calculate the drive output from the drive PID controller.
+  const auto driveOutput = m_drivePIDController.Calculate(
+      m_driveEncoder.GetRate(), state.speed.to<double>());
+
+  const auto driveFeedforward = m_driveFeedforward.Calculate(state.speed);
+
+  // Calculate the turning motor output from the turning PID controller.
+  const auto turnOutput = m_turningPIDController.Calculate(
+      units::radian_t(m_turningEncoder.Get()), state.angle.Radians());
+
+  const auto turnFeedforward = m_turnFeedforward.Calculate(
+      m_turningPIDController.GetSetpoint().velocity);
+
+  // Set the motor outputs.
+  m_driveMotor.SetVoltage(units::volt_t{driveOutput} + driveFeedforward);
+  m_turningMotor.SetVoltage(units::volt_t{turnOutput} + turnFeedforward);
+}

--- a/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/include/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/include/Drivetrain.h
@@ -1,0 +1,62 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/AnalogGyro.h>
+#include <frc/geometry/Translation2d.h>
+#include <frc/kinematics/SwerveDriveKinematics.h>
+#include <frc/kinematics/SwerveDriveOdometry.h>
+#include <wpi/math>
+#include <frc/estimator/SwerveDrivePoseEstimator.h>
+
+#include "SwerveModule.h"
+
+/**
+ * Represents a swerve drive style drivetrain.
+ */
+class Drivetrain {
+ public:
+  Drivetrain() { m_gyro.Reset(); }
+
+  void Drive(units::meters_per_second_t xSpeed,
+             units::meters_per_second_t ySpeed, units::radians_per_second_t rot,
+             bool fieldRelative);
+  void UpdateOdometry();
+
+  static constexpr units::meters_per_second_t kMaxSpeed =
+      3.0_mps;  // 3 meters per second
+  static constexpr units::radians_per_second_t kMaxAngularSpeed{
+      wpi::math::pi};  // 1/2 rotation per second
+
+ private:
+  frc::Translation2d m_frontLeftLocation{+0.381_m, +0.381_m};
+  frc::Translation2d m_frontRightLocation{+0.381_m, -0.381_m};
+  frc::Translation2d m_backLeftLocation{-0.381_m, +0.381_m};
+  frc::Translation2d m_backRightLocation{-0.381_m, -0.381_m};
+
+  SwerveModule m_frontLeft{1, 2};
+  SwerveModule m_frontRight{2, 3};
+  SwerveModule m_backLeft{5, 6};
+  SwerveModule m_backRight{7, 8};
+
+  frc::AnalogGyro m_gyro{0};
+
+  frc::SwerveDriveKinematics<4> m_kinematics{
+      m_frontLeftLocation, m_frontRightLocation, m_backLeftLocation,
+      m_backRightLocation};
+
+  // Gains are for example purposes only - must be determined for your own
+  // robot!
+  frc::SwerveDrivePoseEstimator<4> m_poseEstimator{
+      frc::Rotation2d(),
+      frc::Pose2d(),
+      m_kinematics,
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1),
+      frc::MakeMatrix<1, 1>(0.05),
+      frc::MakeMatrix<3, 1>(0.1, 0.1, 0.1)};
+};

--- a/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/include/ExampleGlobalMeasurementSensor.h
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/include/ExampleGlobalMeasurementSensor.h
@@ -1,0 +1,26 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/StateSpaceUtil.h>
+#include <frc/geometry/Pose2d.h>
+
+/**
+ * This dummy class represents a global measurement sensor, such as a computer
+ * vision solution.
+ */
+class ExampleGlobalMeasurementSensor {
+ public:
+  static frc::Pose2d GetEstimatedGlobalPose(frc::Pose2d estimatedRobotPose) {
+    auto randVec = frc::MakeWhiteNoiseVector(0.1, 0.1, 0.1);
+    return frc::Pose2d(estimatedRobotPose.X() + units::meter_t(randVec(0)),
+                       estimatedRobotPose.Y() + units::meter_t(randVec(1)),
+                       estimatedRobotPose.Rotation() +
+                           frc::Rotation2d(units::radian_t(randVec(3))));
+  }
+};

--- a/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/include/SwerveModule.h
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/include/SwerveModule.h
@@ -1,0 +1,54 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/Encoder.h>
+#include <frc/PWMVictorSPX.h>
+#include <frc/controller/PIDController.h>
+#include <frc/controller/ProfiledPIDController.h>
+#include <frc/controller/SimpleMotorFeedforward.h>
+#include <frc/kinematics/SwerveModuleState.h>
+#include <units/angular_velocity.h>
+#include <units/time.h>
+#include <units/velocity.h>
+#include <units/voltage.h>
+#include <wpi/math>
+
+class SwerveModule {
+ public:
+  SwerveModule(int driveMotorChannel, int turningMotorChannel);
+  frc::SwerveModuleState GetState() const;
+  void SetDesiredState(const frc::SwerveModuleState& state);
+
+ private:
+  static constexpr double kWheelRadius = 0.0508;
+  static constexpr int kEncoderResolution = 4096;
+
+  static constexpr auto kModuleMaxAngularVelocity =
+      wpi::math::pi * 1_rad_per_s;  // radians per second
+  static constexpr auto kModuleMaxAngularAcceleration =
+      wpi::math::pi * 2_rad_per_s / 1_s;  // radians per second^2
+
+  frc::PWMVictorSPX m_driveMotor;
+  frc::PWMVictorSPX m_turningMotor;
+
+  frc::Encoder m_driveEncoder{0, 1};
+  frc::Encoder m_turningEncoder{2, 3};
+
+  frc2::PIDController m_drivePIDController{1.0, 0, 0};
+  frc::ProfiledPIDController<units::radians> m_turningPIDController{
+      1.0,
+      0.0,
+      0.0,
+      {kModuleMaxAngularVelocity, kModuleMaxAngularAcceleration}};
+
+  frc::SimpleMotorFeedforward<units::meters> m_driveFeedforward{1_V,
+                                                                3_V / 1_mps};
+  frc::SimpleMotorFeedforward<units::radians> m_turnFeedforward{
+      1_V, 0.5_V / 1_rad_per_s};
+};

--- a/wpilibcExamples/src/main/cpp/examples/examples.json
+++ b/wpilibcExamples/src/main/cpp/examples/examples.json
@@ -627,6 +627,22 @@
     "gradlebase": "cpp",
     "mainclass": "Main",
     "commandversion": 2
+  }, 
+  {
+    "name": "DifferentialDrivePoseEstimator",
+    "description": "Demonstrates the use of the DifferentialDrivePoseEstimator as a replacement for differential drive odometry.",
+    "tags": [
+      "Drivetrain",
+      "State space",
+      "Vision",
+      "Filter",
+      "Odometry",
+      "Pose"
+    ],
+    "foldername": "DifferentialDrivePoseEstimator",
+    "gradlebase": "cpp",
+    "mainclass": "Main",
+    "commandversion": 2
   },
   {
     "name": "ArmSimulation",
@@ -639,7 +655,6 @@
       "Simulation",
       "Physics"
     ],
-    "foldername": "ArmSimulation",
     "gradlebase": "cpp",
     "mainclass": "Main",
     "commandversion": 2
@@ -657,7 +672,23 @@
       "Drivetrain",
       "Field2d"
     ],
-    "foldername": "DifferentialDriveSimulation",
+    "gradlebase": "cpp",
+    "mainclass": "Main",
+    "commandversion": 2
+  },
+  {
+    "name": "SwerveDrivePoseEstimator",
+    "description": "Demonstrates the use of the SwerveDrivePoseEstimator as a replacement for mecanum drive odometry.",
+    "tags": [
+      "Drivetrain",
+      "State space",
+      "Vision",
+      "Filter",
+      "Odometry",
+      "State",
+      "Swerve"
+    ],
+    "foldername": "SwerveDrivePoseEstimator",
     "gradlebase": "cpp",
     "mainclass": "Main",
     "commandversion": 2

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimator.java
@@ -1,0 +1,337 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.function.BiConsumer;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.math.Discretization;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N3;
+import edu.wpi.first.wpiutil.math.numbers.N4;
+import edu.wpi.first.wpiutil.math.numbers.N5;
+import edu.wpi.first.wpiutil.math.numbers.N6;
+
+/**
+ * This class wraps an
+ * {@link edu.wpi.first.wpilibj.estimator.UnscentedKalmanFilter Extended Kalman Filter}
+ * to fuse latency-compensated vision
+ * measurements with differential drive encoder measurements. It will correct
+ * for noisy vision measurements and encoder drift. It is intended to be an easy
+ * drop-in for
+ * {@link edu.wpi.first.wpilibj.kinematics.DifferentialDriveOdometry}; in fact,
+ * if you never call {@link DifferentialDrivePoseEstimator#addVisionMeasurement}
+ * and only call {@link DifferentialDrivePoseEstimator#update} then this will
+ * behave exactly the same as DifferentialDriveOdometry.
+ *
+ * <p>{@link DifferentialDrivePoseEstimator#update} should be called every robot
+ * loop (if your robot loops are faster than the default then you should change
+ * the {@link DifferentialDrivePoseEstimator#DifferentialDrivePoseEstimator(Rotation2d, Pose2d,
+ * Matrix, Matrix, Matrix, double) nominal delta time}.)
+ * {@link DifferentialDrivePoseEstimator#addVisionMeasurement} can be called as
+ * infrequently as you want; if you never call it then this class will behave
+ * exactly like regular encoder odometry.
+ *
+ * <p>Our state-space system is:
+ *
+ * <p><strong> x = [[x, y, cos(theta), sin(theta), dist_l, dist_r]]^T </strong>
+ * in the field coordinate system (dist_* are wheel distances.)
+ *
+ * <p><strong> u = [[v_left, v_right, omega]]^T </strong> (robot-relative velocities)
+ *  -- NB: using velocities make things considerably easier, because it means that
+ * teams don't have to worry about getting an accurate model.
+ * Basically, we suspect that it's easier for teams to get good encoder data than it is for
+ * them to perform system identification well enough to get a good model.
+ *
+ * <p><strong>y = [[x, y, cos(theta), sin(theta)]]^T </strong> from vision,
+ * or <strong>y = [[dist_l, dist_r, cos(theta), sin(theta)]] </strong> from encoders and gyro.
+ */
+public class DifferentialDrivePoseEstimator {
+  final UnscentedKalmanFilter<N6, N3, N4> m_observer;
+  private final BiConsumer<Matrix<N3, N1>, Matrix<N4, N1>> m_visionCorrect;
+  private final KalmanFilterLatencyCompensator<N6, N3, N4> m_latencyCompensator;
+
+  private final double m_nominalDt; // Seconds
+  private double m_prevTimeSeconds = -1.0;
+
+  private Rotation2d m_gyroOffset;
+  private Rotation2d m_previousAngle;
+
+  /**
+   * Constructs a DifferentialDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less. This is in the
+   *                                 form [x, y, theta, dist_l, dist_r]^T.
+   * @param localMeasurementStdDevs  Standard deviations of the encoder and gyro measurements.
+   *                                 Increase these numbers to trust encoder distances and gyro
+   *                                 angle less. This is in the form [ dist_l, dist_r, theta ]^T.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder measurements. Increase
+   *                                 these numbers to trust vision less. This is in the form
+   *                                 [ x, y, theta ]^T
+   */
+  public DifferentialDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters,
+          Matrix<N5, N1> stateStdDevs,
+          Matrix<N3, N1> localMeasurementStdDevs, Matrix<N3, N1> visionMeasurementStdDevs
+  ) {
+    this(gyroAngle, initialPoseMeters,
+            stateStdDevs, localMeasurementStdDevs, visionMeasurementStdDevs, 0.02);
+  }
+
+  /**
+   * Constructs a DifferentialDrivePoseEstimator. Vectors with heading states are converted internally to
+   * cos/sin form.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less. In the form
+   *                                 [x_field, y_field, theta, dist_l, dist_r]^T.
+   * @param localMeasurementStdDevs  Standard deviations of the encoder and gyro measurements.
+   *                                 Increase these numbers to trust encoder distances and gyro
+   *                                 angle less. In the form [dist_l, dist_r, heading]^T.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder measurements. Increase
+   *                                 these numbers to trust vision less. In the form
+   *                                 [x, y, theta]^T.
+   * @param nominalDtSeconds         The time in seconds between each robot loop.
+   */
+  @SuppressWarnings("ParameterName")
+  public DifferentialDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters,
+          Matrix<N5, N1> stateStdDevs,
+          Matrix<N3, N1> localMeasurementStdDevs, Matrix<N3, N1> visionMeasurementStdDevs,
+          double nominalDtSeconds
+  ) {
+    m_nominalDt = nominalDtSeconds;
+
+    var cosStateStdDevs = VecBuilder.fill(stateStdDevs.get(0, 0), stateStdDevs.get(1, 0),
+        Math.cos(stateStdDevs.get(2, 0)), Math.sin(stateStdDevs.get(2, 0)),
+        stateStdDevs.get(3,0), stateStdDevs.get(4, 0));
+    var cosMeasurementStdDevs = VecBuilder.fill(localMeasurementStdDevs.get(0, 0),
+        localMeasurementStdDevs.get(1, 0), Math.cos(localMeasurementStdDevs.get(2, 0)),
+        Math.sin(localMeasurementStdDevs.get(2, 0)));
+
+    m_observer = new UnscentedKalmanFilter<>(
+        Nat.N6(), Nat.N4(),
+        this::f,
+        this::localMeasurementModel,
+        cosStateStdDevs, cosMeasurementStdDevs,
+        m_nominalDt
+    );
+    m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
+
+    var visionContR = StateSpaceUtil.makeCovarianceMatrix(Nat.N4(), VecBuilder.fill(
+        visionMeasurementStdDevs.get(0, 0),
+        visionMeasurementStdDevs.get(1, 0),
+        Math.cos(visionMeasurementStdDevs.get(2, 0)),
+        Math.sin(visionMeasurementStdDevs.get(2, 0))));
+    var visionDiscR = Discretization.discretizeR(visionContR, m_nominalDt);
+
+    m_visionCorrect = (u, y) -> m_observer.correct(
+        Nat.N4(), u, y,
+        (x, u_) -> x.block(Nat.N4(), Nat.N1(), 0, 0),
+        visionDiscR
+    );
+
+    m_gyroOffset = initialPoseMeters.getRotation().minus(gyroAngle);
+    m_previousAngle = initialPoseMeters.getRotation();
+    m_observer.setXhat(fillStateVector(initialPoseMeters, 0.0, 0.0));
+  }
+
+  /**
+   * Local measurement model. y = [[dist_l, dist_r, cos(theta), sin(theta)]]
+   * Recall that x = [[x_field, y_field, cos(theta), sin(theta), dist_l, dist_r]]^T.
+   */
+  private Matrix<N4, N1> localMeasurementModel(Matrix<N6, N1> x, Matrix<N3, N1> u) {
+    return VecBuilder.fill(x.get(4, 0), x.get(5, 0), x.get(2, 0), x.get(3, 0));
+  }
+
+  /**
+   * The dynamics of a differential drivetrain.
+   * @param x State vector, <strong> x = [[x_field, y_field, cos(theta), sin(theta), dist_l, dist_r]]^T </strong>
+   * @param u input vector, <strong> u = [[v_left, v_right, omega]]^T </strong>
+   * @return x-dot, <strong> x-dot = [[vx_field, vy_field, d/dt cos(theta), d/dt sin(theta), vel_left, vel_right]]^T </strong>
+   */
+  @SuppressWarnings({"ParameterName", "MethodName"})
+  protected Matrix<N6, N1> f(Matrix<N6, N1> x, Matrix<N3, N1> u) {
+    // Apply a rotation matrix. Note that we do *not* add x--Runge-Kutta does that for us.
+
+    var cosTheta = x.get(2, 0);
+    var sinTheta = x.get(3, 0);
+
+    // We want vx and vy to be in the field frame, so we apply a rotation matrix.
+    // to u_Field = u = [[vx_field, vy_field, omega]]^T
+    var chassisVel_local = VecBuilder.fill((u.get(0, 0) + u.get(1, 0)) / 2.0, 0.0);
+    var toFieldRotation = new MatBuilder<>(Nat.N2(), Nat.N2()).fill(
+            cosTheta, -sinTheta,
+            sinTheta, cosTheta
+    );
+    var chassisVel_field = toFieldRotation.times(chassisVel_local);
+
+    // dcos(theta)/dt = -sin(theta) * dtheta/dt = -sin(theta) * omega
+    var dcosTheta = -sinTheta * u.get(2, 0);
+    // dsin(theta)/dt = cos(theta) * omega
+    var dsinTheta = cosTheta * u.get(2, 0);
+
+    // As x = [[x_field, y_field, cos(theta), sin(theta), dist_l, dist_r]]^T,
+    // we need to return x-dot = [[vx_field, vy_field, d/dt cos(theta), d/dt sin(theta), vel_left, vel_right]]^T
+    // Assuming  no wheel slip, vx = (v_left + v_right) / 2, and vy = 0;
+
+    return VecBuilder.fill(chassisVel_field.get(0, 0), chassisVel_field.get(1, 0),
+        dcosTheta, dsinTheta,
+        u.get(0, 0), u.get(1, 0));
+  }
+
+  /**
+   * Resets the robot's position on the field.
+   *
+   * <p>You NEED to reset your encoders (to zero) when calling this method.
+   *
+   * <p>The gyroscope angle does not need to be reset here on the user's robot code.
+   * The library automatically takes care of offsetting the gyro angle.
+   *
+   * @param poseMeters The position on the field that your robot is at.
+   * @param gyroAngle  The angle reported by the gyroscope.
+   */
+  public void resetPosition(Pose2d poseMeters, Rotation2d gyroAngle) {
+    m_previousAngle = poseMeters.getRotation();
+    m_gyroOffset = getEstimatedPosition().getRotation().minus(gyroAngle);
+    m_observer.setXhat(fillStateVector(poseMeters, 0.0, 0.0));
+  }
+
+  /**
+   * Gets the pose of the robot at the current time as estimated by the Extended Kalman Filter.
+   *
+   * @return The estimated robot pose in meters.
+   */
+  public Pose2d getEstimatedPosition() {
+    return new Pose2d(
+            m_observer.getXhat(0),
+            m_observer.getXhat(1),
+            new Rotation2d(m_observer.getXhat(2), m_observer.getXhat(3))
+    );
+  }
+
+  /**
+   * Add a vision measurement to the Extended Kalman Filter. This will correct the
+   * odometry pose estimate while still accounting for measurement noise.
+   *
+   * <p>This method can be called as infrequently as you want, as long as you are
+   * calling {@link DifferentialDrivePoseEstimator#update} every loop.
+   *
+   * @param visionRobotPoseMeters The pose of the robot as measured by the vision
+   *                              camera.
+   * @param timestampSeconds      The timestamp of the vision measurement in seconds. Note that if
+   *                              you don't use your own time source by calling
+   *                              {@link DifferentialDrivePoseEstimator#updateWithTime} then you
+   *                              must use a timestamp with an epoch since FPGA startup
+   *                              (i.e. the epoch of this timestamp is the same epoch as
+   *                              {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp
+   *                              Timer.getFPGATimestamp}.) This means that you should
+   *                              use Timer.getFPGATimestamp as your time source in
+   *                              this case.
+   */
+  public void addVisionMeasurement(Pose2d visionRobotPoseMeters, double timestampSeconds) {
+    m_latencyCompensator.applyPastGlobalMeasurement(
+            Nat.N4(),
+            m_observer, m_nominalDt,
+            StateSpaceUtil.poseTo4dVector(visionRobotPoseMeters),
+            m_visionCorrect,
+            timestampSeconds
+    );
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder information.
+   * Note that this should be called every loop.
+   *
+   * @param gyroAngle                      The current gyro angle.
+   * @param wheelVelocitiesMetersPerSecond The velocities of the wheels in meters per second.
+   * @param distanceLeftMeters             The total distance travelled by the left wheel in meters
+   *                                       since the last time you called
+   *                                       {@link DifferentialDrivePoseEstimator#resetPosition}.
+   * @param distanceRightMeters            The total distance travelled by the right wheel in meters
+   *                                       since the last time you called
+   *                                       {@link DifferentialDrivePoseEstimator#resetPosition}.
+   * @return The estimated pose of the robot in meters.
+   */
+  public Pose2d update(
+          Rotation2d gyroAngle,
+          DifferentialDriveWheelSpeeds wheelVelocitiesMetersPerSecond,
+          double distanceLeftMeters, double distanceRightMeters
+  ) {
+    return updateWithTime(
+            Timer.getFPGATimestamp(), gyroAngle, wheelVelocitiesMetersPerSecond,
+            distanceLeftMeters, distanceRightMeters
+    );
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder information.
+   * Note that this should be called every loop.
+   *
+   * @param currentTimeSeconds             Time at which this method was called, in seconds.
+   * @param gyroAngle                      The current gyro angle.
+   * @param wheelVelocitiesMetersPerSecond The velocities of the wheels in meters per second.
+   * @param distanceLeftMeters             The total distance travelled by the left wheel in meters
+   *                                       since the last time you called
+   *                                       {@link DifferentialDrivePoseEstimator#resetPosition}.
+   * @param distanceRightMeters            The total distance travelled by the right wheel in meters
+   *                                       since the last time you called
+   *                                       {@link DifferentialDrivePoseEstimator#resetPosition}.
+   * @return The estimated pose of the robot in meters.
+   */
+  @SuppressWarnings({"LocalVariableName", "ParameterName"})
+  public Pose2d updateWithTime(
+          double currentTimeSeconds, Rotation2d gyroAngle,
+          DifferentialDriveWheelSpeeds wheelVelocitiesMetersPerSecond,
+          double distanceLeftMeters, double distanceRightMeters
+  ) {
+    double dt = m_prevTimeSeconds >= 0 ? currentTimeSeconds - m_prevTimeSeconds : m_nominalDt;
+    m_prevTimeSeconds = currentTimeSeconds;
+
+    var angle = gyroAngle.plus(m_gyroOffset);
+    // Diff drive forward kinematics:
+    // v_c = (v_l + v_r) / 2
+    var wheelVels = wheelVelocitiesMetersPerSecond;
+    var u = VecBuilder.fill(
+            wheelVels.leftMetersPerSecond, wheelVels.rightMetersPerSecond,
+            angle.minus(m_previousAngle).getRadians() / dt
+    );
+    m_previousAngle = angle;
+
+    var localY = VecBuilder.fill(distanceLeftMeters, distanceRightMeters, angle.getCos(), angle.getSin());
+    m_latencyCompensator.addObserverState(m_observer, u, localY, currentTimeSeconds);
+    m_observer.predict(u, dt);
+    m_observer.correct(u, localY);
+
+    return getEstimatedPosition();
+  }
+
+  private static Matrix<N6, N1> fillStateVector(Pose2d pose, double leftDist, double rightDist) {
+    return VecBuilder.fill(
+            pose.getTranslation().getX(),
+            pose.getTranslation().getY(),
+            pose.getRotation().getCos(),
+            pose.getRotation().getSin(),
+            leftDist,
+            rightDist
+    );
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDriveStateEstimator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDriveStateEstimator.java
@@ -1,0 +1,372 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.function.BiConsumer;
+
+import edu.wpi.first.wpiutil.math.numbers.N12;
+import org.ejml.simple.SimpleMatrix;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.math.Discretization;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.MatrixUtils;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N10;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+import edu.wpi.first.wpiutil.math.numbers.N3;
+import edu.wpi.first.wpiutil.math.numbers.N4;
+import edu.wpi.first.wpiutil.math.numbers.N7;
+
+/**
+ * This class wraps an
+ * {@link edu.wpi.first.wpilibj.estimator.UnscentedKalmanFilter Extended Kalman Filter}
+ * to fuse latency-compensated global measurements(ex. vision) with differential drive encoder
+ * measurements. It will correct for noisy global measurements and encoder drift.
+ *
+ * <p>This class is indented to be paired with an LTVDiffDriveController as it provides a
+ * 10-state estimate. This can then be trimmed into 5-state using {@link Matrix#block}
+ * with the operation
+ * <code>
+ * "10-stateEstimate".block(Nat.N5(), Nat.N1(), new Pair(0, 0))
+ * </code>
+ * then passed into the controller as the current state estimate.
+ *
+ * <p>{@link DifferentialDriveStateEstimator#update} should be called every robot
+ * loop (if your robot loops are faster than the default then you should change
+ * the {@link DifferentialDriveStateEstimator#DifferentialDriveStateEstimator(LinearSystem,
+ * Matrix, Matrix, Matrix, Matrix, DifferentialDriveKinematics, double) nominal delta time}.)
+ *
+ * <p>{@link DifferentialDriveStateEstimator#applyPastGlobalMeasurement} can be called as
+ * infrequently as you want.
+ *
+ * <p>Our state-space system is:
+ *
+ * <p>x = [[x, y, cos(theta), sin(theta), vel_l, vel_r, dist_l, dist_r, voltError_l, voltError_r, cos_error, sin_error]]^T
+ * in the field coordinate system (dist_* are wheel distances.)
+ *
+ * <p>u = [[voltage_l, voltage_r]]^T This is typically the control input of the last timestep
+ * from a LTVDiffDriveController.
+ *
+ * <p>y = [[x, y, theta]]^T from a global measurement source(ex. vision),
+ * or y = [[dist_l, dist_r, cos(theta), sin(theta)]] from encoders and gyro.
+ */
+@SuppressWarnings({"ParameterName", "LocalVariableName", "MemberName", "PMD.SingularField"})
+public class DifferentialDriveStateEstimator {
+  private final UnscentedKalmanFilter<N12, N2, N4> m_observer;
+  private final KalmanFilterLatencyCompensator<N12, N2, N4> m_latencyCompensator;
+
+  private final BiConsumer<Matrix<N2, N1>, Matrix<N3, N1>> m_globalCorrect;
+
+  private final double m_rb;
+  private final LinearSystem<N2, N2, N2> m_plant;
+
+  private final double m_nominalDt; // Seconds
+  private double m_prevTimeSeconds = -1.0;
+
+
+  private Matrix<N3, N1> m_localY;
+  private Matrix<N3, N1> m_globalY;
+
+  /**
+   * Constructs a DifferentialDriveStateEstimator.
+   *
+   * @param plant                    A {@link LinearSystem} representing a differential drivetrain.
+   * @param initialState             The starting state estimate.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your model less.
+   * @param localMeasurementStdDevs  Standard deviations of the encoder and gyro measurements.
+   *                                 Increase these numbers to trust encoder distances and gyro
+   *                                 angle less.
+   * @param globalMeasurementStdDevs Standard deviations of the global(vision) measurements.
+   *                                 Increase these numbers to global(vision) measurements less.
+   * @param kinematics               A {@link DifferentialDriveKinematics} object representing the
+   *                                 differential drivetrain's kinematics.
+   */
+  public DifferentialDriveStateEstimator(LinearSystem<N2, N2, N2> plant,
+                                        Matrix<N10, N1> initialState,
+                                        Matrix<N10, N1> stateStdDevs,
+                                        Matrix<N3, N1> localMeasurementStdDevs,
+                                        Matrix<N3, N1> globalMeasurementStdDevs,
+                                        DifferentialDriveKinematics kinematics
+  ) {
+    this(plant, initialState, stateStdDevs,
+            localMeasurementStdDevs, globalMeasurementStdDevs, kinematics, 0.02);
+  }
+
+  /**
+   * Constructs a DifferentialDriveStateEstimator.
+   *
+   * @param plant                    A {@link LinearSystem} representing a differential drivetrain.
+   * @param initialState             The starting state estimate.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the encoder and gyro measurements.
+   *                                 Increase these numbers to trust encoder distances and gyro
+   *                                 angle less.
+   * @param globalMeasurementStdDevs Standard deviations of the global(vision) measurements.
+   *                                 Increase these numbers to global(vision) measurements less.
+   * @param kinematics               A {@link DifferentialDriveKinematics} object representing the
+   *                                 differential drivetrain's kinematics.
+   * @param nominalDtSeconds         The time in seconds between each robot loop.
+   */
+  public DifferentialDriveStateEstimator(
+          LinearSystem<N2, N2, N2> plant,
+          Matrix<N10, N1> initialState,
+          Matrix<N10, N1> stateStdDevs,
+          Matrix<N3, N1> localMeasurementStdDevs,
+          Matrix<N3, N1> globalMeasurementStdDevs,
+          DifferentialDriveKinematics kinematics,
+          double nominalDtSeconds
+  ) {
+    m_nominalDt = nominalDtSeconds;
+    m_plant = plant;
+    m_rb = kinematics.trackWidthMeters / 2.0;
+
+    m_localY = MatrixUtils.zeros(Nat.N3());
+    m_globalY = MatrixUtils.zeros(Nat.N3());
+
+    // Create R (covariances) for global measurements.
+    var globalContR = StateSpaceUtil.makeCovarianceMatrix(Nat.N3(), globalMeasurementStdDevs);
+    var globalDiscR = Discretization.discretizeR(globalContR, m_nominalDt);
+
+    m_observer = new UnscentedKalmanFilter<>(
+      Nat.N10(), Nat.N3(),
+      this::getDynamics,
+      this::getLocalMeasurementModel,
+      stateStdDevs,
+      localMeasurementStdDevs,
+      nominalDtSeconds
+   );
+
+    // Create correction mechanism for global measurements.
+    m_globalCorrect = (u, y) -> m_observer.correct(
+      Nat.N3(), u, y,
+      this::getGlobalMeasurementModel,
+      globalDiscR
+    );
+    m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
+
+    reset(initialState);
+  }
+
+  @SuppressWarnings("JavadocMethod")
+  protected Matrix<N12, N1> getDynamics(Matrix<N12, N1> x, Matrix<N2, N1> u) {
+    Matrix<N4, N2> B = new Matrix<>(new SimpleMatrix(4, 2));
+    B.getStorage().insertIntoThis(0, 0, m_plant.getB().getStorage());
+    B.getStorage().insertIntoThis(2, 0, new SimpleMatrix(2, 2));
+
+    Matrix<N4, N7> A = new Matrix<>(new SimpleMatrix(4, 7));
+    A.getStorage().insertIntoThis(0, 0, m_plant.getA().getStorage());
+
+    A.getStorage().insertIntoThis(2, 0, SimpleMatrix.identity(2));
+    A.getStorage().insertIntoThis(0, 2, new SimpleMatrix(4, 2));
+    A.getStorage().insertIntoThis(0, 4, B.getStorage());
+    A.getStorage().setColumn(6, 0, 0, 0, 1, -1);
+
+    var v = (x.get(State.kLeftVelocity.value, 0) + x.get(State.kRightVelocity.value, 0)) / 2.0;
+
+    var result = new Matrix<>(Nat.N12(), Nat.N1());
+    result.set(0, 0, v * x.get(State.kCos.value, 0));
+    result.set(1, 0, v * x.get(State.kSin.value, 0));
+    result.set(2, 0, (x.get(State.kRightVelocity.value, 0)
+            - x.get(State.kLeftVelocity.value, 0)) / (2.0 * m_rb));
+
+    result.getStorage().insertIntoThis(4, 0, A.times(new Matrix<N7, N1>(
+            x.getStorage().extractMatrix(3, 10, 0, 1))).plus(B.times(u)).getStorage());
+    result.getStorage().insertIntoThis(7, 0, new SimpleMatrix(3, 1));
+    return result;
+  }
+
+  @SuppressWarnings("JavadocMethod")
+  public Matrix<N3, N1> getLocalMeasurementModel(Matrix<N10, N1> x, Matrix<N2, N1> u) {
+    return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(x.get(State.kCos.value, 0),
+            x.get(State.kLeftPosition.value, 0), x.get(State.kRightPosition.value, 0));
+  }
+
+  @SuppressWarnings("JavadocMethod")
+  public Matrix<N3, N1> getGlobalMeasurementModel(Matrix<N10, N1> x, Matrix<N2, N1> u) {
+    return new MatBuilder<>(Nat.N3(), Nat.N1()).fill(
+        x.get(State.kX.value, 0),
+        x.get(State.kY.value, 0),
+        x.get(State.kCos.value, 0)
+    );
+  }
+
+  /**
+   * Applies a global measurement with a given timestamp.
+   *
+   * @param robotPoseMeters  The measured robot pose.
+   * @param timestampSeconds The timestamp of the global measurement in seconds. Note that if
+   *                         you don't use your own time source by calling
+   *                         {@link DifferentialDriveStateEstimator#updateWithTime} then you
+   *                         must use a timestamp with an epoch since FPGA startup
+   *                         (i.e. the epoch of this timestamp is the same epoch as
+   *                         {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp
+   *                         Timer.getFPGATimestamp}.) This means that you should
+   *                         use Timer.getFPGATimestamp as your time source in
+   *                         this case.
+   */
+  public void applyPastGlobalMeasurement(Pose2d robotPoseMeters,
+                                         double timestampSeconds) {
+    m_globalY.set(GlobalOutput.kX.value, 0, robotPoseMeters.getTranslation().getX());
+    m_globalY.set(GlobalOutput.kY.value, 0, robotPoseMeters.getTranslation().getY());
+    m_globalY.set(GlobalOutput.kHeading.value, 0, robotPoseMeters.getRotation().getRadians());
+
+    m_latencyCompensator.applyPastGlobalMeasurement(
+            Nat.N3(),
+            m_observer, m_nominalDt,
+            m_globalY,
+            m_globalCorrect,
+            timestampSeconds
+    );
+  }
+
+  /**
+   * Gets the state of the robot at the current time as estimated by the Extended Kalman Filter.
+   *
+   * @return The robot state estimate.
+   */
+  public Matrix<N10, N1> getEstimatedState() {
+    return m_observer.getXhat();
+  }
+
+  /**
+   * Gets the state of the robot at the current time as estimated by the Extended Kalman Filter.
+   *
+   * @return The robot state estimate.
+   */
+  public Pose2d getEstimatedPosition() {
+    var xHat = getEstimatedState();
+    return new Pose2d(
+        xHat.get(State.kX.value, 0),
+        xHat.get(State.kY.value, 0),
+        new Rotation2d(xHat.get(State.kCos.value, 0)));
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using wheel encoder information, robot heading and the
+   * previous control input. The control input can be obtained from a LTVDiffDriveController.
+   * Note that this should be called every loop.
+   *
+   * @param headingRadians The current heading of the robot in radians.
+   * @param leftPosition   The distance traveled by the left side of the robot in meters.
+   * @param rightPosition  The distance traveled by the right side of the robot in meters.
+   * @param controlInput   The control input from the last timestep.
+   * @return The robot state estimate.
+   */
+  public Matrix<N10, N1> update(double headingRadians, double leftPosition,
+                                double rightPosition,
+                                Matrix<N2, N1> controlInput) {
+    return updateWithTime(headingRadians,
+            leftPosition,
+            rightPosition,
+            controlInput,
+            Timer.getFPGATimestamp());
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using wheel encoder information, robot heading and the
+   * previous control input. The control input can be obtained from a LTVDiffDriveController.
+   * Note that this should be called every loop.
+   *
+   * @param headingRadians     The current heading of the robot in radians.
+   * @param leftPosition       The distance traveled by the left side of the robot in meters.
+   * @param rightPosition      The distance traveled by the right side of the robot in meters.
+   * @param controlInput       The control input.
+   * @param currentTimeSeconds Time at which this method was called, in seconds.
+   * @return The robot state estimate.
+   */
+  @SuppressWarnings("VariableDeclarationUsageDistance")
+  public Matrix<N10, N1> updateWithTime(double headingRadians, double leftPosition,
+                                        double rightPosition,
+                                        Matrix<N2, N1> controlInput,
+                                        double currentTimeSeconds) {
+    double dt = m_prevTimeSeconds >= 0 ? currentTimeSeconds - m_prevTimeSeconds : m_nominalDt;
+    m_prevTimeSeconds = currentTimeSeconds;
+
+    m_localY.set(LocalOutput.kHeading.value, 0, headingRadians);
+    m_localY.set(LocalOutput.kLeftPosition.value, 0, leftPosition);
+    m_localY.set(LocalOutput.kRightPosition.value, 0, rightPosition);
+
+    m_latencyCompensator.addObserverState(m_observer, controlInput, m_localY, currentTimeSeconds);
+
+    m_observer.predict(controlInput, dt);
+    m_observer.correct(controlInput, m_localY);
+
+    return getEstimatedState();
+  }
+
+  /**
+   * Resets any internal state with a given initial state.
+   *
+   * @param initialState Initial state for state estimate.
+   */
+  public void reset(Matrix<N10, N1> initialState) {
+    m_observer.reset();
+
+    m_observer.setXhat(initialState);
+  }
+
+  /**
+   * Resets any internal state.
+   */
+  public void reset() {
+    m_observer.reset();
+  }
+
+  private enum State {
+    kX(0),
+    kY(1),
+    kCos(2),
+    kSin(3),
+    kLeftVelocity(4),
+    kRightVelocity(5),
+    kLeftPosition(6),
+    kRightPosition(7),
+    kLeftVoltageError(8),
+    kRightVoltageError(9),
+    kCosError(10),
+    kSinError(11);
+
+    private final int value;
+
+    State(int i) {
+      this.value = i;
+    }
+  }
+
+  private enum LocalOutput {
+    kHeading(0), kLeftPosition(1), kRightPosition(2);
+
+    private final int value;
+
+    LocalOutput(int i) {
+      this.value = i;
+    }
+  }
+
+  private enum GlobalOutput {
+    kX(0),
+    kY(1),
+    kHeading(2);
+
+    private final int value;
+
+    GlobalOutput(int i) {
+      this.value = i;
+    }
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilterLatencyCompensator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/KalmanFilterLatencyCompensator.java
@@ -1,0 +1,161 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.Num;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+
+public class KalmanFilterLatencyCompensator<S extends Num, I extends Num, O extends Num> {
+  private static final int k_maxPastObserverStates = 300;
+
+  private final List<Map.Entry<Double, ObserverSnapshot>> m_pastObserverSnapshots;
+
+  KalmanFilterLatencyCompensator() {
+    m_pastObserverSnapshots = new ArrayList<>();
+  }
+
+  /**
+   * Add past observer states to the observer snapshots list.
+   *
+   * @param observer         The observer.
+   * @param u                The input at the timestamp.
+   * @param localY           The local output at the timestamp
+   * @param timestampSeconds The timesnap of the state.
+   */
+  @SuppressWarnings("ParameterName")
+  public void addObserverState(
+          KalmanTypeFilter<S, I, O> observer, Matrix<I, N1> u, Matrix<O, N1> localY,
+          double timestampSeconds
+  ) {
+    m_pastObserverSnapshots.add(Map.entry(
+            timestampSeconds, new ObserverSnapshot(observer, u, localY)
+    ));
+
+    if (m_pastObserverSnapshots.size() > k_maxPastObserverStates) {
+      m_pastObserverSnapshots.remove(0);
+    }
+  }
+
+  /**
+   * Add past global measurements (such as from vision)to the estimator.
+   *
+   * @param <R>                               The rows in the global measurement vector.
+   * @param rows                              The rows in the global measurement vector.
+   * @param observer                          The observer to apply the past global measurement.
+   * @param nominalDtSeconds                  The nominal timestep.
+   * @param globalMeasurement                 The measurement.
+   * @param globalMeasurementCorrect          The function take calls correct() on the observer.
+   * @param globalMeasurementTimestampSeconds The timestamp of the measurement.
+   */
+  @SuppressWarnings({"ParameterName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  public <R extends Num> void applyPastGlobalMeasurement(
+          Nat<R> rows,
+          KalmanTypeFilter<S, I, O> observer,
+          double nominalDtSeconds,
+          Matrix<R, N1> globalMeasurement,
+          BiConsumer<Matrix<I, N1>, Matrix<R, N1>> globalMeasurementCorrect,
+          double globalMeasurementTimestampSeconds
+  ) {
+    if (m_pastObserverSnapshots.isEmpty()) {
+      // State map was empty, which means that we got a past measurement right at startup. The only
+      // thing we can really do is ignore the measurement.
+      return;
+    }
+
+    // This index starts at one because we use the previous state later on, and we always want to
+    // have a "previous state".
+    int maxIdx = m_pastObserverSnapshots.size() - 1;
+    int low = 1;
+    int high = Math.max(maxIdx, 1);
+
+    while (low != high) {
+      int mid = (low + high) / 2;
+      if (m_pastObserverSnapshots.get(mid).getKey() < globalMeasurementTimestampSeconds) {
+        // This index and everything under it are less than the requested timestamp. Therefore, we
+        // can discard them.
+        low = mid + 1;
+      } else {
+        // t is at least as large as the element at this index. This means that anything after it
+        // cannot be what we are looking for.
+        high = mid;
+      }
+    }
+
+    // We are simply assigning this index to a new variable to avoid confusion
+    // with variable names.
+    int index = low;
+    double timestamp = globalMeasurementTimestampSeconds;
+    int indexOfClosestEntry =
+        Math.abs(timestamp - m_pastObserverSnapshots.get(index - 1).getKey())
+            <= Math.abs(timestamp - m_pastObserverSnapshots.get(Math.min(index, maxIdx)).getKey())
+            ? index - 1
+            : index;
+
+    double lastTimestamp =
+            m_pastObserverSnapshots.get(indexOfClosestEntry).getKey() - nominalDtSeconds;
+
+    // We will now go back in time to the state of the system at the time when
+    // the measurement was captured. We will reset the observer to that state,
+    // and apply correction based on the measurement. Then, we will go back
+    // through all observer states until the present and apply past inputs to
+    // get the present estimated state.
+    for (int i = indexOfClosestEntry; i < m_pastObserverSnapshots.size(); i++) {
+      var key = m_pastObserverSnapshots.get(i).getKey();
+      var snapshot = m_pastObserverSnapshots.get(i).getValue();
+
+      if (i == indexOfClosestEntry) {
+        observer.setP(snapshot.errorCovariances);
+        observer.setXhat(snapshot.xHat);
+      }
+
+      observer.predict(snapshot.inputs, key - lastTimestamp);
+      observer.correct(snapshot.inputs, snapshot.localMeasurements);
+
+      if (i == indexOfClosestEntry) {
+        // Note that the measurement is at a timestep close but probably not exactly equal to the
+        // timestep for which we called predict.
+        // This makes the assumption that the dt is small enough that the difference between the
+        // measurement time and the time that the inputs were captured at is very small.
+        globalMeasurementCorrect.accept(snapshot.inputs, globalMeasurement);
+      }
+      lastTimestamp = key;
+
+      m_pastObserverSnapshots.set(i, Map.entry(key,
+              new ObserverSnapshot(observer, snapshot.inputs, snapshot.localMeasurements)));
+    }
+  }
+
+  /**
+   * This class contains all the information about our observer at a given time.
+   */
+  @SuppressWarnings("MemberName")
+  public class ObserverSnapshot {
+    public final Matrix<S, N1> xHat;
+    public final Matrix<S, S> errorCovariances;
+    public final Matrix<I, N1> inputs;
+    public final Matrix<O, N1> localMeasurements;
+
+    @SuppressWarnings("ParameterName")
+    private ObserverSnapshot(
+            KalmanTypeFilter<S, I, O> observer, Matrix<I, N1> u, Matrix<O, N1> localY
+    ) {
+      this.xHat = observer.getXhat();
+      this.errorCovariances = observer.getP();
+
+      inputs = u;
+      localMeasurements = localY;
+    }
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/MecanumDrivePoseEstimator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/MecanumDrivePoseEstimator.java
@@ -1,0 +1,259 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.function.BiConsumer;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.MecanumDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.MecanumDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.math.Discretization;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+import edu.wpi.first.wpiutil.math.numbers.N3;
+import edu.wpi.first.wpiutil.math.numbers.N4;
+
+/**
+ * This class wraps an {@link UnscentedKalmanFilter ExtendedKalmanFilter} to fuse
+ * latency-compensated vision measurements with mecanum drive encoder velocity measurements.
+ * It will correct for noisy measurements and encoder drift. It is intended to be an easy
+ * but more accurate drop-in for {@link edu.wpi.first.wpilibj.kinematics.MecanumDriveOdometry}.
+ *
+ * <p>{@link MecanumDrivePoseEstimator#update} should be called every robot loop. If
+ * your loops are faster or slower than the default of 0.02s, then you should change
+ * the nominal delta time using the secondary constructor:
+ * {@link MecanumDrivePoseEstimator#MecanumDrivePoseEstimator(Rotation2d, Pose2d,
+ * MecanumDriveKinematics, Matrix, Matrix, Matrix, double)}.
+ *
+ * <p>{@link MecanumDrivePoseEstimator#addVisionMeasurement} can be called as
+ * infrequently as you want; if you never call it, then this class will behave mostly like regular
+ * encoder odometry.
+ *
+ * <p>Our state-space system is:
+ *
+ * <p><strong> x = [[x, y, cos(theta), sin(theta)]]^T </strong> in the field-coordinate system.
+ *
+ * <p><strong> u = [[vx, vy, omega]]^T </strong> in the field-coordinate system.
+ *
+ * <p><strong> y = [[x, y, cos(theta), sin(theta)]]^T </strong> in field coords from vision,
+ * or <strong> y = [[cos(theta), sin(theta)]]^T </strong> from the gyro.
+ */
+public class MecanumDrivePoseEstimator {
+  private final UnscentedKalmanFilter<N4, N3, N2> m_observer;
+  private final MecanumDriveKinematics m_kinematics;
+  private final BiConsumer<Matrix<N3, N1>, Matrix<N4, N1>> m_visionCorrect;
+  private final KalmanFilterLatencyCompensator<N4, N3, N2> m_latencyCompensator;
+
+  private final double m_nominalDt; // Seconds
+  private double m_prevTimeSeconds = -1.0;
+
+  private Rotation2d m_gyroOffset;
+  private Rotation2d m_previousAngle;
+
+  /**
+   * Constructs a MecanumDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param kinematics               A correctly-configured kinematics object for your drivetrain.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the gyro measurement. Increase this
+   *                                 number to trust gyro angle measurements less.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder measurements. Increase
+   *                                 these numbers to trust vision less.
+   */
+  public MecanumDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters, MecanumDriveKinematics kinematics,
+          Matrix<N3, N1> stateStdDevs, Matrix<N1, N1> localMeasurementStdDevs,
+          Matrix<N3, N1> visionMeasurementStdDevs
+  ) {
+    this(gyroAngle, initialPoseMeters, kinematics, stateStdDevs, localMeasurementStdDevs,
+            visionMeasurementStdDevs, 0.02);
+  }
+
+  /**
+   * Constructs a MecanumDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param kinematics               A correctly-configured kinematics object for your drivetrain.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the gyro measurement. Increase this
+   *                                 number to trust gyro angle measurements less.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder measurements. Increase
+   *                                 these numbers to trust vision less.
+   * @param nominalDtSeconds         The time in seconds between each robot loop.
+   */
+  @SuppressWarnings("ParameterName")
+  public MecanumDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters, MecanumDriveKinematics kinematics,
+          Matrix<N3, N1> stateStdDevs, Matrix<N1, N1> localMeasurementStdDevs,
+          Matrix<N3, N1> visionMeasurementStdDevs, double nominalDtSeconds
+  ) {
+    m_nominalDt = nominalDtSeconds;
+
+    m_observer = new UnscentedKalmanFilter<>(
+        Nat.N4(), Nat.N2(),
+        this::f,
+        (x, u) -> x.block(Nat.N2(), Nat.N1(), 2, 0),
+        VecBuilder.fill(stateStdDevs.get(0, 0), stateStdDevs.get(1, 0),
+            Math.cos(stateStdDevs.get(2, 0)), Math.sin(stateStdDevs.get(2, 0))),
+        VecBuilder.fill(Math.cos(localMeasurementStdDevs.get(0, 0)),
+                Math.sin(localMeasurementStdDevs.get(0, 0))),
+        m_nominalDt
+    );
+    m_kinematics = kinematics;
+    m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
+
+    var fullVisionMeasurementStdDev = VecBuilder.fill(
+            visionMeasurementStdDevs.get(0, 0), visionMeasurementStdDevs.get(1, 0),
+            Math.cos(visionMeasurementStdDevs.get(2, 0)),
+            Math.sin(visionMeasurementStdDevs.get(2, 0))
+    );
+
+    var visionContR = StateSpaceUtil.makeCovarianceMatrix(Nat.N4(), fullVisionMeasurementStdDev);
+    var visionDiscR = Discretization.discretizeR(visionContR, m_nominalDt);
+
+    m_visionCorrect = (u, y) -> m_observer.correct(
+        Nat.N4(), u, y,
+        (x, u_) -> x,
+        visionDiscR
+    );
+
+    m_gyroOffset = initialPoseMeters.getRotation().minus(gyroAngle);
+    m_previousAngle = initialPoseMeters.getRotation();
+    m_observer.setXhat(StateSpaceUtil.poseTo4dVector(initialPoseMeters));
+  }
+
+  @SuppressWarnings({"ParameterName", "MethodName"})
+  private Matrix<N4, N1> f(Matrix<N4, N1> x, Matrix<N3, N1> u) {
+    return VecBuilder.fill(
+            u.get(0, 0), u.get(1, 0), -x.get(3, 0) * u.get(2, 0), x.get(2, 0) * u.get(2, 0)
+    );
+  }
+
+  /**
+   * Resets the robot's position on the field.
+   *
+   * <p>You NEED to reset your encoders (to zero) when calling this method.
+   *
+   * <p>The gyroscope angle does not need to be reset in the user's robot code.
+   * The library automatically takes care of offsetting the gyro angle.
+   *
+   * @param poseMeters The position on the field that your robot is at.
+   * @param gyroAngle  The angle reported by the gyroscope.
+   */
+  public void resetPosition(Pose2d poseMeters, Rotation2d gyroAngle) {
+    m_previousAngle = poseMeters.getRotation();
+    m_gyroOffset = getEstimatedPosition().getRotation().minus(gyroAngle);
+    m_observer.setXhat(StateSpaceUtil.poseTo4dVector(poseMeters));
+  }
+
+  /**
+   * Gets the pose of the robot at the current time as estimated by the Extended Kalman Filter.
+   *
+   * @return The estimated robot pose in meters.
+   */
+  public Pose2d getEstimatedPosition() {
+    return new Pose2d(
+            m_observer.getXhat(0),
+            m_observer.getXhat(1),
+            new Rotation2d(m_observer.getXhat(2), m_observer.getXhat(3))
+    );
+  }
+
+  /**
+   * Add a vision measurement to the Extended Kalman Filter. This will correct the
+   * odometry pose estimate while still accounting for measurement noise.
+   *
+   * <p>This method can be called as infrequently as you want, as long as you are
+   * calling {@link MecanumDrivePoseEstimator#update} every loop.
+   *
+   * @param visionRobotPoseMeters The pose of the robot as measured by the vision
+   *                              camera.
+   * @param timestampSeconds      The timestamp of the vision measurement in seconds. Note that if
+   *                              you don't use your own time source by calling
+   *                              {@link MecanumDrivePoseEstimator#updateWithTime} then you
+   *                              must use a timestamp with an epoch since FPGA startup
+   *                              (i.e. the epoch of this timestamp is the same epoch as
+   *                              {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp
+   *                              Timer.getFPGATimestamp}.) This means that you should
+   *                              use Timer.getFPGATimestamp as your time source
+   *                              or sync the epochs.
+   */
+  public void addVisionMeasurement(Pose2d visionRobotPoseMeters, double timestampSeconds) {
+    m_latencyCompensator.applyPastGlobalMeasurement(
+            Nat.N4(),
+            m_observer, m_nominalDt,
+            StateSpaceUtil.poseTo4dVector(visionRobotPoseMeters),
+            m_visionCorrect,
+            timestampSeconds
+    );
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder information.
+   * This should be called every loop, and the correct loop period must be passed
+   * into the constructor of this class.
+   *
+   * @param gyroAngle   The current gyro angle.
+   * @param wheelSpeeds The current speeds of the mecanum drive wheels.
+   * @return The estimated pose of the robot in meters.
+   */
+  public Pose2d update(Rotation2d gyroAngle, MecanumDriveWheelSpeeds wheelSpeeds) {
+    return updateWithTime(Timer.getFPGATimestamp(), gyroAngle, wheelSpeeds);
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder information.
+   * This should be called every loop, and the correct loop period must be passed
+   * into the constructor of this class.
+   *
+   * @param currentTimeSeconds Time at which this method was called, in seconds.
+   * @param gyroAngle          The current gyroscope angle.
+   * @param wheelSpeeds        The current speeds of the mecanum drive wheels.
+   * @return The estimated pose of the robot in meters.
+   */
+  @SuppressWarnings("LocalVariableName")
+  public Pose2d updateWithTime(double currentTimeSeconds, Rotation2d gyroAngle,
+                               MecanumDriveWheelSpeeds wheelSpeeds) {
+    double dt = m_prevTimeSeconds >= 0 ? currentTimeSeconds - m_prevTimeSeconds : m_nominalDt;
+    m_prevTimeSeconds = currentTimeSeconds;
+
+    var angle = gyroAngle.plus(m_gyroOffset);
+    var omega = angle.minus(m_previousAngle).getRadians() / dt;
+
+    var chassisSpeeds = m_kinematics.toChassisSpeeds(wheelSpeeds);
+    var fieldRelativeVelocities =
+            new Translation2d(chassisSpeeds.vxMetersPerSecond, chassisSpeeds.vyMetersPerSecond)
+                    .rotateBy(angle);
+
+    var u = VecBuilder.fill(
+            fieldRelativeVelocities.getX(),
+            fieldRelativeVelocities.getY(),
+            omega
+    );
+    m_previousAngle = angle;
+
+    var localY = VecBuilder.fill(angle.getCos(), angle.getSin());
+    m_latencyCompensator.addObserverState(m_observer, u, localY, currentTimeSeconds);
+    m_observer.predict(u, dt);
+    m_observer.correct(u, localY);
+
+    return getEstimatedPosition();
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimator.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimator.java
@@ -1,0 +1,266 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.function.BiConsumer;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.math.Discretization;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+import edu.wpi.first.wpiutil.math.numbers.N3;
+import edu.wpi.first.wpiutil.math.numbers.N4;
+
+/**
+ * This class wraps an {@link UnscentedKalmanFilter ExtendedKalmanFilter} to fuse
+ * latency-compensated vision measurements with swerve drive encoder velocity measurements.
+ * It will correct for noisy measurements and encoder drift. It is intended to be an easy
+ * but more accurate drop-in for {@link edu.wpi.first.wpilibj.kinematics.SwerveDriveOdometry}.
+ *
+ * <p>{@link SwerveDrivePoseEstimator#update} should be called every robot loop. If
+ * your loops are faster or slower than the default of 0.02s, then you should change
+ * the nominal delta time using the secondary constructor:
+ * {@link SwerveDrivePoseEstimator#SwerveDrivePoseEstimator(Rotation2d, Pose2d,
+ * SwerveDriveKinematics, Matrix, Matrix, Matrix, double)}.
+ *
+ * <p>{@link SwerveDrivePoseEstimator#addVisionMeasurement} can be called as
+ * infrequently as you want; if you never call it, then this class will behave mostly like regular
+ * encoder odometry.
+ *
+ * <p>Our state-space system is:
+ *
+ * <p><strong> x = [[x, y, cos(theta), sin(theta)]]^T </strong> in the field-coordinate system.
+ *
+ * <p><strong> u = [[vx, vy, omega]]^T </strong> in the field-coordinate system.
+ *
+ * <p><strong> y = [[x, y, cos(theta), sin(theta)]]^T </strong> in field coords from vision,
+ * or <strong> y = [[cos(theta), sin(theta)]]^T </strong> from the gyro.
+ */
+public class SwerveDrivePoseEstimator {
+  private final UnscentedKalmanFilter<N4, N3, N2> m_observer;
+  private final SwerveDriveKinematics m_kinematics;
+  private final BiConsumer<Matrix<N3, N1>, Matrix<N4, N1>> m_visionCorrect;
+  private final KalmanFilterLatencyCompensator<N4, N3, N2> m_latencyCompensator;
+
+  private final double m_nominalDt; // Seconds
+  private double m_prevTimeSeconds = -1.0;
+
+  private Rotation2d m_gyroOffset;
+  private Rotation2d m_previousAngle;
+
+  /**
+   * Constructs a SwerveDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param kinematics               A correctly-configured kinematics object for your drivetrain.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less. This vector should
+   *                                 be in the form [x, y, theta (in rads)].
+   * @param localMeasurementStdDevs  Standard deviations of the gyro measurement. Increase this
+   *                                 number to trust gyro angle measurements less. This should
+   *                                 be in the form [heading (in rads)].
+   * @param visionMeasurementStdDevs Standard deviations of the encoder measurements. Increase
+   *                                 these numbers to trust vision less. This should be in the
+   *                                 form [x, y, theta (in rads)].
+   */
+  public SwerveDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters, SwerveDriveKinematics kinematics,
+          Matrix<N3, N1> stateStdDevs, Matrix<N1, N1> localMeasurementStdDevs,
+          Matrix<N3, N1> visionMeasurementStdDevs
+  ) {
+    this(gyroAngle, initialPoseMeters, kinematics, stateStdDevs, localMeasurementStdDevs,
+            visionMeasurementStdDevs, 0.02);
+  }
+
+  /**
+   * Constructs a SwerveDrivePoseEstimator.
+   *
+   * @param gyroAngle                The current gyro angle.
+   * @param initialPoseMeters        The starting pose estimate.
+   * @param kinematics               A correctly-configured kinematics object for your drivetrain.
+   * @param stateStdDevs             Standard deviations of model states. Increase these numbers to
+   *                                 trust your wheel and gyro velocities less.
+   * @param localMeasurementStdDevs  Standard deviations of the gyro measurement. Increase this
+   *                                 number to trust gyro angle measurements less.
+   * @param visionMeasurementStdDevs Standard deviations of the encoder measurements. Increase
+   *                                 these numbers to trust vision less.
+   * @param nominalDtSeconds         The time in seconds between each robot loop.
+   */
+  @SuppressWarnings("ParameterName")
+  public SwerveDrivePoseEstimator(
+          Rotation2d gyroAngle, Pose2d initialPoseMeters, SwerveDriveKinematics kinematics,
+          Matrix<N3, N1> stateStdDevs, Matrix<N1, N1> localMeasurementStdDevs,
+          Matrix<N3, N1> visionMeasurementStdDevs, double nominalDtSeconds
+  ) {
+    m_nominalDt = nominalDtSeconds;
+
+    m_observer = new UnscentedKalmanFilter<>(
+        Nat.N4(), Nat.N2(),
+        this::f,
+        (x, u) -> x.block(Nat.N2(), Nat.N1(), 2, 0),
+        VecBuilder.fill(stateStdDevs.get(0, 0), stateStdDevs.get(1, 0),
+            Math.cos(stateStdDevs.get(2, 0)), Math.sin(stateStdDevs.get(2, 0))),
+        VecBuilder.fill(Math.cos(localMeasurementStdDevs.get(0, 0)),
+                Math.sin(localMeasurementStdDevs.get(0, 0))),
+        m_nominalDt
+    );
+    m_kinematics = kinematics;
+    m_latencyCompensator = new KalmanFilterLatencyCompensator<>();
+
+    var fullVisionMeasurementStdDev = VecBuilder.fill(
+            visionMeasurementStdDevs.get(0, 0), visionMeasurementStdDevs.get(1, 0),
+            Math.cos(visionMeasurementStdDevs.get(2, 0)),
+            Math.sin(visionMeasurementStdDevs.get(2, 0)));
+
+    var visionContR = StateSpaceUtil.makeCovarianceMatrix(Nat.N4(), fullVisionMeasurementStdDev);
+    var visionDiscR = Discretization.discretizeR(visionContR, m_nominalDt);
+
+    m_visionCorrect = (u, y) -> m_observer.correct(
+        Nat.N4(), u, y,
+        (x, u_) -> x,
+        visionDiscR
+    );
+
+    m_gyroOffset = initialPoseMeters.getRotation().minus(gyroAngle);
+    m_previousAngle = initialPoseMeters.getRotation();
+    m_observer.setXhat(StateSpaceUtil.poseTo4dVector(initialPoseMeters));
+  }
+
+  @SuppressWarnings({"ParameterName", "MethodName"})
+  private Matrix<N4, N1> f(Matrix<N4, N1> x, Matrix<N3, N1> u) {
+    return VecBuilder.fill(
+            u.get(0, 0), u.get(1, 0), -x.get(3, 0) * u.get(2, 0), x.get(2, 0) * u.get(2, 0)
+    );
+  }
+
+  /**
+   * Resets the robot's position on the field.
+   *
+   * <p>You NEED to reset your encoders (to zero) when calling this method.
+   *
+   * <p>The gyroscope angle does not need to be reset in the user's robot code.
+   * The library automatically takes care of offsetting the gyro angle.
+   *
+   * @param poseMeters The position on the field that your robot is at.
+   * @param gyroAngle  The angle reported by the gyroscope.
+   */
+  public void resetPosition(Pose2d poseMeters, Rotation2d gyroAngle) {
+    m_previousAngle = poseMeters.getRotation();
+    m_gyroOffset = getEstimatedPosition().getRotation().minus(gyroAngle);
+    m_observer.setXhat(StateSpaceUtil.poseTo4dVector(poseMeters));
+  }
+
+  /**
+   * Gets the pose of the robot at the current time as estimated by the Extended Kalman Filter.
+   *
+   * @return The estimated robot pose in meters.
+   */
+  public Pose2d getEstimatedPosition() {
+    return new Pose2d(
+            m_observer.getXhat(0),
+            m_observer.getXhat(1),
+            new Rotation2d(m_observer.getXhat(2), m_observer.getXhat(3))
+    );
+  }
+
+  /**
+   * Add a vision measurement to the Extended Kalman Filter. This will correct the
+   * odometry pose estimate while still accounting for measurement noise.
+   *
+   * <p>This method can be called as infrequently as you want, as long as you are
+   * calling {@link SwerveDrivePoseEstimator#update} every loop.
+   *
+   * @param visionRobotPoseMeters The pose of the robot as measured by the vision
+   *                              camera.
+   * @param timestampSeconds      The timestamp of the vision measurement in seconds. Note that if
+   *                              you don't use your own time source by calling
+   *                              {@link SwerveDrivePoseEstimator#updateWithTime} then you
+   *                              must use a timestamp with an epoch since FPGA startup
+   *                              (i.e. the epoch of this timestamp is the same epoch as
+   *                              {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp
+   *                              Timer.getFPGATimestamp}.) This means that you should
+   *                              use Timer.getFPGATimestamp as your time source or
+   *                              sync the epochs.
+   */
+  public void addVisionMeasurement(Pose2d visionRobotPoseMeters, double timestampSeconds) {
+    m_latencyCompensator.applyPastGlobalMeasurement(
+            Nat.N4(),
+            m_observer, m_nominalDt,
+            StateSpaceUtil.poseTo4dVector(visionRobotPoseMeters),
+            m_visionCorrect,
+            timestampSeconds
+    );
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder information.
+   * This should be called every loop, and the correct loop period must be passed
+   * into the constructor of this class.
+   *
+   * @param gyroAngle    The current gyro angle.
+   * @param moduleStates The current velocities and rotations of the swerve modules.
+   * @return The estimated pose of the robot in meters.
+   */
+  public Pose2d update(
+          Rotation2d gyroAngle,
+          SwerveModuleState... moduleStates
+  ) {
+    return updateWithTime(Timer.getFPGATimestamp(), gyroAngle, moduleStates);
+  }
+
+  /**
+   * Updates the the Extended Kalman Filter using only wheel encoder information.
+   * This should be called every loop, and the correct loop period must be passed
+   * into the constructor of this class.
+   *
+   * @param currentTimeSeconds Time at which this method was called, in seconds.
+   * @param gyroAngle          The current gyroscope angle.
+   * @param moduleStates       The current velocities and rotations of the swerve modules.
+   * @return The estimated pose of the robot in meters.
+   */
+  @SuppressWarnings("LocalVariableName")
+  public Pose2d updateWithTime(
+          double currentTimeSeconds,
+          Rotation2d gyroAngle, SwerveModuleState... moduleStates
+  ) {
+    double dt = m_prevTimeSeconds >= 0 ? currentTimeSeconds - m_prevTimeSeconds : m_nominalDt;
+    m_prevTimeSeconds = currentTimeSeconds;
+
+    var angle = gyroAngle.plus(m_gyroOffset);
+    var omega = angle.minus(m_previousAngle).getRadians() / dt;
+
+    var chassisSpeeds = m_kinematics.toChassisSpeeds(moduleStates);
+    var fieldRelativeVelocities = new Translation2d(
+            chassisSpeeds.vxMetersPerSecond, chassisSpeeds.vyMetersPerSecond
+    ).rotateBy(angle);
+
+    var u = VecBuilder.fill(
+            fieldRelativeVelocities.getX(),
+            fieldRelativeVelocities.getY(),
+            omega
+    );
+    m_previousAngle = angle;
+
+    var localY = VecBuilder.fill(angle.getCos(), angle.getSin());
+    m_latencyCompensator.addObserverState(m_observer, u, localY, currentTimeSeconds);
+    m_observer.predict(u, dt);
+    m_observer.correct(u, localY);
+
+    return getEstimatedPosition();
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -1,0 +1,186 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import edu.wpi.first.wpilibj.system.RungeKutta;
+import edu.wpi.first.wpilibj.util.Units;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N6;
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.trajectory.Trajectory;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Nat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DifferentialDrivePoseEstimatorTest {
+  @SuppressWarnings({"LocalVariableName", "PMD.ExcessiveMethodLength",
+        "PMD.AvoidInstantiatingObjectsInLoops"})
+  @Test
+  public void testAccuracy() {
+    var estimator = new DifferentialDrivePoseEstimator(new Rotation2d(), new Pose2d(),
+            new MatBuilder<>(Nat.N5(), Nat.N1()).fill(0.02, 0.02, 0.01, 0.02, 0.02),
+            new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.02, 0.02, 0.01),
+            new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.1, 0.1, 0.01));
+
+    var traj = TrajectoryGenerator.generateTrajectory(
+            List.of(
+                    new Pose2d(),
+                    new Pose2d(20, 20, Rotation2d.fromDegrees(0)),
+                    new Pose2d(23, 23, Rotation2d.fromDegrees(173)),
+                    new Pose2d(54, 54, new Rotation2d())
+            ),
+            new TrajectoryConfig(0.5, 2));
+
+    var kinematics = new DifferentialDriveKinematics(1);
+    var rand = new Random(4915);
+
+    List<Double> trajXs = new ArrayList<>();
+    List<Double> trajYs = new ArrayList<>();
+    List<Double> observerXs = new ArrayList<>();
+    List<Double> observerYs = new ArrayList<>();
+    List<Double> visionXs = new ArrayList<>();
+    List<Double> visionYs = new ArrayList<>();
+
+    final double dt = 0.02;
+    double t = 0.0;
+
+    final double visionUpdateRate = 0.1;
+    Pose2d lastVisionPose = null;
+    double lastVisionUpdateTime = Double.NEGATIVE_INFINITY;
+
+    double distanceLeft = 0.0;
+    double distanceRight = 0.0;
+
+    double maxError = Double.NEGATIVE_INFINITY;
+    double errorSum = 0;
+    Trajectory.State groundtruthState;
+    DifferentialDriveWheelSpeeds input;
+    while (t <= traj.getTotalTimeSeconds()) {
+      groundtruthState = traj.sample(t);
+      input = kinematics.toWheelSpeeds(new ChassisSpeeds(
+              groundtruthState.velocityMetersPerSecond, 0.0,
+              // ds/dt * dtheta/ds = dtheta/dt
+              groundtruthState.velocityMetersPerSecond * groundtruthState.curvatureRadPerMeter
+      ));
+
+      if (lastVisionUpdateTime + visionUpdateRate + rand.nextGaussian() * 0.4 < t) {
+        if (lastVisionPose != null) {
+          estimator.addVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
+        }
+        var groundPose = groundtruthState.poseMeters;
+        lastVisionPose = new Pose2d(
+                new Translation2d(
+                        groundPose.getTranslation().getX() + rand.nextGaussian() * 0.1,
+                        groundPose.getTranslation().getY() + rand.nextGaussian() * 0.1
+                ),
+                new Rotation2d(rand.nextGaussian() * 0.01).plus(groundPose.getRotation())
+        );
+        lastVisionUpdateTime = t;
+
+        visionXs.add(lastVisionPose.getTranslation().getX());
+        visionYs.add(lastVisionPose.getTranslation().getY());
+      }
+
+      input.leftMetersPerSecond += rand.nextGaussian() * 0.02;
+      input.rightMetersPerSecond += rand.nextGaussian() * 0.02;
+
+      distanceLeft += input.leftMetersPerSecond * dt;
+      distanceRight += input.rightMetersPerSecond * dt;
+
+      var rotNoise = new Rotation2d(rand.nextGaussian() * 0.01);
+      var xHat = estimator.updateWithTime(
+              t,
+              groundtruthState.poseMeters.getRotation().plus(rotNoise),
+              input,
+              distanceLeft, distanceRight
+      );
+
+      double error =
+              groundtruthState.poseMeters.getTranslation().getDistance(xHat.getTranslation());
+      if (error > maxError) {
+        maxError = error;
+      }
+      errorSum += error;
+
+      trajXs.add(groundtruthState.poseMeters.getTranslation().getX());
+      trajYs.add(groundtruthState.poseMeters.getTranslation().getY());
+      observerXs.add(xHat.getTranslation().getX());
+      observerYs.add(xHat.getTranslation().getY());
+
+      t += dt;
+    }
+
+    assertEquals(
+            0.0, errorSum / (traj.getTotalTimeSeconds() / dt), 0.03,
+            "Incorrect mean error"
+    );
+    assertEquals(
+            0.0, maxError, 0.05,
+            "Incorrect max error"
+    );
+
+    //System.out.println("Mean error (meters): " + errorSum / (traj.getTotalTimeSeconds() / dt));
+    //System.out.println("Max error (meters):  " + maxError);
+
+    //var chartBuilder = new XYChartBuilder();
+    //chartBuilder.title = "The Magic of Sensor Fusion";
+    //var chart = chartBuilder.build();
+
+    //chart.addSeries("Vision", visionXs, visionYs);
+    //chart.addSeries("Trajectory", trajXs, trajYs);
+    //chart.addSeries("xHat", observerXs, observerYs);
+
+    //new SwingWrapper<>(chart).displayChart();
+    //try {
+    //  Thread.sleep(1000000000);
+    //} catch (InterruptedException e) {
+    //}
+  }
+
+  @Test void test() {
+    var estimator = new DifferentialDrivePoseEstimator(new Rotation2d(), new Pose2d(),
+        new MatBuilder<>(Nat.N5(), Nat.N1()).fill(0.02, 0.02, 0.01, 0.02, 0.02),
+        new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.02, 0.02, 0.01),
+        new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.1, 0.1, 0.01));
+
+    System.out.println("x, y, cos(theta), sin(theta), dist_l, dist_r");
+
+    estimator.m_observer.setXhat(VecBuilder.fill(0, 0, Math.cos(0), Math.sin(0), 0, 0));
+    for(int i = 0; i < 50; i++) {
+      estimator.m_observer.predict(VecBuilder.fill(1, 1, 0), 0.020);
+    }
+
+    var x = estimator.m_observer.getXhat();
+    assertEquals(1, x.get(0, 0), 0.01);
+    assertEquals(0, x.get(1, 0), 0.01);
+    assertEquals(0, estimator.getEstimatedPosition().getRotation().getRadians(), 0.01);
+  }
+
+  //  String matToCSV(Matrix<?, ?> mat) {
+  //    return Arrays.stream(mat.getStorage().getDDRM().getData())
+  //        .mapToObj(String::valueOf).collect(Collectors.joining(","));
+  //  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDriveStateEstimatorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/DifferentialDriveStateEstimatorTest.java
@@ -1,0 +1,255 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.ejml.dense.row.CommonOps_DDRM;
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.controller.ControlAffinePlantInversionFeedforward;
+import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpilibj.trajectory.Trajectory;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveKinematicsConstraint;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveVoltageConstraint;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.MatrixUtils;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.numbers.N1;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings({"PMD.AvoidInstantiatingObjectsInLoops",
+      "PMD.ExcessiveMethodLength", "ParameterName", "LocalVariableName"})
+public class DifferentialDriveStateEstimatorTest {
+  private void scaleCappedU(Matrix<N2, N1> u) {
+    boolean isOutputCapped = Math.abs(u.get(0, 0)) > 12.0 || Math.abs(u.get(1, 0)) > 12.0;
+
+    if (isOutputCapped) {
+      u.times(12.0 / CommonOps_DDRM.elementMaxAbs(u.getStorage().getDDRM()));
+    }
+  }
+
+  @Test
+  public void testAccuracy() {
+    final double dt = 0.00505;
+
+    final LinearSystem<N2, N2, N2> plant = LinearSystemId.identifyDrivetrainSystem(
+        3.02, 0.642, 1.382, 0.08495);
+    var kinematics = new DifferentialDriveKinematics(0.990405073902434);
+
+    var estimator = new DifferentialDriveStateEstimator(
+            plant,
+            MatrixUtils.zeros(Nat.N10()),
+            new MatBuilder<>(Nat.N10(), Nat.N1()).fill(
+                0.002, 0.002, 0.0001, 1.5, 1.5, 0.5, 0.5, 10.0, 10.0, 2.0),
+            new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.0001, 0.005, 0.005),
+            new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.5, 0.5, 0.5),
+            kinematics);
+
+    var feedforward = new ControlAffinePlantInversionFeedforward<>(Nat.N10(), Nat.N2(),
+        estimator::getDynamics, dt);
+
+    var config = new TrajectoryConfig(12 / 2.5, (12 / 0.642) - 17.5);
+    config.addConstraint(new DifferentialDriveKinematicsConstraint(kinematics, 12.0 / 2.5));
+    config.addConstraint(new DifferentialDriveVoltageConstraint(
+        new SimpleMotorFeedforward(0, 3.02, 0.642),
+        kinematics,
+        12));
+
+    var traj = TrajectoryGenerator.generateTrajectory(
+            new Pose2d(),
+            List.of(),
+            new Pose2d(4.8768, 2.7432, new Rotation2d()),
+            config);
+
+    var rand = new Random(604);
+
+    List<Double> time = new ArrayList<>();
+    List<Double> trajXs = new ArrayList<>();
+    List<Double> trajYs = new ArrayList<>();
+    List<Double> trajLeftVel = new ArrayList<>();
+    List<Double> trajRightVel = new ArrayList<>();
+    List<Double> observerXs = new ArrayList<>();
+    List<Double> observerYs = new ArrayList<>();
+    List<Double> observerLeftVelocity = new ArrayList<>();
+    List<Double> observerRightVelocity = new ArrayList<>();
+    List<Double> observerLeftVoltageError = new ArrayList<>();
+    List<Double> observerRightVoltageError = new ArrayList<>();
+    List<Double> observerAngularVelocityError = new ArrayList<>();
+    List<Double> visionXs = new ArrayList<>();
+    List<Double> visionYs = new ArrayList<>();
+
+    double t = 0.0;
+
+    final double visionUpdateRate = 0.1;
+    Pose2d lastVisionPose = null;
+    double lastVisionUpdateTime = Double.NEGATIVE_INFINITY;
+
+    double distanceLeft = 0.0;
+    double distanceRight = 0.0;
+
+    double maxError = Double.NEGATIVE_INFINITY;
+    double errorSum = 0;
+
+    Trajectory.State groundTruthState;
+
+    Matrix<N2, N1> input;
+
+    while (t <= traj.getTotalTimeSeconds()) {
+      groundTruthState = traj.sample(t);
+
+      var chassisSpeeds = new ChassisSpeeds(
+          groundTruthState.velocityMetersPerSecond, 0,
+          groundTruthState.velocityMetersPerSecond * groundTruthState.curvatureRadPerMeter
+      );
+      var wheelSpeeds = kinematics.toWheelSpeeds(chassisSpeeds);
+
+      var x = new MatBuilder<>(Nat.N10(), Nat.N1()).fill(
+              groundTruthState.poseMeters.getTranslation().getX(),
+              groundTruthState.poseMeters.getTranslation().getY(),
+              groundTruthState.poseMeters.getRotation().getRadians(),
+              wheelSpeeds.leftMetersPerSecond,
+              wheelSpeeds.rightMetersPerSecond,
+              0.0, 0.0, 0.0, 0.0, 0.0);
+
+      input = feedforward.calculate(x, feedforward.getR());
+
+      scaleCappedU(input);
+
+      if (lastVisionUpdateTime + visionUpdateRate + rand.nextGaussian() * 0.4 < t) {
+        if (lastVisionPose != null) {
+          estimator.applyPastGlobalMeasurement(
+                  lastVisionPose,
+                  lastVisionUpdateTime);
+        }
+        var groundPose = groundTruthState.poseMeters;
+        lastVisionPose = new Pose2d(
+                new Translation2d(
+                        groundPose.getTranslation().getX() + rand.nextGaussian() * 0.5,
+                        groundPose.getTranslation().getY() + rand.nextGaussian() * 0.5
+                ),
+                new Rotation2d(rand.nextGaussian() * 0.5).plus(groundPose.getRotation())
+        );
+        lastVisionUpdateTime = t;
+
+        visionXs.add(lastVisionPose.getTranslation().getX());
+        visionYs.add(lastVisionPose.getTranslation().getY());
+      }
+
+      distanceLeft += wheelSpeeds.leftMetersPerSecond * dt;
+      distanceRight += wheelSpeeds.rightMetersPerSecond * dt;
+
+      distanceLeft += rand.nextGaussian() * 0.001;
+      distanceRight += rand.nextGaussian() * 0.001;
+
+      var rotNoise = new Rotation2d(rand.nextGaussian() * 0.0001);
+
+      var xHat = estimator.updateWithTime(groundTruthState.poseMeters.getRotation()
+                      .plus(rotNoise).getRadians(),
+                      distanceLeft,
+                      distanceRight,
+                      input,
+                      t);
+
+      double error =
+              groundTruthState.poseMeters.getTranslation().getDistance(
+                      new Translation2d(xHat.get(0, 0),
+                                        xHat.get(1, 0)));
+      if (error > maxError) {
+        maxError = error;
+      }
+      errorSum += error;
+
+      time.add(t);
+
+      trajXs.add(groundTruthState.poseMeters.getTranslation().getX());
+      trajYs.add(groundTruthState.poseMeters.getTranslation().getY());
+      trajLeftVel.add(wheelSpeeds.leftMetersPerSecond);
+      trajRightVel.add(wheelSpeeds.rightMetersPerSecond);
+
+      observerXs.add(xHat.get(0, 0));
+      observerYs.add(xHat.get(1, 0));
+      observerLeftVelocity.add(xHat.get(3, 0));
+      observerRightVelocity.add(xHat.get(4, 0));
+      observerLeftVoltageError.add(xHat.get(7, 0));
+      observerRightVoltageError.add(xHat.get(8, 0));
+      observerAngularVelocityError.add(xHat.get(9, 0));
+
+      t += dt;
+    }
+
+    assertEquals(
+           0.0, errorSum / (traj.getTotalTimeSeconds() / dt), 0.5,
+           "Incorrect mean error"
+    );
+    assertEquals(
+           0.0, maxError, 0.8,
+           "Incorrect max error"
+    );
+
+    /*
+    List<XYChart> charts = new ArrayList<XYChart>();
+
+    var chartBuilder = new XYChartBuilder();
+    chartBuilder.title = "The Magic of Sensor Fusion";
+    var chart = chartBuilder.build();
+
+    chart.addSeries("Vision", visionXs, visionYs);
+    chart.addSeries("Trajectory", trajXs, trajYs);
+    chart.addSeries("xHat", observerXs, observerYs);
+    charts.add(chart);
+
+    var chartBuilderError = new XYChartBuilder();
+    chartBuilderError.title = "Error versus Time";
+    var chartError = chartBuilderError.build();
+
+    chartError.addSeries("LeftVoltage", time, observerLeftVoltageError);
+    chartError.addSeries("RightVoltage", time, observerRightVoltageError);
+    chartError.addSeries("AngularVelocity", time, observerAngularVelocityError);
+    charts.add(chartError);
+
+    var chartBuilderLeftVelocity = new XYChartBuilder();
+    chartBuilderLeftVelocity.title = "Left Velocity versus Time";
+    var chartLeftVelocity = chartBuilderLeftVelocity.build();
+
+    chartLeftVelocity.addSeries("xHat", time, observerLeftVelocity);
+    chartLeftVelocity.addSeries("Trajectory", time, trajLeftVel);
+    charts.add(chartLeftVelocity);
+
+    var chartBuilderRightVelocity = new XYChartBuilder();
+    chartBuilderRightVelocity.title = "Right Velocity versus Time";
+    var chartRightVelocity = chartBuilderRightVelocity.build();
+
+    chartRightVelocity.addSeries("xHat", time, observerRightVelocity);
+    chartRightVelocity.addSeries("Trajectory", time, trajRightVel);
+
+    charts.add(chartRightVelocity);
+
+    new SwingWrapper<>(charts).displayChartMatrix();
+    try {
+      Thread.sleep(1000000000);
+    } catch (InterruptedException e) {
+    }
+    */
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/MecanumDrivePoseEstimatorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/MecanumDrivePoseEstimatorTest.java
@@ -1,0 +1,208 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.MecanumDriveKinematics;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MecanumDrivePoseEstimatorTest {
+  @Test
+  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops",
+        "PMD.ExcessiveMethodLength"})
+  public void testAccuracy() {
+    var kinematics = new MecanumDriveKinematics(
+            new Translation2d(1, 1), new Translation2d(1, -1),
+            new Translation2d(-1, -1), new Translation2d(-1, 1));
+
+    var estimator = new MecanumDrivePoseEstimator(
+            new Rotation2d(), new Pose2d(), kinematics,
+            VecBuilder.fill(0.01, 0.01, 0.01),
+            VecBuilder.fill(0.05),
+            VecBuilder.fill(0.1, 0.1, 0.1)
+    );
+
+    var trajectory = TrajectoryGenerator.generateTrajectory(
+            List.of(new Pose2d(),
+                    new Pose2d(20, 20, Rotation2d.fromDegrees(0)),
+                    new Pose2d(10, 10, Rotation2d.fromDegrees(180)),
+                    new Pose2d(30, 30, Rotation2d.fromDegrees(0)),
+                    new Pose2d(20, 20, Rotation2d.fromDegrees(180)),
+                    new Pose2d(10, 10, Rotation2d.fromDegrees(0))),
+            new TrajectoryConfig(0.5, 2)
+    );
+
+    var rand = new Random(5190);
+
+    List<Double> trajXs = new ArrayList<>();
+    List<Double> trajYs = new ArrayList<>();
+    List<Double> trajCosine = new ArrayList<>();
+    List<Double> trajSine = new ArrayList<>();
+    List<Double> trajTheta = new ArrayList<>();
+
+    List<Double> observerXs = new ArrayList<>();
+    List<Double> observerYs = new ArrayList<>();
+    List<Double> observerCosine = new ArrayList<>();
+    List<Double> observerSine = new ArrayList<>();
+    List<Double> observerTheta = new ArrayList<>();
+
+    List<Double> visionXs = new ArrayList<>();
+    List<Double> visionYs = new ArrayList<>();
+    List<Double> visionCosine = new ArrayList<>();
+    List<Double> visionSine = new ArrayList<>();
+    List<Double> visionTheta = new ArrayList<>();
+
+    List<Double> time = new ArrayList<>();
+    List<Double> visionTime = new ArrayList<>();
+
+    final double dt = 0.02;
+    double t = 0.0;
+
+    final double visionUpdateRate = 0.1;
+    Pose2d lastVisionPose = null;
+    double lastVisionUpdateTime = Double.NEGATIVE_INFINITY;
+
+    double maxError = Double.NEGATIVE_INFINITY;
+    double errorSum = 0;
+    while (t <= trajectory.getTotalTimeSeconds()) {
+      var groundTruthState = trajectory.sample(t);
+
+      if (lastVisionUpdateTime + visionUpdateRate < t) {
+        if (lastVisionPose != null) {
+          estimator.addVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
+        }
+
+        lastVisionPose = new Pose2d(
+                new Translation2d(
+                        groundTruthState.poseMeters.getTranslation().getX()
+                                + rand.nextGaussian() * 0.1,
+                        groundTruthState.poseMeters.getTranslation().getY()
+                                + rand.nextGaussian() * 0.1
+                ),
+                new Rotation2d(
+                        rand.nextGaussian() * 0.1).plus(groundTruthState.poseMeters.getRotation())
+        );
+
+        lastVisionUpdateTime = t;
+
+        visionXs.add(lastVisionPose.getTranslation().getX());
+        visionYs.add(lastVisionPose.getTranslation().getY());
+        visionTheta.add(lastVisionPose.getRotation().getDegrees());
+        visionCosine.add(lastVisionPose.getRotation().getCos());
+        visionSine.add(lastVisionPose.getRotation().getSin());
+        visionTime.add(t);
+      }
+
+      var wheelSpeeds = kinematics.toWheelSpeeds(new ChassisSpeeds(
+              groundTruthState.velocityMetersPerSecond, 0,
+              groundTruthState.velocityMetersPerSecond * groundTruthState.curvatureRadPerMeter));
+
+      wheelSpeeds.frontLeftMetersPerSecond += rand.nextGaussian() * 0.1;
+      wheelSpeeds.frontRightMetersPerSecond += rand.nextGaussian() * 0.1;
+      wheelSpeeds.rearLeftMetersPerSecond += rand.nextGaussian() * 0.1;
+      wheelSpeeds.rearRightMetersPerSecond += rand.nextGaussian() * 0.1;
+
+      var xHat = estimator.updateWithTime(t,
+              groundTruthState.poseMeters.getRotation()
+                      .plus(new Rotation2d(rand.nextGaussian() * 0.05)), wheelSpeeds);
+
+      double error =
+              groundTruthState.poseMeters.getTranslation().getDistance(xHat.getTranslation());
+      if (error > maxError) {
+        maxError = error;
+      }
+      errorSum += error;
+
+      trajXs.add(groundTruthState.poseMeters.getTranslation().getX());
+      trajYs.add(groundTruthState.poseMeters.getTranslation().getY());
+      trajTheta.add(groundTruthState.poseMeters.getRotation().getDegrees());
+      trajCosine.add(groundTruthState.poseMeters.getRotation().getCos());
+      trajSine.add(groundTruthState.poseMeters.getRotation().getSin());
+      observerXs.add(xHat.getTranslation().getX());
+      observerYs.add(xHat.getTranslation().getY());
+      observerTheta.add(xHat.getRotation().getDegrees());
+      observerCosine.add(xHat.getRotation().getCos());
+      observerSine.add(xHat.getRotation().getSin());
+      time.add(t);
+
+      t += dt;
+    }
+
+    assertEquals(
+           0.0, errorSum / (trajectory.getTotalTimeSeconds() / dt), 0.25,
+           "Incorrect mean error"
+    );
+    assertEquals(
+           0.0, maxError, 0.42,
+           "Incorrect max error"
+    );
+
+    /*
+    List<XYChart> charts = new ArrayList<XYChart>();
+
+    var chartBuilder = new XYChartBuilder();
+    chartBuilder.title = "The Magic of Sensor Fusion";
+    var chart = chartBuilder.build();
+
+    chart.addSeries("Vision", visionXs, visionYs);
+    chart.addSeries("Trajectory", trajXs, trajYs);
+    chart.addSeries("xHat", observerXs, observerYs);
+    charts.add(chart);
+
+    var chartBuilder1 = new XYChartBuilder();
+    chartBuilder1.title = "Cosine";
+    var chart1 = chartBuilder1.build();
+
+    chart1.addSeries("Vision", visionTime, visionCosine);
+    chart1.addSeries("Trajectory", time, trajCosine);
+    chart1.addSeries("xHat", time, observerCosine);
+    charts.add(chart1);
+
+    var chartBuilder2 = new XYChartBuilder();
+    chartBuilder2.title = "Sine";
+    var chart2 = chartBuilder2.build();
+
+    chart2.addSeries("Vision", visionTime, visionSine);
+    chart2.addSeries("Trajectory", time, trajSine);
+    chart2.addSeries("xHat", time, observerSine);
+
+    charts.add(chart2);
+
+    var chartBuilder3 = new XYChartBuilder();
+    chartBuilder3.title = "Degrees";
+    var chart3 = chartBuilder3.build();
+
+    chart3.addSeries("Vision", visionTime, visionTheta);
+    chart3.addSeries("Trajectory", time, trajTheta);
+    chart3.addSeries("xHat", time, observerTheta);
+    charts.add(chart3);
+
+
+
+    new SwingWrapper<>(charts).displayChartMatrix();
+    try {
+      Thread.sleep(1000000000);
+    } catch (InterruptedException e) {
+    }
+    */
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimatorTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimatorTest.java
@@ -1,0 +1,214 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.estimator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryGenerator;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SwerveDrivePoseEstimatorTest {
+  @Test
+  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops",
+        "PMD.ExcessiveMethodLength"})
+  public void testAccuracy() {
+    var kinematics = new SwerveDriveKinematics(
+            new Translation2d(1, 1),
+            new Translation2d(1, -1),
+            new Translation2d(-1, -1),
+            new Translation2d(-1, 1)
+    );
+    var estimator = new SwerveDrivePoseEstimator(
+            new Rotation2d(), new Pose2d(), kinematics,
+            VecBuilder.fill(0.1, 0.1, 0.1),
+            VecBuilder.fill(0.05),
+            VecBuilder.fill(0.1, 0.1, 0.1)
+    );
+
+    var trajectory = TrajectoryGenerator.generateTrajectory(
+            List.of(new Pose2d(),
+                    new Pose2d(20, 20, Rotation2d.fromDegrees(0)),
+                    new Pose2d(10, 10, Rotation2d.fromDegrees(180)),
+                    new Pose2d(30, 30, Rotation2d.fromDegrees(0)),
+                    new Pose2d(20, 20, Rotation2d.fromDegrees(180)),
+                    new Pose2d(10, 10, Rotation2d.fromDegrees(0))),
+            new TrajectoryConfig(0.5, 2)
+    );
+
+    var rand = new Random(4915);
+
+    List<Double> trajXs = new ArrayList<>();
+    List<Double> trajYs = new ArrayList<>();
+    List<Double> trajCosine = new ArrayList<>();
+    List<Double> trajSine = new ArrayList<>();
+    List<Double> trajTheta = new ArrayList<>();
+
+    List<Double> observerXs = new ArrayList<>();
+    List<Double> observerYs = new ArrayList<>();
+    List<Double> observerCosine = new ArrayList<>();
+    List<Double> observerSine = new ArrayList<>();
+    List<Double> observerTheta = new ArrayList<>();
+
+    List<Double> visionXs = new ArrayList<>();
+    List<Double> visionYs = new ArrayList<>();
+    List<Double> visionCosine = new ArrayList<>();
+    List<Double> visionSine = new ArrayList<>();
+    List<Double> visionTheta = new ArrayList<>();
+
+    List<Double> time = new ArrayList<>();
+    List<Double> visionTime = new ArrayList<>();
+
+
+    final double dt = 0.02;
+    double t = 0.0;
+
+    final double visionUpdateRate = 0.1;
+    Pose2d lastVisionPose = null;
+    double lastVisionUpdateTime = Double.NEGATIVE_INFINITY;
+
+    double maxError = Double.NEGATIVE_INFINITY;
+    double errorSum = 0;
+    while (t <= trajectory.getTotalTimeSeconds()) {
+      var groundTruthState = trajectory.sample(t);
+
+      if (lastVisionUpdateTime + visionUpdateRate < t) {
+        if (lastVisionPose != null) {
+          estimator.addVisionMeasurement(lastVisionPose, lastVisionUpdateTime);
+        }
+
+        lastVisionPose = new Pose2d(
+                new Translation2d(
+                        groundTruthState.poseMeters.getTranslation().getX()
+                                + rand.nextGaussian() * 0.1,
+                        groundTruthState.poseMeters.getTranslation().getY()
+                                + rand.nextGaussian() * 0.1
+                ),
+                new Rotation2d(
+                        rand.nextGaussian() * 0.1).plus(groundTruthState.poseMeters.getRotation())
+        );
+
+        lastVisionUpdateTime = t;
+
+        visionXs.add(lastVisionPose.getTranslation().getX());
+        visionYs.add(lastVisionPose.getTranslation().getY());
+        visionTheta.add(lastVisionPose.getRotation().getDegrees());
+        visionCosine.add(lastVisionPose.getRotation().getCos());
+        visionSine.add(lastVisionPose.getRotation().getSin());
+        visionTime.add(t);
+      }
+
+      var moduleStates = kinematics.toSwerveModuleStates(new ChassisSpeeds(
+              groundTruthState.velocityMetersPerSecond,
+              0.0,
+              groundTruthState.velocityMetersPerSecond * groundTruthState.curvatureRadPerMeter)
+      );
+      for (var moduleState : moduleStates) {
+        moduleState.angle = moduleState.angle.plus(new Rotation2d(rand.nextGaussian() * 0.5));
+        moduleState.speedMetersPerSecond += rand.nextGaussian() * 1;
+      }
+
+      var xHat = estimator.updateWithTime(
+              t,
+              groundTruthState.poseMeters.getRotation()
+                      .plus(new Rotation2d(rand.nextGaussian() * 0.05)),
+              moduleStates);
+
+      double error =
+              groundTruthState.poseMeters.getTranslation().getDistance(xHat.getTranslation());
+      if (error > maxError) {
+        maxError = error;
+      }
+      errorSum += error;
+
+      trajXs.add(groundTruthState.poseMeters.getTranslation().getX());
+      trajYs.add(groundTruthState.poseMeters.getTranslation().getY());
+      trajTheta.add(groundTruthState.poseMeters.getRotation().getDegrees());
+      trajCosine.add(groundTruthState.poseMeters.getRotation().getCos());
+      trajSine.add(groundTruthState.poseMeters.getRotation().getSin());
+      observerXs.add(xHat.getTranslation().getX());
+      observerYs.add(xHat.getTranslation().getY());
+      observerTheta.add(xHat.getRotation().getDegrees());
+      observerCosine.add(xHat.getRotation().getCos());
+      observerSine.add(xHat.getRotation().getSin());
+      time.add(t);
+
+      t += dt;
+    }
+
+    assertEquals(
+            0.0, errorSum / (trajectory.getTotalTimeSeconds() / dt), 0.25,
+            "Incorrect mean error"
+    );
+    assertEquals(
+            0.0, maxError, 0.42,
+            "Incorrect max error"
+    );
+
+    /*
+    List<XYChart> charts = new ArrayList<XYChart>();
+
+    var chartBuilder = new XYChartBuilder();
+    chartBuilder.title = "The Magic of Sensor Fusion";
+    var chart = chartBuilder.build();
+
+    chart.addSeries("Vision", visionXs, visionYs);
+    chart.addSeries("Trajectory", trajXs, trajYs);
+    chart.addSeries("xHat", observerXs, observerYs);
+    charts.add(chart);
+
+    var chartBuilder1 = new XYChartBuilder();
+    chartBuilder1.title = "Cosine";
+    var chart1 = chartBuilder1.build();
+
+    chart1.addSeries("Vision", visionTime, visionCosine);
+    chart1.addSeries("Trajectory", time, trajCosine);
+    chart1.addSeries("xHat", time, observerCosine);
+    charts.add(chart1);
+
+    var chartBuilder2 = new XYChartBuilder();
+    chartBuilder2.title = "Sine";
+    var chart2 = chartBuilder2.build();
+
+    chart2.addSeries("Vision", visionTime, visionSine);
+    chart2.addSeries("Trajectory", time, trajSine);
+    chart2.addSeries("xHat", time, observerSine);
+
+    charts.add(chart2);
+
+    var chartBuilder3 = new XYChartBuilder();
+    chartBuilder3.title = "Degrees";
+    var chart3 = chartBuilder3.build();
+
+    chart3.addSeries("Vision", visionTime, visionTheta);
+    chart3.addSeries("Trajectory", time, trajTheta);
+    chart3.addSeries("xHat", time, observerTheta);
+    charts.add(chart3);
+
+
+
+    new SwingWrapper<>(charts).displayChartMatrix();
+    try {
+      Thread.sleep(1000000000);
+    } catch (InterruptedException e) {
+    }
+    */
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdriveposeestimator/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdriveposeestimator/Drivetrain.java
@@ -1,0 +1,133 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.differentialdriveposeestimator;
+
+import edu.wpi.first.wpilibj.AnalogGyro;
+import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.PWMVictorSPX;
+import edu.wpi.first.wpilibj.SpeedController;
+import edu.wpi.first.wpilibj.SpeedControllerGroup;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.controller.PIDController;
+import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.estimator.DifferentialDrivePoseEstimator;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.util.Units;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+import edu.wpi.first.wpilibj.examples.swervesdriveposeestimator.ExampleGlobalMeasurementSensor;
+
+/**
+ * Represents a differential drive style drivetrain.
+ */
+public class Drivetrain {
+  public static final double kMaxSpeed = 3.0; // meters per second
+  public static final double kMaxAngularSpeed = 2 * Math.PI; // one rotation per second
+
+  private static final double kTrackWidth = 0.381 * 2; // meters
+  private static final double kWheelRadius = 0.0508; // meters
+  private static final int kEncoderResolution = 4096;
+
+  private final SpeedController m_leftLeader = new PWMVictorSPX(1);
+  private final SpeedController m_leftFollower = new PWMVictorSPX(2);
+  private final SpeedController m_rightLeader = new PWMVictorSPX(3);
+  private final SpeedController m_rightFollower = new PWMVictorSPX(4);
+
+  private final Encoder m_leftEncoder = new Encoder(0, 1);
+  private final Encoder m_rightEncoder = new Encoder(2, 3);
+
+  private final SpeedControllerGroup m_leftGroup
+      = new SpeedControllerGroup(m_leftLeader, m_leftFollower);
+  private final SpeedControllerGroup m_rightGroup
+      = new SpeedControllerGroup(m_rightLeader, m_rightFollower);
+
+  private final AnalogGyro m_gyro = new AnalogGyro(0);
+
+  private final PIDController m_leftPIDController = new PIDController(1, 0, 0);
+  private final PIDController m_rightPIDController = new PIDController(1, 0, 0);
+
+  private final DifferentialDriveKinematics m_kinematics
+      = new DifferentialDriveKinematics(kTrackWidth);
+
+  /* Here we use DifferentialDrivePoseEstimator so that we can fuse odometry readings. The
+  numbers used  below are robot specific, and should be tuned. */
+  private final DifferentialDrivePoseEstimator m_poseEstimator = new DifferentialDrivePoseEstimator(
+      m_gyro.getRotation2d(),
+      new Pose2d(),
+      VecBuilder.fill(0.05, 0.05, Units.degreesToRadians(5), 0.01, 0.01),
+      VecBuilder.fill(0.02, 0.02, Units.degreesToRadians(1)),
+      VecBuilder.fill(0.5, 0.5, Units.degreesToRadians(30)));
+
+  // Gains are for example purposes only - must be determined for your own robot!
+  private final SimpleMotorFeedforward m_feedforward = new SimpleMotorFeedforward(1, 3);
+
+  /**
+   * Constructs a differential drive object.
+   * Sets the encoder distance per pulse and resets the gyro.
+   */
+  public Drivetrain() {
+    m_gyro.reset();
+
+    // Set the distance per pulse for the drive encoders. We can simply use the
+    // distance traveled for one rotation of the wheel divided by the encoder
+    // resolution.
+    m_leftEncoder.setDistancePerPulse(2 * Math.PI * kWheelRadius / kEncoderResolution);
+    m_rightEncoder.setDistancePerPulse(2 * Math.PI * kWheelRadius / kEncoderResolution);
+
+    m_leftEncoder.reset();
+    m_rightEncoder.reset();
+  }
+
+  /**
+   * Sets the desired wheel speeds.
+   *
+   * @param speeds The desired wheel speeds.
+   */
+  public void setSpeeds(DifferentialDriveWheelSpeeds speeds) {
+    final double leftFeedforward = m_feedforward.calculate(speeds.leftMetersPerSecond);
+    final double rightFeedforward = m_feedforward.calculate(speeds.rightMetersPerSecond);
+
+    final double leftOutput = m_leftPIDController.calculate(m_leftEncoder.getRate(),
+        speeds.leftMetersPerSecond);
+    final double rightOutput = m_rightPIDController.calculate(m_rightEncoder.getRate(),
+        speeds.rightMetersPerSecond);
+    m_leftGroup.setVoltage(leftOutput + leftFeedforward);
+    m_rightGroup.setVoltage(rightOutput + rightFeedforward);
+  }
+
+  /**
+   * Drives the robot with the given linear velocity and angular velocity.
+   *
+   * @param xSpeed Linear velocity in m/s.
+   * @param rot    Angular velocity in rad/s.
+   */
+  @SuppressWarnings("ParameterName")
+  public void drive(double xSpeed, double rot) {
+    var wheelSpeeds = m_kinematics.toWheelSpeeds(new ChassisSpeeds(xSpeed, 0.0, rot));
+    setSpeeds(wheelSpeeds);
+  }
+
+  /**
+   * Updates the field-relative position.
+   */
+  public void updateOdometry() {
+    m_poseEstimator.update(m_gyro.getRotation2d(),
+        new DifferentialDriveWheelSpeeds(m_leftEncoder.getRate(), m_rightEncoder.getRate()),
+        m_leftEncoder.getDistance(), m_rightEncoder.getDistance());
+
+    // Also apply vision measurements. We use 0.3 seconds in the past as an example -- on
+    // a real robot, this must be calculated based either on latency or timestamps.
+    m_poseEstimator.addVisionMeasurement(
+        ExampleGlobalMeasurementSensor.getEstimatedGlobalPose(
+            m_poseEstimator.getEstimatedPosition()),
+        Timer.getFPGATimestamp() - 0.3);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdriveposeestimator/Main.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdriveposeestimator/Main.java
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.differentialdriveposeestimator;
+
+import edu.wpi.first.wpilibj.RobotBase;
+
+/**
+ * Do NOT add any static variables to this class, or any initialization at all.
+ * Unless you know what you are doing, do not modify this file except to
+ * change the parameter class to the startRobot call.
+ */
+public final class Main {
+  private Main() {
+  }
+
+  /**
+   * Main initialization function. Do not perform any initialization here.
+   *
+   * <p>If you change your main robot class, change the parameter type.
+   */
+  public static void main(String... args) {
+    RobotBase.startRobot(Robot::new);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdriveposeestimator/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdriveposeestimator/Robot.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.differentialdriveposeestimator;
+
+import edu.wpi.first.wpilibj.GenericHID;
+import edu.wpi.first.wpilibj.SlewRateLimiter;
+import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj.XboxController;
+
+public class Robot extends TimedRobot {
+  private final XboxController m_controller = new XboxController(0);
+  private final Drivetrain m_drive = new Drivetrain();
+
+  // Slew rate limiters to make joystick inputs more gentle; 1/3 sec from 0 to 1.
+  private final SlewRateLimiter m_speedLimiter = new SlewRateLimiter(3);
+  private final SlewRateLimiter m_rotLimiter = new SlewRateLimiter(3);
+
+
+  @Override
+  public void autonomousPeriodic() {
+    teleopPeriodic();
+    m_drive.updateOdometry();
+  }
+
+  @Override
+  public void teleopPeriodic() {
+    // Get the x speed. We are inverting this because Xbox controllers return
+    // negative values when we push forward.
+    final var xSpeed =
+        -m_speedLimiter.calculate(m_controller.getY(GenericHID.Hand.kLeft))
+            * Drivetrain.kMaxSpeed;
+
+    // Get the rate of angular rotation. We are inverting this because we want a
+    // positive value when we pull to the left (remember, CCW is positive in
+    // mathematics). Xbox controllers return positive values when you pull to
+    // the right by default.
+    final var rot =
+        -m_rotLimiter.calculate(m_controller.getX(GenericHID.Hand.kRight))
+            * Drivetrain.kMaxAngularSpeed;
+
+    m_drive.drive(xSpeed, rot);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivestateestimator/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivestateestimator/Drivetrain.java
@@ -1,0 +1,154 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.differentialdrivestateestimator;
+
+import edu.wpi.first.wpilibj.AnalogGyro;
+import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.PWMVictorSPX;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.SpeedController;
+import edu.wpi.first.wpilibj.SpeedControllerGroup;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.controller.LinearPlantInversionFeedforward;
+import edu.wpi.first.wpilibj.controller.PIDController;
+import edu.wpi.first.wpilibj.estimator.DifferentialDriveStateEstimator;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.system.LinearSystem;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
+import edu.wpi.first.wpiutil.math.MatBuilder;
+import edu.wpi.first.wpiutil.math.Matrix;
+import edu.wpi.first.wpiutil.math.Nat;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+import edu.wpi.first.wpiutil.math.numbers.N2;
+
+import edu.wpi.first.wpilibj.examples.swervesdriveposeestimator.ExampleGlobalMeasurementSensor;
+
+/**
+ * Represents a differential drive style drivetrain.
+ */
+public class Drivetrain {
+  public static final double kMaxSpeed = 3.0; // meters per second
+  public static final double kMaxAngularSpeed = 2 * Math.PI; // one rotation per second
+
+  private static final double kTrackWidth = 0.381 * 2; // meters
+  private static final double kWheelRadius = 0.0508; // meters
+  private static final int kEncoderResolution = 4096;
+
+  private final SpeedController m_leftLeader = new PWMVictorSPX(1);
+  private final SpeedController m_leftFollower = new PWMVictorSPX(2);
+  private final SpeedController m_rightLeader = new PWMVictorSPX(3);
+  private final SpeedController m_rightFollower = new PWMVictorSPX(4);
+
+  private final Encoder m_leftEncoder = new Encoder(0, 1);
+  private final Encoder m_rightEncoder = new Encoder(2, 3);
+
+  private final SpeedControllerGroup m_leftGroup
+      = new SpeedControllerGroup(m_leftLeader, m_leftFollower);
+  private final SpeedControllerGroup m_rightGroup
+      = new SpeedControllerGroup(m_rightLeader, m_rightFollower);
+
+  private final AnalogGyro m_gyro = new AnalogGyro(0);
+
+  private final PIDController m_leftPIDController = new PIDController(1, 0, 0);
+  private final PIDController m_rightPIDController = new PIDController(1, 0, 0);
+
+  private final DifferentialDriveKinematics m_kinematics
+      = new DifferentialDriveKinematics(kTrackWidth);
+
+  // Gains are for example purposes only - must be determined for your own robot!
+  // You can determine this using frc-characterization.
+  private final LinearSystem<N2, N2, N2> m_drivetrainSystem =
+      LinearSystemId.identifyDrivetrainSystem(
+      3, 4, 1, 2);
+
+  /* Here we use DifferentialDriveStateEstimator so that we can fuse odometry readings. The
+  numbers used below are robot specific, and should be tuned. */
+  private final DifferentialDriveStateEstimator m_poseEstimator =
+      new DifferentialDriveStateEstimator(
+      m_drivetrainSystem,
+      new Matrix<>(Nat.N10(), Nat.N1()),
+      new MatBuilder<>(Nat.N10(), Nat.N1()).fill(
+          0.002, 0.002, 0.0001, 1.5, 1.5, 0.5, 0.5, 10.0, 10.0, 2.0),
+      new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.0001, 0.005, 0.005),
+      new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.5, 0.5, 0.5),
+      m_kinematics);
+
+  // we use LinearPlantInversionFeedforward here to estimate feedforward voltages.
+  private final LinearPlantInversionFeedforward<N2, N2, N2> m_feedforward =
+      new LinearPlantInversionFeedforward<>(m_drivetrainSystem, 0.020);
+
+  /**
+   * Constructs a differential drive object.
+   * Sets the encoder distance per pulse and resets the gyro.
+   */
+  public Drivetrain() {
+    m_gyro.reset();
+
+    // Set the distance per pulse for the drive encoders. We can simply use the
+    // distance traveled for one rotation of the wheel divided by the encoder
+    // resolution.
+    m_leftEncoder.setDistancePerPulse(2 * Math.PI * kWheelRadius / kEncoderResolution);
+    m_rightEncoder.setDistancePerPulse(2 * Math.PI * kWheelRadius / kEncoderResolution);
+
+    m_leftEncoder.reset();
+    m_rightEncoder.reset();
+  }
+
+  /**
+   * Sets the desired wheel speeds.
+   *
+   * @param speeds The desired wheel speeds.
+   */
+  public void setSpeeds(DifferentialDriveWheelSpeeds speeds) {
+    final var feedforward = m_feedforward.calculate(
+        VecBuilder.fill(speeds.leftMetersPerSecond, speeds.rightMetersPerSecond));
+
+    final double leftFeedforward = feedforward.get(0, 0);
+    final double rightFeedforward = feedforward.get(1, 0);
+
+    final double leftOutput = m_leftPIDController.calculate(m_leftEncoder.getRate(),
+        speeds.leftMetersPerSecond);
+    final double rightOutput = m_rightPIDController.calculate(m_rightEncoder.getRate(),
+        speeds.rightMetersPerSecond);
+    m_leftGroup.setVoltage(leftOutput + leftFeedforward);
+    m_rightGroup.setVoltage(rightOutput + rightFeedforward);
+  }
+
+  /**
+   * Drives the robot with the given linear velocity and angular velocity.
+   *
+   * @param xSpeed Linear velocity in m/s.
+   * @param rot    Angular velocity in rad/s.
+   */
+  @SuppressWarnings("ParameterName")
+  public void drive(double xSpeed, double rot) {
+    var wheelSpeeds = m_kinematics.toWheelSpeeds(new ChassisSpeeds(xSpeed, 0.0, rot));
+    setSpeeds(wheelSpeeds);
+  }
+
+  /**
+   * Updates the field-relative position.
+   */
+  public void updateOdometry() {
+    m_poseEstimator.update(m_gyro.getRotation2d().getRadians(),
+        m_leftEncoder.getDistance(), m_rightEncoder.getDistance(),
+        VecBuilder.fill(
+            m_leftLeader.get() * RobotController.getBatteryVoltage(),
+            m_rightLeader.get() * RobotController.getBatteryVoltage()
+        ));
+
+    // Also apply vision measurements. We use 0.3 seconds in the past as an example -- on
+    // a real robot, this must be calculated based either on latency or timestamps.
+    m_poseEstimator.applyPastGlobalMeasurement(
+        ExampleGlobalMeasurementSensor.getEstimatedGlobalPose(
+            m_poseEstimator.getEstimatedPosition()),
+        Timer.getFPGATimestamp() - 0.3);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivestateestimator/Main.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivestateestimator/Main.java
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.differentialdrivestateestimator;
+
+import edu.wpi.first.wpilibj.RobotBase;
+
+/**
+ * Do NOT add any static variables to this class, or any initialization at all.
+ * Unless you know what you are doing, do not modify this file except to
+ * change the parameter class to the startRobot call.
+ */
+public final class Main {
+  private Main() {
+  }
+
+  /**
+   * Main initialization function. Do not perform any initialization here.
+   *
+   * <p>If you change your main robot class, change the parameter type.
+   */
+  public static void main(String... args) {
+    RobotBase.startRobot(Robot::new);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivestateestimator/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivestateestimator/Robot.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.differentialdrivestateestimator;
+
+import edu.wpi.first.wpilibj.GenericHID;
+import edu.wpi.first.wpilibj.SlewRateLimiter;
+import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj.XboxController;
+
+public class Robot extends TimedRobot {
+  private final XboxController m_controller = new XboxController(0);
+  private final Drivetrain m_drive = new Drivetrain();
+
+  // Slew rate limiters to make joystick inputs more gentle; 1/3 sec from 0 to 1.
+  private final SlewRateLimiter m_speedLimiter = new SlewRateLimiter(3);
+  private final SlewRateLimiter m_rotLimiter = new SlewRateLimiter(3);
+
+
+  @Override
+  public void autonomousPeriodic() {
+    teleopPeriodic();
+    m_drive.updateOdometry();
+  }
+
+  @Override
+  public void teleopPeriodic() {
+    // Get the x speed. We are inverting this because Xbox controllers return
+    // negative values when we push forward.
+    final var xSpeed =
+        -m_speedLimiter.calculate(m_controller.getY(GenericHID.Hand.kLeft))
+            * Drivetrain.kMaxSpeed;
+
+    // Get the rate of angular rotation. We are inverting this because we want a
+    // positive value when we pull to the left (remember, CCW is positive in
+    // mathematics). Xbox controllers return positive values when you pull to
+    // the right by default.
+    final var rot =
+        -m_rotLimiter.calculate(m_controller.getX(GenericHID.Hand.kRight))
+            * Drivetrain.kMaxAngularSpeed;
+
+    m_drive.drive(xSpeed, rot);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/examples.json
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/examples.json
@@ -680,5 +680,75 @@
     "gradlebase": "java",
     "mainclass": "Main",
     "commandversion": 2
+  },
+  {  
+    "name": "DifferentialDrivePoseEstimator",
+    "description": "Demonstrates the use of the DifferentialDrivePoseEstimator as a replacement for differential drive odometry.",
+    "tags": [
+      "Drivetrain",
+      "State space",
+      "Vision",
+      "Filter",
+      "Odometry",
+      "Pose",
+      "Differential drive"
+    ],
+    "foldername": "differentialdriveposeestimator",
+    "gradlebase": "java",
+    "mainclass": "Main",
+    "commandversion": 2
+  },
+  {
+    "name": "DifferentialDriveStateEstimator",
+    "description": "Demonstrates the use of the DifferentialDriveStateEstimator as a replacement for differential drive odometry.",
+    "tags": [
+      "Drivetrain",
+      "State space",
+      "Vision",
+      "Filter",
+      "Odometry",
+      "Pose",
+      "Differential drive"
+    ],
+    "foldername": "differentialdrivestateestimator",
+    "gradlebase": "java",
+    "mainclass": "Main",
+    "commandversion": 2
+  }
+  ,
+  {
+    "name": "MecanumDrivePoseEstimator",
+    "description": "Demonstrates the use of the MecanumDrivePoseEstimator as a replacement for mecanum drive odometry.",
+    "tags": [
+      "Drivetrain",
+      "State space",
+      "Vision",
+      "Filter",
+      "Odometry",
+      "Pose",
+      "Mecanum"
+    ],
+    "foldername": "mecanumdriveposeestimator",
+    "gradlebase": "java",
+    "mainclass": "Main",
+    "commandversion": 2
+  }
+  ,
+  {
+    "name": "SwerveDrivePoseEstimator",
+    "description": "Demonstrates the use of the SwerveDrivePoseEstimator as a replacement for swerve drive odometry.",
+    "tags": [
+      "Drivetrain",
+      "State space",
+      "Vision",
+      "Filter",
+      "Odometry",
+      "Pose",
+      "Swerve"
+    ],
+    "foldername": "swervesdriveposeestimator",
+    "gradlebase": "java",
+    "mainclass": "Main",
+    "commandversion": 2
   }
 ]

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/Drivetrain.java
@@ -1,0 +1,158 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.mecanumdriveposeestimator;
+
+import edu.wpi.first.wpilibj.AnalogGyro;
+import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.PWMVictorSPX;
+import edu.wpi.first.wpilibj.SpeedController;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.controller.PIDController;
+import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.estimator.MecanumDrivePoseEstimator;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.MecanumDriveKinematics;
+import edu.wpi.first.wpilibj.kinematics.MecanumDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.util.Units;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+import edu.wpi.first.wpilibj.examples.swervesdriveposeestimator.ExampleGlobalMeasurementSensor;
+
+/**
+ * Represents a mecanum drive style drivetrain.
+ */
+@SuppressWarnings("PMD.TooManyFields")
+public class Drivetrain {
+  public static final double kMaxSpeed = 3.0; // 3 meters per second
+  public static final double kMaxAngularSpeed = Math.PI; // 1/2 rotation per second
+
+  private final SpeedController m_frontLeftMotor = new PWMVictorSPX(1);
+  private final SpeedController m_frontRightMotor = new PWMVictorSPX(2);
+  private final SpeedController m_backLeftMotor = new PWMVictorSPX(3);
+  private final SpeedController m_backRightMotor = new PWMVictorSPX(4);
+
+  private final Encoder m_frontLeftEncoder = new Encoder(0, 1);
+  private final Encoder m_frontRightEncoder = new Encoder(2, 3);
+  private final Encoder m_backLeftEncoder = new Encoder(4, 5);
+  private final Encoder m_backRightEncoder = new Encoder(6, 7);
+
+  private final Translation2d m_frontLeftLocation = new Translation2d(0.381, 0.381);
+  private final Translation2d m_frontRightLocation = new Translation2d(0.381, -0.381);
+  private final Translation2d m_backLeftLocation = new Translation2d(-0.381, 0.381);
+  private final Translation2d m_backRightLocation = new Translation2d(-0.381, -0.381);
+
+  private final PIDController m_frontLeftPIDController = new PIDController(1, 0, 0);
+  private final PIDController m_frontRightPIDController = new PIDController(1, 0, 0);
+  private final PIDController m_backLeftPIDController = new PIDController(1, 0, 0);
+  private final PIDController m_backRightPIDController = new PIDController(1, 0, 0);
+
+  private final AnalogGyro m_gyro = new AnalogGyro(0);
+
+  private final MecanumDriveKinematics m_kinematics = new MecanumDriveKinematics(
+      m_frontLeftLocation, m_frontRightLocation, m_backLeftLocation, m_backRightLocation
+  );
+
+  /* Here we use MecanumDrivePoseEstimator so that we can fuse odometry readings. The numbers used
+   below are robot specific, and should be tuned. */
+  private final MecanumDrivePoseEstimator m_poseEstimator = new MecanumDrivePoseEstimator(
+      m_gyro.getRotation2d(),
+      new Pose2d(),
+      m_kinematics,
+      VecBuilder.fill(0.05, 0.05, Units.degreesToRadians(5)),
+      VecBuilder.fill(Units.degreesToRadians(0.01)),
+      VecBuilder.fill(0.5, 0.5, Units.degreesToRadians(30)));
+
+  // Gains are for example purposes only - must be determined for your own robot!
+  private final SimpleMotorFeedforward m_feedforward = new SimpleMotorFeedforward(1, 3);
+
+  /**
+   * Constructs a MecanumDrive and resets the gyro.
+   */
+  public Drivetrain() {
+    m_gyro.reset();
+  }
+
+  /**
+   * Returns the current state of the drivetrain.
+   *
+   * @return The current state of the drivetrain.
+   */
+  public MecanumDriveWheelSpeeds getCurrentState() {
+    return new MecanumDriveWheelSpeeds(
+        m_frontLeftEncoder.getRate(),
+        m_frontRightEncoder.getRate(),
+        m_backLeftEncoder.getRate(),
+        m_backRightEncoder.getRate()
+    );
+  }
+
+  /**
+   * Set the desired speeds for each wheel.
+   *
+   * @param speeds The desired wheel speeds.
+   */
+  public void setSpeeds(MecanumDriveWheelSpeeds speeds) {
+    final double frontLeftFeedforward = m_feedforward.calculate(speeds.frontLeftMetersPerSecond);
+    final double frontRightFeedforward = m_feedforward.calculate(speeds.frontRightMetersPerSecond);
+    final double backLeftFeedforward = m_feedforward.calculate(speeds.rearLeftMetersPerSecond);
+    final double backRightFeedforward = m_feedforward.calculate(speeds.rearRightMetersPerSecond);
+
+    final double frontLeftOutput = m_frontLeftPIDController.calculate(
+        m_frontLeftEncoder.getRate(), speeds.frontLeftMetersPerSecond
+    );
+    final double frontRightOutput = m_frontRightPIDController.calculate(
+        m_frontRightEncoder.getRate(), speeds.frontRightMetersPerSecond
+    );
+    final double backLeftOutput = m_backLeftPIDController.calculate(
+        m_backLeftEncoder.getRate(), speeds.rearLeftMetersPerSecond
+    );
+    final double backRightOutput = m_backRightPIDController.calculate(
+        m_backRightEncoder.getRate(), speeds.rearRightMetersPerSecond
+    );
+
+    m_frontLeftMotor.setVoltage(frontLeftOutput + frontLeftFeedforward);
+    m_frontRightMotor.setVoltage(frontRightOutput + frontRightFeedforward);
+    m_backLeftMotor.setVoltage(backLeftOutput + backLeftFeedforward);
+    m_backRightMotor.setVoltage(backRightOutput + backRightFeedforward);
+  }
+
+  /**
+   * Method to drive the robot using joystick info.
+   *
+   * @param xSpeed        Speed of the robot in the x direction (forward).
+   * @param ySpeed        Speed of the robot in the y direction (sideways).
+   * @param rot           Angular rate of the robot.
+   * @param fieldRelative Whether the provided x and y speeds are relative to the field.
+   */
+  @SuppressWarnings("ParameterName")
+  public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
+    var mecanumDriveWheelSpeeds = m_kinematics.toWheelSpeeds(
+        fieldRelative ? ChassisSpeeds.fromFieldRelativeSpeeds(
+            xSpeed, ySpeed, rot, m_gyro.getRotation2d()
+        ) : new ChassisSpeeds(xSpeed, ySpeed, rot)
+    );
+    mecanumDriveWheelSpeeds.normalize(kMaxSpeed);
+    setSpeeds(mecanumDriveWheelSpeeds);
+  }
+
+  /**
+   * Updates the field relative position of the robot.
+   */
+  public void updateOdometry() {
+    m_poseEstimator.update(m_gyro.getRotation2d(), getCurrentState());
+
+    // Also apply vision measurements. We use 0.3 seconds in the past as an example -- on
+    // a real robot, this must be calculated based either on latency or timestamps.
+    m_poseEstimator.addVisionMeasurement(
+        ExampleGlobalMeasurementSensor.getEstimatedGlobalPose(
+          m_poseEstimator.getEstimatedPosition()),
+        Timer.getFPGATimestamp() - 0.3);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/ExampleGlobalMeasurementSensor.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/ExampleGlobalMeasurementSensor.java
@@ -1,0 +1,37 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.mecanumdriveposeestimator;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpilibj.util.Units;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+/**
+ * This dummy class represents a global measurement sensor, such as a computer vision solution.
+ */
+public final class ExampleGlobalMeasurementSensor {
+  private ExampleGlobalMeasurementSensor() {
+    // Utility class
+  }
+
+  /**
+   * Get a "noisy" fake global pose reading.
+   *
+   * @param estimatedRobotPose The robot pose.
+   */
+  public static Pose2d getEstimatedGlobalPose(Pose2d estimatedRobotPose) {
+    var rand = StateSpaceUtil.makeWhiteNoiseVector(VecBuilder.fill(0.5, 0.5,
+        Units.degreesToRadians(30)));
+    return new Pose2d(estimatedRobotPose.getX() + rand.get(0, 0),
+        estimatedRobotPose.getY() + rand.get(1, 0),
+        estimatedRobotPose.getRotation().plus(new Rotation2d(rand.get(2, 0))));
+  }
+
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/Main.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/Main.java
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.mecanumdriveposeestimator;
+
+import edu.wpi.first.wpilibj.RobotBase;
+
+/**
+ * Do NOT add any static variables to this class, or any initialization at all.
+ * Unless you know what you are doing, do not modify this file except to
+ * change the parameter class to the startRobot call.
+ */
+public final class Main {
+  private Main() {
+  }
+
+  /**
+   * Main initialization function. Do not perform any initialization here.
+   *
+   * <p>If you change your main robot class, change the parameter type.
+   */
+  public static void main(String... args) {
+    RobotBase.startRobot(Robot::new);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/Robot.java
@@ -1,0 +1,59 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.mecanumdriveposeestimator;
+
+import edu.wpi.first.wpilibj.GenericHID;
+import edu.wpi.first.wpilibj.SlewRateLimiter;
+import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj.XboxController;
+
+public class Robot extends TimedRobot {
+  private final XboxController m_controller = new XboxController(0);
+  private final Drivetrain m_mecanum = new Drivetrain();
+
+  // Slew rate limiters to make joystick inputs more gentle; 1/3 sec from 0 to 1.
+  private final SlewRateLimiter m_xspeedLimiter = new SlewRateLimiter(3);
+  private final SlewRateLimiter m_yspeedLimiter = new SlewRateLimiter(3);
+  private final SlewRateLimiter m_rotLimiter = new SlewRateLimiter(3);
+
+  @Override
+  public void autonomousPeriodic() {
+    driveWithJoystick(false);
+    m_mecanum.updateOdometry();
+  }
+
+  @Override
+  public void teleopPeriodic() {
+    driveWithJoystick(true);
+  }
+
+  private void driveWithJoystick(boolean fieldRelative) {
+    // Get the x speed. We are inverting this because Xbox controllers return
+    // negative values when we push forward.
+    final var xSpeed =
+        -m_xspeedLimiter.calculate(m_controller.getY(GenericHID.Hand.kLeft))
+            * Drivetrain.kMaxSpeed;
+
+    // Get the y speed or sideways/strafe speed. We are inverting this because
+    // we want a positive value when we pull to the left. Xbox controllers
+    // return positive values when you pull to the right by default.
+    final var ySpeed =
+        -m_yspeedLimiter.calculate(m_controller.getX(GenericHID.Hand.kLeft))
+            * Drivetrain.kMaxSpeed;
+
+    // Get the rate of angular rotation. We are inverting this because we want a
+    // positive value when we pull to the left (remember, CCW is positive in
+    // mathematics). Xbox controllers return positive values when you pull to
+    // the right by default.
+    final var rot =
+        -m_rotLimiter.calculate(m_controller.getX(GenericHID.Hand.kRight))
+            * Drivetrain.kMaxAngularSpeed;
+
+    m_mecanum.drive(xSpeed, ySpeed, rot, fieldRelative);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervesdriveposeestimator/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervesdriveposeestimator/Drivetrain.java
@@ -1,0 +1,99 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.swervesdriveposeestimator;
+
+import edu.wpi.first.wpilibj.AnalogGyro;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.estimator.SwerveDrivePoseEstimator;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Translation2d;
+import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.wpilibj.util.Units;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+/**
+ * Represents a swerve drive style drivetrain.
+ */
+public class Drivetrain {
+  public static final double kMaxSpeed = 3.0; // 3 meters per second
+  public static final double kMaxAngularSpeed = Math.PI; // 1/2 rotation per second
+
+  private final Translation2d m_frontLeftLocation = new Translation2d(0.381, 0.381);
+  private final Translation2d m_frontRightLocation = new Translation2d(0.381, -0.381);
+  private final Translation2d m_backLeftLocation = new Translation2d(-0.381, 0.381);
+  private final Translation2d m_backRightLocation = new Translation2d(-0.381, -0.381);
+
+  private final SwerveModule m_frontLeft = new SwerveModule(1, 2);
+  private final SwerveModule m_frontRight = new SwerveModule(3, 4);
+  private final SwerveModule m_backLeft = new SwerveModule(5, 6);
+  private final SwerveModule m_backRight = new SwerveModule(7, 8);
+
+  private final AnalogGyro m_gyro = new AnalogGyro(0);
+
+  private final SwerveDriveKinematics m_kinematics = new SwerveDriveKinematics(
+      m_frontLeftLocation, m_frontRightLocation, m_backLeftLocation, m_backRightLocation
+  );
+
+  /* Here we use SwerveDrivePoseEstimator so that we can fuse odometry readings. The numbers used
+     below are robot specific, and should be tuned. */
+  private final SwerveDrivePoseEstimator m_poseEstimator = new SwerveDrivePoseEstimator(
+      m_gyro.getRotation2d(),
+      new Pose2d(),
+      m_kinematics,
+      VecBuilder.fill(0.05, 0.05, Units.degreesToRadians(5)),
+      VecBuilder.fill(Units.degreesToRadians(0.01)),
+      VecBuilder.fill(0.5, 0.5, Units.degreesToRadians(30))
+  );
+
+  public Drivetrain() {
+    m_gyro.reset();
+  }
+
+  /**
+   * Method to drive the robot using joystick info.
+   *
+   * @param xSpeed        Speed of the robot in the x direction (forward).
+   * @param ySpeed        Speed of the robot in the y direction (sideways).
+   * @param rot           Angular rate of the robot.
+   * @param fieldRelative Whether the provided x and y speeds are relative to the field.
+   */
+  @SuppressWarnings("ParameterName")
+  public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
+    var swerveModuleStates = m_kinematics.toSwerveModuleStates(
+        fieldRelative ? ChassisSpeeds.fromFieldRelativeSpeeds(
+            xSpeed, ySpeed, rot, m_gyro.getRotation2d())
+            : new ChassisSpeeds(xSpeed, ySpeed, rot)
+    );
+    SwerveDriveKinematics.normalizeWheelSpeeds(swerveModuleStates, kMaxSpeed);
+    m_frontLeft.setDesiredState(swerveModuleStates[0]);
+    m_frontRight.setDesiredState(swerveModuleStates[1]);
+    m_backLeft.setDesiredState(swerveModuleStates[2]);
+    m_backRight.setDesiredState(swerveModuleStates[3]);
+  }
+
+  /**
+   * Updates the field relative position of the robot.
+   */
+  public void updateOdometry() {
+    m_poseEstimator.update(
+        m_gyro.getRotation2d(),
+        m_frontLeft.getState(),
+        m_frontRight.getState(),
+        m_backLeft.getState(),
+        m_backRight.getState()
+    );
+
+    // Also apply vision measurements. We use 0.3 seconds in the past as an example -- on
+    // a real robot, this must be calculated based either on latency or timestamps.
+    m_poseEstimator.addVisionMeasurement(
+        ExampleGlobalMeasurementSensor.getEstimatedGlobalPose(
+          m_poseEstimator.getEstimatedPosition()),
+        Timer.getFPGATimestamp() - 0.3);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervesdriveposeestimator/ExampleGlobalMeasurementSensor.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervesdriveposeestimator/ExampleGlobalMeasurementSensor.java
@@ -1,0 +1,38 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2020 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.swervesdriveposeestimator;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.math.StateSpaceUtil;
+import edu.wpi.first.wpilibj.util.Units;
+import edu.wpi.first.wpiutil.math.VecBuilder;
+
+/**
+ * This dummy class represents a global measurement sensor, such as a computer vision solution.
+ */
+public final class ExampleGlobalMeasurementSensor {
+  private ExampleGlobalMeasurementSensor() {
+    // Utility class
+  }
+
+
+  /**
+   * Get a "noisy" fake global pose reading.
+   *
+   * @param estimatedRobotPose The robot pose.
+   */
+  public static Pose2d getEstimatedGlobalPose(Pose2d estimatedRobotPose) {
+    var rand = StateSpaceUtil.makeWhiteNoiseVector(VecBuilder.fill(0.5, 0.5,
+        Units.degreesToRadians(30)));
+    return new Pose2d(estimatedRobotPose.getX() + rand.get(0, 0),
+        estimatedRobotPose.getY() + rand.get(1, 0),
+        estimatedRobotPose.getRotation().plus(new Rotation2d(rand.get(2, 0))));
+  }
+
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervesdriveposeestimator/Main.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervesdriveposeestimator/Main.java
@@ -1,0 +1,29 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.swervesdriveposeestimator;
+
+import edu.wpi.first.wpilibj.RobotBase;
+
+/**
+ * Do NOT add any static variables to this class, or any initialization at all.
+ * Unless you know what you are doing, do not modify this file except to
+ * change the parameter class to the startRobot call.
+ */
+public final class Main {
+  private Main() {
+  }
+
+  /**
+   * Main initialization function. Do not perform any initialization here.
+   *
+   * <p>If you change your main robot class, change the parameter type.
+   */
+  public static void main(String... args) {
+    RobotBase.startRobot(Robot::new);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervesdriveposeestimator/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervesdriveposeestimator/Robot.java
@@ -1,0 +1,59 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.swervesdriveposeestimator;
+
+import edu.wpi.first.wpilibj.GenericHID;
+import edu.wpi.first.wpilibj.SlewRateLimiter;
+import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj.XboxController;
+
+public class Robot extends TimedRobot {
+  private final XboxController m_controller = new XboxController(0);
+  private final Drivetrain m_swerve = new Drivetrain();
+
+  // Slew rate limiters to make joystick inputs more gentle; 1/3 sec from 0 to 1.
+  private final SlewRateLimiter m_xspeedLimiter = new SlewRateLimiter(3);
+  private final SlewRateLimiter m_yspeedLimiter = new SlewRateLimiter(3);
+  private final SlewRateLimiter m_rotLimiter = new SlewRateLimiter(3);
+
+  @Override
+  public void autonomousPeriodic() {
+    driveWithJoystick(false);
+    m_swerve.updateOdometry();
+  }
+
+  @Override
+  public void teleopPeriodic() {
+    driveWithJoystick(true);
+  }
+
+  private void driveWithJoystick(boolean fieldRelative) {
+    // Get the x speed. We are inverting this because Xbox controllers return
+    // negative values when we push forward.
+    final var xSpeed =
+        -m_xspeedLimiter.calculate(m_controller.getY(GenericHID.Hand.kLeft))
+            * edu.wpi.first.wpilibj.examples.mecanumbot.Drivetrain.kMaxSpeed;
+
+    // Get the y speed or sideways/strafe speed. We are inverting this because
+    // we want a positive value when we pull to the left. Xbox controllers
+    // return positive values when you pull to the right by default.
+    final var ySpeed =
+        -m_yspeedLimiter.calculate(m_controller.getX(GenericHID.Hand.kLeft))
+            * edu.wpi.first.wpilibj.examples.mecanumbot.Drivetrain.kMaxSpeed;
+
+    // Get the rate of angular rotation. We are inverting this because we want a
+    // positive value when we pull to the left (remember, CCW is positive in
+    // mathematics). Xbox controllers return positive values when you pull to
+    // the right by default.
+    final var rot =
+        -m_rotLimiter.calculate(m_controller.getX(GenericHID.Hand.kRight))
+            * edu.wpi.first.wpilibj.examples.mecanumbot.Drivetrain.kMaxAngularSpeed;
+
+    m_swerve.drive(xSpeed, ySpeed, rot, fieldRelative);
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervesdriveposeestimator/SwerveModule.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervesdriveposeestimator/SwerveModule.java
@@ -1,0 +1,101 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package edu.wpi.first.wpilibj.examples.swervesdriveposeestimator;
+
+import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.PWMVictorSPX;
+import edu.wpi.first.wpilibj.SpeedController;
+import edu.wpi.first.wpilibj.controller.PIDController;
+import edu.wpi.first.wpilibj.controller.ProfiledPIDController;
+import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.trajectory.TrapezoidProfile;
+
+public class SwerveModule {
+  private static final double kWheelRadius = 0.0508;
+  private static final int kEncoderResolution = 4096;
+
+  private static final double kModuleMaxAngularVelocity = Drivetrain.kMaxAngularSpeed;
+  private static final double kModuleMaxAngularAcceleration
+      = 2 * Math.PI; // radians per second squared
+
+  private final SpeedController m_driveMotor;
+  private final SpeedController m_turningMotor;
+
+  private final Encoder m_driveEncoder = new Encoder(0, 1);
+  private final Encoder m_turningEncoder = new Encoder(2, 3);
+
+  private final PIDController m_drivePIDController = new PIDController(1, 0, 0);
+
+  private final ProfiledPIDController m_turningPIDController
+      = new ProfiledPIDController(1, 0, 0,
+      new TrapezoidProfile.Constraints(kModuleMaxAngularVelocity, kModuleMaxAngularAcceleration));
+
+  // Gains are for example purposes only - must be determined for your own robot!
+  private final SimpleMotorFeedforward m_driveFeedforward = new SimpleMotorFeedforward(1, 3);
+  private final SimpleMotorFeedforward m_turnFeedforward = new SimpleMotorFeedforward(1, 0.5);
+
+  /**
+   * Constructs a SwerveModule.
+   *
+   * @param driveMotorChannel   ID for the drive motor.
+   * @param turningMotorChannel ID for the turning motor.
+   */
+  public SwerveModule(int driveMotorChannel, int turningMotorChannel) {
+    m_driveMotor = new PWMVictorSPX(driveMotorChannel);
+    m_turningMotor = new PWMVictorSPX(turningMotorChannel);
+
+    // Set the distance per pulse for the drive encoder. We can simply use the
+    // distance traveled for one rotation of the wheel divided by the encoder
+    // resolution.
+    m_driveEncoder.setDistancePerPulse(2 * Math.PI * kWheelRadius / kEncoderResolution);
+
+    // Set the distance (in this case, angle) per pulse for the turning encoder.
+    // This is the the angle through an entire rotation (2 * wpi::math::pi)
+    // divided by the encoder resolution.
+    m_turningEncoder.setDistancePerPulse(2 * Math.PI / kEncoderResolution);
+
+    // Limit the PID Controller's input range between -pi and pi and set the input
+    // to be continuous.
+    m_turningPIDController.enableContinuousInput(-Math.PI, Math.PI);
+  }
+
+  /**
+   * Returns the current state of the module.
+   *
+   * @return The current state of the module.
+   */
+  public SwerveModuleState getState() {
+    return new SwerveModuleState(m_driveEncoder.getRate(), new Rotation2d(m_turningEncoder.get()));
+  }
+
+  /**
+   * Sets the desired state for the module.
+   *
+   * @param state Desired state with speed and angle.
+   */
+  public void setDesiredState(SwerveModuleState state) {
+    // Calculate the drive output from the drive PID controller.
+    final double driveOutput = m_drivePIDController.calculate(
+        m_driveEncoder.getRate(), state.speedMetersPerSecond);
+
+    final double driveFeedforward = m_driveFeedforward.calculate(state.speedMetersPerSecond);
+
+    // Calculate the turning motor output from the turning PID controller.
+    final double turnOutput = m_turningPIDController.calculate(
+        m_turningEncoder.get(), state.angle.getRadians()
+    );
+
+    final double turnFeedforward =
+        m_turnFeedforward.calculate(m_turningPIDController.getSetpoint().velocity);
+
+    m_driveMotor.setVoltage(driveOutput + driveFeedforward);
+    m_turningMotor.setVoltage(turnOutput + turnFeedforward);
+  }
+}

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/math/StateSpaceUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/math/StateSpaceUtil.java
@@ -20,6 +20,7 @@ import edu.wpi.first.wpiutil.math.Num;
 import edu.wpi.first.wpiutil.math.VecBuilder;
 import edu.wpi.first.wpiutil.math.numbers.N1;
 import edu.wpi.first.wpiutil.math.numbers.N3;
+import edu.wpi.first.wpiutil.math.numbers.N4;
 
 @SuppressWarnings({"PMD.TooManyMethods", "ParameterName"})
 public final class StateSpaceUtil {
@@ -177,4 +178,32 @@ public final class StateSpaceUtil {
     return u;
   }
 
+  /**
+   * Convert a {@link Pose2d} to a vector of [x, y, cos(theta), sin(theta)],
+   * where theta is in radians.
+   *
+   * @param pose A pose to convert to a vector.
+   */
+  public static Matrix<N4, N1> poseTo4dVector(Pose2d pose) {
+    return VecBuilder.fill(
+      pose.getTranslation().getX(),
+      pose.getTranslation().getY(),
+      pose.getRotation().getCos(),
+      pose.getRotation().getSin()
+    );
+  }
+
+  /**
+   * Convert a {@link Pose2d} to a vector of [x, y, theta], where theta is in radians.
+   *
+   * @param pose A pose to convert to a vector.
+   * @return The given pose in vector form, with the third element, theta, in radians.
+   */
+  public static Matrix<N3, N1> poseTo3dVector(Pose2d pose) {
+    return VecBuilder.fill(
+      pose.getTranslation().getX(),
+      pose.getTranslation().getY(),
+      pose.getRotation().getRadians()
+    );
+  }
 }

--- a/wpimath/src/main/native/cpp/StateSpaceUtil.cpp
+++ b/wpimath/src/main/native/cpp/StateSpaceUtil.cpp
@@ -9,6 +9,18 @@
 
 namespace frc {
 
+Eigen::Matrix<double, 3, 1> PoseTo3dVector(const Pose2d& pose) {
+  return frc::MakeMatrix<3, 1>(pose.Translation().X().to<double>(),
+                               pose.Translation().Y().to<double>(),
+                               pose.Rotation().Radians().to<double>());
+}
+
+Eigen::Matrix<double, 4, 1> PoseTo4dVector(const Pose2d& pose) {
+  return frc::MakeMatrix<4, 1>(pose.Translation().X().to<double>(),
+                               pose.Translation().Y().to<double>(),
+                               pose.Rotation().Cos(), pose.Rotation().Sin());
+}
+
 template <>
 bool IsStabilizable<1, 1>(const Eigen::Matrix<double, 1, 1>& A,
                           const Eigen::Matrix<double, 1, 1>& B) {

--- a/wpimath/src/main/native/include/frc/StateSpaceUtil.h
+++ b/wpimath/src/main/native/include/frc/StateSpaceUtil.h
@@ -233,6 +233,24 @@ Eigen::Matrix<double, N, 1> MakeWhiteNoiseVector(
 }
 
 /**
+ * Converts a Pose2d into a vector of [x, y, theta].
+ *
+ * @param pose The pose that is being represented.
+ *
+ * @return The vector.
+ */
+Eigen::Matrix<double, 3, 1> PoseTo3dVector(const Pose2d& pose);
+
+/**
+ * Converts a Pose2d into a vector of [x, y, std::cos(theta), std::sin(theta)].
+ *
+ * @param pose The pose that is being represented.
+ *
+ * @return The vector.
+ */
+Eigen::Matrix<double, 4, 1> PoseTo4dVector(const Pose2d& pose);
+
+/**
  * Returns true if (A, B) is a stabilizable pair.
  *
  * (A,B) is stabilizable if and only if the uncontrollable eigenvalues of A, if

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.h
@@ -76,6 +76,23 @@ class SwerveDriveKinematics {
         wpi::math::MathUsageId::kKinematics_SwerveDrive, 1);
   }
 
+  explicit SwerveDriveKinematics(
+      const std::array<Translation2d, NumModules>& wheels)
+      : m_modules{wheels} {
+    for (size_t i = 0; i < NumModules; i++) {
+      // clang-format off
+      m_inverseKinematics.template block<2, 3>(i * 2, 0) <<
+        1, 0, (-m_modules[i].Y()).template to<double>(),
+        0, 1, (+m_modules[i].X()).template to<double>();
+      // clang-format on
+    }
+
+    m_forwardKinematics = m_inverseKinematics.householderQr();
+
+    wpi::math::MathSharedStore::ReportUsage(
+        wpi::math::MathUsageId::kKinematics_SwerveDrive, 1);
+  }
+
   SwerveDriveKinematics(const SwerveDriveKinematics&) = default;
 
   /**


### PR DESCRIPTION
Pose and state estimators can filter latency-compensated global measurements and fuse them with state-space drivetrain model information to estimate robot position. They are drop-in replacements for the existing odometry classes.

WIP:
- [ ] Switch all estimators to use sin/cos model for heading