### PR TITLE
Fix duplicate port allocations in SwerveBot/SwerveDrivePoseEstimator/RomiReference

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/subsystems/OnBoardIO.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/subsystems/OnBoardIO.cpp
@@ -17,6 +17,7 @@ OnBoardIO::OnBoardIO(OnBoardIO::ChannelMode dio1, OnBoardIO::ChannelMode dio2) {
   }
   if (dio2 == ChannelMode::INPUT) {
     m_buttonC = std::make_unique<frc::DigitalInput>(2);
+  } else {
     m_redLed = std::make_unique<frc::DigitalOutput>(2);
   }
 }

--- a/wpilibcExamples/src/main/cpp/examples/SwerveBot/include/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveBot/include/Drivetrain.h
@@ -36,7 +36,7 @@ class Drivetrain {
   frc::Translation2d m_backRightLocation{-0.381_m, -0.381_m};
 
   SwerveModule m_frontLeft{1, 2, 0, 1, 2, 3};
-  SwerveModule m_frontRight{2, 3, 4, 5, 6, 7};
+  SwerveModule m_frontRight{3, 4, 4, 5, 6, 7};
   SwerveModule m_backLeft{5, 6, 8, 9, 10, 11};
   SwerveModule m_backRight{7, 8, 12, 13, 14, 15};
 

--- a/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/include/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/include/Drivetrain.h
@@ -36,7 +36,7 @@ class Drivetrain {
   frc::Translation2d m_backRightLocation{-0.381_m, -0.381_m};
 
   SwerveModule m_frontLeft{1, 2, 0, 1, 2, 3};
-  SwerveModule m_frontRight{2, 3, 4, 5, 6, 7};
+  SwerveModule m_frontRight{3, 4, 4, 5, 6, 7};
   SwerveModule m_backLeft{5, 6, 8, 9, 10, 11};
   SwerveModule m_backRight{7, 8, 12, 13, 14, 15};
 


### PR DESCRIPTION
These caused the code to crash when running.