### PR TITLE
Fix ADIS16448 imu default constructor not working in Java

### DIFF
--- a/wpilibc/src/main/native/include/frc/ADIS16448_IMU.h
+++ b/wpilibc/src/main/native/include/frc/ADIS16448_IMU.h
@@ -354,7 +354,7 @@ class ADIS16448_IMU : public nt::NTSendable,
 
   bool m_auto_configured = false;
   SPI::Port m_spi_port;
-  CalibrationTime m_calibration_time;
+  CalibrationTime m_calibration_time{0};
   SPI* m_spi = nullptr;
   DigitalInput* m_auto_interrupt = nullptr;
 

--- a/wpilibc/src/main/native/include/frc/ADIS16470_IMU.h
+++ b/wpilibc/src/main/native/include/frc/ADIS16470_IMU.h
@@ -374,7 +374,7 @@ class ADIS16470_IMU : public nt::NTSendable,
   volatile bool m_thread_idle = false;
   bool m_auto_configured = false;
   SPI::Port m_spi_port;
-  uint16_t m_calibration_time;
+  uint16_t m_calibration_time = 0;
   SPI* m_spi = nullptr;
   DigitalInput* m_auto_interrupt = nullptr;
   double m_scaled_sample_rate = 2500.0;  // Default sample rate setting

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
@@ -169,7 +169,7 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
 
   /* State variables */
   private volatile boolean m_thread_active = false;
-  private CalibrationTime m_calibration_time = CalibrationTime._512ms;
+  private CalibrationTime m_calibration_time = CalibrationTime._32ms;
   private volatile boolean m_first_run = true;
   private volatile boolean m_thread_idle = false;
   private boolean m_auto_configured = false;


### PR DESCRIPTION
Also fixes a few related uninitialized variables in C++.