### PR TITLE
Fix @deprecated warning for SerialPort constructor

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SerialPort.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SerialPort.java
@@ -95,6 +95,7 @@ public class SerialPort implements AutoCloseable {
    * @param stopBits The number of stop bits to use as defined by the enum StopBits.
    * @deprecated Will be removed for 2019
    */
+  @Deprecated
   public SerialPort(
       final int baudRate,
       String portName,


### PR DESCRIPTION
The javadoc `@deprecated` tag didn't have a corresponding `@Deprecated`
attribute.