### PR TITLE
[wpilib] Split GenericHID functionality

### DIFF
--- a/hal/src/generate/ResourceType.txt
+++ b/hal/src/generate/ResourceType.txt
@@ -92,3 +92,4 @@ kResourceType_TrapezoidProfile = 90
 kResourceType_DutyCycle = 91
 kResourceType_AddressableLEDs = 92
 kResourceType_FusionVenom = 93
+kResourceType_PS4Controller = 94

--- a/wpilibc/src/main/native/cpp/Joystick.cpp
+++ b/wpilibc/src/main/native/cpp/Joystick.cpp
@@ -61,11 +61,11 @@ int Joystick::GetThrottleChannel() const {
   return m_axes[Axis::kThrottle];
 }
 
-double Joystick::GetX(JoystickHand hand) const {
+double Joystick::GetX() const {
   return GetRawAxis(m_axes[Axis::kX]);
 }
 
-double Joystick::GetY(JoystickHand hand) const {
+double Joystick::GetY() const {
   return GetRawAxis(m_axes[Axis::kY]);
 }
 

--- a/wpilibc/src/main/native/cpp/PS4Controller.cpp
+++ b/wpilibc/src/main/native/cpp/PS4Controller.cpp
@@ -1,0 +1,205 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc/PS4Controller.h"
+
+#include <hal/FRCUsageReporting.h>
+
+using namespace frc;
+
+PS4Controller::PS4Controller(int port) : GenericHID(port) {
+  HAL_Report(HALUsageReporting::kResourceType_PS4Controller, port + 1);
+}
+
+double PS4Controller::GetLeftX() const {
+  return GetRawAxis(Axis::kLeftX);
+}
+
+double PS4Controller::GetRightX() const {
+  return GetRawAxis(Axis::kRightX);
+}
+
+double PS4Controller::GetLeftY() const {
+  return GetRawAxis(Axis::kLeftY);
+}
+
+double PS4Controller::GetRightY() const {
+  return GetRawAxis(Axis::kRightY);
+}
+
+double PS4Controller::GetL2Axis() const {
+  return GetRawAxis(Axis::kL2);
+}
+
+double PS4Controller::GetR2Axis() const {
+  return GetRawAxis(Axis::kR2);
+}
+
+bool PS4Controller::GetSquareButton() const {
+  return GetRawButton(Button::kSquare);
+}
+
+bool PS4Controller::GetSquareButtonPressed() {
+  return GetRawButtonPressed(Button::kSquare);
+}
+
+bool PS4Controller::GetSquareButtonReleased() {
+  return GetRawButtonReleased(Button::kSquare);
+}
+
+bool PS4Controller::GetCrossButton() const {
+  return GetRawButton(Button::kCross);
+}
+
+bool PS4Controller::GetCrossButtonPressed() {
+  return GetRawButtonPressed(Button::kCross);
+}
+
+bool PS4Controller::GetCrossButtonReleased() {
+  return GetRawButtonReleased(Button::kCross);
+}
+
+bool PS4Controller::GetCircleButton() const {
+  return GetRawButton(Button::kCircle);
+}
+
+bool PS4Controller::GetCircleButtonPressed() {
+  return GetRawButtonPressed(Button::kCircle);
+}
+
+bool PS4Controller::GetCircleButtonReleased() {
+  return GetRawButtonReleased(Button::kCircle);
+}
+
+bool PS4Controller::GetTriangleButton() const {
+  return GetRawButton(Button::kTriangle);
+}
+
+bool PS4Controller::GetTriangleButtonPressed() {
+  return GetRawButtonPressed(Button::kTriangle);
+}
+
+bool PS4Controller::GetTriangleButtonReleased() {
+  return GetRawButtonReleased(Button::kTriangle);
+}
+
+bool PS4Controller::GetL1Button() const {
+  return GetRawButton(Button::kL1);
+}
+
+bool PS4Controller::GetL1ButtonPressed() {
+  return GetRawButtonPressed(Button::kL1);
+}
+
+bool PS4Controller::GetL1ButtonReleased() {
+  return GetRawButtonReleased(Button::kL1);
+}
+
+bool PS4Controller::GetR1Button() const {
+  return GetRawButton(Button::kR1);
+}
+
+bool PS4Controller::GetR1ButtonPressed() {
+  return GetRawButtonPressed(Button::kR1);
+}
+
+bool PS4Controller::GetR1ButtonReleased() {
+  return GetRawButtonReleased(Button::kR1);
+}
+
+bool PS4Controller::GetL2Button() const {
+  return GetRawButton(Button::kL2);
+}
+
+bool PS4Controller::GetL2ButtonPressed() {
+  return GetRawButtonPressed(Button::kL2);
+}
+
+bool PS4Controller::GetL2ButtonReleased() {
+  return GetRawButtonReleased(Button::kL2);
+}
+
+bool PS4Controller::GetR2Button() const {
+  return GetRawButton(Button::kR2);
+}
+
+bool PS4Controller::GetR2ButtonPressed() {
+  return GetRawButtonPressed(Button::kR2);
+}
+
+bool PS4Controller::GetR2ButtonReleased() {
+  return GetRawButtonReleased(Button::kR2);
+}
+
+bool PS4Controller::GetShareButton() const {
+  return GetRawButton(Button::kShare);
+}
+
+bool PS4Controller::GetShareButtonPressed() {
+  return GetRawButtonPressed(Button::kShare);
+}
+
+bool PS4Controller::GetShareButtonReleased() {
+  return GetRawButtonReleased(Button::kShare);
+}
+
+bool PS4Controller::GetOptionsButton() const {
+  return GetRawButton(Button::kOptions);
+}
+
+bool PS4Controller::GetOptionsButtonPressed() {
+  return GetRawButtonPressed(Button::kOptions);
+}
+
+bool PS4Controller::GetOptionsButtonReleased() {
+  return GetRawButtonReleased(Button::kOptions);
+}
+
+bool PS4Controller::GetL3Button() const {
+  return GetRawButton(Button::kL3);
+}
+
+bool PS4Controller::GetL3ButtonPressed() {
+  return GetRawButtonPressed(Button::kL3);
+}
+
+bool PS4Controller::GetL3ButtonReleased() {
+  return GetRawButtonReleased(Button::kL3);
+}
+
+bool PS4Controller::GetR3Button() const {
+  return GetRawButton(Button::kR3);
+}
+
+bool PS4Controller::GetR3ButtonPressed() {
+  return GetRawButtonPressed(Button::kR3);
+}
+
+bool PS4Controller::GetR3ButtonReleased() {
+  return GetRawButtonReleased(Button::kR3);
+}
+
+bool PS4Controller::GetPSButton() const {
+  return GetRawButton(Button::kPS);
+}
+
+bool PS4Controller::GetPSButtonPressed() {
+  return GetRawButtonPressed(Button::kPS);
+}
+
+bool PS4Controller::GetPSButtonReleased() {
+  return GetRawButtonReleased(Button::kPS);
+}
+
+bool PS4Controller::GetTouchpad() const {
+  return GetRawButton(Button::kTouchpad);
+}
+
+bool PS4Controller::GetTouchpadPressed() {
+  return GetRawButtonPressed(Button::kTouchpad);
+}
+
+bool PS4Controller::GetTouchpadReleased() {
+  return GetRawButtonReleased(Button::kTouchpad);
+}

--- a/wpilibc/src/main/native/cpp/XboxController.cpp
+++ b/wpilibc/src/main/native/cpp/XboxController.cpp
@@ -12,146 +12,146 @@ XboxController::XboxController(int port) : GenericHID(port) {
   HAL_Report(HALUsageReporting::kResourceType_XboxController, port + 1);
 }
 
-double XboxController::GetX(JoystickHand hand) const {
-  if (hand == kLeftHand) {
-    return GetRawAxis(static_cast<int>(Axis::kLeftX));
-  } else {
-    return GetRawAxis(static_cast<int>(Axis::kRightX));
-  }
+double XboxController::GetLeftX() const {
+  return GetRawAxis(Axis::kLeftX);
 }
 
-double XboxController::GetY(JoystickHand hand) const {
-  if (hand == kLeftHand) {
-    return GetRawAxis(static_cast<int>(Axis::kLeftY));
-  } else {
-    return GetRawAxis(static_cast<int>(Axis::kRightY));
-  }
+double XboxController::GetRightX() const {
+  return GetRawAxis(Axis::kRightX);
 }
 
-double XboxController::GetTriggerAxis(JoystickHand hand) const {
-  if (hand == kLeftHand) {
-    return GetRawAxis(static_cast<int>(Axis::kLeftTrigger));
-  } else {
-    return GetRawAxis(static_cast<int>(Axis::kRightTrigger));
-  }
+double XboxController::GetLeftY() const {
+  return GetRawAxis(Axis::kLeftY);
 }
 
-bool XboxController::GetBumper(JoystickHand hand) const {
-  if (hand == kLeftHand) {
-    return GetRawButton(static_cast<int>(Button::kBumperLeft));
-  } else {
-    return GetRawButton(static_cast<int>(Button::kBumperRight));
-  }
+double XboxController::GetRightY() const {
+  return GetRawAxis(Axis::kRightY);
 }
 
-bool XboxController::GetBumperPressed(JoystickHand hand) {
-  if (hand == kLeftHand) {
-    return GetRawButtonPressed(static_cast<int>(Button::kBumperLeft));
-  } else {
-    return GetRawButtonPressed(static_cast<int>(Button::kBumperRight));
-  }
+double XboxController::GetLeftTriggerAxis() const {
+  return GetRawAxis(Axis::kLeftTrigger);
 }
 
-bool XboxController::GetBumperReleased(JoystickHand hand) {
-  if (hand == kLeftHand) {
-    return GetRawButtonReleased(static_cast<int>(Button::kBumperLeft));
-  } else {
-    return GetRawButtonReleased(static_cast<int>(Button::kBumperRight));
-  }
+double XboxController::GetRightTriggerAxis() const {
+  return GetRawAxis(Axis::kRightTrigger);
 }
 
-bool XboxController::GetStickButton(JoystickHand hand) const {
-  if (hand == kLeftHand) {
-    return GetRawButton(static_cast<int>(Button::kStickLeft));
-  } else {
-    return GetRawButton(static_cast<int>(Button::kStickRight));
-  }
+bool XboxController::GetLeftBumper() const {
+  return GetRawButton(Button::kLeftBumper);
 }
 
-bool XboxController::GetStickButtonPressed(JoystickHand hand) {
-  if (hand == kLeftHand) {
-    return GetRawButtonPressed(static_cast<int>(Button::kStickLeft));
-  } else {
-    return GetRawButtonPressed(static_cast<int>(Button::kStickRight));
-  }
+bool XboxController::GetRightBumper() const {
+  return GetRawButton(Button::kRightBumper);
 }
 
-bool XboxController::GetStickButtonReleased(JoystickHand hand) {
-  if (hand == kLeftHand) {
-    return GetRawButtonReleased(static_cast<int>(Button::kStickLeft));
-  } else {
-    return GetRawButtonReleased(static_cast<int>(Button::kStickRight));
-  }
+bool XboxController::GetLeftBumperPressed() {
+  return GetRawButtonPressed(Button::kLeftBumper);
+}
+
+bool XboxController::GetRightBumperPressed() {
+  return GetRawButtonPressed(Button::kRightBumper);
+}
+
+bool XboxController::GetLeftBumperReleased() {
+  return GetRawButtonReleased(Button::kLeftBumper);
+}
+
+bool XboxController::GetRightBumperReleased() {
+  return GetRawButtonReleased(Button::kRightBumper);
+}
+
+bool XboxController::GetLeftStickButton() const {
+  return GetRawButton(Button::kLeftStick);
+}
+
+bool XboxController::GetRightStickButton() const {
+  return GetRawButton(Button::kRightStick);
+}
+
+bool XboxController::GetLeftStickButtonPressed() {
+  return GetRawButtonPressed(Button::kLeftStick);
+}
+
+bool XboxController::GetRightStickButtonPressed() {
+  return GetRawButtonPressed(Button::kRightStick);
+}
+
+bool XboxController::GetLeftStickButtonReleased() {
+  return GetRawButtonReleased(Button::kLeftStick);
+}
+
+bool XboxController::GetRightStickButtonReleased() {
+  return GetRawButtonReleased(Button::kRightStick);
 }
 
 bool XboxController::GetAButton() const {
-  return GetRawButton(static_cast<int>(Button::kA));
+  return GetRawButton(Button::kA);
 }
 
 bool XboxController::GetAButtonPressed() {
-  return GetRawButtonPressed(static_cast<int>(Button::kA));
+  return GetRawButtonPressed(Button::kA);
 }
 
 bool XboxController::GetAButtonReleased() {
-  return GetRawButtonReleased(static_cast<int>(Button::kA));
+  return GetRawButtonReleased(Button::kA);
 }
 
 bool XboxController::GetBButton() const {
-  return GetRawButton(static_cast<int>(Button::kB));
+  return GetRawButton(Button::kB);
 }
 
 bool XboxController::GetBButtonPressed() {
-  return GetRawButtonPressed(static_cast<int>(Button::kB));
+  return GetRawButtonPressed(Button::kB);
 }
 
 bool XboxController::GetBButtonReleased() {
-  return GetRawButtonReleased(static_cast<int>(Button::kB));
+  return GetRawButtonReleased(Button::kB);
 }
 
 bool XboxController::GetXButton() const {
-  return GetRawButton(static_cast<int>(Button::kX));
+  return GetRawButton(Button::kX);
 }
 
 bool XboxController::GetXButtonPressed() {
-  return GetRawButtonPressed(static_cast<int>(Button::kX));
+  return GetRawButtonPressed(Button::kX);
 }
 
 bool XboxController::GetXButtonReleased() {
-  return GetRawButtonReleased(static_cast<int>(Button::kX));
+  return GetRawButtonReleased(Button::kX);
 }
 
 bool XboxController::GetYButton() const {
-  return GetRawButton(static_cast<int>(Button::kY));
+  return GetRawButton(Button::kY);
 }
 
 bool XboxController::GetYButtonPressed() {
-  return GetRawButtonPressed(static_cast<int>(Button::kY));
+  return GetRawButtonPressed(Button::kY);
 }
 
 bool XboxController::GetYButtonReleased() {
-  return GetRawButtonReleased(static_cast<int>(Button::kY));
+  return GetRawButtonReleased(Button::kY);
 }
 
 bool XboxController::GetBackButton() const {
-  return GetRawButton(static_cast<int>(Button::kBack));
+  return GetRawButton(Button::kBack);
 }
 
 bool XboxController::GetBackButtonPressed() {
-  return GetRawButtonPressed(static_cast<int>(Button::kBack));
+  return GetRawButtonPressed(Button::kBack);
 }
 
 bool XboxController::GetBackButtonReleased() {
-  return GetRawButtonReleased(static_cast<int>(Button::kBack));
+  return GetRawButtonReleased(Button::kBack);
 }
 
 bool XboxController::GetStartButton() const {
-  return GetRawButton(static_cast<int>(Button::kStart));
+  return GetRawButton(Button::kStart);
 }
 
 bool XboxController::GetStartButtonPressed() {
-  return GetRawButtonPressed(static_cast<int>(Button::kStart));
+  return GetRawButtonPressed(Button::kStart);
 }
 
 bool XboxController::GetStartButtonReleased() {
-  return GetRawButtonReleased(static_cast<int>(Button::kStart));
+  return GetRawButtonReleased(Button::kStart);
 }

--- a/wpilibc/src/main/native/cpp/simulation/PS4ControllerSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/PS4ControllerSim.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc/simulation/PS4ControllerSim.h"
+
+#include "frc/PS4Controller.h"
+
+using namespace frc;
+using namespace frc::sim;
+
+PS4ControllerSim::PS4ControllerSim(const PS4Controller& joystick)
+    : GenericHIDSim{joystick} {
+  SetAxisCount(6);
+  SetButtonCount(14);
+}
+
+PS4ControllerSim::PS4ControllerSim(int port) : GenericHIDSim{port} {
+  SetAxisCount(6);
+  SetButtonCount(14);
+}
+
+void PS4ControllerSim::SetLeftX(double value) {
+  SetRawAxis(PS4Controller::Axis::kLeftX, value);
+}
+
+void PS4ControllerSim::SetRightX(double value) {
+  SetRawAxis(PS4Controller::Axis::kRightX, value);
+}
+
+void PS4ControllerSim::SetLeftY(double value) {
+  SetRawAxis(PS4Controller::Axis::kLeftY, value);
+}
+
+void PS4ControllerSim::SetRightY(double value) {
+  SetRawAxis(PS4Controller::Axis::kRightY, value);
+}
+
+void PS4ControllerSim::SetL2Axis(double value) {
+  SetRawAxis(PS4Controller::Axis::kL2, value);
+}
+
+void PS4ControllerSim::SetR2Axis(double value) {
+  SetRawAxis(PS4Controller::Axis::kR2, value);
+}
+
+void PS4ControllerSim::SetSquareButton(bool value) {
+  SetRawButton(PS4Controller::Button::kSquare, value);
+}
+
+void PS4ControllerSim::SetCrossButton(bool value) {
+  SetRawButton(PS4Controller::Button::kCross, value);
+}
+
+void PS4ControllerSim::SetCircleButton(bool value) {
+  SetRawButton(PS4Controller::Button::kCircle, value);
+}
+
+void PS4ControllerSim::SetTriangleButton(bool value) {
+  SetRawButton(PS4Controller::Button::kTriangle, value);
+}
+
+void PS4ControllerSim::SetL1Button(bool value) {
+  SetRawButton(PS4Controller::Button::kL1, value);
+}
+
+void PS4ControllerSim::SetR1Button(bool value) {
+  SetRawButton(PS4Controller::Button::kR1, value);
+}
+
+void PS4ControllerSim::SetL2Button(bool value) {
+  SetRawButton(PS4Controller::Button::kL2, value);
+}
+
+void PS4ControllerSim::SetR2Button(bool value) {
+  SetRawButton(PS4Controller::Button::kR2, value);
+}
+
+void PS4ControllerSim::SetShareButton(bool value) {
+  SetRawButton(PS4Controller::Button::kShare, value);
+}
+
+void PS4ControllerSim::SetOptionsButton(bool value) {
+  SetRawButton(PS4Controller::Button::kOptions, value);
+}
+
+void PS4ControllerSim::SetL3Button(bool value) {
+  SetRawButton(PS4Controller::Button::kL3, value);
+}
+
+void PS4ControllerSim::SetR3Button(bool value) {
+  SetRawButton(PS4Controller::Button::kR3, value);
+}
+
+void PS4ControllerSim::SetPSButton(bool value) {
+  SetRawButton(PS4Controller::Button::kPS, value);
+}
+
+void PS4ControllerSim::SetTouchpad(bool value) {
+  SetRawButton(PS4Controller::Button::kTouchpad, value);
+}

--- a/wpilibc/src/main/native/cpp/simulation/XboxControllerSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/XboxControllerSim.cpp
@@ -20,68 +20,66 @@ XboxControllerSim::XboxControllerSim(int port) : GenericHIDSim{port} {
   SetButtonCount(10);
 }
 
-void XboxControllerSim::SetX(GenericHID::JoystickHand hand, double value) {
-  if (hand == GenericHID::kLeftHand) {
-    SetRawAxis(static_cast<int>(XboxController::Axis::kLeftX), value);
-  } else {
-    SetRawAxis(static_cast<int>(XboxController::Axis::kRightX), value);
-  }
+void XboxControllerSim::SetLeftX(double value) {
+  SetRawAxis(XboxController::Axis::kLeftX, value);
 }
 
-void XboxControllerSim::SetY(GenericHID::JoystickHand hand, double value) {
-  if (hand == GenericHID::kLeftHand) {
-    SetRawAxis(static_cast<int>(XboxController::Axis::kLeftY), value);
-  } else {
-    SetRawAxis(static_cast<int>(XboxController::Axis::kRightY), value);
-  }
+void XboxControllerSim::SetRightX(double value) {
+  SetRawAxis(XboxController::Axis::kRightX, value);
 }
 
-void XboxControllerSim::SetTriggerAxis(GenericHID::JoystickHand hand,
-                                       double value) {
-  if (hand == GenericHID::kLeftHand) {
-    SetRawAxis(static_cast<int>(XboxController::Axis::kLeftTrigger), value);
-  } else {
-    SetRawAxis(static_cast<int>(XboxController::Axis::kRightTrigger), value);
-  }
+void XboxControllerSim::SetLeftY(double value) {
+  SetRawAxis(XboxController::Axis::kLeftY, value);
 }
 
-void XboxControllerSim::SetBumper(GenericHID::JoystickHand hand, bool state) {
-  if (hand == GenericHID::kLeftHand) {
-    SetRawButton(static_cast<int>(XboxController::Button::kBumperLeft), state);
-  } else {
-    SetRawButton(static_cast<int>(XboxController::Button::kBumperRight), state);
-  }
+void XboxControllerSim::SetRightY(double value) {
+  SetRawAxis(XboxController::Axis::kRightY, value);
 }
 
-void XboxControllerSim::SetStickButton(GenericHID::JoystickHand hand,
-                                       bool state) {
-  if (hand == GenericHID::kLeftHand) {
-    SetRawButton(static_cast<int>(XboxController::Button::kStickLeft), state);
-  } else {
-    SetRawButton(static_cast<int>(XboxController::Button::kStickRight), state);
-  }
+void XboxControllerSim::SetLeftTriggerAxis(double value) {
+  SetRawAxis(XboxController::Axis::kLeftTrigger, value);
+}
+
+void XboxControllerSim::SetRightTriggerAxis(double value) {
+  SetRawAxis(XboxController::Axis::kRightTrigger, value);
+}
+
+void XboxControllerSim::SetLeftBumper(bool state) {
+  SetRawButton(XboxController::Button::kLeftBumper, state);
+}
+
+void XboxControllerSim::SetRightBumper(bool state) {
+  SetRawButton(XboxController::Button::kRightBumper, state);
+}
+
+void XboxControllerSim::SetLeftStickButton(bool state) {
+  SetRawButton(XboxController::Button::kLeftStick, state);
+}
+
+void XboxControllerSim::SetRightStickButton(bool state) {
+  SetRawButton(XboxController::Button::kRightStick, state);
 }
 
 void XboxControllerSim::SetAButton(bool state) {
-  SetRawButton(static_cast<int>(XboxController::Button::kA), state);
+  SetRawButton(XboxController::Button::kA, state);
 }
 
 void XboxControllerSim::SetBButton(bool state) {
-  SetRawButton(static_cast<int>(XboxController::Button::kB), state);
+  SetRawButton(XboxController::Button::kB, state);
 }
 
 void XboxControllerSim::SetXButton(bool state) {
-  SetRawButton(static_cast<int>(XboxController::Button::kX), state);
+  SetRawButton(XboxController::Button::kX, state);
 }
 
 void XboxControllerSim::SetYButton(bool state) {
-  SetRawButton(static_cast<int>(XboxController::Button::kY), state);
+  SetRawButton(XboxController::Button::kY, state);
 }
 
 void XboxControllerSim::SetBackButton(bool state) {
-  SetRawButton(static_cast<int>(XboxController::Button::kBack), state);
+  SetRawButton(XboxController::Button::kBack, state);
 }
 
 void XboxControllerSim::SetStartButton(bool state) {
-  SetRawButton(static_cast<int>(XboxController::Button::kStart), state);
+  SetRawButton(XboxController::Button::kStart, state);
 }

--- a/wpilibc/src/main/native/include/frc/GenericHID.h
+++ b/wpilibc/src/main/native/include/frc/GenericHID.h
@@ -13,7 +13,12 @@ namespace frc {
 class DriverStation;
 
 /**
- * GenericHID Interface.
+ * Handle input from standard HID devices connected to the Driver Station.
+ *
+ * <p>This class handles standard input that comes from the Driver Station. Each
+ * time a value is requested the most recent value is returned. There is a
+ * single class instance for each device and the mapping of ports to hardware
+ * buttons depends on the code in the Driver Station.
  */
 class GenericHID {
  public:
@@ -39,16 +44,11 @@ class GenericHID {
     kHID1stPerson = 24
   };
 
-  enum JoystickHand { kLeftHand = 0, kRightHand = 1 };
-
   explicit GenericHID(int port);
   virtual ~GenericHID() = default;
 
   GenericHID(GenericHID&&) = default;
   GenericHID& operator=(GenericHID&&) = default;
-
-  virtual double GetX(JoystickHand hand = kRightHand) const = 0;
-  virtual double GetY(JoystickHand hand = kRightHand) const = 0;
 
   /**
    * Get the button value (starting at button 1).

--- a/wpilibc/src/main/native/include/frc/Joystick.h
+++ b/wpilibc/src/main/native/include/frc/Joystick.h
@@ -119,24 +119,18 @@ class Joystick : public GenericHID {
   int GetThrottleChannel() const;
 
   /**
-   * Get the X value of the joystick.
+   * Get the X value of the current joystick.
    *
    * This depends on the mapping of the joystick connected to the current port.
-   *
-   * @param hand This parameter is ignored for the Joystick class and is only
-   *             here to complete the GenericHID interface.
    */
-  double GetX(JoystickHand hand = kRightHand) const override;
+  double GetX() const;
 
   /**
-   * Get the Y value of the joystick.
+   * Get the Y value of the current joystick.
    *
    * This depends on the mapping of the joystick connected to the current port.
-   *
-   * @param hand This parameter is ignored for the Joystick class and is only
-   *             here to complete the GenericHID interface.
    */
-  double GetY(JoystickHand hand = kRightHand) const override;
+  double GetY() const;
 
   /**
    * Get the Z value of the current joystick.

--- a/wpilibc/src/main/native/include/frc/PS4Controller.h
+++ b/wpilibc/src/main/native/include/frc/PS4Controller.h
@@ -1,0 +1,403 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include "frc/GenericHID.h"
+
+namespace frc {
+
+/**
+ * Handle input from PS4 controllers connected to the Driver Station.
+ *
+ * <p>This class handles PS4 input that comes from the Driver Station. Each time
+ * a value is requested the most recent value is returned. There is a single
+ * class instance for each controller and the mapping of ports to hardware
+ * buttons depends on the code in the Driver Station.
+ */
+class PS4Controller : public GenericHID {
+ public:
+  /**
+   * Construct an instance of an PS4 controller.
+   *
+   * The controller index is the USB port on the Driver Station.
+   *
+   * @param port The port on the Driver Station that the controller is plugged
+   *             into (0-5).
+   */
+  explicit PS4Controller(int port);
+
+  ~PS4Controller() override = default;
+
+  PS4Controller(PS4Controller&&) = default;
+  PS4Controller& operator=(PS4Controller&&) = default;
+
+  /**
+   * Get the X axis value of left side of the controller.
+   *
+   * @return the axis value.
+   */
+  double GetLeftX() const;
+
+  /**
+   * Get the X axis value of right side of the controller.
+   *
+   * @return the axis value.
+   */
+  double GetRightX() const;
+
+  /**
+   * Get the Y axis value of left side of the controller.
+   *
+   * @return the axis value.
+   */
+  double GetLeftY() const;
+
+  /**
+   * Get the Y axis value of right side of the controller.
+   *
+   * @return the axis value.
+   */
+  double GetRightY() const;
+
+  /**
+   * Get the L2 axis value of the controller. Note that this axis is bound to
+   * the range of [0, 1] as opposed to the usual [-1, 1].
+   *
+   * @return the axis value.
+   */
+  double GetL2Axis() const;
+
+  /**
+   * Get the R2 axis value of the controller. Note that this axis is bound to
+   * the range of [0, 1] as opposed to the usual [-1, 1].
+   *
+   * @return the axis value.
+   */
+  double GetR2Axis() const;
+
+  /**
+   * Read the value of the Square button on the controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetSquareButton() const;
+
+  /**
+   * Whether the Square button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  bool GetSquareButtonPressed();
+
+  /**
+   * Whether the Square button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  bool GetSquareButtonReleased();
+
+  /**
+   * Read the value of the Cross button on the controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetCrossButton() const;
+
+  /**
+   * Whether the Cross button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  bool GetCrossButtonPressed();
+
+  /**
+   * Whether the Cross button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  bool GetCrossButtonReleased();
+
+  /**
+   * Read the value of the Circle button on the controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetCircleButton() const;
+
+  /**
+   * Whether the Circle button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  bool GetCircleButtonPressed();
+
+  /**
+   * Whether the Circle button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  bool GetCircleButtonReleased();
+
+  /**
+   * Read the value of the Triangle button on the controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetTriangleButton() const;
+
+  /**
+   * Whether the Triangle button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  bool GetTriangleButtonPressed();
+
+  /**
+   * Whether the Triangle button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  bool GetTriangleButtonReleased();
+
+  /**
+   * Read the value of the L1 button on the controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetL1Button() const;
+
+  /**
+   * Whether the L1 button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  bool GetL1ButtonPressed();
+
+  /**
+   * Whether the L1 button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  bool GetL1ButtonReleased();
+
+  /**
+   * Read the value of the R1 button on the controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetR1Button() const;
+
+  /**
+   * Whether the R1 button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  bool GetR1ButtonPressed();
+
+  /**
+   * Whether the R1 button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  bool GetR1ButtonReleased();
+
+  /**
+   * Read the value of the L2 button on the controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetL2Button() const;
+
+  /**
+   * Whether the L2 button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  bool GetL2ButtonPressed();
+
+  /**
+   * Whether the L2 button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  bool GetL2ButtonReleased();
+
+  /**
+   * Read the value of the R2 button on the controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetR2Button() const;
+
+  /**
+   * Whether the R2 button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  bool GetR2ButtonPressed();
+
+  /**
+   * Whether the R2 button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  bool GetR2ButtonReleased();
+
+  /**
+   * Read the value of the Share button on the controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetShareButton() const;
+
+  /**
+   * Whether the Share button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  bool GetShareButtonPressed();
+
+  /**
+   * Whether the Share button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  bool GetShareButtonReleased();
+
+  /**
+   * Read the value of the Options button on the controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetOptionsButton() const;
+
+  /**
+   * Whether the Options button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  bool GetOptionsButtonPressed();
+
+  /**
+   * Whether the Options button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  bool GetOptionsButtonReleased();
+
+  /**
+   * Read the value of the L3 button (pressing the left analog stick) on the
+   * controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetL3Button() const;
+
+  /**
+   * Whether the L3 (left stick) button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  bool GetL3ButtonPressed();
+
+  /**
+   * Whether the L3 (left stick) button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  bool GetL3ButtonReleased();
+
+  /**
+   * Read the value of the R3 button (pressing the right analog stick) on the
+   * controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetR3Button() const;
+
+  /**
+   * Whether the R3 (right stick) button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  bool GetR3ButtonPressed();
+
+  /**
+   * Whether the R3 (right stick) button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  bool GetR3ButtonReleased();
+
+  /**
+   * Read the value of the PS button on the controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetPSButton() const;
+
+  /**
+   * Whether the PS button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  bool GetPSButtonPressed();
+
+  /**
+   * Whether the PS button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  bool GetPSButtonReleased();
+
+  /**
+   * Read the value of the touchpad button on the controller.
+   *
+   * @return The state of the button.
+   */
+  bool GetTouchpad() const;
+
+  /**
+   * Whether the touchpad was pressed since the last check.
+   *
+   * @return Whether the touchpad was pressed since the last check.
+   */
+  bool GetTouchpadPressed();
+
+  /**
+   * Whether the touchpad was released since the last check.
+   *
+   * @return Whether the touchpad was released since the last check.
+   */
+  bool GetTouchpadReleased();
+
+  struct Button {
+    static constexpr int kSquare = 1;
+    static constexpr int kCross = 2;
+    static constexpr int kCircle = 3;
+    static constexpr int kTriangle = 4;
+    static constexpr int kL1 = 5;
+    static constexpr int kR1 = 6;
+    static constexpr int kL2 = 7;
+    static constexpr int kR2 = 8;
+    static constexpr int kShare = 9;
+    static constexpr int kOptions = 10;
+    static constexpr int kL3 = 11;
+    static constexpr int kR3 = 12;
+    static constexpr int kPS = 13;
+    static constexpr int kTouchpad = 14;
+  };
+
+  struct Axis {
+    static constexpr int kLeftX = 0;
+    static constexpr int kLeftY = 1;
+    static constexpr int kRightX = 2;
+    static constexpr int kRightY = 5;
+    static constexpr int kL2 = 3;
+    static constexpr int kR2 = 4;
+  };
+};
+
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/XboxController.h
+++ b/wpilibc/src/main/native/include/frc/XboxController.h
@@ -35,72 +35,96 @@ class XboxController : public GenericHID {
   XboxController& operator=(XboxController&&) = default;
 
   /**
-   * Get the X axis value of the controller.
-   *
-   * @param hand Side of controller whose value should be returned.
+   * Get the X axis value of left side of the controller.
    */
-  double GetX(JoystickHand hand) const override;
+  double GetLeftX() const;
 
   /**
-   * Get the Y axis value of the controller.
-   *
-   * @param hand Side of controller whose value should be returned.
+   * Get the X axis value of right side of the controller.
    */
-  double GetY(JoystickHand hand) const override;
+  double GetRightX() const;
 
   /**
-   * Get the trigger axis value of the controller.
-   *
-   * @param hand Side of controller whose value should be returned.
+   * Get the Y axis value of left side of the controller.
    */
-  double GetTriggerAxis(JoystickHand hand) const;
+  double GetLeftY() const;
 
   /**
-   * Read the value of the bumper button on the controller.
-   *
-   * @param hand Side of controller whose value should be returned.
+   * Get the Y axis value of right side of the controller.
    */
-  bool GetBumper(JoystickHand hand) const;
+  double GetRightY() const;
 
   /**
-   * Whether the bumper was pressed since the last check.
-   *
-   * @param hand Side of controller whose value should be returned.
-   * @return Whether the button was pressed since the last check.
+   * Get the left trigger (LT) axis value of the controller. Note that this axis
+   * is bound to the range of [0, 1] as opposed to the usual [-1, 1].
    */
-  bool GetBumperPressed(JoystickHand hand);
+  double GetLeftTriggerAxis() const;
 
   /**
-   * Whether the bumper was released since the last check.
-   *
-   * @param hand Side of controller whose value should be returned.
-   * @return Whether the button was released since the last check.
+   * Get the right trigger (RT) axis value of the controller. Note that this
+   * axis is bound to the range of [0, 1] as opposed to the usual [-1, 1].
    */
-  bool GetBumperReleased(JoystickHand hand);
+  double GetRightTriggerAxis() const;
 
   /**
-   * Read the value of the stick button on the controller.
-   *
-   * @param hand Side of controller whose value should be returned.
-   * @return The state of the button.
+   * Read the value of the left bumper (LB) button on the controller.
    */
-  bool GetStickButton(JoystickHand hand) const;
+  bool GetLeftBumper() const;
 
   /**
-   * Whether the stick button was pressed since the last check.
-   *
-   * @param hand Side of controller whose value should be returned.
-   * @return Whether the button was pressed since the last check.
+   * Read the value of the right bumper (RB) button on the controller.
    */
-  bool GetStickButtonPressed(JoystickHand hand);
+  bool GetRightBumper() const;
 
   /**
-   * Whether the stick button was released since the last check.
-   *
-   * @param hand Side of controller whose value should be returned.
-   * @return Whether the button was released since the last check.
+   * Whether the left bumper (LB) was pressed since the last check.
    */
-  bool GetStickButtonReleased(JoystickHand hand);
+  bool GetLeftBumperPressed();
+
+  /**
+   * Whether the right bumper (RB) was pressed since the last check.
+   */
+  bool GetRightBumperPressed();
+
+  /**
+   * Whether the left bumper (LB) was released since the last check.
+   */
+  bool GetLeftBumperReleased();
+
+  /**
+   * Whether the right bumper (RB) was released since the last check.
+   */
+  bool GetRightBumperReleased();
+
+  /**
+   * Read the value of the left stick button (LSB) on the controller.
+   */
+  bool GetLeftStickButton() const;
+
+  /**
+   * Read the value of the right stick button (RSB) on the controller.
+   */
+  bool GetRightStickButton() const;
+
+  /**
+   * Whether the left stick button (LSB) was pressed since the last check.
+   */
+  bool GetLeftStickButtonPressed();
+
+  /**
+   * Whether the right stick button (RSB) was pressed since the last check.
+   */
+  bool GetRightStickButtonPressed();
+
+  /**
+   * Whether the left stick button (LSB) was released since the last check.
+   */
+  bool GetLeftStickButtonReleased();
+
+  /**
+   * Whether the right stick button (RSB) was released since the last check.
+   */
+  bool GetRightStickButtonReleased();
 
   /**
    * Read the value of the A button on the controller.
@@ -210,7 +234,6 @@ class XboxController : public GenericHID {
   /**
    * Read the value of the start button on the controller.
    *
-   * @param hand Side of controller whose value should be returned.
    * @return The state of the button.
    */
   bool GetStartButton() const;
@@ -229,26 +252,26 @@ class XboxController : public GenericHID {
    */
   bool GetStartButtonReleased();
 
-  enum class Button {
-    kBumperLeft = 5,
-    kBumperRight = 6,
-    kStickLeft = 9,
-    kStickRight = 10,
-    kA = 1,
-    kB = 2,
-    kX = 3,
-    kY = 4,
-    kBack = 7,
-    kStart = 8
+  struct Button {
+    static constexpr int kLeftBumper = 5;
+    static constexpr int kRightBumper = 6;
+    static constexpr int kLeftStick = 9;
+    static constexpr int kRightStick = 10;
+    static constexpr int kA = 1;
+    static constexpr int kB = 2;
+    static constexpr int kX = 3;
+    static constexpr int kY = 4;
+    static constexpr int kBack = 7;
+    static constexpr int kStart = 8;
   };
 
-  enum class Axis {
-    kLeftX = 0,
-    kRightX = 4,
-    kLeftY = 1,
-    kRightY = 5,
-    kLeftTrigger = 2,
-    kRightTrigger = 3
+  struct Axis {
+    static constexpr int kLeftX = 0;
+    static constexpr int kRightX = 4;
+    static constexpr int kLeftY = 1;
+    static constexpr int kRightY = 5;
+    static constexpr int kLeftTrigger = 2;
+    static constexpr int kRightTrigger = 3;
   };
 };
 

--- a/wpilibc/src/main/native/include/frc/simulation/PS4ControllerSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/PS4ControllerSim.h
@@ -1,0 +1,176 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include "frc/simulation/GenericHIDSim.h"
+
+namespace frc {
+
+class PS4Controller;
+
+namespace sim {
+
+/**
+ * Class to control a simulated PS4 controller.
+ */
+class PS4ControllerSim : public GenericHIDSim {
+ public:
+  /**
+   * Constructs from a PS4Controller object.
+   *
+   * @param joystick controller to simulate
+   */
+  explicit PS4ControllerSim(const PS4Controller& joystick);
+
+  /**
+   * Constructs from a joystick port number.
+   *
+   * @param port port number
+   */
+  explicit PS4ControllerSim(int port);
+
+  /**
+   * Change the X axis value of the controller's left stick.
+   *
+   * @param value the new value
+   */
+  void SetLeftX(double value);
+
+  /**
+   * Change the X axis value of the controller's right stick.
+   *
+   * @param value the new value
+   */
+  void SetRightX(double value);
+
+  /**
+   * Change the Y axis value of the controller's left stick.
+   *
+   * @param value the new value
+   */
+  void SetLeftY(double value);
+
+  /**
+   * Change the Y axis value of the controller's right stick.
+   *
+   * @param value the new value
+   */
+  void SetRightY(double value);
+
+  /**
+   * Change the L2 axis axis value of the controller.
+   *
+   * @param value the new value
+   */
+  void SetL2Axis(double value);
+
+  /**
+   * Change the R2 axis value of the controller.
+   *
+   * @param value the new value
+   */
+  void SetR2Axis(double value);
+
+  /**
+   * Change the value of the Square button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetSquareButton(bool value);
+
+  /**
+   * Change the value of the Cross button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetCrossButton(bool value);
+
+  /**
+   * Change the value of the Circle button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetCircleButton(bool value);
+
+  /**
+   * Change the value of the Triangle button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetTriangleButton(bool value);
+
+  /**
+   * Change the value of the L1 button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetL1Button(bool value);
+
+  /**
+   * Change the value of the R1 button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetR1Button(bool value);
+
+  /**
+   * Change the value of the L2 button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetL2Button(bool value);
+
+  /**
+   * Change the value of the R2 button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetR2Button(bool value);
+
+  /**
+   * Change the value of the Share button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetShareButton(bool value);
+
+  /**
+   * Change the value of the Options button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetOptionsButton(bool value);
+
+  /**
+   * Change the value of the L3 (left stick) button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetL3Button(bool value);
+
+  /**
+   * Change the value of the R3 (right stick) button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetR3Button(bool value);
+
+  /**
+   * Change the value of the PS button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetPSButton(bool value);
+
+  /**
+   * Change the value of the touchpad button on the controller.
+   *
+   * @param value the new value
+   */
+  void SetTouchpad(bool value);
+};
+
+}  // namespace sim
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/simulation/XboxControllerSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/XboxControllerSim.h
@@ -32,86 +32,116 @@ class XboxControllerSim : public GenericHIDSim {
   explicit XboxControllerSim(int port);
 
   /**
-   * Change the X value of the joystick.
+   * Change the X axis value of the controller's left stick.
    *
-   * @param hand the joystick hand
    * @param value the new value
    */
-  void SetX(GenericHID::JoystickHand hand, double value);
+  void SetLeftX(double value);
 
   /**
-   * Change the Y value of the joystick.
+   * Change the X axis value of the controller's right stick.
    *
-   * @param hand the joystick hand
    * @param value the new value
    */
-  void SetY(GenericHID::JoystickHand hand, double value);
+  void SetRightX(double value);
 
   /**
-   * Change the value of a trigger axis on the joystick.
+   * Change the Y axis value of the controller's left stick.
    *
-   * @param hand the joystick hand
    * @param value the new value
    */
-  void SetTriggerAxis(GenericHID::JoystickHand hand, double value);
+  void SetLeftY(double value);
 
   /**
-   * Change the value of a bumper on the joystick.
+   * Change the Y axis value of the controller's right stick.
    *
-   * @param hand the joystick hand
-   * @param state the new value
+   * @param value the new value
    */
-  void SetBumper(GenericHID::JoystickHand hand, bool state);
+  void SetRightY(double value);
 
   /**
-   * Change the value of a button on the joystick.
+   * Change the left trigger axis value of the joystick.
    *
-   * @param hand the joystick hand
-   * @param state the new value
+   * @param value the new value
    */
-  void SetStickButton(GenericHID::JoystickHand hand, bool state);
+  void SetLeftTriggerAxis(double value);
+
+  /**
+   * Change the right trigger axis value of the joystick.
+   *
+   * @param value the new value
+   */
+  void SetRightTriggerAxis(double value);
+
+  /**
+   * Change the left bumper value of the joystick.
+   *
+   * @param value the new value
+   */
+  void SetLeftBumper(bool value);
+
+  /**
+   * Change the right bumper value of the joystick.
+   *
+   * @param value the new value
+   */
+  void SetRightBumper(bool value);
+
+  /**
+   * Change the left button value of the joystick.
+   *
+   * @param value the new value
+   */
+  void SetLeftStickButton(bool value);
+
+  /**
+   * Change the right button value of the joystick.
+   *
+   * @param value the new value
+   */
+  void SetRightStickButton(bool value);
 
   /**
    * Change the value of the A button.
    *
-   * @param state the new value
+   * @param value the new value
    */
-  void SetAButton(bool state);
+  void SetAButton(bool value);
 
   /**
    * Change the value of the B button.
    *
-   * @param state the new value
+   * @param value the new value
    */
-  void SetBButton(bool state);
+  void SetBButton(bool value);
 
   /**
    * Change the value of the X button.
    *
-   * @param state the new value
+   * @param value the new value
    */
-  void SetXButton(bool state);
+  void SetXButton(bool value);
 
   /**
    * Change the value of the Y button.
    *
-   * @param state the new value
+   * @param value the new value
    */
-  void SetYButton(bool state);
+  void SetYButton(bool value);
 
   /**
    * Change the value of the Back button.
    *
-   * @param state the new value
+   * @param value the new value
    */
-  void SetBackButton(bool state);
+  void SetBackButton(bool value);
 
   /**
    * Change the value of the Start button.
    *
-   * @param state the new value
+   * @param value the new value
    */
-  void SetStartButton(bool state);
+  void SetStartButton(bool value);
 };
 
 }  // namespace sim

--- a/wpilibc/src/test/native/cpp/JoystickTestMacros.h
+++ b/wpilibc/src/test/native/cpp/JoystickTestMacros.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #define AXIS_TEST(JoystickType, AxisName)                    \
-  TEST(JoystickType##Tests, Set##HandType##AxisName##Axis) { \
+  TEST(JoystickType##Test, Get##AxisName) {                  \
     JoystickType joy{2};                                     \
     sim::JoystickType##Sim joysim{joy};                      \
     joysim.Set##AxisName(0.35);                              \
@@ -13,21 +13,8 @@
     ASSERT_NEAR(joy.Get##AxisName(), 0.35, 0.001);           \
   }
 
-#define HANDED_AXIS_TEST_IMPL(JoystickType, HandType, AxisName)          \
-  TEST(JoystickType##Tests, Set##HandType##AxisName##Axis) {             \
-    JoystickType joy{2};                                                 \
-    sim::JoystickType##Sim joysim{joy};                                  \
-    joysim.Set##AxisName(JoystickType::HandType, 0.35);                  \
-    joysim.NotifyNewData();                                              \
-    ASSERT_NEAR(joy.Get##AxisName(JoystickType::HandType), 0.35, 0.001); \
-  }
-
-#define HANDED_AXIS_TEST(JoystickType, AxisName)           \
-  HANDED_AXIS_TEST_IMPL(JoystickType, kLeftHand, AxisName) \
-  HANDED_AXIS_TEST_IMPL(JoystickType, kRightHand, AxisName)
-
 #define BUTTON_TEST(JoystickType, ButtonName)              \
-  TEST(JoystickType##Tests, Set##ButtonName##Button) {     \
+  TEST(JoystickType##Test, Get##ButtonName) {              \
     JoystickType joy{1};                                   \
     sim::JoystickType##Sim joysim{joy};                    \
                                                            \
@@ -50,32 +37,3 @@
     ASSERT_FALSE(joy.Get##ButtonName##Pressed());          \
     ASSERT_TRUE(joy.Get##ButtonName##Released());          \
   }
-
-#define HANDED_BUTTON_TEST_IMPL(JoystickType, HandType, ButtonName)      \
-  TEST(JoystickType##Tests, Get##HandType##ButtonName##Button) {         \
-    JoystickType joy{1};                                                 \
-    sim::JoystickType##Sim joysim{joy};                                  \
-                                                                         \
-    joysim.Set##ButtonName(JoystickType::HandType, false);               \
-    joysim.NotifyNewData();                                              \
-    ASSERT_FALSE(joy.Get##ButtonName(JoystickType::HandType));           \
-    /* need to call pressed and released to clear flags */               \
-    joy.Get##ButtonName##Pressed(JoystickType::HandType);                \
-    joy.Get##ButtonName##Released(JoystickType::HandType);               \
-                                                                         \
-    joysim.Set##ButtonName(JoystickType::HandType, true);                \
-    joysim.NotifyNewData();                                              \
-    ASSERT_TRUE(joy.Get##ButtonName(JoystickType::HandType));            \
-    ASSERT_TRUE(joy.Get##ButtonName##Pressed(JoystickType::HandType));   \
-    ASSERT_FALSE(joy.Get##ButtonName##Released(JoystickType::HandType)); \
-                                                                         \
-    joysim.Set##ButtonName(JoystickType::HandType, false);               \
-    joysim.NotifyNewData();                                              \
-    ASSERT_FALSE(joy.Get##ButtonName(JoystickType::HandType));           \
-    ASSERT_FALSE(joy.Get##ButtonName##Pressed(JoystickType::HandType));  \
-    ASSERT_TRUE(joy.Get##ButtonName##Released(JoystickType::HandType));  \
-  }
-
-#define HANDED_BUTTON_TEST(JoystickType, ButtonName)           \
-  HANDED_BUTTON_TEST_IMPL(JoystickType, kLeftHand, ButtonName) \
-  HANDED_BUTTON_TEST_IMPL(JoystickType, kRightHand, ButtonName)

--- a/wpilibc/src/test/native/cpp/JoystickTestMacros.h
+++ b/wpilibc/src/test/native/cpp/JoystickTestMacros.h
@@ -4,13 +4,13 @@
 
 #pragma once
 
-#define AXIS_TEST(JoystickType, AxisName)                    \
-  TEST(JoystickType##Test, Get##AxisName) {                  \
-    JoystickType joy{2};                                     \
-    sim::JoystickType##Sim joysim{joy};                      \
-    joysim.Set##AxisName(0.35);                              \
-    joysim.NotifyNewData();                                  \
-    ASSERT_NEAR(joy.Get##AxisName(), 0.35, 0.001);           \
+#define AXIS_TEST(JoystickType, AxisName)          \
+  TEST(JoystickType##Test, Get##AxisName) {        \
+    JoystickType joy{2};                           \
+    sim::JoystickType##Sim joysim{joy};            \
+    joysim.Set##AxisName(0.35);                    \
+    joysim.NotifyNewData();                        \
+    ASSERT_NEAR(joy.Get##AxisName(), 0.35, 0.001); \
   }
 
 #define BUTTON_TEST(JoystickType, ButtonName)              \

--- a/wpilibc/src/test/native/cpp/PS4ControllerTest.cpp
+++ b/wpilibc/src/test/native/cpp/PS4ControllerTest.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc/PS4Controller.h"  // NOLINT(build/include_order)
+
+#include "JoystickTestMacros.h"
+#include "frc/simulation/PS4ControllerSim.h"
+#include "gtest/gtest.h"
+
+using namespace frc;
+
+BUTTON_TEST(PS4Controller, SquareButton)
+BUTTON_TEST(PS4Controller, CrossButton)
+BUTTON_TEST(PS4Controller, CircleButton)
+BUTTON_TEST(PS4Controller, TriangleButton)
+
+BUTTON_TEST(PS4Controller, L1Button)
+BUTTON_TEST(PS4Controller, R1Button)
+BUTTON_TEST(PS4Controller, L2Button)
+BUTTON_TEST(PS4Controller, R2Button)
+
+BUTTON_TEST(PS4Controller, ShareButton)
+BUTTON_TEST(PS4Controller, OptionsButton)
+
+BUTTON_TEST(PS4Controller, L3Button)
+BUTTON_TEST(PS4Controller, R3Button)
+
+BUTTON_TEST(PS4Controller, PSButton)
+BUTTON_TEST(PS4Controller, Touchpad)
+
+AXIS_TEST(PS4Controller, LeftX)
+AXIS_TEST(PS4Controller, RightX)
+AXIS_TEST(PS4Controller, LeftY)
+AXIS_TEST(PS4Controller, RightY)
+AXIS_TEST(PS4Controller, L2Axis)
+AXIS_TEST(PS4Controller, R2Axis)

--- a/wpilibc/src/test/native/cpp/XboxControllerTest.cpp
+++ b/wpilibc/src/test/native/cpp/XboxControllerTest.cpp
@@ -10,8 +10,11 @@
 
 using namespace frc;
 
-HANDED_BUTTON_TEST(XboxController, Bumper)
-HANDED_BUTTON_TEST(XboxController, StickButton)
+BUTTON_TEST(XboxController, LeftBumper)
+BUTTON_TEST(XboxController, RightBumper)
+
+BUTTON_TEST(XboxController, LeftStickButton)
+BUTTON_TEST(XboxController, RightStickButton)
 
 BUTTON_TEST(XboxController, AButton)
 BUTTON_TEST(XboxController, BButton)
@@ -20,6 +23,10 @@ BUTTON_TEST(XboxController, YButton)
 BUTTON_TEST(XboxController, BackButton)
 BUTTON_TEST(XboxController, StartButton)
 
-HANDED_AXIS_TEST(XboxController, X)
-HANDED_AXIS_TEST(XboxController, Y)
-HANDED_AXIS_TEST(XboxController, TriggerAxis)
+AXIS_TEST(XboxController, LeftX)
+AXIS_TEST(XboxController, RightX)
+AXIS_TEST(XboxController, LeftY)
+AXIS_TEST(XboxController, RightY)
+
+AXIS_TEST(XboxController, LeftTriggerAxis)
+AXIS_TEST(XboxController, RightTriggerAxis)

--- a/wpilibcExamples/src/main/cpp/examples/ArcadeDriveXboxController/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArcadeDriveXboxController/cpp/Robot.cpp
@@ -2,7 +2,6 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include <frc/GenericHID.h>
 #include <frc/TimedRobot.h>
 #include <frc/XboxController.h>
 #include <frc/drive/DifferentialDrive.h>
@@ -23,9 +22,8 @@ class Robot : public frc::TimedRobot {
     // Drive with split arcade style
     // That means that the Y axis of the left stick moves forward
     // and backward, and the X of the right stick turns left and right.
-    m_robotDrive.ArcadeDrive(
-        m_driverController.GetY(frc::GenericHID::JoystickHand::kLeftHand),
-        m_driverController.GetX(frc::GenericHID::JoystickHand::kRightHand));
+    m_robotDrive.ArcadeDrive(m_driverController.GetLeftY(),
+                             m_driverController.GetRightX());
   }
 };
 

--- a/wpilibcExamples/src/main/cpp/examples/ArmBot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBot/cpp/RobotContainer.cpp
@@ -17,9 +17,8 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
-            m_driverController.GetX(frc::GenericHID::kRightHand));
+        m_drive.ArcadeDrive(m_driverController.GetLeftY(),
+                            m_driverController.GetRightX());
       },
       {&m_drive}));
 }
@@ -28,7 +27,7 @@ void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
 
   // Move the arm to 2 radians above horizontal when the 'A' button is pressed.
-  frc2::JoystickButton(&m_driverController, 1)
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kA)
       .WhenPressed(
           [this] {
             m_arm.SetGoal(2_rad);
@@ -37,7 +36,7 @@ void RobotContainer::ConfigureButtonBindings() {
           {&m_arm});
 
   // Move the arm to neutral position when the 'B' button is pressed.
-  frc2::JoystickButton(&m_driverController, 2)
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kB)
       .WhenPressed(
           [this] {
             m_arm.SetGoal(ArmConstants::kArmOffset);
@@ -46,11 +45,12 @@ void RobotContainer::ConfigureButtonBindings() {
           {&m_arm});
 
   // Disable the arm controller when Y is pressed.
-  frc2::JoystickButton(&m_driverController, 4)
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kY)
       .WhenPressed([this] { m_arm.Disable(); }, {&m_arm});
 
   // While holding the shoulder button, drive at half speed
-  frc2::JoystickButton(&m_driverController, 6)
+  frc2::JoystickButton(&m_driverController,
+                       frc::XboxController::Button::kRightBumper)
       .WhenPressed([this] { m_drive.SetMaxOutput(0.5); })
       .WhenReleased([this] { m_drive.SetMaxOutput(1); });
 }

--- a/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/cpp/RobotContainer.cpp
@@ -17,9 +17,8 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
-            m_driverController.GetX(frc::GenericHID::kRightHand));
+        m_drive.ArcadeDrive(m_driverController.GetLeftY(),
+                            m_driverController.GetRightX());
       },
       {&m_drive}));
 }
@@ -28,16 +27,17 @@ void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
 
   // Move the arm to 2 radians above horizontal when the 'A' button is pressed.
-  frc2::JoystickButton(&m_driverController, 1)
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kA)
       .WhenPressed([this] { m_arm.SetGoal(2_rad); }, {&m_arm});
 
   // Move the arm to neutral position when the 'B' button is pressed.
-  frc2::JoystickButton(&m_driverController, 1)
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kB)
       .WhenPressed([this] { m_arm.SetGoal(ArmConstants::kArmOffset); },
                    {&m_arm});
 
   // While holding the shoulder button, drive at half speed
-  frc2::JoystickButton(&m_driverController, 6)
+  frc2::JoystickButton(&m_driverController,
+                       frc::XboxController::Button::kRightBumper)
       .WhenPressed([this] { m_drive.SetMaxOutput(0.5); })
       .WhenReleased([this] { m_drive.SetMaxOutput(1); });
 }

--- a/wpilibcExamples/src/main/cpp/examples/ArmSimulation/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArmSimulation/cpp/Robot.cpp
@@ -3,7 +3,6 @@
 // the WPILib BSD license file in the root directory of this project.
 
 #include <frc/Encoder.h>
-#include <frc/GenericHID.h>
 #include <frc/Joystick.h>
 #include <frc/RobotController.h>
 #include <frc/StateSpaceUtil.h>

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDriveBot/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDriveBot/cpp/Robot.cpp
@@ -18,16 +18,14 @@ class Robot : public frc::TimedRobot {
   void TeleopPeriodic() override {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    const auto xSpeed = -m_speedLimiter.Calculate(
-                            m_controller.GetY(frc::GenericHID::kLeftHand)) *
+    const auto xSpeed = -m_speedLimiter.Calculate(m_controller.GetLeftY()) *
                         Drivetrain::kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    const auto rot = -m_rotLimiter.Calculate(
-                         m_controller.GetX(frc::GenericHID::kRightHand)) *
+    const auto rot = -m_rotLimiter.Calculate(m_controller.GetRightX()) *
                      Drivetrain::kMaxAngularSpeed;
 
     m_drive.Drive(xSpeed, rot);

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/cpp/Robot.cpp
@@ -18,16 +18,14 @@ class Robot : public frc::TimedRobot {
   void TeleopPeriodic() override {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    const auto xSpeed = -m_speedLimiter.Calculate(
-                            m_controller.GetY(frc::GenericHID::kLeftHand)) *
+    const auto xSpeed = -m_speedLimiter.Calculate(m_controller.GetLeftY()) *
                         Drivetrain::kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    const auto rot = -m_rotLimiter.Calculate(
-                         m_controller.GetX(frc::GenericHID::kRightHand)) *
+    const auto rot = -m_rotLimiter.Calculate(m_controller.GetRightX()) *
                      Drivetrain::kMaxAngularSpeed;
 
     m_drive.Drive(xSpeed, rot);

--- a/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/RobotContainer.cpp
@@ -18,9 +18,8 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
-            m_driverController.GetX(frc::GenericHID::kRightHand));
+        m_drive.ArcadeDrive(m_driverController.GetLeftY(),
+                            m_driverController.GetRightX());
       },
       {&m_drive}));
 }
@@ -29,18 +28,19 @@ void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
 
   // While holding the shoulder button, drive at half speed
-  frc2::JoystickButton(&m_driverController, 6)
+  frc2::JoystickButton(&m_driverController,
+                       frc::XboxController::Button::kRightBumper)
       .WhenPressed(&m_driveHalfSpeed)
       .WhenReleased(&m_driveFullSpeed);
 
   // Drive forward by 3 meters when the 'A' button is pressed, with a timeout of
   // 10 seconds
-  frc2::JoystickButton(&m_driverController, 1)
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kA)
       .WhenPressed(DriveDistanceProfiled(3_m, &m_drive).WithTimeout(10_s));
 
   // Do the same thing as above when the 'B' button is pressed, but defined
   // inline
-  frc2::JoystickButton(&m_driverController, 2)
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kB)
       .WhenPressed(
           frc2::TrapezoidProfileCommand<units::meters>(
               frc::TrapezoidProfile<units::meters>(

--- a/wpilibcExamples/src/main/cpp/examples/ElevatorSimulation/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ElevatorSimulation/cpp/Robot.cpp
@@ -3,7 +3,6 @@
 // the WPILib BSD license file in the root directory of this project.
 
 #include <frc/Encoder.h>
-#include <frc/GenericHID.h>
 #include <frc/Joystick.h>
 #include <frc/RobotController.h>
 #include <frc/StateSpaceUtil.h>

--- a/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/RobotContainer.cpp
@@ -16,9 +16,8 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
-            m_driverController.GetX(frc::GenericHID::kRightHand));
+        m_drive.ArcadeDrive(m_driverController.GetLeftY(),
+                            m_driverController.GetRightX());
       },
       {&m_drive}));
 }
@@ -27,18 +26,21 @@ void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
 
   // Spin up the shooter when the 'A' button is pressed
-  frc2::JoystickButton(&m_driverController, 1).WhenPressed(&m_spinUpShooter);
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kA)
+      .WhenPressed(&m_spinUpShooter);
 
   // Turn off the shooter when the 'B' button is pressed
-  frc2::JoystickButton(&m_driverController, 2).WhenPressed(&m_stopShooter);
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kB)
+      .WhenPressed(&m_stopShooter);
 
   // Shoot when the 'X' button is held
-  frc2::JoystickButton(&m_driverController, 3)
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kX)
       .WhenPressed(&m_shoot)
       .WhenReleased(&m_stopFeeder);
 
   // While holding the shoulder button, drive at half speed
-  frc2::JoystickButton(&m_driverController, 6)
+  frc2::JoystickButton(&m_driverController,
+                       frc::XboxController::Button::kRightBumper)
       .WhenPressed(&m_driveHalfSpeed)
       .WhenReleased(&m_driveFullSpeed);
 }

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/RobotContainer.cpp
@@ -22,10 +22,9 @@ RobotContainer::RobotContainer()
   frc::SmartDashboard::PutData(&m_wrist);
   frc::SmartDashboard::PutData(&m_claw);
 
-  m_drivetrain.SetDefaultCommand(TankDrive(
-      [this] { return m_joy.GetY(frc::GenericHID::JoystickHand::kLeftHand); },
-      [this] { return m_joy.GetY(frc::GenericHID::JoystickHand::kRightHand); },
-      &m_drivetrain));
+  m_drivetrain.SetDefaultCommand(TankDrive([this] { return m_joy.GetLeftY(); },
+                                           [this] { return m_joy.GetRightY(); },
+                                           &m_drivetrain));
 
   // Configure the button bindings
   ConfigureButtonBindings();
@@ -33,24 +32,20 @@ RobotContainer::RobotContainer()
 
 void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
-  frc2::JoystickButton m_dUp{&m_joy, 5};
-  frc2::JoystickButton m_dRight{&m_joy, 6};
-  frc2::JoystickButton m_dDown{&m_joy, 7};
-  frc2::JoystickButton m_dLeft{&m_joy, 8};
-  frc2::JoystickButton m_l2{&m_joy, 9};
-  frc2::JoystickButton m_r2{&m_joy, 10};
-  frc2::JoystickButton m_l1{&m_joy, 11};
-  frc2::JoystickButton m_r1{&m_joy, 12};
-
-  m_dUp.WhenPressed(SetElevatorSetpoint(0.25, &m_elevator));
-  m_dDown.WhenPressed(SetElevatorSetpoint(0.0, &m_elevator));
-  m_dRight.WhenPressed(CloseClaw(&m_claw));
-  m_dLeft.WhenPressed(OpenClaw(&m_claw));
-
-  m_r1.WhenPressed(PrepareToPickup(&m_claw, &m_wrist, &m_elevator));
-  m_r2.WhenPressed(Pickup(&m_claw, &m_wrist, &m_elevator));
-  m_l1.WhenPressed(Place(&m_claw, &m_wrist, &m_elevator));
-  m_l2.WhenPressed(Autonomous(&m_claw, &m_wrist, &m_elevator, &m_drivetrain));
+  frc2::JoystickButton(&m_joy, 5).WhenPressed(
+      SetElevatorSetpoint(0.25, &m_elevator));
+  frc2::JoystickButton(&m_joy, 6).WhenPressed(CloseClaw(&m_claw));
+  frc2::JoystickButton(&m_joy, 7).WhenPressed(
+      SetElevatorSetpoint(0.0, &m_elevator));
+  frc2::JoystickButton(&m_joy, 8).WhenPressed(OpenClaw(&m_claw));
+  frc2::JoystickButton(&m_joy, 9).WhenPressed(
+      Autonomous(&m_claw, &m_wrist, &m_elevator, &m_drivetrain));
+  frc2::JoystickButton(&m_joy, 10)
+      .WhenPressed(Pickup(&m_claw, &m_wrist, &m_elevator));
+  frc2::JoystickButton(&m_joy, 11)
+      .WhenPressed(Place(&m_claw, &m_wrist, &m_elevator));
+  frc2::JoystickButton(&m_joy, 12)
+      .WhenPressed(PrepareToPickup(&m_claw, &m_wrist, &m_elevator));
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/RobotContainer.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <frc/Joystick.h>
+#include <frc/XboxController.h>
 #include <frc2/command/Command.h>
 
 #include "commands/Autonomous.h"
@@ -28,7 +28,7 @@ class RobotContainer {
 
  private:
   // The robot's subsystems and commands are defined here...
-  frc::Joystick m_joy{0};
+  frc::XboxController m_joy{0};
 
   Claw m_claw;
   Wrist m_wrist;

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/RobotContainer.cpp
@@ -19,9 +19,8 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
-            m_driverController.GetX(frc::GenericHID::kRightHand));
+        m_drive.ArcadeDrive(m_driverController.GetLeftY(),
+                            m_driverController.GetRightX());
       },
       {&m_drive}));
 }
@@ -31,8 +30,8 @@ void RobotContainer::ConfigureButtonBindings() {
 
   // Assorted commands to be bound to buttons
 
-  // Stabilize robot to drive straight with gyro when left bumper is held
-  frc2::JoystickButton(&m_driverController, 5)
+  // Stabilize robot to drive straight with gyro when L1 is held
+  frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kL1)
       .WhenHeld(frc2::PIDCommand{
           frc2::PIDController{dc::kStabilizationP, dc::kStabilizationI,
                               dc::kStabilizationD},
@@ -42,24 +41,22 @@ void RobotContainer::ConfigureButtonBindings() {
           0,
           // Pipe the output to the turning controls
           [this](double output) {
-            m_drive.ArcadeDrive(m_driverController.GetY(
-                                    frc::GenericHID::JoystickHand::kLeftHand),
-                                output);
+            m_drive.ArcadeDrive(m_driverController.GetLeftY(), output);
           },
           // Require the robot drive
           {&m_drive}});
 
-  // Turn to 90 degrees when the 'X' button is pressed
-  frc2::JoystickButton(&m_driverController, 3)
+  // Turn to 90 degrees when the 'Cross' button is pressed
+  frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kCross)
       .WhenPressed(TurnToAngle{90_deg, &m_drive}.WithTimeout(5_s));
 
-  // Turn to -90 degrees with a profile when the 'A' button is pressed, with a 5
-  // second timeout
-  frc2::JoystickButton(&m_driverController, 1)
+  // Turn to -90 degrees with a profile when the 'Square' button is pressed,
+  // with a 5 second timeout
+  frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kSquare)
       .WhenPressed(TurnToAngle{90_deg, &m_drive}.WithTimeout(5_s));
 
-  // While holding the shoulder button, drive at half speed
-  frc2::JoystickButton(&m_driverController, 6)
+  // While holding R1, drive at half speed
+  frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kR1)
       .WhenPressed(frc2::InstantCommand{[this] { m_drive.SetMaxOutput(0.5); }})
       .WhenReleased(frc2::InstantCommand{[this] { m_drive.SetMaxOutput(1); }});
 }

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/include/RobotContainer.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <frc/XboxController.h>
+#include <frc/PS4Controller.h>
 #include <frc/controller/PIDController.h>
 #include <frc/smartdashboard/SendableChooser.h>
 #include <frc2/command/Command.h>
@@ -32,7 +32,7 @@ class RobotContainer {
 
  private:
   // The driver's controller
-  frc::XboxController m_driverController{OIConstants::kDriverControllerPort};
+  frc::PS4Controller m_driverController{OIConstants::kDriverControllerPort};
 
   // The robot's subsystems and commands are defined here...
 

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/RobotContainer.cpp
@@ -23,9 +23,8 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
-            m_driverController.GetX(frc::GenericHID::kRightHand));
+        m_drive.ArcadeDrive(m_driverController.GetLeftY(),
+                            m_driverController.GetRightX());
       },
       {&m_drive}));
 }
@@ -33,12 +32,14 @@ RobotContainer::RobotContainer() {
 void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
 
-  // Grab the hatch when the 'A' button is pressed.
-  frc2::JoystickButton(&m_driverController, 1).WhenPressed(&m_grabHatch);
-  // Release the hatch when the 'B' button is pressed.
-  frc2::JoystickButton(&m_driverController, 2).WhenPressed(&m_releaseHatch);
-  // While holding the shoulder button, drive at half speed
-  frc2::JoystickButton(&m_driverController, 6)
+  // Grab the hatch when the 'Circle' button is pressed.
+  frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kCircle)
+      .WhenPressed(&m_grabHatch);
+  // Release the hatch when the 'Square' button is pressed.
+  frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kSquare)
+      .WhenPressed(&m_releaseHatch);
+  // While holding R1, drive at half speed
+  frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kR1)
       .WhenPressed(&m_driveHalfSpeed)
       .WhenReleased(&m_driveFullSpeed);
 }

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/RobotContainer.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <frc/XboxController.h>
+#include <frc/PS4Controller.h>
 #include <frc/smartdashboard/SendableChooser.h>
 #include <frc2/command/Command.h>
 #include <frc2/command/FunctionalCommand.h>
