### PR TITLE
fix comment in degreesToRotations

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
@@ -91,7 +91,7 @@ public final class Units {
    * Converts given degrees to rotations.
    *
    * @param degrees The degrees to convert.
-   * @return rotations Converted from radians.
+   * @return rotations Converted from degrees.
    */
   public static double degreesToRotations(double degrees) {
     return degrees / 360;


### PR DESCRIPTION
degreesToRotations in Units refers to radians in the return value comment instead of degrees.