### PR TITLE
[wpimath] Report uncontrollable and unobservable states

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/StateSpaceUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/StateSpaceUtil.java
@@ -124,6 +124,37 @@ public final class StateSpaceUtil {
   }
 
   /**
+   * Returns the 0-based indices of the uncontrollable states in the given (A, B) pair.
+   *
+   * @param <States> Num representing the size of A.
+   * @param <Inputs> Num representing the columns of B.
+   * @param A System matrix.
+   * @param B Input matrix.
+   * @return List of 0-based indices of the uncontrollable states.
+   */
+  @SuppressWarnings("MethodTypeParameterName")
+  public static <States extends Num, Inputs extends Num> int[] getUncontrollableStates(
+      Matrix<States, States> A, Matrix<States, Inputs> B) {
+    return WPIMathJNI.getUncontrollableStates(
+        A.getNumRows(), B.getNumCols(), A.getData(), B.getData());
+  }
+
+  /**
+   * Returns the 0-based indices of the unobservable states in the given (A, C) pair.
+   *
+   * @param <States> Num representing the size of A.
+   * @param <Outputs> Num representing the rows of C.
+   * @param A System matrix.
+   * @param C Output matrix.
+   * @return List of 0-based indices of the unobservable states.
+   */
+  @SuppressWarnings("MethodTypeParameterName")
+  public static <States extends Num, Outputs extends Num> int[] getUnobservableStates(
+      Matrix<States, States> A, Matrix<Outputs, States> C) {
+    return getUncontrollableStates(A.transpose(), C.transpose());
+  }
+
+  /**
    * Convert a {@link Pose2d} to a vector of [x, y, theta], where theta is in radians.
    *
    * @param pose A pose to convert to a vector.

--- a/wpimath/src/main/java/edu/wpi/first/math/WPIMathJNI.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/WPIMathJNI.java
@@ -92,6 +92,18 @@ public final class WPIMathJNI {
   public static native boolean isStabilizable(int states, int inputs, double[] A, double[] B);
 
   /**
+   * Returns the 0-based indices of the uncontrollable states in the given (A, B) pair.
+   *
+   * @param states the number of states of the system.
+   * @param inputs the number of inputs to the system.
+   * @param A System matrix.
+   * @param B Input matrix.
+   * @return List of 0-based indices of the uncontrollable states.
+   */
+  public static native int[] getUncontrollableStates(
+      int states, int inputs, double[] A, double[] B);
+
+  /**
    * Loads a Pathweaver JSON.
    *
    * @param path The path to the JSON.

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/LinearQuadraticRegulator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/LinearQuadraticRegulator.java
@@ -91,7 +91,7 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
    * @param R The input cost matrix.
    * @param dtSeconds Discretization timestep.
    */
