### PR TITLE
[sim] Use plant output to retrieve simulated position

### DIFF
--- a/wpilibc/src/main/native/cpp/simulation/ElevatorSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/ElevatorSim.cpp
@@ -48,7 +48,7 @@ bool ElevatorSim::HasHitUpperLimit(const Eigen::Matrix<double, 2, 1>& x) const {
 }
 
 units::meter_t ElevatorSim::GetPosition() const {
-  return units::meter_t{m_x(0)};
+  return units::meter_t{m_y(0)};
 }
 
 units::meters_per_second_t ElevatorSim::GetVelocity() const {

--- a/wpilibc/src/main/native/cpp/simulation/SingleJointedArmSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/SingleJointedArmSim.cpp
@@ -50,7 +50,7 @@ bool SingleJointedArmSim::HasHitUpperLimit(
 }
 
 units::radian_t SingleJointedArmSim::GetAngle() const {
-  return units::radian_t{m_x(0)};
+  return units::radian_t{m_y(0)};
 }
 
 units::radians_per_second_t SingleJointedArmSim::GetVelocity() const {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
@@ -199,7 +199,7 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
    * @return The current arm angle.
    */
   public double getAngleRads() {
-    return m_x.get(0, 0);
+    return m_y.get(0, 0);
   }
 
   /**


### PR DESCRIPTION
Using the plant output means that measurement noise can be incorporated.
SingleJointedArmSim (in C++ and Java) and ElevatorSim (in C++) used the
state instead of the measurement.

Closes #3042