### PR TITLE
Change project year to intellisense

### DIFF
--- a/.wpilib/wpilib_preferences.json
+++ b/.wpilib/wpilib_preferences.json
@@ -1,6 +1,6 @@
 {
   "enableCppIntellisense": true,
   "currentLanguage": "cpp",
-  "projectYear": "2021",
+  "projectYear": "intellisense",
   "teamNumber": 0
 }


### PR DESCRIPTION
This means VSCode won't prompt to upgrade (added in beta 4)