### PR TITLE
[wpimath] Fix order of setting gyro offset in pose estimators.

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/estimator/DifferentialDrivePoseEstimator.java
@@ -217,8 +217,8 @@ public class DifferentialDrivePoseEstimator {
    */
   public void resetPosition(Pose2d poseMeters, Rotation2d gyroAngle) {
     m_previousAngle = poseMeters.getRotation();
-    m_gyroOffset = getEstimatedPosition().getRotation().minus(gyroAngle);
     m_observer.setXhat(fillStateVector(poseMeters, 0.0, 0.0));
+    m_gyroOffset = getEstimatedPosition().getRotation().minus(gyroAngle);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/estimator/MecanumDrivePoseEstimator.java
@@ -182,8 +182,8 @@ public class MecanumDrivePoseEstimator {
    */
   public void resetPosition(Pose2d poseMeters, Rotation2d gyroAngle) {
     m_previousAngle = poseMeters.getRotation();
-    m_gyroOffset = getEstimatedPosition().getRotation().minus(gyroAngle);
     m_observer.setXhat(StateSpaceUtil.poseTo3dVector(poseMeters));
+    m_gyroOffset = getEstimatedPosition().getRotation().minus(gyroAngle);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/wpilibj/estimator/SwerveDrivePoseEstimator.java
@@ -182,8 +182,8 @@ public class SwerveDrivePoseEstimator {
    */
   public void resetPosition(Pose2d poseMeters, Rotation2d gyroAngle) {
     m_previousAngle = poseMeters.getRotation();
-    m_gyroOffset = getEstimatedPosition().getRotation().minus(gyroAngle);
     m_observer.setXhat(StateSpaceUtil.poseTo3dVector(poseMeters));
+    m_gyroOffset = getEstimatedPosition().getRotation().minus(gyroAngle);
   }
 
   /**

--- a/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
@@ -56,8 +56,8 @@ void DifferentialDrivePoseEstimator::SetVisionMeasurementStdDevs(
 void DifferentialDrivePoseEstimator::ResetPosition(
     const Pose2d& pose, const Rotation2d& gyroAngle) {
   m_previousAngle = pose.Rotation();
-  m_gyroOffset = GetEstimatedPosition().Rotation() - gyroAngle;
   m_observer.SetXhat(FillStateVector(pose, 0_m, 0_m));
+  m_gyroOffset = GetEstimatedPosition().Rotation() - gyroAngle;
 }
 
 Pose2d DifferentialDrivePoseEstimator::GetEstimatedPosition() const {


### PR DESCRIPTION
The gyro offset should be determined from the desired initial pose, not the current pose. This fix reflects the behavior of the [odometry classes](https://github.com/wpilibsuite/allwpilib/blob/99b5ad9ebb826485d1e8eb6c0940f5bea17b8507/wpimath/src/main/java/edu/wpi/first/wpilibj/kinematics/DifferentialDriveOdometry.java#L68) and the c++ holonomic pose estimators.

Huge thanks to @CptJJ for finding this bug and suggesting a fix.