### PR TITLE
[wpilibcExamples] Make GearsBot use idiomatic C++

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/RobotContainer.cpp
@@ -16,7 +16,7 @@
 #include "commands/TankDrive.h"
 
 RobotContainer::RobotContainer()
-    : m_autonomousCommand(&m_claw, &m_wrist, &m_elevator, &m_drivetrain) {
+    : m_autonomousCommand(m_claw, m_wrist, m_elevator, m_drivetrain) {
   frc::SmartDashboard::PutData(&m_drivetrain);
   frc::SmartDashboard::PutData(&m_elevator);
   frc::SmartDashboard::PutData(&m_wrist);
@@ -24,7 +24,7 @@ RobotContainer::RobotContainer()
 
   m_drivetrain.SetDefaultCommand(TankDrive([this] { return m_joy.GetLeftY(); },
                                            [this] { return m_joy.GetRightY(); },
-                                           &m_drivetrain));
+                                           m_drivetrain));
 
   // Configure the button bindings
   ConfigureButtonBindings();
@@ -33,19 +33,19 @@ RobotContainer::RobotContainer()
 void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
   frc2::JoystickButton(&m_joy, 5).WhenPressed(
-      SetElevatorSetpoint(0.25, &m_elevator));
-  frc2::JoystickButton(&m_joy, 6).WhenPressed(CloseClaw(&m_claw));
+      SetElevatorSetpoint(0.25, m_elevator));
+  frc2::JoystickButton(&m_joy, 6).WhenPressed(CloseClaw(m_claw));
   frc2::JoystickButton(&m_joy, 7).WhenPressed(
-      SetElevatorSetpoint(0.0, &m_elevator));
-  frc2::JoystickButton(&m_joy, 8).WhenPressed(OpenClaw(&m_claw));
+      SetElevatorSetpoint(0.0, m_elevator));
+  frc2::JoystickButton(&m_joy, 8).WhenPressed(OpenClaw(m_claw));
   frc2::JoystickButton(&m_joy, 9).WhenPressed(
-      Autonomous(&m_claw, &m_wrist, &m_elevator, &m_drivetrain));
+      Autonomous(m_claw, m_wrist, m_elevator, m_drivetrain));
   frc2::JoystickButton(&m_joy, 10)
-      .WhenPressed(Pickup(&m_claw, &m_wrist, &m_elevator));
+      .WhenPressed(Pickup(m_claw, m_wrist, m_elevator));
   frc2::JoystickButton(&m_joy, 11)
-      .WhenPressed(Place(&m_claw, &m_wrist, &m_elevator));
+      .WhenPressed(Place(m_claw, m_wrist, m_elevator));
   frc2::JoystickButton(&m_joy, 12)
-      .WhenPressed(PrepareToPickup(&m_claw, &m_wrist, &m_elevator));
+      .WhenPressed(PrepareToPickup(m_claw, m_wrist, m_elevator));
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/Autonomous.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/Autonomous.cpp
@@ -14,8 +14,8 @@
 #include "commands/SetDistanceToBox.h"
 #include "commands/SetWristSetpoint.h"
 
