### PR TITLE
Add comment to clarify requiring return value

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -458,7 +458,7 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
    * requiring the subsystem
    *
    * @param subsystem the subsystem to be inquired about
-   * @return the command currently requiring the subsystem
+   * @return the command currently requiring the subsystem, or null if no command is currently scheduled
    */
   public Command requiring(Subsystem subsystem) {
     return m_requirements.get(subsystem);


### PR DESCRIPTION
Given that m_requirements uses a LinkedHashMap, the behavior of the get method is replicated in the requiring() method.