### PR TITLE
Throw exception if the REV Pneumatic Hub firmware version is older than 22.0.0

### DIFF
--- a/hal/src/main/native/athena/REVPDH.cpp
+++ b/hal/src/main/native/athena/REVPDH.cpp
@@ -533,7 +533,13 @@ void HAL_GetREVPDHVersion(HAL_REVPDHHandle handle,
   version->hardwareMinor = result.hardware_minor;
   version->hardwareMajor = result.hardware_major;
   version->uniqueId = result.unique_id;
-  hpdh->versionInfo = version;
+  
+  hpdh->versionInfo->firmwareMajor = version->firmwareMajor;
+  hpdh->versionInfo->firmwareMinor = version->firmwareMinor;
+  hpdh->versionInfo->firmwareFix = version->firmwareFix;
+  hpdh->versionInfo->hardwareMajor = version->hardwareMajor;
+  hpdh->versionInfo->hardwareMinor = version->hardwareMinor;
+  hpdh->versionInfo->uniqueId = version->uniqueId;
 }
 
 void HAL_GetREVPDHFaults(HAL_REVPDHHandle handle,

--- a/hal/src/main/native/athena/REVPDH.cpp
+++ b/hal/src/main/native/athena/REVPDH.cpp
@@ -228,6 +228,7 @@ HAL_REVPDHHandle HAL_InitializeREVPDH(int32_t module,
   hpdh->previousAllocation = allocationLocation ? allocationLocation : "";
   hpdh->hcan = hcan;
   hpdh->controlPeriod = kDefaultControlPeriod;
+  std::memset(&hpdh->versionInfo, 0, sizeof(hpdh->versionInfo));
 
   return handle;
 }

--- a/hal/src/main/native/athena/REVPDH.cpp
+++ b/hal/src/main/native/athena/REVPDH.cpp
@@ -36,6 +36,7 @@ struct REV_PDHObj {
   int32_t controlPeriod;
   HAL_CANHandle hcan;
   std::string previousAllocation;
+  HAL_PowerDistributionVersion versionInfo;
 };
 
 }  // namespace
@@ -491,6 +492,18 @@ void HAL_GetREVPDHVersion(HAL_REVPDHHandle handle,
     return;
   }
 
+  if (hpdh->versionInfo.firmwareMajor > 0) {
+    version->firmwareMajor = hpdh->versionInfo.firmwareMajor;
+    version->firmwareMinor = hpdh->versionInfo.firmwareMinor;
+    version->firmwareFix = hpdh->versionInfo.firmwareFix;
+    version->hardwareMajor = hpdh->versionInfo.hardwareMajor;
+    version->hardwareMinor = hpdh->versionInfo.hardwareMinor;
+    version->uniqueId = hpdh->versionInfo.uniqueId;
+
+    *status = 0;
+    return;
+  }
+
   HAL_WriteCANRTRFrame(hpdh->hcan, PDH_VERSION_LENGTH, PDH_VERSION_FRAME_API,
                        status);
 
