### PR TITLE
[build] Double gradle build max heap size to 2G

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             build-options: "-Ponlylinuxaarch64bionic"
           - container: wpilib/ubuntu-base:18.04
             artifact-name: Linux
-            build-options: ""
+            build-options: "-Dorg.gradle.jvmargs=-Xmx2g"
     name: "Build - ${{ matrix.artifact-name }}"
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}


### PR DESCRIPTION
The Gradle heap size is currently set to 1G, and that's becoming too
small for our builds.

Developers who want to override this without editing the project's
build.gradle can override these settings with gradle.properties in
GRADLE_USER_HOME (see
https://docs.gradle.org/current/userguide/build_environment.html for
details).