### PR TITLE
[wpilib] Allow SendableCameraWrappers to take arbitrary URLs

### DIFF
--- a/wpilibc/src/main/native/cpp/shuffleboard/SendableCameraWrapper.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/SendableCameraWrapper.cpp
@@ -8,19 +8,19 @@
 #include <memory>
 #include <string>
 
-#include <wpi/DenseMap.h>
+#include <wpi/StringMap.h>
 #include <wpi/sendable/SendableBuilder.h>
 #include <wpi/sendable/SendableRegistry.h>
 
 namespace frc {
 namespace detail {
 std::shared_ptr<SendableCameraWrapper>& GetSendableCameraWrapper(
-    CS_Source source) {
-  static wpi::DenseMap<int, std::shared_ptr<SendableCameraWrapper>> wrappers;
-  return wrappers[static_cast<int>(source)];
+    std::string_view cameraName) {
+  static wpi::StringMap<std::shared_ptr<SendableCameraWrapper>> wrappers;
+  return wrappers[cameraName];
 }
 
-void AddToSendableRegistry(wpi::Sendable* sendable, std::string name) {
+void AddToSendableRegistry(wpi::Sendable* sendable, std::string_view name) {
   wpi::SendableRegistry::Add(sendable, name);
 }
 }  // namespace detail

--- a/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardContainer.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardContainer.h
@@ -128,6 +128,18 @@ class ShuffleboardContainer : public virtual ShuffleboardValue {
   ComplexWidget& Add(std::string_view title, const cs::VideoSource& video);
 
   /**
+   * Adds a widget to this container to display a video stream.
+   *
+   * @param title      the title of the widget
+   * @param cameraName the name of the streamed camera
+   * @param cameraUrls the URLs with which the dashboard can access the camera
+   * stream
+   * @return a widget to display the camera stream
+   */
+  ComplexWidget& AddCamera(std::string_view title, std::string_view cameraName,
+                           wpi::span<const std::string> cameraUrls);
+
+  /**
    * Adds a widget to this container to display the given sendable.
    *
    * @param sendable the sendable to display
@@ -525,5 +537,11 @@ inline frc::ComplexWidget& frc::ShuffleboardContainer::Add(
 inline frc::ComplexWidget& frc::ShuffleboardContainer::Add(
     std::string_view title, const cs::VideoSource& video) {
   return Add(title, frc::SendableCameraWrapper::Wrap(video));
+}
+
+inline frc::ComplexWidget& frc::ShuffleboardContainer::AddCamera(
+    std::string_view title, std::string_view cameraName,
+    wpi::span<const std::string> cameraUrls) {
+  return Add(title, frc::SendableCameraWrapper::Wrap(cameraName, cameraUrls));
 }
 #endif

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardContainer.java
@@ -123,6 +123,20 @@ public interface ShuffleboardContainer extends ShuffleboardValue {
   SimpleWidget add(String title, Object defaultValue);
 
   /**
+   * Adds a widget to this container to display a video stream.
+   *
+   * @param title the title of the widget
+   * @param cameraName the name of the streamed camera
+   * @param cameraUrls the URLs with which the dashboard can access the camera stream
+   * @return a widget to display the camera stream
+   * @throws IllegalArgumentException if a widget already exists in this container with the given
+   *     title
+   */
+  default ComplexWidget addCamera(String title, String cameraName, String... cameraUrls) {
+    return add(title, SendableCameraWrapper.wrap(cameraName, cameraUrls));
+  }
+
+  /**
    * Adds a widget to this container. The widget will display the data provided by the value
    * supplier. Changes made on the dashboard will not propagate to the widget object, and will be
    * overridden by values from the value supplier.

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/SendableCameraWrapperTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/SendableCameraWrapperTest.java
@@ -1,0 +1,63 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.shuffleboard;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import edu.wpi.first.networktables.NetworkTableInstance;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SendableCameraWrapperTest {
+  @BeforeEach
+  void setup() {
+    NetworkTableInstance.getDefault().deleteAllEntries();
+    SendableCameraWrapper.clearWrappers();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    NetworkTableInstance.getDefault().deleteAllEntries();
+  }
+
+  @Test
+  void testNullCameraName() {
+    assertThrows(NullPointerException.class, () -> SendableCameraWrapper.wrap(null, ""));
+  }
+
+  @Test
+  void testEmptyCameraName() {
+    assertThrows(IllegalArgumentException.class, () -> SendableCameraWrapper.wrap("", ""));
+  }
+
+  @Test
+  void testNullUrlArray() {
+    assertThrows(
+        NullPointerException.class, () -> SendableCameraWrapper.wrap("name", (String[]) null));
+  }
+
+  @Test
+  void testNullUrlInArray() {
+    assertThrows(NullPointerException.class, () -> SendableCameraWrapper.wrap("name", "url", null));
+  }
+
+  @Test
+  void testEmptyUrlArray() {
+    assertThrows(IllegalArgumentException.class, () -> SendableCameraWrapper.wrap("name"));
+  }
+
+  @Test
+  void testUrlsAddedToNt() {
+    SendableCameraWrapper.wrap("name", "url1", "url2");
+    assertArrayEquals(
+        new String[] {"url1", "url2"},
+        NetworkTableInstance.getDefault()
+            .getEntry("/CameraPublisher/name/streams")
+            .getValue()
+            .getStringArray());
+  }
+}


### PR DESCRIPTION
Useful for adding cameras that are streamed from a coprocessor

Updated version of #1794.

Closes wpilibsuite/shuffleboard#582
Closes wpilibsuite/shuffleboard#598
Closes #1587