### PR TITLE
[examples] Update RomiReference to match motor directions

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/RobotContainer.cpp
@@ -18,8 +18,8 @@ RobotContainer::RobotContainer() {
 void RobotContainer::ConfigureButtonBindings() {
   // Also set default commands here
   m_drive.SetDefaultCommand(TeleopArcadeDrive(
-      &m_drive, [this] { return m_controller.GetRawAxis(1); },
-      [this] { return -m_controller.GetRawAxis(2); }));
+      &m_drive, [this] { return -m_controller.GetRawAxis(1); },
+      [this] { return m_controller.GetRawAxis(2); }));
 
   // Example of how to use the onboard IO
   m_onboardButtonA.WhenPressed(frc2::PrintCommand("Button A Pressed"))

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/romireference/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/romireference/RobotContainer.java
@@ -92,6 +92,6 @@ public class RobotContainer {
    */
   public Command getArcadeDriveCommand() {
     return new ArcadeDrive(
-        m_drivetrain, () -> m_controller.getRawAxis(1), () -> -m_controller.getRawAxis(2));
+        m_drivetrain, () -> -m_controller.getRawAxis(1), () -> m_controller.getRawAxis(2));
   }
 }


### PR DESCRIPTION
This commit flips the TeleopArcadeDrive axis directions so that positive values for x-axis speed result in the Romi driving forward (in the direction of the Raspberry Pi USB ports). This works in conjunction with version 1.0.3 (and later) of the Romi web service