### PR TITLE
[wpiutil] Unbreak wpi::Format on Windows

### DIFF
--- a/wpiutil/src/main/native/include/wpi/Format.h
+++ b/wpiutil/src/main/native/include/wpi/Format.h
@@ -95,7 +95,7 @@ class format_object final : public format_object_base {
   int snprint_tuple(char *Buffer, unsigned BufferSize,
                     std::index_sequence<Is...>) const {
 #ifdef _MSC_VER
-    return _snprintf_s(Buffer, BufferSize, BufferSize, Fmt, std::get<Is>(Vals)...);
+    return _snprintf(Buffer, BufferSize, Fmt, std::get<Is>(Vals)...);
 #else
 #ifdef __GNUC__
 #pragma GCC diagnostic push


### PR DESCRIPTION
This function relies on the behavior of snprintf returning an error value
when the buffer is too small.  By default, _snprintf_s aborts on Windows
instead of returning an error value.

This caused Glass to fail when trying to print a large NT value to a string.