### PR TITLE
Use DS cache for iterative robot control word cache

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/ControlWord.java
+++ b/hal/src/main/java/edu/wpi/first/hal/ControlWord.java
@@ -28,6 +28,15 @@ public class ControlWord {
     m_dsAttached = dsAttached;
   }
 
+  public void update(ControlWord word) {
+    m_enabled = word.m_enabled;
+    m_autonomous = word.m_autonomous;
+    m_test = word.m_test;
+    m_emergencyStop = word.m_emergencyStop;
+    m_fmsAttached = word.m_fmsAttached;
+    m_dsAttached = word.m_dsAttached;
+  }
+
   public boolean getEnabled() {
     return m_enabled;
   }

--- a/hal/src/main/java/edu/wpi/first/hal/ControlWord.java
+++ b/hal/src/main/java/edu/wpi/first/hal/ControlWord.java
@@ -28,6 +28,11 @@ public class ControlWord {
     m_dsAttached = dsAttached;
   }
 
+  /**
+   * Updates from an existing word.
+   *
+   * @param word word to update from
+   */
   public void update(ControlWord word) {
     m_enabled = word.m_enabled;
     m_autonomous = word.m_autonomous;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DSControlWord.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DSControlWord.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.ControlWord;
-import edu.wpi.first.hal.HAL;
 
 /** A wrapper around Driver Station control word. */
 public class DSControlWord {
@@ -22,7 +21,7 @@ public class DSControlWord {
 
   /** Update internal Driver Station control word. */
   public void update() {
-    HAL.getControlWord(m_controlWord);
+    DriverStation.updateControlWordFromCache(m_controlWord);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -1324,6 +1324,11 @@ public class DriverStation {
     }
   }
 
+  /**
+   * Forces a control word cache update, and update the passed in control work.
+   *
+   * @param word Word to update.
+   */
   public static void updateControlWordFromCache(ControlWord word) {
     synchronized (m_controlWordMutex) {
       updateControlWord(true);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -758,7 +758,7 @@ public class DriverStation {
    */
   public static boolean isEnabled() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false, null);
+      updateControlWord(false);
       return m_controlWordCache.getEnabled() && m_controlWordCache.getDSAttached();
     }
   }
@@ -779,7 +779,7 @@ public class DriverStation {
    */
   public static boolean isEStopped() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false, null);
+      updateControlWord(false);
       return m_controlWordCache.getEStop();
     }
   }
@@ -792,7 +792,7 @@ public class DriverStation {
    */
   public static boolean isAutonomous() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false, null);
+      updateControlWord(false);
       return m_controlWordCache.getAutonomous();
     }
   }
@@ -805,7 +805,7 @@ public class DriverStation {
    */
   public static boolean isAutonomousEnabled() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false, null);
+      updateControlWord(false);
       return m_controlWordCache.getAutonomous() && m_controlWordCache.getEnabled();
     }
   }
@@ -852,7 +852,7 @@ public class DriverStation {
    */
   public static boolean isTeleopEnabled() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false, null);
+      updateControlWord(false);
       return !m_controlWordCache.getAutonomous()
           && !m_controlWordCache.getTest()
           && m_controlWordCache.getEnabled();
@@ -867,7 +867,7 @@ public class DriverStation {
    */
   public static boolean isTest() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false, null);
+      updateControlWord(false);
       return m_controlWordCache.getTest();
     }
   }
@@ -879,7 +879,7 @@ public class DriverStation {
    */
   public static boolean isDSAttached() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false, null);
+      updateControlWord(false);
       return m_controlWordCache.getDSAttached();
     }
   }
@@ -911,7 +911,7 @@ public class DriverStation {
    */
   public static boolean isFMSAttached() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false, null);
+      updateControlWord(false);
       return m_controlWordCache.getFMSAttached();
     }
   }
