### PR TITLE
[ci] Make upstream_utils CI fail on untracked files

### DIFF
--- a/.github/workflows/upstream-utils.yml
+++ b/.github/workflows/upstream-utils.yml
@@ -37,6 +37,10 @@ jobs:
         run: |
           cd upstream_utils
           ./update_eigen.py
+      - name: Run update_fmt.py
+        run: |
+          cd upstream_utils
+          ./update_fmt.py
       - name: Run update_libuv.py
         run: |
           cd upstream_utils

--- a/.github/workflows/upstream-utils.yml
+++ b/.github/workflows/upstream-utils.yml
@@ -49,5 +49,7 @@ jobs:
         run: |
           cd upstream_utils
           ./update_stack_walker.py
+      - name: Add untracked files to index so they count as changes
+        run: git add -A
       - name: Check output
         run: git --no-pager diff --exit-code HEAD


### PR DESCRIPTION
This catches issues like update scripts putting new files in a different
directory from the old ones.