### PR TITLE
[wpiutil] unique_function: Restrict implicit conversion

### DIFF
--- a/wpiutil/src/main/native/include/wpi/FunctionExtras.h
+++ b/wpiutil/src/main/native/include/wpi/FunctionExtras.h
@@ -37,6 +37,7 @@
 #include "wpi/PointerIntPair.h"
 #include "wpi/PointerUnion.h"
 #include <memory>
+#include <type_traits>
 
 namespace wpi {
 
@@ -237,7 +238,11 @@ public:
     return *this;
   }
 
-  template <typename CallableT> unique_function(CallableT Callable) {
+  template <typename CallableT>
+  unique_function(CallableT Callable,
+                  std::enable_if_t<
+                    std::is_invocable_r_v<
+                      ReturnT, CallableT, ParamTs...>>* = nullptr) {
     bool IsInlineStorage = true;
     void *CallableAddr = getInlineStorage();
     if (sizeof(CallableT) > InlineStorageSize ||


### PR DESCRIPTION
Only implicitly convert from invocable objects.  This avoids potential
ambiguity in higher-level overloaded functions.