### PR TITLE
[glass] Use .controllable to set widgets' read-only state

### DIFF
--- a/glass/src/lib/native/cpp/hardware/SpeedController.cpp
+++ b/glass/src/lib/native/cpp/hardware/SpeedController.cpp
@@ -5,6 +5,7 @@
 #include "glass/hardware/SpeedController.h"
 
 #include <imgui.h>
+#include <imgui_internal.h>
 
 #include "glass/Context.h"
 #include "glass/DataSource.h"
@@ -22,6 +23,12 @@ void glass::DisplaySpeedController(SpeedControllerModel* m) {
     return;
   }
 
+  // Set the buttons and sliders to read-only if the model is read-only.
+  if (m->IsReadOnly()) {
+    ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(210, 210, 210, 255));
+  }
+
   // Add button to zero output.
   if (ImGui::Button("Zero")) {
     m->SetPercent(0.0);
@@ -31,7 +38,13 @@ void glass::DisplaySpeedController(SpeedControllerModel* m) {
   // Display a slider for the data.
   float value = dc->GetValue();
   ImGui::SetNextItemWidth(ImGui::GetFontSize() * 8);
+
   if (dc->SliderFloat("% Output", &value, -1.0f, 1.0f)) {
     m->SetPercent(value);
+  }
+
+  if (m->IsReadOnly()) {
+    ImGui::PopStyleColor();
+    ImGui::PopItemFlag();
   }
 }

--- a/glass/src/lib/native/cpp/other/Drive.cpp
+++ b/glass/src/lib/native/cpp/other/Drive.cpp
@@ -106,6 +106,12 @@ void glass::DisplayDrive(DriveModel* m) {
     drawArrow(arrowPos, a2 + adder);
   }
 
+  // Set the buttons and sliders to read-only if the model is read-only.
+  if (m->IsReadOnly()) {
+    ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(210, 210, 210, 255));
+  }
+
   // Add sliders for the wheel percentages.
   ImGui::SetCursorPosY(y2 - pos.y + ImGui::GetFontSize() * 0.5);
   for (auto&& wheel : wheels) {
@@ -123,5 +129,10 @@ void glass::DisplayDrive(DriveModel* m) {
         wheel.setter(value);
       }
     }
+  }
+
+  if (m->IsReadOnly()) {
+    ImGui::PopStyleColor();
+    ImGui::PopItemFlag();
   }
 }

