### PR TITLE
[build] Don't unconditionally regenerate wpimath numbers

### DIFF
--- a/wpimath/generate_numbers.py
+++ b/wpimath/generate_numbers.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import sys
 
 

--- a/wpimath/generate_numbers.py
+++ b/wpimath/generate_numbers.py
@@ -11,22 +11,31 @@ with open(f"{dirname}/src/generate/GenericNumber.java.in", "r") as templateFile:
     template = templateFile.read()
     rootPath = f"{cmake_binary_dir}/generated/main/java/edu/wpi/first/wpiutil/math/numbers"
 
+    doWrite = True
     if os.path.exists(rootPath):
-        shutil.rmtree(rootPath)
-    os.makedirs(rootPath)
+        count = 0
+        for i in range(MAX_NUM + 1):
+            if os.path.exists(f"{rootPath}/N{i}.java"):
+                with open(f"{rootPath}/N{i}.java", "r") as f:
+                    if f.read() == template.replace("${num}", str(i)):
+                        count += 1
+        if count == MAX_NUM + 1:
+            doWrite = False
 
-    for i in range(MAX_NUM + 1):
-        with open(f"{rootPath}/N{i}.java", "w") as f:
-            f.write(template.replace("${num}", str(i)))
+    if doWrite:
+        if os.path.exists(rootPath):
+            shutil.rmtree(rootPath)
+        os.makedirs(rootPath)
+
+        for i in range(MAX_NUM + 1):
+            with open(f"{rootPath}/N{i}.java", "w") as f:
+                f.write(template.replace("${num}", str(i)))
 
 with open(f"{dirname}/src/generate/Nat.java.in", "r") as templateFile:
     template = templateFile.read()
     outputPath = f"{cmake_binary_dir}/generated/main/java/edu/wpi/first/wpiutil/math/Nat.java"
     with open(f"{dirname}/src/generate/NatGetter.java.in", "r") as getterFile:
         getter = getterFile.read()
-
-    if os.path.exists(outputPath):
-        os.remove(outputPath)
 
     importsString = ""
 
@@ -38,5 +47,14 @@ with open(f"{dirname}/src/generate/Nat.java.in", "r") as templateFile:
 
     template = template.replace('{{REPLACEWITHIMPORTS}}', importsString)
 
-    with open(outputPath, "w") as f:
-        f.write(template)
+    doWrite = True
+    if os.path.exists(outputPath):
+        with open(outputPath, "r") as f:
+            if f.read() == template:
+                doWrite = False
+
+    if doWrite:
+        if os.path.exists(outputPath):
+            os.remove(outputPath)
+        with open(outputPath, "w") as f:
+            f.write(template)


### PR DESCRIPTION
The generate_numbers.py script unconditionally generated its output,
which caused every cmake regen to result in a time-consuming rebuild of the
wpimath.jar and WPIMathJNI.

This changes the python script to check if an update is necessary before
writing fresh output.