### PR TITLE
Fix SwerveControllerCommand example code order of Module States

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/subsystems/DriveSubsystem.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/subsystems/DriveSubsystem.cpp
@@ -69,8 +69,8 @@ void DriveSubsystem::SetModuleStates(
   kDriveKinematics.NormalizeWheelSpeeds(&desiredStates,
                                         AutoConstants::kMaxSpeed);
   m_frontLeft.SetDesiredState(desiredStates[0]);
-  m_rearLeft.SetDesiredState(desiredStates[1]);
-  m_frontRight.SetDesiredState(desiredStates[2]);
+  m_frontRight.SetDesiredState(desiredStates[1]);
+  m_rearLeft.SetDesiredState(desiredStates[2]);
   m_rearRight.SetDesiredState(desiredStates[3]);
 }
 


### PR DESCRIPTION
DriveSubsystem::SetModulesStates applies module state to incorrect modules. Fixes issue https://github.com/wpilibsuite/allwpilib/issues/3814#issue-1086313694

