### PR TITLE
Fix sim value changed callbacks by passing correct handle to SimDeviceDataJNI

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimDeviceSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimDeviceSim.java
@@ -79,8 +79,8 @@ public class SimDeviceSim {
     return new CallbackStore(uid, SimDeviceDataJNI::cancelSimValueCreatedCallback);
   }
 
-  public CallbackStore registerValueChangedCallback(SimValueCallback callback, boolean initialNotify) {
-    int uid = SimDeviceDataJNI.registerSimValueChangedCallback(m_handle, callback, initialNotify);
+  public CallbackStore registerValueChangedCallback(SimValue value, SimValueCallback callback, boolean initialNotify) {
+    int uid = SimDeviceDataJNI.registerSimValueChangedCallback(value.getNativeHandle(), callback, initialNotify);
     return new CallbackStore(uid, SimDeviceDataJNI::cancelSimValueChangedCallback);
   }
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/SimDeviceSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/SimDeviceSimTest.java
@@ -126,7 +126,7 @@ class SimDeviceSimTest {
           CallbackStore callback1 = sim.registerValueChangedCallback(val, (name, handle, readonly, value) -> {
             callback1Counter.addAndGet(1);
           }, false);
-          CallbackStore callback2 = sim.registerValueChangedCallback(val,(name, handle, readonly, value) -> {
+          CallbackStore callback2 = sim.registerValueChangedCallback(val, (name, handle, readonly, value) -> {
             callback2Counter.addAndGet(1);
           }, true)) {
         assertEquals(0, callback1Counter.get(), "Callback 1 called early");


### PR DESCRIPTION
SimDeviceSim.registerValueChangedCallback internally calls SimDeviceDataJNI.registerSimValueChangedCallback with its device handle and the arguments passed to it, however, SimDeviceDataJNI.registerSimValueChangedCallback expects a value handle. This fixes #2879.