### PR TITLE
Changed "final" to "exit" in the IterativeRobotBase JavaDoc

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -42,7 +42,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
  *   <li>testPeriodic()
  * </ul>
  *
- * <p>final() functions -- each of the following functions is called once when the appropriate mode
+ * <p>exit() functions -- each of the following functions is called once when the appropriate mode
  * is exited:
  *
  * <ul>


### PR DESCRIPTION
Changed "final" to "exit" in the WPILibJ IterativeRobotBase JavaDoc as "exit" is used in every other instance.