### PR TITLE
[hal] Use setcap instead of setuid for setting thread priorities

### DIFF
--- a/hal/src/main/native/include/hal/Errors.h
+++ b/hal/src/main/native/include/hal/Errors.h
@@ -135,9 +135,6 @@
 #define HAL_USE_LAST_ERROR_MESSAGE \
   "HAL: Use HAL_GetLastError(status) to get last error"
 
-#define HAL_SETUID_ERROR -1157
-#define HAL_SETUID_ERROR_MESSAGE "HAL: Setting the effective user ID has failed"
-
 #define HAL_CAN_BUFFER_OVERRUN -35007
 #define HAL_CAN_BUFFER_OVERRUN_MESSAGE \
   "HAL: CAN Output Buffer Full. Ensure a device is attached"


### PR DESCRIPTION
We originally moved to setuid admin so user programs could do other
things requiring admin if they wanted. However, these things, like
setting RT priorities of other processes, can usually be done instead as
admin during the GradleRIO 2022 deploy process, or adding commands to
the robotCommand script. By going back to setcap, we can simplify the
HAL code.