### PR TITLE
Clean up Java warning suppressions

### DIFF
--- a/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
+++ b/cameraserver/src/main/java/edu/wpi/first/cameraserver/CameraServer.java
@@ -33,12 +33,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Singleton class for creating and keeping camera servers. Also publishes camera information to
  * NetworkTables.
  */
-@SuppressWarnings("PMD.UnusedPrivateField")
 public final class CameraServer {
   public static final int kBasePort = 1181;
 
   private static final String kPublishName = "/CameraPublisher";
-  private static CameraServer server;
 
   private static final AtomicInteger m_defaultUsbDevice = new AtomicInteger();
   private static String m_primarySourceName;
@@ -63,6 +61,7 @@ public final class CameraServer {
   // - "PropertyInfo/{Property}" - Property supporting information
 
   // Listener for video events
+  @SuppressWarnings("PMD.UnusedPrivateField")
   private static final VideoListener m_videoListener =
       new VideoListener(
           event -> {
@@ -185,6 +184,7 @@ public final class CameraServer {
           0x4fff,
           true);
 
+  @SuppressWarnings("PMD.UnusedPrivateField")
   private static final int m_tableListener =
       NetworkTableInstance.getDefault()
           .addEntryListener(
@@ -243,10 +243,15 @@ public final class CameraServer {
                 }
               },
               EntryListenerFlags.kImmediate | EntryListenerFlags.kUpdate);
+
   private static int m_nextPort = kBasePort;
   private static String[] m_addresses = new String[0];
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /**
+   * Return URI of source with the given index.
+   *
+   * @param source Source index.
+   */
   private static String makeSourceValue(int source) {
     switch (VideoSource.getKindFromInt(CameraServerJNI.getSourceKind(source))) {
       case kUsb:
@@ -267,12 +272,21 @@ public final class CameraServer {
     }
   }
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /**
+   * Return URI of stream with the given address and port.
+   *
+   * @param address Stream IP address.
+   * @param port Stream remote port.
+   */
   private static String makeStreamValue(String address, int port) {
     return "mjpg:http://" + address + ":" + port + "/?action=stream";
   }
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /**
+   * Return URI of sink stream with the given index.
+   *
+   * @param sink Sink index.
+   */
   private static synchronized String[] getSinkStreamValues(int sink) {
     // Ignore all but MjpegServer
     if (VideoSink.getKindFromInt(CameraServerJNI.getSinkKind(sink)) != VideoSink.Kind.kMjpeg) {
@@ -302,7 +316,11 @@ public final class CameraServer {
     return values.toArray(new String[0]);
   }
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /**
+   * Return list of stream source URIs for the given source index.
+   *
+   * @param source Source index.
+   */
   private static synchronized String[] getSourceStreamValues(int source) {
     // Ignore all but HttpCamera
     if (VideoSource.getKindFromInt(CameraServerJNI.getSourceKind(source))
@@ -337,7 +355,7 @@ public final class CameraServer {
     return values;
   }
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /** Update list of stream URIs. */
   private static synchronized void updateStreamValues() {
     // Over all the sinks...
     for (VideoSink i : m_sinks.values()) {
@@ -383,7 +401,7 @@ public final class CameraServer {
     }
   }
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /** Provide string description of pixel format. */
   private static String pixelFormatToString(PixelFormat pixelFormat) {
     switch (pixelFormat) {
       case kMJPEG:
@@ -401,9 +419,11 @@ public final class CameraServer {
     }
   }
 
-  /// Provide string description of video mode.
-  /// The returned string is "{width}x{height} {format} {fps} fps".
-  @SuppressWarnings("MissingJavadocMethod")
+  /**
+   * Provide string description of video mode.
+   *
+   * <p>The returned string is "{width}x{height} {format} {fps} fps".
+   */
   private static String videoModeToString(VideoMode mode) {
     return mode.width
         + "x"
@@ -415,7 +435,11 @@ public final class CameraServer {
         + " fps";
   }
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /**
+   * Get list of video modes for the given source handle.
+   *
+   * @param sourceHandle Source handle.
+   */
   private static String[] getSourceModeValues(int sourceHandle) {
     VideoMode[] modes = CameraServerJNI.enumerateSourceVideoModes(sourceHandle);
     String[] modeStrings = new String[modes.length];
@@ -425,7 +449,13 @@ public final class CameraServer {
     return modeStrings;
   }
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /**
+   * Publish a source property value to NetworkTables.
+   *
+   * @param table NetworkTable to which to push value.
+   * @param event Video event.
+   * @param isNew Whether the property value hasn't been pushed to NetworkTables before.
+   */
   private static void putSourcePropertyValue(NetworkTable table, VideoEvent event, boolean isNew) {
     String name;
     String infoName;

--- a/cscore/src/main/java/edu/wpi/first/cscore/UsbCameraInfo.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/UsbCameraInfo.java
@@ -5,6 +5,7 @@
 package edu.wpi.first.cscore;
 
 /** USB camera information. */
+@SuppressWarnings("MemberName")
 public class UsbCameraInfo {
   /**
    * Create a new set of UsbCameraInfo.
@@ -28,26 +29,20 @@ public class UsbCameraInfo {
   }
 
   /** Device number (e.g. N in '/dev/videoN' on Linux). */
-  @SuppressWarnings("MemberName")
   public int dev;
 
   /** Path to device if available (e.g. '/dev/video0' on Linux). */
-  @SuppressWarnings("MemberName")
   public String path;
 
   /** Vendor/model name of the camera as provided by the USB driver. */
-  @SuppressWarnings("MemberName")
   public String name;
 
   /** Other path aliases to device (e.g. '/dev/v4l/by-id/...' etc on Linux). */
-  @SuppressWarnings("MemberName")
   public String[] otherPaths;
 
   /** USB vendor id. */
-  @SuppressWarnings("MemberName")
   public int vendorId;
 
   /** USB product id. */
-  @SuppressWarnings("MemberName")
   public int productId;
 }

--- a/cscore/src/main/java/edu/wpi/first/cscore/VideoEvent.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/VideoEvent.java
@@ -5,6 +5,7 @@
 package edu.wpi.first.cscore;
 
 /** Video event. */
+@SuppressWarnings("MemberName")
 public class VideoEvent {
   public enum Kind {
     kUnknown(0x0000),
@@ -117,39 +118,29 @@ public class VideoEvent {
     this.listener = listener;
   }
 
-  @SuppressWarnings("MemberName")
   public Kind kind;
 
   // Valid for kSource* and kSink* respectively
-  @SuppressWarnings("MemberName")
   public int sourceHandle;
 
-  @SuppressWarnings("MemberName")
   public int sinkHandle;
 
   // Source/sink/property name
-  @SuppressWarnings("MemberName")
   public String name;
 
   // Fields for kSourceVideoModeChanged event
-  @SuppressWarnings("MemberName")
   public VideoMode mode;
 
   // Fields for kSourceProperty* events
-  @SuppressWarnings("MemberName")
   public int propertyHandle;
 
-  @SuppressWarnings("MemberName")
   public VideoProperty.Kind propertyKind;
 
-  @SuppressWarnings("MemberName")
   public int value;
 
-  @SuppressWarnings("MemberName")
   public String valueStr;
 
   // Listener that was triggered
-  @SuppressWarnings("MemberName")
   public int listener;
 
   public VideoSource getSource() {

--- a/cscore/src/main/java/edu/wpi/first/cscore/VideoListener.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/VideoListener.java
@@ -64,7 +64,6 @@ public class VideoListener implements AutoCloseable {
   private static boolean s_waitQueue;
   private static final Condition s_waitQueueCond = s_lock.newCondition();
 
-  @SuppressWarnings("PMD.AvoidCatchingThrowable")
   private static void startThread() {
     s_thread =
         new Thread(

--- a/cscore/src/main/java/edu/wpi/first/cscore/VideoMode.java
+++ b/cscore/src/main/java/edu/wpi/first/cscore/VideoMode.java
@@ -5,6 +5,7 @@
 package edu.wpi.first.cscore;
 
 /** Video mode. */
+@SuppressWarnings("MemberName")
 public class VideoMode {
   public enum PixelFormat {
     kUnknown(0),
@@ -62,18 +63,14 @@ public class VideoMode {
   }
 
   /** Pixel format. */
-  @SuppressWarnings("MemberName")
   public PixelFormat pixelFormat;
 
   /** Width in pixels. */
-  @SuppressWarnings("MemberName")
   public int width;
 
   /** Height in pixels. */
-  @SuppressWarnings("MemberName")
   public int height;
 
   /** Frames per second. */
-  @SuppressWarnings("MemberName")
   public int fps;
 }

--- a/hal/src/generate/FRCNetComm.java.in
+++ b/hal/src/generate/FRCNetComm.java.in
@@ -7,7 +7,6 @@ package edu.wpi.first.hal;
 /**
  * JNI wrapper for library <b>FRC_NetworkCommunication</b><br>.
  */
-@SuppressWarnings({"MethodName", "LineLength"})
 public class FRCNetComm {
   /**
    * Resource type from UsageReporting.

--- a/hal/src/main/java/edu/wpi/first/hal/AccumulatorResult.java
+++ b/hal/src/main/java/edu/wpi/first/hal/AccumulatorResult.java
@@ -5,12 +5,11 @@
 package edu.wpi.first.hal;
 
 /** Structure for holding the values stored in an accumulator. */
+@SuppressWarnings("MemberName")
 public class AccumulatorResult {
   /** The total value accumulated. */
-  @SuppressWarnings("MemberName")
   public long value;
   /** The number of sample value was accumulated over. */
-  @SuppressWarnings("MemberName")
   public long count;
 
   /**

--- a/hal/src/main/java/edu/wpi/first/hal/AddressableLEDJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/AddressableLEDJNI.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class AddressableLEDJNI extends JNIWrapper {
   public static native int initialize(int pwmHandle);
 

--- a/hal/src/main/java/edu/wpi/first/hal/AnalogJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/AnalogJNI.java
@@ -111,6 +111,5 @@ public class AnalogJNI extends JNIWrapper {
 
   public static native boolean getAnalogTriggerOutput(int analogTriggerHandle, int type);
 
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static native int getAnalogTriggerFPGAIndex(int analogTriggerHandle);
 }

--- a/hal/src/main/java/edu/wpi/first/hal/CANAPIJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/CANAPIJNI.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class CANAPIJNI extends JNIWrapper {
   public static native int initializeCAN(int manufacturer, int deviceId, int deviceType);
 

--- a/hal/src/main/java/edu/wpi/first/hal/CANData.java
+++ b/hal/src/main/java/edu/wpi/first/hal/CANData.java
@@ -4,14 +4,10 @@
 
 package edu.wpi.first.hal;
 
+@SuppressWarnings("MemberName")
 public class CANData {
-  @SuppressWarnings("MemberName")
   public final byte[] data = new byte[8];
-
-  @SuppressWarnings("MemberName")
   public int length;
-
-  @SuppressWarnings("MemberName")
   public long timestamp;
 
   /**

--- a/hal/src/main/java/edu/wpi/first/hal/CTREPCMJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/CTREPCMJNI.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class CTREPCMJNI extends JNIWrapper {
   public static native int initialize(int module);
 

--- a/hal/src/main/java/edu/wpi/first/hal/DIOJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/DIOJNI.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class DIOJNI extends JNIWrapper {
   public static native int initializeDIOPort(int halPortHandle, boolean input);
 

--- a/hal/src/main/java/edu/wpi/first/hal/DMAJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/DMAJNI.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class DMAJNI extends JNIWrapper {
   public static native int initialize();
 

--- a/hal/src/main/java/edu/wpi/first/hal/DMAJNISample.java
+++ b/hal/src/main/java/edu/wpi/first/hal/DMAJNISample.java
@@ -7,7 +7,6 @@ package edu.wpi.first.hal;
 import java.util.HashMap;
 import java.util.Map;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class DMAJNISample {
   private static final int kEnable_Accumulator0 = 8;
   private static final int kEnable_Accumulator1 = 9;

--- a/hal/src/main/java/edu/wpi/first/hal/DutyCycleJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/DutyCycleJNI.java
@@ -17,6 +17,5 @@ public class DutyCycleJNI extends JNIWrapper {
 
   public static native int getOutputScaleFactor(int handle);
 
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static native int getFPGAIndex(int handle);
 }

--- a/hal/src/main/java/edu/wpi/first/hal/EncoderJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/EncoderJNI.java
@@ -50,7 +50,6 @@ public class EncoderJNI extends JNIWrapper {
   public static native void setEncoderIndexSource(
       int encoderHandle, int digitalSourceHandle, int analogTriggerType, int indexingType);
 
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static native int getEncoderFPGAIndex(int encoderHandle);
 
   public static native int getEncoderEncodingScale(int encoderHandle);

--- a/hal/src/main/java/edu/wpi/first/hal/HAL.java
+++ b/hal/src/main/java/edu/wpi/first/hal/HAL.java
@@ -12,7 +12,6 @@ import java.util.List;
  * JNI Wrapper for HAL<br>
  * .
  */
-@SuppressWarnings({"AbbreviationAsWordInName", "MethodName"})
 public final class HAL extends JNIWrapper {
   public static native void waitForDSData();
 
@@ -153,7 +152,11 @@ public final class HAL extends JNIWrapper {
 
   public static native int nativeGetControlWord();
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /**
+   * Get the current DriverStation control word.
+   *
+   * @param controlWord Storage for control word.
+   */
   public static void getControlWord(ControlWord controlWord) {
     int word = nativeGetControlWord();
     controlWord.update(
@@ -167,7 +170,11 @@ public final class HAL extends JNIWrapper {
 
   private static native int nativeGetAllianceStation();
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /**
+   * Get the alliance station.
+   *
+   * @return The alliance station.
+   */
   public static AllianceStationID getAllianceStation() {
     switch (nativeGetAllianceStation()) {
       case 0:
@@ -187,13 +194,10 @@ public final class HAL extends JNIWrapper {
     }
   }
 
-  @SuppressWarnings("MissingJavadocMethod")
   public static native boolean isNewControlData();
 
-  @SuppressWarnings("MissingJavadocMethod")
   public static native void releaseDSMutex();
 
-  @SuppressWarnings("MissingJavadocMethod")
   public static native boolean waitForDSDataTimeout(double timeout);
 
   public static final int kMaxJoystickAxes = 12;

--- a/hal/src/main/java/edu/wpi/first/hal/HALUtil.java
+++ b/hal/src/main/java/edu/wpi/first/hal/HALUtil.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public final class HALUtil extends JNIWrapper {
   public static final int NULL_PARAMETER = -1005;
   public static final int SAMPLE_RATE_TOO_HIGH = 1001;

--- a/hal/src/main/java/edu/wpi/first/hal/HALValue.java
+++ b/hal/src/main/java/edu/wpi/first/hal/HALValue.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public final class HALValue {
   public static final int kUnassigned = 0;
   public static final int kBoolean = 0x01;

--- a/hal/src/main/java/edu/wpi/first/hal/I2CJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/I2CJNI.java
@@ -6,7 +6,6 @@ package edu.wpi.first.hal;
 
 import java.nio.ByteBuffer;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class I2CJNI extends JNIWrapper {
   public static native void i2CInitialize(int port);
 

--- a/hal/src/main/java/edu/wpi/first/hal/MatchInfoData.java
+++ b/hal/src/main/java/edu/wpi/first/hal/MatchInfoData.java
@@ -5,25 +5,21 @@
 package edu.wpi.first.hal;
 
 /** Structure for holding the match info data request. */
+@SuppressWarnings("MemberName")
 public class MatchInfoData {
   /** Stores the event name. */
-  @SuppressWarnings("MemberName")
   public String eventName = "";
 
   /** Stores the game specific message. */
-  @SuppressWarnings("MemberName")
   public String gameSpecificMessage = "";
 
   /** Stores the match number. */
-  @SuppressWarnings("MemberName")
   public int matchNumber;
 
   /** Stores the replay number. */
-  @SuppressWarnings("MemberName")
   public int replayNumber;
 
   /** Stores the match type. */
-  @SuppressWarnings("MemberName")
   public int matchType;
 
   /**
@@ -35,7 +31,6 @@ public class MatchInfoData {
    * @param replayNumber Replay number.
    * @param matchType Match type.
    */
-  @SuppressWarnings("MissingJavadocMethod")
   public void setData(
       String eventName,
       String gameSpecificMessage,

--- a/hal/src/main/java/edu/wpi/first/hal/PWMConfigDataResult.java
+++ b/hal/src/main/java/edu/wpi/first/hal/PWMConfigDataResult.java
@@ -5,6 +5,7 @@
 package edu.wpi.first.hal;
 
 /** Structure for holding the config data result for PWM. */
+@SuppressWarnings("MemberName")
 public class PWMConfigDataResult {
   PWMConfigDataResult(int max, int deadbandMax, int center, int deadbandMin, int min) {
     this.max = max;
@@ -15,22 +16,17 @@ public class PWMConfigDataResult {
   }
 
   /** The maximum PWM value. */
-  @SuppressWarnings("MemberName")
   public int max;
 
   /** The deadband maximum PWM value. */
-  @SuppressWarnings("MemberName")
   public int deadbandMax;
 
   /** The center PWM value. */
-  @SuppressWarnings("MemberName")
   public int center;
 
   /** The deadband minimum PWM value. */
-  @SuppressWarnings("MemberName")
   public int deadbandMin;
 
   /** The minimum PWM value. */
-  @SuppressWarnings("MemberName")
   public int min;
 }

--- a/hal/src/main/java/edu/wpi/first/hal/PWMJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/PWMJNI.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class PWMJNI extends DIOJNI {
   public static native int initializePWMPort(int halPortHandle);
 

--- a/hal/src/main/java/edu/wpi/first/hal/PortsJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/PortsJNI.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class PortsJNI extends JNIWrapper {
   public static native int getNumAccumulators();
 

--- a/hal/src/main/java/edu/wpi/first/hal/PowerDistributionFaults.java
+++ b/hal/src/main/java/edu/wpi/first/hal/PowerDistributionFaults.java
@@ -4,86 +4,60 @@
 
 package edu.wpi.first.hal;
 
+@SuppressWarnings("MemberName")
 public class PowerDistributionFaults {
-  @SuppressWarnings("MemberName")
   public final boolean Channel0BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel1BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel2BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel3BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel4BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel5BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel6BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel7BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel8BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel9BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel10BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel11BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel12BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel13BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel14BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel15BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel16BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel17BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel18BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel19BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel20BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel21BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel22BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel23BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Brownout;
 
-  @SuppressWarnings("MemberName")
   public final boolean CanWarning;
 
-  @SuppressWarnings("MemberName")
   public final boolean HardwareFault;
 
   /**

--- a/hal/src/main/java/edu/wpi/first/hal/PowerDistributionJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/PowerDistributionJNI.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class PowerDistributionJNI extends JNIWrapper {
   public static final int AUTOMATIC_TYPE = 0;
   public static final int CTRE_TYPE = 1;

--- a/hal/src/main/java/edu/wpi/first/hal/PowerDistributionStickyFaults.java
+++ b/hal/src/main/java/edu/wpi/first/hal/PowerDistributionStickyFaults.java
@@ -4,89 +4,62 @@
 
 package edu.wpi.first.hal;
 
+@SuppressWarnings("MemberName")
 public class PowerDistributionStickyFaults {
-  @SuppressWarnings("MemberName")
   public final boolean Channel0BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel1BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel2BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel3BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel4BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel5BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel6BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel7BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel8BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel9BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel10BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel11BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel12BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel13BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel14BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel15BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel16BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel17BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel18BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel19BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel20BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel21BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel22BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel23BreakerFault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Brownout;
 
-  @SuppressWarnings("MemberName")
   public final boolean CanWarning;
 
-  @SuppressWarnings("MemberName")
   public final boolean CanBusOff;
 
-  @SuppressWarnings("MemberName")
   public final boolean HasReset;
 
   /**

--- a/hal/src/main/java/edu/wpi/first/hal/PowerDistributionVersion.java
+++ b/hal/src/main/java/edu/wpi/first/hal/PowerDistributionVersion.java
@@ -4,23 +4,18 @@
 
 package edu.wpi.first.hal;
 
+@SuppressWarnings("MemberName")
 public class PowerDistributionVersion {
-  @SuppressWarnings("MemberName")
   public final int firmwareMajor;
 
-  @SuppressWarnings("MemberName")
   public final int firmwareMinor;
 
-  @SuppressWarnings("MemberName")
   public final int firmwareFix;
 
-  @SuppressWarnings("MemberName")
   public final int hardwareMinor;
 
-  @SuppressWarnings("MemberName")
   public final int hardwareMajor;
 
-  @SuppressWarnings("MemberName")
   public final int uniqueId;
 
   /**

--- a/hal/src/main/java/edu/wpi/first/hal/REVPHFaults.java
+++ b/hal/src/main/java/edu/wpi/first/hal/REVPHFaults.java
@@ -4,72 +4,50 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
+@SuppressWarnings("MemberName")
 public class REVPHFaults {
-  @SuppressWarnings("MemberName")
   public final boolean Channel0Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel1Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel2Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel3Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel4Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel5Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel6Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel7Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel8Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel9Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel10Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel11Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel12Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel13Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel14Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean Channel15Fault;
 
-  @SuppressWarnings("MemberName")
   public final boolean CompressorOverCurrent;
 
-  @SuppressWarnings("MemberName")
   public final boolean CompressorOpen;
 
-  @SuppressWarnings("MemberName")
   public final boolean SolenoidOverCurrent;
 
-  @SuppressWarnings("MemberName")
   public final boolean Brownout;
 
-  @SuppressWarnings("MemberName")
   public final boolean CanWarning;
 
-  @SuppressWarnings("MemberName")
   public final boolean HardwareFault;
 
   /**

--- a/hal/src/main/java/edu/wpi/first/hal/REVPHJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/REVPHJNI.java
@@ -4,7 +4,6 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class REVPHJNI extends JNIWrapper {
   public static final int COMPRESSOR_CONFIG_TYPE_DISABLED = 0;
   public static final int COMPRESSOR_CONFIG_TYPE_DIGITAL = 1;

--- a/hal/src/main/java/edu/wpi/first/hal/REVPHStickyFaults.java
+++ b/hal/src/main/java/edu/wpi/first/hal/REVPHStickyFaults.java
@@ -4,27 +4,20 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
+@SuppressWarnings("MemberName")
 public class REVPHStickyFaults {
-  @SuppressWarnings("MemberName")
   public final boolean CompressorOverCurrent;
 
-  @SuppressWarnings("MemberName")
   public final boolean CompressorOpen;
 
-  @SuppressWarnings("MemberName")
   public final boolean SolenoidOverCurrent;
 
-  @SuppressWarnings("MemberName")
   public final boolean Brownout;
 
-  @SuppressWarnings("MemberName")
   public final boolean CanWarning;
 
-  @SuppressWarnings("MemberName")
   public final boolean CanBusOff;
 
-  @SuppressWarnings("MemberName")
   public final boolean HasReset;
 
   /**

--- a/hal/src/main/java/edu/wpi/first/hal/REVPHVersion.java
+++ b/hal/src/main/java/edu/wpi/first/hal/REVPHVersion.java
@@ -4,24 +4,18 @@
 
 package edu.wpi.first.hal;
 
-@SuppressWarnings("AbbreviationAsWordInName")
+@SuppressWarnings("MemberName")
 public class REVPHVersion {
-  @SuppressWarnings("MemberName")
   public final int firmwareMajor;
 
-  @SuppressWarnings("MemberName")
   public final int firmwareMinor;
 
-  @SuppressWarnings("MemberName")
   public final int firmwareFix;
 
-  @SuppressWarnings("MemberName")
   public final int hardwareMinor;
 
-  @SuppressWarnings("MemberName")
   public final int hardwareMajor;
 
-  @SuppressWarnings("MemberName")
   public final int uniqueId;
 
   /**

--- a/hal/src/main/java/edu/wpi/first/hal/SPIJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/SPIJNI.java
@@ -6,7 +6,6 @@ package edu.wpi.first.hal;
 
 import java.nio.ByteBuffer;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class SPIJNI extends JNIWrapper {
   public static native void spiInitialize(int port);
 

--- a/hal/src/main/java/edu/wpi/first/hal/can/CANJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANJNI.java
@@ -8,7 +8,7 @@ import edu.wpi.first.hal.JNIWrapper;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 
-@SuppressWarnings("AbbreviationAsWordInName")
+@SuppressWarnings("MethodName")
 public class CANJNI extends JNIWrapper {
   public static final int CAN_SEND_PERIOD_NO_REPEAT = 0;
   public static final int CAN_SEND_PERIOD_STOP_REPEATING = -1;
@@ -17,14 +17,11 @@ public class CANJNI extends JNIWrapper {
   public static final int CAN_IS_FRAME_REMOTE = 0x80000000;
   public static final int CAN_IS_FRAME_11BIT = 0x40000000;
 
-  @SuppressWarnings("MethodName")
   public static native void FRCNetCommCANSessionMuxSendMessage(
       int messageID, byte[] data, int periodMs);
 
-  @SuppressWarnings("MethodName")
   public static native byte[] FRCNetCommCANSessionMuxReceiveMessage(
       IntBuffer messageID, int messageIDMask, ByteBuffer timeStamp);
 
-  @SuppressWarnings("MethodName")
   public static native void getCANStatus(CANStatus status);
 }

--- a/hal/src/main/java/edu/wpi/first/hal/can/CANStatus.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANStatus.java
@@ -5,28 +5,32 @@
 package edu.wpi.first.hal.can;
 
 /** Structure for holding the result of a CAN Status request. */
+@SuppressWarnings("MemberName")
 public class CANStatus {
   /** The utilization of the CAN Bus. */
-  @SuppressWarnings("MemberName")
   public double percentBusUtilization;
 
   /** The CAN Bus off count. */
-  @SuppressWarnings("MemberName")
   public int busOffCount;
 
   /** The CAN Bus TX full count. */
-  @SuppressWarnings("MemberName")
   public int txFullCount;
 
   /** The CAN Bus receive error count. */
-  @SuppressWarnings("MemberName")
   public int receiveErrorCount;
 
   /** The CAN Bus transmit error count. */
-  @SuppressWarnings("MemberName")
   public int transmitErrorCount;
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /**
+   * Set CAN bus status.
+   *
+   * @param percentBusUtilization CAN bus utilization as a percent.
+   * @param busOffCount Bus off event count.
+   * @param txFullCount TX buffer full event count.
+   * @param receiveErrorCount Receive error event count.
+   * @param transmitErrorCount Transmit error event count.
+   */
   public void setStatus(
       double percentBusUtilization,
       int busOffCount,

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/CTREPCMDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/CTREPCMDataJNI.java
@@ -6,7 +6,6 @@ package edu.wpi.first.hal.simulation;
 
 import edu.wpi.first.hal.JNIWrapper;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class CTREPCMDataJNI extends JNIWrapper {
   public static native int registerInitializedCallback(
       int index, NotifyCallback callback, boolean initialNotify);

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/REVPHDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/REVPHDataJNI.java
@@ -6,7 +6,6 @@ package edu.wpi.first.hal.simulation;
 
 import edu.wpi.first.hal.JNIWrapper;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 public class REVPHDataJNI extends JNIWrapper {
   public static native int registerInitializedCallback(
       int index, NotifyCallback callback, boolean initialNotify);

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/RoboRioDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/RoboRioDataJNI.java
@@ -7,17 +7,13 @@ package edu.wpi.first.hal.simulation;
 import edu.wpi.first.hal.JNIWrapper;
 
 public class RoboRioDataJNI extends JNIWrapper {
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static native int registerFPGAButtonCallback(
       NotifyCallback callback, boolean initialNotify);
 
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static native void cancelFPGAButtonCallback(int uid);
 
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static native boolean getFPGAButton();
 
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static native void setFPGAButton(boolean fPGAButton);
 
   public static native int registerVInVoltageCallback(

--- a/hal/src/main/java/edu/wpi/first/hal/simulation/SimDeviceDataJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/simulation/SimDeviceDataJNI.java
@@ -28,18 +28,21 @@ public class SimDeviceDataJNI extends JNIWrapper {
 
   public static native int getSimValueDeviceHandle(int handle);
 
+  @SuppressWarnings("MemberName")
   public static class SimDeviceInfo {
-    @SuppressWarnings("JavadocMethod")
+    public String name;
+    public int handle;
+
+    /**
+     * SimDeviceInfo constructor.
+     *
+     * @param name SimDevice name.
+     * @param handle SimDevice handle.
+     */
     public SimDeviceInfo(String name, int handle) {
       this.name = name;
       this.handle = handle;
     }
-
-    @SuppressWarnings("MemberName")
-    public String name;
-
-    @SuppressWarnings("MemberName")
-    public int handle;
   }
 
   public static native SimDeviceInfo[] enumerateSimDevices(String prefix);
@@ -70,8 +73,23 @@ public class SimDeviceDataJNI extends JNIWrapper {
 
   public static native int getSimValueHandle(int device, String name);
 
+  @SuppressWarnings("MemberName")
   public static class SimValueInfo {
-    @SuppressWarnings("JavadocMethod")
+    public String name;
+    public int handle;
+    public int direction;
+    public HALValue value;
+
+    /**
+     * SimValueInfo constructor.
+     *
+     * @param name SimValue name.
+     * @param handle SimValue handle.
+     * @param direction SimValue direction.
+     * @param type SimValue type.
+     * @param value1 Value 1.
+     * @param value2 Value 2.
+     */
     public SimValueInfo(
         String name, int handle, int direction, int type, long value1, double value2) {
       this.name = name;
@@ -79,18 +97,6 @@ public class SimDeviceDataJNI extends JNIWrapper {
       this.direction = direction;
       this.value = HALValue.fromNative(type, value1, value2);
     }
-
-    @SuppressWarnings("MemberName")
-    public String name;
-
-    @SuppressWarnings("MemberName")
-    public int handle;
-
-    @SuppressWarnings("MemberName")
-    public int direction;
-
-    @SuppressWarnings("MemberName")
-    public HALValue value;
   }
 
   public static native SimValueInfo[] enumerateSimValues(int device);

--- a/myRobot/src/main/java/frc/robot/MyRobot.java
+++ b/myRobot/src/main/java/frc/robot/MyRobot.java
@@ -6,7 +6,6 @@ package frc.robot;
 
 import edu.wpi.first.wpilibj.TimedRobot;
 
-@SuppressWarnings("all")
 public class MyRobot extends TimedRobot {
   /**
    * This function is run when the robot is first started up and should be used for any
@@ -15,27 +14,27 @@ public class MyRobot extends TimedRobot {
   @Override
   public void robotInit() {}
 
-  /** This function is run once each time the robot enters autonomous mode */
+  /** This function is run once each time the robot enters autonomous mode. */
   @Override
   public void autonomousInit() {}
 
-  /** This function is called periodically during autonomous */
+  /** This function is called periodically during autonomous. */
   @Override
   public void autonomousPeriodic() {}
 
-  /** This function is called once each time the robot enters tele-operated mode */
+  /** This function is called once each time the robot enters tele-operated mode. */
   @Override
   public void teleopInit() {}
 
-  /** This function is called periodically during operator control */
+  /** This function is called periodically during operator control. */
   @Override
   public void teleopPeriodic() {}
 
-  /** This function is called periodically during test mode */
+  /** This function is called periodically during test mode. */
   @Override
   public void testPeriodic() {}
 
-  /** This function is called periodically during all modes */
+  /** This function is called periodically during all modes. */
   @Override
   public void robotPeriodic() {}
 }

--- a/ntcore/src/main/java/edu/wpi/first/networktables/ConnectionInfo.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/ConnectionInfo.java
@@ -5,34 +5,30 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables Connection information. */
+@SuppressWarnings("MemberName")
 public final class ConnectionInfo {
   /**
    * The remote identifier (as set on the remote node by {@link
    * NetworkTableInstance#setNetworkIdentity(String)}).
    */
-  @SuppressWarnings("MemberName")
   public final String remote_id;
 
   /** The IP address of the remote node. */
-  @SuppressWarnings("MemberName")
   public final String remote_ip;
 
   /** The port number of the remote node. */
-  @SuppressWarnings("MemberName")
   public final int remote_port;
 
   /**
    * The last time any update was received from the remote node (same scale as returned by {@link
    * NetworkTablesJNI#now()}).
    */
-  @SuppressWarnings("MemberName")
   public final long last_update;
 
   /**
    * The protocol version being used for this connection. This is in protocol layer format, so
    * 0x0200 = 2.0, 0x0300 = 3.0).
    */
-  @SuppressWarnings("MemberName")
   public final int protocol_version;
 
   /**

--- a/ntcore/src/main/java/edu/wpi/first/networktables/ConnectionNotification.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/ConnectionNotification.java
@@ -5,17 +5,15 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables Connection notification. */
+@SuppressWarnings("MemberName")
 public final class ConnectionNotification {
   /** Listener that was triggered. */
-  @SuppressWarnings("MemberName")
   public final int listener;
 
   /** True if event is due to connection being established. */
-  @SuppressWarnings("MemberName")
   public final boolean connected;
 
   /** Connection information. */
-  @SuppressWarnings("MemberName")
   public final ConnectionInfo conn;
 
   /**

--- a/ntcore/src/main/java/edu/wpi/first/networktables/EntryInfo.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/EntryInfo.java
@@ -5,25 +5,21 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables Entry information. */
+@SuppressWarnings("MemberName")
 public final class EntryInfo {
   /** Entry handle. */
-  @SuppressWarnings("MemberName")
   public final int entry;
 
   /** Entry name. */
-  @SuppressWarnings("MemberName")
   public final String name;
 
   /** Entry type. */
-  @SuppressWarnings("MemberName")
   public final NetworkTableType type;
 
   /** Entry flags. */
-  @SuppressWarnings("MemberName")
   public final int flags;
 
   /** Timestamp of last change to entry (type or value). */
-  @SuppressWarnings("MemberName")
   public final long last_change;
 
   /**

--- a/ntcore/src/main/java/edu/wpi/first/networktables/EntryNotification.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/EntryNotification.java
@@ -5,27 +5,23 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables Entry notification. */
+@SuppressWarnings("MemberName")
 public final class EntryNotification {
   /** Listener that was triggered. */
-  @SuppressWarnings("MemberName")
   public final int listener;
 
   /** Entry handle. */
-  @SuppressWarnings("MemberName")
   public final int entry;
 
   /** Entry name. */
-  @SuppressWarnings("MemberName")
   public final String name;
 
   /** The new value. */
-  @SuppressWarnings("MemberName")
   public final NetworkTableValue value;
 
   /**
    * Update flags. For example, {@link EntryListenerFlags#kNew} if the key did not previously exist.
    */
-  @SuppressWarnings("MemberName")
   public final int flags;
 
   /**

--- a/ntcore/src/main/java/edu/wpi/first/networktables/LogMessage.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/LogMessage.java
@@ -5,6 +5,7 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables log message. */
+@SuppressWarnings("MemberName")
 public final class LogMessage {
   /** Logging levels. */
   public static final int kCritical = 50;
@@ -19,23 +20,18 @@ public final class LogMessage {
   public static final int kDebug4 = 6;
 
   /** The logger that generated the message. */
-  @SuppressWarnings("MemberName")
   public final int logger;
 
   /** Log level of the message. */
-  @SuppressWarnings("MemberName")
   public final int level;
 
   /** The filename of the source file that generated the message. */
-  @SuppressWarnings("MemberName")
   public final String filename;
 
   /** The line number in the source file that generated the message. */
-  @SuppressWarnings("MemberName")
   public final int line;
 
   /** The message. */
-  @SuppressWarnings("MemberName")
   public final String message;
 
   /**

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableInstance.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableInstance.java
@@ -207,7 +207,6 @@ public final class NetworkTableInstance implements AutoCloseable {
   private boolean m_entryListenerWaitQueue;
   private final Condition m_entryListenerWaitQueueCond = m_entryListenerLock.newCondition();
 
-  @SuppressWarnings("PMD.AvoidCatchingThrowable")
   private void startEntryListenerThread() {
     var entryListenerThread =
         new Thread(
@@ -375,7 +374,6 @@ public final class NetworkTableInstance implements AutoCloseable {
   private final Condition m_connectionListenerWaitQueueCond =
       m_connectionListenerLock.newCondition();
 
-  @SuppressWarnings("PMD.AvoidCatchingThrowable")
   private void startConnectionListenerThread() {
     var connectionListenerThread =
         new Thread(
@@ -524,7 +522,6 @@ public final class NetworkTableInstance implements AutoCloseable {
   private boolean m_rpcCallWaitQueue;
   private final Condition m_rpcCallWaitQueueCond = m_rpcCallLock.newCondition();
 
-  @SuppressWarnings("PMD.AvoidCatchingThrowable")
   private void startRpcCallThread() {
     var rpcCallThread =
         new Thread(
@@ -1048,7 +1045,6 @@ public final class NetworkTableInstance implements AutoCloseable {
   private boolean m_loggerWaitQueue;
   private final Condition m_loggerWaitQueueCond = m_loggerLock.newCondition();
 
-  @SuppressWarnings("PMD.AvoidCatchingThrowable")
   private void startLogThread() {
     var loggerThread =
         new Thread(

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableValue.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableValue.java
@@ -7,6 +7,7 @@ package edu.wpi.first.networktables;
 import java.util.Objects;
 
 /** A network table entry value. */
+@SuppressWarnings("PMD.MethodReturnsInternalArray")
 public final class NetworkTableValue {
   NetworkTableValue(NetworkTableType type, Object value, long time) {
     m_type = type;
@@ -183,7 +184,6 @@ public final class NetworkTableValue {
    * @return The raw value.
    * @throws ClassCastException if the entry value is not of raw type.
    */
-  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public byte[] getRaw() {
     if (m_type != NetworkTableType.kRaw) {
       throw new ClassCastException("cannot convert " + m_type + " to raw");
@@ -197,7 +197,6 @@ public final class NetworkTableValue {
    * @return The rpc definition value.
    * @throws ClassCastException if the entry value is not of rpc definition type.
    */
-  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public byte[] getRpc() {
     if (m_type != NetworkTableType.kRpc) {
       throw new ClassCastException("cannot convert " + m_type + " to rpc");
@@ -211,7 +210,6 @@ public final class NetworkTableValue {
    * @return The boolean array value.
    * @throws ClassCastException if the entry value is not of boolean array type.
    */
-  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public boolean[] getBooleanArray() {
     if (m_type != NetworkTableType.kBooleanArray) {
       throw new ClassCastException("cannot convert " + m_type + " to boolean array");
@@ -225,7 +223,6 @@ public final class NetworkTableValue {
    * @return The double array value.
    * @throws ClassCastException if the entry value is not of double array type.
    */
-  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public double[] getDoubleArray() {
     if (m_type != NetworkTableType.kDoubleArray) {
       throw new ClassCastException("cannot convert " + m_type + " to double array");
@@ -239,7 +236,6 @@ public final class NetworkTableValue {
    * @return The string array value.
    * @throws ClassCastException if the entry value is not of string array type.
    */
-  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public String[] getStringArray() {
     if (m_type != NetworkTableType.kStringArray) {
       throw new ClassCastException("cannot convert " + m_type + " to string array");

--- a/ntcore/src/main/java/edu/wpi/first/networktables/RpcAnswer.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/RpcAnswer.java
@@ -5,25 +5,21 @@
 package edu.wpi.first.networktables;
 
 /** NetworkTables Remote Procedure Call (Server Side). */
+@SuppressWarnings("MemberName")
 public final class RpcAnswer {
   /** Entry handle. */
-  @SuppressWarnings("MemberName")
   public final int entry;
 
   /** Call handle. */
-  @SuppressWarnings("MemberName")
   public int call;
 
   /** Entry name. */
-  @SuppressWarnings("MemberName")
   public final String name;
 
   /** Call raw parameters. */
-  @SuppressWarnings("MemberName")
   public final byte[] params;
 
   /** Connection that called the RPC. */
-  @SuppressWarnings("MemberName")
   public final ConnectionInfo conn;
 
   /**

--- a/styleguide/checkstyle-suppressions.xml
+++ b/styleguide/checkstyle-suppressions.xml
@@ -6,6 +6,8 @@ suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN"
   <suppress files=".*test.*" checks="MissingJavadocMethod" />
   <suppress files=".*wpilibjIntegrationTests.*"
     checks="MissingJavadocMethod" />
+  <suppress files="wpimath/*"
+    checks="(LocalVariableName|MemberName|MethodName|MethodTypeParameterName|ParameterName)" />
   <suppress files=".*JNI.*"
-    checks="(LineLength|EmptyLineSeparator|ParameterName|MissingJavadocMethod)" />
+    checks="(EmptyLineSeparator|LineLength|MissingJavadocMethod|ParameterName)" />
 </suppressions>

--- a/styleguide/checkstyle.xml
+++ b/styleguide/checkstyle.xml
@@ -170,19 +170,19 @@ module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
     </module>
     <module name="MemberName">
       <property name="format"
-        value="^(m_[a-z]([a-zA-Z0-9]*)|value)$" />
+        value="^(m_([a-zA-Z]|[a-z][a-zA-Z0-9]+)|value)$" />
       <message key="name.invalidPattern"
         value="Member name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="ParameterName">
       <property name="format"
-        value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+        value="^([a-zA-Z]|[a-z][a-zA-Z0-9]+)$" />
       <message key="name.invalidPattern"
         value="Parameter name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="LambdaParameterName">
       <property name="format"
-        value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+        value="^(_?[a-zA-Z]|_?[a-z][a-zA-Z0-9]+)$" />
       <message key="name.invalidPattern"
         value="Lambda parameter name ''{0}'' must match pattern ''{1}''." />
     </module>
@@ -195,26 +195,23 @@ module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
     <module name="LocalVariableName">
       <property name="tokens" value="VARIABLE_DEF" />
       <property name="format"
-        value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$" />
+        value="^([a-zA-Z][0-9]*|[a-z][a-zA-Z0-9]+)$" />
       <property name="allowOneCharVarInForLoop" value="true" />
       <message key="name.invalidPattern"
         value="Local variable name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="ClassTypeParameterName">
-      <property name="format"
-        value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+      <property name="format" value="^[A-Z][a-zA-Z0-9]*$" />
       <message key="name.invalidPattern"
         value="Class type name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="MethodTypeParameterName">
-      <property name="format"
-        value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+      <property name="format" value="^[A-Z][a-zA-Z0-9]*$" />
       <message key="name.invalidPattern"
         value="Method type name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="InterfaceTypeParameterName">
-      <property name="format"
-        value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)" />
+      <property name="format" value="^[A-Z][a-zA-Z0-9]*$" />
       <message key="name.invalidPattern"
         value="Interface type name ''{0}'' must match pattern ''{1}''." />
     </module>
@@ -228,10 +225,6 @@ module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
         value="GenericWhitespace ''{0}'' should followed by whitespace." />
       <message key="ws.notPreceded"
         value="GenericWhitespace ''{0}'' is not preceded with whitespace." />
-    </module>
-    <module name="AbbreviationAsWordInName">
-      <property name="ignoreFinal" value="false" />
-      <property name="allowedAbbreviationLength" value="4" />
     </module>
     <module name="OverloadMethodsDeclarationOrder" />
     <module name="VariableDeclarationUsageDistance" />

--- a/styleguide/pmd-ruleset.xml
+++ b/styleguide/pmd-ruleset.xml
@@ -13,15 +13,18 @@
     <exclude name="AccessorClassGeneration" />
     <exclude name="AccessorMethodGeneration" />
     <exclude name="AvoidPrintStackTrace" />
+    <exclude name="AvoidReassigningCatchVariables" />
     <exclude name="AvoidReassigningParameters" />
     <exclude name="AvoidUsingHardCodedIP" />
     <exclude name="ConstantsInInterface" />
     <exclude name="JUnitAssertionsShouldIncludeMessage" />
     <exclude name="JUnitTestContainsTooManyAsserts" />
+    <exclude name="JUnitTestsShouldIncludeAssert" />
     <exclude name="JUnit4TestShouldUseAfterAnnotation" />
     <exclude name="JUnit4TestShouldUseBeforeAnnotation" />
     <exclude name="JUnit4TestShouldUseTestAnnotation" />
     <exclude name="LooseCoupling" />
+    <exclude name="PreserveStackTrace" />
     <exclude name="ReplaceHashtableWithMap" />
     <exclude name="ReplaceVectorWithList" />
     <exclude name="SwitchStmtsShouldHaveDefault" />
@@ -58,6 +61,7 @@
 
   <rule ref="category/java/errorprone.xml">
     <exclude name="AssignmentToNonFinalStatic" />
+    <exclude name="AvoidCatchingThrowable" />
     <exclude name="AvoidDuplicateLiterals" />
     <exclude name="AvoidLiteralsInIfCondition" />
     <exclude name="BeanMembersShouldSerialize" />
@@ -65,6 +69,8 @@
     <exclude name="ConstructorCallsOverridableMethod" />
     <exclude name="DataflowAnomalyAnalysis" />
     <exclude name="DoNotTerminateVM" />
+    <exclude name="EmptyCatchBlock" />
+    <exclude name="EmptyWhileStmt" />
     <exclude name="FinalizeDoesNotCallSuperFinalize" />
     <exclude name="JUnitSpelling" />
     <exclude name="MissingSerialVersionUID" />

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/MecanumControllerCommand.java
@@ -38,7 +38,6 @@ import java.util.function.Supplier;
  *
  * <p>This class is provided by the NewCommands VendorDep
  */
-@SuppressWarnings("MemberName")
 public class MecanumControllerCommand extends CommandBase {
   private final Timer m_timer = new Timer();
   private final boolean m_usePID;
@@ -87,7 +86,6 @@ public class MecanumControllerCommand extends CommandBase {
    *     voltages.
    * @param requirements The subsystems to require.
    */
-  @SuppressWarnings("ParameterName")
   public MecanumControllerCommand(
       Trajectory trajectory,
       Supplier<Pose2d> pose,
@@ -179,7 +177,6 @@ public class MecanumControllerCommand extends CommandBase {
    *     voltages.
    * @param requirements The subsystems to require.
    */
-  @SuppressWarnings("ParameterName")
   public MecanumControllerCommand(
       Trajectory trajectory,
       Supplier<Pose2d> pose,
@@ -236,7 +233,6 @@ public class MecanumControllerCommand extends CommandBase {
    * @param outputWheelSpeeds A MecanumDriveWheelSpeeds object containing the output wheel speeds.
    * @param requirements The subsystems to require.
    */
-  @SuppressWarnings("ParameterName")
   public MecanumControllerCommand(
       Trajectory trajectory,
       Supplier<Pose2d> pose,
@@ -308,7 +304,6 @@ public class MecanumControllerCommand extends CommandBase {
    * @param outputWheelSpeeds A MecanumDriveWheelSpeeds object containing the output wheel speeds.
    * @param requirements The subsystems to require.
    */
-  @SuppressWarnings("ParameterName")
   public MecanumControllerCommand(
       Trajectory trajectory,
       Supplier<Pose2d> pose,
@@ -350,7 +345,6 @@ public class MecanumControllerCommand extends CommandBase {
   }
 
   @Override
-  @SuppressWarnings("LocalVariableName")
   public void execute() {
     double curTime = m_timer.get();
     double dt = curTime - m_prevTime;

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SwerveControllerCommand.java
@@ -31,7 +31,6 @@ import java.util.function.Supplier;
  *
  * <p>This class is provided by the NewCommands VendorDep
  */
-@SuppressWarnings("MemberName")
 public class SwerveControllerCommand extends CommandBase {
   private final Timer m_timer = new Timer();
   private final Trajectory m_trajectory;
@@ -61,7 +60,6 @@ public class SwerveControllerCommand extends CommandBase {
    * @param outputModuleStates The raw output module states from the position controllers.
    * @param requirements The subsystems to require.
    */
-  @SuppressWarnings("ParameterName")
   public SwerveControllerCommand(
       Trajectory trajectory,
       Supplier<Pose2d> pose,
@@ -114,7 +112,6 @@ public class SwerveControllerCommand extends CommandBase {
    * @param outputModuleStates The raw output module states from the position controllers.
    * @param requirements The subsystems to require.
    */
-  @SuppressWarnings("ParameterName")
   public SwerveControllerCommand(
       Trajectory trajectory,
       Supplier<Pose2d> pose,
@@ -144,7 +141,6 @@ public class SwerveControllerCommand extends CommandBase {
   }
 
   @Override
-  @SuppressWarnings("LocalVariableName")
   public void execute() {
     double curTime = m_timer.get();
     var desiredState = m_trajectory.sample(curTime);

--- a/wpilibc/src/main/native/include/frc/SynchronousInterrupt.h
+++ b/wpilibc/src/main/native/include/frc/SynchronousInterrupt.h
@@ -21,6 +21,9 @@ class DigitalSource;
  */
 class SynchronousInterrupt {
  public:
+  /**
+   * Event trigger combinations for a synchronous interrupt.
+   */
   enum WaitResult {
     kTimeout = 0x0,
     kRisingEdge = 0x1,

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
@@ -613,7 +613,6 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
     m_spi.write(buf, 2);
   }
 
-  /** {@inheritDoc} */
   public void reset() {
     synchronized (this) {
       m_integ_gyro_angle_x = 0.0;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16470_IMU.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16470_IMU.java
@@ -638,7 +638,6 @@ public class ADIS16470_IMU implements AutoCloseable, NTSendable {
     m_spi.write(buf, 2);
   }
 
-  /** {@inheritDoc} */
   public void reset() {
     synchronized (this) {
       m_integ_angle = 0.0;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_I2C.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_I2C.java
@@ -49,7 +49,6 @@ public class ADXL345_I2C implements Accelerometer, NTSendable, AutoCloseable {
     kZ((byte) 0x04);
 
     /** The integer value representing this enumeration. */
-    @SuppressWarnings("MemberName")
     public final byte value;
 
     Axes(byte value) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.java
@@ -26,7 +26,7 @@ import java.nio.ByteOrder;
  * <p>This class is for the digital ADXRS450 gyro sensor that connects via SPI. Only one instance of
  * an ADXRS Gyro is supported.
  */
-@SuppressWarnings({"TypeName", "AbbreviationAsWordInName", "PMD.UnusedPrivateField"})
+@SuppressWarnings({"TypeName", "PMD.UnusedPrivateField"})
 public class ADXRS450_Gyro implements Gyro, Sendable {
   private static final double kSamplePeriod = 0.0005;
   private static final double kCalibrationSampleTime = 5.0;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AddressableLEDBuffer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AddressableLEDBuffer.java
@@ -28,7 +28,6 @@ public class AddressableLEDBuffer {
    * @param g the g value [0-255]
    * @param b the b value [0-255]
    */
-  @SuppressWarnings("ParameterName")
   public void setRGB(int index, int r, int g, int b) {
     m_buffer[index * 4] = (byte) b;
     m_buffer[(index * 4) + 1] = (byte) g;
@@ -44,7 +43,6 @@ public class AddressableLEDBuffer {
    * @param s the s value [0-255]
    * @param v the v value [0-255]
    */
-  @SuppressWarnings("ParameterName")
   public void setHSV(final int index, final int h, final int s, final int v) {
     if (s == 0) {
       setRGB(index, v, v, v);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Counter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Counter.java
@@ -192,7 +192,6 @@ public class Counter implements CounterBase, Sendable, AutoCloseable {
    *
    * @return the Counter's FPGA index
    */
-  @SuppressWarnings("AbbreviationAsWordInName")
   public int getFPGAIndex() {
     return m_index;
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DataLogManager.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DataLogManager.java
@@ -188,7 +188,6 @@ public final class DataLogManager {
     }
   }
 
-  @SuppressWarnings("PMD.EmptyCatchBlock")
   private static String makeLogDir(String dir) {
     if (!dir.isEmpty()) {
       return dir;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -80,59 +80,25 @@ public final class DriverStation {
     }
   } /* DriverStationTask */
 
+  @SuppressWarnings("MemberName")
   private static class MatchDataSender {
-    @SuppressWarnings("MemberName")
     NetworkTable table;
-
-    @SuppressWarnings("MemberName")
     NetworkTableEntry typeMetadata;
-
-    @SuppressWarnings("MemberName")
     NetworkTableEntry gameSpecificMessage;
-
-    @SuppressWarnings("MemberName")
     NetworkTableEntry eventName;
-
-    @SuppressWarnings("MemberName")
     NetworkTableEntry matchNumber;
-
-    @SuppressWarnings("MemberName")
     NetworkTableEntry replayNumber;
-
-    @SuppressWarnings("MemberName")
     NetworkTableEntry matchType;
-
-    @SuppressWarnings("MemberName")
     NetworkTableEntry alliance;
-
-    @SuppressWarnings("MemberName")
     NetworkTableEntry station;
-
-    @SuppressWarnings("MemberName")
     NetworkTableEntry controlWord;
-
-    @SuppressWarnings("MemberName")
     boolean oldIsRedAlliance = true;
-
-    @SuppressWarnings("MemberName")
     int oldStationNumber = 1;
-
-    @SuppressWarnings("MemberName")
     String oldEventName = "";
-
-    @SuppressWarnings("MemberName")
     String oldGameSpecificMessage = "";
-
-    @SuppressWarnings("MemberName")
     int oldMatchNumber;
-
-    @SuppressWarnings("MemberName")
     int oldReplayNumber;
-
-    @SuppressWarnings("MemberName")
     int oldMatchType;
-
-    @SuppressWarnings("MemberName")
     int oldControlWord;
 
     MatchDataSender() {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycle.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycle.java
@@ -100,7 +100,6 @@ public class DutyCycle implements Sendable, AutoCloseable {
    *
    * @return the FPGA index
    */
-  @SuppressWarnings("AbbreviationAsWordInName")
   public final int getFPGAIndex() {
     return DutyCycleJNI.getFPGAIndex(m_handle);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycleEncoder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycleEncoder.java
@@ -299,7 +299,6 @@ public class DutyCycleEncoder implements Sendable, AutoCloseable {
    *
    * @return the FPGA index
    */
-  @SuppressWarnings("AbbreviationAsWordInName")
   public int getFPGAIndex() {
     return m_dutyCycle.getFPGAIndex();
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Encoder.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Encoder.java
@@ -282,7 +282,6 @@ public class Encoder implements CounterBase, Sendable, AutoCloseable {
    *
    * @return The Encoder's FPGA index.
    */
-  @SuppressWarnings("AbbreviationAsWordInName")
   public int getFPGAIndex() {
     return EncoderJNI.getEncoderFPGAIndex(m_encoder);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/I2C.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/I2C.java
@@ -116,7 +116,6 @@ public class I2C implements AutoCloseable {
    * @param receiveSize Number of bytes to read from the device.
    * @return Transfer Aborted... false for success, true for aborted.
    */
-  @SuppressWarnings("ByteBufferBackingArray")
   public synchronized boolean transaction(
       ByteBuffer dataToSend, int sendSize, ByteBuffer dataReceived, int receiveSize) {
     if (dataToSend.hasArray() && dataReceived.hasArray()) {
@@ -211,7 +210,6 @@ public class I2C implements AutoCloseable {
    * @param size The number of data bytes to write.
    * @return Transfer Aborted... false for success, true for aborted.
    */
-  @SuppressWarnings("ByteBufferBackingArray")
   public synchronized boolean writeBulk(ByteBuffer data, int size) {
     if (data.hasArray()) {
       return writeBulk(data.array(), size);
@@ -266,7 +264,6 @@ public class I2C implements AutoCloseable {
    * @param buffer A buffer to store the data read from the device.
    * @return Transfer Aborted... false for success, true for aborted.
    */
-  @SuppressWarnings("ByteBufferBackingArray")
   public boolean read(int registerAddress, int count, ByteBuffer buffer) {
     if (count < 1) {
       throw new BoundaryException("Value must be at least 1, " + count + " given");
@@ -323,7 +320,6 @@ public class I2C implements AutoCloseable {
    * @param count The number of bytes to read in the transaction.
    * @return Transfer Aborted... false for success, true for aborted.
    */
-  @SuppressWarnings("ByteBufferBackingArray")
   public boolean readOnly(ByteBuffer buffer, int count) {
     if (count < 1) {
       throw new BoundaryException("Value must be at least 1, " + count + " given");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -134,7 +134,6 @@ public abstract class IterativeRobotBase extends RobotBase {
    * <p>Users should override this method for initialization code which will be called each time the
    * robot enters test mode.
    */
-  @SuppressWarnings("PMD.JUnit4TestShouldUseTestAnnotation")
   public void testInit() {}
 
   /* ----------- Overridable periodic code ----------------- */
@@ -196,7 +195,6 @@ public abstract class IterativeRobotBase extends RobotBase {
   private boolean m_tmpFirstRun = true;
 
   /** Periodic code for test mode should go here. */
-  @SuppressWarnings("PMD.JUnit4TestShouldUseTestAnnotation")
   public void testPeriodic() {
     if (m_tmpFirstRun) {
       System.out.println("Default testPeriodic() method... Override me!");
@@ -234,7 +232,6 @@ public abstract class IterativeRobotBase extends RobotBase {
    * <p>Users should override this method for code which will be called each time the robot exits
    * test mode.
    */
-  @SuppressWarnings("PMD.JUnit4TestShouldUseTestAnnotation")
   public void testExit() {}
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -269,27 +269,11 @@ public abstract class RobotBase implements AutoCloseable {
   /** Ends the main loop in startCompetition(). */
   public abstract void endCompetition();
 
-  @SuppressWarnings("MissingJavadocMethod")
-  public static boolean getBooleanProperty(String name, boolean defaultValue) {
-    String propVal = System.getProperty(name);
-    if (propVal == null) {
-      return defaultValue;
-    }
-    if ("false".equalsIgnoreCase(propVal)) {
-      return false;
-    } else if ("true".equalsIgnoreCase(propVal)) {
-      return true;
-    } else {
-      throw new IllegalStateException(propVal);
-    }
-  }
-
   private static final ReentrantLock m_runMutex = new ReentrantLock();
   private static RobotBase m_robotCopy;
   private static boolean m_suppressExitWarning;
 
   /** Run the robot main loop. */
-  @SuppressWarnings({"PMD.AvoidCatchingThrowable", "PMD.AvoidReassigningCatchVariables"})
   private static <T extends RobotBase> void runRobot(Supplier<T> robotSupplier) {
     System.out.println("********** Robot program starting **********");
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotController.java
@@ -21,7 +21,6 @@ public final class RobotController {
    *
    * @return FPGA Version number.
    */
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static int getFPGAVersion() {
     return HALUtil.getFPGAVersion();
   }
@@ -33,7 +32,6 @@ public final class RobotController {
    *
    * @return FPGA Revision number.
    */
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static long getFPGARevision() {
     return (long) HALUtil.getFPGARevision();
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotState.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotState.java
@@ -4,28 +4,57 @@
 
 package edu.wpi.first.wpilibj;
 
-@SuppressWarnings("MissingJavadocMethod")
 public final class RobotState {
+  /**
+   * Returns true if the robot is disabled.
+   *
+   * @return True if the robot is disabled.
+   */
   public static boolean isDisabled() {
     return DriverStation.isDisabled();
   }
 
+  /**
+   * Returns true if the robot is enabled.
+   *
+   * @return True if the robot is enabled.
+   */
   public static boolean isEnabled() {
     return DriverStation.isEnabled();
   }
 
+  /**
+   * Returns true if the robot is E-stopped.
+   *
+   * @return True if the robot is E-stopped.
+   */
   public static boolean isEStopped() {
     return DriverStation.isEStopped();
   }
 
+  /**
+   * Returns true if the robot is in teleop mode.
+   *
+   * @return True if the robot is in teleop mode.
+   */
   public static boolean isTeleop() {
     return DriverStation.isTeleop();
   }
 
+  /**
+   * Returns true if the robot is in autonomous mode.
+   *
+   * @return True if the robot is in autonomous mode.
+   */
   public static boolean isAutonomous() {
     return DriverStation.isAutonomous();
   }
 
+  /**
+   * Returns true if the robot is in test mode.
+   *
+   * @return True if the robot is in test mode.
+   */
   public static boolean isTest() {
     return DriverStation.isTest();
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SPI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SPI.java
@@ -160,7 +160,6 @@ public class SPI implements AutoCloseable {
    * @param size The number of bytes to send.
    * @return Number of bytes written or -1 on error.
    */
-  @SuppressWarnings("ByteBufferBackingArray")
   public int write(ByteBuffer dataToSend, int size) {
     if (dataToSend.hasArray()) {
       return write(dataToSend.array(), size);
@@ -209,7 +208,6 @@ public class SPI implements AutoCloseable {
    * @param size The length of the transaction, in bytes
    * @return Number of bytes read or -1 on error.
    */
-  @SuppressWarnings("ByteBufferBackingArray")
   public int read(boolean initiate, ByteBuffer dataReceived, int size) {
     if (dataReceived.hasArray()) {
       return read(initiate, dataReceived.array(), size);
@@ -249,7 +247,6 @@ public class SPI implements AutoCloseable {
    * @param size The length of the transaction, in bytes
    * @return TODO
    */
-  @SuppressWarnings("ByteBufferBackingArray")
   public int transaction(ByteBuffer dataToSend, ByteBuffer dataReceived, int size) {
     if (dataToSend.hasArray() && dataReceived.hasArray()) {
       return transaction(dataToSend.array(), dataReceived.array(), size);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SensorUtil.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SensorUtil.java
@@ -141,7 +141,6 @@ public final class SensorUtil {
    *
    * @return The number of the default solenoid module.
    */
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static int getDefaultCTREPCMModule() {
     return 0;
   }
@@ -151,7 +150,6 @@ public final class SensorUtil {
    *
    * @return The number of the default solenoid module.
    */
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static int getDefaultREVPHModule() {
     return 1;
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/SynchronousInterrupt.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/SynchronousInterrupt.java
@@ -21,14 +21,13 @@ public class SynchronousInterrupt implements AutoCloseable {
 
   private final int m_handle;
 
-  @SuppressWarnings("JavadocMethod")
+  /** Event trigger combinations for a synchronous interrupt. */
   public enum WaitResult {
     kTimeout(0x0),
     kRisingEdge(0x1),
     kFallingEdge(0x100),
     kBoth(0x101);
 
-    @SuppressWarnings("MemberName")
     public final int value;
 
     WaitResult(int value) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/TimedRobot.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/TimedRobot.java
@@ -101,7 +101,6 @@ public class TimedRobot extends IterativeRobotBase {
 
   /** Provide an alternate "main loop" via startCompetition(). */
   @Override
-  @SuppressWarnings("UnsafeFinalization")
   public void startCompetition() {
     robotInit();
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Timer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Timer.java
@@ -17,7 +17,6 @@ public class Timer {
    *
    * @return Robot running time in seconds.
    */
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static double getFPGATimestamp() {
     return RobotController.getFPGATime() / 1000000.0;
   }
@@ -55,7 +54,7 @@ public class Timer {
   private double m_accumulatedTime;
   private boolean m_running;
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /** Timer constructor. */
   public Timer() {
     reset();
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
@@ -22,7 +22,6 @@ public class Tracer {
   private long m_lastEpochsPrintTime; // microseconds
   private long m_startTime; // microseconds
 
-  @SuppressWarnings("PMD.UseConcurrentHashMap")
   private final Map<String, Long> m_epochs = new HashMap<>(); // microseconds
 
   /** Tracer constructor. */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -208,7 +208,6 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
     m_suppressTimeoutMessage = suppress;
   }
 
-  @SuppressWarnings("resource")
   private static void updateAlarm() {
     if (m_watchdogs.size() == 0) {
       NotifierJNI.cancelNotifierAlarm(m_notifier);
@@ -225,7 +224,6 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
     return inst;
   }
 
-  @SuppressWarnings("PMD.AvoidDeeplyNestedIfStmts")
   private static void schedulerFunc() {
     while (!Thread.currentThread().isInterrupted()) {
       long curTime = NotifierJNI.waitForNotifierAlarm(m_notifier);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/XboxController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/XboxController.java
@@ -30,7 +30,6 @@ public class XboxController extends GenericHID {
     kBack(7),
     kStart(8);
 
-    @SuppressWarnings("MemberName")
     public final int value;
 
     Button(int value) {
@@ -64,7 +63,6 @@ public class XboxController extends GenericHID {
     kLeftTrigger(2),
     kRightTrigger(3);
 
-    @SuppressWarnings("MemberName")
     public final int value;
 
     Axis(int value) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -155,7 +155,6 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
    *     positive.
    */
-  @SuppressWarnings("ParameterName")
   public void arcadeDrive(double xSpeed, double zRotation) {
     arcadeDrive(xSpeed, zRotation, true);
   }
@@ -168,7 +167,6 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    *     positive.
    * @param squareInputs If set, decreases the input sensitivity at low speeds.
    */
-  @SuppressWarnings("ParameterName")
   public void arcadeDrive(double xSpeed, double zRotation, boolean squareInputs) {
     if (!m_reported) {
       HAL.report(
@@ -198,7 +196,6 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * @param allowTurnInPlace If set, overrides constant-curvature turning for turn-in-place
    *     maneuvers. zRotation will control turning rate instead of curvature.
    */
-  @SuppressWarnings("ParameterName")
   public void curvatureDrive(double xSpeed, double zRotation, boolean allowTurnInPlace) {
     if (!m_reported) {
       HAL.report(
@@ -264,7 +261,6 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    * @param squareInputs If set, decreases the input sensitivity at low speeds.
    * @return Wheel speeds [-1.0..1.0].
    */
-  @SuppressWarnings("ParameterName")
   public static WheelSpeeds arcadeDriveIK(double xSpeed, double zRotation, boolean squareInputs) {
     xSpeed = MathUtil.clamp(xSpeed, -1.0, 1.0);
     zRotation = MathUtil.clamp(zRotation, -1.0, 1.0);
@@ -323,7 +319,6 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
    *     maneuvers. zRotation will control rotation rate around the Z axis instead of curvature.
    * @return Wheel speeds [-1.0..1.0].
    */
-  @SuppressWarnings("ParameterName")
   public static WheelSpeeds curvatureDriveIK(
       double xSpeed, double zRotation, boolean allowTurnInPlace) {
     xSpeed = MathUtil.clamp(xSpeed, -1.0, 1.0);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/KilloughDrive.java
@@ -172,7 +172,6 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
    * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
    *     positive.
    */
-  @SuppressWarnings("ParameterName")
   public void driveCartesian(double ySpeed, double xSpeed, double zRotation) {
     driveCartesian(ySpeed, xSpeed, zRotation, 0.0);
   }
@@ -190,7 +189,6 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
    * @param gyroAngle The current angle reading from the gyro in degrees around the Z axis. Use this
    *     to implement field-oriented controls.
    */
-  @SuppressWarnings("ParameterName")
   public void driveCartesian(double ySpeed, double xSpeed, double zRotation, double gyroAngle) {
     if (!m_reported) {
       HAL.report(
@@ -221,7 +219,6 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
    * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
    *     positive.
    */
-  @SuppressWarnings("ParameterName")
   public void drivePolar(double magnitude, double angle, double zRotation) {
     if (!m_reported) {
       HAL.report(tResourceType.kResourceType_RobotDrive, tInstances.kRobotDrive2_KilloughPolar, 3);
@@ -247,7 +244,6 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
    *     positive.
    * @return Wheel speeds [-1.0..1.0].
    */
-  @SuppressWarnings("ParameterName")
   public WheelSpeeds driveCartesianIK(double ySpeed, double xSpeed, double zRotation) {
     return driveCartesianIK(ySpeed, xSpeed, zRotation, 0.0);
   }
@@ -266,7 +262,6 @@ public class KilloughDrive extends RobotDriveBase implements Sendable, AutoClose
    *     to implement field-oriented controls.
    * @return Wheel speeds [-1.0..1.0].
    */
-  @SuppressWarnings("ParameterName")
   public WheelSpeeds driveCartesianIK(
       double ySpeed, double xSpeed, double zRotation, double gyroAngle) {
     ySpeed = MathUtil.clamp(ySpeed, -1.0, 1.0);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
@@ -139,7 +139,6 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
    * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
    *     positive.
    */
-  @SuppressWarnings("ParameterName")
   public void driveCartesian(double ySpeed, double xSpeed, double zRotation) {
     driveCartesian(ySpeed, xSpeed, zRotation, 0.0);
   }
@@ -157,7 +156,6 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
    * @param gyroAngle The current angle reading from the gyro in degrees around the Z axis. Use this
    *     to implement field-oriented controls.
    */
-  @SuppressWarnings("ParameterName")
   public void driveCartesian(double ySpeed, double xSpeed, double zRotation, double gyroAngle) {
     if (!m_reported) {
       HAL.report(
@@ -189,7 +187,6 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
    * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
    *     positive.
    */
-  @SuppressWarnings("ParameterName")
   public void drivePolar(double magnitude, double angle, double zRotation) {
     if (!m_reported) {
       HAL.report(tResourceType.kResourceType_RobotDrive, tInstances.kRobotDrive2_MecanumPolar, 4);
@@ -215,7 +212,6 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
    *     positive.
    * @return Wheel speeds [-1.0..1.0].
    */
-  @SuppressWarnings("ParameterName")
   public static WheelSpeeds driveCartesianIK(double ySpeed, double xSpeed, double zRotation) {
     return driveCartesianIK(ySpeed, xSpeed, zRotation, 0.0);
   }
@@ -234,7 +230,6 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
    *     to implement field-oriented controls.
    * @return Wheel speeds [-1.0..1.0].
    */
-  @SuppressWarnings("ParameterName")
   public static WheelSpeeds driveCartesianIK(
       double ySpeed, double xSpeed, double zRotation, double gyroAngle) {
     ySpeed = MathUtil.clamp(ySpeed, -1.0, 1.0);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/Vector2d.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/Vector2d.java
@@ -5,11 +5,9 @@
 package edu.wpi.first.wpilibj.drive;
 
 /** This is a 2D vector struct that supports basic vector operations. */
+@SuppressWarnings("MemberName")
 public class Vector2d {
-  @SuppressWarnings("MemberName")
   public double x;
-
-  @SuppressWarnings("MemberName")
   public double y;
 
   public Vector2d() {}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/SendableCameraWrapper.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/SendableCameraWrapper.java
@@ -37,7 +37,6 @@ public final class SendableCameraWrapper implements Sendable, AutoCloseable {
   }
 
   /** Clears all cached wrapper objects. This should only be used in tests. */
-  @SuppressWarnings("PMD.DefaultPackage")
   static void clearWrappers() {
     m_wrappers.clear();
   }
@@ -73,7 +72,6 @@ public final class SendableCameraWrapper implements Sendable, AutoCloseable {
    * @return a sendable wrapper object for the video source, usable in Shuffleboard via {@link
    *     ShuffleboardTab#add(Sendable)} and {@link ShuffleboardLayout#add(Sendable)}
    */
-  @SuppressWarnings("PMD.CyclomaticComplexity")
   public static SendableCameraWrapper wrap(String cameraName, String... cameraUrls) {
     if (m_wrappers.containsKey(cameraName)) {
       return m_wrappers.get(cameraName);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADIS16448_IMUSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADIS16448_IMUSim.java
@@ -8,7 +8,7 @@ import edu.wpi.first.hal.SimDouble;
 import edu.wpi.first.wpilibj.ADIS16448_IMU;
 
 /** Class to control a simulated ADIS16448 gyroscope. */
-@SuppressWarnings({"TypeName", "AbbreviationAsWordInName"})
+@SuppressWarnings("TypeName")
 public class ADIS16448_IMUSim {
   private final SimDouble m_simGyroAngleX;
   private final SimDouble m_simGyroAngleY;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADIS16470_IMUSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADIS16470_IMUSim.java
@@ -8,7 +8,7 @@ import edu.wpi.first.hal.SimDouble;
 import edu.wpi.first.wpilibj.ADIS16470_IMU;
 
 /** Class to control a simulated ADIS16470 gyroscope. */
-@SuppressWarnings({"TypeName", "AbbreviationAsWordInName"})
+@SuppressWarnings("TypeName")
 public class ADIS16470_IMUSim {
   private final SimDouble m_simGyroAngleX;
   private final SimDouble m_simGyroAngleY;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADXRS450_GyroSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ADXRS450_GyroSim.java
@@ -8,7 +8,7 @@ import edu.wpi.first.hal.SimDouble;
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;
 
 /** Class to control a simulated ADXRS450 gyroscope. */
-@SuppressWarnings({"TypeName", "AbbreviationAsWordInName"})
+@SuppressWarnings("TypeName")
 public class ADXRS450_GyroSim {
   private final SimDouble m_simAngle;
   private final SimDouble m_simRate;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/BuiltInAccelerometerSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/BuiltInAccelerometerSim.java
@@ -116,7 +116,6 @@ public class BuiltInAccelerometerSim {
    *
    * @param x the new reading of the X axis
    */
-  @SuppressWarnings("ParameterName")
   public void setX(double x) {
     AccelerometerDataJNI.setX(m_index, x);
   }
@@ -148,7 +147,6 @@ public class BuiltInAccelerometerSim {
    *
    * @param y the new reading of the Y axis
    */
-  @SuppressWarnings("ParameterName")
   public void setY(double y) {
     AccelerometerDataJNI.setY(m_index, y);
   }
@@ -180,7 +178,6 @@ public class BuiltInAccelerometerSim {
    *
    * @param z the new reading of the Z axis
    */
-  @SuppressWarnings("ParameterName")
   public void setZ(double z) {
     AccelerometerDataJNI.setZ(m_index, z);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CTREPCMSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/CTREPCMSim.java
@@ -10,7 +10,6 @@ import edu.wpi.first.wpilibj.PneumaticsControlModule;
 import edu.wpi.first.wpilibj.SensorUtil;
 
 /** Class to control a simulated Pneumatic Control Module (PCM). */
-@SuppressWarnings("AbbreviationAsWordInName")
 public class CTREPCMSim extends PneumaticsBaseSim {
   /** Constructs for the default PCM. */
   public CTREPCMSim() {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
@@ -59,7 +59,6 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
    * @param jKgMetersSquared The moment of inertia of the DC motor. If this is unknown, use the
    *     {@link #DCMotorSim(LinearSystem, DCMotor, double, Matrix)} constructor.
    */
-  @SuppressWarnings("ParameterName")
   public DCMotorSim(DCMotor gearbox, double gearing, double jKgMetersSquared) {
     super(LinearSystemId.createDCMotorSystem(gearbox, jKgMetersSquared, gearing));
     m_gearbox = gearbox;
@@ -75,7 +74,6 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
    *     {@link #DCMotorSim(LinearSystem, DCMotor, double, Matrix)} constructor.
    * @param measurementStdDevs The standard deviations of the measurements.
    */
-  @SuppressWarnings("ParameterName")
   public DCMotorSim(
       DCMotor gearbox, double gearing, double jKgMetersSquared, Matrix<N2, N1> measurementStdDevs) {
     super(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DifferentialDrivetrainSim.java
@@ -44,13 +44,8 @@ public class DifferentialDrivetrainSim {
   private double m_currentGearing;
   private final double m_wheelRadiusMeters;
 
-  @SuppressWarnings("MemberName")
   private Matrix<N2, N1> m_u;
-
-  @SuppressWarnings("MemberName")
   private Matrix<N7, N1> m_x;
-
-  @SuppressWarnings("MemberName")
   private Matrix<N7, N1> m_y;
 
   private final double m_rb;
@@ -72,7 +67,6 @@ public class DifferentialDrivetrainSim {
    *     m/s, and position measurement standard deviations of 0.005 meters are a reasonable starting
    *     point.
    */
-  @SuppressWarnings("ParameterName")
   public DifferentialDrivetrainSim(
       DCMotor driveMotor,
       double gearing,
@@ -153,7 +147,6 @@ public class DifferentialDrivetrainSim {
    *
    * @param dtSeconds the time difference
    */
-  @SuppressWarnings("LocalVariableName")
   public void update(double dtSeconds) {
     // Update state estimate with RK4
     m_x = NumericalIntegration.rk4(this::getDynamics, m_x, m_u, dtSeconds);
@@ -316,7 +309,6 @@ public class DifferentialDrivetrainSim {
     m_x.set(State.kRightPosition.value, 0, 0);
   }
 
-  @SuppressWarnings({"DuplicatedCode", "LocalVariableName", "ParameterName"})
   protected Matrix<N7, N1> getDynamics(Matrix<N7, N1> x, Matrix<N2, N1> u) {
     // Because G can be factored out of B, we can divide by the old ratio and multiply
     // by the new ratio to get a new drivetrain model.
@@ -373,10 +365,8 @@ public class DifferentialDrivetrainSim {
     kLeftPosition(5),
     kRightPosition(6);
 
-    @SuppressWarnings("MemberName")
     public final int value;
 
-    @SuppressWarnings("ParameterName")
     State(int i) {
       this.value = i;
     }
@@ -393,10 +383,8 @@ public class DifferentialDrivetrainSim {
     k7p31(7.31),
     k5p95(5.95);
 
-    @SuppressWarnings("MemberName")
     public final double value;
 
-    @SuppressWarnings("ParameterName")
     KitbotGearing(double i) {
       this.value = i;
     }
@@ -413,10 +401,8 @@ public class DifferentialDrivetrainSim {
     kSingleNEOPerSide(DCMotor.getNEO(1)),
     kDoubleNEOPerSide(DCMotor.getNEO(2));
 
-    @SuppressWarnings("MemberName")
     public final DCMotor value;
 
-    @SuppressWarnings("ParameterName")
     KitbotMotor(DCMotor i) {
       this.value = i;
     }
@@ -428,10 +414,8 @@ public class DifferentialDrivetrainSim {
     kEightInch(Units.inchesToMeters(8)),
     kTenInch(Units.inchesToMeters(10));
 
-    @SuppressWarnings("MemberName")
     public final double value;
 
-    @SuppressWarnings("ParameterName")
     KitbotWheelSize(double i) {
       this.value = i;
     }
@@ -479,7 +463,6 @@ public class DifferentialDrivetrainSim {
    *     point.
    * @return A sim for the standard FRC kitbot.
    */
-  @SuppressWarnings("ParameterName")
   public static DifferentialDrivetrainSim createKitbotSim(
       KitbotMotor motor,
       KitbotGearing gearing,

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DriverStationSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DriverStationSim.java
@@ -138,7 +138,6 @@ public final class DriverStationSim {
    *
    * @param eStop true to activate
    */
-  @SuppressWarnings("ParameterName")
   public static void setEStop(boolean eStop) {
     DriverStationDataJNI.setEStop(eStop);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
@@ -244,14 +244,13 @@ public class ElevatorSim extends LinearSystemSim<N2, N1, N1> {
    * @param u The system inputs (voltage).
    * @param dtSeconds The time difference between controller updates.
    */
-  @SuppressWarnings({"ParameterName", "LambdaParameterName"})
   @Override
   protected Matrix<N2, N1> updateX(Matrix<N2, N1> currentXhat, Matrix<N1, N1> u, double dtSeconds) {
     // Calculate updated x-hat from Runge-Kutta.
     var updatedXhat =
         NumericalIntegration.rkdp(
-            (x, u_) -> {
-              Matrix<N2, N1> xdot = m_plant.getA().times(x).plus(m_plant.getB().times(u_));
+            (x, _u) -> {
+              Matrix<N2, N1> xdot = m_plant.getA().times(x).plus(m_plant.getB().times(_u));
               if (m_simulateGravity) {
                 xdot = xdot.plus(VecBuilder.fill(0, -9.8));
               }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/FlywheelSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/FlywheelSim.java
@@ -58,7 +58,6 @@ public class FlywheelSim extends LinearSystemSim<N1, N1, N1> {
    * @param jKgMetersSquared The moment of inertia of the flywheel. If this is unknown, use the
    *     {@link #FlywheelSim(LinearSystem, DCMotor, double, Matrix)} constructor.
    */
-  @SuppressWarnings("ParameterName")
   public FlywheelSim(DCMotor gearbox, double gearing, double jKgMetersSquared) {
     super(LinearSystemId.createFlywheelSystem(gearbox, jKgMetersSquared, gearing));
     m_gearbox = gearbox;
@@ -74,7 +73,6 @@ public class FlywheelSim extends LinearSystemSim<N1, N1, N1> {
    *     {@link #FlywheelSim(LinearSystem, DCMotor, double, Matrix)} constructor.
    * @param measurementStdDevs The standard deviations of the measurements.
    */
-  @SuppressWarnings("ParameterName")
   public FlywheelSim(
       DCMotor gearbox, double gearing, double jKgMetersSquared, Matrix<N1, N1> measurementStdDevs) {
     super(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/LinearSystemSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/LinearSystemSim.java
@@ -27,19 +27,13 @@ import org.ejml.simple.SimpleMatrix;
  * @param <Inputs> The number of inputs to the system.
  * @param <Outputs> The number of outputs of the system.
  */
-@SuppressWarnings("ClassTypeParameterName")
 public class LinearSystemSim<States extends Num, Inputs extends Num, Outputs extends Num> {
   // The plant that represents the linear system.
   protected final LinearSystem<States, Inputs, Outputs> m_plant;
 
   // Variables for state, output, and input.
-  @SuppressWarnings("MemberName")
   protected Matrix<States, N1> m_x;
-
-  @SuppressWarnings("MemberName")
   protected Matrix<Outputs, N1> m_y;
-
-  @SuppressWarnings("MemberName")
   protected Matrix<Inputs, N1> m_u;
 
   // The standard deviations of measurements, used for adding noise
@@ -77,7 +71,6 @@ public class LinearSystemSim<States extends Num, Inputs extends Num, Outputs ext
    *
    * @param dtSeconds The time between updates.
    */
-  @SuppressWarnings("LocalVariableName")
   public void update(double dtSeconds) {
     // Update X. By default, this is the linear system dynamics X = Ax + Bu
     m_x = updateX(m_x, m_u, dtSeconds);
@@ -115,7 +108,6 @@ public class LinearSystemSim<States extends Num, Inputs extends Num, Outputs ext
    *
    * @param u The system inputs.
    */
-  @SuppressWarnings("ParameterName")
   public void setInput(Matrix<Inputs, N1> u) {
     this.m_u = clampInput(u);
   }
@@ -136,7 +128,6 @@ public class LinearSystemSim<States extends Num, Inputs extends Num, Outputs ext
    *
    * @param u An array of doubles that represent the inputs of the system.
    */
-  @SuppressWarnings("ParameterName")
   public void setInput(double... u) {
     if (u.length != m_u.getNumRows()) {
       throw new MatrixDimensionException(
@@ -172,7 +163,6 @@ public class LinearSystemSim<States extends Num, Inputs extends Num, Outputs ext
    * @param dtSeconds The time difference between controller updates.
    * @return The new state.
    */
-  @SuppressWarnings("ParameterName")
   protected Matrix<States, N1> updateX(
       Matrix<States, N1> currentXhat, Matrix<Inputs, N1> u, double dtSeconds) {
     return m_plant.calculateX(currentXhat, u, dtSeconds);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/REVPHSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/REVPHSim.java
@@ -10,7 +10,6 @@ import edu.wpi.first.wpilibj.PneumaticHub;
 import edu.wpi.first.wpilibj.SensorUtil;
 
 /** Class to control a simulated PneumaticHub (PH). */
-@SuppressWarnings("AbbreviationAsWordInName")
 public class REVPHSim extends PneumaticsBaseSim {
   /** Constructs for the default PH. */
   public REVPHSim() {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/RoboRioSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/RoboRioSim.java
@@ -21,7 +21,6 @@ public final class RoboRioSim {
    * @return the {@link CallbackStore} object associated with this callback. Save a reference to
    *     this object so GC doesn't cancel the callback.
    */
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static CallbackStore registerFPGAButtonCallback(
       NotifyCallback callback, boolean initialNotify) {
     int uid = RoboRioDataJNI.registerFPGAButtonCallback(callback, initialNotify);
@@ -33,7 +32,6 @@ public final class RoboRioSim {
    *
    * @return the FPGA button state
    */
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static boolean getFPGAButton() {
     return RoboRioDataJNI.getFPGAButton();
   }
@@ -43,7 +41,6 @@ public final class RoboRioSim {
    *
    * @param fpgaButton the new state
    */
-  @SuppressWarnings("AbbreviationAsWordInName")
   public static void setFPGAButton(boolean fpgaButton) {
     RoboRioDataJNI.setFPGAButton(fpgaButton);
   }
@@ -76,7 +73,6 @@ public final class RoboRioSim {
    *
    * @param vInVoltage the new voltage
    */
-  @SuppressWarnings("ParameterName")
   public static void setVInVoltage(double vInVoltage) {
     RoboRioDataJNI.setVInVoltage(vInVoltage);
   }
@@ -109,7 +105,6 @@ public final class RoboRioSim {
    *
    * @param vInCurrent the new current
    */
-  @SuppressWarnings("ParameterName")
   public static void setVInCurrent(double vInCurrent) {
     RoboRioDataJNI.setVInCurrent(vInCurrent);
   }
@@ -526,7 +521,6 @@ public final class RoboRioSim {
    *
    * @param vInVoltage the new voltage
    */
-  @SuppressWarnings("ParameterName")
   public static void setBrownoutVoltage(double vInVoltage) {
     RoboRioDataJNI.setBrownoutVoltage(vInVoltage);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SPIAccelerometerSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SPIAccelerometerSim.java
@@ -109,7 +109,6 @@ public class SPIAccelerometerSim {
    *
    * @param x the new reading of the X axis
    */
-  @SuppressWarnings("ParameterName")
   public void setX(double x) {
     SPIAccelerometerDataJNI.setX(m_index, x);
   }
@@ -141,7 +140,6 @@ public class SPIAccelerometerSim {
    *
    * @param y the new reading of the Y axis
    */
-  @SuppressWarnings("ParameterName")
   public void setY(double y) {
     SPIAccelerometerDataJNI.setY(m_index, y);
   }
@@ -173,7 +171,6 @@ public class SPIAccelerometerSim {
    *
    * @param z the new reading of the Z axis
    */
-  @SuppressWarnings("ParameterName")
   public void setZ(double z) {
     SPIAccelerometerDataJNI.setZ(m_index, z);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
@@ -22,7 +22,6 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
   private final double m_gearing;
 
   // The length of the arm.
-  @SuppressWarnings("MemberName")
   private final double m_r;
 
   // The minimum angle that the arm is capable of.
@@ -115,7 +114,6 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
    * @param armMassKg The mass of the arm.
    * @param simulateGravity Whether gravity should be simulated or not.
    */
-  @SuppressWarnings("ParameterName")
   public SingleJointedArmSim(
       DCMotor gearbox,
       double gearing,
@@ -150,7 +148,6 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
    * @param simulateGravity Whether gravity should be simulated or not.
    * @param measurementStdDevs The standard deviations of the measurements.
    */
-  @SuppressWarnings("ParameterName")
   public SingleJointedArmSim(
       DCMotor gearbox,
       double gearing,
@@ -270,7 +267,6 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
    * @param dtSeconds The time difference between controller updates.
    */
   @Override
-  @SuppressWarnings({"ParameterName", "LambdaParameterName"})
   protected Matrix<N2, N1> updateX(Matrix<N2, N1> currentXhat, Matrix<N1, N1> u, double dtSeconds) {
     // Horizontal case:
     // Torque = F * r = I * alpha
@@ -283,8 +279,8 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
     // cos(theta)]]
     Matrix<N2, N1> updatedXhat =
         NumericalIntegration.rkdp(
-            (Matrix<N2, N1> x, Matrix<N1, N1> u_) -> {
-              Matrix<N2, N1> xdot = m_plant.getA().times(x).plus(m_plant.getB().times(u_));
+            (Matrix<N2, N1> x, Matrix<N1, N1> _u) -> {
+              Matrix<N2, N1> xdot = m_plant.getA().times(x).plus(m_plant.getB().times(_u));
               if (m_simulateGravity) {
                 xdot =
                     xdot.plus(

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/Field2d.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/Field2d.java
@@ -54,7 +54,6 @@ public class Field2d implements NTSendable {
    * @param yMeters Y location, in meters
    * @param rotation rotation
    */
-  @SuppressWarnings("ParameterName")
   public synchronized void setRobotPose(double xMeters, double yMeters, Rotation2d rotation) {
     m_objects.get(0).setPose(xMeters, yMeters, rotation);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/FieldObject2d.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/FieldObject2d.java
@@ -41,7 +41,6 @@ public class FieldObject2d {
    * @param yMeters Y location, in meters
    * @param rotation rotation
    */
-  @SuppressWarnings("ParameterName")
   public synchronized void setPose(double xMeters, double yMeters, Rotation2d rotation) {
     setPose(new Pose2d(xMeters, yMeters, rotation));
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
@@ -50,7 +50,6 @@ public class Color {
    * @param v The v value [0-255]
    * @return The color
    */
-  @SuppressWarnings("ParameterName")
   public static Color fromHSV(int h, int s, int v) {
     if (s == 0) {
       return new Color(v / 255.0, v / 255.0, v / 255.0);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/AddressableLEDBufferTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/AddressableLEDBufferTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 class AddressableLEDBufferTest {
   @ParameterizedTest
   @MethodSource("hsvToRgbProvider")
-  @SuppressWarnings("ParameterName")
   void hsvConvertTest(int h, int s, int v, int r, int g, int b) {
     var buffer = new AddressableLEDBuffer(1);
     buffer.setHSV(0, h, s, v);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/PS4ControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/PS4ControllerTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 class PS4ControllerTest {
   @ParameterizedTest
   @EnumSource(value = PS4Controller.Button.class)
-  @SuppressWarnings({"VariableDeclarationUsageDistance"})
   void testButtons(PS4Controller.Button button)
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     HAL.initialize(500, 0);
@@ -32,10 +31,10 @@ class PS4ControllerTest {
     String joyPressedMethodName = "get" + buttonName + "Pressed";
     String joyReleasedMethodName = "get" + buttonName + "Released";
 
-    Method simSetMethod = joysim.getClass().getMethod(simSetMethodName, boolean.class);
-    Method joyGetMethod = joy.getClass().getMethod(joyGetMethodName);
-    Method joyPressedMethod = joy.getClass().getMethod(joyPressedMethodName);
-    Method joyReleasedMethod = joy.getClass().getMethod(joyReleasedMethodName);
+    final Method simSetMethod = joysim.getClass().getMethod(simSetMethodName, boolean.class);
+    final Method joyGetMethod = joy.getClass().getMethod(joyGetMethodName);
+    final Method joyPressedMethod = joy.getClass().getMethod(joyPressedMethodName);
+    final Method joyReleasedMethod = joy.getClass().getMethod(joyReleasedMethodName);
 
     simSetMethod.invoke(joysim, false);
     joysim.notifyNewData();
@@ -59,7 +58,6 @@ class PS4ControllerTest {
 
   @ParameterizedTest
   @EnumSource(value = PS4Controller.Axis.class)
-  @SuppressWarnings({"VariableDeclarationUsageDistance"})
   void testAxes(PS4Controller.Axis axis)
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     HAL.initialize(500, 0);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/XboxControllerTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/XboxControllerTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 class XboxControllerTest {
   @ParameterizedTest
   @EnumSource(value = XboxController.Button.class)
-  @SuppressWarnings({"VariableDeclarationUsageDistance"})
   void testButtons(XboxController.Button button)
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     HAL.initialize(500, 0);
@@ -32,10 +31,10 @@ class XboxControllerTest {
     String joyPressedMethodName = "get" + buttonName + "Pressed";
     String joyReleasedMethodName = "get" + buttonName + "Released";
 
-    Method simSetMethod = joysim.getClass().getMethod(simSetMethodName, boolean.class);
-    Method joyGetMethod = joy.getClass().getMethod(joyGetMethodName);
-    Method joyPressedMethod = joy.getClass().getMethod(joyPressedMethodName);
-    Method joyReleasedMethod = joy.getClass().getMethod(joyReleasedMethodName);
+    final Method simSetMethod = joysim.getClass().getMethod(simSetMethodName, boolean.class);
+    final Method joyGetMethod = joy.getClass().getMethod(joyGetMethodName);
+    final Method joyPressedMethod = joy.getClass().getMethod(joyPressedMethodName);
+    final Method joyReleasedMethod = joy.getClass().getMethod(joyReleasedMethodName);
 
     simSetMethod.invoke(joysim, false);
     joysim.notifyNewData();
@@ -59,7 +58,6 @@ class XboxControllerTest {
 
   @ParameterizedTest
   @EnumSource(value = XboxController.Axis.class)
-  @SuppressWarnings({"VariableDeclarationUsageDistance"})
   void testAxes(XboxController.Axis axis)
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     HAL.initialize(500, 0);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/CTREPCMSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/CTREPCMSimTest.java
@@ -18,7 +18,6 @@ import edu.wpi.first.wpilibj.simulation.testutils.BooleanCallback;
 import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 class CTREPCMSimTest {
   @Test
   void testInitialization() {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ElevatorSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ElevatorSimTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 
 class ElevatorSimTest {
   @Test
-  @SuppressWarnings({"LocalVariableName", "resource"})
   void testStateSpaceSimWithElevator() {
     RoboRioSim.resetData();
 

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/REVPHSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/REVPHSimTest.java
@@ -19,7 +19,6 @@ import edu.wpi.first.wpilibj.simulation.testutils.DoubleCallback;
 import edu.wpi.first.wpilibj.simulation.testutils.EnumCallback;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("AbbreviationAsWordInName")
 class REVPHSimTest {
   @Test
   void testInitialization() {

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Drivetrain.java
@@ -98,7 +98,6 @@ public class Drivetrain {
    * @param xSpeed Linear velocity in m/s.
    * @param rot Angular velocity in rad/s.
    */
-  @SuppressWarnings("ParameterName")
   public void drive(double xSpeed, double rot) {
     var wheelSpeeds = m_kinematics.toWheelSpeeds(new ChassisSpeeds(xSpeed, 0.0, rot));
     setSpeeds(wheelSpeeds);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdriveposeestimator/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdriveposeestimator/Drivetrain.java
@@ -108,7 +108,6 @@ public class Drivetrain {
    * @param xSpeed Linear velocity in m/s.
    * @param rot Angular velocity in rad/s.
    */
-  @SuppressWarnings("ParameterName")
   public void drive(double xSpeed, double rot) {
     var wheelSpeeds = m_kinematics.toWheelSpeeds(new ChassisSpeeds(xSpeed, 0.0, rot));
     setSpeeds(wheelSpeeds);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/dutycycleencoder/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/dutycycleencoder/Robot.java
@@ -8,7 +8,6 @@ import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
-@SuppressWarnings("PMD.SingularField")
 public class Robot extends TimedRobot {
   private DutyCycleEncoder m_dutyCycleEncoder;
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/dutycycleinput/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/dutycycleinput/Robot.java
@@ -9,15 +9,12 @@ import edu.wpi.first.wpilibj.DutyCycle;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
-@SuppressWarnings("PMD.SingularField")
 public class Robot extends TimedRobot {
-  private DigitalInput m_input;
   private DutyCycle m_dutyCycle;
 
   @Override
   public void robotInit() {
-    m_input = new DigitalInput(0);
-    m_dutyCycle = new DutyCycle(m_input);
+    m_dutyCycle = new DutyCycle(new DigitalInput(0));
   }
 
   @Override

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumbot/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumbot/Drivetrain.java
@@ -114,7 +114,6 @@ public class Drivetrain {
    * @param rot Angular rate of the robot.
    * @param fieldRelative Whether the provided x and y speeds are relative to the field.
    */
-  @SuppressWarnings("ParameterName")
   public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
     var mecanumDriveWheelSpeeds =
         m_kinematics.toWheelSpeeds(

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumcontrollercommand/subsystems/DriveSubsystem.java
@@ -113,7 +113,6 @@ public class DriveSubsystem extends SubsystemBase {
    * @param rot Angular rate of the robot.
    * @param fieldRelative Whether the provided x and y speeds are relative to the field.
    */
-  @SuppressWarnings("ParameterName")
   public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
     if (fieldRelative) {
       m_drive.driveCartesian(ySpeed, xSpeed, rot, -m_gyro.getAngle());

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumdriveposeestimator/Drivetrain.java
@@ -126,7 +126,6 @@ public class Drivetrain {
    * @param rot Angular rate of the robot.
    * @param fieldRelative Whether the provided x and y speeds are relative to the field.
    */
-  @SuppressWarnings("ParameterName")
   public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
     var mecanumDriveWheelSpeeds =
         m_kinematics.toWheelSpeeds(

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecontroller/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/ramsetecontroller/Drivetrain.java
@@ -99,7 +99,6 @@ public class Drivetrain {
    * @param xSpeed Linear velocity in m/s.
    * @param rot Angular velocity in rad/s.
    */
-  @SuppressWarnings("ParameterName")
   public void drive(double xSpeed, double rot) {
     var wheelSpeeds = m_kinematics.toWheelSpeeds(new ChassisSpeeds(xSpeed, 0.0, rot));
     setSpeeds(wheelSpeeds);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/simpledifferentialdrivesimulation/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/simpledifferentialdrivesimulation/Drivetrain.java
@@ -113,7 +113,6 @@ public class Drivetrain {
    * @param xSpeed the speed for the x axis
    * @param rot the rotation
    */
-  @SuppressWarnings("ParameterName")
   public void drive(double xSpeed, double rot) {
     setSpeeds(m_kinematics.toWheelSpeeds(new ChassisSpeeds(xSpeed, 0, rot)));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/simpledifferentialdrivesimulation/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/simpledifferentialdrivesimulation/Robot.java
@@ -65,7 +65,6 @@ public class Robot extends TimedRobot {
   }
 
   @Override
-  @SuppressWarnings("LocalVariableName")
   public void teleopPeriodic() {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervebot/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervebot/Drivetrain.java
@@ -46,7 +46,6 @@ public class Drivetrain {
    * @param rot Angular rate of the robot.
    * @param fieldRelative Whether the provided x and y speeds are relative to the field.
    */
-  @SuppressWarnings("ParameterName")
   public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
     var swerveModuleStates =
         m_kinematics.toSwerveModuleStates(

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/subsystems/DriveSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/subsystems/DriveSubsystem.java
@@ -99,7 +99,6 @@ public class DriveSubsystem extends SubsystemBase {
    * @param rot Angular rate of the robot.
    * @param fieldRelative Whether the provided x and y speeds are relative to the field.
    */
-  @SuppressWarnings("ParameterName")
   public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
     var swerveModuleStates =
         DriveConstants.kDriveKinematics.toSwerveModuleStates(

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervedriveposeestimator/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervedriveposeestimator/Drivetrain.java
@@ -58,7 +58,6 @@ public class Drivetrain {
    * @param rot Angular rate of the robot.
    * @param fieldRelative Whether the provided x and y speeds are relative to the field.
    */
-  @SuppressWarnings("ParameterName")
   public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
     var swerveModuleStates =
         m_kinematics.toSwerveModuleStates(

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/MockDS.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/MockDS.java
@@ -22,7 +22,7 @@ public class MockDS {
     data[5] = 0x00; // red 1 station
   }
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /** Start the mock DS thread. */
   public void start() {
     m_thread =
         new Thread(
@@ -67,7 +67,7 @@ public class MockDS {
     m_thread.start();
   }
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /** Stop the mock DS thread. */
   public void stop() {
     if (m_thread == null) {
       return;

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PDPTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PDPTest.java
@@ -45,7 +45,12 @@ public class PDPTest extends AbstractComsSetup {
     me = null;
   }
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /**
+   * PDPTest constructor.
+   *
+   * @param mef Motor encoder fixture.
+   * @param expectedCurrentDraw Expected current draw in Amps.
+   */
   public PDPTest(MotorEncoderFixture<?> mef, Double expectedCurrentDraw) {
     logger.fine("Constructor with: " + mef.getType());
     if (me != null && !me.equals(mef)) {

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PIDTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/PIDTest.java
@@ -41,24 +41,32 @@ public class PIDTest extends AbstractComsSetup {
   private PIDController m_controller = null;
   private static MotorEncoderFixture<?> me = null;
 
-  @SuppressWarnings({"MemberName", "EmptyLineSeparator", "MultipleVariableDeclarations"})
-  private final Double k_p, k_i, k_d;
+  private final Double m_p;
+  private final Double m_i;
+  private final Double m_d;
 
   @Override
   protected Logger getClassLogger() {
     return logger;
   }
 
-  @SuppressWarnings({"ParameterName", "MissingJavadocMethod"})
+  /**
+   * PIDTest constructor.
+   *
+   * @param p P gain.
+   * @param i I gain.
+   * @param d D gain.
+   * @param mef Motor encoder fixture.
+   */
   public PIDTest(Double p, Double i, Double d, MotorEncoderFixture<?> mef) {
     logger.fine("Constructor with: " + mef.getType());
     if (PIDTest.me != null && !PIDTest.me.equals(mef)) {
       PIDTest.me.teardown();
     }
     PIDTest.me = mef;
-    this.k_p = p;
-    this.k_i = i;
-    this.k_d = d;
+    this.m_p = p;
+    this.m_i = i;
+    this.m_d = d;
   }
 
   @Parameters
@@ -97,7 +105,7 @@ public class PIDTest extends AbstractComsSetup {
     m_table = NetworkTableInstance.getDefault().getTable("TEST_PID");
     m_builder = new SendableBuilderImpl();
     m_builder.setTable(m_table);
-    m_controller = new PIDController(k_p, k_i, k_d);
+    m_controller = new PIDController(m_p, m_i, m_d);
     m_controller.initSendable(m_builder);
   }
 
@@ -128,9 +136,9 @@ public class PIDTest extends AbstractComsSetup {
         m_controller.getPositionError(),
         0);
     m_builder.update();
-    assertEquals(k_p, m_table.getEntry("Kp").getDouble(9999999), 0);
-    assertEquals(k_i, m_table.getEntry("Ki").getDouble(9999999), 0);
-    assertEquals(k_d, m_table.getEntry("Kd").getDouble(9999999), 0);
+    assertEquals(m_p, m_table.getEntry("Kp").getDouble(9999999), 0);
+    assertEquals(m_i, m_table.getEntry("Ki").getDouble(9999999), 0);
+    assertEquals(m_d, m_table.getEntry("Kd").getDouble(9999999), 0);
     assertEquals(reference, m_table.getEntry("reference").getDouble(9999999), 0);
     assertFalse(m_table.getEntry("enabled").getBoolean(true));
   }

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/fixtures/MotorEncoderFixture.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/fixtures/MotorEncoderFixture.java
@@ -152,7 +152,6 @@ public abstract class MotorEncoderFixture<T extends MotorController> implements 
    * deallocated.
    */
   @Override
-  @SuppressWarnings("Regexp")
   public void teardown() {
     if (!m_tornDown) {
       if (m_motor != null) {

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/test/AbstractTestSuiteTest.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/test/AbstractTestSuiteTest.java
@@ -122,8 +122,7 @@ class FirstSubSuiteTest {
   public static final String METHODNAME = "aTestMethod";
 
   @Test
-  @SuppressWarnings("MethodName")
-  public void aTestMethod() {}
+  public void testMethod() {}
 }
 
 @SuppressWarnings("OneTopLevelClass")

--- a/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/test/TestBench.java
+++ b/wpilibjIntegrationTests/src/main/java/edu/wpi/first/wpilibj/test/TestBench.java
@@ -210,7 +210,7 @@ public final class TestBench {
     return pairs;
   }
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /** Returns the analog I/O cross-connect fixture. */
   public static AnalogCrossConnectFixture getAnalogCrossConnectFixture() {
     return new AnalogCrossConnectFixture() {
       @Override
@@ -225,7 +225,7 @@ public final class TestBench {
     };
   }
 
-  @SuppressWarnings("MissingJavadocMethod")
+  /** Returns the relay cross-connect fixture. */
   public static RelayCrossConnectFixture getRelayCrossConnectFixture() {
     return new RelayCrossConnectFixture() {
       @Override

--- a/wpimath/src/generate/Nat.java.jinja
+++ b/wpimath/src/generate/Nat.java.jinja
@@ -16,7 +16,6 @@ import edu.wpi.first.math.numbers.N{{ num }};
  *
  * @param <T> The {@link Num} this represents.
  */
-@SuppressWarnings({"MethodName", "unused"})
 public interface Nat<T extends Num> {
   /**
    * The number this interface represents.

--- a/wpimath/src/main/java/edu/wpi/first/math/Drake.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/Drake.java
@@ -18,7 +18,6 @@ public final class Drake {
    * @param R Input cost matrix.
    * @return Solution of DARE.
    */
-  @SuppressWarnings({"LocalVariableName", "ParameterName"})
   public static SimpleMatrix discreteAlgebraicRiccatiEquation(
       SimpleMatrix A, SimpleMatrix B, SimpleMatrix Q, SimpleMatrix R) {
     var S = new SimpleMatrix(A.numRows(), A.numCols());
@@ -44,7 +43,6 @@ public final class Drake {
    * @param R Input cost matrix.
    * @return Solution of DARE.
    */
-  @SuppressWarnings({"ParameterName", "MethodTypeParameterName"})
   public static <States extends Num, Inputs extends Num>
       Matrix<States, States> discreteAlgebraicRiccatiEquation(
           Matrix<States, States> A,
@@ -66,7 +64,6 @@ public final class Drake {
    * @param N State-input cross-term cost matrix.
    * @return Solution of DARE.
    */
-  @SuppressWarnings({"LocalVariableName", "ParameterName"})
   public static SimpleMatrix discreteAlgebraicRiccatiEquation(
       SimpleMatrix A, SimpleMatrix B, SimpleMatrix Q, SimpleMatrix R, SimpleMatrix N) {
     // See
@@ -99,7 +96,6 @@ public final class Drake {
    * @param N State-input cross-term cost matrix.
    * @return Solution of DARE.
    */
-  @SuppressWarnings({"ParameterName", "MethodTypeParameterName"})
   public static <States extends Num, Inputs extends Num>
       Matrix<States, States> discreteAlgebraicRiccatiEquation(
           Matrix<States, States> A,

--- a/wpimath/src/main/java/edu/wpi/first/math/MatBuilder.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MatBuilder.java
@@ -24,7 +24,6 @@ public class MatBuilder<R extends Num, C extends Num> {
    * @param data The data to fill the matrix with.
    * @return The constructed matrix.
    */
-  @SuppressWarnings("LineLength")
   public final Matrix<R, C> fill(double... data) {
     if (Objects.requireNonNull(data).length != this.m_rows.getNum() * this.m_cols.getNum()) {
       throw new IllegalArgumentException(

--- a/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathUtil.java
@@ -142,7 +142,6 @@ public final class MathUtil {
    * @param t How far between the two values to interpolate. This is clamped to [0, 1].
    * @return The interpolated value.
    */
-  @SuppressWarnings("ParameterName")
   public static double interpolate(double startValue, double endValue, double t) {
     return startValue + (endValue - startValue) * MathUtil.clamp(t, 0, 1);
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
@@ -331,7 +331,6 @@ public class Matrix<R extends Num, C extends Num> {
    * @param b The right-hand side of the equation to solve.
    * @return The solution to the linear system.
    */
-  @SuppressWarnings("ParameterName")
   public final <C2 extends Num> Matrix<C, C2> solve(Matrix<R, C2> b) {
     return new Matrix<>(this.m_storage.solve(Objects.requireNonNull(b).m_storage));
   }
@@ -464,7 +463,6 @@ public class Matrix<R extends Num, C extends Num> {
    * @param b Scalar.
    * @return The element by element power of "this" and b.
    */
-  @SuppressWarnings("ParameterName")
   public final Matrix<R, C> elementPower(double b) {
     return new Matrix<>(this.m_storage.elementPower(b));
   }
@@ -477,7 +475,6 @@ public class Matrix<R extends Num, C extends Num> {
    * @param b Scalar.
    * @return The element by element power of "this" and b.
    */
-  @SuppressWarnings("ParameterName")
   public final Matrix<R, C> elementPower(int b) {
     return new Matrix<>(this.m_storage.elementPower((double) b));
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/Pair.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/Pair.java
@@ -21,7 +21,6 @@ public class Pair<A, B> {
     return m_second;
   }
 
-  @SuppressWarnings("ParameterName")
   public static <A, B> Pair<A, B> of(A a, B b) {
     return new Pair<>(a, b);
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/SimpleMatrixUtils.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/SimpleMatrixUtils.java
@@ -21,36 +21,34 @@ public final class SimpleMatrixUtils {
    * @param matrix The matrix to compute the exponential of.
    * @return The resultant matrix.
    */
-  @SuppressWarnings({"LocalVariableName", "LineLength"})
   public static SimpleMatrix expm(SimpleMatrix matrix) {
     BiFunction<SimpleMatrix, SimpleMatrix, SimpleMatrix> solveProvider = SimpleBase::solve;
     SimpleMatrix A = matrix;
     double A_L1 = NormOps_DDRM.inducedP1(matrix.getDDRM());
-    int n_squarings = 0;
+    int nSquarings = 0;
 
     if (A_L1 < 1.495585217958292e-002) {
-      Pair<SimpleMatrix, SimpleMatrix> pair = _pade3(A);
-      return dispatchPade(pair.getFirst(), pair.getSecond(), n_squarings, solveProvider);
+      Pair<SimpleMatrix, SimpleMatrix> pair = pade3(A);
+      return dispatchPade(pair.getFirst(), pair.getSecond(), nSquarings, solveProvider);
     } else if (A_L1 < 2.539398330063230e-001) {
-      Pair<SimpleMatrix, SimpleMatrix> pair = _pade5(A);
-      return dispatchPade(pair.getFirst(), pair.getSecond(), n_squarings, solveProvider);
+      Pair<SimpleMatrix, SimpleMatrix> pair = pade5(A);
+      return dispatchPade(pair.getFirst(), pair.getSecond(), nSquarings, solveProvider);
     } else if (A_L1 < 9.504178996162932e-001) {
-      Pair<SimpleMatrix, SimpleMatrix> pair = _pade7(A);
-      return dispatchPade(pair.getFirst(), pair.getSecond(), n_squarings, solveProvider);
+      Pair<SimpleMatrix, SimpleMatrix> pair = pade7(A);
+      return dispatchPade(pair.getFirst(), pair.getSecond(), nSquarings, solveProvider);
     } else if (A_L1 < 2.097847961257068e+000) {
-      Pair<SimpleMatrix, SimpleMatrix> pair = _pade9(A);
-      return dispatchPade(pair.getFirst(), pair.getSecond(), n_squarings, solveProvider);
+      Pair<SimpleMatrix, SimpleMatrix> pair = pade9(A);
+      return dispatchPade(pair.getFirst(), pair.getSecond(), nSquarings, solveProvider);
     } else {
       double maxNorm = 5.371920351148152;
       double log = Math.log(A_L1 / maxNorm) / Math.log(2); // logb(2, arg)
-      n_squarings = (int) Math.max(0, Math.ceil(log));
-      A = A.divide(Math.pow(2.0, n_squarings));
-      Pair<SimpleMatrix, SimpleMatrix> pair = _pade13(A);
-      return dispatchPade(pair.getFirst(), pair.getSecond(), n_squarings, solveProvider);
+      nSquarings = (int) Math.max(0, Math.ceil(log));
+      A = A.divide(Math.pow(2.0, nSquarings));
+      Pair<SimpleMatrix, SimpleMatrix> pair = pade13(A);
+      return dispatchPade(pair.getFirst(), pair.getSecond(), nSquarings, solveProvider);
     }
   }
 
-  @SuppressWarnings({"LocalVariableName", "ParameterName", "LineLength"})
   private static SimpleMatrix dispatchPade(
       SimpleMatrix U,
       SimpleMatrix V,
@@ -68,8 +66,7 @@ public final class SimpleMatrixUtils {
     return R;
   }
 
-  @SuppressWarnings({"MethodName", "LocalVariableName", "ParameterName"})
-  private static Pair<SimpleMatrix, SimpleMatrix> _pade3(SimpleMatrix A) {
+  private static Pair<SimpleMatrix, SimpleMatrix> pade3(SimpleMatrix A) {
     double[] b = new double[] {120, 60, 12, 1};
     SimpleMatrix ident = eye(A.numRows(), A.numCols());
 
@@ -79,8 +76,7 @@ public final class SimpleMatrixUtils {
     return new Pair<>(U, V);
   }
 
-  @SuppressWarnings({"MethodName", "LocalVariableName", "ParameterName"})
-  private static Pair<SimpleMatrix, SimpleMatrix> _pade5(SimpleMatrix A) {
+  private static Pair<SimpleMatrix, SimpleMatrix> pade5(SimpleMatrix A) {
     double[] b = new double[] {30240, 15120, 3360, 420, 30, 1};
     SimpleMatrix ident = eye(A.numRows(), A.numCols());
     SimpleMatrix A2 = A.mult(A);
@@ -92,8 +88,7 @@ public final class SimpleMatrixUtils {
     return new Pair<>(U, V);
   }
 
-  @SuppressWarnings({"MethodName", "LocalVariableName", "LineLength", "ParameterName"})
-  private static Pair<SimpleMatrix, SimpleMatrix> _pade7(SimpleMatrix A) {
+  private static Pair<SimpleMatrix, SimpleMatrix> pade7(SimpleMatrix A) {
     double[] b = new double[] {17297280, 8648640, 1995840, 277200, 25200, 1512, 56, 1};
     SimpleMatrix ident = eye(A.numRows(), A.numCols());
     SimpleMatrix A2 = A.mult(A);
@@ -108,8 +103,7 @@ public final class SimpleMatrixUtils {
     return new Pair<>(U, V);
   }
 
-  @SuppressWarnings({"MethodName", "LocalVariableName", "ParameterName", "LineLength"})
-  private static Pair<SimpleMatrix, SimpleMatrix> _pade9(SimpleMatrix A) {
+  private static Pair<SimpleMatrix, SimpleMatrix> pade9(SimpleMatrix A) {
     double[] b =
         new double[] {
           17643225600.0, 8821612800.0, 2075673600, 302702400, 30270240, 2162160, 110880, 3960, 90, 1
@@ -137,8 +131,7 @@ public final class SimpleMatrixUtils {
     return new Pair<>(U, V);
   }
 
-  @SuppressWarnings({"MethodName", "LocalVariableName", "LineLength", "ParameterName"})
-  private static Pair<SimpleMatrix, SimpleMatrix> _pade13(SimpleMatrix A) {
+  private static Pair<SimpleMatrix, SimpleMatrix> pade13(SimpleMatrix A) {
     double[] b =
         new double[] {
           64764752532480000.0,
@@ -245,7 +238,6 @@ public final class SimpleMatrixUtils {
    * @param A the matrix to exponentiate.
    * @return the exponential of A.
    */
-  @SuppressWarnings("ParameterName")
   public static SimpleMatrix exp(SimpleMatrix A) {
     SimpleMatrix toReturn = new SimpleMatrix(A.numRows(), A.numRows());
     WPIMathJNI.exp(A.getDDRM().getData(), A.numRows(), toReturn.getDDRM().getData());

--- a/wpimath/src/main/java/edu/wpi/first/math/StateSpaceUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/StateSpaceUtil.java
@@ -11,7 +11,6 @@ import edu.wpi.first.math.numbers.N4;
 import java.util.Random;
 import org.ejml.simple.SimpleMatrix;
 
-@SuppressWarnings("ParameterName")
 public final class StateSpaceUtil {
   private static Random rand = new Random();
 
@@ -31,7 +30,6 @@ public final class StateSpaceUtil {
    *     output measurement.
    * @return Process noise or measurement noise covariance matrix.
    */
-  @SuppressWarnings("MethodTypeParameterName")
   public static <States extends Num> Matrix<States, States> makeCovarianceMatrix(
       Nat<States> states, Matrix<States, N1> stdDevs) {
     var result = new Matrix<>(states, states);
@@ -71,7 +69,6 @@ public final class StateSpaceUtil {
    *     excursions of the control inputs from no actuation.
    * @return State excursion or control effort cost matrix.
    */
-  @SuppressWarnings("MethodTypeParameterName")
   public static <Elements extends Num> Matrix<Elements, Elements> makeCostMatrix(
       Matrix<Elements, N1> tolerances) {
     Matrix<Elements, Elements> result =
@@ -102,7 +99,6 @@ public final class StateSpaceUtil {
    * @param B Input matrix.
    * @return If the system is stabilizable.
    */
-  @SuppressWarnings("MethodTypeParameterName")
   public static <States extends Num, Inputs extends Num> boolean isStabilizable(
       Matrix<States, States> A, Matrix<States, Inputs> B) {
     return WPIMathJNI.isStabilizable(A.getNumRows(), B.getNumCols(), A.getData(), B.getData());
@@ -121,7 +117,6 @@ public final class StateSpaceUtil {
    * @param C Output matrix.
    * @return If the system is detectable.
    */
-  @SuppressWarnings("MethodTypeParameterName")
   public static <States extends Num, Outputs extends Num> boolean isDetectable(
       Matrix<States, States> A, Matrix<Outputs, States> C) {
     return WPIMathJNI.isStabilizable(
@@ -147,7 +142,6 @@ public final class StateSpaceUtil {
    * @param <I> The number of inputs.
    * @return The clamped input.
    */
-  @SuppressWarnings({"ParameterName", "LocalVariableName"})
   public static <I extends Num> Matrix<I, N1> clampInputMaxMagnitude(
       Matrix<I, N1> u, Matrix<I, N1> umin, Matrix<I, N1> umax) {
     var result = new Matrix<I, N1>(new SimpleMatrix(u.getNumRows(), 1));

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/ArmFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/ArmFeedforward.java
@@ -8,7 +8,6 @@ package edu.wpi.first.math.controller;
  * A helper class that computes feedforward outputs for a simple arm (modeled as a motor acting
  * against the force of gravity on a beam suspended at an angle).
  */
-@SuppressWarnings("MemberName")
 public class ArmFeedforward {
   public final double ks;
   public final double kcos;

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/ControlAffinePlantInversionFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/ControlAffinePlantInversionFeedforward.java
@@ -29,16 +29,13 @@ import java.util.function.Function;
  * <p>For more on the underlying math, read
  * https://file.tavsys.net/control/controls-engineering-in-frc.pdf.
  */
-@SuppressWarnings({"ParameterName", "LocalVariableName", "MemberName", "ClassTypeParameterName"})
 public class ControlAffinePlantInversionFeedforward<States extends Num, Inputs extends Num> {
   /** The current reference state. */
-  @SuppressWarnings("MemberName")
   private Matrix<States, N1> m_r;
 
   /** The computed feedforward. */
   private Matrix<Inputs, N1> m_uff;
 
-  @SuppressWarnings("MemberName")
   private final Matrix<States, Inputs> m_B;
 
   private final Nat<Inputs> m_inputs;
@@ -181,7 +178,6 @@ public class ControlAffinePlantInversionFeedforward<States extends Num, Inputs e
    * @param nextR The reference state of the future timestep (k + dt).
    * @return The calculated feedforward.
    */
-  @SuppressWarnings({"ParameterName", "LocalVariableName"})
   public Matrix<Inputs, N1> calculate(Matrix<States, N1> r, Matrix<States, N1> nextR) {
     var rDot = (nextR.minus(r)).div(m_dt);
 

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveAccelerationLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveAccelerationLimiter.java
@@ -50,7 +50,6 @@ public class DifferentialDriveAccelerationLimiter {
    * @param rightVoltage The unconstrained right motor voltage.
    * @return The constrained wheel voltages.
    */
-  @SuppressWarnings("LocalVariableName")
   public DifferentialDriveWheelVoltages calculate(
       double leftVelocity, double rightVelocity, double leftVoltage, double rightVoltage) {
     var u = new MatBuilder<>(Nat.N2(), Nat.N1()).fill(leftVoltage, rightVoltage);

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveWheelVoltages.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveWheelVoltages.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.math.controller;
 
 /** Motor voltages for a differential drive. */
-@SuppressWarnings("MemberName")
 public class DifferentialDriveWheelVoltages {
   public double left;
   public double right;

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/ElevatorFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/ElevatorFeedforward.java
@@ -8,7 +8,6 @@ package edu.wpi.first.math.controller;
  * A helper class that computes feedforward outputs for a simple elevator (modeled as a motor acting
  * against the force of gravity).
  */
-@SuppressWarnings("MemberName")
 public class ElevatorFeedforward {
   public final double ks;
   public final double kg;

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/HolonomicDriveController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/HolonomicDriveController.java
@@ -20,7 +20,6 @@ import edu.wpi.first.math.trajectory.Trajectory;
  * are decoupled from translations, users can specify a custom heading that the drivetrain should
  * point toward. This heading reference is profiled for smoothness.
  */
-@SuppressWarnings("MemberName")
 public class HolonomicDriveController {
   private Pose2d m_poseError = new Pose2d();
   private Rotation2d m_rotationError = new Rotation2d();
@@ -40,7 +39,6 @@ public class HolonomicDriveController {
    * @param yController A PID Controller to respond to error in the field-relative y direction.
    * @param thetaController A profiled PID controller to respond to error in angle.
    */
-  @SuppressWarnings("ParameterName")
   public HolonomicDriveController(
       PIDController xController, PIDController yController, ProfiledPIDController thetaController) {
     m_xController = xController;
@@ -81,7 +79,6 @@ public class HolonomicDriveController {
    * @param angleRef The angular reference.
    * @return The next output of the holonomic drive controller.
    */
-  @SuppressWarnings("LocalVariableName")
   public ChassisSpeeds calculate(
       Pose2d currentPose, Pose2d poseRef, double linearVelocityRefMeters, Rotation2d angleRef) {
     // If this is the first run, then we need to reset the theta controller to the current pose's

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/ImplicitModelFollower.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/ImplicitModelFollower.java
@@ -20,18 +20,14 @@ import org.ejml.simple.SimpleMatrix;
  * <p>For more on the underlying math, read appendix B.3 in
  * https://file.tavsys.net/control/controls-engineering-in-frc.pdf.
  */
-@SuppressWarnings("ClassTypeParameterName")
 public class ImplicitModelFollower<States extends Num, Inputs extends Num, Outputs extends Num> {
   // Computed controller output
-  @SuppressWarnings("MemberName")
   private Matrix<Inputs, N1> m_u;
 
   // State space conversion gain
-  @SuppressWarnings("MemberName")
   private Matrix<Inputs, States> m_A;
 
   // Input space conversion gain
-  @SuppressWarnings("MemberName")
   private Matrix<Inputs, Inputs> m_B;
 
   /**
@@ -53,7 +49,6 @@ public class ImplicitModelFollower<States extends Num, Inputs extends Num, Outpu
    * @param Aref Continuous system matrix whose dynamics should be followed.
    * @param Bref Continuous input matrix whose dynamics should be followed.
    */
-  @SuppressWarnings("ParameterName")
   public ImplicitModelFollower(
       Matrix<States, States> A,
       Matrix<States, Inputs> B,

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/LTVDifferentialDriveController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/LTVDifferentialDriveController.java
@@ -45,10 +45,8 @@ public class LTVDifferentialDriveController {
     kLeftVelocity(3),
     kRightVelocity(4);
 
-    @SuppressWarnings("MemberName")
     public final int value;
 
-    @SuppressWarnings("ParameterName")
     State(int i) {
       this.value = i;
     }
@@ -64,7 +62,6 @@ public class LTVDifferentialDriveController {
    * @param relems The maximum desired control effort for each input.
    * @param dt Discretization timestep in seconds.
    */
-  @SuppressWarnings("LocalVariableName")
   public LTVDifferentialDriveController(
       LinearSystem<N2, N2, N2> plant,
       double trackwidth,
@@ -188,7 +185,6 @@ public class LTVDifferentialDriveController {
    * @param rightVelocityRef The desired right velocity in meters per second.
    * @return Left and right output voltages of the LTV controller.
    */
-  @SuppressWarnings("LocalVariableName")
   public DifferentialDriveWheelVoltages calculate(
       Pose2d currentPose,
       double leftVelocity,

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/LTVUnicycleController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/LTVUnicycleController.java
@@ -25,7 +25,6 @@ import edu.wpi.first.math.trajectory.Trajectory;
  * <p>See section 8.9 in Controls Engineering in FRC for a derivation of the control law we used
  * shown in theorem 8.9.1.
  */
-@SuppressWarnings("MemberName")
 public class LTVUnicycleController {
   // LUT from drivetrain linear velocity to LQR gain
   private final InterpolatingMatrixTreeMap<Double, N2, N3> m_table =
@@ -41,10 +40,8 @@ public class LTVUnicycleController {
     kY(1),
     kHeading(2);
 
-    @SuppressWarnings("MemberName")
     public final int value;
 
-    @SuppressWarnings("ParameterName")
     State(int i) {
       this.value = i;
     }
@@ -94,7 +91,6 @@ public class LTVUnicycleController {
    * @param maxVelocity The maximum velocity in meters per second for the controller gain lookup
    *     table. The default is 9 m/s.
    */
-  @SuppressWarnings("LocalVariableName")
   public LTVUnicycleController(
       Vector<N3> qelems, Vector<N2> relems, double dt, double maxVelocity) {
     // The change in global pose for a unicycle is defined by the following
@@ -191,7 +187,6 @@ public class LTVUnicycleController {
 
     m_poseError = poseRef.relativeTo(currentPose);
 
-    @SuppressWarnings("LocalVariableName")
     var K = m_table.get(linearVelocityRef);
     var e =
         new MatBuilder<>(Nat.N3(), Nat.N1())

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/LinearPlantInversionFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/LinearPlantInversionFeedforward.java
@@ -20,20 +20,16 @@ import org.ejml.simple.SimpleMatrix;
  * <p>For more on the underlying math, read
  * https://file.tavsys.net/control/controls-engineering-in-frc.pdf.
  */
-@SuppressWarnings({"ParameterName", "LocalVariableName", "MemberName", "ClassTypeParameterName"})
 public class LinearPlantInversionFeedforward<
     States extends Num, Inputs extends Num, Outputs extends Num> {
   /** The current reference state. */
-  @SuppressWarnings("MemberName")
   private Matrix<States, N1> m_r;
 
   /** The computed feedforward. */
   private Matrix<Inputs, N1> m_uff;
 
-  @SuppressWarnings("MemberName")
   private final Matrix<States, Inputs> m_B;
 
-  @SuppressWarnings("MemberName")
   private final Matrix<States, States> m_A;
 
   /**
@@ -54,7 +50,6 @@ public class LinearPlantInversionFeedforward<
    * @param B Continuous input matrix of the plant being controlled.
    * @param dtSeconds Discretization timestep.
    */
-  @SuppressWarnings({"ParameterName", "LocalVariableName"})
   public LinearPlantInversionFeedforward(
       Matrix<States, States> A, Matrix<States, Inputs> B, double dtSeconds) {
     var discABPair = Discretization.discretizeAB(A, B, dtSeconds);
@@ -143,7 +138,6 @@ public class LinearPlantInversionFeedforward<
    * @param nextR The reference state of the future timestep (k + dt).
    * @return The calculated feedforward.
    */
-  @SuppressWarnings({"ParameterName", "LocalVariableName"})
   public Matrix<Inputs, N1> calculate(Matrix<States, N1> r, Matrix<States, N1> nextR) {
     m_uff = new Matrix<>(m_B.solve(nextR.minus(m_A.times(r))));
 

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/LinearQuadraticRegulator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/LinearQuadraticRegulator.java
@@ -22,18 +22,14 @@ import org.ejml.simple.SimpleMatrix;
  * <p>For more on the underlying math, read
  * https://file.tavsys.net/control/controls-engineering-in-frc.pdf.
  */
-@SuppressWarnings("ClassTypeParameterName")
 public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Outputs extends Num> {
   /** The current reference state. */
-  @SuppressWarnings("MemberName")
   private Matrix<States, N1> m_r;
 
   /** The computed and capped controller output. */
-  @SuppressWarnings("MemberName")
   private Matrix<Inputs, N1> m_u;
 
   // Controller gain.
-  @SuppressWarnings("MemberName")
   private Matrix<Inputs, States> m_K;
 
   /**
@@ -68,7 +64,6 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
    * @param dtSeconds Discretization timestep.
    * @throws IllegalArgumentException If the system is uncontrollable.
    */
-  @SuppressWarnings({"ParameterName", "LocalVariableName"})
   public LinearQuadraticRegulator(
       Matrix<States, States> A,
       Matrix<States, Inputs> B,
@@ -93,7 +88,6 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
    * @param dtSeconds Discretization timestep.
    * @throws IllegalArgumentException If the system is uncontrollable.
    */
-  @SuppressWarnings({"LocalVariableName", "ParameterName"})
   public LinearQuadraticRegulator(
       Matrix<States, States> A,
       Matrix<States, Inputs> B,
@@ -145,7 +139,6 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
    * @param dtSeconds Discretization timestep.
    * @throws IllegalArgumentException If the system is uncontrollable.
    */
-  @SuppressWarnings({"ParameterName", "LocalVariableName"})
   public LinearQuadraticRegulator(
       Matrix<States, States> A,
       Matrix<States, Inputs> B,
@@ -233,7 +226,6 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
    * @param x The current state x.
    * @return The next controller output.
    */
-  @SuppressWarnings("ParameterName")
   public Matrix<Inputs, N1> calculate(Matrix<States, N1> x) {
     m_u = m_K.times(m_r.minus(x));
     return m_u;
@@ -246,7 +238,6 @@ public class LinearQuadraticRegulator<States extends Num, Inputs extends Num, Ou
    * @param nextR the next reference vector r.
    * @return The next controller output.
    */
-  @SuppressWarnings("ParameterName")
   public Matrix<Inputs, N1> calculate(Matrix<States, N1> x, Matrix<States, N1> nextR) {
     m_r = nextR;
     return calculate(x);

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/ProfiledPIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/ProfiledPIDController.java
@@ -33,7 +33,6 @@ public class ProfiledPIDController implements Sendable {
    * @param Kd The derivative coefficient.
    * @param constraints Velocity and acceleration constraints for goal.
    */
-  @SuppressWarnings("ParameterName")
   public ProfiledPIDController(
       double Kp, double Ki, double Kd, TrapezoidProfile.Constraints constraints) {
     this(Kp, Ki, Kd, constraints, 0.02);
@@ -48,7 +47,6 @@ public class ProfiledPIDController implements Sendable {
    * @param constraints Velocity and acceleration constraints for goal.
    * @param period The period between controller updates in seconds. The default is 0.02 seconds.
    */
-  @SuppressWarnings("ParameterName")
   public ProfiledPIDController(
       double Kp, double Ki, double Kd, TrapezoidProfile.Constraints constraints, double period) {
     m_controller = new PIDController(Kp, Ki, Kd, period);
@@ -66,7 +64,6 @@ public class ProfiledPIDController implements Sendable {
    * @param Ki Integral coefficient
    * @param Kd Differential coefficient
    */
-  @SuppressWarnings("ParameterName")
   public void setPID(double Kp, double Ki, double Kd) {
     m_controller.setPID(Kp, Ki, Kd);
   }
@@ -76,7 +73,6 @@ public class ProfiledPIDController implements Sendable {
    *
    * @param Kp proportional coefficient
    */
-  @SuppressWarnings("ParameterName")
   public void setP(double Kp) {
     m_controller.setP(Kp);
   }
@@ -86,7 +82,6 @@ public class ProfiledPIDController implements Sendable {
    *
    * @param Ki integral coefficient
    */
-  @SuppressWarnings("ParameterName")
   public void setI(double Ki) {
     m_controller.setI(Ki);
   }
@@ -96,7 +91,6 @@ public class ProfiledPIDController implements Sendable {
    *
    * @param Kd differential coefficient
    */
-  @SuppressWarnings("ParameterName")
   public void setD(double Kd) {
     m_controller.setD(Kd);
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/RamseteController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/RamseteController.java
@@ -33,10 +33,8 @@ import edu.wpi.first.math.trajectory.Trajectory;
  * derivation and analysis.
  */
 public class RamseteController {
-  @SuppressWarnings("MemberName")
   private final double m_b;
 
-  @SuppressWarnings("MemberName")
   private final double m_zeta;
 
   private Pose2d m_poseError = new Pose2d();
@@ -51,7 +49,6 @@ public class RamseteController {
    * @param zeta Tuning parameter (0 rad⁻¹ &lt; zeta &lt; 1 rad⁻¹) for which larger values provide
    *     more damping in response.
    */
-  @SuppressWarnings("ParameterName")
   public RamseteController(double b, double zeta) {
     m_b = b;
     m_zeta = zeta;
@@ -101,7 +98,6 @@ public class RamseteController {
    * @param angularVelocityRefRadiansPerSecond The desired angular velocity in radians per second.
    * @return The next controller output.
    */
-  @SuppressWarnings("LocalVariableName")
   public ChassisSpeeds calculate(
       Pose2d currentPose,
       Pose2d poseRef,
@@ -141,7 +137,6 @@ public class RamseteController {
    * @param desiredState The desired pose, linear velocity, and angular velocity from a trajectory.
    * @return The next controller output.
    */
-  @SuppressWarnings("LocalVariableName")
   public ChassisSpeeds calculate(Pose2d currentPose, Trajectory.State desiredState) {
     return calculate(
         currentPose,
@@ -164,7 +159,6 @@ public class RamseteController {
    *
    * @param x Value of which to take sinc(x).
    */
-  @SuppressWarnings("ParameterName")
   private static double sinc(double x) {
     if (Math.abs(x) < 1e-9) {
       return 1.0 - 1.0 / 6.0 * x * x;

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/SimpleMotorFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/SimpleMotorFeedforward.java
@@ -9,7 +9,6 @@ import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.system.plant.LinearSystemId;
 
 /** A helper class that computes feedforward outputs for a simple permanent-magnet DC motor. */
-@SuppressWarnings("MemberName")
 public class SimpleMotorFeedforward {
   public final double ks;
   public final double kv;

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/AngleStatistics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/AngleStatistics.java
@@ -87,7 +87,6 @@ public final class AngleStatistics {
    * @param angleStateIdx The row containing the angles.
    * @return Mean of sigma points.
    */
-  @SuppressWarnings("checkstyle:ParameterName")
   public static <S extends Num> Matrix<S, N1> angleMean(
       Matrix<S, ?> sigmas, Matrix<?, N1> Wm, int angleStateIdx) {
     double[] angleSigmas = sigmas.extractRowVector(angleStateIdx).getData();
@@ -115,7 +114,6 @@ public final class AngleStatistics {
    * @param angleStateIdx The row containing the angles.
    * @return Function returning mean of sigma points.
    */
-  @SuppressWarnings("LambdaParameterName")
   public static <S extends Num> BiFunction<Matrix<S, ?>, Matrix<?, N1>, Matrix<S, N1>> angleMean(
       int angleStateIdx) {
     return (sigmas, Wm) -> angleMean(sigmas, Wm, angleStateIdx);

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
@@ -112,7 +112,6 @@ public class DifferentialDrivePoseEstimator {
    *     theta]ᵀ, with units in meters and radians.
    * @param nominalDtSeconds The time in seconds between each robot loop.
    */
-  @SuppressWarnings("ParameterName")
   public DifferentialDrivePoseEstimator(
       Rotation2d gyroAngle,
       Pose2d initialPoseMeters,
@@ -172,7 +171,6 @@ public class DifferentialDrivePoseEstimator {
     m_visionContR = StateSpaceUtil.makeCovarianceMatrix(Nat.N3(), visionMeasurementStdDevs);
   }
 
-  @SuppressWarnings({"ParameterName", "MethodName"})
   private Matrix<N5, N1> f(Matrix<N5, N1> x, Matrix<N3, N1> u) {
     // Apply a rotation matrix. Note that we do *not* add x--Runge-Kutta does that for us.
     var theta = x.get(2, 0);
@@ -343,7 +341,6 @@ public class DifferentialDrivePoseEstimator {
    *     last time you called {@link DifferentialDrivePoseEstimator#resetPosition}.
    * @return The estimated pose of the robot in meters.
    */
-  @SuppressWarnings({"LocalVariableName", "ParameterName"})
   public Pose2d updateWithTime(
       double currentTimeSeconds,
       Rotation2d gyroAngle,

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/KalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/KalmanFilter.java
@@ -29,18 +29,15 @@ import edu.wpi.first.math.system.LinearSystem;
  * https://file.tavsys.net/control/controls-engineering-in-frc.pdf chapter 9 "Stochastic control
  * theory".
  */
-@SuppressWarnings("ClassTypeParameterName")
 public class KalmanFilter<States extends Num, Inputs extends Num, Outputs extends Num> {
   private final Nat<States> m_states;
 
   private final LinearSystem<States, Inputs, Outputs> m_plant;
 
   /** The steady-state Kalman gain matrix. */
-  @SuppressWarnings("MemberName")
   private final Matrix<States, Outputs> m_K;
 
   /** The state estimate. */
-  @SuppressWarnings("MemberName")
   private Matrix<States, N1> m_xHat;
 
   /**
@@ -54,7 +51,6 @@ public class KalmanFilter<States extends Num, Inputs extends Num, Outputs extend
    * @param dtSeconds Nominal discretization timestep.
    * @throws IllegalArgumentException If the system is unobservable.
    */
-  @SuppressWarnings("LocalVariableName")
   public KalmanFilter(
       Nat<States> states,
       Nat<Outputs> outputs,
@@ -185,7 +181,6 @@ public class KalmanFilter<States extends Num, Inputs extends Num, Outputs extend
    * @param u New control input from controller.
    * @param dtSeconds Timestep for prediction.
    */
-  @SuppressWarnings("ParameterName")
   public void predict(Matrix<Inputs, N1> u, double dtSeconds) {
     this.m_xHat = m_plant.calculateX(m_xHat, u, dtSeconds);
   }
@@ -196,7 +191,6 @@ public class KalmanFilter<States extends Num, Inputs extends Num, Outputs extend
    * @param u Same control input used in the last predict step.
    * @param y Measurement vector.
    */
-  @SuppressWarnings("ParameterName")
   public void correct(Matrix<Inputs, N1> u, Matrix<Outputs, N1> y) {
     final var C = m_plant.getC();
     final var D = m_plant.getD();

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/KalmanFilterLatencyCompensator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/KalmanFilterLatencyCompensator.java
@@ -35,7 +35,6 @@ public class KalmanFilterLatencyCompensator<S extends Num, I extends Num, O exte
    * @param localY The local output at the timestamp
    * @param timestampSeconds The timesnap of the state.
    */
-  @SuppressWarnings("ParameterName")
   public void addObserverState(
       KalmanTypeFilter<S, I, O> observer,
       Matrix<I, N1> u,
@@ -60,7 +59,6 @@ public class KalmanFilterLatencyCompensator<S extends Num, I extends Num, O exte
    * @param globalMeasurementCorrect The function take calls correct() on the observer.
    * @param timestampSeconds The timestamp of the measurement.
    */
-  @SuppressWarnings("ParameterName")
   public <R extends Num> void applyPastGlobalMeasurement(
       Nat<R> rows,
       KalmanTypeFilter<S, I, O> observer,
@@ -165,14 +163,12 @@ public class KalmanFilterLatencyCompensator<S extends Num, I extends Num, O exte
   }
 
   /** This class contains all the information about our observer at a given time. */
-  @SuppressWarnings("MemberName")
   public class ObserverSnapshot {
     public final Matrix<S, N1> xHat;
     public final Matrix<S, S> errorCovariances;
     public final Matrix<I, N1> inputs;
     public final Matrix<O, N1> localMeasurements;
 
-    @SuppressWarnings("ParameterName")
     private ObserverSnapshot(
         KalmanTypeFilter<S, I, O> observer, Matrix<I, N1> u, Matrix<O, N1> localY) {
       this.xHat = observer.getXhat();

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/KalmanTypeFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/KalmanTypeFilter.java
@@ -8,7 +8,6 @@ import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.Num;
 import edu.wpi.first.math.numbers.N1;
 
-@SuppressWarnings({"ParameterName", "InterfaceTypeParameterName"})
 interface KalmanTypeFilter<States extends Num, Inputs extends Num, Outputs extends Num> {
   Matrix<States, States> getP();
 

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -110,7 +110,6 @@ public class MecanumDrivePoseEstimator {
    *     theta]ᵀ, with units in meters and radians.
    * @param nominalDtSeconds The time in seconds between each robot loop.
    */
-  @SuppressWarnings("ParameterName")
   public MecanumDrivePoseEstimator(
       Rotation2d gyroAngle,
       Pose2d initialPoseMeters,
@@ -290,7 +289,6 @@ public class MecanumDrivePoseEstimator {
    * @param wheelSpeeds The current speeds of the mecanum drive wheels.
    * @return The estimated pose of the robot in meters.
    */
-  @SuppressWarnings("LocalVariableName")
   public Pose2d updateWithTime(
       double currentTimeSeconds, Rotation2d gyroAngle, MecanumDriveWheelSpeeds wheelSpeeds) {
     double dt = m_prevTimeSeconds >= 0 ? currentTimeSeconds - m_prevTimeSeconds : m_nominalDt;

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MerweScaledSigmaPoints.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MerweScaledSigmaPoints.java
@@ -75,7 +75,6 @@ public class MerweScaledSigmaPoints<S extends Num> {
    * @return Two dimensional array of sigma points. Each column contains all of the sigmas for one
    *     dimension in the problem space. Ordered by Xi_0, Xi_{1..n}, Xi_{n+1..2n}.
    */
-  @SuppressWarnings({"ParameterName", "LocalVariableName"})
   public Matrix<S, ?> squareRootSigmaPoints(Matrix<S, N1> x, Matrix<S, S> s) {
     double lambda = Math.pow(m_alpha, 2) * (m_states.getNum() + m_kappa) - m_states.getNum();
     double eta = Math.sqrt(lambda + m_states.getNum());
@@ -101,7 +100,6 @@ public class MerweScaledSigmaPoints<S extends Num> {
    *
    * @param beta Incorporates prior knowledge of the distribution of the mean.
    */
-  @SuppressWarnings("LocalVariableName")
   private void computeWeights(double beta) {
     double lambda = Math.pow(m_alpha, 2) * (m_states.getNum() + m_kappa) - m_states.getNum();
     double c = 0.5 / (m_states.getNum() + lambda);

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -110,7 +110,6 @@ public class SwerveDrivePoseEstimator {
    *     theta]ᵀ, with units in meters and radians.
    * @param nominalDtSeconds The time in seconds between each robot loop.
    */
-  @SuppressWarnings("ParameterName")
   public SwerveDrivePoseEstimator(
       Rotation2d gyroAngle,
       Pose2d initialPoseMeters,
@@ -288,7 +287,6 @@ public class SwerveDrivePoseEstimator {
    * @param moduleStates The current velocities and rotations of the swerve modules.
    * @return The estimated pose of the robot in meters.
    */
-  @SuppressWarnings("LocalVariableName")
   public Pose2d updateWithTime(
       double currentTimeSeconds, Rotation2d gyroAngle, SwerveModuleState... moduleStates) {
     double dt = m_prevTimeSeconds >= 0 ? currentTimeSeconds - m_prevTimeSeconds : m_nominalDt;

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/UnscentedKalmanFilter.java
@@ -38,7 +38,6 @@ import org.ejml.simple.SimpleMatrix;
  * <p>This class implements a square-root-form unscented Kalman filter (SR-UKF). For more
  * information about the SR-UKF, see https://www.researchgate.net/publication/3908304.
  */
-@SuppressWarnings({"MemberName", "ClassTypeParameterName"})
 public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outputs extends Num>
     implements KalmanTypeFilter<States, Inputs, Outputs> {
   private final Nat<States> m_states;
@@ -73,7 +72,6 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
    * @param measurementStdDevs Standard deviations of measurements.
    * @param nominalDtSeconds Nominal discretization timestep.
    */
-  @SuppressWarnings("LambdaParameterName")
   public UnscentedKalmanFilter(
       Nat<States> states,
       Nat<Outputs> outputs,
@@ -119,7 +117,6 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
    * @param addFuncX A function that adds two state vectors.
    * @param nominalDtSeconds Nominal discretization timestep.
    */
-  @SuppressWarnings("ParameterName")
   public UnscentedKalmanFilter(
       Nat<States> states,
       Nat<Outputs> outputs,
@@ -155,7 +152,6 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
     reset();
   }
 
-  @SuppressWarnings({"ParameterName", "LocalVariableName"})
   static <S extends Num, C extends Num>
       Pair<Matrix<C, N1>, Matrix<C, C>> squareRootUnscentedTransform(
           Nat<S> s,
@@ -300,7 +296,6 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
    *
    * @param xHat The state estimate x-hat.
    */
-  @SuppressWarnings("ParameterName")
   @Override
   public void setXhat(Matrix<States, N1> xHat) {
     m_xHat = xHat;
@@ -331,7 +326,6 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
    * @param u New control input from controller.
    * @param dtSeconds Timestep for prediction.
    */
-  @SuppressWarnings({"LocalVariableName", "ParameterName"})
   @Override
   public void predict(Matrix<Inputs, N1> u, double dtSeconds) {
     // Discretize Q before projecting mean and covariance forward
@@ -370,7 +364,6 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
    * @param u Same control input used in the predict step.
    * @param y Measurement vector.
    */
-  @SuppressWarnings("ParameterName")
   @Override
   public void correct(Matrix<Inputs, N1> u, Matrix<Outputs, N1> y) {
     correct(
@@ -391,7 +384,6 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
    * @param h A vector-valued function of x and u that returns the measurement vector.
    * @param R Measurement noise covariance matrix (continuous-time).
    */
-  @SuppressWarnings({"ParameterName", "LambdaParameterName", "LocalVariableName"})
   public <R extends Num> void correct(
       Nat<R> rows,
       Matrix<Inputs, N1> u,
@@ -428,7 +420,6 @@ public class UnscentedKalmanFilter<States extends Num, Inputs extends Num, Outpu
    *     subtracts them.)
    * @param addFuncX A function that adds two state vectors.
    */
-  @SuppressWarnings({"ParameterName", "LocalVariableName"})
   public <R extends Num> void correct(
       Nat<R> rows,
       Matrix<Inputs, N1> u,

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
@@ -154,7 +154,6 @@ public class LinearFilter {
    * @throws IllegalArgumentException if derivative &lt; 1, samples &lt;= 0, or derivative &gt;=
    *     samples.
    */
-  @SuppressWarnings("LocalVariableName")
   public static LinearFilter finiteDifference(int derivative, int[] stencil, double period) {
     // See
     // https://en.wikipedia.org/wiki/Finite_difference_coefficient#Arbitrary_stencil_points

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/CoordinateAxis.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/CoordinateAxis.java
@@ -36,7 +36,6 @@ public class CoordinateAxis {
    *
    * @return A coordinate axis corresponding to +X in the NWU coordinate system.
    */
-  @SuppressWarnings("MethodName")
   public static CoordinateAxis N() {
     return m_n;
   }
@@ -46,7 +45,6 @@ public class CoordinateAxis {
    *
    * @return A coordinate axis corresponding to -X in the NWU coordinate system.
    */
-  @SuppressWarnings("MethodName")
   public static CoordinateAxis S() {
     return m_s;
   }
@@ -56,7 +54,6 @@ public class CoordinateAxis {
    *
    * @return A coordinate axis corresponding to -Y in the NWU coordinate system.
    */
-  @SuppressWarnings("MethodName")
   public static CoordinateAxis E() {
     return m_e;
   }
@@ -66,7 +63,6 @@ public class CoordinateAxis {
    *
    * @return A coordinate axis corresponding to +Y in the NWU coordinate system.
    */
-  @SuppressWarnings("MethodName")
   public static CoordinateAxis W() {
     return m_w;
   }
@@ -76,7 +72,6 @@ public class CoordinateAxis {
    *
    * @return A coordinate axis corresponding to +Z in the NWU coordinate system.
    */
-  @SuppressWarnings("MethodName")
   public static CoordinateAxis U() {
     return m_u;
   }
@@ -86,7 +81,6 @@ public class CoordinateAxis {
    *
    * @return A coordinate axis corresponding to -Z in the NWU coordinate system.
    */
-  @SuppressWarnings("MethodName")
   public static CoordinateAxis D() {
     return m_d;
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/CoordinateSystem.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/CoordinateSystem.java
@@ -32,7 +32,6 @@ public class CoordinateSystem {
     // Construct a change of basis matrix from the source coordinate system to the
     // NWU coordinate system. Each column vector in the change of basis matrix is
     // one of the old basis vectors mapped to its representation in the new basis.
-    @SuppressWarnings("LocalVariableName")
     var R = new Matrix<>(Nat.N3(), Nat.N3());
     R.assignBlock(0, 0, positiveX.m_axis);
     R.assignBlock(0, 1, positiveY.m_axis);
@@ -50,7 +49,6 @@ public class CoordinateSystem {
    *
    * @return An instance of the North-West-Up (NWU) coordinate system.
    */
-  @SuppressWarnings("MethodName")
   public static CoordinateSystem NWU() {
     return m_nwu;
   }
@@ -62,7 +60,6 @@ public class CoordinateSystem {
    *
    * @return An instance of the East-Down-North (EDN) coordinate system.
    */
-  @SuppressWarnings("MethodName")
   public static CoordinateSystem EDN() {
     return m_edn;
   }
@@ -74,7 +71,6 @@ public class CoordinateSystem {
    *
    * @return An instance of the North-East-Down (NED) coordinate system.
    */
-  @SuppressWarnings("MethodName")
   public static CoordinateSystem NED() {
     return m_ned;
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose2d.java
@@ -244,7 +244,6 @@ public class Pose2d implements Interpolatable<Pose2d> {
   }
 
   @Override
-  @SuppressWarnings("ParameterName")
   public Pose2d interpolate(Pose2d endValue, double t) {
     if (t < 0) {
       return this;

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose3d.java
@@ -158,7 +158,6 @@ public class Pose3d implements Interpolatable<Pose3d> {
    *     Rotation3d(0.0, 0.0, Units.degreesToRadians(0.5))).
    * @return The new pose of the robot.
    */
-  @SuppressWarnings("LocalVariableName")
   public Pose3d exp(Twist3d twist) {
     final var Omega = rotationVectorToMatrix(VecBuilder.fill(twist.rx, twist.ry, twist.rz));
     final var OmegaSq = Omega.times(Omega);
@@ -199,7 +198,6 @@ public class Pose3d implements Interpolatable<Pose3d> {
    * @param end The end pose for the transformation.
    * @return The twist that maps this to end.
    */
-  @SuppressWarnings("LocalVariableName")
   public Twist3d log(Pose3d end) {
     final var transform = end.relativeTo(this);
 
@@ -282,7 +280,6 @@ public class Pose3d implements Interpolatable<Pose3d> {
   }
 
   @Override
-  @SuppressWarnings("ParameterName")
   public Pose3d interpolate(Pose3d endValue, double t) {
     if (t < 0) {
       return this;

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation2d.java
@@ -236,7 +236,6 @@ public class Rotation2d implements Interpolatable<Rotation2d> {
   }
 
   @Override
-  @SuppressWarnings("ParameterName")
   public Rotation2d interpolate(Rotation2d endValue, double t) {
     return plus(endValue.minus(this).times(MathUtil.clamp(t, 0, 1)));
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation3d.java
@@ -170,7 +170,6 @@ public class Rotation3d implements Interpolatable<Rotation3d> {
       // so a 180 degree rotation is required. Any orthogonal vector can be used
       // for it. Q in the QR decomposition is an orthonormal basis, so it
       // contains orthogonal unit vectors.
-      @SuppressWarnings("LocalVariableName")
       var X =
           new MatBuilder<>(Nat.N3(), Nat.N1())
               .fill(initial.get(0, 0), initial.get(1, 0), initial.get(2, 0));
@@ -376,7 +375,6 @@ public class Rotation3d implements Interpolatable<Rotation3d> {
   }
 
   @Override
-  @SuppressWarnings("ParameterName")
   public Rotation3d interpolate(Rotation3d endValue, double t) {
     return plus(endValue.minus(this).times(MathUtil.clamp(t, 0, 1)));
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation2d.java
@@ -18,7 +18,6 @@ import java.util.Objects;
  * <p>This assumes that you are using conventional mathematical axes. When the robot is at the
  * origin facing in the positive X direction, forward is positive X and left is positive Y.
  */
-@SuppressWarnings({"ParameterName", "MemberName"})
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 public class Translation2d implements Interpolatable<Translation2d> {

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
@@ -15,7 +15,6 @@ import java.util.Objects;
  * origin facing in the positive X direction, forward is positive X, left is positive Y, and up is
  * positive Z.
  */
-@SuppressWarnings({"ParameterName", "MemberName"})
 public class Translation3d implements Interpolatable<Translation3d> {
   private final double m_x;
   private final double m_y;

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Twist2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Twist2d.java
@@ -12,7 +12,6 @@ import java.util.Objects;
  *
  * <p>A Twist can be used to represent a difference between two poses.
  */
-@SuppressWarnings("MemberName")
 public class Twist2d {
   /** Linear "dx" component. */
   public double dx;

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Twist3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Twist3d.java
@@ -12,7 +12,6 @@ import java.util.Objects;
  *
  * <p>A Twist can be used to represent a difference between two poses.
  */
-@SuppressWarnings("MemberName")
 public class Twist3d {
   /** Linear "dx" component. */
   public double dx;

--- a/wpimath/src/main/java/edu/wpi/first/math/interpolation/Interpolatable.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/interpolation/Interpolatable.java
@@ -20,6 +20,5 @@ public interface Interpolatable<T> {
    * @param t How far between the lower and upper bound we are. This should be bounded in [0, 1].
    * @return The interpolated value.
    */
-  @SuppressWarnings("ParameterName")
   T interpolate(T endValue, double t);
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/interpolation/TimeInterpolatableBuffer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/interpolation/TimeInterpolatableBuffer.java
@@ -101,7 +101,6 @@ public final class TimeInterpolatableBuffer<T> {
    * @param timeSeconds The time at which to sample.
    * @return The interpolated value at that timestamp or an empty Optional.
    */
-  @SuppressWarnings("UnnecessaryParentheses")
   public Optional<T> getSample(double timeSeconds) {
     if (m_pastSnapshots.isEmpty()) {
       return Optional.empty();
@@ -131,7 +130,7 @@ public final class TimeInterpolatableBuffer<T> {
           m_interpolatingFunc.interpolate(
               bottomBound.getValue(),
               topBound.getValue(),
-              ((timeSeconds - bottomBound.getKey()) / (topBound.getKey() - bottomBound.getKey()))));
+              (timeSeconds - bottomBound.getKey()) / (topBound.getKey() - bottomBound.getKey())));
     }
   }
 
@@ -145,7 +144,6 @@ public final class TimeInterpolatableBuffer<T> {
      * @param t How far between the lower and upper bound we are. This should be bounded in [0, 1].
      * @return The interpolated value.
      */
-    @SuppressWarnings("ParameterName")
     T interpolate(T start, T end, double t);
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/ChassisSpeeds.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/ChassisSpeeds.java
@@ -16,7 +16,6 @@ import edu.wpi.first.math.geometry.Rotation2d;
  * component because it can never move sideways. Holonomic drivetrains such as swerve and mecanum
  * will often have all three components.
  */
-@SuppressWarnings("MemberName")
 public class ChassisSpeeds {
   /** Represents forward velocity w.r.t the robot frame of reference. (Fwd is +) */
   public double vxMetersPerSecond;

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/DifferentialDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/DifferentialDriveKinematics.java
@@ -15,7 +15,6 @@ import edu.wpi.first.math.MathUsageId;
  * whereas forward kinematics converts left and right component velocities into a linear and angular
  * chassis speed.
  */
-@SuppressWarnings("MemberName")
 public class DifferentialDriveKinematics {
   public final double trackWidthMeters;
 

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/DifferentialDriveWheelSpeeds.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/DifferentialDriveWheelSpeeds.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.math.kinematics;
 
 /** Represents the wheel speeds for a differential drive drivetrain. */
-@SuppressWarnings("MemberName")
 public class DifferentialDriveWheelSpeeds {
   /** Speed of the left side of the robot. */
   public double leftMetersPerSecond;

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/MecanumDriveMotorVoltages.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/MecanumDriveMotorVoltages.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.math.kinematics;
 
 /** Represents the motor voltages for a mecanum drive drivetrain. */
-@SuppressWarnings("MemberName")
 public class MecanumDriveMotorVoltages {
   /** Voltage of the front left motor. */
   public double frontLeftVoltage;

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/MecanumDriveWheelSpeeds.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/MecanumDriveWheelSpeeds.java
@@ -6,7 +6,6 @@ package edu.wpi.first.math.kinematics;
 
 import java.util.stream.DoubleStream;
 
-@SuppressWarnings("MemberName")
 public class MecanumDriveWheelSpeeds {
   /** Speed of the front left wheel. */
   public double frontLeftMetersPerSecond;

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
@@ -89,7 +89,7 @@ public class SwerveDriveKinematics {
    *     attainable max velocity. Use the {@link #desaturateWheelSpeeds(SwerveModuleState[], double)
    *     DesaturateWheelSpeeds} function to rectify this issue.
    */
-  @SuppressWarnings({"LocalVariableName", "PMD.MethodReturnsInternalArray"})
+  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public SwerveModuleState[] toSwerveModuleStates(
       ChassisSpeeds chassisSpeeds, Translation2d centerOfRotationMeters) {
     if (chassisSpeeds.vxMetersPerSecond == 0.0

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModuleState.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModuleState.java
@@ -8,7 +8,6 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import java.util.Objects;
 
 /** Represents the state of one swerve module. */
-@SuppressWarnings("MemberName")
 public class SwerveModuleState implements Comparable<SwerveModuleState> {
   /** Speed of the wheel of the module. */
   public double speedMetersPerSecond;

--- a/wpimath/src/main/java/edu/wpi/first/math/spline/CubicHermiteSpline.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/spline/CubicHermiteSpline.java
@@ -19,7 +19,6 @@ public class CubicHermiteSpline extends Spline {
    * @param yInitialControlVector The control vector for the initial point in the y dimension.
    * @param yFinalControlVector The control vector for the final point in the y dimension.
    */
-  @SuppressWarnings("ParameterName")
   public CubicHermiteSpline(
       double[] xInitialControlVector,
       double[] xFinalControlVector,

--- a/wpimath/src/main/java/edu/wpi/first/math/spline/PoseWithCurvature.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/spline/PoseWithCurvature.java
@@ -7,7 +7,6 @@ package edu.wpi.first.math.spline;
 import edu.wpi.first.math.geometry.Pose2d;
 
 /** Represents a pair of a pose and a curvature. */
-@SuppressWarnings("MemberName")
 public class PoseWithCurvature {
   // Represents the pose.
   public Pose2d poseMeters;

--- a/wpimath/src/main/java/edu/wpi/first/math/spline/QuinticHermiteSpline.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/spline/QuinticHermiteSpline.java
@@ -19,7 +19,6 @@ public class QuinticHermiteSpline extends Spline {
    * @param yInitialControlVector The control vector for the initial point in the y dimension.
    * @param yFinalControlVector The control vector for the final point in the y dimension.
    */
-  @SuppressWarnings("ParameterName")
   public QuinticHermiteSpline(
       double[] xInitialControlVector,
       double[] xFinalControlVector,

--- a/wpimath/src/main/java/edu/wpi/first/math/spline/Spline.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/spline/Spline.java
@@ -35,7 +35,6 @@ public abstract class Spline {
    * @param t The point t
    * @return The pose and curvature at that point.
    */
-  @SuppressWarnings("ParameterName")
   public PoseWithCurvature getPoint(double t) {
     SimpleMatrix polynomialBases = new SimpleMatrix(m_degree + 1, 1);
     final var coefficients = getCoefficients();
@@ -85,7 +84,6 @@ public abstract class Spline {
    * <p>Each element in each array represents the value of the derivative at the index. For example,
    * the value of x[2] is the second derivative in the x dimension.
    */
-  @SuppressWarnings("MemberName")
   public static class ControlVector {
     public double[] x;
     public double[] y;
@@ -96,7 +94,6 @@ public abstract class Spline {
      * @param x The x dimension of the control vector.
      * @param y The y dimension of the control vector.
      */
-    @SuppressWarnings("ParameterName")
     public ControlVector(double[] x, double[] y) {
       this.x = Arrays.copyOf(x, x.length);
       this.y = Arrays.copyOf(y, y.length);

--- a/wpimath/src/main/java/edu/wpi/first/math/spline/SplineHelper.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/spline/SplineHelper.java
@@ -78,7 +78,6 @@ public final class SplineHelper {
    * @return A vector of cubic hermite splines that interpolate through the provided waypoints and
    *     control vectors.
    */
-  @SuppressWarnings("LocalVariableName")
   public static CubicHermiteSpline[] getCubicSplinesFromControlVectors(
       Spline.ControlVector start, Translation2d[] waypoints, Spline.ControlVector end) {
     CubicHermiteSpline[] splines = new CubicHermiteSpline[waypoints.length + 1];
@@ -202,7 +201,6 @@ public final class SplineHelper {
    * @param controlVectors The control vectors.
    * @return A vector of quintic hermite splines that interpolate through the provided waypoints.
    */
-  @SuppressWarnings("LocalVariableName")
   public static QuinticHermiteSpline[] getQuinticSplinesFromControlVectors(
       Spline.ControlVector[] controlVectors) {
     QuinticHermiteSpline[] splines = new QuinticHermiteSpline[controlVectors.length - 1];
@@ -228,7 +226,6 @@ public final class SplineHelper {
    * @param d the vector on the rhs
    * @param solutionVector the unknown (solution) vector, modified in-place
    */
-  @SuppressWarnings({"ParameterName", "LocalVariableName"})
   private static void thomasAlgorithm(
       double[] a, double[] b, double[] c, double[] d, double[] solutionVector) {
     int N = d.length;

--- a/wpimath/src/main/java/edu/wpi/first/math/spline/SplineParameterizer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/spline/SplineParameterizer.java
@@ -46,7 +46,6 @@ public final class SplineParameterizer {
    */
   private static final int kMaxIterations = 5000;
 
-  @SuppressWarnings("MemberName")
   private static class StackContents {
     final double t1;
     final double t0;

--- a/wpimath/src/main/java/edu/wpi/first/math/system/Discretization.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/Discretization.java
@@ -9,7 +9,6 @@ import edu.wpi.first.math.Num;
 import edu.wpi.first.math.Pair;
 import org.ejml.simple.SimpleMatrix;
 
-@SuppressWarnings({"ParameterName", "MethodTypeParameterName"})
 public final class Discretization {
   private Discretization() {
     // Utility class
@@ -39,7 +38,6 @@ public final class Discretization {
    * @param dtSeconds Discretization timestep.
    * @return a Pair representing discA and diskB.
    */
-  @SuppressWarnings("LocalVariableName")
   public static <States extends Num, Inputs extends Num>
       Pair<Matrix<States, States>, Matrix<States, Inputs>> discretizeAB(
           Matrix<States, States> contA, Matrix<States, Inputs> contB, double dtSeconds) {
@@ -74,7 +72,6 @@ public final class Discretization {
    * @param dtSeconds Discretization timestep.
    * @return a pair representing the discrete system matrix and process noise covariance matrix.
    */
-  @SuppressWarnings("LocalVariableName")
   public static <States extends Num>
       Pair<Matrix<States, States>, Matrix<States, States>> discretizeAQ(
           Matrix<States, States> contA, Matrix<States, States> contQ, double dtSeconds) {
@@ -130,7 +127,6 @@ public final class Discretization {
    * @param dtSeconds Discretization timestep.
    * @return a pair representing the discrete system matrix and process noise covariance matrix.
    */
-  @SuppressWarnings("LocalVariableName")
   public static <States extends Num>
       Pair<Matrix<States, States>, Matrix<States, States>> discretizeAQTaylor(
           Matrix<States, States> contA, Matrix<States, States> contQ, double dtSeconds) {
@@ -204,12 +200,12 @@ public final class Discretization {
    * Note that dt=0.0 divides R by zero.
    *
    * @param <O> Nat representing the number of outputs.
-   * @param R Continuous measurement noise covariance matrix.
+   * @param contR Continuous measurement noise covariance matrix.
    * @param dtSeconds Discretization timestep.
    * @return Discretized version of the provided continuous measurement noise covariance matrix.
    */
-  public static <O extends Num> Matrix<O, O> discretizeR(Matrix<O, O> R, double dtSeconds) {
+  public static <O extends Num> Matrix<O, O> discretizeR(Matrix<O, O> contR, double dtSeconds) {
     // R_d = 1/T R
-    return R.div(dtSeconds);
+    return contR.div(dtSeconds);
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/system/LinearSystem.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/LinearSystem.java
@@ -8,76 +8,70 @@ import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.Num;
 import edu.wpi.first.math.numbers.N1;
 
-@SuppressWarnings("ClassTypeParameterName")
 public class LinearSystem<States extends Num, Inputs extends Num, Outputs extends Num> {
   /** Continuous system matrix. */
-  @SuppressWarnings("MemberName")
   private final Matrix<States, States> m_A;
 
   /** Continuous input matrix. */
-  @SuppressWarnings("MemberName")
   private final Matrix<States, Inputs> m_B;
 
   /** Output matrix. */
-  @SuppressWarnings("MemberName")
   private final Matrix<Outputs, States> m_C;
 
   /** Feedthrough matrix. */
-  @SuppressWarnings("MemberName")
   private final Matrix<Outputs, Inputs> m_D;
 
   /**
    * Construct a new LinearSystem from the four system matrices.
    *
-   * @param a The system matrix A.
-   * @param b The input matrix B.
-   * @param c The output matrix C.
-   * @param d The feedthrough matrix D.
+   * @param A The system matrix A.
+   * @param B The input matrix B.
+   * @param C The output matrix C.
+   * @param D The feedthrough matrix D.
    * @throws IllegalArgumentException if any matrix element isn't finite.
    */
-  @SuppressWarnings("ParameterName")
   public LinearSystem(
-      Matrix<States, States> a,
-      Matrix<States, Inputs> b,
-      Matrix<Outputs, States> c,
-      Matrix<Outputs, Inputs> d) {
-    for (int row = 0; row < a.getNumRows(); ++row) {
-      for (int col = 0; col < a.getNumCols(); ++col) {
-        if (!Double.isFinite(a.get(row, col))) {
+      Matrix<States, States> A,
+      Matrix<States, Inputs> B,
+      Matrix<Outputs, States> C,
+      Matrix<Outputs, Inputs> D) {
+    for (int row = 0; row < A.getNumRows(); ++row) {
+      for (int col = 0; col < A.getNumCols(); ++col) {
+        if (!Double.isFinite(A.get(row, col))) {
           throw new IllegalArgumentException(
               "Elements of A aren't finite. This is usually due to model implementation errors.");
         }
       }
     }
-    for (int row = 0; row < b.getNumRows(); ++row) {
-      for (int col = 0; col < b.getNumCols(); ++col) {
-        if (!Double.isFinite(b.get(row, col))) {
+    for (int row = 0; row < B.getNumRows(); ++row) {
+      for (int col = 0; col < B.getNumCols(); ++col) {
+        if (!Double.isFinite(B.get(row, col))) {
           throw new IllegalArgumentException(
               "Elements of B aren't finite. This is usually due to model implementation errors.");
         }
       }
     }
-    for (int row = 0; row < c.getNumRows(); ++row) {
-      for (int col = 0; col < c.getNumCols(); ++col) {
-        if (!Double.isFinite(c.get(row, col))) {
+    for (int row = 0; row < C.getNumRows(); ++row) {
+      for (int col = 0; col < C.getNumCols(); ++col) {
+        if (!Double.isFinite(C.get(row, col))) {
           throw new IllegalArgumentException(
               "Elements of C aren't finite. This is usually due to model implementation errors.");
         }
       }
     }
-    for (int row = 0; row < d.getNumRows(); ++row) {
-      for (int col = 0; col < d.getNumCols(); ++col) {
-        if (!Double.isFinite(d.get(row, col))) {
+    for (int row = 0; row < D.getNumRows(); ++row) {
+      for (int col = 0; col < D.getNumCols(); ++col) {
+        if (!Double.isFinite(D.get(row, col))) {
           throw new IllegalArgumentException(
               "Elements of D aren't finite. This is usually due to model implementation errors.");
         }
       }
     }
 
-    this.m_A = a;
-    this.m_B = b;
-    this.m_C = c;
-    this.m_D = d;
+    this.m_A = A;
+    this.m_B = B;
+    this.m_C = C;
+    this.m_D = D;
   }
 
   /**
@@ -170,7 +164,6 @@ public class LinearSystem<States extends Num, Inputs extends Num, Outputs extend
    * @param dtSeconds Timestep for model update.
    * @return the updated x.
    */
-  @SuppressWarnings("ParameterName")
   public Matrix<States, N1> calculateX(
       Matrix<States, N1> x, Matrix<Inputs, N1> clampedU, double dtSeconds) {
     var discABpair = Discretization.discretizeAB(m_A, m_B, dtSeconds);
@@ -187,7 +180,6 @@ public class LinearSystem<States extends Num, Inputs extends Num, Outputs extend
    * @param clampedU The control input.
    * @return the updated output matrix Y.
    */
-  @SuppressWarnings("ParameterName")
   public Matrix<Outputs, N1> calculateY(Matrix<States, N1> x, Matrix<Inputs, N1> clampedU) {
     return m_C.times(x).plus(m_D.times(clampedU));
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/system/LinearSystemLoop.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/LinearSystemLoop.java
@@ -28,7 +28,6 @@ import org.ejml.simple.SimpleMatrix;
  * <p>For more on the underlying math, read
  * https://file.tavsys.net/control/controls-engineering-in-frc.pdf.
  */
-@SuppressWarnings("ClassTypeParameterName")
 public class LinearSystemLoop<States extends Num, Inputs extends Num, Outputs extends Num> {
   private final LinearQuadraticRegulator<States, Inputs, Outputs> m_controller;
   private final LinearPlantInversionFeedforward<States, Inputs, Outputs> m_feedforward;
@@ -315,7 +314,6 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num, Outputs ex
    *
    * @param y Measurement vector.
    */
-  @SuppressWarnings("ParameterName")
   public void correct(Matrix<Outputs, N1> y) {
     getObserver().correct(getU(), y);
   }
@@ -327,7 +325,6 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num, Outputs ex
    *
    * @param dtSeconds Timestep for model update.
    */
-  @SuppressWarnings("LocalVariableName")
   public void predict(double dtSeconds) {
     var u =
         clampInput(

--- a/wpimath/src/main/java/edu/wpi/first/math/system/NumericalIntegration.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/NumericalIntegration.java
@@ -24,7 +24,7 @@ public final class NumericalIntegration {
    * @param dtSeconds The time over which to integrate.
    * @return the integration of dx/dt = f(x) for dt.
    */
-  @SuppressWarnings({"ParameterName", "overloads"})
+  @SuppressWarnings("overloads")
   public static double rk4(DoubleFunction<Double> f, double x, double dtSeconds) {
     final var h = dtSeconds;
     final var k1 = f.apply(x);
@@ -44,7 +44,7 @@ public final class NumericalIntegration {
    * @param dtSeconds The time over which to integrate.
    * @return The result of Runge Kutta integration (4th order).
    */
-  @SuppressWarnings({"ParameterName", "overloads"})
+  @SuppressWarnings("overloads")
   public static double rk4(
       BiFunction<Double, Double, Double> f, double x, Double u, double dtSeconds) {
     final var h = dtSeconds;
@@ -68,7 +68,7 @@ public final class NumericalIntegration {
    * @param dtSeconds The time over which to integrate.
    * @return the integration of dx/dt = f(x, u) for dt.
    */
-  @SuppressWarnings({"ParameterName", "MethodTypeParameterName", "overloads"})
+  @SuppressWarnings("overloads")
   public static <States extends Num, Inputs extends Num> Matrix<States, N1> rk4(
       BiFunction<Matrix<States, N1>, Matrix<Inputs, N1>, Matrix<States, N1>> f,
       Matrix<States, N1> x,
@@ -93,7 +93,7 @@ public final class NumericalIntegration {
    * @param dtSeconds The time over which to integrate.
    * @return 4th order Runge-Kutta integration of dx/dt = f(x) for dt.
    */
-  @SuppressWarnings({"ParameterName", "MethodTypeParameterName", "overloads"})
+  @SuppressWarnings("overloads")
   public static <States extends Num> Matrix<States, N1> rk4(
       Function<Matrix<States, N1>, Matrix<States, N1>> f, Matrix<States, N1> x, double dtSeconds) {
     final var h = dtSeconds;
@@ -119,7 +119,7 @@ public final class NumericalIntegration {
    * @param dtSeconds The time over which to integrate.
    * @return the integration of dx/dt = f(x, u) for dt.
    */
-  @SuppressWarnings("MethodTypeParameterName")
+  @SuppressWarnings("overloads")
   public static <States extends Num, Inputs extends Num> Matrix<States, N1> rkf45(
       BiFunction<Matrix<States, N1>, Matrix<Inputs, N1>, Matrix<States, N1>> f,
       Matrix<States, N1> x,
@@ -141,7 +141,7 @@ public final class NumericalIntegration {
    * @param maxError The maximum acceptable truncation error. Usually a small number like 1e-6.
    * @return the integration of dx/dt = f(x, u) for dt.
    */
-  @SuppressWarnings("MethodTypeParameterName")
+  @SuppressWarnings("overloads")
   public static <States extends Num, Inputs extends Num> Matrix<States, N1> rkf45(
       BiFunction<Matrix<States, N1>, Matrix<Inputs, N1>, Matrix<States, N1>> f,
       Matrix<States, N1> x,
@@ -251,7 +251,7 @@ public final class NumericalIntegration {
    * @param dtSeconds The time over which to integrate.
    * @return the integration of dx/dt = f(x, u) for dt.
    */
-  @SuppressWarnings("MethodTypeParameterName")
+  @SuppressWarnings("overloads")
   public static <States extends Num, Inputs extends Num> Matrix<States, N1> rkdp(
       BiFunction<Matrix<States, N1>, Matrix<Inputs, N1>, Matrix<States, N1>> f,
       Matrix<States, N1> x,
@@ -272,7 +272,7 @@ public final class NumericalIntegration {
    * @param maxError The maximum acceptable truncation error. Usually a small number like 1e-6.
    * @return the integration of dx/dt = f(x, u) for dt.
    */
-  @SuppressWarnings("MethodTypeParameterName")
+  @SuppressWarnings("overloads")
   public static <States extends Num, Inputs extends Num> Matrix<States, N1> rkdp(
       BiFunction<Matrix<States, N1>, Matrix<Inputs, N1>, Matrix<States, N1>> f,
       Matrix<States, N1> x,

--- a/wpimath/src/main/java/edu/wpi/first/math/system/NumericalJacobian.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/NumericalJacobian.java
@@ -30,7 +30,6 @@ public final class NumericalJacobian {
    * @param x Vector argument.
    * @return The numerical Jacobian with respect to x for f(x, u, ...).
    */
-  @SuppressWarnings({"ParameterName", "MethodTypeParameterName"})
   public static <Rows extends Num, Cols extends Num, States extends Num>
       Matrix<Rows, Cols> numericalJacobian(
           Nat<Rows> rows,
@@ -44,7 +43,6 @@ public final class NumericalJacobian {
       var dxMinus = x.copy();
       dxPlus.set(i, 0, dxPlus.get(i, 0) + kEpsilon);
       dxMinus.set(i, 0, dxMinus.get(i, 0) - kEpsilon);
-      @SuppressWarnings("LocalVariableName")
       var dF = f.apply(dxPlus).minus(f.apply(dxMinus)).div(2 * kEpsilon);
 
       result.setColumn(i, Matrix.changeBoundsUnchecked(dF));
@@ -67,7 +65,6 @@ public final class NumericalJacobian {
    * @param u Input vector.
    * @return The numerical Jacobian with respect to x for f(x, u, ...).
    */
-  @SuppressWarnings({"LambdaParameterName", "MethodTypeParameterName"})
   public static <Rows extends Num, States extends Num, Inputs extends Num, Outputs extends Num>
       Matrix<Rows, States> numericalJacobianX(
           Nat<Rows> rows,
@@ -91,7 +88,6 @@ public final class NumericalJacobian {
    * @param u Input vector.
    * @return the numerical Jacobian with respect to u for f(x, u).
    */
-  @SuppressWarnings({"LambdaParameterName", "MethodTypeParameterName"})
   public static <Rows extends Num, States extends Num, Inputs extends Num>
       Matrix<Rows, Inputs> numericalJacobianU(
           Nat<Rows> rows,

--- a/wpimath/src/main/java/edu/wpi/first/math/system/plant/DCMotor.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/plant/DCMotor.java
@@ -8,28 +8,13 @@ import edu.wpi.first.math.util.Units;
 
 /** Holds the constants for a DC motor. */
 public class DCMotor {
-  @SuppressWarnings("MemberName")
   public final double nominalVoltageVolts;
-
-  @SuppressWarnings("MemberName")
   public final double stallTorqueNewtonMeters;
-
-  @SuppressWarnings("MemberName")
   public final double stallCurrentAmps;
-
-  @SuppressWarnings("MemberName")
   public final double freeCurrentAmps;
-
-  @SuppressWarnings("MemberName")
   public final double freeSpeedRadPerSec;
-
-  @SuppressWarnings("MemberName")
   public final double rOhms;
-
-  @SuppressWarnings("MemberName")
   public final double KvRadPerSecPerVolt;
-
-  @SuppressWarnings("MemberName")
   public final double KtNMPerAmp;
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/system/plant/LinearSystemId.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/plant/LinearSystemId.java
@@ -27,7 +27,6 @@ public final class LinearSystemId {
    * @return A LinearSystem representing the given characterized constants.
    * @throws IllegalArgumentException if massKg &lt;= 0, radiusMeters &lt;= 0, or G &lt;= 0.
    */
-  @SuppressWarnings("ParameterName")
   public static LinearSystem<N2, N1, N1> createElevatorSystem(
       DCMotor motor, double massKg, double radiusMeters, double G) {
     if (massKg <= 0.0) {
@@ -68,7 +67,6 @@ public final class LinearSystemId {
    * @return A LinearSystem representing the given characterized constants.
    * @throws IllegalArgumentException if JKgMetersSquared &lt;= 0 or G &lt;= 0.
    */
-  @SuppressWarnings("ParameterName")
   public static LinearSystem<N1, N1, N1> createFlywheelSystem(
       DCMotor motor, double JKgMetersSquared, double G) {
     if (JKgMetersSquared <= 0.0) {
@@ -100,7 +98,6 @@ public final class LinearSystemId {
    * @return A LinearSystem representing the given characterized constants.
    * @throws IllegalArgumentException if JKgMetersSquared &lt;= 0 or G &lt;= 0.
    */
-  @SuppressWarnings("ParameterName")
   public static LinearSystem<N2, N1, N2> createDCMotorSystem(
       DCMotor motor, double JKgMetersSquared, double G) {
     if (JKgMetersSquared <= 0.0) {
@@ -139,7 +136,6 @@ public final class LinearSystemId {
    * @return A LinearSystem representing a differential drivetrain.
    * @throws IllegalArgumentException if m &lt;= 0, r &lt;= 0, rb &lt;= 0, J &lt;= 0, or G &lt;= 0.
    */
-  @SuppressWarnings({"LocalVariableName", "ParameterName"})
   public static LinearSystem<N2, N2, N2> createDrivetrainVelocitySystem(
       DCMotor motor,
       double massKg,
@@ -187,7 +183,6 @@ public final class LinearSystemId {
    *     will be greater than 1.
    * @return A LinearSystem representing the given characterized constants.
    */
-  @SuppressWarnings("ParameterName")
   public static LinearSystem<N2, N1, N1> createSingleJointedArmSystem(
       DCMotor motor, double JKgSquaredMeters, double G) {
     if (JKgSquaredMeters <= 0.0) {
@@ -229,7 +224,6 @@ public final class LinearSystemId {
    * @throws IllegalArgumentException if kV &lt;= 0 or kA &lt;= 0.
    * @see <a href="https://github.com/wpilibsuite/sysid">https://github.com/wpilibsuite/sysid</a>
    */
-  @SuppressWarnings("ParameterName")
   public static LinearSystem<N1, N1, N1> identifyVelocitySystem(double kV, double kA) {
     if (kV <= 0.0) {
       throw new IllegalArgumentException("Kv must be greater than zero.");
@@ -263,7 +257,6 @@ public final class LinearSystemId {
    * @throws IllegalArgumentException if kV &lt;= 0 or kA &lt;= 0.
    * @see <a href="https://github.com/wpilibsuite/sysid">https://github.com/wpilibsuite/sysid</a>
    */
-  @SuppressWarnings("ParameterName")
   public static LinearSystem<N2, N1, N1> identifyPositionSystem(double kV, double kA) {
     if (kV <= 0.0) {
       throw new IllegalArgumentException("Kv must be greater than zero.");
@@ -297,7 +290,6 @@ public final class LinearSystemId {
    *     kAAngular &lt;= 0.
    * @see <a href="https://github.com/wpilibsuite/sysid">https://github.com/wpilibsuite/sysid</a>
    */
-  @SuppressWarnings("ParameterName")
   public static LinearSystem<N2, N2, N2> identifyDrivetrainSystem(
       double kVLinear, double kALinear, double kVAngular, double kAAngular) {
     if (kVLinear <= 0.0) {
@@ -345,7 +337,6 @@ public final class LinearSystemId {
    *     kAAngular &lt;= 0, or trackwidth &lt;= 0.
    * @see <a href="https://github.com/wpilibsuite/sysid">https://github.com/wpilibsuite/sysid</a>
    */
-  @SuppressWarnings("ParameterName")
   public static LinearSystem<N2, N2, N2> identifyDrivetrainSystem(
       double kVLinear, double kALinear, double kVAngular, double kAAngular, double trackwidth) {
     if (kVLinear <= 0.0) {

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/Trajectory.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/Trajectory.java
@@ -44,7 +44,6 @@ public class Trajectory {
    * @param t The fraction for interpolation.
    * @return The interpolated value.
    */
-  @SuppressWarnings("ParameterName")
   private static double lerp(double startValue, double endValue, double t) {
     return startValue + (endValue - startValue) * t;
   }
@@ -57,7 +56,6 @@ public class Trajectory {
    * @param t The fraction for interpolation.
    * @return The interpolated pose.
    */
-  @SuppressWarnings("ParameterName")
   private static Pose2d lerp(Pose2d startValue, Pose2d endValue, double t) {
     return startValue.plus((endValue.minus(startValue)).times(t));
   }
@@ -254,7 +252,6 @@ public class Trajectory {
    * Represents a time-parameterized trajectory. The trajectory contains of various States that
    * represent the pose, curvature, time elapsed, velocity, and acceleration at that point.
    */
-  @SuppressWarnings("MemberName")
   public static class State {
     // The time elapsed since the beginning of the trajectory.
     @JsonProperty("time")
@@ -309,7 +306,6 @@ public class Trajectory {
      * @param i The interpolant (fraction).
      * @return The interpolated state.
      */
-    @SuppressWarnings("ParameterName")
     State interpolate(State endValue, double i) {
       // Find the new t value.
       final double newT = lerp(timeSeconds, endValue.timeSeconds, i);

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrajectoryGenerator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrajectoryGenerator.java
@@ -193,7 +193,6 @@ public final class TrajectoryGenerator {
    * @param config The configuration for the trajectory.
    * @return The generated trajectory.
    */
-  @SuppressWarnings("LocalVariableName")
   public static Trajectory generateTrajectory(List<Pose2d> waypoints, TrajectoryConfig config) {
     final var flip = new Transform2d(new Translation2d(), Rotation2d.fromDegrees(180.0));
 

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrajectoryParameterizer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrajectoryParameterizer.java
@@ -294,7 +294,6 @@ public final class TrajectoryParameterizer {
     }
   }
 
-  @SuppressWarnings("MemberName")
   private static class ConstrainedState {
     PoseWithCurvature pose;
     double distanceMeters;

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrapezoidProfile.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/TrapezoidProfile.java
@@ -51,10 +51,8 @@ public class TrapezoidProfile {
   private double m_endDeccel;
 
   public static class Constraints {
-    @SuppressWarnings("MemberName")
     public final double maxVelocity;
 
-    @SuppressWarnings("MemberName")
     public final double maxAcceleration;
 
     /**
@@ -71,10 +69,8 @@ public class TrapezoidProfile {
   }
 
   public static class State {
-    @SuppressWarnings("MemberName")
     public double position;
 
-    @SuppressWarnings("MemberName")
     public double velocity;
 
     public State() {}

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/constraint/EllipticalRegionConstraint.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/constraint/EllipticalRegionConstraint.java
@@ -23,7 +23,6 @@ public class EllipticalRegionConstraint implements TrajectoryConstraint {
    * @param rotation The rotation to apply to all radii around the origin.
    * @param constraint The constraint to enforce when the robot is within the region.
    */
-  @SuppressWarnings("ParameterName")
   public EllipticalRegionConstraint(
       Translation2d center,
       double xWidth,

--- a/wpimath/src/main/java/edu/wpi/first/math/trajectory/constraint/TrajectoryConstraint.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/trajectory/constraint/TrajectoryConstraint.java
@@ -36,7 +36,6 @@ public interface TrajectoryConstraint {
       Pose2d poseMeters, double curvatureRadPerMeter, double velocityMetersPerSecond);
 
   /** Represents a minimum and maximum acceleration. */
-  @SuppressWarnings("MemberName")
   class MinMax {
     public double minAccelerationMetersPerSecondSq = -Double.MAX_VALUE;
     public double maxAccelerationMetersPerSecondSq = +Double.MAX_VALUE;

--- a/wpimath/src/test/java/edu/wpi/first/math/DrakeTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/DrakeTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.ejml.simple.SimpleMatrix;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings({"ParameterName", "LocalVariableName"})
 class DrakeTest {
   public static void assertMatrixEqual(SimpleMatrix A, SimpleMatrix B) {
     for (int i = 0; i < A.numRows(); i++) {

--- a/wpimath/src/test/java/edu/wpi/first/math/StateSpaceUtilTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/StateSpaceUtilTest.java
@@ -50,7 +50,6 @@ class StateSpaceUtilTest {
   }
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testIsStabilizable() {
     Matrix<N2, N2> A;
     Matrix<N2, N1> B = VecBuilder.fill(0, 1);
@@ -77,7 +76,6 @@ class StateSpaceUtilTest {
   }
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testIsDetectable() {
     Matrix<N2, N2> A;
     Matrix<N1, N2> C = Matrix.mat(Nat.N1(), Nat.N2()).fill(0, 1);

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/ControlAffinePlantInversionFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/ControlAffinePlantInversionFeedforwardTest.java
@@ -14,7 +14,6 @@ import edu.wpi.first.math.numbers.N2;
 import org.junit.jupiter.api.Test;
 
 class ControlAffinePlantInversionFeedforwardTest {
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testCalculate() {
     ControlAffinePlantInversionFeedforward<N2, N1> feedforward =
@@ -25,7 +24,6 @@ class ControlAffinePlantInversionFeedforwardTest {
         48.0, feedforward.calculate(VecBuilder.fill(2, 2), VecBuilder.fill(3, 3)).get(0, 0), 1e-6);
   }
 
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testCalculateState() {
     ControlAffinePlantInversionFeedforward<N2, N1> feedforward =
@@ -36,7 +34,6 @@ class ControlAffinePlantInversionFeedforwardTest {
         48.0, feedforward.calculate(VecBuilder.fill(2, 2), VecBuilder.fill(3, 3)).get(0, 0), 1e-6);
   }
 
-  @SuppressWarnings("ParameterName")
   protected Matrix<N2, N1> getDynamics(Matrix<N2, N1> x, Matrix<N1, N1> u) {
     return Matrix.mat(Nat.N2(), Nat.N2())
         .fill(1.000, 0, 0, 1.000)
@@ -44,7 +41,6 @@ class ControlAffinePlantInversionFeedforwardTest {
         .plus(VecBuilder.fill(0, 1).times(u));
   }
 
-  @SuppressWarnings("ParameterName")
   protected Matrix<N2, N1> getStateDynamics(Matrix<N2, N1> x) {
     return Matrix.mat(Nat.N2(), Nat.N2()).fill(1.000, 0, 0, 1.000).times(x);
   }

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveAccelerationLimiterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveAccelerationLimiterTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 class DifferentialDriveAccelerationLimiterTest {
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testLowLimits() {
     final double trackwidth = 0.9;
     final double dt = 0.005;
@@ -137,7 +136,6 @@ class DifferentialDriveAccelerationLimiterTest {
   }
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testHighLimits() {
     final double trackwidth = 0.9;
     final double dt = 0.005;

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/ImplicitModelFollowerTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/ImplicitModelFollowerTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 class ImplicitModelFollowerTest {
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testSameModel() {
     final double dt = 0.005;
 
@@ -58,7 +57,6 @@ class ImplicitModelFollowerTest {
   }
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testSlowerRefModel() {
     final double dt = 0.005;
 

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/LinearPlantInversionFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/LinearPlantInversionFeedforwardTest.java
@@ -14,7 +14,6 @@ import edu.wpi.first.math.numbers.N2;
 import org.junit.jupiter.api.Test;
 
 class LinearPlantInversionFeedforwardTest {
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testCalculate() {
     Matrix<N2, N2> A = Matrix.mat(Nat.N2(), Nat.N2()).fill(1, 0, 0, 1);

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/LinearQuadraticRegulatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/LinearQuadraticRegulatorTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 class LinearQuadraticRegulatorTest {
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testLQROnElevator() {
     var motors = DCMotor.getVex775Pro(2);
 
@@ -38,7 +37,6 @@ class LinearQuadraticRegulatorTest {
   }
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testFourMotorElevator() {
     var dt = 0.020;
 
@@ -55,7 +53,6 @@ class LinearQuadraticRegulatorTest {
   }
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testLQROnArm() {
     var motors = DCMotor.getVex775Pro(2);
 
@@ -89,7 +86,6 @@ class LinearQuadraticRegulatorTest {
    * @param Aref Desired state matrix.
    * @param dtSeconds Discretization timestep in seconds.
    */
-  @SuppressWarnings({"LocalVariableName", "MethodTypeParameterName", "ParameterName"})
   <States extends Num, Inputs extends Num> Matrix<Inputs, States> getImplicitModelFollowingK(
       Matrix<States, States> A,
       Matrix<States, Inputs> B,
@@ -114,7 +110,6 @@ class LinearQuadraticRegulatorTest {
   }
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testMatrixOverloadsWithSingleIntegrator() {
     var A = Matrix.mat(Nat.N2(), Nat.N2()).fill(0, 0, 0, 0);
     var B = Matrix.mat(Nat.N2(), Nat.N2()).fill(1, 0, 0, 1);
@@ -138,7 +133,6 @@ class LinearQuadraticRegulatorTest {
   }
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testMatrixOverloadsWithDoubleIntegrator() {
     double Kv = 3.02;
     double Ka = 0.642;

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/LinearSystemLoopTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/LinearSystemLoopTest.java
@@ -40,7 +40,6 @@ class LinearSystemLoopTest {
   private final LinearSystemLoop<N2, N1, N1> m_loop =
       new LinearSystemLoop<>(m_plant, m_controller, m_observer, 12, 0.00505);
 
-  @SuppressWarnings("LocalVariableName")
   private static void updateTwoState(
       LinearSystem<N2, N1, N1> plant, LinearSystemLoop<N2, N1, N1> loop, double noise) {
     Matrix<N1, N1> y = plant.calculateY(loop.getXHat(), loop.getU()).plus(VecBuilder.fill(noise));
@@ -50,7 +49,6 @@ class LinearSystemLoopTest {
   }
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testStateSpaceEnabled() {
     m_loop.reset(VecBuilder.fill(0, 0));
     Matrix<N2, N1> references = VecBuilder.fill(2.0, 0.0);
@@ -79,7 +77,6 @@ class LinearSystemLoopTest {
   }
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testFlywheelEnabled() {
     LinearSystem<N1, N1, N1> plant =
         LinearSystemId.createFlywheelSystem(DCMotor.getNEO(2), 0.00289, 1.0);

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/SimpleMotorFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/SimpleMotorFeedforwardTest.java
@@ -13,7 +13,6 @@ import edu.wpi.first.math.numbers.N1;
 import org.junit.jupiter.api.Test;
 
 class SimpleMotorFeedforwardTest {
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testCalculate() {
     double Ks = 0.5;

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -22,7 +22,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 
 class DifferentialDrivePoseEstimatorTest {
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testAccuracy() {
     var estimator =

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/ExtendedKalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/ExtendedKalmanFilterTest.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("ParameterName")
 class ExtendedKalmanFilterTest {
   private static Matrix<N5, N1> getDynamics(final Matrix<N5, N1> x, final Matrix<N2, N1> u) {
     final var motors = DCMotor.getCIM(2);
@@ -68,7 +67,6 @@ class ExtendedKalmanFilterTest {
     return VecBuilder.fill(x.get(0, 0), x.get(1, 0), x.get(2, 0), x.get(3, 0), x.get(4, 0));
   }
 
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testInit() {
     double dtSeconds = 0.00505;
@@ -99,7 +97,6 @@ class ExtendedKalmanFilterTest {
         });
   }
 
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testConvergence() {
     double dtSeconds = 0.00505;

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/KalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/KalmanFilterTest.java
@@ -34,7 +34,6 @@ class KalmanFilterTest {
     createElevator();
   }
 
-  @SuppressWarnings("LocalVariableName")
   private static void createElevator() {
     var motors = DCMotor.getVex775Pro(2);
 
@@ -61,7 +60,6 @@ class KalmanFilterTest {
           new Matrix<>(Nat.N3(), Nat.N3())); // D
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testElevatorKalmanFilter() {
     var Q = VecBuilder.fill(0.05, 1.0);
     var R = VecBuilder.fill(0.0001);
@@ -136,7 +134,6 @@ class KalmanFilterTest {
   }
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testSwerveKFMovingOverTrajectory() {
     var random = new Random();
 

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimatorTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 class MecanumDrivePoseEstimatorTest {
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testAccuracy() {
     var kinematics =
         new MecanumDriveKinematics(

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimatorTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 class SwerveDrivePoseEstimatorTest {
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testAccuracy() {
     var kinematics =
         new SwerveDriveKinematics(

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/UnscentedKalmanFilterTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class UnscentedKalmanFilterTest {
-  @SuppressWarnings({"LocalVariableName", "ParameterName"})
   private static Matrix<N5, N1> getDynamics(Matrix<N5, N1> x, Matrix<N2, N1> u) {
     var motors = DCMotor.getCIM(2);
 
@@ -63,18 +62,17 @@ class UnscentedKalmanFilterTest {
         k2 * (C1 * vl + C2 * Vl) + k1 * (C1 * vr + C2 * Vr));
   }
 
-  @SuppressWarnings({"PMD.UnusedFormalParameter", "ParameterName"})
+  @SuppressWarnings("PMD.UnusedFormalParameter")
   private static Matrix<N3, N1> getLocalMeasurementModel(Matrix<N5, N1> x, Matrix<N2, N1> u) {
     return VecBuilder.fill(x.get(2, 0), x.get(3, 0), x.get(4, 0));
   }
 
-  @SuppressWarnings({"PMD.UnusedFormalParameter", "ParameterName"})
+  @SuppressWarnings("PMD.UnusedFormalParameter")
   private static Matrix<N5, N1> getGlobalMeasurementModel(Matrix<N5, N1> x, Matrix<N2, N1> u) {
     return x.copy();
   }
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testInit() {
     var dtSeconds = 0.005;
     assertDoesNotThrow(
@@ -117,7 +115,6 @@ class UnscentedKalmanFilterTest {
         });
   }
 
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testConvergence() {
     double dtSeconds = 0.005;
@@ -224,7 +221,6 @@ class UnscentedKalmanFilterTest {
   }
 
   @Test
-  @SuppressWarnings({"LocalVariableName", "ParameterName"})
   void testLinearUKF() {
     var dt = 0.020;
     var plant = LinearSystemId.identifyVelocitySystem(0.02, 0.006);
@@ -254,7 +250,6 @@ class UnscentedKalmanFilterTest {
     assertEquals(ref.get(0, 0), observer.getXhat(0), 5);
   }
 
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testRoundTripP() {
     var dtSeconds = 0.005;

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/CoordinateSystemTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/CoordinateSystemTest.java
@@ -29,7 +29,6 @@ class CoordinateSystemTest {
     assertEquals(poseFrom, CoordinateSystem.convert(poseTo, coordTo, coordFrom));
   }
 
-  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @Test
   void testEDNtoNWU() {
     // No rotation from EDN to NWU
@@ -80,7 +79,6 @@ class CoordinateSystemTest {
         CoordinateSystem.NWU());
   }
 
-  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @Test
   void testEDNtoNED() {
     // No rotation from EDN to NED

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Pose3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Pose3dTest.java
@@ -17,7 +17,6 @@ class Pose3dTest {
 
   @Test
   void testTransformBy() {
-    @SuppressWarnings("LocalVariableName")
     var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var initial =
@@ -38,7 +37,6 @@ class Pose3dTest {
 
   @Test
   void testRelativeTo() {
-    @SuppressWarnings("LocalVariableName")
     var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var initial = new Pose3d(0.0, 0.0, 0.0, new Rotation3d(zAxis, Units.degreesToRadians(45.0)));
@@ -54,7 +52,6 @@ class Pose3dTest {
 
   @Test
   void testEquality() {
-    @SuppressWarnings("LocalVariableName")
     var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var one = new Pose3d(0.0, 5.0, 0.0, new Rotation3d(zAxis, Units.degreesToRadians(43.0)));
@@ -64,7 +61,6 @@ class Pose3dTest {
 
   @Test
   void testInequality() {
-    @SuppressWarnings("LocalVariableName")
     var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var one = new Pose3d(0.0, 5.0, 0.0, new Rotation3d(zAxis, Units.degreesToRadians(43.0)));
@@ -74,7 +70,6 @@ class Pose3dTest {
 
   @Test
   void testMinus() {
-    @SuppressWarnings("LocalVariableName")
     var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var initial = new Pose3d(0.0, 0.0, 0.0, new Rotation3d(zAxis, Units.degreesToRadians(45.0)));

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/QuaternionTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/QuaternionTest.java
@@ -47,7 +47,6 @@ class QuaternionTest {
             + q3.getZ() * q3.getZ());
   }
 
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testTimes() {
     // 90° CCW rotations around each axis

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Rotation3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Rotation3dTest.java
@@ -21,19 +21,16 @@ class Rotation3dTest {
 
   @Test
   void testInitAxisAngleAndRollPitchYaw() {
-    @SuppressWarnings("LocalVariableName")
     final var xAxis = VecBuilder.fill(1.0, 0.0, 0.0);
     final var rot1 = new Rotation3d(xAxis, Math.PI / 3);
     final var rot2 = new Rotation3d(Math.PI / 3, 0.0, 0.0);
     assertEquals(rot1, rot2);
 
-    @SuppressWarnings("LocalVariableName")
     final var yAxis = VecBuilder.fill(0.0, 1.0, 0.0);
     final var rot3 = new Rotation3d(yAxis, Math.PI / 3);
     final var rot4 = new Rotation3d(0.0, Math.PI / 3, 0.0);
     assertEquals(rot3, rot4);
 
-    @SuppressWarnings("LocalVariableName")
     final var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
     final var rot5 = new Rotation3d(zAxis, Math.PI / 3);
     final var rot6 = new Rotation3d(0.0, 0.0, Math.PI / 3);
@@ -68,11 +65,8 @@ class Rotation3dTest {
 
   @Test
   void testInitTwoVector() {
-    @SuppressWarnings("LocalVariableName")
     final var xAxis = VecBuilder.fill(1.0, 0.0, 0.0);
-    @SuppressWarnings("LocalVariableName")
     final var yAxis = VecBuilder.fill(0.0, 1.0, 0.0);
-    @SuppressWarnings("LocalVariableName")
     final var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     // 90 degree CW rotation around y-axis
@@ -128,7 +122,6 @@ class Rotation3dTest {
 
   @Test
   void testRadiansToDegrees() {
-    @SuppressWarnings("LocalVariableName")
     final var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var rot1 = new Rotation3d(zAxis, Math.PI / 3);
@@ -146,7 +139,6 @@ class Rotation3dTest {
 
   @Test
   void testRadiansAndDegrees() {
-    @SuppressWarnings("LocalVariableName")
     final var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var rot1 = new Rotation3d(zAxis, Units.degreesToRadians(45.0));
@@ -162,7 +154,6 @@ class Rotation3dTest {
         () -> assertEquals(Math.PI / 6.0, rot2.getZ(), kEpsilon));
   }
 
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testRotationLoop() {
     var rot = new Rotation3d();
@@ -186,7 +177,6 @@ class Rotation3dTest {
     assertEquals(new Rotation3d(), rot);
   }
 
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testRotateByFromZeroX() {
     final var xAxis = VecBuilder.fill(1.0, 0.0, 0.0);
@@ -198,7 +188,6 @@ class Rotation3dTest {
     assertEquals(expected, rotated);
   }
 
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testRotateByFromZeroY() {
     final var yAxis = VecBuilder.fill(0.0, 1.0, 0.0);
@@ -210,7 +199,6 @@ class Rotation3dTest {
     assertEquals(expected, rotated);
   }
 
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testRotateByFromZeroZ() {
     final var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
@@ -224,7 +212,6 @@ class Rotation3dTest {
 
   @Test
   void testRotateByNonZeroX() {
-    @SuppressWarnings("LocalVariableName")
     final var xAxis = VecBuilder.fill(1.0, 0.0, 0.0);
 
     var rot = new Rotation3d(xAxis, Units.degreesToRadians(90.0));
@@ -236,7 +223,6 @@ class Rotation3dTest {
 
   @Test
   void testRotateByNonZeroY() {
-    @SuppressWarnings("LocalVariableName")
     final var yAxis = VecBuilder.fill(0.0, 1.0, 0.0);
 
     var rot = new Rotation3d(yAxis, Units.degreesToRadians(90.0));
@@ -248,7 +234,6 @@ class Rotation3dTest {
 
   @Test
   void testRotateByNonZeroZ() {
-    @SuppressWarnings("LocalVariableName")
     final var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var rot = new Rotation3d(zAxis, Units.degreesToRadians(90.0));
@@ -260,7 +245,6 @@ class Rotation3dTest {
 
   @Test
   void testMinus() {
-    @SuppressWarnings("LocalVariableName")
     final var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var rot1 = new Rotation3d(zAxis, Units.degreesToRadians(70.0));
@@ -271,7 +255,6 @@ class Rotation3dTest {
 
   @Test
   void testEquality() {
-    @SuppressWarnings("LocalVariableName")
     final var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var rot1 = new Rotation3d(zAxis, Units.degreesToRadians(43.0));
@@ -283,7 +266,6 @@ class Rotation3dTest {
     assertEquals(rot1, rot2);
   }
 
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testAxisAngle() {
     final var xAxis = VecBuilder.fill(1.0, 0.0, 0.0);
@@ -317,7 +299,6 @@ class Rotation3dTest {
 
   @Test
   void testInequality() {
-    @SuppressWarnings("LocalVariableName")
     final var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var rot1 = new Rotation3d(zAxis, Units.degreesToRadians(43.0));
@@ -325,7 +306,6 @@ class Rotation3dTest {
     assertNotEquals(rot1, rot2);
   }
 
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testInterpolate() {
     final var xAxis = VecBuilder.fill(1.0, 0.0, 0.0);

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Transform3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Transform3dTest.java
@@ -16,7 +16,6 @@ class Transform3dTest {
 
   @Test
   void testInverse() {
-    @SuppressWarnings("LocalVariableName")
     var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var initial =
@@ -40,7 +39,6 @@ class Transform3dTest {
 
   @Test
   void testComposition() {
-    @SuppressWarnings("LocalVariableName")
     var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var initial =

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Translation3dTest.java
@@ -41,7 +41,6 @@ class Translation3dTest {
         () -> assertEquals(-3.0, difference.getZ(), kEpsilon));
   }
 
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testRotateBy() {
     var xAxis = VecBuilder.fill(1.0, 0.0, 0.0);
@@ -139,7 +138,6 @@ class Translation3dTest {
 
   @Test
   void testPolarConstructor() {
-    @SuppressWarnings("LocalVariableName")
     var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var one = new Translation3d(Math.sqrt(2), new Rotation3d(zAxis, Units.degreesToRadians(45.0)));

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Twist3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Twist3dTest.java
@@ -41,7 +41,6 @@ class Twist3dTest {
 
   @Test
   void testQuarterCirle() {
-    @SuppressWarnings("LocalVariableName")
     var zAxis = VecBuilder.fill(0.0, 0.0, 1.0);
 
     var quarterCircle = new Twist3d(5.0 / 2.0 * Math.PI, 0.0, 0.0, 0.0, 0.0, Math.PI / 2.0);

--- a/wpimath/src/test/java/edu/wpi/first/math/spline/CubicHermiteSplineTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/spline/CubicHermiteSplineTest.java
@@ -23,7 +23,6 @@ class CubicHermiteSplineTest {
   private static final double kMaxDy = 0.00127;
   private static final double kMaxDtheta = 0.0872;
 
-  @SuppressWarnings("ParameterName")
   private void run(Pose2d a, List<Translation2d> waypoints, Pose2d b) {
     // Start the timer.
     // var start = System.nanoTime();
@@ -97,13 +96,11 @@ class CubicHermiteSplineTest {
                 1E-9));
   }
 
-  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @Test
   void testStraightLine() {
     run(new Pose2d(), new ArrayList<>(), new Pose2d(3, 0, new Rotation2d()));
   }
 
-  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @Test
   void testSCurve() {
     var start = new Pose2d(0, 0, Rotation2d.fromDegrees(90.0));
@@ -115,7 +112,6 @@ class CubicHermiteSplineTest {
     run(start, waypoints, end);
   }
 
-  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @Test
   void testOneInterior() {
     var start = new Pose2d(0, 0, Rotation2d.fromDegrees(0.0));
@@ -126,7 +122,6 @@ class CubicHermiteSplineTest {
     run(start, waypoints, end);
   }
 
-  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @Test
   void testWindyPath() {
     final var start = new Pose2d(0, 0, Rotation2d.fromDegrees(0.0));

--- a/wpimath/src/test/java/edu/wpi/first/math/spline/QuinticHermiteSplineTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/spline/QuinticHermiteSplineTest.java
@@ -20,7 +20,6 @@ class QuinticHermiteSplineTest {
   private static final double kMaxDy = 0.00127;
   private static final double kMaxDtheta = 0.0872;
 
-  @SuppressWarnings("ParameterName")
   private void run(Pose2d a, Pose2d b) {
     // Start the timer.
     // var start = System.nanoTime();
@@ -68,19 +67,16 @@ class QuinticHermiteSplineTest {
                 1E-9));
   }
 
-  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @Test
   void testStraightLine() {
     run(new Pose2d(), new Pose2d(3, 0, new Rotation2d()));
   }
 
-  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @Test
   void testSimpleSCurve() {
     run(new Pose2d(), new Pose2d(1, 1, new Rotation2d()));
   }
 
-  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @Test
   void testSquiggly() {
     run(

--- a/wpimath/src/test/java/edu/wpi/first/math/system/RungeKuttaTimeVarying.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/system/RungeKuttaTimeVarying.java
@@ -23,7 +23,6 @@ public final class RungeKuttaTimeVarying {
    * @param y The initial value of y.
    * @param dtSeconds The time over which to integrate.
    */
-  @SuppressWarnings("MethodTypeParameterName")
   public static <Rows extends Num, Cols extends Num> Matrix<Rows, Cols> rungeKuttaTimeVarying(
       BiFunction<Double, Matrix<Rows, Cols>, Matrix<Rows, Cols>> f,
       double t,

--- a/wpimath/src/test/java/edu/wpi/first/math/trajectory/CentripetalAccelerationConstraintTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/trajectory/CentripetalAccelerationConstraintTest.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class CentripetalAccelerationConstraintTest {
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testCentripetalAccelerationConstraint() {
     double maxCentripetalAcceleration = Units.feetToMeters(7.0); // 7 feet per second squared

--- a/wpimath/src/test/java/edu/wpi/first/math/trajectory/DifferentialDriveKinematicsConstraintTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/trajectory/DifferentialDriveKinematicsConstraintTest.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class DifferentialDriveKinematicsConstraintTest {
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testDifferentialDriveKinematicsConstraint() {
     double maxVelocity = Units.feetToMeters(12.0); // 12 feet per second

--- a/wpimath/src/test/java/edu/wpi/first/math/trajectory/DifferentialDriveVoltageConstraintTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/trajectory/DifferentialDriveVoltageConstraintTest.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class DifferentialDriveVoltageConstraintTest {
-  @SuppressWarnings("LocalVariableName")
   @Test
   void testDifferentialDriveVoltageConstraint() {
     // Pick an unreasonably large kA to ensure the constraint has to do some work

--- a/wpimath/src/test/java/edu/wpi/first/math/trajectory/TrajectoryGeneratorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/trajectory/TrajectoryGeneratorTest.java
@@ -50,7 +50,6 @@ class TrajectoryGeneratorTest {
   }
 
   @Test
-  @SuppressWarnings("LocalVariableName")
   void testGenerationAndConstraints() {
     Trajectory trajectory = getTrajectory(new ArrayList<>());
 

--- a/wpiutil/src/main/java/edu/wpi/first/util/CombinedRuntimeLoader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/CombinedRuntimeLoader.java
@@ -56,7 +56,7 @@ public final class CombinedRuntimeLoader {
    * @return List of all libraries that were extracted
    * @throws IOException Thrown if resource not found or file could not be extracted
    */
-  @SuppressWarnings({"PMD.UnnecessaryCastRule", "unchecked"})
+  @SuppressWarnings("unchecked")
   public static <T> List<String> extractLibraries(Class<T> clazz, String resourceName)
       throws IOException {
     TypeReference<HashMap<String, Object>> typeRef =

--- a/wpiutil/src/main/java/edu/wpi/first/util/RuntimeLoader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/RuntimeLoader.java
@@ -80,7 +80,6 @@ public final class RuntimeLoader<T> {
    *
    * @throws IOException if the library fails to load
    */
-  @SuppressWarnings("PMD.PreserveStackTrace")
   public void loadLibrary() throws IOException {
     try {
       // First, try loading path
@@ -132,7 +131,6 @@ public final class RuntimeLoader<T> {
    *
    * @throws IOException if the library failed to load
    */
-  @SuppressWarnings({"PMD.PreserveStackTrace", "PMD.EmptyWhileStmt"})
   public void loadLibraryHashed() throws IOException {
     try {
       // First, try loading path

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/DataLog.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/DataLog.java
@@ -22,7 +22,6 @@ package edu.wpi.first.util.datalog;
  * For this reason (as well as the fact that timestamps can be set to arbitrary values), records in
  * the log are not guaranteed to be sorted by timestamp.
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.ExcessivePublicCount"})
 public final class DataLog implements AutoCloseable {
   /**
    * Construct a new Data Log. The log will be initially created with a temporary filename.

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/DataLogReader.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/DataLogReader.java
@@ -114,7 +114,6 @@ public class DataLogReader implements Iterable<DataLogRecord> {
     return val;
   }
 
-  @SuppressWarnings("PMD.PreserveStackTrace")
   DataLogRecord getRecord(int pos) {
     try {
       int lenbyte = m_buf.get(pos) & 0xff;

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/DataLogRecord.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/DataLogRecord.java
@@ -17,7 +17,6 @@ import java.util.InputMismatchException;
  * A record in the data log. May represent either a control record (entry == 0) or a data record.
  * Used only for reading (e.g. with DataLogReader).
  */
-@SuppressWarnings("PMD.PreserveStackTrace")
 public class DataLogRecord {
   private static final int kControlStart = 0;
   private static final int kControlFinish = 1;
@@ -125,6 +124,7 @@ public class DataLogRecord {
    * Data contained in a start control record as created by DataLog.start() when writing the log.
    * This can be read by calling getStartData().
    */
+  @SuppressWarnings("MemberName")
   public static class StartRecordData {
     StartRecordData(int entry, String name, String type, String metadata) {
       this.entry = entry;
@@ -134,19 +134,15 @@ public class DataLogRecord {
     }
 
     /** Entry ID; this will be used for this entry in future records. */
-    @SuppressWarnings("MemberName")
     public final int entry;
 
     /** Entry name. */
-    @SuppressWarnings("MemberName")
     public final String name;
 
     /** Type of the stored data for this entry, as a string, e.g. "double". */
-    @SuppressWarnings("MemberName")
     public final String type;
 
     /** Initial metadata. */
-    @SuppressWarnings("MemberName")
     public final String metadata;
   }
 
@@ -173,6 +169,7 @@ public class DataLogRecord {
    * Data contained in a set metadata control record as created by DataLog.setMetadata(). This can
    * be read by calling getSetMetadataData().
    */
+  @SuppressWarnings("MemberName")
   public static class MetadataRecordData {
     MetadataRecordData(int entry, String metadata) {
       this.entry = entry;
@@ -180,11 +177,9 @@ public class DataLogRecord {
     }
 
     /** Entry ID. */
-    @SuppressWarnings("MemberName")
     public final int entry;
 
     /** New metadata for the entry. */
-    @SuppressWarnings("MemberName")
     public final String metadata;
   }
 

--- a/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableRegistry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableRegistry.java
@@ -425,29 +425,24 @@ public final class SendableRegistry {
   }
 
   /** Data passed to foreachLiveWindow() callback function. */
+  @SuppressWarnings("MemberName")
   public static class CallbackData {
     /** Sendable object. */
-    @SuppressWarnings("MemberName")
     public Sendable sendable;
 
     /** Name. */
-    @SuppressWarnings("MemberName")
     public String name;
 
     /** Subsystem. */
-    @SuppressWarnings("MemberName")
     public String subsystem;
 
     /** Parent sendable object. */
-    @SuppressWarnings("MemberName")
     public Sendable parent;
 
     /** Data stored in object with setData(). Update this to change the data. */
-    @SuppressWarnings("MemberName")
     public Object data;
 
     /** Sendable builder for the sendable. */
-    @SuppressWarnings("MemberName")
     public SendableBuilder builder;
   }
 
@@ -462,7 +457,6 @@ public final class SendableRegistry {
    * @param dataHandle data handle to get data object passed to callback
    * @param callback function to call for each object
    */
-  @SuppressWarnings({"PMD.AvoidCatchingThrowable", "PMD.AvoidReassigningCatchVariables"})
   public static synchronized void foreachLiveWindow(
       int dataHandle, Consumer<CallbackData> callback) {
     CallbackData cbdata = new CallbackData();


### PR DESCRIPTION
Checkstyle naming conventions were changed to allow most of what's in wpimath. Naming rules were disabled completely in wpimath since almost all suppressions are for math notation.