### PR TITLE
Revert formatting for Rotation2d.rotateBy method comment. Fix typo inRotation2d.rotateBy comments.

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/geometry/Rotation2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/geometry/Rotation2d.java
@@ -112,8 +112,13 @@ public class Rotation2d {
   /**
    * Adds the new rotation to the current rotation using a rotation matrix.
    *
-   * <p>The matrix multiplication is as follows: [cos_new] [other.cos, -other.sin][cos] [sin_new] =
-   * [other.sin, other.cos][sin] value_new = atan2(cos_new, sin_new)
+   * <p>The matrix multiplication is as follows:
+   *
+   * <pre>
+   * [cos_new]   [other.cos, -other.sin][cos]
+   * [sin_new] = [other.sin,  other.cos][sin]
+   * value_new = atan2(sin_new, cos_new)
+   * </pre>
    *
    * @param other The rotation to rotate by.
    * @return The new rotated Rotation2d.

--- a/wpimath/src/main/native/include/frc/geometry/Rotation2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Rotation2d.h
@@ -131,10 +131,11 @@ class Rotation2d {
   /**
    * Adds the new rotation to the current rotation using a rotation matrix.
    *
+   * <pre>
    * [cos_new]   [other.cos, -other.sin][cos]
    * [sin_new] = [other.sin,  other.cos][sin]
-   *
-   * value_new = std::atan2(cos_new, sin_new)
+   * value_new = std::atan2(sin_new, cos_new)
+   * </pre>
    *
    * @param other The rotation to rotate by.
    *


### PR DESCRIPTION
Hey y'all! I was looking at the inline comments for the [Rotation2d.rotateBy](https://github.com/wpilibsuite/allwpilib/blob/43d40c6e9e95ed0d7bb5f1baa932af37d4449189/wpimath/src/main/java/edu/wpi/first/wpilibj/geometry/Rotation2d.java#L115) method the other day and found it very difficult to follow. It looks like the formatting got garbled in https://github.com/wpilibsuite/allwpilib/pull/1768

This PR restores the formatting to it's previous version so it's easier to read. It also fixes an incorrect piece in the documentation where it states return value of the function would be `atan2(cos_new, sin_new)` based on the matrix math, when the return type is actually `atan2(sin_new, cos_new)`