### PR TITLE
Negative GetY() or GetX() calls where necessary to correspond to controller conventions

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/ArcadeDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArcadeDrive/cpp/Robot.cpp
@@ -20,7 +20,7 @@ class Robot : public frc::TimedRobot {
  public:
   void TeleopPeriodic() override {
     // Drive with arcade style
-    m_robotDrive.ArcadeDrive(m_stick.GetY(), m_stick.GetX());
+    m_robotDrive.ArcadeDrive(-m_stick.GetY(), m_stick.GetX());
   }
 };
 

--- a/wpilibcExamples/src/main/cpp/examples/ArcadeDriveXboxController/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArcadeDriveXboxController/cpp/Robot.cpp
@@ -24,7 +24,7 @@ class Robot : public frc::TimedRobot {
     // That means that the Y axis of the left stick moves forward
     // and backward, and the X of the right stick turns left and right.
     m_robotDrive.ArcadeDrive(
-        m_driverController.GetY(frc::GenericHID::JoystickHand::kLeftHand),
+        -m_driverController.GetY(frc::GenericHID::JoystickHand::kLeftHand),
         m_driverController.GetX(frc::GenericHID::JoystickHand::kRightHand));
   }
 };

--- a/wpilibcExamples/src/main/cpp/examples/ArmBot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBot/cpp/RobotContainer.cpp
@@ -18,7 +18,7 @@ RobotContainer::RobotContainer() {
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
         m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
+            -m_driverController.GetY(frc::GenericHID::kLeftHand),
             m_driverController.GetX(frc::GenericHID::kRightHand));
       },
       {&m_drive}));

--- a/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/cpp/RobotContainer.cpp
@@ -18,7 +18,7 @@ RobotContainer::RobotContainer() {
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
         m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
+            -m_driverController.GetY(frc::GenericHID::kLeftHand),
             m_driverController.GetX(frc::GenericHID::kRightHand));
       },
       {&m_drive}));

--- a/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/RobotContainer.cpp
@@ -19,7 +19,7 @@ RobotContainer::RobotContainer() {
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
         m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
+            -m_driverController.GetY(frc::GenericHID::kLeftHand),
             m_driverController.GetX(frc::GenericHID::kRightHand));
       },
       {&m_drive}));

--- a/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/RobotContainer.cpp
@@ -17,7 +17,7 @@ RobotContainer::RobotContainer() {
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
         m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
+            -m_driverController.GetY(frc::GenericHID::kLeftHand),
             m_driverController.GetX(frc::GenericHID::kRightHand));
       },
       {&m_drive}));

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/RobotContainer.cpp
@@ -23,8 +23,8 @@ RobotContainer::RobotContainer()
   frc::SmartDashboard::PutData(&m_claw);
 
   m_drivetrain.SetDefaultCommand(TankDrive(
-      [this] { return m_joy.GetY(frc::GenericHID::JoystickHand::kLeftHand); },
-      [this] { return m_joy.GetY(frc::GenericHID::JoystickHand::kRightHand); },
+      [this] { return -m_joy.GetY(frc::GenericHID::JoystickHand::kLeftHand); },
+      [this] { return -m_joy.GetY(frc::GenericHID::JoystickHand::kRightHand); },
       &m_drivetrain));
 
   // Configure the button bindings

--- a/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
@@ -36,7 +36,7 @@ class Robot : public frc::TimedRobot {
 
   void TeleopPeriodic() override {
     // Drive with arcade style (use right stick)
-    m_robotDrive.ArcadeDrive(m_stick.GetY(), m_stick.GetX());
+    m_robotDrive.ArcadeDrive(-m_stick.GetY(), m_stick.GetX());
   }
 
   void TestInit() override {}

--- a/wpilibcExamples/src/main/cpp/examples/Gyro/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Gyro/cpp/Robot.cpp
@@ -27,8 +27,8 @@ class Robot : public frc::TimedRobot {
   void TeleopPeriodic() override {
     double turningValue = (kAngleSetpoint - m_gyro.GetAngle()) * kP;
     // Invert the direction of the turn if we are going backwards
-    turningValue = std::copysign(turningValue, m_joystick.GetY());
-    m_robotDrive.ArcadeDrive(m_joystick.GetY(), turningValue);
+    turningValue = std::copysign(turningValue, -m_joystick.GetY());
+    m_robotDrive.ArcadeDrive(-m_joystick.GetY(), turningValue);
   }
 
  private:

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/RobotContainer.cpp
@@ -20,7 +20,7 @@ RobotContainer::RobotContainer() {
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
         m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
+            -m_driverController.GetY(frc::GenericHID::kLeftHand),
             m_driverController.GetX(frc::GenericHID::kRightHand));
       },
       {&m_drive}));
