### PR TITLE
Run "Lint and Format" CI job on push as well as pull request

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,5 @@
 name: "Validate Gradle Wrapper"
-on: [push, pull_request]
+on: [pull_request, push]
 
 jobs:
   validation:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -1,6 +1,6 @@
 name: Lint and Format
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   wpiformat:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -1,6 +1,10 @@
 name: Lint and Format
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - main
 
 jobs:
   wpiformat:


### PR DESCRIPTION
This makes the formatter run when pushing to local forks before a pull
request is made.