### PR TITLE
[glass] Shorten SmartDashboard window names

### DIFF
--- a/glass/src/lib/native/cpp/Window.cpp
+++ b/glass/src/lib/native/cpp/Window.cpp
@@ -50,7 +50,8 @@ void Window::Display() {
 
   char label[128];
   std::snprintf(label, sizeof(label), "%s###%s",
-                m_name.empty() ? m_id.c_str() : m_name.c_str(), m_id.c_str());
+                m_name.empty() ? m_defaultName.c_str() : m_name.c_str(),
+                m_id.c_str());
 
   if (Begin(label, &m_visible, m_flags)) {
     if (m_renamePopupEnabled) {

--- a/glass/src/lib/native/include/glass/Window.h
+++ b/glass/src/lib/native/include/glass/Window.h
@@ -23,7 +23,7 @@ namespace glass {
 class Window {
  public:
   Window() = default;
-  explicit Window(wpi::StringRef id) : m_id{id} {}
+  explicit Window(wpi::StringRef id) : m_id{id}, m_defaultName{id} {}
 
   wpi::StringRef GetId() const { return m_id; }
 
@@ -44,6 +44,7 @@ class Window {
   void SetFlags(ImGuiWindowFlags flags) { m_flags = flags; }
 
   void SetName(const wpi::Twine& name) { m_name = name.str(); }
+  void SetDefaultName(const wpi::Twine& name) { m_defaultName = name.str(); }
 
   /**
    * Normally windows provide a right-click popup menu on the title bar to
@@ -115,6 +116,7 @@ class Window {
  private:
   std::string m_id;
   std::string m_name;
+  std::string m_defaultName;
   std::unique_ptr<View> m_view;
   ImGuiWindowFlags m_flags = 0;
   bool m_visible = true;

--- a/glass/src/libnt/native/cpp/NetworkTablesProvider.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTablesProvider.cpp
@@ -153,6 +153,10 @@ void NetworkTablesProvider::Show(ViewEntry* entry, Window* window) {
   if (!window) {
     return;
   }
+  if (wpi::StringRef{entry->name}.startswith("/SmartDashboard/")) {
+    window->SetDefaultName(wpi::StringRef{entry->name}.drop_front(16) +
+                           " (SmartDashboard)");
+  }
   entry->window = window;
 
   // create view


### PR DESCRIPTION
Instead of "/SmartDashboard/name" they now default to "name (SmartDashboard)".
This allows for smaller windows while preserving the name without requiring
user customization.