### PR TITLE
[build] clang-tidy: Remove bugprone-exception-escape

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,6 @@ Checks:
   bugprone-copy-constructor-init,
   bugprone-dangling-handle,
   bugprone-dynamic-static-initializers,
-  bugprone-exception-escape,
   bugprone-forward-declaration-namespace,
   bugprone-forwarding-reference-overload,
   bugprone-inaccurate-erase,


### PR DESCRIPTION
This generates warnings for using fmt::print() in main(), which is a
case we're okay with.