### PR TITLE
[wpiutil] Move json_serializer.h to public headers

### DIFF
--- a/wpiutil/src/main/native/cpp/json_serializer.cpp
+++ b/wpiutil/src/main/native/cpp/json_serializer.cpp
@@ -38,7 +38,7 @@ SOFTWARE.
 #include "wpi/SmallString.h"
 #include "wpi/raw_os_ostream.h"
 
-#include "json_serializer.h"
+#include "wpi/json_serializer.h"
 
 namespace wpi {
 

--- a/wpiutil/src/main/native/include/wpi/json.h
+++ b/wpiutil/src/main/native/include/wpi/json.h
@@ -2678,9 +2678,10 @@ class json
     class binary_writer;
     class lexer;
     class parser;
-    class serializer;
 
   public:
+    class serializer;
+
     using value_t = detail::value_t;
     /// @copydoc wpi::json_pointer
     using json_pointer = ::wpi::json_pointer;

--- a/wpiutil/src/main/native/include/wpi/json_serializer.h
+++ b/wpiutil/src/main/native/include/wpi/json_serializer.h
@@ -75,6 +75,7 @@ class json::serializer
 
     @param[in] val             value to serialize
     @param[in] pretty_print    whether the output shall be pretty-printed
+    @param[in] ensure_ascii    whether the output shall only use ASCII chars
     @param[in] indent_step     the indent level
     @param[in] current_indent  the current indent level (only used internally)
     */
@@ -83,7 +84,6 @@ class json::serializer
               const unsigned int indent_step,
               const unsigned int current_indent = 0);
 
-  private:
     /*!
     @brief dump escaped string
 
@@ -94,9 +94,9 @@ class json::serializer
 
     @param[in] s  the string to escape
     @param[in] ensure_ascii  whether to escape non-ASCII characters with
-                             \uXXXX sequences
+                             "\uXXXX" sequences
 
-    @complexity Linear in the length of string @a s.
+    Complexity: Linear in the length of string @a s.
     */
     void dump_escaped(std::string_view s, const bool ensure_ascii);
 


### PR DESCRIPTION
This makes it possible to do "manual" JSON-compliant serialization more efficiently (e.g. without needing to construct a full json object).