### PR TITLE
[wpimath] Add optimize() to SwerveModuleState

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/SwerveBot/cpp/SwerveModule.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveBot/cpp/SwerveModule.cpp
@@ -32,7 +32,12 @@ frc::SwerveModuleState SwerveModule::GetState() const {
           frc::Rotation2d(units::radian_t(m_turningEncoder.Get()))};
 }
 
-void SwerveModule::SetDesiredState(const frc::SwerveModuleState& state) {
+void SwerveModule::SetDesiredState(
+    const frc::SwerveModuleState& referenceState) {
+  // Optimize the reference state to avoid spinning further than 90 degrees
+  const auto state = frc::SwerveModuleState::Optimize(
+      referenceState, units::radian_t(m_turningEncoder.Get()));
+
   // Calculate the drive output from the drive PID controller.
   const auto driveOutput = m_drivePIDController.Calculate(
       m_driveEncoder.GetRate(), state.speed.to<double>());

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/subsystems/SwerveModule.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/subsystems/SwerveModule.cpp
@@ -43,7 +43,12 @@ frc::SwerveModuleState SwerveModule::GetState() {
           frc::Rotation2d(units::radian_t(m_turningEncoder.Get()))};
 }
 
-void SwerveModule::SetDesiredState(frc::SwerveModuleState& state) {
+void SwerveModule::SetDesiredState(
+    const frc::SwerveModuleState& referenceState) {
+  // Optimize the reference state to avoid spinning further than 90 degrees
+  const auto state = frc::SwerveModuleState::Optimize(
+      referenceState, units::radian_t(m_turningEncoder.Get()));
+
   // Calculate the drive output from the drive PID controller.
   const auto driveOutput = m_drivePIDController.Calculate(
       m_driveEncoder.GetRate(), state.speed.to<double>());

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/include/subsystems/SwerveModule.h
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/include/subsystems/SwerveModule.h
@@ -27,7 +27,7 @@ class SwerveModule {
 
   frc::SwerveModuleState GetState();
 
-  void SetDesiredState(frc::SwerveModuleState& state);
+  void SetDesiredState(const frc::SwerveModuleState& state);
 
   void ResetEncoders();
 

--- a/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/cpp/SwerveModule.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/cpp/SwerveModule.cpp
@@ -35,8 +35,8 @@ frc::SwerveModuleState SwerveModule::GetState() const {
 void SwerveModule::SetDesiredState(
     const frc::SwerveModuleState& referenceState) {
   // Optimize the reference state to avoid spinning further than 90 degrees
-  auto state = frc::SwerveModuleState::Optimize(
-      referenceState, frc::Rotation2d{units::radian_t(m_turningEncoder.Get())});
+  const auto state = frc::SwerveModuleState::Optimize(
+      referenceState, units::radian_t(m_turningEncoder.Get()));
 
   // Calculate the drive output from the drive PID controller.
   const auto driveOutput = m_drivePIDController.Calculate(

--- a/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/cpp/SwerveModule.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/cpp/SwerveModule.cpp
@@ -32,7 +32,12 @@ frc::SwerveModuleState SwerveModule::GetState() const {
           frc::Rotation2d(units::radian_t(m_turningEncoder.Get()))};
 }
 
-void SwerveModule::SetDesiredState(const frc::SwerveModuleState& state) {
+void SwerveModule::SetDesiredState(
+    const frc::SwerveModuleState& referenceState) {
+  // Optimize the reference state to avoid spinning further than 90 degrees
+  auto state = frc::SwerveModuleState::Optimize(
+      referenceState, frc::Rotation2d{units::radian_t(m_turningEncoder.Get())});
+
   // Calculate the drive output from the drive PID controller.
   const auto driveOutput = m_drivePIDController.Calculate(
       m_driveEncoder.GetRate(), state.speed.to<double>());

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervebot/SwerveModule.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervebot/SwerveModule.java
@@ -79,7 +79,7 @@ public class SwerveModule {
   /**
    * Sets the desired state for the module.
    *
-   * @param state Desired state with speed and angle.
+   * @param desiredState Desired state with speed and angle.
    */
   public void setDesiredState(SwerveModuleState desiredState) {
     // Optimize the reference state to avoid spinning further than 90 degrees

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervebot/SwerveModule.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervebot/SwerveModule.java
@@ -81,7 +81,11 @@ public class SwerveModule {
    *
    * @param state Desired state with speed and angle.
    */
-  public void setDesiredState(SwerveModuleState state) {
+  public void setDesiredState(SwerveModuleState desiredState) {
+    // Optimize the reference state to avoid spinning further than 90 degrees
+    SwerveModuleState state =
+        SwerveModuleState.optimize(desiredState, new Rotation2d(m_turningEncoder.get()));
+
     // Calculate the drive output from the drive PID controller.
     final double driveOutput =
         m_drivePIDController.calculate(m_driveEncoder.getRate(), state.speedMetersPerSecond);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/subsystems/SwerveModule.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/subsystems/SwerveModule.java
@@ -87,7 +87,7 @@ public class SwerveModule {
   /**
    * Sets the desired state for the module.
    *
-   * @param state Desired state with speed and angle.
+   * @param desiredState Desired state with speed and angle.
    */
   public void setDesiredState(SwerveModuleState desiredState) {
     // Optimize the reference state to avoid spinning further than 90 degrees

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/subsystems/SwerveModule.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/subsystems/SwerveModule.java
@@ -89,9 +89,13 @@ public class SwerveModule {
    *
    * @param state Desired state with speed and angle.
    */
-  public void setDesiredState(SwerveModuleState state) {
+  public void setDesiredState(SwerveModuleState desiredState) {
+    // Optimize the reference state to avoid spinning further than 90 degrees
+    SwerveModuleState state =
+        SwerveModuleState.optimize(desiredState, new Rotation2d(m_turningEncoder.get()));
+
     // Calculate the drive output from the drive PID controller.
-    final var driveOutput =
+    final double driveOutput =
         m_drivePIDController.calculate(m_driveEncoder.getRate(), state.speedMetersPerSecond);
 
     // Calculate the turning motor output from the turning PID controller.

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervesdriveposeestimator/SwerveModule.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervesdriveposeestimator/SwerveModule.java
@@ -79,9 +79,13 @@ public class SwerveModule {
   /**
    * Sets the desired state for the module.
    *
-   * @param state Desired state with speed and angle.
+   * @param desiredState Desired state with speed and angle.
    */
-  public void setDesiredState(SwerveModuleState state) {
+  public void setDesiredState(SwerveModuleState desiredState) {
+    // Optimize the reference state to avoid spinning further than 90 degrees
+    SwerveModuleState state =
+        SwerveModuleState.optimize(desiredState, new Rotation2d(m_turningEncoder.get()));
+
     // Calculate the drive output from the drive PID controller.
     final double driveOutput =
         m_drivePIDController.calculate(m_driveEncoder.getRate(), state.speedMetersPerSecond);

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/kinematics/SwerveModuleState.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/kinematics/SwerveModuleState.java
@@ -50,10 +50,9 @@ public class SwerveModuleState implements Comparable<SwerveModuleState> {
   }
 
   /**
-   * Minimize the change in heading the desired swerve module state would
-   * require by potentially reversing the direction the wheel spins. If this is
-   * used with the PIDController class's continuous input functionality, the
-   * furthest a wheel will ever rotate is 90 degrees.
+   * Minimize the change in heading the desired swerve module state would require by potentially
+   * reversing the direction the wheel spins. If this is used with the PIDController class's
+   * continuous input functionality, the furthest a wheel will ever rotate is 90 degrees.
    *
    * @param desiredState The desired state.
    * @param currentAngle The current module angle.

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/kinematics/SwerveModuleState.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/kinematics/SwerveModuleState.java
@@ -64,7 +64,8 @@ public class SwerveModuleState implements Comparable<SwerveModuleState> {
       return new SwerveModuleState(
           -desiredState.speedMetersPerSecond,
           desiredState.angle.rotateBy(Rotation2d.fromDegrees(180.0)));
+    } else {
+      return new SwerveModuleState(desiredState.speedMetersPerSecond, desiredState.angle);
     }
-    return new SwerveModuleState(desiredState.speedMetersPerSecond, desiredState.angle);
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/kinematics/SwerveModuleState.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/kinematics/SwerveModuleState.java
@@ -62,7 +62,7 @@ public class SwerveModuleState implements Comparable<SwerveModuleState> {
     var delta = desiredState.angle.minus(currentAngle);
     if (Math.abs(delta.getDegrees()) > 90.0) {
       return new SwerveModuleState(
-          desiredState.speedMetersPerSecond * -1.0,
+          -desiredState.speedMetersPerSecond,
           desiredState.angle.rotateBy(Rotation2d.fromDegrees(180.0)));
     }
     return new SwerveModuleState(desiredState.speedMetersPerSecond, desiredState.angle);

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/kinematics/SwerveModuleState.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/kinematics/SwerveModuleState.java
@@ -48,4 +48,23 @@ public class SwerveModuleState implements Comparable<SwerveModuleState> {
     return String.format(
         "SwerveModuleState(Speed: %.2f m/s, Angle: %s)", speedMetersPerSecond, angle);
   }
+
+  /**
+   * Optimize a desired state by deciding weather to reverse the direction the wheel spins in order
+   * to minimize travel time. This means that the furthest a wheel will ever rotate is 90 degrees,
+   * if used in conjunction with the PIDController class' continuous input functionality.
+   *
+   * @param desiredState The desired state.
+   * @param currentAngle The current module angle.
+   */
+  public static SwerveModuleState optimize(
+      SwerveModuleState desiredState, Rotation2d currentAngle) {
+    var delta = desiredState.angle.minus(currentAngle);
+    if (Math.abs(delta.getDegrees()) > 90.0) {
+      return new SwerveModuleState(
+          desiredState.speedMetersPerSecond * -1.0,
+          desiredState.angle.rotateBy(Rotation2d.fromDegrees(180.0)));
+    }
+    return new SwerveModuleState(desiredState.speedMetersPerSecond, desiredState.angle);
+  }
 }

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/kinematics/SwerveModuleState.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/kinematics/SwerveModuleState.java
@@ -50,9 +50,10 @@ public class SwerveModuleState implements Comparable<SwerveModuleState> {
   }
 
   /**
-   * Optimize a desired state by deciding weather to reverse the direction the wheel spins in order
-   * to minimize travel time. This means that the furthest a wheel will ever rotate is 90 degrees,
-   * if used in conjunction with the PIDController class' continuous input functionality.
+   * Minimize the change in heading the desired swerve module state would
+   * require by potentially reversing the direction the wheel spins. If this is
+   * used with the PIDController class's continuous input functionality, the
+   * furthest a wheel will ever rotate is 90 degrees.
    *
    * @param desiredState The desired state.
    * @param currentAngle The current module angle.

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
@@ -37,7 +37,7 @@ struct SwerveModuleState {
                                     const Rotation2d& currentAngle) {
     auto delta = desiredState.angle - currentAngle;
     if (units::math::abs(delta.Degrees()) > 90_deg) {
-      return {desiredState.speed * -1.0,
+      return {-desiredState.speed,
               desiredState.angle + Rotation2d{180_deg}};
     }
     return {desiredState.speed, desiredState.angle};

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
@@ -25,10 +25,10 @@ struct SwerveModuleState {
   Rotation2d angle;
 
   /**
-   * Optimize a desired state by deciding weather to reverse the direction the
-   * wheel spins in order to minimize travel time. This means that the furthest
-   * a wheel will ever rotate is 90 degrees, if used in conjunction with the
-   * PIDController class' continuous input functionality.
+   * Minimize the change in heading the desired swerve module state would
+   * require by potentially reversing the direction the wheel spins. If this is
+   * used with the PIDController class's continuous input functionality, the
+   * furthest a wheel will ever rotate is 90 degrees.
    *
    * @param desiredState The desired state.
    * @param currentAngle The current module angle.

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
@@ -37,8 +37,7 @@ struct SwerveModuleState {
                                     const Rotation2d& currentAngle) {
     auto delta = desiredState.angle - currentAngle;
     if (units::math::abs(delta.Degrees()) > 90_deg) {
-      return {-desiredState.speed,
-              desiredState.angle + Rotation2d{180_deg}};
+      return {-desiredState.speed, desiredState.angle + Rotation2d{180_deg}};
     }
     return {desiredState.speed, desiredState.angle};
   }

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include "frc/geometry/Rotation2d.h"
+#include "units/angle.h"
+#include "units/math.h"
 #include "units/velocity.h"
 
 namespace frc {
@@ -21,5 +23,24 @@ struct SwerveModuleState {
    * Angle of the module.
    */
   Rotation2d angle;
+
+  /**
+   * Optimize a desired state by deciding weather to reverse the direction the
+   * wheel spins in order to minimize travel time. This means that the furthest
+   * a wheel will ever rotate is 90 degrees, if used in conjunction with the
+   * PIDController class' continuous input functionality.
+   * 
+   * @param desiredState The desired state.
+   * @param currentAngle The current module angle.
+   */
+  static SwerveModuleState Optimize(const SwerveModuleState& desiredState,
+                                    const Rotation2d& currentAngle) {
+    auto delta = desiredState.angle - currentAngle;
+    if (units::math::abs(delta.Degrees()) > 90_deg) {
+      return {desiredState.speed * -1.0,
+              desiredState.angle + Rotation2d{180_deg}};
+    }
+    return {desiredState.speed, desiredState.angle};
+  }
 };
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
@@ -38,8 +38,9 @@ struct SwerveModuleState {
     auto delta = desiredState.angle - currentAngle;
     if (units::math::abs(delta.Degrees()) > 90_deg) {
       return {-desiredState.speed, desiredState.angle + Rotation2d{180_deg}};
+    } else {
+      return {desiredState.speed, desiredState.angle};
     }
-    return {desiredState.speed, desiredState.angle};
   }
 };
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
@@ -29,7 +29,7 @@ struct SwerveModuleState {
    * wheel spins in order to minimize travel time. This means that the furthest
    * a wheel will ever rotate is 90 degrees, if used in conjunction with the
    * PIDController class' continuous input functionality.
-   * 
+   *
    * @param desiredState The desired state.
    * @param currentAngle The current module angle.
    */


### PR DESCRIPTION
This makes it easy for teams to ensure that their modules never rotate more than 90 degrees to reach a given reference.