### PR TITLE
[ntcore] Various fixes and cleanups

### DIFF
--- a/ntcore/src/generate/java/NetworkTableInstance.java.jinja
+++ b/ntcore/src/generate/java/NetworkTableInstance.java.jinja
@@ -68,6 +68,7 @@ public final class NetworkTableInstance implements AutoCloseable {
     if (m_owned && m_handle != 0) {
       m_listeners.close();
       NetworkTablesJNI.destroyInstance(m_handle);
+      m_handle = 0;
     }
   }
 
@@ -986,5 +987,5 @@ public final class NetworkTableInstance implements AutoCloseable {
   }
 
   private boolean m_owned;
-  private final int m_handle;
+  private int m_handle;
 }

--- a/ntcore/src/main/native/cpp/LocalStorage.cpp
+++ b/ntcore/src/main/native/cpp/LocalStorage.cpp
@@ -495,15 +495,19 @@ void LSImpl::NotifyValue(TopicData* topic, unsigned int eventFlags) {
     if (subscriber->active) {
       subscriber->pollStorage.emplace_back(topic->lastValue);
       subscriber->handle.Set();
-      m_listenerStorage.Notify(subscriber->valueListeners, eventFlags,
-                               topic->handle, 0, topic->lastValue);
+      if (!subscriber->valueListeners.empty()) {
+        m_listenerStorage.Notify(subscriber->valueListeners, eventFlags,
+                                 topic->handle, 0, topic->lastValue);
+      }
     }
   }
 
   for (auto&& subscriber : topic->multiSubscribers) {
     subscriber->handle.Set();
-    m_listenerStorage.Notify(subscriber->valueListeners, eventFlags,
-                             topic->handle, 0, topic->lastValue);
+    if (!subscriber->valueListeners.empty()) {
+      m_listenerStorage.Notify(subscriber->valueListeners, eventFlags,
+                               topic->handle, 0, topic->lastValue);
+    }
   }
 }
 

--- a/ntcore/src/main/native/cpp/networktables/NetworkTableInstance.cpp
+++ b/ntcore/src/main/native/cpp/networktables/NetworkTableInstance.cpp
@@ -101,9 +101,44 @@ void NetworkTableInstance::SetServer(std::span<const std::string_view> servers,
   SetServer(serversArr);
 }
 
+NT_Listener NetworkTableInstance::AddListener(Topic topic,
+                                              unsigned int eventMask,
+                                              ListenerCallback listener) {
+  if (::nt::GetInstanceFromHandle(topic.GetHandle()) != m_handle) {
+    fmt::print(stderr, "AddListener: topic is not from this instance\n");
+    return 0;
+  }
+  return ::nt::AddListener(topic.GetHandle(), eventMask, std::move(listener));
+}
+
+NT_Listener NetworkTableInstance::AddListener(Subscriber& subscriber,
+                                              unsigned int eventMask,
+                                              ListenerCallback listener) {
+  if (::nt::GetInstanceFromHandle(subscriber.GetHandle()) != m_handle) {
+    fmt::print(stderr, "AddListener: subscriber is not from this instance\n");
+    return 0;
+  }
+  return ::nt::AddListener(subscriber.GetHandle(), eventMask,
+                           std::move(listener));
+}
+
+NT_Listener NetworkTableInstance::AddListener(NetworkTableEntry& entry,
+                                              int eventMask,
+                                              ListenerCallback listener) {
+  if (::nt::GetInstanceFromHandle(entry.GetHandle()) != m_handle) {
+    fmt::print(stderr, "AddListener: entry is not from this instance\n");
+    return 0;
+  }
+  return ::nt::AddListener(entry.GetHandle(), eventMask, std::move(listener));
+}
+
 NT_Listener NetworkTableInstance::AddListener(MultiSubscriber& subscriber,
                                               int eventMask,
                                               ListenerCallback listener) {
+  if (::nt::GetInstanceFromHandle(subscriber.GetHandle()) != m_handle) {
+    fmt::print(stderr, "AddListener: subscriber is not from this instance\n");
+    return 0;
+  }
   return ::nt::AddListener(subscriber.GetHandle(), eventMask,
                            std::move(listener));
 }

