### PR TITLE
[examples] Fix segfault in GearsBot C++ example

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/DriveStraight.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/DriveStraight.cpp
@@ -11,7 +11,7 @@
 DriveStraight::DriveStraight(double distance, DriveTrain* drivetrain)
     : frc2::CommandHelper<frc2::PIDCommand, DriveStraight>(
           frc2::PIDController(4, 0, 0),
-          [drivetrain]() { return drivetrain->GetDistance(); }, distance,
+          [drivetrain] { return drivetrain->GetDistance(); }, distance,
           [drivetrain](double output) { drivetrain->Drive(output, output); },
           {drivetrain}),
       m_drivetrain(drivetrain) {

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/DriveStraight.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/DriveStraight.cpp
@@ -11,8 +11,8 @@
 DriveStraight::DriveStraight(double distance, DriveTrain* drivetrain)
     : frc2::CommandHelper<frc2::PIDCommand, DriveStraight>(
           frc2::PIDController(4, 0, 0),
-          [this]() { return m_drivetrain->GetDistance(); }, distance,
-          [this](double output) { m_drivetrain->Drive(output, output); },
+          [drivetrain]() { return drivetrain->GetDistance(); }, distance,
+          [drivetrain](double output) { drivetrain->Drive(output, output); },
           {drivetrain}),
       m_drivetrain(drivetrain) {
   m_controller.SetTolerance(0.01);

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetDistanceToBox.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetDistanceToBox.cpp
@@ -11,8 +11,9 @@
 SetDistanceToBox::SetDistanceToBox(double distance, DriveTrain* drivetrain)
     : frc2::CommandHelper<frc2::PIDCommand, SetDistanceToBox>(
           frc2::PIDController(-2, 0, 0),
-          [this]() { return m_drivetrain->GetDistanceToObstacle(); }, distance,
-          [this](double output) { m_drivetrain->Drive(output, output); },
+          [drivetrain]() { return drivetrain->GetDistanceToObstacle(); },
+          distance,
+          [drivetrain](double output) { drivetrain->Drive(output, output); },
           {drivetrain}),
       m_drivetrain(drivetrain) {
   m_controller.SetTolerance(0.01);

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetDistanceToBox.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetDistanceToBox.cpp
@@ -11,7 +11,7 @@
 SetDistanceToBox::SetDistanceToBox(double distance, DriveTrain* drivetrain)
     : frc2::CommandHelper<frc2::PIDCommand, SetDistanceToBox>(
           frc2::PIDController(-2, 0, 0),
-          [drivetrain]() { return drivetrain->GetDistanceToObstacle(); },
+          [drivetrain] { return drivetrain->GetDistanceToObstacle(); },
           distance,
           [drivetrain](double output) { drivetrain->Drive(output, output); },
           {drivetrain}),


### PR DESCRIPTION
This is a temporary fix to prevent a dangling this pointer in the
DriveStraight and SetDistanceToBox commands by directly capturing the
drivetrain pointer by value instead.

Closes #3109