### PR TITLE
[wpimath] Fix classpaths for JNI class loads

### DIFF
--- a/wpimath/src/main/native/cpp/jni/WPIMathJNI.cpp
+++ b/wpimath/src/main/native/cpp/jni/WPIMathJNI.cpp
@@ -273,7 +273,7 @@ Java_edu_wpi_first_math_WPIMathJNI_deserializeTrajectory
     return MakeJDoubleArray(env, elements);
   } catch (std::exception& e) {
     jclass cls = env->FindClass(
-        "edu/wpi/first/wpilibj/trajectory/TrajectoryUtil$"
+        "edu/wpi/first/math/trajectory/TrajectoryUtil$"
         "TrajectorySerializationException");
     if (cls) {
       env->ThrowNew(cls, e.what());
@@ -298,7 +298,7 @@ Java_edu_wpi_first_math_WPIMathJNI_serializeTrajectory
                        frc::TrajectoryUtil::SerializeTrajectory(trajectory));
   } catch (std::exception& e) {
     jclass cls = env->FindClass(
-        "edu/wpi/first/wpilibj/trajectory/TrajectoryUtil$"
+        "edu/wpi/first/math/trajectory/TrajectoryUtil$"
         "TrajectorySerializationException");
     if (cls) {
       env->ThrowNew(cls, e.what());


### PR DESCRIPTION
I found these by inspecting the results of the following rg commands:
`rg --multiline 'FindClass\(\s*"'`
`rg 'JClass' -A 1`

Fixes #3660.