### PR TITLE
Add lambda overload for Watchdog.printEpochs (Java, C++)

### DIFF
--- a/wpilibc/src/main/native/cpp/Watchdog.cpp
+++ b/wpilibc/src/main/native/cpp/Watchdog.cpp
@@ -191,6 +191,8 @@ void Watchdog::AddEpoch(wpi::StringRef epochName) {
 
 void Watchdog::PrintEpochs() { m_tracer.PrintEpochs(); }
 
+void Watchdog::PrintEpochs(wpi::raw_ostream& os) { m_tracer.PrintEpochs(os)}
+
 void Watchdog::Reset() { Enable(); }
 
 void Watchdog::Enable() {

--- a/wpilibc/src/main/native/cpp/Watchdog.cpp
+++ b/wpilibc/src/main/native/cpp/Watchdog.cpp
@@ -191,7 +191,7 @@ void Watchdog::AddEpoch(wpi::StringRef epochName) {
 
 void Watchdog::PrintEpochs() { m_tracer.PrintEpochs(); }
 
-void Watchdog::PrintEpochs(wpi::raw_ostream& os) { m_tracer.PrintEpochs(os)}
+void Watchdog::PrintEpochs(wpi::raw_ostream& os) { m_tracer.PrintEpochs(os); }
 
 void Watchdog::Reset() { Enable(); }
 

--- a/wpilibc/src/main/native/include/frc/Watchdog.h
+++ b/wpilibc/src/main/native/include/frc/Watchdog.h
@@ -118,6 +118,13 @@ class Watchdog {
   void PrintEpochs();
 
   /**
+   * Prints list of epochs added so far and their times to a stream.
+   *
+   * @param os output stream
+   */
+  void PrintEpochs(wpi::raw_ostream& os);
+
+  /**
    * Resets the watchdog timer.
    *
    * This also enables the timer if it was previously disabled.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -149,7 +149,7 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
 
   /**
    * Prints list of epochs added so far and their times.
-   * @see Tracer#printEpochs(Consumer<String>)
+   * @see Tracer#printEpochs(Consumer)
    */
   public void printEpochs(Consumer<String> output) {
     m_tracer.printEpochs(output);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -10,6 +10,7 @@ package edu.wpi.first.wpilibj;
 import java.io.Closeable;
 import java.util.PriorityQueue;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 import edu.wpi.first.hal.NotifierJNI;
 
@@ -144,6 +145,14 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
    */
   public void printEpochs() {
     m_tracer.printEpochs();
+  }
+
+  /**
+   * Prints list of epochs added so far and their times.
+   * @see Tracer#printEpochs(Consumer<String>)
+   */
+  public void printEpochs(Consumer<String> output) {
+    m_tracer.printEpochs(output);
   }
 
   /**


### PR DESCRIPTION
`Tracer` has this overload and it would be useful for the `Watchdog` class too. There are a few use-sites in wpilib itself that should use this. 