### PR TITLE
[wpilib] Default off LiveWindow telemetry

### DIFF
--- a/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
+++ b/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
@@ -18,7 +18,7 @@ using namespace frc;
 namespace {
 struct Component {
   bool firstTime = true;
-  bool telemetryEnabled = true;
+  bool telemetryEnabled = false;
 };
 
 struct Instance {
@@ -39,7 +39,7 @@ struct Instance {
 
   bool startLiveWindow = false;
   bool liveWindowEnabled = false;
-  bool telemetryEnabled = true;
+  bool telemetryEnabled = false;
 
   std::function<void()> enabled;
   std::function<void()> disabled;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -17,7 +17,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableBuilderImpl;
 public final class LiveWindow {
   private static class Component {
     boolean m_firstTime = true;
-    boolean m_telemetryEnabled = false;
+    boolean m_telemetryEnabled;
   }
 
   private static final int dataHandle = SendableRegistry.getDataHandle();
@@ -27,7 +27,7 @@ public final class LiveWindow {
   private static final NetworkTableEntry enabledEntry = statusTable.getEntry("LW Enabled");
   private static boolean startLiveWindow;
   private static boolean liveWindowEnabled;
-  private static boolean telemetryEnabled = false;
+  private static boolean telemetryEnabled;
 
   private static Runnable enabledListener;
   private static Runnable disabledListener;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -17,7 +17,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableBuilderImpl;
 public final class LiveWindow {
   private static class Component {
     boolean m_firstTime = true;
-    boolean m_telemetryEnabled = true;
+    boolean m_telemetryEnabled = false;
   }
 
   private static final int dataHandle = SendableRegistry.getDataHandle();
@@ -27,7 +27,7 @@ public final class LiveWindow {
   private static final NetworkTableEntry enabledEntry = statusTable.getEntry("LW Enabled");
   private static boolean startLiveWindow;
   private static boolean liveWindowEnabled;
-  private static boolean telemetryEnabled = true;
+  private static boolean telemetryEnabled = false;
 
   private static Runnable enabledListener;
   private static Runnable disabledListener;


### PR DESCRIPTION
The original idea of LiveWindow telemetry was to automatically make
telemetry data visible to users.  This has proved increasingly
problematic in recent years due to the "spooky action at a distance"
of telemetry happening for objects that are only constructed but not
used, and blocking or slow object reads resulting in hard-to-debug
loop overrun conditions.