-  @SuppressWarnings({"LocalVariableName", "ParameterName"})
+  @SuppressWarnings({"LocalVariableName", "PMD.AvoidDeeplyNestedIfStmts", "ParameterName"})
   public LinearQuadraticRegulator(
       Matrix<States, States> A,
       Matrix<States, Inputs> B,
@@ -103,11 +103,23 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
     var discB = discABPair.getSecond();
 
     if (!StateSpaceUtil.isStabilizable(discA, discB)) {
+      final var uncontrollableStates = StateSpaceUtil.getUncontrollableStates(discA, discB);
+
       var builder = new StringBuilder("The system passed to the LQR is uncontrollable!\n\nA =\n");
       builder.append(discA.getStorage().toString());
       builder.append("\nB =\n");
       builder.append(discB.getStorage().toString());
       builder.append("\n");
+      if (uncontrollableStates.length > 0) {
+        builder.append("\n0-based indices of uncontrollable states: ");
+        for (int i = 0; i < uncontrollableStates.length; ++i) {
+          builder.append(uncontrollableStates[i]);
+          if (i < uncontrollableStates.length - 1) {
+            builder.append(", ");
+          }
+        }
+        builder.append("\n");
+      }
 
       var msg = builder.toString();
       MathSharedStore.reportError(msg, Thread.currentThread().getStackTrace());

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/KalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/KalmanFilter.java
@@ -53,7 +53,7 @@ public class KalmanFilter<States extends Num, Inputs extends Num, Outputs extend
    * @param measurementStdDevs Standard deviations of measurements.
    * @param dtSeconds Nominal discretization timestep.
    */
-  @SuppressWarnings("LocalVariableName")
+  @SuppressWarnings({"LocalVariableName", "PMD.AvoidDeeplyNestedIfStmts"})
   public KalmanFilter(
       Nat<States> states,
       Nat<Outputs> outputs,
@@ -77,12 +77,24 @@ public class KalmanFilter<States extends Num, Inputs extends Num, Outputs extend
     var C = plant.getC();
 
     if (!StateSpaceUtil.isDetectable(discA, C)) {
+      final var unobservableStates = StateSpaceUtil.getUnobservableStates(discA, C);
+
       var builder =
           new StringBuilder("The system passed to the Kalman filter is unobservable!\n\nA =\n");
       builder.append(discA.getStorage().toString());
       builder.append("\nC =\n");
       builder.append(C.getStorage().toString());
       builder.append("\n");
+      if (unobservableStates.length > 0) {
+        builder.append("\n0-based indices of unobservable states: ");
+        for (int i = 0; i < unobservableStates.length; ++i) {
+          builder.append(unobservableStates[i]);
+          if (i < unobservableStates.length - 1) {
+            builder.append(", ");
+          }
+        }
+        builder.append("\n");
+      }
 
       var msg = builder.toString();
       MathSharedStore.reportError(msg, Thread.currentThread().getStackTrace());

--- a/wpimath/src/main/native/cpp/GetUncontrollableStates1x1.cpp
+++ b/wpimath/src/main/native/cpp/GetUncontrollableStates1x1.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc/StateSpaceUtil.h"
+
+namespace frc {
+
+template <>
+wpi::SmallVector<int, 1> GetUncontrollableStates<1, 1>(
+    const Eigen::Matrix<double, 1, 1>& A,
+    const Eigen::Matrix<double, 1, 1>& B) {
+  return detail::GetUncontrollableStatesImpl<1, 1>(A, B);
+}
+
+}  // namespace frc

--- a/wpimath/src/main/native/cpp/GetUncontrollableStates2x1.cpp
+++ b/wpimath/src/main/native/cpp/GetUncontrollableStates2x1.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc/StateSpaceUtil.h"
+
+namespace frc {
+
+template <>
+wpi::SmallVector<int, 2> GetUncontrollableStates<2, 1>(
+    const Eigen::Matrix<double, 2, 2>& A,
+    const Eigen::Matrix<double, 2, 1>& B) {
+  return detail::GetUncontrollableStatesImpl<2, 1>(A, B);
+}
+
+}  // namespace frc

--- a/wpimath/src/main/native/cpp/GetUncontrollableStates2x2.cpp
+++ b/wpimath/src/main/native/cpp/GetUncontrollableStates2x2.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc/StateSpaceUtil.h"
+
+namespace frc {
+
+template <>
+wpi::SmallVector<int, 2> GetUncontrollableStates<2, 2>(
+    const Eigen::Matrix<double, 2, 2>& A,
+    const Eigen::Matrix<double, 2, 2>& B) {
+  return detail::GetUncontrollableStatesImpl<2, 2>(A, B);
+}
+
+}  // namespace frc

--- a/wpimath/src/main/native/include/frc/controller/LinearQuadraticRegulator.h
+++ b/wpimath/src/main/native/include/frc/controller/LinearQuadraticRegulator.h
@@ -91,10 +91,17 @@ class LinearQuadraticRegulatorImpl {
     DiscretizeAB<States, Inputs>(A, B, dt, &discA, &discB);
 
     if (!IsStabilizable<States, Inputs>(discA, discB)) {
+      auto uncontrollableStates =
+          GetUncontrollableStates<States, Inputs>(discA, discB);
+
       std::string msg = fmt::format(
           "The system passed to the LQR is uncontrollable!\n\nA =\n{}\nB "
           "=\n{}\n",
           discA, discB);
+      if (!uncontrollableStates.empty()) {
+        msg += fmt::format("\n0-based indices of uncontrollable states: {}\n",
+                           fmt::join(uncontrollableStates, ", "));
+      }
 
       wpi::math::MathSharedStore::ReportError(msg);
       throw std::invalid_argument(msg);

--- a/wpimath/src/main/native/include/frc/estimator/KalmanFilter.h
+++ b/wpimath/src/main/native/include/frc/estimator/KalmanFilter.h
@@ -73,10 +73,17 @@ class KalmanFilterImpl {
     const auto& C = plant.C();
 
     if (!IsDetectable<States, Outputs>(discA, C)) {
+      auto unobservableStates =
+          GetUnobservableStates<States, Outputs>(discA, C);
+
       std::string msg = fmt::format(
           "The system passed to the Kalman filter is "
           "unobservable!\n\nA =\n{}\nC =\n{}\n",
           discA, C);
+      if (!unobservableStates.empty()) {
+        msg += fmt::format("\n0-based indices of unobservable states: {}\n",
+                           fmt::join(unobservableStates, ", "));
+      }
 
       wpi::math::MathSharedStore::ReportError(msg);
       throw std::invalid_argument(msg);

--- a/wpimath/src/test/java/edu/wpi/first/math/StateSpaceUtilTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/StateSpaceUtilTest.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.math;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -101,6 +102,54 @@ public class StateSpaceUtilTest {
     // Second eigenvalue is observable and unstable.
     A = Matrix.mat(Nat.N2(), Nat.N2()).fill(0.2, 0, 0, 1.2);
     assertTrue(StateSpaceUtil.isDetectable(A, C));
+  }
+
+  @Test
+  @SuppressWarnings("LocalVariableName")
+  public void testGetUncontrollableStates() {
+    Matrix<N2, N2> A;
+    Matrix<N2, N1> B1 = VecBuilder.fill(0, 1);
+    Matrix<N2, N1> B2 = VecBuilder.fill(1, 0);
+
+    A = Matrix.mat(Nat.N2(), Nat.N2()).fill(1.2, 0, 0, 0.5);
+    assertArrayEquals(new int[] {0}, StateSpaceUtil.getUncontrollableStates(A, B1));
+    assertArrayEquals(new int[] {1}, StateSpaceUtil.getUncontrollableStates(A, B2));
+
+    A = Matrix.mat(Nat.N2(), Nat.N2()).fill(1, 0, 0, 0.5);
+    assertArrayEquals(new int[] {0}, StateSpaceUtil.getUncontrollableStates(A, B1));
+    assertArrayEquals(new int[] {1}, StateSpaceUtil.getUncontrollableStates(A, B2));
+
+    A = Matrix.mat(Nat.N2(), Nat.N2()).fill(0.2, 0, 0, 0.5);
+    assertArrayEquals(new int[] {0}, StateSpaceUtil.getUncontrollableStates(A, B1));
+    assertArrayEquals(new int[] {1}, StateSpaceUtil.getUncontrollableStates(A, B2));
+
+    A = Matrix.mat(Nat.N2(), Nat.N2()).fill(0.2, 0, 0, 1.2);
+    assertArrayEquals(new int[] {0}, StateSpaceUtil.getUncontrollableStates(A, B1));
+    assertArrayEquals(new int[] {1}, StateSpaceUtil.getUncontrollableStates(A, B2));
+  }
+
+  @Test
+  @SuppressWarnings("LocalVariableName")
+  public void testGetUnobservableStates() {
+    Matrix<N2, N2> A;
+    Matrix<N1, N2> C1 = Matrix.mat(Nat.N1(), Nat.N2()).fill(0, 1);
+    Matrix<N1, N2> C2 = Matrix.mat(Nat.N1(), Nat.N2()).fill(1, 0);
+
+    A = Matrix.mat(Nat.N2(), Nat.N2()).fill(1.2, 0, 0, 0.5);
+    assertArrayEquals(new int[] {0}, StateSpaceUtil.getUnobservableStates(A, C1));
+    assertArrayEquals(new int[] {1}, StateSpaceUtil.getUnobservableStates(A, C2));
+
+    A = Matrix.mat(Nat.N2(), Nat.N2()).fill(1, 0, 0, 0.5);
+    assertArrayEquals(new int[] {0}, StateSpaceUtil.getUnobservableStates(A, C1));
+    assertArrayEquals(new int[] {1}, StateSpaceUtil.getUnobservableStates(A, C2));
+
+    A = Matrix.mat(Nat.N2(), Nat.N2()).fill(0.2, 0, 0, 0.5);
+    assertArrayEquals(new int[] {0}, StateSpaceUtil.getUnobservableStates(A, C1));
+    assertArrayEquals(new int[] {1}, StateSpaceUtil.getUnobservableStates(A, C2));
+
+    A = Matrix.mat(Nat.N2(), Nat.N2()).fill(0.2, 0, 0, 1.2);
+    assertArrayEquals(new int[] {0}, StateSpaceUtil.getUnobservableStates(A, C1));
+    assertArrayEquals(new int[] {1}, StateSpaceUtil.getUnobservableStates(A, C2));
   }
 
   @Test

--- a/wpimath/src/test/native/cpp/StateSpaceUtilTest.cpp
+++ b/wpimath/src/test/native/cpp/StateSpaceUtilTest.cpp
@@ -2,6 +2,7 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <array>
@@ -157,4 +158,62 @@ TEST(StateSpaceUtilTest, IsDetectable) {
   // Second eigenvalue is observable and unstable.
   EXPECT_TRUE((frc::IsDetectable<2, 1>(
       Eigen::Matrix<double, 2, 2>{{0.2, 0}, {0, 1.2}}, C)));
+}
+
+TEST(StateSpaceUtilTest, GetUncontrollableStates) {
+  Eigen::Matrix<double, 2, 1> B1{0, 1};
+  Eigen::Matrix<double, 2, 1> B2{1, 0};
+
+  Eigen::Matrix<double, 2, 2> A1{{1.2, 0}, {0, 0.5}};
+  EXPECT_THAT((frc::GetUncontrollableStates<2, 1>(A1, B1)),
+              testing::ElementsAre(0));
+  EXPECT_THAT((frc::GetUncontrollableStates<2, 1>(A1, B2)),
+              testing::ElementsAre(1));
+
+  Eigen::Matrix<double, 2, 2> A2{{1, 0}, {0, 0.5}};
+  EXPECT_THAT((frc::GetUncontrollableStates<2, 1>(A2, B1)),
+              testing::ElementsAre(0));
+  EXPECT_THAT((frc::GetUncontrollableStates<2, 1>(A2, B2)),
+              testing::ElementsAre(1));
+
+  Eigen::Matrix<double, 2, 2> A3{{0.2, 0}, {0, 0.5}};
+  EXPECT_THAT((frc::GetUncontrollableStates<2, 1>(A3, B1)),
+              testing::ElementsAre(0));
+  EXPECT_THAT((frc::GetUncontrollableStates<2, 1>(A3, B2)),
+              testing::ElementsAre(1));
+
+  Eigen::Matrix<double, 2, 2> A4{{0.2, 0}, {0, 1.2}};
+  EXPECT_THAT((frc::GetUncontrollableStates<2, 1>(A4, B1)),
+              testing::ElementsAre(0));
+  EXPECT_THAT((frc::GetUncontrollableStates<2, 1>(A4, B2)),
+              testing::ElementsAre(1));
+}
+
+TEST(StateSpaceUtilTest, GetUnobservableStates) {
+  Eigen::Matrix<double, 1, 2> C1{0, 1};
+  Eigen::Matrix<double, 1, 2> C2{1, 0};
+
+  Eigen::Matrix<double, 2, 2> A1{{1.2, 0}, {0, 0.5}};
+  EXPECT_THAT((frc::GetUnobservableStates<2, 1>(A1, C1)),
+              testing::ElementsAre(0));
+  EXPECT_THAT((frc::GetUnobservableStates<2, 1>(A1, C2)),
+              testing::ElementsAre(1));
+
+  Eigen::Matrix<double, 2, 2> A2{{1, 0}, {0, 0.5}};
+  EXPECT_THAT((frc::GetUnobservableStates<2, 1>(A2, C1)),
+              testing::ElementsAre(0));
+  EXPECT_THAT((frc::GetUnobservableStates<2, 1>(A2, C2)),
+              testing::ElementsAre(1));
+
+  Eigen::Matrix<double, 2, 2> A3{{0.2, 0}, {0, 0.5}};
+  EXPECT_THAT((frc::GetUnobservableStates<2, 1>(A3, C1)),
+              testing::ElementsAre(0));
+  EXPECT_THAT((frc::GetUnobservableStates<2, 1>(A3, C2)),
+              testing::ElementsAre(1));
+
+  Eigen::Matrix<double, 2, 2> A4{{0.2, 0}, {0, 1.2}};
+  EXPECT_THAT((frc::GetUnobservableStates<2, 1>(A4, C1)),
+              testing::ElementsAre(0));
+  EXPECT_THAT((frc::GetUnobservableStates<2, 1>(A4, C2)),
+              testing::ElementsAre(1));
 }


### PR DESCRIPTION
If uncontrollable or unobservable states are detected, the exception
body will contain the uncontrollable/unobservable model as well as the
indices of those states.

Discretization tests were removed from StateSpaceUtilTest.java because
those are already performed in DiscretizationTest.java.

Fixes #3677.