### PR TITLE
[wpimath] Make LinearFilter::Factorial() constexpr

### DIFF
--- a/wpimath/src/main/native/include/frc/filter/LinearFilter.h
+++ b/wpimath/src/main/native/include/frc/filter/LinearFilter.h
@@ -286,7 +286,7 @@ class LinearFilter {
    *
    * @param n Argument of which to take factorial.
    */
-  static int Factorial(int n) {
+  static constexpr int Factorial(int n) {
     if (n < 2) {
       return 1;
     } else {


### PR DESCRIPTION
Since BackwardFiniteDifference() gives it a compile-time constant, it
can be evaluated in a constexpr context.