### PR TITLE
[wpimath] Add Vector overload for times and div

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/wpiutil/math/Matrix.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpiutil/math/Matrix.java
@@ -9,7 +9,6 @@ package edu.wpi.first.wpiutil.math;
 
 import java.util.Objects;
 
-
 import org.ejml.MatrixDimensionException;
 import org.ejml.data.DMatrixRMaj;
 import org.ejml.dense.row.CommonOps_DDRM;
@@ -227,7 +226,7 @@ public class Matrix<R extends Num, C extends Num> {
    * @param value The scalar value to multiply by.
    * @return A new matrix with all the elements multiplied by the given value.
    */
-  public final Matrix<R, C> times(double value) {
+  public Matrix<R, C> times(double value) {
     return new Matrix<>(this.m_storage.scale(value));
   }
 
@@ -293,7 +292,7 @@ public class Matrix<R extends Num, C extends Num> {
    * @param value The value to divide by.
    * @return The resultant matrix.
    */
-  public final Matrix<R, C> div(int value) {
+  public Matrix<R, C> div(int value) {
     return new Matrix<>(this.m_storage.divide((double) value));
   }
 
@@ -303,7 +302,7 @@ public class Matrix<R extends Num, C extends Num> {
    * @param value The value to divide by.
    * @return The resultant matrix.
    */
-  public final Matrix<R, C> div(double value) {
+  public Matrix<R, C> div(double value) {
     return new Matrix<>(this.m_storage.divide(value));
   }
 

--- a/wpimath/src/main/java/edu/wpi/first/wpiutil/math/Vector.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpiutil/math/Vector.java
@@ -52,4 +52,19 @@ public class Vector<R extends Num> extends Matrix<R, N1> {
   public Vector(Matrix<R, N1> other) {
     super(other);
   }
+
+  @Override
+  public Vector<R> times(double value) {
+    return new Vector<>(this.m_storage.scale(value));
+  }
+
+  @Override
+  public Vector<R> div(int value) {
+    return new Vector<>(this.m_storage.divide(value));
+  }
+
+  @Override
+  public Vector<R> div(double value) {
+    return new Vector<>(this.m_storage.divide(value));
+  }
 }


### PR DESCRIPTION
This will allow `Vector.times(double)` to return another `Vector`, helpful for scaling Q and R vectors for the LQR constructor.