### PR TITLE
[hal] Fix miss-spelling in AnalogInput/Output docs (NFC)

### DIFF
--- a/hal/src/main/native/include/hal/AnalogInput.h
+++ b/hal/src/main/native/include/hal/AnalogInput.h
@@ -46,7 +46,7 @@ void HAL_FreeAnalogInputPort(HAL_AnalogInputHandle analogPortHandle);
 HAL_Bool HAL_CheckAnalogModule(int32_t module);
 
 /**
- * Checks that the analog output channel number is value.
+ * Checks that the analog output channel number is valid.
  * Verifies that the analog channel number is one of the legal channel numbers.
  * Channel numbers are 0-based.
  *

--- a/hal/src/main/native/include/hal/AnalogOutput.h
+++ b/hal/src/main/native/include/hal/AnalogOutput.h
@@ -58,7 +58,7 @@ double HAL_GetAnalogOutput(HAL_AnalogOutputHandle analogOutputHandle,
                            int32_t* status);
 
 /**
- * Checks that the analog output channel number is value.
+ * Checks that the analog output channel number is valid.
  *
  * Verifies that the analog channel number is one of the legal channel numbers.
  * Channel numbers are 0-based.


### PR DESCRIPTION
If I find more doc misspellings, is there a different process I should follow? I kind of feel like I'm just generating noise in the issue tracker.