@@ -42,7 +42,7 @@ void RobotContainer::ConfigureButtonBindings() {
           0,
           // Pipe the output to the turning controls
           [this](double output) {
-            m_drive.ArcadeDrive(m_driverController.GetY(
+            m_drive.ArcadeDrive(-m_driverController.GetY(
                                     frc::GenericHID::JoystickHand::kLeftHand),
                                 output);
           },

--- a/wpilibcExamples/src/main/cpp/examples/GyroMecanum/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GyroMecanum/cpp/Robot.cpp
@@ -28,7 +28,7 @@ class Robot : public frc::TimedRobot {
    * Mecanum drive is used with the gyro angle as an input.
    */
   void TeleopPeriodic() override {
-    m_robotDrive.DriveCartesian(m_joystick.GetX(), m_joystick.GetY(),
+    m_robotDrive.DriveCartesian(-m_joystick.GetX(), -m_joystick.GetY(),
                                 m_joystick.GetZ(), m_gyro.GetAngle());
   }
 

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/RobotContainer.cpp
@@ -24,7 +24,7 @@ RobotContainer::RobotContainer() {
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
         m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
+            -m_driverController.GetY(frc::GenericHID::kLeftHand),
             m_driverController.GetX(frc::GenericHID::kRightHand));
       },
       {&m_drive}));

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/RobotContainer.cpp
@@ -28,7 +28,7 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   m_drive.SetDefaultCommand(DefaultDrive(
       &m_drive,
-      [this] { return m_driverController.GetY(frc::GenericHID::kLeftHand); },
+      [this] { return -m_driverController.GetY(frc::GenericHID::kLeftHand); },
       [this] { return m_driverController.GetX(frc::GenericHID::kRightHand); }));
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/RobotContainer.cpp
@@ -30,9 +30,9 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.Drive(m_driverController.GetY(frc::GenericHID::kLeftHand),
-                      m_driverController.GetX(frc::GenericHID::kRightHand),
-                      m_driverController.GetX(frc::GenericHID::kLeftHand),
+        m_drive.Drive(-m_driverController.GetY(frc::GenericHID::kLeftHand),
+                      -m_driverController.GetX(frc::GenericHID::kRightHand),
+                      -m_driverController.GetX(frc::GenericHID::kLeftHand),
                       false);
       },
       {&m_drive}));

--- a/wpilibcExamples/src/main/cpp/examples/MecanumDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumDrive/cpp/Robot.cpp
@@ -24,7 +24,8 @@ class Robot : public frc::TimedRobot {
     /* Use the joystick X axis for lateral movement, Y axis for forward
      * movement, and Z axis for rotation.
      */
-    m_robotDrive.DriveCartesian(m_stick.GetX(), m_stick.GetY(), m_stick.GetZ());
+    m_robotDrive.DriveCartesian(-m_stick.GetX(), -m_stick.GetY(),
+                                m_stick.GetZ());
   }
 
  private:

