### PR TITLE
Add SimDeviceSim ctor overloads

### DIFF
--- a/wpilibc/src/main/native/cpp/simulation/SimDeviceSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/SimDeviceSim.cpp
@@ -7,6 +7,9 @@
 #include <string>
 #include <vector>
 
+#include <wpi/SmallString.h>
+#include <wpi/raw_ostream.h>
+
 #include <hal/SimDevice.h>
 #include <hal/simulation/SimDeviceData.h>
 
@@ -15,6 +18,22 @@ using namespace frc::sim;
 
 SimDeviceSim::SimDeviceSim(const char* name)
     : m_handle{HALSIM_GetSimDeviceHandle(name)} {}
+
+SimDeviceSim::SimDeviceSim(const char* name, int index) {
+  wpi::SmallString<128> fullname;
+  wpi::raw_svector_ostream os(fullname);
+  os << name << '[' << index << ']';
+
+  m_handle = HALSIM_GetSimDeviceHandle(fullname.c_str());
+}
+
+SimDeviceSim::SimDeviceSim(const char* name, int index, int channel) {
+  wpi::SmallString<128> fullname;
+  wpi::raw_svector_ostream os(fullname);
+  os << name << '[' << index << ',' << channel << ']';
+
+  m_handle = HALSIM_GetSimDeviceHandle(fullname.c_str());
+}
 
 hal::SimValue SimDeviceSim::GetValue(const char* name) const {
   return HALSIM_GetSimValueHandle(m_handle, name);

--- a/wpilibc/src/main/native/cpp/simulation/SimDeviceSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/SimDeviceSim.cpp
@@ -7,11 +7,10 @@
 #include <string>
 #include <vector>
 
-#include <wpi/SmallString.h>
-#include <wpi/raw_ostream.h>
-
 #include <hal/SimDevice.h>
 #include <hal/simulation/SimDeviceData.h>
+#include <wpi/SmallString.h>
+#include <wpi/raw_ostream.h>
 
 using namespace frc;
 using namespace frc::sim;

--- a/wpilibc/src/main/native/include/frc/simulation/SimDeviceSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/SimDeviceSim.h
@@ -31,7 +31,7 @@ class SimDeviceSim {
    * @param name name of the SimDevice
    * @param index device index number to append to name
    */
-  explicit SimDeviceSim(const char* name, int index);
+  SimDeviceSim(const char* name, int index);
 
   /**
    * Constructs a SimDeviceSim.
@@ -40,7 +40,7 @@ class SimDeviceSim {
    * @param index device index number to append to name
    * @param channel device channel number to append to name
    */
-  explicit SimDeviceSim(const char* name, int index, int channel);
+  SimDeviceSim(const char* name, int index, int channel);
 
   /**
    * Get the property object with the given name.

--- a/wpilibc/src/main/native/include/frc/simulation/SimDeviceSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/SimDeviceSim.h
@@ -26,6 +26,23 @@ class SimDeviceSim {
   explicit SimDeviceSim(const char* name);
 
   /**
+   * Constructs a SimDeviceSim.
+   *
+   * @param name name of the SimDevice
+   * @param index device index number to append to name
+   */
+  explicit SimDeviceSim(const char* name, int index);
+
+  /**
+   * Constructs a SimDeviceSim.
+   *
+   * @param name name of the SimDevice
+   * @param index device index number to append to name
+   * @param channel device channel number to append to name
+   */
+  explicit SimDeviceSim(const char* name, int index, int channel);
+
+  /**
    * Get the property object with the given name.
    *
    * @param name the property name

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimDeviceSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimDeviceSim.java
@@ -29,6 +29,27 @@ public class SimDeviceSim {
   }
 
   /**
+   * Constructs a SimDeviceSim.
+   *
+   * @param name name of the SimDevice
+   * @param index device index number to append to name
+   */
+  public SimDeviceSim(String name, int index) {
+    this(name + "[" + index + "]");
+  }
+
+  /**
+   * Constructs a SimDeviceSim.
+   *
+   * @param name name of the SimDevice
+   * @param index device index number to append to name
+   * @param channel device channel number to append to name
+   */
+  public SimDeviceSim(String name, int index, int channel) {
+    this(name + "[" + index + "," + channel + "]");
+  }
+
+  /**
    * Get the property object with the given name.
    *
    * @param name the property name


### PR DESCRIPTION
Better parallelism with `SimDevice.create()`, so teams don't have to mess with concatenating the index/channel themselves.

Any chance some can do the C++ side?