### PR TITLE
Fix AnalogTriggerOutput memory leak reported by asan

### DIFF
--- a/wpilibc/src/main/native/cpp/AnalogTrigger.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogTrigger.cpp
@@ -109,8 +109,7 @@ bool AnalogTrigger::GetTriggerState() {
 std::shared_ptr<AnalogTriggerOutput> AnalogTrigger::CreateOutput(
     AnalogTriggerType type) const {
   return std::shared_ptr<AnalogTriggerOutput>(
-      new AnalogTriggerOutput(*this, type),
-      wpi::NullDeleter<AnalogTriggerOutput>());
+      new AnalogTriggerOutput(*this, type));
 }
 
 void AnalogTrigger::InitSendable(wpi::SendableBuilder& builder) {


### PR DESCRIPTION
Fixes #3542.

Co-authored-by: Peter Johnson <johnson.peter@gmail.com>