### PR TITLE
Rename tests for consistency

### DIFF
--- a/crossConnIntegrationTests/src/main/native/cpp/AnalogTest.cpp
+++ b/crossConnIntegrationTests/src/main/native/cpp/AnalogTest.cpp
@@ -108,5 +108,5 @@ TEST(AnalogOutputTest, UnderAllocateFails) {
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_OUT_OF_RANGE);
 }
 
-INSTANTIATE_TEST_SUITE_P(AnalogCrossConnectsTest, AnalogCrossTest,
+INSTANTIATE_TEST_SUITE_P(AnalogCrossConnectsTests, AnalogCrossTest,
                          ::testing::ValuesIn(AnalogCrossConnects));

--- a/crossConnIntegrationTests/src/main/native/cpp/DIOTest.cpp
+++ b/crossConnIntegrationTests/src/main/native/cpp/DIOTest.cpp
@@ -97,5 +97,5 @@ TEST(DIOTest, CrossAllocationFails) {
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_IS_ALLOCATED);
 }
 
-INSTANTIATE_TEST_SUITE_P(DIOCrossConnectsTest, DIOTest,
+INSTANTIATE_TEST_SUITE_P(DIOCrossConnectsTests, DIOTest,
                          ::testing::ValuesIn(DIOCrossConnects));

--- a/crossConnIntegrationTests/src/main/native/cpp/DutyCycleTest.cpp
+++ b/crossConnIntegrationTests/src/main/native/cpp/DutyCycleTest.cpp
@@ -47,5 +47,5 @@ TEST_P(DutyCycleTest, DutyCycle) {
   // TODO measure output
 }
 
-INSTANTIATE_TEST_SUITE_P(DutyCycleCrossConnTest, DutyCycleTest,
+INSTANTIATE_TEST_SUITE_P(DutyCycleCrossConnTests, DutyCycleTest,
                          ::testing::ValuesIn(PWMCrossConnects));

--- a/crossConnIntegrationTests/src/main/native/cpp/RelayAnalogTest.cpp
+++ b/crossConnIntegrationTests/src/main/native/cpp/RelayAnalogTest.cpp
@@ -46,5 +46,5 @@ TEST_P(RelayAnalogTest, RelayAnalogCross) {
   ASSERT_EQ(0, status);
 }
 
-INSTANTIATE_TEST_SUITE_P(RelayAnalogCrossConnectsTest, RelayAnalogTest,
+INSTANTIATE_TEST_SUITE_P(RelayAnalogCrossConnectsTests, RelayAnalogTest,
                          ::testing::ValuesIn(RelayAnalogCrossConnects));

--- a/crossConnIntegrationTests/src/main/native/cpp/RelayDigitalTest.cpp
+++ b/crossConnIntegrationTests/src/main/native/cpp/RelayDigitalTest.cpp
@@ -100,5 +100,5 @@ TEST(RelayDigitalTest, UnderAllocateFails) {
   ASSERT_LAST_ERROR_STATUS(status, RESOURCE_OUT_OF_RANGE);
 }
 
-INSTANTIATE_TEST_SUITE_P(RelayDigitalCrossConnectsTest, RelayDigitalTest,
+INSTANTIATE_TEST_SUITE_P(RelayDigitalCrossConnectsTests, RelayDigitalTest,
                          ::testing::ValuesIn(RelayCrossConnects));

--- a/ntcore/src/test/native/cpp/StorageTest.cpp
+++ b/ntcore/src/test/native/cpp/StorageTest.cpp
@@ -24,10 +24,10 @@ using ::testing::Return;
 
 namespace nt {
 
-class StorageTestEmpty : public StorageTest,
+class StorageEmptyTest : public StorageTest,
                          public ::testing::TestWithParam<bool> {
  public:
-  StorageTestEmpty() {
+  StorageEmptyTest() {
     HookOutgoing(GetParam());
     EXPECT_CALL(notifier, local_notifiers())
         .Times(AnyNumber())
@@ -35,9 +35,9 @@ class StorageTestEmpty : public StorageTest,
   }
 };
 
-class StorageTestPopulateOne : public StorageTestEmpty {
+class StoragePopulateOneTest : public StorageEmptyTest {
  public:
-  StorageTestPopulateOne() {
+  StoragePopulateOneTest() {
     EXPECT_CALL(dispatcher, QueueOutgoing(_, _, _)).Times(AnyNumber());
     EXPECT_CALL(notifier, NotifyEntry(_, _, _, _, _)).Times(AnyNumber());
     EXPECT_CALL(notifier, local_notifiers())
@@ -52,9 +52,9 @@ class StorageTestPopulateOne : public StorageTestEmpty {
   }
 };
 
-class StorageTestPopulated : public StorageTestEmpty {
+class StoragePopulatedTest : public StorageEmptyTest {
  public:
-  StorageTestPopulated() {
+  StoragePopulatedTest() {
     EXPECT_CALL(dispatcher, QueueOutgoing(_, _, _)).Times(AnyNumber());
     EXPECT_CALL(notifier, NotifyEntry(_, _, _, _, _)).Times(AnyNumber());
     EXPECT_CALL(notifier, local_notifiers())
@@ -72,9 +72,9 @@ class StorageTestPopulated : public StorageTestEmpty {
   }
 };
 
-class StorageTestPersistent : public StorageTestEmpty {
+class StoragePersistentTest : public StorageEmptyTest {
  public:
-  StorageTestPersistent() {
+  StoragePersistentTest() {
     EXPECT_CALL(dispatcher, QueueOutgoing(_, _, _)).Times(AnyNumber());
     EXPECT_CALL(notifier, NotifyEntry(_, _, _, _, _)).Times(AnyNumber());
     EXPECT_CALL(notifier, local_notifiers())
@@ -131,12 +131,12 @@ class MockLoadWarn {
   MOCK_METHOD2(Warn, void(size_t line, std::string_view msg));
 };
 
-TEST_P(StorageTestEmpty, Construct) {
+TEST_P(StorageEmptyTest, Construct) {
   EXPECT_TRUE(entries().empty());
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestEmpty, StorageEntryInit) {
+TEST_P(StorageEmptyTest, StorageEntryInit) {
   auto entry = GetEntry("foo");
   EXPECT_FALSE(entry->value);
   EXPECT_EQ(0u, entry->flags);
@@ -145,13 +145,13 @@ TEST_P(StorageTestEmpty, StorageEntryInit) {
   EXPECT_EQ(SequenceNumber(), entry->seq_num);
 }
 
-TEST_P(StorageTestEmpty, GetEntryValueNotExist) {
+TEST_P(StorageEmptyTest, GetEntryValueNotExist) {
   EXPECT_FALSE(storage.GetEntryValue("foo"));
   EXPECT_TRUE(entries().empty());
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestEmpty, GetEntryValueExist) {
+TEST_P(StorageEmptyTest, GetEntryValueExist) {
   auto value = Value::MakeBoolean(true);
   EXPECT_CALL(dispatcher, QueueOutgoing(_, IsNull(), IsNull()));
   EXPECT_CALL(notifier, NotifyEntry(_, _, _, _, _));
@@ -159,7 +159,7 @@ TEST_P(StorageTestEmpty, GetEntryValueExist) {
   EXPECT_EQ(value, storage.GetEntryValue("foo"));
 }
 
-TEST_P(StorageTestEmpty, SetEntryTypeValueAssignNew) {
+TEST_P(StorageEmptyTest, SetEntryTypeValueAssignNew) {
   // brand new entry
   auto value = Value::MakeBoolean(true);
   // id assigned if server
@@ -180,7 +180,7 @@ TEST_P(StorageTestEmpty, SetEntryTypeValueAssignNew) {
   }
 }
 
-TEST_P(StorageTestPopulateOne, SetEntryTypeValueAssignTypeChange) {
+TEST_P(StoragePopulateOneTest, SetEntryTypeValueAssignTypeChange) {
   // update with different type results in assignment message
   auto value = Value::MakeDouble(0.0);
 
@@ -197,7 +197,7 @@ TEST_P(StorageTestPopulateOne, SetEntryTypeValueAssignTypeChange) {
   EXPECT_EQ(value, GetEntry("foo")->value);
 }
 
-TEST_P(StorageTestPopulateOne, SetEntryTypeValueEqualValue) {
+TEST_P(StoragePopulateOneTest, SetEntryTypeValueEqualValue) {
   // update with same type and same value: change value contents but no update
   // message is issued (minimizing bandwidth usage)
   auto value = Value::MakeBoolean(true);
@@ -205,7 +205,7 @@ TEST_P(StorageTestPopulateOne, SetEntryTypeValueEqualValue) {
   EXPECT_EQ(value, GetEntry("foo")->value);
 }
 
-TEST_P(StorageTestPopulated, SetEntryTypeValueDifferentValue) {
+TEST_P(StoragePopulatedTest, SetEntryTypeValueDifferentValue) {
   // update with same type and different value results in value update message
   auto value = Value::MakeDouble(1.0);
 
@@ -228,20 +228,20 @@ TEST_P(StorageTestPopulated, SetEntryTypeValueDifferentValue) {
   }
 }
 
-TEST_P(StorageTestEmpty, SetEntryTypeValueEmptyName) {
+TEST_P(StorageEmptyTest, SetEntryTypeValueEmptyName) {
   auto value = Value::MakeBoolean(true);
   storage.SetEntryTypeValue("", value);
   EXPECT_TRUE(entries().empty());
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestEmpty, SetEntryTypeValueEmptyValue) {
+TEST_P(StorageEmptyTest, SetEntryTypeValueEmptyValue) {
   storage.SetEntryTypeValue("foo", nullptr);
   EXPECT_TRUE(entries().empty());
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestEmpty, SetEntryValueAssignNew) {
+TEST_P(StorageEmptyTest, SetEntryValueAssignNew) {
   // brand new entry
   auto value = Value::MakeBoolean(true);
 
@@ -257,7 +257,7 @@ TEST_P(StorageTestEmpty, SetEntryValueAssignNew) {
   EXPECT_EQ(value, GetEntry("foo")->value);
 }
 
-TEST_P(StorageTestPopulateOne, SetEntryValueAssignTypeChange) {
+TEST_P(StoragePopulateOneTest, SetEntryValueAssignTypeChange) {
   // update with different type results in error and no message or notification
   auto value = Value::MakeDouble(0.0);
   EXPECT_FALSE(storage.SetEntryValue("foo", value));
@@ -265,7 +265,7 @@ TEST_P(StorageTestPopulateOne, SetEntryValueAssignTypeChange) {
   EXPECT_NE(value, entry->value);
 }
 
-TEST_P(StorageTestPopulateOne, SetEntryValueEqualValue) {
+TEST_P(StoragePopulateOneTest, SetEntryValueEqualValue) {
   // update with same type and same value: change value contents but no update
   // message is issued (minimizing bandwidth usage)
   auto value = Value::MakeBoolean(true);
@@ -274,7 +274,7 @@ TEST_P(StorageTestPopulateOne, SetEntryValueEqualValue) {
   EXPECT_EQ(value, entry->value);
 }
 
-TEST_P(StorageTestPopulated, SetEntryValueDifferentValue) {
+TEST_P(StoragePopulatedTest, SetEntryValueDifferentValue) {
   // update with same type and different value results in value update message
   auto value = Value::MakeDouble(1.0);
 
@@ -299,20 +299,20 @@ TEST_P(StorageTestPopulated, SetEntryValueDifferentValue) {
   }
 }
 
-TEST_P(StorageTestEmpty, SetEntryValueEmptyName) {
+TEST_P(StorageEmptyTest, SetEntryValueEmptyName) {
   auto value = Value::MakeBoolean(true);
   EXPECT_TRUE(storage.SetEntryValue("", value));
   EXPECT_TRUE(entries().empty());
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestEmpty, SetEntryValueEmptyValue) {
+TEST_P(StorageEmptyTest, SetEntryValueEmptyValue) {
   EXPECT_TRUE(storage.SetEntryValue("foo", nullptr));
   EXPECT_TRUE(entries().empty());
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestEmpty, SetDefaultEntryAssignNew) {
+TEST_P(StorageEmptyTest, SetDefaultEntryAssignNew) {
   // brand new entry
   auto value = Value::MakeBoolean(true);
 
@@ -329,7 +329,7 @@ TEST_P(StorageTestEmpty, SetDefaultEntryAssignNew) {
   EXPECT_EQ(value, GetEntry("foo")->value);
 }
 
-TEST_P(StorageTestPopulateOne, SetDefaultEntryExistsSameType) {
+TEST_P(StoragePopulateOneTest, SetDefaultEntryExistsSameType) {
   // existing entry
   auto value = Value::MakeBoolean(true);
   auto ret_val = storage.SetDefaultEntryValue("foo", value);
@@ -337,7 +337,7 @@ TEST_P(StorageTestPopulateOne, SetDefaultEntryExistsSameType) {
   EXPECT_NE(value, GetEntry("foo")->value);
 }
 
-TEST_P(StorageTestPopulateOne, SetDefaultEntryExistsDifferentType) {
+TEST_P(StoragePopulateOneTest, SetDefaultEntryExistsDifferentType) {
   // existing entry is boolean
   auto value = Value::MakeDouble(2.0);
   auto ret_val = storage.SetDefaultEntryValue("foo", value);
@@ -346,7 +346,7 @@ TEST_P(StorageTestPopulateOne, SetDefaultEntryExistsDifferentType) {
   EXPECT_NE(value, GetEntry("foo")->value);
 }
 
-TEST_P(StorageTestEmpty, SetDefaultEntryEmptyName) {
+TEST_P(StorageEmptyTest, SetDefaultEntryEmptyName) {
   auto value = Value::MakeBoolean(true);
   auto ret_val = storage.SetDefaultEntryValue("", value);
   EXPECT_FALSE(ret_val);
@@ -360,7 +360,7 @@ TEST_P(StorageTestEmpty, SetDefaultEntryEmptyName) {
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestEmpty, SetDefaultEntryEmptyValue) {
+TEST_P(StorageEmptyTest, SetDefaultEntryEmptyValue) {
   auto value = Value::MakeBoolean(true);
   auto ret_val = storage.SetDefaultEntryValue("", nullptr);
   EXPECT_FALSE(ret_val);
@@ -374,7 +374,7 @@ TEST_P(StorageTestEmpty, SetDefaultEntryEmptyValue) {
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestPopulated, SetDefaultEntryEmptyName) {
+TEST_P(StoragePopulatedTest, SetDefaultEntryEmptyName) {
   auto value = Value::MakeBoolean(true);
   auto ret_val = storage.SetDefaultEntryValue("", value);
   EXPECT_FALSE(ret_val);
@@ -387,7 +387,7 @@ TEST_P(StorageTestPopulated, SetDefaultEntryEmptyName) {
   }
 }
 
-TEST_P(StorageTestPopulated, SetDefaultEntryEmptyValue) {
+TEST_P(StoragePopulatedTest, SetDefaultEntryEmptyValue) {
   auto value = Value::MakeBoolean(true);
   auto ret_val = storage.SetDefaultEntryValue("", nullptr);
   EXPECT_FALSE(ret_val);
@@ -400,14 +400,14 @@ TEST_P(StorageTestPopulated, SetDefaultEntryEmptyValue) {
   }
 }
 
-TEST_P(StorageTestEmpty, SetEntryFlagsNew) {
+TEST_P(StorageEmptyTest, SetEntryFlagsNew) {
   // flags setting doesn't create an entry
   storage.SetEntryFlags("foo", 0u);
   EXPECT_TRUE(entries().empty());
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestPopulateOne, SetEntryFlagsEqualValue) {
+TEST_P(StoragePopulateOneTest, SetEntryFlagsEqualValue) {
   // update with same value: no update message is issued (minimizing bandwidth
   // usage)
   storage.SetEntryFlags("foo", 0u);
@@ -415,7 +415,7 @@ TEST_P(StorageTestPopulateOne, SetEntryFlagsEqualValue) {
   EXPECT_EQ(0u, entry->flags);
 }
 
-TEST_P(StorageTestPopulated, SetEntryFlagsDifferentValue) {
+TEST_P(StoragePopulatedTest, SetEntryFlagsDifferentValue) {
   // update with different value results in flags update message
   // client shouldn't send an update as id not assigned yet
   if (GetParam()) {
@@ -430,19 +430,19 @@ TEST_P(StorageTestPopulated, SetEntryFlagsDifferentValue) {
   EXPECT_EQ(1u, GetEntry("foo2")->flags);
 }
 
-TEST_P(StorageTestEmpty, SetEntryFlagsEmptyName) {
+TEST_P(StorageEmptyTest, SetEntryFlagsEmptyName) {
   storage.SetEntryFlags("", 0u);
   EXPECT_TRUE(entries().empty());
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestEmpty, GetEntryFlagsNotExist) {
+TEST_P(StorageEmptyTest, GetEntryFlagsNotExist) {
   EXPECT_EQ(0u, storage.GetEntryFlags("foo"));
   EXPECT_TRUE(entries().empty());
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestPopulateOne, GetEntryFlagsExist) {
+TEST_P(StoragePopulateOneTest, GetEntryFlagsExist) {
   EXPECT_CALL(dispatcher, QueueOutgoing(_, _, _)).Times(AnyNumber());
   EXPECT_CALL(notifier, NotifyEntry(_, _, _, _, _));
   storage.SetEntryFlags("foo", 1u);
@@ -450,11 +450,11 @@ TEST_P(StorageTestPopulateOne, GetEntryFlagsExist) {
   EXPECT_EQ(1u, storage.GetEntryFlags("foo"));
 }
 
-TEST_P(StorageTestEmpty, DeleteEntryNotExist) {
+TEST_P(StorageEmptyTest, DeleteEntryNotExist) {
   storage.DeleteEntry("foo");
 }
 
-TEST_P(StorageTestPopulated, DeleteEntryExist) {
+TEST_P(StoragePopulatedTest, DeleteEntryExist) {
   // client shouldn't send an update as id not assigned yet
   if (GetParam()) {
     // id assigned as this is the server
@@ -477,12 +477,12 @@ TEST_P(StorageTestPopulated, DeleteEntryExist) {
   }
 }
 
-TEST_P(StorageTestEmpty, DeleteAllEntriesEmpty) {
+TEST_P(StorageEmptyTest, DeleteAllEntriesEmpty) {
   storage.DeleteAllEntries();
   ASSERT_TRUE(entries().empty());
 }
 
-TEST_P(StorageTestPopulated, DeleteAllEntries) {
+TEST_P(StoragePopulatedTest, DeleteAllEntries) {
   EXPECT_CALL(dispatcher, QueueOutgoing(MessageEq(Message::ClearEntries()),
                                         IsNull(), IsNull()));
   EXPECT_CALL(notifier, NotifyEntry(_, _, _, NT_NOTIFY_DELETE | NT_NOTIFY_LOCAL,
@@ -494,7 +494,7 @@ TEST_P(StorageTestPopulated, DeleteAllEntries) {
   EXPECT_EQ(nullptr, entries()["foo2"]->value);
 }
 
-TEST_P(StorageTestPopulated, DeleteAllEntriesPersistent) {
+TEST_P(StoragePopulatedTest, DeleteAllEntriesPersistent) {
   GetEntry("foo2")->flags = NT_PERSISTENT;
 
   EXPECT_CALL(dispatcher, QueueOutgoing(MessageEq(Message::ClearEntries()),
@@ -508,12 +508,12 @@ TEST_P(StorageTestPopulated, DeleteAllEntriesPersistent) {
   EXPECT_NE(nullptr, entries()["foo2"]->value);
 }
 
-TEST_P(StorageTestPopulated, GetEntryInfoAll) {
+TEST_P(StoragePopulatedTest, GetEntryInfoAll) {
   auto info = storage.GetEntryInfo(0, "", 0u);
   ASSERT_EQ(4u, info.size());
 }
 
-TEST_P(StorageTestPopulated, GetEntryInfoPrefix) {
+TEST_P(StoragePopulatedTest, GetEntryInfoPrefix) {
   auto info = storage.GetEntryInfo(0, "foo", 0u);
   ASSERT_EQ(2u, info.size());
   if (info[0].name == "foo") {
@@ -529,7 +529,7 @@ TEST_P(StorageTestPopulated, GetEntryInfoPrefix) {
   }
 }
 
-TEST_P(StorageTestPopulated, GetEntryInfoTypes) {
+TEST_P(StoragePopulatedTest, GetEntryInfoTypes) {
   auto info = storage.GetEntryInfo(0, "", NT_DOUBLE);
   ASSERT_EQ(2u, info.size());
   EXPECT_EQ(NT_DOUBLE, info[0].type);
@@ -543,21 +543,21 @@ TEST_P(StorageTestPopulated, GetEntryInfoTypes) {
   }
 }
 
-TEST_P(StorageTestPopulated, GetEntryInfoPrefixTypes) {
+TEST_P(StoragePopulatedTest, GetEntryInfoPrefixTypes) {
   auto info = storage.GetEntryInfo(0, "bar", NT_BOOLEAN);
   ASSERT_EQ(1u, info.size());
   EXPECT_EQ("bar2", info[0].name);
   EXPECT_EQ(NT_BOOLEAN, info[0].type);
 }
 
-TEST_P(StorageTestPersistent, SavePersistentEmpty) {
+TEST_P(StoragePersistentTest, SavePersistentEmpty) {
   wpi::SmallString<256> buf;
   wpi::raw_svector_ostream oss(buf);
   storage.SavePersistent(oss, false);
   ASSERT_EQ("[NetworkTables Storage 3.0]\n", oss.str());
 }
 
-TEST_P(StorageTestPersistent, SavePersistent) {
+TEST_P(StoragePersistentTest, SavePersistent) {
   for (auto& i : entries()) {
     i.getValue()->flags = NT_PERSISTENT;
   }
@@ -619,7 +619,7 @@ TEST_P(StorageTestPersistent, SavePersistent) {
   ASSERT_EQ("", line);
 }
 
-TEST_P(StorageTestEmpty, LoadPersistentBadHeader) {
+TEST_P(StorageEmptyTest, LoadPersistentBadHeader) {
   MockLoadWarn warn;
   auto warn_func = [&](size_t line, const char* msg) { warn.Warn(line, msg); };
 
@@ -639,7 +639,7 @@ TEST_P(StorageTestEmpty, LoadPersistentBadHeader) {
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestEmpty, LoadPersistentCommentHeader) {
+TEST_P(StorageEmptyTest, LoadPersistentCommentHeader) {
   MockLoadWarn warn;
   auto warn_func = [&](size_t line, const char* msg) { warn.Warn(line, msg); };
 
@@ -650,7 +650,7 @@ TEST_P(StorageTestEmpty, LoadPersistentCommentHeader) {
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestEmpty, LoadPersistentEmptyName) {
+TEST_P(StorageEmptyTest, LoadPersistentEmptyName) {
   MockLoadWarn warn;
   auto warn_func = [&](size_t line, const char* msg) { warn.Warn(line, msg); };
 
@@ -660,7 +660,7 @@ TEST_P(StorageTestEmpty, LoadPersistentEmptyName) {
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestEmpty, LoadPersistentAssign) {
+TEST_P(StorageEmptyTest, LoadPersistentAssign) {
   MockLoadWarn warn;
   auto warn_func = [&](size_t line, const char* msg) { warn.Warn(line, msg); };
 
@@ -683,7 +683,7 @@ TEST_P(StorageTestEmpty, LoadPersistentAssign) {
   EXPECT_EQ(NT_PERSISTENT, entry->flags);
 }
 
-TEST_P(StorageTestPopulated, LoadPersistentUpdateFlags) {
+TEST_P(StoragePopulatedTest, LoadPersistentUpdateFlags) {
   MockLoadWarn warn;
   auto warn_func = [&](size_t line, const char* msg) { warn.Warn(line, msg); };
 
@@ -707,7 +707,7 @@ TEST_P(StorageTestPopulated, LoadPersistentUpdateFlags) {
   EXPECT_EQ(NT_PERSISTENT, entry->flags);
 }
 
-TEST_P(StorageTestPopulated, LoadPersistentUpdateValue) {
+TEST_P(StoragePopulatedTest, LoadPersistentUpdateValue) {
   MockLoadWarn warn;
   auto warn_func = [&](size_t line, const char* msg) { warn.Warn(line, msg); };
 
@@ -740,7 +740,7 @@ TEST_P(StorageTestPopulated, LoadPersistentUpdateValue) {
   }
 }
 
-TEST_P(StorageTestPopulated, LoadPersistentUpdateValueFlags) {
+TEST_P(StoragePopulatedTest, LoadPersistentUpdateValueFlags) {
   MockLoadWarn warn;
   auto warn_func = [&](size_t line, const char* msg) { warn.Warn(line, msg); };
 
@@ -775,7 +775,7 @@ TEST_P(StorageTestPopulated, LoadPersistentUpdateValueFlags) {
   }
 }
 
-TEST_P(StorageTestEmpty, LoadPersistent) {
+TEST_P(StorageEmptyTest, LoadPersistent) {
   MockLoadWarn warn;
   auto warn_func = [&](size_t line, const char* msg) { warn.Warn(line, msg); };
 
@@ -854,7 +854,7 @@ TEST_P(StorageTestEmpty, LoadPersistent) {
   EXPECT_EQ(*Value::MakeBoolean(true), *storage.GetEntryValue("="));
 }
 
-TEST_P(StorageTestEmpty, LoadPersistentWarn) {
+TEST_P(StorageEmptyTest, LoadPersistentWarn) {
   MockLoadWarn warn;
   auto warn_func = [&](size_t line, const char* msg) { warn.Warn(line, msg); };
 
@@ -869,7 +869,7 @@ TEST_P(StorageTestEmpty, LoadPersistentWarn) {
   EXPECT_TRUE(idmap().empty());
 }
 
-TEST_P(StorageTestEmpty, ProcessIncomingEntryAssign) {
+TEST_P(StorageEmptyTest, ProcessIncomingEntryAssign) {
   auto conn = std::make_shared<MockNetworkConnection>();
   auto value = Value::MakeDouble(1.0);
   if (GetParam()) {
@@ -887,7 +887,7 @@ TEST_P(StorageTestEmpty, ProcessIncomingEntryAssign) {
       conn.get(), conn);
 }
 
-TEST_P(StorageTestPopulateOne, ProcessIncomingEntryAssign) {
+TEST_P(StoragePopulateOneTest, ProcessIncomingEntryAssign) {
   auto conn = std::make_shared<MockNetworkConnection>();
   auto value = Value::MakeDouble(1.0);
   EXPECT_CALL(*conn, proto_rev()).WillRepeatedly(Return(0x0300u));
@@ -905,14 +905,14 @@ TEST_P(StorageTestPopulateOne, ProcessIncomingEntryAssign) {
                           conn.get(), conn);
 }
 
-TEST_P(StorageTestPopulateOne, ProcessIncomingEntryAssignIgnore) {
+TEST_P(StoragePopulateOneTest, ProcessIncomingEntryAssignIgnore) {
   auto conn = std::make_shared<MockNetworkConnection>();
   auto value = Value::MakeDouble(1.0);
   storage.ProcessIncoming(Message::EntryAssign("foo", 0xffff, 1, value, 0),
                           conn.get(), conn);
 }
 
-TEST_P(StorageTestPopulateOne, ProcessIncomingEntryAssignWithFlags) {
+TEST_P(StoragePopulateOneTest, ProcessIncomingEntryAssignWithFlags) {
   auto conn = std::make_shared<MockNetworkConnection>();
   auto value = Value::MakeDouble(1.0);
   EXPECT_CALL(*conn, proto_rev()).WillRepeatedly(Return(0x0300u));
@@ -939,7 +939,7 @@ TEST_P(StorageTestPopulateOne, ProcessIncomingEntryAssignWithFlags) {
                           conn.get(), conn);
 }
 
-TEST_P(StorageTestPopulateOne, DeleteCheckHandle) {
+TEST_P(StoragePopulateOneTest, DeleteCheckHandle) {
   EXPECT_CALL(dispatcher, QueueOutgoing(_, _, _)).Times(AnyNumber());
   EXPECT_CALL(notifier, NotifyEntry(_, _, _, _, _)).Times(AnyNumber());
   auto handle = storage.GetEntry("foo");
@@ -952,7 +952,7 @@ TEST_P(StorageTestPopulateOne, DeleteCheckHandle) {
   ASSERT_EQ(handle, handle2);
 }
 
-TEST_P(StorageTestPopulateOne, DeletedEntryFlags) {
+TEST_P(StoragePopulateOneTest, DeletedEntryFlags) {
   EXPECT_CALL(dispatcher, QueueOutgoing(_, _, _)).Times(AnyNumber());
   EXPECT_CALL(notifier, NotifyEntry(_, _, _, _, _)).Times(AnyNumber());
   auto handle = storage.GetEntry("foo");
@@ -969,7 +969,7 @@ TEST_P(StorageTestPopulateOne, DeletedEntryFlags) {
   EXPECT_EQ(storage.GetEntryFlags(handle), 0u);
 }
 
-TEST_P(StorageTestPopulateOne, DeletedDeleteAllEntries) {
+TEST_P(StoragePopulateOneTest, DeletedDeleteAllEntries) {
   EXPECT_CALL(dispatcher, QueueOutgoing(_, _, _)).Times(AnyNumber());
   EXPECT_CALL(notifier, NotifyEntry(_, _, _, _, _)).Times(AnyNumber());
   storage.DeleteEntry("foo");
@@ -981,7 +981,7 @@ TEST_P(StorageTestPopulateOne, DeletedDeleteAllEntries) {
   storage.DeleteAllEntries();
 }
 
-TEST_P(StorageTestPopulateOne, DeletedGetEntries) {
+TEST_P(StoragePopulateOneTest, DeletedGetEntries) {
   EXPECT_CALL(dispatcher, QueueOutgoing(_, _, _)).Times(AnyNumber());
   EXPECT_CALL(notifier, NotifyEntry(_, _, _, _, _)).Times(AnyNumber());
   storage.DeleteEntry("foo");
@@ -991,13 +991,13 @@ TEST_P(StorageTestPopulateOne, DeletedGetEntries) {
   EXPECT_TRUE(storage.GetEntries("", 0).empty());
 }
 
-INSTANTIATE_TEST_SUITE_P(StorageTestsEmpty, StorageTestEmpty,
+INSTANTIATE_TEST_SUITE_P(StorageEmptyTests, StorageEmptyTest,
                          ::testing::Bool());
-INSTANTIATE_TEST_SUITE_P(StorageTestsPopulateOne, StorageTestPopulateOne,
+INSTANTIATE_TEST_SUITE_P(StoragePopulateOneTests, StoragePopulateOneTest,
                          ::testing::Bool());
-INSTANTIATE_TEST_SUITE_P(StorageTestsPopulated, StorageTestPopulated,
+INSTANTIATE_TEST_SUITE_P(StoragePopulatedTests, StoragePopulatedTest,
                          ::testing::Bool());
-INSTANTIATE_TEST_SUITE_P(StorageTestsPersistent, StorageTestPersistent,
+INSTANTIATE_TEST_SUITE_P(StoragePersistentTests, StoragePersistentTest,
                          ::testing::Bool());
 
 }  // namespace nt

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/button/ButtonTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/button/ButtonTest.cpp
@@ -193,7 +193,7 @@ TEST_F(ButtonTest, RValueButton) {
   EXPECT_EQ(counter, 1);
 }
 
-TEST_F(ButtonTest, DebounceTest) {
+TEST_F(ButtonTest, Debounce) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool pressed = false;
   RunCommand command([] {});

--- a/wpilibc/src/test/native/cpp/DriverStationTest.cpp
+++ b/wpilibc/src/test/native/cpp/DriverStationTest.cpp
@@ -11,10 +11,10 @@
 #include "frc/simulation/SimHooks.h"
 #include "gtest/gtest.h"
 
-class IsJoystickConnectedParametersTests
+class IsJoystickConnectedParametersTest
     : public ::testing::TestWithParam<std::tuple<int, int, int, bool>> {};
 
-TEST_P(IsJoystickConnectedParametersTests, IsJoystickConnected) {
+TEST_P(IsJoystickConnectedParametersTest, IsJoystickConnected) {
   frc::sim::DriverStationSim::SetJoystickAxisCount(1, std::get<0>(GetParam()));
   frc::sim::DriverStationSim::SetJoystickButtonCount(1,
                                                      std::get<1>(GetParam()));
@@ -25,18 +25,18 @@ TEST_P(IsJoystickConnectedParametersTests, IsJoystickConnected) {
             frc::DriverStation::IsJoystickConnected(1));
 }
 
-INSTANTIATE_TEST_SUITE_P(IsConnectedTests, IsJoystickConnectedParametersTests,
+INSTANTIATE_TEST_SUITE_P(IsConnectedTests, IsJoystickConnectedParametersTest,
                          ::testing::Values(std::make_tuple(0, 0, 0, false),
                                            std::make_tuple(1, 0, 0, true),
                                            std::make_tuple(0, 1, 0, true),
                                            std::make_tuple(0, 0, 1, true),
                                            std::make_tuple(1, 1, 1, true),
                                            std::make_tuple(4, 10, 1, true)));
-class JoystickConnectionWarningTests
+class JoystickConnectionWarningTest
     : public ::testing::TestWithParam<
           std::tuple<bool, bool, bool, std::string>> {};
 
-TEST_P(JoystickConnectionWarningTests, JoystickConnectionWarnings) {
+TEST_P(JoystickConnectionWarningTest, JoystickConnectionWarnings) {
   // Capture all output to stderr.
   ::testing::internal::CaptureStderr();
 
@@ -58,7 +58,7 @@ TEST_P(JoystickConnectionWarningTests, JoystickConnectionWarnings) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    DriverStation, JoystickConnectionWarningTests,
+    DriverStationTests, JoystickConnectionWarningTest,
     ::testing::Values(
         std::make_tuple(false, true, true, ""),
         std::make_tuple(

--- a/wpilibc/src/test/native/cpp/SpeedControllerGroupTest.cpp
+++ b/wpilibc/src/test/native/cpp/SpeedControllerGroupTest.cpp
@@ -121,5 +121,5 @@ TEST_P(MotorControllerGroupTest, StopMotor) {
   }
 }
 
-INSTANTIATE_TEST_SUITE_P(Test, MotorControllerGroupTest,
+INSTANTIATE_TEST_SUITE_P(Tests, MotorControllerGroupTest,
                          testing::Values(TEST_ONE, TEST_TWO, TEST_THREE));

--- a/wpilibc/src/test/native/cpp/TimedRobotTest.cpp
+++ b/wpilibc/src/test/native/cpp/TimedRobotTest.cpp
@@ -78,7 +78,7 @@ class MockRobot : public TimedRobot {
 };
 }  // namespace
 
-TEST_F(TimedRobotTest, Disabled) {
+TEST_F(TimedRobotTest, DisabledMode) {
   MockRobot robot;
 
   std::thread robotThread{[&] { robot.StartCompetition(); }};
@@ -152,7 +152,7 @@ TEST_F(TimedRobotTest, Disabled) {
   robotThread.join();
 }
 
-TEST_F(TimedRobotTest, Autonomous) {
+TEST_F(TimedRobotTest, AutonomousMode) {
   MockRobot robot;
 
   std::thread robotThread{[&] { robot.StartCompetition(); }};
@@ -228,7 +228,7 @@ TEST_F(TimedRobotTest, Autonomous) {
   robotThread.join();
 }
 
-TEST_F(TimedRobotTest, Teleop) {
+TEST_F(TimedRobotTest, TeleopMode) {
   MockRobot robot;
 
   std::thread robotThread{[&] { robot.StartCompetition(); }};
@@ -304,7 +304,7 @@ TEST_F(TimedRobotTest, Teleop) {
   robotThread.join();
 }
 
-TEST_F(TimedRobotTest, Test) {
+TEST_F(TimedRobotTest, TestMode) {
   MockRobot robot;
 
   std::thread robotThread{[&] { robot.StartCompetition(); }};

--- a/wpilibc/src/test/native/cpp/simulation/DifferentialDriveSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/DifferentialDriveSimTest.cpp
@@ -17,7 +17,7 @@
 #include "frc/trajectory/constraint/DifferentialDriveKinematicsConstraint.h"
 #include "gtest/gtest.h"
 
-TEST(DifferentialDriveSim, Convergence) {
+TEST(DifferentialDriveSimTest, Convergence) {
   auto motor = frc::DCMotor::NEO(2);
   auto plant = frc::LinearSystemId::DrivetrainVelocitySystem(
       motor, 50_kg, 2_in, 12_in, 0.5_kg_sq_m, 1.0);
@@ -71,7 +71,7 @@ TEST(DifferentialDriveSim, Convergence) {
               0.01);
 }
 
-TEST(DifferentialDriveSim, Current) {
+TEST(DifferentialDriveSimTest, Current) {
   auto motor = frc::DCMotor::NEO(2);
   auto plant = frc::LinearSystemId::DrivetrainVelocitySystem(
       motor, 50_kg, 2_in, 12_in, 0.5_kg_sq_m, 1.0);
@@ -98,7 +98,7 @@ TEST(DifferentialDriveSim, Current) {
   EXPECT_TRUE(sim.GetCurrentDraw() > 0_A);
 }
 
-TEST(DifferentialDriveSim, ModelStability) {
+TEST(DifferentialDriveSimTest, ModelStability) {
   auto motor = frc::DCMotor::NEO(2);
   auto plant = frc::LinearSystemId::DrivetrainVelocitySystem(
       motor, 50_kg, 2_in, 12_in, 2_kg_sq_m, 5.0);

--- a/wpilibc/src/test/native/cpp/simulation/ElevatorSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/ElevatorSimTest.cpp
@@ -17,7 +17,7 @@
 #include "frc/system/plant/LinearSystemId.h"
 #include "gtest/gtest.h"
 
-TEST(ElevatorSim, StateSpaceSim) {
+TEST(ElevatorSimTest, StateSpaceSim) {
   frc::sim::ElevatorSim sim(frc::DCMotor::Vex775Pro(4), 14.67, 8_kg,
                             units::meter_t(0.75 * 25.4 / 1000.0), 0_m, 3_m,
                             {0.01});
@@ -44,7 +44,7 @@ TEST(ElevatorSim, StateSpaceSim) {
   EXPECT_NEAR(controller.GetSetpoint(), sim.GetPosition().to<double>(), 0.2);
 }
 
-TEST(ElevatorSim, MinMax) {
+TEST(ElevatorSimTest, MinMax) {
   frc::sim::ElevatorSim sim(frc::DCMotor::Vex775Pro(4), 14.67, 8_kg,
                             units::meter_t(0.75 * 25.4 / 1000.0), 0_m, 1_m,
                             {0.01});
@@ -65,7 +65,7 @@ TEST(ElevatorSim, MinMax) {
   }
 }
 
-TEST(ElevatorSim, Stability) {
+TEST(ElevatorSimTest, Stability) {
   static constexpr double kElevatorGearing = 100.0;
   static constexpr units::meter_t kElevatorDrumRadius = 0.5_in;
   static constexpr units::kilogram_t kCarriageMass = 4.0_kg;

--- a/wpilibcIntegrationTests/src/main/native/cpp/MotorEncoderTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/MotorEncoderTest.cpp
@@ -195,5 +195,5 @@ TEST_P(MotorEncoderTest, Reset) {
   EXPECT_EQ(0, m_encoder->Get()) << "Encoder did not reset to 0";
 }
 
-INSTANTIATE_TEST_SUITE_P(Test, MotorEncoderTest,
+INSTANTIATE_TEST_SUITE_P(Tests, MotorEncoderTest,
                          testing::Values(TEST_VICTOR, TEST_JAGUAR, TEST_TALON));

--- a/wpilibcIntegrationTests/src/main/native/cpp/MotorInvertingTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/MotorInvertingTest.cpp
@@ -151,5 +151,5 @@ TEST_P(MotorInvertingTest, InvertingSwitchingNegToPos) {
   Reset();
 }
 
-INSTANTIATE_TEST_SUITE_P(Test, MotorInvertingTest,
+INSTANTIATE_TEST_SUITE_P(Tests, MotorInvertingTest,
                          testing::Values(TEST_VICTOR, TEST_JAGUAR, TEST_TALON));

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/TimedRobotTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/TimedRobotTest.java
@@ -128,7 +128,7 @@ class TimedRobotTest {
 
   @Test
   @ResourceLock("timing")
-  void disabledTest() {
+  void disabledModeTest() {
     MockRobot robot = new MockRobot();
 
     Thread robotThread =
@@ -215,7 +215,7 @@ class TimedRobotTest {
 
   @Test
   @ResourceLock("timing")
-  void autonomousTest() {
+  void autonomousModeTest() {
     MockRobot robot = new MockRobot();
 
     Thread robotThread =
@@ -304,7 +304,7 @@ class TimedRobotTest {
 
   @Test
   @ResourceLock("timing")
-  void teleopTest() {
+  void teleopModeTest() {
     MockRobot robot = new MockRobot();
 
     Thread robotThread =
@@ -393,7 +393,7 @@ class TimedRobotTest {
 
   @Test
   @ResourceLock("timing")
-  void testTest() {
+  void testModeTest() {
     MockRobot robot = new MockRobot();
 
     Thread robotThread =

--- a/wpimath/src/test/native/cpp/StateSpaceTest.cpp
+++ b/wpimath/src/test/native/cpp/StateSpaceTest.cpp
@@ -22,7 +22,7 @@ namespace frc {
 constexpr double kPositionStddev = 0.0001;
 constexpr auto kDt = 0.00505_s;
 
-class StateSpace : public testing::Test {
+class StateSpaceTest : public testing::Test {
  public:
   LinearSystem<2, 1, 1> plant = [] {
     auto motors = DCMotor::Vex775Pro(2);
@@ -51,7 +51,7 @@ void Update(const LinearSystem<2, 1, 1>& plant, LinearSystemLoop<2, 1, 1>& loop,
   loop.Predict(kDt);
 }
 
-TEST_F(StateSpace, CorrectPredictLoop) {
+TEST_F(StateSpaceTest, CorrectPredictLoop) {
   std::default_random_engine generator;
   std::normal_distribution<double> dist{0.0, kPositionStddev};
 

--- a/wpimath/src/test/native/cpp/filter/LinearFilterNoiseTest.cpp
+++ b/wpimath/src/test/native/cpp/filter/LinearFilterNoiseTest.cpp
@@ -65,5 +65,5 @@ TEST_P(LinearFilterNoiseTest, NoiseReduce) {
       << "Filter should have reduced noise accumulation but failed";
 }
 
-INSTANTIATE_TEST_SUITE_P(Test, LinearFilterNoiseTest,
+INSTANTIATE_TEST_SUITE_P(Tests, LinearFilterNoiseTest,
                          testing::Values(kTestSinglePoleIIR, kTestMovAvg));

--- a/wpimath/src/test/native/cpp/filter/LinearFilterOutputTest.cpp
+++ b/wpimath/src/test/native/cpp/filter/LinearFilterOutputTest.cpp
@@ -115,7 +115,7 @@ TEST_P(LinearFilterOutputTest, Output) {
       << "Filter output didn't match expected value";
 }
 
-INSTANTIATE_TEST_SUITE_P(Test, LinearFilterOutputTest,
+INSTANTIATE_TEST_SUITE_P(Tests, LinearFilterOutputTest,
                          testing::Values(kTestSinglePoleIIR, kTestHighPass,
                                          kTestMovAvg, kTestPulse));
 

--- a/wpimath/src/test/native/cpp/geometry/Translation2dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Translation2dTest.cpp
@@ -47,7 +47,7 @@ TEST(Translation2dTest, Multiplication) {
   EXPECT_NEAR(mult.Y().to<double>(), 15.0, kEpsilon);
 }
 
-TEST(Translation2d, Division) {
+TEST(Translation2dTest, Division) {
   const Translation2d original{3.0_m, 5.0_m};
   const auto div = original / 2;
 

--- a/wpimath/src/test/native/cpp/kinematics/ChassisSpeedsTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/ChassisSpeedsTest.cpp
@@ -7,7 +7,7 @@
 
 static constexpr double kEpsilon = 1E-9;
 
-TEST(ChassisSpeeds, FieldRelativeConstruction) {
+TEST(ChassisSpeedsTest, FieldRelativeConstruction) {
   const auto chassisSpeeds = frc::ChassisSpeeds::FromFieldRelativeSpeeds(
       1.0_mps, 0.0_mps, 0.5_rad_per_s, frc::Rotation2d(-90.0_deg));
 

--- a/wpimath/src/test/native/cpp/kinematics/DifferentialDriveKinematicsTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/DifferentialDriveKinematicsTest.cpp
@@ -15,7 +15,7 @@ using namespace frc;
 
 static constexpr double kEpsilon = 1E-9;
 
-TEST(DifferentialDriveKinematics, InverseKinematicsFromZero) {
+TEST(DifferentialDriveKinematicsTest, InverseKinematicsFromZero) {
   const DifferentialDriveKinematics kinematics{0.381_m * 2};
   const ChassisSpeeds chassisSpeeds;
   const auto wheelSpeeds = kinematics.ToWheelSpeeds(chassisSpeeds);
@@ -24,7 +24,7 @@ TEST(DifferentialDriveKinematics, InverseKinematicsFromZero) {
   EXPECT_NEAR(wheelSpeeds.right.to<double>(), 0, kEpsilon);
 }
 
-TEST(DifferentialDriveKinematics, ForwardKinematicsFromZero) {
+TEST(DifferentialDriveKinematicsTest, ForwardKinematicsFromZero) {
   const DifferentialDriveKinematics kinematics{0.381_m * 2};
   const DifferentialDriveWheelSpeeds wheelSpeeds;
   const auto chassisSpeeds = kinematics.ToChassisSpeeds(wheelSpeeds);
@@ -34,7 +34,7 @@ TEST(DifferentialDriveKinematics, ForwardKinematicsFromZero) {
   EXPECT_NEAR(chassisSpeeds.omega.to<double>(), 0, kEpsilon);
 }
 
-TEST(DifferentialDriveKinematics, InverseKinematicsForStraightLine) {
+TEST(DifferentialDriveKinematicsTest, InverseKinematicsForStraightLine) {
   const DifferentialDriveKinematics kinematics{0.381_m * 2};
   const ChassisSpeeds chassisSpeeds{3.0_mps, 0_mps, 0_rad_per_s};
   const auto wheelSpeeds = kinematics.ToWheelSpeeds(chassisSpeeds);
@@ -43,7 +43,7 @@ TEST(DifferentialDriveKinematics, InverseKinematicsForStraightLine) {
   EXPECT_NEAR(wheelSpeeds.right.to<double>(), 3, kEpsilon);
 }
 
-TEST(DifferentialDriveKinematics, ForwardKinematicsForStraightLine) {
+TEST(DifferentialDriveKinematicsTest, ForwardKinematicsForStraightLine) {
   const DifferentialDriveKinematics kinematics{0.381_m * 2};
   const DifferentialDriveWheelSpeeds wheelSpeeds{3.0_mps, 3.0_mps};
   const auto chassisSpeeds = kinematics.ToChassisSpeeds(wheelSpeeds);
@@ -53,7 +53,7 @@ TEST(DifferentialDriveKinematics, ForwardKinematicsForStraightLine) {
   EXPECT_NEAR(chassisSpeeds.omega.to<double>(), 0, kEpsilon);
 }
 
-TEST(DifferentialDriveKinematics, InverseKinematicsForRotateInPlace) {
+TEST(DifferentialDriveKinematicsTest, InverseKinematicsForRotateInPlace) {
   const DifferentialDriveKinematics kinematics{0.381_m * 2};
   const ChassisSpeeds chassisSpeeds{
       0.0_mps, 0.0_mps, units::radians_per_second_t{wpi::numbers::pi}};
@@ -65,7 +65,7 @@ TEST(DifferentialDriveKinematics, InverseKinematicsForRotateInPlace) {
               kEpsilon);
 }
 
-TEST(DifferentialDriveKinematics, ForwardKinematicsForRotateInPlace) {
+TEST(DifferentialDriveKinematicsTest, ForwardKinematicsForRotateInPlace) {
   const DifferentialDriveKinematics kinematics{0.381_m * 2};
   const DifferentialDriveWheelSpeeds wheelSpeeds{
       units::meters_per_second_t(+0.381 * wpi::numbers::pi),

--- a/wpimath/src/test/native/cpp/kinematics/DifferentialDriveOdometryTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/DifferentialDriveOdometryTest.cpp
@@ -12,7 +12,7 @@ static constexpr double kEpsilon = 1E-9;
 
 using namespace frc;
 
-TEST(DifferentialDriveOdometry, EncoderDistances) {
+TEST(DifferentialDriveOdometryTest, EncoderDistances) {
   DifferentialDriveOdometry odometry{Rotation2d(45_deg)};
 
   const auto& pose = odometry.Update(Rotation2d(135_deg), 0_m,

--- a/wpimath/src/test/native/cpp/kinematics/SwerveModuleStateTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/SwerveModuleStateTest.cpp
@@ -8,7 +8,7 @@
 
 static constexpr double kEpsilon = 1E-9;
 
-TEST(SwerveModuleState, Optimize) {
+TEST(SwerveModuleStateTest, Optimize) {
   frc::Rotation2d angleA{45_deg};
   frc::SwerveModuleState refA{-2_mps, 180_deg};
   auto optimizedA = frc::SwerveModuleState::Optimize(refA, angleA);
@@ -24,7 +24,7 @@ TEST(SwerveModuleState, Optimize) {
   EXPECT_NEAR(optimizedB.angle.Degrees().to<double>(), -139.0, kEpsilon);
 }
 
-TEST(SwerveModuleState, NoOptimize) {
+TEST(SwerveModuleStateTest, NoOptimize) {
   frc::Rotation2d angleA{0_deg};
   frc::SwerveModuleState refA{2_mps, 89_deg};
   auto optimizedA = frc::SwerveModuleState::Optimize(refA, angleA);

--- a/wpimath/src/test/native/cpp/trajectory/TrajectoryConcatenateTest.cpp
+++ b/wpimath/src/test/native/cpp/trajectory/TrajectoryConcatenateTest.cpp
@@ -6,7 +6,7 @@
 #include "frc/trajectory/TrajectoryGenerator.h"
 #include "gtest/gtest.h"
 
-TEST(TrajectoryConcatenate, States) {
+TEST(TrajectoryConcatenateTest, States) {
   auto t1 = frc::TrajectoryGenerator::GenerateTrajectory(
       {}, {}, {1_m, 1_m, 0_deg}, {2_mps, 2_mps_sq});
   auto t2 = frc::TrajectoryGenerator::GenerateTrajectory(

--- a/wpimath/src/test/native/cpp/trajectory/TrajectoryTransformTest.cpp
+++ b/wpimath/src/test/native/cpp/trajectory/TrajectoryTransformTest.cpp
@@ -28,7 +28,7 @@ void TestSameShapedTrajectory(std::vector<frc::Trajectory::State> statesA,
   }
 }
 
-TEST(TrajectoryTransforms, TransformBy) {
+TEST(TrajectoryTransformsTest, TransformBy) {
   frc::TrajectoryConfig config{3_mps, 3_mps_sq};
   auto trajectory = frc::TrajectoryGenerator::GenerateTrajectory(
       frc::Pose2d{}, {}, frc::Pose2d{1_m, 1_m, frc::Rotation2d(90_deg)},
@@ -46,7 +46,7 @@ TEST(TrajectoryTransforms, TransformBy) {
   TestSameShapedTrajectory(trajectory.States(), transformedTrajectory.States());
 }
 
-TEST(TrajectoryTransforms, RelativeTo) {
+TEST(TrajectoryTransformsTest, RelativeTo) {
   frc::TrajectoryConfig config{3_mps, 3_mps_sq};
   auto trajectory = frc::TrajectoryGenerator::GenerateTrajectory(
       frc::Pose2d{1_m, 2_m, frc::Rotation2d(30_deg)}, {},

--- a/wpiutil/src/test/native/cpp/Base64Test.cpp
+++ b/wpiutil/src/test/native/cpp/Base64Test.cpp
@@ -83,7 +83,8 @@ static Base64TestParam sample[] = {
      "mQgc28gb24uLi4K"},
 };
 
-INSTANTIATE_TEST_SUITE_P(Base64Sample, Base64Test, ::testing::ValuesIn(sample));
+INSTANTIATE_TEST_SUITE_P(Base64SampleTests, Base64Test,
+                         ::testing::ValuesIn(sample));
 
 static Base64TestParam standard[] = {
     {0, "", ""},
@@ -96,7 +97,7 @@ static Base64TestParam standard[] = {
     {2, "\xff\xef", "/+8="},
 };
 
-INSTANTIATE_TEST_SUITE_P(Base64Standard, Base64Test,
+INSTANTIATE_TEST_SUITE_P(Base64StandardTests, Base64Test,
                          ::testing::ValuesIn(standard));
 
 }  // namespace wpi

--- a/wpiutil/src/test/native/cpp/WorkerThreadTest.cpp
+++ b/wpiutil/src/test/native/cpp/WorkerThreadTest.cpp
@@ -12,14 +12,14 @@
 
 namespace wpi {
 
-TEST(WorkerThread, Future) {
+TEST(WorkerThreadTest, Future) {
   WorkerThread<int(bool)> worker;
   future<int> f =
       worker.QueueWork([](bool v) -> int { return v ? 1 : 2; }, true);
   ASSERT_EQ(f.get(), 1);
 }
 
-TEST(WorkerThread, FutureVoid) {
+TEST(WorkerThreadTest, FutureVoid) {
   int callbacks = 0;
   WorkerThread<void(int)> worker;
   future<void> f = worker.QueueWork(
@@ -32,7 +32,7 @@ TEST(WorkerThread, FutureVoid) {
   ASSERT_EQ(callbacks, 1);
 }
 
-TEST(WorkerThread, Loop) {
+TEST(WorkerThreadTest, Loop) {
   int callbacks = 0;
   WorkerThread<int(bool)> worker;
   auto loop = uv::Loop::Create();
@@ -50,7 +50,7 @@ TEST(WorkerThread, Loop) {
   ASSERT_EQ(callbacks, 1);
 }
 
-TEST(WorkerThread, LoopVoid) {
+TEST(WorkerThreadTest, LoopVoid) {
   int callbacks = 0;
   WorkerThread<void(bool)> worker;
   auto loop = uv::Loop::Create();

--- a/wpiutil/src/test/native/cpp/future_test.cpp
+++ b/wpiutil/src/test/native/cpp/future_test.cpp
@@ -10,7 +10,7 @@
 
 namespace wpi {
 
-TEST(Future, Then) {
+TEST(FutureTest, Then) {
   promise<bool> inPromise;
   future<int> outFuture =
       inPromise.get_future().then([](bool v) { return v ? 5 : 6; });
@@ -19,7 +19,7 @@ TEST(Future, Then) {
   ASSERT_EQ(outFuture.get(), 5);
 }
 
-TEST(Future, ThenSame) {
+TEST(FutureTest, ThenSame) {
   promise<bool> inPromise;
   future<bool> outFuture =
       inPromise.get_future().then([](bool v) { return !v; });
@@ -28,7 +28,7 @@ TEST(Future, ThenSame) {
   ASSERT_EQ(outFuture.get(), false);
 }
 
-TEST(Future, ThenFromVoid) {
+TEST(FutureTest, ThenFromVoid) {
   promise<void> inPromise;
   future<int> outFuture = inPromise.get_future().then([] { return 5; });
 
@@ -36,7 +36,7 @@ TEST(Future, ThenFromVoid) {
   ASSERT_EQ(outFuture.get(), 5);
 }
 
-TEST(Future, ThenToVoid) {
+TEST(FutureTest, ThenToVoid) {
   promise<bool> inPromise;
   future<void> outFuture = inPromise.get_future().then([](bool v) {});
 
@@ -44,7 +44,7 @@ TEST(Future, ThenToVoid) {
   ASSERT_TRUE(outFuture.is_ready());
 }
 
-TEST(Future, ThenVoidVoid) {
+TEST(FutureTest, ThenVoidVoid) {
   promise<void> inPromise;
   future<void> outFuture = inPromise.get_future().then([] {});
 
@@ -52,7 +52,7 @@ TEST(Future, ThenVoidVoid) {
   ASSERT_TRUE(outFuture.is_ready());
 }
 
-TEST(Future, Implicit) {
+TEST(FutureTest, Implicit) {
   promise<bool> inPromise;
   future<int> outFuture = inPromise.get_future();
 
@@ -60,7 +60,7 @@ TEST(Future, Implicit) {
   ASSERT_EQ(outFuture.get(), 1);
 }
 
-TEST(Future, MoveSame) {
+TEST(FutureTest, MoveSame) {
   promise<bool> inPromise;
   future<bool> outFuture1 = inPromise.get_future();
   future<bool> outFuture(std::move(outFuture1));
@@ -69,7 +69,7 @@ TEST(Future, MoveSame) {
   ASSERT_EQ(outFuture.get(), true);
 }
 
-TEST(Future, MoveVoid) {
+TEST(FutureTest, MoveVoid) {
   promise<void> inPromise;
   future<void> outFuture1 = inPromise.get_future();
   future<void> outFuture(std::move(outFuture1));

--- a/wpiutil/src/test/native/cpp/sigslot/function-traits.cpp
+++ b/wpiutil/src/test/native/cpp/sigslot/function-traits.cpp
@@ -116,7 +116,7 @@ static_assert(is_callable_v<t, o8>, "");
 
 namespace wpi {
 
-TEST(Signal, FunctionTraits) {
+TEST(SignalTest, FunctionTraits) {
   auto l1 = [](int, char, float) {};
   auto l2 = [&](int, char, float) mutable {};
   auto l3 = [&](auto...) mutable {};

--- a/wpiutil/src/test/native/cpp/sigslot/recursive.cpp
+++ b/wpiutil/src/test/native/cpp/sigslot/recursive.cpp
@@ -63,7 +63,7 @@ struct object {
 
 namespace wpi {
 
-TEST(Signal, Recursive) {
+TEST(SignalTest, Recursive) {
   object<int> i1(-1);
   object<int> i2(10);
 
@@ -75,7 +75,7 @@ TEST(Signal, Recursive) {
   ASSERT_EQ(i1.v, i2.v);
 }
 
-TEST(Signal, SelfRecursive) {
+TEST(SignalTest, SelfRecursive) {
   int i = 0;
 
   wpi::sig::Signal_r<int> s;

--- a/wpiutil/src/test/native/cpp/sigslot/signal-extended.cpp
+++ b/wpiutil/src/test/native/cpp/sigslot/signal-extended.cpp
@@ -68,7 +68,7 @@ struct o {
 
 namespace wpi {
 
-TEST(SignalExtended, FreeConnection) {
+TEST(SignalExtendedTest, FreeConnection) {
   sum = 0;
   Signal<int> sig;
   sig.connect_extended(f);
@@ -79,7 +79,7 @@ TEST(SignalExtended, FreeConnection) {
   ASSERT_EQ(sum, 1);
 }
 
-TEST(SignalExtended, StaticConnection) {
+TEST(SignalExtendedTest, StaticConnection) {
   sum = 0;
   Signal<int> sig;
   sig.connect_extended(&s::sf);
@@ -90,7 +90,7 @@ TEST(SignalExtended, StaticConnection) {
   ASSERT_EQ(sum, 1);
 }
 
-TEST(SignalExtended, PmfConnection) {
+TEST(SignalExtendedTest, PmfConnection) {
   sum = 0;
   Signal<int> sig;
   s p;
@@ -102,7 +102,7 @@ TEST(SignalExtended, PmfConnection) {
   ASSERT_EQ(sum, 1);
 }
 
-TEST(SignalExtended, FunctionObjectConnection) {
+TEST(SignalExtendedTest, FunctionObjectConnection) {
   sum = 0;
   Signal<int> sig;
   sig.connect_extended(o{});
@@ -113,7 +113,7 @@ TEST(SignalExtended, FunctionObjectConnection) {
   ASSERT_EQ(sum, 1);
 }
 
-TEST(SignalExtended, LambdaConnection) {
+TEST(SignalExtendedTest, LambdaConnection) {
   sum = 0;
   Signal<int> sig;
 

--- a/wpiutil/src/test/native/cpp/sigslot/signal-threaded.cpp
+++ b/wpiutil/src/test/native/cpp/sigslot/signal-threaded.cpp
@@ -68,7 +68,7 @@ void connect_emit(Signal_mt<int>& sig) {
 
 namespace wpi {
 
-TEST(Signal, ThreadedMix) {
+TEST(SignalTest, ThreadedMix) {
   sum = 0;
 
   Signal_mt<int> sig;
@@ -83,7 +83,7 @@ TEST(Signal, ThreadedMix) {
   }
 }
 
-TEST(Signal, ThreadedEmission) {
+TEST(SignalTest, ThreadedEmission) {
   sum = 0;
 
   Signal_mt<int> sig;

--- a/wpiutil/src/test/native/cpp/sigslot/signal-tracking.cpp
+++ b/wpiutil/src/test/native/cpp/sigslot/signal-tracking.cpp
@@ -72,7 +72,7 @@ static_assert(trait::is_callable_v<trait::typelist<int>, decltype(&s::f1),
 
 namespace wpi {
 
-TEST(Signal, TrackShared) {
+TEST(SignalTest, TrackShared) {
   sum = 0;
   Signal<int> sig;
 
@@ -95,7 +95,7 @@ TEST(Signal, TrackShared) {
   ASSERT_EQ(sum, 5);
 }
 
-TEST(Signal, TrackOther) {
+TEST(SignalTest, TrackOther) {
   sum = 0;
   Signal<int> sig;
 
@@ -118,7 +118,7 @@ TEST(Signal, TrackOther) {
   ASSERT_EQ(sum, 5);
 }
 
-TEST(Signal, TrackOverloadedFunctionObject) {
+TEST(SignalTest, TrackOverloadedFunctionObject) {
   sum = 0;
   Signal<int> sig;
   Signal<double> sig1;
@@ -143,7 +143,7 @@ TEST(Signal, TrackOverloadedFunctionObject) {
   ASSERT_EQ(sum, 5);
 }
 
-TEST(Signal, TrackGenericLambda) {
+TEST(SignalTest, TrackGenericLambda) {
   std::stringstream s;
 
   auto f = [&](auto a, auto... args) {

--- a/wpiutil/src/test/native/cpp/sigslot/signal.cpp
+++ b/wpiutil/src/test/native/cpp/sigslot/signal.cpp
@@ -100,7 +100,7 @@ struct o8 {
 
 namespace wpi {
 
-TEST(Signal, FreeConnection) {
+TEST(SignalTest, FreeConnection) {
   sum = 0;
   Signal<int> sig;
 
@@ -113,7 +113,7 @@ TEST(Signal, FreeConnection) {
   ASSERT_EQ(sum, 4);
 }
 
-TEST(Signal, StaticConnection) {
+TEST(SignalTest, StaticConnection) {
   sum = 0;
   Signal<int> sig;
 
@@ -126,7 +126,7 @@ TEST(Signal, StaticConnection) {
   ASSERT_EQ(sum, 4);
 }
 
-TEST(Signal, PmfConnection) {
+TEST(SignalTest, PmfConnection) {
   sum = 0;
   Signal<int> sig;
   s p;
@@ -144,7 +144,7 @@ TEST(Signal, PmfConnection) {
   ASSERT_EQ(sum, 8);
 }
 
-TEST(Signal, ConstPmfConnection) {
+TEST(SignalTest, ConstPmfConnection) {
   sum = 0;
   Signal<int> sig;
   const s p;
@@ -158,7 +158,7 @@ TEST(Signal, ConstPmfConnection) {
   ASSERT_EQ(sum, 4);
 }
 
-TEST(Signal, FunctionObjectConnection) {
+TEST(SignalTest, FunctionObjectConnection) {
   sum = 0;
   Signal<int> sig;
 
@@ -175,7 +175,7 @@ TEST(Signal, FunctionObjectConnection) {
   ASSERT_EQ(sum, 8);
 }
 
-TEST(Signal, OverloadedFunctionObjectConnection) {
+TEST(SignalTest, OverloadedFunctionObjectConnection) {
   sum = 0;
   Signal<int> sig;
   Signal<double> sig1;
@@ -189,7 +189,7 @@ TEST(Signal, OverloadedFunctionObjectConnection) {
   ASSERT_EQ(sum, 5);
 }
 
-TEST(Signal, LambdaConnection) {
+TEST(SignalTest, LambdaConnection) {
   sum = 0;
   Signal<int> sig;
 
@@ -202,7 +202,7 @@ TEST(Signal, LambdaConnection) {
   ASSERT_EQ(sum, 4);
 }
 
-TEST(Signal, GenericLambdaConnection) {
+TEST(SignalTest, GenericLambdaConnection) {
   std::stringstream s;
 
   auto f = [&](auto a, auto... args) {
@@ -229,7 +229,7 @@ TEST(Signal, GenericLambdaConnection) {
   ASSERT_EQ(s.str(), "1foo4.1");
 }
 
-TEST(Signal, LvalueEmission) {
+TEST(SignalTest, LvalueEmission) {
   sum = 0;
   Signal<int> sig;
 
@@ -243,7 +243,7 @@ TEST(Signal, LvalueEmission) {
   ASSERT_EQ(sum, 4);
 }
 
-TEST(Signal, Mutation) {
+TEST(SignalTest, Mutation) {
   int res = 0;
   Signal<int&> sig;
 
@@ -256,7 +256,7 @@ TEST(Signal, Mutation) {
   ASSERT_EQ(res, 4);
 }
 
-TEST(Signal, CompatibleArgs) {
+TEST(SignalTest, CompatibleArgs) {
   long ll = 0;  // NOLINT(runtime/int)
   std::string ss;
   short ii = 0;  // NOLINT(runtime/int)
@@ -276,7 +276,7 @@ TEST(Signal, CompatibleArgs) {
   ASSERT_EQ(ii, 1);
 }
 
-TEST(Signal, Disconnection) {
+TEST(SignalTest, Disconnection) {
   // test removing only connected
   {
     sum = 0;
@@ -328,7 +328,7 @@ TEST(Signal, Disconnection) {
   }
 }
 
-TEST(Signal, ScopedConnection) {
+TEST(SignalTest, ScopedConnection) {
   sum = 0;
   Signal<int> sig;
 
@@ -361,7 +361,7 @@ TEST(Signal, ScopedConnection) {
   ASSERT_EQ(sum, 4);
 }
 
-TEST(Signal, ConnectionBlocking) {
+TEST(SignalTest, ConnectionBlocking) {
   sum = 0;
   Signal<int> sig;
 
@@ -379,7 +379,7 @@ TEST(Signal, ConnectionBlocking) {
   ASSERT_EQ(sum, 8);
 }
 
-TEST(Signal, ConnectionBlocker) {
+TEST(SignalTest, ConnectionBlocker) {
   sum = 0;
   Signal<int> sig;
 
@@ -398,7 +398,7 @@ TEST(Signal, ConnectionBlocker) {
   ASSERT_EQ(sum, 8);
 }
 
-TEST(Signal, SignalBlocking) {
+TEST(SignalTest, SignalBlocking) {
   sum = 0;
   Signal<int> sig;
 
@@ -416,7 +416,7 @@ TEST(Signal, SignalBlocking) {
   ASSERT_EQ(sum, 6);
 }
 
-TEST(Signal, AllDisconnection) {
+TEST(SignalTest, AllDisconnection) {
   sum = 0;
   Signal<int> sig;
 
@@ -430,7 +430,7 @@ TEST(Signal, AllDisconnection) {
   ASSERT_EQ(sum, 3);
 }
 
-TEST(Signal, ConnectionCopyingMoving) {
+TEST(SignalTest, ConnectionCopyingMoving) {
   sum = 0;
   Signal<int> sig;
 
@@ -459,7 +459,7 @@ TEST(Signal, ConnectionCopyingMoving) {
   ASSERT_EQ(sum, 9);
 }
 
-TEST(Signal, ScopedConnectionMoving) {
+TEST(SignalTest, ScopedConnectionMoving) {
   sum = 0;
   Signal<int> sig;
 
@@ -485,7 +485,7 @@ TEST(Signal, ScopedConnectionMoving) {
   ASSERT_EQ(sum, 10);
 }
 
-TEST(Signal, SignalMoving) {
+TEST(SignalTest, SignalMoving) {
   sum = 0;
   Signal<int> sig;
 
@@ -525,7 +525,7 @@ struct object {
   Signal<T> s;
 };
 
-TEST(Signal, Loop) {
+TEST(SignalTest, Loop) {
   object<int> i1(0);
   object<int> i2(3);
 

--- a/wpiutil/src/test/native/cpp/uv/UvAsyncFunctionTest.cpp
+++ b/wpiutil/src/test/native/cpp/uv/UvAsyncFunctionTest.cpp
@@ -13,7 +13,7 @@
 
 namespace wpi::uv {
 
-TEST(UvAsyncFunction, Test) {
+TEST(UvAsyncFunctionTest, Basic) {
   int prepare_cb_called = 0;
   int async_cb_called[2] = {0, 0};
   int close_cb_called = 0;
@@ -62,7 +62,7 @@ TEST(UvAsyncFunction, Test) {
   }
 }
 
-TEST(UvAsyncFunction, Ref) {
+TEST(UvAsyncFunctionTest, Ref) {
   int prepare_cb_called = 0;
   int val = 0;
 
@@ -96,7 +96,7 @@ TEST(UvAsyncFunction, Ref) {
   }
 }
 
-TEST(UvAsyncFunction, Movable) {
+TEST(UvAsyncFunctionTest, Movable) {
   int prepare_cb_called = 0;
 
   std::thread theThread;
@@ -133,7 +133,7 @@ TEST(UvAsyncFunction, Movable) {
   }
 }
 
-TEST(UvAsyncFunction, CallIgnoreResult) {
+TEST(UvAsyncFunctionTest, CallIgnoreResult) {
   int prepare_cb_called = 0;
 
   std::thread theThread;
@@ -165,7 +165,7 @@ TEST(UvAsyncFunction, CallIgnoreResult) {
   }
 }
 
-TEST(UvAsyncFunction, VoidCall) {
+TEST(UvAsyncFunctionTest, VoidCall) {
   int prepare_cb_called = 0;
 
   std::thread theThread;
@@ -195,7 +195,7 @@ TEST(UvAsyncFunction, VoidCall) {
   }
 }
 
-TEST(UvAsyncFunction, WaitFor) {
+TEST(UvAsyncFunctionTest, WaitFor) {
   int prepare_cb_called = 0;
 
   std::thread theThread;
@@ -228,7 +228,7 @@ TEST(UvAsyncFunction, WaitFor) {
   }
 }
 
-TEST(UvAsyncFunction, VoidWaitFor) {
+TEST(UvAsyncFunctionTest, VoidWaitFor) {
   int prepare_cb_called = 0;
 
   std::thread theThread;

--- a/wpiutil/src/test/native/cpp/uv/UvAsyncTest.cpp
+++ b/wpiutil/src/test/native/cpp/uv/UvAsyncTest.cpp
@@ -36,7 +36,7 @@
 
 namespace wpi::uv {
 
-TEST(UvAsync, Test) {
+TEST(UvAsyncTest, CallbackOnly) {
   std::atomic_int async_cb_called{0};
   int prepare_cb_called = 0;
   int close_cb_called = 0;
@@ -101,7 +101,7 @@ TEST(UvAsync, Test) {
   }
 }
 
-TEST(UvAsync, Data) {
+TEST(UvAsyncTest, Data) {
   int prepare_cb_called = 0;
   int async_cb_called[2] = {0, 0};
   int close_cb_called = 0;
@@ -149,7 +149,7 @@ TEST(UvAsync, Data) {
   }
 }
 
-TEST(UvAsync, DataRef) {
+TEST(UvAsyncTest, DataRef) {
   int prepare_cb_called = 0;
   int val = 0;
 

--- a/wpiutil/src/test/native/cpp/uv/UvBufferTest.cpp
+++ b/wpiutil/src/test/native/cpp/uv/UvBufferTest.cpp
@@ -8,21 +8,21 @@
 
 namespace wpi::uv {
 
-TEST(UvSimpleBufferPool, ConstructDefault) {
+TEST(UvSimpleBufferPoolTest, ConstructDefault) {
   SimpleBufferPool<> pool;
   auto buf1 = pool.Allocate();
   ASSERT_EQ(buf1.len, 4096u);  // NOLINT
   pool.Release({&buf1, 1});
 }
 
-TEST(UvSimpleBufferPool, ConstructSize) {
+TEST(UvSimpleBufferPoolTest, ConstructSize) {
   SimpleBufferPool<4> pool{8192};
   auto buf1 = pool.Allocate();
   ASSERT_EQ(buf1.len, 8192u);  // NOLINT
   pool.Release({&buf1, 1});
 }
 
-TEST(UvSimpleBufferPool, ReleaseReuse) {
+TEST(UvSimpleBufferPoolTest, ReleaseReuse) {
   SimpleBufferPool<4> pool;
   auto buf1 = pool.Allocate();
   auto buf1copy = buf1;
@@ -36,7 +36,7 @@ TEST(UvSimpleBufferPool, ReleaseReuse) {
   pool.Release({&buf2, 1});
 }
 
-TEST(UvSimpleBufferPool, ClearRemaining) {
+TEST(UvSimpleBufferPoolTest, ClearRemaining) {
   SimpleBufferPool<4> pool;
   auto buf1 = pool.Allocate();
   pool.Release({&buf1, 1});

--- a/wpiutil/src/test/native/cpp/uv/UvGetAddrInfoTest.cpp
+++ b/wpiutil/src/test/native/cpp/uv/UvGetAddrInfoTest.cpp
@@ -33,7 +33,7 @@
 
 namespace wpi::uv {
 
-TEST(UvGetAddrInfo, BothNull) {
+TEST(UvGetAddrInfoTest, BothNull) {
   int fail_cb_called = 0;
 
   auto loop = Loop::Create();
@@ -48,7 +48,7 @@ TEST(UvGetAddrInfo, BothNull) {
   ASSERT_EQ(fail_cb_called, 1);
 }
 
-TEST(UvGetAddrInfo, FailedLookup) {
+TEST(UvGetAddrInfoTest, FailedLookup) {
   int fail_cb_called = 0;
 
   auto loop = Loop::Create();
@@ -65,7 +65,7 @@ TEST(UvGetAddrInfo, FailedLookup) {
   ASSERT_EQ(fail_cb_called, 1);
 }
 
-TEST(UvGetAddrInfo, Basic) {
+TEST(UvGetAddrInfoTest, Basic) {
   int getaddrinfo_cbs = 0;
 
   auto loop = Loop::Create();
@@ -80,7 +80,7 @@ TEST(UvGetAddrInfo, Basic) {
 }
 
 #ifndef _WIN32
-TEST(UvGetAddrInfo, Concurrent) {
+TEST(UvGetAddrInfoTest, Concurrent) {
   int getaddrinfo_cbs = 0;
   int callback_counts[CONCURRENT_COUNT];
 

--- a/wpiutil/src/test/native/cpp/uv/UvGetNameInfoTest.cpp
+++ b/wpiutil/src/test/native/cpp/uv/UvGetNameInfoTest.cpp
@@ -31,7 +31,7 @@
 
 namespace wpi::uv {
 
-TEST(UvGetNameInfo, BasicIp4) {
+TEST(UvGetNameInfoTest, BasicIp4) {
   int getnameinfo_cbs = 0;
 
   auto loop = Loop::Create();
@@ -51,7 +51,7 @@ TEST(UvGetNameInfo, BasicIp4) {
   ASSERT_EQ(getnameinfo_cbs, 1);
 }
 
-TEST(UvGetNameInfo, BasicIp6) {
+TEST(UvGetNameInfoTest, BasicIp6) {
   int getnameinfo_cbs = 0;
 
   auto loop = Loop::Create();

--- a/wpiutil/src/test/native/cpp/uv/UvLoopWalkTest.cpp
+++ b/wpiutil/src/test/native/cpp/uv/UvLoopWalkTest.cpp
@@ -31,7 +31,7 @@
 
 namespace wpi::uv {
 
-TEST(UvLoop, Walk) {
+TEST(UvLoopTest, Walk) {
   int seen_timer_handle = 0;
 
   auto loop = Loop::Create();

--- a/wpiutil/src/test/native/cpp/uv/UvTimerTest.cpp
+++ b/wpiutil/src/test/native/cpp/uv/UvTimerTest.cpp
@@ -8,7 +8,7 @@
 
 namespace wpi::uv {
 
-TEST(UvTimer, StartAndStop) {
+TEST(UvTimerTest, StartAndStop) {
   auto loop = Loop::Create();
   auto handleNoRepeat = Timer::Create(loop);
   auto handleRepeat = Timer::Create(loop);
@@ -55,7 +55,7 @@ TEST(UvTimer, StartAndStop) {
   ASSERT_TRUE(checkTimerRepeatEvent);
 }
 
-TEST(UvTimer, Repeat) {
+TEST(UvTimerTest, Repeat) {
   auto loop = Loop::Create();
   auto handle = Timer::Create(loop);
 


### PR DESCRIPTION
I started with the output of wpilibsuite/styleguide#217, then renamed a
few classes to fix compilation. The file rewrites in the cross-connect
tests are due to line endings.

ntcore's StorageTest needed some manual renaming since it put the Test
word in the middle instead of at the end.

One limitation of wpiformat is test cases that were only named "Test"
were unmodified, and an error was generated. These test cases were
manually given more descriptive names:

* TimedRobotTest mode test cases had "Mode" appended to the name. Java
  tests were renamed to match.
* UvAsyncTest and UvAsyncFunctionTest cases were given alternate names