### PR TITLE
Convert DutyCycle Raw output to be a high time measurement

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/DutyCycleJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/DutyCycleJNI.java
@@ -13,7 +13,7 @@ public class DutyCycleJNI extends JNIWrapper {
 
   public static native double getOutput(int handle);
 
-  public static native int getOutputRaw(int handle);
+  public static native int getHighTime(int handle);
 
   public static native int getOutputScaleFactor(int handle);
 

--- a/hal/src/main/native/athena/AnalogTrigger.cpp
+++ b/hal/src/main/native/athena/AnalogTrigger.cpp
@@ -5,6 +5,7 @@
 #include "hal/AnalogTrigger.h"
 
 #include "AnalogInternal.h"
+#include "ConstantsInternal.h"
 #include "DutyCycleInternal.h"
 #include "HALInitializer.h"
 #include "HALInternal.h"
@@ -147,16 +148,10 @@ void HAL_SetAnalogTriggerLimitsDutyCycle(
     return;
   }
 
-  int32_t scaleFactor =
-      HAL_GetDutyCycleOutputScaleFactor(trigger->handle, status);
-  if (*status != 0) {
-    return;
-  }
-
-  trigger->trigger->writeLowerLimit(static_cast<int32_t>(scaleFactor * lower),
-                                    status);
-  trigger->trigger->writeUpperLimit(static_cast<int32_t>(scaleFactor * upper),
-                                    status);
+  trigger->trigger->writeLowerLimit(
+      static_cast<int32_t>(kDutyCycleScaleFactor * lower), status);
+  trigger->trigger->writeUpperLimit(
+      static_cast<int32_t>(kDutyCycleScaleFactor * upper), status);
 }
 
 void HAL_SetAnalogTriggerLimitsVoltage(

--- a/hal/src/main/native/athena/ConstantsInternal.h
+++ b/hal/src/main/native/athena/ConstantsInternal.h
@@ -9,5 +9,6 @@
 namespace hal {
 
 constexpr int32_t kSystemClockTicksPerMicrosecond = 40;
+constexpr int32_t kDutyCycleScaleFactor = 4e7 - 1;
 
 }  // namespace hal

--- a/hal/src/main/native/athena/DutyCycle.cpp
+++ b/hal/src/main/native/athena/DutyCycle.cpp
@@ -88,7 +88,7 @@ int32_t HAL_GetDutyCycleFrequency(HAL_DutyCycleHandle dutyCycleHandle,
 }
 
 double HAL_GetDutyCycleOutput(HAL_DutyCycleHandle dutyCycleHandle,
-                                   int32_t* status) {
+                              int32_t* status) {
   auto dutyCycle = dutyCycleHandles->Get(dutyCycleHandle);
   if (!dutyCycle) {
     *status = HAL_HANDLE_ERROR;

--- a/hal/src/main/native/cpp/jni/DutyCycleJNI.cpp
+++ b/hal/src/main/native/cpp/jni/DutyCycleJNI.cpp
@@ -74,15 +74,15 @@ Java_edu_wpi_first_hal_DutyCycleJNI_getOutput
 
 /*
  * Class:     edu_wpi_first_hal_DutyCycleJNI
- * Method:    getOutputRaw
+ * Method:    getHighTime
  * Signature: (I)I
  */
 JNIEXPORT jint JNICALL
-Java_edu_wpi_first_hal_DutyCycleJNI_getOutputRaw
+Java_edu_wpi_first_hal_DutyCycleJNI_getHighTime
   (JNIEnv* env, jclass, jint handle)
 {
   int32_t status = 0;
-  auto retVal = HAL_GetDutyCycleOutputRaw(
+  auto retVal = HAL_GetDutyCycleHighTime(
       static_cast<HAL_DutyCycleHandle>(handle), &status);
   CheckStatus(env, status);
   return retVal;

--- a/hal/src/main/native/include/hal/DutyCycle.h
+++ b/hal/src/main/native/include/hal/DutyCycle.h
@@ -68,27 +68,24 @@ int32_t HAL_GetDutyCycleFrequency(HAL_DutyCycleHandle dutyCycleHandle,
  * @return output ratio between 0 and 1
  */
 double HAL_GetDutyCycleOutput(HAL_DutyCycleHandle dutyCycleHandle,
-                              int32_t* status);
+                                   int32_t* status);
 
 /**
- * Get the raw output ratio of the duty cycle signal.
- *
- * <p> 0 means always low, an output equal to
- * GetOutputScaleFactor() means always high.
+ * Get the raw high time of the duty cycle signal.
  *
  * @param[in] dutyCycleHandle the duty cycle handle
  * @param[out] status Error status variable. 0 on success.
- * @return output ratio in raw units
+ * @return high time of last pulse in nanoseconds
  */
-int32_t HAL_GetDutyCycleOutputRaw(HAL_DutyCycleHandle dutyCycleHandle,
-                                  int32_t* status);
+int32_t HAL_GetDutyCycleHighTime(HAL_DutyCycleHandle dutyCycleHandle,
+                                 int32_t* status);
 
 /**
  * Get the scale factor of the output.
  *
  * <p> An output equal to this value is always high, and then linearly scales
- * down to 0. Divide the result of getOutputRaw by this in order to get the
- * percentage between 0 and 1.
+ * down to 0. Divide a raw result by this in order to get the
+ * percentage between 0 and 1. Used by DMA.
  *
  * @param[in] dutyCycleHandle the duty cycle handle
  * @param[out] status Error status variable. 0 on success.

--- a/hal/src/main/native/include/hal/DutyCycle.h
+++ b/hal/src/main/native/include/hal/DutyCycle.h
@@ -68,7 +68,7 @@ int32_t HAL_GetDutyCycleFrequency(HAL_DutyCycleHandle dutyCycleHandle,
  * @return output ratio between 0 and 1
  */
 double HAL_GetDutyCycleOutput(HAL_DutyCycleHandle dutyCycleHandle,
-                                   int32_t* status);
+                              int32_t* status);
 
 /**
  * Get the raw high time of the duty cycle signal.

--- a/hal/src/main/native/sim/DutyCycle.cpp
+++ b/hal/src/main/native/sim/DutyCycle.cpp
@@ -84,8 +84,9 @@ int32_t HAL_GetDutyCycleFrequency(HAL_DutyCycleHandle dutyCycleHandle,
   }
   return SimDutyCycleData[dutyCycle->index].frequency;
 }
+
 double HAL_GetDutyCycleOutput(HAL_DutyCycleHandle dutyCycleHandle,
-                              int32_t* status) {
+                                   int32_t* status) {
   auto dutyCycle = dutyCycleHandles->Get(dutyCycleHandle);
   if (dutyCycle == nullptr) {
     *status = HAL_HANDLE_ERROR;
@@ -93,20 +94,29 @@ double HAL_GetDutyCycleOutput(HAL_DutyCycleHandle dutyCycleHandle,
   }
   return SimDutyCycleData[dutyCycle->index].output;
 }
-int32_t HAL_GetDutyCycleOutputRaw(HAL_DutyCycleHandle dutyCycleHandle,
-                                  int32_t* status) {
+
+int32_t HAL_GetDutyCycleHighTime(HAL_DutyCycleHandle dutyCycleHandle,
+                                 int32_t* status) {
   auto dutyCycle = dutyCycleHandles->Get(dutyCycleHandle);
   if (dutyCycle == nullptr) {
     *status = HAL_HANDLE_ERROR;
     return 0;
   }
-  return SimDutyCycleData[dutyCycle->index].output *
-         HAL_GetDutyCycleOutputScaleFactor(dutyCycleHandle, status);
+
+  if (SimDutyCycleData[dutyCycle->index].frequency == 0) {
+    return 0;
+  }
+
+  double periodSeconds = 1.0 / SimDutyCycleData[dutyCycle->index].frequency;
+  double periodNanoSeconds = periodSeconds * 1e9;
+  return periodNanoSeconds * SimDutyCycleData[dutyCycle->index].output;
 }
+
 int32_t HAL_GetDutyCycleOutputScaleFactor(HAL_DutyCycleHandle dutyCycleHandle,
                                           int32_t* status) {
   return 4e7 - 1;
 }
+
 int32_t HAL_GetDutyCycleFPGAIndex(HAL_DutyCycleHandle dutyCycleHandle,
                                   int32_t* status) {
   auto dutyCycle = dutyCycleHandles->Get(dutyCycleHandle);

--- a/hal/src/main/native/sim/DutyCycle.cpp
+++ b/hal/src/main/native/sim/DutyCycle.cpp
@@ -86,7 +86,7 @@ int32_t HAL_GetDutyCycleFrequency(HAL_DutyCycleHandle dutyCycleHandle,
 }
 
 double HAL_GetDutyCycleOutput(HAL_DutyCycleHandle dutyCycleHandle,
-                                   int32_t* status) {
+                              int32_t* status) {
   auto dutyCycle = dutyCycleHandles->Get(dutyCycleHandle);
   if (dutyCycle == nullptr) {
     *status = HAL_HANDLE_ERROR;

--- a/wpilibc/src/main/native/cpp/DutyCycle.cpp
+++ b/wpilibc/src/main/native/cpp/DutyCycle.cpp
@@ -73,18 +73,11 @@ double DutyCycle::GetOutput() const {
   return retVal;
 }
 
-unsigned int DutyCycle::GetOutputRaw() const {
+units::second_t DutyCycle::GetHighTime() const {
   int32_t status = 0;
-  auto retVal = HAL_GetDutyCycleOutputRaw(m_handle, &status);
+  auto retVal = HAL_GetDutyCycleHighTime(m_handle, &status);
   FRC_CheckErrorStatus(status, "Channel {}", GetSourceChannel());
-  return retVal;
-}
-
-unsigned int DutyCycle::GetOutputScaleFactor() const {
-  int32_t status = 0;
-  auto retVal = HAL_GetDutyCycleOutputScaleFactor(m_handle, &status);
-  FRC_CheckErrorStatus(status, "Channel {}", GetSourceChannel());
-  return retVal;
+  return units::nanosecond_t{static_cast<double>(retVal)};
 }
 
 int DutyCycle::GetSourceChannel() const {

--- a/wpilibc/src/main/native/include/frc/DutyCycle.h
+++ b/wpilibc/src/main/native/include/frc/DutyCycle.h
@@ -7,9 +7,9 @@
 #include <memory>
 
 #include <hal/Types.h>
+#include <units/time.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
-#include <units/time.h>
 
 namespace frc {
 class DigitalSource;

--- a/wpilibc/src/main/native/include/frc/DutyCycle.h
+++ b/wpilibc/src/main/native/include/frc/DutyCycle.h
@@ -9,6 +9,7 @@
 #include <hal/Types.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
+#include <units/time.h>
 
 namespace frc {
 class DigitalSource;
@@ -83,21 +84,18 @@ class DutyCycle : public wpi::Sendable, public wpi::SendableHelper<DutyCycle> {
   double GetOutput() const;
 
   /**
-   * Get the raw output ratio of the duty cycle signal.
+   * Get the raw high time of the duty cycle signal.
    *
-   * <p> 0 means always low, an output equal to
-   * GetOutputScaleFactor() means always high.
-   *
-   * @return output ratio in raw units
+   * @return high time of last pulse
    */
-  unsigned int GetOutputRaw() const;
+  units::second_t GetHighTime() const;
 
   /**
    * Get the scale factor of the output.
    *
    * <p> An output equal to this value is always high, and then linearly scales
-   * down to 0. Divide the result of getOutputRaw by this in order to get the
-   * percentage between 0 and 1.
+   * down to 0. Divide a raw result by this in order to get the
+   * percentage between 0 and 1. Used by DMA.
    *
    * @return the output scale factor
    */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycle.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DutyCycle.java
@@ -73,21 +73,19 @@ public class DutyCycle implements Sendable, AutoCloseable {
   }
 
   /**
-   * Get the raw output ratio of the duty cycle signal.
+   * Get the raw high time of the duty cycle signal.
    *
-   * <p>0 means always low, an output equal to getOutputScaleFactor() means always high.
-   *
-   * @return output ratio in raw units
+   * @return high time of last pulse in nanoseconds
    */
-  public int getOutputRaw() {
-    return DutyCycleJNI.getOutputRaw(m_handle);
+  public int getHighTimeNanoseconds() {
+    return DutyCycleJNI.getHighTime(m_handle);
   }
 
   /**
    * Get the scale factor of the output.
    *
-   * <p>An output equal to this value is always high, and then linearly scales down to 0. Divide the
-   * result of getOutputRaw by this in order to get the percentage between 0 and 1.
+   * <p>An output equal to this value is always high, and then linearly scales down to 0. Divide a
+   * raw result by this in order to get the percentage between 0 and 1. Used by DMA.
    *
    * @return the output scale factor
    */


### PR DESCRIPTION
The existing raw time has an issue where it jumps around, as in the FPGA if the frequency is not a multiple or divisor of 25 Mhz it jumps around by 1 every second. While waiting on an FPGA change, update the API to make raw output give nanoseconds rather then a scaled value. This does a longer read cycle to get the correct value, but in the future if a fast FPGA function is added this can be easily changed.

Closes #4221 