### PR TITLE
Move Doxygen comments to headers (NFC)

### DIFF
--- a/hal/src/main/native/athena/FRCDriverStation.cpp
+++ b/hal/src/main/native/athena/FRCDriverStation.cpp
@@ -372,18 +372,10 @@ HAL_Bool HAL_IsNewControlData(void) {
   return true;
 }
 
-/**
- * Waits for the newest DS packet to arrive. Note that this is a blocking call.
- */
 void HAL_WaitForDSData(void) {
   HAL_WaitForDSDataTimeout(0);
 }
 
-/**
- * Waits for the newest DS packet to arrive. If timeout is <= 0, this will wait
- * forever. Otherwise, it will wait until either a new packet, or the timeout
- * time has passed. Returns true on new data, false on timeout.
- */
 HAL_Bool HAL_WaitForDSDataTimeout(double timeout) {
   std::unique_lock lock{*newDSDataAvailableMutex};
   int& lastCount = GetThreadLocalLastCount();

--- a/wpilibc/src/main/native/cpp/PowerDistributionPanel.cpp
+++ b/wpilibc/src/main/native/cpp/PowerDistributionPanel.cpp
@@ -18,9 +18,6 @@ using namespace frc;
 
 PowerDistributionPanel::PowerDistributionPanel() : PowerDistributionPanel(0) {}
 
-/**
- * Initialize the PDP.
- */
 PowerDistributionPanel::PowerDistributionPanel(int module) : m_module(module) {
   int32_t status = 0;
   m_handle = HAL_InitializePDP(module, &status);

--- a/wpilibc/src/main/native/include/frc/PowerDistributionPanel.h
+++ b/wpilibc/src/main/native/include/frc/PowerDistributionPanel.h
@@ -20,7 +20,18 @@ class SendableBuilder;
 class PowerDistributionPanel : public Sendable,
                                public SendableHelper<PowerDistributionPanel> {
  public:
+  /**
+   * Constructs a PowerDistributionPanel.
+   *
+   * Uses the default CAN ID (0).
+   */
   PowerDistributionPanel();
+
+  /**
+   * Constructs a PowerDistributionPanel.
+   *
+   * @param module The CAN ID of the PDP
+   */
   explicit PowerDistributionPanel(int module);
 
   PowerDistributionPanel(PowerDistributionPanel&&) = default;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistributionPanel.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistributionPanel.java
@@ -19,7 +19,7 @@ public class PowerDistributionPanel implements Sendable, AutoCloseable {
   private final int m_module;
 
   /**
-   * Constructor.
+   * Constructs a PowerDistributionPanel.
    *
    * @param module The CAN ID of the PDP
    */
@@ -32,7 +32,11 @@ public class PowerDistributionPanel implements Sendable, AutoCloseable {
     SendableRegistry.addLW(this, "PowerDistributionPanel", module);
   }
 
-  /** Constructor. Uses the default CAN ID (0). */
+  /**
+   * Constructs a PowerDistributionPanel.
+   *
+   * <p>Uses the default CAN ID (0).
+   */
   public PowerDistributionPanel() {
     this(0);
   }


### PR DESCRIPTION
The HAL functions already had more descriptive comments in their corresponding headers.