### PR TITLE
[build] CMake: Fix Metal linking on macOS

### DIFF
--- a/cmake/modules/LinkMacOSGUI.cmake
+++ b/cmake/modules/LinkMacOSGUI.cmake
@@ -1,0 +1,5 @@
+macro(wpilib_link_macos_gui target)
+    if (APPLE)
+        set_target_properties(${target} PROPERTIES LINK_FLAGS "-framework Metal -framework QuartzCore")
+    endif()
+endmacro()

--- a/cscore/CMakeLists.txt
+++ b/cscore/CMakeLists.txt
@@ -3,6 +3,7 @@ project(cscore)
 include(SubDirList)
 include(CompileWarnings)
 include(AddTest)
+include(LinkMacOSGUI)
 
 find_package( OpenCV REQUIRED )
 
@@ -63,6 +64,11 @@ foreach(example ${cscore_examples})
     if(cscore_example_src)
         add_executable(cscore_${example} ${cscore_example_src})
         wpilib_target_warnings(cscore_${example})
+
+        if (${example} STREQUAL "usbviewer")
+            wpilib_link_macos_gui(cscore_${example})
+        endif()
+
         target_link_libraries(cscore_${example} cscore ${add_libs})
         set_property(TARGET cscore_${example} PROPERTY FOLDER "examples")
     endif()

--- a/simulation/halsim_gui/CMakeLists.txt
+++ b/simulation/halsim_gui/CMakeLists.txt
@@ -1,12 +1,15 @@
 project(halsim_gui)
 
 include(CompileWarnings)
+include(LinkMacOSGUI)
 
 file(GLOB halsim_gui_src src/main/native/cpp/*.cpp)
 
 add_library(halsim_gui MODULE ${halsim_gui_src})
 wpilib_target_warnings(halsim_gui)
 set_target_properties(halsim_gui PROPERTIES DEBUG_POSTFIX "d")
+
+wpilib_link_macos_gui(halsim_gui)
 target_link_libraries(halsim_gui PUBLIC hal ntcore wpimath PRIVATE wpigui)
 
 target_include_directories(halsim_gui PRIVATE src/main/native/include)

--- a/wpigui/CMakeLists.txt
+++ b/wpigui/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(wpigui)
 
 include(CompileWarnings)
+include(LinkMacOSGUI)
 
 file(GLOB wpigui_src src/main/native/cpp/*.cpp)
 file(GLOB wpigui_windows_src src/main/native/directx11/*.cpp)
@@ -33,6 +34,7 @@ else()
 endif()
 
 add_executable(wpiguidev src/dev/native/cpp/main.cpp)
+wpilib_link_macos_gui(wpiguidev)
 target_link_libraries(wpiguidev wpigui)
 
 install(TARGETS wpigui EXPORT wpigui DESTINATION "${main_lib_dest}")


### PR DESCRIPTION
```
Undefined symbols for architecture x86_64:
  "_MTLCreateSystemDefaultDevice", referenced from:
      wpi::gui::PlatformInitRenderer() in libwpigui.a(wpigui_metal.mm.o)
  "_OBJC_CLASS_$_CAMetalLayer", referenced from:
      objc-class-ref in libwpigui.a(wpigui_metal.mm.o)
  "_OBJC_CLASS_$_MTLDepthStencilDescriptor", referenced from:
      objc-class-ref in libimgui.a(imgui_impl_metal.mm.o)
  "_OBJC_CLASS_$_MTLRenderPassDescriptor", referenced from:
      objc-class-ref in libwpigui.a(wpigui_metal.mm.o)
  "_OBJC_CLASS_$_MTLRenderPipelineDescriptor", referenced from:
      objc-class-ref in libimgui.a(imgui_impl_metal.mm.o)
  "_OBJC_CLASS_$_MTLTextureDescriptor", referenced from:
      objc-class-ref in libwpigui.a(wpigui_metal.mm.o)
      objc-class-ref in libimgui.a(imgui_impl_metal.mm.o)
  "_OBJC_CLASS_$_MTLVertexDescriptor", referenced from:
      objc-class-ref in libimgui.a(imgui_impl_metal.mm.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)

```

Everything was working before this commit: https://github.com/wpilibsuite/allwpilib/commit/56972447b22d8f9fcb65e1f650c8c824377076d4