### PR TITLE
[field images] Fixing maven publishing

### DIFF
--- a/fieldImages/build.gradle
+++ b/fieldImages/build.gradle
@@ -15,10 +15,14 @@ if (!project.hasProperty('onlylinuxathena') && !project.hasProperty('onlylinuxra
 
     ext {
         nativeName = 'fieldImages'
+        baseId = nativeName
+        groupId = 'edu.wpi.first.fieldImages'
+        devMain = "edu.wpi.first.fieldImages.DevMain"
     }
 
     apply from: "${rootDir}/shared/resources.gradle"
     apply from: "${rootDir}/shared/config.gradle"
+    apply from: "${rootDir}/shared/java/javacommon.gradle"
 
     def generateTask = createGenerateResourcesTask('main', 'FIELDS', 'fields', project)
 

--- a/fieldImages/publish.gradle
+++ b/fieldImages/publish.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'maven-publish'
 
-def baseArtifactId = 'fieldImages'
-def artifactGroupId = 'edu.wpi.first.fieldImages'
-def zipBaseName = '_GROUP_edu_wpi_first_field_images_ID_CLS'
+def baseArtifactId = project.nativeName
+def artifactGroupId = project.groupId
+def cppZipBaseName = "_GROUP_edu_wpi_first_fieldIimages_ID_${baseArtifactId}-cpp_CLS"
 
 def outputsFolder = file("$project.buildDir/outputs")
 
 task cppSourcesZip(type: Zip) {
     destinationDirectory = outputsFolder
-    archiveBaseName = zipBaseName
+    archiveBaseName = cppZipBaseName
     classifier = "sources"
 
     from(licenseFile) {
@@ -25,7 +25,7 @@ task cppSourcesZip(type: Zip) {
 
 task cppHeadersZip(type: Zip) {
     destinationDirectory = outputsFolder
-    archiveBaseName = zipBaseName
+    archiveBaseName = cppZipBaseName
     classifier = "headers"
 
     from(licenseFile) {
@@ -51,7 +51,7 @@ addTaskToCopyAllOutputs(cppSourcesZip)
 
 model {
     publishing {
-        def wpilibCTaskList = createComponentZipTasks($.components, ['fieldImages'], zipBaseName, Zip, project, includeStandardZipFormat)
+        def wpilibCTaskList = createComponentZipTasks($.components, ['fieldImages'], cppZipBaseName, Zip, project, includeStandardZipFormat)
 
         publications {
             cpp(MavenPublication) {
@@ -62,7 +62,7 @@ model {
                 artifact cppHeadersZip
                 artifact cppSourcesZip
 
-                artifactId = baseArtifactId
+                artifactId = "${baseArtifactId}-cpp"
                 groupId artifactGroupId
                 version wpilibVersioning.version.get()
             }


### PR DESCRIPTION
The C++ version of the field image library had some naming problems which caused it not to get picked up by the combination process, and the java version was never actually published to maven / artifactor. My bad.