--- a/wpilibcExamples/src/main/cpp/examples/MotorControl/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MotorControl/cpp/Robot.cpp
@@ -16,7 +16,7 @@
  */
 class Robot : public frc::TimedRobot {
  public:
-  void TeleopPeriodic() override { m_motor.Set(m_stick.GetY()); }
+  void TeleopPeriodic() override { m_motor.Set(-m_stick.GetY()); }
 
  private:
   frc::Joystick m_stick{0};

--- a/wpilibcExamples/src/main/cpp/examples/MotorControlEncoder/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MotorControlEncoder/cpp/Robot.cpp
@@ -22,7 +22,7 @@
  */
 class Robot : public frc::TimedRobot {
  public:
-  void TeleopPeriodic() override { m_motor.Set(m_stick.GetY()); }
+  void TeleopPeriodic() override { m_motor.Set(-m_stick.GetY()); }
 
   /*
    * The RobotPeriodic function is called every control packet no matter the

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/commands/DriveWithJoystick.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/commands/DriveWithJoystick.cpp
@@ -13,7 +13,7 @@ DriveWithJoystick::DriveWithJoystick() {
 // Called repeatedly when this Command is scheduled to run
 void DriveWithJoystick::Execute() {
   auto& joystick = Robot::oi.GetJoystick();
-  Robot::drivetrain.TankDrive(joystick.GetY(), joystick.GetRawAxis(4));
+  Robot::drivetrain.TankDrive(-joystick.GetY(), joystick.GetRawAxis(4));
 }
 
 // Make this return true when this Command no longer needs to run execute()

--- a/wpilibcExamples/src/main/cpp/examples/RamseteCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RamseteCommand/cpp/RobotContainer.cpp
@@ -29,7 +29,7 @@ RobotContainer::RobotContainer() {
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
         m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
+            -m_driverController.GetY(frc::GenericHID::kLeftHand),
             m_driverController.GetX(frc::GenericHID::kRightHand));
       },
       {&m_drive}));

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
@@ -29,7 +29,7 @@ RobotContainer::RobotContainer() {
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
         m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
+            -m_driverController.GetY(frc::GenericHID::kLeftHand),
             m_driverController.GetX(frc::GenericHID::kRightHand));
       },
       {&m_drive}));

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
@@ -32,11 +32,11 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.Drive(units::meters_per_second_t(
+        m_drive.Drive(-units::meters_per_second_t(
                           m_driverController.GetY(frc::GenericHID::kLeftHand)),
-                      units::meters_per_second_t(
+                      -units::meters_per_second_t(
                           m_driverController.GetY(frc::GenericHID::kRightHand)),
-                      units::radians_per_second_t(
+                      -units::radians_per_second_t(
                           m_driverController.GetX(frc::GenericHID::kLeftHand)),
                       false);
       },

--- a/wpilibcExamples/src/main/cpp/examples/TankDriveXboxController/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/TankDriveXboxController/cpp/Robot.cpp
@@ -22,8 +22,8 @@ class Robot : public frc::TimedRobot {
   void TeleopPeriodic() override {
     // Drive with tank style
     m_robotDrive.TankDrive(
-        m_driverController.GetY(frc::GenericHID::JoystickHand::kLeftHand),
-        m_driverController.GetY(frc::GenericHID::JoystickHand::kRightHand));
+        -m_driverController.GetY(frc::GenericHID::JoystickHand::kLeftHand),
+        -m_driverController.GetY(frc::GenericHID::JoystickHand::kRightHand));
   }
 };
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/arcadedrive/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/arcadedrive/Robot.java
@@ -24,6 +24,6 @@ public class Robot extends TimedRobot {
     // Drive with arcade drive.
     // That means that the Y axis drives forward
     // and backward, and the X turns left and right.
-    m_robotDrive.arcadeDrive(m_stick.getY(), m_stick.getX());
+    m_robotDrive.arcadeDrive(-m_stick.getY(), m_stick.getX());
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/arcadedrivexboxcontroller/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/arcadedrivexboxcontroller/Robot.java
@@ -26,6 +26,6 @@ public class Robot extends TimedRobot {
     // That means that the Y axis of the left stick moves forward
     // and backward, and the X of the right stick turns left and right.
     m_robotDrive.arcadeDrive(
-        m_driverController.getY(Hand.kLeft), m_driverController.getX(Hand.kRight));
+        -m_driverController.getY(Hand.kLeft), m_driverController.getX(Hand.kRight));
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbot/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbot/RobotContainer.java
@@ -43,7 +43,7 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
+                    -m_driverController.getY(GenericHID.Hand.kLeft),
                     m_driverController.getX(GenericHID.Hand.kRight)),
             m_robotDrive));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbotoffboard/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbotoffboard/RobotContainer.java
@@ -43,7 +43,7 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
+                    -m_driverController.getY(GenericHID.Hand.kLeft),
                     m_driverController.getX(GenericHID.Hand.kRight)),
             m_robotDrive));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/drivedistanceoffboard/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/drivedistanceoffboard/RobotContainer.java
@@ -45,7 +45,7 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
+                    -m_driverController.getY(GenericHID.Hand.kLeft),
                     m_driverController.getX(GenericHID.Hand.kRight)),
             m_robotDrive));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/RobotContainer.java
@@ -63,7 +63,7 @@ public class RobotContainer {
     // Assign default commands
     m_drivetrain.setDefaultCommand(
         new TankDrive(
-            () -> m_joystick.getY(Hand.kLeft), () -> m_joystick.getY(Hand.kRight), m_drivetrain));
+            () -> -m_joystick.getY(Hand.kLeft), () -> -m_joystick.getY(Hand.kRight), m_drivetrain));
 
     // Show what command your subsystem is running on the SmartDashboard
     SmartDashboard.putData(m_drivetrain);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gettingstarted/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gettingstarted/Robot.java
@@ -54,7 +54,7 @@ public class Robot extends TimedRobot {
   /** This function is called periodically during teleoperated mode. */
   @Override
   public void teleopPeriodic() {
-    m_robotDrive.arcadeDrive(m_stick.getY(), m_stick.getX());
+    m_robotDrive.arcadeDrive(-m_stick.getY(), m_stick.getX());
   }
 
   /** This function is called once each time the robot enters test mode. */

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyro/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyro/Robot.java
@@ -46,7 +46,7 @@ public class Robot extends TimedRobot {
   public void teleopPeriodic() {
     double turningValue = (kAngleSetpoint - m_gyro.getAngle()) * kP;
     // Invert the direction of the turn if we are going backwards
-    turningValue = Math.copySign(turningValue, m_joystick.getY());
-    m_myRobot.arcadeDrive(m_joystick.getY(), turningValue);
+    turningValue = Math.copySign(turningValue, -m_joystick.getY());
+    m_myRobot.arcadeDrive(-m_joystick.getY(), turningValue);
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/RobotContainer.java
@@ -46,7 +46,7 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
+                    -m_driverController.getY(GenericHID.Hand.kLeft),
                     m_driverController.getX(GenericHID.Hand.kRight)),
             m_robotDrive));
   }
