### PR TITLE
Add Subsystem::DisabledInit()

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/PIDSubsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/PIDSubsystem.java
@@ -89,10 +89,15 @@ public abstract class PIDSubsystem extends SubsystemBase {
     m_controller.reset();
   }
 
-  /** Disables the PID control. Sets output to zero. */
+  /** Disables the PID control. Sets output to zero. Called on robot disable. */
   public void disable() {
     m_enabled = false;
     useOutput(0, 0);
+  }
+
+  @Override
+  public void disabledInit() {
+    disable();
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDSubsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDSubsystem.java
@@ -90,10 +90,15 @@ public abstract class ProfiledPIDSubsystem extends SubsystemBase {
     m_controller.reset(getMeasurement());
   }
 
-  /** Disables the PID control. Sets output to zero. */
+  /** Disables the PID control. Sets output to zero. Called on robot disable. */
   public void disable() {
     m_enabled = false;
     useOutput(0, new State());
+  }
+
+  @Override
+  public void disabledInit() {
+    disable();
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
@@ -38,8 +38,8 @@ public interface Subsystem {
   default void simulationPeriodic() {}
 
   /**
-   * This method is called once by the {@link CommandScheduler} when the robot enters disabled
-   * mode. Useful for stopping motor controllers (ie {@link
+   * This method is called once by the {@link CommandScheduler} when the robot enters disabled mode.
+   * Useful for stopping motor controllers (ie {@link
    * edu.wpi.first.wpilibj.motorcontrol.MotorController#stopMotor() MotorController.stopMotor()}),
    * resetting control loops (ie {@link edu.wpi.first.math.controller.PIDController#reset()
    * PIDController.reset()}), etc. to prevent sudden responses to leftover state on re-enable.

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
@@ -32,8 +32,22 @@ public interface Subsystem {
    * This method is called periodically by the {@link CommandScheduler}. Useful for updating
    * subsystem-specific state that needs to be maintained for simulations, such as for updating
    * {@link edu.wpi.first.wpilibj.simulation} classes and setting simulated sensor readings.
+   *
+   * <p>This will be called after {@link #periodic()} but before commands.
    */
   default void simulationPeriodic() {}
+
+  /**
+   * This method is called once by the {@link CommandScheduler} when the robot enters disabled
+   * mode. Useful for stopping motor controllers (ie {@link
+   * edu.wpi.first.wpilibj.motorcontrol.MotorController#stopMotor() MotorController.stopMotor()}),
+   * resetting control loops (ie {@link edu.wpi.first.math.controller.PIDController#reset()
+   * PIDController.reset()}), etc. to prevent sudden responses to leftover state on re-enable.
+   *
+   * <p>This will be called before commands and the {@link #periodic()} and {@link
+   * #simulationPeriodic()} functions.
+   */
+  default void disabledInit() {}
 
   /**
    * Sets the default {@link Command} of the subsystem. The default command will be automatically

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/TrapezoidProfileSubsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/TrapezoidProfileSubsystem.java
@@ -90,9 +90,14 @@ public abstract class TrapezoidProfileSubsystem extends SubsystemBase {
     m_enabled = true;
   }
 
-  /** Disable the TrapezoidProfileSubsystem's output. */
+  /** Disable the TrapezoidProfileSubsystem's output. Called on robot disable. */
   public void disable() {
     m_enabled = false;
+  }
+
+  @Override
+  public void disabledInit() {
+    disable();
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/TrapezoidProfileSubsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/TrapezoidProfileSubsystem.java
@@ -60,9 +60,9 @@ public abstract class TrapezoidProfileSubsystem extends SubsystemBase {
 
   @Override
   public void periodic() {
-    var profile = new TrapezoidProfile(m_constraints, m_goal, m_state);
-    m_state = profile.calculate(m_period);
     if (m_enabled) {
+      var profile = new TrapezoidProfile(m_constraints, m_goal, m_state);
+      m_state = profile.calculate(m_period);
       useState(m_state);
     }
   }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Subsystem.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Subsystem.cpp
@@ -13,6 +13,8 @@ void Subsystem::Periodic() {}
 
 void Subsystem::SimulationPeriodic() {}
 
+void Subsystem::DisabledInit() {}
+
 Command* Subsystem::GetDefaultCommand() const {
   return CommandScheduler::GetInstance().GetDefaultCommand(this);
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
@@ -50,8 +50,22 @@ class Subsystem {
    * updating subsystem-specific state that needs to be maintained for
    * simulations, such as for updating simulation classes and setting simulated
    * sensor readings.
+   *
+   * <p>This will be called after Periodic() but before commands.
    */
   virtual void SimulationPeriodic();
+
+  /**
+   * This method is called once by the CommandScheduler when the robot enters
+   * disabled mode. Useful for stopping motor controllers (ie
+   * MotorController.StopMotor()), resetting control loops (ie
+   * PIDController.Reset()), etc. to prevent sudden responses to leftover state
+   * on re-enable.
+   *
+   * <p>This will be called before commands and the Periodic() and
+   * SimulationPeriodic() functions.
+   */
+  virtual void DisabledInit();
 
   /**
    * Sets the default Command of the subsystem.  The default command will be

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SchedulerTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SchedulerTest.java
@@ -76,12 +76,13 @@ class SchedulerTest extends CommandTestBase {
   void disabledInitTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       AtomicInteger counter = new AtomicInteger(0);
-      Subsystem subsystem = new Subsystem() {
-        @Override
-        public void disabledInit() {
-          counter.incrementAndGet();
-        }
-      };
+      Subsystem subsystem =
+          new Subsystem() {
+            @Override
+            public void disabledInit() {
+              counter.incrementAndGet();
+            }
+          };
       scheduler.registerSubsystem(subsystem);
 
       DriverStationSim.setEnabled(false);

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulerTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulerTest.cpp
@@ -75,8 +75,8 @@ TEST_F(SchedulerTest, SchedulerCancelAllTest) {
 
 class CounterSubsystem : public Subsystem {
  public:
-  int counter;
-  CounterSubsystem() : counter{0} {}
+  int counter{0};
+  CounterSubsystem() {}
   void DisabledInit() override { counter++; }
 };
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/commands/subsystem2/ReplaceMeSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/commands/subsystem2/ReplaceMeSubsystem.java
@@ -14,4 +14,14 @@ public class ReplaceMeSubsystem extends SubsystemBase {
   public void periodic() {
     // This method will be called once per scheduler run
   }
+
+  @Override
+  public void simulationPeriodic() {
+    // This method will be called once per scheduler run during simulation
+  }
+
+  @Override
+  public void disabledInit() {
+    // This method will be called once on entrance to Disabled mode
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbot/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbot/Robot.java
@@ -48,9 +48,7 @@ public class Robot extends TimedRobot {
 
   /** This function is called once each time the robot enters Disabled mode. */
   @Override
-  public void disabledInit() {
-    m_robotContainer.disablePIDSubsystems();
-  }
+  public void disabledInit() {}
 
   @Override
   public void disabledPeriodic() {}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbot/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbot/RobotContainer.java
@@ -81,14 +81,6 @@ public class RobotContainer {
   }
 
   /**
-   * Disables all ProfiledPIDSubsystem and PIDSubsystem instances. This should be called on robot
-   * disable to prevent integral windup.
-   */
-  public void disablePIDSubsystems() {
-    m_robotArm.disable();
-  }
-
-  /**
    * Use this to pass the autonomous command to the main {@link Robot} class.
    *
    * @return the command to run in autonomous

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbot/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbot/subsystems/DriveSubsystem.java
@@ -99,4 +99,9 @@ public class DriveSubsystem extends SubsystemBase {
   public void setMaxOutput(double maxOutput) {
     m_drive.setMaxOutput(maxOutput);
   }
+
+  @Override
+  public void disabledInit() {
+    m_drive.stopMotor();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbotoffboard/subsystems/ArmSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbotoffboard/subsystems/ArmSubsystem.java
@@ -36,4 +36,10 @@ public class ArmSubsystem extends TrapezoidProfileSubsystem {
     m_motor.setSetpoint(
         ExampleSmartMotorController.PIDMode.kPosition, setpoint.position, feedforward / 12.0);
   }
+
+  @Override
+  public void disabledInit() {
+    super.disabledInit();
+    m_motor.set(0); // Stop the motor to prevent integral windup.
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbotoffboard/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbotoffboard/subsystems/DriveSubsystem.java
@@ -99,4 +99,9 @@ public class DriveSubsystem extends SubsystemBase {
   public void setMaxOutput(double maxOutput) {
     m_drive.setMaxOutput(maxOutput);
   }
+
+  @Override
+  public void disabledInit() {
+    m_drive.stopMotor();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/drivedistanceoffboard/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/drivedistanceoffboard/subsystems/DriveSubsystem.java
@@ -112,4 +112,9 @@ public class DriveSubsystem extends SubsystemBase {
   public void setMaxOutput(double maxOutput) {
     m_drive.setMaxOutput(maxOutput);
   }
+
+  @Override
+  public void disabledInit() {
+    m_drive.stopMotor();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/subsystems/DriveSubsystem.java
@@ -104,4 +104,9 @@ public class DriveSubsystem extends SubsystemBase {
   public void setMaxOutput(double maxOutput) {
     m_drive.setMaxOutput(maxOutput);
   }
+
+  @Override
+  public void disabledInit() {
+    m_drive.stopMotor();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/subsystems/ShooterSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/subsystems/ShooterSubsystem.java
@@ -52,4 +52,10 @@ public class ShooterSubsystem extends PIDSubsystem {
   public void stopFeeder() {
     m_feederMotor.set(0);
   }
+
+  @Override
+  public void disabledInit() {
+    super.disabledInit(); // Disable the shooter PID.
+    stopFeeder(); // Stop the feeder.
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Claw.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Claw.java
@@ -53,4 +53,9 @@ public class Claw extends SubsystemBase {
   public void periodic() {
     log();
   }
+
+  @Override
+  public void disabledInit() {
+    stop();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/DriveTrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/DriveTrain.java
@@ -123,4 +123,9 @@ public class DriveTrain extends SubsystemBase {
   public void periodic() {
     log();
   }
+
+  @Override
+  public void disabledInit() {
+    m_drive.stopMotor();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/subsystems/DriveSubsystem.java
@@ -132,4 +132,9 @@ public class DriveSubsystem extends SubsystemBase {
   public double getTurnRate() {
     return m_gyro.getRate() * (DriveConstants.kGyroReversed ? -1.0 : 1.0);
   }
+
+  @Override
+  public void disabledInit() {
+    m_drive.stopMotor();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/subsystems/DriveSubsystem.java
@@ -104,4 +104,9 @@ public class DriveSubsystem extends SubsystemBase {
   public void setMaxOutput(double maxOutput) {
     m_drive.setMaxOutput(maxOutput);
   }
+
+  @Override
+  public void disabledInit() {
+    m_drive.stopMotor();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/subsystems/DriveSubsystem.java
@@ -104,4 +104,9 @@ public class DriveSubsystem extends SubsystemBase {
   public void setMaxOutput(double maxOutput) {
     m_drive.setMaxOutput(maxOutput);
   }
+
+  @Override
+  public void disabledInit() {
+    m_drive.stopMotor();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/subsystems/DriveSubsystem.java
@@ -213,4 +213,9 @@ public class DriveSubsystem extends SubsystemBase {
   public double getTurnRate() {
     return -m_gyro.getRate();
   }
+
+  @Override
+  public void disabledInit() {
+    m_drive.stopMotor();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/subsystems/DriveSubsystem.java
@@ -188,4 +188,9 @@ public class DriveSubsystem extends SubsystemBase {
   public double getTurnRate() {
     return -m_gyro.getRate();
   }
+
+  @Override
+  public void disabledInit() {
+    m_drive.stopMotor();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/romireference/subsystems/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/romireference/subsystems/Drivetrain.java
@@ -139,4 +139,9 @@ public class Drivetrain extends SubsystemBase {
   public void periodic() {
     // This method will be called once per scheduler run
   }
+
+  @Override
+  public void disabledInit() {
+    m_diffDrive.stopMotor();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/Robot.java
@@ -12,7 +12,7 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
 /**
  * This is a sample program to demonstrate the use of state-space classes in robot simulation. This
  * robot has a flywheel, elevator, arm and differential drivetrain, and interfaces with the sim
- * GUI's {@link edu.wpi.first.wpilibj.simulation.Field2d} class.
+ * GUI's {@link edu.wpi.first.wpilibj.smartdashboard.Field2d} class.
  */
 public class Robot extends TimedRobot {
   private RobotContainer m_robotContainer;
@@ -56,6 +56,5 @@ public class Robot extends TimedRobot {
   @Override
   public void disabledInit() {
     CommandScheduler.getInstance().cancelAll();
-    m_robotContainer.zeroAllOutputs();
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
@@ -71,11 +71,6 @@ public class RobotContainer {
     return m_robotDrive;
   }
 
-  /** Zeros the outputs of all subsystems. */
-  public void zeroAllOutputs() {
-    m_robotDrive.tankDriveVolts(0, 0);
-  }
-
   /**
    * Use this to pass the autonomous command to the main {@link Robot} class.
    *

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/subsystems/DriveSubsystem.java
@@ -253,4 +253,9 @@ public class DriveSubsystem extends SubsystemBase {
   public double getHeading() {
     return Math.IEEEremainder(m_gyro.getAngle(), 360) * (DriveConstants.kGyroReversed ? -1.0 : 1.0);
   }
+
+  @Override
+  public void disabledInit() {
+    m_drive.stopMotor();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/subsystems/DriveSubsystem.java
@@ -158,4 +158,12 @@ public class DriveSubsystem extends SubsystemBase {
   public double getTurnRate() {
     return m_gyro.getRate() * (DriveConstants.kGyroReversed ? -1.0 : 1.0);
   }
+
+  @Override
+  public void disabledInit() {
+    m_frontLeft.stop();
+    m_frontRight.stop();
+    m_rearLeft.stop();
+    m_rearRight.stop();
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/subsystems/SwerveModule.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/subsystems/SwerveModule.java
@@ -111,4 +111,12 @@ public class SwerveModule {
     m_driveEncoder.reset();
     m_turningEncoder.reset();
   }
+
+  /** Stop the motors. */
+  public void stop() {
+    m_driveMotor.stopMotor();
+    m_turningMotor.stopMotor();
+    m_drivePIDController.reset();
+    m_turningPIDController.reset(m_turningEncoder.get());
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbased/subsystems/ExampleSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/commandbased/subsystems/ExampleSubsystem.java
@@ -19,4 +19,9 @@ public class ExampleSubsystem extends SubsystemBase {
   public void simulationPeriodic() {
     // This method will be called once per scheduler run during simulation
   }
+
+  @Override
+  public void disabledInit() {
+    // This method will be called once on entrance to Disabled mode
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/romicommandbased/subsystems/RomiDrivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/romicommandbased/subsystems/RomiDrivetrain.java
@@ -60,4 +60,9 @@ public class RomiDrivetrain extends SubsystemBase {
   public void simulationPeriodic() {
     // This method will be called once per scheduler run during simulation
   }
+
+  @Override
+  public void disabledInit() {
+    m_diffDrive.stopMotor(); // Stop motors on disable
+  }
 }


### PR DESCRIPTION
Resolves #3442

Adds tests for `disabledInit()` as well. I didn't add tests for the `[simulation]Periodic()` functions because I wasn't sure if they're in the scope of this PR.

Should I add usage of this in examples, or is it out of scope as well?