### PR TITLE
[wpiutil] circular_buffer: Use value initialization instead of zero

### DIFF
--- a/wpiutil/src/main/native/include/wpi/circular_buffer.inc
+++ b/wpiutil/src/main/native/include/wpi/circular_buffer.inc
@@ -11,7 +11,7 @@
 namespace wpi {
 
 template <class T>
-circular_buffer<T>::circular_buffer(size_t size) : m_data(size, T{0}) {}
+circular_buffer<T>::circular_buffer(size_t size) : m_data(size, T{}) {}
 
 /**
  * Returns number of elements in buffer


### PR DESCRIPTION
Some types don't support zero init.