### PR TITLE
Change CommandBase::withName to return CommandBase

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandBase.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandBase.java
@@ -56,7 +56,7 @@ public abstract class CommandBase implements Sendable, Command {
    * @param name name
    * @return the decorated Command
    */
-  public Command withName(String name) {
+  public CommandBase withName(String name) {
     this.setName(name);
     return this;
   }


### PR DESCRIPTION
This allows it to return the same type, retaining the Sendable portion