### PR TITLE
Add constructor overloads to NetworkTableEntry for table and entry names

### DIFF
--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableEntry.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableEntry.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -28,6 +28,40 @@ public final class NetworkTableEntry {
   public NetworkTableEntry(NetworkTableInstance inst, int handle) {
     m_inst = inst;
     m_handle = handle;
+  }
+
+  /**
+   * Construct an entry instance from a table name and an entry name.
+   *
+   * <p>The default NetworkTables instance is used when creating the table.
+   *
+   * @param tableName The table name.
+   * @param entryName The entry name.
+   */
+  public NetworkTableEntry(String tableName, String entryName) {
+    this(NetworkTableInstance.getDefault(), tableName, entryName);
+  }
+
+  /**
+   * Construct an entry instance from a NetworkTables instance, a table name,
+   * and an entry name.
+   *
+   * @param inst      The NetworkTables instance.
+   * @param tableName The table name.
+   * @param entryName The entry name.
+   */
+  public NetworkTableEntry(NetworkTableInstance inst, String tableName, String entryName) {
+    this(inst.getTable(tableName), entryName);
+  }
+
+  /**
+   * Construct an entry instance from a table and an entry name.
+   *
+   * @param table     The table containing the entry.
+   * @param entryName The entry name.
+   */
+  public NetworkTableEntry(NetworkTable table, String entryName) {
+    m_handle = table.getEntry(entryName).getHandle();
   }
 
   /**

--- a/ntcore/src/main/native/cpp/networktables/NetworkTableEntry.cpp
+++ b/ntcore/src/main/native/cpp/networktables/NetworkTableEntry.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -7,9 +7,24 @@
 
 #include "networktables/NetworkTableEntry.h"
 
+#include "networktables/NetworkTable.h"
 #include "networktables/NetworkTableInstance.h"
 
 using namespace nt;
+
+NetworkTableEntry::NetworkTableEntry(wpi::StringRef tableName,
+                                     wpi::StringRef entryName)
+    : NetworkTableEntry(NetworkTableInstance::GetDefault(), tableName,
+                        entryName) {}
+
+NetworkTableEntry::NetworkTableEntry(NetworkTableInstance inst,
+                                     wpi::StringRef tableName,
+                                     wpi::StringRef entryName)
+    : NetworkTableEntry(inst.GetTable(tableName), entryName) {}
+
+NetworkTableEntry::NetworkTableEntry(std::shared_ptr<NetworkTable> table,
+                                     wpi::StringRef entryName)
+    : m_handle{table->GetEntry(entryName).GetHandle()} {}
 
 NetworkTableInstance NetworkTableEntry::GetInstance() const {
   return NetworkTableInstance{GetInstanceFromHandle(m_handle)};

--- a/ntcore/src/main/native/include/networktables/NetworkTableEntry.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableEntry.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -30,6 +30,7 @@ using wpi::ArrayRef;
 using wpi::StringRef;
 using wpi::Twine;
 
+class NetworkTable;
 class NetworkTableInstance;
 
 /**
@@ -47,6 +48,36 @@ class NetworkTableEntry final {
    * Construct invalid instance.
    */
   NetworkTableEntry();
+
+  /**
+   * Construct an entry instance from a table name and an entry name.
+   *
+   * The default NetworkTables instance is used when creating the table.
+   *
+   * @param tableName The table name.
+   * @param entryName The entry name.
+   */
+  NetworkTableEntry(wpi::StringRef tableName, wpi::StringRef entryName);
+
+  /**
+   * Construct an entry instance from a NetworkTables instance, a table name,
+   * and an entry name.
+   *
+   * @param inst      The NetworkTables instance.
+   * @param tableName The table name.
+   * @param entryName The entry name.
+   */
+  NetworkTableEntry(NetworkTableInstance inst, wpi::StringRef tableName,
+                    wpi::StringRef entryName);
+
+  /**
+   * Construct an entry instance from a table and an entry name.
+   *
+   * @param table     The table containing the entry.
+   * @param entryName The entry name.
+   */
+  NetworkTableEntry(std::shared_ptr<NetworkTable> table,
+                    wpi::StringRef entryName);
 
   /**
    * Construct from native handle.


### PR DESCRIPTION
Currently, one has to make a NetworkTableEntry by doing the following:

```
auto inst = nt::NetworkTableInstance::GetDefault();
auto table = inst.GetTable(tableName);
auto entry = table->GetEntry(entryName);
```
These constructors significantly reduce that boilerplate and facilitate
simpler inline instantiations in the class declaration.