### PR TITLE
[cpp commands] Migrate to unique_ptr

### DIFF
--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -100,8 +100,7 @@ CommandPtr Command::Repeatedly() && {
 }
 
 CommandPtr Command::AsProxy() && {
-  return CommandPtr(std::move(*this).TransferOwnership())
-      .AsProxy();
+  return CommandPtr(std::move(*this).TransferOwnership()).AsProxy();
 }
 
 CommandPtr Command::Unless(std::function<bool()> condition) && {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -35,96 +35,54 @@ void Command::Initialize() {}
 void Command::Execute() {}
 void Command::End(bool interrupted) {}
 
-ParallelRaceGroup Command::WithTimeout(units::second_t duration) && {
-  std::vector<std::unique_ptr<Command>> temp;
-  temp.emplace_back(std::make_unique<WaitCommand>(duration));
-  temp.emplace_back(std::move(*this).TransferOwnership());
-  return ParallelRaceGroup(std::move(temp));
+CommandPtr Command::WithTimeout(units::second_t duration) && {
+  return CommandPtr(std::move(*this).TransferOwnership()).WithTimeout(duration);
 }
 
-ParallelRaceGroup Command::Until(std::function<bool()> condition) && {
-  std::vector<std::unique_ptr<Command>> temp;
-  temp.emplace_back(std::make_unique<WaitUntilCommand>(std::move(condition)));
-  temp.emplace_back(std::move(*this).TransferOwnership());
-  return ParallelRaceGroup(std::move(temp));
+CommandPtr Command::Until(std::function<bool()> condition) && {
+  return CommandPtr(std::move(*this).TransferOwnership())
+      .Until(std::move(condition));
 }
 
-std::unique_ptr<Command> Command::IgnoringDisable(bool doesRunWhenDisabled) && {
-  class RunsWhenDisabledCommand
-      : public CommandHelper<WrapperCommand, RunsWhenDisabledCommand> {
-   public:
-    RunsWhenDisabledCommand(std::unique_ptr<Command>&& command,
-                            bool doesRunWhenDisabled)
-        : CommandHelper(std::move(command)),
-          m_runsWhenDisabled(doesRunWhenDisabled) {}
-    bool RunsWhenDisabled() const override { return m_runsWhenDisabled; }
-
-   private:
-    bool m_runsWhenDisabled;
-  };
-
-  return std::make_unique<RunsWhenDisabledCommand>(
-      std::move(*this).TransferOwnership(), doesRunWhenDisabled);
+CommandPtr Command::IgnoringDisable(bool doesRunWhenDisabled) && {
+  return CommandPtr(std::move(*this).TransferOwnership())
+      .IgnoringDisable(doesRunWhenDisabled);
 }
 
-std::unique_ptr<Command> Command::WithInterruptBehavior(
+CommandPtr Command::WithInterruptBehavior(
     InterruptionBehavior interruptBehavior) && {
-  class InterruptBehaviorCommand
-      : public CommandHelper<WrapperCommand, InterruptBehaviorCommand> {
-   public:
-    InterruptBehaviorCommand(std::unique_ptr<Command>&& command,
-                             InterruptionBehavior interruptBehavior)
-        : CommandHelper(std::move(command)),
-          m_interruptBehavior(interruptBehavior) {}
-    InterruptionBehavior GetInterruptionBehavior() const override {
-      return m_interruptBehavior;
-    }
-
-   private:
-    InterruptionBehavior m_interruptBehavior;
-  };
-
-  return std::make_unique<InterruptBehaviorCommand>(
-      std::move(*this).TransferOwnership(), interruptBehavior);
+  return CommandPtr(std::move(*this).TransferOwnership())
+      .WithInterruptBehavior(interruptBehavior);
 }
 
-ParallelRaceGroup Command::WithInterrupt(std::function<bool()> condition) && {
-  std::vector<std::unique_ptr<Command>> temp;
-  temp.emplace_back(std::make_unique<WaitUntilCommand>(std::move(condition)));
-  temp.emplace_back(std::move(*this).TransferOwnership());
-  return ParallelRaceGroup(std::move(temp));
+CommandPtr Command::WithInterrupt(std::function<bool()> condition) && {
+  return CommandPtr(std::move(*this).TransferOwnership())
+      .Until(std::move(condition));
 }
 
-SequentialCommandGroup Command::BeforeStarting(
+CommandPtr Command::BeforeStarting(
     std::function<void()> toRun,
     std::initializer_list<Subsystem*> requirements) && {
   return std::move(*this).BeforeStarting(
       std::move(toRun), {requirements.begin(), requirements.end()});
 }
 
-SequentialCommandGroup Command::BeforeStarting(
+CommandPtr Command::BeforeStarting(
     std::function<void()> toRun, wpi::span<Subsystem* const> requirements) && {
-  std::vector<std::unique_ptr<Command>> temp;
-  temp.emplace_back(
-      std::make_unique<InstantCommand>(std::move(toRun), requirements));
-  temp.emplace_back(std::move(*this).TransferOwnership());
-  return SequentialCommandGroup(std::move(temp));
+  return CommandPtr(std::move(*this).TransferOwnership())
+      .BeforeStarting(std::move(toRun), requirements);
 }
 
-SequentialCommandGroup Command::AndThen(
-    std::function<void()> toRun,
-    std::initializer_list<Subsystem*> requirements) && {
+CommandPtr Command::AndThen(std::function<void()> toRun,
+                            std::initializer_list<Subsystem*> requirements) && {
   return std::move(*this).AndThen(std::move(toRun),
                                   {requirements.begin(), requirements.end()});
 }
 
-SequentialCommandGroup Command::AndThen(
-    std::function<void()> toRun, wpi::span<Subsystem* const> requirements) && {
-  std::vector<std::unique_ptr<Command>> temp;
-  temp.emplace_back(std::move(*this).TransferOwnership());
-  temp.emplace_back(
-      std::make_unique<InstantCommand>(std::move(toRun), requirements));
-  return SequentialCommandGroup(std::move(temp));
+CommandPtr Command::AndThen(std::function<void()> toRun,
+                            wpi::span<Subsystem* const> requirements) && {
+  return CommandPtr(std::move(*this).TransferOwnership())
+      .AndThen(std::move(toRun), requirements);
 }
 
 PerpetualCommand Command::Perpetually() && {
@@ -133,22 +91,22 @@ PerpetualCommand Command::Perpetually() && {
   WPI_UNIGNORE_DEPRECATED
 }
 
-EndlessCommand Command::Endlessly() && {
-  return EndlessCommand(std::move(*this).TransferOwnership());
+CommandPtr Command::Endlessly() && {
+  return CommandPtr(std::move(*this).TransferOwnership()).Endlessly();
 }
 
-RepeatCommand Command::Repeatedly() && {
-  return RepeatCommand(std::move(*this).TransferOwnership());
+CommandPtr Command::Repeatedly() && {
+  return CommandPtr(std::move(*this).TransferOwnership()).Repeatedly();
 }
 
-ProxyScheduleCommand Command::AsProxy() {
-  return ProxyScheduleCommand(this);
+CommandPtr Command::AsProxy() && {
+  return CommandPtr(std::move(*this).TransferOwnership())
+      .AsProxy();
 }
 
-ConditionalCommand Command::Unless(std::function<bool()> condition) && {
-  return ConditionalCommand(std::make_unique<InstantCommand>(),
-                            std::move(*this).TransferOwnership(),
-                            std::move(condition));
+CommandPtr Command::Unless(std::function<bool()> condition) && {
+  return CommandPtr(std::move(*this).TransferOwnership())
+      .Unless(std::move(condition));
 }
 
 void Command::Schedule() {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
@@ -135,7 +135,7 @@ CommandPtr CommandPtr::Unless(std::function<bool()> condition) && {
   return std::move(*this);
 }
 
-Command* CommandPtr::operator*() const {
+Command* CommandPtr::get() const {
   return m_ptr.get();
 }
 

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
@@ -1,0 +1,154 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc2/command/CommandPtr.h"
+
+#include "frc2/command/CommandScheduler.h"
+#include "frc2/command/ConditionalCommand.h"
+#include "frc2/command/EndlessCommand.h"
+#include "frc2/command/InstantCommand.h"
+#include "frc2/command/ParallelCommandGroup.h"
+#include "frc2/command/ParallelDeadlineGroup.h"
+#include "frc2/command/ParallelRaceGroup.h"
+#include "frc2/command/PerpetualCommand.h"
+#include "frc2/command/ProxyScheduleCommand.h"
+#include "frc2/command/RepeatCommand.h"
+#include "frc2/command/SequentialCommandGroup.h"
+#include "frc2/command/WaitCommand.h"
+#include "frc2/command/WaitUntilCommand.h"
+#include "frc2/command/WrapperCommand.h"
+
+using namespace frc2;
+
+CommandPtr CommandPtr::Repeatedly() && {
+  m_ptr = std::make_unique<RepeatCommand>(std::move(m_ptr));
+  return std::move(*this);
+}
+
+CommandPtr CommandPtr::Endlessly() && {
+  m_ptr = std::make_unique<EndlessCommand>(std::move(m_ptr));
+  return std::move(*this);
+}
+
+CommandPtr CommandPtr::AsProxy() && {
+  m_ptr = std::make_unique<ProxyScheduleCommand>(std::move(m_ptr));
+  return std::move(*this);
+}
+
+class RunsWhenDisabledCommand : public WrapperCommand {
+ public:
+  RunsWhenDisabledCommand(std::unique_ptr<Command>&& command,
+                          bool doesRunWhenDisabled)
+      : WrapperCommand(std::move(command)),
+        m_runsWhenDisabled(doesRunWhenDisabled) {}
+
+  bool RunsWhenDisabled() const override { return m_runsWhenDisabled; }
+
+ private:
+  bool m_runsWhenDisabled;
+};
+
+CommandPtr CommandPtr::IgnoringDisable(bool doesRunWhenDisabled) && {
+  m_ptr = std::make_unique<RunsWhenDisabledCommand>(std::move(m_ptr),
+                                                    doesRunWhenDisabled);
+  return std::move(*this);
+}
+
+using InterruptionBehavior = Command::InterruptionBehavior;
+class InterruptBehaviorCommand : public WrapperCommand {
+ public:
+  InterruptBehaviorCommand(std::unique_ptr<Command>&& command,
+                           InterruptionBehavior interruptBehavior)
+      : WrapperCommand(std::move(command)),
+        m_interruptBehavior(interruptBehavior) {}
+
+  InterruptionBehavior GetInterruptionBehavior() const override {
+    return m_interruptBehavior;
+  }
+
+ private:
+  InterruptionBehavior m_interruptBehavior;
+};
+
+CommandPtr CommandPtr::WithInterruptBehavior(
+    InterruptionBehavior interruptBehavior) && {
+  m_ptr = std::make_unique<InterruptBehaviorCommand>(std::move(m_ptr),
+                                                     interruptBehavior);
+  return std::move(*this);
+}
+
+CommandPtr CommandPtr::AndThen(std::function<void()> toRun,
+                               wpi::span<Subsystem* const> requirements) && {
+  std::vector<std::unique_ptr<Command>> temp;
+  temp.emplace_back(std::move(m_ptr));
+  temp.emplace_back(
+      std::make_unique<InstantCommand>(std::move(toRun), requirements));
+  m_ptr = std::make_unique<SequentialCommandGroup>(std::move(temp));
+  return std::move(*this);
+}
+
+CommandPtr CommandPtr::AndThen(std::function<void()> toRun,
+                               std::initializer_list<Subsystem*> requirements) && {
+  return std::move(*this).AndThen(std::move(toRun), {requirements.begin(), requirements.end()});
+}
+
+CommandPtr CommandPtr::BeforeStarting(
+    std::function<void()> toRun, wpi::span<Subsystem* const> requirements) && {
+  std::vector<std::unique_ptr<Command>> temp;
+  temp.emplace_back(
+      std::make_unique<InstantCommand>(std::move(toRun), requirements));
+  temp.emplace_back(std::move(m_ptr));
+  m_ptr = std::make_unique<SequentialCommandGroup>(std::move(temp));
+  return std::move(*this);
+}
+
+CommandPtr CommandPtr::BeforeStarting(
+    std::function<void()> toRun,
+    std::initializer_list<Subsystem*> requirements) && {
+  return std::move(*this).BeforeStarting(std::move(toRun),
+                        {requirements.begin(), requirements.end()});
+}
+
+CommandPtr CommandPtr::WithTimeout(units::second_t duration) && {
+  std::vector<std::unique_ptr<Command>> temp;
+  temp.emplace_back(std::make_unique<WaitCommand>(duration));
+  temp.emplace_back(std::move(m_ptr));
+  m_ptr = std::make_unique<ParallelRaceGroup>(std::move(temp));
+  return std::move(*this);
+}
+
+CommandPtr CommandPtr::Until(std::function<bool()> condition) && {
+  std::vector<std::unique_ptr<Command>> temp;
+  temp.emplace_back(std::make_unique<WaitUntilCommand>(std::move(condition)));
+  temp.emplace_back(std::move(m_ptr));
+  m_ptr = std::make_unique<ParallelRaceGroup>(std::move(temp));
+  return std::move(*this);
+}
+
+CommandPtr CommandPtr::Unless(std::function<bool()> condition) && {
+  m_ptr = std::make_unique<ConditionalCommand>(
+      std::make_unique<InstantCommand>(), std::move(m_ptr),
+      std::move(condition));
+  return std::move(*this);
+}
+
+Command* CommandPtr::operator*() const {
+  return m_ptr.get();
+}
+
+void CommandPtr::Schedule() const {
+  CommandScheduler::GetInstance().Schedule(*this);
+}
+
+void CommandPtr::Cancel() const {
+  CommandScheduler::GetInstance().Cancel(*this);
+}
+
+bool CommandPtr::IsScheduled() const {
+  return CommandScheduler::GetInstance().IsScheduled(*this);
+}
+
+bool CommandPtr::HasRequirement(Subsystem* requirement) const {
+  return m_ptr->HasRequirement(requirement);
+}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
@@ -88,9 +88,11 @@ CommandPtr CommandPtr::AndThen(std::function<void()> toRun,
   return std::move(*this);
 }
 
-CommandPtr CommandPtr::AndThen(std::function<void()> toRun,
-                               std::initializer_list<Subsystem*> requirements) && {
-  return std::move(*this).AndThen(std::move(toRun), {requirements.begin(), requirements.end()});
+CommandPtr CommandPtr::AndThen(
+    std::function<void()> toRun,
+    std::initializer_list<Subsystem*> requirements) && {
+  return std::move(*this).AndThen(std::move(toRun),
+                                  {requirements.begin(), requirements.end()});
 }
 
 CommandPtr CommandPtr::BeforeStarting(
@@ -106,8 +108,8 @@ CommandPtr CommandPtr::BeforeStarting(
 CommandPtr CommandPtr::BeforeStarting(
     std::function<void()> toRun,
     std::initializer_list<Subsystem*> requirements) && {
-  return std::move(*this).BeforeStarting(std::move(toRun),
-                        {requirements.begin(), requirements.end()});
+  return std::move(*this).BeforeStarting(
+      std::move(toRun), {requirements.begin(), requirements.end()});
 }
 
 CommandPtr CommandPtr::WithTimeout(units::second_t duration) && {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -175,7 +175,7 @@ void CommandScheduler::Schedule(std::initializer_list<Command*> commands) {
 }
 
 void CommandScheduler::Schedule(const CommandPtr& command) {
-  Schedule(*command);
+  Schedule(command.get());
 }
 
 void CommandScheduler::Run() {
@@ -332,7 +332,7 @@ void CommandScheduler::Cancel(Command* command) {
 }
 
 void CommandScheduler::Cancel(const CommandPtr& command) {
-  Cancel(*command);
+  Cancel(command.get());
 }
 
 void CommandScheduler::Cancel(wpi::span<Command* const> commands) {
@@ -380,7 +380,7 @@ bool CommandScheduler::IsScheduled(const Command* command) const {
 }
 
 bool CommandScheduler::IsScheduled(const CommandPtr& command) const {
-  return m_impl->scheduledCommands.contains(*command);
+  return m_impl->scheduledCommands.contains(command.get());
 }
 
 Command* CommandScheduler::Requiring(const Subsystem* subsystem) const {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -19,6 +19,7 @@
 #include <wpi/sendable/SendableRegistry.h>
 
 #include "frc2/command/CommandGroupBase.h"
+#include "frc2/command/CommandPtr.h"
 #include "frc2/command/Subsystem.h"
 
 using namespace frc2;
@@ -171,6 +172,10 @@ void CommandScheduler::Schedule(std::initializer_list<Command*> commands) {
   for (auto command : commands) {
     Schedule(command);
   }
+}
+
+void CommandScheduler::Schedule(const CommandPtr& command) {
+  Schedule(*command);
 }
 
 void CommandScheduler::Run() {
@@ -326,6 +331,10 @@ void CommandScheduler::Cancel(Command* command) {
   m_watchdog.AddEpoch(command->GetName() + ".End(true)");
 }
 
+void CommandScheduler::Cancel(const CommandPtr& command) {
+  Cancel(*command);
+}
+
 void CommandScheduler::Cancel(wpi::span<Command* const> commands) {
   for (auto command : commands) {
     Cancel(command);
@@ -368,6 +377,10 @@ bool CommandScheduler::IsScheduled(
 
 bool CommandScheduler::IsScheduled(const Command* command) const {
   return m_impl->scheduledCommands.contains(command);
+}
+
+bool CommandScheduler::IsScheduled(const CommandPtr& command) const {
+  return m_impl->scheduledCommands.contains(*command);
 }
 
 Command* CommandScheduler::Requiring(const Subsystem* subsystem) const {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Button.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Button.cpp
@@ -13,6 +13,11 @@ Button Button::WhenPressed(Command* command) {
   return *this;
 }
 
+Button Button::WhenPressed(CommandPtr&& command) {
+  WhenActive(std::move(command));
+  return *this;
+}
+
 Button Button::WhenPressed(std::function<void()> toRun,
                            std::initializer_list<Subsystem*> requirements) {
   WhenActive(std::move(toRun), requirements);
@@ -27,6 +32,11 @@ Button Button::WhenPressed(std::function<void()> toRun,
 
 Button Button::WhileHeld(Command* command) {
   WhileActiveContinous(command);
+  return *this;
+}
+
+Button Button::WhileHeld(CommandPtr&& command) {
+  WhileActiveContinous(std::move(command));
   return *this;
 }
 
@@ -47,8 +57,18 @@ Button Button::WhenHeld(Command* command) {
   return *this;
 }
 
+Button Button::WhenHeld(CommandPtr&& command) {
+  WhileActiveOnce(std::move(command));
+  return *this;
+}
+
 Button Button::WhenReleased(Command* command) {
   WhenInactive(command);
+  return *this;
+}
+
+Button Button::WhenReleased(CommandPtr&& command) {
+  WhenInactive(std::move(command));
   return *this;
 }
 
@@ -66,6 +86,11 @@ Button Button::WhenReleased(std::function<void()> toRun,
 
 Button Button::ToggleWhenPressed(Command* command) {
   ToggleWhenActive(command);
+  return *this;
+}
+
+Button Button::ToggleWhenPressed(CommandPtr&& command) {
+  ToggleWhenActive(std::move(command));
   return *this;
 }
 

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/Trigger.cpp
@@ -18,6 +18,11 @@ Trigger Trigger::WhenActive(Command* command) {
   return *this;
 }
 
+Trigger Trigger::WhenActive(CommandPtr&& command) {
+  this->Rising().IfHigh([command = std::move(command)] { command.Schedule(); });
+  return *this;
+}
+
 Trigger Trigger::WhenActive(std::function<void()> toRun,
                             std::initializer_list<Subsystem*> requirements) {
   return WhenActive(std::move(toRun),
@@ -32,6 +37,13 @@ Trigger Trigger::WhenActive(std::function<void()> toRun,
 Trigger Trigger::WhileActiveContinous(Command* command) {
   this->IfHigh([command] { command->Schedule(); });
   this->Falling().IfHigh([command] { command->Cancel(); });
+  return *this;
+}
+
+Trigger Trigger::WhileActiveContinous(CommandPtr&& command) {
+  auto ptr = std::make_shared<CommandPtr>(std::move(command));
+  this->IfHigh([ptr] { ptr->Schedule(); });
+  this->Falling().IfHigh([ptr] { ptr->Cancel(); });
   return *this;
 }
 
@@ -53,8 +65,21 @@ Trigger Trigger::WhileActiveOnce(Command* command) {
   return *this;
 }
 
+Trigger Trigger::WhileActiveOnce(CommandPtr&& command) {
+  auto ptr = std::make_shared<CommandPtr>(std::move(command));
+  this->Rising().IfHigh([ptr] { ptr->Schedule(); });
+  this->Falling().IfHigh([ptr] { ptr->Cancel(); });
+  return *this;
+}
+
 Trigger Trigger::WhenInactive(Command* command) {
   this->Falling().IfHigh([command] { command->Schedule(); });
+  return *this;
+}
+
+Trigger Trigger::WhenInactive(CommandPtr&& command) {
+  this->Falling().IfHigh(
+      [command = std::move(command)] { command.Schedule(); });
   return *this;
 }
 
@@ -75,6 +100,17 @@ Trigger Trigger::ToggleWhenActive(Command* command) {
       command->Cancel();
     } else {
       command->Schedule();
+    }
+  });
+  return *this;
+}
+
+Trigger Trigger::ToggleWhenActive(CommandPtr&& command) {
+  this->Rising().IfHigh([command = std::move(command)] {
+    if (command.IsScheduled()) {
+      command.Cancel();
+    } else {
+      command.Schedule();
     }
   });
   return *this;

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -226,7 +226,7 @@ class Command {
    * ProxyScheduleCommand. This is useful for "forking off" from command groups
    * when the user does not wish to extend the command's requirements to the
    * entire command group.
-   * 
+   *
    * <p>This overload transfers command ownership to the returned CommandPtr.
    *
    * @return the decorated command

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandHelper.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandHelper.h
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "frc2/command/Command.h"
+#include "frc2/command/CommandPtr.h"
 
 namespace frc2 {
 
@@ -27,6 +28,11 @@ class CommandHelper : public Base {
 
  public:
   CommandHelper() = default;
+
+  CommandPtr ToPtr() && {
+    return CommandPtr(
+        std::make_unique<CRTP>(std::move(*static_cast<CRTP*>(this))));
+  }
 
  protected:
   std::unique_ptr<Command> TransferOwnership() && override {

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
@@ -1,0 +1,189 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "frc2/command/Command.h"
+
+namespace frc2 {
+class CommandPtr final {
+ public:
+  explicit CommandPtr(std::unique_ptr<Command>&& command)
+      : m_ptr(std::move(command)) {}
+
+  template <class T, typename = std::enable_if_t<std::is_base_of_v<
+                         Command, std::remove_reference_t<T>>>>
+  explicit CommandPtr(T&& command)
+      : CommandPtr(std::make_unique<std::remove_reference_t<T>>(
+            std::forward<T>(command))) {}
+
+  CommandPtr(CommandPtr&&) = default;
+  CommandPtr& operator=(CommandPtr&&) = default;
+
+  /**
+   * Decorates this command to run repeatedly, restarting it when it ends, until
+   * this command is interrupted. The decorated command can still be canceled.
+   *
+   * @return the decorated command
+   */
+  [[nodiscard]] CommandPtr Repeatedly() &&;
+
+  /**
+   * Decorates this command to run endlessly, ignoring its ordinary end
+   * conditions. The decorated command can still be interrupted or canceled.
+   *
+   * @return the decorated command
+   */
+  [[nodiscard]] CommandPtr Endlessly() &&;
+
+  /**
+   * Decorates this command to run "by proxy" by wrapping it in a
+   * ProxyScheduleCommand. This is useful for "forking off" from command groups
+   * when the user does not wish to extend the command's requirements to the
+   * entire command group. 
+   *
+   * @return the decorated command
+   */
+  [[nodiscard]] CommandPtr AsProxy() &&;
+
+  /**
+   * Decorates this command to run or stop when disabled.
+   *
+   * @param doesRunWhenDisabled true to run when disabled.
+   * @return the decorated command
+   */
+  [[nodiscard]] CommandPtr IgnoringDisable(bool doesRunWhenDisabled) &&;
+
+  /**
+   * Decorates this command to run or stop when disabled.
+   *
+   * @param interruptBehavior true to run when disabled.
+   * @return the decorated command
+   */
+  [[nodiscard]] CommandPtr WithInterruptBehavior(
+      Command::InterruptionBehavior interruptBehavior) &&;
+
+  /**
+   * Decorates this command with a runnable to run after the command finishes.
+   *
+   * @param toRun the Runnable to run
+   * @param requirements the required subsystems
+   * @return the decorated command
+   */
+  [[nodiscard]] CommandPtr AndThen(
+      std::function<void()> toRun,
+      wpi::span<Subsystem* const> requirements = {}) &&;
+
+  /**
+   * Decorates this command with a runnable to run after the command finishes.
+   *
+   * @param toRun the Runnable to run
+   * @param requirements the required subsystems
+   * @return the decorated command
+   */
+  [[nodiscard]] CommandPtr AndThen(
+      std::function<void()> toRun,
+      std::initializer_list<Subsystem*> requirements) &&;
+
+  /**
+   * Decorates this command with a runnable to run before this command starts.
+   *
+   * @param toRun the Runnable to run
+   * @param requirements the required subsystems
+   * @return the decorated command
+   */
+  [[nodiscard]] CommandPtr BeforeStarting(
+      std::function<void()> toRun,
+      std::initializer_list<Subsystem*> requirements) &&;
+
+  /**
+   * Decorates this command with a runnable to run before this command starts.
+   *
+   * @param toRun the Runnable to run
+   * @param requirements the required subsystems
+   * @return the decorated command
+   */
+  [[nodiscard]] CommandPtr BeforeStarting(
+      std::function<void()> toRun,
+      wpi::span<Subsystem* const> requirements = {}) &&;
+
+  /**
+   * Decorates this command with a timeout.  If the specified timeout is
+   * exceeded before the command finishes normally, the command will be
+   * interrupted and un-scheduled.  Note that the timeout only applies to the
+   * command returned by this method; the calling command is not itself changed.
+   *
+   * @param duration the timeout duration
+   * @return the command with the timeout added
+   */
+  [[nodiscard]] CommandPtr WithTimeout(units::second_t duration) &&;
+
+  /**
+   * Decorates this command with an interrupt condition.  If the specified
+   * condition becomes true before the command finishes normally, the command
+   * will be interrupted and un-scheduled. Note that this only applies to the
+   * command returned by this method; the calling command is not itself changed.
+   *
+   * @param condition the interrupt condition
+   * @return the command with the interrupt condition added
+   */
+  [[nodiscard]] CommandPtr Until(std::function<bool()> condition) &&;
+
+  /**
+   * Decorates this command to only run if this condition is not met. If the
+   * command is already running and the condition changes to true, the command
+   * will not stop running. The requirements of this command will be kept for
+   * the new conditonal command.
+   *
+   * @param condition the condition that will prevent the command from running
+   * @return the decorated command
+   */
+  [[nodiscard]] CommandPtr Unless(std::function<bool()> condition) &&;
+
+  /**
+   * Get a raw pointer to the held command.
+   */
+  Command* operator*() const;
+
+  /**
+   * Schedules this command.
+   */
+  void Schedule() const;
+
+  /**
+   * Cancels this command. Will call End(true). Commands will be canceled
+   * regardless of interruption behavior.
+   */
+  void Cancel() const;
+
+  /**
+   * Whether or not the command is currently scheduled. Note that this does not
+   * detect whether the command is being run by a CommandGroup, only whether it
+   * is directly being run by the scheduler.
+   *
+   * @return Whether the command is scheduled.
+   */
+  bool IsScheduled() const;
+
+  /**
+   * Whether the command requires a given subsystem.  Named "HasRequirement"
+   * rather than "requires" to avoid confusion with Command::Requires(Subsystem)
+   * -- this may be able to be changed in a few years.
+   *
+   * @param requirement the subsystem to inquire about
+   * @return whether the subsystem is required
+   */
+  bool HasRequirement(Subsystem* requirement) const;
+
+ private:
+  std::unique_ptr<Command> m_ptr;
+};
+
+}  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
@@ -47,7 +47,7 @@ class CommandPtr final {
    * Decorates this command to run "by proxy" by wrapping it in a
    * ProxyScheduleCommand. This is useful for "forking off" from command groups
    * when the user does not wish to extend the command's requirements to the
-   * entire command group. 
+   * entire command group.
    *
    * @return the decorated command
    */

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
@@ -150,7 +150,7 @@ class CommandPtr final {
   /**
    * Get a raw pointer to the held command.
    */
-  Command* operator*() const;
+  Command* get() const;
 
   /**
    * Schedules this command.

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -20,6 +20,7 @@
 
 namespace frc2 {
 class Command;
+class CommandPtr;
 class Subsystem;
 
 /**
@@ -81,6 +82,17 @@ class CommandScheduler final : public nt::NTSendable,
    */
   WPI_DEPRECATED("Call Clear on the EventLoop instance directly!")
   void ClearButtons();
+
+  /**
+   * Schedules a command for execution. Does nothing if the command is already
+   * scheduled. If a command's requirements are not available, it will only be
+   * started if all the commands currently using those requirements are
+   * interruptible. If this is the case, they will be interrupted and the
+   * command will be scheduled.
+   *
+   * @param command the command to schedule
+   */
+  void Schedule(const CommandPtr& command);
 
   /**
    * Schedules a command for execution. Does nothing if the command is already
@@ -208,6 +220,18 @@ class CommandScheduler final : public nt::NTSendable,
    * <p>Commands will be canceled even if they are not scheduled as
    * interruptible.
    *
+   * @param command the command to cancel
+   */
+  void Cancel(const CommandPtr& command);
+
+  /**
+   * Cancels commands. The scheduler will only call Command::End()
+   * method of the canceled command with true, indicating they were
+   * canceled (as opposed to finishing normally).
+   *
+   * <p>Commands will be canceled even if they are not scheduled as
+   * interruptible.
+   *
    * @param commands the commands to cancel
    */
   void Cancel(wpi::span<Command* const> commands);
@@ -258,6 +282,16 @@ class CommandScheduler final : public nt::NTSendable,
    * @return whether the command is currently scheduled
    */
   bool IsScheduled(const Command* command) const;
+
+  /**
+   * Whether a given command is running.  Note that this only works on commands
+   * that are directly scheduled by the scheduler; it will not work on commands
+   * inside of CommandGroups, as the scheduler does not see them.
+   *
+   * @param command the command to query
+   * @return whether the command is currently scheduled
+   */
+  bool IsScheduled(const CommandPtr& command) const;
 
   /**
    * Returns the command currently requiring a given subsystem.  Null if no

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Button.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Button.h
@@ -11,6 +11,7 @@
 #include <wpi/span.h>
 
 #include "Trigger.h"
+#include "frc2/command/CommandPtr.h"
 
 namespace frc2 {
 class Command;
@@ -46,6 +47,16 @@ class Button : public Trigger {
    * @return The trigger, for chained calls.
    */
   Button WhenPressed(Command* command);
+
+  /**
+   * Binds a command to start when the button is pressed.  Transfers
+   * command ownership to the button scheduler, so the user does not have to
+   * worry about lifespan.
+   *
+   * @param command The command to bind.
+   * @return The trigger, for chained calls.
+   */
+  Button WhenPressed(CommandPtr&& command);
 
   /**
    * Binds a command to start when the button is pressed.  Transfers
@@ -94,6 +105,16 @@ class Button : public Trigger {
   /**
    * Binds a command to be started repeatedly while the button is pressed, and
    * canceled when it is released.  Transfers command ownership to the button
+   * scheduler, so the user does not have to worry about lifespan.
+   *
+   * @param command The command to bind.
+   * @return The button, for chained calls.
+   */
+  Button WhileHeld(CommandPtr&& command);
+
+  /**
+   * Binds a command to be started repeatedly while the button is pressed, and
+   * canceled when it is released.  Transfers command ownership to the button
    * scheduler, so the user does not have to worry about lifespan - rvalue refs
    * will be *moved*, lvalue refs will be *copied.*
    *
@@ -138,6 +159,16 @@ class Button : public Trigger {
   /**
    * Binds a command to be started when the button is pressed, and canceled
    * when it is released.  Transfers command ownership to the button scheduler,
+   * so the user does not have to worry about lifespan.
+   *
+   * @param command The command to bind.
+   * @return The button, for chained calls.
+   */
+  Button WhenHeld(CommandPtr&& command);
+
+  /**
+   * Binds a command to be started when the button is pressed, and canceled
+   * when it is released.  Transfers command ownership to the button scheduler,
    * so the user does not have to worry about lifespan - rvalue refs will be
    * *moved*, lvalue refs will be *copied.*
    *
@@ -160,6 +191,16 @@ class Button : public Trigger {
    * @return The button, for chained calls.
    */
   Button WhenReleased(Command* command);
+
+  /**
+   * Binds a command to start when the button is pressed.  Transfers
+   * command ownership to the button scheduler, so the user does not have to
+   * worry about lifespan.
+   *
+   * @param command The command to bind.
+   * @return The button, for chained calls.
+   */
+  Button WhenReleased(CommandPtr&& command);
 
   /**
    * Binds a command to start when the button is pressed.  Transfers
@@ -204,6 +245,16 @@ class Button : public Trigger {
    * @return The button, for chained calls.
    */
   Button ToggleWhenPressed(Command* command);
+
+  /**
+   * Binds a command to start when the button is pressed, and be canceled when
+   * it is pessed again.  Transfers command ownership to the button scheduler,
+   * so the user does not have to worry about lifespan.
+   *
+   * @param command The command to bind.
+   * @return The button, for chained calls.
+   */
+  Button ToggleWhenPressed(CommandPtr&& command);
 
   /**
    * Binds a command to start when the button is pressed, and be canceled when

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
@@ -70,6 +70,15 @@ class Trigger : public frc::BooleanEvent {
   Trigger WhenActive(Command* command);
 
   /**
+   * Binds a command to start when the trigger becomes active. Moves
+   * command ownership to the button scheduler.
+   *
+   * @param command The command to bind.
+   * @return The trigger, for chained calls.
+   */
+  Trigger WhenActive(CommandPtr&& command);
+
+  /**
    * Binds a command to start when the trigger becomes active. Transfers
    * command ownership to the button scheduler, so the user does not have to
    * worry about lifespan - rvalue refs will be *moved*, lvalue refs will be
@@ -115,6 +124,16 @@ class Trigger : public frc::BooleanEvent {
    * @return The trigger, for chained calls.
    */
   Trigger WhileActiveContinous(Command* command);
+
+  /**
+   * Binds a command to be started repeatedly while the trigger is active, and
+   * canceled when it becomes inactive. Moves command ownership to the button
+   * scheduler.
+   *
+   * @param command The command to bind.
+   * @return The trigger, for chained calls.
+   */
+  Trigger WhileActiveContinous(CommandPtr&& command);
 
   /**
    * Binds a command to be started repeatedly while the trigger is active, and
@@ -166,6 +185,16 @@ class Trigger : public frc::BooleanEvent {
 
   /**
    * Binds a command to be started when the trigger becomes active, and
+   * canceled when it becomes inactive. Moves command ownership to the button
+   * scheduler.
+   *
+   * @param command The command to bind.
+   * @return The trigger, for chained calls.
+   */
+  Trigger WhileActiveOnce(CommandPtr&& command);
+
+  /**
+   * Binds a command to be started when the trigger becomes active, and
    * canceled when it becomes inactive. Transfers command ownership to the
    * button scheduler, so the user does not have to worry about lifespan -
    * rvalue refs will be *moved*, lvalue refs will be *copied.*
@@ -194,6 +223,15 @@ class Trigger : public frc::BooleanEvent {
    * @return The trigger, for chained calls.
    */
   Trigger WhenInactive(Command* command);
+
+  /**
+   * Binds a command to start when the trigger becomes inactive. Moves
+   * command ownership to the button scheduler.
+   *
+   * @param command The command to bind.
+   * @return The trigger, for chained calls.
+   */
+  Trigger WhenInactive(CommandPtr&& command);
 
   /**
    * Binds a command to start when the trigger becomes inactive.  Transfers
@@ -241,6 +279,16 @@ class Trigger : public frc::BooleanEvent {
    * @return The trigger, for chained calls.
    */
   Trigger ToggleWhenActive(Command* command);
+
+  /**
+   * Binds a command to start when the trigger becomes active, and be canceled
+   * when it again becomes active. Moves command ownership to the button
+   * scheduler.
+   *
+   * @param command The command to bind.
+   * @return The trigger, for chained calls.
+   */
+  Trigger ToggleWhenActive(CommandPtr&& command);
 
   /**
    * Binds a command to start when the trigger becomes active, and be canceled

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandDecoratorTest.cpp
@@ -23,15 +23,15 @@ TEST_F(CommandDecoratorTest, WithTimeout) {
 
   auto command = RunCommand([] {}, {}).WithTimeout(100_ms);
 
-  scheduler.Schedule(&command);
+  scheduler.Schedule(command);
 
   scheduler.Run();
-  EXPECT_TRUE(scheduler.IsScheduled(&command));
+  EXPECT_TRUE(scheduler.IsScheduled(command));
 
   frc::sim::StepTiming(150_ms);
 
   scheduler.Run();
-  EXPECT_FALSE(scheduler.IsScheduled(&command));
+  EXPECT_FALSE(scheduler.IsScheduled(command));
 
   frc::sim::ResumeTiming();
 }
@@ -43,15 +43,15 @@ TEST_F(CommandDecoratorTest, Until) {
 
   auto command = RunCommand([] {}, {}).Until([&finished] { return finished; });
 
-  scheduler.Schedule(&command);
+  scheduler.Schedule(command);
 
   scheduler.Run();
-  EXPECT_TRUE(scheduler.IsScheduled(&command));
+  EXPECT_TRUE(scheduler.IsScheduled(command));
 
   finished = true;
 
   scheduler.Run();
-  EXPECT_FALSE(scheduler.IsScheduled(&command));
+  EXPECT_FALSE(scheduler.IsScheduled(command));
 }
 
 TEST_F(CommandDecoratorTest, IgnoringDisable) {
@@ -61,10 +61,10 @@ TEST_F(CommandDecoratorTest, IgnoringDisable) {
 
   SetDSEnabled(false);
 
-  scheduler.Schedule(command.get());
+  scheduler.Schedule(command);
 
   scheduler.Run();
-  EXPECT_TRUE(scheduler.IsScheduled(command.get()));
+  EXPECT_TRUE(scheduler.IsScheduled(command));
 }
 
 TEST_F(CommandDecoratorTest, BeforeStarting) {
@@ -75,14 +75,14 @@ TEST_F(CommandDecoratorTest, BeforeStarting) {
   auto command = InstantCommand([] {}, {}).BeforeStarting(
       [&finished] { finished = true; });
 
-  scheduler.Schedule(&command);
+  scheduler.Schedule(command);
 
   EXPECT_TRUE(finished);
 
   scheduler.Run();
   scheduler.Run();
 
-  EXPECT_FALSE(scheduler.IsScheduled(&command));
+  EXPECT_FALSE(scheduler.IsScheduled(command));
 }
 
 TEST_F(CommandDecoratorTest, AndThen) {
@@ -93,14 +93,14 @@ TEST_F(CommandDecoratorTest, AndThen) {
   auto command =
       InstantCommand([] {}, {}).AndThen([&finished] { finished = true; });
 
-  scheduler.Schedule(&command);
+  scheduler.Schedule(command);
 
   EXPECT_FALSE(finished);
 
   scheduler.Run();
   scheduler.Run();
 
-  EXPECT_FALSE(scheduler.IsScheduled(&command));
+  EXPECT_FALSE(scheduler.IsScheduled(command));
   EXPECT_TRUE(finished);
 }
 
@@ -124,12 +124,12 @@ TEST_F(CommandDecoratorTest, Endlessly) {
 
   auto command = InstantCommand([] {}, {}).Endlessly();
 
-  scheduler.Schedule(&command);
+  scheduler.Schedule(command);
 
   scheduler.Run();
   scheduler.Run();
 
-  EXPECT_TRUE(scheduler.IsScheduled(&command));
+  EXPECT_TRUE(scheduler.IsScheduled(command));
 }
 
 TEST_F(CommandDecoratorTest, Unless) {
@@ -143,12 +143,12 @@ TEST_F(CommandDecoratorTest, Unless) {
         return unlessBool;
       });
 
-  scheduler.Schedule(&command);
+  scheduler.Schedule(command);
   scheduler.Run();
   EXPECT_FALSE(hasRun);
 
   unlessBool = false;
-  scheduler.Schedule(&command);
+  scheduler.Schedule(command);
   scheduler.Run();
   EXPECT_TRUE(hasRun);
 }

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandRequirementsTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandRequirementsTest.cpp
@@ -54,7 +54,7 @@ TEST_F(CommandRequirementsTest, RequirementUninterruptible) {
   int exeCounter = 0;
   int endCounter = 0;
 
-  std::unique_ptr<Command> command1 =
+  CommandPtr command1 =
       FunctionalCommand([&initCounter] { initCounter++; },
                         [&exeCounter] { exeCounter++; },
                         [&endCounter](bool interruptible) { endCounter++; },
@@ -68,13 +68,13 @@ TEST_F(CommandRequirementsTest, RequirementUninterruptible) {
   EXPECT_CALL(command2, End(true)).Times(0);
   EXPECT_CALL(command2, End(false)).Times(0);
 
-  scheduler.Schedule(command1.get());
+  scheduler.Schedule(command1);
   EXPECT_EQ(1, initCounter);
   scheduler.Run();
   EXPECT_EQ(1, exeCounter);
-  EXPECT_TRUE(scheduler.IsScheduled(command1.get()));
+  EXPECT_TRUE(scheduler.IsScheduled(command1));
   scheduler.Schedule(&command2);
-  EXPECT_TRUE(scheduler.IsScheduled(command1.get()));
+  EXPECT_TRUE(scheduler.IsScheduled(command1));
   EXPECT_FALSE(scheduler.IsScheduled(&command2));
   scheduler.Run();
   EXPECT_EQ(2, exeCounter);

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/EndlessCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/EndlessCommandTest.cpp
@@ -3,7 +3,6 @@
 // the WPILib BSD license file in the root directory of this project.
 
 #include "CommandTestBase.h"
-#include "frc2/command/EndlessCommand.h"
 #include "frc2/command/InstantCommand.h"
 
 using namespace frc2;
@@ -14,10 +13,10 @@ TEST_F(EndlessCommandTest, EndlessCommandSchedule) {
 
   bool check = false;
 
-  EndlessCommand command{InstantCommand([&check] { check = true; }, {})};
+  auto command = InstantCommand([&check] { check = true; }, {}).Endlessly();
 
-  scheduler.Schedule(&command);
+  scheduler.Schedule(command);
   scheduler.Run();
-  EXPECT_TRUE(scheduler.IsScheduled(&command));
+  EXPECT_TRUE(scheduler.IsScheduled(command));
   EXPECT_TRUE(check);
 }

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/ProxyScheduleCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/ProxyScheduleCommandTest.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "CommandTestBase.h"
+#include "frc2/command/CommandPtr.h"
 #include "frc2/command/InstantCommand.h"
 #include "frc2/command/ProxyScheduleCommand.h"
 #include "frc2/command/WaitUntilCommand.h"
@@ -51,10 +52,9 @@ TEST_F(ProxyScheduleCommandTest, OwningCommandSchedule) {
 
   bool scheduled = false;
 
-  ProxyScheduleCommand command(
-      std::make_unique<InstantCommand>([&scheduled] { scheduled = true; }));
+  CommandPtr command = InstantCommand([&scheduled] { scheduled = true; }).AsProxy();
 
-  scheduler.Schedule(&command);
+  scheduler.Schedule(command);
   scheduler.Run();
 
   EXPECT_TRUE(scheduled);
@@ -65,15 +65,14 @@ TEST_F(ProxyScheduleCommandTest, OwningCommandEnd) {
 
   bool finished = false;
 
-  ProxyScheduleCommand command(
-      std::make_unique<WaitUntilCommand>([&finished] { return finished; }));
+  CommandPtr command = WaitUntilCommand([&finished] { return finished; }).AsProxy();
 
-  scheduler.Schedule(&command);
+  scheduler.Schedule(command);
   scheduler.Run();
 
-  EXPECT_TRUE(scheduler.IsScheduled(&command));
+  EXPECT_TRUE(scheduler.IsScheduled(command));
   finished = true;
   scheduler.Run();
   scheduler.Run();
-  EXPECT_FALSE(scheduler.IsScheduled(&command));
+  EXPECT_FALSE(scheduler.IsScheduled(command));
 }

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/ProxyScheduleCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/ProxyScheduleCommandTest.cpp
@@ -52,7 +52,8 @@ TEST_F(ProxyScheduleCommandTest, OwningCommandSchedule) {
 
   bool scheduled = false;
 
-  CommandPtr command = InstantCommand([&scheduled] { scheduled = true; }).AsProxy();
+  CommandPtr command =
+      InstantCommand([&scheduled] { scheduled = true; }).AsProxy();
 
   scheduler.Schedule(command);
   scheduler.Run();
@@ -65,7 +66,8 @@ TEST_F(ProxyScheduleCommandTest, OwningCommandEnd) {
 
   bool finished = false;
 
-  CommandPtr command = WaitUntilCommand([&finished] { return finished; }).AsProxy();
+  CommandPtr command =
+      WaitUntilCommand([&finished] { return finished; }).AsProxy();
 
   scheduler.Schedule(command);
   scheduler.Run();

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/RepeatCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/RepeatCommandTest.cpp
@@ -4,7 +4,6 @@
 
 #include "CommandTestBase.h"
 #include "frc2/command/FunctionalCommand.h"
-#include "frc2/command/RepeatCommand.h"
 
 using namespace frc2;
 class RepeatCommandTest : public CommandTestBase {};
@@ -33,7 +32,7 @@ TEST_F(RepeatCommandTest, CallsMethodsCorrectly) {
   EXPECT_EQ(0, isFinishedCounter);
   EXPECT_EQ(0, endCounter);
 
-  scheduler.Schedule(&command);
+  scheduler.Schedule(command);
   EXPECT_EQ(1, initCounter);
   EXPECT_EQ(0, exeCounter);
   EXPECT_EQ(0, isFinishedCounter);

--- a/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/RobotContainer.cpp
@@ -47,5 +47,5 @@ void RobotContainer::ConfigureButtonBindings() {
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {
   // Runs the chosen command in autonomous
-  return *m_autonomousCommand;
+  return m_autonomousCommand.get();
 }

--- a/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/RobotContainer.cpp
@@ -47,5 +47,5 @@ void RobotContainer::ConfigureButtonBindings() {
 
 frc2::Command* RobotContainer::GetAutonomousCommand() {
   // Runs the chosen command in autonomous
-  return &m_autonomousCommand;
+  return *m_autonomousCommand;
 }

--- a/wpilibcExamples/src/main/cpp/examples/Frisbeebot/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/Frisbeebot/include/RobotContainer.h
@@ -45,7 +45,7 @@ class RobotContainer {
   ShooterSubsystem m_shooter;
 
   // A simple autonomous routine that shoots the loaded frisbees
-  frc2::SequentialCommandGroup m_autonomousCommand =
+  frc2::CommandPtr m_autonomousCommand =
       frc2::SequentialCommandGroup{
           // Start the command by spinning up the shooter...
           frc2::InstantCommand([this] { m_shooter.Enable(); }, {&m_shooter}),


### PR DESCRIPTION
closes #4303 

Once this is more advanced, check whether renaming `CommandPtr` to `Command` (removing the current `Command` class at the head of the inheritance hierarchy) would help reducing breaking changes and keep Java/C++ syntax similarity.