### PR TITLE
[examples] Create Robot.cpp for TankDrive with ordinary joystick

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/TankDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/TankDrive/cpp/Robot.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <frc/Joystick.h>
+#include <frc/TimedRobot.h>
+#include <frc/drive/DifferentialDrive.h>
+#include <frc/motorcontrol/PWMSparkMax.h>
+
+/**
+ * This is a demo program showing the use of the DifferentialDrive class.
+ * Runs the motors with tank steering.
+ */
+class Robot : public frc::TimedRobot {
+  frc::PWMSparkMax m_leftMotor{0};
+  frc::PWMSparkMax m_rightMotor{1};
+  frc::DifferentialDrive m_robotDrive{m_leftMotor, m_rightMotor};
+  frc::Joystick m_leftStick{0};
+  frc::Joystick m_rightStick{1};
+
+ public:
+  void RobotInit() override {
+    // We need to invert one side of the drivetrain so that positive voltages
+    // result in both sides moving forward. Depending on how your robot's
+    // gearbox is constructed, you might have to invert the left side instead.
+    m_rightMotor.SetInverted(true);
+  }
+
+  void TeleopPeriodic() override {
+    // Drive with tank style
+    m_robotDrive.TankDrive(m_leftStick.getY(), m_rightStick.getY());
+  }
+};
+
+#ifndef RUNNING_FRC_TESTS
+int main() {
+  return frc::StartRobot<Robot>();
+}
+#endif

--- a/wpilibcExamples/src/main/cpp/examples/TankDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/TankDrive/cpp/Robot.cpp
@@ -28,7 +28,7 @@ class Robot : public frc::TimedRobot {
 
   void TeleopPeriodic() override {
     // Drive with tank style
-    m_robotDrive.TankDrive(m_leftStick.getY(), m_rightStick.getY());
+    m_robotDrive.TankDrive(m_leftStick.GetY(), m_rightStick.GetY());
   }
 };
 


### PR DESCRIPTION
This is a basic C++ example that demonstrates a simple differential drive implementation using “tank”-style controls through the DifferentialDrive class and an ordinary joystick.