### PR TITLE
Resistance to CAN Bus disconnect on REVPH

### DIFF
--- a/hal/src/main/native/athena/CTREPCM.cpp
+++ b/hal/src/main/native/athena/CTREPCM.cpp
@@ -233,9 +233,11 @@ void HAL_SetCTREPCMClosedLoopControl(HAL_CTREPCMHandle handle, HAL_Bool enabled,
     return;
   }
 
+  int32_t can_status = 0;
+
   std::scoped_lock lock{pcm->lock};
   pcm->control.bits.closedLoopEnable = enabled ? 1 : 0;
-  SendControl(pcm.get(), status);
+  SendControl(pcm.get(), &can_status);
 }
 
 HAL_Bool HAL_GetCTREPCMClosedLoopControl(HAL_CTREPCMHandle handle,

--- a/hal/src/main/native/athena/REVPH.cpp
+++ b/hal/src/main/native/athena/REVPH.cpp
@@ -229,18 +229,18 @@ HAL_REVPHHandle HAL_InitializeREVPH(int32_t module,
   std::memset(&hph->versionInfo, 0, sizeof(hph->versionInfo));
 
   // Start closed-loop compressor control by starting solenoid state updates
-  HAL_SendREVPHSolenoidsState(hph.get(), status);
+  int32_t can_status = 0;
+  HAL_SendREVPHSolenoidsState(hph.get(), &can_status);
 
   return handle;
 }
 
 void HAL_FreeREVPH(HAL_REVPHHandle handle) {
   auto hph = REVPHHandles->Get(handle);
-  if (hph == nullptr) {
-    return;
+  if (hph) {
+    HAL_CleanCAN(hph->hcan);
   }
 
-  HAL_CleanCAN(hph->hcan);
 
   REVPHHandles->Free(handle);
 }


### PR DESCRIPTION
Force the status to be 0 (no error) upon initialization of the REV Pneumatic Hub in case of robot code restart and no CAN Bus present preventing a program crash.