### PR TITLE
[glass] Fix PlotSeries::SetSource()

### DIFF
--- a/glass/src/lib/native/cpp/other/Plot.cpp
+++ b/glass/src/lib/native/cpp/other/Plot.cpp
@@ -246,7 +246,7 @@ void PlotSeries::SetSource(DataSource* source) {
   m_source = source;
 
   // add initial value
-  m_data[m_size++] = ImPlotPoint{wpi::Now() * 1.0e-6, source->GetValue()};
+  AppendValue(source->GetValue(), 0);
 
   m_newValueConn = source->valueChanged.connect_connection(
       [this](double value, uint64_t time) { AppendValue(value, time); });


### PR DESCRIPTION
This can be called in a delayed manner, so it's possible for
m_size to already be at maximum, which results in writing past
the end of the array. Instead, just call AppendValue().