### PR TITLE
[wpilibj] DriverStation: Set thread interrupted state

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -1107,6 +1107,7 @@ public class DriverStation {
       return true;
     } catch (InterruptedException ex) {
       // return false on a thread interrupt
+      Thread.currentThread().interrupt();
       return false;
     } finally {
       m_waitForDataMutex.unlock();


### PR DESCRIPTION
This is a Java best practice.