### PR TITLE
[ci] Write wpiformat patch to job summary

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -48,10 +48,10 @@ jobs:
         if: ${{ failure() }}
       - name: Write to job summary
         run: |
-          echo "```diff" >> $GITHUB_STEP_SUMMARY
+          # echo '```diff' >> $GITHUB_STEP_SUMMARY
           cat wpiformat-fixes.patch >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          # echo '```' >> $GITHUB_STEP_SUMMARY
         if: ${{ failure() }}
 
   tidy:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -48,10 +48,10 @@ jobs:
         if: ${{ failure() }}
       - name: Write to job summary
         run: |
-          # echo '```diff' >> $GITHUB_STEP_SUMMARY
+          echo '```diff' >> $GITHUB_STEP_SUMMARY
           cat wpiformat-fixes.patch >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
-          # echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
         if: ${{ failure() }}
 
   tidy:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -46,6 +46,14 @@ jobs:
           name: wpiformat fixes
           path: wpiformat-fixes.patch
         if: ${{ failure() }}
+      - name: Write to job summary
+        run: |
+          echo "```diff" >> $GITHUB_STEP_SUMMARY
+          cat wpiformat-fixes.patch >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "```" >> $GITHUB_STEP_SUMMARY
+        if: ${{ failure() }}
+
   tidy:
     name: "clang-tidy"
     runs-on: ubuntu-latest

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandBase.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandBase.cpp
@@ -10,10 +10,7 @@
 using namespace frc2;
 
 CommandBase::CommandBase() {
-  wpi::SendableRegistry::Add(
-    this, GetTypeName(*
-    this
-    ));
+  wpi::SendableRegistry::Add(this, GetTypeName(*this));
 }
 
 void CommandBase::AddRequirements(

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandBase.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandBase.cpp
@@ -10,7 +10,10 @@
 using namespace frc2;
 
 CommandBase::CommandBase() {
-  wpi::SendableRegistry::Add(this, GetTypeName(*this));
+  wpi::SendableRegistry::Add(
+    this, GetTypeName(*
+    this
+    ));
 }
 
 void CommandBase::AddRequirements(


### PR DESCRIPTION
I find that the workflow of downloading and extracting the zipped patch is quite tiresome, and the `/wpiformat` comment command is quite spammy.
This posts the patch contents to a code block at the [job summary](https://github.com/wpilibsuite/allwpilib/actions/runs/3323062430#summary-9099760328) with a convenient "copy to clipboard" button; the patch text can then be pasted into a local file (with LF line endings) and `git apply`ed.