### PR TITLE
[wpinet] uv::Async: Add UnsafeSend()

### DIFF
--- a/wpinet/src/main/native/include/wpinet/uv/Async.h
+++ b/wpinet/src/main/native/include/wpinet/uv/Async.h
@@ -111,9 +111,7 @@ class Async final : public HandleImpl<Async<T...>, uv_async_t> {
    * It’s safe to call this function from any thread.
    * An async event will be emitted on the loop thread.
    */
-  void UnsafeSend() {
-    Invoke(&uv_async_send, this->GetRaw());
-  }
+  void UnsafeSend() { Invoke(&uv_async_send, this->GetRaw()); }
 
   /**
    * Signal generated (on event loop thread) when the async event occurs.
@@ -179,9 +177,7 @@ class Async<> final : public HandleImpl<Async<>, uv_async_t> {
    * It’s safe to call this function from any thread.
    * An async event will be emitted on the loop thread.
    */
-  void UnsafeSend() {
-    Invoke(&uv_async_send, GetRaw());
-  }
+  void UnsafeSend() { Invoke(&uv_async_send, GetRaw()); }
 
   /**
    * Signal generated (on event loop thread) when the async event occurs.

--- a/wpinet/src/main/native/include/wpinet/uv/Async.h
+++ b/wpinet/src/main/native/include/wpinet/uv/Async.h
@@ -105,6 +105,17 @@ class Async final : public HandleImpl<Async<T...>, uv_async_t> {
   }
 
   /**
+   * Wakeup the event loop and emit the event.
+   * This function assumes the loop still exists, which makes it a bit faster.
+   *
+   * It’s safe to call this function from any thread.
+   * An async event will be emitted on the loop thread.
+   */
+  void UnsafeSend() {
+    Invoke(&uv_async_send, this->GetRaw());
+  }
+
+  /**
    * Signal generated (on event loop thread) when the async event occurs.
    */
   sig::Signal<T...> wakeup;
@@ -159,6 +170,17 @@ class Async<> final : public HandleImpl<Async<>, uv_async_t> {
         Invoke(&uv_async_send, GetRaw());
       }
     }
+  }
+
+  /**
+   * Wakeup the event loop and emit the event.
+   * This function assumes the loop still exists, which makes it a bit faster.
+   *
+   * It’s safe to call this function from any thread.
+   * An async event will be emitted on the loop thread.
+   */
+  void UnsafeSend() {
+    Invoke(&uv_async_send, GetRaw());
   }
 
   /**


### PR DESCRIPTION
This version assumes the loop still exists, avoiding some overhead.