### PR TITLE
Fixed Color FromHSV

### DIFF
--- a/wpilibc/src/main/native/include/frc/util/Color.h
+++ b/wpilibc/src/main/native/include/frc/util/Color.h
@@ -773,18 +773,23 @@ class Color {
   static constexpr Color FromHSV(int h, int s, int v) {
     // Loosely based on
     // https://en.wikipedia.org/wiki/HSL_and_HSV#HSV_to_RGB
+    // The hue range is split into 60 degree regions where in each region there
+    // is one rgb component at a low value (m), one at a high value (v) and one
+    // that changes (X) from low to high (X+m) or high to low (v-X)
 
+    // Difference between highest and lowest value of any rgb component
     int chroma = (s * v) >> 8;
+
+    // Beacuse hue is 0-180 rather than 0-360 use 30 not 60
     int region = h / 30;
 
-    // remainder converted from 0-30 to roughly 0-255
+    // Remainder converted from 0-30 to roughly 0-255
     int remainder = (h - (region * 30)) * 9;
 
-    // lowest value of r, g or b
+    // Value of the lowest rgb component
     int m = v - chroma;
 
-    // part in each region that changes
-    // goes from 0 to chroma
+    // Goes from 0 to chroma as hue increases
     int X = (chroma * remainder) >> 8;
 
     switch (region) {

--- a/wpilibc/src/main/native/include/frc/util/Color.h
+++ b/wpilibc/src/main/native/include/frc/util/Color.h
@@ -751,7 +751,7 @@ class Color {
       : red(roundAndClamp(r)),
         green(roundAndClamp(g)),
         blue(roundAndClamp(b)) {}
-  
+
   /**
    * Constructs a Color from ints (0-255).
    *
@@ -765,38 +765,41 @@ class Color {
   /**
    * Creates a Color from HSV values.
    *
-   * @param h The h value [0-180]
+   * @param h The h value [0-180)
    * @param s The s value [0-255]
    * @param v The v value [0-255]
    * @return The color
    */
   static constexpr Color FromHSV(int h, int s, int v) {
-    // loosly based on
+    // Loosely based on
     // https://en.wikipedia.org/wiki/HSL_and_HSV#HSV_to_RGB
 
     int chroma = (s * v) >> 8;
     int region = h / 30;
+
     // remainder converted from 0-30 to roughly 0-255
-    int remainder = (h - (region * 30)) * 8;
+    int remainder = (h - (region * 30)) * 9;
+
     // lowest value of r, g or b
     int m = v - chroma;
+
     // part in each region that changes
     // goes from 0 to chroma
     int X = (chroma * remainder) >> 8;
 
     switch (region) {
       case 0:
-        return Color(v, X+m, m);
+        return Color(v, X + m, m);
       case 1:
-        return Color(v-X, v, m);
+        return Color(v - X, v, m);
       case 2:
-        return Color(m, v, X+m);
+        return Color(m, v, X + m);
       case 3:
-        return Color(m, v-X, v);
+        return Color(m, v - X, v);
       case 4:
-        return Color(X+m, m, v);
+        return Color(X + m, m, v);
       default:
-        return Color(v, m, v-X);
+        return Color(v, m, v - X);
     }
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
@@ -36,9 +36,9 @@ public class Color {
   /**
    * Constructs a Color from ints.
    *
-   * @param red Red value (0-1)
-   * @param green Green value (0-1)
-   * @param blue Blue value (0-1)
+   * @param red Red value (0-255)
+   * @param green Green value (0-255)
+   * @param blue Blue value (0-255)
    */
   public Color(int red, int green, int blue) {
     this(red / 255.0, green / 255.0, blue / 255.0);
@@ -56,38 +56,41 @@ public class Color {
   /**
    * Creates a Color from HSV values.
    *
-   * @param h The h value [0-180]
+   * @param h The h value [0-180)
    * @param s The s value [0-255]
    * @param v The v value [0-255]
    * @return The color
    */
   public static Color fromHSV(int h, int s, int v) {
-    // loosly based on
+    // Loosely based on
     // https://en.wikipedia.org/wiki/HSL_and_HSV#HSV_to_RGB
 
     final int chroma = (s * v) >> 8;
     final int region = h / 30;
+
     // remainder converted from 0-30 to roughly 0-255
-    final int remainder = (h - (region * 30)) * 8;
+    final int remainder = (h - (region * 30)) * 9;
+
     // lowest value of r, g or b
     final int m = v - chroma;
-    // part in each region that changes
+
+    // color component in each region that changes
     // goes from 0 to chroma
     final int X = (chroma * remainder) >> 8;
 
     switch (region) {
       case 0:
-        return new Color(v, X+m, m);
+        return new Color(v, X + m, m);
       case 1:
-        return new Color(v-X, v, m);
+        return new Color(v - X, v, m);
       case 2:
-        return new Color(m, v, X+m);
+        return new Color(m, v, X + m);
       case 3:
-        return new Color(m, v-X, v);
+        return new Color(m, v - X, v);
       case 4:
-        return new Color(X+m, m, v);
+        return new Color(X + m, m, v);
       default:
-        return new Color(v, m, v-X);
+        return new Color(v, m, v - X);
     }
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
@@ -64,18 +64,23 @@ public class Color {
   public static Color fromHSV(int h, int s, int v) {
     // Loosely based on
     // https://en.wikipedia.org/wiki/HSL_and_HSV#HSV_to_RGB
+    // The hue range is split into 60 degree regions where in each region there
+    // is one rgb component at a low value (m), one at a high value (v) and one
+    // that changes (X) from low to high (X+m) or high to low (v-X)
 
+    // Difference between highest and lowest value of any rgb component
     final int chroma = (s * v) >> 8;
+
+    // Beacuse hue is 0-180 rather than 0-360 use 30 not 60
     final int region = h / 30;
 
-    // remainder converted from 0-30 to roughly 0-255
+    // Remainder converted from 0-30 to roughly 0-255
     final int remainder = (h - (region * 30)) * 9;
 
-    // lowest value of r, g or b
+    // Value of the lowest rgb component
     final int m = v - chroma;
 
-    // color component in each region that changes
-    // goes from 0 to chroma
+    // Goes from 0 to chroma as hue increases
     final int X = (chroma * remainder) >> 8;
 
     switch (region) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
@@ -21,7 +21,7 @@ public class Color {
   public final double blue;
 
   /**
-   * Constructs a Color.
+   * Constructs a Color from doubles.
    *
    * @param red Red value (0-1)
    * @param green Green value (0-1)
@@ -31,6 +31,17 @@ public class Color {
     this.red = roundAndClamp(red);
     this.green = roundAndClamp(green);
     this.blue = roundAndClamp(blue);
+  }
+
+  /**
+   * Constructs a Color from ints.
+   *
+   * @param red Red value (0-1)
+   * @param green Green value (0-1)
+   * @param blue Blue value (0-1)
+   */
+  public Color(int red, int green, int blue) {
+    this(red / 255.0, green / 255.0, blue / 255.0);
   }
 
   /**
@@ -51,30 +62,32 @@ public class Color {
    * @return The color
    */
   public static Color fromHSV(int h, int s, int v) {
-    if (s == 0) {
-      return new Color(v / 255.0, v / 255.0, v / 255.0);
-    }
+    // loosly based on
+    // https://en.wikipedia.org/wiki/HSL_and_HSV#HSV_to_RGB
 
+    final int chroma = (s * v) >> 8;
     final int region = h / 30;
-    final int remainder = (h - (region * 30)) * 6;
-
-    final int p = (v * (255 - s)) >> 8;
-    final int q = (v * (255 - ((s * remainder) >> 8))) >> 8;
-    final int t = (v * (255 - ((s * (255 - remainder)) >> 8))) >> 8;
+    // remainder converted from 0-30 to roughly 0-255
+    final int remainder = (h - (region * 30)) * 8;
+    // lowest value of r, g or b
+    final int m = v - chroma;
+    // part in each region that changes
+    // goes from 0 to chroma
+    final int X = (chroma * remainder) >> 8;
 
     switch (region) {
       case 0:
-        return new Color(v / 255.0, t / 255.0, p / 255.0);
+        return new Color(v, X+m, m);
       case 1:
-        return new Color(q / 255.0, v / 255.0, p / 255.0);
+        return new Color(v-X, v, m);
       case 2:
-        return new Color(p / 255.0, v / 255.0, t / 255.0);
+        return new Color(m, v, X+m);
       case 3:
-        return new Color(p / 255.0, q / 255.0, v / 255.0);
+        return new Color(m, v-X, v);
       case 4:
-        return new Color(t / 255.0, p / 255.0, v / 255.0);
+        return new Color(X+m, m, v);
       default:
-        return new Color(v / 255.0, p / 255.0, q / 255.0);
+        return new Color(v, m, v-X);
     }
   }
 


### PR DESCRIPTION
the current Color.FromHSV method is not accurate and produces disjointed colours, this causes noticeable jumps in colour on real led's
I rewrote the function using the method on this [wikipedia page](https://en.wikipedia.org/wiki/HSL_and_HSV#HSV_to_RGB) with some changes to work with ints

top: actual hsv
middle: current wpilib hsv
bottom: new hsv
![image](https://user-images.githubusercontent.com/34265013/192914626-f0b963a7-7cfa-44b3-b332-d28048830c57.png)