### PR TITLE
Set actions workflow concurrency

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,6 +2,10 @@ name: CMake
 
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,6 +2,10 @@ name: Documentation
 
 on: [push, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   BASE_PATH: allwpilib/docs
 
@@ -10,6 +14,7 @@ jobs:
     name: "Documentation - Publish"
     runs-on: ubuntu-latest
     if: github.repository_owner == 'wpilibsuite' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    concurrency: ci-docs-publish
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/gazebo.yml
+++ b/.github/workflows/gazebo.yml
@@ -2,6 +2,10 @@ name: Gazebo
 
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: "Build"

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,6 +1,10 @@
 name: "Validate Gradle Wrapper"
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validation:
     name: "Validation"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,6 +2,10 @@ name: Gradle
 
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-docker:
     strategy:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -6,6 +6,10 @@ on:
     branches-ignore:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   wpiformat:
     name: "wpiformat"

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -2,6 +2,10 @@ name: Sanitizers
 
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

This sets the workflow concurrency to 1 for all workflows. For PRs this means if you push an additional commit older jobs will be cancelled.

The documentation workflow already only runs on tags or merges to main. For this, we cancel previous runs if they are to the same destination (tag or main) but still prevent 2 jobs from running at once if they are spawned from different refs.