### PR TITLE
Allow composing two triggers directly

### DIFF
--- a/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/button/Trigger.h
@@ -488,12 +488,30 @@ class Trigger {
   }
 
   /**
+   * Composes two triggers with logical AND.
+   *
+   * @return A trigger which is active when both component triggers are active.
+   */
+  Trigger operator&&(Trigger& rhs) {
+    return (m_event && rhs.m_event).CastTo<Trigger>();
+  }
+
+  /**
    * Composes two triggers with logical OR.
    *
    * @return A trigger which is active when either component trigger is active.
    */
   Trigger operator||(std::function<bool()> rhs) {
     return m_event.operator||(rhs).CastTo<Trigger>();
+  }
+
+  /**
+   * Composes two triggers with logical OR.
+   *
+   * @return A trigger which is active when either component trigger is active.
+   */
+  Trigger operator||(Trigger& rhs) {
+    return (m_event || rhs.m_event).CastTo<Trigger>();
   }
 
   /**


### PR DESCRIPTION
- For backwards compatibility reasons

Maybe we don't want to allow this composability... but the comment in `operatorXX(std::function<bool()> rhs)` seems to imply that it's supposed to work? My compiler isn't able to implicitly convert a trigger without this, but maybe I'm missing something?

Someone else should add a test for this.