### PR TITLE
[wpiutil] uv Handle: Use malloc/free instead of new/delete

### DIFF
--- a/wpiutil/src/main/native/cpp/uv/Handle.cpp
+++ b/wpiutil/src/main/native/cpp/uv/Handle.cpp
@@ -8,9 +8,9 @@ using namespace wpi::uv;
 
 Handle::~Handle() noexcept {
   if (!m_closed && m_uv_handle->type != UV_UNKNOWN_HANDLE) {
-    uv_close(m_uv_handle, [](uv_handle_t* uv_handle) { delete uv_handle; });
+    uv_close(m_uv_handle, [](uv_handle_t* uv_handle) { std::free(uv_handle); });
   } else {
-    delete m_uv_handle;
+    std::free(m_uv_handle);
   }
 }
 

--- a/wpiutil/src/main/native/include/wpi/uv/Handle.h
+++ b/wpiutil/src/main/native/include/wpi/uv/Handle.h
@@ -7,6 +7,7 @@
 
 #include <uv.h>
 
+#include <cstdlib>
 #include <functional>
 #include <memory>
 #include <utility>
@@ -288,7 +289,7 @@ class HandleImpl : public Handle {
   }
 
  protected:
-  HandleImpl() : Handle{reinterpret_cast<uv_handle_t*>(new U)} {}
+  HandleImpl() : Handle{static_cast<uv_handle_t*>(std::malloc(sizeof(U)))} {}
 };
 
 }  // namespace wpi::uv

--- a/wpiutil/src/main/native/include/wpi/uv/NetworkStream.h
+++ b/wpiutil/src/main/native/include/wpi/uv/NetworkStream.h
@@ -7,6 +7,7 @@
 
 #include <uv.h>
 
+#include <cstdlib>
 #include <functional>
 #include <memory>
 
@@ -143,7 +144,8 @@ class NetworkStreamImpl : public NetworkStream {
   }
 
  protected:
-  NetworkStreamImpl() : NetworkStream{reinterpret_cast<uv_stream_t*>(new U)} {}
+  NetworkStreamImpl()
+      : NetworkStream{static_cast<uv_stream_t*>(std::malloc(sizeof(U)))} {}
 };
 
 }  // namespace wpi::uv

--- a/wpiutil/src/main/native/include/wpi/uv/Stream.h
+++ b/wpiutil/src/main/native/include/wpi/uv/Stream.h
@@ -7,6 +7,7 @@
 
 #include <uv.h>
 
+#include <cstdlib>
 #include <functional>
 #include <initializer_list>
 #include <memory>
@@ -292,7 +293,7 @@ class StreamImpl : public Stream {
   }
 
  protected:
-  StreamImpl() : Stream{reinterpret_cast<uv_stream_t*>(new U)} {}
+  StreamImpl() : Stream{static_cast<uv_stream_t*>(std::malloc(sizeof(U)))} {}
 };
 
 }  // namespace wpi::uv


### PR DESCRIPTION
This avoids asan warnings for deleting a different pointer type.