### PR TITLE
[doc] older javadoc doesn't recognize HTML5 entities

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
@@ -707,8 +707,8 @@ public class Matrix<R extends Num, C extends Num> {
   /**
    * Performs an inplace Cholesky rank update (or downdate).
    *
-   * <p>If this matrix contains L where A = LL<sup>\u22a4</sup> before the update, it will contain L
-   * where LL<sup>\u22a4</sup> = A + &sigma;vv<sup>\u22a4</sup> after the update.
+   * <p>If this matrix contains L where A = LLᵀ before the update, it will contain L
+   * where LLᵀ = A + σvvᵀ after the update.
    *
    * @param v Vector to use for the update.
    * @param sigma Sigma to use for the update.

--- a/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
@@ -707,8 +707,8 @@ public class Matrix<R extends Num, C extends Num> {
   /**
    * Performs an inplace Cholesky rank update (or downdate).
    *
-   * <p>If this matrix contains L where A = LL<sup>&top;</sup> before the update, it will contain L
-   * where LL<sup>&top;</sup> = A + &sigma;vv<sup>&top;</sup> after the update.
+   * <p>If this matrix contains L where A = LL<sup>\u22a4</sup> before the update, it will contain L
+   * where LL<sup>\u22a4</sup> = A + &sigma;vv<sup>\u22a4</sup> after the update.
    *
    * @param v Vector to use for the update.
    * @param sigma Sigma to use for the update.

--- a/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
@@ -707,8 +707,8 @@ public class Matrix<R extends Num, C extends Num> {
   /**
    * Performs an inplace Cholesky rank update (or downdate).
    *
-   * <p>If this matrix contains L where A = LLᵀ before the update, it will contain L
-   * where LLᵀ = A + σvvᵀ after the update.
+   * <p>If this matrix contains L where A = LLᵀ before the update, it will contain L where LLᵀ = A +
+   * σvvᵀ after the update.
    *
    * @param v Vector to use for the update.
    * @param sigma Sigma to use for the update.


### PR DESCRIPTION
Replace &top; with \u22a4, since Unicode references are supported but HTML5 entities are not. Should be fixed if JDK is ever moved forward