### PR TITLE
[wpilibj] Add unit tests to boost code covareage

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/HALValue.java
+++ b/hal/src/main/java/edu/wpi/first/hal/HALValue.java
@@ -147,15 +147,15 @@ public final class HALValue {
    */
   public static HALValue fromNative(int type, long value1, double value2) {
     switch (type) {
-      case 0x01:
+      case kBoolean:
         return makeBoolean(value1 != 0);
-      case 0x02:
+      case kDouble:
         return makeDouble(value2);
-      case 0x16:
+      case kEnum:
         return makeEnum((int) value1);
-      case 0x32:
+      case kInt:
         return makeInt((int) value1);
-      case 0x64:
+      case kLong:
         return makeLong(value1);
       default:
         return makeUnassigned();

--- a/hal/src/main/native/cpp/jni/simulation/CallbackStore.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/CallbackStore.cpp
@@ -56,9 +56,29 @@ void CallbackStore::performCallback(const char* name, const HAL_Value* value) {
     std::fflush(stdout);
   }
 
+  int64_t longValue = 0;
+
+  switch (value->type) {
+    case HAL_BOOLEAN:
+      longValue = value->data.v_boolean;
+      break;
+    case HAL_ENUM:
+      longValue = value->data.v_enum;
+      break;
+    case HAL_INT:
+      longValue = value->data.v_int;
+      break;
+    case HAL_LONG:
+      longValue = value->data.v_long;
+      break;
+    case HAL_DOUBLE:
+    case HAL_UNASSIGNED:
+      break;
+  }
+
   env->CallVoidMethod(m_call, sim::GetNotifyCallback(), MakeJString(env, name),
                       static_cast<jint>(value->type),
-                      static_cast<jlong>(value->data.v_long),
+                      static_cast<jlong>(longValue),
                       static_cast<jdouble>(value->data.v_double));
 
   if (env->ExceptionCheck()) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DoubleSolenoid.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DoubleSolenoid.java
@@ -70,10 +70,6 @@ public class DoubleSolenoid implements Sendable, AutoCloseable {
       }
     }
 
-    if (module.checkAndReserveSolenoids(m_mask) != 0) {
-      throw new AllocationException("Solenoid(s) already allocated");
-    }
-
     HAL.report(
         tResourceType.kResourceType_Solenoid, forwardChannel + 1, module.getModuleNumber() + 1);
     HAL.report(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticsControlModule.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticsControlModule.java
@@ -32,7 +32,7 @@ public class PneumaticsControlModule implements PneumaticsBase, Sendable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     CTREPCMJNI.free(m_handle);
     SendableRegistry.remove(this);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Relay.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Relay.java
@@ -9,6 +9,7 @@ import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.hal.RelayJNI;
+import edu.wpi.first.hal.util.HalHandleException;
 import edu.wpi.first.hal.util.UncleanStatusException;
 import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.util.sendable.SendableBuilder;
@@ -135,12 +136,12 @@ public class Relay extends MotorSafety implements Sendable, AutoCloseable {
   private void freeRelay() {
     try {
       RelayJNI.setRelay(m_forwardHandle, false);
-    } catch (UncleanStatusException ignored) {
+    } catch (UncleanStatusException | HalHandleException ignored) {
       // do nothing. Ignore
     }
     try {
       RelayJNI.setRelay(m_reverseHandle, false);
-    } catch (UncleanStatusException ignored) {
+    } catch (UncleanStatusException | HalHandleException ignored) {
       // do nothing. Ignore
     }
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/AnalogGyroTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/AnalogGyroTest.java
@@ -1,0 +1,38 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.simulation.AnalogGyroSim;
+import org.junit.jupiter.api.Test;
+
+public class AnalogGyroTest {
+  @Test
+  void testInitializeWithAnalogInput() {
+    HAL.initialize(500, 0);
+    AnalogGyroSim sim = new AnalogGyroSim(0);
+    assertFalse(sim.getInitialized());
+
+    try (AnalogInput ai = new AnalogInput(0);
+        AnalogGyro gyro = new AnalogGyro(ai, 229, 17.4)) {
+      assertEquals(ai, gyro.getAnalogInput());
+    }
+  }
+
+  @Test
+  void testInitializeWithChannel() {
+    HAL.initialize(500, 0);
+    AnalogGyroSim sim = new AnalogGyroSim(0);
+    assertFalse(sim.getInitialized());
+
+    try (AnalogGyro gyro = new AnalogGyro(1, 191, 35.04)) {
+      assertNotNull(gyro.getAnalogInput());
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/AnalogPotentiometerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/AnalogPotentiometerTest.java
@@ -1,0 +1,104 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.simulation.AnalogInputSim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import org.junit.jupiter.api.Test;
+
+public class AnalogPotentiometerTest {
+  @Test
+  void testInitializeWithAnalogInput() {
+    HAL.initialize(500, 0);
+
+    try (AnalogInput ai = new AnalogInput(0);
+        AnalogPotentiometer pot = new AnalogPotentiometer(ai)) {
+      AnalogInputSim sim = new AnalogInputSim(ai);
+
+      RoboRioSim.resetData();
+      sim.setVoltage(4.0);
+      assertEquals(0.8, pot.get());
+    }
+  }
+
+  @Test
+  void testInitializeWithAnalogInputAndScale() {
+    HAL.initialize(500, 0);
+
+    try (AnalogInput ai = new AnalogInput(0);
+        AnalogPotentiometer pot = new AnalogPotentiometer(ai, 270.0)) {
+      RoboRioSim.resetData();
+      AnalogInputSim sim = new AnalogInputSim(ai);
+
+      sim.setVoltage(5.0);
+      assertEquals(270.0, pot.get());
+
+      sim.setVoltage(2.5);
+      assertEquals(135, pot.get());
+
+      sim.setVoltage(0.0);
+      assertEquals(0.0, pot.get());
+    }
+  }
+
+  @Test
+  void testInitializeWithChannel() {
+    HAL.initialize(500, 0);
+
+    try (AnalogPotentiometer pot = new AnalogPotentiometer(1)) {
+      RoboRioSim.resetData();
+      AnalogInputSim sim = new AnalogInputSim(1);
+
+      sim.setVoltage(5.0);
+      assertEquals(1.0, pot.get());
+    }
+  }
+
+  @Test
+  void testInitializeWithChannelAndScale() {
+    HAL.initialize(500, 0);
+
+    try (AnalogPotentiometer pot = new AnalogPotentiometer(1, 180.0)) {
+      RoboRioSim.resetData();
+      AnalogInputSim sim = new AnalogInputSim(1);
+
+      sim.setVoltage(5.0);
+      assertEquals(180.0, pot.get());
+
+      sim.setVoltage(0.0);
+      assertEquals(0.0, pot.get());
+    }
+  }
+
+  @Test
+  void testWithModifiedBatteryVoltage() {
+    try (AnalogPotentiometer pot = new AnalogPotentiometer(1, 180.0, 90.0)) {
+      RoboRioSim.resetData();
+      AnalogInputSim sim = new AnalogInputSim(1);
+
+      // Test at 5v
+      sim.setVoltage(5.0);
+      assertEquals(270, pot.get());
+
+      sim.setVoltage(0.0);
+      assertEquals(90, pot.get());
+
+      // Simulate a lower battery voltage
+      RoboRioSim.setUserVoltage5V(2.5);
+
+      sim.setVoltage(2.5);
+      assertEquals(270, pot.get());
+
+      sim.setVoltage(2.0);
+      assertEquals(234, pot.get());
+
+      sim.setVoltage(0.0);
+      assertEquals(90, pot.get());
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/DigitalOutputTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/DigitalOutputTest.java
@@ -1,0 +1,47 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.simulation.DIOSim;
+import org.junit.jupiter.api.Test;
+
+public class DigitalOutputTest {
+  @Test
+  void testDefaultFunctions() {
+    try (DigitalOutput output = new DigitalOutput(0)) {
+      assertFalse(output.isAnalogTrigger());
+      assertEquals(0, output.getAnalogTriggerTypeForRouting());
+      assertFalse(output.isPulsing());
+    }
+  }
+
+  @Test
+  void testPwmFunctionsWithoutInitialization() {
+    HAL.initialize(500, 0);
+
+    try (DigitalOutput output = new DigitalOutput(0)) {
+      assertDoesNotThrow(() -> output.updateDutyCycle(0.6));
+      assertDoesNotThrow(output::disablePWM);
+    }
+  }
+
+  @Test
+  void testPwmFunctionsWithInitialization() {
+    HAL.initialize(500, 0);
+
+    try (DigitalOutput output = new DigitalOutput(0)) {
+      DIOSim sim = new DIOSim(output);
+      assertEquals(0, sim.getPulseLength());
+
+      output.enablePWM(0.5);
+      output.updateDutyCycle(0.6);
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/DoubleSolenoidTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/DoubleSolenoidTest.java
@@ -1,0 +1,90 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import edu.wpi.first.hal.util.AllocationException;
+import org.junit.jupiter.api.Test;
+
+public class DoubleSolenoidTest {
+  @Test
+  void testValidInitialization() {
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(3);
+        DoubleSolenoid solenoid = new DoubleSolenoid(pcm, 2, 3)) {
+      solenoid.set(DoubleSolenoid.Value.kReverse);
+      assertEquals(DoubleSolenoid.Value.kReverse, solenoid.get());
+
+      solenoid.set(DoubleSolenoid.Value.kForward);
+      assertEquals(DoubleSolenoid.Value.kForward, solenoid.get());
+
+      solenoid.set(DoubleSolenoid.Value.kOff);
+      assertEquals(DoubleSolenoid.Value.kOff, solenoid.get());
+    }
+  }
+
+  @Test
+  void testThrowForwardPortAlreadyInitialized() {
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(5);
+        // Single solenoid that is reused for forward port
+        Solenoid solenoid = new Solenoid(pcm, 2)) {
+      assertThrows(AllocationException.class, () -> new DoubleSolenoid(pcm, 2, 3));
+    }
+  }
+
+  @Test
+  void testThrowReversePortAlreadyInitialized() {
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(6);
+        // Single solenoid that is reused for forward port
+        Solenoid solenoid = new Solenoid(pcm, 3)) {
+      assertThrows(AllocationException.class, () -> new DoubleSolenoid(pcm, 2, 3));
+    }
+  }
+
+  @Test
+  void testThrowBothPortsAlreadyInitialized() {
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(6);
+        // Single solenoid that is reused for forward port
+        Solenoid solenoid0 = new Solenoid(pcm, 2);
+        Solenoid solenoid1 = new Solenoid(pcm, 3)) {
+      assertThrows(AllocationException.class, () -> new DoubleSolenoid(pcm, 2, 3));
+    }
+  }
+
+  @Test
+  void testToggle() {
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(4);
+        DoubleSolenoid solenoid = new DoubleSolenoid(pcm, 2, 3)) {
+      // Bootstrap it into reverse
+      solenoid.set(DoubleSolenoid.Value.kReverse);
+
+      solenoid.toggle();
+      assertEquals(DoubleSolenoid.Value.kForward, solenoid.get());
+
+      solenoid.toggle();
+      assertEquals(DoubleSolenoid.Value.kReverse, solenoid.get());
+
+      // Of shouldn't do anything on toggle
+      solenoid.set(DoubleSolenoid.Value.kOff);
+      solenoid.toggle();
+      assertEquals(DoubleSolenoid.Value.kOff, solenoid.get());
+    }
+  }
+
+  @Test
+  void testInvalidForwardPort() {
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(0)) {
+      assertThrows(IllegalArgumentException.class, () -> new DoubleSolenoid(pcm, 100, 1));
+    }
+  }
+
+  @Test
+  void testInvalidReversePort() {
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(0)) {
+      assertThrows(IllegalArgumentException.class, () -> new DoubleSolenoid(pcm, 0, 100));
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/JoystickTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/JoystickTest.java
@@ -5,6 +5,8 @@
 package edu.wpi.first.wpilibj;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.wpilibj.simulation.JoystickSim;
@@ -39,5 +41,133 @@ class JoystickTest {
     joysim.setY(0);
     joysim.notifyNewData();
     assertEquals(0.0, joy.getY(), 0.001);
+  }
+
+  @Test
+  void testGetZ() {
+    HAL.initialize(500, 0);
+    Joystick joy = new Joystick(1);
+    JoystickSim joysim = new JoystickSim(joy);
+
+    joysim.setZ(0.25);
+    joysim.notifyNewData();
+    assertEquals(0.25, joy.getZ(), 0.001);
+
+    joysim.setZ(0);
+    joysim.notifyNewData();
+    assertEquals(0.0, joy.getZ(), 0.001);
+  }
+
+  @Test
+  void testGetTwist() {
+    HAL.initialize(500, 0);
+    Joystick joy = new Joystick(1);
+    JoystickSim joysim = new JoystickSim(joy);
+
+    joysim.setTwist(0.25);
+    joysim.notifyNewData();
+    assertEquals(0.25, joy.getTwist(), 0.001);
+
+    joysim.setTwist(0);
+    joysim.notifyNewData();
+    assertEquals(0.0, joy.getTwist(), 0.001);
+  }
+
+  @Test
+  void testGetThrottle() {
+    HAL.initialize(500, 0);
+    Joystick joy = new Joystick(1);
+    JoystickSim joysim = new JoystickSim(joy);
+
+    joysim.setThrottle(0.25);
+    joysim.notifyNewData();
+    assertEquals(0.25, joy.getThrottle(), 0.001);
+
+    joysim.setThrottle(0);
+    joysim.notifyNewData();
+    assertEquals(0.0, joy.getThrottle(), 0.001);
+  }
+
+  @Test
+  void testGetTrigger() {
+    HAL.initialize(500, 0);
+    Joystick joy = new Joystick(1);
+    JoystickSim joysim = new JoystickSim(joy);
+
+    joysim.setTrigger(true);
+    joysim.notifyNewData();
+    assertTrue(joy.getTrigger());
+
+    joysim.setTrigger(false);
+    joysim.notifyNewData();
+    assertFalse(joy.getTrigger());
+  }
+
+  @Test
+  void testGetTop() {
+    HAL.initialize(500, 0);
+    Joystick joy = new Joystick(1);
+    JoystickSim joysim = new JoystickSim(joy);
+
+    joysim.setTop(true);
+    joysim.notifyNewData();
+    assertTrue(joy.getTop());
+
+    joysim.setTop(false);
+    joysim.notifyNewData();
+    assertFalse(joy.getTop());
+  }
+
+  @Test
+  void testGetMagnitude() {
+    HAL.initialize(500, 0);
+    Joystick joy = new Joystick(1);
+    JoystickSim joysim = new JoystickSim(joy);
+
+    // X Only
+    joysim.setX(0.5);
+    joysim.setY(0.0);
+    joysim.notifyNewData();
+    assertEquals(0.5, joy.getMagnitude(), 0.001);
+
+    // Y Only
+    joysim.setX(0.0);
+    joysim.setY(-0.5);
+    joysim.notifyNewData();
+    assertEquals(0.5, joy.getMagnitude(), 0.001);
+
+    // Both
+    joysim.setX(0.5);
+    joysim.setY(-0.5);
+    joysim.notifyNewData();
+    assertEquals(0.70710678118, joy.getMagnitude(), 0.001);
+  }
+
+  @Test
+  void testGetDirection() {
+    HAL.initialize(500, 0);
+    Joystick joy = new Joystick(1);
+    JoystickSim joysim = new JoystickSim(joy);
+
+    // X Only
+    joysim.setX(0.5);
+    joysim.setY(0.0);
+    joysim.notifyNewData();
+    assertEquals(90, joy.getDirectionDegrees(), 0.001);
+    assertEquals(Math.toRadians(90), joy.getDirectionRadians(), 0.001);
+
+    // Y Only
+    joysim.setX(0.0);
+    joysim.setY(-0.5);
+    joysim.notifyNewData();
+    assertEquals(0, joy.getDirectionDegrees(), 0.001);
+    assertEquals(Math.toRadians(0), joy.getDirectionRadians(), 0.001);
+
+    // Both
+    joysim.setX(0.5);
+    joysim.setY(-0.5);
+    joysim.notifyNewData();
+    assertEquals(45, joy.getDirectionDegrees(), 0.001);
+    assertEquals(Math.toRadians(45), joy.getDirectionRadians(), 0.001);
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/SensorUtilTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/SensorUtilTest.java
@@ -1,0 +1,42 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class SensorUtilTest {
+  @Test
+  void checkAnalogInputChannel() {
+    assertThrows(IllegalArgumentException.class, () -> SensorUtil.checkAnalogInputChannel(100));
+  }
+
+  @Test
+  void checkAnalogOutputChannel() {
+    assertThrows(IllegalArgumentException.class, () -> SensorUtil.checkAnalogOutputChannel(100));
+  }
+
+  @Test
+  void testInvalidDigitalChannel() {
+    assertThrows(IllegalArgumentException.class, () -> SensorUtil.checkDigitalChannel(100));
+  }
+
+  @Test
+  void testInvalidPwmChannel() {
+    assertThrows(IllegalArgumentException.class, () -> SensorUtil.checkPWMChannel(100));
+  }
+
+  @Test
+  void testInvalidRelayModule() {
+    assertThrows(IllegalArgumentException.class, () -> SensorUtil.checkRelayChannel(100));
+  }
+
+  @Test
+  void testgetDefaultCtrePcmModule() {
+    assertEquals(0, SensorUtil.getDefaultCTREPCMModule());
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/SolenoidTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/SolenoidTest.java
@@ -1,0 +1,67 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.util.AllocationException;
+import org.junit.jupiter.api.Test;
+
+public class SolenoidTest {
+  @Test
+  void testValidInitialization() {
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(3);
+        Solenoid solenoid = new Solenoid(pcm, 2)) {
+      assertEquals(2, solenoid.getChannel());
+
+      solenoid.set(true);
+      assertTrue(solenoid.get());
+
+      solenoid.set(false);
+      assertFalse(solenoid.get());
+    }
+  }
+
+  @Test
+  void testDoubleInitialization() {
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(3);
+        Solenoid solenoid = new Solenoid(pcm, 2)) {
+      assertThrows(AllocationException.class, () -> new Solenoid(pcm, 2));
+    }
+  }
+
+  @Test
+  void testDoubleInitializationFromDoubleSolenoid() {
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(3);
+        DoubleSolenoid solenoid = new DoubleSolenoid(pcm, 2, 3)) {
+      assertThrows(AllocationException.class, () -> new Solenoid(pcm, 2));
+    }
+  }
+
+  @Test
+  void testInvalidChannel() {
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(3)) {
+      assertThrows(IllegalArgumentException.class, () -> new Solenoid(pcm, 100));
+    }
+  }
+
+  @Test
+  void testToggle() {
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(3);
+        Solenoid solenoid = new Solenoid(pcm, 2)) {
+      solenoid.set(true);
+      assertTrue(solenoid.get());
+
+      solenoid.toggle();
+      assertFalse(solenoid.get());
+
+      solenoid.toggle();
+      assertTrue(solenoid.get());
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ADXRS450_GyroSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ADXRS450_GyroSimTest.java
@@ -1,0 +1,35 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.ADXRS450_Gyro;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings({"TypeName"})
+class ADXRS450_GyroSimTest {
+  @Test
+  void testCallbacks() {
+    HAL.initialize(500, 0);
+
+    try (ADXRS450_Gyro gyro = new ADXRS450_Gyro()) {
+      ADXRS450_GyroSim sim = new ADXRS450_GyroSim(gyro);
+
+      assertEquals(0, gyro.getAngle());
+      assertEquals(0, gyro.getRate());
+
+      sim.setAngle(123.456);
+      sim.setRate(229.3504);
+
+      assertEquals(123.456, gyro.getAngle());
+      assertEquals(229.3504, gyro.getRate());
+
+      gyro.reset();
+      assertEquals(0, gyro.getAngle());
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AccelerometerSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AccelerometerSimTest.java
@@ -4,38 +4,139 @@
 
 package edu.wpi.first.wpilibj.simulation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import edu.wpi.first.hal.AccelerometerJNI;
 import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.BuiltInAccelerometer;
+import edu.wpi.first.wpilibj.interfaces.Accelerometer;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.EnumCallback;
 import org.junit.jupiter.api.Test;
 
 class AccelerometerSimTest {
-  static class TriggeredStore {
-    public boolean m_wasTriggered;
-    public boolean m_setValue = true;
-  }
-
   @Test
   void testCallbacks() {
     HAL.initialize(500, 0);
     BuiltInAccelerometerSim sim = new BuiltInAccelerometerSim();
     sim.resetData();
 
-    TriggeredStore store = new TriggeredStore();
+    BooleanCallback store = new BooleanCallback();
 
-    try (CallbackStore cb =
-        sim.registerActiveCallback(
-            (s, v) -> {
-              store.m_wasTriggered = true;
-              store.m_setValue = v.getBoolean();
-            },
-            false)) {
-      assertFalse(store.m_wasTriggered);
-      AccelerometerJNI.setAccelerometerActive(true);
-      assertTrue(store.m_wasTriggered);
-      assertTrue(store.m_setValue);
+    try (CallbackStore cb = sim.registerActiveCallback(store, false)) {
+      assertFalse(store.wasTriggered());
+      sim.setActive(true);
+      assertTrue(sim.getActive());
+      assertTrue(store.wasTriggered());
+      assertTrue(store.getSetValue());
+    }
+  }
+
+  @Test
+  void testX() {
+    HAL.initialize(500, 0);
+    BuiltInAccelerometerSim sim = new BuiltInAccelerometerSim();
+    sim.resetData();
+
+    DoubleCallback callback = new DoubleCallback();
+    final double kTestValue = 1.91;
+
+    try (BuiltInAccelerometer accel = new BuiltInAccelerometer();
+        CallbackStore cb = sim.registerXCallback(callback, false)) {
+      sim.setX(kTestValue);
+      assertEquals(kTestValue, accel.getX());
+      assertEquals(kTestValue, sim.getX());
+      assertTrue(callback.wasTriggered());
+      assertEquals(kTestValue, callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testY() {
+    HAL.initialize(500, 0);
+    BuiltInAccelerometerSim sim = new BuiltInAccelerometerSim();
+    sim.resetData();
+
+    DoubleCallback callback = new DoubleCallback();
+    final double kTestValue = 2.29;
+
+    try (BuiltInAccelerometer accel = new BuiltInAccelerometer();
+        CallbackStore cb = sim.registerYCallback(callback, false)) {
+      sim.setY(kTestValue);
+      assertEquals(kTestValue, accel.getY());
+      assertEquals(kTestValue, sim.getY());
+      assertTrue(callback.wasTriggered());
+      assertEquals(kTestValue, callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testZ() {
+    HAL.initialize(500, 0);
+
+    BuiltInAccelerometerSim sim = new BuiltInAccelerometerSim();
+    sim.resetData();
+
+    DoubleCallback callback = new DoubleCallback();
+    final double kTestValue = 3.405;
+
+    try (BuiltInAccelerometer accel = new BuiltInAccelerometer();
+        CallbackStore cb = sim.registerZCallback(callback, false)) {
+      sim.setZ(kTestValue);
+      assertEquals(kTestValue, accel.getZ());
+      assertEquals(kTestValue, sim.getZ());
+      assertTrue(callback.wasTriggered());
+      assertEquals(kTestValue, callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testRange() {
+    HAL.initialize(500, 0);
+
+    BuiltInAccelerometerSim sim = new BuiltInAccelerometerSim();
+    sim.resetData();
+
+    EnumCallback callback = new EnumCallback();
+
+    Accelerometer.Range range = Accelerometer.Range.k4G;
+    try (CallbackStore cb = sim.registerRangeCallback(callback, false);
+        BuiltInAccelerometer accel = new BuiltInAccelerometer(range)) {
+      assertTrue(callback.wasTriggered());
+      assertEquals(range.ordinal(), sim.getRange());
+      assertEquals(range.ordinal(), callback.getSetValue());
+
+      // 2G
+      callback.reset();
+      range = Accelerometer.Range.k2G;
+      accel.setRange(range);
+      assertTrue(callback.wasTriggered());
+      assertEquals(range.ordinal(), sim.getRange());
+      assertEquals(range.ordinal(), callback.getSetValue());
+
+      // 4G
+      callback.reset();
+      range = Accelerometer.Range.k4G;
+      accel.setRange(range);
+      assertTrue(callback.wasTriggered());
+      assertEquals(range.ordinal(), sim.getRange());
+      assertEquals(range.ordinal(), callback.getSetValue());
+
+      // 8G
+      callback.reset();
+      range = Accelerometer.Range.k8G;
+      accel.setRange(range);
+      assertTrue(callback.wasTriggered());
+      assertEquals(range.ordinal(), sim.getRange());
+      assertEquals(range.ordinal(), callback.getSetValue());
+
+      // 16G - Not supported
+      callback.reset();
+      assertThrows(IllegalArgumentException.class, () -> accel.setRange(Accelerometer.Range.k16G));
+      assertFalse(callback.wasTriggered());
     }
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AddressableLEDSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AddressableLEDSimTest.java
@@ -1,0 +1,133 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.AddressableLED;
+import edu.wpi.first.wpilibj.AddressableLEDBuffer;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.BufferCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.IntCallback;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+class AddressableLEDSimTest {
+  @Test
+  void testInitialization() {
+    HAL.initialize(500, 0);
+    AddressableLEDSim sim = new AddressableLEDSim();
+    assertFalse(sim.getInitialized());
+
+    BooleanCallback initializedCallback = new BooleanCallback();
+
+    try (CallbackStore cb = sim.registerInitializedCallback(initializedCallback, false);
+        AddressableLED led = new AddressableLED(0)) {
+      assertTrue(sim.getInitialized());
+      assertTrue(initializedCallback.wasTriggered());
+      assertTrue(initializedCallback.getSetValue());
+    }
+  }
+
+  @Test
+  void testLength() {
+    AddressableLEDSim sim = new AddressableLEDSim();
+    IntCallback callback = new IntCallback();
+    try (CallbackStore cb = sim.registerLengthCallback(callback, false);
+        AddressableLED led = new AddressableLED(0)) {
+      assertEquals(1, sim.getLength()); // Defaults to 1 led
+
+      AddressableLEDBuffer ledData = new AddressableLEDBuffer(50);
+      led.setLength(ledData.getLength());
+      led.setData(ledData);
+
+      assertEquals(50, sim.getLength());
+      assertTrue(callback.wasTriggered());
+      assertEquals(50, callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testSetRunning() {
+    AddressableLEDSim sim = AddressableLEDSim.createForIndex(0);
+    BooleanCallback callback = new BooleanCallback();
+    try (CallbackStore cb = sim.registerRunningCallback(callback, false);
+        AddressableLED led = new AddressableLED(0)) {
+      assertFalse(sim.getRunning());
+
+      led.start();
+      assertTrue(sim.getRunning());
+      assertTrue(callback.wasTriggered());
+      assertTrue(callback.getSetValue());
+
+      callback.reset();
+      led.stop();
+      assertFalse(sim.getRunning());
+      assertTrue(callback.wasTriggered());
+      assertFalse(callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testSetData() {
+    AddressableLEDSim sim = new AddressableLEDSim();
+    BufferCallback callback = new BufferCallback();
+
+    try (AddressableLED led = new AddressableLED(0);
+        CallbackStore cb = sim.registerDataCallback(callback); ) {
+      assertFalse(sim.getRunning());
+
+      assertEquals(1, sim.getLength()); // Defaults to 1 led
+
+      AddressableLEDBuffer ledData = new AddressableLEDBuffer(3);
+      led.setLength(ledData.getLength());
+
+      ledData.setRGB(0, 255, 0, 0);
+      ledData.setRGB(1, 0, 255, 0);
+      ledData.setRGB(2, 0, 0, 255);
+      led.setData(ledData);
+
+      byte[] data = sim.getData();
+      System.out.println(Arrays.toString(data));
+      assertEquals(12, data.length);
+
+      assertEquals((byte) 0, data[0]);
+      assertEquals((byte) 0, data[1]);
+      assertEquals((byte) 255, data[2]);
+      assertEquals((byte) 0, data[3]);
+
+      assertEquals((byte) 0, data[4]);
+      assertEquals((byte) 255, data[5]);
+      assertEquals((byte) 0, data[6]);
+      assertEquals((byte) 0, data[7]);
+
+      assertEquals((byte) 255, data[8]);
+      assertEquals((byte) 0, data[9]);
+      assertEquals((byte) 0, data[10]);
+      assertEquals((byte) 0, data[11]);
+
+      assertTrue(callback.wasTriggered());
+      data = callback.getSetValue();
+
+      assertEquals((byte) 0, data[0]);
+      assertEquals((byte) 0, data[1]);
+      assertEquals((byte) 255, data[2]);
+      assertEquals((byte) 0, data[3]);
+
+      assertEquals((byte) 0, data[4]);
+      assertEquals((byte) 255, data[5]);
+      assertEquals((byte) 0, data[6]);
+      assertEquals((byte) 0, data[7]);
+
+      assertEquals((byte) 255, data[8]);
+      assertEquals((byte) 0, data[9]);
+      assertEquals((byte) 0, data[10]);
+      assertEquals((byte) 0, data[11]);
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AnalogEncoderSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AnalogEncoderSimTest.java
@@ -14,13 +14,14 @@ import org.junit.jupiter.api.Test;
 public class AnalogEncoderSimTest {
   @Test
   public void testBasic() {
-    var analogInput = new AnalogInput(0);
-    var analogEncoder = new AnalogEncoder(analogInput);
-    var encoderSim = new AnalogEncoderSim(analogEncoder);
+    try (var analogInput = new AnalogInput(0);
+        var analogEncoder = new AnalogEncoder(analogInput)) {
+      var encoderSim = new AnalogEncoderSim(analogEncoder);
 
-    encoderSim.setPosition(Rotation2d.fromDegrees(180));
-    assertEquals(analogEncoder.get(), 0.5, 1E-8);
-    assertEquals(encoderSim.getTurns(), 0.5, 1E-8);
-    assertEquals(encoderSim.getPosition().getRadians(), Math.PI, 1E-8);
+      encoderSim.setPosition(Rotation2d.fromDegrees(180));
+      assertEquals(analogEncoder.get(), 0.5, 1E-8);
+      assertEquals(encoderSim.getTurns(), 0.5, 1E-8);
+      assertEquals(encoderSim.getPosition().getRadians(), Math.PI, 1E-8);
+    }
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AnalogGyroSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AnalogGyroSimTest.java
@@ -1,0 +1,97 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.AnalogGyro;
+import edu.wpi.first.wpilibj.AnalogInput;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
+import org.junit.jupiter.api.Test;
+
+class AnalogGyroSimTest {
+  @Test
+  void testInitialization() {
+    HAL.initialize(500, 0);
+    AnalogGyroSim sim = new AnalogGyroSim(0);
+    assertFalse(sim.getInitialized());
+
+    BooleanCallback initializedCallback = new BooleanCallback();
+
+    try (CallbackStore cb = sim.registerInitializedCallback(initializedCallback, false);
+        AnalogInput ai = new AnalogInput(0);
+        AnalogGyro gyro = new AnalogGyro(ai)) {
+      assertTrue(sim.getInitialized());
+      assertTrue(initializedCallback.wasTriggered());
+      assertTrue(initializedCallback.getSetValue());
+    }
+  }
+
+  @Test
+  void testSetAngle() {
+    HAL.initialize(500, 0);
+
+    AnalogGyroSim sim = new AnalogGyroSim(0);
+    DoubleCallback callback = new DoubleCallback();
+
+    try (AnalogInput ai = new AnalogInput(0);
+        AnalogGyro gyro = new AnalogGyro(ai);
+        CallbackStore cb = sim.registerAngleCallback(callback, false)) {
+      assertEquals(0, gyro.getAngle());
+
+      final double TEST_ANGLE = 35.04;
+      sim.setAngle(TEST_ANGLE);
+      assertEquals(TEST_ANGLE, sim.getAngle());
+      assertEquals(TEST_ANGLE, gyro.getAngle());
+      assertEquals(-TEST_ANGLE, gyro.getRotation2d().getDegrees());
+      assertTrue(callback.wasTriggered());
+      assertEquals(TEST_ANGLE, callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testSetRate() {
+    HAL.initialize(500, 0);
+
+    AnalogGyroSim sim = new AnalogGyroSim(0);
+    DoubleCallback callback = new DoubleCallback();
+
+    try (AnalogInput ai = new AnalogInput(0);
+        AnalogGyro gyro = new AnalogGyro(ai);
+        CallbackStore cb = sim.registerRateCallback(callback, false)) {
+      assertEquals(0, gyro.getRate());
+
+      final double TEST_RATE = -19.1;
+      sim.setRate(TEST_RATE);
+      assertEquals(TEST_RATE, sim.getRate());
+      assertEquals(TEST_RATE, gyro.getRate());
+
+      assertTrue(callback.wasTriggered());
+      assertEquals(TEST_RATE, callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testReset() {
+    HAL.initialize(500, 0);
+
+    try (AnalogInput ai = new AnalogInput(0);
+        AnalogGyro gyro = new AnalogGyro(ai)) {
+      AnalogGyroSim sim = new AnalogGyroSim(gyro);
+      sim.setAngle(12.34);
+      sim.setRate(43.21);
+
+      sim.resetData();
+      assertEquals(0, sim.getAngle());
+      assertEquals(0, sim.getRate());
+      assertEquals(0, gyro.getAngle());
+      assertEquals(0, gyro.getRate());
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AnalogInputSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AnalogInputSimTest.java
@@ -4,35 +4,83 @@
 
 package edu.wpi.first.wpilibj.simulation;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import edu.wpi.first.hal.HAL;
+import edu.wpi.first.hal.util.AllocationException;
 import edu.wpi.first.wpilibj.AnalogInput;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
 import org.junit.jupiter.api.Test;
 
 class AnalogInputSimTest {
-  static class DoubleStore {
-    public boolean m_wasTriggered;
-    public boolean m_wasCorrectType;
-    public double m_setValue0;
+  @Test
+  void setInitializeTest() {
+    HAL.initialize(500, 0);
+
+    AnalogInputSim sim = new AnalogInputSim(5);
+    BooleanCallback callback = new BooleanCallback();
+
+    try (CallbackStore cb = sim.registerInitializedCallback(callback, false);
+        AnalogInput input = new AnalogInput(5)) {
+      assertTrue(callback.wasTriggered());
+      assertTrue(callback.getSetValue());
+    }
   }
 
   @Test
-  void setCallbackTest() {
+  void testSetVoltage() {
     HAL.initialize(500, 0);
 
-    try (AnalogInput input = new AnalogInput(5)) {
-      AnalogInputSim inputSim = new AnalogInputSim(input);
+    AnalogInputSim sim = new AnalogInputSim(5);
+    DoubleCallback callback = new DoubleCallback();
+
+    try (CallbackStore cb = sim.registerVoltageCallback(callback, false);
+        AnalogInput input = new AnalogInput(5)) {
+      // Bootstrap the voltage to be non-zero
+      sim.setVoltage(1.0);
 
       for (double i = 0; i < 5.0; i += 0.1) {
-        inputSim.setVoltage(0);
+        callback.reset();
 
+        sim.setVoltage(0);
         assertEquals(input.getVoltage(), 0, 0.001);
 
-        inputSim.setVoltage(i);
-
+        callback.reset();
+        sim.setVoltage(i);
         assertEquals(input.getVoltage(), i, 0.001);
       }
+    }
+  }
+
+  @Test
+  void testSetOverSampleBits() {
+    HAL.initialize(500, 0);
+    try (AnalogInput input = new AnalogInput(5)) {
+      input.setOversampleBits(3504);
+      assertEquals(3504, input.getOversampleBits());
+    }
+  }
+
+  @Test
+  void tesInitAccumulator() {
+    HAL.initialize(500, 0);
+    try (AnalogInput input = new AnalogInput(0)) {
+      // First initialization works fine
+      assertDoesNotThrow(input::initAccumulator);
+
+      input.resetAccumulator();
+    }
+  }
+
+  @Test
+  void tesInitAccumulatorOnInvalidPort() {
+    HAL.initialize(500, 0);
+    try (AnalogInput input = new AnalogInput(5)) {
+      assertThrows(AllocationException.class, input::initAccumulator);
     }
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AnalogOutputSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AnalogOutputSimTest.java
@@ -10,18 +10,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.wpilibj.AnalogOutput;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
 import org.junit.jupiter.api.Test;
 
 class AnalogOutputSimTest {
-  static class DoubleStore {
-    public boolean m_wasTriggered;
-    public boolean m_wasCorrectType;
-    public double m_setValue = -1;
+  @Test
+  void testInitialization() {
+    HAL.initialize(500, 0);
 
-    public void reset() {
-      m_wasCorrectType = false;
-      m_wasTriggered = false;
-      m_setValue = -1;
+    AnalogOutputSim outputSim = new AnalogOutputSim(0);
+    assertFalse(outputSim.getInitialized());
+
+    BooleanCallback callback = new BooleanCallback();
+
+    try (CallbackStore cb = outputSim.registerInitializedCallback(callback, false);
+        AnalogOutput output = new AnalogOutput(0)) {
+      assertTrue(outputSim.getInitialized());
     }
   }
 
@@ -34,34 +39,46 @@ class AnalogOutputSimTest {
 
       AnalogOutputSim outputSim = new AnalogOutputSim(output);
 
-      DoubleStore store = new DoubleStore();
+      DoubleCallback voltageCallback = new DoubleCallback();
 
-      try (CallbackStore cb =
-          outputSim.registerVoltageCallback(
-              (name, value) -> {
-                store.m_wasTriggered = true;
-                store.m_wasCorrectType = true;
-                store.m_setValue = value.getDouble();
-              },
-              false)) {
-        assertFalse(store.m_wasTriggered);
+      try (CallbackStore cb = outputSim.registerVoltageCallback(voltageCallback, false)) {
+        assertFalse(voltageCallback.wasTriggered());
 
         for (double i = 0.1; i < 5.0; i += 0.1) {
-          store.reset();
+          voltageCallback.reset();
 
           output.setVoltage(0);
 
-          assertTrue(store.m_wasTriggered);
-          assertEquals(store.m_setValue, 0, 0.001);
+          assertEquals(0, output.getVoltage());
+          assertEquals(0, outputSim.getVoltage());
+          assertTrue(voltageCallback.wasTriggered());
+          assertEquals(voltageCallback.getSetValue(), 0, 0.001);
 
-          store.reset();
+          voltageCallback.reset();
 
           output.setVoltage(i);
 
-          assertTrue(store.m_wasTriggered);
-          assertEquals(store.m_setValue, i, 0.001);
+          assertEquals(i, output.getVoltage());
+          assertEquals(i, outputSim.getVoltage());
+          assertTrue(voltageCallback.wasTriggered());
+          assertEquals(voltageCallback.getSetValue(), i, 0.001);
         }
       }
+    }
+  }
+
+  @Test
+  void testReset() {
+    HAL.initialize(500, 0);
+
+    AnalogOutputSim outputSim = new AnalogOutputSim(0);
+
+    try (AnalogOutput output = new AnalogOutput(0)) {
+      output.setVoltage(1.2);
+
+      outputSim.resetData();
+      assertEquals(0, output.getVoltage());
+      assertEquals(0, outputSim.getVoltage());
     }
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AnalogTriggerSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AnalogTriggerSimTest.java
@@ -1,0 +1,59 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.AnalogTrigger;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
+import org.junit.jupiter.api.Test;
+
+class AnalogTriggerSimTest {
+  @Test
+  void testInitialization() {
+    HAL.initialize(500, 0);
+
+    AnalogTriggerSim sim = AnalogTriggerSim.createForIndex(0);
+    sim.resetData();
+    assertFalse(sim.getInitialized());
+
+    BooleanCallback callback = new BooleanCallback();
+
+    try (CallbackStore cb = sim.registerInitializedCallback(callback, false);
+        AnalogTrigger trigger = new AnalogTrigger(0)) {
+      assertTrue(sim.getInitialized());
+      assertTrue(callback.wasTriggered());
+      assertTrue(callback.getSetValue());
+    }
+  }
+
+  @Test
+  void triggerLowerBoundTest() {
+    HAL.initialize(500, 0);
+
+    try (AnalogTrigger trigger = new AnalogTrigger(0)) {
+      AnalogTriggerSim sim = new AnalogTriggerSim(trigger);
+      DoubleCallback lowerCallback = new DoubleCallback();
+      DoubleCallback upperCallback = new DoubleCallback();
+      try (CallbackStore lowerCb = sim.registerTriggerLowerBoundCallback(lowerCallback, false);
+          CallbackStore upperCb = sim.registerTriggerUpperBoundCallback(upperCallback, false)) {
+        trigger.setLimitsVoltage(0.299, 1.91);
+
+        assertEquals(0.299, sim.getTriggerLowerBound());
+        assertEquals(1.91, sim.getTriggerUpperBound());
+
+        assertTrue(lowerCallback.wasTriggered());
+        assertEquals(0.299, lowerCallback.getSetValue());
+
+        assertTrue(upperCallback.wasTriggered());
+        assertEquals(1.91, upperCallback.getSetValue());
+      }
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/CTREPCMSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/CTREPCMSimTest.java
@@ -1,0 +1,163 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.DoubleSolenoid;
+import edu.wpi.first.wpilibj.PneumaticsControlModule;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("AbbreviationAsWordInName")
+class CTREPCMSimTest {
+  @Test
+  void testInitialization() {
+    HAL.initialize(500, 0);
+
+    CTREPCMSim sim = new CTREPCMSim(0);
+    sim.resetData();
+    assertFalse(sim.getInitialized());
+
+    BooleanCallback callback = new BooleanCallback();
+
+    try (CallbackStore cb = sim.registerInitializedCallback(callback, false);
+        PneumaticsControlModule pcm = new PneumaticsControlModule(0)) {
+      assertTrue(sim.getInitialized());
+    }
+  }
+
+  @Test
+  void solenoidOutputTest() {
+    HAL.initialize(500, 0);
+
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(0);
+        DoubleSolenoid doubleSolenoid = new DoubleSolenoid(pcm, 3, 4)) {
+      CTREPCMSim sim = new CTREPCMSim(pcm);
+      sim.resetData();
+
+      BooleanCallback callback3 = new BooleanCallback();
+      BooleanCallback callback4 = new BooleanCallback();
+
+      try (CallbackStore cb3 = sim.registerSolenoidOutputCallback(3, callback3, false);
+          CallbackStore cb4 = sim.registerSolenoidOutputCallback(4, callback4, false)) {
+        // Reverse
+        callback3.reset();
+        callback4.reset();
+        doubleSolenoid.set(DoubleSolenoid.Value.kReverse);
+        assertFalse(callback3.wasTriggered());
+        assertNull(callback3.getSetValue());
+        assertTrue(callback4.wasTriggered());
+        assertTrue(callback4.getSetValue());
+        assertFalse(sim.getSolenoidOutput(3));
+        assertTrue(sim.getSolenoidOutput(4));
+        assertEquals(0x10, pcm.getSolenoids());
+
+        // Forward
+        callback3.reset();
+        callback4.reset();
+        doubleSolenoid.set(DoubleSolenoid.Value.kForward);
+        assertTrue(callback3.wasTriggered());
+        assertTrue(callback3.getSetValue());
+        assertTrue(callback4.wasTriggered());
+        assertFalse(callback4.getSetValue());
+        assertTrue(sim.getSolenoidOutput(3));
+        assertFalse(sim.getSolenoidOutput(4));
+        assertEquals(0x8, pcm.getSolenoids());
+
+        // Off
+        callback3.reset();
+        callback4.reset();
+        doubleSolenoid.set(DoubleSolenoid.Value.kForward);
+        assertFalse(callback3.wasTriggered());
+        assertNull(callback3.getSetValue());
+        assertFalse(callback4.wasTriggered());
+        assertNull(callback4.getSetValue());
+      }
+    }
+  }
+
+  @Test
+  void setCompressorOnTest() {
+    HAL.initialize(500, 0);
+
+    CTREPCMSim sim = new CTREPCMSim(0);
+    BooleanCallback callback = new BooleanCallback();
+
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(0);
+        CallbackStore cb = sim.registerCompressorOnCallback(callback, false)) {
+      assertFalse(pcm.getCompressor());
+      assertFalse(sim.getCompressorOn());
+      sim.setCompressorOn(true);
+      assertTrue(pcm.getCompressor());
+      assertTrue(sim.getCompressorOn());
+      assertTrue(callback.wasTriggered());
+      assertTrue(callback.getSetValue());
+    }
+  }
+
+  @Test
+  void setClosedLoopEnabled() {
+    HAL.initialize(500, 0);
+
+    CTREPCMSim sim = new CTREPCMSim(0);
+    BooleanCallback callback = new BooleanCallback();
+
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(0);
+        CallbackStore cb = sim.registerClosedLoopEnabledCallback(callback, false)) {
+      pcm.setClosedLoopControl(false);
+      assertFalse(pcm.getClosedLoopControl());
+
+      pcm.setClosedLoopControl(true);
+      assertTrue(sim.getClosedLoopEnabled());
+      assertTrue(pcm.getClosedLoopControl());
+      assertTrue(callback.wasTriggered());
+      assertTrue(callback.getSetValue());
+    }
+  }
+
+  @Test
+  void setPressureSwitchEnabledTest() {
+    HAL.initialize(500, 0);
+
+    CTREPCMSim sim = new CTREPCMSim(0);
+    BooleanCallback callback = new BooleanCallback();
+
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(0);
+        CallbackStore cb = sim.registerPressureSwitchCallback(callback, false)) {
+      assertFalse(pcm.getPressureSwitch());
+
+      sim.setPressureSwitch(true);
+      assertTrue(sim.getPressureSwitch());
+      assertTrue(pcm.getPressureSwitch());
+      assertTrue(callback.wasTriggered());
+      assertTrue(callback.getSetValue());
+    }
+  }
+
+  @Test
+  void setCompressorCurrentTest() {
+    HAL.initialize(500, 0);
+
+    CTREPCMSim sim = new CTREPCMSim(0);
+    DoubleCallback callback = new DoubleCallback();
+
+    try (PneumaticsControlModule pcm = new PneumaticsControlModule(0);
+        CallbackStore cb = sim.registerCompressorCurrentCallback(callback, false)) {
+      assertFalse(pcm.getPressureSwitch());
+
+      sim.setCompressorCurrent(35.04);
+      assertEquals(35.04, sim.getCompressorCurrent());
+      assertEquals(35.04, pcm.getCompressorCurrent());
+      assertTrue(callback.wasTriggered());
+      assertEquals(35.04, callback.getSetValue());
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DIOSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DIOSimTest.java
@@ -1,0 +1,85 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.DigitalInput;
+import edu.wpi.first.wpilibj.DigitalOutput;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import org.junit.jupiter.api.Test;
+
+class DIOSimTest {
+  @Test
+  void testInitialization() {
+    DIOSim sim = new DIOSim(2);
+    assertFalse(sim.getInitialized());
+
+    BooleanCallback initializedCallback = new BooleanCallback();
+    BooleanCallback isInputCallback = new BooleanCallback();
+
+    try (CallbackStore initializeCb = sim.registerInitializedCallback(initializedCallback, false);
+        CallbackStore inputCb = sim.registerIsInputCallback(isInputCallback, false);
+        DigitalOutput output = new DigitalOutput(2)) {
+      assertTrue(sim.getInitialized());
+      assertTrue(initializedCallback.wasTriggered());
+      assertTrue(initializedCallback.getSetValue());
+
+      assertFalse(sim.getIsInput());
+      assertTrue(isInputCallback.wasTriggered());
+      assertFalse(isInputCallback.getSetValue());
+
+      initializedCallback.reset();
+      sim.setInitialized(false);
+      assertTrue(initializedCallback.wasTriggered());
+      assertFalse(initializedCallback.getSetValue());
+    }
+  }
+
+  @Test
+  void testInput() {
+    HAL.initialize(500, 0);
+
+    try (DigitalInput input = new DigitalInput(0)) {
+      DIOSim sim = new DIOSim(input);
+      assertTrue(sim.getIsInput());
+
+      BooleanCallback valueCallback = new BooleanCallback();
+
+      try (CallbackStore cb = sim.registerValueCallback(valueCallback, false)) {
+        assertTrue(input.get());
+        assertTrue(sim.getValue());
+
+        assertFalse(valueCallback.wasTriggered());
+        sim.setValue(false);
+        assertTrue(valueCallback.wasTriggered());
+        assertFalse(valueCallback.getSetValue());
+      }
+    }
+  }
+
+  @Test
+  void testOutput() {
+    HAL.initialize(500, 0);
+    try (DigitalOutput output = new DigitalOutput(0)) {
+      DIOSim sim = new DIOSim(output);
+      assertFalse(sim.getIsInput());
+
+      BooleanCallback valueCallback = new BooleanCallback();
+
+      try (CallbackStore cb = sim.registerValueCallback(valueCallback, false)) {
+        assertFalse(output.get());
+        assertFalse(sim.getValue());
+
+        assertFalse(valueCallback.wasTriggered());
+        output.set(true);
+        assertTrue(valueCallback.wasTriggered());
+        assertTrue(valueCallback.getSetValue());
+      }
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DigitalPWMSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DigitalPWMSimTest.java
@@ -1,0 +1,58 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.DigitalOutput;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.IntCallback;
+import org.junit.jupiter.api.Test;
+
+class DigitalPWMSimTest {
+  @Test
+  void testInitialization() {
+    try (DigitalOutput output = new DigitalOutput(0)) {
+      DigitalPWMSim sim = new DigitalPWMSim(output);
+      assertFalse(sim.getInitialized());
+
+      BooleanCallback initializeCallback = new BooleanCallback();
+      DoubleCallback dutyCycleCallback = new DoubleCallback();
+      try (CallbackStore initCb = sim.registerInitializedCallback(initializeCallback, false);
+          CallbackStore dutyCycleCb = sim.registerDutyCycleCallback(dutyCycleCallback, false); ) {
+        final double kTestDutyCycle = 0.191;
+        output.enablePWM(kTestDutyCycle);
+
+        assertTrue(sim.getInitialized());
+        assertTrue(initializeCallback.wasTriggered());
+        assertTrue(initializeCallback.getSetValue());
+
+        assertEquals(kTestDutyCycle, sim.getDutyCycle());
+        assertTrue(dutyCycleCallback.wasTriggered());
+        assertEquals(kTestDutyCycle, dutyCycleCallback.getSetValue());
+      }
+    }
+  }
+
+  @Test
+  void setPinTest() {
+    HAL.initialize(500, 0);
+
+    try (DigitalOutput output = new DigitalOutput(0)) {
+      DigitalPWMSim sim = new DigitalPWMSim(output);
+      IntCallback callback = new IntCallback();
+      try (CallbackStore cb = sim.registerPinCallback(callback, false)) {
+        sim.setPin(191);
+        assertEquals(191, sim.getPin());
+        assertTrue(callback.wasTriggered());
+        assertEquals(191, callback.getSetValue());
+      }
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DriverStationSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DriverStationSimTest.java
@@ -1,0 +1,261 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.AllianceStationID;
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.EnumCallback;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class DriverStationSimTest {
+  @Test
+  void testEnabled() {
+    HAL.initialize(500, 0);
+    DriverStationSim.resetData();
+
+    assertFalse(DriverStation.isEnabled());
+    BooleanCallback callback = new BooleanCallback();
+    try (CallbackStore cb = DriverStationSim.registerEnabledCallback(callback, false)) {
+      DriverStationSim.setEnabled(true);
+      DriverStationSim.notifyNewData();
+      assertTrue(DriverStationSim.getEnabled());
+      assertTrue(DriverStation.isEnabled());
+      assertTrue(callback.wasTriggered());
+      assertTrue(callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testAutonomus() {
+    HAL.initialize(500, 0);
+    DriverStationSim.resetData();
+
+    assertFalse(DriverStation.isAutonomous());
+    BooleanCallback callback = new BooleanCallback();
+    try (CallbackStore cb = DriverStationSim.registerAutonomousCallback(callback, false)) {
+      DriverStationSim.setAutonomous(true);
+      DriverStationSim.notifyNewData();
+      assertTrue(DriverStationSim.getAutonomous());
+      assertTrue(DriverStation.isAutonomous());
+      assertTrue(callback.wasTriggered());
+      assertTrue(callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testTest() {
+    HAL.initialize(500, 0);
+    DriverStationSim.resetData();
+
+    assertFalse(DriverStation.isTest());
+    BooleanCallback callback = new BooleanCallback();
+    try (CallbackStore cb = DriverStationSim.registerTestCallback(callback, false)) {
+      DriverStationSim.setTest(true);
+      DriverStationSim.notifyNewData();
+      assertTrue(DriverStationSim.getTest());
+      assertTrue(DriverStation.isTest());
+      assertTrue(callback.wasTriggered());
+      assertTrue(callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testEstop() {
+    HAL.initialize(500, 0);
+    DriverStationSim.resetData();
+
+    assertFalse(DriverStation.isEStopped());
+    BooleanCallback callback = new BooleanCallback();
+    try (CallbackStore cb = DriverStationSim.registerEStopCallback(callback, false)) {
+      DriverStationSim.setEStop(true);
+      DriverStationSim.notifyNewData();
+      assertTrue(DriverStationSim.getEStop());
+      assertTrue(DriverStation.isEStopped());
+      assertTrue(callback.wasTriggered());
+      assertTrue(callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testFmsAttached() {
+    HAL.initialize(500, 0);
+    DriverStationSim.resetData();
+
+    assertFalse(DriverStation.isFMSAttached());
+    BooleanCallback callback = new BooleanCallback();
+    try (CallbackStore cb = DriverStationSim.registerFmsAttachedCallback(callback, false)) {
+      DriverStationSim.setFmsAttached(true);
+      DriverStationSim.notifyNewData();
+      assertTrue(DriverStationSim.getFmsAttached());
+      assertTrue(DriverStation.isFMSAttached());
+      assertTrue(callback.wasTriggered());
+      assertTrue(callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testDsAttached() {
+    HAL.initialize(500, 0);
+    DriverStationSim.resetData();
+
+    DriverStationSim.notifyNewData();
+    assertTrue(DriverStation.isDSAttached());
+
+    BooleanCallback callback = new BooleanCallback();
+    try (CallbackStore cb = DriverStationSim.registerDsAttachedCallback(callback, false)) {
+      DriverStationSim.setDsAttached(false);
+      DriverStationSim.notifyNewData();
+      assertFalse(DriverStationSim.getDsAttached());
+      assertFalse(DriverStation.isDSAttached());
+      assertTrue(callback.wasTriggered());
+      assertFalse(callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testAllianceStationId() {
+    HAL.initialize(500, 0);
+    DriverStationSim.resetData();
+
+    EnumCallback callback = new EnumCallback();
+
+    AllianceStationID allianceStation = AllianceStationID.Blue2;
+    DriverStationSim.setAllianceStationId(allianceStation);
+
+    try (CallbackStore cb = DriverStationSim.registerAllianceStationIdCallback(callback, false)) {
+      // B1
+      allianceStation = AllianceStationID.Blue1;
+      DriverStationSim.setAllianceStationId(allianceStation);
+      assertEquals(allianceStation, DriverStationSim.getAllianceStationId());
+      assertEquals(DriverStation.Alliance.Blue, DriverStation.getAlliance());
+      assertEquals(1, DriverStation.getLocation());
+      assertTrue(callback.wasTriggered());
+      assertEquals(allianceStation.ordinal(), callback.getSetValue());
+
+      // B2
+      allianceStation = AllianceStationID.Blue2;
+      DriverStationSim.setAllianceStationId(allianceStation);
+      assertEquals(allianceStation, DriverStationSim.getAllianceStationId());
+      assertEquals(DriverStation.Alliance.Blue, DriverStation.getAlliance());
+      assertEquals(2, DriverStation.getLocation());
+      assertTrue(callback.wasTriggered());
+      assertEquals(allianceStation.ordinal(), callback.getSetValue());
+
+      // B3
+      allianceStation = AllianceStationID.Blue3;
+      DriverStationSim.setAllianceStationId(allianceStation);
+      assertEquals(allianceStation, DriverStationSim.getAllianceStationId());
+      assertEquals(DriverStation.Alliance.Blue, DriverStation.getAlliance());
+      assertEquals(3, DriverStation.getLocation());
+      assertTrue(callback.wasTriggered());
+      assertEquals(allianceStation.ordinal(), callback.getSetValue());
+
+      // R1
+      allianceStation = AllianceStationID.Red1;
+      DriverStationSim.setAllianceStationId(allianceStation);
+      assertEquals(allianceStation, DriverStationSim.getAllianceStationId());
+      assertEquals(DriverStation.Alliance.Red, DriverStation.getAlliance());
+      assertEquals(1, DriverStation.getLocation());
+      assertTrue(callback.wasTriggered());
+      assertEquals(allianceStation.ordinal(), callback.getSetValue());
+
+      // R2
+      allianceStation = AllianceStationID.Red2;
+      DriverStationSim.setAllianceStationId(allianceStation);
+      assertEquals(allianceStation, DriverStationSim.getAllianceStationId());
+      assertEquals(DriverStation.Alliance.Red, DriverStation.getAlliance());
+      assertEquals(2, DriverStation.getLocation());
+      assertTrue(callback.wasTriggered());
+      assertEquals(allianceStation.ordinal(), callback.getSetValue());
+
+      // R3
+      allianceStation = AllianceStationID.Red3;
+      DriverStationSim.setAllianceStationId(allianceStation);
+      assertEquals(allianceStation, DriverStationSim.getAllianceStationId());
+      assertEquals(DriverStation.Alliance.Red, DriverStation.getAlliance());
+      assertEquals(3, DriverStation.getLocation());
+      assertTrue(callback.wasTriggered());
+      assertEquals(allianceStation.ordinal(), callback.getSetValue());
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(DriverStation.MatchType.class)
+  public void testMatchType(DriverStation.MatchType matchType) {
+    HAL.initialize(500, 0);
+    DriverStationSim.resetData();
+
+    DriverStationSim.setMatchType(matchType);
+    DriverStationSim.notifyNewData();
+    assertEquals(matchType, DriverStation.getMatchType());
+  }
+
+  @Test
+  public void testReplayNumber() {
+    HAL.initialize(500, 0);
+    DriverStationSim.resetData();
+
+    DriverStationSim.setReplayNumber(4);
+    DriverStationSim.notifyNewData();
+    assertEquals(4, DriverStation.getReplayNumber());
+  }
+
+  @Test
+  public void testMatchNumber() {
+    HAL.initialize(500, 0);
+    DriverStationSim.resetData();
+
+    DriverStationSim.setMatchNumber(3);
+    DriverStationSim.notifyNewData();
+    assertEquals(3, DriverStation.getMatchNumber());
+  }
+
+  @Test
+  public void testMatchTime() {
+    HAL.initialize(500, 0);
+    DriverStationSim.resetData();
+
+    DoubleCallback callback = new DoubleCallback();
+    try (CallbackStore cb = DriverStationSim.registerMatchTimeCallback(callback, false)) {
+      final double testTime = 19.174;
+      DriverStationSim.setMatchTime(testTime);
+      assertEquals(testTime, DriverStationSim.getMatchTime());
+      assertEquals(testTime, DriverStation.getMatchTime());
+      assertTrue(callback.wasTriggered());
+      assertEquals(testTime, callback.getSetValue());
+    }
+  }
+
+  @Test
+  public void testSetGameSpecificMessage() {
+    HAL.initialize(500, 0);
+    DriverStationSim.resetData();
+
+    final String message = "Hello World!";
+    DriverStationSim.setGameSpecificMessage(message);
+    DriverStationSim.notifyNewData();
+    assertEquals(message, DriverStation.getGameSpecificMessage());
+  }
+
+  @Test
+  public void testSetEventName() {
+    HAL.initialize(500, 0);
+    DriverStationSim.resetData();
+
+    final String message = "The Best Event";
+    DriverStationSim.setEventName(message);
+    DriverStationSim.notifyNewData();
+    assertEquals(message, DriverStation.getEventName());
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DutyCycleEncoderSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DutyCycleEncoderSimTest.java
@@ -1,0 +1,35 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.DutyCycleEncoder;
+import org.junit.jupiter.api.Test;
+
+class DutyCycleEncoderSimTest {
+  @Test
+  void setTest() {
+    try (DutyCycleEncoder encoder = new DutyCycleEncoder(0)) {
+      DutyCycleEncoderSim sim = new DutyCycleEncoderSim(encoder);
+
+      sim.set(5.67);
+      assertEquals(5.67, encoder.get());
+    }
+  }
+
+  @Test
+  void setDistanceTest() {
+    HAL.initialize(500, 0);
+
+    try (DutyCycleEncoder encoder = new DutyCycleEncoder(0)) {
+      DutyCycleEncoderSim sim = new DutyCycleEncoderSim(encoder);
+
+      sim.setDistance(19.1);
+      assertEquals(19.1, encoder.getDistance());
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DutyCycleSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DutyCycleSimTest.java
@@ -1,0 +1,71 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.DigitalInput;
+import edu.wpi.first.wpilibj.DutyCycle;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.IntCallback;
+import org.junit.jupiter.api.Test;
+
+class DutyCycleSimTest {
+  @Test
+  void testInitialization() {
+    DutyCycleSim sim = DutyCycleSim.createForIndex(0);
+    assertFalse(sim.getInitialized());
+
+    BooleanCallback callback = new BooleanCallback();
+
+    try (CallbackStore cb = sim.registerInitializedCallback(callback, false);
+        DigitalInput di = new DigitalInput(2);
+        DutyCycle dc = new DutyCycle(di)) {
+      assertTrue(sim.getInitialized());
+      assertTrue(callback.wasTriggered());
+      assertTrue(callback.getSetValue());
+    }
+  }
+
+  @Test
+  void setFrequencyTest() {
+    HAL.initialize(500, 0);
+
+    try (DigitalInput di = new DigitalInput(2);
+        DutyCycle dc = new DutyCycle(di)) {
+      IntCallback callback = new IntCallback();
+      DutyCycleSim sim = new DutyCycleSim(dc);
+      try (CallbackStore cb = sim.registerFrequencyCallback(callback, false)) {
+        sim.setFrequency(191);
+        assertEquals(191, sim.getFrequency());
+        assertEquals(191, dc.getFrequency());
+        assertTrue(callback.wasTriggered());
+        assertEquals(191, callback.getSetValue());
+      }
+    }
+  }
+
+  @Test
+  void setOutputTest() {
+    HAL.initialize(500, 0);
+
+    try (DigitalInput di = new DigitalInput(2);
+        DutyCycle dc = new DutyCycle(di)) {
+      DoubleCallback callback = new DoubleCallback();
+      DutyCycleSim sim = new DutyCycleSim(dc);
+      try (CallbackStore cb = sim.registerOutputCallback(callback, false)) {
+        sim.setOutput(229.174);
+        assertEquals(229.174, sim.getOutput());
+        assertEquals(229.174, dc.getOutput());
+        assertTrue(callback.wasTriggered());
+        assertEquals(229.174, callback.getSetValue());
+      }
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/EncoderSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/EncoderSimTest.java
@@ -1,0 +1,91 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.IntCallback;
+import org.junit.jupiter.api.Test;
+
+class EncoderSimTest {
+  private static final double DEFAULT_DISTANCE_PER_PULSE = 0.0005;
+
+  @Test
+  void testRate() {
+    HAL.initialize(500, 0);
+
+    try (Encoder encoder = new Encoder(0, 1)) {
+      EncoderSim sim = new EncoderSim(encoder);
+      sim.resetData();
+
+      encoder.setDistancePerPulse(DEFAULT_DISTANCE_PER_PULSE);
+
+      sim.setRate(1.91);
+      assertEquals(1.91, sim.getRate());
+    }
+  }
+
+  @Test
+  void testCount() {
+    HAL.initialize(500, 0);
+
+    try (Encoder encoder = new Encoder(0, 1)) {
+      EncoderSim sim = new EncoderSim(encoder);
+      sim.resetData();
+
+      encoder.setDistancePerPulse(DEFAULT_DISTANCE_PER_PULSE);
+
+      IntCallback callback = new IntCallback();
+      try (CallbackStore cb = sim.registerCountCallback(callback, false)) {
+        sim.setCount(3504);
+        assertEquals(3504, sim.getCount());
+
+        assertTrue(callback.wasTriggered());
+        assertEquals(3504, encoder.get());
+        assertEquals(3504, callback.getSetValue());
+      }
+    }
+  }
+
+  @Test
+  void testDistance() {
+    HAL.initialize(500, 0);
+
+    try (Encoder encoder = new Encoder(0, 1)) {
+      EncoderSim sim = new EncoderSim(encoder);
+      sim.resetData();
+
+      encoder.setDistancePerPulse(DEFAULT_DISTANCE_PER_PULSE);
+
+      sim.setDistance(229.174);
+      assertEquals(229.174, sim.getDistance());
+      assertEquals(229.174, encoder.getDistance());
+    }
+  }
+
+  @Test
+  void testPeriod() {
+    HAL.initialize(500, 0);
+
+    try (Encoder encoder = new Encoder(0, 1)) {
+      EncoderSim sim = new EncoderSim(encoder);
+      sim.resetData();
+
+      encoder.setDistancePerPulse(DEFAULT_DISTANCE_PER_PULSE);
+
+      DoubleCallback callback = new DoubleCallback();
+      try (CallbackStore cb = sim.registerPeriodCallback(callback, false)) {
+        sim.setPeriod(123.456);
+        assertEquals(123.456, sim.getPeriod());
+        assertEquals(123.456, encoder.getPeriod());
+        assertEquals(DEFAULT_DISTANCE_PER_PULSE / 123.456, encoder.getRate());
+      }
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/PWMSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/PWMSimTest.java
@@ -1,0 +1,135 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.PWM;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.IntCallback;
+import org.junit.jupiter.api.Test;
+
+class PWMSimTest {
+  @Test
+  void testInitialize() {
+    HAL.initialize(500, 0);
+
+    PWMSim sim = new PWMSim(0);
+    sim.resetData();
+    assertFalse(sim.getInitialized());
+
+    BooleanCallback callback = new BooleanCallback();
+
+    try (CallbackStore cb = sim.registerInitializedCallback(callback, false);
+        PWM pwm = new PWM(0)) {
+      assertTrue(sim.getInitialized());
+    }
+  }
+
+  @Test
+  void testSetRawValue() {
+    HAL.initialize(500, 0);
+
+    PWMSim sim = new PWMSim(0);
+    sim.resetData();
+    assertFalse(sim.getInitialized());
+
+    IntCallback callback = new IntCallback();
+
+    try (CallbackStore cb = sim.registerRawValueCallback(callback, false);
+        PWM pwm = new PWM(0)) {
+      sim.setRawValue(229);
+      assertEquals(229, sim.getRawValue());
+      assertEquals(229, pwm.getRaw());
+      assertTrue(callback.wasTriggered());
+      assertEquals(229, callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testSetSpeed() {
+    HAL.initialize(500, 0);
+
+    PWMSim sim = new PWMSim(0);
+    sim.resetData();
+    assertFalse(sim.getInitialized());
+
+    DoubleCallback callback = new DoubleCallback();
+
+    try (CallbackStore cb = sim.registerSpeedCallback(callback, false);
+        PWM pwm = new PWM(0)) {
+      final double kTestValue = 0.3504;
+      pwm.setSpeed(kTestValue);
+
+      assertEquals(kTestValue, sim.getSpeed());
+      assertEquals(kTestValue, pwm.getSpeed());
+      assertTrue(callback.wasTriggered());
+      assertEquals(kTestValue, callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testSetPosition() {
+    HAL.initialize(500, 0);
+
+    PWMSim sim = new PWMSim(0);
+    sim.resetData();
+    assertFalse(sim.getInitialized());
+
+    DoubleCallback callback = new DoubleCallback();
+
+    try (CallbackStore cb = sim.registerPositionCallback(callback, false);
+        PWM pwm = new PWM(0)) {
+      final double kTestValue = 0.3504;
+      pwm.setPosition(kTestValue);
+
+      assertEquals(kTestValue, sim.getPosition());
+      assertEquals(kTestValue, pwm.getPosition());
+      assertTrue(callback.wasTriggered());
+      assertEquals(kTestValue, callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testSetPeriodScale() {
+    HAL.initialize(500, 0);
+
+    PWMSim sim = new PWMSim(0);
+    sim.resetData();
+    assertFalse(sim.getInitialized());
+
+    IntCallback callback = new IntCallback();
+
+    try (CallbackStore cb = sim.registerPeriodScaleCallback(callback, false);
+        PWM pwm = new PWM(0)) {
+      sim.setPeriodScale(3504);
+      assertEquals(3504, sim.getPeriodScale());
+      assertTrue(callback.wasTriggered());
+      assertEquals(3504, callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testSetZeroLatch() {
+    HAL.initialize(500, 0);
+
+    PWMSim sim = new PWMSim(0);
+    sim.resetData();
+    assertFalse(sim.getInitialized());
+
+    BooleanCallback callback = new BooleanCallback();
+
+    try (CallbackStore cb = sim.registerZeroLatchCallback(callback, false);
+        PWM pwm = new PWM(0)) {
+      pwm.setZeroLatch();
+
+      assertTrue(callback.wasTriggered());
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/RelaySimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/RelaySimTest.java
@@ -1,0 +1,258 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.Relay;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import org.junit.jupiter.api.Test;
+
+class RelaySimTest {
+  @Test
+  void testInitializationBidrectional() {
+    HAL.initialize(500, 0);
+
+    RelaySim sim = new RelaySim(0);
+    sim.resetData();
+
+    BooleanCallback forwardCallback = new BooleanCallback();
+    BooleanCallback reverseCallback = new BooleanCallback();
+
+    assertFalse(sim.getInitializedForward());
+    assertFalse(sim.getInitializedReverse());
+
+    try (CallbackStore fwdCb = sim.registerInitializedForwardCallback(forwardCallback, false);
+        CallbackStore revCb = sim.registerInitializedReverseCallback(reverseCallback, false);
+        Relay relay = new Relay(0)) {
+      assertTrue(sim.getInitializedForward());
+      assertTrue(sim.getInitializedReverse());
+
+      assertTrue(forwardCallback.wasTriggered());
+      assertTrue(forwardCallback.getSetValue());
+      assertTrue(reverseCallback.wasTriggered());
+      assertTrue(reverseCallback.getSetValue());
+    }
+  }
+
+  @Test
+  void testInitializationForwardOnly() {
+    HAL.initialize(500, 0);
+
+    RelaySim sim = new RelaySim(0);
+    sim.resetData();
+
+    BooleanCallback forwardCallback = new BooleanCallback();
+    BooleanCallback reverseCallback = new BooleanCallback();
+
+    assertFalse(sim.getInitializedForward());
+    assertFalse(sim.getInitializedReverse());
+
+    try (CallbackStore fwdCb = sim.registerInitializedForwardCallback(forwardCallback, false);
+        CallbackStore revCb = sim.registerInitializedReverseCallback(reverseCallback, false);
+        Relay relay = new Relay(0, Relay.Direction.kForward); ) {
+      assertTrue(sim.getInitializedForward());
+      assertFalse(sim.getInitializedReverse());
+
+      assertTrue(forwardCallback.wasTriggered());
+      assertTrue(forwardCallback.getSetValue());
+      assertFalse(reverseCallback.wasTriggered());
+      assertNull(reverseCallback.getSetValue());
+    }
+  }
+
+  @Test
+  void testInitializationReverseOnly() {
+    HAL.initialize(500, 0);
+
+    RelaySim sim = new RelaySim(0);
+    sim.resetData();
+
+    BooleanCallback forwardCallback = new BooleanCallback();
+    BooleanCallback reverseCallback = new BooleanCallback();
+
+    assertFalse(sim.getInitializedForward());
+    assertFalse(sim.getInitializedReverse());
+
+    try (CallbackStore fwdCb = sim.registerInitializedForwardCallback(forwardCallback, false);
+        CallbackStore revCb = sim.registerInitializedReverseCallback(reverseCallback, false);
+        Relay relay = new Relay(0, Relay.Direction.kReverse); ) {
+      assertFalse(sim.getInitializedForward());
+      assertTrue(sim.getInitializedReverse());
+
+      assertFalse(forwardCallback.wasTriggered());
+      assertNull(forwardCallback.getSetValue());
+      assertTrue(reverseCallback.wasTriggered());
+      assertTrue(reverseCallback.getSetValue());
+    }
+  }
+
+  @Test
+  void testBidirectionalSetForward() {
+    HAL.initialize(500, 0);
+
+    RelaySim sim = new RelaySim(0);
+    BooleanCallback forwardCallback = new BooleanCallback();
+    BooleanCallback reverseCallback = new BooleanCallback();
+
+    try (Relay relay = new Relay(0);
+        CallbackStore fwdCb = sim.registerForwardCallback(forwardCallback, false);
+        CallbackStore revCb = sim.registerReverseCallback(reverseCallback, false)) {
+      relay.set(Relay.Value.kForward);
+      assertEquals(Relay.Value.kForward, relay.get());
+      assertTrue(sim.getForward());
+      assertFalse(sim.getReverse());
+
+      assertTrue(forwardCallback.wasTriggered());
+      assertTrue(forwardCallback.getSetValue());
+      assertFalse(reverseCallback.wasTriggered());
+      assertNull(reverseCallback.getSetValue());
+    }
+  }
+
+  @Test
+  void testBidirectionalSetReverse() {
+    HAL.initialize(500, 0);
+
+    RelaySim sim = new RelaySim(0);
+    BooleanCallback forwardCallback = new BooleanCallback();
+    BooleanCallback reverseCallback = new BooleanCallback();
+
+    try (Relay relay = new Relay(0);
+        CallbackStore fwdCb = sim.registerForwardCallback(forwardCallback, false);
+        CallbackStore revCb = sim.registerReverseCallback(reverseCallback, false)) {
+      relay.set(Relay.Value.kReverse);
+      assertEquals(Relay.Value.kReverse, relay.get());
+      assertFalse(sim.getForward());
+      assertTrue(sim.getReverse());
+
+      assertFalse(forwardCallback.wasTriggered());
+      assertNull(forwardCallback.getSetValue());
+      assertTrue(reverseCallback.wasTriggered());
+      assertTrue(reverseCallback.getSetValue());
+    }
+  }
+
+  @Test
+  void testBidirectionalSetOn() {
+    HAL.initialize(500, 0);
+
+    RelaySim sim = new RelaySim(0);
+    BooleanCallback forwardCallback = new BooleanCallback();
+    BooleanCallback reverseCallback = new BooleanCallback();
+
+    try (Relay relay = new Relay(0);
+        CallbackStore fwdCb = sim.registerForwardCallback(forwardCallback, false);
+        CallbackStore revCb = sim.registerReverseCallback(reverseCallback, false)) {
+      relay.set(Relay.Value.kOn);
+      assertEquals(Relay.Value.kOn, relay.get());
+      assertTrue(sim.getForward());
+      assertTrue(sim.getReverse());
+
+      assertTrue(forwardCallback.wasTriggered());
+      assertTrue(forwardCallback.getSetValue());
+      assertTrue(reverseCallback.wasTriggered());
+      assertTrue(reverseCallback.getSetValue());
+    }
+  }
+
+  @Test
+  void testBidirectionalSetOff() {
+    HAL.initialize(500, 0);
+
+    RelaySim sim = new RelaySim(0);
+    BooleanCallback forwardCallback = new BooleanCallback();
+    BooleanCallback reverseCallback = new BooleanCallback();
+
+    try (Relay relay = new Relay(0);
+        CallbackStore fwdCb = sim.registerForwardCallback(forwardCallback, false);
+        CallbackStore revCb = sim.registerReverseCallback(reverseCallback, false)) {
+      // Bootstrap into a non-off state to verify the callbacks
+      relay.set(Relay.Value.kOn);
+      forwardCallback.reset();
+      reverseCallback.reset();
+
+      relay.set(Relay.Value.kOff);
+      assertEquals(Relay.Value.kOff, relay.get());
+      assertFalse(sim.getForward());
+      assertFalse(sim.getReverse());
+
+      assertTrue(forwardCallback.wasTriggered());
+      assertFalse(forwardCallback.getSetValue());
+      assertTrue(reverseCallback.wasTriggered());
+      assertFalse(reverseCallback.getSetValue());
+    }
+  }
+
+  @Test
+  void testStopMotor() {
+    try (Relay relay = new Relay(0)) {
+      // Bootstrap into non-off state
+      relay.set(Relay.Value.kOn);
+
+      relay.stopMotor();
+      assertEquals(Relay.Value.kOff, relay.get());
+    }
+  }
+
+  @Test
+  void testForwardOnlyCannotGoReverse() {
+    try (Relay relay = new Relay(0, Relay.Direction.kForward)) {
+      relay.set(Relay.Value.kForward);
+      assertEquals(Relay.Value.kOn, relay.get());
+
+      relay.set(Relay.Value.kOff);
+      assertEquals(Relay.Value.kOff, relay.get());
+
+      assertThrows(Relay.InvalidValueException.class, () -> relay.set(Relay.Value.kReverse));
+      assertDoesNotThrow(() -> relay.set(Relay.Value.kOn));
+    }
+  }
+
+  @Test
+  void testReverseOnlyCannotGoForwards() {
+    try (Relay relay = new Relay(0, Relay.Direction.kReverse)) {
+      relay.set(Relay.Value.kReverse);
+      assertEquals(Relay.Value.kOn, relay.get());
+
+      relay.set(Relay.Value.kOff);
+      assertEquals(Relay.Value.kOff, relay.get());
+
+      assertThrows(Relay.InvalidValueException.class, () -> relay.set(Relay.Value.kForward));
+      assertDoesNotThrow(() -> relay.set(Relay.Value.kOn));
+    }
+  }
+
+  @Test
+  void testSwitchDirections() {
+    try (Relay relay = new Relay(0, Relay.Direction.kBoth)) {
+      // Start with both. Should be able to set all 4 values
+      assertDoesNotThrow(() -> relay.set(Relay.Value.kOff));
+      assertDoesNotThrow(() -> relay.set(Relay.Value.kForward));
+      assertDoesNotThrow(() -> relay.set(Relay.Value.kReverse));
+      assertDoesNotThrow(() -> relay.set(Relay.Value.kOn));
+
+      // Switch it to forward only
+      relay.setDirection(Relay.Direction.kForward);
+      assertDoesNotThrow(() -> relay.set(Relay.Value.kOff));
+      assertDoesNotThrow(() -> relay.set(Relay.Value.kForward));
+      assertThrows(Relay.InvalidValueException.class, () -> relay.set(Relay.Value.kReverse));
+      assertDoesNotThrow(() -> relay.set(Relay.Value.kOn));
+
+      // Switch it to Reverse only
+      relay.setDirection(Relay.Direction.kReverse);
+      assertDoesNotThrow(() -> relay.set(Relay.Value.kOff));
+      assertThrows(Relay.InvalidValueException.class, () -> relay.set(Relay.Value.kForward));
+      assertDoesNotThrow(() -> relay.set(Relay.Value.kReverse));
+      assertDoesNotThrow(() -> relay.set(Relay.Value.kOn));
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/RoboRioSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/RoboRioSimTest.java
@@ -1,0 +1,194 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.hal.HALUtil;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
+import edu.wpi.first.wpilibj.simulation.testutils.IntCallback;
+import org.junit.jupiter.api.Test;
+
+public class RoboRioSimTest {
+  @Test
+  void testFPGAButton() {
+    RoboRioSim.resetData();
+
+    BooleanCallback callback = new BooleanCallback();
+    try (CallbackStore cb = RoboRioSim.registerFPGAButtonCallback(callback, false)) {
+      RoboRioSim.setFPGAButton(true);
+      assertTrue(RoboRioSim.getFPGAButton());
+      assertTrue(HALUtil.getFPGAButton());
+      assertTrue(callback.wasTriggered());
+      assertTrue(callback.getSetValue());
+
+      callback.reset();
+      RoboRioSim.setFPGAButton(false);
+      assertFalse(RoboRioSim.getFPGAButton());
+      assertFalse(HALUtil.getFPGAButton());
+      assertTrue(callback.wasTriggered());
+      assertFalse(callback.getSetValue());
+    }
+  }
+
+  @Test
+  void testSetVin() {
+    RoboRioSim.resetData();
+
+    DoubleCallback voltageCallback = new DoubleCallback();
+    DoubleCallback currentCallback = new DoubleCallback();
+    try (CallbackStore voltageCb = RoboRioSim.registerVInVoltageCallback(voltageCallback, false);
+        CallbackStore currentCb = RoboRioSim.registerVInCurrentCallback(currentCallback, false)) {
+      final double kTestVoltage = 1.91;
+      final double kTestCurrent = 35.04;
+
+      RoboRioSim.setVInVoltage(kTestVoltage);
+      assertTrue(voltageCallback.wasTriggered());
+      assertEquals(kTestVoltage, voltageCallback.getSetValue());
+      assertEquals(kTestVoltage, RoboRioSim.getVInVoltage());
+      assertEquals(kTestVoltage, RobotController.getInputVoltage());
+
+      RoboRioSim.setVInCurrent(kTestCurrent);
+      assertTrue(currentCallback.wasTriggered());
+      assertEquals(kTestCurrent, currentCallback.getSetValue());
+      assertEquals(kTestCurrent, RoboRioSim.getVInCurrent());
+      assertEquals(kTestCurrent, RobotController.getInputCurrent());
+    }
+  }
+
+  @Test
+  void test6V() {
+    RoboRioSim.resetData();
+
+    DoubleCallback voltageCallback = new DoubleCallback();
+    DoubleCallback currentCallback = new DoubleCallback();
+    BooleanCallback activeCallback = new BooleanCallback();
+    IntCallback faultCallback = new IntCallback();
+    try (CallbackStore voltageCb =
+            RoboRioSim.registerUserVoltage6VCallback(voltageCallback, false);
+        CallbackStore currentCb = RoboRioSim.registerUserCurrent6VCallback(currentCallback, false);
+        CallbackStore activeCb = RoboRioSim.registerUserActive6VCallback(activeCallback, false);
+        CallbackStore faultsCb = RoboRioSim.registerUserFaults6VCallback(faultCallback, false)) {
+      final double kTestVoltage = 22.9;
+      final double kTestCurrent = 174;
+      final int kTestFaults = 229;
+
+      RoboRioSim.setUserVoltage6V(kTestVoltage);
+      assertTrue(voltageCallback.wasTriggered());
+      assertEquals(kTestVoltage, voltageCallback.getSetValue());
+      assertEquals(kTestVoltage, RoboRioSim.getUserVoltage6V());
+      assertEquals(kTestVoltage, RobotController.getVoltage6V());
+
+      RoboRioSim.setUserCurrent6V(kTestCurrent);
+      assertTrue(currentCallback.wasTriggered());
+      assertEquals(kTestCurrent, currentCallback.getSetValue());
+      assertEquals(kTestCurrent, RoboRioSim.getUserCurrent6V());
+      assertEquals(kTestCurrent, RobotController.getCurrent6V());
+
+      RoboRioSim.setUserActive6V(false);
+      assertTrue(activeCallback.wasTriggered());
+      assertFalse(activeCallback.getSetValue());
+      assertFalse(RoboRioSim.getUserActive6V());
+      assertFalse(RobotController.getEnabled6V());
+
+      RoboRioSim.setUserFaults6V(kTestFaults);
+      assertTrue(faultCallback.wasTriggered());
+      assertEquals(kTestFaults, faultCallback.getSetValue());
+      assertEquals(kTestFaults, RoboRioSim.getUserFaults6V());
+      assertEquals(kTestFaults, RobotController.getFaultCount6V());
+    }
+  }
+
+  @Test
+  void test5V() {
+    RoboRioSim.resetData();
+
+    DoubleCallback voltageCallback = new DoubleCallback();
+    DoubleCallback currentCallback = new DoubleCallback();
+    BooleanCallback activeCallback = new BooleanCallback();
+    IntCallback faultCallback = new IntCallback();
+    try (CallbackStore voltageCb =
+            RoboRioSim.registerUserVoltage5VCallback(voltageCallback, false);
+        CallbackStore currentCb = RoboRioSim.registerUserCurrent5VCallback(currentCallback, false);
+        CallbackStore activeCb = RoboRioSim.registerUserActive5VCallback(activeCallback, false);
+        CallbackStore faultsCb = RoboRioSim.registerUserFaults5VCallback(faultCallback, false)) {
+      final double kTestVoltage = 22.9;
+      final double kTestCurrent = 174;
+      final int kTestFaults = 229;
+
+      RoboRioSim.setUserVoltage5V(kTestVoltage);
+      assertTrue(voltageCallback.wasTriggered());
+      assertEquals(kTestVoltage, voltageCallback.getSetValue());
+      assertEquals(kTestVoltage, RoboRioSim.getUserVoltage5V());
+      assertEquals(kTestVoltage, RobotController.getVoltage5V());
+
+      RoboRioSim.setUserCurrent5V(kTestCurrent);
+      assertTrue(currentCallback.wasTriggered());
+      assertEquals(kTestCurrent, currentCallback.getSetValue());
+      assertEquals(kTestCurrent, RoboRioSim.getUserCurrent5V());
+      assertEquals(kTestCurrent, RobotController.getCurrent5V());
+
+      RoboRioSim.setUserActive5V(false);
+      assertTrue(activeCallback.wasTriggered());
+      assertFalse(activeCallback.getSetValue());
+      assertFalse(RoboRioSim.getUserActive5V());
+      assertFalse(RobotController.getEnabled5V());
+
+      RoboRioSim.setUserFaults5V(kTestFaults);
+      assertTrue(faultCallback.wasTriggered());
+      assertEquals(kTestFaults, faultCallback.getSetValue());
+      assertEquals(kTestFaults, RoboRioSim.getUserFaults5V());
+      assertEquals(kTestFaults, RobotController.getFaultCount5V());
+    }
+  }
+
+  @Test
+  void test3V3() {
+    RoboRioSim.resetData();
+
+    DoubleCallback voltageCallback = new DoubleCallback();
+    DoubleCallback currentCallback = new DoubleCallback();
+    BooleanCallback activeCallback = new BooleanCallback();
+    IntCallback faultCallback = new IntCallback();
+    try (CallbackStore voltageCb =
+            RoboRioSim.registerUserVoltage3V3Callback(voltageCallback, false);
+        CallbackStore currentCb =
+            RoboRioSim.registerUserCurrent3V3Callback(currentCallback, false);
+        CallbackStore activeCb = RoboRioSim.registerUserActive3V3Callback(activeCallback, false);
+        CallbackStore faultsCb = RoboRioSim.registerUserFaults3V3Callback(faultCallback, false)) {
+      final double kTestVoltage = 22.9;
+      final double kTestCurrent = 174;
+      final int kTestFaults = 229;
+
+      RoboRioSim.setUserVoltage3V3(kTestVoltage);
+      assertTrue(voltageCallback.wasTriggered());
+      assertEquals(kTestVoltage, voltageCallback.getSetValue());
+      assertEquals(kTestVoltage, RoboRioSim.getUserVoltage3V3());
+      assertEquals(kTestVoltage, RobotController.getVoltage3V3());
+
+      RoboRioSim.setUserCurrent3V3(kTestCurrent);
+      assertTrue(currentCallback.wasTriggered());
+      assertEquals(kTestCurrent, currentCallback.getSetValue());
+      assertEquals(kTestCurrent, RoboRioSim.getUserCurrent3V3());
+      assertEquals(kTestCurrent, RobotController.getCurrent3V3());
+
+      RoboRioSim.setUserActive3V3(false);
+      assertTrue(activeCallback.wasTriggered());
+      assertFalse(activeCallback.getSetValue());
+      assertFalse(RoboRioSim.getUserActive3V3());
+      assertFalse(RobotController.getEnabled3V3());
+
+      RoboRioSim.setUserFaults3V3(kTestFaults);
+      assertTrue(faultCallback.wasTriggered());
+      assertEquals(kTestFaults, faultCallback.getSetValue());
+      assertEquals(kTestFaults, RoboRioSim.getUserFaults3V3());
+      assertEquals(kTestFaults, RobotController.getFaultCount3V3());
+    }
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/testutils/BooleanCallback.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/testutils/BooleanCallback.java
@@ -1,0 +1,19 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation.testutils;
+
+import edu.wpi.first.hal.HALValue;
+
+public class BooleanCallback extends CallbackHelperBase<Boolean> {
+  @Override
+  public void callback(String name, HALValue value) {
+    if (value.getType() != HALValue.kBoolean) {
+      throw new IllegalArgumentException("Wrong callback for type " + value.getType());
+    }
+
+    m_wasTriggered = true;
+    m_setValue = value.getBoolean();
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/testutils/BufferCallback.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/testutils/BufferCallback.java
@@ -1,0 +1,27 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation.testutils;
+
+import edu.wpi.first.hal.simulation.ConstBufferCallback;
+import java.util.Arrays;
+
+public class BufferCallback implements ConstBufferCallback {
+  private boolean m_wasTriggered;
+  private byte[] m_setValue;
+
+  @Override
+  public void callback(String name, byte[] buffer, int count) {
+    m_wasTriggered = true;
+    m_setValue = Arrays.copyOf(buffer, buffer.length);
+  }
+
+  public boolean wasTriggered() {
+    return m_wasTriggered;
+  }
+
+  public byte[] getSetValue() {
+    return Arrays.copyOf(m_setValue, m_setValue.length);
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/testutils/CallbackHelperBase.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/testutils/CallbackHelperBase.java
@@ -1,0 +1,25 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation.testutils;
+
+import edu.wpi.first.hal.simulation.NotifyCallback;
+
+public abstract class CallbackHelperBase<T> implements NotifyCallback {
+  protected boolean m_wasTriggered;
+  protected T m_setValue;
+
+  public final boolean wasTriggered() {
+    return m_wasTriggered;
+  }
+
+  public final T getSetValue() {
+    return m_setValue;
+  }
+
+  public final void reset() {
+    m_wasTriggered = false;
+    m_setValue = null;
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/testutils/DoubleCallback.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/testutils/DoubleCallback.java
@@ -1,0 +1,19 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation.testutils;
+
+import edu.wpi.first.hal.HALValue;
+
+public class DoubleCallback extends CallbackHelperBase<Double> {
+  @Override
+  public void callback(String name, HALValue value) {
+    if (value.getType() != HALValue.kDouble) {
+      throw new IllegalArgumentException("Wrong callback for type " + value.getType());
+    }
+
+    m_wasTriggered = true;
+    m_setValue = value.getDouble();
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/testutils/EnumCallback.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/testutils/EnumCallback.java
@@ -1,0 +1,19 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation.testutils;
+
+import edu.wpi.first.hal.HALValue;
+
+public class EnumCallback extends CallbackHelperBase<Long> {
+  @Override
+  public void callback(String name, HALValue value) {
+    if (value.getType() != HALValue.kEnum) {
+      throw new IllegalArgumentException("Wrong callback for type " + value.getType());
+    }
+
+    m_wasTriggered = true;
+    m_setValue = value.getLong();
+  }
+}

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/testutils/IntCallback.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/testutils/IntCallback.java
@@ -1,0 +1,19 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.simulation.testutils;
+
+import edu.wpi.first.hal.HALValue;
+
+public class IntCallback extends CallbackHelperBase<Integer> {
+  @Override
+  public void callback(String name, HALValue value) {
+    if (value.getType() != HALValue.kInt) {
+      throw new IllegalArgumentException("Wrong callback for type " + value.getType());
+    }
+
+    m_wasTriggered = true;
+    m_setValue = (int) value.getLong();
+  }
+}


### PR DESCRIPTION
Sibling of #3494. Adds more unit tests to boost wpilibj coverage, and fixing some bugs discovered during implementation. Results in a ~60% increase in coverage

![JavaCodeCoverageBefore](https://user-images.githubusercontent.com/10381694/128443952-caae70fb-7522-4a83-8f82-295d0fa6d5ad.png)
![JavaCodeCoverageAfter](https://user-images.githubusercontent.com/10381694/128443953-3852a34e-65ee-477d-9990-de29c8005360.png)
