### PR TITLE
[hal] SimDevice class: remove HAL_SimDeviceHandle constructor

### DIFF
--- a/hal/src/main/native/include/hal/SimDevice.h
+++ b/hal/src/main/native/include/hal/SimDevice.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -472,14 +472,6 @@ class SimDevice {
    * @param channel device channel number to append to name
    */
   SimDevice(const char* name, int index, int channel);
-
-  /**
-   * Wraps a simulated device handle as returned by HAL_CreateSimDevice().
-   *
-   * @param handle simulated device handle
-   */
-  /*implicit*/ SimDevice(HAL_SimDeviceHandle val)  // NOLINT(runtime/explicit)
-      : m_handle(val) {}
 
   ~SimDevice() {
     if (m_handle != HAL_kInvalidHandle) HAL_FreeSimDevice(m_handle);


### PR DESCRIPTION
This isn't appropriate for a RAII class.  In particular, it can cause
foot-shooting in simulation mode if the result of
HALSIM_GetSimDeviceHandle is passed instead of HAL_CreateSimDevice.

Fixes #2742.