### PR TITLE
Add comments to StateSpaceDifferentialDrive

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
@@ -30,7 +30,7 @@ RobotContainer::RobotContainer() {
   // hand, and turning controlled by the right.
   // If you are using the keyboard as a joystick, it is recommended that you go
   // to the following link to read about editing the keyboard settings.
-  // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/simulation-gui.html#using-the-keyboard-as-a-joystick:~:text=Using%20the%20Keyboard,%EF%83%81
+  // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/simulation-gui.html#using-the-keyboard-as-a-joystick
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
         m_drive.ArcadeDrive(-m_driverController.GetLeftY(),

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
@@ -26,6 +26,11 @@ RobotContainer::RobotContainer() {
   ConfigureButtonBindings();
 
   // Set up default drive command
+  // A split-stick arcade command, with forward/backward controlled by the left
+  // hand, and turning controlled by the right.
+  // If you are using the keyboard as a joystick, it is recommended that you go 
+  // to the following link to edit the settings of the keyboard.
+  // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/simulation-gui.html#using-the-keyboard-as-a-joystick:~:text=Using%20the%20Keyboard,%EF%83%81
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
         m_drive.ArcadeDrive(-m_driverController.GetLeftY(),

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
@@ -29,7 +29,7 @@ RobotContainer::RobotContainer() {
   // A split-stick arcade command, with forward/backward controlled by the left
   // hand, and turning controlled by the right.
   // If you are using the keyboard as a joystick, it is recommended that you go
-  // to the following link to edit the settings of the keyboard.
+  // to the following link to read about editing the keyboard settings.
   // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/simulation-gui.html#using-the-keyboard-as-a-joystick:~:text=Using%20the%20Keyboard,%EF%83%81
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
@@ -28,7 +28,7 @@ RobotContainer::RobotContainer() {
   // Set up default drive command
   // A split-stick arcade command, with forward/backward controlled by the left
   // hand, and turning controlled by the right.
-  // If you are using the keyboard as a joystick, it is recommended that you go 
+  // If you are using the keyboard as a joystick, it is recommended that you go
   // to the following link to edit the settings of the keyboard.
   // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/simulation-gui.html#using-the-keyboard-as-a-joystick:~:text=Using%20the%20Keyboard,%EF%83%81
   m_drive.SetDefaultCommand(frc2::RunCommand(

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
@@ -49,7 +49,7 @@ public class RobotContainer {
         // hand, and turning controlled by the right.
         // If you are using the keyboard as a joystick, it is recommended that you go
         // to the following link to read about editing the keyboard settings.
-        // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/simulation-gui.html#using-the-keyboard-as-a-joystick:~:text=Using%20the%20Keyboard,%EF%83%81
+        // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/simulation-gui.html#using-the-keyboard-as-a-joystick
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
@@ -47,6 +47,9 @@ public class RobotContainer {
     m_robotDrive.setDefaultCommand(
         // A split-stick arcade command, with forward/backward controlled by the left
         // hand, and turning controlled by the right.
+        // If you are using the keyboard as a joystick, it is recommended that you go 
+        // to the following link to edit the settings of the keyboard.
+        // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/simulation-gui.html#using-the-keyboard-as-a-joystick:~:text=Using%20the%20Keyboard,%EF%83%81
         new RunCommand(
             () ->
                 m_robotDrive.arcadeDrive(

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
@@ -47,7 +47,7 @@ public class RobotContainer {
     m_robotDrive.setDefaultCommand(
         // A split-stick arcade command, with forward/backward controlled by the left
         // hand, and turning controlled by the right.
-        // If you are using the keyboard as a joystick, it is recommended that you go 
+        // If you are using the keyboard as a joystick, it is recommended that you go
         // to the following link to edit the settings of the keyboard.
         // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/simulation-gui.html#using-the-keyboard-as-a-joystick:~:text=Using%20the%20Keyboard,%EF%83%81
         new RunCommand(

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/RobotContainer.java
@@ -48,7 +48,7 @@ public class RobotContainer {
         // A split-stick arcade command, with forward/backward controlled by the left
         // hand, and turning controlled by the right.
         // If you are using the keyboard as a joystick, it is recommended that you go
-        // to the following link to edit the settings of the keyboard.
+        // to the following link to read about editing the keyboard settings.
         // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/simulation-gui.html#using-the-keyboard-as-a-joystick:~:text=Using%20the%20Keyboard,%EF%83%81
         new RunCommand(
             () ->


### PR DESCRIPTION
When I tried moving the robot in the simulation using a keyboard, I was not able to rotate it. To solve this, I copied the settings from the "Using the Keyboard as a Joystick" section of the [Simulation Specific User Interface Elements](https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/simulation-gui.html#using-the-keyboard-as-a-joystick:~:text=Using%20the%20Keyboard,%EF%83%81) page. For this reason, I thought it would be helpful if the link was provided. I also added the arcade drive comments from the Java example to the C++ example. 