### PR TITLE
[upstream_utils] Make work with Python 3.8

### DIFF
--- a/upstream_utils/upstream_utils.py
+++ b/upstream_utils/upstream_utils.py
@@ -19,7 +19,9 @@ def clone_repo(url, treeish, shallow=True):
     os.chdir(tempfile.gettempdir())
 
     repo = os.path.basename(url)
-    dest = os.path.join(os.getcwd(), repo).removesuffix(".git")
+    dest = os.path.join(os.getcwd(), repo)
+    if dest.endswith(".git"):
+        dest = dest[:-4]
 
     # Clone Git repository into current directory or update it
     if not os.path.exists(dest):


### PR DESCRIPTION
str.removesuffix() is only available in Python 3.9, which is not in many
Linux installations.