### PR TITLE
Fix ProfiledPID SetTolerance default velocity value

### DIFF
--- a/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -224,9 +224,9 @@ class ProfiledPIDController
    * @param positionTolerance Position error which is tolerable.
    * @param velocityTolerance Velocity error which is tolerable.
    */
-  void SetTolerance(
-      Distance_t positionTolerance,
-      Velocity_t velocityTolerance = Velocity_t(std::numeric_limits<double>::infinity())) {
+  void SetTolerance(Distance_t positionTolerance,
+                    Velocity_t velocityTolerance =
+                        Velocity_t(std::numeric_limits<double>::infinity())) {
     m_controller.SetTolerance(positionTolerance.value(),
                               velocityTolerance.value());
   }

--- a/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -226,7 +226,7 @@ class ProfiledPIDController
    */
   void SetTolerance(
       Distance_t positionTolerance,
-      Velocity_t velocityTolerance = std::numeric_limits<double>::infinity()) {
+      Velocity_t velocityTolerance = Velocity_t(std::numeric_limits<double>::infinity())) {
     m_controller.SetTolerance(positionTolerance.value(),
                               velocityTolerance.value());
   }


### PR DESCRIPTION
When trying to set the tolerance of a ProfiledPID, it fails if you don't give it a velocity value. It was missing a conversion from double to the appropiate unit.