### PR TITLE
[wpimath] Remove Rho from LQR constructor

### DIFF
--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacearm/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacearm/Robot.java
@@ -78,10 +78,6 @@ public class Robot extends TimedRobot {
         // to more heavily penalize state excursion, or make the controller behave more
         // aggressively. In this example we weight position much more highly than velocity, but this
         // can be tuned to balance the two.
-        1.0, // rho balances Q and R, or velocity and voltage weights. Increasing this
-        // will penalize state excursion more heavily, while decreasing this will penalize control
-        // effort more heavily. Useful for balancing weights for systems with more states such
-        // as drivetrains.
         VecBuilder.fill(12.0), // relms. Control effort (voltage) tolerance. Decrease this to more
         // heavily penalize control effort, or make the controller less aggressive. 12 is a good
         // starting point because that is the (approximate) maximum voltage of a battery.

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespaceelevator/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespaceelevator/Robot.java
@@ -80,10 +80,6 @@ public class Robot extends TimedRobot {
         // heavily penalize state excursion, or make the controller behave more aggressively. In
         // this example we weight position much more highly than velocity, but this can be
         // tuned to balance the two.
-        1.0, // rho balances Q and R, or velocity and voltage weights. Increasing this
-        // will penalize state excursion more heavily, while decreasing this will penalize control
-        // effort more heavily. Useful for balancing weights for systems with more states such
-        // as drivetrains.
         VecBuilder.fill(12.0), // relms. Control effort (voltage) tolerance. Decrease this to more
         // heavily penalize control effort, or make the controller less aggressive. 12 is a good
         // starting point because that is the (approximate) maximum voltage of a battery.

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespaceflywheel/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespaceflywheel/Robot.java
@@ -65,10 +65,6 @@ public class Robot extends TimedRobot {
         VecBuilder.fill(8.0), // qelms. Velocity error tolerance, in radians per second. Decrease
         // this to more heavily penalize state excursion, or make the controller behave more
         // aggressively.
-        1.0, // rho balances Q and R, or velocity and voltage weights. Increasing this
-        // will penalize state excursion more heavily, while decreasing this will penalize control
-        // effort more heavily. Useful for balancing weights for systems with more states such
-        // as drivetrains.
         VecBuilder.fill(12.0), // relms. Control effort (voltage) tolerance. Decrease this to more
         // heavily penalize control effort, or make the controller less aggressive. 12 is a good
         // starting point because that is the (approximate) maximum voltage of a battery.

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/controller/LinearPlantInversionFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/controller/LinearPlantInversionFeedforward.java
@@ -9,7 +9,6 @@ package edu.wpi.first.wpilibj.controller;
 
 import org.ejml.simple.SimpleMatrix;
 
-import edu.wpi.first.wpilibj.math.Discretization;
 import edu.wpi.first.wpilibj.system.LinearSystem;
 import edu.wpi.first.wpiutil.math.Matrix;
 import edu.wpi.first.wpiutil.math.Num;

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/controller/LinearQuadraticRegulator.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/controller/LinearQuadraticRegulator.java
@@ -61,28 +61,7 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num,
         Vector<Inputs> relms,
         double dtSeconds
   ) {
-    this(plant.getA(), plant.getB(), qelms, 1.0, relms, dtSeconds);
-  }
-
-  /**
-   * Constructs a controller with the given coefficients and plant.
-   *
-   * @param plant     The plant being controlled.
-   * @param qelms     The maximum desired error tolerance for each state.
-   * @param rho       A weighting factor that balances control effort and state excursion.
-   *                  Greater values penalize state excursion more heavily. 1 is a good starting
-   *                  value.
-   * @param relms     The maximum desired control effort for each input.
-   * @param dtSeconds Discretization timestep.
-   */
-  public LinearQuadraticRegulator(
-        LinearSystem<States, Inputs, Outputs> plant,
-        Vector<States> qelms,
-        double rho,
-        Vector<Inputs> relms,
-        double dtSeconds
-  ) {
-    this(plant.getA(), plant.getB(), qelms, rho, relms, dtSeconds);
+    this(plant.getA(), plant.getB(), qelms, relms, dtSeconds);
   }
 
   /**
@@ -99,27 +78,7 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num,
                                   Vector<States> qelms, Vector<Inputs> relms,
                                   double dtSeconds
   ) {
-    this(A, B, qelms, 1.0, relms, dtSeconds);
-  }
-
-  /**
-   * Constructs a controller with the given coefficients and plant.
-   *
-   * @param A         Continuous system matrix of the plant being controlled.
-   * @param B         Continuous input matrix of the plant being controlled.
-   * @param qelms     The maximum desired error tolerance for each state.
-   * @param rho       A weighting factor that balances control effort and state excursion.
-   *                  Greater
-   *                  values penalize state excursion more heavily. 1 is a good starting value.
-   * @param relms     The maximum desired control effort for each input.
-   * @param dtSeconds Discretization timestep.
-   */
-  @SuppressWarnings({"ParameterName", "LocalVariableName"})
-  public LinearQuadraticRegulator(Matrix<States, States> A, Matrix<States, Inputs> B,
-                                  Vector<States> qelms, double rho, Vector<Inputs> relms,
-                                  double dtSeconds
-  ) {
-    this(A, B, StateSpaceUtil.makeCostMatrix(qelms).times(rho),
+    this(A, B, StateSpaceUtil.makeCostMatrix(qelms),
         StateSpaceUtil.makeCostMatrix(relms), dtSeconds);
   }
 


### PR DESCRIPTION
"Rho was added as part of Bryson's rule described in https://file.tavsys.net/control/controls-engineering-in-frc.pdf. It doesn't really simplify usage though, and the same thing can be replicated by multiplying the elements of Q by rho manually. It's easier to do it that way, it's how 3512 has been doing controller debugging for a while, and it's probably what other teams will do as well instead of using the "more structured" way. Removing these unhelpful overloads also simplifies the LQR interface."

--Tyler

C++ still WIP