### PR TITLE
Remove automatic pd type from module type enum

### DIFF
--- a/wpilibc/src/main/native/cpp/PowerDistribution.cpp
+++ b/wpilibc/src/main/native/cpp/PowerDistribution.cpp
@@ -31,8 +31,9 @@ PowerDistribution::PowerDistribution() {
 
   int32_t status = 0;
   m_handle = HAL_InitializePowerDistribution(
-      kDefaultModule, HAL_PowerDistributionType::HAL_PowerDistributionType_kAutomatic, stack.c_str(),
-      &status);
+      kDefaultModule,
+      HAL_PowerDistributionType::HAL_PowerDistributionType_kAutomatic,
+      stack.c_str(), &status);
   FRC_CheckErrorStatus(status, "Module {}", kDefaultModule);
   m_module = HAL_GetPowerDistributionModuleNumber(m_handle, &status);
   FRC_ReportError(status, "Module {}", m_module);

--- a/wpilibc/src/main/native/include/frc/PowerDistribution.h
+++ b/wpilibc/src/main/native/include/frc/PowerDistribution.h
@@ -18,7 +18,7 @@ class PowerDistribution : public wpi::Sendable,
                           public wpi::SendableHelper<PowerDistribution> {
  public:
   static constexpr int kDefaultModule = -1;
-  enum class ModuleType { kAutomatic = 0, kCTRE = 1, kRev = 2 };
+  enum class ModuleType { kCTRE = 1, kRev = 2 };
 
   /**
    * Constructs a PowerDistribution.

--- a/wpilibc/src/main/native/include/frc/PowerDistribution.h
+++ b/wpilibc/src/main/native/include/frc/PowerDistribution.h
@@ -23,7 +23,7 @@ class PowerDistribution : public wpi::Sendable,
   /**
    * Constructs a PowerDistribution.
    *
-   * Uses the default CAN ID.
+   * Uses the default CAN ID (0 for CTRE and 1 for REV).
    */
   PowerDistribution();
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistribution.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistribution.java
@@ -49,7 +49,7 @@ public class PowerDistribution implements Sendable, AutoCloseable {
   /**
    * Constructs a PowerDistribution.
    *
-   * <p>Uses the default CAN ID.
+   * <p>Uses the default CAN ID (0 for CTRE and 1 for REV).
    */
   public PowerDistribution() {
     m_handle = PowerDistributionJNI.initialize(kDefaultModule, PowerDistributionJNI.AUTOMATIC_TYPE);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistribution.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PowerDistribution.java
@@ -22,7 +22,6 @@ public class PowerDistribution implements Sendable, AutoCloseable {
   public static final int kDefaultModule = PowerDistributionJNI.DEFAULT_MODULE;
 
   public enum ModuleType {
-    kAutomatic(PowerDistributionJNI.AUTOMATIC_TYPE),
     kCTRE(PowerDistributionJNI.CTRE_TYPE),
     kRev(PowerDistributionJNI.REV_TYPE);
 
@@ -37,7 +36,7 @@ public class PowerDistribution implements Sendable, AutoCloseable {
    * Constructs a PowerDistribution.
    *
    * @param module The CAN ID of the PDP.
-   * @param moduleType Module type (automatic, CTRE, or REV).
+   * @param moduleType Module type (CTRE or REV).
    */
   public PowerDistribution(int module, ModuleType moduleType) {
     m_handle = PowerDistributionJNI.initialize(module, moduleType.value);
@@ -53,7 +52,11 @@ public class PowerDistribution implements Sendable, AutoCloseable {
    * <p>Uses the default CAN ID.
    */
   public PowerDistribution() {
-    this(kDefaultModule, ModuleType.kAutomatic);
+    m_handle = PowerDistributionJNI.initialize(kDefaultModule, PowerDistributionJNI.AUTOMATIC_TYPE);
+    m_module = PowerDistributionJNI.getModuleNumber(m_handle);
+
+    HAL.report(tResourceType.kResourceType_PDP, m_module + 1);
+    SendableRegistry.addLW(this, "PowerDistribution", m_module);
   }
 
   @Override


### PR DESCRIPTION
Using automatic doesn't work with any module number, so the API is confusing