### PR TITLE
[ntcore] React more gracefully to attempted websocket connections

### DIFF
--- a/ntcore/src/main/native/cpp/Dispatcher.cpp
+++ b/ntcore/src/main/native/cpp/Dispatcher.cpp
@@ -404,11 +404,11 @@ void DispatcherBase::ServerThreadMain() {
              << ". Attempted to connect over websockets.");
       // Reject websocket connection with non 101 HTTP Response.
       constexpr auto kResponse =
-          "HTTP/1.1 400 Bad Request\r\n\
-      Connection:close\r\n\
-      Content-Type: text/plain\r\n\
-      \r\n\
-      Server is unable to serve websocket clients. NT4 server may be available on port 5810.";
+          "HTTP/1.1 400 Bad Request\r\n" +
+      "Connection:close\r\n" +
+      "Content-Type: text/plain\r\n" +
+      "\r\n" +
+      "Server is unable to serve websocket clients. NT4 server may be available on port 5810.";
       stream->send(kResponse, std::strlen(kResponse), &err);
       continue;
     }

--- a/ntcore/src/main/native/cpp/Dispatcher.cpp
+++ b/ntcore/src/main/native/cpp/Dispatcher.cpp
@@ -396,9 +396,9 @@ void DispatcherBase::ServerThreadMain() {
 
     char peekBuffer[3];
     wpi::NetworkStream::Error err;
-    stream->peek(peekBuffer, 3, &err);
+    size_t read = stream->peek(peekBuffer, 3, &err);
 
-    if (!strncmp(peekBuffer, "GET", 3)) {
+    if(read == 3 && memcmp(peekBuffer, "GET", 3) == 0) {
       DEBUG0("server: rejecting client from "
              << stream->getPeerIP() << " port " << stream->getPeerPort()
              << ". Attempted to connect over websockets.");

--- a/ntcore/src/main/native/cpp/Dispatcher.cpp
+++ b/ntcore/src/main/native/cpp/Dispatcher.cpp
@@ -404,10 +404,10 @@ void DispatcherBase::ServerThreadMain() {
              << ". Attempted to connect over websockets.");
       // Reject websocket connection with non 101 HTTP Response.
       constexpr auto kResponse =
-          "HTTP/1.1 400 Bad Request\r\n" +
-      "Connection:close\r\n" +
-      "Content-Type: text/plain\r\n" +
-      "\r\n" +
+          "HTTP/1.1 400 Bad Request\r\n"
+      "Connection:close\r\n"
+      "Content-Type: text/plain\r\n"
+      "\r\n"
       "Server is unable to serve websocket clients. NT4 server may be available on port 5810.";
       stream->send(kResponse, std::strlen(kResponse), &err);
       continue;

--- a/ntcore/src/main/native/cpp/Dispatcher.cpp
+++ b/ntcore/src/main/native/cpp/Dispatcher.cpp
@@ -398,7 +398,7 @@ void DispatcherBase::ServerThreadMain() {
     wpi::NetworkStream::Error err;
     size_t read = stream->peek(peekBuffer, 3, &err);
 
-    if (read == 3 && memcmp(peekBuffer, "GET", 3) == 0) {
+    if (read == 3 && std::memcmp(peekBuffer, "GET", 3) == 0) {
       DEBUG0("server: rejecting client from "
              << stream->getPeerIP() << " port " << stream->getPeerPort()
              << ". Attempted to connect over websockets.");

--- a/ntcore/src/main/native/cpp/Dispatcher.cpp
+++ b/ntcore/src/main/native/cpp/Dispatcher.cpp
@@ -398,7 +398,7 @@ void DispatcherBase::ServerThreadMain() {
     wpi::NetworkStream::Error err;
     size_t read = stream->peek(peekBuffer, 3, &err);
 
-    if(read == 3 && memcmp(peekBuffer, "GET", 3) == 0) {
+    if (read == 3 && memcmp(peekBuffer, "GET", 3) == 0) {
       DEBUG0("server: rejecting client from "
              << stream->getPeerIP() << " port " << stream->getPeerPort()
              << ". Attempted to connect over websockets.");

--- a/ntcore/src/main/native/cpp/Dispatcher.cpp
+++ b/ntcore/src/main/native/cpp/Dispatcher.cpp
@@ -405,10 +405,11 @@ void DispatcherBase::ServerThreadMain() {
       // Reject websocket connection with non 101 HTTP Response.
       constexpr auto kResponse =
           "HTTP/1.1 400 Bad Request\r\n"
-      "Connection:close\r\n"
-      "Content-Type: text/plain\r\n"
-      "\r\n"
-      "Server is unable to serve websocket clients. NT4 server may be available on port 5810.";
+          "Connection:close\r\n"
+          "Content-Type: text/plain\r\n"
+          "\r\n"
+          "Server is unable to serve websocket clients. NT4 server may be "
+          "available on port 5810.";
       stream->send(kResponse, std::strlen(kResponse), &err);
       continue;
     }

--- a/wpiutil/src/main/native/cpp/TCPStream.cpp
+++ b/wpiutil/src/main/native/cpp/TCPStream.cpp
@@ -112,6 +112,10 @@ size_t TCPStream::send(const char* buffer, size_t len, Error* err) {
 }
 
 size_t TCPStream::peek(char* buffer, size_t len, Error* err, int timeout) {
+  if (m_sd < 0) {
+    *err = kConnectionClosed;
+    return 0;
+  }
 #ifdef _WIN32
   int rv;
 #else
@@ -122,6 +126,9 @@ size_t TCPStream::peek(char* buffer, size_t len, Error* err, int timeout) {
     rv = recv(m_sd, buffer, len, MSG_PEEK);
   } else if (WaitForReadEvent(timeout)) {
     rv = recv(m_sd, buffer, len, MSG_PEEK);
+  } else {
+    *err = kConnectionTimedOut;
+    return 0;
   }
 
   if (rv < 0) {

--- a/wpiutil/src/main/native/include/wpi/NetworkStream.h
+++ b/wpiutil/src/main/native/include/wpi/NetworkStream.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2015-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2015-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -29,6 +29,8 @@ class NetworkStream {
   virtual size_t send(const char* buffer, size_t len, Error* err) = 0;
   virtual size_t receive(char* buffer, size_t len, Error* err,
                          int timeout = 0) = 0;
+  virtual size_t peek(char* buffer, size_t len, Error* err,
+                      int timeout = 0) = 0;
   virtual void close() = 0;
 
   virtual StringRef getPeerIP() const = 0;

--- a/wpiutil/src/main/native/include/wpi/TCPStream.h
+++ b/wpiutil/src/main/native/include/wpi/TCPStream.h
@@ -48,6 +48,7 @@ class TCPStream : public NetworkStream {
   size_t send(const char* buffer, size_t len, Error* err) override;
   size_t receive(char* buffer, size_t len, Error* err,
                  int timeout = 0) override;
+  size_t peek(char* buffer, size_t len, Error* err, int timeout = 0) override;
   void close() override;
 
   StringRef getPeerIP() const override;


### PR DESCRIPTION
Add a branch to the server loop of ntcore to check whether a client is
attempting to connect over websockets, and if so, respond with a static
HTTP response and terminate the connection. Doing this may provide more
information to the client if its websocket implementation propogates the
HTTP error.

This also introduces a new function to NetworkStream: peek. This is used
to ensure that in the case of a valid client, handshake bytes are not
consumed by the check. The only concrete implementation of this function
that was introduced is in TCPStream.

Resolves #2694.