### PR TITLE
[sim] SimDataValue: Fix cancellation

### DIFF
--- a/hal/src/main/native/include/hal/simulation/NotifyListener.h
+++ b/hal/src/main/native/include/hal/simulation/NotifyListener.h
@@ -31,8 +31,8 @@ struct HalCallbackListener {
 
   explicit operator bool() const { return callback != nullptr; }
 
-  CallbackFunction callback;
-  void* param;
+  CallbackFunction callback = nullptr;
+  void* param = nullptr;
 };
 
 }  // namespace hal

--- a/hal/src/main/native/include/hal/simulation/SimDataValue.h
+++ b/hal/src/main/native/include/hal/simulation/SimDataValue.h
@@ -53,7 +53,7 @@ class SimDataValueBase : protected SimCallbackRegistryBase {
       lock.unlock();
       callback(name, param, &value);
     }
-    return newUid + 1;
+    return newUid;
   }
 
   void DoSet(T value, const char* name) {


### PR DESCRIPTION
The uid was getting incremented by 1 during registration but not decremented
by 1 during cancellation, so cancellation didn't work correctly.

As the underlying registration ensures a non-zero result, don't increment
the result.