### PR TITLE
[wpilib] Make ADIS IMU classes unit-safe

### DIFF
--- a/wpilibc/src/main/native/cpp/simulation/ADIS16448_IMUSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/ADIS16448_IMUSim.cpp
@@ -14,9 +14,6 @@ ADIS16448_IMUSim::ADIS16448_IMUSim(const frc::ADIS16448_IMU& imu) {
   m_simGyroAngleX = deviceSim.GetDouble("gyro_angle_x");
   m_simGyroAngleY = deviceSim.GetDouble("gyro_angle_y");
   m_simGyroAngleZ = deviceSim.GetDouble("gyro_angle_z");
-  m_simGyroRateX = deviceSim.GetDouble("gyro_rate_x");
-  m_simGyroRateY = deviceSim.GetDouble("gyro_rate_y");
-  m_simGyroRateZ = deviceSim.GetDouble("gyro_rate_z");
   m_simAccelX = deviceSim.GetDouble("accel_x");
   m_simAccelY = deviceSim.GetDouble("accel_y");
   m_simAccelZ = deviceSim.GetDouble("accel_z");
@@ -34,26 +31,14 @@ void ADIS16448_IMUSim::SetGyroAngleZ(units::degree_t angle) {
   m_simGyroAngleZ.Set(angle.value());
 }
 
-void ADIS16448_IMUSim::SetGyroRateX(units::degrees_per_second_t rate) {
-  m_simGyroRateX.Set(rate.value());
-}
-
-void ADIS16448_IMUSim::SetGyroRateY(units::degrees_per_second_t rate) {
-  m_simGyroRateY.Set(rate.value());
-}
-
-void ADIS16448_IMUSim::SetGyroRateZ(units::degrees_per_second_t rate) {
-  m_simGyroRateZ.Set(rate.value());
-}
-
 void ADIS16448_IMUSim::SetAccelX(units::meters_per_second_squared_t accel) {
-  m_simAccelX.Set(accel.value() / 9.81);
+  m_simAccelX.Set(accel.value());
 }
 
 void ADIS16448_IMUSim::SetAccelY(units::meters_per_second_squared_t accel) {
-  m_simAccelY.Set(accel.value() / 9.81);
+  m_simAccelY.Set(accel.value());
 }
 
 void ADIS16448_IMUSim::SetAccelZ(units::meters_per_second_squared_t accel) {
-  m_simAccelZ.Set(accel.value() / 9.81);
+  m_simAccelZ.Set(accel.value());
 }

--- a/wpilibc/src/main/native/cpp/simulation/ADIS16470_IMUSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/ADIS16470_IMUSim.cpp
@@ -14,9 +14,6 @@ ADIS16470_IMUSim::ADIS16470_IMUSim(const frc::ADIS16470_IMU& imu) {
   m_simGyroAngleX = deviceSim.GetDouble("gyro_angle_x");
   m_simGyroAngleY = deviceSim.GetDouble("gyro_angle_y");
   m_simGyroAngleZ = deviceSim.GetDouble("gyro_angle_z");
-  m_simGyroRateX = deviceSim.GetDouble("gyro_rate_x");
-  m_simGyroRateY = deviceSim.GetDouble("gyro_rate_y");
-  m_simGyroRateZ = deviceSim.GetDouble("gyro_rate_z");
   m_simAccelX = deviceSim.GetDouble("accel_x");
   m_simAccelY = deviceSim.GetDouble("accel_y");
   m_simAccelZ = deviceSim.GetDouble("accel_z");
@@ -34,26 +31,14 @@ void ADIS16470_IMUSim::SetGyroAngleZ(units::degree_t angle) {
   m_simGyroAngleZ.Set(angle.value());
 }
 
-void ADIS16470_IMUSim::SetGyroRateX(units::degrees_per_second_t rate) {
-  m_simGyroRateX.Set(rate.value());
-}
-
-void ADIS16470_IMUSim::SetGyroRateY(units::degrees_per_second_t rate) {
-  m_simGyroRateY.Set(rate.value());
-}
-
-void ADIS16470_IMUSim::SetGyroRateZ(units::degrees_per_second_t rate) {
-  m_simGyroRateZ.Set(rate.value());
-}
-
 void ADIS16470_IMUSim::SetAccelX(units::meters_per_second_squared_t accel) {
-  m_simAccelX.Set(accel.value() / 9.81);
+  m_simAccelX.Set(accel.value());
 }
 
 void ADIS16470_IMUSim::SetAccelY(units::meters_per_second_squared_t accel) {
-  m_simAccelY.Set(accel.value() / 9.81);
+  m_simAccelY.Set(accel.value());
 }
 
 void ADIS16470_IMUSim::SetAccelZ(units::meters_per_second_squared_t accel) {
-  m_simAccelZ.Set(accel.value() / 9.81);
+  m_simAccelZ.Set(accel.value());
 }

--- a/wpilibc/src/main/native/include/frc/ADIS16470_IMU.h
+++ b/wpilibc/src/main/native/include/frc/ADIS16470_IMU.h
@@ -13,10 +13,6 @@
 
 #pragma once
 
-#include <frc/DigitalInput.h>
-#include <frc/DigitalOutput.h>
-#include <frc/DigitalSource.h>
-#include <frc/SPI.h>
 #include <stdint.h>
 
 #include <atomic>
@@ -25,9 +21,17 @@
 
 #include <hal/SimDevice.h>
 #include <networktables/NTSendable.h>
+#include <units/acceleration.h>
+#include <units/angle.h>
+#include <units/angular_velocity.h>
 #include <wpi/condition_variable.h>
 #include <wpi/mutex.h>
 #include <wpi/sendable/SendableHelper.h>
+
+#include "frc/DigitalInput.h"
+#include "frc/DigitalOutput.h"
+#include "frc/DigitalSource.h"
+#include "frc/SPI.h"
 
 namespace frc {
 /**
@@ -119,41 +123,32 @@ class ADIS16470_IMU : public nt::NTSendable,
   void Reset();
 
   /**
-   * @brief Returns the current integrated angle for the axis specified.
-   *
-   * The angle is based on the current accumulator value corrected by
-   * offset calibration and built-in IMU calibration. The angle is continuous,
-   * that is it will continue from 360->361 degrees. This allows algorithms
-   * that wouldn't want to see a discontinuity in the gyro output as it sweeps
-   * from 360 to 0 on the second time around. The axis returned by this
-   * function is adjusted based on the configured yaw_axis.
-   *
-   * @return the current heading of the robot in degrees. This heading is based
-   *         on integration of the returned rate from the gyro.
+   * Returns the yaw axis angle in degrees (CCW positive).
    */
-  double GetAngle() const;
+  units::degree_t GetAngle() const;
 
-  double GetRate() const;
+  /**
+   * Returns the acceleration in the X axis.
+   */
+  units::meters_per_second_squared_t GetAccelX() const;
 
-  double GetGyroRateX() const;
+  /**
+   * Returns the acceleration in the Y axis.
+   */
+  units::meters_per_second_squared_t GetAccelY() const;
 
-  double GetGyroRateY() const;
+  /**
+   * Returns the acceleration in the Z axis.
+   */
+  units::meters_per_second_squared_t GetAccelZ() const;
 
-  double GetGyroRateZ() const;
+  units::degree_t GetXComplementaryAngle() const;
 
-  double GetAccelX() const;
+  units::degree_t GetYComplementaryAngle() const;
 
-  double GetAccelY() const;
+  units::degree_t GetXFilteredAccelAngle() const;
 
-  double GetAccelZ() const;
-
-  double GetXComplementaryAngle() const;
-
-  double GetYComplementaryAngle() const;
-
-  double GetXFilteredAccelAngle() const;
-
-  double GetYFilteredAccelAngle() const;
+  units::degree_t GetYFilteredAccelAngle() const;
 
   IMUAxis GetYawAxis() const;
 
@@ -380,9 +375,6 @@ class ADIS16470_IMU : public nt::NTSendable,
   hal::SimDouble m_simGyroAngleX;
   hal::SimDouble m_simGyroAngleY;
   hal::SimDouble m_simGyroAngleZ;
-  hal::SimDouble m_simGyroRateX;
-  hal::SimDouble m_simGyroRateY;
-  hal::SimDouble m_simGyroRateZ;
   hal::SimDouble m_simAccelX;
   hal::SimDouble m_simAccelY;
   hal::SimDouble m_simAccelZ;

--- a/wpilibc/src/main/native/include/frc/simulation/ADIS16448_IMUSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/ADIS16448_IMUSim.h
@@ -49,27 +49,6 @@ class ADIS16448_IMUSim {
   void SetGyroAngleZ(units::degree_t angle);
 
   /**
-   * Sets the X axis angular rate (CCW positive).
-   *
-   * @param rate The angular rate.
-   */
-  void SetGyroRateX(units::degrees_per_second_t rate);
-
-  /**
-   * Sets the Y axis angular rate (CCW positive).
-   *
-   * @param rate The angular rate.
-   */
-  void SetGyroRateY(units::degrees_per_second_t rate);
-
-  /**
-   * Sets the Z axis angular rate (CCW positive).
-   *
-   * @param rate The angular rate.
-   */
-  void SetGyroRateZ(units::degrees_per_second_t rate);
-
-  /**
    * Sets the X axis acceleration.
    *
    * @param accel The acceleration.
@@ -94,9 +73,6 @@ class ADIS16448_IMUSim {
   hal::SimDouble m_simGyroAngleX;
   hal::SimDouble m_simGyroAngleY;
   hal::SimDouble m_simGyroAngleZ;
-  hal::SimDouble m_simGyroRateX;
-  hal::SimDouble m_simGyroRateY;
-  hal::SimDouble m_simGyroRateZ;
   hal::SimDouble m_simAccelX;
   hal::SimDouble m_simAccelY;
   hal::SimDouble m_simAccelZ;

--- a/wpilibc/src/main/native/include/frc/simulation/ADIS16470_IMUSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/ADIS16470_IMUSim.h
@@ -49,27 +49,6 @@ class ADIS16470_IMUSim {
   void SetGyroAngleZ(units::degree_t angle);
 
   /**
-   * Sets the X axis angular rate (CCW positive).
-   *
-   * @param rate The angular rate.
-   */
-  void SetGyroRateX(units::degrees_per_second_t rate);
-
-  /**
-   * Sets the Y axis angular rate (CCW positive).
-   *
-   * @param rate The angular rate.
-   */
-  void SetGyroRateY(units::degrees_per_second_t rate);
-
-  /**
-   * Sets the Z axis angular rate (CCW positive).
-   *
-   * @param rate The angular rate.
-   */
-  void SetGyroRateZ(units::degrees_per_second_t rate);
-
-  /**
    * Sets the X axis acceleration.
    *
    * @param accel The acceleration.
@@ -94,9 +73,6 @@ class ADIS16470_IMUSim {
   hal::SimDouble m_simGyroAngleX;
   hal::SimDouble m_simGyroAngleY;
   hal::SimDouble m_simGyroAngleZ;
-  hal::SimDouble m_simGyroRateX;
-  hal::SimDouble m_simGyroRateY;
-  hal::SimDouble m_simGyroRateZ;
   hal::SimDouble m_simAccelX;
   hal::SimDouble m_simAccelY;
   hal::SimDouble m_simAccelZ;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADIS16448_IMUSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADIS16448_IMUSim.java
@@ -13,9 +13,6 @@ public class ADIS16448_IMUSim {
   private final SimDouble m_simGyroAngleX;
   private final SimDouble m_simGyroAngleY;
   private final SimDouble m_simGyroAngleZ;
-  private final SimDouble m_simGyroRateX;
-  private final SimDouble m_simGyroRateY;
-  private final SimDouble m_simGyroRateZ;
   private final SimDouble m_simAccelX;
   private final SimDouble m_simAccelY;
   private final SimDouble m_simAccelZ;
@@ -30,16 +27,13 @@ public class ADIS16448_IMUSim {
     m_simGyroAngleX = wrappedSimDevice.getDouble("gyro_angle_x");
     m_simGyroAngleY = wrappedSimDevice.getDouble("gyro_angle_y");
     m_simGyroAngleZ = wrappedSimDevice.getDouble("gyro_angle_z");
-    m_simGyroRateX = wrappedSimDevice.getDouble("gyro_rate_x");
-    m_simGyroRateY = wrappedSimDevice.getDouble("gyro_rate_y");
-    m_simGyroRateZ = wrappedSimDevice.getDouble("gyro_rate_z");
     m_simAccelX = wrappedSimDevice.getDouble("accel_x");
     m_simAccelY = wrappedSimDevice.getDouble("accel_y");
     m_simAccelZ = wrappedSimDevice.getDouble("accel_z");
   }
 
   /**
-   * Sets the X axis angle (CCW positive).
+   * Sets the X axis angle in degrees (CCW positive).
    *
    * @param angleDegrees The angle.
    */
@@ -48,7 +42,7 @@ public class ADIS16448_IMUSim {
   }
 
   /**
-   * Sets the Y axis angle (CCW positive).
+   * Sets the Y axis angle in degrees (CCW positive).
    *
    * @param angleDegrees The angle.
    */
@@ -57,7 +51,7 @@ public class ADIS16448_IMUSim {
   }
 
   /**
-   * Sets the Z axis angle (CCW positive).
+   * Sets the Z axis angle in degrees (CCW positive).
    *
    * @param angleDegrees The angle.
    */
@@ -66,56 +60,29 @@ public class ADIS16448_IMUSim {
   }
 
   /**
-   * Sets the X axis angular rate (CCW positive).
+   * Sets the X axis acceleration in meters per second squared.
    *
-   * @param rateDegreesPerSecond The angular rate.
+   * @param accelMetersPerSecondSquared The acceleration.
    */
-  public void setGyroRateX(double rateDegreesPerSecond) {
-    m_simGyroRateX.set(rateDegreesPerSecond);
+  public void setAccelX(double accelMetersPerSecondSquared) {
+    m_simAccelX.set(accelMetersPerSecondSquared);
   }
 
   /**
-   * Sets the Y axis angular rate (CCW positive).
+   * Sets the Y axis acceleration in meters per second squared.
    *
-   * @param rateDegreesPerSecond The angular rate.
+   * @param accelMetersPerSecondSquared The acceleration.
    */
-  public void setGyroRateY(double rateDegreesPerSecond) {
-    m_simGyroRateY.set(rateDegreesPerSecond);
+  public void setAccelY(double accelMetersPerSecondSquared) {
+    m_simAccelY.set(accelMetersPerSecondSquared);
   }
 
   /**
-   * Sets the Z axis angular rate (CCW positive).
+   * Sets the Z axis acceleration in meters per second squared.
    *
-   * @param rateDegreesPerSecond The angular rate.
+   * @param accelMetersPerSecondSquared The acceleration.
    */
-  public void setGyroRateZ(double rateDegreesPerSecond) {
-    m_simGyroRateZ.set(rateDegreesPerSecond);
-  }
-
-  /**
-   * Sets the X axis acceleration.
-   *
-   * @param accelMetersPerSecond The acceleration.
-   */
-  public void setAccelX(double accelMetersPerSecond) {
-    m_simAccelX.set(accelMetersPerSecond / 9.81);
-  }
-
-  /**
-   * Sets the Y axis acceleration.
-   *
-   * @param accelMetersPerSecond The acceleration.
-   */
-  public void setAccelY(double accelMetersPerSecond) {
-    m_simAccelY.set(accelMetersPerSecond / 9.81);
-  }
-
-  /**
-   * Sets the Z axis acceleration.
-   *
-   * @param accelMetersPerSecond The acceleration.
-   */
-  public void setAccelZ(double accelMetersPerSecond) {
-    m_simAccelZ.set(accelMetersPerSecond / 9.81);
+  public void setAccelZ(double accelMetersPerSecondSquared) {
+    m_simAccelZ.set(accelMetersPerSecondSquared);
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADIS16470_IMUSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADIS16470_IMUSim.java
@@ -13,9 +13,6 @@ public class ADIS16470_IMUSim {
   private final SimDouble m_simGyroAngleX;
   private final SimDouble m_simGyroAngleY;
   private final SimDouble m_simGyroAngleZ;
-  private final SimDouble m_simGyroRateX;
-  private final SimDouble m_simGyroRateY;
-  private final SimDouble m_simGyroRateZ;
   private final SimDouble m_simAccelX;
   private final SimDouble m_simAccelY;
   private final SimDouble m_simAccelZ;
@@ -30,16 +27,13 @@ public class ADIS16470_IMUSim {
     m_simGyroAngleX = wrappedSimDevice.getDouble("gyro_angle_x");
     m_simGyroAngleY = wrappedSimDevice.getDouble("gyro_angle_y");
     m_simGyroAngleZ = wrappedSimDevice.getDouble("gyro_angle_z");
-    m_simGyroRateX = wrappedSimDevice.getDouble("gyro_rate_x");
-    m_simGyroRateY = wrappedSimDevice.getDouble("gyro_rate_y");
-    m_simGyroRateZ = wrappedSimDevice.getDouble("gyro_rate_z");
     m_simAccelX = wrappedSimDevice.getDouble("accel_x");
     m_simAccelY = wrappedSimDevice.getDouble("accel_y");
     m_simAccelZ = wrappedSimDevice.getDouble("accel_z");
   }
 
   /**
-   * Sets the X axis angle (CCW positive).
+   * Sets the X axis angle in degrees (CCW positive).
    *
    * @param angleDegrees The angle.
    */
@@ -48,7 +42,7 @@ public class ADIS16470_IMUSim {
   }
 
   /**
-   * Sets the Y axis angle (CCW positive).
+   * Sets the Y axis angle in degrees (CCW positive).
    *
    * @param angleDegrees The angle.
    */
@@ -57,7 +51,7 @@ public class ADIS16470_IMUSim {
   }
 
   /**
-   * Sets the Z axis angle (CCW positive).
+   * Sets the Z axis angle in degrees (CCW positive).
    *
    * @param angleDegrees The angle.
    */
@@ -66,56 +60,29 @@ public class ADIS16470_IMUSim {
   }
 
   /**
-   * Sets the X axis angular rate (CCW positive).
+   * Sets the X axis acceleration in meters per second squared.
    *
-   * @param rateDegreesPerSecond The angular rate.
+   * @param accelMetersPerSecondSquared The acceleration.
    */
-  public void setGyroRateX(double rateDegreesPerSecond) {
-    m_simGyroRateX.set(rateDegreesPerSecond);
+  public void setAccelX(double accelMetersPerSecondSquared) {
+    m_simAccelX.set(accelMetersPerSecondSquared);
   }
 
   /**
-   * Sets the Y axis angular rate (CCW positive).
+   * Sets the Y axis acceleration in meters per second squared.
    *
-   * @param rateDegreesPerSecond The angular rate.
+   * @param accelMetersPerSecondSquared The acceleration.
    */
-  public void setGyroRateY(double rateDegreesPerSecond) {
-    m_simGyroRateY.set(rateDegreesPerSecond);
+  public void setAccelY(double accelMetersPerSecondSquared) {
+    m_simAccelY.set(accelMetersPerSecondSquared);
   }
 
   /**
-   * Sets the Z axis angular rate (CCW positive).
+   * Sets the Z axis acceleration in meters per second squared.
    *
-   * @param rateDegreesPerSecond The angular rate.
+   * @param accelMetersPerSecondSquared The acceleration.
    */
-  public void setGyroRateZ(double rateDegreesPerSecond) {
-    m_simGyroRateZ.set(rateDegreesPerSecond);
-  }
-
-  /**
-   * Sets the X axis acceleration.
-   *
-   * @param accelMetersPerSecond The acceleration.
-   */
-  public void setAccelX(double accelMetersPerSecond) {
-    m_simAccelX.set(accelMetersPerSecond / 9.81);
-  }
-
-  /**
-   * Sets the Y axis acceleration.
-   *
-   * @param accelMetersPerSecond The acceleration.
-   */
-  public void setAccelY(double accelMetersPerSecond) {
-    m_simAccelY.set(accelMetersPerSecond / 9.81);
-  }
-
-  /**
-   * Sets the Z axis acceleration.
-   *
-   * @param accelMetersPerSecond The acceleration.
-   */
-  public void setAccelZ(double accelMetersPerSecond) {
-    m_simAccelZ.set(accelMetersPerSecond / 9.81);
+  public void setAccelZ(double accelMetersPerSecondSquared) {
+    m_simAccelZ.set(accelMetersPerSecondSquared);
   }
 }


### PR DESCRIPTION
The gyro rate getters were removed since that data isn't available. The "instant" data was actually unfiltered changes in angle.