### PR TITLE
[wpilibj] Fix egregious typo in ElevatorSim

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
@@ -146,7 +146,7 @@ public class ElevatorSim extends LinearSystemSim<N2, N1, N1> {
    * @return The velocity of the elevator.
    */
   public double getVelocityMetersPerSecond() {
-    return m_x.get(0, 1);
+    return m_x.get(1, 0);
   }
 
   /**


### PR DESCRIPTION
This caused an illegal argument exception whenever the simulated elevator velocity was retrieved.
https://usfirst.collab.net/sf/go/post6820