### PR TITLE
[wpimath] Fix IOException path in WPIMath JNI

### DIFF
--- a/wpimath/src/main/native/cpp/jni/WPIMathJNI.cpp
+++ b/wpimath/src/main/native/cpp/jni/WPIMathJNI.cpp
@@ -219,7 +219,7 @@ Java_edu_wpi_first_math_WPIMathJNI_fromPathweaverJson
     std::vector<double> elements = GetElementsFromTrajectory(trajectory);
     return MakeJDoubleArray(env, elements);
   } catch (std::exception& e) {
-    jclass cls = env->FindClass("java/lang/IOException");
+    jclass cls = env->FindClass("java/io/IOException");
     if (cls) {
       env->ThrowNew(cls, e.what());
     }
@@ -242,7 +242,7 @@ Java_edu_wpi_first_math_WPIMathJNI_toPathweaverJson
     frc::TrajectoryUtil::ToPathweaverJson(trajectory,
                                           JStringRef{env, path}.c_str());
   } catch (std::exception& e) {
-    jclass cls = env->FindClass("java/lang/IOException");
+    jclass cls = env->FindClass("java/io/IOException");
     if (cls) {
       env->ThrowNew(cls, e.what());
     }


### PR DESCRIPTION
The current 2021.3.1 release refers to `java/lang/IOException` which causes the following exception when using `toPathweaverJson` or `fromPathweaverJson`:

```
java.lang.NoClassDefFoundError: java/lang/IOException
    at edu.wpi.first.math.WPIMathJNI.fromPathweaverJson(Native Method)
    at edu.wpi.first.wpilibj.trajectory.TrajectoryUtil.fromPathweaverJson(TrajectoryUtil.java:79)
```