### PR TITLE
[examples] Rename DriveTrain classes to Drivetrain

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/Autonomous.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/Autonomous.cpp
@@ -15,7 +15,7 @@
 #include "commands/SetWristSetpoint.h"
 
 Autonomous::Autonomous(Claw* claw, Wrist* wrist, Elevator* elevator,
-                       DriveTrain* drivetrain) {
+                       Drivetrain* drivetrain) {
   SetName("Autonomous");
   AddCommands(
       // clang-format off

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/DriveStraight.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/DriveStraight.cpp
@@ -8,7 +8,7 @@
 
 #include "Robot.h"
 
-DriveStraight::DriveStraight(double distance, DriveTrain* drivetrain)
+DriveStraight::DriveStraight(double distance, Drivetrain* drivetrain)
     : frc2::CommandHelper<frc2::PIDCommand, DriveStraight>(
           frc2::PIDController(4, 0, 0),
           [drivetrain] { return drivetrain->GetDistance(); }, distance,

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetDistanceToBox.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetDistanceToBox.cpp
@@ -8,7 +8,7 @@
 
 #include "Robot.h"
 
-SetDistanceToBox::SetDistanceToBox(double distance, DriveTrain* drivetrain)
+SetDistanceToBox::SetDistanceToBox(double distance, Drivetrain* drivetrain)
     : frc2::CommandHelper<frc2::PIDCommand, SetDistanceToBox>(
           frc2::PIDController(-2, 0, 0),
           [drivetrain] { return drivetrain->GetDistanceToObstacle(); },

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/TankDrive.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/TankDrive.cpp
@@ -9,7 +9,7 @@
 #include "Robot.h"
 
 TankDrive::TankDrive(std::function<double()> left,
-                     std::function<double()> right, DriveTrain* drivetrain)
+                     std::function<double()> right, Drivetrain* drivetrain)
     : m_left(std::move(left)),
       m_right(std::move(right)),
       m_drivetrain(drivetrain) {

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Drivetrain.cpp
@@ -2,14 +2,14 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include "subsystems/DriveTrain.h"
+#include "subsystems/Drivetrain.h"
 
 #include <frc/Joystick.h>
 #include <frc/smartdashboard/SmartDashboard.h>
 #include <units/length.h>
 #include <wpi/numbers>
 
-DriveTrain::DriveTrain() {
+Drivetrain::Drivetrain() {
   // We need to invert one side of the drivetrain so that positive voltages
   // result in both sides moving forward. Depending on how your robot's
   // gearbox is constructed, you might have to invert the left side instead.
@@ -30,7 +30,7 @@ DriveTrain::DriveTrain() {
   m_rightEncoder.SetDistancePerPulse(units::foot_t{4_in}.to<double>() *
                                      wpi::numbers::pi / 360.0);
 #endif
-  SetName("DriveTrain");
+  SetName("Drivetrain");
   // Let's show everything on the LiveWindow
   AddChild("Front_Left Motor", &m_frontLeft);
   AddChild("Rear Left Motor", &m_rearLeft);
@@ -42,7 +42,7 @@ DriveTrain::DriveTrain() {
   AddChild("Gyro", &m_gyro);
 }
 
-void DriveTrain::Log() {
+void Drivetrain::Log() {
   frc::SmartDashboard::PutNumber("Left Distance", m_leftEncoder.GetDistance());
   frc::SmartDashboard::PutNumber("Right Distance",
                                  m_rightEncoder.GetDistance());
@@ -51,29 +51,29 @@ void DriveTrain::Log() {
   frc::SmartDashboard::PutNumber("Gyro", m_gyro.GetAngle());
 }
 
-void DriveTrain::Drive(double left, double right) {
+void Drivetrain::Drive(double left, double right) {
   m_robotDrive.TankDrive(left, right);
 }
 
-double DriveTrain::GetHeading() {
+double Drivetrain::GetHeading() {
   return m_gyro.GetAngle();
 }
 
-void DriveTrain::Reset() {
+void Drivetrain::Reset() {
   m_gyro.Reset();
   m_leftEncoder.Reset();
   m_rightEncoder.Reset();
 }
 
-double DriveTrain::GetDistance() {
+double Drivetrain::GetDistance() {
   return (m_leftEncoder.GetDistance() + m_rightEncoder.GetDistance()) / 2.0;
 }
 
-double DriveTrain::GetDistanceToObstacle() {
+double Drivetrain::GetDistanceToObstacle() {
   // Really meters in simulation since it's a rangefinder...
   return m_rangefinder.GetAverageVoltage();
 }
 
-void DriveTrain::Periodic() {
+void Drivetrain::Periodic() {
   Log();
 }

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/RobotContainer.h
@@ -9,7 +9,7 @@
 
 #include "commands/Autonomous.h"
 #include "subsystems/Claw.h"
-#include "subsystems/DriveTrain.h"
+#include "subsystems/Drivetrain.h"
 #include "subsystems/Elevator.h"
 #include "subsystems/Wrist.h"
 
@@ -33,7 +33,7 @@ class RobotContainer {
   Claw m_claw;
   Wrist m_wrist;
   Elevator m_elevator;
-  DriveTrain m_drivetrain;
+  Drivetrain m_drivetrain;
 
   Autonomous m_autonomousCommand;
 

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/Autonomous.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/Autonomous.h
@@ -8,7 +8,7 @@
 #include <frc2/command/SequentialCommandGroup.h>
 
 #include "subsystems/Claw.h"
-#include "subsystems/DriveTrain.h"
+#include "subsystems/Drivetrain.h"
 #include "subsystems/Elevator.h"
 #include "subsystems/Wrist.h"
 
@@ -19,5 +19,5 @@ class Autonomous
     : public frc2::CommandHelper<frc2::SequentialCommandGroup, Autonomous> {
  public:
   Autonomous(Claw* claw, Wrist* wrist, Elevator* elevator,
-             DriveTrain* drivetrain);
+             Drivetrain* drivetrain);
 };

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/DriveStraight.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/DriveStraight.h
@@ -7,7 +7,7 @@
 #include <frc2/command/CommandHelper.h>
 #include <frc2/command/PIDCommand.h>
 
-#include "subsystems/DriveTrain.h"
+#include "subsystems/Drivetrain.h"
 
 /**
  * Drive the given distance straight (negative values go backwards).
@@ -18,10 +18,10 @@
 class DriveStraight
     : public frc2::CommandHelper<frc2::PIDCommand, DriveStraight> {
  public:
-  explicit DriveStraight(double distance, DriveTrain* drivetrain);
+  explicit DriveStraight(double distance, Drivetrain* drivetrain);
   void Initialize() override;
   bool IsFinished() override;
 
  private:
-  DriveTrain* m_drivetrain;
+  Drivetrain* m_drivetrain;
 };

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/SetDistanceToBox.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/SetDistanceToBox.h
@@ -7,7 +7,7 @@
 #include <frc2/command/CommandHelper.h>
 #include <frc2/command/PIDCommand.h>
 
-#include "subsystems/DriveTrain.h"
+#include "subsystems/Drivetrain.h"
 
 /**
  * Drive until the robot is the given distance away from the box. Uses a local
@@ -18,10 +18,10 @@
 class SetDistanceToBox
     : public frc2::CommandHelper<frc2::PIDCommand, SetDistanceToBox> {
  public:
-  explicit SetDistanceToBox(double distance, DriveTrain* drivetrain);
+  explicit SetDistanceToBox(double distance, Drivetrain* drivetrain);
   void Initialize() override;
   bool IsFinished() override;
 
  private:
-  DriveTrain* m_drivetrain;
+  Drivetrain* m_drivetrain;
 };

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/TankDrive.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/TankDrive.h
@@ -7,7 +7,7 @@
 #include <frc2/command/CommandBase.h>
 #include <frc2/command/CommandHelper.h>
 
-#include "subsystems/DriveTrain.h"
+#include "subsystems/Drivetrain.h"
 
 /**
  * Have the robot drive tank style using the PS3 Joystick until interrupted.
@@ -15,7 +15,7 @@
 class TankDrive : public frc2::CommandHelper<frc2::CommandBase, TankDrive> {
  public:
   TankDrive(std::function<double()> left, std::function<double()> right,
-            DriveTrain* drivetrain);
+            Drivetrain* drivetrain);
   void Execute() override;
   bool IsFinished() override;
   void End(bool interrupted) override;
@@ -23,5 +23,5 @@ class TankDrive : public frc2::CommandHelper<frc2::CommandBase, TankDrive> {
  private:
   std::function<double()> m_left;
   std::function<double()> m_right;
-  DriveTrain* m_drivetrain;
+  Drivetrain* m_drivetrain;
 };

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Drivetrain.h
@@ -17,13 +17,13 @@ class Joystick;
 }  // namespace frc
 
 /**
- * The DriveTrain subsystem incorporates the sensors and actuators attached to
+ * The Drivetrain subsystem incorporates the sensors and actuators attached to
  * the robots chassis. These include four drive motors, a left and right encoder
  * and a gyro.
  */
-class DriveTrain : public frc2::SubsystemBase {
+class Drivetrain : public frc2::SubsystemBase {
  public:
-  DriveTrain();
+  Drivetrain();
 
   /**
    * The log method puts interesting information to the SmartDashboard.
@@ -31,7 +31,7 @@ class DriveTrain : public frc2::SubsystemBase {
   void Log();
 
   /**
-   * Tank style driving for the DriveTrain.
+   * Tank style driving for the Drivetrain.
    * @param left Speed in range [-1,1]
    * @param right Speed in range [-1,1]
    */

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/Robot.cpp
@@ -10,7 +10,7 @@
 #include <frc/livewindow/LiveWindow.h>
 #include <frc/smartdashboard/SmartDashboard.h>
 
-DriveTrain Robot::drivetrain;
+Drivetrain Robot::drivetrain;
 Pivot Robot::pivot;
 Collector Robot::collector;
 Shooter Robot::shooter;

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/subsystems/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/cpp/subsystems/Drivetrain.cpp
@@ -2,7 +2,7 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include "subsystems/DriveTrain.h"
+#include "subsystems/Drivetrain.h"
 
 #include <frc/Joystick.h>
 #include <units/length.h>
@@ -10,7 +10,7 @@
 
 #include "commands/DriveWithJoystick.h"
 
-DriveTrain::DriveTrain() : frc::Subsystem("DriveTrain") {
+Drivetrain::Drivetrain() : frc::Subsystem("Drivetrain") {
   // AddChild("Front Left CIM", m_frontLeftCIM);
   // AddChild("Front Right CIM", m_frontRightCIM);
   // AddChild("Back Left CIM", m_backLeftCIM);
@@ -46,26 +46,26 @@ DriveTrain::DriveTrain() : frc::Subsystem("DriveTrain") {
   AddChild("Gyro", m_gyro);
 }
 
-void DriveTrain::InitDefaultCommand() {
+void Drivetrain::InitDefaultCommand() {
   SetDefaultCommand(new DriveWithJoystick());
 }
 
-void DriveTrain::TankDrive(double leftAxis, double rightAxis) {
+void Drivetrain::TankDrive(double leftAxis, double rightAxis) {
   m_robotDrive.TankDrive(leftAxis, rightAxis);
 }
 
-void DriveTrain::Stop() {
+void Drivetrain::Stop() {
   m_robotDrive.TankDrive(0.0, 0.0);
 }
 
-frc::Encoder& DriveTrain::GetLeftEncoder() {
+frc::Encoder& Drivetrain::GetLeftEncoder() {
   return m_leftEncoder;
 }
 
-frc::Encoder& DriveTrain::GetRightEncoder() {
+frc::Encoder& Drivetrain::GetRightEncoder() {
   return m_rightEncoder;
 }
 
-double DriveTrain::GetAngle() {
+double Drivetrain::GetAngle() {
   return m_gyro.GetAngle();
 }

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/include/Robot.h
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/include/Robot.h
@@ -12,14 +12,14 @@
 #include "commands/DriveAndShootAutonomous.h"
 #include "commands/DriveForward.h"
 #include "subsystems/Collector.h"
-#include "subsystems/DriveTrain.h"
+#include "subsystems/Drivetrain.h"
 #include "subsystems/Pivot.h"
 #include "subsystems/Pneumatics.h"
 #include "subsystems/Shooter.h"
 
 class Robot : public frc::TimedRobot {
  public:
-  static DriveTrain drivetrain;
+  static Drivetrain drivetrain;
   static Pivot pivot;
   static Collector collector;
   static Shooter shooter;

--- a/wpilibcExamples/src/main/cpp/examples/PacGoat/include/subsystems/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/PacGoat/include/subsystems/Drivetrain.h
@@ -16,12 +16,12 @@ class Joystick;
 }  // namespace frc
 
 /**
- * The DriveTrain subsystem controls the robot's chassis and reads in
+ * The Drivetrain subsystem controls the robot's chassis and reads in
  * information about it's speed and position.
  */
-class DriveTrain : public frc::Subsystem {
+class Drivetrain : public frc::Subsystem {
  public:
-  DriveTrain();
+  Drivetrain();
 
   /**
    * When other commands aren't using the drivetrain, allow tank drive

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/RobotContainer.java
@@ -15,7 +15,7 @@ import edu.wpi.first.wpilibj.examples.gearsbot.commands.SetElevatorSetpoint;
 import edu.wpi.first.wpilibj.examples.gearsbot.commands.SetWristSetpoint;
 import edu.wpi.first.wpilibj.examples.gearsbot.commands.TankDrive;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Claw;
-import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.DriveTrain;
+import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Drivetrain;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Elevator;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Wrist;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -31,7 +31,7 @@ import edu.wpi.first.wpilibj2.command.button.JoystickButton;
  */
 public class RobotContainer {
   // The robot's subsystems and commands are defined here...
-  private final DriveTrain m_drivetrain = new DriveTrain();
+  private final Drivetrain m_drivetrain = new Drivetrain();
   private final Elevator m_elevator = new Elevator();
   private final Wrist m_wrist = new Wrist();
   private final Claw m_claw = new Claw();

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Autonomous.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Autonomous.java
@@ -5,7 +5,7 @@
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Claw;
-import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.DriveTrain;
+import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Drivetrain;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Elevator;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Wrist;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
@@ -13,7 +13,7 @@ import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 /** The main autonomous command to pickup and deliver the soda to the box. */
 public class Autonomous extends SequentialCommandGroup {
   /** Create a new autonomous command. */
-  public Autonomous(DriveTrain drive, Claw claw, Wrist wrist, Elevator elevator) {
+  public Autonomous(Drivetrain drive, Claw claw, Wrist wrist, Elevator elevator) {
     addCommands(
         new PrepareToPickup(claw, wrist, elevator),
         new Pickup(claw, wrist, elevator),

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
@@ -5,7 +5,7 @@
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
 import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.DriveTrain;
+import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Drivetrain;
 import edu.wpi.first.wpilibj2.command.PIDCommand;
 
 /**
@@ -14,14 +14,14 @@ import edu.wpi.first.wpilibj2.command.PIDCommand;
  * averaged values of the left and right encoders.
  */
 public class DriveStraight extends PIDCommand {
-  private final DriveTrain m_drivetrain;
+  private final Drivetrain m_drivetrain;
 
   /**
    * Create a new DriveStraight command.
    *
    * @param distance The distance to drive
    */
-  public DriveStraight(double distance, DriveTrain drivetrain) {
+  public DriveStraight(double distance, Drivetrain drivetrain) {
     super(
         new PIDController(4, 0, 0), drivetrain::getDistance, distance, d -> drivetrain.drive(d, d));
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/SetDistanceToBox.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/SetDistanceToBox.java
@@ -5,7 +5,7 @@
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
 import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.DriveTrain;
+import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Drivetrain;
 import edu.wpi.first.wpilibj2.command.PIDCommand;
 
 /**
@@ -14,14 +14,14 @@ import edu.wpi.first.wpilibj2.command.PIDCommand;
  * values of the left and right encoders.
  */
 public class SetDistanceToBox extends PIDCommand {
-  private final DriveTrain m_drivetrain;
+  private final Drivetrain m_drivetrain;
 
   /**
    * Create a new set distance to box command.
    *
    * @param distance The distance away from the box to drive to
    */
-  public SetDistanceToBox(double distance, DriveTrain drivetrain) {
+  public SetDistanceToBox(double distance, Drivetrain drivetrain) {
     super(
         new PIDController(-2, 0, 0),
         drivetrain::getDistanceToObstacle,

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/TankDrive.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/TankDrive.java
@@ -4,13 +4,13 @@
 
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
-import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.DriveTrain;
+import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Drivetrain;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import java.util.function.DoubleSupplier;
 
 /** Have the robot drive tank style. */
 public class TankDrive extends CommandBase {
-  private final DriveTrain m_drivetrain;
+  private final Drivetrain m_drivetrain;
   private final DoubleSupplier m_left;
   private final DoubleSupplier m_right;
 
@@ -21,7 +21,7 @@ public class TankDrive extends CommandBase {
    * @param right The control input for the right sight of the drive
    * @param drivetrain The drivetrain subsystem to drive
    */
-  public TankDrive(DoubleSupplier left, DoubleSupplier right, DriveTrain drivetrain) {
+  public TankDrive(DoubleSupplier left, DoubleSupplier right, Drivetrain drivetrain) {
     m_drivetrain = drivetrain;
     m_left = left;
     m_right = right;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Drivetrain.java
@@ -15,9 +15,9 @@ import edu.wpi.first.wpilibj.motorcontrol.PWMSparkMax;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
-public class DriveTrain extends SubsystemBase {
+public class Drivetrain extends SubsystemBase {
   /**
-   * The DriveTrain subsystem incorporates the sensors and actuators attached to the robots chassis.
+   * The Drivetrain subsystem incorporates the sensors and actuators attached to the robots chassis.
    * These include four drive motors, a left and right encoder and a gyro.
    */
   private final MotorController m_leftMotor =
@@ -33,8 +33,8 @@ public class DriveTrain extends SubsystemBase {
   private final AnalogInput m_rangefinder = new AnalogInput(6);
   private final AnalogGyro m_gyro = new AnalogGyro(1);
 
-  /** Create a new drive train subsystem. */
-  public DriveTrain() {
+  /** Create a new drivetrain subsystem. */
+  public Drivetrain() {
     super();
 
     // We need to invert one side of the drivetrain so that positive voltages
@@ -74,7 +74,7 @@ public class DriveTrain extends SubsystemBase {
   }
 
   /**
-   * Tank style driving for the DriveTrain.
+   * Tank style driving for the Drivetrain.
    *
    * @param left Speed in range [-1,1]
    * @param right Speed in range [-1,1]

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/Robot.java
@@ -10,7 +10,7 @@ import edu.wpi.first.wpilibj.command.Scheduler;
 import edu.wpi.first.wpilibj.examples.pacgoat.commands.DriveAndShootAutonomous;
 import edu.wpi.first.wpilibj.examples.pacgoat.commands.DriveForward;
 import edu.wpi.first.wpilibj.examples.pacgoat.subsystems.Collector;
-import edu.wpi.first.wpilibj.examples.pacgoat.subsystems.DriveTrain;
+import edu.wpi.first.wpilibj.examples.pacgoat.subsystems.Drivetrain;
 import edu.wpi.first.wpilibj.examples.pacgoat.subsystems.Pivot;
 import edu.wpi.first.wpilibj.examples.pacgoat.subsystems.Pneumatics;
 import edu.wpi.first.wpilibj.examples.pacgoat.subsystems.Shooter;
@@ -30,7 +30,7 @@ public class Robot extends TimedRobot {
   public static OI oi;
 
   // Initialize the subsystems
-  public static DriveTrain drivetrain = new DriveTrain();
+  public static Drivetrain drivetrain = new Drivetrain();
   public static Collector collector = new Collector();
   public static Shooter shooter = new Shooter();
   public static Pneumatics pneumatics = new Pneumatics();

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/subsystems/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/pacgoat/subsystems/Drivetrain.java
@@ -17,10 +17,10 @@ import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup;
 import edu.wpi.first.wpilibj.motorcontrol.Victor;
 
 /**
- * The DriveTrain subsystem controls the robot's chassis and reads in information about it's speed
+ * The Drivetrain subsystem controls the robot's chassis and reads in information about it's speed
  * and position.
  */
-public class DriveTrain extends Subsystem {
+public class Drivetrain extends Subsystem {
   // Subsystem devices
   private final MotorController m_frontLeftCIM = new Victor(1);
   private final MotorController m_frontRightCIM = new Victor(2);
@@ -35,8 +35,8 @@ public class DriveTrain extends Subsystem {
   private final Encoder m_leftEncoder = new Encoder(3, 4, false, EncodingType.k4X);
   private final AnalogGyro m_gyro = new AnalogGyro(0);
 
-  /** Create a new drive train subsystem. */
-  public DriveTrain() {
+  /** Create a new drivetrain subsystem. */
+  public Drivetrain() {
     // Configure drive motors
     addChild("Front Left CIM", (Victor) m_frontLeftCIM);
     addChild("Front Right CIM", (Victor) m_frontRightCIM);

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/HolonomicDriveController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/HolonomicDriveController.java
@@ -10,7 +10,7 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.trajectory.Trajectory;
 
 /**
- * This holonomic drive controller can be used to follow trajectories using a holonomic drive train
+ * This holonomic drive controller can be used to follow trajectories using a holonomic drivetrain
  * (i.e. swerve or mecanum). Holonomic trajectory following is a much simpler problem to solve
  * compared to skid-steer style drivetrains because it is possible to individually control forward,
  * sideways, and angular velocity.

--- a/wpimath/src/main/native/include/frc/controller/HolonomicDriveController.h
+++ b/wpimath/src/main/native/include/frc/controller/HolonomicDriveController.h
@@ -18,10 +18,10 @@
 namespace frc {
 /**
  * This holonomic drive controller can be used to follow trajectories using a
- * holonomic drive train (i.e. swerve or mecanum). Holonomic trajectory
- * following is a much simpler problem to solve compared to skid-steer style
- * drivetrains because it is possible to individually control forward, sideways,
- * and angular velocity.
+ * holonomic drivetrain (i.e. swerve or mecanum). Holonomic trajectory following
+ * is a much simpler problem to solve compared to skid-steer style drivetrains
+ * because it is possible to individually control forward, sideways, and angular
+ * velocity.
  *
  * The holonomic drive controller takes in one PID controller for each
  * direction, forward and sideways, and one profiled PID controller for the


### PR DESCRIPTION
Drivetrain is one word, not two.