### PR TITLE
[ci] Fix comment-command action not running runners

### DIFF
--- a/.github/workflows/comment-command.yml
+++ b/.github/workflows/comment-command.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           gh pr checkout $NUMBER
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.COMMENT_COMMAND_PAT_TOKEN }}"
           NUMBER: ${{ github.event.issue.number }}
       - name: Set up Python 3.8
         uses: actions/setup-python@v2


### PR DESCRIPTION
Triggering runners from a push from a runner requires use of a PAT.
https://stackoverflow.com/questions/67550727/push-event-doesnt-trigger-workflow-on-push-paths-github-actions