@@ -35,7 +35,7 @@ class RobotContainer {
 
  private:
   // The driver's controller
-  frc::XboxController m_driverController{OIConstants::kDriverControllerPort};
+  frc::PS4Controller m_driverController{OIConstants::kDriverControllerPort};
 
   // The robot's subsystems and commands are defined here...
 

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/RobotContainer.cpp
@@ -27,9 +27,8 @@ RobotContainer::RobotContainer() {
 
   // Set up default drive command
   m_drive.SetDefaultCommand(DefaultDrive(
-      &m_drive,
-      [this] { return m_driverController.GetY(frc::GenericHID::kLeftHand); },
-      [this] { return m_driverController.GetX(frc::GenericHID::kRightHand); }));
+      &m_drive, [this] { return m_driverController.GetLeftY(); },
+      [this] { return m_driverController.GetRightX(); }));
 }
 
 void RobotContainer::ConfigureButtonBindings() {
@@ -41,13 +40,14 @@ void RobotContainer::ConfigureButtonBindings() {
   // stack-allocated and declared as members of RobotContainer.
 
   // Grab the hatch when the 'A' button is pressed.
-  frc2::JoystickButton(&m_driverController, 1)
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kA)
       .WhenPressed(new GrabHatch(&m_hatch));
   // Release the hatch when the 'B' button is pressed.
-  frc2::JoystickButton(&m_driverController, 2)
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kB)
       .WhenPressed(new ReleaseHatch(&m_hatch));
   // While holding the shoulder button, drive at half speed
