### PR TITLE
Fix HAL Notifier thread priority setting

### DIFF
--- a/hal/src/main/native/athena/Notifier.cpp
+++ b/hal/src/main/native/athena/Notifier.cpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <thread>
 
+#include <fmt/core.h>
 #include <wpi/condition_variable.h>
 #include <wpi/mutex.h>
 
@@ -153,6 +154,14 @@ HAL_NotifierHandle HAL_InitializeNotifier(int32_t* status) {
     auto native = notifierThread.native_handle();
     HAL_SetThreadPriority(&native, notifierThreadRealTime,
                           notifierThreadPriority, status);
+    if (*status == HAL_THREAD_PRIORITY_ERROR) {
+      fmt::print("{}: HAL Notifier thread\n",
+                 HAL_THREAD_PRIORITY_ERROR_MESSAGE);
+    }
+    if (*status == HAL_THREAD_PRIORITY_RANGE_ERROR) {
+      fmt::print("{}: HAL Notifier thread\n",
+                 HAL_THREAD_PRIORITY_RANGE_ERROR_MESSAGE);
+    }
 
     notifierAlarm.reset(tAlarm::create(status));
   }

--- a/hal/src/main/native/athena/Notifier.cpp
+++ b/hal/src/main/native/athena/Notifier.cpp
@@ -155,10 +155,12 @@ HAL_NotifierHandle HAL_InitializeNotifier(int32_t* status) {
     HAL_SetThreadPriority(&native, notifierThreadRealTime,
                           notifierThreadPriority, status);
     if (*status == HAL_THREAD_PRIORITY_ERROR) {
+      *status = 0;
       fmt::print("{}: HAL Notifier thread\n",
                  HAL_THREAD_PRIORITY_ERROR_MESSAGE);
     }
     if (*status == HAL_THREAD_PRIORITY_RANGE_ERROR) {
+      *status = 0;
       fmt::print("{}: HAL Notifier thread\n",
                  HAL_THREAD_PRIORITY_RANGE_ERROR_MESSAGE);
     }

--- a/hal/src/main/native/athena/Notifier.cpp
+++ b/hal/src/main/native/athena/Notifier.cpp
@@ -27,6 +27,8 @@ static constexpr int32_t kTimerInterruptNumber = 28;
 static wpi::mutex notifierMutex;
 static std::unique_ptr<tAlarm> notifierAlarm;
 static std::thread notifierThread;
+static HAL_Bool notifierThreadRealTime = false;
+static int32_t notifierThreadPriority = 0;
 static uint64_t closestTrigger{UINT64_MAX};
 
 namespace {
@@ -147,6 +149,11 @@ HAL_NotifierHandle HAL_InitializeNotifier(int32_t* status) {
     std::scoped_lock lock(notifierMutex);
     notifierRunning = true;
     notifierThread = std::thread(notifierThreadMain);
+
+    auto native = notifierThread.native_handle();
+    HAL_SetThreadPriority(&native, notifierThreadRealTime,
+                          notifierThreadPriority, status);
+
     notifierAlarm.reset(tAlarm::create(status));
   }
 
@@ -161,8 +168,15 @@ HAL_NotifierHandle HAL_InitializeNotifier(int32_t* status) {
 
 HAL_Bool HAL_SetNotifierThreadPriority(HAL_Bool realTime, int32_t priority,
                                        int32_t* status) {
-  auto native = notifierThread.native_handle();
-  return HAL_SetThreadPriority(&native, realTime, priority, status);
+  std::scoped_lock lock(notifierMutex);
+  notifierThreadRealTime = realTime;
+  notifierThreadPriority = priority;
+  if (notifierThread.joinable()) {
+    auto native = notifierThread.native_handle();
+    return HAL_SetThreadPriority(&native, realTime, priority, status);
+  } else {
+    return true;
+  }
 }
 
 void HAL_SetNotifierName(HAL_NotifierHandle notifierHandle, const char* name,

--- a/hal/src/main/native/include/hal/Errors.h
+++ b/hal/src/main/native/include/hal/Errors.h
@@ -119,7 +119,7 @@
 
 #define HAL_THREAD_PRIORITY_ERROR -1152
 #define HAL_THREAD_PRIORITY_ERROR_MESSAGE \
-  "HAL: Getting or setting the priority of a thread has failed";
+  "HAL: Getting or setting the priority of a thread has failed"
 
 #define HAL_THREAD_PRIORITY_RANGE_ERROR -1153
 #define HAL_THREAD_PRIORITY_RANGE_ERROR_MESSAGE \
@@ -136,14 +136,13 @@
   "HAL: Use HAL_GetLastError(status) to get last error"
 
 #define HAL_SETUID_ERROR -1157
-#define HAL_SETUID_ERROR_MESSAGE \
-  "HAL: Setting the effective user ID has failed";
+#define HAL_SETUID_ERROR_MESSAGE "HAL: Setting the effective user ID has failed"
 
 #define HAL_CAN_BUFFER_OVERRUN -35007
 #define HAL_CAN_BUFFER_OVERRUN_MESSAGE \
   "HAL: CAN Output Buffer Full. Ensure a device is attached"
 
-#define VI_ERROR_SYSTEM_ERROR_MESSAGE "HAL - VISA: System Error";
+#define VI_ERROR_SYSTEM_ERROR_MESSAGE "HAL - VISA: System Error"
 #define VI_ERROR_INV_OBJECT_MESSAGE "HAL - VISA: Invalid Object"
 #define VI_ERROR_RSRC_LOCKED_MESSAGE "HAL - VISA: Resource Locked"
 #define VI_ERROR_RSRC_NFOUND_MESSAGE "HAL - VISA: Resource Not Found"


### PR DESCRIPTION
The HAL Notifier thread is started when the first Notifier is created
and stopped when the last Notifier is destroyed. Currently,
HAL_SetNotifierThreadPriority() will cause a segfault if the Notifier thread
hasn't been started yet (that is, if no Notifier have been created yet).

This change makes HAL_SetNotifierThreadPriority() store the RT and
priority setting. If the thread has already been started, it will set
the priority immediately. If it hasn't, HAL_InitiailizeNotifier() will
set the priority when it starts the thread.