--- a/ntcore/src/main/native/cpp/ntcore_cpp.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_cpp.cpp
@@ -497,6 +497,14 @@ NT_Listener AddPolledListener(NT_ListenerPoller poller,
 NT_Listener AddPolledListener(NT_ListenerPoller poller, NT_Handle handle,
                               unsigned int mask) {
   if (auto ii = InstanceImpl::GetTyped(poller, Handle::kListenerPoller)) {
+    if (Handle{handle}.GetInst() != Handle{poller}.GetInst()) {
+      WPI_ERROR(
+          ii->logger,
+          "AddPolledListener(): trying to listen to handle {} (instance {}) "
+          "with poller {} (instance {}), ignored due to different instance",
+          handle, Handle{handle}.GetInst(), poller, Handle{poller}.GetInst());
+      return {};
+    }
     auto listener = ii->listenerStorage.AddListener(poller);
     DoAddListener(*ii, listener, handle, mask);
     return listener;

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
@@ -132,7 +132,7 @@ class NetworkTableInstance final {
    *
    * @param inst Instance
    */
-  static void Destroy(NetworkTableInstance inst);
+  static void Destroy(NetworkTableInstance& inst);
 
   /**
    * Gets the native handle for the entry.

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
@@ -101,22 +101,6 @@ inline NT_Listener NetworkTableInstance::AddConnectionListener(
 }
 
 inline NT_Listener NetworkTableInstance::AddListener(
-    Topic topic, unsigned int eventMask, ListenerCallback listener) {
-  return ::nt::AddListener(topic.GetHandle(), eventMask, std::move(listener));
-}
-
-inline NT_Listener NetworkTableInstance::AddListener(
-    Subscriber& subscriber, unsigned int eventMask, ListenerCallback listener) {
-  return ::nt::AddListener(subscriber.GetHandle(), eventMask,
-                           std::move(listener));
-}
-
-inline NT_Listener NetworkTableInstance::AddListener(
-    NetworkTableEntry& entry, int eventMask, ListenerCallback listener) {
-  return ::nt::AddListener(entry.GetHandle(), eventMask, std::move(listener));
-}
-
-inline NT_Listener NetworkTableInstance::AddListener(
     std::span<const std::string_view> prefixes, int eventMask,
     ListenerCallback listener) {
   return ::nt::AddListener(m_handle, prefixes, eventMask, std::move(listener));

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
@@ -27,9 +27,10 @@ inline NetworkTableInstance NetworkTableInstance::Create() {
   return NetworkTableInstance{CreateInstance()};
 }
 
-inline void NetworkTableInstance::Destroy(NetworkTableInstance inst) {
+inline void NetworkTableInstance::Destroy(NetworkTableInstance& inst) {
   if (inst.m_handle != 0) {
     DestroyInstance(inst.m_handle);
+    inst.m_handle = 0;
   }
 }
 

--- a/ntcore/src/main/native/include/networktables/NetworkTableListener.inc
+++ b/ntcore/src/main/native/include/networktables/NetworkTableListener.inc
@@ -6,6 +6,7 @@
 
 #include <span>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "networktables/MultiSubscriber.h"

--- a/ntcore/src/main/native/include/networktables/NetworkTableListener.inc
+++ b/ntcore/src/main/native/include/networktables/NetworkTableListener.inc
@@ -6,7 +6,6 @@
 
 #include <span>
 #include <string_view>
-#include <utility>
 #include <vector>
 
 #include "networktables/MultiSubscriber.h"
@@ -72,7 +71,11 @@ inline NetworkTableListener::NetworkTableListener(NetworkTableListener&& rhs)
 
 inline NetworkTableListener& NetworkTableListener::operator=(
     NetworkTableListener&& rhs) {
-  std::swap(m_handle, rhs.m_handle);
+  if (m_handle != 0) {
+    nt::RemoveListener(m_handle);
+  }
+  m_handle = rhs.m_handle;
+  rhs.m_handle = 0;
   return *this;
 }
 
@@ -102,7 +105,11 @@ inline NetworkTableListenerPoller::NetworkTableListenerPoller(
 
 inline NetworkTableListenerPoller& NetworkTableListenerPoller::operator=(
     NetworkTableListenerPoller&& rhs) {
-  std::swap(m_handle, rhs.m_handle);
+  if (m_handle != 0) {
+    nt::DestroyListenerPoller(m_handle);
+  }
+  m_handle = rhs.m_handle;
+  rhs.m_handle = 0;
   return *this;
 }
 


### PR DESCRIPTION
- [x] NetworkTableInstance: set handle to 0 after destroy
- [x] Fix multiple notifications of local values
- [x] Detect mismatch between handles (C/C++ layer done, need to do it at OO layer)
- [x] Fix setting min period from server when no topics are published
- [x] Add ceiling limit to publishers and subscribers to detect accidental leaks