### PR TITLE
[wpigui] Upgrade to imgui 1.86, GLFW 3.3.6

### DIFF
--- a/imgui/CMakeLists.txt.in
+++ b/imgui/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(imgui-download NONE)
 include(ExternalProject)
 ExternalProject_Add(glfw3
   GIT_REPOSITORY    https://github.com/glfw/glfw.git
-  GIT_TAG           3.3.5
+  GIT_TAG           3.3.6
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/glfw-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/glfw-build"
   CONFIGURE_COMMAND ""
@@ -23,7 +23,7 @@ ExternalProject_Add(gl3w
 )
 ExternalProject_Add(imgui
   GIT_REPOSITORY    https://github.com/ocornut/imgui.git
-  GIT_TAG           v1.85
+  GIT_TAG           v1.86
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/imgui-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/imgui-build"
   CONFIGURE_COMMAND ""

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -13,7 +13,7 @@ nativeUtils {
             niLibVersion = "2022.2.3"
             opencvVersion = "4.5.2-1"
             googleTestVersion = "1.9.0-5-437e100-1"
-            imguiVersion = "1.85-2"
+            imguiVersion = "1.86-1"
             wpimathVersion = "-1"
         }
     }


### PR DESCRIPTION
The GLFW upgrade fixes joysticks not being mapped at startup.