### PR TITLE
Upgrade CMake build to googletest 1.11.0

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -22,3 +22,6 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
                  ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
                  EXCLUDE_FROM_ALL)
+
+target_compile_features(gtest PUBLIC cxx_std_17)
+target_compile_features(gtest_main PUBLIC cxx_std_17)

--- a/googletest/CMakeLists.txt.in
+++ b/googletest/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           b4676595c03a26bb84f68542c8b74d3d89b38b68
+  GIT_TAG           e2239ee6043f73722e7aa812a459f54a28552929 # 1.11.0
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/ntcore/CMakeLists.txt
+++ b/ntcore/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories(ntcore PUBLIC
                 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/include>
                             $<INSTALL_INTERFACE:${include_dest}/ntcore>)
 wpilib_target_warnings(ntcore)
+target_compile_features(ntcore PUBLIC cxx_std_17)
 target_link_libraries(ntcore PUBLIC wpiutil)
 
 set_property(TARGET ntcore PROPERTY FOLDER "libraries")

--- a/wpiutil/src/test/native/cpp/span/test_span.cpp
+++ b/wpiutil/src/test/native/cpp/span/test_span.cpp
@@ -1,6 +1,7 @@
 
 #include "wpi/span.h"
 
+#include <algorithm>
 #include <cassert>
 #include <deque>
 #include <initializer_list>


### PR DESCRIPTION
This upgrade uncovered two issues:

ntcore wasn't forcing C++17, which caused a linker error with googletest
Matcher symbols:
```
undefined reference to `testing::Matcher<std::basic_string_view<char, std::char_traits<char> > >::Matcher(std::basic_string_view<char, std::char_traits<char> >)'
```

test_span.cpp wasn't including `<algorithm>` to use std::sort() and
std::is_sorted().