### PR TITLE
Force all linker warnings to be fatal for rio builds

### DIFF
--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -32,6 +32,8 @@ nativeUtils.platformConfigs.each {
     }
 }
 
+nativeUtils.platformConfigs.linuxathena.linker.args.add("-Wl,--fatal-warnings")
+
 model {
     components {
         all {


### PR DESCRIPTION
This will make sure we catch any bugs for missing runtime dependencies before they become bigger problems.

Only done on rio, as iirc mac spits out a bunch of warnings by default.