### PR TITLE
Joystick changed to XboxController in gettingstarted example

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
@@ -39,7 +39,8 @@ class Robot : public frc::TimedRobot {
 
   void TeleopPeriodic() override {
     // Drive with arcade style (use right stick to steer)
-    m_robotDrive.ArcadeDrive(m_controller.GetLeftY(), m_controller.GetRightX());
+    m_robotDrive.ArcadeDrive(-m_controller.GetLeftY(),
+                             m_controller.GetRightX());
   }
 
   void TestInit() override {}

--- a/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GettingStarted/cpp/Robot.cpp
@@ -2,9 +2,9 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include <frc/Joystick.h>
 #include <frc/TimedRobot.h>
 #include <frc/Timer.h>
+#include <frc/XboxController.h>
 #include <frc/drive/DifferentialDrive.h>
 #include <frc/motorcontrol/PWMSparkMax.h>
 
@@ -38,8 +38,8 @@ class Robot : public frc::TimedRobot {
   void TeleopInit() override {}
 
   void TeleopPeriodic() override {
-    // Drive with arcade style (use right stick)
-    m_robotDrive.ArcadeDrive(-m_stick.GetY(), m_stick.GetX());
+    // Drive with arcade style (use right stick to steer)
+    m_robotDrive.ArcadeDrive(m_controller.GetLeftY(), m_controller.GetRightX());
   }
 
   void TestInit() override {}
@@ -52,7 +52,7 @@ class Robot : public frc::TimedRobot {
   frc::PWMSparkMax m_right{1};
   frc::DifferentialDrive m_robotDrive{m_left, m_right};
 
-  frc::Joystick m_stick{0};
+  frc::XboxController m_controller{0};
   frc::Timer m_timer;
 };
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gettingstarted/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gettingstarted/Robot.java
@@ -60,7 +60,7 @@ public class Robot extends TimedRobot {
   /** This function is called periodically during teleoperated mode. */
   @Override
   public void teleopPeriodic() {
-    m_robotDrive.arcadeDrive(m_controller.getLeftY(), m_controller.getRightX());
+    m_robotDrive.arcadeDrive(-m_controller.getLeftY(), m_controller.getRightX());
   }
 
   /** This function is called once each time the robot enters test mode. */

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gettingstarted/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gettingstarted/Robot.java
@@ -4,7 +4,7 @@
 
 package edu.wpi.first.wpilibj.examples.gettingstarted;
 
-import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
@@ -20,7 +20,7 @@ public class Robot extends TimedRobot {
   private final PWMSparkMax m_leftDrive = new PWMSparkMax(0);
   private final PWMSparkMax m_rightDrive = new PWMSparkMax(1);
   private final DifferentialDrive m_robotDrive = new DifferentialDrive(m_leftDrive, m_rightDrive);
-  private final Joystick m_stick = new Joystick(0);
+  private final XboxController m_controller = new XboxController(0);
   private final Timer m_timer = new Timer();
 
   /**
@@ -60,7 +60,7 @@ public class Robot extends TimedRobot {
   /** This function is called periodically during teleoperated mode. */
   @Override
   public void teleopPeriodic() {
-    m_robotDrive.arcadeDrive(m_stick.getY(), m_stick.getX());
+    m_robotDrive.arcadeDrive(m_controller.getLeftY(), m_controller.getRightX());
   }
 
   /** This function is called once each time the robot enters test mode. */

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gettingstarted/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gettingstarted/Robot.java
@@ -4,9 +4,9 @@
 
 package edu.wpi.first.wpilibj.examples.gettingstarted;
 
-import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.motorcontrol.PWMSparkMax;
 


### PR DESCRIPTION
Closes #4146

The existing C++ and Java examples differed both in documentation and in code details (such as C++ inverting the y-input but not Java) but for each I stuck closer to the original version. I am also not very proficient at C++ so if that version is lacking help would be appreciated.