### PR TITLE
[wpilibc] MotorSafety::GetDescription(): Return std::string

### DIFF
--- a/wpilibc/src/main/native/cpp/MotorSafety.cpp
+++ b/wpilibc/src/main/native/cpp/MotorSafety.cpp
@@ -8,8 +8,6 @@
 #include <utility>
 
 #include <wpi/SmallPtrSet.h>
-#include <wpi/SmallString.h>
-#include <wpi/raw_ostream.h>
 
 #include "frc/DriverStation.h"
 #include "frc/Errors.h"
@@ -90,11 +88,8 @@ void MotorSafety::Check() {
   }
 
   if (stopTime < Timer::GetFPGATimestamp()) {
-    wpi::SmallString<128> buf;
-    wpi::raw_svector_ostream desc(buf);
-    GetDescription(desc);
     FRC_ReportError(err::Timeout, "{}... Output not updated often enough",
-                    desc.str());
+                    GetDescription());
     StopMotor();
   }
 }

--- a/wpilibc/src/main/native/cpp/Relay.cpp
+++ b/wpilibc/src/main/native/cpp/Relay.cpp
@@ -6,12 +6,12 @@
 
 #include <utility>
 
+#include <fmt/format.h>
 #include <hal/FRCUsageReporting.h>
 #include <hal/HALBase.h>
 #include <hal/Ports.h>
 #include <hal/Relay.h>
 #include <wpi/StackTrace.h>
-#include <wpi/raw_ostream.h>
 
 #include "frc/Errors.h"
 #include "frc/SensorUtil.h"
@@ -168,8 +168,8 @@ void Relay::StopMotor() {
   Set(kOff);
 }
 
