### PR TITLE
Shorten Gazebo CI build

### DIFF
--- a/.github/workflows/gazebo.yml
+++ b/.github/workflows/gazebo.yml
@@ -11,5 +11,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Build with Gradle
-        run: ./gradlew build -PbuildServer -PmakeSim -Dorg.gradle.jvmargs=-Xmx2g
+      - name: Build Gazebo plugins
+        run: ./gradlew simulation:frc_gazebo_plugins:build -PbuildServer -PmakeSim
+      - name: Build Gazebo HALSIM plugin
+        run: ./gradlew simulation:halsim_gazebo:build -PbuildServer -PmakeSim

--- a/.github/workflows/gazebo.yml
+++ b/.github/workflows/gazebo.yml
@@ -11,7 +11,5 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Build Gazebo plugins
-        run: ./gradlew simulation:frc_gazebo_plugins:build -PbuildServer -PmakeSim
-      - name: Build Gazebo HALSIM plugin
-        run: ./gradlew simulation:halsim_gazebo:build -PbuildServer -PmakeSim
+      - name: Build with Gradle
+        run: ./gradlew simulation:frc_gazebo_plugins:build simulation:halsim_gazebo:build -PbuildServer -PmakeSim


### PR DESCRIPTION
Only build the Gazebo simulation projects instead of all of WPILib.