### PR TITLE
[ntcore] Change Java event mask to EnumSet

### DIFF
--- a/ntcore/src/generate/java/NetworkTableInstance.java.jinja
+++ b/ntcore/src/generate/java/NetworkTableInstance.java.jinja
@@ -36,16 +36,33 @@ import java.util.function.Consumer;
  */
 @SuppressWarnings("PMD.CouplingBetweenObjects")
 public final class NetworkTableInstance implements AutoCloseable {
-  /**
-   * Client/server mode flag values (as returned by {@link #getNetworkMode()}). This is a bitmask.
-   */
-  public static final int kNetModeNone = 0x00;
+  /** Client/server mode flag values (as returned by {@link #getNetworkMode()}). */
+  public enum NetworkMode {
+    /** Running in server mode. */
+    kServer(0x01),
 
-  public static final int kNetModeServer = 0x01;
-  public static final int kNetModeClient3 = 0x02;
-  public static final int kNetModeClient4 = 0x04;
-  public static final int kNetModeStarting = 0x08;
-  public static final int kNetModeLocal = 0x10;
+    /** Running in NT3 client mode. */
+    kClient3(0x02),
+
+    /** Running in NT4 client mode. */
+    kClient4(0x04),
+
+    /** Currently starting up (either client or server). */
+    kStarting(0x08),
+
+    /** Running in local-only mode. */
+    kLocal(0x10);
+
+    private final int value;
+
+    NetworkMode(int value) {
+      this.value = value;
+    }
+
+    public int getValue() {
+      return value;
+    }
+  }
 
   /** The default port that network tables operates on for NT3. */
   public static final int kDefaultPort3 = 1735;
@@ -689,10 +706,17 @@ public final class NetworkTableInstance implements AutoCloseable {
   /**
    * Get the current network mode.
    *
-   * @return Bitmask of NetworkMode.
+   * @return Enum set of NetworkMode.
    */
-  public int getNetworkMode() {
-    return NetworkTablesJNI.getNetworkMode(m_handle);
+  public EnumSet<NetworkMode> getNetworkMode() {
+    int flags = NetworkTablesJNI.getNetworkMode(m_handle);
+    EnumSet<NetworkMode> rv = EnumSet.noneOf(NetworkMode.class);
+    for (NetworkMode mode : NetworkMode.values()) {
+      if ((flags & mode.getValue()) != 0) {
+        rv.add(mode);
+      }
+    }
+    return rv;
   }
 
   /**

--- a/ntcore/src/generate/java/NetworkTableInstance.java.jinja
+++ b/ntcore/src/generate/java/NetworkTableInstance.java.jinja
@@ -7,6 +7,7 @@ package edu.wpi.first.networktables;
 import edu.wpi.first.util.WPIUtilJNI;
 import edu.wpi.first.util.concurrent.Event;
 import edu.wpi.first.util.datalog.DataLog;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -369,14 +370,17 @@ public final class NetworkTableInstance implements AutoCloseable {
       m_inst = inst;
     }
 
-    int add(String[] prefixes, int mask, Consumer<NetworkTableEvent> listener) {
+    int add(
+        String[] prefixes,
+        EnumSet<NetworkTableEvent.Kind> eventKinds,
+        Consumer<NetworkTableEvent> listener) {
       m_lock.lock();
       try {
         if (m_poller == 0) {
           m_poller = NetworkTablesJNI.createListenerPoller(m_inst.getHandle());
           startThread();
         }
-        int h = NetworkTablesJNI.addListener(m_poller, prefixes, mask);
+        int h = NetworkTablesJNI.addListener(m_poller, prefixes, eventKinds);
         m_listeners.put(h, listener);
         return h;
       } finally {
@@ -384,14 +388,17 @@ public final class NetworkTableInstance implements AutoCloseable {
       }
     }
 
-    int add(int handle, int mask, Consumer<NetworkTableEvent> listener) {
+    int add(
+        int handle,
+        EnumSet<NetworkTableEvent.Kind> eventKinds,
+        Consumer<NetworkTableEvent> listener) {
       m_lock.lock();
       try {
         if (m_poller == 0) {
           m_poller = NetworkTablesJNI.createListenerPoller(m_inst.getHandle());
           startThread();
         }
-        int h = NetworkTablesJNI.addListener(m_poller, handle, mask);
+        int h = NetworkTablesJNI.addListener(m_poller, handle, eventKinds);
         m_listeners.put(h, listener);
         return h;
       } finally {
@@ -562,9 +569,11 @@ public final class NetworkTableInstance implements AutoCloseable {
    */
   public int addConnectionListener(
       boolean immediateNotify, Consumer<NetworkTableEvent> listener) {
-    return m_listeners.add(m_handle,
-        NetworkTableEvent.kConnection | (immediateNotify ? NetworkTableEvent.kImmediate : 0),
-        listener);
+    EnumSet<NetworkTableEvent.Kind> eventKinds = EnumSet.of(NetworkTableEvent.Kind.kConnection);
+    if (immediateNotify) {
+      eventKinds.add(NetworkTableEvent.Kind.kImmediate);
+    }
+    return m_listeners.add(m_handle, eventKinds, listener);
   }
 
   /**
@@ -576,16 +585,18 @@ public final class NetworkTableInstance implements AutoCloseable {
    * listener.
    *
    * @param topic Topic
-   * @param eventMask Bitmask of TopicListenerFlags values
+   * @param eventKinds set of event kinds to listen to
    * @param listener Listener function
    * @return Listener handle
    */
   public int addListener(
-      Topic topic, int eventMask, Consumer<NetworkTableEvent> listener) {
+      Topic topic,
+      EnumSet<NetworkTableEvent.Kind> eventKinds,
+      Consumer<NetworkTableEvent> listener) {
     if (topic.getInstance().getHandle() != m_handle) {
       throw new IllegalArgumentException("topic is not from this instance");
     }
-    return m_listeners.add(topic.getHandle(), eventMask, listener);
+    return m_listeners.add(topic.getHandle(), eventKinds, listener);
   }
 
   /**
@@ -595,16 +606,18 @@ public final class NetworkTableInstance implements AutoCloseable {
    * active.
    *
    * @param subscriber Subscriber
-   * @param eventMask Bitmask of TopicListenerFlags values
+   * @param eventKinds set of event kinds to listen to
    * @param listener Listener function
    * @return Listener handle
    */
   public int addListener(
-      Subscriber subscriber, int eventMask, Consumer<NetworkTableEvent> listener) {
+      Subscriber subscriber,
+      EnumSet<NetworkTableEvent.Kind> eventKinds,
+      Consumer<NetworkTableEvent> listener) {
     if (subscriber.getTopic().getInstance().getHandle() != m_handle) {
       throw new IllegalArgumentException("subscriber is not from this instance");
     }
-    return m_listeners.add(subscriber.getHandle(), eventMask, listener);
+    return m_listeners.add(subscriber.getHandle(), eventKinds, listener);
   }
 
   /**
@@ -614,16 +627,18 @@ public final class NetworkTableInstance implements AutoCloseable {
    * active.
    *
    * @param subscriber Subscriber
-   * @param eventMask Bitmask of TopicListenerFlags values
+   * @param eventKinds set of event kinds to listen to
    * @param listener Listener function
    * @return Listener handle
    */
   public int addListener(
-      MultiSubscriber subscriber, int eventMask, Consumer<NetworkTableEvent> listener) {
+      MultiSubscriber subscriber,
+      EnumSet<NetworkTableEvent.Kind> eventKinds,
+      Consumer<NetworkTableEvent> listener) {
     if (subscriber.getInstance().getHandle() != m_handle) {
       throw new IllegalArgumentException("subscriber is not from this instance");
     }
-    return m_listeners.add(subscriber.getHandle(), eventMask, listener);
+    return m_listeners.add(subscriber.getHandle(), eventKinds, listener);
   }
 
   /**
@@ -632,16 +647,18 @@ public final class NetworkTableInstance implements AutoCloseable {
    * accessing any shared state from the callback function.
    *
    * @param entry Entry
-   * @param eventMask Bitmask of TopicListenerFlags values
+   * @param eventKinds set of event kinds to listen to
    * @param listener Listener function
    * @return Listener handle
    */
   public int addListener(
-      NetworkTableEntry entry, int eventMask, Consumer<NetworkTableEvent> listener) {
+      NetworkTableEntry entry,
+      EnumSet<NetworkTableEvent.Kind> eventKinds,
+      Consumer<NetworkTableEvent> listener) {
     if (entry.getTopic().getInstance().getHandle() != m_handle) {
       throw new IllegalArgumentException("entry is not from this instance");
     }
-    return m_listeners.add(entry.getHandle(), eventMask, listener);
+    return m_listeners.add(entry.getHandle(), eventKinds, listener);
   }
 
   /**
@@ -654,15 +671,15 @@ public final class NetworkTableInstance implements AutoCloseable {
    * listener.
    *
    * @param prefixes Topic name string prefixes
-   * @param eventMask Bitmask of TopicListenerFlags values
+   * @param eventKinds set of event kinds to listen to
    * @param listener Listener function
    * @return Listener handle
    */
   public int addListener(
       String[] prefixes,
-      int eventMask,
+      EnumSet<NetworkTableEvent.Kind> eventKinds,
       Consumer<NetworkTableEvent> listener) {
-    return m_listeners.add(prefixes, eventMask, listener);
+    return m_listeners.add(prefixes, eventKinds, listener);
   }
 
   /*

--- a/ntcore/src/generate/java/NetworkTablesJNI.java.jinja
+++ b/ntcore/src/generate/java/NetworkTablesJNI.java.jinja
@@ -7,6 +7,7 @@ package edu.wpi.first.networktables;
 import edu.wpi.first.util.RuntimeLoader;
 import edu.wpi.first.util.datalog.DataLog;
 import java.io.IOException;
+import java.util.EnumSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class NetworkTablesJNI {
@@ -202,6 +203,22 @@ public final class NetworkTablesJNI {
   public static native int createListenerPoller(int inst);
 
   public static native void destroyListenerPoller(int poller);
+
+  private static int kindsToMask(EnumSet<NetworkTableEvent.Kind> kinds) {
+    int mask = 0;
+    for (NetworkTableEvent.Kind kind : kinds) {
+      mask |= kind.getValue();
+    }
+    return mask;
+  }
+
+  public static int addListener(int poller, String[] prefixes, EnumSet<NetworkTableEvent.Kind> kinds) {
+    return addListener(poller, prefixes, kindsToMask(kinds));
+  }
+
+  public static int addListener(int poller, int handle, EnumSet<NetworkTableEvent.Kind> kinds) {
+    return addListener(poller, handle, kindsToMask(kinds));
+  }
 
   public static native int addListener(int poller, String[] prefixes, int mask);
 

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableEvent.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableEvent.java
@@ -13,9 +13,6 @@ package edu.wpi.first.networktables;
 @SuppressWarnings("MemberName")
 public final class NetworkTableEvent {
   public enum Kind {
-    /** No flags. */
-    kNone(0x0000),
-
     /**
      * Initial listener addition. Set this to receive immediate notification of matches to other
      * criteria.

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableEvent.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableEvent.java
@@ -67,43 +67,14 @@ public final class NetworkTableEvent {
   }
 
   /**
-   * Convert from the numerical representation of kind to an enum type. Immediate is not converted.
-   *
-   * @param kind The numerical representation of kind
-   * @return The kind
-   */
-  public static Kind getKindFromInt(int kind) {
-    switch (kind & ~Kind.kImmediate.value) {
-      case 0x0002:
-        return Kind.kConnected;
-      case 0x0004:
-        return Kind.kDisconnected;
-      case 0x0008:
-        return Kind.kPublish;
-      case 0x0010:
-        return Kind.kUnpublish;
-      case 0x0020:
-        return Kind.kProperties;
-      case 0x0040:
-        return Kind.kValueRemote;
-      case 0x0080:
-        return Kind.kValueLocal;
-      case 0x0100:
-        return Kind.kLogMessage;
-      default:
-        return Kind.kNone;
-    }
-  }
-
-  /**
    * Handle of listener that was triggered. The value returned when adding the listener can be used
    * to map this to a specific added listener.
    */
   public final int listener;
 
   /**
-   * Event kind. For example, kPublish if the topic was not previously published. Also indicates the
-   * data included with the event:
+   * Determine if event is of a particular kind. For example, kPublish if the topic was not
+   * previously published. Also indicates the data included with the event:
    *
    * <ul>
    *   <li>kConnected or kDisconnected: connInfo
@@ -111,11 +82,15 @@ public final class NetworkTableEvent {
    *   <li>kValueRemote, kValueLocal: valueData
    *   <li>kLogMessage: logMessage
    * </ul>
+   *
+   * @param kind Kind
+   * @return True if event matches kind
    */
-  public final Kind kind;
+  public boolean is(Kind kind) {
+    return (m_flags & kind.getValue()) != 0;
+  }
 
-  /** If event was triggered due to Kind.kImmediate. */
-  public final boolean immediate;
+  private final int m_flags;
 
   /** Connection information (for connection events). */
   public final ConnectionInfo connInfo;
@@ -150,8 +125,7 @@ public final class NetworkTableEvent {
       LogMessage logMessage) {
     this.m_inst = inst;
     this.listener = listener;
-    this.kind = getKindFromInt(flags);
-    this.immediate = (flags & Kind.kImmediate.value) != 0;
+    this.m_flags = flags;
     this.connInfo = connInfo;
     this.topicInfo = topicInfo;
     this.valueData = valueData;

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableListener.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableListener.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.networktables;
 
+import java.util.EnumSet;
 import java.util.function.Consumer;
 
 /**
@@ -18,16 +19,16 @@ public final class NetworkTableListener implements AutoCloseable {
    *
    * @param inst Instance
    * @param prefixes Topic name string prefixes
-   * @param eventMask Bitmask of NetworkTableEvent flags values
+   * @param eventKinds set of event kinds to listen to
    * @param listener Listener function
    * @return Listener
    */
   public static NetworkTableListener createListener(
       NetworkTableInstance inst,
       String[] prefixes,
-      int eventMask,
+      EnumSet<NetworkTableEvent.Kind> eventKinds,
       Consumer<NetworkTableEvent> listener) {
-    return new NetworkTableListener(inst, inst.addListener(prefixes, eventMask, listener));
+    return new NetworkTableListener(inst, inst.addListener(prefixes, eventKinds, listener));
   }
 
   /**
@@ -35,56 +36,64 @@ public final class NetworkTableListener implements AutoCloseable {
    * subscriber with the lifetime of the listener.
    *
    * @param topic Topic
-   * @param eventMask Bitmask of NetworkTableEvent flags values
+   * @param eventKinds set of event kinds to listen to
    * @param listener Listener function
    * @return Listener
    */
   public static NetworkTableListener createListener(
-      Topic topic, int eventMask, Consumer<NetworkTableEvent> listener) {
+      Topic topic,
+      EnumSet<NetworkTableEvent.Kind> eventKinds,
+      Consumer<NetworkTableEvent> listener) {
     NetworkTableInstance inst = topic.getInstance();
-    return new NetworkTableListener(inst, inst.addListener(topic, eventMask, listener));
+    return new NetworkTableListener(inst, inst.addListener(topic, eventKinds, listener));
   }
 
   /**
    * Create a listener for topic changes on a subscriber. This does NOT keep the subscriber active.
    *
    * @param subscriber Subscriber
-   * @param eventMask Bitmask of NetworkTableEvent flags values
+   * @param eventKinds set of event kinds to listen to
    * @param listener Listener function
    * @return Listener
    */
   public static NetworkTableListener createListener(
-      Subscriber subscriber, int eventMask, Consumer<NetworkTableEvent> listener) {
+      Subscriber subscriber,
+      EnumSet<NetworkTableEvent.Kind> eventKinds,
+      Consumer<NetworkTableEvent> listener) {
     NetworkTableInstance inst = subscriber.getTopic().getInstance();
-    return new NetworkTableListener(inst, inst.addListener(subscriber, eventMask, listener));
+    return new NetworkTableListener(inst, inst.addListener(subscriber, eventKinds, listener));
   }
 
   /**
    * Create a listener for topic changes on a subscriber. This does NOT keep the subscriber active.
    *
    * @param subscriber Subscriber
-   * @param eventMask Bitmask of NetworkTableEvent flags values
+   * @param eventKinds set of event kinds to listen to
    * @param listener Listener function
    * @return Listener
    */
   public static NetworkTableListener createListener(
-      MultiSubscriber subscriber, int eventMask, Consumer<NetworkTableEvent> listener) {
+      MultiSubscriber subscriber,
+      EnumSet<NetworkTableEvent.Kind> eventKinds,
+      Consumer<NetworkTableEvent> listener) {
     NetworkTableInstance inst = subscriber.getInstance();
-    return new NetworkTableListener(inst, inst.addListener(subscriber, eventMask, listener));
+    return new NetworkTableListener(inst, inst.addListener(subscriber, eventKinds, listener));
   }
 
   /**
    * Create a listener for topic changes on an entry.
    *
    * @param entry Entry
-   * @param eventMask Bitmask of NetworkTableEvent flags values
+   * @param eventKinds set of event kinds to listen to
    * @param listener Listener function
    * @return Listener
    */
   public static NetworkTableListener createListener(
-      NetworkTableEntry entry, int eventMask, Consumer<NetworkTableEvent> listener) {
+      NetworkTableEntry entry,
+      EnumSet<NetworkTableEvent.Kind> eventKinds,
+      Consumer<NetworkTableEvent> listener) {
     NetworkTableInstance inst = entry.getInstance();
-    return new NetworkTableListener(inst, inst.addListener(entry, eventMask, listener));
+    return new NetworkTableListener(inst, inst.addListener(entry, eventKinds, listener));
   }
 
   /**

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableListenerPoller.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTableListenerPoller.java
@@ -4,6 +4,8 @@
 
 package edu.wpi.first.networktables;
 
+import java.util.EnumSet;
+
 /**
  * Topic change listener. This queues topic change events matching the specified mask. Code using
  * the listener must periodically call readQueue() to read the events.
@@ -24,11 +26,11 @@ public final class NetworkTableListenerPoller implements AutoCloseable {
    * prefixes. This creates a corresponding internal subscriber with the lifetime of the listener.
    *
    * @param prefixes Topic name string prefixes
-   * @param eventMask Bitmask of TopicListenerFlags values
+   * @param eventKinds set of event kinds to listen to
    * @return Listener handle
    */
-  public int addListener(String[] prefixes, int eventMask) {
-    return NetworkTablesJNI.addListener(m_handle, prefixes, eventMask);
+  public int addListener(String[] prefixes, EnumSet<NetworkTableEvent.Kind> eventKinds) {
+    return NetworkTablesJNI.addListener(m_handle, prefixes, eventKinds);
   }
 
   /**
@@ -36,44 +38,44 @@ public final class NetworkTableListenerPoller implements AutoCloseable {
    * subscriber with the lifetime of the listener.
    *
    * @param topic Topic
-   * @param eventMask Bitmask of TopicListenerFlags values
+   * @param eventKinds set of event kinds to listen to
    * @return Listener handle
    */
-  public int addListener(Topic topic, int eventMask) {
-    return NetworkTablesJNI.addListener(m_handle, topic.getHandle(), eventMask);
+  public int addListener(Topic topic, EnumSet<NetworkTableEvent.Kind> eventKinds) {
+    return NetworkTablesJNI.addListener(m_handle, topic.getHandle(), eventKinds);
   }
 
   /**
    * Start listening to topic changes on a subscriber. This does NOT keep the subscriber active.
    *
    * @param subscriber Subscriber
-   * @param eventMask Bitmask of TopicListenerFlags values
+   * @param eventKinds set of event kinds to listen to
    * @return Listener handle
    */
-  public int addListener(Subscriber subscriber, int eventMask) {
-    return NetworkTablesJNI.addListener(m_handle, subscriber.getHandle(), eventMask);
+  public int addListener(Subscriber subscriber, EnumSet<NetworkTableEvent.Kind> eventKinds) {
+    return NetworkTablesJNI.addListener(m_handle, subscriber.getHandle(), eventKinds);
   }
 
   /**
    * Start listening to topic changes on a subscriber. This does NOT keep the subscriber active.
    *
    * @param subscriber Subscriber
-   * @param eventMask Bitmask of TopicListenerFlags values
+   * @param eventKinds set of event kinds to listen to
    * @return Listener handle
    */
-  public int addListener(MultiSubscriber subscriber, int eventMask) {
-    return NetworkTablesJNI.addListener(m_handle, subscriber.getHandle(), eventMask);
+  public int addListener(MultiSubscriber subscriber, EnumSet<NetworkTableEvent.Kind> eventKinds) {
+    return NetworkTablesJNI.addListener(m_handle, subscriber.getHandle(), eventKinds);
   }
 
   /**
    * Start listening to topic changes on an entry.
    *
    * @param entry Entry
-   * @param eventMask Bitmask of TopicListenerFlags values
+   * @param eventKinds set of event kinds to listen to
    * @return Listener handle
    */
-  public int addListener(NetworkTableEntry entry, int eventMask) {
-    return NetworkTablesJNI.addListener(m_handle, entry.getHandle(), eventMask);
+  public int addListener(NetworkTableEntry entry, EnumSet<NetworkTableEvent.Kind> eventKinds) {
+    return NetworkTablesJNI.addListener(m_handle, entry.getHandle(), eventKinds);
   }
 
   /**
@@ -85,10 +87,11 @@ public final class NetworkTableListenerPoller implements AutoCloseable {
    * @return Listener handle
    */
   public int addConnectionListener(boolean immediateNotify) {
-    return NetworkTablesJNI.addListener(
-        m_handle,
-        m_inst.getHandle(),
-        NetworkTableEvent.kConnection | (immediateNotify ? NetworkTableEvent.kImmediate : 0));
+    EnumSet<NetworkTableEvent.Kind> eventKinds = EnumSet.of(NetworkTableEvent.Kind.kConnection);
+    if (immediateNotify) {
+      eventKinds.add(NetworkTableEvent.Kind.kImmediate);
+    }
+    return NetworkTablesJNI.addListener(m_handle, m_inst.getHandle(), eventKinds);
   }
 
   /**

--- a/ntcore/src/main/native/include/ntcore_cpp.h
+++ b/ntcore/src/main/native/include/ntcore_cpp.h
@@ -223,6 +223,14 @@ class Event {
    */
   unsigned int flags{0};
 
+  /**
+   * Test event flags.
+   *
+   * @param kind event flag(s) to test
+   * @return True if flags matches kind
+   */
+  bool Is(unsigned int kind) const { return (flags & kind) != 0; }
+
   /** Event data; content depends on flags. */
   std::variant<ConnectionInfo, TopicInfo, ValueEventData, LogMessage> data;
 

--- a/ntcore/src/test/java/edu/wpi/first/networktables/ConnectionListenerTest.java
+++ b/ntcore/src/test/java/edu/wpi/first/networktables/ConnectionListenerTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import edu.wpi.first.util.WPIUtilJNI;
@@ -83,7 +84,7 @@ class ConnectionListenerTest {
     assertEquals(1, events.length);
     assertEquals(handle, events[0].listener);
     assertNotNull(events[0].connInfo);
-    assertEquals(events[0].kind, NetworkTableEvent.Kind.kConnected);
+    assertTrue(events[0].is(NetworkTableEvent.Kind.kConnected));
 
     // trigger a disconnect event
     m_clientInst.stopClient();
@@ -104,7 +105,7 @@ class ConnectionListenerTest {
     assertNotNull(events);
     assertEquals(1, events.length);
     assertEquals(handle, events[0].listener);
-    assertEquals(events[0].kind, NetworkTableEvent.Kind.kDisconnected);
+    assertTrue(events[0].is(NetworkTableEvent.Kind.kDisconnected));
   }
 
   private static int threadedPort = 10001;
@@ -156,7 +157,7 @@ class ConnectionListenerTest {
       assertEquals(1, events.size());
       assertEquals(handle, events.get(0).listener);
       assertNotNull(events.get(0).connInfo);
-      assertEquals(events.get(0).kind, NetworkTableEvent.Kind.kConnected);
+      assertTrue(events.get(0).is(NetworkTableEvent.Kind.kConnected));
       events.clear();
     }
 
@@ -181,7 +182,7 @@ class ConnectionListenerTest {
       assertEquals(1, events.size());
       assertEquals(handle, events.get(0).listener);
       assertNotNull(events.get(0).connInfo);
-      assertEquals(events.get(0).kind, NetworkTableEvent.Kind.kDisconnected);
+      assertTrue(events.get(0).is(NetworkTableEvent.Kind.kDisconnected));
     }
   }
 }

--- a/ntcore/src/test/java/edu/wpi/first/networktables/ConnectionListenerTest.java
+++ b/ntcore/src/test/java/edu/wpi/first/networktables/ConnectionListenerTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import edu.wpi.first.util.WPIUtilJNI;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,7 +65,7 @@ class ConnectionListenerTest {
     assertNotSame(poller, 0, "bad poller handle");
     int handle =
         NetworkTablesJNI.addListener(
-            poller, m_serverInst.getHandle(), NetworkTableEvent.kConnection);
+            poller, m_serverInst.getHandle(), EnumSet.of(NetworkTableEvent.Kind.kConnection));
     assertNotSame(handle, 0, "bad listener handle");
 
     // trigger a connect event
@@ -82,7 +83,7 @@ class ConnectionListenerTest {
     assertEquals(1, events.length);
     assertEquals(handle, events[0].listener);
     assertNotNull(events[0].connInfo);
-    assertEquals(events[0].flags, NetworkTableEvent.kConnected);
+    assertEquals(events[0].kind, NetworkTableEvent.Kind.kConnected);
 
     // trigger a disconnect event
     m_clientInst.stopClient();
@@ -103,7 +104,7 @@ class ConnectionListenerTest {
     assertNotNull(events);
     assertEquals(1, events.length);
     assertEquals(handle, events[0].listener);
-    assertEquals(events[0].flags, NetworkTableEvent.kDisconnected);
+    assertEquals(events[0].kind, NetworkTableEvent.Kind.kDisconnected);
   }
 
   private static int threadedPort = 10001;
@@ -155,7 +156,7 @@ class ConnectionListenerTest {
       assertEquals(1, events.size());
       assertEquals(handle, events.get(0).listener);
       assertNotNull(events.get(0).connInfo);
-      assertEquals(events.get(0).flags, NetworkTableEvent.kConnected);
+      assertEquals(events.get(0).kind, NetworkTableEvent.Kind.kConnected);
       events.clear();
     }
 
@@ -180,7 +181,7 @@ class ConnectionListenerTest {
       assertEquals(1, events.size());
       assertEquals(handle, events.get(0).listener);
       assertNotNull(events.get(0).connInfo);
-      assertEquals(events.get(0).flags, NetworkTableEvent.kDisconnected);
+      assertEquals(events.get(0).kind, NetworkTableEvent.Kind.kDisconnected);
     }
   }
 }

--- a/ntcore/src/test/java/edu/wpi/first/networktables/LoggerTest.java
+++ b/ntcore/src/test/java/edu/wpi/first/networktables/LoggerTest.java
@@ -37,7 +37,7 @@ class LoggerTest {
     // wait for client to report it's started, then wait another 0.1 sec
     try {
       int count = 0;
-      while ((m_clientInst.getNetworkMode() & NetworkTableInstance.kNetModeClient4) == 0) {
+      while (!m_clientInst.getNetworkMode().contains(NetworkTableInstance.NetworkMode.kClient4)) {
         Thread.sleep(100);
         count++;
         if (count > 30) {

--- a/ntcore/src/test/java/edu/wpi/first/networktables/TopicListenerTest.java
+++ b/ntcore/src/test/java/edu/wpi/first/networktables/TopicListenerTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import edu.wpi.first.util.WPIUtilJNI;
+import java.util.EnumSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -37,7 +38,8 @@ class TopicListenerTest {
 
     // Use connection listener to ensure we've connected
     int poller = NetworkTablesJNI.createListenerPoller(m_clientInst.getHandle());
-    NetworkTablesJNI.addListener(poller, m_clientInst.getHandle(), NetworkTableEvent.kConnected);
+    NetworkTablesJNI.addListener(
+        poller, m_clientInst.getHandle(), EnumSet.of(NetworkTableEvent.Kind.kConnected));
     try {
       if (WPIUtilJNI.waitForObjectTimeout(poller, 1.0)) {
         fail("client didn't connect to server");
@@ -55,7 +57,8 @@ class TopicListenerTest {
     connect();
     final int poller = NetworkTablesJNI.createListenerPoller(m_serverInst.getHandle());
     final int handle =
-        NetworkTablesJNI.addListener(poller, new String[] {"/foo"}, NetworkTableEvent.kPublish);
+        NetworkTablesJNI.addListener(
+            poller, new String[] {"/foo"}, EnumSet.of(NetworkTableEvent.Kind.kPublish));
 
     // Trigger an event
     m_clientInst.getEntry("/foo/bar").setDouble(1.0);
@@ -83,6 +86,6 @@ class TopicListenerTest {
     assertNotNull(events[0].topicInfo);
     assertEquals(m_serverInst.getTopic("/foo/bar"), events[0].topicInfo.getTopic());
     assertEquals("/foo/bar", events[0].topicInfo.name);
-    assertEquals(NetworkTableEvent.kPublish, events[0].flags);
+    assertEquals(NetworkTableEvent.Kind.kPublish, events[0].kind);
   }
 }

--- a/ntcore/src/test/java/edu/wpi/first/networktables/TopicListenerTest.java
+++ b/ntcore/src/test/java/edu/wpi/first/networktables/TopicListenerTest.java
@@ -6,6 +6,7 @@ package edu.wpi.first.networktables;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import edu.wpi.first.util.WPIUtilJNI;
@@ -86,6 +87,6 @@ class TopicListenerTest {
     assertNotNull(events[0].topicInfo);
     assertEquals(m_serverInst.getTopic("/foo/bar"), events[0].topicInfo.getTopic());
     assertEquals("/foo/bar", events[0].topicInfo.name);
-    assertEquals(NetworkTableEvent.Kind.kPublish, events[0].kind);
+    assertTrue(events[0].is(NetworkTableEvent.Kind.kPublish));
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Preferences.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Preferences.java
@@ -17,6 +17,7 @@ import edu.wpi.first.networktables.NetworkTableListener;
 import edu.wpi.first.networktables.StringPublisher;
 import edu.wpi.first.networktables.Topic;
 import java.util.Collection;
+import java.util.EnumSet;
 
 /**
  * The preferences class provides a relatively simple way to save important values to the roboRIO to
@@ -77,7 +78,7 @@ public final class Preferences {
     m_listener =
         NetworkTableListener.createListener(
             m_tableSubscriber,
-            NetworkTableEvent.kImmediate | NetworkTableEvent.kPublish,
+            EnumSet.of(NetworkTableEvent.Kind.kImmediate, NetworkTableEvent.Kind.kPublish),
             event -> {
               if (event.topicInfo != null) {
                 Topic topic = event.topicInfo.getTopic();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -155,7 +155,7 @@ public abstract class RobotBase implements AutoCloseable {
     // wait for the NT server to actually start
     try {
       int count = 0;
-      while ((inst.getNetworkMode() & NetworkTableInstance.kNetModeStarting) != 0) {
+      while (inst.getNetworkMode().contains(NetworkTableInstance.NetworkMode.kStarting)) {
         Thread.sleep(10);
         count++;
         if (count > 100) {

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/PreferencesTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/PreferencesTest.java
@@ -54,7 +54,7 @@ class PreferencesTest {
     m_inst.startServer(filepath.toString(), "", 0, 0);
     try {
       int count = 0;
-      while ((m_inst.getNetworkMode() & NetworkTableInstance.kNetModeStarting) != 0) {
+      while (m_inst.getNetworkMode().contains(NetworkTableInstance.NetworkMode.kStarting)) {
         Thread.sleep(100);
         count++;
         if (count > 30) {


### PR DESCRIPTION
- [x] ~Check to make sure multiple flags aren't being set in a single event at the C++ layer (this would break the conversion to enum in NetworkTableEvent)~ Change NetworkTableEvent.kind back to int, make private, add `boolean is(Kind)` public function.
- [x] Change getNetworkMode to return an EnumSet