### PR TITLE
[wpimath] Move TrajectoryGenerator::SetErrorHandler definition to .cpp

### DIFF
--- a/wpimath/src/main/native/cpp/trajectory/TrajectoryGenerator.cpp
+++ b/wpimath/src/main/native/cpp/trajectory/TrajectoryGenerator.cpp
@@ -141,3 +141,8 @@ Trajectory TrajectoryGenerator::GenerateTrajectory(
       config.EndVelocity(), config.MaxVelocity(), config.MaxAcceleration(),
       config.IsReversed());
 }
+
+void TrajectoryGenerator::SetErrorHandler(
+    std::function<void(const char*)> func) {
+  s_errorFunc = std::move(func);
+}

--- a/wpimath/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
+++ b/wpimath/src/main/native/include/frc/trajectory/TrajectoryGenerator.h
@@ -119,9 +119,7 @@ class WPILIB_DLLEXPORT TrajectoryGenerator {
    *
    * @param func Error reporting function.
    */
-  static void SetErrorHandler(std::function<void(const char*)> func) {
-    s_errorFunc = std::move(func);
-  }
+  static void SetErrorHandler(std::function<void(const char*)> func);
 
  private:
   static void ReportError(const char* error);


### PR DESCRIPTION
Something something ODR, I think. We're getting link failures in MSVC, and I think this is why?