### PR TITLE
[ci] Separate vcpkg job for Windows builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -65,6 +65,12 @@ jobs:
           vcpkgGitCommitId: f6af75acc923c833a5620943e3fc7d5e4930f0df # HEAD on 2022-04-10
           runVcpkgInstall: true
 
+      - name: Install jinja
+        run: python -m pip install jinja2
+
+      - name: configure
+        run: mkdir build && cd build && cmake -DWITH_JAVA=OFF -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+
   build-windows:
     env:
       VCPKG_DEFAULT_TRIPLET: x64-windows

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,11 +50,27 @@ jobs:
         working-directory: build
         run: ctest --output-on-failure
 
+  vcpkg-windows:
+    env:
+      VCPKG_DEFAULT_TRIPLET: x64-windows
+    name: "vcpkg - Windows"
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run vcpkg
+        uses: lukka/run-vcpkg@v10.2
+        with:
+          vcpkgDirectory: ${{ runner.workspace }}/vcpkg
+          vcpkgGitCommitId: f6af75acc923c833a5620943e3fc7d5e4930f0df # HEAD on 2022-04-10
+          runVcpkgInstall: true
+
   build-windows:
     env:
       VCPKG_DEFAULT_TRIPLET: x64-windows
     name: "Build - Windows"
     runs-on: windows-2019
+    needs: vcpkg-windows
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
When the underlying image changes, vcpkg needs to rebuild and cache packages.  This can run out of disk space when combined with the main build, so run it as a separate job.