### PR TITLE
Some API and behavior fixes to absolute encoders

### DIFF
--- a/wpilibc/src/main/native/cpp/AnalogEncoder.cpp
+++ b/wpilibc/src/main/native/cpp/AnalogEncoder.cpp
@@ -10,6 +10,7 @@
 #include "frc/AnalogInput.h"
 #include "frc/Counter.h"
 #include "frc/Errors.h"
+#include "frc/RobotController.h"
 
 using namespace frc;
 
@@ -42,6 +43,8 @@ void AnalogEncoder::Init() {
 
   if (m_simDevice) {
     m_simPosition = m_simDevice.CreateDouble("Position", false, 0.0);
+    m_simAbsolutePosition =
+        m_simDevice.CreateDouble("absPosition", hal::SimDevice::kInput, 0.0);
   }
 
   m_analogTrigger.SetLimitsVoltage(1.25, 3.75);
@@ -52,6 +55,11 @@ void AnalogEncoder::Init() {
 
   wpi::SendableRegistry::AddLW(this, "DutyCycle Encoder",
                                m_analogInput->GetChannel());
+}
+
+static bool DoubleEquals(double a, double b) {
+  constexpr double epsilon = 0.00001;
+  return std::abs(a - b) < epsilon;
 }
 
 units::turn_t AnalogEncoder::Get() const {
@@ -66,7 +74,8 @@ units::turn_t AnalogEncoder::Get() const {
     auto pos = m_analogInput->GetVoltage();
     auto counter2 = m_counter.Get();
     auto pos2 = m_analogInput->GetVoltage();
-    if (counter == counter2 && pos == pos2) {
+    if (counter == counter2 && DoubleEquals(pos, pos2)) {
+      pos = pos / frc::RobotController::GetVoltage5V();
       units::turn_t turns{counter + pos - m_positionOffset};
       m_lastPosition = turns;
       return turns;
@@ -80,8 +89,20 @@ units::turn_t AnalogEncoder::Get() const {
   return m_lastPosition;
 }
 
+double AnalogEncoder::GetAbsolutePosition() const {
+  if (m_simAbsolutePosition) {
+    return m_simAbsolutePosition.Get();
+  }
+
+  return m_analogInput->GetVoltage() / frc::RobotController::GetVoltage5V();
+}
+
 double AnalogEncoder::GetPositionOffset() const {
   return m_positionOffset;
+}
+
+void AnalogEncoder::SetPositionOffset(double offset) {
+  m_positionOffset = std::clamp(offset, 0.0, 1.0);
 }
 
 void AnalogEncoder::SetDistancePerRotation(double distancePerRotation) {
@@ -98,7 +119,8 @@ double AnalogEncoder::GetDistance() const {
 
 void AnalogEncoder::Reset() {
   m_counter.Reset();
-  m_positionOffset = m_analogInput->GetVoltage();
+  m_positionOffset =
+      m_analogInput->GetVoltage() / frc::RobotController::GetVoltage5V();
 }
 
 int AnalogEncoder::GetChannel() const {

--- a/wpilibc/src/main/native/include/frc/AnalogEncoder.h
+++ b/wpilibc/src/main/native/include/frc/AnalogEncoder.h
@@ -72,15 +72,37 @@ class AnalogEncoder : public wpi::Sendable,
   units::turn_t Get() const;
 
   /**
+   * Get the absolute position of the analog encoder.
+   *
+   * <p>GetAbsolutePosition() - GetPositionOffset() will give an encoder absolute position
+   * relative to the last reset. This could potentially be negative, which needs to be accounted
+   * for.
+   *
+   * <p>This will not account for rollovers, and will always be just the raw absolute position.
+   *
+   * @return the absolute position
+   */
+  double GetAbsolutePosition() const;
+
+  /**
    * Get the offset of position relative to the last reset.
    *
-   * GetPositionInRotation() - GetPositionOffset() will give an encoder absolute
+   * GetAbsolutePosition() - GetPositionOffset() will give an encoder absolute
    * position relative to the last reset. This could potentially be negative,
    * which needs to be accounted for.
    *
    * @return the position offset
    */
   double GetPositionOffset() const;
+
+  /**
+   * Set the position offset.
+   *
+   * <p>This must be in the range of 0-1.
+   *
+   * @param offset the offset
+   */
+  void SetPositionOffset(double offset);
 
   /**
    * Set the distance per rotation of the encoder. This sets the multiplier used
@@ -131,5 +153,6 @@ class AnalogEncoder : public wpi::Sendable,
 
   hal::SimDevice m_simDevice;
   hal::SimDouble m_simPosition;
+  hal::SimDouble m_simAbsolutePosition;
 };
 }  // namespace frc

--- a/wpilibc/src/main/native/include/frc/AnalogEncoder.h
+++ b/wpilibc/src/main/native/include/frc/AnalogEncoder.h
@@ -74,11 +74,12 @@ class AnalogEncoder : public wpi::Sendable,
   /**
    * Get the absolute position of the analog encoder.
    *
-   * <p>GetAbsolutePosition() - GetPositionOffset() will give an encoder absolute position
-   * relative to the last reset. This could potentially be negative, which needs to be accounted
-   * for.
+   * <p>GetAbsolutePosition() - GetPositionOffset() will give an encoder
+   * absolute position relative to the last reset. This could potentially be
+   * negative, which needs to be accounted for.
    *
-   * <p>This will not account for rollovers, and will always be just the raw absolute position.
+   * <p>This will not account for rollovers, and will always be just the raw
+   * absolute position.
    *
    * @return the absolute position
    */

--- a/wpilibc/src/main/native/include/frc/DutyCycleEncoder.h
+++ b/wpilibc/src/main/native/include/frc/DutyCycleEncoder.h
@@ -124,11 +124,12 @@ class DutyCycleEncoder : public wpi::Sendable,
   /**
    * Get the absolute position of the duty cycle encoder encoder.
    *
-   * <p>GetAbsolutePosition() - GetPositionOffset() will give an encoder absolute position
-   * relative to the last reset. This could potentially be negative, which needs to be accounted
-   * for.
+   * <p>GetAbsolutePosition() - GetPositionOffset() will give an encoder
+   * absolute position relative to the last reset. This could potentially be
+   * negative, which needs to be accounted for.
    *
-   * <p>This will not account for rollovers, and will always be just the raw absolute position.
+   * <p>This will not account for rollovers, and will always be just the raw
+   * absolute position.
    *
    * @return the absolute position
    */

--- a/wpilibc/src/main/native/include/frc/DutyCycleEncoder.h
+++ b/wpilibc/src/main/native/include/frc/DutyCycleEncoder.h
@@ -122,6 +122,39 @@ class DutyCycleEncoder : public wpi::Sendable,
   units::turn_t Get() const;
 
   /**
+   * Get the absolute position of the duty cycle encoder encoder.
+   *
+   * <p>GetAbsolutePosition() - GetPositionOffset() will give an encoder absolute position
+   * relative to the last reset. This could potentially be negative, which needs to be accounted
+   * for.
+   *
+   * <p>This will not account for rollovers, and will always be just the raw absolute position.
+   *
+   * @return the absolute position
+   */
+  double GetAbsolutePosition() const;
+
+  /**
+   * Get the offset of position relative to the last reset.
+   *
+   * GetAbsolutePosition() - GetPositionOffset() will give an encoder absolute
+   * position relative to the last reset. This could potentially be negative,
+   * which needs to be accounted for.
+   *
+   * @return the position offset
+   */
+  double GetPositionOffset() const;
+
+  /**
+   * Set the position offset.
+   *
+   * <p>This must be in the range of 0-1.
+   *
+   * @param offset the offset
+   */
+  void SetPositionOffset(double offset);
+
+  /**
    * Set the encoder duty cycle range. As the encoder needs to maintain a duty
    * cycle, the duty cycle cannot go all the way to 0% or all the way to 100%.
    * For example, an encoder with a 4096 us period might have a minimum duty
@@ -182,6 +215,7 @@ class DutyCycleEncoder : public wpi::Sendable,
 
  private:
   void Init();
+  double MapSensorRange(double pos) const;
 
   std::shared_ptr<DutyCycle> m_dutyCycle;
   std::unique_ptr<AnalogTrigger> m_analogTrigger;
@@ -195,6 +229,7 @@ class DutyCycleEncoder : public wpi::Sendable,
 
   hal::SimDevice m_simDevice;
   hal::SimDouble m_simPosition;
+  hal::SimDouble m_simAbsolutePosition;
   hal::SimDouble m_simDistancePerRotation;
   hal::SimBoolean m_simIsConnected;
 };

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogEncoder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogEncoder.java
@@ -7,6 +7,7 @@ package edu.wpi.first.wpilibj;
 import edu.wpi.first.hal.SimDevice;
 import edu.wpi.first.hal.SimDevice.Direction;
 import edu.wpi.first.hal.SimDouble;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.util.sendable.SendableRegistry;
@@ -23,6 +24,7 @@ public class AnalogEncoder implements Sendable, AutoCloseable {
 
   protected SimDevice m_simDevice;
   protected SimDouble m_simPosition;
+  protected SimDouble m_simAbsolutePosition;
 
   /**
    * Construct a new AnalogEncoder attached to a specific AnalogIn channel.
@@ -51,6 +53,7 @@ public class AnalogEncoder implements Sendable, AutoCloseable {
 
     if (m_simDevice != null) {
       m_simPosition = m_simDevice.createDouble("Position", Direction.kInput, 0.0);
+      m_simAbsolutePosition = m_simDevice.createDouble("absPosition", Direction.kInput, 0.0);
     }
 
     // Limits need to be 25% from each end
@@ -59,6 +62,11 @@ public class AnalogEncoder implements Sendable, AutoCloseable {
     m_counter.setDownSource(m_analogTrigger, AnalogTriggerType.kFallingPulse);
 
     SendableRegistry.addLW(this, "Analog Encoder", m_analogInput.getChannel());
+  }
+
+  private boolean doubleEquals(double a, double b) {
+    double epsilon = 0.00001d;
+    return Math.abs(a - b) < epsilon;
   }
 
   /**
@@ -80,7 +88,8 @@ public class AnalogEncoder implements Sendable, AutoCloseable {
       double pos = m_analogInput.getVoltage();
       double counter2 = m_counter.get();
       double pos2 = m_analogInput.getVoltage();
-      if (counter == counter2 && pos == pos2) {
+      if (counter == counter2 && doubleEquals(pos, pos2)) {
+        pos = pos / RobotController.getVoltage5V();
         double position = counter + pos - m_positionOffset;
         m_lastPosition = position;
         return position;
@@ -93,16 +102,44 @@ public class AnalogEncoder implements Sendable, AutoCloseable {
   }
 
   /**
+   * Get the absolute position of the analog encoder.
+   *
+   * <p>getAbsolutePosition() - getPositionOffset() will give an encoder absolute position relative
+   * to the last reset. This could potentially be negative, which needs to be accounted for.
+   *
+   * <p>This will not account for rollovers, and will always be just the raw absolute position.
+   *
+   * @return the absolute position
+   */
+  public double getAbsolutePosition() {
+    if (m_simAbsolutePosition != null) {
+      return m_simAbsolutePosition.get();
+    }
+
+    return m_analogInput.getVoltage() / RobotController.getVoltage5V();
+  }
+
+  /**
    * Get the offset of position relative to the last reset.
    *
-   * <p>getPositionInRotation() - getPositionOffset() will give an encoder absolute position
-   * relative to the last reset. This could potentially be negative, which needs to be accounted
-   * for.
+   * <p>getAbsolutePosition() - getPositionOffset() will give an encoder absolute position relative
+   * to the last reset. This could potentially be negative, which needs to be accounted for.
    *
    * @return the position offset
    */
   public double getPositionOffset() {
     return m_positionOffset;
+  }
+
+  /**
+   * Set the position offset.
+   *
+   * <p>This must be in the range of 0-1.
+   *
+   * @param offset the offset
+   */
+  public void setPositionOffset(double offset) {
+    m_positionOffset = MathUtil.clamp(offset, 0.0, 1.0);
   }
 
   /**
@@ -148,7 +185,7 @@ public class AnalogEncoder implements Sendable, AutoCloseable {
   /** Reset the Encoder distance to zero. */
   public void reset() {
     m_counter.reset();
-    m_positionOffset = m_analogInput.getVoltage();
+    m_positionOffset = m_analogInput.getVoltage() / RobotController.getVoltage5V();
   }
 
   @Override


### PR DESCRIPTION
SetPositionOffset was added. Been requested multiple times, and easy to implement.

The javadocs mentioned GetPositionInRotation. It has tripped up many people how to get the absolute position from the encoder (You currently have to have precreated the DutyCycle object). Add this method (as GetAbsolutePostition) to make this easier to do.

The checks for making sure a matching set of values was read was doing direct double comparisions. This worked ok in the DutyCycle case, but has problems in the analog case. Solve this by using an epsilon comparison.

And finally, scale AnalogEncoders analog input to 0-1 instead of 0-5. This was reported a few years ago, but the issue was missed. This caused the encoder to count from 0-5, then 1-6, then 2-7 etc. This is solved and now works correctly.

Closes #3188 
Closes #4046 
Closes #4051 

And fixes the following issue on CD
https://www.chiefdelphi.com/t/wpilib-analogencoder-java/372649