### PR TITLE
[glass] Auto-size plots to fit window

### DIFF
--- a/glass/src/lib/native/cpp/other/Plot.cpp
+++ b/glass/src/lib/native/cpp/other/Plot.cpp
@@ -897,9 +897,11 @@ void PlotView::Display() {
       ++numAuto;
     }
   }
-  availHeight /= numAuto;
-  for (size_t i = 0; i < m_plots.size(); ++i) {
-    m_plots[i]->SetAutoHeight(availHeight);
+  if (numAuto > 0) {
+    availHeight /= numAuto;
+    for (size_t i = 0; i < m_plots.size(); ++i) {
+      m_plots[i]->SetAutoHeight(availHeight);
+    }
   }
 
   double now = wpi::Now() * 1.0e-6;


### PR DESCRIPTION
Plots can still be set to have a fixed height, in which case the remaining
space is distributed amongst the auto-sized plots.

Fixes #3192.