### PR TITLE
[wpigui] Remove wpiutil linkage

### DIFF
--- a/wpigui/.styleguide
+++ b/wpigui/.styleguide
@@ -27,5 +27,4 @@ includeOtherLibs {
   ^imgui
   ^implot
   ^stb
-  ^wpi/
 }

--- a/wpigui/CMakeLists.txt
+++ b/wpigui/CMakeLists.txt
@@ -15,7 +15,7 @@ set_property(TARGET wpigui PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET wpigui PROPERTY FOLDER "libraries")
 
 wpilib_target_warnings(wpigui)
-target_link_libraries(wpigui PUBLIC imgui wpiutil)
+target_link_libraries(wpigui PUBLIC imgui)
 
 target_include_directories(wpigui PUBLIC
                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/include>

--- a/wpigui/build.gradle
+++ b/wpigui/build.gradle
@@ -62,7 +62,6 @@ if (!project.hasProperty('onlylinuxathena') && !project.hasProperty('onlylinuxra
                 }
                 binaries.all {
                     nativeUtils.useRequiredLibrary(it, 'imgui_static')
-                    lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
                     if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.raspbian || it.targetPlatform.name == nativeUtils.wpi.platforms.aarch64bionic) {
                         it.buildable = false
                         return
@@ -120,7 +119,6 @@ if (!project.hasProperty('onlylinuxathena') && !project.hasProperty('onlylinuxra
                 binaries.all {
                     lib library: 'wpigui'
                     nativeUtils.useRequiredLibrary(it, 'imgui_static')
-                    lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
                 }
             }
         }

--- a/wpigui/src/main/native/cpp/wpigui.cpp
+++ b/wpigui/src/main/native/cpp/wpigui.cpp
@@ -15,7 +15,6 @@
 #include <imgui_internal.h>
 #include <implot.h>
 #include <stb_image.h>
-#include <wpi/fs.h>
 
 #include "wpigui_internal.h"
 
@@ -320,7 +319,7 @@ void gui::Main() {
 
   // Delete the save file if requested.
   if (!gContext->saveSettings && gContext->resetOnExit) {
-    fs::remove(fs::path{gContext->iniPath});
+    std::remove(gContext->iniPath.c_str());
   }
 
   glfwDestroyWindow(gContext->window);


### PR DESCRIPTION
It was only being used for fs::remove() (added in #3463), which is easily
replaced by std::remove().