### PR TITLE
[wpimath] Make copies of trajectory constraint arguments

### DIFF
--- a/wpimath/src/main/native/include/frc/trajectory/constraint/DifferentialDriveKinematicsConstraint.h
+++ b/wpimath/src/main/native/include/frc/trajectory/constraint/DifferentialDriveKinematicsConstraint.h
@@ -32,7 +32,7 @@ class WPILIB_DLLEXPORT DifferentialDriveKinematicsConstraint
                             units::meters_per_second_t speed) const override;
 
  private:
-  const DifferentialDriveKinematics& m_kinematics;
+  DifferentialDriveKinematics m_kinematics;
   units::meters_per_second_t m_maxSpeed;
 };
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h
+++ b/wpimath/src/main/native/include/frc/trajectory/constraint/DifferentialDriveVoltageConstraint.h
@@ -44,8 +44,8 @@ class WPILIB_DLLEXPORT DifferentialDriveVoltageConstraint
                             units::meters_per_second_t speed) const override;
 
  private:
-  const SimpleMotorFeedforward<units::meter>& m_feedforward;
-  const DifferentialDriveKinematics& m_kinematics;
+  SimpleMotorFeedforward<units::meter> m_feedforward;
+  DifferentialDriveKinematics m_kinematics;
   units::volt_t m_maxVoltage;
 };
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/trajectory/constraint/MecanumDriveKinematicsConstraint.h
+++ b/wpimath/src/main/native/include/frc/trajectory/constraint/MecanumDriveKinematicsConstraint.h
@@ -33,7 +33,7 @@ class WPILIB_DLLEXPORT MecanumDriveKinematicsConstraint
                             units::meters_per_second_t speed) const override;
 
  private:
-  const MecanumDriveKinematics& m_kinematics;
+  MecanumDriveKinematics m_kinematics;
   units::meters_per_second_t m_maxSpeed;
 };
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.h
+++ b/wpimath/src/main/native/include/frc/trajectory/constraint/SwerveDriveKinematicsConstraint.h
@@ -32,7 +32,7 @@ class SwerveDriveKinematicsConstraint : public TrajectoryConstraint {
                             units::meters_per_second_t speed) const override;
 
  private:
-  const frc::SwerveDriveKinematics<NumModules>& m_kinematics;
+  frc::SwerveDriveKinematics<NumModules> m_kinematics;
   units::meters_per_second_t m_maxSpeed;
 };
 }  // namespace frc


### PR DESCRIPTION
This avoids stack-use-after-scope bugs in code like the following when
the original argument goes out of scope:
```cpp
frc2::Command* RobotContainer::GetAutonomousCommand() {
  // Create a voltage constraint to ensure we don't accelerate too fast
  frc::DifferentialDriveVoltageConstraint autoVoltageConstraint(
      frc::SimpleMotorFeedforward<units::meters>(
          DriveConstants::ks, DriveConstants::kv, DriveConstants::ka),
      DriveConstants::kDriveKinematics, 10_V);
```