### PR TITLE
Fixed opencv version mismatch causing errors while running simulation

### DIFF
--- a/shared/opencv.gradle
+++ b/shared/opencv.gradle
@@ -1,4 +1,4 @@
-def opencvVersion = '4.5.2-1'
+def opencvVersion = '4.5.5-3'
 
 if (project.hasProperty('useCpp') && project.useCpp) {
     model {
@@ -22,12 +22,12 @@ if (project.hasProperty('useCpp') && project.useCpp) {
 
 if (project.hasProperty('useJava') && project.useJava) {
     dependencies {
-        implementation "edu.wpi.first.thirdparty.frc2022.opencv:opencv-java:${opencvVersion}"
+        implementation "edu.wpi.first.thirdparty.frc2023.opencv:opencv-java:${opencvVersion}"
         if (!project.hasProperty('skipDev') || !project.skipDev) {
-            devImplementation "edu.wpi.first.thirdparty.frc2022.opencv:opencv-java:${opencvVersion}"
+            devImplementation "edu.wpi.first.thirdparty.frc2023.opencv:opencv-java:${opencvVersion}"
         }
         if (project.hasProperty('useDocumentation') && project.useDocumentation) {
-            javaSource "edu.wpi.first.thirdparty.frc2022.opencv:opencv-java:${opencvVersion}:sources"
+            javaSource "edu.wpi.first.thirdparty.frc2023.opencv:opencv-java:${opencvVersion}:sources"
         }
     }
 }


### PR DESCRIPTION
I'm currently seeing these errors when running simulated code on a local build of HEAD:

```
led-test\build\jni\release\cscorejni.dll: Can't find dependent libraries
A common cause of this error is missing the C++ runtime.
Download the latest at https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads

        at edu.wpi.first.util.RuntimeLoader.loadLibrary(RuntimeLoader.java:93)
        at edu.wpi.first.cscore.CameraServerJNI.<clinit>(CameraServerJNI.java:37)
        at edu.wpi.first.wpilibj.RobotBase.startRobot(RobotBase.java:390)
        at frc.robot.Main.main(Main.java:23)

```

When I inspected the dll to see what dependencies it was using it showed a different version of opencv than what was used in the `jni/release` folder:

<img width="812" alt="wrong-opencsv-version" src="https://user-images.githubusercontent.com/6786620/193467691-147e1d71-1d5c-4c29-aaae-9727969ff2b8.png">

I believe the issue is caused by the mismatch here:
https://github.com/wpilibsuite/allwpilib/blob/main/shared/opencv.gradle#L1
https://github.com/wpilibsuite/allwpilib/blob/main/shared/config.gradle#L18

However, updating this did not change the dlls produced in later builds. I can't yet confirm if this fixes the issue, or if there's some additional change I need to make.