### PR TITLE
[wpigui] Only build static for both gradle and cmake

### DIFF
--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -11,7 +11,7 @@ nativeUtils {
       niLibVersion = "2020.10.1"
       opencvVersion = "3.4.7-3"
       googleTestVersion = "1.9.0-5-437e100-1"
-      imguiVersion = "1.76-7"
+      imguiVersion = "1.76-9"
       wpimathVersion = "-1"
     }
   }

--- a/wpigui/CMakeLists.txt
+++ b/wpigui/CMakeLists.txt
@@ -7,13 +7,14 @@ file(GLOB wpigui_windows_src src/main/native/directx11/*.cpp)
 file(GLOB wpigui_mac_src src/main/native/metal/*.mm)
 file(GLOB wpigui_unix_src src/main/native/opengl3/*.cpp)
 
-add_library(wpigui ${wpigui_src})
+add_library(wpigui STATIC ${wpigui_src})
 set_target_properties(wpigui PROPERTIES DEBUG_POSTFIX "d")
+set_property(TARGET wpigui PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 set_property(TARGET wpigui PROPERTY FOLDER "libraries")
 
 wpilib_target_warnings(wpigui)
-target_link_libraries(wpigui imgui)
+target_link_libraries(wpigui PUBLIC imgui)
 
 target_include_directories(wpigui PUBLIC
                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/include>

--- a/wpigui/build.gradle
+++ b/wpigui/build.gradle
@@ -92,7 +92,6 @@ if (!project.hasProperty('onlylinuxathena') && !project.hasProperty('onlylinuxra
                         source {
                             srcDirs 'src/dev/native/cpp'
                             include '**/*.cpp'
-                            lib library: 'wpigui'
                         }
                         exportedHeaders {
                             srcDirs 'src/dev/native/include'
@@ -100,6 +99,7 @@ if (!project.hasProperty('onlylinuxathena') && !project.hasProperty('onlylinuxra
                     }
                 }
                 binaries.all {
+                    lib library: 'wpigui'
                     nativeUtils.useRequiredLibrary(it, 'imgui_static')
                 }
             }
@@ -117,6 +117,9 @@ if (!project.hasProperty('onlylinuxathena') && !project.hasProperty('onlylinuxra
                 } else {
                     it.linker.args << '-lX11'
                 }
+            }
+            withType(SharedLibraryBinarySpec) {
+                buildable = false
             }
         }
     }


### PR DESCRIPTION
Final use of wpigui is essentially always the static library.