### PR TITLE
Disable frivolous PMD warnings and enable PMD in ntcore

### DIFF
--- a/cameraserver/multiCameraServer/src/main/java/edu/wpi/Main.java
+++ b/cameraserver/multiCameraServer/src/main/java/edu/wpi/Main.java
@@ -94,7 +94,6 @@ public final class Main {
   }
 
   /** Read configuration file. */
-  @SuppressWarnings("PMD.CyclomaticComplexity")
   public static boolean readConfig() {
     // parse file
     JsonElement top;

--- a/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
+++ b/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
@@ -90,7 +90,7 @@ public final class CameraServer {
     return "mjpg:http://" + address + ":" + port + "/?action=stream";
   }
 
-  @SuppressWarnings({"MissingJavadocMethod", "PMD.AvoidUsingHardCodedIP"})
+  @SuppressWarnings("MissingJavadocMethod")
   private synchronized String[] getSinkStreamValues(int sink) {
     // Ignore all but MjpegServer
     if (VideoSink.getKindFromInt(CameraServerJNI.getSinkKind(sink)) != VideoSink.Kind.kMjpeg) {
@@ -120,7 +120,7 @@ public final class CameraServer {
     return values.toArray(new String[0]);
   }
 
-  @SuppressWarnings({"MissingJavadocMethod", "PMD.AvoidUsingHardCodedIP"})
+  @SuppressWarnings("MissingJavadocMethod")
   private synchronized String[] getSourceStreamValues(int source) {
     // Ignore all but HttpCamera
     if (VideoSource.getKindFromInt(CameraServerJNI.getSourceKind(source))
@@ -155,11 +155,7 @@ public final class CameraServer {
     return values;
   }
 
-  @SuppressWarnings({
-    "MissingJavadocMethod",
-    "PMD.AvoidUsingHardCodedIP",
-    "PMD.CyclomaticComplexity"
-  })
+  @SuppressWarnings("MissingJavadocMethod")
   private synchronized void updateStreamValues() {
     // Over all the sinks...
     for (VideoSink i : m_sinks.values()) {
@@ -247,7 +243,7 @@ public final class CameraServer {
     return modeStrings;
   }
 
-  @SuppressWarnings({"MissingJavadocMethod", "PMD.CyclomaticComplexity"})
+  @SuppressWarnings("MissingJavadocMethod")
   private static void putSourcePropertyValue(NetworkTable table, VideoEvent event, boolean isNew) {
     String name;
     String infoName;
@@ -304,12 +300,7 @@ public final class CameraServer {
     }
   }
 
-  @SuppressWarnings({
-    "MissingJavadocMethod",
-    "PMD.UnusedLocalVariable",
-    "PMD.ExcessiveMethodLength",
-    "PMD.NPathComplexity"
-  })
+  @SuppressWarnings("MissingJavadocMethod")
   private CameraServer() {
     m_defaultUsbDevice = new AtomicInteger();
     m_sources = new HashMap<>();

--- a/cscore/src/main/java/edu/wpi/first/cscore/VideoEvent.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/VideoEvent.java
@@ -46,7 +46,6 @@ public class VideoEvent {
    * @param kind The numerical representation of kind
    * @return The kind
    */
-  @SuppressWarnings("PMD.CyclomaticComplexity")
   public static Kind getKindFromInt(int kind) {
     switch (kind) {
       case 0x0001:
@@ -92,7 +91,6 @@ public class VideoEvent {
     }
   }
 
-  @SuppressWarnings("PMD.ExcessiveParameterList")
   VideoEvent(
       int kind,
       int source,

--- a/cscore/src/main/java/edu/wpi/first/cscore/VideoSink.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/VideoSink.java
@@ -112,7 +112,6 @@ public class VideoSink implements AutoCloseable {
   }
 
   /** Enumerate all properties of this sink. */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   public VideoProperty[] enumerateProperties() {
     int[] handles = CameraServerJNI.enumerateSinkProperties(m_handle);
     VideoProperty[] rv = new VideoProperty[handles.length];
@@ -195,7 +194,6 @@ public class VideoSink implements AutoCloseable {
    *
    * @return Vector of sinks.
    */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   public static VideoSink[] enumerateSinks() {
     int[] handles = CameraServerJNI.enumerateSinks();
     VideoSink[] rv = new VideoSink[handles.length];

--- a/cscore/src/main/java/edu/wpi/first/cscore/VideoSource.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/VideoSource.java
@@ -179,7 +179,6 @@ public class VideoSource implements AutoCloseable {
   }
 
   /** Enumerate all properties of this source. */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   public VideoProperty[] enumerateProperties() {
     int[] handles = CameraServerJNI.enumerateSourceProperties(m_handle);
     VideoProperty[] rv = new VideoProperty[handles.length];
@@ -323,7 +322,6 @@ public class VideoSource implements AutoCloseable {
    *
    * @return Vector of sinks.
    */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   public VideoSink[] enumerateSinks() {
     int[] handles = CameraServerJNI.enumerateSourceSinks(m_handle);
     VideoSink[] rv = new VideoSink[handles.length];
@@ -338,7 +336,6 @@ public class VideoSource implements AutoCloseable {
    *
    * @return Vector of sources.
    */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   public static VideoSource[] enumerateSources() {
     int[] handles = CameraServerJNI.enumerateSources();
     VideoSource[] rv = new VideoSource[handles.length];

--- a/hal/src/generate/FRCNetComm.java.in
+++ b/hal/src/generate/FRCNetComm.java.in
@@ -12,7 +12,7 @@ public class FRCNetComm {
   /**
    * Resource type from UsageReporting.
    */
-  @SuppressWarnings({"TypeName", "PMD.ConstantsInInterface"})
+  @SuppressWarnings("TypeName")
   public static final class tResourceType {
     private tResourceType() {
     }
@@ -23,7 +23,7 @@ ${usage_reporting_types}
   /**
    * Instances from UsageReporting.
    */
-  @SuppressWarnings({"TypeName", "PMD.ConstantsInInterface"})
+  @SuppressWarnings("TypeName")
   public static final class tInstances {
     private tInstances() {
     }

--- a/hal/src/main/java/edu/wpi/first/hal/can/CANExceptionFactory.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANExceptionFactory.java
@@ -14,7 +14,7 @@ public final class CANExceptionFactory {
   static final int ERR_CANSessionMux_NotAllowed = -44088;
   static final int ERR_CANSessionMux_NotInitialized = -44089;
 
-  @SuppressWarnings({"MissingJavadocMethod", "PMD.CyclomaticComplexity"})
+  @SuppressWarnings("MissingJavadocMethod")
   public static void checkStatus(int status, int messageID)
       throws CANInvalidBufferException, CANMessageNotAllowedException, CANNotInitializedException,
           UncleanStatusException {

--- a/ntcore/build.gradle
+++ b/ntcore/build.gradle
@@ -43,9 +43,3 @@ nativeUtils.exportsConfigs {
         }
     }
 }
-
-if (!project.hasProperty('skipPMD')) {
-    pmdMain {
-        pmdMain.enabled = false
-    }
-}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableEntry.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableEntry.java
@@ -853,6 +853,6 @@ public final class NetworkTableEntry {
     return m_handle;
   }
 
-  private NetworkTableInstance m_inst;
-  private int m_handle;
+  private final NetworkTableInstance m_inst;
+  private final int m_handle;
 }

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableInstance.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableInstance.java
@@ -161,7 +161,7 @@ public final class NetworkTableInstance implements AutoCloseable {
   public NetworkTable getTable(String key) {
     // prepend leading / if not present
     String theKey;
-    if (key.isEmpty() || key.equals("/")) {
+    if (key.isEmpty() || "/".equals(key)) {
       theKey = "";
     } else if (key.charAt(0) == NetworkTable.PATH_SEPARATOR) {
       theKey = key;
@@ -202,13 +202,13 @@ public final class NetworkTableInstance implements AutoCloseable {
 
   private final ReentrantLock m_entryListenerLock = new ReentrantLock();
   private final Map<Integer, EntryConsumer<EntryNotification>> m_entryListeners = new HashMap<>();
-  private Thread m_entryListenerThread;
   private int m_entryListenerPoller;
   private boolean m_entryListenerWaitQueue;
   private final Condition m_entryListenerWaitQueueCond = m_entryListenerLock.newCondition();
 
+  @SuppressWarnings("PMD.AvoidCatchingThrowable")
   private void startEntryListenerThread() {
-    m_entryListenerThread =
+    var entryListenerThread =
         new Thread(
             () -> {
               boolean wasInterrupted = false;
@@ -264,8 +264,8 @@ public final class NetworkTableInstance implements AutoCloseable {
               }
             },
             "NTEntryListener");
-    m_entryListenerThread.setDaemon(true);
-    m_entryListenerThread.start();
+    entryListenerThread.setDaemon(true);
+    entryListenerThread.start();
   }
 
   /**
@@ -369,14 +369,14 @@ public final class NetworkTableInstance implements AutoCloseable {
   private final ReentrantLock m_connectionListenerLock = new ReentrantLock();
   private final Map<Integer, Consumer<ConnectionNotification>> m_connectionListeners =
       new HashMap<>();
-  private Thread m_connectionListenerThread;
   private int m_connectionListenerPoller;
   private boolean m_connectionListenerWaitQueue;
   private final Condition m_connectionListenerWaitQueueCond =
       m_connectionListenerLock.newCondition();
 
+  @SuppressWarnings("PMD.AvoidCatchingThrowable")
   private void startConnectionListenerThread() {
-    m_connectionListenerThread =
+    var connectionListenerThread =
         new Thread(
             () -> {
               boolean wasInterrupted = false;
@@ -432,8 +432,8 @@ public final class NetworkTableInstance implements AutoCloseable {
               }
             },
             "NTConnectionListener");
-    m_connectionListenerThread.setDaemon(true);
-    m_connectionListenerThread.start();
+    connectionListenerThread.setDaemon(true);
+    connectionListenerThread.start();
   }
 
   /**
@@ -519,13 +519,13 @@ public final class NetworkTableInstance implements AutoCloseable {
 
   private final ReentrantLock m_rpcCallLock = new ReentrantLock();
   private final Map<Integer, EntryConsumer<RpcAnswer>> m_rpcCalls = new HashMap<>();
-  private Thread m_rpcCallThread;
   private int m_rpcCallPoller;
   private boolean m_rpcCallWaitQueue;
   private final Condition m_rpcCallWaitQueueCond = m_rpcCallLock.newCondition();
 
+  @SuppressWarnings("PMD.AvoidCatchingThrowable")
   private void startRpcCallThread() {
-    m_rpcCallThread =
+    var rpcCallThread =
         new Thread(
             () -> {
               boolean wasInterrupted = false;
@@ -581,8 +581,8 @@ public final class NetworkTableInstance implements AutoCloseable {
               }
             },
             "NTRpcCall");
-    m_rpcCallThread.setDaemon(true);
-    m_rpcCallThread.start();
+    rpcCallThread.setDaemon(true);
+    rpcCallThread.start();
   }
 
   private static final byte[] rev0def = new byte[] {0};
@@ -999,13 +999,13 @@ public final class NetworkTableInstance implements AutoCloseable {
 
   private final ReentrantLock m_loggerLock = new ReentrantLock();
   private final Map<Integer, Consumer<LogMessage>> m_loggers = new HashMap<>();
-  private Thread m_loggerThread;
   private int m_loggerPoller;
   private boolean m_loggerWaitQueue;
   private final Condition m_loggerWaitQueueCond = m_loggerLock.newCondition();
 
+  @SuppressWarnings("PMD.AvoidCatchingThrowable")
   private void startLogThread() {
-    m_loggerThread =
+    var loggerThread =
         new Thread(
             () -> {
               boolean wasInterrupted = false;
@@ -1049,8 +1049,8 @@ public final class NetworkTableInstance implements AutoCloseable {
               }
             },
             "NTLogger");
-    m_loggerThread.setDaemon(true);
-    m_loggerThread.start();
+    loggerThread.setDaemon(true);
+    loggerThread.start();
   }
 
   /**
@@ -1149,5 +1149,5 @@ public final class NetworkTableInstance implements AutoCloseable {
   }
 
   private boolean m_owned;
-  private int m_handle;
+  private final int m_handle;
 }

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableValue.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableValue.java
@@ -183,6 +183,7 @@ public final class NetworkTableValue {
    * @return The raw value.
    * @throws ClassCastException if the entry value is not of raw type.
    */
+  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public byte[] getRaw() {
     if (m_type != NetworkTableType.kRaw) {
       throw new ClassCastException("cannot convert " + m_type + " to raw");
@@ -196,6 +197,7 @@ public final class NetworkTableValue {
    * @return The rpc definition value.
    * @throws ClassCastException if the entry value is not of rpc definition type.
    */
+  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public byte[] getRpc() {
     if (m_type != NetworkTableType.kRpc) {
       throw new ClassCastException("cannot convert " + m_type + " to rpc");
@@ -209,6 +211,7 @@ public final class NetworkTableValue {
    * @return The boolean array value.
    * @throws ClassCastException if the entry value is not of boolean array type.
    */
+  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public boolean[] getBooleanArray() {
     if (m_type != NetworkTableType.kBooleanArray) {
       throw new ClassCastException("cannot convert " + m_type + " to boolean array");
@@ -222,6 +225,7 @@ public final class NetworkTableValue {
    * @return The double array value.
    * @throws ClassCastException if the entry value is not of double array type.
    */
+  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public double[] getDoubleArray() {
     if (m_type != NetworkTableType.kDoubleArray) {
       throw new ClassCastException("cannot convert " + m_type + " to double array");
@@ -235,6 +239,7 @@ public final class NetworkTableValue {
    * @return The string array value.
    * @throws ClassCastException if the entry value is not of string array type.
    */
+  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public String[] getStringArray() {
     if (m_type != NetworkTableType.kStringArray) {
       throw new ClassCastException("cannot convert " + m_type + " to string array");
@@ -475,33 +480,25 @@ public final class NetworkTableValue {
 
   static boolean[] toNative(Boolean[] arr) {
     boolean[] out = new boolean[arr.length];
-    for (int i = 0; i < arr.length; i++) {
-      out[i] = arr[i];
-    }
+    System.arraycopy(arr, 0, out, 0, arr.length);
     return out;
   }
 
   static double[] toNative(Number[] arr) {
     double[] out = new double[arr.length];
-    for (int i = 0; i < arr.length; i++) {
-      out[i] = arr[i].doubleValue();
-    }
+    System.arraycopy(arr, 0, out, 0, arr.length);
     return out;
   }
 
   static Boolean[] fromNative(boolean[] arr) {
     Boolean[] out = new Boolean[arr.length];
-    for (int i = 0; i < arr.length; i++) {
-      out[i] = arr[i];
-    }
+    System.arraycopy(arr, 0, out, 0, arr.length);
     return out;
   }
 
   static Double[] fromNative(double[] arr) {
     Double[] out = new Double[arr.length];
-    for (int i = 0; i < arr.length; i++) {
-      out[i] = arr[i];
-    }
+    System.arraycopy(arr, 0, out, 0, arr.length);
     return out;
   }
 

--- a/ntcore/src/main/java/edu/wpi/first/networktables/RpcAnswer.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/RpcAnswer.java
@@ -36,6 +36,7 @@ public final class RpcAnswer {
    * @param params Call raw parameters
    * @param conn Connection info
    */
+  @SuppressWarnings("PMD.ArrayIsStoredDirectly")
   public RpcAnswer(
       NetworkTableInstance inst,
       int entry,

--- a/ntcore/src/test/java/edu/wpi/first/networktables/ConnectionListenerTest.java
+++ b/ntcore/src/test/java/edu/wpi/first/networktables/ConnectionListenerTest.java
@@ -41,7 +41,6 @@ class ConnectionListenerTest {
   }
 
   /** Connect to the server. */
-  @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
   private void connect() {
     m_serverInst.startServer("connectionlistenertest.ini", "127.0.0.1", 10000);
     m_clientInst.startClient("127.0.0.1", 10000);
@@ -109,7 +108,6 @@ class ConnectionListenerTest {
 
   @ParameterizedTest
   @DisabledOnOs(OS.WINDOWS)
-  @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
   @ValueSource(strings = {"127.0.0.1", "127.0.0.1 ", " 127.0.0.1 "})
   void testThreaded(String address) {
     m_serverInst.startServer("connectionlistenertest.ini", address, 10000);

--- a/ntcore/src/test/java/edu/wpi/first/networktables/EntryListenerTest.java
+++ b/ntcore/src/test/java/edu/wpi/first/networktables/EntryListenerTest.java
@@ -34,7 +34,6 @@ class EntryListenerTest {
     m_serverInst.close();
   }
 
-  @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
   private void connect() {
     m_serverInst.startServer("connectionlistenertest.ini", "127.0.0.1", 10000);
     m_clientInst.startClient("127.0.0.1", 10000);

--- a/ntcore/src/test/java/edu/wpi/first/networktables/LoggerTest.java
+++ b/ntcore/src/test/java/edu/wpi/first/networktables/LoggerTest.java
@@ -27,7 +27,6 @@ class LoggerTest {
   }
 
   @Test
-  @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
   void addMessageTest() {
     List<LogMessage> msgs = new ArrayList<>();
     m_clientInst.addLogger(msgs::add, LogMessage.kInfo, 100);

--- a/styleguide/pmd-ruleset.xml
+++ b/styleguide/pmd-ruleset.xml
@@ -14,11 +14,14 @@
     <exclude name="AccessorMethodGeneration" />
     <exclude name="AvoidPrintStackTrace" />
     <exclude name="AvoidReassigningParameters" />
+    <exclude name="AvoidUsingHardCodedIP" />
+    <exclude name="ConstantsInInterface" />
     <exclude name="JUnitAssertionsShouldIncludeMessage" />
     <exclude name="JUnitTestContainsTooManyAsserts" />
     <exclude name="JUnit4TestShouldUseAfterAnnotation" />
     <exclude name="JUnit4TestShouldUseBeforeAnnotation" />
     <exclude name="JUnit4TestShouldUseTestAnnotation" />
+    <exclude name="LooseCoupling" />
     <exclude name="ReplaceHashtableWithMap" />
     <exclude name="ReplaceVectorWithList" />
     <exclude name="SwitchStmtsShouldHaveDefault" />
@@ -33,12 +36,22 @@
   </rule>
 
   <rule ref="category/java/design.xml">
+    <exclude name="AvoidThrowingRawExceptionTypes" />
+    <exclude name="CyclomaticComplexity" />
     <exclude name="DataClass" />
+    <exclude name="ExcessiveClassLength" />
+    <exclude name="ExcessiveImports" />
+    <exclude name="ExcessiveMethodLength" />
+    <exclude name="ExcessiveParameterList" />
+    <exclude name="ExcessivePublicCount" />
+    <exclude name="GodClass" />
     <exclude name="LawOfDemeter" />
     <exclude name="LoosePackageCoupling" />
+    <exclude name="NPathComplexity" />
     <exclude name="NcssConstructorCount" />
     <exclude name="NcssCount" />
     <exclude name="NcssMethodCount" />
+    <exclude name="TooManyFields" />
     <exclude name="TooManyMethods" />
   </rule>
 
@@ -65,6 +78,7 @@
 
   <rule ref="category/java/performance.xml">
     <exclude name="AvoidUsingShortType" />
+    <exclude name="AvoidInstantiatingObjectsInLoops" />
   </rule>
 
   <rule name="UnnecessaryCastRule" language="java"

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandBase.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandBase.java
@@ -11,7 +11,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 /** A {@link Sendable} base class for {@link Command}s. */
-@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
 public abstract class CommandBase implements Sendable, Command {
 
   protected Set<Subsystem> m_requirements = new HashSet<>();

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -34,7 +34,6 @@ import java.util.function.Consumer;
  * CommandScheduler#registerSubsystem(Subsystem...)} in order for their {@link Subsystem#periodic()}
  * methods to be called and for their default commands to be scheduled.
  */
-@SuppressWarnings({"PMD.GodClass", "PMD.TooManyFields"})
 public final class CommandScheduler implements Sendable, AutoCloseable {
   /** The Singleton Instance. */
   private static CommandScheduler instance;
@@ -157,7 +156,6 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
    * @param interruptible whether this command can be interrupted
    * @param command the command to schedule
    */
-  @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
   private void schedule(boolean interruptible, Command command) {
     if (m_inRunLoop) {
       m_toSchedule.put(command, interruptible);
@@ -239,7 +237,6 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
    *
    * <p>Any subsystems not being used as requirements have their default methods started.
    */
-  @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
   public void run() {
     if (m_disabled) {
       return;

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommand.java
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
  * <p>The robot angle controller does not follow the angle given by the trajectory but rather goes
  * to the angle given in the final state of the trajectory.
  */
-@SuppressWarnings({"PMD.TooManyFields", "MemberName"})
+@SuppressWarnings("MemberName")
 public class MecanumControllerCommand extends CommandBase {
   private final Timer m_timer = new Timer();
   private final boolean m_usePID;
@@ -85,7 +85,7 @@ public class MecanumControllerCommand extends CommandBase {
    *     voltages.
    * @param requirements The subsystems to require.
    */
-  @SuppressWarnings({"PMD.ExcessiveParameterList", "ParameterName"})
+  @SuppressWarnings("ParameterName")
   public MecanumControllerCommand(
       Trajectory trajectory,
       Supplier<Pose2d> pose,
@@ -177,7 +177,7 @@ public class MecanumControllerCommand extends CommandBase {
    *     voltages.
    * @param requirements The subsystems to require.
    */
-  @SuppressWarnings({"PMD.ExcessiveParameterList", "ParameterName"})
+  @SuppressWarnings("ParameterName")
   public MecanumControllerCommand(
       Trajectory trajectory,
       Supplier<Pose2d> pose,
@@ -235,7 +235,7 @@ public class MecanumControllerCommand extends CommandBase {
    * @param outputWheelSpeeds A MecanumDriveWheelSpeeds object containing the output wheel speeds.
    * @param requirements The subsystems to require.
    */
-  @SuppressWarnings({"PMD.ExcessiveParameterList", "ParameterName"})
+  @SuppressWarnings("ParameterName")
   public MecanumControllerCommand(
       Trajectory trajectory,
       Supplier<Pose2d> pose,
@@ -307,7 +307,7 @@ public class MecanumControllerCommand extends CommandBase {
    * @param outputWheelSpeeds A MecanumDriveWheelSpeeds object containing the output wheel speeds.
    * @param requirements The subsystems to require.
    */
-  @SuppressWarnings({"PMD.ExcessiveParameterList", "ParameterName"})
+  @SuppressWarnings("ParameterName")
   public MecanumControllerCommand(
       Trajectory trajectory,
       Supplier<Pose2d> pose,

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RamseteCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RamseteCommand.java
@@ -30,7 +30,6 @@ import java.util.function.Supplier;
  * functionality of a "smart" motor controller) may use the secondary constructor that omits the PID
  * and feedforward functionality, returning only the raw wheel speeds from the RAMSETE controller.
  */
-@SuppressWarnings("PMD.TooManyFields")
 public class RamseteCommand extends CommandBase {
   private final Timer m_timer = new Timer();
   private final boolean m_usePID;
@@ -68,7 +67,6 @@ public class RamseteCommand extends CommandBase {
    *     the robot drive.
    * @param requirements The subsystems to require.
    */
-  @SuppressWarnings("PMD.ExcessiveParameterList")
   public RamseteCommand(
       Trajectory trajectory,
       Supplier<Pose2d> pose,

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandTestBase.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandTestBase.java
@@ -13,8 +13,9 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 
 /** Basic setup for all {@link Command tests}." */
-@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
 public abstract class CommandTestBase {
+  protected CommandTestBase() {}
+
   @BeforeEach
   void commandSetup() {
     CommandScheduler.getInstance().cancelAll();

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommandTest.java
@@ -87,7 +87,6 @@ class MecanumControllerCommandTest {
 
   @Test
   @ResourceLock("timing")
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   void testReachesReference() {
     final var subsystem = new Subsystem() {};
 

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommandTest.java
@@ -82,7 +82,6 @@ class SwerveControllerCommandTest {
 
   @Test
   @ResourceLock("timing")
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   void testReachesReference() {
     final var subsystem = new Subsystem() {};
 

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
@@ -27,7 +27,6 @@ import java.util.concurrent.locks.ReentrantLock;
  * @deprecated All APIs which use this have been deprecated.
  */
 @Deprecated(since = "2020", forRemoval = true)
-@SuppressWarnings("PMD.TooManyFields")
 public class PIDBase implements PIDInterface, PIDOutput, Sendable, AutoCloseable {
   public static final double kDefaultPeriod = 0.05;
   private static int instances;
@@ -80,9 +79,6 @@ public class PIDBase implements PIDInterface, PIDOutput, Sendable, AutoCloseable
 
   private double m_setpoint;
   private double m_prevSetpoint;
-
-  @SuppressWarnings("PMD.UnusedPrivateField")
-  private double m_error;
 
   private double m_result;
 
@@ -199,7 +195,7 @@ public class PIDBase implements PIDInterface, PIDOutput, Sendable, AutoCloseable
    * Read the input, calculate the output accordingly, and write to the output. This should only be
    * called by the PIDTask and is created during initialization.
    */
-  @SuppressWarnings({"LocalVariableName", "PMD.ExcessiveMethodLength", "PMD.NPathComplexity"})
+  @SuppressWarnings("LocalVariableName")
   protected void calculate() {
     if (m_pidInput == null || m_pidOutput == null) {
       return;
@@ -291,7 +287,6 @@ public class PIDBase implements PIDInterface, PIDOutput, Sendable, AutoCloseable
       m_thisMutex.lock();
       try {
         m_prevError = error;
-        m_error = error;
         m_totalError = totalError;
         m_result = result;
       } finally {

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/Command.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/Command.java
@@ -36,7 +36,6 @@ import java.util.Enumeration;
  * @see CommandGroup
  * @see IllegalUseOfCommandException
  */
-@SuppressWarnings("PMD.GodClass")
 public abstract class Command implements Sendable, AutoCloseable {
   /** The time since this command was initialized. */
   private double m_startTime = -1;

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/CommandGroup.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/CommandGroup.java
@@ -30,13 +30,13 @@ import java.util.Vector;
  */
 public class CommandGroup extends Command {
   /** The commands in this group (stored in entries). */
-  @SuppressWarnings({"PMD.LooseCoupling", "PMD.UseArrayListInsteadOfVector"})
+  @SuppressWarnings("PMD.UseArrayListInsteadOfVector")
   private final Vector<Entry> m_commands = new Vector<>();
   /*
    * Intentionally package private
    */
   /** The active children in this group (stored in entries). */
-  @SuppressWarnings({"PMD.LooseCoupling", "PMD.UseArrayListInsteadOfVector"})
+  @SuppressWarnings("PMD.UseArrayListInsteadOfVector")
   final Vector<Entry> m_children = new Vector<>();
   /** The current command, -1 signifies that none have been run. */
   private int m_currentCommandIndex = -1;
@@ -205,7 +205,7 @@ public class CommandGroup extends Command {
   }
 
   @Override
-  @SuppressWarnings({"MethodName", "PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
+  @SuppressWarnings("MethodName")
   void _execute() {
     Entry entry = null;
     Command cmd = null;

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/Scheduler.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/Scheduler.java
@@ -15,6 +15,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.Vector;
 
 /**
@@ -46,8 +47,7 @@ public final class Scheduler implements Sendable, AutoCloseable {
   }
 
   /** A hashtable of active {@link Command Commands} to their {@link LinkedListElement}. */
-  @SuppressWarnings("PMD.LooseCoupling")
-  private final Hashtable<Command, LinkedListElement> m_commandTable = new Hashtable<>();
+  private final Map<Command, LinkedListElement> m_commandTable = new Hashtable<>();
   /** The {@link Set} of all {@link Subsystem Subsystems}. */
   private final Set m_subsystems = new Set();
   /** The first {@link Command} in the list. */
@@ -59,13 +59,12 @@ public final class Scheduler implements Sendable, AutoCloseable {
   /** Whether or not we are currently disabled. */
   private boolean m_disabled;
   /** A list of all {@link Command Commands} which need to be added. */
-  @SuppressWarnings({"PMD.LooseCoupling", "PMD.UseArrayListInsteadOfVector"})
+  @SuppressWarnings("PMD.UseArrayListInsteadOfVector")
   private final Vector<Command> m_additions = new Vector<>();
   /**
    * A list of all {@link edu.wpi.first.wpilibj.buttons.Trigger.ButtonScheduler Buttons}. It is
    * created lazily.
    */
-  @SuppressWarnings("PMD.LooseCoupling")
   private Vector<ButtonScheduler> m_buttons;
 
   private boolean m_runningCommandsChanged;
@@ -129,7 +128,7 @@ public final class Scheduler implements Sendable, AutoCloseable {
    *
    * @param command the {@link Command} to add
    */
-  @SuppressWarnings({"MethodName", "PMD.CyclomaticComplexity"})
+  @SuppressWarnings("MethodName")
   private void _add(Command command) {
     if (command == null) {
       return;
@@ -194,7 +193,6 @@ public final class Scheduler implements Sendable, AutoCloseable {
    *   <li>Add Defaults
    * </ol>
    */
-  @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
   public void run() {
     m_runningCommandsChanged = false;
 

--- a/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTabTest.java
+++ b/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTabTest.java
@@ -135,7 +135,7 @@ public class ShuffleboardTabTest {
   }
 
   /** Stub for Java 9 {@code Map.of()}. */
-  @SuppressWarnings({"unchecked", "PMD"})
+  @SuppressWarnings("unchecked")
   private static <K, V> Map<K, V> mapOf(Object... entries) {
     Map<K, V> map = new HashMap<>();
     for (int i = 0; i < entries.length; i += 2) {

--- a/wpilibc/src/main/native/include/frc/simulation/BatterySim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/BatterySim.h
@@ -12,6 +12,9 @@
 
 namespace frc::sim {
 
+/**
+ * A utility class to simulate the robot battery.
+ */
 class BatterySim {
  public:
   /**

--- a/wpilibc/src/main/native/include/frc/simulation/RoboRioSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/RoboRioSim.h
@@ -14,7 +14,7 @@
 namespace frc::sim {
 
 /**
- * Class to control a simulated RoboRIO.
+ * A utility class to control a simulated RoboRIO.
  */
 class RoboRioSim {
  public:

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL362.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL362.java
@@ -21,7 +21,6 @@ import java.nio.ByteOrder;
  *
  * <p>This class allows access to an Analog Devices ADXL362 3-axis accelerometer.
  */
-@SuppressWarnings("PMD.UnusedPrivateField")
 public class ADXL362 implements Accelerometer, Sendable, AutoCloseable {
   private static final byte kRegWrite = 0x0A;
   private static final byte kRegRead = 0x0B;
@@ -37,7 +36,10 @@ public class ADXL362 implements Accelerometer, Sendable, AutoCloseable {
   private static final byte kFilterCtl_ODR_100Hz = 0x03;
 
   private static final byte kPowerCtl_UltraLowNoise = 0x20;
+
+  @SuppressWarnings("PMD.UnusedPrivateField")
   private static final byte kPowerCtl_AutoSleep = 0x04;
+
   private static final byte kPowerCtl_Measure = 0x02;
 
   public enum Axes {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalGlitchFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalGlitchFilter.java
@@ -163,7 +163,6 @@ public class DigitalGlitchFilter implements Sendable, AutoCloseable {
   }
 
   @Override
-  @SuppressWarnings("PMD.UnusedFormalParameter")
   public void initSendable(SendableBuilder builder) {}
 
   private int m_channelIndex = -1;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -18,13 +18,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /** Provide access to the network communication data to / from the Driver Station. */
-@SuppressWarnings({
-  "PMD.CyclomaticComplexity",
-  "PMD.ExcessiveClassLength",
-  "PMD.ExcessivePublicCount",
-  "PMD.GodClass",
-  "PMD.TooManyFields"
-})
 public class DriverStation {
   /** Number of Joystick Ports. */
   public static final int kJoystickPorts = 6;
@@ -162,7 +155,6 @@ public class DriverStation {
       controlWord.forceSetDouble(0);
     }
 
-    @SuppressWarnings("PMD.NPathComplexity")
     private void sendMatchData(DriverStation driverStation) {
       AllianceStationID allianceID = HAL.getAllianceStation();
       boolean isRedAlliance = false;
@@ -268,8 +260,7 @@ public class DriverStation {
   private final MatchDataSender m_matchDataSender;
 
   // Internal Driver Station thread
-  @SuppressWarnings("PMD.SingularField")
-  private final Thread m_thread;
+  private Thread m_thread;
 
   private volatile boolean m_threadKeepAlive = true;
 
@@ -308,7 +299,6 @@ public class DriverStation {
    * <p>The single DriverStation instance is created statically with the instance static member
    * variable.
    */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   private DriverStation() {
     HAL.initialize(500, 0);
     m_waitForDataCount = 0;
@@ -340,6 +330,14 @@ public class DriverStation {
   /** Kill the thread. */
   public void release() {
     m_threadKeepAlive = false;
+    if (m_thread != null) {
+      try {
+        m_thread.join();
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+      }
+      m_thread = null;
+    }
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/I2C.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/I2C.java
@@ -18,7 +18,6 @@ import java.nio.ByteBuffer;
  * <p>This class is intended to be used by sensor (and other I2C device) drivers. It probably should
  * not be used directly.
  */
-@SuppressWarnings("PMD.GodClass")
 public class I2C implements AutoCloseable {
   public enum Port {
     kOnboard(0),
@@ -99,7 +98,7 @@ public class I2C implements AutoCloseable {
    * @param receiveSize Number of bytes to read from the device.
    * @return Transfer Aborted... false for success, true for aborted.
    */
-  @SuppressWarnings({"PMD.CyclomaticComplexity", "ByteBufferBackingArray"})
+  @SuppressWarnings("ByteBufferBackingArray")
   public synchronized boolean transaction(
       ByteBuffer dataToSend, int sendSize, ByteBuffer dataReceived, int receiveSize) {
     if (dataToSend.hasArray() && dataReceived.hasArray()) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -208,7 +208,6 @@ public abstract class IterativeRobotBase extends RobotBase {
     return m_period;
   }
 
-  @SuppressWarnings("PMD.CyclomaticComplexity")
   protected void loopFunc() {
     m_watchdog.reset();
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Relay.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Relay.java
@@ -163,7 +163,6 @@ public class Relay extends MotorSafety implements Sendable, AutoCloseable {
    *
    * @param value The state to set the relay.
    */
-  @SuppressWarnings("PMD.CyclomaticComplexity")
   public void set(Value value) {
     switch (value) {
       case kOff:

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -277,10 +277,7 @@ public abstract class RobotBase implements AutoCloseable {
   private static boolean m_suppressExitWarning;
 
   /** Run the robot main loop. */
-  @SuppressWarnings({
-    "PMD.AvoidInstantiatingObjectsInLoops", "PMD.AvoidCatchingThrowable",
-    "PMD.CyclomaticComplexity", "PMD.NPathComplexity"
-  })
+  @SuppressWarnings("PMD.AvoidCatchingThrowable")
   private static <T extends RobotBase> void runRobot(Supplier<T> robotSupplier) {
     System.out.println("********** Robot program starting **********");
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SPI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SPI.java
@@ -13,7 +13,6 @@ import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 
 /** Represents a SPI bus port. */
-@SuppressWarnings("PMD.CyclomaticComplexity")
 public class SPI implements AutoCloseable {
   public enum Port {
     kOnboardCS0(0),
@@ -258,7 +257,7 @@ public class SPI implements AutoCloseable {
    * @param dataReceived Buffer to receive data from the device.
    * @param size The length of the transaction, in bytes
    */
-  @SuppressWarnings({"PMD.CyclomaticComplexity", "ByteBufferBackingArray"})
+  @SuppressWarnings("ByteBufferBackingArray")
   public int transaction(ByteBuffer dataToSend, ByteBuffer dataReceived, int size) {
     if (dataToSend.hasArray() && dataReceived.hasArray()) {
       return transaction(dataToSend.array(), dataReceived.array(), size);
@@ -425,7 +424,6 @@ public class SPI implements AutoCloseable {
 
   private static final int kAccumulateDepth = 2048;
 
-  @SuppressWarnings("PMD.TooManyFields")
   private static class Accumulator implements AutoCloseable {
     Accumulator(
         int port,
@@ -482,7 +480,6 @@ public class SPI implements AutoCloseable {
     final boolean m_bigEndian; // is response big endian?
     final int m_port;
 
-    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     void update() {
       synchronized (m_mutex) {
         boolean done = false;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SpeedControllerGroup.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SpeedControllerGroup.java
@@ -26,14 +26,11 @@ public class SpeedControllerGroup implements MotorController, Sendable, AutoClos
    *
    * @param speedControllers The SpeedControllers to add
    */
-  @SuppressWarnings("PMD.AvoidArrayLoops")
   public SpeedControllerGroup(
       SpeedController speedController, SpeedController... speedControllers) {
     m_speedControllers = new SpeedController[speedControllers.length + 1];
     m_speedControllers[0] = speedController;
-    for (int i = 0; i < speedControllers.length; i++) {
-      m_speedControllers[i + 1] = speedControllers[i];
-    }
+    System.arraycopy(speedControllers, 0, m_speedControllers, 1, speedControllers.length);
     init();
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/XboxController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/XboxController.java
@@ -28,7 +28,7 @@ public class XboxController extends GenericHID {
     kBack(7),
     kStart(8);
 
-    @SuppressWarnings({"MemberName", "PMD.SingularField"})
+    @SuppressWarnings("MemberName")
     public final int value;
 
     Button(int value) {
@@ -45,7 +45,7 @@ public class XboxController extends GenericHID {
     kLeftTrigger(2),
     kRightTrigger(3);
 
-    @SuppressWarnings({"MemberName", "PMD.SingularField"})
+    @SuppressWarnings("MemberName")
     public final int value;
 
     Axis(int value) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
@@ -12,7 +12,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /** Implements a PID control loop. */
-@SuppressWarnings("PMD.TooManyFields")
 public class PIDController implements Sendable, AutoCloseable {
   private static int instances;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -4,6 +4,8 @@
 
 package edu.wpi.first.wpilibj.drive;
 
+import static java.util.Objects.requireNonNull;
+
 import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
@@ -12,7 +14,6 @@ import edu.wpi.first.wpilibj.Sendable;
 import edu.wpi.first.wpilibj.SpeedController;
 import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
-import java.util.StringJoiner;
 
 /**
  * A class for driving differential drive/skid-steer drive platforms such as the Kit of Parts drive
@@ -121,7 +122,9 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * so before passing it in.
    */
   public DifferentialDrive(SpeedController leftMotor, SpeedController rightMotor) {
-    verify(leftMotor, rightMotor);
+    requireNonNull(leftMotor, "Left motor cannot be null");
+    requireNonNull(rightMotor, "Right motor cannot be null");
+
     m_leftMotor = leftMotor;
     m_rightMotor = rightMotor;
     SendableRegistry.addChild(this, m_leftMotor);
@@ -133,29 +136,6 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
   @Override
   public void close() {
     SendableRegistry.remove(this);
-  }
-
-  /**
-   * Verifies that all motors are nonnull, throwing a NullPointerException if any of them are. The
-   * exception's error message will specify all null motors, e.g. {@code
-   * NullPointerException("leftMotor, rightMotor")}, to give as much information as possible to the
-   * programmer.
-   *
-   * @throws NullPointerException if any of the given motors are null
-   */
-  @SuppressWarnings("PMD.AvoidThrowingNullPointerException")
-  private void verify(SpeedController leftMotor, SpeedController rightMotor) {
-    if (leftMotor != null && rightMotor != null) {
-      return;
-    }
-    StringJoiner joiner = new StringJoiner(", ");
-    if (leftMotor == null) {
-      joiner.add("leftMotor");
-    }
-    if (rightMotor == null) {
-      joiner.add("rightMotor");
-    }
-    throw new NullPointerException(joiner.toString());
   }
 
   /**
@@ -212,7 +192,7 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * @param allowTurnInPlace If set, overrides constant-curvature turning for turn-in-place
    *     maneuvers.
    */
-  @SuppressWarnings({"ParameterName", "PMD.CyclomaticComplexity"})
+  @SuppressWarnings("ParameterName")
   public void curvatureDrive(double xSpeed, double zRotation, boolean allowTurnInPlace) {
     if (!m_reported) {
       HAL.report(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
@@ -4,6 +4,8 @@
 
 package edu.wpi.first.wpilibj.drive;
 
+import static java.util.Objects.requireNonNull;
+
 import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
@@ -12,7 +14,6 @@ import edu.wpi.first.wpilibj.Sendable;
 import edu.wpi.first.wpilibj.SpeedController;
 import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
-import java.util.StringJoiner;
 
 /**
  * A class for driving Killough drive platforms.
@@ -122,7 +123,10 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
       double leftMotorAngle,
       double rightMotorAngle,
       double backMotorAngle) {
-    verify(leftMotor, rightMotor, backMotor);
+    requireNonNull(leftMotor, "Left motor cannot be null");
+    requireNonNull(rightMotor, "Right motor cannot be null");
+    requireNonNull(backMotor, "Back motor cannot be null");
+
     m_leftMotor = leftMotor;
     m_rightMotor = rightMotor;
     m_backMotor = backMotor;
@@ -148,33 +152,6 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
   @Override
   public void close() {
     SendableRegistry.remove(this);
-  }
-
-  /**
-   * Verifies that all motors are nonnull, throwing a NullPointerException if any of them are. The
-   * exception's error message will specify all null motors, e.g. {@code
-   * NullPointerException("leftMotor, rightMotor")}, to give as much information as possible to the
-   * programmer.
-   *
-   * @throws NullPointerException if any of the given motors are null
-   */
-  @SuppressWarnings("PMD.AvoidThrowingNullPointerException")
-  private void verify(
-      SpeedController leftMotor, SpeedController rightMotor, SpeedController backMotor) {
-    if (leftMotor != null && rightMotor != null && backMotor != null) {
-      return;
-    }
-    StringJoiner joiner = new StringJoiner(", ");
-    if (leftMotor == null) {
-      joiner.add("leftMotor");
-    }
-    if (rightMotor == null) {
-      joiner.add("rightMotor");
-    }
-    if (backMotor == null) {
-      joiner.add("backMotor");
-    }
-    throw new NullPointerException(joiner.toString());
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
@@ -4,6 +4,8 @@
 
 package edu.wpi.first.wpilibj.drive;
 
+import static java.util.Objects.requireNonNull;
+
 import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
@@ -12,7 +14,6 @@ import edu.wpi.first.wpilibj.Sendable;
 import edu.wpi.first.wpilibj.SpeedController;
 import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
-import java.util.StringJoiner;
 
 /**
  * A class for driving Mecanum drive platforms.
@@ -104,7 +105,11 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
       SpeedController rearLeftMotor,
       SpeedController frontRightMotor,
       SpeedController rearRightMotor) {
-    verify(frontLeftMotor, rearLeftMotor, frontRightMotor, rearRightMotor);
+    requireNonNull(frontLeftMotor, "Front-left motor cannot be null");
+    requireNonNull(rearLeftMotor, "Rear-left motor cannot be null");
+    requireNonNull(frontRightMotor, "Front-right motor cannot be null");
+    requireNonNull(rearRightMotor, "Rear-right motor cannot be null");
+
     m_frontLeftMotor = frontLeftMotor;
     m_rearLeftMotor = rearLeftMotor;
     m_frontRightMotor = frontRightMotor;
@@ -120,39 +125,6 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
   @Override
   public void close() {
     SendableRegistry.remove(this);
-  }
-
-  /**
-   * Verifies that all motors are nonnull, throwing a NullPointerException if any of them are. The
-   * exception's error message will specify all null motors, e.g. {@code
-   * NullPointerException("frontLeftMotor, rearRightMotor")}, to give as much information as
-   * possible to the programmer.
-   *
-   * @throws NullPointerException if any of the given motors are null
-   */
-  @SuppressWarnings({"PMD.AvoidThrowingNullPointerException", "PMD.CyclomaticComplexity"})
-  private void verify(
-      SpeedController frontLeft,
-      SpeedController rearLeft,
-      SpeedController frontRight,
-      SpeedController rearRightMotor) {
-    if (frontLeft != null && rearLeft != null && frontRight != null && rearRightMotor != null) {
-      return;
-    }
-    StringJoiner joiner = new StringJoiner(", ");
-    if (frontLeft == null) {
-      joiner.add("frontLeftMotor");
-    }
-    if (rearLeft == null) {
-      joiner.add("rearLeftMotor");
-    }
-    if (frontRight == null) {
-      joiner.add("frontRightMotor");
-    }
-    if (rearRightMotor == null) {
-      joiner.add("rearRightMotor");
-    }
-    throw new NullPointerException(joiner.toString());
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -128,7 +128,6 @@ public class LiveWindow {
    * <p>Actuators are handled through callbacks on their value changing from the SmartDashboard
    * widgets.
    */
-  @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
   public static synchronized void updateValues() {
     // Only do this if either LiveWindow mode or telemetry is enabled.
     if (!liveWindowEnabled && !telemetryEnabled) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/MotorControllerGroup.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/MotorControllerGroup.java
@@ -20,14 +20,11 @@ public class MotorControllerGroup implements MotorController, Sendable, AutoClos
    *
    * @param motorControllers The MotorControllers to add
    */
-  @SuppressWarnings("PMD.AvoidArrayLoops")
   public MotorControllerGroup(
       MotorController motorController, MotorController... motorControllers) {
     m_motorControllers = new MotorController[motorControllers.length + 1];
     m_motorControllers[0] = motorController;
-    for (int i = 0; i < motorControllers.length; i++) {
-      m_motorControllers[i + 1] = motorControllers[i];
-    }
+    System.arraycopy(motorControllers, 0, m_motorControllers, 1, motorControllers.length);
     init();
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DriverStationSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DriverStationSim.java
@@ -10,7 +10,6 @@ import edu.wpi.first.hal.simulation.NotifyCallback;
 import edu.wpi.first.wpilibj.DriverStation;
 
 /** Class to control a simulated driver station. */
-@SuppressWarnings({"PMD.UseUtilityClass", "PMD.GodClass", "PMD.ExcessivePublicCount"})
 public final class DriverStationSim {
   private DriverStationSim() {
     throw new UnsupportedOperationException("This is a utility class!");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/RoboRioSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/RoboRioSim.java
@@ -7,9 +7,12 @@ package edu.wpi.first.wpilibj.simulation;
 import edu.wpi.first.hal.simulation.NotifyCallback;
 import edu.wpi.first.hal.simulation.RoboRioDataJNI;
 
-/** Class to control a simulated RoboRIO. */
-@SuppressWarnings({"PMD.ExcessivePublicCount", "PMD.UseUtilityClass"})
-public class RoboRioSim {
+/** A utility class to control a simulated RoboRIO. */
+public final class RoboRioSim {
+  private RoboRioSim() {
+    // Utility class
+  }
+
   /**
    * Register a callback to be run when the FPGA button state changes.
    *

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/FieldObject2d.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/FieldObject2d.java
@@ -153,7 +153,6 @@ public class FieldObject2d {
     }
   }
 
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   private synchronized void updateFromEntry() {
     if (m_entry == null) {
       return;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableRegistry.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableRegistry.java
@@ -441,11 +441,7 @@ public class SendableRegistry {
    * @param dataHandle data handle to get data object passed to callback
    * @param callback function to call for each object
    */
-  @SuppressWarnings({
-    "PMD.CyclomaticComplexity",
-    "PMD.AvoidInstantiatingObjectsInLoops",
-    "PMD.AvoidCatchingThrowable"
-  })
+  @SuppressWarnings("PMD.AvoidCatchingThrowable")
   public static synchronized void foreachLiveWindow(
       int dataHandle, Consumer<CallbackData> callback) {
     CallbackData cbdata = new CallbackData();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
@@ -22,7 +22,6 @@ import java.util.Set;
  * <p>When a value is put into the SmartDashboard here, it pops up on the SmartDashboard on the
  * laptop. Users can put values into and get values from the SmartDashboard.
  */
-@SuppressWarnings("PMD.GodClass")
 public final class SmartDashboard {
   /** The {@link NetworkTable} used by {@link SmartDashboard}. */
   private static final NetworkTable table =

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
@@ -19,8 +19,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
-@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
-public abstract class UtilityClassTest<T> {
+public class UtilityClassTest<T> {
   private final Class<T> m_clazz;
 
   protected UtilityClassTest(Class<T> clazz) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
@@ -19,7 +19,14 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
-public class UtilityClassTest<T> {
+// Declaring this class abstract prevents UtilityClassTest from running on itself and throwing the
+// following exception:
+//
+// org.junit.jupiter.api.extension.ParameterResolutionException: No ParameterResolver registered
+// for parameter [java.lang.Class<T> arg0] in constructor [protected
+// edu.wpi.first.wpilibj.UtilityClassTest(java.lang.Class<T>)].
+@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
+public abstract class UtilityClassTest<T> {
   private final Class<T> m_clazz;
 
   protected UtilityClassTest(Class<T> clazz) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/HolonomicDriveControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/controller/HolonomicDriveControllerTest.java
@@ -25,7 +25,6 @@ class HolonomicDriveControllerTest {
   private static final double kAngularTolerance = Math.toRadians(2);
 
   @Test
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   void testReachesReference() {
     HolonomicDriveController controller =
         new HolonomicDriveController(

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/dutycycleencoder/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/dutycycleencoder/Robot.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
-@SuppressWarnings({"PMD.SingularField"})
+@SuppressWarnings("PMD.SingularField")
 public class Robot extends TimedRobot {
   private DutyCycleEncoder m_dutyCycleEncoder;
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/dutycycleinput/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/dutycycleinput/Robot.java
@@ -9,7 +9,7 @@ import edu.wpi.first.wpilibj.DutyCycle;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
-@SuppressWarnings({"PMD.SingularField"})
+@SuppressWarnings("PMD.SingularField")
 public class Robot extends TimedRobot {
   private DigitalInput m_input;
   private DutyCycle m_dutyCycle;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumbot/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumbot/Drivetrain.java
@@ -17,7 +17,6 @@ import edu.wpi.first.wpilibj.motorcontrol.MotorController;
 import edu.wpi.first.wpilibj.motorcontrol.PWMSparkMax;
 
 /** Represents a mecanum drive style drivetrain. */
-@SuppressWarnings("PMD.TooManyFields")
 public class Drivetrain {
   public static final double kMaxSpeed = 3.0; // 3 meters per second
   public static final double kMaxAngularSpeed = Math.PI; // 1/2 rotation per second

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/RobotContainer.java
@@ -31,7 +31,6 @@ import java.util.List;
  * periodic methods (other than the scheduler calls).  Instead, the structure of the robot
  * (including subsystems, commands, and button mappings) should be declared here.
  */
-@SuppressWarnings("PMD.ExcessiveImports")
 public class RobotContainer {
   // The robot's subsystems
   private final DriveSubsystem m_robotDrive = new DriveSubsystem();

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/Drivetrain.java
@@ -21,7 +21,6 @@ import edu.wpi.first.wpilibj.motorcontrol.MotorController;
 import edu.wpi.first.wpilibj.motorcontrol.PWMSparkMax;
 
 /** Represents a mecanum drive style drivetrain. */
-@SuppressWarnings("PMD.TooManyFields")
 public class Drivetrain {
   public static final double kMaxSpeed = 3.0; // 3 meters per second
   public static final double kMaxAngularSpeed = Math.PI; // 1/2 rotation per second

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/simpledifferentialdrivesimulation/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/simpledifferentialdrivesimulation/Drivetrain.java
@@ -26,7 +26,6 @@ import edu.wpi.first.wpilibj.simulation.EncoderSim;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
-@SuppressWarnings("PMD.TooManyFields")
 public class Drivetrain {
   // 3 meters per second.
   public static final double kMaxSpeed = 3.0;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/subsystems/DriveSubsystem.java
@@ -14,7 +14,6 @@ import edu.wpi.first.wpilibj.examples.swervecontrollercommand.Constants.DriveCon
 import edu.wpi.first.wpilibj.interfaces.Gyro;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
-@SuppressWarnings("PMD.ExcessiveImports")
 public class DriveSubsystem extends SubsystemBase {
   // Robot swerve modules
   private final SwerveModule m_frontLeft =

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/educational/EducationalRobot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/educational/EducationalRobot.java
@@ -29,7 +29,6 @@ public class EducationalRobot extends RobotBase {
 
   private volatile boolean m_exit;
 
-  @SuppressWarnings("PMD.CyclomaticComplexity")
   @Override
   public void startCompetition() {
     robotInit();

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/robotbaseskeleton/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/robotbaseskeleton/Robot.java
@@ -26,7 +26,6 @@ public class Robot extends RobotBase {
 
   private volatile boolean m_exit;
 
-  @SuppressWarnings("PMD.CyclomaticComplexity")
   @Override
   public void startCompetition() {
     robotInit();

--- a/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
@@ -23,7 +23,6 @@ import org.ejml.simple.SimpleMatrix;
  * @param <R> The number of rows in this matrix.
  * @param <C> The number of columns in this matrix.
  */
-@SuppressWarnings("PMD.ExcessivePublicCount")
 public class Matrix<R extends Num, C extends Num> {
   protected final SimpleMatrix m_storage;
 
@@ -531,7 +530,6 @@ public class Matrix<R extends Num, C extends Num> {
    * @throws RuntimeException if the matrix could not be decomposed(ie. is not positive
    *     semidefinite).
    */
-  @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
   public Matrix<R, C> lltDecompose(boolean lowerTriangular) {
     SimpleMatrix temp = m_storage.copy();
 

--- a/wpimath/src/main/java/edu/wpi/first/math/SimpleMatrixUtils.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/SimpleMatrixUtils.java
@@ -216,7 +216,6 @@ public final class SimpleMatrixUtils {
    * @throws RuntimeException if the matrix could not be decomposed (ie. is not positive
    *     semidefinite).
    */
-  @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
   public static SimpleMatrix lltDecompose(SimpleMatrix src, boolean lowerTriangular) {
     SimpleMatrix temp = src.copy();
 

--- a/wpimath/src/main/java/edu/wpi/first/math/VecBuilder.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/VecBuilder.java
@@ -171,7 +171,6 @@ public class VecBuilder<N extends Num> extends MatBuilder<N, N1> {
    * @param n9 the ninth element.
    * @param n10 the tenth element.
    */
-  @SuppressWarnings("PMD.ExcessiveParameterList")
   public static Vector<N10> fill(
       double n1,
       double n2,

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/ExtendedKalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/ExtendedKalmanFilter.java
@@ -101,7 +101,7 @@ public class ExtendedKalmanFilter<States extends Num, Inputs extends Num, Output
    * @param addFuncX A function that adds two state vectors.
    * @param dtSeconds Nominal discretization timestep.
    */
-  @SuppressWarnings({"ParameterName", "PMD.ExcessiveParameterList"})
+  @SuppressWarnings("ParameterName")
   public ExtendedKalmanFilter(
       Nat<States> states,
       Nat<Inputs> inputs,

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/KalmanFilterLatencyCompensator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/KalmanFilterLatencyCompensator.java
@@ -60,7 +60,7 @@ public class KalmanFilterLatencyCompensator<S extends Num, I extends Num, O exte
    * @param globalMeasurementCorrect The function take calls correct() on the observer.
    * @param timestampSeconds The timestamp of the measurement.
    */
-  @SuppressWarnings({"ParameterName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  @SuppressWarnings("ParameterName")
   public <R extends Num> void applyPastGlobalMeasurement(
       Nat<R> rows,
       KalmanTypeFilter<S, I, O> observer,

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
@@ -26,7 +26,7 @@ import org.ejml.simple.SimpleMatrix;
  * an estimate of the true covariance (as opposed to a linearized version of it). This means that
  * the UKF works with nonlinear systems.
  */
-@SuppressWarnings({"MemberName", "ClassTypeParameterName", "PMD.TooManyFields"})
+@SuppressWarnings({"MemberName", "ClassTypeParameterName"})
 public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outputs extends Num>
     implements KalmanTypeFilter<States, Inputs, Outputs> {
 
@@ -108,7 +108,7 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
    * @param addFuncX A function that adds two state vectors.
    * @param nominalDtSeconds Nominal discretization timestep.
    */
-  @SuppressWarnings({"ParameterName", "PMD.ExcessiveParameterList"})
+  @SuppressWarnings("ParameterName")
   public UnscentedKalmanFilter(
       Nat<States> states,
       Nat<Outputs> outputs,
@@ -144,7 +144,7 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
     reset();
   }
 
-  @SuppressWarnings({"ParameterName", "LocalVariableName", "PMD.CyclomaticComplexity"})
+  @SuppressWarnings({"ParameterName", "LocalVariableName"})
   static <S extends Num, C extends Num> Pair<Matrix<C, N1>, Matrix<C, C>> unscentedTransform(
       Nat<S> s,
       Nat<C> dim,

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
@@ -83,7 +83,7 @@ public class SwerveDriveKinematics {
    *     attainable max velocity. Use the {@link #normalizeWheelSpeeds(SwerveModuleState[], double)
    *     normalizeWheelSpeeds} function to rectify this issue.
    */
-  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  @SuppressWarnings("LocalVariableName")
   public SwerveModuleState[] toSwerveModuleStates(
       ChassisSpeeds chassisSpeeds, Translation2d centerOfRotationMeters) {
     if (!centerOfRotationMeters.equals(m_prevCoR)) {

--- a/wpimath/src/main/java/edu/wpi/first/math/spline/SplineHelper.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/spline/SplineHelper.java
@@ -48,7 +48,6 @@ public final class SplineHelper {
    * @param waypoints The waypoints
    * @return List of splines.
    */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   public static QuinticHermiteSpline[] getQuinticSplinesFromWaypoints(List<Pose2d> waypoints) {
     QuinticHermiteSpline[] splines = new QuinticHermiteSpline[waypoints.size() - 1];
     for (int i = 0; i < waypoints.size() - 1; ++i) {
@@ -79,11 +78,7 @@ public final class SplineHelper {
    * @return A vector of cubic hermite splines that interpolate through the provided waypoints and
    *     control vectors.
    */
-  @SuppressWarnings({
-    "LocalVariableName",
-    "PMD.ExcessiveMethodLength",
-    "PMD.AvoidInstantiatingObjectsInLoops"
-  })
+  @SuppressWarnings("LocalVariableName")
   public static CubicHermiteSpline[] getCubicSplinesFromControlVectors(
       Spline.ControlVector start, Translation2d[] waypoints, Spline.ControlVector end) {
 
@@ -208,7 +203,7 @@ public final class SplineHelper {
    * @param controlVectors The control vectors.
    * @return A vector of quintic hermite splines that interpolate through the provided waypoints.
    */
-  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  @SuppressWarnings("LocalVariableName")
   public static QuinticHermiteSpline[] getQuinticSplinesFromControlVectors(
       Spline.ControlVector[] controlVectors) {
     QuinticHermiteSpline[] splines = new QuinticHermiteSpline[controlVectors.length - 1];

--- a/wpimath/src/main/java/edu/wpi/first/math/spline/SplineParameterizer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/spline/SplineParameterizer.java
@@ -96,7 +96,6 @@ public final class SplineParameterizer {
    * @throws MalformedSplineException When the spline is malformed (e.g. has close adjacent points
    *     with approximately opposing headings)
    */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   public static List<PoseWithCurvature> parameterize(Spline spline, double t0, double t1) {
     var splinePoints = new ArrayList<PoseWithCurvature>();
 

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/Trajectory.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/Trajectory.java
@@ -152,7 +152,6 @@ public class Trajectory {
    * @param transform The transform to transform the trajectory by.
    * @return The transformed trajectory.
    */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   public Trajectory transformBy(Transform2d transform) {
     var firstState = m_states.get(0);
     var firstPose = firstState.poseMeters;
@@ -214,7 +213,6 @@ public class Trajectory {
    * @param other The trajectory to concatenate.
    * @return The concatenated trajectory.
    */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   public Trajectory concatenate(Trajectory other) {
     // If this is a default constructed trajectory with no states, then we can
     // simply return the rhs trajectory.

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrajectoryGenerator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrajectoryGenerator.java
@@ -138,7 +138,6 @@ public final class TrajectoryGenerator {
    * @param config The configuration for the trajectory.
    * @return The generated trajectory.
    */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   public static Trajectory generateTrajectory(
       ControlVectorList controlVectors, TrajectoryConfig config) {
     final var flip = new Transform2d(new Translation2d(), Rotation2d.fromDegrees(180.0));

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrajectoryParameterizer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrajectoryParameterizer.java
@@ -54,12 +54,6 @@ public final class TrajectoryParameterizer {
    *     from a -&gt; b -&gt; ... -&gt; z as defined in the waypoints.
    * @return The trajectory.
    */
-  @SuppressWarnings({
-    "PMD.ExcessiveMethodLength",
-    "PMD.CyclomaticComplexity",
-    "PMD.NPathComplexity",
-    "PMD.AvoidInstantiatingObjectsInLoops"
-  })
   public static Trajectory timeParameterizeTrajectory(
       List<PoseWithCurvature> points,
       List<TrajectoryConstraint> constraints,

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrajectoryUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrajectoryUtil.java
@@ -23,7 +23,6 @@ public final class TrajectoryUtil {
    * @param elements A double[] containing the raw elements of the trajectory.
    * @return A trajectory created from the elements.
    */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   private static Trajectory createTrajectoryFromElements(double[] elements) {
     // Make sure that the elements have the correct length.
     if (elements.length % 7 != 0) {

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/LinearSystemLoopTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/LinearSystemLoopTest.java
@@ -52,7 +52,7 @@ public class LinearSystemLoopTest {
   }
 
   @Test
-  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  @SuppressWarnings("LocalVariableName")
   public void testStateSpaceEnabled() {
 
     m_loop.reset(VecBuilder.fill(0, 0));
@@ -82,7 +82,7 @@ public class LinearSystemLoopTest {
   }
 
   @Test
-  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  @SuppressWarnings("LocalVariableName")
   public void testFlywheelEnabled() {
 
     LinearSystem<N1, N1, N1> plant =

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/RamseteControllerTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/RamseteControllerTest.java
@@ -21,7 +21,6 @@ class RamseteControllerTest {
   private static final double kAngularTolerance = Math.toRadians(2);
 
   @Test
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   void testReachesReference() {
     final var controller = new RamseteController(2.0, 0.7);
     var robotPose = new Pose2d(2.7, 23.0, Rotation2d.fromDegrees(0.0));

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -22,11 +22,7 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 
 public class DifferentialDrivePoseEstimatorTest {
-  @SuppressWarnings({
-    "LocalVariableName",
-    "PMD.ExcessiveMethodLength",
-    "PMD.AvoidInstantiatingObjectsInLoops"
-  })
+  @SuppressWarnings("LocalVariableName")
   @Test
   public void testAccuracy() {
     var estimator =

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/ExtendedKalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/ExtendedKalmanFilterTest.java
@@ -98,11 +98,7 @@ public class ExtendedKalmanFilterTest {
         });
   }
 
-  @SuppressWarnings({
-    "LocalVariableName",
-    "PMD.AvoidInstantiatingObjectsInLoops",
-    "PMD.ExcessiveMethodLength"
-  })
+  @SuppressWarnings("LocalVariableName")
   @Test
   public void testConvergence() {
     double dtSeconds = 0.00505;

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/KalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/KalmanFilterTest.java
@@ -72,7 +72,6 @@ public class KalmanFilterTest {
   }
 
   @Test
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   public void testSwerveKFStationary() {
 
     var random = new Random();
@@ -121,7 +120,6 @@ public class KalmanFilterTest {
   }
 
   @Test
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   public void testSwerveKFMovingWithoutAccelerating() {
 
     var random = new Random();
@@ -178,7 +176,7 @@ public class KalmanFilterTest {
   }
 
   @Test
-  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  @SuppressWarnings("LocalVariableName")
   public void testSwerveKFMovingOverTrajectory() {
 
     var random = new Random();

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimatorTest.java
@@ -20,11 +20,7 @@ import org.junit.jupiter.api.Test;
 
 public class MecanumDrivePoseEstimatorTest {
   @Test
-  @SuppressWarnings({
-    "LocalVariableName",
-    "PMD.AvoidInstantiatingObjectsInLoops",
-    "PMD.ExcessiveMethodLength"
-  })
+  @SuppressWarnings("LocalVariableName")
   public void testAccuracy() {
     var kinematics =
         new MecanumDriveKinematics(

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimatorTest.java
@@ -20,11 +20,7 @@ import org.junit.jupiter.api.Test;
 
 public class SwerveDrivePoseEstimatorTest {
   @Test
-  @SuppressWarnings({
-    "LocalVariableName",
-    "PMD.AvoidInstantiatingObjectsInLoops",
-    "PMD.ExcessiveMethodLength"
-  })
+  @SuppressWarnings("LocalVariableName")
   public void testAccuracy() {
     var kinematics =
         new SwerveDriveKinematics(

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
@@ -103,11 +103,7 @@ public class UnscentedKalmanFilterTest {
         });
   }
 
-  @SuppressWarnings({
-    "LocalVariableName",
-    "PMD.AvoidInstantiatingObjectsInLoops",
-    "PMD.ExcessiveMethodLength"
-  })
+  @SuppressWarnings("LocalVariableName")
   @Test
   public void testConvergence() {
     double dtSeconds = 0.00505;
@@ -293,7 +289,7 @@ public class UnscentedKalmanFilterTest {
   }
 
   @Test
-  @SuppressWarnings({"LocalVariableName", "ParameterName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  @SuppressWarnings({"LocalVariableName", "ParameterName"})
   public void testLinearUKF() {
     var dt = 0.020;
     var plant = LinearSystemId.identifyVelocitySystem(0.02, 0.006);

--- a/wpimath/src/test/java/edu/wpi/first/math/spline/CubicHermiteSplineTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/spline/CubicHermiteSplineTest.java
@@ -23,7 +23,7 @@ class CubicHermiteSplineTest {
   private static final double kMaxDy = 0.00127;
   private static final double kMaxDtheta = 0.0872;
 
-  @SuppressWarnings({"ParameterName", "PMD.UnusedLocalVariable"})
+  @SuppressWarnings("ParameterName")
   private void run(Pose2d a, List<Translation2d> waypoints, Pose2d b) {
     // Start the timer.
     // var start = System.nanoTime();

--- a/wpimath/src/test/java/edu/wpi/first/math/spline/QuinticHermiteSplineTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/spline/QuinticHermiteSplineTest.java
@@ -20,7 +20,7 @@ class QuinticHermiteSplineTest {
   private static final double kMaxDy = 0.00127;
   private static final double kMaxDtheta = 0.0872;
 
-  @SuppressWarnings({"ParameterName", "PMD.UnusedLocalVariable"})
+  @SuppressWarnings("ParameterName")
   private void run(Pose2d a, Pose2d b) {
     // Start the timer.
     // var start = System.nanoTime();

--- a/wpimath/src/test/java/edu/wpi/first/math/trajectory/DifferentialDriveKinematicsConstraintTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/trajectory/DifferentialDriveKinematicsConstraintTest.java
@@ -15,7 +15,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class DifferentialDriveKinematicsConstraintTest {
-  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  @SuppressWarnings("LocalVariableName")
   @Test
   void testDifferentialDriveKinematicsConstraint() {
     double maxVelocity = Units.feetToMeters(12.0); // 12 feet per second

--- a/wpimath/src/test/java/edu/wpi/first/math/trajectory/DifferentialDriveVoltageConstraintTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/trajectory/DifferentialDriveVoltageConstraintTest.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class DifferentialDriveVoltageConstraintTest {
-  @SuppressWarnings({"LocalVariableName", "PMD.AvoidInstantiatingObjectsInLoops"})
+  @SuppressWarnings("LocalVariableName")
   @Test
   void testDifferentialDriveVoltageConstraint() {
     // Pick an unreasonably large kA to ensure the constraint has to do some work

--- a/wpimath/src/test/java/edu/wpi/first/math/trajectory/TrapezoidProfileTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/trajectory/TrapezoidProfileTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
 class TrapezoidProfileTest {
   private static final double kDt = 0.01;
 

--- a/wpimath/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
@@ -19,8 +19,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
-@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
-public abstract class UtilityClassTest<T> {
+public class UtilityClassTest<T> {
   private final Class<T> m_clazz;
 
   protected UtilityClassTest(Class<T> clazz) {

--- a/wpimath/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
@@ -19,7 +19,14 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
-public class UtilityClassTest<T> {
+// Declaring this class abstract prevents UtilityClassTest from running on itself and throwing the
+// following exception:
+//
+// org.junit.jupiter.api.extension.ParameterResolutionException: No ParameterResolver registered
+// for parameter [java.lang.Class<T> arg0] in constructor [protected
+// edu.wpi.first.wpilibj.UtilityClassTest(java.lang.Class<T>)].
+@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
+public abstract class UtilityClassTest<T> {
   private final Class<T> m_clazz;
 
   protected UtilityClassTest(Class<T> clazz) {

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/CombinedRuntimeLoader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/CombinedRuntimeLoader.java
@@ -56,11 +56,7 @@ public final class CombinedRuntimeLoader {
    * @return List of all libraries that were extracted
    * @throws IOException Thrown if resource not found or file could not be extracted
    */
-  @SuppressWarnings({
-    "PMD.AvoidInstantiatingObjectsInLoops",
-    "PMD.UnnecessaryCastRule",
-    "unchecked"
-  })
+  @SuppressWarnings({"PMD.UnnecessaryCastRule", "unchecked"})
   public static <T> List<String> extractLibraries(Class<T> clazz, String resourceName)
       throws IOException {
     TypeReference<HashMap<String, Object>> typeRef =

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeDetector.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeDetector.java
@@ -15,7 +15,6 @@ public final class RuntimeDetector {
   private static String fileExtension;
   private static String filePath;
 
-  @SuppressWarnings("PMD.CyclomaticComplexity")
   private static synchronized void computePlatform() {
     if (fileExtension != null && filePath != null && filePrefix != null) {
       return;

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeLoader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeLoader.java
@@ -107,13 +107,7 @@ public final class RuntimeLoader<T> {
   }
 
   /** Load a native library by directly hashing the file. */
-  @SuppressWarnings({
-    "PMD.NPathComplexity",
-    "PMD.PreserveStackTrace",
-    "PMD.EmptyWhileStmt",
-    "PMD.AvoidThrowingRawExceptionTypes",
-    "PMD.CyclomaticComplexity"
-  })
+  @SuppressWarnings({"PMD.PreserveStackTrace", "PMD.EmptyWhileStmt"})
   public void loadLibraryHashed() throws IOException {
     try {
       // First, try loading path

--- a/wpiutil/src/test/java/edu/wpi/first/wpiutil/CircularBufferTest.java
+++ b/wpiutil/src/test/java/edu/wpi/first/wpiutil/CircularBufferTest.java
@@ -105,7 +105,6 @@ class CircularBufferTest {
   }
 
   @Test
-  @SuppressWarnings("PMD.ExcessiveMethodLength")
   void resizeTest() {
     CircularBuffer queue = new CircularBuffer(5);
 


### PR DESCRIPTION
Some valid warnings like throwing NullPointerException or using a for
loop instead of System.arraycopy() were fixed.

Abstract classes marked with PMD.AbstractClassWithoutAbstractMethod were
made concrete because they already had protected constructors.

Fixes #1697.