### PR TITLE
[wpilibc] Make ShuffleboardValue non-copyable

### DIFF
--- a/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardValue.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardValue.h
@@ -18,6 +18,9 @@ class ShuffleboardValue {
 
   virtual ~ShuffleboardValue() = default;
 
+  ShuffleboardValue(const ShuffleboardValue&) = delete;
+  ShuffleboardValue& operator=(const ShuffleboardValue&) = delete;
+
   /**
    * Gets the title of this Shuffleboard value.
    */


### PR DESCRIPTION
This avoids the possibility of it being accidentally sliced by users.