### PR TITLE
Prevents crash when enabling autonomous mode in StateSpaceDifferentialDriveSim

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
@@ -57,7 +57,7 @@ frc2::Command* RobotContainer::GetAutonomousCommand() {
   frc::DifferentialDriveVoltageConstraint autoVoltageConstraint(
       frc::SimpleMotorFeedforward<units::meters>(
           DriveConstants::ks, DriveConstants::kv, DriveConstants::ka),
-      DriveConstants::kDriveKinematics, 10_V);
+      DriveConstants::kDriveKinematics, 12_V);
 
   // Set up config for trajectory
   frc::TrajectoryConfig config(AutoConstants::kMaxSpeed,

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
@@ -90,7 +90,7 @@ public class RobotContainer {
                 Constants.DriveConstants.kvVoltSecondsPerMeter,
                 Constants.DriveConstants.kaVoltSecondsSquaredPerMeter),
             Constants.DriveConstants.kDriveKinematics,
-            7);
+            12);
 
     // Create config for trajectory
     TrajectoryConfig config =


### PR DESCRIPTION
Increase DifferentialDriveVoltageConstraint to 12_V

Prevents a min acceleration greater than max acceleration crash
when enabling autonomous mode (at least, in sim)