### PR TITLE
Upgrade all maven deps to latest versions and fix new linter errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.hubspot.jinjava:jinjava:2.5.8'
+        classpath 'com.hubspot.jinjava:jinjava:2.6.0'
     }
 }
 
@@ -18,10 +18,10 @@ plugins {
     id 'edu.wpi.first.GradleVsCode'
     id 'idea'
     id 'visual-studio'
-    id 'net.ltgt.errorprone' version '1.1.1' apply false
-    id 'com.github.johnrengelman.shadow' version '5.2.0' apply false
-    id 'com.diffplug.spotless' version '5.5.0' apply false
-    id 'com.github.spotbugs' version '5.0.0-beta.1' apply false
+    id 'net.ltgt.errorprone' version '2.0.2' apply false
+    id 'com.github.johnrengelman.shadow' version '7.1.0' apply false
+    id 'com.diffplug.spotless' version '6.0.3' apply false
+    id 'com.github.spotbugs' version '5.0.0' apply false
 }
 
 wpilibVersioning.buildServerMode = project.hasProperty('buildServer')

--- a/cameraserver/multiCameraServer/build.gradle
+++ b/cameraserver/multiCameraServer/build.gradle
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.9'
 
     implementation project(':wpiutil')
     implementation project(':ntcore')

--- a/cameraserver/multiCameraServer/src/main/java/edu/wpi/Main.java
+++ b/cameraserver/multiCameraServer/src/main/java/edu/wpi/Main.java
@@ -56,9 +56,9 @@ public final class Main {
     public JsonObject config;
   }
 
-  static int team;
-  static boolean server;
-  static List<CameraConfig> cameras = new ArrayList<>();
+  private static int team;
+  private static boolean server;
+  private static List<CameraConfig> cameras = new ArrayList<>();
 
   private Main() {}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,8 @@
