### PR TITLE
[build] Add Developer ID signing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,6 @@ jobs:
           - os: macos-latest
             artifact-name: macOS
             architecture: x64
-    env:
-      developer-id: ${{ secrets.DEVELOPER_ID }}
     name: "Build - ${{ matrix.artifact-name }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -62,19 +60,25 @@ jobs:
           architecture: ${{ matrix.architecture }}
       - uses: devbotsxyz/xcode-import-certificate@v1
         name: Import Developer ID Certificate
-        if: ${{ matrix.artifact-name == 'macOS' && env.developer-id != 0 }}
+        if: |
+          github.repository_owner == 'wpilibsuite' &&
+          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
         with:
           certificate-data: ${{ secrets.CERTIFICATE_DATA }}
           certificate-passphrase: ${{ secrets.CERTIFICATE_PASSWORD }}
           keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
       - name: Set Keychain Lock Timeout
         run: security set-keychain-settings -lut 2700
-        if: ${{ matrix.artifact-name == 'macOS' && env.developer-id != 0}}
+        if: |
+          github.repository_owner == 'wpilibsuite' &&
+          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
       - name: Build with Gradle
         run: ./gradlew build -PbuildServer
       - name: Sign Libraries with Developer ID
         run: ./gradlew build -PbuildServer -PdeveloperID=${{ secrets.DEVELOPER_ID }}
-        if: ${{ matrix.artifact-name == 'macOS' && env.developer-id != 0 }}
+        if: |
+          github.repository_owner == 'wpilibsuite' &&
+          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact-name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
           - os: macos-latest
             artifact-name: macOS
             architecture: x64
+    env:
+      developer-id: ${{ secrets.DEVELOPER_ID }}
     name: "Build - ${{ matrix.artifact-name }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -60,19 +62,19 @@ jobs:
           architecture: ${{ matrix.architecture }}
       - uses: devbotsxyz/xcode-import-certificate@v1
         name: Import Developer ID Certificate
-        if: ${{ matrix.artifact-name == 'macOS' }}
+        if: ${{ matrix.artifact-name == 'macOS' && env.developer-id != 0 }}
         with:
           certificate-data: ${{ secrets.CERTIFICATE_DATA }}
           certificate-passphrase: ${{ secrets.CERTIFICATE_PASSWORD }}
           keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
       - name: Set Keychain Lock Timeout
         run: security set-keychain-settings -lut 2700
-        if: ${{ matrix.artifact-name == 'macOS' }}
+        if: ${{ matrix.artifact-name == 'macOS' && env.developer-id != 0}}
       - name: Build with Gradle
         run: ./gradlew build -PbuildServer
       - name: Sign Libraries with Developer ID
         run: ./gradlew build -PbuildServer -PdeveloperID=${{ secrets.DEVELOPER_ID }}
-        if: ${{ matrix.artifact-name == 'macOS' }}
+        if: ${{ matrix.artifact-name == 'macOS' && env.developer-id != 0 }}
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact-name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,27 +58,25 @@ jobs:
         with:
           java-version: 11
           architecture: ${{ matrix.architecture }}
-      - uses: devbotsxyz/xcode-import-certificate@v1
-        name: Import Developer ID Certificate
+      - name: Import Developer ID Certificate
+        run: |
+          base64 -d <<< "${{ secrets.APPLE_CERTIFICATE_DATA }}" > /tmp/signing-certificate.p12
+          security create-keychain -p ${{ secrets.APPLE_KEYCHAIN_PASSWORD }} wpilibsuite-keychain
+          security default-keychain -s wpilibsuite-keychain
+          security unlock-keychain -p ${{ secrets.APPLE_KEYCHAIN_PASSWORD }} wpilibsuite-keychain
+          security import /tmp/signing-certificate.p12 -f pkcs12 -k wpilibsuite-keychain -P ${{ secrets.APPLE_CERTIFICATE_PASSWORD }} -T /usr/bin/codesign -x
+          security set-key-partition-list -S apple-tool:,apple: -s -k ${{ secrets.APPLE_KEYCHAIN_PASSWORD }} wpilibsuite-keychain > /tmp/output.txt
+          security set-keychain-settings -lut 2700
         if: |
