### PR TITLE
Fix issues with build on windows, deprecations, and native utils

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.gradle text eol=lf
+*.java text eol=lf
+*.md text eol=lf
+*.xml text eol=lf

--- a/.wpilib/wpilib_preferences.json
+++ b/.wpilib/wpilib_preferences.json
@@ -1,6 +1,6 @@
 {
   "enableCppIntellisense": true,
   "currentLanguage": "cpp",
-  "projectYear": "2020",
+  "projectYear": "2021",
   "teamNumber": 0
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,5 +5,5 @@ repositories {
     }
 }
 dependencies {
-    implementation "edu.wpi.first:native-utils:2021.1.0"
+    implementation "edu.wpi.first:native-utils:2021.1.1"
 }

--- a/glass/publish.gradle
+++ b/glass/publish.gradle
@@ -53,7 +53,7 @@ model {
                         def outputsFolder = file("$project.buildDir/outputs")
                         def task = project.tasks.create("copyGlassExecutable", Zip) {
                             description("Copies the Glass executable to the outputs directory.")
-                            destinationDir(outputsFolder)
+                            destinationDirectory = outputsFolder
 
                             archiveBaseName = '_M_' + zipBaseName
                             duplicatesStrategy = 'exclude'


### PR DESCRIPTION
Updates native utils to latest.
Fixes a deprecation warning from gradle
Adds .gitattributes so building without autocrlf on windows works.
Fixes vs code project year.
Fixes file with bad line endings.