### PR TITLE
[upstream utils] Fix stack walker

### DIFF
--- a/upstream_utils/stack_walker_patches/0001-Apply-PR-35.patch
+++ b/upstream_utils/stack_walker_patches/0001-Apply-PR-35.patch
@@ -1,0 +1,3428 @@
+From debe4e850ff2cd19b55be75dcd7ace176bbaf5f0 Mon Sep 17 00:00:00 2001
+From: PJ Reiniger <pj.reiniger@gmail.com>
+Date: Sun, 22 May 2022 23:58:57 -0400
+Subject: [PATCH 1/3] Apply PR #35
+
+---
+ .gitignore                              |    9 +
+ Main/StackWalker/StackWalker.cpp        | 2842 +++++++++++------------
+ Main/StackWalker/StackWalker.h          |  500 ++--
+ Main/StackWalker/StackWalker_VC2017.sln |   16 +-
+ Main/StackWalker/main.cpp               |    2 +-
+ 5 files changed, 1636 insertions(+), 1733 deletions(-)
+ create mode 100644 .gitignore
+
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 0000000..5d102c5
+--- /dev/null
++++ b/.gitignore
+@@ -0,0 +1,9 @@
++﻿################################################################################
++# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
++################################################################################
++
++*.suo
++*.db
++*.sqlite
++/Main/StackWalker/_ReSharper.Caches/*
++/.vs/*
+diff --git a/Main/StackWalker/StackWalker.cpp b/Main/StackWalker/StackWalker.cpp
+index e1b25eb..48c7c57 100644
+--- a/Main/StackWalker/StackWalker.cpp
++++ b/Main/StackWalker/StackWalker.cpp
+@@ -1,1469 +1,1373 @@
+-/**********************************************************************
+- *
+- * StackWalker.cpp
+- * https://github.com/JochenKalmbach/StackWalker
+- *
+- * Old location: http://stackwalker.codeplex.com/
+- *
+- *
+- * History:
+- *  2005-07-27   v1    - First public release on http://www.codeproject.com/
+- *                       http://www.codeproject.com/threads/StackWalker.asp
+- *  2005-07-28   v2    - Changed the params of the constructor and ShowCallstack
+- *                       (to simplify the usage)
+- *  2005-08-01   v3    - Changed to use 'CONTEXT_FULL' instead of CONTEXT_ALL
+- *                       (should also be enough)
+- *                     - Changed to compile correctly with the PSDK of VC7.0
+- *                       (GetFileVersionInfoSizeA and GetFileVersionInfoA is wrongly defined:
+- *                        it uses LPSTR instead of LPCSTR as first parameter)
+- *                     - Added declarations to support VC5/6 without using 'dbghelp.h'
+- *                     - Added a 'pUserData' member to the ShowCallstack function and the
+- *                       PReadProcessMemoryRoutine declaration (to pass some user-defined data,
+- *                       which can be used in the readMemoryFunction-callback)
+- *  2005-08-02   v4    - OnSymInit now also outputs the OS-Version by default
+- *                     - Added example for doing an exception-callstack-walking in main.cpp
+- *                       (thanks to owillebo: http://www.codeproject.com/script/profile/whos_who.asp?id=536268)
+- *  2005-08-05   v5    - Removed most Lint (http://www.gimpel.com/) errors... thanks to Okko Willeboordse!
+- *  2008-08-04   v6    - Fixed Bug: Missing LEAK-end-tag
+- *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2502890#xx2502890xx
+- *                       Fixed Bug: Compiled with "WIN32_LEAN_AND_MEAN"
+- *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=1824718#xx1824718xx
+- *                       Fixed Bug: Compiling with "/Wall"
+- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2638243#xx2638243xx
+- *                       Fixed Bug: Now checking SymUseSymSrv
+- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1388979#xx1388979xx
+- *                       Fixed Bug: Support for recursive function calls
+- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1434538#xx1434538xx
+- *                       Fixed Bug: Missing FreeLibrary call in "GetModuleListTH32"
+- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1326923#xx1326923xx
+- *                       Fixed Bug: SymDia is number 7, not 9!
+- *  2008-09-11   v7      For some (undocumented) reason, dbhelp.h is needing a packing of 8!
+- *                       Thanks to Teajay which reported the bug...
+- *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2718933#xx2718933xx
+- *  2008-11-27   v8      Debugging Tools for Windows are now stored in a different directory
+- *                       Thanks to Luiz Salamon which reported this "bug"...
+- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2822736#xx2822736xx
+- *  2009-04-10   v9      License slightly corrected (<ORGANIZATION> replaced)
+- *  2009-11-01   v10     Moved to http://stackwalker.codeplex.com/
+- *  2009-11-02   v11     Now try to use IMAGEHLP_MODULE64_V3 if available
+- *  2010-04-15   v12     Added support for VS2010 RTM
+- *  2010-05-25   v13     Now using secure MyStrcCpy. Thanks to luke.simon:
+- *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=3477467#xx3477467xx
+- *  2013-01-07   v14     Runtime Check Error VS2010 Debug Builds fixed:
+- *                       http://stackwalker.codeplex.com/workitem/10511
+- *
+- *
+- * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
+- *
+- *   Copyright (c) 2005-2013, Jochen Kalmbach
+- *   All rights reserved.
+- *
+- *   Redistribution and use in source and binary forms, with or without modification,
+- *   are permitted provided that the following conditions are met:
+- *
+- *   Redistributions of source code must retain the above copyright notice,
+- *   this list of conditions and the following disclaimer.
+- *   Redistributions in binary form must reproduce the above copyright notice,
+- *   this list of conditions and the following disclaimer in the documentation
+- *   and/or other materials provided with the distribution.
+- *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
+- *   used to endorse or promote products derived from this software without
+- *   specific prior written permission.
+- *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+- *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+- *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+- *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+- *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+- *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+- *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+- *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+- *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+- *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- *
+- **********************************************************************/
+-
+-#include "StackWalker.h"
+-
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <tchar.h>
+-#include <windows.h>
+-#pragma comment(lib, "version.lib") // for "VerQueryValue"
+-#pragma warning(disable : 4826)
+-
+-
+-// If VC7 and later, then use the shipped 'dbghelp.h'-file
+-#pragma pack(push, 8)
+-#if _MSC_VER >= 1300
+-#include <dbghelp.h>
+-#else
+-// inline the important dbghelp.h-declarations...
+-typedef enum
+-{
+-  SymNone = 0,
+-  SymCoff,
+-  SymCv,
+-  SymPdb,
+-  SymExport,
+-  SymDeferred,
+-  SymSym,
+-  SymDia,
+-  SymVirtual,
+-  NumSymTypes
+-} SYM_TYPE;
+-typedef struct _IMAGEHLP_LINE64
+-{
+-  DWORD   SizeOfStruct; // set to sizeof(IMAGEHLP_LINE64)
+-  PVOID   Key;          // internal
+-  DWORD   LineNumber;   // line number in file
+-  PCHAR   FileName;     // full filename
+-  DWORD64 Address;      // first instruction of line
+-} IMAGEHLP_LINE64, *PIMAGEHLP_LINE64;
+-typedef struct _IMAGEHLP_MODULE64
+-{
+-  DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
+-  DWORD64  BaseOfImage;          // base load address of module
+-  DWORD    ImageSize;            // virtual size of the loaded module
+-  DWORD    TimeDateStamp;        // date/time stamp from pe header
+-  DWORD    CheckSum;             // checksum from the pe header
+-  DWORD    NumSyms;              // number of symbols in the symbol table
+-  SYM_TYPE SymType;              // type of symbols loaded
+-  CHAR     ModuleName[32];       // module name
+-  CHAR     ImageName[256];       // image name
+-  CHAR     LoadedImageName[256]; // symbol file name
+-} IMAGEHLP_MODULE64, *PIMAGEHLP_MODULE64;
+-typedef struct _IMAGEHLP_SYMBOL64
+-{
+-  DWORD   SizeOfStruct;  // set to sizeof(IMAGEHLP_SYMBOL64)
+-  DWORD64 Address;       // virtual address including dll base address
+-  DWORD   Size;          // estimated size of symbol, can be zero
+-  DWORD   Flags;         // info about the symbols, see the SYMF defines
+-  DWORD   MaxNameLength; // maximum size of symbol name in 'Name'
+-  CHAR    Name[1];       // symbol name (null terminated string)
+-} IMAGEHLP_SYMBOL64, *PIMAGEHLP_SYMBOL64;
+-typedef enum
+-{
+-  AddrMode1616,
+-  AddrMode1632,
+-  AddrModeReal,
+-  AddrModeFlat
+-} ADDRESS_MODE;
+-typedef struct _tagADDRESS64
+-{
+-  DWORD64      Offset;
+-  WORD         Segment;
+-  ADDRESS_MODE Mode;
+-} ADDRESS64, *LPADDRESS64;
+-typedef struct _KDHELP64
+-{
+-  DWORD64 Thread;
+-  DWORD   ThCallbackStack;
+-  DWORD   ThCallbackBStore;
+-  DWORD   NextCallback;
+-  DWORD   FramePointer;
+-  DWORD64 KiCallUserMode;
+-  DWORD64 KeUserCallbackDispatcher;
+-  DWORD64 SystemRangeStart;
+-  DWORD64 Reserved[8];
+-} KDHELP64, *PKDHELP64;
+-typedef struct _tagSTACKFRAME64
+-{
+-  ADDRESS64 AddrPC;         // program counter
+-  ADDRESS64 AddrReturn;     // return address
+-  ADDRESS64 AddrFrame;      // frame pointer
+-  ADDRESS64 AddrStack;      // stack pointer
+-  ADDRESS64 AddrBStore;     // backing store pointer
+-  PVOID     FuncTableEntry; // pointer to pdata/fpo or NULL
+-  DWORD64   Params[4];      // possible arguments to the function
+-  BOOL      Far;            // WOW far call
+-  BOOL      Virtual;        // is this a virtual frame?
+-  DWORD64   Reserved[3];
+-  KDHELP64  KdHelp;
+-} STACKFRAME64, *LPSTACKFRAME64;
+-typedef BOOL(__stdcall* PREAD_PROCESS_MEMORY_ROUTINE64)(HANDLE  hProcess,
+-                                                        DWORD64 qwBaseAddress,
+-                                                        PVOID   lpBuffer,
+-                                                        DWORD   nSize,
+-                                                        LPDWORD lpNumberOfBytesRead);
+-typedef PVOID(__stdcall* PFUNCTION_TABLE_ACCESS_ROUTINE64)(HANDLE hProcess, DWORD64 AddrBase);
+-typedef DWORD64(__stdcall* PGET_MODULE_BASE_ROUTINE64)(HANDLE hProcess, DWORD64 Address);
+-typedef DWORD64(__stdcall* PTRANSLATE_ADDRESS_ROUTINE64)(HANDLE      hProcess,
+-                                                         HANDLE      hThread,
+-                                                         LPADDRESS64 lpaddr);
+-
+-// clang-format off
+-#define SYMOPT_CASE_INSENSITIVE         0x00000001
+-#define SYMOPT_UNDNAME                  0x00000002
+-#define SYMOPT_DEFERRED_LOADS           0x00000004
+-#define SYMOPT_NO_CPP                   0x00000008
+-#define SYMOPT_LOAD_LINES               0x00000010
+-#define SYMOPT_OMAP_FIND_NEAREST        0x00000020
+-#define SYMOPT_LOAD_ANYTHING            0x00000040
+-#define SYMOPT_IGNORE_CVREC             0x00000080
+-#define SYMOPT_NO_UNQUALIFIED_LOADS     0x00000100
+-#define SYMOPT_FAIL_CRITICAL_ERRORS     0x00000200
+-#define SYMOPT_EXACT_SYMBOLS            0x00000400
+-#define SYMOPT_ALLOW_ABSOLUTE_SYMBOLS   0x00000800
+-#define SYMOPT_IGNORE_NT_SYMPATH        0x00001000
+-#define SYMOPT_INCLUDE_32BIT_MODULES    0x00002000
+-#define SYMOPT_PUBLICS_ONLY             0x00004000
+-#define SYMOPT_NO_PUBLICS               0x00008000
+-#define SYMOPT_AUTO_PUBLICS             0x00010000
+-#define SYMOPT_NO_IMAGE_SEARCH          0x00020000
+-#define SYMOPT_SECURE                   0x00040000
+-#define SYMOPT_DEBUG                    0x80000000
+-#define UNDNAME_COMPLETE                 (0x0000) // Enable full undecoration
+-#define UNDNAME_NAME_ONLY                (0x1000) // Crack only the name for primary declaration;
+-// clang-format on
+-
+-#endif // _MSC_VER < 1300
+-#pragma pack(pop)
+-
+-// Some missing defines (for VC5/6):
+-#ifndef INVALID_FILE_ATTRIBUTES
+-#define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
+-#endif
+-
+-// secure-CRT_functions are only available starting with VC8
+-#if _MSC_VER < 1400
+-#define strcpy_s(dst, len, src) strcpy(dst, src)
+-#define strncpy_s(dst, len, src, maxLen) strncpy(dst, len, src)
+-#define strcat_s(dst, len, src) strcat(dst, src)
+-#define _snprintf_s _snprintf
+-#define _tcscat_s _tcscat
+-#endif
+-
+-static void MyStrCpy(char* szDest, size_t nMaxDestSize, const char* szSrc)
+-{
+-  if (nMaxDestSize <= 0)
+-    return;
+-  strncpy_s(szDest, nMaxDestSize, szSrc, _TRUNCATE);
+-  // INFO: _TRUNCATE will ensure that it is null-terminated;
+-  // but with older compilers (<1400) it uses "strncpy" and this does not!)
+-  szDest[nMaxDestSize - 1] = 0;
+-} // MyStrCpy
+-
+-// Normally it should be enough to use 'CONTEXT_FULL' (better would be 'CONTEXT_ALL')
+-#define USED_CONTEXT_FLAGS CONTEXT_FULL
+-
+-class StackWalkerInternal
+-{
+-public:
+-  StackWalkerInternal(StackWalker* parent, HANDLE hProcess)
+-  {
+-    m_parent = parent;
+-    m_hDbhHelp = NULL;
+-    pSC = NULL;
+-    m_hProcess = hProcess;
+-    m_szSymPath = NULL;
+-    pSFTA = NULL;
+-    pSGLFA = NULL;
+-    pSGMB = NULL;
+-    pSGMI = NULL;
+-    pSGO = NULL;
+-    pSGSFA = NULL;
+-    pSI = NULL;
+-    pSLM = NULL;
+-    pSSO = NULL;
+-    pSW = NULL;
+-    pUDSN = NULL;
+-    pSGSP = NULL;
+-  }
+-  ~StackWalkerInternal()
+-  {
+-    if (pSC != NULL)
+-      pSC(m_hProcess); // SymCleanup
+-    if (m_hDbhHelp != NULL)
+-      FreeLibrary(m_hDbhHelp);
+-    m_hDbhHelp = NULL;
+-    m_parent = NULL;
+-    if (m_szSymPath != NULL)
+-      free(m_szSymPath);
+-    m_szSymPath = NULL;
+-  }
+-  BOOL Init(LPCSTR szSymPath)
+-  {
+-    if (m_parent == NULL)
+-      return FALSE;
+-    // Dynamically load the Entry-Points for dbghelp.dll:
+-    // First try to load the newest one from
+-    TCHAR szTemp[4096];
+-    // But before we do this, we first check if the ".local" file exists
+-    if (GetModuleFileName(NULL, szTemp, 4096) > 0)
+-    {
+-      _tcscat_s(szTemp, _T(".local"));
+-      if (GetFileAttributes(szTemp) == INVALID_FILE_ATTRIBUTES)
+-      {
+-        // ".local" file does not exist, so we can try to load the dbghelp.dll from the "Debugging Tools for Windows"
+-        // Ok, first try the new path according to the architecture:
+-#ifdef _M_IX86
+-        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+-        {
+-          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x86)\\dbghelp.dll"));
+-          // now check if the file exists:
+-          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+-          {
+-            m_hDbhHelp = LoadLibrary(szTemp);
+-          }
+-        }
+-#elif _M_X64
+-        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+-        {
+-          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x64)\\dbghelp.dll"));
+-          // now check if the file exists:
+-          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+-          {
+-            m_hDbhHelp = LoadLibrary(szTemp);
+-          }
+-        }
+-#elif _M_IA64
+-        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+-        {
+-          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (ia64)\\dbghelp.dll"));
+-          // now check if the file exists:
+-          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+-          {
+-            m_hDbhHelp = LoadLibrary(szTemp);
+-          }
+-        }
+-#endif
+-        // If still not found, try the old directories...
+-        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+-        {
+-          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows\\dbghelp.dll"));
+-          // now check if the file exists:
+-          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+-          {
+-            m_hDbhHelp = LoadLibrary(szTemp);
+-          }
+-        }
+-#if defined _M_X64 || defined _M_IA64
+-        // Still not found? Then try to load the (old) 64-Bit version:
+-        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+-        {
+-          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows 64-Bit\\dbghelp.dll"));
+-          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+-          {
+-            m_hDbhHelp = LoadLibrary(szTemp);
+-          }
+-        }
+-#endif
+-      }
+-    }
+-    if (m_hDbhHelp == NULL) // if not already loaded, try to load a default-one
+-      m_hDbhHelp = LoadLibrary(_T("dbghelp.dll"));
+-    if (m_hDbhHelp == NULL)
+-      return FALSE;
+-    pSI = (tSI)GetProcAddress(m_hDbhHelp, "SymInitialize");
+-    pSC = (tSC)GetProcAddress(m_hDbhHelp, "SymCleanup");
+-
+-    pSW = (tSW)GetProcAddress(m_hDbhHelp, "StackWalk64");
+-    pSGO = (tSGO)GetProcAddress(m_hDbhHelp, "SymGetOptions");
+-    pSSO = (tSSO)GetProcAddress(m_hDbhHelp, "SymSetOptions");
+-
+-    pSFTA = (tSFTA)GetProcAddress(m_hDbhHelp, "SymFunctionTableAccess64");
+-    pSGLFA = (tSGLFA)GetProcAddress(m_hDbhHelp, "SymGetLineFromAddr64");
+-    pSGMB = (tSGMB)GetProcAddress(m_hDbhHelp, "SymGetModuleBase64");
+-    pSGMI = (tSGMI)GetProcAddress(m_hDbhHelp, "SymGetModuleInfo64");
+-    pSGSFA = (tSGSFA)GetProcAddress(m_hDbhHelp, "SymGetSymFromAddr64");
+-    pUDSN = (tUDSN)GetProcAddress(m_hDbhHelp, "UnDecorateSymbolName");
+-    pSLM = (tSLM)GetProcAddress(m_hDbhHelp, "SymLoadModule64");
+-    pSGSP = (tSGSP)GetProcAddress(m_hDbhHelp, "SymGetSearchPath");
+-
+-    if (pSC == NULL || pSFTA == NULL || pSGMB == NULL || pSGMI == NULL || pSGO == NULL ||
+-        pSGSFA == NULL || pSI == NULL || pSSO == NULL || pSW == NULL || pUDSN == NULL ||
+-        pSLM == NULL)
+-    {
+-      FreeLibrary(m_hDbhHelp);
+-      m_hDbhHelp = NULL;
+-      pSC = NULL;
+-      return FALSE;
+-    }
+-
+-    // SymInitialize
+-    if (szSymPath != NULL)
+-      m_szSymPath = _strdup(szSymPath);
+-    if (this->pSI(m_hProcess, m_szSymPath, FALSE) == FALSE)
+-      this->m_parent->OnDbgHelpErr("SymInitialize", GetLastError(), 0);
+-
+-    DWORD symOptions = this->pSGO(); // SymGetOptions
+-    symOptions |= SYMOPT_LOAD_LINES;
+-    symOptions |= SYMOPT_FAIL_CRITICAL_ERRORS;
+-    //symOptions |= SYMOPT_NO_PROMPTS;
+-    // SymSetOptions
+-    symOptions = this->pSSO(symOptions);
+-
+-    char buf[StackWalker::STACKWALK_MAX_NAMELEN] = {0};
+-    if (this->pSGSP != NULL)
+-    {
+-      if (this->pSGSP(m_hProcess, buf, StackWalker::STACKWALK_MAX_NAMELEN) == FALSE)
+-        this->m_parent->OnDbgHelpErr("SymGetSearchPath", GetLastError(), 0);
+-    }
+-    char  szUserName[1024] = {0};
+-    DWORD dwSize = 1024;
+-    GetUserNameA(szUserName, &dwSize);
+-    this->m_parent->OnSymInit(buf, symOptions, szUserName);
+-
+-    return TRUE;
+-  }
+-
+-  StackWalker* m_parent;
+-
+-  HMODULE m_hDbhHelp;
+-  HANDLE  m_hProcess;
+-  LPSTR   m_szSymPath;
+-
+-#pragma pack(push, 8)
+-  typedef struct IMAGEHLP_MODULE64_V3
+-  {
+-    DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
+-    DWORD64  BaseOfImage;          // base load address of module
+-    DWORD    ImageSize;            // virtual size of the loaded module
+-    DWORD    TimeDateStamp;        // date/time stamp from pe header
+-    DWORD    CheckSum;             // checksum from the pe header
+-    DWORD    NumSyms;              // number of symbols in the symbol table
+-    SYM_TYPE SymType;              // type of symbols loaded
+-    CHAR     ModuleName[32];       // module name
+-    CHAR     ImageName[256];       // image name
+-    CHAR     LoadedImageName[256]; // symbol file name
+-    // new elements: 07-Jun-2002
+-    CHAR  LoadedPdbName[256];   // pdb file name
+-    DWORD CVSig;                // Signature of the CV record in the debug directories
+-    CHAR  CVData[MAX_PATH * 3]; // Contents of the CV record
+-    DWORD PdbSig;               // Signature of PDB
+-    GUID  PdbSig70;             // Signature of PDB (VC 7 and up)
+-    DWORD PdbAge;               // DBI age of pdb
+-    BOOL  PdbUnmatched;         // loaded an unmatched pdb
+-    BOOL  DbgUnmatched;         // loaded an unmatched dbg
+-    BOOL  LineNumbers;          // we have line number information
+-    BOOL  GlobalSymbols;        // we have internal symbol information
+-    BOOL  TypeInfo;             // we have type information
+-    // new elements: 17-Dec-2003
+-    BOOL SourceIndexed; // pdb supports source server
+-    BOOL Publics;       // contains public symbols
+-  };
+-
+-  typedef struct IMAGEHLP_MODULE64_V2
+-  {
+-    DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
+-    DWORD64  BaseOfImage;          // base load address of module
+-    DWORD    ImageSize;            // virtual size of the loaded module
+-    DWORD    TimeDateStamp;        // date/time stamp from pe header
+-    DWORD    CheckSum;             // checksum from the pe header
+-    DWORD    NumSyms;              // number of symbols in the symbol table
+-    SYM_TYPE SymType;              // type of symbols loaded
+-    CHAR     ModuleName[32];       // module name
+-    CHAR     ImageName[256];       // image name
+-    CHAR     LoadedImageName[256]; // symbol file name
+-  };
+-#pragma pack(pop)
+-
+-  // SymCleanup()
+-  typedef BOOL(__stdcall* tSC)(IN HANDLE hProcess);
+-  tSC pSC;
+-
+-  // SymFunctionTableAccess64()
+-  typedef PVOID(__stdcall* tSFTA)(HANDLE hProcess, DWORD64 AddrBase);
+-  tSFTA pSFTA;
+-
+-  // SymGetLineFromAddr64()
+-  typedef BOOL(__stdcall* tSGLFA)(IN HANDLE hProcess,
+-                                  IN DWORD64 dwAddr,
+-                                  OUT PDWORD pdwDisplacement,
+-                                  OUT PIMAGEHLP_LINE64 Line);
+-  tSGLFA pSGLFA;
+-
+-  // SymGetModuleBase64()
+-  typedef DWORD64(__stdcall* tSGMB)(IN HANDLE hProcess, IN DWORD64 dwAddr);
+-  tSGMB pSGMB;
+-
+-  // SymGetModuleInfo64()
+-  typedef BOOL(__stdcall* tSGMI)(IN HANDLE hProcess,
+-                                 IN DWORD64 dwAddr,
+-                                 OUT IMAGEHLP_MODULE64_V3* ModuleInfo);
+-  tSGMI pSGMI;
+-
+-  // SymGetOptions()
+-  typedef DWORD(__stdcall* tSGO)(VOID);
+-  tSGO pSGO;
+-
+-  // SymGetSymFromAddr64()
+-  typedef BOOL(__stdcall* tSGSFA)(IN HANDLE hProcess,
+-                                  IN DWORD64 dwAddr,
+-                                  OUT PDWORD64 pdwDisplacement,
+-                                  OUT PIMAGEHLP_SYMBOL64 Symbol);
+-  tSGSFA pSGSFA;
+-
+-  // SymInitialize()
+-  typedef BOOL(__stdcall* tSI)(IN HANDLE hProcess, IN PSTR UserSearchPath, IN BOOL fInvadeProcess);
+-  tSI pSI;
+-
+-  // SymLoadModule64()
+-  typedef DWORD64(__stdcall* tSLM)(IN HANDLE hProcess,
+-                                   IN HANDLE hFile,
+-                                   IN PSTR ImageName,
+-                                   IN PSTR ModuleName,
+-                                   IN DWORD64 BaseOfDll,
+-                                   IN DWORD SizeOfDll);
+-  tSLM pSLM;
+-
+-  // SymSetOptions()
+-  typedef DWORD(__stdcall* tSSO)(IN DWORD SymOptions);
+-  tSSO pSSO;
+-
+-  // StackWalk64()
+-  typedef BOOL(__stdcall* tSW)(DWORD                            MachineType,
+-                               HANDLE                           hProcess,
+-                               HANDLE                           hThread,
+-                               LPSTACKFRAME64                   StackFrame,
+-                               PVOID                            ContextRecord,
+-                               PREAD_PROCESS_MEMORY_ROUTINE64   ReadMemoryRoutine,
+-                               PFUNCTION_TABLE_ACCESS_ROUTINE64 FunctionTableAccessRoutine,
+-                               PGET_MODULE_BASE_ROUTINE64       GetModuleBaseRoutine,
+-                               PTRANSLATE_ADDRESS_ROUTINE64     TranslateAddress);
+-  tSW pSW;
+-
+-  // UnDecorateSymbolName()
+-  typedef DWORD(__stdcall WINAPI* tUDSN)(PCSTR DecoratedName,
+-                                         PSTR  UnDecoratedName,
+-                                         DWORD UndecoratedLength,
+-                                         DWORD Flags);
+-  tUDSN pUDSN;
+-
+-  typedef BOOL(__stdcall WINAPI* tSGSP)(HANDLE hProcess, PSTR SearchPath, DWORD SearchPathLength);
+-  tSGSP pSGSP;
+-
+-private:
+-// **************************************** ToolHelp32 ************************
+-#define MAX_MODULE_NAME32 255
+-#define TH32CS_SNAPMODULE 0x00000008
+-#pragma pack(push, 8)
+-  typedef struct tagMODULEENTRY32
+-  {
+-    DWORD   dwSize;
+-    DWORD   th32ModuleID;  // This module
+-    DWORD   th32ProcessID; // owning process
+-    DWORD   GlblcntUsage;  // Global usage count on the module
+-    DWORD   ProccntUsage;  // Module usage count in th32ProcessID's context
+-    BYTE*   modBaseAddr;   // Base address of module in th32ProcessID's context
+-    DWORD   modBaseSize;   // Size in bytes of module starting at modBaseAddr
+-    HMODULE hModule;       // The hModule of this module in th32ProcessID's context
+-    char    szModule[MAX_MODULE_NAME32 + 1];
+-    char    szExePath[MAX_PATH];
+-  } MODULEENTRY32;
+-  typedef MODULEENTRY32* PMODULEENTRY32;
+-  typedef MODULEENTRY32* LPMODULEENTRY32;
+-#pragma pack(pop)
+-
+-  BOOL GetModuleListTH32(HANDLE hProcess, DWORD pid)
+-  {
+-    // CreateToolhelp32Snapshot()
+-    typedef HANDLE(__stdcall * tCT32S)(DWORD dwFlags, DWORD th32ProcessID);
+-    // Module32First()
+-    typedef BOOL(__stdcall * tM32F)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
+-    // Module32Next()
+-    typedef BOOL(__stdcall * tM32N)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
+-
+-    // try both dlls...
+-    const TCHAR* dllname[] = {_T("kernel32.dll"), _T("tlhelp32.dll")};
+-    HINSTANCE    hToolhelp = NULL;
+-    tCT32S       pCT32S = NULL;
+-    tM32F        pM32F = NULL;
+-    tM32N        pM32N = NULL;
+-
+-    HANDLE        hSnap;
+-    MODULEENTRY32 me;
+-    me.dwSize = sizeof(me);
+-    BOOL   keepGoing;
+-    size_t i;
+-
+-    for (i = 0; i < (sizeof(dllname) / sizeof(dllname[0])); i++)
+-    {
+-      hToolhelp = LoadLibrary(dllname[i]);
+-      if (hToolhelp == NULL)
+-        continue;
+-      pCT32S = (tCT32S)GetProcAddress(hToolhelp, "CreateToolhelp32Snapshot");
+-      pM32F = (tM32F)GetProcAddress(hToolhelp, "Module32First");
+-      pM32N = (tM32N)GetProcAddress(hToolhelp, "Module32Next");
+-      if ((pCT32S != NULL) && (pM32F != NULL) && (pM32N != NULL))
+-        break; // found the functions!
+-      FreeLibrary(hToolhelp);
+-      hToolhelp = NULL;
+-    }
+-
+-    if (hToolhelp == NULL)
+-      return FALSE;
+-
+-    hSnap = pCT32S(TH32CS_SNAPMODULE, pid);
+-    if (hSnap == (HANDLE)-1)
+-    {
+-      FreeLibrary(hToolhelp);
+-      return FALSE;
+-    }
+-
+-    keepGoing = !!pM32F(hSnap, &me);
+-    int cnt = 0;
+-    while (keepGoing)
+-    {
+-      this->LoadModule(hProcess, me.szExePath, me.szModule, (DWORD64)me.modBaseAddr,
+-                       me.modBaseSize);
+-      cnt++;
+-      keepGoing = !!pM32N(hSnap, &me);
+-    }
+-    CloseHandle(hSnap);
+-    FreeLibrary(hToolhelp);
+-    if (cnt <= 0)
+-      return FALSE;
+-    return TRUE;
+-  } // GetModuleListTH32
+-
+-  // **************************************** PSAPI ************************
+-  typedef struct _MODULEINFO
+-  {
+-    LPVOID lpBaseOfDll;
+-    DWORD  SizeOfImage;
+-    LPVOID EntryPoint;
+-  } MODULEINFO, *LPMODULEINFO;
+-
+-  BOOL GetModuleListPSAPI(HANDLE hProcess)
+-  {
+-    // EnumProcessModules()
+-    typedef BOOL(__stdcall * tEPM)(HANDLE hProcess, HMODULE * lphModule, DWORD cb,
+-                                   LPDWORD lpcbNeeded);
+-    // GetModuleFileNameEx()
+-    typedef DWORD(__stdcall * tGMFNE)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename,
+-                                      DWORD nSize);
+-    // GetModuleBaseName()
+-    typedef DWORD(__stdcall * tGMBN)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename,
+-                                     DWORD nSize);
+-    // GetModuleInformation()
+-    typedef BOOL(__stdcall * tGMI)(HANDLE hProcess, HMODULE hModule, LPMODULEINFO pmi, DWORD nSize);
+-
+-    HINSTANCE hPsapi;
+-    tEPM      pEPM;
+-    tGMFNE    pGMFNE;
+-    tGMBN     pGMBN;
+-    tGMI      pGMI;
+-
+-    DWORD i;
+-    //ModuleEntry e;
+-    DWORD        cbNeeded;
+-    MODULEINFO   mi;
+-    HMODULE*     hMods = 0;
+-    char*        tt = NULL;
+-    char*        tt2 = NULL;
+-    const SIZE_T TTBUFLEN = 8096;
+-    int          cnt = 0;
+-
+-    hPsapi = LoadLibrary(_T("psapi.dll"));
+-    if (hPsapi == NULL)
+-      return FALSE;
+-
+-    pEPM = (tEPM)GetProcAddress(hPsapi, "EnumProcessModules");
+-    pGMFNE = (tGMFNE)GetProcAddress(hPsapi, "GetModuleFileNameExA");
+-    pGMBN = (tGMFNE)GetProcAddress(hPsapi, "GetModuleBaseNameA");
+-    pGMI = (tGMI)GetProcAddress(hPsapi, "GetModuleInformation");
+-    if ((pEPM == NULL) || (pGMFNE == NULL) || (pGMBN == NULL) || (pGMI == NULL))
+-    {
+-      // we couldn't find all functions
+-      FreeLibrary(hPsapi);
+-      return FALSE;
+-    }
+-
+-    hMods = (HMODULE*)malloc(sizeof(HMODULE) * (TTBUFLEN / sizeof(HMODULE)));
+-    tt = (char*)malloc(sizeof(char) * TTBUFLEN);
+-    tt2 = (char*)malloc(sizeof(char) * TTBUFLEN);
+-    if ((hMods == NULL) || (tt == NULL) || (tt2 == NULL))
+-      goto cleanup;
+-
+-    if (!pEPM(hProcess, hMods, TTBUFLEN, &cbNeeded))
+-    {
+-      //_ftprintf(fLogFile, _T("%lu: EPM failed, GetLastError = %lu\n"), g_dwShowCount, gle );
+-      goto cleanup;
+-    }
+-
+-    if (cbNeeded > TTBUFLEN)
+-    {
+-      //_ftprintf(fLogFile, _T("%lu: More than %lu module handles. Huh?\n"), g_dwShowCount, lenof( hMods ) );
+-      goto cleanup;
+-    }
+-
+-    for (i = 0; i < cbNeeded / sizeof(hMods[0]); i++)
+-    {
+-      // base address, size
+-      pGMI(hProcess, hMods[i], &mi, sizeof(mi));
+-      // image file name
+-      tt[0] = 0;
+-      pGMFNE(hProcess, hMods[i], tt, TTBUFLEN);
+-      // module name
+-      tt2[0] = 0;
+-      pGMBN(hProcess, hMods[i], tt2, TTBUFLEN);
+-
+-      DWORD dwRes = this->LoadModule(hProcess, tt, tt2, (DWORD64)mi.lpBaseOfDll, mi.SizeOfImage);
+-      if (dwRes != ERROR_SUCCESS)
+-        this->m_parent->OnDbgHelpErr("LoadModule", dwRes, 0);
+-      cnt++;
+-    }
+-
+-  cleanup:
+-    if (hPsapi != NULL)
+-      FreeLibrary(hPsapi);
+-    if (tt2 != NULL)
+-      free(tt2);
+-    if (tt != NULL)
+-      free(tt);
+-    if (hMods != NULL)
+-      free(hMods);
+-
+-    return cnt != 0;
+-  } // GetModuleListPSAPI
+-
+-  DWORD LoadModule(HANDLE hProcess, LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size)
+-  {
+-    CHAR* szImg = _strdup(img);
+-    CHAR* szMod = _strdup(mod);
+-    DWORD result = ERROR_SUCCESS;
+-    if ((szImg == NULL) || (szMod == NULL))
+-      result = ERROR_NOT_ENOUGH_MEMORY;
+-    else
+-    {
+-      if (pSLM(hProcess, 0, szImg, szMod, baseAddr, size) == 0)
+-        result = GetLastError();
+-    }
+-    ULONGLONG fileVersion = 0;
+-    if ((m_parent != NULL) && (szImg != NULL))
+-    {
+-      // try to retrieve the file-version:
+-      if ((this->m_parent->m_options & StackWalker::RetrieveFileVersion) != 0)
+-      {
+-        VS_FIXEDFILEINFO* fInfo = NULL;
+-        DWORD             dwHandle;
+-        DWORD             dwSize = GetFileVersionInfoSizeA(szImg, &dwHandle);
+-        if (dwSize > 0)
+-        {
+-          LPVOID vData = malloc(dwSize);
+-          if (vData != NULL)
+-          {
+-            if (GetFileVersionInfoA(szImg, dwHandle, dwSize, vData) != 0)
+-            {
+-              UINT  len;
+-              TCHAR szSubBlock[] = _T("\\");
+-              if (VerQueryValue(vData, szSubBlock, (LPVOID*)&fInfo, &len) == 0)
+-                fInfo = NULL;
+-              else
+-              {
+-                fileVersion =
+-                    ((ULONGLONG)fInfo->dwFileVersionLS) + ((ULONGLONG)fInfo->dwFileVersionMS << 32);
+-              }
+-            }
+-            free(vData);
+-          }
+-        }
+-      }
+-
+-      // Retrieve some additional-infos about the module
+-      IMAGEHLP_MODULE64_V3 Module;
+-      const char*          szSymType = "-unknown-";
+-      if (this->GetModuleInfo(hProcess, baseAddr, &Module) != FALSE)
+-      {
+-        switch (Module.SymType)
+-        {
+-          case SymNone:
+-            szSymType = "-nosymbols-";
+-            break;
+-          case SymCoff: // 1
+-            szSymType = "COFF";
+-            break;
+-          case SymCv: // 2
+-            szSymType = "CV";
+-            break;
+-          case SymPdb: // 3
+-            szSymType = "PDB";
+-            break;
+-          case SymExport: // 4
+-            szSymType = "-exported-";
+-            break;
+-          case SymDeferred: // 5
+-            szSymType = "-deferred-";
+-            break;
+-          case SymSym: // 6
+-            szSymType = "SYM";
+-            break;
+-          case 7: // SymDia:
+-            szSymType = "DIA";
+-            break;
+-          case 8: //SymVirtual:
+-            szSymType = "Virtual";
+-            break;
+-        }
+-      }
+-      LPCSTR pdbName = Module.LoadedImageName;
+-      if (Module.LoadedPdbName[0] != 0)
+-        pdbName = Module.LoadedPdbName;
+-      this->m_parent->OnLoadModule(img, mod, baseAddr, size, result, szSymType, pdbName,
+-                                   fileVersion);
+-    }
+-    if (szImg != NULL)
+-      free(szImg);
+-    if (szMod != NULL)
+-      free(szMod);
+-    return result;
+-  }
+-
+-public:
+-  BOOL LoadModules(HANDLE hProcess, DWORD dwProcessId)
+-  {
+-    // first try toolhelp32
+-    if (GetModuleListTH32(hProcess, dwProcessId))
+-      return true;
+-    // then try psapi
+-    return GetModuleListPSAPI(hProcess);
+-  }
+-
+-  BOOL GetModuleInfo(HANDLE hProcess, DWORD64 baseAddr, IMAGEHLP_MODULE64_V3* pModuleInfo)
+-  {
+-    memset(pModuleInfo, 0, sizeof(IMAGEHLP_MODULE64_V3));
+-    if (this->pSGMI == NULL)
+-    {
+-      SetLastError(ERROR_DLL_INIT_FAILED);
+-      return FALSE;
+-    }
+-    // First try to use the larger ModuleInfo-Structure
+-    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
+-    void* pData = malloc(
+-        4096); // reserve enough memory, so the bug in v6.3.5.1 does not lead to memory-overwrites...
+-    if (pData == NULL)
+-    {
+-      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+-      return FALSE;
+-    }
+-    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V3));
+-    static bool s_useV3Version = true;
+-    if (s_useV3Version)
+-    {
+-      if (this->pSGMI(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
+-      {
+-        // only copy as much memory as is reserved...
+-        memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V3));
+-        pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
+-        free(pData);
+-        return TRUE;
+-      }
+-      s_useV3Version = false; // to prevent unnecessary calls with the larger struct...
+-    }
+-
+-    // could not retrieve the bigger structure, try with the smaller one (as defined in VC7.1)...
+-    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
+-    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V2));
+-    if (this->pSGMI(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
+-    {
+-      // only copy as much memory as is reserved...
+-      memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V2));
+-      pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
+-      free(pData);
+-      return TRUE;
+-    }
+-    free(pData);
+-    SetLastError(ERROR_DLL_INIT_FAILED);
+-    return FALSE;
+-  }
+-};
+-
+-// #############################################################
+-StackWalker::StackWalker(DWORD dwProcessId, HANDLE hProcess)
+-{
+-  this->m_options = OptionsAll;
+-  this->m_modulesLoaded = FALSE;
+-  this->m_hProcess = hProcess;
+-  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
+-  this->m_dwProcessId = dwProcessId;
+-  this->m_szSymPath = NULL;
+-  this->m_MaxRecursionCount = 1000;
+-}
+-StackWalker::StackWalker(int options, LPCSTR szSymPath, DWORD dwProcessId, HANDLE hProcess)
+-{
+-  this->m_options = options;
+-  this->m_modulesLoaded = FALSE;
+-  this->m_hProcess = hProcess;
+-  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
+-  this->m_dwProcessId = dwProcessId;
+-  if (szSymPath != NULL)
+-  {
+-    this->m_szSymPath = _strdup(szSymPath);
+-    this->m_options |= SymBuildPath;
+-  }
+-  else
+-    this->m_szSymPath = NULL;
+-  this->m_MaxRecursionCount = 1000;
+-}
+-
+-StackWalker::~StackWalker()
+-{
+-  if (m_szSymPath != NULL)
+-    free(m_szSymPath);
+-  m_szSymPath = NULL;
+-  if (this->m_sw != NULL)
+-    delete this->m_sw;
+-  this->m_sw = NULL;
+-}
+-
+-BOOL StackWalker::LoadModules()
+-{
+-  if (this->m_sw == NULL)
+-  {
+-    SetLastError(ERROR_DLL_INIT_FAILED);
+-    return FALSE;
+-  }
+-  if (m_modulesLoaded != FALSE)
+-    return TRUE;
+-
+-  // Build the sym-path:
+-  char* szSymPath = NULL;
+-  if ((this->m_options & SymBuildPath) != 0)
+-  {
+-    const size_t nSymPathLen = 4096;
+-    szSymPath = (char*)malloc(nSymPathLen);
+-    if (szSymPath == NULL)
+-    {
+-      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+-      return FALSE;
+-    }
+-    szSymPath[0] = 0;
+-    // Now first add the (optional) provided sympath:
+-    if (this->m_szSymPath != NULL)
+-    {
+-      strcat_s(szSymPath, nSymPathLen, this->m_szSymPath);
+-      strcat_s(szSymPath, nSymPathLen, ";");
+-    }
+-
+-    strcat_s(szSymPath, nSymPathLen, ".;");
+-
+-    const size_t nTempLen = 1024;
+-    char         szTemp[nTempLen];
+-    // Now add the current directory:
+-    if (GetCurrentDirectoryA(nTempLen, szTemp) > 0)
+-    {
+-      szTemp[nTempLen - 1] = 0;
+-      strcat_s(szSymPath, nSymPathLen, szTemp);
+-      strcat_s(szSymPath, nSymPathLen, ";");
+-    }
+-
+-    // Now add the path for the main-module:
+-    if (GetModuleFileNameA(NULL, szTemp, nTempLen) > 0)
+-    {
+-      szTemp[nTempLen - 1] = 0;
+-      for (char* p = (szTemp + strlen(szTemp) - 1); p >= szTemp; --p)
+-      {
+-        // locate the rightmost path separator
+-        if ((*p == '\\') || (*p == '/') || (*p == ':'))
+-        {
+-          *p = 0;
+-          break;
+-        }
+-      } // for (search for path separator...)
+-      if (strlen(szTemp) > 0)
+-      {
+-        strcat_s(szSymPath, nSymPathLen, szTemp);
+-        strcat_s(szSymPath, nSymPathLen, ";");
+-      }
+-    }
+-    if (GetEnvironmentVariableA("_NT_SYMBOL_PATH", szTemp, nTempLen) > 0)
+-    {
+-      szTemp[nTempLen - 1] = 0;
+-      strcat_s(szSymPath, nSymPathLen, szTemp);
+-      strcat_s(szSymPath, nSymPathLen, ";");
+-    }
+-    if (GetEnvironmentVariableA("_NT_ALTERNATE_SYMBOL_PATH", szTemp, nTempLen) > 0)
+-    {
+-      szTemp[nTempLen - 1] = 0;
+-      strcat_s(szSymPath, nSymPathLen, szTemp);
+-      strcat_s(szSymPath, nSymPathLen, ";");
+-    }
+-    if (GetEnvironmentVariableA("SYSTEMROOT", szTemp, nTempLen) > 0)
+-    {
+-      szTemp[nTempLen - 1] = 0;
+-      strcat_s(szSymPath, nSymPathLen, szTemp);
+-      strcat_s(szSymPath, nSymPathLen, ";");
+-      // also add the "system32"-directory:
+-      strcat_s(szTemp, nTempLen, "\\system32");
+-      strcat_s(szSymPath, nSymPathLen, szTemp);
+-      strcat_s(szSymPath, nSymPathLen, ";");
+-    }
+-
+-    if ((this->m_options & SymUseSymSrv) != 0)
+-    {
+-      if (GetEnvironmentVariableA("SYSTEMDRIVE", szTemp, nTempLen) > 0)
+-      {
+-        szTemp[nTempLen - 1] = 0;
+-        strcat_s(szSymPath, nSymPathLen, "SRV*");
+-        strcat_s(szSymPath, nSymPathLen, szTemp);
+-        strcat_s(szSymPath, nSymPathLen, "\\websymbols");
+-        strcat_s(szSymPath, nSymPathLen, "*http://msdl.microsoft.com/download/symbols;");
+-      }
+-      else
+-        strcat_s(szSymPath, nSymPathLen,
+-                 "SRV*c:\\websymbols*http://msdl.microsoft.com/download/symbols;");
+-    }
+-  } // if SymBuildPath
+-
+-  // First Init the whole stuff...
+-  BOOL bRet = this->m_sw->Init(szSymPath);
+-  if (szSymPath != NULL)
+-    free(szSymPath);
+-  szSymPath = NULL;
+-  if (bRet == FALSE)
+-  {
+-    this->OnDbgHelpErr("Error while initializing dbghelp.dll", 0, 0);
+-    SetLastError(ERROR_DLL_INIT_FAILED);
+-    return FALSE;
+-  }
+-
+-  bRet = this->m_sw->LoadModules(this->m_hProcess, this->m_dwProcessId);
+-  if (bRet != FALSE)
+-    m_modulesLoaded = TRUE;
+-  return bRet;
+-}
+-
+-// The following is used to pass the "userData"-Pointer to the user-provided readMemoryFunction
+-// This has to be done due to a problem with the "hProcess"-parameter in x64...
+-// Because this class is in no case multi-threading-enabled (because of the limitations
+-// of dbghelp.dll) it is "safe" to use a static-variable
+-static StackWalker::PReadProcessMemoryRoutine s_readMemoryFunction = NULL;
+-static LPVOID                                 s_readMemoryFunction_UserData = NULL;
+-
+-BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
+-                                const CONTEXT*            context,
+-                                PReadProcessMemoryRoutine readMemoryFunction,
+-                                LPVOID                    pUserData)
+-{
+-  CONTEXT                                   c;
+-  CallstackEntry                            csEntry;
+-  IMAGEHLP_SYMBOL64*                        pSym = NULL;
+-  StackWalkerInternal::IMAGEHLP_MODULE64_V3 Module;
+-  IMAGEHLP_LINE64                           Line;
+-  int                                       frameNum;
+-  bool                                      bLastEntryCalled = true;
+-  int                                       curRecursionCount = 0;
+-
+-  if (m_modulesLoaded == FALSE)
+-    this->LoadModules(); // ignore the result...
+-
+-  if (this->m_sw->m_hDbhHelp == NULL)
+-  {
+-    SetLastError(ERROR_DLL_INIT_FAILED);
+-    return FALSE;
+-  }
+-
+-  s_readMemoryFunction = readMemoryFunction;
+-  s_readMemoryFunction_UserData = pUserData;
+-
+-  if (context == NULL)
+-  {
+-    // If no context is provided, capture the context
+-    // See: https://stackwalker.codeplex.com/discussions/446958
+-#if _WIN32_WINNT <= 0x0501
+-    // If we need to support XP, we need to use the "old way", because "GetThreadId" is not available!
+-    if (hThread == GetCurrentThread())
+-#else
+-    if (GetThreadId(hThread) == GetCurrentThreadId())
+-#endif
+-    {
+-      GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, USED_CONTEXT_FLAGS);
+-    }
+-    else
+-    {
+-      SuspendThread(hThread);
+-      memset(&c, 0, sizeof(CONTEXT));
+-      c.ContextFlags = USED_CONTEXT_FLAGS;
+-
+-      // TODO: Detect if you want to get a thread context of a different process, which is running a different processor architecture...
+-      // This does only work if we are x64 and the target process is x64 or x86;
+-      // It cannot work, if this process is x64 and the target process is x64... this is not supported...
+-      // See also: http://www.howzatt.demon.co.uk/articles/DebuggingInWin64.html
+-      if (GetThreadContext(hThread, &c) == FALSE)
+-      {
+-        ResumeThread(hThread);
+-        return FALSE;
+-      }
+-    }
+-  }
+-  else
+-    c = *context;
+-
+-  // init STACKFRAME for first call
+-  STACKFRAME64 s; // in/out stackframe
+-  memset(&s, 0, sizeof(s));
+-  DWORD imageType;
+-#ifdef _M_IX86
+-  // normally, call ImageNtHeader() and use machine info from PE header
+-  imageType = IMAGE_FILE_MACHINE_I386;
+-  s.AddrPC.Offset = c.Eip;
+-  s.AddrPC.Mode = AddrModeFlat;
+-  s.AddrFrame.Offset = c.Ebp;
+-  s.AddrFrame.Mode = AddrModeFlat;
+-  s.AddrStack.Offset = c.Esp;
+-  s.AddrStack.Mode = AddrModeFlat;
+-#elif _M_X64
+-  imageType = IMAGE_FILE_MACHINE_AMD64;
+-  s.AddrPC.Offset = c.Rip;
+-  s.AddrPC.Mode = AddrModeFlat;
+-  s.AddrFrame.Offset = c.Rsp;
+-  s.AddrFrame.Mode = AddrModeFlat;
+-  s.AddrStack.Offset = c.Rsp;
+-  s.AddrStack.Mode = AddrModeFlat;
+-#elif _M_IA64
+-  imageType = IMAGE_FILE_MACHINE_IA64;
+-  s.AddrPC.Offset = c.StIIP;
+-  s.AddrPC.Mode = AddrModeFlat;
+-  s.AddrFrame.Offset = c.IntSp;
+-  s.AddrFrame.Mode = AddrModeFlat;
+-  s.AddrBStore.Offset = c.RsBSP;
+-  s.AddrBStore.Mode = AddrModeFlat;
+-  s.AddrStack.Offset = c.IntSp;
+-  s.AddrStack.Mode = AddrModeFlat;
+-#else
+-#error "Platform not supported!"
+-#endif
+-
+-  pSym = (IMAGEHLP_SYMBOL64*)malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+-  if (!pSym)
+-    goto cleanup; // not enough memory...
+-  memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+-  pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+-  pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
+-
+-  memset(&Line, 0, sizeof(Line));
+-  Line.SizeOfStruct = sizeof(Line);
+-
+-  memset(&Module, 0, sizeof(Module));
+-  Module.SizeOfStruct = sizeof(Module);
+-
+-  for (frameNum = 0;; ++frameNum)
+-  {
+-    // get next stack frame (StackWalk64(), SymFunctionTableAccess64(), SymGetModuleBase64())
+-    // if this returns ERROR_INVALID_ADDRESS (487) or ERROR_NOACCESS (998), you can
+-    // assume that either you are done, or that the stack is so hosed that the next
+-    // deeper frame could not be found.
+-    // CONTEXT need not to be supplied if imageTyp is IMAGE_FILE_MACHINE_I386!
+-    if (!this->m_sw->pSW(imageType, this->m_hProcess, hThread, &s, &c, myReadProcMem,
+-                         this->m_sw->pSFTA, this->m_sw->pSGMB, NULL))
+-    {
+-      // INFO: "StackWalk64" does not set "GetLastError"...
+-      this->OnDbgHelpErr("StackWalk64", 0, s.AddrPC.Offset);
+-      break;
+-    }
+-
+-    csEntry.offset = s.AddrPC.Offset;
+-    csEntry.name[0] = 0;
+-    csEntry.undName[0] = 0;
+-    csEntry.undFullName[0] = 0;
+-    csEntry.offsetFromSmybol = 0;
+-    csEntry.offsetFromLine = 0;
+-    csEntry.lineFileName[0] = 0;
+-    csEntry.lineNumber = 0;
+-    csEntry.loadedImageName[0] = 0;
+-    csEntry.moduleName[0] = 0;
+-    if (s.AddrPC.Offset == s.AddrReturn.Offset)
+-    {
+-      if ((this->m_MaxRecursionCount > 0) && (curRecursionCount > m_MaxRecursionCount))
+-      {
+-        this->OnDbgHelpErr("StackWalk64-Endless-Callstack!", 0, s.AddrPC.Offset);
+-        break;
+-      }
+-      curRecursionCount++;
+-    }
+-    else
+-      curRecursionCount = 0;
+-    if (s.AddrPC.Offset != 0)
+-    {
+-      // we seem to have a valid PC
+-      // show procedure info (SymGetSymFromAddr64())
+-      if (this->m_sw->pSGSFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromSmybol),
+-                             pSym) != FALSE)
+-      {
+-        MyStrCpy(csEntry.name, STACKWALK_MAX_NAMELEN, pSym->Name);
+-        // UnDecorateSymbolName()
+-        this->m_sw->pUDSN(pSym->Name, csEntry.undName, STACKWALK_MAX_NAMELEN, UNDNAME_NAME_ONLY);
+-        this->m_sw->pUDSN(pSym->Name, csEntry.undFullName, STACKWALK_MAX_NAMELEN, UNDNAME_COMPLETE);
+-      }
+-      else
+-      {
+-        this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), s.AddrPC.Offset);
+-      }
+-
+-      // show line number info, NT5.0-method (SymGetLineFromAddr64())
+-      if (this->m_sw->pSGLFA != NULL)
+-      { // yes, we have SymGetLineFromAddr64()
+-        if (this->m_sw->pSGLFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromLine),
+-                               &Line) != FALSE)
+-        {
+-          csEntry.lineNumber = Line.LineNumber;
+-          MyStrCpy(csEntry.lineFileName, STACKWALK_MAX_NAMELEN, Line.FileName);
+-        }
+-        else
+-        {
+-          this->OnDbgHelpErr("SymGetLineFromAddr64", GetLastError(), s.AddrPC.Offset);
+-        }
+-      } // yes, we have SymGetLineFromAddr64()
+-
+-      // show module info (SymGetModuleInfo64())
+-      if (this->m_sw->GetModuleInfo(this->m_hProcess, s.AddrPC.Offset, &Module) != FALSE)
+-      { // got module info OK
+-        switch (Module.SymType)
+-        {
+-          case SymNone:
+-            csEntry.symTypeString = "-nosymbols-";
+-            break;
+-          case SymCoff:
+-            csEntry.symTypeString = "COFF";
+-            break;
+-          case SymCv:
+-            csEntry.symTypeString = "CV";
+-            break;
+-          case SymPdb:
+-            csEntry.symTypeString = "PDB";
+-            break;
+-          case SymExport:
+-            csEntry.symTypeString = "-exported-";
+-            break;
+-          case SymDeferred:
+-            csEntry.symTypeString = "-deferred-";
+-            break;
+-          case SymSym:
+-            csEntry.symTypeString = "SYM";
+-            break;
+-#if API_VERSION_NUMBER >= 9
+-          case SymDia:
+-            csEntry.symTypeString = "DIA";
+-            break;
+-#endif
+-          case 8: //SymVirtual:
+-            csEntry.symTypeString = "Virtual";
+-            break;
+-          default:
+-            //_snprintf( ty, sizeof(ty), "symtype=%ld", (long) Module.SymType );
+-            csEntry.symTypeString = NULL;
+-            break;
+-        }
+-
+-        MyStrCpy(csEntry.moduleName, STACKWALK_MAX_NAMELEN, Module.ModuleName);
+-        csEntry.baseOfImage = Module.BaseOfImage;
+-        MyStrCpy(csEntry.loadedImageName, STACKWALK_MAX_NAMELEN, Module.LoadedImageName);
+-      } // got module info OK
+-      else
+-      {
+-        this->OnDbgHelpErr("SymGetModuleInfo64", GetLastError(), s.AddrPC.Offset);
+-      }
+-    } // we seem to have a valid PC
+-
+-    CallstackEntryType et = nextEntry;
+-    if (frameNum == 0)
+-      et = firstEntry;
+-    bLastEntryCalled = false;
+-    this->OnCallstackEntry(et, csEntry);
+-
+-    if (s.AddrReturn.Offset == 0)
+-    {
+-      bLastEntryCalled = true;
+-      this->OnCallstackEntry(lastEntry, csEntry);
+-      SetLastError(ERROR_SUCCESS);
+-      break;
+-    }
+-  } // for ( frameNum )
+-
+-cleanup:
+-  if (pSym)
+-    free(pSym);
+-
+-  if (bLastEntryCalled == false)
+-    this->OnCallstackEntry(lastEntry, csEntry);
+-
+-  if (context == NULL)
+-    ResumeThread(hThread);
+-
+-  return TRUE;
+-}
+-
+-BOOL StackWalker::ShowObject(LPVOID pObject)
+-{
+-  // Load modules if not done yet
+-  if (m_modulesLoaded == FALSE)
+-    this->LoadModules(); // ignore the result...
+-
+-  // Verify that the DebugHelp.dll was actually found
+-  if (this->m_sw->m_hDbhHelp == NULL)
+-  {
+-    SetLastError(ERROR_DLL_INIT_FAILED);
+-    return FALSE;
+-  }
+-
+-  // SymGetSymFromAddr64() is required
+-  if (this->m_sw->pSGSFA == NULL)
+-    return FALSE;
+-
+-  // Show object info (SymGetSymFromAddr64())
+-  DWORD64            dwAddress = DWORD64(pObject);
+-  DWORD64            dwDisplacement = 0;
+-  IMAGEHLP_SYMBOL64* pSym =
+-      (IMAGEHLP_SYMBOL64*)malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+-  memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+-  pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+-  pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
+-  if (this->m_sw->pSGSFA(this->m_hProcess, dwAddress, &dwDisplacement, pSym) == FALSE)
+-  {
+-    this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), dwAddress);
+-    return FALSE;
+-  }
+-  // Object name output
+-  this->OnOutput(pSym->Name);
+-
+-  free(pSym);
+-  return TRUE;
+-};
+-
+-BOOL __stdcall StackWalker::myReadProcMem(HANDLE  hProcess,
+-                                          DWORD64 qwBaseAddress,
+-                                          PVOID   lpBuffer,
+-                                          DWORD   nSize,
+-                                          LPDWORD lpNumberOfBytesRead)
+-{
+-  if (s_readMemoryFunction == NULL)
+-  {
+-    SIZE_T st;
+-    BOOL   bRet = ReadProcessMemory(hProcess, (LPVOID)qwBaseAddress, lpBuffer, nSize, &st);
+-    *lpNumberOfBytesRead = (DWORD)st;
+-    //printf("ReadMemory: hProcess: %p, baseAddr: %p, buffer: %p, size: %d, read: %d, result: %d\n", hProcess, (LPVOID) qwBaseAddress, lpBuffer, nSize, (DWORD) st, (DWORD) bRet);
+-    return bRet;
+-  }
+-  else
+-  {
+-    return s_readMemoryFunction(hProcess, qwBaseAddress, lpBuffer, nSize, lpNumberOfBytesRead,
+-                                s_readMemoryFunction_UserData);
+-  }
+-}
+-
+-void StackWalker::OnLoadModule(LPCSTR    img,
+-                               LPCSTR    mod,
+-                               DWORD64   baseAddr,
+-                               DWORD     size,
+-                               DWORD     result,
+-                               LPCSTR    symType,
+-                               LPCSTR    pdbName,
+-                               ULONGLONG fileVersion)
+-{
+-  CHAR   buffer[STACKWALK_MAX_NAMELEN];
+-  size_t maxLen = STACKWALK_MAX_NAMELEN;
+-#if _MSC_VER >= 1400
+-  maxLen = _TRUNCATE;
+-#endif
+-  if (fileVersion == 0)
+-    _snprintf_s(buffer, maxLen, "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s'\n",
+-                img, mod, (LPVOID)baseAddr, size, result, symType, pdbName);
+-  else
+-  {
+-    DWORD v4 = (DWORD)(fileVersion & 0xFFFF);
+-    DWORD v3 = (DWORD)((fileVersion >> 16) & 0xFFFF);
+-    DWORD v2 = (DWORD)((fileVersion >> 32) & 0xFFFF);
+-    DWORD v1 = (DWORD)((fileVersion >> 48) & 0xFFFF);
+-    _snprintf_s(
+-        buffer, maxLen,
+-        "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s', fileVersion: %d.%d.%d.%d\n",
+-        img, mod, (LPVOID)baseAddr, size, result, symType, pdbName, v1, v2, v3, v4);
+-  }
+-  buffer[STACKWALK_MAX_NAMELEN - 1] = 0; // be sure it is NULL terminated
+-  OnOutput(buffer);
+-}
+-
+-void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry)
+-{
+-  CHAR   buffer[STACKWALK_MAX_NAMELEN];
+-  size_t maxLen = STACKWALK_MAX_NAMELEN;
+-#if _MSC_VER >= 1400
+-  maxLen = _TRUNCATE;
+-#endif
+-  if ((eType != lastEntry) && (entry.offset != 0))
+-  {
+-    if (entry.name[0] == 0)
+-      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, "(function-name not available)");
+-    if (entry.undName[0] != 0)
+-      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undName);
+-    if (entry.undFullName[0] != 0)
+-      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undFullName);
+-    if (entry.lineFileName[0] == 0)
+-    {
+-      MyStrCpy(entry.lineFileName, STACKWALK_MAX_NAMELEN, "(filename not available)");
+-      if (entry.moduleName[0] == 0)
+-        MyStrCpy(entry.moduleName, STACKWALK_MAX_NAMELEN, "(module-name not available)");
+-      _snprintf_s(buffer, maxLen, "%p (%s): %s: %s\n", (LPVOID)entry.offset, entry.moduleName,
+-                  entry.lineFileName, entry.name);
+-    }
+-    else
+-      _snprintf_s(buffer, maxLen, "%s (%d): %s\n", entry.lineFileName, entry.lineNumber,
+-                  entry.name);
+-    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+-    OnOutput(buffer);
+-  }
+-}
+-
+-void StackWalker::OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr)
+-{
+-  CHAR   buffer[STACKWALK_MAX_NAMELEN];
+-  size_t maxLen = STACKWALK_MAX_NAMELEN;
+-#if _MSC_VER >= 1400
+-  maxLen = _TRUNCATE;
+-#endif
+-  _snprintf_s(buffer, maxLen, "ERROR: %s, GetLastError: %d (Address: %p)\n", szFuncName, gle,
+-              (LPVOID)addr);
+-  buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+-  OnOutput(buffer);
+-}
+-
+-void StackWalker::OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName)
+-{
+-  CHAR   buffer[STACKWALK_MAX_NAMELEN];
+-  size_t maxLen = STACKWALK_MAX_NAMELEN;
+-#if _MSC_VER >= 1400
+-  maxLen = _TRUNCATE;
+-#endif
+-  _snprintf_s(buffer, maxLen, "SymInit: Symbol-SearchPath: '%s', symOptions: %d, UserName: '%s'\n",
+-              szSearchPath, symOptions, szUserName);
+-  buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+-  OnOutput(buffer);
+-  // Also display the OS-version
+-#if _MSC_VER <= 1200
+-  OSVERSIONINFOA ver;
+-  ZeroMemory(&ver, sizeof(OSVERSIONINFOA));
+-  ver.dwOSVersionInfoSize = sizeof(ver);
+-  if (GetVersionExA(&ver) != FALSE)
+-  {
+-    _snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s)\n", ver.dwMajorVersion,
+-                ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion);
+-    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+-    OnOutput(buffer);
+-  }
+-#else
+-  OSVERSIONINFOEXA ver;
+-  ZeroMemory(&ver, sizeof(OSVERSIONINFOEXA));
+-  ver.dwOSVersionInfoSize = sizeof(ver);
+-#if _MSC_VER >= 1900
+-#pragma warning(push)
+-#pragma warning(disable : 4996)
+-#endif
+-  if (GetVersionExA((OSVERSIONINFOA*)&ver) != FALSE)
+-  {
+-    _snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s) 0x%x-0x%x\n", ver.dwMajorVersion,
+-                ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion, ver.wSuiteMask,
+-                ver.wProductType);
+-    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+-    OnOutput(buffer);
+-  }
+-#if _MSC_VER >= 1900
+-#pragma warning(pop)
+-#endif
+-#endif
+-}
+-
+-void StackWalker::OnOutput(LPCSTR buffer)
+-{
+-  OutputDebugStringA(buffer);
+-}
++﻿/**********************************************************************
++ *
++ * StackWalker.cpp
++ * https://github.com/JochenKalmbach/StackWalker
++ *
++ * Old location: http://stackwalker.codeplex.com/
++ *
++ *
++ * History:
++ *  2005-07-27   v1    - First public release on http://www.codeproject.com/
++ *                       http://www.codeproject.com/threads/StackWalker.asp
++ *  2005-07-28   v2    - Changed the params of the constructor and ShowCallstack
++ *                       (to simplify the usage)
++ *  2005-08-01   v3    - Changed to use 'CONTEXT_FULL' instead of CONTEXT_ALL
++ *                       (should also be enough)
++ *                     - Changed to compile correctly with the PSDK of VC7.0
++ *                       (GetFileVersionInfoSizeA and GetFileVersionInfoA is wrongly defined:
++ *                        it uses LPSTR instead of LPCSTR as first parameter)
++ *                     - Added declarations to support VC5/6 without using 'dbghelp.h'
++ *                     - Added a 'pUserData' member to the ShowCallstack function and the
++ *                       PReadProcessMemoryRoutine declaration (to pass some user-defined data,
++ *                       which can be used in the readMemoryFunction-callback)
++ *  2005-08-02   v4    - OnSymInit now also outputs the OS-Version by default
++ *                     - Added example for doing an exception-callstack-walking in main.cpp
++ *                       (thanks to owillebo: http://www.codeproject.com/script/profile/whos_who.asp?id=536268)
++ *  2005-08-05   v5    - Removed most Lint (http://www.gimpel.com/) errors... thanks to Okko Willeboordse!
++ *  2008-08-04   v6    - Fixed Bug: Missing LEAK-end-tag
++ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2502890#xx2502890xx
++ *                       Fixed Bug: Compiled with "WIN32_LEAN_AND_MEAN"
++ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=1824718#xx1824718xx
++ *                       Fixed Bug: Compiling with "/Wall"
++ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2638243#xx2638243xx
++ *                       Fixed Bug: Now checking SymUseSymSrv
++ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1388979#xx1388979xx
++ *                       Fixed Bug: Support for recursive function calls
++ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1434538#xx1434538xx
++ *                       Fixed Bug: Missing FreeLibrary call in "GetModuleListTH32"
++ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1326923#xx1326923xx
++ *                       Fixed Bug: SymDia is number 7, not 9!
++ *  2008-09-11   v7      For some (undocumented) reason, dbhelp.h is needing a packing of 8!
++ *                       Thanks to Teajay which reported the bug...
++ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2718933#xx2718933xx
++ *  2008-11-27   v8      Debugging Tools for Windows are now stored in a different directory
++ *                       Thanks to Luiz Salamon which reported this "bug"...
++ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2822736#xx2822736xx
++ *  2009-04-10   v9      License slightly corrected (<ORGANIZATION> replaced)
++ *  2009-11-01   v10     Moved to http://stackwalker.codeplex.com/
++ *  2009-11-02   v11     Now try to use IMAGEHLP_MODULE64_V3 if available
++ *  2010-04-15   v12     Added support for VS2010 RTM
++ *  2010-05-25   v13     Now using secure MyStrcCpy. Thanks to luke.simon:
++ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=3477467#xx3477467xx
++ *  2013-01-07   v14     Runtime Check Error VS2010 Debug Builds fixed:
++ *                       http://stackwalker.codeplex.com/workitem/10511
++ *
++ *
++ * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
++ *
++ *   Copyright (c) 2005-2013, Jochen Kalmbach
++ *   All rights reserved.
++ *
++ *   Redistribution and use in source and binary forms, with or without modification,
++ *   are permitted provided that the following conditions are met:
++ *
++ *   Redistributions of source code must retain the above copyright notice,
++ *   this list of conditions and the following disclaimer.
++ *   Redistributions in binary form must reproduce the above copyright notice,
++ *   this list of conditions and the following disclaimer in the documentation
++ *   and/or other materials provided with the distribution.
++ *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
++ *   used to endorse or promote products derived from this software without
++ *   specific prior written permission.
++ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++ *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
++ *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
++ *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++ *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++ *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++ *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++ *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++ *
++ **********************************************************************/
++
++#include "StackWalker.h"
++
++#include <stdio.h>
++#include <stdlib.h>
++#include <tchar.h>
++#pragma comment(lib, "version.lib") // for "VerQueryValue"
++#pragma warning(disable : 4826)
++
++#ifdef UNICODE
++  #define DBGHELP_TRANSLATE_TCHAR
++
++#endif
++#pragma pack(push, 8)
++#include <dbghelp.h>
++#pragma pack(pop)
++
++
++static void MyStrCpy(TCHAR* szDest, size_t nMaxDestSize, const TCHAR* szSrc)
++{
++  if (nMaxDestSize <= 0)
++    return;
++  _tcsncpy_s(szDest, nMaxDestSize, szSrc, _TRUNCATE);
++  // INFO: _TRUNCATE will ensure that it is null-terminated;
++  // but with older compilers (<1400) it uses "strncpy" and this does not!)
++  szDest[nMaxDestSize - 1] = 0;
++} // MyStrCpy
++
++#ifdef _UNICODE
++  typedef SYMBOL_INFOW   tSymbolInfo;
++  typedef IMAGEHLP_LINEW64  tImageHelperLine;
++#else
++  typedef SYMBOL_INFO   tSymbolInfo;
++  typedef IMAGEHLP_LINE64  tImageHelperLine;
++#endif
++
++// Normally it should be enough to use 'CONTEXT_FULL' (better would be 'CONTEXT_ALL')
++#define USED_CONTEXT_FLAGS CONTEXT_FULL
++
++class StackWalkerInternal
++{
++public:
++  StackWalkerInternal(StackWalker* parent, HANDLE hProcess)
++  {
++    m_parent = parent;
++    m_hDbhHelp = NULL;
++    symCleanup = NULL;
++    m_hProcess = hProcess;
++    m_szSymPath = NULL;
++    symFunctionTableAccess64 = NULL;
++    symGetLineFromAddr64 = NULL;
++    symGetModuleBase64 = NULL;
++    symGetModuleInfo64 = NULL;
++    symGetOptions = NULL;
++    symFromAddr = NULL;
++    symInitialize = NULL;
++    symLoadModuleEx = NULL;
++    symSetOptions = NULL;
++    stackWalk64 = NULL;
++    unDecorateSymbolName = NULL;
++    symGetSearchPath = NULL;
++  }
++  ~StackWalkerInternal()
++  {
++    if (symCleanup != NULL)
++      symCleanup(m_hProcess); // SymCleanup
++    if (m_hDbhHelp != NULL)
++      FreeLibrary(m_hDbhHelp);
++    m_hDbhHelp = NULL;
++    m_parent = NULL;
++    if (m_szSymPath != NULL)
++      free(m_szSymPath);
++    m_szSymPath = NULL;
++  }
++  BOOL Init(LPCTSTR szSymPath)
++  {
++    if (m_parent == NULL)
++      return FALSE;
++    // Dynamically load the Entry-Points for dbghelp.dll:
++    // First try to load the newest one from
++    TCHAR szTemp[4096];
++    // But before we do this, we first check if the ".local" file exists
++    if (GetModuleFileName(NULL, szTemp, 4096) > 0)
++    {
++      _tcscat_s(szTemp, _T(".local"));
++      if (GetFileAttributes(szTemp) == INVALID_FILE_ATTRIBUTES)
++      {
++        // ".local" file does not exist, so we can try to load the dbghelp.dll from the "Debugging Tools for Windows"
++        // Ok, first try the new path according to the architecture:
++#ifdef _M_IX86
++        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
++        {
++          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x86)\\dbghelp.dll"));
++          // now check if the file exists:
++          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
++          {
++            m_hDbhHelp = LoadLibrary(szTemp);
++          }
++        }
++#elif _M_X64
++        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
++        {
++          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x64)\\dbghelp.dll"));
++          // now check if the file exists:
++          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
++          {
++            m_hDbhHelp = LoadLibrary(szTemp);
++          }
++        }
++#elif _M_IA64
++        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
++        {
++          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (ia64)\\dbghelp.dll"));
++          // now check if the file exists:
++          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
++          {
++            m_hDbhHelp = LoadLibrary(szTemp);
++          }
++        }
++#endif
++        // If still not found, try the old directories...
++        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
++        {
++          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows\\dbghelp.dll"));
++          // now check if the file exists:
++          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
++          {
++            m_hDbhHelp = LoadLibrary(szTemp);
++          }
++        }
++#if defined _M_X64 || defined _M_IA64
++        // Still not found? Then try to load the (old) 64-Bit version:
++        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
++        {
++          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows 64-Bit\\dbghelp.dll"));
++          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
++          {
++            m_hDbhHelp = LoadLibrary(szTemp);
++          }
++        }
++#endif
++      }
++    }
++    if (m_hDbhHelp == NULL) // if not already loaded, try to load a default-one
++      m_hDbhHelp = LoadLibrary(_T("dbghelp.dll"));
++    if (m_hDbhHelp == NULL)
++      return FALSE;
++
++#ifdef _UNICODE
++    static const char strSymInitialize[] = "SymInitializeW";
++    static const char strUnDecorateSymbolName[] = "UnDecorateSymbolNameW";
++    static const char strSymGetSearchPath[] = "SymGetSearchPathW";
++    static const char strSymLoadModuleEx[] = "SymLoadModuleExW";
++    static const char strSymGetLineFromAddr64[] = "SymGetLineFromAddrW64";
++    static const char strSymGetModuleInfo64[] = "SymGetModuleInfoW64";
++    static const char strSymFromAddr[] = "SymFromAddrW";
++#else
++    static const char strSymInitialize[] = "SymInitialize";
++    static const char strUnDecorateSymbolName[] = "UnDecorateSymbolName";
++    static const char strSymGetSearchPath[] = "SymGetSearchPath";
++    static const char strSymLoadModuleEx[] = "SymLoadModuleEx";
++    static const char strSymGetLineFromAddr64[] = "SymGetLineFromAddr64";
++    static const char strSymGetModuleInfo64[] = "SymGetModuleInfo64";
++    static const char strSymFromAddr[] = "SymFromAddr";
++#endif
++    symInitialize = (tSI)GetProcAddress(m_hDbhHelp, strSymInitialize);
++    symCleanup = (tSC)GetProcAddress(m_hDbhHelp, "SymCleanup");
++
++    stackWalk64 = (tSW)GetProcAddress(m_hDbhHelp, "StackWalk64");
++    symGetOptions = (tSGO)GetProcAddress(m_hDbhHelp, "SymGetOptions");
++    symSetOptions = (tSSO)GetProcAddress(m_hDbhHelp, "SymSetOptions");
++
++    symFunctionTableAccess64 = (tSFTA)GetProcAddress(m_hDbhHelp, "SymFunctionTableAccess64");
++    symGetLineFromAddr64 = (tSGLFA)GetProcAddress(m_hDbhHelp, strSymGetLineFromAddr64);
++    symGetModuleBase64 = (tSGMB)GetProcAddress(m_hDbhHelp, "SymGetModuleBase64");
++    symGetModuleInfo64 = (tSGMI)GetProcAddress(m_hDbhHelp, strSymGetModuleInfo64);
++    symFromAddr = (tSFA)GetProcAddress(m_hDbhHelp, strSymFromAddr);
++    unDecorateSymbolName = (tUDSN)GetProcAddress(m_hDbhHelp, strUnDecorateSymbolName);
++    symLoadModuleEx = (tSLM)GetProcAddress(m_hDbhHelp, strSymLoadModuleEx);
++    symGetSearchPath = (tSGSP)GetProcAddress(m_hDbhHelp, strSymGetSearchPath);
++
++    if (symCleanup == NULL || symFunctionTableAccess64 == NULL || symGetModuleBase64 == NULL || symGetModuleInfo64 == NULL || symGetOptions == NULL ||
++        symFromAddr == NULL || symInitialize == NULL || symSetOptions == NULL || stackWalk64 == NULL || unDecorateSymbolName == NULL ||
++        symLoadModuleEx == NULL)
++    {
++      FreeLibrary(m_hDbhHelp);
++      m_hDbhHelp = NULL;
++      symCleanup = NULL;
++      return FALSE;
++    }
++
++    // SymInitialize
++    if (szSymPath != NULL)
++      m_szSymPath = _tcsdup(szSymPath);
++    if (this->symInitialize(m_hProcess, m_szSymPath, FALSE) == FALSE)
++      this->m_parent->OnDbgHelpErr(_T("SymInitialize"), GetLastError(), 0);
++
++    DWORD symOptions = this->symGetOptions(); // SymGetOptions
++    symOptions |= SYMOPT_LOAD_LINES;
++    symOptions |= SYMOPT_FAIL_CRITICAL_ERRORS;
++    //symOptions |= SYMOPT_NO_PROMPTS;
++    // SymSetOptions
++    symOptions = this->symSetOptions(symOptions);
++
++    TCHAR buf[StackWalker::STACKWALK_MAX_NAMELEN] = {0};
++    if (this->symGetSearchPath != NULL)
++    {
++      if (this->symGetSearchPath(m_hProcess, buf, StackWalker::STACKWALK_MAX_NAMELEN) == FALSE)
++        this->m_parent->OnDbgHelpErr(_T("SymGetSearchPath"), GetLastError(), 0);
++    }
++    TCHAR  szUserName[1024] = {0};
++    DWORD dwSize = 1024;
++    GetUserName(szUserName, &dwSize);
++    this->m_parent->OnSymInit(buf, symOptions, szUserName);
++
++    return TRUE;
++  }
++
++  StackWalker* m_parent;
++
++  HMODULE m_hDbhHelp;
++  HANDLE  m_hProcess;
++  LPTSTR   m_szSymPath;
++
++#pragma pack(push, 8)
++  typedef struct IMAGEHLP_MODULE64_V3
++  {
++    DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
++    DWORD64  BaseOfImage;          // base load address of module
++    DWORD    ImageSize;            // virtual size of the loaded module
++    DWORD    TimeDateStamp;        // date/time stamp from pe header
++    DWORD    CheckSum;             // checksum from the pe header
++    DWORD    NumSyms;              // number of symbols in the symbol table
++    SYM_TYPE SymType;              // type of symbols loaded
++    TCHAR     ModuleName[32];       // module name
++    TCHAR     ImageName[256];       // image name
++    TCHAR     LoadedImageName[256]; // symbol file name
++    // new elements: 07-Jun-2002
++    TCHAR  LoadedPdbName[256];   // pdb file name
++    DWORD CVSig;                // Signature of the CV record in the debug directories
++    TCHAR  CVData[MAX_PATH * 3]; // Contents of the CV record
++    DWORD PdbSig;               // Signature of PDB
++    GUID  PdbSig70;             // Signature of PDB (VC 7 and up)
++    DWORD PdbAge;               // DBI age of pdb
++    BOOL  PdbUnmatched;         // loaded an unmatched pdb
++    BOOL  DbgUnmatched;         // loaded an unmatched dbg
++    BOOL  LineNumbers;          // we have line number information
++    BOOL  GlobalSymbols;        // we have internal symbol information
++    BOOL  TypeInfo;             // we have type information
++    // new elements: 17-Dec-2003
++    BOOL SourceIndexed; // pdb supports source server
++    BOOL Publics;       // contains public symbols
++  };
++
++  typedef struct IMAGEHLP_MODULE64_V2
++  {
++    DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
++    DWORD64  BaseOfImage;          // base load address of module
++    DWORD    ImageSize;            // virtual size of the loaded module
++    DWORD    TimeDateStamp;        // date/time stamp from pe header
++    DWORD    CheckSum;             // checksum from the pe header
++    DWORD    NumSyms;              // number of symbols in the symbol table
++    SYM_TYPE SymType;              // type of symbols loaded
++    CHAR     ModuleName[32];       // module name
++    CHAR     ImageName[256];       // image name
++    CHAR     LoadedImageName[256]; // symbol file name
++  };
++#pragma pack(pop)
++
++  // SymCleanup()
++  typedef BOOL(__stdcall* tSC)(IN HANDLE hProcess);
++  tSC symCleanup;
++
++  // SymFunctionTableAccess64()
++  typedef PVOID(__stdcall* tSFTA)(HANDLE hProcess, DWORD64 AddrBase);
++  tSFTA symFunctionTableAccess64;
++
++  // SymGetLineFromAddr64()
++  typedef BOOL(__stdcall* tSGLFA)(IN HANDLE hProcess,
++                                  IN DWORD64 dwAddr,
++                                  OUT PDWORD pdwDisplacement,
++                                  OUT tImageHelperLine* Line);
++  tSGLFA symGetLineFromAddr64;
++
++  // SymGetModuleBase64()
++  typedef DWORD64(__stdcall* tSGMB)(IN HANDLE hProcess, IN DWORD64 dwAddr);
++  tSGMB symGetModuleBase64;
++
++  // SymGetModuleInfo64()
++  typedef BOOL(__stdcall* tSGMI)(IN HANDLE hProcess,
++                                 IN DWORD64 dwAddr,
++                                 OUT IMAGEHLP_MODULE64_V3* ModuleInfo);
++  tSGMI symGetModuleInfo64;
++
++  // SymGetOptions()
++  typedef DWORD(__stdcall* tSGO)(VOID);
++  tSGO symGetOptions;
++
++
++  // SymGetSymFromAddr64()
++  typedef BOOL(__stdcall* tSFA)(IN HANDLE hProcess,
++                                  IN DWORD64 Address,
++                                  OUT PDWORD64 pdwDisplacement,
++                                  OUT tSymbolInfo* Symbol);
++  tSFA symFromAddr;
++
++  // SymInitialize()
++  typedef BOOL(__stdcall* tSI)(IN HANDLE hProcess, IN PTSTR UserSearchPath, IN BOOL fInvadeProcess);
++  tSI symInitialize;
++
++  // SymLoadModule64()
++  typedef DWORD64(__stdcall* tSLM)(IN HANDLE hProcess,
++                                   IN HANDLE hFile,
++                                   IN PTSTR ImageName,
++                                   IN PTSTR ModuleName,
++                                   IN DWORD64 BaseOfDll,
++                                   IN DWORD SizeOfDll,
++                                   IN PMODLOAD_DATA Data,
++                                   IN DWORD         Flags);
++  tSLM symLoadModuleEx;
++
++  // SymSetOptions()
++  typedef DWORD(__stdcall* tSSO)(IN DWORD SymOptions);
++  tSSO symSetOptions;
++
++  // StackWalk64()
++  typedef BOOL(__stdcall* tSW)(DWORD                            MachineType,
++                               HANDLE                           hProcess,
++                               HANDLE                           hThread,
++                               LPSTACKFRAME64                   StackFrame,
++                               PVOID                            ContextRecord,
++                               PREAD_PROCESS_MEMORY_ROUTINE64   ReadMemoryRoutine,
++                               PFUNCTION_TABLE_ACCESS_ROUTINE64 FunctionTableAccessRoutine,
++                               PGET_MODULE_BASE_ROUTINE64       GetModuleBaseRoutine,
++                               PTRANSLATE_ADDRESS_ROUTINE64     TranslateAddress);
++  tSW stackWalk64;
++
++  // UnDecorateSymbolName()
++  typedef DWORD(__stdcall WINAPI* tUDSN)(PCTSTR DecoratedName,
++                                         PTSTR  UnDecoratedName,
++                                         DWORD UndecoratedLength,
++                                         DWORD Flags);
++  tUDSN unDecorateSymbolName;
++
++  typedef BOOL(__stdcall WINAPI* tSGSP)(HANDLE hProcess, PTSTR SearchPath, DWORD SearchPathLength);
++  tSGSP symGetSearchPath;
++
++private:
++// **************************************** ToolHelp32 ************************
++#define MAX_MODULE_NAME32 255
++#define TH32CS_SNAPMODULE 0x00000008
++#pragma pack(push, 8)
++  typedef struct tagMODULEENTRY32
++  {
++    DWORD   dwSize;
++    DWORD   th32ModuleID;  // This module
++    DWORD   th32ProcessID; // owning process
++    DWORD   GlblcntUsage;  // Global usage count on the module
++    DWORD   ProccntUsage;  // Module usage count in th32ProcessID's context
++    BYTE*   modBaseAddr;   // Base address of module in th32ProcessID's context
++    DWORD   modBaseSize;   // Size in bytes of module starting at modBaseAddr
++    HMODULE hModule;       // The hModule of this module in th32ProcessID's context
++    TCHAR   szModule[MAX_MODULE_NAME32 + 1];
++    TCHAR   szExePath[MAX_PATH];
++  } MODULEENTRY32;
++  typedef MODULEENTRY32* PMODULEENTRY32;
++  typedef MODULEENTRY32* LPMODULEENTRY32;
++#pragma pack(pop)
++
++  BOOL GetModuleListTH32(HANDLE hProcess, DWORD pid)
++  {
++    // CreateToolhelp32Snapshot()
++    typedef HANDLE(__stdcall * tCT32S)(DWORD dwFlags, DWORD th32ProcessID);
++    // Module32First()
++    typedef BOOL(__stdcall * tM32F)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
++    // Module32Next()
++    typedef BOOL(__stdcall * tM32N)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
++
++    // try both dlls...
++    const TCHAR* dllname[] = {_T("kernel32.dll"), _T("tlhelp32.dll")};
++    HINSTANCE    hToolhelp = NULL;
++    tCT32S       createToolhelp32Snapshot = NULL;
++    tM32F        module32First = NULL;
++    tM32N        module32Next = NULL;
++
++    HANDLE        hSnap;
++    MODULEENTRY32 moduleEntry32;
++    moduleEntry32.dwSize = sizeof(moduleEntry32);
++    BOOL   keepGoing;
++
++#ifdef _UNICODE
++    static const char strModule32First[] = "Module32FirstW";
++    static const char strModule32Next[] = "Module32NextW";
++ #else
++    static const char strModule32First[] = "Module32First";
++    static const char strModule32Next[] = "Module32Next";
++#endif
++    for (size_t i = 0; i < (sizeof(dllname) / sizeof(dllname[0])); i++)
++    {
++      hToolhelp = LoadLibrary(dllname[i]);
++      if (hToolhelp == NULL)
++        continue;
++      createToolhelp32Snapshot = (tCT32S)GetProcAddress(hToolhelp, "CreateToolhelp32Snapshot");
++      module32First = (tM32F)GetProcAddress(hToolhelp, strModule32First);  
++      module32Next = (tM32N)GetProcAddress(hToolhelp, strModule32Next); 
++      if ((createToolhelp32Snapshot != NULL) && (module32First != NULL) && (module32Next != NULL))
++        break; // found the functions!
++      FreeLibrary(hToolhelp);
++      hToolhelp = NULL;
++    }
++
++    if (hToolhelp == NULL)
++      return FALSE;
++
++    hSnap = createToolhelp32Snapshot(TH32CS_SNAPMODULE, pid);
++    if (hSnap == (HANDLE)-1)
++    {
++      FreeLibrary(hToolhelp);
++      return FALSE;
++    }
++
++    keepGoing = !!module32First(hSnap, &moduleEntry32);
++    int cnt = 0;
++    while (keepGoing)
++    {
++      this->LoadModule(hProcess, moduleEntry32.szExePath, moduleEntry32.szModule, (DWORD64)moduleEntry32.modBaseAddr,
++                       moduleEntry32.modBaseSize);
++      cnt++;
++      keepGoing = !!module32Next(hSnap, &moduleEntry32);
++    }
++    CloseHandle(hSnap);
++    FreeLibrary(hToolhelp);
++    if (cnt <= 0)
++      return FALSE;
++    return TRUE;
++  } // GetModuleListTH32
++
++  // **************************************** PSAPI ************************
++  typedef struct _MODULEINFO
++  {
++    LPVOID lpBaseOfDll;
++    DWORD  SizeOfImage;
++    LPVOID EntryPoint;
++  } MODULEINFO, *LPMODULEINFO;
++
++  BOOL GetModuleListPSAPI(HANDLE hProcess)
++  {
++    // EnumProcessModules()
++    typedef BOOL(__stdcall * tEPM)(HANDLE hProcess, HMODULE * lphModule, DWORD cb,
++                                   LPDWORD lpcbNeeded);
++    // GetModuleFileNameEx()
++    typedef DWORD(__stdcall * tGMFNE)(HANDLE hProcess, HMODULE hModule, LPTSTR lpFilename,
++                                      DWORD nSize);
++    // GetModuleBaseName()
++    typedef DWORD(__stdcall * tGMBN)(HANDLE hProcess, HMODULE hModule, LPTSTR lpFilename,
++                                     DWORD nSize);
++    // GetModuleInformation()
++    typedef BOOL(__stdcall * tGMI)(HANDLE hProcess, HMODULE hModule, LPMODULEINFO pmi, DWORD nSize);
++
++      //ModuleEntry e;
++    DWORD        cbNeeded;
++    MODULEINFO   mi;
++    HMODULE*     hMods = 0;
++    TCHAR*        tt = NULL;
++    TCHAR*        tt2 = NULL;
++    const SIZE_T TTBUFLEN = 8096;
++    int          cnt = 0;
++
++    HINSTANCE hPsapi = LoadLibrary(_T("psapi.dll"));
++    if (hPsapi == NULL)
++      return FALSE;
++
++#ifdef _UNICODE
++    static const char strGetModuleFileName[] = "GetModuleFileNameExW";
++    static const char strGetModuleBaseName[] = "GetModuleBaseNameW";
++#else
++    static const char strGetModuleFileName[] = "GetModulefileNameExA";
++    static const char strGetModuleBaseName[] = "GetModuleBaseNameA";
++#endif
++
++    tEPM   enumProcessModules = (tEPM)GetProcAddress(hPsapi, "EnumProcessModules");
++    tGMFNE getModuleFileNameEx = (tGMFNE)GetProcAddress(hPsapi, strGetModuleFileName);
++    tGMBN  getModuleBaseName = (tGMFNE)GetProcAddress(hPsapi, strGetModuleBaseName);
++    tGMI   getModuleInformation = (tGMI)GetProcAddress(hPsapi, "GetModuleInformation");
++    if ((enumProcessModules == NULL) || (getModuleFileNameEx == NULL) ||
++        (getModuleBaseName == NULL) || (getModuleInformation == NULL))
++    {
++      // we couldn't find all functions
++      FreeLibrary(hPsapi);
++      return FALSE;
++    }
++
++    hMods = (HMODULE*)malloc(sizeof(HMODULE) * (TTBUFLEN / sizeof(HMODULE)));
++    tt = (TCHAR*)malloc(sizeof(TCHAR) * TTBUFLEN);
++    tt2 = (TCHAR*)malloc(sizeof(TCHAR) * TTBUFLEN);
++    if ((hMods == NULL) || (tt == NULL) || (tt2 == NULL))
++      goto cleanup;
++
++    if (!enumProcessModules(hProcess, hMods, TTBUFLEN, &cbNeeded))
++    {
++      //_ftprintf(fLogFile, _T("%lu: EPM failed, GetLastError = %lu\n"), g_dwShowCount, gle );
++      goto cleanup;
++    }
++
++    if (cbNeeded > TTBUFLEN)
++    {
++      //_ftprintf(fLogFile, _T("%lu: More than %lu module handles. Huh?\n"), g_dwShowCount, lenof( hMods ) );
++      goto cleanup;
++    }
++
++    for (DWORD i = 0; i < cbNeeded / sizeof(hMods[0]); i++)
++    {
++      // base address, size
++      getModuleInformation(hProcess, hMods[i], &mi, sizeof(mi));
++      // image file name
++      tt[0] = 0;
++      getModuleFileNameEx(hProcess, hMods[i], tt, TTBUFLEN);
++      // module name
++      tt2[0] = 0;
++      getModuleBaseName(hProcess, hMods[i], tt2, TTBUFLEN);
++
++      DWORD dwRes = this->LoadModule(hProcess, tt, tt2, (DWORD64)mi.lpBaseOfDll, mi.SizeOfImage);
++      if (dwRes != ERROR_SUCCESS)
++        this->m_parent->OnDbgHelpErr(_T("LoadModule"), dwRes, 0);
++      cnt++;
++    }
++
++  cleanup:
++    if (hPsapi != NULL)
++      FreeLibrary(hPsapi);
++    if (tt2 != NULL)
++      free(tt2);
++    if (tt != NULL)
++      free(tt);
++    if (hMods != NULL)
++      free(hMods);
++
++    return cnt != 0;
++  } // GetModuleListPSAPI
++
++  DWORD LoadModule(HANDLE hProcess, LPCTSTR img, LPCTSTR mod, DWORD64 baseAddr, DWORD size)
++  {
++    TCHAR* szImg = _tcsdup(img);
++    TCHAR* szMod = _tcsdup(mod);
++    DWORD result = ERROR_SUCCESS;
++    if ((szImg == NULL) || (szMod == NULL))
++      result = ERROR_NOT_ENOUGH_MEMORY;
++    else
++    {
++      if (symLoadModuleEx(hProcess, 0, szImg, szMod, baseAddr, size, 0, 0) == 0)
++        result = GetLastError();
++    }
++    ULONGLONG fileVersion = 0;
++    if ((m_parent != NULL) && (szImg != NULL))
++    {
++      // try to retrieve the file-version:
++      if ((this->m_parent->m_options & StackWalker::RetrieveFileVersion) != 0)
++      {
++        VS_FIXEDFILEINFO* fInfo = NULL;
++        DWORD             dwHandle;
++        DWORD             dwSize = GetFileVersionInfoSize(szImg, &dwHandle);
++        if (dwSize > 0)
++        {
++          LPVOID vData = malloc(dwSize);
++          if (vData != NULL)
++          {
++            if (GetFileVersionInfo(szImg, dwHandle, dwSize, vData) != 0)
++            {
++              UINT  len;
++              TCHAR szSubBlock[] = _T("\\");
++              if (VerQueryValue(vData, szSubBlock, (LPVOID*)&fInfo, &len) == 0)
++                fInfo = NULL;
++              else
++              {
++                fileVersion =
++                    ((ULONGLONG)fInfo->dwFileVersionLS) + ((ULONGLONG)fInfo->dwFileVersionMS << 32);
++              }
++            }
++            free(vData);
++          }
++        }
++      }
++
++      // Retrieve some additional-infos about the module
++      IMAGEHLP_MODULE64_V3 Module;
++      const TCHAR*          szSymType = _T("-unknown-");
++      if (this->GetModuleInfo(hProcess, baseAddr, &Module) != FALSE)
++      {
++        switch (Module.SymType)
++        {
++          case SymNone:
++            szSymType = _T("-nosymbols-");
++            break;
++          case SymCoff: // 1
++            szSymType = _T("COFF");
++            break;
++          case SymCv: // 2
++            szSymType = _T("CV");
++            break;
++          case SymPdb: // 3
++            szSymType = _T("PDB");
++            break;
++          case SymExport: // 4
++            szSymType = _T("-exported-");
++            break;
++          case SymDeferred: // 5
++            szSymType = _T("-deferred-");
++            break;
++          case SymSym: // 6
++            szSymType = _T("SYM");
++            break;
++          case 7: // SymDia:
++            szSymType = _T("DIA");
++            break;
++          case 8: //SymVirtual:
++            szSymType = _T("Virtual");
++            break;
++        }
++      }
++      LPCTSTR pdbName = Module.LoadedImageName;
++      if (Module.LoadedPdbName[0] != 0)
++        pdbName = Module.LoadedPdbName;
++      this->m_parent->OnLoadModule(img, mod, baseAddr, size, result, szSymType, pdbName,
++                                   fileVersion);
++    }
++    if (szImg != NULL)
++      free(szImg);
++    if (szMod != NULL)
++      free(szMod);
++    return result;
++  }
++
++public:
++  BOOL LoadModules(HANDLE hProcess, DWORD dwProcessId)
++  {
++    // first try toolhelp32
++    if (GetModuleListTH32(hProcess, dwProcessId))
++      return true;
++    // then try psapi
++    return GetModuleListPSAPI(hProcess);
++  }
++
++  BOOL GetModuleInfo(HANDLE hProcess, DWORD64 baseAddr, IMAGEHLP_MODULE64_V3* pModuleInfo)
++  {
++    memset(pModuleInfo, 0, sizeof(IMAGEHLP_MODULE64_V3));
++    if (this->symGetModuleInfo64 == NULL)
++    {
++      SetLastError(ERROR_DLL_INIT_FAILED);
++      return FALSE;
++    }
++    // First try to use the larger ModuleInfo-Structure
++    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
++    void* pData = malloc(
++        4096); // reserve enough memory, so the bug in v6.3.5.1 does not lead to memory-overwrites...
++    if (pData == NULL)
++    {
++      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
++      return FALSE;
++    }
++    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V3));
++    static bool s_useV3Version = true;
++    if (s_useV3Version)
++    {
++      if (this->symGetModuleInfo64(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
++      {
++        // only copy as much memory as is reserved...
++        memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V3));
++        pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
++        free(pData);
++        return TRUE;
++      }
++      s_useV3Version = false; // to prevent unnecessary calls with the larger struct...
++    }
++
++    // could not retrieve the bigger structure, try with the smaller one (as defined in VC7.1)...
++    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
++    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V2));
++    if (this->symGetModuleInfo64(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
++    {
++      // only copy as much memory as is reserved...
++      memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V2));
++      pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
++      free(pData);
++      return TRUE;
++    }
++    free(pData);
++    SetLastError(ERROR_DLL_INIT_FAILED);
++    return FALSE;
++  }
++};
++
++// #############################################################
++StackWalker::StackWalker(DWORD dwProcessId, HANDLE hProcess)
++{
++  this->m_options = OptionsAll;
++  this->m_modulesLoaded = FALSE;
++  this->m_hProcess = hProcess;
++  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
++  this->m_dwProcessId = dwProcessId;
++  this->m_szSymPath = NULL;
++  this->m_MaxRecursionCount = 1000;
++}
++StackWalker::StackWalker(int options, LPCTSTR szSymPath, DWORD dwProcessId, HANDLE hProcess)
++{
++  this->m_options = options;
++  this->m_modulesLoaded = FALSE;
++  this->m_hProcess = hProcess;
++  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
++  this->m_dwProcessId = dwProcessId;
++  if (szSymPath != NULL)
++  {
++    this->m_szSymPath = _tcsdup(szSymPath);
++    this->m_options |= SymBuildPath;
++  }
++  else
++    this->m_szSymPath = NULL;
++  this->m_MaxRecursionCount = 1000;
++}
++
++StackWalker::~StackWalker()
++{
++  if (m_szSymPath != NULL)
++    free(m_szSymPath);
++  m_szSymPath = NULL;
++  if (this->m_sw != NULL)
++    delete this->m_sw;
++  this->m_sw = NULL;
++}
++
++BOOL StackWalker::LoadModules()
++{
++  if (this->m_sw == NULL)
++  {
++    SetLastError(ERROR_DLL_INIT_FAILED);
++    return FALSE;
++  }
++  if (m_modulesLoaded != FALSE)
++    return TRUE;
++
++  // Build the sym-path:
++  TCHAR* szSymPath = NULL;
++  if ((this->m_options & SymBuildPath) != 0)
++  {
++    const size_t nSymPathLen = 4096;
++    szSymPath = (TCHAR*)malloc(nSymPathLen * sizeof(TCHAR));
++    if (szSymPath == NULL)
++    {
++      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
++      return FALSE;
++    }
++    szSymPath[0] = 0;
++    // Now first add the (optional) provided sympath:
++    if (this->m_szSymPath != NULL)
++    {
++      _tcscat_s(szSymPath, nSymPathLen, this->m_szSymPath);
++      _tcscat_s(szSymPath, nSymPathLen, _T(";"));
++    }
++
++    _tcscat_s(szSymPath, nSymPathLen, _T(".;"));
++
++    const size_t nTempLen = 1024;
++    TCHAR         szTemp[nTempLen];
++    // Now add the current directory:
++    if (GetCurrentDirectory(nTempLen, szTemp) > 0)
++    {
++      szTemp[nTempLen - 1] = 0;
++      _tcscat_s(szSymPath, nSymPathLen, szTemp);
++      _tcscat_s(szSymPath, nSymPathLen, _T(";"));
++    }
++
++    // Now add the path for the main-module:
++    if (GetModuleFileName(NULL, szTemp, nTempLen) > 0)
++    {
++      szTemp[nTempLen - 1] = 0;
++      for (TCHAR* p = (szTemp + _tcslen(szTemp) - 1); p >= szTemp; --p)
++      {
++        // locate the rightmost path separator
++        if ((*p == '\\') || (*p == '/') || (*p == ':'))
++        {
++          *p = 0;
++          break;
++        }
++      } // for (search for path separator...)
++      if (_tcslen(szTemp) > 0)
++      {
++        _tcscat_s(szSymPath, nSymPathLen, szTemp);
++        _tcscat_s(szSymPath, nSymPathLen, _T(";"));
++      }
++    }
++    if (GetEnvironmentVariable(_T("_NT_SYMBOL_PATH"), szTemp, nTempLen) > 0)
++    {
++      szTemp[nTempLen - 1] = 0;
++      _tcscat_s(szSymPath, nSymPathLen, szTemp);
++      _tcscat_s(szSymPath, nSymPathLen, _T(";"));
++    }
++    if (GetEnvironmentVariable(_T("_NT_ALTERNATE_SYMBOL_PATH"), szTemp, nTempLen) > 0)
++    {
++      szTemp[nTempLen - 1] = 0;
++      _tcscat_s(szSymPath, nSymPathLen, szTemp);
++      _tcscat_s(szSymPath, nSymPathLen, _T(";"));
++    }
++    if (GetEnvironmentVariable(_T("SYSTEMROOT"), szTemp, nTempLen) > 0)
++    {
++      szTemp[nTempLen - 1] = 0;
++      _tcscat_s(szSymPath, nSymPathLen, szTemp);
++      _tcscat_s(szSymPath, nSymPathLen, _T(";"));
++      // also add the "system32"-directory:
++      _tcscat_s(szTemp, nTempLen, _T("\\system32"));
++      _tcscat_s(szSymPath, nSymPathLen, szTemp);
++      _tcscat_s(szSymPath, nSymPathLen, _T(";"));
++    }
++
++    if ((this->m_options & SymUseSymSrv) != 0)
++    {
++      if (GetEnvironmentVariable(_T("SYSTEMDRIVE"), szTemp, nTempLen) > 0)
++      {
++        szTemp[nTempLen - 1] = 0;
++        _tcscat_s(szSymPath, nSymPathLen, _T("SRV*"));
++        _tcscat_s(szSymPath, nSymPathLen, szTemp);
++        _tcscat_s(szSymPath, nSymPathLen, _T("\\websymbols"));
++        _tcscat_s(szSymPath, nSymPathLen, _T("*http://msdl.microsoft.com/download/symbols;"));
++      }
++      else
++        _tcscat_s(szSymPath, nSymPathLen,
++                 _T("SRV*c:\\websymbols*http://msdl.microsoft.com/download/symbols;"));
++    }
++  } // if SymBuildPath
++
++  // First Init the whole stuff...
++  BOOL bRet = this->m_sw->Init(szSymPath);
++  if (szSymPath != NULL)
++    free(szSymPath);
++  szSymPath = NULL;
++  if (bRet == FALSE)
++  {
++    this->OnDbgHelpErr(_T("Error while initializing dbghelp.dll"), 0, 0);
++    SetLastError(ERROR_DLL_INIT_FAILED);
++    return FALSE;
++  }
++
++  bRet = this->m_sw->LoadModules(this->m_hProcess, this->m_dwProcessId);
++  if (bRet != FALSE)
++    m_modulesLoaded = TRUE;
++  return bRet;
++}
++
++// The following is used to pass the "userData"-Pointer to the user-provided readMemoryFunction
++// This has to be done due to a problem with the "hProcess"-parameter in x64...
++// Because this class is in no case multi-threading-enabled (because of the limitations
++// of dbghelp.dll) it is "safe" to use a static-variable
++static StackWalker::PReadProcessMemoryRoutine s_readMemoryFunction = NULL;
++static LPVOID                                 s_readMemoryFunction_UserData = NULL;
++
++BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
++                                const CONTEXT*            context,
++                                PReadProcessMemoryRoutine readMemoryFunction,
++                                LPVOID                    pUserData)
++{
++  CONTEXT                                   c;
++  CallstackEntry                            csEntry;
++
++  tSymbolInfo* pSym = NULL;
++  StackWalkerInternal::IMAGEHLP_MODULE64_V3 Module;
++  tImageHelperLine                           Line;
++  int                                       frameNum;
++  bool                                      bLastEntryCalled = true;
++  int                                       curRecursionCount = 0;
++
++  if (m_modulesLoaded == FALSE)
++    this->LoadModules(); // ignore the result...
++
++  if (this->m_sw->m_hDbhHelp == NULL)
++  {
++    SetLastError(ERROR_DLL_INIT_FAILED);
++    return FALSE;
++  }
++
++  s_readMemoryFunction = readMemoryFunction;
++  s_readMemoryFunction_UserData = pUserData;
++
++  if (context == NULL)
++  {
++    // If no context is provided, capture the context
++    // See: https://stackwalker.codeplex.com/discussions/446958
++#if _WIN32_WINNT <= 0x0501
++    // If we need to support XP, we need to use the "old way", because "GetThreadId" is not available!
++    if (hThread == GetCurrentThread())
++#else
++    if (GetThreadId(hThread) == GetCurrentThreadId())
++#endif
++    {
++      GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, USED_CONTEXT_FLAGS);
++    }
++    else
++    {
++      SuspendThread(hThread);
++      memset(&c, 0, sizeof(CONTEXT));
++      c.ContextFlags = USED_CONTEXT_FLAGS;
++
++      // TODO: Detect if you want to get a thread context of a different process, which is running a different processor architecture...
++      // This does only work if we are x64 and the target process is x64 or x86;
++      // It cannot work, if this process is x64 and the target process is x64... this is not supported...
++      // See also: http://www.howzatt.demon.co.uk/articles/DebuggingInWin64.html
++      if (GetThreadContext(hThread, &c) == FALSE)
++      {
++        ResumeThread(hThread);
++        return FALSE;
++      }
++    }
++  }
++  else
++    c = *context;
++
++  // init STACKFRAME for first call
++  STACKFRAME64 s; // in/out stackframe
++  memset(&s, 0, sizeof(s));
++  DWORD imageType;
++#ifdef _M_IX86
++  // normally, call ImageNtHeader() and use machine info from PE header
++  imageType = IMAGE_FILE_MACHINE_I386;
++  s.AddrPC.Offset = c.Eip;
++  s.AddrPC.Mode = AddrModeFlat;
++  s.AddrFrame.Offset = c.Ebp;
++  s.AddrFrame.Mode = AddrModeFlat;
++  s.AddrStack.Offset = c.Esp;
++  s.AddrStack.Mode = AddrModeFlat;
++#elif _M_X64
++  imageType = IMAGE_FILE_MACHINE_AMD64;
++  s.AddrPC.Offset = c.Rip;
++  s.AddrPC.Mode = AddrModeFlat;
++  s.AddrFrame.Offset = c.Rsp;
++  s.AddrFrame.Mode = AddrModeFlat;
++  s.AddrStack.Offset = c.Rsp;
++  s.AddrStack.Mode = AddrModeFlat;
++#elif _M_IA64
++  imageType = IMAGE_FILE_MACHINE_IA64;
++  s.AddrPC.Offset = c.StIIP;
++  s.AddrPC.Mode = AddrModeFlat;
++  s.AddrFrame.Offset = c.IntSp;
++  s.AddrFrame.Mode = AddrModeFlat;
++  s.AddrBStore.Offset = c.RsBSP;
++  s.AddrBStore.Mode = AddrModeFlat;
++  s.AddrStack.Offset = c.IntSp;
++  s.AddrStack.Mode = AddrModeFlat;
++#else
++#error "Platform not supported!"
++#endif
++
++  pSym = (tSymbolInfo*)malloc(sizeof(tSymbolInfo) + STACKWALK_MAX_NAMELEN*sizeof(TCHAR));
++  if (!pSym)
++    goto cleanup; // not enough memory...
++  memset(pSym, 0, sizeof(tSymbolInfo) + STACKWALK_MAX_NAMELEN*sizeof(TCHAR));
++  pSym->SizeOfStruct = sizeof(tSymbolInfo);
++  pSym->MaxNameLen = STACKWALK_MAX_NAMELEN;
++
++  memset(&Line, 0, sizeof(Line));
++  Line.SizeOfStruct = sizeof(Line);
++
++  memset(&Module, 0, sizeof(Module));
++  Module.SizeOfStruct = sizeof(Module);
++
++  for (frameNum = 0;; ++frameNum)
++  {
++    // get next stack frame (StackWalk64(), SymFunctionTableAccess64(), SymGetModuleBase64())
++    // if this returns ERROR_INVALID_ADDRESS (487) or ERROR_NOACCESS (998), you can
++    // assume that either you are done, or that the stack is so hosed that the next
++    // deeper frame could not be found.
++    // CONTEXT need not to be supplied if imageTyp is IMAGE_FILE_MACHINE_I386!
++    if (!this->m_sw->stackWalk64(imageType, this->m_hProcess, hThread, &s, &c, myReadProcMem,
++                         this->m_sw->symFunctionTableAccess64, this->m_sw->symGetModuleBase64, NULL))
++    {
++      // INFO: "StackWalk64" does not set "GetLastError"...
++      this->OnDbgHelpErr(_T("StackWalk64"), 0, s.AddrPC.Offset);
++      break;
++    }
++
++    csEntry.offset = s.AddrPC.Offset;
++    csEntry.name[0] = 0;
++    csEntry.undName[0] = 0;
++    csEntry.undFullName[0] = 0;
++    csEntry.offsetFromSmybol = 0;
++    csEntry.offsetFromLine = 0;
++    csEntry.lineFileName[0] = 0;
++    csEntry.lineNumber = 0;
++    csEntry.loadedImageName[0] = 0;
++    csEntry.moduleName[0] = 0;
++    if (s.AddrPC.Offset == s.AddrReturn.Offset)
++    {
++      if ((this->m_MaxRecursionCount > 0) && (curRecursionCount > m_MaxRecursionCount))
++      {
++        this->OnDbgHelpErr(_T("StackWalk64-Endless-Callstack!"), 0, s.AddrPC.Offset);
++        break;
++      }
++      curRecursionCount++;
++    }
++    else
++      curRecursionCount = 0;
++    if (s.AddrPC.Offset != 0)
++    {
++      // we seem to have a valid PC
++      // show procedure info (SymGetSymFromAddr64())
++      if (this->m_sw->symFromAddr(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromSmybol),
++                             pSym) != FALSE)
++      {
++        MyStrCpy(csEntry.name, STACKWALK_MAX_NAMELEN, pSym->Name);
++        // UnDecorateSymbolName()
++        DWORD res = this->m_sw->unDecorateSymbolName(pSym->Name, csEntry.undName, STACKWALK_MAX_NAMELEN, UNDNAME_NAME_ONLY);
++        res = this->m_sw->unDecorateSymbolName(pSym->Name, csEntry.undFullName, STACKWALK_MAX_NAMELEN, UNDNAME_COMPLETE);
++      }
++      else
++      {
++        this->OnDbgHelpErr(_T("SymGetSymFromAddr64"), GetLastError(), s.AddrPC.Offset);
++      }
++
++      // show line number info, NT5.0-method (SymGetLineFromAddr64())
++      if (this->m_sw->symGetLineFromAddr64 != NULL)
++      { // yes, we have SymGetLineFromAddr64()
++        if (this->m_sw->symGetLineFromAddr64(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromLine),
++                               &Line) != FALSE)
++        {
++          csEntry.lineNumber = Line.LineNumber;
++          MyStrCpy(csEntry.lineFileName, STACKWALK_MAX_NAMELEN, Line.FileName);
++        }
++        else
++        {
++          this->OnDbgHelpErr(_T("SymGetLineFromAddr64"), GetLastError(), s.AddrPC.Offset);
++        }
++      } // yes, we have SymGetLineFromAddr64()
++
++      // show module info (SymGetModuleInfo64())
++      if (this->m_sw->GetModuleInfo(this->m_hProcess, s.AddrPC.Offset, &Module) != FALSE)
++      { // got module info OK
++        switch (Module.SymType)
++        {
++          case SymNone:
++            csEntry.symTypeString = "-nosymbols-";
++            break;
++          case SymCoff:
++            csEntry.symTypeString = "COFF";
++            break;
++          case SymCv:
++            csEntry.symTypeString = "CV";
++            break;
++          case SymPdb:
++            csEntry.symTypeString = "PDB";
++            break;
++          case SymExport:
++            csEntry.symTypeString = "-exported-";
++            break;
++          case SymDeferred:
++            csEntry.symTypeString = "-deferred-";
++            break;
++          case SymSym:
++            csEntry.symTypeString = "SYM";
++            break;
++#if API_VERSION_NUMBER >= 9
++          case SymDia:
++            csEntry.symTypeString = "DIA";
++            break;
++#endif
++          case 8: //SymVirtual:
++            csEntry.symTypeString = "Virtual";
++            break;
++          default:
++            //_snprintf( ty, sizeof(ty), "symtype=%ld", (long) Module.SymType );
++            csEntry.symTypeString = NULL;
++            break;
++        }
++
++        MyStrCpy(csEntry.moduleName, STACKWALK_MAX_NAMELEN, Module.ModuleName);
++        csEntry.baseOfImage = Module.BaseOfImage;
++        MyStrCpy(csEntry.loadedImageName, STACKWALK_MAX_NAMELEN, Module.LoadedImageName);
++      } // got module info OK
++      else
++      {
++        this->OnDbgHelpErr(_T("SymGetModuleInfo64"), GetLastError(), s.AddrPC.Offset);
++      }
++    } // we seem to have a valid PC
++
++    CallstackEntryType et = nextEntry;
++    if (frameNum == 0)
++      et = firstEntry;
++    bLastEntryCalled = false;
++    this->OnCallstackEntry(et, csEntry);
++
++    if (s.AddrReturn.Offset == 0)
++    {
++      bLastEntryCalled = true;
++      this->OnCallstackEntry(lastEntry, csEntry);
++      SetLastError(ERROR_SUCCESS);
++      break;
++    }
++  } // for ( frameNum )
++
++cleanup:
++  if (pSym)
++    free(pSym);
++
++  if (bLastEntryCalled == false)
++    this->OnCallstackEntry(lastEntry, csEntry);
++
++  if (context == NULL)
++    ResumeThread(hThread);
++
++  return TRUE;
++}
++
++BOOL StackWalker::ShowObject(LPVOID pObject)
++{
++  // Load modules if not done yet
++  if (m_modulesLoaded == FALSE)
++    this->LoadModules(); // ignore the result...
++
++  // Verify that the DebugHelp.dll was actually found
++  if (this->m_sw->m_hDbhHelp == NULL)
++  {
++    SetLastError(ERROR_DLL_INIT_FAILED);
++    return FALSE;
++  }
++
++  // SymGetSymFromAddr64() is required
++  if (this->m_sw->symFromAddr == NULL)
++    return FALSE;
++
++  // Show object info (SymGetSymFromAddr64())
++  DWORD64            dwAddress = DWORD64(pObject);
++  DWORD64            dwDisplacement = 0;
++  tSymbolInfo* pSym =
++      (tSymbolInfo*)malloc(sizeof(tSymbolInfo) + STACKWALK_MAX_NAMELEN*sizeof(TCHAR));
++  memset(pSym, 0, sizeof(tSymbolInfo) + STACKWALK_MAX_NAMELEN*sizeof(TCHAR));
++  pSym->SizeOfStruct = sizeof(tSymbolInfo);
++  pSym->MaxNameLen = STACKWALK_MAX_NAMELEN;
++  if (this->m_sw->symFromAddr(this->m_hProcess, dwAddress, &dwDisplacement, pSym) == FALSE)
++  {
++    this->OnDbgHelpErr(_T("SymGetSymFromAddr64"), GetLastError(), dwAddress);
++    return FALSE;
++  }
++  // Object name output
++  this->OnOutput(pSym->Name);
++
++  free(pSym);
++  return TRUE;
++};
++
++BOOL __stdcall StackWalker::myReadProcMem(HANDLE  hProcess,
++                                          DWORD64 qwBaseAddress,
++                                          PVOID   lpBuffer,
++                                          DWORD   nSize,
++                                          LPDWORD lpNumberOfBytesRead)
++{
++  if (s_readMemoryFunction == NULL)
++  {
++    SIZE_T st;
++    BOOL   bRet = ReadProcessMemory(hProcess, (LPVOID)qwBaseAddress, lpBuffer, nSize, &st);
++    *lpNumberOfBytesRead = (DWORD)st;
++    //printf("ReadMemory: hProcess: %p, baseAddr: %p, buffer: %p, size: %d, read: %d, result: %d\n", hProcess, (LPVOID) qwBaseAddress, lpBuffer, nSize, (DWORD) st, (DWORD) bRet);
++    return bRet;
++  }
++  else
++  {
++    return s_readMemoryFunction(hProcess, qwBaseAddress, lpBuffer, nSize, lpNumberOfBytesRead,
++                                s_readMemoryFunction_UserData);
++  }
++}
++
++void StackWalker::OnLoadModule(LPCTSTR    img,
++                               LPCTSTR    mod,
++                               DWORD64   baseAddr,
++                               DWORD     size,
++                               DWORD     result,
++                               LPCTSTR    symType,
++                               LPCTSTR    pdbName,
++                               ULONGLONG fileVersion)
++{
++  TCHAR   buffer[STACKWALK_MAX_NAMELEN];
++  size_t maxLen = STACKWALK_MAX_NAMELEN;
++#if _MSC_VER >= 1400
++  maxLen = _TRUNCATE;
++#endif
++  if (fileVersion == 0)
++    _sntprintf_s(buffer, maxLen, _T("%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s'\n"),
++                img, mod, (LPVOID)baseAddr, size, result, symType, pdbName);
++  else
++  {
++    DWORD v4 = (DWORD)(fileVersion & 0xFFFF);
++    DWORD v3 = (DWORD)((fileVersion >> 16) & 0xFFFF);
++    DWORD v2 = (DWORD)((fileVersion >> 32) & 0xFFFF);
++    DWORD v1 = (DWORD)((fileVersion >> 48) & 0xFFFF);
++    _sntprintf_s(
++        buffer, maxLen,
++        _T("%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s', fileVersion: %d.%d.%d.%d\n"),
++        img, mod, (LPVOID)baseAddr, size, result, symType, pdbName, v1, v2, v3, v4);
++  }
++  buffer[STACKWALK_MAX_NAMELEN - 1] = 0; // be sure it is NULL terminated
++  OnOutput(buffer);
++}
++
++void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry)
++{
++  TCHAR   buffer[STACKWALK_MAX_NAMELEN];
++  size_t maxLen = STACKWALK_MAX_NAMELEN;
++#if _MSC_VER >= 1400
++  maxLen = _TRUNCATE;
++#endif
++  if ((eType != lastEntry) && (entry.offset != 0))
++  {
++    if (entry.name[0] == 0)
++      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, _T("(function-name not available)"));
++    if (entry.undName[0] != 0)
++      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undName);
++    if (entry.undFullName[0] != 0)
++      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undFullName);
++    if (entry.lineFileName[0] == 0)
++    {
++      MyStrCpy(entry.lineFileName, STACKWALK_MAX_NAMELEN, _T("(filename not available)"));
++      if (entry.moduleName[0] == 0)
++        MyStrCpy(entry.moduleName, STACKWALK_MAX_NAMELEN, _T("(module-name not available)"));
++      _sntprintf_s(buffer, maxLen, _T("%p (%s): %s: %s\n"), (LPVOID)entry.offset, entry.moduleName,
++                  entry.lineFileName, entry.name);
++    }
++    else
++      _sntprintf_s(buffer, maxLen, _T("%s (%d): %s\n"), entry.lineFileName, entry.lineNumber,
++                  entry.name);
++    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
++    OnOutput(buffer);
++  }
++}
++
++void StackWalker::OnDbgHelpErr(LPCTSTR szFuncName, DWORD gle, DWORD64 addr)
++{
++  TCHAR   buffer[STACKWALK_MAX_NAMELEN];
++  size_t maxLen = STACKWALK_MAX_NAMELEN;
++#if _MSC_VER >= 1400
++  maxLen = _TRUNCATE;
++#endif
++  _sntprintf_s(buffer, maxLen, _T("ERROR: %s, GetLastError: %d (Address: %p)\n"), szFuncName, gle,
++              (LPVOID)addr);
++  buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
++  OnOutput(buffer);
++}
++
++void StackWalker::OnSymInit(LPCTSTR szSearchPath, DWORD symOptions, LPCTSTR szUserName)
++{
++  TCHAR   buffer[STACKWALK_MAX_NAMELEN];
++  size_t maxLen = STACKWALK_MAX_NAMELEN;
++#if _MSC_VER >= 1400
++  maxLen = _TRUNCATE;
++#endif
++  _sntprintf_s(buffer, maxLen, _T("SymInit: Symbol-SearchPath: '%s', symOptions: %d, UserName: '%s'\n"),
++              szSearchPath, symOptions, szUserName);
++  buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
++  OnOutput(buffer);
++  // Also display the OS-version
++#if _MSC_VER <= 1200
++  OSVERSIONINFOA ver;
++  ZeroMemory(&ver, sizeof(OSVERSIONINFOA));
++  ver.dwOSVersionInfoSize = sizeof(ver);
++  if (GetVersionExA(&ver) != FALSE)
++  {
++    _snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s)\n", ver.dwMajorVersion,
++                ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion);
++    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
++    OnOutput(buffer);
++  }
++#else
++  OSVERSIONINFOEX ver;
++  ZeroMemory(&ver, sizeof(OSVERSIONINFOEX));
++  ver.dwOSVersionInfoSize = sizeof(ver);
++#if _MSC_VER >= 1900
++#pragma warning(push)
++#pragma warning(disable : 4996)
++#endif
++  if (GetVersionEx((OSVERSIONINFO*)&ver) != FALSE)
++  {
++    _sntprintf_s(buffer, maxLen, _T("OS-Version: %d.%d.%d (%s) 0x%x-0x%x\n"), ver.dwMajorVersion,
++                ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion, ver.wSuiteMask,
++                ver.wProductType);
++    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
++    OnOutput(buffer);
++  }
++#if _MSC_VER >= 1900
++#pragma warning(pop)
++#endif
++#endif
++}
++
++void StackWalker::OnOutput(LPCTSTR buffer)
++{
++  OutputDebugString(buffer);
++}
+diff --git a/Main/StackWalker/StackWalker.h b/Main/StackWalker/StackWalker.h
+index 66c8260..03efcec 100644
+--- a/Main/StackWalker/StackWalker.h
++++ b/Main/StackWalker/StackWalker.h
+@@ -1,255 +1,245 @@
+-#ifndef __STACKWALKER_H__
+-#define __STACKWALKER_H__
+-
+-#if defined(_MSC_VER)
+-
+-/**********************************************************************
+- *
+- * StackWalker.h
+- *
+- *
+- *
+- * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
+- *
+- *   Copyright (c) 2005-2009, Jochen Kalmbach
+- *   All rights reserved.
+- *
+- *   Redistribution and use in source and binary forms, with or without modification,
+- *   are permitted provided that the following conditions are met:
+- *
+- *   Redistributions of source code must retain the above copyright notice,
+- *   this list of conditions and the following disclaimer.
+- *   Redistributions in binary form must reproduce the above copyright notice,
+- *   this list of conditions and the following disclaimer in the documentation
+- *   and/or other materials provided with the distribution.
+- *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
+- *   used to endorse or promote products derived from this software without
+- *   specific prior written permission.
+- *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+- *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+- *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+- *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+- *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+- *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+- *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+- *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+- *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+- *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- *
+- * **********************************************************************/
+-// #pragma once is supported starting with _MSC_VER 1000,
+-// so we need not to check the version (because we only support _MSC_VER >= 1100)!
+-#pragma once
+-
+-#include <windows.h>
+-
+-#if _MSC_VER >= 1900
+-#pragma warning(disable : 4091)
+-#endif
+-
+-// special defines for VC5/6 (if no actual PSDK is installed):
+-#if _MSC_VER < 1300
+-typedef unsigned __int64 DWORD64, *PDWORD64;
+-#if defined(_WIN64)
+-typedef unsigned __int64 SIZE_T, *PSIZE_T;
+-#else
+-typedef unsigned long SIZE_T, *PSIZE_T;
+-#endif
+-#endif // _MSC_VER < 1300
+-
+-class StackWalkerInternal; // forward
+-class StackWalker
+-{
+-public:
+-  typedef enum StackWalkOptions
+-  {
+-    // No addition info will be retrieved
+-    // (only the address is available)
+-    RetrieveNone = 0,
+-
+-    // Try to get the symbol-name
+-    RetrieveSymbol = 1,
+-
+-    // Try to get the line for this symbol
+-    RetrieveLine = 2,
+-
+-    // Try to retrieve the module-infos
+-    RetrieveModuleInfo = 4,
+-
+-    // Also retrieve the version for the DLL/EXE
+-    RetrieveFileVersion = 8,
+-
+-    // Contains all the above
+-    RetrieveVerbose = 0xF,
+-
+-    // Generate a "good" symbol-search-path
+-    SymBuildPath = 0x10,
+-
+-    // Also use the public Microsoft-Symbol-Server
+-    SymUseSymSrv = 0x20,
+-
+-    // Contains all the above "Sym"-options
+-    SymAll = 0x30,
+-
+-    // Contains all options (default)
+-    OptionsAll = 0x3F
+-  } StackWalkOptions;
+-
+-  StackWalker(int    options = OptionsAll, // 'int' is by design, to combine the enum-flags
+-              LPCSTR szSymPath = NULL,
+-              DWORD  dwProcessId = GetCurrentProcessId(),
+-              HANDLE hProcess = GetCurrentProcess());
+-  StackWalker(DWORD dwProcessId, HANDLE hProcess);
+-  virtual ~StackWalker();
+-
+-  typedef BOOL(__stdcall* PReadProcessMemoryRoutine)(
+-      HANDLE  hProcess,
+-      DWORD64 qwBaseAddress,
+-      PVOID   lpBuffer,
+-      DWORD   nSize,
+-      LPDWORD lpNumberOfBytesRead,
+-      LPVOID  pUserData // optional data, which was passed in "ShowCallstack"
+-  );
+-
+-  BOOL LoadModules();
+-
+-  BOOL ShowCallstack(
+-      HANDLE                    hThread = GetCurrentThread(),
+-      const CONTEXT*            context = NULL,
+-      PReadProcessMemoryRoutine readMemoryFunction = NULL,
+-      LPVOID pUserData = NULL // optional to identify some data in the 'readMemoryFunction'-callback
+-  );
+-
+-  BOOL ShowObject(LPVOID pObject);
+-
+-#if _MSC_VER >= 1300
+-  // due to some reasons, the "STACKWALK_MAX_NAMELEN" must be declared as "public"
+-  // in older compilers in order to use it... starting with VC7 we can declare it as "protected"
+-protected:
+-#endif
+-  enum
+-  {
+-    STACKWALK_MAX_NAMELEN = 1024
+-  }; // max name length for found symbols
+-
+-protected:
+-  // Entry for each Callstack-Entry
+-  typedef struct CallstackEntry
+-  {
+-    DWORD64 offset; // if 0, we have no valid entry
+-    CHAR    name[STACKWALK_MAX_NAMELEN];
+-    CHAR    undName[STACKWALK_MAX_NAMELEN];
+-    CHAR    undFullName[STACKWALK_MAX_NAMELEN];
+-    DWORD64 offsetFromSmybol;
+-    DWORD   offsetFromLine;
+-    DWORD   lineNumber;
+-    CHAR    lineFileName[STACKWALK_MAX_NAMELEN];
+-    DWORD   symType;
+-    LPCSTR  symTypeString;
+-    CHAR    moduleName[STACKWALK_MAX_NAMELEN];
+-    DWORD64 baseOfImage;
+-    CHAR    loadedImageName[STACKWALK_MAX_NAMELEN];
+-  } CallstackEntry;
+-
+-  typedef enum CallstackEntryType
+-  {
+-    firstEntry,
+-    nextEntry,
+-    lastEntry
+-  } CallstackEntryType;
+-
+-  virtual void OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName);
+-  virtual void OnLoadModule(LPCSTR    img,
+-                            LPCSTR    mod,
+-                            DWORD64   baseAddr,
+-                            DWORD     size,
+-                            DWORD     result,
+-                            LPCSTR    symType,
+-                            LPCSTR    pdbName,
+-                            ULONGLONG fileVersion);
+-  virtual void OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry);
+-  virtual void OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr);
+-  virtual void OnOutput(LPCSTR szText);
+-
+-  StackWalkerInternal* m_sw;
+-  HANDLE               m_hProcess;
+-  DWORD                m_dwProcessId;
+-  BOOL                 m_modulesLoaded;
+-  LPSTR                m_szSymPath;
+-
+-  int m_options;
+-  int m_MaxRecursionCount;
+-
+-  static BOOL __stdcall myReadProcMem(HANDLE  hProcess,
+-                                      DWORD64 qwBaseAddress,
+-                                      PVOID   lpBuffer,
+-                                      DWORD   nSize,
+-                                      LPDWORD lpNumberOfBytesRead);
+-
+-  friend StackWalkerInternal;
+-}; // class StackWalker
+-
+-// The "ugly" assembler-implementation is needed for systems before XP
+-// If you have a new PSDK and you only compile for XP and later, then you can use
+-// the "RtlCaptureContext"
+-// Currently there is no define which determines the PSDK-Version...
+-// So we just use the compiler-version (and assumes that the PSDK is
+-// the one which was installed by the VS-IDE)
+-
+-// INFO: If you want, you can use the RtlCaptureContext if you only target XP and later...
+-//       But I currently use it in x64/IA64 environments...
+-//#if defined(_M_IX86) && (_WIN32_WINNT <= 0x0500) && (_MSC_VER < 1400)
+-
+-#if defined(_M_IX86)
+-#ifdef CURRENT_THREAD_VIA_EXCEPTION
+-// TODO: The following is not a "good" implementation,
+-// because the callstack is only valid in the "__except" block...
+-#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags)               \
+-  do                                                                            \
+-  {                                                                             \
+-    memset(&c, 0, sizeof(CONTEXT));                                             \
+-    EXCEPTION_POINTERS* pExp = NULL;                                            \
+-    __try                                                                       \
+-    {                                                                           \
+-      throw 0;                                                                  \
+-    }                                                                           \
+-    __except (((pExp = GetExceptionInformation()) ? EXCEPTION_EXECUTE_HANDLER   \
+-                                                  : EXCEPTION_EXECUTE_HANDLER)) \
+-    {                                                                           \
+-    }                                                                           \
+-    if (pExp != NULL)                                                           \
+-      memcpy(&c, pExp->ContextRecord, sizeof(CONTEXT));                         \
+-    c.ContextFlags = contextFlags;                                              \
+-  } while (0);
+-#else
+-// clang-format off
+-// The following should be enough for walking the callstack...
+-#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
+-  do                                                              \
+-  {                                                               \
+-    memset(&c, 0, sizeof(CONTEXT));                               \
+-    c.ContextFlags = contextFlags;                                \
+-    __asm    call x                                               \
+-    __asm x: pop eax                                              \
+-    __asm    mov c.Eip, eax                                       \
+-    __asm    mov c.Ebp, ebp                                       \
+-    __asm    mov c.Esp, esp                                       \
+-  } while (0)
+-// clang-format on
+-#endif
+-
+-#else
+-
+-// The following is defined for x86 (XP and higher), x64 and IA64:
+-#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
+-  do                                                              \
+-  {                                                               \
+-    memset(&c, 0, sizeof(CONTEXT));                               \
+-    c.ContextFlags = contextFlags;                                \
+-    RtlCaptureContext(&c);                                        \
+-  } while (0);
+-#endif
+-
+-#endif //defined(_MSC_VER)
+-
+-#endif // __STACKWALKER_H__
++#ifndef __STACKWALKER_H__
++#define __STACKWALKER_H__
++
++#if defined(_MSC_VER)
++
++/**********************************************************************
++ *
++ * StackWalker.h
++ *
++ *
++ *
++ * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
++ *
++ *   Copyright (c) 2005-2009, Jochen Kalmbach
++ *   All rights reserved.
++ *
++ *   Redistribution and use in source and binary forms, with or without modification,
++ *   are permitted provided that the following conditions are met:
++ *
++ *   Redistributions of source code must retain the above copyright notice,
++ *   this list of conditions and the following disclaimer.
++ *   Redistributions in binary form must reproduce the above copyright notice,
++ *   this list of conditions and the following disclaimer in the documentation
++ *   and/or other materials provided with the distribution.
++ *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
++ *   used to endorse or promote products derived from this software without
++ *   specific prior written permission.
++ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++ *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
++ *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
++ *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++ *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++ *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++ *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++ *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++ *
++ * **********************************************************************/
++// #pragma once is supported starting with _MSC_VER 1000,
++// so we need not to check the version (because we only support _MSC_VER >= 1100)!
++#pragma once
++
++#include <windows.h>
++
++#if _MSC_VER >= 1900
++#pragma warning(disable : 4091)
++#endif
++
++class StackWalkerInternal; // forward
++class StackWalker
++{
++public:
++  typedef enum StackWalkOptions
++  {
++    // No addition info will be retrieved
++    // (only the address is available)
++    RetrieveNone = 0,
++
++    // Try to get the symbol-name
++    RetrieveSymbol = 1,
++
++    // Try to get the line for this symbol
++    RetrieveLine = 2,
++
++    // Try to retrieve the module-infos
++    RetrieveModuleInfo = 4,
++
++    // Also retrieve the version for the DLL/EXE
++    RetrieveFileVersion = 8,
++
++    // Contains all the above
++    RetrieveVerbose = 0xF,
++
++    // Generate a "good" symbol-search-path
++    SymBuildPath = 0x10,
++
++    // Also use the public Microsoft-Symbol-Server
++    SymUseSymSrv = 0x20,
++
++    // Contains all the above "Sym"-options
++    SymAll = 0x30,
++
++    // Contains all options (default)
++    OptionsAll = 0x3F
++  } StackWalkOptions;
++
++  StackWalker(int    options = OptionsAll, // 'int' is by design, to combine the enum-flags
++              LPCTSTR szSymPath = NULL,
++              DWORD  dwProcessId = GetCurrentProcessId(),
++              HANDLE hProcess = GetCurrentProcess());
++  StackWalker(DWORD dwProcessId, HANDLE hProcess);
++  virtual ~StackWalker();
++
++  typedef BOOL(__stdcall* PReadProcessMemoryRoutine)(
++      HANDLE  hProcess,
++      DWORD64 qwBaseAddress,
++      PVOID   lpBuffer,
++      DWORD   nSize,
++      LPDWORD lpNumberOfBytesRead,
++      LPVOID  pUserData // optional data, which was passed in "ShowCallstack"
++  );
++
++  BOOL LoadModules();
++
++  BOOL ShowCallstack(
++      HANDLE                    hThread = GetCurrentThread(),
++      const CONTEXT*            context = NULL,
++      PReadProcessMemoryRoutine readMemoryFunction = NULL,
++      LPVOID pUserData = NULL // optional to identify some data in the 'readMemoryFunction'-callback
++  );
++
++  BOOL ShowObject(LPVOID pObject);
++
++#if _MSC_VER >= 1300
++  // due to some reasons, the "STACKWALK_MAX_NAMELEN" must be declared as "public"
++  // in older compilers in order to use it... starting with VC7 we can declare it as "protected"
++protected:
++#endif
++  enum
++  {
++    STACKWALK_MAX_NAMELEN = 1024
++  }; // max name length for found symbols
++
++protected:
++  // Entry for each Callstack-Entry
++  typedef struct CallstackEntry
++  {
++    DWORD64 offset; // if 0, we have no valid entry
++    TCHAR    name[STACKWALK_MAX_NAMELEN];
++    TCHAR    undName[STACKWALK_MAX_NAMELEN];
++    TCHAR    undFullName[STACKWALK_MAX_NAMELEN];
++    DWORD64 offsetFromSmybol;
++    DWORD   offsetFromLine;
++    DWORD   lineNumber;
++    TCHAR    lineFileName[STACKWALK_MAX_NAMELEN];
++    DWORD   symType;
++    LPCSTR  symTypeString;
++    TCHAR    moduleName[STACKWALK_MAX_NAMELEN];
++    DWORD64 baseOfImage;
++    TCHAR    loadedImageName[STACKWALK_MAX_NAMELEN];
++  } CallstackEntry;
++
++  typedef enum CallstackEntryType
++  {
++    firstEntry,
++    nextEntry,
++    lastEntry
++  } CallstackEntryType;
++
++  virtual void OnSymInit(LPCTSTR szSearchPath, DWORD symOptions, LPCTSTR szUserName);
++  virtual void OnLoadModule(LPCTSTR    img,
++                            LPCTSTR    mod,
++                            DWORD64   baseAddr,
++                            DWORD     size,
++                            DWORD     result,
++                            LPCTSTR    symType,
++                            LPCTSTR    pdbName,
++                            ULONGLONG fileVersion);
++  virtual void OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry);
++  virtual void OnDbgHelpErr(LPCTSTR szFuncName, DWORD gle, DWORD64 addr);
++  virtual void OnOutput(LPCTSTR szText);
++
++  StackWalkerInternal* m_sw;
++  HANDLE               m_hProcess;
++  DWORD                m_dwProcessId;
++  BOOL                 m_modulesLoaded;
++  LPTSTR               m_szSymPath;
++
++  int m_options;
++  int m_MaxRecursionCount;
++
++  static BOOL __stdcall myReadProcMem(HANDLE  hProcess,
++                                      DWORD64 qwBaseAddress,
++                                      PVOID   lpBuffer,
++                                      DWORD   nSize,
++                                      LPDWORD lpNumberOfBytesRead);
++
++  friend StackWalkerInternal;
++}; // class StackWalker
++
++// The "ugly" assembler-implementation is needed for systems before XP
++// If you have a new PSDK and you only compile for XP and later, then you can use
++// the "RtlCaptureContext"
++// Currently there is no define which determines the PSDK-Version...
++// So we just use the compiler-version (and assumes that the PSDK is
++// the one which was installed by the VS-IDE)
++
++// INFO: If you want, you can use the RtlCaptureContext if you only target XP and later...
++//       But I currently use it in x64/IA64 environments...
++//#if defined(_M_IX86) && (_WIN32_WINNT <= 0x0500) && (_MSC_VER < 1400)
++
++#if defined(_M_IX86)
++#ifdef CURRENT_THREAD_VIA_EXCEPTION
++// TODO: The following is not a "good" implementation,
++// because the callstack is only valid in the "__except" block...
++#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags)               \
++  do                                                                            \
++  {                                                                             \
++    memset(&c, 0, sizeof(CONTEXT));                                             \
++    EXCEPTION_POINTERS* pExp = NULL;                                            \
++    __try                                                                       \
++    {                                                                           \
++      throw 0;                                                                  \
++    }                                                                           \
++    __except (((pExp = GetExceptionInformation()) ? EXCEPTION_EXECUTE_HANDLER   \
++                                                  : EXCEPTION_EXECUTE_HANDLER)) \
++    {                                                                           \
++    }                                                                           \
++    if (pExp != NULL)                                                           \
++      memcpy(&c, pExp->ContextRecord, sizeof(CONTEXT));                         \
++    c.ContextFlags = contextFlags;                                              \
++  } while (0);
++#else
++// clang-format off
++// The following should be enough for walking the callstack...
++#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
++  do                                                              \
++  {                                                               \
++    memset(&c, 0, sizeof(CONTEXT));                               \
++    c.ContextFlags = contextFlags;                                \
++    __asm    call x                                               \
++    __asm x: pop eax                                              \
++    __asm    mov c.Eip, eax                                       \
++    __asm    mov c.Ebp, ebp                                       \
++    __asm    mov c.Esp, esp                                       \
++  } while (0)
++// clang-format on
++#endif
++
++#else
++
++// The following is defined for x86 (XP and higher), x64 and IA64:
++#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
++  do                                                              \
++  {                                                               \
++    memset(&c, 0, sizeof(CONTEXT));                               \
++    c.ContextFlags = contextFlags;                                \
++    RtlCaptureContext(&c);                                        \
++  } while (0);
++#endif
++
++#endif //defined(_MSC_VER)
++
++#endif // __STACKWALKER_H__
+diff --git a/Main/StackWalker/StackWalker_VC2017.sln b/Main/StackWalker/StackWalker_VC2017.sln
+index 790d550..2209e23 100644
+--- a/Main/StackWalker/StackWalker_VC2017.sln
++++ b/Main/StackWalker/StackWalker_VC2017.sln
+@@ -16,18 +16,18 @@ Global
+ 		Release_VC2017-UNICODE|x64 = Release_VC2017-UNICODE|x64
+ 	EndGlobalSection
+ 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+-		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Debug_VC2017|Win32.ActiveCfg = Debug_VC2017-UNICODE|Win32
+-		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Debug_VC2017|Win32.Build.0 = Debug_VC2017-UNICODE|Win32
+-		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Debug_VC2017|x64.ActiveCfg = Debug_VC2017-UNICODE|x64
+-		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Debug_VC2017|x64.Build.0 = Debug_VC2017-UNICODE|x64
++		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Debug_VC2017|Win32.ActiveCfg = Debug_VC2017|Win32
++		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Debug_VC2017|Win32.Build.0 = Debug_VC2017|Win32
++		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Debug_VC2017|x64.ActiveCfg = Debug_VC2017|x64
++		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Debug_VC2017|x64.Build.0 = Debug_VC2017|x64
+ 		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Debug_VC2017-UNICODE|Win32.ActiveCfg = Debug_VC2017-UNICODE|Win32
+ 		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Debug_VC2017-UNICODE|Win32.Build.0 = Debug_VC2017-UNICODE|Win32
+ 		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Debug_VC2017-UNICODE|x64.ActiveCfg = Debug_VC2017-UNICODE|x64
+ 		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Debug_VC2017-UNICODE|x64.Build.0 = Debug_VC2017-UNICODE|x64
+-		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Release_VC2017|Win32.ActiveCfg = Release_VC2017-UNICODE|Win32
+-		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Release_VC2017|Win32.Build.0 = Release_VC2017-UNICODE|Win32
+-		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Release_VC2017|x64.ActiveCfg = Release_VC2017-UNICODE|x64
+-		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Release_VC2017|x64.Build.0 = Release_VC2017-UNICODE|x64
++		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Release_VC2017|Win32.ActiveCfg = Release_VC2017|Win32
++		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Release_VC2017|Win32.Build.0 = Release_VC2017|Win32
++		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Release_VC2017|x64.ActiveCfg = Release_VC2017|x64
++		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Release_VC2017|x64.Build.0 = Release_VC2017|x64
+ 		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Release_VC2017-UNICODE|Win32.ActiveCfg = Release_VC2017-UNICODE|Win32
+ 		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Release_VC2017-UNICODE|Win32.Build.0 = Release_VC2017-UNICODE|Win32
+ 		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Release_VC2017-UNICODE|x64.ActiveCfg = Release_VC2017-UNICODE|x64
+diff --git a/Main/StackWalker/main.cpp b/Main/StackWalker/main.cpp
+index 2db23c6..85769ed 100644
+--- a/Main/StackWalker/main.cpp
++++ b/Main/StackWalker/main.cpp
+@@ -33,7 +33,7 @@ void (*pGlobalFuncPtr)() = 0;
+ class StackWalkerToConsole : public StackWalker
+ {
+ protected:
+-  virtual void OnOutput(LPCSTR szText) { printf("%s", szText); }
++  virtual void OnOutput(LPCTSTR szText) { _tprintf(_T("%s"), szText); }
+ };
+ 
+ void Func5()
+-- 
+2.20.1.windows.1
+

--- a/upstream_utils/stack_walker_patches/0001-Apply-PR-35.patch
+++ b/upstream_utils/stack_walker_patches/0001-Apply-PR-35.patch
@@ -1,15 +1,15 @@
-From debe4e850ff2cd19b55be75dcd7ace176bbaf5f0 Mon Sep 17 00:00:00 2001
+From 6e2f70b7bb7c59fe99b7469bf3e3a257876403dc Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 22 May 2022 23:58:57 -0400
 Subject: [PATCH 1/3] Apply PR #35
 
 ---
- .gitignore                              |    9 +
- Main/StackWalker/StackWalker.cpp        | 2842 +++++++++++------------
- Main/StackWalker/StackWalker.h          |  500 ++--
- Main/StackWalker/StackWalker_VC2017.sln |   16 +-
- Main/StackWalker/main.cpp               |    2 +-
- 5 files changed, 1636 insertions(+), 1733 deletions(-)
+ .gitignore                              |   9 +
+ Main/StackWalker/StackWalker.cpp        | 642 ++++++++++--------------
+ Main/StackWalker/StackWalker.h          |  40 +-
+ Main/StackWalker/StackWalker_VC2017.sln |  16 +-
+ Main/StackWalker/main.cpp               |   2 +-
+ 5 files changed, 306 insertions(+), 403 deletions(-)
  create mode 100644 .gitignore
 
 diff --git a/.gitignore b/.gitignore
@@ -28,108 +28,31 @@ index 0000000..5d102c5
 +/Main/StackWalker/_ReSharper.Caches/*
 +/.vs/*
 diff --git a/Main/StackWalker/StackWalker.cpp b/Main/StackWalker/StackWalker.cpp
-index e1b25eb..48c7c57 100644
+index 7008ac6..48c7c57 100644
 --- a/Main/StackWalker/StackWalker.cpp
 +++ b/Main/StackWalker/StackWalker.cpp
-@@ -1,1469 +1,1373 @@
+@@ -1,4 +1,4 @@
 -/**********************************************************************
-- *
-- * StackWalker.cpp
-- * https://github.com/JochenKalmbach/StackWalker
-- *
-- * Old location: http://stackwalker.codeplex.com/
-- *
-- *
-- * History:
-- *  2005-07-27   v1    - First public release on http://www.codeproject.com/
-- *                       http://www.codeproject.com/threads/StackWalker.asp
-- *  2005-07-28   v2    - Changed the params of the constructor and ShowCallstack
-- *                       (to simplify the usage)
-- *  2005-08-01   v3    - Changed to use 'CONTEXT_FULL' instead of CONTEXT_ALL
-- *                       (should also be enough)
-- *                     - Changed to compile correctly with the PSDK of VC7.0
-- *                       (GetFileVersionInfoSizeA and GetFileVersionInfoA is wrongly defined:
-- *                        it uses LPSTR instead of LPCSTR as first parameter)
-- *                     - Added declarations to support VC5/6 without using 'dbghelp.h'
-- *                     - Added a 'pUserData' member to the ShowCallstack function and the
-- *                       PReadProcessMemoryRoutine declaration (to pass some user-defined data,
-- *                       which can be used in the readMemoryFunction-callback)
-- *  2005-08-02   v4    - OnSymInit now also outputs the OS-Version by default
-- *                     - Added example for doing an exception-callstack-walking in main.cpp
-- *                       (thanks to owillebo: http://www.codeproject.com/script/profile/whos_who.asp?id=536268)
-- *  2005-08-05   v5    - Removed most Lint (http://www.gimpel.com/) errors... thanks to Okko Willeboordse!
-- *  2008-08-04   v6    - Fixed Bug: Missing LEAK-end-tag
-- *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2502890#xx2502890xx
-- *                       Fixed Bug: Compiled with "WIN32_LEAN_AND_MEAN"
-- *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=1824718#xx1824718xx
-- *                       Fixed Bug: Compiling with "/Wall"
-- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2638243#xx2638243xx
-- *                       Fixed Bug: Now checking SymUseSymSrv
-- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1388979#xx1388979xx
-- *                       Fixed Bug: Support for recursive function calls
-- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1434538#xx1434538xx
-- *                       Fixed Bug: Missing FreeLibrary call in "GetModuleListTH32"
-- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1326923#xx1326923xx
-- *                       Fixed Bug: SymDia is number 7, not 9!
-- *  2008-09-11   v7      For some (undocumented) reason, dbhelp.h is needing a packing of 8!
-- *                       Thanks to Teajay which reported the bug...
-- *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2718933#xx2718933xx
-- *  2008-11-27   v8      Debugging Tools for Windows are now stored in a different directory
-- *                       Thanks to Luiz Salamon which reported this "bug"...
-- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2822736#xx2822736xx
-- *  2009-04-10   v9      License slightly corrected (<ORGANIZATION> replaced)
-- *  2009-11-01   v10     Moved to http://stackwalker.codeplex.com/
-- *  2009-11-02   v11     Now try to use IMAGEHLP_MODULE64_V3 if available
-- *  2010-04-15   v12     Added support for VS2010 RTM
-- *  2010-05-25   v13     Now using secure MyStrcCpy. Thanks to luke.simon:
-- *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=3477467#xx3477467xx
-- *  2013-01-07   v14     Runtime Check Error VS2010 Debug Builds fixed:
-- *                       http://stackwalker.codeplex.com/workitem/10511
-- *
-- *
-- * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
-- *
-- *   Copyright (c) 2005-2013, Jochen Kalmbach
-- *   All rights reserved.
-- *
-- *   Redistribution and use in source and binary forms, with or without modification,
-- *   are permitted provided that the following conditions are met:
-- *
-- *   Redistributions of source code must retain the above copyright notice,
-- *   this list of conditions and the following disclaimer.
-- *   Redistributions in binary form must reproduce the above copyright notice,
-- *   this list of conditions and the following disclaimer in the documentation
-- *   and/or other materials provided with the distribution.
-- *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
-- *   used to endorse or promote products derived from this software without
-- *   specific prior written permission.
-- *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-- *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-- *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-- *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-- *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-- *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-- *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-- *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-- *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-- *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-- *
-- **********************************************************************/
--
--#include "StackWalker.h"
--
--#include <stdio.h>
--#include <stdlib.h>
--#include <tchar.h>
++﻿/**********************************************************************
+  *
+  * StackWalker.cpp
+  * https://github.com/JochenKalmbach/StackWalker
+@@ -87,162 +87,36 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <tchar.h>
 -#include <windows.h>
--#pragma comment(lib, "version.lib") // for "VerQueryValue"
--#pragma warning(disable : 4826)
--
--
+ #pragma comment(lib, "version.lib") // for "VerQueryValue"
+ #pragma warning(disable : 4826)
+ 
++#ifdef UNICODE
++  #define DBGHELP_TRANSLATE_TCHAR
+ 
 -// If VC7 and later, then use the shipped 'dbghelp.h'-file
--#pragma pack(push, 8)
++#endif
+ #pragma pack(push, 8)
 -#if _MSC_VER >= 1300
--#include <dbghelp.h>
+ #include <dbghelp.h>
 -#else
 -// inline the important dbghelp.h-declarations...
 -typedef enum
@@ -251,13 +174,13 @@ index e1b25eb..48c7c57 100644
 -// clang-format on
 -
 -#endif // _MSC_VER < 1300
--#pragma pack(pop)
--
+ #pragma pack(pop)
+ 
 -// Some missing defines (for VC5/6):
 -#ifndef INVALID_FILE_ATTRIBUTES
 -#define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
 -#endif
--
+ 
 -// secure-CRT_functions are only available starting with VC8
 -#if _MSC_VER < 1400
 -#define strcpy_s(dst, len, src) strcpy(dst, src)
@@ -268,28 +191,36 @@ index e1b25eb..48c7c57 100644
 -#endif
 -
 -static void MyStrCpy(char* szDest, size_t nMaxDestSize, const char* szSrc)
--{
--  if (nMaxDestSize <= 0)
--    return;
++static void MyStrCpy(TCHAR* szDest, size_t nMaxDestSize, const TCHAR* szSrc)
+ {
+   if (nMaxDestSize <= 0)
+     return;
 -  strncpy_s(szDest, nMaxDestSize, szSrc, _TRUNCATE);
--  // INFO: _TRUNCATE will ensure that it is null-terminated;
--  // but with older compilers (<1400) it uses "strncpy" and this does not!)
--  szDest[nMaxDestSize - 1] = 0;
--} // MyStrCpy
--
--// Normally it should be enough to use 'CONTEXT_FULL' (better would be 'CONTEXT_ALL')
--#define USED_CONTEXT_FLAGS CONTEXT_FULL
--
--class StackWalkerInternal
--{
--public:
--  StackWalkerInternal(StackWalker* parent, HANDLE hProcess)
--  {
--    m_parent = parent;
--    m_hDbhHelp = NULL;
++  _tcsncpy_s(szDest, nMaxDestSize, szSrc, _TRUNCATE);
+   // INFO: _TRUNCATE will ensure that it is null-terminated;
+   // but with older compilers (<1400) it uses "strncpy" and this does not!)
+   szDest[nMaxDestSize - 1] = 0;
+ } // MyStrCpy
+ 
++#ifdef _UNICODE
++  typedef SYMBOL_INFOW   tSymbolInfo;
++  typedef IMAGEHLP_LINEW64  tImageHelperLine;
++#else
++  typedef SYMBOL_INFO   tSymbolInfo;
++  typedef IMAGEHLP_LINE64  tImageHelperLine;
++#endif
++
+ // Normally it should be enough to use 'CONTEXT_FULL' (better would be 'CONTEXT_ALL')
+ #define USED_CONTEXT_FLAGS CONTEXT_FULL
+ 
+@@ -253,26 +127,26 @@ public:
+   {
+     m_parent = parent;
+     m_hDbhHelp = NULL;
 -    pSC = NULL;
--    m_hProcess = hProcess;
--    m_szSymPath = NULL;
++    symCleanup = NULL;
+     m_hProcess = hProcess;
+     m_szSymPath = NULL;
 -    pSFTA = NULL;
 -    pSGLFA = NULL;
 -    pSGMB = NULL;
@@ -302,92 +233,41 @@ index e1b25eb..48c7c57 100644
 -    pSW = NULL;
 -    pUDSN = NULL;
 -    pSGSP = NULL;
--  }
--  ~StackWalkerInternal()
--  {
++    symFunctionTableAccess64 = NULL;
++    symGetLineFromAddr64 = NULL;
++    symGetModuleBase64 = NULL;
++    symGetModuleInfo64 = NULL;
++    symGetOptions = NULL;
++    symFromAddr = NULL;
++    symInitialize = NULL;
++    symLoadModuleEx = NULL;
++    symSetOptions = NULL;
++    stackWalk64 = NULL;
++    unDecorateSymbolName = NULL;
++    symGetSearchPath = NULL;
+   }
+   ~StackWalkerInternal()
+   {
 -    if (pSC != NULL)
 -      pSC(m_hProcess); // SymCleanup
--    if (m_hDbhHelp != NULL)
--      FreeLibrary(m_hDbhHelp);
--    m_hDbhHelp = NULL;
--    m_parent = NULL;
--    if (m_szSymPath != NULL)
--      free(m_szSymPath);
--    m_szSymPath = NULL;
--  }
++    if (symCleanup != NULL)
++      symCleanup(m_hProcess); // SymCleanup
+     if (m_hDbhHelp != NULL)
+       FreeLibrary(m_hDbhHelp);
+     m_hDbhHelp = NULL;
+@@ -281,7 +155,7 @@ public:
+       free(m_szSymPath);
+     m_szSymPath = NULL;
+   }
 -  BOOL Init(LPCSTR szSymPath)
--  {
--    if (m_parent == NULL)
--      return FALSE;
--    // Dynamically load the Entry-Points for dbghelp.dll:
--    // First try to load the newest one from
--    TCHAR szTemp[4096];
--    // But before we do this, we first check if the ".local" file exists
--    if (GetModuleFileName(NULL, szTemp, 4096) > 0)
--    {
--      _tcscat_s(szTemp, _T(".local"));
--      if (GetFileAttributes(szTemp) == INVALID_FILE_ATTRIBUTES)
--      {
--        // ".local" file does not exist, so we can try to load the dbghelp.dll from the "Debugging Tools for Windows"
--        // Ok, first try the new path according to the architecture:
--#ifdef _M_IX86
--        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
--        {
--          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x86)\\dbghelp.dll"));
--          // now check if the file exists:
--          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
--          {
--            m_hDbhHelp = LoadLibrary(szTemp);
--          }
--        }
--#elif _M_X64
--        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
--        {
--          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x64)\\dbghelp.dll"));
--          // now check if the file exists:
--          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
--          {
--            m_hDbhHelp = LoadLibrary(szTemp);
--          }
--        }
--#elif _M_IA64
--        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
--        {
--          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (ia64)\\dbghelp.dll"));
--          // now check if the file exists:
--          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
--          {
--            m_hDbhHelp = LoadLibrary(szTemp);
--          }
--        }
--#endif
--        // If still not found, try the old directories...
--        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
--        {
--          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows\\dbghelp.dll"));
--          // now check if the file exists:
--          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
--          {
--            m_hDbhHelp = LoadLibrary(szTemp);
--          }
--        }
--#if defined _M_X64 || defined _M_IA64
--        // Still not found? Then try to load the (old) 64-Bit version:
--        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
--        {
--          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows 64-Bit\\dbghelp.dll"));
--          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
--          {
--            m_hDbhHelp = LoadLibrary(szTemp);
--          }
--        }
--#endif
--      }
--    }
--    if (m_hDbhHelp == NULL) // if not already loaded, try to load a default-one
--      m_hDbhHelp = LoadLibrary(_T("dbghelp.dll"));
--    if (m_hDbhHelp == NULL)
--      return FALSE;
++  BOOL Init(LPCTSTR szSymPath)
+   {
+     if (m_parent == NULL)
+       return FALSE;
+@@ -354,54 +228,72 @@ public:
+       m_hDbhHelp = LoadLibrary(_T("dbghelp.dll"));
+     if (m_hDbhHelp == NULL)
+       return FALSE;
 -    pSI = (tSI)GetProcAddress(m_hDbhHelp, "SymInitialize");
 -    pSC = (tSC)GetProcAddress(m_hDbhHelp, "SymCleanup");
 -
@@ -407,1330 +287,6 @@ index e1b25eb..48c7c57 100644
 -    if (pSC == NULL || pSFTA == NULL || pSGMB == NULL || pSGMI == NULL || pSGO == NULL ||
 -        pSGSFA == NULL || pSI == NULL || pSSO == NULL || pSW == NULL || pUDSN == NULL ||
 -        pSLM == NULL)
--    {
--      FreeLibrary(m_hDbhHelp);
--      m_hDbhHelp = NULL;
--      pSC = NULL;
--      return FALSE;
--    }
--
--    // SymInitialize
--    if (szSymPath != NULL)
--      m_szSymPath = _strdup(szSymPath);
--    if (this->pSI(m_hProcess, m_szSymPath, FALSE) == FALSE)
--      this->m_parent->OnDbgHelpErr("SymInitialize", GetLastError(), 0);
--
--    DWORD symOptions = this->pSGO(); // SymGetOptions
--    symOptions |= SYMOPT_LOAD_LINES;
--    symOptions |= SYMOPT_FAIL_CRITICAL_ERRORS;
--    //symOptions |= SYMOPT_NO_PROMPTS;
--    // SymSetOptions
--    symOptions = this->pSSO(symOptions);
--
--    char buf[StackWalker::STACKWALK_MAX_NAMELEN] = {0};
--    if (this->pSGSP != NULL)
--    {
--      if (this->pSGSP(m_hProcess, buf, StackWalker::STACKWALK_MAX_NAMELEN) == FALSE)
--        this->m_parent->OnDbgHelpErr("SymGetSearchPath", GetLastError(), 0);
--    }
--    char  szUserName[1024] = {0};
--    DWORD dwSize = 1024;
--    GetUserNameA(szUserName, &dwSize);
--    this->m_parent->OnSymInit(buf, symOptions, szUserName);
--
--    return TRUE;
--  }
--
--  StackWalker* m_parent;
--
--  HMODULE m_hDbhHelp;
--  HANDLE  m_hProcess;
--  LPSTR   m_szSymPath;
--
--#pragma pack(push, 8)
--  typedef struct IMAGEHLP_MODULE64_V3
--  {
--    DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
--    DWORD64  BaseOfImage;          // base load address of module
--    DWORD    ImageSize;            // virtual size of the loaded module
--    DWORD    TimeDateStamp;        // date/time stamp from pe header
--    DWORD    CheckSum;             // checksum from the pe header
--    DWORD    NumSyms;              // number of symbols in the symbol table
--    SYM_TYPE SymType;              // type of symbols loaded
--    CHAR     ModuleName[32];       // module name
--    CHAR     ImageName[256];       // image name
--    CHAR     LoadedImageName[256]; // symbol file name
--    // new elements: 07-Jun-2002
--    CHAR  LoadedPdbName[256];   // pdb file name
--    DWORD CVSig;                // Signature of the CV record in the debug directories
--    CHAR  CVData[MAX_PATH * 3]; // Contents of the CV record
--    DWORD PdbSig;               // Signature of PDB
--    GUID  PdbSig70;             // Signature of PDB (VC 7 and up)
--    DWORD PdbAge;               // DBI age of pdb
--    BOOL  PdbUnmatched;         // loaded an unmatched pdb
--    BOOL  DbgUnmatched;         // loaded an unmatched dbg
--    BOOL  LineNumbers;          // we have line number information
--    BOOL  GlobalSymbols;        // we have internal symbol information
--    BOOL  TypeInfo;             // we have type information
--    // new elements: 17-Dec-2003
--    BOOL SourceIndexed; // pdb supports source server
--    BOOL Publics;       // contains public symbols
--  };
--
--  typedef struct IMAGEHLP_MODULE64_V2
--  {
--    DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
--    DWORD64  BaseOfImage;          // base load address of module
--    DWORD    ImageSize;            // virtual size of the loaded module
--    DWORD    TimeDateStamp;        // date/time stamp from pe header
--    DWORD    CheckSum;             // checksum from the pe header
--    DWORD    NumSyms;              // number of symbols in the symbol table
--    SYM_TYPE SymType;              // type of symbols loaded
--    CHAR     ModuleName[32];       // module name
--    CHAR     ImageName[256];       // image name
--    CHAR     LoadedImageName[256]; // symbol file name
--  };
--#pragma pack(pop)
--
--  // SymCleanup()
--  typedef BOOL(__stdcall* tSC)(IN HANDLE hProcess);
--  tSC pSC;
--
--  // SymFunctionTableAccess64()
--  typedef PVOID(__stdcall* tSFTA)(HANDLE hProcess, DWORD64 AddrBase);
--  tSFTA pSFTA;
--
--  // SymGetLineFromAddr64()
--  typedef BOOL(__stdcall* tSGLFA)(IN HANDLE hProcess,
--                                  IN DWORD64 dwAddr,
--                                  OUT PDWORD pdwDisplacement,
--                                  OUT PIMAGEHLP_LINE64 Line);
--  tSGLFA pSGLFA;
--
--  // SymGetModuleBase64()
--  typedef DWORD64(__stdcall* tSGMB)(IN HANDLE hProcess, IN DWORD64 dwAddr);
--  tSGMB pSGMB;
--
--  // SymGetModuleInfo64()
--  typedef BOOL(__stdcall* tSGMI)(IN HANDLE hProcess,
--                                 IN DWORD64 dwAddr,
--                                 OUT IMAGEHLP_MODULE64_V3* ModuleInfo);
--  tSGMI pSGMI;
--
--  // SymGetOptions()
--  typedef DWORD(__stdcall* tSGO)(VOID);
--  tSGO pSGO;
--
--  // SymGetSymFromAddr64()
--  typedef BOOL(__stdcall* tSGSFA)(IN HANDLE hProcess,
--                                  IN DWORD64 dwAddr,
--                                  OUT PDWORD64 pdwDisplacement,
--                                  OUT PIMAGEHLP_SYMBOL64 Symbol);
--  tSGSFA pSGSFA;
--
--  // SymInitialize()
--  typedef BOOL(__stdcall* tSI)(IN HANDLE hProcess, IN PSTR UserSearchPath, IN BOOL fInvadeProcess);
--  tSI pSI;
--
--  // SymLoadModule64()
--  typedef DWORD64(__stdcall* tSLM)(IN HANDLE hProcess,
--                                   IN HANDLE hFile,
--                                   IN PSTR ImageName,
--                                   IN PSTR ModuleName,
--                                   IN DWORD64 BaseOfDll,
--                                   IN DWORD SizeOfDll);
--  tSLM pSLM;
--
--  // SymSetOptions()
--  typedef DWORD(__stdcall* tSSO)(IN DWORD SymOptions);
--  tSSO pSSO;
--
--  // StackWalk64()
--  typedef BOOL(__stdcall* tSW)(DWORD                            MachineType,
--                               HANDLE                           hProcess,
--                               HANDLE                           hThread,
--                               LPSTACKFRAME64                   StackFrame,
--                               PVOID                            ContextRecord,
--                               PREAD_PROCESS_MEMORY_ROUTINE64   ReadMemoryRoutine,
--                               PFUNCTION_TABLE_ACCESS_ROUTINE64 FunctionTableAccessRoutine,
--                               PGET_MODULE_BASE_ROUTINE64       GetModuleBaseRoutine,
--                               PTRANSLATE_ADDRESS_ROUTINE64     TranslateAddress);
--  tSW pSW;
--
--  // UnDecorateSymbolName()
--  typedef DWORD(__stdcall WINAPI* tUDSN)(PCSTR DecoratedName,
--                                         PSTR  UnDecoratedName,
--                                         DWORD UndecoratedLength,
--                                         DWORD Flags);
--  tUDSN pUDSN;
--
--  typedef BOOL(__stdcall WINAPI* tSGSP)(HANDLE hProcess, PSTR SearchPath, DWORD SearchPathLength);
--  tSGSP pSGSP;
--
--private:
--// **************************************** ToolHelp32 ************************
--#define MAX_MODULE_NAME32 255
--#define TH32CS_SNAPMODULE 0x00000008
--#pragma pack(push, 8)
--  typedef struct tagMODULEENTRY32
--  {
--    DWORD   dwSize;
--    DWORD   th32ModuleID;  // This module
--    DWORD   th32ProcessID; // owning process
--    DWORD   GlblcntUsage;  // Global usage count on the module
--    DWORD   ProccntUsage;  // Module usage count in th32ProcessID's context
--    BYTE*   modBaseAddr;   // Base address of module in th32ProcessID's context
--    DWORD   modBaseSize;   // Size in bytes of module starting at modBaseAddr
--    HMODULE hModule;       // The hModule of this module in th32ProcessID's context
--    char    szModule[MAX_MODULE_NAME32 + 1];
--    char    szExePath[MAX_PATH];
--  } MODULEENTRY32;
--  typedef MODULEENTRY32* PMODULEENTRY32;
--  typedef MODULEENTRY32* LPMODULEENTRY32;
--#pragma pack(pop)
--
--  BOOL GetModuleListTH32(HANDLE hProcess, DWORD pid)
--  {
--    // CreateToolhelp32Snapshot()
--    typedef HANDLE(__stdcall * tCT32S)(DWORD dwFlags, DWORD th32ProcessID);
--    // Module32First()
--    typedef BOOL(__stdcall * tM32F)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
--    // Module32Next()
--    typedef BOOL(__stdcall * tM32N)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
--
--    // try both dlls...
--    const TCHAR* dllname[] = {_T("kernel32.dll"), _T("tlhelp32.dll")};
--    HINSTANCE    hToolhelp = NULL;
--    tCT32S       pCT32S = NULL;
--    tM32F        pM32F = NULL;
--    tM32N        pM32N = NULL;
--
--    HANDLE        hSnap;
--    MODULEENTRY32 me;
--    me.dwSize = sizeof(me);
--    BOOL   keepGoing;
--    size_t i;
--
--    for (i = 0; i < (sizeof(dllname) / sizeof(dllname[0])); i++)
--    {
--      hToolhelp = LoadLibrary(dllname[i]);
--      if (hToolhelp == NULL)
--        continue;
--      pCT32S = (tCT32S)GetProcAddress(hToolhelp, "CreateToolhelp32Snapshot");
--      pM32F = (tM32F)GetProcAddress(hToolhelp, "Module32First");
--      pM32N = (tM32N)GetProcAddress(hToolhelp, "Module32Next");
--      if ((pCT32S != NULL) && (pM32F != NULL) && (pM32N != NULL))
--        break; // found the functions!
--      FreeLibrary(hToolhelp);
--      hToolhelp = NULL;
--    }
--
--    if (hToolhelp == NULL)
--      return FALSE;
--
--    hSnap = pCT32S(TH32CS_SNAPMODULE, pid);
--    if (hSnap == (HANDLE)-1)
--    {
--      FreeLibrary(hToolhelp);
--      return FALSE;
--    }
--
--    keepGoing = !!pM32F(hSnap, &me);
--    int cnt = 0;
--    while (keepGoing)
--    {
--      this->LoadModule(hProcess, me.szExePath, me.szModule, (DWORD64)me.modBaseAddr,
--                       me.modBaseSize);
--      cnt++;
--      keepGoing = !!pM32N(hSnap, &me);
--    }
--    CloseHandle(hSnap);
--    FreeLibrary(hToolhelp);
--    if (cnt <= 0)
--      return FALSE;
--    return TRUE;
--  } // GetModuleListTH32
--
--  // **************************************** PSAPI ************************
--  typedef struct _MODULEINFO
--  {
--    LPVOID lpBaseOfDll;
--    DWORD  SizeOfImage;
--    LPVOID EntryPoint;
--  } MODULEINFO, *LPMODULEINFO;
--
--  BOOL GetModuleListPSAPI(HANDLE hProcess)
--  {
--    // EnumProcessModules()
--    typedef BOOL(__stdcall * tEPM)(HANDLE hProcess, HMODULE * lphModule, DWORD cb,
--                                   LPDWORD lpcbNeeded);
--    // GetModuleFileNameEx()
--    typedef DWORD(__stdcall * tGMFNE)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename,
--                                      DWORD nSize);
--    // GetModuleBaseName()
--    typedef DWORD(__stdcall * tGMBN)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename,
--                                     DWORD nSize);
--    // GetModuleInformation()
--    typedef BOOL(__stdcall * tGMI)(HANDLE hProcess, HMODULE hModule, LPMODULEINFO pmi, DWORD nSize);
--
--    HINSTANCE hPsapi;
--    tEPM      pEPM;
--    tGMFNE    pGMFNE;
--    tGMBN     pGMBN;
--    tGMI      pGMI;
--
--    DWORD i;
--    //ModuleEntry e;
--    DWORD        cbNeeded;
--    MODULEINFO   mi;
--    HMODULE*     hMods = 0;
--    char*        tt = NULL;
--    char*        tt2 = NULL;
--    const SIZE_T TTBUFLEN = 8096;
--    int          cnt = 0;
--
--    hPsapi = LoadLibrary(_T("psapi.dll"));
--    if (hPsapi == NULL)
--      return FALSE;
--
--    pEPM = (tEPM)GetProcAddress(hPsapi, "EnumProcessModules");
--    pGMFNE = (tGMFNE)GetProcAddress(hPsapi, "GetModuleFileNameExA");
--    pGMBN = (tGMFNE)GetProcAddress(hPsapi, "GetModuleBaseNameA");
--    pGMI = (tGMI)GetProcAddress(hPsapi, "GetModuleInformation");
--    if ((pEPM == NULL) || (pGMFNE == NULL) || (pGMBN == NULL) || (pGMI == NULL))
--    {
--      // we couldn't find all functions
--      FreeLibrary(hPsapi);
--      return FALSE;
--    }
--
--    hMods = (HMODULE*)malloc(sizeof(HMODULE) * (TTBUFLEN / sizeof(HMODULE)));
--    tt = (char*)malloc(sizeof(char) * TTBUFLEN);
--    tt2 = (char*)malloc(sizeof(char) * TTBUFLEN);
--    if ((hMods == NULL) || (tt == NULL) || (tt2 == NULL))
--      goto cleanup;
--
--    if (!pEPM(hProcess, hMods, TTBUFLEN, &cbNeeded))
--    {
--      //_ftprintf(fLogFile, _T("%lu: EPM failed, GetLastError = %lu\n"), g_dwShowCount, gle );
--      goto cleanup;
--    }
--
--    if (cbNeeded > TTBUFLEN)
--    {
--      //_ftprintf(fLogFile, _T("%lu: More than %lu module handles. Huh?\n"), g_dwShowCount, lenof( hMods ) );
--      goto cleanup;
--    }
--
--    for (i = 0; i < cbNeeded / sizeof(hMods[0]); i++)
--    {
--      // base address, size
--      pGMI(hProcess, hMods[i], &mi, sizeof(mi));
--      // image file name
--      tt[0] = 0;
--      pGMFNE(hProcess, hMods[i], tt, TTBUFLEN);
--      // module name
--      tt2[0] = 0;
--      pGMBN(hProcess, hMods[i], tt2, TTBUFLEN);
--
--      DWORD dwRes = this->LoadModule(hProcess, tt, tt2, (DWORD64)mi.lpBaseOfDll, mi.SizeOfImage);
--      if (dwRes != ERROR_SUCCESS)
--        this->m_parent->OnDbgHelpErr("LoadModule", dwRes, 0);
--      cnt++;
--    }
--
--  cleanup:
--    if (hPsapi != NULL)
--      FreeLibrary(hPsapi);
--    if (tt2 != NULL)
--      free(tt2);
--    if (tt != NULL)
--      free(tt);
--    if (hMods != NULL)
--      free(hMods);
--
--    return cnt != 0;
--  } // GetModuleListPSAPI
--
--  DWORD LoadModule(HANDLE hProcess, LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size)
--  {
--    CHAR* szImg = _strdup(img);
--    CHAR* szMod = _strdup(mod);
--    DWORD result = ERROR_SUCCESS;
--    if ((szImg == NULL) || (szMod == NULL))
--      result = ERROR_NOT_ENOUGH_MEMORY;
--    else
--    {
--      if (pSLM(hProcess, 0, szImg, szMod, baseAddr, size) == 0)
--        result = GetLastError();
--    }
--    ULONGLONG fileVersion = 0;
--    if ((m_parent != NULL) && (szImg != NULL))
--    {
--      // try to retrieve the file-version:
--      if ((this->m_parent->m_options & StackWalker::RetrieveFileVersion) != 0)
--      {
--        VS_FIXEDFILEINFO* fInfo = NULL;
--        DWORD             dwHandle;
--        DWORD             dwSize = GetFileVersionInfoSizeA(szImg, &dwHandle);
--        if (dwSize > 0)
--        {
--          LPVOID vData = malloc(dwSize);
--          if (vData != NULL)
--          {
--            if (GetFileVersionInfoA(szImg, dwHandle, dwSize, vData) != 0)
--            {
--              UINT  len;
--              TCHAR szSubBlock[] = _T("\\");
--              if (VerQueryValue(vData, szSubBlock, (LPVOID*)&fInfo, &len) == 0)
--                fInfo = NULL;
--              else
--              {
--                fileVersion =
--                    ((ULONGLONG)fInfo->dwFileVersionLS) + ((ULONGLONG)fInfo->dwFileVersionMS << 32);
--              }
--            }
--            free(vData);
--          }
--        }
--      }
--
--      // Retrieve some additional-infos about the module
--      IMAGEHLP_MODULE64_V3 Module;
--      const char*          szSymType = "-unknown-";
--      if (this->GetModuleInfo(hProcess, baseAddr, &Module) != FALSE)
--      {
--        switch (Module.SymType)
--        {
--          case SymNone:
--            szSymType = "-nosymbols-";
--            break;
--          case SymCoff: // 1
--            szSymType = "COFF";
--            break;
--          case SymCv: // 2
--            szSymType = "CV";
--            break;
--          case SymPdb: // 3
--            szSymType = "PDB";
--            break;
--          case SymExport: // 4
--            szSymType = "-exported-";
--            break;
--          case SymDeferred: // 5
--            szSymType = "-deferred-";
--            break;
--          case SymSym: // 6
--            szSymType = "SYM";
--            break;
--          case 7: // SymDia:
--            szSymType = "DIA";
--            break;
--          case 8: //SymVirtual:
--            szSymType = "Virtual";
--            break;
--        }
--      }
--      LPCSTR pdbName = Module.LoadedImageName;
--      if (Module.LoadedPdbName[0] != 0)
--        pdbName = Module.LoadedPdbName;
--      this->m_parent->OnLoadModule(img, mod, baseAddr, size, result, szSymType, pdbName,
--                                   fileVersion);
--    }
--    if (szImg != NULL)
--      free(szImg);
--    if (szMod != NULL)
--      free(szMod);
--    return result;
--  }
--
--public:
--  BOOL LoadModules(HANDLE hProcess, DWORD dwProcessId)
--  {
--    // first try toolhelp32
--    if (GetModuleListTH32(hProcess, dwProcessId))
--      return true;
--    // then try psapi
--    return GetModuleListPSAPI(hProcess);
--  }
--
--  BOOL GetModuleInfo(HANDLE hProcess, DWORD64 baseAddr, IMAGEHLP_MODULE64_V3* pModuleInfo)
--  {
--    memset(pModuleInfo, 0, sizeof(IMAGEHLP_MODULE64_V3));
--    if (this->pSGMI == NULL)
--    {
--      SetLastError(ERROR_DLL_INIT_FAILED);
--      return FALSE;
--    }
--    // First try to use the larger ModuleInfo-Structure
--    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
--    void* pData = malloc(
--        4096); // reserve enough memory, so the bug in v6.3.5.1 does not lead to memory-overwrites...
--    if (pData == NULL)
--    {
--      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
--      return FALSE;
--    }
--    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V3));
--    static bool s_useV3Version = true;
--    if (s_useV3Version)
--    {
--      if (this->pSGMI(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
--      {
--        // only copy as much memory as is reserved...
--        memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V3));
--        pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
--        free(pData);
--        return TRUE;
--      }
--      s_useV3Version = false; // to prevent unnecessary calls with the larger struct...
--    }
--
--    // could not retrieve the bigger structure, try with the smaller one (as defined in VC7.1)...
--    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
--    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V2));
--    if (this->pSGMI(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
--    {
--      // only copy as much memory as is reserved...
--      memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V2));
--      pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
--      free(pData);
--      return TRUE;
--    }
--    free(pData);
--    SetLastError(ERROR_DLL_INIT_FAILED);
--    return FALSE;
--  }
--};
--
--// #############################################################
--StackWalker::StackWalker(DWORD dwProcessId, HANDLE hProcess)
--{
--  this->m_options = OptionsAll;
--  this->m_modulesLoaded = FALSE;
--  this->m_hProcess = hProcess;
--  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
--  this->m_dwProcessId = dwProcessId;
--  this->m_szSymPath = NULL;
--  this->m_MaxRecursionCount = 1000;
--}
--StackWalker::StackWalker(int options, LPCSTR szSymPath, DWORD dwProcessId, HANDLE hProcess)
--{
--  this->m_options = options;
--  this->m_modulesLoaded = FALSE;
--  this->m_hProcess = hProcess;
--  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
--  this->m_dwProcessId = dwProcessId;
--  if (szSymPath != NULL)
--  {
--    this->m_szSymPath = _strdup(szSymPath);
--    this->m_options |= SymBuildPath;
--  }
--  else
--    this->m_szSymPath = NULL;
--  this->m_MaxRecursionCount = 1000;
--}
--
--StackWalker::~StackWalker()
--{
--  if (m_szSymPath != NULL)
--    free(m_szSymPath);
--  m_szSymPath = NULL;
--  if (this->m_sw != NULL)
--    delete this->m_sw;
--  this->m_sw = NULL;
--}
--
--BOOL StackWalker::LoadModules()
--{
--  if (this->m_sw == NULL)
--  {
--    SetLastError(ERROR_DLL_INIT_FAILED);
--    return FALSE;
--  }
--  if (m_modulesLoaded != FALSE)
--    return TRUE;
--
--  // Build the sym-path:
--  char* szSymPath = NULL;
--  if ((this->m_options & SymBuildPath) != 0)
--  {
--    const size_t nSymPathLen = 4096;
--    szSymPath = (char*)malloc(nSymPathLen);
--    if (szSymPath == NULL)
--    {
--      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
--      return FALSE;
--    }
--    szSymPath[0] = 0;
--    // Now first add the (optional) provided sympath:
--    if (this->m_szSymPath != NULL)
--    {
--      strcat_s(szSymPath, nSymPathLen, this->m_szSymPath);
--      strcat_s(szSymPath, nSymPathLen, ";");
--    }
--
--    strcat_s(szSymPath, nSymPathLen, ".;");
--
--    const size_t nTempLen = 1024;
--    char         szTemp[nTempLen];
--    // Now add the current directory:
--    if (GetCurrentDirectoryA(nTempLen, szTemp) > 0)
--    {
--      szTemp[nTempLen - 1] = 0;
--      strcat_s(szSymPath, nSymPathLen, szTemp);
--      strcat_s(szSymPath, nSymPathLen, ";");
--    }
--
--    // Now add the path for the main-module:
--    if (GetModuleFileNameA(NULL, szTemp, nTempLen) > 0)
--    {
--      szTemp[nTempLen - 1] = 0;
--      for (char* p = (szTemp + strlen(szTemp) - 1); p >= szTemp; --p)
--      {
--        // locate the rightmost path separator
--        if ((*p == '\\') || (*p == '/') || (*p == ':'))
--        {
--          *p = 0;
--          break;
--        }
--      } // for (search for path separator...)
--      if (strlen(szTemp) > 0)
--      {
--        strcat_s(szSymPath, nSymPathLen, szTemp);
--        strcat_s(szSymPath, nSymPathLen, ";");
--      }
--    }
--    if (GetEnvironmentVariableA("_NT_SYMBOL_PATH", szTemp, nTempLen) > 0)
--    {
--      szTemp[nTempLen - 1] = 0;
--      strcat_s(szSymPath, nSymPathLen, szTemp);
--      strcat_s(szSymPath, nSymPathLen, ";");
--    }
--    if (GetEnvironmentVariableA("_NT_ALTERNATE_SYMBOL_PATH", szTemp, nTempLen) > 0)
--    {
--      szTemp[nTempLen - 1] = 0;
--      strcat_s(szSymPath, nSymPathLen, szTemp);
--      strcat_s(szSymPath, nSymPathLen, ";");
--    }
--    if (GetEnvironmentVariableA("SYSTEMROOT", szTemp, nTempLen) > 0)
--    {
--      szTemp[nTempLen - 1] = 0;
--      strcat_s(szSymPath, nSymPathLen, szTemp);
--      strcat_s(szSymPath, nSymPathLen, ";");
--      // also add the "system32"-directory:
--      strcat_s(szTemp, nTempLen, "\\system32");
--      strcat_s(szSymPath, nSymPathLen, szTemp);
--      strcat_s(szSymPath, nSymPathLen, ";");
--    }
--
--    if ((this->m_options & SymUseSymSrv) != 0)
--    {
--      if (GetEnvironmentVariableA("SYSTEMDRIVE", szTemp, nTempLen) > 0)
--      {
--        szTemp[nTempLen - 1] = 0;
--        strcat_s(szSymPath, nSymPathLen, "SRV*");
--        strcat_s(szSymPath, nSymPathLen, szTemp);
--        strcat_s(szSymPath, nSymPathLen, "\\websymbols");
--        strcat_s(szSymPath, nSymPathLen, "*http://msdl.microsoft.com/download/symbols;");
--      }
--      else
--        strcat_s(szSymPath, nSymPathLen,
--                 "SRV*c:\\websymbols*http://msdl.microsoft.com/download/symbols;");
--    }
--  } // if SymBuildPath
--
--  // First Init the whole stuff...
--  BOOL bRet = this->m_sw->Init(szSymPath);
--  if (szSymPath != NULL)
--    free(szSymPath);
--  szSymPath = NULL;
--  if (bRet == FALSE)
--  {
--    this->OnDbgHelpErr("Error while initializing dbghelp.dll", 0, 0);
--    SetLastError(ERROR_DLL_INIT_FAILED);
--    return FALSE;
--  }
--
--  bRet = this->m_sw->LoadModules(this->m_hProcess, this->m_dwProcessId);
--  if (bRet != FALSE)
--    m_modulesLoaded = TRUE;
--  return bRet;
--}
--
--// The following is used to pass the "userData"-Pointer to the user-provided readMemoryFunction
--// This has to be done due to a problem with the "hProcess"-parameter in x64...
--// Because this class is in no case multi-threading-enabled (because of the limitations
--// of dbghelp.dll) it is "safe" to use a static-variable
--static StackWalker::PReadProcessMemoryRoutine s_readMemoryFunction = NULL;
--static LPVOID                                 s_readMemoryFunction_UserData = NULL;
--
--BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
--                                const CONTEXT*            context,
--                                PReadProcessMemoryRoutine readMemoryFunction,
--                                LPVOID                    pUserData)
--{
--  CONTEXT                                   c;
--  CallstackEntry                            csEntry;
--  IMAGEHLP_SYMBOL64*                        pSym = NULL;
--  StackWalkerInternal::IMAGEHLP_MODULE64_V3 Module;
--  IMAGEHLP_LINE64                           Line;
--  int                                       frameNum;
--  bool                                      bLastEntryCalled = true;
--  int                                       curRecursionCount = 0;
--
--  if (m_modulesLoaded == FALSE)
--    this->LoadModules(); // ignore the result...
--
--  if (this->m_sw->m_hDbhHelp == NULL)
--  {
--    SetLastError(ERROR_DLL_INIT_FAILED);
--    return FALSE;
--  }
--
--  s_readMemoryFunction = readMemoryFunction;
--  s_readMemoryFunction_UserData = pUserData;
--
--  if (context == NULL)
--  {
--    // If no context is provided, capture the context
--    // See: https://stackwalker.codeplex.com/discussions/446958
--#if _WIN32_WINNT <= 0x0501
--    // If we need to support XP, we need to use the "old way", because "GetThreadId" is not available!
--    if (hThread == GetCurrentThread())
--#else
--    if (GetThreadId(hThread) == GetCurrentThreadId())
--#endif
--    {
--      GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, USED_CONTEXT_FLAGS);
--    }
--    else
--    {
--      SuspendThread(hThread);
--      memset(&c, 0, sizeof(CONTEXT));
--      c.ContextFlags = USED_CONTEXT_FLAGS;
--
--      // TODO: Detect if you want to get a thread context of a different process, which is running a different processor architecture...
--      // This does only work if we are x64 and the target process is x64 or x86;
--      // It cannot work, if this process is x64 and the target process is x64... this is not supported...
--      // See also: http://www.howzatt.demon.co.uk/articles/DebuggingInWin64.html
--      if (GetThreadContext(hThread, &c) == FALSE)
--      {
--        ResumeThread(hThread);
--        return FALSE;
--      }
--    }
--  }
--  else
--    c = *context;
--
--  // init STACKFRAME for first call
--  STACKFRAME64 s; // in/out stackframe
--  memset(&s, 0, sizeof(s));
--  DWORD imageType;
--#ifdef _M_IX86
--  // normally, call ImageNtHeader() and use machine info from PE header
--  imageType = IMAGE_FILE_MACHINE_I386;
--  s.AddrPC.Offset = c.Eip;
--  s.AddrPC.Mode = AddrModeFlat;
--  s.AddrFrame.Offset = c.Ebp;
--  s.AddrFrame.Mode = AddrModeFlat;
--  s.AddrStack.Offset = c.Esp;
--  s.AddrStack.Mode = AddrModeFlat;
--#elif _M_X64
--  imageType = IMAGE_FILE_MACHINE_AMD64;
--  s.AddrPC.Offset = c.Rip;
--  s.AddrPC.Mode = AddrModeFlat;
--  s.AddrFrame.Offset = c.Rsp;
--  s.AddrFrame.Mode = AddrModeFlat;
--  s.AddrStack.Offset = c.Rsp;
--  s.AddrStack.Mode = AddrModeFlat;
--#elif _M_IA64
--  imageType = IMAGE_FILE_MACHINE_IA64;
--  s.AddrPC.Offset = c.StIIP;
--  s.AddrPC.Mode = AddrModeFlat;
--  s.AddrFrame.Offset = c.IntSp;
--  s.AddrFrame.Mode = AddrModeFlat;
--  s.AddrBStore.Offset = c.RsBSP;
--  s.AddrBStore.Mode = AddrModeFlat;
--  s.AddrStack.Offset = c.IntSp;
--  s.AddrStack.Mode = AddrModeFlat;
--#else
--#error "Platform not supported!"
--#endif
--
--  pSym = (IMAGEHLP_SYMBOL64*)malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
--  if (!pSym)
--    goto cleanup; // not enough memory...
--  memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
--  pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
--  pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
--
--  memset(&Line, 0, sizeof(Line));
--  Line.SizeOfStruct = sizeof(Line);
--
--  memset(&Module, 0, sizeof(Module));
--  Module.SizeOfStruct = sizeof(Module);
--
--  for (frameNum = 0;; ++frameNum)
--  {
--    // get next stack frame (StackWalk64(), SymFunctionTableAccess64(), SymGetModuleBase64())
--    // if this returns ERROR_INVALID_ADDRESS (487) or ERROR_NOACCESS (998), you can
--    // assume that either you are done, or that the stack is so hosed that the next
--    // deeper frame could not be found.
--    // CONTEXT need not to be supplied if imageTyp is IMAGE_FILE_MACHINE_I386!
--    if (!this->m_sw->pSW(imageType, this->m_hProcess, hThread, &s, &c, myReadProcMem,
--                         this->m_sw->pSFTA, this->m_sw->pSGMB, NULL))
--    {
--      // INFO: "StackWalk64" does not set "GetLastError"...
--      this->OnDbgHelpErr("StackWalk64", 0, s.AddrPC.Offset);
--      break;
--    }
--
--    csEntry.offset = s.AddrPC.Offset;
--    csEntry.name[0] = 0;
--    csEntry.undName[0] = 0;
--    csEntry.undFullName[0] = 0;
--    csEntry.offsetFromSmybol = 0;
--    csEntry.offsetFromLine = 0;
--    csEntry.lineFileName[0] = 0;
--    csEntry.lineNumber = 0;
--    csEntry.loadedImageName[0] = 0;
--    csEntry.moduleName[0] = 0;
--    if (s.AddrPC.Offset == s.AddrReturn.Offset)
--    {
--      if ((this->m_MaxRecursionCount > 0) && (curRecursionCount > m_MaxRecursionCount))
--      {
--        this->OnDbgHelpErr("StackWalk64-Endless-Callstack!", 0, s.AddrPC.Offset);
--        break;
--      }
--      curRecursionCount++;
--    }
--    else
--      curRecursionCount = 0;
--    if (s.AddrPC.Offset != 0)
--    {
--      // we seem to have a valid PC
--      // show procedure info (SymGetSymFromAddr64())
--      if (this->m_sw->pSGSFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromSmybol),
--                             pSym) != FALSE)
--      {
--        MyStrCpy(csEntry.name, STACKWALK_MAX_NAMELEN, pSym->Name);
--        // UnDecorateSymbolName()
--        this->m_sw->pUDSN(pSym->Name, csEntry.undName, STACKWALK_MAX_NAMELEN, UNDNAME_NAME_ONLY);
--        this->m_sw->pUDSN(pSym->Name, csEntry.undFullName, STACKWALK_MAX_NAMELEN, UNDNAME_COMPLETE);
--      }
--      else
--      {
--        this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), s.AddrPC.Offset);
--      }
--
--      // show line number info, NT5.0-method (SymGetLineFromAddr64())
--      if (this->m_sw->pSGLFA != NULL)
--      { // yes, we have SymGetLineFromAddr64()
--        if (this->m_sw->pSGLFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromLine),
--                               &Line) != FALSE)
--        {
--          csEntry.lineNumber = Line.LineNumber;
--          MyStrCpy(csEntry.lineFileName, STACKWALK_MAX_NAMELEN, Line.FileName);
--        }
--        else
--        {
--          this->OnDbgHelpErr("SymGetLineFromAddr64", GetLastError(), s.AddrPC.Offset);
--        }
--      } // yes, we have SymGetLineFromAddr64()
--
--      // show module info (SymGetModuleInfo64())
--      if (this->m_sw->GetModuleInfo(this->m_hProcess, s.AddrPC.Offset, &Module) != FALSE)
--      { // got module info OK
--        switch (Module.SymType)
--        {
--          case SymNone:
--            csEntry.symTypeString = "-nosymbols-";
--            break;
--          case SymCoff:
--            csEntry.symTypeString = "COFF";
--            break;
--          case SymCv:
--            csEntry.symTypeString = "CV";
--            break;
--          case SymPdb:
--            csEntry.symTypeString = "PDB";
--            break;
--          case SymExport:
--            csEntry.symTypeString = "-exported-";
--            break;
--          case SymDeferred:
--            csEntry.symTypeString = "-deferred-";
--            break;
--          case SymSym:
--            csEntry.symTypeString = "SYM";
--            break;
--#if API_VERSION_NUMBER >= 9
--          case SymDia:
--            csEntry.symTypeString = "DIA";
--            break;
--#endif
--          case 8: //SymVirtual:
--            csEntry.symTypeString = "Virtual";
--            break;
--          default:
--            //_snprintf( ty, sizeof(ty), "symtype=%ld", (long) Module.SymType );
--            csEntry.symTypeString = NULL;
--            break;
--        }
--
--        MyStrCpy(csEntry.moduleName, STACKWALK_MAX_NAMELEN, Module.ModuleName);
--        csEntry.baseOfImage = Module.BaseOfImage;
--        MyStrCpy(csEntry.loadedImageName, STACKWALK_MAX_NAMELEN, Module.LoadedImageName);
--      } // got module info OK
--      else
--      {
--        this->OnDbgHelpErr("SymGetModuleInfo64", GetLastError(), s.AddrPC.Offset);
--      }
--    } // we seem to have a valid PC
--
--    CallstackEntryType et = nextEntry;
--    if (frameNum == 0)
--      et = firstEntry;
--    bLastEntryCalled = false;
--    this->OnCallstackEntry(et, csEntry);
--
--    if (s.AddrReturn.Offset == 0)
--    {
--      bLastEntryCalled = true;
--      this->OnCallstackEntry(lastEntry, csEntry);
--      SetLastError(ERROR_SUCCESS);
--      break;
--    }
--  } // for ( frameNum )
--
--cleanup:
--  if (pSym)
--    free(pSym);
--
--  if (bLastEntryCalled == false)
--    this->OnCallstackEntry(lastEntry, csEntry);
--
--  if (context == NULL)
--    ResumeThread(hThread);
--
--  return TRUE;
--}
--
--BOOL StackWalker::ShowObject(LPVOID pObject)
--{
--  // Load modules if not done yet
--  if (m_modulesLoaded == FALSE)
--    this->LoadModules(); // ignore the result...
--
--  // Verify that the DebugHelp.dll was actually found
--  if (this->m_sw->m_hDbhHelp == NULL)
--  {
--    SetLastError(ERROR_DLL_INIT_FAILED);
--    return FALSE;
--  }
--
--  // SymGetSymFromAddr64() is required
--  if (this->m_sw->pSGSFA == NULL)
--    return FALSE;
--
--  // Show object info (SymGetSymFromAddr64())
--  DWORD64            dwAddress = DWORD64(pObject);
--  DWORD64            dwDisplacement = 0;
--  IMAGEHLP_SYMBOL64* pSym =
--      (IMAGEHLP_SYMBOL64*)malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
--  memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
--  pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
--  pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
--  if (this->m_sw->pSGSFA(this->m_hProcess, dwAddress, &dwDisplacement, pSym) == FALSE)
--  {
--    this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), dwAddress);
--    return FALSE;
--  }
--  // Object name output
--  this->OnOutput(pSym->Name);
--
--  free(pSym);
--  return TRUE;
--};
--
--BOOL __stdcall StackWalker::myReadProcMem(HANDLE  hProcess,
--                                          DWORD64 qwBaseAddress,
--                                          PVOID   lpBuffer,
--                                          DWORD   nSize,
--                                          LPDWORD lpNumberOfBytesRead)
--{
--  if (s_readMemoryFunction == NULL)
--  {
--    SIZE_T st;
--    BOOL   bRet = ReadProcessMemory(hProcess, (LPVOID)qwBaseAddress, lpBuffer, nSize, &st);
--    *lpNumberOfBytesRead = (DWORD)st;
--    //printf("ReadMemory: hProcess: %p, baseAddr: %p, buffer: %p, size: %d, read: %d, result: %d\n", hProcess, (LPVOID) qwBaseAddress, lpBuffer, nSize, (DWORD) st, (DWORD) bRet);
--    return bRet;
--  }
--  else
--  {
--    return s_readMemoryFunction(hProcess, qwBaseAddress, lpBuffer, nSize, lpNumberOfBytesRead,
--                                s_readMemoryFunction_UserData);
--  }
--}
--
--void StackWalker::OnLoadModule(LPCSTR    img,
--                               LPCSTR    mod,
--                               DWORD64   baseAddr,
--                               DWORD     size,
--                               DWORD     result,
--                               LPCSTR    symType,
--                               LPCSTR    pdbName,
--                               ULONGLONG fileVersion)
--{
--  CHAR   buffer[STACKWALK_MAX_NAMELEN];
--  size_t maxLen = STACKWALK_MAX_NAMELEN;
--#if _MSC_VER >= 1400
--  maxLen = _TRUNCATE;
--#endif
--  if (fileVersion == 0)
--    _snprintf_s(buffer, maxLen, "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s'\n",
--                img, mod, (LPVOID)baseAddr, size, result, symType, pdbName);
--  else
--  {
--    DWORD v4 = (DWORD)(fileVersion & 0xFFFF);
--    DWORD v3 = (DWORD)((fileVersion >> 16) & 0xFFFF);
--    DWORD v2 = (DWORD)((fileVersion >> 32) & 0xFFFF);
--    DWORD v1 = (DWORD)((fileVersion >> 48) & 0xFFFF);
--    _snprintf_s(
--        buffer, maxLen,
--        "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s', fileVersion: %d.%d.%d.%d\n",
--        img, mod, (LPVOID)baseAddr, size, result, symType, pdbName, v1, v2, v3, v4);
--  }
--  buffer[STACKWALK_MAX_NAMELEN - 1] = 0; // be sure it is NULL terminated
--  OnOutput(buffer);
--}
--
--void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry)
--{
--  CHAR   buffer[STACKWALK_MAX_NAMELEN];
--  size_t maxLen = STACKWALK_MAX_NAMELEN;
--#if _MSC_VER >= 1400
--  maxLen = _TRUNCATE;
--#endif
--  if ((eType != lastEntry) && (entry.offset != 0))
--  {
--    if (entry.name[0] == 0)
--      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, "(function-name not available)");
--    if (entry.undName[0] != 0)
--      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undName);
--    if (entry.undFullName[0] != 0)
--      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undFullName);
--    if (entry.lineFileName[0] == 0)
--    {
--      MyStrCpy(entry.lineFileName, STACKWALK_MAX_NAMELEN, "(filename not available)");
--      if (entry.moduleName[0] == 0)
--        MyStrCpy(entry.moduleName, STACKWALK_MAX_NAMELEN, "(module-name not available)");
--      _snprintf_s(buffer, maxLen, "%p (%s): %s: %s\n", (LPVOID)entry.offset, entry.moduleName,
--                  entry.lineFileName, entry.name);
--    }
--    else
--      _snprintf_s(buffer, maxLen, "%s (%d): %s\n", entry.lineFileName, entry.lineNumber,
--                  entry.name);
--    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
--    OnOutput(buffer);
--  }
--}
--
--void StackWalker::OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr)
--{
--  CHAR   buffer[STACKWALK_MAX_NAMELEN];
--  size_t maxLen = STACKWALK_MAX_NAMELEN;
--#if _MSC_VER >= 1400
--  maxLen = _TRUNCATE;
--#endif
--  _snprintf_s(buffer, maxLen, "ERROR: %s, GetLastError: %d (Address: %p)\n", szFuncName, gle,
--              (LPVOID)addr);
--  buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
--  OnOutput(buffer);
--}
--
--void StackWalker::OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName)
--{
--  CHAR   buffer[STACKWALK_MAX_NAMELEN];
--  size_t maxLen = STACKWALK_MAX_NAMELEN;
--#if _MSC_VER >= 1400
--  maxLen = _TRUNCATE;
--#endif
--  _snprintf_s(buffer, maxLen, "SymInit: Symbol-SearchPath: '%s', symOptions: %d, UserName: '%s'\n",
--              szSearchPath, symOptions, szUserName);
--  buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
--  OnOutput(buffer);
--  // Also display the OS-version
--#if _MSC_VER <= 1200
--  OSVERSIONINFOA ver;
--  ZeroMemory(&ver, sizeof(OSVERSIONINFOA));
--  ver.dwOSVersionInfoSize = sizeof(ver);
--  if (GetVersionExA(&ver) != FALSE)
--  {
--    _snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s)\n", ver.dwMajorVersion,
--                ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion);
--    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
--    OnOutput(buffer);
--  }
--#else
--  OSVERSIONINFOEXA ver;
--  ZeroMemory(&ver, sizeof(OSVERSIONINFOEXA));
--  ver.dwOSVersionInfoSize = sizeof(ver);
--#if _MSC_VER >= 1900
--#pragma warning(push)
--#pragma warning(disable : 4996)
--#endif
--  if (GetVersionExA((OSVERSIONINFOA*)&ver) != FALSE)
--  {
--    _snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s) 0x%x-0x%x\n", ver.dwMajorVersion,
--                ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion, ver.wSuiteMask,
--                ver.wProductType);
--    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
--    OnOutput(buffer);
--  }
--#if _MSC_VER >= 1900
--#pragma warning(pop)
--#endif
--#endif
--}
--
--void StackWalker::OnOutput(LPCSTR buffer)
--{
--  OutputDebugStringA(buffer);
--}
-+﻿/**********************************************************************
-+ *
-+ * StackWalker.cpp
-+ * https://github.com/JochenKalmbach/StackWalker
-+ *
-+ * Old location: http://stackwalker.codeplex.com/
-+ *
-+ *
-+ * History:
-+ *  2005-07-27   v1    - First public release on http://www.codeproject.com/
-+ *                       http://www.codeproject.com/threads/StackWalker.asp
-+ *  2005-07-28   v2    - Changed the params of the constructor and ShowCallstack
-+ *                       (to simplify the usage)
-+ *  2005-08-01   v3    - Changed to use 'CONTEXT_FULL' instead of CONTEXT_ALL
-+ *                       (should also be enough)
-+ *                     - Changed to compile correctly with the PSDK of VC7.0
-+ *                       (GetFileVersionInfoSizeA and GetFileVersionInfoA is wrongly defined:
-+ *                        it uses LPSTR instead of LPCSTR as first parameter)
-+ *                     - Added declarations to support VC5/6 without using 'dbghelp.h'
-+ *                     - Added a 'pUserData' member to the ShowCallstack function and the
-+ *                       PReadProcessMemoryRoutine declaration (to pass some user-defined data,
-+ *                       which can be used in the readMemoryFunction-callback)
-+ *  2005-08-02   v4    - OnSymInit now also outputs the OS-Version by default
-+ *                     - Added example for doing an exception-callstack-walking in main.cpp
-+ *                       (thanks to owillebo: http://www.codeproject.com/script/profile/whos_who.asp?id=536268)
-+ *  2005-08-05   v5    - Removed most Lint (http://www.gimpel.com/) errors... thanks to Okko Willeboordse!
-+ *  2008-08-04   v6    - Fixed Bug: Missing LEAK-end-tag
-+ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2502890#xx2502890xx
-+ *                       Fixed Bug: Compiled with "WIN32_LEAN_AND_MEAN"
-+ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=1824718#xx1824718xx
-+ *                       Fixed Bug: Compiling with "/Wall"
-+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2638243#xx2638243xx
-+ *                       Fixed Bug: Now checking SymUseSymSrv
-+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1388979#xx1388979xx
-+ *                       Fixed Bug: Support for recursive function calls
-+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1434538#xx1434538xx
-+ *                       Fixed Bug: Missing FreeLibrary call in "GetModuleListTH32"
-+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1326923#xx1326923xx
-+ *                       Fixed Bug: SymDia is number 7, not 9!
-+ *  2008-09-11   v7      For some (undocumented) reason, dbhelp.h is needing a packing of 8!
-+ *                       Thanks to Teajay which reported the bug...
-+ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2718933#xx2718933xx
-+ *  2008-11-27   v8      Debugging Tools for Windows are now stored in a different directory
-+ *                       Thanks to Luiz Salamon which reported this "bug"...
-+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2822736#xx2822736xx
-+ *  2009-04-10   v9      License slightly corrected (<ORGANIZATION> replaced)
-+ *  2009-11-01   v10     Moved to http://stackwalker.codeplex.com/
-+ *  2009-11-02   v11     Now try to use IMAGEHLP_MODULE64_V3 if available
-+ *  2010-04-15   v12     Added support for VS2010 RTM
-+ *  2010-05-25   v13     Now using secure MyStrcCpy. Thanks to luke.simon:
-+ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=3477467#xx3477467xx
-+ *  2013-01-07   v14     Runtime Check Error VS2010 Debug Builds fixed:
-+ *                       http://stackwalker.codeplex.com/workitem/10511
-+ *
-+ *
-+ * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
-+ *
-+ *   Copyright (c) 2005-2013, Jochen Kalmbach
-+ *   All rights reserved.
-+ *
-+ *   Redistribution and use in source and binary forms, with or without modification,
-+ *   are permitted provided that the following conditions are met:
-+ *
-+ *   Redistributions of source code must retain the above copyright notice,
-+ *   this list of conditions and the following disclaimer.
-+ *   Redistributions in binary form must reproduce the above copyright notice,
-+ *   this list of conditions and the following disclaimer in the documentation
-+ *   and/or other materials provided with the distribution.
-+ *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
-+ *   used to endorse or promote products derived from this software without
-+ *   specific prior written permission.
-+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-+ *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-+ *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-+ *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-+ *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-+ *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-+ *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-+ *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-+ *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-+ *
-+ **********************************************************************/
-+
-+#include "StackWalker.h"
-+
-+#include <stdio.h>
-+#include <stdlib.h>
-+#include <tchar.h>
-+#pragma comment(lib, "version.lib") // for "VerQueryValue"
-+#pragma warning(disable : 4826)
-+
-+#ifdef UNICODE
-+  #define DBGHELP_TRANSLATE_TCHAR
-+
-+#endif
-+#pragma pack(push, 8)
-+#include <dbghelp.h>
-+#pragma pack(pop)
-+
-+
-+static void MyStrCpy(TCHAR* szDest, size_t nMaxDestSize, const TCHAR* szSrc)
-+{
-+  if (nMaxDestSize <= 0)
-+    return;
-+  _tcsncpy_s(szDest, nMaxDestSize, szSrc, _TRUNCATE);
-+  // INFO: _TRUNCATE will ensure that it is null-terminated;
-+  // but with older compilers (<1400) it uses "strncpy" and this does not!)
-+  szDest[nMaxDestSize - 1] = 0;
-+} // MyStrCpy
-+
-+#ifdef _UNICODE
-+  typedef SYMBOL_INFOW   tSymbolInfo;
-+  typedef IMAGEHLP_LINEW64  tImageHelperLine;
-+#else
-+  typedef SYMBOL_INFO   tSymbolInfo;
-+  typedef IMAGEHLP_LINE64  tImageHelperLine;
-+#endif
-+
-+// Normally it should be enough to use 'CONTEXT_FULL' (better would be 'CONTEXT_ALL')
-+#define USED_CONTEXT_FLAGS CONTEXT_FULL
-+
-+class StackWalkerInternal
-+{
-+public:
-+  StackWalkerInternal(StackWalker* parent, HANDLE hProcess)
-+  {
-+    m_parent = parent;
-+    m_hDbhHelp = NULL;
-+    symCleanup = NULL;
-+    m_hProcess = hProcess;
-+    m_szSymPath = NULL;
-+    symFunctionTableAccess64 = NULL;
-+    symGetLineFromAddr64 = NULL;
-+    symGetModuleBase64 = NULL;
-+    symGetModuleInfo64 = NULL;
-+    symGetOptions = NULL;
-+    symFromAddr = NULL;
-+    symInitialize = NULL;
-+    symLoadModuleEx = NULL;
-+    symSetOptions = NULL;
-+    stackWalk64 = NULL;
-+    unDecorateSymbolName = NULL;
-+    symGetSearchPath = NULL;
-+  }
-+  ~StackWalkerInternal()
-+  {
-+    if (symCleanup != NULL)
-+      symCleanup(m_hProcess); // SymCleanup
-+    if (m_hDbhHelp != NULL)
-+      FreeLibrary(m_hDbhHelp);
-+    m_hDbhHelp = NULL;
-+    m_parent = NULL;
-+    if (m_szSymPath != NULL)
-+      free(m_szSymPath);
-+    m_szSymPath = NULL;
-+  }
-+  BOOL Init(LPCTSTR szSymPath)
-+  {
-+    if (m_parent == NULL)
-+      return FALSE;
-+    // Dynamically load the Entry-Points for dbghelp.dll:
-+    // First try to load the newest one from
-+    TCHAR szTemp[4096];
-+    // But before we do this, we first check if the ".local" file exists
-+    if (GetModuleFileName(NULL, szTemp, 4096) > 0)
-+    {
-+      _tcscat_s(szTemp, _T(".local"));
-+      if (GetFileAttributes(szTemp) == INVALID_FILE_ATTRIBUTES)
-+      {
-+        // ".local" file does not exist, so we can try to load the dbghelp.dll from the "Debugging Tools for Windows"
-+        // Ok, first try the new path according to the architecture:
-+#ifdef _M_IX86
-+        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
-+        {
-+          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x86)\\dbghelp.dll"));
-+          // now check if the file exists:
-+          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
-+          {
-+            m_hDbhHelp = LoadLibrary(szTemp);
-+          }
-+        }
-+#elif _M_X64
-+        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
-+        {
-+          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x64)\\dbghelp.dll"));
-+          // now check if the file exists:
-+          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
-+          {
-+            m_hDbhHelp = LoadLibrary(szTemp);
-+          }
-+        }
-+#elif _M_IA64
-+        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
-+        {
-+          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (ia64)\\dbghelp.dll"));
-+          // now check if the file exists:
-+          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
-+          {
-+            m_hDbhHelp = LoadLibrary(szTemp);
-+          }
-+        }
-+#endif
-+        // If still not found, try the old directories...
-+        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
-+        {
-+          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows\\dbghelp.dll"));
-+          // now check if the file exists:
-+          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
-+          {
-+            m_hDbhHelp = LoadLibrary(szTemp);
-+          }
-+        }
-+#if defined _M_X64 || defined _M_IA64
-+        // Still not found? Then try to load the (old) 64-Bit version:
-+        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
-+        {
-+          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows 64-Bit\\dbghelp.dll"));
-+          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
-+          {
-+            m_hDbhHelp = LoadLibrary(szTemp);
-+          }
-+        }
-+#endif
-+      }
-+    }
-+    if (m_hDbhHelp == NULL) // if not already loaded, try to load a default-one
-+      m_hDbhHelp = LoadLibrary(_T("dbghelp.dll"));
-+    if (m_hDbhHelp == NULL)
-+      return FALSE;
 +
 +#ifdef _UNICODE
 +    static const char strSymInitialize[] = "SymInitializeW";
@@ -1768,212 +324,211 @@ index e1b25eb..48c7c57 100644
 +    if (symCleanup == NULL || symFunctionTableAccess64 == NULL || symGetModuleBase64 == NULL || symGetModuleInfo64 == NULL || symGetOptions == NULL ||
 +        symFromAddr == NULL || symInitialize == NULL || symSetOptions == NULL || stackWalk64 == NULL || unDecorateSymbolName == NULL ||
 +        symLoadModuleEx == NULL)
-+    {
-+      FreeLibrary(m_hDbhHelp);
-+      m_hDbhHelp = NULL;
+     {
+       FreeLibrary(m_hDbhHelp);
+       m_hDbhHelp = NULL;
+-      pSC = NULL;
 +      symCleanup = NULL;
-+      return FALSE;
-+    }
-+
-+    // SymInitialize
-+    if (szSymPath != NULL)
+       return FALSE;
+     }
+ 
+     // SymInitialize
+     if (szSymPath != NULL)
+-      m_szSymPath = _strdup(szSymPath);
+-    if (this->pSI(m_hProcess, m_szSymPath, FALSE) == FALSE)
+-      this->m_parent->OnDbgHelpErr("SymInitialize", GetLastError(), 0);
 +      m_szSymPath = _tcsdup(szSymPath);
 +    if (this->symInitialize(m_hProcess, m_szSymPath, FALSE) == FALSE)
 +      this->m_parent->OnDbgHelpErr(_T("SymInitialize"), GetLastError(), 0);
-+
+ 
+-    DWORD symOptions = this->pSGO(); // SymGetOptions
 +    DWORD symOptions = this->symGetOptions(); // SymGetOptions
-+    symOptions |= SYMOPT_LOAD_LINES;
-+    symOptions |= SYMOPT_FAIL_CRITICAL_ERRORS;
-+    //symOptions |= SYMOPT_NO_PROMPTS;
-+    // SymSetOptions
+     symOptions |= SYMOPT_LOAD_LINES;
+     symOptions |= SYMOPT_FAIL_CRITICAL_ERRORS;
+     //symOptions |= SYMOPT_NO_PROMPTS;
+     // SymSetOptions
+-    symOptions = this->pSSO(symOptions);
 +    symOptions = this->symSetOptions(symOptions);
-+
+ 
+-    char buf[StackWalker::STACKWALK_MAX_NAMELEN] = {0};
+-    if (this->pSGSP != NULL)
 +    TCHAR buf[StackWalker::STACKWALK_MAX_NAMELEN] = {0};
 +    if (this->symGetSearchPath != NULL)
-+    {
+     {
+-      if (this->pSGSP(m_hProcess, buf, StackWalker::STACKWALK_MAX_NAMELEN) == FALSE)
+-        this->m_parent->OnDbgHelpErr("SymGetSearchPath", GetLastError(), 0);
 +      if (this->symGetSearchPath(m_hProcess, buf, StackWalker::STACKWALK_MAX_NAMELEN) == FALSE)
 +        this->m_parent->OnDbgHelpErr(_T("SymGetSearchPath"), GetLastError(), 0);
-+    }
+     }
+-    char  szUserName[1024] = {0};
 +    TCHAR  szUserName[1024] = {0};
-+    DWORD dwSize = 1024;
+     DWORD dwSize = 1024;
+-    GetUserNameA(szUserName, &dwSize);
 +    GetUserName(szUserName, &dwSize);
-+    this->m_parent->OnSymInit(buf, symOptions, szUserName);
-+
-+    return TRUE;
-+  }
-+
-+  StackWalker* m_parent;
-+
-+  HMODULE m_hDbhHelp;
-+  HANDLE  m_hProcess;
+     this->m_parent->OnSymInit(buf, symOptions, szUserName);
+ 
+     return TRUE;
+@@ -411,7 +303,7 @@ public:
+ 
+   HMODULE m_hDbhHelp;
+   HANDLE  m_hProcess;
+-  LPSTR   m_szSymPath;
 +  LPTSTR   m_szSymPath;
-+
-+#pragma pack(push, 8)
-+  typedef struct IMAGEHLP_MODULE64_V3
-+  {
-+    DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
-+    DWORD64  BaseOfImage;          // base load address of module
-+    DWORD    ImageSize;            // virtual size of the loaded module
-+    DWORD    TimeDateStamp;        // date/time stamp from pe header
-+    DWORD    CheckSum;             // checksum from the pe header
-+    DWORD    NumSyms;              // number of symbols in the symbol table
-+    SYM_TYPE SymType;              // type of symbols loaded
+ 
+ #pragma pack(push, 8)
+   typedef struct IMAGEHLP_MODULE64_V3
+@@ -423,13 +315,13 @@ public:
+     DWORD    CheckSum;             // checksum from the pe header
+     DWORD    NumSyms;              // number of symbols in the symbol table
+     SYM_TYPE SymType;              // type of symbols loaded
+-    CHAR     ModuleName[32];       // module name
+-    CHAR     ImageName[256];       // image name
+-    CHAR     LoadedImageName[256]; // symbol file name
 +    TCHAR     ModuleName[32];       // module name
 +    TCHAR     ImageName[256];       // image name
 +    TCHAR     LoadedImageName[256]; // symbol file name
-+    // new elements: 07-Jun-2002
+     // new elements: 07-Jun-2002
+-    CHAR  LoadedPdbName[256];   // pdb file name
 +    TCHAR  LoadedPdbName[256];   // pdb file name
-+    DWORD CVSig;                // Signature of the CV record in the debug directories
+     DWORD CVSig;                // Signature of the CV record in the debug directories
+-    CHAR  CVData[MAX_PATH * 3]; // Contents of the CV record
 +    TCHAR  CVData[MAX_PATH * 3]; // Contents of the CV record
-+    DWORD PdbSig;               // Signature of PDB
-+    GUID  PdbSig70;             // Signature of PDB (VC 7 and up)
-+    DWORD PdbAge;               // DBI age of pdb
-+    BOOL  PdbUnmatched;         // loaded an unmatched pdb
-+    BOOL  DbgUnmatched;         // loaded an unmatched dbg
-+    BOOL  LineNumbers;          // we have line number information
-+    BOOL  GlobalSymbols;        // we have internal symbol information
-+    BOOL  TypeInfo;             // we have type information
-+    // new elements: 17-Dec-2003
-+    BOOL SourceIndexed; // pdb supports source server
-+    BOOL Publics;       // contains public symbols
-+  };
-+
-+  typedef struct IMAGEHLP_MODULE64_V2
-+  {
-+    DWORD    SizeOfStruct;         // set to sizeof(IMAGEHLP_MODULE64)
-+    DWORD64  BaseOfImage;          // base load address of module
-+    DWORD    ImageSize;            // virtual size of the loaded module
-+    DWORD    TimeDateStamp;        // date/time stamp from pe header
-+    DWORD    CheckSum;             // checksum from the pe header
-+    DWORD    NumSyms;              // number of symbols in the symbol table
-+    SYM_TYPE SymType;              // type of symbols loaded
-+    CHAR     ModuleName[32];       // module name
-+    CHAR     ImageName[256];       // image name
-+    CHAR     LoadedImageName[256]; // symbol file name
-+  };
-+#pragma pack(pop)
-+
-+  // SymCleanup()
-+  typedef BOOL(__stdcall* tSC)(IN HANDLE hProcess);
+     DWORD PdbSig;               // Signature of PDB
+     GUID  PdbSig70;             // Signature of PDB (VC 7 and up)
+     DWORD PdbAge;               // DBI age of pdb
+@@ -460,56 +352,59 @@ public:
+ 
+   // SymCleanup()
+   typedef BOOL(__stdcall* tSC)(IN HANDLE hProcess);
+-  tSC pSC;
 +  tSC symCleanup;
-+
-+  // SymFunctionTableAccess64()
-+  typedef PVOID(__stdcall* tSFTA)(HANDLE hProcess, DWORD64 AddrBase);
+ 
+   // SymFunctionTableAccess64()
+   typedef PVOID(__stdcall* tSFTA)(HANDLE hProcess, DWORD64 AddrBase);
+-  tSFTA pSFTA;
 +  tSFTA symFunctionTableAccess64;
-+
-+  // SymGetLineFromAddr64()
-+  typedef BOOL(__stdcall* tSGLFA)(IN HANDLE hProcess,
-+                                  IN DWORD64 dwAddr,
-+                                  OUT PDWORD pdwDisplacement,
+ 
+   // SymGetLineFromAddr64()
+   typedef BOOL(__stdcall* tSGLFA)(IN HANDLE hProcess,
+                                   IN DWORD64 dwAddr,
+                                   OUT PDWORD pdwDisplacement,
+-                                  OUT PIMAGEHLP_LINE64 Line);
+-  tSGLFA pSGLFA;
 +                                  OUT tImageHelperLine* Line);
 +  tSGLFA symGetLineFromAddr64;
-+
-+  // SymGetModuleBase64()
-+  typedef DWORD64(__stdcall* tSGMB)(IN HANDLE hProcess, IN DWORD64 dwAddr);
+ 
+   // SymGetModuleBase64()
+   typedef DWORD64(__stdcall* tSGMB)(IN HANDLE hProcess, IN DWORD64 dwAddr);
+-  tSGMB pSGMB;
 +  tSGMB symGetModuleBase64;
-+
-+  // SymGetModuleInfo64()
-+  typedef BOOL(__stdcall* tSGMI)(IN HANDLE hProcess,
-+                                 IN DWORD64 dwAddr,
-+                                 OUT IMAGEHLP_MODULE64_V3* ModuleInfo);
+ 
+   // SymGetModuleInfo64()
+   typedef BOOL(__stdcall* tSGMI)(IN HANDLE hProcess,
+                                  IN DWORD64 dwAddr,
+                                  OUT IMAGEHLP_MODULE64_V3* ModuleInfo);
+-  tSGMI pSGMI;
 +  tSGMI symGetModuleInfo64;
-+
-+  // SymGetOptions()
-+  typedef DWORD(__stdcall* tSGO)(VOID);
+ 
+   // SymGetOptions()
+   typedef DWORD(__stdcall* tSGO)(VOID);
+-  tSGO pSGO;
 +  tSGO symGetOptions;
 +
-+
-+  // SymGetSymFromAddr64()
+ 
+   // SymGetSymFromAddr64()
+-  typedef BOOL(__stdcall* tSGSFA)(IN HANDLE hProcess,
+-                                  IN DWORD64 dwAddr,
 +  typedef BOOL(__stdcall* tSFA)(IN HANDLE hProcess,
 +                                  IN DWORD64 Address,
-+                                  OUT PDWORD64 pdwDisplacement,
+                                   OUT PDWORD64 pdwDisplacement,
+-                                  OUT PIMAGEHLP_SYMBOL64 Symbol);
+-  tSGSFA pSGSFA;
 +                                  OUT tSymbolInfo* Symbol);
 +  tSFA symFromAddr;
-+
-+  // SymInitialize()
+ 
+   // SymInitialize()
+-  typedef BOOL(__stdcall* tSI)(IN HANDLE hProcess, IN PSTR UserSearchPath, IN BOOL fInvadeProcess);
+-  tSI pSI;
 +  typedef BOOL(__stdcall* tSI)(IN HANDLE hProcess, IN PTSTR UserSearchPath, IN BOOL fInvadeProcess);
 +  tSI symInitialize;
-+
-+  // SymLoadModule64()
-+  typedef DWORD64(__stdcall* tSLM)(IN HANDLE hProcess,
-+                                   IN HANDLE hFile,
+ 
+   // SymLoadModule64()
+   typedef DWORD64(__stdcall* tSLM)(IN HANDLE hProcess,
+                                    IN HANDLE hFile,
+-                                   IN PSTR ImageName,
+-                                   IN PSTR ModuleName,
 +                                   IN PTSTR ImageName,
 +                                   IN PTSTR ModuleName,
-+                                   IN DWORD64 BaseOfDll,
+                                    IN DWORD64 BaseOfDll,
+-                                   IN DWORD SizeOfDll);
+-  tSLM pSLM;
 +                                   IN DWORD SizeOfDll,
 +                                   IN PMODLOAD_DATA Data,
 +                                   IN DWORD         Flags);
 +  tSLM symLoadModuleEx;
-+
-+  // SymSetOptions()
-+  typedef DWORD(__stdcall* tSSO)(IN DWORD SymOptions);
+ 
+   // SymSetOptions()
+   typedef DWORD(__stdcall* tSSO)(IN DWORD SymOptions);
+-  tSSO pSSO;
 +  tSSO symSetOptions;
-+
-+  // StackWalk64()
-+  typedef BOOL(__stdcall* tSW)(DWORD                            MachineType,
-+                               HANDLE                           hProcess,
-+                               HANDLE                           hThread,
-+                               LPSTACKFRAME64                   StackFrame,
-+                               PVOID                            ContextRecord,
-+                               PREAD_PROCESS_MEMORY_ROUTINE64   ReadMemoryRoutine,
-+                               PFUNCTION_TABLE_ACCESS_ROUTINE64 FunctionTableAccessRoutine,
-+                               PGET_MODULE_BASE_ROUTINE64       GetModuleBaseRoutine,
-+                               PTRANSLATE_ADDRESS_ROUTINE64     TranslateAddress);
+ 
+   // StackWalk64()
+   typedef BOOL(__stdcall* tSW)(DWORD                            MachineType,
+@@ -521,17 +416,17 @@ public:
+                                PFUNCTION_TABLE_ACCESS_ROUTINE64 FunctionTableAccessRoutine,
+                                PGET_MODULE_BASE_ROUTINE64       GetModuleBaseRoutine,
+                                PTRANSLATE_ADDRESS_ROUTINE64     TranslateAddress);
+-  tSW pSW;
 +  tSW stackWalk64;
-+
-+  // UnDecorateSymbolName()
+ 
+   // UnDecorateSymbolName()
+-  typedef DWORD(__stdcall WINAPI* tUDSN)(PCSTR DecoratedName,
+-                                         PSTR  UnDecoratedName,
 +  typedef DWORD(__stdcall WINAPI* tUDSN)(PCTSTR DecoratedName,
 +                                         PTSTR  UnDecoratedName,
-+                                         DWORD UndecoratedLength,
-+                                         DWORD Flags);
+                                          DWORD UndecoratedLength,
+                                          DWORD Flags);
+-  tUDSN pUDSN;
 +  tUDSN unDecorateSymbolName;
-+
+ 
+-  typedef BOOL(__stdcall WINAPI* tSGSP)(HANDLE hProcess, PSTR SearchPath, DWORD SearchPathLength);
+-  tSGSP pSGSP;
 +  typedef BOOL(__stdcall WINAPI* tSGSP)(HANDLE hProcess, PTSTR SearchPath, DWORD SearchPathLength);
 +  tSGSP symGetSearchPath;
-+
-+private:
-+// **************************************** ToolHelp32 ************************
-+#define MAX_MODULE_NAME32 255
-+#define TH32CS_SNAPMODULE 0x00000008
-+#pragma pack(push, 8)
-+  typedef struct tagMODULEENTRY32
-+  {
-+    DWORD   dwSize;
-+    DWORD   th32ModuleID;  // This module
-+    DWORD   th32ProcessID; // owning process
-+    DWORD   GlblcntUsage;  // Global usage count on the module
-+    DWORD   ProccntUsage;  // Module usage count in th32ProcessID's context
-+    BYTE*   modBaseAddr;   // Base address of module in th32ProcessID's context
-+    DWORD   modBaseSize;   // Size in bytes of module starting at modBaseAddr
-+    HMODULE hModule;       // The hModule of this module in th32ProcessID's context
+ 
+ private:
+ // **************************************** ToolHelp32 ************************
+@@ -548,8 +443,8 @@ private:
+     BYTE*   modBaseAddr;   // Base address of module in th32ProcessID's context
+     DWORD   modBaseSize;   // Size in bytes of module starting at modBaseAddr
+     HMODULE hModule;       // The hModule of this module in th32ProcessID's context
+-    char    szModule[MAX_MODULE_NAME32 + 1];
+-    char    szExePath[MAX_PATH];
 +    TCHAR   szModule[MAX_MODULE_NAME32 + 1];
 +    TCHAR   szExePath[MAX_PATH];
-+  } MODULEENTRY32;
-+  typedef MODULEENTRY32* PMODULEENTRY32;
-+  typedef MODULEENTRY32* LPMODULEENTRY32;
-+#pragma pack(pop)
-+
-+  BOOL GetModuleListTH32(HANDLE hProcess, DWORD pid)
-+  {
-+    // CreateToolhelp32Snapshot()
-+    typedef HANDLE(__stdcall * tCT32S)(DWORD dwFlags, DWORD th32ProcessID);
-+    // Module32First()
-+    typedef BOOL(__stdcall * tM32F)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
-+    // Module32Next()
-+    typedef BOOL(__stdcall * tM32N)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
-+
-+    // try both dlls...
-+    const TCHAR* dllname[] = {_T("kernel32.dll"), _T("tlhelp32.dll")};
-+    HINSTANCE    hToolhelp = NULL;
+   } MODULEENTRY32;
+   typedef MODULEENTRY32* PMODULEENTRY32;
+   typedef MODULEENTRY32* LPMODULEENTRY32;
+@@ -567,25 +462,31 @@ private:
+     // try both dlls...
+     const TCHAR* dllname[] = {_T("kernel32.dll"), _T("tlhelp32.dll")};
+     HINSTANCE    hToolhelp = NULL;
+-    tCT32S       pCT32S = NULL;
+-    tM32F        pM32F = NULL;
+-    tM32N        pM32N = NULL;
 +    tCT32S       createToolhelp32Snapshot = NULL;
 +    tM32F        module32First = NULL;
 +    tM32N        module32Next = NULL;
-+
-+    HANDLE        hSnap;
+ 
+     HANDLE        hSnap;
+-    MODULEENTRY32 me;
+-    me.dwSize = sizeof(me);
 +    MODULEENTRY32 moduleEntry32;
 +    moduleEntry32.dwSize = sizeof(moduleEntry32);
-+    BOOL   keepGoing;
-+
+     BOOL   keepGoing;
+-    size_t i;
+ 
+-    for (i = 0; i < (sizeof(dllname) / sizeof(dllname[0])); i++)
 +#ifdef _UNICODE
 +    static const char strModule32First[] = "Module32FirstW";
 +    static const char strModule32Next[] = "Module32NextW";
@@ -1982,80 +537,91 @@ index e1b25eb..48c7c57 100644
 +    static const char strModule32Next[] = "Module32Next";
 +#endif
 +    for (size_t i = 0; i < (sizeof(dllname) / sizeof(dllname[0])); i++)
-+    {
-+      hToolhelp = LoadLibrary(dllname[i]);
-+      if (hToolhelp == NULL)
-+        continue;
+     {
+       hToolhelp = LoadLibrary(dllname[i]);
+       if (hToolhelp == NULL)
+         continue;
+-      pCT32S = (tCT32S)GetProcAddress(hToolhelp, "CreateToolhelp32Snapshot");
+-      pM32F = (tM32F)GetProcAddress(hToolhelp, "Module32First");
+-      pM32N = (tM32N)GetProcAddress(hToolhelp, "Module32Next");
+-      if ((pCT32S != NULL) && (pM32F != NULL) && (pM32N != NULL))
 +      createToolhelp32Snapshot = (tCT32S)GetProcAddress(hToolhelp, "CreateToolhelp32Snapshot");
 +      module32First = (tM32F)GetProcAddress(hToolhelp, strModule32First);  
 +      module32Next = (tM32N)GetProcAddress(hToolhelp, strModule32Next); 
 +      if ((createToolhelp32Snapshot != NULL) && (module32First != NULL) && (module32Next != NULL))
-+        break; // found the functions!
-+      FreeLibrary(hToolhelp);
-+      hToolhelp = NULL;
-+    }
-+
-+    if (hToolhelp == NULL)
-+      return FALSE;
-+
+         break; // found the functions!
+       FreeLibrary(hToolhelp);
+       hToolhelp = NULL;
+@@ -594,21 +495,21 @@ private:
+     if (hToolhelp == NULL)
+       return FALSE;
+ 
+-    hSnap = pCT32S(TH32CS_SNAPMODULE, pid);
 +    hSnap = createToolhelp32Snapshot(TH32CS_SNAPMODULE, pid);
-+    if (hSnap == (HANDLE)-1)
-+    {
-+      FreeLibrary(hToolhelp);
-+      return FALSE;
-+    }
-+
+     if (hSnap == (HANDLE)-1)
+     {
+       FreeLibrary(hToolhelp);
+       return FALSE;
+     }
+ 
+-    keepGoing = !!pM32F(hSnap, &me);
 +    keepGoing = !!module32First(hSnap, &moduleEntry32);
-+    int cnt = 0;
-+    while (keepGoing)
-+    {
+     int cnt = 0;
+     while (keepGoing)
+     {
+-      this->LoadModule(hProcess, me.szExePath, me.szModule, (DWORD64)me.modBaseAddr,
+-                       me.modBaseSize);
 +      this->LoadModule(hProcess, moduleEntry32.szExePath, moduleEntry32.szModule, (DWORD64)moduleEntry32.modBaseAddr,
 +                       moduleEntry32.modBaseSize);
-+      cnt++;
+       cnt++;
+-      keepGoing = !!pM32N(hSnap, &me);
 +      keepGoing = !!module32Next(hSnap, &moduleEntry32);
-+    }
-+    CloseHandle(hSnap);
-+    FreeLibrary(hToolhelp);
-+    if (cnt <= 0)
-+      return FALSE;
-+    return TRUE;
-+  } // GetModuleListTH32
-+
-+  // **************************************** PSAPI ************************
-+  typedef struct _MODULEINFO
-+  {
-+    LPVOID lpBaseOfDll;
-+    DWORD  SizeOfImage;
-+    LPVOID EntryPoint;
-+  } MODULEINFO, *LPMODULEINFO;
-+
-+  BOOL GetModuleListPSAPI(HANDLE hProcess)
-+  {
-+    // EnumProcessModules()
-+    typedef BOOL(__stdcall * tEPM)(HANDLE hProcess, HMODULE * lphModule, DWORD cb,
-+                                   LPDWORD lpcbNeeded);
-+    // GetModuleFileNameEx()
+     }
+     CloseHandle(hSnap);
+     FreeLibrary(hToolhelp);
+@@ -631,39 +532,41 @@ private:
+     typedef BOOL(__stdcall * tEPM)(HANDLE hProcess, HMODULE * lphModule, DWORD cb,
+                                    LPDWORD lpcbNeeded);
+     // GetModuleFileNameEx()
+-    typedef DWORD(__stdcall * tGMFNE)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename,
 +    typedef DWORD(__stdcall * tGMFNE)(HANDLE hProcess, HMODULE hModule, LPTSTR lpFilename,
-+                                      DWORD nSize);
-+    // GetModuleBaseName()
+                                       DWORD nSize);
+     // GetModuleBaseName()
+-    typedef DWORD(__stdcall * tGMBN)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename,
 +    typedef DWORD(__stdcall * tGMBN)(HANDLE hProcess, HMODULE hModule, LPTSTR lpFilename,
-+                                     DWORD nSize);
-+    // GetModuleInformation()
-+    typedef BOOL(__stdcall * tGMI)(HANDLE hProcess, HMODULE hModule, LPMODULEINFO pmi, DWORD nSize);
-+
+                                      DWORD nSize);
+     // GetModuleInformation()
+     typedef BOOL(__stdcall * tGMI)(HANDLE hProcess, HMODULE hModule, LPMODULEINFO pmi, DWORD nSize);
+ 
+-    HINSTANCE hPsapi;
+-    tEPM      pEPM;
+-    tGMFNE    pGMFNE;
+-    tGMBN     pGMBN;
+-    tGMI      pGMI;
+-
+-    DWORD i;
+-    //ModuleEntry e;
 +      //ModuleEntry e;
-+    DWORD        cbNeeded;
-+    MODULEINFO   mi;
-+    HMODULE*     hMods = 0;
+     DWORD        cbNeeded;
+     MODULEINFO   mi;
+     HMODULE*     hMods = 0;
+-    char*        tt = NULL;
+-    char*        tt2 = NULL;
 +    TCHAR*        tt = NULL;
 +    TCHAR*        tt2 = NULL;
-+    const SIZE_T TTBUFLEN = 8096;
-+    int          cnt = 0;
-+
+     const SIZE_T TTBUFLEN = 8096;
+     int          cnt = 0;
+ 
+-    hPsapi = LoadLibrary(_T("psapi.dll"));
 +    HINSTANCE hPsapi = LoadLibrary(_T("psapi.dll"));
-+    if (hPsapi == NULL)
-+      return FALSE;
-+
+     if (hPsapi == NULL)
+       return FALSE;
+ 
+-    pEPM = (tEPM)GetProcAddress(hPsapi, "EnumProcessModules");
+-    pGMFNE = (tGMFNE)GetProcAddress(hPsapi, "GetModuleFileNameExA");
+-    pGMBN = (tGMFNE)GetProcAddress(hPsapi, "GetModuleBaseNameA");
+-    pGMI = (tGMI)GetProcAddress(hPsapi, "GetModuleInformation");
+-    if ((pEPM == NULL) || (pGMFNE == NULL) || (pGMBN == NULL) || (pGMI == NULL))
 +#ifdef _UNICODE
 +    static const char strGetModuleFileName[] = "GetModuleFileNameExW";
 +    static const char strGetModuleBaseName[] = "GetModuleBaseNameW";
@@ -2070,864 +636,597 @@ index e1b25eb..48c7c57 100644
 +    tGMI   getModuleInformation = (tGMI)GetProcAddress(hPsapi, "GetModuleInformation");
 +    if ((enumProcessModules == NULL) || (getModuleFileNameEx == NULL) ||
 +        (getModuleBaseName == NULL) || (getModuleInformation == NULL))
-+    {
-+      // we couldn't find all functions
-+      FreeLibrary(hPsapi);
-+      return FALSE;
-+    }
-+
-+    hMods = (HMODULE*)malloc(sizeof(HMODULE) * (TTBUFLEN / sizeof(HMODULE)));
+     {
+       // we couldn't find all functions
+       FreeLibrary(hPsapi);
+@@ -671,12 +574,12 @@ private:
+     }
+ 
+     hMods = (HMODULE*)malloc(sizeof(HMODULE) * (TTBUFLEN / sizeof(HMODULE)));
+-    tt = (char*)malloc(sizeof(char) * TTBUFLEN);
+-    tt2 = (char*)malloc(sizeof(char) * TTBUFLEN);
 +    tt = (TCHAR*)malloc(sizeof(TCHAR) * TTBUFLEN);
 +    tt2 = (TCHAR*)malloc(sizeof(TCHAR) * TTBUFLEN);
-+    if ((hMods == NULL) || (tt == NULL) || (tt2 == NULL))
-+      goto cleanup;
-+
+     if ((hMods == NULL) || (tt == NULL) || (tt2 == NULL))
+       goto cleanup;
+ 
+-    if (!pEPM(hProcess, hMods, TTBUFLEN, &cbNeeded))
 +    if (!enumProcessModules(hProcess, hMods, TTBUFLEN, &cbNeeded))
-+    {
-+      //_ftprintf(fLogFile, _T("%lu: EPM failed, GetLastError = %lu\n"), g_dwShowCount, gle );
-+      goto cleanup;
-+    }
-+
-+    if (cbNeeded > TTBUFLEN)
-+    {
-+      //_ftprintf(fLogFile, _T("%lu: More than %lu module handles. Huh?\n"), g_dwShowCount, lenof( hMods ) );
-+      goto cleanup;
-+    }
-+
+     {
+       //_ftprintf(fLogFile, _T("%lu: EPM failed, GetLastError = %lu\n"), g_dwShowCount, gle );
+       goto cleanup;
+@@ -688,20 +591,20 @@ private:
+       goto cleanup;
+     }
+ 
+-    for (i = 0; i < cbNeeded / sizeof(hMods[0]); i++)
 +    for (DWORD i = 0; i < cbNeeded / sizeof(hMods[0]); i++)
-+    {
-+      // base address, size
+     {
+       // base address, size
+-      pGMI(hProcess, hMods[i], &mi, sizeof(mi));
 +      getModuleInformation(hProcess, hMods[i], &mi, sizeof(mi));
-+      // image file name
-+      tt[0] = 0;
+       // image file name
+       tt[0] = 0;
+-      pGMFNE(hProcess, hMods[i], tt, TTBUFLEN);
 +      getModuleFileNameEx(hProcess, hMods[i], tt, TTBUFLEN);
-+      // module name
-+      tt2[0] = 0;
+       // module name
+       tt2[0] = 0;
+-      pGMBN(hProcess, hMods[i], tt2, TTBUFLEN);
 +      getModuleBaseName(hProcess, hMods[i], tt2, TTBUFLEN);
-+
-+      DWORD dwRes = this->LoadModule(hProcess, tt, tt2, (DWORD64)mi.lpBaseOfDll, mi.SizeOfImage);
-+      if (dwRes != ERROR_SUCCESS)
+ 
+       DWORD dwRes = this->LoadModule(hProcess, tt, tt2, (DWORD64)mi.lpBaseOfDll, mi.SizeOfImage);
+       if (dwRes != ERROR_SUCCESS)
+-        this->m_parent->OnDbgHelpErr("LoadModule", dwRes, 0);
 +        this->m_parent->OnDbgHelpErr(_T("LoadModule"), dwRes, 0);
-+      cnt++;
-+    }
-+
-+  cleanup:
-+    if (hPsapi != NULL)
-+      FreeLibrary(hPsapi);
-+    if (tt2 != NULL)
-+      free(tt2);
-+    if (tt != NULL)
-+      free(tt);
-+    if (hMods != NULL)
-+      free(hMods);
-+
-+    return cnt != 0;
-+  } // GetModuleListPSAPI
-+
+       cnt++;
+     }
+ 
+@@ -718,16 +621,16 @@ private:
+     return cnt != 0;
+   } // GetModuleListPSAPI
+ 
+-  DWORD LoadModule(HANDLE hProcess, LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size)
 +  DWORD LoadModule(HANDLE hProcess, LPCTSTR img, LPCTSTR mod, DWORD64 baseAddr, DWORD size)
-+  {
+   {
+-    CHAR* szImg = _strdup(img);
+-    CHAR* szMod = _strdup(mod);
 +    TCHAR* szImg = _tcsdup(img);
 +    TCHAR* szMod = _tcsdup(mod);
-+    DWORD result = ERROR_SUCCESS;
-+    if ((szImg == NULL) || (szMod == NULL))
-+      result = ERROR_NOT_ENOUGH_MEMORY;
-+    else
-+    {
+     DWORD result = ERROR_SUCCESS;
+     if ((szImg == NULL) || (szMod == NULL))
+       result = ERROR_NOT_ENOUGH_MEMORY;
+     else
+     {
+-      if (pSLM(hProcess, 0, szImg, szMod, baseAddr, size) == 0)
 +      if (symLoadModuleEx(hProcess, 0, szImg, szMod, baseAddr, size, 0, 0) == 0)
-+        result = GetLastError();
-+    }
-+    ULONGLONG fileVersion = 0;
-+    if ((m_parent != NULL) && (szImg != NULL))
-+    {
-+      // try to retrieve the file-version:
-+      if ((this->m_parent->m_options & StackWalker::RetrieveFileVersion) != 0)
-+      {
-+        VS_FIXEDFILEINFO* fInfo = NULL;
-+        DWORD             dwHandle;
+         result = GetLastError();
+     }
+     ULONGLONG fileVersion = 0;
+@@ -738,13 +641,13 @@ private:
+       {
+         VS_FIXEDFILEINFO* fInfo = NULL;
+         DWORD             dwHandle;
+-        DWORD             dwSize = GetFileVersionInfoSizeA(szImg, &dwHandle);
 +        DWORD             dwSize = GetFileVersionInfoSize(szImg, &dwHandle);
-+        if (dwSize > 0)
-+        {
-+          LPVOID vData = malloc(dwSize);
-+          if (vData != NULL)
-+          {
+         if (dwSize > 0)
+         {
+           LPVOID vData = malloc(dwSize);
+           if (vData != NULL)
+           {
+-            if (GetFileVersionInfoA(szImg, dwHandle, dwSize, vData) != 0)
 +            if (GetFileVersionInfo(szImg, dwHandle, dwSize, vData) != 0)
-+            {
-+              UINT  len;
-+              TCHAR szSubBlock[] = _T("\\");
-+              if (VerQueryValue(vData, szSubBlock, (LPVOID*)&fInfo, &len) == 0)
-+                fInfo = NULL;
-+              else
-+              {
-+                fileVersion =
-+                    ((ULONGLONG)fInfo->dwFileVersionLS) + ((ULONGLONG)fInfo->dwFileVersionMS << 32);
-+              }
-+            }
-+            free(vData);
-+          }
-+        }
-+      }
-+
-+      // Retrieve some additional-infos about the module
-+      IMAGEHLP_MODULE64_V3 Module;
+             {
+               UINT  len;
+               TCHAR szSubBlock[] = _T("\\");
+@@ -763,41 +666,41 @@ private:
+ 
+       // Retrieve some additional-infos about the module
+       IMAGEHLP_MODULE64_V3 Module;
+-      const char*          szSymType = "-unknown-";
 +      const TCHAR*          szSymType = _T("-unknown-");
-+      if (this->GetModuleInfo(hProcess, baseAddr, &Module) != FALSE)
-+      {
-+        switch (Module.SymType)
-+        {
-+          case SymNone:
+       if (this->GetModuleInfo(hProcess, baseAddr, &Module) != FALSE)
+       {
+         switch (Module.SymType)
+         {
+           case SymNone:
+-            szSymType = "-nosymbols-";
 +            szSymType = _T("-nosymbols-");
-+            break;
-+          case SymCoff: // 1
+             break;
+           case SymCoff: // 1
+-            szSymType = "COFF";
 +            szSymType = _T("COFF");
-+            break;
-+          case SymCv: // 2
+             break;
+           case SymCv: // 2
+-            szSymType = "CV";
 +            szSymType = _T("CV");
-+            break;
-+          case SymPdb: // 3
+             break;
+           case SymPdb: // 3
+-            szSymType = "PDB";
 +            szSymType = _T("PDB");
-+            break;
-+          case SymExport: // 4
+             break;
+           case SymExport: // 4
+-            szSymType = "-exported-";
 +            szSymType = _T("-exported-");
-+            break;
-+          case SymDeferred: // 5
+             break;
+           case SymDeferred: // 5
+-            szSymType = "-deferred-";
 +            szSymType = _T("-deferred-");
-+            break;
-+          case SymSym: // 6
+             break;
+           case SymSym: // 6
+-            szSymType = "SYM";
 +            szSymType = _T("SYM");
-+            break;
-+          case 7: // SymDia:
+             break;
+           case 7: // SymDia:
+-            szSymType = "DIA";
 +            szSymType = _T("DIA");
-+            break;
-+          case 8: //SymVirtual:
+             break;
+           case 8: //SymVirtual:
+-            szSymType = "Virtual";
 +            szSymType = _T("Virtual");
-+            break;
-+        }
-+      }
+             break;
+         }
+       }
+-      LPCSTR pdbName = Module.LoadedImageName;
 +      LPCTSTR pdbName = Module.LoadedImageName;
-+      if (Module.LoadedPdbName[0] != 0)
-+        pdbName = Module.LoadedPdbName;
-+      this->m_parent->OnLoadModule(img, mod, baseAddr, size, result, szSymType, pdbName,
-+                                   fileVersion);
-+    }
-+    if (szImg != NULL)
-+      free(szImg);
-+    if (szMod != NULL)
-+      free(szMod);
-+    return result;
-+  }
-+
-+public:
-+  BOOL LoadModules(HANDLE hProcess, DWORD dwProcessId)
-+  {
-+    // first try toolhelp32
-+    if (GetModuleListTH32(hProcess, dwProcessId))
-+      return true;
-+    // then try psapi
-+    return GetModuleListPSAPI(hProcess);
-+  }
-+
-+  BOOL GetModuleInfo(HANDLE hProcess, DWORD64 baseAddr, IMAGEHLP_MODULE64_V3* pModuleInfo)
-+  {
-+    memset(pModuleInfo, 0, sizeof(IMAGEHLP_MODULE64_V3));
+       if (Module.LoadedPdbName[0] != 0)
+         pdbName = Module.LoadedPdbName;
+       this->m_parent->OnLoadModule(img, mod, baseAddr, size, result, szSymType, pdbName,
+@@ -823,7 +726,7 @@ public:
+   BOOL GetModuleInfo(HANDLE hProcess, DWORD64 baseAddr, IMAGEHLP_MODULE64_V3* pModuleInfo)
+   {
+     memset(pModuleInfo, 0, sizeof(IMAGEHLP_MODULE64_V3));
+-    if (this->pSGMI == NULL)
 +    if (this->symGetModuleInfo64 == NULL)
-+    {
-+      SetLastError(ERROR_DLL_INIT_FAILED);
-+      return FALSE;
-+    }
-+    // First try to use the larger ModuleInfo-Structure
-+    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
-+    void* pData = malloc(
-+        4096); // reserve enough memory, so the bug in v6.3.5.1 does not lead to memory-overwrites...
-+    if (pData == NULL)
-+    {
-+      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
-+      return FALSE;
-+    }
-+    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V3));
-+    static bool s_useV3Version = true;
-+    if (s_useV3Version)
-+    {
+     {
+       SetLastError(ERROR_DLL_INIT_FAILED);
+       return FALSE;
+@@ -841,7 +744,7 @@ public:
+     static bool s_useV3Version = true;
+     if (s_useV3Version)
+     {
+-      if (this->pSGMI(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
 +      if (this->symGetModuleInfo64(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
-+      {
-+        // only copy as much memory as is reserved...
-+        memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V3));
-+        pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
-+        free(pData);
-+        return TRUE;
-+      }
-+      s_useV3Version = false; // to prevent unnecessary calls with the larger struct...
-+    }
-+
-+    // could not retrieve the bigger structure, try with the smaller one (as defined in VC7.1)...
-+    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
-+    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V2));
+       {
+         // only copy as much memory as is reserved...
+         memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V3));
+@@ -855,7 +758,7 @@ public:
+     // could not retrieve the bigger structure, try with the smaller one (as defined in VC7.1)...
+     pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
+     memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V2));
+-    if (this->pSGMI(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
 +    if (this->symGetModuleInfo64(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
-+    {
-+      // only copy as much memory as is reserved...
-+      memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V2));
-+      pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
-+      free(pData);
-+      return TRUE;
-+    }
-+    free(pData);
-+    SetLastError(ERROR_DLL_INIT_FAILED);
-+    return FALSE;
-+  }
-+};
-+
-+// #############################################################
-+StackWalker::StackWalker(DWORD dwProcessId, HANDLE hProcess)
-+{
-+  this->m_options = OptionsAll;
-+  this->m_modulesLoaded = FALSE;
-+  this->m_hProcess = hProcess;
-+  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
-+  this->m_dwProcessId = dwProcessId;
-+  this->m_szSymPath = NULL;
-+  this->m_MaxRecursionCount = 1000;
-+}
+     {
+       // only copy as much memory as is reserved...
+       memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V2));
+@@ -880,7 +783,7 @@ StackWalker::StackWalker(DWORD dwProcessId, HANDLE hProcess)
+   this->m_szSymPath = NULL;
+   this->m_MaxRecursionCount = 1000;
+ }
+-StackWalker::StackWalker(int options, LPCSTR szSymPath, DWORD dwProcessId, HANDLE hProcess)
 +StackWalker::StackWalker(int options, LPCTSTR szSymPath, DWORD dwProcessId, HANDLE hProcess)
-+{
-+  this->m_options = options;
-+  this->m_modulesLoaded = FALSE;
-+  this->m_hProcess = hProcess;
-+  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
-+  this->m_dwProcessId = dwProcessId;
-+  if (szSymPath != NULL)
-+  {
+ {
+   this->m_options = options;
+   this->m_modulesLoaded = FALSE;
+@@ -889,7 +792,7 @@ StackWalker::StackWalker(int options, LPCSTR szSymPath, DWORD dwProcessId, HANDL
+   this->m_dwProcessId = dwProcessId;
+   if (szSymPath != NULL)
+   {
+-    this->m_szSymPath = _strdup(szSymPath);
 +    this->m_szSymPath = _tcsdup(szSymPath);
-+    this->m_options |= SymBuildPath;
-+  }
-+  else
-+    this->m_szSymPath = NULL;
-+  this->m_MaxRecursionCount = 1000;
-+}
-+
-+StackWalker::~StackWalker()
-+{
-+  if (m_szSymPath != NULL)
-+    free(m_szSymPath);
-+  m_szSymPath = NULL;
-+  if (this->m_sw != NULL)
-+    delete this->m_sw;
-+  this->m_sw = NULL;
-+}
-+
-+BOOL StackWalker::LoadModules()
-+{
-+  if (this->m_sw == NULL)
-+  {
-+    SetLastError(ERROR_DLL_INIT_FAILED);
-+    return FALSE;
-+  }
-+  if (m_modulesLoaded != FALSE)
-+    return TRUE;
-+
-+  // Build the sym-path:
+     this->m_options |= SymBuildPath;
+   }
+   else
+@@ -918,11 +821,11 @@ BOOL StackWalker::LoadModules()
+     return TRUE;
+ 
+   // Build the sym-path:
+-  char* szSymPath = NULL;
 +  TCHAR* szSymPath = NULL;
-+  if ((this->m_options & SymBuildPath) != 0)
-+  {
-+    const size_t nSymPathLen = 4096;
+   if ((this->m_options & SymBuildPath) != 0)
+   {
+     const size_t nSymPathLen = 4096;
+-    szSymPath = (char*)malloc(nSymPathLen);
 +    szSymPath = (TCHAR*)malloc(nSymPathLen * sizeof(TCHAR));
-+    if (szSymPath == NULL)
-+    {
-+      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
-+      return FALSE;
-+    }
-+    szSymPath[0] = 0;
-+    // Now first add the (optional) provided sympath:
-+    if (this->m_szSymPath != NULL)
-+    {
+     if (szSymPath == NULL)
+     {
+       SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+@@ -932,27 +835,27 @@ BOOL StackWalker::LoadModules()
+     // Now first add the (optional) provided sympath:
+     if (this->m_szSymPath != NULL)
+     {
+-      strcat_s(szSymPath, nSymPathLen, this->m_szSymPath);
+-      strcat_s(szSymPath, nSymPathLen, ";");
 +      _tcscat_s(szSymPath, nSymPathLen, this->m_szSymPath);
 +      _tcscat_s(szSymPath, nSymPathLen, _T(";"));
-+    }
-+
+     }
+ 
+-    strcat_s(szSymPath, nSymPathLen, ".;");
 +    _tcscat_s(szSymPath, nSymPathLen, _T(".;"));
-+
-+    const size_t nTempLen = 1024;
+ 
+     const size_t nTempLen = 1024;
+-    char         szTemp[nTempLen];
 +    TCHAR         szTemp[nTempLen];
-+    // Now add the current directory:
+     // Now add the current directory:
+-    if (GetCurrentDirectoryA(nTempLen, szTemp) > 0)
 +    if (GetCurrentDirectory(nTempLen, szTemp) > 0)
-+    {
-+      szTemp[nTempLen - 1] = 0;
+     {
+       szTemp[nTempLen - 1] = 0;
+-      strcat_s(szSymPath, nSymPathLen, szTemp);
+-      strcat_s(szSymPath, nSymPathLen, ";");
 +      _tcscat_s(szSymPath, nSymPathLen, szTemp);
 +      _tcscat_s(szSymPath, nSymPathLen, _T(";"));
-+    }
-+
-+    // Now add the path for the main-module:
+     }
+ 
+     // Now add the path for the main-module:
+-    if (GetModuleFileNameA(NULL, szTemp, nTempLen) > 0)
 +    if (GetModuleFileName(NULL, szTemp, nTempLen) > 0)
-+    {
-+      szTemp[nTempLen - 1] = 0;
+     {
+       szTemp[nTempLen - 1] = 0;
+-      for (char* p = (szTemp + strlen(szTemp) - 1); p >= szTemp; --p)
 +      for (TCHAR* p = (szTemp + _tcslen(szTemp) - 1); p >= szTemp; --p)
-+      {
-+        // locate the rightmost path separator
-+        if ((*p == '\\') || (*p == '/') || (*p == ':'))
-+        {
-+          *p = 0;
-+          break;
-+        }
-+      } // for (search for path separator...)
+       {
+         // locate the rightmost path separator
+         if ((*p == '\\') || (*p == '/') || (*p == ':'))
+@@ -961,48 +864,48 @@ BOOL StackWalker::LoadModules()
+           break;
+         }
+       } // for (search for path separator...)
+-      if (strlen(szTemp) > 0)
 +      if (_tcslen(szTemp) > 0)
-+      {
+       {
+-        strcat_s(szSymPath, nSymPathLen, szTemp);
+-        strcat_s(szSymPath, nSymPathLen, ";");
 +        _tcscat_s(szSymPath, nSymPathLen, szTemp);
 +        _tcscat_s(szSymPath, nSymPathLen, _T(";"));
-+      }
-+    }
+       }
+     }
+-    if (GetEnvironmentVariableA("_NT_SYMBOL_PATH", szTemp, nTempLen) > 0)
 +    if (GetEnvironmentVariable(_T("_NT_SYMBOL_PATH"), szTemp, nTempLen) > 0)
-+    {
-+      szTemp[nTempLen - 1] = 0;
+     {
+       szTemp[nTempLen - 1] = 0;
+-      strcat_s(szSymPath, nSymPathLen, szTemp);
+-      strcat_s(szSymPath, nSymPathLen, ";");
 +      _tcscat_s(szSymPath, nSymPathLen, szTemp);
 +      _tcscat_s(szSymPath, nSymPathLen, _T(";"));
-+    }
+     }
+-    if (GetEnvironmentVariableA("_NT_ALTERNATE_SYMBOL_PATH", szTemp, nTempLen) > 0)
 +    if (GetEnvironmentVariable(_T("_NT_ALTERNATE_SYMBOL_PATH"), szTemp, nTempLen) > 0)
-+    {
-+      szTemp[nTempLen - 1] = 0;
+     {
+       szTemp[nTempLen - 1] = 0;
+-      strcat_s(szSymPath, nSymPathLen, szTemp);
+-      strcat_s(szSymPath, nSymPathLen, ";");
 +      _tcscat_s(szSymPath, nSymPathLen, szTemp);
 +      _tcscat_s(szSymPath, nSymPathLen, _T(";"));
-+    }
+     }
+-    if (GetEnvironmentVariableA("SYSTEMROOT", szTemp, nTempLen) > 0)
 +    if (GetEnvironmentVariable(_T("SYSTEMROOT"), szTemp, nTempLen) > 0)
-+    {
-+      szTemp[nTempLen - 1] = 0;
+     {
+       szTemp[nTempLen - 1] = 0;
+-      strcat_s(szSymPath, nSymPathLen, szTemp);
+-      strcat_s(szSymPath, nSymPathLen, ";");
 +      _tcscat_s(szSymPath, nSymPathLen, szTemp);
 +      _tcscat_s(szSymPath, nSymPathLen, _T(";"));
-+      // also add the "system32"-directory:
+       // also add the "system32"-directory:
+-      strcat_s(szTemp, nTempLen, "\\system32");
+-      strcat_s(szSymPath, nSymPathLen, szTemp);
+-      strcat_s(szSymPath, nSymPathLen, ";");
 +      _tcscat_s(szTemp, nTempLen, _T("\\system32"));
 +      _tcscat_s(szSymPath, nSymPathLen, szTemp);
 +      _tcscat_s(szSymPath, nSymPathLen, _T(";"));
-+    }
-+
-+    if ((this->m_options & SymUseSymSrv) != 0)
-+    {
+     }
+ 
+     if ((this->m_options & SymUseSymSrv) != 0)
+     {
+-      if (GetEnvironmentVariableA("SYSTEMDRIVE", szTemp, nTempLen) > 0)
 +      if (GetEnvironmentVariable(_T("SYSTEMDRIVE"), szTemp, nTempLen) > 0)
-+      {
-+        szTemp[nTempLen - 1] = 0;
+       {
+         szTemp[nTempLen - 1] = 0;
+-        strcat_s(szSymPath, nSymPathLen, "SRV*");
+-        strcat_s(szSymPath, nSymPathLen, szTemp);
+-        strcat_s(szSymPath, nSymPathLen, "\\websymbols");
+-        strcat_s(szSymPath, nSymPathLen, "*http://msdl.microsoft.com/download/symbols;");
 +        _tcscat_s(szSymPath, nSymPathLen, _T("SRV*"));
 +        _tcscat_s(szSymPath, nSymPathLen, szTemp);
 +        _tcscat_s(szSymPath, nSymPathLen, _T("\\websymbols"));
 +        _tcscat_s(szSymPath, nSymPathLen, _T("*http://msdl.microsoft.com/download/symbols;"));
-+      }
-+      else
+       }
+       else
+-        strcat_s(szSymPath, nSymPathLen,
+-                 "SRV*c:\\websymbols*http://msdl.microsoft.com/download/symbols;");
 +        _tcscat_s(szSymPath, nSymPathLen,
 +                 _T("SRV*c:\\websymbols*http://msdl.microsoft.com/download/symbols;"));
-+    }
-+  } // if SymBuildPath
-+
-+  // First Init the whole stuff...
-+  BOOL bRet = this->m_sw->Init(szSymPath);
-+  if (szSymPath != NULL)
-+    free(szSymPath);
-+  szSymPath = NULL;
-+  if (bRet == FALSE)
-+  {
+     }
+   } // if SymBuildPath
+ 
+@@ -1013,7 +916,7 @@ BOOL StackWalker::LoadModules()
+   szSymPath = NULL;
+   if (bRet == FALSE)
+   {
+-    this->OnDbgHelpErr("Error while initializing dbghelp.dll", 0, 0);
 +    this->OnDbgHelpErr(_T("Error while initializing dbghelp.dll"), 0, 0);
-+    SetLastError(ERROR_DLL_INIT_FAILED);
-+    return FALSE;
-+  }
-+
-+  bRet = this->m_sw->LoadModules(this->m_hProcess, this->m_dwProcessId);
-+  if (bRet != FALSE)
-+    m_modulesLoaded = TRUE;
-+  return bRet;
-+}
-+
-+// The following is used to pass the "userData"-Pointer to the user-provided readMemoryFunction
-+// This has to be done due to a problem with the "hProcess"-parameter in x64...
-+// Because this class is in no case multi-threading-enabled (because of the limitations
-+// of dbghelp.dll) it is "safe" to use a static-variable
-+static StackWalker::PReadProcessMemoryRoutine s_readMemoryFunction = NULL;
-+static LPVOID                                 s_readMemoryFunction_UserData = NULL;
-+
-+BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
-+                                const CONTEXT*            context,
-+                                PReadProcessMemoryRoutine readMemoryFunction,
-+                                LPVOID                    pUserData)
-+{
-+  CONTEXT                                   c;
-+  CallstackEntry                            csEntry;
+     SetLastError(ERROR_DLL_INIT_FAILED);
+     return FALSE;
+   }
+@@ -1038,9 +941,10 @@ BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
+ {
+   CONTEXT                                   c;
+   CallstackEntry                            csEntry;
+-  IMAGEHLP_SYMBOL64*                        pSym = NULL;
 +
 +  tSymbolInfo* pSym = NULL;
-+  StackWalkerInternal::IMAGEHLP_MODULE64_V3 Module;
+   StackWalkerInternal::IMAGEHLP_MODULE64_V3 Module;
+-  IMAGEHLP_LINE64                           Line;
 +  tImageHelperLine                           Line;
-+  int                                       frameNum;
-+  bool                                      bLastEntryCalled = true;
-+  int                                       curRecursionCount = 0;
-+
-+  if (m_modulesLoaded == FALSE)
-+    this->LoadModules(); // ignore the result...
-+
-+  if (this->m_sw->m_hDbhHelp == NULL)
-+  {
-+    SetLastError(ERROR_DLL_INIT_FAILED);
-+    return FALSE;
-+  }
-+
-+  s_readMemoryFunction = readMemoryFunction;
-+  s_readMemoryFunction_UserData = pUserData;
-+
-+  if (context == NULL)
-+  {
-+    // If no context is provided, capture the context
-+    // See: https://stackwalker.codeplex.com/discussions/446958
-+#if _WIN32_WINNT <= 0x0501
-+    // If we need to support XP, we need to use the "old way", because "GetThreadId" is not available!
-+    if (hThread == GetCurrentThread())
-+#else
-+    if (GetThreadId(hThread) == GetCurrentThreadId())
-+#endif
-+    {
-+      GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, USED_CONTEXT_FLAGS);
-+    }
-+    else
-+    {
-+      SuspendThread(hThread);
-+      memset(&c, 0, sizeof(CONTEXT));
-+      c.ContextFlags = USED_CONTEXT_FLAGS;
-+
-+      // TODO: Detect if you want to get a thread context of a different process, which is running a different processor architecture...
-+      // This does only work if we are x64 and the target process is x64 or x86;
-+      // It cannot work, if this process is x64 and the target process is x64... this is not supported...
-+      // See also: http://www.howzatt.demon.co.uk/articles/DebuggingInWin64.html
-+      if (GetThreadContext(hThread, &c) == FALSE)
-+      {
-+        ResumeThread(hThread);
-+        return FALSE;
-+      }
-+    }
-+  }
-+  else
-+    c = *context;
-+
-+  // init STACKFRAME for first call
-+  STACKFRAME64 s; // in/out stackframe
-+  memset(&s, 0, sizeof(s));
-+  DWORD imageType;
-+#ifdef _M_IX86
-+  // normally, call ImageNtHeader() and use machine info from PE header
-+  imageType = IMAGE_FILE_MACHINE_I386;
-+  s.AddrPC.Offset = c.Eip;
-+  s.AddrPC.Mode = AddrModeFlat;
-+  s.AddrFrame.Offset = c.Ebp;
-+  s.AddrFrame.Mode = AddrModeFlat;
-+  s.AddrStack.Offset = c.Esp;
-+  s.AddrStack.Mode = AddrModeFlat;
-+#elif _M_X64
-+  imageType = IMAGE_FILE_MACHINE_AMD64;
-+  s.AddrPC.Offset = c.Rip;
-+  s.AddrPC.Mode = AddrModeFlat;
-+  s.AddrFrame.Offset = c.Rsp;
-+  s.AddrFrame.Mode = AddrModeFlat;
-+  s.AddrStack.Offset = c.Rsp;
-+  s.AddrStack.Mode = AddrModeFlat;
-+#elif _M_IA64
-+  imageType = IMAGE_FILE_MACHINE_IA64;
-+  s.AddrPC.Offset = c.StIIP;
-+  s.AddrPC.Mode = AddrModeFlat;
-+  s.AddrFrame.Offset = c.IntSp;
-+  s.AddrFrame.Mode = AddrModeFlat;
-+  s.AddrBStore.Offset = c.RsBSP;
-+  s.AddrBStore.Mode = AddrModeFlat;
-+  s.AddrStack.Offset = c.IntSp;
-+  s.AddrStack.Mode = AddrModeFlat;
-+#else
-+#error "Platform not supported!"
-+#endif
-+
+   int                                       frameNum;
+   bool                                      bLastEntryCalled = true;
+   int                                       curRecursionCount = 0;
+@@ -1125,12 +1029,12 @@ BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
+ #error "Platform not supported!"
+ #endif
+ 
+-  pSym = (IMAGEHLP_SYMBOL64*)malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
 +  pSym = (tSymbolInfo*)malloc(sizeof(tSymbolInfo) + STACKWALK_MAX_NAMELEN*sizeof(TCHAR));
-+  if (!pSym)
-+    goto cleanup; // not enough memory...
+   if (!pSym)
+     goto cleanup; // not enough memory...
+-  memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+-  pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+-  pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
 +  memset(pSym, 0, sizeof(tSymbolInfo) + STACKWALK_MAX_NAMELEN*sizeof(TCHAR));
 +  pSym->SizeOfStruct = sizeof(tSymbolInfo);
 +  pSym->MaxNameLen = STACKWALK_MAX_NAMELEN;
-+
-+  memset(&Line, 0, sizeof(Line));
-+  Line.SizeOfStruct = sizeof(Line);
-+
-+  memset(&Module, 0, sizeof(Module));
-+  Module.SizeOfStruct = sizeof(Module);
-+
-+  for (frameNum = 0;; ++frameNum)
-+  {
-+    // get next stack frame (StackWalk64(), SymFunctionTableAccess64(), SymGetModuleBase64())
-+    // if this returns ERROR_INVALID_ADDRESS (487) or ERROR_NOACCESS (998), you can
-+    // assume that either you are done, or that the stack is so hosed that the next
-+    // deeper frame could not be found.
-+    // CONTEXT need not to be supplied if imageTyp is IMAGE_FILE_MACHINE_I386!
+ 
+   memset(&Line, 0, sizeof(Line));
+   Line.SizeOfStruct = sizeof(Line);
+@@ -1145,11 +1049,11 @@ BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
+     // assume that either you are done, or that the stack is so hosed that the next
+     // deeper frame could not be found.
+     // CONTEXT need not to be supplied if imageTyp is IMAGE_FILE_MACHINE_I386!
+-    if (!this->m_sw->pSW(imageType, this->m_hProcess, hThread, &s, &c, myReadProcMem,
+-                         this->m_sw->pSFTA, this->m_sw->pSGMB, NULL))
 +    if (!this->m_sw->stackWalk64(imageType, this->m_hProcess, hThread, &s, &c, myReadProcMem,
 +                         this->m_sw->symFunctionTableAccess64, this->m_sw->symGetModuleBase64, NULL))
-+    {
-+      // INFO: "StackWalk64" does not set "GetLastError"...
+     {
+       // INFO: "StackWalk64" does not set "GetLastError"...
+-      this->OnDbgHelpErr("StackWalk64", 0, s.AddrPC.Offset);
 +      this->OnDbgHelpErr(_T("StackWalk64"), 0, s.AddrPC.Offset);
-+      break;
-+    }
-+
-+    csEntry.offset = s.AddrPC.Offset;
-+    csEntry.name[0] = 0;
-+    csEntry.undName[0] = 0;
-+    csEntry.undFullName[0] = 0;
-+    csEntry.offsetFromSmybol = 0;
-+    csEntry.offsetFromLine = 0;
-+    csEntry.lineFileName[0] = 0;
-+    csEntry.lineNumber = 0;
-+    csEntry.loadedImageName[0] = 0;
-+    csEntry.moduleName[0] = 0;
-+    if (s.AddrPC.Offset == s.AddrReturn.Offset)
-+    {
-+      if ((this->m_MaxRecursionCount > 0) && (curRecursionCount > m_MaxRecursionCount))
-+      {
+       break;
+     }
+ 
+@@ -1167,7 +1071,7 @@ BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
+     {
+       if ((this->m_MaxRecursionCount > 0) && (curRecursionCount > m_MaxRecursionCount))
+       {
+-        this->OnDbgHelpErr("StackWalk64-Endless-Callstack!", 0, s.AddrPC.Offset);
 +        this->OnDbgHelpErr(_T("StackWalk64-Endless-Callstack!"), 0, s.AddrPC.Offset);
-+        break;
-+      }
-+      curRecursionCount++;
-+    }
-+    else
-+      curRecursionCount = 0;
-+    if (s.AddrPC.Offset != 0)
-+    {
-+      // we seem to have a valid PC
-+      // show procedure info (SymGetSymFromAddr64())
+         break;
+       }
+       curRecursionCount++;
+@@ -1178,23 +1082,23 @@ BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
+     {
+       // we seem to have a valid PC
+       // show procedure info (SymGetSymFromAddr64())
+-      if (this->m_sw->pSGSFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromSmybol),
 +      if (this->m_sw->symFromAddr(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromSmybol),
-+                             pSym) != FALSE)
-+      {
-+        MyStrCpy(csEntry.name, STACKWALK_MAX_NAMELEN, pSym->Name);
-+        // UnDecorateSymbolName()
+                              pSym) != FALSE)
+       {
+         MyStrCpy(csEntry.name, STACKWALK_MAX_NAMELEN, pSym->Name);
+         // UnDecorateSymbolName()
+-        this->m_sw->pUDSN(pSym->Name, csEntry.undName, STACKWALK_MAX_NAMELEN, UNDNAME_NAME_ONLY);
+-        this->m_sw->pUDSN(pSym->Name, csEntry.undFullName, STACKWALK_MAX_NAMELEN, UNDNAME_COMPLETE);
 +        DWORD res = this->m_sw->unDecorateSymbolName(pSym->Name, csEntry.undName, STACKWALK_MAX_NAMELEN, UNDNAME_NAME_ONLY);
 +        res = this->m_sw->unDecorateSymbolName(pSym->Name, csEntry.undFullName, STACKWALK_MAX_NAMELEN, UNDNAME_COMPLETE);
-+      }
-+      else
-+      {
+       }
+       else
+       {
+-        this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), s.AddrPC.Offset);
 +        this->OnDbgHelpErr(_T("SymGetSymFromAddr64"), GetLastError(), s.AddrPC.Offset);
-+      }
-+
-+      // show line number info, NT5.0-method (SymGetLineFromAddr64())
+       }
+ 
+       // show line number info, NT5.0-method (SymGetLineFromAddr64())
+-      if (this->m_sw->pSGLFA != NULL)
 +      if (this->m_sw->symGetLineFromAddr64 != NULL)
-+      { // yes, we have SymGetLineFromAddr64()
+       { // yes, we have SymGetLineFromAddr64()
+-        if (this->m_sw->pSGLFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromLine),
 +        if (this->m_sw->symGetLineFromAddr64(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromLine),
-+                               &Line) != FALSE)
-+        {
-+          csEntry.lineNumber = Line.LineNumber;
-+          MyStrCpy(csEntry.lineFileName, STACKWALK_MAX_NAMELEN, Line.FileName);
-+        }
-+        else
-+        {
+                                &Line) != FALSE)
+         {
+           csEntry.lineNumber = Line.LineNumber;
+@@ -1202,7 +1106,7 @@ BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
+         }
+         else
+         {
+-          this->OnDbgHelpErr("SymGetLineFromAddr64", GetLastError(), s.AddrPC.Offset);
 +          this->OnDbgHelpErr(_T("SymGetLineFromAddr64"), GetLastError(), s.AddrPC.Offset);
-+        }
-+      } // yes, we have SymGetLineFromAddr64()
-+
-+      // show module info (SymGetModuleInfo64())
-+      if (this->m_sw->GetModuleInfo(this->m_hProcess, s.AddrPC.Offset, &Module) != FALSE)
-+      { // got module info OK
-+        switch (Module.SymType)
-+        {
-+          case SymNone:
-+            csEntry.symTypeString = "-nosymbols-";
-+            break;
-+          case SymCoff:
-+            csEntry.symTypeString = "COFF";
-+            break;
-+          case SymCv:
-+            csEntry.symTypeString = "CV";
-+            break;
-+          case SymPdb:
-+            csEntry.symTypeString = "PDB";
-+            break;
-+          case SymExport:
-+            csEntry.symTypeString = "-exported-";
-+            break;
-+          case SymDeferred:
-+            csEntry.symTypeString = "-deferred-";
-+            break;
-+          case SymSym:
-+            csEntry.symTypeString = "SYM";
-+            break;
-+#if API_VERSION_NUMBER >= 9
-+          case SymDia:
-+            csEntry.symTypeString = "DIA";
-+            break;
-+#endif
-+          case 8: //SymVirtual:
-+            csEntry.symTypeString = "Virtual";
-+            break;
-+          default:
-+            //_snprintf( ty, sizeof(ty), "symtype=%ld", (long) Module.SymType );
-+            csEntry.symTypeString = NULL;
-+            break;
-+        }
-+
-+        MyStrCpy(csEntry.moduleName, STACKWALK_MAX_NAMELEN, Module.ModuleName);
-+        csEntry.baseOfImage = Module.BaseOfImage;
-+        MyStrCpy(csEntry.loadedImageName, STACKWALK_MAX_NAMELEN, Module.LoadedImageName);
-+      } // got module info OK
-+      else
-+      {
+         }
+       } // yes, we have SymGetLineFromAddr64()
+ 
+@@ -1252,7 +1156,7 @@ BOOL StackWalker::ShowCallstack(HANDLE                    hThread,
+       } // got module info OK
+       else
+       {
+-        this->OnDbgHelpErr("SymGetModuleInfo64", GetLastError(), s.AddrPC.Offset);
 +        this->OnDbgHelpErr(_T("SymGetModuleInfo64"), GetLastError(), s.AddrPC.Offset);
-+      }
-+    } // we seem to have a valid PC
-+
-+    CallstackEntryType et = nextEntry;
-+    if (frameNum == 0)
-+      et = firstEntry;
-+    bLastEntryCalled = false;
-+    this->OnCallstackEntry(et, csEntry);
-+
-+    if (s.AddrReturn.Offset == 0)
-+    {
-+      bLastEntryCalled = true;
-+      this->OnCallstackEntry(lastEntry, csEntry);
-+      SetLastError(ERROR_SUCCESS);
-+      break;
-+    }
-+  } // for ( frameNum )
-+
-+cleanup:
-+  if (pSym)
-+    free(pSym);
-+
-+  if (bLastEntryCalled == false)
-+    this->OnCallstackEntry(lastEntry, csEntry);
-+
-+  if (context == NULL)
-+    ResumeThread(hThread);
-+
-+  return TRUE;
-+}
-+
-+BOOL StackWalker::ShowObject(LPVOID pObject)
-+{
-+  // Load modules if not done yet
-+  if (m_modulesLoaded == FALSE)
-+    this->LoadModules(); // ignore the result...
-+
-+  // Verify that the DebugHelp.dll was actually found
-+  if (this->m_sw->m_hDbhHelp == NULL)
-+  {
-+    SetLastError(ERROR_DLL_INIT_FAILED);
-+    return FALSE;
-+  }
-+
-+  // SymGetSymFromAddr64() is required
+       }
+     } // we seem to have a valid PC
+ 
+@@ -1298,20 +1202,20 @@ BOOL StackWalker::ShowObject(LPVOID pObject)
+   }
+ 
+   // SymGetSymFromAddr64() is required
+-  if (this->m_sw->pSGSFA == NULL)
 +  if (this->m_sw->symFromAddr == NULL)
-+    return FALSE;
-+
-+  // Show object info (SymGetSymFromAddr64())
-+  DWORD64            dwAddress = DWORD64(pObject);
-+  DWORD64            dwDisplacement = 0;
+     return FALSE;
+ 
+   // Show object info (SymGetSymFromAddr64())
+   DWORD64            dwAddress = DWORD64(pObject);
+   DWORD64            dwDisplacement = 0;
+-  IMAGEHLP_SYMBOL64* pSym =
+-      (IMAGEHLP_SYMBOL64*)malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+-  memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+-  pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+-  pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
+-  if (this->m_sw->pSGSFA(this->m_hProcess, dwAddress, &dwDisplacement, pSym) == FALSE)
 +  tSymbolInfo* pSym =
 +      (tSymbolInfo*)malloc(sizeof(tSymbolInfo) + STACKWALK_MAX_NAMELEN*sizeof(TCHAR));
 +  memset(pSym, 0, sizeof(tSymbolInfo) + STACKWALK_MAX_NAMELEN*sizeof(TCHAR));
 +  pSym->SizeOfStruct = sizeof(tSymbolInfo);
 +  pSym->MaxNameLen = STACKWALK_MAX_NAMELEN;
 +  if (this->m_sw->symFromAddr(this->m_hProcess, dwAddress, &dwDisplacement, pSym) == FALSE)
-+  {
+   {
+-    this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), dwAddress);
 +    this->OnDbgHelpErr(_T("SymGetSymFromAddr64"), GetLastError(), dwAddress);
-+    return FALSE;
-+  }
-+  // Object name output
-+  this->OnOutput(pSym->Name);
-+
-+  free(pSym);
-+  return TRUE;
-+};
-+
-+BOOL __stdcall StackWalker::myReadProcMem(HANDLE  hProcess,
-+                                          DWORD64 qwBaseAddress,
-+                                          PVOID   lpBuffer,
-+                                          DWORD   nSize,
-+                                          LPDWORD lpNumberOfBytesRead)
-+{
-+  if (s_readMemoryFunction == NULL)
-+  {
-+    SIZE_T st;
-+    BOOL   bRet = ReadProcessMemory(hProcess, (LPVOID)qwBaseAddress, lpBuffer, nSize, &st);
-+    *lpNumberOfBytesRead = (DWORD)st;
-+    //printf("ReadMemory: hProcess: %p, baseAddr: %p, buffer: %p, size: %d, read: %d, result: %d\n", hProcess, (LPVOID) qwBaseAddress, lpBuffer, nSize, (DWORD) st, (DWORD) bRet);
-+    return bRet;
-+  }
-+  else
-+  {
-+    return s_readMemoryFunction(hProcess, qwBaseAddress, lpBuffer, nSize, lpNumberOfBytesRead,
-+                                s_readMemoryFunction_UserData);
-+  }
-+}
-+
+     return FALSE;
+   }
+   // Object name output
+@@ -1342,22 +1246,22 @@ BOOL __stdcall StackWalker::myReadProcMem(HANDLE  hProcess,
+   }
+ }
+ 
+-void StackWalker::OnLoadModule(LPCSTR    img,
+-                               LPCSTR    mod,
 +void StackWalker::OnLoadModule(LPCTSTR    img,
 +                               LPCTSTR    mod,
-+                               DWORD64   baseAddr,
-+                               DWORD     size,
-+                               DWORD     result,
+                                DWORD64   baseAddr,
+                                DWORD     size,
+                                DWORD     result,
+-                               LPCSTR    symType,
+-                               LPCSTR    pdbName,
 +                               LPCTSTR    symType,
 +                               LPCTSTR    pdbName,
-+                               ULONGLONG fileVersion)
-+{
+                                ULONGLONG fileVersion)
+ {
+-  CHAR   buffer[STACKWALK_MAX_NAMELEN];
 +  TCHAR   buffer[STACKWALK_MAX_NAMELEN];
-+  size_t maxLen = STACKWALK_MAX_NAMELEN;
-+#if _MSC_VER >= 1400
-+  maxLen = _TRUNCATE;
-+#endif
-+  if (fileVersion == 0)
+   size_t maxLen = STACKWALK_MAX_NAMELEN;
+ #if _MSC_VER >= 1400
+   maxLen = _TRUNCATE;
+ #endif
+   if (fileVersion == 0)
+-    _snprintf_s(buffer, maxLen, "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s'\n",
 +    _sntprintf_s(buffer, maxLen, _T("%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s'\n"),
-+                img, mod, (LPVOID)baseAddr, size, result, symType, pdbName);
-+  else
-+  {
-+    DWORD v4 = (DWORD)(fileVersion & 0xFFFF);
-+    DWORD v3 = (DWORD)((fileVersion >> 16) & 0xFFFF);
-+    DWORD v2 = (DWORD)((fileVersion >> 32) & 0xFFFF);
-+    DWORD v1 = (DWORD)((fileVersion >> 48) & 0xFFFF);
+                 img, mod, (LPVOID)baseAddr, size, result, symType, pdbName);
+   else
+   {
+@@ -1365,9 +1269,9 @@ void StackWalker::OnLoadModule(LPCSTR    img,
+     DWORD v3 = (DWORD)((fileVersion >> 16) & 0xFFFF);
+     DWORD v2 = (DWORD)((fileVersion >> 32) & 0xFFFF);
+     DWORD v1 = (DWORD)((fileVersion >> 48) & 0xFFFF);
+-    _snprintf_s(
 +    _sntprintf_s(
-+        buffer, maxLen,
+         buffer, maxLen,
+-        "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s', fileVersion: %d.%d.%d.%d\n",
 +        _T("%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s', fileVersion: %d.%d.%d.%d\n"),
-+        img, mod, (LPVOID)baseAddr, size, result, symType, pdbName, v1, v2, v3, v4);
-+  }
-+  buffer[STACKWALK_MAX_NAMELEN - 1] = 0; // be sure it is NULL terminated
-+  OnOutput(buffer);
-+}
-+
-+void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry)
-+{
+         img, mod, (LPVOID)baseAddr, size, result, symType, pdbName, v1, v2, v3, v4);
+   }
+   buffer[STACKWALK_MAX_NAMELEN - 1] = 0; // be sure it is NULL terminated
+@@ -1376,7 +1280,7 @@ void StackWalker::OnLoadModule(LPCSTR    img,
+ 
+ void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry)
+ {
+-  CHAR   buffer[STACKWALK_MAX_NAMELEN];
 +  TCHAR   buffer[STACKWALK_MAX_NAMELEN];
-+  size_t maxLen = STACKWALK_MAX_NAMELEN;
-+#if _MSC_VER >= 1400
-+  maxLen = _TRUNCATE;
-+#endif
-+  if ((eType != lastEntry) && (entry.offset != 0))
-+  {
-+    if (entry.name[0] == 0)
+   size_t maxLen = STACKWALK_MAX_NAMELEN;
+ #if _MSC_VER >= 1400
+   maxLen = _TRUNCATE;
+@@ -1384,48 +1288,48 @@ void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry& ent
+   if ((eType != lastEntry) && (entry.offset != 0))
+   {
+     if (entry.name[0] == 0)
+-      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, "(function-name not available)");
 +      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, _T("(function-name not available)"));
-+    if (entry.undName[0] != 0)
-+      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undName);
-+    if (entry.undFullName[0] != 0)
-+      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undFullName);
-+    if (entry.lineFileName[0] == 0)
-+    {
+     if (entry.undName[0] != 0)
+       MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undName);
+     if (entry.undFullName[0] != 0)
+       MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undFullName);
+     if (entry.lineFileName[0] == 0)
+     {
+-      MyStrCpy(entry.lineFileName, STACKWALK_MAX_NAMELEN, "(filename not available)");
 +      MyStrCpy(entry.lineFileName, STACKWALK_MAX_NAMELEN, _T("(filename not available)"));
-+      if (entry.moduleName[0] == 0)
+       if (entry.moduleName[0] == 0)
+-        MyStrCpy(entry.moduleName, STACKWALK_MAX_NAMELEN, "(module-name not available)");
+-      _snprintf_s(buffer, maxLen, "%p (%s): %s: %s\n", (LPVOID)entry.offset, entry.moduleName,
 +        MyStrCpy(entry.moduleName, STACKWALK_MAX_NAMELEN, _T("(module-name not available)"));
 +      _sntprintf_s(buffer, maxLen, _T("%p (%s): %s: %s\n"), (LPVOID)entry.offset, entry.moduleName,
-+                  entry.lineFileName, entry.name);
-+    }
-+    else
+                   entry.lineFileName, entry.name);
+     }
+     else
+-      _snprintf_s(buffer, maxLen, "%s (%d): %s\n", entry.lineFileName, entry.lineNumber,
 +      _sntprintf_s(buffer, maxLen, _T("%s (%d): %s\n"), entry.lineFileName, entry.lineNumber,
-+                  entry.name);
-+    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
-+    OnOutput(buffer);
-+  }
-+}
-+
+                   entry.name);
+     buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+     OnOutput(buffer);
+   }
+ }
+ 
+-void StackWalker::OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr)
 +void StackWalker::OnDbgHelpErr(LPCTSTR szFuncName, DWORD gle, DWORD64 addr)
-+{
+ {
+-  CHAR   buffer[STACKWALK_MAX_NAMELEN];
 +  TCHAR   buffer[STACKWALK_MAX_NAMELEN];
-+  size_t maxLen = STACKWALK_MAX_NAMELEN;
-+#if _MSC_VER >= 1400
-+  maxLen = _TRUNCATE;
-+#endif
+   size_t maxLen = STACKWALK_MAX_NAMELEN;
+ #if _MSC_VER >= 1400
+   maxLen = _TRUNCATE;
+ #endif
+-  _snprintf_s(buffer, maxLen, "ERROR: %s, GetLastError: %d (Address: %p)\n", szFuncName, gle,
 +  _sntprintf_s(buffer, maxLen, _T("ERROR: %s, GetLastError: %d (Address: %p)\n"), szFuncName, gle,
-+              (LPVOID)addr);
-+  buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
-+  OnOutput(buffer);
-+}
-+
+               (LPVOID)addr);
+   buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+   OnOutput(buffer);
+ }
+ 
+-void StackWalker::OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName)
 +void StackWalker::OnSymInit(LPCTSTR szSearchPath, DWORD symOptions, LPCTSTR szUserName)
-+{
+ {
+-  CHAR   buffer[STACKWALK_MAX_NAMELEN];
 +  TCHAR   buffer[STACKWALK_MAX_NAMELEN];
-+  size_t maxLen = STACKWALK_MAX_NAMELEN;
-+#if _MSC_VER >= 1400
-+  maxLen = _TRUNCATE;
-+#endif
+   size_t maxLen = STACKWALK_MAX_NAMELEN;
+ #if _MSC_VER >= 1400
+   maxLen = _TRUNCATE;
+ #endif
+-  _snprintf_s(buffer, maxLen, "SymInit: Symbol-SearchPath: '%s', symOptions: %d, UserName: '%s'\n",
 +  _sntprintf_s(buffer, maxLen, _T("SymInit: Symbol-SearchPath: '%s', symOptions: %d, UserName: '%s'\n"),
-+              szSearchPath, symOptions, szUserName);
-+  buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
-+  OnOutput(buffer);
-+  // Also display the OS-version
-+#if _MSC_VER <= 1200
-+  OSVERSIONINFOA ver;
-+  ZeroMemory(&ver, sizeof(OSVERSIONINFOA));
-+  ver.dwOSVersionInfoSize = sizeof(ver);
-+  if (GetVersionExA(&ver) != FALSE)
-+  {
-+    _snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s)\n", ver.dwMajorVersion,
-+                ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion);
-+    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
-+    OnOutput(buffer);
-+  }
-+#else
+               szSearchPath, symOptions, szUserName);
+   buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+   OnOutput(buffer);
+@@ -1442,16 +1346,16 @@ void StackWalker::OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUser
+     OnOutput(buffer);
+   }
+ #else
+-  OSVERSIONINFOEXA ver;
+-  ZeroMemory(&ver, sizeof(OSVERSIONINFOEXA));
 +  OSVERSIONINFOEX ver;
 +  ZeroMemory(&ver, sizeof(OSVERSIONINFOEX));
-+  ver.dwOSVersionInfoSize = sizeof(ver);
-+#if _MSC_VER >= 1900
-+#pragma warning(push)
-+#pragma warning(disable : 4996)
-+#endif
+   ver.dwOSVersionInfoSize = sizeof(ver);
+ #if _MSC_VER >= 1900
+ #pragma warning(push)
+ #pragma warning(disable : 4996)
+ #endif
+-  if (GetVersionExA((OSVERSIONINFOA*)&ver) != FALSE)
 +  if (GetVersionEx((OSVERSIONINFO*)&ver) != FALSE)
-+  {
+   {
+-    _snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s) 0x%x-0x%x\n", ver.dwMajorVersion,
 +    _sntprintf_s(buffer, maxLen, _T("OS-Version: %d.%d.%d (%s) 0x%x-0x%x\n"), ver.dwMajorVersion,
-+                ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion, ver.wSuiteMask,
-+                ver.wProductType);
-+    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
-+    OnOutput(buffer);
-+  }
-+#if _MSC_VER >= 1900
-+#pragma warning(pop)
-+#endif
-+#endif
-+}
-+
+                 ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion, ver.wSuiteMask,
+                 ver.wProductType);
+     buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+@@ -1463,7 +1367,7 @@ void StackWalker::OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUser
+ #endif
+ }
+ 
+-void StackWalker::OnOutput(LPCSTR buffer)
 +void StackWalker::OnOutput(LPCTSTR buffer)
-+{
+ {
+-  OutputDebugStringA(buffer);
 +  OutputDebugString(buffer);
-+}
+ }
 diff --git a/Main/StackWalker/StackWalker.h b/Main/StackWalker/StackWalker.h
-index 66c8260..03efcec 100644
+index 0a004d9..03efcec 100644
 --- a/Main/StackWalker/StackWalker.h
 +++ b/Main/StackWalker/StackWalker.h
-@@ -1,255 +1,245 @@
--#ifndef __STACKWALKER_H__
--#define __STACKWALKER_H__
--
--#if defined(_MSC_VER)
--
--/**********************************************************************
-- *
-- * StackWalker.h
-- *
-- *
-- *
-- * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
-- *
-- *   Copyright (c) 2005-2009, Jochen Kalmbach
-- *   All rights reserved.
-- *
-- *   Redistribution and use in source and binary forms, with or without modification,
-- *   are permitted provided that the following conditions are met:
-- *
-- *   Redistributions of source code must retain the above copyright notice,
-- *   this list of conditions and the following disclaimer.
-- *   Redistributions in binary form must reproduce the above copyright notice,
-- *   this list of conditions and the following disclaimer in the documentation
-- *   and/or other materials provided with the distribution.
-- *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
-- *   used to endorse or promote products derived from this software without
-- *   specific prior written permission.
-- *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-- *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-- *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-- *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-- *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-- *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-- *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-- *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-- *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-- *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-- *
-- * **********************************************************************/
--// #pragma once is supported starting with _MSC_VER 1000,
--// so we need not to check the version (because we only support _MSC_VER >= 1100)!
--#pragma once
--
--#include <windows.h>
--
--#if _MSC_VER >= 1900
--#pragma warning(disable : 4091)
--#endif
--
+@@ -47,16 +47,6 @@
+ #pragma warning(disable : 4091)
+ #endif
+ 
 -// special defines for VC5/6 (if no actual PSDK is installed):
 -#if _MSC_VER < 1300
 -typedef unsigned __int64 DWORD64, *PDWORD64;
@@ -2938,447 +1237,76 @@ index 66c8260..03efcec 100644
 -#endif
 -#endif // _MSC_VER < 1300
 -
--class StackWalkerInternal; // forward
--class StackWalker
--{
--public:
--  typedef enum StackWalkOptions
--  {
--    // No addition info will be retrieved
--    // (only the address is available)
--    RetrieveNone = 0,
--
--    // Try to get the symbol-name
--    RetrieveSymbol = 1,
--
--    // Try to get the line for this symbol
--    RetrieveLine = 2,
--
--    // Try to retrieve the module-infos
--    RetrieveModuleInfo = 4,
--
--    // Also retrieve the version for the DLL/EXE
--    RetrieveFileVersion = 8,
--
--    // Contains all the above
--    RetrieveVerbose = 0xF,
--
--    // Generate a "good" symbol-search-path
--    SymBuildPath = 0x10,
--
--    // Also use the public Microsoft-Symbol-Server
--    SymUseSymSrv = 0x20,
--
--    // Contains all the above "Sym"-options
--    SymAll = 0x30,
--
--    // Contains all options (default)
--    OptionsAll = 0x3F
--  } StackWalkOptions;
--
--  StackWalker(int    options = OptionsAll, // 'int' is by design, to combine the enum-flags
+ class StackWalkerInternal; // forward
+ class StackWalker
+ {
+@@ -96,7 +86,7 @@ public:
+   } StackWalkOptions;
+ 
+   StackWalker(int    options = OptionsAll, // 'int' is by design, to combine the enum-flags
 -              LPCSTR szSymPath = NULL,
--              DWORD  dwProcessId = GetCurrentProcessId(),
--              HANDLE hProcess = GetCurrentProcess());
--  StackWalker(DWORD dwProcessId, HANDLE hProcess);
--  virtual ~StackWalker();
--
--  typedef BOOL(__stdcall* PReadProcessMemoryRoutine)(
--      HANDLE  hProcess,
--      DWORD64 qwBaseAddress,
--      PVOID   lpBuffer,
--      DWORD   nSize,
--      LPDWORD lpNumberOfBytesRead,
--      LPVOID  pUserData // optional data, which was passed in "ShowCallstack"
--  );
--
--  BOOL LoadModules();
--
--  BOOL ShowCallstack(
--      HANDLE                    hThread = GetCurrentThread(),
--      const CONTEXT*            context = NULL,
--      PReadProcessMemoryRoutine readMemoryFunction = NULL,
--      LPVOID pUserData = NULL // optional to identify some data in the 'readMemoryFunction'-callback
--  );
--
--  BOOL ShowObject(LPVOID pObject);
--
--#if _MSC_VER >= 1300
--  // due to some reasons, the "STACKWALK_MAX_NAMELEN" must be declared as "public"
--  // in older compilers in order to use it... starting with VC7 we can declare it as "protected"
--protected:
--#endif
--  enum
--  {
--    STACKWALK_MAX_NAMELEN = 1024
--  }; // max name length for found symbols
--
--protected:
--  // Entry for each Callstack-Entry
--  typedef struct CallstackEntry
--  {
--    DWORD64 offset; // if 0, we have no valid entry
++              LPCTSTR szSymPath = NULL,
+               DWORD  dwProcessId = GetCurrentProcessId(),
+               HANDLE hProcess = GetCurrentProcess());
+   StackWalker(DWORD dwProcessId, HANDLE hProcess);
+@@ -137,18 +127,18 @@ protected:
+   typedef struct CallstackEntry
+   {
+     DWORD64 offset; // if 0, we have no valid entry
 -    CHAR    name[STACKWALK_MAX_NAMELEN];
 -    CHAR    undName[STACKWALK_MAX_NAMELEN];
 -    CHAR    undFullName[STACKWALK_MAX_NAMELEN];
--    DWORD64 offsetFromSmybol;
--    DWORD   offsetFromLine;
--    DWORD   lineNumber;
--    CHAR    lineFileName[STACKWALK_MAX_NAMELEN];
--    DWORD   symType;
--    LPCSTR  symTypeString;
--    CHAR    moduleName[STACKWALK_MAX_NAMELEN];
--    DWORD64 baseOfImage;
--    CHAR    loadedImageName[STACKWALK_MAX_NAMELEN];
--  } CallstackEntry;
--
--  typedef enum CallstackEntryType
--  {
--    firstEntry,
--    nextEntry,
--    lastEntry
--  } CallstackEntryType;
--
--  virtual void OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName);
--  virtual void OnLoadModule(LPCSTR    img,
--                            LPCSTR    mod,
--                            DWORD64   baseAddr,
--                            DWORD     size,
--                            DWORD     result,
--                            LPCSTR    symType,
--                            LPCSTR    pdbName,
--                            ULONGLONG fileVersion);
--  virtual void OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry);
--  virtual void OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr);
--  virtual void OnOutput(LPCSTR szText);
--
--  StackWalkerInternal* m_sw;
--  HANDLE               m_hProcess;
--  DWORD                m_dwProcessId;
--  BOOL                 m_modulesLoaded;
--  LPSTR                m_szSymPath;
--
--  int m_options;
--  int m_MaxRecursionCount;
--
--  static BOOL __stdcall myReadProcMem(HANDLE  hProcess,
--                                      DWORD64 qwBaseAddress,
--                                      PVOID   lpBuffer,
--                                      DWORD   nSize,
--                                      LPDWORD lpNumberOfBytesRead);
--
--  friend StackWalkerInternal;
--}; // class StackWalker
--
--// The "ugly" assembler-implementation is needed for systems before XP
--// If you have a new PSDK and you only compile for XP and later, then you can use
--// the "RtlCaptureContext"
--// Currently there is no define which determines the PSDK-Version...
--// So we just use the compiler-version (and assumes that the PSDK is
--// the one which was installed by the VS-IDE)
--
--// INFO: If you want, you can use the RtlCaptureContext if you only target XP and later...
--//       But I currently use it in x64/IA64 environments...
--//#if defined(_M_IX86) && (_WIN32_WINNT <= 0x0500) && (_MSC_VER < 1400)
--
--#if defined(_M_IX86)
--#ifdef CURRENT_THREAD_VIA_EXCEPTION
--// TODO: The following is not a "good" implementation,
--// because the callstack is only valid in the "__except" block...
--#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags)               \
--  do                                                                            \
--  {                                                                             \
--    memset(&c, 0, sizeof(CONTEXT));                                             \
--    EXCEPTION_POINTERS* pExp = NULL;                                            \
--    __try                                                                       \
--    {                                                                           \
--      throw 0;                                                                  \
--    }                                                                           \
--    __except (((pExp = GetExceptionInformation()) ? EXCEPTION_EXECUTE_HANDLER   \
--                                                  : EXCEPTION_EXECUTE_HANDLER)) \
--    {                                                                           \
--    }                                                                           \
--    if (pExp != NULL)                                                           \
--      memcpy(&c, pExp->ContextRecord, sizeof(CONTEXT));                         \
--    c.ContextFlags = contextFlags;                                              \
--  } while (0);
--#else
--// clang-format off
--// The following should be enough for walking the callstack...
--#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
--  do                                                              \
--  {                                                               \
--    memset(&c, 0, sizeof(CONTEXT));                               \
--    c.ContextFlags = contextFlags;                                \
--    __asm    call x                                               \
--    __asm x: pop eax                                              \
--    __asm    mov c.Eip, eax                                       \
--    __asm    mov c.Ebp, ebp                                       \
--    __asm    mov c.Esp, esp                                       \
--  } while (0)
--// clang-format on
--#endif
--
--#else
--
--// The following is defined for x86 (XP and higher), x64 and IA64:
--#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
--  do                                                              \
--  {                                                               \
--    memset(&c, 0, sizeof(CONTEXT));                               \
--    c.ContextFlags = contextFlags;                                \
--    RtlCaptureContext(&c);                                        \
--  } while (0);
--#endif
--
--#endif //defined(_MSC_VER)
--
--#endif // __STACKWALKER_H__
-+#ifndef __STACKWALKER_H__
-+#define __STACKWALKER_H__
-+
-+#if defined(_MSC_VER)
-+
-+/**********************************************************************
-+ *
-+ * StackWalker.h
-+ *
-+ *
-+ *
-+ * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
-+ *
-+ *   Copyright (c) 2005-2009, Jochen Kalmbach
-+ *   All rights reserved.
-+ *
-+ *   Redistribution and use in source and binary forms, with or without modification,
-+ *   are permitted provided that the following conditions are met:
-+ *
-+ *   Redistributions of source code must retain the above copyright notice,
-+ *   this list of conditions and the following disclaimer.
-+ *   Redistributions in binary form must reproduce the above copyright notice,
-+ *   this list of conditions and the following disclaimer in the documentation
-+ *   and/or other materials provided with the distribution.
-+ *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
-+ *   used to endorse or promote products derived from this software without
-+ *   specific prior written permission.
-+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-+ *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-+ *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-+ *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-+ *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-+ *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-+ *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-+ *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-+ *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-+ *
-+ * **********************************************************************/
-+// #pragma once is supported starting with _MSC_VER 1000,
-+// so we need not to check the version (because we only support _MSC_VER >= 1100)!
-+#pragma once
-+
-+#include <windows.h>
-+
-+#if _MSC_VER >= 1900
-+#pragma warning(disable : 4091)
-+#endif
-+
-+class StackWalkerInternal; // forward
-+class StackWalker
-+{
-+public:
-+  typedef enum StackWalkOptions
-+  {
-+    // No addition info will be retrieved
-+    // (only the address is available)
-+    RetrieveNone = 0,
-+
-+    // Try to get the symbol-name
-+    RetrieveSymbol = 1,
-+
-+    // Try to get the line for this symbol
-+    RetrieveLine = 2,
-+
-+    // Try to retrieve the module-infos
-+    RetrieveModuleInfo = 4,
-+
-+    // Also retrieve the version for the DLL/EXE
-+    RetrieveFileVersion = 8,
-+
-+    // Contains all the above
-+    RetrieveVerbose = 0xF,
-+
-+    // Generate a "good" symbol-search-path
-+    SymBuildPath = 0x10,
-+
-+    // Also use the public Microsoft-Symbol-Server
-+    SymUseSymSrv = 0x20,
-+
-+    // Contains all the above "Sym"-options
-+    SymAll = 0x30,
-+
-+    // Contains all options (default)
-+    OptionsAll = 0x3F
-+  } StackWalkOptions;
-+
-+  StackWalker(int    options = OptionsAll, // 'int' is by design, to combine the enum-flags
-+              LPCTSTR szSymPath = NULL,
-+              DWORD  dwProcessId = GetCurrentProcessId(),
-+              HANDLE hProcess = GetCurrentProcess());
-+  StackWalker(DWORD dwProcessId, HANDLE hProcess);
-+  virtual ~StackWalker();
-+
-+  typedef BOOL(__stdcall* PReadProcessMemoryRoutine)(
-+      HANDLE  hProcess,
-+      DWORD64 qwBaseAddress,
-+      PVOID   lpBuffer,
-+      DWORD   nSize,
-+      LPDWORD lpNumberOfBytesRead,
-+      LPVOID  pUserData // optional data, which was passed in "ShowCallstack"
-+  );
-+
-+  BOOL LoadModules();
-+
-+  BOOL ShowCallstack(
-+      HANDLE                    hThread = GetCurrentThread(),
-+      const CONTEXT*            context = NULL,
-+      PReadProcessMemoryRoutine readMemoryFunction = NULL,
-+      LPVOID pUserData = NULL // optional to identify some data in the 'readMemoryFunction'-callback
-+  );
-+
-+  BOOL ShowObject(LPVOID pObject);
-+
-+#if _MSC_VER >= 1300
-+  // due to some reasons, the "STACKWALK_MAX_NAMELEN" must be declared as "public"
-+  // in older compilers in order to use it... starting with VC7 we can declare it as "protected"
-+protected:
-+#endif
-+  enum
-+  {
-+    STACKWALK_MAX_NAMELEN = 1024
-+  }; // max name length for found symbols
-+
-+protected:
-+  // Entry for each Callstack-Entry
-+  typedef struct CallstackEntry
-+  {
-+    DWORD64 offset; // if 0, we have no valid entry
 +    TCHAR    name[STACKWALK_MAX_NAMELEN];
 +    TCHAR    undName[STACKWALK_MAX_NAMELEN];
 +    TCHAR    undFullName[STACKWALK_MAX_NAMELEN];
-+    DWORD64 offsetFromSmybol;
-+    DWORD   offsetFromLine;
-+    DWORD   lineNumber;
+     DWORD64 offsetFromSmybol;
+     DWORD   offsetFromLine;
+     DWORD   lineNumber;
+-    CHAR    lineFileName[STACKWALK_MAX_NAMELEN];
 +    TCHAR    lineFileName[STACKWALK_MAX_NAMELEN];
-+    DWORD   symType;
-+    LPCSTR  symTypeString;
+     DWORD   symType;
+     LPCSTR  symTypeString;
+-    CHAR    moduleName[STACKWALK_MAX_NAMELEN];
 +    TCHAR    moduleName[STACKWALK_MAX_NAMELEN];
-+    DWORD64 baseOfImage;
+     DWORD64 baseOfImage;
+-    CHAR    loadedImageName[STACKWALK_MAX_NAMELEN];
 +    TCHAR    loadedImageName[STACKWALK_MAX_NAMELEN];
-+  } CallstackEntry;
-+
-+  typedef enum CallstackEntryType
-+  {
-+    firstEntry,
-+    nextEntry,
-+    lastEntry
-+  } CallstackEntryType;
-+
+   } CallstackEntry;
+ 
+   typedef enum CallstackEntryType
+@@ -158,24 +148,24 @@ protected:
+     lastEntry
+   } CallstackEntryType;
+ 
+-  virtual void OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName);
+-  virtual void OnLoadModule(LPCSTR    img,
+-                            LPCSTR    mod,
 +  virtual void OnSymInit(LPCTSTR szSearchPath, DWORD symOptions, LPCTSTR szUserName);
 +  virtual void OnLoadModule(LPCTSTR    img,
 +                            LPCTSTR    mod,
-+                            DWORD64   baseAddr,
-+                            DWORD     size,
-+                            DWORD     result,
+                             DWORD64   baseAddr,
+                             DWORD     size,
+                             DWORD     result,
+-                            LPCSTR    symType,
+-                            LPCSTR    pdbName,
 +                            LPCTSTR    symType,
 +                            LPCTSTR    pdbName,
-+                            ULONGLONG fileVersion);
-+  virtual void OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry);
+                             ULONGLONG fileVersion);
+   virtual void OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry);
+-  virtual void OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr);
+-  virtual void OnOutput(LPCSTR szText);
 +  virtual void OnDbgHelpErr(LPCTSTR szFuncName, DWORD gle, DWORD64 addr);
 +  virtual void OnOutput(LPCTSTR szText);
-+
-+  StackWalkerInternal* m_sw;
-+  HANDLE               m_hProcess;
-+  DWORD                m_dwProcessId;
-+  BOOL                 m_modulesLoaded;
+ 
+   StackWalkerInternal* m_sw;
+   HANDLE               m_hProcess;
+   DWORD                m_dwProcessId;
+   BOOL                 m_modulesLoaded;
+-  LPSTR                m_szSymPath;
 +  LPTSTR               m_szSymPath;
-+
-+  int m_options;
-+  int m_MaxRecursionCount;
-+
-+  static BOOL __stdcall myReadProcMem(HANDLE  hProcess,
-+                                      DWORD64 qwBaseAddress,
-+                                      PVOID   lpBuffer,
-+                                      DWORD   nSize,
-+                                      LPDWORD lpNumberOfBytesRead);
-+
-+  friend StackWalkerInternal;
-+}; // class StackWalker
-+
-+// The "ugly" assembler-implementation is needed for systems before XP
-+// If you have a new PSDK and you only compile for XP and later, then you can use
-+// the "RtlCaptureContext"
-+// Currently there is no define which determines the PSDK-Version...
-+// So we just use the compiler-version (and assumes that the PSDK is
-+// the one which was installed by the VS-IDE)
-+
-+// INFO: If you want, you can use the RtlCaptureContext if you only target XP and later...
-+//       But I currently use it in x64/IA64 environments...
-+//#if defined(_M_IX86) && (_WIN32_WINNT <= 0x0500) && (_MSC_VER < 1400)
-+
-+#if defined(_M_IX86)
-+#ifdef CURRENT_THREAD_VIA_EXCEPTION
-+// TODO: The following is not a "good" implementation,
-+// because the callstack is only valid in the "__except" block...
-+#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags)               \
-+  do                                                                            \
-+  {                                                                             \
-+    memset(&c, 0, sizeof(CONTEXT));                                             \
-+    EXCEPTION_POINTERS* pExp = NULL;                                            \
-+    __try                                                                       \
-+    {                                                                           \
-+      throw 0;                                                                  \
-+    }                                                                           \
-+    __except (((pExp = GetExceptionInformation()) ? EXCEPTION_EXECUTE_HANDLER   \
-+                                                  : EXCEPTION_EXECUTE_HANDLER)) \
-+    {                                                                           \
-+    }                                                                           \
-+    if (pExp != NULL)                                                           \
-+      memcpy(&c, pExp->ContextRecord, sizeof(CONTEXT));                         \
-+    c.ContextFlags = contextFlags;                                              \
-+  } while (0);
-+#else
-+// clang-format off
-+// The following should be enough for walking the callstack...
-+#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
-+  do                                                              \
-+  {                                                               \
-+    memset(&c, 0, sizeof(CONTEXT));                               \
-+    c.ContextFlags = contextFlags;                                \
-+    __asm    call x                                               \
-+    __asm x: pop eax                                              \
-+    __asm    mov c.Eip, eax                                       \
-+    __asm    mov c.Ebp, ebp                                       \
-+    __asm    mov c.Esp, esp                                       \
-+  } while (0)
-+// clang-format on
-+#endif
-+
-+#else
-+
-+// The following is defined for x86 (XP and higher), x64 and IA64:
-+#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
-+  do                                                              \
-+  {                                                               \
-+    memset(&c, 0, sizeof(CONTEXT));                               \
-+    c.ContextFlags = contextFlags;                                \
-+    RtlCaptureContext(&c);                                        \
-+  } while (0);
-+#endif
-+
-+#endif //defined(_MSC_VER)
-+
-+#endif // __STACKWALKER_H__
+ 
+   int m_options;
+   int m_MaxRecursionCount;
 diff --git a/Main/StackWalker/StackWalker_VC2017.sln b/Main/StackWalker/StackWalker_VC2017.sln
 index 790d550..2209e23 100644
 --- a/Main/StackWalker/StackWalker_VC2017.sln
@@ -3411,7 +1339,7 @@ index 790d550..2209e23 100644
  		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Release_VC2017-UNICODE|Win32.Build.0 = Release_VC2017-UNICODE|Win32
  		{89B2BD42-B130-4811-9043-71A8EBC40DE5}.Release_VC2017-UNICODE|x64.ActiveCfg = Release_VC2017-UNICODE|x64
 diff --git a/Main/StackWalker/main.cpp b/Main/StackWalker/main.cpp
-index 2db23c6..85769ed 100644
+index 220c97b..496021e 100644
 --- a/Main/StackWalker/main.cpp
 +++ b/Main/StackWalker/main.cpp
 @@ -33,7 +33,7 @@ void (*pGlobalFuncPtr)() = 0;

--- a/upstream_utils/stack_walker_patches/0002-Remove-_M_IX86-checks.patch
+++ b/upstream_utils/stack_walker_patches/0002-Remove-_M_IX86-checks.patch
@@ -1,4 +1,4 @@
-From cb08f60ab046ec3f63880a86a529fc641c4084f8 Mon Sep 17 00:00:00 2001
+From 238eda525de70b57bade634447c967f4f92bc96d Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Mon, 23 May 2022 00:06:45 -0400
 Subject: [PATCH 2/3] Remove _M_IX86 checks

--- a/upstream_utils/stack_walker_patches/0002-Remove-_M_IX86-checks.patch
+++ b/upstream_utils/stack_walker_patches/0002-Remove-_M_IX86-checks.patch
@@ -1,0 +1,82 @@
+From cb08f60ab046ec3f63880a86a529fc641c4084f8 Mon Sep 17 00:00:00 2001
+From: PJ Reiniger <pj.reiniger@gmail.com>
+Date: Mon, 23 May 2022 00:06:45 -0400
+Subject: [PATCH 2/3] Remove _M_IX86 checks
+
+---
+ Main/StackWalker/StackWalker.h | 52 ----------------------------------
+ 1 file changed, 52 deletions(-)
+
+diff --git a/Main/StackWalker/StackWalker.h b/Main/StackWalker/StackWalker.h
+index 03efcec..89be951 100644
+--- a/Main/StackWalker/StackWalker.h
++++ b/Main/StackWalker/StackWalker.h
+@@ -179,57 +179,6 @@ protected:
+   friend StackWalkerInternal;
+ }; // class StackWalker
+ 
+-// The "ugly" assembler-implementation is needed for systems before XP
+-// If you have a new PSDK and you only compile for XP and later, then you can use
+-// the "RtlCaptureContext"
+-// Currently there is no define which determines the PSDK-Version...
+-// So we just use the compiler-version (and assumes that the PSDK is
+-// the one which was installed by the VS-IDE)
+-
+-// INFO: If you want, you can use the RtlCaptureContext if you only target XP and later...
+-//       But I currently use it in x64/IA64 environments...
+-//#if defined(_M_IX86) && (_WIN32_WINNT <= 0x0500) && (_MSC_VER < 1400)
+-
+-#if defined(_M_IX86)
+-#ifdef CURRENT_THREAD_VIA_EXCEPTION
+-// TODO: The following is not a "good" implementation,
+-// because the callstack is only valid in the "__except" block...
+-#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags)               \
+-  do                                                                            \
+-  {                                                                             \
+-    memset(&c, 0, sizeof(CONTEXT));                                             \
+-    EXCEPTION_POINTERS* pExp = NULL;                                            \
+-    __try                                                                       \
+-    {                                                                           \
+-      throw 0;                                                                  \
+-    }                                                                           \
+-    __except (((pExp = GetExceptionInformation()) ? EXCEPTION_EXECUTE_HANDLER   \
+-                                                  : EXCEPTION_EXECUTE_HANDLER)) \
+-    {                                                                           \
+-    }                                                                           \
+-    if (pExp != NULL)                                                           \
+-      memcpy(&c, pExp->ContextRecord, sizeof(CONTEXT));                         \
+-    c.ContextFlags = contextFlags;                                              \
+-  } while (0);
+-#else
+-// clang-format off
+-// The following should be enough for walking the callstack...
+-#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
+-  do                                                              \
+-  {                                                               \
+-    memset(&c, 0, sizeof(CONTEXT));                               \
+-    c.ContextFlags = contextFlags;                                \
+-    __asm    call x                                               \
+-    __asm x: pop eax                                              \
+-    __asm    mov c.Eip, eax                                       \
+-    __asm    mov c.Ebp, ebp                                       \
+-    __asm    mov c.Esp, esp                                       \
+-  } while (0)
+-// clang-format on
+-#endif
+-
+-#else
+-
+ // The following is defined for x86 (XP and higher), x64 and IA64:
+ #define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
+   do                                                              \
+@@ -238,7 +187,6 @@ protected:
+     c.ContextFlags = contextFlags;                                \
+     RtlCaptureContext(&c);                                        \
+   } while (0);
+-#endif
+ 
+ #endif //defined(_MSC_VER)
+ 
+-- 
+2.20.1.windows.1
+

--- a/upstream_utils/stack_walker_patches/0003-Add-advapi-pragma.patch
+++ b/upstream_utils/stack_walker_patches/0003-Add-advapi-pragma.patch
@@ -1,4 +1,4 @@
-From 813edc726d4b50892baf05c291ac5bab4cb10d47 Mon Sep 17 00:00:00 2001
+From 61646f76602a77059c18298caa575b95b702c94c Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 24 May 2022 01:24:31 -0400
 Subject: [PATCH 3/3] Add advapi pragma

--- a/upstream_utils/stack_walker_patches/0003-Add-advapi-pragma.patch
+++ b/upstream_utils/stack_walker_patches/0003-Add-advapi-pragma.patch
@@ -1,0 +1,24 @@
+From 813edc726d4b50892baf05c291ac5bab4cb10d47 Mon Sep 17 00:00:00 2001
+From: PJ Reiniger <pj.reiniger@gmail.com>
+Date: Tue, 24 May 2022 01:24:31 -0400
+Subject: [PATCH 3/3] Add advapi pragma
+
+---
+ Main/StackWalker/StackWalker.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Main/StackWalker/StackWalker.cpp b/Main/StackWalker/StackWalker.cpp
+index 48c7c57..6f0fbf2 100644
+--- a/Main/StackWalker/StackWalker.cpp
++++ b/Main/StackWalker/StackWalker.cpp
+@@ -88,6 +88,7 @@
+ #include <stdlib.h>
+ #include <tchar.h>
+ #pragma comment(lib, "version.lib") // for "VerQueryValue"
++#pragma comment(lib, "Advapi32.lib") // for "GetUserName"
+ #pragma warning(disable : 4826)
+ 
+ #ifdef UNICODE
+-- 
+2.20.1.windows.1
+

--- a/upstream_utils/update_stack_walker.py
+++ b/upstream_utils/update_stack_walker.py
@@ -6,6 +6,7 @@ import subprocess
 
 from upstream_utils import setup_upstream_repo, comment_out_invalid_includes, walk_cwd_and_copy_if, am_patches, walk_if, copy_to
 
+
 def crlf_to_lf(stackwalker_dir):
     for root, _, files in os.walk(stackwalker_dir):
         if ".git" in root:
@@ -23,6 +24,7 @@ def crlf_to_lf(stackwalker_dir):
 
     subprocess.check_call(["git", "add", "-A"])
     subprocess.check_call(["git", "commit", "-m", "Fix line endings"])
+
 
 def main():
     root, repo = setup_upstream_repo(

--- a/upstream_utils/update_stack_walker.py
+++ b/upstream_utils/update_stack_walker.py
@@ -2,9 +2,27 @@
 
 import os
 import shutil
+import subprocess
 
 from upstream_utils import setup_upstream_repo, comment_out_invalid_includes, walk_cwd_and_copy_if, am_patches, walk_if, copy_to
 
+def crlf_to_lf(stackwalker_dir):
+    for root, _, files in os.walk(stackwalker_dir):
+        if ".git" in root:
+            continue
+
+        for fname in files:
+            filename = os.path.join(root, fname)
+            print(f"Converting CRLF -> LF for {filename}")
+            with open(filename, 'rb') as f:
+                content = f.read()
+                content = content.replace(b'\r\n', b'\n')
+
+                with open(filename, 'wb') as f:
+                    f.write(content)
+
+    subprocess.check_call(["git", "add", "-A"])
+    subprocess.check_call(["git", "commit", "-m", "Fix line endings"])
 
 def main():
     root, repo = setup_upstream_repo(
@@ -12,6 +30,9 @@ def main():
         "42e7a6e056a9e7aca911a7e9e54e2e4f90bc2652",
         shallow=False)
     wpiutil = os.path.join(root, "wpiutil")
+
+    # Run CRLF -> LF before trying any patches
+    crlf_to_lf(repo)
 
     # Apply patches to original git repo
     patch_dir = os.path.join(root, "upstream_utils/stack_walker_patches")

--- a/upstream_utils/update_stack_walker.py
+++ b/upstream_utils/update_stack_walker.py
@@ -2,11 +2,6 @@
 
 import os
 import shutil
-import re
-import requests
-import tempfile
-import urllib
-import subprocess
 
 from upstream_utils import setup_upstream_repo, comment_out_invalid_includes, walk_cwd_and_copy_if, am_patches, walk_if, copy_to
 

--- a/upstream_utils/update_stack_walker.py
+++ b/upstream_utils/update_stack_walker.py
@@ -14,19 +14,18 @@ from upstream_utils import setup_upstream_repo, comment_out_invalid_includes, wa
 def main():
     root, repo = setup_upstream_repo(
         "https://github.com/JochenKalmbach/StackWalker",
-        "42e7a6e056a9e7aca911a7e9e54e2e4f90bc2652")
+        "42e7a6e056a9e7aca911a7e9e54e2e4f90bc2652",
+        shallow=False)
     wpiutil = os.path.join(root, "wpiutil")
 
-    pr35_url = "http://patch-diff.githubusercontent.com/raw/JochenKalmbach/StackWalker/pull/35.patch"
-    pr35_patch_download_path = os.path.join(tempfile.gettempdir(),
-                                            "stackwalker.patch")
-
-    response = urllib.request.urlopen(pr35_url)
-
-    with open(pr35_patch_download_path, 'wb') as f:
-        f.write(response.read())
-
-    am_patches(repo, [pr35_patch_download_path])
+    # Apply patches to original git repo
+    patch_dir = os.path.join(root, "upstream_utils/stack_walker_patches")
+    am_patches(repo, [
+        os.path.join(patch_dir, "0001-Apply-PR-35.patch"),
+        os.path.join(patch_dir, "0002-Remove-_M_IX86-checks.patch"),
+        os.path.join(patch_dir, "0003-Add-advapi-pragma.patch"),
+    ],
+               ignore_whitespce=True)
 
     shutil.copy(os.path.join("Main", "StackWalker", "StackWalker.h"),
                 os.path.join(wpiutil, "src/main/native/windows/StackWalker.h"))

--- a/upstream_utils/upstream_utils.py
+++ b/upstream_utils/upstream_utils.py
@@ -62,7 +62,7 @@ def get_repo_root():
     return ""
 
 
-def setup_upstream_repo(url, treeish):
+def setup_upstream_repo(url, treeish, shallow=True):
     """Clones the given upstream repository, then returns the root of the
     destination Git repository as well as the cloned upstream Git repository.
 
@@ -78,7 +78,7 @@ def setup_upstream_repo(url, treeish):
     repo -- root directory of cloned upstream Git repository
     """
     root = get_repo_root()
-    clone_repo(url, treeish)
+    clone_repo(url, treeish, shallow=shallow)
     return root, os.getcwd()
 
 
@@ -208,7 +208,7 @@ def apply_patches(root, patches):
         subprocess.check_output(["git", "apply", patch])
 
 
-def am_patches(root, patches, use_threeway=False):
+def am_patches(root, patches, use_threeway=False, ignore_whitespce=False):
     """Apply list of patches to the destination Git repository using "git am".
 
     Keyword arguments:
@@ -219,6 +219,8 @@ def am_patches(root, patches, use_threeway=False):
     args = ["git", "am"]
     if use_threeway:
         args.append("-3")
+    if ignore_whitespce:
+        args.append("--ignore-whitespace")
 
     for patch in patches:
         subprocess.check_output(args + [patch])

--- a/wpiutil/src/main/native/windows/StackWalker.cpp
+++ b/wpiutil/src/main/native/windows/StackWalker.cpp
@@ -1,4 +1,4 @@
-/**********************************************************************
+﻿/**********************************************************************
  *
  * StackWalker.cpp
  * https://github.com/JochenKalmbach/StackWalker
@@ -485,8 +485,8 @@ private:
       if (hToolhelp == NULL)
         continue;
       createToolhelp32Snapshot = (tCT32S)GetProcAddress(hToolhelp, "CreateToolhelp32Snapshot");
-      module32First = (tM32F)GetProcAddress(hToolhelp, strModule32First);
-      module32Next = (tM32N)GetProcAddress(hToolhelp, strModule32Next);
+      module32First = (tM32F)GetProcAddress(hToolhelp, strModule32First);  
+      module32Next = (tM32N)GetProcAddress(hToolhelp, strModule32Next); 
       if ((createToolhelp32Snapshot != NULL) && (module32First != NULL) && (module32Next != NULL))
         break; // found the functions!
       FreeLibrary(hToolhelp);

--- a/wpiutil/src/main/native/windows/StackWalker.h
+++ b/wpiutil/src/main/native/windows/StackWalker.h
@@ -1,3 +1,8 @@
+#ifndef __STACKWALKER_H__
+#define __STACKWALKER_H__
+
+#if defined(_MSC_VER)
+
 /**********************************************************************
  *
  * StackWalker.h
@@ -32,6 +37,8 @@
  *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * **********************************************************************/
+// #pragma once is supported starting with _MSC_VER 1000,
+// so we need not to check the version (because we only support _MSC_VER >= 1100)!
 #pragma once
 
 #include <windows.h>
@@ -105,7 +112,11 @@ public:
 
   BOOL ShowObject(LPVOID pObject);
 
+#if _MSC_VER >= 1300
+  // due to some reasons, the "STACKWALK_MAX_NAMELEN" must be declared as "public"
+  // in older compilers in order to use it... starting with VC7 we can declare it as "protected"
 protected:
+#endif
   enum
   {
     STACKWALK_MAX_NAMELEN = 1024
@@ -176,3 +187,7 @@ protected:
     c.ContextFlags = contextFlags;                                \
     RtlCaptureContext(&c);                                        \
   } while (0);
+
+#endif //defined(_MSC_VER)
+
+#endif // __STACKWALKER_H__


### PR DESCRIPTION
TL;DR. Windows line endings suck

From what I can surmise, the failure was caused by a whitespace error because of line endings. I don't know if the "download patch" from github was pulling down `\r\n`, like the repo is and github changed it to be just `\n`. Or maybe my windows computer wasn't doing the autocrlf until I went to commit stuff which caused headaches. Embarrassingly, I also seemed to have dropped two patches when I was moving between branches, and they are now included.

The patches are now part of the repo rather than downloading from the repo, and LF is update is included in the patches.

Tested with my (soon to be obsolete) patch checker branch https://github.com/pjreiniger/allwpilib/tree/beyonce_patches
