### PR TITLE
[build] Fix cmake shared library build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
             brew install opencv
           fi
       - name: configure
-        run: mkdir build && cd build && cmake -DWITH_SIMULATION_MODULES=OFF ${{ matrix.flags }} ..
+        run: mkdir build && cd build && cmake -DWITH_GUI=OFF ${{ matrix.flags }} ..
       - name: build
         working-directory: build
         run: make -j3
@@ -130,7 +130,7 @@ jobs:
         uses: lukka/run-cmake@v3
         with:
           buildDirectory: ${{ runner.workspace }}/build/
-          cmakeAppendedArgs: -DWITH_JAVA=OFF -DWITH_SIMULATION_MODULES=OFF
+          cmakeAppendedArgs: -DWITH_JAVA=OFF -DWITH_GUI=OFF
           cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
           useVcpkgToolchainFile: true
       - name: Run Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ option(WITH_JAVA "Include java and JNI in the build" ON)
 option(WITH_CSCORE "Build cscore (needs OpenCV)" ON)
 option(WITH_WPILIB "Build hal, wpilibc/j, wpimath, and myRobot (needs OpenCV)" ON)
 option(WITH_TESTS "Build unit tests (requires internet connection)" ON)
+option(WITH_GUI "Build GUI items" ON)
 option(WITH_SIMULATION_MODULES "Build simulation modules" ON)
 
 # Options for external HAL.
@@ -155,7 +156,7 @@ endif()
 add_subdirectory(wpiutil)
 add_subdirectory(ntcore)
 
-if (WITH_SIMULATION_MODULES AND NOT WITH_EXTERNAL_HAL)
+if (WITH_GUI)
     add_subdirectory(imgui)
     add_subdirectory(wpigui)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,8 @@ IF("${isSystemDir}" STREQUAL "-1")
 ENDIF("${isSystemDir}" STREQUAL "-1")
 
 # Options for building certain parts of the repo. Everything is built by default.
+option(BUILD_SHARED_LIBS "Build with shared libs (needed for JNI)" ON)
 option(WITH_JAVA "Include java and JNI in the build" ON)
-option(WITH_SHARED_LIBS "Build with shared libs (needed for JNI)" ON)
 option(WITH_CSCORE "Build cscore (needs OpenCV)" ON)
 option(WITH_WPILIB "Build hal, wpilibc/j, wpimath, and myRobot (needs OpenCV)" ON)
 option(WITH_TESTS "Build unit tests (requires internet connection)" ON)
@@ -73,11 +73,19 @@ if (MSVC)
   set(WITH_FLAT_INSTALL ON)
 endif()
 
-if (WITH_JAVA AND NOT WITH_SHARED_LIBS)
+if (WITH_JAVA AND NOT BUILD_SHARED_LIBS)
     message(FATAL_ERROR "
 FATAL: Cannot build static libs with Java enabled.
-       Static libs requires both WITH_SHARED_LIBS=OFF and
+       Static libs requires both BUILD_SHARED_LIBS=OFF and
        WITH_JAVA=OFF
+")
+endif()
+
+if (WITH_SIMULATION_MODULES AND NOT BUILD_SHARED_LIBS)
+    message(FATAL_ERROR "
+FATAL: Cannot build static libs with simulation modules enabled.
+       Static libs requires both BUILD_SHARED_LIBS=OFF and
+       WITH_SIMULATION_MODULES=OFF
 ")
 endif()
 

--- a/simulation/CMakeLists.txt
+++ b/simulation/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_subdirectory(halsim_gui)
+if (WITH_GUI)
+    add_subdirectory(halsim_gui)
+endif()
 #add_subdirectory(gz_msgs)
 #add_subdirectory(frc_gazebo_plugins)
 #add_subdirectory(halsim_gazebo)


### PR DESCRIPTION
BUILD_SHARED_LIBS is a cmake built-in and must be this name.

Also check for BUILD_SHARED_LIBS with WITH_SIMULATION_MODULES.

While we're here, add WITH_GUI cmake option.