### PR TITLE
[wpiutil] Add disableMockTime to JNI

### DIFF
--- a/wpiutil/src/main/java/edu/wpi/first/util/WPIUtilJNI.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/WPIUtilJNI.java
@@ -56,6 +56,8 @@ public final class WPIUtilJNI {
 
   public static native void enableMockTime();
 
+  public static native void disableMockTime();
+
   public static native void setMockTime(long time);
 
   public static native long now();

--- a/wpiutil/src/main/native/cpp/jni/WPIUtilJNI.cpp
+++ b/wpiutil/src/main/native/cpp/jni/WPIUtilJNI.cpp
@@ -77,6 +77,19 @@ Java_edu_wpi_first_util_WPIUtilJNI_enableMockTime
 
 /*
  * Class:     edu_wpi_first_util_WPIUtilJNI
+ * Method:    disableMockTime
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_util_WPIUtilJNI_disableMockTime
+  (JNIEnv*, jclass)
+{
+  mockTimeEnabled = false;
+  wpi::SetNowImpl(nullptr);
+}
+
+/*
+ * Class:     edu_wpi_first_util_WPIUtilJNI
  * Method:    setMockTime
  * Signature: (J)V
  */


### PR DESCRIPTION
This exposes the equivalent of SetNowImpl(nullptr) to Java.