-Autonomous::Autonomous(Claw* claw, Wrist* wrist, Elevator* elevator,
-                       Drivetrain* drivetrain) {
+Autonomous::Autonomous(Claw& claw, Wrist& wrist, Elevator& elevator,
+                       Drivetrain& drivetrain) {
   SetName("Autonomous");
   AddCommands(
       // clang-format off

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/CloseClaw.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/CloseClaw.cpp
@@ -6,7 +6,7 @@
 
 #include "Robot.h"
 
-CloseClaw::CloseClaw(Claw* claw) : m_claw(claw) {
+CloseClaw::CloseClaw(Claw& claw) : m_claw(&claw) {
   SetName("CloseClaw");
   AddRequirements({m_claw});
 }

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/DriveStraight.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/DriveStraight.cpp
@@ -8,13 +8,13 @@
 
 #include "Robot.h"
 
-DriveStraight::DriveStraight(double distance, Drivetrain* drivetrain)
+DriveStraight::DriveStraight(double distance, Drivetrain& drivetrain)
     : frc2::CommandHelper<frc2::PIDCommand, DriveStraight>(
           frc2::PIDController(4, 0, 0),
-          [drivetrain] { return drivetrain->GetDistance(); }, distance,
-          [drivetrain](double output) { drivetrain->Drive(output, output); },
-          {drivetrain}),
-      m_drivetrain(drivetrain) {
+          [&drivetrain] { return drivetrain.GetDistance(); }, distance,
+          [&drivetrain](double output) { drivetrain.Drive(output, output); },
+          {&drivetrain}),
+      m_drivetrain(&drivetrain) {
   m_controller.SetTolerance(0.01);
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/OpenClaw.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/OpenClaw.cpp
@@ -6,8 +6,8 @@
 
 #include "Robot.h"
 
-OpenClaw::OpenClaw(Claw* claw)
-    : frc2::CommandHelper<frc2::WaitCommand, OpenClaw>(1_s), m_claw(claw) {
+OpenClaw::OpenClaw(Claw& claw)
+    : frc2::CommandHelper<frc2::WaitCommand, OpenClaw>(1_s), m_claw(&claw) {
   SetName("OpenClaw");
   AddRequirements({m_claw});
 }

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/Pickup.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/Pickup.cpp
@@ -10,7 +10,7 @@
 #include "commands/SetElevatorSetpoint.h"
 #include "commands/SetWristSetpoint.h"
 
-Pickup::Pickup(Claw* claw, Wrist* wrist, Elevator* elevator) {
+Pickup::Pickup(Claw& claw, Wrist& wrist, Elevator& elevator) {
   SetName("Pickup");
   AddCommands(CloseClaw(claw),
               frc2::ParallelCommandGroup(SetWristSetpoint(-45, wrist),

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/Place.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/Place.cpp
@@ -8,7 +8,7 @@
 #include "commands/SetElevatorSetpoint.h"
 #include "commands/SetWristSetpoint.h"
 
-Place::Place(Claw* claw, Wrist* wrist, Elevator* elevator) {
+Place::Place(Claw& claw, Wrist& wrist, Elevator& elevator) {
   SetName("Place");
   // clang-format off
   AddCommands(SetElevatorSetpoint(0.25, elevator),

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/PrepareToPickup.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/PrepareToPickup.cpp
@@ -10,7 +10,7 @@
 #include "commands/SetElevatorSetpoint.h"
 #include "commands/SetWristSetpoint.h"
 
-PrepareToPickup::PrepareToPickup(Claw* claw, Wrist* wrist, Elevator* elevator) {
+PrepareToPickup::PrepareToPickup(Claw& claw, Wrist& wrist, Elevator& elevator) {
   SetName("PrepareToPickup");
   AddCommands(OpenClaw(claw),
               frc2::ParallelCommandGroup(SetElevatorSetpoint(0, elevator),

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetDistanceToBox.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetDistanceToBox.cpp
@@ -8,14 +8,14 @@
 
 #include "Robot.h"
 
-SetDistanceToBox::SetDistanceToBox(double distance, Drivetrain* drivetrain)
+SetDistanceToBox::SetDistanceToBox(double distance, Drivetrain& drivetrain)
     : frc2::CommandHelper<frc2::PIDCommand, SetDistanceToBox>(
           frc2::PIDController(-2, 0, 0),
-          [drivetrain] { return drivetrain->GetDistanceToObstacle(); },
+          [&drivetrain] { return drivetrain.GetDistanceToObstacle(); },
           distance,
-          [drivetrain](double output) { drivetrain->Drive(output, output); },
-          {drivetrain}),
-      m_drivetrain(drivetrain) {
+          [&drivetrain](double output) { drivetrain.Drive(output, output); },
+          {&drivetrain}),
+      m_drivetrain(&drivetrain) {
   m_controller.SetTolerance(0.01);
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetElevatorSetpoint.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetElevatorSetpoint.cpp
@@ -8,8 +8,8 @@
 
 #include "Robot.h"
 
-SetElevatorSetpoint::SetElevatorSetpoint(double setpoint, Elevator* elevator)
-    : m_setpoint(setpoint), m_elevator(elevator) {
+SetElevatorSetpoint::SetElevatorSetpoint(double setpoint, Elevator& elevator)
+    : m_setpoint(setpoint), m_elevator(&elevator) {
   SetName("SetElevatorSetpoint");
   AddRequirements({m_elevator});
 }

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetWristSetpoint.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetWristSetpoint.cpp
@@ -6,8 +6,8 @@
 
 #include "Robot.h"
 
-SetWristSetpoint::SetWristSetpoint(double setpoint, Wrist* wrist)
-    : m_setpoint(setpoint), m_wrist(wrist) {
+SetWristSetpoint::SetWristSetpoint(double setpoint, Wrist& wrist)
+    : m_setpoint(setpoint), m_wrist(&wrist) {
   SetName("SetWristSetpoint");
   AddRequirements({m_wrist});
 }

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/TankDrive.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/TankDrive.cpp
@@ -9,10 +9,10 @@
 #include "Robot.h"
 
 TankDrive::TankDrive(std::function<double()> left,
-                     std::function<double()> right, Drivetrain* drivetrain)
+                     std::function<double()> right, Drivetrain& drivetrain)
     : m_left(std::move(left)),
       m_right(std::move(right)),
-      m_drivetrain(drivetrain) {
+      m_drivetrain(&drivetrain) {
   SetName("TankDrive");
   AddRequirements({m_drivetrain});
 }

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Claw.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Claw.cpp
@@ -24,7 +24,7 @@ void Claw::Stop() {
   m_motor.Set(0);
 }
 
-bool Claw::IsGripping() {
+bool Claw::IsGripping() const {
   return m_contact.Get();
 }
 

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Drivetrain.cpp
@@ -55,7 +55,7 @@ void Drivetrain::Drive(double left, double right) {
   m_robotDrive.TankDrive(left, right);
 }
 
-double Drivetrain::GetHeading() {
+double Drivetrain::GetHeading() const {
   return m_gyro.GetAngle();
 }
 
@@ -65,11 +65,11 @@ void Drivetrain::Reset() {
   m_rightEncoder.Reset();
 }
 
-double Drivetrain::GetDistance() {
+double Drivetrain::GetDistance() const {
   return (m_leftEncoder.GetDistance() + m_rightEncoder.GetDistance()) / 2.0;
 }
 
-double Drivetrain::GetDistanceToObstacle() {
+double Drivetrain::GetDistanceToObstacle() const {
   // Really meters in simulation since it's a rangefinder...
   return m_rangefinder.GetAverageVoltage();
 }

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Wrist.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Wrist.cpp
@@ -7,10 +7,7 @@
 #include <frc/controller/PIDController.h>
 #include <frc/smartdashboard/SmartDashboard.h>
 
-Wrist::Wrist() : frc2::PIDSubsystem(frc2::PIDController(kP_real, 0, 0)) {
-#ifdef SIMULATION  // Check for simulation and update PID values
-  GetPIDController()->SetPID(kP_simulation, 0, 0, 0);
-#endif
+Wrist::Wrist() : frc2::PIDSubsystem(frc2::PIDController(kP, 0, 0)) {
   m_controller.SetTolerance(2.5);
 
   SetName("Wrist");

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/Autonomous.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/Autonomous.h
@@ -18,6 +18,6 @@
 class Autonomous
     : public frc2::CommandHelper<frc2::SequentialCommandGroup, Autonomous> {
  public:
-  Autonomous(Claw* claw, Wrist* wrist, Elevator* elevator,
-             Drivetrain* drivetrain);
+  Autonomous(Claw& claw, Wrist& wrist, Elevator& elevator,
+             Drivetrain& drivetrain);
 };

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/CloseClaw.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/CloseClaw.h
@@ -14,7 +14,7 @@
  */
 class CloseClaw : public frc2::CommandHelper<frc2::CommandBase, CloseClaw> {
  public:
-  explicit CloseClaw(Claw* claw);
+  explicit CloseClaw(Claw& claw);
   void Initialize() override;
   bool IsFinished() override;
   void End(bool interrupted) override;

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/DriveStraight.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/DriveStraight.h
@@ -18,7 +18,7 @@
 class DriveStraight
     : public frc2::CommandHelper<frc2::PIDCommand, DriveStraight> {
  public:
-  explicit DriveStraight(double distance, Drivetrain* drivetrain);
+  explicit DriveStraight(double distance, Drivetrain& drivetrain);
   void Initialize() override;
   bool IsFinished() override;
 

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/OpenClaw.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/OpenClaw.h
@@ -15,7 +15,7 @@
  */
 class OpenClaw : public frc2::CommandHelper<frc2::WaitCommand, OpenClaw> {
  public:
-  explicit OpenClaw(Claw* claw);
+  explicit OpenClaw(Claw& claw);
   void Initialize() override;
   void End(bool interrupted) override;
 

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/Pickup.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/Pickup.h
@@ -18,5 +18,5 @@
 class Pickup
     : public frc2::CommandHelper<frc2::SequentialCommandGroup, Pickup> {
  public:
-  Pickup(Claw* claw, Wrist* wrist, Elevator* elevator);
+  Pickup(Claw& claw, Wrist& wrist, Elevator& elevator);
 };

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/Place.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/Place.h
@@ -16,5 +16,5 @@
  */
 class Place : public frc2::CommandHelper<frc2::SequentialCommandGroup, Place> {
  public:
-  Place(Claw* claw, Wrist* wrist, Elevator* elevator);
+  Place(Claw& claw, Wrist& wrist, Elevator& elevator);
 };

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/PrepareToPickup.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/PrepareToPickup.h
@@ -17,5 +17,5 @@
 class PrepareToPickup : public frc2::CommandHelper<frc2::SequentialCommandGroup,
                                                    PrepareToPickup> {
  public:
-  PrepareToPickup(Claw* claw, Wrist* wrist, Elevator* elevator);
+  PrepareToPickup(Claw& claw, Wrist& wrist, Elevator& elevator);
 };

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/SetDistanceToBox.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/SetDistanceToBox.h
@@ -18,7 +18,7 @@
 class SetDistanceToBox
     : public frc2::CommandHelper<frc2::PIDCommand, SetDistanceToBox> {
  public:
-  explicit SetDistanceToBox(double distance, Drivetrain* drivetrain);
+  explicit SetDistanceToBox(double distance, Drivetrain& drivetrain);
   void Initialize() override;
   bool IsFinished() override;
 

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/SetElevatorSetpoint.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/SetElevatorSetpoint.h
@@ -19,7 +19,7 @@
 class SetElevatorSetpoint
     : public frc2::CommandHelper<frc2::CommandBase, SetElevatorSetpoint> {
  public:
-  explicit SetElevatorSetpoint(double setpoint, Elevator* elevator);
+  explicit SetElevatorSetpoint(double setpoint, Elevator& elevator);
   void Initialize() override;
   bool IsFinished() override;
 

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/SetWristSetpoint.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/SetWristSetpoint.h
@@ -17,7 +17,7 @@
 class SetWristSetpoint
     : public frc2::CommandHelper<frc2::CommandBase, SetWristSetpoint> {
  public:
-  explicit SetWristSetpoint(double setpoint, Wrist* wrist);
+  explicit SetWristSetpoint(double setpoint, Wrist& wrist);
   void Initialize() override;
   bool IsFinished() override;
 

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/TankDrive.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/commands/TankDrive.h
@@ -15,7 +15,7 @@
 class TankDrive : public frc2::CommandHelper<frc2::CommandBase, TankDrive> {
  public:
   TankDrive(std::function<double()> left, std::function<double()> right,
-            Drivetrain* drivetrain);
+            Drivetrain& drivetrain);
   void Execute() override;
   bool IsFinished() override;
   void End(bool interrupted) override;

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Claw.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Claw.h
@@ -36,7 +36,7 @@ class Claw : public frc2::SubsystemBase {
    * Return true when the robot is grabbing an object hard enough
    * to trigger the limit switch.
    */
-  bool IsGripping();
+  bool IsGripping() const;
 
   /**
    * The log method puts interesting information to the SmartDashboard.

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Drivetrain.h
@@ -40,7 +40,7 @@ class Drivetrain : public frc2::SubsystemBase {
   /**
    * @return The robots heading in degrees.
    */
-  double GetHeading();
+  double GetHeading() const;
 
   /**
    * Reset the robots sensors to the zero states.
@@ -50,12 +50,12 @@ class Drivetrain : public frc2::SubsystemBase {
   /**
    * @return The distance driven (average of left and right encoders).
    */
-  double GetDistance();
+  double GetDistance() const;
 
   /**
    * @return The distance to the obstacle detected by the rangefinder.
    */
-  double GetDistanceToObstacle();
+  double GetDistanceToObstacle() const;
 
   /**
    * Log the data periodically. This method is automatically called

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Wrist.h
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/include/subsystems/Wrist.h
@@ -51,6 +51,5 @@ class Wrist : public frc2::PIDSubsystem {
   frc::AnalogPotentiometer m_pot{3};  // Defaults to degrees
 #endif
 
-  static constexpr double kP_real = 1;
-  static constexpr double kP_simulation = 0.05;
+  static constexpr double kP = 1;
 };

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Wrist.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Wrist.java
@@ -18,15 +18,11 @@ public class Wrist extends PIDSubsystem {
   private final Victor m_motor;
   private final AnalogPotentiometer m_pot;
 
-  private static final double kP_real = 1;
-  private static final double kP_simulation = 0.05;
+  private static final double kP = 1;
 
   /** Create a new wrist subsystem. */
   public Wrist() {
-    super(new PIDController(kP_real, 0, 0));
-    if (Robot.isSimulation()) { // Check for simulation and update PID values
-      getController().setPID(kP_simulation, 0, 0);
-    }
+    super(new PIDController(kP, 0, 0));
     getController().setTolerance(2.5);
 
     m_motor = new Victor(6);


### PR DESCRIPTION
Replace pointer constructor arguments with references, and const qualify
getters where possible.

Also remove redundant simulation P gain.

Fixes #1146.