### PR TITLE
[sim] Create Left/Right drivetrain current accessors

### DIFF
--- a/wpilibc/src/main/native/cpp/simulation/DifferentialDrivetrainSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/DifferentialDrivetrainSim.cpp
@@ -88,7 +88,7 @@ Pose2d DifferentialDrivetrainSim::GetPose() const {
                 units::meter_t(GetOutput(State::kY)), GetHeading());
 }
 
-units::ampere_t DifferentialDrivetrainSim::GetCurrentDraw() const {
+units::ampere_t DifferentialDrivetrainSim::GetRightCurrentDraw() const {
   auto loadIleft =
       m_motor.Current(units::radians_per_second_t(m_x(State::kLeftVelocity) *
                                                   m_currentGearing /
@@ -96,6 +96,10 @@ units::ampere_t DifferentialDrivetrainSim::GetCurrentDraw() const {
                       units::volt_t(m_u(0))) *
       wpi::sgn(m_u(0));
 
+  return loadIleft;
+}
+
+units::ampere_t DifferentialDrivetrainSim::GetLeftCurrentDraw() const {
   auto loadIRight =
       m_motor.Current(units::radians_per_second_t(m_x(State::kRightVelocity) *
                                                   m_currentGearing /
@@ -103,7 +107,10 @@ units::ampere_t DifferentialDrivetrainSim::GetCurrentDraw() const {
                       units::volt_t(m_u(1))) *
       wpi::sgn(m_u(1));
 
-  return loadIleft + loadIRight;
+  return loadIRight;
+}
+units::ampere_t DifferentialDrivetrainSim::GetCurrentDraw() const {
+  return GetLeftCurrentDraw() + GetRightCurrentDraw();
 }
 
 void DifferentialDrivetrainSim::SetState(

--- a/wpilibc/src/main/native/cpp/simulation/DifferentialDrivetrainSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/DifferentialDrivetrainSim.cpp
@@ -88,7 +88,7 @@ Pose2d DifferentialDrivetrainSim::GetPose() const {
                 units::meter_t(GetOutput(State::kY)), GetHeading());
 }
 
-units::ampere_t DifferentialDrivetrainSim::GetRightCurrentDraw() const {
+units::ampere_t DifferentialDrivetrainSim::GetLeftCurrentDraw() const {
   auto loadIleft =
       m_motor.Current(units::radians_per_second_t(m_x(State::kLeftVelocity) *
                                                   m_currentGearing /
@@ -99,7 +99,7 @@ units::ampere_t DifferentialDrivetrainSim::GetRightCurrentDraw() const {
   return loadIleft;
 }
 
-units::ampere_t DifferentialDrivetrainSim::GetLeftCurrentDraw() const {
+units::ampere_t DifferentialDrivetrainSim::GetRightCurrentDraw() const {
   auto loadIRight =
       m_motor.Current(units::radians_per_second_t(m_x(State::kRightVelocity) *
                                                   m_currentGearing /

--- a/wpilibc/src/main/native/include/frc/simulation/DifferentialDrivetrainSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/DifferentialDrivetrainSim.h
@@ -159,6 +159,16 @@ class DifferentialDrivetrainSim {
   }
 
   /**
+   * Returns the currently drawn current for the right side.
+   */
+  units::ampere_t GetRightCurrentDraw() const;
+
+  /**
+   * Returns the currently drawn current for the left side.
+   */
+  units::ampere_t GetLeftCurrentDraw() const;
+
+  /**
    * Returns the currently drawn current.
    */
   units::ampere_t GetCurrentDraw() const;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSim.java
@@ -201,17 +201,25 @@ public class DifferentialDrivetrainSim {
     return getOutput(State.kLeftVelocity);
   }
 
-  public double getCurrentDrawAmps() {
+  public double getLeftCurrentDrawAmps() {
     var loadIleft = m_motor.getCurrent(
         getState(State.kLeftVelocity) * m_currentGearing / m_wheelRadiusMeters,
         m_u.get(0, 0)) * Math.signum(m_u.get(0, 0));
+    return loadIleft;
+  }
 
+  public double getRightCurrentDrawAmps() {
     var loadIright = m_motor.getCurrent(
         getState(State.kRightVelocity) * m_currentGearing / m_wheelRadiusMeters,
         m_u.get(1, 0)) * Math.signum(m_u.get(1, 0));
 
-    return loadIleft + loadIright;
+    return loadIright;
   }
+
+  public double getCurrentDrawAmps() {
+    return getLeftCurrentDrawAmps() + getRightCurrentDrawAmps();
+  }
+
 
   public double getCurrentGearing() {
     return m_currentGearing;


### PR DESCRIPTION
Breaks the function into two, so you can query the left and the right separately. Useful if you want to set the PDP channels or set the current for the 3rd party smart controllers