### PR TITLE
Ensure HAL status variables are initialized to zero

### DIFF
--- a/hal/src/main/native/athena/Accelerometer.cpp
+++ b/hal/src/main/native/athena/Accelerometer.cpp
@@ -89,7 +89,7 @@ static uint8_t readRegister(Register reg);
  */
 static void initializeAccelerometer() {
   hal::init::CheckInit();
-  int32_t status;
+  int32_t status = 0;
 
   if (!accel) {
     accel.reset(tAccel::create(&status));

--- a/hal/src/test/native/cpp/mockdata/AnalogInDataTests.cpp
+++ b/hal/src/test/native/cpp/mockdata/AnalogInDataTests.cpp
@@ -28,12 +28,11 @@ TEST(AnalogInSimTests, TestAnalogInInitialization) {
       false);
   ASSERT_TRUE(0 != callbackId);
 
-  int32_t status;
+  int32_t status = 0;
   HAL_PortHandle portHandle;
   HAL_DigitalHandle analogInHandle;
 
   // Use out of range index
-  status = 0;
   portHandle = 8000;
   gTestAnalogInCallbackName = "Unset";
   analogInHandle = HAL_InitializeAnalogInputPort(portHandle, nullptr, &status);

--- a/hal/src/test/native/cpp/mockdata/AnalogOutDataTests.cpp
+++ b/hal/src/test/native/cpp/mockdata/AnalogOutDataTests.cpp
@@ -28,12 +28,11 @@ TEST(AnalogOutSimTests, TestAnalogOutInitialization) {
       false);
   ASSERT_TRUE(0 != callbackId);
 
-  int32_t status;
+  int32_t status = 0;
   HAL_PortHandle portHandle;
   HAL_DigitalHandle analogOutHandle;
 
   // Use out of range index
-  status = 0;
   portHandle = 8000;
   gTestAnalogOutCallbackName = "Unset";
   analogOutHandle =

--- a/hal/src/test/native/cpp/mockdata/DIODataTests.cpp
+++ b/hal/src/test/native/cpp/mockdata/DIODataTests.cpp
@@ -28,12 +28,11 @@ TEST(DigitalIoSimTests, TestDigitalIoInitialization) {
       false);
   ASSERT_TRUE(0 != callbackId);
 
-  int32_t status;
+  int32_t status = 0;
   HAL_PortHandle portHandle;
   HAL_DigitalHandle digitalIoHandle;
 
   // Use out of range index
-  status = 0;
   portHandle = 8000;
   gTestDigitalIoCallbackName = "Unset";
   digitalIoHandle = HAL_InitializeDIOPort(portHandle, true, nullptr, &status);

--- a/hal/src/test/native/cpp/mockdata/I2CDataTests.cpp
+++ b/hal/src/test/native/cpp/mockdata/I2CDataTests.cpp
@@ -22,7 +22,7 @@ void TestI2CInitializationCallback(const char* name, void* param,
 TEST(I2CSimTests, TestI2CInitialization) {
   const int INDEX_TO_TEST = 1;
 
-  int32_t status;
+  int32_t status = 0;
   HAL_I2CPort port;
 
   int callbackParam = 0;
@@ -30,7 +30,6 @@ TEST(I2CSimTests, TestI2CInitialization) {
       INDEX_TO_TEST, &TestI2CInitializationCallback, &callbackParam, false);
   ASSERT_TRUE(0 != callbackId);
 
-  status = 0;
   port = HAL_I2C_kMXP;
   gTestI2CCallbackName = "Unset";
   HAL_InitializeI2C(port, &status);

--- a/hal/src/test/native/cpp/mockdata/PCMDataTests.cpp
+++ b/hal/src/test/native/cpp/mockdata/PCMDataTests.cpp
@@ -28,12 +28,11 @@ TEST(SolenoidSimTests, TestPCMInitialization) {
       false);
   ASSERT_TRUE(0 != callbackId);
 
-  int32_t status;
+  int32_t status = 0;
   int32_t module;
   HAL_CTREPCMHandle pcmHandle;
 
   // Use out of range index
-  status = 0;
   module = 8000;
   gTestSolenoidCallbackName = "Unset";
   pcmHandle = HAL_InitializeCTREPCM(module, nullptr, &status);

--- a/hal/src/test/native/cpp/mockdata/PDPDataTests.cpp
+++ b/hal/src/test/native/cpp/mockdata/PDPDataTests.cpp
@@ -27,10 +27,9 @@ TEST(PdpSimTests, TestPdpInitialization) {
       INDEX_TO_TEST, &TestPdpInitializationCallback, &callbackParam, false);
   ASSERT_TRUE(0 != callbackId);
 
-  int32_t status;
+  int32_t status = 0;
 
   // Use out of range index
-  status = 0;
   gTestPdpCallbackName = "Unset";
   HAL_InitializePDP(INDEX_TO_TEST, &status);
   EXPECT_EQ(0, status);

--- a/hal/src/test/native/cpp/mockdata/PWMDataTests.cpp
+++ b/hal/src/test/native/cpp/mockdata/PWMDataTests.cpp
@@ -27,12 +27,11 @@ TEST(PWMSimTests, TestPwmInitialization) {
       INDEX_TO_TEST, &TestPwmInitializationCallback, &callbackParam, false);
   ASSERT_TRUE(0 != callbackId);
 
-  int32_t status;
+  int32_t status = 0;
   HAL_PortHandle portHandle;
   HAL_DigitalHandle pwmHandle;
 
   // Use out of range index
-  status = 0;
   portHandle = 8000;
   gTestPwmCallbackName = "Unset";
   pwmHandle = HAL_InitializePWMPort(portHandle, nullptr, &status);

--- a/hal/src/test/native/cpp/mockdata/RelayDataTests.cpp
+++ b/hal/src/test/native/cpp/mockdata/RelayDataTests.cpp
@@ -27,12 +27,11 @@ TEST(RelaySimTests, TestRelayInitialization) {
       INDEX_TO_TEST, &TestRelayInitializationCallback, &callbackParam, false);
   ASSERT_TRUE(0 != callbackId);
 
-  int32_t status;
+  int32_t status = 0;
   HAL_PortHandle portHandle;
   HAL_DigitalHandle pdpHandle;
 
   // Use out of range index
-  status = 0;
   portHandle = 8000;
   gTestRelayCallbackName = "Unset";
   pdpHandle = HAL_InitializeRelayPort(portHandle, true, nullptr, &status);

--- a/hal/src/test/native/cpp/mockdata/SPIDataTests.cpp
+++ b/hal/src/test/native/cpp/mockdata/SPIDataTests.cpp
@@ -22,7 +22,7 @@ void TestSpiInitializationCallback(const char* name, void* param,
 TEST(SpiSimTests, TestSpiInitialization) {
   const int INDEX_TO_TEST = 2;
 
-  int32_t status;
+  int32_t status = 0;
   HAL_SPIPort port;
 
   int callbackParam = 0;
@@ -30,7 +30,6 @@ TEST(SpiSimTests, TestSpiInitialization) {
       INDEX_TO_TEST, &TestSpiInitializationCallback, &callbackParam, false);
   ASSERT_TRUE(0 != callbackId);
 
-  status = 0;
   port = HAL_SPI_kOnboardCS2;
   gTestSpiCallbackName = "Unset";
   HAL_InitializeSPI(port, &status);

--- a/simulation/halsim_gazebo/src/main/native/cpp/GazeboAnalogIn.cpp
+++ b/simulation/halsim_gazebo/src/main/native/cpp/GazeboAnalogIn.cpp
@@ -37,7 +37,7 @@ void GazeboAnalogIn::Listen() {
 void GazeboAnalogIn::Callback(const gazebo::msgs::ConstFloat64Ptr& msg) {
   /* This value is going to be divided by the 5V rail in the HAL, so
      we multiply by that value to make the change neutral */
-  int32_t status;
+  int32_t status = 0;
   HALSIM_SetAnalogInVoltage(m_index,
                             msg->data() * HAL_GetUserVoltage5V(&status));
 }

--- a/wpilibc/src/main/native/cpp/DriverStation.cpp
+++ b/wpilibc/src/main/native/cpp/DriverStation.cpp
@@ -514,7 +514,7 @@ bool DriverStation::WaitForData(units::second_t timeout) {
 }
 
 double DriverStation::GetMatchTime() const {
-  int32_t status;
+  int32_t status = 0;
   return HAL_GetMatchTime(&status);
 }
 

--- a/wpilibc/src/main/native/cpp/Relay.cpp
+++ b/wpilibc/src/main/native/cpp/Relay.cpp
@@ -125,7 +125,7 @@ void Relay::Set(Relay::Value value) {
 
 Relay::Value Relay::Get() const {
   Relay::Value value = kOff;
-  int32_t status;
+  int32_t status = 0;
 
   if (m_direction == kForwardOnly) {
     if (HAL_GetRelay(m_forwardHandle, &status)) {


### PR DESCRIPTION
HAL functions don't set the status variable on success, so it's possible
to use the status variable in an uninitialized state.