### PR TITLE
[commands] Deprecate withInterrupt decorator

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
@@ -110,7 +110,9 @@ public interface Command {
    *
    * @param condition the interrupt condition
    * @return the command with the interrupt condition added
+   * @deprecated Replace with {@link #until(BooleanSupplier)}
    */
+  @Deprecated(since = "2023")
   default ParallelRaceGroup withInterrupt(BooleanSupplier condition) {
     return until(condition);
   }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -151,7 +151,9 @@ class Command {
    *
    * @param condition the interrupt condition
    * @return the command with the interrupt condition added
+   * @deprecated Replace with Until()
    */
+  WPI_DEPRECATED("Replace with Until()")
   ParallelRaceGroup WithInterrupt(std::function<bool()> condition) &&;
 
   /**


### PR DESCRIPTION
`until()` was added in #3981 as a more intuitive alias. At this point, keeping this decorator will just cause confusion, given the functionally equivalent `until()` alias and the similarly-named `getInterruptionBehavior()`/`withInterruptBehavior()` methods.
