### PR TITLE
[build] Also build sim modules as static libraries

### DIFF
--- a/shared/plugins/setupBuild.gradle
+++ b/shared/plugins/setupBuild.gradle
@@ -21,10 +21,15 @@ if (!project.hasProperty('onlylinuxathena')) {
                     }
                 }
                 binaries.all {
+                    // Define a custom entry point if we are building statically to avoid symbol collision.
                     if (it instanceof StaticLibraryBinarySpec) {
-                        it.buildable = false
-                        return
+                        // These scenario is seldom used, except in sysid to build a fully static exe
+                        // with simulation modules. When building static, it is important that no two
+                        // modules have the same entry point symbolically.
+                        def name = project.name.replace("halsim_", "").toUpperCase()
+                        it.cppCompiler.define("HALSIM_InitExtension", "HALSIM_InitExtension_$name")
                     }
+
                     project(':hal').addHalDependency(it, 'shared')
                     if (project.hasProperty('includeNtCore')) {
                         lib project: ':ntcore', library: 'ntcore', linkage: 'shared'

--- a/simulation/halsim_ws_core/build.gradle
+++ b/simulation/halsim_ws_core/build.gradle
@@ -23,6 +23,7 @@ if (!project.hasProperty('onlylinuxathena')) {
     apply from: "${rootDir}/shared/googletest.gradle"
 
     apply from: "${rootDir}/shared/config.gradle"
+    apply from: "${rootDir}/shared/plugins/publish.gradle"
 
     model {
         components {


### PR DESCRIPTION
This allows sim modules to be statically linked into an executable to
create a "perfectly static" simulated desktop program. The entry point
was changed to be unique when building static libraries to avoid symbol
collisions.