### PR TITLE
[examples] Zero motors on disabledInit() in sim physics examples

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/Robot.cpp
@@ -31,6 +31,7 @@ void Robot::RobotPeriodic() { frc2::CommandScheduler::GetInstance().Run(); }
  */
 void Robot::DisabledInit() {
   frc2::CommandScheduler::GetInstance().CancelAll();
+  m_container.ZeroAllOutputs();
 }
 
 void Robot::DisabledPeriodic() {}

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
@@ -36,6 +36,8 @@ RobotContainer::RobotContainer() {
       {&m_drive}));
 }
 
+void RobotContainer::ZeroAllOutputs() { m_drive.TankDriveVolts(0_V, 0_V); }
+
 const DriveSubsystem& RobotContainer::GetRobotDrive() const { return m_drive; }
 
 void RobotContainer::ConfigureButtonBindings() {

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/include/RobotContainer.h
@@ -30,6 +30,7 @@ class RobotContainer {
  public:
   RobotContainer();
 
+  void ZeroAllOutputs();
   frc2::Command* GetAutonomousCommand();
   const DriveSubsystem& GetRobotDrive() const;
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/Robot.java
@@ -55,5 +55,6 @@ public class Robot extends TimedRobot {
   @Override
   public void disabledInit() {
     CommandScheduler.getInstance().cancelAll();
+    m_robotContainer.zeroAllOutputs();
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
@@ -78,6 +78,13 @@ public class RobotContainer {
   }
 
   /**
+   * Zeros the outputs of all subsystems.
+   */
+  public void zeroAllOutputs() {
+    m_robotDrive.tankDriveVolts(0, 0);
+  }
+
+  /**
    * Use this to pass the autonomous command to the main {@link Robot} class.
    *
    * @return the command to run in autonomous


### PR DESCRIPTION
This ensures that mechanisms will stop moving if the robot is disabled while motors are in motion