### PR TITLE
Remove use of getDmaDescriptor from autospi

### DIFF
--- a/hal/src/main/native/athena/SPI.cpp
+++ b/hal/src/main/native/athena/SPI.cpp
@@ -496,7 +496,7 @@ void HAL_InitSPIAuto(HAL_SPIPort port, int32_t bufferSize, int32_t* status) {
   }
 
   // configure DMA
-  spiAutoDMA = 
+  spiAutoDMA =
       std::make_unique<tDMAManager>(g_SpiAutoData_index, bufferSize, status);
 }
 

--- a/hal/src/main/native/athena/SPI.cpp
+++ b/hal/src/main/native/athena/SPI.cpp
@@ -496,7 +496,8 @@ void HAL_InitSPIAuto(HAL_SPIPort port, int32_t bufferSize, int32_t* status) {
   }
 
   // configure DMA
-  spiAutoDMA = std::make_unique<tDMAManager>(g_SpiAutoData_index, bufferSize, status);
+  spiAutoDMA = 
+      std::make_unique<tDMAManager>(g_SpiAutoData_index, bufferSize, status);
 }
 
 void HAL_FreeSPIAuto(HAL_SPIPort port, int32_t* status) {

--- a/hal/src/main/native/athena/SPI.cpp
+++ b/hal/src/main/native/athena/SPI.cpp
@@ -496,9 +496,7 @@ void HAL_InitSPIAuto(HAL_SPIPort port, int32_t bufferSize, int32_t* status) {
   }
 
   // configure DMA
-  tDMAChannelDescriptor desc;
-  spiSystem->getSystemInterface()->getDmaDescriptor(g_SpiAutoData_index, &desc);
-  spiAutoDMA = std::make_unique<tDMAManager>(desc.channel, bufferSize, status);
+  spiAutoDMA = std::make_unique<tDMAManager>(g_SpiAutoData_index, bufferSize, status);
 }
 
 void HAL_FreeSPIAuto(HAL_SPIPort port, int32_t* status) {


### PR DESCRIPTION
It's a virtual in chipobject, so at risk of breaking. SIt's not necessary, as the index equals the channel