### PR TITLE
[command] Replace Command HID inheritance with delegation

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandGenericHID.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandGenericHID.java
@@ -9,23 +9,29 @@ import edu.wpi.first.wpilibj.event.EventLoop;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 
 /**
- * A subclass of {@link GenericHID} with {@link Trigger} factories for command-based.
+ * A version of {@link GenericHID} with {@link Trigger} factories for command-based.
  *
  * @see GenericHID
  */
-public class CommandGenericHID extends GenericHID {
+public class CommandGenericHID {
+  private final GenericHID m_hid;
+
   /**
    * Construct an instance of a device.
    *
    * @param port The port index on the Driver Station that the device is plugged into.
    */
   public CommandGenericHID(int port) {
-    super(port);
+    m_hid = new GenericHID(port);
   }
 
-  @Override
-  public Trigger button(int button, EventLoop loop) {
-    return super.button(button, loop).castTo(Trigger::new);
+  /**
+   * Get the underlying GenericHID object.
+   *
+   * @return the wrapped GenericHID object
+   */
+  public GenericHID getHID() {
+    return m_hid;
   }
 
   /**
@@ -37,6 +43,157 @@ public class CommandGenericHID extends GenericHID {
    * @see #button(int, EventLoop)
    */
   public Trigger button(int button) {
-    return button(button, CommandScheduler.getInstance().getDefaultButtonLoop());
+    return this.button(button, CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs an event instance around this button's digital signal.
+   *
+   * @param button the button index
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the button's digital signal attached to the given loop.
+   */
+  public Trigger button(int button, EventLoop loop) {
+    return new Trigger(loop, () -> m_hid.getRawButton(button));
+  }
+
+  /**
+   * Constructs a Trigger instance based around this angle of the default (index 0) POV on the HID,
+   * attached to {@link CommandScheduler#getDefaultButtonLoop() the default command scheduler button
+   * loop}.
+   *
+   * <p>The POV angles start at 0 in the up direction, and increase clockwise (eg right is 90,
+   * upper-left is 315).
+   *
+   * @param angle POV angle in degrees, or -1 for the center / not pressed.
+   * @return a Trigger instance based around this angle of a POV on the HID.
+   */
+  public Trigger pov(int angle) {
+    return pov(0, angle, CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs a Trigger instance based around this angle of a POV on the HID.
+   *
+   * <p>The POV angles start at 0 in the up direction, and increase clockwise (eg right is 90,
+   * upper-left is 315).
+   *
+   * @param pov index of the POV to read (starting at 0). Defaults to 0.
+   * @param angle POV angle in degrees, or -1 for the center / not pressed.
+   * @param loop the event loop instance to attach the event to. Defaults to {@link
+   *     CommandScheduler#getDefaultButtonLoop() the default command scheduler button loop}.
+   * @return a Trigger instance based around this angle of a POV on the HID.
+   */
+  public Trigger pov(int pov, int angle, EventLoop loop) {
+    return new Trigger(loop, () -> m_hid.getPOV(pov) == angle);
+  }
+
+  /**
+   * Constructs a Trigger instance based around the 0-degree angle (up) of the default (index 0) POV
+   * on the HID, attached to {@link CommandScheduler#getDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   *
+   * @return a Trigger instance based around the 0-degree angle of a POV on the HID.
+   */
+  public Trigger povUp() {
+    return pov(0);
+  }
+
+  /**
+   * Constructs a Trigger instance based around the 45-degree angle (right up) of the default (index
+   * 0) POV on the HID, attached to {@link CommandScheduler#getDefaultButtonLoop() the default
+   * command scheduler button loop}.
+   *
+   * @return a Trigger instance based around the 45-degree angle of a POV on the HID.
+   */
+  public Trigger povUpRight() {
+    return pov(45);
+  }
+
+  /**
+   * Constructs a Trigger instance based around the 90-degree angle (right) of the default (index 0)
+   * POV on the HID, attached to {@link CommandScheduler#getDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   *
+   * @return a Trigger instance based around the 90-degree angle of a POV on the HID.
+   */
+  public Trigger povRight() {
+    return pov(90);
+  }
+
+  /**
+   * Constructs a Trigger instance based around the 135-degree angle (right down) of the default
+   * (index 0) POV on the HID, attached to {@link CommandScheduler#getDefaultButtonLoop() the
+   * default command scheduler button loop}.
+   *
+   * @return a Trigger instance based around the 135-degree angle of a POV on the HID.
+   */
+  public Trigger povDownRight() {
+    return pov(135);
+  }
+
+  /**
+   * Constructs a Trigger instance based around the 180-degree angle (down) of the default (index 0)
+   * POV on the HID, attached to {@link CommandScheduler#getDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   *
+   * @return a Trigger instance based around the 180-degree angle of a POV on the HID.
+   */
+  public Trigger povDown() {
+    return pov(180);
+  }
+
+  /**
+   * Constructs a Trigger instance based around the 45-degree angle (down left) of the default
+   * (index 0) POV on the HID, attached to {@link CommandScheduler#getDefaultButtonLoop() the
+   * default command scheduler button loop}.
+   *
+   * @return a Trigger instance based around the 225-degree angle of a POV on the HID.
+   */
+  public Trigger povDownLeft() {
+    return pov(225);
+  }
+
+  /**
+   * Constructs a Trigger instance based around the 270-degree angle (left) of the default (index 0)
+   * POV on the HID, attached to {@link CommandScheduler#getDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   *
+   * @return a Trigger instance based around the 270-degree angle of a POV on the HID.
+   */
+  public Trigger povLeft() {
+    return pov(270);
+  }
+
+  /**
+   * Constructs a Trigger instance based around the 315-degree angle (left up) of the default (index
+   * 0) POV on the HID, attached to {@link CommandScheduler#getDefaultButtonLoop() the default
+   * command scheduler button loop}.
+   *
+   * @return a Trigger instance based around the 315-degree angle of a POV on the HID.
+   */
+  public Trigger povUpLeft() {
+    return pov(315);
+  }
+
+  /**
+   * Constructs a Trigger instance based around the center (not pressed) of the default (index 0)
+   * POV on the HID, attached to {@link CommandScheduler#getDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   *
+   * @return a Trigger instance based around the center of a POV on the HID.
+   */
+  public Trigger povCenter() {
+    return pov(-1);
+  }
+
+  /**
+   * Get the value of the axis.
+   *
+   * @param axis The axis to read, starting at 0.
+   * @return The value of the axis.
+   */
+  public double getRawAxis(int axis) {
+    return m_hid.getRawAxis(axis);
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandJoystick.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandJoystick.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.wpilibj2.command.button;
 
+import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.event.EventLoop;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
@@ -13,7 +14,9 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
  *
  * @see Joystick
  */
-public class CommandJoystick extends Joystick {
+public class CommandJoystick extends CommandGenericHID {
+  private final Joystick m_hid;
+
   /**
    * Construct an instance of a controller.
    *
@@ -21,23 +24,17 @@ public class CommandJoystick extends Joystick {
    */
   public CommandJoystick(int port) {
     super(port);
-  }
-
-  @Override
-  public Trigger button(int button, EventLoop loop) {
-    return super.button(button, loop).castTo(Trigger::new);
+    m_hid = new Joystick(port);
   }
 
   /**
-   * Constructs an event instance around this button's digital signal.
+   * Get the underlying GenericHID object.
    *
-   * @param button the button index
-   * @return an event instance representing the button's digital signal attached to the {@link
-   *     CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
-   * @see #button(int, EventLoop)
+   * @return the wrapped GenericHID object
    */
-  public Trigger button(int button) {
-    return button(button, CommandScheduler.getInstance().getDefaultButtonLoop());
+  @Override
+  public GenericHID getHID() {
+    return m_hid;
   }
 
   /**
@@ -51,9 +48,15 @@ public class CommandJoystick extends Joystick {
     return trigger(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the trigger button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the trigger button's digital signal attached to the
+   *     given loop.
+   */
   public Trigger trigger(EventLoop loop) {
-    return super.trigger(loop).castTo(Trigger::new);
+    return m_hid.trigger(loop).castTo(Trigger::new);
   }
 
   /**
@@ -67,8 +70,161 @@ public class CommandJoystick extends Joystick {
     return top(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the top button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the top button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger top(EventLoop loop) {
-    return super.top(loop).castTo(Trigger::new);
+    return m_hid.top(loop).castTo(Trigger::new);
+  }
+
+  /**
+   * Set the channel associated with the X axis.
+   *
+   * @param channel The channel to set the axis to.
+   */
+  public void setXChannel(int channel) {
+    m_hid.setXChannel(channel);
+  }
+
+  /**
+   * Set the channel associated with the Y axis.
+   *
+   * @param channel The channel to set the axis to.
+   */
+  public void setYChannel(int channel) {
+    m_hid.setYChannel(channel);
+  }
+
+  /**
+   * Set the channel associated with the Z axis.
+   *
+   * @param channel The channel to set the axis to.
+   */
+  public void setZChannel(int channel) {
+    m_hid.setZChannel(channel);
+  }
+
+  /**
+   * Set the channel associated with the throttle axis.
+   *
+   * @param channel The channel to set the axis to.
+   */
+  public void setThrottleChannel(int channel) {
+    m_hid.setThrottleChannel(channel);
+  }
+
+  /**
+   * Set the channel associated with the twist axis.
+   *
+   * @param channel The channel to set the axis to.
+   */
+  public void setTwistChannel(int channel) {
+    m_hid.setTwistChannel(channel);
+  }
+
+  /**
+   * Get the channel currently associated with the X axis.
+   *
+   * @return The channel for the axis.
+   */
+  public int getXChannel() {
+    return m_hid.getXChannel();
+  }
+
+  /**
+   * Get the channel currently associated with the Y axis.
+   *
+   * @return The channel for the axis.
+   */
+  public int getYChannel() {
+    return m_hid.getYChannel();
+  }
+
+  /**
+   * Get the channel currently associated with the Z axis.
+   *
+   * @return The channel for the axis.
+   */
+  public int getZChannel() {
+    return m_hid.getZChannel();
+  }
+
+  /**
+   * Get the channel currently associated with the twist axis.
+   *
+   * @return The channel for the axis.
+   */
+  public int getTwistChannel() {
+    return m_hid.getTwistChannel();
+  }
+
+  /**
+   * Get the channel currently associated with the throttle axis.
+   *
+   * @return The channel for the axis.
+   */
+  public int getThrottleChannel() {
+    return m_hid.getThrottleChannel();
+  }
+
+  /**
+   * Get the z position of the HID.
+   *
+   * @return the z position
+   */
+  public double getZ() {
+    return m_hid.getZ();
+  }
+
+  /**
+   * Get the twist value of the current joystick. This depends on the mapping of the joystick
+   * connected to the current port.
+   *
+   * @return The Twist value of the joystick.
+   */
+  public double getTwist() {
+    return m_hid.getTwist();
+  }
+
+  /**
+   * Get the throttle value of the current joystick. This depends on the mapping of the joystick
+   * connected to the current port.
+   *
+   * @return The Throttle value of the joystick.
+   */
+  public double getThrottle() {
+    return m_hid.getThrottle();
+  }
+
+  /**
+   * Get the magnitude of the direction vector formed by the joystick's current position relative to
+   * its origin.
+   *
+   * @return The magnitude of the direction vector
+   */
+  public double getMagnitude() {
+    return m_hid.getMagnitude();
+  }
+
+  /**
+   * Get the direction of the vector formed by the joystick and its origin in radians.
+   *
+   * @return The direction of the vector in radians
+   */
+  public double getDirectionRadians() {
+    return m_hid.getDirectionRadians();
+  }
+
+  /**
+   * Get the direction of the vector formed by the joystick and its origin in degrees.
+   *
+   * @return The direction of the vector in degrees
+   */
+  public double getDirectionDegrees() {
+    return m_hid.getDirectionDegrees();
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandPS4Controller.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandPS4Controller.java
@@ -4,17 +4,20 @@
 
 package edu.wpi.first.wpilibj2.command.button;
 
+import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.PS4Controller;
 import edu.wpi.first.wpilibj.event.EventLoop;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 
 /**
- * A subclass of {@link PS4Controller} with {@link Trigger} factories for command-based.
+ * A version of {@link PS4Controller} with {@link Trigger} factories for command-based.
  *
  * @see PS4Controller
  */
 @SuppressWarnings("MethodName")
-public class CommandPS4Controller extends PS4Controller {
+public class CommandPS4Controller extends CommandGenericHID {
+  private final PS4Controller m_hid;
+
   /**
    * Construct an instance of a device.
    *
@@ -22,6 +25,17 @@ public class CommandPS4Controller extends PS4Controller {
    */
   public CommandPS4Controller(int port) {
     super(port);
+    m_hid = new PS4Controller(port);
+  }
+
+  /**
+   * Get the underlying GenericHID object.
+   *
+   * @return the wrapped GenericHID object
+   */
+  @Override
+  public GenericHID getHID() {
+    return m_hid;
   }
 
   /**
@@ -34,9 +48,15 @@ public class CommandPS4Controller extends PS4Controller {
     return L2(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the L2 button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the L2 button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger L2(EventLoop loop) {
-    return super.L2(loop).castTo(Trigger::new);
+    return m_hid.L2(loop).castTo(Trigger::new);
   }
 
   /**
@@ -49,9 +69,15 @@ public class CommandPS4Controller extends PS4Controller {
     return R2(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the R2 button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the R2 button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger R2(EventLoop loop) {
-    return super.R2(loop).castTo(Trigger::new);
+    return m_hid.R2(loop).castTo(Trigger::new);
   }
 
   /**
@@ -64,9 +90,15 @@ public class CommandPS4Controller extends PS4Controller {
     return L1(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the L1 button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the L1 button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger L1(EventLoop loop) {
-    return super.L1(loop).castTo(Trigger::new);
+    return m_hid.L1(loop).castTo(Trigger::new);
   }
 
   /**
@@ -79,9 +111,15 @@ public class CommandPS4Controller extends PS4Controller {
     return R1(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the R1 button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the R1 button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger R1(EventLoop loop) {
-    return super.R1(loop).castTo(Trigger::new);
+    return m_hid.R1(loop).castTo(Trigger::new);
   }
 
   /**
@@ -94,9 +132,15 @@ public class CommandPS4Controller extends PS4Controller {
     return L3(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the L3 button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the L3 button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger L3(EventLoop loop) {
-    return super.L3(loop).castTo(Trigger::new);
+    return m_hid.L3(loop).castTo(Trigger::new);
   }
 
   /**
@@ -109,9 +153,15 @@ public class CommandPS4Controller extends PS4Controller {
     return R3(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the R3 button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the R3 button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger R3(EventLoop loop) {
-    return super.R3(loop).castTo(Trigger::new);
+    return m_hid.R3(loop).castTo(Trigger::new);
   }
 
   /**
@@ -124,9 +174,15 @@ public class CommandPS4Controller extends PS4Controller {
     return square(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the square button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the square button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger square(EventLoop loop) {
-    return super.square(loop).castTo(Trigger::new);
+    return m_hid.square(loop).castTo(Trigger::new);
   }
 
   /**
@@ -139,9 +195,15 @@ public class CommandPS4Controller extends PS4Controller {
     return cross(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the cross button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the cross button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger cross(EventLoop loop) {
-    return super.cross(loop).castTo(Trigger::new);
+    return m_hid.cross(loop).castTo(Trigger::new);
   }
 
   /**
@@ -154,9 +216,15 @@ public class CommandPS4Controller extends PS4Controller {
     return circle(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the circle button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the circle button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger circle(EventLoop loop) {
-    return super.circle(loop).castTo(Trigger::new);
+    return m_hid.circle(loop).castTo(Trigger::new);
   }
 
   /**
@@ -169,9 +237,15 @@ public class CommandPS4Controller extends PS4Controller {
     return share(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the share button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the share button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger share(EventLoop loop) {
-    return super.share(loop).castTo(Trigger::new);
+    return m_hid.share(loop).castTo(Trigger::new);
   }
 
   /**
@@ -184,9 +258,15 @@ public class CommandPS4Controller extends PS4Controller {
     return PS(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the PS button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the PS button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger PS(EventLoop loop) {
-    return super.PS(loop).castTo(Trigger::new);
+    return m_hid.PS(loop).castTo(Trigger::new);
   }
 
   /**
@@ -199,9 +279,15 @@ public class CommandPS4Controller extends PS4Controller {
     return options(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the options button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the options button's digital signal attached to the
+   *     given loop.
+   */
   public Trigger options(EventLoop loop) {
-    return super.options(loop).castTo(Trigger::new);
+    return m_hid.options(loop).castTo(Trigger::new);
   }
 
   /**
@@ -214,8 +300,70 @@ public class CommandPS4Controller extends PS4Controller {
     return touchpad(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the touchpad's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the touchpad's digital signal attached to the given
+   *     loop.
+   */
   public Trigger touchpad(EventLoop loop) {
-    return super.touchpad(loop).castTo(Trigger::new);
+    return m_hid.touchpad(loop).castTo(Trigger::new);
+  }
+
+  /**
+   * Get the X axis value of left side of the controller.
+   *
+   * @return the axis value.
+   */
+  public double getLeftX() {
+    return m_hid.getLeftX();
+  }
+
+  /**
+   * Get the X axis value of right side of the controller.
+   *
+   * @return the axis value.
+   */
+  public double getRightX() {
+    return m_hid.getRightX();
+  }
+
+  /**
+   * Get the Y axis value of left side of the controller.
+   *
+   * @return the axis value.
+   */
+  public double getLeftY() {
+    return m_hid.getLeftY();
+  }
+
+  /**
+   * Get the Y axis value of right side of the controller.
+   *
+   * @return the axis value.
+   */
+  public double getRightY() {
+    return m_hid.getRightY();
+  }
+
+  /**
+   * Get the L2 axis value of the controller. Note that this axis is bound to the range of [0, 1] as
+   * opposed to the usual [-1, 1].
+   *
+   * @return the axis value.
+   */
+  public double getL2Axis() {
+    return m_hid.getL2Axis();
+  }
+
+  /**
+   * Get the R2 axis value of the controller. Note that this axis is bound to the range of [0, 1] as
+   * opposed to the usual [-1, 1].
+   *
+   * @return the axis value.
+   */
+  public double getR2Axis() {
+    return m_hid.getR2Axis();
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandXboxController.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandXboxController.java
@@ -14,7 +14,9 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
  * @see XboxController
  */
 @SuppressWarnings("MethodName")
-public class CommandXboxController extends XboxController {
+public class CommandXboxController extends CommandGenericHID {
+  private final XboxController m_hid;
+
   /**
    * Construct an instance of a controller.
    *
@@ -22,6 +24,17 @@ public class CommandXboxController extends XboxController {
    */
   public CommandXboxController(int port) {
     super(port);
+    m_hid = new XboxController(port);
+  }
+
+  /**
+   * Get the underlying GenericHID object.
+   *
+   * @return the wrapped GenericHID object
+   */
+  @Override
+  public XboxController getHID() {
+    return m_hid;
   }
 
   /**
@@ -35,9 +48,15 @@ public class CommandXboxController extends XboxController {
     return leftBumper(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the right bumper's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the right bumper's digital signal attached to the given
+   *     loop.
+   */
   public Trigger leftBumper(EventLoop loop) {
-    return super.leftBumper(loop).castTo(Trigger::new);
+    return m_hid.leftBumper(loop).castTo(Trigger::new);
   }
 
   /**
@@ -51,9 +70,15 @@ public class CommandXboxController extends XboxController {
     return rightBumper(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the left bumper's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the left bumper's digital signal attached to the given
+   *     loop.
+   */
   public Trigger rightBumper(EventLoop loop) {
-    return super.rightBumper(loop).castTo(Trigger::new);
+    return m_hid.rightBumper(loop).castTo(Trigger::new);
   }
 
   /**
@@ -67,9 +92,15 @@ public class CommandXboxController extends XboxController {
     return leftStick(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the left stick button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the left stick button's digital signal attached to the
+   *     given loop.
+   */
   public Trigger leftStick(EventLoop loop) {
-    return super.leftStick(loop).castTo(Trigger::new);
+    return m_hid.leftStick(loop).castTo(Trigger::new);
   }
 
   /**
@@ -83,41 +114,15 @@ public class CommandXboxController extends XboxController {
     return rightStick(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the right stick button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the right stick button's digital signal attached to the
+   *     given loop.
+   */
   public Trigger rightStick(EventLoop loop) {
-    return super.rightStick(loop).castTo(Trigger::new);
-  }
-
-  /**
-   * Constructs an event instance around the X button's digital signal.
-   *
-   * @return an event instance representing the X button's digital signal attached to the {@link
-   *     CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
-   * @see #x(EventLoop)
-   */
-  public Trigger x() {
-    return x(CommandScheduler.getInstance().getDefaultButtonLoop());
-  }
-
-  @Override
-  public Trigger x(EventLoop loop) {
-    return super.x(loop).castTo(Trigger::new);
-  }
-
-  /**
-   * Constructs an event instance around the Y button's digital signal.
-   *
-   * @return an event instance representing the Y button's digital signal attached to the {@link
-   *     CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
-   * @see #y(EventLoop)
-   */
-  public Trigger y() {
-    return y(CommandScheduler.getInstance().getDefaultButtonLoop());
-  }
-
-  @Override
-  public Trigger y(EventLoop loop) {
-    return super.y(loop).castTo(Trigger::new);
+    return m_hid.rightStick(loop).castTo(Trigger::new);
   }
 
   /**
@@ -131,9 +136,15 @@ public class CommandXboxController extends XboxController {
     return a(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the A button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the A button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger a(EventLoop loop) {
-    return super.a(loop).castTo(Trigger::new);
+    return m_hid.a(loop).castTo(Trigger::new);
   }
 
   /**
@@ -147,9 +158,59 @@ public class CommandXboxController extends XboxController {
     return b(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the B button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the B button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger b(EventLoop loop) {
-    return super.b(loop).castTo(Trigger::new);
+    return m_hid.b(loop).castTo(Trigger::new);
+  }
+
+  /**
+   * Constructs an event instance around the X button's digital signal.
+   *
+   * @return an event instance representing the X button's digital signal attached to the {@link
+   *     CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #x(EventLoop)
+   */
+  public Trigger x() {
+    return x(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs an event instance around the X button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the X button's digital signal attached to the given
+   *     loop.
+   */
+  public Trigger x(EventLoop loop) {
+    return m_hid.x(loop).castTo(Trigger::new);
+  }
+
+  /**
+   * Constructs an event instance around the Y button's digital signal.
+   *
+   * @return an event instance representing the Y button's digital signal attached to the {@link
+   *     CommandScheduler#getDefaultButtonLoop() default scheduler button loop}.
+   * @see #y(EventLoop)
+   */
+  public Trigger y() {
+    return y(CommandScheduler.getInstance().getDefaultButtonLoop());
+  }
+
+  /**
+   * Constructs an event instance around the Y button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the Y button's digital signal attached to the given
+   *     loop.
+   */
+  public Trigger y(EventLoop loop) {
+    return m_hid.y(loop).castTo(Trigger::new);
   }
 
   /**
@@ -163,9 +224,15 @@ public class CommandXboxController extends XboxController {
     return start(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the start button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the start button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger start(EventLoop loop) {
-    return super.start(loop).castTo(Trigger::new);
+    return m_hid.start(loop).castTo(Trigger::new);
   }
 
   /**
@@ -179,8 +246,70 @@ public class CommandXboxController extends XboxController {
     return back(CommandScheduler.getInstance().getDefaultButtonLoop());
   }
 
-  @Override
+  /**
+   * Constructs an event instance around the back button's digital signal.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return an event instance representing the back button's digital signal attached to the given
+   *     loop.
+   */
   public Trigger back(EventLoop loop) {
-    return super.back(loop).castTo(Trigger::new);
+    return m_hid.back(loop).castTo(Trigger::new);
+  }
+
+  /**
+   * Get the X axis value of left side of the controller.
+   *
+   * @return The axis value.
+   */
+  public double getLeftX() {
+    return m_hid.getLeftX();
+  }
+
+  /**
+   * Get the X axis value of right side of the controller.
+   *
+   * @return The axis value.
+   */
+  public double getRightX() {
+    return m_hid.getRightX();
+  }
+
+  /**
+   * Get the Y axis value of left side of the controller.
+   *
+   * @return The axis value.
+   */
+  public double getLeftY() {
+    return m_hid.getLeftY();
+  }
+
+  /**
+   * Get the Y axis value of right side of the controller.
+   *
+   * @return The axis value.
+   */
+  public double getRightY() {
+    return m_hid.getRightY();
+  }
+
+  /**
+   * Get the left trigger (LT) axis value of the controller. Note that this axis is bound to the
+   * range of [0, 1] as opposed to the usual [-1, 1].
+   *
+   * @return The axis value.
+   */
+  public double getLeftTriggerAxis() {
+    return m_hid.getLeftTriggerAxis();
+  }
+
+  /**
+   * Get the right trigger (RT) axis value of the controller. Note that this axis is bound to the
+   * range of [0, 1] as opposed to the usual [-1, 1].
+   *
+   * @return The axis value.
+   */
+  public double getRightTriggerAxis() {
+    return m_hid.getRightTriggerAxis();
   }
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/CommandGenericHID.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/CommandGenericHID.cpp
@@ -9,3 +9,48 @@ using namespace frc2;
 Trigger CommandGenericHID::Button(int button, frc::EventLoop* loop) const {
   return GenericHID::Button(button, loop).CastTo<Trigger>();
 }
+
+Trigger CommandGenericHID::POV(int angle, frc::EventLoop* loop) const {
+  return POV(0, angle, loop);
+}
+
+Trigger CommandGenericHID::POV(int pov, int angle, frc::EventLoop* loop) const {
+  return Trigger(loop,
+                 [this, pov, angle] { return this->GetPOV(pov) == angle; });
+}
+
+Trigger CommandGenericHID::POVUp(frc::EventLoop* loop) const {
+  return POV(0, loop);
+}
+
+Trigger CommandGenericHID::POVUpRight(frc::EventLoop* loop) const {
+  return POV(45, loop);
+}
+
+Trigger CommandGenericHID::POVRight(frc::EventLoop* loop) const {
+  return POV(90, loop);
+}
+
+Trigger CommandGenericHID::POVDownRight(frc::EventLoop* loop) const {
+  return POV(135, loop);
+}
+
+Trigger CommandGenericHID::POVDown(frc::EventLoop* loop) const {
+  return POV(180, loop);
+}
+
+Trigger CommandGenericHID::POVDownLeft(frc::EventLoop* loop) const {
+  return POV(225, loop);
+}
+
+Trigger CommandGenericHID::POVLeft(frc::EventLoop* loop) const {
+  return POV(270, loop);
+}
+
+Trigger CommandGenericHID::POVUpLeft(frc::EventLoop* loop) const {
+  return POV(315, loop);
+}
+
+Trigger CommandGenericHID::POVCenter(frc::EventLoop* loop) const {
+  return POV(360, loop);
+}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/CommandPS4Controller.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/CommandPS4Controller.cpp
@@ -6,6 +6,10 @@
 
 using namespace frc2;
 
+Trigger CommandPS4Controller::Button(int button, frc::EventLoop* loop) const {
+  return GenericHID::Button(button, loop).CastTo<Trigger>();
+}
+
 Trigger CommandPS4Controller::Square(frc::EventLoop* loop) const {
   return PS4Controller::Square(loop).CastTo<Trigger>();
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/button/CommandXboxController.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/button/CommandXboxController.cpp
@@ -6,6 +6,10 @@
 
 using namespace frc2;
 
+Trigger CommandXboxController::Button(int button, frc::EventLoop* loop) const {
+  return GenericHID::Button(button, loop).CastTo<Trigger>();
+}
+
 Trigger CommandXboxController::LeftBumper(frc::EventLoop* loop) const {
   return XboxController::LeftBumper(loop).CastTo<Trigger>();
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/CommandGenericHID.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/CommandGenericHID.h
@@ -31,5 +31,153 @@ class CommandGenericHID : public frc::GenericHID {
   Trigger Button(int button,
                  frc::EventLoop* loop = CommandScheduler::GetInstance()
                                             .GetDefaultButtonLoop()) const;
+
+  /**
+   * Constructs a Trigger instance based around this angle of a POV on the HID.
+   *
+   * <p>The POV angles start at 0 in the up direction, and increase clockwise
+   * (eg right is 90, upper-left is 315).
+   *
+   * @param loop  the event loop instance to attach the event to. Defaults to
+   * {@link CommandScheduler::GetDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   * @param angle POV angle in degrees, or -1 for the center / not pressed.
+   * @return a Trigger instance based around this angle of a POV on the HID.
+   */
+  Trigger POV(int angle,
+              frc::EventLoop* loop =
+                  CommandScheduler::GetInstance().GetDefaultButtonLoop()) const;
+
+  /**
+   * Constructs a Trigger instance based around this angle of a POV on the HID.
+   *
+   * <p>The POV angles start at 0 in the up direction, and increase clockwise
+   * (eg right is 90, upper-left is 315).
+   *
+   * @param loop  the event loop instance to attach the event to. Defaults to
+   * {@link CommandScheduler::GetDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   * @param pov   index of the POV to read (starting at 0). Defaults to 0.
+   * @param angle POV angle in degrees, or -1 for the center / not pressed.
+   * @return a Trigger instance based around this angle of a POV on the HID.
+   */
+  Trigger POV(int pov, int angle,
+              frc::EventLoop* loop =
+                  CommandScheduler::GetInstance().GetDefaultButtonLoop()) const;
+
+  /**
+   * Constructs a Trigger instance based around the 0-degree angle (up) of the
+   * default (index 0) POV on the HID.
+   *
+   * @param loop  the event loop instance to attach the event to. Defaults to
+   * {@link CommandScheduler::GetDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   * @return a Trigger instance based around the 90-degree angle of a POV on the
+   * HID.
+   */
+  Trigger POVUp(frc::EventLoop* loop = CommandScheduler::GetInstance()
+                                           .GetDefaultButtonLoop()) const;
+
+  /**
+   * Constructs a Trigger instance based around the 45-degree angle (right up)
+   * of the default (index 0) POV on the HID.
+   *
+   * @param loop  the event loop instance to attach the event to. Defaults to
+   * {@link CommandScheduler::GetDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   * @return a Trigger instance based around the 90-degree angle of a POV on the
+   * HID.
+   */
+  Trigger POVUpRight(frc::EventLoop* loop = CommandScheduler::GetInstance()
+                                                .GetDefaultButtonLoop()) const;
+
+  /**
+   * Constructs a Trigger instance based around the 90-degree angle (right) of
+   * the default (index 0) POV on the HID.
+   *
+   * @param loop  the event loop instance to attach the event to. Defaults to
+   * {@link CommandScheduler::GetDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   * @return a Trigger instance based around the 90-degree angle of a POV on the
+   * HID.
+   */
+  Trigger POVRight(frc::EventLoop* loop = CommandScheduler::GetInstance()
+                                              .GetDefaultButtonLoop()) const;
+
+  /**
+   * Constructs a Trigger instance based around the 135-degree angle (right
+   * down) of the default (index 0) POV on the HID.
+   *
+   * @return a Trigger instance based around the 135-degree angle of a POV on
+   * the HID.
+   */
+  Trigger POVDownRight(
+      frc::EventLoop* loop =
+          CommandScheduler::GetInstance().GetDefaultButtonLoop()) const;
+
+  /**
+   * Constructs a Trigger instance based around the 180-degree angle (down) of
+   * the default (index 0) POV on the HID.
+   *
+   * @param loop  the event loop instance to attach the event to. Defaults to
+   * {@link CommandScheduler::GetDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   * @return a Trigger instance based around the 90-degree angle of a POV on the
+   * HID.
+   */
+  Trigger POVDown(frc::EventLoop* loop = CommandScheduler::GetInstance()
+                                             .GetDefaultButtonLoop()) const;
+
+  /**
+   * Constructs a Trigger instance based around the 225-degree angle (down left)
+   * of the default (index 0) POV on the HID.
+   *
+   * @param loop  the event loop instance to attach the event to. Defaults to
+   * {@link CommandScheduler::GetDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   * @return a Trigger instance based around the 90-degree angle of a POV on the
+   * HID.
+   */
+  Trigger POVDownLeft(frc::EventLoop* loop = CommandScheduler::GetInstance()
+                                                 .GetDefaultButtonLoop()) const;
+
+  /**
+   * Constructs a Trigger instance based around the 270-degree angle (left) of
+   * the default (index 0) POV on the HID.
+   *
+   * @param loop  the event loop instance to attach the event to. Defaults to
+   * {@link CommandScheduler::GetDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   * @return a Trigger instance based around the 90-degree angle of a POV on the
+   * HID.
+   */
+  Trigger POVLeft(frc::EventLoop* loop = CommandScheduler::GetInstance()
+                                             .GetDefaultButtonLoop()) const;
+
+  /**
+   * Constructs a Trigger instance based around the 315-degree angle (left up)
+   * of the default (index 0) POV on the HID.
+   *
+   * @param loop  the event loop instance to attach the event to. Defaults to
+   * {@link CommandScheduler::GetDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   * @return a Trigger instance based around the 90-degree angle of a POV on the
+   * HID.
+   */
+  Trigger POVUpLeft(frc::EventLoop* loop = CommandScheduler::GetInstance()
+                                               .GetDefaultButtonLoop()) const;
+
+  /**
+   * Constructs a Trigger instance based around the center (not pressed) of the
+   * default (index 0) POV on the HID.
+   *
+   * @param loop  the event loop instance to attach the event to. Defaults to
+   * {@link CommandScheduler::GetDefaultButtonLoop() the default command
+   * scheduler button loop}.
+   * @return a Trigger instance based around the 90-degree angle of a POV on the
+   * HID.
+   */
+  Trigger POVCenter(frc::EventLoop* loop = CommandScheduler::GetInstance()
+                                               .GetDefaultButtonLoop()) const;
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/CommandPS4Controller.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/CommandPS4Controller.h
@@ -20,6 +20,19 @@ class CommandPS4Controller : public frc::PS4Controller {
   using PS4Controller::PS4Controller;
 
   /**
+   * Constructs an event instance around this button's digital signal.
+   *
+   * @param button the button index
+   * @param loop the event loop instance to attach the event to. Defaults to the
+   * CommandScheduler's default loop.
+   * @return an event instance representing the button's digital signal attached
+   * to the given loop.
+   */
+  Trigger Button(int button,
+                 frc::EventLoop* loop = CommandScheduler::GetInstance()
+                                            .GetDefaultButtonLoop()) const;
+
+  /**
    * Constructs an event instance around the square button's digital signal.
    *
    * @param loop the event loop instance to attach the event to. Defaults to the

--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/CommandXboxController.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/CommandXboxController.h
@@ -20,6 +20,19 @@ class CommandXboxController : public frc::XboxController {
   using XboxController::XboxController;
 
   /**
+   * Constructs an event instance around this button's digital signal.
+   *
+   * @param button the button index
+   * @param loop the event loop instance to attach the event to. Defaults to the
+   * CommandScheduler's default loop.
+   * @return an event instance representing the button's digital signal attached
+   * to the given loop.
+   */
+  Trigger Button(int button,
+                 frc::EventLoop* loop = CommandScheduler::GetInstance()
+                                            .GetDefaultButtonLoop()) const;
+
+  /**
    * Constructs an event instance around the left bumper's digital signal.
    *
    * @param loop the event loop instance to attach the event to. Defaults to the

--- a/wpilibc/src/main/native/cpp/GenericHID.cpp
+++ b/wpilibc/src/main/native/cpp/GenericHID.cpp
@@ -44,6 +44,51 @@ int GenericHID::GetPOV(int pov) const {
   return DriverStation::GetStickPOV(m_port, pov);
 }
 
+BooleanEvent GenericHID::POV(int angle, EventLoop* loop) const {
+  return POV(0, angle, loop);
+}
+
+BooleanEvent GenericHID::POV(int pov, int angle, EventLoop* loop) const {
+  return BooleanEvent(
+      loop, [this, pov, angle] { return this->GetPOV(pov) == angle; });
+}
+
+BooleanEvent GenericHID::POVUp(EventLoop* loop) const {
+  return POV(0, loop);
+}
+
+BooleanEvent GenericHID::POVUpRight(EventLoop* loop) const {
+  return POV(45, loop);
+}
+
+BooleanEvent GenericHID::POVRight(EventLoop* loop) const {
+  return POV(90, loop);
+}
+
+BooleanEvent GenericHID::POVDownRight(EventLoop* loop) const {
+  return POV(135, loop);
+}
+
+BooleanEvent GenericHID::POVDown(EventLoop* loop) const {
+  return POV(180, loop);
+}
+
+BooleanEvent GenericHID::POVDownLeft(EventLoop* loop) const {
+  return POV(225, loop);
+}
+
+BooleanEvent GenericHID::POVLeft(EventLoop* loop) const {
+  return POV(270, loop);
+}
+
+BooleanEvent GenericHID::POVUpLeft(EventLoop* loop) const {
+  return POV(315, loop);
+}
+
+BooleanEvent GenericHID::POVCenter(EventLoop* loop) const {
+  return POV(360, loop);
+}
+
 int GenericHID::GetAxisCount() const {
   return DriverStation::GetStickAxisCount(m_port);
 }

--- a/wpilibc/src/main/native/include/frc/GenericHID.h
+++ b/wpilibc/src/main/native/include/frc/GenericHID.h
@@ -122,6 +122,116 @@ class GenericHID {
   int GetPOV(int pov = 0) const;
 
   /**
+   * Constructs a BooleanEvent instance based around this angle of a POV on the
+   * HID.
+   *
+   * <p>The POV angles start at 0 in the up direction, and increase clockwise
+   * (eg right is 90, upper-left is 315).
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @param angle POV angle in degrees, or -1 for the center / not pressed.
+   * @return a BooleanEvent instance based around this angle of a POV on the
+   * HID.
+   */
+  BooleanEvent POV(int angle, EventLoop* loop) const;
+
+  /**
+   * Constructs a BooleanEvent instance based around this angle of a POV on the
+   * HID.
+   *
+   * <p>The POV angles start at 0 in the up direction, and increase clockwise
+   * (eg right is 90, upper-left is 315).
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @param pov   index of the POV to read (starting at 0). Defaults to 0.
+   * @param angle POV angle in degrees, or -1 for the center / not pressed.
+   * @return a BooleanEvent instance based around this angle of a POV on the
+   * HID.
+   */
+  BooleanEvent POV(int pov, int angle, EventLoop* loop) const;
+
+  /**
+   * Constructs a BooleanEvent instance based around the 0-degree angle (up) of
+   * the default (index 0) POV on the HID.
+   *
+   * @return a BooleanEvent instance based around the 0-degree angle of a POV on
+   * the HID.
+   */
+  BooleanEvent POVUp(EventLoop* loop) const;
+
+  /**
+   * Constructs a BooleanEvent instance based around the 45-degree angle (right
+   * up) of the default (index 0) POV on the HID.
+   *
+   * @return a BooleanEvent instance based around the 45-degree angle of a POV
+   * on the HID.
+   */
+  BooleanEvent POVUpRight(EventLoop* loop) const;
+
+  /**
+   * Constructs a BooleanEvent instance based around the 90-degree angle (right)
+   * of the default (index 0) POV on the HID.
+   *
+   * @return a BooleanEvent instance based around the 90-degree angle of a POV
+   * on the HID.
+   */
+  BooleanEvent POVRight(EventLoop* loop) const;
+
+  /**
+   * Constructs a BooleanEvent instance based around the 135-degree angle (right
+   * down) of the default (index 0) POV on the HID.
+   *
+   * @return a BooleanEvent instance based around the 135-degree angle of a POV
+   * on the HID.
+   */
+  BooleanEvent POVDownRight(EventLoop* loop) const;
+
+  /**
+   * Constructs a BooleanEvent instance based around the 180-degree angle (down)
+   * of the default (index 0) POV on the HID.
+   *
+   * @return a BooleanEvent instance based around the 180-degree angle of a POV
+   * on the HID.
+   */
+  BooleanEvent POVDown(EventLoop* loop) const;
+
+  /**
+   * Constructs a BooleanEvent instance based around the 225-degree angle (down
+   * left) of the default (index 0) POV on the HID.
+   *
+   * @return a BooleanEvent instance based around the 225-degree angle of a POV
+   * on the HID.
+   */
+  BooleanEvent POVDownLeft(EventLoop* loop) const;
+
+  /**
+   * Constructs a BooleanEvent instance based around the 270-degree angle (left)
+   * of the default (index 0) POV on the HID.
+   *
+   * @return a BooleanEvent instance based around the 270-degree angle of a POV
+   * on the HID.
+   */
+  BooleanEvent POVLeft(EventLoop* loop) const;
+
+  /**
+   * Constructs a BooleanEvent instance based around the 315-degree angle (left
+   * up) of the default (index 0) POV on the HID.
+   *
+   * @return a BooleanEvent instance based around the 315-degree angle of a POV
+   * on the HID.
+   */
+  BooleanEvent POVUpLeft(EventLoop* loop) const;
+
+  /**
+   * Constructs a BooleanEvent instance based around the center (not pressed) of
+   * the default (index 0) POV on the HID.
+   *
+   * @return a BooleanEvent instance based around the center of a POV on the
+   * HID.
+   */
+  BooleanEvent POVCenter(EventLoop* loop) const;
+
+  /**
    * Get the number of axes for the HID.
    *
    * @return the number of axis for the current HID

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
@@ -168,6 +168,134 @@ public class GenericHID {
   }
 
   /**
+   * Constructs a BooleanEvent instance based around this angle of a POV on the HID.
+   *
+   * <p>The POV angles start at 0 in the up direction, and increase clockwise (eg right is 90,
+   * upper-left is 315).
+   *
+   * @param angle POV angle in degrees, or -1 for the center / not pressed.
+   * @param loop the event loop instance to attach the event to.
+   * @return a BooleanEvent instance based around this angle of a POV on the HID.
+   */
+  public BooleanEvent pov(int angle, EventLoop loop) {
+    return pov(0, angle, loop);
+  }
+
+  /**
+   * Constructs a BooleanEvent instance based around this angle of a POV on the HID.
+   *
+   * <p>The POV angles start at 0 in the up direction, and increase clockwise (eg right is 90,
+   * upper-left is 315).
+   *
+   * @param pov index of the POV to read (starting at 0). Defaults to 0.
+   * @param angle POV angle in degrees, or -1 for the center / not pressed.
+   * @param loop the event loop instance to attach the event to.
+   * @return a BooleanEvent instance based around this angle of a POV on the HID.
+   */
+  public BooleanEvent pov(int pov, int angle, EventLoop loop) {
+    return new BooleanEvent(loop, () -> getPOV(pov) == angle);
+  }
+
+  /**
+   * Constructs a BooleanEvent instance based around the 0-degree angle (up) of the default (index
+   * 0) POV on the HID.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a BooleanEvent instance based around the 0-degree angle of a POV on the HID.
+   */
+  public BooleanEvent povUp(EventLoop loop) {
+    return pov(0, loop);
+  }
+
+  /**
+   * Constructs a BooleanEvent instance based around the 45-degree angle (right up) of the default
+   * (index 0) POV on the HID.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a BooleanEvent instance based around the 45-degree angle of a POV on the HID.
+   */
+  public BooleanEvent povUpRight(EventLoop loop) {
+    return pov(45, loop);
+  }
+
+  /**
+   * Constructs a BooleanEvent instance based around the 90-degree angle (right) of the default
+   * (index 0) POV on the HID.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a BooleanEvent instance based around the 90-degree angle of a POV on the HID.
+   */
+  public BooleanEvent povRight(EventLoop loop) {
+    return pov(90, loop);
+  }
+
+  /**
+   * Constructs a BooleanEvent instance based around the 135-degree angle (right down) of the
+   * default (index 0) POV on the HID.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a BooleanEvent instance based around the 135-degree angle of a POV on the HID.
+   */
+  public BooleanEvent povDownRight(EventLoop loop) {
+    return pov(135, loop);
+  }
+
+  /**
+   * Constructs a BooleanEvent instance based around the 180-degree angle (down) of the default
+   * (index 0) POV on the HID.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a BooleanEvent instance based around the 180-degree angle of a POV on the HID.
+   */
+  public BooleanEvent povDown(EventLoop loop) {
+    return pov(180, loop);
+  }
+
+  /**
+   * Constructs a BooleanEvent instance based around the 225-degree angle (down left) of the default
+   * (index 0) POV on the HID.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a BooleanEvent instance based around the 225-degree angle of a POV on the HID.
+   */
+  public BooleanEvent povDownLeft(EventLoop loop) {
+    return pov(225, loop);
+  }
+
+  /**
+   * Constructs a BooleanEvent instance based around the 270-degree angle (left) of the default
+   * (index 0) POV on the HID.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a BooleanEvent instance based around the 270-degree angle of a POV on the HID.
+   */
+  public BooleanEvent povLeft(EventLoop loop) {
+    return pov(270, loop);
+  }
+
+  /**
+   * Constructs a BooleanEvent instance based around the 315-degree angle (left up) of the default
+   * (index 0) POV on the HID.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a BooleanEvent instance based around the 315-degree angle of a POV on the HID.
+   */
+  public BooleanEvent povUpLeft(EventLoop loop) {
+    return pov(315, loop);
+  }
+
+  /**
+   * Constructs a BooleanEvent instance based around the center (not pressed) of the default (index
+   * 0) POV on the HID.
+   *
+   * @param loop the event loop instance to attach the event to.
+   * @return a BooleanEvent instance based around the center of a POV on the HID.
+   */
+  public BooleanEvent povCenter(EventLoop loop) {
+    return pov(-1, loop);
+  }
+
+  /**
    * Get the number of axes for the HID.
    *
    * @return the number of axis for the current HID


### PR DESCRIPTION
In C++ due to value semantics and method hiding, there's no need to replace the inheritance with delegation; only missing methods were added.
In Java, the `Trigger` factories were incompatible with the `BooleanEvent` ones, so the command HID classes couldn't inherit from the non-command ones. Thus, delegation. The missing methods are now available due to inheriting from CommandGenericHID.

Also add `Trigger` factories for POVs. Since more than one POV is extremely rare, the povIndex argument is defaulted to 0 in all methods but the root factory.