### PR TITLE
[wpilibc] SuppliedValueWidget.h: Forward declare ShuffleboardContainer

### DIFF
--- a/wpilibc/src/main/native/include/frc/shuffleboard/SuppliedValueWidget.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/SuppliedValueWidget.h
@@ -14,10 +14,11 @@
 #include "frc/shuffleboard/ShuffleboardComponent.h"
 #include "frc/shuffleboard/ShuffleboardComponent.inc"
 #include "frc/shuffleboard/ShuffleboardComponentBase.h"
-#include "frc/shuffleboard/ShuffleboardContainer.h"
 #include "frc/shuffleboard/ShuffleboardWidget.h"
 
 namespace frc {
+class ShuffleboardContainer;
+
 template <typename T>
 class SuppliedValueWidget : public ShuffleboardWidget<SuppliedValueWidget<T> > {
  public:


### PR DESCRIPTION
This is needed to break an include loop between ShuffleboardContainer.h
and SuppliedValueWidget.h.