### PR TITLE
[wpimath] Remove redundant LinearFilter.finiteDifference() argument

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
@@ -147,17 +147,15 @@ public class LinearFilter {
    * stream-based online filtering.
    *
    * @param derivative The order of the derivative to compute.
-   * @param samples The number of samples to use to compute the given derivative. This must be one
-   *     more than the order of derivative or higher.
-   * @param stencil List of stencil points.
+   * @param stencil List of stencil points. Its length is the number of samples to use to compute
+   *     the given derivative. This must be one more than the order of the derivative or higher.
    * @param period The period in seconds between samples taken by the user.
    * @return Linear filter.
    * @throws IllegalArgumentException if derivative &lt; 1, samples &lt;= 0, or derivative &gt;=
    *     samples.
    */
   @SuppressWarnings("LocalVariableName")
-  public static LinearFilter finiteDifference(
-      int derivative, int samples, int[] stencil, double period) {
+  public static LinearFilter finiteDifference(int derivative, int[] stencil, double period) {
     // See
     // https://en.wikipedia.org/wiki/Finite_difference_coefficient#Arbitrary_stencil_points
     //
@@ -178,6 +176,8 @@ public class LinearFilter {
       throw new IllegalArgumentException(
           "Order of derivative must be greater than or equal to one.");
     }
+
+    int samples = stencil.length;
 
     if (samples <= 0) {
       throw new IllegalArgumentException("Number of samples must be greater than zero.");
@@ -236,7 +236,7 @@ public class LinearFilter {
       stencil[i] = -(samples - 1) + i;
     }
 
-    return finiteDifference(derivative, samples, stencil, period);
+    return finiteDifference(derivative, stencil, period);
   }
 
   /** Reset the filter state. */

--- a/wpimath/src/main/native/include/frc/filter/LinearFilter.h
+++ b/wpimath/src/main/native/include/frc/filter/LinearFilter.h
@@ -180,7 +180,7 @@ class LinearFilter {
    * @tparam Derivative The order of the derivative to compute.
    * @tparam Samples    The number of samples to use to compute the given
    *                    derivative. This must be one more than the order of
-   *                    derivative or higher.
+   *                    the derivative or higher.
    * @param stencil     List of stencil points.
    * @param period      The period in seconds between samples taken by the user.
    */

--- a/wpimath/src/test/java/edu/wpi/first/math/filter/LinearFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/filter/LinearFilterTest.java
@@ -282,7 +282,7 @@ class LinearFilterTest {
       stencil[i] = -(samples - 1) / 2 + i;
     }
 
-    var filter = LinearFilter.finiteDifference(derivative, samples, stencil, h);
+    var filter = LinearFilter.finiteDifference(derivative, stencil, h);
 
     for (int i = (int) (min / h); i < (int) (max / h); ++i) {
       // Let filter initialize


### PR DESCRIPTION
The number of samples is already determined by the length of the stencil
list.