### PR TITLE
Increase Gradle JVM heap size

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,7 +23,7 @@ jobs:
             build-options: "-Ponlylinuxaarch64bionic"
           - container: wpilib/ubuntu-base:18.04
             artifact-name: Linux
-            build-options: "-Dorg.gradle.jvmargs=-Xmx2g"
+            build-options: "-Ponlylinuxx86-64"
     name: "Build - ${{ matrix.artifact-name }}"
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # The --add-exports flags work around a bug with spotless and JDK 17
 # https://github.com/diffplug/spotless/issues/834
-org.gradle.jvmargs=-Xmx1g \
+org.gradle.jvmargs=-Xmx2g \
   --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \


### PR DESCRIPTION
I've had to increase it during local compiles since wpimath artifact
publishing runs out of heap.