### PR TITLE
[wpilib] MotorControllerGroup: Override setVoltage

### DIFF
--- a/wpilibc/src/main/native/cpp/motorcontrol/MotorControllerGroup.cpp
+++ b/wpilibc/src/main/native/cpp/motorcontrol/MotorControllerGroup.cpp
@@ -33,6 +33,12 @@ void MotorControllerGroup::Set(double speed) {
   }
 }
 
+void MotorControllerGroup::SetVoltage(units::volt_t output) {
+  for (auto motorController : m_motorControllers) {
+    motorController.get().SetVoltage(m_isInverted ? -output : output);
+  }
+}
+
 double MotorControllerGroup::Get() const {
   if (!m_motorControllers.empty()) {
     return m_motorControllers.front().get().Get() * (m_isInverted ? -1 : 1);

--- a/wpilibc/src/main/native/include/frc/motorcontrol/MotorControllerGroup.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/MotorControllerGroup.h
@@ -31,6 +31,7 @@ class MotorControllerGroup : public wpi::Sendable,
   MotorControllerGroup& operator=(MotorControllerGroup&&) = default;
 
   void Set(double speed) override;
+  void SetVoltage(units::volt_t output) override;
   double Get() const override;
   void SetInverted(bool isInverted) override;
   bool GetInverted() const override;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/MotorControllerGroup.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/MotorControllerGroup.java
@@ -55,6 +55,13 @@ public class MotorControllerGroup implements MotorController, Sendable, AutoClos
   }
 
   @Override
+  public void setVoltage(double outputVolts) {
+    for (MotorController motorController : m_motorControllers) {
+      motorController.setVoltage(m_isInverted ? -outputVolts : outputVolts);
+    }
+  }
+
+  @Override
   public double get() {
     if (m_motorControllers.length > 0) {
       return m_motorControllers[0].get() * (m_isInverted ? -1 : 1);


### PR DESCRIPTION
This causes setVoltage to be called on the lower level motor contollers,
which is benefical in cases when they are smart motor controllers.
Previously, the default implementation (using the bus voltage and
calling set()) was used in this case.

This does slightly pessimize the case when the lower level motor
controllers use the default setVoltage implementation, but given the
prevalence of smart motor controllers, this seems like an overall win.