### PR TITLE
Fix rtns icons

### DIFF
--- a/roborioteamnumbersetter/CMakeLists.txt
+++ b/roborioteamnumbersetter/CMakeLists.txt
@@ -12,7 +12,7 @@ file(GLOB rtns_src src/main/native/cpp/*.cpp ${CMAKE_CURRENT_BINARY_DIR}/WPILibV
 if (WIN32)
     set(rtns_rc src/main/native/win/roborioteamnumbersetter.rc)
 elseif(APPLE)
-    set(MACOSX_BUNDLE_ICON_FILE glass.icns)
+    set(MACOSX_BUNDLE_ICON_FILE rtns.icns)
     set(APP_ICON_MACOSX src/main/native/mac/rtns.icns)
     set_source_files_properties(${APP_ICON_MACOSX} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 endif()

--- a/roborioteamnumbersetter/src/main/native/cpp/App.cpp
+++ b/roborioteamnumbersetter/src/main/native/cpp/App.cpp
@@ -31,6 +31,16 @@ namespace gui = wpi::gui;
 
 const char* GetWPILibVersion();
 
+namespace rtns {
+std::string_view GetResource_rtns_16_png();
+std::string_view GetResource_rtns_32_png();
+std::string_view GetResource_rtns_48_png();
+std::string_view GetResource_rtns_64_png();
+std::string_view GetResource_rtns_128_png();
+std::string_view GetResource_rtns_256_png();
+std::string_view GetResource_rtns_512_png();
+}  // namespace rtns
+
 #define GLFWAPI extern "C"
 GLFWAPI void glfwGetWindowSize(GLFWwindow* window, int* width, int* height);
 #define GLFW_DONT_CARE -1
@@ -239,6 +249,15 @@ static void DisplayGui() {
 void Application(std::string_view saveDir) {
   gui::CreateContext();
   glass::CreateContext();
+
+  // Add icons
+  gui::AddIcon(rtns::GetResource_rtns_16_png());
+  gui::AddIcon(rtns::GetResource_rtns_32_png());
+  gui::AddIcon(rtns::GetResource_rtns_48_png());
+  gui::AddIcon(rtns::GetResource_rtns_64_png());
+  gui::AddIcon(rtns::GetResource_rtns_128_png());
+  gui::AddIcon(rtns::GetResource_rtns_256_png());
+  gui::AddIcon(rtns::GetResource_rtns_512_png());
 
   glass::SetStorageName("roborioteamnumbersetter");
   glass::SetStorageDir(saveDir.empty() ? gui::GetPlatformSaveFileDir()


### PR DESCRIPTION
We were not setting icons up in RTNS code, and also an incorrect name was used in the cmake build.