### PR TITLE
Split Sendable into NT and non-NT portions

### DIFF
--- a/ntcore/src/main/java/edu/wpi/first/networktables/NTSendable.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NTSendable.java
@@ -1,0 +1,25 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+
+/** Interface for NetworkTable Sendable objects. */
+public interface NTSendable extends Sendable {
+  /**
+   * Initializes this {@link Sendable} object.
+   *
+   * @param builder sendable builder
+   */
+  void initSendable(NTSendableBuilder builder);
+
+  @Override
+  default void initSendable(SendableBuilder builder) {
+    if (builder.getBackendKind() == SendableBuilder.BackendKind.kNetworkTables) {
+      initSendable((NTSendableBuilder) builder);
+    }
+  }
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NTSendableBuilder.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NTSendableBuilder.java
@@ -1,0 +1,51 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import edu.wpi.first.util.sendable.SendableBuilder;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public interface NTSendableBuilder extends SendableBuilder {
+  /**
+   * Set the function that should be called to update the network table for things other than
+   * properties. Note this function is not passed the network table object; instead it should use
+   * the entry handles returned by getEntry().
+   *
+   * @param func function
+   */
+  void setUpdateTable(Runnable func);
+
+  /**
+   * Add a property without getters or setters. This can be used to get entry handles for the
+   * function called by setUpdateTable().
+   *
+   * @param key property name
+   * @return Network table entry
+   */
+  NetworkTableEntry getEntry(String key);
+
+  /**
+   * Add a NetworkTableValue property.
+   *
+   * @param key property name
+   * @param getter getter function (returns current value)
+   * @param setter setter function (sets new value)
+   */
+  void addValueProperty(
+      String key, Supplier<NetworkTableValue> getter, Consumer<NetworkTableValue> setter);
+
+  /**
+   * Get the network table.
+   *
+   * @return The network table
+   */
+  NetworkTable getTable();
+
+  @Override
+  default BackendKind getBackendKind() {
+    return BackendKind.kNetworkTables;
+  }
+}

--- a/ntcore/src/main/native/cpp/networktables/NTSendable.cpp
+++ b/ntcore/src/main/native/cpp/networktables/NTSendable.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "networktables/NTSendable.h"
+
+#include <wpi/sendable/SendableBuilder.h>
+
+#include "networktables/NTSendableBuilder.h"
+
+using namespace nt;
+
+void NTSendable::InitSendable(wpi::SendableBuilder& builder) {
+  if (builder.GetBackendKind() == wpi::SendableBuilder::kNetworkTables) {
+    InitSendable(static_cast<NTSendableBuilder&>(builder));
+  }
+}

--- a/ntcore/src/main/native/cpp/networktables/NTSendableBuilder.cpp
+++ b/ntcore/src/main/native/cpp/networktables/NTSendableBuilder.cpp
@@ -1,0 +1,11 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "networktables/NTSendableBuilder.h"
+
+using namespace nt;
+
+NTSendableBuilder::BackendKind NTSendableBuilder::GetBackendKind() const {
+  return kNetworkTables;
+}

--- a/ntcore/src/main/native/include/networktables/NTSendable.h
+++ b/ntcore/src/main/native/include/networktables/NTSendable.h
@@ -4,16 +4,25 @@
 
 #pragma once
 
-#include <string_view>
-
 #include <wpi/sendable/Sendable.h>
 
+namespace nt {
+
+class NTSendableBuilder;
+
 /**
- * A mock sendable that marks itself as an actuator.
+ * Interface for NetworkTable Sendable objects.
  */
-class MockActuatorSendable : public wpi::Sendable {
+class NTSendable : public wpi::Sendable {
  public:
-  explicit MockActuatorSendable(std::string_view name);
+  /**
+   * Initializes this Sendable object.
+   *
+   * @param builder sendable builder
+   */
+  virtual void InitSendable(NTSendableBuilder& builder) = 0;
 
   void InitSendable(wpi::SendableBuilder& builder) override;
 };
+
+}  // namespace nt

--- a/ntcore/src/main/native/include/networktables/NTSendableBuilder.h
+++ b/ntcore/src/main/native/include/networktables/NTSendableBuilder.h
@@ -1,0 +1,65 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string_view>
+
+#include <wpi/sendable/SendableBuilder.h>
+
+#include "networktables/NetworkTable.h"
+#include "networktables/NetworkTableEntry.h"
+#include "networktables/NetworkTableValue.h"
+
+namespace nt {
+
+class NTSendableBuilder : public wpi::SendableBuilder {
+ public:
+  /**
+   * Set the function that should be called to update the network table
+   * for things other than properties.  Note this function is not passed
+   * the network table object; instead it should use the entry handles
+   * returned by GetEntry().
+   *
+   * @param func    function
+   */
+  virtual void SetUpdateTable(std::function<void()> func) = 0;
+
+  /**
+   * Add a property without getters or setters.  This can be used to get
+   * entry handles for the function called by SetUpdateTable().
+   *
+   * @param key   property name
+   * @return Network table entry
+   */
+  virtual NetworkTableEntry GetEntry(std::string_view key) = 0;
+
+  /**
+   * Add a NetworkTableValue property.
+   *
+   * @param key     property name
+   * @param getter  getter function (returns current value)
+   * @param setter  setter function (sets new value)
+   */
+  virtual void AddValueProperty(
+      std::string_view key, std::function<std::shared_ptr<Value>()> getter,
+      std::function<void(std::shared_ptr<Value>)> setter) = 0;
+
+  /**
+   * Get the network table.
+   * @return The network table
+   */
+  virtual std::shared_ptr<NetworkTable> GetTable() = 0;
+
+  /**
+   * Gets the kind of backend being used.
+   *
+   * @return Backend kind
+   */
+  BackendKind GetBackendKind() const override;
+};
+
+}  // namespace nt

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandBase.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandBase.java
@@ -4,9 +4,9 @@
 
 package edu.wpi.first.wpilibj2.command;
 
-import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -7,15 +7,15 @@ package edu.wpi.first.wpilibj2.command;
 import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
+import edu.wpi.first.networktables.NTSendable;
+import edu.wpi.first.networktables.NTSendableBuilder;
 import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.RobotState;
-import edu.wpi.first.wpilibj.Sendable;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Watchdog;
 import edu.wpi.first.wpilibj.livewindow.LiveWindow;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,7 +34,7 @@ import java.util.function.Consumer;
  * CommandScheduler#registerSubsystem(Subsystem...)} in order for their {@link Subsystem#periodic()}
  * methods to be called and for their default commands to be scheduled.
  */
-public final class CommandScheduler implements Sendable, AutoCloseable {
+public final class CommandScheduler implements NTSendable, AutoCloseable {
   /** The Singleton Instance. */
   private static CommandScheduler instance;
 
@@ -501,7 +501,7 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   }
 
   @Override
-  public void initSendable(SendableBuilder builder) {
+  public void initSendable(NTSendableBuilder builder) {
     builder.setSmartDashboardType("Scheduler");
     final NetworkTableEntry namesEntry = builder.getEntry("Names");
     final NetworkTableEntry idsEntry = builder.getEntry("Ids");

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SubsystemBase.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SubsystemBase.java
@@ -4,9 +4,9 @@
 
 package edu.wpi.first.wpilibj2.command;
 
-import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /**
  * A base for subsystems that handles registration in the constructor, and provides a more intuitive

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/WaitCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/WaitCommand.java
@@ -4,8 +4,8 @@
 
 package edu.wpi.first.wpilibj2.command;
 
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * A command that does nothing but takes a specified amount of time to finish. Useful for

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandBase.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandBase.cpp
@@ -4,13 +4,13 @@
 
 #include "frc2/command/CommandBase.h"
 
-#include <frc/smartdashboard/SendableBuilder.h>
-#include <frc/smartdashboard/SendableRegistry.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 using namespace frc2;
 
 CommandBase::CommandBase() {
-  frc::SendableRegistry::GetInstance().Add(this, GetTypeName(*this));
+  wpi::SendableRegistry::GetInstance().Add(this, GetTypeName(*this));
 }
 
 void CommandBase::AddRequirements(
@@ -31,22 +31,22 @@ wpi::SmallSet<Subsystem*, 4> CommandBase::GetRequirements() const {
 }
 
 void CommandBase::SetName(std::string_view name) {
-  frc::SendableRegistry::GetInstance().SetName(this, name);
+  wpi::SendableRegistry::GetInstance().SetName(this, name);
 }
 
 std::string CommandBase::GetName() const {
-  return frc::SendableRegistry::GetInstance().GetName(this);
+  return wpi::SendableRegistry::GetInstance().GetName(this);
 }
 
 std::string CommandBase::GetSubsystem() const {
-  return frc::SendableRegistry::GetInstance().GetSubsystem(this);
+  return wpi::SendableRegistry::GetInstance().GetSubsystem(this);
 }
 
 void CommandBase::SetSubsystem(std::string_view subsystem) {
-  frc::SendableRegistry::GetInstance().SetSubsystem(this, subsystem);
+  wpi::SendableRegistry::GetInstance().SetSubsystem(this, subsystem);
 }
 
-void CommandBase::InitSendable(frc::SendableBuilder& builder) {
+void CommandBase::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Command");
   builder.AddStringProperty(
       ".name", [this] { return GetName(); }, nullptr);

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -10,13 +10,13 @@
 #include <frc/RobotState.h>
 #include <frc/TimedRobot.h>
 #include <frc/livewindow/LiveWindow.h>
-#include <frc/smartdashboard/SendableBuilder.h>
-#include <frc/smartdashboard/SendableRegistry.h>
 #include <hal/FRCUsageReporting.h>
 #include <hal/HALBase.h>
+#include <networktables/NTSendableBuilder.h>
 #include <networktables/NetworkTableEntry.h>
 #include <wpi/DenseMap.h>
 #include <wpi/SmallVector.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc2/command/CommandGroupBase.h"
 #include "frc2/command/CommandState.h"
@@ -70,7 +70,7 @@ CommandScheduler::CommandScheduler()
       }) {
   HAL_Report(HALUsageReporting::kResourceType_Command,
              HALUsageReporting::kCommand2_Scheduler);
-  frc::SendableRegistry::GetInstance().AddLW(this, "Scheduler");
+  wpi::SendableRegistry::GetInstance().AddLW(this, "Scheduler");
   auto scheduler = frc::LiveWindow::GetInstance();
   scheduler->enabled = [this] {
     this->Disable();
@@ -80,7 +80,7 @@ CommandScheduler::CommandScheduler()
 }
 
 CommandScheduler::~CommandScheduler() {
-  frc::SendableRegistry::GetInstance().Remove(this);
+  wpi::SendableRegistry::GetInstance().Remove(this);
   auto scheduler = frc::LiveWindow::GetInstance();
   scheduler->enabled = nullptr;
   scheduler->disabled = nullptr;
@@ -428,7 +428,7 @@ void CommandScheduler::OnCommandFinish(Action action) {
   m_impl->finishActions.emplace_back(std::move(action));
 }
 
-void CommandScheduler::InitSendable(frc::SendableBuilder& builder) {
+void CommandScheduler::InitSendable(nt::NTSendableBuilder& builder) {
   builder.SetSmartDashboardType("Scheduler");
   auto namesEntry = builder.GetEntry("Names");
   auto idsEntry = builder.GetEntry("Ids");

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/SubsystemBase.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/SubsystemBase.cpp
@@ -4,8 +4,8 @@
 
 #include "frc2/command/SubsystemBase.h"
 
-#include <frc/smartdashboard/SendableBuilder.h>
-#include <frc/smartdashboard/SendableRegistry.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc2/command/Command.h"
 #include "frc2/command/CommandScheduler.h"
@@ -13,11 +13,11 @@
 using namespace frc2;
 
 SubsystemBase::SubsystemBase() {
-  frc::SendableRegistry::GetInstance().AddLW(this, GetTypeName(*this));
+  wpi::SendableRegistry::GetInstance().AddLW(this, GetTypeName(*this));
   CommandScheduler::GetInstance().RegisterSubsystem({this});
 }
 
-void SubsystemBase::InitSendable(frc::SendableBuilder& builder) {
+void SubsystemBase::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Subsystem");
   builder.AddBooleanProperty(
       ".hasDefault", [this] { return GetDefaultCommand() != nullptr; },
@@ -48,22 +48,22 @@ void SubsystemBase::InitSendable(frc::SendableBuilder& builder) {
 }
 
 std::string SubsystemBase::GetName() const {
-  return frc::SendableRegistry::GetInstance().GetName(this);
+  return wpi::SendableRegistry::GetInstance().GetName(this);
 }
 
 void SubsystemBase::SetName(std::string_view name) {
-  frc::SendableRegistry::GetInstance().SetName(this, name);
+  wpi::SendableRegistry::GetInstance().SetName(this, name);
 }
 
 std::string SubsystemBase::GetSubsystem() const {
-  return frc::SendableRegistry::GetInstance().GetSubsystem(this);
+  return wpi::SendableRegistry::GetInstance().GetSubsystem(this);
 }
 
 void SubsystemBase::SetSubsystem(std::string_view name) {
-  frc::SendableRegistry::GetInstance().SetSubsystem(this, name);
+  wpi::SendableRegistry::GetInstance().SetSubsystem(this, name);
 }
 
-void SubsystemBase::AddChild(std::string name, frc::Sendable* child) {
-  auto& registry = frc::SendableRegistry::GetInstance();
+void SubsystemBase::AddChild(std::string name, wpi::Sendable* child) {
+  auto& registry = wpi::SendableRegistry::GetInstance();
   registry.AddLW(child, GetSubsystem(), name);
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandBase.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandBase.h
@@ -8,9 +8,9 @@
 #include <string>
 #include <string_view>
 
-#include <frc/smartdashboard/Sendable.h>
-#include <frc/smartdashboard/SendableHelper.h>
 #include <wpi/SmallSet.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 #include <wpi/span.h>
 
 #include "frc2/command/Command.h"
@@ -20,8 +20,8 @@ namespace frc2 {
  * A Sendable base class for Commands.
  */
 class CommandBase : public Command,
-                    public frc::Sendable,
-                    public frc::SendableHelper<CommandBase> {
+                    public wpi::Sendable,
+                    public wpi::SendableHelper<CommandBase> {
  public:
   /**
    * Adds the specified requirements to the command.
@@ -69,7 +69,7 @@ class CommandBase : public Command,
    */
   void SetSubsystem(std::string_view subsystem);
 
-  void InitSendable(frc::SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  protected:
   CommandBase();

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -10,10 +10,10 @@
 
 #include <frc/Errors.h>
 #include <frc/Watchdog.h>
-#include <frc/smartdashboard/Sendable.h>
-#include <frc/smartdashboard/SendableHelper.h>
+#include <networktables/NTSendable.h>
 #include <units/time.h>
 #include <wpi/FunctionExtras.h>
+#include <wpi/sendable/SendableHelper.h>
 #include <wpi/span.h>
 
 namespace frc2 {
@@ -27,8 +27,8 @@ class Subsystem;
  * with the scheduler using RegisterSubsystem() in order for their Periodic()
  * methods to be called and for their default commands to be scheduled.
  */
-class CommandScheduler final : public frc::Sendable,
-                               public frc::SendableHelper<CommandScheduler> {
+class CommandScheduler final : public nt::NTSendable,
+                               public wpi::SendableHelper<CommandScheduler> {
  public:
   /**
    * Returns the Scheduler instance.
@@ -332,7 +332,7 @@ class CommandScheduler final : public frc::Sendable,
    */
   void OnCommandFinish(Action action);
 
-  void InitSendable(frc::SendableBuilder& builder) override;
+  void InitSendable(nt::NTSendableBuilder& builder) override;
 
  private:
   // Constructor; private as this is a singleton

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SubsystemBase.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SubsystemBase.h
@@ -7,8 +7,8 @@
 #include <string>
 #include <string_view>
 
-#include <frc/smartdashboard/Sendable.h>
-#include <frc/smartdashboard/SendableHelper.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc2/command/Subsystem.h"
 
@@ -18,10 +18,10 @@ namespace frc2 {
  * provides a more intuitive method for setting the default command.
  */
 class SubsystemBase : public Subsystem,
-                      public frc::Sendable,
-                      public frc::SendableHelper<SubsystemBase> {
+                      public wpi::Sendable,
+                      public wpi::SendableHelper<SubsystemBase> {
  public:
-  void InitSendable(frc::SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
   /**
    * Gets the name of this Subsystem.
@@ -58,7 +58,7 @@ class SubsystemBase : public Subsystem,
    * @param name name to give child
    * @param child sendable
    */
-  void AddChild(std::string name, frc::Sendable* child);
+  void AddChild(std::string name, wpi::Sendable* child);
 
  protected:
   SubsystemBase();

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
@@ -10,8 +10,9 @@ import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.util.BoundaryException;
 import edu.wpi.first.math.filter.LinearFilter;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDController.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDController.java
@@ -4,7 +4,7 @@
 
 package edu.wpi.first.wpilibj;
 
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableBuilder;
 
 /**
  * Class implements a PID Control Loop.

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/buttons/Trigger.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/buttons/Trigger.java
@@ -4,10 +4,10 @@
 
 package edu.wpi.first.wpilibj.buttons;
 
-import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.command.Scheduler;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 
 /**
  * This class provides an easy way to link commands to inputs.

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/Command.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/Command.java
@@ -4,11 +4,11 @@
 
 package edu.wpi.first.wpilibj.command;
 
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.RobotState;
-import edu.wpi.first.wpilibj.Sendable;
 import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 import java.util.Enumeration;
 
 /**

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/PIDCommand.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/PIDCommand.java
@@ -4,11 +4,11 @@
 
 package edu.wpi.first.wpilibj.command;
 
+import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.wpilibj.PIDController;
 import edu.wpi.first.wpilibj.PIDOutput;
 import edu.wpi.first.wpilibj.PIDSource;
 import edu.wpi.first.wpilibj.PIDSourceType;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
 
 /**
  * This class defines a {@link Command} which interacts heavily with a PID loop.

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/Scheduler.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/Scheduler.java
@@ -7,12 +7,12 @@ package edu.wpi.first.wpilibj.command;
 import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
+import edu.wpi.first.networktables.NTSendable;
+import edu.wpi.first.networktables.NTSendableBuilder;
 import edu.wpi.first.networktables.NetworkTableEntry;
-import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.buttons.Trigger.ButtonScheduler;
 import edu.wpi.first.wpilibj.livewindow.LiveWindow;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Map;
@@ -30,7 +30,7 @@ import java.util.Vector;
  *
  * @see Command
  */
-public final class Scheduler implements Sendable, AutoCloseable {
+public final class Scheduler implements NTSendable, AutoCloseable {
   /** The Singleton Instance. */
   private static Scheduler instance;
 
@@ -301,7 +301,7 @@ public final class Scheduler implements Sendable, AutoCloseable {
   }
 
   @Override
-  public void initSendable(SendableBuilder builder) {
+  public void initSendable(NTSendableBuilder builder) {
     builder.setSmartDashboardType("Scheduler");
     final NetworkTableEntry namesEntry = builder.getEntry("Names");
     final NetworkTableEntry idsEntry = builder.getEntry("Ids");

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/Subsystem.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/Subsystem.java
@@ -4,9 +4,9 @@
 
 package edu.wpi.first.wpilibj.command;
 
-import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.util.Collections;
 
 /**

--- a/wpilibOldCommands/src/main/native/cpp/PIDBase.cpp
+++ b/wpilibOldCommands/src/main/native/cpp/PIDBase.cpp
@@ -8,10 +8,10 @@
 #include <cmath>
 
 #include <hal/FRCUsageReporting.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/PIDOutput.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -41,7 +41,7 @@ PIDBase::PIDBase(double Kp, double Ki, double Kd, double Kf, PIDSource& source,
   static int instances = 0;
   instances++;
   HAL_Report(HALUsageReporting::kResourceType_PIDController, instances);
-  SendableRegistry::GetInstance().Add(this, "PIDController", instances);
+  wpi::SendableRegistry::GetInstance().Add(this, "PIDController", instances);
 }
 
 double PIDBase::Get() const {
@@ -228,7 +228,7 @@ void PIDBase::PIDWrite(double output) {
   SetSetpoint(output);
 }
 
-void PIDBase::InitSendable(SendableBuilder& builder) {
+void PIDBase::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("PIDController");
   builder.SetSafeState([=] { Reset(); });
   builder.AddDoubleProperty(

--- a/wpilibOldCommands/src/main/native/cpp/PIDController.cpp
+++ b/wpilibOldCommands/src/main/native/cpp/PIDController.cpp
@@ -4,9 +4,10 @@
 
 #include "frc/PIDController.h"
 
+#include <wpi/sendable/SendableBuilder.h>
+
 #include "frc/Notifier.h"
 #include "frc/PIDOutput.h"
-#include "frc/smartdashboard/SendableBuilder.h"
 
 using namespace frc;
 
@@ -75,7 +76,7 @@ void PIDController::Reset() {
   PIDBase::Reset();
 }
 
-void PIDController::InitSendable(SendableBuilder& builder) {
+void PIDController::InitSendable(wpi::SendableBuilder& builder) {
   PIDBase::InitSendable(builder);
   builder.AddBooleanProperty(
       "enabled", [=] { return IsEnabled(); },

--- a/wpilibOldCommands/src/main/native/cpp/buttons/Trigger.cpp
+++ b/wpilibOldCommands/src/main/native/cpp/buttons/Trigger.cpp
@@ -2,13 +2,14 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+#include <wpi/sendable/SendableBuilder.h>
+
 #include "frc/buttons/Button.h"
 #include "frc/buttons/CancelButtonScheduler.h"
 #include "frc/buttons/HeldButtonScheduler.h"
 #include "frc/buttons/PressedButtonScheduler.h"
 #include "frc/buttons/ReleasedButtonScheduler.h"
 #include "frc/buttons/ToggleButtonScheduler.h"
-#include "frc/smartdashboard/SendableBuilder.h"
 
 using namespace frc;
 
@@ -62,7 +63,7 @@ void Trigger::ToggleWhenActive(Command* command) {
   tbs->Start();
 }
 
-void Trigger::InitSendable(SendableBuilder& builder) {
+void Trigger::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Button");
   builder.SetSafeState([=] { m_sendablePressed = false; });
   builder.AddBooleanProperty(

--- a/wpilibOldCommands/src/main/native/cpp/commands/Command.cpp
+++ b/wpilibOldCommands/src/main/native/cpp/commands/Command.cpp
@@ -6,14 +6,15 @@
 
 #include <typeinfo>
 
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
+
 #include "frc/Errors.h"
 #include "frc/RobotState.h"
 #include "frc/Timer.h"
 #include "frc/commands/CommandGroup.h"
 #include "frc/commands/Scheduler.h"
 #include "frc/livewindow/LiveWindow.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -40,10 +41,10 @@ Command::Command(std::string_view name, units::second_t timeout) {
 
   // If name contains an empty string
   if (name.empty()) {
-    SendableRegistry::GetInstance().Add(
+    wpi::SendableRegistry::GetInstance().Add(
         this, fmt::format("Command_{}", typeid(*this).name()));
   } else {
-    SendableRegistry::GetInstance().Add(this, name);
+    wpi::SendableRegistry::GetInstance().Add(this, name);
   }
 }
 
@@ -277,25 +278,26 @@ void Command::StartTiming() {
 }
 
 std::string Command::GetName() const {
-  return SendableRegistry::GetInstance().GetName(this);
+  return wpi::SendableRegistry::GetInstance().GetName(this);
 }
 
 void Command::SetName(std::string_view name) {
-  SendableRegistry::GetInstance().SetName(this, name);
+  wpi::SendableRegistry::GetInstance().SetName(this, name);
 }
 
 std::string Command::GetSubsystem() const {
-  return SendableRegistry::GetInstance().GetSubsystem(this);
+  return wpi::SendableRegistry::GetInstance().GetSubsystem(this);
 }
 
 void Command::SetSubsystem(std::string_view name) {
-  SendableRegistry::GetInstance().SetSubsystem(this, name);
+  wpi::SendableRegistry::GetInstance().SetSubsystem(this, name);
 }
 
-void Command::InitSendable(SendableBuilder& builder) {
+void Command::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Command");
   builder.AddStringProperty(
-      ".name", [=] { return SendableRegistry::GetInstance().GetName(this); },
+      ".name",
+      [=] { return wpi::SendableRegistry::GetInstance().GetName(this); },
       nullptr);
   builder.AddBooleanProperty(
       "running", [=] { return IsRunning(); },

--- a/wpilibOldCommands/src/main/native/cpp/commands/PIDCommand.cpp
+++ b/wpilibOldCommands/src/main/native/cpp/commands/PIDCommand.cpp
@@ -4,7 +4,7 @@
 
 #include "frc/commands/PIDCommand.h"
 
-#include "frc/smartdashboard/SendableBuilder.h"
+#include <wpi/sendable/SendableBuilder.h>
 
 using namespace frc;
 
@@ -112,7 +112,7 @@ double PIDCommand::GetPosition() {
   return ReturnPIDInput();
 }
 
-void PIDCommand::InitSendable(SendableBuilder& builder) {
+void PIDCommand::InitSendable(wpi::SendableBuilder& builder) {
   m_controller->InitSendable(builder);
   Command::InitSendable(builder);
   builder.SetSmartDashboardType("PIDCommand");

--- a/wpilibOldCommands/src/main/native/cpp/commands/Scheduler.cpp
+++ b/wpilibOldCommands/src/main/native/cpp/commands/Scheduler.cpp
@@ -10,16 +10,16 @@
 #include <vector>
 
 #include <hal/FRCUsageReporting.h>
+#include <networktables/NTSendableBuilder.h>
 #include <networktables/NetworkTableEntry.h>
 #include <wpi/mutex.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
 #include "frc/buttons/ButtonScheduler.h"
 #include "frc/commands/Command.h"
 #include "frc/commands/Subsystem.h"
 #include "frc/livewindow/LiveWindow.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -157,7 +157,7 @@ void Scheduler::SetEnabled(bool enabled) {
   m_impl->enabled = enabled;
 }
 
-void Scheduler::InitSendable(SendableBuilder& builder) {
+void Scheduler::InitSendable(nt::NTSendableBuilder& builder) {
   builder.SetSmartDashboardType("Scheduler");
   auto namesEntry = builder.GetEntry("Names");
   auto idsEntry = builder.GetEntry("Ids");
@@ -186,7 +186,7 @@ void Scheduler::InitSendable(SendableBuilder& builder) {
     if (m_impl->runningCommandsChanged) {
       m_impl->commandsBuf.resize(0);
       m_impl->idsBuf.resize(0);
-      auto& registry = SendableRegistry::GetInstance();
+      auto& registry = wpi::SendableRegistry::GetInstance();
       for (const auto& command : m_impl->commands) {
         m_impl->commandsBuf.emplace_back(registry.GetName(command));
         m_impl->idsBuf.emplace_back(command->GetID());
@@ -200,7 +200,7 @@ void Scheduler::InitSendable(SendableBuilder& builder) {
 Scheduler::Scheduler() : m_impl(new Impl) {
   HAL_Report(HALUsageReporting::kResourceType_Command,
              HALUsageReporting::kCommand_Scheduler);
-  SendableRegistry::GetInstance().AddLW(this, "Scheduler");
+  wpi::SendableRegistry::GetInstance().AddLW(this, "Scheduler");
   auto scheduler = frc::LiveWindow::GetInstance();
   scheduler->enabled = [this] {
     this->SetEnabled(false);
@@ -210,7 +210,7 @@ Scheduler::Scheduler() : m_impl(new Impl) {
 }
 
 Scheduler::~Scheduler() {
-  SendableRegistry::GetInstance().Remove(this);
+  wpi::SendableRegistry::GetInstance().Remove(this);
   auto scheduler = frc::LiveWindow::GetInstance();
   scheduler->enabled = nullptr;
   scheduler->disabled = nullptr;

--- a/wpilibOldCommands/src/main/native/cpp/commands/Subsystem.cpp
+++ b/wpilibOldCommands/src/main/native/cpp/commands/Subsystem.cpp
@@ -4,17 +4,18 @@
 
 #include "frc/commands/Subsystem.h"
 
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
+
 #include "frc/Errors.h"
 #include "frc/commands/Command.h"
 #include "frc/commands/Scheduler.h"
 #include "frc/livewindow/LiveWindow.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
 Subsystem::Subsystem(std::string_view name) {
-  SendableRegistry::GetInstance().AddLW(this, name, name);
+  wpi::SendableRegistry::GetInstance().AddLW(this, name, name);
   Scheduler::GetInstance()->RegisterSubsystem(this);
 }
 
@@ -43,7 +44,7 @@ Command* Subsystem::GetDefaultCommand() {
 std::string Subsystem::GetDefaultCommandName() {
   Command* defaultCommand = GetDefaultCommand();
   if (defaultCommand) {
-    return SendableRegistry::GetInstance().GetName(defaultCommand);
+    return wpi::SendableRegistry::GetInstance().GetName(defaultCommand);
   } else {
     return {};
   }
@@ -61,7 +62,7 @@ Command* Subsystem::GetCurrentCommand() const {
 std::string Subsystem::GetCurrentCommandName() const {
   Command* currentCommand = GetCurrentCommand();
   if (currentCommand) {
-    return SendableRegistry::GetInstance().GetName(currentCommand);
+    return wpi::SendableRegistry::GetInstance().GetName(currentCommand);
   } else {
     return {};
   }
@@ -72,19 +73,19 @@ void Subsystem::Periodic() {}
 void Subsystem::InitDefaultCommand() {}
 
 std::string Subsystem::GetName() const {
-  return SendableRegistry::GetInstance().GetName(this);
+  return wpi::SendableRegistry::GetInstance().GetName(this);
 }
 
 void Subsystem::SetName(std::string_view name) {
-  SendableRegistry::GetInstance().SetName(this, name);
+  wpi::SendableRegistry::GetInstance().SetName(this, name);
 }
 
 std::string Subsystem::GetSubsystem() const {
-  return SendableRegistry::GetInstance().GetSubsystem(this);
+  return wpi::SendableRegistry::GetInstance().GetSubsystem(this);
 }
 
 void Subsystem::SetSubsystem(std::string_view name) {
-  SendableRegistry::GetInstance().SetSubsystem(this, name);
+  wpi::SendableRegistry::GetInstance().SetSubsystem(this, name);
 }
 
 void Subsystem::AddChild(std::string_view name,
@@ -92,25 +93,25 @@ void Subsystem::AddChild(std::string_view name,
   AddChild(name, *child);
 }
 
-void Subsystem::AddChild(std::string_view name, Sendable* child) {
+void Subsystem::AddChild(std::string_view name, wpi::Sendable* child) {
   AddChild(name, *child);
 }
 
-void Subsystem::AddChild(std::string_view name, Sendable& child) {
-  auto& registry = SendableRegistry::GetInstance();
+void Subsystem::AddChild(std::string_view name, wpi::Sendable& child) {
+  auto& registry = wpi::SendableRegistry::GetInstance();
   registry.AddLW(&child, registry.GetSubsystem(this), name);
 }
 
-void Subsystem::AddChild(std::shared_ptr<Sendable> child) {
+void Subsystem::AddChild(std::shared_ptr<wpi::Sendable> child) {
   AddChild(*child);
 }
 
-void Subsystem::AddChild(Sendable* child) {
+void Subsystem::AddChild(wpi::Sendable* child) {
   AddChild(*child);
 }
 
-void Subsystem::AddChild(Sendable& child) {
-  auto& registry = SendableRegistry::GetInstance();
+void Subsystem::AddChild(wpi::Sendable& child) {
+  auto& registry = wpi::SendableRegistry::GetInstance();
   registry.SetSubsystem(&child, registry.GetSubsystem(this));
   registry.EnableLiveWindow(&child);
 }
@@ -121,7 +122,7 @@ void Subsystem::ConfirmCommand() {
   }
 }
 
-void Subsystem::InitSendable(SendableBuilder& builder) {
+void Subsystem::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Subsystem");
 
   builder.AddBooleanProperty(

--- a/wpilibOldCommands/src/main/native/include/frc/PIDBase.h
+++ b/wpilibOldCommands/src/main/native/include/frc/PIDBase.h
@@ -9,18 +9,16 @@
 
 #include <wpi/deprecated.h>
 #include <wpi/mutex.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/PIDInterface.h"
 #include "frc/PIDOutput.h"
 #include "frc/PIDSource.h"
 #include "frc/Timer.h"
 #include "frc/filter/LinearFilter.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
-
-class SendableBuilder;
 
 /**
  * Class implements a PID Control Loop.
@@ -36,8 +34,8 @@ class SendableBuilder;
  */
 class PIDBase : public PIDInterface,
                 public PIDOutput,
-                public Sendable,
-                public SendableHelper<PIDBase> {
+                public wpi::Sendable,
+                public wpi::SendableHelper<PIDBase> {
  public:
   /**
    * Allocate a PID object with the given constants for P, I, D.
@@ -301,7 +299,7 @@ class PIDBase : public PIDInterface,
    */
   void PIDWrite(double output) override;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  protected:
   // Is the pid controller enabled

--- a/wpilibOldCommands/src/main/native/include/frc/PIDController.h
+++ b/wpilibOldCommands/src/main/native/include/frc/PIDController.h
@@ -126,7 +126,7 @@ class PIDController : public PIDBase, public Controller {
    */
   void Reset() override;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   std::unique_ptr<Notifier> m_controlLoop;

--- a/wpilibOldCommands/src/main/native/include/frc/buttons/Trigger.h
+++ b/wpilibOldCommands/src/main/native/include/frc/buttons/Trigger.h
@@ -6,8 +6,8 @@
 
 #include <atomic>
 
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 namespace frc {
 
@@ -26,7 +26,7 @@ class Command;
  * only have to write the {@link Trigger#Get()} method to get the full
  * functionality of the Trigger class.
  */
-class Trigger : public Sendable, public SendableHelper<Trigger> {
+class Trigger : public wpi::Sendable, public wpi::SendableHelper<Trigger> {
  public:
   Trigger() = default;
   ~Trigger() override = default;
@@ -44,7 +44,7 @@ class Trigger : public Sendable, public SendableHelper<Trigger> {
   void CancelWhenActive(Command* command);
   void ToggleWhenActive(Command* command);
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   std::atomic_bool m_sendablePressed{false};

--- a/wpilibOldCommands/src/main/native/include/frc/commands/Command.h
+++ b/wpilibOldCommands/src/main/native/include/frc/commands/Command.h
@@ -10,10 +10,10 @@
 
 #include <units/time.h>
 #include <wpi/SmallPtrSet.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/commands/Subsystem.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
@@ -43,7 +43,7 @@ class CommandGroup;
  * @see CommandGroup
  * @see Subsystem
  */
-class Command : public Sendable, public SendableHelper<Command> {
+class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
   friend class CommandGroup;
   friend class Scheduler;
 
@@ -482,7 +482,7 @@ class Command : public Sendable, public SendableHelper<Command> {
   static int m_commandCounter;
 
  public:
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 };
 
 }  // namespace frc

--- a/wpilibOldCommands/src/main/native/include/frc/commands/PIDCommand.h
+++ b/wpilibOldCommands/src/main/native/include/frc/commands/PIDCommand.h
@@ -64,7 +64,7 @@ class PIDCommand : public Command, public PIDOutput, public PIDSource {
   std::shared_ptr<PIDController> m_controller;
 
  public:
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 };
 
 }  // namespace frc

--- a/wpilibOldCommands/src/main/native/include/frc/commands/Scheduler.h
+++ b/wpilibOldCommands/src/main/native/include/frc/commands/Scheduler.h
@@ -6,8 +6,8 @@
 
 #include <memory>
 
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
+#include <networktables/NTSendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 namespace frc {
 
@@ -15,7 +15,7 @@ class ButtonScheduler;
 class Command;
 class Subsystem;
 
-class Scheduler : public Sendable, public SendableHelper<Scheduler> {
+class Scheduler : public nt::NTSendable, public wpi::SendableHelper<Scheduler> {
  public:
   /**
    * Returns the Scheduler, creating it if one does not exist.
@@ -78,7 +78,7 @@ class Scheduler : public Sendable, public SendableHelper<Scheduler> {
 
   void SetEnabled(bool enabled);
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(nt::NTSendableBuilder& builder) override;
 
  private:
   Scheduler();

--- a/wpilibOldCommands/src/main/native/include/frc/commands/Subsystem.h
+++ b/wpilibOldCommands/src/main/native/include/frc/commands/Subsystem.h
@@ -8,14 +8,14 @@
 #include <string>
 #include <string_view>
 
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 namespace frc {
 
 class Command;
 
-class Subsystem : public Sendable, public SendableHelper<Subsystem> {
+class Subsystem : public wpi::Sendable, public wpi::SendableHelper<Subsystem> {
   friend class Scheduler;
 
  public:
@@ -127,7 +127,7 @@ class Subsystem : public Sendable, public SendableHelper<Subsystem> {
    * @param name name to give child
    * @param child sendable
    */
-  void AddChild(std::string_view name, std::shared_ptr<Sendable> child);
+  void AddChild(std::string_view name, std::shared_ptr<wpi::Sendable> child);
 
   /**
    * Associate a Sendable with this Subsystem.
@@ -136,7 +136,7 @@ class Subsystem : public Sendable, public SendableHelper<Subsystem> {
    * @param name name to give child
    * @param child sendable
    */
-  void AddChild(std::string_view name, Sendable* child);
+  void AddChild(std::string_view name, wpi::Sendable* child);
 
   /**
    * Associate a Sendable with this Subsystem.
@@ -145,28 +145,28 @@ class Subsystem : public Sendable, public SendableHelper<Subsystem> {
    * @param name name to give child
    * @param child sendable
    */
-  void AddChild(std::string_view name, Sendable& child);
+  void AddChild(std::string_view name, wpi::Sendable& child);
 
   /**
    * Associate a {@link Sendable} with this Subsystem.
    *
    * @param child sendable
    */
-  void AddChild(std::shared_ptr<Sendable> child);
+  void AddChild(std::shared_ptr<wpi::Sendable> child);
 
   /**
    * Associate a {@link Sendable} with this Subsystem.
    *
    * @param child sendable
    */
-  void AddChild(Sendable* child);
+  void AddChild(wpi::Sendable* child);
 
   /**
    * Associate a {@link Sendable} with this Subsystem.
    *
    * @param child sendable
    */
-  void AddChild(Sendable& child);
+  void AddChild(wpi::Sendable& child);
 
  private:
   /**
@@ -185,7 +185,7 @@ class Subsystem : public Sendable, public SendableHelper<Subsystem> {
   bool m_initializedDefaultCommand = false;
 
  public:
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 };
 
 }  // namespace frc

--- a/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTabTest.java
+++ b/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTabTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
-import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.wpilibj.command.InstantCommand;
 import java.util.HashMap;
 import java.util.Map;

--- a/wpilibOldCommands/src/test/native/cpp/shuffleboard/ShuffleboardTabTest.cpp
+++ b/wpilibOldCommands/src/test/native/cpp/shuffleboard/ShuffleboardTabTest.cpp
@@ -12,7 +12,6 @@
 #include "frc/commands/InstantCommand.h"
 #include "frc/shuffleboard/ShuffleboardInstance.h"
 #include "frc/shuffleboard/ShuffleboardTab.h"
-#include "frc/smartdashboard/Sendable.h"
 #include "gtest/gtest.h"
 
 using namespace frc;

--- a/wpilibOldCommands/src/test/native/cpp/shuffleboard/ShuffleboardWidgetTest.cpp
+++ b/wpilibOldCommands/src/test/native/cpp/shuffleboard/ShuffleboardWidgetTest.cpp
@@ -14,7 +14,6 @@
 #include "frc/shuffleboard/ShuffleboardInstance.h"
 #include "frc/shuffleboard/ShuffleboardTab.h"
 #include "frc/shuffleboard/ShuffleboardWidget.h"
-#include "frc/smartdashboard/Sendable.h"
 #include "gtest/gtest.h"
 
 using namespace frc;

--- a/wpilibc/src/main/native/cpp/ADXL345_I2C.cpp
+++ b/wpilibc/src/main/native/cpp/ADXL345_I2C.cpp
@@ -5,9 +5,8 @@
 #include "frc/ADXL345_I2C.h"
 
 #include <hal/FRCUsageReporting.h>
-
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
+#include <networktables/NTSendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 using namespace frc;
 
@@ -30,7 +29,7 @@ ADXL345_I2C::ADXL345_I2C(I2C::Port port, Range range, int deviceAddress)
   HAL_Report(HALUsageReporting::kResourceType_ADXL345,
              HALUsageReporting::kADXL345_I2C, 0);
 
-  SendableRegistry::GetInstance().AddLW(this, "ADXL345_I2C", port);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "ADXL345_I2C", port);
 }
 
 void ADXL345_I2C::SetRange(Range range) {
@@ -84,7 +83,7 @@ ADXL345_I2C::AllAxes ADXL345_I2C::GetAccelerations() {
   return data;
 }
 
-void ADXL345_I2C::InitSendable(SendableBuilder& builder) {
+void ADXL345_I2C::InitSendable(nt::NTSendableBuilder& builder) {
   builder.SetSmartDashboardType("3AxisAccelerometer");
   auto x = builder.GetEntry("X").GetHandle();
   auto y = builder.GetEntry("Y").GetHandle();

--- a/wpilibc/src/main/native/cpp/ADXL345_SPI.cpp
+++ b/wpilibc/src/main/native/cpp/ADXL345_SPI.cpp
@@ -5,9 +5,8 @@
 #include "frc/ADXL345_SPI.h"
 
 #include <hal/FRCUsageReporting.h>
-
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
+#include <networktables/NTSendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 using namespace frc;
 
@@ -38,7 +37,7 @@ ADXL345_SPI::ADXL345_SPI(SPI::Port port, ADXL345_SPI::Range range)
   HAL_Report(HALUsageReporting::kResourceType_ADXL345,
              HALUsageReporting::kADXL345_SPI);
 
-  SendableRegistry::GetInstance().AddLW(this, "ADXL345_SPI", port);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "ADXL345_SPI", port);
 }
 
 void ADXL345_SPI::SetRange(Range range) {
@@ -115,7 +114,7 @@ ADXL345_SPI::AllAxes ADXL345_SPI::GetAccelerations() {
   return data;
 }
 
-void ADXL345_SPI::InitSendable(SendableBuilder& builder) {
+void ADXL345_SPI::InitSendable(nt::NTSendableBuilder& builder) {
   builder.SetSmartDashboardType("3AxisAccelerometer");
   auto x = builder.GetEntry("X").GetHandle();
   auto y = builder.GetEntry("Y").GetHandle();

--- a/wpilibc/src/main/native/cpp/ADXL362.cpp
+++ b/wpilibc/src/main/native/cpp/ADXL362.cpp
@@ -5,10 +5,10 @@
 #include "frc/ADXL362.h"
 
 #include <hal/FRCUsageReporting.h>
+#include <networktables/NTSendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -72,7 +72,7 @@ ADXL362::ADXL362(SPI::Port port, Range range)
 
   HAL_Report(HALUsageReporting::kResourceType_ADXL362, port + 1);
 
-  SendableRegistry::GetInstance().AddLW(this, "ADXL362", port);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "ADXL362", port);
 }
 
 void ADXL362::SetRange(Range range) {
@@ -178,7 +178,7 @@ ADXL362::AllAxes ADXL362::GetAccelerations() {
   return data;
 }
 
-void ADXL362::InitSendable(SendableBuilder& builder) {
+void ADXL362::InitSendable(nt::NTSendableBuilder& builder) {
   builder.SetSmartDashboardType("3AxisAccelerometer");
   auto x = builder.GetEntry("X").GetHandle();
   auto y = builder.GetEntry("Y").GetHandle();

--- a/wpilibc/src/main/native/cpp/ADXRS450_Gyro.cpp
+++ b/wpilibc/src/main/native/cpp/ADXRS450_Gyro.cpp
@@ -5,11 +5,11 @@
 #include "frc/ADXRS450_Gyro.h"
 
 #include <hal/FRCUsageReporting.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
 #include "frc/Timer.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -58,7 +58,7 @@ ADXRS450_Gyro::ADXRS450_Gyro(SPI::Port port)
 
   HAL_Report(HALUsageReporting::kResourceType_ADXRS450, port + 1);
 
-  SendableRegistry::GetInstance().AddLW(this, "ADXRS450_Gyro", port);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "ADXRS450_Gyro", port);
 }
 
 static bool CalcParity(int v) {
@@ -136,7 +136,7 @@ int ADXRS450_Gyro::GetPort() const {
   return m_port;
 }
 
-void ADXRS450_Gyro::InitSendable(SendableBuilder& builder) {
+void ADXRS450_Gyro::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Gyro");
   builder.AddDoubleProperty(
       "Value", [=] { return GetAngle(); }, nullptr);

--- a/wpilibc/src/main/native/cpp/AnalogAccelerometer.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogAccelerometer.cpp
@@ -6,16 +6,16 @@
 
 #include <hal/FRCUsageReporting.h>
 #include <wpi/NullDeleter.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
 AnalogAccelerometer::AnalogAccelerometer(int channel)
     : AnalogAccelerometer(std::make_shared<AnalogInput>(channel)) {
-  SendableRegistry::GetInstance().AddChild(this, m_analogInput.get());
+  wpi::SendableRegistry::GetInstance().AddChild(this, m_analogInput.get());
 }
 
 AnalogAccelerometer::AnalogAccelerometer(AnalogInput* channel)
@@ -46,7 +46,7 @@ void AnalogAccelerometer::SetZero(double zero) {
   m_zeroGVoltage = zero;
 }
 
-void AnalogAccelerometer::InitSendable(SendableBuilder& builder) {
+void AnalogAccelerometer::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Accelerometer");
   builder.AddDoubleProperty(
       "Value", [=] { return GetAcceleration(); }, nullptr);
@@ -56,6 +56,6 @@ void AnalogAccelerometer::InitAccelerometer() {
   HAL_Report(HALUsageReporting::kResourceType_Accelerometer,
              m_analogInput->GetChannel() + 1);
 
-  SendableRegistry::GetInstance().AddLW(this, "Accelerometer",
-                                        m_analogInput->GetChannel());
+  wpi::SendableRegistry::GetInstance().AddLW(this, "Accelerometer",
+                                             m_analogInput->GetChannel());
 }

--- a/wpilibc/src/main/native/cpp/AnalogEncoder.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogEncoder.cpp
@@ -5,11 +5,11 @@
 #include "frc/AnalogEncoder.h"
 
 #include <wpi/NullDeleter.h>
+#include <wpi/sendable/SendableBuilder.h>
 
 #include "frc/AnalogInput.h"
 #include "frc/Counter.h"
 #include "frc/Errors.h"
-#include "frc/smartdashboard/SendableBuilder.h"
 
 using namespace frc;
 
@@ -50,8 +50,8 @@ void AnalogEncoder::Init() {
   m_counter.SetDownSource(
       m_analogTrigger.CreateOutput(AnalogTriggerType::kFallingPulse));
 
-  SendableRegistry::GetInstance().AddLW(this, "DutyCycle Encoder",
-                                        m_analogInput->GetChannel());
+  wpi::SendableRegistry::GetInstance().AddLW(this, "DutyCycle Encoder",
+                                             m_analogInput->GetChannel());
 }
 
 units::turn_t AnalogEncoder::Get() const {
@@ -105,7 +105,7 @@ int AnalogEncoder::GetChannel() const {
   return m_analogInput->GetChannel();
 }
 
-void AnalogEncoder::InitSendable(SendableBuilder& builder) {
+void AnalogEncoder::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("AbsoluteEncoder");
   builder.AddDoubleProperty(
       "Distance", [this] { return this->GetDistance(); }, nullptr);

--- a/wpilibc/src/main/native/cpp/AnalogGyro.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogGyro.cpp
@@ -12,18 +12,18 @@
 #include <hal/FRCUsageReporting.h>
 #include <wpi/NullDeleter.h>
 #include <wpi/StackTrace.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/AnalogInput.h"
 #include "frc/Errors.h"
 #include "frc/Timer.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
 AnalogGyro::AnalogGyro(int channel)
     : AnalogGyro(std::make_shared<AnalogInput>(channel)) {
-  SendableRegistry::GetInstance().AddChild(this, m_analog.get());
+  wpi::SendableRegistry::GetInstance().AddChild(this, m_analog.get());
 }
 
 AnalogGyro::AnalogGyro(AnalogInput* channel)
@@ -41,7 +41,7 @@ AnalogGyro::AnalogGyro(std::shared_ptr<AnalogInput> channel)
 
 AnalogGyro::AnalogGyro(int channel, int center, double offset)
     : AnalogGyro(std::make_shared<AnalogInput>(channel), center, offset) {
-  SendableRegistry::GetInstance().AddChild(this, m_analog.get());
+  wpi::SendableRegistry::GetInstance().AddChild(this, m_analog.get());
 }
 
 AnalogGyro::AnalogGyro(std::shared_ptr<AnalogInput> channel, int center,
@@ -124,8 +124,8 @@ void AnalogGyro::InitGyro() {
 
   HAL_Report(HALUsageReporting::kResourceType_Gyro, m_analog->GetChannel() + 1);
 
-  SendableRegistry::GetInstance().AddLW(this, "AnalogGyro",
-                                        m_analog->GetChannel());
+  wpi::SendableRegistry::GetInstance().AddLW(this, "AnalogGyro",
+                                             m_analog->GetChannel());
 }
 
 void AnalogGyro::Calibrate() {
@@ -138,7 +138,7 @@ std::shared_ptr<AnalogInput> AnalogGyro::GetAnalogInput() const {
   return m_analog;
 }
 
-void AnalogGyro::InitSendable(SendableBuilder& builder) {
+void AnalogGyro::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Gyro");
   builder.AddDoubleProperty(
       "Value", [=] { return GetAngle(); }, nullptr);

--- a/wpilibc/src/main/native/cpp/AnalogInput.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogInput.cpp
@@ -10,12 +10,12 @@
 #include <hal/HALBase.h>
 #include <hal/Ports.h>
 #include <wpi/StackTrace.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
 #include "frc/SensorUtil.h"
 #include "frc/Timer.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -34,7 +34,7 @@ AnalogInput::AnalogInput(int channel) {
 
   HAL_Report(HALUsageReporting::kResourceType_AnalogChannel, channel + 1);
 
-  SendableRegistry::GetInstance().AddLW(this, "AnalogInput", channel);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "AnalogInput", channel);
 }
 
 AnalogInput::~AnalogInput() {
@@ -194,7 +194,7 @@ void AnalogInput::SetSimDevice(HAL_SimDeviceHandle device) {
   HAL_SetAnalogInputSimDevice(m_port, device);
 }
 
-void AnalogInput::InitSendable(SendableBuilder& builder) {
+void AnalogInput::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Analog Input");
   builder.AddDoubleProperty(
       "Value", [=] { return GetAverageVoltage(); }, nullptr);

--- a/wpilibc/src/main/native/cpp/AnalogOutput.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogOutput.cpp
@@ -12,11 +12,11 @@
 #include <hal/HALBase.h>
 #include <hal/Ports.h>
 #include <wpi/StackTrace.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
 #include "frc/SensorUtil.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -34,7 +34,7 @@ AnalogOutput::AnalogOutput(int channel) {
   FRC_CheckErrorStatus(status, "Channel {}", channel);
 
   HAL_Report(HALUsageReporting::kResourceType_AnalogOutput, m_channel + 1);
-  SendableRegistry::GetInstance().AddLW(this, "AnalogOutput", m_channel);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "AnalogOutput", m_channel);
 }
 
 AnalogOutput::~AnalogOutput() {
@@ -58,7 +58,7 @@ int AnalogOutput::GetChannel() const {
   return m_channel;
 }
 
-void AnalogOutput::InitSendable(SendableBuilder& builder) {
+void AnalogOutput::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Analog Output");
   builder.AddDoubleProperty(
       "Value", [=] { return GetVoltage(); },

--- a/wpilibc/src/main/native/cpp/AnalogPotentiometer.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogPotentiometer.cpp
@@ -7,10 +7,10 @@
 #include <utility>
 
 #include <wpi/NullDeleter.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/RobotController.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -18,7 +18,7 @@ AnalogPotentiometer::AnalogPotentiometer(int channel, double fullRange,
                                          double offset)
     : AnalogPotentiometer(std::make_shared<AnalogInput>(channel), fullRange,
                           offset) {
-  SendableRegistry::GetInstance().AddChild(this, m_analog_input.get());
+  wpi::SendableRegistry::GetInstance().AddChild(this, m_analog_input.get());
 }
 
 AnalogPotentiometer::AnalogPotentiometer(AnalogInput* input, double fullRange,
@@ -32,8 +32,8 @@ AnalogPotentiometer::AnalogPotentiometer(std::shared_ptr<AnalogInput> input,
     : m_analog_input(std::move(input)),
       m_fullRange(fullRange),
       m_offset(offset) {
-  SendableRegistry::GetInstance().AddLW(this, "AnalogPotentiometer",
-                                        m_analog_input->GetChannel());
+  wpi::SendableRegistry::GetInstance().AddLW(this, "AnalogPotentiometer",
+                                             m_analog_input->GetChannel());
 }
 
 double AnalogPotentiometer::Get() const {
@@ -43,7 +43,7 @@ double AnalogPotentiometer::Get() const {
          m_offset;
 }
 
-void AnalogPotentiometer::InitSendable(SendableBuilder& builder) {
+void AnalogPotentiometer::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Analog Input");
   builder.AddDoubleProperty(
       "Value", [=] { return Get(); }, nullptr);

--- a/wpilibc/src/main/native/cpp/AnalogTrigger.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogTrigger.cpp
@@ -9,18 +9,18 @@
 #include <hal/AnalogTrigger.h>
 #include <hal/FRCUsageReporting.h>
 #include <wpi/NullDeleter.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/AnalogInput.h"
 #include "frc/DutyCycle.h"
 #include "frc/Errors.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
 AnalogTrigger::AnalogTrigger(int channel)
     : AnalogTrigger(new AnalogInput(channel)) {
   m_ownsAnalog = true;
-  SendableRegistry::GetInstance().AddChild(this, m_analogInput);
+  wpi::SendableRegistry::GetInstance().AddChild(this, m_analogInput);
 }
 
 AnalogTrigger::AnalogTrigger(AnalogInput* input) {
@@ -31,7 +31,7 @@ AnalogTrigger::AnalogTrigger(AnalogInput* input) {
   int index = GetIndex();
 
   HAL_Report(HALUsageReporting::kResourceType_AnalogTrigger, index + 1);
-  SendableRegistry::GetInstance().AddLW(this, "AnalogTrigger", index);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "AnalogTrigger", index);
 }
 
 AnalogTrigger::AnalogTrigger(DutyCycle* input) {
@@ -42,7 +42,7 @@ AnalogTrigger::AnalogTrigger(DutyCycle* input) {
   int index = GetIndex();
 
   HAL_Report(HALUsageReporting::kResourceType_AnalogTrigger, index + 1);
-  SendableRegistry::GetInstance().AddLW(this, "AnalogTrigger", index);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "AnalogTrigger", index);
 }
 
 AnalogTrigger::~AnalogTrigger() {
@@ -113,7 +113,7 @@ std::shared_ptr<AnalogTriggerOutput> AnalogTrigger::CreateOutput(
       wpi::NullDeleter<AnalogTriggerOutput>());
 }
 
-void AnalogTrigger::InitSendable(SendableBuilder& builder) {
+void AnalogTrigger::InitSendable(wpi::SendableBuilder& builder) {
   if (m_ownsAnalog) {
     m_analogInput->InitSendable(builder);
   }

--- a/wpilibc/src/main/native/cpp/AnalogTriggerOutput.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogTriggerOutput.cpp
@@ -38,7 +38,7 @@ int AnalogTriggerOutput::GetChannel() const {
   return m_trigger->GetIndex();
 }
 
-void AnalogTriggerOutput::InitSendable(SendableBuilder&) {}
+void AnalogTriggerOutput::InitSendable(wpi::SendableBuilder&) {}
 
 AnalogTriggerOutput::AnalogTriggerOutput(const AnalogTrigger& trigger,
                                          AnalogTriggerType outputType)

--- a/wpilibc/src/main/native/cpp/BuiltInAccelerometer.cpp
+++ b/wpilibc/src/main/native/cpp/BuiltInAccelerometer.cpp
@@ -6,10 +6,10 @@
 
 #include <hal/Accelerometer.h>
 #include <hal/FRCUsageReporting.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -18,7 +18,7 @@ BuiltInAccelerometer::BuiltInAccelerometer(Range range) {
 
   HAL_Report(HALUsageReporting::kResourceType_Accelerometer, 0, 0,
              "Built-in accelerometer");
-  SendableRegistry::GetInstance().AddLW(this, "BuiltInAccel");
+  wpi::SendableRegistry::GetInstance().AddLW(this, "BuiltInAccel");
 }
 
 void BuiltInAccelerometer::SetRange(Range range) {
@@ -44,7 +44,7 @@ double BuiltInAccelerometer::GetZ() {
   return HAL_GetAccelerometerZ();
 }
 
-void BuiltInAccelerometer::InitSendable(SendableBuilder& builder) {
+void BuiltInAccelerometer::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("3AxisAccelerometer");
   builder.AddDoubleProperty(
       "X", [=] { return GetX(); }, nullptr);

--- a/wpilibc/src/main/native/cpp/Counter.cpp
+++ b/wpilibc/src/main/native/cpp/Counter.cpp
@@ -9,12 +9,12 @@
 #include <hal/Counter.h>
 #include <hal/FRCUsageReporting.h>
 #include <wpi/NullDeleter.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/AnalogTrigger.h"
 #include "frc/DigitalInput.h"
 #include "frc/Errors.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -27,7 +27,7 @@ Counter::Counter(Mode mode) {
   SetMaxPeriod(0.5_s);
 
   HAL_Report(HALUsageReporting::kResourceType_Counter, m_index + 1, mode + 1);
-  SendableRegistry::GetInstance().AddLW(this, "Counter", m_index);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "Counter", m_index);
 }
 
 Counter::Counter(int channel) : Counter(kTwoPulse) {
@@ -97,7 +97,7 @@ Counter::~Counter() {
 
 void Counter::SetUpSource(int channel) {
   SetUpSource(std::make_shared<DigitalInput>(channel));
-  SendableRegistry::GetInstance().AddChild(this, m_upSource.get());
+  wpi::SendableRegistry::GetInstance().AddChild(this, m_upSource.get());
 }
 
 void Counter::SetUpSource(AnalogTrigger* analogTrigger,
@@ -152,7 +152,7 @@ void Counter::ClearUpSource() {
 
 void Counter::SetDownSource(int channel) {
   SetDownSource(std::make_shared<DigitalInput>(channel));
-  SendableRegistry::GetInstance().AddChild(this, m_downSource.get());
+  wpi::SendableRegistry::GetInstance().AddChild(this, m_downSource.get());
 }
 
 void Counter::SetDownSource(AnalogTrigger* analogTrigger,
@@ -306,7 +306,7 @@ bool Counter::GetDirection() const {
   return value;
 }
 
-void Counter::InitSendable(SendableBuilder& builder) {
+void Counter::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Counter");
   builder.AddDoubleProperty(
       "Value", [=] { return Get(); }, nullptr);

--- a/wpilibc/src/main/native/cpp/DigitalGlitchFilter.cpp
+++ b/wpilibc/src/main/native/cpp/DigitalGlitchFilter.cpp
@@ -11,12 +11,12 @@
 #include <hal/Constants.h>
 #include <hal/DIO.h>
 #include <hal/FRCUsageReporting.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Counter.h"
 #include "frc/Encoder.h"
 #include "frc/Errors.h"
 #include "frc/SensorUtil.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -35,8 +35,8 @@ DigitalGlitchFilter::DigitalGlitchFilter() {
 
   HAL_Report(HALUsageReporting::kResourceType_DigitalGlitchFilter,
              m_channelIndex + 1);
-  SendableRegistry::GetInstance().AddLW(this, "DigitalGlitchFilter",
-                                        m_channelIndex);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "DigitalGlitchFilter",
+                                             m_channelIndex);
 }
 
 DigitalGlitchFilter::~DigitalGlitchFilter() {
@@ -125,4 +125,4 @@ uint64_t DigitalGlitchFilter::GetPeriodNanoSeconds() {
          static_cast<uint64_t>(HAL_GetSystemClockTicksPerMicrosecond() / 4);
 }
 
-void DigitalGlitchFilter::InitSendable(SendableBuilder&) {}
+void DigitalGlitchFilter::InitSendable(wpi::SendableBuilder&) {}

--- a/wpilibc/src/main/native/cpp/DigitalInput.cpp
+++ b/wpilibc/src/main/native/cpp/DigitalInput.cpp
@@ -12,11 +12,11 @@
 #include <hal/HALBase.h>
 #include <hal/Ports.h>
 #include <wpi/StackTrace.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
 #include "frc/SensorUtil.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -33,7 +33,7 @@ DigitalInput::DigitalInput(int channel) {
   FRC_CheckErrorStatus(status, "Channel {}", channel);
 
   HAL_Report(HALUsageReporting::kResourceType_DigitalInput, channel + 1);
-  SendableRegistry::GetInstance().AddLW(this, "DigitalInput", channel);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "DigitalInput", channel);
 }
 
 DigitalInput::~DigitalInput() {
@@ -67,7 +67,7 @@ int DigitalInput::GetChannel() const {
   return m_channel;
 }
 
-void DigitalInput::InitSendable(SendableBuilder& builder) {
+void DigitalInput::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Digital Input");
   builder.AddBooleanProperty(
       "Value", [=] { return Get(); }, nullptr);

--- a/wpilibc/src/main/native/cpp/DigitalOutput.cpp
+++ b/wpilibc/src/main/native/cpp/DigitalOutput.cpp
@@ -11,11 +11,11 @@
 #include <hal/HALBase.h>
 #include <hal/Ports.h>
 #include <wpi/StackTrace.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
 #include "frc/SensorUtil.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -33,7 +33,7 @@ DigitalOutput::DigitalOutput(int channel) {
   FRC_CheckErrorStatus(status, "Channel {}", channel);
 
   HAL_Report(HALUsageReporting::kResourceType_DigitalOutput, channel + 1);
-  SendableRegistry::GetInstance().AddLW(this, "DigitalOutput", channel);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "DigitalOutput", channel);
 }
 
 DigitalOutput::~DigitalOutput() {
@@ -140,7 +140,7 @@ void DigitalOutput::SetSimDevice(HAL_SimDeviceHandle device) {
   HAL_SetDIOSimDevice(m_handle, device);
 }
 
-void DigitalOutput::InitSendable(SendableBuilder& builder) {
+void DigitalOutput::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Digital Output");
   builder.AddBooleanProperty(
       "Value", [=] { return Get(); }, [=](bool value) { Set(value); });

--- a/wpilibc/src/main/native/cpp/DoubleSolenoid.cpp
+++ b/wpilibc/src/main/native/cpp/DoubleSolenoid.cpp
@@ -10,11 +10,11 @@
 #include <hal/HALBase.h>
 #include <hal/Ports.h>
 #include <wpi/NullDeleter.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
 #include "frc/SensorUtil.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -53,7 +53,7 @@ DoubleSolenoid::DoubleSolenoid(std::shared_ptr<PneumaticsBase> module,
              m_module->GetModuleNumber() + 1);
   HAL_Report(HALUsageReporting::kResourceType_Solenoid, m_reverseChannel + 1,
              m_module->GetModuleNumber() + 1);
-  SendableRegistry::GetInstance().AddLW(
+  wpi::SendableRegistry::GetInstance().AddLW(
       this, "DoubleSolenoid", m_module->GetModuleNumber(), m_forwardChannel);
 }
 
@@ -115,7 +115,7 @@ bool DoubleSolenoid::IsRevSolenoidDisabled() const {
   return (m_module->GetSolenoidDisabledList() & m_reverseMask) != 0;
 }
 
-void DoubleSolenoid::InitSendable(SendableBuilder& builder) {
+void DoubleSolenoid::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Double Solenoid");
   builder.SetActuator(true);
   builder.SetSafeState([=] { Set(kOff); });

--- a/wpilibc/src/main/native/cpp/DutyCycle.cpp
+++ b/wpilibc/src/main/native/cpp/DutyCycle.cpp
@@ -7,10 +7,10 @@
 #include <hal/DutyCycle.h>
 #include <hal/FRCUsageReporting.h>
 #include <wpi/NullDeleter.h>
+#include <wpi/sendable/SendableBuilder.h>
 
 #include "frc/DigitalSource.h"
 #include "frc/Errors.h"
-#include "frc/smartdashboard/SendableBuilder.h"
 
 using namespace frc;
 
@@ -49,7 +49,7 @@ void DutyCycle::InitDutyCycle() {
   FRC_CheckErrorStatus(status, "Channel {}", GetSourceChannel());
   int index = GetFPGAIndex();
   HAL_Report(HALUsageReporting::kResourceType_DutyCycle, index + 1);
-  SendableRegistry::GetInstance().AddLW(this, "Duty Cycle", index);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "Duty Cycle", index);
 }
 
 int DutyCycle::GetFPGAIndex() const {
@@ -91,7 +91,7 @@ int DutyCycle::GetSourceChannel() const {
   return m_source->GetChannel();
 }
 
-void DutyCycle::InitSendable(SendableBuilder& builder) {
+void DutyCycle::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Duty Cycle");
   builder.AddDoubleProperty(
       "Frequency", [this] { return this->GetFrequency(); }, nullptr);

--- a/wpilibc/src/main/native/cpp/DutyCycleEncoder.cpp
+++ b/wpilibc/src/main/native/cpp/DutyCycleEncoder.cpp
@@ -5,13 +5,13 @@
 #include "frc/DutyCycleEncoder.h"
 
 #include <wpi/NullDeleter.h>
+#include <wpi/sendable/SendableBuilder.h>
 
 #include "frc/Counter.h"
 #include "frc/DigitalInput.h"
 #include "frc/DigitalSource.h"
 #include "frc/DutyCycle.h"
 #include "frc/Errors.h"
-#include "frc/smartdashboard/SendableBuilder.h"
 
 using namespace frc;
 
@@ -72,8 +72,8 @@ void DutyCycleEncoder::Init() {
         m_analogTrigger->CreateOutput(AnalogTriggerType::kFallingPulse));
   }
 
-  SendableRegistry::GetInstance().AddLW(this, "DutyCycle Encoder",
-                                        m_dutyCycle->GetSourceChannel());
+  wpi::SendableRegistry::GetInstance().AddLW(this, "DutyCycle Encoder",
+                                             m_dutyCycle->GetSourceChannel());
 }
 
 units::turn_t DutyCycleEncoder::Get() const {
@@ -148,7 +148,7 @@ int DutyCycleEncoder::GetSourceChannel() const {
   return m_dutyCycle->GetSourceChannel();
 }
 
-void DutyCycleEncoder::InitSendable(SendableBuilder& builder) {
+void DutyCycleEncoder::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("AbsoluteEncoder");
   builder.AddDoubleProperty(
       "Distance", [this] { return this->GetDistance(); }, nullptr);

--- a/wpilibc/src/main/native/cpp/Encoder.cpp
+++ b/wpilibc/src/main/native/cpp/Encoder.cpp
@@ -9,11 +9,11 @@
 #include <hal/Encoder.h>
 #include <hal/FRCUsageReporting.h>
 #include <wpi/NullDeleter.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/DigitalInput.h"
 #include "frc/Errors.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -22,7 +22,7 @@ Encoder::Encoder(int aChannel, int bChannel, bool reverseDirection,
   m_aSource = std::make_shared<DigitalInput>(aChannel);
   m_bSource = std::make_shared<DigitalInput>(bChannel);
   InitEncoder(reverseDirection, encodingType);
-  auto& registry = SendableRegistry::GetInstance();
+  auto& registry = wpi::SendableRegistry::GetInstance();
   registry.AddChild(this, m_aSource.get());
   registry.AddChild(this, m_bSource.get());
 }
@@ -181,7 +181,7 @@ int Encoder::GetSamplesToAverage() const {
 void Encoder::SetIndexSource(int channel, Encoder::IndexingType type) {
   // Force digital input if just given an index
   m_indexSource = std::make_shared<DigitalInput>(channel);
-  SendableRegistry::GetInstance().AddChild(this, m_indexSource.get());
+  wpi::SendableRegistry::GetInstance().AddChild(this, m_indexSource.get());
   SetIndexSource(*m_indexSource.get(), type);
 }
 
@@ -207,7 +207,7 @@ int Encoder::GetFPGAIndex() const {
   return val;
 }
 
-void Encoder::InitSendable(SendableBuilder& builder) {
+void Encoder::InitSendable(wpi::SendableBuilder& builder) {
   int32_t status = 0;
   HAL_EncoderEncodingType type = HAL_GetEncoderEncodingType(m_encoder, &status);
   FRC_CheckErrorStatus(status, "{}", "GetEncodingType");
@@ -240,8 +240,8 @@ void Encoder::InitEncoder(bool reverseDirection, EncodingType encodingType) {
 
   HAL_Report(HALUsageReporting::kResourceType_Encoder, GetFPGAIndex() + 1,
              encodingType);
-  SendableRegistry::GetInstance().AddLW(this, "Encoder",
-                                        m_aSource->GetChannel());
+  wpi::SendableRegistry::GetInstance().AddLW(this, "Encoder",
+                                             m_aSource->GetChannel());
 }
 
 double Encoder::DecodingScaleFactor() const {

--- a/wpilibc/src/main/native/cpp/PWM.cpp
+++ b/wpilibc/src/main/native/cpp/PWM.cpp
@@ -11,11 +11,11 @@
 #include <hal/PWM.h>
 #include <hal/Ports.h>
 #include <wpi/StackTrace.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
 #include "frc/SensorUtil.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -40,7 +40,7 @@ PWM::PWM(int channel, bool registerSendable) {
 
   HAL_Report(HALUsageReporting::kResourceType_PWM, channel + 1);
   if (registerSendable) {
-    SendableRegistry::GetInstance().AddLW(this, "PWM", channel);
+    wpi::SendableRegistry::GetInstance().AddLW(this, "PWM", channel);
   }
 }
 
@@ -163,7 +163,7 @@ int PWM::GetChannel() const {
   return m_channel;
 }
 
-void PWM::InitSendable(SendableBuilder& builder) {
+void PWM::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("PWM");
   builder.SetActuator(true);
   builder.SetSafeState([=] { SetDisabled(); });

--- a/wpilibc/src/main/native/cpp/PowerDistributionPanel.cpp
+++ b/wpilibc/src/main/native/cpp/PowerDistributionPanel.cpp
@@ -8,11 +8,11 @@
 #include <hal/FRCUsageReporting.h>
 #include <hal/PDP.h>
 #include <hal/Ports.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
 #include "frc/SensorUtil.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -24,7 +24,8 @@ PowerDistributionPanel::PowerDistributionPanel(int module) : m_module(module) {
   FRC_CheckErrorStatus(status, "Module {}", module);
 
   HAL_Report(HALUsageReporting::kResourceType_PDP, module + 1);
-  SendableRegistry::GetInstance().AddLW(this, "PowerDistributionPanel", module);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "PowerDistributionPanel",
+                                             module);
 }
 
 double PowerDistributionPanel::GetVoltage() const {
@@ -93,7 +94,7 @@ int PowerDistributionPanel::GetModule() const {
   return m_module;
 }
 
-void PowerDistributionPanel::InitSendable(SendableBuilder& builder) {
+void PowerDistributionPanel::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("PowerDistributionPanel");
   for (int i = 0; i < SensorUtil::kPDPChannels; ++i) {
     builder.AddDoubleProperty(

--- a/wpilibc/src/main/native/cpp/Relay.cpp
+++ b/wpilibc/src/main/native/cpp/Relay.cpp
@@ -12,11 +12,11 @@
 #include <hal/Ports.h>
 #include <hal/Relay.h>
 #include <wpi/StackTrace.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
 #include "frc/SensorUtil.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -56,7 +56,7 @@ Relay::Relay(int channel, Relay::Direction direction)
     FRC_CheckErrorStatus(status, "Channel {}", m_channel);
   }
 
-  SendableRegistry::GetInstance().AddLW(this, "Relay", m_channel);
+  wpi::SendableRegistry::GetInstance().AddLW(this, "Relay", m_channel);
 }
 
 Relay::~Relay() {
@@ -172,7 +172,7 @@ std::string Relay::GetDescription() const {
   return fmt::format("Relay {}", GetChannel());
 }
 
-void Relay::InitSendable(SendableBuilder& builder) {
+void Relay::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Relay");
   builder.SetActuator(true);
   builder.SetSafeState([=] { Set(kOff); });

--- a/wpilibc/src/main/native/cpp/Servo.cpp
+++ b/wpilibc/src/main/native/cpp/Servo.cpp
@@ -5,9 +5,8 @@
 #include "frc/Servo.h"
 
 #include <hal/FRCUsageReporting.h>
-
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 using namespace frc;
 
@@ -25,7 +24,7 @@ Servo::Servo(int channel) : PWM(channel) {
   SetPeriodMultiplier(kPeriodMultiplier_4X);
 
   HAL_Report(HALUsageReporting::kResourceType_Servo, channel + 1);
-  SendableRegistry::GetInstance().SetName(this, "Servo", channel);
+  wpi::SendableRegistry::GetInstance().SetName(this, "Servo", channel);
 }
 
 void Servo::Set(double value) {
@@ -62,7 +61,7 @@ double Servo::GetMinAngle() const {
   return kMinServoAngle;
 }
 
-void Servo::InitSendable(SendableBuilder& builder) {
+void Servo::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Servo");
   builder.AddDoubleProperty(
       "Value", [=] { return Get(); }, [=](double value) { Set(value); });

--- a/wpilibc/src/main/native/cpp/Solenoid.cpp
+++ b/wpilibc/src/main/native/cpp/Solenoid.cpp
@@ -8,11 +8,11 @@
 
 #include <hal/FRCUsageReporting.h>
 #include <wpi/NullDeleter.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
 #include "frc/SensorUtil.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -36,8 +36,8 @@ Solenoid::Solenoid(std::shared_ptr<PneumaticsBase> module, int channel)
 
   HAL_Report(HALUsageReporting::kResourceType_Solenoid, m_channel + 1,
              m_module->GetModuleNumber() + 1);
-  SendableRegistry::GetInstance().AddLW(this, "Solenoid",
-                                        m_module->GetModuleNumber(), m_channel);
+  wpi::SendableRegistry::GetInstance().AddLW(
+      this, "Solenoid", m_module->GetModuleNumber(), m_channel);
 }
 
 Solenoid::~Solenoid() {}
@@ -72,7 +72,7 @@ void Solenoid::StartPulse() {
   m_module->FireOneShot(m_channel);
 }
 
-void Solenoid::InitSendable(SendableBuilder& builder) {
+void Solenoid::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Solenoid");
   builder.SetActuator(true);
   builder.SetSafeState([=] { Set(false); });

--- a/wpilibc/src/main/native/cpp/SpeedControllerGroup.cpp
+++ b/wpilibc/src/main/native/cpp/SpeedControllerGroup.cpp
@@ -4,8 +4,8 @@
 
 #include "frc/SpeedControllerGroup.h"
 
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 using namespace frc;
 
@@ -20,11 +20,12 @@ SpeedControllerGroup::SpeedControllerGroup(
 
 void SpeedControllerGroup::Initialize() {
   for (auto& speedController : m_speedControllers) {
-    SendableRegistry::GetInstance().AddChild(this, &speedController.get());
+    wpi::SendableRegistry::GetInstance().AddChild(this, &speedController.get());
   }
   static int instances = 0;
   ++instances;
-  SendableRegistry::GetInstance().Add(this, "SpeedControllerGroup", instances);
+  wpi::SendableRegistry::GetInstance().Add(this, "SpeedControllerGroup",
+                                           instances);
 }
 
 void SpeedControllerGroup::Set(double speed) {
@@ -60,7 +61,7 @@ void SpeedControllerGroup::StopMotor() {
   }
 }
 
-void SpeedControllerGroup::InitSendable(SendableBuilder& builder) {
+void SpeedControllerGroup::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Speed Controller");
   builder.SetActuator(true);
   builder.SetSafeState([=] { StopMotor(); });

--- a/wpilibc/src/main/native/cpp/Ultrasonic.cpp
+++ b/wpilibc/src/main/native/cpp/Ultrasonic.cpp
@@ -8,14 +8,14 @@
 
 #include <hal/FRCUsageReporting.h>
 #include <wpi/NullDeleter.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Counter.h"
 #include "frc/DigitalInput.h"
 #include "frc/DigitalOutput.h"
 #include "frc/Errors.h"
 #include "frc/Timer.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -30,7 +30,7 @@ Ultrasonic::Ultrasonic(int pingChannel, int echoChannel)
       m_echoChannel(std::make_shared<DigitalInput>(echoChannel)),
       m_counter(m_echoChannel) {
   Initialize();
-  auto& registry = SendableRegistry::GetInstance();
+  auto& registry = wpi::SendableRegistry::GetInstance();
   registry.AddChild(this, m_pingChannel.get());
   registry.AddChild(this, m_echoChannel.get());
 }
@@ -156,7 +156,7 @@ void Ultrasonic::SetEnabled(bool enable) {
   m_enabled = enable;
 }
 
-void Ultrasonic::InitSendable(SendableBuilder& builder) {
+void Ultrasonic::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Ultrasonic");
   builder.AddDoubleProperty(
       "Value", [=] { return units::inch_t{GetRange()}.to<double>(); }, nullptr);
@@ -185,8 +185,8 @@ void Ultrasonic::Initialize() {
   static int instances = 0;
   instances++;
   HAL_Report(HALUsageReporting::kResourceType_Ultrasonic, instances);
-  SendableRegistry::GetInstance().AddLW(this, "Ultrasonic",
-                                        m_echoChannel->GetChannel());
+  wpi::SendableRegistry::GetInstance().AddLW(this, "Ultrasonic",
+                                             m_echoChannel->GetChannel());
 }
 
 void Ultrasonic::UltrasonicChecker() {

--- a/wpilibc/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpilibc/src/main/native/cpp/controller/PIDController.cpp
@@ -8,11 +8,11 @@
 #include <cmath>
 
 #include <hal/FRCUsageReporting.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/Errors.h"
 #include "frc/MathUtil.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc2;
 
@@ -31,7 +31,7 @@ PIDController::PIDController(double Kp, double Ki, double Kd,
   static int instances = 0;
   instances++;
   HAL_Report(HALUsageReporting::kResourceType_PIDController2, instances);
-  frc::SendableRegistry::GetInstance().Add(this, "PIDController", instances);
+  wpi::SendableRegistry::GetInstance().Add(this, "PIDController", instances);
 }
 
 void PIDController::SetPID(double Kp, double Ki, double Kd) {
@@ -161,7 +161,7 @@ void PIDController::Reset() {
   m_totalError = 0;
 }
 
-void PIDController::InitSendable(frc::SendableBuilder& builder) {
+void PIDController::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("PIDController");
   builder.AddDoubleProperty(
       "p", [this] { return GetP(); }, [this](double value) { SetP(value); });

--- a/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/DifferentialDrive.cpp
@@ -8,10 +8,10 @@
 #include <cmath>
 
 #include <hal/FRCUsageReporting.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/SpeedController.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -26,7 +26,7 @@ using namespace frc;
 DifferentialDrive::DifferentialDrive(SpeedController& leftMotor,
                                      SpeedController& rightMotor)
     : m_leftMotor(&leftMotor), m_rightMotor(&rightMotor) {
-  auto& registry = SendableRegistry::GetInstance();
+  auto& registry = wpi::SendableRegistry::GetInstance();
   registry.AddChild(this, m_leftMotor);
   registry.AddChild(this, m_rightMotor);
   static int instances = 0;
@@ -193,7 +193,7 @@ std::string DifferentialDrive::GetDescription() const {
   return "DifferentialDrive";
 }
 
-void DifferentialDrive::InitSendable(SendableBuilder& builder) {
+void DifferentialDrive::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("DifferentialDrive");
   builder.SetActuator(true);
   builder.SetSafeState([=] { StopMotor(); });

--- a/wpilibc/src/main/native/cpp/drive/KilloughDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/KilloughDrive.cpp
@@ -9,10 +9,10 @@
 
 #include <hal/FRCUsageReporting.h>
 #include <wpi/numbers>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/SpeedController.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -43,7 +43,7 @@ KilloughDrive::KilloughDrive(SpeedController& leftMotor,
                 std::sin(rightMotorAngle * (wpi::numbers::pi / 180.0))};
   m_backVec = {std::cos(backMotorAngle * (wpi::numbers::pi / 180.0)),
                std::sin(backMotorAngle * (wpi::numbers::pi / 180.0))};
-  auto& registry = SendableRegistry::GetInstance();
+  auto& registry = wpi::SendableRegistry::GetInstance();
   registry.AddChild(this, m_leftMotor);
   registry.AddChild(this, m_rightMotor);
   registry.AddChild(this, m_backMotor);
@@ -118,7 +118,7 @@ std::string KilloughDrive::GetDescription() const {
   return "KilloughDrive";
 }
 
-void KilloughDrive::InitSendable(SendableBuilder& builder) {
+void KilloughDrive::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("KilloughDrive");
   builder.SetActuator(true);
   builder.SetSafeState([=] { StopMotor(); });

--- a/wpilibc/src/main/native/cpp/drive/MecanumDrive.cpp
+++ b/wpilibc/src/main/native/cpp/drive/MecanumDrive.cpp
@@ -9,11 +9,11 @@
 
 #include <hal/FRCUsageReporting.h>
 #include <wpi/numbers>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/SpeedController.h"
 #include "frc/drive/Vector2d.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -33,7 +33,7 @@ MecanumDrive::MecanumDrive(SpeedController& frontLeftMotor,
       m_rearLeftMotor(&rearLeftMotor),
       m_frontRightMotor(&frontRightMotor),
       m_rearRightMotor(&rearRightMotor) {
-  auto& registry = SendableRegistry::GetInstance();
+  auto& registry = wpi::SendableRegistry::GetInstance();
   registry.AddChild(this, m_frontLeftMotor);
   registry.AddChild(this, m_rearLeftMotor);
   registry.AddChild(this, m_frontRightMotor);
@@ -113,7 +113,7 @@ std::string MecanumDrive::GetDescription() const {
   return "MecanumDrive";
 }
 
-void MecanumDrive::InitSendable(SendableBuilder& builder) {
+void MecanumDrive::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("MecanumDrive");
   builder.SetActuator(true);
   builder.SetSafeState([=] { StopMotor(); });

--- a/wpilibc/src/main/native/cpp/motorcontrol/MotorControllerGroup.cpp
+++ b/wpilibc/src/main/native/cpp/motorcontrol/MotorControllerGroup.cpp
@@ -4,8 +4,8 @@
 
 #include "frc/motorcontrol/MotorControllerGroup.h"
 
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 using namespace frc;
 
@@ -20,11 +20,12 @@ MotorControllerGroup::MotorControllerGroup(
 
 void MotorControllerGroup::Initialize() {
   for (auto& motorController : m_motorControllers) {
-    SendableRegistry::GetInstance().AddChild(this, &motorController.get());
+    wpi::SendableRegistry::GetInstance().AddChild(this, &motorController.get());
   }
   static int instances = 0;
   ++instances;
-  SendableRegistry::GetInstance().Add(this, "MotorControllerGroup", instances);
+  wpi::SendableRegistry::GetInstance().Add(this, "MotorControllerGroup",
+                                           instances);
 }
 
 void MotorControllerGroup::Set(double speed) {
@@ -60,7 +61,7 @@ void MotorControllerGroup::StopMotor() {
   }
 }
 
-void MotorControllerGroup::InitSendable(SendableBuilder& builder) {
+void MotorControllerGroup::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Motor Controller");
   builder.SetActuator(true);
   builder.SetSafeState([=] { StopMotor(); });

--- a/wpilibc/src/main/native/cpp/motorcontrol/NidecBrushless.cpp
+++ b/wpilibc/src/main/native/cpp/motorcontrol/NidecBrushless.cpp
@@ -6,15 +6,14 @@
 
 #include <fmt/format.h>
 #include <hal/FRCUsageReporting.h>
-
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 using namespace frc;
 
 NidecBrushless::NidecBrushless(int pwmChannel, int dioChannel)
     : m_dio(dioChannel), m_pwm(pwmChannel) {
-  auto& registry = SendableRegistry::GetInstance();
+  auto& registry = wpi::SendableRegistry::GetInstance();
   registry.AddChild(this, &m_dio);
   registry.AddChild(this, &m_pwm);
   SetExpiration(0_s);
@@ -72,7 +71,7 @@ int NidecBrushless::GetChannel() const {
   return m_pwm.GetChannel();
 }
 
-void NidecBrushless::InitSendable(SendableBuilder& builder) {
+void NidecBrushless::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Nidec Brushless");
   builder.SetActuator(true);
   builder.SetSafeState([=] { StopMotor(); });

--- a/wpilibc/src/main/native/cpp/motorcontrol/PWMMotorController.cpp
+++ b/wpilibc/src/main/native/cpp/motorcontrol/PWMMotorController.cpp
@@ -5,8 +5,8 @@
 #include "frc/motorcontrol/PWMMotorController.h"
 
 #include <fmt/format.h>
-
-#include "frc/smartdashboard/SendableBuilder.h"
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 using namespace frc;
 
@@ -44,10 +44,10 @@ int PWMMotorController::GetChannel() const {
 
 PWMMotorController::PWMMotorController(std::string_view name, int channel)
     : m_pwm(channel, false) {
-  SendableRegistry::GetInstance().AddLW(this, name, channel);
+  wpi::SendableRegistry::GetInstance().AddLW(this, name, channel);
 }
 
-void PWMMotorController::InitSendable(SendableBuilder& builder) {
+void PWMMotorController::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Motor Controller");
   builder.SetActuator(true);
   builder.SetSafeState([=] { Disable(); });

--- a/wpilibc/src/main/native/cpp/motorcontrol/PWMSparkMax.cpp
+++ b/wpilibc/src/main/native/cpp/motorcontrol/PWMSparkMax.cpp
@@ -6,8 +6,6 @@
 
 #include <hal/FRCUsageReporting.h>
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
 using namespace frc;
 
 PWMSparkMax::PWMSparkMax(int channel)

--- a/wpilibc/src/main/native/cpp/shuffleboard/SendableCameraWrapper.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/SendableCameraWrapper.cpp
@@ -9,9 +9,8 @@
 #include <string>
 
 #include <wpi/DenseMap.h>
-
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 namespace frc {
 namespace detail {
@@ -21,12 +20,12 @@ std::shared_ptr<SendableCameraWrapper>& GetSendableCameraWrapper(
   return wrappers[static_cast<int>(source)];
 }
 
-void AddToSendableRegistry(frc::Sendable* sendable, std::string name) {
-  SendableRegistry::GetInstance().Add(sendable, name);
+void AddToSendableRegistry(wpi::Sendable* sendable, std::string name) {
+  wpi::SendableRegistry::GetInstance().Add(sendable, name);
 }
 }  // namespace detail
 
-void SendableCameraWrapper::InitSendable(SendableBuilder& builder) {
+void SendableCameraWrapper::InitSendable(wpi::SendableBuilder& builder) {
   builder.AddStringProperty(
       ".ShuffleboardURI", [this] { return m_uri; }, nullptr);
 }

--- a/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardContainer.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardContainer.cpp
@@ -4,12 +4,13 @@
 
 #include "frc/shuffleboard/ShuffleboardContainer.h"
 
+#include <wpi/sendable/SendableRegistry.h>
+
 #include "frc/Errors.h"
 #include "frc/shuffleboard/ComplexWidget.h"
 #include "frc/shuffleboard/ShuffleboardComponent.h"
 #include "frc/shuffleboard/ShuffleboardLayout.h"
 #include "frc/shuffleboard/SimpleWidget.h"
-#include "frc/smartdashboard/SendableRegistry.h"
 
 using namespace frc;
 
@@ -57,7 +58,7 @@ ShuffleboardLayout& ShuffleboardContainer::GetLayout(std::string_view title) {
 }
 
 ComplexWidget& ShuffleboardContainer::Add(std::string_view title,
-                                          Sendable& sendable) {
+                                          wpi::Sendable& sendable) {
   CheckTitle(title);
   auto widget = std::make_unique<ComplexWidget>(*this, title, sendable);
   auto ptr = widget.get();
@@ -65,8 +66,8 @@ ComplexWidget& ShuffleboardContainer::Add(std::string_view title,
   return *ptr;
 }
 
-ComplexWidget& ShuffleboardContainer::Add(Sendable& sendable) {
-  auto name = SendableRegistry::GetInstance().GetName(&sendable);
+ComplexWidget& ShuffleboardContainer::Add(wpi::Sendable& sendable) {
+  auto name = wpi::SendableRegistry::GetInstance().GetName(&sendable);
   if (name.empty()) {
     FRC_ReportError(err::Error, "{}", "Sendable must have a name");
   }

--- a/wpilibc/src/main/native/cpp/smartdashboard/Field2d.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/Field2d.cpp
@@ -4,8 +4,8 @@
 
 #include "frc/smartdashboard/Field2d.h"
 
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableRegistry.h"
+#include <networktables/NTSendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 using namespace frc;
 
@@ -13,7 +13,7 @@ Field2d::Field2d() {
   m_objects.emplace_back(
       std::make_unique<FieldObject2d>("Robot", FieldObject2d::private_init{}));
   m_objects[0]->SetPose(Pose2d{});
-  SendableRegistry::GetInstance().Add(this, "Field");
+  wpi::SendableRegistry::GetInstance().Add(this, "Field");
 }
 
 Field2d::Field2d(Field2d&& rhs) : SendableHelper(std::move(rhs)) {
@@ -67,7 +67,7 @@ FieldObject2d* Field2d::GetRobotObject() {
   return m_objects[0].get();
 }
 
-void Field2d::InitSendable(SendableBuilder& builder) {
+void Field2d::InitSendable(nt::NTSendableBuilder& builder) {
   builder.SetSmartDashboardType("Field2d");
   m_table = builder.GetTable();
 

--- a/wpilibc/src/main/native/cpp/smartdashboard/Mechanism2d.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/Mechanism2d.cpp
@@ -6,7 +6,7 @@
 
 #include <cstdio>
 
-#include "frc/smartdashboard/SendableBuilder.h"
+#include <networktables/NTSendableBuilder.h>
 
 using namespace frc;
 
@@ -41,7 +41,7 @@ void Mechanism2d::SetBackgroundColor(const Color8Bit& color) {
   }
 }
 
-void Mechanism2d::InitSendable(SendableBuilder& builder) {
+void Mechanism2d::InitSendable(nt::NTSendableBuilder& builder) {
   builder.SetSmartDashboardType("Mechanism2d");
   m_table = builder.GetTable();
 

--- a/wpilibc/src/main/native/cpp/smartdashboard/MechanismRoot2d.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/MechanismRoot2d.cpp
@@ -4,8 +4,6 @@
 
 #include "frc/smartdashboard/MechanismRoot2d.h"
 
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 #include "frc/util/Color8Bit.h"
 
 using namespace frc;

--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
@@ -20,7 +20,7 @@ std::shared_ptr<nt::NetworkTable> SendableBuilderImpl::GetTable() {
   return m_table;
 }
 
-bool SendableBuilderImpl::HasTable() const {
+bool SendableBuilderImpl::IsPublished() const {
   return m_table != nullptr;
 }
 
@@ -28,7 +28,7 @@ bool SendableBuilderImpl::IsActuator() const {
   return m_actuator;
 }
 
-void SendableBuilderImpl::UpdateTable() {
+void SendableBuilderImpl::Update() {
   uint64_t time = nt::Now();
   for (auto& property : m_properties) {
     if (property.update) {

--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableChooserBase.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableChooserBase.cpp
@@ -4,14 +4,14 @@
 
 #include "frc/smartdashboard/SendableChooserBase.h"
 
-#include "frc/smartdashboard/SendableRegistry.h"
+#include <wpi/sendable/SendableRegistry.h>
 
 using namespace frc;
 
 std::atomic_int SendableChooserBase::s_instances{0};
 
 SendableChooserBase::SendableChooserBase() : m_instance{s_instances++} {
-  SendableRegistry::GetInstance().Add(this, "SendableChooser", m_instance);
+  wpi::SendableRegistry::GetInstance().Add(this, "SendableChooser", m_instance);
 }
 
 SendableChooserBase::SendableChooserBase(SendableChooserBase&& oth)

--- a/wpilibc/src/main/native/include/frc/ADXL345_I2C.h
+++ b/wpilibc/src/main/native/include/frc/ADXL345_I2C.h
@@ -5,15 +5,13 @@
 #pragma once
 
 #include <hal/SimDevice.h>
+#include <networktables/NTSendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/I2C.h"
 #include "frc/interfaces/Accelerometer.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
-
-class SendableBuilder;
 
 /**
  * ADXL345 Accelerometer on I2C.
@@ -23,8 +21,8 @@ class SendableBuilder;
  * 0x1D (7-bit address).
  */
 class ADXL345_I2C : public Accelerometer,
-                    public Sendable,
-                    public SendableHelper<ADXL345_I2C> {
+                    public nt::NTSendable,
+                    public wpi::SendableHelper<ADXL345_I2C> {
  public:
   enum Axes { kAxis_X = 0x00, kAxis_Y = 0x02, kAxis_Z = 0x04 };
 
@@ -70,7 +68,7 @@ class ADXL345_I2C : public Accelerometer,
    */
   virtual AllAxes GetAccelerations();
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(nt::NTSendableBuilder& builder) override;
 
  protected:
   I2C m_i2c;

--- a/wpilibc/src/main/native/include/frc/ADXL345_SPI.h
+++ b/wpilibc/src/main/native/include/frc/ADXL345_SPI.h
@@ -5,11 +5,11 @@
 #pragma once
 
 #include <hal/SimDevice.h>
+#include <networktables/NTSendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/SPI.h"
 #include "frc/interfaces/Accelerometer.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
@@ -20,8 +20,8 @@ namespace frc {
  * via SPI. This class assumes the sensor is wired in 4-wire SPI mode.
  */
 class ADXL345_SPI : public Accelerometer,
-                    public Sendable,
-                    public SendableHelper<ADXL345_SPI> {
+                    public nt::NTSendable,
+                    public wpi::SendableHelper<ADXL345_SPI> {
  public:
   enum Axes { kAxis_X = 0x00, kAxis_Y = 0x02, kAxis_Z = 0x04 };
 
@@ -66,7 +66,7 @@ class ADXL345_SPI : public Accelerometer,
    */
   virtual AllAxes GetAccelerations();
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(nt::NTSendableBuilder& builder) override;
 
  protected:
   SPI m_spi;

--- a/wpilibc/src/main/native/include/frc/ADXL362.h
+++ b/wpilibc/src/main/native/include/frc/ADXL362.h
@@ -5,15 +5,13 @@
 #pragma once
 
 #include <hal/SimDevice.h>
+#include <networktables/NTSendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/SPI.h"
 #include "frc/interfaces/Accelerometer.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
-
-class SendableBuilder;
 
 /**
  * ADXL362 SPI Accelerometer.
@@ -21,8 +19,8 @@ class SendableBuilder;
  * This class allows access to an Analog Devices ADXL362 3-axis accelerometer.
  */
 class ADXL362 : public Accelerometer,
-                public Sendable,
-                public SendableHelper<ADXL362> {
+                public nt::NTSendable,
+                public wpi::SendableHelper<ADXL362> {
  public:
   enum Axes { kAxis_X = 0x00, kAxis_Y = 0x02, kAxis_Z = 0x04 };
   struct AllAxes {
@@ -74,7 +72,7 @@ class ADXL362 : public Accelerometer,
    */
   virtual AllAxes GetAccelerations();
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(nt::NTSendableBuilder& builder) override;
 
  private:
   SPI m_spi;

--- a/wpilibc/src/main/native/include/frc/ADXRS450_Gyro.h
+++ b/wpilibc/src/main/native/include/frc/ADXRS450_Gyro.h
@@ -7,11 +7,11 @@
 #include <stdint.h>
 
 #include <hal/SimDevice.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/SPI.h"
 #include "frc/interfaces/Gyro.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
@@ -29,8 +29,8 @@ namespace frc {
  * Only one instance of an ADXRS Gyro is supported.
  */
 class ADXRS450_Gyro : public Gyro,
-                      public Sendable,
-                      public SendableHelper<ADXRS450_Gyro> {
+                      public wpi::Sendable,
+                      public wpi::SendableHelper<ADXRS450_Gyro> {
  public:
   /**
    * Gyro constructor on onboard CS0.
@@ -100,7 +100,7 @@ class ADXRS450_Gyro : public Gyro,
    */
   int GetPort() const;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   SPI m_spi;

--- a/wpilibc/src/main/native/include/frc/AnalogAccelerometer.h
+++ b/wpilibc/src/main/native/include/frc/AnalogAccelerometer.h
@@ -6,13 +6,12 @@
 
 #include <memory>
 
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
+
 #include "frc/AnalogInput.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
-
-class SendableBuilder;
 
 /**
  * Handle operation of an analog accelerometer.
@@ -21,8 +20,8 @@ class SendableBuilder;
  * sensors have multiple axis and can be treated as multiple devices. Each is
  * calibrated by finding the center value over a period of time.
  */
-class AnalogAccelerometer : public Sendable,
-                            public SendableHelper<AnalogAccelerometer> {
+class AnalogAccelerometer : public wpi::Sendable,
+                            public wpi::SendableHelper<AnalogAccelerometer> {
  public:
   /**
    * Create a new instance of an accelerometer.
@@ -93,7 +92,7 @@ class AnalogAccelerometer : public Sendable,
    */
   void SetZero(double zero);
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   /**

--- a/wpilibc/src/main/native/include/frc/AnalogEncoder.h
+++ b/wpilibc/src/main/native/include/frc/AnalogEncoder.h
@@ -9,11 +9,11 @@
 #include <hal/SimDevice.h>
 #include <hal/Types.h>
 #include <units/angle.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/AnalogTrigger.h"
 #include "frc/Counter.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 class AnalogInput;
@@ -21,7 +21,8 @@ class AnalogInput;
 /**
  * Class for supporting continuous analog encoders, such as the US Digital MA3.
  */
-class AnalogEncoder : public Sendable, public SendableHelper<AnalogEncoder> {
+class AnalogEncoder : public wpi::Sendable,
+                      public wpi::SendableHelper<AnalogEncoder> {
  public:
   /**
    * Construct a new AnalogEncoder attached to a specific AnalogIn channel.
@@ -116,7 +117,7 @@ class AnalogEncoder : public Sendable, public SendableHelper<AnalogEncoder> {
    */
   int GetChannel() const;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   void Init();

--- a/wpilibc/src/main/native/include/frc/AnalogGyro.h
+++ b/wpilibc/src/main/native/include/frc/AnalogGyro.h
@@ -7,10 +7,10 @@
 #include <memory>
 
 #include <hal/Types.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/interfaces/Gyro.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
@@ -30,8 +30,8 @@ class AnalogInput;
  * This class is for gyro sensors that connect to an analog input.
  */
 class AnalogGyro : public Gyro,
-                   public Sendable,
-                   public SendableHelper<AnalogGyro> {
+                   public wpi::Sendable,
+                   public wpi::SendableHelper<AnalogGyro> {
  public:
   static constexpr int kOversampleBits = 10;
   static constexpr int kAverageBits = 0;
@@ -192,7 +192,7 @@ class AnalogGyro : public Gyro,
    */
   std::shared_ptr<AnalogInput> GetAnalogInput() const;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  protected:
   std::shared_ptr<AnalogInput> m_analog;

--- a/wpilibc/src/main/native/include/frc/AnalogInput.h
+++ b/wpilibc/src/main/native/include/frc/AnalogInput.h
@@ -7,13 +7,11 @@
 #include <stdint.h>
 
 #include <hal/Types.h>
-
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 namespace frc {
 
-class SendableBuilder;
 class DMA;
 class DMASample;
 
@@ -29,7 +27,8 @@ class DMASample;
  * are divided by the number of samples to retain the resolution, but get more
  * stable values.
  */
-class AnalogInput : public Sendable, public SendableHelper<AnalogInput> {
+class AnalogInput : public wpi::Sendable,
+                    public wpi::SendableHelper<AnalogInput> {
   friend class AnalogTrigger;
   friend class AnalogGyro;
   friend class DMA;
@@ -282,7 +281,7 @@ class AnalogInput : public Sendable, public SendableHelper<AnalogInput> {
    */
   void SetSimDevice(HAL_SimDeviceHandle device);
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   int m_channel;

--- a/wpilibc/src/main/native/include/frc/AnalogOutput.h
+++ b/wpilibc/src/main/native/include/frc/AnalogOutput.h
@@ -5,18 +5,16 @@
 #pragma once
 
 #include <hal/Types.h>
-
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 namespace frc {
-
-class SendableBuilder;
 
 /**
  * MXP analog output class.
  */
-class AnalogOutput : public Sendable, public SendableHelper<AnalogOutput> {
+class AnalogOutput : public wpi::Sendable,
+                     public wpi::SendableHelper<AnalogOutput> {
  public:
   /**
    * Construct an analog output on the given channel.
@@ -51,7 +49,7 @@ class AnalogOutput : public Sendable, public SendableHelper<AnalogOutput> {
    */
   int GetChannel() const;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  protected:
   int m_channel;

--- a/wpilibc/src/main/native/include/frc/AnalogPotentiometer.h
+++ b/wpilibc/src/main/native/include/frc/AnalogPotentiometer.h
@@ -6,13 +6,12 @@
 
 #include <memory>
 
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
+
 #include "frc/AnalogInput.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
-
-class SendableBuilder;
 
 /**
  * Class for reading analog potentiometers. Analog potentiometers read in an
@@ -20,8 +19,8 @@ class SendableBuilder;
  * units you choose, by way of the scaling and offset constants passed to the
  * constructor.
  */
-class AnalogPotentiometer : public Sendable,
-                            public SendableHelper<AnalogPotentiometer> {
+class AnalogPotentiometer : public wpi::Sendable,
+                            public wpi::SendableHelper<AnalogPotentiometer> {
  public:
   /**
    * Construct an Analog Potentiometer object from a channel number.
@@ -103,7 +102,7 @@ class AnalogPotentiometer : public Sendable,
    */
   double Get() const;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   std::shared_ptr<AnalogInput> m_analog_input;

--- a/wpilibc/src/main/native/include/frc/AnalogTrigger.h
+++ b/wpilibc/src/main/native/include/frc/AnalogTrigger.h
@@ -7,18 +7,18 @@
 #include <memory>
 
 #include <hal/Types.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/AnalogTriggerOutput.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
 class AnalogInput;
 class DutyCycle;
-class SendableBuilder;
 
-class AnalogTrigger : public Sendable, public SendableHelper<AnalogTrigger> {
+class AnalogTrigger : public wpi::Sendable,
+                      public wpi::SendableHelper<AnalogTrigger> {
   friend class AnalogTriggerOutput;
 
  public:
@@ -148,7 +148,7 @@ class AnalogTrigger : public Sendable, public SendableHelper<AnalogTrigger> {
   std::shared_ptr<AnalogTriggerOutput> CreateOutput(
       AnalogTriggerType type) const;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   int GetSourceChannel() const;

--- a/wpilibc/src/main/native/include/frc/AnalogTriggerOutput.h
+++ b/wpilibc/src/main/native/include/frc/AnalogTriggerOutput.h
@@ -4,9 +4,10 @@
 
 #pragma once
 
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
+
 #include "frc/DigitalSource.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
@@ -44,8 +45,8 @@ class AnalogTrigger;
  * may help with this, but rotational speeds of the sensor will then be limited.
  */
 class AnalogTriggerOutput : public DigitalSource,
-                            public Sendable,
-                            public SendableHelper<AnalogTriggerOutput> {
+                            public wpi::Sendable,
+                            public wpi::SendableHelper<AnalogTriggerOutput> {
   friend class AnalogTrigger;
 
  public:
@@ -77,7 +78,7 @@ class AnalogTriggerOutput : public DigitalSource,
    */
   int GetChannel() const override;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  protected:
   /**

--- a/wpilibc/src/main/native/include/frc/BuiltInAccelerometer.h
+++ b/wpilibc/src/main/native/include/frc/BuiltInAccelerometer.h
@@ -4,13 +4,12 @@
 
 #pragma once
 
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
+
 #include "frc/interfaces/Accelerometer.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
-
-class SendableBuilder;
 
 /**
  * Built-in accelerometer.
@@ -18,8 +17,8 @@ class SendableBuilder;
  * This class allows access to the roboRIO's internal accelerometer.
  */
 class BuiltInAccelerometer : public Accelerometer,
-                             public Sendable,
-                             public SendableHelper<BuiltInAccelerometer> {
+                             public wpi::Sendable,
+                             public wpi::SendableHelper<BuiltInAccelerometer> {
  public:
   /**
    * Constructor.
@@ -56,7 +55,7 @@ class BuiltInAccelerometer : public Accelerometer,
    */
   double GetZ() override;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/Counter.h
+++ b/wpilibc/src/main/native/include/frc/Counter.h
@@ -8,16 +8,15 @@
 
 #include <hal/Types.h>
 #include <units/time.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/AnalogTrigger.h"
 #include "frc/CounterBase.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
 class DigitalGlitchFilter;
-class SendableBuilder;
 class DMA;
 class DMASample;
 
@@ -32,8 +31,8 @@ class DMASample;
  * to be zeroed before use.
  */
 class Counter : public CounterBase,
-                public Sendable,
-                public SendableHelper<Counter> {
+                public wpi::Sendable,
+                public wpi::SendableHelper<Counter> {
   friend class DMA;
   friend class DMASample;
 
@@ -421,7 +420,7 @@ class Counter : public CounterBase,
    */
   bool GetDirection() const override;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  protected:
   // Makes the counter count up.

--- a/wpilibc/src/main/native/include/frc/DigitalGlitchFilter.h
+++ b/wpilibc/src/main/native/include/frc/DigitalGlitchFilter.h
@@ -9,10 +9,10 @@
 #include <array>
 
 #include <wpi/mutex.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/DigitalSource.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
@@ -26,8 +26,8 @@ class Counter;
  * filter. The filter lets the user configure the time that an input must remain
  * high or low before it is classified as high or low.
  */
-class DigitalGlitchFilter : public Sendable,
-                            public SendableHelper<DigitalGlitchFilter> {
+class DigitalGlitchFilter : public wpi::Sendable,
+                            public wpi::SendableHelper<DigitalGlitchFilter> {
  public:
   DigitalGlitchFilter();
   ~DigitalGlitchFilter() override;
@@ -114,7 +114,7 @@ class DigitalGlitchFilter : public Sendable,
    */
   uint64_t GetPeriodNanoSeconds();
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   // Sets the filter for the input to be the requested index. A value of 0

--- a/wpilibc/src/main/native/include/frc/DigitalInput.h
+++ b/wpilibc/src/main/native/include/frc/DigitalInput.h
@@ -4,14 +4,14 @@
 
 #pragma once
 
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
+
 #include "frc/DigitalSource.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
 class DigitalGlitchFilter;
-class SendableBuilder;
 
 /**
  * Class to read a digital input.
@@ -23,8 +23,8 @@ class SendableBuilder;
  * implemented anywhere else.
  */
 class DigitalInput : public DigitalSource,
-                     public Sendable,
-                     public SendableHelper<DigitalInput> {
+                     public wpi::Sendable,
+                     public wpi::SendableHelper<DigitalInput> {
  public:
   /**
    * Create an instance of a Digital Input class.
@@ -75,7 +75,7 @@ class DigitalInput : public DigitalSource,
    */
   void SetSimDevice(HAL_SimDeviceHandle device);
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   int m_channel;

--- a/wpilibc/src/main/native/include/frc/DigitalOutput.h
+++ b/wpilibc/src/main/native/include/frc/DigitalOutput.h
@@ -5,14 +5,12 @@
 #pragma once
 
 #include <hal/Types.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/DigitalSource.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
-
-class SendableBuilder;
 
 /**
  * Class to write to digital outputs.
@@ -22,8 +20,8 @@ class SendableBuilder;
  * shouldn't be done here.
  */
 class DigitalOutput : public DigitalSource,
-                      public Sendable,
-                      public SendableHelper<DigitalOutput> {
+                      public wpi::Sendable,
+                      public wpi::SendableHelper<DigitalOutput> {
  public:
   /**
    * Create an instance of a digital output.
@@ -145,7 +143,7 @@ class DigitalOutput : public DigitalSource,
    */
   void SetSimDevice(HAL_SimDeviceHandle device);
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   int m_channel;

--- a/wpilibc/src/main/native/include/frc/DoubleSolenoid.h
+++ b/wpilibc/src/main/native/include/frc/DoubleSolenoid.h
@@ -7,14 +7,12 @@
 #include <memory>
 
 #include <hal/Types.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/PneumaticsBase.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
-
-class SendableBuilder;
 
 /**
  * DoubleSolenoid class for running 2 channels of high voltage Digital Output
@@ -23,7 +21,8 @@ class SendableBuilder;
  * The DoubleSolenoid class is typically used for pneumatics solenoids that
  * have two positions controlled by two separate channels.
  */
-class DoubleSolenoid : public Sendable, public SendableHelper<DoubleSolenoid> {
+class DoubleSolenoid : public wpi::Sendable,
+                       public wpi::SendableHelper<DoubleSolenoid> {
  public:
   enum Value { kOff, kForward, kReverse };
 
@@ -98,7 +97,7 @@ class DoubleSolenoid : public Sendable, public SendableHelper<DoubleSolenoid> {
    */
   bool IsRevSolenoidDisabled() const;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   int m_forwardChannel;  // The forward channel on the module to control.

--- a/wpilibc/src/main/native/include/frc/DutyCycle.h
+++ b/wpilibc/src/main/native/include/frc/DutyCycle.h
@@ -7,9 +7,8 @@
 #include <memory>
 
 #include <hal/Types.h>
-
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 namespace frc {
 class DigitalSource;
@@ -28,7 +27,7 @@ class DMASample;
  * order to implement rollover checking.
  *
  */
-class DutyCycle : public Sendable, public SendableHelper<DutyCycle> {
+class DutyCycle : public wpi::Sendable, public wpi::SendableHelper<DutyCycle> {
   friend class AnalogTrigger;
   friend class DMA;
   friend class DMASample;
@@ -119,7 +118,7 @@ class DutyCycle : public Sendable, public SendableHelper<DutyCycle> {
   int GetSourceChannel() const;
 
  protected:
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   void InitDutyCycle();

--- a/wpilibc/src/main/native/include/frc/DutyCycleEncoder.h
+++ b/wpilibc/src/main/native/include/frc/DutyCycleEncoder.h
@@ -9,11 +9,11 @@
 #include <hal/SimDevice.h>
 #include <hal/Types.h>
 #include <units/angle.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/AnalogTrigger.h"
 #include "frc/Counter.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 class DutyCycle;
@@ -24,8 +24,8 @@ class DigitalSource;
  * PWM Output, the CTRE Mag Encoder, the Rev Hex Encoder, and the AM Mag
  * Encoder.
  */
-class DutyCycleEncoder : public Sendable,
-                         public SendableHelper<DutyCycleEncoder> {
+class DutyCycleEncoder : public wpi::Sendable,
+                         public wpi::SendableHelper<DutyCycleEncoder> {
  public:
   /**
    * Construct a new DutyCycleEncoder on a specific channel.
@@ -163,7 +163,7 @@ class DutyCycleEncoder : public Sendable,
    */
   int GetSourceChannel() const;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   void Init();

--- a/wpilibc/src/main/native/include/frc/Encoder.h
+++ b/wpilibc/src/main/native/include/frc/Encoder.h
@@ -7,17 +7,16 @@
 #include <memory>
 
 #include <hal/Types.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/Counter.h"
 #include "frc/CounterBase.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
 class DigitalSource;
 class DigitalGlitchFilter;
-class SendableBuilder;
 class DMA;
 class DMASample;
 
@@ -37,8 +36,8 @@ class DMASample;
  * to be zeroed before use.
  */
 class Encoder : public CounterBase,
-                public Sendable,
-                public SendableHelper<Encoder> {
+                public wpi::Sendable,
+                public wpi::SendableHelper<Encoder> {
   friend class DMA;
   friend class DMASample;
 
@@ -340,7 +339,7 @@ class Encoder : public CounterBase,
 
   int GetFPGAIndex() const;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   /**

--- a/wpilibc/src/main/native/include/frc/PWM.h
+++ b/wpilibc/src/main/native/include/frc/PWM.h
@@ -7,13 +7,11 @@
 #include <stdint.h>
 
 #include <hal/Types.h>
-
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 namespace frc {
 class AddressableLED;
-class SendableBuilder;
 
 /**
  * Class implements the PWM generation in the FPGA.
@@ -32,7 +30,7 @@ class SendableBuilder;
  *   - 1 = minimum pulse width (currently 0.5ms)
  *   - 0 = disabled (i.e. PWM output is held low)
  */
-class PWM : public Sendable, public SendableHelper<PWM> {
+class PWM : public wpi::Sendable, public wpi::SendableHelper<PWM> {
  public:
   friend class AddressableLED;
   /**
@@ -224,7 +222,7 @@ class PWM : public Sendable, public SendableHelper<PWM> {
   int GetChannel() const;
 
  protected:
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   int m_channel;

--- a/wpilibc/src/main/native/include/frc/PowerDistributionPanel.h
+++ b/wpilibc/src/main/native/include/frc/PowerDistributionPanel.h
@@ -5,20 +5,18 @@
 #pragma once
 
 #include <hal/Types.h>
-
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 namespace frc {
-
-class SendableBuilder;
 
 /**
  * Class for getting voltage, current, temperature, power and energy from the
  * CAN PDP.
  */
-class PowerDistributionPanel : public Sendable,
-                               public SendableHelper<PowerDistributionPanel> {
+class PowerDistributionPanel
+    : public wpi::Sendable,
+      public wpi::SendableHelper<PowerDistributionPanel> {
  public:
   /**
    * Constructs a PowerDistributionPanel.
@@ -96,7 +94,7 @@ class PowerDistributionPanel : public Sendable,
    */
   int GetModule() const;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   hal::Handle<HAL_PDPHandle> m_handle;

--- a/wpilibc/src/main/native/include/frc/Relay.h
+++ b/wpilibc/src/main/native/include/frc/Relay.h
@@ -8,14 +8,12 @@
 #include <string>
 
 #include <hal/Types.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/MotorSafety.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
-
-class SendableBuilder;
 
 /**
  * Class for Spike style relay outputs.
@@ -30,8 +28,8 @@ class SendableBuilder;
  * a solenoid).
  */
 class Relay : public MotorSafety,
-              public Sendable,
-              public SendableHelper<Relay> {
+              public wpi::Sendable,
+              public wpi::SendableHelper<Relay> {
  public:
   enum Value { kOff, kOn, kForward, kReverse };
   enum Direction { kBothDirections, kForwardOnly, kReverseOnly };
@@ -93,7 +91,7 @@ class Relay : public MotorSafety,
 
   std::string GetDescription() const override;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   int m_channel;

--- a/wpilibc/src/main/native/include/frc/Servo.h
+++ b/wpilibc/src/main/native/include/frc/Servo.h
@@ -92,7 +92,7 @@ class Servo : public PWM {
    */
   double GetMinAngle() const;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   double GetServoAngleRange() const;

--- a/wpilibc/src/main/native/include/frc/Solenoid.h
+++ b/wpilibc/src/main/native/include/frc/Solenoid.h
@@ -8,14 +8,12 @@
 
 #include <hal/Types.h>
 #include <units/time.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/PneumaticsBase.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
-
-class SendableBuilder;
 
 /**
  * Solenoid class for running high voltage Digital Output (PCM).
@@ -23,7 +21,7 @@ class SendableBuilder;
  * The Solenoid class is typically used for pneumatics solenoids, but could be
  * used for any device within the current spec of the PCM.
  */
-class Solenoid : public Sendable, public SendableHelper<Solenoid> {
+class Solenoid : public wpi::Sendable, public wpi::SendableHelper<Solenoid> {
  public:
   Solenoid(PneumaticsBase& module, int channel);
   Solenoid(PneumaticsBase* module, int channel);
@@ -93,7 +91,7 @@ class Solenoid : public Sendable, public SendableHelper<Solenoid> {
    */
   void StartPulse();
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   std::shared_ptr<PneumaticsBase> m_module;

--- a/wpilibc/src/main/native/include/frc/SpeedControllerGroup.h
+++ b/wpilibc/src/main/native/include/frc/SpeedControllerGroup.h
@@ -8,17 +8,17 @@
 #include <vector>
 
 #include <wpi/deprecated.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/motorcontrol/MotorController.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
 class WPI_DEPRECATED("use MotorControllerGroup") SpeedControllerGroup
-    : public Sendable,
+    : public wpi::Sendable,
       public MotorController,
-      public SendableHelper<SpeedControllerGroup> {
+      public wpi::SendableHelper<SpeedControllerGroup> {
  public:
   template <class... SpeedControllers>
   explicit SpeedControllerGroup(SpeedController& speedController,
@@ -36,7 +36,7 @@ class WPI_DEPRECATED("use MotorControllerGroup") SpeedControllerGroup
   void Disable() override;
   void StopMotor() override;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   bool m_isInverted = false;

--- a/wpilibc/src/main/native/include/frc/Ultrasonic.h
+++ b/wpilibc/src/main/native/include/frc/Ultrasonic.h
@@ -13,10 +13,10 @@
 #include <units/length.h>
 #include <units/time.h>
 #include <units/velocity.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/Counter.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
@@ -35,7 +35,8 @@ class DigitalOutput;
  * received. The time that the line is high determines the round trip distance
  * (time of flight).
  */
-class Ultrasonic : public Sendable, public SendableHelper<Ultrasonic> {
+class Ultrasonic : public wpi::Sendable,
+                   public wpi::SendableHelper<Ultrasonic> {
  public:
   /**
    * Create an instance of the Ultrasonic Sensor.
@@ -136,7 +137,7 @@ class Ultrasonic : public Sendable, public SendableHelper<Ultrasonic> {
 
   void SetEnabled(bool enable);
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   /**

--- a/wpilibc/src/main/native/include/frc/controller/PIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/PIDController.h
@@ -8,17 +8,16 @@
 #include <limits>
 
 #include <units/time.h>
-
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 namespace frc2 {
 
 /**
  * Implements a PID control loop.
  */
-class PIDController : public frc::Sendable,
-                      public frc::SendableHelper<PIDController> {
+class PIDController : public wpi::Sendable,
+                      public wpi::SendableHelper<PIDController> {
  public:
   /**
    * Allocates a PIDController with the given constants for Kp, Ki, and Kd.
@@ -193,7 +192,7 @@ class PIDController : public frc::Sendable,
    */
   void Reset();
 
-  void InitSendable(frc::SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   // Factor for "proportional" control

--- a/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpilibc/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -10,12 +10,12 @@
 #include <limits>
 
 #include <units/time.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/MathUtil.h"
 #include "frc/controller/PIDController.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableHelper.h"
 #include "frc/trajectory/TrapezoidProfile.h"
 
 namespace frc {
@@ -29,8 +29,8 @@ void ReportProfiledPIDController();
  */
 template <class Distance>
 class ProfiledPIDController
-    : public Sendable,
-      public SendableHelper<ProfiledPIDController<Distance>> {
+    : public wpi::Sendable,
+      public wpi::SendableHelper<ProfiledPIDController<Distance>> {
  public:
   using Distance_t = units::unit_t<Distance>;
   using Velocity =
@@ -340,7 +340,7 @@ class ProfiledPIDController
     Reset(measuredPosition, Velocity_t(0));
   }
 
-  void InitSendable(frc::SendableBuilder& builder) override {
+  void InitSendable(wpi::SendableBuilder& builder) override {
     builder.SetSmartDashboardType("ProfiledPIDController");
     builder.AddDoubleProperty(
         "p", [this] { return GetP(); }, [this](double value) { SetP(value); });

--- a/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
@@ -6,9 +6,10 @@
 
 #include <string>
 
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
+
 #include "frc/drive/RobotDriveBase.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
@@ -97,8 +98,8 @@ class SpeedController;
  * with SetDeadband().
  */
 class DifferentialDrive : public RobotDriveBase,
-                          public Sendable,
-                          public SendableHelper<DifferentialDrive> {
+                          public wpi::Sendable,
+                          public wpi::SendableHelper<DifferentialDrive> {
  public:
   struct WheelSpeeds {
     double left = 0.0;
@@ -208,7 +209,7 @@ class DifferentialDrive : public RobotDriveBase,
   void StopMotor() override;
   std::string GetDescription() const override;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   SpeedController* m_leftMotor;

--- a/wpilibc/src/main/native/include/frc/drive/KilloughDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/KilloughDrive.h
@@ -7,10 +7,11 @@
 #include <memory>
 #include <string>
 
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
+
 #include "frc/drive/RobotDriveBase.h"
 #include "frc/drive/Vector2d.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
@@ -54,8 +55,8 @@ class SpeedController;
  * clockwise rotation around the Z axis is positive.
  */
 class KilloughDrive : public RobotDriveBase,
-                      public Sendable,
-                      public SendableHelper<KilloughDrive> {
+                      public wpi::Sendable,
+                      public wpi::SendableHelper<KilloughDrive> {
  public:
   static constexpr double kDefaultLeftMotorAngle = 60.0;
   static constexpr double kDefaultRightMotorAngle = 120.0;
@@ -160,7 +161,7 @@ class KilloughDrive : public RobotDriveBase,
   void StopMotor() override;
   std::string GetDescription() const override;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   SpeedController* m_leftMotor;

--- a/wpilibc/src/main/native/include/frc/drive/MecanumDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/MecanumDrive.h
@@ -7,9 +7,10 @@
 #include <memory>
 #include <string>
 
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
+
 #include "frc/drive/RobotDriveBase.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
@@ -72,8 +73,8 @@ class SpeedController;
  * deadband of 0 is used.
  */
 class MecanumDrive : public RobotDriveBase,
-                     public Sendable,
-                     public SendableHelper<MecanumDrive> {
+                     public wpi::Sendable,
+                     public wpi::SendableHelper<MecanumDrive> {
  public:
   struct WheelSpeeds {
     double frontLeft = 0.0;
@@ -150,7 +151,7 @@ class MecanumDrive : public RobotDriveBase,
   void StopMotor() override;
   std::string GetDescription() const override;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   SpeedController* m_frontLeftMotor;

--- a/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
+++ b/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
@@ -7,9 +7,11 @@
 #include <functional>
 #include <memory>
 
-namespace frc {
-
+namespace wpi {
 class Sendable;
+}  // namespace wpi
+
+namespace frc {
 
 /**
  * The LiveWindow class is the public interface for putting sensors and
@@ -36,14 +38,14 @@ class LiveWindow {
    *
    * @param sendable component
    */
-  void EnableTelemetry(Sendable* component);
+  void EnableTelemetry(wpi::Sendable* component);
 
   /**
    * Disable telemetry for a single component.
    *
    * @param sendable component
    */
-  void DisableTelemetry(Sendable* component);
+  void DisableTelemetry(wpi::Sendable* component);
 
   /**
    * Disable ALL telemetry.

--- a/wpilibc/src/main/native/include/frc/motorcontrol/MotorControllerGroup.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/MotorControllerGroup.h
@@ -7,15 +7,16 @@
 #include <functional>
 #include <vector>
 
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
+
 #include "frc/motorcontrol/MotorController.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
-class MotorControllerGroup : public Sendable,
+class MotorControllerGroup : public wpi::Sendable,
                              public MotorController,
-                             public SendableHelper<MotorControllerGroup> {
+                             public wpi::SendableHelper<MotorControllerGroup> {
  public:
   template <class... MotorControllers>
   explicit MotorControllerGroup(MotorController& motorController,
@@ -33,7 +34,7 @@ class MotorControllerGroup : public Sendable,
   void Disable() override;
   void StopMotor() override;
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   bool m_isInverted = false;

--- a/wpilibc/src/main/native/include/frc/motorcontrol/NidecBrushless.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/NidecBrushless.h
@@ -6,24 +6,23 @@
 
 #include <string>
 
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
+
 #include "frc/DigitalOutput.h"
 #include "frc/MotorSafety.h"
 #include "frc/PWM.h"
 #include "frc/motorcontrol/MotorController.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
-
-class SendableBuilder;
 
 /**
  * Nidec Brushless Motor.
  */
 class NidecBrushless : public MotorController,
                        public MotorSafety,
-                       public Sendable,
-                       public SendableHelper<NidecBrushless> {
+                       public wpi::Sendable,
+                       public wpi::SendableHelper<NidecBrushless> {
  public:
   /**
    * Constructor.
@@ -86,7 +85,7 @@ class NidecBrushless : public MotorController,
   int GetChannel() const;
 
   // Sendable interface
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   bool m_isInverted = false;

--- a/wpilibc/src/main/native/include/frc/motorcontrol/PWMMotorController.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/PWMMotorController.h
@@ -7,11 +7,12 @@
 #include <string>
 #include <string_view>
 
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
+
 #include "frc/MotorSafety.h"
 #include "frc/PWM.h"
 #include "frc/motorcontrol/MotorController.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
@@ -20,8 +21,8 @@ namespace frc {
  */
 class PWMMotorController : public MotorController,
                            public MotorSafety,
-                           public Sendable,
-                           public SendableHelper<PWMMotorController> {
+                           public wpi::Sendable,
+                           public wpi::SendableHelper<PWMMotorController> {
  public:
   PWMMotorController(PWMMotorController&&) = default;
   PWMMotorController& operator=(PWMMotorController&&) = default;
@@ -67,7 +68,7 @@ class PWMMotorController : public MotorController,
    */
   PWMMotorController(std::string_view name, int channel);
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
   PWM m_pwm;
 

--- a/wpilibc/src/main/native/include/frc/shuffleboard/ComplexWidget.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ComplexWidget.h
@@ -10,12 +10,14 @@
 #include <networktables/NetworkTable.h>
 
 #include "frc/shuffleboard/ShuffleboardWidget.h"
-#include "frc/smartdashboard/SendableBuilder.h"
-#include "frc/smartdashboard/SendableBuilderImpl.h"
+
+namespace wpi {
+class Sendable;
+class SendableBuilder;
+}  // namespace wpi
 
 namespace frc {
 
-class Sendable;
 class ShuffleboardContainer;
 
 /**
@@ -25,7 +27,9 @@ class ShuffleboardContainer;
 class ComplexWidget final : public ShuffleboardWidget<ComplexWidget> {
  public:
   ComplexWidget(ShuffleboardContainer& parent, std::string_view title,
-                Sendable& sendable);
+                wpi::Sendable& sendable);
+
+  ~ComplexWidget() override;
 
   void EnableIfActuator() override;
 
@@ -35,9 +39,8 @@ class ComplexWidget final : public ShuffleboardWidget<ComplexWidget> {
                  std::shared_ptr<nt::NetworkTable> metaTable) override;
 
  private:
-  Sendable& m_sendable;
-  SendableBuilderImpl m_builder;
-  bool m_builderInit = false;
+  wpi::Sendable& m_sendable;
+  std::unique_ptr<wpi::SendableBuilder> m_builder;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/shuffleboard/SendableCameraWrapper.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/SendableCameraWrapper.h
@@ -18,8 +18,8 @@ using CS_Handle = int;        // NOLINT
 using CS_Source = CS_Handle;  // NOLINT
 #endif
 
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 
 namespace frc {
 
@@ -29,14 +29,15 @@ namespace detail {
 constexpr const char* kProtocol = "camera_server://";
 std::shared_ptr<SendableCameraWrapper>& GetSendableCameraWrapper(
     CS_Source source);
-void AddToSendableRegistry(Sendable* sendable, std::string name);
+void AddToSendableRegistry(wpi::Sendable* sendable, std::string name);
 }  // namespace detail
 
 /**
  * A wrapper to make video sources sendable and usable from Shuffleboard.
  */
-class SendableCameraWrapper : public Sendable,
-                              public SendableHelper<SendableCameraWrapper> {
+class SendableCameraWrapper
+    : public wpi::Sendable,
+      public wpi::SendableHelper<SendableCameraWrapper> {
  private:
   struct private_init {};
 
@@ -60,7 +61,7 @@ class SendableCameraWrapper : public Sendable,
   static SendableCameraWrapper& Wrap(const cs::VideoSource& source);
   static SendableCameraWrapper& Wrap(CS_Source source);
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
   std::string m_uri;

--- a/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardComponent.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardComponent.h
@@ -29,8 +29,6 @@ class ShuffleboardComponent : public ShuffleboardComponentBase {
   ShuffleboardComponent(ShuffleboardContainer& parent, std::string_view title,
                         std::string_view type = "");
 
-  ~ShuffleboardComponent() override = default;
-
   /**
    * Sets custom properties for this component. Property names are
    * case-sensitive and whitespace-insensitive (capitalization and spaces do not

--- a/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardComponentBase.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardComponentBase.h
@@ -26,8 +26,6 @@ class ShuffleboardComponentBase : public virtual ShuffleboardValue {
   ShuffleboardComponentBase(ShuffleboardContainer& parent,
                             std::string_view title, std::string_view type = "");
 
-  ~ShuffleboardComponentBase() override = default;
-
   void SetType(std::string_view type);
 
   void BuildMetadata(std::shared_ptr<nt::NetworkTable> metaTable);

--- a/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardContainer.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardContainer.h
@@ -26,10 +26,13 @@ namespace cs {
 class VideoSource;
 }  // namespace cs
 
+namespace wpi {
+class Sendable;
+}  // namespace wpi
+
 namespace frc {
 
 class ComplexWidget;
-class Sendable;
 class ShuffleboardLayout;
 class SimpleWidget;
 
@@ -111,7 +114,7 @@ class ShuffleboardContainer : public virtual ShuffleboardValue {
    * @throws IllegalArgumentException if a widget already exists in this
    * container with the given title
    */
-  ComplexWidget& Add(std::string_view title, Sendable& sendable);
+  ComplexWidget& Add(std::string_view title, wpi::Sendable& sendable);
 
   /**
    * Adds a widget to this container to display the given video stream.
@@ -133,7 +136,7 @@ class ShuffleboardContainer : public virtual ShuffleboardValue {
    * container with the given title, or if the sendable's name has not been
    * specified
    */
-  ComplexWidget& Add(Sendable& sendable);
+  ComplexWidget& Add(wpi::Sendable& sendable);
 
   /**
    * Adds a widget to this container to display the given video stream.

--- a/wpilibc/src/main/native/include/frc/smartdashboard/Field2d.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/Field2d.h
@@ -8,16 +8,16 @@
 #include <string_view>
 #include <vector>
 
+#include <networktables/NTSendable.h>
 #include <networktables/NetworkTable.h>
 #include <networktables/NetworkTableEntry.h>
 #include <units/length.h>
 #include <wpi/mutex.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/geometry/Pose2d.h"
 #include "frc/geometry/Rotation2d.h"
 #include "frc/smartdashboard/FieldObject2d.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
@@ -39,7 +39,7 @@ namespace frc {
  * also be shown by using the GetObject() function.  Other objects can
  * also have multiple poses (which will show the object at multiple locations).
  */
-class Field2d : public Sendable, public SendableHelper<Field2d> {
+class Field2d : public nt::NTSendable, public wpi::SendableHelper<Field2d> {
  public:
   using Entry = size_t;
 
@@ -85,7 +85,7 @@ class Field2d : public Sendable, public SendableHelper<Field2d> {
    */
   FieldObject2d* GetRobotObject();
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(nt::NTSendableBuilder& builder) override;
 
  private:
   std::shared_ptr<nt::NetworkTable> m_table;

--- a/wpilibc/src/main/native/include/frc/smartdashboard/Mechanism2d.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/Mechanism2d.h
@@ -7,13 +7,13 @@
 #include <memory>
 #include <string>
 
+#include <networktables/NTSendable.h>
 #include <networktables/NetworkTableEntry.h>
 #include <wpi/StringMap.h>
 #include <wpi/mutex.h>
+#include <wpi/sendable/SendableHelper.h>
 
 #include "frc/smartdashboard/MechanismRoot2d.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 #include "frc/util/Color8Bit.h"
 
 namespace frc {
@@ -36,7 +36,8 @@ namespace frc {
  * @see MechanismLigament2d
  * @see MechanismRoot2d
  */
-class Mechanism2d : public Sendable, public SendableHelper<Mechanism2d> {
+class Mechanism2d : public nt::NTSendable,
+                    public wpi::SendableHelper<Mechanism2d> {
  public:
   /**
    * Create a new Mechanism2d with the given dimensions and background color.
@@ -68,7 +69,7 @@ class Mechanism2d : public Sendable, public SendableHelper<Mechanism2d> {
    */
   void SetBackgroundColor(const Color8Bit& color);
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(nt::NTSendableBuilder& builder) override;
 
  private:
   double m_width;

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableBuilderImpl.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableBuilderImpl.h
@@ -11,17 +11,16 @@
 #include <utility>
 #include <vector>
 
+#include <networktables/NTSendableBuilder.h>
 #include <networktables/NetworkTable.h>
 #include <networktables/NetworkTableEntry.h>
 #include <networktables/NetworkTableValue.h>
 #include <wpi/SmallVector.h>
 #include <wpi/span.h>
 
-#include "frc/smartdashboard/SendableBuilder.h"
-
 namespace frc {
 
-class SendableBuilderImpl : public SendableBuilder {
+class SendableBuilderImpl : public nt::NTSendableBuilder {
  public:
   SendableBuilderImpl() = default;
   ~SendableBuilderImpl() override = default;
@@ -46,7 +45,7 @@ class SendableBuilderImpl : public SendableBuilder {
    * Return whether this sendable has an associated table.
    * @return True if it has a table, false if not.
    */
-  bool HasTable() const;
+  bool IsPublished() const override;
 
   /**
    * Return whether this sendable should be treated as an actuator.
@@ -57,7 +56,7 @@ class SendableBuilderImpl : public SendableBuilder {
   /**
    * Update the network table values by calling the getters for all properties.
    */
-  void UpdateTable();
+  void Update() override;
 
   /**
    * Hook setters for all properties.
@@ -84,7 +83,7 @@ class SendableBuilderImpl : public SendableBuilder {
   /**
    * Clear properties.
    */
-  void ClearProperties();
+  void ClearProperties() override;
 
   void SetSmartDashboardType(std::string_view type) override;
   void SetActuator(bool value) override;

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.h
@@ -10,7 +10,6 @@
 #include <wpi/StringMap.h>
 #include <wpi/deprecated.h>
 
-#include "frc/smartdashboard/SendableBuilder.h"
 #include "frc/smartdashboard/SendableChooserBase.h"
 
 namespace frc {
@@ -112,7 +111,7 @@ class SendableChooser : public SendableChooserBase {
    */
   auto GetSelected() -> decltype(_unwrap_smart_ptr(m_choices[""]));
 
-  void InitSendable(SendableBuilder& builder) override;
+  void InitSendable(nt::NTSendableBuilder& builder) override;
 };
 
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.inc
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooser.inc
@@ -11,6 +11,8 @@
 #include <utility>
 #include <vector>
 
+#include <networktables/NTSendableBuilder.h>
+
 #include "frc/smartdashboard/SendableChooser.h"
 
 namespace frc {
@@ -44,7 +46,7 @@ auto SendableChooser<T>::GetSelected()
 }
 
 template <class T>
-void SendableChooser<T>::InitSendable(SendableBuilder& builder) {
+void SendableChooser<T>::InitSendable(nt::NTSendableBuilder& builder) {
   builder.SetSmartDashboardType("String Chooser");
   builder.GetEntry(kInstance).SetDouble(m_instance);
   builder.AddStringArrayProperty(

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooserBase.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableChooserBase.h
@@ -7,12 +7,11 @@
 #include <atomic>
 #include <string>
 
+#include <networktables/NTSendable.h>
 #include <networktables/NetworkTableEntry.h>
 #include <wpi/SmallVector.h>
 #include <wpi/mutex.h>
-
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
+#include <wpi/sendable/SendableHelper.h>
 
 namespace frc {
 
@@ -22,8 +21,8 @@ namespace frc {
  * It contains static, non-templated variables to avoid their duplication in the
  * template class.
  */
-class SendableChooserBase : public Sendable,
-                            public SendableHelper<SendableChooserBase> {
+class SendableChooserBase : public nt::NTSendable,
+                            public wpi::SendableHelper<SendableChooserBase> {
  public:
   SendableChooserBase();
   ~SendableChooserBase() override = default;

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SmartDashboard.h
@@ -11,15 +11,16 @@
 
 #include <networktables/NetworkTableEntry.h>
 #include <networktables/NetworkTableValue.h>
+#include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableHelper.h>
 #include <wpi/span.h>
 
 #include "frc/smartdashboard/ListenerExecutor.h"
-#include "frc/smartdashboard/Sendable.h"
-#include "frc/smartdashboard/SendableHelper.h"
 
 namespace frc {
 
-class SmartDashboard : public Sendable, public SendableHelper<SmartDashboard> {
+class SmartDashboard : public wpi::Sendable,
+                       public wpi::SendableHelper<SmartDashboard> {
  public:
   static void init();
 
@@ -115,7 +116,7 @@ class SmartDashboard : public Sendable, public SendableHelper<SmartDashboard> {
    * @param keyName the key
    * @param value   the value
    */
-  static void PutData(std::string_view key, Sendable* data);
+  static void PutData(std::string_view key, wpi::Sendable* data);
 
   /**
    * Maps the specified key (where the key is the name of the Sendable)
@@ -129,7 +130,7 @@ class SmartDashboard : public Sendable, public SendableHelper<SmartDashboard> {
    *
    * @param value the value
    */
-  static void PutData(Sendable* value);
+  static void PutData(wpi::Sendable* value);
 
   /**
    * Returns the value at the specified key.
@@ -137,7 +138,7 @@ class SmartDashboard : public Sendable, public SendableHelper<SmartDashboard> {
    * @param keyName the key
    * @return the value
    */
-  static Sendable* GetData(std::string_view keyName);
+  static wpi::Sendable* GetData(std::string_view keyName);
 
   /**
    * Maps the specified key to the specified value in this table.

--- a/wpilibc/src/test/native/cpp/shuffleboard/MockActuatorSendable.cpp
+++ b/wpilibc/src/test/native/cpp/shuffleboard/MockActuatorSendable.cpp
@@ -4,14 +4,13 @@
 
 #include "shuffleboard/MockActuatorSendable.h"
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
-using namespace frc;
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
 
 MockActuatorSendable::MockActuatorSendable(std::string_view name) {
-  SendableRegistry::GetInstance().Add(this, name);
+  wpi::SendableRegistry::GetInstance().Add(this, name);
 }
 
-void MockActuatorSendable::InitSendable(SendableBuilder& builder) {
+void MockActuatorSendable::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetActuator(true);
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_I2C.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_I2C.java
@@ -10,16 +10,17 @@ import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.SimDevice;
 import edu.wpi.first.hal.SimDouble;
 import edu.wpi.first.hal.SimEnum;
+import edu.wpi.first.networktables.NTSendable;
+import edu.wpi.first.networktables.NTSendableBuilder;
 import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.interfaces.Accelerometer;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 /** ADXL345 I2C Accelerometer. */
 @SuppressWarnings({"TypeName", "PMD.UnusedPrivateField"})
-public class ADXL345_I2C implements Accelerometer, Sendable, AutoCloseable {
+public class ADXL345_I2C implements Accelerometer, NTSendable, AutoCloseable {
   private static final byte kAddress = 0x1D;
   private static final byte kPowerCtlRegister = 0x2D;
   private static final byte kDataFormatRegister = 0x31;
@@ -215,7 +216,7 @@ public class ADXL345_I2C implements Accelerometer, Sendable, AutoCloseable {
   }
 
   @Override
-  public void initSendable(SendableBuilder builder) {
+  public void initSendable(NTSendableBuilder builder) {
     builder.setSmartDashboardType("3AxisAccelerometer");
     NetworkTableEntry entryX = builder.getEntry("X");
     NetworkTableEntry entryY = builder.getEntry("Y");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_SPI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_SPI.java
@@ -10,16 +10,17 @@ import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.SimDevice;
 import edu.wpi.first.hal.SimDouble;
 import edu.wpi.first.hal.SimEnum;
+import edu.wpi.first.networktables.NTSendable;
+import edu.wpi.first.networktables.NTSendableBuilder;
 import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.interfaces.Accelerometer;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 /** ADXL345 SPI Accelerometer. */
 @SuppressWarnings({"TypeName", "PMD.UnusedPrivateField"})
-public class ADXL345_SPI implements Accelerometer, Sendable, AutoCloseable {
+public class ADXL345_SPI implements Accelerometer, NTSendable, AutoCloseable {
   private static final int kPowerCtlRegister = 0x2D;
   private static final int kDataFormatRegister = 0x31;
   private static final int kDataRegister = 0x32;
@@ -229,7 +230,7 @@ public class ADXL345_SPI implements Accelerometer, Sendable, AutoCloseable {
   }
 
   @Override
-  public void initSendable(SendableBuilder builder) {
+  public void initSendable(NTSendableBuilder builder) {
     builder.setSmartDashboardType("3AxisAccelerometer");
     NetworkTableEntry entryX = builder.getEntry("X");
     NetworkTableEntry entryY = builder.getEntry("Y");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL362.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL362.java
@@ -9,10 +9,11 @@ import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.SimDevice;
 import edu.wpi.first.hal.SimDouble;
 import edu.wpi.first.hal.SimEnum;
+import edu.wpi.first.networktables.NTSendable;
+import edu.wpi.first.networktables.NTSendableBuilder;
 import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.interfaces.Accelerometer;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -21,7 +22,7 @@ import java.nio.ByteOrder;
  *
  * <p>This class allows access to an Analog Devices ADXL362 3-axis accelerometer.
  */
-public class ADXL362 implements Accelerometer, Sendable, AutoCloseable {
+public class ADXL362 implements Accelerometer, NTSendable, AutoCloseable {
   private static final byte kRegWrite = 0x0A;
   private static final byte kRegRead = 0x0B;
 
@@ -258,7 +259,7 @@ public class ADXL362 implements Accelerometer, Sendable, AutoCloseable {
   }
 
   @Override
-  public void initSendable(SendableBuilder builder) {
+  public void initSendable(NTSendableBuilder builder) {
     builder.setSmartDashboardType("3AxisAccelerometer");
     NetworkTableEntry entryX = builder.getEntry("X");
     NetworkTableEntry entryY = builder.getEntry("Y");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.java
@@ -9,9 +9,10 @@ import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.SimBoolean;
 import edu.wpi.first.hal.SimDevice;
 import edu.wpi.first.hal.SimDouble;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.interfaces.Gyro;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogAccelerometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogAccelerometer.java
@@ -8,8 +8,9 @@ import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /**
  * Handle operation of an analog accelerometer. The accelerometer reads acceleration directly

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogEncoder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogEncoder.java
@@ -7,9 +7,10 @@ package edu.wpi.first.wpilibj;
 import edu.wpi.first.hal.SimDevice;
 import edu.wpi.first.hal.SimDevice.Direction;
 import edu.wpi.first.hal.SimDouble;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.AnalogTriggerOutput.AnalogTriggerType;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /** Class for supporting continuous analog encoders, such as the US Digital MA3. */
 public class AnalogEncoder implements Sendable, AutoCloseable {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogGyro.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogGyro.java
@@ -9,9 +9,10 @@ import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
 import edu.wpi.first.hal.AnalogGyroJNI;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.interfaces.Gyro;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Use a rate gyro to return the robots heading relative to a starting position. The Gyro class

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogInput.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogInput.java
@@ -10,8 +10,9 @@ import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.SimDevice;
 import edu.wpi.first.hal.util.AllocationException;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /**
  * Analog channel class.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogOutput.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogOutput.java
@@ -7,8 +7,9 @@ package edu.wpi.first.wpilibj;
 import edu.wpi.first.hal.AnalogJNI;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /** Analog output class. */
 public class AnalogOutput implements Sendable, AutoCloseable {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogPotentiometer.java
@@ -4,8 +4,9 @@
 
 package edu.wpi.first.wpilibj;
 
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /**
  * Class for reading analog potentiometers. Analog potentiometers read in an analog voltage that

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogTrigger.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogTrigger.java
@@ -8,9 +8,10 @@ import edu.wpi.first.hal.AnalogJNI;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.util.BoundaryException;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.AnalogTriggerOutput.AnalogTriggerType;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /** Class for creating and configuring Analog Triggers. */
 public class AnalogTrigger implements Sendable, AutoCloseable {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogTriggerOutput.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogTriggerOutput.java
@@ -9,7 +9,8 @@ import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
 import edu.wpi.first.hal.AnalogJNI;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
 
 /**
  * Class to represent a specific output from an analog trigger. This class is used to get the

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/BuiltInAccelerometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/BuiltInAccelerometer.java
@@ -7,9 +7,10 @@ package edu.wpi.first.wpilibj;
 import edu.wpi.first.hal.AccelerometerJNI;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.interfaces.Accelerometer;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Built-in accelerometer.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Counter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Counter.java
@@ -10,9 +10,10 @@ import static java.util.Objects.requireNonNull;
 import edu.wpi.first.hal.CounterJNI;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.AnalogTriggerOutput.AnalogTriggerType;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalGlitchFilter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalGlitchFilter.java
@@ -7,8 +7,9 @@ package edu.wpi.first.wpilibj;
 import edu.wpi.first.hal.DigitalGlitchFilterJNI;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalInput.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalInput.java
@@ -8,8 +8,9 @@ import edu.wpi.first.hal.DIOJNI;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.SimDevice;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /**
  * Class to read a digital input. This class will read digital inputs and return the current value

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalOutput.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalOutput.java
@@ -8,8 +8,9 @@ import edu.wpi.first.hal.DIOJNI;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.SimDevice;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /**
  * Class to write digital outputs. This class will write digital outputs. Other devices that are

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DoubleSolenoid.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DoubleSolenoid.java
@@ -6,8 +6,9 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.util.Objects;
 
 /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycle.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycle.java
@@ -7,8 +7,9 @@ package edu.wpi.first.wpilibj;
 import edu.wpi.first.hal.DutyCycleJNI;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /**
  * Class to read a duty cycle PWM input.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycleEncoder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycleEncoder.java
@@ -7,9 +7,10 @@ package edu.wpi.first.wpilibj;
 import edu.wpi.first.hal.SimBoolean;
 import edu.wpi.first.hal.SimDevice;
 import edu.wpi.first.hal.SimDouble;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.AnalogTriggerOutput.AnalogTriggerType;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * Class for supporting duty cycle/PWM encoders, such as the US Digital MA3 with PWM Output, the

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Encoder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Encoder.java
@@ -11,8 +11,9 @@ import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.SimDevice;
 import edu.wpi.first.hal.util.AllocationException;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /**
  * Class to read quadrature encoders.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWM.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PWM.java
@@ -8,8 +8,9 @@ import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.PWMConfigDataResult;
 import edu.wpi.first.hal.PWMJNI;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /**
  * Class implements the PWM generation in the FPGA.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistributionPanel.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistributionPanel.java
@@ -7,8 +7,9 @@ package edu.wpi.first.wpilibj;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.PDPJNI;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /**
  * Class for getting voltage, current, temperature, power and energy from the Power Distribution

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Relay.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Relay.java
@@ -10,8 +10,9 @@ import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.RelayJNI;
 import edu.wpi.first.hal.util.UncleanStatusException;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.util.Arrays;
 import java.util.Optional;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Servo.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Servo.java
@@ -6,8 +6,8 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /**
  * Standard hobby style servo.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Solenoid.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Solenoid.java
@@ -6,8 +6,9 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.util.Objects;
 
 /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SpeedControllerGroup.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SpeedControllerGroup.java
@@ -4,9 +4,10 @@
 
 package edu.wpi.first.wpilibj;
 
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.motorcontrol.MotorController;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 import java.util.Arrays;
 
 /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Ultrasonic.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Ultrasonic.java
@@ -12,8 +12,9 @@ import edu.wpi.first.hal.SimBoolean;
 import edu.wpi.first.hal.SimDevice;
 import edu.wpi.first.hal.SimDevice.Direction;
 import edu.wpi.first.hal.SimDouble;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/PIDController.java
@@ -7,9 +7,9 @@ package edu.wpi.first.wpilibj.controller;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /** Implements a PID control loop. */
 public class PIDController implements Sendable, AutoCloseable {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/controller/ProfiledPIDController.java
@@ -8,8 +8,8 @@ import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
-import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
 
 /**
  * Implements a PID control loop whose setpoint is constrained by a trapezoid profile. Users should

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -10,10 +10,10 @@ import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.SpeedController;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * A class for driving differential drive/skid-steer drive platforms such as the Kit of Parts drive

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
@@ -10,10 +10,10 @@ import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.SpeedController;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * A class for driving Killough drive platforms.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
@@ -10,10 +10,10 @@ import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.SpeedController;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /**
  * A class for driving Mecanum drive platforms.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -7,8 +7,9 @@ package edu.wpi.first.wpilibj.livewindow;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
-import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableRegistry;
+import edu.wpi.first.wpilibj.smartdashboard.SendableBuilderImpl;
 
 /**
  * The LiveWindow class is the public interface for putting sensors and actuators on the LiveWindow.
@@ -30,6 +31,10 @@ public class LiveWindow {
 
   private static Runnable enabledListener;
   private static Runnable disabledListener;
+
+  static {
+    SendableRegistry.setLiveWindowBuilderFactory(() -> new SendableBuilderImpl());
+  }
 
   private static Component getOrAdd(Sendable sendable) {
     Component data = (Component) SendableRegistry.getData(sendable, dataHandle);
@@ -84,7 +89,7 @@ public class LiveWindow {
         SendableRegistry.foreachLiveWindow(
             dataHandle,
             cbdata -> {
-              cbdata.builder.stopLiveWindowMode();
+              ((SendableBuilderImpl) cbdata.builder).stopLiveWindowMode();
             });
         if (disabledListener != null) {
           disabledListener.run();
@@ -173,7 +178,7 @@ public class LiveWindow {
               table = ssTable.getSubTable(cbdata.name);
             }
             table.getEntry(".name").setString(cbdata.name);
-            cbdata.builder.setTable(table);
+            ((SendableBuilderImpl) cbdata.builder).setTable(table);
             cbdata.sendable.initSendable(cbdata.builder);
             ssTable.getEntry(".type").setString("LW Subsystem");
 
@@ -181,9 +186,9 @@ public class LiveWindow {
           }
 
           if (startLiveWindow) {
-            cbdata.builder.startLiveWindowMode();
+            ((SendableBuilderImpl) cbdata.builder).startLiveWindowMode();
           }
-          cbdata.builder.updateTable();
+          cbdata.builder.update();
         });
 
     startLiveWindow = false;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/MotorControllerGroup.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/MotorControllerGroup.java
@@ -4,9 +4,9 @@
 
 package edu.wpi.first.wpilibj.motorcontrol;
 
-import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.util.Arrays;
 
 /** Allows multiple {@link MotorController} objects to be linked together. */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/NidecBrushless.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/NidecBrushless.java
@@ -6,12 +6,12 @@ package edu.wpi.first.wpilibj.motorcontrol;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.DigitalOutput;
 import edu.wpi.first.wpilibj.MotorSafety;
 import edu.wpi.first.wpilibj.PWM;
-import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /** Nidec Brushless Motor. */
 public class NidecBrushless extends MotorSafety

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/PWMMotorController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/PWMMotorController.java
@@ -4,11 +4,11 @@
 
 package edu.wpi.first.wpilibj.motorcontrol;
 
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.MotorSafety;
 import edu.wpi.first.wpilibj.PWM;
-import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
 
 /** Common base class for all PWM Motor Controllers. */
 public abstract class PWMMotorController extends MotorSafety

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ComplexWidget.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ComplexWidget.java
@@ -5,8 +5,7 @@
 package edu.wpi.first.wpilibj.shuffleboard;
 
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.wpilibj.smartdashboard.SendableBuilderImpl;
 
 /**
@@ -31,7 +30,7 @@ public final class ComplexWidget extends ShuffleboardWidget<ComplexWidget> {
       m_sendable.initSendable(m_builder);
       m_builder.startListeners();
     }
-    m_builder.updateTable();
+    m_builder.update();
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ContainerHelper.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ContainerHelper.java
@@ -5,8 +5,8 @@
 package edu.wpi.first.wpilibj.shuffleboard;
 
 import edu.wpi.first.networktables.NetworkTableEntry;
-import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/SendableCameraWrapper.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/SendableCameraWrapper.java
@@ -5,9 +5,9 @@
 package edu.wpi.first.wpilibj.shuffleboard;
 
 import edu.wpi.first.cscore.VideoSource;
-import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.util.Map;
 import java.util.WeakHashMap;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
@@ -5,7 +5,7 @@
 package edu.wpi.first.wpilibj.shuffleboard;
 
 import edu.wpi.first.cscore.VideoSource;
-import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.util.sendable.Sendable;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.BooleanSupplier;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardLayout.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardLayout.java
@@ -7,7 +7,7 @@ package edu.wpi.first.wpilibj.shuffleboard;
 import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
 
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.util.sendable.Sendable;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.BooleanSupplier;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTab.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTab.java
@@ -5,7 +5,7 @@
 package edu.wpi.first.wpilibj.shuffleboard;
 
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.util.sendable.Sendable;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.BooleanSupplier;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/Field2d.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/Field2d.java
@@ -6,8 +6,10 @@ package edu.wpi.first.wpilibj.smartdashboard;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.networktables.NTSendable;
+import edu.wpi.first.networktables.NTSendableBuilder;
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,7 +29,7 @@ import java.util.List;
  * using the getObject() function. Other objects can also have multiple poses (which will show the
  * object at multiple locations).
  */
-public class Field2d implements Sendable {
+public class Field2d implements NTSendable {
   /** Constructor. */
   public Field2d() {
     FieldObject2d obj = new FieldObject2d("Robot");
@@ -98,7 +100,7 @@ public class Field2d implements Sendable {
   }
 
   @Override
-  public void initSendable(SendableBuilder builder) {
+  public void initSendable(NTSendableBuilder builder) {
     builder.setSmartDashboardType("Field2d");
     m_table = builder.getTable();
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/Mechanism2d.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/Mechanism2d.java
@@ -4,8 +4,9 @@
 
 package edu.wpi.first.wpilibj.smartdashboard;
 
+import edu.wpi.first.networktables.NTSendable;
+import edu.wpi.first.networktables.NTSendableBuilder;
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.wpilibj.Sendable;
 import edu.wpi.first.wpilibj.util.Color8Bit;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +22,7 @@ import java.util.Map.Entry;
  * @see MechanismLigament2d
  * @see MechanismRoot2d
  */
-public final class Mechanism2d implements Sendable {
+public final class Mechanism2d implements NTSendable {
   private static final String kBackgroundColor = "backgroundColor";
   private NetworkTable m_table;
   private final Map<String, MechanismRoot2d> m_roots;
@@ -89,7 +90,7 @@ public final class Mechanism2d implements Sendable {
   }
 
   @Override
-  public void initSendable(SendableBuilder builder) {
+  public void initSendable(NTSendableBuilder builder) {
     builder.setSmartDashboardType("Mechanism2d");
     m_table = builder.getTable();
     m_table.getEntry("dims").setDoubleArray(m_dims);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
@@ -5,6 +5,7 @@
 package edu.wpi.first.wpilibj.smartdashboard;
 
 import edu.wpi.first.networktables.EntryListenerFlags;
+import edu.wpi.first.networktables.NTSendableBuilder;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableValue;
@@ -17,7 +18,7 @@ import java.util.function.DoubleSupplier;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-public class SendableBuilderImpl implements SendableBuilder {
+public class SendableBuilderImpl implements NTSendableBuilder {
   private static class Property {
     Property(NetworkTable table, String key) {
       m_entry = table.getEntry(key);
@@ -80,7 +81,8 @@ public class SendableBuilderImpl implements SendableBuilder {
    *
    * @return True if it has a table, false if not.
    */
-  public boolean hasTable() {
+  @Override
+  public boolean isPublished() {
     return m_table != null;
   }
 
@@ -94,7 +96,8 @@ public class SendableBuilderImpl implements SendableBuilder {
   }
 
   /** Update the network table values by calling the getters for all properties. */
-  public void updateTable() {
+  @Override
+  public void update() {
     for (Property property : m_properties) {
       if (property.m_update != null) {
         property.m_update.accept(property.m_entry);
@@ -148,6 +151,7 @@ public class SendableBuilderImpl implements SendableBuilder {
   }
 
   /** Clear properties. */
+  @Override
   public void clearProperties() {
     stopListeners();
     m_properties.clear();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
@@ -6,8 +6,10 @@ package edu.wpi.first.wpilibj.smartdashboard;
 
 import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
 
+import edu.wpi.first.networktables.NTSendable;
+import edu.wpi.first.networktables.NTSendableBuilder;
 import edu.wpi.first.networktables.NetworkTableEntry;
-import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -27,7 +29,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @param <V> The type of the values to be stored
  */
-public class SendableChooser<V> implements Sendable, AutoCloseable {
+public class SendableChooser<V> implements NTSendable, AutoCloseable {
   /** The key for the default value. */
   private static final String DEFAULT = "default";
   /** The key for the selected option. */
@@ -130,7 +132,7 @@ public class SendableChooser<V> implements Sendable, AutoCloseable {
   private final ReentrantLock m_mutex = new ReentrantLock();
 
   @Override
-  public void initSendable(SendableBuilder builder) {
+  public void initSendable(NTSendableBuilder builder) {
     builder.setSmartDashboardType("String Chooser");
     builder.getEntry(INSTANCE).setDouble(m_instance);
     builder.addStringProperty(DEFAULT, () -> m_defaultChoice, null);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
@@ -9,7 +9,8 @@ import edu.wpi.first.hal.HAL;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
-import edu.wpi.first.wpilibj.Sendable;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableRegistry;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
@@ -58,7 +59,10 @@ public final class SmartDashboard {
     if (sddata == null || sddata != data) {
       tablesToData.put(key, data);
       NetworkTable dataTable = table.getSubTable(key);
-      SendableRegistry.publish(data, dataTable);
+      SendableBuilderImpl builder = new SendableBuilderImpl();
+      builder.setTable(dataTable);
+      SendableRegistry.publish(data, builder);
+      builder.startListeners();
       dataTable.getEntry(".name").setString(key);
     }
   }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/MockActuatorSendable.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/MockActuatorSendable.java
@@ -4,9 +4,9 @@
 
 package edu.wpi.first.wpilibj.shuffleboard;
 
-import edu.wpi.first.wpilibj.Sendable;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 /** A mock sendable that marks itself as an actuator. */
 public class MockActuatorSendable implements Sendable {

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PIDTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PIDTest.java
@@ -127,7 +127,7 @@ public class PIDTest extends AbstractComsSetup {
         reference,
         m_controller.getPositionError(),
         0);
-    m_builder.updateTable();
+    m_builder.update();
     assertEquals(k_p, m_table.getEntry("Kp").getDouble(9999999), 0);
     assertEquals(k_i, m_table.getEntry("Ki").getDouble(9999999), 0);
     assertEquals(k_d, m_table.getEntry("Kd").getDouble(9999999), 0);

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/RelayCrossConnectTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/RelayCrossConnectTest.java
@@ -49,7 +49,7 @@ public class RelayCrossConnectTest extends AbstractComsSetup {
   public void testBothHigh() {
     m_relayFixture.getRelay().setDirection(Direction.kBoth);
     m_relayFixture.getRelay().set(Value.kOn);
-    m_builder.updateTable();
+    m_builder.update();
     assertTrue(
         "Input one was not high when relay set both high", m_relayFixture.getInputOne().get());
     assertTrue(
@@ -62,7 +62,7 @@ public class RelayCrossConnectTest extends AbstractComsSetup {
   public void testFirstHigh() {
     m_relayFixture.getRelay().setDirection(Direction.kBoth);
     m_relayFixture.getRelay().set(Value.kForward);
-    m_builder.updateTable();
+    m_builder.update();
     assertFalse(
         "Input one was not low when relay set Value.kForward", m_relayFixture.getInputOne().get());
     assertTrue(
@@ -75,7 +75,7 @@ public class RelayCrossConnectTest extends AbstractComsSetup {
   public void testSecondHigh() {
     m_relayFixture.getRelay().setDirection(Direction.kBoth);
     m_relayFixture.getRelay().set(Value.kReverse);
-    m_builder.updateTable();
+    m_builder.update();
     assertTrue(
         "Input one was not high when relay set Value.kReverse", m_relayFixture.getInputOne().get());
     assertFalse(
@@ -88,7 +88,7 @@ public class RelayCrossConnectTest extends AbstractComsSetup {
   public void testForwardDirection() {
     m_relayFixture.getRelay().setDirection(Direction.kForward);
     m_relayFixture.getRelay().set(Value.kOn);
-    m_builder.updateTable();
+    m_builder.update();
     assertFalse(
         "Input one was not low when relay set Value.kOn in kForward Direction",
         m_relayFixture.getInputOne().get());
@@ -103,7 +103,7 @@ public class RelayCrossConnectTest extends AbstractComsSetup {
   public void testReverseDirection() {
     m_relayFixture.getRelay().setDirection(Direction.kReverse);
     m_relayFixture.getRelay().set(Value.kOn);
-    m_builder.updateTable();
+    m_builder.update();
     assertTrue(
         "Input one was not high when relay set Value.kOn in kReverse Direction",
         m_relayFixture.getInputOne().get());
@@ -128,7 +128,7 @@ public class RelayCrossConnectTest extends AbstractComsSetup {
 
   @Test
   public void testInitialSettings() {
-    m_builder.updateTable();
+    m_builder.update();
     assertEquals(Value.kOff, m_relayFixture.getRelay().get());
     // Initially both outputs should be off
     assertFalse(m_relayFixture.getInputOne().get());

--- a/wpiutil/src/main/java/edu/wpi/first/util/sendable/Sendable.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/sendable/Sendable.java
@@ -2,11 +2,9 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package edu.wpi.first.wpilibj;
+package edu.wpi.first.util.sendable;
 
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
-
-/** The base interface for objects that can be sent over the network through network tables. */
+/** The base interface for objects that can be sent over the network. */
 public interface Sendable {
   /**
    * Initializes this {@link Sendable} object.

--- a/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableBuilder.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableBuilder.java
@@ -2,11 +2,8 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package edu.wpi.first.wpilibj.smartdashboard;
+package edu.wpi.first.util.sendable;
 
-import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.networktables.NetworkTableEntry;
-import edu.wpi.first.networktables.NetworkTableValue;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.DoubleConsumer;
@@ -14,12 +11,11 @@ import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 
 public interface SendableBuilder {
-  /**
-   * Get the network table.
-   *
-   * @return The network table
-   */
-  NetworkTable getTable();
+  /** The backend kinds used for the sendable builder. */
+  enum BackendKind {
+    kUnknown,
+    kNetworkTables
+  }
 
   /**
    * Set the string representation of the named data type that will be used by the smart dashboard
@@ -44,24 +40,6 @@ public interface SendableBuilder {
    * @param func function
    */
   void setSafeState(Runnable func);
-
-  /**
-   * Set the function that should be called to update the network table for things other than
-   * properties. Note this function is not passed the network table object; instead it should use
-   * the entry handles returned by getEntry().
-   *
-   * @param func function
-   */
-  void setUpdateTable(Runnable func);
-
-  /**
-   * Add a property without getters or setters. This can be used to get entry handles for the
-   * function called by setUpdateTable().
-   *
-   * @param key property name
-   * @return Network table entry
-   */
-  NetworkTableEntry getEntry(String key);
 
   /**
    * Represents an operation that accepts a single boolean-valued argument and returns no result.
@@ -144,12 +122,22 @@ public interface SendableBuilder {
   void addRawProperty(String key, Supplier<byte[]> getter, Consumer<byte[]> setter);
 
   /**
-   * Add a NetworkTableValue property.
+   * Gets the kind of backend being used.
    *
-   * @param key property name
-   * @param getter getter function (returns current value)
-   * @param setter setter function (sets new value)
+   * @return Backend kind
    */
-  void addValueProperty(
-      String key, Supplier<NetworkTableValue> getter, Consumer<NetworkTableValue> setter);
+  BackendKind getBackendKind();
+
+  /**
+   * Return whether this sendable has been published.
+   *
+   * @return True if it has been published, false if not.
+   */
+  boolean isPublished();
+
+  /** Update the published values by calling the getters for all properties. */
+  void update();
+
+  /** Clear properties. */
+  void clearProperties();
 }

--- a/wpiutil/src/main/native/include/wpi/sendable/Sendable.h
+++ b/wpiutil/src/main/native/include/wpi/sendable/Sendable.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-namespace frc {
+namespace wpi {
 
 class SendableBuilder;
 
@@ -23,4 +23,4 @@ class Sendable {
   virtual void InitSendable(SendableBuilder& builder) = 0;
 };
 
-}  // namespace frc
+}  // namespace wpi

--- a/wpiutil/src/main/native/include/wpi/sendable/SendableHelper.h
+++ b/wpiutil/src/main/native/include/wpi/sendable/SendableHelper.h
@@ -8,11 +8,10 @@
 #include <string>
 #include <string_view>
 
-#include <wpi/deprecated.h>
+#include "wpi/deprecated.h"
+#include "wpi/sendable/SendableRegistry.h"
 
-#include "frc/smartdashboard/SendableRegistry.h"
-
-namespace frc {
+namespace wpi {
 
 /**
  * A helper class for use with objects that add themselves to SendableRegistry.
@@ -173,4 +172,4 @@ class SendableHelper {
   }
 };
 
-}  // namespace frc
+}  // namespace wpi

--- a/wpiutil/src/main/native/include/wpi/sendable/SendableRegistry.h
+++ b/wpiutil/src/main/native/include/wpi/sendable/SendableRegistry.h
@@ -4,17 +4,17 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <string_view>
 
-#include <networktables/NetworkTable.h>
-#include <wpi/function_ref.h>
+#include "wpi/function_ref.h"
 
-namespace frc {
+namespace wpi {
 
 class Sendable;
-class SendableBuilderImpl;
+class SendableBuilder;
 
 /**
  * The SendableRegistry class is the public interface for registering sensors
@@ -34,6 +34,14 @@ class SendableRegistry {
    * regardless of how many times GetInstance is called.
    */
   static SendableRegistry& GetInstance();
+
+  /**
+   * Sets the factory for LiveWindow builders.
+   *
+   * @param factory factory function
+   */
+  void SetLiveWindowBuilderFactory(
+      std::function<std::unique_ptr<SendableBuilder>()> factory);
 
   /**
    * Adds an object to the registry.
@@ -280,15 +288,15 @@ class SendableRegistry {
   Sendable* GetSendable(UID uid);
 
   /**
-   * Publishes an object in the registry to a network table.
+   * Publishes an object in the registry.
    *
    * @param sendableUid sendable unique id
-   * @param table network table
+   * @param builder publisher backend
    */
-  void Publish(UID sendableUid, std::shared_ptr<nt::NetworkTable> table);
+  void Publish(UID sendableUid, std::unique_ptr<SendableBuilder> builder);
 
   /**
-   * Updates network table information from an object.
+   * Updates published information from an object.
    *
    * @param sendableUid sendable unique id
    */
@@ -299,8 +307,8 @@ class SendableRegistry {
    */
   struct CallbackData {
     CallbackData(Sendable* sendable_, std::string_view name_,
-                 std::string_view subsystem_, Sendable* parent_,
-                 std::shared_ptr<void>& data_, SendableBuilderImpl& builder_)
+                 std::string_view subsystem_, wpi::Sendable* parent_,
+                 std::shared_ptr<void>& data_, SendableBuilder& builder_)
         : sendable(sendable_),
           name(name_),
           subsystem(subsystem_),
@@ -313,7 +321,7 @@ class SendableRegistry {
     std::string_view subsystem;
     Sendable* parent;
     std::shared_ptr<void>& data;
-    SendableBuilderImpl& builder;
+    SendableBuilder& builder;
   };
 
   /**
@@ -335,4 +343,4 @@ class SendableRegistry {
   std::unique_ptr<Impl> m_impl;
 };
 
-}  // namespace frc
+}  // namespace wpi


### PR DESCRIPTION
The non-NT portion has been moved to wpiutil.
The NT portion has been moved to ntcore (as NTSendable).

SendableBuilder similarly split and moved.

SendableRegistry moved to wpiutil.

In C++, SendableHelper also moved to wpiutil.

This enables use of Sendable from wpimath and also enables
moving several classes from wpilib to wpimath.