@@ -78,7 +78,7 @@ public class RobotContainer {
                 // Pipe the output to the turning controls
                 output ->
                     m_robotDrive.arcadeDrive(
-                        m_driverController.getY(GenericHID.Hand.kLeft), output),
+                        -m_driverController.getY(GenericHID.Hand.kLeft), output),
                 // Require the robot drive
                 m_robotDrive));
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyromecanum/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyromecanum/Robot.java
@@ -51,6 +51,6 @@ public class Robot extends TimedRobot {
   @Override
   public void teleopPeriodic() {
     m_robotDrive.driveCartesian(
-        m_joystick.getX(), m_joystick.getY(), m_joystick.getZ(), m_gyro.getAngle());
+        -m_joystick.getX(), -m_joystick.getY(), m_joystick.getZ(), m_gyro.getAngle());
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
@@ -70,7 +70,7 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
+                    -m_driverController.getY(GenericHID.Hand.kLeft),
                     m_driverController.getX(GenericHID.Hand.kRight)),
             m_robotDrive));
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/RobotContainer.java
@@ -62,7 +62,7 @@ public class RobotContainer {
         // hand, and turning controlled by the right.
         new DefaultDrive(
             m_robotDrive,
-            () -> m_driverController.getY(GenericHID.Hand.kLeft),
+            () -> -m_driverController.getY(GenericHID.Hand.kLeft),
             () -> m_driverController.getX(GenericHID.Hand.kRight)));
 
     // Add commands to the autonomous command chooser

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/RobotContainer.java
@@ -52,9 +52,9 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.drive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
-                    m_driverController.getX(GenericHID.Hand.kRight),
-                    m_driverController.getX(GenericHID.Hand.kLeft),
+                    -m_driverController.getY(GenericHID.Hand.kLeft),
+                    -m_driverController.getX(GenericHID.Hand.kRight),
+                    -m_driverController.getX(GenericHID.Hand.kLeft),
                     false)));
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdrive/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdrive/Robot.java
@@ -42,6 +42,6 @@ public class Robot extends TimedRobot {
   public void teleopPeriodic() {
     // Use the joystick X axis for lateral movement, Y axis for forward
     // movement, and Z axis for rotation.
-    m_robotDrive.driveCartesian(m_stick.getX(), m_stick.getY(), m_stick.getZ(), 0.0);
+    m_robotDrive.driveCartesian(-m_stick.getX(), -m_stick.getY(), m_stick.getZ(), 0.0);
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/motorcontrol/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/motorcontrol/Robot.java
@@ -31,6 +31,6 @@ public class Robot extends TimedRobot {
 
   @Override
   public void teleopPeriodic() {
-    m_motor.set(m_joystick.getY());
+    m_motor.set(-m_joystick.getY());
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/motorcontrolencoder/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/motorcontrolencoder/Robot.java
@@ -52,6 +52,6 @@ public class Robot extends TimedRobot {
 
   @Override
   public void teleopPeriodic() {
-    m_motor.set(m_joystick.getY());
+    m_motor.set(-m_joystick.getY());
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/subsystems/DriveTrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/subsystems/DriveTrain.java
@@ -82,7 +82,7 @@ public class DriveTrain extends Subsystem {
    * @param joy PS3 style joystick to use as the input for tank drive.
    */
   public void tankDrive(Joystick joy) {
-    m_drive.tankDrive(joy.getY(), joy.getRawAxis(4));
+    m_drive.tankDrive(-joy.getY(), joy.getRawAxis(4));
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
@@ -54,7 +54,7 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
+                    -m_driverController.getY(GenericHID.Hand.kLeft),
                     m_driverController.getX(GenericHID.Hand.kRight)),
             m_robotDrive));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/RobotContainer.java
@@ -50,9 +50,9 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.drive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
-                    m_driverController.getX(GenericHID.Hand.kRight),
-                    m_driverController.getX(GenericHID.Hand.kLeft),
+                    -m_driverController.getY(GenericHID.Hand.kLeft),
+                    -m_driverController.getX(GenericHID.Hand.kRight),
+                    -m_driverController.getX(GenericHID.Hand.kLeft),
                     false)));
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/tankdrive/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/tankdrive/Robot.java
@@ -27,6 +27,6 @@ public class Robot extends TimedRobot {
 
   @Override
   public void teleopPeriodic() {
-    m_myRobot.tankDrive(m_leftStick.getY(), m_rightStick.getY());
+    m_myRobot.tankDrive(-m_leftStick.getY(), -m_rightStick.getY());
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/tankdrivexboxcontroller/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/tankdrivexboxcontroller/Robot.java
@@ -27,6 +27,6 @@ public class Robot extends TimedRobot {
     // of the robot forward and backward, and the Y axis of the right stick
     // moves the right side of the robot forward and backward.
     m_robotDrive.tankDrive(
-        m_driverController.getY(Hand.kLeft), m_driverController.getY(Hand.kRight));
+        -m_driverController.getY(Hand.kLeft), -m_driverController.getY(Hand.kRight));
   }
 }


### PR DESCRIPTION
- [ ] Need to test atleast some of these out on real robots to confirm sim behaviour - I can't do this 
- [x] Test C++ Simulation
- [ ] Test Java Simulation (I don't have java setup so if someone else could)
- [ ] Should we be negating `frc::Joystick::GetY()`? Strictly speaking these aren't controllers with the changed functionality but for most people they will have XboxControllers, and the default sim keybinds make "w" go negative on the axis a la the XboxController

* Note that the [Java version](https://github.com/wpilibsuite/allwpilib/blob/4488e25f16c6bb98cdbfa48095db56b7f6390da3/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java#L56) of StateSpaceDifferentialDriveSimulation already has a negation whilst the [C++ version](https://github.com/wpilibsuite/allwpilib/blob/4488e25f16c6bb98cdbfa48095db56b7f6390da3/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp#L32) does not.

Specific examples which I'd like some help width:
- [ ] The [Gyro example](https://github.com/Modelmat/allwpilib/blob/controller-y-inversion-fix/wpilibcExamples/src/main/cpp/examples/Gyro/cpp/Robot.cpp#L31). I'm not sure if the turn to angle is getting moved the right direction (the direction of the actual controller is fine)
- [ ] I need some help testing Swerve/Mecanum simulations because it seems to need a three-axis Joystick? I'm also not sure how the controller should work either...