### PR TITLE
[wpilib] Remove redundant "quick turn" docs for curvature drive (NFC)

### DIFF
--- a/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
@@ -138,8 +138,7 @@ class DifferentialDrive : public RobotDriveBase,
    *
    * The rotation argument controls the curvature of the robot's path rather
    * than its rate of heading change. This makes the robot more controllable at
-   * high speeds. Also handles the robot's quick turn functionality - "quick
-   * turn" overrides constant-curvature turning for turn-in-place maneuvers.
+   * high speeds.
    *
    * @param xSpeed           The robot's speed along the X axis [-1.0..1.0].
    *                         Forward is positive.
@@ -181,8 +180,7 @@ class DifferentialDrive : public RobotDriveBase,
    *
    * The rotation argument controls the curvature of the robot's path rather
    * than its rate of heading change. This makes the robot more controllable at
-   * high speeds. Also handles the robot's quick turn functionality - "quick
-   * turn" overrides constant-curvature turning for turn-in-place maneuvers.
+   * high speeds.
    *
    * @param xSpeed           The robot's speed along the X axis [-1.0..1.0].
    *                         Forward is positive.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -185,9 +185,7 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * Curvature drive method for differential drive platform.
    *
    * <p>The rotation argument controls the curvature of the robot's path rather than its rate of
-   * heading change. This makes the robot more controllable at high speeds. Also handles the robot's
-   * quick turn functionality - "quick turn" overrides constant-curvature turning for turn-in-place
-   * maneuvers.
+   * heading change. This makes the robot more controllable at high speeds.
    *
    * @param xSpeed The robot's speed along the X axis [-1.0..1.0]. Forward is positive.
    * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
@@ -312,9 +310,7 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * Curvature drive inverse kinematics for differential drive platform.
    *
    * <p>The rotation argument controls the curvature of the robot's path rather than its rate of
-   * heading change. This makes the robot more controllable at high speeds. Also handles the robot's
-   * quick turn functionality - "quick turn" overrides constant-curvature turning for turn-in-place
-   * maneuvers.
+   * heading change. This makes the robot more controllable at high speeds.
    *
    * @param xSpeed The robot's speed along the X axis [-1.0..1.0]. Forward is positive.
    * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is


### PR DESCRIPTION
The parameter docs for allowTurnInPlace say the same thing, and it's no
longer called "quick turn".