### PR TITLE
[hal] Notifier: Ignore HAL_SETUID_ERROR

### DIFF
--- a/hal/src/main/native/athena/Notifier.cpp
+++ b/hal/src/main/native/athena/Notifier.cpp
@@ -164,6 +164,10 @@ HAL_NotifierHandle HAL_InitializeNotifier(int32_t* status) {
       fmt::print("{}: HAL Notifier thread\n",
                  HAL_THREAD_PRIORITY_RANGE_ERROR_MESSAGE);
     }
+    if (*status == HAL_SETUID_ERROR) {
+      *status = 0;
+      fmt::print("{}: HAL Notifier thread\n", HAL_SETUID_ERROR);
+    }
 
     notifierAlarm.reset(tAlarm::create(status));
   }

--- a/hal/src/main/native/athena/Notifier.cpp
+++ b/hal/src/main/native/athena/Notifier.cpp
@@ -166,7 +166,7 @@ HAL_NotifierHandle HAL_InitializeNotifier(int32_t* status) {
     }
     if (*status == HAL_SETUID_ERROR) {
       *status = 0;
-      fmt::print("{}: HAL Notifier thread\n", HAL_SETUID_ERROR);
+      fmt::print("{}: HAL Notifier thread\n", HAL_SETUID_ERROR_MESSAGE);
     }
 
     notifierAlarm.reset(tAlarm::create(status));


### PR DESCRIPTION
This error can occur if the user program has insufficient permissions, which causes any user program to immediately terminate.