-          github.repository_owner == 'wpilibsuite' &&
-          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
-        with:
-          certificate-data: ${{ secrets.APPLE_CERTIFICATE_DATA }}
-          certificate-passphrase: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          keychain-password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
-      - name: Set Keychain Lock Timeout
-        run: security set-keychain-settings -lut 2700
-        if: |
-          github.repository_owner == 'wpilibsuite' &&
-          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+          github.repository_owner == 'prateekma' || (github.repository_owner == 'wpilibsuite' &&
+          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')))
       - name: Build with Gradle
         run: ./gradlew build -PbuildServer
       - name: Sign Libraries with Developer ID
         run: ./gradlew build -PbuildServer -PdeveloperID=${{ secrets.APPLE_DEVELOPER_ID }}
         if: |
-          github.repository_owner == 'wpilibsuite' &&
-          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+          github.repository_owner == 'prateekma' || (github.repository_owner == 'wpilibsuite' &&
+          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')))
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact-name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,11 @@ jobs:
           java-version: 11
           architecture: ${{ matrix.architecture }}
       - name: Import Developer ID Certificate
-        run: |
-          base64 -d <<< "${{ secrets.APPLE_CERTIFICATE_DATA }}" > /tmp/signing-certificate.p12
-          security create-keychain -p ${{ secrets.APPLE_KEYCHAIN_PASSWORD }} wpilibsuite-keychain
-          security default-keychain -s wpilibsuite-keychain
-          security unlock-keychain -p ${{ secrets.APPLE_KEYCHAIN_PASSWORD }} wpilibsuite-keychain
-          security import /tmp/signing-certificate.p12 -f pkcs12 -k wpilibsuite-keychain -P ${{ secrets.APPLE_CERTIFICATE_PASSWORD }} -T /usr/bin/codesign -x
-          security set-key-partition-list -S apple-tool:,apple: -s -k ${{ secrets.APPLE_KEYCHAIN_PASSWORD }} wpilibsuite-keychain > /tmp/output.txt
-          security set-keychain-settings -lut 2700
+        uses: wpilibsuite/import-signing-certificate@v1
+        with:
+          certificate-data: ${{ secrets.APPLE_CERTIFICATE_DATA }}
+          certificate-passphrase: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          keychain-password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
         if: |
           matrix.artifact-name == 'macOS' && (github.repository_owner == 'wpilibsuite' &&
           (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,21 @@ jobs:
         with:
           java-version: 11
           architecture: ${{ matrix.architecture }}
+      - uses: devbotsxyz/xcode-import-certificate@v1
+        name: Import Developer ID Certificate
+        if: ${{ matrix.artifact-name == 'macOS' }}
+        with:
+          certificate-data: ${{ secrets.CERTIFICATE_DATA }}
+          certificate-passphrase: ${{ secrets.CERTIFICATE_PASSWORD }}
+          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
+      - name: Set Keychain Lock Timeout
+        run: security set-keychain-settings -lut 2700
+        if: ${{ matrix.artifact-name == 'macOS' }}
       - name: Build with Gradle
         run: ./gradlew build -PbuildServer
+      - name: Sign Libraries with Developer ID
+        run: ./gradlew build -PbuildServer -PdeveloperID=${{ secrets.DEVELOPER_ID }}
+        if: ${{ matrix.artifact-name == 'macOS' }}
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact-name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,11 @@ jobs:
         if: |
           matrix.artifact-name == 'macOS' && (github.repository_owner == 'wpilibsuite' &&
           (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')))
+      - name: Set Keychain Lock Timeout
+        run: security set-keychain-settings -lut 3600
+        if: |
+          matrix.artifact-name == 'macOS' && (github.repository_owner == 'wpilibsuite' &&
+          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')))
       - name: Build with Gradle
         run: ./gradlew build -PbuildServer
       - name: Sign Libraries with Developer ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,9 @@ jobs:
           github.repository_owner == 'wpilibsuite' &&
           (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
         with:
-          certificate-data: ${{ secrets.CERTIFICATE_DATA }}
-          certificate-passphrase: ${{ secrets.CERTIFICATE_PASSWORD }}
-          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
+          certificate-data: ${{ secrets.APPLE_CERTIFICATE_DATA }}
+          certificate-passphrase: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          keychain-password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
       - name: Set Keychain Lock Timeout
         run: security set-keychain-settings -lut 2700
         if: |
@@ -75,7 +75,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build -PbuildServer
       - name: Sign Libraries with Developer ID
-        run: ./gradlew build -PbuildServer -PdeveloperID=${{ secrets.DEVELOPER_ID }}
+        run: ./gradlew build -PbuildServer -PdeveloperID=${{ secrets.APPLE_DEVELOPER_ID }}
         if: |
           github.repository_owner == 'wpilibsuite' &&
           (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,14 +68,14 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -s -k ${{ secrets.APPLE_KEYCHAIN_PASSWORD }} wpilibsuite-keychain > /tmp/output.txt
           security set-keychain-settings -lut 2700
         if: |
-          github.repository_owner == 'prateekma' || (github.repository_owner == 'wpilibsuite' &&
+          matrix.artifact-name == 'macOS' && (github.repository_owner == 'wpilibsuite' &&
           (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')))
       - name: Build with Gradle
         run: ./gradlew build -PbuildServer
       - name: Sign Libraries with Developer ID
         run: ./gradlew build -PbuildServer -PdeveloperID=${{ secrets.APPLE_DEVELOPER_ID }}
         if: |
-          github.repository_owner == 'prateekma' || (github.repository_owner == 'wpilibsuite' &&
+          matrix.artifact-name == 'macOS' && (github.repository_owner == 'wpilibsuite' &&
           (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')))
       - uses: actions/upload-artifact@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,8 @@ subprojects {
                     String path = task.getLinkedFile().getAsFile().get().getAbsolutePath()
                     exec {
                         workingDir rootDir
-                        def args = ['sh', 'codesign.sh', project.findProperty("developerID"), path]
+                        def args = ["sh", "-c", "codesign --force --strict --timestamp --options=runtime " +
+                                    "--verbose -s ${project.findProperty("developerID")} ${path}"]
                         commandLine args
                     }
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,25 @@ subprojects {
             }
         }
     }
+
+    // Sign outputs with Developer ID
+    if (project.hasProperty("developerID")) {
+        tasks.withType(AbstractLinkTask) { task ->
+            // Don't sign any executables because codesign complains
+            // about relative rpath.
+            if (!(task instanceof LinkExecutable)) {
+                doLast {
+                    // Get path to binary.
+                    String path = task.getLinkedFile().getAsFile().get().getAbsolutePath()
+                    exec {
+                        workingDir rootDir
+                        def args = ['sh', 'codesign.sh', project.findProperty("developerID"), path]
+                        commandLine args
+                    }
+                }
+            }
+        }
+    }
 }
 
 ext.getCurrentArch = {

--- a/codesign.sh
+++ b/codesign.sh
@@ -1,0 +1,1 @@
+codesign --force --strict --timestamp --options=runtime --verbose -s $1 $2

--- a/codesign.sh
+++ b/codesign.sh
@@ -1,1 +1,0 @@
-codesign --force --strict --timestamp --options=runtime --verbose -s $1 $2


### PR DESCRIPTION
Closes #2777 

If the logic should be moved to native-utils, I'll need a little bit of help because I'm not sure where exactly to move it (cc: @ThadHouse).

This also depends on the existence of the following secrets:

| Secret | Description |
| --- | --- |
| CERTIFICATE_DATA | Base64 encoded `.p12` Developer ID Certificate Data |
| CERTIFICATE_PASSWORD | Password used to encrypt `.p12` when exporting from Keychain |
| KEYCHAIN_PASSWORD | Any random secure string of characters to be used as Keychain password |
| DEVELOPER_ID | The Developer ID used to sign the binaries |

Note that the `DEVELOPER_ID` isn't a "secret" (i.e. it is public information), but it's easiest to store in a GitHub secret so that we don't have to hardcode it everywhere.

Marking this PR as draft so I can get feedback as to where I should put the `codesign.sh` script and/or the Gradle task.

I have the secrets setup on my fork with my team's Developer ID. The output dylibs in the macOS build task and the macOS binaries in the Maven artifact should be signed: https://github.com/prateekma/allwpilib/runs/1262325345?check_suite_focus=true