### PR TITLE
[halsim_gui] Link to wpinet

### DIFF
--- a/simulation/halsim_gui/build.gradle
+++ b/simulation/halsim_gui/build.gradle
@@ -26,6 +26,7 @@ if (!project.hasProperty('onlylinuxathena') && !project.hasProperty('onlylinuxra
                 lib project: ':wpigui', library: 'wpigui', linkage: 'static'
                 lib project: ':wpimath', library: 'wpimath', linkage: 'shared'
                 lib project: ':ntcore', library: 'ntcore', linkage: 'shared'
+                lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
                 nativeUtils.useRequiredLibrary(it, 'imgui_static')
                 if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio || it.targetPlatform.name == nativeUtils.wpi.platforms.raspbian || it.targetPlatform.name == nativeUtils.wpi.platforms.aarch64bionic) {


### PR DESCRIPTION
This fixes the following linker error:
```
> Task :simulation:halsim_gui:linkHalsim_guiDevLinuxx86-64Executable FAILED
/usr/bin/ld: warning: libwpinetd.so, needed by /home/tav/frc/wpilib/allwpilib/ntcore/build/libs/ntcore/shared/linuxx86-64/debug/libntcored.so, not found (try using -rpath or -rpath-link)
/usr/bin/ld: /home/tav/frc/wpilib/allwpilib/ntcore/build/libs/ntcore/shared/linuxx86-64/debug/libntcored.so: undefined reference to `wpi::TCPAcceptor::TCPAcceptor(int, std::basic_string_view<char, std::char_traits<char> >, wpi::Logger&)'
/usr/bin/ld: /home/tav/frc/wpilib/allwpilib/ntcore/build/libs/ntcore/shared/linuxx86-64/debug/libntcored.so: undefined reference to `wpi::TCPConnector::connect_parallel(wpi::span<std::pair<char const*, int> const, 18446744073709551615ul>, wpi::Logger&, int)'
/usr/bin/ld: /home/tav/frc/wpilib/allwpilib/ntcore/build/libs/ntcore/shared/linuxx86-64/debug/libntcored.so: undefined reference to `wpi::TCPConnector::connect(char const*, int, wpi::Logger&, int)'
/usr/bin/ld: /home/tav/frc/wpilib/allwpilib/ntcore/build/libs/ntcore/shared/linuxx86-64/debug/libntcored.so: undefined reference to `vtable for wpi::raw_socket_istream'
collect2: error: ld returned 1 exit status
```