### PR TITLE
[ntcore] Fix NetworkTableEntry::GetRaw()

### DIFF
--- a/ntcore/src/main/native/include/networktables/NetworkTableEntry.inl
+++ b/ntcore/src/main/native/include/networktables/NetworkTableEntry.inl
@@ -79,7 +79,7 @@ inline std::string NetworkTableEntry::GetRaw(StringRef defaultValue) const {
   if (!value || value->type() != NT_RAW) {
     return defaultValue;
   }
-  return value->GetString();
+  return value->GetRaw();
 }
 
 inline std::vector<int> NetworkTableEntry::GetBooleanArray(


### PR DESCRIPTION
It was calling value->GetString() instead of GetRaw(), which would assert.