### PR TITLE
[wpiutil] Logger: Conditionalize around WPI_LOG

### DIFF
--- a/wpiutil/src/main/native/include/wpi/Logger.h
+++ b/wpiutil/src/main/native/include/wpi/Logger.h
@@ -60,8 +60,11 @@ class Logger {
   unsigned int m_min_level = 20;
 };
 
-#define WPI_LOG(logger_inst, level, format, ...) \
-  (logger_inst).Log(level, __FILE__, __LINE__, FMT_STRING(format), __VA_ARGS__)
+#define WPI_LOG(logger_inst, level, format, ...)                          \
+  if ((logger_inst).HasLogger() && level >= (logger_inst).min_level()) {  \
+    (logger_inst)                                                         \
+        .Log(level, __FILE__, __LINE__, FMT_STRING(format), __VA_ARGS__); \
+  }
 
 #define WPI_ERROR(inst, format, ...) \
   WPI_LOG(inst, ::wpi::WPI_LOG_ERROR, format, __VA_ARGS__)


### PR DESCRIPTION
The FMT_STRING() call used in the macro does formatter initialization, overhead that's not required if Log() is not going to be called.