### PR TITLE
Fix up DIO pulse API

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/DIOJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/DIOJNI.java
@@ -22,7 +22,9 @@ public class DIOJNI extends JNIWrapper {
 
   public static native boolean getDIODirection(int dioPortHandle);
 
-  public static native void pulse(int dioPortHandle, double pulseLength);
+  public static native void pulse(int dioPortHandle, int pulseLengthMicroseconds);
+
+  public static native void pulseMultiple(long channelMask, int pulseLengthMicroseconds);
 
   public static native boolean isPulsing(int dioPortHandle);
 

--- a/hal/src/main/native/cpp/jni/DIOJNI.cpp
+++ b/hal/src/main/native/cpp/jni/DIOJNI.cpp
@@ -133,14 +133,28 @@ Java_edu_wpi_first_hal_DIOJNI_getDIODirection
 /*
  * Class:     edu_wpi_first_hal_DIOJNI
  * Method:    pulse
- * Signature: (ID)V
+ * Signature: (II)V
  */
 JNIEXPORT void JNICALL
 Java_edu_wpi_first_hal_DIOJNI_pulse
-  (JNIEnv* env, jclass, jint id, jdouble value)
+  (JNIEnv* env, jclass, jint id, jint value)
 {
   int32_t status = 0;
   HAL_Pulse((HAL_DigitalHandle)id, value, &status);
+  CheckStatus(env, status);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_DIOJNI
+ * Method:    pulseMultiple
+ * Signature: (JI)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_DIOJNI_pulseMultiple
+  (JNIEnv* env, jclass, jlong channelMask, jint value)
+{
+  int32_t status = 0;
+  HAL_PulseMultiple(static_cast<uint32_t>(channelMask), value, &status);
   CheckStatus(env, status);
 }
 

--- a/hal/src/main/native/include/hal/DIO.h
+++ b/hal/src/main/native/include/hal/DIO.h
@@ -150,11 +150,26 @@ HAL_Bool HAL_GetDIODirection(HAL_DigitalHandle dioPortHandle, int32_t* status);
  * single pulse going at any time.
  *
  * @param[in] dioPortHandle the digital port handle
- * @param[in] pulseLength   the active length of the pulse (in seconds)
+ * @param[in] pulseLengthMicroseconds   the active length of the pulse (in
+ * microseconds)
  * @param[out] status       Error status variable. 0 on success.
  */
-void HAL_Pulse(HAL_DigitalHandle dioPortHandle, double pulseLength,
+void HAL_Pulse(HAL_DigitalHandle dioPortHandle, int32_t pulseLengthMicroseconds,
                int32_t* status);
+
+/**
+ * Generates a single digital pulse on multiple channels.
+ *
+ * Write a pulse to the channels enabled by the mask. There can only be a
+ * single pulse going at any time.
+ *
+ * @param[in] channelMask the channel mask
+ * @param[in] pulseLengthMicroseconds   the active length of the pulse (in
+ * microseconds)
+ * @param[out] status       Error status variable. 0 on success.
+ */
+void HAL_PulseMultiple(uint32_t channelMask, int32_t pulseLengthMicroseconds,
+                       int32_t* status);
 
 /**
  * Checks a DIO line to see if it is currently generating a pulse.

--- a/hal/src/main/native/sim/DIO.cpp
+++ b/hal/src/main/native/sim/DIO.cpp
@@ -225,13 +225,18 @@ HAL_Bool HAL_GetDIODirection(HAL_DigitalHandle dioPortHandle, int32_t* status) {
   return value;
 }
 
-void HAL_Pulse(HAL_DigitalHandle dioPortHandle, double pulseLength,
+void HAL_Pulse(HAL_DigitalHandle dioPortHandle, int32_t pulseLengthMicroseconds,
                int32_t* status) {
   auto port = digitalChannelHandles->Get(dioPortHandle, HAL_HandleEnum::DIO);
   if (port == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return;
   }
+  // TODO (Thad) Add this
+}
+
+void HAL_PulseMultiple(uint32_t channelMask, int32_t pulseLengthMicroseconds,
+               int32_t* status) {
   // TODO (Thad) Add this
 }
 

--- a/wpilibc/src/main/native/cpp/DigitalOutput.cpp
+++ b/wpilibc/src/main/native/cpp/DigitalOutput.cpp
@@ -76,9 +76,9 @@ int DigitalOutput::GetChannel() const {
   return m_channel;
 }
 
-void DigitalOutput::Pulse(double length) {
+void DigitalOutput::Pulse(units::microsecond_t pulseLength) {
   int32_t status = 0;
-  HAL_Pulse(m_handle, length, &status);
+  HAL_Pulse(m_handle, pulseLength.to<int32_t>(), &status);
   FRC_CheckErrorStatus(status, "Channel {}", m_channel);
 }
 

--- a/wpilibc/src/main/native/include/frc/DigitalOutput.h
+++ b/wpilibc/src/main/native/include/frc/DigitalOutput.h
@@ -9,6 +9,7 @@
 #include <wpi/sendable/SendableHelper.h>
 
 #include "frc/DigitalSource.h"
+#include "units/time.h"
 
 namespace frc {
 
@@ -79,11 +80,11 @@ class DigitalOutput : public DigitalSource,
    * Output a single pulse on the digital output line.
    *
    * Send a single pulse on the digital output line where the pulse duration is
-   * specified in seconds. Maximum pulse length is 0.0016 seconds.
+   * specified in microseconds. Maximum of 65535 microseconds
    *
-   * @param length The pulse length in seconds
+   * @param pulseLength The pulse length in microseconds
    */
-  void Pulse(double length);
+  void Pulse(units::microsecond_t pulseLength);
 
   /**
    * Determine if the pulse is still going.

--- a/wpilibc/src/main/native/include/frc/Ultrasonic.h
+++ b/wpilibc/src/main/native/include/frc/Ultrasonic.h
@@ -164,8 +164,8 @@ class Ultrasonic : public wpi::Sendable,
    */
   static void UltrasonicChecker();
 
-  // Time (sec) for the ping trigger pulse.
-  static constexpr double kPingTime = 10 * 1e-6;
+  // Time (usec) for the ping trigger pulse.
+  static constexpr auto kPingTime = 10_us;
 
   // Max time (ms) between readings.
   static constexpr auto kMaxUltrasonicTime = 0.1_s;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalOutput.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DigitalOutput.java
@@ -80,12 +80,15 @@ public class DigitalOutput extends DigitalSource implements Sendable {
   }
 
   /**
-   * Generate a single pulse. There can only be a single pulse going at any time.
+   * Output a single pulse on the digital output line.
    *
-   * @param pulseLength The length of the pulse.
+   * <p>Send a single pulse on the digital output line where the pulse duration is
+   * specified in microseconds. Maximum of 65535 microseconds
+   *
+   * @param pulseLengthMicroseconds The pulse length in microseconds
    */
-  public void pulse(final double pulseLength) {
-    DIOJNI.pulse(m_handle, pulseLength);
+  public void pulse(final int pulseLengthMicroseconds) {
+    DIOJNI.pulse(m_handle, pulseLengthMicroseconds);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Ultrasonic.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Ultrasonic.java
@@ -28,8 +28,8 @@ import java.util.List;
  * flight).
  */
 public class Ultrasonic implements Sendable, AutoCloseable {
-  // Time (sec) for the ping trigger pulse.
-  private static final double kPingTime = 10 * 1e-6;
+  // Time (usec) for the ping trigger pulse.
+  private static final int kPingTime = 10;
   private static final double kSpeedOfSoundInchesPerSec = 1130.0 * 12.0;
   // ultrasonic sensor list
   private static final List<Ultrasonic> m_sensors = new ArrayList<>();


### PR DESCRIPTION
Turns out that the FPGA API takes microseconds directly, instead of a weird scaled value. Update the API and docs. Also add a new HAL level API to trigger multiple DIOs with the same pulse at once.

Closes #4331 