### PR TITLE
[wpimath] Remove Java LQR constructor that takes a controller gain matrix

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/controller/LinearQuadraticRegulator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/LinearQuadraticRegulator.java
@@ -7,7 +7,6 @@ package edu.wpi.first.math.controller;
 import edu.wpi.first.math.Drake;
 import edu.wpi.first.math.MathSharedStore;
 import edu.wpi.first.math.Matrix;
-import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.Num;
 import edu.wpi.first.math.StateSpaceUtil;
 import edu.wpi.first.math.Vector;
@@ -167,24 +166,6 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
 
     m_r = new Matrix<>(new SimpleMatrix(B.getNumRows(), 1));
     m_u = new Matrix<>(new SimpleMatrix(B.getNumCols(), 1));
-
-    reset();
-  }
-
-  /**
-   * Constructs a controller with the given coefficients and plant.
-   *
-   * @param states The number of states.
-   * @param inputs The number of inputs.
-   * @param k The gain matrix.
-   */
-  @SuppressWarnings("ParameterName")
-  public LinearQuadraticRegulator(
-      Nat<States> states, Nat<Inputs> inputs, Matrix<Inputs, States> k) {
-    m_K = k;
-
-    m_r = new Matrix<>(states, Nat.N1());
-    m_u = new Matrix<>(inputs, Nat.N1());
 
     reset();
   }


### PR DESCRIPTION
The controller gain matrix K should be computed from the solution to the DARE, but this constructor does not do that. It effectively violates a postcondition enforced by the other constructors by letting the user throw in a controller gain matrix that didn't come from an LQR.

Removing this constructor is a breaking change, but it never should have been included in the class in the first place. There's also no valid reason to use it. I assume it was originally added for debugging the class internals.

This constructor does not exist in C++.