### PR TITLE
Improvements to Elevator Simulation Example

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/ElevatorSimulation/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/ElevatorSimulation/cpp/Robot.cpp
@@ -35,7 +35,9 @@ class Robot : public frc::TimedRobot {
   static constexpr int kEncoderBChannel = 1;
   static constexpr int kJoystickPort = 0;
 
-  static constexpr double kElevatorKp = 5.0;
+  static constexpr double kElevatorKp = 10.0;
+  static constexpr double kElevatorKi = 4.0;
+  static constexpr double kElevatorKd = 0.1;
   static constexpr double kElevatorGearing = 10.0;
   static constexpr units::meter_t kElevatorDrumRadius = 2_in;
   static constexpr units::kilogram_t kCarriageMass = 4.0_kg;
@@ -52,7 +54,7 @@ class Robot : public frc::TimedRobot {
   frc::DCMotor m_elevatorGearbox = frc::DCMotor::Vex775Pro(4);
 
   // Standard classes for controlling our elevator
-  frc2::PIDController m_controller{kElevatorKp, 0, 0};
+  frc2::PIDController m_controller{kElevatorKp, kElevatorKi, kElevatorKd};
   frc::Encoder m_encoder{kEncoderAChannel, kEncoderBChannel};
   frc::PWMSparkMax m_motor{kMotorPort};
   frc::Joystick m_joystick{kJoystickPort};
@@ -117,6 +119,7 @@ class Robot : public frc::TimedRobot {
       m_motor.Set(0.0);
     }
   }
+  // To view the Elevator Sim in the simulator, select Network Tables -> SmartDashboard -> Elevator Sim
 
   void DisabledInit() override {
     // This just makes sure that our simulation code knows that the motor's off.

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/elevatorsimulation/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/elevatorsimulation/Robot.java
@@ -29,7 +29,7 @@ public class Robot extends TimedRobot {
   private static final int kEncoderBChannel = 1;
   private static final int kJoystickPort = 0;
 
-  private static final double kElevatorKp = 10;
+  private static final double kElevatorKp = 10.0;
   private static final double kElevatorKi = 4.0;
   private static final double kElevatorKd = 0.1;
   private static final double kElevatorGearing = 10.0;
@@ -111,12 +111,11 @@ public class Robot extends TimedRobot {
       m_motor.set(0.0);
     }
   }
+  // To view the Elevator Sim in the simulator, select Network Tables -> SmartDashboard -> Elevator Sim
 
   @Override
   public void disabledInit() {
     // This just makes sure that our simulation code knows that the motor's off.
     m_motor.set(0.0);
-    
-    // To view the Elevator Sim in the simulator, select Network Tables -> SmartDashboard -> Elevator Sim
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/elevatorsimulation/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/elevatorsimulation/Robot.java
@@ -29,7 +29,9 @@ public class Robot extends TimedRobot {
   private static final int kEncoderBChannel = 1;
   private static final int kJoystickPort = 0;
 
-  private static final double kElevatorKp = 5.0;
+  private static final double kElevatorKp = 10;
+  private static final double kElevatorKi = 4.0;
+  private static final double kElevatorKd = 0.1;
   private static final double kElevatorGearing = 10.0;
   private static final double kElevatorDrumRadius = Units.inchesToMeters(2.0);
   private static final double kCarriageMass = 4.0; // kg
@@ -45,7 +47,7 @@ public class Robot extends TimedRobot {
   private final DCMotor m_elevatorGearbox = DCMotor.getVex775Pro(4);
 
   // Standard classes for controlling our elevator
-  private final PIDController m_controller = new PIDController(kElevatorKp, 0, 0);
+  private final PIDController m_controller = new PIDController(kElevatorKp, kElevatorKi, kElevatorKd);
   private final Encoder m_encoder = new Encoder(kEncoderAChannel, kEncoderBChannel);
   private final PWMSparkMax m_motor = new PWMSparkMax(kMotorPort);
   private final Joystick m_joystick = new Joystick(kJoystickPort);
@@ -114,5 +116,7 @@ public class Robot extends TimedRobot {
   public void disabledInit() {
     // This just makes sure that our simulation code knows that the motor's off.
     m_motor.set(0.0);
+    
+    // To view the Elevator Sim in the simulator, select Network Tables -> SmartDashboard -> Elevator Sim
   }
 }


### PR DESCRIPTION
- Add and use dedicated kI and kD variables
- Add instructions to view Elevator Sim in simulator
- More accurate PID gains
![10 4  1](https://user-images.githubusercontent.com/43558768/184849733-84a32847-898a-4c60-85ad-11b34e60334b.jpg)
kP = 10, kI = 4, kD = 1
![5 0 0](https://user-images.githubusercontent.com/43558768/184849752-c18e9deb-bd4f-4224-b45b-8dcf3edb85de.jpg)
kP = 5, kI = 0, kD = 0
