### PR TITLE
[wpilib] Write REV PH firmware version to roboRIO to display on driver station

### DIFF
--- a/wpilibc/src/main/native/cpp/PneumaticHub.cpp
+++ b/wpilibc/src/main/native/cpp/PneumaticHub.cpp
@@ -12,6 +12,7 @@
 #include "frc/Compressor.h"
 #include "frc/DoubleSolenoid.h"
 #include "frc/Errors.h"
+#include "frc/RobotBase.h"
 #include "frc/SensorUtil.h"
 #include "frc/Solenoid.h"
 #include "frc/fmt/Units.h"
@@ -58,7 +59,7 @@ class PneumaticHub::DataStore {
 
     auto version = m_moduleObject.GetVersion();
 
-    if (version.FirmwareMajor > 0) {
+    if (version.FirmwareMajor > 0 && RobotBase::IsReal()) {
       // Write PH firmware version to roboRIO
       std::FILE* file = nullptr;
       file = std::fopen(
@@ -77,16 +78,15 @@ class PneumaticHub::DataStore {
                    file);
         std::fclose(file);
       }
+    }
 
-      // Check PH firmware version
-      if (version.FirmwareMajor < 22) {
-        throw FRC_MakeError(
-            err::AssertionFailure,
-            "The Pneumatic Hub has firmware version {}.{}.{}, and must be "
-            "updated to version 2022.0.0 or later using the REV Hardware "
-            "Client",
-            version.FirmwareMajor, version.FirmwareMinor, version.FirmwareFix);
-      }
+    // Check PH firmware version
+    if (version.FirmwareMajor > 0 && version.FirmwareMajor < 22) {
+      throw FRC_MakeError(
+          err::AssertionFailure,
+          "The Pneumatic Hub has firmware version {}.{}.{}, and must be "
+          "updated to version 2022.0.0 or later using the REV Hardware Client",
+          version.FirmwareMajor, version.FirmwareMinor, version.FirmwareFix);
     }
   }
 

--- a/wpilibc/src/main/native/cpp/PneumaticHub.cpp
+++ b/wpilibc/src/main/native/cpp/PneumaticHub.cpp
@@ -4,6 +4,7 @@
 
 #include "frc/PneumaticHub.h"
 
+#include <fmt/format.h>
 #include <hal/REVPH.h>
 #include <wpi/NullDeleter.h>
 #include <wpi/StackTrace.h>
@@ -56,12 +57,36 @@ class PneumaticHub::DataStore {
         std::shared_ptr<DataStore>{this, wpi::NullDeleter<DataStore>()};
 
     auto version = m_moduleObject.GetVersion();
-    if (version.FirmwareMajor > 0 && version.FirmwareMajor < 22) {
-      throw FRC_MakeError(
-          err::AssertionFailure,
-          "The Pneumatic Hub has firmware version {}.{}.{}, and must be "
-          "updated to version 2022.0.0 or later using the REV Hardware Client",
-          version.FirmwareMajor, version.FirmwareMinor, version.FirmwareFix);
+
+    if (version.FirmwareMajor > 0) {
+      // Write PH firmware version to roboRIO
+      std::FILE* file = nullptr;
+      file = std::fopen(
+          fmt::format("/tmp/frc_versions/REV_PH_{:0>2}_WPILib_Version.ini",
+                      module)
+              .c_str(),
+          "w");
+      if (file != nullptr) {
+        std::fputs("[Version]\n", file);
+        std::fputs(fmt::format("model=REV PH\n").c_str(), file);
+        std::fputs(fmt::format("deviceID={:x}\n", (0x9052600 | module)).c_str(),
+                   file);
+        std::fputs(fmt::format("currentVersion={}.{}.{}", version.FirmwareMajor,
+                               version.FirmwareMinor, version.FirmwareFix)
+                       .c_str(),
+                   file);
+        std::fclose(file);
+      }
+
+      // Check PH firmware version
+      if (version.FirmwareMajor < 22) {
+        throw FRC_MakeError(
+            err::AssertionFailure,
+            "The Pneumatic Hub has firmware version {}.{}.{}, and must be "
+            "updated to version 2022.0.0 or later using the REV Hardware "
+            "Client",
+            version.FirmwareMajor, version.FirmwareMinor, version.FirmwareFix);
+      }
     }
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
@@ -37,7 +37,7 @@ public class PneumaticHub implements PneumaticsBase {
       final String fwVersion =
           version.firmwareMajor + "." + version.firmwareMinor + "." + version.firmwareFix;
 
-      if (version.firmwareMajor > 0) {
+      if (version.firmwareMajor > 0 && RobotBase.isReal()) {
         // Write PH firmware version to roboRIO
         final String fileName = "REV_PH_" + String.format("%02d", module) + "_WPILib_Version.ini";
         final File file = new File("/tmp/frc_versions/" + fileName);
@@ -62,15 +62,15 @@ public class PneumaticHub implements PneumaticsBase {
           DriverStation.reportError(
               "Could not write " + fileName + ": " + ex.toString(), ex.getStackTrace());
         }
+      }
 
-        // Check PH firmware version
-        if (version.firmwareMajor < 22) {
-          throw new IllegalStateException(
-              "The Pneumatic Hub has firmware version "
-                  + fwVersion
-                  + ", and must be updated to version 2022.0.0 or later "
-                  + "using the REV Hardware Client.");
-        }
+      // Check PH firmware version
+      if (version.firmwareMajor > 0 && version.firmwareMajor < 22) {
+        throw new IllegalStateException(
+            "The Pneumatic Hub has firmware version "
+                + fwVersion
+                + ", and must be updated to version 2022.0.0 or later "
+                + "using the REV Hardware Client.");
       }
     }
 


### PR DESCRIPTION
When a PH object is initialized, the firmware version is retrieved from the device and will be written to a file in _/tmp/frc_version/_, which will be read by NetComm and sent to the driver station. 

For each PH object initialized, there will be a corresponding file named `REV_PH_<CAN_ID>_WPILib_Version.ini` containing the model, deviceID, and currentVersion which are used to be read by NetComm.