### PR TITLE
Set sim display names programatically

### DIFF
--- a/cscore/src/main/java/edu/wpi/cscore/MjpegServer.java
+++ b/cscore/src/main/java/edu/wpi/cscore/MjpegServer.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2016-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2016-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/cscore/src/main/java/edu/wpi/cscore/MjpegServer.java
+++ b/cscore/src/main/java/edu/wpi/cscore/MjpegServer.java
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2016-2020 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2016-2019 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/AccelerometerDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/AccelerometerDataJNI.java
@@ -10,6 +10,9 @@ package edu.wpi.first.hal.simulation;
 import edu.wpi.first.hal.JNIWrapper;
 
 public class AccelerometerDataJNI extends JNIWrapper {
+  public static native String getDisplayName(int index);
+  public static native void setDisplayName(int index, String displayName);
+
   public static native int registerActiveCallback(int index, NotifyCallback callback, boolean initialNotify);
   public static native void cancelActiveCallback(int index, int uid);
   public static native boolean getActive(int index);

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/AddressableLEDDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/AddressableLEDDataJNI.java
@@ -10,6 +10,9 @@ package edu.wpi.first.hal.simulation;
 import edu.wpi.first.hal.JNIWrapper;
 
 public class AddressableLEDDataJNI extends JNIWrapper {
+  public static native String getDisplayName(int index);
+  public static native void setDisplayName(int index, String displayName);
+
   public static native int registerInitializedCallback(int index, NotifyCallback callback, boolean initialNotify);
   public static native void cancelInitializedCallback(int index, int uid);
   public static native boolean getInitialized(int index);

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/AnalogGyroDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/AnalogGyroDataJNI.java
@@ -10,6 +10,9 @@ package edu.wpi.first.hal.simulation;
 import edu.wpi.first.hal.JNIWrapper;
 
 public class AnalogGyroDataJNI extends JNIWrapper {
+  public static native String getDisplayName(int index);
+  public static native void setDisplayName(int index, String displayName);
+
   public static native int registerAngleCallback(int index, NotifyCallback callback, boolean initialNotify);
   public static native void cancelAngleCallback(int index, int uid);
   public static native double getAngle(int index);

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/AnalogInDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/AnalogInDataJNI.java
@@ -10,6 +10,9 @@ package edu.wpi.first.hal.simulation;
 import edu.wpi.first.hal.JNIWrapper;
 
 public class AnalogInDataJNI extends JNIWrapper {
+  public static native String getDisplayName(int index);
+  public static native void setDisplayName(int index, String displayName);
+
   public static native int registerInitializedCallback(int index, NotifyCallback callback, boolean initialNotify);
   public static native void cancelInitializedCallback(int index, int uid);
   public static native boolean getInitialized(int index);

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/AnalogOutDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/AnalogOutDataJNI.java
@@ -10,6 +10,9 @@ package edu.wpi.first.hal.simulation;
 import edu.wpi.first.hal.JNIWrapper;
 
 public class AnalogOutDataJNI extends JNIWrapper {
+  public static native String getDisplayName(int index);
+  public static native void setDisplayName(int index, String displayName);
+
   public static native int registerVoltageCallback(int index, NotifyCallback callback, boolean initialNotify);
   public static native void cancelVoltageCallback(int index, int uid);
   public static native double getVoltage(int index);

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/DIODataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/DIODataJNI.java
@@ -10,6 +10,9 @@ package edu.wpi.first.hal.simulation;
 import edu.wpi.first.hal.JNIWrapper;
 
 public class DIODataJNI extends JNIWrapper {
+  public static native String getDisplayName(int index);
+  public static native void setDisplayName(int index, String displayName);
+
   public static native int registerInitializedCallback(int index, NotifyCallback callback, boolean initialNotify);
   public static native void cancelInitializedCallback(int index, int uid);
   public static native boolean getInitialized(int index);

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/EncoderDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/EncoderDataJNI.java
@@ -10,6 +10,9 @@ package edu.wpi.first.hal.simulation;
 import edu.wpi.first.hal.JNIWrapper;
 
 public class EncoderDataJNI extends JNIWrapper {
+  public static native String getDisplayName(int index);
+  public static native void setDisplayName(int index, String displayName);
+
   public static native int registerInitializedCallback(int index, NotifyCallback callback, boolean initialNotify);
   public static native void cancelInitializedCallback(int index, int uid);
   public static native boolean getInitialized(int index);

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/PCMDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/PCMDataJNI.java
@@ -15,6 +15,9 @@ public class PCMDataJNI extends JNIWrapper {
   public static native boolean getSolenoidInitialized(int index, int channel);
   public static native void setSolenoidInitialized(int index, int channel, boolean solenoidInitialized);
 
+  public static native String getSolenoidDisplayName(int index, int channel);
+  public static native void setSolenoidDisplayName(int index, int channel, String displayName);
+
   public static native int registerSolenoidOutputCallback(int index, int channel, NotifyCallback callback, boolean initialNotify);
   public static native void cancelSolenoidOutputCallback(int index, int channel, int uid);
   public static native boolean getSolenoidOutput(int index, int channel);

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/PWMDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/PWMDataJNI.java
@@ -10,6 +10,9 @@ package edu.wpi.first.hal.simulation;
 import edu.wpi.first.hal.JNIWrapper;
 
 public class PWMDataJNI extends JNIWrapper {
+  public static native String getDisplayName(int index);
+  public static native void setDisplayName(int index, String displayName);
+
   public static native int registerInitializedCallback(int index, NotifyCallback callback, boolean initialNotify);
   public static native void cancelInitializedCallback(int index, int uid);
   public static native boolean getInitialized(int index);

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/RelayDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/RelayDataJNI.java
@@ -10,6 +10,9 @@ package edu.wpi.first.hal.simulation;
 import edu.wpi.first.hal.JNIWrapper;
 
 public class RelayDataJNI extends JNIWrapper {
+  public static native String getDisplayName(int index);
+  public static native void setDisplayName(int index, String displayName);
+
   public static native int registerInitializedForwardCallback(int index, NotifyCallback callback, boolean initialNotify);
   public static native void cancelInitializedForwardCallback(int index, int uid);
   public static native boolean getInitializedForward(int index);

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/SimDeviceDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/SimDeviceDataJNI.java
@@ -71,4 +71,7 @@ public class SimDeviceDataJNI extends JNIWrapper {
   public static native String[] getSimValueEnumOptions(int handle);
 
   public static native void resetSimDeviceData();
+
+  public static native void setDisplayName(int handle, String displayName);
+  public static native String getDisplayName(int handle);
 }

--- a/hal/src/main/native/athena/mockdata/AccelerometerData.cpp
+++ b/hal/src/main/native/athena/mockdata/AccelerometerData.cpp
@@ -15,6 +15,9 @@ void HALSIM_ResetAccelerometerData(int32_t index) {}
 #define DEFINE_CAPI(TYPE, CAPINAME, RETURN) \
   HAL_SIMDATAVALUE_STUB_CAPI(TYPE, HALSIM, Accelerometer##CAPINAME, RETURN)
 
+const char* HALSIM_GetAccelerometerDisplayName(int32_t index) { return ""; }
+void HALSIM_SetAccelerometerDisplayName(int32_t index,
+                                        const char* displayName) {}
 DEFINE_CAPI(HAL_Bool, Active, false)
 DEFINE_CAPI(HAL_AccelerometerRange, Range, HAL_AccelerometerRange_k2G)
 DEFINE_CAPI(double, X, 0)

--- a/hal/src/main/native/athena/mockdata/AddressableLEDData.cpp
+++ b/hal/src/main/native/athena/mockdata/AddressableLEDData.cpp
@@ -27,6 +27,9 @@ void HALSIM_SetAddressableLEDData(int32_t index,
 #define DEFINE_CAPI(TYPE, CAPINAME, RETURN) \
   HAL_SIMDATAVALUE_STUB_CAPI(TYPE, HALSIM, AddressableLED##CAPINAME, RETURN)
 
+const char* HALSIM_GetAddressableLEDDisplayName(int32_t index) { return ""; }
+void HALSIM_SetAddressableLEDDisplayName(int32_t index,
+                                         const char* displayName) {}
 DEFINE_CAPI(HAL_Bool, Initialized, false)
 DEFINE_CAPI(int32_t, OutputPort, 0)
 DEFINE_CAPI(int32_t, Length, 0)

--- a/hal/src/main/native/athena/mockdata/AnalogGyroData.cpp
+++ b/hal/src/main/native/athena/mockdata/AnalogGyroData.cpp
@@ -15,6 +15,8 @@ void HALSIM_ResetAnalogGyroData(int32_t index) {}
 #define DEFINE_CAPI(TYPE, CAPINAME, RETURN) \
   HAL_SIMDATAVALUE_STUB_CAPI(TYPE, HALSIM, AnalogGyro##CAPINAME, RETURN)
 
+const char* HALSIM_GetAnalogGyroDisplayName(int32_t index) { return ""; }
+void HALSIM_SetAnalogGyroDisplayName(int32_t index, const char* displayName) {}
 DEFINE_CAPI(double, Angle, 0)
 DEFINE_CAPI(double, Rate, 0)
 DEFINE_CAPI(HAL_Bool, Initialized, false)

--- a/hal/src/main/native/athena/mockdata/AnalogInData.cpp
+++ b/hal/src/main/native/athena/mockdata/AnalogInData.cpp
@@ -17,6 +17,8 @@ HAL_SimDeviceHandle HALSIM_GetAnalogInSimDevice(int32_t index) { return 0; }
 #define DEFINE_CAPI(TYPE, CAPINAME, RETURN) \
   HAL_SIMDATAVALUE_STUB_CAPI(TYPE, HALSIM, AnalogIn##CAPINAME, RETURN)
 
+const char* HALSIM_GetAnalogInDisplayName(int32_t index) { return ""; }
+void HALSIM_SetAnalogInDisplayName(int32_t index, const char* displayName) {}
 DEFINE_CAPI(HAL_Bool, Initialized, false)
 DEFINE_CAPI(int32_t, AverageBits, 0)
 DEFINE_CAPI(int32_t, OversampleBits, 0)

--- a/hal/src/main/native/athena/mockdata/AnalogOutData.cpp
+++ b/hal/src/main/native/athena/mockdata/AnalogOutData.cpp
@@ -15,6 +15,8 @@ void HALSIM_ResetAnalogOutData(int32_t index) {}
 #define DEFINE_CAPI(TYPE, CAPINAME, RETURN) \
   HAL_SIMDATAVALUE_STUB_CAPI(TYPE, HALSIM, AnalogOut##CAPINAME, RETURN)
 
+const char* HALSIM_GetAnalogOutDisplayName(int32_t index) { return ""; }
+void HALSIM_SetAnalogOutDisplayName(int32_t index, const char* displayName) {}
 DEFINE_CAPI(double, Voltage, 0)
 DEFINE_CAPI(HAL_Bool, Initialized, false)
 

--- a/hal/src/main/native/athena/mockdata/DIOData.cpp
+++ b/hal/src/main/native/athena/mockdata/DIOData.cpp
@@ -17,6 +17,8 @@ HAL_SimDeviceHandle HALSIM_GetDIOSimDevice(int32_t index) { return 0; }
 #define DEFINE_CAPI(TYPE, CAPINAME, RETURN) \
   HAL_SIMDATAVALUE_STUB_CAPI(TYPE, HALSIM, DIO##CAPINAME, RETURN)
 
+const char* HALSIM_GetDIODisplayName(int32_t index) { return ""; }
+void HALSIM_SetDIODisplayName(int32_t index, const char* displayName) {}
 DEFINE_CAPI(HAL_Bool, Initialized, false)
 DEFINE_CAPI(HAL_Bool, Value, false)
 DEFINE_CAPI(double, PulseLength, 0)

--- a/hal/src/main/native/athena/mockdata/EncoderData.cpp
+++ b/hal/src/main/native/athena/mockdata/EncoderData.cpp
@@ -23,6 +23,8 @@ HAL_SimDeviceHandle HALSIM_GetEncoderSimDevice(int32_t index) { return 0; }
 #define DEFINE_CAPI(TYPE, CAPINAME, RETURN) \
   HAL_SIMDATAVALUE_STUB_CAPI(TYPE, HALSIM, Encoder##CAPINAME, RETURN)
 
+const char* HALSIM_GetEncoderDisplayName(int32_t index) { return ""; }
+void HALSIM_SetEncoderDisplayName(int32_t index, const char* displayName) {}
 DEFINE_CAPI(HAL_Bool, Initialized, false)
 DEFINE_CAPI(int32_t, Count, 0)
 DEFINE_CAPI(double, Period, 0)

--- a/hal/src/main/native/athena/mockdata/PCMData.cpp
+++ b/hal/src/main/native/athena/mockdata/PCMData.cpp
@@ -18,6 +18,12 @@ void HALSIM_ResetPCMData(int32_t index) {}
 HAL_SIMDATAVALUE_STUB_CAPI_CHANNEL(HAL_Bool, HALSIM, PCMSolenoidInitialized,
                                    false)
 HAL_SIMDATAVALUE_STUB_CAPI_CHANNEL(HAL_Bool, HALSIM, PCMSolenoidOutput, false)
+
+const char* HALSIM_GetSolenoidDisplayName(int32_t index, int32_t channel) {
+  return "";
+}
+void HALSIM_SetSolenoidDisplayName(int32_t index, int32_t channel,
+                                   const char* displayName) {}
 DEFINE_CAPI(HAL_Bool, CompressorInitialized, false)
 DEFINE_CAPI(HAL_Bool, CompressorOn, false)
 DEFINE_CAPI(HAL_Bool, ClosedLoopEnabled, false)

--- a/hal/src/main/native/athena/mockdata/PDPData.cpp
+++ b/hal/src/main/native/athena/mockdata/PDPData.cpp
@@ -16,6 +16,8 @@ void HALSIM_ResetPDPData(int32_t index) {}
 #define DEFINE_CAPI(TYPE, CAPINAME, RETURN) \
   HAL_SIMDATAVALUE_STUB_CAPI(TYPE, HALSIM, PDP##CAPINAME, RETURN)
 
+const char* HALSIM_GePDPDisplayName(int32_t index) { return ""; }
+void HALSIM_SetPDPDisplayName(int32_t index, const char* displayName) {}
 DEFINE_CAPI(HAL_Bool, Initialized, false)
 DEFINE_CAPI(double, Temperature, 0)
 DEFINE_CAPI(double, Voltage, 0)

--- a/hal/src/main/native/athena/mockdata/PWMData.cpp
+++ b/hal/src/main/native/athena/mockdata/PWMData.cpp
@@ -15,6 +15,8 @@ void HALSIM_ResetPWMData(int32_t index) {}
 #define DEFINE_CAPI(TYPE, CAPINAME, RETURN) \
   HAL_SIMDATAVALUE_STUB_CAPI(TYPE, HALSIM, PWM##CAPINAME, RETURN)
 
+const char* HALSIM_GetPWMDisplayName(int32_t index) { return ""; }
+void HALSIM_SetPWMDisplayName(int32_t index, const char* displayName) {}
 DEFINE_CAPI(HAL_Bool, Initialized, false)
 DEFINE_CAPI(int32_t, RawValue, 0)
 DEFINE_CAPI(double, Speed, 0)

--- a/hal/src/main/native/athena/mockdata/RelayData.cpp
+++ b/hal/src/main/native/athena/mockdata/RelayData.cpp
@@ -15,6 +15,8 @@ void HALSIM_ResetRelayData(int32_t index) {}
 #define DEFINE_CAPI(TYPE, CAPINAME, RETURN) \
   HAL_SIMDATAVALUE_STUB_CAPI(TYPE, HALSIM, Relay##CAPINAME, RETURN)
 
+const char* HALSIM_GetRelayDisplayName(int32_t index) { return ""; }
+void HALSIM_SetRelayDisplayName(int32_t index, const char* displayName) {}
 DEFINE_CAPI(HAL_Bool, InitializedForward, false)
 DEFINE_CAPI(HAL_Bool, InitializedReverse, false)
 DEFINE_CAPI(HAL_Bool, Forward, false)

--- a/hal/src/main/native/athena/mockdata/SimDeviceData.cpp
+++ b/hal/src/main/native/athena/mockdata/SimDeviceData.cpp
@@ -35,6 +35,12 @@ HAL_SimDeviceHandle HALSIM_GetSimDeviceHandle(const char* name) { return 0; }
 
 const char* HALSIM_GetSimDeviceName(HAL_SimDeviceHandle handle) { return ""; }
 
+const char* HALSIM_GetSimDeviceDisplayName(HAL_SimDeviceHandle handle) {
+  return "";
+}
+void HALSIM_SetSimDeviceDisplayName(HAL_SimDeviceHandle handle,
+                                    const char* displayName) {}
+
 HAL_SimDeviceHandle HALSIM_GetSimValueDeviceHandle(HAL_SimValueHandle handle) {
   return 0;
 }

--- a/hal/src/main/native/cpp/jni/simulation/AccelerometerDataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/AccelerometerDataJNI.cpp
@@ -17,6 +17,32 @@ extern "C" {
 
 /*
  * Class:     edu_wpi_first_hal_simulation_AccelerometerDataJNI
+ * Method:    getDisplayName
+ * Signature: (I)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_first_hal_simulation_AccelerometerDataJNI_getDisplayName
+  (JNIEnv* env, jclass, jint index)
+{
+  const char* displayName = HALSIM_GetAccelerometerDisplayName(index);
+  return wpi::java::MakeJString(env, displayName);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_AccelerometerDataJNI
+ * Method:    setDisplayName
+ * Signature: (ILjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_simulation_AccelerometerDataJNI_setDisplayName
+  (JNIEnv* env, jclass, jint index, jstring displayName)
+{
+  wpi::java::JStringRef displayNameRef{env, displayName};
+  HALSIM_SetAccelerometerDisplayName(index, displayNameRef.c_str());
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_AccelerometerDataJNI
  * Method:    registerActiveCallback
  * Signature: (ILjava/lang/Object;Z)I
  */

--- a/hal/src/main/native/cpp/jni/simulation/AddressableLEDDataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/AddressableLEDDataJNI.cpp
@@ -72,6 +72,32 @@ Java_edu_wpi_first_hal_simulation_AddressableLEDDataJNI_setInitialized
 
 /*
  * Class:     edu_wpi_first_hal_simulation_AddressableLEDDataJNI
+ * Method:    getDisplayName
+ * Signature: (I)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_first_hal_simulation_AddressableLEDDataJNI_getDisplayName
+  (JNIEnv* env, jclass, jint index)
+{
+  const char* displayName = HALSIM_GetAddressableLEDDisplayName(index);
+  return wpi::java::MakeJString(env, displayName);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_AddressableLEDDataJNI
+ * Method:    setDisplayName
+ * Signature: (ILjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_simulation_AddressableLEDDataJNI_setDisplayName
+  (JNIEnv* env, jclass, jint index, jstring displayName)
+{
+  wpi::java::JStringRef displayNameRef{env, displayName};
+  HALSIM_SetAddressableLEDDisplayName(index, displayNameRef.c_str());
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_AddressableLEDDataJNI
  * Method:    registerOutputPortCallback
  * Signature: (ILjava/lang/Object;Z)I
  */

--- a/hal/src/main/native/cpp/jni/simulation/AnalogGyroDataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/AnalogGyroDataJNI.cpp
@@ -17,6 +17,32 @@ extern "C" {
 
 /*
  * Class:     edu_wpi_first_hal_simulation_AnalogGyroDataJNI
+ * Method:    getDisplayName
+ * Signature: (I)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_first_hal_simulation_AnalogGyroDataJNI_getDisplayName
+  (JNIEnv* env, jclass, jint index)
+{
+  const char* displayName = HALSIM_GetAnalogGyroDisplayName(index);
+  return wpi::java::MakeJString(env, displayName);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_AnalogGyroDataJNI
+ * Method:    setDisplayName
+ * Signature: (ILjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_simulation_AnalogGyroDataJNI_setDisplayName
+  (JNIEnv* env, jclass, jint index, jstring displayName)
+{
+  wpi::java::JStringRef displayNameRef{env, displayName};
+  HALSIM_SetAnalogGyroDisplayName(index, displayNameRef.c_str());
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_AnalogGyroDataJNI
  * Method:    registerAngleCallback
  * Signature: (ILjava/lang/Object;Z)I
  */

--- a/hal/src/main/native/cpp/jni/simulation/AnalogInDataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/AnalogInDataJNI.cpp
@@ -17,6 +17,32 @@ extern "C" {
 
 /*
  * Class:     edu_wpi_first_hal_simulation_AnalogInDataJNI
+ * Method:    getDisplayName
+ * Signature: (I)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_first_hal_simulation_AnalogInDataJNI_getDisplayName
+  (JNIEnv* env, jclass, jint index)
+{
+  const char* displayName = HALSIM_GetAnalogInDisplayName(index);
+  return wpi::java::MakeJString(env, displayName);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_AnalogInDataJNI
+ * Method:    setDisplayName
+ * Signature: (ILjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_simulation_AnalogInDataJNI_setDisplayName
+  (JNIEnv* env, jclass, jint index, jstring displayName)
+{
+  wpi::java::JStringRef displayNameRef{env, displayName};
+  HALSIM_SetAnalogInDisplayName(index, displayNameRef.c_str());
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_AnalogInDataJNI
  * Method:    registerInitializedCallback
  * Signature: (ILjava/lang/Object;Z)I
  */

--- a/hal/src/main/native/cpp/jni/simulation/AnalogOutDataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/AnalogOutDataJNI.cpp
@@ -17,6 +17,32 @@ extern "C" {
 
 /*
  * Class:     edu_wpi_first_hal_simulation_AnalogOutDataJNI
+ * Method:    getDisplayName
+ * Signature: (I)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_first_hal_simulation_AnalogOutDataJNI_getDisplayName
+  (JNIEnv* env, jclass, jint index)
+{
+  const char* displayName = HALSIM_GetAnalogOutDisplayName(index);
+  return wpi::java::MakeJString(env, displayName);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_AnalogOutDataJNI
+ * Method:    setDisplayName
+ * Signature: (ILjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_simulation_AnalogOutDataJNI_setDisplayName
+  (JNIEnv* env, jclass, jint index, jstring displayName)
+{
+  wpi::java::JStringRef displayNameRef{env, displayName};
+  HALSIM_SetAnalogOutDisplayName(index, displayNameRef.c_str());
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_AnalogOutDataJNI
  * Method:    registerVoltageCallback
  * Signature: (ILjava/lang/Object;Z)I
  */

--- a/hal/src/main/native/cpp/jni/simulation/DIODataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/DIODataJNI.cpp
@@ -7,6 +7,8 @@
 
 #include <jni.h>
 
+#include <wpi/jni_util.h>
+
 #include "CallbackStore.h"
 #include "edu_wpi_first_hal_simulation_DIODataJNI.h"
 #include "hal/simulation/DIOData.h"
@@ -14,6 +16,32 @@
 using namespace hal;
 
 extern "C" {
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_DIODataJNI
+ * Method:    getDisplayName
+ * Signature: (I)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_first_hal_simulation_DIODataJNI_getDisplayName
+  (JNIEnv* env, jclass, jint index)
+{
+  const char* displayName = HALSIM_GetDIODisplayName(index);
+  return wpi::java::MakeJString(env, displayName);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_DIODataJNI
+ * Method:    setDisplayName
+ * Signature: (ILjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_simulation_DIODataJNI_setDisplayName
+  (JNIEnv* env, jclass, jint index, jstring displayName)
+{
+  wpi::java::JStringRef displayNameRef{env, displayName};
+  HALSIM_SetDIODisplayName(index, displayNameRef.c_str());
+}
 
 /*
  * Class:     edu_wpi_first_hal_simulation_DIODataJNI

--- a/hal/src/main/native/cpp/jni/simulation/EncoderDataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/EncoderDataJNI.cpp
@@ -7,6 +7,8 @@
 
 #include <jni.h>
 
+#include <wpi/jni_util.h>
+
 #include "CallbackStore.h"
 #include "edu_wpi_first_hal_simulation_EncoderDataJNI.h"
 #include "hal/simulation/EncoderData.h"
@@ -14,6 +16,32 @@
 using namespace hal;
 
 extern "C" {
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_EncoderDataJNI
+ * Method:    getDisplayName
+ * Signature: (I)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_first_hal_simulation_EncoderDataJNI_getDisplayName
+  (JNIEnv* env, jclass, jint index)
+{
+  const char* displayName = HALSIM_GetEncoderDisplayName(index);
+  return wpi::java::MakeJString(env, displayName);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_EncoderDataJNI
+ * Method:    setDisplayName
+ * Signature: (ILjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_simulation_EncoderDataJNI_setDisplayName
+  (JNIEnv* env, jclass, jint index, jstring displayName)
+{
+  wpi::java::JStringRef displayNameRef{env, displayName};
+  HALSIM_SetEncoderDisplayName(index, displayNameRef.c_str());
+}
 
 /*
  * Class:     edu_wpi_first_hal_simulation_EncoderDataJNI

--- a/hal/src/main/native/cpp/jni/simulation/PCMDataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/PCMDataJNI.cpp
@@ -17,6 +17,32 @@ extern "C" {
 
 /*
  * Class:     edu_wpi_first_hal_simulation_PCMDataJNI
+ * Method:    getSolenoidDisplayName
+ * Signature: (II)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_first_hal_simulation_PCMDataJNI_getSolenoidDisplayName
+  (JNIEnv* env, jclass, jint index, jint channel)
+{
+  const char* displayName = HALSIM_GetSolenoidDisplayName(index, channel);
+  return wpi::java::MakeJString(env, displayName);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_PCMDataJNI
+ * Method:    setSolenoidDisplayName
+ * Signature: (IILjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_simulation_PCMDataJNI_setSolenoidDisplayName
+  (JNIEnv* env, jclass, jint index, jint channel, jstring displayName)
+{
+  wpi::java::JStringRef displayNameRef{env, displayName};
+  HALSIM_SetSolenoidDisplayName(index, channel, displayNameRef.c_str());
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_PCMDataJNI
  * Method:    registerSolenoidInitializedCallback
  * Signature: (IILjava/lang/Object;Z)I
  */

--- a/hal/src/main/native/cpp/jni/simulation/PWMDataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/PWMDataJNI.cpp
@@ -17,6 +17,32 @@ extern "C" {
 
 /*
  * Class:     edu_wpi_first_hal_simulation_PWMDataJNI
+ * Method:    getDisplayName
+ * Signature: (I)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_first_hal_simulation_PWMDataJNI_getDisplayName
+  (JNIEnv* env, jclass, jint index)
+{
+  const char* displayName = HALSIM_GetPWMDisplayName(index);
+  return wpi::java::MakeJString(env, displayName);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_PWMDataJNI
+ * Method:    setDisplayName
+ * Signature: (ILjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_simulation_PWMDataJNI_setDisplayName
+  (JNIEnv* env, jclass, jint index, jstring displayName)
+{
+  wpi::java::JStringRef displayNameRef{env, displayName};
+  HALSIM_SetPWMDisplayName(index, displayNameRef.c_str());
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_PWMDataJNI
  * Method:    registerInitializedCallback
  * Signature: (ILjava/lang/Object;Z)I
  */

--- a/hal/src/main/native/cpp/jni/simulation/RelayDataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/RelayDataJNI.cpp
@@ -17,6 +17,32 @@ extern "C" {
 
 /*
  * Class:     edu_wpi_first_hal_simulation_RelayDataJNI
+ * Method:    getDisplayName
+ * Signature: (I)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_first_hal_simulation_RelayDataJNI_getDisplayName
+  (JNIEnv* env, jclass, jint index)
+{
+  const char* displayName = HALSIM_GetRelayDisplayName(index);
+  return wpi::java::MakeJString(env, displayName);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_RelayDataJNI
+ * Method:    setDisplayName
+ * Signature: (ILjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_simulation_RelayDataJNI_setDisplayName
+  (JNIEnv* env, jclass, jint index, jstring displayName)
+{
+  wpi::java::JStringRef displayNameRef{env, displayName};
+  HALSIM_SetRelayDisplayName(index, displayNameRef.c_str());
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_RelayDataJNI
  * Method:    registerInitializedForwardCallback
  * Signature: (ILjava/lang/Object;Z)I
  */

--- a/hal/src/main/native/cpp/jni/simulation/SimDeviceDataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/SimDeviceDataJNI.cpp
@@ -610,4 +610,32 @@ Java_edu_wpi_first_hal_simulation_SimDeviceDataJNI_resetSimDeviceData
   HALSIM_ResetSimDeviceData();
 }
 
+/*
+ * Class:     edu_wpi_first_hal_simulation_SimDeviceDataJNI
+ * Method:    getDisplayName
+ * Signature: (I)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_edu_wpi_first_hal_simulation_SimDeviceDataJNI_getDisplayName
+  (JNIEnv* env, jclass, jint handle)
+{
+  const char* displayName =
+      HALSIM_GetSimDeviceDisplayName(static_cast<HAL_SimValueHandle>(handle));
+  return wpi::java::MakeJString(env, displayName);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_simulation_SimDeviceDataJNI
+ * Method:    setDisplayName
+ * Signature: (ILjava/lang/String;)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_simulation_SimDeviceDataJNI_setDisplayName
+  (JNIEnv* env, jclass, jint handle, jstring displayName)
+{
+  wpi::java::JStringRef displayNameRef{env, displayName};
+  HALSIM_SetSimDeviceDisplayName(static_cast<HAL_SimValueHandle>(handle),
+                                 displayNameRef.c_str());
+}
+
 }  // extern "C"

--- a/hal/src/main/native/include/hal/simulation/AccelerometerData.h
+++ b/hal/src/main/native/include/hal/simulation/AccelerometerData.h
@@ -16,6 +16,10 @@ extern "C" {
 #endif
 
 void HALSIM_ResetAccelerometerData(int32_t index);
+
+const char* HALSIM_GetAccelerometerDisplayName(int32_t index);
+void HALSIM_SetAccelerometerDisplayName(int32_t index, const char* displayName);
+
 int32_t HALSIM_RegisterAccelerometerActiveCallback(int32_t index,
                                                    HAL_NotifyCallback callback,
                                                    void* param,

--- a/hal/src/main/native/include/hal/simulation/AddressableLEDData.h
+++ b/hal/src/main/native/include/hal/simulation/AddressableLEDData.h
@@ -19,6 +19,10 @@ int32_t HALSIM_FindAddressableLEDForChannel(int32_t channel);
 
 void HALSIM_ResetAddressableLEDData(int32_t index);
 
+const char* HALSIM_GetAddressableLEDDisplayName(int32_t index);
+void HALSIM_SetAddressableLEDDisplayName(int32_t index,
+                                         const char* displayName);
+
 int32_t HALSIM_RegisterAddressableLEDInitializedCallback(
     int32_t index, HAL_NotifyCallback callback, void* param,
     HAL_Bool initialNotify);

--- a/hal/src/main/native/include/hal/simulation/AnalogGyroData.h
+++ b/hal/src/main/native/include/hal/simulation/AnalogGyroData.h
@@ -15,6 +15,10 @@ extern "C" {
 #endif
 
 void HALSIM_ResetAnalogGyroData(int32_t index);
+
+const char* HALSIM_GetAnalogGyroDisplayName(int32_t index);
+void HALSIM_SetAnalogGyroDisplayName(int32_t index, const char* displayName);
+
 int32_t HALSIM_RegisterAnalogGyroAngleCallback(int32_t index,
                                                HAL_NotifyCallback callback,
                                                void* param,

--- a/hal/src/main/native/include/hal/simulation/AnalogInData.h
+++ b/hal/src/main/native/include/hal/simulation/AnalogInData.h
@@ -15,6 +15,10 @@ extern "C" {
 #endif
 
 void HALSIM_ResetAnalogInData(int32_t index);
+
+const char* HALSIM_GetAnalogInDisplayName(int32_t index);
+void HALSIM_SetAnalogInDisplayName(int32_t index, const char* displayName);
+
 int32_t HALSIM_RegisterAnalogInInitializedCallback(int32_t index,
                                                    HAL_NotifyCallback callback,
                                                    void* param,

--- a/hal/src/main/native/include/hal/simulation/AnalogOutData.h
+++ b/hal/src/main/native/include/hal/simulation/AnalogOutData.h
@@ -15,6 +15,10 @@ extern "C" {
 #endif
 
 void HALSIM_ResetAnalogOutData(int32_t index);
+
+const char* HALSIM_GetAnalogOutDisplayName(int32_t index);
+void HALSIM_SetAnalogOutDisplayName(int32_t index, const char* displayName);
+
 int32_t HALSIM_RegisterAnalogOutVoltageCallback(int32_t index,
                                                 HAL_NotifyCallback callback,
                                                 void* param,

--- a/hal/src/main/native/include/hal/simulation/DIOData.h
+++ b/hal/src/main/native/include/hal/simulation/DIOData.h
@@ -15,6 +15,10 @@ extern "C" {
 #endif
 
 void HALSIM_ResetDIOData(int32_t index);
+
+const char* HALSIM_GetDIODisplayName(int32_t index);
+void HALSIM_SetDIODisplayName(int32_t index, const char* displayName);
+
 int32_t HALSIM_RegisterDIOInitializedCallback(int32_t index,
                                               HAL_NotifyCallback callback,
                                               void* param,

--- a/hal/src/main/native/include/hal/simulation/EncoderData.h
+++ b/hal/src/main/native/include/hal/simulation/EncoderData.h
@@ -16,6 +16,9 @@ extern "C" {
 
 int32_t HALSIM_FindEncoderForChannel(int32_t channel);
 
+const char* HALSIM_GetEncoderDisplayName(int32_t index);
+void HALSIM_SetEncoderDisplayName(int32_t index, const char* displayName);
+
 void HALSIM_ResetEncoderData(int32_t index);
 int32_t HALSIM_GetEncoderDigitalChannelA(int32_t index);
 int32_t HALSIM_GetEncoderDigitalChannelB(int32_t index);

--- a/hal/src/main/native/include/hal/simulation/PCMData.h
+++ b/hal/src/main/native/include/hal/simulation/PCMData.h
@@ -15,6 +15,11 @@ extern "C" {
 #endif
 
 void HALSIM_ResetPCMData(int32_t index);
+
+const char* HALSIM_GetSolenoidDisplayName(int32_t index, int32_t channel);
+void HALSIM_SetSolenoidDisplayName(int32_t index, int32_t channel,
+                                   const char* displayName);
+
 int32_t HALSIM_RegisterPCMSolenoidInitializedCallback(
     int32_t index, int32_t channel, HAL_NotifyCallback callback, void* param,
     HAL_Bool initialNotify);

--- a/hal/src/main/native/include/hal/simulation/PDPData.h
+++ b/hal/src/main/native/include/hal/simulation/PDPData.h
@@ -15,6 +15,10 @@ extern "C" {
 #endif
 
 void HALSIM_ResetPDPData(int32_t index);
+
+const char* HALSIM_GetPDPDisplayName(int32_t index);
+void HALSIM_SetPDPDisplayName(int32_t index, const char* displayName);
+
 int32_t HALSIM_RegisterPDPInitializedCallback(int32_t index,
                                               HAL_NotifyCallback callback,
                                               void* param,

--- a/hal/src/main/native/include/hal/simulation/PWMData.h
+++ b/hal/src/main/native/include/hal/simulation/PWMData.h
@@ -15,6 +15,10 @@ extern "C" {
 #endif
 
 void HALSIM_ResetPWMData(int32_t index);
+
+const char* HALSIM_GetPWMDisplayName(int32_t index);
+void HALSIM_SetPWMDisplayName(int32_t index, const char* displayName);
+
 int32_t HALSIM_RegisterPWMInitializedCallback(int32_t index,
                                               HAL_NotifyCallback callback,
                                               void* param,

--- a/hal/src/main/native/include/hal/simulation/RelayData.h
+++ b/hal/src/main/native/include/hal/simulation/RelayData.h
@@ -15,6 +15,10 @@ extern "C" {
 #endif
 
 void HALSIM_ResetRelayData(int32_t index);
+
+const char* HALSIM_GetRelayDisplayName(int32_t index);
+void HALSIM_SetRelayDisplayName(int32_t index, const char* displayName);
+
 int32_t HALSIM_RegisterRelayInitializedForwardCallback(
     int32_t index, HAL_NotifyCallback callback, void* param,
     HAL_Bool initialNotify);

--- a/hal/src/main/native/include/hal/simulation/SimDeviceData.h
+++ b/hal/src/main/native/include/hal/simulation/SimDeviceData.h
@@ -39,6 +39,9 @@ void HALSIM_CancelSimDeviceFreedCallback(int32_t uid);
 
 HAL_SimDeviceHandle HALSIM_GetSimDeviceHandle(const char* name);
 
+const char* HALSIM_GetSimDeviceDisplayName(HAL_SimDeviceHandle handle);
+void HALSIM_SetSimDeviceDisplayName(HAL_SimDeviceHandle handle,
+                                    const char* displayName);
 const char* HALSIM_GetSimDeviceName(HAL_SimDeviceHandle handle);
 
 HAL_SimDeviceHandle HALSIM_GetSimValueDeviceHandle(HAL_SimValueHandle handle);

--- a/hal/src/main/native/include/hal/simulation/SimDisplayName.h
+++ b/hal/src/main/native/include/hal/simulation/SimDisplayName.h
@@ -1,0 +1,41 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <cstring>
+#include <functional>
+
+#include <wpi/spinlock.h>
+
+namespace hal {
+
+class SimDisplayName {
+ public:
+  void Reset() {
+    std::scoped_lock lock(m_mutex);
+    displayName[0] = '\0';
+  }
+
+  const char* Get() {
+    std::scoped_lock lock(m_mutex);
+    return displayName;
+  }
+
+  void Set(const char* newDisplayName) {
+    std::scoped_lock lock(m_mutex);
+
+    std::strncpy(displayName, newDisplayName, sizeof(displayName) - 1);
+    *(std::end(displayName) - 1) = '\0';
+  }
+
+ protected:
+  mutable wpi::recursive_spinlock m_mutex;
+  char displayName[256];
+};
+
+}  // namespace hal

--- a/hal/src/main/native/include/hal/simulation/SimDisplayName.h
+++ b/hal/src/main/native/include/hal/simulation/SimDisplayName.h
@@ -21,7 +21,7 @@ class SimDisplayName {
     displayName[0] = '\0';
   }
 
-  const char* Get() {
+  const char* Get() const {
     std::scoped_lock lock(m_mutex);
     return displayName;
   }

--- a/hal/src/main/native/sim/mockdata/AccelerometerData.cpp
+++ b/hal/src/main/native/sim/mockdata/AccelerometerData.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -26,6 +26,7 @@ void AccelerometerData::ResetData() {
   x.Reset(0.0);
   y.Reset(0.0);
   z.Reset(0.0);
+  displayName.Reset();
 }
 
 extern "C" {
@@ -46,6 +47,14 @@ DEFINE_CAPI(double, Z, z)
 #define REGISTER(NAME)                                               \
   SimAccelerometerData[index].NAME.RegisterCallback(callback, param, \
                                                     initialNotify)
+
+const char* HALSIM_GetAccelerometerDisplayName(int32_t index) {
+  return SimAccelerometerData[index].displayName.Get();
+}
+void HALSIM_SetAccelerometerDisplayName(int32_t index,
+                                        const char* displayName) {
+  SimAccelerometerData[index].displayName.Set(displayName);
+}
 
 void HALSIM_RegisterAccelerometerAllCallbacks(int32_t index,
                                               HAL_NotifyCallback callback,

--- a/hal/src/main/native/sim/mockdata/AccelerometerDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/AccelerometerDataInternal.h
@@ -9,6 +9,7 @@
 
 #include "hal/simulation/AccelerometerData.h"
 #include "hal/simulation/SimDataValue.h"
+#include "hal/simulation/SimDisplayName.h"
 
 namespace hal {
 class AccelerometerData {
@@ -23,6 +24,7 @@ class AccelerometerData {
   }
 
  public:
+  SimDisplayName displayName;
   SimDataValue<HAL_Bool, HAL_MakeBoolean, GetActiveName> active{false};
   SimDataValue<HAL_AccelerometerRange, MakeRangeValue, GetRangeName> range{
       static_cast<HAL_AccelerometerRange>(0)};

--- a/hal/src/main/native/sim/mockdata/AddressableLEDData.cpp
+++ b/hal/src/main/native/sim/mockdata/AddressableLEDData.cpp
@@ -30,6 +30,7 @@ void AddressableLEDData::ResetData() {
   length.Reset(1);
   running.Reset(false);
   data.Reset();
+  displayName.Reset();
 }
 
 void AddressableLEDData::SetData(const HAL_AddressableLEDData* d, int32_t len) {
@@ -61,6 +62,14 @@ int32_t HALSIM_FindAddressableLEDForChannel(int32_t channel) {
 
 void HALSIM_ResetAddressableLEDData(int32_t index) {
   SimAddressableLEDData[index].ResetData();
+}
+
+const char* HALSIM_GetAddressableLEDDisplayName(int32_t index) {
+  return SimAddressableLEDData[index].displayName.Get();
+}
+void HALSIM_SetAddressableLEDDisplayName(int32_t index,
+                                         const char* displayName) {
+  SimAddressableLEDData[index].displayName.Set(displayName);
 }
 
 int32_t HALSIM_GetAddressableLEDData(int32_t index,

--- a/hal/src/main/native/sim/mockdata/AddressableLEDDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/AddressableLEDDataInternal.h
@@ -14,6 +14,7 @@
 #include "hal/simulation/AddressableLEDData.h"
 #include "hal/simulation/SimCallbackRegistry.h"
 #include "hal/simulation/SimDataValue.h"
+#include "hal/simulation/SimDisplayName.h"
 
 namespace hal {
 class AddressableLEDData {
@@ -30,6 +31,7 @@ class AddressableLEDData {
   void SetData(const HAL_AddressableLEDData* d, int32_t len);
   int32_t GetData(HAL_AddressableLEDData* d);
 
+  SimDisplayName displayName;
   SimDataValue<HAL_Bool, HAL_MakeBoolean, GetInitializedName> initialized{
       false};
   SimDataValue<int32_t, HAL_MakeInt, GetOutputPortName> outputPort{-1};

--- a/hal/src/main/native/sim/mockdata/AnalogGyroData.cpp
+++ b/hal/src/main/native/sim/mockdata/AnalogGyroData.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -24,6 +24,7 @@ void AnalogGyroData::ResetData() {
   angle.Reset(0.0);
   rate.Reset(0.0);
   initialized.Reset(false);
+  displayName.Reset();
 }
 
 extern "C" {
@@ -34,6 +35,13 @@ void HALSIM_ResetAnalogGyroData(int32_t index) {
 #define DEFINE_CAPI(TYPE, CAPINAME, LOWERNAME)                     \
   HAL_SIMDATAVALUE_DEFINE_CAPI(TYPE, HALSIM, AnalogGyro##CAPINAME, \
                                SimAnalogGyroData, LOWERNAME)
+
+const char* HALSIM_GetAnalogGyroDisplayName(int32_t index) {
+  return SimAnalogGyroData[index].displayName.Get();
+}
+void HALSIM_SetAnalogGyroDisplayName(int32_t index, const char* displayName) {
+  SimAnalogGyroData[index].displayName.Set(displayName);
+}
 
 DEFINE_CAPI(double, Angle, angle)
 DEFINE_CAPI(double, Rate, rate)

--- a/hal/src/main/native/sim/mockdata/AnalogGyroDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/AnalogGyroDataInternal.h
@@ -9,6 +9,7 @@
 
 #include "hal/simulation/AnalogGyroData.h"
 #include "hal/simulation/SimDataValue.h"
+#include "hal/simulation/SimDisplayName.h"
 
 namespace hal {
 class AnalogGyroData {
@@ -17,6 +18,7 @@ class AnalogGyroData {
   HAL_SIMDATAVALUE_DEFINE_NAME(Initialized)
 
  public:
+  SimDisplayName displayName;
   SimDataValue<double, HAL_MakeDouble, GetAngleName> angle{0.0};
   SimDataValue<double, HAL_MakeDouble, GetRateName> rate{0.0};
   SimDataValue<HAL_Bool, HAL_MakeBoolean, GetInitializedName> initialized{

--- a/hal/src/main/native/sim/mockdata/AnalogInData.cpp
+++ b/hal/src/main/native/sim/mockdata/AnalogInData.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -31,6 +31,7 @@ void AnalogInData::ResetData() {
   accumulatorCount.Reset(0);
   accumulatorCenter.Reset(0);
   accumulatorDeadband.Reset(0);
+  displayName.Reset();
 }
 
 extern "C" {
@@ -46,6 +47,12 @@ HAL_SimDeviceHandle HALSIM_GetAnalogInSimDevice(int32_t index) {
   HAL_SIMDATAVALUE_DEFINE_CAPI(TYPE, HALSIM, AnalogIn##CAPINAME, \
                                SimAnalogInData, LOWERNAME)
 
+const char* HALSIM_GetAnalogInDisplayName(int32_t index) {
+  return SimAnalogInData[index].displayName.Get();
+}
+void HALSIM_SetAnalogInDisplayName(int32_t index, const char* displayName) {
+  SimAnalogInData[index].displayName.Set(displayName);
+}
 DEFINE_CAPI(HAL_Bool, Initialized, initialized)
 DEFINE_CAPI(int32_t, AverageBits, averageBits)
 DEFINE_CAPI(int32_t, OversampleBits, oversampleBits)

--- a/hal/src/main/native/sim/mockdata/AnalogInDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/AnalogInDataInternal.h
@@ -9,6 +9,7 @@
 
 #include "hal/simulation/AnalogInData.h"
 #include "hal/simulation/SimDataValue.h"
+#include "hal/simulation/SimDisplayName.h"
 
 namespace hal {
 class AnalogInData {
@@ -23,6 +24,7 @@ class AnalogInData {
   HAL_SIMDATAVALUE_DEFINE_NAME(AccumulatorDeadband)
 
  public:
+  SimDisplayName displayName;
   SimDataValue<HAL_Bool, HAL_MakeBoolean, GetInitializedName> initialized{
       false};
   std::atomic<HAL_SimDeviceHandle> simDevice;

--- a/hal/src/main/native/sim/mockdata/AnalogOutData.cpp
+++ b/hal/src/main/native/sim/mockdata/AnalogOutData.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -23,6 +23,7 @@ AnalogOutData* hal::SimAnalogOutData;
 void AnalogOutData::ResetData() {
   voltage.Reset(0.0);
   initialized.Reset(0);
+  displayName.Reset();
 }
 
 extern "C" {
@@ -34,6 +35,12 @@ void HALSIM_ResetAnalogOutData(int32_t index) {
   HAL_SIMDATAVALUE_DEFINE_CAPI(TYPE, HALSIM, AnalogOut##CAPINAME, \
                                SimAnalogOutData, LOWERNAME)
 
+const char* HALSIM_GetAnalogOutDisplayName(int32_t index) {
+  return SimAnalogOutData[index].displayName.Get();
+}
+void HALSIM_SetAnalogOutDisplayName(int32_t index, const char* displayName) {
+  SimAnalogOutData[index].displayName.Set(displayName);
+}
 DEFINE_CAPI(double, Voltage, voltage)
 DEFINE_CAPI(HAL_Bool, Initialized, initialized)
 

--- a/hal/src/main/native/sim/mockdata/AnalogOutDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/AnalogOutDataInternal.h
@@ -9,6 +9,7 @@
 
 #include "hal/simulation/AnalogOutData.h"
 #include "hal/simulation/SimDataValue.h"
+#include "hal/simulation/SimDisplayName.h"
 
 namespace hal {
 class AnalogOutData {
@@ -16,6 +17,7 @@ class AnalogOutData {
   HAL_SIMDATAVALUE_DEFINE_NAME(Initialized)
 
  public:
+  SimDisplayName displayName;
   SimDataValue<double, HAL_MakeDouble, GetVoltageName> voltage{0.0};
   SimDataValue<HAL_Bool, HAL_MakeBoolean, GetInitializedName> initialized{0};
 

--- a/hal/src/main/native/sim/mockdata/DIOData.cpp
+++ b/hal/src/main/native/sim/mockdata/DIOData.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -27,6 +27,7 @@ void DIOData::ResetData() {
   pulseLength.Reset(0.0);
   isInput.Reset(true);
   filterIndex.Reset(-1);
+  displayName.Reset();
 }
 
 extern "C" {
@@ -39,6 +40,13 @@ HAL_SimDeviceHandle HALSIM_GetDIOSimDevice(int32_t index) {
 #define DEFINE_CAPI(TYPE, CAPINAME, LOWERNAME)                          \
   HAL_SIMDATAVALUE_DEFINE_CAPI(TYPE, HALSIM, DIO##CAPINAME, SimDIOData, \
                                LOWERNAME)
+
+const char* HALSIM_GetDIODisplayName(int32_t index) {
+  return SimDIOData[index].displayName.Get();
+}
+void HALSIM_SetDIODisplayName(int32_t index, const char* displayName) {
+  SimDIOData[index].displayName.Set(displayName);
+}
 
 DEFINE_CAPI(HAL_Bool, Initialized, initialized)
 DEFINE_CAPI(HAL_Bool, Value, value)

--- a/hal/src/main/native/sim/mockdata/DIODataInternal.h
+++ b/hal/src/main/native/sim/mockdata/DIODataInternal.h
@@ -9,6 +9,7 @@
 
 #include "hal/simulation/DIOData.h"
 #include "hal/simulation/SimDataValue.h"
+#include "hal/simulation/SimDisplayName.h"
 
 namespace hal {
 class DIOData {
@@ -19,6 +20,7 @@ class DIOData {
   HAL_SIMDATAVALUE_DEFINE_NAME(FilterIndex)
 
  public:
+  SimDisplayName displayName;
   SimDataValue<HAL_Bool, HAL_MakeBoolean, GetInitializedName> initialized{
       false};
   std::atomic<HAL_SimDeviceHandle> simDevice;

--- a/hal/src/main/native/sim/mockdata/EncoderData.cpp
+++ b/hal/src/main/native/sim/mockdata/EncoderData.cpp
@@ -33,6 +33,7 @@ void EncoderData::ResetData() {
   reverseDirection.Reset(false);
   samplesToAverage.Reset(0);
   distancePerPulse.Reset(1);
+  displayName.Reset();
 }
 
 extern "C" {
@@ -44,6 +45,13 @@ int32_t HALSIM_FindEncoderForChannel(int32_t channel) {
       return i;
   }
   return -1;
+}
+
+const char* HALSIM_GetEncoderDisplayName(int32_t index) {
+  return SimEncoderData[index].displayName.Get();
+}
+void HALSIM_SetEncoderDisplayName(int32_t index, const char* displayName) {
+  SimEncoderData[index].displayName.Set(displayName);
 }
 
 void HALSIM_ResetEncoderData(int32_t index) {

--- a/hal/src/main/native/sim/mockdata/EncoderDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/EncoderDataInternal.h
@@ -12,6 +12,7 @@
 
 #include "hal/simulation/EncoderData.h"
 #include "hal/simulation/SimDataValue.h"
+#include "hal/simulation/SimDisplayName.h"
 
 namespace hal {
 class EncoderData {
@@ -26,6 +27,7 @@ class EncoderData {
   HAL_SIMDATAVALUE_DEFINE_NAME(DistancePerPulse)
 
  public:
+  SimDisplayName displayName;
   std::atomic<int32_t> digitalChannelA{0};
   std::atomic<int32_t> digitalChannelB{0};
   SimDataValue<HAL_Bool, HAL_MakeBoolean, GetInitializedName> initialized{

--- a/hal/src/main/native/sim/mockdata/PCMData.cpp
+++ b/hal/src/main/native/sim/mockdata/PCMData.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -24,6 +24,7 @@ void PCMData::ResetData() {
   for (int i = 0; i < kNumSolenoidChannels; i++) {
     solenoidInitialized[i].Reset(false);
     solenoidOutput[i].Reset(false);
+    solenoidDisplayName[i].Reset();
   }
   compressorInitialized.Reset(false);
   compressorOn.Reset(false);
@@ -48,6 +49,15 @@ DEFINE_CAPI(HAL_Bool, CompressorOn, compressorOn)
 DEFINE_CAPI(HAL_Bool, ClosedLoopEnabled, closedLoopEnabled)
 DEFINE_CAPI(HAL_Bool, PressureSwitch, pressureSwitch)
 DEFINE_CAPI(double, CompressorCurrent, compressorCurrent)
+
+const char* HALSIM_GetSolenoidDisplayName(int32_t index, int32_t channel) {
+  return SimPCMData[index].solenoidDisplayName[channel].Get();
+}
+
+void HALSIM_SetSolenoidDisplayName(int32_t index, int32_t channel,
+                                   const char* displayName) {
+  SimPCMData[index].solenoidDisplayName[channel].Set(displayName);
+}
 
 void HALSIM_GetPCMAllSolenoids(int32_t index, uint8_t* values) {
   auto& data = SimPCMData[index].solenoidOutput;

--- a/hal/src/main/native/sim/mockdata/PCMDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/PCMDataInternal.h
@@ -10,6 +10,7 @@
 #include "../PortsInternal.h"
 #include "hal/simulation/PCMData.h"
 #include "hal/simulation/SimDataValue.h"
+#include "hal/simulation/SimDisplayName.h"
 
 namespace hal {
 class PCMData {
@@ -31,6 +32,8 @@ class PCMData {
   }
 
  public:
+  SimDisplayName solenoidDisplayName[kNumSolenoidChannels];
+
   SimDataValue<HAL_Bool, HAL_MakeBoolean, GetSolenoidInitializedName,
                GetSolenoidInitializedDefault>
       solenoidInitialized[kNumSolenoidChannels];

--- a/hal/src/main/native/sim/mockdata/PDPData.cpp
+++ b/hal/src/main/native/sim/mockdata/PDPData.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2019 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -55,6 +55,12 @@ void HALSIM_SetPDPAllCurrents(int32_t index, const double* currents) {
     data[i] = currents[i];
   }
 }
+
+const char* HALSIM_GetPDPDisplayName(int32_t index) {
+  return SimPDPData[index].displayName.Get();
+}
+
+void HALSIM_SetPDPDisplayName(int32_t index, const char* displayName) {}
 
 #define REGISTER(NAME) \
   SimPDPData[index].NAME.RegisterCallback(callback, param, initialNotify)

--- a/hal/src/main/native/sim/mockdata/PDPDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/PDPDataInternal.h
@@ -10,6 +10,7 @@
 #include "../PortsInternal.h"
 #include "hal/simulation/PDPData.h"
 #include "hal/simulation/SimDataValue.h"
+#include "hal/simulation/SimDisplayName.h"
 
 namespace hal {
 class PDPData {
@@ -23,6 +24,7 @@ class PDPData {
   }
 
  public:
+  SimDisplayName displayName;
   SimDataValue<HAL_Bool, HAL_MakeBoolean, GetInitializedName> initialized{
       false};
   SimDataValue<double, HAL_MakeDouble, GetTemperatureName> temperature{0.0};

--- a/hal/src/main/native/sim/mockdata/PWMData.cpp
+++ b/hal/src/main/native/sim/mockdata/PWMData.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -27,6 +27,7 @@ void PWMData::ResetData() {
   position.Reset(0);
   periodScale.Reset(0);
   zeroLatch.Reset(false);
+  displayName.Reset();
 }
 
 extern "C" {
@@ -35,6 +36,13 @@ void HALSIM_ResetPWMData(int32_t index) { SimPWMData[index].ResetData(); }
 #define DEFINE_CAPI(TYPE, CAPINAME, LOWERNAME)                          \
   HAL_SIMDATAVALUE_DEFINE_CAPI(TYPE, HALSIM, PWM##CAPINAME, SimPWMData, \
                                LOWERNAME)
+
+const char* HALSIM_GetPWMDisplayName(int32_t index) {
+  return SimPWMData[index].displayName.Get();
+}
+void HALSIM_SetPWMDisplayName(int32_t index, const char* displayName) {
+  SimPWMData[index].displayName.Set(displayName);
+}
 
 DEFINE_CAPI(HAL_Bool, Initialized, initialized)
 DEFINE_CAPI(int32_t, RawValue, rawValue)

--- a/hal/src/main/native/sim/mockdata/PWMDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/PWMDataInternal.h
@@ -9,6 +9,7 @@
 
 #include "hal/simulation/PWMData.h"
 #include "hal/simulation/SimDataValue.h"
+#include "hal/simulation/SimDisplayName.h"
 
 namespace hal {
 class PWMData {
@@ -20,6 +21,7 @@ class PWMData {
   HAL_SIMDATAVALUE_DEFINE_NAME(ZeroLatch)
 
  public:
+  SimDisplayName displayName;
   SimDataValue<HAL_Bool, HAL_MakeBoolean, GetInitializedName> initialized{
       false};
   SimDataValue<int32_t, HAL_MakeInt, GetRawValueName> rawValue{0};

--- a/hal/src/main/native/sim/mockdata/RelayData.cpp
+++ b/hal/src/main/native/sim/mockdata/RelayData.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*/
-/* Copyright (c) 2017-2018 FIRST. All Rights Reserved.                        */
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
 /* Open Source Software - may be modified and shared by FRC teams. The code   */
 /* must be accompanied by the FIRST BSD license file in the root directory of */
 /* the project.                                                               */
@@ -25,6 +25,7 @@ void RelayData::ResetData() {
   initializedReverse.Reset(false);
   forward.Reset(false);
   reverse.Reset(false);
+  displayName.Reset();
 }
 
 extern "C" {
@@ -33,6 +34,13 @@ void HALSIM_ResetRelayData(int32_t index) { SimRelayData[index].ResetData(); }
 #define DEFINE_CAPI(TYPE, CAPINAME, LOWERNAME)                              \
   HAL_SIMDATAVALUE_DEFINE_CAPI(TYPE, HALSIM, Relay##CAPINAME, SimRelayData, \
                                LOWERNAME)
+
+const char* HALSIM_GetRelayDisplayName(int32_t index) {
+  return SimRelayData[index].displayName.Get();
+}
+void HALSIM_SetRelayDisplayName(int32_t index, const char* displayName) {
+  SimRelayData[index].displayName.Set(displayName);
+}
 
 DEFINE_CAPI(HAL_Bool, InitializedForward, initializedForward)
 DEFINE_CAPI(HAL_Bool, InitializedReverse, initializedReverse)

--- a/hal/src/main/native/sim/mockdata/RelayDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/RelayDataInternal.h
@@ -9,6 +9,7 @@
 
 #include "hal/simulation/RelayData.h"
 #include "hal/simulation/SimDataValue.h"
+#include "hal/simulation/SimDisplayName.h"
 
 namespace hal {
 class RelayData {
@@ -18,6 +19,7 @@ class RelayData {
   HAL_SIMDATAVALUE_DEFINE_NAME(Reverse)
 
  public:
+  SimDisplayName displayName;
   SimDataValue<HAL_Bool, HAL_MakeBoolean, GetInitializedForwardName>
       initializedForward{false};
   SimDataValue<HAL_Bool, HAL_MakeBoolean, GetInitializedReverseName>

--- a/hal/src/main/native/sim/mockdata/SimDeviceData.cpp
+++ b/hal/src/main/native/sim/mockdata/SimDeviceData.cpp
@@ -251,6 +251,27 @@ const char* SimDeviceData::GetDeviceName(HAL_SimDeviceHandle handle) {
   return deviceImpl->name.c_str();
 }
 
+const char* SimDeviceData::GetDeviceDisplayName(HAL_SimDeviceHandle handle) {
+  std::scoped_lock lock(m_mutex);
+
+  // look up device
+  Device* deviceImpl = LookupDevice(handle);
+  if (!deviceImpl) return nullptr;
+
+  return deviceImpl->displayName.c_str();
+}
+
+void SimDeviceData::SetDeviceDisplayName(HAL_SimDeviceHandle handle,
+                                         const char* newDeviceName) {
+  std::scoped_lock lock(m_mutex);
+
+  // look up device
+  Device* deviceImpl = LookupDevice(handle);
+  if (deviceImpl) {
+    deviceImpl->name = newDeviceName;
+  }
+}
+
 void SimDeviceData::EnumerateDevices(const char* prefix, void* param,
                                      HALSIM_SimDeviceCallback callback) {
   std::scoped_lock lock(m_mutex);
@@ -401,6 +422,14 @@ HAL_SimDeviceHandle HALSIM_GetSimDeviceHandle(const char* name) {
 
 const char* HALSIM_GetSimDeviceName(HAL_SimDeviceHandle handle) {
   return SimSimDeviceData->GetDeviceName(handle);
+}
+
+const char* HALSIM_GetSimDeviceDisplayName(HAL_SimDeviceHandle handle) {
+  return SimSimDeviceData->GetDeviceDisplayName(handle);
+}
+void HALSIM_SetSimDeviceDisplayName(HAL_SimDeviceHandle handle,
+                                    const char* displayName) {
+  SimSimDeviceData->SetDeviceDisplayName(handle, displayName);
 }
 
 HAL_SimDeviceHandle HALSIM_GetSimValueDeviceHandle(HAL_SimValueHandle handle) {

--- a/hal/src/main/native/sim/mockdata/SimDeviceDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/SimDeviceDataInternal.h
@@ -143,6 +143,7 @@ class SimDeviceData {
 
     HAL_SimDeviceHandle handle{0};
     std::string name;
+    std::string displayName;
     wpi::UidVector<std::unique_ptr<Value>, 16> values;
     wpi::StringMap<Value*> valueMap;
     impl::SimUnnamedCallbackRegistry<HALSIM_SimValueCallback> valueCreated;
@@ -187,6 +188,10 @@ class SimDeviceData {
 
   HAL_SimDeviceHandle GetDeviceHandle(const char* name);
   const char* GetDeviceName(HAL_SimDeviceHandle handle);
+
+  const char* GetDeviceDisplayName(HAL_SimDeviceHandle handle);
+  void SetDeviceDisplayName(HAL_SimDeviceHandle handle,
+                            const char* newDeviceName);
 
   void EnumerateDevices(const char* prefix, void* param,
                         HALSIM_SimDeviceCallback callback);

--- a/simulation/halsim_gui/src/main/native/cpp/AccelerometerGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/AccelerometerGui.cpp
@@ -39,7 +39,8 @@ static void UpdateAccelSources() {
 
 static void DisplayAccelerometers() {
   if (!HALSIM_GetAccelerometerActive(0)) return;
-  if (SimDeviceGui::StartDevice("BuiltInAccel")) {
+  if (SimDeviceGui::StartDevice("BuiltInAccel",
+                                HALSIM_GetAccelerometerDisplayName(0))) {
     HAL_Value value;
 
     // Range

--- a/simulation/halsim_gui/src/main/native/cpp/AnalogGyroGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/AnalogGyroGui.cpp
@@ -52,7 +52,7 @@ static void DisplayAnalogGyros() {
     if (auto source = gAnalogGyroSources[i].get()) {
       char name[32];
       std::snprintf(name, sizeof(name), "AnalogGyro[%d]", i);
-      if (SimDeviceGui::StartDevice(name)) {
+      if (SimDeviceGui::StartDevice(name, HALSIM_GetAnalogGyroDisplayName(i))) {
         HAL_Value value;
 
         // angle

--- a/simulation/halsim_gui/src/main/native/cpp/AnalogInputGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/AnalogInputGui.cpp
@@ -25,10 +25,24 @@ using namespace halsimgui;
 
 namespace {
 HALSIMGUI_DATASOURCE_DOUBLE_INDEXED(AnalogInVoltage, "AIn");
+
+class AnalogInNameAccessor {
+ public:
+  void GetLabel(char* buf, size_t size, const char* defaultName,
+                int index) const {
+    const char* displayName = HALSIM_GetAnalogInDisplayName(index);
+    if (displayName[0] != '\0') {
+      std::snprintf(buf, size, "%s", displayName);
+    } else {
+      std::snprintf(buf, size, "%s[%d]###Name%d", defaultName, index, index);
+    }
+  }
+};
+
 }  // namespace
 
 // indexed by channel
-static IniSaver<NameInfo> gAnalogInputs{"AnalogInput"};
+static std::vector<AnalogInNameAccessor> gAnalogInputs;
 static std::vector<std::unique_ptr<AnalogInVoltageSource>> gAnalogInputSources;
 
 static void UpdateAnalogInputSources() {
@@ -37,7 +51,6 @@ static void UpdateAnalogInputSources() {
     if (HALSIM_GetAnalogInInitialized(i)) {
       if (!source) {
         source = std::make_unique<AnalogInVoltageSource>(i);
-        source->SetName(gAnalogInputs[i].GetName());
       }
     } else {
       source.reset();
@@ -81,10 +94,6 @@ static void DisplayAnalogInputs() {
           HALSIM_SetAnalogInVoltage(i, val);
       }
 
-      // context menu to change name
-      if (info.PopupEditName(i)) {
-        source->SetName(info.GetName());
-      }
       ImGui::PopID();
     }
   }
@@ -92,7 +101,7 @@ static void DisplayAnalogInputs() {
 }
 
 void AnalogInputGui::Initialize() {
-  gAnalogInputs.Initialize();
+  gAnalogInputs.resize(HAL_GetNumAnalogInputs());
   gAnalogInputSources.resize(HAL_GetNumAnalogInputs());
 
   HALSimGui::AddExecute(UpdateAnalogInputSources);

--- a/simulation/halsim_gui/src/main/native/cpp/CompressorGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/CompressorGui.cpp
@@ -57,7 +57,7 @@ static void DisplayCompressors() {
     if (auto source = gCompressorSources[i].get()) {
       char name[32];
       std::snprintf(name, sizeof(name), "Compressor[%d]", i);
-      if (SimDeviceGui::StartDevice(name)) {
+      if (SimDeviceGui::StartDevice(name, name)) {
         HAL_Value value;
 
         // enabled

--- a/simulation/halsim_gui/src/main/native/cpp/DIOGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/DIOGui.cpp
@@ -29,9 +29,23 @@ namespace {
 HALSIMGUI_DATASOURCE_BOOLEAN_INDEXED(DIOValue, "DIO");
 HALSIMGUI_DATASOURCE_DOUBLE_INDEXED(DigitalPWMDutyCycle, "DPWM");
 HALSIMGUI_DATASOURCE_DOUBLE_INDEXED(DutyCycleOutput, "DutyCycle");
+
+class DigitalIONameAccessor {
+ public:
+  void GetLabel(char* buf, size_t size, const char* defaultName,
+                int index) const {
+    const char* displayName = HALSIM_GetDIODisplayName(index);
+    if (displayName[0] != '\0') {
+      std::snprintf(buf, size, "%s", displayName);
+    } else {
+      std::snprintf(buf, size, "%s[%d]###Name%d", defaultName, index, index);
+    }
+  }
+};
+
 }  // namespace
 
-static IniSaver<NameInfo> gDIO{"DIO"};
+static std::vector<DigitalIONameAccessor> gDIO;
 static std::vector<std::unique_ptr<DIOValueSource>> gDIOSources;
 static std::vector<std::unique_ptr<DigitalPWMDutyCycleSource>> gDPWMSources;
 static std::vector<std::unique_ptr<DutyCycleOutputSource>> gDutyCycleSources;
@@ -48,7 +62,6 @@ static void UpdateDIOSources() {
     if (HALSIM_GetDIOInitialized(i)) {
       if (!source) {
         source = std::make_unique<DIOValueSource>(i);
-        source->SetName(gDIO[i].GetName());
       }
     } else {
       source.reset();
@@ -65,7 +78,6 @@ static void UpdateDPWMSources() {
         int channel = HALSIM_GetDigitalPWMPin(i);
         if (channel >= 0 && channel < numDIO) {
           source = std::make_unique<DigitalPWMDutyCycleSource>(i, channel);
-          source->SetName(gDIO[channel].GetName());
         }
       }
     } else {
@@ -83,7 +95,6 @@ static void UpdateDutyCycleSources() {
         int channel = HALSIM_GetDutyCycleDigitalChannel(i);
         if (channel >= 0 && channel < numDIO) {
           source = std::make_unique<DutyCycleOutputSource>(i, channel);
-          source->SetName(gDIO[channel].GetName());
         }
       }
     } else {
@@ -188,11 +199,6 @@ static void DisplayDIO() {
             HALSIM_SetDIOValue(i, val);
         }
       }
-      if (info.PopupEditName(i)) {
-        dioSource->SetName(info.GetName());
-        if (dpwmSource) dpwmSource->SetName(info.GetName());
-        if (dutyCycleSource) dutyCycleSource->SetName(info.GetName());
-      }
       ImGui::PopID();
     }
   }
@@ -201,7 +207,7 @@ static void DisplayDIO() {
 }
 
 void DIOGui::Initialize() {
-  gDIO.Initialize();
+  gDIO.resize(HAL_GetNumDigitalChannels());
   gDIOSources.resize(HAL_GetNumDigitalChannels());
   gDPWMSources.resize(HAL_GetNumDigitalPWMOutputs());
   gDutyCycleSources.resize(HAL_GetNumDutyCycles());

--- a/simulation/halsim_gui/src/main/native/cpp/EncoderGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/EncoderGui.cpp
@@ -25,16 +25,26 @@ using namespace halsimgui;
 
 namespace {
 
-struct EncoderInfo : public NameInfo, public OpenInfo {
+class EncoderNameAccessor {
+ public:
+  void GetLabel(char* buf, size_t size, const char* defaultName, int index,
+                int channelA, int channelB) const {
+    const char* displayName = HALSIM_GetEncoderDisplayName(index);
+    if (displayName[0] != '\0') {
+      std::snprintf(buf, size, "%s", displayName);
+    } else {
+      std::snprintf(buf, size, "%s[%d,%d]###Name%d", defaultName, channelA,
+                    channelB, index);
+    }
+  }
+};
+
+struct EncoderInfo : public EncoderNameAccessor, public OpenInfo {
   bool ReadIni(wpi::StringRef name, wpi::StringRef value) {
-    if (NameInfo::ReadIni(name, value)) return true;
     if (OpenInfo::ReadIni(name, value)) return true;
     return false;
   }
-  void WriteIni(ImGuiTextBuffer* out) {
-    NameInfo::WriteIni(out);
-    OpenInfo::WriteIni(out);
-  }
+  void WriteIni(ImGuiTextBuffer* out) { OpenInfo::WriteIni(out); }
 };
 
 class EncoderSource {
@@ -183,7 +193,6 @@ static void UpdateEncoderSources() {
     if (HALSIM_GetEncoderInitialized(i)) {
       if (!source) {
         source = std::make_unique<EncoderSource>(i);
-        source->SetName(gEncoders[source->GetChannelA()].GetName());
       }
     } else {
       source.reset();
@@ -208,17 +217,12 @@ static void DisplayEncoders() {
         // build header name
         auto& info = gEncoders[chA];
         char name[128];
-        info.GetLabel(name, sizeof(name), "Encoder", chA, chB);
+        info.GetLabel(name, sizeof(name), "Encoder", i, chA, chB);
 
         // header
         bool open = ImGui::CollapsingHeader(
             name, gEncoders[chA].IsOpen() ? ImGuiTreeNodeFlags_DefaultOpen : 0);
         info.SetOpen(open);
-
-        // context menu to change name
-        if (info.PopupEditName(chA)) {
-          source->SetName(info.GetName());
-        }
 
         if (open) {
           ImGui::PushID(i);

--- a/simulation/halsim_gui/src/main/native/cpp/SimDeviceGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/SimDeviceGui.cpp
@@ -10,6 +10,7 @@
 #include <stdint.h>
 
 #include <functional>
+#include <iostream>
 #include <memory>
 #include <vector>
 
@@ -27,21 +28,15 @@ using namespace halsimgui;
 
 namespace {
 
-struct ElementInfo : public OpenInfo {
+struct ElementInfo : public NameInfo, public OpenInfo {
   bool ReadIni(wpi::StringRef name, wpi::StringRef value) {
+    if (NameInfo::ReadIni(name, value)) return true;
     if (OpenInfo::ReadIni(name, value)) return true;
     return false;
   }
-  void WriteIni(ImGuiTextBuffer* out) { OpenInfo::WriteIni(out); }
-
-  const char* GetDisplayName(const char* defaultName,
-                             HAL_SimDeviceHandle handle) const {
-    const char* displayName = HALSIM_GetSimDeviceDisplayName(handle);
-    if (displayName[0] == '\0') {
-      return defaultName;
-    } else {
-      return displayName;
-    }
+  void WriteIni(ImGuiTextBuffer* out) {
+    NameInfo::WriteIni(out);
+    OpenInfo::WriteIni(out);
   }
 
   bool visible = true;  // not saved
@@ -108,10 +103,16 @@ bool SimDeviceGui::StartDevice(const char* label, const char* displayName,
   auto& element = gElements[label];
   if (!element.visible) return false;
 
+  char name[128];
+  element.GetLabel(name, sizeof(name), label);
+
+  const char* nameToUse = displayName[0] != '\0' ? displayName : name;
+
   bool open = ImGui::CollapsingHeader(
-      displayName,
+      nameToUse,
       flags | (element.IsOpen() ? ImGuiTreeNodeFlags_DefaultOpen : 0));
   element.SetOpen(open);
+  element.PopupEditName(label);
 
   if (open) ImGui::PushID(label);
   return open;
@@ -250,7 +251,7 @@ static void SimDeviceDisplayDevice(const char* name, void*,
   auto it = gElements.find(name);
   if (it != gElements.end() && !it->second.visible) return;
 
-  const char* displayName = it->second.GetDisplayName(name, handle);
+  const char* displayName = HALSIM_GetSimDeviceDisplayName(handle);
 
   if (SimDeviceGui::StartDevice(name, displayName)) {
     ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.5f);

--- a/simulation/halsim_gui/src/main/native/include/SimDeviceGui.h
+++ b/simulation/halsim_gui/src/main/native/include/SimDeviceGui.h
@@ -26,8 +26,6 @@ HAL_Bool HALSIMGUI_DeviceTreeDisplayValue(const char* name, HAL_Bool readonly,
                                           struct HAL_Value* value,
                                           const char** options,
                                           int32_t numOptions);
-HAL_Bool HALSIMGUI_DeviceTreeStartDevice(const char* label, int32_t flags);
-void HALSIMGUI_DeviceTreeFinishDevice(void);
 
 }  // extern "C"
 
@@ -96,7 +94,8 @@ class SimDeviceGui {
    * @param flags ImGuiTreeNodeFlags flags
    * @return True if expanded
    */
-  static bool StartDevice(const char* label, ImGuiTreeNodeFlags flags = 0);
+  static bool StartDevice(const char* label, const char* displayName,
+                          ImGuiTreeNodeFlags flags = 0);
 
   /**
    * Finish a device block started with StartDevice().

--- a/wpilibc/src/main/native/cpp/simulation/SimDeviceSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/SimDeviceSim.cpp
@@ -19,6 +19,13 @@ using namespace frc::sim;
 SimDeviceSim::SimDeviceSim(const char* name)
     : m_handle{HALSIM_GetSimDeviceHandle(name)} {}
 
+const char* SimDeviceSim::GetDisplayName() const {
+  return HALSIM_GetSimDeviceDisplayName(m_handle);
+}
+void SimDeviceSim::SetDisplayName(const char* displayName) {
+  HALSIM_SetSimDeviceDisplayName(m_handle, displayName);
+}
+
 hal::SimValue SimDeviceSim::GetValue(const char* name) const {
   return HALSIM_GetSimValueHandle(m_handle, name);
 }

--- a/wpilibc/src/main/native/include/frc/simulation/AnalogGyroSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/AnalogGyroSim.h
@@ -36,6 +36,9 @@ class AnalogGyroSim {
    */
   explicit AnalogGyroSim(int channel);
 
+  void setDisplayName(const char* displayName);
+  const char* getDisplayName();
+
   std::unique_ptr<CallbackStore> RegisterAngleCallback(NotifyCallback callback,
                                                        bool initialNotify);
 

--- a/wpilibc/src/main/native/include/frc/simulation/AnalogInputSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/AnalogInputSim.h
@@ -36,6 +36,9 @@ class AnalogInputSim {
    */
   explicit AnalogInputSim(int channel);
 
+  void setDisplayName(const char* displayName);
+  const char* getDisplayName();
+
   std::unique_ptr<CallbackStore> RegisterInitializedCallback(
       NotifyCallback callback, bool initialNotify);
 

--- a/wpilibc/src/main/native/include/frc/simulation/AnalogOutputSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/AnalogOutputSim.h
@@ -36,6 +36,9 @@ class AnalogOutputSim {
    */
   explicit AnalogOutputSim(int channel);
 
+  void setDisplayName(const char* displayName);
+  const char* getDisplayName();
+
   std::unique_ptr<CallbackStore> RegisterVoltageCallback(
       NotifyCallback callback, bool initialNotify);
 

--- a/wpilibc/src/main/native/include/frc/simulation/DIOSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/DIOSim.h
@@ -44,6 +44,9 @@ class DIOSim {
    */
   explicit DIOSim(int channel);
 
+  void setDisplayName(const char* displayName);
+  const char* getDisplayName();
+
   std::unique_ptr<CallbackStore> RegisterInitializedCallback(
       NotifyCallback callback, bool initialNotify);
 

--- a/wpilibc/src/main/native/include/frc/simulation/EncoderSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/EncoderSim.h
@@ -48,6 +48,9 @@ class EncoderSim {
    */
   static EncoderSim CreateForIndex(int index);
 
+  void setDisplayName(const char* displayName);
+  const char* getDisplayName();
+
   std::unique_ptr<CallbackStore> RegisterInitializedCallback(
       NotifyCallback callback, bool initialNotify);
 

--- a/wpilibc/src/main/native/include/frc/simulation/PWMSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/PWMSim.h
@@ -36,6 +36,9 @@ class PWMSim {
    */
   explicit PWMSim(int channel);
 
+  void setDisplayName(const char* displayName);
+  const char* getDisplayName();
+
   std::unique_ptr<CallbackStore> RegisterInitializedCallback(
       NotifyCallback callback, bool initialNotify);
 

--- a/wpilibc/src/main/native/include/frc/simulation/RelaySim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/RelaySim.h
@@ -36,6 +36,9 @@ class RelaySim {
    */
   explicit RelaySim(int channel);
 
+  void setDisplayName(const char* displayName);
+  const char* getDisplayName();
+
   std::unique_ptr<CallbackStore> RegisterInitializedForwardCallback(
       NotifyCallback callback, bool initialNotify);
 

--- a/wpilibc/src/main/native/include/frc/simulation/SimDeviceSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/SimDeviceSim.h
@@ -29,6 +29,9 @@ class SimDeviceSim {
    */
   explicit SimDeviceSim(const char* name);
 
+  const char* GetDisplayName() const;
+  void SetDisplayName(const char* displayName);
+
   hal::SimValue GetValue(const char* name) const;
 
   hal::SimDouble GetDouble(const char* name) const;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADXRS450_GyroSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADXRS450_GyroSim.java
@@ -15,6 +15,7 @@ import edu.wpi.first.wpilibj.ADXRS450_Gyro;
  */
 @SuppressWarnings("TypeName")
 public class ADXRS450_GyroSim {
+  private final SimDeviceSim m_wrappedSimDevice;
   private final SimDouble m_simAngle;
   private final SimDouble m_simRate;
 
@@ -24,9 +25,13 @@ public class ADXRS450_GyroSim {
    * @param gyro ADXRS450_Gyro to simulate
    */
   public ADXRS450_GyroSim(ADXRS450_Gyro gyro) {
-    SimDeviceSim wrappedSimDevice = new SimDeviceSim("ADXRS450_Gyro" + "[" + gyro.getPort() + "]");
-    m_simAngle = wrappedSimDevice.getDouble("Angle");
-    m_simRate = wrappedSimDevice.getDouble("Rate");
+    m_wrappedSimDevice = new SimDeviceSim("ADXRS450_Gyro" + "[" + gyro.getPort() + "]");
+    m_simAngle = m_wrappedSimDevice.getDouble("Angle");
+    m_simRate = m_wrappedSimDevice.getDouble("Rate");
+  }
+
+  public void setDisplayName(String displayName) {
+    m_wrappedSimDevice.setDisplayName(displayName);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/AnalogEncoderSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/AnalogEncoderSim.java
@@ -15,6 +15,7 @@ import edu.wpi.first.wpilibj.geometry.Rotation2d;
  * Class to control a simulated analog encoder.
  */
 public class AnalogEncoderSim {
+  private final SimDeviceSim m_wrappedSimDevice;
   private final SimDouble m_simPosition;
 
   /**
@@ -23,8 +24,12 @@ public class AnalogEncoderSim {
    * @param encoder AnalogEncoder to simulate
    */
   public AnalogEncoderSim(AnalogEncoder encoder) {
-    SimDeviceSim wrappedSimDevice = new SimDeviceSim("AnalogEncoder" + "[" + encoder.getChannel() + "]");
-    m_simPosition = wrappedSimDevice.getDouble("Position");
+    m_wrappedSimDevice = new SimDeviceSim("AnalogEncoder" + "[" + encoder.getChannel() + "]");
+    m_simPosition = m_wrappedSimDevice.getDouble("Position");
+  }
+
+  public void setDisplayName(String displayName) {
+    m_wrappedSimDevice.setDisplayName(displayName);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/AnalogGyroSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/AnalogGyroSim.java
@@ -26,6 +26,10 @@ public class AnalogGyroSim {
     m_index = gyro.getAnalogInput().getChannel();
   }
 
+  public void setDisplayName(String displayName) {
+    AnalogGyroDataJNI.setDisplayName(m_index, displayName);
+  }
+
   /**
    * Constructs from an analog input channel number.
    *

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/AnalogInputSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/AnalogInputSim.java
@@ -35,6 +35,15 @@ public class AnalogInputSim {
     m_index = channel;
   }
 
+  public String getDisplayName() {
+    return AnalogInDataJNI.getDisplayName(m_index);
+  }
+
+  public void setDisplayName(String displayName) {
+    AnalogInDataJNI.setDisplayName(m_index, displayName);
+  }
+
+
   public CallbackStore registerInitializedCallback(NotifyCallback callback, boolean initialNotify) {
     int uid = AnalogInDataJNI.registerInitializedCallback(m_index, callback, initialNotify);
     return new CallbackStore(m_index, uid, AnalogInDataJNI::cancelInitializedCallback);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/AnalogOutputSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/AnalogOutputSim.java
@@ -35,6 +35,14 @@ public class AnalogOutputSim {
     m_index = channel;
   }
 
+  public String getDisplayName() {
+    return AnalogOutDataJNI.getDisplayName(m_index);
+  }
+
+  public void setDisplayName(String displayName) {
+    AnalogOutDataJNI.setDisplayName(m_index, displayName);
+  }
+
   public CallbackStore registerVoltageCallback(NotifyCallback callback, boolean initialNotify) {
     int uid = AnalogOutDataJNI.registerVoltageCallback(m_index, callback, initialNotify);
     return new CallbackStore(m_index, uid, AnalogOutDataJNI::cancelVoltageCallback);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/BuiltInAccelerometerSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/BuiltInAccelerometerSim.java
@@ -34,6 +34,10 @@ public class BuiltInAccelerometerSim {
     m_index = 0;
   }
 
+  public void setDisplayName(String displayName) {
+    AccelerometerDataJNI.setDisplayName(m_index, displayName);
+  }
+
   public CallbackStore registerActiveCallback(NotifyCallback callback, boolean initialNotify) {
     int uid = AccelerometerDataJNI.registerActiveCallback(m_index, callback, initialNotify);
     return new CallbackStore(m_index, uid, AccelerometerDataJNI::cancelActiveCallback);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DIOSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DIOSim.java
@@ -45,6 +45,15 @@ public class DIOSim {
     m_index = channel;
   }
 
+
+  public String getDisplayName() {
+    return DIODataJNI.getDisplayName(m_index);
+  }
+
+  public void setDisplayName(String displayName) {
+    DIODataJNI.setDisplayName(m_index, displayName);
+  }
+
   public CallbackStore registerInitializedCallback(NotifyCallback callback, boolean initialNotify) {
     int uid = DIODataJNI.registerInitializedCallback(m_index, callback, initialNotify);
     return new CallbackStore(m_index, uid, DIODataJNI::cancelInitializedCallback);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/EncoderSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/EncoderSim.java
@@ -58,6 +58,13 @@ public class EncoderSim {
     return new EncoderSim(index);
   }
 
+  public String getDisplayName() {
+    return EncoderDataJNI.getDisplayName(m_index);
+  }
+  public void setDisplayName(String displayName) {
+    EncoderDataJNI.setDisplayName(m_index, displayName);
+  }
+
   public CallbackStore registerInitializedCallback(NotifyCallback callback, boolean initialNotify) {
     int uid = EncoderDataJNI.registerInitializedCallback(m_index, callback, initialNotify);
     return new CallbackStore(m_index, uid, EncoderDataJNI::cancelInitializedCallback);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/PCMSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/PCMSim.java
@@ -43,6 +43,13 @@ public class PCMSim {
     m_index = compressor.getModule();
   }
 
+  public String getSolenoidDisplayName(int channel) {
+    return PCMDataJNI.getSolenoidDisplayName(m_index, channel);
+  }
+  public void setSolenoidDisplayName(int channel, String displayName) {
+    PCMDataJNI.setSolenoidDisplayName(m_index, channel, displayName);
+  }
+
   public CallbackStore registerSolenoidInitializedCallback(int channel, NotifyCallback callback, boolean initialNotify) {
     int uid = PCMDataJNI.registerSolenoidInitializedCallback(m_index, channel, callback, initialNotify);
     return new CallbackStore(m_index, channel, uid, PCMDataJNI::cancelSolenoidInitializedCallback);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/PWMSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/PWMSim.java
@@ -35,6 +35,14 @@ public class PWMSim {
     m_index = channel;
   }
 
+  public String getDisplayName() {
+    return PWMDataJNI.getDisplayName(m_index);
+  }
+
+  public void setDisplayName(String displayName) {
+    PWMDataJNI.setDisplayName(m_index, displayName);
+  }
+
   public CallbackStore registerInitializedCallback(NotifyCallback callback, boolean initialNotify) {
     int uid = PWMDataJNI.registerInitializedCallback(m_index, callback, initialNotify);
     return new CallbackStore(m_index, uid, PWMDataJNI::cancelInitializedCallback);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/RelaySim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/RelaySim.java
@@ -35,6 +35,14 @@ public class RelaySim {
     m_index = channel;
   }
 
+  public String getDisplayName() {
+    return RelayDataJNI.getDisplayName(m_index);
+  }
+
+  public void setDisplayName(String displayName) {
+    RelayDataJNI.setDisplayName(m_index, displayName);
+  }
+
   public CallbackStore registerInitializedForwardCallback(NotifyCallback callback, boolean initialNotify) {
     int uid = RelayDataJNI.registerInitializedForwardCallback(m_index, callback, initialNotify);
     return new CallbackStore(m_index, uid, RelayDataJNI::cancelInitializedForwardCallback);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimDeviceSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimDeviceSim.java
@@ -30,6 +30,11 @@ public class SimDeviceSim {
     m_handle = SimDeviceDataJNI.getSimDeviceHandle(name);
   }
 
+  public void setDisplayName(String displayName) {
+    SimDeviceDataJNI.setDisplayName(m_handle, displayName);
+  }
+
+
   public SimValue getValue(String name) {
     int handle = SimDeviceDataJNI.getSimValueHandle(m_handle, name);
     if (handle <= 0) {


### PR DESCRIPTION
This allows you to set the names of SimDeviceSim, and all of the basic
components programatically, instead of only in the HAL GUI. This will be
more robust while refactoring port mappings, be more sharable
between different computers, and provide a single interface regardless
of what kind of sim front end you are using (HAL GUI, ws, some fancy
custom one)

Fixes #2890