### PR TITLE
[glass] Increase plot depth to 20K points

### DIFF
--- a/glass/src/lib/native/cpp/other/Plot.cpp
+++ b/glass/src/lib/native/cpp/other/Plot.cpp
@@ -105,7 +105,7 @@ class PlotSeries {
   int& m_digitalBitGap;
 
   // value storage
-  static constexpr int kMaxSize = 2000;
+  static constexpr int kMaxSize = 20000;
   static constexpr double kTimeGap = 0.05;
   std::atomic<int> m_size = 0;
   std::atomic<int> m_offset = 0;


### PR DESCRIPTION
2K was sufficient for simulation because it's possible to pause time,
but isn't quite enough for looking at real robot data. 20K points
is 400 seconds at 50 Hz which should make pausing plots much more
useful.

As every point is looped over, this does increase CPU utilization
somewhat but doesn't seem to have much of an impact for typical
use cases. Increasing this further will necessitate some greater
optimizations (e.g. an initial cull using binary search).