### PR TITLE
Add PCM to HALSim WebSocket backend

### DIFF
--- a/simulation/halsim_ws_client/src/main/native/cpp/HALSimWSClient.cpp
+++ b/simulation/halsim_ws_client/src/main/native/cpp/HALSimWSClient.cpp
@@ -13,6 +13,7 @@
 #include <WSProvider_DriverStation.h>
 #include <WSProvider_Encoder.h>
 #include <WSProvider_Joystick.h>
+#include <WSProvider_PCM.h>
 #include <WSProvider_PWM.h>
 #include <WSProvider_Relay.h>
 #include <WSProvider_RoboRIO.h>
@@ -43,6 +44,7 @@ bool HALSimWSClient::Initialize() {
     HALSimWSProviderDriverStation::Initialize(registerFunc);
     HALSimWSProviderEncoder::Initialize(registerFunc);
     HALSimWSProviderJoystick::Initialize(registerFunc);
+    HALSimWSProviderPCM::Initialize(registerFunc);
     HALSimWSProviderPWM::Initialize(registerFunc);
     HALSimWSProviderRelay::Initialize(registerFunc);
     HALSimWSProviderRoboRIO::Initialize(registerFunc);

--- a/simulation/halsim_ws_core/src/main/native/cpp/WSProvider_PCM.cpp
+++ b/simulation/halsim_ws_core/src/main/native/cpp/WSProvider_PCM.cpp
@@ -1,0 +1,92 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#include "WSProvider_PCM.h"
+
+#include <hal/Ports.h>
+#include <hal/simulation/PCMData.h>
+
+#define SOLENOID_INITIALIZED_JSONID(channel) "<solenoid_init_" #channel
+#define SOLENOID_OUTPUT_JSONID(channel) "<solenoid_output_" #channel
+
+#define REGISTER_SOLENOID(solenoidChannel, halsim, jsonid, ctype, haltype) \
+  HALSIM_RegisterPCM##halsim##Callback(                                    \
+      m_channel,                                                           \
+      solenoidChannel,                                                     \
+      [](const char* name, void* param, const struct HAL_Value* value) {   \
+        static_cast<HALSimWSProviderPCM*>(param)->ProcessHalCallback(      \
+            {{jsonid, static_cast<ctype>(value->data.v_##haltype)}});      \
+      },                                                                   \
+      this, true)
+
+#define REGISTER(halsim, jsonid, ctype, haltype)                         \
+  HALSIM_RegisterPCM##halsim##Callback(                                  \
+      m_channel,                                                         \
+      [](const char* name, void* param, const struct HAL_Value* value) { \
+        static_cast<HALSimWSProviderPCM*>(param)->ProcessHalCallback(    \
+            {{jsonid, static_cast<ctype>(value->data.v_##haltype)}});    \
+      },                                                                 \
+      this, true)
+
+#define REGISTER_SOLENOID_CALLBACKS(channel) \
+  m_solenoidInitCbKeys[channel] = REGISTER_SOLENOID(channel, SolenoidInitialized, SOLENOID_INITIALIZED_JSONID(channel), bool, boolean); \
+  m_solenoidOutputCbKeys[channel] = REGISTER_SOLENOID(channel, SolenoidOutput, SOLENOID_OUTPUT_JSONID(channel), bool, boolean);
+
+#define CANCEL_SOLENOID_CALLBACKS(channel) \
+  HALSIM_CancelPCMSolenoidInitializedCallback(m_channel, channel, m_solenoidInitCbKeys[channel]); \
+  HALSIM_CancelPCMSolenoidOutputCallback(m_channel, channel, m_solenoidOutputCbKeys[channel]);
+
+namespace wpilibws {
+void HALSimWSProviderPCM::Initialize(WSRegisterFunc webRegisterFunc) {
+  CreateProviders<HALSimWSProviderPCM>("PCM", HAL_GetNumPCMModules(), webRegisterFunc);
+}
+
+HALSimWSProviderPCM::~HALSimWSProviderPCM() { DoCancelCallbacks(); }
+
+void HALSimWSProviderPCM::RegisterCallbacks() {
+  REGISTER_SOLENOID_CALLBACKS(0);
+  REGISTER_SOLENOID_CALLBACKS(1);
+  REGISTER_SOLENOID_CALLBACKS(2);
+  REGISTER_SOLENOID_CALLBACKS(3);
+  REGISTER_SOLENOID_CALLBACKS(4);
+  REGISTER_SOLENOID_CALLBACKS(5);
+  REGISTER_SOLENOID_CALLBACKS(6);
+  REGISTER_SOLENOID_CALLBACKS(7);
+
+  m_anySolenoidInitCbKey = REGISTER(AnySolenoidInitialized, "<any_solenoid_init", bool, boolean);
+  m_compressorInitCbKey = REGISTER(CompressorInitialized, "<compressor_init", bool, boolean);
+  m_compressorOnCbKey = REGISTER(CompressorOn, "<compressor_on", bool, boolean);
+  m_closedLoopEnabledCbKey = REGISTER(ClosedLoopEnabled, "<closed_loop_enabled", bool, boolean);
+  m_pressureSwitchCbKey = REGISTER(PressureSwitch, "<pressure_switch", bool, boolean);
+  m_compressorCurrentCbKey = REGISTER(CompressorCurrent, "<compressor_current", double, double);
+}
+
+void HALSimWSProviderPCM::CancelCallbacks() { DoCancelCallbacks(); }
+
+void HALSimWSProviderPCM::DoCancelCallbacks() {
+  CANCEL_SOLENOID_CALLBACKS(0);
+  CANCEL_SOLENOID_CALLBACKS(1);
+  CANCEL_SOLENOID_CALLBACKS(2);
+  CANCEL_SOLENOID_CALLBACKS(3);
+  CANCEL_SOLENOID_CALLBACKS(4);
+  CANCEL_SOLENOID_CALLBACKS(5);
+  CANCEL_SOLENOID_CALLBACKS(6);
+  CANCEL_SOLENOID_CALLBACKS(7);
+  for (int i = 0; i < NUM_SOLENOIDS_PER_PCM; i++) {
+    m_solenoidInitCbKeys[0] = 0;
+    m_solenoidOutputCbKeys[0] = 0;
+  }
+
+  HALSIM_CancelPCMAnySolenoidInitializedCallback(m_channel, m_anySolenoidInitCbKey);
+  HALSIM_CancelPCMCompressorInitializedCallback(m_channel, m_compressorInitCbKey);
+  HALSIM_CancelPCMCompressorOnCallback(m_channel, m_compressorOnCbKey);
+  HALSIM_CancelPCMClosedLoopEnabledCallback(m_channel, m_closedLoopEnabledCbKey);
+  HALSIM_CancelPCMPressureSwitchCallback(m_channel, m_pressureSwitchCbKey);
+  HALSIM_CancelPCMCompressorCurrentCallback(m_channel, m_compressorCurrentCbKey);
+}
+
+}  // namespace wpilibws

--- a/simulation/halsim_ws_core/src/main/native/include/WSProvider_PCM.h
+++ b/simulation/halsim_ws_core/src/main/native/include/WSProvider_PCM.h
@@ -1,0 +1,41 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2017-2020 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <memory>
+
+#include "WSHalProviders.h"
+
+#define NUM_SOLENOIDS_PER_PCM 8
+
+namespace wpilibws {
+
+class HALSimWSProviderPCM : public HALSimWSHalChanProvider {
+ public:
+  static void Initialize(WSRegisterFunc webRegisterFunc);
+
+  using HALSimWSHalChanProvider::HALSimWSHalChanProvider;
+  ~HALSimWSProviderPCM();
+
+ protected:
+  void RegisterCallbacks() override;
+  void CancelCallbacks() override;
+  void DoCancelCallbacks();
+
+ private:
+  int32_t m_solenoidInitCbKeys[NUM_SOLENOIDS_PER_PCM] = {0};
+  int32_t m_solenoidOutputCbKeys[NUM_SOLENOIDS_PER_PCM] = {0};
+  int32_t m_anySolenoidInitCbKey = 0;
+  int32_t m_compressorInitCbKey = 0;
+  int32_t m_compressorOnCbKey = 0;
+  int32_t m_closedLoopEnabledCbKey = 0;
+  int32_t m_pressureSwitchCbKey = 0;
+  int32_t m_compressorCurrentCbKey = 0;
+};
+
+}  // namespace wpilibws

--- a/simulation/halsim_ws_server/src/main/native/cpp/HALSimWSServer.cpp
+++ b/simulation/halsim_ws_server/src/main/native/cpp/HALSimWSServer.cpp
@@ -13,6 +13,7 @@
 #include <WSProvider_DriverStation.h>
 #include <WSProvider_Encoder.h>
 #include <WSProvider_Joystick.h>
+#include <WSProvider_PCM.h>
 #include <WSProvider_PWM.h>
 #include <WSProvider_Relay.h>
 #include <WSProvider_RoboRIO.h>
@@ -42,6 +43,7 @@ bool HALSimWSServer::Initialize() {
     HALSimWSProviderDriverStation::Initialize(registerFunc);
     HALSimWSProviderEncoder::Initialize(registerFunc);
     HALSimWSProviderJoystick::Initialize(registerFunc);
+    HALSimWSProviderPCM::Initialize(registerFunc);
     HALSimWSProviderPWM::Initialize(registerFunc);
     HALSimWSProviderRelay::Initialize(registerFunc);
     HALSimWSProviderRoboRIO::Initialize(registerFunc);


### PR DESCRIPTION
Adds PCM features to the HALSim WebSocket backend (Solenoid and Compressor). Should help out a bit with #2731.