### PR TITLE
gitignore: Ignore .cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,5 +222,6 @@ compile_commands.json
 # clang configuration and clangd cache
 .clang
 .clangd/
+.cache/
 
 imgui.ini


### PR DESCRIPTION
This is used by newer clangd versions.