### PR TITLE
Fix CPP MechanisimRoot2D to use same NT entries as Java/Glass

### DIFF
--- a/wpilibc/src/main/native/cpp/smartdashboard/MechanismRoot2d.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/MechanismRoot2d.cpp
@@ -8,8 +8,6 @@
 
 using namespace frc;
 
-static constexpr char kPosition[] = "pos";
-
 MechanismRoot2d::MechanismRoot2d(std::string_view name, double x, double y,
                                  const private_init&)
     : MechanismObject2d(name), m_x{x}, m_y{y} {}
@@ -22,12 +20,16 @@ void MechanismRoot2d::SetPosition(double x, double y) {
 }
 
 void MechanismRoot2d::UpdateEntries(std::shared_ptr<nt::NetworkTable> table) {
-  m_posEntry = table->GetEntry(kPosition);
+  m_xEntry = table->GetEntry("x");
+  m_yEntry = table->GetEntry("y");
   Flush();
 }
 
 inline void MechanismRoot2d::Flush() {
-  if (m_posEntry) {
-    m_posEntry.SetDoubleArray({m_x, m_y});
+  if (m_xEntry) {
+    m_xEntry.SetDouble(m_x);
+  }
+  if (m_yEntry) {
+    m_yEntry.SetDouble(m_y);
   }
 }

--- a/wpilibc/src/main/native/include/frc/smartdashboard/MechanismRoot2d.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/MechanismRoot2d.h
@@ -44,6 +44,7 @@ class MechanismRoot2d : private MechanismObject2d {
   inline void Flush();
   double m_x;
   double m_y;
-  nt::NetworkTableEntry m_posEntry;
+  nt::NetworkTableEntry m_xEntry;
+  nt::NetworkTableEntry m_yEntry;
 };
 }  // namespace frc


### PR DESCRIPTION
Fixes #3578