### PR TITLE
[command] Reorder Scheduler operations

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandBase.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandBase.java
@@ -4,6 +4,8 @@
 
 package edu.wpi.first.wpilibj2.command;
 
+import static edu.wpi.first.util.ErrorMessages.requireNonNullParam;
+
 import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.util.sendable.SendableRegistry;
@@ -29,7 +31,9 @@ public abstract class CommandBase implements Sendable, Command {
    * @param requirements the requirements to add
    */
   public final void addRequirements(Subsystem... requirements) {
-    m_requirements.addAll(Set.of(requirements));
+    for (Subsystem requirement : requirements) {
+      m_requirements.add(requireNonNullParam(requirement, "requirement", "addRequirements"));
+    }
   }
 
   @Override

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -151,11 +151,11 @@ void CommandScheduler::Schedule(bool interruptible, Command* command) {
         Cancel(cmdToCancel);
       }
     }
-    command->Initialize();
     m_impl->scheduledCommands[command] = CommandState{interruptible};
     for (auto&& requirement : requirements) {
       m_impl->requirements[requirement] = command;
     }
+    command->Initialize();
     for (auto&& action : m_impl->initActions) {
       action(*command);
     }
@@ -336,17 +336,17 @@ void CommandScheduler::Cancel(Command* command) {
   if (find == m_impl->scheduledCommands.end()) {
     return;
   }
-  command->End(true);
-  for (auto&& action : m_impl->interruptActions) {
-    action(*command);
-  }
-  m_watchdog.AddEpoch(command->GetName() + ".End(true)");
   m_impl->scheduledCommands.erase(find);
   for (auto&& requirement : m_impl->requirements) {
     if (requirement.second == command) {
       m_impl->requirements.erase(requirement.first);
     }
   }
+  command->End(true);
+  for (auto&& action : m_impl->interruptActions) {
+    action(*command);
+  }
+  m_watchdog.AddEpoch(command->GetName() + ".End(true)");
 }
 
 void CommandScheduler::Cancel(wpi::span<Command* const> commands) {

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -367,5 +367,8 @@ class CommandScheduler final : public nt::NTSendable,
   frc::Watchdog m_watchdog;
 
   friend class CommandTestBase;
+
+  template <typename T>
+  friend class CommandTestBaseWithParam;
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SchedulingRecursionTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SchedulingRecursionTest.java
@@ -1,0 +1,193 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj2.command;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class SchedulingRecursionTest extends CommandTestBase {
+  /**
+   * <a href="https://github.com/wpilibsuite/allwpilib/issues/4259">wpilibsuite/allwpilib#4259</a>.
+   */
+  @ValueSource(booleans = {true, false})
+  @ParameterizedTest
+  void cancelFromInitialize(boolean interruptible) {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicBoolean hasOtherRun = new AtomicBoolean();
+      Subsystem requirement = new SubsystemBase() {};
+      Command selfCancels =
+          new CommandBase() {
+            {
+              addRequirements(requirement);
+            }
+
+            @Override
+            public void initialize() {
+              scheduler.cancel(this);
+            }
+          };
+      Command other = new RunCommand(() -> hasOtherRun.set(true), requirement);
+
+      assertDoesNotThrow(
+          () -> {
+            scheduler.schedule(interruptible, selfCancels);
+            scheduler.run();
+            // interruptibility of new arrival isn't checked
+            scheduler.schedule(other);
+          });
+      assertFalse(scheduler.isScheduled(selfCancels));
+      assertTrue(scheduler.isScheduled(other));
+      scheduler.run();
+      assertTrue(hasOtherRun.get());
+    }
+  }
+
+  @ValueSource(booleans = {true, false})
+  @ParameterizedTest
+  void defaultCommand(boolean interruptible) {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicBoolean hasOtherRun = new AtomicBoolean();
+      Subsystem requirement = new SubsystemBase() {};
+      Command selfCancels =
+          new CommandBase() {
+            {
+              addRequirements(requirement);
+            }
+
+            @Override
+            public void initialize() {
+              scheduler.cancel(this);
+            }
+          };
+      Command other = new RunCommand(() -> hasOtherRun.set(true), requirement);
+      scheduler.setDefaultCommand(requirement, other);
+
+      assertDoesNotThrow(
+          () -> {
+            scheduler.schedule(interruptible, selfCancels);
+            scheduler.run();
+          });
+      scheduler.run();
+      assertFalse(scheduler.isScheduled(selfCancels));
+      assertTrue(scheduler.isScheduled(other));
+      scheduler.run();
+      assertTrue(hasOtherRun.get());
+    }
+  }
+
+  @Test
+  void cancelFromEnd() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicInteger counter = new AtomicInteger();
+      Command selfCancels =
+          new CommandBase() {
+            @Override
+            public void end(boolean interrupted) {
+              counter.incrementAndGet();
+              scheduler.cancel(this);
+            }
+          };
+      scheduler.schedule(selfCancels);
+
+      assertDoesNotThrow(() -> scheduler.cancel(selfCancels));
+      assertEquals(1, counter.get());
+      assertFalse(scheduler.isScheduled(selfCancels));
+    }
+  }
+
+  @Test
+  void scheduleFromEndCancel() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicInteger counter = new AtomicInteger();
+      Subsystem requirement = new SubsystemBase() {};
+      InstantCommand other = new InstantCommand(() -> {}, requirement);
+      Command selfCancels =
+          new CommandBase() {
+            {
+              addRequirements(requirement);
+            }
+
+            @Override
+            public void end(boolean interrupted) {
+              counter.incrementAndGet();
+              scheduler.schedule(other);
+            }
+          };
+
+      scheduler.schedule(selfCancels);
+
+      assertDoesNotThrow(() -> scheduler.cancel(selfCancels));
+      assertEquals(1, counter.get());
+      assertFalse(scheduler.isScheduled(selfCancels));
+    }
+  }
+
+  @Test
+  void scheduleFromEndInterrupt() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicInteger counter = new AtomicInteger();
+      Subsystem requirement = new SubsystemBase() {};
+      InstantCommand other = new InstantCommand(() -> {}, requirement);
+      Command selfCancels =
+          new CommandBase() {
+            {
+              addRequirements(requirement);
+            }
+
+            @Override
+            public void end(boolean interrupted) {
+              counter.incrementAndGet();
+              scheduler.schedule(other);
+            }
+          };
+
+      scheduler.schedule(selfCancels);
+
+      assertDoesNotThrow(() -> scheduler.schedule(other));
+      assertEquals(1, counter.get());
+      assertFalse(scheduler.isScheduled(selfCancels));
+      assertTrue(scheduler.isScheduled(other));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void scheduleInitializeFromDefaultCommand(boolean interruptible) {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      AtomicInteger counter = new AtomicInteger();
+      Subsystem requirement = new SubsystemBase() {};
+      Command other = new InstantCommand(() -> {}, requirement);
+      Command defaultCommand =
+          new CommandBase() {
+            {
+              addRequirements(requirement);
+            }
+
+            @Override
+            public void initialize() {
+              counter.incrementAndGet();
+              scheduler.schedule(interruptible, other);
+            }
+          };
+
+      scheduler.setDefaultCommand(requirement, defaultCommand);
+
+      scheduler.run();
+      scheduler.run();
+      scheduler.run();
+      assertEquals(3, counter.get());
+      assertFalse(scheduler.isScheduled(defaultCommand));
+      assertTrue(scheduler.isScheduled(other));
+    }
+  }
+}

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.h
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.h
@@ -18,6 +18,7 @@
 #include "make_vector.h"
 
 namespace frc2 {
+
 class CommandTestBase : public ::testing::Test {
  public:
   CommandTestBase();
@@ -93,4 +94,91 @@ class CommandTestBase : public ::testing::Test {
 
   void SetDSEnabled(bool enabled);
 };
+
+template <typename T>
+class CommandTestBaseWithParam : public ::testing::TestWithParam<T> {
+ public:
+  CommandTestBaseWithParam() {
+    auto& scheduler = CommandScheduler::GetInstance();
+    scheduler.CancelAll();
+    scheduler.Enable();
+    scheduler.GetActiveButtonLoop()->Clear();
+  }
+
+  class TestSubsystem : public SubsystemBase {};
+
+ protected:
+  class MockCommand : public Command {
+   public:
+    MOCK_CONST_METHOD0(GetRequirements, wpi::SmallSet<Subsystem*, 4>());
+    MOCK_METHOD0(IsFinished, bool());
+    MOCK_CONST_METHOD0(RunsWhenDisabled, bool());
+    MOCK_METHOD0(Initialize, void());
+    MOCK_METHOD0(Execute, void());
+    MOCK_METHOD1(End, void(bool interrupted));
+
+    MockCommand() {
+      m_requirements = {};
+      EXPECT_CALL(*this, GetRequirements())
+          .WillRepeatedly(::testing::Return(m_requirements));
+      EXPECT_CALL(*this, IsFinished()).WillRepeatedly(::testing::Return(false));
+      EXPECT_CALL(*this, RunsWhenDisabled())
+          .WillRepeatedly(::testing::Return(true));
+    }
+
+    MockCommand(std::initializer_list<Subsystem*> requirements,
+                bool finished = false, bool runWhenDisabled = true) {
+      m_requirements.insert(requirements.begin(), requirements.end());
+      EXPECT_CALL(*this, GetRequirements())
+          .WillRepeatedly(::testing::Return(m_requirements));
+      EXPECT_CALL(*this, IsFinished())
+          .WillRepeatedly(::testing::Return(finished));
+      EXPECT_CALL(*this, RunsWhenDisabled())
+          .WillRepeatedly(::testing::Return(runWhenDisabled));
+    }
+
+    MockCommand(MockCommand&& other) {
+      EXPECT_CALL(*this, IsFinished())
+          .WillRepeatedly(::testing::Return(other.IsFinished()));
+      EXPECT_CALL(*this, RunsWhenDisabled())
+          .WillRepeatedly(::testing::Return(other.RunsWhenDisabled()));
+      std::swap(m_requirements, other.m_requirements);
+      EXPECT_CALL(*this, GetRequirements())
+          .WillRepeatedly(::testing::Return(m_requirements));
+    }
+
+    MockCommand(const MockCommand& other) : Command{other} {}
+
+    void SetFinished(bool finished) {
+      EXPECT_CALL(*this, IsFinished())
+          .WillRepeatedly(::testing::Return(finished));
+    }
+
+    ~MockCommand() {  // NOLINT
+      auto& scheduler = CommandScheduler::GetInstance();
+      scheduler.Cancel(this);
+    }
+
+   protected:
+    std::unique_ptr<Command> TransferOwnership() && {  // NOLINT
+      return std::make_unique<MockCommand>(std::move(*this));
+    }
+
+   private:
+    wpi::SmallSet<Subsystem*, 4> m_requirements;
+  };
+
+  CommandScheduler GetScheduler() { return CommandScheduler(); }
+
+  void SetUp() override { frc::sim::DriverStationSim::SetEnabled(true); }
+
+  void TearDown() override {
+    CommandScheduler::GetInstance().GetActiveButtonLoop()->Clear();
+  }
+
+  void SetDSEnabled(bool enabled) {
+    frc::sim::DriverStationSim::SetEnabled(enabled);
+  }
+};
+
 }  // namespace frc2

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulingRecursionTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulingRecursionTest.cpp
@@ -5,10 +5,11 @@
 #include "CommandTestBase.h"
 #include "frc2/command/CommandHelper.h"
 #include "frc2/command/RunCommand.h"
+#include "gtest/gtest.h"
 
 using namespace frc2;
-class SchedulingRecursionTest : public CommandTestBase,
-                                public testing::WithParamInterface<bool> {};
+
+class SchedulingRecursionTest : public CommandTestBaseWithParam<bool> {};
 
 class SelfCancellingCommand
     : public CommandHelper<CommandBase, SelfCancellingCommand> {
@@ -28,7 +29,7 @@ class SelfCancellingCommand
  * Checks <a
  * href="https://github.com/wpilibsuite/allwpilib/issues/4259">wpilibsuite/allwpilib#4259</a>.
  */
-TEST_P(SchedulingRecursionTest, CancelFromInitializeTest) {
+TEST_P(SchedulingRecursionTest, CancelFromInitialize) {
   CommandScheduler scheduler = GetScheduler();
   bool hasOtherRun = false;
   TestSubsystem requirement;
@@ -47,10 +48,7 @@ TEST_P(SchedulingRecursionTest, CancelFromInitializeTest) {
   EXPECT_TRUE(hasOtherRun);
 }
 
-INSTANTIATE_TEST_SUITE_P(SchedulingRecursionTest, CancelFromInitializeTest,
-                         testing::Bool());
-
-TEST_P(SchedulingRecursionTest, DefaultCommandTest) {
+TEST_P(SchedulingRecursionTest, DefaultCommand) {
   CommandScheduler scheduler = GetScheduler();
   bool hasOtherRun = false;
   TestSubsystem requirement;
@@ -68,9 +66,6 @@ TEST_P(SchedulingRecursionTest, DefaultCommandTest) {
   EXPECT_TRUE(hasOtherRun);
 }
 
-INSTANTIATE_TEST_SUITE_P(SchedulingRecursionTest, DefaultCommandTest,
-                         testing::Bool());
-
 class CancelEndCommand : public CommandHelper<CommandBase, CancelEndCommand> {
  public:
   CancelEndCommand(CommandScheduler* scheduler, int& counter)
@@ -86,7 +81,7 @@ class CancelEndCommand : public CommandHelper<CommandBase, CancelEndCommand> {
   int& m_counter;
 };
 
-TEST_F(SchedulingRecursionTest, CancelFromEndTest) {
+TEST_F(SchedulingRecursionTest, CancelFromEnd) {
   CommandScheduler scheduler = GetScheduler();
   int counter = 0;
   CancelEndCommand selfCancels{&scheduler, counter};
@@ -97,3 +92,6 @@ TEST_F(SchedulingRecursionTest, CancelFromEndTest) {
   EXPECT_EQ(1, counter);
   EXPECT_TRUE(scheduler.IsScheduled(&selfCancels));
 }
+
+INSTANTIATE_TEST_SUITE_P(SchedulingRecursionTests, SchedulingRecursionTest,
+                         testing::Bool());

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulingRecursionTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulingRecursionTest.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "CommandTestBase.h"
+#include "frc2/command/CommandHelper.h"
+#include "frc2/command/RunCommand.h"
+
+using namespace frc2;
+class SchedulingRecursionTest : public CommandTestBase,
+                                public testing::WithParamInterface<bool> {};
+
+class SelfCancellingCommand
+    : public CommandHelper<CommandBase, SelfCancellingCommand> {
+ public:
+  SelfCancellingCommand(CommandScheduler* scheduler, Subsystem* requirement)
+      : m_scheduler(scheduler) {
+    AddRequirements(requirement);
+  }
+
+  void Initialize() override { m_scheduler->Cancel(this); }
+
+ private:
+  CommandScheduler* m_scheduler;
+};
+
+/**
+ * Checks <a
+ * href="https://github.com/wpilibsuite/allwpilib/issues/4259">wpilibsuite/allwpilib#4259</a>.
+ */
+TEST_P(SchedulingRecursionTest, CancelFromInitializeTest) {
+  CommandScheduler scheduler = GetScheduler();
+  bool hasOtherRun = false;
+  TestSubsystem requirement;
+  SelfCancellingCommand selfCancels{&scheduler, &requirement};
+  RunCommand other =
+      RunCommand([&hasOtherRun] { hasOtherRun = true; }, {&requirement});
+
+  scheduler.Schedule(GetParam(), &selfCancels);
+  scheduler.Run();
+  // interruptibility of new arrival isn't checked
+  scheduler.Schedule(&other);
+
+  EXPECT_FALSE(scheduler.IsScheduled(&selfCancels));
+  EXPECT_TRUE(scheduler.IsScheduled(&other));
+  scheduler.Run();
+  EXPECT_TRUE(hasOtherRun);
+}
+
+INSTANTIATE_TEST_SUITE_P(SchedulingRecursionTest, CancelFromInitializeTest,
+                         testing::Bool());
+
+TEST_P(SchedulingRecursionTest, DefaultCommandTest) {
+  CommandScheduler scheduler = GetScheduler();
+  bool hasOtherRun = false;
+  TestSubsystem requirement;
+  SelfCancellingCommand selfCancels{&scheduler, &requirement};
+  RunCommand other =
+      RunCommand([&hasOtherRun] { hasOtherRun = true; }, {&requirement});
+  scheduler.SetDefaultCommand(&requirement, std::move(other));
+
+  scheduler.Schedule(GetParam(), &selfCancels);
+  scheduler.Run();
+  scheduler.Run();
+  EXPECT_FALSE(scheduler.IsScheduled(&selfCancels));
+  EXPECT_TRUE(scheduler.IsScheduled(&other));
+  scheduler.Run();
+  EXPECT_TRUE(hasOtherRun);
+}
+
+INSTANTIATE_TEST_SUITE_P(SchedulingRecursionTest, DefaultCommandTest,
+                         testing::Bool());
+
+class CancelEndCommand : public CommandHelper<CommandBase, CancelEndCommand> {
+ public:
+  CancelEndCommand(CommandScheduler* scheduler, int& counter)
+      : m_scheduler(scheduler), m_counter(counter) {}
+
+  void End(bool interrupted) override {
+    m_counter++;
+    m_scheduler->Cancel(this);
+  }
+
+ private:
+  CommandScheduler* m_scheduler;
+  int& m_counter;
+};
+
+TEST_F(SchedulingRecursionTest, CancelFromEndTest) {
+  CommandScheduler scheduler = GetScheduler();
+  int counter = 0;
+  CancelEndCommand selfCancels{&scheduler, counter};
+
+  scheduler.Schedule(&selfCancels);
+
+  EXPECT_NO_THROW({ scheduler.Cancel(&selfCancels); });
+  EXPECT_EQ(1, counter);
+  EXPECT_TRUE(scheduler.IsScheduled(&selfCancels));
+}

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulingRecursionTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulingRecursionTest.cpp
@@ -61,7 +61,7 @@ TEST_P(SchedulingRecursionTest, DefaultCommand) {
   scheduler.Run();
   scheduler.Run();
   EXPECT_FALSE(scheduler.IsScheduled(&selfCancels));
-  EXPECT_TRUE(scheduler.IsScheduled(&other));
+  EXPECT_TRUE(scheduler.IsScheduled(scheduler.GetDefaultCommand(&requirement)));
   scheduler.Run();
   EXPECT_TRUE(hasOtherRun);
 }
@@ -90,7 +90,7 @@ TEST_F(SchedulingRecursionTest, CancelFromEnd) {
 
   EXPECT_NO_THROW({ scheduler.Cancel(&selfCancels); });
   EXPECT_EQ(1, counter);
-  EXPECT_TRUE(scheduler.IsScheduled(&selfCancels));
+  EXPECT_FALSE(scheduler.IsScheduled(&selfCancels));
 }
 
 INSTANTIATE_TEST_SUITE_P(SchedulingRecursionTests, SchedulingRecursionTest,


### PR DESCRIPTION
Resolves #4259.
Resolves #3362.

Checked for if the map returns `null`. Added a test to confirm this has been fixed.