### PR TITLE
Recompute the error in AtSetpoint()

### DIFF
--- a/wpilibc/src/main/native/include/frc/controller/PIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/PIDController.h
@@ -238,6 +238,7 @@ class PIDController : public frc::Sendable,
   double m_velocityTolerance = std::numeric_limits<double>::infinity();
 
   double m_setpoint = 0;
+  double m_measurement = 0;
 };
 
 }  // namespace frc2

--- a/wpilibc/src/test/native/cpp/controller/PIDToleranceTest.cpp
+++ b/wpilibc/src/test/native/cpp/controller/PIDToleranceTest.cpp
@@ -24,7 +24,7 @@ TEST(PIDToleranceTest, AbsoluteTolerance) {
   controller.EnableContinuousInput(-kRange / 2, kRange / 2);
 
   EXPECT_TRUE(controller.AtSetpoint())
-      << "Error was in tolerance when it should not have been. Error was "
+      << "Error was not in tolerance when it should have been. Error was "
       << controller.GetPositionError();
 
   controller.SetTolerance(kTolerance);

--- a/wpilibc/src/test/native/cpp/controller/PIDToleranceTest.cpp
+++ b/wpilibc/src/test/native/cpp/controller/PIDToleranceTest.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2014-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2014-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -23,8 +23,16 @@ TEST(PIDToleranceTest, AbsoluteTolerance) {
   frc2::PIDController controller{0.5, 0.0, 0.0};
   controller.EnableContinuousInput(-kRange / 2, kRange / 2);
 
+  EXPECT_TRUE(controller.AtSetpoint())
+      << "Error was in tolerance when it should not have been. Error was "
+      << controller.GetPositionError();
+
   controller.SetTolerance(kTolerance);
   controller.SetSetpoint(kSetpoint);
+
+  EXPECT_FALSE(controller.AtSetpoint())
+      << "Error was in tolerance when it should not have been. Error was "
+      << controller.GetPositionError();
 
   controller.Calculate(0.0);
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/PIDToleranceTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/PIDToleranceTest.java
@@ -32,7 +32,7 @@ class PIDToleranceTest {
       controller.enableContinuousInput(-kRange / 2, kRange / 2);
 
       assertTrue(controller.atSetpoint(),
-          "Error was in tolerance when it should not have been. Error was "
+          "Error was not in tolerance when it should have been. Error was "
           + controller.getPositionError());
 
       controller.setTolerance(kTolerance);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/PIDToleranceTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/PIDToleranceTest.java
@@ -31,8 +31,16 @@ class PIDToleranceTest {
     try (var controller = new PIDController(0.05, 0.0, 0.0)) {
       controller.enableContinuousInput(-kRange / 2, kRange / 2);
 
+      assertTrue(controller.atSetpoint(),
+          "Error was in tolerance when it should not have been. Error was "
+          + controller.getPositionError());
+
       controller.setTolerance(kTolerance);
       controller.setSetpoint(kSetpoint);
+
+      assertFalse(controller.atSetpoint(),
+          "Error was in tolerance when it should not have been. Error was "
+          + controller.getPositionError());
 
       controller.calculate(0.0);
 


### PR DESCRIPTION
This makes AtSetpoint() return false after the setpoint is changed with
SetSetpoint().

Closes #2821.