### PR TITLE
[wpiutil] DataLog: Add LazyLog variant for each LogEntry type

### DIFF
--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/BooleanArrayLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/BooleanArrayLogEntry.java
@@ -40,6 +40,6 @@ public class BooleanArrayLogEntry extends DataLogEntry {
    * @param value Value to record
    */
   public void append(boolean[] value) {
-    m_log.appendBooleanArray(m_entry, value, 0);
+    append(value, 0);
   }
 }

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/BooleanLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/BooleanLogEntry.java
@@ -40,6 +40,6 @@ public class BooleanLogEntry extends DataLogEntry {
    * @param value Value to record
    */
   public void append(boolean value) {
-    m_log.appendBoolean(m_entry, value, 0);
+    append(value, 0);
   }
 }

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/DoubleArrayLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/DoubleArrayLogEntry.java
@@ -40,6 +40,6 @@ public class DoubleArrayLogEntry extends DataLogEntry {
    * @param value Value to record
    */
   public void append(double[] value) {
-    m_log.appendDoubleArray(m_entry, value, 0);
+    append(value, 0);
   }
 }

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/DoubleLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/DoubleLogEntry.java
@@ -40,6 +40,6 @@ public class DoubleLogEntry extends DataLogEntry {
    * @param value Value to record
    */
   public void append(double value) {
-    m_log.appendDouble(m_entry, value, 0);
+    append(value, 0);
   }
 }

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/FloatArrayLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/FloatArrayLogEntry.java
@@ -40,6 +40,6 @@ public class FloatArrayLogEntry extends DataLogEntry {
    * @param value Value to record
    */
   public void append(float[] value) {
-    m_log.appendFloatArray(m_entry, value, 0);
+    append(value, 0);
   }
 }

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/FloatLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/FloatLogEntry.java
@@ -40,6 +40,6 @@ public class FloatLogEntry extends DataLogEntry {
    * @param value Value to record
    */
   public void append(float value) {
-    m_log.appendFloat(m_entry, value, 0);
+    append(value, 0);
   }
 }

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/IntegerArrayLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/IntegerArrayLogEntry.java
@@ -40,6 +40,6 @@ public class IntegerArrayLogEntry extends DataLogEntry {
    * @param value Value to record
    */
   public void append(long[] value) {
-    m_log.appendIntegerArray(m_entry, value, 0);
+    append(value, 0);
   }
 }

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/IntegerLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/IntegerLogEntry.java
@@ -40,6 +40,6 @@ public class IntegerLogEntry extends DataLogEntry {
    * @param value Value to record
    */
   public void append(long value) {
-    m_log.appendInteger(m_entry, value, 0);
+    append(value, 0);
   }
 }

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyBooleanArrayLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyBooleanArrayLogEntry.java
@@ -1,0 +1,34 @@
+package edu.wpi.first.util.datalog;
+
+import java.util.Arrays;
+
+/** Lazy log array of boolean values. This will only write if the value has been changed since last append call */
+public class LazyBooleanArrayLogEntry extends BooleanArrayLogEntry {
+    private boolean[] lastValue;
+    private boolean firstAppend = true;
+
+    public LazyBooleanArrayLogEntry(DataLog log, String name, String metadata, long timestamp) {
+        super(log, name, metadata, timestamp);
+    }
+
+    public LazyBooleanArrayLogEntry(DataLog log, String name, String metadata) {
+        super(log, name, metadata);
+    }
+
+    public LazyBooleanArrayLogEntry(DataLog log, String name, long timestamp) {
+        super(log, name, timestamp);
+    }
+
+    public LazyBooleanArrayLogEntry(DataLog log, String name) {
+        super(log, name);
+    }
+
+    @Override
+    public void append(boolean[] value, long timestamp) {
+        if (firstAppend || !Arrays.equals(value, lastValue)) {
+            firstAppend = false;
+            lastValue = value;
+            super.append(value, timestamp);
+        }
+    }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyBooleanLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyBooleanLogEntry.java
@@ -1,0 +1,32 @@
+package edu.wpi.first.util.datalog;
+
+/** Lazy log boolean values. This will only write if the value has been changed since last append call */
+public class LazyBooleanLogEntry extends BooleanLogEntry {
+    private boolean lastValue;
+    private boolean firstAppend = true;
+
+    public LazyBooleanLogEntry(DataLog log, String name, String metadata, long timestamp) {
+        super(log, name, metadata, timestamp);
+    }
+
+    public LazyBooleanLogEntry(DataLog log, String name, String metadata) {
+        super(log, name, metadata);
+    }
+
+    public LazyBooleanLogEntry(DataLog log, String name, long timestamp) {
+        super(log, name, timestamp);
+    }
+
+    public LazyBooleanLogEntry(DataLog log, String name) {
+        super(log, name);
+    }
+
+    @Override
+    public void append(boolean value, long timestamp) {
+        if (firstAppend || value != lastValue) {
+            firstAppend = false;
+            lastValue = value;
+            super.append(value, timestamp);
+        }
+    }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyDoubleArrayLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyDoubleArrayLogEntry.java
@@ -1,0 +1,34 @@
+package edu.wpi.first.util.datalog;
+
+import java.util.Arrays;
+
+/** Lazy log array of double values. This will only write if the value has been changed since last append call */
+public class LazyDoubleArrayLogEntry extends DoubleArrayLogEntry {
+    private double[] lastValue;
+    private boolean firstCall = true;
+
+    public LazyDoubleArrayLogEntry(DataLog log, String name, String metadata, long timestamp) {
+        super(log, name, metadata, timestamp);
+    }
+
+    public LazyDoubleArrayLogEntry(DataLog log, String name, String metadata) {
+        super(log, name, metadata);
+    }
+
+    public LazyDoubleArrayLogEntry(DataLog log, String name, long timestamp) {
+        super(log, name, timestamp);
+    }
+
+    public LazyDoubleArrayLogEntry(DataLog log, String name) {
+        super(log, name);
+    }
+
+    @Override
+    public void append(double[] value, long timestamp) {
+        if (firstCall || !Arrays.equals(value, lastValue)) {
+            firstCall = false;
+            lastValue = value;
+            super.append(value, timestamp);
+        }
+    }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyDoubleLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyDoubleLogEntry.java
@@ -1,0 +1,32 @@
+package edu.wpi.first.util.datalog;
+
+/** Lazy log double values. This will only write if the value has been changed since last append call */
+public class LazyDoubleLogEntry extends DoubleLogEntry {
+    private double lastValue;
+    private boolean firstAppend = true;
+
+    public LazyDoubleLogEntry(DataLog log, String name, String metadata, long timestamp) {
+        super(log, name, metadata, timestamp);
+    }
+
+    public LazyDoubleLogEntry(DataLog log, String name, String metadata) {
+        super(log, name, metadata);
+    }
+
+    public LazyDoubleLogEntry(DataLog log, String name, long timestamp) {
+        super(log, name, timestamp);
+    }
+
+    public LazyDoubleLogEntry(DataLog log, String name) {
+        super(log, name);
+    }
+
+    @Override
+    public void append(double value, long timestamp) {
+        if (firstAppend || value != lastValue) {
+            firstAppend = false;
+            lastValue = value;
+            super.append(value, timestamp);
+        }
+    }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyFloatArrayLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyFloatArrayLogEntry.java
@@ -1,0 +1,34 @@
+package edu.wpi.first.util.datalog;
+
+import java.util.Arrays;
+
+/** Lazy log array of float values. This will only write if the value has been changed since last append call */
+public class LazyFloatArrayLogEntry extends FloatArrayLogEntry {
+    private float[] lastValue;
+    private boolean firstAppend = true;
+
+    public LazyFloatArrayLogEntry(DataLog log, String name, String metadata, long timestamp) {
+        super(log, name, metadata, timestamp);
+    }
+
+    public LazyFloatArrayLogEntry(DataLog log, String name, String metadata) {
+        super(log, name, metadata);
+    }
+
+    public LazyFloatArrayLogEntry(DataLog log, String name, long timestamp) {
+        super(log, name, timestamp);
+    }
+
+    public LazyFloatArrayLogEntry(DataLog log, String name) {
+        super(log, name);
+    }
+
+    @Override
+    public void append(float[] value, long timestamp) {
+        if (firstAppend || !Arrays.equals(value, lastValue)) {
+            firstAppend = false;
+            lastValue = value;
+            super.append(value, timestamp);
+        }
+    }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyFloatLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyFloatLogEntry.java
@@ -1,0 +1,32 @@
+package edu.wpi.first.util.datalog;
+
+/** Lazy log float values. This will only write if the value has been changed since last append call */
+public class LazyFloatLogEntry extends FloatLogEntry {
+    private float lastValue;
+    private boolean firstAppend = true;
+
+    public LazyFloatLogEntry(DataLog log, String name, String metadata, long timestamp) {
+        super(log, name, metadata, timestamp);
+    }
+
+    public LazyFloatLogEntry(DataLog log, String name, String metadata) {
+        super(log, name, metadata);
+    }
+
+    public LazyFloatLogEntry(DataLog log, String name, long timestamp) {
+        super(log, name, timestamp);
+    }
+
+    public LazyFloatLogEntry(DataLog log, String name) {
+        super(log, name);
+    }
+
+    @Override
+    public void append(float value, long timestamp) {
+        if (firstAppend || value != lastValue) {
+            firstAppend = false;
+            lastValue = value;
+            super.append(value, timestamp);
+        }
+    }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyIntegerArrayLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyIntegerArrayLogEntry.java
@@ -1,0 +1,34 @@
+package edu.wpi.first.util.datalog;
+
+import java.util.Arrays;
+
+/** Lazy log array of integer values. This will only write if the value has been changed since last append call */
+public class LazyIntegerArrayLogEntry extends IntegerArrayLogEntry {
+    private long[] lastValue;
+    private boolean firstAppend = true;
+
+    public LazyIntegerArrayLogEntry(DataLog log, String name, String metadata, long timestamp) {
+        super(log, name, metadata, timestamp);
+    }
+
+    public LazyIntegerArrayLogEntry(DataLog log, String name, String metadata) {
+        super(log, name, metadata);
+    }
+
+    public LazyIntegerArrayLogEntry(DataLog log, String name, long timestamp) {
+        super(log, name, timestamp);
+    }
+
+    public LazyIntegerArrayLogEntry(DataLog log, String name) {
+        super(log, name);
+    }
+
+    @Override
+    public void append(long[] value, long timestamp) {
+        if (firstAppend || !Arrays.equals(value, lastValue)) {
+            firstAppend = false;
+            lastValue = value;
+            super.append(value, timestamp);
+        }
+    }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyIntegerLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyIntegerLogEntry.java
@@ -1,0 +1,32 @@
+package edu.wpi.first.util.datalog;
+
+/** Lazy log integer values. This will only write if the value has been changed since last append call */
+public class LazyIntegerLogEntry extends IntegerLogEntry {
+    private long lastValue;
+    private boolean firstAppend = true;
+
+    public LazyIntegerLogEntry(DataLog log, String name, String metadata, long timestamp) {
+        super(log, name, metadata, timestamp);
+    }
+
+    public LazyIntegerLogEntry(DataLog log, String name, String metadata) {
+        super(log, name, metadata);
+    }
+
+    public LazyIntegerLogEntry(DataLog log, String name, long timestamp) {
+        super(log, name, timestamp);
+    }
+
+    public LazyIntegerLogEntry(DataLog log, String name) {
+        super(log, name);
+    }
+
+    @Override
+    public void append(long value, long timestamp) {
+        if (firstAppend || value != lastValue) {
+            firstAppend = false;
+            lastValue = value;
+            super.append(value, timestamp);
+        }
+    }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyRawLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyRawLogEntry.java
@@ -1,0 +1,42 @@
+package edu.wpi.first.util.datalog;
+
+import java.util.Arrays;
+
+/** Lazy log raw byte array values. This will only write if the value has been changed since last append call */
+public class LazyRawLogEntry extends RawLogEntry {
+    private byte[] lastValue;
+    private boolean firstAppend = true;
+
+    public LazyRawLogEntry(DataLog log, String name, String metadata, String type, long timestamp) {
+        super(log, name, metadata, type, timestamp);
+    }
+
+    public LazyRawLogEntry(DataLog log, String name, String metadata, String type) {
+        super(log, name, metadata, type);
+    }
+
+    public LazyRawLogEntry(DataLog log, String name, String metadata, long timestamp) {
+        super(log, name, metadata, timestamp);
+    }
+
+    public LazyRawLogEntry(DataLog log, String name, String metadata) {
+        super(log, name, metadata);
+    }
+
+    public LazyRawLogEntry(DataLog log, String name, long timestamp) {
+        super(log, name, timestamp);
+    }
+
+    public LazyRawLogEntry(DataLog log, String name) {
+        super(log, name);
+    }
+
+    @Override
+    public void append(byte[] value, long timestamp) {
+        if (firstAppend || !Arrays.equals(value, lastValue)) {
+            firstAppend = false;
+            lastValue = value;
+            super.append(value, timestamp);
+        }
+    }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyStringArrayLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyStringArrayLogEntry.java
@@ -1,0 +1,34 @@
+package edu.wpi.first.util.datalog;
+
+import java.util.Arrays;
+
+/** Lazy log array of string values. This will only write if the value has been changed since last append call */
+public class LazyStringArrayLogEntry extends StringArrayLogEntry {
+    private String[] lastValue;
+    private boolean firstAppend = true;
+
+    public LazyStringArrayLogEntry(DataLog log, String name, String metadata, long timestamp) {
+        super(log, name, metadata, timestamp);
+    }
+
+    public LazyStringArrayLogEntry(DataLog log, String name, String metadata) {
+        super(log, name, metadata);
+    }
+
+    public LazyStringArrayLogEntry(DataLog log, String name, long timestamp) {
+        super(log, name, timestamp);
+    }
+
+    public LazyStringArrayLogEntry(DataLog log, String name) {
+        super(log, name);
+    }
+
+    @Override
+    public void append(String[] value, long timestamp) {
+        if (firstAppend || !Arrays.equals(value, lastValue)) {
+            firstAppend = false;
+            lastValue = value;
+            super.append(value, timestamp);
+        }
+    }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyStringLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/LazyStringLogEntry.java
@@ -1,0 +1,40 @@
+package edu.wpi.first.util.datalog;
+
+/** Lazy log string values. This will only write if the value has been changed since last append call */
+public class LazyStringLogEntry extends StringLogEntry {
+    private String lastValue;
+    private boolean firstAppend = true;
+
+    public LazyStringLogEntry(DataLog log, String name, String metadata, String type, long timestamp) {
+        super(log, name, metadata, type, timestamp);
+    }
+
+    public LazyStringLogEntry(DataLog log, String name, String metadata, String type) {
+        super(log, name, metadata, type);
+    }
+
+    public LazyStringLogEntry(DataLog log, String name, String metadata, long timestamp) {
+        super(log, name, metadata, timestamp);
+    }
+
+    public LazyStringLogEntry(DataLog log, String name, String metadata) {
+        super(log, name, metadata);
+    }
+
+    public LazyStringLogEntry(DataLog log, String name, long timestamp) {
+        super(log, name, timestamp);
+    }
+
+    public LazyStringLogEntry(DataLog log, String name) {
+        super(log, name);
+    }
+
+    @Override
+    public void append(String value, long timestamp) {
+        if (firstAppend || !value.equals(lastValue)) {
+            firstAppend = false;
+            lastValue = value;
+            super.append(value, timestamp);
+        }
+    }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/RawLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/RawLogEntry.java
@@ -48,6 +48,6 @@ public class RawLogEntry extends DataLogEntry {
    * @param value Value to record
    */
   public void append(byte[] value) {
-    m_log.appendRaw(m_entry, value, 0);
+    append(value, 0);
   }
 }

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/StringArrayLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/StringArrayLogEntry.java
@@ -40,6 +40,6 @@ public class StringArrayLogEntry extends DataLogEntry {
    * @param value Value to record
    */
   public void append(String[] value) {
-    m_log.appendStringArray(m_entry, value, 0);
+    append(value, 0);
   }
 }

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/StringLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/StringLogEntry.java
@@ -48,6 +48,6 @@ public class StringLogEntry extends DataLogEntry {
    * @param value Value to record
    */
   public void append(String value) {
-    m_log.appendString(m_entry, value, 0);
+    append(value, 0);
   }
 }


### PR DESCRIPTION
These classes help make it easier for only logging when a value changes. Before I (possibly unsuccessfully) add the C++ I'd like some feedback on the Java to make sure I'm in the right direction if this is even something that should be added. I also made it so `append` without timestamp calls its other append method instead of directly calling the `DataLog` with a zeroed timestamp.