### PR TITLE
[wpilib] Field2d enhancements

### DIFF
--- a/glass/.styleguide
+++ b/glass/.styleguide
@@ -21,6 +21,7 @@ repoRootNameOverride {
 includeOtherLibs {
   ^GLFW
   ^cscore
+  ^frc/
   ^imgui
   ^ntcore
   ^wpi/

--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -671,10 +671,9 @@ void glass::DisplayField2D(Field2DModel* model, const ImVec2& contentSize) {
   if (!targets.empty()) {
     // Find the "best" drag target of the available options.  Prefer
     // center to non-center, and then pick the closest hit.
-    std::sort(targets.begin(), targets.end(),
-              [](const auto& a, const auto& b) {
-                return a.corner == 0 || a.dist < b.dist;
-              });
+    std::sort(targets.begin(), targets.end(), [](const auto& a, const auto& b) {
+      return a.corner == 0 || a.dist < b.dist;
+    });
     auto& target = targets.front();
 
     targetCenter = target.center;

--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -790,9 +790,13 @@ void glass::DisplayField2D(Field2DModel* model, const ImVec2& contentSize) {
   // drag targets
   wpi::SmallVector<ObjectDragTargetInfo, 4> targets;
 
+  // splitter so lines are put behind arrows
+  static ImDrawListSplitter drawSplit;
+
   // lines; static so buffer gets reused
   static std::vector<ImVec2> centerLine, leftLine, rightLine;
 
+  drawSplit.Split(drawList, 2);
   model->ForEachFieldObjectGroup([&](auto& groupModel, auto name) {
     if (!groupModel.Exists()) {
       return;
@@ -811,6 +815,7 @@ void glass::DisplayField2D(Field2DModel* model, const ImVec2& contentSize) {
     leftLine.resize(0);
     rightLine.resize(0);
 
+    drawSplit.SetCurrentChannel(drawList, 1);
     groupModel.ForEachFieldObject([&](auto& objModel) {
       ObjectFrameData ofd{objModel, ffd, displayOptions};
 
@@ -831,12 +836,14 @@ void glass::DisplayField2D(Field2DModel* model, const ImVec2& contentSize) {
       ofd.Draw(drawList, &centerLine, &leftLine, &rightLine);
     });
 
+    drawSplit.SetCurrentChannel(drawList, 0);
     objGroup->DrawLine(drawList, centerLine);
     objGroup->DrawLine(drawList, leftLine);
     objGroup->DrawLine(drawList, rightLine);
 
     PopID();
   });
+  drawSplit.Merge(drawList);
 
   ObjectDragTargetInfo* target = &gDragState.target;
 

--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -65,17 +65,17 @@ struct DisplayOptions {
   explicit DisplayOptions(const gui::Texture& texture) : texture{texture} {}
 
   enum Style { kBoxImage = 0, kLine, kLineClosed, kTrack };
-  Style style;
-  float weight;
-  int color;
+  Style style = kBoxImage;
+  float weight = 4.0f;
+  int color = 0;
 
-  float width;
-  float length;
+  float width = 0.0f;
+  float length = 0.0f;
 
-  bool arrows;
-  int arrowSize;
-  float arrowWeight;
-  int arrowColor;
+  bool arrows = true;
+  int arrowSize = 50;
+  float arrowWeight = 4.0f;
+  int arrowColor = 0;
 
   const gui::Texture& texture;
 };

--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -118,6 +118,7 @@ struct DisplayOptions {
   static constexpr int kDefaultArrowSize = 50;
   static constexpr float kDefaultArrowWeight = 4.0f;
   static constexpr ImU32 kDefaultArrowColor = IM_COL32(0, 255, 0, 255);
+  static constexpr bool kDefaultSelectable = true;
 
   Style style = kDefaultStyle;
   float weight = kDefaultWeight;
@@ -130,6 +131,8 @@ struct DisplayOptions {
   int arrowSize = kDefaultArrowSize;
   float arrowWeight = kDefaultArrowWeight;
   int arrowColor = kDefaultArrowColor;
+
+  bool selectable = kDefaultSelectable;
 
   const gui::Texture& texture;
 };
@@ -201,6 +204,8 @@ class ObjectInfo {
   int* m_pArrowSize;
   float* m_pArrowWeight;
   int* m_pArrowColor;
+
+  bool* m_pSelectable;
 
   std::string* m_pFilename;
   gui::Texture m_texture;
@@ -550,6 +555,8 @@ ObjectInfo::ObjectInfo() {
       storage.GetFloatRef("arrowWeight", DisplayOptions::kDefaultArrowWeight);
   m_pArrowColor =
       storage.GetIntRef("arrowColor", DisplayOptions::kDefaultArrowColor);
+  m_pSelectable =
+      storage.GetBoolRef("selectable", DisplayOptions::kDefaultSelectable);
 }
 
 DisplayOptions ObjectInfo::GetDisplayOptions() const {
@@ -563,6 +570,7 @@ DisplayOptions ObjectInfo::GetDisplayOptions() const {
   rv.arrowSize = *m_pArrowSize;
   rv.arrowWeight = *m_pArrowWeight;
   rv.arrowColor = *m_pArrowColor;
+  rv.selectable = *m_pSelectable;
   return rv;
 }
 
@@ -611,6 +619,8 @@ void ObjectInfo::DisplaySettings() {
       *m_pArrowColor = col;
     }
   }
+
+  ImGui::Checkbox("Selectable", m_pSelectable);
 }
 
 void ObjectInfo::DrawLine(ImDrawList* drawList,
@@ -1037,7 +1047,8 @@ void FieldDisplay::DisplayObject(FieldObjectModel& model, wpi::StringRef name) {
     PoseFrameData pfd{pose, model, i, m_ffd, displayOptions};
 
     // check for potential drag targets
-    if (m_isHovered && !gDragState.target.objModel) {
+    if (displayOptions.selectable && m_isHovered &&
+        !gDragState.target.objModel) {
       auto [corner, dist] = pfd.IsHovered(m_mousePos);
       if (corner > 0) {
         m_targets.emplace_back(pfd.GetDragTarget(corner, dist));

--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -959,13 +959,11 @@ void FieldDisplay::Display(FieldInfo* field, Field2DModel* model,
 
   // field objects
   m_targets.resize(0);
-  m_drawSplit.Split(m_drawList, 2);
   model->ForEachFieldObject([this](auto& objModel, auto name) {
     if (objModel.Exists()) {
       DisplayObject(objModel, name);
     }
   });
-  m_drawSplit.Merge(m_drawList);
 
   SelectedTargetInfo* target = nullptr;
 
@@ -1038,6 +1036,7 @@ void FieldDisplay::DisplayObject(FieldObjectModel& model, wpi::StringRef name) {
   m_leftLine.resize(0);
   m_rightLine.resize(0);
 
+  m_drawSplit.Split(m_drawList, 2);
   m_drawSplit.SetCurrentChannel(m_drawList, 1);
   wpi::ArrayRef<frc::Pose2d> poses = gPopupState.GetInsertModel() == &model
                                          ? gPopupState.GetInsertPoses()
@@ -1071,6 +1070,7 @@ void FieldDisplay::DisplayObject(FieldObjectModel& model, wpi::StringRef name) {
   obj->DrawLine(m_drawList, m_centerLine);
   obj->DrawLine(m_drawList, m_leftLine);
   obj->DrawLine(m_drawList, m_rightLine);
+  m_drawSplit.Merge(m_drawList);
 
   PopID();
 }

--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -1110,7 +1110,7 @@ void PopupState::DisplayTarget(Field2DModel* model, const FieldFrameData& ffd) {
     ImGui::CloseCurrentPopup();
   }
   if (ImGui::Button("Delete Object (ALL Poses)")) {
-    model->RemoveFieldObject(m_target.objModel->GetName());
+    model->RemoveFieldObject(m_target.name);
     ImGui::CloseCurrentPopup();
   }
 }

--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -833,7 +833,9 @@ void glass::DisplayField2D(Field2DModel* model, const ImVec2& contentSize) {
 
       // check for potential drag targets
       if (isHovered && !gDragState.target.objModel) {
-        auto [corner, dist] = ofd.IsHovered(mousePos);
+        int corner;
+        double dist;
+        std::tie(corner, dist) = ofd.IsHovered(mousePos);
         if (corner > 0) {
           targets.emplace_back(ofd.GetDragTarget(corner, dist));
           targets.back().name = name;

--- a/glass/src/lib/native/cpp/other/Field2D.cpp
+++ b/glass/src/lib/native/cpp/other/Field2D.cpp
@@ -8,10 +8,11 @@
 #include <cmath>
 #include <memory>
 #include <utility>
-#include "frc/geometry/Pose2d.h"
 
+#include <frc/geometry/Pose2d.h>
 #include <frc/geometry/Rotation2d.h>
 #include <frc/geometry/Translation2d.h>
+
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui.h>
 #include <imgui_internal.h>

--- a/glass/src/lib/native/include/glass/other/Field2D.h
+++ b/glass/src/lib/native/include/glass/other/Field2D.h
@@ -4,7 +4,11 @@
 
 #pragma once
 
+#include <frc/geometry/Pose2d.h>
+#include <frc/geometry/Rotation2d.h>
+#include <frc/geometry/Translation2d.h>
 #include <imgui.h>
+#include <wpi/ArrayRef.h>
 #include <wpi/STLExtras.h>
 #include <wpi/StringRef.h>
 
@@ -13,29 +17,23 @@
 
 namespace glass {
 
-class DataSource;
-
 class FieldObjectModel : public Model {
  public:
-  virtual DataSource* GetXData() = 0;
-  virtual DataSource* GetYData() = 0;
-  virtual DataSource* GetRotationData() = 0;
+  virtual const char* GetName() const = 0;
 
-  virtual void SetPose(double x, double y, double rot) = 0;
-  virtual void SetPosition(double x, double y) = 0;
-  virtual void SetRotation(double rot) = 0;
-};
-
-class FieldObjectGroupModel : public Model {
- public:
-  virtual void ForEachFieldObject(
-      wpi::function_ref<void(FieldObjectModel& model)> func) = 0;
+  virtual wpi::ArrayRef<frc::Pose2d> GetPoses() = 0;
+  virtual void SetPoses(wpi::ArrayRef<frc::Pose2d> poses) = 0;
+  virtual void SetPose(size_t i, frc::Pose2d pose) = 0;
+  virtual void SetPosition(size_t i, frc::Translation2d pos) = 0;
+  virtual void SetRotation(size_t i, frc::Rotation2d rot) = 0;
 };
 
 class Field2DModel : public Model {
  public:
-  virtual void ForEachFieldObjectGroup(
-      wpi::function_ref<void(FieldObjectGroupModel& model, wpi::StringRef name)>
+  virtual FieldObjectModel* AddFieldObject(wpi::StringRef name) = 0;
+  virtual void RemoveFieldObject(wpi::StringRef name) = 0;
+  virtual void ForEachFieldObject(
+      wpi::function_ref<void(FieldObjectModel& model, wpi::StringRef name)>
           func) = 0;
 };
 

--- a/glass/src/lib/native/include/glass/other/Field2D.h
+++ b/glass/src/lib/native/include/glass/other/Field2D.h
@@ -11,6 +11,7 @@
 #include <wpi/ArrayRef.h>
 #include <wpi/STLExtras.h>
 #include <wpi/StringRef.h>
+#include <wpi/Twine.h>
 
 #include "glass/Model.h"
 #include "glass/View.h"
@@ -30,8 +31,8 @@ class FieldObjectModel : public Model {
 
 class Field2DModel : public Model {
  public:
-  virtual FieldObjectModel* AddFieldObject(wpi::StringRef name) = 0;
-  virtual void RemoveFieldObject(wpi::StringRef name) = 0;
+  virtual FieldObjectModel* AddFieldObject(const wpi::Twine& name) = 0;
+  virtual void RemoveFieldObject(const wpi::Twine& name) = 0;
   virtual void ForEachFieldObject(
       wpi::function_ref<void(FieldObjectModel& model, wpi::StringRef name)>
           func) = 0;

--- a/glass/src/libnt/native/cpp/NTField2D.cpp
+++ b/glass/src/libnt/native/cpp/NTField2D.cpp
@@ -12,16 +12,14 @@
 #include <wpi/MathExtras.h>
 #include <wpi/SmallVector.h>
 
-#include "glass/DataSource.h"
-
 using namespace glass;
 
-class NTField2DModel::GroupModel : public FieldObjectGroupModel {
+class NTField2DModel::ObjectModel : public FieldObjectModel {
  public:
-  GroupModel(wpi::StringRef name, NT_Entry entry)
+  ObjectModel(wpi::StringRef name, NT_Entry entry)
       : m_name{name}, m_entry{entry} {}
 
-  wpi::StringRef GetName() const { return m_name; }
+  const char* GetName() const override { return m_name.c_str(); }
   NT_Entry GetEntry() const { return m_entry; }
 
   void NTUpdate(const nt::Value& value);
@@ -34,200 +32,117 @@ class NTField2DModel::GroupModel : public FieldObjectGroupModel {
   bool Exists() override { return nt::GetEntryType(m_entry) != NT_UNASSIGNED; }
   bool IsReadOnly() override { return false; }
 
-  void ForEachFieldObject(
-      wpi::function_ref<void(FieldObjectModel& model)> func) override;
+  wpi::ArrayRef<frc::Pose2d> GetPoses() override { return m_poses; }
+  void SetPoses(wpi::ArrayRef<frc::Pose2d> poses) override;
+  void SetPose(size_t i, frc::Pose2d pose) override;
+  void SetPosition(size_t i, frc::Translation2d pos) override;
+  void SetRotation(size_t i, frc::Rotation2d rot) override;
 
  private:
+  void UpdateNT();
+
   std::string m_name;
   NT_Entry m_entry;
 
-  // keep count of objects rather than resizing vector, as there is a fair
-  // amount of overhead associated with the latter (DataSource record keeping)
-  size_t m_count = 0;
-  class ObjectModel;
-  std::vector<std::unique_ptr<ObjectModel>> m_objects;
+  std::vector<frc::Pose2d> m_poses;
 };
 
-class NTField2DModel::GroupModel::ObjectModel : public FieldObjectModel {
- public:
-  ObjectModel(wpi::StringRef name, NT_Entry entry, int index)
-      : m_entry{entry},
-        m_index{index},
-        m_x{name + "[" + wpi::Twine{index} + "]/x"},
-        m_y{name + "[" + wpi::Twine{index} + "]/y"},
-        m_rot{name + "[" + wpi::Twine{index} + "]/rot"} {}
-
-  void SetExists(bool exists) { m_exists = exists; }
-
-  void Update() override {}
-  bool Exists() override { return m_exists; }
-  bool IsReadOnly() override { return false; }
-
-  DataSource* GetXData() override { return &m_x; }
-  DataSource* GetYData() override { return &m_y; }
-  DataSource* GetRotationData() override { return &m_rot; }
-
-  void SetPose(double x, double y, double rot) override;
-  void SetPosition(double x, double y) override;
-  void SetRotation(double rot) override;
-
- private:
-  void SetPoseImpl(double x, double y, double rot, bool setX, bool setY,
-                   bool setRot);
-
-  NT_Entry m_entry;
-  int m_index;
-  bool m_exists = true;
-
- public:
-  DataSource m_x;
-  DataSource m_y;
-  DataSource m_rot;
-};
-
-void NTField2DModel::GroupModel::NTUpdate(const nt::Value& value) {
-  // Allow raw for large arrays (since NT is limited to 255 elements)
-  wpi::ArrayRef<double> arr;
-  std::vector<double> storage;
-  if (value.IsRaw()) {
+void NTField2DModel::ObjectModel::NTUpdate(const nt::Value& value) {
+  if (value.IsDoubleArray()) {
+    auto arr = value.GetDoubleArray();
+    auto size = arr.size();
+    if ((size % 3) != 0) {
+      return;
+    }
+    m_poses.resize(size / 3);
+    for (size_t i = 0; i < size / 3; ++i) {
+      m_poses[i] = frc::Pose2d{
+          units::meter_t{arr[i * 3 + 0]}, units::meter_t{arr[i * 3 + 1]},
+          frc::Rotation2d{units::degree_t{arr[i * 3 + 2]}}};
+    }
+  } else if (value.IsRaw()) {
     // treat it simply as an array of doubles
     wpi::StringRef data = value.GetRaw();
 
     // must be triples of doubles
-    if ((data.size() % (3 * 8)) != 0) {
-      m_count = 0;
+    auto size = data.size();
+    if ((size % (3 * 8)) != 0) {
       return;
     }
-    storage.reserve(data.size() / 8);
+    m_poses.resize(size / (3 * 8));
     const char* p = data.begin();
-    while (p < data.end()) {
-      storage.emplace_back(wpi::BitsToDouble(
+    for (size_t i = 0; i < size / (3 * 8); ++i) {
+      double x = wpi::BitsToDouble(
           wpi::support::endian::readNext<uint64_t, wpi::support::big,
-                                         wpi::support::unaligned>(p)));
+                                         wpi::support::unaligned>(p));
+      double y = wpi::BitsToDouble(
+          wpi::support::endian::readNext<uint64_t, wpi::support::big,
+                                         wpi::support::unaligned>(p));
+      double rot = wpi::BitsToDouble(
+          wpi::support::endian::readNext<uint64_t, wpi::support::big,
+                                         wpi::support::unaligned>(p));
+      m_poses[i] = frc::Pose2d{units::meter_t{x}, units::meter_t{y},
+                               frc::Rotation2d{units::degree_t{rot}}};
     }
-
-    arr = storage;
-  } else if (value.IsDoubleArray()) {
-    arr = value.GetDoubleArray();
-
-    // must be triples
-    if ((arr.size() % 3) != 0) {
-      m_count = 0;
-      return;
-    }
-  } else {
-    m_count = 0;
-    return;
-  }
-
-  m_count = arr.size() / 3;
-  if (m_count > m_objects.size()) {
-    m_objects.reserve(m_count);
-    for (size_t i = m_objects.size(); i < m_count; ++i) {
-      m_objects.emplace_back(std::make_unique<ObjectModel>(m_name, m_entry, i));
-    }
-  }
-  if (m_count < m_objects.size()) {
-    for (size_t i = m_count; i < m_objects.size(); ++i) {
-      m_objects[i]->SetExists(false);
-    }
-  }
-
-  for (size_t i = 0; i < m_count; ++i) {
-    auto& obj = m_objects[i];
-    obj->SetExists(true);
-    obj->m_x.SetValue(arr[i * 3], value.last_change());
-    obj->m_y.SetValue(arr[i * 3 + 1], value.last_change());
-    obj->m_rot.SetValue(arr[i * 3 + 2], value.last_change());
   }
 }
 
-void NTField2DModel::GroupModel::ForEachFieldObject(
-    wpi::function_ref<void(FieldObjectModel& model)> func) {
-  for (size_t i = 0; i < m_count; ++i) {
-    func(*m_objects[i]);
-  }
-}
-
-void NTField2DModel::GroupModel::ObjectModel::SetPose(double x, double y,
-                                                      double rot) {
-  SetPoseImpl(x, y, rot, true, true, true);
-}
-
-void NTField2DModel::GroupModel::ObjectModel::SetPosition(double x, double y) {
-  SetPoseImpl(x, y, 0, true, true, false);
-}
-
-void NTField2DModel::GroupModel::ObjectModel::SetRotation(double rot) {
-  SetPoseImpl(0, 0, rot, false, false, true);
-}
-
-void NTField2DModel::GroupModel::ObjectModel::SetPoseImpl(double x, double y,
-                                                          double rot, bool setX,
-                                                          bool setY,
-                                                          bool setRot) {
-  // get from NT, validate type and size
-  auto value = nt::GetEntryValue(m_entry);
-  if (!value) {
-    return;
-  }
-
-  if (value->IsDoubleArray()) {
-    auto origArr = value->GetDoubleArray();
-    if (static_cast<int>(origArr.size()) < ((m_index + 1) * 3)) {
-      return;
+void NTField2DModel::ObjectModel::UpdateNT() {
+  if (m_poses.size() < (255 / 3)) {
+    wpi::SmallVector<double, 9> arr;
+    for (auto&& pose : m_poses) {
+      auto& translation = pose.Translation();
+      arr.push_back(translation.X().to<double>());
+      arr.push_back(translation.Y().to<double>());
+      arr.push_back(pose.Rotation().Degrees().to<double>());
     }
-
-    // copy existing array
-    wpi::SmallVector<double, 8> arr;
-    arr.reserve(origArr.size());
-    for (auto&& elem : origArr) {
-      arr.emplace_back(elem);
-    }
-
-    // update value
-    if (setX) {
-      arr[m_index * 3 + 0] = x;
-    }
-    if (setY) {
-      arr[m_index * 3 + 1] = y;
-    }
-    if (setRot) {
-      arr[m_index * 3 + 2] = rot;
-    }
-
-    // set back to NT
     nt::SetEntryTypeValue(m_entry, nt::Value::MakeDoubleArray(arr));
-  } else if (value->IsRaw()) {
-    auto origData = value->GetRaw();
-    if (static_cast<int>(origData.size()) < ((m_index + 1) * 3)) {
-      return;
+  } else {
+    // send as raw array of doubles if too big for NT array
+    std::vector<char> arr;
+    arr.resize(m_poses.size() * 3 * 8);
+    char* p = arr.data();
+    for (auto&& pose : m_poses) {
+      auto& translation = pose.Translation();
+      wpi::support::endian::write64be(
+          p, wpi::DoubleToBits(translation.X().to<double>()));
+      p += 8;
+      wpi::support::endian::write64be(
+          p, wpi::DoubleToBits(translation.Y().to<double>()));
+      p += 8;
+      wpi::support::endian::write64be(
+          p, wpi::DoubleToBits(pose.Rotation().Degrees().to<double>()));
+      p += 8;
     }
-
-    // copy existing array
-    std::vector<char> data;
-    data.reserve(origData.size());
-    for (auto&& elem : origData) {
-      data.emplace_back(elem);
-    }
-
-    // update value
-    if (setX) {
-      wpi::support::endian::write64be(&data[(m_index * 3 + 0) * 8],
-                                      wpi::DoubleToBits(x));
-    }
-    if (setY) {
-      wpi::support::endian::write64be(&data[(m_index * 3 + 1) * 8],
-                                      wpi::DoubleToBits(y));
-    }
-    if (setRot) {
-      wpi::support::endian::write64be(&data[(m_index * 3 + 2) * 8],
-                                      wpi::DoubleToBits(rot));
-    }
-
-    // set back to NT
     nt::SetEntryTypeValue(
-        m_entry, nt::Value::MakeRaw(wpi::StringRef{data.data(), data.size()}));
+        m_entry, nt::Value::MakeRaw(wpi::StringRef{arr.data(), arr.size()}));
+  }
+}
+
+void NTField2DModel::ObjectModel::SetPoses(wpi::ArrayRef<frc::Pose2d> poses) {
+  m_poses = poses;
+  UpdateNT();
+}
+
+void NTField2DModel::ObjectModel::SetPose(size_t i, frc::Pose2d pose) {
+  if (i < m_poses.size()) {
+    m_poses[i] = pose;
+    UpdateNT();
+  }
+}
+
+void NTField2DModel::ObjectModel::SetPosition(size_t i,
+                                              frc::Translation2d pos) {
+  if (i < m_poses.size()) {
+    m_poses[i] = frc::Pose2d{pos, m_poses[i].Rotation()};
+    UpdateNT();
+  }
+}
+
+void NTField2DModel::ObjectModel::SetRotation(size_t i, frc::Rotation2d rot) {
+  if (i < m_poses.size()) {
+    m_poses[i] = frc::Pose2d{m_poses[i].Translation(), rot};
+    UpdateNT();
   }
 }
 
@@ -257,9 +172,9 @@ void NTField2DModel::Update() {
     // common case: update of existing entry; search by entry
     if (event.flags & NT_NOTIFY_UPDATE) {
       auto it = std::find_if(
-          m_groups.begin(), m_groups.end(),
+          m_objects.begin(), m_objects.end(),
           [&](const auto& e) { return e->GetEntry() == event.entry; });
-      if (it != m_groups.end()) {
+      if (it != m_objects.end()) {
         (*it)->NTUpdate(*event.value);
         continue;
       }
@@ -271,20 +186,20 @@ void NTField2DModel::Update() {
       if (name.empty() || name[0] == '.') {
         continue;
       }
-      auto it = std::lower_bound(m_groups.begin(), m_groups.end(), event.name,
+      auto it = std::lower_bound(m_objects.begin(), m_objects.end(), event.name,
                                  [](const auto& e, wpi::StringRef name) {
                                    return e->GetName() < name;
                                  });
-      bool match = (it != m_groups.end() && (*it)->GetName() == event.name);
+      bool match = (it != m_objects.end() && (*it)->GetName() == event.name);
       if (event.flags & NT_NOTIFY_DELETE) {
         if (match) {
-          m_groups.erase(it);
+          m_objects.erase(it);
         }
         continue;
       } else if (event.flags & NT_NOTIFY_NEW) {
         if (!match) {
-          it = m_groups.emplace(
-              it, std::make_unique<GroupModel>(event.name, event.entry));
+          it = m_objects.emplace(
+              it, std::make_unique<ObjectModel>(event.name, event.entry));
         }
       } else if (!match) {
         continue;
@@ -304,12 +219,36 @@ bool NTField2DModel::IsReadOnly() {
   return false;
 }
 
-void NTField2DModel::ForEachFieldObjectGroup(
-    wpi::function_ref<void(FieldObjectGroupModel& model, wpi::StringRef name)>
+FieldObjectModel* NTField2DModel::AddFieldObject(wpi::StringRef name) {
+  auto it = std::lower_bound(
+      m_objects.begin(), m_objects.end(), name,
+      [](const auto& e, wpi::StringRef name) { return e->GetName() < name; });
+  bool match = (it != m_objects.end() && (*it)->GetName() == name);
+  if (!match) {
+    it = m_objects.emplace(
+        it, std::make_unique<ObjectModel>(name, m_nt.GetEntry(name)));
+  }
+  return it->get();
+}
+
+void NTField2DModel::RemoveFieldObject(wpi::StringRef name) {
+  auto it = std::lower_bound(
+      m_objects.begin(), m_objects.end(), name,
+      [](const auto& e, wpi::StringRef name) { return e->GetName() < name; });
+  bool match = (it != m_objects.end() && (*it)->GetName() == name);
+  if (!match) {
+    return;
+  }
+  nt::DeleteEntry((*it)->GetEntry());
+  m_objects.erase(it);
+}
+
+void NTField2DModel::ForEachFieldObject(
+    wpi::function_ref<void(FieldObjectModel& model, wpi::StringRef name)>
         func) {
-  for (auto&& group : m_groups) {
-    if (group->Exists()) {
-      func(*group, wpi::StringRef{group->GetName()}.drop_front(m_path.size()));
+  for (auto&& obj : m_objects) {
+    if (obj->Exists()) {
+      func(*obj, wpi::StringRef{obj->GetName()}.drop_front(m_path.size()));
     }
   }
 }

--- a/glass/src/libnt/native/cpp/NTField2D.cpp
+++ b/glass/src/libnt/native/cpp/NTField2D.cpp
@@ -94,7 +94,7 @@ void NTField2DModel::GroupModel::NTUpdate(const nt::Value& value) {
     wpi::StringRef data = value.GetRaw();
 
     // must be triples of doubles
-    if ((data.size() % (3*8)) != 0) {
+    if ((data.size() % (3 * 8)) != 0) {
       m_count = 0;
       return;
     }

--- a/glass/src/libnt/native/include/glass/networktables/NTField2D.h
+++ b/glass/src/libnt/native/include/glass/networktables/NTField2D.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <ntcore_cpp.h>
@@ -32,8 +33,8 @@ class NTField2DModel : public Field2DModel {
   bool Exists() override;
   bool IsReadOnly() override;
 
-  FieldObjectModel* AddFieldObject(wpi::StringRef name) override;
-  void RemoveFieldObject(wpi::StringRef name) override;
+  FieldObjectModel* AddFieldObject(const wpi::Twine& name) override;
+  void RemoveFieldObject(const wpi::Twine& name) override;
   void ForEachFieldObject(
       wpi::function_ref<void(FieldObjectModel& model, wpi::StringRef name)>
           func) override;
@@ -45,7 +46,10 @@ class NTField2DModel : public Field2DModel {
   std::string m_nameValue;
 
   class ObjectModel;
-  std::vector<std::unique_ptr<ObjectModel>> m_objects;
+  using Objects = std::vector<std::unique_ptr<ObjectModel>>;
+  Objects m_objects;
+
+  std::pair<Objects::iterator, bool> Find(wpi::StringRef fullName);
 };
 
 }  // namespace glass

--- a/glass/src/libnt/native/include/glass/networktables/NTField2D.h
+++ b/glass/src/libnt/native/include/glass/networktables/NTField2D.h
@@ -32,8 +32,10 @@ class NTField2DModel : public Field2DModel {
   bool Exists() override;
   bool IsReadOnly() override;
 
-  void ForEachFieldObjectGroup(
-      wpi::function_ref<void(FieldObjectGroupModel& model, wpi::StringRef name)>
+  FieldObjectModel* AddFieldObject(wpi::StringRef name) override;
+  void RemoveFieldObject(wpi::StringRef name) override;
+  void ForEachFieldObject(
+      wpi::function_ref<void(FieldObjectModel& model, wpi::StringRef name)>
           func) override;
 
  private:
@@ -42,8 +44,8 @@ class NTField2DModel : public Field2DModel {
   NT_Entry m_name;
   std::string m_nameValue;
 
-  class GroupModel;
-  std::vector<std::unique_ptr<GroupModel>> m_groups;
+  class ObjectModel;
+  std::vector<std::unique_ptr<ObjectModel>> m_objects;
 };
 
 }  // namespace glass

--- a/wpilibc/src/main/native/cpp/smartdashboard/FieldObject2d.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/FieldObject2d.cpp
@@ -115,7 +115,7 @@ void FieldObject2d::UpdateFromEntry() const {
   }
   auto val = m_entry.GetValue();
   if (!val) {
-   return;
+    return;
   }
 
   if (val->IsDoubleArray()) {

--- a/wpilibc/src/main/native/cpp/smartdashboard/FieldObject2d.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/FieldObject2d.cpp
@@ -4,6 +4,11 @@
 
 #include "frc/smartdashboard/FieldObject2d.h"
 
+#include <vector>
+
+#include <wpi/Endian.h>
+#include <wpi/MathExtras.h>
+
 using namespace frc;
 
 FieldObject2d::FieldObject2d(FieldObject2d&& rhs) {
@@ -66,17 +71,41 @@ void FieldObject2d::UpdateEntry(bool setDefault) {
   if (!m_entry) {
     return;
   }
-  wpi::SmallVector<double, 9> arr;
-  for (auto&& pose : m_poses) {
-    auto& translation = pose.Translation();
-    arr.push_back(translation.X().to<double>());
-    arr.push_back(translation.Y().to<double>());
-    arr.push_back(pose.Rotation().Degrees().to<double>());
-  }
-  if (setDefault) {
-    m_entry.SetDefaultDoubleArray(arr);
+  if (m_poses.size() < (255 / 3)) {
+    wpi::SmallVector<double, 9> arr;
+    for (auto&& pose : m_poses) {
+      auto& translation = pose.Translation();
+      arr.push_back(translation.X().to<double>());
+      arr.push_back(translation.Y().to<double>());
+      arr.push_back(pose.Rotation().Degrees().to<double>());
+    }
+    if (setDefault) {
+      m_entry.SetDefaultDoubleArray(arr);
+    } else {
+      m_entry.ForceSetDoubleArray(arr);
+    }
   } else {
-    m_entry.SetDoubleArray(arr);
+    // send as raw array of doubles if too big for NT array
+    std::vector<char> arr;
+    arr.resize(m_poses.size() * 3 * 8);
+    char* p = arr.data();
+    for (auto&& pose : m_poses) {
+      auto& translation = pose.Translation();
+      wpi::support::endian::write64be(
+          p, wpi::DoubleToBits(translation.X().to<double>()));
+      p += 8;
+      wpi::support::endian::write64be(
+          p, wpi::DoubleToBits(translation.Y().to<double>()));
+      p += 8;
+      wpi::support::endian::write64be(
+          p, wpi::DoubleToBits(pose.Rotation().Degrees().to<double>()));
+      p += 8;
+    }
+    if (setDefault) {
+      m_entry.SetDefaultRaw(wpi::StringRef{arr.data(), arr.size()});
+    } else {
+      m_entry.ForceSetRaw(wpi::StringRef{arr.data(), arr.size()});
+    }
   }
 }
 
@@ -85,18 +114,45 @@ void FieldObject2d::UpdateFromEntry() const {
     return;
   }
   auto val = m_entry.GetValue();
-  if (!val || !val->IsDoubleArray()) {
-    return;
+  if (!val) {
+   return;
   }
-  auto arr = val->GetDoubleArray();
-  auto size = arr.size();
-  if ((size % 3) != 0) {
-    return;
-  }
-  m_poses.resize(size / 3);
-  for (size_t i = 0; i < size / 3; ++i) {
-    m_poses[i] =
-        Pose2d{units::meter_t{arr[i * 3 + 0]}, units::meter_t{arr[i * 3 + 1]},
-               Rotation2d{units::degree_t{arr[i * 3 + 2]}}};
+
+  if (val->IsDoubleArray()) {
+    auto arr = val->GetDoubleArray();
+    auto size = arr.size();
+    if ((size % 3) != 0) {
+      return;
+    }
+    m_poses.resize(size / 3);
+    for (size_t i = 0; i < size / 3; ++i) {
+      m_poses[i] =
+          Pose2d{units::meter_t{arr[i * 3 + 0]}, units::meter_t{arr[i * 3 + 1]},
+                 Rotation2d{units::degree_t{arr[i * 3 + 2]}}};
+    }
+  } else if (val->IsRaw()) {
+    // treat it simply as an array of doubles
+    wpi::StringRef data = val->GetRaw();
+
+    // must be triples of doubles
+    auto size = data.size();
+    if ((size % (3 * 8)) != 0) {
+      return;
+    }
+    m_poses.resize(size / (3 * 8));
+    const char* p = data.begin();
+    for (size_t i = 0; i < size / (3 * 8); ++i) {
+      double x = wpi::BitsToDouble(
+          wpi::support::endian::readNext<uint64_t, wpi::support::big,
+                                         wpi::support::unaligned>(p));
+      double y = wpi::BitsToDouble(
+          wpi::support::endian::readNext<uint64_t, wpi::support::big,
+                                         wpi::support::unaligned>(p));
+      double rot = wpi::BitsToDouble(
+          wpi::support::endian::readNext<uint64_t, wpi::support::big,
+                                         wpi::support::unaligned>(p));
+      m_poses[i] = Pose2d{units::meter_t{x}, units::meter_t{y},
+                          Rotation2d{units::degree_t{rot}}};
+    }
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/FieldObject2d.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/FieldObject2d.java
@@ -8,6 +8,8 @@ import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.geometry.Translation2d;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -101,20 +103,39 @@ public class FieldObject2d {
       return;
     }
 
-    double[] arr = new double[m_poses.size() * 3];
-    int ndx = 0;
-    for (Pose2d pose : m_poses) {
-      Translation2d translation = pose.getTranslation();
-      arr[ndx + 0] = translation.getX();
-      arr[ndx + 1] = translation.getY();
-      arr[ndx + 2] = pose.getRotation().getDegrees();
-      ndx += 3;
-    }
+    if (m_poses.size() < (255 / 3)) {
+      double[] arr = new double[m_poses.size() * 3];
+      int ndx = 0;
+      for (Pose2d pose : m_poses) {
+        Translation2d translation = pose.getTranslation();
+        arr[ndx + 0] = translation.getX();
+        arr[ndx + 1] = translation.getY();
+        arr[ndx + 2] = pose.getRotation().getDegrees();
+        ndx += 3;
+      }
 
-    if (setDefault) {
-      m_entry.setDefaultDoubleArray(arr);
+      if (setDefault) {
+        m_entry.setDefaultDoubleArray(arr);
+      } else {
+        m_entry.setDoubleArray(arr);
+      }
     } else {
-      m_entry.setDoubleArray(arr);
+      // send as raw array of doubles if too big for NT array
+      ByteBuffer output = ByteBuffer.allocate(m_poses.size() * 3 * 8);
+      output.order(ByteOrder.BIG_ENDIAN);
+
+      for (Pose2d pose : m_poses) {
+        Translation2d translation = pose.getTranslation();
+        output.putDouble(translation.getX());
+        output.putDouble(translation.getY());
+        output.putDouble(pose.getRotation().getDegrees());
+      }
+
+      if (setDefault) {
+        m_entry.setDefaultRaw(output.array());
+      } else {
+        m_entry.forceSetRaw(output.array());
+      }
     }
   }
 
@@ -125,17 +146,36 @@ public class FieldObject2d {
     }
 
     double[] arr = m_entry.getDoubleArray((double[]) null);
-    if (arr == null) {
-      return;
-    }
+    if (arr != null) {
+      if ((arr.length % 3) != 0) {
+        return;
+      }
 
-    if ((arr.length % 3) != 0) {
-      return;
-    }
+      m_poses.clear();
+      for (int i = 0; i < arr.length; i += 3) {
+        m_poses.add(new Pose2d(arr[i], arr[i + 1], Rotation2d.fromDegrees(arr[i + 2])));
+      }
+    } else {
+      // read as raw array of doubles
+      byte[] data = m_entry.getRaw((byte[]) null);
+      if (data == null) {
+        return;
+      }
 
-    m_poses.clear();
-    for (int i = 0; i < arr.length; i += 3) {
-      m_poses.add(new Pose2d(arr[i], arr[i + 1], Rotation2d.fromDegrees(arr[i + 2])));
+      // must be triples of doubles
+      if ((data.length % (3 * 8)) != 0) {
+        return;
+      }
+      ByteBuffer input = ByteBuffer.wrap(data);
+      input.order(ByteOrder.BIG_ENDIAN);
+
+      m_poses.clear();
+      for (int i = 0; i < (data.length / (3 * 8)); i++) {
+        double x = input.getDouble();
+        double y = input.getDouble();
+        double rot = input.getDouble();
+        m_poses.add(new Pose2d(x, y, Rotation2d.fromDegrees(rot)));
+      }
     }
   }
 


### PR DESCRIPTION
- Add raw support for pose lists > 255/3 in length
- Improve drag selection, especially with closely overlapping objects
- Drag selection of corner also highlights center of object with smaller circle
- Multiple styles (box, line, closed line, track)
- Configurable line and arrow settings (color, weight)
- Add tooltip for object name, index, x, y, rotation
- Context menu for pose edit/add/remove
- View/edit in feet or inches as well as meters
- Configurable object selectability

Implementation: use vector of Pose2d internally, use units

Fixes #3197.