### PR TITLE
[build] Docs: set case_sense_names to false

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -79,6 +79,7 @@ doxygen {
     generate_treeview true
     extract_static true
     full_path_names true
+    case_sense_names false
     strip_from_inc_path cppIncludeRoots as String[]
     strip_from_path cppIncludeRoots as String[]
 }


### PR DESCRIPTION
This means the output will be consistent for all 3 major os and prevent case issues when sharing files