### PR TITLE
Fix MacOS binary @rpath generation

### DIFF
--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -37,7 +37,11 @@ nativeUtils.platformConfigs.each {
     if (it.name.contains('windows')) {
         return
     }
-    it.linker.args << '-Wl,-rpath,\'$ORIGIN\''
+    if (it.name.contains('osx')) {
+        it.linker.args << '-Wl,-rpath,\'@loader_path\''
+    } else {
+        it.linker.args << '-Wl,-rpath,\'$ORIGIN\''
+    }
     if (it.name == 'osxx86-64' || it.name == 'osxarm64') {
         it.linker.args << "-headerpad_max_install_names"
     }


### PR DESCRIPTION
For RPATH on MacOS use `@loader_path` instead of `$ORIGIN` to reference the directory where the executable is located. The latter is the mechanism used on Linux.

I think this was exposed due to newer OS X ignoring `$DYLD_LIBRARY_PATH` for security reasons.

Sourced when building on MacOS 12.5.1 on Apple Silicon (M2) for `:cscore:test` task, and noting that libcscorejni.dylib existed but still failed loading and that some of the dependent libraries used `@rpath/<lib>`. Inspection of cscoreDev binary with `otool -l` was where I found `$ORIGIN` for `LC_RPATH`