### PR TITLE
Update runtime enum to allow selecting roborio 2

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/HALUtil.java
+++ b/hal/src/main/java/edu/wpi/first/hal/HALUtil.java
@@ -15,6 +15,10 @@ public final class HALUtil extends JNIWrapper {
   public static final int NO_AVAILABLE_RESOURCES = -104;
   public static final int PARAMETER_OUT_OF_RANGE = -1028;
 
+  public static final int RUNTIME_ROBORIO = 0;
+  public static final int RUNTIME_ROBORIO2 = 1;
+  public static final int RUNTIME_SIMULATION = 2;
+
   public static native short getFPGAVersion();
 
   public static native int getFPGARevision();

--- a/hal/src/main/native/athena/HAL.cpp
+++ b/hal/src/main/native/athena/HAL.cpp
@@ -232,7 +232,11 @@ const char* HAL_GetErrorMessage(int32_t code) {
 }
 
 HAL_RuntimeType HAL_GetRuntimeType(void) {
-  return HAL_Athena;
+  nLoadOut::tTargetClass targetClass = nLoadOut::getTargetClass();
+  if (targetClass == nLoadOut::kTargetClass_RoboRIO2) {
+    return HAL_Runtime_RoboRIO2;
+  }
+  return HAL_Runtime_RoboRIO;
 }
 
 int32_t HAL_GetFPGAVersion(int32_t* status) {

--- a/hal/src/main/native/cpp/jni/HALUtil.cpp
+++ b/hal/src/main/native/cpp/jni/HALUtil.cpp
@@ -30,6 +30,10 @@ using namespace wpi::java;
 #define kRIOStatusFeatureNotSupported (kRioStatusOffset - 193)
 #define kRIOStatusResourceNotInitialized -52010
 
+static_assert(edu_wpi_first_hal_HALUtil_RUNTIME_ROBORIO == HAL_Runtime_RoboRIO);
+static_assert(edu_wpi_first_hal_HALUtil_RUNTIME_ROBORIO2 == HAL_Runtime_RoboRIO2);
+static_assert(edu_wpi_first_hal_HALUtil_RUNTIME_SIMULATION == HAL_Runtime_Simulation);
+
 static JavaVM* jvm = nullptr;
 static JException illegalArgExCls;
 static JException boundaryExCls;

--- a/hal/src/main/native/cpp/jni/HALUtil.cpp
+++ b/hal/src/main/native/cpp/jni/HALUtil.cpp
@@ -31,8 +31,10 @@ using namespace wpi::java;
 #define kRIOStatusResourceNotInitialized -52010
 
 static_assert(edu_wpi_first_hal_HALUtil_RUNTIME_ROBORIO == HAL_Runtime_RoboRIO);
-static_assert(edu_wpi_first_hal_HALUtil_RUNTIME_ROBORIO2 == HAL_Runtime_RoboRIO2);
-static_assert(edu_wpi_first_hal_HALUtil_RUNTIME_SIMULATION == HAL_Runtime_Simulation);
+static_assert(edu_wpi_first_hal_HALUtil_RUNTIME_ROBORIO2 ==
+              HAL_Runtime_RoboRIO2);
+static_assert(edu_wpi_first_hal_HALUtil_RUNTIME_SIMULATION ==
+              HAL_Runtime_Simulation);
 
 static JavaVM* jvm = nullptr;
 static JException illegalArgExCls;

--- a/hal/src/main/native/include/hal/HALBase.h
+++ b/hal/src/main/native/include/hal/HALBase.h
@@ -15,7 +15,7 @@
  */
 
 // clang-format off
-HAL_ENUM(HAL_RuntimeType) { HAL_Athena, HAL_Mock };
+HAL_ENUM(HAL_RuntimeType) { HAL_Runtime_RoboRIO, HAL_Runtime_RoboRIO2, HAL_Runtime_Simulation };
 // clang-format on
 
 #ifdef __cplusplus
@@ -64,6 +64,11 @@ int32_t HAL_GetFPGAVersion(int32_t* status);
  */
 int64_t HAL_GetFPGARevision(int32_t* status);
 
+/**
+ * Returns the runtime type of the HAL.
+ * 
+ * @return HAL Runtime Type
+ */
 HAL_RuntimeType HAL_GetRuntimeType(void);
 
 /**

--- a/hal/src/main/native/include/hal/HALBase.h
+++ b/hal/src/main/native/include/hal/HALBase.h
@@ -66,7 +66,7 @@ int64_t HAL_GetFPGARevision(int32_t* status);
 
 /**
  * Returns the runtime type of the HAL.
- * 
+ *
  * @return HAL Runtime Type
  */
 HAL_RuntimeType HAL_GetRuntimeType(void);

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -51,7 +51,7 @@ class SimPeriodicCallbackRegistry : public impl::SimCallbackRegistryBase {
 };
 }  // namespace
 
-static HAL_RuntimeType runtimeType{HAL_Mock};
+static HAL_RuntimeType runtimeType{HAL_Runtime_Simulation};
 static wpi::spinlock gOnShutdownMutex;
 static std::vector<std::pair<void*, void (*)(void*)>> gOnShutdown;
 static SimPeriodicCallbackRegistry gSimPeriodicBefore;

--- a/wpilibc/src/main/native/cppcs/RobotBase.cpp
+++ b/wpilibc/src/main/native/cppcs/RobotBase.cpp
@@ -25,9 +25,12 @@
 #include "frc/livewindow/LiveWindow.h"
 #include "frc/smartdashboard/SmartDashboard.h"
 
-static_assert(frc::RuntimeType::kRoboRIO == HAL_Runtime_RoboRIO);
-static_assert(frc::RuntimeType::kRoboRIO2 == HAL_Runtime_RoboRIO2);
-static_assert(frc::RuntimeType::kSimulation == HAL_Runtime_Simulation);
+static_assert(frc::RuntimeType::kRoboRIO ==
+              static_cast<frc::RuntimeType>(HAL_Runtime_RoboRIO));
+static_assert(frc::RuntimeType::kRoboRIO2 ==
+              static_cast<frc::RuntimeType>(HAL_Runtime_RoboRIO2));
+static_assert(frc::RuntimeType::kSimulation ==
+              static_cast<frc::RuntimeType>(HAL_Runtime_Simulation));
 
 using SetCameraServerSharedFP = void (*)(frc::CameraServerShared*);
 

--- a/wpilibc/src/main/native/cppcs/RobotBase.cpp
+++ b/wpilibc/src/main/native/cppcs/RobotBase.cpp
@@ -25,6 +25,10 @@
 #include "frc/livewindow/LiveWindow.h"
 #include "frc/smartdashboard/SmartDashboard.h"
 
+static_assert(frc::RuntimeType::kRoboRIO == HAL_Runtime_RoboRIO);
+static_assert(frc::RuntimeType::kRoboRIO2 == HAL_Runtime_RoboRIO2);
+static_assert(frc::RuntimeType::kSimulation == HAL_Runtime_Simulation);
+
 using SetCameraServerSharedFP = void (*)(frc::CameraServerShared*);
 
 using namespace frc;
@@ -211,6 +215,10 @@ bool RobotBase::IsNewDataAvailable() const {
 
 std::thread::id RobotBase::GetThreadId() {
   return m_threadId;
+}
+
+RuntimeType RobotBase::GetRuntimeType() {
+  return static_cast<RuntimeType>(HAL_GetRuntimeType());
 }
 
 RobotBase::RobotBase() {

--- a/wpilibc/src/main/native/include/frc/RobotBase.h
+++ b/wpilibc/src/main/native/include/frc/RobotBase.h
@@ -214,7 +214,7 @@ class RobotBase {
 
   /**
    * Get the current runtime type.
-   * 
+   *
    * @return Current runtime type.
    */
   static RuntimeType GetRuntimeType();

--- a/wpilibc/src/main/native/include/frc/RobotBase.h
+++ b/wpilibc/src/main/native/include/frc/RobotBase.h
@@ -15,6 +15,7 @@
 #include <wpi/mutex.h>
 
 #include "frc/Errors.h"
+#include "frc/RuntimeType.h"
 
 namespace frc {
 
@@ -210,6 +211,13 @@ class RobotBase {
   virtual void StartCompetition() = 0;
 
   virtual void EndCompetition() = 0;
+
+  /**
+   * Get the current runtime type.
+   * 
+   * @return Current runtime type.
+   */
+  static RuntimeType GetRuntimeType();
 
   /**
    * Get if the robot is real.

--- a/wpilibc/src/main/native/include/frc/RuntimeType.h
+++ b/wpilibc/src/main/native/include/frc/RuntimeType.h
@@ -6,4 +6,4 @@
 
 namespace frc {
 enum RuntimeType { kRoboRIO, kRoboRIO2, kSimulation };
-} // namespace frc
+}  // namespace frc

--- a/wpilibc/src/main/native/include/frc/RuntimeType.h
+++ b/wpilibc/src/main/native/include/frc/RuntimeType.h
@@ -2,10 +2,12 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+#pragma once
+
 namespace frc {
 enum RuntimeType {
-    kRoboRIO,
-    kRoboRIO2,
-    kSimulation
+  kRoboRIO,
+  kRoboRIO2,
+  kSimulation
 };
 }

--- a/wpilibc/src/main/native/include/frc/RuntimeType.h
+++ b/wpilibc/src/main/native/include/frc/RuntimeType.h
@@ -5,9 +5,5 @@
 #pragma once
 
 namespace frc {
-enum RuntimeType {
-  kRoboRIO,
-  kRoboRIO2,
-  kSimulation
-};
+enum RuntimeType { kRoboRIO, kRoboRIO2, kSimulation };
 }

--- a/wpilibc/src/main/native/include/frc/RuntimeType.h
+++ b/wpilibc/src/main/native/include/frc/RuntimeType.h
@@ -2,11 +2,10 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include "gtest/gtest.h"
-#include "hal/HAL.h"
-
-namespace hal {
-TEST(HALTests, RuntimeType) {
-  EXPECT_EQ(HAL_RuntimeType::HAL_Runtime_Simulation, HAL_GetRuntimeType());
+namespace frc {
+enum RuntimeType {
+    kRoboRIO,
+    kRoboRIO2,
+    kSimulation
+};
 }
-}  // namespace hal

--- a/wpilibc/src/main/native/include/frc/RuntimeType.h
+++ b/wpilibc/src/main/native/include/frc/RuntimeType.h
@@ -6,4 +6,4 @@
 
 namespace frc {
 enum RuntimeType { kRoboRIO, kRoboRIO2, kSimulation };
-}
+} // namespace frc

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -161,6 +161,15 @@ public abstract class RobotBase implements AutoCloseable {
   public void close() {}
 
   /**
+   * Get the current runtime type.
+   * 
+   * @return Current runtime type.
+   */
+  public static RuntimeType getRuntimeType() {
+    return RuntimeType.getValue(HALUtil.getHALRuntimeType());
+  }
+
+  /**
    * Get if the robot is a simulation.
    *
    * @return If the robot is running in simulation.
@@ -175,7 +184,9 @@ public abstract class RobotBase implements AutoCloseable {
    * @return If the robot is running in the real world.
    */
   public static boolean isReal() {
-    return HALUtil.getHALRuntimeType() == 0;
+    RuntimeType runtimeType = getRuntimeType();
+    return runtimeType == RuntimeType.kRoboRIO || 
+           runtimeType == RuntimeType.kRoboRIO2;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -162,7 +162,7 @@ public abstract class RobotBase implements AutoCloseable {
 
   /**
    * Get the current runtime type.
-   * 
+   *
    * @return Current runtime type.
    */
   public static RuntimeType getRuntimeType() {
@@ -185,8 +185,7 @@ public abstract class RobotBase implements AutoCloseable {
    */
   public static boolean isReal() {
     RuntimeType runtimeType = getRuntimeType();
-    return runtimeType == RuntimeType.kRoboRIO || 
-           runtimeType == RuntimeType.kRoboRIO2;
+    return runtimeType == RuntimeType.kRoboRIO || runtimeType == RuntimeType.kRoboRIO2;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RuntimeType.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RuntimeType.java
@@ -27,7 +27,7 @@ public enum RuntimeType {
     if (type == HALUtil.RUNTIME_ROBORIO) {
       return RuntimeType.kRoboRIO;
     } else if (type == HALUtil.RUNTIME_ROBORIO2) {
-      return RuntimeType.kRoboRIO;
+      return RuntimeType.kRoboRIO2;
     }
     return RuntimeType.kSimulation;
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RuntimeType.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RuntimeType.java
@@ -7,22 +7,28 @@ package edu.wpi.first.wpilibj;
 import edu.wpi.first.hal.HALUtil;
 
 public enum RuntimeType {
-    kRoboRIO(HALUtil.RUNTIME_ROBORIO),
-    kRoboRIO2(HALUtil.RUNTIME_ROBORIO2),
-    kSimulation(HALUtil.RUNTIME_SIMULATION);
+  kRoboRIO(HALUtil.RUNTIME_ROBORIO),
+  kRoboRIO2(HALUtil.RUNTIME_ROBORIO2),
+  kSimulation(HALUtil.RUNTIME_SIMULATION);
 
-    public final int value;
+  public final int value;
 
-    RuntimeType(int value) {
-      this.value = value;
+  RuntimeType(int value) {
+    this.value = value;
+  }
+
+  /**
+   * Construct a runtime type from an int value.
+   *
+   * @param type Runtime type as int
+   * @return Matching runtime type
+   */
+  public static RuntimeType getValue(int type) {
+    if (type == HALUtil.RUNTIME_ROBORIO) {
+      return RuntimeType.kRoboRIO;
+    } else if (type == HALUtil.RUNTIME_ROBORIO2) {
+      return RuntimeType.kRoboRIO;
     }
-
-    public static RuntimeType getValue(int type) {
-        if (type == HALUtil.RUNTIME_ROBORIO) {
-            return RuntimeType.kRoboRIO;
-        } else if (type == HALUtil.RUNTIME_ROBORIO2) {
-            return RuntimeType.kRoboRIO;
-        }
-        return RuntimeType.kSimulation;
-    }
+    return RuntimeType.kSimulation;
+  }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RuntimeType.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RuntimeType.java
@@ -1,0 +1,28 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj;
+
+import edu.wpi.first.hal.HALUtil;
+
+public enum RuntimeType {
+    kRoboRIO(HALUtil.RUNTIME_ROBORIO),
+    kRoboRIO2(HALUtil.RUNTIME_ROBORIO2),
+    kSimulation(HALUtil.RUNTIME_SIMULATION);
+
+    public final int value;
+
+    RuntimeType(int value) {
+      this.value = value;
+    }
+
+    public static RuntimeType getValue(int type) {
+        if (type == HALUtil.RUNTIME_ROBORIO) {
+            return RuntimeType.kRoboRIO;
+        } else if (type == HALUtil.RUNTIME_ROBORIO2) {
+            return RuntimeType.kRoboRIO;
+        }
+        return RuntimeType.kSimulation;
+    }
+}


### PR DESCRIPTION
In some cases, knowing roborio 2 might be useful. This also creates a higher level enum that might be usable later for the discussion on more complex runtime types.