### PR TITLE
[wpilibc] SimDeviceSim: use fmtlib

### DIFF
--- a/wpilibc/src/main/native/cpp/simulation/ADXRS450_GyroSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/ADXRS450_GyroSim.cpp
@@ -4,19 +4,13 @@
 
 #include "frc/simulation/ADXRS450_GyroSim.h"
 
-#include <wpi/SmallString.h>
-#include <wpi/raw_ostream.h>
-
 #include "frc/ADXRS450_Gyro.h"
 #include "frc/simulation/SimDeviceSim.h"
 
 using namespace frc::sim;
 
 ADXRS450_GyroSim::ADXRS450_GyroSim(const frc::ADXRS450_Gyro& gyro) {
-  wpi::SmallString<128> fullname;
-  wpi::raw_svector_ostream os(fullname);
-  os << "Gyro:ADXRS450" << '[' << gyro.GetPort() << ']';
-  frc::sim::SimDeviceSim deviceSim{fullname.c_str()};
+  frc::sim::SimDeviceSim deviceSim{"Gyro:ADXRS450", gyro.GetPort()};
   m_simAngle = deviceSim.GetDouble("angle_x");
   m_simRate = deviceSim.GetDouble("rate_x");
 }

--- a/wpilibc/src/main/native/cpp/simulation/AnalogEncoderSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/AnalogEncoderSim.cpp
@@ -4,19 +4,13 @@
 
 #include "frc/simulation/AnalogEncoderSim.h"
 
-#include <wpi/SmallString.h>
-#include <wpi/raw_ostream.h>
-
 #include "frc/AnalogEncoder.h"
 #include "frc/simulation/SimDeviceSim.h"
 
 using namespace frc::sim;
 
 AnalogEncoderSim::AnalogEncoderSim(const frc::AnalogEncoder& encoder) {
-  wpi::SmallString<128> fullname;
-  wpi::raw_svector_ostream os(fullname);
-  os << "AnalogEncoder" << '[' << encoder.GetChannel() << ']';
-  frc::sim::SimDeviceSim deviceSim{fullname.c_str()};
+  frc::sim::SimDeviceSim deviceSim{"AnalogEncoder", encoder.GetChannel()};
   m_positionSim = deviceSim.GetDouble("Position");
 }
 

--- a/wpilibc/src/main/native/cpp/simulation/DutyCycleEncoderSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/DutyCycleEncoderSim.cpp
@@ -4,20 +4,14 @@
 
 #include "frc/simulation/DutyCycleEncoderSim.h"
 
-#include <wpi/SmallString.h>
-#include <wpi/raw_ostream.h>
-
 #include "frc/DutyCycleEncoder.h"
 #include "frc/simulation/SimDeviceSim.h"
 
 using namespace frc::sim;
 
 DutyCycleEncoderSim::DutyCycleEncoderSim(const frc::DutyCycleEncoder& encoder) {
-  wpi::SmallString<128> fullname;
-  wpi::raw_svector_ostream os(fullname);
-  os << "DutyCycle:DutyCycleEncoder" << '[' << encoder.GetSourceChannel()
-     << ']';
-  frc::sim::SimDeviceSim deviceSim{fullname.c_str()};
+  frc::sim::SimDeviceSim deviceSim{"DutyCycle:DutyCycleEncoder",
+                                   encoder.GetSourceChannel()};
   m_simPosition = deviceSim.GetDouble("position");
   m_simDistancePerRotation = deviceSim.GetDouble("distance_per_rot");
 }

--- a/wpilibc/src/main/native/cpp/simulation/SimDeviceSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/SimDeviceSim.cpp
@@ -7,10 +7,9 @@
 #include <string>
 #include <vector>
 
+#include <fmt/format.h>
 #include <hal/SimDevice.h>
 #include <hal/simulation/SimDeviceData.h>
-#include <wpi/SmallString.h>
-#include <wpi/raw_ostream.h>
 
 using namespace frc;
 using namespace frc::sim;
@@ -19,19 +18,13 @@ SimDeviceSim::SimDeviceSim(const char* name)
     : m_handle{HALSIM_GetSimDeviceHandle(name)} {}
 
 SimDeviceSim::SimDeviceSim(const char* name, int index) {
-  wpi::SmallString<128> fullname;
-  wpi::raw_svector_ostream os(fullname);
-  os << name << '[' << index << ']';
-
-  m_handle = HALSIM_GetSimDeviceHandle(fullname.c_str());
+  m_handle =
+      HALSIM_GetSimDeviceHandle(fmt::format("{}[{}]", name, index).c_str());
 }
 
 SimDeviceSim::SimDeviceSim(const char* name, int index, int channel) {
-  wpi::SmallString<128> fullname;
-  wpi::raw_svector_ostream os(fullname);
-  os << name << '[' << index << ',' << channel << ']';
-
-  m_handle = HALSIM_GetSimDeviceHandle(fullname.c_str());
+  m_handle = HALSIM_GetSimDeviceHandle(
+      fmt::format("{}[{},{}]", name, index, channel).c_str());
 }
 
 hal::SimValue SimDeviceSim::GetValue(const char* name) const {


### PR DESCRIPTION
Also clean up several sim classes to use the channel constructor.