### PR TITLE
[glass] Add support for plot Y axis labels

### DIFF
--- a/glass/src/lib/native/cpp/support/ExtraGuiWidgets.cpp
+++ b/glass/src/lib/native/cpp/support/ExtraGuiWidgets.cpp
@@ -160,7 +160,7 @@ bool DeleteButton(ImGuiID id, const ImVec2& pos) {
 bool HeaderDeleteButton(const char* label) {
   ImGuiWindow* window = ImGui::GetCurrentWindow();
   ImGuiContext& g = *GImGui;
-  ImGuiItemHoveredDataBackup last_item_backup;
+  ImGuiLastItemDataBackup last_item_backup;
   ImGuiID id = window->GetID(label);
   float button_size = g.FontSize;
   float button_x = ImMax(window->DC.LastItemRect.Min.x,

--- a/imgui/CMakeLists.txt.in
+++ b/imgui/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(imgui-download NONE)
 include(ExternalProject)
 ExternalProject_Add(glfw3
   GIT_REPOSITORY    https://github.com/glfw/glfw.git
-  GIT_TAG           63af05c41961c238c2f891e2c923e1b89c1271b6
+  GIT_TAG           2a5ac9a6d6cbe9f4113c0f17158cb13ab7f263bf
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/glfw-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/glfw-build"
   CONFIGURE_COMMAND ""
@@ -23,7 +23,7 @@ ExternalProject_Add(gl3w
 )
 ExternalProject_Add(imgui
   GIT_REPOSITORY    https://github.com/ocornut/imgui.git
-  GIT_TAG           v1.76
+  GIT_TAG           v1.79
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/imgui-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/imgui-build"
   CONFIGURE_COMMAND ""
@@ -33,7 +33,7 @@ ExternalProject_Add(imgui
 )
 ExternalProject_Add(implot
   GIT_REPOSITORY    https://github.com/epezent/implot.git
-  GIT_TAG           90693cca1bd0ca5f0d49bc9cb8187d56b0b8f289
+  GIT_TAG           a6bab98517b1baa3116db52518dda1eb2d7eaab7
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/implot-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/implot-build"
   CONFIGURE_COMMAND ""

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -11,7 +11,7 @@ nativeUtils {
             niLibVersion = "2020.10.1"
             opencvVersion = "3.4.7-5"
             googleTestVersion = "1.9.0-5-437e100-1"
-            imguiVersion = "1.76-10"
+            imguiVersion = "1.79-1"
             wpimathVersion = "-1"
         }
     }


### PR DESCRIPTION
Also update imgui and implot to latest, to enable secondary Y axis labels (recently added to implot).

Depends on wpilibsuite/thirdparty-imgui#23.

![image](https://user-images.githubusercontent.com/297126/103996335-883e1100-514e-11eb-9669-6fd0b184222d.png)
