### PR TITLE
[wpilib] PWMSpeedController: Use PWM by composition

### DIFF
--- a/wpilibc/src/main/native/cpp/DMC60.cpp
+++ b/wpilibc/src/main/native/cpp/DMC60.cpp
@@ -6,16 +6,13 @@
 
 #include <hal/FRCUsageReporting.h>
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
 using namespace frc;
 
-DMC60::DMC60(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
-  SetPeriodMultiplier(kPeriodMultiplier_1X);
-  SetSpeed(0.0);
-  SetZeroLatch();
+DMC60::DMC60(int channel) : PWMSpeedController("DMC60", channel) {
+  m_pwm.SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
+  m_pwm.SetPeriodMultiplier(PWM::kPeriodMultiplier_1X);
+  m_pwm.SetSpeed(0.0);
+  m_pwm.SetZeroLatch();
 
   HAL_Report(HALUsageReporting::kResourceType_DigilentDMC60, GetChannel() + 1);
-  SendableRegistry::GetInstance().SetName(this, "DMC60", GetChannel());
 }

--- a/wpilibc/src/main/native/cpp/Jaguar.cpp
+++ b/wpilibc/src/main/native/cpp/Jaguar.cpp
@@ -6,16 +6,13 @@
 
 #include <hal/FRCUsageReporting.h>
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
 using namespace frc;
 
-Jaguar::Jaguar(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.31, 1.55, 1.507, 1.454, 0.697);
-  SetPeriodMultiplier(kPeriodMultiplier_1X);
-  SetSpeed(0.0);
-  SetZeroLatch();
+Jaguar::Jaguar(int channel) : PWMSpeedController("Jaguar", channel) {
+  m_pwm.SetBounds(2.31, 1.55, 1.507, 1.454, 0.697);
+  m_pwm.SetPeriodMultiplier(PWM::kPeriodMultiplier_1X);
+  m_pwm.SetSpeed(0.0);
+  m_pwm.SetZeroLatch();
 
   HAL_Report(HALUsageReporting::kResourceType_Jaguar, GetChannel() + 1);
-  SendableRegistry::GetInstance().SetName(this, "Jaguar", GetChannel());
 }

--- a/wpilibc/src/main/native/cpp/NidecBrushless.cpp
+++ b/wpilibc/src/main/native/cpp/NidecBrushless.cpp
@@ -5,6 +5,7 @@
 #include "frc/NidecBrushless.h"
 
 #include <hal/FRCUsageReporting.h>
+#include <wpi/raw_ostream.h>
 
 #include "frc/smartdashboard/SendableBuilder.h"
 #include "frc/smartdashboard/SendableRegistry.h"

--- a/wpilibc/src/main/native/cpp/PWMSparkMax.cpp
+++ b/wpilibc/src/main/native/cpp/PWMSparkMax.cpp
@@ -10,12 +10,12 @@
 
 using namespace frc;
 
-PWMSparkMax::PWMSparkMax(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.003, 1.55, 1.50, 1.46, 0.999);
-  SetPeriodMultiplier(kPeriodMultiplier_1X);
-  SetSpeed(0.0);
-  SetZeroLatch();
+PWMSparkMax::PWMSparkMax(int channel)
+    : PWMSpeedController("PWMSparkMax", channel) {
+  m_pwm.SetBounds(2.003, 1.55, 1.50, 1.46, 0.999);
+  m_pwm.SetPeriodMultiplier(PWM::kPeriodMultiplier_1X);
+  m_pwm.SetSpeed(0.0);
+  m_pwm.SetZeroLatch();
 
   HAL_Report(HALUsageReporting::kResourceType_RevSparkMaxPWM, GetChannel() + 1);
-  SendableRegistry::GetInstance().SetName(this, "PWMSparkMax", GetChannel());
 }

--- a/wpilibc/src/main/native/cpp/PWMTalonFX.cpp
+++ b/wpilibc/src/main/native/cpp/PWMTalonFX.cpp
@@ -6,16 +6,14 @@
 
 #include <hal/FRCUsageReporting.h>
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
 using namespace frc;
 
-PWMTalonFX::PWMTalonFX(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
-  SetPeriodMultiplier(kPeriodMultiplier_1X);
-  SetSpeed(0.0);
-  SetZeroLatch();
+PWMTalonFX::PWMTalonFX(int channel)
+    : PWMSpeedController("PWMTalonFX", channel) {
+  m_pwm.SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
+  m_pwm.SetPeriodMultiplier(PWM::kPeriodMultiplier_1X);
+  m_pwm.SetSpeed(0.0);
+  m_pwm.SetZeroLatch();
 
   HAL_Report(HALUsageReporting::kResourceType_TalonFX, GetChannel() + 1);
-  SendableRegistry::GetInstance().SetName(this, "PWMTalonFX", GetChannel());
 }

--- a/wpilibc/src/main/native/cpp/PWMTalonSRX.cpp
+++ b/wpilibc/src/main/native/cpp/PWMTalonSRX.cpp
@@ -6,16 +6,14 @@
 
 #include <hal/FRCUsageReporting.h>
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
 using namespace frc;
 
-PWMTalonSRX::PWMTalonSRX(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
-  SetPeriodMultiplier(kPeriodMultiplier_1X);
-  SetSpeed(0.0);
-  SetZeroLatch();
+PWMTalonSRX::PWMTalonSRX(int channel)
+    : PWMSpeedController("PWMTalonSRX", channel) {
+  m_pwm.SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
+  m_pwm.SetPeriodMultiplier(PWM::kPeriodMultiplier_1X);
+  m_pwm.SetSpeed(0.0);
+  m_pwm.SetZeroLatch();
 
   HAL_Report(HALUsageReporting::kResourceType_PWMTalonSRX, GetChannel() + 1);
-  SendableRegistry::GetInstance().SetName(this, "PWMTalonSRX", GetChannel());
 }

--- a/wpilibc/src/main/native/cpp/PWMVenom.cpp
+++ b/wpilibc/src/main/native/cpp/PWMVenom.cpp
@@ -6,16 +6,13 @@
 
 #include <hal/FRCUsageReporting.h>
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
 using namespace frc;
 
-PWMVenom::PWMVenom(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
-  SetPeriodMultiplier(kPeriodMultiplier_1X);
-  SetSpeed(0.0);
-  SetZeroLatch();
+PWMVenom::PWMVenom(int channel) : PWMSpeedController("PWMVenom", channel) {
+  m_pwm.SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
+  m_pwm.SetPeriodMultiplier(PWM::kPeriodMultiplier_1X);
+  m_pwm.SetSpeed(0.0);
+  m_pwm.SetZeroLatch();
 
   HAL_Report(HALUsageReporting::kResourceType_FusionVenom, GetChannel() + 1);
-  SendableRegistry::GetInstance().SetName(this, "PWMVenom", GetChannel());
 }

--- a/wpilibc/src/main/native/cpp/PWMVictorSPX.cpp
+++ b/wpilibc/src/main/native/cpp/PWMVictorSPX.cpp
@@ -6,16 +6,14 @@
 
 #include <hal/FRCUsageReporting.h>
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
 using namespace frc;
 
-PWMVictorSPX::PWMVictorSPX(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
-  SetPeriodMultiplier(kPeriodMultiplier_1X);
-  SetSpeed(0.0);
-  SetZeroLatch();
+PWMVictorSPX::PWMVictorSPX(int channel)
+    : PWMSpeedController("PWMVictorSPX", channel) {
+  m_pwm.SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
+  m_pwm.SetPeriodMultiplier(PWM::kPeriodMultiplier_1X);
+  m_pwm.SetSpeed(0.0);
+  m_pwm.SetZeroLatch();
 
   HAL_Report(HALUsageReporting::kResourceType_PWMVictorSPX, GetChannel() + 1);
-  SendableRegistry::GetInstance().SetName(this, "PWMVictorSPX", GetChannel());
 }

--- a/wpilibc/src/main/native/cpp/SD540.cpp
+++ b/wpilibc/src/main/native/cpp/SD540.cpp
@@ -6,17 +6,14 @@
 
 #include <hal/FRCUsageReporting.h>
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
 using namespace frc;
 
-SD540::SD540(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.05, 1.55, 1.50, 1.44, 0.94);
-  SetPeriodMultiplier(kPeriodMultiplier_1X);
-  SetSpeed(0.0);
-  SetZeroLatch();
+SD540::SD540(int channel) : PWMSpeedController("SD540", channel) {
+  m_pwm.SetBounds(2.05, 1.55, 1.50, 1.44, 0.94);
+  m_pwm.SetPeriodMultiplier(PWM::kPeriodMultiplier_1X);
+  m_pwm.SetSpeed(0.0);
+  m_pwm.SetZeroLatch();
 
   HAL_Report(HALUsageReporting::kResourceType_MindsensorsSD540,
              GetChannel() + 1);
-  SendableRegistry::GetInstance().SetName(this, "SD540", GetChannel());
 }

--- a/wpilibc/src/main/native/cpp/Spark.cpp
+++ b/wpilibc/src/main/native/cpp/Spark.cpp
@@ -6,16 +6,13 @@
 
 #include <hal/FRCUsageReporting.h>
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
 using namespace frc;
 
-Spark::Spark(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.003, 1.55, 1.50, 1.46, 0.999);
-  SetPeriodMultiplier(kPeriodMultiplier_1X);
-  SetSpeed(0.0);
-  SetZeroLatch();
+Spark::Spark(int channel) : PWMSpeedController("Spark", channel) {
+  m_pwm.SetBounds(2.003, 1.55, 1.50, 1.46, 0.999);
+  m_pwm.SetPeriodMultiplier(PWM::kPeriodMultiplier_1X);
+  m_pwm.SetSpeed(0.0);
+  m_pwm.SetZeroLatch();
 
   HAL_Report(HALUsageReporting::kResourceType_RevSPARK, GetChannel() + 1);
-  SendableRegistry::GetInstance().SetName(this, "Spark", GetChannel());
 }

--- a/wpilibc/src/main/native/cpp/Talon.cpp
+++ b/wpilibc/src/main/native/cpp/Talon.cpp
@@ -6,16 +6,13 @@
 
 #include <hal/FRCUsageReporting.h>
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
 using namespace frc;
 
-Talon::Talon(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.037, 1.539, 1.513, 1.487, 0.989);
-  SetPeriodMultiplier(kPeriodMultiplier_1X);
-  SetSpeed(0.0);
-  SetZeroLatch();
+Talon::Talon(int channel) : PWMSpeedController("Talon", channel) {
+  m_pwm.SetBounds(2.037, 1.539, 1.513, 1.487, 0.989);
+  m_pwm.SetPeriodMultiplier(PWM::kPeriodMultiplier_1X);
+  m_pwm.SetSpeed(0.0);
+  m_pwm.SetZeroLatch();
 
   HAL_Report(HALUsageReporting::kResourceType_Talon, GetChannel() + 1);
-  SendableRegistry::GetInstance().SetName(this, "Talon", GetChannel());
 }

--- a/wpilibc/src/main/native/cpp/Victor.cpp
+++ b/wpilibc/src/main/native/cpp/Victor.cpp
@@ -6,16 +6,13 @@
 
 #include <hal/FRCUsageReporting.h>
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
 using namespace frc;
 
-Victor::Victor(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.027, 1.525, 1.507, 1.49, 1.026);
-  SetPeriodMultiplier(kPeriodMultiplier_2X);
-  SetSpeed(0.0);
-  SetZeroLatch();
+Victor::Victor(int channel) : PWMSpeedController("Victor", channel) {
+  m_pwm.SetBounds(2.027, 1.525, 1.507, 1.49, 1.026);
+  m_pwm.SetPeriodMultiplier(PWM::kPeriodMultiplier_2X);
+  m_pwm.SetSpeed(0.0);
+  m_pwm.SetZeroLatch();
 
   HAL_Report(HALUsageReporting::kResourceType_Victor, GetChannel() + 1);
-  SendableRegistry::GetInstance().SetName(this, "Victor", GetChannel());
 }

--- a/wpilibc/src/main/native/cpp/VictorSP.cpp
+++ b/wpilibc/src/main/native/cpp/VictorSP.cpp
@@ -6,16 +6,13 @@
 
 #include <hal/FRCUsageReporting.h>
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
 using namespace frc;
 
-VictorSP::VictorSP(int channel) : PWMSpeedController(channel) {
-  SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
-  SetPeriodMultiplier(kPeriodMultiplier_1X);
-  SetSpeed(0.0);
-  SetZeroLatch();
+VictorSP::VictorSP(int channel) : PWMSpeedController("VictorSP", channel) {
+  m_pwm.SetBounds(2.004, 1.52, 1.50, 1.48, 0.997);
+  m_pwm.SetPeriodMultiplier(PWM::kPeriodMultiplier_1X);
+  m_pwm.SetSpeed(0.0);
+  m_pwm.SetZeroLatch();
 
   HAL_Report(HALUsageReporting::kResourceType_VictorSP, GetChannel() + 1);
-  SendableRegistry::GetInstance().SetName(this, "VictorSP", GetChannel());
 }

--- a/wpilibc/src/main/native/include/frc/MotorSafety.h
+++ b/wpilibc/src/main/native/include/frc/MotorSafety.h
@@ -5,10 +5,13 @@
 #pragma once
 
 #include <wpi/mutex.h>
-#include <wpi/raw_ostream.h>
 
 #include "frc/ErrorBase.h"
 #include "frc/Timer.h"
+
+namespace wpi {
+class raw_ostream;
+}  // namespace wpi
 
 namespace frc {
 

--- a/wpilibc/src/main/native/include/frc/PWM.h
+++ b/wpilibc/src/main/native/include/frc/PWM.h
@@ -7,9 +7,8 @@
 #include <stdint.h>
 
 #include <hal/Types.h>
-#include <wpi/raw_ostream.h>
 
-#include "frc/MotorSafety.h"
+#include "frc/ErrorBase.h"
 #include "frc/smartdashboard/Sendable.h"
 #include "frc/smartdashboard/SendableHelper.h"
 
@@ -34,7 +33,7 @@ class SendableBuilder;
  *   - 1 = minimum pulse width (currently 0.5ms)
  *   - 0 = disabled (i.e. PWM output is held low)
  */
-class PWM : public MotorSafety, public Sendable, public SendableHelper<PWM> {
+class PWM : public ErrorBase, public Sendable, public SendableHelper<PWM> {
  public:
   friend class AddressableLED;
   /**
@@ -64,8 +63,10 @@ class PWM : public MotorSafety, public Sendable, public SendableHelper<PWM> {
    *
    * @param channel The PWM channel number. 0-9 are on-board, 10-19 are on the
    *                MXP port
+   * @param registerSendable If true, adds this instance to SendableRegistry
+   *                         and LiveWindow
    */
-  explicit PWM(int channel);
+  explicit PWM(int channel, bool registerSendable = true);
 
   /**
    * Free the PWM channel.
@@ -76,10 +77,6 @@ class PWM : public MotorSafety, public Sendable, public SendableHelper<PWM> {
 
   PWM(PWM&&) = default;
   PWM& operator=(PWM&&) = default;
-
-  // MotorSafety interface
-  void StopMotor() override;
-  void GetDescription(wpi::raw_ostream& desc) const override;
 
   /**
    * Set the PWM value directly to the hardware.

--- a/wpilibc/src/main/native/include/frc/PWMSpeedController.h
+++ b/wpilibc/src/main/native/include/frc/PWMSpeedController.h
@@ -4,15 +4,27 @@
 
 #pragma once
 
+#include <wpi/Twine.h>
+
+#include "frc/MotorSafety.h"
 #include "frc/PWM.h"
 #include "frc/SpeedController.h"
+#include "frc/smartdashboard/Sendable.h"
+#include "frc/smartdashboard/SendableHelper.h"
+
+namespace wpi {
+class raw_ostream;
+}  // namespace wpi
 
 namespace frc {
 
 /**
  * Common base class for all PWM Speed Controllers.
  */
-class PWMSpeedController : public PWM, public SpeedController {
+class PWMSpeedController : public SpeedController,
+                           public MotorSafety,
+                           public Sendable,
+                           public SendableHelper<PWMSpeedController> {
  public:
   PWMSpeedController(PWMSpeedController&&) = default;
   PWMSpeedController& operator=(PWMSpeedController&&) = default;
@@ -42,7 +54,11 @@ class PWMSpeedController : public PWM, public SpeedController {
 
   void Disable() override;
 
+  // MotorSafety interface
   void StopMotor() override;
+  void GetDescription(wpi::raw_ostream& desc) const override;
+
+  int GetChannel() const;
 
   /**
    * Write out the PID value as seen in the PIDOutput base object.
@@ -55,12 +71,15 @@ class PWMSpeedController : public PWM, public SpeedController {
   /**
    * Constructor for a PWM Speed Controller connected via PWM.
    *
+   * @param name Name to use for SendableRegistry
    * @param channel The PWM channel that the controller is attached to. 0-9 are
    *                on-board, 10-19 are on the MXP port
    */
-  explicit PWMSpeedController(int channel);
+  PWMSpeedController(const wpi::Twine& name, int channel);
 
   void InitSendable(SendableBuilder& builder) override;
+
+  PWM m_pwm;
 
  private:
   bool m_isInverted = false;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DMC60.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DMC60.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Digilent DMC 60 Speed Controller.
@@ -33,14 +32,13 @@ public class DMC60 extends PWMSpeedController {
    *     the MXP port
    */
   public DMC60(final int channel) {
-    super(channel);
+    super("DMC60", channel);
 
-    setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
-    setPeriodMultiplier(PeriodMultiplier.k1X);
-    setSpeed(0.0);
-    setZeroLatch();
+    m_pwm.setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
+    m_pwm.setPeriodMultiplier(PWM.PeriodMultiplier.k1X);
+    m_pwm.setSpeed(0.0);
+    m_pwm.setZeroLatch();
 
     HAL.report(tResourceType.kResourceType_DigilentDMC60, getChannel() + 1);
-    SendableRegistry.setName(this, "DMC60", getChannel());
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Jaguar.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Jaguar.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Texas Instruments / Vex Robotics Jaguar Speed Controller as a PWM device.
@@ -32,14 +31,13 @@ public class Jaguar extends PWMSpeedController {
    *     the MXP port
    */
   public Jaguar(final int channel) {
-    super(channel);
+    super("Jaguar", channel);
 
-    setBounds(2.31, 1.55, 1.507, 1.454, 0.697);
-    setPeriodMultiplier(PeriodMultiplier.k1X);
-    setSpeed(0.0);
-    setZeroLatch();
+    m_pwm.setBounds(2.31, 1.55, 1.507, 1.454, 0.697);
+    m_pwm.setPeriodMultiplier(PWM.PeriodMultiplier.k1X);
+    m_pwm.setSpeed(0.0);
+    m_pwm.setZeroLatch();
 
     HAL.report(tResourceType.kResourceType_Jaguar, getChannel() + 1);
-    SendableRegistry.setName(this, "Jaguar", getChannel());
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWM.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWM.java
@@ -23,7 +23,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * center value - 999 to 2 = linear scaling from "center" to "full reverse" - 1 = minimum pulse
  * width (currently .5ms) - 0 = disabled (i.e. PWM output is held low)
  */
-public class PWM extends MotorSafety implements Sendable, AutoCloseable {
+public class PWM implements Sendable, AutoCloseable {
   /** Represents the amount to multiply the minimum servo-pulse pwm period by. */
   public enum PeriodMultiplier {
     /** Period Multiplier: don't skip pulses. PWM pulses occur every 5.005 ms */
@@ -42,9 +42,24 @@ public class PWM extends MotorSafety implements Sendable, AutoCloseable {
   /**
    * Allocate a PWM given a channel.
    *
+   * <p>Checks channel value range and allocates the appropriate channel. The allocation is only
+   * done to help users ensure that they don't double assign channels.
+   *
+   * <p>By default, adds itself to SendableRegistry and LiveWindow.
+   *
    * @param channel The PWM channel number. 0-9 are on-board, 10-19 are on the MXP port
    */
   public PWM(final int channel) {
+    this(channel, true);
+  }
+
+  /**
+   * Allocate a PWM given a channel.
+   *
+   * @param channel The PWM channel number. 0-9 are on-board, 10-19 are on the MXP port
+   * @param registerSendable If true, adds this instance to SendableRegistry and LiveWindow
+   */
+  public PWM(final int channel, final boolean registerSendable) {
     SensorUtil.checkPWMChannel(channel);
     m_channel = channel;
 
@@ -55,9 +70,9 @@ public class PWM extends MotorSafety implements Sendable, AutoCloseable {
     PWMJNI.setPWMEliminateDeadband(m_handle, false);
 
     HAL.report(tResourceType.kResourceType_PWM, channel + 1);
-    SendableRegistry.addLW(this, "PWM", channel);
-
-    setSafetyEnabled(false);
+    if (registerSendable) {
+      SendableRegistry.addLW(this, "PWM", channel);
+    }
   }
 
   /** Free the resource associated with the PWM channel and set the value to 0. */
@@ -70,16 +85,6 @@ public class PWM extends MotorSafety implements Sendable, AutoCloseable {
     setDisabled();
     PWMJNI.freePWMPort(m_handle);
     m_handle = 0;
-  }
-
-  @Override
-  public void stopMotor() {
-    setDisabled();
-  }
-
-  @Override
-  public String getDescription() {
-    return "PWM " + getChannel();
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMSparkMax.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * REV Robotics SPARK MAX Speed Controller with PWM control.
@@ -28,14 +27,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 public class PWMSparkMax extends PWMSpeedController {
   /** Common initialization code called by all constructors. */
   public PWMSparkMax(final int channel) {
-    super(channel);
+    super("PWMSparkMax", channel);
 
-    setBounds(2.003, 1.55, 1.50, 1.46, 0.999);
-    setPeriodMultiplier(PeriodMultiplier.k1X);
-    setSpeed(0.0);
-    setZeroLatch();
+    m_pwm.setBounds(2.003, 1.55, 1.50, 1.46, 0.999);
+    m_pwm.setPeriodMultiplier(PWM.PeriodMultiplier.k1X);
+    m_pwm.setSpeed(0.0);
+    m_pwm.setZeroLatch();
 
     HAL.report(tResourceType.kResourceType_RevSparkMaxPWM, getChannel() + 1);
-    SendableRegistry.setName(this, "PWMSparkMax", getChannel());
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonFX.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonFX.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Cross the Road Electronics (CTRE) Talon FX Speed Controller with PWM control.
@@ -33,14 +32,13 @@ public class PWMTalonFX extends PWMSpeedController {
    *     the MXP port
    */
   public PWMTalonFX(final int channel) {
-    super(channel);
+    super("PWMTalonFX", channel);
 
-    setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
-    setPeriodMultiplier(PeriodMultiplier.k1X);
-    setSpeed(0.0);
-    setZeroLatch();
+    m_pwm.setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
+    m_pwm.setPeriodMultiplier(PWM.PeriodMultiplier.k1X);
+    m_pwm.setSpeed(0.0);
+    m_pwm.setZeroLatch();
 
     HAL.report(tResourceType.kResourceType_TalonFX, getChannel() + 1);
-    SendableRegistry.setName(this, "PWMTalonFX", getChannel());
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonSRX.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMTalonSRX.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Cross the Road Electronics (CTRE) Talon SRX Speed Controller with PWM control.
@@ -33,14 +32,13 @@ public class PWMTalonSRX extends PWMSpeedController {
    *     on the MXP port
    */
   public PWMTalonSRX(final int channel) {
-    super(channel);
+    super("PWMTalonSRX", channel);
 
-    setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
-    setPeriodMultiplier(PeriodMultiplier.k1X);
-    setSpeed(0.0);
-    setZeroLatch();
+    m_pwm.setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
+    m_pwm.setPeriodMultiplier(PWM.PeriodMultiplier.k1X);
+    m_pwm.setSpeed(0.0);
+    m_pwm.setZeroLatch();
 
     HAL.report(tResourceType.kResourceType_PWMTalonSRX, getChannel() + 1);
-    SendableRegistry.setName(this, "PWMTalonSRX", getChannel());
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMVenom.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMVenom.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Playing with Fusion Venom Smart Motor with PWM control.
@@ -32,14 +31,13 @@ public class PWMVenom extends PWMSpeedController {
    *     the MXP port
    */
   public PWMVenom(final int channel) {
-    super(channel);
+    super("PWMVenom", channel);
 
-    setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
-    setPeriodMultiplier(PeriodMultiplier.k1X);
-    setSpeed(0.0);
-    setZeroLatch();
+    m_pwm.setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
+    m_pwm.setPeriodMultiplier(PWM.PeriodMultiplier.k1X);
+    m_pwm.setSpeed(0.0);
+    m_pwm.setZeroLatch();
 
     HAL.report(tResourceType.kResourceType_FusionVenom, getChannel() + 1);
-    SendableRegistry.setName(this, "PWMVenom", getChannel());
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMVictorSPX.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWMVictorSPX.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Cross the Road Electronics (CTRE) Victor SPX Speed Controller with PWM control.
@@ -33,14 +32,13 @@ public class PWMVictorSPX extends PWMSpeedController {
    *     are on the MXP port
    */
   public PWMVictorSPX(final int channel) {
-    super(channel);
+    super("PWMVictorSPX", channel);
 
-    setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
-    setPeriodMultiplier(PeriodMultiplier.k1X);
-    setSpeed(0.0);
-    setZeroLatch();
+    m_pwm.setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
+    m_pwm.setPeriodMultiplier(PWM.PeriodMultiplier.k1X);
+    m_pwm.setSpeed(0.0);
+    m_pwm.setZeroLatch();
 
     HAL.report(tResourceType.kResourceType_PWMVictorSPX, getChannel() + 1);
-    SendableRegistry.setName(this, "PWMVictorSPX", getChannel());
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SD540.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SD540.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Mindsensors SD540 Speed Controller.
@@ -26,17 +25,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * </ul>
  */
 public class SD540 extends PWMSpeedController {
-  /** Common initialization code called by all constructors. */
-  protected void initSD540() {
-    setBounds(2.05, 1.55, 1.50, 1.44, 0.94);
-    setPeriodMultiplier(PeriodMultiplier.k1X);
-    setSpeed(0.0);
-    setZeroLatch();
-
-    HAL.report(tResourceType.kResourceType_MindsensorsSD540, getChannel() + 1);
-    SendableRegistry.setName(this, "SD540", getChannel());
-  }
-
   /**
    * Constructor.
    *
@@ -44,7 +32,13 @@ public class SD540 extends PWMSpeedController {
    *     the MXP port
    */
   public SD540(final int channel) {
-    super(channel);
-    initSD540();
+    super("SD540", channel);
+
+    m_pwm.setBounds(2.05, 1.55, 1.50, 1.44, 0.94);
+    m_pwm.setPeriodMultiplier(PWM.PeriodMultiplier.k1X);
+    m_pwm.setSpeed(0.0);
+    m_pwm.setZeroLatch();
+
+    HAL.report(tResourceType.kResourceType_MindsensorsSD540, getChannel() + 1);
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Spark.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Spark.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * REV Robotics SPARK Speed Controller.
@@ -26,17 +25,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
  * </ul>
  */
 public class Spark extends PWMSpeedController {
-  /** Common initialization code called by all constructors. */
-  protected void initSpark() {
-    setBounds(2.003, 1.55, 1.50, 1.46, 0.999);
-    setPeriodMultiplier(PeriodMultiplier.k1X);
-    setSpeed(0.0);
-    setZeroLatch();
-
-    HAL.report(tResourceType.kResourceType_RevSPARK, getChannel() + 1);
-    SendableRegistry.setName(this, "Spark", getChannel());
-  }
-
   /**
    * Constructor.
    *
@@ -44,7 +32,13 @@ public class Spark extends PWMSpeedController {
    *     the MXP port
    */
   public Spark(final int channel) {
-    super(channel);
-    initSpark();
+    super("Spark", channel);
+
+    m_pwm.setBounds(2.003, 1.55, 1.50, 1.46, 0.999);
+    m_pwm.setPeriodMultiplier(PWM.PeriodMultiplier.k1X);
+    m_pwm.setSpeed(0.0);
+    m_pwm.setZeroLatch();
+
+    HAL.report(tResourceType.kResourceType_RevSPARK, getChannel() + 1);
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Talon.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Talon.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Cross the Road Electronics (CTRE) Talon and Talon SR Speed Controller.
@@ -32,14 +31,13 @@ public class Talon extends PWMSpeedController {
    *     the MXP port
    */
   public Talon(final int channel) {
-    super(channel);
+    super("Talon", channel);
 
-    setBounds(2.037, 1.539, 1.513, 1.487, 0.989);
-    setPeriodMultiplier(PeriodMultiplier.k1X);
-    setSpeed(0.0);
-    setZeroLatch();
+    m_pwm.setBounds(2.037, 1.539, 1.513, 1.487, 0.989);
+    m_pwm.setPeriodMultiplier(PWM.PeriodMultiplier.k1X);
+    m_pwm.setSpeed(0.0);
+    m_pwm.setZeroLatch();
 
     HAL.report(tResourceType.kResourceType_Talon, getChannel() + 1);
-    SendableRegistry.setName(this, "Talon", getChannel());
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Victor.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Victor.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * VEX Robotics Victor 888 Speed Controller The Vex Robotics Victor 884 Speed Controller can also be
@@ -35,14 +34,13 @@ public class Victor extends PWMSpeedController {
    *     the MXP port
    */
   public Victor(final int channel) {
-    super(channel);
+    super("Victor", channel);
 
-    setBounds(2.027, 1.525, 1.507, 1.49, 1.026);
-    setPeriodMultiplier(PeriodMultiplier.k2X);
-    setSpeed(0.0);
-    setZeroLatch();
+    m_pwm.setBounds(2.027, 1.525, 1.507, 1.49, 1.026);
+    m_pwm.setPeriodMultiplier(PWM.PeriodMultiplier.k2X);
+    m_pwm.setSpeed(0.0);
+    m_pwm.setZeroLatch();
 
     HAL.report(tResourceType.kResourceType_Victor, getChannel() + 1);
-    SendableRegistry.setName(this, "Victor", getChannel());
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/VictorSP.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/VictorSP.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * VEX Robotics Victor SP Speed Controller.
@@ -33,14 +32,13 @@ public class VictorSP extends PWMSpeedController {
    *     the MXP port
    */
   public VictorSP(final int channel) {
-    super(channel);
+    super("VictorSP", channel);
 
-    setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
-    setPeriodMultiplier(PeriodMultiplier.k1X);
-    setSpeed(0.0);
-    setZeroLatch();
+    m_pwm.setBounds(2.004, 1.52, 1.50, 1.48, 0.997);
+    m_pwm.setPeriodMultiplier(PWM.PeriodMultiplier.k1X);
+    m_pwm.setSpeed(0.0);
+    m_pwm.setZeroLatch();
 
     HAL.report(tResourceType.kResourceType_VictorSP, getChannel() + 1);
-    SendableRegistry.setName(this, "VictorSP", getChannel());
   }
 }


### PR DESCRIPTION
This cleans up the user experience by removing lower-level functions from the
interface.

Also remove MotorSafety from "raw" PWM.
