### PR TITLE
[gitignore] update gitignore to ignore bazel / clion files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,9 @@ compile_commands.json
 .cache/
 
 imgui.ini
+
+# Bazel
+/.ijwb/
+/bazel-*
+user.bazelrc
+coverage_report/


### PR DESCRIPTION
I know the org doesn't want bazel support, but I don't see why updating the `.gitignore` file should hurt. Would help me out when I switch back to a bazel-less branch so I don't have 4 folders / thousands of untracked files