### PR TITLE
[wpilibc] Fix return value of DriverStation::GetJoystickAxisType()

### DIFF
--- a/wpilibc/src/main/native/cpp/DriverStation.cpp
+++ b/wpilibc/src/main/native/cpp/DriverStation.cpp
@@ -456,6 +456,10 @@ int DriverStation::GetJoystickAxisType(int stick, int axis) {
     FRC_ReportError(warn::BadJoystickIndex, "stick {} out of range", stick);
     return -1;
   }
+  if (axis < 0 || axis >= HAL_kMaxJoystickAxes) {
+    FRC_ReportError(warn::BadJoystickAxis, "axis {} out of range", axis);
+    return -1;
+  }
 
   HAL_JoystickDescriptor descriptor;
   HAL_GetJoystickDescriptor(stick, &descriptor);

--- a/wpilibc/src/main/native/cpp/DriverStation.cpp
+++ b/wpilibc/src/main/native/cpp/DriverStation.cpp
@@ -460,7 +460,7 @@ int DriverStation::GetJoystickAxisType(int stick, int axis) {
   HAL_JoystickDescriptor descriptor;
   HAL_GetJoystickDescriptor(stick, &descriptor);
 
-  return static_cast<bool>(descriptor.axisTypes);
+  return descriptor.axisTypes[axis];
 }
 
 bool DriverStation::IsJoystickConnected(int stick) {


### PR DESCRIPTION
It was returning a pointer to the axis type array cast to a bool (always
1\) instead of returning the desired axis type.

This was caught by the following warning from GCC 12.1.
```
/home/tav/frc/wpilib/allwpilib/wpilibc/src/main/native/cpp/DriverStation.cpp: In static member function ‘static int frc::DriverStation::GetJoystickAxisType(int, int)’:
/home/tav/frc/wpilib/allwpilib/wpilibc/src/main/native/cpp/DriverStation.cpp:463:39: error: the address of ‘HAL_JoystickDescriptor::axisTypes’ will never be NULL [-Werror=address]
  463 |   return static_cast<bool>(descriptor.axisTypes);
      |                            ~~~~~~~~~~~^~~~~~~~~
In file included from /home/tav/frc/wpilib/allwpilib/hal/src/main/native/include/hal/DriverStation.h:9,
                 from /home/tav/frc/wpilib/allwpilib/wpilibc/src/main/native/cpp/DriverStation.cpp:18:
/home/tav/frc/wpilib/allwpilib/hal/src/main/native/include/hal/DriverStationTypes.h:92:11: note: ‘HAL_JoystickDescriptor::axisTypes’ declared here
   92 |   uint8_t axisTypes[HAL_kMaxJoystickAxes];
      |           ^~~~~~~~~
```