### PR TITLE
change tachometer units to RPS from RPM

### DIFF
--- a/wpilibc/src/main/native/cpp/counter/Tachometer.cpp
+++ b/wpilibc/src/main/native/cpp/counter/Tachometer.cpp
@@ -64,17 +64,21 @@ void Tachometer::SetEdgesPerRevolution(int edges) {
   m_edgesPerRevolution = edges;
 }
 
-units::revolutions_per_minute_t Tachometer::GetRevolutionsPerMinute() const {
+units::turns_per_second_t Tachometer::GetRevolutionsPerSecond() const {
   auto period = GetPeriod();
   if (period.to<double>() == 0) {
-    return units::revolutions_per_minute_t{0.0};
+    return units::turns_per_second_t{0.0};
   }
   int edgesPerRevolution = GetEdgesPerRevolution();
   if (edgesPerRevolution == 0) {
-    return units::revolutions_per_minute_t{0.0};
+    return units::turns_per_second_t{0.0};
   }
   auto rotationHz = ((1.0 / edgesPerRevolution) / period);
-  return units::revolutions_per_minute_t{rotationHz.to<double>() * 60};
+  return units::turns_per_second_t{rotationHz.to<double>()};
+}
+
+units::revolutions_per_minute_t Tachometer::GetRevolutionsPerMinute() const {
+  return units::revolutions_per_minute_t{GetRevolutionsPerSecond()};
 }
 
 bool Tachometer::GetStopped() const {
@@ -111,6 +115,8 @@ void Tachometer::SetUpdateWhenEmpty(bool updateWhenEmpty) {
 
 void Tachometer::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Tachometer");
+  builder.AddDoubleProperty(
+      "RPS", [&] { return GetRevolutionsPerSecond().to<double>(); }, nullptr);
   builder.AddDoubleProperty(
       "RPM", [&] { return GetRevolutionsPerMinute().to<double>(); }, nullptr);
 }

--- a/wpilibc/src/main/native/include/frc/counter/Tachometer.h
+++ b/wpilibc/src/main/native/include/frc/counter/Tachometer.h
@@ -76,6 +76,15 @@ class Tachometer : public wpi::Sendable,
   void SetEdgesPerRevolution(int edges);
 
   /**
+   * Gets the current tachometer revolutions per second.
+   *
+   * SetEdgesPerRevolution must be set with a non 0 value for this to work.
+   *
+   * @return Current RPS.
+   */
+  units::turns_per_second_t GetRevolutionsPerSecond() const;
+
+  /**
    * Gets the current tachometer revolutions per minute.
    *
    * SetEdgesPerRevolution must be set with a non 0 value for this to work.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/counter/Tachometer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/counter/Tachometer.java
@@ -99,13 +99,13 @@ public class Tachometer implements Sendable, AutoCloseable {
   }
 
   /**
-   * Gets the current tachometer revolution per minute.
+   * Gets the current tachometer revolutions per second.
    *
    * <p>setEdgesPerRevolution must be set with a non 0 value for this to return valid values.
    *
-   * @return Current RPM.
+   * @return Current RPS.
    */
-  public double getRevolutionsPerMinute() {
+  public double getRevolutionsPerSecond() {
     double period = getPeriod();
     if (period == 0) {
       return 0;
@@ -114,7 +114,18 @@ public class Tachometer implements Sendable, AutoCloseable {
     if (edgesPerRevolution == 0) {
       return 0;
     }
-    return ((1.0 / edgesPerRevolution) / period) * 60;
+    return (1.0 / edgesPerRevolution) / period;
+  }
+
+  /**
+   * Gets the current tachometer revolutions per minute.
+   *
+   * <p>setEdgesPerRevolution must be set with a non 0 value for this to return valid values.
+   *
+   * @return Current RPM.
+   */
+  public double getRevolutionsPerMinute() {
+    return getRevolutionsPerSecond() * 60;
   }
 
   /**
@@ -165,6 +176,7 @@ public class Tachometer implements Sendable, AutoCloseable {
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("Tachometer");
+    builder.addDoubleProperty("RPS", this::getRevolutionsPerSecond, null);
     builder.addDoubleProperty("RPM", this::getRevolutionsPerMinute, null);
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
@@ -78,6 +78,46 @@ public final class Units {
   }
 
   /**
+   * Converts given radians to rotations.
+   *
+   * @param radians The radians to convert.
+   * @return rotations Converted from radians.
+   */
+  public static double radiansToRotations(double radians) {
+    return radians / (Math.PI * 2);
+  }
+
+  /**
+   * Converts given degrees to rotations.
+   *
+   * @param degrees The degrees to convert.
+   * @return rotations Converted from radians.
+   */
+  public static double degreesToRotations(double degrees) {
+    return degrees / 360;
+  }
+
+  /**
+   * Converts given rotations to degrees.
+   *
+   * @param rotations The rotations to convert.
+   * @return degrees Converted from rotations.
+   */
+  public static double rotationsToDegrees(double rotations) {
+    return rotations * 360;
+  }
+
+  /**
+   * Converts given rotations to radians.
+   *
+   * @param rotations The rotations to convert.
+   * @return radians Converted from rotations.
+   */
+  public static double rotationsToRadians(double rotations) {
+    return rotations * 2 * Math.PI;
+  }
+
+  /**
    * Converts rotations per minute to radians per second.
    *
    * @param rpm The rotations per minute to convert to radians per second.

--- a/wpimath/src/main/native/include/units/angular_velocity.h
+++ b/wpimath/src/main/native/include/units/angular_velocity.h
@@ -46,6 +46,8 @@ UNIT_ADD(angular_velocity, radians_per_second, radians_per_second, rad_per_s,
          unit<std::ratio<1>, units::category::angular_velocity_unit>)
 UNIT_ADD(angular_velocity, degrees_per_second, degrees_per_second, deg_per_s,
          compound_unit<angle::degrees, inverse<time::seconds>>)
+UNIT_ADD(angular_velocity, turns_per_second, turns_per_second, tps,
+         compound_unit<angle::turns, inverse<time::seconds>>)
 UNIT_ADD(angular_velocity, revolutions_per_minute, revolutions_per_minute, rpm,
          unit<std::ratio<2, 60>, radians_per_second, std::ratio<1>>)
 UNIT_ADD(angular_velocity, milliarcseconds_per_year, milliarcseconds_per_year,


### PR DESCRIPTION
We standardize on seconds elsewhere, so it doesn't make sense for this to return in minutes (especially given typical relevant timescales for robot mechanisms).