### PR TITLE
[wpilibc] Fix REV PH pulse duration units

### DIFF
--- a/wpilibc/src/main/native/cpp/PneumaticHub.cpp
+++ b/wpilibc/src/main/native/cpp/PneumaticHub.cpp
@@ -76,7 +76,7 @@ class PneumaticHub::DataStore {
   bool m_compressorReserved{false};
   wpi::mutex m_reservedLock;
   PneumaticHub m_moduleObject{HAL_kInvalidHandle, 0};
-  std::array<units::second_t, 16> m_oneShotDurMs{0_s};
+  std::array<units::millisecond_t, 16> m_oneShotDurMs{0_ms};
 };
 
 PneumaticHub::PneumaticHub()


### PR DESCRIPTION
C++ API asks for  pulse duration parameter in seconds, but treats it as milliseconds.

This PR fixes the units in the REV PH data store to treat the duration as seconds.