### PR TITLE
[wpilib] Fix Xbox/PS4 POV sim for port number constructors

### DIFF
--- a/wpilibc/src/main/native/cpp/simulation/PS4ControllerSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/PS4ControllerSim.cpp
@@ -19,6 +19,7 @@ PS4ControllerSim::PS4ControllerSim(const PS4Controller& joystick)
 PS4ControllerSim::PS4ControllerSim(int port) : GenericHIDSim{port} {
   SetAxisCount(6);
   SetButtonCount(14);
+  SetPOVCount(1);
 }
 
 void PS4ControllerSim::SetLeftX(double value) {

--- a/wpilibc/src/main/native/cpp/simulation/XboxControllerSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/XboxControllerSim.cpp
@@ -19,6 +19,7 @@ XboxControllerSim::XboxControllerSim(const XboxController& joystick)
 XboxControllerSim::XboxControllerSim(int port) : GenericHIDSim{port} {
   SetAxisCount(6);
   SetButtonCount(10);
+  SetPOVCount(1);
 }
 
 void XboxControllerSim::SetLeftX(double value) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/PS4ControllerSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/PS4ControllerSim.java
@@ -29,6 +29,7 @@ public class PS4ControllerSim extends GenericHIDSim {
     super(port);
     setAxisCount(6);
     setButtonCount(14);
+    setPOVCount(1);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/XboxControllerSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/XboxControllerSim.java
@@ -29,6 +29,7 @@ public class XboxControllerSim extends GenericHIDSim {
     super(port);
     setAxisCount(6);
     setButtonCount(10);
+    setPOVCount(1);
   }
 
   /**


### PR DESCRIPTION
#4546 Fixes the POV sim for constructors accepting a controller object, but does not apply the fix for constructors accepting a port number. This PR applies the fix to the remaining controller sim constructors.

Further fixes #4543 