### PR TITLE
Require non-zero positive value for `PIDController.period`

### DIFF
--- a/wpilibc/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/PIDController.cpp
@@ -20,7 +20,8 @@ PIDController::PIDController(double Kp, double Ki, double Kd,
                              units::second_t period)
     : m_Kp(Kp), m_Ki(Ki), m_Kd(Kd), m_period(period) {
   if (period == 0_s) {
-    frc::DriverStation::ReportError("Controller period must be a non-zero positive number!");
+    frc::DriverStation::ReportError(
+        "Controller period must be a non-zero positive number!");
   }
   static int instances = 0;
   instances++;

--- a/wpilibc/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/PIDController.cpp
@@ -19,9 +19,12 @@ using namespace frc2;
 PIDController::PIDController(double Kp, double Ki, double Kd,
                              units::second_t period)
     : m_Kp(Kp), m_Ki(Ki), m_Kd(Kd), m_period(period) {
-  if (period == 0_s) {
+  if (period <= 0_s) {
     frc::DriverStation::ReportError(
         "Controller period must be a non-zero positive number!");
+    m_period = 20_ms;
+    frc::DriverStation::ReportWarning(
+         "Set controller period to default of 20ms.");
   }
   static int instances = 0;
   instances++;

--- a/wpilibc/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/PIDController.cpp
@@ -24,7 +24,7 @@ PIDController::PIDController(double Kp, double Ki, double Kd,
         "Controller period must be a non-zero positive number!");
     m_period = 20_ms;
     frc::DriverStation::ReportWarning(
-         "Set controller period to default of 20ms.");
+        "Controller period defaulted to 20ms.");
   }
   static int instances = 0;
   instances++;

--- a/wpilibc/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/PIDController.cpp
@@ -9,6 +9,7 @@
 
 #include <hal/FRCUsageReporting.h>
 
+#include "frc/DriverStation.h"
 #include "frc/MathUtil.h"
 #include "frc/smartdashboard/SendableBuilder.h"
 #include "frc/smartdashboard/SendableRegistry.h"
@@ -18,6 +19,9 @@ using namespace frc2;
 PIDController::PIDController(double Kp, double Ki, double Kd,
                              units::second_t period)
     : m_Kp(Kp), m_Ki(Ki), m_Kd(Kd), m_period(period) {
+  if (period == 0_s) {
+    frc::DriverStation::ReportError("Controller period must be a non-zero positive number!");
+  }
   static int instances = 0;
   instances++;
   HAL_Report(HALUsageReporting::kResourceType_PIDController2, instances);

--- a/wpilibc/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/PIDController.cpp
@@ -23,8 +23,7 @@ PIDController::PIDController(double Kp, double Ki, double Kd,
     frc::DriverStation::ReportError(
         "Controller period must be a non-zero positive number!");
     m_period = 20_ms;
-    frc::DriverStation::ReportWarning(
-        "Controller period defaulted to 20ms.");
+    frc::DriverStation::ReportWarning("Controller period defaulted to 20ms.");
   }
   static int instances = 0;
   instances++;

--- a/wpilibc/src/main/native/include/frc/controller/PIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/PIDController.h
@@ -27,7 +27,7 @@ class PIDController : public frc::Sendable,
    * @param Ki     The integral coefficient.
    * @param Kd     The derivative coefficient.
    * @param period The period between controller updates in seconds. The
-   *               default is 20 milliseconds.
+   *               default is 20 milliseconds. Must be non-zero and positive.
    */
   PIDController(double Kp, double Ki, double Kd,
                 units::second_t period = 20_ms);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
@@ -74,13 +74,16 @@ public class PIDController implements Sendable, AutoCloseable {
    * @param kp The proportional coefficient.
    * @param ki The integral coefficient.
    * @param kd The derivative coefficient.
-   * @param period The period between controller updates in seconds.
+   * @param period The period between controller updates in seconds. Must be non-zero and positive.
    */
   public PIDController(double kp, double ki, double kd, double period) {
     m_kp = kp;
     m_ki = ki;
     m_kd = kd;
 
+    if (period <= 0) {
+      throw new IllegalArgumentException("Controller period must be a non-zero positive number!");
+    }
     m_period = period;
 
     instances++;


### PR DESCRIPTION
Fixes #3173 