### PR TITLE
[wpilib] Fix a documentation typo

### DIFF
--- a/wpilibc/src/main/native/include/frc/AsynchronousInterrupt.h
+++ b/wpilibc/src/main/native/include/frc/AsynchronousInterrupt.h
@@ -17,7 +17,7 @@ namespace frc {
  * Class for handling asynchronous interrupts.
  *
  * <p> By default, interrupts will occur on rising edge. Callbacks are disabled
- * by default, and enable() must be called before they will occur.
+ * by default, and Enable() must be called before they will occur.
  *
  * <p> Both rising and falling edges can be indicated in one callback if both a
  * rising and falling edge occurred since the previous callback.

--- a/wpilibc/src/main/native/include/frc/AsynchronousInterrupt.h
+++ b/wpilibc/src/main/native/include/frc/AsynchronousInterrupt.h
@@ -17,10 +17,10 @@ namespace frc {
  * Class for handling asynchronous interrupts.
  *
  * <p> By default, interrupts will occur on rising edge. Callbacks are disabled
- * by default, and Enable() must be called before they will occur.
+ * by default, and enable() must be called before they will occur.
  *
- * <p> Both rising and falling edge can be indiciated if both a rising and
- * falling happen between callbacks.
+ * <p> Both rising and falling edges can be indicated in one callback if both a
+ * rising and falling edge occurred since the previous callback.
  *
  * <p>Synchronous interrupts are handled by the SynchronousInterrupt class.
  */
@@ -31,7 +31,7 @@ class AsynchronousInterrupt {
    *
    * <p> At construction, the interrupt will trigger on the rising edge.
    *
-   * <p> The first bool in the callback is rising, the 2nd is falling.
+   * <p> The first bool in the callback is rising, the second is falling.
    */
   AsynchronousInterrupt(DigitalSource& source,
                         std::function<void(bool, bool)> callback);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AsynchronousInterrupt.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AsynchronousInterrupt.java
@@ -15,8 +15,8 @@ import java.util.function.BiConsumer;
  * <p>By default, interrupts will occur on rising edge. Callbacks are disabled by default, and
  * Enable() must be called before they will occur.
  *
- * <p>Both rising and falling edge can be indiciated if both a rising and falling happen between
- * callbacks.
+ * <p>Both rising and falling edges can be indicated in one callback if both a rising and falling
+ * edge occurred since the previous callback.
  *
  * <p>Synchronous interrupts are handled by the SynchronousInterrupt class.
  */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AsynchronousInterrupt.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AsynchronousInterrupt.java
@@ -13,7 +13,7 @@ import java.util.function.BiConsumer;
  * Class for handling asynchrounous interrupts.
  *
  * <p>By default, interrupts will occur on rising edge. Callbacks are disabled by default, and
- * Enable() must be called before they will occur.
+ * enable() must be called before they will occur.
  *
  * <p>Both rising and falling edges can be indicated in one callback if both a rising and falling
  * edge occurred since the previous callback.


### PR DESCRIPTION
"indicated" was misspelled.