### PR TITLE
Fix clang-tidy false positive on Linux

### DIFF
--- a/wpinet/src/main/native/macOS/MulticastServiceResolver.cpp
+++ b/wpinet/src/main/native/macOS/MulticastServiceResolver.cpp
@@ -2,6 +2,8 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+#if defined(__APPLE__)
+
 #include "wpinet/MulticastServiceResolver.h"
 
 #include <netinet/in.h>
@@ -212,3 +214,5 @@ void MulticastServiceResolver::Stop() {
   pImpl->ResolveStates.clear();
   pImpl->serviceRef = nullptr;
 }
+
+#endif  // defined(__APPLE__)

--- a/wpinet/src/main/native/macOS/ResolverThread.cpp
+++ b/wpinet/src/main/native/macOS/ResolverThread.cpp
@@ -2,6 +2,8 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+#if defined(__APPLE__)
+
 #include "ResolverThread.h"
 
 #include <algorithm>
@@ -109,3 +111,5 @@ std::shared_ptr<ResolverThread> ResolverThread::Get() {
   }
   return locked;
 }
+
+#endif  // defined(__APPLE__)

--- a/wpinet/src/main/native/macOS/ResolverThread.h
+++ b/wpinet/src/main/native/macOS/ResolverThread.h
@@ -2,6 +2,8 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+#if defined(__APPLE__)
+
 #pragma once
 
 #include <netinet/in.h>
@@ -44,3 +46,5 @@ class ResolverThread {
   std::atomic_bool running;
 };
 }  // namespace wpi
+
+#endif  // defined(__APPLE__)

--- a/wpiutil/src/main/native/windows/StackTrace.cpp
+++ b/wpiutil/src/main/native/windows/StackTrace.cpp
@@ -8,6 +8,8 @@
 #include "wpi/ConvertUTF.h"
 #include "wpi/SmallString.h"
 
+#if defined(_MSC_VER)
+
 namespace {
 class StackTraceWalker : public StackWalker {
  public:
@@ -40,3 +42,5 @@ std::string GetStackTraceDefault(int offset) {
 }
 
 }  // namespace wpi
+
+#endif  // defined(_MSC_VER)


### PR DESCRIPTION
```
== clang-tidy /home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/windows/StackTrace.cpp ==
/home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/windows/StackTrace.cpp:12:33: error: expected class name [clang-diagnostic-error]
class StackTraceWalker : public StackWalker {
                                ^
/home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/windows/StackTrace.cpp:16:17: error: unknown type name 'LPCTSTR' [clang-diagnostic-error]
  void OnOutput(LPCTSTR szText) override;
                ^
/home/tav/frc/wpilib/allwpilib/wpiutil/src/main/native/windows/StackTrace.cpp:23:33: error: unknown type name 'LPCTSTR' [clang-diagnostic-error]
void StackTraceWalker::OnOutput(LPCTSTR szText) {
                                ^
```