### PR TITLE
Explicitly mark EventLoop as non-copyable/non-movable

### DIFF
--- a/wpilibc/src/main/native/include/frc/event/EventLoop.h
+++ b/wpilibc/src/main/native/include/frc/event/EventLoop.h
@@ -16,6 +16,9 @@ class EventLoop {
  public:
   EventLoop();
 
+  EventLoop(const EventLoop&) = delete;
+  EventLoop& operator=(const EventLoop&) = delete;
+
   /**
    * Bind a new action to run whenever the condition is true.
    *


### PR DESCRIPTION
- It's already not movable because m_bindings isn't copyable, but pybind11 isn't able to detect that