### PR TITLE
Unless decorator for commands

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
@@ -303,6 +303,17 @@ public interface Command {
   }
 
   /**
+   * Decorates this command to only run if this condition is not met. If the command is already
+   * running and the condition changes to true, the command will not stop running
+   *
+   * @param condition the condition that will prevent the command from running
+   * @return the decorated command
+   */
+  default ConditionalCommand unless(BooleanSupplier condition) {
+    return new ConditionalCommand(new InstantCommand(), this, condition);
+  }
+
+  /**
    * Schedules this command.
    *
    * @param interruptible whether this command can be interrupted by another command that shares one

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
@@ -305,8 +305,7 @@ public interface Command {
   /**
    * Decorates this command to only run if this condition is not met. If the command is already
    * running and the condition changes to true, the command will not stop running. The requirements
-   * of this command will be kept for the new conditonal command. If this is undesirable consider
-   * using the asProxy decorator before this.
+   * of this command will be kept for the new conditonal command.
    *
    * @param condition the condition that will prevent the command from running
    * @return the decorated command

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
@@ -304,7 +304,9 @@ public interface Command {
 
   /**
    * Decorates this command to only run if this condition is not met. If the command is already
-   * running and the condition changes to true, the command will not stop running
+   * running and the condition changes to true, the command will not stop running. The requirements
+   * of this command will be kept for the new conditonal command. If this is undesirable consider
+   * using the asProxy decorator before this.
    *
    * @param condition the condition that will prevent the command from running
    * @return the decorated command

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -5,6 +5,7 @@
 #include "frc2/command/Command.h"
 
 #include "frc2/command/CommandScheduler.h"
+#include "frc2/command/ConditionalCommand.h"
 #include "frc2/command/EndlessCommand.h"
 #include "frc2/command/InstantCommand.h"
 #include "frc2/command/ParallelCommandGroup.h"
@@ -99,6 +100,12 @@ RepeatCommand Command::Repeat() && {
 
 ProxyScheduleCommand Command::AsProxy() {
   return ProxyScheduleCommand(this);
+}
+
+ConditionalCommand Command::Unless(std::function<bool()> condition) {
+  return ConditionalCommand(std::make_unique<InstantCommand>(),
+                            std::move(*this).TransferOwnership(),
+                            std::move(condition));
 }
 
 void Command::Schedule(bool interruptible) {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -102,7 +102,7 @@ ProxyScheduleCommand Command::AsProxy() {
   return ProxyScheduleCommand(this);
 }
 
-ConditionalCommand Command::Unless(std::function<bool()> condition) {
+ConditionalCommand Command::Unless(std::function<bool()> condition) && {
   return ConditionalCommand(std::make_unique<InstantCommand>(),
                             std::move(*this).TransferOwnership(),
                             std::move(condition));

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -32,27 +32,27 @@ class SequentialCommandGroup;
 class PerpetualCommand;
 class ProxyScheduleCommand;
 class RepeatCommand;
-class ConditionalCommand
+class ConditionalCommand;
 
-    /**
-     * A state machine representing a complete action to be performed by the
-     * robot. Commands are run by the CommandScheduler, and can be composed into
-     * CommandGroups to allow users to build complicated multi-step actions
-     * without the need to roll the state machine logic themselves.
-     *
-     * <p>Commands are run synchronously from the main robot loop; no
-     * multithreading is used, unless specified explicitly from the command
-     * implementation.
-     *
-     * <p>Note: ALWAYS create a subclass by extending CommandHelper<Base,
-     * Subclass>, or decorators will not function!
-     *
-     * This class is provided by the NewCommands VendorDep
-     *
-     * @see CommandScheduler
-     * @see CommandHelper
-     */
-    class Command {
+/**
+ * A state machine representing a complete action to be performed by the
+ * robot. Commands are run by the CommandScheduler, and can be composed into
+ * CommandGroups to allow users to build complicated multi-step actions
+ * without the need to roll the state machine logic themselves.
+ *
+ * <p>Commands are run synchronously from the main robot loop; no
+ * multithreading is used, unless specified explicitly from the command
+ * implementation.
+ *
+ * <p>Note: ALWAYS create a subclass by extending CommandHelper<Base,
+ * Subclass>, or decorators will not function!
+ *
+ * This class is provided by the NewCommands VendorDep
+ *
+ * @see CommandScheduler
+ * @see CommandHelper
+ */
+class Command {
  public:
   Command() = default;
   virtual ~Command();

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -221,7 +221,9 @@ class Command {
   /**
    * Decorates this command to only run if this condition is not met. If the
    * command is already running and the condition changes to true, the command
-   * will not stop running
+   * will not stop running. The requirements of this command will be kept for
+   * the new conditonal command. If this is undesirable consider using the
+   * AsProxy decorator before this.
    *
    * @param condition the condition that will prevent the command from running
    * @return the decorated command

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -35,17 +35,17 @@ class RepeatCommand;
 class ConditionalCommand;
 
 /**
- * A state machine representing a complete action to be performed by the
- * robot. Commands are run by the CommandScheduler, and can be composed into
- * CommandGroups to allow users to build complicated multi-step actions
- * without the need to roll the state machine logic themselves.
+ * A state machine representing a complete action to be performed by the robot.
+ * Commands are run by the CommandScheduler, and can be composed into
+ * CommandGroups to allow users to build complicated multi-step actions without
+ * the need to roll the state machine logic themselves.
  *
  * <p>Commands are run synchronously from the main robot loop; no
  * multithreading is used, unless specified explicitly from the command
  * implementation.
  *
- * <p>Note: ALWAYS create a subclass by extending CommandHelper<Base,
- * Subclass>, or decorators will not function!
+ * <p>Note: ALWAYS create a subclass by extending CommandHelper<Base, Subclass>,
+ * or decorators will not function!
  *
  * This class is provided by the NewCommands VendorDep
  *

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -222,8 +222,7 @@ class Command {
    * Decorates this command to only run if this condition is not met. If the
    * command is already running and the condition changes to true, the command
    * will not stop running. The requirements of this command will be kept for
-   * the new conditonal command. If this is undesirable consider using the
-   * AsProxy decorator before this.
+   * the new conditonal command.
    *
    * @param condition the condition that will prevent the command from running
    * @return the decorated command

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -32,25 +32,27 @@ class SequentialCommandGroup;
 class PerpetualCommand;
 class ProxyScheduleCommand;
 class RepeatCommand;
+class ConditionalCommand
 
-/**
- * A state machine representing a complete action to be performed by the robot.
- * Commands are run by the CommandScheduler, and can be composed into
- * CommandGroups to allow users to build complicated multi-step actions without
- * the need to roll the state machine logic themselves.
- *
- * <p>Commands are run synchronously from the main robot loop; no multithreading
- * is used, unless specified explicitly from the command implementation.
- *
- * <p>Note: ALWAYS create a subclass by extending CommandHelper<Base, Subclass>,
- * or decorators will not function!
- *
- * This class is provided by the NewCommands VendorDep
- *
- * @see CommandScheduler
- * @see CommandHelper
- */
-class Command {
+    /**
+     * A state machine representing a complete action to be performed by the
+     * robot. Commands are run by the CommandScheduler, and can be composed into
+     * CommandGroups to allow users to build complicated multi-step actions
+     * without the need to roll the state machine logic themselves.
+     *
+     * <p>Commands are run synchronously from the main robot loop; no
+     * multithreading is used, unless specified explicitly from the command
+     * implementation.
+     *
+     * <p>Note: ALWAYS create a subclass by extending CommandHelper<Base,
+     * Subclass>, or decorators will not function!
+     *
+     * This class is provided by the NewCommands VendorDep
+     *
+     * @see CommandScheduler
+     * @see CommandHelper
+     */
+    class Command {
  public:
   Command() = default;
   virtual ~Command();
@@ -215,6 +217,16 @@ class Command {
    * @return the decorated command
    */
   virtual ProxyScheduleCommand AsProxy();
+
+  /**
+   * Decorates this command to only run if this condition is not met. If the
+   * command is already running and the condition changes to true, the command
+   * will not stop running
+   *
+   * @param condition the condition that will prevent the command from running
+   * @return the decorated command
+   */
+  virtual ConditionalCommand Unless(std::function<bool()> condition) &&;
 
   /**
    * Schedules this command.

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
@@ -168,11 +168,11 @@ class CommandDecoratorTest extends CommandTestBase {
   }
 
   @Test
-  void perpetuallyTest() {
+  void endlesslyTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       Command command = new InstantCommand();
 
-      Command perpetual = command.perpetually();
+      Command perpetual = command.endlessly();
 
       scheduler.schedule(perpetual);
       scheduler.run();
@@ -180,6 +180,27 @@ class CommandDecoratorTest extends CommandTestBase {
       scheduler.run();
 
       assertTrue(scheduler.isScheduled(perpetual));
+    }
+  }
+
+  @Test
+  void unlessTest() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      ConditionHolder unlessCondition = new ConditionHolder();
+      ConditionHolder hasRunCondition = new ConditionHolder();
+      hasRunCondition.setCondition(false);
+
+      Command command = new InstantCommand(() -> hasRunCondition.setCondition(true)).unless(unlessCondition::getCondition);
+
+      unlessCondition.setCondition(true);
+      scheduler.schedule(command);
+      scheduler.run();
+      assertFalse(hasRunCondition.getCondition());
+
+      unlessCondition.setCondition(false);
+      scheduler.schedule(command);
+      scheduler.run();
+      assertTrue(hasRunCondition.getCondition());
     }
   }
 }

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
@@ -7,6 +7,8 @@ package edu.wpi.first.wpilibj2.command;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.wpilibj.simulation.SimHooks;
 import org.junit.jupiter.api.Test;
@@ -168,11 +170,11 @@ class CommandDecoratorTest extends CommandTestBase {
   }
 
   @Test
-  void endlesslyTest() {
+  void perpetuallyTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
       Command command = new InstantCommand();
 
-      Command perpetual = command.endlessly();
+      Command perpetual = command.perpetually();
 
       scheduler.schedule(perpetual);
       scheduler.run();
@@ -186,23 +188,23 @@ class CommandDecoratorTest extends CommandTestBase {
   @Test
   void unlessTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      ConditionHolder unlessCondition = new ConditionHolder();
-      ConditionHolder hasRunCondition = new ConditionHolder();
-      hasRunCondition.setCondition(false);
+      AtomicBoolean unlessCondition = new AtomicBoolean();
+      AtomicBoolean hasRunCondition = new AtomicBoolean();
+      hasRunCondition.set(false);
 
       Command command =
-          new InstantCommand(() -> hasRunCondition.setCondition(true))
-              .unless(unlessCondition::getCondition);
+          new InstantCommand(() -> hasRunCondition.set(true))
+              .unless(unlessCondition::get);
 
-      unlessCondition.setCondition(true);
+      unlessCondition.set(true);
       scheduler.schedule(command);
       scheduler.run();
-      assertFalse(hasRunCondition.getCondition());
+      assertFalse(hasRunCondition.get());
 
-      unlessCondition.setCondition(false);
+      unlessCondition.set(false);
       scheduler.schedule(command);
       scheduler.run();
-      assertTrue(hasRunCondition.getCondition());
+      assertTrue(hasRunCondition.get());
     }
   }
 }

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
@@ -187,14 +187,12 @@ class CommandDecoratorTest extends CommandTestBase {
   @Test
   void unlessTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
-      AtomicBoolean unlessCondition = new AtomicBoolean();
-      AtomicBoolean hasRunCondition = new AtomicBoolean();
-      hasRunCondition.set(false);
+      AtomicBoolean unlessCondition = new AtomicBoolean(true);
+      AtomicBoolean hasRunCondition = new AtomicBoolean(false);
 
       Command command =
           new InstantCommand(() -> hasRunCondition.set(true)).unless(unlessCondition::get);
 
-      unlessCondition.set(true);
       scheduler.schedule(command);
       scheduler.run();
       assertFalse(hasRunCondition.get());

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
@@ -192,8 +192,7 @@ class CommandDecoratorTest extends CommandTestBase {
       hasRunCondition.set(false);
 
       Command command =
-          new InstantCommand(() -> hasRunCondition.set(true))
-              .unless(unlessCondition::get);
+          new InstantCommand(() -> hasRunCondition.set(true)).unless(unlessCondition::get);
 
       unlessCondition.set(true);
       scheduler.schedule(command);

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
@@ -7,10 +7,9 @@ package edu.wpi.first.wpilibj2.command;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.wpilibj.simulation.SimHooks;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandDecoratorTest.java
@@ -190,7 +190,9 @@ class CommandDecoratorTest extends CommandTestBase {
       ConditionHolder hasRunCondition = new ConditionHolder();
       hasRunCondition.setCondition(false);
 
-      Command command = new InstantCommand(() -> hasRunCondition.setCondition(true)).unless(unlessCondition::getCondition);
+      Command command =
+          new InstantCommand(() -> hasRunCondition.setCondition(true))
+              .unless(unlessCondition::getCondition);
 
       unlessCondition.setCondition(true);
       scheduler.schedule(command);

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
@@ -89,10 +89,10 @@ TEST_F(CommandDecoratorTest, AndThen) {
   EXPECT_TRUE(finished);
 }
 
-TEST_F(CommandDecoratorTest, Perpetually) {
+TEST_F(CommandDecoratorTest, Endlessly) {
   CommandScheduler scheduler = GetScheduler();
 
-  auto command = InstantCommand([] {}, {}).Perpetually();
+  auto command = InstantCommand([] {}, {}).Endlessly();
 
   scheduler.Schedule(&command);
 
@@ -100,4 +100,18 @@ TEST_F(CommandDecoratorTest, Perpetually) {
   scheduler.Run();
 
   EXPECT_TRUE(scheduler.IsScheduled(&command));
+}
+
+TEST_F(CommandDecoratorTest, Unless) {
+  CommandScheduler scheduler = GetScheduler();
+
+  bool hasRun = false;
+  bool unlessBool = true;
+
+  auto command = InstantCommand([] { hasRun = true; }, {}).unless([&unlessBool] { return unlessBool; });
+
+  scheduler.Schedule(&command) EXPECT_FALSE(hasRun);
+
+  unlessBool = false;
+  scheduler.Schedule(&command) EXPECT_TRUE(hasRun);
 }

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
@@ -5,6 +5,7 @@
 #include <frc/simulation/SimHooks.h>
 
 #include "CommandTestBase.h"
+#include "frc2/command/ConditionalCommand.h"
 #include "frc2/command/InstantCommand.h"
 #include "frc2/command/ParallelRaceGroup.h"
 #include "frc2/command/PerpetualCommand.h"
@@ -109,14 +110,16 @@ TEST_F(CommandDecoratorTest, Unless) {
   bool unlessBool = true;
 
   auto command =
-      InstantCommand([] { hasRun = true; }, {}).unless([&unlessBool] {
+      InstantCommand([&hasRun] { hasRun = true; }, {}).Unless([&unlessBool] {
         return unlessBool;
       });
 
   scheduler.Schedule(&command);
+  scheduler.Run();
   EXPECT_FALSE(hasRun);
 
   unlessBool = false;
   scheduler.Schedule(&command);
+  scheduler.Run();
   EXPECT_TRUE(hasRun);
 }

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
@@ -108,7 +108,10 @@ TEST_F(CommandDecoratorTest, Unless) {
   bool hasRun = false;
   bool unlessBool = true;
 
-  auto command = InstantCommand([] { hasRun = true; }, {}).unless([&unlessBool] { return unlessBool; });
+  auto command =
+      InstantCommand([] { hasRun = true; }, {}).unless([&unlessBool] {
+        return unlessBool;
+      });
 
   scheduler.Schedule(&command) EXPECT_FALSE(hasRun);
 

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
@@ -89,10 +89,10 @@ TEST_F(CommandDecoratorTest, AndThen) {
   EXPECT_TRUE(finished);
 }
 
-TEST_F(CommandDecoratorTest, Endlessly) {
+TEST_F(CommandDecoratorTest, Perpetually) {
   CommandScheduler scheduler = GetScheduler();
 
-  auto command = InstantCommand([] {}, {}).Endlessly();
+  auto command = InstantCommand([] {}, {}).Perpetually();
 
   scheduler.Schedule(&command);
 
@@ -113,8 +113,10 @@ TEST_F(CommandDecoratorTest, Unless) {
         return unlessBool;
       });
 
-  scheduler.Schedule(&command) EXPECT_FALSE(hasRun);
+  scheduler.Schedule(&command);
+  EXPECT_FALSE(hasRun);
 
   unlessBool = false;
-  scheduler.Schedule(&command) EXPECT_TRUE(hasRun);
+  scheduler.Schedule(&command);
+  EXPECT_TRUE(hasRun);
 }


### PR DESCRIPTION
Part of #4234. Instead of a null passed to conditional command I opted to use an `InstantCommand` to avoid NPEs. C++ was patched together so feedback on that would be appreciated. Docs PR to come. Also changed perpetually to endless in the tests.