### PR TITLE
Revert "[commands] Change grouping decorator impl to flatten nested g…

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/EndlessCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/EndlessCommand.java
@@ -52,9 +52,4 @@ public class EndlessCommand extends CommandBase {
   public boolean runsWhenDisabled() {
     return m_command.runsWhenDisabled();
   }
-
-  @Override
-  public EndlessCommand endlessly() {
-    return this;
-  }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelCommandGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelCommandGroup.java
@@ -95,10 +95,4 @@ public class ParallelCommandGroup extends CommandGroupBase {
   public boolean runsWhenDisabled() {
     return m_runWhenDisabled;
   }
-
-  @Override
-  public ParallelCommandGroup alongWith(Command... parallel) {
-    addCommands(parallel);
-    return this;
-  }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelDeadlineGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelDeadlineGroup.java
@@ -119,10 +119,4 @@ public class ParallelDeadlineGroup extends CommandGroupBase {
   public boolean runsWhenDisabled() {
     return m_runWhenDisabled;
   }
-
-  @Override
-  public ParallelDeadlineGroup deadlineWith(Command... parallel) {
-    addCommands(parallel);
-    return this;
-  }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelRaceGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelRaceGroup.java
@@ -88,10 +88,4 @@ public class ParallelRaceGroup extends CommandGroupBase {
   public boolean runsWhenDisabled() {
     return m_runWhenDisabled;
   }
-
-  @Override
-  public ParallelRaceGroup raceWith(Command... parallel) {
-    addCommands(parallel);
-    return this;
-  }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/PerpetualCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/PerpetualCommand.java
@@ -55,10 +55,4 @@ public class PerpetualCommand extends CommandBase {
   public boolean runsWhenDisabled() {
     return m_command.runsWhenDisabled();
   }
-
-  @SuppressWarnings("removal") // Command.perpetually()
-  @Override
-  public PerpetualCommand perpetually() {
-    return this;
-  }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RepeatCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RepeatCommand.java
@@ -62,9 +62,4 @@ public class RepeatCommand extends CommandBase {
   public boolean runsWhenDisabled() {
     return m_command.runsWhenDisabled();
   }
-
-  @Override
-  public RepeatCommand repeatedly() {
-    return this;
-  }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SequentialCommandGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SequentialCommandGroup.java
@@ -94,28 +94,4 @@ public class SequentialCommandGroup extends CommandGroupBase {
   public boolean runsWhenDisabled() {
     return m_runWhenDisabled;
   }
-
-  @Override
-  public SequentialCommandGroup beforeStarting(Command before) {
-    // store all the commands
-    var commands = new ArrayList<Command>();
-    commands.add(before);
-    commands.addAll(m_commands);
-
-    // reset current state
-    commands.forEach(CommandGroupBase::clearGroupedCommand);
-    m_commands.clear();
-    m_requirements.clear();
-    m_runWhenDisabled = true;
-
-    // add them back
-    addCommands(commands.toArray(Command[]::new));
-    return this;
-  }
-
-  @Override
-  public SequentialCommandGroup andThen(Command... next) {
-    addCommands(next);
-    return this;
-  }
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/EndlessCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/EndlessCommand.cpp
@@ -26,7 +26,3 @@ void EndlessCommand::Execute() {
 void EndlessCommand::End(bool interrupted) {
   m_command->End(interrupted);
 }
-
-EndlessCommand EndlessCommand::Endlessly() && {
-  return std::move(*this);
-}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/PerpetualCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/PerpetualCommand.cpp
@@ -26,7 +26,3 @@ void PerpetualCommand::Execute() {
 void PerpetualCommand::End(bool interrupted) {
   m_command->End(interrupted);
 }
-
-PerpetualCommand PerpetualCommand::Perpetually() && {
-  return std::move(*this);
-}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/RepeatCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/RepeatCommand.cpp
@@ -39,7 +39,3 @@ void RepeatCommand::End(bool interrupted) {
 bool RepeatCommand::RunsWhenDisabled() const {
   return m_command->RunsWhenDisabled();
 }
-
-RepeatCommand RepeatCommand::Repeatedly() && {
-  return std::move(*this);
-}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/SequentialCommandGroup.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/SequentialCommandGroup.cpp
@@ -4,8 +4,6 @@
 
 #include "frc2/command/SequentialCommandGroup.h"
 
-#include "frc2/command/InstantCommand.h"
-
 using namespace frc2;
 
 SequentialCommandGroup::SequentialCommandGroup(
@@ -73,34 +71,4 @@ void SequentialCommandGroup::AddCommands(
     m_runWhenDisabled &= command->RunsWhenDisabled();
     m_commands.emplace_back(std::move(command));
   }
-}
-
-SequentialCommandGroup SequentialCommandGroup::BeforeStarting(
-    std::function<void()> toRun, wpi::span<Subsystem* const> requirements) && {
-  // store all the commands
-  std::vector<std::unique_ptr<Command>> tmp;
-  tmp.emplace_back(
-      std::make_unique<InstantCommand>(std::move(toRun), requirements));
-  for (auto&& command : m_commands) {
-    command->SetGrouped(false);
-    tmp.emplace_back(std::move(command));
-  }
-
-  // reset current state
-  m_commands.clear();
-  m_requirements.clear();
-  m_runWhenDisabled = true;
-
-  // add the commands back
-  AddCommands(std::move(tmp));
-  return std::move(*this);
-}
-
-SequentialCommandGroup SequentialCommandGroup::AndThen(
-    std::function<void()> toRun, wpi::span<Subsystem* const> requirements) && {
-  std::vector<std::unique_ptr<Command>> tmp;
-  tmp.emplace_back(
-      std::make_unique<InstantCommand>(std::move(toRun), requirements));
-  AddCommands(std::move(tmp));
-  return std::move(*this);
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -130,7 +130,7 @@ class Command {
    * @param duration the timeout duration
    * @return the command with the timeout added
    */
-  virtual ParallelRaceGroup WithTimeout(units::second_t duration) &&;
+  ParallelRaceGroup WithTimeout(units::second_t duration) &&;
 
   /**
    * Decorates this command with an interrupt condition.  If the specified
@@ -141,7 +141,7 @@ class Command {
    * @param condition the interrupt condition
    * @return the command with the interrupt condition added
    */
-  virtual ParallelRaceGroup Until(std::function<bool()> condition) &&;
+  ParallelRaceGroup Until(std::function<bool()> condition) &&;
 
   /**
    * Decorates this command with an interrupt condition.  If the specified
@@ -152,7 +152,7 @@ class Command {
    * @param condition the interrupt condition
    * @return the command with the interrupt condition added
    */
-  virtual ParallelRaceGroup WithInterrupt(std::function<bool()> condition) &&;
+  ParallelRaceGroup WithInterrupt(std::function<bool()> condition) &&;
 
   /**
    * Decorates this command with a runnable to run before this command starts.
@@ -161,7 +161,7 @@ class Command {
    * @param requirements the required subsystems
    * @return the decorated command
    */
-  virtual SequentialCommandGroup BeforeStarting(
+  SequentialCommandGroup BeforeStarting(
       std::function<void()> toRun,
       std::initializer_list<Subsystem*> requirements) &&;
 
@@ -172,7 +172,7 @@ class Command {
    * @param requirements the required subsystems
    * @return the decorated command
    */
-  virtual SequentialCommandGroup BeforeStarting(
+  SequentialCommandGroup BeforeStarting(
       std::function<void()> toRun,
       wpi::span<Subsystem* const> requirements = {}) &&;
 
@@ -183,7 +183,7 @@ class Command {
    * @param requirements the required subsystems
    * @return the decorated command
    */
-  virtual SequentialCommandGroup AndThen(
+  SequentialCommandGroup AndThen(
       std::function<void()> toRun,
       std::initializer_list<Subsystem*> requirements) &&;
 
@@ -194,7 +194,7 @@ class Command {
    * @param requirements the required subsystems
    * @return the decorated command
    */
-  virtual SequentialCommandGroup AndThen(
+  SequentialCommandGroup AndThen(
       std::function<void()> toRun,
       wpi::span<Subsystem* const> requirements = {}) &&;
 
@@ -206,7 +206,7 @@ class Command {
    * @deprecated replace with EndlessCommand
    */
   WPI_DEPRECATED("Replace with Endlessly()")
-  virtual PerpetualCommand Perpetually() &&;
+  PerpetualCommand Perpetually() &&;
 
   /**
    * Decorates this command to run endlessly, ignoring its ordinary end
@@ -214,7 +214,7 @@ class Command {
    *
    * @return the decorated command
    */
-  virtual EndlessCommand Endlessly() &&;
+  EndlessCommand Endlessly() &&;
 
   /**
    * Decorates this command to run repeatedly, restarting it when it ends, until
@@ -222,7 +222,7 @@ class Command {
    *
    * @return the decorated command
    */
-  virtual RepeatCommand Repeatedly() &&;
+  RepeatCommand Repeatedly() &&;
 
   /**
    * Decorates this command to run "by proxy" by wrapping it in a
@@ -232,7 +232,7 @@ class Command {
    *
    * @return the decorated command
    */
-  virtual ProxyScheduleCommand AsProxy();
+  ProxyScheduleCommand AsProxy();
 
   /**
    * Decorates this command to only run if this condition is not met. If the
@@ -243,7 +243,7 @@ class Command {
    * @param condition the condition that will prevent the command from running
    * @return the decorated command
    */
-  virtual ConditionalCommand Unless(std::function<bool()> condition) &&;
+  ConditionalCommand Unless(std::function<bool()> condition) &&;
 
   /**
    * Decorates this command to run or stop when disabled.
@@ -251,7 +251,7 @@ class Command {
    * @param doesRunWhenDisabled true to run when disabled.
    * @return the decorated command
    */
-  virtual std::unique_ptr<Command> IgnoringDisable(bool doesRunWhenDisabled) &&;
+  std::unique_ptr<Command> IgnoringDisable(bool doesRunWhenDisabled) &&;
 
   /**
    * Decorates this command to run or stop when disabled.
@@ -259,7 +259,7 @@ class Command {
    * @param interruptBehavior true to run when disabled.
    * @return the decorated command
    */
-  virtual std::unique_ptr<Command> WithInterruptBehavior(
+  std::unique_ptr<Command> WithInterruptBehavior(
       InterruptionBehavior interruptBehavior) &&;
 
   /**

--- a/wpilibNewCommands/src/main/native/include/frc2/command/EndlessCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/EndlessCommand.h
@@ -67,8 +67,6 @@ class EndlessCommand : public CommandHelper<CommandBase, EndlessCommand> {
 
   void End(bool interrupted) override;
 
-  EndlessCommand Endlessly() && override;
-
  private:
   std::unique_ptr<Command> m_command;
 };

--- a/wpilibNewCommands/src/main/native/include/frc2/command/PerpetualCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/PerpetualCommand.h
@@ -73,8 +73,6 @@ class PerpetualCommand : public CommandHelper<CommandBase, PerpetualCommand> {
 
   void End(bool interrupted) override;
 
-  PerpetualCommand Perpetually() && override;
-
  private:
   std::unique_ptr<Command> m_command;
 };

--- a/wpilibNewCommands/src/main/native/include/frc2/command/RepeatCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/RepeatCommand.h
@@ -69,8 +69,6 @@ class RepeatCommand : public CommandHelper<CommandBase, RepeatCommand> {
 
   bool RunsWhenDisabled() const override;
 
-  RepeatCommand Repeatedly() && override;
-
  private:
   std::unique_ptr<Command> m_command;
 };

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SequentialCommandGroup.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SequentialCommandGroup.h
@@ -15,8 +15,6 @@
 #include <utility>
 #include <vector>
 
-#include <wpi/span.h>
-
 #include "frc2/command/CommandGroupBase.h"
 #include "frc2/command/CommandHelper.h"
 
@@ -87,16 +85,6 @@ class SequentialCommandGroup
   bool IsFinished() final;
 
   bool RunsWhenDisabled() const override;
-
-  SequentialCommandGroup BeforeStarting(
-      std::function<void()> toRun,
-      wpi::span<Subsystem* const> requirements = {}) &&
-      override;
-
-  SequentialCommandGroup AndThen(
-      std::function<void()> toRun,
-      wpi::span<Subsystem* const> requirements = {}) &&
-      override;
 
  private:
   void AddCommands(std::vector<std::unique_ptr<Command>>&& commands) final;


### PR DESCRIPTION
This special-casing was rarely encountered, and in hindsight, the few reduced allocations caused negligible improvements in Java and negatively affected C++ (due to vtable lookups).
Removing these special-case overrides will simplify #4319 and any spec we might want to write in the future.