### PR TITLE
Added docs clarification on units for drive class WheelSpeeds

### DIFF
--- a/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
@@ -102,10 +102,8 @@ class DifferentialDrive : public RobotDriveBase,
                           public wpi::SendableHelper<DifferentialDrive> {
  public:
   /**
-  * Wheel speeds for a differential drive. 
-  *
-  * Uses normalized voltage [-1.0..1.0].
-  */
+   * Wheel speeds for a differential drive. Uses normalized voltage [-1.0..1.0].
+   */
   struct WheelSpeeds {
     double left = 0.0;
     double right = 0.0;

--- a/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
@@ -101,6 +101,11 @@ class DifferentialDrive : public RobotDriveBase,
                           public wpi::Sendable,
                           public wpi::SendableHelper<DifferentialDrive> {
  public:
+  /**
+  * Wheel speeds for a differential drive. 
+  *
+  * Uses normalized voltage [-1.0..1.0].
+  */
   struct WheelSpeeds {
     double left = 0.0;
     double right = 0.0;
@@ -172,6 +177,7 @@ class DifferentialDrive : public RobotDriveBase,
    * @param zRotation    The rotation rate of the robot around the Z axis
    *                     [-1.0..1.0]. Clockwise is positive.
    * @param squareInputs If set, decreases the input sensitivity at low speeds.
+   * @return Wheel speeds [-1.0..1.0].
    */
   static WheelSpeeds ArcadeDriveIK(double xSpeed, double zRotation,
                                    bool squareInputs = true);
@@ -190,6 +196,7 @@ class DifferentialDrive : public RobotDriveBase,
    * @param allowTurnInPlace If set, overrides constant-curvature turning for
    *                         turn-in-place maneuvers. zRotation will control
    *                         turning rate instead of curvature.
+   * @return Wheel speeds [-1.0..1.0].
    */
   static WheelSpeeds CurvatureDriveIK(double xSpeed, double zRotation,
                                       bool allowTurnInPlace);
@@ -202,6 +209,7 @@ class DifferentialDrive : public RobotDriveBase,
    * @param rightSpeed   The robot right side's speed along the X axis
    *                     [-1.0..1.0]. Forward is positive.
    * @param squareInputs If set, decreases the input sensitivity at low speeds.
+   * @return Wheel speeds [-1.0..1.0].
    */
   static WheelSpeeds TankDriveIK(double leftSpeed, double rightSpeed,
                                  bool squareInputs = true);

--- a/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/DifferentialDrive.h
@@ -102,7 +102,9 @@ class DifferentialDrive : public RobotDriveBase,
                           public wpi::SendableHelper<DifferentialDrive> {
  public:
   /**
-   * Wheel speeds for a differential drive. Uses normalized voltage [-1.0..1.0].
+   * Wheel speeds for a differential drive.
+   *
+   * Uses normalized voltage [-1.0..1.0].
    */
   struct WheelSpeeds {
     double left = 0.0;

--- a/wpilibc/src/main/native/include/frc/drive/KilloughDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/KilloughDrive.h
@@ -63,10 +63,8 @@ class KilloughDrive : public RobotDriveBase,
   static constexpr double kDefaultBackMotorAngle = 270.0;
 
   /**
-  * Wheel speeds for a Killough drive. 
-  *
-  * Uses normalized voltage [-1.0..1.0].
-  */
+   * Wheel speeds for a Killough drive. Uses normalized voltage [-1.0..1.0].
+   */
   struct WheelSpeeds {
     double left = 0.0;
     double right = 0.0;

--- a/wpilibc/src/main/native/include/frc/drive/KilloughDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/KilloughDrive.h
@@ -63,7 +63,9 @@ class KilloughDrive : public RobotDriveBase,
   static constexpr double kDefaultBackMotorAngle = 270.0;
 
   /**
-   * Wheel speeds for a Killough drive. Uses normalized voltage [-1.0..1.0].
+   * Wheel speeds for a Killough drive.
+   *
+   * Uses normalized voltage [-1.0..1.0].
    */
   struct WheelSpeeds {
     double left = 0.0;

--- a/wpilibc/src/main/native/include/frc/drive/KilloughDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/KilloughDrive.h
@@ -62,6 +62,11 @@ class KilloughDrive : public RobotDriveBase,
   static constexpr double kDefaultRightMotorAngle = 120.0;
   static constexpr double kDefaultBackMotorAngle = 270.0;
 
+  /**
+  * Wheel speeds for a Killough drive. 
+  *
+  * Uses normalized voltage [-1.0..1.0].
+  */
   struct WheelSpeeds {
     double left = 0.0;
     double right = 0.0;
@@ -154,6 +159,7 @@ class KilloughDrive : public RobotDriveBase,
    *                  Clockwise is positive.
    * @param gyroAngle The current angle reading from the gyro in degrees around
    *                  the Z axis. Use this to implement field-oriented controls.
+   * @return Wheel speeds [-1.0..1.0].
    */
   WheelSpeeds DriveCartesianIK(double ySpeed, double xSpeed, double zRotation,
                                double gyroAngle = 0.0);

--- a/wpilibc/src/main/native/include/frc/drive/MecanumDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/MecanumDrive.h
@@ -72,9 +72,11 @@ class MecanumDrive : public RobotDriveBase,
                      public wpi::Sendable,
                      public wpi::SendableHelper<MecanumDrive> {
  public:
- /**
-  * Wheel speeds for a mecanum drive. Uses normalized voltage [-1.0..1.0].
-  */
+  /**
+   * Wheel speeds for a mecanum drive.
+   *
+   * Uses normalized voltage [-1.0..1.0].
+   */
   struct WheelSpeeds {
     double frontLeft = 0.0;
     double frontRight = 0.0;

--- a/wpilibc/src/main/native/include/frc/drive/MecanumDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/MecanumDrive.h
@@ -72,6 +72,11 @@ class MecanumDrive : public RobotDriveBase,
                      public wpi::Sendable,
                      public wpi::SendableHelper<MecanumDrive> {
  public:
+ /**
+  * Wheel speeds for a mecanum drive. 
+  *
+  * Uses normalized voltage [-1.0..1.0].
+  */
   struct WheelSpeeds {
     double frontLeft = 0.0;
     double frontRight = 0.0;
@@ -140,6 +145,7 @@ class MecanumDrive : public RobotDriveBase,
    *                  Clockwise is positive.
    * @param gyroAngle The current angle reading from the gyro in degrees around
    *                  the Z axis. Use this to implement field-oriented controls.
+   * @return Wheel speeds [-1.0..1.0].
    */
   static WheelSpeeds DriveCartesianIK(double ySpeed, double xSpeed,
                                       double zRotation, double gyroAngle = 0.0);

--- a/wpilibc/src/main/native/include/frc/drive/MecanumDrive.h
+++ b/wpilibc/src/main/native/include/frc/drive/MecanumDrive.h
@@ -73,9 +73,7 @@ class MecanumDrive : public RobotDriveBase,
                      public wpi::SendableHelper<MecanumDrive> {
  public:
  /**
-  * Wheel speeds for a mecanum drive. 
-  *
-  * Uses normalized voltage [-1.0..1.0].
+  * Wheel speeds for a mecanum drive. Uses normalized voltage [-1.0..1.0].
   */
   struct WheelSpeeds {
     double frontLeft = 0.0;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -93,9 +93,11 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
   private final SpeedController m_rightMotor;
 
   private boolean m_reported;
-  
+
   /**
-   * Wheel speeds for a differential drive. Uses normalized voltage [-1.0..1.0].
+   * Wheel speeds for a differential drive.
+   *
+   * <p>Uses normalized voltage [-1.0..1.0].
    */
   @SuppressWarnings("MemberName")
   public static class WheelSpeeds {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -95,10 +95,8 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
   private boolean m_reported;
   
   /**
-  * Wheel speeds for a differential drive. 
-  *
-  * Uses normalized voltage [-1.0..1.0].
-  */
+   * Wheel speeds for a differential drive. Uses normalized voltage [-1.0..1.0].
+   */
   @SuppressWarnings("MemberName")
   public static class WheelSpeeds {
     public double left;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -93,7 +93,12 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
   private final SpeedController m_rightMotor;
 
   private boolean m_reported;
-
+  
+  /**
+  * Wheel speeds for a differential drive. 
+  *
+  * Uses normalized voltage [-1.0..1.0].
+  */
   @SuppressWarnings("MemberName")
   public static class WheelSpeeds {
     public double left;
@@ -105,8 +110,8 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
     /**
      * Constructs a WheelSpeeds.
      *
-     * @param left The left speed.
-     * @param right The right speed.
+     * @param left The left speed [-1.0..1.0].
+     * @param right The right speed [-1.0..1.0].
      */
     public WheelSpeeds(double left, double right) {
       this.left = left;
@@ -256,7 +261,7 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
    *     positive.
    * @param squareInputs If set, decreases the input sensitivity at low speeds.
-   * @return Wheel speeds.
+   * @return Wheel speeds [-1.0..1.0].
    */
   @SuppressWarnings("ParameterName")
   public static WheelSpeeds arcadeDriveIK(double xSpeed, double zRotation, boolean squareInputs) {
@@ -315,7 +320,7 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * @param zRotation The normalized curvature [-1.0..1.0]. Clockwise is positive.
    * @param allowTurnInPlace If set, overrides constant-curvature turning for turn-in-place
    *     maneuvers. zRotation will control rotation rate around the Z axis instead of curvature.
-   * @return Wheel speeds.
+   * @return Wheel speeds [-1.0..1.0].
    */
   @SuppressWarnings("ParameterName")
   public static WheelSpeeds curvatureDriveIK(
@@ -351,7 +356,7 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * @param rightSpeed The robot right side's speed along the X axis [-1.0..1.0]. Forward is
    *     positive.
    * @param squareInputs If set, decreases the input sensitivity at low speeds.
-   * @return Wheel speeds.
+   * @return Wheel speeds [-1.0..1.0].
    */
   public static WheelSpeeds tankDriveIK(double leftSpeed, double rightSpeed, boolean squareInputs) {
     leftSpeed = MathUtil.clamp(leftSpeed, -1.0, 1.0);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
@@ -59,7 +59,9 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
   private boolean m_reported;
 
   /**
-   * Wheel speeds for a Killough drive. Uses normalized voltage [-1.0..1.0].
+   * Wheel speeds for a Killough drive.
+   *
+   * <p>Uses normalized voltage [-1.0..1.0].
    */
   @SuppressWarnings("MemberName")
   public static class WheelSpeeds {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
@@ -58,11 +58,9 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
 
   private boolean m_reported;
 
- /**
-  * Wheel speeds for a Killough drive. 
-  *
-  * Uses normalized voltage [-1.0..1.0].
-  */
+  /**
+   * Wheel speeds for a Killough drive. Uses normalized voltage [-1.0..1.0].
+   */
   @SuppressWarnings("MemberName")
   public static class WheelSpeeds {
     public double left;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
@@ -77,7 +77,7 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
      *
      * @param left The left speed [-1.0..1.0].
      * @param right The right speed [-1.0..1.0].
-     * @param back The back speed,[-1.0..1.0].
+     * @param back The back speed [-1.0..1.0].
      */
     public WheelSpeeds(double left, double right, double back) {
       this.left = left;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
@@ -58,6 +58,11 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
 
   private boolean m_reported;
 
+ /**
+  * Wheel speeds for a Killough drive. 
+  *
+  * Uses normalized voltage [-1.0..1.0].
+  */
   @SuppressWarnings("MemberName")
   public static class WheelSpeeds {
     public double left;
@@ -70,9 +75,9 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
     /**
      * Constructs a WheelSpeeds.
      *
-     * @param left The left speed.
-     * @param right The right speed.
-     * @param back The back speed.
+     * @param left The left speed [-1.0..1.0].
+     * @param right The right speed [-1.0..1.0].
+     * @param back The back speed,[-1.0..1.0].
      */
     public WheelSpeeds(double left, double right, double back) {
       this.left = left;
@@ -240,7 +245,7 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
    *     positive.
    * @param gyroAngle The current angle reading from the gyro in degrees around the Z axis. Use this
    *     to implement field-oriented controls.
-   * @return Wheel speeds.
+   * @return Wheel speeds [-1.0..1.0].
    */
   @SuppressWarnings("ParameterName")
   public WheelSpeeds driveCartesianIK(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
@@ -66,6 +66,11 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
 
   private boolean m_reported;
 
+  /**
+  * Wheel speeds for a mecanum drive. 
+  *
+  * Uses normalized voltage [-1.0..1.0].
+  */
   @SuppressWarnings("MemberName")
   public static class WheelSpeeds {
     public double frontLeft;
@@ -79,10 +84,10 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
     /**
      * Constructs a WheelSpeeds.
      *
-     * @param frontLeft The front left speed.
-     * @param frontRight The front right speed.
-     * @param rearLeft The rear left speed.
-     * @param rearRight The rear right speed.
+     * @param frontLeft The front left speed [-1.0..1.0].
+     * @param frontRight The front right speed [-1.0..1.0].
+     * @param rearLeft The rear left speed [-1.0..1.0].
+     * @param rearRight The rear right speed [-1.0..1.0].
      */
     public WheelSpeeds(double frontLeft, double frontRight, double rearLeft, double rearRight) {
       this.frontLeft = frontLeft;
@@ -216,7 +221,7 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
    *     positive.
    * @param gyroAngle The current angle reading from the gyro in degrees around the Z axis. Use this
    *     to implement field-oriented controls.
-   * @return Wheel speeds.
+   * @return Wheel speeds [-1.0..1.0].
    */
   @SuppressWarnings("ParameterName")
   public static WheelSpeeds driveCartesianIK(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
@@ -67,7 +67,9 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
   private boolean m_reported;
 
   /**
-   * Wheel speeds for a mecanum drive. Uses normalized voltage [-1.0..1.0].
+   * Wheel speeds for a mecanum drive.
+   *
+   * <p>Uses normalized voltage [-1.0..1.0].
    */
   @SuppressWarnings("MemberName")
   public static class WheelSpeeds {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
@@ -67,10 +67,8 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
   private boolean m_reported;
 
   /**
-  * Wheel speeds for a mecanum drive. 
-  *
-  * Uses normalized voltage [-1.0..1.0].
-  */
+   * Wheel speeds for a mecanum drive. Uses normalized voltage [-1.0..1.0].
+   */
   @SuppressWarnings("MemberName")
   public static class WheelSpeeds {
     public double frontLeft;


### PR DESCRIPTION
For the drive classes `DifferentialDrive`, `MecanumDrive`, and `KilloughDrive`, in both C++ and Java, I have commented on the WheelSpeeds structs/data classes, as well as on the return tags on the IK methods, to clarify that in drive classes, WheelSpeeds uses normalized voltage units, [-1.0..1.0].