-  frc2::JoystickButton(&m_driverController, 6)
+  frc2::JoystickButton(&m_driverController,
+                       frc::XboxController::Button::kRightBumper)
       .WhenHeld(new HalveDriveSpeed(&m_drive));
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/HidRumble/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HidRumble/cpp/Robot.cpp
@@ -2,7 +2,6 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include <frc/GenericHID.h>
 #include <frc/TimedRobot.h>
 #include <frc/XboxController.h>
 
@@ -24,7 +23,7 @@ class Robot : public frc::TimedRobot {
   }
 
  private:
-  frc::XboxController m_hid{0};
+  frc::GenericHID m_hid{0};
 };
 
 #ifndef RUNNING_FRC_TESTS

--- a/wpilibcExamples/src/main/cpp/examples/MecanumBot/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumBot/cpp/Robot.cpp
@@ -30,23 +30,20 @@ class Robot : public frc::TimedRobot {
   void DriveWithJoystick(bool fieldRelative) {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    const auto xSpeed = -m_xspeedLimiter.Calculate(
-                            m_controller.GetY(frc::GenericHID::kLeftHand)) *
+    const auto xSpeed = -m_xspeedLimiter.Calculate(m_controller.GetLeftY()) *
                         Drivetrain::kMaxSpeed;
 
     // Get the y speed or sideways/strafe speed. We are inverting this because
     // we want a positive value when we pull to the left. Xbox controllers
     // return positive values when you pull to the right by default.
-    const auto ySpeed = -m_yspeedLimiter.Calculate(
-                            m_controller.GetX(frc::GenericHID::kLeftHand)) *
+    const auto ySpeed = -m_yspeedLimiter.Calculate(m_controller.GetLeftX()) *
                         Drivetrain::kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    const auto rot = -m_rotLimiter.Calculate(
-                         m_controller.GetX(frc::GenericHID::kRightHand)) *
+    const auto rot = -m_rotLimiter.Calculate(m_controller.GetRightX()) *
                      Drivetrain::kMaxAngularSpeed;
 
     m_mecanum.Drive(xSpeed, ySpeed, rot, fieldRelative);

--- a/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/RobotContainer.cpp
@@ -30,10 +30,9 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.Drive(m_driverController.GetY(frc::GenericHID::kLeftHand),
-                      m_driverController.GetX(frc::GenericHID::kRightHand),
-                      m_driverController.GetX(frc::GenericHID::kLeftHand),
-                      false);
+        m_drive.Drive(m_driverController.GetLeftY(),
+                      m_driverController.GetRightX(),
+                      m_driverController.GetLeftX(), false);
       },
       {&m_drive}));
 }
