### PR TITLE
[wpilib] Rename enabled to isEnabled in the compressor class

### DIFF
--- a/wpilibc/src/main/native/cpp/Compressor.cpp
+++ b/wpilibc/src/main/native/cpp/Compressor.cpp
@@ -43,6 +43,10 @@ void Compressor::Stop() {
 }
 
 bool Compressor::Enabled() const {
+  return IsEnabled();
+}
+
+bool Compressor::IsEnabled() const {
   return m_module->GetCompressor();
 }
 
@@ -87,7 +91,7 @@ CompressorConfigType Compressor::GetConfigType() const {
 void Compressor::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Compressor");
   builder.AddBooleanProperty(
-      "Enabled", [=] { return Enabled(); }, nullptr);
+      "Enabled", [=] { return IsEnabled(); }, nullptr);
   builder.AddBooleanProperty(
       "Pressure switch", [=]() { return GetPressureSwitchValue(); }, nullptr);
 }

--- a/wpilibc/src/main/native/include/frc/Compressor.h
+++ b/wpilibc/src/main/native/include/frc/Compressor.h
@@ -78,10 +78,20 @@ class Compressor : public wpi::Sendable,
 
   /**
    * Check if compressor output is active.
+   * To (re)enable the compressor use EnableDigital() or EnableAnalog(...).
    *
-   * @return true if the compressor is on
+   * @return true if the compressor is on.
+   * @deprecated To avoid confusion in thinking this (re)enables the compressor use IsEnabled().
    */
+  WPI_DEPRECATED("To avoid confusion in thinking this (re)enables the compressor use IsEnabled()")
   bool Enabled() const;
+
+  /**
+   * Returns whether the compressor is active or not.
+   *
+   * @return ture if the compressor is on - otherwise false.
+   */
+  bool IsEnabled() const;
 
   /**
    * Check if the pressure switch is triggered.

--- a/wpilibc/src/main/native/include/frc/Compressor.h
+++ b/wpilibc/src/main/native/include/frc/Compressor.h
@@ -92,7 +92,7 @@ class Compressor : public wpi::Sendable,
   /**
    * Returns whether the compressor is active or not.
    *
-   * @return ture if the compressor is on - otherwise false.
+   * @return true if the compressor is on - otherwise false.
    */
   bool IsEnabled() const;
 

--- a/wpilibc/src/main/native/include/frc/Compressor.h
+++ b/wpilibc/src/main/native/include/frc/Compressor.h
@@ -81,9 +81,12 @@ class Compressor : public wpi::Sendable,
    * To (re)enable the compressor use EnableDigital() or EnableAnalog(...).
    *
    * @return true if the compressor is on.
-   * @deprecated To avoid confusion in thinking this (re)enables the compressor use IsEnabled().
+   * @deprecated To avoid confusion in thinking this (re)enables the compressor
+   * use IsEnabled().
    */
