### PR TITLE
[wpilibc] Don't hang waiting for NT server to start

### DIFF
--- a/wpilibc/src/main/native/cppcs/RobotBase.cpp
+++ b/wpilibc/src/main/native/cppcs/RobotBase.cpp
@@ -235,6 +235,7 @@ RobotBase::RobotBase() {
     ++count;
     if (count > 100) {
       fmt::print(stderr, "timed out while waiting for NT server to start\n");
+      break;
     }
   }
 


### PR DESCRIPTION
This matches Java behavior.