### PR TITLE
[glass] Fix CollapsingHeader in Encoder, PCM, and DeviceTree

### DIFF
--- a/glass/src/lib/native/cpp/hardware/Encoder.cpp
+++ b/glass/src/lib/native/cpp/hardware/Encoder.cpp
@@ -70,17 +70,17 @@ void glass::DisplayEncoder(EncoderModel* model) {
   std::string& name = GetStorage().GetString("name");
   char label[128];
   if (!name.empty()) {
-    std::snprintf(label, sizeof(label), "%s [%d,%d]###name", name.c_str(), chA,
-                  chB);
+    std::snprintf(label, sizeof(label), "%s [%d,%d]###header", name.c_str(),
+                  chA, chB);
   } else {
-    std::snprintf(label, sizeof(label), "Encoder[%d,%d]###name", chA, chB);
+    std::snprintf(label, sizeof(label), "Encoder[%d,%d]###header", chA, chB);
   }
 
   // header
   bool open = CollapsingHeader(label);
 
   // context menu to change name
-  if (PopupEditName("name", &name)) {
+  if (PopupEditName("header", &name)) {
     model->SetName(name);
   }
 

--- a/glass/src/lib/native/cpp/hardware/PCM.cpp
+++ b/glass/src/lib/native/cpp/hardware/PCM.cpp
@@ -46,15 +46,16 @@ bool glass::DisplayPCMSolenoids(PCMModel* model, int index,
   std::string& name = GetStorage().GetString("name");
   char label[128];
   if (!name.empty()) {
-    std::snprintf(label, sizeof(label), "%s [%d]###name", name.c_str(), index);
+    std::snprintf(label, sizeof(label), "%s [%d]###header", name.c_str(),
+                  index);
   } else {
-    std::snprintf(label, sizeof(label), "PCM[%d]###name", index);
+    std::snprintf(label, sizeof(label), "PCM[%d]###header", index);
   }
 
   // header
   bool open = CollapsingHeader(label);
 
-  PopupEditName("name", &name);
+  PopupEditName("header", &name);
 
   ImGui::SetItemAllowOverlap();
   ImGui::SameLine();

--- a/glass/src/lib/native/cpp/other/DeviceTree.cpp
+++ b/glass/src/lib/native/cpp/other/DeviceTree.cpp
@@ -53,11 +53,11 @@ bool glass::BeginDevice(const char* id, ImGuiTreeNodeFlags flags) {
   // build label
   std::string& name = GetStorage().GetString("name");
   char label[128];
-  std::snprintf(label, sizeof(label), "%s###name",
+  std::snprintf(label, sizeof(label), "%s###header",
                 name.empty() ? id : name.c_str());
 
   bool open = CollapsingHeader(label, flags);
-  PopupEditName("name", &name);
+  PopupEditName("header", &name);
 
   if (!open) {
     PopID();


### PR DESCRIPTION
The new storage approach was attempting to save both the name and the
open status to the same storage key.

Fixes #3789.