### PR TITLE
[sim] Provide function that resets all simulation data

### DIFF
--- a/hal/src/main/native/athena/mockdata/Reset.cpp
+++ b/hal/src/main/native/athena/mockdata/Reset.cpp
@@ -1,0 +1,5 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+extern "C" void HALSIM_ResetAllSimData(void) {}

--- a/hal/src/main/native/include/hal/simulation/Reset.h
+++ b/hal/src/main/native/include/hal/simulation/Reset.h
@@ -1,0 +1,7 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+extern "C" void HALSIM_ResetAllSimData(void);

--- a/hal/src/main/native/sim/mockdata/Reset.cpp
+++ b/hal/src/main/native/sim/mockdata/Reset.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <hal/simulation/AccelerometerData.h>
+#include <hal/simulation/AddressableLEDData.h>
+#include <hal/simulation/AnalogGyroData.h>
+#include <hal/simulation/AnalogInData.h>
+#include <hal/simulation/AnalogOutData.h>
+#include <hal/simulation/AnalogTriggerData.h>
+#include <hal/simulation/CTREPCMData.h>
+#include <hal/simulation/CanData.h>
+#include <hal/simulation/DIOData.h>
+#include <hal/simulation/DigitalPWMData.h>
+#include <hal/simulation/DriverStationData.h>
+#include <hal/simulation/DutyCycleData.h>
+#include <hal/simulation/EncoderData.h>
+#include <hal/simulation/I2CData.h>
+#include <hal/simulation/PWMData.h>
+#include <hal/simulation/PowerDistributionData.h>
+#include <hal/simulation/REVPHData.h>
+#include <hal/simulation/RelayData.h>
+#include <hal/simulation/RoboRioData.h>
+#include <hal/simulation/SPIAccelerometerData.h>
+#include <hal/simulation/SPIData.h>
+#include <hal/simulation/SimDeviceData.h>
+
+#include "../PortsInternal.h"
+
+extern "C" void HALSIM_ResetAllSimData(void) {
+  for (int32_t i = 0; i < hal::kAccelerometers; i++) {
+    HALSIM_ResetAccelerometerData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kNumAddressableLEDs; i++) {
+    HALSIM_ResetAddressableLEDData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kNumAccumulators; i++) {
+    HALSIM_ResetAnalogGyroData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kNumAnalogInputs; i++) {
+    HALSIM_ResetAnalogInData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kNumAnalogOutputs; i++) {
+    HALSIM_ResetAnalogOutData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kNumAnalogTriggers; i++) {
+    HALSIM_ResetAnalogTriggerData(i);
+  }
+
+  HALSIM_ResetCanData();
+
+  for (int32_t i = 0; i < hal::kNumCTREPCMModules; i++) {
+    HALSIM_ResetCTREPCMData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kNumDigitalPWMOutputs; i++) {
+    HALSIM_ResetDigitalPWMData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kNumDigitalChannels; i++) {
+    HALSIM_ResetDIOData(i);
+  }
+
+  HALSIM_ResetDriverStationData();
+
+  for (int32_t i = 0; i < hal::kNumDutyCycles; i++) {
+    HALSIM_ResetDutyCycleData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kNumEncoders; i++) {
+    HALSIM_ResetEncoderData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kI2CPorts; i++) {
+    HALSIM_ResetI2CData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kNumPDSimModules; i++) {
+    HALSIM_ResetPowerDistributionData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kNumPWMChannels; i++) {
+    HALSIM_ResetPWMData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kNumRelayHeaders; i++) {
+    HALSIM_ResetRelayData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kNumREVPHModules; i++) {
+    HALSIM_ResetREVPHData(i);
+  }
+
+  HALSIM_ResetRoboRioData();
+  HALSIM_ResetSimDeviceData();
+
+  for (int32_t i = 0; i < hal::kSPIAccelerometers; i++) {
+    HALSIM_ResetSPIAccelerometerData(i);
+  }
+
+  for (int32_t i = 0; i < hal::kSPIPorts; i++) {
+    HALSIM_ResetSPIData(i);
+  }
+}


### PR DESCRIPTION
- Fixes #3867
- Include #4015, but they can be considered separately

This works, but I don't necessarily need this merged this season if we want to defer this. Questions:

* I like `HALSIM_ResetAllSimData`, but I'm open to other names
* There were a lot of includes, so I put it into its own file. Maybe it should go into MockHooks.{cpp,h} instead?
* This is separate from resetting all handles, and I think that makes sense to stay that way
* For RobotPy, I'm going wrap this in `wpilib.simulation` along with the other global reset functions that were introduced in #4007. I do think this is a generally useful functionality for writing unit tests.
  * Should that wrapper be put into WPILib's wpilib.simulation then? 
  * RobotPy's wrapper implementation: https://github.com/robotpy/robotpy-wpilib/pull/704
  * The function in https://github.com/wpilibsuite/allwpilib/pull/4037 will also need to be reset by the `wpilib.simulation` function
* Should this be exposed up through JNI? Not sure how to do this. But maybe that can wait until the `wpilib.simulation` wrapper is written.
* Should existing unit tests be changed to call this function instead of any individual reset functions? That would give this nice test coverage and illuminate any potential issues?
  * It does seem existing unit tests only use functions at the wpilib layer, so maybe this should be deferred until then
* I wonder how this will break vendor libraries...

I do plan on including a version of this in RobotPy's hal this season to support full-robot integration tests (which are really useful in python), so it might make sense to defer some of these questions about a `wpilib.simulation` wrapper until I get some experience and fix bugs that users will invariably run into.

cc @ThadHouse @agelsomini @PeterJohnson @pjreiniger 