### PR TITLE
[commands] Add owning overload to ProxyScheduleCommand

### DIFF
--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyScheduleCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyScheduleCommand.cpp
@@ -15,8 +15,9 @@ ProxyScheduleCommand::ProxyScheduleCommand(Command* toSchedule) {
   SetInsert(m_toSchedule, {&toSchedule, 1});
 }
 
-ProxyScheduleCommand::ProxyScheduleCommand(std::unique_ptr<Command>&& toSchedule)
-                : m_owning(std::move(toSchedule)) {
+ProxyScheduleCommand::ProxyScheduleCommand(
+    std::unique_ptr<Command>&& toSchedule)
+    : m_owning(std::move(toSchedule)) {
   Command* ptr = m_owning.get();
   SetInsert(m_toSchedule, {&ptr, 1});
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyScheduleCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/ProxyScheduleCommand.cpp
@@ -15,6 +15,12 @@ ProxyScheduleCommand::ProxyScheduleCommand(Command* toSchedule) {
   SetInsert(m_toSchedule, {&toSchedule, 1});
 }
 
+ProxyScheduleCommand::ProxyScheduleCommand(std::unique_ptr<Command>&& toSchedule)
+                : m_owning(std::move(toSchedule)) {
+  Command* ptr = m_owning.get();
+  SetInsert(m_toSchedule, {&ptr, 1});
+}
+
 void ProxyScheduleCommand::Initialize() {
   for (auto* command : m_toSchedule) {
     command->Schedule();

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ProxyScheduleCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ProxyScheduleCommand.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <wpi/SmallVector.h>
 #include <wpi/span.h>
 
@@ -33,6 +35,17 @@ class ProxyScheduleCommand
 
   explicit ProxyScheduleCommand(Command* toSchedule);
 
+  /**
+   * Creates a new ProxyScheduleCommand that schedules the given commands when
+   * initialized, and ends when they are all no longer scheduled.
+   *
+   * <p>Note that this constructor passes ownership of the given command to the returned
+   * ProxyScheduleCommand.
+   *
+   * @param toSchedule the commands to schedule
+   */
+  explicit ProxyScheduleCommand(std::unique_ptr<Command>&& toSchedule);
+
   ProxyScheduleCommand(ProxyScheduleCommand&& other) = default;
 
   ProxyScheduleCommand(const ProxyScheduleCommand& other) = default;
@@ -47,6 +60,7 @@ class ProxyScheduleCommand
 
  private:
   wpi::SmallVector<Command*, 4> m_toSchedule;
+  std::unique_ptr<Command> m_owning;
   bool m_finished{false};
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ProxyScheduleCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ProxyScheduleCommand.h
@@ -48,8 +48,6 @@ class ProxyScheduleCommand
 
   ProxyScheduleCommand(ProxyScheduleCommand&& other) = default;
 
-  ProxyScheduleCommand(const ProxyScheduleCommand& other) = default;
-
   void Initialize() override;
 
   void End(bool interrupted) override;

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ProxyScheduleCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ProxyScheduleCommand.h
@@ -36,13 +36,13 @@ class ProxyScheduleCommand
   explicit ProxyScheduleCommand(Command* toSchedule);
 
   /**
-   * Creates a new ProxyScheduleCommand that schedules the given commands when
-   * initialized, and ends when they are all no longer scheduled.
+   * Creates a new ProxyScheduleCommand that schedules the given command when
+   * initialized, and ends when it is no longer scheduled.
    *
    * <p>Note that this constructor passes ownership of the given command to the
    * returned ProxyScheduleCommand.
    *
-   * @param toSchedule the commands to schedule
+   * @param toSchedule the command to schedule
    */
   explicit ProxyScheduleCommand(std::unique_ptr<Command>&& toSchedule);
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ProxyScheduleCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ProxyScheduleCommand.h
@@ -39,8 +39,8 @@ class ProxyScheduleCommand
    * Creates a new ProxyScheduleCommand that schedules the given commands when
    * initialized, and ends when they are all no longer scheduled.
    *
-   * <p>Note that this constructor passes ownership of the given command to the returned
-   * ProxyScheduleCommand.
+   * <p>Note that this constructor passes ownership of the given command to the
+   * returned ProxyScheduleCommand.
    *
    * @param toSchedule the commands to schedule
    */

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/ProxyScheduleCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/ProxyScheduleCommandTest.cpp
@@ -2,7 +2,7 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include <regex>
+#include <memory>
 
 #include "CommandTestBase.h"
 #include "frc2/command/InstantCommand.h"
@@ -12,7 +12,7 @@
 using namespace frc2;
 class ProxyScheduleCommandTest : public CommandTestBase {};
 
-TEST_F(ProxyScheduleCommandTest, ProxyScheduleCommandSchedule) {
+TEST_F(ProxyScheduleCommandTest, NonOwningCommandSchedule) {
   CommandScheduler& scheduler = CommandScheduler::GetInstance();
 
   bool scheduled = false;
@@ -27,7 +27,7 @@ TEST_F(ProxyScheduleCommandTest, ProxyScheduleCommandSchedule) {
   EXPECT_TRUE(scheduled);
 }
 
-TEST_F(ProxyScheduleCommandTest, ProxyScheduleCommandEnd) {
+TEST_F(ProxyScheduleCommandTest, NonOwningCommandEnd) {
   CommandScheduler& scheduler = CommandScheduler::GetInstance();
 
   bool finished = false;
@@ -35,6 +35,36 @@ TEST_F(ProxyScheduleCommandTest, ProxyScheduleCommandEnd) {
   WaitUntilCommand toSchedule([&finished] { return finished; });
 
   ProxyScheduleCommand command(&toSchedule);
+
+  scheduler.Schedule(&command);
+  scheduler.Run();
+
+  EXPECT_TRUE(scheduler.IsScheduled(&command));
+  finished = true;
+  scheduler.Run();
+  scheduler.Run();
+  EXPECT_FALSE(scheduler.IsScheduled(&command));
+}
+
+TEST_F(ProxyScheduleCommandTest, OwningCommandSchedule) {
+  CommandScheduler& scheduler = CommandScheduler::GetInstance();
+
+  bool scheduled = false;
+
+  ProxyScheduleCommand command(std::make_unique<InstantCommand>([&scheduled] { scheduled = true; }, {}));
+
+  scheduler.Schedule(&command);
+  scheduler.Run();
+
+  EXPECT_TRUE(scheduled);
+}
+
+TEST_F(ProxyScheduleCommandTest, OwningCommandEnd) {
+  CommandScheduler& scheduler = CommandScheduler::GetInstance();
+
+  bool finished = false;
+
+  ProxyScheduleCommand command(std::make_unique<WaitUntilCommand>([&finished] { return finished; }));
 
   scheduler.Schedule(&command);
   scheduler.Run();

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/ProxyScheduleCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/ProxyScheduleCommandTest.cpp
@@ -51,7 +51,8 @@ TEST_F(ProxyScheduleCommandTest, OwningCommandSchedule) {
 
   bool scheduled = false;
 
-  ProxyScheduleCommand command(std::make_unique<InstantCommand>([&scheduled] { scheduled = true; }));
+  ProxyScheduleCommand command(
+      std::make_unique<InstantCommand>([&scheduled] { scheduled = true; }));
 
   scheduler.Schedule(&command);
   scheduler.Run();
@@ -64,7 +65,8 @@ TEST_F(ProxyScheduleCommandTest, OwningCommandEnd) {
 
   bool finished = false;
 
-  ProxyScheduleCommand command(std::make_unique<WaitUntilCommand>([&finished] { return finished; }));
+  ProxyScheduleCommand command(
+      std::make_unique<WaitUntilCommand>([&finished] { return finished; }));
 
   scheduler.Schedule(&command);
   scheduler.Run();

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/ProxyScheduleCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/ProxyScheduleCommandTest.cpp
@@ -51,7 +51,7 @@ TEST_F(ProxyScheduleCommandTest, OwningCommandSchedule) {
 
   bool scheduled = false;
 
-  ProxyScheduleCommand command(std::make_unique<InstantCommand>([&scheduled] { scheduled = true; }, {}));
+  ProxyScheduleCommand command(std::make_unique<InstantCommand>([&scheduled] { scheduled = true; }));
 
   scheduler.Schedule(&command);
   scheduler.Run();


### PR DESCRIPTION
The non-owning overloads aren't memory-safe, especially with the `AsProxy()` decorator.