### PR TITLE
[simulation] Disable flaky web server integration tests

### DIFF
--- a/simulation/halsim_ws_server/src/test/native/cpp/main.cpp
+++ b/simulation/halsim_ws_server/src/test/native/cpp/main.cpp
@@ -41,7 +41,7 @@ class WebServerIntegrationTest : public ::testing::Test {
   HALSimWSServer m_server;
 };
 
-TEST_F(WebServerIntegrationTest, DigitalOutput) {
+TEST_F(WebServerIntegrationTest, DISABLED_DigitalOutput) {
   // Create expected results
   const bool EXPECTED_VALUE = false;
   const int PIN = 0;
@@ -92,7 +92,7 @@ TEST_F(WebServerIntegrationTest, DigitalOutput) {
   EXPECT_EQ(EXPECTED_VALUE, test_value);
 }
 
-TEST_F(WebServerIntegrationTest, DigitalInput) {
+TEST_F(WebServerIntegrationTest, DISABLED_DigitalInput) {
   // Create expected results
   const bool EXPECTED_VALUE = false;
   const int PIN = 0;


### PR DESCRIPTION
I've seen the digital output test fail on Linux and the digital input
test fail on macOS.