### PR TITLE
Initial commit of making IndexedHandleResource support ref counting

### DIFF
--- a/hal/src/main/native/athena/AnalogAccumulator.cpp
+++ b/hal/src/main/native/athena/AnalogAccumulator.cpp
@@ -13,6 +13,13 @@
 using namespace hal;
 
 namespace hal {
+bool IsAccumulatorChannelDirect(uint8_t channel) {
+  for (int32_t i = 0; i < kNumAccumulators; i++) {
+    if (channel == kAccumulatorChannels[i]) return true;
+  }
+  return false;
+}
+
 namespace init {
 void InitializeAnalogAccumulator() {}
 }  // namespace init
@@ -27,10 +34,7 @@ HAL_Bool HAL_IsAccumulatorChannel(HAL_AnalogInputHandle analogPortHandle,
     *status = HAL_HANDLE_ERROR;
     return false;
   }
-  for (int32_t i = 0; i < kNumAccumulators; i++) {
-    if (port->channel == kAccumulatorChannels[i]) return true;
-  }
-  return false;
+  return IsAccumulatorChannelDirect(port->channel);
 }
 
 void HAL_InitAccumulator(HAL_AnalogInputHandle analogPortHandle,

--- a/hal/src/main/native/athena/AnalogInternal.cpp
+++ b/hal/src/main/native/athena/AnalogInternal.cpp
@@ -23,7 +23,7 @@ std::unique_ptr<tAI> analogInputSystem;
 std::unique_ptr<tAO> analogOutputSystem;
 
 IndexedHandleResource<HAL_AnalogInputHandle, ::hal::AnalogPort,
-                      kNumAnalogInputs, HAL_HandleEnum::AnalogInput>*
+                      kNumAnalogInputs, HAL_HandleEnum::AnalogInput, 1>*
     analogInputHandles;
 
 static int32_t analogNumChannelsToActivate = 0;
@@ -35,7 +35,7 @@ bool analogSampleRateSet = false;
 namespace init {
 void InitializeAnalogInternal() {
   static IndexedHandleResource<HAL_AnalogInputHandle, ::hal::AnalogPort,
-                               kNumAnalogInputs, HAL_HandleEnum::AnalogInput>
+                               kNumAnalogInputs, HAL_HandleEnum::AnalogInput, 1>
       alH;
   analogInputHandles = &alH;
 }

--- a/hal/src/main/native/athena/AnalogInternal.h
+++ b/hal/src/main/native/athena/AnalogInternal.h
@@ -37,7 +37,7 @@ struct AnalogPort {
 };
 
 extern IndexedHandleResource<HAL_AnalogInputHandle, hal::AnalogPort,
-                             kNumAnalogInputs, HAL_HandleEnum::AnalogInput>*
+                             kNumAnalogInputs, HAL_HandleEnum::AnalogInput, 1>*
     analogInputHandles;
 
 /**

--- a/hal/src/main/native/athena/PDP.cpp
+++ b/hal/src/main/native/athena/PDP.cpp
@@ -16,7 +16,6 @@
 #include "hal/CANAPI.h"
 #include "hal/Errors.h"
 #include "hal/Ports.h"
-#include "hal/handles/IndexedHandleResource.h"
 
 using namespace hal;
 


### PR DESCRIPTION
Certain things (PDP, PCM and I2c Ports) need to support ref counting. Adding ref counting support to all indexed handles is easy and basically cost free except for initialization and freeing, and makes it easy to make more things have a ref count in the future.