### PR TITLE
[build] Add publish documentation script

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,53 @@
+name: Documentation
+
+on: [push, workflow_dispatch]
+
+env:
+  BASE_PATH: allwpilib/docs
+
+jobs:
+  publish:
+    name: "Documentation - Publish"
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'wpilibsuite'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 13
+      - name: Set environment variables (Development)
+        run: |
+          echo "TARGET_FOLDER=$BASE_PATH/development" >> $GITHUB_ENV
+        if: github.ref == 'refs/heads/master'
+      - name: Set environment variables (Tag)
+        run: |
+          echo "EXTRA_GRADLE_ARGS=-PreleaseMode" >> $GITHUB_ENV
+          echo "TARGET_FOLDER=$BASE_PATH/beta" >> $GITHUB_ENV
+        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Set environment variables (Release)
+        run: |
+          echo "EXTRA_GRADLE_ARGS=-PreleaseMode" >> $GITHUB_ENV
+          echo "TARGET_FOLDER=$BASE_PATH/release" >> $GITHUB_ENV
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta')
+      - name: Build with Gradle
+        run: ./gradlew docs:generateJavaDocs docs:doxygen -PbuildServer ${{ env.EXTRA_GRADLE_ARGS }}
+      - name: Deploy Java 🚀
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          ACCESS_TOKEN: ${{ secrets.GH_PAT }}
+          REPOSITORY_NAME: wpilibsuite/wpilibsuite.github.io
+          BRANCH: main
+          CLEAN: true
+          FOLDER: docs/build/docs/javadoc
+          TARGET_FOLDER: ${{ env.TARGET_FOLDER }}/java
+      - name: Deploy C++ 🚀
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          ACCESS_TOKEN: ${{ secrets.GH_PAT }}
+          REPOSITORY_NAME: wpilibsuite/wpilibsuite.github.io
+          BRANCH: main
+          CLEAN: true
+          FOLDER: docs/build/docs/doxygen/html
+          TARGET_FOLDER: ${{ env.TARGET_FOLDER }}/cpp


### PR DESCRIPTION
This will publish our Javadoc and Doxygen documentation to `https://github.wpilib.org/allwpilib/docs/<track>/<lang>`. It requires a GitHub PAT secret to be added to the repo.

A slightly modified demo is available here:
https://github.com/AustinShalit/allwpilib/tree/gh-pages/allwpilib/docs

Development:
https://austinshalit.github.io/allwpilib/allwpilib/docs/development/java/
https://austinshalit.github.io/allwpilib/allwpilib/docs/development/cpp/

Beta:
https://austinshalit.github.io/allwpilib/allwpilib/docs/beta/java/
https://austinshalit.github.io/allwpilib/allwpilib/docs/beta/cpp/

Release:
https://austinshalit.github.io/allwpilib/allwpilib/docs/release/java/
https://austinshalit.github.io/allwpilib/allwpilib/docs/release/cpp/