### PR TITLE
[wpimath] Fix reference to Rotation2d.fromRadians() (NFC)

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation2d.java
@@ -71,7 +71,7 @@ public class Rotation2d implements Interpolatable<Rotation2d> {
    * Adds two rotations together, with the result being bounded between -pi and pi.
    *
    * <p>For example, <code>Rotation2d.fromDegrees(30).plus(Rotation2d.fromDegrees(60))</code> equals
-   * <code>Rotation2d.fromRadians(Math.PI/2.0)</code>
+   * <code>Rotation2d(Math.PI/2.0)</code>
    *
    * @param other The rotation to add.
    * @return The sum of the two rotations.
@@ -84,7 +84,7 @@ public class Rotation2d implements Interpolatable<Rotation2d> {
    * Subtracts the new rotation from the current rotation and returns the new rotation.
    *
    * <p>For example, <code>Rotation2d.fromDegrees(10).minus(Rotation2d.fromDegrees(100))</code>
-   * equals <code>Rotation2d.fromRadians(-Math.PI/2.0)</code>
+   * equals <code>Rotation2d(-Math.PI/2.0)</code>
    *
    * @param other The rotation to subtract.
    * @return The difference between the two rotations.


### PR DESCRIPTION
Rotation2d.fromRadians() doesn't exist. The constructor should be used
instead.