### PR TITLE
[build] cmake: Fix libssh include directory order

### DIFF
--- a/datalogtool/CMakeLists.txt
+++ b/datalogtool/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 add_executable(datalogtool ${datalogtool_src} ${datalogtool_resources_src} ${datalogtool_rc} ${APP_ICON_MACOSX})
 wpilib_link_macos_gui(datalogtool)
 target_link_libraries(datalogtool libglass ${LIBSSH_LIBRARIES})
-target_include_directories(datalogtool PRIVATE ${LIBSSH_INCLUDE_DIRS})
+target_include_directories(datalogtool SYSTEM PRIVATE ${LIBSSH_INCLUDE_DIRS})
 
 if (WIN32)
     set_target_properties(datalogtool PROPERTIES WIN32_EXECUTABLE YES)

--- a/roborioteamnumbersetter/CMakeLists.txt
+++ b/roborioteamnumbersetter/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 add_executable(roborioteamnumbersetter ${rtns_src} ${rtns_resources_src} ${rtns_rc} ${APP_ICON_MACOSX})
 wpilib_link_macos_gui(roborioteamnumbersetter)
 target_link_libraries(roborioteamnumbersetter libglass wpinet ${LIBSSH_LIBRARIES})
-target_include_directories(roborioteamnumbersetter PRIVATE ${LIBSSH_INCLUDE_DIRS})
+target_include_directories(roborioteamnumbersetter SYSTEM PRIVATE ${LIBSSH_INCLUDE_DIRS})
 
 if (WIN32)
     set_target_properties(roborioteamnumbersetter PROPERTIES WIN32_EXECUTABLE YES)


### PR DESCRIPTION
This broke the build if the directory where libssh was installed also contained a system libuv install.