### PR TITLE
Add warning about battery damage to the brownout voltage documentation

### DIFF
--- a/wpilibc/src/main/native/include/frc/RobotController.h
+++ b/wpilibc/src/main/native/include/frc/RobotController.h
@@ -196,7 +196,11 @@ class RobotController {
   static units::volt_t GetBrownoutVoltage();
 
   /**
-   * Set the voltage the roboRIO will brownout and disable all outputs.
+   * Set the voltage at which the roboRIO will brownout and disable all outputs.
+   *
+   * Excessive operation at low voltages will cause permanent damage to
+   * batteries and degrade their performance irreversibly. Ensure you have other
+   * brownout voltage mitigation techniques in place before changing this value.
    *
    * Note that this only does anything on the roboRIO 2.
    * On the roboRIO it is a no-op.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotController.java
@@ -225,6 +225,10 @@ public final class RobotController {
   /**
    * Set the voltage the roboRIO will brownout and disable all outputs.
    *
+   * <p>Excessive operation at low voltages will cause permanent damage to batteries and degrade
+   * their performance irreversibly. Ensure you have other brownout voltage mitigation techniques in
+   * place before changing this value.
+   *
    * <p>Note that this only does anything on the roboRIO 2. On the roboRIO it is a no-op.
    *
    * @param brownoutVoltage The brownout voltage


### PR DESCRIPTION
Need to add warring about operating the FRC battery at such low voltages. The potential for batteries getting damaged is very high. This can also lead to hot batteries when they are placed onto their charges and can cause a safety concern.

Adding a warning to the user to help them understand the implications of altering this value is important.

Sources: 
[WHAT ARE THE MOST COMMON CAUSES OF PREMATURE BATTERY FAILURES?](https://www.interstatebatteries.com/support#:~:text=Deep%20discharges%3A%20Discharging,keep%20them%20healthy.)

[Depth of Discharge for Lead Acid Battery](https://www.ecosoch.com/lead-acid-battery/)
