### PR TITLE
[wpilibc] Kick off DriverStation thread from RobotBase

### DIFF
--- a/wpilibc/src/main/native/cppcs/RobotBase.cpp
+++ b/wpilibc/src/main/native/cppcs/RobotBase.cpp
@@ -251,6 +251,9 @@ RobotBase::RobotBase() {
     }
   }
 
+  // Call DriverStation::InDisabled() to kick off DS thread
+  DriverStation::InDisabled(true);
+
   // First and one-time initialization
   inst.GetTable("LiveWindow")
       ->GetSubTable(".status")


### PR DESCRIPTION
With the change from GetInstance to static functions, many functions
don't call DriverStation::GetInstance(), so the DS thread wasn't
getting started by default.  Call InDisabled() to make sure this
happens.