### PR TITLE
[hal] Replace SerialHelper "goto done" with continue

### DIFF
--- a/hal/src/main/native/athena/cpp/SerialHelper.cpp
+++ b/hal/src/main/native/athena/cpp/SerialHelper.cpp
@@ -193,7 +193,7 @@ void SerialHelper::QueryHubPaths(int32_t* status) {
     ViSession vSession;
     *status = viOpen(m_resourceHandle, desc, VI_NULL, VI_NULL, &vSession);
     if (*status < 0)
-      goto done;
+      continue;
     *status = 0;
 
     *status = viGetAttribute(vSession, VI_ATTR_INTF_INST_NAME, &osName);
@@ -201,9 +201,9 @@ void SerialHelper::QueryHubPaths(int32_t* status) {
     // Use a separate close variable so we can check
     ViStatus closeStatus = viClose(vSession);
     if (*status < 0)
-      goto done;
+      continue;
     if (closeStatus < 0)
-      goto done;
+      continue;
     *status = 0;
 
     // split until (/dev/


### PR DESCRIPTION
From the FRC Discord programming-help channel:
```
Ben | 217 Alum | CTRE Intern — 05/23/2022
Yeah that sounds right from what I'm seeing. Replacing the goto done; with continue; does seem to fix the issue as well (devices show up).
thadhouse WPILib Alumni — 05/23/2022
We should replace all of those goto dones with continue
The logic is already correct for closing all the objects. So we should just be continuing on error.
Since I'm not super concerned about the error if the devices still show up afterwards.
```