### PR TITLE
[wpimath] Fix classpath used by generate_numbers.py

### DIFF
--- a/wpimath/generate_numbers.py
+++ b/wpimath/generate_numbers.py
@@ -11,7 +11,7 @@ def main():
     with open(f"{dirname}/src/generate/GenericNumber.java.in",
               "r") as templateFile:
         template = templateFile.read()
-        rootPath = f"{cmake_binary_dir}/generated/main/java/edu/wpi/first/wpiutil/math/numbers"
+        rootPath = f"{cmake_binary_dir}/generated/main/java/edu/wpi/first/math/numbers"
 
         if not os.path.exists(rootPath):
             os.makedirs(rootPath)
@@ -30,7 +30,7 @@ def main():
 
     with open(f"{dirname}/src/generate/Nat.java.in", "r") as templateFile:
         template = templateFile.read()
-        outputPath = f"{cmake_binary_dir}/generated/main/java/edu/wpi/first/wpiutil/math/Nat.java"
+        outputPath = f"{cmake_binary_dir}/generated/main/java/edu/wpi/first/math/Nat.java"
         with open(f"{dirname}/src/generate/NatGetter.java.in",
                   "r") as getterFile:
             getter = getterFile.read()


### PR DESCRIPTION
Without this fix, I was getting the following kinds of errors from
`./gradlew testDesktopJava`.

```
> Task :wpimath:compileJava FAILED
/home/tav/git/wpilib/allwpilib/wpimath/build/generated/java/edu/wpi/first/wpiutil/math/numbers/N0.java:11: error: cannot find symbol
import edu.wpi.first.wpiutil.math.Num;
                                 ^
  symbol:   class Num
  location: package edu.wpi.first.wpiutil.math
```