### PR TITLE
[hal] Refactor REV PDH

### DIFF
--- a/hal/src/main/native/athena/PowerDistribution.cpp
+++ b/hal/src/main/native/athena/PowerDistribution.cpp
@@ -55,7 +55,7 @@ HAL_PowerDistributionHandle HAL_InitializePowerDistribution(
       HAL_CleanPDP(pdpHandle);
     }
     *status = 0;
-    auto pdhHandle = HAL_REV_InitializePDH(1, allocationLocation, status);
+    auto pdhHandle = HAL_InitializeREVPDH(1, allocationLocation, status);
     return static_cast<HAL_PowerDistributionHandle>(pdhHandle);
   }
 
@@ -70,7 +70,7 @@ HAL_PowerDistributionHandle HAL_InitializePowerDistribution(
       moduleNumber = 1;
     }
     return static_cast<HAL_PowerDistributionHandle>(
-        HAL_REV_InitializePDH(moduleNumber, allocationLocation, status));
+        HAL_InitializeREVPDH(moduleNumber, allocationLocation, status));
   }
 }
 
@@ -80,7 +80,7 @@ void HAL_CleanPowerDistribution(HAL_PowerDistributionHandle handle) {
   if (IsCtre(handle)) {
     HAL_CleanPDP(handle);
   } else {
-    HAL_REV_FreePDH(handle);
+    HAL_FreeREVPDH(handle);
   }
 }
 
@@ -89,7 +89,7 @@ int32_t HAL_GetPowerDistributionModuleNumber(HAL_PowerDistributionHandle handle,
   if (IsCtre(handle)) {
     return HAL_GetPDPModuleNumber(handle, status);
   } else {
-    return HAL_REV_GetPDHModuleNumber(handle, status);
+    return HAL_GetREVPDHModuleNumber(handle, status);
   }
 }
 
@@ -98,7 +98,7 @@ HAL_Bool HAL_CheckPowerDistributionChannel(HAL_PowerDistributionHandle handle,
   if (IsCtre(handle)) {
     return HAL_CheckPDPChannel(channel);
   } else {
-    return HAL_REV_CheckPDHChannelNumber(channel);
+    return HAL_CheckREVPDHChannelNumber(channel);
   }
 }
 
@@ -107,7 +107,7 @@ HAL_Bool HAL_CheckPowerDistributionModule(int32_t module,
   if (type == HAL_PowerDistributionType::HAL_PowerDistributionType_kCTRE) {
     return HAL_CheckPDPModule(module);
   } else {
-    return HAL_REV_CheckPDHModuleNumber(module);
+    return HAL_CheckREVPDHModuleNumber(module);
   }
 }
 
@@ -142,7 +142,7 @@ double HAL_GetPowerDistributionVoltage(HAL_PowerDistributionHandle handle,
   if (IsCtre(handle)) {
     return HAL_GetPDPVoltage(handle, status);
   } else {
-    return HAL_REV_GetPDHSupplyVoltage(handle, status);
+    return HAL_GetREVPDHVoltage(handle, status);
   }
 }
 
@@ -151,7 +151,7 @@ double HAL_GetPowerDistributionChannelCurrent(
   if (IsCtre(handle)) {
     return HAL_GetPDPChannelCurrent(handle, channel, status);
   } else {
-    return HAL_REV_GetPDHChannelCurrent(handle, channel, status);
+    return HAL_GetREVPDHChannelCurrent(handle, channel, status);
   }
 }
 
@@ -171,7 +171,7 @@ void HAL_GetPowerDistributionAllChannelCurrents(
       SetLastError(status, "Output array not large enough");
       return;
     }
-    return HAL_REV_GetPDHAllChannelCurrents(handle, currents, status);
+    return HAL_GetREVPDHAllChannelCurrents(handle, currents, status);
   }
 }
 
@@ -180,7 +180,7 @@ double HAL_GetPowerDistributionTotalCurrent(HAL_PowerDistributionHandle handle,
   if (IsCtre(handle)) {
     return HAL_GetPDPTotalCurrent(handle, status);
   } else {
-    return HAL_REV_GetPDHTotalCurrent(handle, status);
+    return HAL_GetREVPDHTotalCurrent(handle, status);
   }
 }
 
@@ -218,7 +218,7 @@ void HAL_ClearPowerDistributionStickyFaults(HAL_PowerDistributionHandle handle,
   if (IsCtre(handle)) {
     HAL_ClearPDPStickyFaults(handle, status);
   } else {
-    HAL_REV_ClearPDHStickyFaults(handle, status);
+    HAL_ClearREVPDHStickyFaults(handle, status);
   }
 }
 
@@ -228,7 +228,7 @@ void HAL_SetPowerDistributionSwitchableChannel(
     // No-op on CTRE
     return;
   } else {
-    HAL_REV_SetPDHSwitchableChannel(handle, enabled, status);
+    HAL_SetREVPDHSwitchableChannel(handle, enabled, status);
   }
 }
 
@@ -238,7 +238,7 @@ HAL_Bool HAL_GetPowerDistributionSwitchableChannel(
     // No-op on CTRE
     return false;
   } else {
-    return HAL_REV_GetPDHSwitchableChannelState(handle, status);
+    return HAL_GetREVPDHSwitchableChannelState(handle, status);
   }
 }
 

--- a/hal/src/main/native/athena/PowerDistribution.cpp
+++ b/hal/src/main/native/athena/PowerDistribution.cpp
@@ -218,7 +218,7 @@ void HAL_ClearPowerDistributionStickyFaults(HAL_PowerDistributionHandle handle,
   if (IsCtre(handle)) {
     HAL_ClearPDPStickyFaults(handle, status);
   } else {
-    HAL_REV_ClearPDHFaults(handle, status);
+    HAL_REV_ClearPDHStickyFaults(handle, status);
   }
 }
 

--- a/hal/src/main/native/athena/REVPDH.cpp
+++ b/hal/src/main/native/athena/REVPDH.cpp
@@ -43,31 +43,25 @@ static constexpr uint32_t APIFromExtId(uint32_t extId) {
   return (extId >> 6) & 0x3FF;
 }
 
-static constexpr uint32_t PDH_SWITCH_CHANNEL_SET_FRAME_API =
-    APIFromExtId(PDH_SWITCH_CHANNEL_SET_FRAME_ID);
+static constexpr uint32_t PDH_SET_SWITCH_CHANNEL_FRAME_API =
+    APIFromExtId(PDH_SET_SWITCH_CHANNEL_FRAME_ID);
 
-static constexpr uint32_t PDH_STATUS0_FRAME_API =
-    APIFromExtId(PDH_STATUS0_FRAME_ID);
-static constexpr uint32_t PDH_STATUS1_FRAME_API =
-    APIFromExtId(PDH_STATUS1_FRAME_ID);
-static constexpr uint32_t PDH_STATUS2_FRAME_API =
-    APIFromExtId(PDH_STATUS2_FRAME_ID);
-static constexpr uint32_t PDH_STATUS3_FRAME_API =
-    APIFromExtId(PDH_STATUS3_FRAME_ID);
-static constexpr uint32_t PDH_STATUS4_FRAME_API =
-    APIFromExtId(PDH_STATUS4_FRAME_ID);
+static constexpr uint32_t PDH_STATUS_0_FRAME_API =
+    APIFromExtId(PDH_STATUS_0_FRAME_ID);
+static constexpr uint32_t PDH_STATUS_1_FRAME_API =
+    APIFromExtId(PDH_STATUS_1_FRAME_ID);
+static constexpr uint32_t PDH_STATUS_2_FRAME_API =
+    APIFromExtId(PDH_STATUS_2_FRAME_ID);
+static constexpr uint32_t PDH_STATUS_3_FRAME_API =
+    APIFromExtId(PDH_STATUS_3_FRAME_ID);
+static constexpr uint32_t PDH_STATUS_4_FRAME_API =
+    APIFromExtId(PDH_STATUS_4_FRAME_ID);
 
 static constexpr uint32_t PDH_CLEAR_FAULTS_FRAME_API =
     APIFromExtId(PDH_CLEAR_FAULTS_FRAME_ID);
 
-static constexpr uint32_t PDH_IDENTIFY_FRAME_API =
-    APIFromExtId(PDH_IDENTIFY_FRAME_ID);
-
 static constexpr uint32_t PDH_VERSION_FRAME_API =
     APIFromExtId(PDH_VERSION_FRAME_ID);
-
-static constexpr uint32_t PDH_CONFIGURE_HR_CHANNEL_FRAME_API =
-    APIFromExtId(PDH_CONFIGURE_HR_CHANNEL_FRAME_ID);
 
 static constexpr int32_t kPDHFrameStatus0Timeout = 20;
 static constexpr int32_t kPDHFrameStatus1Timeout = 20;