@@ -42,7 +41,8 @@ void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
 
   // While holding the shoulder button, drive at half speed
-  frc2::JoystickButton(&m_driverController, 6)
+  frc2::JoystickButton(&m_driverController,
+                       frc::XboxController::Button::kRightBumper)
       .WhenPressed(&m_driveHalfSpeed)
       .WhenReleased(&m_driveFullSpeed);
 }

--- a/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/cpp/Robot.cpp
@@ -30,23 +30,20 @@ class Robot : public frc::TimedRobot {
   void DriveWithJoystick(bool fieldRelative) {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    const auto xSpeed = -m_xspeedLimiter.Calculate(
-                            m_controller.GetY(frc::GenericHID::kLeftHand)) *
+    const auto xSpeed = -m_xspeedLimiter.Calculate(m_controller.GetLeftY()) *
                         Drivetrain::kMaxSpeed;
 
     // Get the y speed or sideways/strafe speed. We are inverting this because
     // we want a positive value when we pull to the left. Xbox controllers
     // return positive values when you pull to the right by default.
-    const auto ySpeed = -m_yspeedLimiter.Calculate(
-                            m_controller.GetX(frc::GenericHID::kLeftHand)) *
+    const auto ySpeed = -m_yspeedLimiter.Calculate(m_controller.GetLeftX()) *
                         Drivetrain::kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    const auto rot = -m_rotLimiter.Calculate(
-                         m_controller.GetX(frc::GenericHID::kRightHand)) *
+    const auto rot = -m_rotLimiter.Calculate(m_controller.GetRightX()) *
                      Drivetrain::kMaxAngularSpeed;
 
     m_mecanum.Drive(xSpeed, ySpeed, rot, fieldRelative);

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/triggers/DoubleButton.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/triggers/DoubleButton.cpp
@@ -4,9 +4,9 @@
 
 #include "triggers/DoubleButton.h"
 
-#include <frc/Joystick.h>
+#include <frc/GenericHID.h>
 
-DoubleButton::DoubleButton(frc::Joystick* joy, int button1, int button2)
+DoubleButton::DoubleButton(frc::GenericHID* joy, int button1, int button2)
     : m_joy(*joy) {
   m_button1 = button1;
   m_button2 = button2;

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/include/triggers/DoubleButton.h
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/include/triggers/DoubleButton.h
@@ -7,17 +7,17 @@
 #include <frc/buttons/Trigger.h>
 
 namespace frc {
-class Joystick;
+class GenericHID;
 }  // namespace frc
 
 class DoubleButton : public frc::Trigger {
  public:
-  DoubleButton(frc::Joystick* joy, int button1, int button2);
+  DoubleButton(frc::GenericHID* joy, int button1, int button2);
 
   bool Get() override;
 
  private:
-  frc::Joystick& m_joy;
+  frc::GenericHID& m_joy;
   int m_button1;
   int m_button2;
 };

--- a/wpilibcExamples/src/main/cpp/examples/RamseteCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RamseteCommand/cpp/RobotContainer.cpp
@@ -28,9 +28,8 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
-            m_driverController.GetX(frc::GenericHID::kRightHand));
+        m_drive.ArcadeDrive(m_driverController.GetLeftY(),
+                            m_driverController.GetRightX());
       },
       {&m_drive}));
 }

--- a/wpilibcExamples/src/main/cpp/examples/RamseteController/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RamseteController/cpp/Robot.cpp
@@ -54,16 +54,14 @@ class Robot : public frc::TimedRobot {
   void TeleopPeriodic() override {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    const auto xSpeed = -m_speedLimiter.Calculate(
-                            m_controller.GetY(frc::GenericHID::kLeftHand)) *
+    const auto xSpeed = -m_speedLimiter.Calculate(m_controller.GetLeftY()) *
                         Drivetrain::kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    const auto rot = -m_rotLimiter.Calculate(
-                         m_controller.GetX(frc::GenericHID::kRightHand)) *
+    const auto rot = -m_rotLimiter.Calculate(m_controller.GetRightX()) *
                      Drivetrain::kMaxAngularSpeed;
 
     m_drive.Drive(xSpeed, rot);

--- a/wpilibcExamples/src/main/cpp/examples/SchedulerEventLogging/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SchedulerEventLogging/cpp/RobotContainer.cpp
@@ -45,12 +45,15 @@ void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
 
   // Run instant command 1 when the 'A' button is pressed
-  frc2::JoystickButton(&m_driverController, 0).WhenPressed(&m_instantCommand1);
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kA)
+      .WhenPressed(&m_instantCommand1);
   // Run instant command 2 when the 'X' button is pressed
-  frc2::JoystickButton(&m_driverController, 3).WhenPressed(&m_instantCommand2);
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kX)
+      .WhenPressed(&m_instantCommand2);
   // Run instant command 3 when the 'Y' button is held; release early to
   // interrupt
-  frc2::JoystickButton(&m_driverController, 4).WhenHeld(&m_waitCommand);
+  frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kY)
+      .WhenHeld(&m_waitCommand);
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/wpilibcExamples/src/main/cpp/examples/SimpleDifferentialDriveSimulation/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SimpleDifferentialDriveSimulation/cpp/Robot.cpp
@@ -41,16 +41,14 @@ class Robot : public frc::TimedRobot {
   void TeleopPeriodic() override {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    const auto xSpeed = -m_speedLimiter.Calculate(
-                            m_controller.GetY(frc::GenericHID::kLeftHand)) *
+    const auto xSpeed = -m_speedLimiter.Calculate(m_controller.GetLeftY()) *
                         Drivetrain::kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    auto rot = -m_rotLimiter.Calculate(
-                   m_controller.GetX(frc::GenericHID::kRightHand)) *
+    auto rot = -m_rotLimiter.Calculate(m_controller.GetRightX()) *
                Drivetrain::kMaxAngularSpeed;
 
     m_drive.Drive(xSpeed, rot);

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceArm/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceArm/cpp/Robot.cpp
@@ -3,7 +3,6 @@
 // the WPILib BSD license file in the root directory of this project.
 
 #include <frc/Encoder.h>
-#include <frc/GenericHID.h>
 #include <frc/StateSpaceUtil.h>
 #include <frc/TimedRobot.h>
 #include <frc/XboxController.h>
@@ -112,7 +111,7 @@ class Robot : public frc::TimedRobot {
     // Sets the target position of our arm. This is similar to setting the
     // setpoint of a PID controller.
     frc::TrapezoidProfile<units::radians>::State goal;
-    if (m_joystick.GetBumper(frc::GenericHID::kRightHand)) {
+    if (m_joystick.GetRightBumper()) {
       // We pressed the bumper, so let's set our next reference
       goal = {kRaisedPosition, 0_rad_per_s};
     } else {

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
@@ -28,9 +28,8 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
-            m_driverController.GetX(frc::GenericHID::kRightHand));
+        m_drive.ArcadeDrive(m_driverController.GetLeftY(),
+                            m_driverController.GetRightX());
       },
       {&m_drive}));
 }
@@ -47,7 +46,8 @@ void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
 
   // While holding the shoulder button, drive at half speed
-  frc2::JoystickButton(&m_driverController, 6)
+  frc2::JoystickButton(&m_driverController,
+                       frc::XboxController::Button::kRightBumper)
       .WhenPressed(&m_driveHalfSpeed)
       .WhenReleased(&m_driveFullSpeed);
 }

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceElevator/cpp/Robot.cpp
@@ -3,7 +3,6 @@
 // the WPILib BSD license file in the root directory of this project.
 
 #include <frc/Encoder.h>
-#include <frc/GenericHID.h>
 #include <frc/StateSpaceUtil.h>
 #include <frc/TimedRobot.h>
 #include <frc/XboxController.h>
