### PR TITLE
[wpilibc] Try to work around ABI break introduced in #2901

### DIFF
--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableBuilder.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableBuilder.h
@@ -26,12 +26,6 @@ class SendableBuilder {
   virtual ~SendableBuilder() = default;
 
   /**
-   * Get the network table.
-   * @return The network table
-   */
-  virtual std::shared_ptr<nt::NetworkTable> GetTable() = 0;
-
-  /**
    * Set the string representation of the named data type that will be used
    * by the smart dashboard for this sendable.
    *
@@ -224,6 +218,12 @@ class SendableBuilder {
       const wpi::Twine& key,
       std::function<wpi::StringRef(wpi::SmallVectorImpl<char>& buf)> getter,
       std::function<void(wpi::StringRef)> setter) = 0;
+
+  /**
+   * Get the network table.
+   * @return The network table
+   */
+  virtual std::shared_ptr<nt::NetworkTable> GetTable() = 0;
 };
 
 }  // namespace frc


### PR DESCRIPTION
The change to SendableBuilder to add GetTable() added a virtual function
early in the class definition.  This is an ABI break for vendor libraries.
Attempt to workaround this breakage by moving GetTable() to the end of the
class definition.