### PR TITLE
Fix documentation warnings generated by JavaDoc (NFC)

### DIFF
--- a/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
+++ b/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
@@ -43,7 +43,11 @@ public final class CameraServer {
   private static final String kPublishName = "/CameraPublisher";
   private static CameraServer server;
 
-  /** Get the CameraServer instance. */
+  /**
+   * Get the CameraServer instance.
+   *
+   * @return CameraServer instance
+   */
   public static synchronized CameraServer getInstance() {
     if (server == null) {
       server = new CameraServer();
@@ -522,6 +526,8 @@ public final class CameraServer {
    * <p>The first time this overload is called, it calls {@link #startAutomaticCapture(int)} with
    * device 0, creating a camera named "USB Camera 0". Subsequent calls increment the device number
    * (e.g. 1, 2, etc).
+   *
+   * @return The USB camera capturing images.
    */
   public UsbCamera startAutomaticCapture() {
     UsbCamera camera = startAutomaticCapture(m_defaultUsbDevice.getAndIncrement());
@@ -536,6 +542,7 @@ public final class CameraServer {
    * {dev}".
    *
    * @param dev The device number of the camera interface
+   * @return The USB camera capturing images.
    */
   public UsbCamera startAutomaticCapture(int dev) {
     UsbCamera camera = new UsbCamera("USB Camera " + dev, dev);
@@ -549,6 +556,7 @@ public final class CameraServer {
    *
    * @param name The name to give the camera
    * @param dev The device number of the camera interface
+   * @return The USB camera capturing images.
    */
   public UsbCamera startAutomaticCapture(String name, int dev) {
     UsbCamera camera = new UsbCamera(name, dev);
@@ -562,6 +570,7 @@ public final class CameraServer {
    *
    * @param name The name to give the camera
    * @param path The device path (e.g. "/dev/video0") of the camera
+   * @return The USB camera capturing images.
    */
   public UsbCamera startAutomaticCapture(String name, String path) {
     UsbCamera camera = new UsbCamera(name, path);
@@ -574,6 +583,7 @@ public final class CameraServer {
    * Start automatically capturing images to send to the dashboard from an existing camera.
    *
    * @param camera Camera
+   * @return The MJPEG server serving images from the given camera.
    */
   public MjpegServer startAutomaticCapture(VideoSource camera) {
     addCamera(camera);
@@ -588,6 +598,7 @@ public final class CameraServer {
    * <p>This overload calls {@link #addAxisCamera(String, String)} with name "Axis Camera".
    *
    * @param host Camera host IP or DNS name (e.g. "10.x.y.11")
+   * @return The Axis camera capturing images.
    */
   public AxisCamera addAxisCamera(String host) {
     return addAxisCamera("Axis Camera", host);
@@ -599,6 +610,7 @@ public final class CameraServer {
    * <p>This overload calls {@link #addAxisCamera(String, String[])} with name "Axis Camera".
    *
    * @param hosts Array of Camera host IPs/DNS names
+   * @return The Axis camera capturing images.
    */
   public AxisCamera addAxisCamera(String[] hosts) {
     return addAxisCamera("Axis Camera", hosts);
@@ -609,6 +621,7 @@ public final class CameraServer {
    *
    * @param name The name to give the camera
    * @param host Camera host IP or DNS name (e.g. "10.x.y.11")
+   * @return The Axis camera capturing images.
    */
   public AxisCamera addAxisCamera(String name, String host) {
     AxisCamera camera = new AxisCamera(name, host);
@@ -623,6 +636,7 @@ public final class CameraServer {
    *
    * @param name The name to give the camera
    * @param hosts Array of Camera host IPs/DNS names
+   * @return The Axis camera capturing images.
    */
   public AxisCamera addAxisCamera(String name, String[] hosts) {
     AxisCamera camera = new AxisCamera(name, hosts);
@@ -636,6 +650,9 @@ public final class CameraServer {
    * Adds a virtual camera for switching between two streams. Unlike the other addCamera methods,
    * this returns a VideoSink rather than a VideoSource. Calling setSource() on the returned object
    * can be used to switch the actual source of the stream.
+   *
+   * @param name The name to give the camera
+   * @return The MJPEG server serving images from the given camera.
    */
   public MjpegServer addSwitchedCamera(String name) {
     // create a dummy CvSource
@@ -654,6 +671,8 @@ public final class CameraServer {
    *
    * <p>This is only valid to call after a camera feed has been added with startAutomaticCapture()
    * or addServer().
+   *
+   * @return OpenCV sink for the primary camera feed
    */
   public CvSink getVideo() {
     VideoSource source;
@@ -674,6 +693,7 @@ public final class CameraServer {
    * image processing on the roboRIO.
    *
    * @param camera Camera (e.g. as returned by startAutomaticCapture).
+   * @return OpenCV sink for the specified camera
    */
   public CvSink getVideo(VideoSource camera) {
     String name = "opencv_" + camera.getName();
@@ -700,6 +720,7 @@ public final class CameraServer {
    * image processing on the roboRIO.
    *
    * @param name Camera name
+   * @return OpenCV sink for the specified camera
    */
   public CvSink getVideo(String name) {
     VideoSource source;
@@ -719,6 +740,7 @@ public final class CameraServer {
    * @param name Name to give the stream
    * @param width Width of the image being sent
    * @param height Height of the image being sent
+   * @return OpenCV source for the MJPEG stream
    */
   public CvSource putVideo(String name, int width, int height) {
     CvSource source = new CvSource(name, VideoMode.PixelFormat.kMJPEG, width, height, 30);
@@ -730,6 +752,7 @@ public final class CameraServer {
    * Adds a MJPEG server at the next available port.
    *
    * @param name Server name
+   * @return The MJPEG server
    */
   public MjpegServer addServer(String name) {
     int port;
@@ -744,6 +767,8 @@ public final class CameraServer {
    * Adds a MJPEG server.
    *
    * @param name Server name
+   * @param port Server port
+   * @return The MJPEG server
    */
   public MjpegServer addServer(String name, int port) {
     MjpegServer server = new MjpegServer(name, port);
@@ -778,6 +803,8 @@ public final class CameraServer {
    *
    * <p>This is only valid to call after a camera feed has been added with startAutomaticCapture()
    * or addServer().
+   *
+   * @return The server for the primary camera feed
    */
   public VideoSink getServer() {
     synchronized (this) {
@@ -792,6 +819,7 @@ public final class CameraServer {
    * Gets a server by name.
    *
    * @param name Server name
+   * @return The server
    */
   public VideoSink getServer(String name) {
     synchronized (this) {

--- a/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServerSharedStore.java
+++ b/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServerSharedStore.java
@@ -9,7 +9,11 @@ public final class CameraServerSharedStore {
 
   private CameraServerSharedStore() {}
 
-  /** get the CameraServerShared object. */
+  /**
+   * Get the CameraServerShared object.
+   *
+   * @return The CameraServerSharedObject
+   */
   public static synchronized CameraServerShared getCameraServerShared() {
     if (cameraServerShared == null) {
       cameraServerShared =
@@ -36,7 +40,11 @@ public final class CameraServerSharedStore {
     return cameraServerShared;
   }
 
-  /** set the CameraServerShared object. */
+  /**
+   * Set the CameraServerShared object.
+   *
+   * @param shared The CameraServerShared object.
+   */
   public static synchronized void setCameraServerShared(CameraServerShared shared) {
     cameraServerShared = shared;
   }

--- a/cameraserver/src/main/java/edu/wpi/first/vision/VisionPipeline.java
+++ b/cameraserver/src/main/java/edu/wpi/first/vision/VisionPipeline.java
@@ -17,6 +17,8 @@ public interface VisionPipeline {
   /**
    * Processes the image input and sets the result objects. Implementations should make these
    * objects accessible.
+   *
+   * @param image The image to process.
    */
   void process(Mat image);
 }

--- a/cameraserver/src/main/native/include/vision/VisionRunner.h
+++ b/cameraserver/src/main/native/include/vision/VisionRunner.h
@@ -49,9 +49,9 @@ class VisionRunnerBase {
   void RunOnce();
 
   /**
-   * A convenience method that calls {@link #runOnce()} in an infinite loop.
-   * This must be run in a dedicated thread, and cannot be used in the main
-   * robot thread because it will freeze the robot program.
+   * A convenience method that calls runOnce() in an infinite loop. This must be
+   * run in a dedicated thread, and cannot be used in the main robot thread
+   * because it will freeze the robot program.
    *
    * <strong>Do not call this method directly from the main thread.</strong>
    */

--- a/cscore/src/main/java/edu/wpi/first/cscore/CameraServerCvJNI.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/CameraServerCvJNI.java
@@ -42,7 +42,11 @@ public class CameraServerCvJNI {
     }
   }
 
-  /** Force load the library. */
+  /**
+   * Force load the library.
+   *
+   * @throws IOException if library load failed
+   */
   public static synchronized void forceLoad() throws IOException {
     if (libraryLoaded) {
       return;

--- a/cscore/src/main/java/edu/wpi/first/cscore/CameraServerJNI.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/CameraServerJNI.java
@@ -43,7 +43,11 @@ public class CameraServerJNI {
     }
   }
 
-  /** Force load the library. */
+  /**
+   * Force load the library.
+   *
+   * @throws IOException if library load failed
+   */
   public static synchronized void forceLoad() throws IOException {
     if (libraryLoaded) {
       return;

--- a/cscore/src/main/java/edu/wpi/first/cscore/CvSink.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/CvSink.java
@@ -38,6 +38,7 @@ public class CvSink extends ImageSink {
    * Wait for the next frame and get the image. Times out (returning 0) after 0.225 seconds. The
    * provided image will have three 3-bit channels stored in BGR order.
    *
+   * @param image Where to store the image.
    * @return Frame time, or 0 on error (call GetError() to obtain the error message)
    */
   public long grabFrame(Mat image) {
@@ -48,6 +49,8 @@ public class CvSink extends ImageSink {
    * Wait for the next frame and get the image. Times out (returning 0) after timeout seconds. The
    * provided image will have three 3-bit channels stored in BGR order.
    *
+   * @param image Where to store the image.
+   * @param timeout Retrieval timeout in seconds.
    * @return Frame time, or 0 on error (call GetError() to obtain the error message); the frame time
    *     is in 1 us increments.
    */
@@ -59,6 +62,7 @@ public class CvSink extends ImageSink {
    * Wait for the next frame and get the image. May block forever. The provided image will have
    * three 3-bit channels stored in BGR order.
    *
+   * @param image Where to store the image.
    * @return Frame time, or 0 on error (call GetError() to obtain the error message); the frame time
    *     is in 1 us increments.
    */

--- a/cscore/src/main/java/edu/wpi/first/cscore/HttpCamera.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/HttpCamera.java
@@ -88,17 +88,27 @@ public class HttpCamera extends VideoCamera {
    * Get the kind of HTTP camera.
    *
    * <p>Autodetection can result in returning a different value than the camera was created with.
+   *
+   * @return The kind of HTTP camera.
    */
   public HttpCameraKind getHttpCameraKind() {
     return getHttpCameraKindFromInt(CameraServerJNI.getHttpCameraKind(m_handle));
   }
 
-  /** Change the URLs used to connect to the camera. */
+  /**
+   * Change the URLs used to connect to the camera.
+   *
+   * @param urls Array of Camera URLs
+   */
   public void setUrls(String[] urls) {
     CameraServerJNI.setHttpCameraUrls(m_handle, urls);
   }
 
-  /** Get the URLs used to connect to the camera. */
+  /**
+   * Get the URLs used to connect to the camera.
+   *
+   * @return Array of camera URLs.
+   */
   public String[] getUrls() {
     return CameraServerJNI.getHttpCameraUrls(m_handle);
   }

--- a/cscore/src/main/java/edu/wpi/first/cscore/ImageSink.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/ImageSink.java
@@ -18,7 +18,11 @@ public abstract class ImageSink extends VideoSink {
     CameraServerJNI.setSinkDescription(m_handle, description);
   }
 
-  /** Get error string. Call this if WaitForFrame() returns 0 to determine what the error is. */
+  /**
+   * Get error string. Call this if WaitForFrame() returns 0 to determine what the error is.
+   *
+   * @return Error string.
+   */
   public String getError() {
     return CameraServerJNI.getSinkError(m_handle);
   }
@@ -27,6 +31,8 @@ public abstract class ImageSink extends VideoSink {
    * Enable or disable getting new frames. Disabling will cause processFrame (for callback-based
    * CvSinks) to not be called and WaitForFrame() to not return. This can be used to save processor
    * resources when frames are not needed.
+   *
+   * @param enabled Enable to get new frames.
    */
   public void setEnabled(boolean enabled) {
     CameraServerJNI.setSinkEnabled(m_handle, enabled);

--- a/cscore/src/main/java/edu/wpi/first/cscore/ImageSource.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/ImageSource.java
@@ -12,6 +12,8 @@ public abstract class ImageSource extends VideoSource {
   /**
    * Signal sinks that an error has occurred. This should be called instead of NotifyFrame when an
    * error occurs.
+   *
+   * @param msg Error message.
    */
   public void notifyError(String msg) {
     CameraServerJNI.notifySourceError(m_handle, msg);

--- a/cscore/src/main/java/edu/wpi/first/cscore/MjpegServer.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/MjpegServer.java
@@ -27,12 +27,20 @@ public class MjpegServer extends VideoSink {
     this(name, "", port);
   }
 
-  /** Get the listen address of the server. */
+  /**
+   * Get the listen address of the server.
+   *
+   * @return The listen address.
+   */
   public String getListenAddress() {
     return CameraServerJNI.getMjpegServerListenAddress(m_handle);
   }
 
-  /** Get the port number of the server. */
+  /**
+   * Get the port number of the server.
+   *
+   * @return The port number.
+   */
   public int getPort() {
     return CameraServerJNI.getMjpegServerPort(m_handle);
   }

--- a/cscore/src/main/java/edu/wpi/first/cscore/UsbCamera.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/UsbCamera.java
@@ -35,17 +35,29 @@ public class UsbCamera extends VideoCamera {
     return CameraServerJNI.enumerateUsbCameras();
   }
 
-  /** Change the path to the device. */
+  /**
+   * Change the path to the device.
+   *
+   * @param path New device path.
+   */
   void setPath(String path) {
     CameraServerJNI.setUsbCameraPath(m_handle, path);
   }
 
-  /** Get the path to the device. */
+  /**
+   * Get the path to the device.
+   *
+   * @return The device path.
+   */
   public String getPath() {
     return CameraServerJNI.getUsbCameraPath(m_handle);
   }
 
-  /** Get the full camera information for the device. */
+  /**
+   * Get the full camera information for the device.
+   *
+   * @return The camera information.
+   */
   public UsbCameraInfo getInfo() {
     return CameraServerJNI.getUsbCameraInfo(m_handle);
   }

--- a/cscore/src/main/java/edu/wpi/first/cscore/VideoCamera.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/VideoCamera.java
@@ -18,12 +18,20 @@ public class VideoCamera extends VideoSource {
     super(handle);
   }
 
-  /** Set the brightness, as a percentage (0-100). */
+  /**
+   * Set the brightness, as a percentage (0-100).
+   *
+   * @param brightness Brightness as a percentage (0-100).
+   */
   public synchronized void setBrightness(int brightness) {
     CameraServerJNI.setCameraBrightness(m_handle, brightness);
   }
 
-  /** Get the brightness, as a percentage (0-100). */
+  /**
+   * Get the brightness, as a percentage (0-100).
+   *
+   * @return The brightness as a percentage (0-100).
+   */
   public synchronized int getBrightness() {
     return CameraServerJNI.getCameraBrightness(m_handle);
   }
@@ -38,7 +46,11 @@ public class VideoCamera extends VideoSource {
     CameraServerJNI.setCameraWhiteBalanceHoldCurrent(m_handle);
   }
 
-  /** Set the white balance to manual, with specified color temperature. */
+  /**
+   * Set the white balance to manual, with specified color temperature.
+   *
+   * @param value The specified color temperature.
+   */
   public synchronized void setWhiteBalanceManual(int value) {
     CameraServerJNI.setCameraWhiteBalanceManual(m_handle, value);
   }
@@ -53,7 +65,11 @@ public class VideoCamera extends VideoSource {
     CameraServerJNI.setCameraExposureHoldCurrent(m_handle);
   }
 
-  /** Set the exposure to manual, as a percentage (0-100). */
+  /**
+   * Set the exposure to manual, as a percentage (0-100).
+   *
+   * @param value The exposure as a percentage (0-100).
+   */
   public synchronized void setExposureManual(int value) {
     CameraServerJNI.setCameraExposureManual(m_handle, value);
   }

--- a/cscore/src/main/java/edu/wpi/first/cscore/VideoMode.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/VideoMode.java
@@ -31,7 +31,14 @@ public class VideoMode {
     return m_pixelFormatValues[pixelFormat];
   }
 
-  /** Create a new video mode. */
+  /**
+   * Create a new video mode.
+   *
+   * @param pixelFormat The pixel format enum as an integer.
+   * @param width The image width in pixels.
+   * @param height The image height in pixels.
+   * @param fps The camera's frames per second.
+   */
   public VideoMode(int pixelFormat, int width, int height, int fps) {
     this.pixelFormat = getPixelFormatFromInt(pixelFormat);
     this.width = width;
@@ -39,7 +46,14 @@ public class VideoMode {
     this.fps = fps;
   }
 
-  /** Create a new video mode. */
+  /**
+   * Create a new video mode.
+   *
+   * @param pixelFormat The pixel format.
+   * @param width The image width in pixels.
+   * @param height The image height in pixels.
+   * @param fps The camera's frames per second.
+   */
   public VideoMode(PixelFormat pixelFormat, int width, int height, int fps) {
     this.pixelFormat = pixelFormat;
     this.width = width;

--- a/cscore/src/main/java/edu/wpi/first/cscore/VideoSink.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/VideoSink.java
@@ -83,7 +83,11 @@ public class VideoSink implements AutoCloseable {
     return m_handle;
   }
 
-  /** Get the kind of the sink. */
+  /**
+   * Get the kind of the sink.
+   *
+   * @return The kind of the sink.
+   */
   public Kind getKind() {
     return getKindFromInt(CameraServerJNI.getSinkKind(m_handle));
   }
@@ -91,12 +95,18 @@ public class VideoSink implements AutoCloseable {
   /**
    * Get the name of the sink. The name is an arbitrary identifier provided when the sink is
    * created, and should be unique.
+   *
+   * @return The name of the sink.
    */
   public String getName() {
     return CameraServerJNI.getSinkName(m_handle);
   }
 
-  /** Get the sink description. This is sink-kind specific. */
+  /**
+   * Get the sink description. This is sink-kind specific.
+   *
+   * @return The sink description.
+   */
   public String getDescription() {
     return CameraServerJNI.getSinkDescription(m_handle);
   }
@@ -111,7 +121,11 @@ public class VideoSink implements AutoCloseable {
     return new VideoProperty(CameraServerJNI.getSinkProperty(m_handle, name));
   }
 
-  /** Enumerate all properties of this sink. */
+  /**
+   * Enumerate all properties of this sink.
+   *
+   * @return List of properties.
+   */
   public VideoProperty[] enumerateProperties() {
     int[] handles = CameraServerJNI.enumerateSinkProperties(m_handle);
     VideoProperty[] rv = new VideoProperty[handles.length];

--- a/cscore/src/main/java/edu/wpi/first/cscore/VideoSource.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/VideoSource.java
@@ -113,7 +113,11 @@ public class VideoSource implements AutoCloseable {
     return m_handle;
   }
 
-  /** Get the kind of the source. */
+  /**
+   * Get the kind of the source.
+   *
+   * @return The kind of the source.
+   */
   public Kind getKind() {
     return getKindFromInt(CameraServerJNI.getSourceKind(m_handle));
   }
@@ -121,12 +125,18 @@ public class VideoSource implements AutoCloseable {
   /**
    * Get the name of the source. The name is an arbitrary identifier provided when the source is
    * created, and should be unique.
+   *
+   * @return The name of the source.
    */
   public String getName() {
     return CameraServerJNI.getSourceName(m_handle);
   }
 
-  /** Get the source description. This is source-kind specific. */
+  /**
+   * Get the source description. This is source-kind specific.
+   *
+   * @return The source description.
+   */
   public String getDescription() {
     return CameraServerJNI.getSourceDescription(m_handle);
   }
@@ -153,7 +163,11 @@ public class VideoSource implements AutoCloseable {
     CameraServerJNI.setSourceConnectionStrategy(m_handle, strategy.getValue());
   }
 
-  /** Returns if the source currently connected to whatever is providing the images. */
+  /**
+   * Returns true if the source currently connected to whatever is providing the images.
+   *
+   * @return True if the source currently connected to whatever is providing the images.
+   */
   public boolean isConnected() {
     return CameraServerJNI.isSourceConnected(m_handle);
   }
@@ -178,7 +192,11 @@ public class VideoSource implements AutoCloseable {
     return new VideoProperty(CameraServerJNI.getSourceProperty(m_handle, name));
   }
 
-  /** Enumerate all properties of this source. */
+  /**
+   * Enumerate all properties of this source.
+   *
+   * @return Array of video properties.
+   */
   public VideoProperty[] enumerateProperties() {
     int[] handles = CameraServerJNI.enumerateSourceProperties(m_handle);
     VideoProperty[] rv = new VideoProperty[handles.length];
@@ -188,7 +206,11 @@ public class VideoSource implements AutoCloseable {
     return rv;
   }
 
-  /** Get the current video mode. */
+  /**
+   * Get the current video mode.
+   *
+   * @return The current video mode.
+   */
   public VideoMode getVideoMode() {
     return CameraServerJNI.getSourceVideoMode(m_handle);
   }
@@ -197,6 +219,7 @@ public class VideoSource implements AutoCloseable {
    * Set the video mode.
    *
    * @param mode Video mode
+   * @return True if set successfully.
    */
   public boolean setVideoMode(VideoMode mode) {
     return CameraServerJNI.setSourceVideoMode(
@@ -312,7 +335,11 @@ public class VideoSource implements AutoCloseable {
         m_handle, CameraServerJNI.TelemetryKind.kSourceBytesReceived);
   }
 
-  /** Enumerate all known video modes for this source. */
+  /**
+   * Enumerate all known video modes for this source.
+   *
+   * @return Vector of video modes.
+   */
   public VideoMode[] enumerateVideoModes() {
     return CameraServerJNI.enumerateSourceVideoModes(m_handle);
   }

--- a/cscore/src/main/java/edu/wpi/first/cscore/raw/RawFrame.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/raw/RawFrame.java
@@ -35,7 +35,16 @@ public class RawFrame implements AutoCloseable {
     CameraServerJNI.freeRawFrame(m_framePtr);
   }
 
-  /** Called from JNI to set data in class. */
+  /**
+   * Called from JNI to set data in class.
+   *
+   * @param dataByteBuffer A ByteBuffer pointing to the frame data.
+   * @param dataPtr A long (a char* in native code) pointing to the frame data.
+   * @param totalData The total length of the data stored in the frame.
+   * @param width The width of the frame.
+   * @param height The height of the frame.
+   * @param pixelFormat The PixelFormat of the frame.
+   */
   public void setData(
       ByteBuffer dataByteBuffer,
       long dataPtr,
@@ -51,7 +60,11 @@ public class RawFrame implements AutoCloseable {
     m_pixelFormat = pixelFormat;
   }
 
-  /** Get the pointer to native representation of this frame. */
+  /**
+   * Get the pointer to native representation of this frame.
+   *
+   * @return The pointer to native representation of this frame.
+   */
   public long getFramePtr() {
     return m_framePtr;
   }
@@ -60,6 +73,8 @@ public class RawFrame implements AutoCloseable {
    * Get a ByteBuffer pointing to the frame data. This ByteBuffer is backed by the frame directly.
    * Its lifetime is controlled by the frame. If a new frame gets read, it will overwrite the
    * current one.
+   *
+   * @return A ByteBuffer pointing to the frame data.
    */
   public ByteBuffer getDataByteBuffer() {
     return m_dataByteBuffer;
@@ -69,42 +84,72 @@ public class RawFrame implements AutoCloseable {
    * Get a long (is a char* in native code) pointing to the frame data. This pointer is backed by
    * the frame directly. Its lifetime is controlled by the frame. If a new frame gets read, it will
    * overwrite the current one.
+   *
+   * @return A long pointing to the frame data.
    */
   public long getDataPtr() {
     return m_dataPtr;
   }
 
-  /** Get the total length of the data stored in the frame. */
+  /**
+   * Get the total length of the data stored in the frame.
+   *
+   * @return The total length of the data stored in the frame.
+   */
   public int getTotalData() {
     return m_totalData;
   }
 
-  /** Get the width of the frame. */
+  /**
+   * Get the width of the frame.
+   *
+   * @return The width of the frame.
+   */
   public int getWidth() {
     return m_width;
   }
 
-  /** Set the width of the frame. */
+  /**
+   * Set the width of the frame.
+   *
+   * @param width The width of the frame.
+   */
   public void setWidth(int width) {
     this.m_width = width;
   }
 
-  /** Get the height of the frame. */
+  /**
+   * Get the height of the frame.
+   *
+   * @return The height of the frame.
+   */
   public int getHeight() {
     return m_height;
   }
 
-  /** Set the height of the frame. */
+  /**
+   * Set the height of the frame.
+   *
+   * @param height The height of the frame.
+   */
   public void setHeight(int height) {
     this.m_height = height;
   }
 
-  /** Get the PixelFormat of the frame. */
+  /**
+   * Get the PixelFormat of the frame.
+   *
+   * @return The PixelFormat of the frame.
+   */
   public int getPixelFormat() {
     return m_pixelFormat;
   }
 
-  /** Set the PixelFormat of the frame. */
+  /**
+   * Set the PixelFormat of the frame.
+   *
+   * @param pixelFormat The PixelFormat of the frame.
+   */
   public void setPixelFormat(int pixelFormat) {
     this.m_pixelFormat = pixelFormat;
   }

--- a/cscore/src/main/java/edu/wpi/first/cscore/raw/RawSink.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/raw/RawSink.java
@@ -28,6 +28,7 @@ public class RawSink extends ImageSink {
    * Wait for the next frame and get the image. Times out (returning 0) after 0.225 seconds. The
    * provided image will have three 8-bit channels stored in BGR order.
    *
+   * @param frame The frame object in which to store the image.
    * @return Frame time, or 0 on error (call getError() to obtain the error message); the frame time
    *     is in the same time base as wpi::Now(), and is in 1 us increments.
    */
@@ -39,6 +40,8 @@ public class RawSink extends ImageSink {
    * Wait for the next frame and get the image. Times out (returning 0) after timeout seconds. The
    * provided image will have three 8-bit channels stored in BGR order.
    *
+   * @param frame The frame object in which to store the image.
+   * @param timeout The frame timeout in seconds.
    * @return Frame time, or 0 on error (call getError() to obtain the error message); the frame time
    *     is in the same time base as wpi::Now(), and is in 1 us increments.
    */
@@ -50,6 +53,7 @@ public class RawSink extends ImageSink {
    * Wait for the next frame and get the image. May block forever. The provided image will have
    * three 8-bit channels stored in BGR order.
    *
+   * @param frame The frame object in which to store the image.
    * @return Frame time, or 0 on error (call getError() to obtain the error message); the frame time
    *     is in the same time base as wpi::Now(), and is in 1 us increments.
    */

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -68,10 +68,6 @@ doxygen {
     recursive true
     quiet true
     warnings false
-    warn_if_doc_error false
-    warn_no_paramdoc false
-    warn_format false
-    warn_logfile false
     warn_if_undocumented false
     generate_latex false
     use_mathjax true

--- a/hal/src/main/java/edu/wpi/first/hal/AccumulatorResult.java
+++ b/hal/src/main/java/edu/wpi/first/hal/AccumulatorResult.java
@@ -13,7 +13,12 @@ public class AccumulatorResult {
   @SuppressWarnings("MemberName")
   public long count;
 
-  /** Set the value and count. */
+  /**
+   * Set the value and count.
+   *
+   * @param value The total value accumulated.
+   * @param count The number of samples accumulated.
+   */
   public void set(long value, long count) {
     this.value = value;
     this.count = count;

--- a/hal/src/main/java/edu/wpi/first/hal/CANData.java
+++ b/hal/src/main/java/edu/wpi/first/hal/CANData.java
@@ -14,7 +14,13 @@ public class CANData {
   @SuppressWarnings("MemberName")
   public long timestamp;
 
-  /** API used from JNI to set the data. */
+  /**
+   * API used from JNI to set the data.
+   *
+   * @param length Length of packet in bytes.
+   * @param timestamp CAN frame timestamp in microseconds.
+   * @return Buffer containing CAN frame.
+   */
   @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public byte[] setData(int length, long timestamp) {
     this.length = length;

--- a/hal/src/main/java/edu/wpi/first/hal/HAL.java
+++ b/hal/src/main/java/edu/wpi/first/hal/HAL.java
@@ -136,17 +136,18 @@ public final class HAL extends JNIWrapper {
   }
 
   /**
-   * Report the usage of a resource of interest. <br>
+   * Report the usage of a resource of interest.
    *
    * <p>Original signature: <code>uint32_t report(tResourceType, uint8_t, uint8_t, const
    * char*)</code>
    *
-   * @param resource one of the values in the tResourceType above (max value 51). <br>
-   * @param instanceNumber an index that identifies the resource instance. <br>
+   * @param resource one of the values in the tResourceType above (max value 51).
+   * @param instanceNumber an index that identifies the resource instance.
    * @param context an optional additional context number for some cases (such as module number).
-   *     Set to 0 to omit. <br>
+   *     Set to 0 to omit.
    * @param feature a string to be included describing features in use on a specific resource.
    *     Setting the same resource more than once allows you to change the feature string.
+   * @return TODO
    */
   public static native int report(int resource, int instanceNumber, int context, String feature);
 

--- a/hal/src/main/java/edu/wpi/first/hal/JNIWrapper.java
+++ b/hal/src/main/java/edu/wpi/first/hal/JNIWrapper.java
@@ -40,7 +40,11 @@ public class JNIWrapper {
     }
   }
 
-  /** Force load the library. */
+  /**
+   * Force load the library.
+   *
+   * @throws IOException if the library load failed
+   */
   public static synchronized void forceLoad() throws IOException {
     if (libraryLoaded) {
       return;

--- a/hal/src/main/java/edu/wpi/first/hal/MatchInfoData.java
+++ b/hal/src/main/java/edu/wpi/first/hal/MatchInfoData.java
@@ -26,7 +26,15 @@ public class MatchInfoData {
   @SuppressWarnings("MemberName")
   public int matchType;
 
-  /** Called from JNI to set the structure data. */
+  /**
+   * Called from JNI to set the structure data.
+   *
+   * @param eventName Event name.
+   * @param gameSpecificMessage Game-specific message.
+   * @param matchNumber Match number.
+   * @param replayNumber Replay number.
+   * @param matchType Match type.
+   */
   @SuppressWarnings("MissingJavadocMethod")
   public void setData(
       String eventName,

--- a/hal/src/main/java/edu/wpi/first/hal/NotifierJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/NotifierJNI.java
@@ -11,33 +11,65 @@ package edu.wpi.first.hal;
  * class, which corresponds to the C++ Notifier class, should be used.
  */
 public class NotifierJNI extends JNIWrapper {
-  /** Initializes the notifier. */
+  /**
+   * Initializes the notifier.
+   *
+   * @return True on success.
+   */
   public static native int initializeNotifier();
 
-  /** Sets the HAL notifier thread priority. */
+  /**
+   * Sets the HAL notifier thread priority.
+   *
+   * @param realTime Set to true to set a real-time priority, false for standard priority.
+   * @param priority Priority to set the thread to. For real-time, this is 1-99 with 99 being
+   *     highest. For non-real-time, this is forced to 0. See "man 7 sched" for more details.
+   * @return True on success.
+   */
   public static native boolean setHALThreadPriority(boolean realTime, int priority);
 
-  /** Sets the name of the notifier. */
+  /**
+   * Sets the name of the notifier.
+   *
+   * @param notifierHandle Notifier handle.
+   * @param name Notifier name.
+   */
   public static native void setNotifierName(int notifierHandle, String name);
 
   /**
    * Wakes up the waiter with time=0. Note: after this function is called, all calls to
    * waitForNotifierAlarm() will immediately start returning 0.
+   *
+   * @param notifierHandle Notifier handle.
    */
   public static native void stopNotifier(int notifierHandle);
 
-  /** Deletes the notifier object when we are done with it. */
+  /**
+   * Deletes the notifier object when we are done with it.
+   *
+   * @param notifierHandle Notifier handle.
+   */
   public static native void cleanNotifier(int notifierHandle);
 
-  /** Sets the notifier to wakeup the waiter in another triggerTime microseconds. */
+  /**
+   * Sets the notifier to wakeup the waiter in another triggerTime microseconds.
+   *
+   * @param notifierHandle Notifier handle.
+   * @param triggerTime Trigger time in microseconds.
+   */
   public static native void updateNotifierAlarm(int notifierHandle, long triggerTime);
 
-  /** Cancels any pending wakeups set by updateNotifierAlarm(). Does NOT wake up any waiters. */
+  /**
+   * Cancels any pending wakeups set by updateNotifierAlarm(). Does NOT wake up any waiters.
+   *
+   * @param notifierHandle Notifier handle.
+   */
   public static native void cancelNotifierAlarm(int notifierHandle);
 
   /**
    * Block until woken up by an alarm (or stop).
    *
+   * @param notifierHandle Notifier handle.
    * @return Time when woken up.
    */
   public static native long waitForNotifierAlarm(int notifierHandle);

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/SimDeviceDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/SimDeviceDataJNI.java
@@ -61,6 +61,7 @@ public class SimDeviceDataJNI extends JNIWrapper {
    * @param handle simulated value handle
    * @param callback callback
    * @param initialNotify ignored (present for consistency)
+   * @return TODO
    */
   public static native int registerSimValueResetCallback(
       int handle, SimValueCallback callback, boolean initialNotify);

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTable.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTable.java
@@ -366,7 +366,11 @@ public final class NetworkTable {
     return getEntry(key).getValue();
   }
 
-  /** Get the path of the NetworkTable. */
+  /**
+   * Get the path of the NetworkTable.
+   *
+   * @return The path of the NetworkTable.
+   */
   public String getPath() {
     return m_path;
   }

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTablesJNI.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTablesJNI.java
@@ -40,7 +40,11 @@ public final class NetworkTablesJNI {
     }
   }
 
-  /** Force load the library. */
+  /**
+   * Force load the library.
+   *
+   * @throws IOException if the library fails to load
+   */
   public static synchronized void forceLoad() throws IOException {
     if (libraryLoaded) {
       return;

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Button.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Button.java
@@ -177,6 +177,7 @@ public class Button extends Trigger {
    *
    * @param command the command to start
    * @param interruptible whether the command is interruptible
+   * @return this button, so calls can be chained
    */
   public Button toggleWhenPressed(final Command command, boolean interruptible) {
     toggleWhenActive(command, interruptible);

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -173,8 +173,8 @@ class Command {
   PerpetualCommand Perpetually() &&;
 
   /**
-   * Decorates this command to run "by proxy" by wrapping it in a {@link
-   * ProxyScheduleCommand}. This is useful for "forking off" from command groups
+   * Decorates this command to run "by proxy" by wrapping it in a
+   * ProxyScheduleCommand. This is useful for "forking off" from command groups
    * when the user does not wish to extend the command's requirements to the
    * entire command group.
    *

--- a/wpilibNewCommands/src/main/native/include/frc2/command/MecanumControllerCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/MecanumControllerCommand.h
@@ -30,9 +30,9 @@
 
 namespace frc2 {
 /**
- * A command that uses two PID controllers ({@link PIDController}) and a
- * ProfiledPIDController ({@link ProfiledPIDController}) to follow a trajectory
- * {@link Trajectory} with a mecanum drive.
+ * A command that uses two PID controllers (PIDController) and a profiled PID
+ * controller (ProfiledPIDController) to follow a trajectory (Trajectory) with a
+ * mecanum drive.
  *
  * <p>The command handles trajectory-following,
  * Velocity PID calculations, and feedforwards internally. This

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SwerveControllerCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SwerveControllerCommand.h
@@ -29,9 +29,9 @@
 namespace frc2 {
 
 /**
- * A command that uses two PID controllers ({@link PIDController}) and a
- * ProfiledPIDController ({@link ProfiledPIDController}) to follow a trajectory
- * {@link Trajectory} with a swerve drive.
+ * A command that uses two PID controllers (PIDController) and a profiled PID
+ * controller (ProfiledPIDController) to follow a trajectory (Trajectory) with a
+ * swerve drive.
  *
  * <p>The command handles trajectory-following, Velocity PID calculations, and
  * feedforwards internally. This is intended to be a more-or-less "complete

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/NetworkButton.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/NetworkButton.h
@@ -14,7 +14,7 @@
 
 namespace frc2 {
 /**
- * A {@link Button} that uses a {@link NetworkTable} boolean field.
+ * A Button that uses a NetworkTable boolean field.
  */
 class NetworkButton : public Button {
  public:

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
@@ -307,6 +307,8 @@ public class PIDBase implements PIDInterface, PIDOutput, Sendable, AutoCloseable
    * setpoint for the output. If a position PID controller is being used, the F term should be set
    * to 1 over the maximum speed for the output measured in setpoint units per this controller's
    * update period (see the default period in this class's constructor).
+   *
+   * @return The feedforward value.
    */
   protected double calculateFeedForward() {
     if (m_pidInput.getPIDSourceType().equals(PIDSourceType.kRate)) {

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDController.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDController.java
@@ -137,7 +137,11 @@ public class PIDController extends PIDBase implements Controller {
     }
   }
 
-  /** Set the enabled state of the PIDController. */
+  /**
+   * Set the enabled state of the PIDController.
+   *
+   * @param enable True to enable the PIDController.
+   */
   public void setEnabled(boolean enable) {
     if (enable) {
       enable();
@@ -146,7 +150,11 @@ public class PIDController extends PIDBase implements Controller {
     }
   }
 
-  /** Return true if PIDController is enabled. */
+  /**
+   * Return true if PIDController is enabled.
+   *
+   * @return True if PIDController is enabled.
+   */
   public boolean isEnabled() {
     m_thisMutex.lock();
     try {

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
@@ -422,8 +422,7 @@ class SmartDashboard : public Sendable, public SendableHelper<SmartDashboard> {
 
   /**
    * Posts a task from a listener to the ListenerExecutor, so that it can be run
-   * synchronously from the main loop on the next call to {@link
-   * SmartDashboard#updateValues()}.
+   * synchronously from the main loop on the next call to updateValues().
    *
    * @param task The task to run synchronously from the main thread.
    */

--- a/wpilibc/src/main/native/include/frc/util/Color.h
+++ b/wpilibc/src/main/native/include/frc/util/Color.h
@@ -20,17 +20,17 @@ class Color {
    */
 
   /**
-   * #1560BD.
+   * 0x1560BD.
    */
   static const Color kDenim;
 
   /**
-   * #0066B3.
+   * 0x0066B3.
    */
   static const Color kFirstBlue;
 
   /**
-   * #ED1C24.
+   * 0xED1C24.
    */
   static const Color kFirstRed;
 
@@ -39,702 +39,702 @@ class Color {
    */
 
   /**
-   * #F0F8FF.
+   * 0xF0F8FF.
    */
   static const Color kAliceBlue;
 
   /**
-   * #FAEBD7.
+   * 0xFAEBD7.
    */
   static const Color kAntiqueWhite;
 
   /**
-   * #00FFFF.
+   * 0x00FFFF.
    */
   static const Color kAqua;
 
   /**
-   * #7FFFD4.
+   * 0x7FFFD4.
    */
   static const Color kAquamarine;
 
   /**
-   * #F0FFFF.
+   * 0xF0FFFF.
    */
   static const Color kAzure;
 
   /**
-   * #F5F5DC.
+   * 0xF5F5DC.
    */
   static const Color kBeige;
 
   /**
-   * #FFE4C4.
+   * 0xFFE4C4.
    */
   static const Color kBisque;
 
   /**
-   * #000000.
+   * 0x000000.
    */
   static const Color kBlack;
 
   /**
-   * #FFEBCD.
+   * 0xFFEBCD.
    */
   static const Color kBlanchedAlmond;
 
   /**
-   * #0000FF.
+   * 0x0000FF.
    */
   static const Color kBlue;
 
   /**
-   * #8A2BE2.
+   * 0x8A2BE2.
    */
   static const Color kBlueViolet;
 
   /**
-   * #A52A2A.
+   * 0xA52A2A.
    */
   static const Color kBrown;
 
   /**
-   * #DEB887.
+   * 0xDEB887.
    */
   static const Color kBurlywood;
 
   /**
-   * #5F9EA0.
+   * 0x5F9EA0.
    */
   static const Color kCadetBlue;
 
   /**
-   * #7FFF00.
+   * 0x7FFF00.
    */
   static const Color kChartreuse;
 
   /**
-   * #D2691E.
+   * 0xD2691E.
    */
   static const Color kChocolate;
 
   /**
-   * #FF7F50.
+   * 0xFF7F50.
    */
   static const Color kCoral;
 
   /**
-   * #6495ED.
+   * 0x6495ED.
    */
   static const Color kCornflowerBlue;
 
   /**
-   * #FFF8DC.
+   * 0xFFF8DC.
    */
   static const Color kCornsilk;
 
   /**
-   * #DC143C.
+   * 0xDC143C.
    */
   static const Color kCrimson;
 
   /**
-   * #00FFFF.
+   * 0x00FFFF.
    */
   static const Color kCyan;
 
   /**
-   * #00008B.
+   * 0x00008B.
    */
   static const Color kDarkBlue;
 
   /**
-   * #008B8B.
+   * 0x008B8B.
    */
   static const Color kDarkCyan;
 
   /**
-   * #B8860B.
+   * 0xB8860B.
    */
   static const Color kDarkGoldenrod;
 
   /**
-   * #A9A9A9.
+   * 0xA9A9A9.
    */
   static const Color kDarkGray;
 
   /**
-   * #006400.
+   * 0x006400.
    */
   static const Color kDarkGreen;
 
   /**
-   * #BDB76B.
+   * 0xBDB76B.
    */
   static const Color kDarkKhaki;
 
   /**
-   * #8B008B.
+   * 0x8B008B.
    */
   static const Color kDarkMagenta;
 
   /**
-   * #556B2F.
+   * 0x556B2F.
    */
   static const Color kDarkOliveGreen;
 
   /**
-   * #FF8C00.
+   * 0xFF8C00.
    */
   static const Color kDarkOrange;
 
   /**
-   * #9932CC.
+   * 0x9932CC.
    */
   static const Color kDarkOrchid;
 
   /**
-   * #8B0000.
+   * 0x8B0000.
    */
   static const Color kDarkRed;
 
   /**
-   * #E9967A.
+   * 0xE9967A.
    */
   static const Color kDarkSalmon;
 
   /**
-   * #8FBC8F.
+   * 0x8FBC8F.
    */
   static const Color kDarkSeaGreen;
 
   /**
-   * #483D8B.
+   * 0x483D8B.
    */
   static const Color kDarkSlateBlue;
 
   /**
-   * #2F4F4F.
+   * 0x2F4F4F.
    */
   static const Color kDarkSlateGray;
 
   /**
-   * #00CED1.
+   * 0x00CED1.
    */
   static const Color kDarkTurquoise;
 
   /**
-   * #9400D3.
+   * 0x9400D3.
    */
   static const Color kDarkViolet;
 
   /**
-   * #FF1493.
+   * 0xFF1493.
    */
   static const Color kDeepPink;
 
   /**
-   * #00BFFF.
+   * 0x00BFFF.
    */
   static const Color kDeepSkyBlue;
 
   /**
-   * #696969.
+   * 0x696969.
    */
   static const Color kDimGray;
 
   /**
-   * #1E90FF.
+   * 0x1E90FF.
    */
   static const Color kDodgerBlue;
 
   /**
-   * #B22222.
+   * 0xB22222.
    */
   static const Color kFirebrick;
 
   /**
-   * #FFFAF0.
+   * 0xFFFAF0.
    */
   static const Color kFloralWhite;
 
   /**
-   * #228B22.
+   * 0x228B22.
    */
   static const Color kForestGreen;
 
   /**
-   * #FF00FF.
+   * 0xFF00FF.
    */
   static const Color kFuchsia;
 
   /**
-   * #DCDCDC.
+   * 0xDCDCDC.
    */
   static const Color kGainsboro;
 
   /**
-   * #F8F8FF.
+   * 0xF8F8FF.
    */
   static const Color kGhostWhite;
 
   /**
-   * #FFD700.
+   * 0xFFD700.
    */
   static const Color kGold;
 
   /**
-   * #DAA520.
+   * 0xDAA520.
    */
   static const Color kGoldenrod;
 
   /**
-   * #808080.
+   * 0x808080.
    */
   static const Color kGray;
 
   /**
-   * #008000.
+   * 0x008000.
    */
   static const Color kGreen;
 
   /**
-   * #ADFF2F.
+   * 0xADFF2F.
    */
   static const Color kGreenYellow;
 
   /**
-   * #F0FFF0.
+   * 0xF0FFF0.
    */
   static const Color kHoneydew;
 
   /**
-   * #FF69B4.
+   * 0xFF69B4.
    */
   static const Color kHotPink;
 
   /**
-   * #CD5C5C.
+   * 0xCD5C5C.
    */
   static const Color kIndianRed;
 
   /**
-   * #4B0082.
+   * 0x4B0082.
    */
   static const Color kIndigo;
 
   /**
-   * #FFFFF0.
+   * 0xFFFFF0.
    */
   static const Color kIvory;
 
   /**
-   * #F0E68C.
+   * 0xF0E68C.
    */
   static const Color kKhaki;
 
   /**
-   * #E6E6FA.
+   * 0xE6E6FA.
    */
   static const Color kLavender;
 
   /**
-   * #FFF0F5.
+   * 0xFFF0F5.
    */
   static const Color kLavenderBlush;
 
   /**
-   * #7CFC00.
+   * 0x7CFC00.
    */
   static const Color kLawnGreen;
 
   /**
-   * #FFFACD.
+   * 0xFFFACD.
    */
   static const Color kLemonChiffon;
 
   /**
-   * #ADD8E6.
+   * 0xADD8E6.
    */
   static const Color kLightBlue;
 
   /**
-   * #F08080.
+   * 0xF08080.
    */
   static const Color kLightCoral;
 
   /**
-   * #E0FFFF.
+   * 0xE0FFFF.
    */
   static const Color kLightCyan;
 
   /**
-   * #FAFAD2.
+   * 0xFAFAD2.
    */
   static const Color kLightGoldenrodYellow;
 
   /**
-   * #D3D3D3.
+   * 0xD3D3D3.
    */
   static const Color kLightGray;
 
   /**
-   * #90EE90.
+   * 0x90EE90.
    */
   static const Color kLightGreen;
 
   /**
-   * #FFB6C1.
+   * 0xFFB6C1.
    */
   static const Color kLightPink;
 
   /**
-   * #FFA07A.
+   * 0xFFA07A.
    */
   static const Color kLightSalmon;
 
   /**
-   * #20B2AA.
+   * 0x20B2AA.
    */
   static const Color kLightSeaGreen;
 
   /**
-   * #87CEFA.
+   * 0x87CEFA.
    */
   static const Color kLightSkyBlue;
 
   /**
-   * #778899.
+   * 0x778899.
    */
   static const Color kLightSlateGray;
 
   /**
-   * #B0C4DE.
+   * 0xB0C4DE.
    */
   static const Color kLightSteelBlue;
 
   /**
-   * #FFFFE0.
+   * 0xFFFFE0.
    */
   static const Color kLightYellow;
 
   /**
-   * #00FF00.
+   * 0x00FF00.
    */
   static const Color kLime;
 
   /**
-   * #32CD32.
+   * 0x32CD32.
    */
   static const Color kLimeGreen;
 
   /**
-   * #FAF0E6.
+   * 0xFAF0E6.
    */
   static const Color kLinen;
 
   /**
-   * #FF00FF.
+   * 0xFF00FF.
    */
   static const Color kMagenta;
 
   /**
-   * #800000.
+   * 0x800000.
    */
   static const Color kMaroon;
 
   /**
-   * #66CDAA.
+   * 0x66CDAA.
    */
   static const Color kMediumAquamarine;
 
   /**
-   * #0000CD.
+   * 0x0000CD.
    */
   static const Color kMediumBlue;
 
   /**
-   * #BA55D3.
+   * 0xBA55D3.
    */
   static const Color kMediumOrchid;
 
   /**
-   * #9370DB.
+   * 0x9370DB.
    */
   static const Color kMediumPurple;
 
   /**
-   * #3CB371.
+   * 0x3CB371.
    */
   static const Color kMediumSeaGreen;
 
   /**
-   * #7B68EE.
+   * 0x7B68EE.
    */
   static const Color kMediumSlateBlue;
 
   /**
-   * #00FA9A.
+   * 0x00FA9A.
    */
   static const Color kMediumSpringGreen;
 
   /**
-   * #48D1CC.
+   * 0x48D1CC.
    */
   static const Color kMediumTurquoise;
 
   /**
-   * #C71585.
+   * 0xC71585.
    */
   static const Color kMediumVioletRed;
 
   /**
-   * #191970.
+   * 0x191970.
    */
   static const Color kMidnightBlue;
 
   /**
-   * #F5FFFA.
+   * 0xF5FFFA.
    */
   static const Color kMintcream;
 
   /**
-   * #FFE4E1.
+   * 0xFFE4E1.
    */
   static const Color kMistyRose;
 
   /**
-   * #FFE4B5.
+   * 0xFFE4B5.
    */
   static const Color kMoccasin;
 
   /**
-   * #FFDEAD.
+   * 0xFFDEAD.
    */
   static const Color kNavajoWhite;
 
   /**
-   * #000080.
+   * 0x000080.
    */
   static const Color kNavy;
 
   /**
-   * #FDF5E6.
+   * 0xFDF5E6.
    */
   static const Color kOldLace;
 
   /**
-   * #808000.
+   * 0x808000.
    */
   static const Color kOlive;
 
   /**
-   * #6B8E23.
+   * 0x6B8E23.
    */
   static const Color kOliveDrab;
 
   /**
-   * #FFA500.
+   * 0xFFA500.
    */
   static const Color kOrange;
 
   /**
-   * #FF4500.
+   * 0xFF4500.
    */
   static const Color kOrangeRed;
 
   /**
-   * #DA70D6.
+   * 0xDA70D6.
    */
   static const Color kOrchid;
 
   /**
-   * #EEE8AA.
+   * 0xEEE8AA.
    */
   static const Color kPaleGoldenrod;
 
   /**
-   * #98FB98.
+   * 0x98FB98.
    */
   static const Color kPaleGreen;
 
   /**
-   * #AFEEEE.
+   * 0xAFEEEE.
    */
   static const Color kPaleTurquoise;
 
   /**
-   * #DB7093.
+   * 0xDB7093.
    */
   static const Color kPaleVioletRed;
 
   /**
-   * #FFEFD5.
+   * 0xFFEFD5.
    */
   static const Color kPapayaWhip;
 
   /**
-   * #FFDAB9.
+   * 0xFFDAB9.
    */
   static const Color kPeachPuff;
 
   /**
-   * #CD853F.
+   * 0xCD853F.
    */
   static const Color kPeru;
 
   /**
-   * #FFC0CB.
+   * 0xFFC0CB.
    */
   static const Color kPink;
 
   /**
-   * #DDA0DD.
+   * 0xDDA0DD.
    */
   static const Color kPlum;
 
   /**
-   * #B0E0E6.
+   * 0xB0E0E6.
    */
   static const Color kPowderBlue;
 
   /**
-   * #800080.
+   * 0x800080.
    */
   static const Color kPurple;
 
   /**
-   * #FF0000.
+   * 0xFF0000.
    */
   static const Color kRed;
 
   /**
-   * #BC8F8F.
+   * 0xBC8F8F.
    */
   static const Color kRosyBrown;
 
   /**
-   * #4169E1.
+   * 0x4169E1.
    */
   static const Color kRoyalBlue;
 
   /**
-   * #8B4513.
+   * 0x8B4513.
    */
   static const Color kSaddleBrown;
 
   /**
-   * #FA8072.
+   * 0xFA8072.
    */
   static const Color kSalmon;
 
   /**
-   * #F4A460.
+   * 0xF4A460.
    */
   static const Color kSandyBrown;
 
   /**
-   * #2E8B57.
+   * 0x2E8B57.
    */
   static const Color kSeaGreen;
 
   /**
-   * #FFF5EE.
+   * 0xFFF5EE.
    */
   static const Color kSeashell;
 
   /**
-   * #A0522D.
+   * 0xA0522D.
    */
   static const Color kSienna;
 
   /**
-   * #C0C0C0.
+   * 0xC0C0C0.
    */
   static const Color kSilver;
 
   /**
-   * #87CEEB.
+   * 0x87CEEB.
    */
   static const Color kSkyBlue;
 
   /**
-   * #6A5ACD.
+   * 0x6A5ACD.
    */
   static const Color kSlateBlue;
 
   /**
-   * #708090.
+   * 0x708090.
    */
   static const Color kSlateGray;
 
   /**
-   * #FFFAFA.
+   * 0xFFFAFA.
    */
   static const Color kSnow;
 
   /**
-   * #00FF7F.
+   * 0x00FF7F.
    */
   static const Color kSpringGreen;
 
   /**
-   * #4682B4.
+   * 0x4682B4.
    */
   static const Color kSteelBlue;
 
   /**
-   * #D2B48C.
+   * 0xD2B48C.
    */
   static const Color kTan;
 
   /**
-   * #008080.
+   * 0x008080.
    */
   static const Color kTeal;
 
   /**
-   * #D8BFD8.
+   * 0xD8BFD8.
    */
   static const Color kThistle;
 
   /**
-   * #FF6347.
+   * 0xFF6347.
    */
   static const Color kTomato;
 
   /**
-   * #40E0D0.
+   * 0x40E0D0.
    */
   static const Color kTurquoise;
 
   /**
-   * #EE82EE.
+   * 0xEE82EE.
    */
   static const Color kViolet;
 
   /**
-   * #F5DEB3.
+   * 0xF5DEB3.
    */
   static const Color kWheat;
 
   /**
-   * #FFFFFF.
+   * 0xFFFFFF.
    */
   static const Color kWhite;
 
   /**
-   * #F5F5F5.
+   * 0xF5F5F5.
    */
   static const Color kWhiteSmoke;
 
   /**
-   * #FFFF00.
+   * 0xFFFF00.
    */
   static const Color kYellow;
 
   /**
-   * #9ACD32.
+   * 0x9ACD32.
    */
   static const Color kYellowGreen;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogInput.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogInput.java
@@ -227,6 +227,8 @@ public class AnalogInput implements Sendable, AutoCloseable {
    * <p>This center value is based on the output of the oversampled and averaged source the
    * accumulator channel. Because of this, any non-zero oversample bits will affect the size of the
    * value for this field.
+   *
+   * @param center The accumulator's center value.
    */
   public void setAccumulatorCenter(int center) {
     AnalogJNI.setAccumulatorCenter(m_port, center);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogOutput.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogOutput.java
@@ -39,7 +39,11 @@ public class AnalogOutput implements Sendable, AutoCloseable {
     m_channel = 0;
   }
 
-  /** Get the channel of this AnalogOutput. */
+  /**
+   * Get the channel of this AnalogOutput.
+   *
+   * @return The channel of this AnalogOutput.
+   */
   public int getChannel() {
     return m_channel;
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/CAN.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/CAN.java
@@ -96,6 +96,7 @@ public class CAN implements Closeable {
    *
    * @param data The data to write (8 bytes max)
    * @param apiId The API ID to write.
+   * @return TODO
    */
   public int writePacketNoThrow(byte[] data, int apiId) {
     return CANAPIJNI.writeCANPacketNoThrow(m_handle, data, apiId);
@@ -108,6 +109,7 @@ public class CAN implements Closeable {
    * @param data The data to write (8 bytes max)
    * @param apiId The API ID to write.
    * @param repeatMs The period to repeat the packet at.
+   * @return TODO
    */
   public int writePacketRepeatingNoThrow(byte[] data, int apiId, int repeatMs) {
     return CANAPIJNI.writeCANPacketRepeatingNoThrow(m_handle, data, apiId, repeatMs);
@@ -119,6 +121,7 @@ public class CAN implements Closeable {
    *
    * @param length The length to request (0 to 8)
    * @param apiId The API ID to write.
+   * @return TODO
    */
   public int writeRTRFrameNoThrow(int length, int apiId) {
     return CANAPIJNI.writeCANRTRFrameNoThrow(m_handle, length, apiId);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Counter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Counter.java
@@ -53,7 +53,11 @@ public class Counter implements CounterBase, Sendable, AutoCloseable {
   private int m_index; // /< The index of this counter.
   private double m_distancePerPulse; // distance of travel for each tick
 
-  /** Create an instance of a counter with the given mode. */
+  /**
+   * Create an instance of a counter with the given mode.
+   *
+   * @param mode The counter mode.
+   */
   public Counter(final Mode mode) {
     ByteBuffer index = ByteBuffer.allocateDirect(4);
     // set the byte order

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -343,6 +343,7 @@ public class DriverStation {
   /**
    * Report error to Driver Station. Optionally appends Stack trace to error message.
    *
+   * @param error The error to report.
    * @param printTrace If true, append stack trace to error string
    */
   public static void reportError(String error, boolean printTrace) {
@@ -352,6 +353,7 @@ public class DriverStation {
   /**
    * Report error to Driver Station. Appends provided stack trace to error message.
    *
+   * @param error The error to report.
    * @param stackTrace The stack trace to append
    */
   public static void reportError(String error, StackTraceElement[] stackTrace) {
@@ -361,19 +363,21 @@ public class DriverStation {
   /**
    * Report warning to Driver Station. Optionally appends Stack trace to warning message.
    *
+   * @param warning The warning to report.
    * @param printTrace If true, append stack trace to warning string
    */
-  public static void reportWarning(String error, boolean printTrace) {
-    reportErrorImpl(false, 1, error, printTrace);
+  public static void reportWarning(String warning, boolean printTrace) {
+    reportErrorImpl(false, 1, warning, printTrace);
   }
 
   /**
    * Report warning to Driver Station. Appends provided stack trace to warning message.
    *
+   * @param warning The warning to report.
    * @param stackTrace The stack trace to append
    */
-  public static void reportWarning(String error, StackTraceElement[] stackTrace) {
-    reportErrorImpl(false, 1, error, stackTrace);
+  public static void reportWarning(String warning, StackTraceElement[] stackTrace) {
+    reportErrorImpl(false, 1, warning, stackTrace);
   }
 
   private static void reportErrorImpl(boolean isError, int code, String error, boolean printTrace) {
@@ -565,6 +569,8 @@ public class DriverStation {
   /**
    * Get the state of a POV on the joystick.
    *
+   * @param stick The joystick to read.
+   * @param pov The POV to read.
    * @return the angle of the POV in degrees, or -1 if the POV is not pressed.
    */
   public int getStickPOV(int stick, int pov) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
@@ -192,12 +192,20 @@ public abstract class GenericHID {
     return m_ds.getStickAxisCount(m_port);
   }
 
-  /** For the current HID, return the number of POVs. */
+  /**
+   * For the current HID, return the number of POVs.
+   *
+   * @return the number of POVs for the current HID
+   */
   public int getPOVCount() {
     return m_ds.getStickPOVCount(m_port);
   }
 
-  /** For the current HID, return the number of buttons. */
+  /**
+   * For the current HID, return the number of buttons.
+   *
+   * @return the number of buttons for the current HID
+   */
   public int getButtonCount() {
     return m_ds.getStickButtonCount(m_port);
   }
@@ -232,6 +240,7 @@ public abstract class GenericHID {
   /**
    * Get the axis type of a joystick axis.
    *
+   * @param axis The axis to read, starting at 0.
    * @return the axis type of a joystick axis.
    */
   public int getAxisType(int axis) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -203,7 +203,11 @@ public abstract class IterativeRobotBase extends RobotBase {
     m_ntFlushEnabled = enabled;
   }
 
-  /** Gets time period between calls to Periodic() functions. */
+  /**
+   * Gets time period between calls to Periodic() functions.
+   *
+   * @return The time period between calls to Periodic() functions.
+   */
   public double getPeriod() {
     return m_period;
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWM.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWM.java
@@ -117,6 +117,8 @@ public class PWM implements Sendable, AutoCloseable {
    * Gets the bounds on the PWM pulse widths. This Gets the bounds on the PWM values for a
    * particular type of controller. The values determine the upper and lower speeds as well as the
    * deadband bracket.
+   *
+   * @return The bounds on the PWM pulse widths.
    */
   public PWMConfigDataResult getRawBounds() {
     return PWMJNI.getPWMConfigRaw(m_handle);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistributionPanel.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistributionPanel.java
@@ -67,6 +67,7 @@ public class PowerDistributionPanel implements Sendable, AutoCloseable {
   /**
    * Query the current of a single channel of the PDP.
    *
+   * @param channel The PDP channel to query.
    * @return The current of one of the PDP channels (channels 0-15) in Amperes
    */
   public double getCurrent(int channel) {
@@ -114,7 +115,11 @@ public class PowerDistributionPanel implements Sendable, AutoCloseable {
     PDPJNI.clearPDPStickyFaults(m_handle);
   }
 
-  /** Gets module number (CAN ID). */
+  /**
+   * Gets module number (CAN ID).
+   *
+   * @return The module number (CAN ID).
+   */
   public int getModule() {
     return m_module;
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -357,14 +357,23 @@ public abstract class RobotBase implements AutoCloseable {
     }
   }
 
-  /** Suppress the "Robots should not quit" message. */
+  /**
+   * Suppress the "Robots should not quit" message.
+   *
+   * @param value True if exit warning should be suppressed.
+   */
   public static void suppressExitWarning(boolean value) {
     m_runMutex.lock();
     m_suppressExitWarning = value;
     m_runMutex.unlock();
   }
 
-  /** Starting point for the applications. */
+  /**
+   * Starting point for the applications.
+   *
+   * @param <T> Robot subclass.
+   * @param robotSupplier Function that returns an instance of the robot subclass.
+   */
   public static <T extends RobotBase> void startRobot(Supplier<T> robotSupplier) {
     if (!HAL.initialize(500, 0)) {
       throw new IllegalStateException("Failed to initialize. Terminating");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SPI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SPI.java
@@ -158,6 +158,10 @@ public class SPI implements AutoCloseable {
    *
    * <p>If not running in output only mode, also saves the data received on the CIPO input during
    * the transfer into the receive FIFO.
+   *
+   * @param dataToSend The buffer containing the data to send.
+   * @param size The number of bytes to send.
+   * @return Number of bytes written or -1 on error.
    */
   public int write(byte[] dataToSend, int size) {
     if (dataToSend.length < size) {
@@ -173,6 +177,8 @@ public class SPI implements AutoCloseable {
    * the transfer into the receive FIFO.
    *
    * @param dataToSend The buffer containing the data to send.
+   * @param size The number of bytes to send.
+   * @return Number of bytes written or -1 on error.
    */
   @SuppressWarnings("ByteBufferBackingArray")
   public int write(ByteBuffer dataToSend, int size) {
@@ -198,6 +204,9 @@ public class SPI implements AutoCloseable {
    * @param initiate If true, this function pushes "0" into the transmit buffer and initiates a
    *     transfer. If false, this function assumes that data is already in the receive FIFO from a
    *     previous write.
+   * @param dataReceived Buffer in which to store bytes read.
+   * @param size Number of bytes to read.
+   * @return Number of bytes read or -1 on error.
    */
   public int read(boolean initiate, byte[] dataReceived, int size) {
     if (dataReceived.length < size) {
@@ -218,6 +227,7 @@ public class SPI implements AutoCloseable {
    *     previous write.
    * @param dataReceived The buffer to be filled with the received data.
    * @param size The length of the transaction, in bytes
+   * @return Number of bytes read or -1 on error.
    */
   @SuppressWarnings("ByteBufferBackingArray")
   public int read(boolean initiate, ByteBuffer dataReceived, int size) {
@@ -239,6 +249,7 @@ public class SPI implements AutoCloseable {
    * @param dataToSend The data to be written out to the device
    * @param dataReceived Buffer to receive data from the device
    * @param size The length of the transaction, in bytes
+   * @return TODO
    */
   public int transaction(byte[] dataToSend, byte[] dataReceived, int size) {
     if (dataToSend.length < size) {
@@ -256,6 +267,7 @@ public class SPI implements AutoCloseable {
    * @param dataToSend The data to be written out to the device.
    * @param dataReceived Buffer to receive data from the device.
    * @param size The length of the transaction, in bytes
+   * @return TODO
    */
   @SuppressWarnings("ByteBufferBackingArray")
   public int transaction(ByteBuffer dataToSend, ByteBuffer dataReceived, int size) {
@@ -640,6 +652,8 @@ public class SPI implements AutoCloseable {
    * <p>The center value is subtracted from each value before it is added to the accumulator. This
    * is used for the center value of devices like gyros and accelerometers to make integration work
    * and to take the device offset into account when integrating.
+   *
+   * @param center The accumulator's center value.
    */
   public void setAccumulatorCenter(int center) {
     if (m_accum == null) {
@@ -650,7 +664,11 @@ public class SPI implements AutoCloseable {
     }
   }
 
-  /** Set the accumulator's deadband. */
+  /**
+   * Set the accumulator's deadband.
+   *
+   * @param deadband The accumulator's deadband.
+   */
   public void setAccumulatorDeadband(int deadband) {
     if (m_accum == null) {
       return;
@@ -660,7 +678,11 @@ public class SPI implements AutoCloseable {
     }
   }
 
-  /** Read the last value read by the accumulator engine. */
+  /**
+   * Read the last value read by the accumulator engine.
+   *
+   * @return The last value read by the accumulator engine.
+   */
   public int getAccumulatorLastValue() {
     if (m_accum == null) {
       return 0;
@@ -750,6 +772,8 @@ public class SPI implements AutoCloseable {
    * <p>The center value is subtracted from each value*dt before it is added to the integrated
    * value. This is used for the center value of devices like gyros and accelerometers to take the
    * device offset into account when integrating.
+   *
+   * @param center The accumulator integrator's center value.
    */
   public void setAccumulatorIntegratedCenter(double center) {
     if (m_accum == null) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SerialPort.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SerialPort.java
@@ -158,6 +158,7 @@ public class SerialPort implements AutoCloseable {
    * Create an instance of a Serial Port class. Defaults to one stop bit.
    *
    * @param baudRate The baud rate to configure the serial port.
+   * @param port The serial port to use.
    * @param dataBits The number of data bits per transfer. Valid values are between 5 and 8 bits.
    * @param parity Select the type of parity checking to use.
    */
@@ -169,6 +170,7 @@ public class SerialPort implements AutoCloseable {
    * Create an instance of a Serial Port class. Defaults to no parity and one stop bit.
    *
    * @param baudRate The baud rate to configure the serial port.
+   * @param port The serial port to use.
    * @param dataBits The number of data bits per transfer. Valid values are between 5 and 8 bits.
    */
   public SerialPort(final int baudRate, Port port, final int dataBits) {
@@ -179,6 +181,7 @@ public class SerialPort implements AutoCloseable {
    * Create an instance of a Serial Port class. Defaults to 8 databits, no parity, and one stop bit.
    *
    * @param baudRate The baud rate to configure the serial port.
+   * @param port The serial port to use.
    */
   public SerialPort(final int baudRate, Port port) {
     this(baudRate, port, 8, Parity.kNone, StopBits.kOne);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Solenoid.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Solenoid.java
@@ -77,7 +77,11 @@ public class Solenoid implements Sendable, AutoCloseable {
     set(!get());
   }
 
-  /** Get the channel this solenoid is connected to. */
+  /**
+   * Get the channel this solenoid is connected to.
+   *
+   * @return The channel this solenoid is connected to.
+   */
   public int getChannel() {
     return m_channel;
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SpeedControllerGroup.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SpeedControllerGroup.java
@@ -24,6 +24,7 @@ public class SpeedControllerGroup implements MotorController, Sendable, AutoClos
   /**
    * Create a new SpeedControllerGroup with the provided SpeedControllers.
    *
+   * @param speedController The first SpeedController to add.
    * @param speedControllers The SpeedControllers to add
    */
   public SpeedControllerGroup(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SynchronousInterrupt.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SynchronousInterrupt.java
@@ -35,7 +35,13 @@ public class SynchronousInterrupt implements AutoCloseable {
       this.value = value;
     }
 
-    /** Create a wait result. */
+    /**
+     * Create a wait result.
+     *
+     * @param rising True if a rising edge occured.
+     * @param falling True if a falling edge occured.
+     * @return A wait result.
+     */
     public static WaitResult getValue(boolean rising, boolean falling) {
       if (rising && falling) {
         return kBoth;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -81,7 +81,11 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
     return Double.hashCode(m_expirationTime);
   }
 
-  /** Returns the time in seconds since the watchdog was last fed. */
+  /**
+   * Returns the time in seconds since the watchdog was last fed.
+   *
+   * @return The time in seconds since the watchdog was last fed.
+   */
   public double getTime() {
     return Timer.getFPGATimestamp() - m_startTime;
   }
@@ -109,7 +113,11 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
     }
   }
 
-  /** Returns the watchdog's timeout in seconds. */
+  /**
+   * Returns the watchdog's timeout in seconds.
+   *
+   * @return The watchdog's timeout in seconds.
+   */
   public double getTimeout() {
     m_queueMutex.lock();
     try {
@@ -119,7 +127,11 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
     }
   }
 
-  /** Returns true if the watchdog timer has expired. */
+  /**
+   * Returns true if the watchdog timer has expired.
+   *
+   * @return True if the watchdog timer has expired.
+   */
   public boolean isExpired() {
     m_queueMutex.lock();
     try {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
@@ -234,7 +234,11 @@ public class PIDController implements Sendable, AutoCloseable {
     m_continuous = false;
   }
 
-  /** Returns true if continuous input is enabled. */
+  /**
+   * Returns true if continuous input is enabled.
+   *
+   * @return True if continuous input is enabled.
+   */
   public boolean isContinuousInputEnabled() {
     return m_continuous;
   }
@@ -282,7 +286,11 @@ public class PIDController implements Sendable, AutoCloseable {
     return m_positionError;
   }
 
-  /** Returns the velocity error. */
+  /**
+   * Returns the velocity error.
+   *
+   * @return The velocity error.
+   */
   public double getVelocityError() {
     return m_velocityError;
   }
@@ -292,6 +300,7 @@ public class PIDController implements Sendable, AutoCloseable {
    *
    * @param measurement The current measurement of the process variable.
    * @param setpoint The new setpoint of the controller.
+   * @return The next controller output.
    */
   public double calculate(double measurement, double setpoint) {
     // Set setpoint to provided value
@@ -303,6 +312,7 @@ public class PIDController implements Sendable, AutoCloseable {
    * Returns the next output of the PID controller.
    *
    * @param measurement The current measurement of the process variable.
+   * @return The next controller output.
    */
   public double calculate(double measurement) {
     m_measurement = measurement;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
@@ -155,7 +155,11 @@ public class ProfiledPIDController implements Sendable {
     m_goal = new TrapezoidProfile.State(goal, 0);
   }
 
-  /** Gets the goal for the ProfiledPIDController. */
+  /**
+   * Gets the goal for the ProfiledPIDController.
+   *
+   * @return The goal.
+   */
   public TrapezoidProfile.State getGoal() {
     return m_goal;
   }
@@ -164,6 +168,8 @@ public class ProfiledPIDController implements Sendable {
    * Returns true if the error is within the tolerance of the error.
    *
    * <p>This will return false until at least one input value has been computed.
+   *
+   * @return True if the error is within the tolerance of the error.
    */
   public boolean atGoal() {
     return atSetpoint() && m_goal.equals(m_setpoint);
@@ -191,6 +197,8 @@ public class ProfiledPIDController implements Sendable {
    * Returns true if the error is within the tolerance of the error.
    *
    * <p>This will return false until at least one input value has been computed.
+   *
+   * @return True if the error is within the tolerance of the error.
    */
   public boolean atSetpoint() {
     return m_controller.atSetpoint();
@@ -257,7 +265,11 @@ public class ProfiledPIDController implements Sendable {
     return m_controller.getPositionError();
   }
 
-  /** Returns the change in error per second. */
+  /**
+   * Returns the change in error per second.
+   *
+   * @return The change in error per second.
+   */
   public double getVelocityError() {
     return m_controller.getVelocityError();
   }
@@ -266,6 +278,7 @@ public class ProfiledPIDController implements Sendable {
    * Returns the next output of the PID controller.
    *
    * @param measurement The current measurement of the process variable.
+   * @return The controller's next output.
    */
   public double calculate(double measurement) {
     if (m_controller.isContinuousInputEnabled()) {
@@ -294,6 +307,7 @@ public class ProfiledPIDController implements Sendable {
    *
    * @param measurement The current measurement of the process variable.
    * @param goal The new goal of the controller.
+   * @return The controller's next output.
    */
   public double calculate(double measurement, TrapezoidProfile.State goal) {
     setGoal(goal);
@@ -305,6 +319,7 @@ public class ProfiledPIDController implements Sendable {
    *
    * @param measurement The current measurement of the process variable.
    * @param goal The new goal of the controller.
+   * @return The controller's next output.
    */
   public double calculate(double measurement, double goal) {
     setGoal(goal);
@@ -317,6 +332,7 @@ public class ProfiledPIDController implements Sendable {
    * @param measurement The current measurement of the process variable.
    * @param goal The new goal of the controller.
    * @param constraints Velocity and acceleration constraints for goal.
+   * @return The controller's next output.
    */
   public double calculate(
       double measurement, TrapezoidProfile.State goal, TrapezoidProfile.Constraints constraints) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -120,6 +120,9 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * <p>To pass multiple motors per side, use a {@link
    * edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup}. If a motor needs to be inverted, do
    * so before passing it in.
+   *
+   * @param leftMotor Left motor.
+   * @param rightMotor Right motor.
    */
   public DifferentialDrive(SpeedController leftMotor, SpeedController rightMotor) {
     requireNonNull(leftMotor, "Left motor cannot be null");
@@ -256,6 +259,7 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
    *     positive.
    * @param squareInputs If set, decreases the input sensitivity at low speeds.
+   * @return Wheel speeds.
    */
   @SuppressWarnings("ParameterName")
   public static WheelSpeeds arcadeDriveIK(double xSpeed, double zRotation, boolean squareInputs) {
@@ -317,6 +321,7 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    *     positive.
    * @param allowTurnInPlace If set, overrides constant-curvature turning for turn-in-place
    *     maneuvers.
+   * @return Wheel speeds.
    */
   @SuppressWarnings("ParameterName")
   public static WheelSpeeds curvatureDriveIK(
@@ -352,6 +357,7 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * @param rightSpeed The robot right side's speed along the X axis [-1.0..1.0]. Forward is
    *     positive.
    * @param squareInputs If set, decreases the input sensitivity at low speeds.
+   * @return Wheel speeds.
    */
   public static WheelSpeeds tankDriveIK(double leftSpeed, double rightSpeed, boolean squareInputs) {
     leftSpeed = MathUtil.clamp(leftSpeed, -1.0, 1.0);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
@@ -240,6 +240,7 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
    *     positive.
    * @param gyroAngle The current angle reading from the gyro in degrees around the Z axis. Use this
    *     to implement field-oriented controls.
+   * @return Wheel speeds.
    */
   @SuppressWarnings("ParameterName")
   public WheelSpeeds driveCartesianIK(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
@@ -99,6 +99,11 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
    * Construct a MecanumDrive.
    *
    * <p>If a motor needs to be inverted, do so before passing it in.
+   *
+   * @param frontLeftMotor The motor on the front-left corner.
+   * @param rearLeftMotor The motor on the rear-left corner.
+   * @param frontRightMotor The motor on the front-right corner.
+   * @param rearRightMotor The motor on the rear-right corner.
    */
   public MecanumDrive(
       SpeedController frontLeftMotor,
@@ -214,6 +219,7 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
    *     positive.
    * @param gyroAngle The current angle reading from the gyro in degrees around the Z axis. Use this
    *     to implement field-oriented controls.
+   * @return Wheel speeds.
    */
   @SuppressWarnings("ParameterName")
   public static WheelSpeeds driveCartesianIK(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/RobotDriveBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/RobotDriveBase.java
@@ -82,6 +82,7 @@ public abstract class RobotDriveBase extends MotorSafety {
    *
    * @param value value to clip
    * @param deadband range around zero
+   * @return The value after the deadband is applied.
    */
   protected static double applyDeadband(double value, double deadband) {
     if (Math.abs(value) > deadband) {
@@ -95,7 +96,11 @@ public abstract class RobotDriveBase extends MotorSafety {
     }
   }
 
-  /** Normalize all wheel speeds if the magnitude of any wheel is greater than 1.0. */
+  /**
+   * Normalize all wheel speeds if the magnitude of any wheel is greater than 1.0.
+   *
+   * @param wheelSpeeds List of wheel speeds to normalize.
+   */
   protected static void normalize(double[] wheelSpeeds) {
     double maxMagnitude = Math.abs(wheelSpeeds[0]);
     for (int i = 1; i < wheelSpeeds.length; i++) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/Vector2d.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/Vector2d.java
@@ -38,12 +38,17 @@ public class Vector2d {
    * Returns dot product of this vector with argument.
    *
    * @param vec Vector with which to perform dot product.
+   * @return Dot product of this vector with argument.
    */
   public double dot(Vector2d vec) {
     return x * vec.x + y * vec.y;
   }
 
-  /** Returns magnitude of vector. */
+  /**
+   * Returns magnitude of vector.
+   *
+   * @return Magnitude of vector.
+   */
   public double magnitude() {
     return Math.sqrt(x * x + y * y);
   }
@@ -52,6 +57,7 @@ public class Vector2d {
    * Returns scalar projection of this vector onto argument.
    *
    * @param vec Vector onto which to project this vector.
+   * @return scalar projection of this vector onto argument.
    */
   public double scalarProject(Vector2d vec) {
     return dot(vec) / vec.magnitude();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -57,12 +57,17 @@ public class LiveWindow {
   }
 
   /**
-   * Set the enabled state of LiveWindow. If it's being enabled, turn off the scheduler and remove
-   * all the commands from the queue and enable all the components registered for LiveWindow. If
-   * it's being disabled, stop all the registered components and reenable the scheduler. TODO: add
-   * code to disable PID loops when enabling LiveWindow. The commands should reenable the PID loops
-   * themselves when they get rescheduled. This prevents arms from starting to move around, etc.
-   * after a period of adjusting them in LiveWindow mode.
+   * Set the enabled state of LiveWindow.
+   *
+   * <p>If it's being enabled, turn off the scheduler and remove all the commands from the queue and
+   * enable all the components registered for LiveWindow. If it's being disabled, stop all the
+   * registered components and reenable the scheduler.
+   *
+   * <p>TODO: add code to disable PID loops when enabling LiveWindow. The commands should reenable
+   * the PID loops themselves when they get rescheduled. This prevents arms from starting to move
+   * around, etc. after a period of adjusting them in LiveWindow mode.
+   *
+   * @param enabled True to enable LiveWindow.
    */
   public static synchronized void setEnabled(boolean enabled) {
     if (liveWindowEnabled != enabled) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/MotorControllerGroup.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/MotorControllerGroup.java
@@ -18,6 +18,7 @@ public class MotorControllerGroup implements MotorController, Sendable, AutoClos
   /**
    * Create a new MotorControllerGroup with the provided MotorControllers.
    *
+   * @param motorController The first MotorController to add
    * @param motorControllers The MotorControllers to add
    */
   public MotorControllerGroup(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/PWMSparkMax.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/PWMSparkMax.java
@@ -26,7 +26,11 @@ import edu.wpi.first.wpilibj.PWM;
  * </ul>
  */
 public class PWMSparkMax extends PWMMotorController {
-  /** Common initialization code called by all constructors. */
+  /**
+   * Common initialization code called by all constructors.
+   *
+   * @param channel The PWM channel number. 0-9 are on-board, 10-19 are on the MXP port
+   */
   public PWMSparkMax(final int channel) {
     super("PWMSparkMax", channel);
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/LayoutType.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/LayoutType.java
@@ -11,6 +11,10 @@ package edu.wpi.first.wpilibj.shuffleboard;
  * @see BuiltInWidgets the built-in widget types
  */
 public interface LayoutType {
-  /** Gets the string type of the layout as defined by that layout in Shuffleboard. */
+  /**
+   * Gets the string type of the layout as defined by that layout in Shuffleboard.
+   *
+   * @return The string type of the layout.
+   */
   String getLayoutName();
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
@@ -15,7 +15,11 @@ import java.util.function.Supplier;
 /** Common interface for objects that can contain shuffleboard components. */
 public interface ShuffleboardContainer extends ShuffleboardValue {
 
-  /** Gets the components that are direct children of this container. */
+  /**
+   * Gets the components that are direct children of this container.
+   *
+   * @return The components that are direct children of this container.
+   */
   List<ShuffleboardComponent<?>> getComponents();
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardValue.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardValue.java
@@ -8,7 +8,11 @@ import edu.wpi.first.networktables.NetworkTable;
 
 interface ShuffleboardValue {
 
-  /** Gets the title of this Shuffleboard value. */
+  /**
+   * Gets the title of this Shuffleboard value.
+   *
+   * @return The title of this Shuffleboard value.
+   */
   String getTitle();
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/SimpleWidget.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/SimpleWidget.java
@@ -15,7 +15,11 @@ public final class SimpleWidget extends ShuffleboardWidget<SimpleWidget> {
     super(parent, title);
   }
 
-  /** Gets the NetworkTable entry that contains the data for this widget. */
+  /**
+   * Gets the NetworkTable entry that contains the data for this widget.
+   *
+   * @return The NetworkTable entry that contains the data for this widget.
+   */
   public NetworkTableEntry getEntry() {
     if (m_entry == null) {
       forceGenerate();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/WidgetType.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/WidgetType.java
@@ -11,6 +11,10 @@ package edu.wpi.first.wpilibj.shuffleboard;
  * @see BuiltInWidgets the built-in widget types
  */
 public interface WidgetType {
-  /** Gets the string type of the widget as defined by that widget in Shuffleboard. */
+  /**
+   * Gets the string type of the widget as defined by that widget in Shuffleboard.
+   *
+   * @return The string type of the widget.
+   */
   String getWidgetName();
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/AnalogEncoderSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/AnalogEncoderSim.java
@@ -41,12 +41,20 @@ public class AnalogEncoderSim {
     m_simPosition.set(turns);
   }
 
-  /** Get the simulated position. */
+  /**
+   * Get the simulated position.
+   *
+   * @return The simulated position.
+   */
   public double getTurns() {
     return m_simPosition.get();
   }
 
-  /** Get the position as a {@link Rotation2d}. */
+  /**
+   * Get the position as a {@link Rotation2d}.
+   *
+   * @return The position as a {@link Rotation2d}.
+   */
   public Rotation2d getPosition() {
     return Rotation2d.fromDegrees(getTurns() * 360.0);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CallbackStore.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CallbackStore.java
@@ -23,6 +23,10 @@ public class CallbackStore implements AutoCloseable {
 
   /**
    * <b>Note: This constructor is for simulation classes only. It should not be called by teams!</b>
+   *
+   * @param index TODO
+   * @param uid TODO
+   * @param ccf TODO
    */
   public CallbackStore(int index, int uid, CancelCallbackFunc ccf) {
     this.m_cancelType = kNormalCancel;
@@ -33,6 +37,11 @@ public class CallbackStore implements AutoCloseable {
 
   /**
    * <b>Note: This constructor is for simulation classes only. It should not be called by teams!</b>
+   *
+   * @param index TODO
+   * @param channel TODO
+   * @param uid TODO
+   * @param ccf TODO
    */
   public CallbackStore(int index, int channel, int uid, CancelCallbackChannelFunc ccf) {
     this.m_cancelType = kChannelCancel;
@@ -44,6 +53,9 @@ public class CallbackStore implements AutoCloseable {
 
   /**
    * <b>Note: This constructor is for simulation classes only. It should not be called by teams!</b>
+   *
+   * @param uid TODO
+   * @param ccf TODO
    */
   public CallbackStore(int uid, CancelCallbackNoIndexFunc ccf) {
     this.m_cancelType = kNoIndexCancel;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSim.java
@@ -187,12 +187,18 @@ public class DifferentialDrivetrainSim {
    * Returns the direction the robot is pointing.
    *
    * <p>Note that this angle is counterclockwise-positive, while most gyros are clockwise positive.
+   *
+   * @return The direction the robot is pointing.
    */
   public Rotation2d getHeading() {
     return new Rotation2d(getOutput(State.kHeading));
   }
 
-  /** Returns the current pose. */
+  /**
+   * Returns the current pose.
+   *
+   * @return The current pose.
+   */
   public Pose2d getPose() {
     return new Pose2d(getOutput(State.kX), getOutput(State.kY), getHeading());
   }
@@ -447,6 +453,7 @@ public class DifferentialDrivetrainSim {
    *     desired. Gyro standard deviations of 0.0001 radians, velocity standard deviations of 0.05
    *     m/s, and position measurement standard deviations of 0.005 meters are a reasonable starting
    *     point.
+   * @return A sim for the standard FRC kitbot.
    */
   public static DifferentialDrivetrainSim createKitbotSim(
       KitbotMotor motor,
@@ -475,6 +482,7 @@ public class DifferentialDrivetrainSim {
    *     desired. Gyro standard deviations of 0.0001 radians, velocity standard deviations of 0.05
    *     m/s, and position measurement standard deviations of 0.005 meters are a reasonable starting
    *     point.
+   * @return A sim for the standard FRC kitbot.
    */
   @SuppressWarnings("ParameterName")
   public static DifferentialDrivetrainSim createKitbotSim(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DutyCycleEncoderSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DutyCycleEncoderSim.java
@@ -33,7 +33,11 @@ public class DutyCycleEncoderSim {
     m_simPosition.set(turns);
   }
 
-  /** Set the position. */
+  /**
+   * Set the position.
+   *
+   * @param distance The position.
+   */
   public void setDistance(double distance) {
     m_simPosition.set(distance / m_simDistancePerRotation.get());
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimDeviceSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimDeviceSim.java
@@ -177,6 +177,7 @@ public class SimDeviceSim {
   /**
    * Register a callback to be run every time a value is changed on this device.
    *
+   * @param value simulated value
    * @param callback the callback
    * @param initialNotify should the callback be run with the initial state
    * @return the {@link CallbackStore} object associated with this callback. Save a reference to
@@ -197,6 +198,8 @@ public class SimDeviceSim {
    * @param value simulated value
    * @param callback callback
    * @param initialNotify ignored (present for consistency)
+   * @return the {@link CallbackStore} object associated with this callback. Save a reference to
+   *     this object so GC doesn't cancel the callback.
    */
   public CallbackStore registerValueResetCallback(
       SimValue value, SimValueCallback callback, boolean initialNotify) {
@@ -219,6 +222,7 @@ public class SimDeviceSim {
   /**
    * Register a callback to be run every time a new {@link edu.wpi.first.hal.SimDevice} is created.
    *
+   * @param prefix the prefix to filter sim devices
    * @param callback the callback
    * @param initialNotify should the callback be run with the initial state
    * @return the {@link CallbackStore} object associated with this callback. Save a reference to
@@ -234,7 +238,9 @@ public class SimDeviceSim {
    * Register a callback to be run every time a {@link edu.wpi.first.hal.SimDevice} is
    * freed/destroyed.
    *
+   * @param prefix the prefix to filter sim devices
    * @param callback the callback
+   * @param initialNotify should the callback be run with the initial state
    * @return the {@link CallbackStore} object associated with this callback. Save a reference to
    *     this object so GC doesn't cancel the callback.
    */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/Field2d.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/Field2d.java
@@ -69,6 +69,7 @@ public class Field2d implements Sendable {
   /**
    * Get or create a field object.
    *
+   * @param name The field object's name.
    * @return Field object
    */
   public synchronized FieldObject2d getObject(String name) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/MechanismLigament2d.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/MechanismLigament2d.java
@@ -24,7 +24,15 @@ public class MechanismLigament2d extends MechanismObject2d {
   private double m_weight;
   private NetworkTableEntry m_weightEntry;
 
-  /** Create a new ligament. */
+  /**
+   * Create a new ligament.
+   *
+   * @param name The ligament name.
+   * @param length The ligament length.
+   * @param angle The ligament angle.
+   * @param lineWidth The ligament's line width.
+   * @param color The ligament's color.
+   */
   public MechanismLigament2d(
       String name, double length, double angle, double lineWidth, Color8Bit color) {
     super(name);
@@ -34,7 +42,13 @@ public class MechanismLigament2d extends MechanismObject2d {
     setLineWeight(lineWidth);
   }
 
-  /** Create a new ligament with the default color (dark blue) and thickness (6). */
+  /**
+   * Create a new ligament with the default color (dark blue) and thickness (6).
+   *
+   * @param name The ligament's name.
+   * @param length The ligament's length.
+   * @param angle The ligament's angle relative to its parent.
+   */
   public MechanismLigament2d(String name, double length, double angle) {
     this(name, length, angle, 10, new Color8Bit(235, 137, 52));
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/MechanismObject2d.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/MechanismObject2d.java
@@ -35,6 +35,7 @@ public abstract class MechanismObject2d {
   /**
    * Append a Mechanism object that is based on this one.
    *
+   * @param <T> The object type.
    * @param object the object to add.
    * @return the object given as a parameter, useful for variable assignments and call chaining.
    * @throws UnsupportedOperationException if the object's name is already used - object names must

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/MechanismRoot2d.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/MechanismRoot2d.java
@@ -42,6 +42,7 @@ public final class MechanismRoot2d {
   /**
    * Append a Mechanism object that is based on this one.
    *
+   * @param <T> The object type.
    * @param object the object to add.
    * @return the object given as a parameter, useful for variable assignments and call chaining.
    * @throws UnsupportedOperationException if the object's name is already used - object names must

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
@@ -108,436 +108,436 @@ public class Color {
    * FIRST Colors
    */
 
-  /** #1560BD. */
+  /** 0x1560BD. */
   public static final Color kDenim = new Color(0.0823529412, 0.376470589, 0.7411764706);
 
-  /** #0066B3. */
+  /** 0x0066B3. */
   public static final Color kFirstBlue = new Color(0.0, 0.4, 0.7019607844);
 
-  /** #ED1C24. */
+  /** 0xED1C24. */
   public static final Color kFirstRed = new Color(0.9294117648, 0.1098039216, 0.1411764706);
 
   /*
    * Standard Colors
    */
 
-  /** #F0F8FF. */
+  /** 0xF0F8FF. */
   public static final Color kAliceBlue = new Color(0.9411765f, 0.972549f, 1.0f);
 
-  /** #FAEBD7. */
+  /** 0xFAEBD7. */
   public static final Color kAntiqueWhite = new Color(0.98039216f, 0.92156863f, 0.84313726f);
 
-  /** #00FFFF. */
+  /** 0x00FFFF. */
   public static final Color kAqua = new Color(0.0f, 1.0f, 1.0f);
 
-  /** #7FFFD4. */
+  /** 0x7FFFD4. */
   public static final Color kAquamarine = new Color(0.49803922f, 1.0f, 0.83137256f);
 
-  /** #F0FFFF. */
+  /** 0xF0FFFF. */
   public static final Color kAzure = new Color(0.9411765f, 1.0f, 1.0f);
 
-  /** #F5F5DC. */
+  /** 0xF5F5DC. */
   public static final Color kBeige = new Color(0.9607843f, 0.9607843f, 0.8627451f);
 
-  /** #FFE4C4. */
+  /** 0xFFE4C4. */
   public static final Color kBisque = new Color(1.0f, 0.89411765f, 0.76862746f);
 
-  /** #000000. */
+  /** 0x000000. */
   public static final Color kBlack = new Color(0.0f, 0.0f, 0.0f);
 
-  /** #FFEBCD. */
+  /** 0xFFEBCD. */
   public static final Color kBlanchedAlmond = new Color(1.0f, 0.92156863f, 0.8039216f);
 
-  /** #0000FF. */
+  /** 0x0000FF. */
   public static final Color kBlue = new Color(0.0f, 0.0f, 1.0f);
 
-  /** #8A2BE2. */
+  /** 0x8A2BE2. */
   public static final Color kBlueViolet = new Color(0.5411765f, 0.16862746f, 0.8862745f);
 
-  /** #A52A2A. */
+  /** 0xA52A2A. */
   public static final Color kBrown = new Color(0.64705884f, 0.16470589f, 0.16470589f);
 
-  /** #DEB887. */
+  /** 0xDEB887. */
   public static final Color kBurlywood = new Color(0.87058824f, 0.72156864f, 0.5294118f);
 
-  /** #5F9EA0. */
+  /** 0x5F9EA0. */
   public static final Color kCadetBlue = new Color(0.37254903f, 0.61960787f, 0.627451f);
 
-  /** #7FFF00. */
+  /** 0x7FFF00. */
   public static final Color kChartreuse = new Color(0.49803922f, 1.0f, 0.0f);
 
-  /** #D2691E. */
+  /** 0xD2691E. */
   public static final Color kChocolate = new Color(0.8235294f, 0.4117647f, 0.11764706f);
 
-  /** #FF7F50. */
+  /** 0xFF7F50. */
   public static final Color kCoral = new Color(1.0f, 0.49803922f, 0.3137255f);
 
-  /** #6495ED. */
+  /** 0x6495ED. */
   public static final Color kCornflowerBlue = new Color(0.39215687f, 0.58431375f, 0.92941177f);
 
-  /** #FFF8DC. */
+  /** 0xFFF8DC. */
   public static final Color kCornsilk = new Color(1.0f, 0.972549f, 0.8627451f);
 
-  /** #DC143C. */
+  /** 0xDC143C. */
   public static final Color kCrimson = new Color(0.8627451f, 0.078431375f, 0.23529412f);
 
-  /** #00FFFF. */
+  /** 0x00FFFF. */
   public static final Color kCyan = new Color(0.0f, 1.0f, 1.0f);
 
-  /** #00008B. */
+  /** 0x00008B. */
   public static final Color kDarkBlue = new Color(0.0f, 0.0f, 0.54509807f);
 
-  /** #008B8B. */
+  /** 0x008B8B. */
   public static final Color kDarkCyan = new Color(0.0f, 0.54509807f, 0.54509807f);
 
-  /** #B8860B. */
+  /** 0xB8860B. */
   public static final Color kDarkGoldenrod = new Color(0.72156864f, 0.5254902f, 0.043137256f);
 
-  /** #A9A9A9. */
+  /** 0xA9A9A9. */
   public static final Color kDarkGray = new Color(0.6627451f, 0.6627451f, 0.6627451f);
 
-  /** #006400. */
+  /** 0x006400. */
   public static final Color kDarkGreen = new Color(0.0f, 0.39215687f, 0.0f);
 
-  /** #BDB76B. */
+  /** 0xBDB76B. */
   public static final Color kDarkKhaki = new Color(0.7411765f, 0.7176471f, 0.41960785f);
 
-  /** #8B008B. */
+  /** 0x8B008B. */
   public static final Color kDarkMagenta = new Color(0.54509807f, 0.0f, 0.54509807f);
 
-  /** #556B2F. */
+  /** 0x556B2F. */
   public static final Color kDarkOliveGreen = new Color(0.33333334f, 0.41960785f, 0.18431373f);
 
-  /** #FF8C00. */
+  /** 0xFF8C00. */
   public static final Color kDarkOrange = new Color(1.0f, 0.54901963f, 0.0f);
 
-  /** #9932CC. */
+  /** 0x9932CC. */
   public static final Color kDarkOrchid = new Color(0.6f, 0.19607843f, 0.8f);
 
-  /** #8B0000. */
+  /** 0x8B0000. */
   public static final Color kDarkRed = new Color(0.54509807f, 0.0f, 0.0f);
 
-  /** #E9967A. */
+  /** 0xE9967A. */
   public static final Color kDarkSalmon = new Color(0.9137255f, 0.5882353f, 0.47843137f);
 
-  /** #8FBC8F. */
+  /** 0x8FBC8F. */
   public static final Color kDarkSeaGreen = new Color(0.56078434f, 0.7372549f, 0.56078434f);
 
-  /** #483D8B. */
+  /** 0x483D8B. */
   public static final Color kDarkSlateBlue = new Color(0.28235295f, 0.23921569f, 0.54509807f);
 
-  /** #2F4F4F. */
+  /** 0x2F4F4F. */
   public static final Color kDarkSlateGray = new Color(0.18431373f, 0.30980393f, 0.30980393f);
 
-  /** #00CED1. */
+  /** 0x00CED1. */
   public static final Color kDarkTurquoise = new Color(0.0f, 0.80784315f, 0.81960785f);
 
-  /** #9400D3. */
+  /** 0x9400D3. */
   public static final Color kDarkViolet = new Color(0.5803922f, 0.0f, 0.827451f);
 
-  /** #FF1493. */
+  /** 0xFF1493. */
   public static final Color kDeepPink = new Color(1.0f, 0.078431375f, 0.5764706f);
 
-  /** #00BFFF. */
+  /** 0x00BFFF. */
   public static final Color kDeepSkyBlue = new Color(0.0f, 0.7490196f, 1.0f);
 
-  /** #696969. */
+  /** 0x696969. */
   public static final Color kDimGray = new Color(0.4117647f, 0.4117647f, 0.4117647f);
 
-  /** #1E90FF. */
+  /** 0x1E90FF. */
   public static final Color kDodgerBlue = new Color(0.11764706f, 0.5647059f, 1.0f);
 
-  /** #B22222. */
+  /** 0xB22222. */
   public static final Color kFirebrick = new Color(0.69803923f, 0.13333334f, 0.13333334f);
 
-  /** #FFFAF0. */
+  /** 0xFFFAF0. */
   public static final Color kFloralWhite = new Color(1.0f, 0.98039216f, 0.9411765f);
 
-  /** #228B22. */
+  /** 0x228B22. */
   public static final Color kForestGreen = new Color(0.13333334f, 0.54509807f, 0.13333334f);
 
-  /** #FF00FF. */
+  /** 0xFF00FF. */
   public static final Color kFuchsia = new Color(1.0f, 0.0f, 1.0f);
 
-  /** #DCDCDC. */
+  /** 0xDCDCDC. */
   public static final Color kGainsboro = new Color(0.8627451f, 0.8627451f, 0.8627451f);
 
-  /** #F8F8FF. */
+  /** 0xF8F8FF. */
   public static final Color kGhostWhite = new Color(0.972549f, 0.972549f, 1.0f);
 
-  /** #FFD700. */
+  /** 0xFFD700. */
   public static final Color kGold = new Color(1.0f, 0.84313726f, 0.0f);
 
-  /** #DAA520. */
+  /** 0xDAA520. */
   public static final Color kGoldenrod = new Color(0.85490197f, 0.64705884f, 0.1254902f);
 
-  /** #808080. */
+  /** 0x808080. */
   public static final Color kGray = new Color(0.5019608f, 0.5019608f, 0.5019608f);
 
-  /** #008000. */
+  /** 0x008000. */
   public static final Color kGreen = new Color(0.0f, 0.5019608f, 0.0f);
 
-  /** #ADFF2F. */
+  /** 0xADFF2F. */
   public static final Color kGreenYellow = new Color(0.6784314f, 1.0f, 0.18431373f);
 
-  /** #F0FFF0. */
+  /** 0xF0FFF0. */
   public static final Color kHoneydew = new Color(0.9411765f, 1.0f, 0.9411765f);
 
-  /** #FF69B4. */
+  /** 0xFF69B4. */
   public static final Color kHotPink = new Color(1.0f, 0.4117647f, 0.7058824f);
 
-  /** #CD5C5C. */
+  /** 0xCD5C5C. */
   public static final Color kIndianRed = new Color(0.8039216f, 0.36078432f, 0.36078432f);
 
-  /** #4B0082. */
+  /** 0x4B0082. */
   public static final Color kIndigo = new Color(0.29411766f, 0.0f, 0.50980395f);
 
-  /** #FFFFF0. */
+  /** 0xFFFFF0. */
   public static final Color kIvory = new Color(1.0f, 1.0f, 0.9411765f);
 
-  /** #F0E68C. */
+  /** 0xF0E68C. */
   public static final Color kKhaki = new Color(0.9411765f, 0.9019608f, 0.54901963f);
 
-  /** #E6E6FA. */
+  /** 0xE6E6FA. */
   public static final Color kLavender = new Color(0.9019608f, 0.9019608f, 0.98039216f);
 
-  /** #FFF0F5. */
+  /** 0xFFF0F5. */
   public static final Color kLavenderBlush = new Color(1.0f, 0.9411765f, 0.9607843f);
 
-  /** #7CFC00. */
+  /** 0x7CFC00. */
   public static final Color kLawnGreen = new Color(0.4862745f, 0.9882353f, 0.0f);
 
-  /** #FFFACD. */
+  /** 0xFFFACD. */
   public static final Color kLemonChiffon = new Color(1.0f, 0.98039216f, 0.8039216f);
 
-  /** #ADD8E6. */
+  /** 0xADD8E6. */
   public static final Color kLightBlue = new Color(0.6784314f, 0.84705883f, 0.9019608f);
 
-  /** #F08080. */
+  /** 0xF08080. */
   public static final Color kLightCoral = new Color(0.9411765f, 0.5019608f, 0.5019608f);
 
-  /** #E0FFFF. */
+  /** 0xE0FFFF. */
   public static final Color kLightCyan = new Color(0.8784314f, 1.0f, 1.0f);
 
-  /** #FAFAD2. */
+  /** 0xFAFAD2. */
   public static final Color kLightGoldenrodYellow = new Color(0.98039216f, 0.98039216f, 0.8235294f);
 
-  /** #D3D3D3. */
+  /** 0xD3D3D3. */
   public static final Color kLightGray = new Color(0.827451f, 0.827451f, 0.827451f);
 
-  /** #90EE90. */
+  /** 0x90EE90. */
   public static final Color kLightGreen = new Color(0.5647059f, 0.93333334f, 0.5647059f);
 
-  /** #FFB6C1. */
+  /** 0xFFB6C1. */
   public static final Color kLightPink = new Color(1.0f, 0.7137255f, 0.75686276f);
 
-  /** #FFA07A. */
+  /** 0xFFA07A. */
   public static final Color kLightSalmon = new Color(1.0f, 0.627451f, 0.47843137f);
 
-  /** #20B2AA. */
+  /** 0x20B2AA. */
   public static final Color kLightSeaGreen = new Color(0.1254902f, 0.69803923f, 0.6666667f);
 
-  /** #87CEFA. */
+  /** 0x87CEFA. */
   public static final Color kLightSkyBlue = new Color(0.5294118f, 0.80784315f, 0.98039216f);
 
-  /** #778899. */
+  /** 0x778899. */
   public static final Color kLightSlateGray = new Color(0.46666667f, 0.53333336f, 0.6f);
 
-  /** #B0C4DE. */
+  /** 0xB0C4DE. */
   public static final Color kLightSteelBlue = new Color(0.6901961f, 0.76862746f, 0.87058824f);
 
-  /** #FFFFE0. */
+  /** 0xFFFFE0. */
   public static final Color kLightYellow = new Color(1.0f, 1.0f, 0.8784314f);
 
-  /** #00FF00. */
+  /** 0x00FF00. */
   public static final Color kLime = new Color(0.0f, 1.0f, 0.0f);
 
-  /** #32CD32. */
+  /** 0x32CD32. */
   public static final Color kLimeGreen = new Color(0.19607843f, 0.8039216f, 0.19607843f);
 
-  /** #FAF0E6. */
+  /** 0xFAF0E6. */
   public static final Color kLinen = new Color(0.98039216f, 0.9411765f, 0.9019608f);
 
-  /** #FF00FF. */
+  /** 0xFF00FF. */
   public static final Color kMagenta = new Color(1.0f, 0.0f, 1.0f);
 
-  /** #800000. */
+  /** 0x800000. */
   public static final Color kMaroon = new Color(0.5019608f, 0.0f, 0.0f);
 
-  /** #66CDAA. */
+  /** 0x66CDAA. */
   public static final Color kMediumAquamarine = new Color(0.4f, 0.8039216f, 0.6666667f);
 
-  /** #0000CD. */
+  /** 0x0000CD. */
   public static final Color kMediumBlue = new Color(0.0f, 0.0f, 0.8039216f);
 
-  /** #BA55D3. */
+  /** 0xBA55D3. */
   public static final Color kMediumOrchid = new Color(0.7294118f, 0.33333334f, 0.827451f);
 
-  /** #9370DB. */
+  /** 0x9370DB. */
   public static final Color kMediumPurple = new Color(0.5764706f, 0.4392157f, 0.85882354f);
 
-  /** #3CB371. */
+  /** 0x3CB371. */
   public static final Color kMediumSeaGreen = new Color(0.23529412f, 0.7019608f, 0.44313726f);
 
-  /** #7B68EE. */
+  /** 0x7B68EE. */
   public static final Color kMediumSlateBlue = new Color(0.48235294f, 0.40784314f, 0.93333334f);
 
-  /** #00FA9A. */
+  /** 0x00FA9A. */
   public static final Color kMediumSpringGreen = new Color(0.0f, 0.98039216f, 0.6039216f);
 
-  /** #48D1CC. */
+  /** 0x48D1CC. */
   public static final Color kMediumTurquoise = new Color(0.28235295f, 0.81960785f, 0.8f);
 
-  /** #C71585. */
+  /** 0xC71585. */
   public static final Color kMediumVioletRed = new Color(0.78039217f, 0.08235294f, 0.52156866f);
 
-  /** #191970. */
+  /** 0x191970. */
   public static final Color kMidnightBlue = new Color(0.09803922f, 0.09803922f, 0.4392157f);
 
-  /** #F5FFFA. */
+  /** 0xF5FFFA. */
   public static final Color kMintcream = new Color(0.9607843f, 1.0f, 0.98039216f);
 
-  /** #FFE4E1. */
+  /** 0xFFE4E1. */
   public static final Color kMistyRose = new Color(1.0f, 0.89411765f, 0.88235295f);
 
-  /** #FFE4B5. */
+  /** 0xFFE4B5. */
   public static final Color kMoccasin = new Color(1.0f, 0.89411765f, 0.70980394f);
 
-  /** #FFDEAD. */
+  /** 0xFFDEAD. */
   public static final Color kNavajoWhite = new Color(1.0f, 0.87058824f, 0.6784314f);
 
-  /** #000080. */
+  /** 0x000080. */
   public static final Color kNavy = new Color(0.0f, 0.0f, 0.5019608f);
 
-  /** #FDF5E6. */
+  /** 0xFDF5E6. */
   public static final Color kOldLace = new Color(0.99215686f, 0.9607843f, 0.9019608f);
 
-  /** #808000. */
+  /** 0x808000. */
   public static final Color kOlive = new Color(0.5019608f, 0.5019608f, 0.0f);
 
-  /** #6B8E23. */
+  /** 0x6B8E23. */
   public static final Color kOliveDrab = new Color(0.41960785f, 0.5568628f, 0.13725491f);
 
-  /** #FFA500. */
+  /** 0xFFA500. */
   public static final Color kOrange = new Color(1.0f, 0.64705884f, 0.0f);
 
-  /** #FF4500. */
+  /** 0xFF4500. */
   public static final Color kOrangeRed = new Color(1.0f, 0.27058825f, 0.0f);
 
-  /** #DA70D6. */
+  /** 0xDA70D6. */
   public static final Color kOrchid = new Color(0.85490197f, 0.4392157f, 0.8392157f);
 
-  /** #EEE8AA. */
+  /** 0xEEE8AA. */
   public static final Color kPaleGoldenrod = new Color(0.93333334f, 0.9098039f, 0.6666667f);
 
-  /** #98FB98. */
+  /** 0x98FB98. */
   public static final Color kPaleGreen = new Color(0.59607846f, 0.9843137f, 0.59607846f);
 
-  /** #AFEEEE. */
+  /** 0xAFEEEE. */
   public static final Color kPaleTurquoise = new Color(0.6862745f, 0.93333334f, 0.93333334f);
 
-  /** #DB7093. */
+  /** 0xDB7093. */
   public static final Color kPaleVioletRed = new Color(0.85882354f, 0.4392157f, 0.5764706f);
 
-  /** #FFEFD5. */
+  /** 0xFFEFD5. */
   public static final Color kPapayaWhip = new Color(1.0f, 0.9372549f, 0.8352941f);
 
-  /** #FFDAB9. */
+  /** 0xFFDAB9. */
   public static final Color kPeachPuff = new Color(1.0f, 0.85490197f, 0.7254902f);
 
-  /** #CD853F. */
+  /** 0xCD853F. */
   public static final Color kPeru = new Color(0.8039216f, 0.52156866f, 0.24705882f);
 
-  /** #FFC0CB. */
+  /** 0xFFC0CB. */
   public static final Color kPink = new Color(1.0f, 0.7529412f, 0.79607844f);
 
-  /** #DDA0DD. */
+  /** 0xDDA0DD. */
   public static final Color kPlum = new Color(0.8666667f, 0.627451f, 0.8666667f);
 
-  /** #B0E0E6. */
+  /** 0xB0E0E6. */
   public static final Color kPowderBlue = new Color(0.6901961f, 0.8784314f, 0.9019608f);
 
-  /** #800080. */
+  /** 0x800080. */
   public static final Color kPurple = new Color(0.5019608f, 0.0f, 0.5019608f);
 
-  /** #FF0000. */
+  /** 0xFF0000. */
   public static final Color kRed = new Color(1.0f, 0.0f, 0.0f);
 
-  /** #BC8F8F. */
+  /** 0xBC8F8F. */
   public static final Color kRosyBrown = new Color(0.7372549f, 0.56078434f, 0.56078434f);
 
-  /** #4169E1. */
+  /** 0x4169E1. */
   public static final Color kRoyalBlue = new Color(0.25490198f, 0.4117647f, 0.88235295f);
 
-  /** #8B4513. */
+  /** 0x8B4513. */
   public static final Color kSaddleBrown = new Color(0.54509807f, 0.27058825f, 0.07450981f);
 
-  /** #FA8072. */
+  /** 0xFA8072. */
   public static final Color kSalmon = new Color(0.98039216f, 0.5019608f, 0.44705883f);
 
-  /** #F4A460. */
+  /** 0xF4A460. */
   public static final Color kSandyBrown = new Color(0.95686275f, 0.6431373f, 0.3764706f);
 
-  /** #2E8B57. */
+  /** 0x2E8B57. */
   public static final Color kSeaGreen = new Color(0.18039216f, 0.54509807f, 0.34117648f);
 
-  /** #FFF5EE. */
+  /** 0xFFF5EE. */
   public static final Color kSeashell = new Color(1.0f, 0.9607843f, 0.93333334f);
 
-  /** #A0522D. */
+  /** 0xA0522D. */
   public static final Color kSienna = new Color(0.627451f, 0.32156864f, 0.1764706f);
 
-  /** #C0C0C0. */
+  /** 0xC0C0C0. */
   public static final Color kSilver = new Color(0.7529412f, 0.7529412f, 0.7529412f);
 
-  /** #87CEEB. */
+  /** 0x87CEEB. */
   public static final Color kSkyBlue = new Color(0.5294118f, 0.80784315f, 0.92156863f);
 
-  /** #6A5ACD. */
+  /** 0x6A5ACD. */
   public static final Color kSlateBlue = new Color(0.41568628f, 0.3529412f, 0.8039216f);
 
-  /** #708090. */
+  /** 0x708090. */
   public static final Color kSlateGray = new Color(0.4392157f, 0.5019608f, 0.5647059f);
 
-  /** #FFFAFA. */
+  /** 0xFFFAFA. */
   public static final Color kSnow = new Color(1.0f, 0.98039216f, 0.98039216f);
 
-  /** #00FF7F. */
+  /** 0x00FF7F. */
   public static final Color kSpringGreen = new Color(0.0f, 1.0f, 0.49803922f);
 
-  /** #4682B4. */
+  /** 0x4682B4. */
   public static final Color kSteelBlue = new Color(0.27450982f, 0.50980395f, 0.7058824f);
 
-  /** #D2B48C. */
+  /** 0xD2B48C. */
   public static final Color kTan = new Color(0.8235294f, 0.7058824f, 0.54901963f);
 
-  /** #008080. */
+  /** 0x008080. */
   public static final Color kTeal = new Color(0.0f, 0.5019608f, 0.5019608f);
 
-  /** #D8BFD8. */
+  /** 0xD8BFD8. */
   public static final Color kThistle = new Color(0.84705883f, 0.7490196f, 0.84705883f);
 
-  /** #FF6347. */
+  /** 0xFF6347. */
   public static final Color kTomato = new Color(1.0f, 0.3882353f, 0.2784314f);
 
-  /** #40E0D0. */
+  /** 0x40E0D0. */
   public static final Color kTurquoise = new Color(0.2509804f, 0.8784314f, 0.8156863f);
 
-  /** #EE82EE. */
+  /** 0xEE82EE. */
   public static final Color kViolet = new Color(0.93333334f, 0.50980395f, 0.93333334f);
 
-  /** #F5DEB3. */
+  /** 0xF5DEB3. */
   public static final Color kWheat = new Color(0.9607843f, 0.87058824f, 0.7019608f);
 
-  /** #FFFFFF. */
+  /** 0xFFFFFF. */
   public static final Color kWhite = new Color(1.0f, 1.0f, 1.0f);
 
-  /** #F5F5F5. */
+  /** 0xF5F5F5. */
   public static final Color kWhiteSmoke = new Color(0.9607843f, 0.9607843f, 0.9607843f);
 
-  /** #FFFF00. */
+  /** 0xFFFF00. */
   public static final Color kYellow = new Color(1.0f, 1.0f, 0.0f);
 
-  /** #9ACD32. */
+  /** 0x9ACD32. */
   public static final Color kYellowGreen = new Color(0.6039216f, 0.8039216f, 0.19607843f);
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/ErrorMessages.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/ErrorMessages.java
@@ -17,9 +17,11 @@ public final class ErrorMessages {
    * Requires that a parameter of a method not be null; prints an error message with helpful
    * debugging instructions if the parameter is null.
    *
+   * @param <T> Type of object.
    * @param obj The parameter that must not be null.
    * @param paramName The name of the parameter.
    * @param methodName The name of the method.
+   * @return The object parameter confirmed not to be null.
    */
   public static <T> T requireNonNullParam(T obj, String paramName, String methodName) {
     return requireNonNull(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/vision/VisionPipeline.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/vision/VisionPipeline.java
@@ -19,6 +19,8 @@ public interface VisionPipeline {
   /**
    * Processes the image input and sets the result objects. Implementations should make these
    * objects accessible.
+   *
+   * @param image The image to process.
    */
   void process(Mat image);
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/Discretization.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/Discretization.java
@@ -36,10 +36,13 @@ public final class Discretization {
    * taylor series to several terms and still be substantially cheaper than taking the big
    * exponential.
    *
+   * @param <States> Number of states.
+   * @param <Inputs> Number of inputs.
    * @param states Nat representing the states of the system.
    * @param contA Continuous system matrix.
    * @param contB Continuous input matrix.
    * @param dtseconds Discretization timestep.
+   * @return Pair containing discretized A and B matrices.
    */
   public static <States extends Num, Inputs extends Num>
       Pair<Matrix<States, States>, Matrix<States, Inputs>> discretizeABTaylor(

--- a/wpimath/src/main/java/edu/wpi/first/math/Drake.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/Drake.java
@@ -36,6 +36,8 @@ public final class Drake {
   /**
    * Solves the discrete alegebraic Riccati equation.
    *
+   * @param <States> Number of states.
+   * @param <Inputs> Number of inputs.
    * @param A System matrix.
    * @param B Input matrix.
    * @param Q State cost matrix.
@@ -88,6 +90,8 @@ public final class Drake {
   /**
    * Solves the discrete alegebraic Riccati equation.
    *
+   * @param <States> Number of states.
+   * @param <Inputs> Number of inputs.
    * @param A System matrix.
    * @param B Input matrix.
    * @param Q State cost matrix.

--- a/wpimath/src/main/java/edu/wpi/first/math/MathShared.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathShared.java
@@ -9,6 +9,7 @@ public interface MathShared {
    * Report an error.
    *
    * @param error the error to set
+   * @param stackTrace array of stacktrace elements
    */
   void reportError(String error, StackTraceElement[] stackTrace);
 

--- a/wpimath/src/main/java/edu/wpi/first/math/MathSharedStore.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathSharedStore.java
@@ -9,7 +9,11 @@ public final class MathSharedStore {
 
   private MathSharedStore() {}
 
-  /** get the MathShared object. */
+  /**
+   * Get the MathShared object.
+   *
+   * @return The MathShared object.
+   */
   public static synchronized MathShared getMathShared() {
     if (mathShared == null) {
       mathShared =
@@ -24,7 +28,11 @@ public final class MathSharedStore {
     return mathShared;
   }
 
-  /** set the MathShared object. */
+  /**
+   * Set the MathShared object.
+   *
+   * @param shared The MathShared object.
+   */
   public static synchronized void setMathShared(MathShared shared) {
     mathShared = shared;
   }
@@ -33,6 +41,7 @@ public final class MathSharedStore {
    * Report an error.
    *
    * @param error the error to set
+   * @param stackTrace array of stacktrace elements
    */
   public static void reportError(String error, StackTraceElement[] stackTrace) {
     getMathShared().reportError(error, stackTrace);

--- a/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
@@ -15,6 +15,7 @@ public final class MathUtil {
    * @param value Value to clamp.
    * @param low The lower boundary to which to clamp value.
    * @param high The higher boundary to which to clamp value.
+   * @return The clamped value.
    */
   public static int clamp(int value, int low, int high) {
     return Math.max(low, Math.min(value, high));
@@ -26,6 +27,7 @@ public final class MathUtil {
    * @param value Value to clamp.
    * @param low The lower boundary to which to clamp value.
    * @param high The higher boundary to which to clamp value.
+   * @return The clamped value.
    */
   public static double clamp(double value, double low, double high) {
     return Math.max(low, Math.min(value, high));
@@ -37,6 +39,7 @@ public final class MathUtil {
    * @param input Input value to wrap.
    * @param minimumInput The minimum value expected from the input.
    * @param maximumInput The maximum value expected from the input.
+   * @return The wrapped value.
    */
   public static double inputModulus(double input, double minimumInput, double maximumInput) {
     double modulus = maximumInput - minimumInput;
@@ -56,6 +59,7 @@ public final class MathUtil {
    * Wraps an angle to the range -pi to pi radians.
    *
    * @param angleRadians Angle to wrap in radians.
+   * @return The wrapped angle.
    */
   public static double angleModulus(double angleRadians) {
     return inputModulus(angleRadians, -Math.PI, Math.PI);

--- a/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
@@ -323,6 +323,7 @@ public class Matrix<R extends Num, C extends Num> {
    * <p>The matrix equation could also be written as x = A<sup>-1</sup>b. Where the pseudo inverse
    * is used if A is not square.
    *
+   * @param <C2> Columns in b.
    * @param b The right-hand side of the equation to solve.
    * @return The solution to the linear system.
    */
@@ -477,6 +478,8 @@ public class Matrix<R extends Num, C extends Num> {
   /**
    * Extracts a matrix of a given size and start position with new underlying storage.
    *
+   * @param <R2> Number of rows to extract.
+   * @param <C2> Number of columns to extract.
    * @param height The number of rows of the extracted matrix.
    * @param width The number of columns of the extracted matrix.
    * @param startingRow The starting row of the extracted matrix.
@@ -496,6 +499,8 @@ public class Matrix<R extends Num, C extends Num> {
   /**
    * Assign a matrix of a given size and start position.
    *
+   * @param <R2> Rows in block assignment.
+   * @param <C2> Columns in block assignment.
    * @param startingRow The row to start at.
    * @param startingCol The column to start at.
    * @param other The matrix to assign the block to.
@@ -510,6 +515,8 @@ public class Matrix<R extends Num, C extends Num> {
    * Extracts a submatrix from the supplied matrix and inserts it in a submatrix in "this". The
    * shape of "this" is used to determine the size of the matrix extracted.
    *
+   * @param <R2> Number of rows to extract.
+   * @param <C2> Number of columns to extract.
    * @param startingRow The starting row in the supplied matrix to extract the submatrix.
    * @param startingCol The starting column in the supplied matrix to extract the submatrix.
    * @param other The matrix to extract the submatrix from.
@@ -603,6 +610,8 @@ public class Matrix<R extends Num, C extends Num> {
    * Reassigns dimensions of a {@link Matrix} to allow for operations with other matrices that have
    * wildcard dimensions.
    *
+   * @param <R1> Row dimension to assign.
+   * @param <C1> Column dimension to assign.
    * @param mat The {@link Matrix} to remove the dimensions from.
    * @return The matrix with reassigned dimensions.
    */

--- a/wpimath/src/main/java/edu/wpi/first/math/StateSpaceUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/StateSpaceUtil.java
@@ -157,6 +157,7 @@ public final class StateSpaceUtil {
    * radians.
    *
    * @param pose A pose to convert to a vector.
+   * @return The given pose in as a 4x1 vector of x, y, cos(theta), and sin(theta).
    */
   public static Matrix<N4, N1> poseTo4dVector(Pose2d pose) {
     return VecBuilder.fill(

--- a/wpimath/src/main/java/edu/wpi/first/math/VecBuilder.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/VecBuilder.java
@@ -33,6 +33,7 @@ public class VecBuilder<N extends Num> extends MatBuilder<N, N1> {
    * Returns a 1x1 vector containing the given elements.
    *
    * @param n1 the first element.
+   * @return 1x1 vector
    */
   public static Vector<N1> fill(double n1) {
     return new VecBuilder<>(Nat.N1()).fillVec(n1);
@@ -43,6 +44,7 @@ public class VecBuilder<N extends Num> extends MatBuilder<N, N1> {
    *
    * @param n1 the first element.
    * @param n2 the second element.
+   * @return 2x1 vector
    */
   public static Vector<N2> fill(double n1, double n2) {
     return new VecBuilder<>(Nat.N2()).fillVec(n1, n2);
@@ -54,6 +56,7 @@ public class VecBuilder<N extends Num> extends MatBuilder<N, N1> {
    * @param n1 the first element.
    * @param n2 the second element.
    * @param n3 the third element.
+   * @return 3x1 vector
    */
   public static Vector<N3> fill(double n1, double n2, double n3) {
     return new VecBuilder<>(Nat.N3()).fillVec(n1, n2, n3);
@@ -66,6 +69,7 @@ public class VecBuilder<N extends Num> extends MatBuilder<N, N1> {
    * @param n2 the second element.
    * @param n3 the third element.
    * @param n4 the fourth element.
+   * @return 4x1 vector
    */
   public static Vector<N4> fill(double n1, double n2, double n3, double n4) {
     return new VecBuilder<>(Nat.N4()).fillVec(n1, n2, n3, n4);
@@ -79,6 +83,7 @@ public class VecBuilder<N extends Num> extends MatBuilder<N, N1> {
    * @param n3 the third element.
    * @param n4 the fourth element.
    * @param n5 the fifth element.
+   * @return 5x1 vector
    */
   public static Vector<N5> fill(double n1, double n2, double n3, double n4, double n5) {
     return new VecBuilder<>(Nat.N5()).fillVec(n1, n2, n3, n4, n5);
@@ -93,6 +98,7 @@ public class VecBuilder<N extends Num> extends MatBuilder<N, N1> {
    * @param n4 the fourth element.
    * @param n5 the fifth element.
    * @param n6 the sixth element.
+   * @return 6x1 vector
    */
   public static Vector<N6> fill(double n1, double n2, double n3, double n4, double n5, double n6) {
     return new VecBuilder<>(Nat.N6()).fillVec(n1, n2, n3, n4, n5, n6);
@@ -108,6 +114,7 @@ public class VecBuilder<N extends Num> extends MatBuilder<N, N1> {
    * @param n5 the fifth element.
    * @param n6 the sixth element.
    * @param n7 the seventh element.
+   * @return 7x1 vector
    */
   public static Vector<N7> fill(
       double n1, double n2, double n3, double n4, double n5, double n6, double n7) {
@@ -125,6 +132,7 @@ public class VecBuilder<N extends Num> extends MatBuilder<N, N1> {
    * @param n6 the sixth element.
    * @param n7 the seventh element.
    * @param n8 the eighth element.
+   * @return 8x1 vector
    */
   public static Vector<N8> fill(
       double n1, double n2, double n3, double n4, double n5, double n6, double n7, double n8) {
@@ -143,6 +151,7 @@ public class VecBuilder<N extends Num> extends MatBuilder<N, N1> {
    * @param n7 the seventh element.
    * @param n8 the eighth element.
    * @param n9 the ninth element.
+   * @return 9x1 vector
    */
   public static Vector<N9> fill(
       double n1,
@@ -170,6 +179,7 @@ public class VecBuilder<N extends Num> extends MatBuilder<N, N1> {
    * @param n8 the eighth element.
    * @param n9 the ninth element.
    * @param n10 the tenth element.
+   * @return 10x1 vector
    */
   public static Vector<N10> fill(
       double n1,

--- a/wpimath/src/main/java/edu/wpi/first/math/WPIMathJNI.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/WPIMathJNI.java
@@ -96,6 +96,7 @@ public final class WPIMathJNI {
    *
    * @param path The path to the JSON.
    * @return A double array with the trajectory states from the JSON.
+   * @throws IOException if the JSON could not be read.
    */
   public static native double[] fromPathweaverJson(String path) throws IOException;
 
@@ -104,6 +105,7 @@ public final class WPIMathJNI {
    *
    * @param elements The elements of the trajectory.
    * @param path The location to save the JSON to.
+   * @throws IOException if the JSON could not be written.
    */
   public static native void toPathweaverJson(double[] elements, String path) throws IOException;
 

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/LinearQuadraticRegulator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/LinearQuadraticRegulator.java
@@ -222,6 +222,7 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
    * Returns the next output of the controller.
    *
    * @param x The current state x.
+   * @return The next controller output.
    */
   @SuppressWarnings("ParameterName")
   public Matrix<Inputs, N1> calculate(Matrix<States, N1> x) {
@@ -234,6 +235,7 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
    *
    * @param x The current state x.
    * @param nextR the next reference vector r.
+   * @return The next controller output.
    */
   @SuppressWarnings("ParameterName")
   public Matrix<Inputs, N1> calculate(Matrix<States, N1> x, Matrix<States, N1> nextR) {

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/RamseteController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/RamseteController.java
@@ -65,7 +65,11 @@ public class RamseteController {
     this(2.0, 0.7);
   }
 
-  /** Returns true if the pose error is within tolerance of the reference. */
+  /**
+   * Returns true if the pose error is within tolerance of the reference.
+   *
+   * @return True if the pose error is within tolerance of the reference.
+   */
   public boolean atReference() {
     final var eTranslate = m_poseError.getTranslation();
     final var eRotate = m_poseError.getRotation();
@@ -95,6 +99,7 @@ public class RamseteController {
    * @param poseRef The desired pose.
    * @param linearVelocityRefMeters The desired linear velocity in meters per second.
    * @param angularVelocityRefRadiansPerSecond The desired angular velocity in radians per second.
+   * @return The next controller output.
    */
   @SuppressWarnings("LocalVariableName")
   public ChassisSpeeds calculate(
@@ -131,6 +136,7 @@ public class RamseteController {
    *
    * @param currentPose The current pose.
    * @param desiredState The desired pose, linear velocity, and angular velocity from a trajectory.
+   * @return The next controller output.
    */
   @SuppressWarnings("LocalVariableName")
   public ChassisSpeeds calculate(Pose2d currentPose, Trajectory.State desiredState) {

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/AngleStatistics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/AngleStatistics.java
@@ -20,9 +20,11 @@ public final class AngleStatistics {
    * Subtracts a and b while normalizing the resulting value in the selected row as if it were an
    * angle.
    *
+   * @param <S> Number of rows in vector.
    * @param a A vector to subtract from.
    * @param b A vector to subtract with.
    * @param angleStateIdx The row containing angles to be normalized.
+   * @return Difference of two vectors with angle at the given index normalized.
    */
   public static <S extends Num> Matrix<S, N1> angleResidual(
       Matrix<S, N1> a, Matrix<S, N1> b, int angleStateIdx) {
@@ -36,7 +38,9 @@ public final class AngleStatistics {
    * Returns a function that subtracts two vectors while normalizing the resulting value in the
    * selected row as if it were an angle.
    *
+   * @param <S> Number of rows in vector.
    * @param angleStateIdx The row containing angles to be normalized.
+   * @return Function returning difference of two vectors with angle at the given index normalized.
    */
   public static <S extends Num>
       BiFunction<Matrix<S, N1>, Matrix<S, N1>, Matrix<S, N1>> angleResidual(int angleStateIdx) {
@@ -46,9 +50,11 @@ public final class AngleStatistics {
   /**
    * Adds a and b while normalizing the resulting value in the selected row as an angle.
    *
+   * @param <S> Number of rows in vector.
    * @param a A vector to add with.
    * @param b A vector to add with.
    * @param angleStateIdx The row containing angles to be normalized.
+   * @return Sum of two vectors with angle at the given index normalized.
    */
   public static <S extends Num> Matrix<S, N1> angleAdd(
       Matrix<S, N1> a, Matrix<S, N1> b, int angleStateIdx) {
@@ -62,7 +68,9 @@ public final class AngleStatistics {
    * Returns a function that adds two vectors while normalizing the resulting value in the selected
    * row as an angle.
    *
+   * @param <S> Number of rows in vector.
    * @param angleStateIdx The row containing angles to be normalized.
+   * @return Function returning of two vectors with angle at the given index normalized.
    */
   public static <S extends Num> BiFunction<Matrix<S, N1>, Matrix<S, N1>, Matrix<S, N1>> angleAdd(
       int angleStateIdx) {
@@ -73,9 +81,11 @@ public final class AngleStatistics {
    * Computes the mean of sigmas with the weights Wm while computing a special angle mean for a
    * select row.
    *
+   * @param <S> Number of rows in sigma point matrix.
    * @param sigmas Sigma points.
    * @param Wm Weights for the mean.
    * @param angleStateIdx The row containing the angles.
+   * @return Mean of sigma points.
    */
   @SuppressWarnings("checkstyle:ParameterName")
   public static <S extends Num> Matrix<S, N1> angleMean(
@@ -101,7 +111,9 @@ public final class AngleStatistics {
    * Returns a function that computes the mean of sigmas with the weights Wm while computing a
    * special angle mean for a select row.
    *
+   * @param <S> Number of rows in sigma point matrix.
    * @param angleStateIdx The row containing the angles.
+   * @return Function returning mean of sigma points.
    */
   @SuppressWarnings("LambdaParameterName")
   public static <S extends Num> BiFunction<Matrix<S, ?>, Matrix<?, N1>, Matrix<S, N1>> angleMean(

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
@@ -329,6 +329,8 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
    * The h(x, u) passed to the constructor is used if one is not provided (the two-argument version
    * of this function).
    *
+   * @param <R> Number of measurements in y.
+   * @param rows Number of rows in y.
    * @param u Same control input used in the predict step.
    * @param y Measurement vector.
    * @param h A vector-valued function of x and u that returns the measurement vector.
@@ -357,6 +359,8 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
    * The h(x, u) passed to the constructor is used if one is not provided (the two-argument version
    * of this function).
    *
+   * @param <R> Number of measurements in y.
+   * @param rows Number of rows in y.
    * @param u Same control input used in the predict step.
    * @param y Measurement vector.
    * @param h A vector-valued function of x and u that returns the measurement vector.

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
@@ -81,6 +81,7 @@ public class LinearFilter {
    *
    * @param timeConstant The discrete-time time constant in seconds.
    * @param period The period in seconds between samples taken by the user.
+   * @return Linear filter.
    */
   public static LinearFilter singlePoleIIR(double timeConstant, double period) {
     double gain = Math.exp(-period / timeConstant);
@@ -101,6 +102,7 @@ public class LinearFilter {
    *
    * @param timeConstant The discrete-time time constant in seconds.
    * @param period The period in seconds between samples taken by the user.
+   * @return Linear filter.
    */
   public static LinearFilter highPass(double timeConstant, double period) {
     double gain = Math.exp(-period / timeConstant);
@@ -117,6 +119,7 @@ public class LinearFilter {
    * <p>This filter is always stable.
    *
    * @param taps The number of samples to average over. Higher = smoother but slower.
+   * @return Linear filter.
    * @throws IllegalArgumentException if number of taps is less than 1.
    */
   public static LinearFilter movingAverage(int taps) {

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModuleState.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModuleState.java
@@ -56,6 +56,7 @@ public class SwerveModuleState implements Comparable<SwerveModuleState> {
    *
    * @param desiredState The desired state.
    * @param currentAngle The current module angle.
+   * @return Optimized swerve module state.
    */
   public static SwerveModuleState optimize(
       SwerveModuleState desiredState, Rotation2d currentAngle) {

--- a/wpimath/src/main/java/edu/wpi/first/math/system/LinearSystemLoop.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/LinearSystemLoop.java
@@ -302,7 +302,11 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num, Outputs ex
     return m_clampFunction;
   }
 
-  /** Set the clamping function used to clamp inputs. */
+  /**
+   * Set the clamping function used to clamp inputs.
+   *
+   * @param clampFunction The clamping function.
+   */
   public void setClampFunction(Function<Matrix<Inputs, N1>, Matrix<Inputs, N1>> clampFunction) {
     this.m_clampFunction = clampFunction;
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/system/plant/DCMotor.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/plant/DCMotor.java
@@ -66,6 +66,7 @@ public class DCMotor {
    *
    * @param speedRadiansPerSec The speed of the rotor.
    * @param voltageInputVolts The input voltage.
+   * @return The estimated current.
    */
   public double getCurrent(double speedRadiansPerSec, double voltageInputVolts) {
     return -1.0 / KvRadPerSecPerVolt / rOhms * speedRadiansPerSec + 1.0 / rOhms * voltageInputVolts;
@@ -75,6 +76,7 @@ public class DCMotor {
    * Return a gearbox of CIM motors.
    *
    * @param numMotors Number of motors in the gearbox.
+   * @return A gearbox of CIM motors.
    */
   public static DCMotor getCIM(int numMotors) {
     return new DCMotor(
@@ -85,6 +87,7 @@ public class DCMotor {
    * Return a gearbox of 775Pro motors.
    *
    * @param numMotors Number of motors in the gearbox.
+   * @return A gearbox of 775Pro motors.
    */
   public static DCMotor getVex775Pro(int numMotors) {
     return new DCMotor(
@@ -95,6 +98,7 @@ public class DCMotor {
    * Return a gearbox of NEO motors.
    *
    * @param numMotors Number of motors in the gearbox.
+   * @return A gearbox of NEO motors.
    */
   public static DCMotor getNEO(int numMotors) {
     return new DCMotor(
@@ -105,6 +109,7 @@ public class DCMotor {
    * Return a gearbox of MiniCIM motors.
    *
    * @param numMotors Number of motors in the gearbox.
+   * @return A gearbox of MiniCIM motors.
    */
   public static DCMotor getMiniCIM(int numMotors) {
     return new DCMotor(
@@ -115,6 +120,7 @@ public class DCMotor {
    * Return a gearbox of Bag motors.
    *
    * @param numMotors Number of motors in the gearbox.
+   * @return A gearbox of Bag motors.
    */
   public static DCMotor getBag(int numMotors) {
     return new DCMotor(
@@ -125,6 +131,7 @@ public class DCMotor {
    * Return a gearbox of Andymark RS775-125 motors.
    *
    * @param numMotors Number of motors in the gearbox.
+   * @return A gearbox of Andymark RS775-125 motors.
    */
   public static DCMotor getAndymarkRs775_125(int numMotors) {
     return new DCMotor(
@@ -135,6 +142,7 @@ public class DCMotor {
    * Return a gearbox of Banebots RS775 motors.
    *
    * @param numMotors Number of motors in the gearbox.
+   * @return A gearbox of Banebots RS775 motors.
    */
   public static DCMotor getBanebotsRs775(int numMotors) {
     return new DCMotor(
@@ -145,6 +153,7 @@ public class DCMotor {
    * Return a gearbox of Andymark 9015 motors.
    *
    * @param numMotors Number of motors in the gearbox.
+   * @return A gearbox of Andymark 9015 motors.
    */
   public static DCMotor getAndymark9015(int numMotors) {
     return new DCMotor(
@@ -155,6 +164,7 @@ public class DCMotor {
    * Return a gearbox of Banebots RS 550 motors.
    *
    * @param numMotors Number of motors in the gearbox.
+   * @return A gearbox of Banebots RS 550 motors.
    */
   public static DCMotor getBanebotsRs550(int numMotors) {
     return new DCMotor(
@@ -162,9 +172,10 @@ public class DCMotor {
   }
 
   /**
-   * Return a gearbox of Neo 550 motors.
+   * Return a gearbox of NEO 550 motors.
    *
    * @param numMotors Number of motors in the gearbox.
+   * @return A gearbox of NEO 550 motors.
    */
   public static DCMotor getNeo550(int numMotors) {
     return new DCMotor(
@@ -175,6 +186,7 @@ public class DCMotor {
    * Return a gearbox of Falcon 500 motors.
    *
    * @param numMotors Number of motors in the gearbox.
+   * @return A gearbox of Falcon 500 motors.
    */
   public static DCMotor getFalcon500(int numMotors) {
     return new DCMotor(
@@ -185,6 +197,7 @@ public class DCMotor {
    * Return a gearbox of Romi/TI_RSLK MAX motors.
    *
    * @param numMotors Number of motors in the gearbox.
+   * @return A gearbox of Romi/TI_RSLK MAX motors.
    */
   public static DCMotor getRomiBuiltIn(int numMotors) {
     // From https://www.pololu.com/product/1520/specs

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrapezoidProfile.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrapezoidProfile.java
@@ -166,6 +166,7 @@ public class TrapezoidProfile {
    * the profile was at time t = 0.
    *
    * @param t The time since the beginning of the profile.
+   * @return The position and velocity of the profile at time t.
    */
   public State calculate(double t) {
     State result = new State(m_initial.position, m_initial.velocity);
@@ -195,6 +196,7 @@ public class TrapezoidProfile {
    * Returns the time left until a target distance in the profile is reached.
    *
    * @param target The target distance.
+   * @return The time left until a target distance in the profile is reached.
    */
   public double timeLeftUntil(double target) {
     double position = m_initial.position * m_direction;
@@ -263,7 +265,11 @@ public class TrapezoidProfile {
     return accelTime + fullSpeedTime + deccelTime;
   }
 
-  /** Returns the total time the profile takes to reach the goal. */
+  /**
+   * Returns the total time the profile takes to reach the goal.
+   *
+   * @return The total time the profile takes to reach the goal.
+   */
   public double totalTime() {
     return m_endDeccel;
   }
@@ -275,6 +281,7 @@ public class TrapezoidProfile {
    * profile's total time.
    *
    * @param t The time since the beginning of the profile.
+   * @return True if the profile has reached the goal.
    */
   public boolean isFinished(double t) {
     return t >= totalTime();

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/constraint/MecanumDriveKinematicsConstraint.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/constraint/MecanumDriveKinematicsConstraint.java
@@ -18,8 +18,9 @@ public class MecanumDriveKinematicsConstraint implements TrajectoryConstraint {
   private final MecanumDriveKinematics m_kinematics;
 
   /**
-   * Constructs a mecanum drive dynamics constraint.
+   * Constructs a mecanum drive kinematics constraint.
    *
+   * @param kinematics Mecanum drive kinematics.
    * @param maxSpeedMetersPerSecond The max speed that a side of the robot can travel at.
    */
   public MecanumDriveKinematicsConstraint(

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/constraint/SwerveDriveKinematicsConstraint.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/constraint/SwerveDriveKinematicsConstraint.java
@@ -18,8 +18,9 @@ public class SwerveDriveKinematicsConstraint implements TrajectoryConstraint {
   private final SwerveDriveKinematics m_kinematics;
 
   /**
-   * Constructs a swerve drive dynamics constraint.
+   * Constructs a swerve drive kinematics constraint.
    *
+   * @param kinematics Swerve drive kinematics.
    * @param maxSpeedMetersPerSecond The max speed that a side of the robot can travel at.
    */
   public SwerveDriveKinematicsConstraint(

--- a/wpimath/src/main/native/include/drake/common/drake_throw.h
+++ b/wpimath/src/main/native/include/drake/common/drake_throw.h
@@ -7,7 +7,7 @@
 /// @file
 /// Provides a convenient wrapper to throw an exception when a condition is
 /// unmet.  This is similar to an assertion, but uses exceptions instead of
-/// ::abort(), and cannot be disabled.
+/// std::abort(), and cannot be disabled.
 
 namespace drake {
 namespace internal {

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/CircularBuffer.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/CircularBuffer.java
@@ -61,6 +61,8 @@ public class CircularBuffer {
   /**
    * Push new value onto front of the buffer. The value at the back is overwritten if the buffer is
    * full.
+   *
+   * @param value The value to push.
    */
   public void addFirst(double value) {
     if (m_data.length == 0) {
@@ -79,6 +81,8 @@ public class CircularBuffer {
   /**
    * Push new value onto back of the buffer. The value at the front is overwritten if the buffer is
    * full.
+   *
+   * @param value The value to push.
    */
   public void addLast(double value) {
     if (m_data.length == 0) {
@@ -112,7 +116,11 @@ public class CircularBuffer {
     return temp;
   }
 
-  /** Pop value at back of buffer. */
+  /**
+   * Pop value at back of buffer.
+   *
+   * @return value at back of buffer
+   */
   public double removeLast() {
     // If there are no elements in the buffer, do nothing
     if (m_length == 0) {
@@ -127,6 +135,8 @@ public class CircularBuffer {
    * Resizes internal buffer to given size.
    *
    * <p>A new buffer is allocated because arrays are not resizable.
+   *
+   * @param size New buffer size.
    */
   void resize(int size) {
     double[] newBuffer = new double[size];
@@ -150,18 +160,27 @@ public class CircularBuffer {
   /**
    * Get the element at the provided index relative to the start of the buffer.
    *
+   * @param index Index into the buffer.
    * @return Element at index starting from front of buffer.
    */
   public double get(int index) {
     return m_data[(m_front + index) % m_data.length];
   }
 
-  /** Increment an index modulo the length of the m_data buffer. */
+  /**
+   * Increment an index modulo the length of the m_data buffer.
+   *
+   * @param index Index into the buffer.
+   */
   private int moduloInc(int index) {
     return (index + 1) % m_data.length;
   }
 
-  /** Decrement an index modulo the length of the m_data buffer. */
+  /**
+   * Decrement an index modulo the length of the m_data buffer.
+   *
+   * @param index Index into the buffer.
+   */
   private int moduloDec(int index) {
     if (index == 0) {
       return m_data.length - 1;

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/ErrorMessages.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/ErrorMessages.java
@@ -17,9 +17,11 @@ public final class ErrorMessages {
    * Requires that a parameter of a method not be null; prints an error message with helpful
    * debugging instructions if the parameter is null.
    *
+   * @param <T> Type of object.
    * @param obj The parameter that must not be null.
    * @param paramName The name of the parameter.
    * @param methodName The name of the method.
+   * @return The object parameter confirmed not to be null.
    */
   public static <T> T requireNonNullParam(T obj, String paramName, String methodName) {
     return requireNonNull(

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeDetector.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeDetector.java
@@ -60,50 +60,77 @@ public final class RuntimeDetector {
     }
   }
 
-  /** Get the file prefix for the current system. */
+  /**
+   * Get the file prefix for the current system.
+   *
+   * @return The file prefix.
+   */
   public static synchronized String getFilePrefix() {
     computePlatform();
 
     return filePrefix;
   }
 
-  /** Get the file extension for the current system. */
+  /**
+   * Get the file extension for the current system.
+   *
+   * @return The file extension.
+   */
   public static synchronized String getFileExtension() {
     computePlatform();
 
     return fileExtension;
   }
 
-  /** Get the platform path for the current system. */
+  /**
+   * Get the platform path for the current system.
+   *
+   * @return The platform path.
+   */
   public static synchronized String getPlatformPath() {
     computePlatform();
 
     return filePath;
   }
 
-  /** Get the path to the requested resource. */
+  /**
+   * Get the path to the requested resource.
+   *
+   * @param libName Library name.
+   * @return The path to the requested resource.
+   */
   public static synchronized String getLibraryResource(String libName) {
     computePlatform();
 
     return filePath + filePrefix + libName + fileExtension;
   }
 
-  /** Get the path to the hash to the requested resource. */
+  /**
+   * Get the path to the hash to the requested resource.
+   *
+   * @param libName Library name.
+   * @return The path to the hash to the requested resource.
+   */
   public static synchronized String getHashLibraryResource(String libName) {
     computePlatform();
 
     return filePath + libName + ".hash";
   }
 
+  /**
+   * Check if hardware platform is Athena.
+   *
+   * @return True if hardware platform is Athena.
+   */
   public static boolean isAthena() {
     File runRobotFile = new File("/usr/local/frc/bin/frcRunRobot.sh");
     return runRobotFile.exists();
   }
 
   /**
-   * check if os is raspbian.
+   * Check if OS is Raspbian.
    *
-   * @return if os is raspbian
+   * @return True if OS is Raspbian.
    */
   public static boolean isRaspbian() {
     try (BufferedReader reader = Files.newBufferedReader(Paths.get("/etc/os-release"))) {

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeLoader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/RuntimeLoader.java
@@ -20,7 +20,11 @@ import java.util.Scanner;
 public final class RuntimeLoader<T> {
   private static String defaultExtractionRoot;
 
-  /** Gets the default extration root location (~/.wpilib/nativecache). */
+  /**
+   * Gets the default extration root location (~/.wpilib/nativecache).
+   *
+   * @return The default extraction root location.
+   */
   public static synchronized String getDefaultExtractionRoot() {
     if (defaultExtractionRoot != null) {
       return defaultExtractionRoot;
@@ -37,8 +41,9 @@ public final class RuntimeLoader<T> {
   /**
    * Creates a new library loader.
    *
-   * <p>Resources loaded on disk from extractionRoot, and from classpath from the passed in class.
-   * Library name is the passed in name.
+   * @param libraryName Name of library to load.
+   * @param extractionRoot Location from which to load the library.
+   * @param cls Class whose classpath the given library belongs.
    */
   public RuntimeLoader(String libraryName, String extractionRoot, Class<T> cls) {
     m_libraryName = libraryName;
@@ -46,6 +51,12 @@ public final class RuntimeLoader<T> {
     m_extractionRoot = extractionRoot;
   }
 
+  /**
+   * Returns a load error message given the information in the provided UnsatisfiedLinkError.
+   *
+   * @param ule UnsatisfiedLinkError object.
+   * @return A load error message.
+   */
   private String getLoadErrorMessage(UnsatisfiedLinkError ule) {
     StringBuilder msg = new StringBuilder(512);
     msg.append(m_libraryName)
@@ -64,7 +75,11 @@ public final class RuntimeLoader<T> {
     return msg.toString();
   }
 
-  /** Loads a native library. */
+  /**
+   * Loads a native library.
+   *
+   * @throws IOException if the library fails to load
+   */
   @SuppressWarnings("PMD.PreserveStackTrace")
   public void loadLibrary() throws IOException {
     try {
@@ -106,7 +121,11 @@ public final class RuntimeLoader<T> {
     }
   }
 
-  /** Load a native library by directly hashing the file. */
+  /**
+   * Load a native library by directly hashing the file.
+   *
+   * @throws IOException if the library failed to load
+   */
   @SuppressWarnings({"PMD.PreserveStackTrace", "PMD.EmptyWhileStmt"})
   public void loadLibraryHashed() throws IOException {
     try {

--- a/wpiutil/src/main/java/edu/wpi/first/wpiutil/WPIUtilJNI.java
+++ b/wpiutil/src/main/java/edu/wpi/first/wpiutil/WPIUtilJNI.java
@@ -38,7 +38,11 @@ public final class WPIUtilJNI {
     }
   }
 
-  /** Force load the library. */
+  /**
+   * Force load the library.
+   *
+   * @throws IOException if the library failed to load
+   */
   public static synchronized void forceLoad() throws IOException {
     if (libraryLoaded) {
       return;

--- a/wpiutil/src/main/native/include/wpi/Endian.h
+++ b/wpiutil/src/main/native/include/wpi/Endian.h
@@ -38,7 +38,7 @@ enum {aligned = 0, unaligned = 1};
 
 namespace detail {
 
-/// ::value is either alignment, or alignof(T) if alignment is 0.
+// value is either alignment, or alignof(T) if alignment is 0.
 template<class T, int alignment>
 struct PickAlignment {
  enum { value = alignment == 0 ? alignof(T) : alignment };

--- a/wpiutil/src/main/native/include/wpi/json.h
+++ b/wpiutil/src/main/native/include/wpi/json.h
@@ -7562,7 +7562,7 @@ class json
                                    const bool strict = true);
 
     /*!
-    @copydoc from_msgpack(raw_istream, const bool)
+    @copydoc from_msgpack(raw_istream&, const bool)
     */
     static json from_msgpack(span<const uint8_t> arr, const bool strict = true);
 


### PR DESCRIPTION
Some C++ Doxygen comments were updated to reflect any wording changes.

See `rg "(@return|@param \w+) TODO" | less` for list of incomplete docs. I don't know what those docs or return types are for, so I couldn't document them.