### PR TITLE
[wpilib] Set AnalogPotentiometer dashboard type

### DIFF
--- a/wpilibc/src/main/native/cpp/AnalogPotentiometer.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogPotentiometer.cpp
@@ -44,6 +44,7 @@ double AnalogPotentiometer::Get() const {
 double AnalogPotentiometer::PIDGet() { return Get(); }
 
 void AnalogPotentiometer::InitSendable(SendableBuilder& builder) {
+  builder.SetSmartDashboardType("Analog Input");
   builder.AddDoubleProperty(
       "Value", [=]() { return Get(); }, nullptr);
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
@@ -159,6 +159,7 @@ public class AnalogPotentiometer implements Potentiometer, Sendable, AutoCloseab
   @Override
   public void initSendable(SendableBuilder builder) {
     if (m_analogInput != null) {
+      builder.setSmartDashboardType("Analog Input");
       builder.addDoubleProperty("Value", this::get, null);
     }
   }


### PR DESCRIPTION
There's not a specific dashboard type for potentiometers, so use analog input.