### PR TITLE
Switch MulticastResolver to a manual reset event, add way to read multiple

### DIFF
--- a/wpiutil/src/main/java/edu/wpi/first/util/MulticastServiceResolver.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/MulticastServiceResolver.java
@@ -38,7 +38,7 @@ public class MulticastServiceResolver implements AutoCloseable {
     return WPIUtilJNI.getMulticastServiceResolverEventHandle(m_handle);
   }
 
-  public ServiceData getData() {
+  public ServiceData[] getData() {
     return WPIUtilJNI.getMulticastServiceResolverData(m_handle);
   }
 }

--- a/wpiutil/src/main/java/edu/wpi/first/util/WPIUtilJNI.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/WPIUtilJNI.java
@@ -146,5 +146,5 @@ public final class WPIUtilJNI {
 
   public static native int getMulticastServiceResolverEventHandle(int handle);
 
-  public static native ServiceData getMulticastServiceResolverData(int handle);
+  public static native ServiceData[] getMulticastServiceResolverData(int handle);
 }

--- a/wpiutil/src/main/native/cpp/MulticastServiceResolver.cpp
+++ b/wpiutil/src/main/native/cpp/MulticastServiceResolver.cpp
@@ -63,72 +63,89 @@ WPI_EventHandle WPI_GetMulticastServiceResolverEventHandle(
   return resolver->GetEventHandle();
 }
 
