### PR TITLE
[commands] Code injection decorators: onInit, onExecute, until, onEnd

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
@@ -4,8 +4,8 @@
 
 package edu.wpi.first.wpilibj2.command;
 
-import java.util.Set;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -331,22 +331,21 @@ public interface Command {
     return this.getClass().getSimpleName();
   }
 
- /**
+  /**
    * Decorates this command with a code injection at the end of this command's initialize() method.
-   * 
+   *
    * @param toRun the Runnable that should be run at the end of the initialize() method.
-   * @returns the decorated Command
+   * @param requirements any additional requirements for the added code.
+   * @return the decorated Command
    */
 
   default Command onInit(Runnable toRun, Subsystem... requirements) {
-
     Set<Subsystem> requirementsSet = new HashSet<Subsystem>();
     Command command = this;
 
     requirementsSet.addAll(Set.of(requirements));
     requirementsSet.addAll(this.getRequirements());
     return new Command() {
-
       protected final Command m_command = command;
       protected final Runnable m_toRun = toRun;
       protected final Set<Subsystem> m_requirements = requirementsSet;
@@ -361,12 +360,12 @@ public interface Command {
         m_command.initialize();
         m_toRun.run();
       }
-    
+
       @Override
       public void execute() {
         m_command.execute();
       }
-      
+
       @Override
       public boolean isFinished() {
         return m_command.isFinished();

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
@@ -182,4 +182,36 @@ class CommandDecoratorTest extends CommandTestBase {
       assertTrue(scheduler.isScheduled(perpetual));
     }
   }
+
+  @Test
+  void onInitTest() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      Counter counter = new Counter();
+      Command command = new InstantCommand();
+
+      Command init = command.onInit(counter::increment);
+
+      scheduler.schedule(init);
+      scheduler.run();
+      assertTrue(counter.m_counter == 1);
+
+      scheduler.schedule(init);
+      scheduler.run();
+      assertTrue(counter.m_counter == 2);
+    }
+  }
+
+  @Test
+  void onInitRequirementsTest() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      Subsystem instantReq = new TestSubsystem();
+      Subsystem initReq = new TestSubsystem();
+
+      Command command = new InstantCommand(()->{}, instantReq);
+      Command init = command.onInit(()->{}, initReq);
+
+      assertTrue(init.hasRequirement(instantReq));
+      assertTrue(init.hasRequirement(initReq));
+    }
+  }
 }


### PR DESCRIPTION
This PR adds four new command decorators:
`onInit(Runnable init, Subsystem... requirements)` - Runs the provided Runnable after this command's `initialize()` method, adding the provided Subsystems as requirements.
`onExecute(Runnable execute, Subsystem... requirements)`  - Runs the provided Runnable after this command's `execute()` method, adding the provided Subsystems as requirements.
`until(BooleanSupplier condition)` - Inserts the provided condition as a logical OR with this command's `isFinished()` method, providing an alternate finishing condition.
`onEnd(Consumer<Boolean> end)`  - Runs the provided code after this command's `end()` method, adding the provided Subsystems as requirements. The Consumer<Boolean> accepts `interrupted`.

Notes:
 - As of #3981, `.until` is an alias for `.withInterrupt`. Under this code, both would exist separately. `.until` would specify a "natural end" condition, not an interrupt condition.
 - `.onEnd` is useful to add cleanup code to a CommandGroup, which could otherwise be interrupted and not be able to run any end code.
 - `.until` is useful in inline commands, to specify an end condition that is not an interrupt. For example, here is a turret homing command from 6995's 2022 codebase:
```java
    return new FunctionalCommand(
      ()->{},
      turretS::spinHoming,
      (boolean interrupted) -> {
        turretS.stop();
        if(!interrupted) {
          turretS.zeroEncoder();
        }
      },
      turretS::isHomed,
      turretS);
```

With these new decorators, this command could be:
```java
    return new RunCommand(turretS::spinHoming, turretS)
       .until(turretS::isHomed)
       .onEnd((boolean interrupted) -> {
        turretS.stop();
        if(!interrupted) {
          turretS.zeroEncoder();
        }
      }, 
    turretS);
```
Using `withInterrupt` here would provide no difference to the `end` method between "turret is homed" and "homing was interrupted", so the `end` method would not know whether to zero the encoder. 

### Possible improvements
 - To allow further use of method refs in the end code, two more decorators could be provided: `onInterrupt` and `onFinish`, which correspond to ending with `interrupted` true and false respectively. 

### Progress

- [ ] `onInit`
  - [x] Java
  - [x] Java tests
  - [ ] C++
  - [ ] C++ tests
 - [ ] `onExecute`
  - [ ] Java
  - [ ] Java tests
  - [ ] C++
  - [ ] C++ tests
- [ ] `until`
  - [ ] Java
  - [ ] Java tests
  - [ ] C++
  - [ ] C++ tests
- [ ] `onEnd`
  - [ ] Java
  - [ ] Java tests
  - [ ] C++
  - [ ] C++ tests
- [ ] Add to https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html

