### PR TITLE
[wpinet] Fix JNI loading error

### DIFF
--- a/hal/src/test/java/edu/wpi/first/hal/JNITest.java
+++ b/hal/src/test/java/edu/wpi/first/hal/JNITest.java
@@ -2,16 +2,14 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package edu.wpi.first.net;
+package edu.wpi.first.hal;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
-public class WPINetJNITest {
-
+public class JNITest {
     @Test
-    void jniLinkTest() throws IOException  {
-        WPINetJNI.forceLoad();
+    void jniLinkTest() {
+        // Test to verify that the JNI test link works correctly.
+        HAL.initialize(500, 0);
     }
 }

--- a/hal/src/test/java/edu/wpi/first/hal/JNITest.java
+++ b/hal/src/test/java/edu/wpi/first/hal/JNITest.java
@@ -7,9 +7,9 @@ package edu.wpi.first.hal;
 import org.junit.jupiter.api.Test;
 
 public class JNITest {
-    @Test
-    void jniLinkTest() {
-        // Test to verify that the JNI test link works correctly.
-        HAL.initialize(500, 0);
-    }
+  @Test
+  void jniLinkTest() {
+    // Test to verify that the JNI test link works correctly.
+    HAL.initialize(500, 0);
+  }
 }

--- a/wpinet/src/main/native/cpp/jni/WPINetJNI.cpp
+++ b/wpinet/src/main/native/cpp/jni/WPINetJNI.cpp
@@ -25,7 +25,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
     return JNI_ERR;
   }
 
-  serviceDataCls = JClass{env, "edu/wpi/first/util/ServiceData"};
+  serviceDataCls = JClass{env, "edu/wpi/first/net/ServiceData"};
   if (!serviceDataCls) {
     return JNI_ERR;
   }

--- a/wpinet/src/test/java/edu/wpi/first/net/WPINetJNITest.java
+++ b/wpinet/src/test/java/edu/wpi/first/net/WPINetJNITest.java
@@ -4,14 +4,12 @@
 
 package edu.wpi.first.net;
 
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 public class WPINetJNITest {
-
-    @Test
-    void jniLinkTest() throws IOException  {
-        WPINetJNI.forceLoad();
-    }
+  @Test
+  void jniLinkTest() throws IOException {
+    WPINetJNI.forceLoad();
+  }
 }


### PR DESCRIPTION
Package rename was not caught. Added unit test that would have exposed the problem, and also one for the HAL since it was the only JNI that didn't have a test loading it.