### PR TITLE
[wpilibc] Revert "Return reference from GetInstance"

### DIFF
--- a/cameraserver/multiCameraServer/src/main/native/cpp/main.cpp
+++ b/cameraserver/multiCameraServer/src/main/native/cpp/main.cpp
@@ -158,7 +158,7 @@ bool ReadConfig() {
 void StartCamera(const CameraConfig& config) {
   wpi::outs() << "Starting camera '" << config.name << "' on " << config.path
               << '\n';
-  auto camera = frc::CameraServer::GetInstance().StartAutomaticCapture(
+  auto camera = frc::CameraServer::GetInstance()->StartAutomaticCapture(
       config.name, config.path);
 
   camera.SetConfigJson(config.config);

--- a/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
+++ b/cameraserver/src/main/native/cpp/cameraserver/CameraServer.cpp
@@ -45,7 +45,7 @@ struct CameraServer::Impl {
   std::vector<std::string> m_addresses;
 };
 
-CameraServer& CameraServer::GetInstance() {
+CameraServer* CameraServer::GetInstance() {
   struct Creator {
     static void* call() { return new CameraServer{}; }
   };
@@ -53,7 +53,7 @@ CameraServer& CameraServer::GetInstance() {
     static void call(void* ptr) { delete static_cast<CameraServer*>(ptr); }
   };
   static wpi::ManagedStatic<CameraServer, Creator, Deleter> instance;
-  return *instance;
+  return &(*instance);
 }
 
 static wpi::StringRef MakeSourceValue(CS_Source source,

--- a/cameraserver/src/main/native/include/cameraserver/CameraServer.h
+++ b/cameraserver/src/main/native/include/cameraserver/CameraServer.h
@@ -32,7 +32,7 @@ class CameraServer {
   /**
    * Get the CameraServer instance.
    */
-  static CameraServer& GetInstance();
+  static CameraServer* GetInstance();
 
   /**
    * Start automatically capturing images to send to the dashboard.

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -70,19 +70,19 @@ CommandScheduler::CommandScheduler()
   HAL_Report(HALUsageReporting::kResourceType_Command,
              HALUsageReporting::kCommand2_Scheduler);
   frc::SendableRegistry::GetInstance().AddLW(this, "Scheduler");
-  auto& scheduler = frc::LiveWindow::GetInstance();
-  scheduler.enabled = [this] {
-    Disable();
-    CancelAll();
+  auto scheduler = frc::LiveWindow::GetInstance();
+  scheduler->enabled = [this] {
+    this->Disable();
+    this->CancelAll();
   };
-  scheduler.disabled = [this] { Enable(); };
+  scheduler->disabled = [this] { this->Enable(); };
 }
 
 CommandScheduler::~CommandScheduler() {
   frc::SendableRegistry::GetInstance().Remove(this);
-  auto& scheduler = frc::LiveWindow::GetInstance();
-  scheduler.enabled = nullptr;
-  scheduler.disabled = nullptr;
+  auto scheduler = frc::LiveWindow::GetInstance();
+  scheduler->enabled = nullptr;
+  scheduler->disabled = nullptr;
 
   std::unique_ptr<Impl>().swap(m_impl);
 }

--- a/wpilibOldCommands/src/main/native/cpp/commands/Scheduler.cpp
+++ b/wpilibOldCommands/src/main/native/cpp/commands/Scheduler.cpp
@@ -201,19 +201,19 @@ Scheduler::Scheduler() : m_impl(new Impl) {
   HAL_Report(HALUsageReporting::kResourceType_Command,
              HALUsageReporting::kCommand_Scheduler);
   SendableRegistry::GetInstance().AddLW(this, "Scheduler");
-  auto& scheduler = frc::LiveWindow::GetInstance();
-  scheduler.enabled = [this] {
-    SetEnabled(false);
-    RemoveAll();
+  auto scheduler = frc::LiveWindow::GetInstance();
+  scheduler->enabled = [this] {
+    this->SetEnabled(false);
+    this->RemoveAll();
   };
-  scheduler.disabled = [this] { SetEnabled(true); };
+  scheduler->disabled = [this] { this->SetEnabled(true); };
 }
 
 Scheduler::~Scheduler() {
   SendableRegistry::GetInstance().Remove(this);
-  auto& scheduler = frc::LiveWindow::GetInstance();
-  scheduler.enabled = nullptr;
-  scheduler.disabled = nullptr;
+  auto scheduler = frc::LiveWindow::GetInstance();
+  scheduler->enabled = nullptr;
+  scheduler->disabled = nullptr;
 }
 
 void Scheduler::Impl::Remove(Command* command) {

--- a/wpilibc/src/main/native/cpp/IterativeRobotBase.cpp
+++ b/wpilibc/src/main/native/cpp/IterativeRobotBase.cpp
@@ -112,7 +112,7 @@ void IterativeRobotBase::LoopFunc() {
     // Call DisabledInit() if we are now just entering disabled mode from
     // either a different mode or from power-on.
     if (m_lastMode != Mode::kDisabled) {
-      LiveWindow::GetInstance().SetEnabled(false);
+      LiveWindow::GetInstance()->SetEnabled(false);
       Shuffleboard::DisableActuatorWidgets();
       DisabledInit();
       m_watchdog.AddEpoch("DisabledInit()");
@@ -126,7 +126,7 @@ void IterativeRobotBase::LoopFunc() {
     // Call AutonomousInit() if we are now just entering autonomous mode from
     // either a different mode or from power-on.
     if (m_lastMode != Mode::kAutonomous) {
-      LiveWindow::GetInstance().SetEnabled(false);
+      LiveWindow::GetInstance()->SetEnabled(false);
       Shuffleboard::DisableActuatorWidgets();
       AutonomousInit();
       m_watchdog.AddEpoch("AutonomousInit()");
@@ -140,7 +140,7 @@ void IterativeRobotBase::LoopFunc() {
     // Call TeleopInit() if we are now just entering teleop mode from
     // either a different mode or from power-on.
     if (m_lastMode != Mode::kTeleop) {
-      LiveWindow::GetInstance().SetEnabled(false);
+      LiveWindow::GetInstance()->SetEnabled(false);
       Shuffleboard::DisableActuatorWidgets();
       TeleopInit();
       m_watchdog.AddEpoch("TeleopInit()");
@@ -154,7 +154,7 @@ void IterativeRobotBase::LoopFunc() {
     // Call TestInit() if we are now just entering test mode from
     // either a different mode or from power-on.
     if (m_lastMode != Mode::kTest) {
-      LiveWindow::GetInstance().SetEnabled(true);
+      LiveWindow::GetInstance()->SetEnabled(true);
       Shuffleboard::EnableActuatorWidgets();
       TestInit();
       m_watchdog.AddEpoch("TestInit()");
@@ -171,7 +171,7 @@ void IterativeRobotBase::LoopFunc() {
 
   SmartDashboard::UpdateValues();
   m_watchdog.AddEpoch("SmartDashboard::UpdateValues()");
-  LiveWindow::GetInstance().UpdateValues();
+  LiveWindow::GetInstance()->UpdateValues();
   m_watchdog.AddEpoch("LiveWindow::UpdateValues()");
   Shuffleboard::Update();
   m_watchdog.AddEpoch("Shuffleboard::Update()");

--- a/wpilibc/src/main/native/cpp/Preferences.cpp
+++ b/wpilibc/src/main/native/cpp/Preferences.cpp
@@ -15,9 +15,9 @@ using namespace frc;
 // The Preferences table name
 static wpi::StringRef kTableName{"Preferences"};
 
-Preferences& Preferences::GetInstance() {
+Preferences* Preferences::GetInstance() {
   static Preferences instance;
-  return instance;
+  return &instance;
 }
 
 std::vector<std::string> Preferences::GetKeys() {
@@ -165,5 +165,3 @@ Preferences::Preferences()
       NT_NOTIFY_NEW | NT_NOTIFY_IMMEDIATE);
   HAL_Report(HALUsageReporting::kResourceType_Preferences, 0);
 }
-
-Preferences::~Preferences() = default;

--- a/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
+++ b/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
@@ -61,9 +61,9 @@ std::shared_ptr<LiveWindow::Impl::Component> LiveWindow::Impl::GetOrAdd(
   return data;
 }
 
-LiveWindow& LiveWindow::GetInstance() {
+LiveWindow* LiveWindow::GetInstance() {
   static LiveWindow instance;
-  return instance;
+  return &instance;
 }
 
 void LiveWindow::EnableTelemetry(Sendable* sendable) {

--- a/wpilibc/src/main/native/cppcs/RobotBase.cpp
+++ b/wpilibc/src/main/native/cppcs/RobotBase.cpp
@@ -214,7 +214,7 @@ RobotBase::RobotBase() : m_ds(DriverStation::GetInstance()) {
       ->GetEntry("LW Enabled")
       .SetBoolean(false);
 
-  LiveWindow::GetInstance().SetEnabled(false);
+  LiveWindow::GetInstance()->SetEnabled(false);
 }
 
 RobotBase::RobotBase(RobotBase&&) noexcept

--- a/wpilibc/src/main/native/include/frc/Preferences.h
+++ b/wpilibc/src/main/native/include/frc/Preferences.h
@@ -34,9 +34,9 @@ class Preferences {
   /**
    * Get the one and only {@link Preferences} object.
    *
-   * @return reference to the {@link Preferences}
+   * @return pointer to the {@link Preferences}
    */
-  static Preferences& GetInstance();
+  static Preferences* GetInstance();
 
   /**
    * Returns a vector of all the keys.
@@ -292,7 +292,6 @@ class Preferences {
 
  protected:
   Preferences();
-  ~Preferences();
 
   Preferences(Preferences&&) = default;
   Preferences& operator=(Preferences&&) = default;

--- a/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
+++ b/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
@@ -29,7 +29,7 @@ class LiveWindow {
    * This is a singleton to guarantee that there is only a single instance
    * regardless of how many times GetInstance is called.
    */
-  static LiveWindow& GetInstance();
+  static LiveWindow* GetInstance();
 
   /**
    * Enable telemetry for a single component.
@@ -69,7 +69,6 @@ class LiveWindow {
 
  private:
   LiveWindow();
-  ~LiveWindow() = default;
 
   struct Impl;
   std::unique_ptr<Impl> m_impl;

--- a/wpilibcExamples/src/main/cpp/examples/AxisCameraSample/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/AxisCameraSample/cpp/Robot.cpp
@@ -19,15 +19,15 @@ class Robot : public frc::TimedRobot {
   static void VisionThread() {
     // Get the Axis camera from CameraServer
     cs::AxisCamera camera =
-        frc::CameraServer::GetInstance().AddAxisCamera("axis-camera.local");
+        frc::CameraServer::GetInstance()->AddAxisCamera("axis-camera.local");
     // Set the resolution
     camera.SetResolution(640, 480);
 
     // Get a CvSink. This will capture Mats from the Camera
-    cs::CvSink cvSink = frc::CameraServer::GetInstance().GetVideo();
+    cs::CvSink cvSink = frc::CameraServer::GetInstance()->GetVideo();
     // Setup a CvSource. This will send images back to the Dashboard
     cs::CvSource outputStream =
-        frc::CameraServer::GetInstance().PutVideo("Rectangle", 640, 480);
+        frc::CameraServer::GetInstance()->PutVideo("Rectangle", 640, 480);
 
     // Mats are very memory expensive. Lets reuse this Mat.
     cv::Mat mat;

--- a/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
@@ -50,7 +50,7 @@ class Robot : public frc::TimedRobot {
   frc::DifferentialDrive m_robotDrive{m_left, m_right};
 
   frc::Joystick m_stick{0};
-  frc::LiveWindow& m_lw = frc::LiveWindow::GetInstance();
+  frc::LiveWindow& m_lw = *frc::LiveWindow::GetInstance();
   frc::Timer m_timer;
 };
 

--- a/wpilibcExamples/src/main/cpp/examples/IntermediateVision/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/IntermediateVision/cpp/Robot.cpp
@@ -24,15 +24,15 @@ class Robot : public frc::TimedRobot {
   static void VisionThread() {
     // Get the USB camera from CameraServer
     cs::UsbCamera camera =
-        frc::CameraServer::GetInstance().StartAutomaticCapture();
+        frc::CameraServer::GetInstance()->StartAutomaticCapture();
     // Set the resolution
     camera.SetResolution(640, 480);
 
     // Get a CvSink. This will capture Mats from the Camera
-    cs::CvSink cvSink = frc::CameraServer::GetInstance().GetVideo();
+    cs::CvSink cvSink = frc::CameraServer::GetInstance()->GetVideo();
     // Setup a CvSource. This will send images back to the Dashboard
     cs::CvSource outputStream =
-        frc::CameraServer::GetInstance().PutVideo("Rectangle", 640, 480);
+        frc::CameraServer::GetInstance()->PutVideo("Rectangle", 640, 480);
 
     // Mats are very memory expensive. Lets reuse this Mat.
     cv::Mat mat;

--- a/wpilibcExamples/src/main/cpp/examples/QuickVision/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/QuickVision/cpp/Robot.cpp
@@ -16,7 +16,7 @@ class Robot : public frc::TimedRobot {
  public:
   void RobotInit() override {
 #if defined(__linux__)
-    frc::CameraServer::GetInstance().StartAutomaticCapture();
+    frc::CameraServer::GetInstance()->StartAutomaticCapture();
 #else
     wpi::errs() << "Vision only available on Linux.\n";
     wpi::errs().flush();

--- a/wpilibcExamples/src/main/cpp/templates/robotbaseskeleton/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/templates/robotbaseskeleton/cpp/Robot.cpp
@@ -21,7 +21,7 @@ void Robot::Teleop() {}
 void Robot::Test() {}
 
 void Robot::StartCompetition() {
-  auto& lw = frc::LiveWindow::GetInstance();
+  auto& lw = *frc::LiveWindow::GetInstance();
 
   RobotInit();
 

--- a/wpilibcIntegrationTests/src/main/native/cpp/PreferencesTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/PreferencesTest.cpp
@@ -44,14 +44,14 @@ TEST(PreferencesTest, ReadPreferencesFromFile) {
   preferencesFile.close();
   inst.StartServer();
 
-  Preferences& preferences = Preferences::GetInstance();
+  Preferences* preferences = Preferences::GetInstance();
   EXPECT_EQ("Hello, preferences file",
-            preferences.GetString("testFileGetString"));
-  EXPECT_EQ(1, preferences.GetInt("testFileGetInt"));
-  EXPECT_FLOAT_EQ(0.5, preferences.GetDouble("testFileGetDouble"));
-  EXPECT_FLOAT_EQ(0.25f, preferences.GetFloat("testFileGetFloat"));
-  EXPECT_TRUE(preferences.GetBoolean("testFileGetBoolean"));
-  EXPECT_EQ(1000000000000000000ll, preferences.GetLong("testFileGetLong"));
+            preferences->GetString("testFileGetString"));
+  EXPECT_EQ(1, preferences->GetInt("testFileGetInt"));
+  EXPECT_FLOAT_EQ(0.5, preferences->GetDouble("testFileGetDouble"));
+  EXPECT_FLOAT_EQ(0.25f, preferences->GetFloat("testFileGetFloat"));
+  EXPECT_TRUE(preferences->GetBoolean("testFileGetBoolean"));
+  EXPECT_EQ(1000000000000000000ll, preferences->GetLong("testFileGetLong"));
 }
 
 /**
@@ -61,22 +61,22 @@ TEST(PreferencesTest, ReadPreferencesFromFile) {
 TEST(PreferencesTest, WritePreferencesToFile) {
   auto inst = nt::NetworkTableInstance::GetDefault();
   inst.StartServer();
-  Preferences& preferences = Preferences::GetInstance();
-  preferences.Remove("testFileGetString");
-  preferences.Remove("testFileGetInt");
-  preferences.Remove("testFileGetDouble");
-  preferences.Remove("testFileGetFloat");
-  preferences.Remove("testFileGetBoolean");
-  preferences.Remove("testFileGetLong");
+  Preferences* preferences = Preferences::GetInstance();
+  preferences->Remove("testFileGetString");
+  preferences->Remove("testFileGetInt");
+  preferences->Remove("testFileGetDouble");
+  preferences->Remove("testFileGetFloat");
+  preferences->Remove("testFileGetBoolean");
+  preferences->Remove("testFileGetLong");
 
   Wait(kSaveTime);
 
-  preferences.PutString("testFilePutString", "Hello, preferences file");
-  preferences.PutInt("testFilePutInt", 1);
-  preferences.PutDouble("testFilePutDouble", 0.5);
-  preferences.PutFloat("testFilePutFloat", 0.25f);
-  preferences.PutBoolean("testFilePutBoolean", true);
-  preferences.PutLong("testFilePutLong", 1000000000000000000ll);
+  preferences->PutString("testFilePutString", "Hello, preferences file");
+  preferences->PutInt("testFilePutInt", 1);
+  preferences->PutDouble("testFilePutDouble", 0.5);
+  preferences->PutFloat("testFilePutFloat", 0.25f);
+  preferences->PutBoolean("testFilePutBoolean", true);
+  preferences->PutLong("testFilePutLong", 1000000000000000000ll);
 
   Wait(kSaveTime);
 

--- a/wpilibcIntegrationTests/src/main/native/cpp/TestEnvironment.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/TestEnvironment.cpp
@@ -40,7 +40,7 @@ class TestEnvironment : public testing::Environment {
             station returns that the robot is enabled, to ensure that tests
             will be able to run on the hardware. */
     HAL_ObserveUserProgramStarting();
-    LiveWindow::GetInstance().SetEnabled(false);
+    LiveWindow::GetInstance()->SetEnabled(false);
 
     wpi::outs() << "Started coms\n";
 


### PR DESCRIPTION
This reverts commit a79faace1ba608ebca8bcf2f95a66ea5f78d88e8.

This change will be superseded in a non-breaking way by changing to static functions and deprecating GetInstance() entirely (#3341).