### PR TITLE
[ci] Fix comment command commit push

### DIFF
--- a/.github/workflows/comment-command.yml
+++ b/.github/workflows/comment-command.yml
@@ -54,4 +54,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # Commit
           git commit -am "wpiformat"
-          git push
+          git push origin HEAD


### PR DESCRIPTION
This was the error:
```
fatal: The upstream branch of your current branch does not match
the name of your current branch.  To push to the upstream branch
on the remote, use

    git push origin HEAD:refs/pull/4503/head

To push to the branch of the same name on the remote, use

    git push origin HEAD
```