### PR TITLE
[build] Update NativeUtils to 2021.0.4

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,5 +5,5 @@ repositories {
     }
 }
 dependencies {
-    implementation "edu.wpi.first:native-utils:2021.0.2"
+    implementation "edu.wpi.first:native-utils:2021.0.4"
 }


### PR DESCRIPTION
This pulls in the 2021 versions of thirdparty libs.