### PR TITLE
Merge roboRIO toolchain installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ Using Gradle makes building WPILib very straightforward. It only has a few depen
 
 - [JDK 11](https://adoptopenjdk.net/)
 - C++ compiler
-    - On Linux, install GCC
+    - On Linux, install GCC 7 or greater
     - On Windows, install [Visual Studio Community 2019](https://visualstudio.microsoft.com/vs/community/) and select the C++ programming language during installation (Gradle can't use the build tools for Visual Studio 2019)
     - On macOS, install the Xcode command-line build tools via `xcode-select --install`
 - ARM compiler toolchain
-    - For 2020 and beyond, use GCC version 7 or greater
     - Run `./gradlew installRoboRioToolchain` after cloning this repository
     - If the WPILib installer was used, this toolchain is already installed
 - Raspberry Pi toolchain (optional)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Using Gradle makes building WPILib very straightforward. It only has a few depen
 - ARM compiler toolchain
     - For 2020 and beyond, use GCC version 7 or greater
     - Run `./gradlew installRoboRioToolchain` after cloning this repository
+    - If the WPILib installer was used, this toolchain is already installed
 - Raspberry Pi toolchain (optional)
     - Run `./gradlew installRaspbianToolchain` after cloning this repository
 

--- a/README.md
+++ b/README.md
@@ -35,22 +35,15 @@ Using Gradle makes building WPILib very straightforward. It only has a few depen
     - On Linux, install GCC
     - On Windows, install [Visual Studio Community 2019](https://visualstudio.microsoft.com/vs/community/) and select the C++ programming language during installation (Gradle can't use the build tools for Visual Studio 2019)
     - On macOS, install the Xcode command-line build tools via `xcode-select --install`
-- [ARM compiler toolchain](https://github.com/wpilibsuite/roborio-toolchain/releases)
+- ARM compiler toolchain
     - For 2020 and beyond, use GCC version 7 or greater
+    - Run `./gradlew installRoboRioToolchain` after cloning this repository
+- Raspberry Pi toolchain (optional)
+    - Run `./gradlew installRaspbianToolchain` after cloning this repository
 
 ## Setup
 
-Clone the WPILib repository. If the toolchains are not installed, install them, and make sure they are available on the system PATH. The roboRIO toolchain can be installed via
-
-```bash
-./gradlew installRoboRioToolchain
-```
-
-and the Raspberry Pi toolchain can be installed via
-
-```bash
-./gradlew installRaspbianToolchain
-```
+Clone the WPILib repository and follow the instructions above for installing any required tooling.
 
 See the [styleguide README](https://github.com/wpilibsuite/styleguide/blob/master/README.md) for wpiformat setup instructions.
 


### PR DESCRIPTION
There's currently conflicting instructions: install via the archive on
the releases page, and install using a gradlew command.