### PR TITLE
Stop halsim gui setting joysticks it doesn't have.

### DIFF
--- a/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
@@ -370,6 +370,7 @@ void RobotJoystick::Update() {
 }
 
 void RobotJoystick::SetHAL(int i) {
+  if (!sys || !sys->present) return;
   // set at HAL level
   HALSIM_SetJoystickDescriptor(i, &desc);
   HALSIM_SetJoystickAxes(i, &axes);

--- a/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
@@ -103,6 +103,7 @@ static RobotJoystick gRobotJoysticks[HAL_kMaxJoysticks];
 static std::unique_ptr<JoystickSource> gJoystickSources[HAL_kMaxJoysticks];
 
 static bool gDisableDS = false;
+static bool gDisableMissingJoysticks = false;
 static std::atomic<bool>* gDSSocketConnected = nullptr;
 
 static inline bool IsDSDisabled() {
@@ -229,13 +230,19 @@ static void DriverStationReadLine(ImGuiContext* ctx,
     int num;
     if (value.getAsInteger(10, num)) return;
     gDisableDS = num;
+  } else if (name == "disableMissingJoysticks") {
+    int num;
+    if (value.getAsInteger(10, num)) return;
+    gDisableMissingJoysticks = num;
   }
 }
 
 static void DriverStationWriteAll(ImGuiContext* ctx,
                                   ImGuiSettingsHandler* handler,
                                   ImGuiTextBuffer* out_buf) {
-  out_buf->appendf("[DriverStation][Main]\ndisable=%d\n\n", gDisableDS ? 1 : 0);
+  out_buf->appendf(
+      "[DriverStation][Main]\ndisable=%d\ndisableMissingJoysticks=%d\n\n",
+      gDisableDS ? 1 : 0, gDisableMissingJoysticks ? 1 : 0);
 }
 
 void SystemJoystick::Update(int i) {
@@ -370,7 +377,7 @@ void RobotJoystick::Update() {
 }
 
 void RobotJoystick::SetHAL(int i) {
-  if (!sys || !sys->present) return;
+  if (gDisableMissingJoysticks && (!sys || !sys->present)) return;
   // set at HAL level
   HALSIM_SetJoystickDescriptor(i, &desc);
   HALSIM_SetJoystickAxes(i, &axes);
@@ -676,6 +683,8 @@ static void DriverStationOptionMenu() {
     ImGui::MenuItem("Turn off DS (real DS connected)", nullptr, true, false);
   } else {
     ImGui::MenuItem("Turn off DS", nullptr, &gDisableDS);
+    ImGui::MenuItem("Turn off missing joysticks", nullptr,
+                    &gDisableMissingJoysticks);
   }
 }
 


### PR DESCRIPTION
This is a simple fix for #2872.

The only exception I see is that when the sim gui starts registers/initializes the DS sim with halsim, the initial joystick values are sent which can overwrite any set by `JoystickSim`. But after that startup process, it seems fine.
