### PR TITLE
Fix potential gamedata out of bounds read

### DIFF
--- a/hal/src/main/native/athena/FRCDriverStation.cpp
+++ b/hal/src/main/native/athena/FRCDriverStation.cpp
@@ -115,6 +115,10 @@ static int32_t HAL_GetMatchInfoInternal(HAL_MatchInfo* info) {
       info->eventName, &matchType, &info->matchNumber, &info->replayNumber,
       info->gameSpecificMessage, &info->gameSpecificMessageSize);
 
+  if (info->gameSpecificMessageSize > sizeof(info->gameSpecificMessage)) {
+    info->gameSpecificMessageSize = 0;
+  }
+
   info->matchType = static_cast<HAL_MatchType>(matchType);
 
   *(std::end(info->eventName) - 1) = '\0';

--- a/hal/src/main/native/athena/FRCDriverStation.cpp
+++ b/hal/src/main/native/athena/FRCDriverStation.cpp
@@ -110,6 +110,7 @@ static int32_t HAL_GetControlWordInternal(HAL_ControlWord* controlWord) {
 
 static int32_t HAL_GetMatchInfoInternal(HAL_MatchInfo* info) {
   MatchType_t matchType = MatchType_t::kMatchType_none;
+  info->gameSpecificMessageSize = sizeof(info->gameSpecificMessage);
   int status = FRC_NetworkCommunication_getMatchInfo(
       info->eventName, &matchType, &info->matchNumber, &info->replayNumber,
       info->gameSpecificMessage, &info->gameSpecificMessageSize);


### PR DESCRIPTION
The game specific message size might be uninitialized. If this happens, the uninitialized value is > 64, and the DS sends > 64 bytes, we have a buffer overflow. Force the message size to max to fix the issue.