### PR TITLE
[command] Add PIDSubsystem PIDController as child

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/PIDSubsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/PIDSubsystem.java
@@ -30,6 +30,7 @@ public abstract class PIDSubsystem extends SubsystemBase {
   public PIDSubsystem(PIDController controller, double initialPosition) {
     setSetpoint(initialPosition);
     m_controller = requireNonNullParam(controller, "controller", "PIDSubsystem");
+    addChild("PID Controller", m_controller);
   }
 
   /**

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/PIDSubsystem.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/PIDSubsystem.cpp
@@ -12,6 +12,7 @@ using namespace frc2;
 PIDSubsystem::PIDSubsystem(PIDController controller, double initialPosition)
     : m_controller{controller} {
   SetSetpoint(initialPosition);
+  AddChild("PID Controller", &m_controller);
 }
 
 void PIDSubsystem::Periodic() {


### PR DESCRIPTION
Previously, the PIDSubsystem's PID Controller would show as ungrouped in
livewindow.

This will fix wpilibsuite/RobotBuilder#260