### PR TITLE
[commands] Mark command group lifecycle methods as final

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelCommandGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelCommandGroup.java
@@ -54,7 +54,7 @@ public class ParallelCommandGroup extends CommandGroupBase {
   }
 
   @Override
-  public void initialize() {
+  public final void initialize() {
     for (Map.Entry<Command, Boolean> commandRunning : m_commands.entrySet()) {
       commandRunning.getKey().initialize();
       commandRunning.setValue(true);
@@ -62,7 +62,7 @@ public class ParallelCommandGroup extends CommandGroupBase {
   }
 
   @Override
-  public void execute() {
+  public final void execute() {
     for (Map.Entry<Command, Boolean> commandRunning : m_commands.entrySet()) {
       if (!commandRunning.getValue()) {
         continue;
@@ -76,7 +76,7 @@ public class ParallelCommandGroup extends CommandGroupBase {
   }
 
   @Override
-  public void end(boolean interrupted) {
+  public final void end(boolean interrupted) {
     if (interrupted) {
       for (Map.Entry<Command, Boolean> commandRunning : m_commands.entrySet()) {
         if (commandRunning.getValue()) {
@@ -87,7 +87,7 @@ public class ParallelCommandGroup extends CommandGroupBase {
   }
 
   @Override
-  public boolean isFinished() {
+  public final boolean isFinished() {
     return !m_commands.containsValue(true);
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelDeadlineGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelDeadlineGroup.java
@@ -76,7 +76,7 @@ public class ParallelDeadlineGroup extends CommandGroupBase {
   }
 
   @Override
-  public void initialize() {
+  public final void initialize() {
     for (Map.Entry<Command, Boolean> commandRunning : m_commands.entrySet()) {
       commandRunning.getKey().initialize();
       commandRunning.setValue(true);
@@ -85,7 +85,7 @@ public class ParallelDeadlineGroup extends CommandGroupBase {
   }
 
   @Override
-  public void execute() {
+  public final void execute() {
     for (Map.Entry<Command, Boolean> commandRunning : m_commands.entrySet()) {
       if (!commandRunning.getValue()) {
         continue;
@@ -102,7 +102,7 @@ public class ParallelDeadlineGroup extends CommandGroupBase {
   }
 
   @Override
-  public void end(boolean interrupted) {
+  public final void end(boolean interrupted) {
     for (Map.Entry<Command, Boolean> commandRunning : m_commands.entrySet()) {
       if (commandRunning.getValue()) {
         commandRunning.getKey().end(true);
@@ -111,7 +111,7 @@ public class ParallelDeadlineGroup extends CommandGroupBase {
   }
 
   @Override
-  public boolean isFinished() {
+  public final boolean isFinished() {
     return m_finished;
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelRaceGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelRaceGroup.java
@@ -55,7 +55,7 @@ public class ParallelRaceGroup extends CommandGroupBase {
   }
 
   @Override
-  public void initialize() {
+  public final void initialize() {
     m_finished = false;
     for (Command command : m_commands) {
       command.initialize();
@@ -63,7 +63,7 @@ public class ParallelRaceGroup extends CommandGroupBase {
   }
 
   @Override
-  public void execute() {
+  public final void execute() {
     for (Command command : m_commands) {
       command.execute();
       if (command.isFinished()) {
@@ -73,14 +73,14 @@ public class ParallelRaceGroup extends CommandGroupBase {
   }
 
   @Override
-  public void end(boolean interrupted) {
+  public final void end(boolean interrupted) {
     for (Command command : m_commands) {
       command.end(!command.isFinished());
     }
   }
 
   @Override
-  public boolean isFinished() {
+  public final boolean isFinished() {
     return m_finished;
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SequentialCommandGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SequentialCommandGroup.java
@@ -48,7 +48,7 @@ public class SequentialCommandGroup extends CommandGroupBase {
   }
 
   @Override
-  public void initialize() {
+  public final void initialize() {
     m_currentCommandIndex = 0;
 
     if (!m_commands.isEmpty()) {
@@ -57,7 +57,7 @@ public class SequentialCommandGroup extends CommandGroupBase {
   }
 
   @Override
-  public void execute() {
+  public final void execute() {
     if (m_commands.isEmpty()) {
       return;
     }
@@ -75,7 +75,7 @@ public class SequentialCommandGroup extends CommandGroupBase {
   }
 
   @Override
-  public void end(boolean interrupted) {
+  public final void end(boolean interrupted) {
     if (interrupted
         && !m_commands.isEmpty()
         && m_currentCommandIndex > -1
@@ -86,7 +86,7 @@ public class SequentialCommandGroup extends CommandGroupBase {
   }
 
   @Override
-  public boolean isFinished() {
+  public final boolean isFinished() {
     return m_currentCommandIndex == m_commands.size();
   }
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ParallelCommandGroup.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ParallelCommandGroup.h
@@ -74,13 +74,13 @@ class ParallelCommandGroup
     AddCommands(std::move(foo));
   }
 
-  void Initialize() final override;
+  void Initialize() final;
 
-  void Execute() final override;
+  void Execute() final;
 
-  void End(bool interrupted) final override;
+  void End(bool interrupted) final;
 
-  bool IsFinished() final override;
+  bool IsFinished() final;
 
   bool RunsWhenDisabled() const override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ParallelCommandGroup.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ParallelCommandGroup.h
@@ -74,13 +74,13 @@ class ParallelCommandGroup
     AddCommands(std::move(foo));
   }
 
-  void Initialize() final;
+  void Initialize() final override;
 
-  void Execute() final;
+  void Execute() final override;
 
-  void End(bool interrupted) final;
+  void End(bool interrupted) final override;
 
-  bool IsFinished() final;
+  bool IsFinished() final override;
 
   bool RunsWhenDisabled() const override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ParallelCommandGroup.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ParallelCommandGroup.h
@@ -74,13 +74,13 @@ class ParallelCommandGroup
     AddCommands(std::move(foo));
   }
 
-  void Initialize() override;
+  void Initialize() final;
 
-  void Execute() override;
+  void Execute() final;
 
-  void End(bool interrupted) override;
+  void End(bool interrupted) final;
 
-  bool IsFinished() override;
+  bool IsFinished() final;
 
   bool RunsWhenDisabled() const override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
@@ -82,13 +82,13 @@ class ParallelDeadlineGroup
     AddCommands(std::move(foo));
   }
 
-  void Initialize() final override;
+  void Initialize() final;
 
-  void Execute() final override;
+  void Execute() final;
 
-  void End(bool interrupted) final override;
+  void End(bool interrupted) final;
 
-  bool IsFinished() final override;
+  bool IsFinished() final;
 
   bool RunsWhenDisabled() const override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
@@ -82,13 +82,13 @@ class ParallelDeadlineGroup
     AddCommands(std::move(foo));
   }
 
-  void Initialize() override;
+  void Initialize() final;
 
-  void Execute() override;
+  void Execute() final;
 
-  void End(bool interrupted) override;
+  void End(bool interrupted) final;
 
-  bool IsFinished() override;
+  bool IsFinished() final;
 
   bool RunsWhenDisabled() const override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ParallelDeadlineGroup.h
@@ -82,13 +82,13 @@ class ParallelDeadlineGroup
     AddCommands(std::move(foo));
   }
 
-  void Initialize() final;
+  void Initialize() final override;
 
-  void Execute() final;
+  void Execute() final override;
 
-  void End(bool interrupted) final;
+  void End(bool interrupted) final override;
 
-  bool IsFinished() final;
+  bool IsFinished() final override;
 
   bool RunsWhenDisabled() const override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ParallelRaceGroup.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ParallelRaceGroup.h
@@ -62,13 +62,13 @@ class ParallelRaceGroup
     AddCommands(std::move(foo));
   }
 
-  void Initialize() override;
+  void Initialize() final;
 
-  void Execute() override;
+  void Execute() final;
 
-  void End(bool interrupted) override;
+  void End(bool interrupted) final;
 
-  bool IsFinished() override;
+  bool IsFinished() final;
 
   bool RunsWhenDisabled() const override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ParallelRaceGroup.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ParallelRaceGroup.h
@@ -62,13 +62,13 @@ class ParallelRaceGroup
     AddCommands(std::move(foo));
   }
 
-  void Initialize() final;
+  void Initialize() final override;
 
-  void Execute() final;
+  void Execute() final override;
 
-  void End(bool interrupted) final;
+  void End(bool interrupted) final override;
 
-  bool IsFinished() final;
+  bool IsFinished() final override;
 
   bool RunsWhenDisabled() const override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ParallelRaceGroup.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ParallelRaceGroup.h
@@ -62,13 +62,13 @@ class ParallelRaceGroup
     AddCommands(std::move(foo));
   }
 
-  void Initialize() final override;
+  void Initialize() final;
 
-  void Execute() final override;
+  void Execute() final;
 
-  void End(bool interrupted) final override;
+  void End(bool interrupted) final;
 
-  bool IsFinished() final override;
+  bool IsFinished() final;
 
   bool RunsWhenDisabled() const override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SequentialCommandGroup.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SequentialCommandGroup.h
@@ -78,13 +78,13 @@ class SequentialCommandGroup
     AddCommands(std::move(foo));
   }
 
-  void Initialize() override;
+  void Initialize() final;
 
-  void Execute() override;
+  void Execute() final;
 
-  void End(bool interrupted) override;
+  void End(bool interrupted) final;
 
-  bool IsFinished() override;
+  bool IsFinished() final;
 
   bool RunsWhenDisabled() const override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SequentialCommandGroup.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SequentialCommandGroup.h
@@ -78,13 +78,13 @@ class SequentialCommandGroup
     AddCommands(std::move(foo));
   }
 
-  void Initialize() final override;
+  void Initialize() final;
 
-  void Execute() final override;
+  void Execute() final;
 
-  void End(bool interrupted) final override;
+  void End(bool interrupted) final;
 
-  bool IsFinished() final override;
+  bool IsFinished() final;
 
   bool RunsWhenDisabled() const override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SequentialCommandGroup.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SequentialCommandGroup.h
@@ -78,13 +78,13 @@ class SequentialCommandGroup
     AddCommands(std::move(foo));
   }
 
-  void Initialize() final;
+  void Initialize() final override;
 
-  void Execute() final;
+  void Execute() final override;
 
-  void End(bool interrupted) final;
+  void End(bool interrupted) final override;
 
-  bool IsFinished() final;
+  bool IsFinished() final override;
 
   bool RunsWhenDisabled() const override;
 


### PR DESCRIPTION
Piecemeal replacement of #3608 in an attempt to advance #3536.