### PR TITLE
Add default initialization of m_u in drivetrain sim

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSim.java
@@ -98,6 +98,7 @@ public class DifferentialDrivetrainSim {
     m_currentGearing = m_originalGearing;
 
     m_x = new Matrix<>(Nat.N7(), Nat.N1());
+    m_u = VecBuilder.fill(0, 0);
   }
 
   /**


### PR DESCRIPTION
`m_u` isn't initialized in the ctor, meaning that if the user calls `update()` before `setInputs()` the program will crash with an NPE. 
The even bigger problem is that the NPE is thrown a few levels deeper in the stack trace, making it even harder to debug. 
Calling functions out of the intended order shouldn't crash the program.