### PR TITLE
Don't recursively render frames

### DIFF
--- a/wpigui/src/main/native/cpp/wpigui.cpp
+++ b/wpigui/src/main/native/cpp/wpigui.cpp
@@ -34,7 +34,9 @@ static void WindowSizeCallback(GLFWwindow* window, int width, int height) {
     gContext->width = width;
     gContext->height = height;
   }
-  PlatformRenderFrame();
+  if (!gContext->isPlatformRendering) {
+    PlatformRenderFrame();
+  }
 }
 
 static void FramebufferSizeCallback(GLFWwindow* window, int width, int height) {
@@ -291,7 +293,9 @@ void gui::Main() {
   while (!glfwWindowShouldClose(gContext->window) && !gContext->exit) {
     // Poll and handle events (inputs, window resize, etc.)
     glfwPollEvents();
+    gContext->isPlatformRendering = true;
     PlatformRenderFrame();
+    gContext->isPlatformRendering = false;
 
     // custom saving
     if (gContext->saveSettings) {

--- a/wpigui/src/main/native/include/wpigui_internal.h
+++ b/wpigui/src/main/native/include/wpigui_internal.h
@@ -37,6 +37,7 @@ struct Context : public SavedSettings {
   std::string title;
   int defaultWidth;
   int defaultHeight;
+  bool isPlatformRendering{false};
 
   GLFWwindow* window = nullptr;
 


### PR DESCRIPTION
WindowSizeCallback can sometimes be called while doing a render. If this occurs, imgui asserts. Avoid this case