### PR TITLE
[wpimath] Add Rotation2d.fromRadians factory

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation2d.java
@@ -59,6 +59,16 @@ public class Rotation2d implements Interpolatable<Rotation2d> {
   }
 
   /**
+   * Constructs and returns a Rotation2d with the given radian value.
+   *
+   * @param radians The value of the angle in degrees.
+   * @return The rotation object with the desired angle value.
+   */
+  public static Rotation2d fromRadians(double radians) {
+    return new Rotation2d(radians);
+  }
+
+  /**
    * Constructs and returns a Rotation2d with the given degree value.
    *
    * @param degrees The value of the angle in degrees.

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Rotation2dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Rotation2dTest.java
@@ -15,8 +15,8 @@ class Rotation2dTest {
 
   @Test
   void testRadiansToDegrees() {
-    var rot1 = new Rotation2d(Math.PI / 3);
-    var rot2 = new Rotation2d(Math.PI / 4);
+    var rot1 = Rotation2d.fromRadians(Math.PI / 3);
+    var rot2 = Rotation2d.fromRadians(Math.PI / 4);
 
     assertAll(
         () -> assertEquals(rot1.getDegrees(), 60.0, kEpsilon),


### PR DESCRIPTION
Resolves #4164 

Maybe `fromRotations` can be renamed without a deprecation cycle due to there being no release containing it?