-  WPI_DEPRECATED("To avoid confusion in thinking this (re)enables the compressor use IsEnabled()")
+  WPI_DEPRECATED(
+      "To avoid confusion in thinking this (re)enables the compressor use "
+      "IsEnabled()")
   bool Enabled() const;
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
@@ -105,7 +105,7 @@ public class Compressor implements Sendable, AutoCloseable {
   /**
    * Returns whether the compressor is active or not.
    *
-   * @return ture if the compressor is on - otherwise false.
+   * @return true if the compressor is on - otherwise false.
    */
   public boolean isEnabled() {
     return m_module.getCompressor();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
@@ -28,7 +28,7 @@ public class Compressor implements Sendable, AutoCloseable {
   /**
    * Constructs a compressor for a specified module and type.
    *
-   * @param module     The module ID to use.
+   * @param module The module ID to use.
    * @param moduleType The module type to use.
    */
   public Compressor(int module, PneumaticsModuleType moduleType) {
@@ -91,8 +91,8 @@ public class Compressor implements Sendable, AutoCloseable {
   }
 
   /**
-   * Get the status of the compressor.
-   * To (re)enable the compressor use enableDigital() or enableAnalog(...).
+   * Get the status of the compressor. To (re)enable the compressor use enableDigital() or
+   * enableAnalog(...).
    *
    * @return true if the compressor is on
    * @deprecated To avoid confusion in thinking this (re)enables the compressor use IsEnabled().
@@ -148,16 +148,12 @@ public class Compressor implements Sendable, AutoCloseable {
     return m_module.getPressure(0);
   }
 
-  /**
-   * Disable the compressor.
-   */
+  /** Disable the compressor. */
   public void disable() {
     m_module.disableCompressor();
   }
 
-  /**
-   * Enable compressor closed loop control using digital input.
-   */
+  /** Enable compressor closed loop control using digital input. */
   public void enableDigital() {
     m_module.enableCompressorDigital();
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
@@ -28,7 +28,7 @@ public class Compressor implements Sendable, AutoCloseable {
   /**
    * Constructs a compressor for a specified module and type.
    *
-   * @param module The module ID to use.
+   * @param module     The module ID to use.
    * @param moduleType The module type to use.
    */
   public Compressor(int module, PneumaticsModuleType moduleType) {
@@ -97,13 +97,14 @@ public class Compressor implements Sendable, AutoCloseable {
    * @return true if the compressor is on
    * @deprecated To avoid confusion in thinking this (re)enables the compressor use IsEnabled().
    */
-  @Deprecated(since = "2022", forRemoval = true)
+  @Deprecated(since = "2023", forRemoval = true)
   public boolean enabled() {
     return isEnabled();
   }
 
   /**
    * Returns whether the compressor is active or not.
+   *
    * @return ture if the compressor is on - otherwise false.
    */
   public boolean isEnabled() {
@@ -147,12 +148,16 @@ public class Compressor implements Sendable, AutoCloseable {
     return m_module.getPressure(0);
   }
 
-  /** Disable the compressor. */
+  /**
+   * Disable the compressor.
+   */
   public void disable() {
     m_module.disableCompressor();
   }
 
-  /** Enable compressor closed loop control using digital input. */
+  /**
+   * Enable compressor closed loop control using digital input.
+   */
   public void enableDigital() {
     m_module.enableCompressorDigital();
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Compressor.java
@@ -92,10 +92,21 @@ public class Compressor implements Sendable, AutoCloseable {
 
   /**
    * Get the status of the compressor.
+   * To (re)enable the compressor use enableDigital() or enableAnalog(...).
    *
    * @return true if the compressor is on
+   * @deprecated To avoid confusion in thinking this (re)enables the compressor use IsEnabled().
    */
+  @Deprecated(since = "2022", forRemoval = true)
   public boolean enabled() {
+    return isEnabled();
+  }
+
+  /**
+   * Returns whether the compressor is active or not.
+   * @return ture if the compressor is on - otherwise false.
+   */
+  public boolean isEnabled() {
     return m_module.getCompressor();
   }
 
@@ -184,7 +195,7 @@ public class Compressor implements Sendable, AutoCloseable {
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("Compressor");
-    builder.addBooleanProperty("Enabled", this::enabled, null);
+    builder.addBooleanProperty("Enabled", this::isEnabled, null);
     builder.addBooleanProperty("Pressure switch", this::getPressureSwitchValue, null);
   }
 }


### PR DESCRIPTION
Heya!

A few members on my team confused the `enabled()` function in the compressor class for the function that re-enables the compressor. 

While I did point out that the documentation said the function in question just retrieves whether the compressor is on, and later found the function they should actually be using I couldn't help but notice how easy it was for them (and potentially others) to get confused. 

As a result I added the function `isEnabled()` to replace the `enabled()` function in the compressor clwss with the hope that it will lead to less confusion. 

In order to not have it break existing teams' code I chose to just deprecate the old function and point it to the new one, but keep the functionality the same. 