-WPI_ServiceData* WPI_GetMulticastServiceResolverData(
-    WPI_MulticastServiceResolverHandle handle) {
-  wpi::MulticastServiceResolver::ServiceData data;
+WPI_ServiceData** WPI_GetMulticastServiceResolverData(
+    WPI_MulticastServiceResolverHandle handle, int32_t* dataCount) {
+  std::vector<wpi::MulticastServiceResolver::ServiceData> allData;
   {
     auto& manager = wpi::GetMulticastManager();
     std::scoped_lock lock{manager.mutex};
     auto& resolver = manager.resolvers[handle];
-    data = resolver->GetData();
+    allData = resolver->GetData();
   }
-  size_t allocSize = sizeof(WPI_ServiceData);
-  // Include space for hostName and serviceType (+ terminators)
-  allocSize += data.hostName.size() + data.serviceName.size() + 2;
+  if (allData.empty()) {
+    *dataCount = 0;
+    return nullptr;
+  }
+  size_t allocSize = sizeof(WPI_ServiceData) * allData.size();
+  allocSize += sizeof(WPI_ServiceData*) * allData.size();
 
-  size_t keysTotalLength = 0;
-  size_t valuesTotalLength = 0;
-  // Include space for all keys and values, and pointer array
-  for (auto&& t : data.txt) {
-    allocSize += sizeof(const char*);
-    keysTotalLength += (t.first.size() + 1);
-    allocSize += sizeof(const char*);
-    valuesTotalLength += (t.second.size() + 1);
+  for (auto&& data : allData) {
+      // Include space for hostName and serviceType (+ terminators)
+    allocSize += data.hostName.size() + data.serviceName.size() + 2;
+
+    size_t keysTotalLength = 0;
+    size_t valuesTotalLength = 0;
+    // Include space for all keys and values, and pointer array
+    for (auto&& t : data.txt) {
+      allocSize += sizeof(const char*);
+      keysTotalLength += (t.first.size() + 1);
+      allocSize += sizeof(const char*);
+      valuesTotalLength += (t.second.size() + 1);
+    }
+    allocSize += keysTotalLength;
+    allocSize += valuesTotalLength;
   }
-  allocSize += keysTotalLength;
-  allocSize += valuesTotalLength;
+
   uint8_t* cDataRaw = reinterpret_cast<uint8_t*>(wpi::safe_malloc(allocSize));
   if (!cDataRaw) {
     return nullptr;
   }
-  WPI_ServiceData* cData = reinterpret_cast<WPI_ServiceData*>(cDataRaw);
-  cData->ipv4Address = data.ipv4Address;
-  cData->port = data.port;
-  cData->txtCount = data.txt.size();
-  cDataRaw += sizeof(WPI_ServiceData);
+  WPI_ServiceData** rootArray = reinterpret_cast<WPI_ServiceData**>(cDataRaw);
+  cDataRaw += (sizeof(WPI_ServiceData*) + allData.size());
+  WPI_ServiceData** currentData = rootArray;
 
-  std::memcpy(cDataRaw, data.hostName.c_str(), data.hostName.size() + 1);
-  cData->hostName = reinterpret_cast<const char*>(cDataRaw);
-  cDataRaw += data.hostName.size() + 1;
+  for (auto&& data : allData) {
+    WPI_ServiceData* cData = reinterpret_cast<WPI_ServiceData*>(cDataRaw);
+    *currentData = cData;
+    currentData++;
+    cData->ipv4Address = data.ipv4Address;
+    cData->port = data.port;
+    cData->txtCount = data.txt.size();
+    cDataRaw += sizeof(WPI_ServiceData);
 
-  std::memcpy(cDataRaw, data.serviceName.c_str(), data.serviceName.size() + 1);
-  cData->serviceName = reinterpret_cast<const char*>(cDataRaw);
-  cDataRaw += data.serviceName.size() + 1;
+    std::memcpy(cDataRaw, data.hostName.c_str(), data.hostName.size() + 1);
+    cData->hostName = reinterpret_cast<const char*>(cDataRaw);
+    cDataRaw += data.hostName.size() + 1;
 
-  char** valuesPtrArr = reinterpret_cast<char**>(cDataRaw);
-  cDataRaw += (sizeof(char**) * data.txt.size());
-  char** keysPtrArr = reinterpret_cast<char**>(cDataRaw);
-  cDataRaw += (sizeof(char**) * data.txt.size());
+    std::memcpy(cDataRaw, data.serviceName.c_str(), data.serviceName.size() + 1);
+    cData->serviceName = reinterpret_cast<const char*>(cDataRaw);
+    cDataRaw += data.serviceName.size() + 1;
 
-  cData->txtKeys = const_cast<const char**>(keysPtrArr);
-  cData->txtValues = const_cast<const char**>(valuesPtrArr);
+    char** valuesPtrArr = reinterpret_cast<char**>(cDataRaw);
+    cDataRaw += (sizeof(char**) * data.txt.size());
+    char** keysPtrArr = reinterpret_cast<char**>(cDataRaw);
+    cDataRaw += (sizeof(char**) * data.txt.size());
 
-  for (size_t i = 0; i < data.txt.size(); i++) {
-    keysPtrArr[i] = reinterpret_cast<char*>(cDataRaw);
-    std::memcpy(keysPtrArr[i], data.txt[i].first.c_str(),
-                data.txt[i].first.size() + 1);
-    cDataRaw += (data.txt[i].first.size() + 1);
+    cData->txtKeys = const_cast<const char**>(keysPtrArr);
+    cData->txtValues = const_cast<const char**>(valuesPtrArr);
 
-    valuesPtrArr[i] = reinterpret_cast<char*>(cDataRaw);
-    std::memcpy(valuesPtrArr[i], data.txt[i].second.c_str(),
-                data.txt[i].second.size() + 1);
-    cDataRaw += (data.txt[i].second.size() + 1);
+    for (size_t i = 0; i < data.txt.size(); i++) {
+      keysPtrArr[i] = reinterpret_cast<char*>(cDataRaw);
+      std::memcpy(keysPtrArr[i], data.txt[i].first.c_str(),
+                  data.txt[i].first.size() + 1);
+      cDataRaw += (data.txt[i].first.size() + 1);
+
+      valuesPtrArr[i] = reinterpret_cast<char*>(cDataRaw);
+      std::memcpy(valuesPtrArr[i], data.txt[i].second.c_str(),
+                  data.txt[i].second.size() + 1);
+      cDataRaw += (data.txt[i].second.size() + 1);
+    }
   }
 
-  return cData;
+  return rootArray;
 }
 
-void WPI_FreeServiceData(WPI_ServiceData* serviceData) {
+void WPI_FreeServiceData(WPI_ServiceData** serviceData) {
   std::free(serviceData);
 }
 }  // extern "C"

--- a/wpiutil/src/main/native/cpp/MulticastServiceResolver.cpp
+++ b/wpiutil/src/main/native/cpp/MulticastServiceResolver.cpp
@@ -80,7 +80,7 @@ WPI_ServiceData** WPI_GetMulticastServiceResolverData(
   allocSize += sizeof(WPI_ServiceData*) * allData.size();
 
   for (auto&& data : allData) {
-      // Include space for hostName and serviceType (+ terminators)
+    // Include space for hostName and serviceType (+ terminators)
     allocSize += data.hostName.size() + data.serviceName.size() + 2;
 
     size_t keysTotalLength = 0;
@@ -117,7 +117,8 @@ WPI_ServiceData** WPI_GetMulticastServiceResolverData(
     cData->hostName = reinterpret_cast<const char*>(cDataRaw);
     cDataRaw += data.hostName.size() + 1;
 
-    std::memcpy(cDataRaw, data.serviceName.c_str(), data.serviceName.size() + 1);
+    std::memcpy(cDataRaw, data.serviceName.c_str(),
+                data.serviceName.size() + 1);
     cData->serviceName = reinterpret_cast<const char*>(cDataRaw);
     cDataRaw += data.serviceName.size() + 1;
 

--- a/wpiutil/src/main/native/cpp/jni/WPIUtilJNI.cpp
+++ b/wpiutil/src/main/native/cpp/jni/WPIUtilJNI.cpp
@@ -496,9 +496,13 @@ Java_edu_wpi_first_util_WPIUtilJNI_getMulticastServiceResolverData
                        "(JILjava/lang/String;Ljava/lang/String;[Ljava/lang/"
                        "String;[Ljava/lang/String;)V");
   auto& manager = wpi::GetMulticastManager();
-  std::scoped_lock lock{manager.mutex};
-  auto& resolver = manager.resolvers[handle];
-  auto data = resolver->GetData();
+  wpi::MulticastServiceResolver::ServiceData data;
+  {
+    std::scoped_lock lock{manager.mutex};
+    auto& resolver = manager.resolvers[handle];
+    data = resolver->GetData();
+  }
+
   JLocal<jstring> serviceName{env, MakeJString(env, data.serviceName)};
   JLocal<jstring> hostName{env, MakeJString(env, data.hostName)};
 

--- a/wpiutil/src/main/native/include/wpi/MulticastServiceResolver.h
+++ b/wpiutil/src/main/native/include/wpi/MulticastServiceResolver.h
@@ -9,8 +9,6 @@
 #ifdef __cplusplus
 #include <functional>
 #include <memory>
-#include <optional>
-#include <queue>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/wpiutil/src/main/native/include/wpi/MulticastServiceResolver.h
+++ b/wpiutil/src/main/native/include/wpi/MulticastServiceResolver.h
@@ -18,7 +18,6 @@
 
 #include "wpi/mutex.h"
 #include "wpi/span.h"
-
 namespace wpi {
 class MulticastServiceResolver {
  public:
@@ -33,7 +32,6 @@ class MulticastServiceResolver {
   };
   void Start();
   void Stop();
-
   WPI_EventHandle GetEventHandle() const { return event.GetHandle(); }
   ServiceData GetData() {
     std::scoped_lock lock{mutex};
@@ -44,7 +42,6 @@ class MulticastServiceResolver {
     }
     return item;
   }
-
   bool HasImplementation() const;
   struct Impl;
 
@@ -54,7 +51,6 @@ class MulticastServiceResolver {
     queue.push(std::forward<ServiceData>(data));
     event.Set();
   }
-
   wpi::Event event{true};
   std::queue<ServiceData> queue;
   mutable wpi::mutex mutex;

--- a/wpiutil/src/main/native/linux/MulticastServiceResolver.cpp
+++ b/wpiutil/src/main/native/linux/MulticastServiceResolver.cpp
@@ -18,9 +18,7 @@ struct MulticastServiceResolver::Impl {
   std::string serviceType;
   MulticastServiceResolver* resolver;
 
-  void onFound(ServiceData&& data) {
-    resolver->PushData(std::move(data));
-  }
+  void onFound(ServiceData&& data) { resolver->PushData(std::move(data)); }
 };
 
 MulticastServiceResolver::MulticastServiceResolver(

--- a/wpiutil/src/main/native/linux/MulticastServiceResolver.cpp
+++ b/wpiutil/src/main/native/linux/MulticastServiceResolver.cpp
@@ -18,7 +18,9 @@ struct MulticastServiceResolver::Impl {
   std::string serviceType;
   MulticastServiceResolver* resolver;
 
-  void onFound(ServiceData&& data) { resolver->PushData(std::move(data)); }
+  void onFound(ServiceData&& data) {
+    resolver->PushData(std::forward<ServiceData>(data));
+  }
 };
 
 MulticastServiceResolver::MulticastServiceResolver(

--- a/wpiutil/src/main/native/linux/MulticastServiceResolver.cpp
+++ b/wpiutil/src/main/native/linux/MulticastServiceResolver.cpp
@@ -19,8 +19,7 @@ struct MulticastServiceResolver::Impl {
   MulticastServiceResolver* resolver;
 
   void onFound(ServiceData&& data) {
-    resolver->eventQueue.push(std::move(data));
-    resolver->event.Set();
+    resolver->PushData(std::move(data));
   }
 };
 

--- a/wpiutil/src/main/native/macOS/MulticastServiceResolver.cpp
+++ b/wpiutil/src/main/native/macOS/MulticastServiceResolver.cpp
@@ -37,9 +37,7 @@ struct MulticastServiceResolver::Impl {
   std::vector<std::unique_ptr<DnsResolveState>> ResolveStates;
   DNSServiceRef serviceRef = nullptr;
 
-  void onFound(ServiceData&& data) {
-    resolver->PushData(std::move(data));
-  }
+  void onFound(ServiceData&& data) { resolver->PushData(std::move(data)); }
 };
 
 MulticastServiceResolver::MulticastServiceResolver(

--- a/wpiutil/src/main/native/macOS/MulticastServiceResolver.cpp
+++ b/wpiutil/src/main/native/macOS/MulticastServiceResolver.cpp
@@ -37,7 +37,9 @@ struct MulticastServiceResolver::Impl {
   std::vector<std::unique_ptr<DnsResolveState>> ResolveStates;
   DNSServiceRef serviceRef = nullptr;
 
-  void onFound(ServiceData&& data) { resolver->PushData(std::move(data)); }
+  void onFound(ServiceData&& data) {
+    resolver->PushData(std::forward<ServiceData>(data));
+  }
 };
 
 MulticastServiceResolver::MulticastServiceResolver(

--- a/wpiutil/src/main/native/macOS/MulticastServiceResolver.cpp
+++ b/wpiutil/src/main/native/macOS/MulticastServiceResolver.cpp
@@ -38,8 +38,7 @@ struct MulticastServiceResolver::Impl {
   DNSServiceRef serviceRef = nullptr;
 
   void onFound(ServiceData&& data) {
-    resolver->eventQueue.push(std::move(data));
-    resolver->event.Set();
+    resolver->PushData(std::move(data));
   }
 };
 

--- a/wpiutil/src/main/native/windows/MulticastServiceResolver.cpp
+++ b/wpiutil/src/main/native/windows/MulticastServiceResolver.cpp
@@ -27,9 +27,7 @@ struct MulticastServiceResolver::Impl {
 
   MulticastServiceResolver* resolver;
 
-  void onFound(ServiceData&& data) {
-    resolver->PushData(std::move(data));
-  }
+  void onFound(ServiceData&& data) { resolver->PushData(std::move(data)); }
 };
 
 MulticastServiceResolver::MulticastServiceResolver(

--- a/wpiutil/src/main/native/windows/MulticastServiceResolver.cpp
+++ b/wpiutil/src/main/native/windows/MulticastServiceResolver.cpp
@@ -27,7 +27,9 @@ struct MulticastServiceResolver::Impl {
 
   MulticastServiceResolver* resolver;
 
-  void onFound(ServiceData&& data) { resolver->PushData(std::move(data)); }
+  void onFound(ServiceData&& data) {
+    resolver->PushData(std::forward<ServiceData>(data));
+  }
 };
 
 MulticastServiceResolver::MulticastServiceResolver(

--- a/wpiutil/src/main/native/windows/MulticastServiceResolver.cpp
+++ b/wpiutil/src/main/native/windows/MulticastServiceResolver.cpp
@@ -28,8 +28,7 @@ struct MulticastServiceResolver::Impl {
   MulticastServiceResolver* resolver;
 
   void onFound(ServiceData&& data) {
-    resolver->eventQueue.push(std::move(data));
-    resolver->event.Set();
+    resolver->PushData(std::move(data));
   }
 };
 


### PR DESCRIPTION
Adding a way to read multiple items makes it so you'll never miss an event, but you also need manual reset to not accidentally trigger an empty event.