### PR TITLE
Correct documentation on updateNotifierAlarm

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/NotifierJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/NotifierJNI.java
@@ -52,7 +52,7 @@ public class NotifierJNI extends JNIWrapper {
   public static native void cleanNotifier(int notifierHandle);
 
   /**
-   * Sets the notifier to wakeup the waiter in another triggerTime microseconds.
+   * Sets the notifier to wake up the waiter at triggerTime microseconds.
    *
    * @param notifierHandle Notifier handle.
    * @param triggerTime Trigger time in microseconds.


### PR DESCRIPTION
The previous documentation suggested that `triggerTime` is the interval until the next alarm, but I believe the implementation is that it is the absolute alarm time.