### PR TITLE
[wpilib] Use DutyCycleEncoder FPGA index for sim device number

### DIFF
--- a/wpilibc/src/main/native/cpp/DutyCycleEncoder.cpp
+++ b/wpilibc/src/main/native/cpp/DutyCycleEncoder.cpp
@@ -132,6 +132,10 @@ void DutyCycleEncoder::SetConnectedFrequencyThreshold(int frequency) {
   m_frequencyThreshold = frequency;
 }
 
+int DutyCycleEncoder::GetFPGAIndex() const {
+  return m_dutyCycle->GetFPGAIndex();
+}
+
 int DutyCycleEncoder::GetSourceChannel() const {
   return m_dutyCycle->GetSourceChannel();
 }

--- a/wpilibc/src/main/native/cpp/simulation/DutyCycleEncoderSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/DutyCycleEncoderSim.cpp
@@ -18,7 +18,7 @@ using namespace frc::sim;
 DutyCycleEncoderSim::DutyCycleEncoderSim(const frc::DutyCycleEncoder& encoder) {
   wpi::SmallString<128> fullname;
   wpi::raw_svector_ostream os(fullname);
-  os << "DutyCycleEncoder" << '[' << encoder.GetSourceChannel() << ']';
+  os << "DutyCycleEncoder" << '[' << encoder.GetFPGAIndex() << ']';
   frc::sim::SimDeviceSim deviceSim{fullname.c_str()};
   m_simPosition = deviceSim.GetDouble("Position");
   m_simDistancePerRotation = deviceSim.GetDouble("DistancePerRotation");

--- a/wpilibc/src/main/native/include/frc/DutyCycleEncoder.h
+++ b/wpilibc/src/main/native/include/frc/DutyCycleEncoder.h
@@ -155,6 +155,13 @@ class DutyCycleEncoder : public ErrorBase,
   double GetDistance() const;
 
   /**
+   * Get the FPGA index for the DutyCycleEncoder.
+   *
+   * @return the FPGA index
+   */
+  int GetFPGAIndex() const;
+
+  /**
    * Get the channel of the source.
    *
    * @return the source channel

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycleEncoder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycleEncoder.java
@@ -237,6 +237,16 @@ public class DutyCycleEncoder implements Sendable, AutoCloseable {
   }
 
   /**
+   * Get the FPGA index for the DutyCycleEncoder.
+   *
+   * @return the FPGA index
+   */
+  @SuppressWarnings("AbbreviationAsWordInName")
+  public int getFPGAIndex() {
+    return m_dutyCycle.getFPGAIndex();
+  }
+
+  /**
    * Get the channel of the source.
    *
    * @return the source channel

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DutyCycleEncoderSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DutyCycleEncoderSim.java
@@ -23,7 +23,7 @@ public class DutyCycleEncoderSim {
    * @param encoder DutyCycleEncoder to simulate
    */
   public DutyCycleEncoderSim(DutyCycleEncoder encoder) {
-    SimDeviceSim wrappedSimDevice = new SimDeviceSim("DutyCycleEncoder" + "[" + encoder.getSourceChannel() + "]");
+    SimDeviceSim wrappedSimDevice = new SimDeviceSim("DutyCycleEncoder" + "[" + encoder.getFPGAIndex() + "]");
     m_simPosition = wrappedSimDevice.getDouble("Position");
     m_simDistancePerRotation = wrappedSimDevice.getDouble("DistancePerRotation");
   }


### PR DESCRIPTION
The source channel doesn't necessarily correspond with the HALSIM device
index.