### PR TITLE
Fix build error when building with GCC 11.1

### DIFF
--- a/simulation/halsim_ws_core/src/main/native/include/WSProviderContainer.h
+++ b/simulation/halsim_ws_core/src/main/native/include/WSProviderContainer.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <shared_mutex>
+#include <mutex>
 
 #include <wpi/StringMap.h>
 

--- a/simulation/halsim_ws_core/src/main/native/include/WSProviderContainer.h
+++ b/simulation/halsim_ws_core/src/main/native/include/WSProviderContainer.h
@@ -6,8 +6,8 @@
 
 #include <functional>
 #include <memory>
-#include <shared_mutex>
 #include <mutex>
+#include <shared_mutex>
 
 #include <wpi/StringMap.h>
 


### PR DESCRIPTION
This fix adds the mutex header to WSProviderContainer.h

I was building with CMake and the build failed as it could not find std::unique_lock. I am guessing this is a gcc 11 issue but I have not tested it on other compilers.

To reproduce this problem, run on Arch Linux and use CMake as `cmake -GNinja -DWITH_JAVA=OFF .. && ninja`. This demo should also work with Unix Makefiles 