-void Relay::GetDescription(wpi::raw_ostream& desc) const {
-  desc << "Relay " << GetChannel();
+std::string Relay::GetDescription() const {
+  return fmt::format("Relay {}", GetChannel());
 }
 
 void Relay::InitSendable(SendableBuilder& builder) {

--- a/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
@@ -189,8 +189,8 @@ void DifferentialDrive::StopMotor() {
   Feed();
 }
 
-void DifferentialDrive::GetDescription(wpi::raw_ostream& desc) const {
-  desc << "DifferentialDrive";
+std::string DifferentialDrive::GetDescription() const {
+  return "DifferentialDrive";
 }
 
 void DifferentialDrive::InitSendable(SendableBuilder& builder) {

--- a/wpilibc/src/main/native/cpp/drive/KilloughDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/KilloughDrive.cpp
@@ -114,8 +114,8 @@ void KilloughDrive::StopMotor() {
   Feed();
 }
 
-void KilloughDrive::GetDescription(wpi::raw_ostream& desc) const {
-  desc << "KilloughDrive";
+std::string KilloughDrive::GetDescription() const {
+  return "KilloughDrive";
 }
 
 void KilloughDrive::InitSendable(SendableBuilder& builder) {

--- a/wpilibc/src/main/native/cpp/drive/MecanumDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/MecanumDrive.cpp
@@ -109,8 +109,8 @@ MecanumDrive::WheelSpeeds MecanumDrive::DriveCartesianIK(double ySpeed,
           wheelSpeeds[kRearLeft], wheelSpeeds[kRearRight]};
 }
 
-void MecanumDrive::GetDescription(wpi::raw_ostream& desc) const {
-  desc << "MecanumDrive";
+std::string MecanumDrive::GetDescription() const {
+  return "MecanumDrive";
 }
 
 void MecanumDrive::InitSendable(SendableBuilder& builder) {

--- a/wpilibc/src/main/native/cpp/motorcontrol/NidecBrushless.cpp
+++ b/wpilibc/src/main/native/cpp/motorcontrol/NidecBrushless.cpp
@@ -4,8 +4,8 @@
 
 #include "frc/motorcontrol/NidecBrushless.h"
 
+#include <fmt/format.h>
 #include <hal/FRCUsageReporting.h>
-#include <wpi/raw_ostream.h>
 
 #include "frc/smartdashboard/SendableBuilder.h"
 #include "frc/smartdashboard/SendableRegistry.h"
@@ -64,8 +64,8 @@ void NidecBrushless::StopMotor() {
   m_pwm.SetDisabled();
 }
 
-void NidecBrushless::GetDescription(wpi::raw_ostream& desc) const {
-  desc << "Nidec " << GetChannel();
+std::string NidecBrushless::GetDescription() const {
+  return fmt::format("Nidec {}", GetChannel());
 }
 
 int NidecBrushless::GetChannel() const {

--- a/wpilibc/src/main/native/cpp/motorcontrol/PWMMotorController.cpp
+++ b/wpilibc/src/main/native/cpp/motorcontrol/PWMMotorController.cpp
@@ -4,7 +4,7 @@
 
 #include "frc/motorcontrol/PWMMotorController.h"
 
-#include <wpi/raw_ostream.h>
+#include <fmt/format.h>
 
 #include "frc/smartdashboard/SendableBuilder.h"
 
@@ -34,8 +34,8 @@ void PWMMotorController::StopMotor() {
   Disable();
 }
 
-void PWMMotorController::GetDescription(wpi::raw_ostream& desc) const {
-  desc << "PWM " << GetChannel();
+std::string PWMMotorController::GetDescription() const {
+  return fmt::format("PWM {}", GetChannel());
 }
 
 int PWMMotorController::GetChannel() const {

--- a/wpilibc/src/main/native/include/frc/MotorSafety.h
+++ b/wpilibc/src/main/native/include/frc/MotorSafety.h
@@ -4,13 +4,11 @@
 
 #pragma once
 
+#include <string>
+
 #include <wpi/mutex.h>
 
 #include "frc/Timer.h"
-
-namespace wpi {
-class raw_ostream;
-}  // namespace wpi
 
 namespace frc {
 
@@ -92,7 +90,7 @@ class MotorSafety {
   static void CheckMotors();
 
   virtual void StopMotor() = 0;
-  virtual void GetDescription(wpi::raw_ostream& desc) const = 0;
+  virtual std::string GetDescription() const = 0;
 
  private:
   static constexpr double kDefaultSafetyExpiration = 0.1;

--- a/wpilibc/src/main/native/include/frc/Relay.h
+++ b/wpilibc/src/main/native/include/frc/Relay.h
@@ -5,9 +5,9 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include <hal/Types.h>
-#include <wpi/raw_ostream.h>
 
 #include "frc/MotorSafety.h"
 #include "frc/smartdashboard/Sendable.h"
@@ -91,7 +91,7 @@ class Relay : public MotorSafety,
   // MotorSafety interface
   void StopMotor() override;
 
-  void GetDescription(wpi::raw_ostream& desc) const override;
+  std::string GetDescription() const override;
 
   void InitSendable(SendableBuilder& builder) override;
 

--- a/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <wpi/raw_ostream.h>
+#include <string>
 
 #include "frc/drive/RobotDriveBase.h"
 #include "frc/smartdashboard/Sendable.h"
@@ -206,7 +206,7 @@ class DifferentialDrive : public RobotDriveBase,
                                  bool squareInputs = true);
 
   void StopMotor() override;
-  void GetDescription(wpi::raw_ostream& desc) const override;
+  std::string GetDescription() const override;
 
   void InitSendable(SendableBuilder& builder) override;
 

--- a/wpilibc/src/main/native/include/frc/drive/KilloughDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/KilloughDrive.h
@@ -5,8 +5,7 @@
 #pragma once
 
 #include <memory>
-
-#include <wpi/raw_ostream.h>
+#include <string>
 
 #include "frc/drive/RobotDriveBase.h"
 #include "frc/drive/Vector2d.h"
@@ -159,7 +158,7 @@ class KilloughDrive : public RobotDriveBase,
                                double gyroAngle = 0.0);
 
   void StopMotor() override;
-  void GetDescription(wpi::raw_ostream& desc) const override;
+  std::string GetDescription() const override;
 
   void InitSendable(SendableBuilder& builder) override;
 

--- a/wpilibc/src/main/native/include/frc/drive/MecanumDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/MecanumDrive.h
@@ -5,8 +5,7 @@
 #pragma once
 
 #include <memory>
-
-#include <wpi/raw_ostream.h>
+#include <string>
 
 #include "frc/drive/RobotDriveBase.h"
 #include "frc/smartdashboard/Sendable.h"
@@ -149,7 +148,7 @@ class MecanumDrive : public RobotDriveBase,
                                       double zRotation, double gyroAngle = 0.0);
 
   void StopMotor() override;
-  void GetDescription(wpi::raw_ostream& desc) const override;
+  std::string GetDescription() const override;
 
   void InitSendable(SendableBuilder& builder) override;
 

--- a/wpilibc/src/main/native/include/frc/drive/RobotDriveBase.h
+++ b/wpilibc/src/main/native/include/frc/drive/RobotDriveBase.h
@@ -5,9 +5,9 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include <wpi/ArrayRef.h>
-#include <wpi/raw_ostream.h>
 
 #include "frc/MotorSafety.h"
 
@@ -66,7 +66,7 @@ class RobotDriveBase : public MotorSafety {
   void FeedWatchdog();
 
   void StopMotor() override = 0;
-  void GetDescription(wpi::raw_ostream& desc) const override = 0;
+  std::string GetDescription() const override = 0;
 
  protected:
   /**

--- a/wpilibc/src/main/native/include/frc/motorcontrol/NidecBrushless.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/NidecBrushless.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "frc/DigitalOutput.h"
 #include "frc/MotorSafety.h"
 #include "frc/PWM.h"
@@ -74,7 +76,7 @@ class NidecBrushless : public MotorController,
 
   // MotorSafety interface
   void StopMotor() override;
-  void GetDescription(wpi::raw_ostream& desc) const override;
+  std::string GetDescription() const override;
 
   /**
    * Gets the channel number associated with the object.

--- a/wpilibc/src/main/native/include/frc/motorcontrol/PWMMotorController.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/PWMMotorController.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+
 #include <wpi/Twine.h>
 
 #include "frc/MotorSafety.h"
@@ -11,10 +13,6 @@
 #include "frc/motorcontrol/MotorController.h"
 #include "frc/smartdashboard/Sendable.h"
 #include "frc/smartdashboard/SendableHelper.h"
-
-namespace wpi {
-class raw_ostream;
-}  // namespace wpi
 
 namespace frc {
 
@@ -56,7 +54,7 @@ class PWMMotorController : public MotorController,
 
   // MotorSafety interface
   void StopMotor() override;
-  void GetDescription(wpi::raw_ostream& desc) const override;
+  std::string GetDescription() const override;
 
   int GetChannel() const;
 


### PR DESCRIPTION
This is only called in an error condition, so it's not necessary to over
optimize it.