### PR TITLE
Throw exceptions for invalid sizes in I2C and SPI JNI

### DIFF
--- a/hal/src/main/native/cpp/jni/I2CJNI.cpp
+++ b/hal/src/main/native/cpp/jni/I2CJNI.cpp
@@ -64,6 +64,16 @@ Java_edu_wpi_first_hal_I2CJNI_i2CTransactionB
   (JNIEnv* env, jclass, jint port, jbyte address, jbyteArray dataToSend,
    jbyte sendSize, jbyteArray dataReceived, jbyte receiveSize)
 {
+  if (sendSize < 0) {
+    ThrowIllegalArgumentException(env, "I2CJNI.i2cTransactionB() sendSize < 0");
+    return 0;
+  }
+  if (receiveSize < 0) {
+    ThrowIllegalArgumentException(env,
+                                  "I2CJNI.i2cTransactionB() receiveSize < 0");
+    return 0;
+  }
+
   wpi::SmallVector<uint8_t, 128> recvBuf;
   recvBuf.resize(receiveSize);
   jint returnValue =
@@ -142,6 +152,11 @@ Java_edu_wpi_first_hal_I2CJNI_i2CReadB
   (JNIEnv* env, jclass, jint port, jbyte address, jbyteArray dataReceived,
    jbyte receiveSize)
 {
+  if (receiveSize < 0) {
+    ThrowIllegalArgumentException(env, "I2CJNI.i2cReadB() receiveSize < 0");
+    return 0;
+  }
+
   wpi::SmallVector<uint8_t, 128> recvBuf;
   recvBuf.resize(receiveSize);
   jint returnValue = HAL_ReadI2C(static_cast<HAL_I2CPort>(port), address,

--- a/hal/src/main/native/cpp/jni/SPIJNI.cpp
+++ b/hal/src/main/native/cpp/jni/SPIJNI.cpp
@@ -63,6 +63,11 @@ Java_edu_wpi_first_hal_SPIJNI_spiTransactionB
   (JNIEnv* env, jclass, jint port, jbyteArray dataToSend,
    jbyteArray dataReceived, jbyte size)
 {
+  if (size < 0) {
+    ThrowIllegalArgumentException(env, "SPIJNI.spiTransactionB() size < 0");
+    return 0;
+  }
+
   wpi::SmallVector<uint8_t, 128> recvBuf;
   recvBuf.resize(size);
   jint retVal =
@@ -120,6 +125,11 @@ Java_edu_wpi_first_hal_SPIJNI_spiRead
   (JNIEnv* env, jclass, jint port, jboolean initiate, jobject dataReceived,
    jbyte size)
 {
+  if (size < 0) {
+    ThrowIllegalArgumentException(env, "SPIJNI.spiRead() size < 0");
+    return 0;
+  }
+
   uint8_t* dataReceivedPtr =
       reinterpret_cast<uint8_t*>(env->GetDirectBufferAddress(dataReceived));
   jint retVal;
@@ -145,6 +155,11 @@ Java_edu_wpi_first_hal_SPIJNI_spiReadB
   (JNIEnv* env, jclass, jint port, jboolean initiate, jbyteArray dataReceived,
    jbyte size)
 {
+  if (size < 0) {
+    ThrowIllegalArgumentException(env, "SPIJNI.spiReadB() size < 0");
+    return 0;
+  }
+
   jint retVal;
   wpi::SmallVector<uint8_t, 128> recvBuf;
   recvBuf.resize(size);
@@ -361,6 +376,12 @@ Java_edu_wpi_first_hal_SPIJNI_spiReadAutoReceivedData__I_3IID
   (JNIEnv* env, jclass, jint port, jintArray buffer, jint numToRead,
    jdouble timeout)
 {
+  if (numToRead < 0) {
+    ThrowIllegalArgumentException(
+        env, "SPIJNI.spiReadAutoReceivedData() numToRead < 0");
+    return 0;
+  }
+
   wpi::SmallVector<uint32_t, 128> recvBuf;
   recvBuf.resize(numToRead);
   int32_t status = 0;


### PR DESCRIPTION
I was getting warnings from GCC 12 like the following in I2CJNI.cpp and
SPIJNI.cpp:
```
In file included from /home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/include/wpi/SmallString.h:16,
                 from /home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/include/wpi/jni_util.h:19,
                 from /home/tav/frc/wpilib/allwpilib/hal/src/main/native/cpp/jni/I2CJNI.cpp:9:
In member function ‘void wpi::SmallVectorImpl<T>::resizeImpl(size_type) [with bool ForOverwrite = false; T = unsigned char]’,
    inlined from ‘void wpi::SmallVectorImpl<T>::resizeImpl(size_type) [with bool ForOverwrite = false; T = unsigned char]’ at /home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/include/wpi/SmallVector.h:594:37,
    inlined from ‘void wpi::SmallVectorImpl<T>::resize(size_type) [with T = unsigned char]’ at /home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/include/wpi/SmallVector.h:609:47,
    inlined from ‘jint Java_edu_wpi_first_hal_I2CJNI_i2CReadB(JNIEnv*, jclass, jint, jbyte, jbyteArray, jbyte)’ at /home/tav/frc/wpilib/allwpilib/hal/src/main/native/cpp/jni/I2CJNI.cpp:146:17:
/home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/include/wpi/SmallVector.h:603:11: error: ‘void* __builtin_memset(void*, int, long unsigned int)’ specified size between 18446744069414584193 and 18446744073709551615 exceeds maximum object size 9223372036854775807 [-Werror=stringop-overflow=]
  603 |           new (&*I) T();
      |           ^~~~~~~~~~~~~
In member function ‘T* wpi::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::begin() [with T = unsigned char; <template-parameter-1-2> = void]’,
    inlined from ‘T* wpi::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::end() [with T = unsigned char; <template-parameter-1-2> = void]’ at /home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/include/wpi/SmallVector.h:258:32,
    inlined from ‘void wpi::SmallVectorImpl<T>::resizeImpl(size_type) [with bool ForOverwrite = false; T = unsigned char]’ at /home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/include/wpi/SmallVector.h:599:30,
    inlined from ‘void wpi::SmallVectorImpl<T>::resizeImpl(size_type) [with bool ForOverwrite = false; T = unsigned char]’ at /home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/include/wpi/SmallVector.h:594:37,
    inlined from ‘void wpi::SmallVectorImpl<T>::resize(size_type) [with T = unsigned char]’ at /home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/include/wpi/SmallVector.h:609:47,
    inlined from ‘jint Java_edu_wpi_first_hal_I2CJNI_i2CReadB(JNIEnv*, jclass, jint, jbyte, jbyteArray, jbyte)’ at /home/tav/frc/wpilib/allwpilib/hal/src/main/native/cpp/jni/I2CJNI.cpp:146:17:
/home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/include/wpi/SmallVector.h:256:45: note: destination object allocated here
  256 |   iterator begin() { return (iterator)this->BeginX; }
      |                                       ~~~~~~^~~~~~
```

Putting the sizes into a more familiar format, it reads:
```
specified size between 2^64-2^32-2^7+1 and 2^64-1` exceeds maximum object size 2**63-1
```
I2CJNI.cpp:146 is the resize() call below:
```
JNIEXPORT jint JNICALL
Java_edu_wpi_first_hal_I2CJNI_i2CReadB
  (JNIEnv* env, jclass, jint port, jbyte address, jbyteArray dataReceived,
   jbyte receiveSize)
{
  wpi::SmallVector<uint8_t, 128> recvBuf;
  recvBuf.resize(receiveSize);
  jint returnValue = HAL_ReadI2C(static_cast<HAL_I2CPort>(port), address,
                                 recvBuf.data(), receiveSize);
  env->SetByteArrayRegion(dataReceived, 0, receiveSize,
                          reinterpret_cast<const jbyte*>(recvBuf.data()));
  return returnValue;
}
```

GCC's static analyzer is correctly reporting that resize() requires an
unsigned integer, but the argument provided in the JNI function could be
negative since it's a signed byte. Throwing an exception if the argument
is negative fixes the warning.