### PR TITLE
Export some of the wpigui functions so they can be linked to

### DIFF
--- a/simulation/halsim_gui/src/main/native/cpp/HALSimGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/HALSimGui.cpp
@@ -32,3 +32,23 @@ void HALSimGui::GlobalInit() {
 
   glass::AddStandardNetworkTablesViews(*ntProvider);
 }
+
+namespace halsimgui {
+
+void AddGuiInit(std::function<void()> initialize) {
+  wpi::gui::AddInit(std::move(initialize));
+}
+
+void AddGuiEarlyExecute(std::function<void()> execute) {
+  wpi::gui::AddEarlyExecute(std::move(execute));
+}
+
+void AddGuiLateExecute(std::function<void()> execute) {
+  wpi::gui::AddLateExecute(std::move(execute));
+}
+
+void GuiExit() {
+  wpi::gui::Exit();
+}
+
+}  // namespace halsimgui

--- a/simulation/halsim_gui/src/main/native/include/HALSimGui.h
+++ b/simulation/halsim_gui/src/main/native/include/HALSimGui.h
@@ -8,6 +8,7 @@
 #include <glass/WindowManager.h>
 #include <glass/networktables/NetworkTablesProvider.h>
 
+#include <functional>
 #include <memory>
 
 #include "HALProvider.h"
@@ -24,5 +25,10 @@ class HALSimGui {
   static std::unique_ptr<HALProvider> halProvider;
   static std::unique_ptr<glass::NetworkTablesProvider> ntProvider;
 };
+
+void AddGuiInit(std::function<void()> initialize);
+void AddGuiLateExecute(std::function<void()> execute);
+void AddGuiEarlyExecute(std::function<void()> execute);
+void GuiExit();
 
 }  // namespace halsimgui


### PR DESCRIPTION
Allows RobotPy to add hooks to gui on windows (https://github.com/robotpy/robotpy-halsim-gui/pull/10)

... seems like maybe you should just export everything? But, this seems like the most useful set of things to export.