### PR TITLE
Delete all test folders after tests execute.

### DIFF
--- a/hal/build.gradle
+++ b/hal/build.gradle
@@ -43,8 +43,6 @@ def generateUsageReporting = tasks.register('generateUsageReporting') {
     }
 }
 
-apply plugin: DisableBuildingGTest
-
 ext {
     addHalDependency = { binary, shared->
         binary.tasks.withType(AbstractNativeSourceCompileTask) {

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -47,7 +47,7 @@ model {
 
 apply plugin: DisableBuildingGTest
 
-if (project.hasProperty('CIBuild')) {
+if (project.hasProperty('buildServer')) {
     tasks.withType(org.gradle.nativeplatform.test.tasks.RunTestExecutable) {
         def exeFile = file(it.executable)
         def folder = exeFile.parentFile

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -45,6 +45,19 @@ model {
     }
 }
 
+apply plugin: DisableBuildingGTest
+
+if (project.hasProperty('CIBuild')) {
+    tasks.withType(org.gradle.nativeplatform.test.tasks.RunTestExecutable) {
+        def exeFile = file(it.executable)
+        def folder = exeFile.parentFile
+
+        it.doLast {
+            folder.deleteDir()
+        }
+    }
+}
+
 ext.appendDebugPathToBinaries = { binaries->
     binaries.withType(StaticLibraryBinarySpec) {
         if (it.buildType.name.contains('debug')) {

--- a/shared/jni/setupBuild.gradle
+++ b/shared/jni/setupBuild.gradle
@@ -258,7 +258,7 @@ model {
                                 def filePath = it.tasks.install.installDirectory.get().toString() + File.separatorChar + 'lib'
                                 test.dependsOn it.tasks.install
 
-                                if (project.hasProperty('CIBuild')) {
+                                if (project.hasProperty('buildServer')) {
                                     def folderDir = it.tasks.install.installDirectory.get().toString()
                                     test.doLast {
                                         def folder = file(folderDir)

--- a/shared/jni/setupBuild.gradle
+++ b/shared/jni/setupBuild.gradle
@@ -257,6 +257,15 @@ model {
                                 commandLine it.tasks.install.runScriptFile.get().asFile.toString()
                                 def filePath = it.tasks.install.installDirectory.get().toString() + File.separatorChar + 'lib'
                                 test.dependsOn it.tasks.install
+
+                                if (project.hasProperty('CIBuild')) {
+                                    def folderDir = it.tasks.install.installDirectory.get().toString()
+                                    test.doLast {
+                                        def folder = file(folderDir)
+                                        folder.deleteDir()
+                                    }
+                                }
+
                                 test.systemProperty 'java.library.path', filePath
                                 test.environment 'LD_LIBRARY_PATH', filePath
                                 test.workingDir filePath

--- a/wpilibNewCommands/build.gradle
+++ b/wpilibNewCommands/build.gradle
@@ -43,8 +43,6 @@ nativeUtils.exportsConfigs {
     }
 }
 
-apply plugin: DisableBuildingGTest
-
 model {
     components {}
     binaries {

--- a/wpilibOldCommands/build.gradle
+++ b/wpilibOldCommands/build.gradle
@@ -41,8 +41,6 @@ nativeUtils.exportsConfigs {
     }
 }
 
-apply plugin: DisableBuildingGTest
-
 model {
     components {}
     binaries {

--- a/wpilibc/build.gradle
+++ b/wpilibc/build.gradle
@@ -60,8 +60,6 @@ staticGtestConfigs["${nativeName}Test"] = []
 
 apply from: "${rootDir}/shared/googletest.gradle"
 
-apply plugin: DisableBuildingGTest
-
 nativeUtils.exportsConfigs {
     wpilibc {
         x86ExcludeSymbols = ['_CT??_R0?AV_System_error', '_CT??_R0?AVexception', '_CT??_R0?AVfailure',


### PR DESCRIPTION
This will remove all test folders, which removes lots of copies of dependencies.

This also fixes an issue where gtest exectubables were installed for cross builds, even though they should not have been