### PR TITLE
[wpilib] Fix bugs in Hatchbot examples

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/commands/ComplexAuto.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/commands/ComplexAuto.cpp
@@ -38,7 +38,7 @@ ComplexAuto::ComplexAuto(DriveSubsystem* drive, HatchSubsystem* hatch) {
       frc2::FunctionalCommand(
           // Reset encoders on command start
           [&] { drive->ResetEncoders(); },
-          // Drive forward while the command is executing
+          // Drive backward while the command is executing
           [&] { drive->ArcadeDrive(-AutoConstants::kAutoDriveSpeed, 0); },
           // Stop driving at the end of the command
           [&](bool interrupted) { drive->ArcadeDrive(0, 0); },

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/commands/ComplexAuto.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/commands/ComplexAuto.cpp
@@ -20,14 +20,14 @@ ComplexAuto::ComplexAuto(DriveSubsystem* drive, HatchSubsystem* hatch) {
           // Reset encoders on command start
           [&] { drive->ResetEncoders(); },
           // Drive forward while the command is executing
-          [&] { drive->ArcadeDrive(AutoConstants::kAutoDriveSpeed, 0); },
+          [&] { drive->ArcadeDrive(kAutoDriveSpeed, 0); },
           // Stop driving at the end of the command
           [&](bool interrupted) { drive->ArcadeDrive(0, 0); },
           // End the command when the robot's driven distance exceeds the
           // desired value
           [&] {
             return drive->GetAverageEncoderDistance() >=
-                   AutoConstants::kAutoDriveDistanceInches;
+                   kAutoDriveDistanceInches;
           },
           // Requires the drive subsystem
           {drive}),
@@ -39,14 +39,14 @@ ComplexAuto::ComplexAuto(DriveSubsystem* drive, HatchSubsystem* hatch) {
           // Reset encoders on command start
           [&] { drive->ResetEncoders(); },
           // Drive backward while the command is executing
-          [&] { drive->ArcadeDrive(-AutoConstants::kAutoDriveSpeed, 0); },
+          [&] { drive->ArcadeDrive(-kAutoDriveSpeed, 0); },
           // Stop driving at the end of the command
           [&](bool interrupted) { drive->ArcadeDrive(0, 0); },
           // End the command when the robot's driven distance exceeds the
           // desired value
           [&] {
             return drive->GetAverageEncoderDistance() <=
-                   AutoConstants::kAutoBackupDistanceInches;
+                   kAutoBackupDistanceInches;
           },
           // Requires the drive subsystem
           {drive}));

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/commands/ComplexAuto.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/commands/ComplexAuto.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -7,31 +7,47 @@
 
 #include "commands/ComplexAuto.h"
 
+#include <frc2/command/FunctionalCommand.h>
 #include <frc2/command/InstantCommand.h>
 #include <frc2/command/ParallelRaceGroup.h>
-#include <frc2/command/StartEndCommand.h>
 
 using namespace AutoConstants;
 
 ComplexAuto::ComplexAuto(DriveSubsystem* drive, HatchSubsystem* hatch) {
   AddCommands(
       // Drive forward the specified distance
-      frc2::StartEndCommand([drive] { drive->ArcadeDrive(kAutoDriveSpeed, 0); },
-                            [drive] { drive->ArcadeDrive(0, 0); }, {drive})
-          .BeforeStarting([drive] { drive->ResetEncoders(); })
-          .WithInterrupt([drive] {
+      frc2::FunctionalCommand(
+          // Reset encoders on command start
+          [&] { drive->ResetEncoders(); },
+          // Drive forward while the command is executing
+          [&] { drive->ArcadeDrive(AutoConstants::kAutoDriveSpeed, 0); },
+          // Stop driving at the end of the command
+          [&](bool interrupted) { drive->ArcadeDrive(0, 0); },
+          // End the command when the robot's driven distance exceeds the
+          // desired value
+          [&] {
             return drive->GetAverageEncoderDistance() >=
-                   kAutoDriveDistanceInches;
-          }),
+                   AutoConstants::kAutoDriveDistanceInches;
+          },
+          // Requires the drive subsystem
+          {drive}),
       // Release the hatch
       frc2::InstantCommand([hatch] { hatch->ReleaseHatch(); }, {hatch}),
       // Drive backward the specified distance
-      frc2::StartEndCommand(
-          [drive] { drive->ArcadeDrive(-kAutoDriveSpeed, 0); },
-          [drive] { drive->ArcadeDrive(0, 0); }, {drive})
-          .BeforeStarting([drive] { drive->ResetEncoders(); })
-          .WithInterrupt([drive] {
+      // Drive forward the specified distance
+      frc2::FunctionalCommand(
+          // Reset encoders on command start
+          [&] { drive->ResetEncoders(); },
+          // Drive forward while the command is executing
+          [&] { drive->ArcadeDrive(-AutoConstants::kAutoDriveSpeed, 0); },
+          // Stop driving at the end of the command
+          [&](bool interrupted) { drive->ArcadeDrive(0, 0); },
+          // End the command when the robot's driven distance exceeds the
+          // desired value
+          [&] {
             return drive->GetAverageEncoderDistance() <=
-                   kAutoBackupDistanceInches;
-          }));
+                   AutoConstants::kAutoBackupDistanceInches;
+          },
+          // Requires the drive subsystem
+          {drive}));
 }

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/RobotContainer.h
@@ -50,7 +50,7 @@ class RobotContainer {
   frc2::FunctionalCommand m_simpleAuto = frc2::FunctionalCommand(
       // Reset encoders on command start
       [this] { m_drive.ResetEncoders(); },
-      // Start driving forward at the start of the command
+      // Drive forward while the command is executing
       [this] { m_drive.ArcadeDrive(AutoConstants::kAutoDriveSpeed, 0); },
       // Stop driving at the end of the command
       [this](bool interrupted) { m_drive.ArcadeDrive(0, 0); },

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/RobotContainer.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -14,7 +14,6 @@
 #include <frc2/command/ParallelRaceGroup.h>
 #include <frc2/command/RunCommand.h>
 #include <frc2/command/SequentialCommandGroup.h>
-#include <frc2/command/StartEndCommand.h>
 
 #include "Constants.h"
 #include "commands/ComplexAuto.h"
@@ -48,10 +47,9 @@ class RobotContainer {
 
   // The autonomous routines
   frc2::ParallelRaceGroup m_simpleAuto =
-      frc2::StartEndCommand(
-          [this] { m_drive.ArcadeDrive(ac::kAutoDriveSpeed, 0); },
-          [this] { m_drive.ArcadeDrive(0, 0); }, {&m_drive})
+      frc2::RunCommand([this] { m_drive.ArcadeDrive(ac::kAutoDriveSpeed, 0); })
           .BeforeStarting([this] { m_drive.ResetEncoders(); })
+          .AndThen([this] { m_drive.ArcadeDrive(0, 0); }, {&m_drive})
           .WithInterrupt([this] {
             return m_drive.GetAverageEncoderDistance() >=
                    ac::kAutoDriveDistanceInches;

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/commands/DriveDistance.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/commands/DriveDistance.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -19,6 +19,8 @@ void DriveDistance::Initialize() {
   m_drive->ResetEncoders();
   m_drive->ArcadeDrive(m_speed, 0);
 }
+
+void DriveDistance::Execute() { m_drive->ArcadeDrive(m_speed, 0); }
 
 void DriveDistance::End(bool interrupted) { m_drive->ArcadeDrive(0, 0); }
 

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/include/commands/DriveDistance.h
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/include/commands/DriveDistance.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Copyright (c) 2019-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -25,6 +25,8 @@ class DriveDistance
   DriveDistance(double inches, double speed, DriveSubsystem* subsystem);
 
   void Initialize() override;
+
+  void Execute() override;
 
   void End(bool interrupted) override;
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
@@ -12,6 +12,7 @@ import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
@@ -38,18 +39,18 @@ public class RobotContainer {
   // The autonomous routines
 
   // A simple auto routine that drives forward a specified distance, and then stops.
-  private final Command m_simpleAuto = new RunCommand(
-      // Drive forward
+  private final Command m_simpleAuto = new FunctionalCommand(
+      // Reset encoders on command start
+      m_robotDrive::resetEncoders,
+      // Start driving forward at the start of the command
       () -> m_robotDrive.arcadeDrive(AutoConstants.kAutoDriveSpeed, 0),
-      // Requires the drive subsystem
-      m_robotDrive)
-      // Reset the encoders before starting
-      .beforeStarting(m_robotDrive::resetEncoders)
       // Stop driving at the end of the command
-      .andThen(() -> m_robotDrive.arcadeDrive(0, 0))
+      (interrupt) -> m_robotDrive.arcadeDrive(0, 0),
       // End the command when the robot's driven distance exceeds the desired value
-      .withInterrupt(
-          () -> m_robotDrive.getAverageEncoderDistance() >= AutoConstants.kAutoDriveDistanceInches);
+      () -> m_robotDrive.getAverageEncoderDistance() >= AutoConstants.kAutoDriveDistanceInches,
+      // Require the drive subsystem
+      m_robotDrive
+  );
 
   // A complex auto routine that drives forward, drops a hatch, and then drives backward.
   private final Command m_complexAuto = new ComplexAutoCommand(m_robotDrive, m_hatchSubsystem);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
@@ -14,7 +14,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
-import edu.wpi.first.wpilibj2.command.StartEndCommand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 
 import edu.wpi.first.wpilibj.examples.hatchbotinlined.Constants.AutoConstants;
@@ -39,15 +38,15 @@ public class RobotContainer {
   // The autonomous routines
 
   // A simple auto routine that drives forward a specified distance, and then stops.
-  private final Command m_simpleAuto = new StartEndCommand(
-      // Start driving forward at the start of the command
+  private final Command m_simpleAuto = new RunCommand(
+      // Drive forward
       () -> m_robotDrive.arcadeDrive(AutoConstants.kAutoDriveSpeed, 0),
-      // Stop driving at the end of the command
-      () -> m_robotDrive.arcadeDrive(0, 0),
       // Requires the drive subsystem
       m_robotDrive)
       // Reset the encoders before starting
       .beforeStarting(m_robotDrive::resetEncoders)
+      // Stop driving at the end of the command
+      .andThen(() -> m_robotDrive.arcadeDrive(0, 0))
       // End the command when the robot's driven distance exceeds the desired value
       .withInterrupt(
           () -> m_robotDrive.getAverageEncoderDistance() >= AutoConstants.kAutoDriveDistanceInches);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
@@ -42,7 +42,7 @@ public class RobotContainer {
   private final Command m_simpleAuto = new FunctionalCommand(
       // Reset encoders on command start
       m_robotDrive::resetEncoders,
-      // Start driving forward at the start of the command
+      // Drive forward while the command is executing
       () -> m_robotDrive.arcadeDrive(AutoConstants.kAutoDriveSpeed, 0),
       // Stop driving at the end of the command
       interrupt -> m_robotDrive.arcadeDrive(0, 0),

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
@@ -45,7 +45,7 @@ public class RobotContainer {
       // Start driving forward at the start of the command
       () -> m_robotDrive.arcadeDrive(AutoConstants.kAutoDriveSpeed, 0),
       // Stop driving at the end of the command
-      (interrupt) -> m_robotDrive.arcadeDrive(0, 0),
+      interrupt -> m_robotDrive.arcadeDrive(0, 0),
       // End the command when the robot's driven distance exceeds the desired value
       () -> m_robotDrive.getAverageEncoderDistance() >= AutoConstants.kAutoDriveDistanceInches,
       // Require the drive subsystem

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/commands/ComplexAutoCommand.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/commands/ComplexAutoCommand.java
@@ -7,9 +7,9 @@
 
 package edu.wpi.first.wpilibj.examples.hatchbotinlined.commands;
 
+import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import edu.wpi.first.wpilibj2.command.StartEndCommand;
 
 import edu.wpi.first.wpilibj.examples.hatchbotinlined.Constants.AutoConstants;
 import edu.wpi.first.wpilibj.examples.hatchbotinlined.subsystems.DriveSubsystem;
@@ -28,28 +28,38 @@ public class ComplexAutoCommand extends SequentialCommandGroup {
   public ComplexAutoCommand(DriveSubsystem driveSubsystem, HatchSubsystem hatchSubsystem) {
     addCommands(
         // Drive forward up to the front of the cargo ship
-        new StartEndCommand(
-            // Start driving forward at the start of the command
+        new FunctionalCommand(
+            // Reset encoders on command start
+            driveSubsystem::resetEncoders,
+            // Drive forward while the command is executing
             () -> driveSubsystem.arcadeDrive(AutoConstants.kAutoDriveSpeed, 0),
             // Stop driving at the end of the command
-            () -> driveSubsystem.arcadeDrive(0, 0), driveSubsystem)
-            // Reset the encoders before starting
-            .beforeStarting(driveSubsystem::resetEncoders)
+            interrupt -> driveSubsystem.arcadeDrive(0, 0),
             // End the command when the robot's driven distance exceeds the desired value
-            .withInterrupt(() -> driveSubsystem.getAverageEncoderDistance()
-                >= AutoConstants.kAutoDriveDistanceInches),
+            () -> driveSubsystem.getAverageEncoderDistance()
+                >= AutoConstants.kAutoDriveDistanceInches,
+            // Require the drive subsystem
+            driveSubsystem
+        ),
 
         // Release the hatch
         new InstantCommand(hatchSubsystem::releaseHatch, hatchSubsystem),
 
         // Drive backward the specified distance
-        new StartEndCommand(
+        new FunctionalCommand(
+            // Reset encoders on command start
+            driveSubsystem::resetEncoders,
+            // Drive forward while the command is executing
             () -> driveSubsystem.arcadeDrive(-AutoConstants.kAutoDriveSpeed, 0),
-            () -> driveSubsystem.arcadeDrive(0, 0), driveSubsystem)
-            .beforeStarting(driveSubsystem::resetEncoders)
-            .withInterrupt(
-                () -> driveSubsystem.getAverageEncoderDistance()
-                    <= -AutoConstants.kAutoBackupDistanceInches));
+            // Stop driving at the end of the command
+            interrupt -> driveSubsystem.arcadeDrive(0, 0),
+            // End the command when the robot's driven distance exceeds the desired value
+            () -> driveSubsystem.getAverageEncoderDistance()
+                <= AutoConstants.kAutoBackupDistanceInches,
+            // Require the drive subsystem
+            driveSubsystem
+        )
+    );
   }
 
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/commands/ComplexAutoCommand.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/commands/ComplexAutoCommand.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -49,7 +49,7 @@ public class ComplexAutoCommand extends SequentialCommandGroup {
         new FunctionalCommand(
             // Reset encoders on command start
             driveSubsystem::resetEncoders,
-            // Drive forward while the command is executing
+            // Drive backward while the command is executing
             () -> driveSubsystem.arcadeDrive(-AutoConstants.kAutoDriveSpeed, 0),
             // Stop driving at the end of the command
             interrupt -> driveSubsystem.arcadeDrive(0, 0),

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/commands/DriveDistance.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/commands/DriveDistance.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -27,11 +27,17 @@ public class DriveDistance extends CommandBase {
     m_distance = inches;
     m_speed = speed;
     m_drive = drive;
+    addRequirements(m_drive);
   }
 
   @Override
   public void initialize() {
     m_drive.resetEncoders();
+    m_drive.arcadeDrive(m_speed, 0);
+  }
+
+  @Override
+  public void execute() {
     m_drive.arcadeDrive(m_speed, 0);
   }
 


### PR DESCRIPTION
This fixes an issue with some commands not correctly requiring their
subsytems. Furthermore, an execute() method was added to the
DriveDistance command to continuously update the voltage command.

https://www.chiefdelphi.com/t/simulation-and-command-bot/389311?u=prateek_m