@@ -520,6 +533,7 @@ void HAL_GetREVPDHVersion(HAL_REVPDHHandle handle,
   version->hardwareMinor = result.hardware_minor;
   version->hardwareMajor = result.hardware_major;
   version->uniqueId = result.unique_id;
+  hpdh->versionInfo = version;
 }
 
 void HAL_GetREVPDHFaults(HAL_REVPDHHandle handle,

--- a/hal/src/main/native/athena/REVPDH.cpp
+++ b/hal/src/main/native/athena/REVPDH.cpp
@@ -534,12 +534,7 @@ void HAL_GetREVPDHVersion(HAL_REVPDHHandle handle,
   version->hardwareMajor = result.hardware_major;
   version->uniqueId = result.unique_id;
   
-  hpdh->versionInfo->firmwareMajor = version->firmwareMajor;
-  hpdh->versionInfo->firmwareMinor = version->firmwareMinor;
-  hpdh->versionInfo->firmwareFix = version->firmwareFix;
-  hpdh->versionInfo->hardwareMajor = version->hardwareMajor;
-  hpdh->versionInfo->hardwareMinor = version->hardwareMinor;
-  hpdh->versionInfo->uniqueId = version->uniqueId;
+  hpdh->versionInfo = *version;
 }
 
 void HAL_GetREVPDHFaults(HAL_REVPDHHandle handle,

--- a/hal/src/main/native/athena/REVPDH.cpp
+++ b/hal/src/main/native/athena/REVPDH.cpp
@@ -11,6 +11,7 @@
 #include <hal/handles/IndexedHandleResource.h>
 
 #include <cstring>
+#include <thread>
 
 #include <fmt/format.h>
 
@@ -497,9 +498,15 @@ void HAL_GetREVPDHVersion(HAL_REVPDHHandle handle,
     return;
   }
 
-  HAL_ReadCANPacketTimeout(hpdh->hcan, PDH_VERSION_FRAME_API, packedData,
-                           &length, &timestamp, kDefaultControlPeriod * 2,
-                           status);
+  uint32_t timeoutMs = 100;
+  for (uint32_t i = 0; i <= timeoutMs; i++) {
+    HAL_ReadCANPacketNew(hpdh->hcan, PDH_VERSION_FRAME_API, packedData, &length,
+                         &timestamp, status);
+    if (*status == 0) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
 
   if (*status != 0) {
     return;

--- a/hal/src/main/native/athena/REVPDH.cpp
+++ b/hal/src/main/native/athena/REVPDH.cpp
@@ -533,7 +533,7 @@ void HAL_GetREVPDHVersion(HAL_REVPDHHandle handle,
   version->hardwareMinor = result.hardware_minor;
   version->hardwareMajor = result.hardware_major;
   version->uniqueId = result.unique_id;
-  
+
   hpdh->versionInfo = *version;
 }
 

--- a/hal/src/main/native/athena/REVPH.cpp
+++ b/hal/src/main/native/athena/REVPH.cpp
@@ -4,6 +4,8 @@
 
 #include "hal/REVPH.h"
 
+#include <thread>
+
 #include <fmt/format.h>
 
 #include "HALInitializer.h"
@@ -487,8 +489,15 @@ void HAL_GetREVPHVersion(HAL_REVPHHandle handle, HAL_REVPHVersion* version,
     return;
   }
 
-  HAL_ReadCANPacketTimeout(ph->hcan, PH_VERSION_FRAME_API, packedData, &length,
-                           &timestamp, kDefaultControlPeriod * 2, status);
+  uint32_t timeoutMs = 100;
+  for (uint32_t i = 0; i <= timeoutMs; i++) {
+    HAL_ReadCANPacketNew(ph->hcan, PH_VERSION_FRAME_API, packedData, &length,
+                         &timestamp, status);
+    if (*status == 0) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
 
   if (*status != 0) {
     return;

--- a/hal/src/main/native/athena/REVPH.cpp
+++ b/hal/src/main/native/athena/REVPH.cpp
@@ -65,6 +65,7 @@ struct REV_PHObj {
   wpi::mutex solenoidLock;
   HAL_CANHandle hcan;
   std::string previousAllocation;
+  HAL_REVPHVersion versionInfo;
 };
 
 }  // namespace
@@ -482,6 +483,18 @@ void HAL_GetREVPHVersion(HAL_REVPHHandle handle, HAL_REVPHVersion* version,
     return;
   }
 
+  if (ph->versionInfo.firmwareMajor > 0) {
+    version->firmwareMajor = ph->versionInfo.firmwareMajor;
+    version->firmwareMinor = ph->versionInfo.firmwareMinor;
+    version->firmwareFix = ph->versionInfo.firmwareFix;
+    version->hardwareMajor = ph->versionInfo.hardwareMajor;
+    version->hardwareMinor = ph->versionInfo.hardwareMinor;
+    version->uniqueId = ph->versionInfo.uniqueId;
+
+    *status = 0;
+    return;
+  }
+
   HAL_WriteCANRTRFrame(ph->hcan, PH_VERSION_LENGTH, PH_VERSION_FRAME_API,
                        status);
 
@@ -511,6 +524,7 @@ void HAL_GetREVPHVersion(HAL_REVPHHandle handle, HAL_REVPHVersion* version,
   version->hardwareMinor = result.hardware_minor;
   version->hardwareMajor = result.hardware_major;
   version->uniqueId = result.unique_id;
+  ph->versionInfo = version;
 }
 
 int32_t HAL_GetREVPHSolenoids(HAL_REVPHHandle handle, int32_t* status) {

--- a/hal/src/main/native/athena/REVPH.cpp
+++ b/hal/src/main/native/athena/REVPH.cpp
@@ -524,7 +524,13 @@ void HAL_GetREVPHVersion(HAL_REVPHHandle handle, HAL_REVPHVersion* version,
   version->hardwareMinor = result.hardware_minor;
   version->hardwareMajor = result.hardware_major;
   version->uniqueId = result.unique_id;
-  ph->versionInfo = version;
+
+  ph->versionInfo->firmwareMajor = version->firmwareMajor;
+  ph->versionInfo->firmwareMinor = version->firmwareMinor;
+  ph->versionInfo->firmwareFix = version->firmwareFix;
+  ph->versionInfo->hardwareMajor = version->hardwareMajor;
+  ph->versionInfo->hardwareMinor = version->hardwareMinor;
+  ph->versionInfo->uniqueId = version->uniqueId;
 }
 
 int32_t HAL_GetREVPHSolenoids(HAL_REVPHHandle handle, int32_t* status) {

--- a/hal/src/main/native/athena/REVPH.cpp
+++ b/hal/src/main/native/athena/REVPH.cpp
@@ -525,12 +525,7 @@ void HAL_GetREVPHVersion(HAL_REVPHHandle handle, HAL_REVPHVersion* version,
   version->hardwareMajor = result.hardware_major;
   version->uniqueId = result.unique_id;
 
-  ph->versionInfo->firmwareMajor = version->firmwareMajor;
-  ph->versionInfo->firmwareMinor = version->firmwareMinor;
-  ph->versionInfo->firmwareFix = version->firmwareFix;
-  ph->versionInfo->hardwareMajor = version->hardwareMajor;
-  ph->versionInfo->hardwareMinor = version->hardwareMinor;
-  ph->versionInfo->uniqueId = version->uniqueId;
+  ph->versionInfo = *version;
 }
 
 int32_t HAL_GetREVPHSolenoids(HAL_REVPHHandle handle, int32_t* status) {

--- a/hal/src/main/native/athena/REVPH.cpp
+++ b/hal/src/main/native/athena/REVPH.cpp
@@ -224,6 +224,9 @@ HAL_REVPHHandle HAL_InitializeREVPH(int32_t module,
   hph->previousAllocation = allocationLocation ? allocationLocation : "";
   hph->hcan = hcan;
   hph->controlPeriod = kDefaultControlPeriod;
+  std::memset(&hph->desiredSolenoidsState, 0,
+              sizeof(hph->desiredSolenoidsState));
+  std::memset(&hph->versionInfo, 0, sizeof(hph->versionInfo));
 
   // Start closed-loop compressor control by starting solenoid state updates
   HAL_SendREVPHSolenoidsState(hph.get(), status);

--- a/wpilibc/src/main/native/cpp/PneumaticHub.cpp
+++ b/wpilibc/src/main/native/cpp/PneumaticHub.cpp
@@ -39,6 +39,15 @@ class PneumaticHub::DataStore {
     m_moduleObject = PneumaticHub{handle, module};
     m_moduleObject.m_dataStore =
         std::shared_ptr<DataStore>{this, wpi::NullDeleter<DataStore>()};
+
+    auto version = m_moduleObject.GetVersion();
+    if (version.FirmwareMajor > 0 && version.FirmwareMajor < 22) {
+      throw FRC_MakeError(
+          err::AssertionFailure,
+          "The Pneumatic Hub has firmware version {}.{}.{}, and must be "
+          "updated to version 2022.0.0 or later using the REV Hardware Client",
+          version.FirmwareMajor, version.FirmwareMinor, version.FirmwareFix);
+    }
   }
 
   ~DataStore() noexcept { HAL_FreeREVPH(m_moduleObject.m_handle); }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
@@ -27,6 +27,17 @@ public class PneumaticHub implements PneumaticsBase {
       m_handle = REVPHJNI.initialize(module);
       m_module = module;
       m_handleMap.put(module, this);
+
+      final REVPHVersion version = REVPHJNI.getVersion(m_handle);
+      if (version.firmwareMajor > 0 && version.firmwareMajor < 22) {
+        final String fwVersion =
+            version.firmwareMajor + "." + version.firmwareMinor + "." + version.firmwareFix;
+        throw new IllegalStateException(
+            "The Pneumatic Hub has firmware version "
+                + fwVersion
+                + ", and must be updated to version 2022.0.0 or later "
+                + "using the REV Hardware Client.");
+      }
     }
 
     @Override


### PR DESCRIPTION
For C++, I used the AssertionFailure error type, because I didn't whether I should add an additional value (like exists for the Jaguar), and if so, where that would belong in the file's order.