### PR TITLE
[wpilibc] Speed up ScopedTracerTest

### DIFF
--- a/wpilibc/src/test/native/cpp/ScopedTracerTest.cpp
+++ b/wpilibc/src/test/native/cpp/ScopedTracerTest.cpp
@@ -2,28 +2,24 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include <string>
-#include <thread>
-
 #include <wpi/SmallString.h>
 #include <wpi/StringRef.h>
 #include <wpi/raw_ostream.h>
 
 #include "frc/ScopedTracer.h"
+#include "frc/simulation/SimHooks.h"
 #include "gtest/gtest.h"
 
 wpi::SmallString<128> buf;
 wpi::raw_svector_ostream os(buf);
 
-#ifdef __APPLE__
-TEST(ScopedTracerTest, DISABLED_Timing) {
-#else
 TEST(ScopedTracerTest, Timing) {
-#endif
+  frc::sim::PauseTiming();
   {
     frc::ScopedTracer tracer("timing_test", os);
-    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    frc::sim::StepTiming(1.5_s);
   }
+  frc::sim::ResumeTiming();
 
   wpi::StringRef out = os.str();
   EXPECT_TRUE(out.startswith("	timing_test: 1.5"));


### PR DESCRIPTION
ScopedTracerTest now uses simulation time instead of wall clock time, so
it doesn't have to actually wait 1.5 seconds.