### PR TITLE
Use one worker for Windows release Gradle build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -59,7 +59,7 @@ jobs:
           - os: windows-2019
             artifact-name: Win64Release
             architecture: x64
-            build-options: "-PciReleaseOnly"
+            build-options: "-PciReleaseOnly --max-workers 1"
             task: "copyAllOutputs"
           - os: macOS-11
             artifact-name: macOS


### PR DESCRIPTION
It was running out of heap space.