### PR TITLE
Create getters for position & velocity tolerances in PIDController

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/PIDController.java
@@ -175,6 +175,24 @@ public class PIDController implements Sendable, AutoCloseable {
   }
 
   /**
+   * Returns the position tolerance of this controller.
+   *
+   * @return the position tolerance of the controller.
+   */
+  public double getPositionTolerance() {
+    return m_positionTolerance;
+  }
+
+  /**
+   * Returns the velocity tolerance of this controller.
+   *
+   * @return the velocity tolerance of the controller.
+   */
+  public double getVelocityTolerance() {
+    return m_velocityTolerance;
+  }
+
+  /**
    * Sets the setpoint for the PIDController.
    *
    * @param setpoint The desired setpoint.

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/ProfiledPIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/ProfiledPIDController.java
@@ -269,6 +269,24 @@ public class ProfiledPIDController implements Sendable {
   }
 
   /**
+   * Returns the position tolerance of this controller.
+   *
+   * @return the position tolerance of the controller.
+   */
+  public double getPositionTolerance() {
+    return m_controller.getPositionTolerance();
+  }
+
+  /**
+   * Returns the velocity tolerance of this controller.
+   *
+   * @return the velocity tolerance of the controller.
+   */
+  public double getVelocityTolerance() {
+    return m_controller.getVelocityTolerance();
+  }
+
+  /**
    * Returns the next output of the PID controller.
    *
    * @param measurement The current measurement of the process variable.

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/ProfiledPIDController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/ProfiledPIDController.java
@@ -132,6 +132,24 @@ public class ProfiledPIDController implements Sendable {
   }
 
   /**
+   * Returns the position tolerance of this controller.
+   *
+   * @return the position tolerance of the controller.
+   */
+  public double getPositionTolerance() {
+    return m_controller.getPositionTolerance();
+  }
+
+  /**
+   * Returns the velocity tolerance of this controller.
+   *
+   * @return the velocity tolerance of the controller.
+   */
+  public double getVelocityTolerance() {
+    return m_controller.getVelocityTolerance();
+  }
+
+  /**
    * Sets the goal for the ProfiledPIDController.
    *
    * @param goal The desired goal state.
@@ -266,24 +284,6 @@ public class ProfiledPIDController implements Sendable {
    */
   public double getVelocityError() {
     return m_controller.getVelocityError();
-  }
-
-  /**
-   * Returns the position tolerance of this controller.
-   *
-   * @return the position tolerance of the controller.
-   */
-  public double getPositionTolerance() {
-    return m_controller.getPositionTolerance();
-  }
-
-  /**
-   * Returns the velocity tolerance of this controller.
-   *
-   * @return the velocity tolerance of the controller.
-   */
-  public double getVelocityTolerance() {
-    return m_controller.getVelocityTolerance();
   }
 
   /**

--- a/wpimath/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpimath/src/main/native/cpp/controller/PIDController.cpp
@@ -64,6 +64,14 @@ double PIDController::GetD() const {
   return m_Kd;
 }
 
+double PIDController::GetPositionTolerance() const {
+  return m_positionTolerance;
+}
+
+double PIDController::GetVelocityTolerance() const {
+  return m_velocityTolerance;
+}
+
 units::second_t PIDController::GetPeriod() const {
   return m_period;
 }

--- a/wpimath/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpimath/src/main/native/cpp/controller/PIDController.cpp
@@ -64,16 +64,16 @@ double PIDController::GetD() const {
   return m_Kd;
 }
 
+units::second_t PIDController::GetPeriod() const {
+  return m_period;
+}
+
 double PIDController::GetPositionTolerance() const {
   return m_positionTolerance;
 }
 
 double PIDController::GetVelocityTolerance() const {
   return m_velocityTolerance;
-}
-
-units::second_t PIDController::GetPeriod() const {
-  return m_period;
 }
 
 void PIDController::SetSetpoint(double setpoint) {

--- a/wpimath/src/main/native/include/frc/controller/PIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/PIDController.h
@@ -102,6 +102,20 @@ class WPILIB_DLLEXPORT PIDController
   units::second_t GetPeriod() const;
 
   /**
+   * Gets the position tolerance of this controller.
+   *
+   * @return The position tolerance of the controller.
+   */
+  double GetPositionTolerance() const;
+
+  /**
+   * Gets the velocity tolerance of this controller.
+   *
+   * @return The velocity tolerance of the controller.
+   */
+  double GetVelocityTolerance() const;
+
+  /**
    * Sets the setpoint for the PIDController.
    *
    * @param setpoint The desired setpoint.

--- a/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -136,14 +136,18 @@ class ProfiledPIDController
    *
    * @return The position tolerance of the controller.
    */
-  double GetPositionTolerance() const { return m_controller.GetPositionTolerance(); };
+  double GetPositionTolerance() const {
+    return m_controller.GetPositionTolerance();
+  }
 
   /**
    * Gets the velocity tolerance of this controller.
    *
    * @return The velocity tolerance of the controller.
    */
-  double GetVelocityTolerance() const { return m_controller.GetVelocityTolerance(); };
+  double GetVelocityTolerance() const {
+    return m_controller.GetVelocityTolerance();
+  }
 
   /**
    * Sets the goal for the ProfiledPIDController.

--- a/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -132,6 +132,20 @@ class ProfiledPIDController
   units::second_t GetPeriod() const { return m_controller.GetPeriod(); }
 
   /**
+   * Gets the position tolerance of this controller.
+   *
+   * @return The position tolerance of the controller.
+   */
+  double GetPositionTolerance() const { return m_controller.GetPositionTolerance(); };
+
+  /**
+   * Gets the velocity tolerance of this controller.
+   *
+   * @return The velocity tolerance of the controller.
+   */
+  double GetVelocityTolerance() const { return m_controller.GetVelocityTolerance(); };
+
+  /**
    * Sets the goal for the ProfiledPIDController.
    *
    * @param goal The desired unprofiled setpoint.


### PR DESCRIPTION
These were missing and we have a use for them. Also adds them to ProfiledPIDController by just returning the value from the inner controller.