### PR TITLE
[cscore] Fix Java direct callback notifications

### DIFF
--- a/cscore/src/main/native/cpp/Notifier.h
+++ b/cscore/src/main/native/cpp/Notifier.h
@@ -35,8 +35,11 @@ struct ListenerData : public wpi::CallbackListenerData<
 class NotifierThread
     : public wpi::CallbackThread<NotifierThread, RawEvent, ListenerData> {
  public:
-  bool Matches(const ListenerData& /*listener*/, const RawEvent& /*data*/) {
-    return true;
+  NotifierThread(std::function<void()> on_start, std::function<void()> on_exit)
+      : CallbackThread(std::move(on_start), std::move(on_exit)) {}
+
+  bool Matches(const ListenerData& listener, const RawEvent& data) {
+    return (data.kind & listener.eventMask) != 0;
   }
 
   void SetListener(RawEvent* data, unsigned int listener_uid) {

--- a/cscore/src/main/native/cpp/cscore_cpp.cpp
+++ b/cscore/src/main/native/cpp/cscore_cpp.cpp
@@ -708,9 +708,13 @@ void ReleaseSink(CS_Sink sink, CS_Status* status) {
 // Listener Functions
 //
 
-void SetListenerOnStart(std::function<void()> onStart) {}
+void SetListenerOnStart(std::function<void()> onStart) {
+  Instance::GetInstance().notifier.SetOnStart(onStart);
+}
 
-void SetListenerOnExit(std::function<void()> onExit) {}
+void SetListenerOnExit(std::function<void()> onExit) {
+  Instance::GetInstance().notifier.SetOnExit(onExit);
+}
 
 static void StartBackground(int eventMask, bool immediateNotify) {
   auto& inst = Instance::GetInstance();

--- a/ntcore/src/main/native/cpp/ConnectionNotifier.h
+++ b/ntcore/src/main/native/cpp/ConnectionNotifier.h
@@ -5,6 +5,8 @@
 #ifndef NTCORE_CONNECTIONNOTIFIER_H_
 #define NTCORE_CONNECTIONNOTIFIER_H_
 
+#include <utility>
+
 #include <wpi/CallbackManager.h>
 
 #include "Handle.h"
@@ -19,7 +21,9 @@ class ConnectionNotifierThread
     : public wpi::CallbackThread<ConnectionNotifierThread,
                                  ConnectionNotification> {
  public:
-  explicit ConnectionNotifierThread(int inst) : m_inst(inst) {}
+  ConnectionNotifierThread(std::function<void()> on_start,
+                           std::function<void()> on_exit, int inst)
+      : CallbackThread(std::move(on_start), std::move(on_exit)), m_inst(inst) {}
 
   bool Matches(const ListenerData& /*listener*/,
                const ConnectionNotification& /*data*/) {

--- a/ntcore/src/main/native/cpp/EntryNotifier.h
+++ b/ntcore/src/main/native/cpp/EntryNotifier.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <wpi/CallbackManager.h>
 
@@ -52,7 +53,9 @@ class EntryNotifierThread
     : public wpi::CallbackThread<EntryNotifierThread, EntryNotification,
                                  EntryListenerData> {
  public:
-  explicit EntryNotifierThread(int inst) : m_inst(inst) {}
+  EntryNotifierThread(std::function<void()> on_start,
+                      std::function<void()> on_exit, int inst)
+      : CallbackThread(std::move(on_start), std::move(on_exit)), m_inst(inst) {}
 
   bool Matches(const EntryListenerData& listener,
                const EntryNotification& data);

--- a/ntcore/src/main/native/cpp/LoggerImpl.h
+++ b/ntcore/src/main/native/cpp/LoggerImpl.h
@@ -5,6 +5,8 @@
 #ifndef NTCORE_LOGGERIMPL_H_
 #define NTCORE_LOGGERIMPL_H_
 
+#include <utility>
+
 #include <wpi/CallbackManager.h>
 
 #include "Handle.h"
@@ -35,7 +37,9 @@ struct LoggerListenerData : public wpi::CallbackListenerData<
 class LoggerThread
     : public wpi::CallbackThread<LoggerThread, LogMessage, LoggerListenerData> {
  public:
-  explicit LoggerThread(int inst) : m_inst(inst) {}
+  LoggerThread(std::function<void()> on_start, std::function<void()> on_exit,
+               int inst)
+      : CallbackThread(std::move(on_start), std::move(on_exit)), m_inst(inst) {}
 
   bool Matches(const LoggerListenerData& listener, const LogMessage& data) {
     return data.level >= listener.min_level && data.level <= listener.max_level;

--- a/ntcore/src/main/native/cpp/RpcServer.h
+++ b/ntcore/src/main/native/cpp/RpcServer.h
@@ -38,8 +38,11 @@ class RpcServerThread
     : public wpi::CallbackThread<RpcServerThread, RpcAnswer, RpcListenerData,
                                  RpcNotifierData> {
  public:
-  RpcServerThread(int inst, wpi::Logger& logger)
-      : m_inst(inst), m_logger(logger) {}
+  RpcServerThread(std::function<void()> on_start, std::function<void()> on_exit,
+                  int inst, wpi::Logger& logger)
+      : CallbackThread(std::move(on_start), std::move(on_exit)),
+        m_inst(inst),
+        m_logger(logger) {}
 
   bool Matches(const RpcListenerData& /*listener*/,
                const RpcNotifierData& data) {


### PR DESCRIPTION
The JNI layer needs the the OnStart and OnExit callbacks which were not present
in the wpiutil common CallbackManager code.  Add support for these and
fix up other use cases.

Also fixes notifications to correctly filter on event kind.

Broken in #3133.