### PR TITLE
[build] Change CI back to 18.04 docker images

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,7 +10,7 @@ jobs:
         include:
           - os: ubuntu-latest
             name: Linux
-            container: wpilib/roborio-cross-ubuntu:2021-20.04
+            container: wpilib/roborio-cross-ubuntu:2021-18.04
             flags: ""
           - os: macos-latest
             name: macOS

--- a/.github/workflows/gazebo.yml
+++ b/.github/workflows/gazebo.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     name: "Build"
     runs-on: ubuntu-latest
-    container: wpilib/gazebo-ubuntu:20.04
+    container: wpilib/gazebo-ubuntu:18.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,16 +8,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: wpilib/roborio-cross-ubuntu:2021-20.04
+          - container: wpilib/roborio-cross-ubuntu:2021-18.04
             artifact-name: Athena
             build-options: "-Ponlylinuxathena"
-          - container: wpilib/raspbian-cross-ubuntu:10-20.04
+          - container: wpilib/raspbian-cross-ubuntu:10-18.04
             artifact-name: Raspbian
             build-options: "-Ponlylinuxraspbian"
-          - container: wpilib/aarch64-cross-ubuntu:bionic-20.04
+          - container: wpilib/aarch64-cross-ubuntu:bionic-18.04
             artifact-name: Aarch64
             build-options: "-Ponlylinuxaarch64bionic"
-          - container: wpilib/ubuntu-base:20.04
+          - container: wpilib/ubuntu-base:18.04
             artifact-name: Linux
             build-options: "-Dorg.gradle.jvmargs=-Xmx2g"
     name: "Build - ${{ matrix.artifact-name }}"


### PR DESCRIPTION
This reverts commit d068fb321fa912a2e8685acd7728de1f19a3ee64 (#3420).

The 18.04 docker images now use GCC 8, which was the original reason for
updating.  20.04 uses a much more recent libc, so staying with 18.04
enables more Linux platforms to use the binaries.