### PR TITLE
Use PSI for compressor config and sensor reading

### DIFF
--- a/wpilibc/src/main/native/cpp/Compressor.cpp
+++ b/wpilibc/src/main/native/cpp/Compressor.cpp
@@ -56,6 +56,10 @@ units::volt_t Compressor::GetAnalogVoltage() const {
   return m_module->GetAnalogVoltage(0);
 }
 
+units::pounds_per_square_inch_t Compressor::GetPressure() const {
+  return m_module->GetPressure(0);
+}
+
 void Compressor::Disable() {
   m_module->DisableCompressor();
 }
@@ -64,14 +68,14 @@ void Compressor::EnableDigital() {
   m_module->EnableCompressorDigital();
 }
 
-void Compressor::EnableAnalog(units::volt_t minAnalogVoltage,
-                              units::volt_t maxAnalogVoltage) {
-  m_module->EnableCompressorAnalog(minAnalogVoltage, maxAnalogVoltage);
+void Compressor::EnableAnalog(units::pounds_per_square_inch_t minPressure,
+                              units::pounds_per_square_inch_t maxPressure) {
+  m_module->EnableCompressorAnalog(minPressure, maxPressure);
 }
 
-void Compressor::EnableHybrid(units::volt_t minAnalogVoltage,
-                              units::volt_t maxAnalogVoltage) {
-  m_module->EnableCompressorHybrid(minAnalogVoltage, maxAnalogVoltage);
+void Compressor::EnableHybrid(units::pounds_per_square_inch_t minPressure,
+                              units::pounds_per_square_inch_t maxPressure) {
+  m_module->EnableCompressorHybrid(minPressure, maxPressure);
 }
 
 CompressorConfigType Compressor::GetConfigType() const {

--- a/wpilibc/src/main/native/cpp/PneumaticHub.cpp
+++ b/wpilibc/src/main/native/cpp/PneumaticHub.cpp
@@ -13,6 +13,7 @@
 #include "frc/Errors.h"
 #include "frc/SensorUtil.h"
 #include "frc/Solenoid.h"
+#include "frc/fmt/Units.h"
 
 using namespace frc;
 
@@ -117,12 +118,12 @@ void PneumaticHub::EnableCompressorAnalog(
   if (minPressure < 0_psi || minPressure > 120_psi) {
     throw FRC_MakeError(err::ParameterOutOfRange,
                         "minPressure must be between 0 and 120 PSI, got {}",
-                        minPressure.value());
+                        minPressure);
   }
   if (maxPressure < 0_psi || maxPressure > 120_psi) {
     throw FRC_MakeError(err::ParameterOutOfRange,
                         "maxPressure must be between 0 and 120 PSI, got {}",
-                        maxPressure.value());
+                        maxPressure);
   }
   int32_t status = 0;
   units::volt_t minAnalogVoltage = PSIToVolts(minPressure, 5_V);
@@ -142,12 +143,12 @@ void PneumaticHub::EnableCompressorHybrid(
   if (minPressure < 0_psi || minPressure > 120_psi) {
     throw FRC_MakeError(err::ParameterOutOfRange,
                         "minPressure must be between 0 and 120 PSI, got {}",
-                        minPressure.value());
+                        minPressure);
   }
   if (maxPressure < 0_psi || maxPressure > 120_psi) {
     throw FRC_MakeError(err::ParameterOutOfRange,
                         "maxPressure must be between 0 and 120 PSI, got {}",
-                        maxPressure.value());
+                        maxPressure);
   }
   int32_t status = 0;
   units::volt_t minAnalogVoltage = PSIToVolts(minPressure, 5_V);

--- a/wpilibc/src/main/native/cpp/PneumaticHub.cpp
+++ b/wpilibc/src/main/native/cpp/PneumaticHub.cpp
@@ -110,23 +110,23 @@ void PneumaticHub::EnableCompressorDigital() {
 void PneumaticHub::EnableCompressorAnalog(
     units::pounds_per_square_inch_t minPressure,
     units::pounds_per_square_inch_t maxPressure) {
-  if (minPressure.value() >= maxPressure.value()) {
+  if (minPressure >= maxPressure) {
     throw FRC_MakeError(err::InvalidParameter, "{}",
                         "maxPressure must be greater than minPresure");
   }
-  if (minPressure.value() < 0 || minPressure.value() > 120) {
+  if (minPressure < 0_psi || minPressure > 120_psi) {
     throw FRC_MakeError(err::ParameterOutOfRange,
                         "minPressure must be between 0 and 120 PSI, got {}",
                         minPressure.value());
   }
-  if (maxPressure.value() < 0 || maxPressure.value() > 120) {
+  if (maxPressure < 0_psi || maxPressure > 120_psi) {
     throw FRC_MakeError(err::ParameterOutOfRange,
                         "maxPressure must be between 0 and 120 PSI, got {}",
                         maxPressure.value());
   }
   int32_t status = 0;
-  units::volt_t minAnalogVoltage = PSIToVolts(minPressure, units::volt_t{5.0});
-  units::volt_t maxAnalogVoltage = PSIToVolts(maxPressure, units::volt_t{5.0});
+  units::volt_t minAnalogVoltage = PSIToVolts(minPressure, 5_V);
+  units::volt_t maxAnalogVoltage = PSIToVolts(maxPressure, 5_V);
   HAL_SetREVPHClosedLoopControlAnalog(m_handle, minAnalogVoltage.value(),
                                       maxAnalogVoltage.value(), &status);
   FRC_ReportError(status, "Module {}", m_module);
@@ -135,23 +135,23 @@ void PneumaticHub::EnableCompressorAnalog(
 void PneumaticHub::EnableCompressorHybrid(
     units::pounds_per_square_inch_t minPressure,
     units::pounds_per_square_inch_t maxPressure) {
-  if (minPressure.value() >= maxPressure.value()) {
+  if (minPressure >= maxPressure) {
     throw FRC_MakeError(err::InvalidParameter, "{}",
                         "maxPressure must be greater than minPresure");
   }
-  if (minPressure.value() < 0 || minPressure.value() > 120) {
+  if (minPressure < 0_psi || minPressure > 120_psi) {
     throw FRC_MakeError(err::ParameterOutOfRange,
                         "minPressure must be between 0 and 120 PSI, got {}",
                         minPressure.value());
   }
-  if (maxPressure.value() < 0 || maxPressure.value() > 120) {
+  if (maxPressure < 0_psi || maxPressure > 120_psi) {
     throw FRC_MakeError(err::ParameterOutOfRange,
                         "maxPressure must be between 0 and 120 PSI, got {}",
                         maxPressure.value());
   }
   int32_t status = 0;
-  units::volt_t minAnalogVoltage = PSIToVolts(minPressure, units::volt_t{5.0});
-  units::volt_t maxAnalogVoltage = PSIToVolts(maxPressure, units::volt_t{5.0});
+  units::volt_t minAnalogVoltage = PSIToVolts(minPressure, 5_V);
+  units::volt_t maxAnalogVoltage = PSIToVolts(maxPressure, 5_V);
   HAL_SetREVPHClosedLoopControlHybrid(m_handle, minAnalogVoltage.value(),
                                       maxAnalogVoltage.value(), &status);
   FRC_ReportError(status, "Module {}", m_module);

--- a/wpilibc/src/main/native/cpp/PneumaticsControlModule.cpp
+++ b/wpilibc/src/main/native/cpp/PneumaticsControlModule.cpp
@@ -269,7 +269,7 @@ units::volt_t PneumaticsControlModule::GetAnalogVoltage(int channel) const {
 
 units::pounds_per_square_inch_t PneumaticsControlModule::GetPressure(
     int channel) const {
-  return units::pounds_per_square_inch_t{0};
+  return 0_psi;
 }
 
 Solenoid PneumaticsControlModule::MakeSolenoid(int channel) {

--- a/wpilibc/src/main/native/cpp/PneumaticsControlModule.cpp
+++ b/wpilibc/src/main/native/cpp/PneumaticsControlModule.cpp
@@ -97,14 +97,16 @@ void PneumaticsControlModule::EnableCompressorDigital() {
 }
 
 void PneumaticsControlModule::EnableCompressorAnalog(
-    units::volt_t minAnalogVoltage, units::volt_t maxAnalogVoltage) {
+    units::pounds_per_square_inch_t minPressure,
+    units::pounds_per_square_inch_t maxPressure) {
   int32_t status = 0;
   HAL_SetCTREPCMClosedLoopControl(m_handle, true, &status);
   FRC_CheckErrorStatus(status, "Module {}", m_module);
 }
 
 void PneumaticsControlModule::EnableCompressorHybrid(
-    units::volt_t minAnalogVoltage, units::volt_t maxAnalogVoltage) {
+    units::pounds_per_square_inch_t minPressure,
+    units::pounds_per_square_inch_t maxPressure) {
   int32_t status = 0;
   HAL_SetCTREPCMClosedLoopControl(m_handle, true, &status);
   FRC_CheckErrorStatus(status, "Module {}", m_module);
@@ -263,6 +265,11 @@ void PneumaticsControlModule::UnreserveCompressor() {
 
 units::volt_t PneumaticsControlModule::GetAnalogVoltage(int channel) const {
   return units::volt_t{0};
+}
+
+units::pounds_per_square_inch_t PneumaticsControlModule::GetPressure(
+    int channel) const {
+  return units::pounds_per_square_inch_t{0};
 }
 
 Solenoid PneumaticsControlModule::MakeSolenoid(int channel) {

--- a/wpilibc/src/main/native/include/frc/Compressor.h
+++ b/wpilibc/src/main/native/include/frc/Compressor.h
@@ -105,6 +105,14 @@ class Compressor : public wpi::Sendable,
   units::volt_t GetAnalogVoltage() const;
 
   /**
+   * Query the analog sensor pressure (on channel 0) (if supported). Note this
+   * is only for use with the REV Analog Pressure Sensor.
+   *
+   * @return The analog sensor pressure, in PSI
+   */
+  units::pounds_per_square_inch_t GetPressure() const;
+
+  /**
    * Disable the compressor.
    */
   void Disable();
@@ -115,26 +123,28 @@ class Compressor : public wpi::Sendable,
   void EnableDigital();
 
   /**
-   * Enable compressor closed loop control using analog input.
+   * Enable compressor closed loop control using analog input. Note this is only
+   * for use with the REV Analog Pressure Sensor.
    *
    * <p>On CTRE PCM, this will enable digital control.
    *
-   * @param minAnalogVoltage The minimum voltage to enable compressor
-   * @param maxAnalogVoltage The maximum voltage to disable compressor
+   * @param minPressure The minimum pressure in PSI to enable compressor
+   * @param maxPressure The maximum pressure in PSI to disable compressor
    */
-  void EnableAnalog(units::volt_t minAnalogVoltage,
-                    units::volt_t maxAnalogVoltage);
+  void EnableAnalog(units::pounds_per_square_inch_t minPressure,
+                    units::pounds_per_square_inch_t maxPressure);
 
   /**
-   * Enable compressor closed loop control using hybrid input.
+   * Enable compressor closed loop control using hybrid input. Note this is only
+   * for use with the REV Analog Pressure Sensor.
    *
    * On CTRE PCM, this will enable digital control.
    *
-   * @param minAnalogVoltage The minimum voltage to enable compressor
-   * @param maxAnalogVoltage The maximum voltage to disable compressor
+   * @param minPressure The minimum pressure in PSI to enable compressor
+   * @param maxPressure The maximum pressure in PSI to disable compressor
    */
-  void EnableHybrid(units::volt_t minAnalogVoltage,
-                    units::volt_t maxAnalogVoltage);
+  void EnableHybrid(units::pounds_per_square_inch_t minPressure,
+                    units::pounds_per_square_inch_t maxPressure);
 
   CompressorConfigType GetConfigType() const;
 

--- a/wpilibc/src/main/native/include/frc/PneumaticHub.h
+++ b/wpilibc/src/main/native/include/frc/PneumaticHub.h
@@ -26,11 +26,13 @@ class PneumaticHub : public PneumaticsBase {
 
   void EnableCompressorDigital() override;
 
-  void EnableCompressorAnalog(units::volt_t minAnalogVoltage,
-                              units::volt_t maxAnalogVoltage) override;
+  void EnableCompressorAnalog(
+      units::pounds_per_square_inch_t minPressure,
+      units::pounds_per_square_inch_t maxPressure) override;
 
-  void EnableCompressorHybrid(units::volt_t minAnalogVoltage,
-                              units::volt_t maxAnalogVoltage) override;
+  void EnableCompressorHybrid(
+      units::pounds_per_square_inch_t minPressure,
+      units::pounds_per_square_inch_t maxPressure) override;
 
   CompressorConfigType GetCompressorConfigType() const override;
 
@@ -126,6 +128,8 @@ class PneumaticHub : public PneumaticsBase {
   units::volt_t GetSolenoidsVoltage() const;
 
   units::volt_t GetAnalogVoltage(int channel) const override;
+
+  units::pounds_per_square_inch_t GetPressure(int channel) const override;
 
  private:
   class DataStore;

--- a/wpilibc/src/main/native/include/frc/PneumaticsBase.h
+++ b/wpilibc/src/main/native/include/frc/PneumaticsBase.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include <units/current.h>
+#include <units/pressure.h>
 #include <units/time.h>
 #include <units/voltage.h>
 
@@ -31,11 +32,13 @@ class PneumaticsBase {
 
   virtual void EnableCompressorDigital() = 0;
 
-  virtual void EnableCompressorAnalog(units::volt_t minAnalogVoltage,
-                                      units::volt_t maxAnalogVoltage) = 0;
+  virtual void EnableCompressorAnalog(
+      units::pounds_per_square_inch_t minPressure,
+      units::pounds_per_square_inch_t maxPressure) = 0;
 
-  virtual void EnableCompressorHybrid(units::volt_t minAnalogVoltage,
-                                      units::volt_t maxAnalogVoltage) = 0;
+  virtual void EnableCompressorHybrid(
+      units::pounds_per_square_inch_t minPressure,
+      units::pounds_per_square_inch_t maxPressure) = 0;
 
   virtual CompressorConfigType GetCompressorConfigType() const = 0;
 
@@ -62,6 +65,8 @@ class PneumaticsBase {
   virtual void UnreserveCompressor() = 0;
 
   virtual units::volt_t GetAnalogVoltage(int channel) const = 0;
+
+  virtual units::pounds_per_square_inch_t GetPressure(int channel) const = 0;
 
   virtual Solenoid MakeSolenoid(int channel) = 0;
   virtual DoubleSolenoid MakeDoubleSolenoid(int forwardChannel,

--- a/wpilibc/src/main/native/include/frc/PneumaticsControlModule.h
+++ b/wpilibc/src/main/native/include/frc/PneumaticsControlModule.h
@@ -26,11 +26,13 @@ class PneumaticsControlModule : public PneumaticsBase {
 
   void EnableCompressorDigital() override;
 
-  void EnableCompressorAnalog(units::volt_t minAnalogVoltage,
-                              units::volt_t maxAnalogVoltage) override;
+  void EnableCompressorAnalog(
+      units::pounds_per_square_inch_t minPressure,
+      units::pounds_per_square_inch_t maxPressure) override;
 
-  void EnableCompressorHybrid(units::volt_t minAnalogVoltage,
-                              units::volt_t maxAnalogVoltage) override;
+  void EnableCompressorHybrid(
+      units::pounds_per_square_inch_t minPressure,
+      units::pounds_per_square_inch_t maxPressure) override;
 
   CompressorConfigType GetCompressorConfigType() const override;
 
@@ -73,6 +75,8 @@ class PneumaticsControlModule : public PneumaticsBase {
   void UnreserveCompressor() override;
 
   units::volt_t GetAnalogVoltage(int channel) const override;
+
+  units::pounds_per_square_inch_t GetPressure(int channel) const override;
 
   Solenoid MakeSolenoid(int channel) override;
   DoubleSolenoid MakeDoubleSolenoid(int forwardChannel,

--- a/wpilibc/src/test/native/cpp/simulation/REVPHSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/REVPHSimTest.cpp
@@ -129,7 +129,7 @@ TEST(REVPHSimTest, SetEnableAnalog) {
   ph.DisableCompressor();
   EXPECT_EQ(ph.GetCompressorConfigType(), CompressorConfigType::Disabled);
 
-  ph.EnableCompressorAnalog(1_V, 2_V);
+  ph.EnableCompressorAnalog(1_psi, 2_psi);
   EXPECT_EQ(sim.GetCompressorConfigType(),
             static_cast<int>(CompressorConfigType::Analog));
   EXPECT_EQ(ph.GetCompressorConfigType(), CompressorConfigType::Analog);
@@ -150,7 +150,7 @@ TEST(REVPHSimTest, SetEnableHybrid) {
   ph.DisableCompressor();
   EXPECT_EQ(ph.GetCompressorConfigType(), CompressorConfigType::Disabled);
 
-  ph.EnableCompressorHybrid(1_V, 2_V);
+  ph.EnableCompressorHybrid(1_psi, 2_psi);
   EXPECT_EQ(sim.GetCompressorConfigType(),
             static_cast<int>(CompressorConfigType::Hybrid));
   EXPECT_EQ(ph.GetCompressorConfigType(), CompressorConfigType::Hybrid);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
@@ -126,6 +126,16 @@ public class Compressor implements Sendable, AutoCloseable {
     return m_module.getAnalogVoltage(0);
   }
 
+  /**
+   * Query the analog sensor pressure (on channel 0) (if supported). Note this is only for use with
+   * the REV Analog Pressure Sensor.
+   *
+   * @return The analog sensor pressure, in PSI
+   */
+  public double getPressure() {
+    return m_module.getPressure(0);
+  }
+
   /** Disable the compressor. */
   public void disable() {
     m_module.disableCompressor();
@@ -137,27 +147,29 @@ public class Compressor implements Sendable, AutoCloseable {
   }
 
   /**
-   * Enable compressor closed loop control using analog input.
+   * Enable compressor closed loop control using analog input. Note this is only for use with the
+   * REV Analog Pressure Sensor.
    *
    * <p>On CTRE PCM, this will enable digital control.
    *
-   * @param minAnalogVoltage The minimum voltage to enable compressor
-   * @param maxAnalogVoltage The maximum voltage to disable compressor
+   * @param minPressure The minimum pressure in PSI to enable compressor
+   * @param maxPressure The maximum pressure in PSI to disable compressor
    */
-  public void enableAnalog(double minAnalogVoltage, double maxAnalogVoltage) {
-    m_module.enableCompressorAnalog(minAnalogVoltage, maxAnalogVoltage);
+  public void enableAnalog(double minPressure, double maxPressure) {
+    m_module.enableCompressorAnalog(minPressure, maxPressure);
   }
 
   /**
-   * Enable compressor closed loop control using hybrid input.
+   * Enable compressor closed loop control using hybrid input. Note this is only for use with the
+   * REV Analog Pressure Sensor.
    *
    * <p>On CTRE PCM, this will enable digital control.
    *
-   * @param minAnalogVoltage The minimum voltage to enable compressor
-   * @param maxAnalogVoltage The maximum voltage to disable compressor
+   * @param minPressure The minimum pressure in PSI to enable compressor
+   * @param maxPressure The maximum pressure in PSI to disable compressor
    */
-  public void enableHybrid(double minAnalogVoltage, double maxAnalogVoltage) {
-    m_module.enableCompressorHybrid(minAnalogVoltage, maxAnalogVoltage);
+  public void enableHybrid(double minPressure, double maxPressure) {
+    m_module.enableCompressorHybrid(minPressure, maxPressure);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
@@ -68,6 +68,18 @@ public class PneumaticHub implements PneumaticsBase {
     }
   }
 
+  /** Converts volts to PSI per the REV Analog Pressure Sensor datasheet. */
+  private static double voltsToPsi(double sensorVoltage, double supplyVoltage) {
+    double pressure = 250 * (sensorVoltage / supplyVoltage) - 25;
+    return pressure;
+  }
+
+  /** Converts PSI to volts per the REV Analog Pressure Sensor datasheet. */
+  private static double psiToVolts(double pressure, double supplyVoltage) {
+    double voltage = supplyVoltage * (0.004 * pressure + 0.1);
+    return voltage;
+  }
+
   private final DataStore m_dataStore;
   private final int m_handle;
 
@@ -210,18 +222,51 @@ public class PneumaticHub implements PneumaticsBase {
   }
 
   @Override
-  public void enableCompressorAnalog(double minAnalogVoltage, double maxAnalogVoltage) {
+  public void enableCompressorAnalog(double minPressure, double maxPressure) {
+    if (minPressure >= maxPressure) {
+      throw new IllegalArgumentException("maxPressure must be greater than minPressure");
+    }
+    if (minPressure < 0 || minPressure > 120) {
+      throw new IllegalArgumentException(
+          "minPressure must be between 0 and 120 PSI, got " + minPressure);
+    }
+    if (maxPressure < 0 || maxPressure > 120) {
+      throw new IllegalArgumentException(
+          "maxPressure must be between 0 and 120 PSI, got " + maxPressure);
+    }
+    double minAnalogVoltage = psiToVolts(minPressure, 5);
+    double maxAnalogVoltage = psiToVolts(maxPressure, 5);
     REVPHJNI.setClosedLoopControlAnalog(m_handle, minAnalogVoltage, maxAnalogVoltage);
   }
 
   @Override
-  public void enableCompressorHybrid(double minAnalogVoltage, double maxAnalogVoltage) {
+  public void enableCompressorHybrid(double minPressure, double maxPressure) {
+    if (minPressure >= maxPressure) {
+      throw new IllegalArgumentException("maxPressure must be greater than minPressure");
+    }
+    if (minPressure < 0 || minPressure > 120) {
+      throw new IllegalArgumentException(
+          "minPressure must be between 0 and 120 PSI, got " + minPressure);
+    }
+    if (maxPressure < 0 || maxPressure > 120) {
+      throw new IllegalArgumentException(
+          "maxPressure must be between 0 and 120 PSI, got " + maxPressure);
+    }
+    double minAnalogVoltage = psiToVolts(minPressure, 5);
+    double maxAnalogVoltage = psiToVolts(maxPressure, 5);
     REVPHJNI.setClosedLoopControlHybrid(m_handle, minAnalogVoltage, maxAnalogVoltage);
   }
 
   @Override
   public double getAnalogVoltage(int channel) {
     return REVPHJNI.getAnalogVoltage(m_handle, channel);
+  }
+
+  @Override
+  public double getPressure(int channel) {
+    double sensorVoltage = REVPHJNI.getAnalogVoltage(m_handle, channel);
+    double supplyVoltage = REVPHJNI.get5VVoltage(m_handle);
+    return voltsToPsi(sensorVoltage, supplyVoltage);
   }
 
   void clearStickyFaults() {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticsBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticsBase.java
@@ -90,11 +90,13 @@ public interface PneumaticsBase extends AutoCloseable {
 
   void enableCompressorDigital();
 
-  void enableCompressorAnalog(double minAnalogVoltage, double maxAnalogVoltage);
+  void enableCompressorAnalog(double minPressure, double maxPressure);
 
-  void enableCompressorHybrid(double minAnalogVoltage, double maxAnalogVoltage);
+  void enableCompressorHybrid(double minPressure, double maxPressure);
 
   double getAnalogVoltage(int channel);
+
+  double getPressure(int channel);
 
   CompressorConfigType getCompressorConfigType();
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticsControlModule.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticsControlModule.java
@@ -235,12 +235,12 @@ public class PneumaticsControlModule implements PneumaticsBase {
   }
 
   @Override
-  public void enableCompressorAnalog(double minAnalogVoltage, double maxAnalogVoltage) {
+  public void enableCompressorAnalog(double minPressure, double maxPressure) {
     CTREPCMJNI.setClosedLoopControl(m_handle, false);
   }
 
   @Override
-  public void enableCompressorHybrid(double minAnalogVoltage, double maxAnalogVoltage) {
+  public void enableCompressorHybrid(double minPressure, double maxPressure) {
     CTREPCMJNI.setClosedLoopControl(m_handle, false);
   }
 
@@ -253,6 +253,11 @@ public class PneumaticsControlModule implements PneumaticsBase {
 
   @Override
   public double getAnalogVoltage(int channel) {
+    return 0;
+  }
+
+  @Override
+  public double getPressure(int channel) {
     return 0;
   }
 }


### PR DESCRIPTION
This adds the REV Analog Pressure Sensor PSI to volt (and vice versa) conversion to allow setting the compressor config in PSI and getting the sensor reading in PSI. Also adds input validation for pressure values in the API