### PR TITLE
[wpilibc] Prevent StopMotor from terminating robot during MotorSafety check

### DIFF
--- a/wpilibc/src/main/native/cpp/MotorSafety.cpp
+++ b/wpilibc/src/main/native/cpp/MotorSafety.cpp
@@ -89,7 +89,15 @@ void MotorSafety::Check() {
   if (stopTime < Timer::GetFPGATimestamp()) {
     FRC_ReportError(err::Timeout, "{}... Output not updated often enough",
                     GetDescription());
-    StopMotor();
+
+    try {
+      StopMotor();
+    } catch (frc::RuntimeError& e) {
+      e.Report();
+    } catch (std::exception& e) {
+      FRC_ReportError(err::Error, "{} StopMotor threw unexpected exception: {}",
+                      GetDescription(), e.what());
+    }
   }
 }
 

--- a/wpilibc/src/main/native/include/frc/MotorSafety.h
+++ b/wpilibc/src/main/native/include/frc/MotorSafety.h
@@ -91,6 +91,12 @@ class MotorSafety {
   static void CheckMotors();
 
   virtual void StopMotor() = 0;
+
+  /**
+   * The return value from this method is printed out when an error occurs
+   *
+   * This method must not throw!
+   */
   virtual std::string GetDescription() const = 0;
 
  private:


### PR DESCRIPTION
- Nothing else in that function can throw, so protecting StopMotor should be sufficient
- Fixes #4036

I'm not certain about how the error message will present itself. Will try to provoke this locally and see what happens.