### PR TITLE
Fix Java integration tests not correctly working

### DIFF
--- a/wpilibcIntegrationTests/build.gradle
+++ b/wpilibcIntegrationTests/build.gradle
@@ -48,6 +48,9 @@ model {
                     project(':hal').addHalDependency(binary, 'shared')
                     project(':hal').addHalJniDependency(binary)
                     lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
+                    lib project: ':wpimath', library: 'wpimathJNIShared', linkage: 'shared'
+                    lib project: ':wpinet', library: 'wpinetJNIShared', linkage: 'shared'
+                    lib project: ':wpiutil', library: 'wpiutilJNIShared', linkage: 'shared'
                     lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
                     lib project: ':cameraserver', library: 'cameraserver', linkage: 'shared'
                     if (binary.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {


### PR DESCRIPTION
The new jni libraries for the libraries were never added, so they never get deployed.