### PR TITLE
Fix boolean supplier with buttons

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
@@ -69,7 +69,7 @@ public class Trigger implements BooleanSupplier {
    * @return whether or not the trigger condition is active.
    */
   @Override
-  public boolean getAsBoolean() {
+  public final boolean getAsBoolean() {
     return this.get();
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
@@ -56,7 +56,7 @@ public class Trigger implements BooleanSupplier {
    * @return whether or not the trigger condition is active.
    */
   public boolean get() {
-    return this.getAsBoolean();
+    return m_isActive.getAsBoolean();
   }
 
   /**
@@ -70,7 +70,7 @@ public class Trigger implements BooleanSupplier {
    */
   @Override
   public boolean getAsBoolean() {
-    return m_isActive.getAsBoolean();
+    return this.get();
   }
 
   /**

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/ButtonTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/ButtonTest.java
@@ -195,4 +195,14 @@ class ButtonTest extends CommandTestBase {
     scheduler.run();
     verify(command).schedule(true);
   }
+
+
+  @Test
+  void booleanSupplierTest() {
+    InternalButton button = new InternalButton();
+
+    assertFalse(button.getAsBoolean());
+    button.setPressed(true);
+    assertTrue(button.getAsBoolean());
+  }
 }

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/ButtonTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/ButtonTest.java
@@ -196,7 +196,6 @@ class ButtonTest extends CommandTestBase {
     verify(command).schedule(true);
   }
 
-
   @Test
   void booleanSupplierTest() {
     InternalButton button = new InternalButton();


### PR DESCRIPTION
When you called `JoystickButton#getAsBoolean` it would always return false as the `get` method it inherited was not used in the `getAsBoolean` defined in the `Trigger` class. I think this should fix it, but I have an M1 mac and do not have the know how to get this to build. I wrote a short test to check if it does. 