### PR TITLE
Suppress the -Wmaybe-uninitialized warning in Eigen

### DIFF
--- a/wpimath/.styleguide
+++ b/wpimath/.styleguide
@@ -8,6 +8,10 @@ cppSrcFileInclude {
   \.cpp$
 }
 
+modifiableFileExclude {
+  \.patch$
+}
+
 generatedFileExclude {
   src/main/native/cpp/drake/
   src/main/native/eigeninclude/

--- a/wpimath/eigen-maybe-uninitialized.patch
+++ b/wpimath/eigen-maybe-uninitialized.patch
@@ -1,0 +1,15 @@
+diff --git a/wpimath/src/main/native/eigeninclude/Eigen/src/Core/util/DisableStupidWarnings.h b/wpimath/src/main/native/eigeninclude/Eigen/src/Core/util/DisableStupidWarnings.h
+index 74f74cc42..5fe86fa0d 100644
+--- a/wpimath/src/main/native/eigeninclude/Eigen/src/Core/util/DisableStupidWarnings.h
++++ b/wpimath/src/main/native/eigeninclude/Eigen/src/Core/util/DisableStupidWarnings.h
+@@ -61,6 +61,10 @@
+     // See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89325
+     #pragma GCC diagnostic ignored "-Wattributes"
+   #endif
++  #if __GNUC__==11
++    // This warning is a false positive
++    #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
++  #endif
+ #endif
+ 
+ #if defined __NVCC__

--- a/wpimath/src/main/native/eigeninclude/Eigen/src/Core/util/DisableStupidWarnings.h
+++ b/wpimath/src/main/native/eigeninclude/Eigen/src/Core/util/DisableStupidWarnings.h
@@ -61,6 +61,10 @@
     // See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89325
     #pragma GCC diagnostic ignored "-Wattributes"
   #endif
+  #if __GNUC__==11
+    // This warning is a false positive
+    #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+  #endif
 #endif
 
 #if defined __NVCC__

--- a/wpimath/update_eigen.py
+++ b/wpimath/update_eigen.py
@@ -187,6 +187,10 @@ def main():
             os.makedirs(dest_dir)
         shutil.copyfile(f, dest_file)
 
+    # Apply patches
+    os.chdir(cwd)
+    subprocess.check_output(["git", "apply", "eigen-maybe-uninitialized.patch"])
+
     # Comment out missing headers
     for f in files:
         dest_file = os.path.join(include_root, f)


### PR DESCRIPTION
GCC 11 emits a false positive when compiling Eigen and breaks the
allwpilib build.

Fixes #3363.