### PR TITLE
[ci] Update deprecated github actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Set up Python 3.8 (macOS)
         if: runner.os == 'macOS'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/comment-command.yml
+++ b/.github/workflows/comment-command.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: React Rocket
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           script: |
             const {owner, repo} = context.issue
@@ -34,7 +34,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.COMMENT_COMMAND_PAT_TOKEN }}"
           NUMBER: ${{ github.event.issue.number }}
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install clang-format

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: 13
       - name: Install libclang-9
@@ -42,11 +42,11 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew docs:generateJavaDocs docs:doxygen -PbuildServer ${{ env.EXTRA_GRADLE_ARGS }}
       - name: Install SSH Client 🔑
-        uses: webfactory/ssh-agent@v0.4.1
+        uses: webfactory/ssh-agent@v0.7.0
         with:
           ssh-private-key: ${{ secrets.GH_DEPLOY_KEY }}
       - name: Deploy Java 🚀
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           SSH: true
           REPOSITORY_NAME: wpilibsuite/wpilibsuite.github.io
@@ -55,7 +55,7 @@ jobs:
           FOLDER: docs/build/docs/javadoc
           TARGET_FOLDER: ${{ env.TARGET_FOLDER }}/java
       - name: Deploy C++ 🚀
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           SSH: true
           REPOSITORY_NAME: wpilibsuite/wpilibsuite.github.io

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,6 +22,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 13
       - name: Install libclang-9
         run: sudo apt update && sudo apt install -y libclang-cpp9 libclang1-9

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           ARTIFACTORY_PUBLISH_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PUBLISH_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.artifact-name }}
           path: build/allOutputs
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: 11
           architecture: ${{ matrix.architecture }}
@@ -115,7 +115,7 @@ jobs:
         if: |
           matrix.artifact-name == 'macOS' && (github.repository_owner == 'wpilibsuite' &&
           (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.outputs }}
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: 13
       - name: Install libclang-9
@@ -140,7 +140,7 @@ jobs:
         env:
           ARTIFACTORY_PUBLISH_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PUBLISH_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Documentation
           path: docs/build/outputs
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: wpilibsuite/build-tools
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: combiner/products/build/allOutputs
       - name: Flatten Artifacts
@@ -162,7 +162,7 @@ jobs:
         run: |
           cat combiner/products/build/allOutputs/version.txt
           test -s combiner/products/build/allOutputs/version.txt
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: 11
       - name: Combine
@@ -188,7 +188,7 @@ jobs:
           RUN_AZURE_ARTIFACTORY_RELEASE: "TRUE"
           ARTIFACTORY_PUBLISH_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PUBLISH_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Maven
           path: ~/releases

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -82,6 +82,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 11
           architecture: ${{ matrix.architecture }}
       - name: Import Developer ID Certificate
@@ -129,6 +130,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 13
       - name: Install libclang-9
         run: sudo apt update && sudo apt install -y libclang-cpp9 libclang1-9
@@ -164,6 +166,7 @@ jobs:
           test -s combiner/products/build/allOutputs/version.txt
       - uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 11
       - name: Combine
         if: |

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -23,7 +23,7 @@ jobs:
           git checkout -b pr
           git branch -f main origin/main
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install clang-format
@@ -41,7 +41,7 @@ jobs:
       - name: Generate diff
         run: git diff HEAD > wpiformat-fixes.patch
         if: ${{ failure() }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wpiformat fixes
           path: wpiformat-fixes.patch
@@ -59,7 +59,7 @@ jobs:
           git checkout -b pr
           git branch -f main origin/main
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install clang-tidy
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: 13
       - name: Install libclang-9

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -104,6 +104,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 13
       - name: Install libclang-9
         run: sudo apt update && sudo apt install -y libclang-cpp9 libclang1-9

--- a/.github/workflows/upstream-utils.yml
+++ b/.github/workflows/upstream-utils.yml
@@ -22,7 +22,7 @@ jobs:
           git checkout -b pr
           git branch -f main origin/main
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Configure committer identity


### PR DESCRIPTION
I noticed a lot of warning on one of my last builds, so I turned on dependabot on my fork and had it auto-update all of the github actions.

Might be worth setting up dependabot in a separate PR. It can be noisy for java deps, but actions updates should be few and far between.