### PR TITLE
[wpilib] Add GetRate() to ADIS classes

### DIFF
--- a/wpilibc/src/main/native/cpp/simulation/ADIS16448_IMUSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/ADIS16448_IMUSim.cpp
@@ -14,6 +14,9 @@ ADIS16448_IMUSim::ADIS16448_IMUSim(const frc::ADIS16448_IMU& imu) {
   m_simGyroAngleX = deviceSim.GetDouble("gyro_angle_x");
   m_simGyroAngleY = deviceSim.GetDouble("gyro_angle_y");
   m_simGyroAngleZ = deviceSim.GetDouble("gyro_angle_z");
+  m_simGyroRateX = deviceSim.GetDouble("gyro_rate_x");
+  m_simGyroRateY = deviceSim.GetDouble("gyro_rate_y");
+  m_simGyroRateZ = deviceSim.GetDouble("gyro_rate_z");
   m_simAccelX = deviceSim.GetDouble("accel_x");
   m_simAccelY = deviceSim.GetDouble("accel_y");
   m_simAccelZ = deviceSim.GetDouble("accel_z");
@@ -29,6 +32,18 @@ void ADIS16448_IMUSim::SetGyroAngleY(units::degree_t angle) {
 
 void ADIS16448_IMUSim::SetGyroAngleZ(units::degree_t angle) {
   m_simGyroAngleZ.Set(angle.value());
+}
+
+void ADIS16448_IMUSim::SetGyroRateX(units::degrees_per_second_t angularRate) {
+  m_simGyroRateX.Set(angularRate.value());
+}
+
+void ADIS16448_IMUSim::SetGyroRateY(units::degrees_per_second_t angularRate) {
+  m_simGyroRateY.Set(angularRate.value());
+}
+
+void ADIS16448_IMUSim::SetGyroRateZ(units::degrees_per_second_t angularRate) {
+  m_simGyroRateZ.Set(angularRate.value());
 }
 
 void ADIS16448_IMUSim::SetAccelX(units::meters_per_second_squared_t accel) {

--- a/wpilibc/src/main/native/cpp/simulation/ADIS16470_IMUSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/ADIS16470_IMUSim.cpp
@@ -14,6 +14,9 @@ ADIS16470_IMUSim::ADIS16470_IMUSim(const frc::ADIS16470_IMU& imu) {
   m_simGyroAngleX = deviceSim.GetDouble("gyro_angle_x");
   m_simGyroAngleY = deviceSim.GetDouble("gyro_angle_y");
   m_simGyroAngleZ = deviceSim.GetDouble("gyro_angle_z");
+  m_simGyroRateX = deviceSim.GetDouble("gyro_rate_x");
+  m_simGyroRateY = deviceSim.GetDouble("gyro_rate_y");
+  m_simGyroRateZ = deviceSim.GetDouble("gyro_rate_z");
   m_simAccelX = deviceSim.GetDouble("accel_x");
   m_simAccelY = deviceSim.GetDouble("accel_y");
   m_simAccelZ = deviceSim.GetDouble("accel_z");
@@ -29,6 +32,18 @@ void ADIS16470_IMUSim::SetGyroAngleY(units::degree_t angle) {
 
 void ADIS16470_IMUSim::SetGyroAngleZ(units::degree_t angle) {
   m_simGyroAngleZ.Set(angle.value());
+}
+
+void ADIS16470_IMUSim::SetGyroRateX(units::degrees_per_second_t angularRate) {
+  m_simGyroRateX.Set(angularRate.value());
+}
+
+void ADIS16470_IMUSim::SetGyroRateY(units::degrees_per_second_t angularRate) {
+  m_simGyroRateY.Set(angularRate.value());
+}
+
+void ADIS16470_IMUSim::SetGyroRateZ(units::degrees_per_second_t angularRate) {
+  m_simGyroRateZ.Set(angularRate.value());
 }
 
 void ADIS16470_IMUSim::SetAccelX(units::meters_per_second_squared_t accel) {

--- a/wpilibc/src/main/native/include/frc/ADIS16448_IMU.h
+++ b/wpilibc/src/main/native/include/frc/ADIS16448_IMU.h
@@ -134,6 +134,11 @@ class ADIS16448_IMU : public nt::NTSendable,
   units::degree_t GetAngle() const;
 
   /**
+   * Returns the yaw axis angular rate in degrees per second (CCW positive).
+   */
+  units::degrees_per_second_t GetRate() const;
+
+  /**
    * Returns the accumulated gyro angle in the X axis.
    */
   units::degree_t GetGyroAngleX() const;
@@ -147,6 +152,21 @@ class ADIS16448_IMU : public nt::NTSendable,
    * Returns the accumulated gyro angle in the Z axis.
    */
   units::degree_t GetGyroAngleZ() const;
+
+  /**
+   * Returns the angular rate in the X axis.
+   */
+  units::degrees_per_second_t GetGyroRateX() const;
+
+  /**
+   * Returns the angular rate in the Y axis.
+   */
+  units::degrees_per_second_t GetGyroRateY() const;
+
+  /**
+   * Returns the angular rate in the Z axis.
+   */
+  units::degrees_per_second_t GetGyroRateZ() const;
 
   /**
    * Returns the acceleration in the X axis.
@@ -259,10 +279,10 @@ class ADIS16448_IMU : public nt::NTSendable,
   static constexpr double grav = 9.81;
 
   /** @brief struct to store offset data */
-  struct offset_data {
-    double m_accum_gyro_x = 0.0;
-    double m_accum_gyro_y = 0.0;
-    double m_accum_gyro_z = 0.0;
+  struct OffsetData {
+    double gyro_rate_x = 0.0;
+    double gyro_rate_y = 0.0;
+    double gyro_rate_z = 0.0;
   };
 
   bool SwitchToStandardSPI();
@@ -281,9 +301,9 @@ class ADIS16448_IMU : public nt::NTSendable,
   IMUAxis m_yaw_axis;
 
   // Last read values (post-scaling)
-  double m_gyro_x = 0.0;
-  double m_gyro_y = 0.0;
-  double m_gyro_z = 0.0;
+  double m_gyro_rate_x = 0.0;
+  double m_gyro_rate_y = 0.0;
+  double m_gyro_rate_z = 0.0;
   double m_accel_x = 0.0;
   double m_accel_y = 0.0;
   double m_accel_z = 0.0;
@@ -299,11 +319,11 @@ class ADIS16448_IMU : public nt::NTSendable,
   double m_compAngleX, m_compAngleY, m_accelAngleX, m_accelAngleY = 0.0;
 
   // vector for storing most recent imu values
-  offset_data* m_offset_buffer = nullptr;
+  OffsetData* m_offset_buffer = nullptr;
 
-  double m_gyro_offset_x = 0.0;
-  double m_gyro_offset_y = 0.0;
-  double m_gyro_offset_z = 0.0;
+  double m_gyro_rate_offset_x = 0.0;
+  double m_gyro_rate_offset_y = 0.0;
+  double m_gyro_rate_offset_z = 0.0;
 
   // function to re-init offset buffer
   void InitOffsetBuffer(int size);
@@ -313,9 +333,9 @@ class ADIS16448_IMU : public nt::NTSendable,
   int m_accum_count = 0;
 
   // Integrated gyro values
-  double m_integ_gyro_x = 0.0;
-  double m_integ_gyro_y = 0.0;
-  double m_integ_gyro_z = 0.0;
+  double m_integ_gyro_angle_x = 0.0;
+  double m_integ_gyro_angle_y = 0.0;
+  double m_integ_gyro_angle_z = 0.0;
 
   // Complementary filter functions
   double FormatFastConverge(double compAngle, double accAngle);
@@ -344,6 +364,9 @@ class ADIS16448_IMU : public nt::NTSendable,
   hal::SimDouble m_simGyroAngleX;
   hal::SimDouble m_simGyroAngleY;
   hal::SimDouble m_simGyroAngleZ;
+  hal::SimDouble m_simGyroRateX;
+  hal::SimDouble m_simGyroRateY;
+  hal::SimDouble m_simGyroRateZ;
   hal::SimDouble m_simAccelX;
   hal::SimDouble m_simAccelY;
   hal::SimDouble m_simAccelZ;

--- a/wpilibc/src/main/native/include/frc/ADIS16470_IMU.h
+++ b/wpilibc/src/main/native/include/frc/ADIS16470_IMU.h
@@ -128,6 +128,11 @@ class ADIS16470_IMU : public nt::NTSendable,
   units::degree_t GetAngle() const;
 
   /**
+   * Returns the yaw axis angular rate in degrees per second (CCW positive).
+   */
+  units::degrees_per_second_t GetRate() const;
+
+  /**
    * Returns the acceleration in the X axis.
    */
   units::meters_per_second_squared_t GetAccelX() const;
@@ -342,7 +347,12 @@ class ADIS16470_IMU : public nt::NTSendable,
   double m_integ_angle = 0.0;
 
   // Instant raw outputs
-  double m_gyro_x, m_gyro_y, m_gyro_z, m_accel_x, m_accel_y, m_accel_z = 0.0;
+  double m_gyro_rate_x = 0.0;
+  double m_gyro_rate_y = 0.0;
+  double m_gyro_rate_z = 0.0;
+  double m_accel_x = 0.0;
+  double m_accel_y = 0.0;
+  double m_accel_z = 0.0;
 
   // Complementary filter variables
   double m_tau = 1.0;
@@ -375,6 +385,9 @@ class ADIS16470_IMU : public nt::NTSendable,
   hal::SimDouble m_simGyroAngleX;
   hal::SimDouble m_simGyroAngleY;
   hal::SimDouble m_simGyroAngleZ;
+  hal::SimDouble m_simGyroRateX;
+  hal::SimDouble m_simGyroRateY;
+  hal::SimDouble m_simGyroRateZ;
   hal::SimDouble m_simAccelX;
   hal::SimDouble m_simAccelY;
   hal::SimDouble m_simAccelZ;

--- a/wpilibc/src/main/native/include/frc/simulation/ADIS16448_IMUSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/ADIS16448_IMUSim.h
@@ -49,6 +49,27 @@ class ADIS16448_IMUSim {
   void SetGyroAngleZ(units::degree_t angle);
 
   /**
+   * Sets the X axis angular rate (CCW positive).
+   *
+   * @param angularRate The angular rate.
+   */
+  void SetGyroRateX(units::degrees_per_second_t angularRate);
+
+  /**
+   * Sets the Y axis angular rate (CCW positive).
+   *
+   * @param angularRate The angular rate.
+   */
+  void SetGyroRateY(units::degrees_per_second_t angularRate);
+
+  /**
+   * Sets the Z axis angular rate (CCW positive).
+   *
+   * @param angularRate The angular rate.
+   */
+  void SetGyroRateZ(units::degrees_per_second_t angularRate);
+
+  /**
    * Sets the X axis acceleration.
    *
    * @param accel The acceleration.
@@ -73,6 +94,9 @@ class ADIS16448_IMUSim {
   hal::SimDouble m_simGyroAngleX;
   hal::SimDouble m_simGyroAngleY;
   hal::SimDouble m_simGyroAngleZ;
+  hal::SimDouble m_simGyroRateX;
+  hal::SimDouble m_simGyroRateY;
+  hal::SimDouble m_simGyroRateZ;
   hal::SimDouble m_simAccelX;
   hal::SimDouble m_simAccelY;
   hal::SimDouble m_simAccelZ;

--- a/wpilibc/src/main/native/include/frc/simulation/ADIS16470_IMUSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/ADIS16470_IMUSim.h
@@ -49,6 +49,27 @@ class ADIS16470_IMUSim {
   void SetGyroAngleZ(units::degree_t angle);
 
   /**
+   * Sets the X axis angular rate (CCW positive).
+   *
+   * @param angularRate The angular rate.
+   */
+  void SetGyroRateX(units::degrees_per_second_t angularRate);
+
+  /**
+   * Sets the Y axis angular rate (CCW positive).
+   *
+   * @param angularRate The angular rate.
+   */
+  void SetGyroRateY(units::degrees_per_second_t angularRate);
+
+  /**
+   * Sets the Z axis angular rate (CCW positive).
+   *
+   * @param angularRate The angular rate.
+   */
+  void SetGyroRateZ(units::degrees_per_second_t angularRate);
+
+  /**
    * Sets the X axis acceleration.
    *
    * @param accel The acceleration.
@@ -73,6 +94,9 @@ class ADIS16470_IMUSim {
   hal::SimDouble m_simGyroAngleX;
   hal::SimDouble m_simGyroAngleY;
   hal::SimDouble m_simGyroAngleZ;
+  hal::SimDouble m_simGyroRateX;
+  hal::SimDouble m_simGyroRateY;
+  hal::SimDouble m_simGyroRateZ;
   hal::SimDouble m_simAccelX;
   hal::SimDouble m_simAccelY;
   hal::SimDouble m_simAccelZ;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADIS16448_IMUSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADIS16448_IMUSim.java
@@ -13,6 +13,9 @@ public class ADIS16448_IMUSim {
   private final SimDouble m_simGyroAngleX;
   private final SimDouble m_simGyroAngleY;
   private final SimDouble m_simGyroAngleZ;
+  private final SimDouble m_simGyroRateX;
+  private final SimDouble m_simGyroRateY;
+  private final SimDouble m_simGyroRateZ;
   private final SimDouble m_simAccelX;
   private final SimDouble m_simAccelY;
   private final SimDouble m_simAccelZ;
@@ -27,6 +30,9 @@ public class ADIS16448_IMUSim {
     m_simGyroAngleX = wrappedSimDevice.getDouble("gyro_angle_x");
     m_simGyroAngleY = wrappedSimDevice.getDouble("gyro_angle_y");
     m_simGyroAngleZ = wrappedSimDevice.getDouble("gyro_angle_z");
+    m_simGyroRateX = wrappedSimDevice.getDouble("gyro_rate_x");
+    m_simGyroRateY = wrappedSimDevice.getDouble("gyro_rate_y");
+    m_simGyroRateZ = wrappedSimDevice.getDouble("gyro_rate_z");
     m_simAccelX = wrappedSimDevice.getDouble("accel_x");
     m_simAccelY = wrappedSimDevice.getDouble("accel_y");
     m_simAccelZ = wrappedSimDevice.getDouble("accel_z");
@@ -57,6 +63,33 @@ public class ADIS16448_IMUSim {
    */
   public void setGyroAngleZ(double angleDegrees) {
     m_simGyroAngleZ.set(angleDegrees);
+  }
+
+  /**
+   * Sets the X axis angle in degrees per second (CCW positive).
+   *
+   * @param angularRateDegreesPerSecond The angular rate.
+   */
+  public void setGyroRateX(double angularRateDegreesPerSecond) {
+    m_simGyroRateX.set(angularRateDegreesPerSecond);
+  }
+
+  /**
+   * Sets the Y axis angle in degrees per second (CCW positive).
+   *
+   * @param angularRateDegreesPerSecond The angular rate.
+   */
+  public void setGyroRateY(double angularRateDegreesPerSecond) {
+    m_simGyroRateY.set(angularRateDegreesPerSecond);
+  }
+
+  /**
+   * Sets the Z axis angle in degrees per second (CCW positive).
+   *
+   * @param angularRateDegreesPerSecond The angular rate.
+   */
+  public void setGyroRateZ(double angularRateDegreesPerSecond) {
+    m_simGyroRateZ.set(angularRateDegreesPerSecond);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADIS16470_IMUSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADIS16470_IMUSim.java
@@ -13,6 +13,9 @@ public class ADIS16470_IMUSim {
   private final SimDouble m_simGyroAngleX;
   private final SimDouble m_simGyroAngleY;
   private final SimDouble m_simGyroAngleZ;
+  private final SimDouble m_simGyroRateX;
+  private final SimDouble m_simGyroRateY;
+  private final SimDouble m_simGyroRateZ;
   private final SimDouble m_simAccelX;
   private final SimDouble m_simAccelY;
   private final SimDouble m_simAccelZ;
@@ -27,6 +30,9 @@ public class ADIS16470_IMUSim {
     m_simGyroAngleX = wrappedSimDevice.getDouble("gyro_angle_x");
     m_simGyroAngleY = wrappedSimDevice.getDouble("gyro_angle_y");
     m_simGyroAngleZ = wrappedSimDevice.getDouble("gyro_angle_z");
+    m_simGyroRateX = wrappedSimDevice.getDouble("gyro_rate_x");
+    m_simGyroRateY = wrappedSimDevice.getDouble("gyro_rate_y");
+    m_simGyroRateZ = wrappedSimDevice.getDouble("gyro_rate_z");
     m_simAccelX = wrappedSimDevice.getDouble("accel_x");
     m_simAccelY = wrappedSimDevice.getDouble("accel_y");
     m_simAccelZ = wrappedSimDevice.getDouble("accel_z");
@@ -57,6 +63,33 @@ public class ADIS16470_IMUSim {
    */
   public void setGyroAngleZ(double angleDegrees) {
     m_simGyroAngleZ.set(angleDegrees);
+  }
+
+  /**
+   * Sets the X axis angle in degrees per second (CCW positive).
+   *
+   * @param angularRateDegreesPerSecond The angular rate.
+   */
+  public void setGyroRateX(double angularRateDegreesPerSecond) {
+    m_simGyroRateX.set(angularRateDegreesPerSecond);
+  }
+
+  /**
+   * Sets the Y axis angle in degrees per second (CCW positive).
+   *
+   * @param angularRateDegreesPerSecond The angular rate.
+   */
+  public void setGyroRateY(double angularRateDegreesPerSecond) {
+    m_simGyroRateY.set(angularRateDegreesPerSecond);
+  }
+
+  /**
+   * Sets the Z axis angle in degrees per second (CCW positive).
+   *
+   * @param angularRateDegreesPerSecond The angular rate.
+   */
+  public void setGyroRateZ(double angularRateDegreesPerSecond) {
+    m_simGyroRateZ.set(angularRateDegreesPerSecond);
   }
 
   /**


### PR DESCRIPTION
The angular rate is treated somewhat like an angle during calibration,
but the datasheet says it's angular rate. The variables were renamed to
make this clearer.