### PR TITLE
Upgrade to Dear ImGUI 1.88

### DIFF
--- a/imgui/CMakeLists.txt.in
+++ b/imgui/CMakeLists.txt.in
@@ -23,7 +23,7 @@ ExternalProject_Add(gl3w
 )
 ExternalProject_Add(imgui
   GIT_REPOSITORY    https://github.com/ocornut/imgui.git
-  GIT_TAG           v1.86
+  GIT_TAG           v1.88
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/imgui-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/imgui-build"
   CONFIGURE_COMMAND ""

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -17,7 +17,7 @@ nativeUtils {
             niLibVersion = "2022.4.0"
             opencvVersion = "4.5.5-3"
             googleTestVersion = "1.11.0-2"
-            imguiVersion = "1.87-2"
+            imguiVersion = "1.88-3"
             wpimathVersion = "-1"
         }
     }


### PR DESCRIPTION
This disables a C++20 warning in imgui about enum-enum conversions.