### PR TITLE
[templates] Change the template ordering to put command based first

### DIFF
--- a/wpilibcExamples/src/main/cpp/templates/templates.json
+++ b/wpilibcExamples/src/main/cpp/templates/templates.json
@@ -1,5 +1,15 @@
 [
   {
+    "name": "Command Robot",
+    "description": "Command style",
+    "tags": [
+      "Command"
+    ],
+    "foldername": "commandbased",
+    "gradlebase": "cpp",
+    "commandversion": 2
+  },
+  {
     "name": "Timed Robot",
     "description": "Timed style",
     "tags": [
@@ -30,13 +40,13 @@
     "commandversion": 2
   },
   {
-    "name": "Command Robot",
-    "description": "Command style",
+    "name": "Romi - Command Robot",
+    "description": "Romi - Command style",
     "tags": [
-      "Command"
+      "Command", "Romi"
     ],
     "foldername": "commandbased",
-    "gradlebase": "cpp",
+    "gradlebase": "cppromi",
     "commandversion": 2
   },
   {
@@ -46,16 +56,6 @@
       "Timed", "Romi"
     ],
     "foldername": "timed",
-    "gradlebase": "cppromi",
-    "commandversion": 2
-  },
-  {
-    "name": "Romi - Command Robot",
-    "description": "Romi - Command style",
-    "tags": [
-      "Command", "Romi"
-    ],
-    "foldername": "commandbased",
     "gradlebase": "cppromi",
     "commandversion": 2
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/templates.json
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/templates/templates.json
@@ -1,5 +1,16 @@
 [
   {
+    "name": "Command Robot",
+    "description": "Command style",
+    "tags": [
+      "Command"
+    ],
+    "foldername": "commandbased",
+    "gradlebase": "java",
+    "mainclass": "Main",
+    "commandversion": 2
+  },
+  {
     "name": "Timed Robot",
     "description": "Timed style",
     "tags": [
@@ -35,13 +46,14 @@
     "commandversion": 2
   },
   {
-    "name": "Command Robot",
-    "description": "Command style",
+    "name": "Romi - Command Robot",
+    "description": "Romi - Command style",
     "tags": [
-      "Command"
+      "Command",
+      "Romi"
     ],
-    "foldername": "commandbased",
-    "gradlebase": "java",
+    "foldername": "romicommandbased",
+    "gradlebase": "javaromi",
     "mainclass": "Main",
     "commandversion": 2
   },
@@ -53,18 +65,6 @@
       "Romi"
     ],
     "foldername": "romitimed",
-    "gradlebase": "javaromi",
-    "mainclass": "Main",
-    "commandversion": 2
-  },
-  {
-    "name": "Romi - Command Robot",
-    "description": "Romi - Command style",
-    "tags": [
-      "Command",
-      "Romi"
-    ],
-    "foldername": "romicommandbased",
     "gradlebase": "javaromi",
     "mainclass": "Main",
     "commandversion": 2


### PR DESCRIPTION
Previously it was a bit buried (listed after the advanced skeletons).