### PR TITLE
[build] Suppress deprecation/removal warnings for old commands

### DIFF
--- a/wpilibOldCommands/build.gradle
+++ b/wpilibOldCommands/build.gradle
@@ -113,3 +113,7 @@ test {
         showStandardStreams = true
     }
 }
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs += "-Xlint:-removal"
+}


### PR DESCRIPTION
The old commands use deprecated symbols, and that's not going to change. All the warnings pollute the build logs. I don't see a reason not to suppress them.