### PR TITLE
[wpilibc] Add range check for Sendable UID and null check

### DIFF
--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableRegistry.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableRegistry.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -296,9 +296,13 @@ SendableRegistry::UID SendableRegistry::GetUniqueId(Sendable* sendable) {
 }
 
 Sendable* SendableRegistry::GetSendable(UID uid) {
-  if (uid == 0) return nullptr;
+  if (uid == 0 || uid - 1 >= m_impl->components.size()) return nullptr;
   std::scoped_lock lock(m_impl->mutex);
-  return m_impl->components[uid - 1]->sendable;
+  if (m_impl->components[uid - 1] != nullptr) {
+    return m_impl->components[uid - 1]->sendable;
+  } else {
+    return nullptr;
+  }
 }
 
 void SendableRegistry::Publish(UID sendableUid,


### PR DESCRIPTION
If a Sendable like SendableChooser is destroyed and recreated, it leaves
a stale object in the Sendable registry. Using this object results in a
crash. This patch avoids using the stale object.

We should remove stale objects from the global registry upon object
destruction, but this fixes the crashing issue for now.

Closes #2818.