### PR TITLE
[wpimath] Remove LinearSystem from LinearSystemLoop

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/system/LinearSystemLoop.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/system/LinearSystemLoop.java
@@ -38,7 +38,6 @@ import edu.wpi.first.wpiutil.math.numbers.N1;
 public class LinearSystemLoop<States extends Num, Inputs extends Num,
         Outputs extends Num> {
 
-  private final LinearSystem<States, Inputs, Outputs> m_plant;
   private final LinearQuadraticRegulator<States, Inputs, Outputs> m_controller;
   private final LinearPlantInversionFeedforward<States, Inputs, Outputs> m_feedforward;
   private final KalmanFilter<States, Inputs, Outputs> m_observer;
@@ -62,7 +61,7 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num,
                           KalmanFilter<States, Inputs, Outputs> observer,
                           double maxVoltageVolts,
                           double dtSeconds) {
-    this(plant, controller,
+    this(controller,
         new LinearPlantInversionFeedforward<>(plant, dtSeconds), observer,
         u -> StateSpaceUtil.normalizeInputVector(u, maxVoltageVolts));
   }
@@ -83,7 +82,7 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num,
                           KalmanFilter<States, Inputs, Outputs> observer,
                           Function<Matrix<Inputs, N1>, Matrix<Inputs, N1>> clampFunction,
                           double dtSeconds) {
-    this(plant, controller, new LinearPlantInversionFeedforward<>(plant, dtSeconds),
+    this(controller, new LinearPlantInversionFeedforward<>(plant, dtSeconds),
           observer, clampFunction);
   }
 
@@ -92,20 +91,18 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num,
    * observer. By default, the initial reference is all zeros. Users should
    * call reset with the initial system state before enabling the loop.
    *
-   * @param plant      State-space plant.
    * @param controller State-space controller.
    * @param feedforward Plant inversion feedforward.
    * @param observer   State-space observer.
    * @param maxVoltageVolts The maximum voltage that can be applied. Assumes that the
    *                        inputs are voltages.
    */
-  public LinearSystemLoop(LinearSystem<States, Inputs, Outputs> plant,
-                          LinearQuadraticRegulator<States, Inputs, Outputs> controller,
+  public LinearSystemLoop(LinearQuadraticRegulator<States, Inputs, Outputs> controller,
                           LinearPlantInversionFeedforward<States, Inputs, Outputs> feedforward,
                           KalmanFilter<States, Inputs, Outputs> observer,
                           double maxVoltageVolts
   ) {
-    this(plant, controller, feedforward,
+    this(controller, feedforward,
           observer, u -> StateSpaceUtil.normalizeInputVector(u, maxVoltageVolts));
   }
 
@@ -114,18 +111,15 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num,
    * observer. By default, the initial reference is all zeros. Users should
    * call reset with the initial system state before enabling the loop.
    *
-   * @param plant      State-space plant.
    * @param controller State-space controller.
    * @param feedforward Plant inversion feedforward.
    * @param observer   State-space observer.
    * @param clampFunction The function used to clamp the input U.
    */
-  public LinearSystemLoop(LinearSystem<States, Inputs, Outputs> plant,
-                          LinearQuadraticRegulator<States, Inputs, Outputs> controller,
+  public LinearSystemLoop(LinearQuadraticRegulator<States, Inputs, Outputs> controller,
                           LinearPlantInversionFeedforward<States, Inputs, Outputs> feedforward,
                           KalmanFilter<States, Inputs, Outputs> observer,
                           Function<Matrix<Inputs, N1>, Matrix<Inputs, N1>> clampFunction) {
-    this.m_plant = plant;
     this.m_controller = controller;
     this.m_feedforward = feedforward;
     this.m_observer = observer;
@@ -233,15 +227,6 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num,
    */
   public double getU(int row) {
     return getU().get(row, 0);
-  }
-
-  /**
-   * Return the plant used internally.
-   *
-   * @return the plant used internally.
-   */
-  public LinearSystem<States, Inputs, Outputs> getPlant() {
-    return m_plant;
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/system/LinearSystemLoop.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/system/LinearSystemLoop.java
@@ -21,7 +21,7 @@ import edu.wpi.first.wpiutil.math.Num;
 import edu.wpi.first.wpiutil.math.numbers.N1;
 
 /**
- * Combines a plant, controller, and observer for controlling a mechanism with
+ * Combines a controller, feedforward, and observer for controlling a mechanism with
  * full state feedback.
  *
  * <p>For everything in this file, "inputs" and "outputs" are defined from the
@@ -87,7 +87,7 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num,
   }
 
   /**
-   * Constructs a state-space loop with the given plant, controller, and
+   * Constructs a state-space loop with the given controller, feedforward and
    * observer. By default, the initial reference is all zeros. Users should
    * call reset with the initial system state before enabling the loop.
    *
@@ -107,7 +107,7 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num,
   }
 
   /**
-   * Constructs a state-space loop with the given plant, controller, and
+   * Constructs a state-space loop with the given controller, feedforward, and
    * observer. By default, the initial reference is all zeros. Users should
    * call reset with the initial system state before enabling the loop.
    *

--- a/wpimath/src/main/native/include/frc/system/LinearSystemLoop.h
+++ b/wpimath/src/main/native/include/frc/system/LinearSystemLoop.h
@@ -40,7 +40,6 @@ class LinearSystemLoop {
    * call reset with the initial system state before enabling the loop. This
    * constructor assumes that the input(s) to this system are voltage.
    *
-   * @param plant      State-space plant.
    * @param controller State-space controller.
    * @param observer   State-space observer.
    * @param maxVoltage The maximum voltage that can be applied. Commonly 12.
@@ -77,8 +76,7 @@ class LinearSystemLoop {
                        const Eigen::Matrix<double, Inputs, 1>&)>
                        clampFunction,
                    units::second_t dt)
-      : LinearSystemLoop(
-            plant, controller,
+      : LinearSystemLoop(controller,
             LinearPlantInversionFeedforward<States, Inputs>{plant, dt},
             observer, clampFunction) {}
 
@@ -87,7 +85,6 @@ class LinearSystemLoop {
    * observer. By default, the initial reference is all zeros. Users should
    * call reset with the initial system state before enabling the loop.
    *
-   * @param plant       State-space plant.
    * @param controller  State-space controller.
    * @param feedforward Plant inversion feedforward.
    * @param observer    State-space observer.
@@ -95,11 +92,10 @@ class LinearSystemLoop {
    * that the inputs are voltages.
    */
   LinearSystemLoop(
-      LinearSystem<States, Inputs, Outputs>& plant,
       LinearQuadraticRegulator<States, Inputs>& controller,
       const LinearPlantInversionFeedforward<States, Inputs>& feedforward,
       KalmanFilter<States, Inputs, Outputs>& observer, units::volt_t maxVoltage)
-      : LinearSystemLoop(plant, controller, feedforward, observer,
+      : LinearSystemLoop(controller, feedforward, observer,
                          [=](Eigen::Matrix<double, Inputs, 1> u) {
                            return frc::NormalizeInputVector<Inputs>(
                                u, maxVoltage.template to<double>());
@@ -109,22 +105,19 @@ class LinearSystemLoop {
    * Constructs a state-space loop with the given plant, controller, and
    * observer.
    *
-   * @param plant         State-space plant.
    * @param controller    State-space controller.
    * @param feedforward   Plant-inversion feedforward.
    * @param observer      State-space observer.
    * @param clampFunction The function used to clamp the input vector.
    */
   LinearSystemLoop(
-      LinearSystem<States, Inputs, Outputs>& plant,
       LinearQuadraticRegulator<States, Inputs>& controller,
       const LinearPlantInversionFeedforward<States, Inputs>& feedforward,
       KalmanFilter<States, Inputs, Outputs>& observer,
       std::function<Eigen::Matrix<double, Inputs, 1>(
           const Eigen::Matrix<double, Inputs, 1>&)>
           clampFunction)
-      : m_plant(plant),
-        m_controller(controller),
+      : m_controller(controller),
         m_feedforward(feedforward),
         m_observer(observer),
         m_clampFunc(clampFunction) {
@@ -197,11 +190,6 @@ class LinearSystemLoop {
   void SetNextR(const Eigen::Matrix<double, States, 1>& nextR) {
     m_nextR = nextR;
   }
-
-  /**
-   * Return the plant used internally.
-   */
-  const LinearSystem<States, Inputs, Outputs>& Plant() const { return m_plant; }
 
   /**
    * Return the controller used internally.
@@ -284,7 +272,6 @@ class LinearSystemLoop {
   }
 
  protected:
-  LinearSystem<States, Inputs, Outputs>& m_plant;
   LinearQuadraticRegulator<States, Inputs>& m_controller;
   LinearPlantInversionFeedforward<States, Inputs> m_feedforward;
   KalmanFilter<States, Inputs, Outputs>& m_observer;

--- a/wpimath/src/main/native/include/frc/system/LinearSystemLoop.h
+++ b/wpimath/src/main/native/include/frc/system/LinearSystemLoop.h
@@ -76,7 +76,8 @@ class LinearSystemLoop {
                        const Eigen::Matrix<double, Inputs, 1>&)>
                        clampFunction,
                    units::second_t dt)
-      : LinearSystemLoop(controller,
+      : LinearSystemLoop(
+            controller,
             LinearPlantInversionFeedforward<States, Inputs>{plant, dt},
             observer, clampFunction) {}
 

--- a/wpimath/src/main/native/include/frc/system/LinearSystemLoop.h
+++ b/wpimath/src/main/native/include/frc/system/LinearSystemLoop.h
@@ -18,8 +18,8 @@
 namespace frc {
 
 /**
- * Combines a plant, controller, and observer for controlling a mechanism with
- * full state feedback.
+ * Combines a controller, feedforward, and observer for controlling a mechanism
+ * with full state feedback.
  *
  * For everything in this file, "inputs" and "outputs" are defined from the
  * perspective of the plant. This means U is an input and Y is an output
@@ -81,9 +81,9 @@ class LinearSystemLoop {
             observer, clampFunction) {}
 
   /**
-   * Constructs a state-space loop with the given plant, controller, and
+   * Constructs a state-space loop with the given controller, feedforward and
    * observer. By default, the initial reference is all zeros. Users should
-   * call reset with the initial system state before enabling the loop.
+   * call reset with the initial system state.
    *
    * @param controller  State-space controller.
    * @param feedforward Plant inversion feedforward.
@@ -102,8 +102,9 @@ class LinearSystemLoop {
                          }) {}
 
   /**
-   * Constructs a state-space loop with the given plant, controller, and
-   * observer.
+   * Constructs a state-space loop with the given controller, feedforward,
+   * observer and clamp function. By default, the initial reference is all
+   * zeros. Users should call reset with the initial system state.
    *
    * @param controller    State-space controller.
    * @param feedforward   Plant-inversion feedforward.

--- a/wpimath/src/test/java/edu/wpi/first/wpilibj/controller/LinearSystemLoopTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/wpilibj/controller/LinearSystemLoopTest.java
@@ -44,11 +44,11 @@ public class LinearSystemLoopTest {
       m_plant, VecBuilder.fill(0.02, 0.4), VecBuilder.fill(12.0),
         0.00505);
 
-  private final LinearSystemLoop<N2, N1, N1> m_loop = 
+  private final LinearSystemLoop<N2, N1, N1> m_loop =
       new LinearSystemLoop<>(m_plant, m_controller, m_observer, 12, 0.00505);
 
   @SuppressWarnings("LocalVariableName")
-  private static void updateTwoState(LinearSystem<N2, N1, N1> plant, LinearSystemLoop<N2, N1, N1> 
+  private static void updateTwoState(LinearSystem<N2, N1, N1> plant, LinearSystemLoop<N2, N1, N1>
       loop, double noise) {
     Matrix<N1, N1> y = plant.calculateY(loop.getXHat(), loop.getU()).plus(
           VecBuilder.fill(noise)

--- a/wpimath/src/test/java/edu/wpi/first/wpilibj/controller/LinearSystemLoopTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/wpilibj/controller/LinearSystemLoopTest.java
@@ -32,29 +32,25 @@ public class LinearSystemLoopTest {
   public static final double kDt = 0.00505;
   private static final double kPositionStddev = 0.0001;
   private static final Random random = new Random();
-  private final LinearSystemLoop<N2, N1, N1> m_loop;
+
+  LinearSystem<N2, N1, N1> m_plant = LinearSystemId.createElevatorSystem(DCMotor.getVex775Pro(2), 5,
+      0.0181864, 1.0);
+
+  KalmanFilter<N2, N1, N1> m_observer = new KalmanFilter<>(Nat.N2(), Nat.N1(), m_plant,
+      VecBuilder.fill(0.05, 1.0),
+      VecBuilder.fill(0.0001), kDt);
+
+  LinearQuadraticRegulator<N2, N1, N1> m_controller = new LinearQuadraticRegulator<>(
+      m_plant, VecBuilder.fill(0.02, 0.4), VecBuilder.fill(12.0),
+        0.00505);
+
+  private final LinearSystemLoop<N2, N1, N1> m_loop = 
+      new LinearSystemLoop<>(m_plant, m_controller, m_observer, 12, 0.00505);
 
   @SuppressWarnings("LocalVariableName")
-  public LinearSystemLoopTest() {
-    LinearSystem<N2, N1, N1> plant = LinearSystemId.createElevatorSystem(DCMotor.getVex775Pro(2), 5,
-          0.0181864, 1.0);
-    KalmanFilter<N2, N1, N1> observer = new KalmanFilter<>(Nat.N2(), Nat.N1(), plant,
-          VecBuilder.fill(0.05, 1.0),
-          VecBuilder.fill(0.0001), kDt);
-
-    var qElms = VecBuilder.fill(0.02, 0.4);
-    var rElms = VecBuilder.fill(12.0);
-    var dt = 0.00505;
-
-    var controller = new LinearQuadraticRegulator<>(
-          plant, qElms, rElms, dt);
-
-    m_loop = new LinearSystemLoop<>(plant, controller, observer, 12, dt);
-  }
-
-  @SuppressWarnings("LocalVariableName")
-  private static void updateTwoState(LinearSystemLoop<N2, N1, N1> loop, double noise) {
-    Matrix<N1, N1> y = loop.getPlant().calculateY(loop.getXHat(), loop.getU()).plus(
+  private static void updateTwoState(LinearSystem<N2, N1, N1> plant, LinearSystemLoop<N2, N1, N1> 
+      loop, double noise) {
+    Matrix<N1, N1> y = plant.calculateY(loop.getXHat(), loop.getU()).plus(
           VecBuilder.fill(noise)
     );
 
@@ -81,7 +77,7 @@ public class LinearSystemLoopTest {
       state = profile.calculate(kDt);
       m_loop.setNextR(VecBuilder.fill(state.position, state.velocity));
 
-      updateTwoState(m_loop, (random.nextGaussian()) * kPositionStddev);
+      updateTwoState(m_plant, m_loop, (random.nextGaussian()) * kPositionStddev);
       var u = m_loop.getU(0);
 
       assertTrue(u >= -12.1 && u <= 12.1, "U out of bounds! Got " + u);
@@ -110,7 +106,7 @@ public class LinearSystemLoopTest {
 
     var feedforward = new LinearPlantInversionFeedforward<>(plant, kDt);
 
-    var loop = new LinearSystemLoop<>(plant, controller, feedforward, observer, 12);
+    var loop = new LinearSystemLoop<>(controller, feedforward, observer, 12);
 
     loop.reset(VecBuilder.fill(0.0));
     var references = VecBuilder.fill(3000 / 60d * 2 * Math.PI);
@@ -132,7 +128,7 @@ public class LinearSystemLoopTest {
 
       loop.setNextR(references);
 
-      Matrix<N1, N1> y = loop.getPlant().calculateY(loop.getXHat(), loop.getU()).plus(
+      Matrix<N1, N1> y = plant.calculateY(loop.getXHat(), loop.getU()).plus(
             VecBuilder.fill(random.nextGaussian() * kPositionStddev)
       );
 

--- a/wpimath/src/test/native/cpp/StateSpaceTest.cpp
+++ b/wpimath/src/test/native/cpp/StateSpaceTest.cpp
@@ -46,9 +46,9 @@ class StateSpace : public testing::Test {
   LinearSystemLoop<2, 1, 1> loop{plant, controller, observer, 12_V, kDt};
 };
 
-void Update(LinearSystemLoop<2, 1, 1>& loop, double noise) {
+void Update(const LinearSystem<2, 1, 1>& plant, LinearSystemLoop<2, 1, 1>& loop, double noise) {
   Eigen::Matrix<double, 1, 1> y =
-      loop.Plant().CalculateY(loop.Xhat(), loop.U()) +
+      plant.CalculateY(loop.Xhat(), loop.U()) +
       Eigen::Matrix<double, 1, 1>(noise);
   loop.Correct(y);
   loop.Predict(kDt);
@@ -63,7 +63,7 @@ TEST_F(StateSpace, CorrectPredictLoop) {
   loop.SetNextR(references);
 
   for (int i = 0; i < 1000; i++) {
-    Update(loop, dist(generator));
+    Update(plant, loop, dist(generator));
     EXPECT_PRED_FORMAT2(testing::DoubleLE, -12.0, loop.U(0));
     EXPECT_PRED_FORMAT2(testing::DoubleLE, loop.U(0), 12.0);
   }

--- a/wpimath/src/test/native/cpp/StateSpaceTest.cpp
+++ b/wpimath/src/test/native/cpp/StateSpaceTest.cpp
@@ -46,10 +46,10 @@ class StateSpace : public testing::Test {
   LinearSystemLoop<2, 1, 1> loop{plant, controller, observer, 12_V, kDt};
 };
 
-void Update(const LinearSystem<2, 1, 1>& plant, LinearSystemLoop<2, 1, 1>& loop, double noise) {
-  Eigen::Matrix<double, 1, 1> y =
-      plant.CalculateY(loop.Xhat(), loop.U()) +
-      Eigen::Matrix<double, 1, 1>(noise);
+void Update(const LinearSystem<2, 1, 1>& plant, LinearSystemLoop<2, 1, 1>& loop,
+            double noise) {
+  Eigen::Matrix<double, 1, 1> y = plant.CalculateY(loop.Xhat(), loop.U()) +
+                                  Eigen::Matrix<double, 1, 1>(noise);
   loop.Correct(y);
   loop.Predict(kDt);
 }


### PR DESCRIPTION
The system wasn't being used internally, and as LinearSystem is stateless, it doesn't need to be held by LinearSystemLoop.