### PR TITLE
[ntcore] Fix dangling pointer in logger

### DIFF
--- a/ntcore/src/main/native/cpp/LoggerImpl.cpp
+++ b/ntcore/src/main/native/cpp/LoggerImpl.cpp
@@ -71,5 +71,5 @@ void LoggerImpl::Log(unsigned int level, const char* file, unsigned int line,
       DefaultLogger(level, filename.string().c_str(), line, msg);
     }
   }
-  Send(UINT_MAX, 0, level, filename.string().c_str(), line, msg);
+  Send(UINT_MAX, 0, level, filename.string(), line, msg);
 }

--- a/ntcore/src/main/native/cpp/ntcore_c.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_c.cpp
@@ -96,7 +96,7 @@ static void ConvertToC(const ConnectionNotification& in,
 static void ConvertToC(const LogMessage& in, NT_LogMessage* out) {
   out->logger = in.logger;
   out->level = in.level;
-  out->filename = in.filename;
+  ConvertToC(in.filename, &out->filename);
   out->line = in.line;
   ConvertToC(in.message, &out->message);
 }
@@ -847,6 +847,7 @@ void NT_DisposeLogMessageArray(NT_LogMessage* arr, size_t count) {
 }
 
 void NT_DisposeLogMessage(NT_LogMessage* info) {
+  std::free(info->filename);
   std::free(info->message);
 }
 

--- a/ntcore/src/main/native/include/ntcore_c.h
+++ b/ntcore/src/main/native/include/ntcore_c.h
@@ -258,7 +258,7 @@ struct NT_LogMessage {
   unsigned int level;
 
   /** The filename of the source file that generated the message. */
-  const char* filename;
+  char* filename;
 
   /** The line number in the source file that generated the message. */
   unsigned int line;

--- a/ntcore/src/main/native/include/ntcore_cpp.h
+++ b/ntcore/src/main/native/include/ntcore_cpp.h
@@ -243,7 +243,7 @@ class ConnectionNotification {
 class LogMessage {
  public:
   LogMessage() = default;
-  LogMessage(NT_Logger logger_, unsigned int level_, const char* filename_,
+  LogMessage(NT_Logger logger_, unsigned int level_, std::string_view filename_,
              unsigned int line_, std::string_view message_)
       : logger(logger_),
         level(level_),
@@ -258,7 +258,7 @@ class LogMessage {
   unsigned int level{0};
 
   /** The filename of the source file that generated the message. */
-  const char* filename{""};
+  std::string filename;
 
   /** The line number in the source file that generated the message. */
   unsigned int line{0};


### PR DESCRIPTION
This is a breaking change (it changes LogMessage::filename from const
char* to std::string) but there should be few users of it.