### PR TITLE
Remove debug info from examples

### DIFF
--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -21,7 +21,10 @@ nativeUtils {
 
 nativeUtils.wpi.addWarnings()
 nativeUtils.wpi.addWarningsAsErrors()
-nativeUtils.wpi.addReleaseSymbolGeneration()
+
+if (project.name != 'wpilibcExamples') {
+    nativeUtils.wpi.addReleaseSymbolGeneration()
+}
 
 nativeUtils.setSinglePrintPerPlatform()
 nativeUtils.enableSourceLink()

--- a/wpilibcExamples/build.gradle
+++ b/wpilibcExamples/build.gradle
@@ -39,6 +39,12 @@ nativeUtils.platformConfigs.named(nativeUtils.wpi.platforms.roborio).configure {
     cppCompiler.args.add('-Werror=deprecated-declarations')
 }
 
+nativeUtils.platformConfigs.named(nativeUtils.wpi.platforms.windowsx64).configure {
+    linker.args.remove('/DEBUG:FULL')
+    cppCompiler.debugArgs.remove('/Zi')
+    cCompiler.debugArgs.remove('/Zi')
+}
+
 ext {
     sharedCvConfigs = examplesMap + templatesMap + [commands: []]
     staticCvConfigs = [:]


### PR DESCRIPTION
They take up a LOT of disk space.