### PR TITLE
Add ability to use boolean supplier for trigger operations

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
@@ -359,8 +359,8 @@ public class Trigger implements BooleanSupplier {
   }
 
   /**
-   * Composes this trigger with a boolean supplier, returning a new trigger that is active when either
-   * trigger is active.
+   * Composes this trigger with a boolean supplier, returning a new trigger that is active when
+   * either trigger is active.
    *
    * @param booleanSupplier the boolean supplier to compose with
    * @return the trigger that is active when either trigger is active

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
@@ -359,6 +359,17 @@ public class Trigger implements BooleanSupplier {
   }
 
   /**
+   * Composes this trigger with a boolean supplier, returning a new trigger that is active when both
+   * triggers are active.
+   *
+   * @param booleanSupplier the boolean supplier to compose with
+   * @return the trigger that is active when both triggers are active
+   */
+  public Trigger and(BooleanSupplier booleanSupplier) {
+    return and(new Trigger(booleanSupplier));
+  }
+
+  /**
    * Composes this trigger with another trigger, returning a new trigger that is active when either
    * trigger is active.
    *
@@ -367,6 +378,18 @@ public class Trigger implements BooleanSupplier {
    */
   public Trigger or(Trigger trigger) {
     return new Trigger(() -> get() || trigger.get());
+  }
+
+
+  /**
+   * Composes this trigger with a boolean supplier, returning a new trigger that is active when either
+   * trigger is active.
+   *
+   * @param booleanSupplier the boolean supplier to compose with
+   * @return the trigger that is active when either trigger is active
+   */
+  public Trigger or(BooleanSupplier booleanSupplier) {
+    return or(new Trigger(booleanSupplier));
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
@@ -348,17 +348,6 @@ public class Trigger implements BooleanSupplier {
   }
 
   /**
-   * Composes this trigger with another trigger, returning a new trigger that is active when both
-   * triggers are active.
-   *
-   * @param trigger the trigger to compose with
-   * @return the trigger that is active when both triggers are active
-   */
-  public Trigger and(Trigger trigger) {
-    return new Trigger(() -> get() && trigger.get());
-  }
-
-  /**
    * Composes this trigger with a boolean supplier, returning a new trigger that is active when both
    * triggers are active.
    *
@@ -366,20 +355,8 @@ public class Trigger implements BooleanSupplier {
    * @return the trigger that is active when both triggers are active
    */
   public Trigger and(BooleanSupplier booleanSupplier) {
-    return and(new Trigger(booleanSupplier));
+    return new Trigger(() -> get() && booleanSupplier.getAsBoolean());
   }
-
-  /**
-   * Composes this trigger with another trigger, returning a new trigger that is active when either
-   * trigger is active.
-   *
-   * @param trigger the trigger to compose with
-   * @return the trigger that is active when either trigger is active
-   */
-  public Trigger or(Trigger trigger) {
-    return new Trigger(() -> get() || trigger.get());
-  }
-
 
   /**
    * Composes this trigger with a boolean supplier, returning a new trigger that is active when either
@@ -389,7 +366,7 @@ public class Trigger implements BooleanSupplier {
    * @return the trigger that is active when either trigger is active
    */
   public Trigger or(BooleanSupplier booleanSupplier) {
-    return or(new Trigger(booleanSupplier));
+    return new Trigger(() -> get() || booleanSupplier.getAsBoolean());
   }
 
   /**

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
@@ -35,7 +35,7 @@ class Trigger {
    *
    * @param isActive Whether the trigger is active.
    */
-  explicit Trigger(std::function<bool()> isActive)
+  Trigger(std::function<bool()> isActive) // NOLINT
       : m_isActive{std::move(isActive)} {}
 
   /**

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
@@ -331,30 +331,12 @@ class Trigger {
   }
 
   /**
-   * Composes a trigger and a boolean function with logical AND.
-   *
-   * @return A trigger which is active when both components are active.
-   */
-  Trigger operator&&(std::function<bool()> rhs) {
-    return Trigger([*this, rhs] { return m_isActive() && rhs(); });
-  }
-
-  /**
    * Composes two triggers with logical OR.
    *
    * @return A trigger which is active when either component trigger is active.
    */
   Trigger operator||(Trigger rhs) {
     return Trigger([*this, rhs] { return m_isActive() || rhs.m_isActive(); });
-  }
-
-  /**
-   * Composes a trigger and a boolean function with logical OR.
-   *
-   * @return A trigger which is active when either component is active.
-   */
-  Trigger operator||(std::function<bool()> rhs) {
-    return Trigger([*this, rhs] { return m_isActive() || rhs(); });
   }
 
   /**

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
@@ -35,7 +35,7 @@ class Trigger {
    *
    * @param isActive Whether the trigger is active.
    */
-  Trigger(std::function<bool()> isActive) // NOLINT
+  Trigger(std::function<bool()> isActive)  // NOLINT
       : m_isActive{std::move(isActive)} {}
 
   /**

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
@@ -331,12 +331,30 @@ class Trigger {
   }
 
   /**
+   * Composes a trigger and a boolean function with logical AND.
+   *
+   * @return A trigger which is active when both components are active.
+   */
+  Trigger operator&&(std::function<bool()> rhs) {
+    return Trigger([*this, rhs] { return m_isActive() && rhs(); });
+  }
+
+  /**
    * Composes two triggers with logical OR.
    *
    * @return A trigger which is active when either component trigger is active.
    */
   Trigger operator||(Trigger rhs) {
     return Trigger([*this, rhs] { return m_isActive() || rhs.m_isActive(); });
+  }
+
+  /**
+   * Composes a trigger and a boolean function with logical OR.
+   *
+   * @return A trigger which is active when either component is active.
+   */
+  Trigger operator||(std::function<bool()> rhs) {
+    return Trigger([*this, rhs] { return m_isActive() || rhs(); });
   }
 
   /**

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/ButtonTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/ButtonTest.java
@@ -181,6 +181,8 @@ class ButtonTest extends CommandTestBase {
     InternalButton button1 = new InternalButton();
     BooleanSupplier booleanSupplier = () -> false;
 
+    button1.setPressed(true);
+
     assertFalse(button1.and(booleanSupplier).get());
     assertTrue(button1.or(booleanSupplier).get());
   }

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/ButtonTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/ButtonTest.java
@@ -18,6 +18,8 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.CommandTestBase;
 import org.junit.jupiter.api.Test;
 
+import java.util.function.BooleanSupplier;
+
 class ButtonTest extends CommandTestBase {
   @Test
   void whenPressedTest() {
@@ -172,6 +174,15 @@ class ButtonTest extends CommandTestBase {
     assertTrue(button1.or(button2).get());
     assertFalse(button1.negate().get());
     assertTrue(button1.and(button2.negate()).get());
+  }
+
+  @Test
+  void buttonCompositionSupplierTest() {
+    InternalButton button1 = new InternalButton();
+    BooleanSupplier booleanSupplier = () -> false;
+
+    assertFalse(button1.and(booleanSupplier).get());
+    assertTrue(button1.or(booleanSupplier).get());
   }
 
   @Test

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/ButtonTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/ButtonTest.java
@@ -16,9 +16,8 @@ import edu.wpi.first.wpilibj.simulation.SimHooks;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.CommandTestBase;
-import org.junit.jupiter.api.Test;
-
 import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.Test;
 
 class ButtonTest extends CommandTestBase {
   @Test


### PR DESCRIPTION
Adds ability to do:
```java
button.and(intake::isDeployed).whileActiveContinuous(new RunIntakeCommand(intake));
```
Previously one would have to do:
```java
button.and(new Trigger(intake::isDeployed)).whileActiveContinuous(new RunIntakeCommand(intake));
```

My C++ is very lacking so help on that would be appreciated. 