### PR TITLE
[wpilibj] Remove finalizers

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Notifier.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Notifier.java
@@ -31,12 +31,6 @@ public class Notifier implements AutoCloseable {
   private double m_periodSeconds;
 
   @Override
-  @SuppressWarnings("NoFinalizer")
-  protected void finalize() {
-    close();
-  }
-
-  @Override
   public void close() {
     int handle = m_notifier.getAndSet(0);
     if (handle == 0) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/TimedRobot.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/TimedRobot.java
@@ -94,8 +94,7 @@ public class TimedRobot extends IterativeRobotBase {
   }
 
   @Override
-  @SuppressWarnings("NoFinalizer")
-  protected void finalize() {
+  public void close() {
     NotifierJNI.stopNotifier(m_notifier);
     NotifierJNI.cleanNotifier(m_notifier);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CallbackStore.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CallbackStore.java
@@ -93,16 +93,4 @@ public class CallbackStore implements AutoCloseable {
     }
     m_cancelType = -1;
   }
-
-  @SuppressWarnings({"NoFinalizer", "deprecation"})
-  @Override
-  protected void finalize() throws Throwable {
-    try {
-      if (m_cancelType >= 0) {
-        close(); // close open files
-      }
-    } finally {
-      super.finalize();
-    }
-  }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
@@ -20,14 +20,13 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class SendableBuilderImpl implements NTSendableBuilder {
-  private static class Property {
+  private static class Property implements AutoCloseable {
     Property(NetworkTable table, String key) {
       m_entry = table.getEntry(key);
     }
 
     @Override
-    @SuppressWarnings("NoFinalizer")
-    protected synchronized void finalize() {
+    public void close() {
       stopListener();
     }
 


### PR DESCRIPTION
They were deprecated for removal in Java 18 because they're error-prone.
Prefer AutoCloseable and Cleaner instead.

https://openjdk.java.net/jeps/421
https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/ref/Cleaner.html