### PR TITLE
[glass] Fix handling of "/" NetworkTables key

### DIFF
--- a/glass/src/libnt/native/cpp/NetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTables.cpp
@@ -190,6 +190,11 @@ void NetworkTablesModel::Update() {
     parts.clear();
     wpi::StringRef{entry->name}.split(parts, '/', -1, false);
 
+    // ignore a raw "/" key
+    if (parts.empty()) {
+      continue;
+    }
+
     // get to leaf
     auto nodes = &m_root;
     for (auto part : wpi::ArrayRef(parts.begin(), parts.end()).drop_back()) {


### PR DESCRIPTION
Just hide it from view in the tree view.

Fixes #2990.