### PR TITLE
[wpilib] Shorten differential drive simulation stability test

### DIFF
--- a/wpilibc/src/test/native/cpp/simulation/DifferentialDriveSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/DifferentialDriveSimTest.cpp
@@ -6,6 +6,7 @@
 /*----------------------------------------------------------------------------*/
 
 #include <units/current.h>
+#include <units/math.h>
 #include <units/moment_of_inertia.h>
 
 #include "frc/controller/LinearPlantInversionFeedforward.h"
@@ -105,9 +106,11 @@ TEST(DifferentialDriveSim, ModelStability) {
 
   sim.SetInputs(2_V, 4_V);
 
-  for (int i = 0; i < 10000; ++i) {
+  // 10 seconds should be enough time to verify stability
+  for (int i = 0; i < 500; ++i) {
     sim.Update(20_ms);
   }
 
-  EXPECT_TRUE(std::abs(sim.GetEstimatedPosition().X().to<double>()) < 10000);
+  EXPECT_LT(units::math::abs(sim.GetEstimatedPosition().Translation().Norm()),
+            100_m);
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSimTest.java
@@ -136,10 +136,11 @@ class DifferentialDrivetrainSimTest {
 
     sim.setInputs(2, 4);
 
-    for (int i = 0; i < 10000; i++) {
+    // 10 seconds should be enough time to verify stability
+    for (int i = 0; i < 500; i++) {
       sim.update(0.020);
     }
 
-    assertTrue(Math.abs(sim.getEstimatedPosition().getX()) < 10000);
+    assertTrue(Math.abs(sim.getEstimatedPosition().getTranslation().getNorm()) < 100);
   }
 }


### PR DESCRIPTION
If the model is unstable, it will almost always diverge within 10
seconds, and the results are rather dramatic. We're also reducing the
threshold to 100 meters because the drivetrain is moving in a small
circle. The translation norm is also used for this reason; the X
component alone regularly crosses zero since the drivetrain moves in a
circle.