### PR TITLE
[wpilib] Fix Shuffleboard SuppliedValueWidget

### DIFF
--- a/wpilibc/src/main/native/include/frc/shuffleboard/SuppliedValueWidget.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/SuppliedValueWidget.h
@@ -36,12 +36,16 @@ class SuppliedValueWidget : public ShuffleboardWidget<SuppliedValueWidget<T>> {
   void BuildInto(std::shared_ptr<nt::NetworkTable> parentTable,
                  std::shared_ptr<nt::NetworkTable> metaTable) override {
     this->BuildMetadata(metaTable);
-    m_controllablePub =
-        nt::BooleanTopic{metaTable->GetTopic("Controllable")}.Publish();
-    m_controllablePub.Set(false);
+    if (!m_controllablePub) {
+      m_controllablePub =
+          nt::BooleanTopic{metaTable->GetTopic("Controllable")}.Publish();
+      m_controllablePub.Set(false);
+    }
 
-    m_entry =
-        parentTable->GetTopic(this->GetTitle()).GenericPublish(m_typeString);
+    if (!m_entry) {
+      m_entry =
+          parentTable->GetTopic(this->GetTitle()).GenericPublish(m_typeString);
+    }
     m_setter(m_entry, m_supplier());
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/SuppliedValueWidget.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/SuppliedValueWidget.java
@@ -48,10 +48,14 @@ public final class SuppliedValueWidget<T> extends ShuffleboardWidget<SuppliedVal
   @Override
   public void buildInto(NetworkTable parentTable, NetworkTable metaTable) {
     buildMetadata(metaTable);
-    m_controllablePub = new BooleanTopic(metaTable.getTopic("Controllable")).publish();
-    m_controllablePub.set(false);
+    if (m_controllablePub == null) {
+      m_controllablePub = new BooleanTopic(metaTable.getTopic("Controllable")).publish();
+      m_controllablePub.set(false);
+    }
 
-    m_entry = parentTable.getTopic(getTitle()).genericPublish(m_typeString);
+    if (m_entry == null) {
+      m_entry = parentTable.getTopic(getTitle()).genericPublish(m_typeString);
+    }
     m_setter.accept(m_entry, m_supplier.get());
   }
 


### PR DESCRIPTION
It was creating duplicate publishers.  In C++ the old publisher was destroyed, but since it wasn't being closed in Java, publishers simply accumulated.