### PR TITLE
Remove Java formatting from build task in CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,7 @@ jobs:
         run: echo "EXTRA_GRADLE_ARGS=-PreleaseMode" >> $GITHUB_ENV
         if: startsWith(github.ref, 'refs/tags/v')
       - name: Build with Gradle
-        run: ./gradlew build -PbuildServer ${{ matrix.build-options }} ${{ env.EXTRA_GRADLE_ARGS }}
+        run: ./gradlew build -PbuildServer -PskipJavaFormat ${{ matrix.build-options }} ${{ env.EXTRA_GRADLE_ARGS }}
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact-name }}
@@ -82,9 +82,9 @@ jobs:
         shell: bash
         if: startsWith(github.ref, 'refs/tags/v')
       - name: Build with Gradle
-        run: ./gradlew build -PbuildServer ${{ env.EXTRA_GRADLE_ARGS }}
+        run: ./gradlew build -PbuildServer -PskipJavaFormat ${{ env.EXTRA_GRADLE_ARGS }}
       - name: Sign Libraries with Developer ID
-        run: ./gradlew build -PbuildServer -PdeveloperID=${{ secrets.APPLE_DEVELOPER_ID }} ${{ env.EXTRA_GRADLE_ARGS }}
+        run: ./gradlew build -PbuildServer -PskipJavaFormat -PdeveloperID=${{ secrets.APPLE_DEVELOPER_ID }} ${{ env.EXTRA_GRADLE_ARGS }}
         if: |
           matrix.artifact-name == 'macOS' && (github.repository_owner == 'wpilibsuite' &&
           (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -69,3 +69,23 @@ jobs:
         run: wpiformat -list-changed-files
       - name: Run clang-tidy
         run: wpiformat -clang 12 -no-format -tidy-changed -compile-commands=build-cmake
+  spotless:
+    name: "Spotless"
+    runs-on: ubuntu-latest
+    container: wpilib/ubuntu-base:18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run spotless
+        run: ./gradlew spotlessCheck
+  javaformat:
+    name: "Checkstyle and PMD"
+    runs-on: ubuntu-latest
+    container: wpilib/ubuntu-base:18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run Java format
+        run: ./gradlew javaFormat

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ wpiformat can be executed anywhere in the repository via `py -3 -m wpiformat` on
 
 #### Java Code Quality Tools
 
-The Java code quality tools (checkstyle, pmd, etc.) can be run with the `./gradlew javaFormat` task.
+The Java code quality tools Checkstyle and PMD can be run via `./gradlew javaFormat`. Spotless can be run via `./gradlew spotlessCheck` to preview changes, and via `./gradlew spotlessApply` to immediately apply changes. These tools will all be run automatically by the build task. To disable this behavior, pass the `-PskipJavaFormat` flag.
 
 ### CMake
 

--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,9 @@ ext.getCurrentArch = {
 }
 
 spotless {
+    if (project.hasProperty('skipJavaFormat')) {
+        enforceCheck false
+    }
     java {
         target fileTree('.') {
             include '**/*.java'

--- a/shared/java/javastyle.gradle
+++ b/shared/java/javastyle.gradle
@@ -1,13 +1,12 @@
+if (!project.hasProperty('skipJavaFormat')) {
+    apply plugin: 'checkstyle'
 
-apply plugin: 'checkstyle'
+    checkstyle {
+        toolVersion = "8.38"
+        configDirectory = file("${project.rootDir}/styleguide")
+        config = resources.text.fromFile(new File(configDirectory.get().getAsFile(), "checkstyle.xml"))
+    }
 
-checkstyle {
-    toolVersion = "8.38"
-    configDirectory = file("${project.rootDir}/styleguide")
-    config = resources.text.fromFile(new File(configDirectory.get().getAsFile(), "checkstyle.xml"))
-}
-
-if (!project.hasProperty('skipPMD')) {
     apply plugin: 'pmd'
 
     pmd {

--- a/wpilibjExamples/build.gradle
+++ b/wpilibjExamples/build.gradle
@@ -53,7 +53,7 @@ jacocoTestReport {
     }
 }
 
-if (!project.hasProperty('skipPMD')) {
+if (!project.hasProperty('skipJavaFormat')) {
     apply plugin: 'pmd'
 
     pmd {


### PR DESCRIPTION
This saves time in CI spent performing the same source-level checks in
every build job. Checkstyle, PMD, and Spotless are now run once in the
"Lint and Format" job.

The -PskipPMD flag was replaced with a -PskipJavaFormat flag that
disables Checkstyle, PMD, and Spotless.