### PR TITLE
[build] Increase Gradle heap size in Gazebo build

### DIFF
--- a/.github/workflows/gazebo.yml
+++ b/.github/workflows/gazebo.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build with Gradle
-        run: ./gradlew build -PbuildServer -PmakeSim
+        run: ./gradlew build -PbuildServer -PmakeSim -Dorg.gradle.jvmargs=-Xmx2g


### PR DESCRIPTION
Several builds on master are failing due to Gradle running out of memory.