### PR TITLE
[wpilibc] Fix a use-after-free in DifferentialDrivetrainSim

### DIFF
--- a/wpilibc/src/main/native/include/frc/simulation/DifferentialDrivetrainSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/DifferentialDrivetrainSim.h
@@ -203,7 +203,7 @@ class DifferentialDrivetrainSim {
   }
 
  private:
-  const LinearSystem<2, 2, 2>& m_plant;
+  LinearSystem<2, 2, 2> m_plant;
   units::meter_t m_rb;
   units::meter_t m_wheelRadius;
 


### PR DESCRIPTION
In the second constructor, a new LinearSystem is created and set to
m_plant. This takes a const ref though, so it's storing a reference to a
temporary object. After the constructor finishes, m_plant points to an
invalid object. When Update() is called, it will crash with a
segmentation fault.

This patch fixes the use-after-free by making m_plant a LinearSystem
value type. The first constructor will generate a copy, but that only
happens once.