### PR TITLE
[build] Generate spotless patch on failure

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -79,6 +79,17 @@ jobs:
           fetch-depth: 0
       - name: Run spotless
         run: ./gradlew spotlessCheck
+      - name: Apply Spotless
+        run: ./gradlew :spotlessApply
+        if: ${{ failure() }}
+      - name: Generate diff
+        run: git diff HEAD > spotless-fixes.patch
+        if: ${{ failure() }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: spotless fixes
+          path: spotless-fixes.patch
+        if: ${{ failure() }}
   javaformat:
     name: "Checkstyle and PMD"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Doing it for `wpiformat`, might as well cover all of the auto-formatting options.