### PR TITLE
[wpilib] Rename LinearSystemSim's ResetState() to SetState()

### DIFF
--- a/wpilibc/src/main/native/include/frc/simulation/LinearSystemSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/LinearSystemSim.h
@@ -99,13 +99,11 @@ class LinearSystemSim {
   void SetInput(const Eigen::Matrix<double, Inputs, 1>& u) { m_u = u; }
 
   /**
-   * Resets the system state.
+   * Sets the system state.
    *
-   * @param state The state to reset to.
+   * @param state The state.
    */
-  void ResetState(const Eigen::Matrix<double, States, 1>& state) {
-    m_x = state;
-  }
+  void SetState(const Eigen::Matrix<double, States, 1>& state) { m_x = state; }
 
  protected:
   /**

--- a/wpilibc/src/test/native/cpp/simulation/SingleJointedArmSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/SingleJointedArmSimTest.cpp
@@ -14,7 +14,7 @@ TEST(SingleJointedArmTest, Disabled) {
   frc::sim::SingleJointedArmSim sim(frc::DCMotor::Vex775Pro(2), 100, 10_kg,
                                     9.5_in, -180_deg, 0_deg, false, {0.0},
                                     true);
-  sim.ResetState(frc::MakeMatrix<2, 1>(0.0, 0.0));
+  sim.SetState(frc::MakeMatrix<2, 1>(0.0, 0.0));
 
   for (size_t i = 0; i < 12 / 0.02; ++i) {
     sim.SetInput(frc::MakeMatrix<1, 1>(0.0));

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/LinearSystemSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/LinearSystemSim.java
@@ -121,7 +121,12 @@ public class LinearSystemSim<States extends Num, Inputs extends Num,
     return m_y.get(row, 0);
   }
 
-  public void resetState(Matrix<States, N1> state) {
+  /**
+   * Sets the system state.
+   *
+   * @param state The state.
+   */
+  public void setState(Matrix<States, N1> state) {
     m_x = state;
   }
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ArmSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ArmSimTest.java
@@ -25,7 +25,7 @@ public class ArmSimTest {
 
   @Test
   public void testArmDisabled() {
-    m_sim.resetState(VecBuilder.fill(0.0, 0.0));
+    m_sim.setState(VecBuilder.fill(0.0, 0.0));
 
     for (int i = 0; i < 12 / 0.02; i++) {
       m_sim.setInput(0.0);


### PR DESCRIPTION
This makes it more consistent with all other simulation classes,
including the differential drive simulation class.