### PR TITLE
[command] Rename trigger methods

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Button.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Button.java
@@ -17,7 +17,9 @@ import java.util.function.BooleanSupplier;
  * <p>This class represents a subclass of Trigger that is specifically aimed at buttons on an
  * operator interface as a common use case of the more generalized Trigger objects. This is a simple
  * wrapper around Trigger with the method names renamed to fit the Button object use.
+ * @deprecated Replace with {@link Trigger}.
  */
+@Deprecated
 public class Button extends Trigger {
   /**
    * Default constructor; creates a button that is never pressed.
@@ -31,7 +33,9 @@ public class Button extends Trigger {
    * Creates a new button with the given condition determining whether it is pressed.
    *
    * @param isPressed returns whether or not the trigger should be active
+   * @deprecated Replace with Trigger.
    */
+  @Deprecated
   public Button(BooleanSupplier isPressed) {
     super(isPressed);
   }
@@ -41,7 +45,9 @@ public class Button extends Trigger {
    *
    * @param command the command to start
    * @return this button, so calls can be chained
+   * @deprecated Replace with {@link Trigger#onTrue(Command)}
    */
+  @Deprecated
   public Button whenPressed(final Command command) {
     whenActive(command);
     return this;
@@ -53,7 +59,9 @@ public class Button extends Trigger {
    * @param toRun the runnable to run
    * @param requirements the required subsystems
    * @return this button, so calls can be chained
+   * @deprecated Replace with {@link Trigger#onTrue(Command)}, creating the InstantCommand manually
    */
+  @Deprecated
   public Button whenPressed(final Runnable toRun, Subsystem... requirements) {
     whenActive(toRun, requirements);
     return this;
@@ -67,7 +75,9 @@ public class Button extends Trigger {
    *
    * @param command the command to start
    * @return this button, so calls can be chained
+   * @deprecated Replace with {@link Trigger#whileTrue(Command)}
    */
+  @Deprecated
   public Button whileHeld(final Command command) {
     whileActiveContinuous(command);
     return this;
@@ -79,7 +89,9 @@ public class Button extends Trigger {
    * @param toRun the runnable to run
    * @param requirements the required subsystems
    * @return this button, so calls can be chained
+   * @deprecated Replace with {@link Trigger#whileTrue(Command)}
    */
+  @Deprecated
   public Button whileHeld(final Runnable toRun, Subsystem... requirements) {
     whileActiveContinuous(toRun, requirements);
     return this;
@@ -91,7 +103,9 @@ public class Button extends Trigger {
    *
    * @param command the command to start
    * @return this button, so calls can be chained
+   * @deprecated Replace with {@link Trigger#whileTrue(Command)}
    */
+  @Deprecated
   public Button whenHeld(final Command command) {
     whileActiveOnce(command);
     return this;
@@ -102,7 +116,9 @@ public class Button extends Trigger {
    *
    * @param command the command to start
    * @return this button, so calls can be chained
+   * @deprecated Replace with {@link Trigger#onFalse(Command)}
    */
+  @Deprecated
   public Button whenReleased(final Command command) {
     whenInactive(command);
     return this;
@@ -114,7 +130,9 @@ public class Button extends Trigger {
    * @param toRun the runnable to run
    * @param requirements the required subsystems
    * @return this button, so calls can be chained
+   * @deprecated Replace with {@link Trigger#onFalse(Command)}, creating the InstantCommand manually
    */
+  @Deprecated
   public Button whenReleased(final Runnable toRun, Subsystem... requirements) {
     whenInactive(toRun, requirements);
     return this;
@@ -126,7 +144,9 @@ public class Button extends Trigger {
    *
    * @param command the command to start
    * @return this button, so calls can be chained
+   * @deprecated Replace with {@link Trigger#toggleOnTrue(Command)}
    */
+  @Deprecated
   public Button toggleWhenPressed(final Command command) {
     toggleWhenActive(command);
     return this;
@@ -137,7 +157,10 @@ public class Button extends Trigger {
    *
    * @param command the command to start
    * @return this button, so calls can be chained
+   * @deprecated Instead, pass {@link #rising()} as an end condition to {@link
+   *     Command#until(BooleanSupplier)}.
    */
+  @Deprecated
   public Button cancelWhenPressed(final Command command) {
     cancelWhenActive(command);
     return this;

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Button.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Button.java
@@ -60,7 +60,7 @@ public class Button extends Trigger {
    * @param toRun the runnable to run
    * @param requirements the required subsystems
    * @return this button, so calls can be chained
-   * @deprecated Replace with {@link Trigger#onTrue(Command)}, creating the InstantCommand manually
+   * @deprecated Replace with {@link #onTrue(Command)}, creating the InstantCommand manually
    */
   @Deprecated
   public Button whenPressed(final Runnable toRun, Subsystem... requirements) {
@@ -76,7 +76,8 @@ public class Button extends Trigger {
    *
    * @param command the command to start
    * @return this button, so calls can be chained
-   * @deprecated Replace with {@link Trigger#whileTrue(Command)}
+   * @deprecated Use {@link #whileTrue(Command)} with {@link
+   *     edu.wpi.first.wpilibj2.command.RepeatCommand RepeatCommand}.
    */
   @Deprecated
   public Button whileHeld(final Command command) {
@@ -90,7 +91,7 @@ public class Button extends Trigger {
    * @param toRun the runnable to run
    * @param requirements the required subsystems
    * @return this button, so calls can be chained
-   * @deprecated Replace with {@link Trigger#whileTrue(Command)}
+   * @deprecated Use {@link #whileTrue(Command)} and construct a RunCommand manually
    */
   @Deprecated
   public Button whileHeld(final Runnable toRun, Subsystem... requirements) {

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Button.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Button.java
@@ -17,6 +17,7 @@ import java.util.function.BooleanSupplier;
  * <p>This class represents a subclass of Trigger that is specifically aimed at buttons on an
  * operator interface as a common use case of the more generalized Trigger objects. This is a simple
  * wrapper around Trigger with the method names renamed to fit the Button object use.
+ *
  * @deprecated Replace with {@link Trigger}.
  */
 @Deprecated

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/InternalButton.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/InternalButton.java
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * <p>This class is provided by the NewCommands VendorDep
  */
+@SuppressWarnings("deprecation")
 public class InternalButton extends Button {
   // need to be references, so they can be mutated after being captured in the constructor.
   private final AtomicBoolean m_pressed;

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/JoystickButton.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/JoystickButton.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj.GenericHID;
  *
  * <p>This class is provided by the NewCommands VendorDep
  */
+@SuppressWarnings("deprecation")
 public class JoystickButton extends Button {
   /**
    * Creates a joystick button for triggering commands.

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/NetworkButton.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/NetworkButton.java
@@ -16,6 +16,7 @@ import edu.wpi.first.networktables.NetworkTableInstance;
  *
  * <p>This class is provided by the NewCommands VendorDep
  */
+@SuppressWarnings("deprecation")
 public class NetworkButton extends Button {
   /**
    * Creates a NetworkButton that commands can be bound to.

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/POVButton.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/POVButton.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj.GenericHID;
  *
  * <p>This class is provided by the NewCommands VendorDep
  */
+@SuppressWarnings("deprecation")
 public class POVButton extends Button {
   /**
    * Creates a POV button for triggering commands.

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
@@ -184,8 +184,7 @@ public class Trigger implements BooleanSupplier {
    * @param toRun the runnable to run
    * @param requirements the required subsystems
    * @return this trigger, so calls can be chained
-   * @deprecated Replace with {@link #onTrue(Command)} ) } and constructing the InstantCommand
-   *     manually
+   * @deprecated Replace with {@link #onTrue(Command)}, creating the InstantCommand manually
    */
   @Deprecated
   public Trigger whenActive(final Runnable toRun, Subsystem... requirements) {

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
@@ -129,15 +129,16 @@ public class Trigger implements BooleanSupplier {
    */
   public Trigger toggleOnTrue(Command command) {
     requireNonNullParam(command, "command", "toggleOnRising");
-    m_event.rising()
-            .ifHigh(
-                    () -> {
-                      if (!command.isScheduled()) {
-                        command.schedule();
-                      } else {
-                        command.cancel();
-                      }
-                    });
+    m_event
+        .rising()
+        .ifHigh(
+            () -> {
+              if (!command.isScheduled()) {
+                command.schedule();
+              } else {
+                command.cancel();
+              }
+            });
     return this;
   }
 
@@ -149,15 +150,16 @@ public class Trigger implements BooleanSupplier {
    */
   public Trigger toggleOnFalse(Command command) {
     requireNonNullParam(command, "command", "toggleOnFalling");
-    m_event.falling()
-            .ifHigh(
-                    () -> {
-                      if (!command.isScheduled()) {
-                        command.schedule();
-                      } else {
-                        command.cancel();
-                      }
-                    });
+    m_event
+        .falling()
+        .ifHigh(
+            () -> {
+              if (!command.isScheduled()) {
+                command.schedule();
+              } else {
+                command.cancel();
+              }
+            });
     return this;
   }
 
@@ -182,7 +184,8 @@ public class Trigger implements BooleanSupplier {
    * @param toRun the runnable to run
    * @param requirements the required subsystems
    * @return this trigger, so calls can be chained
-   * @deprecated Replace with {@link #onTrue(Command)} ) } and constructing the InstantCommand manually
+   * @deprecated Replace with {@link #onTrue(Command)} ) } and constructing the InstantCommand
+   *     manually
    */
   @Deprecated
   public Trigger whenActive(final Runnable toRun, Subsystem... requirements) {
@@ -199,8 +202,8 @@ public class Trigger implements BooleanSupplier {
    * @return this trigger, so calls can be chained
    * @deprecated Use {@link #whileTrue(Command)} with {@link
    *     edu.wpi.first.wpilibj2.command.RepeatCommand RepeatCommand}, or bind {@link
-   *     Command#schedule() command::schedule} to {@link BooleanEvent#ifHigh(Runnable)}
-   *     (passing no requirements).
+   *     Command#schedule() command::schedule} to {@link BooleanEvent#ifHigh(Runnable)} (passing no
+   *     requirements).
    */
   @Deprecated
   public Trigger whileActiveContinuous(final Command command) {
@@ -283,7 +286,8 @@ public class Trigger implements BooleanSupplier {
   public Trigger toggleWhenActive(final Command command) {
     requireNonNullParam(command, "command", "toggleWhenActive");
 
-    m_event.rising()
+    m_event
+        .rising()
         .ifHigh(
             () -> {
               if (command.isScheduled()) {
@@ -322,6 +326,7 @@ public class Trigger implements BooleanSupplier {
     return m_event;
   }
 
+  @Override
   public boolean getAsBoolean() {
     return m_event.getAsBoolean();
   }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/Trigger.java
@@ -22,7 +22,9 @@ import java.util.function.BooleanSupplier;
  *
  * <p>This class is provided by the NewCommands VendorDep
  */
-public class Trigger extends BooleanEvent {
+public class Trigger implements BooleanSupplier {
+  private final BooleanEvent m_event;
+
   /**
    * Creates a new trigger with the given condition/digital signal.
    *
@@ -30,7 +32,7 @@ public class Trigger extends BooleanEvent {
    * @param signal the digital signal represented.
    */
   public Trigger(EventLoop loop, BooleanSupplier signal) {
-    super(loop, signal);
+    m_event = new BooleanEvent(loop, signal);
   }
 
   /**
@@ -62,18 +64,101 @@ public class Trigger extends BooleanEvent {
   }
 
   /**
-   * Returns whether or not the trigger is active.
+   * Starts the given command whenever the signal rises from the low state to the high state.
    *
-   * <p>This method will be called repeatedly a command is linked to the Trigger.
-   *
-   * <p>Functionally identical to {@link Trigger#getAsBoolean()}.
-   *
-   * @return whether or not the trigger condition is active.
-   * @deprecated use {@link #getAsBoolean()}
+   * @param command the command to start
+   * @return this trigger, so calls can be chained
+   * @see #rising()
    */
-  @Deprecated
-  public final boolean get() {
-    return getAsBoolean();
+  public Trigger onTrue(Command command) {
+    requireNonNullParam(command, "command", "onRising");
+    m_event.rising().ifHigh(command::schedule);
+    return this;
+  }
+
+  /**
+   * Starts the given command whenever the signal falls from the high state to the low state.
+   *
+   * @param command the command to start
+   * @return this trigger, so calls can be chained
+   * @see #falling()
+   */
+  public Trigger onFalse(Command command) {
+    requireNonNullParam(command, "command", "onFalling");
+    m_event.falling().ifHigh(command::schedule);
+    return this;
+  }
+
+  /**
+   * Starts the given command when the signal rises to the high state and cancels it when the signal
+   * falls.
+   *
+   * <p>Doesn't re-start the command in-between.
+   *
+   * @param command the command to start
+   * @return this trigger, so calls can be chained
+   */
+  public Trigger whileTrue(Command command) {
+    requireNonNullParam(command, "command", "whileHigh");
+    m_event.rising().ifHigh(command::schedule);
+    m_event.falling().ifHigh(command::cancel);
+    return this;
+  }
+
+  /**
+   * Starts the given command when the signal falls to the low state and cancels it when the signal
+   * rises.
+   *
+   * <p>Does not re-start the command in-between.
+   *
+   * @param command the command to start
+   * @return this trigger, so calls can be chained
+   */
+  public Trigger whileFalse(Command command) {
+    requireNonNullParam(command, "command", "whileLow");
+    m_event.falling().ifHigh(command::schedule);
+    m_event.rising().ifHigh(command::cancel);
+    return this;
+  }
+
+  /**
+   * Toggles a command when the signal rises from the low state to the high state.
+   *
+   * @param command the command to toggle
+   * @return this trigger, so calls can be chained
+   */
+  public Trigger toggleOnTrue(Command command) {
+    requireNonNullParam(command, "command", "toggleOnRising");
+    m_event.rising()
+            .ifHigh(
+                    () -> {
+                      if (!command.isScheduled()) {
+                        command.schedule();
+                      } else {
+                        command.cancel();
+                      }
+                    });
+    return this;
+  }
+
+  /**
+   * Toggles a command when the signal rises from the low state to the high state.
+   *
+   * @param command the command to toggle
+   * @return this trigger, so calls can be chained
+   */
+  public Trigger toggleOnFalse(Command command) {
+    requireNonNullParam(command, "command", "toggleOnFalling");
+    m_event.falling()
+            .ifHigh(
+                    () -> {
+                      if (!command.isScheduled()) {
+                        command.schedule();
+                      } else {
+                        command.cancel();
+                      }
+                    });
+    return this;
   }
 
   /**
@@ -81,11 +166,13 @@ public class Trigger extends BooleanEvent {
    *
    * @param command the command to start
    * @return this trigger, so calls can be chained
+   * @deprecated Use {@link #onTrue(Command)} instead.
    */
+  @Deprecated
   public Trigger whenActive(final Command command) {
     requireNonNullParam(command, "command", "whenActive");
 
-    this.rising().ifHigh(command::schedule);
+    m_event.rising().ifHigh(command::schedule);
     return this;
   }
 
@@ -95,7 +182,9 @@ public class Trigger extends BooleanEvent {
    * @param toRun the runnable to run
    * @param requirements the required subsystems
    * @return this trigger, so calls can be chained
+   * @deprecated Replace with {@link #onTrue(Command)} ) } and constructing the InstantCommand manually
    */
+  @Deprecated
   public Trigger whenActive(final Runnable toRun, Subsystem... requirements) {
     return whenActive(new InstantCommand(toRun, requirements));
   }
@@ -108,12 +197,17 @@ public class Trigger extends BooleanEvent {
    *
    * @param command the command to start
    * @return this trigger, so calls can be chained
+   * @deprecated Use {@link #whileTrue(Command)} with {@link
+   *     edu.wpi.first.wpilibj2.command.RepeatCommand RepeatCommand}, or bind {@link
+   *     Command#schedule() command::schedule} to {@link BooleanEvent#ifHigh(Runnable)}
+   *     (passing no requirements).
    */
+  @Deprecated
   public Trigger whileActiveContinuous(final Command command) {
     requireNonNullParam(command, "command", "whileActiveContinuous");
 
-    this.ifHigh(command::schedule);
-    this.falling().ifHigh(command::cancel);
+    m_event.ifHigh(command::schedule);
+    m_event.falling().ifHigh(command::cancel);
 
     return this;
   }
@@ -124,7 +218,9 @@ public class Trigger extends BooleanEvent {
    * @param toRun the runnable to run
    * @param requirements the required subsystems
    * @return this trigger, so calls can be chained
+   * @deprecated Use {@link #whileTrue(Command)} and construct a RunCommand manually
    */
+  @Deprecated
   public Trigger whileActiveContinuous(final Runnable toRun, Subsystem... requirements) {
     return whileActiveContinuous(new InstantCommand(toRun, requirements));
   }
@@ -135,12 +231,14 @@ public class Trigger extends BooleanEvent {
    *
    * @param command the command to start
    * @return this trigger, so calls can be chained
+   * @deprecated Use {@link #whileTrue(Command)} instead.
    */
+  @Deprecated
   public Trigger whileActiveOnce(final Command command) {
     requireNonNullParam(command, "command", "whileActiveOnce");
 
-    this.rising().ifHigh(command::schedule);
-    this.falling().ifHigh(command::cancel);
+    m_event.rising().ifHigh(command::schedule);
+    m_event.falling().ifHigh(command::cancel);
 
     return this;
   }
@@ -150,11 +248,13 @@ public class Trigger extends BooleanEvent {
    *
    * @param command the command to start
    * @return this trigger, so calls can be chained
+   * @deprecated Use {@link #onFalse(Command)} instead.
    */
+  @Deprecated
   public Trigger whenInactive(final Command command) {
     requireNonNullParam(command, "command", "whenInactive");
 
-    this.falling().ifHigh(command::schedule);
+    m_event.falling().ifHigh(command::schedule);
 
     return this;
   }
@@ -165,7 +265,9 @@ public class Trigger extends BooleanEvent {
    * @param toRun the runnable to run
    * @param requirements the required subsystems
    * @return this trigger, so calls can be chained
+   * @deprecated Construct the InstantCommand manually and replace with {@link #onFalse(Command)}
    */
+  @Deprecated
   public Trigger whenInactive(final Runnable toRun, Subsystem... requirements) {
     return whenInactive(new InstantCommand(toRun, requirements));
   }
@@ -175,11 +277,13 @@ public class Trigger extends BooleanEvent {
    *
    * @param command the command to toggle
    * @return this trigger, so calls can be chained
+   * @deprecated Use {@link #toggleOnTrue(Command)} instead.
    */
+  @Deprecated
   public Trigger toggleWhenActive(final Command command) {
     requireNonNullParam(command, "command", "toggleWhenActive");
 
-    this.rising()
+    m_event.rising()
         .ifHigh(
             () -> {
               if (command.isScheduled()) {
@@ -197,49 +301,56 @@ public class Trigger extends BooleanEvent {
    *
    * @param command the command to cancel
    * @return this trigger, so calls can be chained
+   * @deprecated Instead, pass {@link #rising()} as an end condition to {@link
+   *     Command#until(BooleanSupplier)}.
    */
+  @Deprecated
   public Trigger cancelWhenActive(final Command command) {
     requireNonNullParam(command, "command", "cancelWhenActive");
 
-    this.rising().ifHigh(command::cancel);
+    m_event.rising().ifHigh(command::cancel);
 
     return this;
   }
 
-  /* ----------- Super method type redeclarations ----------------- */
+  /**
+   * Get the wrapped BooleanEvent.
+   *
+   * @return the wrapped BooleanEvent instance.
+   */
+  public BooleanEvent getEvent() {
+    return m_event;
+  }
 
-  @Override
+  public boolean getAsBoolean() {
+    return m_event.getAsBoolean();
+  }
+
   public Trigger and(BooleanSupplier trigger) {
-    return cast(super.and(trigger));
+    return cast(m_event.and(trigger));
   }
 
-  @Override
   public Trigger or(BooleanSupplier trigger) {
-    return cast(super.or(trigger));
+    return cast(m_event.or(trigger));
   }
 
-  @Override
   public Trigger negate() {
-    return cast(super.negate());
+    return cast(m_event.negate());
   }
 
-  @Override
   public Trigger debounce(double seconds) {
     return debounce(seconds, Debouncer.DebounceType.kRising);
   }
 
-  @Override
   public Trigger debounce(double seconds, Debouncer.DebounceType type) {
-    return cast(super.debounce(seconds, type));
+    return cast(m_event.debounce(seconds, type));
   }
 
-  @Override
   public Trigger rising() {
-    return cast(super.rising());
+    return cast(m_event.rising());
   }
 
-  @Override
   public Trigger falling() {
-    return cast(super.falling());
+    return cast(m_event.falling());
   }
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Button.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Button.cpp
@@ -9,12 +9,9 @@ using namespace frc2;
 Button::Button(std::function<bool()> isPressed) : Trigger(isPressed) {}
 
 Button Button::WhenPressed(Command* command) {
+  WPI_IGNORE_DEPRECATED
   WhenActive(command);
-  return *this;
-}
-
-Button Button::WhenPressed(CommandPtr&& command) {
-  WhenActive(std::move(command));
+  WPI_UNIGNORE_DEPRECATED
   return *this;
 }
 
@@ -31,12 +28,9 @@ Button Button::WhenPressed(std::function<void()> toRun,
 }
 
 Button Button::WhileHeld(Command* command) {
+  WPI_IGNORE_DEPRECATED
   WhileActiveContinous(command);
-  return *this;
-}
-
-Button Button::WhileHeld(CommandPtr&& command) {
-  WhileActiveContinous(std::move(command));
+  WPI_UNIGNORE_DEPRECATED
   return *this;
 }
 
@@ -53,22 +47,16 @@ Button Button::WhileHeld(std::function<void()> toRun,
 }
 
 Button Button::WhenHeld(Command* command) {
+  WPI_IGNORE_DEPRECATED
   WhileActiveOnce(command);
-  return *this;
-}
-
-Button Button::WhenHeld(CommandPtr&& command) {
-  WhileActiveOnce(std::move(command));
+  WPI_UNIGNORE_DEPRECATED
   return *this;
 }
 
 Button Button::WhenReleased(Command* command) {
+  WPI_IGNORE_DEPRECATED
   WhenInactive(command);
-  return *this;
-}
-
-Button Button::WhenReleased(CommandPtr&& command) {
-  WhenInactive(std::move(command));
+  WPI_UNIGNORE_DEPRECATED
   return *this;
 }
 
@@ -85,16 +73,15 @@ Button Button::WhenReleased(std::function<void()> toRun,
 }
 
 Button Button::ToggleWhenPressed(Command* command) {
+  WPI_IGNORE_DEPRECATED
   ToggleWhenActive(command);
-  return *this;
-}
-
-Button Button::ToggleWhenPressed(CommandPtr&& command) {
-  ToggleWhenActive(std::move(command));
+  WPI_UNIGNORE_DEPRECATED
   return *this;
 }
 
 Button Button::CancelWhenPressed(Command* command) {
+  WPI_IGNORE_DEPRECATED
   CancelWhenActive(command);
+  WPI_UNIGNORE_DEPRECATED
   return *this;
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Button.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Button.cpp
@@ -17,13 +17,17 @@ Button Button::WhenPressed(Command* command) {
 
 Button Button::WhenPressed(std::function<void()> toRun,
                            std::initializer_list<Subsystem*> requirements) {
+  WPI_IGNORE_DEPRECATED
   WhenActive(std::move(toRun), requirements);
+  WPI_UNIGNORE_DEPRECATED
   return *this;
 }
 
 Button Button::WhenPressed(std::function<void()> toRun,
                            std::span<Subsystem* const> requirements) {
+  WPI_IGNORE_DEPRECATED
   WhenActive(std::move(toRun), requirements);
+  WPI_UNIGNORE_DEPRECATED
   return *this;
 }
 
@@ -36,13 +40,17 @@ Button Button::WhileHeld(Command* command) {
 
 Button Button::WhileHeld(std::function<void()> toRun,
                          std::initializer_list<Subsystem*> requirements) {
+  WPI_IGNORE_DEPRECATED
   WhileActiveContinous(std::move(toRun), requirements);
+  WPI_UNIGNORE_DEPRECATED
   return *this;
 }
 
 Button Button::WhileHeld(std::function<void()> toRun,
                          std::span<Subsystem* const> requirements) {
+  WPI_IGNORE_DEPRECATED
   WhileActiveContinous(std::move(toRun), requirements);
+  WPI_UNIGNORE_DEPRECATED
   return *this;
 }
 
@@ -62,13 +70,17 @@ Button Button::WhenReleased(Command* command) {
 
 Button Button::WhenReleased(std::function<void()> toRun,
                             std::initializer_list<Subsystem*> requirements) {
+  WPI_IGNORE_DEPRECATED
   WhenInactive(std::move(toRun), requirements);
+  WPI_UNIGNORE_DEPRECATED
   return *this;
 }
 
 Button Button::WhenReleased(std::function<void()> toRun,
                             std::span<Subsystem* const> requirements) {
+  WPI_IGNORE_DEPRECATED
   WhenInactive(std::move(toRun), requirements);
+  WPI_UNIGNORE_DEPRECATED
   return *this;
 }
 

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/NetworkButton.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/NetworkButton.cpp
@@ -4,8 +4,11 @@
 
 #include "frc2/command/button/NetworkButton.h"
 
+#include <wpi/deprecated.h>
+
 using namespace frc2;
 
+WPI_IGNORE_DEPRECATED
 NetworkButton::NetworkButton(nt::BooleanTopic topic)
     : NetworkButton(topic.Subscribe(false)) {}
 
@@ -13,6 +16,7 @@ NetworkButton::NetworkButton(nt::BooleanSubscriber sub)
     : Button([sub = std::make_shared<nt::BooleanSubscriber>(std::move(sub))] {
         return sub->GetTopic().GetInstance().IsConnected() && sub->Get();
       }) {}
+WPI_UNIGNORE_DEPRECATED
 
 NetworkButton::NetworkButton(std::shared_ptr<nt::NetworkTable> table,
                              std::string_view field)

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
@@ -105,6 +105,7 @@ Trigger Trigger::ToggleOnFalse(CommandPtr&& command) {
   return *this;
 }
 
+WPI_IGNORE_DEPRECATED
 Trigger Trigger::WhenActive(Command* command) {
   m_event.Rising().IfHigh([command] { command->Schedule(); });
   return *this;
@@ -176,6 +177,7 @@ Trigger Trigger::CancelWhenActive(Command* command) {
   m_event.Rising().IfHigh([command] { command->Cancel(); });
   return *this;
 }
+WPI_UNIGNORE_DEPRECATED
 
 BooleanEvent Trigger::GetEvent() const {
   return m_event;

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
@@ -13,13 +13,100 @@ using namespace frc2;
 
 Trigger::Trigger(const Trigger& other) = default;
 
-Trigger Trigger::WhenActive(Command* command) {
-  this->Rising().IfHigh([command] { command->Schedule(); });
+Trigger Trigger::OnTrue(Command* command) {
+  m_event.Rising().IfHigh([command] { command->Schedule(); });
   return *this;
 }
 
-Trigger Trigger::WhenActive(CommandPtr&& command) {
-  this->Rising().IfHigh([command = std::move(command)] { command.Schedule(); });
+Trigger Trigger::OnTrue(CommandPtr&& command) {
+  m_event.Rising().IfHigh(
+      [command = std::move(command)] { command.Schedule(); });
+  return *this;
+}
+
+Trigger Trigger::OnFalse(Command* command) {
+  m_event.Falling().IfHigh([command] { command->Schedule(); });
+  return *this;
+}
+
+Trigger Trigger::OnFalse(CommandPtr&& command) {
+  m_event.Falling().IfHigh(
+      [command = std::move(command)] { command.Schedule(); });
+  return *this;
+}
+
+Trigger Trigger::WhileTrue(Command* command) {
+  m_event.Rising().IfHigh([command] { command->Schedule(); });
+  m_event.Falling().IfHigh([command] { command->Cancel(); });
+  return *this;
+}
+
+Trigger Trigger::WhileTrue(CommandPtr&& command) {
+  auto ptr = std::make_shared<CommandPtr>(std::move(command));
+  m_event.Rising().IfHigh([ptr] { ptr->Schedule(); });
+  m_event.Falling().IfHigh([ptr] { ptr->Cancel(); });
+  return *this;
+}
+
+Trigger Trigger::WhileFalse(Command* command) {
+  m_event.Falling().IfHigh([command] { command->Schedule(); });
+  m_event.Rising().IfHigh([command] { command->Cancel(); });
+  return *this;
+}
+
+Trigger Trigger::WhileFalse(CommandPtr&& command) {
+  auto ptr = std::make_shared<CommandPtr>(std::move(command));
+  m_event.Falling().IfHigh([ptr] { ptr->Schedule(); });
+  m_event.Rising().IfHigh([ptr] { ptr->Cancel(); });
+  return *this;
+}
+
+Trigger Trigger::ToggleOnTrue(Command* command) {
+  m_event.Rising().IfHigh([command] {
+    if (command->IsScheduled()) {
+      command->Cancel();
+    } else {
+      command->Schedule();
+    }
+  });
+  return *this;
+}
+
+Trigger Trigger::ToggleOnTrue(CommandPtr&& command) {
+  m_event.Rising().IfHigh([command = std::move(command)] {
+    if (command.IsScheduled()) {
+      command.Cancel();
+    } else {
+      command.Schedule();
+    }
+  });
+  return *this;
+}
+
+Trigger Trigger::ToggleOnFalse(Command* command) {
+  m_event.Falling().IfHigh([command] {
+    if (command->IsScheduled()) {
+      command->Cancel();
+    } else {
+      command->Schedule();
+    }
+  });
+  return *this;
+}
+
+Trigger Trigger::ToggleOnFalse(CommandPtr&& command) {
+  m_event.Falling().IfHigh([command = std::move(command)] {
+    if (command.IsScheduled()) {
+      command.Cancel();
+    } else {
+      command.Schedule();
+    }
+  });
+  return *this;
+}
+
+Trigger Trigger::WhenActive(Command* command) {
+  m_event.Rising().IfHigh([command] { command->Schedule(); });
   return *this;
 }
 
@@ -35,15 +122,8 @@ Trigger Trigger::WhenActive(std::function<void()> toRun,
 }
 
 Trigger Trigger::WhileActiveContinous(Command* command) {
-  this->IfHigh([command] { command->Schedule(); });
-  this->Falling().IfHigh([command] { command->Cancel(); });
-  return *this;
-}
-
-Trigger Trigger::WhileActiveContinous(CommandPtr&& command) {
-  auto ptr = std::make_shared<CommandPtr>(std::move(command));
-  this->IfHigh([ptr] { ptr->Schedule(); });
-  this->Falling().IfHigh([ptr] { ptr->Cancel(); });
+  m_event.IfHigh([command] { command->Schedule(); });
+  m_event.Falling().IfHigh([command] { command->Cancel(); });
   return *this;
 }
 
@@ -60,26 +140,13 @@ Trigger Trigger::WhileActiveContinous(
 }
 
 Trigger Trigger::WhileActiveOnce(Command* command) {
-  this->Rising().IfHigh([command] { command->Schedule(); });
-  this->Falling().IfHigh([command] { command->Cancel(); });
-  return *this;
-}
-
-Trigger Trigger::WhileActiveOnce(CommandPtr&& command) {
-  auto ptr = std::make_shared<CommandPtr>(std::move(command));
-  this->Rising().IfHigh([ptr] { ptr->Schedule(); });
-  this->Falling().IfHigh([ptr] { ptr->Cancel(); });
+  m_event.Rising().IfHigh([command] { command->Schedule(); });
+  m_event.Falling().IfHigh([command] { command->Cancel(); });
   return *this;
 }
 
 Trigger Trigger::WhenInactive(Command* command) {
-  this->Falling().IfHigh([command] { command->Schedule(); });
-  return *this;
-}
-
-Trigger Trigger::WhenInactive(CommandPtr&& command) {
-  this->Falling().IfHigh(
-      [command = std::move(command)] { command.Schedule(); });
+  m_event.Falling().IfHigh([command] { command->Schedule(); });
   return *this;
 }
 
@@ -95,7 +162,7 @@ Trigger Trigger::WhenInactive(std::function<void()> toRun,
 }
 
 Trigger Trigger::ToggleWhenActive(Command* command) {
-  this->Rising().IfHigh([command] {
+  m_event.Rising().IfHigh([command] {
     if (command->IsScheduled()) {
       command->Cancel();
     } else {
@@ -105,18 +172,11 @@ Trigger Trigger::ToggleWhenActive(Command* command) {
   return *this;
 }
 
-Trigger Trigger::ToggleWhenActive(CommandPtr&& command) {
-  this->Rising().IfHigh([command = std::move(command)] {
-    if (command.IsScheduled()) {
-      command.Cancel();
-    } else {
-      command.Schedule();
-    }
-  });
+Trigger Trigger::CancelWhenActive(Command* command) {
+  m_event.Rising().IfHigh([command] { command->Cancel(); });
   return *this;
 }
 
-Trigger Trigger::CancelWhenActive(Command* command) {
-  this->Rising().IfHigh([command] { command->Cancel(); });
-  return *this;
+BooleanEvent Trigger::GetEvent() const {
+  return m_event;
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Button.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Button.h
@@ -9,6 +9,8 @@
 #include <span>
 #include <utility>
 
+#include <wpi/deprecated.h>
+
 #include "Trigger.h"
 #include "frc2/command/CommandPtr.h"
 
@@ -29,12 +31,14 @@ class Button : public Trigger {
    *
    * @param isPressed Whether the button is pressed.
    */
+  WPI_DEPRECATED("Replace with Trigger")
   explicit Button(std::function<bool()> isPressed);
 
   /**
    * Create a new button that is pressed active (default constructor) - activity
    *  can be further determined by subclass code.
    */
+  WPI_DEPRECATED("Replace with Trigger")
   Button() = default;
 
   /**
@@ -45,17 +49,8 @@ class Button : public Trigger {
    * @param command The command to bind.
    * @return The trigger, for chained calls.
    */
+  WPI_DEPRECATED("Replace with Trigger#WhenActive()")
   Button WhenPressed(Command* command);
-
-  /**
-   * Binds a command to start when the button is pressed.  Transfers
-   * command ownership to the button scheduler, so the user does not have to
-   * worry about lifespan.
-   *
-   * @param command The command to bind.
-   * @return The trigger, for chained calls.
-   */
-  Button WhenPressed(CommandPtr&& command);
 
   /**
    * Binds a command to start when the button is pressed.  Transfers
@@ -68,6 +63,7 @@ class Button : public Trigger {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
+  WPI_DEPRECATED("Replace with Trigger#WhenActive()")
   Button WhenPressed(T&& command) {
     WhenActive(std::forward<T>(command));
     return *this;
@@ -79,6 +75,7 @@ class Button : public Trigger {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
+  WPI_DEPRECATED("Replace with Trigger#WhenActive()")
   Button WhenPressed(std::function<void()> toRun,
                      std::initializer_list<Subsystem*> requirements);
 
@@ -88,6 +85,7 @@ class Button : public Trigger {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
+  WPI_DEPRECATED("Replace with Trigger#WhenActive()")
   Button WhenPressed(std::function<void()> toRun,
                      std::span<Subsystem* const> requirements = {});
 
@@ -99,17 +97,8 @@ class Button : public Trigger {
    * @param command The command to bind.
    * @return The button, for chained calls.
    */
+  WPI_DEPRECATED("Replace with Trigger#WhileActiveContinuous()")
   Button WhileHeld(Command* command);
-
-  /**
-   * Binds a command to be started repeatedly while the button is pressed, and
-   * canceled when it is released.  Transfers command ownership to the button
-   * scheduler, so the user does not have to worry about lifespan.
-   *
-   * @param command The command to bind.
-   * @return The button, for chained calls.
-   */
-  Button WhileHeld(CommandPtr&& command);
 
   /**
    * Binds a command to be started repeatedly while the button is pressed, and
@@ -122,6 +111,7 @@ class Button : public Trigger {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
+  WPI_DEPRECATED("Replace with Trigger#WhileActiveContinuous()")
   Button WhileHeld(T&& command) {
     WhileActiveContinous(std::forward<T>(command));
     return *this;
@@ -133,6 +123,7 @@ class Button : public Trigger {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
+  WPI_DEPRECATED("Replace with Trigger#WhileActiveContinuous()")
   Button WhileHeld(std::function<void()> toRun,
                    std::initializer_list<Subsystem*> requirements);
 
@@ -142,6 +133,7 @@ class Button : public Trigger {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
+  WPI_DEPRECATED("Replace with Trigger#WhileActiveContinuous()")
   Button WhileHeld(std::function<void()> toRun,
                    std::span<Subsystem* const> requirements = {});
 
@@ -153,17 +145,8 @@ class Button : public Trigger {
    * @param command The command to bind.
    * @return The button, for chained calls.
    */
+  WPI_DEPRECATED("Replace with Trigger#WhileActiveOnce()")
   Button WhenHeld(Command* command);
-
-  /**
-   * Binds a command to be started when the button is pressed, and canceled
-   * when it is released.  Transfers command ownership to the button scheduler,
-   * so the user does not have to worry about lifespan.
-   *
-   * @param command The command to bind.
-   * @return The button, for chained calls.
-   */
-  Button WhenHeld(CommandPtr&& command);
 
   /**
    * Binds a command to be started when the button is pressed, and canceled
@@ -176,6 +159,7 @@ class Button : public Trigger {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
+  WPI_DEPRECATED("Replace with Trigger#WhileActiveOnce()")
   Button WhenHeld(T&& command) {
     WhileActiveOnce(std::forward<T>(command));
     return *this;
@@ -189,17 +173,8 @@ class Button : public Trigger {
    * @param command The command to bind.
    * @return The button, for chained calls.
    */
+  WPI_DEPRECATED("Replace with Trigger#WhenInactive()")
   Button WhenReleased(Command* command);
-
-  /**
-   * Binds a command to start when the button is pressed.  Transfers
-   * command ownership to the button scheduler, so the user does not have to
-   * worry about lifespan.
-   *
-   * @param command The command to bind.
-   * @return The button, for chained calls.
-   */
-  Button WhenReleased(CommandPtr&& command);
 
   /**
    * Binds a command to start when the button is pressed.  Transfers
@@ -212,6 +187,7 @@ class Button : public Trigger {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
+  WPI_DEPRECATED("Replace with Trigger#WhenInactive()")
   Button WhenReleased(T&& command) {
     WhenInactive(std::forward<T>(command));
     return *this;
@@ -223,6 +199,7 @@ class Button : public Trigger {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
+  WPI_DEPRECATED("Replace with Trigger#WhenInactive()")
   Button WhenReleased(std::function<void()> toRun,
                       std::initializer_list<Subsystem*> requirements);
 
@@ -232,6 +209,7 @@ class Button : public Trigger {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
+  WPI_DEPRECATED("Replace with Trigger#WhenInactive()")
   Button WhenReleased(std::function<void()> toRun,
                       std::span<Subsystem* const> requirements = {});
 
@@ -243,17 +221,8 @@ class Button : public Trigger {
    * @param command The command to bind.
    * @return The button, for chained calls.
    */
+  WPI_DEPRECATED("Replace with Trigger#ToggleWhenActive()")
   Button ToggleWhenPressed(Command* command);
-
-  /**
-   * Binds a command to start when the button is pressed, and be canceled when
-   * it is pessed again.  Transfers command ownership to the button scheduler,
-   * so the user does not have to worry about lifespan.
-   *
-   * @param command The command to bind.
-   * @return The button, for chained calls.
-   */
-  Button ToggleWhenPressed(CommandPtr&& command);
 
   /**
    * Binds a command to start when the button is pressed, and be canceled when
@@ -266,6 +235,7 @@ class Button : public Trigger {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
+  WPI_DEPRECATED("Replace with Trigger#ToggleWhenActive()")
   Button ToggleWhenPressed(T&& command) {
     ToggleWhenActive(std::forward<T>(command));
     return *this;
@@ -279,6 +249,7 @@ class Button : public Trigger {
    * @param command The command to bind.
    * @return The button, for chained calls.
    */
+  WPI_DEPRECATED("Replace with Trigger#CancelWhenActive()")
   Button CancelWhenPressed(Command* command);
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Button.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Button.h
@@ -49,7 +49,7 @@ class Button : public Trigger {
    * @param command The command to bind.
    * @return The trigger, for chained calls.
    */
-  WPI_DEPRECATED("Replace with Trigger#WhenActive()")
+  WPI_DEPRECATED("Replace with Trigger#OnTrue()")
   Button WhenPressed(Command* command);
 
   /**
@@ -63,7 +63,7 @@ class Button : public Trigger {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
-  WPI_DEPRECATED("Replace with Trigger#WhenActive()")
+  WPI_DEPRECATED("Replace with Trigger#OnTrue()")
   Button WhenPressed(T&& command) {
     WhenActive(std::forward<T>(command));
     return *this;
@@ -75,7 +75,7 @@ class Button : public Trigger {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
-  WPI_DEPRECATED("Replace with Trigger#WhenActive()")
+  WPI_DEPRECATED("Replace with Trigger#OnTrue(cmd::RunOnce())")
   Button WhenPressed(std::function<void()> toRun,
                      std::initializer_list<Subsystem*> requirements);
 
@@ -85,7 +85,7 @@ class Button : public Trigger {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
-  WPI_DEPRECATED("Replace with Trigger#WhenActive()")
+  WPI_DEPRECATED("Replace with Trigger#OnTrue(cmd::RunOnce())")
   Button WhenPressed(std::function<void()> toRun,
                      std::span<Subsystem* const> requirements = {});
 
@@ -97,7 +97,7 @@ class Button : public Trigger {
    * @param command The command to bind.
    * @return The button, for chained calls.
    */
-  WPI_DEPRECATED("Replace with Trigger#WhileActiveContinuous()")
+  WPI_DEPRECATED("Replace with Trigger#WhileTrue(command.Repeatedly())")
   Button WhileHeld(Command* command);
 
   /**
@@ -111,7 +111,7 @@ class Button : public Trigger {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
-  WPI_DEPRECATED("Replace with Trigger#WhileActiveContinuous()")
+  WPI_DEPRECATED("Replace with Trigger#WhileTrue(command.Repeatedly())")
   Button WhileHeld(T&& command) {
     WhileActiveContinous(std::forward<T>(command));
     return *this;
@@ -123,7 +123,7 @@ class Button : public Trigger {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
-  WPI_DEPRECATED("Replace with Trigger#WhileActiveContinuous()")
+  WPI_DEPRECATED("Replace with Trigger#WhileTrue(cmd::Run())")
   Button WhileHeld(std::function<void()> toRun,
                    std::initializer_list<Subsystem*> requirements);
 
@@ -133,7 +133,7 @@ class Button : public Trigger {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
-  WPI_DEPRECATED("Replace with Trigger#WhileActiveContinuous()")
+  WPI_DEPRECATED("Replace with Trigger#WhileTrue(cmd::Run())")
   Button WhileHeld(std::function<void()> toRun,
                    std::span<Subsystem* const> requirements = {});
 
@@ -145,7 +145,7 @@ class Button : public Trigger {
    * @param command The command to bind.
    * @return The button, for chained calls.
    */
-  WPI_DEPRECATED("Replace with Trigger#WhileActiveOnce()")
+  WPI_DEPRECATED("Replace with Trigger#WhileTrue()")
   Button WhenHeld(Command* command);
 
   /**
@@ -159,7 +159,7 @@ class Button : public Trigger {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
-  WPI_DEPRECATED("Replace with Trigger#WhileActiveOnce()")
+  WPI_DEPRECATED("Replace with Trigger#WhileTrue()")
   Button WhenHeld(T&& command) {
     WhileActiveOnce(std::forward<T>(command));
     return *this;
@@ -173,7 +173,7 @@ class Button : public Trigger {
    * @param command The command to bind.
    * @return The button, for chained calls.
    */
-  WPI_DEPRECATED("Replace with Trigger#WhenInactive()")
+  WPI_DEPRECATED("Replace with Trigger#OnFalse()")
   Button WhenReleased(Command* command);
 
   /**
@@ -187,7 +187,7 @@ class Button : public Trigger {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
-  WPI_DEPRECATED("Replace with Trigger#WhenInactive()")
+  WPI_DEPRECATED("Replace with Trigger#OnFalse()")
   Button WhenReleased(T&& command) {
     WhenInactive(std::forward<T>(command));
     return *this;
@@ -199,7 +199,7 @@ class Button : public Trigger {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
-  WPI_DEPRECATED("Replace with Trigger#WhenInactive()")
+  WPI_DEPRECATED("Replace with Trigger#OnFalse(cmd::RunOnce())")
   Button WhenReleased(std::function<void()> toRun,
                       std::initializer_list<Subsystem*> requirements);
 
@@ -209,7 +209,7 @@ class Button : public Trigger {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
-  WPI_DEPRECATED("Replace with Trigger#WhenInactive()")
+  WPI_DEPRECATED("Replace with Trigger#OnFalse(cmd::RunOnce())")
   Button WhenReleased(std::function<void()> toRun,
                       std::span<Subsystem* const> requirements = {});
 
@@ -221,7 +221,7 @@ class Button : public Trigger {
    * @param command The command to bind.
    * @return The button, for chained calls.
    */
-  WPI_DEPRECATED("Replace with Trigger#ToggleWhenActive()")
+  WPI_DEPRECATED("Replace with Trigger#ToggleOnTrue()")
   Button ToggleWhenPressed(Command* command);
 
   /**
@@ -235,7 +235,7 @@ class Button : public Trigger {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
-  WPI_DEPRECATED("Replace with Trigger#ToggleWhenActive()")
+  WPI_DEPRECATED("Replace with Trigger#ToggleOnTrue()")
   Button ToggleWhenPressed(T&& command) {
     ToggleWhenActive(std::forward<T>(command));
     return *this;
@@ -249,7 +249,8 @@ class Button : public Trigger {
    * @param command The command to bind.
    * @return The button, for chained calls.
    */
-  WPI_DEPRECATED("Replace with Trigger#CancelWhenActive()")
+  WPI_DEPRECATED(
+      "Use Rising() as a command end condition with Until() instead.")
   Button CancelWhenPressed(Command* command);
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Button.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Button.h
@@ -30,6 +30,7 @@ class Button : public Trigger {
    * Create a new button that is pressed when the given condition is true.
    *
    * @param isPressed Whether the button is pressed.
+   * @deprecated Replace with Trigger
    */
   WPI_DEPRECATED("Replace with Trigger")
   explicit Button(std::function<bool()> isPressed);
@@ -37,6 +38,7 @@ class Button : public Trigger {
   /**
    * Create a new button that is pressed active (default constructor) - activity
    *  can be further determined by subclass code.
+   * @deprecated Replace with Trigger
    */
   WPI_DEPRECATED("Replace with Trigger")
   Button() = default;
@@ -48,6 +50,7 @@ class Button : public Trigger {
    *
    * @param command The command to bind.
    * @return The trigger, for chained calls.
+   * @deprecated Replace with Trigger::OnTrue()
    */
   WPI_DEPRECATED("Replace with Trigger#OnTrue()")
   Button WhenPressed(Command* command);
@@ -60,6 +63,7 @@ class Button : public Trigger {
    *
    * @param command The command to bind.
    * @return The trigger, for chained calls.
+   * @deprecated Replace with Trigger::OnTrue()
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
@@ -74,6 +78,7 @@ class Button : public Trigger {
    *
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
+   * @deprecated Replace with Trigger::OnTrue(cmd::RunOnce())
    */
   WPI_DEPRECATED("Replace with Trigger#OnTrue(cmd::RunOnce())")
   Button WhenPressed(std::function<void()> toRun,
@@ -84,6 +89,7 @@ class Button : public Trigger {
    *
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
+   * @deprecated Replace with Trigger::OnTrue(cmd::RunOnce())
    */
   WPI_DEPRECATED("Replace with Trigger#OnTrue(cmd::RunOnce())")
   Button WhenPressed(std::function<void()> toRun,
@@ -96,6 +102,7 @@ class Button : public Trigger {
    *
    * @param command The command to bind.
    * @return The button, for chained calls.
+   * @deprecated Replace with Trigger::WhileTrue(command.Repeatedly())
    */
   WPI_DEPRECATED("Replace with Trigger#WhileTrue(command.Repeatedly())")
   Button WhileHeld(Command* command);
@@ -108,6 +115,7 @@ class Button : public Trigger {
    *
    * @param command The command to bind.
    * @return The button, for chained calls.
+   * @deprecated Replace with Trigger::WhileTrue(command.Repeatedly())
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
@@ -122,6 +130,7 @@ class Button : public Trigger {
    *
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
+   * @deprecated Replace with Trigger::WhileTrue(cmd::Run())
    */
   WPI_DEPRECATED("Replace with Trigger#WhileTrue(cmd::Run())")
   Button WhileHeld(std::function<void()> toRun,
@@ -132,6 +141,7 @@ class Button : public Trigger {
    *
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
+   * @deprecated Replace with Trigger::WhileTrue(cmd::Run())
    */
   WPI_DEPRECATED("Replace with Trigger#WhileTrue(cmd::Run())")
   Button WhileHeld(std::function<void()> toRun,
@@ -144,6 +154,7 @@ class Button : public Trigger {
    *
    * @param command The command to bind.
    * @return The button, for chained calls.
+   * @deprecated Replace with Trigger::WhileTrue()
    */
   WPI_DEPRECATED("Replace with Trigger#WhileTrue()")
   Button WhenHeld(Command* command);
@@ -156,6 +167,7 @@ class Button : public Trigger {
    *
    * @param command The command to bind.
    * @return The button, for chained calls.
+   * @deprecated Replace with Trigger::WhileTrue()
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
@@ -172,6 +184,7 @@ class Button : public Trigger {
    *
    * @param command The command to bind.
    * @return The button, for chained calls.
+   * @deprecated Replace with Trigger::OnFalse()
    */
   WPI_DEPRECATED("Replace with Trigger#OnFalse()")
   Button WhenReleased(Command* command);
@@ -184,6 +197,7 @@ class Button : public Trigger {
    *
    * @param command The command to bind.
    * @return The button, for chained calls.
+   * @deprecated Replace with Trigger::OnFalse()
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
@@ -198,6 +212,7 @@ class Button : public Trigger {
    *
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
+   * @deprecated Replace with Trigger::OnFalse(cmd::RunOnce())
    */
   WPI_DEPRECATED("Replace with Trigger#OnFalse(cmd::RunOnce())")
   Button WhenReleased(std::function<void()> toRun,
@@ -208,6 +223,7 @@ class Button : public Trigger {
    *
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
+   * @deprecated Replace with Trigger::OnFalse(cmd::RunOnce())
    */
   WPI_DEPRECATED("Replace with Trigger#OnFalse(cmd::RunOnce())")
   Button WhenReleased(std::function<void()> toRun,
@@ -220,6 +236,7 @@ class Button : public Trigger {
    *
    * @param command The command to bind.
    * @return The button, for chained calls.
+   * @deprecated Replace with Trigger::ToggleOnTrue()
    */
   WPI_DEPRECATED("Replace with Trigger#ToggleOnTrue()")
   Button ToggleWhenPressed(Command* command);
@@ -232,6 +249,7 @@ class Button : public Trigger {
    *
    * @param command The command to bind.
    * @return The button, for chained calls.
+   * @deprecated Replace with Trigger::ToggleOnTrue()
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
@@ -248,6 +266,7 @@ class Button : public Trigger {
    *
    * @param command The command to bind.
    * @return The button, for chained calls.
+   * @deprecated Use Rising() as a command end condition with Until() instead.
    */
   WPI_DEPRECATED(
       "Use Rising() as a command end condition with Until() instead.")

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/JoystickButton.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/JoystickButton.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include <frc/GenericHID.h>
+#include <wpi/deprecated.h>
 
 #include "Button.h"
 
@@ -24,9 +25,11 @@ class JoystickButton : public Button {
    * @param joystick The joystick on which the button is located.
    * @param buttonNumber The number of the button on the joystic.
    */
+  WPI_IGNORE_DEPRECATED
   explicit JoystickButton(frc::GenericHID* joystick, int buttonNumber)
       : Button([joystick, buttonNumber] {
           return joystick->GetRawButton(buttonNumber);
         }) {}
+  WPI_UNIGNORE_DEPRECATED
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/POVButton.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/POVButton.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include <frc/GenericHID.h>
+#include <wpi/deprecated.h>
 
 #include "Button.h"
 
@@ -25,9 +26,11 @@ class POVButton : public Button {
    * @param angle The angle of the POV corresponding to a button press.
    * @param povNumber The number of the POV on the joystick.
    */
+  WPI_IGNORE_DEPRECATED
   POVButton(frc::GenericHID* joystick, int angle, int povNumber = 0)
       : Button([joystick, angle, povNumber] {
           return joystick->GetPOV(povNumber) == angle;
         }) {}
+  WPI_UNIGNORE_DEPRECATED
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
@@ -204,6 +204,7 @@ class Trigger {
    *
    * @param command The command to bind.
    * @return The trigger, for chained calls.
+   * @deprecated Use OnTrue(Command) instead
    */
   WPI_DEPRECATED("Use OnTrue(Command) instead")
   Trigger WhenActive(Command* command);
@@ -216,6 +217,7 @@ class Trigger {
    *
    * @param command The command to bind.
    * @return The trigger, for chained calls.
+   * @deprecated Use OnTrue(Command) instead
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
@@ -233,6 +235,8 @@ class Trigger {
    *
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
+   * @deprecated Use OnTrue(Command) instead and construct the InstantCommand
+   * manually
    */
   WPI_DEPRECATED(
       "Use OnTrue(Command) instead and construct the InstantCommand manually")
@@ -244,6 +248,8 @@ class Trigger {
    *
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
+   * @deprecated Use OnTrue(Command) instead and construct the InstantCommand
+   * manually
    */
   WPI_DEPRECATED(
       "Use OnTrue(Command) instead and construct the InstantCommand manually")
@@ -257,6 +263,8 @@ class Trigger {
    *
    * @param command The command to bind.
    * @return The trigger, for chained calls.
+   * @deprecated Use WhileTrue(Command) with RepeatCommand, or bind
+   command::Schedule with IfHigh(std::function<void()>).
    */
   WPI_DEPRECATED(
       "Use WhileTrue(Command) with RepeatCommand, or bind command::Schedule "
@@ -271,6 +279,8 @@ class Trigger {
    *
    * @param command The command to bind.
    * @return The trigger, for chained calls.
+   * @deprecated Use WhileTrue(Command) with RepeatCommand, or bind
+   command::Schedule with IfHigh(std::function<void()>).
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
@@ -291,6 +301,7 @@ class Trigger {
    *
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
+   * @deprecated Use WhileTrue(Command) and construct a RunCommand manually
    */
   WPI_DEPRECATED("Use WhileTrue(Command) and construct a RunCommand manually")
   Trigger WhileActiveContinous(std::function<void()> toRun,
@@ -301,6 +312,7 @@ class Trigger {
    *
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
+   * @deprecated Use WhileTrue(Command) and construct a RunCommand manually
    */
   WPI_DEPRECATED("Use WhileTrue(Command) and construct a RunCommand manually")
   Trigger WhileActiveContinous(std::function<void()> toRun,
@@ -313,6 +325,7 @@ class Trigger {
    *
    * @param command The command to bind.
    * @return The trigger, for chained calls.
+   * @deprecated Use WhileTrue(Command) instead.
    */
   WPI_DEPRECATED("Use WhileTrue(Command) instead.")
   Trigger WhileActiveOnce(Command* command);
@@ -325,6 +338,7 @@ class Trigger {
    *
    * @param command The command to bind.
    * @return The trigger, for chained calls.
+   * @deprecated Use WhileTrue(Command) instead.
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
@@ -346,6 +360,7 @@ class Trigger {
    *
    * @param command The command to bind.
    * @return The trigger, for chained calls.
+   * @deprecated Use OnFalse(Command) instead.
    */
   WPI_DEPRECATED("Use OnFalse(Command) instead.")
   Trigger WhenInactive(Command* command);
@@ -358,6 +373,7 @@ class Trigger {
    *
    * @param command The command to bind.
    * @return The trigger, for chained calls.
+   * @deprecated Use OnFalse(Command) instead.
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
@@ -375,6 +391,8 @@ class Trigger {
    *
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
+   * @deprecated Use OnFalse(Command) instead and construct the InstantCommand
+   * manually
    */
   WPI_DEPRECATED(
       "Use OnFalse(Command) instead and construct the InstantCommand manually")
@@ -386,6 +404,8 @@ class Trigger {
    *
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
+   * @deprecated Use OnFalse(Command) instead and construct the InstantCommand
+   * manually
    */
   WPI_DEPRECATED(
       "Use OnFalse(Command) instead and construct the InstantCommand manually")
@@ -399,6 +419,7 @@ class Trigger {
    *
    * @param command The command to bind.
    * @return The trigger, for chained calls.
+   * @deprecated Use ToggleOnTrue(Command) instead.
    */
   WPI_DEPRECATED("Use ToggleOnTrue(Command) instead.")
   Trigger ToggleWhenActive(Command* command);
@@ -411,6 +432,7 @@ class Trigger {
    *
    * @param command The command to bind.
    * @return The trigger, for chained calls.
+   * @deprecated Use ToggleOnTrue(Command) instead.
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
@@ -436,6 +458,7 @@ class Trigger {
    *
    * @param command The command to bind.
    * @return The trigger, for chained calls.
+   * @deprecated Use Rising() as a command end condition with Until() instead.
    */
   WPI_DEPRECATED(
       "Use Rising() as a command end condition with Until() instead.")

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
@@ -22,8 +22,8 @@
 namespace frc2 {
 class Command;
 /**
- * This class is a command-based wrapper around {@link BooleanEvent}, providing
- * an easy way to link commands to inputs.
+ * This class is a command-based wrapper around {@link frc::BooleanEvent},
+ * providing an easy way to link commands to inputs.
  *
  * This class is provided by the NewCommands VendorDep
  *

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
@@ -14,6 +14,7 @@
 #include <frc/event/EventLoop.h>
 #include <frc/filter/Debouncer.h>
 #include <units/time.h>
+#include <wpi/deprecated.h>
 
 #include "frc2/command/Command.h"
 #include "frc2/command/CommandScheduler.h"
@@ -28,7 +29,7 @@ class Command;
  *
  * @see Button
  */
-class Trigger : public frc::BooleanEvent {
+class Trigger {
  public:
   /**
    * Creates a new trigger with the given condition determining whether it is
@@ -39,8 +40,8 @@ class Trigger : public frc::BooleanEvent {
    * @param isActive returns whether or not the trigger should be active
    */
   explicit Trigger(std::function<bool()> isActive)
-      : BooleanEvent{CommandScheduler::GetInstance().GetDefaultButtonLoop(),
-                     std::move(isActive)} {}
+      : m_event{CommandScheduler::GetInstance().GetDefaultButtonLoop(),
+                std::move(isActive)} {}
 
   /**
    * Create a new trigger that is active when the given condition is true.
@@ -49,7 +50,7 @@ class Trigger : public frc::BooleanEvent {
    * @param isActive Whether the trigger is active.
    */
   Trigger(frc::EventLoop* loop, std::function<bool()> isActive)
-      : BooleanEvent{loop, std::move(isActive)} {}
+      : m_event{loop, std::move(isActive)} {}
 
   /**
    * Create a new trigger that is never active (default constructor) - activity
@@ -60,6 +61,143 @@ class Trigger : public frc::BooleanEvent {
   Trigger(const Trigger& other);
 
   /**
+   * Starts the given command whenever the signal rises from `false` to `true`.
+   *
+   * <p>Takes a raw pointer, and so is non-owning; users are responsible for the
+   * lifespan of the command.
+   *
+   * @param command the command to start
+   * @return this trigger, so calls can be chained
+   * @see #Rising()
+   */
+  Trigger OnTrue(Command* command);
+
+  /**
+   * Starts the given command whenever the signal rises from `false` to `true`.
+   * Moves command ownership to the button scheduler.
+   *
+   * @param command The command to bind.
+   * @return The trigger, for chained calls.
+   */
+  Trigger OnTrue(CommandPtr&& command);
+
+  /**
+   * Starts the given command whenever the signal falls from `true` to `false`.
+   *
+   * <p>Takes a raw pointer, and so is non-owning; users are responsible for the
+   * lifespan of the command.
+   *
+   * @param command the command to start
+   * @return this trigger, so calls can be chained
+   * @see #Falling()
+   */
+  Trigger OnFalse(Command* command);
+
+  /**
+   * Starts the given command whenever the signal falls from `true` to `false`.
+   *
+   * @param command The command to bind.
+   * @return The trigger, for chained calls.
+   */
+  Trigger OnFalse(CommandPtr&& command);
+
+  /**
+   * Starts the given command when the signal rises to `true` and cancels it
+   * when the signal falls to `false`.
+   *
+   * <p>Doesn't re-start the command in-between.
+   *
+   * <p>Takes a raw pointer, and so is non-owning; users are responsible for the
+   * lifespan of the command.
+   *
+   * @param command the command to start
+   * @return this trigger, so calls can be chained
+   */
+  Trigger WhileTrue(Command* command);
+
+  /**
+   * Starts the given command when the signal rises to `true` and cancels it
+   * when the signal falls to `false`. Moves command ownership to the button
+   * scheduler.
+   *
+   * @param command The command to bind.
+   * @return The trigger, for chained calls.
+   */
+  Trigger WhileTrue(CommandPtr&& command);
+
+  /**
+   * Starts the given command when the signal falls to `false` and cancels
+   * it when the signal rises.
+   *
+   * <p>Doesn't re-start the command in-between.
+   *
+   * <p>Takes a raw pointer, and so is non-owning; users are responsible for the
+   * lifespan of the command.
+   *
+   * @param command the command to start
+   * @return this trigger, so calls can be chained
+   */
+  Trigger WhileFalse(Command* command);
+
+  /**
+   * Starts the given command when the signal falls to `false` and cancels
+   * it when the signal rises. Moves command ownership to the button
+   * scheduler.
+   *
+   * @param command The command to bind.
+   * @return The trigger, for chained calls.
+   */
+  Trigger WhileFalse(CommandPtr&& command);
+
+  /**
+   * Toggles a command when the signal rises from `false` to the high
+   * state.
+   *
+   * <p>Takes a raw pointer, and so is non-owning; users are responsible for the
+   * lifespan of the command.
+   *
+   * @param command the command to toggle
+   * @return this trigger, so calls can be chained
+   */
+  Trigger ToggleOnTrue(Command* command);
+
+  /**
+   * Toggles a command when the signal rises from `false` to the high
+   * state.
+   *
+   * <p>Takes a raw pointer, and so is non-owning; users are responsible for the
+   * lifespan of the command.
+   *
+   * @param command the command to toggle
+   * @return this trigger, so calls can be chained
+   */
+  Trigger ToggleOnTrue(CommandPtr&& command);
+
+  /**
+   * Toggles a command when the signal falls from `true` to the low
+   * state.
+   *
+   * <p>Takes a raw pointer, and so is non-owning; users are responsible for the
+   * lifespan of the command.
+   *
+   * @param command the command to toggle
+   * @return this trigger, so calls can be chained
+   */
+  Trigger ToggleOnFalse(Command* command);
+
+  /**
+   * Toggles a command when the signal falls from `true` to the low
+   * state.
+   *
+   * <p>Takes a raw pointer, and so is non-owning; users are responsible for the
+   * lifespan of the command.
+   *
+   * @param command the command to toggle
+   * @return this trigger, so calls can be chained
+   */
+  Trigger ToggleOnFalse(CommandPtr&& command);
+
+  /**
    * Binds a command to start when the trigger becomes active. Takes a
    * raw pointer, and so is non-owning; users are responsible for the lifespan
    * of the command.
@@ -67,16 +205,8 @@ class Trigger : public frc::BooleanEvent {
    * @param command The command to bind.
    * @return The trigger, for chained calls.
    */
+  WPI_DEPRECATED("Use OnTrue(Command) instead")
   Trigger WhenActive(Command* command);
-
-  /**
-   * Binds a command to start when the trigger becomes active. Moves
-   * command ownership to the button scheduler.
-   *
-   * @param command The command to bind.
-   * @return The trigger, for chained calls.
-   */
-  Trigger WhenActive(CommandPtr&& command);
 
   /**
    * Binds a command to start when the trigger becomes active. Transfers
@@ -89,8 +219,9 @@ class Trigger : public frc::BooleanEvent {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
+  WPI_DEPRECATED("Use OnTrue(Command) instead")
   Trigger WhenActive(T&& command) {
-    this->Rising().IfHigh(
+    m_event.Rising().IfHigh(
         [command = std::make_unique<std::remove_reference_t<T>>(
              std::forward<T>(command))] { command->Schedule(); });
 
@@ -103,6 +234,8 @@ class Trigger : public frc::BooleanEvent {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
+  WPI_DEPRECATED(
+      "Use OnTrue(Command) instead and construct the InstantCommand manually")
   Trigger WhenActive(std::function<void()> toRun,
                      std::initializer_list<Subsystem*> requirements);
 
@@ -112,6 +245,8 @@ class Trigger : public frc::BooleanEvent {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
+  WPI_DEPRECATED(
+      "Use OnTrue(Command) instead and construct the InstantCommand manually")
   Trigger WhenActive(std::function<void()> toRun,
                      std::span<Subsystem* const> requirements = {});
 
@@ -123,17 +258,10 @@ class Trigger : public frc::BooleanEvent {
    * @param command The command to bind.
    * @return The trigger, for chained calls.
    */
+  WPI_DEPRECATED(
+      "Use WhileTrue(Command) with RepeatCommand, or bind command::Schedule "
+      "with IfHigh(std::function<void()>).")
   Trigger WhileActiveContinous(Command* command);
-
-  /**
-   * Binds a command to be started repeatedly while the trigger is active, and
-   * canceled when it becomes inactive. Moves command ownership to the button
-   * scheduler.
-   *
-   * @param command The command to bind.
-   * @return The trigger, for chained calls.
-   */
-  Trigger WhileActiveContinous(CommandPtr&& command);
 
   /**
    * Binds a command to be started repeatedly while the trigger is active, and
@@ -146,11 +274,14 @@ class Trigger : public frc::BooleanEvent {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
+  WPI_DEPRECATED(
+      "Use WhileTrue(Command) with RepeatCommand, or bind command::Schedule "
+      "with IfHigh(std::function<void()>).")
   Trigger WhileActiveContinous(T&& command) {
     std::shared_ptr<T> ptr =
         std::make_shared<std::remove_reference_t<T>>(std::forward<T>(command));
-    this->IfHigh([ptr] { ptr->Schedule(); });
-    this->Falling().IfHigh([ptr] { ptr->Cancel(); });
+    m_event.IfHigh([ptr] { ptr->Schedule(); });
+    m_event.Falling().IfHigh([ptr] { ptr->Cancel(); });
 
     return *this;
   }
@@ -161,6 +292,7 @@ class Trigger : public frc::BooleanEvent {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
+  WPI_DEPRECATED("Use WhileTrue(Command) and construct a RunCommand manually")
   Trigger WhileActiveContinous(std::function<void()> toRun,
                                std::initializer_list<Subsystem*> requirements);
 
@@ -170,6 +302,7 @@ class Trigger : public frc::BooleanEvent {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
+  WPI_DEPRECATED("Use WhileTrue(Command) and construct a RunCommand manually")
   Trigger WhileActiveContinous(std::function<void()> toRun,
                                std::span<Subsystem* const> requirements = {});
 
@@ -181,17 +314,8 @@ class Trigger : public frc::BooleanEvent {
    * @param command The command to bind.
    * @return The trigger, for chained calls.
    */
+  WPI_DEPRECATED("Use WhileTrue(Command) instead.")
   Trigger WhileActiveOnce(Command* command);
-
-  /**
-   * Binds a command to be started when the trigger becomes active, and
-   * canceled when it becomes inactive. Moves command ownership to the button
-   * scheduler.
-   *
-   * @param command The command to bind.
-   * @return The trigger, for chained calls.
-   */
-  Trigger WhileActiveOnce(CommandPtr&& command);
 
   /**
    * Binds a command to be started when the trigger becomes active, and
@@ -204,12 +328,13 @@ class Trigger : public frc::BooleanEvent {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
+  WPI_DEPRECATED("Use WhileTrue(Command) instead.")
   Trigger WhileActiveOnce(T&& command) {
     std::shared_ptr<T> ptr =
         std::make_shared<std::remove_reference_t<T>>(std::forward<T>(command));
 
-    this->Rising().IfHigh([ptr] { ptr->Schedule(); });
-    this->Falling().IfHigh([ptr] { ptr->Cancel(); });
+    m_event.Rising().IfHigh([ptr] { ptr->Schedule(); });
+    m_event.Falling().IfHigh([ptr] { ptr->Cancel(); });
 
     return *this;
   }
@@ -222,16 +347,8 @@ class Trigger : public frc::BooleanEvent {
    * @param command The command to bind.
    * @return The trigger, for chained calls.
    */
+  WPI_DEPRECATED("Use OnFalse(Command) instead.")
   Trigger WhenInactive(Command* command);
-
-  /**
-   * Binds a command to start when the trigger becomes inactive. Moves
-   * command ownership to the button scheduler.
-   *
-   * @param command The command to bind.
-   * @return The trigger, for chained calls.
-   */
-  Trigger WhenInactive(CommandPtr&& command);
 
   /**
    * Binds a command to start when the trigger becomes inactive.  Transfers
@@ -244,8 +361,9 @@ class Trigger : public frc::BooleanEvent {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
+  WPI_DEPRECATED("Use OnFalse(Command) instead.")
   Trigger WhenInactive(T&& command) {
-    this->Falling().IfHigh(
+    m_event.Falling().IfHigh(
         [command = std::make_unique<std::remove_reference_t<T>>(
              std::forward<T>(command))] { command->Schedule(); });
 
@@ -258,6 +376,8 @@ class Trigger : public frc::BooleanEvent {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
+  WPI_DEPRECATED(
+      "Use OnFalse(Command) instead and construct the InstantCommand manually")
   Trigger WhenInactive(std::function<void()> toRun,
                        std::initializer_list<Subsystem*> requirements);
 
@@ -267,6 +387,8 @@ class Trigger : public frc::BooleanEvent {
    * @param toRun the runnable to execute.
    * @param requirements the required subsystems.
    */
+  WPI_DEPRECATED(
+      "Use OnFalse(Command) instead and construct the InstantCommand manually")
   Trigger WhenInactive(std::function<void()> toRun,
                        std::span<Subsystem* const> requirements = {});
 
@@ -278,17 +400,8 @@ class Trigger : public frc::BooleanEvent {
    * @param command The command to bind.
    * @return The trigger, for chained calls.
    */
+  WPI_DEPRECATED("Use ToggleOnTrue(Command) instead.")
   Trigger ToggleWhenActive(Command* command);
-
-  /**
-   * Binds a command to start when the trigger becomes active, and be canceled
-   * when it again becomes active. Moves command ownership to the button
-   * scheduler.
-   *
-   * @param command The command to bind.
-   * @return The trigger, for chained calls.
-   */
-  Trigger ToggleWhenActive(CommandPtr&& command);
 
   /**
    * Binds a command to start when the trigger becomes active, and be canceled
@@ -301,8 +414,9 @@ class Trigger : public frc::BooleanEvent {
    */
   template <class T, typename = std::enable_if_t<std::is_base_of_v<
                          Command, std::remove_reference_t<T>>>>
+  WPI_DEPRECATED("Use ToggleOnTrue(Command) instead.")
   Trigger ToggleWhenActive(T&& command) {
-    this->Rising().IfHigh(
+    m_event.Rising().IfHigh(
         [command = std::make_unique<std::remove_reference_t<T>>(
              std::forward<T>(command))] {
           if (!command->IsScheduled()) {
@@ -323,6 +437,8 @@ class Trigger : public frc::BooleanEvent {
    * @param command The command to bind.
    * @return The trigger, for chained calls.
    */
+  WPI_DEPRECATED(
+      "Use Rising() as a command end condition with Until() instead.")
   Trigger CancelWhenActive(Command* command);
 
   /**
@@ -330,14 +446,14 @@ class Trigger : public frc::BooleanEvent {
    *
    * @return a new event representing when this one newly changes to true.
    */
-  Trigger Rising() { return BooleanEvent::Rising().CastTo<Trigger>(); }
+  Trigger Rising() { return m_event.Rising().CastTo<Trigger>(); }
 
   /**
    * Get a new event that triggers only when this one newly changes to false.
    *
    * @return a new event representing when this one newly changes to false.
    */
-  Trigger Falling() { return BooleanEvent::Falling().CastTo<Trigger>(); }
+  Trigger Falling() { return m_event.Falling().CastTo<Trigger>(); }
 
   /**
    * Composes two triggers with logical AND.
@@ -345,7 +461,7 @@ class Trigger : public frc::BooleanEvent {
    * @return A trigger which is active when both component triggers are active.
    */
   Trigger operator&&(std::function<bool()> rhs) {
-    return BooleanEvent::operator&&(rhs).CastTo<Trigger>();
+    return m_event.operator&&(rhs).CastTo<Trigger>();
   }
 
   /**
@@ -354,7 +470,7 @@ class Trigger : public frc::BooleanEvent {
    * @return A trigger which is active when either component trigger is active.
    */
   Trigger operator||(std::function<bool()> rhs) {
-    return BooleanEvent::operator||(rhs).CastTo<Trigger>();
+    return m_event.operator||(rhs).CastTo<Trigger>();
   }
 
   /**
@@ -363,7 +479,7 @@ class Trigger : public frc::BooleanEvent {
    * @return A trigger which is active when the component trigger is inactive,
    * and vice-versa.
    */
-  Trigger operator!() { return BooleanEvent::operator!().CastTo<Trigger>(); }
+  Trigger operator!() { return m_event.operator!().CastTo<Trigger>(); }
 
   /**
    * Creates a new debounced trigger from this trigger - it will become active
@@ -376,7 +492,15 @@ class Trigger : public frc::BooleanEvent {
   Trigger Debounce(units::second_t debounceTime,
                    frc::Debouncer::DebounceType type =
                        frc::Debouncer::DebounceType::kRising) {
-    return BooleanEvent::Debounce(debounceTime, type).CastTo<Trigger>();
+    return m_event.Debounce(debounceTime, type).CastTo<Trigger>();
   }
+
+  /**
+   * Get the wrapped BooleanEvent instance.
+   */
+  frc::BooleanEvent GetEvent() const;
+
+ private:
+  frc::BooleanEvent m_event;
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/NetworkButtonTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/NetworkButtonTest.java
@@ -37,7 +37,7 @@ class NetworkButtonTest extends CommandTestBase {
 
     var button = new NetworkButton(m_inst, "TestTable", "Test");
     pub.set(false);
-    button.whenPressed(command);
+    button.onTrue(command);
     scheduler.run();
     verify(command, never()).schedule();
     pub.set(true);

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/TriggerTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/button/TriggerTest.java
@@ -14,15 +14,12 @@ import edu.wpi.first.wpilibj.simulation.SimHooks;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.CommandTestBase;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BooleanSupplier;
-
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.StartEndCommand;
 import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
-
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.Test;
 
 class TriggerTest extends CommandTestBase {
@@ -90,7 +87,8 @@ class TriggerTest extends CommandTestBase {
     CommandScheduler scheduler = CommandScheduler.getInstance();
     AtomicInteger startCounter = new AtomicInteger(0);
     AtomicInteger endCounter = new AtomicInteger(0);
-    Command command1 = new StartEndCommand(startCounter::incrementAndGet, endCounter::incrementAndGet);
+    Command command1 =
+        new StartEndCommand(startCounter::incrementAndGet, endCounter::incrementAndGet);
 
     InternalButton button = new InternalButton();
     button.setPressed(false);
@@ -114,7 +112,8 @@ class TriggerTest extends CommandTestBase {
     CommandScheduler scheduler = CommandScheduler.getInstance();
     AtomicInteger startCounter = new AtomicInteger(0);
     AtomicInteger endCounter = new AtomicInteger(0);
-    Command command1 = new StartEndCommand(startCounter::incrementAndGet, endCounter::incrementAndGet);
+    Command command1 =
+        new StartEndCommand(startCounter::incrementAndGet, endCounter::incrementAndGet);
 
     InternalButton button = new InternalButton();
     button.setPressed(false);
@@ -144,7 +143,9 @@ class TriggerTest extends CommandTestBase {
     AtomicInteger endCounter = new AtomicInteger(0);
 
     InternalButton button = new InternalButton();
-    Command command1 = new StartEndCommand(startCounter::incrementAndGet, endCounter::incrementAndGet).until(button.rising());
+    Command command1 =
+        new StartEndCommand(startCounter::incrementAndGet, endCounter::incrementAndGet)
+            .until(button.rising());
 
     button.setPressed(false);
     command1.schedule();
@@ -174,7 +175,7 @@ class TriggerTest extends CommandTestBase {
 
     AtomicInteger counter = new AtomicInteger(0);
 
-    buttonWhenActive.whenActive(counter::incrementAndGet);
+    buttonWhenActive.whenPressed(counter::incrementAndGet);
     buttonWhileActiveContinuous.whileActiveContinuous(counter::incrementAndGet);
     buttonWhenInactive.whenInactive(counter::incrementAndGet);
 

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/POVButtonTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/POVButtonTest.cpp
@@ -26,7 +26,7 @@ TEST_F(POVButtonTest, SetPOV) {
   WaitUntilCommand command([&finished] { return finished; });
 
   frc::Joystick joy(1);
-  POVButton(&joy, 90).WhenActive(&command);
+  POVButton(&joy, 90).OnTrue(&command);
   scheduler.Run();
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/POVButtonTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/POVButtonTest.cpp
@@ -26,7 +26,7 @@ TEST_F(POVButtonTest, SetPOV) {
   WaitUntilCommand command([&finished] { return finished; });
 
   frc::Joystick joy(1);
-  POVButton(&joy, 90).WhenPressed(&command);
+  POVButton(&joy, 90).WhenActive(&command);
   scheduler.Run();
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/button/NetworkButtonTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/button/NetworkButtonTest.cpp
@@ -32,7 +32,7 @@ TEST_F(NetworkButtonTest, SetNetworkButton) {
 
   WaitUntilCommand command([&finished] { return finished; });
 
-  NetworkButton(inst, "TestTable", "Test").WhenActive(&command);
+  NetworkButton(inst, "TestTable", "Test").OnTrue(&command);
   scheduler.Run();
   EXPECT_FALSE(scheduler.IsScheduled(&command));
   pub.Set(true);

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/button/TriggerTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/button/TriggerTest.cpp
@@ -5,6 +5,7 @@
 #include <frc/simulation/SimHooks.h>
 
 #include "../CommandTestBase.h"
+#include "frc2/command/CommandPtr.h"
 #include "frc2/command/CommandScheduler.h"
 #include "frc2/command/RunCommand.h"
 #include "frc2/command/WaitUntilCommand.h"
@@ -12,16 +13,16 @@
 #include "gtest/gtest.h"
 
 using namespace frc2;
-class ButtonTest : public CommandTestBase {};
+class TriggerTest : public CommandTestBase {};
 
-TEST_F(ButtonTest, WhenPressed) {
+TEST_F(TriggerTest, OnTrue) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
   bool pressed = false;
 
   WaitUntilCommand command([&finished] { return finished; });
 
-  Trigger([&pressed] { return pressed; }).WhenActive(&command);
+  Trigger([&pressed] { return pressed; }).OnTrue(&command);
   scheduler.Run();
   EXPECT_FALSE(scheduler.IsScheduled(&command));
   pressed = true;
@@ -32,14 +33,14 @@ TEST_F(ButtonTest, WhenPressed) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(ButtonTest, WhenReleased) {
+TEST_F(TriggerTest, OnFalse) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
   bool pressed = false;
   WaitUntilCommand command([&finished] { return finished; });
 
   pressed = true;
-  Trigger([&pressed] { return pressed; }).WhenInactive(&command);
+  Trigger([&pressed] { return pressed; }).OnFalse(&command);
   scheduler.Run();
   EXPECT_FALSE(scheduler.IsScheduled(&command));
   pressed = false;
@@ -50,78 +51,80 @@ TEST_F(ButtonTest, WhenReleased) {
   EXPECT_FALSE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(ButtonTest, WhileHeld) {
+TEST_F(TriggerTest, WhileTrueRepeatedly) {
   auto& scheduler = CommandScheduler::GetInstance();
-  bool finished = false;
+  int counter = 0;
   bool pressed = false;
-  WaitUntilCommand command([&finished] { return finished; });
+  CommandPtr command = InstantCommand([&counter] { counter++; }).Repeatedly();
 
   pressed = false;
-  Trigger([&pressed] { return pressed; }).WhileActiveContinous(&command);
+  Trigger([&pressed] { return pressed; }).WhileTrue(std::move(command));
   scheduler.Run();
-  EXPECT_FALSE(scheduler.IsScheduled(&command));
+  EXPECT_EQ(0, counter);
   pressed = true;
   scheduler.Run();
-  EXPECT_TRUE(scheduler.IsScheduled(&command));
-  finished = true;
   scheduler.Run();
-  finished = false;
-  scheduler.Run();
-  EXPECT_TRUE(scheduler.IsScheduled(&command));
+  EXPECT_EQ(2, counter);
   pressed = false;
   scheduler.Run();
-  EXPECT_FALSE(scheduler.IsScheduled(&command));
+  EXPECT_EQ(2, counter);
 }
 
-TEST_F(ButtonTest, WhenHeld) {
+TEST_F(TriggerTest, WhenTrueOnce) {
   auto& scheduler = CommandScheduler::GetInstance();
-  bool finished = false;
+  int startCounter = 0;
+  int endCounter = 0;
   bool pressed = false;
-  WaitUntilCommand command([&finished] { return finished; });
+
+  CommandPtr command = StartEndCommand([&startCounter] { startCounter++; },
+                                       [&endCounter] { endCounter++; })
+                           .ToPtr();
 
   pressed = false;
-  Trigger([&pressed] { return pressed; }).WhileActiveOnce(&command);
+  Trigger([&pressed] { return pressed; }).WhileTrue(std::move(command));
   scheduler.Run();
-  EXPECT_FALSE(scheduler.IsScheduled(&command));
+  EXPECT_EQ(0, startCounter);
+  EXPECT_EQ(0, endCounter);
   pressed = true;
   scheduler.Run();
-  EXPECT_TRUE(scheduler.IsScheduled(&command));
-  finished = true;
   scheduler.Run();
-  finished = false;
-  scheduler.Run();
-  EXPECT_FALSE(scheduler.IsScheduled(&command));
-
-  pressed = false;
-  Trigger([&pressed] { return pressed; }).WhileActiveOnce(&command);
-  pressed = true;
-  scheduler.Run();
+  EXPECT_EQ(1, startCounter);
+  EXPECT_EQ(0, endCounter);
   pressed = false;
   scheduler.Run();
-  EXPECT_FALSE(scheduler.IsScheduled(&command));
+  EXPECT_EQ(1, startCounter);
+  EXPECT_EQ(1, endCounter);
 }
 
-TEST_F(ButtonTest, ToggleWhenPressed) {
+TEST_F(TriggerTest, ToggleWhenActive) {
   auto& scheduler = CommandScheduler::GetInstance();
-  bool finished = false;
   bool pressed = false;
-  WaitUntilCommand command([&finished] { return finished; });
+  int startCounter = 0;
+  int endCounter = 0;
+  CommandPtr command = StartEndCommand([&startCounter] { startCounter++; },
+                                       [&endCounter] { endCounter++; })
+                           .ToPtr();
 
-  pressed = false;
-  Trigger([&pressed] { return pressed; }).ToggleWhenActive(&command);
-  scheduler.Run();
-  EXPECT_FALSE(scheduler.IsScheduled(&command));
+  Trigger([&pressed] { return pressed; }).ToggleOnTrue(std::move(command));
+  scheduler.run();
+  EXPECT_EQ(0, startCounter);
+  EXPECT_EQ(0, endCounter);
   pressed = true;
   scheduler.Run();
-  EXPECT_TRUE(scheduler.IsScheduled(&command));
+  scheduler.Run();
+  EXPECT_EQ(1, startCounter);
+  EXPECT_EQ(0, endCounter);
   pressed = false;
   scheduler.Run();
+  EXPECT_EQ(1, startCounter);
+  EXPECT_EQ(0, endCounter);
   pressed = true;
   scheduler.Run();
-  EXPECT_FALSE(scheduler.IsScheduled(&command));
+  EXPECT_EQ(1, startCounter);
+  EXPECT_EQ(1, endCounter);
 }
 
-TEST_F(ButtonTest, And) {
+TEST_F(TriggerTest, And) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
   bool pressed1 = false;
@@ -139,7 +142,7 @@ TEST_F(ButtonTest, And) {
   EXPECT_TRUE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(ButtonTest, Or) {
+TEST_F(TriggerTest, Or) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
   bool pressed1 = false;
@@ -164,7 +167,7 @@ TEST_F(ButtonTest, Or) {
   EXPECT_TRUE(scheduler.IsScheduled(&command2));
 }
 
-TEST_F(ButtonTest, Negate) {
+TEST_F(TriggerTest, Negate) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool finished = false;
   bool pressed = true;
@@ -178,7 +181,9 @@ TEST_F(ButtonTest, Negate) {
   EXPECT_TRUE(scheduler.IsScheduled(&command));
 }
 
-TEST_F(ButtonTest, RValueButton) {
+// this type of binding is deprecated and identical to OnTrue
+WPI_IGNORE_DEPRECATED
+TEST_F(TriggerTest, RValueTrigger) {
   auto& scheduler = CommandScheduler::GetInstance();
   int counter = 0;
   bool pressed = false;
@@ -192,13 +197,14 @@ TEST_F(ButtonTest, RValueButton) {
   scheduler.Run();
   EXPECT_EQ(counter, 1);
 }
+WPI_UNIGNORE_DEPRECATED
 
-TEST_F(ButtonTest, Debounce) {
+TEST_F(TriggerTest, Debounce) {
   auto& scheduler = CommandScheduler::GetInstance();
   bool pressed = false;
   RunCommand command([] {});
 
-  Trigger([&pressed] { return pressed; }).Debounce(100_ms).WhenActive(&command);
+  Trigger([&pressed] { return pressed; }).Debounce(100_ms).OnTrue(&command);
   pressed = true;
   scheduler.Run();
   EXPECT_FALSE(scheduler.IsScheduled(&command));

--- a/wpilibc/src/main/native/include/frc/event/BooleanEvent.h
+++ b/wpilibc/src/main/native/include/frc/event/BooleanEvent.h
@@ -64,8 +64,7 @@ class BooleanEvent {
    * second.
    * @return an instance of the subclass.
    */
-  template <class T,
-            typename = std::enable_if_t<std::is_base_of_v<BooleanEvent, T>>>
+  template <class T>
   T CastTo(std::function<T(EventLoop*, std::function<bool()>)> ctor =
                [](EventLoop* loop, std::function<bool()> condition) {
                  return T(loop, condition);

--- a/wpilibcExamples/src/main/cpp/examples/ArmBot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBot/cpp/RobotContainer.cpp
@@ -5,6 +5,9 @@
 #include "RobotContainer.h"
 
 #include <frc/shuffleboard/Shuffleboard.h>
+#include <frc2/command/Commands.h>
+#include <frc2/command/InstantCommand.h>
+#include <frc2/command/RunCommand.h>
 #include <frc2/command/button/JoystickButton.h>
 #include <units/angle.h>
 
@@ -15,7 +18,7 @@ RobotContainer::RobotContainer() {
   ConfigureButtonBindings();
 
   // Set up default drive command
-  m_drive.SetDefaultCommand(frc2::cmd::Run(
+  m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
         m_drive.ArcadeDrive(-m_driverController.GetLeftY(),
                             m_driverController.GetRightX());

--- a/wpilibcExamples/src/main/cpp/examples/ArmBot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBot/cpp/RobotContainer.cpp
@@ -15,7 +15,7 @@ RobotContainer::RobotContainer() {
   ConfigureButtonBindings();
 
   // Set up default drive command
-  m_drive.SetDefaultCommand(frc2::RunCommand(
+  m_drive.SetDefaultCommand(frc2::cmd::Run(
       [this] {
         m_drive.ArcadeDrive(-m_driverController.GetLeftY(),
                             m_driverController.GetRightX());
@@ -28,31 +28,31 @@ void RobotContainer::ConfigureButtonBindings() {
 
   // Move the arm to 2 radians above horizontal when the 'A' button is pressed.
   frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kA)
-      .WhenPressed(
+      .OnTrue(frc2::cmd::RunOnce(
           [this] {
             m_arm.SetGoal(2_rad);
             m_arm.Enable();
           },
-          {&m_arm});
+          {&m_arm}));
 
   // Move the arm to neutral position when the 'B' button is pressed.
   frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kB)
-      .WhenPressed(
+      .OnTrue(frc2::cmd::RunOnce(
           [this] {
             m_arm.SetGoal(ArmConstants::kArmOffset);
             m_arm.Enable();
           },
-          {&m_arm});
+          {&m_arm}));
 
   // Disable the arm controller when Y is pressed.
   frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kY)
-      .WhenPressed([this] { m_arm.Disable(); }, {&m_arm});
+      .OnTrue(frc2::cmd::RunOnce([this] { m_arm.Disable(); }, {&m_arm}));
 
   // While holding the shoulder button, drive at half speed
   frc2::JoystickButton(&m_driverController,
                        frc::XboxController::Button::kRightBumper)
-      .WhenPressed([this] { m_drive.SetMaxOutput(0.5); })
-      .WhenReleased([this] { m_drive.SetMaxOutput(1); });
+      .OnTrue(frc2::cmd::RunOnce([this] { m_drive.SetMaxOutput(0.5); }))
+      .OnFalse(frc2::cmd::RunOnce([this] { m_drive.SetMaxOutput(1); }));
 }
 
 void RobotContainer::DisablePIDSubsystems() {

--- a/wpilibcExamples/src/main/cpp/examples/ArmBot/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBot/include/RobotContainer.h
@@ -7,13 +7,7 @@
 #include <frc/XboxController.h>
 #include <frc/smartdashboard/SendableChooser.h>
 #include <frc2/command/Command.h>
-#include <frc2/command/ConditionalCommand.h>
-#include <frc2/command/InstantCommand.h>
-#include <frc2/command/ParallelRaceGroup.h>
-#include <frc2/command/RunCommand.h>
-#include <frc2/command/SequentialCommandGroup.h>
-#include <frc2/command/WaitCommand.h>
-#include <frc2/command/WaitUntilCommand.h>
+#include <frc2/command/CommandPtr.h>
 
 #include "Constants.h"
 #include "subsystems/ArmSubsystem.h"

--- a/wpilibcExamples/src/main/cpp/examples/ArmBot/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBot/include/RobotContainer.h
@@ -7,7 +7,6 @@
 #include <frc/XboxController.h>
 #include <frc/smartdashboard/SendableChooser.h>
 #include <frc2/command/Command.h>
-#include <frc2/command/CommandPtr.h>
 
 #include "Constants.h"
 #include "subsystems/ArmSubsystem.h"

--- a/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/cpp/RobotContainer.cpp
@@ -5,6 +5,9 @@
 #include "RobotContainer.h"
 
 #include <frc/shuffleboard/Shuffleboard.h>
+#include <frc2/command/Commands.h>
+#include <frc2/command/InstantCommand.h>
+#include <frc2/command/RunCommand.h>
 #include <frc2/command/button/JoystickButton.h>
 #include <units/angle.h>
 

--- a/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/cpp/RobotContainer.cpp
@@ -28,18 +28,18 @@ void RobotContainer::ConfigureButtonBindings() {
 
   // Move the arm to 2 radians above horizontal when the 'A' button is pressed.
   frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kA)
-      .WhenPressed([this] { m_arm.SetGoal(2_rad); }, {&m_arm});
+      .OnTrue(frc2::cmd::RunOnce([this] { m_arm.SetGoal(2_rad); }, {&m_arm}));
 
   // Move the arm to neutral position when the 'B' button is pressed.
   frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kB)
-      .WhenPressed([this] { m_arm.SetGoal(ArmConstants::kArmOffset); },
-                   {&m_arm});
+      .OnTrue(frc2::cmd::RunOnce(
+          [this] { m_arm.SetGoal(ArmConstants::kArmOffset); }, {&m_arm}));
 
   // While holding the shoulder button, drive at half speed
   frc2::JoystickButton(&m_driverController,
                        frc::XboxController::Button::kRightBumper)
-      .WhenPressed([this] { m_drive.SetMaxOutput(0.5); })
-      .WhenReleased([this] { m_drive.SetMaxOutput(1); });
+      .OnTrue(frc2::cmd::RunOnce([this] { m_drive.SetMaxOutput(0.5); }))
+      .OnFalse(frc2::cmd::RunOnce([this] { m_drive.SetMaxOutput(1); }));
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/include/RobotContainer.h
@@ -7,13 +7,7 @@
 #include <frc/XboxController.h>
 #include <frc/smartdashboard/SendableChooser.h>
 #include <frc2/command/Command.h>
-#include <frc2/command/ConditionalCommand.h>
-#include <frc2/command/InstantCommand.h>
-#include <frc2/command/ParallelRaceGroup.h>
-#include <frc2/command/RunCommand.h>
-#include <frc2/command/SequentialCommandGroup.h>
-#include <frc2/command/WaitCommand.h>
-#include <frc2/command/WaitUntilCommand.h>
+#include <frc2/command/CommandPtr.h>
 
 #include "Constants.h"
 #include "subsystems/ArmSubsystem.h"

--- a/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/include/RobotContainer.h
@@ -7,7 +7,6 @@
 #include <frc/XboxController.h>
 #include <frc/smartdashboard/SendableChooser.h>
 #include <frc2/command/Command.h>
-#include <frc2/command/CommandPtr.h>
 
 #include "Constants.h"
 #include "subsystems/ArmSubsystem.h"

--- a/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/cpp/RobotContainer.cpp
@@ -5,6 +5,7 @@
 #include "RobotContainer.h"
 
 #include <frc/shuffleboard/Shuffleboard.h>
+#include <frc2/command/Commands.h>
 #include <frc2/command/button/JoystickButton.h>
 
 #include "commands/DriveDistanceProfiled.h"
@@ -30,8 +31,8 @@ void RobotContainer::ConfigureButtonBindings() {
   // While holding the shoulder button, drive at half speed
   frc2::JoystickButton(&m_driverController,
                        frc::XboxController::Button::kRightBumper)
-      .OnTrue(frc2::cmd::RunOnce([this] { m_drive.SetMaxOutput(0.5); }, {}))
-      .OnFalse(frc2::cmd::RunOnce([this] { m_drive.SetMaxOutput(1); }, {}));
+      .OnTrue(&m_driveHalfSpeed)
+      .OnFalse(&m_driveFullSpeed);
 
   // Drive forward by 3 meters when the 'A' button is pressed, with a timeout of
   // 10 seconds
@@ -54,6 +55,7 @@ void RobotContainer::ConfigureButtonBindings() {
               },
               // Require the drive
               {&m_drive})
+              .ToPtr()
               .BeforeStarting(
                   frc2::cmd::RunOnce([this]() { m_drive.ResetEncoders(); }, {}))
               .WithTimeout(10_s));

--- a/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/RobotContainer.cpp
@@ -27,22 +27,22 @@ void RobotContainer::ConfigureButtonBindings() {
 
   // Spin up the shooter when the 'A' button is pressed
   frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kA)
-      .WhenPressed(&m_spinUpShooter);
+      .OnTrue(&m_spinUpShooter);
 
   // Turn off the shooter when the 'B' button is pressed
   frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kB)
-      .WhenPressed(&m_stopShooter);
+      .OnTrue(&m_stopShooter);
 
   // Shoot when the 'X' button is held
   frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kX)
-      .WhenPressed(&m_shoot)
-      .WhenReleased(&m_stopFeeder);
+      .OnTrue(&m_shoot)
+      .OnFalse(&m_stopFeeder);
 
   // While holding the shoulder button, drive at half speed
   frc2::JoystickButton(&m_driverController,
                        frc::XboxController::Button::kRightBumper)
-      .WhenPressed(&m_driveHalfSpeed)
-      .WhenReleased(&m_driveFullSpeed);
+      .OnTrue(&m_driveHalfSpeed)
+      .OnFalse(&m_driveFullSpeed);
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/RobotContainer.cpp
@@ -34,7 +34,7 @@ void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
   frc2::JoystickButton(&m_joy, 5).OnTrue(
       SetElevatorSetpoint(0.25, m_elevator).ToPtr());
-  frc2::JoystickButton(&m_joy, 6).OnTrue(CloseClaw(m_claw).ToPtr()));
+  frc2::JoystickButton(&m_joy, 6).OnTrue(CloseClaw(m_claw).ToPtr());
   frc2::JoystickButton(&m_joy, 7).OnTrue(
       SetElevatorSetpoint(0.0, m_elevator).ToPtr());
   frc2::JoystickButton(&m_joy, 8).OnTrue(OpenClaw(m_claw).ToPtr());

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/RobotContainer.cpp
@@ -32,20 +32,20 @@ RobotContainer::RobotContainer()
 
 void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
-  frc2::JoystickButton(&m_joy, 5).WhenPressed(
-      SetElevatorSetpoint(0.25, m_elevator));
-  frc2::JoystickButton(&m_joy, 6).WhenPressed(CloseClaw(m_claw));
-  frc2::JoystickButton(&m_joy, 7).WhenPressed(
-      SetElevatorSetpoint(0.0, m_elevator));
-  frc2::JoystickButton(&m_joy, 8).WhenPressed(OpenClaw(m_claw));
-  frc2::JoystickButton(&m_joy, 9).WhenPressed(
-      Autonomous(m_claw, m_wrist, m_elevator, m_drivetrain));
+  frc2::JoystickButton(&m_joy, 5).OnTrue(
+      SetElevatorSetpoint(0.25, m_elevator).ToPtr());
+  frc2::JoystickButton(&m_joy, 6).OnTrue(CloseClaw(m_claw).ToPtr()));
+  frc2::JoystickButton(&m_joy, 7).OnTrue(
+      SetElevatorSetpoint(0.0, m_elevator).ToPtr());
+  frc2::JoystickButton(&m_joy, 8).OnTrue(OpenClaw(m_claw).ToPtr());
+  frc2::JoystickButton(&m_joy, 9).OnTrue(
+      Autonomous(m_claw, m_wrist, m_elevator, m_drivetrain).ToPtr());
   frc2::JoystickButton(&m_joy, 10)
-      .WhenPressed(Pickup(m_claw, m_wrist, m_elevator));
+      .OnTrue(Pickup(m_claw, m_wrist, m_elevator).ToPtr());
   frc2::JoystickButton(&m_joy, 11)
-      .WhenPressed(Place(m_claw, m_wrist, m_elevator));
+      .OnTrue(Place(m_claw, m_wrist, m_elevator).ToPtr());
   frc2::JoystickButton(&m_joy, 12)
-      .WhenPressed(PrepareToPickup(m_claw, m_wrist, m_elevator));
+      .OnTrue(PrepareToPickup(m_claw, m_wrist, m_elevator).ToPtr());
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/RobotContainer.cpp
@@ -5,6 +5,7 @@
 #include "RobotContainer.h"
 
 #include <frc/shuffleboard/Shuffleboard.h>
+#include <frc2/command/Commands.h>
 #include <frc2/command/PIDCommand.h>
 #include <frc2/command/ParallelRaceGroup.h>
 #include <frc2/command/RunCommand.h>

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/RobotContainer.cpp
@@ -32,33 +32,35 @@ void RobotContainer::ConfigureButtonBindings() {
 
   // Stabilize robot to drive straight with gyro when L1 is held
   frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kL1)
-      .WhenHeld(frc2::PIDCommand{
-          frc2::PIDController{dc::kStabilizationP, dc::kStabilizationI,
-                              dc::kStabilizationD},
-          // Close the loop on the turn rate
-          [this] { return m_drive.GetTurnRate(); },
-          // Setpoint is 0
-          0,
-          // Pipe the output to the turning controls
-          [this](double output) {
-            m_drive.ArcadeDrive(m_driverController.GetLeftY(), output);
-          },
-          // Require the robot drive
-          {&m_drive}});
+      .WhileTrue(
+          frc2::PIDCommand(
+              frc2::PIDController{dc::kStabilizationP, dc::kStabilizationI,
+                                  dc::kStabilizationD},
+              // Close the loop on the turn rate
+              [this] { return m_drive.GetTurnRate(); },
+              // Setpoint is 0
+              0,
+              // Pipe the output to the turning controls
+              [this](double output) {
+                m_drive.ArcadeDrive(m_driverController.GetLeftY(), output);
+              },
+              // Require the robot drive
+              {&m_drive})
+              .ToPtr());
 
   // Turn to 90 degrees when the 'Cross' button is pressed
   frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kCross)
-      .WhenPressed(TurnToAngle{90_deg, &m_drive}.WithTimeout(5_s));
+      .OnTrue(TurnToAngle{90_deg, &m_drive}.WithTimeout(5_s));
 
   // Turn to -90 degrees with a profile when the 'Square' button is pressed,
   // with a 5 second timeout
   frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kSquare)
-      .WhenPressed(TurnToAngle{90_deg, &m_drive}.WithTimeout(5_s));
+      .OnTrue(TurnToAngle{90_deg, &m_drive}.WithTimeout(5_s));
 
   // While holding R1, drive at half speed
   frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kR1)
-      .WhenPressed(frc2::InstantCommand{[this] { m_drive.SetMaxOutput(0.5); }})
-      .WhenReleased(frc2::InstantCommand{[this] { m_drive.SetMaxOutput(1); }});
+      .OnTrue(frc2::cmd::RunOnce([this] { m_drive.SetMaxOutput(0.5); }, {}))
+      .OnFalse(frc2::cmd::RunOnce([this] { m_drive.SetMaxOutput(1); }, {}));
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/RobotContainer.cpp
@@ -34,14 +34,14 @@ void RobotContainer::ConfigureButtonBindings() {
 
   // Grab the hatch when the 'Circle' button is pressed.
   frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kCircle)
-      .WhenPressed(&m_grabHatch);
+      .OnTrue(&m_grabHatch);
   // Release the hatch when the 'Square' button is pressed.
   frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kSquare)
-      .WhenPressed(&m_releaseHatch);
+      .OnTrue(&m_releaseHatch);
   // While holding R1, drive at half speed
   frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kR1)
-      .WhenPressed(&m_driveHalfSpeed)
-      .WhenReleased(&m_driveFullSpeed);
+      .OnTrue(&m_driveHalfSpeed)
+      .OnFalse(&m_driveFullSpeed);
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/RobotContainer.cpp
@@ -41,14 +41,14 @@ void RobotContainer::ConfigureButtonBindings() {
 
   // Grab the hatch when the 'A' button is pressed.
   frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kA)
-      .WhenPressed(new GrabHatch(&m_hatch));
+      .OnTrue(GrabHatch(&m_hatch).ToPtr());
   // Release the hatch when the 'B' button is pressed.
   frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kB)
-      .WhenPressed(new ReleaseHatch(&m_hatch));
+      .OnTrue(ReleaseHatch(&m_hatch).ToPtr());
   // While holding the shoulder button, drive at half speed
   frc2::JoystickButton(&m_driverController,
                        frc::XboxController::Button::kRightBumper)
-      .WhenHeld(new HalveDriveSpeed(&m_drive));
+      .WhileTrue(HalveDriveSpeed(&m_drive).ToPtr());
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/RobotContainer.cpp
@@ -43,8 +43,8 @@ void RobotContainer::ConfigureButtonBindings() {
   // While holding the shoulder button, drive at half speed
   frc2::JoystickButton(&m_driverController,
                        frc::XboxController::Button::kRightBumper)
-      .WhenPressed(&m_driveHalfSpeed)
-      .WhenReleased(&m_driveFullSpeed);
+      .OnTrue(&m_driveHalfSpeed)
+      .OnFalse(&m_driveFullSpeed);
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/wpilibcExamples/src/main/cpp/examples/RamseteCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RamseteCommand/cpp/RobotContainer.cpp
@@ -39,8 +39,8 @@ void RobotContainer::ConfigureButtonBindings() {
 
   // While holding the shoulder button, drive at half speed
   frc2::JoystickButton{&m_driverController, 6}
-      .WhenPressed(&m_driveHalfSpeed)
-      .WhenReleased(&m_driveFullSpeed);
+      .OnTrue(&m_driveHalfSpeed)
+      .OnFalse(&m_driveFullSpeed);
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/RobotContainer.cpp
@@ -5,7 +5,7 @@
 #include "RobotContainer.h"
 
 #include <frc/smartdashboard/SmartDashboard.h>
-#include <frc2/command/PrintCommand.h>
+#include <frc2/command/Commands.h>
 #include <frc2/command/button/Button.h>
 
 #include "commands/TeleopArcadeDrive.h"

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/RobotContainer.cpp
@@ -22,8 +22,8 @@ void RobotContainer::ConfigureButtonBindings() {
       [this] { return m_controller.GetRawAxis(2); }));
 
   // Example of how to use the onboard IO
-  m_onboardButtonA.WhenPressed(frc2::PrintCommand("Button A Pressed"))
-      .WhenReleased(frc2::PrintCommand("Button A Released"));
+  m_onboardButtonA.OnTrue(frc2::cmd::Print("Button A Pressed"))
+      .OnFalse(frc2::cmd::Print("Button A Released"));
 
   // Setup SmartDashboard options.
   m_chooser.SetDefaultOption("Auto Routine Distance", &m_autoDistance);

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/include/RobotContainer.h
@@ -7,6 +7,7 @@
 #include <frc/Joystick.h>
 #include <frc/smartdashboard/SendableChooser.h>
 #include <frc2/command/Command.h>
+#include <frc2/command/CommandPtr.h>
 #include <frc2/command/button/Button.h>
 
 #include "Constants.h"

--- a/wpilibcExamples/src/main/cpp/examples/SchedulerEventLogging/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SchedulerEventLogging/cpp/RobotContainer.cpp
@@ -46,14 +46,14 @@ void RobotContainer::ConfigureButtonBindings() {
 
   // Run instant command 1 when the 'A' button is pressed
   frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kA)
-      .WhenPressed(&m_instantCommand1);
+      .OnTrue(&m_instantCommand1);
   // Run instant command 2 when the 'X' button is pressed
   frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kX)
-      .WhenPressed(&m_instantCommand2);
+      .OnTrue(&m_instantCommand2);
   // Run instant command 3 when the 'Y' button is held; release early to
   // interrupt
   frc2::JoystickButton(&m_driverController, frc::XboxController::Button::kY)
-      .WhenHeld(&m_waitCommand);
+      .OnTrue(&m_waitCommand);
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
@@ -53,8 +53,8 @@ void RobotContainer::ConfigureButtonBindings() {
   // While holding the shoulder button, drive at half speed
   frc2::JoystickButton(&m_driverController,
                        frc::XboxController::Button::kRightBumper)
-      .WhenPressed(&m_driveHalfSpeed)
-      .WhenReleased(&m_driveFullSpeed);
+      .OnTrue(&m_driveHalfSpeed)
+      .OnFalse(&m_driveFullSpeed);
 }
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/event/BooleanEvent.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/event/BooleanEvent.java
@@ -178,7 +178,7 @@ public class BooleanEvent implements BooleanSupplier {
    * @param <T> the subclass type
    * @return an instance of the subclass.
    */
-  public <T extends BooleanEvent> T castTo(BiFunction<EventLoop, BooleanSupplier, T> ctor) {
+  public <T extends BooleanSupplier> T castTo(BiFunction<EventLoop, BooleanSupplier, T> ctor) {
     return ctor.apply(m_loop, m_signal);
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbot/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbot/RobotContainer.java
@@ -55,29 +55,32 @@ public class RobotContainer {
   private void configureButtonBindings() {
     // Move the arm to 2 radians above horizontal when the 'A' button is pressed.
     new JoystickButton(m_driverController, Button.kA.value)
-        .whenPressed(
-            () -> {
-              m_robotArm.setGoal(2);
-              m_robotArm.enable();
-            },
-            m_robotArm);
+        .onTrue(
+            new InstantCommand(
+                () -> {
+                  m_robotArm.setGoal(2);
+                  m_robotArm.enable();
+                },
+                m_robotArm));
 
     // Move the arm to neutral position when the 'B' button is pressed.
     new JoystickButton(m_driverController, Button.kB.value)
-        .whenPressed(
-            () -> {
-              m_robotArm.setGoal(Constants.ArmConstants.kArmOffsetRads);
-              m_robotArm.enable();
-            },
-            m_robotArm);
+        .onTrue(
+            new InstantCommand(
+                () -> {
+                  m_robotArm.setGoal(Constants.ArmConstants.kArmOffsetRads);
+                  m_robotArm.enable();
+                },
+                m_robotArm));
 
     // Disable the arm controller when Y is pressed.
-    new JoystickButton(m_driverController, Button.kY.value).whenPressed(m_robotArm::disable);
+    new JoystickButton(m_driverController, Button.kY.value)
+        .onTrue(new InstantCommand(m_robotArm::disable));
 
     // Drive at half speed when the bumper is held
     new JoystickButton(m_driverController, Button.kRightBumper.value)
-        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
-        .whenReleased(() -> m_robotDrive.setMaxOutput(1));
+        .onTrue(new InstantCommand(() -> m_robotDrive.setMaxOutput(0.5)))
+        .onFalse(new InstantCommand(() -> m_robotDrive.setMaxOutput(1)));
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbotoffboard/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armbotoffboard/RobotContainer.java
@@ -55,16 +55,18 @@ public class RobotContainer {
   private void configureButtonBindings() {
     // Move the arm to 2 radians above horizontal when the 'A' button is pressed.
     new JoystickButton(m_driverController, Button.kA.value)
-        .whenPressed(() -> m_robotArm.setGoal(2), m_robotArm);
+        .onTrue(new InstantCommand(() -> m_robotArm.setGoal(2), m_robotArm));
 
     // Move the arm to neutral position when the 'B' button is pressed.
     new JoystickButton(m_driverController, Button.kB.value)
-        .whenPressed(() -> m_robotArm.setGoal(Constants.ArmConstants.kArmOffsetRads), m_robotArm);
+        .onTrue(
+            new InstantCommand(
+                () -> m_robotArm.setGoal(Constants.ArmConstants.kArmOffsetRads), m_robotArm));
 
     // Drive at half speed when the bumper is held
     new JoystickButton(m_driverController, Button.kRightBumper.value)
-        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
-        .whenReleased(() -> m_robotDrive.setMaxOutput(1));
+        .onTrue(new InstantCommand(() -> m_robotDrive.setMaxOutput(0.5)))
+        .onFalse(new InstantCommand(() -> m_robotDrive.setMaxOutput(1)));
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/drivedistanceoffboard/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/drivedistanceoffboard/RobotContainer.java
@@ -57,11 +57,11 @@ public class RobotContainer {
   private void configureButtonBindings() {
     // Drive forward by 3 meters when the 'A' button is pressed, with a timeout of 10 seconds
     new JoystickButton(m_driverController, Button.kA.value)
-        .whenPressed(new DriveDistanceProfiled(3, m_robotDrive).withTimeout(10));
+        .onTrue(new DriveDistanceProfiled(3, m_robotDrive).withTimeout(10));
 
     // Do the same thing as above when the 'B' button is pressed, but defined inline
     new JoystickButton(m_driverController, Button.kB.value)
-        .whenPressed(
+        .onTrue(
             new TrapezoidProfileCommand(
                     new TrapezoidProfile(
                         // Limit the max acceleration and velocity
@@ -79,8 +79,8 @@ public class RobotContainer {
 
     // Drive at half speed when the bumper is held
     new JoystickButton(m_driverController, Button.kRightBumper.value)
-        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
-        .whenReleased(() -> m_robotDrive.setMaxOutput(1));
+        .onTrue(new InstantCommand(() -> m_robotDrive.setMaxOutput(0.5)))
+        .onFalse(new InstantCommand(() -> m_robotDrive.setMaxOutput(1)));
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/frisbeebot/RobotContainer.java
@@ -80,15 +80,15 @@ public class RobotContainer {
   private void configureButtonBindings() {
     // Spin up the shooter when the 'A' button is pressed
     new JoystickButton(m_driverController, Button.kA.value)
-        .whenPressed(new InstantCommand(m_shooter::enable, m_shooter));
+        .onTrue(new InstantCommand(m_shooter::enable, m_shooter));
 
     // Turn off the shooter when the 'B' button is pressed
     new JoystickButton(m_driverController, Button.kB.value)
-        .whenPressed(new InstantCommand(m_shooter::disable, m_shooter));
+        .onTrue(new InstantCommand(m_shooter::disable, m_shooter));
 
     // Run the feeder when the 'X' button is held, but only if the shooter is at speed
     new JoystickButton(m_driverController, Button.kX.value)
-        .whenPressed(
+        .onTrue(
             new ConditionalCommand(
                 // Run the feeder
                 new InstantCommand(m_shooter::runFeeder, m_shooter),
@@ -97,12 +97,12 @@ public class RobotContainer {
                 // Determine which of the above to do based on whether the shooter has reached the
                 // desired speed
                 m_shooter::atSetpoint))
-        .whenReleased(new InstantCommand(m_shooter::stopFeeder, m_shooter));
+        .onFalse(new InstantCommand(m_shooter::stopFeeder, m_shooter));
 
     // Drive at half speed when the bumper is held
     new JoystickButton(m_driverController, Button.kRightBumper.value)
-        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
-        .whenReleased(() -> m_robotDrive.setMaxOutput(1));
+        .onTrue(new InstantCommand(() -> m_robotDrive.setMaxOutput(0.5)))
+        .onFalse(new InstantCommand(() -> m_robotDrive.setMaxOutput(1)));
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/RobotContainer.java
@@ -88,15 +88,15 @@ public class RobotContainer {
     final JoystickButton r1 = new JoystickButton(m_joystick, 12);
 
     // Connect the buttons to commands
-    dpadUp.whenPressed(new SetElevatorSetpoint(0.25, m_elevator));
-    dpadDown.whenPressed(new SetElevatorSetpoint(0.0, m_elevator));
-    dpadRight.whenPressed(new CloseClaw(m_claw));
-    dpadLeft.whenPressed(new OpenClaw(m_claw));
+    dpadUp.onTrue(new SetElevatorSetpoint(0.25, m_elevator));
+    dpadDown.onTrue(new SetElevatorSetpoint(0.0, m_elevator));
+    dpadRight.onTrue(new CloseClaw(m_claw));
+    dpadLeft.onTrue(new OpenClaw(m_claw));
 
-    r1.whenPressed(new PrepareToPickup(m_claw, m_wrist, m_elevator));
-    r2.whenPressed(new Pickup(m_claw, m_wrist, m_elevator));
-    l1.whenPressed(new Place(m_claw, m_wrist, m_elevator));
-    l2.whenPressed(new Autonomous(m_drivetrain, m_claw, m_wrist, m_elevator));
+    r1.onTrue(new PrepareToPickup(m_claw, m_wrist, m_elevator));
+    r2.onTrue(new Pickup(m_claw, m_wrist, m_elevator));
+    l1.onTrue(new Place(m_claw, m_wrist, m_elevator));
+    l2.onTrue(new Autonomous(m_drivetrain, m_claw, m_wrist, m_elevator));
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gyrodrivecommands/RobotContainer.java
@@ -58,12 +58,12 @@ public class RobotContainer {
   private void configureButtonBindings() {
     // Drive at half speed when the right bumper is held
     new JoystickButton(m_driverController, Button.kR1.value)
-        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
-        .whenReleased(() -> m_robotDrive.setMaxOutput(1));
+        .onTrue(new InstantCommand(() -> m_robotDrive.setMaxOutput(0.5)))
+        .onFalse(new InstantCommand(() -> m_robotDrive.setMaxOutput(1)));
 
     // Stabilize robot to drive straight with gyro when left bumper is held
     new JoystickButton(m_driverController, Button.kL1.value)
-        .whenHeld(
+        .whileTrue(
             new PIDCommand(
                 new PIDController(
                     DriveConstants.kStabilizationP,
@@ -80,11 +80,11 @@ public class RobotContainer {
 
     // Turn to 90 degrees when the 'X' button is pressed, with a 5 second timeout
     new JoystickButton(m_driverController, Button.kCross.value)
-        .whenPressed(new TurnToAngle(90, m_robotDrive).withTimeout(5));
+        .onTrue(new TurnToAngle(90, m_robotDrive).withTimeout(5));
 
     // Turn to -90 degrees with a profile when the Circle button is pressed, with a 5 second timeout
     new JoystickButton(m_driverController, Button.kCircle.value)
-        .whenPressed(new TurnToAngleProfiled(-90, m_robotDrive).withTimeout(5));
+        .onTrue(new TurnToAngleProfiled(-90, m_robotDrive).withTimeout(5));
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
@@ -89,14 +89,14 @@ public class RobotContainer {
   private void configureButtonBindings() {
     // Grab the hatch when the Circle button is pressed.
     new JoystickButton(m_driverController, Button.kCircle.value)
-        .whenPressed(new InstantCommand(m_hatchSubsystem::grabHatch, m_hatchSubsystem));
+        .onTrue(new InstantCommand(m_hatchSubsystem::grabHatch, m_hatchSubsystem));
     // Release the hatch when the Square button is pressed.
     new JoystickButton(m_driverController, Button.kSquare.value)
-        .whenPressed(new InstantCommand(m_hatchSubsystem::releaseHatch, m_hatchSubsystem));
+        .onTrue(new InstantCommand(m_hatchSubsystem::releaseHatch, m_hatchSubsystem));
     // While holding R1, drive at half speed
     new JoystickButton(m_driverController, Button.kR1.value)
-        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
-        .whenReleased(() -> m_robotDrive.setMaxOutput(1));
+        .onTrue(new InstantCommand(() -> m_robotDrive.setMaxOutput(0.5)))
+        .onFalse(new InstantCommand(() -> m_robotDrive.setMaxOutput(1)));
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/RobotContainer.java
@@ -78,8 +78,7 @@ public class RobotContainer {
    */
   private void configureButtonBindings() {
     // Grab the hatch when the 'A' button is pressed.
-    new JoystickButton(m_driverController, Button.kA.value)
-        .onTrue(new GrabHatch(m_hatchSubsystem));
+    new JoystickButton(m_driverController, Button.kA.value).onTrue(new GrabHatch(m_hatchSubsystem));
     // Release the hatch when the 'B' button is pressed.
     new JoystickButton(m_driverController, Button.kB.value)
         .onTrue(new ReleaseHatch(m_hatchSubsystem));

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbottraditional/RobotContainer.java
@@ -79,13 +79,13 @@ public class RobotContainer {
   private void configureButtonBindings() {
     // Grab the hatch when the 'A' button is pressed.
     new JoystickButton(m_driverController, Button.kA.value)
-        .whenPressed(new GrabHatch(m_hatchSubsystem));
+        .onTrue(new GrabHatch(m_hatchSubsystem));
     // Release the hatch when the 'B' button is pressed.
     new JoystickButton(m_driverController, Button.kB.value)
-        .whenPressed(new ReleaseHatch(m_hatchSubsystem));
+        .onTrue(new ReleaseHatch(m_hatchSubsystem));
     // While holding the shoulder button, drive at half speed
     new JoystickButton(m_driverController, Button.kRightBumper.value)
-        .whenHeld(new HalveDriveSpeed(m_robotDrive));
+        .whileTrue(new HalveDriveSpeed(m_robotDrive));
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/RobotContainer.java
@@ -19,6 +19,7 @@ import edu.wpi.first.wpilibj.examples.mecanumcontrollercommand.Constants.DriveCo
 import edu.wpi.first.wpilibj.examples.mecanumcontrollercommand.Constants.OIConstants;
 import edu.wpi.first.wpilibj.examples.mecanumcontrollercommand.subsystems.DriveSubsystem;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.MecanumControllerCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
@@ -66,8 +67,8 @@ public class RobotContainer {
   private void configureButtonBindings() {
     // Drive at half speed when the right bumper is held
     new JoystickButton(m_driverController, Button.kRightBumper.value)
-        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
-        .whenReleased(() -> m_robotDrive.setMaxOutput(1));
+        .onTrue(new InstantCommand(() -> m_robotDrive.setMaxOutput(0.5)))
+        .onFalse(new InstantCommand(() -> m_robotDrive.setMaxOutput(1)));
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecommand/RobotContainer.java
@@ -22,6 +22,7 @@ import edu.wpi.first.wpilibj.examples.ramsetecommand.Constants.DriveConstants;
 import edu.wpi.first.wpilibj.examples.ramsetecommand.Constants.OIConstants;
 import edu.wpi.first.wpilibj.examples.ramsetecommand.subsystems.DriveSubsystem;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.RamseteCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
@@ -66,8 +67,8 @@ public class RobotContainer {
   private void configureButtonBindings() {
     // Drive at half speed when the right bumper is held
     new JoystickButton(m_driverController, Button.kRightBumper.value)
-        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
-        .whenReleased(() -> m_robotDrive.setMaxOutput(1));
+        .onTrue(new InstantCommand(() -> m_robotDrive.setMaxOutput(0.5)))
+        .onFalse(new InstantCommand(() -> m_robotDrive.setMaxOutput(1)));
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/romireference/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/romireference/RobotContainer.java
@@ -17,7 +17,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.PrintCommand;
-import edu.wpi.first.wpilibj2.command.button.Button;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -65,10 +65,10 @@ public class RobotContainer {
     m_drivetrain.setDefaultCommand(getArcadeDriveCommand());
 
     // Example of how to use the onboard IO
-    Button onboardButtonA = new Button(m_onboardIO::getButtonAPressed);
+    Trigger onboardButtonA = new Trigger(m_onboardIO::getButtonAPressed);
     onboardButtonA
-        .whenActive(new PrintCommand("Button A Pressed"))
-        .whenInactive(new PrintCommand("Button A Released"));
+        .onTrue(new PrintCommand("Button A Pressed"))
+        .onFalse(new PrintCommand("Button A Released"));
 
     // Setup SmartDashboard options
     m_chooser.setDefaultOption("Auto Routine Distance", new AutonomousDistance(m_drivetrain));

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/schedulereventlogging/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/schedulereventlogging/RobotContainer.java
@@ -70,11 +70,11 @@ public class RobotContainer {
    */
   private void configureButtonBindings() {
     // Run instant command 1 when the 'A' button is pressed
-    new JoystickButton(m_driverController, Button.kA.value).whenPressed(m_instantCommand1);
+    new JoystickButton(m_driverController, Button.kA.value).onTrue(m_instantCommand1);
     // Run instant command 2 when the 'X' button is pressed
-    new JoystickButton(m_driverController, Button.kX.value).whenPressed(m_instantCommand2);
+    new JoystickButton(m_driverController, Button.kX.value).onTrue(m_instantCommand2);
     // Run instant command 3 when the 'Y' button is held; release early to interrupt
-    new JoystickButton(m_driverController, Button.kY.value).whenHeld(m_waitCommand);
+    new JoystickButton(m_driverController, Button.kY.value).whileTrue(m_waitCommand);
   }
 
   /**

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
@@ -18,6 +18,7 @@ import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.XboxController.Button;
 import edu.wpi.first.wpilibj.examples.statespacedifferentialdrivesimulation.subsystems.DriveSubsystem;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.RamseteCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
@@ -66,8 +67,8 @@ public class RobotContainer {
   private void configureButtonBindings() {
     // Drive at half speed when the right bumper is held
     new JoystickButton(m_driverController, Button.kRightBumper.value)
-        .whenPressed(() -> m_robotDrive.setMaxOutput(0.5))
-        .whenReleased(() -> m_robotDrive.setMaxOutput(1));
+        .onTrue(new InstantCommand(() -> m_robotDrive.setMaxOutput(0.5)))
+        .onFalse(new InstantCommand(() -> m_robotDrive.setMaxOutput(1)));
   }
 
   public DriveSubsystem getRobotDrive() {


### PR DESCRIPTION
### Motivation
Feedback from 2022 showed that the Trigger API is rather confusing, mostly due to the following:
- duplicate Trigger and Button APIs were available; users were confused searching for a nonexistent difference between them.
- the `when` terminology was ambiguous and unclear whether it refers to the high state or specifically the rising edge.
- the `Active` terminology didn't unambiguously refer to the high state; it wasn't unintuitive to understand it as "when the binding is active/polled".
- `whileHeld` vs `whenHeld` was _very_ confusing, and the difference between them wasn't obvious. The parallel `Trigger` verbs, `whileActiveContinuously` and `whileActiveOnce` are much less confusing.

### Solution
Deprecating `Button` and its binding methods. The rationale for deprecating `Button` (and not `Trigger`) is because `Button` uses terminology that is needlessly more specific and restricting to the button use case, making the use case of arbitrary trigger conditions unintuitive.

> After consideration, deprecation of `Button`'s subclasses was decided against:
> - `NetworkButton` (a trigger condition based on a boolean NT entry/topic) is a use case that is not necessarily intuitive for teams to implement themselves, so it is an abstraction that should be provided in the library. A parallel class for the `BooleanEvent` level, `NetworkBooleanEvent`, was also added as part of NT4. NT listeners were considered as a alternative solution, but they require attention to thread safety, and aren't interoperable with the `EventLoop` API.
> - `JoystickButton`/`POVButton` provide abstractions around HID buttons. The new `Trigger`-returning factories on the HID classes are an equal (if not more concise) alternative, but there is no reason not to keep them for those who find their use preferable.
>
> At a later date in the deprecation cycle (perhaps for 2024), when `Button` is removed, these subclasses should be changed to inherit directly from `Trigger`.

`Trigger`'s bindings are changed to use `True`/`False` terminology, as it should be unambiguous. Each binding type has both `True` and `False` variants; for brevity, only the `True` variants are listed here:
- `onTrue` (replaces `whenActive`): schedule on rising edge.
- `whileTrue` (replaces `whileActiveOnce`): schedule on rising edge, cancel on falling edge.
- `toggleOnTrue` (replaces `toggleWhenActive`): on rising edge, schedule if unscheduled and cancel if scheduled.

> Two binding types are completely deprecated:
> - `cancelWhenActive`: this is a fairly niche use case which is better described as having the trigger's rising edge (`Trigger.rising()`) as an end condition for the command (using `Command.until()`).
> - `whileActiveContinuously`: however common, this relied on the no-op behavior of scheduling an already-scheduled command. The more correct way to repeat the command if it ends before the falling edge is using `Command.repeatedly`/`RepeatCommand` or a `RunCommand` -- the only difference is if the command is interrupted, but that is more likely to result in two commands perpetually canceling each other than achieve the desired behavior. Manually implementing a blindly-scheduling binding like `whileActiveContinuously` is still possible, though might not be intuitive.

---

### Notes
It was considered to share `BooleanEvent`'s digital signal terminology; however, once it was decided that `Trigger` should not inherit from `BooleanEvent` (due to overload incompatibility) the common terminology was not worth the unintuitiveness stemming from users' unfamiliarity with the signal processing terms.