### PR TITLE
[wpilibj] Fix typos in error messages for non-null assertions

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommand.java
@@ -112,9 +112,9 @@ public class MecanumControllerCommand extends CommandBase {
 
     m_controller =
         new HolonomicDriveController(
-            requireNonNullParam(xController, "xController", "SwerveControllerCommand"),
-            requireNonNullParam(yController, "xController", "SwerveControllerCommand"),
-            requireNonNullParam(thetaController, "thetaController", "SwerveControllerCommand"));
+            requireNonNullParam(xController, "xController", "MecanumControllerCommand"),
+            requireNonNullParam(yController, "xController", "MecanumControllerCommand"),
+            requireNonNullParam(thetaController, "thetaController", "MecanumControllerCommand"));
 
     m_desiredRotation =
         requireNonNullParam(desiredRotation, "desiredRotation", "MecanumControllerCommand");
@@ -255,9 +255,9 @@ public class MecanumControllerCommand extends CommandBase {
 
     m_controller =
         new HolonomicDriveController(
-            requireNonNullParam(xController, "xController", "SwerveControllerCommand"),
-            requireNonNullParam(yController, "xController", "SwerveControllerCommand"),
-            requireNonNullParam(thetaController, "thetaController", "SwerveControllerCommand"));
+            requireNonNullParam(xController, "xController", "MecanumControllerCommand"),
+            requireNonNullParam(yController, "xController", "MecanumControllerCommand"),
+            requireNonNullParam(thetaController, "thetaController", "MecanumControllerCommand"));
 
     m_desiredRotation =
         requireNonNullParam(desiredRotation, "desiredRotation", "MecanumControllerCommand");

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommand.java
@@ -113,7 +113,7 @@ public class MecanumControllerCommand extends CommandBase {
     m_controller =
         new HolonomicDriveController(
             requireNonNullParam(xController, "xController", "MecanumControllerCommand"),
-            requireNonNullParam(yController, "xController", "MecanumControllerCommand"),
+            requireNonNullParam(yController, "yController", "MecanumControllerCommand"),
             requireNonNullParam(thetaController, "thetaController", "MecanumControllerCommand"));
 
     m_desiredRotation =
@@ -256,7 +256,7 @@ public class MecanumControllerCommand extends CommandBase {
     m_controller =
         new HolonomicDriveController(
             requireNonNullParam(xController, "xController", "MecanumControllerCommand"),
-            requireNonNullParam(yController, "xController", "MecanumControllerCommand"),
+            requireNonNullParam(yController, "yController", "MecanumControllerCommand"),
             requireNonNullParam(thetaController, "thetaController", "MecanumControllerCommand"));
 
     m_desiredRotation =

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/PIDCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/PIDCommand.java
@@ -39,10 +39,10 @@ public class PIDCommand extends CommandBase {
       DoubleSupplier setpointSource,
       DoubleConsumer useOutput,
       Subsystem... requirements) {
-    requireNonNullParam(controller, "controller", "SynchronousPIDCommand");
-    requireNonNullParam(measurementSource, "measurementSource", "SynchronousPIDCommand");
-    requireNonNullParam(setpointSource, "setpointSource", "SynchronousPIDCommand");
-    requireNonNullParam(useOutput, "useOutput", "SynchronousPIDCommand");
+    requireNonNullParam(controller, "controller", "PIDCommand");
+    requireNonNullParam(measurementSource, "measurementSource", "PIDCommand");
+    requireNonNullParam(setpointSource, "setpointSource", "PIDCommand");
+    requireNonNullParam(useOutput, "useOutput", "PIDCommand");
 
     m_controller = controller;
     m_useOutput = useOutput;

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ProfiledPIDCommand.java
@@ -42,10 +42,10 @@ public class ProfiledPIDCommand extends CommandBase {
       Supplier<State> goalSource,
       BiConsumer<Double, State> useOutput,
       Subsystem... requirements) {
-    requireNonNullParam(controller, "controller", "SynchronousPIDCommand");
-    requireNonNullParam(measurementSource, "measurementSource", "SynchronousPIDCommand");
-    requireNonNullParam(goalSource, "goalSource", "SynchronousPIDCommand");
-    requireNonNullParam(useOutput, "useOutput", "SynchronousPIDCommand");
+    requireNonNullParam(controller, "controller", "ProfiledPIDCommand");
+    requireNonNullParam(measurementSource, "measurementSource", "ProfiledPIDCommand");
+    requireNonNullParam(goalSource, "goalSource", "ProfiledPIDCommand");
+    requireNonNullParam(useOutput, "useOutput", "ProfiledPIDCommand");
 
     m_controller = controller;
     m_useOutput = useOutput;

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RamseteCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RamseteCommand.java
@@ -119,7 +119,8 @@ public class RamseteCommand extends CommandBase {
     m_pose = requireNonNullParam(pose, "pose", "RamseteCommand");
     m_follower = requireNonNullParam(follower, "follower", "RamseteCommand");
     m_kinematics = requireNonNullParam(kinematics, "kinematics", "RamseteCommand");
-    m_output = requireNonNullParam(outputMetersPerSecond, "outputMetersPerSecond", "RamseteCommand");
+    m_output =
+        requireNonNullParam(outputMetersPerSecond, "outputMetersPerSecond", "RamseteCommand");
 
     m_feedforward = null;
     m_speeds = null;

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RamseteCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RamseteCommand.java
@@ -119,7 +119,7 @@ public class RamseteCommand extends CommandBase {
     m_pose = requireNonNullParam(pose, "pose", "RamseteCommand");
     m_follower = requireNonNullParam(follower, "follower", "RamseteCommand");
     m_kinematics = requireNonNullParam(kinematics, "kinematics", "RamseteCommand");
-    m_output = requireNonNullParam(outputMetersPerSecond, "output", "RamseteCommand");
+    m_output = requireNonNullParam(outputMetersPerSecond, "outputMetersPerSecond", "RamseteCommand");
 
     m_feedforward = null;
     m_speeds = null;

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommand.java
@@ -79,11 +79,11 @@ public class SwerveControllerCommand extends CommandBase {
     m_controller =
         new HolonomicDriveController(
             requireNonNullParam(xController, "xController", "SwerveControllerCommand"),
-            requireNonNullParam(yController, "xController", "SwerveControllerCommand"),
+            requireNonNullParam(yController, "yController", "SwerveControllerCommand"),
             requireNonNullParam(thetaController, "thetaController", "SwerveControllerCommand"));
 
     m_outputModuleStates =
-        requireNonNullParam(outputModuleStates, "frontLeftOutput", "SwerveControllerCommand");
+        requireNonNullParam(outputModuleStates, "outputModuleStates", "SwerveControllerCommand");
 
     m_desiredRotation =
         requireNonNullParam(desiredRotation, "desiredRotation", "SwerveControllerCommand");

--- a/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
+++ b/wpilibOldCommands/src/main/java/edu/wpi/first/wpilibj/PIDBase.java
@@ -153,7 +153,7 @@ public class PIDBase implements PIDInterface, PIDOutput, Sendable, AutoCloseable
    */
   @SuppressWarnings("ParameterName")
   public PIDBase(double Kp, double Ki, double Kd, double Kf, PIDSource source, PIDOutput output) {
-    requireNonNullParam(source, "PIDSource", "PIDBase");
+    requireNonNullParam(source, "source", "PIDBase");
     requireNonNullParam(output, "output", "PIDBase");
 
     m_setpointTimer = new Timer();


### PR DESCRIPTION
~~Looks like the assertions were copy-pasted from `SwerveControllerCommand` without having the class name updated.~~

Many of the non-null assertions for parameters have incorrect values for the parameter name or class they belong to.