### PR TITLE
[wpilib] DutyCycleEncoder: add setting of duty cycle range

### DIFF
--- a/wpilibc/src/main/native/cpp/DutyCycleEncoder.cpp
+++ b/wpilibc/src/main/native/cpp/DutyCycleEncoder.cpp
@@ -89,6 +89,14 @@ units::turn_t DutyCycleEncoder::Get() const {
     auto counter2 = m_counter->Get();
     auto pos2 = m_dutyCycle->GetOutput();
     if (counter == counter2 && pos == pos2) {
+      // map sensor range
+      if (pos < m_sensorMin) {
+        pos = m_sensorMin;
+      }
+      if (pos > m_sensorMax) {
+        pos = m_sensorMax;
+      }
+      pos = (pos - m_sensorMin) / (m_sensorMax - m_sensorMin);
       units::turn_t turns{counter + pos - m_positionOffset};
       m_lastPosition = turns;
       return turns;
@@ -100,6 +108,11 @@ units::turn_t DutyCycleEncoder::Get() const {
       "Failed to read DutyCycle Encoder. Potential Speed Overrun. Returning "
       "last value");
   return m_lastPosition;
+}
+
+void DutyCycleEncoder::SetDutyCycleRange(double min, double max) {
+  m_sensorMin = std::clamp(min, 0.0, 1.0);
+  m_sensorMax = std::clamp(max, 0.0, 1.0);
 }
 
 void DutyCycleEncoder::SetDistancePerRotation(double distancePerRotation) {

--- a/wpilibc/src/main/native/include/frc/DutyCycleEncoder.h
+++ b/wpilibc/src/main/native/include/frc/DutyCycleEncoder.h
@@ -122,6 +122,21 @@ class DutyCycleEncoder : public wpi::Sendable,
   units::turn_t Get() const;
 
   /**
+   * Set the encoder duty cycle range. As the encoder needs to maintain a duty
+   * cycle, the duty cycle cannot go all the way to 0% or all the way to 100%.
+   * For example, an encoder with a 4096 us period might have a minimum duty
+   * cycle of 1 us / 4096 us and a maximum duty cycle of 4095 / 4096 us. Setting
+   * the range will result in an encoder duty cycle less than or equal to the
+   * minimum being output as 0 rotation, the duty cycle greater than or equal to
+   * the maximum being output as 1 rotation, and values in between linearly
+   * scaled from 0 to 1.
+   *
+   * @param min minimum duty cycle (0-1 range)
+   * @param max maximum duty cycle (0-1 range)
+   */
+  void SetDutyCycleRange(double min, double max);
+
+  /**
    * Set the distance per rotation of the encoder. This sets the multiplier used
    * to determine the distance driven based on the rotation value from the
    * encoder. Set this value based on the how far the mechanism travels in 1
@@ -175,6 +190,8 @@ class DutyCycleEncoder : public wpi::Sendable,
   double m_positionOffset = 0;
   double m_distancePerRotation = 1.0;
   mutable units::turn_t m_lastPosition{0.0};
+  double m_sensorMin = 0;
+  double m_sensorMax = 1;
 
   hal::SimDevice m_simDevice;
   hal::SimDouble m_simPosition;


### PR DESCRIPTION
As the sensor needs to maintain an actual duty cycle, it can't go all
the way from 0-100, so provide a way to set the min and max and linearly
map between the two.

Not sure if SetDutyCycleRange() is the best name, or SetSensorRange() might be better?

The default range is 0-1 so this is a non-breaking change.