-org.gradle.jvmargs=-Xmx1g
+# The --add-exports flags work around a bug with spotless and JDK 17
+# https://github.com/diffplug/spotless/issues/834
+org.gradle.jvmargs=-Xmx1g \
+  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/hal/src/main/java/edu/wpi/first/hal/HAL.java
+++ b/hal/src/main/java/edu/wpi/first/hal/HAL.java
@@ -196,8 +196,8 @@ public final class HAL extends JNIWrapper {
   @SuppressWarnings("MissingJavadocMethod")
   public static native boolean waitForDSDataTimeout(double timeout);
 
-  public static int kMaxJoystickAxes = 12;
-  public static int kMaxJoystickPOVs = 12;
+  public static final int kMaxJoystickAxes = 12;
+  public static final int kMaxJoystickPOVs = 12;
 
   public static native short getJoystickAxes(byte joystickNum, float[] axesArray);
 

--- a/hal/src/main/java/edu/wpi/first/hal/can/CANExceptionFactory.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANExceptionFactory.java
@@ -14,10 +14,17 @@ public final class CANExceptionFactory {
   static final int ERR_CANSessionMux_NotAllowed = -44088;
   static final int ERR_CANSessionMux_NotInitialized = -44089;
 
-  @SuppressWarnings({"MissingJavadocMethod", "PMD.AvoidUncheckedExceptionsInSignatures"})
-  public static void checkStatus(int status, int messageID)
-      throws CANInvalidBufferException, CANMessageNotAllowedException, CANNotInitializedException,
-          UncleanStatusException {
+  /**
+   * Checks the status of a CAN message with the given message ID.
+   *
+   * @param status The CAN status.
+   * @param messageID The CAN message ID.
+   * @throws CANInvalidBufferException if the buffer is invalid.
+   * @throws CANMessageNotAllowedException if the message isn't allowed.
+   * @throws CANNotInitializedException if the CAN bus isn't initialized.
+   * @throws UncleanStatusException if the status code passed in reports an error.
+   */
+  public static void checkStatus(int status, int messageID) {
     switch (status) {
       case NIRioStatus.kRioStatusSuccess:
         // Everything is ok... don't throw.

--- a/hal/src/main/java/edu/wpi/first/hal/can/CANExceptionFactory.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANExceptionFactory.java
@@ -14,7 +14,7 @@ public final class CANExceptionFactory {
   static final int ERR_CANSessionMux_NotAllowed = -44088;
   static final int ERR_CANSessionMux_NotInitialized = -44089;
 
-  @SuppressWarnings("MissingJavadocMethod")
+  @SuppressWarnings({"MissingJavadocMethod", "PMD.AvoidUncheckedExceptionsInSignatures"})
   public static void checkStatus(int status, int messageID)
       throws CANInvalidBufferException, CANMessageNotAllowedException, CANNotInitializedException,
           UncleanStatusException {

--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -104,9 +104,9 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.4.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 
     devImplementation sourceSets.main.output
 }
@@ -120,7 +120,7 @@ task run(type: JavaExec) {
 build.dependsOn devClasses
 
 jacoco {
-    toolVersion = "0.8.4"
+    toolVersion = "0.8.7"
 }
 
 jacocoTestReport {

--- a/shared/java/javastyle.gradle
+++ b/shared/java/javastyle.gradle
@@ -2,7 +2,7 @@ if (!project.hasProperty('skipJavaFormat')) {
     apply plugin: 'checkstyle'
 
     checkstyle {
-        toolVersion = "8.38"
+        toolVersion = "9.2"
         configDirectory = file("${project.rootDir}/styleguide")
         config = resources.text.fromFile(new File(configDirectory.get().getAsFile(), "checkstyle.xml"))
     }
@@ -10,7 +10,7 @@ if (!project.hasProperty('skipJavaFormat')) {
     apply plugin: 'pmd'
 
     pmd {
-        toolVersion = '6.7.0'
+        toolVersion = '6.41.0'
         consoleOutput = true
         reportsDir = file("$project.buildDir/reports/pmd")
         ruleSetFiles = files(new File(rootDir, "styleguide/pmd-ruleset.xml"))

--- a/styleguide/checkstyle.xml
+++ b/styleguide/checkstyle.xml
@@ -266,7 +266,7 @@ module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
         value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF" />
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="public" />
+      <property name="accessModifiers" value="public" />
       <property name="allowMissingParamTags" value="true" />
       <property name="allowMissingReturnTag" value="true" />
       <property name="allowedAnnotations" value="Override, Test" />

--- a/styleguide/pmd-ruleset.xml
+++ b/styleguide/pmd-ruleset.xml
@@ -37,6 +37,7 @@
 
   <rule ref="category/java/design.xml">
     <exclude name="AvoidThrowingRawExceptionTypes" />
+    <exclude name="CognitiveComplexity" />
     <exclude name="CyclomaticComplexity" />
     <exclude name="DataClass" />
     <exclude name="ExcessiveClassLength" />
@@ -60,9 +61,10 @@
     <exclude name="AvoidDuplicateLiterals" />
     <exclude name="AvoidLiteralsInIfCondition" />
     <exclude name="BeanMembersShouldSerialize" />
+    <exclude name="CloseResource" />
     <exclude name="ConstructorCallsOverridableMethod" />
     <exclude name="DataflowAnomalyAnalysis" />
-    <exclude name="DoNotCallSystemExit" />
+    <exclude name="DoNotTerminateVM" />
     <exclude name="FinalizeDoesNotCallSuperFinalize" />
     <exclude name="JUnitSpelling" />
     <exclude name="MissingSerialVersionUID" />
@@ -83,8 +85,8 @@
 
   <rule name="UnnecessaryCastRule" language="java"
     message="Avoid unnecessary casts"
-    class="net.sourceforge.pmd.lang.java.rule.migrating.UnnecessaryCastRule"
-    externalInfoUrl="https://github.com/pmd/pmd/blob/master/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/migrating/UnnecessaryCastRule.java" />
+    class="net.sourceforge.pmd.lang.java.rule.codestyle.UnnecessaryCastRule"
+    externalInfoUrl="https://github.com/pmd/pmd/blob/master/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java" />
 
   <!-- Custom Rules -->
   <rule name="UseRequireNonNull"

--- a/styleguide/spotbugs-exclude.xml
+++ b/styleguide/spotbugs-exclude.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
   <Match>
+    <Bug pattern="DCN_NULLPOINTER_EXCEPTION" />
+    <Class name="edu.wpi.first.wpilibj.test.TestSuite" />
+  </Match>
+  <Match>
     <Bug pattern="DM_DEFAULT_ENCODING" />
   </Match>
   <Match>

--- a/wpilibNewCommands/build.gradle
+++ b/wpilibNewCommands/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     devImplementation project(':hal')
     devImplementation project(':wpimath')
     devImplementation project(':wpilibj')
-    testImplementation 'com.google.guava:guava:31.0.1-jre'
     testImplementation 'org.mockito:mockito-core:4.1.0'
 }
 

--- a/wpilibNewCommands/build.gradle
+++ b/wpilibNewCommands/build.gradle
@@ -26,8 +26,8 @@ dependencies {
     devImplementation project(':hal')
     devImplementation project(':wpimath')
     devImplementation project(':wpilibj')
-    testImplementation 'com.google.guava:guava:19.0'
-    testImplementation 'org.mockito:mockito-core:2.27.0'
+    testImplementation 'com.google.guava:guava:31.0.1-jre'
+    testImplementation 'org.mockito:mockito-core:4.1.0'
 }
 
 nativeUtils.exportsConfigs {

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -170,7 +170,7 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
     // Do nothing if the scheduler is disabled, the robot is disabled and the command doesn't
     // run when disabled, or the command is already scheduled.
     if (m_disabled
-        || (RobotState.isDisabled() && !command.runsWhenDisabled())
+        || RobotState.isDisabled() && !command.runsWhenDisabled()
         || m_scheduledCommands.containsKey(command)) {
       return;
     }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelDeadlineGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelDeadlineGroup.java
@@ -92,7 +92,7 @@ public class ParallelDeadlineGroup extends CommandGroupBase {
       if (commandRunning.getKey().isFinished()) {
         commandRunning.getKey().end(false);
         commandRunning.setValue(false);
-        if (commandRunning.getKey() == m_deadline) {
+        if (commandRunning.getKey().equals(m_deadline)) {
           m_finished = true;
         }
       }

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandTestBase.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandTestBase.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 
 /** Basic setup for all {@link Command tests}." */
-public abstract class CommandTestBase {
+public class CommandTestBase {
   protected CommandTestBase() {}
 
   @BeforeEach

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
@@ -639,8 +639,8 @@ public class PIDBase implements PIDInterface, PIDOutput, Sendable, AutoCloseable
    * number of iterations to average with setToleranceBuffer() (defaults to 1). getAvgError() is
    * used for the onTarget() function.
    *
-   * @deprecated Use getError(), which is now already filtered.
    * @return the current average of the error
+   * @deprecated Use getError(), which is now already filtered.
    */
   @Deprecated
   public double getAvgError() {
@@ -676,9 +676,9 @@ public class PIDBase implements PIDInterface, PIDOutput, Sendable, AutoCloseable
    * object. Use it by creating the type of tolerance that you want to use: setTolerance(new
    * PIDController.AbsoluteTolerance(0.1))
    *
-   * @deprecated Use setPercentTolerance() instead.
    * @param tolerance A tolerance object of the right type, e.g. PercentTolerance or
    *     AbsoluteTolerance
+   * @deprecated Use setPercentTolerance() instead.
    */
   @Deprecated
   public void setTolerance(Tolerance tolerance) {
@@ -721,8 +721,8 @@ public class PIDBase implements PIDInterface, PIDOutput, Sendable, AutoCloseable
    * erroneous measurements when the mechanism is on target. However, the mechanism will not
    * register as on target for at least the specified bufLength cycles.
    *
-   * @deprecated Use a LinearFilter as the input.
    * @param bufLength Number of previous cycles to average.
+   * @deprecated Use a LinearFilter as the input.
    */
   @Deprecated
   public void setToleranceBuffer(int bufLength) {

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/CommandGroup.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/command/CommandGroup.java
@@ -205,7 +205,7 @@ public class CommandGroup extends Command {
   }
 
   @Override
-  @SuppressWarnings("MethodName")
+  @SuppressWarnings({"MethodName", "PMD.AvoidReassigningLoopVariables"})
   void _execute() {
     Entry entry = null;
     Command cmd = null;
@@ -357,6 +357,7 @@ public class CommandGroup extends Command {
     return true;
   }
 
+  @SuppressWarnings("PMD.AvoidReassigningLoopVariables")
   private void cancelConflicts(Command command) {
     for (int i = 0; i < m_children.size(); i++) {
       Command child = m_children.elementAt(i).m_command;

--- a/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/command/AbstractCommandTest.java
+++ b/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/command/AbstractCommandTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.BeforeEach;
 
 /** The basic test for all {@link Command} tests. */
-public abstract class AbstractCommandTest {
+public class AbstractCommandTest {
   @BeforeEach
   void commandSetup() {
     Scheduler.getInstance().removeAll();

--- a/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/command/CommandSequentialGroupTest.java
+++ b/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/command/CommandSequentialGroupTest.java
@@ -16,7 +16,7 @@ class CommandSequentialGroupTest extends AbstractCommandTest {
    * timeout.
    */
   @Test
-  public void testThreeCommandOnSubSystem() {
+  void testThreeCommandOnSubSystem() {
     logger.fine("Beginning Test");
     final ASubsystem subsystem = new ASubsystem();
 

--- a/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/command/CommandSupersedeTest.java
+++ b/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/command/CommandSupersedeTest.java
@@ -60,12 +60,8 @@ class CommandSupersedeTest extends AbstractCommandTest {
   void commandFailingSupersedingBecauseFirstCanNotBeInterruptedTest() {
     final ASubsystem subsystem = new ASubsystem();
 
-    final MockCommand command1 =
-        new MockCommand(subsystem) {
-          {
-            setInterruptible(false);
-          }
-        };
+    final MockCommand command1 = new MockCommand(subsystem);
+    command1.setInterruptible(false);
 
     final MockCommand command2 = new MockCommand(subsystem);
 

--- a/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/command/DefaultCommandTest.java
+++ b/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/command/DefaultCommandTest.java
@@ -7,7 +7,7 @@ package edu.wpi.first.wpilibj.command;
 import org.junit.jupiter.api.Test;
 
 /** Tests the {@link Command} library. */
-public class DefaultCommandTest extends AbstractCommandTest {
+class DefaultCommandTest extends AbstractCommandTest {
   /** Testing of default commands where the interrupting command ends itself. */
   @Test
   void defaultCommandWhereTheInteruptingCommandEndsItselfTest() {

--- a/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTabTest.java
+++ b/wpilibOldCommands/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTabTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ShuffleboardTabTest {
+class ShuffleboardTabTest {
   private NetworkTableInstance m_ntInstance;
   private ShuffleboardTab m_tab;
   private ShuffleboardInstance m_instance;

--- a/wpilibj/build.gradle
+++ b/wpilibj/build.gradle
@@ -66,7 +66,6 @@ dependencies {
     implementation project(':ntcore')
     implementation project(':cscore')
     implementation project(':cameraserver')
-    testImplementation 'com.google.guava:guava:31.0.1-jre'
     testImplementation 'org.mockito:mockito-core:4.1.0'
     devImplementation project(':hal')
     devImplementation project(':wpiutil')

--- a/wpilibj/build.gradle
+++ b/wpilibj/build.gradle
@@ -66,8 +66,8 @@ dependencies {
     implementation project(':ntcore')
     implementation project(':cscore')
     implementation project(':cameraserver')
-    testImplementation 'com.google.guava:guava:19.0'
-    testImplementation 'org.mockito:mockito-core:2.27.0'
+    testImplementation 'com.google.guava:guava:31.0.1-jre'
+    testImplementation 'org.mockito:mockito-core:4.1.0'
     devImplementation project(':hal')
     devImplementation project(':wpiutil')
     devImplementation project(':wpimath')

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
@@ -33,30 +33,16 @@ public class Compressor implements Sendable, AutoCloseable {
    */
   public Compressor(int module, PneumaticsModuleType moduleType) {
     m_module = PneumaticsBase.getForType(module, moduleType);
-    boolean allocatedCompressor = false;
-    boolean successfulCompletion = false;
 
-    try {
-      if (!m_module.reserveCompressor()) {
-        throw new AllocationException("Compressor already allocated");
-      }
-
-      allocatedCompressor = true;
-
-      m_module.enableCompressorDigital();
-
-      HAL.report(tResourceType.kResourceType_Compressor, module + 1);
-      SendableRegistry.addLW(this, "Compressor", module);
-      successfulCompletion = true;
-
-    } finally {
-      if (!successfulCompletion) {
-        if (allocatedCompressor) {
-          m_module.unreserveCompressor();
-        }
-        m_module.close();
-      }
+    if (!m_module.reserveCompressor()) {
+      m_module.close();
+      throw new AllocationException("Compressor already allocated");
     }
+
+    m_module.enableCompressorDigital();
+
+    HAL.report(tResourceType.kResourceType_Compressor, module + 1);
+    SendableRegistry.addLW(this, "Compressor", module);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DoubleSolenoid.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DoubleSolenoid.java
@@ -53,6 +53,7 @@ public class DoubleSolenoid implements Sendable, AutoCloseable {
    * @param forwardChannel The forward channel on the module to control.
    * @param reverseChannel The reverse channel on the module to control.
    */
+  @SuppressWarnings("PMD.UseTryWithResources")
   public DoubleSolenoid(
       final int module,
       final PneumaticsModuleType moduleType,

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Notifier.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Notifier.java
@@ -99,7 +99,7 @@ public class Notifier implements AutoCloseable {
                   break;
                 }
 
-                Runnable handler = null;
+                Runnable handler;
                 m_processLock.lock();
                 try {
                   handler = m_handler;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -313,7 +313,7 @@ public abstract class RobotBase implements AutoCloseable {
   private static boolean m_suppressExitWarning;
 
   /** Run the robot main loop. */
-  @SuppressWarnings("PMD.AvoidCatchingThrowable")
+  @SuppressWarnings({"PMD.AvoidCatchingThrowable", "PMD.AvoidReassigningCatchVariables"})
   private static <T extends RobotBase> void runRobot(Supplier<T> robotSupplier) {
     System.out.println("********** Robot program starting **********");
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Solenoid.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Solenoid.java
@@ -41,35 +41,22 @@ public class Solenoid implements Sendable, AutoCloseable {
    */
   public Solenoid(final int module, final PneumaticsModuleType moduleType, final int channel) {
     m_module = PneumaticsBase.getForType(module, moduleType);
-    boolean allocatedSolenoids = false;
-    boolean successfulCompletion = false;
 
     m_mask = 1 << channel;
     m_channel = channel;
 
-    try {
-      if (!m_module.checkSolenoidChannel(channel)) {
-        throw new IllegalArgumentException("Channel " + channel + " out of range");
-      }
-
-      if (m_module.checkAndReserveSolenoids(m_mask) != 0) {
-        throw new AllocationException("Solenoid already allocated");
-      }
-
-      allocatedSolenoids = true;
-
-      HAL.report(tResourceType.kResourceType_Solenoid, channel + 1, m_module.getModuleNumber() + 1);
-      SendableRegistry.addLW(this, "Solenoid", m_module.getModuleNumber(), channel);
-      successfulCompletion = true;
-
-    } finally {
-      if (!successfulCompletion) {
-        if (allocatedSolenoids) {
-          m_module.unreserveSolenoids(m_mask);
-        }
-        m_module.close();
-      }
+    if (!m_module.checkSolenoidChannel(channel)) {
+      m_module.close();
+      throw new IllegalArgumentException("Channel " + channel + " out of range");
     }
+
+    if (m_module.checkAndReserveSolenoids(m_mask) != 0) {
+      m_module.close();
+      throw new AllocationException("Solenoid already allocated");
+    }
+
+    HAL.report(tResourceType.kResourceType_Solenoid, channel + 1, m_module.getModuleNumber() + 1);
+    SendableRegistry.addLW(this, "Solenoid", m_module.getModuleNumber(), channel);
   }
 
   @Override

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -325,8 +325,8 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
     xSpeed = MathUtil.clamp(xSpeed, -1.0, 1.0);
     zRotation = MathUtil.clamp(zRotation, -1.0, 1.0);
 
-    double leftSpeed = 0.0;
-    double rightSpeed = 0.0;
+    double leftSpeed;
+    double rightSpeed;
 
     if (allowTurnInPlace) {
       leftSpeed = xSpeed + zRotation;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ContainerHelper.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ContainerHelper.java
@@ -59,7 +59,7 @@ final class ContainerHelper {
     return widget;
   }
 
-  ComplexWidget add(Sendable sendable) throws IllegalArgumentException {
+  ComplexWidget add(Sendable sendable) {
     String name = SendableRegistry.getName(sendable);
     if (name.isEmpty()) {
       throw new IllegalArgumentException("Sendable must have a name");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
@@ -62,7 +62,7 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
    * @return the layout with the given title
    * @throws NoSuchElementException if no layout has yet been defined with the given title
    */
-  ShuffleboardLayout getLayout(String title) throws NoSuchElementException;
+  ShuffleboardLayout getLayout(String title);
 
   /**
    * Adds a widget to this container to display the given sendable.
@@ -73,7 +73,7 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
    * @throws IllegalArgumentException if a widget already exists in this container with the given
    *     title
    */
-  ComplexWidget add(String title, Sendable sendable) throws IllegalArgumentException;
+  ComplexWidget add(String title, Sendable sendable);
 
   /**
    * Adds a widget to this container to display the given video stream.
@@ -84,7 +84,7 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
    * @throws IllegalArgumentException if a widget already exists in this container with the given
    *     title
    */
-  default ComplexWidget add(String title, VideoSource video) throws IllegalArgumentException {
+  default ComplexWidget add(String title, VideoSource video) {
     return add(title, SendableCameraWrapper.wrap(video));
   }
 
@@ -120,7 +120,7 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
    *     title
    * @see #addPersistent(String, Object) add(String title, Object defaultValue)
    */
-  SimpleWidget add(String title, Object defaultValue) throws IllegalArgumentException;
+  SimpleWidget add(String title, Object defaultValue);
 
   /**
    * Adds a widget to this container. The widget will display the data provided by the value
@@ -133,8 +133,7 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
    * @throws IllegalArgumentException if a widget already exists in this container with the given
    *     title
    */
-  SuppliedValueWidget<String> addString(String title, Supplier<String> valueSupplier)
-      throws IllegalArgumentException;
+  SuppliedValueWidget<String> addString(String title, Supplier<String> valueSupplier);
 
   /**
    * Adds a widget to this container. The widget will display the data provided by the value
@@ -147,8 +146,7 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
    * @throws IllegalArgumentException if a widget already exists in this container with the given
    *     title
    */
-  SuppliedValueWidget<Double> addNumber(String title, DoubleSupplier valueSupplier)
-      throws IllegalArgumentException;
+  SuppliedValueWidget<Double> addNumber(String title, DoubleSupplier valueSupplier);
 
   /**
    * Adds a widget to this container. The widget will display the data provided by the value
@@ -161,8 +159,7 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
    * @throws IllegalArgumentException if a widget already exists in this container with the given
    *     title
    */
-  SuppliedValueWidget<Boolean> addBoolean(String title, BooleanSupplier valueSupplier)
-      throws IllegalArgumentException;
+  SuppliedValueWidget<Boolean> addBoolean(String title, BooleanSupplier valueSupplier);
 
   /**
    * Adds a widget to this container. The widget will display the data provided by the value
@@ -175,8 +172,7 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
    * @throws IllegalArgumentException if a widget already exists in this container with the given
    *     title
    */
-  SuppliedValueWidget<String[]> addStringArray(String title, Supplier<String[]> valueSupplier)
-      throws IllegalArgumentException;
+  SuppliedValueWidget<String[]> addStringArray(String title, Supplier<String[]> valueSupplier);
 
   /**
    * Adds a widget to this container. The widget will display the data provided by the value
@@ -189,8 +185,7 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
    * @throws IllegalArgumentException if a widget already exists in this container with the given
    *     title
    */
-  SuppliedValueWidget<double[]> addDoubleArray(String title, Supplier<double[]> valueSupplier)
-      throws IllegalArgumentException;
+  SuppliedValueWidget<double[]> addDoubleArray(String title, Supplier<double[]> valueSupplier);
 
   /**
    * Adds a widget to this container. The widget will display the data provided by the value
@@ -203,8 +198,7 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
    * @throws IllegalArgumentException if a widget already exists in this container with the given
    *     title
    */
-  SuppliedValueWidget<boolean[]> addBooleanArray(String title, Supplier<boolean[]> valueSupplier)
-      throws IllegalArgumentException;
+  SuppliedValueWidget<boolean[]> addBooleanArray(String title, Supplier<boolean[]> valueSupplier);
 
   /**
    * Adds a widget to this container. The widget will display the data provided by the value
@@ -217,8 +211,7 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
    * @throws IllegalArgumentException if a widget already exists in this container with the given
    *     title
    */
-  SuppliedValueWidget<byte[]> addRaw(String title, Supplier<byte[]> valueSupplier)
-      throws IllegalArgumentException;
+  SuppliedValueWidget<byte[]> addRaw(String title, Supplier<byte[]> valueSupplier);
 
   /**
    * Adds a widget to this container to display a simple piece of data. Unlike {@link #add(String,
@@ -232,8 +225,7 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
    *     title
    * @see #add(String, Object) add(String title, Object defaultValue)
    */
-  default SimpleWidget addPersistent(String title, Object defaultValue)
-      throws IllegalArgumentException {
+  default SimpleWidget addPersistent(String title, Object defaultValue) {
     SimpleWidget widget = add(title, defaultValue);
     widget.getEntry().setPersistent();
     return widget;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardLayout.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardLayout.java
@@ -9,7 +9,6 @@ import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.util.sendable.Sendable;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
@@ -34,64 +33,60 @@ public class ShuffleboardLayout extends ShuffleboardComponent<ShuffleboardLayout
   }
 
   @Override
-  public ShuffleboardLayout getLayout(String title) throws NoSuchElementException {
+  public ShuffleboardLayout getLayout(String title) {
     return m_helper.getLayout(title);
   }
 
   @Override
-  public ComplexWidget add(String title, Sendable sendable) throws IllegalArgumentException {
+  public ComplexWidget add(String title, Sendable sendable) {
     return m_helper.add(title, sendable);
   }
 
   @Override
-  public ComplexWidget add(Sendable sendable) throws IllegalArgumentException {
+  public ComplexWidget add(Sendable sendable) {
     return m_helper.add(sendable);
   }
 
   @Override
-  public SimpleWidget add(String title, Object defaultValue) throws IllegalArgumentException {
+  public SimpleWidget add(String title, Object defaultValue) {
     return m_helper.add(title, defaultValue);
   }
 
   @Override
-  public SuppliedValueWidget<String> addString(String title, Supplier<String> valueSupplier)
-      throws IllegalArgumentException {
+  public SuppliedValueWidget<String> addString(String title, Supplier<String> valueSupplier) {
     return m_helper.addString(title, valueSupplier);
   }
 
   @Override
-  public SuppliedValueWidget<Double> addNumber(String title, DoubleSupplier valueSupplier)
-      throws IllegalArgumentException {
+  public SuppliedValueWidget<Double> addNumber(String title, DoubleSupplier valueSupplier) {
     return m_helper.addNumber(title, valueSupplier);
   }
 
   @Override
-  public SuppliedValueWidget<Boolean> addBoolean(String title, BooleanSupplier valueSupplier)
-      throws IllegalArgumentException {
+  public SuppliedValueWidget<Boolean> addBoolean(String title, BooleanSupplier valueSupplier) {
     return m_helper.addBoolean(title, valueSupplier);
   }
 
   @Override
   public SuppliedValueWidget<String[]> addStringArray(
-      String title, Supplier<String[]> valueSupplier) throws IllegalArgumentException {
+      String title, Supplier<String[]> valueSupplier) {
     return m_helper.addStringArray(title, valueSupplier);
   }
 
   @Override
   public SuppliedValueWidget<double[]> addDoubleArray(
-      String title, Supplier<double[]> valueSupplier) throws IllegalArgumentException {
+      String title, Supplier<double[]> valueSupplier) {
     return m_helper.addDoubleArray(title, valueSupplier);
   }
 
   @Override
   public SuppliedValueWidget<boolean[]> addBooleanArray(
-      String title, Supplier<boolean[]> valueSupplier) throws IllegalArgumentException {
+      String title, Supplier<boolean[]> valueSupplier) {
     return m_helper.addBooleanArray(title, valueSupplier);
   }
 
   @Override
-  public SuppliedValueWidget<byte[]> addRaw(String title, Supplier<byte[]> valueSupplier)
-      throws IllegalArgumentException {
+  public SuppliedValueWidget<byte[]> addRaw(String title, Supplier<byte[]> valueSupplier) {
     return m_helper.addRaw(title, valueSupplier);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTab.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTab.java
@@ -7,7 +7,6 @@ package edu.wpi.first.wpilibj.shuffleboard;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.util.sendable.Sendable;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
@@ -48,7 +47,7 @@ public final class ShuffleboardTab implements ShuffleboardContainer {
   }
 
   @Override
-  public ShuffleboardLayout getLayout(String title) throws NoSuchElementException {
+  public ShuffleboardLayout getLayout(String title) {
     return m_helper.getLayout(title);
   }
 
@@ -58,7 +57,7 @@ public final class ShuffleboardTab implements ShuffleboardContainer {
   }
 
   @Override
-  public ComplexWidget add(Sendable sendable) throws IllegalArgumentException {
+  public ComplexWidget add(Sendable sendable) {
     return m_helper.add(sendable);
   }
 
@@ -68,44 +67,40 @@ public final class ShuffleboardTab implements ShuffleboardContainer {
   }
 
   @Override
-  public SuppliedValueWidget<String> addString(String title, Supplier<String> valueSupplier)
-      throws IllegalArgumentException {
+  public SuppliedValueWidget<String> addString(String title, Supplier<String> valueSupplier) {
     return m_helper.addString(title, valueSupplier);
   }
 
   @Override
-  public SuppliedValueWidget<Double> addNumber(String title, DoubleSupplier valueSupplier)
-      throws IllegalArgumentException {
+  public SuppliedValueWidget<Double> addNumber(String title, DoubleSupplier valueSupplier) {
     return m_helper.addNumber(title, valueSupplier);
   }
 
   @Override
-  public SuppliedValueWidget<Boolean> addBoolean(String title, BooleanSupplier valueSupplier)
-      throws IllegalArgumentException {
+  public SuppliedValueWidget<Boolean> addBoolean(String title, BooleanSupplier valueSupplier) {
     return m_helper.addBoolean(title, valueSupplier);
   }
 
   @Override
   public SuppliedValueWidget<String[]> addStringArray(
-      String title, Supplier<String[]> valueSupplier) throws IllegalArgumentException {
+      String title, Supplier<String[]> valueSupplier) {
     return m_helper.addStringArray(title, valueSupplier);
   }
 
   @Override
   public SuppliedValueWidget<double[]> addDoubleArray(
-      String title, Supplier<double[]> valueSupplier) throws IllegalArgumentException {
+      String title, Supplier<double[]> valueSupplier) {
     return m_helper.addDoubleArray(title, valueSupplier);
   }
 
   @Override
   public SuppliedValueWidget<boolean[]> addBooleanArray(
-      String title, Supplier<boolean[]> valueSupplier) throws IllegalArgumentException {
+      String title, Supplier<boolean[]> valueSupplier) {
     return m_helper.addBooleanArray(title, valueSupplier);
   }
 
   @Override
-  public SuppliedValueWidget<byte[]> addRaw(String title, Supplier<byte[]> valueSupplier)
-      throws IllegalArgumentException {
+  public SuppliedValueWidget<byte[]> addRaw(String title, Supplier<byte[]> valueSupplier) {
     return m_helper.addRaw(title, valueSupplier);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooser.java
@@ -72,9 +72,9 @@ public class SendableChooser<V> implements NTSendable, AutoCloseable {
   /**
    * Adds the given object to the list of options.
    *
-   * @deprecated Use {@link #addOption(String, Object)} instead.
    * @param name the name of the option
    * @param object the option
+   * @deprecated Use {@link #addOption(String, Object)} instead.
    */
   @Deprecated
   public void addObject(String name, V object) {
@@ -99,9 +99,9 @@ public class SendableChooser<V> implements NTSendable, AutoCloseable {
   /**
    * Adds the given object to the list of options and marks it as the default.
    *
-   * @deprecated Use {@link #setDefaultOption(String, Object)} instead.
    * @param name the name of the option
    * @param object the option
+   * @deprecated Use {@link #setDefaultOption(String, Object)} instead.
    */
   @Deprecated
   public void addDefault(String name, V object) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/AddressableLEDBufferTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/AddressableLEDBufferTest.java
@@ -6,7 +6,6 @@ package edu.wpi.first.wpilibj;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import edu.wpi.first.wpilibj.util.Color;
@@ -63,13 +62,13 @@ class AddressableLEDBufferTest {
     buffer.setLED(2, Color.kFirstRed);
     buffer.setLED(3, Color.kFirstBlue);
 
-    assertTrue(buffer.getLED(0).equals(Color.kFirstBlue));
-    assertTrue(buffer.getLED(1).equals(Color.kDenim));
-    assertTrue(buffer.getLED(2).equals(Color.kFirstRed));
-    assertTrue(buffer.getLED(3).equals(Color.kFirstBlue));
-    assertTrue(buffer.getLED8Bit(0).equals(firstBlueColor8Bit));
-    assertTrue(buffer.getLED8Bit(1).equals(denimColor8Bit));
-    assertTrue(buffer.getLED8Bit(2).equals(firstRedColor8Bit));
-    assertTrue(buffer.getLED8Bit(3).equals(firstBlueColor8Bit));
+    assertEquals(Color.kFirstBlue, buffer.getLED(0));
+    assertEquals(Color.kDenim, buffer.getLED(1));
+    assertEquals(Color.kFirstRed, buffer.getLED(2));
+    assertEquals(Color.kFirstBlue, buffer.getLED(3));
+    assertEquals(firstBlueColor8Bit, buffer.getLED8Bit(0));
+    assertEquals(denimColor8Bit, buffer.getLED8Bit(1));
+    assertEquals(firstRedColor8Bit, buffer.getLED8Bit(2));
+    assertEquals(firstBlueColor8Bit, buffer.getLED8Bit(3));
   }
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/AnalogGyroTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/AnalogGyroTest.java
@@ -12,7 +12,7 @@ import edu.wpi.first.hal.HAL;
 import edu.wpi.first.wpilibj.simulation.AnalogGyroSim;
 import org.junit.jupiter.api.Test;
 
-public class AnalogGyroTest {
+class AnalogGyroTest {
   @Test
   void testInitializeWithAnalogInput() {
     HAL.initialize(500, 0);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/AnalogPotentiometerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/AnalogPotentiometerTest.java
@@ -11,7 +11,7 @@ import edu.wpi.first.wpilibj.simulation.AnalogInputSim;
 import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 import org.junit.jupiter.api.Test;
 
-public class AnalogPotentiometerTest {
+class AnalogPotentiometerTest {
   @Test
   void testInitializeWithAnalogInput() {
     HAL.initialize(500, 0);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/DebouncerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/DebouncerTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import edu.wpi.first.wpilibj.simulation.SimHooks;
 import org.junit.jupiter.api.Test;
 
-public class DebouncerTest {
+class DebouncerTest {
   @Test
   void debounceRisingTest() {
     var debouncer = new Debouncer(0.02, Debouncer.DebounceType.kRising);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/DigitalOutputTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/DigitalOutputTest.java
@@ -12,7 +12,7 @@ import edu.wpi.first.hal.HAL;
 import edu.wpi.first.wpilibj.simulation.DIOSim;
 import org.junit.jupiter.api.Test;
 
-public class DigitalOutputTest {
+class DigitalOutputTest {
   @Test
   void testDefaultFunctions() {
     try (DigitalOutput output = new DigitalOutput(0)) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/DoubleSolenoidTestCTRE.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/DoubleSolenoidTestCTRE.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import edu.wpi.first.hal.util.AllocationException;
 import org.junit.jupiter.api.Test;
 
-public class DoubleSolenoidTestCTRE {
+class DoubleSolenoidTestCTRE {
   @Test
   void testValidInitialization() {
     try (DoubleSolenoid solenoid = new DoubleSolenoid(3, PneumaticsModuleType.CTREPCM, 2, 3)) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/DoubleSolenoidTestREV.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/DoubleSolenoidTestREV.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import edu.wpi.first.hal.util.AllocationException;
 import org.junit.jupiter.api.Test;
 
-public class DoubleSolenoidTestREV {
+class DoubleSolenoidTestREV {
   @Test
   void testValidInitialization() {
     try (DoubleSolenoid solenoid = new DoubleSolenoid(3, PneumaticsModuleType.REVPH, 2, 3)) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/InterruptTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/InterruptTest.java
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
-public class InterruptTest {
+class InterruptTest {
   @Test
   void testAsynchronousInterrupt() {
     AtomicBoolean hasFired = new AtomicBoolean(false);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/PS4ControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/PS4ControllerTest.java
@@ -19,7 +19,7 @@ class PS4ControllerTest {
   @ParameterizedTest
   @EnumSource(value = PS4Controller.Button.class)
   @SuppressWarnings({"VariableDeclarationUsageDistance"})
-  public void testButtons(PS4Controller.Button button)
+  void testButtons(PS4Controller.Button button)
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     HAL.initialize(500, 0);
     PS4Controller joy = new PS4Controller(2);
@@ -60,7 +60,7 @@ class PS4ControllerTest {
   @ParameterizedTest
   @EnumSource(value = PS4Controller.Axis.class)
   @SuppressWarnings({"VariableDeclarationUsageDistance"})
-  public void testAxes(PS4Controller.Axis axis)
+  void testAxes(PS4Controller.Axis axis)
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     HAL.initialize(500, 0);
     PS4Controller joy = new PS4Controller(2);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/SensorUtilTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/SensorUtilTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-public class SensorUtilTest {
+class SensorUtilTest {
   @Test
   void checkAnalogInputChannel() {
     assertThrows(IllegalArgumentException.class, () -> SensorUtil.checkAnalogInputChannel(100));

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/SolenoidTestCTRE.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/SolenoidTestCTRE.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import edu.wpi.first.hal.util.AllocationException;
 import org.junit.jupiter.api.Test;
 
-public class SolenoidTestCTRE {
+class SolenoidTestCTRE {
   @Test
   void testValidInitialization() {
     try (Solenoid solenoid = new Solenoid(3, PneumaticsModuleType.CTREPCM, 2)) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/SolenoidTestREV.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/SolenoidTestREV.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import edu.wpi.first.hal.util.AllocationException;
 import org.junit.jupiter.api.Test;
 
-public class SolenoidTestREV {
+class SolenoidTestREV {
   @Test
   void testValidInitialization() {
     try (Solenoid solenoid = new Solenoid(3, PneumaticsModuleType.REVPH, 2)) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/UltrasonicTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/UltrasonicTest.java
@@ -11,9 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import edu.wpi.first.wpilibj.simulation.UltrasonicSim;
 import org.junit.jupiter.api.Test;
 
-public class UltrasonicTest {
+class UltrasonicTest {
   @Test
-  public void testUltrasonic() {
+  void testUltrasonic() {
     try (Ultrasonic ultrasonic = new Ultrasonic(0, 1)) {
       UltrasonicSim sim = new UltrasonicSim(ultrasonic);
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
@@ -34,19 +34,20 @@ public abstract class UtilityClassTest<T> {
   }
 
   @Test
-  public void singleConstructorTest() {
+  void singleConstructorTest() {
     assertEquals(1, m_clazz.getDeclaredConstructors().length, "More than one constructor defined");
   }
 
   @Test
-  public void constructorPrivateTest() {
+  void constructorPrivateTest() {
     Constructor<?> constructor = m_clazz.getDeclaredConstructors()[0];
 
     assertFalse(constructor.canAccess(null), "Constructor is not private");
   }
 
   @Test
-  public void constructorReflectionTest() {
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+  void constructorReflectionTest() {
     Constructor<?> constructor = m_clazz.getDeclaredConstructors()[0];
     constructor.setAccessible(true);
     assertThrows(InvocationTargetException.class, constructor::newInstance);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/XboxControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/XboxControllerTest.java
@@ -19,7 +19,7 @@ class XboxControllerTest {
   @ParameterizedTest
   @EnumSource(value = XboxController.Button.class)
   @SuppressWarnings({"VariableDeclarationUsageDistance"})
-  public void testButtons(XboxController.Button button)
+  void testButtons(XboxController.Button button)
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     HAL.initialize(500, 0);
     XboxController joy = new XboxController(2);
@@ -60,7 +60,7 @@ class XboxControllerTest {
   @ParameterizedTest
   @EnumSource(value = XboxController.Axis.class)
   @SuppressWarnings({"VariableDeclarationUsageDistance"})
-  public void testAxes(XboxController.Axis axis)
+  void testAxes(XboxController.Axis axis)
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     HAL.initialize(500, 0);
     XboxController joy = new XboxController(2);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstanceTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstanceTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ShuffleboardInstanceTest {
+class ShuffleboardInstanceTest {
   private NetworkTableInstance m_ntInstance;
   private ShuffleboardInstance m_shuffleboardInstance;
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardTest.java
@@ -9,8 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import edu.wpi.first.wpilibj.UtilityClassTest;
 import org.junit.jupiter.api.Test;
 
-public class ShuffleboardTest extends UtilityClassTest<Shuffleboard> {
-  public ShuffleboardTest() {
+class ShuffleboardTest extends UtilityClassTest<Shuffleboard> {
+  ShuffleboardTest() {
     super(Shuffleboard.class);
   }
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ADXL345SimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ADXL345SimTest.java
@@ -15,7 +15,7 @@ import edu.wpi.first.wpilibj.interfaces.Accelerometer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-public class ADXL345SimTest {
+class ADXL345SimTest {
   @ParameterizedTest
   @EnumSource(Accelerometer.Range.class)
   void testInitI2C(Accelerometer.Range range) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ADXL362SimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ADXL362SimTest.java
@@ -13,7 +13,7 @@ import edu.wpi.first.wpilibj.interfaces.Accelerometer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-public class ADXL362SimTest {
+class ADXL362SimTest {
   @ParameterizedTest
   @EnumSource(Accelerometer.Range.class)
   void testAccel(Accelerometer.Range range) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AnalogEncoderSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/AnalogEncoderSimTest.java
@@ -11,9 +11,9 @@ import edu.wpi.first.wpilibj.AnalogEncoder;
 import edu.wpi.first.wpilibj.AnalogInput;
 import org.junit.jupiter.api.Test;
 
-public class AnalogEncoderSimTest {
+class AnalogEncoderSimTest {
   @Test
-  public void testBasic() {
+  void testBasic() {
     try (var analogInput = new AnalogInput(0);
         var analogEncoder = new AnalogEncoder(analogInput)) {
       var encoderSim = new AnalogEncoderSim(analogEncoder);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSimTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 class DifferentialDrivetrainSimTest {
   @Test
-  public void testConvergence() {
+  void testConvergence() {
     var motor = DCMotor.getNEO(2);
     var plant =
         LinearSystemId.createDrivetrainVelocitySystem(
@@ -96,7 +96,7 @@ class DifferentialDrivetrainSimTest {
   }
 
   @Test
-  public void testCurrent() {
+  void testCurrent() {
     var motor = DCMotor.getNEO(2);
     var plant =
         LinearSystemId.createDrivetrainVelocitySystem(
@@ -126,7 +126,7 @@ class DifferentialDrivetrainSimTest {
   }
 
   @Test
-  public void testModelStability() {
+  void testModelStability() {
     var motor = DCMotor.getNEO(2);
     var plant =
         LinearSystemId.createDrivetrainVelocitySystem(

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DriverStationSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/DriverStationSimTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-public class DriverStationSimTest {
+class DriverStationSimTest {
   @Test
   void testEnabled() {
     HAL.initialize(500, 0);
@@ -192,7 +192,7 @@ public class DriverStationSimTest {
 
   @ParameterizedTest
   @EnumSource(DriverStation.MatchType.class)
-  public void testMatchType(DriverStation.MatchType matchType) {
+  void testMatchType(DriverStation.MatchType matchType) {
     HAL.initialize(500, 0);
     DriverStationSim.resetData();
 
@@ -202,7 +202,7 @@ public class DriverStationSimTest {
   }
 
   @Test
-  public void testReplayNumber() {
+  void testReplayNumber() {
     HAL.initialize(500, 0);
     DriverStationSim.resetData();
 
@@ -212,7 +212,7 @@ public class DriverStationSimTest {
   }
 
   @Test
-  public void testMatchNumber() {
+  void testMatchNumber() {
     HAL.initialize(500, 0);
     DriverStationSim.resetData();
 
@@ -222,7 +222,7 @@ public class DriverStationSimTest {
   }
 
   @Test
-  public void testMatchTime() {
+  void testMatchTime() {
     HAL.initialize(500, 0);
     DriverStationSim.resetData();
 
@@ -238,7 +238,7 @@ public class DriverStationSimTest {
   }
 
   @Test
-  public void testSetGameSpecificMessage() {
+  void testSetGameSpecificMessage() {
     HAL.initialize(500, 0);
     DriverStationSim.resetData();
 
@@ -249,7 +249,7 @@ public class DriverStationSimTest {
   }
 
   @Test
-  public void testSetEventName() {
+  void testSetEventName() {
     HAL.initialize(500, 0);
     DriverStationSim.resetData();
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ElevatorSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ElevatorSimTest.java
@@ -17,10 +17,10 @@ import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.motorcontrol.PWMVictorSPX;
 import org.junit.jupiter.api.Test;
 
-public class ElevatorSimTest {
+class ElevatorSimTest {
   @Test
   @SuppressWarnings({"LocalVariableName", "resource"})
-  public void testStateSpaceSimWithElevator() {
+  void testStateSpaceSimWithElevator() {
     RoboRioSim.resetData();
 
     var controller = new PIDController(10, 0, 0);
@@ -61,7 +61,7 @@ public class ElevatorSimTest {
   }
 
   @Test
-  public void testMinMax() {
+  void testMinMax() {
     var plant =
         LinearSystemId.createElevatorSystem(
             DCMotor.getVex775Pro(4), 8.0, 0.75 * 25.4 / 1000.0, 14.67);
@@ -92,7 +92,7 @@ public class ElevatorSimTest {
   }
 
   @Test
-  public void testStability() {
+  void testStability() {
     var sim = new ElevatorSim(DCMotor.getVex775Pro(4), 100, 4, Units.inchesToMeters(0.5), 0, 10);
 
     sim.setState(VecBuilder.fill(0, 0));

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/RoboRioSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/RoboRioSimTest.java
@@ -15,7 +15,7 @@ import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
 import edu.wpi.first.wpilibj.simulation.testutils.IntCallback;
 import org.junit.jupiter.api.Test;
 
-public class RoboRioSimTest {
+class RoboRioSimTest {
   @Test
   void testFPGAButton() {
     RoboRioSim.resetData();

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSimTest.java
@@ -11,7 +11,7 @@ import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.util.Units;
 import org.junit.jupiter.api.Test;
 
-public class SingleJointedArmSimTest {
+class SingleJointedArmSimTest {
   SingleJointedArmSim m_sim =
       new SingleJointedArmSim(
           DCMotor.getVex775Pro(2),
@@ -24,7 +24,7 @@ public class SingleJointedArmSimTest {
           true);
 
   @Test
-  public void testArmDisabled() {
+  void testArmDisabled() {
     m_sim.setState(VecBuilder.fill(0.0, 0.0));
 
     for (int i = 0; i < 12 / 0.02; i++) {

--- a/wpilibjExamples/build.gradle
+++ b/wpilibjExamples/build.gradle
@@ -37,13 +37,13 @@ dependencies {
     implementation project(':wpilibOldCommands')
     implementation project(':wpilibNewCommands')
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.4.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
 jacoco {
-    toolVersion = "0.8.4"
+    toolVersion = "0.8.7"
 }
 
 jacocoTestReport {

--- a/wpilibjIntegrationTests/build.gradle
+++ b/wpilibjIntegrationTests/build.gradle
@@ -27,11 +27,11 @@ dependencies {
     implementation project(':ntcore')
     implementation project(':cscore')
     implementation project(':cameraserver')
-    implementation 'junit:junit:4.11'
+    implementation 'junit:junit:4.13.2'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    implementation 'com.googlecode.junit-toolbox:junit-toolbox:2.0'
-    implementation 'org.apache.ant:ant:1.9.4'
-    implementation 'org.apache.ant:ant-junit:1.9.4'
+    implementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
+    implementation 'org.apache.ant:ant:1.10.12'
+    implementation 'org.apache.ant:ant-junit:1.10.12'
 }
 
 build.dependsOn shadowJar

--- a/wpimath/build.gradle
+++ b/wpimath/build.gradle
@@ -33,9 +33,9 @@ model {
 
 dependencies {
     api "org.ejml:ejml-simple:0.41"
-    api "com.fasterxml.jackson.core:jackson-annotations:2.10.0"
-    api "com.fasterxml.jackson.core:jackson-core:2.10.0"
-    api "com.fasterxml.jackson.core:jackson-databind:2.10.0"
+    api "com.fasterxml.jackson.core:jackson-annotations:2.12.4"
+    api "com.fasterxml.jackson.core:jackson-core:2.12.4"
+    api "com.fasterxml.jackson.core:jackson-databind:2.12.4"
 }
 
 def wpilibNumberFileInput = file("src/generate/GenericNumber.java.jinja")

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/LinearQuadraticRegulator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/LinearQuadraticRegulator.java
@@ -104,10 +104,11 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
 
     if (!StateSpaceUtil.isStabilizable(discA, discB)) {
       var builder = new StringBuilder("The system passed to the LQR is uncontrollable!\n\nA =\n");
-      builder.append(discA.getStorage().toString());
-      builder.append("\nB =\n");
-      builder.append(discB.getStorage().toString());
-      builder.append("\n");
+      builder
+          .append(discA.getStorage().toString())
+          .append("\nB =\n")
+          .append(discB.getStorage().toString())
+          .append('\n');
 
       var msg = builder.toString();
       MathSharedStore.reportError(msg, Thread.currentThread().getStackTrace());

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/KalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/KalmanFilter.java
@@ -79,10 +79,11 @@ public class KalmanFilter<States extends Num, Inputs extends Num, Outputs extend
     if (!StateSpaceUtil.isDetectable(discA, C)) {
       var builder =
           new StringBuilder("The system passed to the Kalman filter is unobservable!\n\nA =\n");
-      builder.append(discA.getStorage().toString());
-      builder.append("\nC =\n");
-      builder.append(C.getStorage().toString());
-      builder.append("\n");
+      builder
+          .append(discA.getStorage().toString())
+          .append("\nC =\n")
+          .append(C.getStorage().toString())
+          .append('\n');
 
       var msg = builder.toString();
       MathSharedStore.reportError(msg, Thread.currentThread().getStackTrace());

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrapezoidProfile.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrapezoidProfile.java
@@ -209,8 +209,6 @@ public class TrapezoidProfile {
 
     endAccel = Math.max(endAccel, 0);
     endFullSpeed = Math.max(endFullSpeed, 0);
-    double endDeccel = m_endDeccel - endAccel - endFullSpeed;
-    endDeccel = Math.max(endDeccel, 0);
 
     final double acceleration = m_constraints.maxAcceleration;
     final double decceleration = -m_constraints.maxAcceleration;
@@ -229,11 +227,8 @@ public class TrapezoidProfile {
       deccelVelocity = velocity;
     }
 
-    double deccelDist = deccelVelocity * endDeccel + 0.5 * decceleration * endDeccel * endDeccel;
-
-    deccelDist = Math.max(deccelDist, 0);
-
     double fullSpeedDist = m_constraints.maxVelocity * endFullSpeed;
+    double deccelDist;
 
     if (accelDist > distToTarget) {
       accelDist = distToTarget;

--- a/wpimath/src/main/native/include/frc/trajectory/TrapezoidProfile.inc
+++ b/wpimath/src/main/native/include/frc/trajectory/TrapezoidProfile.inc
@@ -104,8 +104,6 @@ units::second_t TrapezoidProfile<Distance>::TimeLeftUntil(
 
   endAccel = units::math::max(endAccel, 0_s);
   endFullSpeed = units::math::max(endFullSpeed, 0_s);
-  units::second_t endDeccel = m_endDeccel - endAccel - endFullSpeed;
-  endDeccel = units::math::max(endDeccel, 0_s);
 
   const Acceleration_t acceleration = m_constraints.maxAcceleration;
   const Acceleration_t decceleration = -m_constraints.maxAcceleration;
@@ -127,20 +125,16 @@ units::second_t TrapezoidProfile<Distance>::TimeLeftUntil(
     deccelVelocity = velocity;
   }
 
-  Distance_t deccelDist =
-      deccelVelocity * endDeccel + 0.5 * decceleration * endDeccel * endDeccel;
-
-  deccelDist = units::math::max(deccelDist, Distance_t(0));
-
   Distance_t fullSpeedDist = m_constraints.maxVelocity * endFullSpeed;
+  Distance_t deccelDist;
 
   if (accelDist > distToTarget) {
     accelDist = distToTarget;
-    fullSpeedDist = Distance_t(0);
-    deccelDist = Distance_t(0);
+    fullSpeedDist = Distance_t{0};
+    deccelDist = Distance_t{0};
   } else if (accelDist + fullSpeedDist > distToTarget) {
     fullSpeedDist = distToTarget - accelDist;
-    deccelDist = Distance_t(0);
+    deccelDist = Distance_t{0};
   } else {
     deccelDist = distToTarget - fullSpeedDist - accelDist;
   }

--- a/wpimath/src/test/java/edu/wpi/first/math/DrakeTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/DrakeTest.java
@@ -11,7 +11,7 @@ import org.ejml.simple.SimpleMatrix;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({"ParameterName", "LocalVariableName"})
-public class DrakeTest {
+class DrakeTest {
   public static void assertMatrixEqual(SimpleMatrix A, SimpleMatrix B) {
     for (int i = 0; i < A.numRows(); i++) {
       for (int j = 0; j < A.numCols(); j++) {
@@ -49,7 +49,7 @@ public class DrakeTest {
   }
 
   @Test
-  public void testDiscreteAlgebraicRicattiEquation() {
+  void testDiscreteAlgebraicRicattiEquation() {
     int n1 = 4;
     int m1 = 1;
 

--- a/wpimath/src/test/java/edu/wpi/first/math/MatrixTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/MatrixTest.java
@@ -15,7 +15,7 @@ import edu.wpi.first.math.numbers.N4;
 import org.ejml.data.SingularMatrixException;
 import org.junit.jupiter.api.Test;
 
-public class MatrixTest {
+class MatrixTest {
   @Test
   void testMatrixMultiplication() {
     var mat1 = Matrix.mat(Nat.N2(), Nat.N2()).fill(2.0, 1.0, 0.0, 1.0);

--- a/wpimath/src/test/java/edu/wpi/first/math/StateSpaceUtilTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/StateSpaceUtilTest.java
@@ -18,9 +18,9 @@ import org.ejml.dense.row.MatrixFeatures_DDRM;
 import org.ejml.simple.SimpleMatrix;
 import org.junit.jupiter.api.Test;
 
-public class StateSpaceUtilTest {
+class StateSpaceUtilTest {
   @Test
-  public void testCostArray() {
+  void testCostArray() {
     var mat = StateSpaceUtil.makeCostMatrix(VecBuilder.fill(1.0, 2.0, 3.0));
 
     assertEquals(1.0, mat.get(0, 0), 1e-3);
@@ -35,7 +35,7 @@ public class StateSpaceUtilTest {
   }
 
   @Test
-  public void testCovArray() {
+  void testCovArray() {
     var mat = StateSpaceUtil.makeCovarianceMatrix(Nat.N3(), VecBuilder.fill(1.0, 2.0, 3.0));
 
     assertEquals(1.0, mat.get(0, 0), 1e-3);
@@ -51,7 +51,7 @@ public class StateSpaceUtilTest {
 
   @Test
   @SuppressWarnings("LocalVariableName")
-  public void testIsStabilizable() {
+  void testIsStabilizable() {
     Matrix<N2, N2> A;
     Matrix<N2, N1> B = VecBuilder.fill(0, 1);
 
@@ -78,7 +78,7 @@ public class StateSpaceUtilTest {
 
   @Test
   @SuppressWarnings("LocalVariableName")
-  public void testIsDetectable() {
+  void testIsDetectable() {
     Matrix<N2, N2> A;
     Matrix<N1, N2> C = Matrix.mat(Nat.N1(), Nat.N2()).fill(0, 1);
 
@@ -104,7 +104,7 @@ public class StateSpaceUtilTest {
   }
 
   @Test
-  public void testMakeWhiteNoiseVector() {
+  void testMakeWhiteNoiseVector() {
     var firstData = new ArrayList<Double>();
     var secondData = new ArrayList<Double>();
     for (int i = 0; i < 1000; i++) {
@@ -135,7 +135,7 @@ public class StateSpaceUtilTest {
   }
 
   @Test
-  public void testMatrixExp() {
+  void testMatrixExp() {
     Matrix<N2, N2> wrappedMatrix = Matrix.eye(Nat.N2());
     var wrappedResult = wrappedMatrix.exp();
 
@@ -152,7 +152,7 @@ public class StateSpaceUtilTest {
   }
 
   @Test
-  public void testSimpleMatrixExp() {
+  void testSimpleMatrixExp() {
     SimpleMatrix matrix = SimpleMatrixUtils.eye(2);
     var result = SimpleMatrixUtils.exp(matrix);
 
@@ -175,7 +175,7 @@ public class StateSpaceUtilTest {
   }
 
   @Test
-  public void testPoseToVector() {
+  void testPoseToVector() {
     Pose2d pose = new Pose2d(1, 2, new Rotation2d(3));
     var vector = StateSpaceUtil.poseToVector(pose);
     assertEquals(pose.getTranslation().getX(), vector.get(0, 0), 1e-6);

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/BangBangInputOutputTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/BangBangInputOutputTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BangBangInputOutputTest {
+class BangBangInputOutputTest {
   private BangBangController m_controller;
 
   @BeforeEach

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/BangBangToleranceTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/BangBangToleranceTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BangBangToleranceTest {
+class BangBangToleranceTest {
   private BangBangController m_controller;
 
   @BeforeEach

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/LinearQuadraticRegulatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/LinearQuadraticRegulatorTest.java
@@ -11,10 +11,10 @@ import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
 import org.junit.jupiter.api.Test;
 
-public class LinearQuadraticRegulatorTest {
+class LinearQuadraticRegulatorTest {
   @Test
   @SuppressWarnings("LocalVariableName")
-  public void testLQROnElevator() {
+  void testLQROnElevator() {
     var motors = DCMotor.getVex775Pro(2);
 
     var m = 5.0;
@@ -36,7 +36,7 @@ public class LinearQuadraticRegulatorTest {
   }
 
   @Test
-  public void testFourMotorElevator() {
+  void testFourMotorElevator() {
     var dt = 0.020;
 
     var plant =
@@ -52,7 +52,7 @@ public class LinearQuadraticRegulatorTest {
 
   @Test
   @SuppressWarnings("LocalVariableName")
-  public void testLQROnArm() {
+  void testLQROnArm() {
     var motors = DCMotor.getVex775Pro(2);
 
     var m = 4.0;
@@ -74,7 +74,7 @@ public class LinearQuadraticRegulatorTest {
   }
 
   @Test
-  public void testLatencyCompensate() {
+  void testLatencyCompensate() {
     var dt = 0.02;
 
     var plant =

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/LinearSystemLoopTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/LinearSystemLoopTest.java
@@ -21,8 +21,8 @@ import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-public class LinearSystemLoopTest {
-  public static final double kDt = 0.00505;
+class LinearSystemLoopTest {
+  private static final double kDt = 0.00505;
   private static final double kPositionStddev = 0.0001;
   private static final Random random = new Random();
 
@@ -51,7 +51,7 @@ public class LinearSystemLoopTest {
 
   @Test
   @SuppressWarnings("LocalVariableName")
-  public void testStateSpaceEnabled() {
+  void testStateSpaceEnabled() {
     m_loop.reset(VecBuilder.fill(0, 0));
     Matrix<N2, N1> references = VecBuilder.fill(2.0, 0.0);
     var constraints = new TrapezoidProfile.Constraints(4, 3);
@@ -80,7 +80,7 @@ public class LinearSystemLoopTest {
 
   @Test
   @SuppressWarnings("LocalVariableName")
-  public void testFlywheelEnabled() {
+  void testFlywheelEnabled() {
     LinearSystem<N1, N1, N1> plant =
         LinearSystemId.createFlywheelSystem(DCMotor.getNEO(2), 0.00289, 1.0);
     KalmanFilter<N1, N1, N1> observer =

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/AngleStatisticsTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/AngleStatisticsTest.java
@@ -11,9 +11,9 @@ import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.VecBuilder;
 import org.junit.jupiter.api.Test;
 
-public class AngleStatisticsTest {
+class AngleStatisticsTest {
   @Test
-  public void testMean() {
+  void testMean() {
     // 3 states, 2 sigmas
     var sigmas =
         Matrix.mat(Nat.N3(), Nat.N2()).fill(1, 1.2, Math.toRadians(359), Math.toRadians(3), 1, 2);
@@ -27,7 +27,7 @@ public class AngleStatisticsTest {
   }
 
   @Test
-  public void testResidual() {
+  void testResidual() {
     var first = VecBuilder.fill(1, Math.toRadians(1), 2);
     var second = VecBuilder.fill(1, Math.toRadians(359), 1);
     assertTrue(
@@ -36,7 +36,7 @@ public class AngleStatisticsTest {
   }
 
   @Test
-  public void testAdd() {
+  void testAdd() {
     var first = VecBuilder.fill(1, Math.toRadians(1), 2);
     var second = VecBuilder.fill(1, Math.toRadians(359), 1);
     assertTrue(AngleStatistics.angleAdd(first, second, 1).isEqual(VecBuilder.fill(2, 0, 3), 1e-6));

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -21,10 +21,10 @@ import java.util.List;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-public class DifferentialDrivePoseEstimatorTest {
+class DifferentialDrivePoseEstimatorTest {
   @SuppressWarnings("LocalVariableName")
   @Test
-  public void testAccuracy() {
+  void testAccuracy() {
     var estimator =
         new DifferentialDrivePoseEstimator(
             new Rotation2d(),

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/ExtendedKalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/ExtendedKalmanFilterTest.java
@@ -27,8 +27,8 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("ParameterName")
-public class ExtendedKalmanFilterTest {
-  public static Matrix<N5, N1> getDynamics(final Matrix<N5, N1> x, final Matrix<N2, N1> u) {
+class ExtendedKalmanFilterTest {
+  private static Matrix<N5, N1> getDynamics(final Matrix<N5, N1> x, final Matrix<N2, N1> u) {
     final var motors = DCMotor.getCIM(2);
 
     final var gr = 7.08; // Gear ratio
@@ -58,17 +58,19 @@ public class ExtendedKalmanFilterTest {
     return result;
   }
 
-  public static Matrix<N3, N1> getLocalMeasurementModel(Matrix<N5, N1> x, Matrix<N2, N1> u) {
+  @SuppressWarnings("PMD.UnusedFormalParameter")
+  private static Matrix<N3, N1> getLocalMeasurementModel(Matrix<N5, N1> x, Matrix<N2, N1> u) {
     return VecBuilder.fill(x.get(2, 0), x.get(3, 0), x.get(4, 0));
   }
 
-  public static Matrix<N5, N1> getGlobalMeasurementModel(Matrix<N5, N1> x, Matrix<N2, N1> u) {
+  @SuppressWarnings("PMD.UnusedFormalParameter")
+  private static Matrix<N5, N1> getGlobalMeasurementModel(Matrix<N5, N1> x, Matrix<N2, N1> u) {
     return VecBuilder.fill(x.get(0, 0), x.get(1, 0), x.get(2, 0), x.get(3, 0), x.get(4, 0));
   }
 
   @SuppressWarnings("LocalVariableName")
   @Test
-  public void testInit() {
+  void testInit() {
     double dtSeconds = 0.00505;
 
     assertDoesNotThrow(
@@ -99,7 +101,7 @@ public class ExtendedKalmanFilterTest {
 
   @SuppressWarnings("LocalVariableName")
   @Test
-  public void testConvergence() {
+  void testConvergence() {
     double dtSeconds = 0.00505;
     double rbMeters = 0.8382 / 2.0; // Robot radius
 

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/KalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/KalmanFilterTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-public class KalmanFilterTest {
+class KalmanFilterTest {
   private static LinearSystem<N2, N1, N1> elevatorPlant;
 
   private static final double kDt = 0.00505;
@@ -35,7 +35,7 @@ public class KalmanFilterTest {
   }
 
   @SuppressWarnings("LocalVariableName")
-  public static void createElevator() {
+  private static void createElevator() {
     var motors = DCMotor.getVex775Pro(2);
 
     var m = 5.0;
@@ -62,7 +62,7 @@ public class KalmanFilterTest {
 
   @Test
   @SuppressWarnings("LocalVariableName")
-  public void testElevatorKalmanFilter() {
+  void testElevatorKalmanFilter() {
     var Q = VecBuilder.fill(0.05, 1.0);
     var R = VecBuilder.fill(0.0001);
 
@@ -70,7 +70,7 @@ public class KalmanFilterTest {
   }
 
   @Test
-  public void testSwerveKFStationary() {
+  void testSwerveKFStationary() {
     var random = new Random();
 
     var filter =
@@ -99,7 +99,7 @@ public class KalmanFilterTest {
   }
 
   @Test
-  public void testSwerveKFMovingWithoutAccelerating() {
+  void testSwerveKFMovingWithoutAccelerating() {
     var random = new Random();
 
     var filter =
@@ -137,7 +137,7 @@ public class KalmanFilterTest {
 
   @Test
   @SuppressWarnings("LocalVariableName")
-  public void testSwerveKFMovingOverTrajectory() {
+  void testSwerveKFMovingOverTrajectory() {
     var random = new Random();
 
     var filter =

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimatorTest.java
@@ -18,10 +18,10 @@ import java.util.List;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-public class MecanumDrivePoseEstimatorTest {
+class MecanumDrivePoseEstimatorTest {
   @Test
   @SuppressWarnings("LocalVariableName")
-  public void testAccuracy() {
+  void testAccuracy() {
     var kinematics =
         new MecanumDriveKinematics(
             new Translation2d(1, 1), new Translation2d(1, -1),

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/MerweScaledSigmaPointsTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/MerweScaledSigmaPointsTest.java
@@ -11,9 +11,9 @@ import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.VecBuilder;
 import org.junit.jupiter.api.Test;
 
-public class MerweScaledSigmaPointsTest {
+class MerweScaledSigmaPointsTest {
   @Test
-  public void testZeroMeanPoints() {
+  void testZeroMeanPoints() {
     var merweScaledSigmaPoints = new MerweScaledSigmaPoints<>(Nat.N2());
     var points =
         merweScaledSigmaPoints.sigmaPoints(
@@ -28,7 +28,7 @@ public class MerweScaledSigmaPointsTest {
   }
 
   @Test
-  public void testNonzeroMeanPoints() {
+  void testNonzeroMeanPoints() {
     var merweScaledSigmaPoints = new MerweScaledSigmaPoints<>(Nat.N2());
     var points =
         merweScaledSigmaPoints.sigmaPoints(

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimatorTest.java
@@ -18,10 +18,10 @@ import java.util.List;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
-public class SwerveDrivePoseEstimatorTest {
+class SwerveDrivePoseEstimatorTest {
   @Test
   @SuppressWarnings("LocalVariableName")
-  public void testAccuracy() {
+  void testAccuracy() {
     var kinematics =
         new SwerveDriveKinematics(
             new Translation2d(1, 1),

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
@@ -29,9 +29,9 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class UnscentedKalmanFilterTest {
+class UnscentedKalmanFilterTest {
   @SuppressWarnings({"LocalVariableName", "ParameterName"})
-  public static Matrix<N6, N1> getDynamics(Matrix<N6, N1> x, Matrix<N2, N1> u) {
+  private static Matrix<N6, N1> getDynamics(Matrix<N6, N1> x, Matrix<N2, N1> u) {
     var motors = DCMotor.getCIM(2);
 
     var gHigh = 7.08;
@@ -69,19 +69,19 @@ public class UnscentedKalmanFilterTest {
         k2 * ((C1 * vl) + (C2 * Vl)) + k1 * ((C1 * vr) + (C2 * Vr)));
   }
 
-  @SuppressWarnings("ParameterName")
-  public static Matrix<N4, N1> getLocalMeasurementModel(Matrix<N6, N1> x, Matrix<N2, N1> u) {
+  @SuppressWarnings({"PMD.UnusedFormalParameter", "ParameterName"})
+  private static Matrix<N4, N1> getLocalMeasurementModel(Matrix<N6, N1> x, Matrix<N2, N1> u) {
     return VecBuilder.fill(x.get(2, 0), x.get(3, 0), x.get(4, 0), x.get(5, 0));
   }
 
-  @SuppressWarnings("ParameterName")
-  public static Matrix<N6, N1> getGlobalMeasurementModel(Matrix<N6, N1> x, Matrix<N2, N1> u) {
+  @SuppressWarnings({"PMD.UnusedFormalParameter", "ParameterName"})
+  private static Matrix<N6, N1> getGlobalMeasurementModel(Matrix<N6, N1> x, Matrix<N2, N1> u) {
     return x.copy();
   }
 
   @Test
   @SuppressWarnings("LocalVariableName")
-  public void testInit() {
+  void testInit() {
     assertDoesNotThrow(
         () -> {
           UnscentedKalmanFilter<N6, N2, N4> observer =
@@ -104,7 +104,7 @@ public class UnscentedKalmanFilterTest {
 
   @SuppressWarnings("LocalVariableName")
   @Test
-  public void testConvergence() {
+  void testConvergence() {
     double dtSeconds = 0.00505;
     double rbMeters = 0.8382 / 2.0; // Robot radius
 
@@ -206,7 +206,7 @@ public class UnscentedKalmanFilterTest {
 
   @Test
   @SuppressWarnings({"LocalVariableName", "ParameterName"})
-  public void testLinearUKF() {
+  void testLinearUKF() {
     var dt = 0.020;
     var plant = LinearSystemId.identifyVelocitySystem(0.02, 0.006);
     var observer =
@@ -236,7 +236,7 @@ public class UnscentedKalmanFilterTest {
   }
 
   @Test
-  public void testUnscentedTransform() {
+  void testUnscentedTransform() {
     // From FilterPy
     var ret =
         UnscentedKalmanFilter.unscentedTransform(

--- a/wpimath/src/test/java/edu/wpi/first/math/filter/MedianFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/filter/MedianFilterTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-public class MedianFilterTest {
+class MedianFilterTest {
   @Test
   void medianFilterNotFullTestEven() {
     MedianFilter filter = new MedianFilter(10);

--- a/wpimath/src/test/java/edu/wpi/first/math/filter/SlewRateLimiterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/filter/SlewRateLimiterTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import edu.wpi.first.util.WPIUtilJNI;
 import org.junit.jupiter.api.Test;
 
-public class SlewRateLimiterTest {
+class SlewRateLimiterTest {
   @Test
   void slewRateLimitTest() {
     WPIUtilJNI.enableMockTime();

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Pose2dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Pose2dTest.java
@@ -53,6 +53,7 @@ class Pose2dTest {
     assertNotEquals(one, two);
   }
 
+  @Test
   void testMinus() {
     var initial = new Pose2d(0.0, 0.0, Rotation2d.fromDegrees(45.0));
     var last = new Pose2d(5.0, 5.0, Rotation2d.fromDegrees(45.0));

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Twist2dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Twist2dTest.java
@@ -60,6 +60,7 @@ class Twist2dTest {
     assertNotEquals(one, two);
   }
 
+  @Test
   void testPose2dLog() {
     final var start = new Pose2d();
     final var end = new Pose2d(5.0, 5.0, Rotation2d.fromDegrees(90.0));

--- a/wpimath/src/test/java/edu/wpi/first/math/system/DiscretizationTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/system/DiscretizationTest.java
@@ -14,11 +14,11 @@ import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.numbers.N2;
 import org.junit.jupiter.api.Test;
 
-public class DiscretizationTest {
+class DiscretizationTest {
   // Check that for a simple second-order system that we can easily analyze
   // analytically,
   @Test
-  public void testDiscretizeA() {
+  void testDiscretizeA() {
     final var contA = new MatBuilder<>(Nat.N2(), Nat.N2()).fill(0, 1, 0, 0);
     final var x0 = VecBuilder.fill(1, 1);
 
@@ -36,7 +36,7 @@ public class DiscretizationTest {
   // Check that for a simple second-order system that we can easily analyze
   // analytically,
   @Test
-  public void testDiscretizeAB() {
+  void testDiscretizeAB() {
     final var contA = new MatBuilder<>(Nat.N2(), Nat.N2()).fill(0, 1, 0, 0);
     final var contB = new MatBuilder<>(Nat.N2(), Nat.N1()).fill(0, 1);
 
@@ -62,7 +62,7 @@ public class DiscretizationTest {
   // Test that the discrete approximation of Q ≈ ∫ e^(Aτ) Q e^(Aᵀτ) dτ
   //                                             0
   @Test
-  public void testDiscretizeSlowModelAQ() {
+  void testDiscretizeSlowModelAQ() {
     final var contA = new MatBuilder<>(Nat.N2(), Nat.N2()).fill(0, 1, 0, 0);
     final var contQ = new MatBuilder<>(Nat.N2(), Nat.N2()).fill(1, 0, 0, 1);
 
@@ -91,7 +91,7 @@ public class DiscretizationTest {
   // Test that the discrete approximation of Q ≈ ∫ e^(Aτ) Q e^(Aᵀτ) dτ
   //                                             0
   @Test
-  public void testDiscretizeFastModelAQ() {
+  void testDiscretizeFastModelAQ() {
     final var contA = new MatBuilder<>(Nat.N2(), Nat.N2()).fill(0, 1, 0, -1406.29);
     final var contQ = new MatBuilder<>(Nat.N2(), Nat.N2()).fill(0.0025, 0, 0, 1);
 
@@ -118,7 +118,7 @@ public class DiscretizationTest {
 
   // Test that the Taylor series discretization produces nearly identical results.
   @Test
-  public void testDiscretizeSlowModelAQTaylor() {
+  void testDiscretizeSlowModelAQTaylor() {
     final var contA = new MatBuilder<>(Nat.N2(), Nat.N2()).fill(0, 1, 0, 0);
     final var contQ = new MatBuilder<>(Nat.N2(), Nat.N2()).fill(1, 0, 0, 1);
 
@@ -161,7 +161,7 @@ public class DiscretizationTest {
 
   // Test that the Taylor series discretization produces nearly identical results.
   @Test
-  public void testDiscretizeFastModelAQTaylor() {
+  void testDiscretizeFastModelAQTaylor() {
     final var contA = new MatBuilder<>(Nat.N2(), Nat.N2()).fill(0, 1, 0, -1500);
     final var contQ = new MatBuilder<>(Nat.N2(), Nat.N2()).fill(0.0025, 0, 0, 1);
 
@@ -204,7 +204,7 @@ public class DiscretizationTest {
 
   // Test that DiscretizeR() works
   @Test
-  public void testDiscretizeR() {
+  void testDiscretizeR() {
     var contR = Matrix.mat(Nat.N2(), Nat.N2()).fill(2.0, 0.0, 0.0, 1.0);
     var discRTruth = Matrix.mat(Nat.N2(), Nat.N2()).fill(4.0, 0.0, 0.0, 2.0);
 

--- a/wpimath/src/test/java/edu/wpi/first/math/system/LinearSystemIDTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/system/LinearSystemIDTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 class LinearSystemIDTest {
   @Test
-  public void testDrivetrainVelocitySystem() {
+  void testDrivetrainVelocitySystem() {
     var model =
         LinearSystemId.createDrivetrainVelocitySystem(DCMotor.getNEO(4), 70, 0.05, 0.4, 6.0, 6);
     assertTrue(
@@ -40,7 +40,7 @@ class LinearSystemIDTest {
   }
 
   @Test
-  public void testElevatorSystem() {
+  void testElevatorSystem() {
     var model = LinearSystemId.createElevatorSystem(DCMotor.getNEO(2), 5, 0.05, 12);
     assertTrue(
         model.getA().isEqual(Matrix.mat(Nat.N2(), Nat.N2()).fill(0, 1, 0, -99.05473), 0.001));
@@ -53,7 +53,7 @@ class LinearSystemIDTest {
   }
 
   @Test
-  public void testFlywheelSystem() {
+  void testFlywheelSystem() {
     var model = LinearSystemId.createFlywheelSystem(DCMotor.getNEO(2), 0.00032, 1.0);
     assertTrue(model.getA().isEqual(VecBuilder.fill(-26.87032), 0.001));
 
@@ -65,7 +65,7 @@ class LinearSystemIDTest {
   }
 
   @Test
-  public void testIdentifyPositionSystem() {
+  void testIdentifyPositionSystem() {
     // By controls engineering in frc,
     // x-dot = [0 1 | 0 -kv/ka] x = [0 | 1/ka] u
     var kv = 1.0;
@@ -77,7 +77,7 @@ class LinearSystemIDTest {
   }
 
   @Test
-  public void testIdentifyVelocitySystem() {
+  void testIdentifyVelocitySystem() {
     // By controls engineering in frc,
     // V = kv * velocity + ka * acceleration
     // x-dot =  -kv/ka * v + 1/ka \cdot V

--- a/wpimath/src/test/java/edu/wpi/first/math/system/NumericalIntegrationTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/system/NumericalIntegrationTest.java
@@ -12,9 +12,9 @@ import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.numbers.N1;
 import org.junit.jupiter.api.Test;
 
-public class NumericalIntegrationTest {
+class NumericalIntegrationTest {
   @Test
-  public void testExponential() {
+  void testExponential() {
     Matrix<N1, N1> y0 = VecBuilder.fill(0.0);
 
     var y1 =
@@ -31,7 +31,7 @@ public class NumericalIntegrationTest {
   }
 
   @Test
-  public void testExponentialRKF45() {
+  void testExponentialRKF45() {
     Matrix<N1, N1> y0 = VecBuilder.fill(0.0);
 
     var y1 =
@@ -49,7 +49,7 @@ public class NumericalIntegrationTest {
   }
 
   @Test
-  public void testExponentialRKDP() {
+  void testExponentialRKDP() {
     Matrix<N1, N1> y0 = VecBuilder.fill(0.0);
 
     var y1 =

--- a/wpimath/src/test/java/edu/wpi/first/math/system/RungeKuttaTimeVaryingTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/system/RungeKuttaTimeVaryingTest.java
@@ -12,7 +12,7 @@ import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.numbers.N1;
 import org.junit.jupiter.api.Test;
 
-public class RungeKuttaTimeVaryingTest {
+class RungeKuttaTimeVaryingTest {
   private static Matrix<N1, N1> rungeKuttaTimeVaryingSolution(double t) {
     return new MatBuilder<>(Nat.N1(), Nat.N1())
         .fill(12.0 * Math.exp(t) / (Math.pow(Math.exp(t) + 1.0, 2.0)));
@@ -26,7 +26,7 @@ public class RungeKuttaTimeVaryingTest {
   //
   // x(t) = 12 * e^t / ((e^t + 1)^2)
   @Test
-  public void rungeKuttaTimeVaryingTest() {
+  void rungeKuttaTimeVaryingTest() {
     final var y0 = rungeKuttaTimeVaryingSolution(5.0);
 
     final var y1 =

--- a/wpimath/src/test/java/edu/wpi/first/math/trajectory/EllipticalRegionConstraintTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/trajectory/EllipticalRegionConstraintTest.java
@@ -16,7 +16,7 @@ import edu.wpi.first.math.util.Units;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class EllipticalRegionConstraintTest {
+class EllipticalRegionConstraintTest {
   @Test
   void testConstraint() {
     // Create constraints

--- a/wpimath/src/test/java/edu/wpi/first/math/trajectory/RectangularRegionConstraintTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/trajectory/RectangularRegionConstraintTest.java
@@ -16,7 +16,7 @@ import edu.wpi.first.math.util.Units;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class RectangularRegionConstraintTest {
+class RectangularRegionConstraintTest {
   @Test
   void testConstraint() {
     // Create constraints

--- a/wpimath/src/test/java/edu/wpi/first/math/trajectory/TrajectoryJsonTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/trajectory/TrajectoryJsonTest.java
@@ -12,7 +12,7 @@ import edu.wpi.first.math.trajectory.constraint.DifferentialDriveKinematicsConst
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class TrajectoryJsonTest {
+class TrajectoryJsonTest {
   @Test
   void deserializeMatches() {
     var config =

--- a/wpimath/src/test/java/edu/wpi/first/math/trajectory/TrapezoidProfileTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/trajectory/TrapezoidProfileTest.java
@@ -201,7 +201,7 @@ class TrapezoidProfileTest {
     for (int i = 0; i < 400; i++) {
       profile = new TrapezoidProfile(constraints, goal, state);
       state = profile.calculate(kDt);
-      if (!reachedGoal && (Math.abs(state.velocity - 1) < 10e-5)) {
+      if (!reachedGoal && Math.abs(state.velocity - 1) < 10e-5) {
         assertNear(predictedTimeLeft, i / 100.0, 2e-2);
         reachedGoal = true;
       }
@@ -244,7 +244,7 @@ class TrapezoidProfileTest {
     for (int i = 0; i < 400; i++) {
       profile = new TrapezoidProfile(constraints, goal, state);
       state = profile.calculate(kDt);
-      if (!reachedGoal && (Math.abs(state.velocity + 1) < 10e-5)) {
+      if (!reachedGoal && Math.abs(state.velocity + 1) < 10e-5) {
         assertNear(predictedTimeLeft, i / 100.0, 2e-2);
         reachedGoal = true;
       }

--- a/wpimath/src/test/java/edu/wpi/first/math/util/UnitsTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/util/UnitsTest.java
@@ -64,6 +64,7 @@ class UnitsTest extends UtilityClassTest<Units> {
     assertEquals(1500, Units.secondsToMilliseconds(1.5), 1e-2);
   }
 
+  @Test
   void kilogramsToLbsTest() {
     assertEquals(2.20462, Units.kilogramsToLbs(1), 1e-2);
   }

--- a/wpimath/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/wpilibj/UtilityClassTest.java
@@ -34,19 +34,20 @@ public abstract class UtilityClassTest<T> {
   }
 
   @Test
-  public void singleConstructorTest() {
+  void singleConstructorTest() {
     assertEquals(1, m_clazz.getDeclaredConstructors().length, "More than one constructor defined");
   }
 
   @Test
-  public void constructorPrivateTest() {
+  void constructorPrivateTest() {
     Constructor<?> constructor = m_clazz.getDeclaredConstructors()[0];
 
     assertFalse(constructor.canAccess(null), "Constructor is not private");
   }
 
   @Test
-  public void constructorReflectionTest() {
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+  void constructorReflectionTest() {
     Constructor<?> constructor = m_clazz.getDeclaredConstructors()[0];
     constructor.setAccessible(true);
     assertThrows(InvocationTargetException.class, constructor::newInstance);

--- a/wpiutil/CMakeLists.txt
+++ b/wpiutil/CMakeLists.txt
@@ -14,18 +14,18 @@ if (WITH_JAVA)
   include(UseJava)
   set(CMAKE_JAVA_COMPILE_FLAGS "-encoding" "UTF8" "-Xlint:unchecked")
 
-  if(NOT EXISTS "${WPILIB_BINARY_DIR}/wpiutil/thirdparty/jackson/jackson-core-2.10.0.jar")
+  if(NOT EXISTS "${WPILIB_BINARY_DIR}/wpiutil/thirdparty/jackson/jackson-core-2.12.4.jar")
         set(BASE_URL "https://search.maven.org/remotecontent?filepath=")
         set(JAR_ROOT "${WPILIB_BINARY_DIR}/wpiutil/thirdparty/jackson")
 
         message(STATUS "Downloading Jackson jarfiles...")
 
-        file(DOWNLOAD "${BASE_URL}com/fasterxml/jackson/core/jackson-core/2.10.0/jackson-core-2.10.0.jar"
-            "${JAR_ROOT}/jackson-core-2.10.0.jar")
-        file(DOWNLOAD "${BASE_URL}com/fasterxml/jackson/core/jackson-databind/2.10.0/jackson-databind-2.10.0.jar"
-            "${JAR_ROOT}/jackson-databind-2.10.0.jar")
-        file(DOWNLOAD "${BASE_URL}com/fasterxml/jackson/core/jackson-annotations/2.10.0/jackson-annotations-2.10.0.jar"
-            "${JAR_ROOT}/jackson-annotations-2.10.0.jar")
+        file(DOWNLOAD "${BASE_URL}com/fasterxml/jackson/core/jackson-core/2.12.4/jackson-core-2.12.4.jar"
+            "${JAR_ROOT}/jackson-core-2.12.4.jar")
+        file(DOWNLOAD "${BASE_URL}com/fasterxml/jackson/core/jackson-databind/2.12.4/jackson-databind-2.12.4.jar"
+            "${JAR_ROOT}/jackson-databind-2.12.4.jar")
+        file(DOWNLOAD "${BASE_URL}com/fasterxml/jackson/core/jackson-annotations/2.12.4/jackson-annotations-2.12.4.jar"
+            "${JAR_ROOT}/jackson-annotations-2.12.4.jar")
 
         message(STATUS "All files downloaded.")
     endif()

--- a/wpiutil/build.gradle
+++ b/wpiutil/build.gradle
@@ -294,7 +294,7 @@ model {
 }
 
 dependencies {
-    api "com.fasterxml.jackson.core:jackson-annotations:2.10.0"
-    api "com.fasterxml.jackson.core:jackson-core:2.10.0"
-    api "com.fasterxml.jackson.core:jackson-databind:2.10.0"
+    api "com.fasterxml.jackson.core:jackson-annotations:2.12.4"
+    api "com.fasterxml.jackson.core:jackson-core:2.12.4"
+    api "com.fasterxml.jackson.core:jackson-databind:2.12.4"
 }

--- a/wpiutil/src/main/java/edu/wpi/first/util/RuntimeDetector.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/RuntimeDetector.java
@@ -150,7 +150,7 @@ public final class RuntimeDetector {
    * @return if architecture is aarch64
    */
   public static boolean isAarch64() {
-    return System.getProperty("os.arch").equals("aarch64");
+    return "aarch64".equals(System.getProperty("os.arch"));
   }
 
   public static boolean isLinux() {

--- a/wpiutil/src/main/java/edu/wpi/first/util/RuntimeLoader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/RuntimeLoader.java
@@ -140,12 +140,12 @@ public final class RuntimeLoader<T> {
     } catch (UnsatisfiedLinkError ule) {
       // Then load the hash from the input file
       String resname = RuntimeDetector.getLibraryResource(m_libraryName);
-      String hash = null;
+      String hash;
       try (InputStream is = m_loadClass.getResourceAsStream(resname)) {
         if (is == null) {
           throw new IOException(getLoadErrorMessage(ule));
         }
-        MessageDigest md = null;
+        MessageDigest md;
         try {
           md = MessageDigest.getInstance("MD5");
         } catch (NoSuchAlgorithmException nsae) {

--- a/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableRegistry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableRegistry.java
@@ -462,7 +462,7 @@ public class SendableRegistry {
    * @param dataHandle data handle to get data object passed to callback
    * @param callback function to call for each object
    */
-  @SuppressWarnings("PMD.AvoidCatchingThrowable")
+  @SuppressWarnings({"PMD.AvoidCatchingThrowable", "PMD.AvoidReassigningCatchVariables"})
   public static synchronized void foreachLiveWindow(
       int dataHandle, Consumer<CallbackData> callback) {
     CallbackData cbdata = new CallbackData();


### PR DESCRIPTION
This also makes the Gradle build work with JDK 17.

The extra JVM args in gradle.properties works around a bug with spotless
and JDK 17: https://github.com/diffplug/spotless/issues/834

PMD.CloseResource was ignored because it's almost always a false
positive, and there are many of them.