### PR TITLE
[build] cmake: Move fieldImages to WITH_GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,6 @@ if (WITH_TESTS)
     include(GoogleTest)
 endif()
 
-add_subdirectory(fieldImages)
 add_subdirectory(wpiutil)
 add_subdirectory(ntcore)
 
@@ -256,6 +255,7 @@ if (WITH_WPIMATH)
 endif()
 
 if (WITH_GUI)
+    add_subdirectory(fieldImages)
     add_subdirectory(imgui)
     add_subdirectory(wpigui)
     add_subdirectory(glass)


### PR DESCRIPTION
This will only ever be used by GUI applications, and the jar build
method it uses can misbehave in some cross-compile scenarios.