### PR TITLE
PH: Start closed-loop compressor control on init

### DIFF
--- a/hal/src/main/native/athena/REVPH.cpp
+++ b/hal/src/main/native/athena/REVPH.cpp
@@ -217,7 +217,7 @@ HAL_REVPHHandle HAL_InitializeREVPH(int32_t module,
   hph->controlPeriod = kDefaultControlPeriod;
 
   // Start closed-loop compressor control by starting solenoid state updates
-  HAL_REV_SendSolenoidsState(&hph, status);
+  HAL_REV_SendSolenoidsState(hph.get(), status);
 
   return handle;
 }


### PR DESCRIPTION
Similar to the PCM, we're going to make the PH not do anything with the compressor until the PH HAL object has been initialized. The mechanism we're going to use to signal to the PH that that has happened is to begin sending the state of the solenoids (which will all be set to off at this point).