@@ -89,97 +83,97 @@ void InitializeREVPDH() {
 
 extern "C" {
 
-static PDH_status0_t HAL_REV_ReadPDHStatus0(HAL_CANHandle hcan,
-                                            int32_t* status) {
+static PDH_status_0_t HAL_REV_ReadPDHStatus0(HAL_CANHandle hcan,
+                                             int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
   uint64_t timestamp = 0;
-  PDH_status0_t result = {};
+  PDH_status_0_t result = {};
 
-  HAL_ReadCANPacketTimeout(hcan, PDH_STATUS0_FRAME_API, packedData, &length,
+  HAL_ReadCANPacketTimeout(hcan, PDH_STATUS_0_FRAME_API, packedData, &length,
                            &timestamp, kPDHFrameStatus0Timeout * 2, status);
 
   if (*status != 0) {
     return result;
   }
 
-  PDH_status0_unpack(&result, packedData, PDH_STATUS0_LENGTH);
+  PDH_status_0_unpack(&result, packedData, PDH_STATUS_0_LENGTH);
 
   return result;
 }
 
-static PDH_status1_t HAL_REV_ReadPDHStatus1(HAL_CANHandle hcan,
-                                            int32_t* status) {
+static PDH_status_1_t HAL_REV_ReadPDHStatus1(HAL_CANHandle hcan,
+                                             int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
   uint64_t timestamp = 0;
-  PDH_status1_t result = {};
+  PDH_status_1_t result = {};
 
-  HAL_ReadCANPacketTimeout(hcan, PDH_STATUS1_FRAME_API, packedData, &length,
+  HAL_ReadCANPacketTimeout(hcan, PDH_STATUS_1_FRAME_API, packedData, &length,
                            &timestamp, kPDHFrameStatus1Timeout * 2, status);
 
   if (*status != 0) {
     return result;
   }
 
-  PDH_status1_unpack(&result, packedData, PDH_STATUS1_LENGTH);
+  PDH_status_1_unpack(&result, packedData, PDH_STATUS_1_LENGTH);
 
   return result;
 }
 
-static PDH_status2_t HAL_REV_ReadPDHStatus2(HAL_CANHandle hcan,
-                                            int32_t* status) {
+static PDH_status_2_t HAL_REV_ReadPDHStatus2(HAL_CANHandle hcan,
+                                             int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
   uint64_t timestamp = 0;
-  PDH_status2_t result = {};
+  PDH_status_2_t result = {};
 
-  HAL_ReadCANPacketTimeout(hcan, PDH_STATUS2_FRAME_API, packedData, &length,
+  HAL_ReadCANPacketTimeout(hcan, PDH_STATUS_2_FRAME_API, packedData, &length,
                            &timestamp, kPDHFrameStatus2Timeout * 2, status);
 
   if (*status != 0) {
     return result;
   }
 
-  PDH_status2_unpack(&result, packedData, PDH_STATUS2_LENGTH);
+  PDH_status_2_unpack(&result, packedData, PDH_STATUS_2_LENGTH);
 
   return result;
 }
 
-static PDH_status3_t HAL_REV_ReadPDHStatus3(HAL_CANHandle hcan,
-                                            int32_t* status) {
+static PDH_status_3_t HAL_REV_ReadPDHStatus3(HAL_CANHandle hcan,
+                                             int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
   uint64_t timestamp = 0;
-  PDH_status3_t result = {};
+  PDH_status_3_t result = {};
 
-  HAL_ReadCANPacketTimeout(hcan, PDH_STATUS3_FRAME_API, packedData, &length,
+  HAL_ReadCANPacketTimeout(hcan, PDH_STATUS_3_FRAME_API, packedData, &length,
                            &timestamp, kPDHFrameStatus3Timeout * 2, status);
 
   if (*status != 0) {
     return result;
   }
 
-  PDH_status3_unpack(&result, packedData, PDH_STATUS3_LENGTH);
+  PDH_status_3_unpack(&result, packedData, PDH_STATUS_3_LENGTH);
 
   return result;
 }
 
-static PDH_status4_t HAL_REV_ReadPDHStatus4(HAL_CANHandle hcan,
-                                            int32_t* status) {
+static PDH_status_4_t HAL_REV_ReadPDHStatus4(HAL_CANHandle hcan,
+                                             int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
   uint64_t timestamp = 0;
-  PDH_status4_t result = {};
+  PDH_status_4_t result = {};
 
-  HAL_ReadCANPacketTimeout(hcan, PDH_STATUS4_FRAME_API, packedData, &length,
+  HAL_ReadCANPacketTimeout(hcan, PDH_STATUS_4_FRAME_API, packedData, &length,
                            &timestamp, kPDHFrameStatus4Timeout * 2, status);
 
   if (*status != 0) {
     return result;
   }
 
-  PDH_status4_unpack(&result, packedData, PDH_STATUS4_LENGTH);
+  PDH_status_4_unpack(&result, packedData, PDH_STATUS_4_LENGTH);
 
   return result;
 }
@@ -187,8 +181,8 @@ static PDH_status4_t HAL_REV_ReadPDHStatus4(HAL_CANHandle hcan,
 /**
  * Helper function for the individual getter functions for status 4
  */
-PDH_status4_t HAL_REV_GetPDHStatus4(HAL_REVPDHHandle handle, int32_t* status) {
-  PDH_status4_t statusFrame = {};
+PDH_status_4_t HAL_REV_GetPDHStatus4(HAL_REVPDHHandle handle, int32_t* status) {
+  PDH_status_4_t statusFrame = {};
   auto hpdh = REVPDHHandles->Get(handle);
   if (hpdh == nullptr) {
     *status = HAL_HANDLE_ERROR;
@@ -275,94 +269,94 @@ double HAL_REV_GetPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
   // Determine what periodic status the channel is in
   if (channel < 6) {
     // Periodic status 0
-    PDH_status0_t statusFrame = HAL_REV_ReadPDHStatus0(hpdh->hcan, status);
+    PDH_status_0_t statusFrame = HAL_REV_ReadPDHStatus0(hpdh->hcan, status);
     switch (channel) {
       case 0:
-        return PDH_status0_channel_0_current_decode(
+        return PDH_status_0_channel_0_current_decode(
             statusFrame.channel_0_current);
       case 1:
-        return PDH_status0_channel_1_current_decode(
+        return PDH_status_0_channel_1_current_decode(
             statusFrame.channel_1_current);
       case 2:
-        return PDH_status0_channel_2_current_decode(
+        return PDH_status_0_channel_2_current_decode(
             statusFrame.channel_2_current);
       case 3:
-        return PDH_status0_channel_3_current_decode(
+        return PDH_status_0_channel_3_current_decode(
             statusFrame.channel_3_current);
       case 4:
-        return PDH_status0_channel_4_current_decode(
+        return PDH_status_0_channel_4_current_decode(
             statusFrame.channel_4_current);
       case 5:
-        return PDH_status0_channel_5_current_decode(
+        return PDH_status_0_channel_5_current_decode(
             statusFrame.channel_5_current);
     }
   } else if (channel < 12) {
     // Periodic status 1
-    PDH_status1_t statusFrame = HAL_REV_ReadPDHStatus1(hpdh->hcan, status);
+    PDH_status_1_t statusFrame = HAL_REV_ReadPDHStatus1(hpdh->hcan, status);
     switch (channel) {
       case 6:
-        return PDH_status1_channel_6_current_decode(
+        return PDH_status_1_channel_6_current_decode(
             statusFrame.channel_6_current);
       case 7:
-        return PDH_status1_channel_7_current_decode(
+        return PDH_status_1_channel_7_current_decode(
             statusFrame.channel_7_current);
       case 8:
-        return PDH_status1_channel_8_current_decode(
+        return PDH_status_1_channel_8_current_decode(
             statusFrame.channel_8_current);
       case 9:
-        return PDH_status1_channel_9_current_decode(
+        return PDH_status_1_channel_9_current_decode(
             statusFrame.channel_9_current);
       case 10:
-        return PDH_status1_channel_10_current_decode(
+        return PDH_status_1_channel_10_current_decode(
             statusFrame.channel_10_current);
       case 11:
-        return PDH_status1_channel_11_current_decode(
+        return PDH_status_1_channel_11_current_decode(
             statusFrame.channel_11_current);
     }
   } else if (channel < 18) {
     // Periodic status 2
-    PDH_status2_t statusFrame = HAL_REV_ReadPDHStatus2(hpdh->hcan, status);
+    PDH_status_2_t statusFrame = HAL_REV_ReadPDHStatus2(hpdh->hcan, status);
     switch (channel) {
       case 12:
-        return PDH_status2_channel_12_current_decode(
+        return PDH_status_2_channel_12_current_decode(
             statusFrame.channel_12_current);
       case 13:
-        return PDH_status2_channel_13_current_decode(
+        return PDH_status_2_channel_13_current_decode(
             statusFrame.channel_13_current);
       case 14:
-        return PDH_status2_channel_14_current_decode(
+        return PDH_status_2_channel_14_current_decode(
             statusFrame.channel_14_current);
       case 15:
-        return PDH_status2_channel_15_current_decode(
+        return PDH_status_2_channel_15_current_decode(
             statusFrame.channel_15_current);
       case 16:
-        return PDH_status2_channel_16_current_decode(
+        return PDH_status_2_channel_16_current_decode(
             statusFrame.channel_16_current);
       case 17:
-        return PDH_status2_channel_17_current_decode(
+        return PDH_status_2_channel_17_current_decode(
             statusFrame.channel_17_current);
     }
   } else if (channel < 24) {
     // Periodic status 3
-    PDH_status3_t statusFrame = HAL_REV_ReadPDHStatus3(hpdh->hcan, status);
+    PDH_status_3_t statusFrame = HAL_REV_ReadPDHStatus3(hpdh->hcan, status);
     switch (channel) {
       case 18:
-        return PDH_status3_channel_18_current_decode(
+        return PDH_status_3_channel_18_current_decode(
             statusFrame.channel_18_current);
       case 19:
-        return PDH_status3_channel_19_current_decode(
+        return PDH_status_3_channel_19_current_decode(
             statusFrame.channel_19_current);
       case 20:
-        return PDH_status3_channel_20_current_decode(
+        return PDH_status_3_channel_20_current_decode(
             statusFrame.channel_20_current);
       case 21:
-        return PDH_status3_channel_21_current_decode(
+        return PDH_status_3_channel_21_current_decode(
             statusFrame.channel_21_current);
       case 22:
-        return PDH_status3_channel_22_current_decode(
+        return PDH_status_3_channel_22_current_decode(
             statusFrame.channel_22_current);
       case 23:
-        return PDH_status3_channel_23_current_decode(
+        return PDH_status_3_channel_23_current_decode(
             statusFrame.channel_23_current);
     }
   }
@@ -377,69 +371,69 @@ void HAL_REV_GetPDHAllChannelCurrents(HAL_REVPDHHandle handle, double* currents,
     return;
   }
 
-  PDH_status0_t statusFrame0 = HAL_REV_ReadPDHStatus0(hpdh->hcan, status);
-  PDH_status1_t statusFrame1 = HAL_REV_ReadPDHStatus1(hpdh->hcan, status);
-  PDH_status2_t statusFrame2 = HAL_REV_ReadPDHStatus2(hpdh->hcan, status);
-  PDH_status3_t statusFrame3 = HAL_REV_ReadPDHStatus3(hpdh->hcan, status);
+  PDH_status_0_t statusFrame0 = HAL_REV_ReadPDHStatus0(hpdh->hcan, status);
+  PDH_status_1_t statusFrame1 = HAL_REV_ReadPDHStatus1(hpdh->hcan, status);
+  PDH_status_2_t statusFrame2 = HAL_REV_ReadPDHStatus2(hpdh->hcan, status);
+  PDH_status_3_t statusFrame3 = HAL_REV_ReadPDHStatus3(hpdh->hcan, status);
 
   currents[0] =
-      PDH_status0_channel_0_current_decode(statusFrame0.channel_0_current);
+      PDH_status_0_channel_0_current_decode(statusFrame0.channel_0_current);
   currents[1] =
-      PDH_status0_channel_1_current_decode(statusFrame0.channel_1_current);
+      PDH_status_0_channel_1_current_decode(statusFrame0.channel_1_current);
   currents[2] =
-      PDH_status0_channel_2_current_decode(statusFrame0.channel_2_current);
+      PDH_status_0_channel_2_current_decode(statusFrame0.channel_2_current);
   currents[3] =
-      PDH_status0_channel_3_current_decode(statusFrame0.channel_3_current);
+      PDH_status_0_channel_3_current_decode(statusFrame0.channel_3_current);
   currents[4] =
-      PDH_status0_channel_4_current_decode(statusFrame0.channel_4_current);
+      PDH_status_0_channel_4_current_decode(statusFrame0.channel_4_current);
   currents[5] =
-      PDH_status0_channel_5_current_decode(statusFrame0.channel_5_current);
+      PDH_status_0_channel_5_current_decode(statusFrame0.channel_5_current);
   currents[6] =
-      PDH_status1_channel_6_current_decode(statusFrame1.channel_6_current);
+      PDH_status_1_channel_6_current_decode(statusFrame1.channel_6_current);
   currents[7] =
-      PDH_status1_channel_7_current_decode(statusFrame1.channel_7_current);
+      PDH_status_1_channel_7_current_decode(statusFrame1.channel_7_current);
   currents[8] =
-      PDH_status1_channel_8_current_decode(statusFrame1.channel_8_current);
+      PDH_status_1_channel_8_current_decode(statusFrame1.channel_8_current);
   currents[9] =
-      PDH_status1_channel_9_current_decode(statusFrame1.channel_9_current);
+      PDH_status_1_channel_9_current_decode(statusFrame1.channel_9_current);
   currents[10] =
-      PDH_status1_channel_10_current_decode(statusFrame1.channel_10_current);
+      PDH_status_1_channel_10_current_decode(statusFrame1.channel_10_current);
   currents[11] =
-      PDH_status1_channel_11_current_decode(statusFrame1.channel_11_current);
+      PDH_status_1_channel_11_current_decode(statusFrame1.channel_11_current);
   currents[12] =
-      PDH_status2_channel_12_current_decode(statusFrame2.channel_12_current);
+      PDH_status_2_channel_12_current_decode(statusFrame2.channel_12_current);
   currents[13] =
-      PDH_status2_channel_13_current_decode(statusFrame2.channel_13_current);
+      PDH_status_2_channel_13_current_decode(statusFrame2.channel_13_current);
   currents[14] =
-      PDH_status2_channel_14_current_decode(statusFrame2.channel_14_current);
+      PDH_status_2_channel_14_current_decode(statusFrame2.channel_14_current);
   currents[15] =
-      PDH_status2_channel_15_current_decode(statusFrame2.channel_15_current);
+      PDH_status_2_channel_15_current_decode(statusFrame2.channel_15_current);
   currents[16] =
-      PDH_status2_channel_16_current_decode(statusFrame2.channel_16_current);
+      PDH_status_2_channel_16_current_decode(statusFrame2.channel_16_current);
   currents[17] =
-      PDH_status2_channel_17_current_decode(statusFrame2.channel_17_current);
+      PDH_status_2_channel_17_current_decode(statusFrame2.channel_17_current);
   currents[18] =
-      PDH_status3_channel_18_current_decode(statusFrame3.channel_18_current);
+      PDH_status_3_channel_18_current_decode(statusFrame3.channel_18_current);
   currents[19] =
-      PDH_status3_channel_19_current_decode(statusFrame3.channel_19_current);
+      PDH_status_3_channel_19_current_decode(statusFrame3.channel_19_current);
   currents[20] =
-      PDH_status3_channel_20_current_decode(statusFrame3.channel_20_current);
+      PDH_status_3_channel_20_current_decode(statusFrame3.channel_20_current);
   currents[21] =
-      PDH_status3_channel_21_current_decode(statusFrame3.channel_21_current);
+      PDH_status_3_channel_21_current_decode(statusFrame3.channel_21_current);
   currents[22] =
-      PDH_status3_channel_22_current_decode(statusFrame3.channel_22_current);
+      PDH_status_3_channel_22_current_decode(statusFrame3.channel_22_current);
   currents[23] =
-      PDH_status3_channel_23_current_decode(statusFrame3.channel_23_current);
+      PDH_status_3_channel_23_current_decode(statusFrame3.channel_23_current);
 }
 
 uint16_t HAL_REV_GetPDHTotalCurrent(HAL_REVPDHHandle handle, int32_t* status) {
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
+  PDH_status_4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
 
   if (*status != 0) {
     return 0;
   }
 
-  return PDH_status4_total_current_decode(statusFrame.total_current);
+  return PDH_status_4_total_current_decode(statusFrame.total_current);
 }
 
 void HAL_REV_SetPDHSwitchableChannel(HAL_REVPDHHandle handle, HAL_Bool enabled,
@@ -451,284 +445,35 @@ void HAL_REV_SetPDHSwitchableChannel(HAL_REVPDHHandle handle, HAL_Bool enabled,
   }
 
   uint8_t packedData[8] = {0};
-  PDH_switch_channel_set_t frame;
+  PDH_set_switch_channel_t frame;
   frame.output_set_value = enabled;
-  frame.use_system_enable = false;
-  PDH_switch_channel_set_pack(packedData, &frame, 1);
+  PDH_set_switch_channel_pack(packedData, &frame,
+                              PDH_SET_SWITCH_CHANNEL_LENGTH);
 
-  HAL_WriteCANPacket(hpdh->hcan, packedData, PDH_SWITCH_CHANNEL_SET_LENGTH,
-                     PDH_SWITCH_CHANNEL_SET_FRAME_API, status);
+  HAL_WriteCANPacket(hpdh->hcan, packedData, PDH_SET_SWITCH_CHANNEL_LENGTH,
+                     PDH_SET_SWITCH_CHANNEL_FRAME_API, status);
 }
 
 HAL_Bool HAL_REV_GetPDHSwitchableChannelState(HAL_REVPDHHandle handle,
                                               int32_t* status) {
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
+  PDH_status_4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
 
   if (*status != 0) {
     return 0.0;
   }
 
-  return PDH_status4_sw_state_decode(statusFrame.sw_state);
-}
-
-HAL_Bool HAL_REV_CheckPDHChannelBrownout(HAL_REVPDHHandle handle,
-                                         int32_t channel, int32_t* status) {
-  auto hpdh = REVPDHHandles->Get(handle);
-  if (hpdh == nullptr) {
-    *status = HAL_HANDLE_ERROR;
-    return 0;
-  }
-
-  if (!HAL_REV_CheckPDHChannelNumber(channel)) {
-    *status = RESOURCE_OUT_OF_RANGE;
-    return 0;
-  }
-
-  // Determine what periodic status the channel is in
-  if (channel < 4) {
-    // Periodic status 0
-    PDH_status0_t statusFrame = HAL_REV_ReadPDHStatus0(hpdh->hcan, status);
-    switch (channel) {
-      case 0:
-        return PDH_status0_channel_0_brownout_decode(
-            statusFrame.channel_0_brownout);
-      case 1:
-        return PDH_status0_channel_1_brownout_decode(
-            statusFrame.channel_1_brownout);
-      case 2:
-        return PDH_status0_channel_2_brownout_decode(
-            statusFrame.channel_2_brownout);
-      case 3:
-        return PDH_status0_channel_3_brownout_decode(
-            statusFrame.channel_3_brownout);
-    }
-  } else if (channel < 8) {
-    // Periodic status 1
-    PDH_status1_t statusFrame = HAL_REV_ReadPDHStatus1(hpdh->hcan, status);
-    switch (channel) {
-      case 4:
-        return PDH_status1_channel_4_brownout_decode(
-            statusFrame.channel_4_brownout);
-      case 5:
-        return PDH_status1_channel_5_brownout_decode(
-            statusFrame.channel_5_brownout);
-      case 6:
-        return PDH_status1_channel_6_brownout_decode(
-            statusFrame.channel_6_brownout);
-      case 7:
-        return PDH_status1_channel_7_brownout_decode(
-            statusFrame.channel_7_brownout);
-    }
-  } else if (channel < 12) {
-    // Periodic status 2
-    PDH_status2_t statusFrame = HAL_REV_ReadPDHStatus2(hpdh->hcan, status);
-    switch (channel) {
-      case 8:
-        return PDH_status2_channel_8_brownout_decode(
-            statusFrame.channel_8_brownout);
-      case 9:
-        return PDH_status2_channel_9_brownout_decode(
-            statusFrame.channel_9_brownout);
-      case 10:
-        return PDH_status2_channel_10_brownout_decode(
-            statusFrame.channel_10_brownout);
-      case 11:
-        return PDH_status2_channel_11_brownout_decode(
-            statusFrame.channel_11_brownout);
-    }
-  } else if (channel < 24) {
-    // Periodic status 3
-    PDH_status3_t statusFrame = HAL_REV_ReadPDHStatus3(hpdh->hcan, status);
-    switch (channel) {
-      case 12:
-        return PDH_status3_channel_12_brownout_decode(
-            statusFrame.channel_12_brownout);
-      case 13:
-        return PDH_status3_channel_13_brownout_decode(
-            statusFrame.channel_13_brownout);
-      case 14:
-        return PDH_status3_channel_14_brownout_decode(
-            statusFrame.channel_14_brownout);
-      case 15:
-        return PDH_status3_channel_15_brownout_decode(
-            statusFrame.channel_15_brownout);
-      case 16:
-        return PDH_status3_channel_16_brownout_decode(
-            statusFrame.channel_16_brownout);
-      case 17:
-        return PDH_status3_channel_17_brownout_decode(
-            statusFrame.channel_17_brownout);
-      case 18:
-        return PDH_status3_channel_18_brownout_decode(
-            statusFrame.channel_18_brownout);
-      case 19:
-        return PDH_status3_channel_19_brownout_decode(
-            statusFrame.channel_19_brownout);
-      case 20:
-        return PDH_status3_channel_20_brownout_decode(
-            statusFrame.channel_20_brownout);
-      case 21:
-        return PDH_status3_channel_21_brownout_decode(
-            statusFrame.channel_21_brownout);
-      case 22:
-        return PDH_status3_channel_22_brownout_decode(
-            statusFrame.channel_22_brownout);
-      case 23:
-        return PDH_status3_channel_23_brownout_decode(
-            statusFrame.channel_23_brownout);
-    }
-  }
-  return 0;
+  return PDH_status_4_switch_channel_state_decode(
+      statusFrame.switch_channel_state);
 }
 
 double HAL_REV_GetPDHSupplyVoltage(HAL_REVPDHHandle handle, int32_t* status) {
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
+  PDH_status_4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
 
   if (*status != 0) {
     return 0.0;
   }
 
-  return PDH_status4_v_bus_decode(statusFrame.v_bus);
-}
-
-HAL_Bool HAL_REV_IsPDHEnabled(HAL_REVPDHHandle handle, int32_t* status) {
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
-
-  if (*status != 0) {
-    return false;
-  }
-
-  return PDH_status4_system_enable_decode(statusFrame.system_enable);
-}
-
-HAL_Bool HAL_REV_CheckPDHBrownout(HAL_REVPDHHandle handle, int32_t* status) {
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
-
-  if (*status != 0) {
-    return false;
-  }
-
-  return PDH_status4_brownout_decode(statusFrame.brownout);
-}
-
-HAL_Bool HAL_REV_CheckPDHCANWarning(HAL_REVPDHHandle handle, int32_t* status) {
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
-
-  if (*status != 0) {
-    return 0.0;
-  }
-
-  return PDH_status4_can_warning_decode(statusFrame.can_warning);
-}
-
-HAL_Bool HAL_REV_CheckPDHHardwareFault(HAL_REVPDHHandle handle,
-                                       int32_t* status) {
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
-
-  if (*status != 0) {
-    return 0.0;
-  }
-
-  return PDH_status4_hardware_fault_decode(statusFrame.hardware_fault);
-}
-
-HAL_Bool HAL_REV_CheckPDHStickyBrownout(HAL_REVPDHHandle handle,
-                                        int32_t* status) {
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
-
-  if (*status != 0) {
-    return 0.0;
-  }
-
-  return PDH_status4_sticky_brownout_decode(statusFrame.sticky_brownout);
-}
-
-HAL_Bool HAL_REV_CheckPDHStickyCANWarning(HAL_REVPDHHandle handle,
-                                          int32_t* status) {
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
-
-  if (*status != 0) {
-    return 0.0;
-  }
-
-  return PDH_status4_sticky_can_warning_decode(statusFrame.sticky_can_warning);
-}
-
-HAL_Bool HAL_REV_CheckPDHStickyCANBusOff(HAL_REVPDHHandle handle,
-                                         int32_t* status) {
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
-
-  if (*status != 0) {
-    return 0.0;
-  }
-
-  return PDH_status4_sticky_can_bus_off_decode(statusFrame.sticky_can_bus_off);
-}
-
-HAL_Bool HAL_REV_CheckPDHStickyHardwareFault(HAL_REVPDHHandle handle,
-                                             int32_t* status) {
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
-
-  if (*status != 0) {
-    return 0.0;
-  }
-
-  return PDH_status4_sticky_hardware_fault_decode(
-      statusFrame.sticky_hardware_fault);
-}
-
-HAL_Bool HAL_REV_CheckPDHStickyFirmwareFault(HAL_REVPDHHandle handle,
-                                             int32_t* status) {
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
-
-  if (*status != 0) {
-    return 0.0;
-  }
-
-  return PDH_status4_sticky_firmware_fault_decode(
-      statusFrame.sticky_firmware_fault);
-}
-
-HAL_Bool HAL_REV_CheckPDHStickyChannelBrownout(HAL_REVPDHHandle handle,
-                                               int32_t channel,
-                                               int32_t* status) {
-  if (channel < 20 || channel > 23) {
-    *status = RESOURCE_OUT_OF_RANGE;
-    return 0.0;
-  }
-
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
-
-  if (*status != 0) {
-    return 0.0;
-  }
-
-  switch (channel) {
-    case 20:
-      return PDH_status4_sticky_ch20_brownout_decode(
-          statusFrame.sticky_ch20_brownout);
-    case 21:
-      return PDH_status4_sticky_ch21_brownout_decode(
-          statusFrame.sticky_ch21_brownout);
-    case 22:
-      return PDH_status4_sticky_ch22_brownout_decode(
-          statusFrame.sticky_ch22_brownout);
-    case 23:
-      return PDH_status4_sticky_ch23_brownout_decode(
-          statusFrame.sticky_ch23_brownout);
-  }
-  return 0;
-}
-
-HAL_Bool HAL_REV_CheckPDHStickyHasReset(HAL_REVPDHHandle handle,
-                                        int32_t* status) {
-  PDH_status4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
-
-  if (*status != 0) {
-    return 0.0;
-  }
-
-  return PDH_status4_sticky_has_reset_decode(statusFrame.sticky_has_reset);
+  return PDH_status_4_v_bus_decode(statusFrame.v_bus);
 }
 
 REV_PDH_Version HAL_REV_GetPDHVersion(HAL_REVPDHHandle handle,
@@ -765,10 +510,99 @@ REV_PDH_Version HAL_REV_GetPDHVersion(HAL_REVPDHHandle handle,
   version.firmwareMajor = result.firmware_year;
   version.firmwareMinor = result.firmware_minor;
   version.firmwareFix = result.firmware_fix;
-  version.hardwareRev = result.hardware_code;
+  version.hardwareMinor = result.hardware_minor;
+  version.hardwareMajor = result.hardware_major;
   version.uniqueId = result.unique_id;
 
   return version;
+}
+
+HAL_REVPDHFaults HAL_GetREVPDHFaults(HAL_REVPDHHandle handle, int32_t* status) {
+  HAL_REVPDHFaults faults = {};
+  auto hpdh = REVPDHHandles->Get(handle);
+  if (hpdh == nullptr) {
+    *status = HAL_HANDLE_ERROR;
+    return faults;
+  }
+
+  PDH_status_0_t status0 = HAL_REV_ReadPDHStatus0(hpdh->hcan, status);
+  PDH_status_1_t status1 = HAL_REV_ReadPDHStatus1(hpdh->hcan, status);
+  PDH_status_2_t status2 = HAL_REV_ReadPDHStatus2(hpdh->hcan, status);
+  PDH_status_3_t status3 = HAL_REV_ReadPDHStatus3(hpdh->hcan, status);
+  PDH_status_4_t status4 = HAL_REV_ReadPDHStatus4(hpdh->hcan, status);
+
+  faults.channel0BreakerFault = status0.channel_0_breaker_fault;
+  faults.channel1BreakerFault = status0.channel_1_breaker_fault;
+  faults.channel2BreakerFault = status0.channel_2_breaker_fault;
+  faults.channel3BreakerFault = status0.channel_3_breaker_fault;
+  faults.channel4BreakerFault = status1.channel_4_breaker_fault;
+  faults.channel5BreakerFault = status1.channel_5_breaker_fault;
+  faults.channel6BreakerFault = status1.channel_6_breaker_fault;
+  faults.channel7BreakerFault = status1.channel_7_breaker_fault;
+  faults.channel8BreakerFault = status2.channel_8_breaker_fault;
+  faults.channel9BreakerFault = status2.channel_9_breaker_fault;
+  faults.channel10BreakerFault = status2.channel_10_breaker_fault;
+  faults.channel11BreakerFault = status2.channel_11_breaker_fault;
+  faults.channel12BreakerFault = status3.channel_12_breaker_fault;
+  faults.channel13BreakerFault = status3.channel_13_breaker_fault;
+  faults.channel14BreakerFault = status3.channel_14_breaker_fault;
+  faults.channel15BreakerFault = status3.channel_15_breaker_fault;
+  faults.channel16BreakerFault = status3.channel_16_breaker_fault;
+  faults.channel17BreakerFault = status3.channel_17_breaker_fault;
+  faults.channel18BreakerFault = status3.channel_18_breaker_fault;
+  faults.channel19BreakerFault = status3.channel_19_breaker_fault;
+  faults.channel20BreakerFault = status3.channel_20_breaker_fault;
+  faults.channel21BreakerFault = status3.channel_21_breaker_fault;
+  faults.channel22BreakerFault = status3.channel_22_breaker_fault;
+  faults.channel23BreakerFault = status3.channel_23_breaker_fault;
+  faults.brownout = status4.brownout_fault;
+  faults.canWarning = status4.can_warning_fault;
+  faults.hardwareFault = status4.hardware_fault;
+
+  return faults;
+}
+
+HAL_REVPDHStickyFaults HAL_GetREVPDHStickyFaults(HAL_REVPDHHandle handle,
+                                                 int32_t* status) {
+  HAL_REVPDHStickyFaults stickyFaults = {};
+  auto hpdh = REVPDHHandles->Get(handle);
+  if (hpdh == nullptr) {
+    *status = HAL_HANDLE_ERROR;
+    return stickyFaults;
+  }
+
+  PDH_status_4_t status4 = HAL_REV_ReadPDHStatus4(hpdh->hcan, status);
+
+  stickyFaults.channel0BreakerFault = status4.sticky_ch0_breaker_fault;
+  stickyFaults.channel1BreakerFault = status4.sticky_ch1_breaker_fault;
+  stickyFaults.channel2BreakerFault = status4.sticky_ch2_breaker_fault;
+  stickyFaults.channel3BreakerFault = status4.sticky_ch3_breaker_fault;
+  stickyFaults.channel4BreakerFault = status4.sticky_ch4_breaker_fault;
+  stickyFaults.channel5BreakerFault = status4.sticky_ch5_breaker_fault;
+  stickyFaults.channel6BreakerFault = status4.sticky_ch6_breaker_fault;
+  stickyFaults.channel7BreakerFault = status4.sticky_ch7_breaker_fault;
+  stickyFaults.channel8BreakerFault = status4.sticky_ch8_breaker_fault;
+  stickyFaults.channel9BreakerFault = status4.sticky_ch9_breaker_fault;
+  stickyFaults.channel10BreakerFault = status4.sticky_ch10_breaker_fault;
+  stickyFaults.channel11BreakerFault = status4.sticky_ch11_breaker_fault;
+  stickyFaults.channel12BreakerFault = status4.sticky_ch12_breaker_fault;
+  stickyFaults.channel13BreakerFault = status4.sticky_ch13_breaker_fault;
+  stickyFaults.channel14BreakerFault = status4.sticky_ch14_breaker_fault;
+  stickyFaults.channel15BreakerFault = status4.sticky_ch15_breaker_fault;
+  stickyFaults.channel16BreakerFault = status4.sticky_ch16_breaker_fault;
+  stickyFaults.channel17BreakerFault = status4.sticky_ch17_breaker_fault;
+  stickyFaults.channel18BreakerFault = status4.sticky_ch18_breaker_fault;
+  stickyFaults.channel19BreakerFault = status4.sticky_ch19_breaker_fault;
+  stickyFaults.channel20BreakerFault = status4.sticky_ch20_breaker_fault;
+  stickyFaults.channel21BreakerFault = status4.sticky_ch21_breaker_fault;
+  stickyFaults.channel22BreakerFault = status4.sticky_ch22_breaker_fault;
+  stickyFaults.channel23BreakerFault = status4.sticky_ch23_breaker_fault;
+  stickyFaults.brownout = status4.sticky_brownout_fault;
+  stickyFaults.canWarning = status4.sticky_can_warning_fault;
+  stickyFaults.canBusOff = status4.sticky_can_bus_off_fault;
+  stickyFaults.hasReset = status4.sticky_has_reset_fault;
+
+  return stickyFaults;
 }
 
 void HAL_REV_ClearPDHFaults(HAL_REVPDHHandle handle, int32_t* status) {
@@ -781,18 +615,6 @@ void HAL_REV_ClearPDHFaults(HAL_REVPDHHandle handle, int32_t* status) {
   uint8_t packedData[8] = {0};
   HAL_WriteCANPacket(hpdh->hcan, packedData, PDH_CLEAR_FAULTS_LENGTH,
                      PDH_CLEAR_FAULTS_FRAME_API, status);
-}
-
-void HAL_REV_IdentifyPDH(HAL_REVPDHHandle handle, int32_t* status) {
-  auto hpdh = REVPDHHandles->Get(handle);
-  if (hpdh == nullptr) {
-    *status = HAL_HANDLE_ERROR;
-    return;
-  }
-
-  uint8_t packedData[8] = {0};
-  HAL_WriteCANPacket(hpdh->hcan, packedData, PDH_IDENTIFY_LENGTH,
-                     PDH_IDENTIFY_FRAME_API, status);
 }
 
 }  // extern "C"

--- a/hal/src/main/native/athena/REVPDH.cpp
+++ b/hal/src/main/native/athena/REVPDH.cpp
@@ -84,7 +84,7 @@ void InitializeREVPDH() {
 extern "C" {
 
 static PDH_status_0_t HAL_ReadREVPDHStatus0(HAL_CANHandle hcan,
-                                             int32_t* status) {
+                                            int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
   uint64_t timestamp = 0;
@@ -103,7 +103,7 @@ static PDH_status_0_t HAL_ReadREVPDHStatus0(HAL_CANHandle hcan,
 }
 
 static PDH_status_1_t HAL_ReadREVPDHStatus1(HAL_CANHandle hcan,
-                                             int32_t* status) {
+                                            int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
   uint64_t timestamp = 0;
@@ -122,7 +122,7 @@ static PDH_status_1_t HAL_ReadREVPDHStatus1(HAL_CANHandle hcan,
 }
 
 static PDH_status_2_t HAL_ReadREVPDHStatus2(HAL_CANHandle hcan,
-                                             int32_t* status) {
+                                            int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
   uint64_t timestamp = 0;
@@ -141,7 +141,7 @@ static PDH_status_2_t HAL_ReadREVPDHStatus2(HAL_CANHandle hcan,
 }
 
 static PDH_status_3_t HAL_ReadREVPDHStatus3(HAL_CANHandle hcan,
-                                             int32_t* status) {
+                                            int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
   uint64_t timestamp = 0;
@@ -160,7 +160,7 @@ static PDH_status_3_t HAL_ReadREVPDHStatus3(HAL_CANHandle hcan,
 }
 
 static PDH_status_4_t HAL_ReadREVPDHStatus4(HAL_CANHandle hcan,
-                                             int32_t* status) {
+                                            int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
   uint64_t timestamp = 0;
@@ -194,8 +194,8 @@ PDH_status_4_t HAL_GetREVPDHStatus4(HAL_REVPDHHandle handle, int32_t* status) {
 }
 
 HAL_REVPDHHandle HAL_InitializeREVPDH(int32_t module,
-                                       const char* allocationLocation,
-                                       int32_t* status) {
+                                      const char* allocationLocation,
+                                      int32_t* status) {
   hal::init::CheckInit();
   if (!HAL_CheckREVPDHModuleNumber(module)) {
     *status = RESOURCE_OUT_OF_RANGE;
@@ -254,7 +254,7 @@ HAL_Bool HAL_CheckREVPDHChannelNumber(int32_t channel) {
 }
 
 double HAL_GetREVPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
-                                    int32_t* status) {
+                                   int32_t* status) {
   auto hpdh = REVPDHHandles->Get(handle);
   if (hpdh == nullptr) {
     *status = HAL_HANDLE_ERROR;
@@ -364,7 +364,7 @@ double HAL_GetREVPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
 }
 
 void HAL_GetREVPDHAllChannelCurrents(HAL_REVPDHHandle handle, double* currents,
-                                      int32_t* status) {
+                                     int32_t* status) {
   auto hpdh = REVPDHHandles->Get(handle);
   if (hpdh == nullptr) {
     *status = HAL_HANDLE_ERROR;
@@ -437,7 +437,7 @@ uint16_t HAL_GetREVPDHTotalCurrent(HAL_REVPDHHandle handle, int32_t* status) {
 }
 
 void HAL_SetREVPDHSwitchableChannel(HAL_REVPDHHandle handle, HAL_Bool enabled,
-                                     int32_t* status) {
+                                    int32_t* status) {
   auto hpdh = REVPDHHandles->Get(handle);
   if (hpdh == nullptr) {
     *status = HAL_HANDLE_ERROR;
@@ -455,7 +455,7 @@ void HAL_SetREVPDHSwitchableChannel(HAL_REVPDHHandle handle, HAL_Bool enabled,
 }
 
 HAL_Bool HAL_GetREVPDHSwitchableChannelState(HAL_REVPDHHandle handle,
-                                              int32_t* status) {
+                                             int32_t* status) {
   PDH_status_4_t statusFrame = HAL_GetREVPDHStatus4(handle, status);
 
   if (*status != 0) {
@@ -477,7 +477,7 @@ double HAL_GetREVPDHVoltage(HAL_REVPDHHandle handle, int32_t* status) {
 }
 
 HAL_REVPDHVersion HAL_GetREVPDHVersion(HAL_REVPDHHandle handle,
-                                      int32_t* status) {
+                                       int32_t* status) {
   HAL_REVPDHVersion version;
   std::memset(&version, 0, sizeof(version));
   uint8_t packedData[8] = {0};

--- a/hal/src/main/native/athena/REVPDH.cpp
+++ b/hal/src/main/native/athena/REVPDH.cpp
@@ -83,7 +83,7 @@ void InitializeREVPDH() {
 
 extern "C" {
 
-static PDH_status_0_t HAL_REV_ReadPDHStatus0(HAL_CANHandle hcan,
+static PDH_status_0_t HAL_ReadREVPDHStatus0(HAL_CANHandle hcan,
                                              int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
@@ -102,7 +102,7 @@ static PDH_status_0_t HAL_REV_ReadPDHStatus0(HAL_CANHandle hcan,
   return result;
 }
 
-static PDH_status_1_t HAL_REV_ReadPDHStatus1(HAL_CANHandle hcan,
+static PDH_status_1_t HAL_ReadREVPDHStatus1(HAL_CANHandle hcan,
                                              int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
@@ -121,7 +121,7 @@ static PDH_status_1_t HAL_REV_ReadPDHStatus1(HAL_CANHandle hcan,
   return result;
 }
 
-static PDH_status_2_t HAL_REV_ReadPDHStatus2(HAL_CANHandle hcan,
+static PDH_status_2_t HAL_ReadREVPDHStatus2(HAL_CANHandle hcan,
                                              int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
@@ -140,7 +140,7 @@ static PDH_status_2_t HAL_REV_ReadPDHStatus2(HAL_CANHandle hcan,
   return result;
 }
 
-static PDH_status_3_t HAL_REV_ReadPDHStatus3(HAL_CANHandle hcan,
+static PDH_status_3_t HAL_ReadREVPDHStatus3(HAL_CANHandle hcan,
                                              int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
@@ -159,7 +159,7 @@ static PDH_status_3_t HAL_REV_ReadPDHStatus3(HAL_CANHandle hcan,
   return result;
 }
 
-static PDH_status_4_t HAL_REV_ReadPDHStatus4(HAL_CANHandle hcan,
+static PDH_status_4_t HAL_ReadREVPDHStatus4(HAL_CANHandle hcan,
                                              int32_t* status) {
   uint8_t packedData[8] = {0};
   int32_t length = 0;
@@ -181,7 +181,7 @@ static PDH_status_4_t HAL_REV_ReadPDHStatus4(HAL_CANHandle hcan,
 /**
  * Helper function for the individual getter functions for status 4
  */
-PDH_status_4_t HAL_REV_GetPDHStatus4(HAL_REVPDHHandle handle, int32_t* status) {
+PDH_status_4_t HAL_GetREVPDHStatus4(HAL_REVPDHHandle handle, int32_t* status) {
   PDH_status_4_t statusFrame = {};
   auto hpdh = REVPDHHandles->Get(handle);
   if (hpdh == nullptr) {
@@ -189,7 +189,7 @@ PDH_status_4_t HAL_REV_GetPDHStatus4(HAL_REVPDHHandle handle, int32_t* status) {
     return statusFrame;
   }
 
-  statusFrame = HAL_REV_ReadPDHStatus4(hpdh->hcan, status);
+  statusFrame = HAL_ReadREVPDHStatus4(hpdh->hcan, status);
   return statusFrame;
 }
 
@@ -269,7 +269,7 @@ double HAL_GetREVPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
   // Determine what periodic status the channel is in
   if (channel < 6) {
     // Periodic status 0
-    PDH_status_0_t statusFrame = HAL_REV_ReadPDHStatus0(hpdh->hcan, status);
+    PDH_status_0_t statusFrame = HAL_ReadREVPDHStatus0(hpdh->hcan, status);
     switch (channel) {
       case 0:
         return PDH_status_0_channel_0_current_decode(
@@ -292,7 +292,7 @@ double HAL_GetREVPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
     }
   } else if (channel < 12) {
     // Periodic status 1
-    PDH_status_1_t statusFrame = HAL_REV_ReadPDHStatus1(hpdh->hcan, status);
+    PDH_status_1_t statusFrame = HAL_ReadREVPDHStatus1(hpdh->hcan, status);
     switch (channel) {
       case 6:
         return PDH_status_1_channel_6_current_decode(
@@ -315,7 +315,7 @@ double HAL_GetREVPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
     }
   } else if (channel < 18) {
     // Periodic status 2
-    PDH_status_2_t statusFrame = HAL_REV_ReadPDHStatus2(hpdh->hcan, status);
+    PDH_status_2_t statusFrame = HAL_ReadREVPDHStatus2(hpdh->hcan, status);
     switch (channel) {
       case 12:
         return PDH_status_2_channel_12_current_decode(
@@ -338,7 +338,7 @@ double HAL_GetREVPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
     }
   } else if (channel < 24) {
     // Periodic status 3
-    PDH_status_3_t statusFrame = HAL_REV_ReadPDHStatus3(hpdh->hcan, status);
+    PDH_status_3_t statusFrame = HAL_ReadREVPDHStatus3(hpdh->hcan, status);
     switch (channel) {
       case 18:
         return PDH_status_3_channel_18_current_decode(
@@ -371,10 +371,10 @@ void HAL_GetREVPDHAllChannelCurrents(HAL_REVPDHHandle handle, double* currents,
     return;
   }
 
-  PDH_status_0_t statusFrame0 = HAL_REV_ReadPDHStatus0(hpdh->hcan, status);
-  PDH_status_1_t statusFrame1 = HAL_REV_ReadPDHStatus1(hpdh->hcan, status);
-  PDH_status_2_t statusFrame2 = HAL_REV_ReadPDHStatus2(hpdh->hcan, status);
-  PDH_status_3_t statusFrame3 = HAL_REV_ReadPDHStatus3(hpdh->hcan, status);
+  PDH_status_0_t statusFrame0 = HAL_ReadREVPDHStatus0(hpdh->hcan, status);
+  PDH_status_1_t statusFrame1 = HAL_ReadREVPDHStatus1(hpdh->hcan, status);
+  PDH_status_2_t statusFrame2 = HAL_ReadREVPDHStatus2(hpdh->hcan, status);
+  PDH_status_3_t statusFrame3 = HAL_ReadREVPDHStatus3(hpdh->hcan, status);
 
   currents[0] =
       PDH_status_0_channel_0_current_decode(statusFrame0.channel_0_current);
@@ -427,7 +427,7 @@ void HAL_GetREVPDHAllChannelCurrents(HAL_REVPDHHandle handle, double* currents,
 }
 
 uint16_t HAL_GetREVPDHTotalCurrent(HAL_REVPDHHandle handle, int32_t* status) {
-  PDH_status_4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
+  PDH_status_4_t statusFrame = HAL_GetREVPDHStatus4(handle, status);
 
   if (*status != 0) {
     return 0;
@@ -456,7 +456,7 @@ void HAL_SetREVPDHSwitchableChannel(HAL_REVPDHHandle handle, HAL_Bool enabled,
 
 HAL_Bool HAL_GetREVPDHSwitchableChannelState(HAL_REVPDHHandle handle,
                                               int32_t* status) {
-  PDH_status_4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
+  PDH_status_4_t statusFrame = HAL_GetREVPDHStatus4(handle, status);
 
   if (*status != 0) {
     return 0.0;
@@ -467,7 +467,7 @@ HAL_Bool HAL_GetREVPDHSwitchableChannelState(HAL_REVPDHHandle handle,
 }
 
 double HAL_GetREVPDHVoltage(HAL_REVPDHHandle handle, int32_t* status) {
-  PDH_status_4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
+  PDH_status_4_t statusFrame = HAL_GetREVPDHStatus4(handle, status);
 
   if (*status != 0) {
     return 0.0;
@@ -525,11 +525,11 @@ HAL_REVPDHFaults HAL_GetREVPDHFaults(HAL_REVPDHHandle handle, int32_t* status) {
     return faults;
   }
 
-  PDH_status_0_t status0 = HAL_REV_ReadPDHStatus0(hpdh->hcan, status);
-  PDH_status_1_t status1 = HAL_REV_ReadPDHStatus1(hpdh->hcan, status);
-  PDH_status_2_t status2 = HAL_REV_ReadPDHStatus2(hpdh->hcan, status);
-  PDH_status_3_t status3 = HAL_REV_ReadPDHStatus3(hpdh->hcan, status);
-  PDH_status_4_t status4 = HAL_REV_ReadPDHStatus4(hpdh->hcan, status);
+  PDH_status_0_t status0 = HAL_ReadREVPDHStatus0(hpdh->hcan, status);
+  PDH_status_1_t status1 = HAL_ReadREVPDHStatus1(hpdh->hcan, status);
+  PDH_status_2_t status2 = HAL_ReadREVPDHStatus2(hpdh->hcan, status);
+  PDH_status_3_t status3 = HAL_ReadREVPDHStatus3(hpdh->hcan, status);
+  PDH_status_4_t status4 = HAL_ReadREVPDHStatus4(hpdh->hcan, status);
 
   faults.channel0BreakerFault = status0.channel_0_breaker_fault;
   faults.channel1BreakerFault = status0.channel_1_breaker_fault;
@@ -571,7 +571,7 @@ HAL_REVPDHStickyFaults HAL_GetREVPDHStickyFaults(HAL_REVPDHHandle handle,
     return stickyFaults;
   }
 
-  PDH_status_4_t status4 = HAL_REV_ReadPDHStatus4(hpdh->hcan, status);
+  PDH_status_4_t status4 = HAL_ReadREVPDHStatus4(hpdh->hcan, status);
 
   stickyFaults.channel0BreakerFault = status4.sticky_ch0_breaker_fault;
   stickyFaults.channel1BreakerFault = status4.sticky_ch1_breaker_fault;

--- a/hal/src/main/native/athena/REVPDH.cpp
+++ b/hal/src/main/native/athena/REVPDH.cpp
@@ -193,11 +193,11 @@ PDH_status_4_t HAL_REV_GetPDHStatus4(HAL_REVPDHHandle handle, int32_t* status) {
   return statusFrame;
 }
 
-HAL_REVPDHHandle HAL_REV_InitializePDH(int32_t module,
+HAL_REVPDHHandle HAL_InitializeREVPDH(int32_t module,
                                        const char* allocationLocation,
                                        int32_t* status) {
   hal::init::CheckInit();
-  if (!HAL_REV_CheckPDHModuleNumber(module)) {
+  if (!HAL_CheckREVPDHModuleNumber(module)) {
     *status = RESOURCE_OUT_OF_RANGE;
     return HAL_kInvalidHandle;
   }
@@ -230,7 +230,7 @@ HAL_REVPDHHandle HAL_REV_InitializePDH(int32_t module,
   return handle;
 }
 
-void HAL_REV_FreePDH(HAL_REVPDHHandle handle) {
+void HAL_FreeREVPDH(HAL_REVPDHHandle handle) {
   auto hpdh = REVPDHHandles->Get(handle);
   if (hpdh == nullptr) {
     return;
@@ -241,19 +241,19 @@ void HAL_REV_FreePDH(HAL_REVPDHHandle handle) {
   REVPDHHandles->Free(handle);
 }
 
-int32_t HAL_REV_GetPDHModuleNumber(HAL_REVPDHHandle handle, int32_t* status) {
+int32_t HAL_GetREVPDHModuleNumber(HAL_REVPDHHandle handle, int32_t* status) {
   return hal::getHandleIndex(handle);
 }
 
-HAL_Bool HAL_REV_CheckPDHModuleNumber(int32_t module) {
+HAL_Bool HAL_CheckREVPDHModuleNumber(int32_t module) {
   return ((module >= 1) && (module < kNumREVPDHModules)) ? 1 : 0;
 }
 
-HAL_Bool HAL_REV_CheckPDHChannelNumber(int32_t channel) {
+HAL_Bool HAL_CheckREVPDHChannelNumber(int32_t channel) {
   return ((channel >= 0) && (channel < kNumREVPDHChannels)) ? 1 : 0;
 }
 
-double HAL_REV_GetPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
+double HAL_GetREVPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
                                     int32_t* status) {
   auto hpdh = REVPDHHandles->Get(handle);
   if (hpdh == nullptr) {
@@ -261,7 +261,7 @@ double HAL_REV_GetPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
     return 0;
   }
 
-  if (!HAL_REV_CheckPDHChannelNumber(channel)) {
+  if (!HAL_CheckREVPDHChannelNumber(channel)) {
     *status = RESOURCE_OUT_OF_RANGE;
     return 0;
   }
@@ -363,7 +363,7 @@ double HAL_REV_GetPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
   return 0;
 }
 
-void HAL_REV_GetPDHAllChannelCurrents(HAL_REVPDHHandle handle, double* currents,
+void HAL_GetREVPDHAllChannelCurrents(HAL_REVPDHHandle handle, double* currents,
                                       int32_t* status) {
   auto hpdh = REVPDHHandles->Get(handle);
   if (hpdh == nullptr) {
@@ -426,7 +426,7 @@ void HAL_REV_GetPDHAllChannelCurrents(HAL_REVPDHHandle handle, double* currents,
       PDH_status_3_channel_23_current_decode(statusFrame3.channel_23_current);
 }
 
-uint16_t HAL_REV_GetPDHTotalCurrent(HAL_REVPDHHandle handle, int32_t* status) {
+uint16_t HAL_GetREVPDHTotalCurrent(HAL_REVPDHHandle handle, int32_t* status) {
   PDH_status_4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
 
   if (*status != 0) {
@@ -436,7 +436,7 @@ uint16_t HAL_REV_GetPDHTotalCurrent(HAL_REVPDHHandle handle, int32_t* status) {
   return PDH_status_4_total_current_decode(statusFrame.total_current);
 }
 
-void HAL_REV_SetPDHSwitchableChannel(HAL_REVPDHHandle handle, HAL_Bool enabled,
+void HAL_SetREVPDHSwitchableChannel(HAL_REVPDHHandle handle, HAL_Bool enabled,
                                      int32_t* status) {
   auto hpdh = REVPDHHandles->Get(handle);
   if (hpdh == nullptr) {
@@ -454,7 +454,7 @@ void HAL_REV_SetPDHSwitchableChannel(HAL_REVPDHHandle handle, HAL_Bool enabled,
                      PDH_SET_SWITCH_CHANNEL_FRAME_API, status);
 }
 
-HAL_Bool HAL_REV_GetPDHSwitchableChannelState(HAL_REVPDHHandle handle,
+HAL_Bool HAL_GetREVPDHSwitchableChannelState(HAL_REVPDHHandle handle,
                                               int32_t* status) {
   PDH_status_4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
 
@@ -466,7 +466,7 @@ HAL_Bool HAL_REV_GetPDHSwitchableChannelState(HAL_REVPDHHandle handle,
       statusFrame.switch_channel_state);
 }
 
-double HAL_REV_GetPDHSupplyVoltage(HAL_REVPDHHandle handle, int32_t* status) {
+double HAL_GetREVPDHVoltage(HAL_REVPDHHandle handle, int32_t* status) {
   PDH_status_4_t statusFrame = HAL_REV_GetPDHStatus4(handle, status);
 
   if (*status != 0) {
@@ -476,9 +476,9 @@ double HAL_REV_GetPDHSupplyVoltage(HAL_REVPDHHandle handle, int32_t* status) {
   return PDH_status_4_v_bus_decode(statusFrame.v_bus);
 }
 
-REV_PDH_Version HAL_REV_GetPDHVersion(HAL_REVPDHHandle handle,
+HAL_REVPDHVersion HAL_GetREVPDHVersion(HAL_REVPDHHandle handle,
                                       int32_t* status) {
-  REV_PDH_Version version;
+  HAL_REVPDHVersion version;
   std::memset(&version, 0, sizeof(version));
   uint8_t packedData[8] = {0};
   int32_t length = 0;
@@ -605,7 +605,7 @@ HAL_REVPDHStickyFaults HAL_GetREVPDHStickyFaults(HAL_REVPDHHandle handle,
   return stickyFaults;
 }
 
-void HAL_REV_ClearPDHStickyFaults(HAL_REVPDHHandle handle, int32_t* status) {
+void HAL_ClearREVPDHStickyFaults(HAL_REVPDHHandle handle, int32_t* status) {
   auto hpdh = REVPDHHandles->Get(handle);
   if (hpdh == nullptr) {
     *status = HAL_HANDLE_ERROR;

--- a/hal/src/main/native/athena/REVPDH.cpp
+++ b/hal/src/main/native/athena/REVPDH.cpp
@@ -605,7 +605,7 @@ HAL_REVPDHStickyFaults HAL_GetREVPDHStickyFaults(HAL_REVPDHHandle handle,
   return stickyFaults;
 }
 
-void HAL_REV_ClearPDHFaults(HAL_REVPDHHandle handle, int32_t* status) {
+void HAL_REV_ClearPDHStickyFaults(HAL_REVPDHHandle handle, int32_t* status) {
   auto hpdh = REVPDHHandles->Get(handle);
   if (hpdh == nullptr) {
     *status = HAL_HANDLE_ERROR;

--- a/hal/src/main/native/athena/REVPDH.h
+++ b/hal/src/main/native/athena/REVPDH.h
@@ -104,8 +104,8 @@ extern "C" {
  * @return the created PDH handle
  */
 HAL_REVPDHHandle HAL_InitializeREVPDH(int32_t module,
-                                       const char* allocationLocation,
-                                       int32_t* status);
+                                      const char* allocationLocation,
+                                      int32_t* status);
 
 /**
  * Frees a PDH device handle.
@@ -147,14 +147,14 @@ HAL_Bool HAL_CheckREVPDHChannelNumber(int32_t channel);
  * @return the current of the PDH channel in Amps
  */
 double HAL_GetREVPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
-                                    int32_t* status);
+                                   int32_t* status);
 
 /**
  * @param handle        PDH handle
  * @param currents      array of currents
  */
 void HAL_GetREVPDHAllChannelCurrents(HAL_REVPDHHandle handle, double* currents,
-                                      int32_t* status);
+                                     int32_t* status);
 
 /**
  * Gets the total current of the PDH in Amps, measured to the nearest even
@@ -174,7 +174,7 @@ uint16_t HAL_GetREVPDHTotalCurrent(HAL_REVPDHHandle handle, int32_t* status);
  * otherwise
  */
 void HAL_SetREVPDHSwitchableChannel(HAL_REVPDHHandle handle, HAL_Bool enabled,
-                                     int32_t* status);
+                                    int32_t* status);
 
 /**
  * Gets the current state of the switchable channel on a PDH device.
@@ -186,7 +186,7 @@ void HAL_SetREVPDHSwitchableChannel(HAL_REVPDHHandle handle, HAL_Bool enabled,
  * @return 1 if the switchable channel is enabled; 0 otherwise
  */
 HAL_Bool HAL_GetREVPDHSwitchableChannelState(HAL_REVPDHHandle handle,
-                                              int32_t* status);
+                                             int32_t* status);
 
 /**
  * Gets the firmware and hardware versions of a PDH device.

--- a/hal/src/main/native/athena/REVPDH.h
+++ b/hal/src/main/native/athena/REVPDH.h
@@ -14,7 +14,10 @@
  * @{
  */
 
-struct REV_PDH_Version {
+/**
+ * Storage for REV PDH Version
+ */
+struct HAL_REVPDHVersion {
   uint32_t firmwareMajor;
   uint32_t firmwareMinor;
   uint32_t firmwareFix;
@@ -100,7 +103,7 @@ extern "C" {
  * @param module       the device CAN ID (1 .. 63)
  * @return the created PDH handle
  */
-HAL_REVPDHHandle HAL_REV_InitializePDH(int32_t module,
+HAL_REVPDHHandle HAL_InitializeREVPDH(int32_t module,
                                        const char* allocationLocation,
                                        int32_t* status);
 
@@ -109,12 +112,12 @@ HAL_REVPDHHandle HAL_REV_InitializePDH(int32_t module,
  *
  * @param handle        the previously created PDH handle
  */
-void HAL_REV_FreePDH(HAL_REVPDHHandle handle);
+void HAL_FreeREVPDH(HAL_REVPDHHandle handle);
 
 /**
  * Gets the module number for a pdh.
  */
-int32_t HAL_REV_GetPDHModuleNumber(HAL_REVPDHHandle handle, int32_t* status);
+int32_t HAL_GetREVPDHModuleNumber(HAL_REVPDHHandle handle, int32_t* status);
 
 /**
  * Checks if a PDH module number is valid.
@@ -124,33 +127,33 @@ int32_t HAL_REV_GetPDHModuleNumber(HAL_REVPDHHandle handle, int32_t* status);
  * @param module        module number (1 .. 63)
  * @return 1 if the module number is valid; 0 otherwise
  */
-HAL_Bool HAL_REV_CheckPDHModuleNumber(int32_t module);
+HAL_Bool HAL_CheckREVPDHModuleNumber(int32_t module);
 
 /**
  * Checks if a PDH channel number is valid.
  *
- * @param module        channel number (0 .. HAL_REV_PDH_NUM_CHANNELS)
+ * @param module        channel number (0 .. kNumREVPDHChannels)
  * @return 1 if the channel number is valid; 0 otherwise
  */
-HAL_Bool HAL_REV_CheckPDHChannelNumber(int32_t channel);
+HAL_Bool HAL_CheckREVPDHChannelNumber(int32_t channel);
 
 /**
  * Gets the current of a PDH channel in Amps.
  *
  * @param handle        PDH handle
  * @param channel       the channel to retrieve the current of (0 ..
- * HAL_REV_PDH_NUM_CHANNELS)
+ * kNumREVPDHChannels)
  *
  * @return the current of the PDH channel in Amps
  */
-double HAL_REV_GetPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
+double HAL_GetREVPDHChannelCurrent(HAL_REVPDHHandle handle, int32_t channel,
                                     int32_t* status);
 
 /**
  * @param handle        PDH handle
  * @param currents      array of currents
  */
-void HAL_REV_GetPDHAllChannelCurrents(HAL_REVPDHHandle handle, double* currents,
+void HAL_GetREVPDHAllChannelCurrents(HAL_REVPDHHandle handle, double* currents,
                                       int32_t* status);
 
 /**
@@ -161,7 +164,7 @@ void HAL_REV_GetPDHAllChannelCurrents(HAL_REVPDHHandle handle, double* currents,
  *
  * @return the total current of the PDH in Amps
  */
-uint16_t HAL_REV_GetPDHTotalCurrent(HAL_REVPDHHandle handle, int32_t* status);
+uint16_t HAL_GetREVPDHTotalCurrent(HAL_REVPDHHandle handle, int32_t* status);
 
 /**
  * Sets the state of the switchable channel on a PDH device.
@@ -170,7 +173,7 @@ uint16_t HAL_REV_GetPDHTotalCurrent(HAL_REVPDHHandle handle, int32_t* status);
  * @param enabled       1 if the switchable channel should be enabled; 0
  * otherwise
  */
-void HAL_REV_SetPDHSwitchableChannel(HAL_REVPDHHandle handle, HAL_Bool enabled,
+void HAL_SetREVPDHSwitchableChannel(HAL_REVPDHHandle handle, HAL_Bool enabled,
                                      int32_t* status);
 
 /**
@@ -182,7 +185,7 @@ void HAL_REV_SetPDHSwitchableChannel(HAL_REVPDHHandle handle, HAL_Bool enabled,
  * @param handle        PDH handle
  * @return 1 if the switchable channel is enabled; 0 otherwise
  */
-HAL_Bool HAL_REV_GetPDHSwitchableChannelState(HAL_REVPDHHandle handle,
+HAL_Bool HAL_GetREVPDHSwitchableChannelState(HAL_REVPDHHandle handle,
                                               int32_t* status);
 
 /**
@@ -192,7 +195,7 @@ HAL_Bool HAL_REV_GetPDHSwitchableChannelState(HAL_REVPDHHandle handle,
  *
  * @return version information
  */
-REV_PDH_Version HAL_REV_GetPDHVersion(HAL_REVPDHHandle handle, int32_t* status);
+HAL_REVPDHVersion HAL_GetREVPDHVersion(HAL_REVPDHHandle handle, int32_t* status);
 
 /**
  * Gets the voltage being supplied to a PDH device.
@@ -201,7 +204,7 @@ REV_PDH_Version HAL_REV_GetPDHVersion(HAL_REVPDHHandle handle, int32_t* status);
  *
  * @return the voltage at the input of the PDH in Volts
  */
-double HAL_REV_GetPDHSupplyVoltage(HAL_REVPDHHandle handle, int32_t* status);
+double HAL_GetREVPDHVoltage(HAL_REVPDHHandle handle, int32_t* status);
 
 /**
  * Gets the faults of a PDH device.
@@ -227,7 +230,7 @@ HAL_REVPDHStickyFaults HAL_GetREVPDHStickyFaults(HAL_REVPDHHandle handle,
  *
  * @param handle        PDH handle
  */
-void HAL_REV_ClearPDHStickyFaults(HAL_REVPDHHandle handle, int32_t* status);
+void HAL_ClearREVPDHStickyFaults(HAL_REVPDHHandle handle, int32_t* status);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/hal/src/main/native/athena/REVPDH.h
+++ b/hal/src/main/native/athena/REVPDH.h
@@ -227,7 +227,7 @@ HAL_REVPDHStickyFaults HAL_GetREVPDHStickyFaults(HAL_REVPDHHandle handle,
  *
  * @param handle        PDH handle
  */
-void HAL_REV_ClearPDHFaults(HAL_REVPDHHandle handle, int32_t* status);
+void HAL_REV_ClearPDHStickyFaults(HAL_REVPDHHandle handle, int32_t* status);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/hal/src/main/native/athena/REVPDH.h
+++ b/hal/src/main/native/athena/REVPDH.h
@@ -18,8 +18,76 @@ struct REV_PDH_Version {
   uint32_t firmwareMajor;
   uint32_t firmwareMinor;
   uint32_t firmwareFix;
-  uint32_t hardwareRev;
+  uint32_t hardwareMinor;
+  uint32_t hardwareMajor;
   uint32_t uniqueId;
+};
+
+/**
+ * Storage for REV PDH Faults
+ */
+struct HAL_REVPDHFaults {
+  uint32_t channel0BreakerFault : 1;
+  uint32_t channel1BreakerFault : 1;
+  uint32_t channel2BreakerFault : 1;
+  uint32_t channel3BreakerFault : 1;
+  uint32_t channel4BreakerFault : 1;
+  uint32_t channel5BreakerFault : 1;
+  uint32_t channel6BreakerFault : 1;
+  uint32_t channel7BreakerFault : 1;
+  uint32_t channel8BreakerFault : 1;
+  uint32_t channel9BreakerFault : 1;
+  uint32_t channel10BreakerFault : 1;
+  uint32_t channel11BreakerFault : 1;
+  uint32_t channel12BreakerFault : 1;
+  uint32_t channel13BreakerFault : 1;
+  uint32_t channel14BreakerFault : 1;
+  uint32_t channel15BreakerFault : 1;
+  uint32_t channel16BreakerFault : 1;
+  uint32_t channel17BreakerFault : 1;
+  uint32_t channel18BreakerFault : 1;
+  uint32_t channel19BreakerFault : 1;
+  uint32_t channel20BreakerFault : 1;
+  uint32_t channel21BreakerFault : 1;
+  uint32_t channel22BreakerFault : 1;
+  uint32_t channel23BreakerFault : 1;
+  uint32_t brownout : 1;
+  uint32_t canWarning : 1;
+  uint32_t hardwareFault : 1;
+};
+
+/**
+ * Storage for REV PDH Sticky Faults
+ */
+struct HAL_REVPDHStickyFaults {
+  uint32_t channel0BreakerFault : 1;
+  uint32_t channel1BreakerFault : 1;
+  uint32_t channel2BreakerFault : 1;
+  uint32_t channel3BreakerFault : 1;
+  uint32_t channel4BreakerFault : 1;
+  uint32_t channel5BreakerFault : 1;
+  uint32_t channel6BreakerFault : 1;
+  uint32_t channel7BreakerFault : 1;
+  uint32_t channel8BreakerFault : 1;
+  uint32_t channel9BreakerFault : 1;
+  uint32_t channel10BreakerFault : 1;
+  uint32_t channel11BreakerFault : 1;
+  uint32_t channel12BreakerFault : 1;
+  uint32_t channel13BreakerFault : 1;
+  uint32_t channel14BreakerFault : 1;
+  uint32_t channel15BreakerFault : 1;
+  uint32_t channel16BreakerFault : 1;
+  uint32_t channel17BreakerFault : 1;
+  uint32_t channel18BreakerFault : 1;
+  uint32_t channel19BreakerFault : 1;
+  uint32_t channel20BreakerFault : 1;
+  uint32_t channel21BreakerFault : 1;
+  uint32_t channel22BreakerFault : 1;
+  uint32_t channel23BreakerFault : 1;
+  uint32_t brownout : 1;
+  uint32_t canWarning : 1;
+  uint32_t canBusOff : 1;
+  uint32_t hasReset : 1;
 };
 
 #ifdef __cplusplus
@@ -118,17 +186,13 @@ HAL_Bool HAL_REV_GetPDHSwitchableChannelState(HAL_REVPDHHandle handle,
                                               int32_t* status);
 
 /**
- * Checks if a PDH channel is currently experiencing a brownout condition.
- *
- * NOTE: Not implemented in firmware as of 2021-04-23.
+ * Gets the firmware and hardware versions of a PDH device.
  *
  * @param handle        PDH handle
- * @param channel       the channel to retrieve the brownout status of
  *
- * @return 1 if the channel is experiencing a brownout; 0 otherwise
+ * @return version information
  */
-HAL_Bool HAL_REV_CheckPDHChannelBrownout(HAL_REVPDHHandle handle,
-                                         int32_t channel, int32_t* status);
+REV_PDH_Version HAL_REV_GetPDHVersion(HAL_REVPDHHandle handle, int32_t* status);
 
 /**
  * Gets the voltage being supplied to a PDH device.
@@ -140,174 +204,30 @@ HAL_Bool HAL_REV_CheckPDHChannelBrownout(HAL_REVPDHHandle handle,
 double HAL_REV_GetPDHSupplyVoltage(HAL_REVPDHHandle handle, int32_t* status);
 
 /**
- * Checks if a PDH device is currently enabled.
+ * Gets the faults of a PDH device.
  *
  * @param handle        PDH handle
  *
- * @return 1 if the PDH is enabled; 0 otherwise
+ * @return the faults of the PDH
  */
-HAL_Bool HAL_REV_IsPDHEnabled(HAL_REVPDHHandle handle, int32_t* status);
+HAL_REVPDHFaults HAL_GetREVPDHFaults(HAL_REVPDHHandle handle, int32_t* status);
 
 /**
- * Checks if the input voltage on a PDH device is currently below the minimum
- * voltage.
- *
- * NOTE: Not implemented in firmware as of 2021-04-23.
+ * Gets the sticky faults of a PDH device.
  *
  * @param handle        PDH handle
  *
- * @return 1 if the PDH is experiencing a brownout; 0 otherwise
+ * @return the sticky faults of the PDH
  */
-HAL_Bool HAL_REV_CheckPDHBrownout(HAL_REVPDHHandle handle, int32_t* status);
-
-/**
- * Checks if the CAN RX or TX error levels on a PDH device have exceeded the
- * warning threshold.
- *
- * NOTE: Not implemented in firmware as of 2021-04-23.
- *
- * @param handle        PDH handle
- *
- * @return 1 if the device has exceeded the warning threshold; 0
- * otherwise
- */
-HAL_Bool HAL_REV_CheckPDHCANWarning(HAL_REVPDHHandle handle, int32_t* status);
-
-/**
- * Checks if a PDH device is currently malfunctioning.
- *
- * NOTE: Not implemented in firmware as of 2021-04-23.
- *
- * @param handle        PDH handle
- *
- * @return 1 if the device is in a hardware fault state; 0
- * otherwise
- */
-HAL_Bool HAL_REV_CheckPDHHardwareFault(HAL_REVPDHHandle handle,
-                                       int32_t* status);
-
-/**
- * Checks if the input voltage on a PDH device has gone below the specified
- * minimum voltage.
- *
- * NOTE: Not implemented in firmware as of 2021-04-23.
- *
- * @param handle        PDH handle
- *
- * @return 1 if the device has had a brownout; 0 otherwise
- */
-HAL_Bool HAL_REV_CheckPDHStickyBrownout(HAL_REVPDHHandle handle,
-                                        int32_t* status);
-
-/**
- * Checks if the CAN RX or TX error levels on a PDH device have exceeded the
- * warning threshold.
- *
- * NOTE: Not implemented in firmware as of 2021-04-23.
- *
- * @param handle        PDH handle
- *
- * @return 1 if the device has exceeded the CAN warning threshold;
- * 0 otherwise
- */
-HAL_Bool HAL_REV_CheckPDHStickyCANWarning(HAL_REVPDHHandle handle,
-                                          int32_t* status);
-
-/**
- * Checks if the CAN bus on a PDH device has previously experienced a 'Bus Off'
- * event.
- *
- * NOTE: Not implemented in firmware as of 2021-04-23.
- *
- * @param handle        PDH handle
- *
- * @return 1 if the device has experienced a 'Bus Off' event; 0
- * otherwise
- */
-HAL_Bool HAL_REV_CheckPDHStickyCANBusOff(HAL_REVPDHHandle handle,
-                                         int32_t* status);
-
-/**
- * Checks if a PDH device has malfunctioned.
- *
- * NOTE: Not implemented in firmware as of 2021-04-23.
- *
- * @param handle        PDH handle
- *
- * @return 1 if the device has had a malfunction; 0 otherwise
- */
-HAL_Bool HAL_REV_CheckPDHStickyHardwareFault(HAL_REVPDHHandle handle,
-                                             int32_t* status);
-
-/**
- * Checks if the firmware on a PDH device has malfunctioned and reset during
- * operation.
- *
- * NOTE: Not implemented in firmware as of 2021-04-23.
- *
- * @param handle        PDH handle
- *
- * @return 1 if the device has had a malfunction and reset; 0
- * otherwise
- */
-HAL_Bool HAL_REV_CheckPDHStickyFirmwareFault(HAL_REVPDHHandle handle,
-                                             int32_t* status);
-
-/**
- * Checks if a brownout has happened on channels 20-23 of a PDH device while it
- * was enabled.
- *
- * NOTE: Not implemented in firmware as of 2021-04-23.
- *
- * @param handle        PDH handle
- * @param channel       PDH channel to retrieve sticky brownout status (20 ..
- * 23)
- *
- *
- * @return 1 if the channel has had a brownout; 0 otherwise
- */
-HAL_Bool HAL_REV_CheckPDHStickyChannelBrownout(HAL_REVPDHHandle handle,
-                                               int32_t channel,
-                                               int32_t* status);
-
-/**
- * Checks if a PDH device has reset.
- *
- * NOTE: Not implemented in firmware as of 2021-04-23.
- *
- * @param handle        PDH handle
- *
- * @return 1 if the device has reset; 0 otherwise
- */
-HAL_Bool HAL_REV_CheckPDHStickyHasReset(HAL_REVPDHHandle handle,
-                                        int32_t* status);
-
-/**
- * Gets the firmware and hardware versions of a PDH device.
- *
- * @param handle        PDH handle
- *
- * @return version information
- */
-REV_PDH_Version HAL_REV_GetPDHVersion(HAL_REVPDHHandle handle, int32_t* status);
+HAL_REVPDHStickyFaults HAL_GetREVPDHStickyFaults(HAL_REVPDHHandle handle,
+                                                 int32_t* status);
 
 /**
  * Clears the sticky faults on a PDH device.
  *
- * NOTE: Not implemented in firmware as of 2021-04-23.
- *
  * @param handle        PDH handle
  */
 void HAL_REV_ClearPDHFaults(HAL_REVPDHHandle handle, int32_t* status);
-
-/**
- * Identifies a PDH device by blinking its LED.
- *
- * NOTE: Not implemented in firmware as of 2021-04-23.
- *
- * @param handle        PDH handle
- */
-void HAL_REV_IdentifyPDH(HAL_REVPDHHandle handle, int32_t* status);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/hal/src/main/native/athena/REVPDH.h
+++ b/hal/src/main/native/athena/REVPDH.h
@@ -195,7 +195,8 @@ HAL_Bool HAL_GetREVPDHSwitchableChannelState(HAL_REVPDHHandle handle,
  *
  * @return version information
  */
-HAL_REVPDHVersion HAL_GetREVPDHVersion(HAL_REVPDHHandle handle, int32_t* status);
+HAL_REVPDHVersion HAL_GetREVPDHVersion(HAL_REVPDHHandle handle,
+                                       int32_t* status);
 
 /**
  * Gets the voltage being supplied to a PDH device.

--- a/hal/src/main/native/athena/rev/PDHFrames.cpp
+++ b/hal/src/main/native/athena/rev/PDHFrames.cpp
@@ -112,9 +112,9 @@ static inline uint32_t unpack_right_shift_u32(
     return (uint32_t)((uint32_t)(value & mask) >> shift);
 }
 
-int PDH_switch_channel_set_pack(
+int PDH_set_switch_channel_pack(
     uint8_t *dst_p,
-    const struct PDH_switch_channel_set_t *src_p,
+    const struct PDH_set_switch_channel_t *src_p,
     size_t size)
 {
     if (size < 1u) {
@@ -124,13 +124,12 @@ int PDH_switch_channel_set_pack(
     memset(&dst_p[0], 0, 1);
 
     dst_p[0] |= pack_left_shift_u8(src_p->output_set_value, 0u, 0x01u);
-    dst_p[0] |= pack_left_shift_u8(src_p->use_system_enable, 1u, 0x02u);
 
     return (1);
 }
 
-int PDH_switch_channel_set_unpack(
-    struct PDH_switch_channel_set_t *dst_p,
+int PDH_set_switch_channel_unpack(
+    struct PDH_set_switch_channel_t *dst_p,
     const uint8_t *src_p,
     size_t size)
 {
@@ -139,44 +138,28 @@ int PDH_switch_channel_set_unpack(
     }
 
     dst_p->output_set_value = unpack_right_shift_u8(src_p[0], 0u, 0x01u);
-    dst_p->use_system_enable = unpack_right_shift_u8(src_p[0], 1u, 0x02u);
 
     return (0);
 }
 
-uint8_t PDH_switch_channel_set_output_set_value_encode(double value)
+uint8_t PDH_set_switch_channel_output_set_value_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_switch_channel_set_output_set_value_decode(uint8_t value)
+double PDH_set_switch_channel_output_set_value_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_switch_channel_set_output_set_value_is_in_range(uint8_t value)
+bool PDH_set_switch_channel_output_set_value_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_switch_channel_set_use_system_enable_encode(double value)
-{
-    return (uint8_t)(value);
-}
-
-double PDH_switch_channel_set_use_system_enable_decode(uint8_t value)
-{
-    return ((double)value);
-}
-
-bool PDH_switch_channel_set_use_system_enable_is_in_range(uint8_t value)
-{
-    return (value <= 1u);
-}
-
-int PDH_status0_pack(
+int PDH_status_0_pack(
     uint8_t *dst_p,
-    const struct PDH_status0_t *src_p,
+    const struct PDH_status_0_t *src_p,
     size_t size)
 {
     if (size < 8u) {
@@ -191,22 +174,22 @@ int PDH_status0_pack(
     dst_p[2] |= pack_right_shift_u16(src_p->channel_1_current, 6u, 0x0fu);
     dst_p[2] |= pack_left_shift_u16(src_p->channel_2_current, 4u, 0xf0u);
     dst_p[3] |= pack_right_shift_u16(src_p->channel_2_current, 4u, 0x3fu);
-    dst_p[3] |= pack_left_shift_u8(src_p->channel_0_brownout, 6u, 0x40u);
-    dst_p[3] |= pack_left_shift_u8(src_p->channel_1_brownout, 7u, 0x80u);
+    dst_p[3] |= pack_left_shift_u8(src_p->channel_0_breaker_fault, 6u, 0x40u);
+    dst_p[3] |= pack_left_shift_u8(src_p->channel_1_breaker_fault, 7u, 0x80u);
     dst_p[4] |= pack_left_shift_u16(src_p->channel_3_current, 0u, 0xffu);
     dst_p[5] |= pack_right_shift_u16(src_p->channel_3_current, 8u, 0x03u);
     dst_p[5] |= pack_left_shift_u16(src_p->channel_4_current, 2u, 0xfcu);
     dst_p[6] |= pack_right_shift_u16(src_p->channel_4_current, 6u, 0x0fu);
     dst_p[6] |= pack_left_shift_u16(src_p->channel_5_current, 4u, 0xf0u);
     dst_p[7] |= pack_right_shift_u16(src_p->channel_5_current, 4u, 0x3fu);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_2_brownout, 6u, 0x40u);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_3_brownout, 7u, 0x80u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_2_breaker_fault, 6u, 0x40u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_3_breaker_fault, 7u, 0x80u);
 
     return (8);
 }
 
-int PDH_status0_unpack(
-    struct PDH_status0_t *dst_p,
+int PDH_status_0_unpack(
+    struct PDH_status_0_t *dst_p,
     const uint8_t *src_p,
     size_t size)
 {
@@ -220,173 +203,173 @@ int PDH_status0_unpack(
     dst_p->channel_1_current |= unpack_left_shift_u16(src_p[2], 6u, 0x0fu);
     dst_p->channel_2_current = unpack_right_shift_u16(src_p[2], 4u, 0xf0u);
     dst_p->channel_2_current |= unpack_left_shift_u16(src_p[3], 4u, 0x3fu);
-    dst_p->channel_0_brownout = unpack_right_shift_u8(src_p[3], 6u, 0x40u);
-    dst_p->channel_1_brownout = unpack_right_shift_u8(src_p[3], 7u, 0x80u);
+    dst_p->channel_0_breaker_fault = unpack_right_shift_u8(src_p[3], 6u, 0x40u);
+    dst_p->channel_1_breaker_fault = unpack_right_shift_u8(src_p[3], 7u, 0x80u);
     dst_p->channel_3_current = unpack_right_shift_u16(src_p[4], 0u, 0xffu);
     dst_p->channel_3_current |= unpack_left_shift_u16(src_p[5], 8u, 0x03u);
     dst_p->channel_4_current = unpack_right_shift_u16(src_p[5], 2u, 0xfcu);
     dst_p->channel_4_current |= unpack_left_shift_u16(src_p[6], 6u, 0x0fu);
     dst_p->channel_5_current = unpack_right_shift_u16(src_p[6], 4u, 0xf0u);
     dst_p->channel_5_current |= unpack_left_shift_u16(src_p[7], 4u, 0x3fu);
-    dst_p->channel_2_brownout = unpack_right_shift_u8(src_p[7], 6u, 0x40u);
-    dst_p->channel_3_brownout = unpack_right_shift_u8(src_p[7], 7u, 0x80u);
+    dst_p->channel_2_breaker_fault = unpack_right_shift_u8(src_p[7], 6u, 0x40u);
+    dst_p->channel_3_breaker_fault = unpack_right_shift_u8(src_p[7], 7u, 0x80u);
 
     return (0);
 }
 
-uint16_t PDH_status0_channel_0_current_encode(double value)
+uint16_t PDH_status_0_channel_0_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status0_channel_0_current_decode(uint16_t value)
+double PDH_status_0_channel_0_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status0_channel_0_current_is_in_range(uint16_t value)
+bool PDH_status_0_channel_0_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint16_t PDH_status0_channel_1_current_encode(double value)
+uint16_t PDH_status_0_channel_1_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status0_channel_1_current_decode(uint16_t value)
+double PDH_status_0_channel_1_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status0_channel_1_current_is_in_range(uint16_t value)
+bool PDH_status_0_channel_1_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint16_t PDH_status0_channel_2_current_encode(double value)
+uint16_t PDH_status_0_channel_2_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status0_channel_2_current_decode(uint16_t value)
+double PDH_status_0_channel_2_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status0_channel_2_current_is_in_range(uint16_t value)
+bool PDH_status_0_channel_2_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint8_t PDH_status0_channel_0_brownout_encode(double value)
+uint8_t PDH_status_0_channel_0_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status0_channel_0_brownout_decode(uint8_t value)
+double PDH_status_0_channel_0_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status0_channel_0_brownout_is_in_range(uint8_t value)
+bool PDH_status_0_channel_0_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status0_channel_1_brownout_encode(double value)
+uint8_t PDH_status_0_channel_1_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status0_channel_1_brownout_decode(uint8_t value)
+double PDH_status_0_channel_1_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status0_channel_1_brownout_is_in_range(uint8_t value)
+bool PDH_status_0_channel_1_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint16_t PDH_status0_channel_3_current_encode(double value)
+uint16_t PDH_status_0_channel_3_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status0_channel_3_current_decode(uint16_t value)
+double PDH_status_0_channel_3_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status0_channel_3_current_is_in_range(uint16_t value)
+bool PDH_status_0_channel_3_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint16_t PDH_status0_channel_4_current_encode(double value)
+uint16_t PDH_status_0_channel_4_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status0_channel_4_current_decode(uint16_t value)
+double PDH_status_0_channel_4_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status0_channel_4_current_is_in_range(uint16_t value)
+bool PDH_status_0_channel_4_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint16_t PDH_status0_channel_5_current_encode(double value)
+uint16_t PDH_status_0_channel_5_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status0_channel_5_current_decode(uint16_t value)
+double PDH_status_0_channel_5_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status0_channel_5_current_is_in_range(uint16_t value)
+bool PDH_status_0_channel_5_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint8_t PDH_status0_channel_2_brownout_encode(double value)
+uint8_t PDH_status_0_channel_2_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status0_channel_2_brownout_decode(uint8_t value)
+double PDH_status_0_channel_2_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status0_channel_2_brownout_is_in_range(uint8_t value)
+bool PDH_status_0_channel_2_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status0_channel_3_brownout_encode(double value)
+uint8_t PDH_status_0_channel_3_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status0_channel_3_brownout_decode(uint8_t value)
+double PDH_status_0_channel_3_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status0_channel_3_brownout_is_in_range(uint8_t value)
+bool PDH_status_0_channel_3_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-int PDH_status1_pack(
+int PDH_status_1_pack(
     uint8_t *dst_p,
-    const struct PDH_status1_t *src_p,
+    const struct PDH_status_1_t *src_p,
     size_t size)
 {
     if (size < 8u) {
@@ -401,22 +384,22 @@ int PDH_status1_pack(
     dst_p[2] |= pack_right_shift_u16(src_p->channel_7_current, 6u, 0x0fu);
     dst_p[2] |= pack_left_shift_u16(src_p->channel_8_current, 4u, 0xf0u);
     dst_p[3] |= pack_right_shift_u16(src_p->channel_8_current, 4u, 0x3fu);
-    dst_p[3] |= pack_left_shift_u8(src_p->channel_4_brownout, 6u, 0x40u);
-    dst_p[3] |= pack_left_shift_u8(src_p->channel_5_brownout, 7u, 0x80u);
+    dst_p[3] |= pack_left_shift_u8(src_p->channel_4_breaker_fault, 6u, 0x40u);
+    dst_p[3] |= pack_left_shift_u8(src_p->channel_5_breaker_fault, 7u, 0x80u);
     dst_p[4] |= pack_left_shift_u16(src_p->channel_9_current, 0u, 0xffu);
     dst_p[5] |= pack_right_shift_u16(src_p->channel_9_current, 8u, 0x03u);
     dst_p[5] |= pack_left_shift_u16(src_p->channel_10_current, 2u, 0xfcu);
     dst_p[6] |= pack_right_shift_u16(src_p->channel_10_current, 6u, 0x0fu);
     dst_p[6] |= pack_left_shift_u16(src_p->channel_11_current, 4u, 0xf0u);
     dst_p[7] |= pack_right_shift_u16(src_p->channel_11_current, 4u, 0x3fu);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_6_brownout, 6u, 0x40u);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_7_brownout, 7u, 0x80u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_6_breaker_fault, 6u, 0x40u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_7_breaker_fault, 7u, 0x80u);
 
     return (8);
 }
 
-int PDH_status1_unpack(
-    struct PDH_status1_t *dst_p,
+int PDH_status_1_unpack(
+    struct PDH_status_1_t *dst_p,
     const uint8_t *src_p,
     size_t size)
 {
@@ -430,173 +413,173 @@ int PDH_status1_unpack(
     dst_p->channel_7_current |= unpack_left_shift_u16(src_p[2], 6u, 0x0fu);
     dst_p->channel_8_current = unpack_right_shift_u16(src_p[2], 4u, 0xf0u);
     dst_p->channel_8_current |= unpack_left_shift_u16(src_p[3], 4u, 0x3fu);
-    dst_p->channel_4_brownout = unpack_right_shift_u8(src_p[3], 6u, 0x40u);
-    dst_p->channel_5_brownout = unpack_right_shift_u8(src_p[3], 7u, 0x80u);
+    dst_p->channel_4_breaker_fault = unpack_right_shift_u8(src_p[3], 6u, 0x40u);
+    dst_p->channel_5_breaker_fault = unpack_right_shift_u8(src_p[3], 7u, 0x80u);
     dst_p->channel_9_current = unpack_right_shift_u16(src_p[4], 0u, 0xffu);
     dst_p->channel_9_current |= unpack_left_shift_u16(src_p[5], 8u, 0x03u);
     dst_p->channel_10_current = unpack_right_shift_u16(src_p[5], 2u, 0xfcu);
     dst_p->channel_10_current |= unpack_left_shift_u16(src_p[6], 6u, 0x0fu);
     dst_p->channel_11_current = unpack_right_shift_u16(src_p[6], 4u, 0xf0u);
     dst_p->channel_11_current |= unpack_left_shift_u16(src_p[7], 4u, 0x3fu);
-    dst_p->channel_6_brownout = unpack_right_shift_u8(src_p[7], 6u, 0x40u);
-    dst_p->channel_7_brownout = unpack_right_shift_u8(src_p[7], 7u, 0x80u);
+    dst_p->channel_6_breaker_fault = unpack_right_shift_u8(src_p[7], 6u, 0x40u);
+    dst_p->channel_7_breaker_fault = unpack_right_shift_u8(src_p[7], 7u, 0x80u);
 
     return (0);
 }
 
-uint16_t PDH_status1_channel_6_current_encode(double value)
+uint16_t PDH_status_1_channel_6_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status1_channel_6_current_decode(uint16_t value)
+double PDH_status_1_channel_6_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status1_channel_6_current_is_in_range(uint16_t value)
+bool PDH_status_1_channel_6_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint16_t PDH_status1_channel_7_current_encode(double value)
+uint16_t PDH_status_1_channel_7_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status1_channel_7_current_decode(uint16_t value)
+double PDH_status_1_channel_7_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status1_channel_7_current_is_in_range(uint16_t value)
+bool PDH_status_1_channel_7_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint16_t PDH_status1_channel_8_current_encode(double value)
+uint16_t PDH_status_1_channel_8_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status1_channel_8_current_decode(uint16_t value)
+double PDH_status_1_channel_8_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status1_channel_8_current_is_in_range(uint16_t value)
+bool PDH_status_1_channel_8_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint8_t PDH_status1_channel_4_brownout_encode(double value)
+uint8_t PDH_status_1_channel_4_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status1_channel_4_brownout_decode(uint8_t value)
+double PDH_status_1_channel_4_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status1_channel_4_brownout_is_in_range(uint8_t value)
+bool PDH_status_1_channel_4_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status1_channel_5_brownout_encode(double value)
+uint8_t PDH_status_1_channel_5_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status1_channel_5_brownout_decode(uint8_t value)
+double PDH_status_1_channel_5_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status1_channel_5_brownout_is_in_range(uint8_t value)
+bool PDH_status_1_channel_5_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint16_t PDH_status1_channel_9_current_encode(double value)
+uint16_t PDH_status_1_channel_9_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status1_channel_9_current_decode(uint16_t value)
+double PDH_status_1_channel_9_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status1_channel_9_current_is_in_range(uint16_t value)
+bool PDH_status_1_channel_9_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint16_t PDH_status1_channel_10_current_encode(double value)
+uint16_t PDH_status_1_channel_10_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status1_channel_10_current_decode(uint16_t value)
+double PDH_status_1_channel_10_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status1_channel_10_current_is_in_range(uint16_t value)
+bool PDH_status_1_channel_10_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint16_t PDH_status1_channel_11_current_encode(double value)
+uint16_t PDH_status_1_channel_11_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status1_channel_11_current_decode(uint16_t value)
+double PDH_status_1_channel_11_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status1_channel_11_current_is_in_range(uint16_t value)
+bool PDH_status_1_channel_11_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint8_t PDH_status1_channel_6_brownout_encode(double value)
+uint8_t PDH_status_1_channel_6_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status1_channel_6_brownout_decode(uint8_t value)
+double PDH_status_1_channel_6_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status1_channel_6_brownout_is_in_range(uint8_t value)
+bool PDH_status_1_channel_6_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status1_channel_7_brownout_encode(double value)
+uint8_t PDH_status_1_channel_7_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status1_channel_7_brownout_decode(uint8_t value)
+double PDH_status_1_channel_7_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status1_channel_7_brownout_is_in_range(uint8_t value)
+bool PDH_status_1_channel_7_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-int PDH_status2_pack(
+int PDH_status_2_pack(
     uint8_t *dst_p,
-    const struct PDH_status2_t *src_p,
+    const struct PDH_status_2_t *src_p,
     size_t size)
 {
     if (size < 8u) {
@@ -611,22 +594,22 @@ int PDH_status2_pack(
     dst_p[2] |= pack_right_shift_u16(src_p->channel_13_current, 6u, 0x0fu);
     dst_p[2] |= pack_left_shift_u16(src_p->channel_14_current, 4u, 0xf0u);
     dst_p[3] |= pack_right_shift_u16(src_p->channel_14_current, 4u, 0x3fu);
-    dst_p[3] |= pack_left_shift_u8(src_p->channel_8_brownout, 6u, 0x40u);
-    dst_p[3] |= pack_left_shift_u8(src_p->channel_9_brownout, 7u, 0x80u);
+    dst_p[3] |= pack_left_shift_u8(src_p->channel_8_breaker_fault, 6u, 0x40u);
+    dst_p[3] |= pack_left_shift_u8(src_p->channel_9_breaker_fault, 7u, 0x80u);
     dst_p[4] |= pack_left_shift_u16(src_p->channel_15_current, 0u, 0xffu);
     dst_p[5] |= pack_right_shift_u16(src_p->channel_15_current, 8u, 0x03u);
     dst_p[5] |= pack_left_shift_u16(src_p->channel_16_current, 2u, 0xfcu);
     dst_p[6] |= pack_right_shift_u16(src_p->channel_16_current, 6u, 0x0fu);
     dst_p[6] |= pack_left_shift_u16(src_p->channel_17_current, 4u, 0xf0u);
     dst_p[7] |= pack_right_shift_u16(src_p->channel_17_current, 4u, 0x3fu);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_10_brownout, 6u, 0x40u);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_11_brownout, 7u, 0x80u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_10_breaker_fault, 6u, 0x40u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_11_breaker_fault, 7u, 0x80u);
 
     return (8);
 }
 
-int PDH_status2_unpack(
-    struct PDH_status2_t *dst_p,
+int PDH_status_2_unpack(
+    struct PDH_status_2_t *dst_p,
     const uint8_t *src_p,
     size_t size)
 {
@@ -640,173 +623,173 @@ int PDH_status2_unpack(
     dst_p->channel_13_current |= unpack_left_shift_u16(src_p[2], 6u, 0x0fu);
     dst_p->channel_14_current = unpack_right_shift_u16(src_p[2], 4u, 0xf0u);
     dst_p->channel_14_current |= unpack_left_shift_u16(src_p[3], 4u, 0x3fu);
-    dst_p->channel_8_brownout = unpack_right_shift_u8(src_p[3], 6u, 0x40u);
-    dst_p->channel_9_brownout = unpack_right_shift_u8(src_p[3], 7u, 0x80u);
+    dst_p->channel_8_breaker_fault = unpack_right_shift_u8(src_p[3], 6u, 0x40u);
+    dst_p->channel_9_breaker_fault = unpack_right_shift_u8(src_p[3], 7u, 0x80u);
     dst_p->channel_15_current = unpack_right_shift_u16(src_p[4], 0u, 0xffu);
     dst_p->channel_15_current |= unpack_left_shift_u16(src_p[5], 8u, 0x03u);
     dst_p->channel_16_current = unpack_right_shift_u16(src_p[5], 2u, 0xfcu);
     dst_p->channel_16_current |= unpack_left_shift_u16(src_p[6], 6u, 0x0fu);
     dst_p->channel_17_current = unpack_right_shift_u16(src_p[6], 4u, 0xf0u);
     dst_p->channel_17_current |= unpack_left_shift_u16(src_p[7], 4u, 0x3fu);
-    dst_p->channel_10_brownout = unpack_right_shift_u8(src_p[7], 6u, 0x40u);
-    dst_p->channel_11_brownout = unpack_right_shift_u8(src_p[7], 7u, 0x80u);
+    dst_p->channel_10_breaker_fault = unpack_right_shift_u8(src_p[7], 6u, 0x40u);
+    dst_p->channel_11_breaker_fault = unpack_right_shift_u8(src_p[7], 7u, 0x80u);
 
     return (0);
 }
 
-uint16_t PDH_status2_channel_12_current_encode(double value)
+uint16_t PDH_status_2_channel_12_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status2_channel_12_current_decode(uint16_t value)
+double PDH_status_2_channel_12_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status2_channel_12_current_is_in_range(uint16_t value)
+bool PDH_status_2_channel_12_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint16_t PDH_status2_channel_13_current_encode(double value)
+uint16_t PDH_status_2_channel_13_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status2_channel_13_current_decode(uint16_t value)
+double PDH_status_2_channel_13_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status2_channel_13_current_is_in_range(uint16_t value)
+bool PDH_status_2_channel_13_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint16_t PDH_status2_channel_14_current_encode(double value)
+uint16_t PDH_status_2_channel_14_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status2_channel_14_current_decode(uint16_t value)
+double PDH_status_2_channel_14_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status2_channel_14_current_is_in_range(uint16_t value)
+bool PDH_status_2_channel_14_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint8_t PDH_status2_channel_8_brownout_encode(double value)
+uint8_t PDH_status_2_channel_8_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status2_channel_8_brownout_decode(uint8_t value)
+double PDH_status_2_channel_8_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status2_channel_8_brownout_is_in_range(uint8_t value)
+bool PDH_status_2_channel_8_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status2_channel_9_brownout_encode(double value)
+uint8_t PDH_status_2_channel_9_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status2_channel_9_brownout_decode(uint8_t value)
+double PDH_status_2_channel_9_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status2_channel_9_brownout_is_in_range(uint8_t value)
+bool PDH_status_2_channel_9_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint16_t PDH_status2_channel_15_current_encode(double value)
+uint16_t PDH_status_2_channel_15_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status2_channel_15_current_decode(uint16_t value)
+double PDH_status_2_channel_15_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status2_channel_15_current_is_in_range(uint16_t value)
+bool PDH_status_2_channel_15_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint16_t PDH_status2_channel_16_current_encode(double value)
+uint16_t PDH_status_2_channel_16_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status2_channel_16_current_decode(uint16_t value)
+double PDH_status_2_channel_16_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status2_channel_16_current_is_in_range(uint16_t value)
+bool PDH_status_2_channel_16_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint16_t PDH_status2_channel_17_current_encode(double value)
+uint16_t PDH_status_2_channel_17_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status2_channel_17_current_decode(uint16_t value)
+double PDH_status_2_channel_17_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status2_channel_17_current_is_in_range(uint16_t value)
+bool PDH_status_2_channel_17_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint8_t PDH_status2_channel_10_brownout_encode(double value)
+uint8_t PDH_status_2_channel_10_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status2_channel_10_brownout_decode(uint8_t value)
+double PDH_status_2_channel_10_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status2_channel_10_brownout_is_in_range(uint8_t value)
+bool PDH_status_2_channel_10_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status2_channel_11_brownout_encode(double value)
+uint8_t PDH_status_2_channel_11_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status2_channel_11_brownout_decode(uint8_t value)
+double PDH_status_2_channel_11_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status2_channel_11_brownout_is_in_range(uint8_t value)
+bool PDH_status_2_channel_11_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-int PDH_status3_pack(
+int PDH_status_3_pack(
     uint8_t *dst_p,
-    const struct PDH_status3_t *src_p,
+    const struct PDH_status_3_t *src_p,
     size_t size)
 {
     if (size < 8u) {
@@ -819,28 +802,28 @@ int PDH_status3_pack(
     dst_p[1] |= pack_right_shift_u16(src_p->channel_18_current, 8u, 0x03u);
     dst_p[1] |= pack_left_shift_u16(src_p->channel_19_current, 2u, 0xfcu);
     dst_p[2] |= pack_right_shift_u16(src_p->channel_19_current, 6u, 0x0fu);
-    dst_p[2] |= pack_left_shift_u8(src_p->channel_12_brownout, 4u, 0x10u);
-    dst_p[2] |= pack_left_shift_u8(src_p->channel_13_brownout, 5u, 0x20u);
-    dst_p[2] |= pack_left_shift_u8(src_p->channel_14_brownout, 6u, 0x40u);
-    dst_p[2] |= pack_left_shift_u8(src_p->channel_15_brownout, 7u, 0x80u);
+    dst_p[2] |= pack_left_shift_u8(src_p->channel_12_breaker_fault, 4u, 0x10u);
+    dst_p[2] |= pack_left_shift_u8(src_p->channel_13_breaker_fault, 5u, 0x20u);
+    dst_p[2] |= pack_left_shift_u8(src_p->channel_14_breaker_fault, 6u, 0x40u);
+    dst_p[2] |= pack_left_shift_u8(src_p->channel_15_breaker_fault, 7u, 0x80u);
     dst_p[3] |= pack_left_shift_u8(src_p->channel_20_current, 0u, 0xffu);
     dst_p[4] |= pack_left_shift_u8(src_p->channel_21_current, 0u, 0xffu);
     dst_p[5] |= pack_left_shift_u8(src_p->channel_22_current, 0u, 0xffu);
     dst_p[6] |= pack_left_shift_u8(src_p->channel_23_current, 0u, 0xffu);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_16_brownout, 0u, 0x01u);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_17_brownout, 1u, 0x02u);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_18_brownout, 2u, 0x04u);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_19_brownout, 3u, 0x08u);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_20_brownout, 4u, 0x10u);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_21_brownout, 5u, 0x20u);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_22_brownout, 6u, 0x40u);
-    dst_p[7] |= pack_left_shift_u8(src_p->channel_23_brownout, 7u, 0x80u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_16_breaker_fault, 0u, 0x01u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_17_breaker_fault, 1u, 0x02u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_18_breaker_fault, 2u, 0x04u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_19_breaker_fault, 3u, 0x08u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_20_breaker_fault, 4u, 0x10u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_21_breaker_fault, 5u, 0x20u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_22_breaker_fault, 6u, 0x40u);
+    dst_p[7] |= pack_left_shift_u8(src_p->channel_23_breaker_fault, 7u, 0x80u);
 
     return (8);
 }
 
-int PDH_status3_unpack(
-    struct PDH_status3_t *dst_p,
+int PDH_status_3_unpack(
+    struct PDH_status_3_t *dst_p,
     const uint8_t *src_p,
     size_t size)
 {
@@ -852,307 +835,307 @@ int PDH_status3_unpack(
     dst_p->channel_18_current |= unpack_left_shift_u16(src_p[1], 8u, 0x03u);
     dst_p->channel_19_current = unpack_right_shift_u16(src_p[1], 2u, 0xfcu);
     dst_p->channel_19_current |= unpack_left_shift_u16(src_p[2], 6u, 0x0fu);
-    dst_p->channel_12_brownout = unpack_right_shift_u8(src_p[2], 4u, 0x10u);
-    dst_p->channel_13_brownout = unpack_right_shift_u8(src_p[2], 5u, 0x20u);
-    dst_p->channel_14_brownout = unpack_right_shift_u8(src_p[2], 6u, 0x40u);
-    dst_p->channel_15_brownout = unpack_right_shift_u8(src_p[2], 7u, 0x80u);
+    dst_p->channel_12_breaker_fault = unpack_right_shift_u8(src_p[2], 4u, 0x10u);
+    dst_p->channel_13_breaker_fault = unpack_right_shift_u8(src_p[2], 5u, 0x20u);
+    dst_p->channel_14_breaker_fault = unpack_right_shift_u8(src_p[2], 6u, 0x40u);
+    dst_p->channel_15_breaker_fault = unpack_right_shift_u8(src_p[2], 7u, 0x80u);
     dst_p->channel_20_current = unpack_right_shift_u8(src_p[3], 0u, 0xffu);
     dst_p->channel_21_current = unpack_right_shift_u8(src_p[4], 0u, 0xffu);
     dst_p->channel_22_current = unpack_right_shift_u8(src_p[5], 0u, 0xffu);
     dst_p->channel_23_current = unpack_right_shift_u8(src_p[6], 0u, 0xffu);
-    dst_p->channel_16_brownout = unpack_right_shift_u8(src_p[7], 0u, 0x01u);
-    dst_p->channel_17_brownout = unpack_right_shift_u8(src_p[7], 1u, 0x02u);
-    dst_p->channel_18_brownout = unpack_right_shift_u8(src_p[7], 2u, 0x04u);
-    dst_p->channel_19_brownout = unpack_right_shift_u8(src_p[7], 3u, 0x08u);
-    dst_p->channel_20_brownout = unpack_right_shift_u8(src_p[7], 4u, 0x10u);
-    dst_p->channel_21_brownout = unpack_right_shift_u8(src_p[7], 5u, 0x20u);
-    dst_p->channel_22_brownout = unpack_right_shift_u8(src_p[7], 6u, 0x40u);
-    dst_p->channel_23_brownout = unpack_right_shift_u8(src_p[7], 7u, 0x80u);
+    dst_p->channel_16_breaker_fault = unpack_right_shift_u8(src_p[7], 0u, 0x01u);
+    dst_p->channel_17_breaker_fault = unpack_right_shift_u8(src_p[7], 1u, 0x02u);
+    dst_p->channel_18_breaker_fault = unpack_right_shift_u8(src_p[7], 2u, 0x04u);
+    dst_p->channel_19_breaker_fault = unpack_right_shift_u8(src_p[7], 3u, 0x08u);
+    dst_p->channel_20_breaker_fault = unpack_right_shift_u8(src_p[7], 4u, 0x10u);
+    dst_p->channel_21_breaker_fault = unpack_right_shift_u8(src_p[7], 5u, 0x20u);
+    dst_p->channel_22_breaker_fault = unpack_right_shift_u8(src_p[7], 6u, 0x40u);
+    dst_p->channel_23_breaker_fault = unpack_right_shift_u8(src_p[7], 7u, 0x80u);
 
     return (0);
 }
 
-uint16_t PDH_status3_channel_18_current_encode(double value)
+uint16_t PDH_status_3_channel_18_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status3_channel_18_current_decode(uint16_t value)
+double PDH_status_3_channel_18_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status3_channel_18_current_is_in_range(uint16_t value)
+bool PDH_status_3_channel_18_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint16_t PDH_status3_channel_19_current_encode(double value)
+uint16_t PDH_status_3_channel_19_current_encode(double value)
 {
     return (uint16_t)(value / 0.125);
 }
 
-double PDH_status3_channel_19_current_decode(uint16_t value)
+double PDH_status_3_channel_19_current_decode(uint16_t value)
 {
     return ((double)value * 0.125);
 }
 
-bool PDH_status3_channel_19_current_is_in_range(uint16_t value)
+bool PDH_status_3_channel_19_current_is_in_range(uint16_t value)
 {
     return (value <= 1023u);
 }
 
-uint8_t PDH_status3_channel_12_brownout_encode(double value)
+uint8_t PDH_status_3_channel_12_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status3_channel_12_brownout_decode(uint8_t value)
+double PDH_status_3_channel_12_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status3_channel_12_brownout_is_in_range(uint8_t value)
+bool PDH_status_3_channel_12_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status3_channel_13_brownout_encode(double value)
+uint8_t PDH_status_3_channel_13_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status3_channel_13_brownout_decode(uint8_t value)
+double PDH_status_3_channel_13_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status3_channel_13_brownout_is_in_range(uint8_t value)
+bool PDH_status_3_channel_13_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status3_channel_14_brownout_encode(double value)
+uint8_t PDH_status_3_channel_14_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status3_channel_14_brownout_decode(uint8_t value)
+double PDH_status_3_channel_14_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status3_channel_14_brownout_is_in_range(uint8_t value)
+bool PDH_status_3_channel_14_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status3_channel_15_brownout_encode(double value)
+uint8_t PDH_status_3_channel_15_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status3_channel_15_brownout_decode(uint8_t value)
+double PDH_status_3_channel_15_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status3_channel_15_brownout_is_in_range(uint8_t value)
+bool PDH_status_3_channel_15_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status3_channel_20_current_encode(double value)
+uint8_t PDH_status_3_channel_20_current_encode(double value)
 {
     return (uint8_t)(value / 0.0625);
 }
 
-double PDH_status3_channel_20_current_decode(uint8_t value)
+double PDH_status_3_channel_20_current_decode(uint8_t value)
 {
     return ((double)value * 0.0625);
 }
 
-bool PDH_status3_channel_20_current_is_in_range(uint8_t value)
+bool PDH_status_3_channel_20_current_is_in_range(uint8_t value)
 {
     (void)value;
 
     return (true);
 }
 
-uint8_t PDH_status3_channel_21_current_encode(double value)
+uint8_t PDH_status_3_channel_21_current_encode(double value)
 {
     return (uint8_t)(value / 0.0625);
 }
 
-double PDH_status3_channel_21_current_decode(uint8_t value)
+double PDH_status_3_channel_21_current_decode(uint8_t value)
 {
     return ((double)value * 0.0625);
 }
 
-bool PDH_status3_channel_21_current_is_in_range(uint8_t value)
+bool PDH_status_3_channel_21_current_is_in_range(uint8_t value)
 {
     (void)value;
 
     return (true);
 }
 
-uint8_t PDH_status3_channel_22_current_encode(double value)
+uint8_t PDH_status_3_channel_22_current_encode(double value)
 {
     return (uint8_t)(value / 0.0625);
 }
 
-double PDH_status3_channel_22_current_decode(uint8_t value)
+double PDH_status_3_channel_22_current_decode(uint8_t value)
 {
     return ((double)value * 0.0625);
 }
 
-bool PDH_status3_channel_22_current_is_in_range(uint8_t value)
+bool PDH_status_3_channel_22_current_is_in_range(uint8_t value)
 {
     (void)value;
 
     return (true);
 }
 
-uint8_t PDH_status3_channel_23_current_encode(double value)
+uint8_t PDH_status_3_channel_23_current_encode(double value)
 {
     return (uint8_t)(value / 0.0625);
 }
 
-double PDH_status3_channel_23_current_decode(uint8_t value)
+double PDH_status_3_channel_23_current_decode(uint8_t value)
 {
     return ((double)value * 0.0625);
 }
 
-bool PDH_status3_channel_23_current_is_in_range(uint8_t value)
+bool PDH_status_3_channel_23_current_is_in_range(uint8_t value)
 {
     (void)value;
 
     return (true);
 }
 
-uint8_t PDH_status3_channel_16_brownout_encode(double value)
+uint8_t PDH_status_3_channel_16_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status3_channel_16_brownout_decode(uint8_t value)
+double PDH_status_3_channel_16_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status3_channel_16_brownout_is_in_range(uint8_t value)
+bool PDH_status_3_channel_16_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status3_channel_17_brownout_encode(double value)
+uint8_t PDH_status_3_channel_17_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status3_channel_17_brownout_decode(uint8_t value)
+double PDH_status_3_channel_17_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status3_channel_17_brownout_is_in_range(uint8_t value)
+bool PDH_status_3_channel_17_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status3_channel_18_brownout_encode(double value)
+uint8_t PDH_status_3_channel_18_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status3_channel_18_brownout_decode(uint8_t value)
+double PDH_status_3_channel_18_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status3_channel_18_brownout_is_in_range(uint8_t value)
+bool PDH_status_3_channel_18_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status3_channel_19_brownout_encode(double value)
+uint8_t PDH_status_3_channel_19_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status3_channel_19_brownout_decode(uint8_t value)
+double PDH_status_3_channel_19_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status3_channel_19_brownout_is_in_range(uint8_t value)
+bool PDH_status_3_channel_19_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status3_channel_20_brownout_encode(double value)
+uint8_t PDH_status_3_channel_20_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status3_channel_20_brownout_decode(uint8_t value)
+double PDH_status_3_channel_20_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status3_channel_20_brownout_is_in_range(uint8_t value)
+bool PDH_status_3_channel_20_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status3_channel_21_brownout_encode(double value)
+uint8_t PDH_status_3_channel_21_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status3_channel_21_brownout_decode(uint8_t value)
+double PDH_status_3_channel_21_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status3_channel_21_brownout_is_in_range(uint8_t value)
+bool PDH_status_3_channel_21_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status3_channel_22_brownout_encode(double value)
+uint8_t PDH_status_3_channel_22_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status3_channel_22_brownout_decode(uint8_t value)
+double PDH_status_3_channel_22_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status3_channel_22_brownout_is_in_range(uint8_t value)
+bool PDH_status_3_channel_22_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status3_channel_23_brownout_encode(double value)
+uint8_t PDH_status_3_channel_23_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status3_channel_23_brownout_decode(uint8_t value)
+double PDH_status_3_channel_23_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status3_channel_23_brownout_is_in_range(uint8_t value)
+bool PDH_status_3_channel_23_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-int PDH_status4_pack(
+int PDH_status_4_pack(
     uint8_t *dst_p,
-    const struct PDH_status4_t *src_p,
+    const struct PDH_status_4_t *src_p,
     size_t size)
 {
     if (size < 8u) {
@@ -1165,29 +1148,49 @@ int PDH_status4_pack(
     dst_p[1] |= pack_right_shift_u16(src_p->v_bus, 8u, 0x0fu);
     dst_p[1] |= pack_left_shift_u8(src_p->system_enable, 4u, 0x10u);
     dst_p[1] |= pack_left_shift_u8(src_p->rsvd0, 5u, 0xe0u);
-    dst_p[2] |= pack_left_shift_u8(src_p->brownout, 0u, 0x01u);
+    dst_p[2] |= pack_left_shift_u8(src_p->brownout_fault, 0u, 0x01u);
     dst_p[2] |= pack_left_shift_u8(src_p->rsvd1, 1u, 0x02u);
-    dst_p[2] |= pack_left_shift_u8(src_p->can_warning, 2u, 0x04u);
+    dst_p[2] |= pack_left_shift_u8(src_p->can_warning_fault, 2u, 0x04u);
     dst_p[2] |= pack_left_shift_u8(src_p->hardware_fault, 3u, 0x08u);
-    dst_p[2] |= pack_left_shift_u8(src_p->sw_state, 4u, 0x10u);
-    dst_p[2] |= pack_left_shift_u8(src_p->sticky_brownout, 5u, 0x20u);
+    dst_p[2] |= pack_left_shift_u8(src_p->switch_channel_state, 4u, 0x10u);
+    dst_p[2] |= pack_left_shift_u8(src_p->sticky_brownout_fault, 5u, 0x20u);
     dst_p[2] |= pack_left_shift_u8(src_p->rsvd2, 6u, 0x40u);
-    dst_p[2] |= pack_left_shift_u8(src_p->sticky_can_warning, 7u, 0x80u);
-    dst_p[3] |= pack_left_shift_u8(src_p->sticky_can_bus_off, 0u, 0x01u);
+    dst_p[2] |= pack_left_shift_u8(src_p->sticky_can_warning_fault, 7u, 0x80u);
+    dst_p[3] |= pack_left_shift_u8(src_p->sticky_can_bus_off_fault, 0u, 0x01u);
     dst_p[3] |= pack_left_shift_u8(src_p->sticky_hardware_fault, 1u, 0x02u);
     dst_p[3] |= pack_left_shift_u8(src_p->sticky_firmware_fault, 2u, 0x04u);
-    dst_p[3] |= pack_left_shift_u8(src_p->sticky_ch20_brownout, 3u, 0x08u);
-    dst_p[3] |= pack_left_shift_u8(src_p->sticky_ch21_brownout, 4u, 0x10u);
-    dst_p[3] |= pack_left_shift_u8(src_p->sticky_ch22_brownout, 5u, 0x20u);
-    dst_p[3] |= pack_left_shift_u8(src_p->sticky_ch23_brownout, 6u, 0x40u);
-    dst_p[3] |= pack_left_shift_u8(src_p->sticky_has_reset, 7u, 0x80u);
+    dst_p[3] |= pack_left_shift_u8(src_p->sticky_ch20_breaker_fault, 3u, 0x08u);
+    dst_p[3] |= pack_left_shift_u8(src_p->sticky_ch21_breaker_fault, 4u, 0x10u);
+    dst_p[3] |= pack_left_shift_u8(src_p->sticky_ch22_breaker_fault, 5u, 0x20u);
+    dst_p[3] |= pack_left_shift_u8(src_p->sticky_ch23_breaker_fault, 6u, 0x40u);
+    dst_p[3] |= pack_left_shift_u8(src_p->sticky_has_reset_fault, 7u, 0x80u);
     dst_p[4] |= pack_left_shift_u8(src_p->total_current, 0u, 0xffu);
+    dst_p[5] |= pack_left_shift_u8(src_p->sticky_ch0_breaker_fault, 0u, 0x01u);
+    dst_p[5] |= pack_left_shift_u8(src_p->sticky_ch1_breaker_fault, 1u, 0x02u);
+    dst_p[5] |= pack_left_shift_u8(src_p->sticky_ch2_breaker_fault, 2u, 0x04u);
+    dst_p[5] |= pack_left_shift_u8(src_p->sticky_ch3_breaker_fault, 3u, 0x08u);
+    dst_p[5] |= pack_left_shift_u8(src_p->sticky_ch4_breaker_fault, 4u, 0x10u);
+    dst_p[5] |= pack_left_shift_u8(src_p->sticky_ch5_breaker_fault, 5u, 0x20u);
+    dst_p[5] |= pack_left_shift_u8(src_p->sticky_ch6_breaker_fault, 6u, 0x40u);
+    dst_p[5] |= pack_left_shift_u8(src_p->sticky_ch7_breaker_fault, 7u, 0x80u);
+    dst_p[6] |= pack_left_shift_u8(src_p->sticky_ch8_breaker_fault, 0u, 0x01u);
+    dst_p[6] |= pack_left_shift_u8(src_p->sticky_ch9_breaker_fault, 1u, 0x02u);
+    dst_p[6] |= pack_left_shift_u8(src_p->sticky_ch10_breaker_fault, 2u, 0x04u);
+    dst_p[6] |= pack_left_shift_u8(src_p->sticky_ch11_breaker_fault, 3u, 0x08u);
+    dst_p[6] |= pack_left_shift_u8(src_p->sticky_ch12_breaker_fault, 4u, 0x10u);
+    dst_p[6] |= pack_left_shift_u8(src_p->sticky_ch13_breaker_fault, 5u, 0x20u);
+    dst_p[6] |= pack_left_shift_u8(src_p->sticky_ch14_breaker_fault, 6u, 0x40u);
+    dst_p[6] |= pack_left_shift_u8(src_p->sticky_ch15_breaker_fault, 7u, 0x80u);
+    dst_p[7] |= pack_left_shift_u8(src_p->sticky_ch16_breaker_fault, 0u, 0x01u);
+    dst_p[7] |= pack_left_shift_u8(src_p->sticky_ch17_breaker_fault, 1u, 0x02u);
+    dst_p[7] |= pack_left_shift_u8(src_p->sticky_ch18_breaker_fault, 2u, 0x04u);
+    dst_p[7] |= pack_left_shift_u8(src_p->sticky_ch19_breaker_fault, 3u, 0x08u);
 
     return (8);
 }
 
-int PDH_status4_unpack(
-    struct PDH_status4_t *dst_p,
+int PDH_status_4_unpack(
+    struct PDH_status_4_t *dst_p,
     const uint8_t *src_p,
     size_t size)
 {
@@ -1199,327 +1202,647 @@ int PDH_status4_unpack(
     dst_p->v_bus |= unpack_left_shift_u16(src_p[1], 8u, 0x0fu);
     dst_p->system_enable = unpack_right_shift_u8(src_p[1], 4u, 0x10u);
     dst_p->rsvd0 = unpack_right_shift_u8(src_p[1], 5u, 0xe0u);
-    dst_p->brownout = unpack_right_shift_u8(src_p[2], 0u, 0x01u);
+    dst_p->brownout_fault = unpack_right_shift_u8(src_p[2], 0u, 0x01u);
     dst_p->rsvd1 = unpack_right_shift_u8(src_p[2], 1u, 0x02u);
-    dst_p->can_warning = unpack_right_shift_u8(src_p[2], 2u, 0x04u);
+    dst_p->can_warning_fault = unpack_right_shift_u8(src_p[2], 2u, 0x04u);
     dst_p->hardware_fault = unpack_right_shift_u8(src_p[2], 3u, 0x08u);
-    dst_p->sw_state = unpack_right_shift_u8(src_p[2], 4u, 0x10u);
-    dst_p->sticky_brownout = unpack_right_shift_u8(src_p[2], 5u, 0x20u);
+    dst_p->switch_channel_state = unpack_right_shift_u8(src_p[2], 4u, 0x10u);
+    dst_p->sticky_brownout_fault = unpack_right_shift_u8(src_p[2], 5u, 0x20u);
     dst_p->rsvd2 = unpack_right_shift_u8(src_p[2], 6u, 0x40u);
-    dst_p->sticky_can_warning = unpack_right_shift_u8(src_p[2], 7u, 0x80u);
-    dst_p->sticky_can_bus_off = unpack_right_shift_u8(src_p[3], 0u, 0x01u);
+    dst_p->sticky_can_warning_fault = unpack_right_shift_u8(src_p[2], 7u, 0x80u);
+    dst_p->sticky_can_bus_off_fault = unpack_right_shift_u8(src_p[3], 0u, 0x01u);
     dst_p->sticky_hardware_fault = unpack_right_shift_u8(src_p[3], 1u, 0x02u);
     dst_p->sticky_firmware_fault = unpack_right_shift_u8(src_p[3], 2u, 0x04u);
-    dst_p->sticky_ch20_brownout = unpack_right_shift_u8(src_p[3], 3u, 0x08u);
-    dst_p->sticky_ch21_brownout = unpack_right_shift_u8(src_p[3], 4u, 0x10u);
-    dst_p->sticky_ch22_brownout = unpack_right_shift_u8(src_p[3], 5u, 0x20u);
-    dst_p->sticky_ch23_brownout = unpack_right_shift_u8(src_p[3], 6u, 0x40u);
-    dst_p->sticky_has_reset = unpack_right_shift_u8(src_p[3], 7u, 0x80u);
+    dst_p->sticky_ch20_breaker_fault = unpack_right_shift_u8(src_p[3], 3u, 0x08u);
+    dst_p->sticky_ch21_breaker_fault = unpack_right_shift_u8(src_p[3], 4u, 0x10u);
+    dst_p->sticky_ch22_breaker_fault = unpack_right_shift_u8(src_p[3], 5u, 0x20u);
+    dst_p->sticky_ch23_breaker_fault = unpack_right_shift_u8(src_p[3], 6u, 0x40u);
+    dst_p->sticky_has_reset_fault = unpack_right_shift_u8(src_p[3], 7u, 0x80u);
     dst_p->total_current = unpack_right_shift_u8(src_p[4], 0u, 0xffu);
+    dst_p->sticky_ch0_breaker_fault = unpack_right_shift_u8(src_p[5], 0u, 0x01u);
+    dst_p->sticky_ch1_breaker_fault = unpack_right_shift_u8(src_p[5], 1u, 0x02u);
+    dst_p->sticky_ch2_breaker_fault = unpack_right_shift_u8(src_p[5], 2u, 0x04u);
+    dst_p->sticky_ch3_breaker_fault = unpack_right_shift_u8(src_p[5], 3u, 0x08u);
+    dst_p->sticky_ch4_breaker_fault = unpack_right_shift_u8(src_p[5], 4u, 0x10u);
+    dst_p->sticky_ch5_breaker_fault = unpack_right_shift_u8(src_p[5], 5u, 0x20u);
+    dst_p->sticky_ch6_breaker_fault = unpack_right_shift_u8(src_p[5], 6u, 0x40u);
+    dst_p->sticky_ch7_breaker_fault = unpack_right_shift_u8(src_p[5], 7u, 0x80u);
+    dst_p->sticky_ch8_breaker_fault = unpack_right_shift_u8(src_p[6], 0u, 0x01u);
+    dst_p->sticky_ch9_breaker_fault = unpack_right_shift_u8(src_p[6], 1u, 0x02u);
+    dst_p->sticky_ch10_breaker_fault = unpack_right_shift_u8(src_p[6], 2u, 0x04u);
+    dst_p->sticky_ch11_breaker_fault = unpack_right_shift_u8(src_p[6], 3u, 0x08u);
+    dst_p->sticky_ch12_breaker_fault = unpack_right_shift_u8(src_p[6], 4u, 0x10u);
+    dst_p->sticky_ch13_breaker_fault = unpack_right_shift_u8(src_p[6], 5u, 0x20u);
+    dst_p->sticky_ch14_breaker_fault = unpack_right_shift_u8(src_p[6], 6u, 0x40u);
+    dst_p->sticky_ch15_breaker_fault = unpack_right_shift_u8(src_p[6], 7u, 0x80u);
+    dst_p->sticky_ch16_breaker_fault = unpack_right_shift_u8(src_p[7], 0u, 0x01u);
+    dst_p->sticky_ch17_breaker_fault = unpack_right_shift_u8(src_p[7], 1u, 0x02u);
+    dst_p->sticky_ch18_breaker_fault = unpack_right_shift_u8(src_p[7], 2u, 0x04u);
+    dst_p->sticky_ch19_breaker_fault = unpack_right_shift_u8(src_p[7], 3u, 0x08u);
 
     return (0);
 }
 
-uint16_t PDH_status4_v_bus_encode(double value)
+uint16_t PDH_status_4_v_bus_encode(double value)
 {
     return (uint16_t)(value / 0.0078125);
 }
 
-double PDH_status4_v_bus_decode(uint16_t value)
+double PDH_status_4_v_bus_decode(uint16_t value)
 {
     return ((double)value * 0.0078125);
 }
 
-bool PDH_status4_v_bus_is_in_range(uint16_t value)
+bool PDH_status_4_v_bus_is_in_range(uint16_t value)
 {
     return (value <= 4095u);
 }
 
-uint8_t PDH_status4_system_enable_encode(double value)
+uint8_t PDH_status_4_system_enable_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_system_enable_decode(uint8_t value)
+double PDH_status_4_system_enable_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_system_enable_is_in_range(uint8_t value)
+bool PDH_status_4_system_enable_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_rsvd0_encode(double value)
+uint8_t PDH_status_4_rsvd0_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_rsvd0_decode(uint8_t value)
+double PDH_status_4_rsvd0_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_rsvd0_is_in_range(uint8_t value)
+bool PDH_status_4_rsvd0_is_in_range(uint8_t value)
 {
     return (value <= 7u);
 }
 
-uint8_t PDH_status4_brownout_encode(double value)
+uint8_t PDH_status_4_brownout_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_brownout_decode(uint8_t value)
+double PDH_status_4_brownout_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_brownout_is_in_range(uint8_t value)
+bool PDH_status_4_brownout_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_rsvd1_encode(double value)
+uint8_t PDH_status_4_rsvd1_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_rsvd1_decode(uint8_t value)
+double PDH_status_4_rsvd1_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_rsvd1_is_in_range(uint8_t value)
+bool PDH_status_4_rsvd1_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_can_warning_encode(double value)
+uint8_t PDH_status_4_can_warning_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_can_warning_decode(uint8_t value)
+double PDH_status_4_can_warning_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_can_warning_is_in_range(uint8_t value)
+bool PDH_status_4_can_warning_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_hardware_fault_encode(double value)
+uint8_t PDH_status_4_hardware_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_hardware_fault_decode(uint8_t value)
+double PDH_status_4_hardware_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_hardware_fault_is_in_range(uint8_t value)
+bool PDH_status_4_hardware_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_sw_state_encode(double value)
+uint8_t PDH_status_4_switch_channel_state_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_sw_state_decode(uint8_t value)
+double PDH_status_4_switch_channel_state_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_sw_state_is_in_range(uint8_t value)
+bool PDH_status_4_switch_channel_state_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_sticky_brownout_encode(double value)
+uint8_t PDH_status_4_sticky_brownout_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_sticky_brownout_decode(uint8_t value)
+double PDH_status_4_sticky_brownout_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_sticky_brownout_is_in_range(uint8_t value)
+bool PDH_status_4_sticky_brownout_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_rsvd2_encode(double value)
+uint8_t PDH_status_4_rsvd2_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_rsvd2_decode(uint8_t value)
+double PDH_status_4_rsvd2_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_rsvd2_is_in_range(uint8_t value)
+bool PDH_status_4_rsvd2_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_sticky_can_warning_encode(double value)
+uint8_t PDH_status_4_sticky_can_warning_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_sticky_can_warning_decode(uint8_t value)
+double PDH_status_4_sticky_can_warning_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_sticky_can_warning_is_in_range(uint8_t value)
+bool PDH_status_4_sticky_can_warning_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_sticky_can_bus_off_encode(double value)
+uint8_t PDH_status_4_sticky_can_bus_off_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_sticky_can_bus_off_decode(uint8_t value)
+double PDH_status_4_sticky_can_bus_off_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_sticky_can_bus_off_is_in_range(uint8_t value)
+bool PDH_status_4_sticky_can_bus_off_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_sticky_hardware_fault_encode(double value)
+uint8_t PDH_status_4_sticky_hardware_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_sticky_hardware_fault_decode(uint8_t value)
+double PDH_status_4_sticky_hardware_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_sticky_hardware_fault_is_in_range(uint8_t value)
+bool PDH_status_4_sticky_hardware_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_sticky_firmware_fault_encode(double value)
+uint8_t PDH_status_4_sticky_firmware_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_sticky_firmware_fault_decode(uint8_t value)
+double PDH_status_4_sticky_firmware_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_sticky_firmware_fault_is_in_range(uint8_t value)
+bool PDH_status_4_sticky_firmware_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_sticky_ch20_brownout_encode(double value)
+uint8_t PDH_status_4_sticky_ch20_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_sticky_ch20_brownout_decode(uint8_t value)
+double PDH_status_4_sticky_ch20_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_sticky_ch20_brownout_is_in_range(uint8_t value)
+bool PDH_status_4_sticky_ch20_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_sticky_ch21_brownout_encode(double value)
+uint8_t PDH_status_4_sticky_ch21_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_sticky_ch21_brownout_decode(uint8_t value)
+double PDH_status_4_sticky_ch21_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_sticky_ch21_brownout_is_in_range(uint8_t value)
+bool PDH_status_4_sticky_ch21_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_sticky_ch22_brownout_encode(double value)
+uint8_t PDH_status_4_sticky_ch22_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_sticky_ch22_brownout_decode(uint8_t value)
+double PDH_status_4_sticky_ch22_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_sticky_ch22_brownout_is_in_range(uint8_t value)
+bool PDH_status_4_sticky_ch22_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_sticky_ch23_brownout_encode(double value)
+uint8_t PDH_status_4_sticky_ch23_breaker_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_sticky_ch23_brownout_decode(uint8_t value)
+double PDH_status_4_sticky_ch23_breaker_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_sticky_ch23_brownout_is_in_range(uint8_t value)
+bool PDH_status_4_sticky_ch23_breaker_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_sticky_has_reset_encode(double value)
+uint8_t PDH_status_4_sticky_has_reset_fault_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_status4_sticky_has_reset_decode(uint8_t value)
+double PDH_status_4_sticky_has_reset_fault_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_status4_sticky_has_reset_is_in_range(uint8_t value)
+bool PDH_status_4_sticky_has_reset_fault_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }
 
-uint8_t PDH_status4_total_current_encode(double value)
+uint8_t PDH_status_4_total_current_encode(double value)
 {
     return (uint8_t)(value / 2.0);
 }
 
-double PDH_status4_total_current_decode(uint8_t value)
+double PDH_status_4_total_current_decode(uint8_t value)
 {
     return ((double)value * 2.0);
 }
 
-bool PDH_status4_total_current_is_in_range(uint8_t value)
+bool PDH_status_4_total_current_is_in_range(uint8_t value)
 {
     (void)value;
 
     return (true);
+}
+
+uint8_t PDH_status_4_sticky_ch0_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch0_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch0_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch1_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch1_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch1_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch2_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch2_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch2_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch3_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch3_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch3_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch4_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch4_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch4_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch5_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch5_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch5_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch6_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch6_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch6_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch7_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch7_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch7_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch8_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch8_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch8_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch9_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch9_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch9_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch10_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch10_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch10_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch11_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch11_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch11_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch12_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch12_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch12_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch13_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch13_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch13_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch14_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch14_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch14_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch15_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch15_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch15_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch16_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch16_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch16_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch17_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch17_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch17_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch18_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch18_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch18_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t PDH_status_4_sticky_ch19_breaker_fault_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_status_4_sticky_ch19_breaker_fault_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_status_4_sticky_ch19_breaker_fault_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
 }
 
 int PDH_clear_faults_pack(
@@ -1546,30 +1869,6 @@ int PDH_clear_faults_unpack(
     return (0);
 }
 
-int PDH_identify_pack(
-    uint8_t *dst_p,
-    const struct PDH_identify_t *src_p,
-    size_t size)
-{
-    (void)dst_p;
-    (void)src_p;
-    (void)size;
-
-    return (0);
-}
-
-int PDH_identify_unpack(
-    struct PDH_identify_t *dst_p,
-    const uint8_t *src_p,
-    size_t size)
-{
-    (void)dst_p;
-    (void)src_p;
-    (void)size;
-
-    return (0);
-}
-
 int PDH_version_pack(
     uint8_t *dst_p,
     const struct PDH_version_t *src_p,
@@ -1584,11 +1883,11 @@ int PDH_version_pack(
     dst_p[0] |= pack_left_shift_u8(src_p->firmware_fix, 0u, 0xffu);
     dst_p[1] |= pack_left_shift_u8(src_p->firmware_minor, 0u, 0xffu);
     dst_p[2] |= pack_left_shift_u8(src_p->firmware_year, 0u, 0xffu);
-    dst_p[3] |= pack_left_shift_u8(src_p->hardware_code, 0u, 0xffu);
-    dst_p[4] |= pack_left_shift_u32(src_p->unique_id, 0u, 0xffu);
-    dst_p[5] |= pack_right_shift_u32(src_p->unique_id, 8u, 0xffu);
-    dst_p[6] |= pack_right_shift_u32(src_p->unique_id, 16u, 0xffu);
-    dst_p[7] |= pack_right_shift_u32(src_p->unique_id, 24u, 0xffu);
+    dst_p[3] |= pack_left_shift_u8(src_p->hardware_minor, 0u, 0xffu);
+    dst_p[4] |= pack_left_shift_u8(src_p->hardware_major, 0u, 0xffu);
+    dst_p[5] |= pack_left_shift_u32(src_p->unique_id, 0u, 0xffu);
+    dst_p[6] |= pack_right_shift_u32(src_p->unique_id, 8u, 0xffu);
+    dst_p[7] |= pack_right_shift_u32(src_p->unique_id, 16u, 0xffu);
 
     return (8);
 }
@@ -1605,11 +1904,11 @@ int PDH_version_unpack(
     dst_p->firmware_fix = unpack_right_shift_u8(src_p[0], 0u, 0xffu);
     dst_p->firmware_minor = unpack_right_shift_u8(src_p[1], 0u, 0xffu);
     dst_p->firmware_year = unpack_right_shift_u8(src_p[2], 0u, 0xffu);
-    dst_p->hardware_code = unpack_right_shift_u8(src_p[3], 0u, 0xffu);
-    dst_p->unique_id = unpack_right_shift_u32(src_p[4], 0u, 0xffu);
-    dst_p->unique_id |= unpack_left_shift_u32(src_p[5], 8u, 0xffu);
-    dst_p->unique_id |= unpack_left_shift_u32(src_p[6], 16u, 0xffu);
-    dst_p->unique_id |= unpack_left_shift_u32(src_p[7], 24u, 0xffu);
+    dst_p->hardware_minor = unpack_right_shift_u8(src_p[3], 0u, 0xffu);
+    dst_p->hardware_major = unpack_right_shift_u8(src_p[4], 0u, 0xffu);
+    dst_p->unique_id = unpack_right_shift_u32(src_p[5], 0u, 0xffu);
+    dst_p->unique_id |= unpack_left_shift_u32(src_p[6], 8u, 0xffu);
+    dst_p->unique_id |= unpack_left_shift_u32(src_p[7], 16u, 0xffu);
 
     return (0);
 }
@@ -1665,17 +1964,34 @@ bool PDH_version_firmware_year_is_in_range(uint8_t value)
     return (true);
 }
 
-uint8_t PDH_version_hardware_code_encode(double value)
+uint8_t PDH_version_hardware_minor_encode(double value)
 {
     return (uint8_t)(value);
 }
 
-double PDH_version_hardware_code_decode(uint8_t value)
+double PDH_version_hardware_minor_decode(uint8_t value)
 {
     return ((double)value);
 }
 
-bool PDH_version_hardware_code_is_in_range(uint8_t value)
+bool PDH_version_hardware_minor_is_in_range(uint8_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+uint8_t PDH_version_hardware_major_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double PDH_version_hardware_major_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool PDH_version_hardware_major_is_in_range(uint8_t value)
 {
     (void)value;
 
@@ -1694,97 +2010,5 @@ double PDH_version_unique_id_decode(uint32_t value)
 
 bool PDH_version_unique_id_is_in_range(uint32_t value)
 {
-    (void)value;
-
-    return (true);
-}
-
-int PDH_configure_hr_channel_pack(
-    uint8_t *dst_p,
-    const struct PDH_configure_hr_channel_t *src_p,
-    size_t size)
-{
-    if (size < 3u) {
-        return (-EINVAL);
-    }
-
-    memset(&dst_p[0], 0, 3);
-
-    dst_p[0] |= pack_left_shift_u8(src_p->channel, 0u, 0xffu);
-    dst_p[1] |= pack_left_shift_u16(src_p->period, 0u, 0xffu);
-    dst_p[2] |= pack_right_shift_u16(src_p->period, 8u, 0xffu);
-
-    return (3);
-}
-
-int PDH_configure_hr_channel_unpack(
-    struct PDH_configure_hr_channel_t *dst_p,
-    const uint8_t *src_p,
-    size_t size)
-{
-    if (size < 3u) {
-        return (-EINVAL);
-    }
-
-    dst_p->channel = unpack_right_shift_u8(src_p[0], 0u, 0xffu);
-    dst_p->period = unpack_right_shift_u16(src_p[1], 0u, 0xffu);
-    dst_p->period |= unpack_left_shift_u16(src_p[2], 8u, 0xffu);
-
-    return (0);
-}
-
-uint8_t PDH_configure_hr_channel_channel_encode(double value)
-{
-    return (uint8_t)(value);
-}
-
-double PDH_configure_hr_channel_channel_decode(uint8_t value)
-{
-    return ((double)value);
-}
-
-bool PDH_configure_hr_channel_channel_is_in_range(uint8_t value)
-{
-    return (value <= 23u);
-}
-
-uint16_t PDH_configure_hr_channel_period_encode(double value)
-{
-    return (uint16_t)(value);
-}
-
-double PDH_configure_hr_channel_period_decode(uint16_t value)
-{
-    return ((double)value);
-}
-
-bool PDH_configure_hr_channel_period_is_in_range(uint16_t value)
-{
-    (void)value;
-
-    return (true);
-}
-
-int PDH_enter_bootloader_pack(
-    uint8_t *dst_p,
-    const struct PDH_enter_bootloader_t *src_p,
-    size_t size)
-{
-    (void)dst_p;
-    (void)src_p;
-    (void)size;
-
-    return (0);
-}
-
-int PDH_enter_bootloader_unpack(
-    struct PDH_enter_bootloader_t *dst_p,
-    const uint8_t *src_p,
-    size_t size)
-{
-    (void)dst_p;
-    (void)src_p;
-    (void)size;
-
-    return (0);
+    return (value <= 16777215u);
 }

--- a/hal/src/main/native/athena/rev/PDHFrames.h
+++ b/hal/src/main/native/athena/rev/PDHFrames.h
@@ -44,43 +44,34 @@ extern "C" {
 #endif
 
 /* Frame ids. */
-#define PDH_SWITCH_CHANNEL_SET_FRAME_ID (0x8050840u)
-#define PDH_STATUS0_FRAME_ID (0x8051800u)
-#define PDH_STATUS1_FRAME_ID (0x8051840u)
-#define PDH_STATUS2_FRAME_ID (0x8051880u)
-#define PDH_STATUS3_FRAME_ID (0x80518c0u)
-#define PDH_STATUS4_FRAME_ID (0x8051900u)
+#define PDH_SET_SWITCH_CHANNEL_FRAME_ID (0x8050840u)
+#define PDH_STATUS_0_FRAME_ID (0x8051800u)
+#define PDH_STATUS_1_FRAME_ID (0x8051840u)
+#define PDH_STATUS_2_FRAME_ID (0x8051880u)
+#define PDH_STATUS_3_FRAME_ID (0x80518c0u)
+#define PDH_STATUS_4_FRAME_ID (0x8051900u)
 #define PDH_CLEAR_FAULTS_FRAME_ID (0x8051b80u)
-#define PDH_IDENTIFY_FRAME_ID (0x8051d80u)
 #define PDH_VERSION_FRAME_ID (0x8052600u)
-#define PDH_CONFIGURE_HR_CHANNEL_FRAME_ID (0x80538c0u)
-#define PDH_ENTER_BOOTLOADER_FRAME_ID (0x8057fc0u)
 
 /* Frame lengths in bytes. */
-#define PDH_SWITCH_CHANNEL_SET_LENGTH (1u)
-#define PDH_STATUS0_LENGTH (8u)
-#define PDH_STATUS1_LENGTH (8u)
-#define PDH_STATUS2_LENGTH (8u)
-#define PDH_STATUS3_LENGTH (8u)
-#define PDH_STATUS4_LENGTH (8u)
+#define PDH_SET_SWITCH_CHANNEL_LENGTH (1u)
+#define PDH_STATUS_0_LENGTH (8u)
+#define PDH_STATUS_1_LENGTH (8u)
+#define PDH_STATUS_2_LENGTH (8u)
+#define PDH_STATUS_3_LENGTH (8u)
+#define PDH_STATUS_4_LENGTH (8u)
 #define PDH_CLEAR_FAULTS_LENGTH (0u)
-#define PDH_IDENTIFY_LENGTH (0u)
 #define PDH_VERSION_LENGTH (8u)
-#define PDH_CONFIGURE_HR_CHANNEL_LENGTH (3u)
-#define PDH_ENTER_BOOTLOADER_LENGTH (0u)
 
 /* Extended or standard frame types. */
-#define PDH_SWITCH_CHANNEL_SET_IS_EXTENDED (1)
-#define PDH_STATUS0_IS_EXTENDED (1)
-#define PDH_STATUS1_IS_EXTENDED (1)
-#define PDH_STATUS2_IS_EXTENDED (1)
-#define PDH_STATUS3_IS_EXTENDED (1)
-#define PDH_STATUS4_IS_EXTENDED (1)
+#define PDH_SET_SWITCH_CHANNEL_IS_EXTENDED (1)
+#define PDH_STATUS_0_IS_EXTENDED (1)
+#define PDH_STATUS_1_IS_EXTENDED (1)
+#define PDH_STATUS_2_IS_EXTENDED (1)
+#define PDH_STATUS_3_IS_EXTENDED (1)
+#define PDH_STATUS_4_IS_EXTENDED (1)
 #define PDH_CLEAR_FAULTS_IS_EXTENDED (1)
-#define PDH_IDENTIFY_IS_EXTENDED (1)
 #define PDH_VERSION_IS_EXTENDED (1)
-#define PDH_CONFIGURE_HR_CHANNEL_IS_EXTENDED (1)
-#define PDH_ENTER_BOOTLOADER_IS_EXTENDED (1)
 
 /* Frame cycle times in milliseconds. */
 
@@ -89,36 +80,29 @@ extern "C" {
 
 
 /**
- * Signals in message SwitchChannelSet.
+ * Signals in message Set_Switch_Channel.
  *
  * Set the switch channel output
  *
  * All signal values are as on the CAN bus.
  */
-struct PDH_switch_channel_set_t {
+struct PDH_set_switch_channel_t {
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
     uint8_t output_set_value : 1;
-
-    /**
-     * Range: 0..1 (0..1 -)
-     * Scale: 1
-     * Offset: 0
-     */
-    uint8_t use_system_enable : 1;
 };
 
 /**
- * Signals in message Status0.
+ * Signals in message Status_0.
  *
  * Periodic status frame 0
  *
  * All signal values are as on the CAN bus.
  */
-struct PDH_status0_t {
+struct PDH_status_0_t {
     /**
      * Range: 0..1023 (0..127.875 A)
      * Scale: 0.125
@@ -145,14 +129,14 @@ struct PDH_status0_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_0_brownout : 1;
+    uint8_t channel_0_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_1_brownout : 1;
+    uint8_t channel_1_breaker_fault : 1;
 
     /**
      * Range: 0..1023 (0..127.875 A)
@@ -180,24 +164,24 @@ struct PDH_status0_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_2_brownout : 1;
+    uint8_t channel_2_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_3_brownout : 1;
+    uint8_t channel_3_breaker_fault : 1;
 };
 
 /**
- * Signals in message Status1.
+ * Signals in message Status_1.
  *
  * Periodic status frame 1
  *
  * All signal values are as on the CAN bus.
  */
-struct PDH_status1_t {
+struct PDH_status_1_t {
     /**
      * Range: 0..1023 (0..127.875 A)
      * Scale: 0.125
@@ -224,14 +208,14 @@ struct PDH_status1_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_4_brownout : 1;
+    uint8_t channel_4_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_5_brownout : 1;
+    uint8_t channel_5_breaker_fault : 1;
 
     /**
      * Range: 0..1023 (0..127.875 A)
@@ -259,24 +243,24 @@ struct PDH_status1_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_6_brownout : 1;
+    uint8_t channel_6_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_7_brownout : 1;
+    uint8_t channel_7_breaker_fault : 1;
 };
 
 /**
- * Signals in message Status2.
+ * Signals in message Status_2.
  *
  * Periodic status frame 2
  *
  * All signal values are as on the CAN bus.
  */
-struct PDH_status2_t {
+struct PDH_status_2_t {
     /**
      * Range: 0..1023 (0..127.875 A)
      * Scale: 0.125
@@ -303,14 +287,14 @@ struct PDH_status2_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_8_brownout : 1;
+    uint8_t channel_8_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_9_brownout : 1;
+    uint8_t channel_9_breaker_fault : 1;
 
     /**
      * Range: 0..1023 (0..127.875 A)
@@ -338,24 +322,24 @@ struct PDH_status2_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_10_brownout : 1;
+    uint8_t channel_10_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_11_brownout : 1;
+    uint8_t channel_11_breaker_fault : 1;
 };
 
 /**
- * Signals in message Status3.
+ * Signals in message Status_3.
  *
  * Periodic status frame 3
  *
  * All signal values are as on the CAN bus.
  */
-struct PDH_status3_t {
+struct PDH_status_3_t {
     /**
      * Range: 0..1023 (0..127.875 A)
      * Scale: 0.125
@@ -375,38 +359,38 @@ struct PDH_status3_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_12_brownout : 1;
+    uint8_t channel_12_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_13_brownout : 1;
+    uint8_t channel_13_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_14_brownout : 1;
+    uint8_t channel_14_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_15_brownout : 1;
+    uint8_t channel_15_breaker_fault : 1;
 
     /**
-     * Range: 0..255 (0..15.9375 A)
+     * Range: 0..511 (0..31.9375 A)
      * Scale: 0.0625
      * Offset: 0
      */
     uint8_t channel_20_current : 8;
 
     /**
-     * Range: 0..255 (0..15.9375 A)
+     * Range: 0..511 (0..31.9375 A)
      * Scale: 0.0625
      * Offset: 0
      */
@@ -431,66 +415,66 @@ struct PDH_status3_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_16_brownout : 1;
+    uint8_t channel_16_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_17_brownout : 1;
+    uint8_t channel_17_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_18_brownout : 1;
+    uint8_t channel_18_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_19_brownout : 1;
+    uint8_t channel_19_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_20_brownout : 1;
+    uint8_t channel_20_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_21_brownout : 1;
+    uint8_t channel_21_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_22_brownout : 1;
+    uint8_t channel_22_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel_23_brownout : 1;
+    uint8_t channel_23_breaker_fault : 1;
 };
 
 /**
- * Signals in message Status4.
+ * Signals in message Status_4.
  *
  * Periodic status frame 4
  *
  * All signal values are as on the CAN bus.
  */
-struct PDH_status4_t {
+struct PDH_status_4_t {
     /**
      * Range: 0..4095 (0..31.9921875 V)
      * Scale: 0.0078125
@@ -517,7 +501,7 @@ struct PDH_status4_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t brownout : 1;
+    uint8_t brownout_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
@@ -531,7 +515,7 @@ struct PDH_status4_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t can_warning : 1;
+    uint8_t can_warning_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
@@ -545,14 +529,14 @@ struct PDH_status4_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t sw_state : 1;
+    uint8_t switch_channel_state : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t sticky_brownout : 1;
+    uint8_t sticky_brownout_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
@@ -566,14 +550,14 @@ struct PDH_status4_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t sticky_can_warning : 1;
+    uint8_t sticky_can_warning_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t sticky_can_bus_off : 1;
+    uint8_t sticky_can_bus_off_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
@@ -594,35 +578,35 @@ struct PDH_status4_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t sticky_ch20_brownout : 1;
+    uint8_t sticky_ch20_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t sticky_ch21_brownout : 1;
+    uint8_t sticky_ch21_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t sticky_ch22_brownout : 1;
+    uint8_t sticky_ch22_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t sticky_ch23_brownout : 1;
+    uint8_t sticky_ch23_breaker_fault : 1;
 
     /**
      * Range: 0..1 (0..1 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t sticky_has_reset : 1;
+    uint8_t sticky_has_reset_fault : 1;
 
     /**
      * Range: 0..255 (0..510 A)
@@ -630,30 +614,156 @@ struct PDH_status4_t {
      * Offset: 0
      */
     uint8_t total_current : 8;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch0_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch1_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch2_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch3_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch4_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch5_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch6_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch7_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch8_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch9_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch10_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch11_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch12_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch13_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch14_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch15_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch16_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch17_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch18_breaker_fault : 1;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t sticky_ch19_breaker_fault : 1;
 };
 
 /**
- * Signals in message ClearFaults.
+ * Signals in message Clear_Faults.
  *
  * Clear sticky faults on the device
  *
  * All signal values are as on the CAN bus.
  */
 struct PDH_clear_faults_t {
-    /**
-     * Dummy signal in empty message.
-     */
-    uint8_t dummy;
-};
-
-/**
- * Signals in message Identify.
- *
- * Flash the LED on the device to identify this device
- *
- * All signal values are as on the CAN bus.
- */
-struct PDH_identify_t {
     /**
      * Dummy signal in empty message.
      */
@@ -694,55 +804,25 @@ struct PDH_version_t {
      * Scale: 1
      * Offset: 0
      */
-    uint8_t hardware_code : 8;
+    uint8_t hardware_minor : 8;
 
     /**
-     * Range: 0..4294967295 (0..4294967295 -)
+     * Range: 0..255 (0..255 -)
      * Scale: 1
      * Offset: 0
      */
-    uint32_t unique_id : 32;
-};
+    uint8_t hardware_major : 8;
 
-/**
- * Signals in message ConfigureHRChannel.
- *
- * Configure a periodic high-resolution channel frame to send back data for a particular channel. This can be useful for more detailed diagnostics, or even for current based control or monitoring.
- *
- * All signal values are as on the CAN bus.
- */
-struct PDH_configure_hr_channel_t {
     /**
-     * Range: 0..23 (0..23 -)
+     * Range: 0..16777215 (0..16777215 -)
      * Scale: 1
      * Offset: 0
      */
-    uint8_t channel : 8;
-
-    /**
-     * Range: 0..65535 (0..65535 -)
-     * Scale: 1
-     * Offset: 0
-     */
-    uint16_t period : 16;
+    uint32_t unique_id : 24;
 };
 
 /**
- * Signals in message Enter_Bootloader.
- *
- * Enter the REV bootloader from user application
- *
- * All signal values are as on the CAN bus.
- */
-struct PDH_enter_bootloader_t {
-    /**
-     * Dummy signal in empty message.
-     */
-    uint8_t dummy;
-};
-
-/**
- * Pack message SwitchChannelSet.
+ * Pack message Set_Switch_Channel.
  *
  * @param[out] dst_p Buffer to pack the message into.
  * @param[in] src_p Data to pack.
@@ -750,13 +830,13 @@ struct PDH_enter_bootloader_t {
  *
  * @return Size of packed data, or negative error code.
  */
-int PDH_switch_channel_set_pack(
+int PDH_set_switch_channel_pack(
     uint8_t *dst_p,
-    const struct PDH_switch_channel_set_t *src_p,
+    const struct PDH_set_switch_channel_t *src_p,
     size_t size);
 
 /**
- * Unpack message SwitchChannelSet.
+ * Unpack message Set_Switch_Channel.
  *
  * @param[out] dst_p Object to unpack the message into.
  * @param[in] src_p Message to unpack.
@@ -764,8 +844,8 @@ int PDH_switch_channel_set_pack(
  *
  * @return zero(0) or negative error code.
  */
-int PDH_switch_channel_set_unpack(
-    struct PDH_switch_channel_set_t *dst_p,
+int PDH_set_switch_channel_unpack(
+    struct PDH_set_switch_channel_t *dst_p,
     const uint8_t *src_p,
     size_t size);
 
@@ -776,7 +856,7 @@ int PDH_switch_channel_set_unpack(
  *
  * @return Encoded signal.
  */
-uint8_t PDH_switch_channel_set_output_set_value_encode(double value);
+uint8_t PDH_set_switch_channel_output_set_value_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -785,7 +865,7 @@ uint8_t PDH_switch_channel_set_output_set_value_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_switch_channel_set_output_set_value_decode(uint8_t value);
+double PDH_set_switch_channel_output_set_value_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -794,37 +874,10 @@ double PDH_switch_channel_set_output_set_value_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_switch_channel_set_output_set_value_is_in_range(uint8_t value);
+bool PDH_set_switch_channel_output_set_value_is_in_range(uint8_t value);
 
 /**
- * Encode given signal by applying scaling and offset.
- *
- * @param[in] value Signal to encode.
- *
- * @return Encoded signal.
- */
-uint8_t PDH_switch_channel_set_use_system_enable_encode(double value);
-
-/**
- * Decode given signal by applying scaling and offset.
- *
- * @param[in] value Signal to decode.
- *
- * @return Decoded signal.
- */
-double PDH_switch_channel_set_use_system_enable_decode(uint8_t value);
-
-/**
- * Check that given signal is in allowed range.
- *
- * @param[in] value Signal to check.
- *
- * @return true if in range, false otherwise.
- */
-bool PDH_switch_channel_set_use_system_enable_is_in_range(uint8_t value);
-
-/**
- * Pack message Status0.
+ * Pack message Status_0.
  *
  * @param[out] dst_p Buffer to pack the message into.
  * @param[in] src_p Data to pack.
@@ -832,13 +885,13 @@ bool PDH_switch_channel_set_use_system_enable_is_in_range(uint8_t value);
  *
  * @return Size of packed data, or negative error code.
  */
-int PDH_status0_pack(
+int PDH_status_0_pack(
     uint8_t *dst_p,
-    const struct PDH_status0_t *src_p,
+    const struct PDH_status_0_t *src_p,
     size_t size);
 
 /**
- * Unpack message Status0.
+ * Unpack message Status_0.
  *
  * @param[out] dst_p Object to unpack the message into.
  * @param[in] src_p Message to unpack.
@@ -846,8 +899,8 @@ int PDH_status0_pack(
  *
  * @return zero(0) or negative error code.
  */
-int PDH_status0_unpack(
-    struct PDH_status0_t *dst_p,
+int PDH_status_0_unpack(
+    struct PDH_status_0_t *dst_p,
     const uint8_t *src_p,
     size_t size);
 
@@ -858,7 +911,7 @@ int PDH_status0_unpack(
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status0_channel_0_current_encode(double value);
+uint16_t PDH_status_0_channel_0_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -867,7 +920,7 @@ uint16_t PDH_status0_channel_0_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status0_channel_0_current_decode(uint16_t value);
+double PDH_status_0_channel_0_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -876,7 +929,7 @@ double PDH_status0_channel_0_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status0_channel_0_current_is_in_range(uint16_t value);
+bool PDH_status_0_channel_0_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -885,7 +938,7 @@ bool PDH_status0_channel_0_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status0_channel_1_current_encode(double value);
+uint16_t PDH_status_0_channel_1_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -894,7 +947,7 @@ uint16_t PDH_status0_channel_1_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status0_channel_1_current_decode(uint16_t value);
+double PDH_status_0_channel_1_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -903,7 +956,7 @@ double PDH_status0_channel_1_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status0_channel_1_current_is_in_range(uint16_t value);
+bool PDH_status_0_channel_1_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -912,7 +965,7 @@ bool PDH_status0_channel_1_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status0_channel_2_current_encode(double value);
+uint16_t PDH_status_0_channel_2_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -921,7 +974,7 @@ uint16_t PDH_status0_channel_2_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status0_channel_2_current_decode(uint16_t value);
+double PDH_status_0_channel_2_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -930,7 +983,7 @@ double PDH_status0_channel_2_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status0_channel_2_current_is_in_range(uint16_t value);
+bool PDH_status_0_channel_2_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -939,7 +992,7 @@ bool PDH_status0_channel_2_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status0_channel_0_brownout_encode(double value);
+uint8_t PDH_status_0_channel_0_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -948,7 +1001,7 @@ uint8_t PDH_status0_channel_0_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status0_channel_0_brownout_decode(uint8_t value);
+double PDH_status_0_channel_0_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -957,7 +1010,7 @@ double PDH_status0_channel_0_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status0_channel_0_brownout_is_in_range(uint8_t value);
+bool PDH_status_0_channel_0_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -966,7 +1019,7 @@ bool PDH_status0_channel_0_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status0_channel_1_brownout_encode(double value);
+uint8_t PDH_status_0_channel_1_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -975,7 +1028,7 @@ uint8_t PDH_status0_channel_1_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status0_channel_1_brownout_decode(uint8_t value);
+double PDH_status_0_channel_1_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -984,7 +1037,7 @@ double PDH_status0_channel_1_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status0_channel_1_brownout_is_in_range(uint8_t value);
+bool PDH_status_0_channel_1_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -993,7 +1046,7 @@ bool PDH_status0_channel_1_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status0_channel_3_current_encode(double value);
+uint16_t PDH_status_0_channel_3_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1002,7 +1055,7 @@ uint16_t PDH_status0_channel_3_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status0_channel_3_current_decode(uint16_t value);
+double PDH_status_0_channel_3_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1011,7 +1064,7 @@ double PDH_status0_channel_3_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status0_channel_3_current_is_in_range(uint16_t value);
+bool PDH_status_0_channel_3_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1020,7 +1073,7 @@ bool PDH_status0_channel_3_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status0_channel_4_current_encode(double value);
+uint16_t PDH_status_0_channel_4_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1029,7 +1082,7 @@ uint16_t PDH_status0_channel_4_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status0_channel_4_current_decode(uint16_t value);
+double PDH_status_0_channel_4_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1038,7 +1091,7 @@ double PDH_status0_channel_4_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status0_channel_4_current_is_in_range(uint16_t value);
+bool PDH_status_0_channel_4_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1047,7 +1100,7 @@ bool PDH_status0_channel_4_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status0_channel_5_current_encode(double value);
+uint16_t PDH_status_0_channel_5_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1056,7 +1109,7 @@ uint16_t PDH_status0_channel_5_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status0_channel_5_current_decode(uint16_t value);
+double PDH_status_0_channel_5_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1065,7 +1118,7 @@ double PDH_status0_channel_5_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status0_channel_5_current_is_in_range(uint16_t value);
+bool PDH_status_0_channel_5_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1074,7 +1127,7 @@ bool PDH_status0_channel_5_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status0_channel_2_brownout_encode(double value);
+uint8_t PDH_status_0_channel_2_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1083,7 +1136,7 @@ uint8_t PDH_status0_channel_2_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status0_channel_2_brownout_decode(uint8_t value);
+double PDH_status_0_channel_2_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1092,7 +1145,7 @@ double PDH_status0_channel_2_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status0_channel_2_brownout_is_in_range(uint8_t value);
+bool PDH_status_0_channel_2_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1101,7 +1154,7 @@ bool PDH_status0_channel_2_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status0_channel_3_brownout_encode(double value);
+uint8_t PDH_status_0_channel_3_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1110,7 +1163,7 @@ uint8_t PDH_status0_channel_3_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status0_channel_3_brownout_decode(uint8_t value);
+double PDH_status_0_channel_3_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1119,10 +1172,10 @@ double PDH_status0_channel_3_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status0_channel_3_brownout_is_in_range(uint8_t value);
+bool PDH_status_0_channel_3_breaker_fault_is_in_range(uint8_t value);
 
 /**
- * Pack message Status1.
+ * Pack message Status_1.
  *
  * @param[out] dst_p Buffer to pack the message into.
  * @param[in] src_p Data to pack.
@@ -1130,13 +1183,13 @@ bool PDH_status0_channel_3_brownout_is_in_range(uint8_t value);
  *
  * @return Size of packed data, or negative error code.
  */
-int PDH_status1_pack(
+int PDH_status_1_pack(
     uint8_t *dst_p,
-    const struct PDH_status1_t *src_p,
+    const struct PDH_status_1_t *src_p,
     size_t size);
 
 /**
- * Unpack message Status1.
+ * Unpack message Status_1.
  *
  * @param[out] dst_p Object to unpack the message into.
  * @param[in] src_p Message to unpack.
@@ -1144,8 +1197,8 @@ int PDH_status1_pack(
  *
  * @return zero(0) or negative error code.
  */
-int PDH_status1_unpack(
-    struct PDH_status1_t *dst_p,
+int PDH_status_1_unpack(
+    struct PDH_status_1_t *dst_p,
     const uint8_t *src_p,
     size_t size);
 
@@ -1156,7 +1209,7 @@ int PDH_status1_unpack(
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status1_channel_6_current_encode(double value);
+uint16_t PDH_status_1_channel_6_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1165,7 +1218,7 @@ uint16_t PDH_status1_channel_6_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status1_channel_6_current_decode(uint16_t value);
+double PDH_status_1_channel_6_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1174,7 +1227,7 @@ double PDH_status1_channel_6_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status1_channel_6_current_is_in_range(uint16_t value);
+bool PDH_status_1_channel_6_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1183,7 +1236,7 @@ bool PDH_status1_channel_6_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status1_channel_7_current_encode(double value);
+uint16_t PDH_status_1_channel_7_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1192,7 +1245,7 @@ uint16_t PDH_status1_channel_7_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status1_channel_7_current_decode(uint16_t value);
+double PDH_status_1_channel_7_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1201,7 +1254,7 @@ double PDH_status1_channel_7_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status1_channel_7_current_is_in_range(uint16_t value);
+bool PDH_status_1_channel_7_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1210,7 +1263,7 @@ bool PDH_status1_channel_7_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status1_channel_8_current_encode(double value);
+uint16_t PDH_status_1_channel_8_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1219,7 +1272,7 @@ uint16_t PDH_status1_channel_8_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status1_channel_8_current_decode(uint16_t value);
+double PDH_status_1_channel_8_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1228,7 +1281,7 @@ double PDH_status1_channel_8_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status1_channel_8_current_is_in_range(uint16_t value);
+bool PDH_status_1_channel_8_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1237,7 +1290,7 @@ bool PDH_status1_channel_8_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status1_channel_4_brownout_encode(double value);
+uint8_t PDH_status_1_channel_4_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1246,7 +1299,7 @@ uint8_t PDH_status1_channel_4_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status1_channel_4_brownout_decode(uint8_t value);
+double PDH_status_1_channel_4_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1255,7 +1308,7 @@ double PDH_status1_channel_4_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status1_channel_4_brownout_is_in_range(uint8_t value);
+bool PDH_status_1_channel_4_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1264,7 +1317,7 @@ bool PDH_status1_channel_4_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status1_channel_5_brownout_encode(double value);
+uint8_t PDH_status_1_channel_5_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1273,7 +1326,7 @@ uint8_t PDH_status1_channel_5_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status1_channel_5_brownout_decode(uint8_t value);
+double PDH_status_1_channel_5_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1282,7 +1335,7 @@ double PDH_status1_channel_5_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status1_channel_5_brownout_is_in_range(uint8_t value);
+bool PDH_status_1_channel_5_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1291,7 +1344,7 @@ bool PDH_status1_channel_5_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status1_channel_9_current_encode(double value);
+uint16_t PDH_status_1_channel_9_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1300,7 +1353,7 @@ uint16_t PDH_status1_channel_9_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status1_channel_9_current_decode(uint16_t value);
+double PDH_status_1_channel_9_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1309,7 +1362,7 @@ double PDH_status1_channel_9_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status1_channel_9_current_is_in_range(uint16_t value);
+bool PDH_status_1_channel_9_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1318,7 +1371,7 @@ bool PDH_status1_channel_9_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status1_channel_10_current_encode(double value);
+uint16_t PDH_status_1_channel_10_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1327,7 +1380,7 @@ uint16_t PDH_status1_channel_10_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status1_channel_10_current_decode(uint16_t value);
+double PDH_status_1_channel_10_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1336,7 +1389,7 @@ double PDH_status1_channel_10_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status1_channel_10_current_is_in_range(uint16_t value);
+bool PDH_status_1_channel_10_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1345,7 +1398,7 @@ bool PDH_status1_channel_10_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status1_channel_11_current_encode(double value);
+uint16_t PDH_status_1_channel_11_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1354,7 +1407,7 @@ uint16_t PDH_status1_channel_11_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status1_channel_11_current_decode(uint16_t value);
+double PDH_status_1_channel_11_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1363,7 +1416,7 @@ double PDH_status1_channel_11_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status1_channel_11_current_is_in_range(uint16_t value);
+bool PDH_status_1_channel_11_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1372,7 +1425,7 @@ bool PDH_status1_channel_11_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status1_channel_6_brownout_encode(double value);
+uint8_t PDH_status_1_channel_6_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1381,7 +1434,7 @@ uint8_t PDH_status1_channel_6_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status1_channel_6_brownout_decode(uint8_t value);
+double PDH_status_1_channel_6_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1390,7 +1443,7 @@ double PDH_status1_channel_6_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status1_channel_6_brownout_is_in_range(uint8_t value);
+bool PDH_status_1_channel_6_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1399,7 +1452,7 @@ bool PDH_status1_channel_6_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status1_channel_7_brownout_encode(double value);
+uint8_t PDH_status_1_channel_7_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1408,7 +1461,7 @@ uint8_t PDH_status1_channel_7_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status1_channel_7_brownout_decode(uint8_t value);
+double PDH_status_1_channel_7_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1417,10 +1470,10 @@ double PDH_status1_channel_7_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status1_channel_7_brownout_is_in_range(uint8_t value);
+bool PDH_status_1_channel_7_breaker_fault_is_in_range(uint8_t value);
 
 /**
- * Pack message Status2.
+ * Pack message Status_2.
  *
  * @param[out] dst_p Buffer to pack the message into.
  * @param[in] src_p Data to pack.
@@ -1428,13 +1481,13 @@ bool PDH_status1_channel_7_brownout_is_in_range(uint8_t value);
  *
  * @return Size of packed data, or negative error code.
  */
-int PDH_status2_pack(
+int PDH_status_2_pack(
     uint8_t *dst_p,
-    const struct PDH_status2_t *src_p,
+    const struct PDH_status_2_t *src_p,
     size_t size);
 
 /**
- * Unpack message Status2.
+ * Unpack message Status_2.
  *
  * @param[out] dst_p Object to unpack the message into.
  * @param[in] src_p Message to unpack.
@@ -1442,8 +1495,8 @@ int PDH_status2_pack(
  *
  * @return zero(0) or negative error code.
  */
-int PDH_status2_unpack(
-    struct PDH_status2_t *dst_p,
+int PDH_status_2_unpack(
+    struct PDH_status_2_t *dst_p,
     const uint8_t *src_p,
     size_t size);
 
@@ -1454,7 +1507,7 @@ int PDH_status2_unpack(
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status2_channel_12_current_encode(double value);
+uint16_t PDH_status_2_channel_12_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1463,7 +1516,7 @@ uint16_t PDH_status2_channel_12_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status2_channel_12_current_decode(uint16_t value);
+double PDH_status_2_channel_12_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1472,7 +1525,7 @@ double PDH_status2_channel_12_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status2_channel_12_current_is_in_range(uint16_t value);
+bool PDH_status_2_channel_12_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1481,7 +1534,7 @@ bool PDH_status2_channel_12_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status2_channel_13_current_encode(double value);
+uint16_t PDH_status_2_channel_13_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1490,7 +1543,7 @@ uint16_t PDH_status2_channel_13_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status2_channel_13_current_decode(uint16_t value);
+double PDH_status_2_channel_13_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1499,7 +1552,7 @@ double PDH_status2_channel_13_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status2_channel_13_current_is_in_range(uint16_t value);
+bool PDH_status_2_channel_13_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1508,7 +1561,7 @@ bool PDH_status2_channel_13_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status2_channel_14_current_encode(double value);
+uint16_t PDH_status_2_channel_14_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1517,7 +1570,7 @@ uint16_t PDH_status2_channel_14_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status2_channel_14_current_decode(uint16_t value);
+double PDH_status_2_channel_14_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1526,7 +1579,7 @@ double PDH_status2_channel_14_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status2_channel_14_current_is_in_range(uint16_t value);
+bool PDH_status_2_channel_14_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1535,7 +1588,7 @@ bool PDH_status2_channel_14_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status2_channel_8_brownout_encode(double value);
+uint8_t PDH_status_2_channel_8_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1544,7 +1597,7 @@ uint8_t PDH_status2_channel_8_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status2_channel_8_brownout_decode(uint8_t value);
+double PDH_status_2_channel_8_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1553,7 +1606,7 @@ double PDH_status2_channel_8_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status2_channel_8_brownout_is_in_range(uint8_t value);
+bool PDH_status_2_channel_8_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1562,7 +1615,7 @@ bool PDH_status2_channel_8_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status2_channel_9_brownout_encode(double value);
+uint8_t PDH_status_2_channel_9_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1571,7 +1624,7 @@ uint8_t PDH_status2_channel_9_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status2_channel_9_brownout_decode(uint8_t value);
+double PDH_status_2_channel_9_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1580,7 +1633,7 @@ double PDH_status2_channel_9_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status2_channel_9_brownout_is_in_range(uint8_t value);
+bool PDH_status_2_channel_9_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1589,7 +1642,7 @@ bool PDH_status2_channel_9_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status2_channel_15_current_encode(double value);
+uint16_t PDH_status_2_channel_15_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1598,7 +1651,7 @@ uint16_t PDH_status2_channel_15_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status2_channel_15_current_decode(uint16_t value);
+double PDH_status_2_channel_15_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1607,7 +1660,7 @@ double PDH_status2_channel_15_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status2_channel_15_current_is_in_range(uint16_t value);
+bool PDH_status_2_channel_15_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1616,7 +1669,7 @@ bool PDH_status2_channel_15_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status2_channel_16_current_encode(double value);
+uint16_t PDH_status_2_channel_16_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1625,7 +1678,7 @@ uint16_t PDH_status2_channel_16_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status2_channel_16_current_decode(uint16_t value);
+double PDH_status_2_channel_16_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1634,7 +1687,7 @@ double PDH_status2_channel_16_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status2_channel_16_current_is_in_range(uint16_t value);
+bool PDH_status_2_channel_16_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1643,7 +1696,7 @@ bool PDH_status2_channel_16_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status2_channel_17_current_encode(double value);
+uint16_t PDH_status_2_channel_17_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1652,7 +1705,7 @@ uint16_t PDH_status2_channel_17_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status2_channel_17_current_decode(uint16_t value);
+double PDH_status_2_channel_17_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1661,7 +1714,7 @@ double PDH_status2_channel_17_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status2_channel_17_current_is_in_range(uint16_t value);
+bool PDH_status_2_channel_17_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1670,7 +1723,7 @@ bool PDH_status2_channel_17_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status2_channel_10_brownout_encode(double value);
+uint8_t PDH_status_2_channel_10_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1679,7 +1732,7 @@ uint8_t PDH_status2_channel_10_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status2_channel_10_brownout_decode(uint8_t value);
+double PDH_status_2_channel_10_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1688,7 +1741,7 @@ double PDH_status2_channel_10_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status2_channel_10_brownout_is_in_range(uint8_t value);
+bool PDH_status_2_channel_10_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1697,7 +1750,7 @@ bool PDH_status2_channel_10_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status2_channel_11_brownout_encode(double value);
+uint8_t PDH_status_2_channel_11_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1706,7 +1759,7 @@ uint8_t PDH_status2_channel_11_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status2_channel_11_brownout_decode(uint8_t value);
+double PDH_status_2_channel_11_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1715,10 +1768,10 @@ double PDH_status2_channel_11_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status2_channel_11_brownout_is_in_range(uint8_t value);
+bool PDH_status_2_channel_11_breaker_fault_is_in_range(uint8_t value);
 
 /**
- * Pack message Status3.
+ * Pack message Status_3.
  *
  * @param[out] dst_p Buffer to pack the message into.
  * @param[in] src_p Data to pack.
@@ -1726,13 +1779,13 @@ bool PDH_status2_channel_11_brownout_is_in_range(uint8_t value);
  *
  * @return Size of packed data, or negative error code.
  */
-int PDH_status3_pack(
+int PDH_status_3_pack(
     uint8_t *dst_p,
-    const struct PDH_status3_t *src_p,
+    const struct PDH_status_3_t *src_p,
     size_t size);
 
 /**
- * Unpack message Status3.
+ * Unpack message Status_3.
  *
  * @param[out] dst_p Object to unpack the message into.
  * @param[in] src_p Message to unpack.
@@ -1740,8 +1793,8 @@ int PDH_status3_pack(
  *
  * @return zero(0) or negative error code.
  */
-int PDH_status3_unpack(
-    struct PDH_status3_t *dst_p,
+int PDH_status_3_unpack(
+    struct PDH_status_3_t *dst_p,
     const uint8_t *src_p,
     size_t size);
 
@@ -1752,7 +1805,7 @@ int PDH_status3_unpack(
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status3_channel_18_current_encode(double value);
+uint16_t PDH_status_3_channel_18_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1761,7 +1814,7 @@ uint16_t PDH_status3_channel_18_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_18_current_decode(uint16_t value);
+double PDH_status_3_channel_18_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1770,7 +1823,7 @@ double PDH_status3_channel_18_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_18_current_is_in_range(uint16_t value);
+bool PDH_status_3_channel_18_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1779,7 +1832,7 @@ bool PDH_status3_channel_18_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status3_channel_19_current_encode(double value);
+uint16_t PDH_status_3_channel_19_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1788,7 +1841,7 @@ uint16_t PDH_status3_channel_19_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_19_current_decode(uint16_t value);
+double PDH_status_3_channel_19_current_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1797,7 +1850,7 @@ double PDH_status3_channel_19_current_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_19_current_is_in_range(uint16_t value);
+bool PDH_status_3_channel_19_current_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1806,7 +1859,7 @@ bool PDH_status3_channel_19_current_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_12_brownout_encode(double value);
+uint8_t PDH_status_3_channel_12_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1815,7 +1868,7 @@ uint8_t PDH_status3_channel_12_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_12_brownout_decode(uint8_t value);
+double PDH_status_3_channel_12_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1824,7 +1877,7 @@ double PDH_status3_channel_12_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_12_brownout_is_in_range(uint8_t value);
+bool PDH_status_3_channel_12_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1833,7 +1886,7 @@ bool PDH_status3_channel_12_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_13_brownout_encode(double value);
+uint8_t PDH_status_3_channel_13_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1842,7 +1895,7 @@ uint8_t PDH_status3_channel_13_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_13_brownout_decode(uint8_t value);
+double PDH_status_3_channel_13_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1851,7 +1904,7 @@ double PDH_status3_channel_13_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_13_brownout_is_in_range(uint8_t value);
+bool PDH_status_3_channel_13_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1860,7 +1913,7 @@ bool PDH_status3_channel_13_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_14_brownout_encode(double value);
+uint8_t PDH_status_3_channel_14_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1869,7 +1922,7 @@ uint8_t PDH_status3_channel_14_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_14_brownout_decode(uint8_t value);
+double PDH_status_3_channel_14_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1878,7 +1931,7 @@ double PDH_status3_channel_14_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_14_brownout_is_in_range(uint8_t value);
+bool PDH_status_3_channel_14_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1887,7 +1940,7 @@ bool PDH_status3_channel_14_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_15_brownout_encode(double value);
+uint8_t PDH_status_3_channel_15_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1896,7 +1949,7 @@ uint8_t PDH_status3_channel_15_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_15_brownout_decode(uint8_t value);
+double PDH_status_3_channel_15_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1905,7 +1958,7 @@ double PDH_status3_channel_15_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_15_brownout_is_in_range(uint8_t value);
+bool PDH_status_3_channel_15_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1914,7 +1967,7 @@ bool PDH_status3_channel_15_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_20_current_encode(double value);
+uint8_t PDH_status_3_channel_20_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1923,7 +1976,7 @@ uint8_t PDH_status3_channel_20_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_20_current_decode(uint8_t value);
+double PDH_status_3_channel_20_current_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1932,7 +1985,7 @@ double PDH_status3_channel_20_current_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_20_current_is_in_range(uint8_t value);
+bool PDH_status_3_channel_20_current_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1941,7 +1994,7 @@ bool PDH_status3_channel_20_current_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_21_current_encode(double value);
+uint8_t PDH_status_3_channel_21_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1950,7 +2003,7 @@ uint8_t PDH_status3_channel_21_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_21_current_decode(uint8_t value);
+double PDH_status_3_channel_21_current_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1959,7 +2012,7 @@ double PDH_status3_channel_21_current_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_21_current_is_in_range(uint8_t value);
+bool PDH_status_3_channel_21_current_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1968,7 +2021,7 @@ bool PDH_status3_channel_21_current_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_22_current_encode(double value);
+uint8_t PDH_status_3_channel_22_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -1977,7 +2030,7 @@ uint8_t PDH_status3_channel_22_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_22_current_decode(uint8_t value);
+double PDH_status_3_channel_22_current_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -1986,7 +2039,7 @@ double PDH_status3_channel_22_current_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_22_current_is_in_range(uint8_t value);
+bool PDH_status_3_channel_22_current_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -1995,7 +2048,7 @@ bool PDH_status3_channel_22_current_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_23_current_encode(double value);
+uint8_t PDH_status_3_channel_23_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2004,7 +2057,7 @@ uint8_t PDH_status3_channel_23_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_23_current_decode(uint8_t value);
+double PDH_status_3_channel_23_current_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2013,7 +2066,7 @@ double PDH_status3_channel_23_current_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_23_current_is_in_range(uint8_t value);
+bool PDH_status_3_channel_23_current_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2022,7 +2075,7 @@ bool PDH_status3_channel_23_current_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_16_brownout_encode(double value);
+uint8_t PDH_status_3_channel_16_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2031,7 +2084,7 @@ uint8_t PDH_status3_channel_16_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_16_brownout_decode(uint8_t value);
+double PDH_status_3_channel_16_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2040,7 +2093,7 @@ double PDH_status3_channel_16_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_16_brownout_is_in_range(uint8_t value);
+bool PDH_status_3_channel_16_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2049,7 +2102,7 @@ bool PDH_status3_channel_16_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_17_brownout_encode(double value);
+uint8_t PDH_status_3_channel_17_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2058,7 +2111,7 @@ uint8_t PDH_status3_channel_17_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_17_brownout_decode(uint8_t value);
+double PDH_status_3_channel_17_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2067,7 +2120,7 @@ double PDH_status3_channel_17_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_17_brownout_is_in_range(uint8_t value);
+bool PDH_status_3_channel_17_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2076,7 +2129,7 @@ bool PDH_status3_channel_17_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_18_brownout_encode(double value);
+uint8_t PDH_status_3_channel_18_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2085,7 +2138,7 @@ uint8_t PDH_status3_channel_18_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_18_brownout_decode(uint8_t value);
+double PDH_status_3_channel_18_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2094,7 +2147,7 @@ double PDH_status3_channel_18_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_18_brownout_is_in_range(uint8_t value);
+bool PDH_status_3_channel_18_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2103,7 +2156,7 @@ bool PDH_status3_channel_18_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_19_brownout_encode(double value);
+uint8_t PDH_status_3_channel_19_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2112,7 +2165,7 @@ uint8_t PDH_status3_channel_19_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_19_brownout_decode(uint8_t value);
+double PDH_status_3_channel_19_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2121,7 +2174,7 @@ double PDH_status3_channel_19_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_19_brownout_is_in_range(uint8_t value);
+bool PDH_status_3_channel_19_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2130,7 +2183,7 @@ bool PDH_status3_channel_19_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_20_brownout_encode(double value);
+uint8_t PDH_status_3_channel_20_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2139,7 +2192,7 @@ uint8_t PDH_status3_channel_20_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_20_brownout_decode(uint8_t value);
+double PDH_status_3_channel_20_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2148,7 +2201,7 @@ double PDH_status3_channel_20_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_20_brownout_is_in_range(uint8_t value);
+bool PDH_status_3_channel_20_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2157,7 +2210,7 @@ bool PDH_status3_channel_20_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_21_brownout_encode(double value);
+uint8_t PDH_status_3_channel_21_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2166,7 +2219,7 @@ uint8_t PDH_status3_channel_21_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_21_brownout_decode(uint8_t value);
+double PDH_status_3_channel_21_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2175,7 +2228,7 @@ double PDH_status3_channel_21_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_21_brownout_is_in_range(uint8_t value);
+bool PDH_status_3_channel_21_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2184,7 +2237,7 @@ bool PDH_status3_channel_21_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_22_brownout_encode(double value);
+uint8_t PDH_status_3_channel_22_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2193,7 +2246,7 @@ uint8_t PDH_status3_channel_22_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_22_brownout_decode(uint8_t value);
+double PDH_status_3_channel_22_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2202,7 +2255,7 @@ double PDH_status3_channel_22_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_22_brownout_is_in_range(uint8_t value);
+bool PDH_status_3_channel_22_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2211,7 +2264,7 @@ bool PDH_status3_channel_22_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status3_channel_23_brownout_encode(double value);
+uint8_t PDH_status_3_channel_23_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2220,7 +2273,7 @@ uint8_t PDH_status3_channel_23_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status3_channel_23_brownout_decode(uint8_t value);
+double PDH_status_3_channel_23_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2229,10 +2282,10 @@ double PDH_status3_channel_23_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status3_channel_23_brownout_is_in_range(uint8_t value);
+bool PDH_status_3_channel_23_breaker_fault_is_in_range(uint8_t value);
 
 /**
- * Pack message Status4.
+ * Pack message Status_4.
  *
  * @param[out] dst_p Buffer to pack the message into.
  * @param[in] src_p Data to pack.
@@ -2240,13 +2293,13 @@ bool PDH_status3_channel_23_brownout_is_in_range(uint8_t value);
  *
  * @return Size of packed data, or negative error code.
  */
-int PDH_status4_pack(
+int PDH_status_4_pack(
     uint8_t *dst_p,
-    const struct PDH_status4_t *src_p,
+    const struct PDH_status_4_t *src_p,
     size_t size);
 
 /**
- * Unpack message Status4.
+ * Unpack message Status_4.
  *
  * @param[out] dst_p Object to unpack the message into.
  * @param[in] src_p Message to unpack.
@@ -2254,8 +2307,8 @@ int PDH_status4_pack(
  *
  * @return zero(0) or negative error code.
  */
-int PDH_status4_unpack(
-    struct PDH_status4_t *dst_p,
+int PDH_status_4_unpack(
+    struct PDH_status_4_t *dst_p,
     const uint8_t *src_p,
     size_t size);
 
@@ -2266,7 +2319,7 @@ int PDH_status4_unpack(
  *
  * @return Encoded signal.
  */
-uint16_t PDH_status4_v_bus_encode(double value);
+uint16_t PDH_status_4_v_bus_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2275,7 +2328,7 @@ uint16_t PDH_status4_v_bus_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_v_bus_decode(uint16_t value);
+double PDH_status_4_v_bus_decode(uint16_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2284,7 +2337,7 @@ double PDH_status4_v_bus_decode(uint16_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_v_bus_is_in_range(uint16_t value);
+bool PDH_status_4_v_bus_is_in_range(uint16_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2293,7 +2346,7 @@ bool PDH_status4_v_bus_is_in_range(uint16_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_system_enable_encode(double value);
+uint8_t PDH_status_4_system_enable_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2302,7 +2355,7 @@ uint8_t PDH_status4_system_enable_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_system_enable_decode(uint8_t value);
+double PDH_status_4_system_enable_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2311,7 +2364,7 @@ double PDH_status4_system_enable_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_system_enable_is_in_range(uint8_t value);
+bool PDH_status_4_system_enable_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2320,7 +2373,7 @@ bool PDH_status4_system_enable_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_rsvd0_encode(double value);
+uint8_t PDH_status_4_rsvd0_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2329,7 +2382,7 @@ uint8_t PDH_status4_rsvd0_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_rsvd0_decode(uint8_t value);
+double PDH_status_4_rsvd0_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2338,7 +2391,7 @@ double PDH_status4_rsvd0_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_rsvd0_is_in_range(uint8_t value);
+bool PDH_status_4_rsvd0_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2347,7 +2400,7 @@ bool PDH_status4_rsvd0_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_brownout_encode(double value);
+uint8_t PDH_status_4_brownout_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2356,7 +2409,7 @@ uint8_t PDH_status4_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_brownout_decode(uint8_t value);
+double PDH_status_4_brownout_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2365,7 +2418,7 @@ double PDH_status4_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_brownout_is_in_range(uint8_t value);
+bool PDH_status_4_brownout_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2374,7 +2427,7 @@ bool PDH_status4_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_rsvd1_encode(double value);
+uint8_t PDH_status_4_rsvd1_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2383,7 +2436,7 @@ uint8_t PDH_status4_rsvd1_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_rsvd1_decode(uint8_t value);
+double PDH_status_4_rsvd1_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2392,7 +2445,7 @@ double PDH_status4_rsvd1_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_rsvd1_is_in_range(uint8_t value);
+bool PDH_status_4_rsvd1_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2401,7 +2454,7 @@ bool PDH_status4_rsvd1_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_can_warning_encode(double value);
+uint8_t PDH_status_4_can_warning_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2410,7 +2463,7 @@ uint8_t PDH_status4_can_warning_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_can_warning_decode(uint8_t value);
+double PDH_status_4_can_warning_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2419,7 +2472,7 @@ double PDH_status4_can_warning_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_can_warning_is_in_range(uint8_t value);
+bool PDH_status_4_can_warning_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2428,7 +2481,7 @@ bool PDH_status4_can_warning_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_hardware_fault_encode(double value);
+uint8_t PDH_status_4_hardware_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2437,7 +2490,7 @@ uint8_t PDH_status4_hardware_fault_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_hardware_fault_decode(uint8_t value);
+double PDH_status_4_hardware_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2446,7 +2499,7 @@ double PDH_status4_hardware_fault_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_hardware_fault_is_in_range(uint8_t value);
+bool PDH_status_4_hardware_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2455,7 +2508,7 @@ bool PDH_status4_hardware_fault_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_sw_state_encode(double value);
+uint8_t PDH_status_4_switch_channel_state_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2464,7 +2517,7 @@ uint8_t PDH_status4_sw_state_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_sw_state_decode(uint8_t value);
+double PDH_status_4_switch_channel_state_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2473,7 +2526,7 @@ double PDH_status4_sw_state_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_sw_state_is_in_range(uint8_t value);
+bool PDH_status_4_switch_channel_state_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2482,7 +2535,7 @@ bool PDH_status4_sw_state_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_sticky_brownout_encode(double value);
+uint8_t PDH_status_4_sticky_brownout_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2491,7 +2544,7 @@ uint8_t PDH_status4_sticky_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_sticky_brownout_decode(uint8_t value);
+double PDH_status_4_sticky_brownout_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2500,7 +2553,7 @@ double PDH_status4_sticky_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_sticky_brownout_is_in_range(uint8_t value);
+bool PDH_status_4_sticky_brownout_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2509,7 +2562,7 @@ bool PDH_status4_sticky_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_rsvd2_encode(double value);
+uint8_t PDH_status_4_rsvd2_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2518,7 +2571,7 @@ uint8_t PDH_status4_rsvd2_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_rsvd2_decode(uint8_t value);
+double PDH_status_4_rsvd2_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2527,7 +2580,7 @@ double PDH_status4_rsvd2_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_rsvd2_is_in_range(uint8_t value);
+bool PDH_status_4_rsvd2_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2536,7 +2589,7 @@ bool PDH_status4_rsvd2_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_sticky_can_warning_encode(double value);
+uint8_t PDH_status_4_sticky_can_warning_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2545,7 +2598,7 @@ uint8_t PDH_status4_sticky_can_warning_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_sticky_can_warning_decode(uint8_t value);
+double PDH_status_4_sticky_can_warning_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2554,7 +2607,7 @@ double PDH_status4_sticky_can_warning_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_sticky_can_warning_is_in_range(uint8_t value);
+bool PDH_status_4_sticky_can_warning_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2563,7 +2616,7 @@ bool PDH_status4_sticky_can_warning_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_sticky_can_bus_off_encode(double value);
+uint8_t PDH_status_4_sticky_can_bus_off_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2572,7 +2625,7 @@ uint8_t PDH_status4_sticky_can_bus_off_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_sticky_can_bus_off_decode(uint8_t value);
+double PDH_status_4_sticky_can_bus_off_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2581,7 +2634,7 @@ double PDH_status4_sticky_can_bus_off_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_sticky_can_bus_off_is_in_range(uint8_t value);
+bool PDH_status_4_sticky_can_bus_off_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2590,7 +2643,7 @@ bool PDH_status4_sticky_can_bus_off_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_sticky_hardware_fault_encode(double value);
+uint8_t PDH_status_4_sticky_hardware_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2599,7 +2652,7 @@ uint8_t PDH_status4_sticky_hardware_fault_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_sticky_hardware_fault_decode(uint8_t value);
+double PDH_status_4_sticky_hardware_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2608,7 +2661,7 @@ double PDH_status4_sticky_hardware_fault_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_sticky_hardware_fault_is_in_range(uint8_t value);
+bool PDH_status_4_sticky_hardware_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2617,7 +2670,7 @@ bool PDH_status4_sticky_hardware_fault_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_sticky_firmware_fault_encode(double value);
+uint8_t PDH_status_4_sticky_firmware_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2626,7 +2679,7 @@ uint8_t PDH_status4_sticky_firmware_fault_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_sticky_firmware_fault_decode(uint8_t value);
+double PDH_status_4_sticky_firmware_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2635,7 +2688,7 @@ double PDH_status4_sticky_firmware_fault_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_sticky_firmware_fault_is_in_range(uint8_t value);
+bool PDH_status_4_sticky_firmware_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2644,7 +2697,7 @@ bool PDH_status4_sticky_firmware_fault_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_sticky_ch20_brownout_encode(double value);
+uint8_t PDH_status_4_sticky_ch20_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2653,7 +2706,7 @@ uint8_t PDH_status4_sticky_ch20_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_sticky_ch20_brownout_decode(uint8_t value);
+double PDH_status_4_sticky_ch20_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2662,7 +2715,7 @@ double PDH_status4_sticky_ch20_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_sticky_ch20_brownout_is_in_range(uint8_t value);
+bool PDH_status_4_sticky_ch20_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2671,7 +2724,7 @@ bool PDH_status4_sticky_ch20_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_sticky_ch21_brownout_encode(double value);
+uint8_t PDH_status_4_sticky_ch21_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2680,7 +2733,7 @@ uint8_t PDH_status4_sticky_ch21_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_sticky_ch21_brownout_decode(uint8_t value);
+double PDH_status_4_sticky_ch21_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2689,7 +2742,7 @@ double PDH_status4_sticky_ch21_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_sticky_ch21_brownout_is_in_range(uint8_t value);
+bool PDH_status_4_sticky_ch21_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2698,7 +2751,7 @@ bool PDH_status4_sticky_ch21_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_sticky_ch22_brownout_encode(double value);
+uint8_t PDH_status_4_sticky_ch22_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2707,7 +2760,7 @@ uint8_t PDH_status4_sticky_ch22_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_sticky_ch22_brownout_decode(uint8_t value);
+double PDH_status_4_sticky_ch22_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2716,7 +2769,7 @@ double PDH_status4_sticky_ch22_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_sticky_ch22_brownout_is_in_range(uint8_t value);
+bool PDH_status_4_sticky_ch22_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2725,7 +2778,7 @@ bool PDH_status4_sticky_ch22_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_sticky_ch23_brownout_encode(double value);
+uint8_t PDH_status_4_sticky_ch23_breaker_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2734,7 +2787,7 @@ uint8_t PDH_status4_sticky_ch23_brownout_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_sticky_ch23_brownout_decode(uint8_t value);
+double PDH_status_4_sticky_ch23_breaker_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2743,7 +2796,7 @@ double PDH_status4_sticky_ch23_brownout_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_sticky_ch23_brownout_is_in_range(uint8_t value);
+bool PDH_status_4_sticky_ch23_breaker_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2752,7 +2805,7 @@ bool PDH_status4_sticky_ch23_brownout_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_sticky_has_reset_encode(double value);
+uint8_t PDH_status_4_sticky_has_reset_fault_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2761,7 +2814,7 @@ uint8_t PDH_status4_sticky_has_reset_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_sticky_has_reset_decode(uint8_t value);
+double PDH_status_4_sticky_has_reset_fault_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2770,7 +2823,7 @@ double PDH_status4_sticky_has_reset_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_sticky_has_reset_is_in_range(uint8_t value);
+bool PDH_status_4_sticky_has_reset_fault_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -2779,7 +2832,7 @@ bool PDH_status4_sticky_has_reset_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_status4_total_current_encode(double value);
+uint8_t PDH_status_4_total_current_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2788,7 +2841,7 @@ uint8_t PDH_status4_total_current_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_status4_total_current_decode(uint8_t value);
+double PDH_status_4_total_current_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2797,10 +2850,550 @@ double PDH_status4_total_current_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_status4_total_current_is_in_range(uint8_t value);
+bool PDH_status_4_total_current_is_in_range(uint8_t value);
 
 /**
- * Pack message ClearFaults.
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch0_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch0_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch0_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch1_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch1_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch1_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch2_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch2_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch2_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch3_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch3_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch3_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch4_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch4_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch4_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch5_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch5_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch5_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch6_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch6_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch6_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch7_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch7_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch7_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch8_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch8_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch8_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch9_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch9_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch9_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch10_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch10_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch10_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch11_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch11_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch11_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch12_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch12_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch12_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch13_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch13_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch13_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch14_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch14_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch14_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch15_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch15_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch15_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch16_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch16_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch16_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch17_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch17_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch17_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch18_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch18_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch18_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_status_4_sticky_ch19_breaker_fault_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_status_4_sticky_ch19_breaker_fault_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_status_4_sticky_ch19_breaker_fault_is_in_range(uint8_t value);
+
+/**
+ * Pack message Clear_Faults.
  *
  * @param[out] dst_p Buffer to pack the message into.
  * @param[in] src_p Data to pack.
@@ -2814,7 +3407,7 @@ int PDH_clear_faults_pack(
     size_t size);
 
 /**
- * Unpack message ClearFaults.
+ * Unpack message Clear_Faults.
  *
  * @param[out] dst_p Object to unpack the message into.
  * @param[in] src_p Message to unpack.
@@ -2824,34 +3417,6 @@ int PDH_clear_faults_pack(
  */
 int PDH_clear_faults_unpack(
     struct PDH_clear_faults_t *dst_p,
-    const uint8_t *src_p,
-    size_t size);
-
-/**
- * Pack message Identify.
- *
- * @param[out] dst_p Buffer to pack the message into.
- * @param[in] src_p Data to pack.
- * @param[in] size Size of dst_p.
- *
- * @return Size of packed data, or negative error code.
- */
-int PDH_identify_pack(
-    uint8_t *dst_p,
-    const struct PDH_identify_t *src_p,
-    size_t size);
-
-/**
- * Unpack message Identify.
- *
- * @param[out] dst_p Object to unpack the message into.
- * @param[in] src_p Message to unpack.
- * @param[in] size Size of src_p.
- *
- * @return zero(0) or negative error code.
- */
-int PDH_identify_unpack(
-    struct PDH_identify_t *dst_p,
     const uint8_t *src_p,
     size_t size);
 
@@ -2971,7 +3536,7 @@ bool PDH_version_firmware_year_is_in_range(uint8_t value);
  *
  * @return Encoded signal.
  */
-uint8_t PDH_version_hardware_code_encode(double value);
+uint8_t PDH_version_hardware_minor_encode(double value);
 
 /**
  * Decode given signal by applying scaling and offset.
@@ -2980,7 +3545,7 @@ uint8_t PDH_version_hardware_code_encode(double value);
  *
  * @return Decoded signal.
  */
-double PDH_version_hardware_code_decode(uint8_t value);
+double PDH_version_hardware_minor_decode(uint8_t value);
 
 /**
  * Check that given signal is in allowed range.
@@ -2989,7 +3554,34 @@ double PDH_version_hardware_code_decode(uint8_t value);
  *
  * @return true if in range, false otherwise.
  */
-bool PDH_version_hardware_code_is_in_range(uint8_t value);
+bool PDH_version_hardware_minor_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t PDH_version_hardware_major_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double PDH_version_hardware_major_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool PDH_version_hardware_major_is_in_range(uint8_t value);
 
 /**
  * Encode given signal by applying scaling and offset.
@@ -3017,116 +3609,6 @@ double PDH_version_unique_id_decode(uint32_t value);
  * @return true if in range, false otherwise.
  */
 bool PDH_version_unique_id_is_in_range(uint32_t value);
-
-/**
- * Pack message ConfigureHRChannel.
- *
- * @param[out] dst_p Buffer to pack the message into.
- * @param[in] src_p Data to pack.
- * @param[in] size Size of dst_p.
- *
- * @return Size of packed data, or negative error code.
- */
-int PDH_configure_hr_channel_pack(
-    uint8_t *dst_p,
-    const struct PDH_configure_hr_channel_t *src_p,
-    size_t size);
-
-/**
- * Unpack message ConfigureHRChannel.
- *
- * @param[out] dst_p Object to unpack the message into.
- * @param[in] src_p Message to unpack.
- * @param[in] size Size of src_p.
- *
- * @return zero(0) or negative error code.
- */
-int PDH_configure_hr_channel_unpack(
-    struct PDH_configure_hr_channel_t *dst_p,
-    const uint8_t *src_p,
-    size_t size);
-
-/**
- * Encode given signal by applying scaling and offset.
- *
- * @param[in] value Signal to encode.
- *
- * @return Encoded signal.
- */
-uint8_t PDH_configure_hr_channel_channel_encode(double value);
-
-/**
- * Decode given signal by applying scaling and offset.
- *
- * @param[in] value Signal to decode.
- *
- * @return Decoded signal.
- */
-double PDH_configure_hr_channel_channel_decode(uint8_t value);
-
-/**
- * Check that given signal is in allowed range.
- *
- * @param[in] value Signal to check.
- *
- * @return true if in range, false otherwise.
- */
-bool PDH_configure_hr_channel_channel_is_in_range(uint8_t value);
-
-/**
- * Encode given signal by applying scaling and offset.
- *
- * @param[in] value Signal to encode.
- *
- * @return Encoded signal.
- */
-uint16_t PDH_configure_hr_channel_period_encode(double value);
-
-/**
- * Decode given signal by applying scaling and offset.
- *
- * @param[in] value Signal to decode.
- *
- * @return Decoded signal.
- */
-double PDH_configure_hr_channel_period_decode(uint16_t value);
-
-/**
- * Check that given signal is in allowed range.
- *
- * @param[in] value Signal to check.
- *
- * @return true if in range, false otherwise.
- */
-bool PDH_configure_hr_channel_period_is_in_range(uint16_t value);
-
-/**
- * Pack message Enter_Bootloader.
- *
- * @param[out] dst_p Buffer to pack the message into.
- * @param[in] src_p Data to pack.
- * @param[in] size Size of dst_p.
- *
- * @return Size of packed data, or negative error code.
- */
-int PDH_enter_bootloader_pack(
-    uint8_t *dst_p,
-    const struct PDH_enter_bootloader_t *src_p,
-    size_t size);
-
-/**
- * Unpack message Enter_Bootloader.
- *
- * @param[out] dst_p Object to unpack the message into.
- * @param[in] src_p Message to unpack.
- * @param[in] size Size of src_p.
- *
- * @return zero(0) or negative error code.
- */
-int PDH_enter_bootloader_unpack(
-    struct PDH_enter_bootloader_t *dst_p,
-    const uint8_t *src_p,
-    size_t size);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Changes:
- Refactors retrieving the faults from the device to match the implementation that we have for the Pneumatic Hub. Instead of having a getter function for each fault, there is a single function to get all faults (sticky or normal) for use with the higher level API
- Renames functions to be consistent
- Removes some functions that don't need to be included in wpilib:
   - Identify device - this just flashes the module LED on the device and has no use in wpilib
   - Is PDH enabled - the PDH does not change state depending on robot enabled state
- PDH frame and signal names were updated in our DBC, and this PR makes use of the newly generated CAN frame helper functions