### PR TITLE
[hal] Use fixed size enums in clang C

### DIFF
--- a/hal/src/main/native/include/hal/Types.h
+++ b/hal/src/main/native/include/hal/Types.h
@@ -68,6 +68,11 @@ typedef int32_t HAL_Bool;
 
 #ifdef __cplusplus
 #define HAL_ENUM(name) enum name : int32_t
+#elif defined(__clang__)
+#define HAL_ENUM(name)    \
+  enum name : int32_t;    \
+  typedef enum name name; \
+  enum name : int32_t
 #else
 #define HAL_ENUM(name)  \
   typedef int32_t name; \


### PR DESCRIPTION
Enumerations with fixed underlying type have been proposed for C2x in [N2575](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2575.pdf). It turns out that Clang already supports this in C since Clang 8.

This will allow static analysis tools that use clang to always determine the correct intended parameter types for HAL functions.