### PR TITLE
[glass, outlineviewer] Return 0 from WinMain

### DIFF
--- a/glass/src/app/native/cpp/main.cpp
+++ b/glass/src/app/native/cpp/main.cpp
@@ -215,4 +215,6 @@ int main() {
 
   glass::DestroyContext();
   gui::DestroyContext();
+
+  return 0;
 }

--- a/outlineviewer/src/main/native/cpp/main.cpp
+++ b/outlineviewer/src/main/native/cpp/main.cpp
@@ -221,4 +221,6 @@ int main() {
 
   glass::DestroyContext();
   gui::DestroyContext();
+
+  return 0;
 }


### PR DESCRIPTION
While this is implicit in main(), WinMain() requires an explicit return.