### PR TITLE
Add a javaFormat Gradle task

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,15 @@ make
 ```
 
 
-### Formatting/linting with wpiformat
+### Formatting/linting
+
+#### wpiformat
 
 wpiformat can be executed anywhere in the repository via `py -3 -m wpiformat` on Windows or `python3 -m wpiformat` on other platforms.
 
+#### Java Code Quality Tools
+
+The Java code quality tools (checkstyle, pmd, etc.) can be run with the `./gradlew javaFormat` task.
 
 ### CMake
 

--- a/shared/java/javastyle.gradle
+++ b/shared/java/javastyle.gradle
@@ -18,3 +18,8 @@ if (!project.hasProperty('skipPMD')) {
         ruleSets = []
     }
 }
+
+task javaFormat {
+    dependsOn(tasks.withType(Checkstyle))
+    dependsOn(tasks.withType(Pmd))
+}


### PR DESCRIPTION
This task allows developers to run all of the Java code quality tools at once.

Closes #2804 