### PR TITLE
[wpilibc] Make SPI destructor virtual since SPI contains virtual functions

### DIFF
--- a/wpilibc/src/main/native/include/frc/SPI.h
+++ b/wpilibc/src/main/native/include/frc/SPI.h
@@ -35,7 +35,7 @@ class SPI {
    */
   explicit SPI(Port port);
 
-  ~SPI();
+  virtual ~SPI();
 
   SPI(SPI&&) = default;
   SPI& operator=(SPI&&) = default;


### PR DESCRIPTION
```
/home/tav/git/calcmogul/Robot-2020/src/main/cpp/adi/ADIS16470_IMU.cpp: In member function ‘void frc::ADIS16470_IMU::Close()’:
/home/tav/git/calcmogul/Robot-2020/src/main/cpp/adi/ADIS16470_IMU.cpp:427:3: error: deleting object of polymorphic class type ‘frc::SPI’ which has non-virtual destructor might cause undefined behavior [-Werror=delete-non-virtual-dtor]
  427 |   delete m_spi;
      |   ^~~~~~~~~~~~
```