### PR TITLE
[wpigui] disable changing directory when initializing on MacOS

### DIFF
--- a/wpigui/src/main/native/cpp/wpigui.cpp
+++ b/wpigui/src/main/native/cpp/wpigui.cpp
@@ -125,6 +125,7 @@ bool gui::Initialize(const char* title, int width, int height) {
   // Setup window
   glfwSetErrorCallback(ErrorCallback);
   glfwInitHint(GLFW_JOYSTICK_HAT_BUTTONS, GLFW_FALSE);
+  glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
   PlatformGlfwInitHints();
   if (!glfwInit()) {
     return false;


### PR DESCRIPTION
- Seems to be intended for resource bundles in MacOS apps, which we don't use

... haven't tested this yet, but maybe later this weekend I'll build everything on OSX and test this.