### PR TITLE
Make C++ test names more consistent

### DIFF
--- a/crossConnIntegrationTests/src/main/native/cpp/AnalogTest.cpp
+++ b/crossConnIntegrationTests/src/main/native/cpp/AnalogTest.cpp
@@ -14,7 +14,7 @@ using namespace hlt;
 
 class AnalogCrossTest : public ::testing::TestWithParam<std::pair<int, int>> {};
 
-TEST_P(AnalogCrossTest, TestAnalogCross) {
+TEST_P(AnalogCrossTest, AnalogCross) {
   auto param = GetParam();
 
   int32_t status = 0;
@@ -40,7 +40,7 @@ TEST_P(AnalogCrossTest, TestAnalogCross) {
   }
 }
 
-TEST(AnalogInputTest, TestAllocateAll) {
+TEST(AnalogInputTest, AllocateAll) {
   wpi::SmallVector<AnalogInputHandle, 21> analogHandles;
   for (int i = 0; i < HAL_GetNumAnalogInputs(); i++) {
     int32_t status = 0;
@@ -49,7 +49,7 @@ TEST(AnalogInputTest, TestAllocateAll) {
   }
 }
 
-TEST(AnalogInputTest, TestMultipleAllocateFails) {
+TEST(AnalogInputTest, MultipleAllocateFails) {
   int32_t status = 0;
   AnalogInputHandle handle(0, &status);
   ASSERT_NE(handle, HAL_kInvalidHandle);
@@ -60,21 +60,21 @@ TEST(AnalogInputTest, TestMultipleAllocateFails) {
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_IS_ALLOCATED);
 }
 
-TEST(AnalogInputTest, TestOverAllocateFails) {
+TEST(AnalogInputTest, OverAllocateFails) {
   int32_t status = 0;
   AnalogInputHandle handle(HAL_GetNumAnalogInputs(), &status);
   ASSERT_EQ(handle, HAL_kInvalidHandle);
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_OUT_OF_RANGE);
 }
 
-TEST(AnalogInputTest, TestUnderAllocateFails) {
+TEST(AnalogInputTest, UnderAllocateFails) {
   int32_t status = 0;
   AnalogInputHandle handle(-1, &status);
   ASSERT_EQ(handle, HAL_kInvalidHandle);
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_OUT_OF_RANGE);
 }
 
-TEST(AnalogOutputTest, TestAllocateAll) {
+TEST(AnalogOutputTest, AllocateAll) {
   wpi::SmallVector<AnalogOutputHandle, 21> analogHandles;
   for (int i = 0; i < HAL_GetNumAnalogOutputs(); i++) {
     int32_t status = 0;
@@ -83,7 +83,7 @@ TEST(AnalogOutputTest, TestAllocateAll) {
   }
 }
 
-TEST(AnalogOutputTest, TestMultipleAllocateFails) {
+TEST(AnalogOutputTest, MultipleAllocateFails) {
   int32_t status = 0;
   AnalogOutputHandle handle(0, &status);
   ASSERT_NE(handle, HAL_kInvalidHandle);
@@ -94,14 +94,14 @@ TEST(AnalogOutputTest, TestMultipleAllocateFails) {
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_IS_ALLOCATED);
 }
 
-TEST(AnalogOutputTest, TestOverAllocateFails) {
+TEST(AnalogOutputTest, OverAllocateFails) {
   int32_t status = 0;
   AnalogOutputHandle handle(HAL_GetNumAnalogOutputs(), &status);
   ASSERT_EQ(handle, HAL_kInvalidHandle);
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_OUT_OF_RANGE);
 }
 
-TEST(AnalogOutputTest, TestUnderAllocateFails) {
+TEST(AnalogOutputTest, UnderAllocateFails) {
   int32_t status = 0;
   AnalogOutputHandle handle(-1, &status);
   ASSERT_EQ(handle, HAL_kInvalidHandle);

--- a/crossConnIntegrationTests/src/main/native/cpp/DIOTest.cpp
+++ b/crossConnIntegrationTests/src/main/native/cpp/DIOTest.cpp
@@ -13,7 +13,7 @@ using namespace hlt;
 
 class DIOTest : public ::testing::TestWithParam<std::pair<int, int>> {};
 
-TEST_P(DIOTest, TestDIOCross) {
+TEST_P(DIOTest, DIOCross) {
   auto param = GetParam();
   int32_t status = 0;
   DIOHandle first{param.first, false, &status};
@@ -53,7 +53,7 @@ TEST_P(DIOTest, TestDIOCross) {
   ASSERT_EQ(0, status);
 }
 
-TEST(DIOTest, TestAllocateAll) {
+TEST(DIOTest, AllocateAll) {
   wpi::SmallVector<DIOHandle, 32> dioHandles;
   for (int i = 0; i < HAL_GetNumDigitalChannels(); i++) {
     int32_t status = 0;
@@ -62,7 +62,7 @@ TEST(DIOTest, TestAllocateAll) {
   }
 }
 
-TEST(DIOTest, TestMultipleAllocateFails) {
+TEST(DIOTest, MultipleAllocateFails) {
   int32_t status = 0;
   DIOHandle handle(0, true, &status);
   ASSERT_NE(handle, HAL_kInvalidHandle);
@@ -73,21 +73,21 @@ TEST(DIOTest, TestMultipleAllocateFails) {
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_IS_ALLOCATED);
 }
 
-TEST(DIOTest, TestOverAllocateFails) {
+TEST(DIOTest, OverAllocateFails) {
   int32_t status = 0;
   DIOHandle handle(HAL_GetNumDigitalChannels(), true, &status);
   ASSERT_EQ(handle, HAL_kInvalidHandle);
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_OUT_OF_RANGE);
 }
 
-TEST(DIOTest, TestUnderAllocateFails) {
+TEST(DIOTest, UnderAllocateFails) {
   int32_t status = 0;
   DIOHandle handle(-1, true, &status);
   ASSERT_EQ(handle, HAL_kInvalidHandle);
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_OUT_OF_RANGE);
 }
 
-TEST(DIOTest, TestCrossAllocationFails) {
+TEST(DIOTest, CrossAllocationFails) {
   int32_t status = 0;
   PWMHandle pwmHandle(10, &status);
   ASSERT_NE(pwmHandle, HAL_kInvalidHandle);

--- a/crossConnIntegrationTests/src/main/native/cpp/DutyCycleTest.cpp
+++ b/crossConnIntegrationTests/src/main/native/cpp/DutyCycleTest.cpp
@@ -12,7 +12,7 @@ using namespace hlt;
 
 class DutyCycleTest : public ::testing::TestWithParam<std::pair<int, int>> {};
 
-TEST_P(DutyCycleTest, TestDutyCycle) {
+TEST_P(DutyCycleTest, DutyCycle) {
   auto param = GetParam();
 
   int32_t status = 0;

--- a/crossConnIntegrationTests/src/main/native/cpp/PWMTest.cpp
+++ b/crossConnIntegrationTests/src/main/native/cpp/PWMTest.cpp
@@ -279,37 +279,37 @@ void TestTiming(int squelch, std::pair<int, int> param) {
   }
 }
 
-TEST_P(PWMTest, TestTiming4x) {
+TEST_P(PWMTest, Timing4x) {
   auto param = GetParam();
   TestTiming(3, param);
 }
 
-TEST_P(PWMTest, TestTiming2x) {
+TEST_P(PWMTest, Timing2x) {
   auto param = GetParam();
   TestTiming(1, param);
 }
 
-TEST_P(PWMTest, TestTiming1x) {
+TEST_P(PWMTest, Timing1x) {
   auto param = GetParam();
   TestTiming(0, param);
 }
 
-TEST_P(PWMTest, TestTimingDMA4x) {
+TEST_P(PWMTest, TimingDMA4x) {
   auto param = GetParam();
   TestTimingDMA(3, param);
 }
 
-TEST_P(PWMTest, TestTimingDMA2x) {
+TEST_P(PWMTest, TimingDMA2x) {
   auto param = GetParam();
   TestTimingDMA(1, param);
 }
 
-TEST_P(PWMTest, TestTimingDMA1x) {
+TEST_P(PWMTest, TimingDMA1x) {
   auto param = GetParam();
   TestTimingDMA(0, param);
 }
 
-TEST(PWMTest, TestAllocateAll) {
+TEST(PWMTest, AllocateAll) {
   wpi::SmallVector<PWMHandle, 21> pwmHandles;
   for (int i = 0; i < HAL_GetNumPWMChannels(); i++) {
     int32_t status = 0;
@@ -318,7 +318,7 @@ TEST(PWMTest, TestAllocateAll) {
   }
 }
 
-TEST(PWMTest, TestMultipleAllocateFails) {
+TEST(PWMTest, MultipleAllocateFails) {
   int32_t status = 0;
   PWMHandle handle(0, &status);
   ASSERT_NE(handle, HAL_kInvalidHandle);
@@ -329,21 +329,21 @@ TEST(PWMTest, TestMultipleAllocateFails) {
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_IS_ALLOCATED);
 }
 
-TEST(PWMTest, TestOverAllocateFails) {
+TEST(PWMTest, OverAllocateFails) {
   int32_t status = 0;
   PWMHandle handle(HAL_GetNumPWMChannels(), &status);
   ASSERT_EQ(handle, HAL_kInvalidHandle);
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_OUT_OF_RANGE);
 }
 
-TEST(PWMTest, TestUnderAllocateFails) {
+TEST(PWMTest, UnderAllocateFails) {
   int32_t status = 0;
   PWMHandle handle(-1, &status);
   ASSERT_EQ(handle, HAL_kInvalidHandle);
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_OUT_OF_RANGE);
 }
 
-TEST(PWMTest, TestCrossAllocationFails) {
+TEST(PWMTest, CrossAllocationFails) {
   int32_t status = 0;
   DIOHandle dioHandle(10, true, &status);
   ASSERT_NE(dioHandle, HAL_kInvalidHandle);

--- a/crossConnIntegrationTests/src/main/native/cpp/RelayAnalogTest.cpp
+++ b/crossConnIntegrationTests/src/main/native/cpp/RelayAnalogTest.cpp
@@ -14,7 +14,7 @@ using namespace hlt;
 
 class RelayAnalogTest : public ::testing::TestWithParam<std::pair<int, int>> {};
 
-TEST_P(RelayAnalogTest, TestRelayAnalogCross) {
+TEST_P(RelayAnalogTest, RelayAnalogCross) {
   auto param = GetParam();
 
   int32_t status = 0;

--- a/crossConnIntegrationTests/src/main/native/cpp/RelayDigitalTest.cpp
+++ b/crossConnIntegrationTests/src/main/native/cpp/RelayDigitalTest.cpp
@@ -13,7 +13,7 @@ using namespace hlt;
 
 class RelayDigitalTest : public ::testing::TestWithParam<RelayCross> {};
 
-TEST_P(RelayDigitalTest, TestRelayCross) {
+TEST_P(RelayDigitalTest, RelayCross) {
   auto param = GetParam();
   int32_t status = 0;
   RelayHandle fwd{param.Relay, true, &status};
@@ -66,7 +66,7 @@ TEST_P(RelayDigitalTest, TestRelayCross) {
   ASSERT_EQ(0, status);
 }
 
-TEST(RelayDigitalTest, TestAllocateAll) {
+TEST(RelayDigitalTest, AllocateAll) {
   wpi::SmallVector<RelayHandle, 32> relayHandles;
   for (int i = 0; i < HAL_GetNumRelayChannels(); i++) {
     int32_t status = 0;
@@ -75,7 +75,7 @@ TEST(RelayDigitalTest, TestAllocateAll) {
   }
 }
 
-TEST(RelayDigitalTest, TestMultipleAllocateFails) {
+TEST(RelayDigitalTest, MultipleAllocateFails) {
   int32_t status = 0;
   RelayHandle handle(0, true, &status);
   ASSERT_NE(handle, HAL_kInvalidHandle);
@@ -86,14 +86,14 @@ TEST(RelayDigitalTest, TestMultipleAllocateFails) {
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_IS_ALLOCATED);
 }
 
-TEST(RelayDigitalTest, TestOverAllocateFails) {
+TEST(RelayDigitalTest, OverAllocateFails) {
   int32_t status = 0;
   RelayHandle handle(HAL_GetNumRelayChannels(), true, &status);
   ASSERT_EQ(handle, HAL_kInvalidHandle);
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_OUT_OF_RANGE);
 }
 
-TEST(RelayDigitalTest, TestUnderAllocateFails) {
+TEST(RelayDigitalTest, UnderAllocateFails) {
   int32_t status = 0;
   RelayHandle handle(-1, true, &status);
   ASSERT_EQ(handle, HAL_kInvalidHandle);

--- a/hal/src/test/native/cpp/HALTest.cpp
+++ b/hal/src/test/native/cpp/HALTest.cpp
@@ -6,7 +6,7 @@
 #include "hal/HAL.h"
 
 namespace hal {
-TEST(HALTests, RuntimeType) {
+TEST(HALTest, RuntimeType) {
   EXPECT_EQ(HAL_RuntimeType::HAL_Runtime_Simulation, HAL_GetRuntimeType());
 }
 }  // namespace hal

--- a/hal/src/test/native/cpp/can/CANTest.cpp
+++ b/hal/src/test/native/cpp/can/CANTest.cpp
@@ -38,7 +38,7 @@ struct CANSendCallbackStore {
   int32_t handle;
 };
 
-TEST(HALCanTests, CanIdPackingTest) {
+TEST(CANTest, CanIdPacking) {
   int32_t status = 0;
   int32_t deviceId = 12;
   CANTestStore testStore(deviceId, &status);

--- a/hal/src/test/native/cpp/handles/HandleTest.cpp
+++ b/hal/src/test/native/cpp/handles/HandleTest.cpp
@@ -13,7 +13,7 @@ class MyTestClass {};
 }  // namespace
 
 namespace hal {
-TEST(HandleTests, ClassedHandleTest) {
+TEST(HandleTest, ClassedHandle) {
   hal::IndexedClassedHandleResource<HAL_TestHandle, MyTestClass, 8,
                                     HAL_HandleEnum::Vendor>
       testClass;

--- a/hal/src/test/native/cpp/mockdata/AnalogInDataTest.cpp
+++ b/hal/src/test/native/cpp/mockdata/AnalogInDataTest.cpp
@@ -19,7 +19,7 @@ void TestAnalogInInitializationCallback(const char* name, void* param,
   gTestAnalogInCallbackValue = *value;
 }
 
-TEST(AnalogInSimTests, TestAnalogInInitialization) {
+TEST(AnalogInSimTest, AnalogInInitialization) {
   const int INDEX_TO_TEST = 1;
 
   int callbackParam = 0;

--- a/hal/src/test/native/cpp/mockdata/AnalogOutDataTest.cpp
+++ b/hal/src/test/native/cpp/mockdata/AnalogOutDataTest.cpp
@@ -19,7 +19,7 @@ void TestAnalogOutInitializationCallback(const char* name, void* param,
   gTestAnalogOutCallbackValue = *value;
 }
 
-TEST(AnalogOutSimTests, TestAnalogOutInitialization) {
+TEST(AnalogOutSimTest, AnalogOutInitialization) {
   const int INDEX_TO_TEST = 1;
 
   int callbackParam = 0;

--- a/hal/src/test/native/cpp/mockdata/DIODataTest.cpp
+++ b/hal/src/test/native/cpp/mockdata/DIODataTest.cpp
@@ -19,7 +19,7 @@ void TestDigitalIoInitializationCallback(const char* name, void* param,
   gTestDigitalIoCallbackValue = *value;
 }
 
-TEST(DigitalIoSimTests, TestDigitalIoInitialization) {
+TEST(DigitalIoSimTest, DigitalIoInitialization) {
   const int INDEX_TO_TEST = 3;
 
   int callbackParam = 0;

--- a/hal/src/test/native/cpp/mockdata/DriverStationDataTest.cpp
+++ b/hal/src/test/native/cpp/mockdata/DriverStationDataTest.cpp
@@ -10,7 +10,7 @@
 
 namespace hal {
 
-TEST(DriverStationTests, JoystickTests) {
+TEST(DriverStationTest, Joystick) {
   HAL_JoystickAxes axes;
   HAL_JoystickPOVs povs;
   HAL_JoystickButtons buttons;
@@ -109,7 +109,7 @@ TEST(DriverStationTests, JoystickTests) {
   }
 }
 
-TEST(DriverStationTests, EventInfoTest) {
+TEST(DriverStationTest, EventInfo) {
   std::string eventName = "UnitTest";
   std::string gameData = "Insert game specific info here :D";
   HAL_MatchInfo info;

--- a/hal/src/test/native/cpp/mockdata/I2CDataTest.cpp
+++ b/hal/src/test/native/cpp/mockdata/I2CDataTest.cpp
@@ -19,7 +19,7 @@ void TestI2CInitializationCallback(const char* name, void* param,
   gTestI2CCallbackValue = *value;
 }
 
-TEST(I2CSimTests, TestI2CInitialization) {
+TEST(I2CSimTest, I2CInitialization) {
   const int INDEX_TO_TEST = 1;
 
   int32_t status = 0;

--- a/hal/src/test/native/cpp/mockdata/PCMDataTest.cpp
+++ b/hal/src/test/native/cpp/mockdata/PCMDataTest.cpp
@@ -19,7 +19,7 @@ void TestSolenoidInitializationCallback(const char* name, void* param,
   gTestSolenoidCallbackValue = *value;
 }
 
-TEST(SolenoidSimTests, TestPCMInitialization) {
+TEST(PCMDataTest, PCMInitialization) {
   const int MODULE_TO_TEST = 2;
 
   int callbackParam = 0;

--- a/hal/src/test/native/cpp/mockdata/PDPDataTest.cpp
+++ b/hal/src/test/native/cpp/mockdata/PDPDataTest.cpp
@@ -19,7 +19,7 @@ void TestPdpInitializationCallback(const char* name, void* param,
   gTestPdpCallbackValue = *value;
 }
 
-TEST(PdpSimTests, TestPdpInitialization) {
+TEST(PdpSimTest, PdpInitialization) {
   const int INDEX_TO_TEST = 1;
 
   int callbackParam = 0;

--- a/hal/src/test/native/cpp/mockdata/PWMDataTest.cpp
+++ b/hal/src/test/native/cpp/mockdata/PWMDataTest.cpp
@@ -19,7 +19,7 @@ void TestPwmInitializationCallback(const char* name, void* param,
   gTestPwmCallbackValue = *value;
 }
 
-TEST(PWMSimTests, TestPwmInitialization) {
+TEST(PWMSimTest, PwmInitialization) {
   const int INDEX_TO_TEST = 7;
 
   int callbackParam = 0;

--- a/hal/src/test/native/cpp/mockdata/RelayDataTest.cpp
+++ b/hal/src/test/native/cpp/mockdata/RelayDataTest.cpp
@@ -19,7 +19,7 @@ void TestRelayInitializationCallback(const char* name, void* param,
   gTestRelayCallbackValue = *value;
 }
 
-TEST(RelaySimTests, TestRelayInitialization) {
+TEST(RelaySimTest, RelayInitialization) {
   const int INDEX_TO_TEST = 3;
 
   int callbackParam = 0;

--- a/hal/src/test/native/cpp/mockdata/SPIDataTest.cpp
+++ b/hal/src/test/native/cpp/mockdata/SPIDataTest.cpp
@@ -19,7 +19,7 @@ void TestSpiInitializationCallback(const char* name, void* param,
   gTestSpiCallbackValue = *value;
 }
 
-TEST(SpiSimTests, TestSpiInitialization) {
+TEST(SpiSimTest, SpiInitialization) {
   const int INDEX_TO_TEST = 2;
 
   int32_t status = 0;

--- a/hal/src/test/native/cpp/mockdata/SimDeviceDataTest.cpp
+++ b/hal/src/test/native/cpp/mockdata/SimDeviceDataTest.cpp
@@ -8,7 +8,7 @@
 
 namespace hal {
 
-TEST(SimDeviceSimTests, TestEnabled) {
+TEST(SimDeviceSimTest, Enabled) {
   ASSERT_TRUE(HALSIM_IsSimDeviceEnabled("foo"));
   HALSIM_SetSimDeviceEnabled("f", false);
   HALSIM_SetSimDeviceEnabled("foob", true);

--- a/simulation/frc_gazebo_plugins/src/clockTest/cpp/ClockTest.cpp
+++ b/simulation/frc_gazebo_plugins/src/clockTest/cpp/ClockTest.cpp
@@ -22,7 +22,7 @@ void cb(gazebo::msgs::ConstFloat64Ptr& msg) {
   latest_time = msg->data();
 }
 
-TEST(ClockTests, TestClock) {
+TEST(ClockTest, Clock) {
   gazebo::physics::WorldPtr world;
 
   ASSERT_TRUE(library);

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/ButtonTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/ButtonTest.cpp
@@ -12,7 +12,7 @@
 using namespace frc2;
 class ButtonTest : public CommandTestBase {};
 
-TEST_F(ButtonTest, WhenPressedTest) {
+TEST_F(ButtonTest, WhenPressed) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
   bool pressed = false;
@@ -30,7 +30,7 @@ TEST_F(ButtonTest, WhenPressedTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(ButtonTest, WhenReleasedTest) {
+TEST_F(ButtonTest, WhenReleased) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
   bool pressed = false;
@@ -48,7 +48,7 @@ TEST_F(ButtonTest, WhenReleasedTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(ButtonTest, WhileHeldTest) {
+TEST_F(ButtonTest, WhileHeld) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
   bool pressed = false;
@@ -71,7 +71,7 @@ TEST_F(ButtonTest, WhileHeldTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(ButtonTest, WhenHeldTest) {
+TEST_F(ButtonTest, WhenHeld) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
   bool pressed = false;
@@ -99,7 +99,7 @@ TEST_F(ButtonTest, WhenHeldTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(ButtonTest, ToggleWhenPressedTest) {
+TEST_F(ButtonTest, ToggleWhenPressed) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
   bool pressed = false;
@@ -119,7 +119,7 @@ TEST_F(ButtonTest, ToggleWhenPressedTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(ButtonTest, AndTest) {
+TEST_F(ButtonTest, And) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
   bool pressed1 = false;
@@ -137,7 +137,7 @@ TEST_F(ButtonTest, AndTest) {
   EXPECT_TRUE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(ButtonTest, OrTest) {
+TEST_F(ButtonTest, Or) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
   bool pressed1 = false;
@@ -162,7 +162,7 @@ TEST_F(ButtonTest, OrTest) {
   EXPECT_TRUE(scheduler.IsScheduled(&command2));
 }
 
-TEST_F(ButtonTest, NegateTest) {
+TEST_F(ButtonTest, Negate) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
   bool pressed = true;
@@ -176,7 +176,7 @@ TEST_F(ButtonTest, NegateTest) {
   EXPECT_TRUE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(ButtonTest, RValueButtonTest) {
+TEST_F(ButtonTest, RValueButton) {
   auto& scheduler = CommandScheduler::GetInstance();
   int counter = 0;
   bool pressed = false;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
@@ -14,7 +14,7 @@
 using namespace frc2;
 class CommandDecoratorTest : public CommandTestBase {};
 
-TEST_F(CommandDecoratorTest, WithTimeoutTest) {
+TEST_F(CommandDecoratorTest, WithTimeout) {
   CommandScheduler scheduler = GetScheduler();
 
   frc::sim::PauseTiming();
@@ -34,7 +34,7 @@ TEST_F(CommandDecoratorTest, WithTimeoutTest) {
   frc::sim::ResumeTiming();
 }
 
-TEST_F(CommandDecoratorTest, WithInterruptTest) {
+TEST_F(CommandDecoratorTest, WithInterrupt) {
   CommandScheduler scheduler = GetScheduler();
 
   bool finished = false;
@@ -53,7 +53,7 @@ TEST_F(CommandDecoratorTest, WithInterruptTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(CommandDecoratorTest, BeforeStartingTest) {
+TEST_F(CommandDecoratorTest, BeforeStarting) {
   CommandScheduler scheduler = GetScheduler();
 
   bool finished = false;
@@ -71,7 +71,7 @@ TEST_F(CommandDecoratorTest, BeforeStartingTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(CommandDecoratorTest, AndThenTest) {
+TEST_F(CommandDecoratorTest, AndThen) {
   CommandScheduler scheduler = GetScheduler();
 
   bool finished = false;
@@ -90,7 +90,7 @@ TEST_F(CommandDecoratorTest, AndThenTest) {
   EXPECT_TRUE(finished);
 }
 
-TEST_F(CommandDecoratorTest, PerpetuallyTest) {
+TEST_F(CommandDecoratorTest, Perpetually) {
   CommandScheduler scheduler = GetScheduler();
 
   auto command = InstantCommand([] {}, {}).Perpetually();

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandRequirementsTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandRequirementsTest.cpp
@@ -17,7 +17,7 @@
 using namespace frc2;
 class CommandRequirementsTest : public CommandTestBase {};
 
-TEST_F(CommandRequirementsTest, RequirementInterruptTest) {
+TEST_F(CommandRequirementsTest, RequirementInterrupt) {
   CommandScheduler scheduler = GetScheduler();
 
   TestSubsystem requirement;
@@ -44,7 +44,7 @@ TEST_F(CommandRequirementsTest, RequirementInterruptTest) {
   scheduler.Run();
 }
 
-TEST_F(CommandRequirementsTest, RequirementUninterruptibleTest) {
+TEST_F(CommandRequirementsTest, RequirementUninterruptible) {
   CommandScheduler scheduler = GetScheduler();
 
   TestSubsystem requirement;
@@ -71,7 +71,7 @@ TEST_F(CommandRequirementsTest, RequirementUninterruptibleTest) {
   scheduler.Run();
 }
 
-TEST_F(CommandRequirementsTest, DefaultCommandRequirementErrorTest) {
+TEST_F(CommandRequirementsTest, DefaultCommandRequirementError) {
   TestSubsystem requirement1;
 
   MockCommand command1;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandScheduleTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandScheduleTest.cpp
@@ -7,7 +7,7 @@
 using namespace frc2;
 class CommandScheduleTest : public CommandTestBase {};
 
-TEST_F(CommandScheduleTest, InstantScheduleTest) {
+TEST_F(CommandScheduleTest, InstantSchedule) {
   CommandScheduler scheduler = GetScheduler();
   MockCommand command;
 
@@ -22,7 +22,7 @@ TEST_F(CommandScheduleTest, InstantScheduleTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(CommandScheduleTest, SingleIterationScheduleTest) {
+TEST_F(CommandScheduleTest, SingleIterationSchedule) {
   CommandScheduler scheduler = GetScheduler();
   MockCommand command;
 
@@ -38,7 +38,7 @@ TEST_F(CommandScheduleTest, SingleIterationScheduleTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(CommandScheduleTest, MultiScheduleTest) {
+TEST_F(CommandScheduleTest, MultiSchedule) {
   CommandScheduler scheduler = GetScheduler();
   MockCommand command1;
   MockCommand command2;
@@ -75,7 +75,7 @@ TEST_F(CommandScheduleTest, MultiScheduleTest) {
   EXPECT_FALSE(scheduler.IsScheduled({&command1, &command2, &command3}));
 }
 
-TEST_F(CommandScheduleTest, SchedulerCancelTest) {
+TEST_F(CommandScheduleTest, SchedulerCancel) {
   CommandScheduler scheduler = GetScheduler();
   MockCommand command;
 
@@ -92,7 +92,7 @@ TEST_F(CommandScheduleTest, SchedulerCancelTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(CommandScheduleTest, NotScheduledCancelTest) {
+TEST_F(CommandScheduleTest, NotScheduledCancel) {
   CommandScheduler scheduler = GetScheduler();
   MockCommand command;
 

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/ConditionalCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/ConditionalCommandTest.cpp
@@ -10,7 +10,7 @@
 using namespace frc2;
 class ConditionalCommandTest : public CommandTestBase {};
 
-TEST_F(ConditionalCommandTest, ConditionalCommandScheduleTest) {
+TEST_F(ConditionalCommandTest, ConditionalCommandSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   std::unique_ptr<MockCommand> mock = std::make_unique<MockCommand>();
@@ -31,7 +31,7 @@ TEST_F(ConditionalCommandTest, ConditionalCommandScheduleTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&conditional));
 }
 
-TEST_F(ConditionalCommandTest, ConditionalCommandRequirementTest) {
+TEST_F(ConditionalCommandTest, ConditionalCommandRequirement) {
   CommandScheduler scheduler = GetScheduler();
 
   TestSubsystem requirement1;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/DefaultCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/DefaultCommandTest.cpp
@@ -8,7 +8,7 @@
 using namespace frc2;
 class DefaultCommandTest : public CommandTestBase {};
 
-TEST_F(DefaultCommandTest, DefaultCommandScheduleTest) {
+TEST_F(DefaultCommandTest, DefaultCommandSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   TestSubsystem subsystem;
@@ -22,7 +22,7 @@ TEST_F(DefaultCommandTest, DefaultCommandScheduleTest) {
   EXPECT_TRUE(scheduler.IsScheduled(handle));
 }
 
-TEST_F(DefaultCommandTest, DefaultCommandInterruptResumeTest) {
+TEST_F(DefaultCommandTest, DefaultCommandInterruptResume) {
   CommandScheduler scheduler = GetScheduler();
 
   TestSubsystem subsystem;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/FunctionalCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/FunctionalCommandTest.cpp
@@ -8,7 +8,7 @@
 using namespace frc2;
 class FunctionalCommandTest : public CommandTestBase {};
 
-TEST_F(FunctionalCommandTest, FunctionalCommandScheduleTest) {
+TEST_F(FunctionalCommandTest, FunctionalCommandSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   int counter = 0;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/InstantCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/InstantCommandTest.cpp
@@ -8,7 +8,7 @@
 using namespace frc2;
 class InstantCommandTest : public CommandTestBase {};
 
-TEST_F(InstantCommandTest, InstantCommandScheduleTest) {
+TEST_F(InstantCommandTest, InstantCommandSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   int counter = 0;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/NotifierCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/NotifierCommandTest.cpp
@@ -12,7 +12,7 @@ using namespace std::chrono_literals;
 
 class NotifierCommandTest : public CommandTestBase {};
 
-TEST_F(NotifierCommandTest, NotifierCommandScheduleTest) {
+TEST_F(NotifierCommandTest, NotifierCommandSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   frc::sim::PauseTiming();

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/POVButtonTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/POVButtonTest.cpp
@@ -15,7 +15,7 @@
 using namespace frc2;
 class POVButtonTest : public CommandTestBase {};
 
-TEST_F(POVButtonTest, SetPOVTest) {
+TEST_F(POVButtonTest, SetPOV) {
   frc::sim::JoystickSim joysim(1);
   joysim.SetPOV(0);
   joysim.NotifyNewData();

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/ParallelCommandGroupTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/ParallelCommandGroupTest.cpp
@@ -10,7 +10,7 @@
 using namespace frc2;
 class ParallelCommandGroupTest : public CommandTestBase {};
 
-TEST_F(ParallelCommandGroupTest, ParallelGroupScheduleTest) {
+TEST_F(ParallelCommandGroupTest, ParallelGroupSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   std::unique_ptr<MockCommand> command1Holder = std::make_unique<MockCommand>();
@@ -40,7 +40,7 @@ TEST_F(ParallelCommandGroupTest, ParallelGroupScheduleTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group));
 }
 
-TEST_F(ParallelCommandGroupTest, ParallelGroupInterruptTest) {
+TEST_F(ParallelCommandGroupTest, ParallelGroupInterrupt) {
   CommandScheduler scheduler = GetScheduler();
 
   std::unique_ptr<MockCommand> command1Holder = std::make_unique<MockCommand>();
@@ -71,7 +71,7 @@ TEST_F(ParallelCommandGroupTest, ParallelGroupInterruptTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group));
 }
 
-TEST_F(ParallelCommandGroupTest, ParallelGroupNotScheduledCancelTest) {
+TEST_F(ParallelCommandGroupTest, ParallelGroupNotScheduledCancel) {
   CommandScheduler scheduler = GetScheduler();
 
   ParallelCommandGroup group((InstantCommand(), InstantCommand()));
@@ -79,7 +79,7 @@ TEST_F(ParallelCommandGroupTest, ParallelGroupNotScheduledCancelTest) {
   EXPECT_NO_FATAL_FAILURE(scheduler.Cancel(&group));
 }
 
-TEST_F(ParallelCommandGroupTest, ParallelGroupCopyTest) {
+TEST_F(ParallelCommandGroupTest, ParallelGroupCopy) {
   CommandScheduler scheduler = GetScheduler();
 
   bool finished = false;
@@ -95,7 +95,7 @@ TEST_F(ParallelCommandGroupTest, ParallelGroupCopyTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group));
 }
 
-TEST_F(ParallelCommandGroupTest, ParallelGroupRequirementTest) {
+TEST_F(ParallelCommandGroupTest, ParallelGroupRequirement) {
   CommandScheduler scheduler = GetScheduler();
 
   TestSubsystem requirement1;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/ParallelDeadlineGroupTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/ParallelDeadlineGroupTest.cpp
@@ -10,7 +10,7 @@
 using namespace frc2;
 class ParallelDeadlineGroupTest : public CommandTestBase {};
 
-TEST_F(ParallelDeadlineGroupTest, DeadlineGroupScheduleTest) {
+TEST_F(ParallelDeadlineGroupTest, DeadlineGroupSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   std::unique_ptr<MockCommand> command1Holder = std::make_unique<MockCommand>();
@@ -48,7 +48,7 @@ TEST_F(ParallelDeadlineGroupTest, DeadlineGroupScheduleTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group));
 }
 
-TEST_F(ParallelDeadlineGroupTest, SequentialGroupInterruptTest) {
+TEST_F(ParallelDeadlineGroupTest, SequentialGroupInterrupt) {
   CommandScheduler scheduler = GetScheduler();
 
   TestSubsystem subsystem;
@@ -87,7 +87,7 @@ TEST_F(ParallelDeadlineGroupTest, SequentialGroupInterruptTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group));
 }
 
-TEST_F(ParallelDeadlineGroupTest, DeadlineGroupNotScheduledCancelTest) {
+TEST_F(ParallelDeadlineGroupTest, DeadlineGroupNotScheduledCancel) {
   CommandScheduler scheduler = GetScheduler();
 
   ParallelDeadlineGroup group{InstantCommand(), InstantCommand()};
@@ -95,7 +95,7 @@ TEST_F(ParallelDeadlineGroupTest, DeadlineGroupNotScheduledCancelTest) {
   EXPECT_NO_FATAL_FAILURE(scheduler.Cancel(&group));
 }
 
-TEST_F(ParallelDeadlineGroupTest, ParallelDeadlineCopyTest) {
+TEST_F(ParallelDeadlineGroupTest, ParallelDeadlineCopy) {
   CommandScheduler scheduler = GetScheduler();
 
   bool finished = false;
@@ -111,7 +111,7 @@ TEST_F(ParallelDeadlineGroupTest, ParallelDeadlineCopyTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group));
 }
 
-TEST_F(ParallelDeadlineGroupTest, ParallelDeadlineRequirementTest) {
+TEST_F(ParallelDeadlineGroupTest, ParallelDeadlineRequirement) {
   CommandScheduler scheduler = GetScheduler();
 
   TestSubsystem requirement1;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/ParallelRaceGroupTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/ParallelRaceGroupTest.cpp
@@ -11,7 +11,7 @@
 using namespace frc2;
 class ParallelRaceGroupTest : public CommandTestBase {};
 
-TEST_F(ParallelRaceGroupTest, ParallelRaceScheduleTest) {
+TEST_F(ParallelRaceGroupTest, ParallelRaceSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   std::unique_ptr<MockCommand> command1Holder = std::make_unique<MockCommand>();
@@ -47,7 +47,7 @@ TEST_F(ParallelRaceGroupTest, ParallelRaceScheduleTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group));
 }
 
-TEST_F(ParallelRaceGroupTest, ParallelRaceInterruptTest) {
+TEST_F(ParallelRaceGroupTest, ParallelRaceInterrupt) {
   CommandScheduler scheduler = GetScheduler();
 
   std::unique_ptr<MockCommand> command1Holder = std::make_unique<MockCommand>();
@@ -83,7 +83,7 @@ TEST_F(ParallelRaceGroupTest, ParallelRaceInterruptTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group));
 }
 
-TEST_F(ParallelRaceGroupTest, ParallelRaceNotScheduledCancelTest) {
+TEST_F(ParallelRaceGroupTest, ParallelRaceNotScheduledCancel) {
   CommandScheduler scheduler = GetScheduler();
 
   ParallelRaceGroup group{InstantCommand(), InstantCommand()};
@@ -91,7 +91,7 @@ TEST_F(ParallelRaceGroupTest, ParallelRaceNotScheduledCancelTest) {
   EXPECT_NO_FATAL_FAILURE(scheduler.Cancel(&group));
 }
 
-TEST_F(ParallelRaceGroupTest, ParallelRaceCopyTest) {
+TEST_F(ParallelRaceGroupTest, ParallelRaceCopy) {
   CommandScheduler scheduler = GetScheduler();
 
   bool finished = false;
@@ -107,7 +107,7 @@ TEST_F(ParallelRaceGroupTest, ParallelRaceCopyTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group));
 }
 
-TEST_F(ParallelRaceGroupTest, RaceGroupRequirementTest) {
+TEST_F(ParallelRaceGroupTest, RaceGroupRequirement) {
   CommandScheduler scheduler = GetScheduler();
 
   TestSubsystem requirement1;
@@ -128,7 +128,7 @@ TEST_F(ParallelRaceGroupTest, RaceGroupRequirementTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group));
 }
 
-TEST_F(ParallelRaceGroupTest, ParallelRaceOnlyCallsEndOnceTest) {
+TEST_F(ParallelRaceGroupTest, ParallelRaceOnlyCallsEndOnce) {
   CommandScheduler scheduler = GetScheduler();
 
   bool finished1 = false;
@@ -152,7 +152,7 @@ TEST_F(ParallelRaceGroupTest, ParallelRaceOnlyCallsEndOnceTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group2));
 }
 
-TEST_F(ParallelRaceGroupTest, ParallelRaceScheduleTwiceTest) {
+TEST_F(ParallelRaceGroupTest, ParallelRaceScheduleTwice) {
   CommandScheduler scheduler = GetScheduler();
 
   std::unique_ptr<MockCommand> command1Holder = std::make_unique<MockCommand>();

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/PerpetualCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/PerpetualCommandTest.cpp
@@ -9,7 +9,7 @@
 using namespace frc2;
 class PerpetualCommandTest : public CommandTestBase {};
 
-TEST_F(PerpetualCommandTest, PerpetualCommandScheduleTest) {
+TEST_F(PerpetualCommandTest, PerpetualCommandSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   bool check = false;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/PrintCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/PrintCommandTest.cpp
@@ -10,7 +10,7 @@
 using namespace frc2;
 class PrintCommandTest : public CommandTestBase {};
 
-TEST_F(PrintCommandTest, PrintCommandScheduleTest) {
+TEST_F(PrintCommandTest, PrintCommandSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   PrintCommand command("Test!");

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/ProxyScheduleCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/ProxyScheduleCommandTest.cpp
@@ -12,7 +12,7 @@
 using namespace frc2;
 class ProxyScheduleCommandTest : public CommandTestBase {};
 
-TEST_F(ProxyScheduleCommandTest, ProxyScheduleCommandScheduleTest) {
+TEST_F(ProxyScheduleCommandTest, ProxyScheduleCommandSchedule) {
   CommandScheduler& scheduler = CommandScheduler::GetInstance();
 
   bool scheduled = false;
@@ -27,7 +27,7 @@ TEST_F(ProxyScheduleCommandTest, ProxyScheduleCommandScheduleTest) {
   EXPECT_TRUE(scheduled);
 }
 
-TEST_F(ProxyScheduleCommandTest, ProxyScheduleCommandEndTest) {
+TEST_F(ProxyScheduleCommandTest, ProxyScheduleCommandEnd) {
   CommandScheduler& scheduler = CommandScheduler::GetInstance();
 
   bool finished = false;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/RobotDisabledCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/RobotDisabledCommandTest.cpp
@@ -13,7 +13,7 @@
 using namespace frc2;
 class RobotDisabledCommandTest : public CommandTestBase {};
 
-TEST_F(RobotDisabledCommandTest, RobotDisabledCommandCancelTest) {
+TEST_F(RobotDisabledCommandTest, RobotDisabledCommandCancel) {
   CommandScheduler scheduler = GetScheduler();
 
   MockCommand command({}, false, false);
@@ -34,7 +34,7 @@ TEST_F(RobotDisabledCommandTest, RobotDisabledCommandCancelTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(RobotDisabledCommandTest, RunWhenDisabledTest) {
+TEST_F(RobotDisabledCommandTest, RunWhenDisabled) {
   CommandScheduler scheduler = GetScheduler();
 
   MockCommand command1;
@@ -52,7 +52,7 @@ TEST_F(RobotDisabledCommandTest, RunWhenDisabledTest) {
   EXPECT_TRUE(scheduler.IsScheduled(&command2));
 }
 
-TEST_F(RobotDisabledCommandTest, SequentialGroupRunWhenDisabledTest) {
+TEST_F(RobotDisabledCommandTest, SequentialGroupRunWhenDisabled) {
   CommandScheduler scheduler = GetScheduler();
 
   SequentialCommandGroup runWhenDisabled{MockCommand(), MockCommand()};
@@ -68,7 +68,7 @@ TEST_F(RobotDisabledCommandTest, SequentialGroupRunWhenDisabledTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&dontRunWhenDisabled));
 }
 
-TEST_F(RobotDisabledCommandTest, ParallelGroupRunWhenDisabledTest) {
+TEST_F(RobotDisabledCommandTest, ParallelGroupRunWhenDisabled) {
   CommandScheduler scheduler = GetScheduler();
 
   ParallelCommandGroup runWhenDisabled{MockCommand(), MockCommand()};
@@ -84,7 +84,7 @@ TEST_F(RobotDisabledCommandTest, ParallelGroupRunWhenDisabledTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&dontRunWhenDisabled));
 }
 
-TEST_F(RobotDisabledCommandTest, ParallelRaceRunWhenDisabledTest) {
+TEST_F(RobotDisabledCommandTest, ParallelRaceRunWhenDisabled) {
   CommandScheduler scheduler = GetScheduler();
 
   ParallelRaceGroup runWhenDisabled{MockCommand(), MockCommand()};
@@ -100,7 +100,7 @@ TEST_F(RobotDisabledCommandTest, ParallelRaceRunWhenDisabledTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&dontRunWhenDisabled));
 }
 
-TEST_F(RobotDisabledCommandTest, ParallelDeadlineRunWhenDisabledTest) {
+TEST_F(RobotDisabledCommandTest, ParallelDeadlineRunWhenDisabled) {
   CommandScheduler scheduler = GetScheduler();
 
   ParallelDeadlineGroup runWhenDisabled{MockCommand(), MockCommand()};
@@ -116,7 +116,7 @@ TEST_F(RobotDisabledCommandTest, ParallelDeadlineRunWhenDisabledTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&dontRunWhenDisabled));
 }
 
-TEST_F(RobotDisabledCommandTest, ConditionalCommandRunWhenDisabledTest) {
+TEST_F(RobotDisabledCommandTest, ConditionalCommandRunWhenDisabled) {
   CommandScheduler scheduler = GetScheduler();
 
   ConditionalCommand runWhenDisabled{MockCommand(), MockCommand(),
@@ -133,7 +133,7 @@ TEST_F(RobotDisabledCommandTest, ConditionalCommandRunWhenDisabledTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&dontRunWhenDisabled));
 }
 
-TEST_F(RobotDisabledCommandTest, SelectCommandRunWhenDisabledTest) {
+TEST_F(RobotDisabledCommandTest, SelectCommandRunWhenDisabled) {
   CommandScheduler scheduler = GetScheduler();
 
   SelectCommand<int> runWhenDisabled{[] { return 1; },

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/RunCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/RunCommandTest.cpp
@@ -8,7 +8,7 @@
 using namespace frc2;
 class RunCommandTest : public CommandTestBase {};
 
-TEST_F(RunCommandTest, RunCommandScheduleTest) {
+TEST_F(RunCommandTest, RunCommandSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   int counter = 0;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/ScheduleCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/ScheduleCommandTest.cpp
@@ -12,7 +12,7 @@
 using namespace frc2;
 class ScheduleCommandTest : public CommandTestBase {};
 
-TEST_F(ScheduleCommandTest, ScheduleCommandScheduleTest) {
+TEST_F(ScheduleCommandTest, ScheduleCommandSchedule) {
   CommandScheduler& scheduler = CommandScheduler::GetInstance();
 
   bool scheduled = false;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulerTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulerTest.cpp
@@ -26,7 +26,7 @@ TEST_F(SchedulerTest, SchedulerLambdaTestNoInterrupt) {
   EXPECT_EQ(counter, 3);
 }
 
-TEST_F(SchedulerTest, SchedulerLambdaInterruptTest) {
+TEST_F(SchedulerTest, SchedulerLambdaInterrupt) {
   CommandScheduler scheduler = GetScheduler();
 
   RunCommand command([] {}, {});
@@ -42,7 +42,7 @@ TEST_F(SchedulerTest, SchedulerLambdaInterruptTest) {
   EXPECT_EQ(counter, 1);
 }
 
-TEST_F(SchedulerTest, UnregisterSubsystemTest) {
+TEST_F(SchedulerTest, UnregisterSubsystem) {
   CommandScheduler scheduler = GetScheduler();
 
   TestSubsystem system;
@@ -52,7 +52,7 @@ TEST_F(SchedulerTest, UnregisterSubsystemTest) {
   EXPECT_NO_FATAL_FAILURE(scheduler.UnregisterSubsystem(&system));
 }
 
-TEST_F(SchedulerTest, SchedulerCancelAllTest) {
+TEST_F(SchedulerTest, SchedulerCancelAll) {
   CommandScheduler scheduler = GetScheduler();
 
   RunCommand command([] {}, {});

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/SelectCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/SelectCommandTest.cpp
@@ -10,7 +10,7 @@
 using namespace frc2;
 class SelectCommandTest : public CommandTestBase {};
 
-TEST_F(SelectCommandTest, SelectCommandTest) {
+TEST_F(SelectCommandTest, SelectCommand) {
   CommandScheduler scheduler = GetScheduler();
 
   std::unique_ptr<MockCommand> mock = std::make_unique<MockCommand>();
@@ -36,7 +36,7 @@ TEST_F(SelectCommandTest, SelectCommandTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&select));
 }
 
-TEST_F(SelectCommandTest, SelectCommandRequirementTest) {
+TEST_F(SelectCommandTest, SelectCommandRequirement) {
   CommandScheduler scheduler = GetScheduler();
 
   TestSubsystem requirement1;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/SequentialCommandGroupTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/SequentialCommandGroupTest.cpp
@@ -10,7 +10,7 @@
 using namespace frc2;
 class SequentialCommandGroupTest : public CommandTestBase {};
 
-TEST_F(SequentialCommandGroupTest, SequentialGroupScheduleTest) {
+TEST_F(SequentialCommandGroupTest, SequentialGroupSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   std::unique_ptr<MockCommand> command1Holder = std::make_unique<MockCommand>();
@@ -49,7 +49,7 @@ TEST_F(SequentialCommandGroupTest, SequentialGroupScheduleTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group));
 }
 
-TEST_F(SequentialCommandGroupTest, SequentialGroupInterruptTest) {
+TEST_F(SequentialCommandGroupTest, SequentialGroupInterrupt) {
   CommandScheduler scheduler = GetScheduler();
 
   std::unique_ptr<MockCommand> command1Holder = std::make_unique<MockCommand>();
@@ -88,7 +88,7 @@ TEST_F(SequentialCommandGroupTest, SequentialGroupInterruptTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group));
 }
 
-TEST_F(SequentialCommandGroupTest, SequentialGroupNotScheduledCancelTest) {
+TEST_F(SequentialCommandGroupTest, SequentialGroupNotScheduledCancel) {
   CommandScheduler scheduler = GetScheduler();
 
   SequentialCommandGroup group{InstantCommand(), InstantCommand()};
@@ -96,7 +96,7 @@ TEST_F(SequentialCommandGroupTest, SequentialGroupNotScheduledCancelTest) {
   EXPECT_NO_FATAL_FAILURE(scheduler.Cancel(&group));
 }
 
-TEST_F(SequentialCommandGroupTest, SequentialGroupCopyTest) {
+TEST_F(SequentialCommandGroupTest, SequentialGroupCopy) {
   CommandScheduler scheduler = GetScheduler();
 
   bool finished = false;
@@ -112,7 +112,7 @@ TEST_F(SequentialCommandGroupTest, SequentialGroupCopyTest) {
   EXPECT_FALSE(scheduler.IsScheduled(&group));
 }
 
-TEST_F(SequentialCommandGroupTest, SequentialGroupRequirementTest) {
+TEST_F(SequentialCommandGroupTest, SequentialGroupRequirement) {
   CommandScheduler scheduler = GetScheduler();
 
   TestSubsystem requirement1;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/StartEndCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/StartEndCommandTest.cpp
@@ -8,7 +8,7 @@
 using namespace frc2;
 class StartEndCommandTest : public CommandTestBase {};
 
-TEST_F(StartEndCommandTest, StartEndCommandScheduleTest) {
+TEST_F(StartEndCommandTest, StartEndCommandSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   int counter = 0;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/WaitCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/WaitCommandTest.cpp
@@ -11,7 +11,7 @@
 using namespace frc2;
 class WaitCommandTest : public CommandTestBase {};
 
-TEST_F(WaitCommandTest, WaitCommandScheduleTest) {
+TEST_F(WaitCommandTest, WaitCommandSchedule) {
   frc::sim::PauseTiming();
 
   CommandScheduler scheduler = GetScheduler();

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/WaitUntilCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/WaitUntilCommandTest.cpp
@@ -8,7 +8,7 @@
 using namespace frc2;
 class WaitUntilCommandTest : public CommandTestBase {};
 
-TEST_F(WaitUntilCommandTest, WaitUntilCommandScheduleTest) {
+TEST_F(WaitUntilCommandTest, WaitUntilCommandSchedule) {
   CommandScheduler scheduler = GetScheduler();
 
   bool finished = false;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/button/NetworkButtonTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/button/NetworkButtonTest.cpp
@@ -22,7 +22,7 @@ class NetworkButtonTest : public CommandTestBase {
   }
 };
 
-TEST_F(NetworkButtonTest, SetNetworkButtonTest) {
+TEST_F(NetworkButtonTest, SetNetworkButton) {
   auto& scheduler = CommandScheduler::GetInstance();
   auto entry = nt::NetworkTableInstance::GetDefault()
                    .GetTable("TestTable")

--- a/wpilibc/src/test/native/cpp/simulation/ADXL345SimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/ADXL345SimTest.cpp
@@ -12,7 +12,7 @@
 
 namespace frc::sim {
 
-TEST(ADXL345SimTests, SetSpiAttributes) {
+TEST(ADXL345SimTest, SetSpiAttributes) {
   HAL_Initialize(500, 0);
 
   ADXL345_SPI accel(SPI::kMXP, Accelerometer::kRange_2G);
@@ -36,7 +36,7 @@ TEST(ADXL345SimTests, SetSpiAttributes) {
   EXPECT_EQ(2.29, allAccel.ZAxis);
 }
 
-TEST(ADXL345SimTests, SetI2CAttribute) {
+TEST(ADXL345SimTest, SetI2CAttribute) {
   HAL_Initialize(500, 0);
 
   ADXL345_I2C accel(I2C::kMXP);

--- a/wpilibc/src/test/native/cpp/simulation/ADXL362SimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/ADXL362SimTest.cpp
@@ -11,7 +11,7 @@
 
 namespace frc::sim {
 
-TEST(ADXL362SimTests, SetAttributes) {
+TEST(ADXL362SimTest, SetAttributes) {
   HAL_Initialize(500, 0);
 
   ADXL362 accel(SPI::kMXP, Accelerometer::kRange_2G);

--- a/wpilibc/src/test/native/cpp/simulation/AnalogEncoderSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/AnalogEncoderSimTest.cpp
@@ -14,7 +14,7 @@
 #define EXPECT_NEAR_UNITS(val1, val2, eps) \
   EXPECT_LE(units::math::abs(val1 - val2), eps)
 
-TEST(AnalogEncoderSimTest, TestBasic) {
+TEST(AnalogEncoderSimTest, Basic) {
   frc::AnalogInput ai(0);
   frc::AnalogEncoder encoder{ai};
   frc::sim::AnalogEncoderSim encoderSim{encoder};

--- a/wpilibc/src/test/native/cpp/simulation/DriverStationSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/DriverStationSimTest.cpp
@@ -50,7 +50,7 @@ TEST(DriverStationTest, AutonomousMode) {
   EXPECT_TRUE(callback.GetLastValue());
 }
 
-TEST(DriverStationTest, TestMode) {
+TEST(DriverStationTest, Mode) {
   HAL_Initialize(500, 0);
   DriverStationSim::ResetData();
 

--- a/wpilibc/src/test/native/cpp/simulation/SimDeviceSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/SimDeviceSimTest.cpp
@@ -11,7 +11,7 @@
 
 using namespace frc::sim;
 
-TEST(SimDeviceSimTests, TestBasic) {
+TEST(SimDeviceSimTest, Basic) {
   hal::SimDevice dev{"test"};
   hal::SimBoolean devBool = dev.CreateBoolean("bool", false, false);
 
@@ -22,7 +22,7 @@ TEST(SimDeviceSimTests, TestBasic) {
   EXPECT_TRUE(devBool.Get());
 }
 
-TEST(SimDeviceSimTests, TestEnumerateDevices) {
+TEST(SimDeviceSimTest, EnumerateDevices) {
   hal::SimDevice dev{"test"};
 
   bool foundit = false;

--- a/wpilibc/src/test/native/cpp/simulation/SimInitializationTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/SimInitializationTest.cpp
@@ -27,7 +27,7 @@
 
 using namespace frc::sim;
 
-TEST(SimInitializationTests, TestAllInitialize) {
+TEST(SimInitializationTest, AllInitialize) {
   HAL_Initialize(500, 0);
   BuiltInAccelerometerSim biacsim;
   AnalogGyroSim agsim{0};

--- a/wpilibc/src/test/native/cpp/simulation/StateSpaceSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/StateSpaceSimTest.cpp
@@ -24,7 +24,7 @@
 #include "frc/system/plant/LinearSystemId.h"
 #include "gtest/gtest.h"
 
-TEST(StateSpaceSimTest, TestFlywheelSim) {
+TEST(StateSpaceSimTest, FlywheelSim) {
   const frc::LinearSystem<1, 1, 1> plant =
       frc::LinearSystemId::IdentifyVelocitySystem<units::radian>(
           0.02_V / 1_rad_per_s, 0.01_V / 1_rad_per_s_sq);

--- a/wpilibcIntegrationTests/src/main/native/cpp/AnalogPotentiometerTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/AnalogPotentiometerTest.cpp
@@ -13,7 +13,7 @@
 static constexpr double kScale = 270.0;
 static constexpr double kAngle = 180.0;
 
-TEST(AnalogPotentiometerTest, TestInitialSettings) {
+TEST(AnalogPotentiometerTest, InitialSettings) {
   frc::AnalogOutput m_fakePot{TestBench::kAnalogOutputChannel};
   frc::AnalogPotentiometer m_pot{TestBench::kFakeAnalogOutputChannel, kScale};
 
@@ -23,7 +23,7 @@ TEST(AnalogPotentiometerTest, TestInitialSettings) {
       << "The potentiometer did not initialize to 0.";
 }
 
-TEST(AnalogPotentiometerTest, TestRangeValues) {
+TEST(AnalogPotentiometerTest, RangeValues) {
   frc::AnalogOutput m_fakePot{TestBench::kAnalogOutputChannel};
   frc::AnalogPotentiometer m_pot{TestBench::kFakeAnalogOutputChannel, kScale};
 

--- a/wpilibcIntegrationTests/src/main/native/cpp/DigitalGlitchFilterTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/DigitalGlitchFilterTest.cpp
@@ -16,7 +16,7 @@
  * implementation works as intended.  We configure the FPGA and then query it to
  * make sure that the acutal configuration matches.
  */
-TEST(DigitalGlitchFilterTest, BasicTest) {
+TEST(DigitalGlitchFilterTest, Basic) {
   frc::DigitalInput input1{1};
   frc::DigitalInput input2{2};
   frc::DigitalInput input3{3};

--- a/wpilibcIntegrationTests/src/main/native/cpp/FakeEncoderTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/FakeEncoderTest.cpp
@@ -64,14 +64,14 @@ class FakeEncoderTest : public testing::Test {
 /**
  * Test the encoder by reseting it to 0 and reading the value.
  */
-TEST_F(FakeEncoderTest, TestDefaultState) {
+TEST_F(FakeEncoderTest, DefaultState) {
   EXPECT_DOUBLE_EQ(0.0, m_encoder.Get()) << "The encoder did not start at 0.";
 }
 
 /**
  * Test the encoder by setting the digital outputs and reading the value.
  */
-TEST_F(FakeEncoderTest, TestCountUp) {
+TEST_F(FakeEncoderTest, CountUp) {
   m_encoder.Reset();
   Simulate100QuadratureTicks();
 
@@ -81,7 +81,7 @@ TEST_F(FakeEncoderTest, TestCountUp) {
 /**
  * Test that the encoder can stay reset while the index source is high
  */
-TEST_F(FakeEncoderTest, TestResetWhileHigh) {
+TEST_F(FakeEncoderTest, ResetWhileHigh) {
   m_encoder.SetIndexSource(*m_indexAnalogTriggerOutput,
                            frc::Encoder::IndexingType::kResetWhileHigh);
 
@@ -97,7 +97,7 @@ TEST_F(FakeEncoderTest, TestResetWhileHigh) {
 /**
  * Test that the encoder can reset when the index source goes from low to high
  */
-TEST_F(FakeEncoderTest, TestResetOnRisingEdge) {
+TEST_F(FakeEncoderTest, ResetOnRisingEdge) {
   m_encoder.SetIndexSource(*m_indexAnalogTriggerOutput,
                            frc::Encoder::IndexingType::kResetOnRisingEdge);
 
@@ -113,7 +113,7 @@ TEST_F(FakeEncoderTest, TestResetOnRisingEdge) {
 /**
  * Test that the encoder can stay reset while the index source is low
  */
-TEST_F(FakeEncoderTest, TestResetWhileLow) {
+TEST_F(FakeEncoderTest, ResetWhileLow) {
   m_encoder.SetIndexSource(*m_indexAnalogTriggerOutput,
                            frc::Encoder::IndexingType::kResetWhileLow);
 
@@ -129,7 +129,7 @@ TEST_F(FakeEncoderTest, TestResetWhileLow) {
 /**
  * Test that the encoder can reset when the index source goes from high to low
  */
-TEST_F(FakeEncoderTest, TestResetOnFallingEdge) {
+TEST_F(FakeEncoderTest, ResetOnFallingEdge) {
   m_encoder.SetIndexSource(*m_indexAnalogTriggerOutput,
                            frc::Encoder::IndexingType::kResetOnFallingEdge);
 

--- a/wpilibcIntegrationTests/src/main/native/cpp/NotifierTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/NotifierTest.cpp
@@ -9,7 +9,7 @@
 #include "frc/Timer.h"
 #include "gtest/gtest.h"
 
-TEST(NotifierTest, TestStartPeriodicAndStop) {
+TEST(NotifierTest, StartPeriodicAndStop) {
   uint32_t counter = 0;
 
   frc::Notifier notifier{[&] { ++counter; }};
@@ -29,7 +29,7 @@ TEST(NotifierTest, TestStartPeriodicAndStop) {
   fmt::print("Received {} notifications in 3 seconds\n", counter - 10);
 }
 
-TEST(NotifierTest, TestStartSingle) {
+TEST(NotifierTest, StartSingle) {
   uint32_t counter = 0;
 
   frc::Notifier notifier{[&] { ++counter; }};

--- a/wpimath/src/test/native/cpp/EigenTest.cpp
+++ b/wpimath/src/test/native/cpp/EigenTest.cpp
@@ -6,7 +6,7 @@
 #include "Eigen/LU"
 #include "gtest/gtest.h"
 
-TEST(EigenTest, MultiplicationTest) {
+TEST(EigenTest, Multiplication) {
   Eigen::Matrix<double, 2, 2> m1{{2, 1}, {0, 1}};
   Eigen::Matrix<double, 2, 2> m2{{3, 0}, {0, 2.5}};
 
@@ -28,7 +28,7 @@ TEST(EigenTest, MultiplicationTest) {
   EXPECT_TRUE(expectedResult2.isApprox(result2));
 }
 
-TEST(EigenTest, TransposeTest) {
+TEST(EigenTest, Transpose) {
   Eigen::Vector<double, 3> vec{1, 2, 3};
 
   const auto transpose = vec.transpose();
@@ -38,7 +38,7 @@ TEST(EigenTest, TransposeTest) {
   EXPECT_TRUE(expectedTranspose.isApprox(transpose));
 }
 
-TEST(EigenTest, InverseTest) {
+TEST(EigenTest, Inverse) {
   Eigen::Matrix<double, 3, 3> mat{
       {1.0, 3.0, 2.0}, {5.0, 2.0, 1.5}, {0.0, 1.3, 2.5}};
 

--- a/wpimath/src/test/native/cpp/controller/PIDInputOutputTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/PIDInputOutputTest.cpp
@@ -14,7 +14,7 @@ class PIDInputOutputTest : public testing::Test {
   void TearDown() override { delete controller; }
 };
 
-TEST_F(PIDInputOutputTest, ContinuousInputTest) {
+TEST_F(PIDInputOutputTest, ContinuousInput) {
   controller->SetP(1);
   controller->EnableContinuousInput(-180, 180);
   EXPECT_DOUBLE_EQ(controller->Calculate(-179, 179), -2);
@@ -23,13 +23,13 @@ TEST_F(PIDInputOutputTest, ContinuousInputTest) {
   EXPECT_DOUBLE_EQ(controller->Calculate(1, 359), -2);
 }
 
-TEST_F(PIDInputOutputTest, ProportionalGainOutputTest) {
+TEST_F(PIDInputOutputTest, ProportionalGainOutput) {
   controller->SetP(4);
 
   EXPECT_DOUBLE_EQ(-0.1, controller->Calculate(0.025, 0));
 }
 
-TEST_F(PIDInputOutputTest, IntegralGainOutputTest) {
+TEST_F(PIDInputOutputTest, IntegralGainOutput) {
   controller->SetI(4);
 
   double out = 0;
@@ -41,7 +41,7 @@ TEST_F(PIDInputOutputTest, IntegralGainOutputTest) {
   EXPECT_DOUBLE_EQ(-0.5 * controller->GetPeriod().to<double>(), out);
 }
 
-TEST_F(PIDInputOutputTest, DerivativeGainOutputTest) {
+TEST_F(PIDInputOutputTest, DerivativeGainOutput) {
   controller->SetD(4);
 
   controller->Calculate(0, 0);

--- a/wpimath/src/test/native/cpp/controller/ProfiledPIDInputOutputTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/ProfiledPIDInputOutputTest.cpp
@@ -22,7 +22,7 @@ class ProfiledPIDInputOutputTest : public testing::Test {
   void TearDown() override { delete controller; }
 };
 
-TEST_F(ProfiledPIDInputOutputTest, ContinuousInputTest1) {
+TEST_F(ProfiledPIDInputOutputTest, ContinuousInput1) {
   controller->SetP(1);
   controller->EnableContinuousInput(-180_deg, 180_deg);
 
@@ -38,7 +38,7 @@ TEST_F(ProfiledPIDInputOutputTest, ContinuousInputTest1) {
             180_deg);
 }
 
-TEST_F(ProfiledPIDInputOutputTest, ContinuousInputTest2) {
+TEST_F(ProfiledPIDInputOutputTest, ContinuousInput2) {
   controller->SetP(1);
   controller->EnableContinuousInput(-units::radian_t{wpi::numbers::pi},
                                     units::radian_t{wpi::numbers::pi});
@@ -55,7 +55,7 @@ TEST_F(ProfiledPIDInputOutputTest, ContinuousInputTest2) {
             units::radian_t{wpi::numbers::pi});
 }
 
-TEST_F(ProfiledPIDInputOutputTest, ContinuousInputTest3) {
+TEST_F(ProfiledPIDInputOutputTest, ContinuousInput3) {
   controller->SetP(1);
   controller->EnableContinuousInput(-units::radian_t{wpi::numbers::pi},
                                     units::radian_t{wpi::numbers::pi});
@@ -72,7 +72,7 @@ TEST_F(ProfiledPIDInputOutputTest, ContinuousInputTest3) {
             units::radian_t{wpi::numbers::pi});
 }
 
-TEST_F(ProfiledPIDInputOutputTest, ContinuousInputTest4) {
+TEST_F(ProfiledPIDInputOutputTest, ContinuousInput4) {
   controller->SetP(1);
   controller->EnableContinuousInput(0_rad,
                                     units::radian_t{2.0 * wpi::numbers::pi});
@@ -89,13 +89,13 @@ TEST_F(ProfiledPIDInputOutputTest, ContinuousInputTest4) {
             units::radian_t{wpi::numbers::pi});
 }
 
-TEST_F(ProfiledPIDInputOutputTest, ProportionalGainOutputTest) {
+TEST_F(ProfiledPIDInputOutputTest, ProportionalGainOutput) {
   controller->SetP(4);
 
   EXPECT_DOUBLE_EQ(-0.1, controller->Calculate(0.025_deg, 0_deg));
 }
 
-TEST_F(ProfiledPIDInputOutputTest, IntegralGainOutputTest) {
+TEST_F(ProfiledPIDInputOutputTest, IntegralGainOutput) {
   controller->SetI(4);
 
   double out = 0;
@@ -107,7 +107,7 @@ TEST_F(ProfiledPIDInputOutputTest, IntegralGainOutputTest) {
   EXPECT_DOUBLE_EQ(-0.5 * controller->GetPeriod().to<double>(), out);
 }
 
-TEST_F(ProfiledPIDInputOutputTest, DerivativeGainOutputTest) {
+TEST_F(ProfiledPIDInputOutputTest, DerivativeGainOutput) {
   controller->SetD(4);
 
   controller->Calculate(0_deg, 0_deg);

--- a/wpimath/src/test/native/cpp/estimator/AngleStatisticsTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/AngleStatisticsTest.cpp
@@ -9,7 +9,7 @@
 #include "Eigen/Core"
 #include "frc/estimator/AngleStatistics.h"
 
-TEST(AngleStatisticsTest, TestMean) {
+TEST(AngleStatisticsTest, Mean) {
   Eigen::Matrix<double, 3, 3> sigmas{
       {1, 1.2, 0},
       {359 * wpi::numbers::pi / 180, 3 * wpi::numbers::pi / 180, 0},
@@ -22,7 +22,7 @@ TEST(AngleStatisticsTest, TestMean) {
                   .isApprox(frc::AngleMean<3, 1>(sigmas, weights, 1), 1e-3));
 }
 
-TEST(AngleStatisticsTest, TestResidual) {
+TEST(AngleStatisticsTest, Residual) {
   Eigen::Vector3d a{1, 1 * wpi::numbers::pi / 180, 2};
   Eigen::Vector3d b{1, 359 * wpi::numbers::pi / 180, 1};
 
@@ -30,7 +30,7 @@ TEST(AngleStatisticsTest, TestResidual) {
       Eigen::Vector3d{0, 2 * wpi::numbers::pi / 180, 1}));
 }
 
-TEST(AngleStatisticsTest, TestAdd) {
+TEST(AngleStatisticsTest, Add) {
   Eigen::Vector3d a{1, 1 * wpi::numbers::pi / 180, 2};
   Eigen::Vector3d b{1, 359 * wpi::numbers::pi / 180, 1};
 

--- a/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
@@ -17,7 +17,7 @@
 #include "units/length.h"
 #include "units/time.h"
 
-TEST(DifferentialDrivePoseEstimatorTest, TestAccuracy) {
+TEST(DifferentialDrivePoseEstimatorTest, Accuracy) {
   frc::DifferentialDrivePoseEstimator estimator{frc::Rotation2d(),
                                                 frc::Pose2d(),
                                                 {0.02, 0.02, 0.01, 0.02, 0.02},

--- a/wpimath/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
@@ -12,7 +12,7 @@
 #include "frc/trajectory/TrajectoryGenerator.h"
 #include "gtest/gtest.h"
 
-TEST(MecanumDrivePoseEstimatorTest, TestAccuracy) {
+TEST(MecanumDrivePoseEstimatorTest, Accuracy) {
   frc::MecanumDriveKinematics kinematics{
       frc::Translation2d{1_m, 1_m}, frc::Translation2d{1_m, -1_m},
       frc::Translation2d{-1_m, -1_m}, frc::Translation2d{-1_m, 1_m}};

--- a/wpimath/src/test/native/cpp/estimator/MerweScaledSigmaPointsTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/MerweScaledSigmaPointsTest.cpp
@@ -8,7 +8,7 @@
 
 namespace drake::math {
 namespace {
-TEST(MerweScaledSigmaPointsTest, TestZeroMean) {
+TEST(MerweScaledSigmaPointsTest, ZeroMean) {
   frc::MerweScaledSigmaPoints<2> sigmaPoints;
   auto points = sigmaPoints.SigmaPoints(
       Eigen::Vector<double, 2>{0.0, 0.0},
@@ -21,7 +21,7 @@ TEST(MerweScaledSigmaPointsTest, TestZeroMean) {
           .norm() < 1e-3);
 }
 
-TEST(MerweScaledSigmaPointsTest, TestNonzeroMean) {
+TEST(MerweScaledSigmaPointsTest, NonzeroMean) {
   frc::MerweScaledSigmaPoints<2> sigmaPoints;
   auto points = sigmaPoints.SigmaPoints(
       Eigen::Vector<double, 2>{1.0, 2.0},

--- a/wpimath/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
@@ -12,7 +12,7 @@
 #include "frc/trajectory/TrajectoryGenerator.h"
 #include "gtest/gtest.h"
 
-TEST(SwerveDrivePoseEstimatorTest, TestAccuracy) {
+TEST(SwerveDrivePoseEstimatorTest, Accuracy) {
   frc::SwerveDriveKinematics<4> kinematics{
       frc::Translation2d{1_m, 1_m}, frc::Translation2d{1_m, -1_m},
       frc::Translation2d{-1_m, -1_m}, frc::Translation2d{-1_m, 1_m}};

--- a/wpimath/src/test/native/cpp/filter/SlewRateLimiterTest.cpp
+++ b/wpimath/src/test/native/cpp/filter/SlewRateLimiterTest.cpp
@@ -12,7 +12,7 @@
 
 static units::second_t now = 0_s;
 
-TEST(SlewRateLimiterTest, SlewRateLimitTest) {
+TEST(SlewRateLimiterTest, SlewRateLimit) {
   WPI_SetNowImpl([] { return units::microsecond_t{now}.to<uint64_t>(); });
 
   frc::SlewRateLimiter<units::meters> limiter(1_mps);
@@ -22,7 +22,7 @@ TEST(SlewRateLimiterTest, SlewRateLimitTest) {
   EXPECT_LT(limiter.Calculate(2_m), 2_m);
 }
 
-TEST(SlewRateLimiterTest, SlewRateNoLimitTest) {
+TEST(SlewRateLimiterTest, SlewRateNoLimit) {
   WPI_SetNowImpl([] { return units::microsecond_t{now}.to<uint64_t>(); });
 
   frc::SlewRateLimiter<units::meters> limiter(1_mps);

--- a/wpimath/src/test/native/cpp/kinematics/MecanumDriveKinematicsTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/MecanumDriveKinematicsTest.cpp
@@ -143,7 +143,7 @@ TEST_F(MecanumDriveKinematicsTest,
   EXPECT_NEAR(0.707, chassisSpeeds.omega.to<double>(), 0.1);
 }
 
-TEST_F(MecanumDriveKinematicsTest, NormalizeTest) {
+TEST_F(MecanumDriveKinematicsTest, Normalize) {
   MecanumDriveWheelSpeeds wheelSpeeds{5_mps, 6_mps, 4_mps, 7_mps};
   wheelSpeeds.Normalize(5.5_mps);
 

--- a/wpimath/src/test/native/cpp/kinematics/MecanumDriveOdometryTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/MecanumDriveOdometryTest.cpp
@@ -43,7 +43,7 @@ TEST_F(MecanumDriveOdometryTest, TwoIterations) {
   EXPECT_NEAR(pose.Rotation().Radians().to<double>(), 0.0, 0.01);
 }
 
-TEST_F(MecanumDriveOdometryTest, Test90DegreeTurn) {
+TEST_F(MecanumDriveOdometryTest, 90DegreeTurn) {
   odometry.ResetPosition(Pose2d(), 0_rad);
   MecanumDriveWheelSpeeds speeds{-13.328_mps, 39.986_mps, -13.329_mps,
                                  39.986_mps};

--- a/wpimath/src/test/native/cpp/kinematics/SwerveDriveKinematicsTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/SwerveDriveKinematicsTest.cpp
@@ -162,7 +162,7 @@ TEST_F(SwerveDriveKinematicsTest,
   EXPECT_NEAR(chassisSpeeds.omega.to<double>(), 1.5, kEpsilon);
 }
 
-TEST_F(SwerveDriveKinematicsTest, NormalizeTest) {
+TEST_F(SwerveDriveKinematicsTest, Normalize) {
   SwerveModuleState state1{5.0_mps, Rotation2d()};
   SwerveModuleState state2{6.0_mps, Rotation2d()};
   SwerveModuleState state3{4.0_mps, Rotation2d()};

--- a/wpiutil/src/test/native/cpp/CircularBufferTest.cpp
+++ b/wpiutil/src/test/native/cpp/CircularBufferTest.cpp
@@ -18,7 +18,7 @@ static const std::array<double, 8> pushFrontOut = {
 static const std::array<double, 8> pushBackOut = {
     {342.657, 234.252, 716.126, 132.344, 445.697, 22.727, 421.125, 799.913}};
 
-TEST(CircularBufferTest, PushFrontTest) {
+TEST(CircularBufferTest, PushFront) {
   wpi::circular_buffer<double> queue(8);
 
   for (auto& value : values) {
@@ -30,7 +30,7 @@ TEST(CircularBufferTest, PushFrontTest) {
   }
 }
 
-TEST(CircularBufferTest, PushBackTest) {
+TEST(CircularBufferTest, PushBack) {
   wpi::circular_buffer<double> queue(8);
 
   for (auto& value : values) {
@@ -42,7 +42,7 @@ TEST(CircularBufferTest, PushBackTest) {
   }
 }
 
-TEST(CircularBufferTest, EmplaceFrontTest) {
+TEST(CircularBufferTest, EmplaceFront) {
   wpi::circular_buffer<double> queue(8);
 
   for (auto& value : values) {
@@ -54,7 +54,7 @@ TEST(CircularBufferTest, EmplaceFrontTest) {
   }
 }
 
-TEST(CircularBufferTest, EmplaceBackTest) {
+TEST(CircularBufferTest, EmplaceBack) {
   wpi::circular_buffer<double> queue(8);
 
   for (auto& value : values) {
@@ -66,7 +66,7 @@ TEST(CircularBufferTest, EmplaceBackTest) {
   }
 }
 
-TEST(CircularBufferTest, PushPopTest) {
+TEST(CircularBufferTest, PushPop) {
   wpi::circular_buffer<double> queue(3);
 
   // Insert three elements into the buffer
@@ -109,7 +109,7 @@ TEST(CircularBufferTest, PushPopTest) {
   EXPECT_EQ(4.0, queue[0]);
 }
 
-TEST(CircularBufferTest, ResetTest) {
+TEST(CircularBufferTest, Reset) {
   wpi::circular_buffer<double> queue(5);
 
   for (size_t i = 1; i < 6; ++i) {
@@ -121,7 +121,7 @@ TEST(CircularBufferTest, ResetTest) {
   EXPECT_EQ(queue.size(), size_t{0});
 }
 
-TEST(CircularBufferTest, ResizeTest) {
+TEST(CircularBufferTest, Resize) {
   wpi::circular_buffer<double> queue(5);
 
   /* Buffer contains {1, 2, 3, _, _}
@@ -227,7 +227,7 @@ TEST(CircularBufferTest, ResizeTest) {
   EXPECT_EQ(3.0, queue[3]);
 }
 
-TEST(CircularBufferTest, IteratorTest) {
+TEST(CircularBufferTest, Iterator) {
   wpi::circular_buffer<double> queue(3);
 
   queue.push_back(1.0);

--- a/wpiutil/src/test/native/cpp/StaticCircularBufferTest.cpp
+++ b/wpiutil/src/test/native/cpp/StaticCircularBufferTest.cpp
@@ -18,7 +18,7 @@ static const std::array<double, 8> pushFrontOut = {
 static const std::array<double, 8> pushBackOut = {
     {342.657, 234.252, 716.126, 132.344, 445.697, 22.727, 421.125, 799.913}};
 
-TEST(StaticCircularBufferTest, PushFrontTest) {
+TEST(StaticCircularBufferTest, PushFront) {
   wpi::static_circular_buffer<double, 8> queue;
 
   for (auto& value : values) {
@@ -30,7 +30,7 @@ TEST(StaticCircularBufferTest, PushFrontTest) {
   }
 }
 
-TEST(StaticCircularBufferTest, PushBackTest) {
+TEST(StaticCircularBufferTest, PushBack) {
   wpi::static_circular_buffer<double, 8> queue;
 
   for (auto& value : values) {
@@ -42,7 +42,7 @@ TEST(StaticCircularBufferTest, PushBackTest) {
   }
 }
 
-TEST(StaticCircularBufferTest, EmplaceFrontTest) {
+TEST(StaticCircularBufferTest, EmplaceFront) {
   wpi::static_circular_buffer<double, 8> queue;
 
   for (auto& value : values) {
@@ -54,7 +54,7 @@ TEST(StaticCircularBufferTest, EmplaceFrontTest) {
   }
 }
 
-TEST(StaticCircularBufferTest, EmplaceBackTest) {
+TEST(StaticCircularBufferTest, EmplaceBack) {
   wpi::static_circular_buffer<double, 8> queue;
 
   for (auto& value : values) {
@@ -66,7 +66,7 @@ TEST(StaticCircularBufferTest, EmplaceBackTest) {
   }
 }
 
-TEST(StaticCircularBufferTest, PushPopTest) {
+TEST(StaticCircularBufferTest, PushPop) {
   wpi::static_circular_buffer<double, 3> queue;
 
   // Insert three elements into the buffer
@@ -109,7 +109,7 @@ TEST(StaticCircularBufferTest, PushPopTest) {
   EXPECT_EQ(4.0, queue[0]);
 }
 
-TEST(StaticCircularBufferTest, ResetTest) {
+TEST(StaticCircularBufferTest, Reset) {
   wpi::static_circular_buffer<double, 5> queue;
 
   for (size_t i = 1; i < 6; ++i) {
@@ -121,7 +121,7 @@ TEST(StaticCircularBufferTest, ResetTest) {
   EXPECT_EQ(queue.size(), size_t{0});
 }
 
-TEST(StaticCircularBufferTest, IteratorTest) {
+TEST(StaticCircularBufferTest, Iterator) {
   wpi::static_circular_buffer<double, 3> queue;
 
   queue.push_back(1.0);

--- a/wpiutil/src/test/native/cpp/priority_mutex_test.cpp
+++ b/wpiutil/src/test/native/cpp/priority_mutex_test.cpp
@@ -222,7 +222,7 @@ class InversionTestRunner {
 // TODO: Fix roborio permissions to run as root.
 
 // Priority inversion test.
-TEST(MutexTest, DISABLED_PriorityInversionTest) {
+TEST(MutexTest, DISABLED_PriorityInversion) {
   InversionTestRunner<priority_mutex> runner;
   std::thread runner_thread(std::ref(runner));
   runner_thread.join();
@@ -230,7 +230,7 @@ TEST(MutexTest, DISABLED_PriorityInversionTest) {
 }
 
 // Verify that the non-priority inversion mutex doesn't pass the test.
-TEST(MutexTest, DISABLED_StdMutexPriorityInversionTest) {
+TEST(MutexTest, DISABLED_StdMutexPriorityInversion) {
   InversionTestRunner<std::mutex> runner;
   std::thread runner_thread(std::ref(runner));
   runner_thread.join();
@@ -247,7 +247,7 @@ TEST(MutexTest, TryLock) {
 }
 
 // Priority inversion test.
-TEST(MutexTest, DISABLED_ReentrantPriorityInversionTest) {
+TEST(MutexTest, DISABLED_ReentrantPriorityInversion) {
   InversionTestRunner<priority_recursive_mutex> runner;
   std::thread runner_thread(std::ref(runner));
   runner_thread.join();


### PR DESCRIPTION
Inconsistent names were found using the following regular expressions.

* `rg "TEST(_F|_P)?\(\w+,\s+\w+Test\)"`
* `rg "TEST(_F|_P)?\(\w+,\s+Test\w+\)"`
* `rg "TEST(_F|_P)?\(\w+Tests,\s+\w+\)"`

Fixes #3495.