### PR TITLE
Update Drake DARE solver to v0.29.0

### DIFF
--- a/wpimath/src/main/native/cpp/drake/math/discrete_algebraic_riccati_equation.cpp
+++ b/wpimath/src/main/native/cpp/drake/math/discrete_algebraic_riccati_equation.cpp
@@ -7,9 +7,6 @@
 #include <Eigen/Eigenvalues>
 #include <Eigen/QR>
 
-// This code has https://github.com/RobotLocomotion/drake/pull/11118 applied to
-// fix an infinite loop in reorder_eigen().
-
 namespace drake {
 namespace math {
 namespace {

--- a/wpimath/src/main/native/include/drake/math/discrete_algebraic_riccati_equation.h
+++ b/wpimath/src/main/native/include/drake/math/discrete_algebraic_riccati_equation.h
@@ -11,9 +11,9 @@ namespace math {
 /// Computes the unique stabilizing solution X to the discrete-time algebraic
 /// Riccati equation:
 ///
-/// \f[
+/// @f[
 /// A'XA - X - A'XB(B'XB+R)^{-1}B'XA + Q = 0
-/// \f]
+/// @f]
 ///
 /// @throws std::runtime_error if Q is not positive semi-definite.
 /// @throws std::runtime_error if R is not positive definite.

--- a/wpimath/src/test/native/cpp/drake/math/discrete_algebraic_riccati_equation_test.cpp
+++ b/wpimath/src/test/native/cpp/drake/math/discrete_algebraic_riccati_equation_test.cpp
@@ -63,12 +63,10 @@ GTEST_TEST(DARE, SolveDAREandVerify) {
   R3 << 1;
   SolveDAREandVerify(A3, B3, Q3, R3);
   // Test 4: A = B = Q = R = I_2 (2-by-2 identity matrix)
-  int n4 = 2, m4 = 2;
-  MatrixXd A4(n4, n4), B4(n4, m4), Q4(n4, n4), R4(m4, m4);
-  A4 << 1, 0, 0, 1;
-  B4 << 1, 0, 0, 1;
-  Q4 << 1, 0, 0, 1;
-  R4 << 1, 0, 0, 1;
+  const Eigen::MatrixXd A4{Eigen::Matrix2d::Identity()};
+  const Eigen::MatrixXd B4{Eigen::Matrix2d::Identity()};
+  const Eigen::MatrixXd Q4{Eigen::Matrix2d::Identity()};
+  const Eigen::MatrixXd R4{Eigen::Matrix2d::Identity()};
   SolveDAREandVerify(A4, B4, Q4, R4);
 }
 }  // namespace


### PR DESCRIPTION
This version incorporated the patch we were manually applying, so we're
synced back up with upstream now except for some minor #include changes
to reduce header bloat.