### PR TITLE
[commands] Remove unsafe default command isFinished check

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -405,10 +405,6 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
       throw new IllegalArgumentException("Default commands must require their subsystem!");
     }
 
-    if (defaultCommand.isFinished()) {
-      throw new IllegalArgumentException("Default commands should not end!");
-    }
-
     if (defaultCommand.getInterruptionBehavior() == InterruptionBehavior.kCancelIncoming) {
       DriverStation.reportWarning(
           "Registering a non-interruptible default command!\n"

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -182,10 +182,6 @@ class CommandScheduler final : public nt::NTSendable,
       throw FRC_MakeError(frc::err::CommandIllegalUse,
                           "Default commands must require their subsystem!");
     }
-    if (defaultCommand.IsFinished()) {
-      throw FRC_MakeError(frc::err::CommandIllegalUse,
-                          "Default commands should not end!");
-    }
     SetDefaultCommandImpl(subsystem,
                           std::make_unique<std::remove_reference_t<T>>(
                               std::forward<T>(defaultCommand)));

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandRequirementsTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/CommandRequirementsTest.java
@@ -64,12 +64,10 @@ class CommandRequirementsTest extends CommandTestBase {
       Subsystem system = new SubsystemBase() {};
 
       Command missingRequirement = new WaitUntilCommand(() -> false);
-      Command ends = new InstantCommand(() -> {}, system);
 
       assertThrows(
           IllegalArgumentException.class,
           () -> scheduler.setDefaultCommand(system, missingRequirement));
-      assertThrows(IllegalArgumentException.class, () -> scheduler.setDefaultCommand(system, ends));
     }
   }
 }


### PR DESCRIPTION
The `isFinished` call is unsafe, since `initialize` hasn't been called yet. It also blocks various common use cases.

No assumptions are violated by this; it's just that the use cases are rather narrow so it's likely a user mistake.