@@ -1228,7 +1228,7 @@ public class DriverStation {
     HAL.getMatchInfo(m_matchInfoCache);
 
     // Force a control word update, to make sure the data is the newest.
-    updateControlWord(true, null);
+    updateControlWord(true);
 
     // lock joystick mutex to swap cache data
     m_cacheDataMutex.lock();
@@ -1325,7 +1325,10 @@ public class DriverStation {
   }
 
   public static void updateControlWordFromCache(ControlWord word) {
-    updateControlWord(true, word);
+    synchronized (m_controlWordMutex) {
+      updateControlWord(true);
+      word.update(m_controlWordCache);
+    }
   }
 
   /**
@@ -1334,15 +1337,12 @@ public class DriverStation {
    *
    * @param force True to force an update to the cache, otherwise update if 50ms have passed.
    */
-  private static void updateControlWord(boolean force, ControlWord wordToUpdate) {
+  private static void updateControlWord(boolean force) {
     long now = System.currentTimeMillis();
     synchronized (m_controlWordMutex) {
       if (now - m_lastControlWordUpdate > 50 || force) {
         HAL.getControlWord(m_controlWordCache);
         m_lastControlWordUpdate = now;
-        if (wordToUpdate != null) {
-          wordToUpdate.update(m_controlWordCache);
-        }
       }
     }
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -758,7 +758,7 @@ public class DriverStation {
    */
   public static boolean isEnabled() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false);
+      updateControlWord(false, null);
       return m_controlWordCache.getEnabled() && m_controlWordCache.getDSAttached();
     }
   }
@@ -779,7 +779,7 @@ public class DriverStation {
    */
   public static boolean isEStopped() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false);
+      updateControlWord(false, null);
       return m_controlWordCache.getEStop();
     }
   }
@@ -792,7 +792,7 @@ public class DriverStation {
    */
   public static boolean isAutonomous() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false);
+      updateControlWord(false, null);
       return m_controlWordCache.getAutonomous();
     }
   }
@@ -805,7 +805,7 @@ public class DriverStation {
    */
   public static boolean isAutonomousEnabled() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false);
+      updateControlWord(false, null);
       return m_controlWordCache.getAutonomous() && m_controlWordCache.getEnabled();
     }
   }
@@ -852,7 +852,7 @@ public class DriverStation {
    */
   public static boolean isTeleopEnabled() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false);
+      updateControlWord(false, null);
       return !m_controlWordCache.getAutonomous()
           && !m_controlWordCache.getTest()
           && m_controlWordCache.getEnabled();
@@ -867,7 +867,7 @@ public class DriverStation {
    */
   public static boolean isTest() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false);
+      updateControlWord(false, null);
       return m_controlWordCache.getTest();
     }
   }
@@ -879,7 +879,7 @@ public class DriverStation {
    */
   public static boolean isDSAttached() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false);
+      updateControlWord(false, null);
       return m_controlWordCache.getDSAttached();
     }
   }
@@ -911,7 +911,7 @@ public class DriverStation {
    */
   public static boolean isFMSAttached() {
     synchronized (m_controlWordMutex) {
-      updateControlWord(false);
+      updateControlWord(false, null);
       return m_controlWordCache.getFMSAttached();
     }
   }
@@ -1228,7 +1228,7 @@ public class DriverStation {
     HAL.getMatchInfo(m_matchInfoCache);
 
     // Force a control word update, to make sure the data is the newest.
-    updateControlWord(true);
+    updateControlWord(true, null);
 
     // lock joystick mutex to swap cache data
     m_cacheDataMutex.lock();
@@ -1324,18 +1324,25 @@ public class DriverStation {
     }
   }
 
+  public static void updateControlWordFromCache(ControlWord word) {
+    updateControlWord(true, word);
+  }
+
   /**
    * Updates the data in the control word cache. Updates if the force parameter is set, or if 50ms
    * have passed since the last update.
    *
    * @param force True to force an update to the cache, otherwise update if 50ms have passed.
    */
-  private static void updateControlWord(boolean force) {
+  private static void updateControlWord(boolean force, ControlWord wordToUpdate) {
     long now = System.currentTimeMillis();
     synchronized (m_controlWordMutex) {
       if (now - m_lastControlWordUpdate > 50 || force) {
         HAL.getControlWord(m_controlWordCache);
         m_lastControlWordUpdate = now;
+        if (wordToUpdate != null) {
+          wordToUpdate.update(m_controlWordCache);
+        }
       }
     }
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -1325,7 +1325,7 @@ public class DriverStation {
   }
 
   /**
-   * Forces a control word cache update, and update the passed in control work.
+   * Forces a control word cache update, and update the passed in control word.
    *
    * @param word Word to update.
    */


### PR DESCRIPTION
The root cause of https://github.com/wpilibsuite/allwpilib/issues/3747 is CommandScheduler's ds state checks are behind iterative robots checks. This means that the iterative robot state could return enabled, but the DS cache could still be reporting disabled. This results in a race in the Disabled -> Enabled transition, which manifests in commands not running.

Previously, iterative robot base pulled from the DS cache. This meant that the ds cache was always updated before an iterative robot base loop could run. This still had a race, but this could only occur on the Enabled -> Disable transition, which is much less noticeable and would usually just result in a command running for an extra loop. 

We can move back to the old behavior by grabbing the new iterative robot base check variables to use the DS cache.