### PR TITLE
[commands] Refactor lambda-based commands to inherit FunctionalCommand

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/InstantCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/InstantCommand.java
@@ -4,8 +4,6 @@
 
 package edu.wpi.first.wpilibj2.command;
 
-import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
-
 /**
  * A Command that runs instantly; it will initialize, execute once, and end on the same iteration of
  * the scheduler. Users can either pass in a Runnable and a set of requirements, or else subclass
@@ -13,9 +11,7 @@ import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
  *
  * <p>This class is provided by the NewCommands VendorDep
  */
-public class InstantCommand extends CommandBase {
-  private final Runnable m_toRun;
-
+public class InstantCommand extends FunctionalCommand {
   /**
    * Creates a new InstantCommand that runs the given Runnable with the given requirements.
    *
@@ -23,9 +19,7 @@ public class InstantCommand extends CommandBase {
    * @param requirements the subsystems required by this command
    */
   public InstantCommand(Runnable toRun, Subsystem... requirements) {
-    m_toRun = requireNonNullParam(toRun, "toRun", "InstantCommand");
-
-    addRequirements(requirements);
+    super(toRun, () -> {}, interrupted -> {}, () -> true, requirements);
   }
 
   /**
@@ -33,16 +27,6 @@ public class InstantCommand extends CommandBase {
    * constructor to call implicitly from subclass constructors.
    */
   public InstantCommand() {
-    m_toRun = () -> {};
-  }
-
-  @Override
-  public void initialize() {
-    m_toRun.run();
-  }
-
-  @Override
-  public final boolean isFinished() {
-    return true;
+    this(() -> {});
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RunCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RunCommand.java
@@ -4,8 +4,6 @@
 
 package edu.wpi.first.wpilibj2.command;
 
-import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
-
 import java.util.function.BooleanSupplier;
 
 /**
@@ -15,9 +13,7 @@ import java.util.function.BooleanSupplier;
  *
  * <p>This class is provided by the NewCommands VendorDep
  */
-public class RunCommand extends CommandBase {
-  protected final Runnable m_toRun;
-
+public class RunCommand extends FunctionalCommand {
   /**
    * Creates a new RunCommand. The Runnable will be run continuously until the command ends. Does
    * not run when disabled.
@@ -26,12 +22,6 @@ public class RunCommand extends CommandBase {
    * @param requirements the subsystems to require
    */
   public RunCommand(Runnable toRun, Subsystem... requirements) {
-    m_toRun = requireNonNullParam(toRun, "toRun", "RunCommand");
-    addRequirements(requirements);
-  }
-
-  @Override
-  public void execute() {
-    m_toRun.run();
+    super(() -> {}, toRun, interrupted -> {}, () -> false, requirements);
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/StartEndCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/StartEndCommand.java
@@ -6,6 +6,8 @@ package edu.wpi.first.wpilibj2.command;
 
 import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
 
+import java.util.function.Consumer;
+
 /**
  * A command that runs a given runnable when it is initialized, and another runnable when it ends.
  * Useful for running and then stopping a motor, or extending and then retracting a solenoid. Has no
@@ -14,10 +16,7 @@ import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
  *
  * <p>This class is provided by the NewCommands VendorDep
  */
-public class StartEndCommand extends CommandBase {
-  protected final Runnable m_onInit;
-  protected final Runnable m_onEnd;
-
+public class StartEndCommand extends FunctionalCommand {
   /**
    * Creates a new StartEndCommand. Will run the given runnables when the command starts and when it
    * ends.
@@ -27,19 +26,16 @@ public class StartEndCommand extends CommandBase {
    * @param requirements the subsystems required by this command
    */
   public StartEndCommand(Runnable onInit, Runnable onEnd, Subsystem... requirements) {
-    m_onInit = requireNonNullParam(onInit, "onInit", "StartEndCommand");
-    m_onEnd = requireNonNullParam(onEnd, "onEnd", "StartEndCommand");
-
-    addRequirements(requirements);
+    super(
+        onInit,
+        () -> {},
+        // we need to do some magic here to null-check `onEnd` before it's captured
+        droppingParameter(requireNonNullParam(onEnd, "onEnd", "StartEndCommand")),
+        () -> false,
+        requirements);
   }
 
-  @Override
-  public void initialize() {
-    m_onInit.run();
-  }
-
-  @Override
-  public void end(boolean interrupted) {
-    m_onEnd.run();
+  private static Consumer<Boolean> droppingParameter(Runnable run) {
+    return bool -> run.run();
   }
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/InstantCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/InstantCommand.cpp
@@ -8,22 +8,14 @@ using namespace frc2;
 
 InstantCommand::InstantCommand(std::function<void()> toRun,
                                std::initializer_list<Subsystem*> requirements)
-    : m_toRun{std::move(toRun)} {
-  AddRequirements(requirements);
-}
+    : CommandHelper(
+          std::move(toRun), [] {}, [](bool interrupted) {}, [] { return true; },
+          requirements) {}
 
 InstantCommand::InstantCommand(std::function<void()> toRun,
                                wpi::span<Subsystem* const> requirements)
-    : m_toRun{std::move(toRun)} {
-  AddRequirements(requirements);
-}
+    : CommandHelper(
+          std::move(toRun), [] {}, [](bool interrupted) {}, [] { return true; },
+          requirements) {}
 
-InstantCommand::InstantCommand() : m_toRun{[] {}} {}
-
-void InstantCommand::Initialize() {
-  m_toRun();
-}
-
-bool InstantCommand::IsFinished() {
-  return true;
-}
+InstantCommand::InstantCommand() : InstantCommand([] {}) {}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/RunCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/RunCommand.cpp
@@ -8,16 +8,10 @@ using namespace frc2;
 
 RunCommand::RunCommand(std::function<void()> toRun,
                        std::initializer_list<Subsystem*> requirements)
-    : m_toRun{std::move(toRun)} {
-  AddRequirements(requirements);
-}
+    : CommandHelper([] {}, std::move(toRun), [](bool interrupted) {},
+                    [] { return false; }, requirements) {}
 
 RunCommand::RunCommand(std::function<void()> toRun,
                        wpi::span<Subsystem* const> requirements)
-    : m_toRun{std::move(toRun)} {
-  AddRequirements(requirements);
-}
-
-void RunCommand::Execute() {
-  m_toRun();
-}
+    : CommandHelper([] {}, std::move(toRun), [](bool interrupted) {},
+                    [] { return false; }, requirements) {}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/StartEndCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/StartEndCommand.cpp
@@ -9,27 +9,15 @@ using namespace frc2;
 StartEndCommand::StartEndCommand(std::function<void()> onInit,
                                  std::function<void()> onEnd,
                                  std::initializer_list<Subsystem*> requirements)
-    : m_onInit{std::move(onInit)}, m_onEnd{std::move(onEnd)} {
-  AddRequirements(requirements);
-}
+    : CommandHelper(
+          std::move(onInit), [] {},
+          [onEnd = std::move(onEnd)](bool interrupted) { onEnd(); },
+          [] { return false; }, requirements) {}
 
 StartEndCommand::StartEndCommand(std::function<void()> onInit,
                                  std::function<void()> onEnd,
                                  wpi::span<Subsystem* const> requirements)
-    : m_onInit{std::move(onInit)}, m_onEnd{std::move(onEnd)} {
-  AddRequirements(requirements);
-}
-
-StartEndCommand::StartEndCommand(const StartEndCommand& other)
-    : CommandHelper(other) {
-  m_onInit = other.m_onInit;
-  m_onEnd = other.m_onEnd;
-}
-
-void StartEndCommand::Initialize() {
-  m_onInit();
-}
-
-void StartEndCommand::End(bool interrupted) {
-  m_onEnd();
-}
+    : CommandHelper(
+          std::move(onInit), [] {},
+          [onEnd = std::move(onEnd)](bool interrupted) { onEnd(); },
+          [] { return false; }, requirements) {}

--- a/wpilibNewCommands/src/main/native/include/frc2/command/InstantCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/InstantCommand.h
@@ -9,8 +9,8 @@
 
 #include <wpi/span.h>
 
-#include "frc2/command/CommandBase.h"
 #include "frc2/command/CommandHelper.h"
+#include "frc2/command/FunctionalCommand.h"
 
 namespace frc2 {
 /**
@@ -20,7 +20,7 @@ namespace frc2 {
  *
  * This class is provided by the NewCommands VendorDep
  */
-class InstantCommand : public CommandHelper<CommandBase, InstantCommand> {
+class InstantCommand : public CommandHelper<FunctionalCommand, InstantCommand> {
  public:
   /**
    * Creates a new InstantCommand that runs the given Runnable with the given
@@ -51,12 +51,5 @@ class InstantCommand : public CommandHelper<CommandBase, InstantCommand> {
    * only as a no-arg constructor to call implicitly from subclass constructors.
    */
   InstantCommand();
-
-  void Initialize() override;
-
-  bool IsFinished() final;
-
- private:
-  std::function<void()> m_toRun;
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/RunCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/RunCommand.h
@@ -9,8 +9,8 @@
 
 #include <wpi/span.h>
 
-#include "frc2/command/CommandBase.h"
 #include "frc2/command/CommandHelper.h"
+#include "frc2/command/FunctionalCommand.h"
 
 namespace frc2 {
 /**
@@ -21,7 +21,7 @@ namespace frc2 {
  *
  * This class is provided by the NewCommands VendorDep
  */
-class RunCommand : public CommandHelper<CommandBase, RunCommand> {
+class RunCommand : public CommandHelper<FunctionalCommand, RunCommand> {
  public:
   /**
    * Creates a new RunCommand.  The Runnable will be run continuously until the
@@ -46,10 +46,5 @@ class RunCommand : public CommandHelper<CommandBase, RunCommand> {
   RunCommand(RunCommand&& other) = default;
 
   RunCommand(const RunCommand& other) = default;
-
-  void Execute() override;
-
- protected:
-  std::function<void()> m_toRun;
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/StartEndCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/StartEndCommand.h
@@ -9,8 +9,8 @@
 
 #include <wpi/span.h>
 
-#include "frc2/command/CommandBase.h"
 #include "frc2/command/CommandHelper.h"
+#include "frc2/command/FunctionalCommand.h"
 
 namespace frc2 {
 /**
@@ -22,7 +22,8 @@ namespace frc2 {
  *
  * This class is provided by the NewCommands VendorDep
  */
-class StartEndCommand : public CommandHelper<CommandBase, StartEndCommand> {
+class StartEndCommand
+    : public CommandHelper<FunctionalCommand, StartEndCommand> {
  public:
   /**
    * Creates a new StartEndCommand.  Will run the given runnables when the
@@ -48,14 +49,6 @@ class StartEndCommand : public CommandHelper<CommandBase, StartEndCommand> {
 
   StartEndCommand(StartEndCommand&& other) = default;
 
-  StartEndCommand(const StartEndCommand& other);
-
-  void Initialize() override;
-
-  void End(bool interrupted) override;
-
- protected:
-  std::function<void()> m_onInit;
-  std::function<void()> m_onEnd;
+  StartEndCommand(const StartEndCommand& other) = default;
 };
 }  // namespace frc2


### PR DESCRIPTION
InstantCommand, StartEndCommand, and RunCommand are all practically FunctionalCommand with differently defaulted arguments. This makes that explicit, reducing code duplication..

Tests should prove no behavior changed.