### PR TITLE
Analog Potentiometer return Scaled Value to Dashboard

### DIFF
--- a/wpilibc/src/main/native/cpp/AnalogPotentiometer.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogPotentiometer.cpp
@@ -44,5 +44,6 @@ double AnalogPotentiometer::Get() const {
 double AnalogPotentiometer::PIDGet() { return Get(); }
 
 void AnalogPotentiometer::InitSendable(SendableBuilder& builder) {
-  m_analog_input->InitSendable(builder);
+  builder.AddDoubleProperty(
+      "Value", [=]() { return Get(); }, nullptr);
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
@@ -159,7 +159,7 @@ public class AnalogPotentiometer implements Potentiometer, Sendable, AutoCloseab
   @Override
   public void initSendable(SendableBuilder builder) {
     if (m_analogInput != null) {
-      m_analogInput.initSendable(builder);
+      builder.addDoubleProperty("Value", this::get, null);
     }
   }
 


### PR DESCRIPTION
Made just a few edits to the initSendable methods to output to the Dashboards the scaled value of the device vs the 0-5 volt average. This is much better in my opinion for users to see the returned value in the user units they set up vs a widget that scale a bar from 0 to 5 volts. This takes care of issue #2814 

I would invite a discussion if there is a reason not to deploy this so I can better understand why keeping the 0-5v display. 