@@ -109,7 +108,7 @@ class Robot : public frc::TimedRobot {
     // Sets the target height of our elevator. This is similar to setting the
     // setpoint of a PID controller.
     frc::TrapezoidProfile<units::meters>::State goal;
-    if (m_joystick.GetBumper(frc::GenericHID::kRightHand)) {
+    if (m_joystick.GetRightBumper()) {
       // We pressed the bumper, so let's set our next reference
       goal = {kRaisedPosition, 0_fps};
     } else {

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheel/cpp/Robot.cpp
@@ -4,7 +4,6 @@
 
 #include <frc/DriverStation.h>
 #include <frc/Encoder.h>
-#include <frc/GenericHID.h>
 #include <frc/StateSpaceUtil.h>
 #include <frc/TimedRobot.h>
 #include <frc/XboxController.h>
@@ -93,7 +92,7 @@ class Robot : public frc::TimedRobot {
   void TeleopPeriodic() override {
     // Sets the target speed of our flywheel. This is similar to setting the
     // setpoint of a PID controller.
-    if (m_joystick.GetBumper(frc::GenericHID::kRightHand)) {
+    if (m_joystick.GetRightBumper()) {
       // We pressed the bumper, so let's set our next reference
       m_loop.SetNextR(frc::MakeMatrix<1, 1>(kSpinup.to<double>()));
     } else {

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheelSysId/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceFlywheelSysId/cpp/Robot.cpp
@@ -4,7 +4,6 @@
 
 #include <frc/DriverStation.h>
 #include <frc/Encoder.h>
-#include <frc/GenericHID.h>
 #include <frc/StateSpaceUtil.h>
 #include <frc/TimedRobot.h>
 #include <frc/XboxController.h>
@@ -94,7 +93,7 @@ class Robot : public frc::TimedRobot {
   void TeleopPeriodic() override {
     // Sets the target speed of our flywheel. This is similar to setting the
     // setpoint of a PID controller.
-    if (m_joystick.GetBumper(frc::GenericHID::kRightHand)) {
+    if (m_joystick.GetRightBumper()) {
       // We pressed the bumper, so let's set our next reference
       m_loop.SetNextR(frc::MakeMatrix<1, 1>(kSpinup.to<double>()));
     } else {

--- a/wpilibcExamples/src/main/cpp/examples/SwerveBot/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveBot/cpp/Robot.cpp
@@ -30,23 +30,20 @@ class Robot : public frc::TimedRobot {
   void DriveWithJoystick(bool fieldRelative) {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    const auto xSpeed = -m_xspeedLimiter.Calculate(
-                            m_controller.GetY(frc::GenericHID::kLeftHand)) *
+    const auto xSpeed = -m_xspeedLimiter.Calculate(m_controller.GetLeftY()) *
                         Drivetrain::kMaxSpeed;
 
     // Get the y speed or sideways/strafe speed. We are inverting this because
     // we want a positive value when we pull to the left. Xbox controllers
     // return positive values when you pull to the right by default.
-    const auto ySpeed = -m_yspeedLimiter.Calculate(
-                            m_controller.GetX(frc::GenericHID::kLeftHand)) *
+    const auto ySpeed = -m_yspeedLimiter.Calculate(m_controller.GetLeftX()) *
                         Drivetrain::kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    const auto rot = -m_rotLimiter.Calculate(
-                         m_controller.GetX(frc::GenericHID::kRightHand)) *
+    const auto rot = -m_rotLimiter.Calculate(m_controller.GetRightX()) *
                      Drivetrain::kMaxAngularSpeed;
 
     m_swerve.Drive(xSpeed, ySpeed, rot, fieldRelative);

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
@@ -32,13 +32,10 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.Drive(units::meters_per_second_t(
-                          m_driverController.GetY(frc::GenericHID::kLeftHand)),
-                      units::meters_per_second_t(
-                          m_driverController.GetY(frc::GenericHID::kRightHand)),
-                      units::radians_per_second_t(
-                          m_driverController.GetX(frc::GenericHID::kLeftHand)),
-                      false);
+        m_drive.Drive(
+            units::meters_per_second_t(m_driverController.GetLeftY()),
+            units::meters_per_second_t(m_driverController.GetRightY()),
+            units::radians_per_second_t(m_driverController.GetLeftX()), false);
       },
       {&m_drive}));
 }

--- a/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/cpp/Robot.cpp
@@ -30,23 +30,20 @@ class Robot : public frc::TimedRobot {
   void DriveWithJoystick(bool fieldRelative) {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    const auto xSpeed = -m_xspeedLimiter.Calculate(
-                            m_controller.GetY(frc::GenericHID::kLeftHand)) *
+    const auto xSpeed = -m_xspeedLimiter.Calculate(m_controller.GetLeftY()) *
                         Drivetrain::kMaxSpeed;
 
     // Get the y speed or sideways/strafe speed. We are inverting this because
     // we want a positive value when we pull to the left. Xbox controllers
     // return positive values when you pull to the right by default.
-    const auto ySpeed = -m_yspeedLimiter.Calculate(
-                            m_controller.GetX(frc::GenericHID::kLeftHand)) *
+    const auto ySpeed = -m_yspeedLimiter.Calculate(m_controller.GetLeftX()) *
                         Drivetrain::kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    const auto rot = -m_rotLimiter.Calculate(
-                         m_controller.GetX(frc::GenericHID::kRightHand)) *
+    const auto rot = -m_rotLimiter.Calculate(m_controller.GetRightX()) *
                      Drivetrain::kMaxAngularSpeed;
 
     m_swerve.Drive(xSpeed, ySpeed, rot, fieldRelative);

--- a/wpilibcExamples/src/main/cpp/examples/TankDriveXboxController/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/TankDriveXboxController/cpp/Robot.cpp
@@ -2,7 +2,6 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include <frc/GenericHID.h>
 #include <frc/TimedRobot.h>
 #include <frc/XboxController.h>
 #include <frc/drive/DifferentialDrive.h>
@@ -28,9 +27,8 @@ class Robot : public frc::TimedRobot {
 
   void TeleopPeriodic() override {
     // Drive with tank style
-    m_robotDrive.TankDrive(
-        m_driverController.GetY(frc::GenericHID::JoystickHand::kLeftHand),
-        m_driverController.GetY(frc::GenericHID::JoystickHand::kRightHand));
+    m_robotDrive.TankDrive(m_driverController.GetLeftY(),
+                           m_driverController.GetRightY());
   }
 };
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
@@ -8,8 +8,14 @@ import edu.wpi.first.hal.HAL;
 import java.util.HashMap;
 import java.util.Map;
 
-/** GenericHID Interface. */
-public abstract class GenericHID {
+/**
+ * Handle input from standard HID devices connected to the Driver Station.
+ *
+ * <p>This class handles standard input that comes from the Driver Station. Each time a value is
+ * requested the most recent value is returned. There is a single class instance for each device and
+ * the mapping of ports to hardware buttons depends on the code in the Driver Station.
+ */
+public class GenericHID {
   /** Represents a rumble output on the JoyStick. */
   public enum RumbleType {
     kLeftRumble,
@@ -55,60 +61,19 @@ public abstract class GenericHID {
     }
   }
 
-  /** Which hand the Human Interface Device is associated with. */
-  public enum Hand {
-    kLeft(0),
-    kRight(1);
-
-    public final int value;
-
-    Hand(int value) {
-      this.value = value;
-    }
-  }
-
   private final int m_port;
   private int m_outputs;
   private short m_leftRumble;
   private short m_rightRumble;
 
+  /**
+   * Construct an instance of a device.
+   *
+   * @param port The port index on the Driver Station that the device is plugged into.
+   */
   public GenericHID(int port) {
     m_port = port;
   }
-
-  /**
-   * Get the x position of the HID.
-   *
-   * @return the x position of the HID
-   */
-  public final double getX() {
-    return getX(Hand.kRight);
-  }
-
-  /**
-   * Get the x position of HID.
-   *
-   * @param hand which hand, left or right
-   * @return the x position
-   */
-  public abstract double getX(Hand hand);
-
-  /**
-   * Get the y position of the HID.
-   *
-   * @return the y position
-   */
-  public final double getY() {
-    return getY(Hand.kRight);
-  }
-
-  /**
-   * Get the y position of the HID.
-   *
-   * @param hand which hand, left or right
-   * @return the y position
-   */
-  public abstract double getY(Hand hand);
 
   /**
    * Get the button value (starting at button 1).
@@ -170,13 +135,21 @@ public abstract class GenericHID {
    * <p>The POV angles start at 0 in the up direction, and increase clockwise (eg right is 90,
    * upper-left is 315).
    *
-   * @param pov The index of the POV to read (starting at 0)
+   * @param pov The index of the POV to read (starting at 0). Defaults to 0.
    * @return the angle of the POV in degrees, or -1 if the POV is not pressed.
    */
   public int getPOV(int pov) {
     return DriverStation.getStickPOV(m_port, pov);
   }
 
+  /**
+   * Get the angle in degrees of the default POV (index 0) on the HID.
+   *
+   * <p>The POV angles start at 0 in the up direction, and increase clockwise (eg right is 90,
+   * upper-left is 315).
+   *
+   * @return the angle of the POV in degrees, or -1 if the POV is not pressed.
+   */
   public int getPOV() {
     return getPOV(0);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
@@ -8,7 +8,7 @@ import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 
 /**
- * Handle input from standard Joysticks connected to the Driver Station.
+ * Handle input from Flight Joysticks connected to the Driver Station.
  *
  * <p>This class handles standard input that comes from the Driver Station. Each time a value is
  * requested the most recent value is returned. There is a single class instance for each joystick
@@ -79,9 +79,9 @@ public class Joystick extends GenericHID {
   private final byte[] m_axes = new byte[Axis.kNumAxes.value];
 
   /**
-   * Construct an instance of a joystick. The joystick index is the USB port on the drivers station.
+   * Construct an instance of a joystick.
    *
-   * @param port The port on the Driver Station that the joystick is plugged into.
+   * @param port The port index on the Driver Station that the joystick is plugged into.
    */
   public Joystick(final int port) {
     super(port);
@@ -189,11 +189,9 @@ public class Joystick extends GenericHID {
    * Get the X value of the joystick. This depends on the mapping of the joystick connected to the
    * current port.
    *
-   * @param hand Unused
    * @return The X value of the joystick.
    */
-  @Override
-  public final double getX(Hand hand) {
+  public final double getX() {
     return getRawAxis(m_axes[Axis.kX.value]);
   }
 
@@ -201,11 +199,9 @@ public class Joystick extends GenericHID {
    * Get the Y value of the joystick. This depends on the mapping of the joystick connected to the
    * current port.
    *
-   * @param hand Unused
    * @return The Y value of the joystick.
    */
-  @Override
-  public final double getY(Hand hand) {
+  public final double getY() {
     return getRawAxis(m_axes[Axis.kY.value]);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
@@ -48,35 +48,7 @@ public class Joystick extends GenericHID {
     }
   }
 
-  /** Represents a digital button on a joystick. */
-  private enum Button {
-    kTrigger(1),
-    kTop(2);
-
-    public final int value;
-
-    Button(int value) {
-      this.value = value;
-    }
-  }
-
-  /** Represents an analog axis on a joystick. */
-  private enum Axis {
-    kX(0),
-    kY(1),
-    kZ(2),
-    kTwist(3),
-    kThrottle(4),
-    kNumAxes(5);
-
-    public final int value;
-
-    Axis(int value) {
-      this.value = value;
-    }
-  }
-
-  private final byte[] m_axes = new byte[Axis.kNumAxes.value];
+  private final byte[] m_axes = new byte[AxisType.values().length];
 
   /**
    * Construct an instance of a joystick.
@@ -86,11 +58,11 @@ public class Joystick extends GenericHID {
   public Joystick(final int port) {
     super(port);
 
-    m_axes[Axis.kX.value] = kDefaultXChannel;
-    m_axes[Axis.kY.value] = kDefaultYChannel;
-    m_axes[Axis.kZ.value] = kDefaultZChannel;
-    m_axes[Axis.kTwist.value] = kDefaultTwistChannel;
-    m_axes[Axis.kThrottle.value] = kDefaultThrottleChannel;
+    m_axes[AxisType.kX.value] = kDefaultXChannel;
+    m_axes[AxisType.kY.value] = kDefaultYChannel;
+    m_axes[AxisType.kZ.value] = kDefaultZChannel;
+    m_axes[AxisType.kTwist.value] = kDefaultTwistChannel;
+    m_axes[AxisType.kThrottle.value] = kDefaultThrottleChannel;
 
     HAL.report(tResourceType.kResourceType_Joystick, port + 1);
   }
@@ -101,7 +73,7 @@ public class Joystick extends GenericHID {
    * @param channel The channel to set the axis to.
    */
   public void setXChannel(int channel) {
-    m_axes[Axis.kX.value] = (byte) channel;
+    m_axes[AxisType.kX.value] = (byte) channel;
   }
 
   /**
@@ -110,7 +82,7 @@ public class Joystick extends GenericHID {
    * @param channel The channel to set the axis to.
    */
   public void setYChannel(int channel) {
-    m_axes[Axis.kY.value] = (byte) channel;
+    m_axes[AxisType.kY.value] = (byte) channel;
   }
 
   /**
@@ -119,7 +91,7 @@ public class Joystick extends GenericHID {
    * @param channel The channel to set the axis to.
    */
   public void setZChannel(int channel) {
-    m_axes[Axis.kZ.value] = (byte) channel;
+    m_axes[AxisType.kZ.value] = (byte) channel;
   }
 
   /**
@@ -128,7 +100,7 @@ public class Joystick extends GenericHID {
    * @param channel The channel to set the axis to.
    */
   public void setThrottleChannel(int channel) {
-    m_axes[Axis.kThrottle.value] = (byte) channel;
+    m_axes[AxisType.kThrottle.value] = (byte) channel;
   }
 
   /**
@@ -137,7 +109,7 @@ public class Joystick extends GenericHID {
    * @param channel The channel to set the axis to.
    */
   public void setTwistChannel(int channel) {
-    m_axes[Axis.kTwist.value] = (byte) channel;
+    m_axes[AxisType.kTwist.value] = (byte) channel;
   }
 
   /**
@@ -146,7 +118,7 @@ public class Joystick extends GenericHID {
    * @return The channel for the axis.
    */
   public int getXChannel() {
-    return m_axes[Axis.kX.value];
+    return m_axes[AxisType.kX.value];
   }
 
   /**
@@ -155,7 +127,7 @@ public class Joystick extends GenericHID {
    * @return The channel for the axis.
    */
   public int getYChannel() {
-    return m_axes[Axis.kY.value];
+    return m_axes[AxisType.kY.value];
   }
 
   /**
@@ -164,7 +136,7 @@ public class Joystick extends GenericHID {
    * @return The channel for the axis.
    */
   public int getZChannel() {
-    return m_axes[Axis.kZ.value];
+    return m_axes[AxisType.kZ.value];
   }
 
   /**
@@ -173,7 +145,7 @@ public class Joystick extends GenericHID {
    * @return The channel for the axis.
    */
   public int getTwistChannel() {
-    return m_axes[Axis.kTwist.value];
+    return m_axes[AxisType.kTwist.value];
   }
 
   /**
@@ -182,7 +154,7 @@ public class Joystick extends GenericHID {
    * @return The channel for the axis.
    */
   public int getThrottleChannel() {
-    return m_axes[Axis.kThrottle.value];
+    return m_axes[AxisType.kThrottle.value];
   }
 
   /**
@@ -192,7 +164,7 @@ public class Joystick extends GenericHID {
    * @return The X value of the joystick.
    */
   public final double getX() {
-    return getRawAxis(m_axes[Axis.kX.value]);
+    return getRawAxis(m_axes[AxisType.kX.value]);
   }
 
   /**
@@ -202,7 +174,7 @@ public class Joystick extends GenericHID {
    * @return The Y value of the joystick.
    */
   public final double getY() {
-    return getRawAxis(m_axes[Axis.kY.value]);
+    return getRawAxis(m_axes[AxisType.kY.value]);
   }
 
   /**
@@ -211,7 +183,7 @@ public class Joystick extends GenericHID {
    * @return the z position
    */
   public double getZ() {
-    return getRawAxis(m_axes[Axis.kZ.value]);
+    return getRawAxis(m_axes[AxisType.kZ.value]);
   }
 
   /**
@@ -221,7 +193,7 @@ public class Joystick extends GenericHID {
    * @return The Twist value of the joystick.
    */
   public double getTwist() {
-    return getRawAxis(m_axes[Axis.kTwist.value]);
+    return getRawAxis(m_axes[AxisType.kTwist.value]);
   }
 
   /**
@@ -231,7 +203,7 @@ public class Joystick extends GenericHID {
    * @return The Throttle value of the joystick.
    */
   public double getThrottle() {
-    return getRawAxis(m_axes[Axis.kThrottle.value]);
+    return getRawAxis(m_axes[AxisType.kThrottle.value]);
   }
 
   /**
@@ -240,7 +212,7 @@ public class Joystick extends GenericHID {
    * @return The state of the trigger.
    */
   public boolean getTrigger() {
-    return getRawButton(Button.kTrigger.value);
+    return getRawButton(ButtonType.kTrigger.value);
   }
 
   /**
@@ -249,7 +221,7 @@ public class Joystick extends GenericHID {
    * @return Whether the button was pressed since the last check.
    */
   public boolean getTriggerPressed() {
-    return getRawButtonPressed(Button.kTrigger.value);
+    return getRawButtonPressed(ButtonType.kTrigger.value);
   }
 
   /**
@@ -258,7 +230,7 @@ public class Joystick extends GenericHID {
    * @return Whether the button was released since the last check.
    */
   public boolean getTriggerReleased() {
-    return getRawButtonReleased(Button.kTrigger.value);
+    return getRawButtonReleased(ButtonType.kTrigger.value);
   }
 
   /**
@@ -267,7 +239,7 @@ public class Joystick extends GenericHID {
    * @return The state of the top button.
    */
   public boolean getTop() {
-    return getRawButton(Button.kTop.value);
+    return getRawButton(ButtonType.kTop.value);
   }
 
   /**
@@ -276,7 +248,7 @@ public class Joystick extends GenericHID {
    * @return Whether the button was pressed since the last check.
    */
   public boolean getTopPressed() {
-    return getRawButtonPressed(Button.kTop.value);
+    return getRawButtonPressed(ButtonType.kTop.value);
   }
 
   /**
@@ -285,7 +257,7 @@ public class Joystick extends GenericHID {
    * @return Whether the button was released since the last check.
    */
   public boolean getTopReleased() {
-    return getRawButtonReleased(Button.kTop.value);
+    return getRawButtonReleased(ButtonType.kTop.value);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PS4Controller.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PS4Controller.java
@@ -47,6 +47,23 @@ public class PS4Controller extends GenericHID {
     Button(int index) {
       this.value = index;
     }
+
+    /**
+     * Get the human-friendly name of the button, matching the relevant methods. This is done by
+     * stripping the leading `k`, and if not the touchpad append `Button`.
+     *
+     * <p>Primarily used for automated unit tests.
+     *
+     * @return the human-friendly name of the button.
+     */
+    @Override
+    public String toString() {
+      var name = this.name().substring(1); // Remove leading `k`
+      if (this == kTouchpad) {
+        return name;
+      }
+      return name + "Button";
+    }
   }
 
   /** Represents an axis on a PS4Controller. */
@@ -62,6 +79,23 @@ public class PS4Controller extends GenericHID {
 
     Axis(int index) {
       value = index;
+    }
+
+    /**
+     * Get the human-friendly name of the axis, matching the relevant methods. This is done by
+     * stripping the leading `k`, and if one of L2/R2 append `Axis`.
+     *
+     * <p>Primarily used for automated unit tests.
+     *
+     * @return the human-friendly name of the axis.
+     */
+    @Override
+    public String toString() {
+      var name = this.name().substring(1); // Remove leading `k`
+      if (name.endsWith("2")) {
+        return name + "Axis";
+      }
+      return name;
     }
   }
 
@@ -172,7 +206,7 @@ public class PS4Controller extends GenericHID {
    * @return Whether the button was released since the last check.
    */
   public boolean getR2ButtonReleased() {
-    return getRawButtonPressed(Button.kR2.value);
+    return getRawButtonReleased(Button.kR2.value);
   }
 
   /**
@@ -198,7 +232,7 @@ public class PS4Controller extends GenericHID {
    *
    * @return Whether the button was pressed since the last check.
    */
-  public boolean getL1Pressed() {
+  public boolean getL1ButtonPressed() {
     return getRawButtonPressed(Button.kL1.value);
   }
 
@@ -207,7 +241,7 @@ public class PS4Controller extends GenericHID {
    *
    * @return Whether the button was pressed since the last check.
    */
-  public boolean getR1Pressed() {
+  public boolean getR1ButtonPressed() {
     return getRawButtonPressed(Button.kR1.value);
   }
 
@@ -216,7 +250,7 @@ public class PS4Controller extends GenericHID {
    *
    * @return Whether the button was released since the last check.
    */
-  public boolean getL1Released() {
+  public boolean getL1ButtonReleased() {
     return getRawButtonReleased(Button.kL1.value);
   }
 
@@ -225,7 +259,7 @@ public class PS4Controller extends GenericHID {
    *
    * @return Whether the button was released since the last check.
    */
-  public boolean getR1Released() {
+  public boolean getR1ButtonReleased() {
     return getRawButtonReleased(Button.kR1.value);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PS4Controller.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PS4Controller.java
@@ -1,0 +1,501 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj;
+
+import edu.wpi.first.hal.FRCNetComm.tResourceType;
+import edu.wpi.first.hal.HAL;
+
+/**
+ * Handle input from PS4 controllers connected to the Driver Station.
+ *
+ * <p>This class handles PS4 input that comes from the Driver Station. Each time a value is
+ * requested the most recent value is returned. There is a single class instance for each controller
+ * and the mapping of ports to hardware buttons depends on the code in the Driver Station.
+ */
+public class PS4Controller extends GenericHID {
+  /**
+   * Construct an instance of a device.
+   *
+   * @param port The port index on the Driver Station that the device is plugged into.
+   */
+  public PS4Controller(int port) {
+    super(port);
+    HAL.report(tResourceType.kResourceType_PS4Controller, port + 1);
+  }
+
+  /** Represents a digital button on a PS4Controller. */
+  public enum Button {
+    kSquare(1),
+    kCross(2),
+    kCircle(3),
+    kTriangle(4),
+    kL1(5),
+    kR1(6),
+    kL2(7),
+    kR2(8),
+    kShare(9),
+    kOptions(10),
+    kL3(11),
+    kR3(12),
+    kPS(13),
+    kTouchpad(14);
+
+    public final int value;
+
+    Button(int index) {
+      this.value = index;
+    }
+  }
+
+  /** Represents an axis on a PS4Controller. */
+  public enum Axis {
+    kLeftX(0),
+    kLeftY(1),
+    kRightX(2),
+    kRightY(5),
+    kL2(3),
+    kR2(4);
+
+    public final int value;
+
+    Axis(int index) {
+      value = index;
+    }
+  }
+
+  /**
+   * Get the X axis value of left side of the controller.
+   *
+   * @return the axis value.
+   */
+  public double getLeftX() {
+    return getRawAxis(Axis.kLeftX.value);
+  }
+
+  /**
+   * Get the X axis value of right side of the controller.
+   *
+   * @return the axis value.
+   */
+  public double getRightX() {
+    return getRawAxis(Axis.kRightX.value);
+  }
+
+  /**
+   * Get the Y axis value of left side of the controller.
+   *
+   * @return the axis value.
+   */
+  public double getLeftY() {
+    return getRawAxis(Axis.kLeftY.value);
+  }
+
+  /**
+   * Get the Y axis value of right side of the controller.
+   *
+   * @return the axis value.
+   */
+  public double getRightY() {
+    return getRawAxis(Axis.kRightY.value);
+  }
+
+  /**
+   * Get the L2 axis value of the controller. Note that this axis is bound to the range of [0, 1] as
+   * opposed to the usual [-1, 1].
+   *
+   * @return the axis value.
+   */
+  public double getL2Axis() {
+    return getRawAxis(Axis.kL2.value);
+  }
+
+  /**
+   * Get the R2 axis value of the controller. Note that this axis is bound to the range of [0, 1] as
+   * opposed to the usual [-1, 1].
+   *
+   * @return the axis value.
+   */
+  public double getR2Axis() {
+    return getRawAxis(Axis.kR2.value);
+  }
+
+  /**
+   * Read the value of the left trigger button on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getL2Button() {
+    return getRawButton(Button.kL2.value);
+  }
+
+  /**
+   * Read the value of the right trigger button on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getR2Button() {
+    return getRawButton(Button.kR2.value);
+  }
+
+  /**
+   * Whether the L2 button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getL2ButtonPressed() {
+    return getRawButtonPressed(Button.kL2.value);
+  }
+
+  /**
+   * Whether the R2 button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getR2ButtonPressed() {
+    return getRawButtonPressed(Button.kR2.value);
+  }
+
+  /**
+   * Whether the L2 button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getL2ButtonReleased() {
+    return getRawButtonReleased(Button.kL2.value);
+  }
+
+  /**
+   * Whether the R2 button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getR2ButtonReleased() {
+    return getRawButtonPressed(Button.kR2.value);
+  }
+
+  /**
+   * Read the value of the L1 button on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getL1Button() {
+    return getRawButton(Button.kL1.value);
+  }
+
+  /**
+   * Read the value of the R1 button on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getR1Button() {
+    return getRawButton(Button.kR1.value);
+  }
+
+  /**
+   * Whether the L1 button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getL1Pressed() {
+    return getRawButtonPressed(Button.kL1.value);
+  }
+
+  /**
+   * Whether the R1 button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getR1Pressed() {
+    return getRawButtonPressed(Button.kR1.value);
+  }
+
+  /**
+   * Whether the L1 button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getL1Released() {
+    return getRawButtonReleased(Button.kL1.value);
+  }
+
+  /**
+   * Whether the R1 button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getR1Released() {
+    return getRawButtonReleased(Button.kR1.value);
+  }
+
+  /**
+   * Read the value of the L3 button (pressing the left analog stick) on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getL3Button() {
+    return getRawButton(Button.kL3.value);
+  }
+
+  /**
+   * Read the value of the R3 button (pressing the right analog stick) on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getR3Button() {
+    return getRawButton(Button.kR3.value);
+  }
+
+  /**
+   * Whether the L3 (left stick) button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getL3ButtonPressed() {
+    return getRawButtonPressed(Button.kL3.value);
+  }
+
+  /**
+   * Whether the R3 (right stick) button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getR3ButtonPressed() {
+    return getRawButtonPressed(Button.kR3.value);
+  }
+
+  /**
+   * Whether the L3 (left stick) button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getL3ButtonReleased() {
+    return getRawButtonReleased(Button.kL3.value);
+  }
+
+  /**
+   * Whether the R3 (right stick) button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getR3ButtonReleased() {
+    return getRawButtonReleased(Button.kR3.value);
+  }
+
+  /**
+   * Read the value of the Square button on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getSquareButton() {
+    return getRawButton(Button.kSquare.value);
+  }
+
+  /**
+   * Whether the Square button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getSquareButtonPressed() {
+    return getRawButtonPressed(Button.kSquare.value);
+  }
+
+  /**
+   * Whether the Square button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getSquareButtonReleased() {
+    return getRawButtonReleased(Button.kSquare.value);
+  }
+
+  /**
+   * Read the value of the Cross button on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getCrossButton() {
+    return getRawButton(Button.kCross.value);
+  }
+
+  /**
+   * Whether the Cross button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getCrossButtonPressed() {
+    return getRawButtonPressed(Button.kCross.value);
+  }
+
+  /**
+   * Whether the Cross button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getCrossButtonReleased() {
+    return getRawButtonReleased(Button.kCross.value);
+  }
+
+  /**
+   * Read the value of the Triangle button on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getTriangleButton() {
+    return getRawButton(Button.kTriangle.value);
+  }
+
+  /**
+   * Whether the Triangle button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getTriangleButtonPressed() {
+    return getRawButtonPressed(Button.kTriangle.value);
+  }
+
+  /**
+   * Whether the Triangle button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getTriangleButtonReleased() {
+    return getRawButtonReleased(Button.kTriangle.value);
+  }
+
+  /**
+   * Read the value of the Circle button on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getCircleButton() {
+    return getRawButton(Button.kCircle.value);
+  }
+
+  /**
+   * Whether the Circle button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getCircleButtonPressed() {
+    return getRawButtonPressed(Button.kCircle.value);
+  }
+
+  /**
+   * Whether the Circle button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getCircleButtonReleased() {
+    return getRawButtonReleased(Button.kCircle.value);
+  }
+
+  /**
+   * Read the value of the share button on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getShareButton() {
+    return getRawButton(Button.kShare.value);
+  }
+
+  /**
+   * Whether the share button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getShareButtonPressed() {
+    return getRawButtonPressed(Button.kShare.value);
+  }
+
+  /**
+   * Whether the share button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getShareButtonReleased() {
+    return getRawButtonReleased(Button.kShare.value);
+  }
+
+  /**
+   * Read the value of the PS button on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getPSButton() {
+    return getRawButton(Button.kPS.value);
+  }
+
+  /**
+   * Whether the PS button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getPSButtonPressed() {
+    return getRawButtonPressed(Button.kPS.value);
+  }
+
+  /**
+   * Whether the PS button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getPSButtonReleased() {
+    return getRawButtonReleased(Button.kPS.value);
+  }
+
+  /**
+   * Read the value of the options button on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getOptionsButton() {
+    return getRawButton(Button.kOptions.value);
+  }
+
+  /**
+   * Whether the options button was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getOptionsButtonPressed() {
+    return getRawButtonPressed(Button.kOptions.value);
+  }
+
+  /**
+   * Whether the options button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getOptionsButtonReleased() {
+    return getRawButtonReleased(Button.kOptions.value);
+  }
+
+  /**
+   * Read the value of the touchpad on the controller.
+   *
+   * @return The state of the touchpad.
+   */
+  public boolean getTouchpad() {
+    return getRawButton(Button.kTouchpad.value);
+  }
+
+  /**
+   * Whether the touchpad was pressed since the last check.
+   *
+   * @return Whether the touchpad was pressed since the last check.
+   */
+  public boolean getTouchpadPressed() {
+    return getRawButtonPressed(Button.kTouchpad.value);
+  }
+
+  /**
+   * Whether the touchpad was released since the last check.
+   *
+   * @return Whether the touchpad was released since the last check.
+   */
+  public boolean getTouchpadReleased() {
+    return getRawButtonReleased(Button.kTouchpad.value);
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/XboxController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/XboxController.java
@@ -17,10 +17,10 @@ import edu.wpi.first.hal.HAL;
 public class XboxController extends GenericHID {
   /** Represents a digital button on an XboxController. */
   public enum Button {
-    kBumperLeft(5),
-    kBumperRight(6),
-    kStickLeft(9),
-    kStickRight(10),
+    kLeftBumper(5),
+    kRightBumper(6),
+    kLeftStick(9),
+    kRightStick(10),
     kA(1),
     kB(2),
     kX(3),
@@ -54,9 +54,9 @@ public class XboxController extends GenericHID {
   }
 
   /**
-   * Construct an instance of a joystick. The joystick index is the USB port on the drivers station.
+   * Construct an instance of a controller.
    *
-   * @param port The port on the Driver Station that the joystick is plugged into.
+   * @param port The port index on the Driver Station that the controller is plugged into.
    */
   public XboxController(final int port) {
     super(port);
@@ -65,131 +65,167 @@ public class XboxController extends GenericHID {
   }
 
   /**
-   * Get the X axis value of the controller.
+   * Get the X axis value of left side of the controller.
    *
-   * @param hand Side of controller whose value should be returned.
-   * @return The X axis value of the controller.
+   * @return The axis value.
    */
-  @Override
-  public double getX(Hand hand) {
-    if (hand.equals(Hand.kLeft)) {
-      return getRawAxis(Axis.kLeftX.value);
-    } else {
-      return getRawAxis(Axis.kRightX.value);
-    }
+  public double getLeftX() {
+    return getRawAxis(Axis.kLeftX.value);
   }
 
   /**
-   * Get the Y axis value of the controller.
+   * Get the X axis value of right side of the controller.
    *
-   * @param hand Side of controller whose value should be returned.
-   * @return The Y axis value of the controller.
+   * @return The axis value.
    */
-  @Override
-  public double getY(Hand hand) {
-    if (hand.equals(Hand.kLeft)) {
-      return getRawAxis(Axis.kLeftY.value);
-    } else {
-      return getRawAxis(Axis.kRightY.value);
-    }
+  public double getRightX() {
+    return getRawAxis(Axis.kRightX.value);
   }
 
   /**
-   * Get the trigger axis value of the controller.
+   * Get the Y axis value of left side of the controller.
    *
-   * @param hand Side of controller whose value should be returned.
-   * @return The trigger axis value of the controller.
+   * @return The axis value.
    */
-  public double getTriggerAxis(Hand hand) {
-    if (hand.equals(Hand.kLeft)) {
-      return getRawAxis(Axis.kLeftTrigger.value);
-    } else {
-      return getRawAxis(Axis.kRightTrigger.value);
-    }
+  public double getLeftY() {
+    return getRawAxis(Axis.kLeftY.value);
   }
 
   /**
-   * Read the value of the bumper button on the controller.
+   * Get the Y axis value of right side of the controller.
    *
-   * @param hand Side of controller whose value should be returned.
+   * @return The axis value.
+   */
+  public double getRightY() {
+    return getRawAxis(Axis.kRightY.value);
+  }
+
+  /**
+   * Get the left trigger (LT) axis value of the controller. Note that this axis is bound to the
+   * range of [0, 1] as opposed to the usual [-1, 1].
+   *
+   * @return The axis value.
+   */
+  public double getLeftTriggerAxis() {
+    return getRawAxis(Axis.kLeftTrigger.value);
+  }
+
+  /**
+   * Get the right trigger (RT) axis value of the controller. Note that this axis is bound to the
+   * range of [0, 1] as opposed to the usual [-1, 1].
+   *
+   * @return The axis value.
+   */
+  public double getRightTriggerAxis() {
+    return getRawAxis(Axis.kRightTrigger.value);
+  }
+
+  /**
+   * Read the value of the left bumper (LB) button on the controller.
+   *
    * @return The state of the button.
    */
-  public boolean getBumper(Hand hand) {
-    if (hand.equals(Hand.kLeft)) {
-      return getRawButton(Button.kBumperLeft.value);
-    } else {
-      return getRawButton(Button.kBumperRight.value);
-    }
+  public boolean getLeftBumper() {
+    return getRawButton(Button.kLeftBumper.value);
   }
 
   /**
-   * Whether the bumper was pressed since the last check.
+   * Read the value of the right bumper (RB) button on the controller.
    *
-   * @param hand Side of controller whose value should be returned.
-   * @return Whether the button was pressed since the last check.
-   */
-  public boolean getBumperPressed(Hand hand) {
-    if (hand == Hand.kLeft) {
-      return getRawButtonPressed(Button.kBumperLeft.value);
-    } else {
-      return getRawButtonPressed(Button.kBumperRight.value);
-    }
-  }
-
-  /**
-   * Whether the bumper was released since the last check.
-   *
-   * @param hand Side of controller whose value should be returned.
-   * @return Whether the button was released since the last check.
-   */
-  public boolean getBumperReleased(Hand hand) {
-    if (hand == Hand.kLeft) {
-      return getRawButtonReleased(Button.kBumperLeft.value);
-    } else {
-      return getRawButtonReleased(Button.kBumperRight.value);
-    }
-  }
-
-  /**
-   * Read the value of the stick button on the controller.
-   *
-   * @param hand Side of controller whose value should be returned.
    * @return The state of the button.
    */
-  public boolean getStickButton(Hand hand) {
-    if (hand.equals(Hand.kLeft)) {
-      return getRawButton(Button.kStickLeft.value);
-    } else {
-      return getRawButton(Button.kStickRight.value);
-    }
+  public boolean getRightBumper() {
+    return getRawButton(Button.kRightBumper.value);
   }
 
   /**
-   * Whether the stick button was pressed since the last check.
+   * Whether the left bumper (LB) was pressed since the last check.
    *
-   * @param hand Side of controller whose value should be returned.
    * @return Whether the button was pressed since the last check.
    */
-  public boolean getStickButtonPressed(Hand hand) {
-    if (hand == Hand.kLeft) {
-      return getRawButtonPressed(Button.kStickLeft.value);
-    } else {
-      return getRawButtonPressed(Button.kStickRight.value);
-    }
+  public boolean getLeftBumperPressed() {
+    return getRawButtonPressed(Button.kLeftBumper.value);
   }
 
   /**
-   * Whether the stick button was released since the last check.
+   * Whether the right bumper (RB) was pressed since the last check.
    *
-   * @param hand Side of controller whose value should be returned.
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getRightBumperPressed() {
+    return getRawButtonPressed(Button.kRightBumper.value);
+  }
+
+  /**
+   * Whether the left bumper (LB) was released since the last check.
+   *
    * @return Whether the button was released since the last check.
    */
-  public boolean getStickButtonReleased(Hand hand) {
-    if (hand == Hand.kLeft) {
-      return getRawButtonReleased(Button.kStickLeft.value);
-    } else {
-      return getRawButtonReleased(Button.kStickRight.value);
-    }
+  public boolean getLeftBumperReleased() {
+    return getRawButtonReleased(Button.kLeftBumper.value);
+  }
+
+  /**
+   * Whether the right bumper (RB) was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getRightBumperReleased() {
+    return getRawButtonReleased(Button.kRightBumper.value);
+  }
+
+  /**
+   * Read the value of the left stick button (LSB) on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getLeftStickButton() {
+    return getRawButton(Button.kLeftStick.value);
+  }
+
+  /**
+   * Read the value of the right stick button (RSB) on the controller.
+   *
+   * @return The state of the button.
+   */
+  public boolean getRightStickButton() {
+    return getRawButton(Button.kRightStick.value);
+  }
+
+  /**
+   * Whether the left stick button (LSB) was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getLeftStickButtonPressed() {
+    return getRawButtonPressed(Button.kLeftStick.value);
+  }
+
+  /**
+   * Whether the right stick button (RSB) was pressed since the last check.
+   *
+   * @return Whether the button was pressed since the last check.
+   */
+  public boolean getRightStickButtonPressed() {
+    return getRawButtonPressed(Button.kRightStick.value);
+  }
+
+  /**
+   * Whether the left stick button (LSB) was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getLeftStickButtonReleased() {
+    return getRawButtonReleased(Button.kLeftStick.value);
+  }
+
+  /**
+   * Whether the right stick (RSB) button was released since the last check.
+   *
+   * @return Whether the button was released since the last check.
+   */
+  public boolean getRightStickButtonReleased() {
+    return getRawButtonReleased(Button.kRightStick.value);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/XboxController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/XboxController.java
@@ -34,6 +34,23 @@ public class XboxController extends GenericHID {
     Button(int value) {
       this.value = value;
     }
+
+    /**
+     * Get the human-friendly name of the button, matching the relevant methods. This is done by
+     * stripping the leading `k`, and if not a Bumper button append `Button`.
+     *
+     * <p>Primarily used for automated unit tests.
+     *
+     * @return the human-friendly name of the button.
+     */
+    @Override
+    public String toString() {
+      var name = this.name().substring(1); // Remove leading `k`
+      if (name.endsWith("Bumper")) {
+        return name;
+      }
+      return name + "Button";
+    }
   }
 
   /** Represents an axis on an XboxController. */
@@ -50,6 +67,23 @@ public class XboxController extends GenericHID {
 
     Axis(int value) {
       this.value = value;
+    }
+
+    /**
+     * Get the human-friendly name of the axis, matching the relevant methods. This is done by
+     * stripping the leading `k`, and if a trigger axis append `Axis`.
+     *
+     * <p>Primarily used for automated unit tests.
+     *
+     * @return the human-friendly name of the axis.
+     */
+    @Override
+    public String toString() {
+      var name = this.name().substring(1); // Remove leading `k`
+      if (name.endsWith("Trigger")) {
+        return name + "Axis";
+      }
+      return name;
     }
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/PS4ControllerSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/PS4ControllerSim.java
@@ -1,0 +1,212 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import edu.wpi.first.wpilibj.PS4Controller;
+
+/** Class to control a simulated PS4 controller. */
+public class PS4ControllerSim extends GenericHIDSim {
+  /**
+   * Constructs from a PS4Controller object.
+   *
+   * @param joystick controller to simulate
+   */
+  public PS4ControllerSim(PS4Controller joystick) {
+    super(joystick);
+    setAxisCount(6);
+    setButtonCount(14);
+  }
+
+  /**
+   * Constructs from a joystick port number.
+   *
+   * @param port port number
+   */
+  public PS4ControllerSim(int port) {
+    super(port);
+    setAxisCount(6);
+    setButtonCount(14);
+  }
+
+  /**
+   * Change the X axis value of the controller's left stick.
+   *
+   * @param value the new value
+   */
+  public void setLeftX(double value) {
+    setRawAxis(PS4Controller.Axis.kLeftX.value, value);
+  }
+
+  /**
+   * Change the X axis value of the controller's right stick.
+   *
+   * @param value the new value
+   */
+  public void setRightX(double value) {
+    setRawAxis(PS4Controller.Axis.kRightX.value, value);
+  }
+
+  /**
+   * Change the Y axis value of the controller's left stick.
+   *
+   * @param value the new value
+   */
+  public void setLeftY(double value) {
+    setRawAxis(PS4Controller.Axis.kLeftY.value, value);
+  }
+
+  /**
+   * Change the Y axis value of the controller's right stick.
+   *
+   * @param value the new value
+   */
+  public void setRightY(double value) {
+    setRawAxis(PS4Controller.Axis.kRightY.value, value);
+  }
+
+  /**
+   * Change the L2 axis axis value of the controller.
+   *
+   * @param value the new value
+   */
+  public void setL2Axis(double value) {
+    setRawAxis(PS4Controller.Axis.kL2.value, value);
+  }
+
+  /**
+   * Change the R2 axis value of the controller.
+   *
+   * @param value the new value
+   */
+  public void setR2Axis(double value) {
+    setRawAxis(PS4Controller.Axis.kR2.value, value);
+  }
+
+  /**
+   * Change the value of the Square button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setSquareButton(boolean value) {
+    setRawButton(PS4Controller.Button.kSquare.value, value);
+  }
+
+  /**
+   * Change the value of the Cross button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setCrossButton(boolean value) {
+    setRawButton(PS4Controller.Button.kCross.value, value);
+  }
+
+  /**
+   * Change the value of the Circle button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setCircleButton(boolean value) {
+    setRawButton(PS4Controller.Button.kCircle.value, value);
+  }
+
+  /**
+   * Change the value of the Triangle button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setTriangleButton(boolean value) {
+    setRawButton(PS4Controller.Button.kTriangle.value, value);
+  }
+
+  /**
+   * Change the value of the L1 button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setL1Button(boolean value) {
+    setRawButton(PS4Controller.Button.kL1.value, value);
+  }
+
+  /**
+   * Change the value of the R1 button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setR1Button(boolean value) {
+    setRawButton(PS4Controller.Button.kR1.value, value);
+  }
+
+  /**
+   * Change the value of the L2 button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setL2Button(boolean value) {
+    setRawButton(PS4Controller.Button.kL2.value, value);
+  }
+
+  /**
+   * Change the value of the R2 button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setR2Button(boolean value) {
+    setRawButton(PS4Controller.Button.kR2.value, value);
+  }
+
+  /**
+   * Change the value of the Share button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setShareButton(boolean value) {
+    setRawButton(PS4Controller.Button.kShare.value, value);
+  }
+
+  /**
+   * Change the value of the Options button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setOptionsButton(boolean value) {
+    setRawButton(PS4Controller.Button.kOptions.value, value);
+  }
+
+  /**
+   * Change the value of the L3 (left stick) button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setL3Button(boolean value) {
+    setRawButton(PS4Controller.Button.kL3.value, value);
+  }
+
+  /**
+   * Change the value of the R3 (right stick) button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setR3Button(boolean value) {
+    setRawButton(PS4Controller.Button.kR3.value, value);
+  }
+
+  /**
+   * Change the value of the PS button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setPSButton(boolean value) {
+    setRawButton(PS4Controller.Button.kPS.value, value);
+  }
+
+  /**
+   * Change the value of the touchpad button on the controller.
+   *
+   * @param value the new value
+   */
+  public void setTouchpad(boolean value) {
+    setRawButton(PS4Controller.Button.kTouchpad.value, value);
+  }
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/XboxControllerSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/XboxControllerSim.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.wpilibj.simulation;
 
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 
 /** Class to control a simulated Xbox 360 or Xbox One controller. */
@@ -32,73 +31,93 @@ public class XboxControllerSim extends GenericHIDSim {
   }
 
   /**
-   * Change the X value of the joystick.
+   * Change the left X value of the joystick.
    *
-   * @param hand the joystick hand
    * @param value the new value
    */
-  public void setX(GenericHID.Hand hand, double value) {
-    if (hand.equals(GenericHID.Hand.kLeft)) {
-      setRawAxis(XboxController.Axis.kLeftX.value, value);
-    } else {
-      setRawAxis(XboxController.Axis.kRightX.value, value);
-    }
+  public void setLeftX(double value) {
+    setRawAxis(XboxController.Axis.kLeftX.value, value);
   }
 
   /**
-   * Change the Y value of the joystick.
+   * Change the right X value of the joystick.
    *
-   * @param hand the joystick hand
    * @param value the new value
    */
-  public void setY(GenericHID.Hand hand, double value) {
-    if (hand.equals(GenericHID.Hand.kLeft)) {
-      setRawAxis(XboxController.Axis.kLeftY.value, value);
-    } else {
-      setRawAxis(XboxController.Axis.kRightY.value, value);
-    }
+  public void setRightX(double value) {
+    setRawAxis(XboxController.Axis.kRightX.value, value);
   }
 
   /**
-   * Change the value of a trigger axis on the joystick.
+   * Change the left Y value of the joystick.
    *
-   * @param hand the joystick hand
    * @param value the new value
    */
-  public void setTriggerAxis(GenericHID.Hand hand, double value) {
-    if (hand.equals(GenericHID.Hand.kLeft)) {
-      setRawAxis(XboxController.Axis.kLeftTrigger.value, value);
-    } else {
-      setRawAxis(XboxController.Axis.kRightTrigger.value, value);
-    }
+  public void setLeftY(double value) {
+    setRawAxis(XboxController.Axis.kLeftY.value, value);
   }
 
   /**
-   * Change the value of a bumper on the joystick.
+   * Change the right Y value of the joystick.
    *
-   * @param hand the joystick hand
+   * @param value the new value
+   */
+  public void setRightY(double value) {
+    setRawAxis(XboxController.Axis.kRightY.value, value);
+  }
+
+  /**
+   * Change the value of the left trigger axis on the joystick.
+   *
+   * @param value the new value
+   */
+  public void setLeftTriggerAxis(double value) {
+    setRawAxis(XboxController.Axis.kLeftTrigger.value, value);
+  }
+
+  /**
+   * Change the value of the right trigger axis on the joystick.
+   *
+   * @param value the new value
+   */
+  public void setRightTriggerAxis(double value) {
+    setRawAxis(XboxController.Axis.kRightTrigger.value, value);
+  }
+
+  /**
+   * Change the value of the left bumper on the joystick.
+   *
    * @param state the new value
    */
-  public void setBumper(GenericHID.Hand hand, boolean state) {
-    if (hand.equals(GenericHID.Hand.kLeft)) {
-      setRawButton(XboxController.Button.kBumperLeft.value, state);
-    } else {
-      setRawButton(XboxController.Button.kBumperRight.value, state);
-    }
+  public void setLeftBumper(boolean state) {
+    setRawButton(XboxController.Button.kLeftBumper.value, state);
   }
 
   /**
-   * Change the value of a button on the joystick.
+   * Change the value of the right bumper on the joystick.
    *
-   * @param hand the joystick hand
    * @param state the new value
    */
-  public void setStickButton(GenericHID.Hand hand, boolean state) {
-    if (hand.equals(GenericHID.Hand.kLeft)) {
-      setRawButton(XboxController.Button.kStickLeft.value, state);
-    } else {
-      setRawButton(XboxController.Button.kStickRight.value, state);
-    }
+  public void setRightBumper(boolean state) {
+    setRawButton(XboxController.Button.kRightBumper.value, state);
+  }
+
+  /**
+   * Change the value of the left stick button on the joystick.
+   *
+   * @param state the new value
+   */
+  public void setLeftStickButton(boolean state) {
+    setRawButton(XboxController.Button.kLeftStick.value, state);
+  }
+
+  /**
+   * Change the value of the right stick button on the joystick.
+   *
+   * @param state the new value
+   */
+  public void setRightStickButton(boolean state) {
+    setRawButton(XboxController.Button.kRightStick.value, state);
   }
 
   /**

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/PS4ControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/PS4ControllerTest.java
@@ -9,21 +9,21 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.simulation.XboxControllerSim;
+import edu.wpi.first.wpilibj.simulation.PS4ControllerSim;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-class XboxControllerTest {
+class PS4ControllerTest {
   @ParameterizedTest
-  @EnumSource(value = XboxController.Button.class)
+  @EnumSource(value = PS4Controller.Button.class)
   @SuppressWarnings({"VariableDeclarationUsageDistance"})
-  public void testButtons(XboxController.Button button)
+  public void testButtons(PS4Controller.Button button)
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     HAL.initialize(500, 0);
-    XboxController joy = new XboxController(2);
-    XboxControllerSim joysim = new XboxControllerSim(joy);
+    PS4Controller joy = new PS4Controller(2);
+    PS4ControllerSim joysim = new PS4ControllerSim(joy);
 
     var buttonName = button.toString();
 
@@ -58,13 +58,13 @@ class XboxControllerTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = XboxController.Axis.class)
+  @EnumSource(value = PS4Controller.Axis.class)
   @SuppressWarnings({"VariableDeclarationUsageDistance"})
-  public void testAxes(XboxController.Axis axis)
+  public void testAxes(PS4Controller.Axis axis)
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     HAL.initialize(500, 0);
-    XboxController joy = new XboxController(2);
-    XboxControllerSim joysim = new XboxControllerSim(joy);
+    PS4Controller joy = new PS4Controller(2);
+    PS4ControllerSim joysim = new PS4ControllerSim(joy);
 
     var axisName = axis.toString();
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/arcadedrivexboxcontroller/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/arcadedrivexboxcontroller/Robot.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.wpilibj.examples.arcadedrivexboxcontroller;
 
-import edu.wpi.first.wpilibj.GenericHID.Hand;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
@@ -25,7 +24,6 @@ public class Robot extends TimedRobot {
     // Drive with split arcade drive.
     // That means that the Y axis of the left stick moves forward
     // and backward, and the X of the right stick turns left and right.
-    m_robotDrive.arcadeDrive(
-        m_driverController.getY(Hand.kLeft), m_driverController.getX(Hand.kRight));
+    m_robotDrive.arcadeDrive(m_driverController.getLeftY(), m_driverController.getRightX());
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbot/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbot/RobotContainer.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj.examples.armbot;
 
 import static edu.wpi.first.wpilibj.XboxController.Button;
 
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.examples.armbot.Constants.OIConstants;
 import edu.wpi.first.wpilibj.examples.armbot.subsystems.ArmSubsystem;
@@ -43,14 +42,13 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
-                    m_driverController.getX(GenericHID.Hand.kRight)),
+                    m_driverController.getLeftY(), m_driverController.getRightX()),
             m_robotDrive));
   }
 
   /**
    * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * instantiating a {@link edu.wpi.first.wpilibj.GenericHID} or one of its subclasses ({@link
    * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then passing it to a {@link
    * JoystickButton}.
    */
@@ -77,7 +75,7 @@ public class RobotContainer {
     new JoystickButton(m_driverController, Button.kY.value).whenPressed(m_robotArm::disable);
 
     // Drive at half speed when the bumper is held
-    new JoystickButton(m_driverController, Button.kBumperRight.value)
+    new JoystickButton(m_driverController, Button.kRightBumper.value)
         .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
         .whenReleased(() -> m_robotDrive.setMaxOutput(1));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbotoffboard/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbotoffboard/RobotContainer.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj.examples.armbotoffboard;
 
 import static edu.wpi.first.wpilibj.XboxController.Button;
 
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.examples.armbotoffboard.Constants.OIConstants;
 import edu.wpi.first.wpilibj.examples.armbotoffboard.subsystems.ArmSubsystem;
@@ -43,14 +42,13 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
-                    m_driverController.getX(GenericHID.Hand.kRight)),
+                    m_driverController.getLeftY(), m_driverController.getRightX()),
             m_robotDrive));
   }
 
   /**
    * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * instantiating a {@link edu.wpi.first.wpilibj.GenericHID} or one of its subclasses ({@link
    * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then passing it to a {@link
    * JoystickButton}.
    */
@@ -64,7 +62,7 @@ public class RobotContainer {
         .whenPressed(() -> m_robotArm.setGoal(Constants.ArmConstants.kArmOffsetRads), m_robotArm);
 
     // Drive at half speed when the bumper is held
-    new JoystickButton(m_driverController, Button.kBumperRight.value)
+    new JoystickButton(m_driverController, Button.kRightBumper.value)
         .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
         .whenReleased(() -> m_robotDrive.setMaxOutput(1));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Robot.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.wpilibj.examples.differentialdrivebot;
 
 import edu.wpi.first.math.filter.SlewRateLimiter;
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.XboxController;
 
@@ -27,16 +26,13 @@ public class Robot extends TimedRobot {
   public void teleopPeriodic() {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    final var xSpeed =
-        -m_speedLimiter.calculate(m_controller.getY(GenericHID.Hand.kLeft)) * Drivetrain.kMaxSpeed;
+    final var xSpeed = -m_speedLimiter.calculate(m_controller.getLeftY()) * Drivetrain.kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    final var rot =
-        -m_rotLimiter.calculate(m_controller.getX(GenericHID.Hand.kRight))
-            * Drivetrain.kMaxAngularSpeed;
+    final var rot = -m_rotLimiter.calculate(m_controller.getRightX()) * Drivetrain.kMaxAngularSpeed;
 
     m_drive.drive(xSpeed, rot);
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdriveposeestimator/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdriveposeestimator/Robot.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.wpilibj.examples.differentialdriveposeestimator;
 
 import edu.wpi.first.math.filter.SlewRateLimiter;
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.XboxController;
 
@@ -27,16 +26,13 @@ public class Robot extends TimedRobot {
   public void teleopPeriodic() {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    final var xSpeed =
-        -m_speedLimiter.calculate(m_controller.getY(GenericHID.Hand.kLeft)) * Drivetrain.kMaxSpeed;
+    final var xSpeed = -m_speedLimiter.calculate(m_controller.getLeftY()) * Drivetrain.kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    final var rot =
-        -m_rotLimiter.calculate(m_controller.getX(GenericHID.Hand.kRight))
-            * Drivetrain.kMaxAngularSpeed;
+    final var rot = -m_rotLimiter.calculate(m_controller.getRightX()) * Drivetrain.kMaxAngularSpeed;
 
     m_drive.drive(xSpeed, rot);
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/drivedistanceoffboard/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/drivedistanceoffboard/RobotContainer.java
@@ -7,7 +7,6 @@ package edu.wpi.first.wpilibj.examples.drivedistanceoffboard;
 import static edu.wpi.first.wpilibj.XboxController.Button;
 
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.examples.drivedistanceoffboard.Constants.DriveConstants;
 import edu.wpi.first.wpilibj.examples.drivedistanceoffboard.Constants.OIConstants;
@@ -45,14 +44,13 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
-                    m_driverController.getX(GenericHID.Hand.kRight)),
+                    m_driverController.getLeftY(), m_driverController.getRightX()),
             m_robotDrive));
   }
 
   /**
    * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * instantiating a {@link edu.wpi.first.wpilibj.GenericHID} or one of its subclasses ({@link
    * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then passing it to a {@link
    * JoystickButton}.
    */
@@ -80,7 +78,7 @@ public class RobotContainer {
                 .withTimeout(10));
 
     // Drive at half speed when the bumper is held
-    new JoystickButton(m_driverController, Button.kBumperRight.value)
+    new JoystickButton(m_driverController, Button.kRightBumper.value)
         .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
         .whenReleased(() -> m_robotDrive.setMaxOutput(1));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/RobotContainer.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj.examples.frisbeebot;
 
 import static edu.wpi.first.wpilibj.XboxController.Button;
 
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.examples.frisbeebot.Constants.AutoConstants;
 import edu.wpi.first.wpilibj.examples.frisbeebot.Constants.OIConstants;
@@ -68,14 +67,13 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
-                    m_driverController.getX(GenericHID.Hand.kRight)),
+                    m_driverController.getLeftY(), m_driverController.getRightX()),
             m_robotDrive));
   }
 
   /**
    * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * instantiating a {@link edu.wpi.first.wpilibj.GenericHID} or one of its subclasses ({@link
    * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then passing it to a {@link
    * edu.wpi.first.wpilibj2.command.button.JoystickButton}.
    */
@@ -102,7 +100,7 @@ public class RobotContainer {
         .whenReleased(new InstantCommand(m_shooter::stopFeeder, m_shooter));
 
     // Drive at half speed when the bumper is held
-    new JoystickButton(m_driverController, Button.kBumperRight.value)
+    new JoystickButton(m_driverController, Button.kRightBumper.value)
         .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
         .whenReleased(() -> m_robotDrive.setMaxOutput(1));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/RobotContainer.java
@@ -4,9 +4,6 @@
 
 package edu.wpi.first.wpilibj.examples.gearsbot;
 
-import edu.wpi.first.wpilibj.GenericHID;
-import edu.wpi.first.wpilibj.GenericHID.Hand;
-import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.examples.gearsbot.commands.Autonomous;
 import edu.wpi.first.wpilibj.examples.gearsbot.commands.CloseClaw;
@@ -39,7 +36,7 @@ public class RobotContainer {
   private final Wrist m_wrist = new Wrist();
   private final Claw m_claw = new Claw();
 
-  private final Joystick m_joystick = new Joystick(0);
+  private final XboxController m_joystick = new XboxController(0);
 
   private final CommandBase m_autonomousCommand =
       new Autonomous(m_drivetrain, m_claw, m_wrist, m_elevator);
@@ -61,8 +58,7 @@ public class RobotContainer {
 
     // Assign default commands
     m_drivetrain.setDefaultCommand(
-        new TankDrive(
-            () -> m_joystick.getY(Hand.kLeft), () -> m_joystick.getY(Hand.kRight), m_drivetrain));
+        new TankDrive(m_joystick::getLeftY, m_joystick::getRightY, m_drivetrain));
 
     // Show what command your subsystem is running on the SmartDashboard
     SmartDashboard.putData(m_drivetrain);
@@ -76,7 +72,7 @@ public class RobotContainer {
 
   /**
    * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * instantiating a {@link edu.wpi.first.wpilibj.GenericHID} or one of its subclasses ({@link
    * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then passing it to a {@link
    * edu.wpi.first.wpilibj2.command.button.JoystickButton}.
    */

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/RobotContainer.java
@@ -4,11 +4,10 @@
 
 package edu.wpi.first.wpilibj.examples.gyrodrivecommands;
 
-import static edu.wpi.first.wpilibj.XboxController.Button;
+import static edu.wpi.first.wpilibj.PS4Controller.Button;
 
 import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.wpilibj.GenericHID;
-import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.PS4Controller;
 import edu.wpi.first.wpilibj.examples.gyrodrivecommands.Constants.DriveConstants;
 import edu.wpi.first.wpilibj.examples.gyrodrivecommands.Constants.OIConstants;
 import edu.wpi.first.wpilibj.examples.gyrodrivecommands.commands.TurnToAngle;
@@ -31,7 +30,7 @@ public class RobotContainer {
   private final DriveSubsystem m_robotDrive = new DriveSubsystem();
 
   // The driver's controller
-  XboxController m_driverController = new XboxController(OIConstants.kDriverControllerPort);
+  PS4Controller m_driverController = new PS4Controller(OIConstants.kDriverControllerPort);
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
@@ -46,25 +45,24 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
-                    m_driverController.getX(GenericHID.Hand.kRight)),
+                    m_driverController.getLeftY(), m_driverController.getRightX()),
             m_robotDrive));
   }
 
   /**
    * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses ({@link
-   * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then passing it to a {@link
+   * instantiating a {@link edu.wpi.first.wpilibj.GenericHID} or one of its subclasses ({@link
+   * edu.wpi.first.wpilibj.Joystick} or {@link PS4Controller}), and then passing it to a {@link
    * edu.wpi.first.wpilibj2.command.button.JoystickButton}.
    */
   private void configureButtonBindings() {
     // Drive at half speed when the right bumper is held
-    new JoystickButton(m_driverController, Button.kBumperRight.value)
+    new JoystickButton(m_driverController, Button.kR1.value)
         .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
         .whenReleased(() -> m_robotDrive.setMaxOutput(1));
 
     // Stabilize robot to drive straight with gyro when left bumper is held
-    new JoystickButton(m_driverController, Button.kBumperLeft.value)
+    new JoystickButton(m_driverController, Button.kL1.value)
         .whenHeld(
             new PIDCommand(
                 new PIDController(
@@ -76,18 +74,16 @@ public class RobotContainer {
                 // Setpoint is 0
                 0,
                 // Pipe the output to the turning controls
-                output ->
-                    m_robotDrive.arcadeDrive(
-                        m_driverController.getY(GenericHID.Hand.kLeft), output),
+                output -> m_robotDrive.arcadeDrive(m_driverController.getLeftY(), output),
                 // Require the robot drive
                 m_robotDrive));
 
     // Turn to 90 degrees when the 'X' button is pressed, with a 5 second timeout
-    new JoystickButton(m_driverController, Button.kX.value)
+    new JoystickButton(m_driverController, Button.kCross.value)
         .whenPressed(new TurnToAngle(90, m_robotDrive).withTimeout(5));
 
-    // Turn to -90 degrees with a profile when the 'A' button is pressed, with a 5 second timeout
-    new JoystickButton(m_driverController, Button.kA.value)
+    // Turn to -90 degrees with a profile when the Circle button is pressed, with a 5 second timeout
+    new JoystickButton(m_driverController, Button.kCircle.value)
         .whenPressed(new TurnToAngleProfiled(-90, m_robotDrive).withTimeout(5));
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
@@ -4,10 +4,9 @@
 
 package edu.wpi.first.wpilibj.examples.hatchbotinlined;
 
-import static edu.wpi.first.wpilibj.XboxController.Button;
+import static edu.wpi.first.wpilibj.PS4Controller.Button;
 
-import edu.wpi.first.wpilibj.GenericHID;
-import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.PS4Controller;
 import edu.wpi.first.wpilibj.examples.hatchbotinlined.Constants.AutoConstants;
 import edu.wpi.first.wpilibj.examples.hatchbotinlined.Constants.OIConstants;
 import edu.wpi.first.wpilibj.examples.hatchbotinlined.commands.ComplexAutoCommand;
@@ -55,7 +54,7 @@ public class RobotContainer {
   SendableChooser<Command> m_chooser = new SendableChooser<>();
 
   // The driver's controller
-  XboxController m_driverController = new XboxController(OIConstants.kDriverControllerPort);
+  PS4Controller m_driverController = new PS4Controller(OIConstants.kDriverControllerPort);
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
@@ -70,8 +69,7 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
-                    m_driverController.getX(GenericHID.Hand.kRight)),
+                    m_driverController.getLeftY(), m_driverController.getRightX()),
             m_robotDrive));
 
     // Add commands to the autonomous command chooser
@@ -84,19 +82,19 @@ public class RobotContainer {
 
   /**
    * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses ({@link
-   * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then passing it to a {@link
+   * instantiating a {@link edu.wpi.first.wpilibj.GenericHID} or one of its subclasses ({@link
+   * edu.wpi.first.wpilibj.Joystick} or {@link PS4Controller}), and then passing it to a {@link
    * edu.wpi.first.wpilibj2.command.button.JoystickButton}.
    */
   private void configureButtonBindings() {
-    // Grab the hatch when the 'A' button is pressed.
-    new JoystickButton(m_driverController, Button.kA.value)
+    // Grab the hatch when the Circle button is pressed.
+    new JoystickButton(m_driverController, Button.kCircle.value)
         .whenPressed(new InstantCommand(m_hatchSubsystem::grabHatch, m_hatchSubsystem));
-    // Release the hatch when the 'B' button is pressed.
-    new JoystickButton(m_driverController, Button.kB.value)
+    // Release the hatch when the Square button is pressed.
+    new JoystickButton(m_driverController, Button.kSquare.value)
         .whenPressed(new InstantCommand(m_hatchSubsystem::releaseHatch, m_hatchSubsystem));
-    // While holding the shoulder button, drive at half speed
-    new JoystickButton(m_driverController, Button.kBumperRight.value)
+    // While holding R1, drive at half speed
+    new JoystickButton(m_driverController, Button.kR1.value)
         .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
         .whenReleased(() -> m_robotDrive.setMaxOutput(1));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/RobotContainer.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj.examples.hatchbottraditional;
 
 import static edu.wpi.first.wpilibj.XboxController.Button;
 
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.examples.hatchbottraditional.Constants.AutoConstants;
 import edu.wpi.first.wpilibj.examples.hatchbottraditional.Constants.OIConstants;
@@ -61,9 +60,7 @@ public class RobotContainer {
         // A split-stick arcade command, with forward/backward controlled by the left
         // hand, and turning controlled by the right.
         new DefaultDrive(
-            m_robotDrive,
-            () -> m_driverController.getY(GenericHID.Hand.kLeft),
-            () -> m_driverController.getX(GenericHID.Hand.kRight)));
+            m_robotDrive, m_driverController::getLeftY, m_driverController::getRightX));
 
     // Add commands to the autonomous command chooser
     m_chooser.setDefaultOption("Simple Auto", m_simpleAuto);
@@ -75,7 +72,7 @@ public class RobotContainer {
 
   /**
    * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * instantiating a {@link edu.wpi.first.wpilibj.GenericHID} or one of its subclasses ({@link
    * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then passing it to a {@link
    * edu.wpi.first.wpilibj2.command.button.JoystickButton}.
    */
@@ -87,7 +84,7 @@ public class RobotContainer {
     new JoystickButton(m_driverController, Button.kB.value)
         .whenPressed(new ReleaseHatch(m_hatchSubsystem));
     // While holding the shoulder button, drive at half speed
-    new JoystickButton(m_driverController, Button.kBumperRight.value)
+    new JoystickButton(m_driverController, Button.kRightBumper.value)
         .whenHeld(new HalveDriveSpeed(m_robotDrive));
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumbot/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumbot/Robot.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.wpilibj.examples.mecanumbot;
 
 import edu.wpi.first.math.filter.SlewRateLimiter;
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.XboxController;
 
@@ -32,22 +31,18 @@ public class Robot extends TimedRobot {
   private void driveWithJoystick(boolean fieldRelative) {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    final var xSpeed =
-        -m_xspeedLimiter.calculate(m_controller.getY(GenericHID.Hand.kLeft)) * Drivetrain.kMaxSpeed;
+    final var xSpeed = -m_xspeedLimiter.calculate(m_controller.getLeftY()) * Drivetrain.kMaxSpeed;
 
     // Get the y speed or sideways/strafe speed. We are inverting this because
     // we want a positive value when we pull to the left. Xbox controllers
     // return positive values when you pull to the right by default.
-    final var ySpeed =
-        -m_yspeedLimiter.calculate(m_controller.getX(GenericHID.Hand.kLeft)) * Drivetrain.kMaxSpeed;
+    final var ySpeed = -m_yspeedLimiter.calculate(m_controller.getLeftX()) * Drivetrain.kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    final var rot =
-        -m_rotLimiter.calculate(m_controller.getX(GenericHID.Hand.kRight))
-            * Drivetrain.kMaxAngularSpeed;
+    final var rot = -m_rotLimiter.calculate(m_controller.getRightX()) * Drivetrain.kMaxAngularSpeed;
 
     m_mecanum.drive(xSpeed, ySpeed, rot, fieldRelative);
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/RobotContainer.java
@@ -12,7 +12,6 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.trajectory.TrajectoryConfig;
 import edu.wpi.first.math.trajectory.TrajectoryGenerator;
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.XboxController.Button;
 import edu.wpi.first.wpilibj.examples.mecanumcontrollercommand.Constants.AutoConstants;
@@ -51,22 +50,22 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.drive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
-                    m_driverController.getX(GenericHID.Hand.kRight),
-                    m_driverController.getX(GenericHID.Hand.kLeft),
+                    m_driverController.getLeftY(),
+                    m_driverController.getRightX(),
+                    m_driverController.getLeftX(),
                     false),
             m_robotDrive));
   }
 
   /**
    * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * instantiating a {@link edu.wpi.first.wpilibj.GenericHID} or one of its subclasses ({@link
    * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then calling passing it to a
    * {@link JoystickButton}.
    */
   private void configureButtonBindings() {
     // Drive at half speed when the right bumper is held
-    new JoystickButton(m_driverController, Button.kBumperRight.value)
+    new JoystickButton(m_driverController, Button.kRightBumper.value)
         .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
         .whenReleased(() -> m_robotDrive.setMaxOutput(1));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/Robot.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.wpilibj.examples.mecanumdriveposeestimator;
 
 import edu.wpi.first.math.filter.SlewRateLimiter;
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.XboxController;
 
@@ -32,22 +31,18 @@ public class Robot extends TimedRobot {
   private void driveWithJoystick(boolean fieldRelative) {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    final var xSpeed =
-        -m_xspeedLimiter.calculate(m_controller.getY(GenericHID.Hand.kLeft)) * Drivetrain.kMaxSpeed;
+    final var xSpeed = -m_xspeedLimiter.calculate(m_controller.getLeftY()) * Drivetrain.kMaxSpeed;
 
     // Get the y speed or sideways/strafe speed. We are inverting this because
     // we want a positive value when we pull to the left. Xbox controllers
     // return positive values when you pull to the right by default.
-    final var ySpeed =
-        -m_yspeedLimiter.calculate(m_controller.getX(GenericHID.Hand.kLeft)) * Drivetrain.kMaxSpeed;
+    final var ySpeed = -m_yspeedLimiter.calculate(m_controller.getLeftX()) * Drivetrain.kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    final var rot =
-        -m_rotLimiter.calculate(m_controller.getX(GenericHID.Hand.kRight))
-            * Drivetrain.kMaxAngularSpeed;
+    final var rot = -m_rotLimiter.calculate(m_controller.getRightX()) * Drivetrain.kMaxAngularSpeed;
 
     m_mecanum.drive(xSpeed, ySpeed, rot, fieldRelative);
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/triggers/DoubleButton.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/triggers/DoubleButton.java
@@ -4,12 +4,12 @@
 
 package edu.wpi.first.wpilibj.examples.pacgoat.triggers;
 
-import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.buttons.Trigger;
 
 /** A custom button that is triggered when TWO buttons on a Joystick are simultaneously pressed. */
 public class DoubleButton extends Trigger {
-  private final Joystick m_joy;
+  private final GenericHID m_joy;
   private final int m_button1;
   private final int m_button2;
 
@@ -20,7 +20,7 @@ public class DoubleButton extends Trigger {
    * @param button1 The first button
    * @param button2 The second button
    */
-  public DoubleButton(Joystick joy, int button1, int button2) {
+  public DoubleButton(GenericHID joy, int button1, int button2) {
     this.m_joy = joy;
     this.m_button1 = button1;
     this.m_button2 = button2;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
@@ -16,7 +16,6 @@ import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.trajectory.TrajectoryConfig;
 import edu.wpi.first.math.trajectory.TrajectoryGenerator;
 import edu.wpi.first.math.trajectory.constraint.DifferentialDriveVoltageConstraint;
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.examples.ramsetecommand.Constants.AutoConstants;
 import edu.wpi.first.wpilibj.examples.ramsetecommand.Constants.DriveConstants;
@@ -54,20 +53,19 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
-                    m_driverController.getX(GenericHID.Hand.kRight)),
+                    m_driverController.getLeftY(), m_driverController.getRightX()),
             m_robotDrive));
   }
 
   /**
    * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * instantiating a {@link edu.wpi.first.wpilibj.GenericHID} or one of its subclasses ({@link
    * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then calling passing it to a
    * {@link JoystickButton}.
    */
   private void configureButtonBindings() {
     // Drive at half speed when the right bumper is held
-    new JoystickButton(m_driverController, Button.kBumperRight.value)
+    new JoystickButton(m_driverController, Button.kRightBumper.value)
         .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
         .whenReleased(() -> m_robotDrive.setMaxOutput(1));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecontroller/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecontroller/Robot.java
@@ -13,7 +13,6 @@ import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.trajectory.TrajectoryConfig;
 import edu.wpi.first.math.trajectory.TrajectoryGenerator;
 import edu.wpi.first.math.util.Units;
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.XboxController;
@@ -96,16 +95,13 @@ public class Robot extends TimedRobot {
   public void teleopPeriodic() {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    final var xSpeed =
-        -m_speedLimiter.calculate(m_controller.getY(GenericHID.Hand.kLeft)) * Drivetrain.kMaxSpeed;
+    final var xSpeed = -m_speedLimiter.calculate(m_controller.getLeftY()) * Drivetrain.kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    final var rot =
-        -m_rotLimiter.calculate(m_controller.getX(GenericHID.Hand.kRight))
-            * Drivetrain.kMaxAngularSpeed;
+    final var rot = -m_rotLimiter.calculate(m_controller.getRightX()) * Drivetrain.kMaxAngularSpeed;
 
     m_drive.drive(xSpeed, rot);
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/simpledifferentialdrivesimulation/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/simpledifferentialdrivesimulation/Robot.java
@@ -12,7 +12,6 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.trajectory.TrajectoryConfig;
 import edu.wpi.first.math.trajectory.TrajectoryGenerator;
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.XboxController;
@@ -70,16 +69,13 @@ public class Robot extends TimedRobot {
   public void teleopPeriodic() {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    double xSpeed =
-        -m_speedLimiter.calculate(m_controller.getY(GenericHID.Hand.kLeft)) * Drivetrain.kMaxSpeed;
+    double xSpeed = -m_speedLimiter.calculate(m_controller.getLeftY()) * Drivetrain.kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    double rot =
-        -m_rotLimiter.calculate(m_controller.getX(GenericHID.Hand.kRight))
-            * Drivetrain.kMaxAngularSpeed;
+    double rot = -m_rotLimiter.calculate(m_controller.getRightX()) * Drivetrain.kMaxAngularSpeed;
     m_drive.drive(xSpeed, rot);
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
@@ -14,7 +14,6 @@ import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.trajectory.TrajectoryConfig;
 import edu.wpi.first.math.trajectory.TrajectoryGenerator;
 import edu.wpi.first.math.trajectory.constraint.DifferentialDriveVoltageConstraint;
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.XboxController.Button;
 import edu.wpi.first.wpilibj.examples.statespacedifferentialdrivesimulation.subsystems.DriveSubsystem;
@@ -51,20 +50,19 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(
-                    -m_driverController.getY(GenericHID.Hand.kRight),
-                    m_driverController.getX(GenericHID.Hand.kLeft)),
+                    -m_driverController.getRightY(), m_driverController.getLeftX()),
             m_robotDrive));
   }
 
   /**
    * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * instantiating a {@link edu.wpi.first.wpilibj.GenericHID} or one of its subclasses ({@link
    * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then calling passing it to a
    * {@link JoystickButton}.
    */
   private void configureButtonBindings() {
     // Drive at half speed when the right bumper is held
-    new JoystickButton(m_driverController, Button.kBumperRight.value)
+    new JoystickButton(m_driverController, Button.kRightBumper.value)
         .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
         .whenReleased(() -> m_robotDrive.setMaxOutput(1));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervebot/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervebot/Robot.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.wpilibj.examples.swervebot;
 
 import edu.wpi.first.math.filter.SlewRateLimiter;
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.XboxController;
 
@@ -32,22 +31,18 @@ public class Robot extends TimedRobot {
   private void driveWithJoystick(boolean fieldRelative) {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    final var xSpeed =
-        -m_xspeedLimiter.calculate(m_controller.getY(GenericHID.Hand.kLeft)) * Drivetrain.kMaxSpeed;
+    final var xSpeed = -m_xspeedLimiter.calculate(m_controller.getLeftY()) * Drivetrain.kMaxSpeed;
 
     // Get the y speed or sideways/strafe speed. We are inverting this because
     // we want a positive value when we pull to the left. Xbox controllers
     // return positive values when you pull to the right by default.
-    final var ySpeed =
-        -m_yspeedLimiter.calculate(m_controller.getX(GenericHID.Hand.kLeft)) * Drivetrain.kMaxSpeed;
+    final var ySpeed = -m_yspeedLimiter.calculate(m_controller.getLeftX()) * Drivetrain.kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    final var rot =
-        -m_rotLimiter.calculate(m_controller.getX(GenericHID.Hand.kRight))
-            * Drivetrain.kMaxAngularSpeed;
+    final var rot = -m_rotLimiter.calculate(m_controller.getRightX()) * Drivetrain.kMaxAngularSpeed;
 
     m_swerve.drive(xSpeed, ySpeed, rot, fieldRelative);
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/RobotContainer.java
@@ -12,7 +12,6 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.trajectory.TrajectoryConfig;
 import edu.wpi.first.math.trajectory.TrajectoryGenerator;
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.examples.swervecontrollercommand.Constants.AutoConstants;
 import edu.wpi.first.wpilibj.examples.swervecontrollercommand.Constants.DriveConstants;
@@ -50,16 +49,16 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.drive(
-                    m_driverController.getY(GenericHID.Hand.kLeft),
-                    m_driverController.getX(GenericHID.Hand.kRight),
-                    m_driverController.getX(GenericHID.Hand.kLeft),
+                    m_driverController.getLeftY(),
+                    m_driverController.getRightX(),
+                    m_driverController.getLeftX(),
                     false),
             m_robotDrive));
   }
 
   /**
    * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * instantiating a {@link edu.wpi.first.wpilibj.GenericHID} or one of its subclasses ({@link
    * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then calling passing it to a
    * {@link JoystickButton}.
    */

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervedriveposeestimator/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervedriveposeestimator/Robot.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.wpilibj.examples.swervedriveposeestimator;
 
 import edu.wpi.first.math.filter.SlewRateLimiter;
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.XboxController;
 
@@ -32,22 +31,18 @@ public class Robot extends TimedRobot {
   private void driveWithJoystick(boolean fieldRelative) {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    final var xSpeed =
-        -m_xspeedLimiter.calculate(m_controller.getY(GenericHID.Hand.kLeft)) * Drivetrain.kMaxSpeed;
+    final var xSpeed = -m_xspeedLimiter.calculate(m_controller.getLeftY()) * Drivetrain.kMaxSpeed;
 
     // Get the y speed or sideways/strafe speed. We are inverting this because
     // we want a positive value when we pull to the left. Xbox controllers
     // return positive values when you pull to the right by default.
-    final var ySpeed =
-        -m_yspeedLimiter.calculate(m_controller.getX(GenericHID.Hand.kLeft)) * Drivetrain.kMaxSpeed;
+    final var ySpeed = -m_yspeedLimiter.calculate(m_controller.getLeftX()) * Drivetrain.kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    final var rot =
-        -m_rotLimiter.calculate(m_controller.getX(GenericHID.Hand.kRight))
-            * Drivetrain.kMaxAngularSpeed;
+    final var rot = -m_rotLimiter.calculate(m_controller.getRightX()) * Drivetrain.kMaxAngularSpeed;
 
     m_swerve.drive(xSpeed, ySpeed, rot, fieldRelative);
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/tankdrivexboxcontroller/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/tankdrivexboxcontroller/Robot.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.wpilibj.examples.tankdrivexboxcontroller;
 
-import edu.wpi.first.wpilibj.GenericHID.Hand;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
@@ -34,7 +33,6 @@ public class Robot extends TimedRobot {
     // That means that the Y axis of the left stick moves the left side
     // of the robot forward and backward, and the Y axis of the right stick
     // moves the right side of the robot forward and backward.
-    m_robotDrive.tankDrive(
-        m_driverController.getY(Hand.kLeft), m_driverController.getY(Hand.kRight));
+    m_robotDrive.tankDrive(m_driverController.getLeftY(), m_driverController.getRightY());
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/romicommandbased/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/romicommandbased/RobotContainer.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.wpilibj.templates.romicommandbased;
 
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.templates.romicommandbased.commands.ExampleCommand;
 import edu.wpi.first.wpilibj.templates.romicommandbased.subsystems.RomiDrivetrain;
@@ -30,7 +29,7 @@ public class RobotContainer {
 
   /**
    * Use this method to define your button->command mappings. Buttons can be created by
-   * instantiating a {@link GenericHID} or one of its subclasses ({@link
+   * instantiating a {@link edu.wpi.first.wpilibj.GenericHID} or one of its subclasses ({@link
    * edu.wpi.first.wpilibj.Joystick} or {@link XboxController}), and then passing it to a {@link
    * edu.wpi.first.wpilibj2.command.button.JoystickButton}.
    */


### PR DESCRIPTION
Fixes #3338 

This PR accomplishes the following changes:

- GenericHID is now concrete, and has only `getRawAxis/Button(int)` functionality.
- `getXxx()` has been moved into `Joystick` as that's the only place where it makes sense.
- `Hand` (and therefore `getXxx(Hand)`) has been removed, replaced by specific `getLeft/RightXxx()` methods in `XboxController` and the new `PS4Controller` class.
- C++ `::Button::` and `::Axis::` enums have been converted to identically-namespaced `static constexpr int`s

Obviously, most of these changes are breaking.


---
Old version:
> This splits the device-specific `getXxx()` and `getXxx(Hand)` methods into the relevant `XboxController` and `Joystick` classes.
Since the `Hand` enum is now used (and makes sense) only in the context of an `XBoxController`, I moved it there. 
**THIS IS BREAKING** - it removes functions from `GenericHID` but especially the `Hand` move (see how many examples had to change).
Discussion of renaming `XboxController` to something more controller-agnostic is on the issue.