### PR TITLE
[docs] Upgrade to doxygen 1.9.4

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -37,7 +37,7 @@ cppProjectZips.add(project(':wpilibNewCommands').cppHeadersZip)
 
 doxygen {
     executables {
-        doxygen version : '1.9.2',
+        doxygen version : '1.9.4',
         baseURI : 'https://frcmaven.wpi.edu/artifactory/generic-release-mirror/doxygen'
     }
 }


### PR DESCRIPTION
Doxygen 1.9.2 requires libclang-9, which is no longer available on
Ubuntu 22.04.