### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/crossConnIntegrationTests/src/main/native/cpp/PWMTest.cpp
+++ b/crossConnIntegrationTests/src/main/native/cpp/PWMTest.cpp
@@ -100,8 +100,9 @@ void TestTimingDMA(int squelch, std::pair<int, int> param) {
       auto value = HAL_GetDMASampleDigitalSource(&dmaSamples[startIndex],
                                                  dioHandle, &status);
       ASSERT_EQ(0, status);
-      if (value)
+      if (value) {
         break;
+      }
       startIndex++;
     }
     ASSERT_LT(startIndex, 6);

--- a/cscore/src/main/native/windows/UsbCameraImpl.cpp
+++ b/cscore/src/main/native/windows/UsbCameraImpl.cpp
@@ -279,19 +279,23 @@ static bool IsPercentageProperty(std::string_view name) {
 
 void UsbCameraImpl::ProcessFrame(IMFSample* videoSample,
                                  const VideoMode& mode) {
-  if (!videoSample)
+  if (!videoSample) {
     return;
+  }
 
   ComPtr<IMFMediaBuffer> buf;
 
   if (!SUCCEEDED(videoSample->ConvertToContiguousBuffer(buf.GetAddressOf()))) {
     DWORD bcnt = 0;
-    if (!SUCCEEDED(videoSample->GetBufferCount(&bcnt)))
+    if (!SUCCEEDED(videoSample->GetBufferCount(&bcnt))) {
       return;
-    if (bcnt == 0)
+    }
+    if (bcnt == 0) {
       return;
-    if (!SUCCEEDED(videoSample->GetBufferByIndex(0, buf.GetAddressOf())))
+    }
+    if (!SUCCEEDED(videoSample->GetBufferByIndex(0, buf.GetAddressOf()))) {
       return;
+    }
   }
 
   BYTE* ptr = NULL;
@@ -474,11 +478,13 @@ static cs::VideoMode::PixelFormat GetFromGUID(const GUID& guid) {
 }
 
 bool UsbCameraImpl::DeviceConnect() {
-  if (m_mediaSource && m_sourceReader)
+  if (m_mediaSource && m_sourceReader) {
     return true;
+  }
 
-  if (m_connectVerbose)
+  if (m_connectVerbose) {
     SINFO("Connecting to USB camera on {}", m_path);
+  }
 
   SDEBUG3("{}", "opening device");
 
@@ -580,8 +586,9 @@ template void UsbCameraImpl::DeviceAddProperty(std::string_view name_,
   DeviceAddProperty(#val, CameraControl_##val, pCamControl);
 
 void UsbCameraImpl::DeviceCacheProperties() {
-  if (!m_sourceReader)
+  if (!m_sourceReader) {
     return;
+  }
 
   IAMVideoProcAmp* pProcAmp = NULL;
 
@@ -778,22 +785,25 @@ CS_StatusValue UsbCameraImpl::DeviceCmdSetProperty(
 
   // Look up
   auto prop = static_cast<UsbCameraProperty*>(GetProperty(property));
-  if (!prop)
+  if (!prop) {
     return CS_INVALID_PROPERTY;
+  }
 
   // If setting before we get, guess initial type based on set
   if (prop->propKind == CS_PROP_NONE) {
-    if (setString)
+    if (setString) {
       prop->propKind = CS_PROP_STRING;
-    else
+    } else {
       prop->propKind = CS_PROP_INTEGER;
+    }
   }
 
   // Check kind match
   if ((setString && prop->propKind != CS_PROP_STRING) ||
       (!setString && (prop->propKind &
-                      (CS_PROP_BOOLEAN | CS_PROP_INTEGER | CS_PROP_ENUM)) == 0))
+                      (CS_PROP_BOOLEAN | CS_PROP_INTEGER | CS_PROP_ENUM)) == 0)) {
     return CS_WRONG_PROPERTY_TYPE;
+  }
 
   // Handle percentage property
   int percentageProperty = prop->propPair;
@@ -810,8 +820,9 @@ CS_StatusValue UsbCameraImpl::DeviceCmdSetProperty(
 
   // Actually set the new value on the device (if possible)
   if (!prop->device) {
-    if (prop->id == kPropConnectVerboseId)
+    if (prop->id == kPropConnectVerboseId) {
       m_connectVerbose = value;
+    }
   } else {
     if (!prop->DeviceSet(lock, m_sourceReader.Get())) {
       return CS_PROPERTY_WRITE_FAILED;
@@ -913,11 +924,13 @@ bool UsbCameraImpl::DeviceStreamOff() {
 }
 
 void UsbCameraImpl::DeviceCacheMode() {
-  if (!m_sourceReader)
+  if (!m_sourceReader) {
     return;
+  }
 
-  if (m_windowsVideoModes.size() == 0)
+  if (m_windowsVideoModes.size() == 0) {
     return;
+  }
 
   if (!m_currentMode) {
     // First, see if our set mode is valid
@@ -982,8 +995,9 @@ CS_StatusValue UsbCameraImpl::DeviceSetMode() {
 }
 
 void UsbCameraImpl::DeviceCacheVideoModes() {
-  if (!m_sourceReader)
+  if (!m_sourceReader) {
     return;
+  }
 
   std::vector<VideoMode> modes;
   m_windowsVideoModes.clear();

--- a/cscore/src/main/native/windows/UsbCameraImpl.cpp
+++ b/cscore/src/main/native/windows/UsbCameraImpl.cpp
@@ -800,8 +800,8 @@ CS_StatusValue UsbCameraImpl::DeviceCmdSetProperty(
 
   // Check kind match
   if ((setString && prop->propKind != CS_PROP_STRING) ||
-      (!setString && (prop->propKind &
-                      (CS_PROP_BOOLEAN | CS_PROP_INTEGER | CS_PROP_ENUM)) == 0)) {
+      (!setString && (prop->propKind & (CS_PROP_BOOLEAN | CS_PROP_INTEGER |
+                                        CS_PROP_ENUM)) == 0)) {
     return CS_WRONG_PROPERTY_TYPE;
   }
 

--- a/cscore/src/main/native/windows/UsbCameraImpl.h
+++ b/cscore/src/main/native/windows/UsbCameraImpl.h
@@ -96,7 +96,7 @@ class UsbCameraImpl : public SourceImpl,
     };
 
     explicit Message(Kind kind_)
-        : kind(kind_), data{0}, from(std::this_thread::get_id()) {}
+        : kind(kind_), from(std::this_thread::get_id()) {}
 
     Kind kind;
     int data[4]{0};

--- a/cscore/src/main/native/windows/UsbCameraImpl.h
+++ b/cscore/src/main/native/windows/UsbCameraImpl.h
@@ -99,7 +99,7 @@ class UsbCameraImpl : public SourceImpl,
         : kind(kind_), data{0}, from(std::this_thread::get_id()) {}
 
     Kind kind;
-    int data[4];
+    int data[4]{0};
     std::string dataStr;
     std::thread::id from;
   };

--- a/cscore/src/main/native/windows/UsbCameraProperty.cpp
+++ b/cscore/src/main/native/windows/UsbCameraProperty.cpp
@@ -40,8 +40,9 @@ UsbCameraProperty::UsbCameraProperty(std::string_view name_,
 
 bool UsbCameraProperty::DeviceGet(std::unique_lock<wpi::mutex>& lock,
                                   IAMVideoProcAmp* pProcAmp) {
-  if (!pProcAmp)
+  if (!pProcAmp) {
     return true;
+  }
 
   lock.unlock();
   long newValue = 0, paramFlag = 0;  // NOLINT(runtime/int)
@@ -60,8 +61,9 @@ bool UsbCameraProperty::DeviceSet(std::unique_lock<wpi::mutex>& lock,
 bool UsbCameraProperty::DeviceSet(std::unique_lock<wpi::mutex>& lock,
                                   IAMVideoProcAmp* pProcAmp,
                                   int newValue) const {
-  if (!pProcAmp)
+  if (!pProcAmp) {
     return true;
+  }
 
   lock.unlock();
   if (SUCCEEDED(
@@ -104,8 +106,9 @@ UsbCameraProperty::UsbCameraProperty(std::string_view name_,
 
 bool UsbCameraProperty::DeviceGet(std::unique_lock<wpi::mutex>& lock,
                                   IAMCameraControl* pProcAmp) {
-  if (!pProcAmp)
+  if (!pProcAmp) {
     return true;
+  }
 
   lock.unlock();
   long newValue = 0, paramFlag = 0;  // NOLINT(runtime/int)
@@ -124,8 +127,9 @@ bool UsbCameraProperty::DeviceSet(std::unique_lock<wpi::mutex>& lock,
 bool UsbCameraProperty::DeviceSet(std::unique_lock<wpi::mutex>& lock,
                                   IAMCameraControl* pProcAmp,
                                   int newValue) const {
-  if (!pProcAmp)
+  if (!pProcAmp) {
     return true;
+  }
 
   lock.unlock();
   if (SUCCEEDED(pProcAmp->Set(tagCameraControl, newValue,
@@ -139,8 +143,9 @@ bool UsbCameraProperty::DeviceSet(std::unique_lock<wpi::mutex>& lock,
 
 bool UsbCameraProperty::DeviceGet(std::unique_lock<wpi::mutex>& lock,
                                   IMFSourceReader* sourceReader) {
-  if (!sourceReader)
+  if (!sourceReader) {
     return true;
+  }
 
   if (isControlProperty) {
     ComPtr<IAMCameraControl> pProcAmp;
@@ -169,8 +174,9 @@ bool UsbCameraProperty::DeviceSet(std::unique_lock<wpi::mutex>& lock,
 bool UsbCameraProperty::DeviceSet(std::unique_lock<wpi::mutex>& lock,
                                   IMFSourceReader* sourceReader,
                                   int newValue) const {
-  if (!sourceReader)
+  if (!sourceReader) {
     return true;
+  }
 
   if (isControlProperty) {
     ComPtr<IAMCameraControl> pProcAmp;

--- a/hal/src/main/native/athena/Accelerometer.cpp
+++ b/hal/src/main/native/athena/Accelerometer.cpp
@@ -121,8 +121,9 @@ static void writeRegister(Register reg, uint8_t data) {
   // Execute and wait until it's done (up to a millisecond)
   initialTime = HAL_GetFPGATime(&status);
   while (accel->readSTAT(&status) & 1) {
-    if (HAL_GetFPGATime(&status) > initialTime + 1000)
+    if (HAL_GetFPGATime(&status) > initialTime + 1000) {
       break;
+    }
   }
 
   // Send a stop transmit/receive message with the data
@@ -133,8 +134,9 @@ static void writeRegister(Register reg, uint8_t data) {
   // Execute and wait until it's done (up to a millisecond)
   initialTime = HAL_GetFPGATime(&status);
   while (accel->readSTAT(&status) & 1) {
-    if (HAL_GetFPGATime(&status) > initialTime + 1000)
+    if (HAL_GetFPGATime(&status) > initialTime + 1000) {
       break;
+    }
   }
 }
 
@@ -151,8 +153,9 @@ static uint8_t readRegister(Register reg) {
   // Execute and wait until it's done (up to a millisecond)
   initialTime = HAL_GetFPGATime(&status);
   while (accel->readSTAT(&status) & 1) {
-    if (HAL_GetFPGATime(&status) > initialTime + 1000)
+    if (HAL_GetFPGATime(&status) > initialTime + 1000) {
       break;
+    }
   }
 
   // Receive a message with the data and stop
@@ -163,8 +166,9 @@ static uint8_t readRegister(Register reg) {
   // Execute and wait until it's done (up to a millisecond)
   initialTime = HAL_GetFPGATime(&status);
   while (accel->readSTAT(&status) & 1) {
-    if (HAL_GetFPGATime(&status) > initialTime + 1000)
+    if (HAL_GetFPGATime(&status) > initialTime + 1000) {
       break;
+    }
   }
 
   return accel->readDATI(&status);

--- a/hal/src/main/native/athena/AnalogAccumulator.cpp
+++ b/hal/src/main/native/athena/AnalogAccumulator.cpp
@@ -23,8 +23,9 @@ HAL_Bool HAL_IsAccumulatorChannel(HAL_AnalogInputHandle analogPortHandle,
     return false;
   }
   for (int32_t i = 0; i < kNumAccumulators; i++) {
-    if (port->channel == kAccumulatorChannels[i])
+    if (port->channel == kAccumulatorChannels[i]) {
       return true;
+    }
   }
   return false;
 }

--- a/hal/src/main/native/athena/DIO.cpp
+++ b/hal/src/main/native/athena/DIO.cpp
@@ -133,8 +133,9 @@ HAL_Bool HAL_CheckDIOChannel(int32_t channel) {
 void HAL_FreeDIOPort(HAL_DigitalHandle dioPortHandle) {
   auto port = digitalChannelHandles->Get(dioPortHandle, HAL_HandleEnum::DIO);
   // no status, so no need to check for a proper free.
-  if (port == nullptr)
+  if (port == nullptr) {
     return;
+  }
   digitalChannelHandles->Free(dioPortHandle, HAL_HandleEnum::DIO);
 
   // Wait for no other object to hold this handle.

--- a/hal/src/main/native/athena/DMA.cpp
+++ b/hal/src/main/native/athena/DMA.cpp
@@ -130,8 +130,9 @@ void HAL_FreeDMA(HAL_DMAHandle handle) {
   auto dma = dmaHandles->Get(handle);
   dmaHandles->Free(handle);
 
-  if (!dma)
+  if (!dma) {
     return;
+  }
 
   int32_t status = 0;
   if (dma->manager) {

--- a/hal/src/main/native/athena/DigitalInternal.cpp
+++ b/hal/src/main/native/athena/DigitalInternal.cpp
@@ -98,8 +98,9 @@ void initializeDigital(int32_t* status) {
 
   // Make sure that the 9403 IONode has had a chance to initialize before
   // continuing.
-  while (pwmSystem->readLoopTiming(status) == 0)
+  while (pwmSystem->readLoopTiming(status) == 0) {
     std::this_thread::yield();
+  }
 
   if (pwmSystem->readLoopTiming(status) != kExpectedLoopTiming) {
     *status = LOOP_TIMING_ERROR;  // NOTE: Doesn't display the error

--- a/hal/src/main/native/athena/Notifier.cpp
+++ b/hal/src/main/native/athena/Notifier.cpp
@@ -113,8 +113,9 @@ static void notifierThreadMain() {
     if (!notifierRunning) {
       break;
     }
-    if (triggeredMask == 0)
+    if (triggeredMask == 0) {
       continue;
+    }
     alarmCallback();
   }
 }
@@ -195,8 +196,9 @@ void HAL_SetNotifierName(HAL_NotifierHandle notifierHandle, const char* name,
 
 void HAL_StopNotifier(HAL_NotifierHandle notifierHandle, int32_t* status) {
   auto notifier = notifierHandles->Get(notifierHandle);
-  if (!notifier)
+  if (!notifier) {
     return;
+  }
 
   {
     std::scoped_lock lock(notifier->mutex);
@@ -209,8 +211,9 @@ void HAL_StopNotifier(HAL_NotifierHandle notifierHandle, int32_t* status) {
 
 void HAL_CleanNotifier(HAL_NotifierHandle notifierHandle, int32_t* status) {
   auto notifier = notifierHandles->Free(notifierHandle);
-  if (!notifier)
+  if (!notifier) {
     return;
+  }
 
   // Just in case HAL_StopNotifier() wasn't called...
   {
@@ -244,8 +247,9 @@ void HAL_CleanNotifier(HAL_NotifierHandle notifierHandle, int32_t* status) {
 void HAL_UpdateNotifierAlarm(HAL_NotifierHandle notifierHandle,
                              uint64_t triggerTime, int32_t* status) {
   auto notifier = notifierHandles->Get(notifierHandle);
-  if (!notifier)
+  if (!notifier) {
     return;
+  }
 
   {
     std::scoped_lock lock(notifier->mutex);
@@ -270,8 +274,9 @@ void HAL_UpdateNotifierAlarm(HAL_NotifierHandle notifierHandle,
 void HAL_CancelNotifierAlarm(HAL_NotifierHandle notifierHandle,
                              int32_t* status) {
   auto notifier = notifierHandles->Get(notifierHandle);
-  if (!notifier)
+  if (!notifier) {
     return;
+  }
 
   {
     std::scoped_lock lock(notifier->mutex);
@@ -282,8 +287,9 @@ void HAL_CancelNotifierAlarm(HAL_NotifierHandle notifierHandle,
 uint64_t HAL_WaitForNotifierAlarm(HAL_NotifierHandle notifierHandle,
                                   int32_t* status) {
   auto notifier = notifierHandles->Get(notifierHandle);
-  if (!notifier)
+  if (!notifier) {
     return 0;
+  }
   std::unique_lock lock(notifier->mutex);
   notifier->cond.wait(lock, [&] {
     return !notifier->active || notifier->triggeredTime != UINT64_MAX;

--- a/hal/src/main/native/athena/REVPH.cpp
+++ b/hal/src/main/native/athena/REVPH.cpp
@@ -236,8 +236,9 @@ HAL_REVPHHandle HAL_InitializeREVPH(int32_t module,
 
 void HAL_FreeREVPH(HAL_REVPHHandle handle) {
   auto hph = REVPHHandles->Get(handle);
-  if (hph == nullptr)
+  if (hph == nullptr) {
     return;
+  }
 
   HAL_CleanCAN(hph->hcan);
 

--- a/wpigui/src/main/native/directx11/wpigui_directx11.cpp
+++ b/wpigui/src/main/native/directx11/wpigui_directx11.cpp
@@ -69,8 +69,9 @@ static bool CreateDeviceD3D(HWND hWnd) {
           nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, createDeviceFlags,
           featureLevelArray, 2, D3D11_SDK_VERSION, &sd,
           &gPlatformContext->pSwapChain, &gPlatformContext->pd3dDevice,
-          &featureLevel, &gPlatformContext->pd3dDeviceContext) != S_OK)
+          &featureLevel, &gPlatformContext->pd3dDeviceContext) != S_OK) {
     return false;
+  }
 
   CreateRenderTarget();
   return true;

--- a/wpinet/src/main/native/macOS/MulticastServiceAnnouncer.cpp
+++ b/wpinet/src/main/native/macOS/MulticastServiceAnnouncer.cpp
@@ -4,6 +4,8 @@
 
 #include "wpinet/MulticastServiceAnnouncer.h"
 
+#include <arpa/inet.h>
+
 #include <wpi/SmallString.h>
 
 #include "dns_sd.h"

--- a/wpinet/src/main/native/macOS/ResolverThread.cpp
+++ b/wpinet/src/main/native/macOS/ResolverThread.cpp
@@ -4,6 +4,8 @@
 
 #include "ResolverThread.h"
 
+#include <algorithm>
+
 #include <wpi/mutex.h>
 
 using namespace wpi;

--- a/wpiutil/src/main/native/windows/Demangle.cpp
+++ b/wpiutil/src/main/native/windows/Demangle.cpp
@@ -22,8 +22,9 @@ std::string Demangle(std::string_view mangledSymbol) {
   char buffer[256];
   DWORD sz = UnDecorateSymbolName(buf.c_str(), buffer, sizeof(buffer),
                                   UNDNAME_COMPLETE);
-  if (sz == 0)
+  if (sz == 0) {
     return std::string{mangledSymbol};
+  }
   return std::string(buffer, sz);
 }
 


### PR DESCRIPTION
The warnings included recommendations of braces for if statement
readability, a recommendation for default initialization of an int
array, and include-what-you-use (indirectly through clang-tidy reporting
undefined symbols).