### PR TITLE
[wpiutil] Add Java function package

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
@@ -9,6 +9,7 @@ import edu.wpi.first.networktables.NTSendableBuilder;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableValue;
+import edu.wpi.first.util.function.BooleanConsumer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BooleanSupplier;

--- a/wpiutil/src/main/java/edu/wpi/first/util/function/BooleanConsumer.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/function/BooleanConsumer.java
@@ -1,0 +1,22 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.function;
+
+/**
+ * Represents an operation that accepts a single boolean-valued argument and returns no result. This
+ * is the primitive type specialization of {@link java.util.function.Consumer} for boolean. Unlike
+ * most other functional interfaces, BooleanConsumer is expected to operate via side-effects.
+ *
+ * <p>This is a functional interface whose functional method is {@link #accept(boolean)}.
+ */
+@FunctionalInterface
+public interface BooleanConsumer {
+  /**
+   * Performs this operation on the given argument.
+   *
+   * @param value the input argument
+   */
+  void accept(boolean value);
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/function/FloatConsumer.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/function/FloatConsumer.java
@@ -1,0 +1,22 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.function;
+
+/**
+ * Represents an operation that accepts a single float-valued argument and returns no result. This
+ * is the primitive type specialization of {@link java.util.function.Consumer} for float. Unlike
+ * most other functional interfaces, BooleanConsumer is expected to operate via side-effects.
+ *
+ * <p>This is a functional interface whose functional method is {@link #accept(float)}.
+ */
+@FunctionalInterface
+public interface FloatConsumer {
+  /**
+   * Performs this operation on the given argument.
+   *
+   * @param value the input argument
+   */
+  void accept(float value);
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/function/FloatSupplier.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/function/FloatSupplier.java
@@ -1,0 +1,24 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.function;
+
+/**
+ * Represents a supplier of float-valued results.
+ *
+ * <p>This is the float-producing primitive specialization of {@link java.util.function.Supplier}.
+ *
+ * <p>There is no requirement that a distinct result be returned each time the supplier is invoked.
+ *
+ * <p>This is a functional interface whose functional method is {@link #getAsFloat()}.
+ */
+@FunctionalInterface
+public interface FloatSupplier {
+  /**
+   * Gets a result.
+   *
+   * @return a result
+   */
+  float getAsFloat();
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableBuilder.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableBuilder.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.util.sendable;
 
+import edu.wpi.first.util.function.BooleanConsumer;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.DoubleConsumer;
@@ -40,23 +41,6 @@ public interface SendableBuilder {
    * @param func function
    */
   void setSafeState(Runnable func);
-
-  /**
-   * Represents an operation that accepts a single boolean-valued argument and returns no result.
-   * This is the primitive type specialization of Consumer for boolean. Unlike most other functional
-   * interfaces, BooleanConsumer is expected to operate via side-effects.
-   *
-   * <p>This is a functional interface whose functional method is accept(boolean).
-   */
-  @FunctionalInterface
-  interface BooleanConsumer {
-    /**
-     * Performs the operation on the given value.
-     *
-     * @param value the value
-     */
-    void accept(boolean value);
-  }
 
   /**
    * Add a boolean property.


### PR DESCRIPTION
The standard Java package is missing BooleanConsumer as well as Float classes.

Update SendableBuilder to use it instead of internal BooleanConsumer
interface.