### PR TITLE
[build] Add Run* task to wpilibcExamples

### DIFF
--- a/wpilibcExamples/build.gradle
+++ b/wpilibcExamples/build.gradle
@@ -253,3 +253,28 @@ ext {
     isCppCommands = true
 }
 apply from: "${rootDir}/shared/examplecheck.gradle"
+
+ext.examplesMap.each { key, value ->
+    Task deleteTask = tasks.findByPath("deleteMyRobot")
+    if (deleteTask == null) {
+        deleteTask = task("deleteMyRobot", type: Delete) {
+            delete "${rootDir}/myRobot/src/main/native/"
+        }
+    }
+    def copyTask = task("copy${key}ToMyRobotDir", type: Copy) {
+
+        from "${rootDir}/wpilibcExamples/src/main/cpp/examples/${key}/"
+        into "${rootDir}/myRobot/src/main/native/"
+        doLast {
+            println "copied to ${getDestinationDir()}"
+        }
+    }
+    def runTask = project.getParent().tasks.findByPath(':myRobot:runCpp')
+    project.tasks.register("Run${key}") {
+        dependsOn deleteTask
+        dependsOn copyTask
+        dependsOn runTask
+        copyTask.mustRunAfter(deleteTask)
+        runTask.mustRunAfter(copyTask)
+    }
+}


### PR DESCRIPTION
This is a workaround, there might be a more efficient way of doing this - @ThadHouse , do you have any ideas?

Java examples don't need this, they already have `run*` tasks.