### PR TITLE
Disable doxygen linking for common words that are also classes

### DIFF
--- a/wpilibc/src/main/native/include/frc/ADXRS450_Gyro.h
+++ b/wpilibc/src/main/native/include/frc/ADXRS450_Gyro.h
@@ -18,7 +18,7 @@ namespace frc {
 /**
  * Use a rate gyro to return the robots heading relative to a starting position.
  *
- * The Gyro class tracks the robots heading based on the starting position. As
+ * The %Gyro class tracks the robots heading based on the starting position. As
  * the robot rotates the new heading is computed by integrating the rate of
  * rotation returned by the sensor. When the class is instantiated, it does a
  * short calibration routine where it samples the gyro while at rest to
@@ -26,19 +26,19 @@ namespace frc {
  * determine the heading.
  *
  * This class is for the digital ADXRS450 gyro sensor that connects via SPI.
- * Only one instance of an ADXRS Gyro is supported.
+ * Only one instance of an ADXRS %Gyro is supported.
  */
 class ADXRS450_Gyro : public Gyro,
                       public wpi::Sendable,
                       public wpi::SendableHelper<ADXRS450_Gyro> {
  public:
   /**
-   * Gyro constructor on onboard CS0.
+   * %Gyro constructor on onboard CS0.
    */
   ADXRS450_Gyro();
 
   /**
-   * Gyro constructor on the specified SPI port.
+   * %Gyro constructor on the specified SPI port.
    *
    * @param port The SPI port the gyro is attached to.
    */

--- a/wpilibc/src/main/native/include/frc/AnalogGyro.h
+++ b/wpilibc/src/main/native/include/frc/AnalogGyro.h
@@ -40,7 +40,7 @@ class AnalogGyro : public Gyro,
   static constexpr double kDefaultVoltsPerDegreePerSecond = 0.007;
 
   /**
-   * Gyro constructor using the Analog Input channel number.
+   * %Gyro constructor using the Analog Input channel number.
    *
    * @param channel The analog channel the gyro is connected to. Gyros can only
    *                be used on on-board Analog Inputs 0-1.
@@ -48,7 +48,7 @@ class AnalogGyro : public Gyro,
   explicit AnalogGyro(int channel);
 
   /**
-   * Gyro constructor with a precreated AnalogInput object.
+   * @Gyro constructor with a precreated AnalogInput object.
    *
    * Use this constructor when the analog channel needs to be shared.
    * This object will not clean up the AnalogInput object when using this
@@ -62,7 +62,7 @@ class AnalogGyro : public Gyro,
   explicit AnalogGyro(AnalogInput* channel);
 
   /**
-   * Gyro constructor with a precreated AnalogInput object.
+   * %Gyro constructor with a precreated AnalogInput object.
    *
    * Use this constructor when the analog channel needs to be shared.
    * This object will not clean up the AnalogInput object when using this
@@ -74,7 +74,7 @@ class AnalogGyro : public Gyro,
   explicit AnalogGyro(std::shared_ptr<AnalogInput> channel);
 
   /**
-   * Gyro constructor using the Analog Input channel number with parameters for
+   * %Gyro constructor using the Analog Input channel number with parameters for
    * presetting the center and offset values. Bypasses calibration.
    *
    * @param channel The analog channel the gyro is connected to. Gyros can only
@@ -86,7 +86,7 @@ class AnalogGyro : public Gyro,
   AnalogGyro(int channel, int center, double offset);
 
   /**
-   * Gyro constructor with a precreated AnalogInput object and calibrated
+   * %Gyro constructor with a precreated AnalogInput object and calibrated
    * parameters.
    *
    * Use this constructor when the analog channel needs to be shared.

--- a/wpilibc/src/main/native/include/frc/AsynchronousInterrupt.h
+++ b/wpilibc/src/main/native/include/frc/AsynchronousInterrupt.h
@@ -116,8 +116,8 @@ class AsynchronousInterrupt {
   /**
    * Set which edges to trigger the interrupt on.
    *
-   * @param risingEdge Trigger on rising edge
-   * @param fallingEdge Trigger on falling edge
+   * @param risingEdge %Trigger on rising edge
+   * @param fallingEdge %Trigger on falling edge
    */
   void SetInterruptEdges(bool risingEdge, bool fallingEdge);
 

--- a/wpilibc/src/main/native/include/frc/Counter.h
+++ b/wpilibc/src/main/native/include/frc/Counter.h
@@ -77,7 +77,7 @@ class Counter : public CounterBase,
    *
    * This is used if an existing digital input is to be shared by multiple other
    * objects such as encoders or if the Digital Source is not a Digital Input
-   * channel (such as an Analog Trigger).
+   * channel (such as an Analog %Trigger).
    *
    * The counter will start counting immediately.
    * @param source A pointer to the existing DigitalSource object. It will be
@@ -91,7 +91,7 @@ class Counter : public CounterBase,
    *
    * This is used if an existing digital input is to be shared by multiple other
    * objects such as encoders or if the Digital Source is not a Digital Input
-   * channel (such as an Analog Trigger).
+   * channel (such as an Analog %Trigger).
    *
    * The counter will start counting immediately.
    *

--- a/wpilibc/src/main/native/include/frc/DriverStation.h
+++ b/wpilibc/src/main/native/include/frc/DriverStation.h
@@ -32,7 +32,7 @@ class DriverStation {
   static constexpr int kJoystickPorts = 6;
 
   /**
-   * The state of one joystick button. Button indexes begin at 1.
+   * The state of one joystick button. %Button indexes begin at 1.
    *
    * @param stick  The joystick to read.
    * @param button The button index, beginning at 1.
@@ -41,7 +41,7 @@ class DriverStation {
   static bool GetStickButton(int stick, int button);
 
   /**
-   * Whether one joystick button was pressed since the last check. Button
+   * Whether one joystick button was pressed since the last check. %Button
    * indexes begin at 1.
    *
    * @param stick  The joystick to read.
@@ -51,7 +51,7 @@ class DriverStation {
   static bool GetStickButtonPressed(int stick, int button);
 
   /**
-   * Whether one joystick button was released since the last check. Button
+   * Whether one joystick button was released since the last check. %Button
    * indexes begin at 1.
    *
    * @param stick  The joystick to read.

--- a/wpilibc/src/main/native/include/frc/GenericHID.h
+++ b/wpilibc/src/main/native/include/frc/GenericHID.h
@@ -66,7 +66,7 @@ class GenericHID {
   bool GetRawButton(int button) const;
 
   /**
-   * Whether the button was pressed since the last check. Button indexes begin
+   * Whether the button was pressed since the last check. %Button indexes begin
    * at 1.
    *
    * This method returns true if the button went from not pressed to held down
@@ -79,7 +79,7 @@ class GenericHID {
   bool GetRawButtonPressed(int button);
 
   /**
-   * Whether the button was released since the last check. Button indexes begin
+   * Whether the button was released since the last check. %Button indexes begin
    * at 1.
    *
    * This method returns true if the button went from held down to not pressed

--- a/wpilibc/src/main/native/include/frc/Solenoid.h
+++ b/wpilibc/src/main/native/include/frc/Solenoid.h
@@ -84,7 +84,7 @@ class Solenoid : public wpi::Sendable, public wpi::SendableHelper<Solenoid> {
   void SetPulseDuration(units::second_t duration);
 
   /**
-   * Trigger the PCM to generate a pulse of the duration set in
+   * %Trigger the PCM to generate a pulse of the duration set in
    * setPulseDuration.
    *
    * @see setPulseDuration()

--- a/wpilibc/src/main/native/include/frc/motorcontrol/DMC60.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/DMC60.h
@@ -9,7 +9,7 @@
 namespace frc {
 
 /**
- * Digilent DMC 60 Motor Controller.
+ * Digilent DMC 60 Motor %Controller.
  *
  * Note that the DMC 60 uses the following bounds for PWM values. These
  * values should work reasonably well for most controllers, but if users

--- a/wpilibc/src/main/native/include/frc/motorcontrol/Jaguar.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/Jaguar.h
@@ -9,7 +9,7 @@
 namespace frc {
 
 /**
- * Luminary Micro / Vex Robotics Jaguar Motor Controller with PWM control.
+ * Luminary Micro / Vex Robotics Jaguar Motor %Controller with PWM control.
  *
  * Note that the Jaguar uses the following bounds for PWM values. These values
  * should work reasonably well for most controllers, but if users experience

--- a/wpilibc/src/main/native/include/frc/motorcontrol/PWMMotorController.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/PWMMotorController.h
@@ -63,7 +63,7 @@ class PWMMotorController : public MotorController,
 
  protected:
   /**
-   * Constructor for a PWM Motor Controller connected via PWM.
+   * Constructor for a PWM Motor %Controller connected via PWM.
    *
    * @param name Name to use for SendableRegistry
    * @param channel The PWM channel that the controller is attached to. 0-9 are

--- a/wpilibc/src/main/native/include/frc/motorcontrol/PWMSparkMax.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/PWMSparkMax.h
@@ -9,7 +9,7 @@
 namespace frc {
 
 /**
- * REV Robotics SPARK MAX Motor Controller.
+ * REV Robotics SPARK MAX Motor %Controller.
  *
  * Note that the SPARK MAX uses the following bounds for PWM values. These
  * values should work reasonably well for most controllers, but if users

--- a/wpilibc/src/main/native/include/frc/motorcontrol/PWMTalonFX.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/PWMTalonFX.h
@@ -9,14 +9,14 @@
 namespace frc {
 
 /**
- * Cross the Road Electronics (CTRE) Talon FX Motor Controller with PWM
+ * Cross the Road Electronics (CTRE) %Talon FX Motor %Controller with PWM
  * control.
  *
- * Note that the Talon FX uses the following bounds for PWM values. These
+ * Note that the %Talon FX uses the following bounds for PWM values. These
  * values should work reasonably well for most controllers, but if users
  * experience issues such as asymmetric behavior around the deadband or
  * inability to saturate the controller in either direction, calibration is
- * recommended. The calibration procedure can be found in the Talon FX User
+ * recommended. The calibration procedure can be found in the %Talon FX User
  * Manual available from Cross The Road Electronics.
  *
  * \li 2.004ms = full "forward"
@@ -28,9 +28,9 @@ namespace frc {
 class PWMTalonFX : public PWMMotorController {
  public:
   /**
-   * Construct a Talon FX connected via PWM.
+   * Construct a %Talon FX connected via PWM.
    *
-   * @param channel The PWM channel that the Talon FX is attached to. 0-9 are
+   * @param channel The PWM channel that the %Talon FX is attached to. 0-9 are
    *                on-board, 10-19 are on the MXP port
    */
   explicit PWMTalonFX(int channel);

--- a/wpilibc/src/main/native/include/frc/motorcontrol/PWMTalonSRX.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/PWMTalonSRX.h
@@ -9,14 +9,14 @@
 namespace frc {
 
 /**
- * Cross the Road Electronics (CTRE) Talon SRX Motor Controller with PWM
+ * Cross the Road Electronics (CTRE) %Talon SRX Motor %Controller with PWM
  * control.
  *
- * Note that the Talon SRX uses the following bounds for PWM values. These
+ * Note that the %Talon SRX uses the following bounds for PWM values. These
  * values should work reasonably well for most controllers, but if users
  * experience issues such as asymmetric behavior around the deadband or
  * inability to saturate the controller in either direction, calibration is
- * recommended. The calibration procedure can be found in the Talon SRX User
+ * recommended. The calibration procedure can be found in the %Talon SRX User
  * Manual available from Cross The Road Electronics.
  *
  * \li 2.004ms = full "forward"
@@ -28,9 +28,9 @@ namespace frc {
 class PWMTalonSRX : public PWMMotorController {
  public:
   /**
-   * Construct a Talon SRX connected via PWM.
+   * Construct a %Talon SRX connected via PWM.
    *
-   * @param channel The PWM channel that the Talon SRX is attached to. 0-9 are
+   * @param channel The PWM channel that the %Talon SRX is attached to. 0-9 are
    *                on-board, 10-19 are on the MXP port
    */
   explicit PWMTalonSRX(int channel);

--- a/wpilibc/src/main/native/include/frc/motorcontrol/PWMVictorSPX.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/PWMVictorSPX.h
@@ -9,14 +9,14 @@
 namespace frc {
 
 /**
- * Cross the Road Electronics (CTRE) Victor SPX Motor Controller with PWM
+ * Cross the Road Electronics (CTRE) %Victor SPX Motor %Controller with PWM
  * control.
  *
- * Note that the Victor SPX uses the following bounds for PWM values. These
+ * Note that the %Victor SPX uses the following bounds for PWM values. These
  * values should work reasonably well for most controllers, but if users
  * experience issues such as asymmetric behavior around the deadband or
  * inability to saturate the controller in either direction, calibration is
- * recommended. The calibration procedure can be found in the Victor SPX User
+ * recommended. The calibration procedure can be found in the %Victor SPX User
  * Manual available from Cross The Road Electronics.
  *
  * \li 2.004ms = full "forward"
@@ -28,9 +28,9 @@ namespace frc {
 class PWMVictorSPX : public PWMMotorController {
  public:
   /**
-   * Construct a Victor SPX connected via PWM.
+   * Construct a %Victor SPX connected via PWM.
    *
-   * @param channel The PWM channel that the Victor SPX is attached to. 0-9
+   * @param channel The PWM channel that the %Victor SPX is attached to. 0-9
    *                are on-board, 10-19 are on the MXP port
    */
   explicit PWMVictorSPX(int channel);

--- a/wpilibc/src/main/native/include/frc/motorcontrol/SD540.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/SD540.h
@@ -9,7 +9,7 @@
 namespace frc {
 
 /**
- * Mindsensors SD540 Motor Controller.
+ * Mindsensors SD540 Motor %Controller.
  *
  * Note that the SD540 uses the following bounds for PWM values. These values
  * should work reasonably well for most controllers, but if users experience

--- a/wpilibc/src/main/native/include/frc/motorcontrol/Spark.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/Spark.h
@@ -9,7 +9,7 @@
 namespace frc {
 
 /**
- * REV Robotics SPARK Motor Controller.
+ * REV Robotics SPARK Motor %Controller.
  *
  * Note that the SPARK uses the following bounds for PWM values. These values
  * should work reasonably well for most controllers, but if users experience

--- a/wpilibc/src/main/native/include/frc/motorcontrol/Talon.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/Talon.h
@@ -9,13 +9,13 @@
 namespace frc {
 
 /**
- * Cross the Road Electronics (CTRE) Talon and Talon SR Motor Controller.
+ * Cross the Road Electronics (CTRE) %Talon and %Talon SR Motor %Controller.
  *
- * Note that the Talon uses the following bounds for PWM values. These values
+ * Note that the %Talon uses the following bounds for PWM values. These values
  * should work reasonably well for most controllers, but if users experience
  * issues such as asymmetric behavior around the deadband or inability to
  * saturate the controller in either direction, calibration is recommended.
- * The calibration procedure can be found in the Talon User Manual available
+ * The calibration procedure can be found in the %Talon User Manual available
  * from CTRE.
  *
  * \li 2.037ms = full "forward"
@@ -27,9 +27,9 @@ namespace frc {
 class Talon : public PWMMotorController {
  public:
   /**
-   * Constructor for a Talon (original or Talon SR).
+   * Constructor for a %Talon (original or %Talon SR).
    *
-   * @param channel The PWM channel number that the Talon is attached to. 0-9
+   * @param channel The PWM channel number that the %Talon is attached to. 0-9
    *                are on-board, 10-19 are on the MXP port
    */
   explicit Talon(int channel);

--- a/wpilibc/src/main/native/include/frc/motorcontrol/Victor.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/Victor.h
@@ -9,17 +9,17 @@
 namespace frc {
 
 /**
- * Vex Robotics Victor 888 Motor Controller.
+ * Vex Robotics %Victor 888 Motor %Controller.
  *
- * The Vex Robotics Victor 884 Motor Controller can also be used with this
+ * The Vex Robotics %Victor 884 Motor %Controller can also be used with this
  * class but may need to be calibrated per the Victor 884 user manual.
  *
- * Note that the Victor uses the following bounds for PWM values.  These
- * values were determined empirically and optimized for the Victor 888. These
- * values should work reasonably well for Victor 884 controllers as well but
+ * Note that the %Victor uses the following bounds for PWM values.  These
+ * values were determined empirically and optimized for the %Victor 888. These
+ * values should work reasonably well for %Victor 884 controllers as well but
  * if users experience issues such as asymmetric behavior around the deadband
  * or inability to saturate the controller in either direction, calibration is
- * recommended. The calibration procedure can be found in the Victor 884 User
+ * recommended. The calibration procedure can be found in the %Victor 884 User
  * Manual available from Vex.
  *
  * \li 2.027ms = full "forward"
@@ -31,9 +31,9 @@ namespace frc {
 class Victor : public PWMMotorController {
  public:
   /**
-   * Constructor for a Victor.
+   * Constructor for a %Victor.
    *
-   * @param channel The PWM channel number that the Victor is attached to. 0-9
+   * @param channel The PWM channel number that the %Victor is attached to. 0-9
    *                are on-board, 10-19 are on the MXP port
    */
   explicit Victor(int channel);

--- a/wpilibc/src/main/native/include/frc/motorcontrol/VictorSP.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/VictorSP.h
@@ -9,13 +9,13 @@
 namespace frc {
 
 /**
- * Vex Robotics Victor SP Motor Controller.
+ * Vex Robotics %Victor SP Motor %Controller.
  *
- * Note that the Victor SP uses the following bounds for PWM values. These
+ * Note that the %Victor SP uses the following bounds for PWM values. These
  * values should work reasonably well for most controllers, but if users
  * experience issues such as asymmetric behavior around the deadband or
  * inability to saturate the controller in either direction, calibration is
- * recommended. The calibration procedure can be found in the Victor SP User
+ * recommended. The calibration procedure can be found in the %Victor SP User
  * Manual available from Vex.
  *
  * \li 2.004ms = full "forward"
@@ -27,9 +27,9 @@ namespace frc {
 class VictorSP : public PWMMotorController {
  public:
   /**
-   * Constructor for a Victor SP.
+   * Constructor for a %Victor SP.
    *
-   * @param channel The PWM channel that the VictorSP is attached to. 0-9 are
+   * @param channel The PWM channel that the Victor SP is attached to. 0-9 are
    *                on-board, 10-19 are on the MXP port
    */
   explicit VictorSP(int channel);

--- a/wpilibc/src/main/native/include/frc/simulation/DriverStationSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/DriverStationSim.h
@@ -257,7 +257,7 @@ class DriverStationSim {
   static int GetJoystickRumble(int stick, int rumbleNum);
 
   /**
-   * Sets the state of one joystick button. Button indexes begin at 1.
+   * Sets the state of one joystick button. %Button indexes begin at 1.
    *
    * @param stick The joystick number
    * @param button The button index, beginning at 1


### PR DESCRIPTION
Add % in front of name in order to suppress doxygen link creation. https://www.doxygen.nl/manual/autolink.html

Here's an example of what it looked like before: 
![image](https://user-images.githubusercontent.com/4885091/133001396-5eabf780-0754-4561-800e-707381a4b5ff.png)

Both Victor and Controller are suppressed. After:
![image](https://user-images.githubusercontent.com/4885091/133001684-43308318-67bd-481a-b14d-6af922fc5def.png)
