### PR TITLE
[sim] GUI: Add keyboard virtual joystick support

### DIFF
--- a/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
@@ -123,8 +123,8 @@ class KeyboardJoystick : public SystemJoystick {
   struct AxisConfig {
     int incKey = -1;
     int decKey = -1;
-    float keyRate = 0.05;
-    float decayRate = 0.05;
+    float keyRate = 0.05f;
+    float decayRate = 0.05f;
   };
   AxisConfig m_axisConfig[HAL_kMaxJoystickAxes];
 
@@ -926,7 +926,7 @@ GlfwKeyboardJoystick::GlfwKeyboardJoystick(int index, bool noDefaults)
     m_axisConfig[1].decKey = GLFW_KEY_W;
     m_axisConfig[2].incKey = GLFW_KEY_R;
     m_axisConfig[2].decKey = GLFW_KEY_E;
-    m_axisConfig[2].keyRate = 0.01;
+    m_axisConfig[2].keyRate = 0.01f;
     m_axisConfig[2].decayRate = 0;  // works like a throttle
     m_data.buttons.count = 4;
     m_buttonKey[0] = GLFW_KEY_Z;


### PR DESCRIPTION
This allows joystick testing without a physical joystick.  Comes with a default set of keyboard mappings, but these are fully customizable by the user.  Up to 4 virtual joysticks are supported.

Default keyboard mappings:
- Joystick 0: axis 0: `AD`, axis 1: `WS`, axis 2: `ER`, buttons `ZXCV`, POV on numeric keypad
- Joystick 1: axis 0: `JL`, axis 1: `IK`, buttons `M,./`
- Joystick 2: axis 0: left/right arrow, axis 1: up/down arrow, buttons insert/home/pgup/del/end/pgdn

This PR also adds support for DS-style hotkeys of `[]\` enable, Enter disable, and spacebar disable.  All of these are disabled by default and must be explicitly enabled by the user.