### PR TITLE
[wpiutil] Fix wpi::array for move-only types

### DIFF
--- a/wpiutil/src/main/native/include/wpi/array.h
+++ b/wpiutil/src/main/native/include/wpi/array.h
@@ -18,8 +18,8 @@ constexpr empty_array_t empty_array;
  * This class is a wrapper around std::array that does compile time size
  * checking.
  *
- * std::array's implicit constructor can lead result in uninitialized elements
- * if the number of arguments doesn't match the std::array size.
+ * std::array's implicit constructor can result in uninitialized elements if the
+ * number of arguments doesn't match the std::array size.
  */
 template <typename T, size_t N>
 class array : public std::array<T, N> {
@@ -28,7 +28,7 @@ class array : public std::array<T, N> {
 
   template <typename... Ts>
   array(T arg, Ts&&... args)  // NOLINT
-      : std::array<T, N>{arg, std::forward<Ts>(args)...} {
+      : std::array<T, N>{std::forward<T>(arg), std::forward<Ts>(args)...} {
     static_assert(1 + sizeof...(args) == N, "Dimension mismatch");
   }
 

--- a/wpiutil/src/test/native/cpp/ArrayTest.cpp
+++ b/wpiutil/src/test/native/cpp/ArrayTest.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "gtest/gtest.h"
+#include "wpi/array.h"
+
+namespace {
+class MoveOnlyType {
+ public:
+  MoveOnlyType() = default;
+  MoveOnlyType(MoveOnlyType&&) = default;
+  MoveOnlyType& operator=(MoveOnlyType&&) = default;
+};
+}  // namespace
+
+TEST(ArrayTest, CopyableTypeCompiles) {
+  wpi::array<int, 3> arr1{1, 2, 3};
+
+  // Test deduction guide
+  wpi::array ar2{1, 2, 3};
+}
+
+TEST(ArrayTest, MoveOnlyTypeCompiles) {
+  wpi::array<MoveOnlyType, 3> arr1{MoveOnlyType{}, MoveOnlyType{},
+                                   MoveOnlyType{}};
+
+  // Test deduction guide
+  wpi::array arr2{MoveOnlyType{}, MoveOnlyType{}, MoveOnlyType{}};
+}


### PR DESCRIPTION
Fixes #3916.