### PR TITLE
Add direction to slew rate limiter

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
@@ -41,7 +41,8 @@ public class SlewRateLimiter {
    *
    * @param rateLimit The rate-of-change limit, in units per second.
    * @param initalValue The initial value of the input.
-   * @deprecated Use SlewRateLimiter(double positiveRateLimit, double negativeRateLimit, double initalValue) instead.
+   * @deprecated Use SlewRateLimiter(double positiveRateLimit, double negativeRateLimit, double
+   *     initalValue) instead.
    */
   @Deprecated(since = "2023", forRemoval = true)
   public SlewRateLimiter(double rateLimit, double initalValue) {

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
@@ -14,20 +14,33 @@ import edu.wpi.first.util.WPIUtilJNI;
  * edu.wpi.first.math.trajectory.TrapezoidProfile} instead.
  */
 public class SlewRateLimiter {
-  private final double m_rateLimit;
+  private final double m_positiveRateLimit;
+  private final double m_negativeRateLimit;
   private double m_prevVal;
   private double m_prevTime;
 
   /**
-   * Creates a new SlewRateLimiter with the given rate limit and initial value.
-   *
-   * @param rateLimit The rate-of-change limit, in units per second.
+   * Constructs a SlewRateLimiter with the given positive and negative rate limits and inital value.
+   * 
+   * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per second.
+   * @param negativeRateLimit The rate-of-change limit in the negative direction, in units per second.
    * @param initialValue The initial value of the input.
    */
-  public SlewRateLimiter(double rateLimit, double initialValue) {
-    m_rateLimit = rateLimit;
+  public SlewRateLimiter(double positiveRateLimit, double negativeRateLimit, double initialValue) {
+    m_positiveRateLimit = positiveRateLimit;
+    m_negativeRateLimit = negativeRateLimit;
     m_prevVal = initialValue;
     m_prevTime = WPIUtilJNI.now() * 1e-6;
+  }
+
+  /**
+   * Creates a new SlewRateLimiter with the given positive and negative rate limits.
+   *
+   * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per second.
+   * @param negativeRateLimit The rate-of-change limit in the negative direction, in units per second.
+   */
+  public SlewRateLimiter(double positiveRateLimit, double negativeRateLimit) {
+    this(positiveRateLimit, negativeRateLimit, 0);
   }
 
   /**
@@ -36,7 +49,7 @@ public class SlewRateLimiter {
    * @param rateLimit The rate-of-change limit, in units per second.
    */
   public SlewRateLimiter(double rateLimit) {
-    this(rateLimit, 0);
+    this(rateLimit, -rateLimit, 0);
   }
 
   /**
@@ -49,7 +62,7 @@ public class SlewRateLimiter {
     double currentTime = WPIUtilJNI.now() * 1e-6;
     double elapsedTime = currentTime - m_prevTime;
     m_prevVal +=
-        MathUtil.clamp(input - m_prevVal, -m_rateLimit * elapsedTime, m_rateLimit * elapsedTime);
+        MathUtil.clamp(input - m_prevVal, m_negativeRateLimit * elapsedTime, m_positiveRateLimit * elapsedTime);
     m_prevTime = currentTime;
     return m_prevVal;
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
@@ -20,7 +20,8 @@ public class SlewRateLimiter {
   private double m_prevTime;
 
   /**
-   * Creates a new SlewRateLimiter with the given positive and negative rate limit and initial value.
+   * Creates a new SlewRateLimiter with the given positive and negative rate limit and initial
+   * value.
    *
    * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per
    *     second.

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
@@ -20,13 +20,13 @@ public class SlewRateLimiter {
   private double m_prevTime;
 
   /**
-   * Creates a new SlewRateLimiter with the given positive and negative rate limit and initial
+   * Creates a new SlewRateLimiter with the given positive and negative rate limits and initial
    * value.
    *
    * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per
-   *     second.
+   *     second. This is expected to be positive.
    * @param negativeRateLimit The rate-of-change limit in the negative direction, in units per
-   *     second. This is expected to be less than 0.
+   *     second. This is expected to be negative.
    * @param initialValue The initial value of the input.
    */
   public SlewRateLimiter(double positiveRateLimit, double negativeRateLimit, double initialValue) {
@@ -37,7 +37,8 @@ public class SlewRateLimiter {
   }
 
   /**
-   * Creates a new SlewRateLimiter with the given positive and negative rate limits.
+   * Creates a new SlewRateLimiter with the given positive rate limit and negative rate limit of
+   * -rateLimit and initial value.
    *
    * @param rateLimit The rate-of-change limit, in units per second.
    * @param initalValue The initial value of the input.
@@ -50,7 +51,8 @@ public class SlewRateLimiter {
   }
 
   /**
-   * Creates a new SlewRateLimiter with the given rate limit and an initial value of zero.
+   * Creates a new SlewRateLimiter with the given positive rate limit and negative rate limit of
+   * -rateLimit.
    *
    * @param rateLimit The rate-of-change limit, in units per second.
    */

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
@@ -46,7 +46,7 @@ public class SlewRateLimiter {
    */
   @Deprecated(since = "2023", forRemoval = true)
   public SlewRateLimiter(double rateLimit, double initalValue) {
-    this(rateLimit, -rateLimit, 0);
+    this(rateLimit, -rateLimit, initalValue);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
@@ -26,7 +26,7 @@ public class SlewRateLimiter {
    * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per
    *     second.
    * @param negativeRateLimit The rate-of-change limit in the negative direction, in units per
-   *     second.
+   *     second. This is expected to be less than 0.
    * @param initialValue The initial value of the input.
    */
   public SlewRateLimiter(double positiveRateLimit, double negativeRateLimit, double initialValue) {
@@ -39,13 +39,13 @@ public class SlewRateLimiter {
   /**
    * Creates a new SlewRateLimiter with the given positive and negative rate limits.
    *
-   * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per
-   *     second.
-   * @param negativeRateLimit The rate-of-change limit in the negative direction, in units per
-   *     second.
+   * @param rateLimit The rate-of-change limit, in units per second.
+   * @param initalValue The initial value of the input.
+   * @deprecated Use SlewRateLimiter(double positiveRateLimit, double negativeRateLimit, double initalValue) instead.
    */
-  public SlewRateLimiter(double positiveRateLimit, double negativeRateLimit) {
-    this(positiveRateLimit, negativeRateLimit, 0);
+  @Deprecated(since = "2023", forRemoval = true)
+  public SlewRateLimiter(double rateLimit, double initalValue) {
+    this(rateLimit, -rateLimit, 0);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
@@ -21,9 +21,11 @@ public class SlewRateLimiter {
 
   /**
    * Constructs a SlewRateLimiter with the given positive and negative rate limits and inital value.
-   * 
-   * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per second.
-   * @param negativeRateLimit The rate-of-change limit in the negative direction, in units per second.
+   *
+   * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per
+   *     second.
+   * @param negativeRateLimit The rate-of-change limit in the negative direction, in units per
+   *     second.
    * @param initialValue The initial value of the input.
    */
   public SlewRateLimiter(double positiveRateLimit, double negativeRateLimit, double initialValue) {
@@ -36,8 +38,10 @@ public class SlewRateLimiter {
   /**
    * Creates a new SlewRateLimiter with the given positive and negative rate limits.
    *
-   * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per second.
-   * @param negativeRateLimit The rate-of-change limit in the negative direction, in units per second.
+   * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per
+   *     second.
+   * @param negativeRateLimit The rate-of-change limit in the negative direction, in units per
+   *     second.
    */
   public SlewRateLimiter(double positiveRateLimit, double negativeRateLimit) {
     this(positiveRateLimit, negativeRateLimit, 0);
@@ -62,7 +66,10 @@ public class SlewRateLimiter {
     double currentTime = WPIUtilJNI.now() * 1e-6;
     double elapsedTime = currentTime - m_prevTime;
     m_prevVal +=
-        MathUtil.clamp(input - m_prevVal, m_negativeRateLimit * elapsedTime, m_positiveRateLimit * elapsedTime);
+        MathUtil.clamp(
+            input - m_prevVal,
+            m_negativeRateLimit * elapsedTime,
+            m_positiveRateLimit * elapsedTime);
     m_prevTime = currentTime;
     return m_prevVal;
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
@@ -20,7 +20,7 @@ public class SlewRateLimiter {
   private double m_prevTime;
 
   /**
-   * Constructs a SlewRateLimiter with the given positive and negative rate limits and inital value.
+   * Creates a new SlewRateLimiter with the given positive and negative rate limit and initial value.
    *
    * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per
    *     second.

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -34,6 +34,16 @@ class SlewRateLimiter {
    */
   explicit SlewRateLimiter(Rate_t rateLimit)
       : SlewRateLimiter(rateLimit, -rateLimit) {}
+  
+  /**
+   * Creates a new SlewRateLimiter with the given rate limit and initial value.
+   *
+   * @param rateLimit The rate-of-change limit.
+   * @param initialValue The initial value of the input.
+   */
+  WPI_DEPRECATED("Use SlewRateLimiter(Rate_t positiveRateLimit, Rate_t negativeRateLimit, Unit_t initalValue) instead")
+  explicit SlewRateLimiter(Rate_t rateLimit, Unit_t initialValue = Unit_t{0})
+      : SlewRateLimiter(rateLimit, -rateLimit, initialValue) {}
 
   /**
    * Creates a new SlewRateLimiter with the given positive and negative rate
@@ -42,10 +52,10 @@ class SlewRateLimiter {
    * @param positiveRateLimit The rate-of-change limit in the positive
    * direction, in units per second.
    * @param negativeRateLimit The rate-of-change limit in the negative
-   * direction, in units per second.
+   * direction, in units per second. This is expected to be less than 0.
    * @param initialValue The initial value of the input.
    */
-  explicit SlewRateLimiter(Rate_t positiveRateLimit, Rate_t negativeRateLimit,
+  SlewRateLimiter(Rate_t positiveRateLimit, Rate_t negativeRateLimit,
                            Unit_t initialValue = Unit_t{0})
       : m_positiveRateLimit{positiveRateLimit},
         m_negativeRateLimit{negativeRateLimit},

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -28,7 +28,7 @@ class SlewRateLimiter {
   using Rate_t = units::unit_t<Rate>;
 
   /**
-   * Creates a new SlewRateLimiter with the given rate limit and initial value.
+   * Creates a new SlewRateLimiter with the given rate limit.
    *
    * @param rateLimit The rate-of-change limit.
    */
@@ -36,7 +36,7 @@ class SlewRateLimiter {
       : SlewRateLimiter(rateLimit, -rateLimit) {}
 
   /**
-   * Creates a new SlewRateLimiter with the given rate limit and initial value.
+   * Creates a new SlewRateLimiter with the given positive and negative rate limit and initial value.
    *
    * @param positiveRateLimit The rate-of-change limit in the positive
    * direction, in units per second.

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -32,16 +32,20 @@ class SlewRateLimiter {
    *
    * @param rateLimit The rate-of-change limit.
    */
-  explicit SlewRateLimiter(Rate_t rateLimit) : SlewRateLimiter(rateLimit, -rateLimit) {}
+  explicit SlewRateLimiter(Rate_t rateLimit)
+      : SlewRateLimiter(rateLimit, -rateLimit) {}
 
   /**
    * Creates a new SlewRateLimiter with the given rate limit and initial value.
    *
-   * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per second.
-   * @param negativeRateLimit The rate-of-change limit in the negative direction, in units per second.
+   * @param positiveRateLimit The rate-of-change limit in the positive
+   * direction, in units per second.
+   * @param negativeRateLimit The rate-of-change limit in the negative
+   * direction, in units per second.
    * @param initialValue The initial value of the input.
    */
-  explicit SlewRateLimiter(Rate_t positiveRateLimit, Rate_t negativeRateLimit, Unit_t initialValue = Unit_t{0})
+  explicit SlewRateLimiter(Rate_t positiveRateLimit, Rate_t negativeRateLimit,
+                           Unit_t initialValue = Unit_t{0})
       : m_positiveRateLimit{positiveRateLimit},
         m_negativeRateLimit{negativeRateLimit},
         m_prevVal{initialValue},
@@ -57,8 +61,9 @@ class SlewRateLimiter {
   Unit_t Calculate(Unit_t input) {
     units::second_t currentTime = units::microsecond_t(wpi::Now());
     units::second_t elapsedTime = currentTime - m_prevTime;
-    m_prevVal += std::clamp(input - m_prevVal, m_negativeRateLimit * elapsedTime,
-                            m_positiveRateLimit * elapsedTime);
+    m_prevVal +=
+        std::clamp(input - m_prevVal, m_negativeRateLimit * elapsedTime,
+                   m_positiveRateLimit * elapsedTime);
     m_prevTime = currentTime;
     return m_prevVal;
   }

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -33,9 +33,11 @@ class SlewRateLimiter {
    * limits and initial value.
    *
    * @param positiveRateLimit The rate-of-change limit in the positive
-   * direction, in units per second. This is expected to be positive.
+   *                          direction, in units per second. This is expected
+   *                          to be positive.
    * @param negativeRateLimit The rate-of-change limit in the negative
-   * direction, in units per second. This is expected to be negative.
+   *                          direction, in units per second. This is expected
+   *                          to be negative.
    * @param initialValue The initial value of the input.
    */
   SlewRateLimiter(Rate_t positiveRateLimit, Rate_t negativeRateLimit,

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -30,12 +30,12 @@ class SlewRateLimiter {
 
   /**
    * Creates a new SlewRateLimiter with the given positive and negative rate
-   * limit and initial value.
+   * limits and initial value.
    *
    * @param positiveRateLimit The rate-of-change limit in the positive
-   * direction, in units per second.
+   * direction, in units per second. This is expected to be positive.
    * @param negativeRateLimit The rate-of-change limit in the negative
-   * direction, in units per second. This is expected to be less than 0.
+   * direction, in units per second. This is expected to be negative.
    * @param initialValue The initial value of the input.
    */
   SlewRateLimiter(Rate_t positiveRateLimit, Rate_t negativeRateLimit,
@@ -46,7 +46,8 @@ class SlewRateLimiter {
         m_prevTime{units::microsecond_t(wpi::Now())} {}
 
   /**
-   * Creates a new SlewRateLimiter with the given rate limit.
+   * Creates a new SlewRateLimiter with the given positive rate limit and
+   * negative rate limit of -rateLimit.
    *
    * @param rateLimit The rate-of-change limit.
    */
@@ -54,7 +55,8 @@ class SlewRateLimiter {
       : SlewRateLimiter(rateLimit, -rateLimit) {}
 
   /**
-   * Creates a new SlewRateLimiter with the given rate limit and initial value.
+   * Creates a new SlewRateLimiter with the given positive rate limit and
+   * negative rate limit of -rateLimit and initial value.
    *
    * @param rateLimit The rate-of-change limit.
    * @param initialValue The initial value of the input.

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 
+#include <wpi/deprecated.h>
 #include <wpi/timestamp.h>
 
 #include "units/time.h"
@@ -28,24 +29,6 @@ class SlewRateLimiter {
   using Rate_t = units::unit_t<Rate>;
 
   /**
-   * Creates a new SlewRateLimiter with the given rate limit.
-   *
-   * @param rateLimit The rate-of-change limit.
-   */
-  explicit SlewRateLimiter(Rate_t rateLimit)
-      : SlewRateLimiter(rateLimit, -rateLimit) {}
-  
-  /**
-   * Creates a new SlewRateLimiter with the given rate limit and initial value.
-   *
-   * @param rateLimit The rate-of-change limit.
-   * @param initialValue The initial value of the input.
-   */
-  WPI_DEPRECATED("Use SlewRateLimiter(Rate_t positiveRateLimit, Rate_t negativeRateLimit, Unit_t initalValue) instead")
-  explicit SlewRateLimiter(Rate_t rateLimit, Unit_t initialValue = Unit_t{0})
-      : SlewRateLimiter(rateLimit, -rateLimit, initialValue) {}
-
-  /**
    * Creates a new SlewRateLimiter with the given positive and negative rate
    * limit and initial value.
    *
@@ -56,11 +39,31 @@ class SlewRateLimiter {
    * @param initialValue The initial value of the input.
    */
   SlewRateLimiter(Rate_t positiveRateLimit, Rate_t negativeRateLimit,
-                           Unit_t initialValue = Unit_t{0})
+                  Unit_t initialValue = Unit_t{0})
       : m_positiveRateLimit{positiveRateLimit},
         m_negativeRateLimit{negativeRateLimit},
         m_prevVal{initialValue},
         m_prevTime{units::microsecond_t(wpi::Now())} {}
+
+  /**
+   * Creates a new SlewRateLimiter with the given rate limit.
+   *
+   * @param rateLimit The rate-of-change limit.
+   */
+  explicit SlewRateLimiter(Rate_t rateLimit)
+      : SlewRateLimiter(rateLimit, -rateLimit) {}
+
+  /**
+   * Creates a new SlewRateLimiter with the given rate limit and initial value.
+   *
+   * @param rateLimit The rate-of-change limit.
+   * @param initialValue The initial value of the input.
+   */
+  WPI_DEPRECATED(
+      "Use SlewRateLimiter(Rate_t positiveRateLimit, Rate_t negativeRateLimit, "
+      "Unit_t initalValue) instead")
+  SlewRateLimiter(Rate_t rateLimit, Unit_t initialValue)
+      : SlewRateLimiter(rateLimit, -rateLimit, initialValue) {}
 
   /**
    * Filters the input to limit its slew rate.

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -36,7 +36,8 @@ class SlewRateLimiter {
       : SlewRateLimiter(rateLimit, -rateLimit) {}
 
   /**
-   * Creates a new SlewRateLimiter with the given positive and negative rate limit and initial value.
+   * Creates a new SlewRateLimiter with the given positive and negative rate
+   * limit and initial value.
    *
    * @param positiveRateLimit The rate-of-change limit in the positive
    * direction, in units per second.

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -31,10 +31,19 @@ class SlewRateLimiter {
    * Creates a new SlewRateLimiter with the given rate limit and initial value.
    *
    * @param rateLimit The rate-of-change limit.
+   */
+  explicit SlewRateLimiter(Rate_t rateLimit) : SlewRateLimiter(rateLimit, -rateLimit) {}
+
+  /**
+   * Creates a new SlewRateLimiter with the given rate limit and initial value.
+   *
+   * @param positiveRateLimit The rate-of-change limit in the positive direction, in units per second.
+   * @param negativeRateLimit The rate-of-change limit in the negative direction, in units per second.
    * @param initialValue The initial value of the input.
    */
-  explicit SlewRateLimiter(Rate_t rateLimit, Unit_t initialValue = Unit_t{0})
-      : m_rateLimit{rateLimit},
+  explicit SlewRateLimiter(Rate_t positiveRateLimit, Rate_t negativeRateLimit, Unit_t initialValue = Unit_t{0})
+      : m_positiveRateLimit{positiveRateLimit},
+        m_negativeRateLimit{negativeRateLimit},
         m_prevVal{initialValue},
         m_prevTime{units::microsecond_t(wpi::Now())} {}
 
@@ -48,8 +57,8 @@ class SlewRateLimiter {
   Unit_t Calculate(Unit_t input) {
     units::second_t currentTime = units::microsecond_t(wpi::Now());
     units::second_t elapsedTime = currentTime - m_prevTime;
-    m_prevVal += std::clamp(input - m_prevVal, -m_rateLimit * elapsedTime,
-                            m_rateLimit * elapsedTime);
+    m_prevVal += std::clamp(input - m_prevVal, m_negativeRateLimit * elapsedTime,
+                            m_positiveRateLimit * elapsedTime);
     m_prevTime = currentTime;
     return m_prevVal;
   }
@@ -66,7 +75,8 @@ class SlewRateLimiter {
   }
 
  private:
-  Rate_t m_rateLimit;
+  Rate_t m_positiveRateLimit;
+  Rate_t m_negativeRateLimit;
   Unit_t m_prevVal;
   units::second_t m_prevTime;
 };

--- a/wpimath/src/test/java/edu/wpi/first/math/filter/SlewRateLimiterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/filter/SlewRateLimiterTest.java
@@ -38,4 +38,13 @@ class SlewRateLimiterTest {
     WPIUtilJNI.setMockTime(1000000L);
     assertEquals(limiter.calculate(0.5), 0.5);
   }
+
+  @Test
+  void slewRatePositiveNegativeTest() {
+    var limiter = new SlewRateLimiter(1, -0.5);
+    WPIUtilJNI.setMockTime(1000000L);
+    assertEquals(limiter.calculate(2), 1);
+    WPIUtilJNI.setMockTime(2000000L);
+    assertEquals(limiter.calculate(0), 0.5);
+  }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/filter/SlewRateLimiterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/filter/SlewRateLimiterTest.java
@@ -41,7 +41,7 @@ class SlewRateLimiterTest {
 
   @Test
   void slewRatePositiveNegativeTest() {
-    var limiter = new SlewRateLimiter(1, -0.5);
+    var limiter = new SlewRateLimiter(1, -0.5, 0);
     WPIUtilJNI.setMockTime(1000000L);
     assertEquals(limiter.calculate(2), 1);
     WPIUtilJNI.setMockTime(2000000L);

--- a/wpimath/src/test/native/cpp/filter/SlewRateLimiterTest.cpp
+++ b/wpimath/src/test/native/cpp/filter/SlewRateLimiterTest.cpp
@@ -45,7 +45,7 @@ TEST_F(SlewRateLimiterTest, SlewRatePositveNegativeLimit) {
   now += 1_s;
 
   EXPECT_EQ(limiter.Calculate(2_m), 1_m);
-  
+
   now += 1_s;
 
   EXPECT_EQ(limiter.Calculate(0_m), 0.5_m);

--- a/wpimath/src/test/native/cpp/filter/SlewRateLimiterTest.cpp
+++ b/wpimath/src/test/native/cpp/filter/SlewRateLimiterTest.cpp
@@ -38,3 +38,15 @@ TEST_F(SlewRateLimiterTest, SlewRateNoLimit) {
 
   EXPECT_EQ(limiter.Calculate(0.5_m), 0.5_m);
 }
+
+TEST_F(SlewRateLimiterTest, SlewRatePositveNegativeLimit) {
+  frc::SlewRateLimiter<units::meters> limiter(1_mps, -0.5_mps);
+
+  now += 1_s;
+
+  EXPECT_EQ(limiter.Calculate(2_m), 1_m);
+  
+  now += 1_s;
+
+  EXPECT_EQ(limiter.Calculate(0_m), 0.5_m);
+}


### PR DESCRIPTION
Adds the option to have a separate positive and negative rate limit in the `SlewRateLimiter`. 

As of now, the change silently breaks the `SlewRateLimiter(double rateLimit, double initialValue)` constructor in favor of `SlewRateLimiter(double positiveRateLimit, double negativeRateLimit)` which to me seems like the one that would be used more often. Would a separate object (named something like `DirectionalSlewRateLimiter`) be better to avoid breaking changes? Feedback would be appreciated, particularly on the C++ constructor as I am unsure if I did that right.