### PR TITLE
Update Java linters and fix new PMD errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,8 @@ plugins {
     id 'visual-studio'
     id 'net.ltgt.errorprone' version '2.0.2' apply false
     id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
-    id 'com.diffplug.spotless' version '6.1.2' apply false
-    id 'com.github.spotbugs' version '5.0.4' apply false
+    id 'com.diffplug.spotless' version '6.4.2' apply false
+    id 'com.github.spotbugs' version '5.0.6' apply false
 }
 
 wpilibVersioning.buildServerMode = project.hasProperty('buildServer')

--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -120,7 +120,7 @@ task run(type: JavaExec) {
 build.dependsOn devClasses
 
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = "0.8.8"
 }
 
 jacocoTestReport {

--- a/shared/java/javastyle.gradle
+++ b/shared/java/javastyle.gradle
@@ -2,7 +2,7 @@ if (!project.hasProperty('skipJavaFormat')) {
     apply plugin: 'checkstyle'
 
     checkstyle {
-        toolVersion = "9.2"
+        toolVersion = "10.1"
         configDirectory = file("${project.rootDir}/styleguide")
         config = resources.text.fromFile(new File(configDirectory.get().getAsFile(), "checkstyle.xml"))
     }
@@ -10,7 +10,7 @@ if (!project.hasProperty('skipJavaFormat')) {
     apply plugin: 'pmd'
 
     pmd {
-        toolVersion = '6.41.0'
+        toolVersion = '6.44.0'
         consoleOutput = true
         reportsDir = file("$project.buildDir/reports/pmd")
         ruleSetFiles = files(new File(rootDir, "styleguide/pmd-ruleset.xml"))

--- a/wpilibc/src/main/native/include/frc/DriverStation.h
+++ b/wpilibc/src/main/native/include/frc/DriverStation.h
@@ -19,7 +19,7 @@ namespace frc {
  * Provide access to the network communication data to / from the Driver
  * Station.
  */
-class DriverStation {
+class DriverStation final {
  public:
   enum Alliance { kRed, kBlue, kInvalid };
   enum MatchType { kNone, kPractice, kQualification, kElimination };

--- a/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
+++ b/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
@@ -18,7 +18,7 @@ namespace frc {
  * The LiveWindow class is the public interface for putting sensors and
  * actuators on the LiveWindow.
  */
-class LiveWindow {
+class LiveWindow final {
  public:
   /**
    * Get an instance of the LiveWindow main class.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -24,7 +24,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /** Provide access to the network communication data to / from the Driver Station. */
-public class DriverStation {
+public final class DriverStation {
   /** Number of Joystick Ports. */
   public static final int kJoystickPorts = 6;
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/counter/UpDownCounter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/counter/UpDownCounter.java
@@ -21,8 +21,8 @@ import java.nio.ByteOrder;
  * digital input and down on an edge from another digital input.
  */
 public class UpDownCounter implements Sendable, AutoCloseable {
-  private DigitalSource m_upSource;
-  private DigitalSource m_downSource;
+  private final DigitalSource m_upSource;
+  private final DigitalSource m_downSource;
 
   private final int m_handle;
 
@@ -43,6 +43,8 @@ public class UpDownCounter implements Sendable, AutoCloseable {
       CounterJNI.setCounterUpSource(
           m_handle, upSource.getPortHandleForRouting(), upSource.getAnalogTriggerTypeForRouting());
       CounterJNI.setCounterUpSourceEdge(m_handle, true, false);
+    } else {
+      m_upSource = null;
     }
 
     if (downSource != null) {
@@ -52,6 +54,8 @@ public class UpDownCounter implements Sendable, AutoCloseable {
           downSource.getPortHandleForRouting(),
           downSource.getAnalogTriggerTypeForRouting());
       CounterJNI.setCounterDownSourceEdge(m_handle, true, false);
+    } else {
+      m_downSource = null;
     }
 
     reset();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -14,7 +14,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableBuilderImpl;
 /**
  * The LiveWindow class is the public interface for putting sensors and actuators on the LiveWindow.
  */
-public class LiveWindow {
+public final class LiveWindow {
   private static class Component {
     boolean m_firstTime = true;
     boolean m_telemetryEnabled = true;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/romireference/sensors/RomiGyro.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/romireference/sensors/RomiGyro.java
@@ -9,12 +9,12 @@ import edu.wpi.first.hal.SimDevice.Direction;
 import edu.wpi.first.hal.SimDouble;
 
 public class RomiGyro {
-  private SimDouble m_simRateX;
-  private SimDouble m_simRateY;
-  private SimDouble m_simRateZ;
-  private SimDouble m_simAngleX;
-  private SimDouble m_simAngleY;
-  private SimDouble m_simAngleZ;
+  private final SimDouble m_simRateX;
+  private final SimDouble m_simRateY;
+  private final SimDouble m_simRateZ;
+  private final SimDouble m_simAngleX;
+  private final SimDouble m_simAngleY;
+  private final SimDouble m_simAngleZ;
 
   private double m_angleXOffset;
   private double m_angleYOffset;
@@ -32,6 +32,14 @@ public class RomiGyro {
       m_simAngleX = gyroSimDevice.createDouble("angle_x", Direction.kInput, 0.0);
       m_simAngleY = gyroSimDevice.createDouble("angle_y", Direction.kInput, 0.0);
       m_simAngleZ = gyroSimDevice.createDouble("angle_z", Direction.kInput, 0.0);
+    } else {
+      m_simRateX = null;
+      m_simRateY = null;
+      m_simRateZ = null;
+
+      m_simAngleX = null;
+      m_simAngleY = null;
+      m_simAngleZ = null;
     }
   }
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/romireference/subsystems/OnBoardIO.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/romireference/subsystems/OnBoardIO.java
@@ -22,12 +22,12 @@ public class OnBoardIO extends SubsystemBase {
   private final DigitalOutput m_yellowLed = new DigitalOutput(3);
 
   // DIO 1
-  private DigitalInput m_buttonB;
-  private DigitalOutput m_greenLed;
+  private final DigitalInput m_buttonB;
+  private final DigitalOutput m_greenLed;
 
   // DIO 2
-  private DigitalInput m_buttonC;
-  private DigitalOutput m_redLed;
+  private final DigitalInput m_buttonC;
+  private final DigitalOutput m_redLed;
 
   private static final double MESSAGE_INTERVAL = 1.0;
   private double m_nextMessageTime;
@@ -46,13 +46,17 @@ public class OnBoardIO extends SubsystemBase {
   public OnBoardIO(ChannelMode dio1, ChannelMode dio2) {
     if (dio1 == ChannelMode.INPUT) {
       m_buttonB = new DigitalInput(1);
+      m_greenLed = null;
     } else {
+      m_buttonB = null;
       m_greenLed = new DigitalOutput(1);
     }
 
     if (dio2 == ChannelMode.INPUT) {
       m_buttonC = new DigitalInput(2);
+      m_redLed = null;
     } else {
+      m_buttonC = null;
       m_redLed = new DigitalOutput(2);
     }
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/subsystems/DriveSubsystem.java
@@ -62,11 +62,11 @@ public class DriveSubsystem extends SubsystemBase {
 
   // These classes help us simulate our drivetrain
   public DifferentialDrivetrainSim m_drivetrainSimulator;
-  private EncoderSim m_leftEncoderSim;
-  private EncoderSim m_rightEncoderSim;
+  private final EncoderSim m_leftEncoderSim;
+  private final EncoderSim m_rightEncoderSim;
   // The Field2d class shows the field in the sim GUI
-  private Field2d m_fieldSim;
-  private ADXRS450_GyroSim m_gyroSim;
+  private final Field2d m_fieldSim;
+  private final ADXRS450_GyroSim m_gyroSim;
 
   /** Creates a new DriveSubsystem. */
   public DriveSubsystem() {
@@ -101,6 +101,12 @@ public class DriveSubsystem extends SubsystemBase {
       // the Field2d class lets us visualize our robot in the simulation GUI.
       m_fieldSim = new Field2d();
       SmartDashboard.putData("Field", m_fieldSim);
+    } else {
+      m_leftEncoderSim = null;
+      m_rightEncoderSim = null;
+      m_gyroSim = null;
+
+      m_fieldSim = null;
     }
   }
 

--- a/wpimath/src/main/java/edu/wpi/first/math/interpolation/TimeInterpolatableBuffer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/interpolation/TimeInterpolatableBuffer.java
@@ -16,7 +16,7 @@ import java.util.TreeMap;
  *
  * @param <T> The type stored in this buffer.
  */
-public class TimeInterpolatableBuffer<T> {
+public final class TimeInterpolatableBuffer<T> {
   private final double m_historySize;
   private final InterpolateFunction<T> m_interpolatingFunc;
   private final NavigableMap<Double, T> m_buffer = new TreeMap<>();

--- a/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableRegistry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableRegistry.java
@@ -17,7 +17,7 @@ import java.util.function.Supplier;
  * The SendableRegistry class is the public interface for registering sensors and actuators for use
  * on dashboards and LiveWindow.
  */
-public class SendableRegistry {
+public final class SendableRegistry {
   private static class Component {
     Component() {}
 

--- a/wpiutil/src/main/native/include/wpi/sendable/SendableRegistry.h
+++ b/wpiutil/src/main/native/include/wpi/sendable/SendableRegistry.h
@@ -20,7 +20,7 @@ class SendableBuilder;
  * The SendableRegistry class is the public interface for registering sensors
  * and actuators for use on dashboards and LiveWindow.
  */
-class SendableRegistry {
+class SendableRegistry final {
  public:
   SendableRegistry() = delete;
 


### PR DESCRIPTION
PMD requires that variables only initialized in the constructor be
final. The compiler errors if those final variables aren't guaranteed to
be initialized, so extra else branches were added to ensure that.

PMD also requires that classes with only private constructors be final.
The equivalent C++ classes were finalized as well, except for
TimeInterpolatableBuffer because it doesn't expose factory functions.