--- a/glass/src/lib/native/cpp/other/PIDController.cpp
+++ b/glass/src/lib/native/cpp/other/PIDController.cpp
@@ -20,10 +20,12 @@ void glass::DisplayPIDController(PIDControllerModel* m) {
   }
 
   if (m->Exists()) {
-    auto createTuningParameter = [](const char* name, double* v,
-                                    std::function<void(double)> callback) {
+    auto flag = m->IsReadOnly() ? ImGuiInputTextFlags_ReadOnly
+                                : ImGuiInputTextFlags_None;
+    auto createTuningParameter = [flag](const char* name, double* v,
+                                        std::function<void(double)> callback) {
       ImGui::SetNextItemWidth(ImGui::GetFontSize() * 4);
-      if (ImGui::InputDouble(name, v, 0.0, 0.0, "%.3f")) {
+      if (ImGui::InputDouble(name, v, 0.0, 0.0, "%.3f", flag)) {
         callback(*v);
       }
     };

--- a/glass/src/libnt/native/cpp/NTDifferentialDrive.cpp
+++ b/glass/src/libnt/native/cpp/NTDifferentialDrive.cpp
@@ -16,12 +16,14 @@ NTDifferentialDriveModel::NTDifferentialDriveModel(NT_Inst instance,
                                                    wpi::StringRef path)
     : m_nt(instance),
       m_name(m_nt.GetEntry(path + "/.name")),
+      m_controllable(m_nt.GetEntry(path + "/.controllable")),
       m_lPercent(m_nt.GetEntry(path + "/Left Motor Speed")),
       m_rPercent(m_nt.GetEntry(path + "/Right Motor Speed")),
       m_nameValue(path.rsplit('/').second),
       m_lPercentData("NTDiffDriveL:" + path),
       m_rPercentData("NTDiffDriveR:" + path) {
   m_nt.AddListener(m_name);
+  m_nt.AddListener(m_controllable);
   m_nt.AddListener(m_lPercent);
   m_nt.AddListener(m_rPercent);
 
@@ -44,6 +46,9 @@ void NTDifferentialDriveModel::Update() {
     } else if (event.entry == m_rPercent && event.value &&
                event.value->IsDouble()) {
       m_rPercentData.SetValue(event.value->GetDouble());
+    } else if (event.entry == m_controllable && event.value &&
+               event.value->IsBoolean()) {
+      m_controllableValue = event.value->GetBoolean();
     }
   }
 

--- a/glass/src/libnt/native/cpp/NTMecanumDrive.cpp
+++ b/glass/src/libnt/native/cpp/NTMecanumDrive.cpp
@@ -15,6 +15,7 @@ NTMecanumDriveModel::NTMecanumDriveModel(wpi::StringRef path)
 NTMecanumDriveModel::NTMecanumDriveModel(NT_Inst instance, wpi::StringRef path)
     : m_nt(instance),
       m_name(m_nt.GetEntry(path + "/.name")),
+      m_controllable(m_nt.GetEntry(path + "/.controllable")),
       m_flPercent(m_nt.GetEntry(path + "/Front Left Motor Speed")),
       m_frPercent(m_nt.GetEntry(path + "/Front Right Motor Speed")),
       m_rlPercent(m_nt.GetEntry(path + "/Rear Left Motor Speed")),
@@ -25,6 +26,7 @@ NTMecanumDriveModel::NTMecanumDriveModel(NT_Inst instance, wpi::StringRef path)
       m_rlPercentData("NTMcnmDriveRL:" + path),
       m_rrPercentData("NTMcnmDriveRR:" + path) {
   m_nt.AddListener(m_name);
+  m_nt.AddListener(m_controllable);
   m_nt.AddListener(m_flPercent);
   m_nt.AddListener(m_frPercent);
   m_nt.AddListener(m_rlPercent);
@@ -63,6 +65,9 @@ void NTMecanumDriveModel::Update() {
     } else if (event.entry == m_rrPercent && event.value &&
                event.value->IsDouble()) {
       m_rrPercentData.SetValue(event.value->GetDouble());
+    } else if (event.entry == m_controllable && event.value &&
+               event.value->IsBoolean()) {
+      m_controllableValue = event.value->GetBoolean();
     }
   }
 

--- a/glass/src/libnt/native/cpp/NTPIDController.cpp
+++ b/glass/src/libnt/native/cpp/NTPIDController.cpp
@@ -13,6 +13,7 @@ NTPIDControllerModel::NTPIDControllerModel(NT_Inst instance,
                                            wpi::StringRef path)
     : m_nt(instance),
       m_name(m_nt.GetEntry(path + "/.name")),
+      m_controllable(m_nt.GetEntry(path + "/.controllable")),
       m_p(m_nt.GetEntry(path + "/p")),
       m_i(m_nt.GetEntry(path + "/i")),
       m_d(m_nt.GetEntry(path + "/d")),
@@ -23,6 +24,7 @@ NTPIDControllerModel::NTPIDControllerModel(NT_Inst instance,
       m_setpointData("NTPIDCtrlStpt:" + path),
       m_nameValue(path.rsplit('/').second) {
   m_nt.AddListener(m_name);
+  m_nt.AddListener(m_controllable);
   m_nt.AddListener(m_p);
   m_nt.AddListener(m_i);
   m_nt.AddListener(m_d);
@@ -66,6 +68,10 @@ void NTPIDControllerModel::Update() {
     } else if (event.entry == m_setpoint) {
       if (event.value && event.value->IsDouble()) {
         m_setpointData.SetValue(event.value->GetDouble());
+      }
+    } else if (event.entry == m_controllable) {
+      if (event.value && event.value->IsBoolean()) {
+        m_controllableValue = event.value->GetBoolean();
       }
     }
   }

--- a/glass/src/libnt/native/cpp/NTSpeedController.cpp
+++ b/glass/src/libnt/native/cpp/NTSpeedController.cpp
@@ -14,10 +14,12 @@ NTSpeedControllerModel::NTSpeedControllerModel(NT_Inst instance,
     : m_nt(instance),
       m_value(m_nt.GetEntry(path + "/Value")),
       m_name(m_nt.GetEntry(path + "/.name")),
+      m_controllable(m_nt.GetEntry(path + "/.controllable")),
       m_valueData("NT_SpdCtrl:" + path),
       m_nameValue(path.rsplit('/').second) {
   m_nt.AddListener(m_value);
   m_nt.AddListener(m_name);
+  m_nt.AddListener(m_controllable);
 }
 
 void NTSpeedControllerModel::SetPercent(double value) {
@@ -33,6 +35,10 @@ void NTSpeedControllerModel::Update() {
     } else if (event.entry == m_name) {
       if (event.value && event.value->IsString()) {
         m_nameValue = event.value->GetString();
+      }
+    } else if (event.entry == m_controllable) {
+      if (event.value && event.value->IsBoolean()) {
+        m_controllableValue = event.value->GetBoolean();
       }
     }
   }

--- a/glass/src/libnt/native/include/glass/networktables/NTDifferentialDrive.h
+++ b/glass/src/libnt/native/include/glass/networktables/NTDifferentialDrive.h
@@ -33,15 +33,17 @@ class NTDifferentialDriveModel : public DriveModel {
 
   void Update() override;
   bool Exists() override;
-  bool IsReadOnly() override { return false; }
+  bool IsReadOnly() override { return !m_controllableValue; }
 
  private:
   NetworkTablesHelper m_nt;
   NT_Entry m_name;
+  NT_Entry m_controllable;
   NT_Entry m_lPercent;
   NT_Entry m_rPercent;
 
   std::string m_nameValue;
+  bool m_controllableValue = false;
   DataSource m_lPercentData;
   DataSource m_rPercentData;
 

--- a/glass/src/libnt/native/include/glass/networktables/NTMecanumDrive.h
+++ b/glass/src/libnt/native/include/glass/networktables/NTMecanumDrive.h
@@ -33,17 +33,19 @@ class NTMecanumDriveModel : public DriveModel {
 
   void Update() override;
   bool Exists() override;
-  bool IsReadOnly() override { return false; }
+  bool IsReadOnly() override { return !m_controllableValue; }
 
  private:
   NetworkTablesHelper m_nt;
   NT_Entry m_name;
+  NT_Entry m_controllable;
   NT_Entry m_flPercent;
   NT_Entry m_frPercent;
   NT_Entry m_rlPercent;
   NT_Entry m_rrPercent;
 
   std::string m_nameValue;
+  bool m_controllableValue = false;
   DataSource m_flPercentData;
   DataSource m_frPercentData;
   DataSource m_rlPercentData;

--- a/glass/src/libnt/native/include/glass/networktables/NTPIDController.h
+++ b/glass/src/libnt/native/include/glass/networktables/NTPIDController.h
@@ -35,11 +35,12 @@ class NTPIDControllerModel : public PIDControllerModel {
 
   void Update() override;
   bool Exists() override;
-  bool IsReadOnly() override { return false; }
+  bool IsReadOnly() override { return !m_controllableValue; }
 
  private:
   NetworkTablesHelper m_nt;
   NT_Entry m_name;
+  NT_Entry m_controllable;
   NT_Entry m_p;
   NT_Entry m_i;
   NT_Entry m_d;
@@ -51,5 +52,6 @@ class NTPIDControllerModel : public PIDControllerModel {
   DataSource m_setpointData;
 
   std::string m_nameValue;
+  bool m_controllableValue = false;
 };
 }  // namespace glass

--- a/glass/src/libnt/native/include/glass/networktables/NTSpeedController.h
+++ b/glass/src/libnt/native/include/glass/networktables/NTSpeedController.h
@@ -29,14 +29,16 @@ class NTSpeedControllerModel : public SpeedControllerModel {
 
   void Update() override;
   bool Exists() override;
-  bool IsReadOnly() override { return false; }
+  bool IsReadOnly() override { return !m_controllableValue; }
 
  private:
   NetworkTablesHelper m_nt;
   NT_Entry m_value;
   NT_Entry m_name;
+  NT_Entry m_controllable;
 
   DataSource m_valueData;
   std::string m_nameValue;
+  bool m_controllableValue = false;
 };
 }  // namespace glass


### PR DESCRIPTION
This modifies the mecanum drive, differential drive, speed controller,
and PID controller widgets to only be writeable when .controllable is
set to true.

Closes #3034