### PR TITLE
Reset m_positionError when PIDController.reset() is called.

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -340,6 +340,7 @@ public class PIDController implements Sendable, AutoCloseable {
 
   /** Resets the previous error and the integral term. */
   public void reset() {
+    m_positionError = 0;
     m_prevError = 0;
     m_totalError = 0;
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -343,6 +343,7 @@ public class PIDController implements Sendable, AutoCloseable {
     m_positionError = 0;
     m_prevError = 0;
     m_totalError = 0;
+    m_velocityError = 0;
   }
 
   @Override

--- a/wpimath/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpimath/src/main/native/cpp/controller/PIDController.cpp
@@ -157,6 +157,7 @@ double PIDController::Calculate(double measurement, double setpoint) {
 }
 
 void PIDController::Reset() {
+  m_positionError = 0;
   m_prevError = 0;
   m_totalError = 0;
 }

--- a/wpimath/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpimath/src/main/native/cpp/controller/PIDController.cpp
@@ -160,6 +160,7 @@ void PIDController::Reset() {
   m_positionError = 0;
   m_prevError = 0;
   m_totalError = 0;
+  m_velocityError = 0;
 }
 
 void PIDController::InitSendable(wpi::SendableBuilder& builder) {


### PR DESCRIPTION
In addition to m_prevError and m_totalError, m_positionError needs to be reset
to 0 when reset() is called. Otherwise, the next time calculate() is
called, the old value of m_positionError will be used as the previous
error, but this is inaccurate since the caller wanted to reset the state
of the PID controller.