### PR TITLE
Add DifferentialDriveFeedforward classes which wrap LinearPlantInversionFeedforward

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveFeedforward.java
@@ -9,10 +9,20 @@ import edu.wpi.first.math.numbers.N2;
 import edu.wpi.first.math.system.LinearSystem;
 import edu.wpi.first.math.system.plant.LinearSystemId;
 
+/** A helper class which computes the feedforward outputs for a differential drive drivetrain. */
 public class DifferentialDriveFeedforward {
-
   private final LinearSystem<N2, N2, N2> m_plant;
 
+  /**
+   * Creates a new DifferentialDriveFeedforward with the specified parameters.
+   *
+   * @param kVLinear The linear velocity gain in volts per (meters per second).
+   * @param kALinear The linear acceleration gain in volts per (meters per second squared).
+   * @param kVAngular The angular velocity gain in volts per (radians per second).
+   * @param kAAngular The angular acceleration gain in volts per (radians per second squared).
+   * @param trackwidth The distance between the differential drive's left and right wheels, in
+   *     meters.
+   */
   public DifferentialDriveFeedforward(
       double kVLinear, double kALinear, double kVAngular, double kAAngular, double trackwidth) {
     m_plant =
@@ -20,20 +30,35 @@ public class DifferentialDriveFeedforward {
             kVLinear, kALinear, kVAngular, kAAngular, trackwidth);
   }
 
+  /**
+   * Creates a new DifferentialDriveFeedforward with the specified parameters.
+   *
+   * @param kVLinear The linear velocity gain in volts per (meters per second).
+   * @param kALinear The linear acceleration gain in volts per (meters per second squared).
+   * @param kVAngular The angular velocity gain in volts per (radians per second).
+   * @param kAAngular The angular acceleration gain in volts per (radians per second squared).
+   */
   public DifferentialDriveFeedforward(
       double kVLinear, double kALinear, double kVAngular, double kAAngular) {
     m_plant = LinearSystemId.identifyDrivetrainSystem(kVLinear, kALinear, kVAngular, kAAngular);
   }
 
-  // need to add constructor which creates default trackwidth
-
+  /**
+   * Calculates the differential drive feedforward inputs given velocity setpoints.
+   *
+   * @param currentLVelocity The current left velocity of the differential drive in meters/second.
+   * @param nextLVelocity The next left velocity of the differential drive in meters/second.
+   * @param currentRVelocity The current right velocity of the differential drive in meters/second.
+   * @param nextRVelocity The next right velocity of the differential drive in meters/second.
+   * @param dtSeconds Discretization timestep.
+   * @return A DifferentialDriveWheelVoltages object containing the computed feedforward voltages.
+   */
   public DifferentialDriveWheelVoltages calculate(
       double currentLVelocity,
       double nextLVelocity,
       double currentRVelocity,
       double nextRVelocity,
       double dtSeconds) {
-
     var feedforward = new LinearPlantInversionFeedforward<>(m_plant, dtSeconds);
     var r = VecBuilder.fill(currentLVelocity, currentRVelocity);
     var nextR = VecBuilder.fill(nextLVelocity, nextRVelocity);

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveFeedforward.java
@@ -1,0 +1,43 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.math.controller;
+
+import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.numbers.N2;
+import edu.wpi.first.math.system.LinearSystem;
+import edu.wpi.first.math.system.plant.LinearSystemId;
+
+public class DifferentialDriveFeedforward {
+
+  private final LinearSystem<N2, N2, N2> m_plant;
+
+  public DifferentialDriveFeedforward(
+      double kVLinear, double kALinear, double kVAngular, double kAAngular, double trackwidth) {
+    m_plant =
+        LinearSystemId.identifyDrivetrainSystem(
+            kVLinear, kALinear, kVAngular, kAAngular, trackwidth);
+  }
+
+  public DifferentialDriveFeedforward(
+      double kVLinear, double kALinear, double kVAngular, double kAAngular) {
+    m_plant = LinearSystemId.identifyDrivetrainSystem(kVLinear, kALinear, kVAngular, kAAngular);
+  }
+
+  // need to add constructor which creates default trackwidth
+
+  public DifferentialDriveWheelVoltages calculate(
+      double currentLVelocity,
+      double nextLVelocity,
+      double currentRVelocity,
+      double nextRVelocity,
+      double dtSeconds) {
+
+    var feedforward = new LinearPlantInversionFeedforward<>(m_plant, dtSeconds);
+    var r = VecBuilder.fill(currentLVelocity, currentRVelocity);
+    var nextR = VecBuilder.fill(nextLVelocity, nextRVelocity);
+    var u = feedforward.calculate(r, nextR);
+    return new DifferentialDriveWheelVoltages(u.get(0, 0), u.get(1, 0));
+  }
+}

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveFeedforward.java
@@ -35,8 +35,8 @@ public class DifferentialDriveFeedforward {
    *
    * @param kVLinear The linear velocity gain in volts per (meters per second).
    * @param kALinear The linear acceleration gain in volts per (meters per second squared).
-   * @param kVAngular The angular velocity gain in volts per (radians per second).
-   * @param kAAngular The angular acceleration gain in volts per (radians per second squared).
+   * @param kVAngular The angular velocity gain in volts per (meters per second).
+   * @param kAAngular The angular acceleration gain in volts per (meters per second squared).
    */
   public DifferentialDriveFeedforward(
       double kVLinear, double kALinear, double kVAngular, double kAAngular) {

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/DifferentialDriveFeedforward.java
@@ -46,22 +46,24 @@ public class DifferentialDriveFeedforward {
   /**
    * Calculates the differential drive feedforward inputs given velocity setpoints.
    *
-   * @param currentLVelocity The current left velocity of the differential drive in meters/second.
-   * @param nextLVelocity The next left velocity of the differential drive in meters/second.
-   * @param currentRVelocity The current right velocity of the differential drive in meters/second.
-   * @param nextRVelocity The next right velocity of the differential drive in meters/second.
+   * @param currentLeftVelocity The current left velocity of the differential drive in
+   *     meters/second.
+   * @param nextLeftVelocity The next left velocity of the differential drive in meters/second.
+   * @param currentRightVelocity The current right velocity of the differential drive in
+   *     meters/second.
+   * @param nextRightVelocity The next right velocity of the differential drive in meters/second.
    * @param dtSeconds Discretization timestep.
    * @return A DifferentialDriveWheelVoltages object containing the computed feedforward voltages.
    */
   public DifferentialDriveWheelVoltages calculate(
-      double currentLVelocity,
-      double nextLVelocity,
-      double currentRVelocity,
-      double nextRVelocity,
+      double currentLeftVelocity,
+      double nextLeftVelocity,
+      double currentRightVelocity,
+      double nextRightVelocity,
       double dtSeconds) {
     var feedforward = new LinearPlantInversionFeedforward<>(m_plant, dtSeconds);
-    var r = VecBuilder.fill(currentLVelocity, currentRVelocity);
-    var nextR = VecBuilder.fill(nextLVelocity, nextRVelocity);
+    var r = VecBuilder.fill(currentLeftVelocity, currentRightVelocity);
+    var nextR = VecBuilder.fill(nextLeftVelocity, nextRightVelocity);
     var u = feedforward.calculate(r, nextR);
     return new DifferentialDriveWheelVoltages(u.get(0, 0), u.get(1, 0));
   }

--- a/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
+++ b/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
@@ -16,8 +16,5 @@ frc::DifferentialDriveFeedforward::Calculate(units::meters_per_second_t currentL
   frc::Vectord<2> r{currentLVelocity, currentRVelocity};
   frc::Vectord<2> nextR{nextLVelocity, nextRVelocity};
   auto u = feedforward.Calculate(r, nextR);
-  frc::DifferentialDriveWheelVoltages voltages;
-  voltages.left = units::volt_t{u[0]};
-  voltages.right = units::volt_t{u[1]};
-  return voltages;
+  return {units::volt_t{u(0)}, units::volt_t{u(1)}};
 }

--- a/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
+++ b/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
@@ -8,21 +8,22 @@
 #include "frc/controller/LinearPlantInversionFeedforward.h"
 #include "frc/system/plant/LinearSystemId.h"
 
-frc::DifferentialDriveFeedforward::DifferentialDriveFeedforward(
+using namespace frc;
+
+DifferentialDriveFeedforward::DifferentialDriveFeedforward(
     decltype(1_V / 1_mps) kVLinear, decltype(1_V / 1_mps_sq) kALinear,
     decltype(1_V / 1_rad_per_s) kVAngular,
     decltype(1_V / 1_rad_per_s_sq) kAAngular, units::meter_t trackwidth)
     : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
           kVLinear, kALinear, kVAngular, kAAngular, trackwidth)} {}
 
-frc::DifferentialDriveFeedforward::DifferentialDriveFeedforward(
+DifferentialDriveFeedforward::DifferentialDriveFeedforward(
     decltype(1_V / 1_mps) kVLinear, decltype(1_V / 1_mps_sq) kALinear,
     decltype(1_V / 1_mps) kVAngular, decltype(1_V / 1_mps_sq) kAAngular)
     : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
           kVLinear, kALinear, kVAngular, kAAngular)} {}
 
-frc::DifferentialDriveWheelVoltages
-frc::DifferentialDriveFeedforward::Calculate(
+DifferentialDriveWheelVoltages DifferentialDriveFeedforward::Calculate(
     units::meters_per_second_t currentLeftVelocity,
     units::meters_per_second_t nextLeftVelocity,
     units::meters_per_second_t currentRightVelocity,

--- a/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
+++ b/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
@@ -4,6 +4,10 @@
 
 #include "frc/controller/DifferentialDriveFeedforward.h"
 
+#include "frc/EigenCore.h"
+#include "frc/controller/LinearPlantInversionFeedforward.h"
+#include "frc/system/plant/LinearSystemId.h"
+
 frc::DifferentialDriveFeedforward::DifferentialDriveFeedforward(
     decltype(1_V / 1_mps) kVLinear, decltype(1_V / 1_mps_sq) kALinear,
     decltype(1_V / 1_rad_per_s) kVAngular,

--- a/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
+++ b/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
@@ -5,13 +5,12 @@
 #include "frc/controller/DifferentialDriveFeedforward.h"
 
 frc::DifferentialDriveWheelVoltages
-frc::DifferentialDriveFeedforward::Calculate(units::meters_per_second_t currentLVelocity,
-                                             units::meters_per_second_t nextLVelocity,
-                                             units::meters_per_second_t currentRVelocity,
-                                             units::meters_per_second_t nextRVelocity,
-                                             units::second_t dt) {
-  frc::LinearPlantInversionFeedforward<2, 2> feedforward{
-      m_plant, dt};
+frc::DifferentialDriveFeedforward::Calculate(
+    units::meters_per_second_t currentLVelocity,
+    units::meters_per_second_t nextLVelocity,
+    units::meters_per_second_t currentRVelocity,
+    units::meters_per_second_t nextRVelocity, units::second_t dt) {
+  frc::LinearPlantInversionFeedforward<2, 2> feedforward{m_plant, dt};
 
   frc::Vectord<2> r{currentLVelocity, currentRVelocity};
   frc::Vectord<2> nextR{nextLVelocity, nextRVelocity};

--- a/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
+++ b/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc/controller/DifferentialDriveFeedforward.h"
+
+frc::DifferentialDriveWheelVoltages
+frc::DifferentialDriveFeedforward::calculate(double currentLVelocity,
+                                             double nextLVelocity,
+                                             double currentRVelocity,
+                                             double nextRVelocity,
+                                             double dtSeconds) {
+  frc::LinearPlantInversionFeedforward<2, 2> feedforward{
+      frc::DifferentialDriveFeedforward::m_plant, units::second_t{dtSeconds}};
+
+  frc::Vectord<2> r{currentLVelocity, currentRVelocity};
+  frc::Vectord<2> nextR{nextLVelocity, nextRVelocity};
+  auto u = feedforward.Calculate(r, nextR);
+  frc::DifferentialDriveWheelVoltages voltages;
+  voltages.left = units::volt_t{u[0]};
+  voltages.right = units::volt_t{u[1]};
+  return voltages;
+}

--- a/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
+++ b/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
@@ -5,13 +5,13 @@
 #include "frc/controller/DifferentialDriveFeedforward.h"
 
 frc::DifferentialDriveWheelVoltages
-frc::DifferentialDriveFeedforward::calculate(double currentLVelocity,
+frc::DifferentialDriveFeedforward::Calculate(double currentLVelocity,
                                              double nextLVelocity,
                                              double currentRVelocity,
                                              double nextRVelocity,
-                                             double dtSeconds) {
+                                             units::second_t dtSeconds) {
   frc::LinearPlantInversionFeedforward<2, 2> feedforward{
-      frc::DifferentialDriveFeedforward::m_plant, units::second_t{dtSeconds}};
+      frc::DifferentialDriveFeedforward::m_plant, dtSeconds};
 
   frc::Vectord<2> r{currentLVelocity, currentRVelocity};
   frc::Vectord<2> nextR{nextLVelocity, nextRVelocity};

--- a/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
+++ b/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
@@ -4,6 +4,19 @@
 
 #include "frc/controller/DifferentialDriveFeedforward.h"
 
+frc::DifferentialDriveFeedforward::DifferentialDriveFeedforward(
+    decltype(1_V / 1_mps) kVLinear, decltype(1_V / 1_mps_sq) kALinear,
+    decltype(1_V / 1_rad_per_s) kVAngular,
+    decltype(1_V / 1_rad_per_s_sq) kAAngular, units::meter_t trackwidth)
+    : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
+          kVLinear, kALinear, kVAngular, kAAngular, trackwidth)} {}
+
+frc::DifferentialDriveFeedforward::DifferentialDriveFeedforward(
+    decltype(1_V / 1_mps) kVLinear, decltype(1_V / 1_mps_sq) kALinear,
+    decltype(1_V / 1_mps) kVAngular, decltype(1_V / 1_mps_sq) kAAngular)
+    : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
+          kVLinear, kALinear, kVAngular, kAAngular)} {}
+
 frc::DifferentialDriveWheelVoltages
 frc::DifferentialDriveFeedforward::Calculate(
     units::meters_per_second_t currentLeftVelocity,
@@ -17,16 +30,3 @@ frc::DifferentialDriveFeedforward::Calculate(
   auto u = feedforward.Calculate(r, nextR);
   return {units::volt_t{u(0)}, units::volt_t{u(1)}};
 }
-
-frc::DifferentialDriveFeedforward::DifferentialDriveFeedforward(
-    decltype(1_V / 1_mps) kVLinear, decltype(1_V / 1_mps_sq) kALinear,
-    decltype(1_V / 1_rad_per_s) kVAngular,
-    decltype(1_V / 1_rad_per_s_sq) kAAngular, units::meter_t trackwidth)
-    : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
-          kVLinear, kALinear, kVAngular, kAAngular, trackwidth)} {}
-
-frc::DifferentialDriveFeedforward::DifferentialDriveFeedforward(
-    decltype(1_V / 1_mps) kVLinear, decltype(1_V / 1_mps_sq) kALinear,
-    decltype(1_V / 1_mps) kVAngular, decltype(1_V / 1_mps_sq) kAAngular)
-    : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
-          kVLinear, kALinear, kVAngular, kAAngular)} {}

--- a/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
+++ b/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
@@ -5,13 +5,13 @@
 #include "frc/controller/DifferentialDriveFeedforward.h"
 
 frc::DifferentialDriveWheelVoltages
-frc::DifferentialDriveFeedforward::Calculate(double currentLVelocity,
-                                             double nextLVelocity,
-                                             double currentRVelocity,
-                                             double nextRVelocity,
-                                             units::second_t dtSeconds) {
+frc::DifferentialDriveFeedforward::Calculate(units::meters_per_second_t currentLVelocity,
+                                             units::meters_per_second_t nextLVelocity,
+                                             units::meters_per_second_t currentRVelocity,
+                                             units::meters_per_second_t nextRVelocity,
+                                             units::second_t dt) {
   frc::LinearPlantInversionFeedforward<2, 2> feedforward{
-      frc::DifferentialDriveFeedforward::m_plant, dtSeconds};
+      frc::DifferentialDriveFeedforward::m_plant, dt};
 
   frc::Vectord<2> r{currentLVelocity, currentRVelocity};
   frc::Vectord<2> nextR{nextLVelocity, nextRVelocity};

--- a/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
+++ b/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
@@ -11,7 +11,7 @@ frc::DifferentialDriveFeedforward::Calculate(units::meters_per_second_t currentL
                                              units::meters_per_second_t nextRVelocity,
                                              units::second_t dt) {
   frc::LinearPlantInversionFeedforward<2, 2> feedforward{
-      frc::DifferentialDriveFeedforward::m_plant, dt};
+      m_plant, dt};
 
   frc::Vectord<2> r{currentLVelocity, currentRVelocity};
   frc::Vectord<2> nextR{nextLVelocity, nextRVelocity};

--- a/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
+++ b/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
@@ -17,3 +17,16 @@ frc::DifferentialDriveFeedforward::Calculate(
   auto u = feedforward.Calculate(r, nextR);
   return {units::volt_t{u(0)}, units::volt_t{u(1)}};
 }
+
+frc::DifferentialDriveFeedforward::DifferentialDriveFeedforward(
+    decltype(1_V / 1_mps) kVLinear, decltype(1_V / 1_mps_sq) kALinear,
+    decltype(1_V / 1_rad_per_s) kVAngular,
+    decltype(1_V / 1_rad_per_s_sq) kAAngular, units::meter_t trackwidth)
+    : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
+          kVLinear, kALinear, kVAngular, kAAngular, trackwidth)} {}
+
+frc::DifferentialDriveFeedforward::DifferentialDriveFeedforward(
+    decltype(1_V / 1_mps) kVLinear, decltype(1_V / 1_mps_sq) kALinear,
+    decltype(1_V / 1_mps) kVAngular, decltype(1_V / 1_mps_sq) kAAngular)
+    : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
+          kVLinear, kALinear, kVAngular, kAAngular)} {}

--- a/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
+++ b/wpimath/src/main/native/cpp/controller/DifferentialDriveFeedforward.cpp
@@ -6,14 +6,14 @@
 
 frc::DifferentialDriveWheelVoltages
 frc::DifferentialDriveFeedforward::Calculate(
-    units::meters_per_second_t currentLVelocity,
-    units::meters_per_second_t nextLVelocity,
-    units::meters_per_second_t currentRVelocity,
-    units::meters_per_second_t nextRVelocity, units::second_t dt) {
+    units::meters_per_second_t currentLeftVelocity,
+    units::meters_per_second_t nextLeftVelocity,
+    units::meters_per_second_t currentRightVelocity,
+    units::meters_per_second_t nextRightVelocity, units::second_t dt) {
   frc::LinearPlantInversionFeedforward<2, 2> feedforward{m_plant, dt};
 
-  frc::Vectord<2> r{currentLVelocity, currentRVelocity};
-  frc::Vectord<2> nextR{nextLVelocity, nextRVelocity};
+  frc::Vectord<2> r{currentLeftVelocity, currentRightVelocity};
+  frc::Vectord<2> nextR{nextLeftVelocity, nextRightVelocity};
   auto u = feedforward.Calculate(r, nextR);
   return {units::volt_t{u(0)}, units::volt_t{u(1)}};
 }

--- a/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
+++ b/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
@@ -6,7 +6,6 @@
 
 #include <wpi/MathExtras.h>
 #include <wpi/SymbolExports.h>
-#include <units/velocity.h>
 
 #include "frc/EigenCore.h"
 #include "frc/controller/DifferentialDriveWheelVoltages.h"
@@ -14,6 +13,7 @@
 #include "frc/system/plant/LinearSystemId.h"
 #include "units/time.h"
 #include "units/voltage.h"
+#include "units/velocity.h"
 
 namespace frc {
 /**

--- a/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
+++ b/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
@@ -67,20 +67,20 @@ class WPILIB_DLLEXPORT DifferentialDriveFeedforward {
    * Calculates the differential drive feedforward inputs given velocity
    * setpoints.
    *
-   * @param currentLVelocity The current left velocity of the differential drive
-   * in meters/second.
-   * @param nextLVelocity The next left velocity of the differential drive in
-   * meters/second.
-   * @param currentRVelocity The current right velocity of the differential
+   * @param currentLeftVelocity The current left velocity of the differential
    * drive in meters/second.
-   * @param nextRVelocity The next right velocity of the differential drive in
+   * @param nextLeftVelocity The next left velocity of the differential drive in
    * meters/second.
+   * @param currentRightVelocity The current right velocity of the differential
+   * drive in meters/second.
+   * @param nextRightVelocity The next right velocity of the differential drive
+   * in meters/second.
    * @param dt Discretization timestep.
    */
   DifferentialDriveWheelVoltages Calculate(
-      units::meters_per_second_t currentLVelocity,
-      units::meters_per_second_t nextLVelocity,
-      units::meters_per_second_t currentRVelocity,
-      units::meters_per_second_t nextRVelocity, units::second_t dt);
+      units::meters_per_second_t currentLeftVelocity,
+      units::meters_per_second_t nextLeftVelocity,
+      units::meters_per_second_t currentRightVelocity,
+      units::meters_per_second_t nextRightVelocity, units::second_t dt);
 };
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
+++ b/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
@@ -1,0 +1,63 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <wpi/MathExtras.h>
+
+#include "frc/EigenCore.h"
+#include "frc/controller/DifferentialDriveWheelVoltages.h"
+#include "frc/controller/LinearPlantInversionFeedforward.h"
+#include "frc/system/plant/LinearSystemId.h"
+#include "units/time.h"
+#include "units/voltage.h"
+
+namespace frc {
+/** A helper class which computes the feedforward outputs for a differential
+ * drive drivetrain. */
+class DifferentialDriveFeedforward {
+  frc::LinearSystem<2, 2, 2> m_plant;
+
+ public:
+  /**
+   * Creates a new DifferentialDriveFeedforward with the specified parameters.
+   * @param kVLinear The linear velocity gain in volts per (meters per second).
+   * @param kALinear The linear acceleration gain in volts per (meters per
+   * second squared).
+   * @param kVAngular The angular velocity gain in volts per (radians per
+   * second).
+   * @param kAAngular The angular acceleration gain in volts per (radians per
+   * second squared).
+   * @param trackwidth The distance between the differential drive's left and
+   * right wheels, in meters.
+   */
+  DifferentialDriveFeedforward(double kVLinear, double kALinear,
+                               double kVAngular, double kAAngular,
+                               double trackwidth)
+      : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
+            units::volt_t{kVLinear} / 1_mps, units::volt_t{kALinear} / 1_mps_sq,
+            units::volt_t{kVAngular} / 1_rad_per_s,
+            units::volt_t{kAAngular} / 1_rad_per_s_sq,
+            units::meter_t{trackwidth})} {}
+
+  /**
+   * Calculates the differential drive feedforward inputs given velocity
+   * setpoints.
+   * @param currentLVelocity The current left velocity of the differential drive
+   * in meters/second.
+   * @param nextLVelocity The next left velocity of the differential drive in
+   * meters/second.
+   * @param currentRVelocity The current right velocity of the differential
+   * drive in meters/second.
+   * @param nextRVelocity The next right velocity of the differential drive in
+   * meters/second.
+   * @param dtSeconds Discretization timestep.
+   */
+  DifferentialDriveWheelVoltages calculate(double currentLVelocity,
+                                           double nextLVelocity,
+                                           double currentRVelocity,
+                                           double nextRVelocity,
+                                           double dtSeconds);
+};
+}  // namespace frc

--- a/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
+++ b/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
@@ -12,8 +12,8 @@
 #include "frc/controller/LinearPlantInversionFeedforward.h"
 #include "frc/system/plant/LinearSystemId.h"
 #include "units/time.h"
-#include "units/voltage.h"
 #include "units/velocity.h"
+#include "units/voltage.h"
 
 namespace frc {
 /**
@@ -37,14 +37,13 @@ class WPILIB_DLLEXPORT DifferentialDriveFeedforward {
    * @param trackwidth The distance between the differential drive's left and
    * right wheels, in meters.
    */
-  DifferentialDriveFeedforward(decltype(1_V / 1_mps) kVLinear, decltype(1_V / 1_mps_sq) kALinear,
-                               decltype(1_V / 1_rad_per_s) kVAngular, decltype(1_V / 1_rad_per_s_sq) kAAngular,
+  DifferentialDriveFeedforward(decltype(1_V / 1_mps) kVLinear,
+                               decltype(1_V / 1_mps_sq) kALinear,
+                               decltype(1_V / 1_rad_per_s) kVAngular,
+                               decltype(1_V / 1_rad_per_s_sq) kAAngular,
                                units::meter_t trackwidth)
       : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
-            kVLinear, kALinear,
-            kVAngular,
-            kAAngular,
-            trackwidth)} {}
+            kVLinear, kALinear, kVAngular, kAAngular, trackwidth)} {}
 
   /**
    * Calculates the differential drive feedforward inputs given velocity
@@ -60,10 +59,10 @@ class WPILIB_DLLEXPORT DifferentialDriveFeedforward {
    * meters/second.
    * @param dt Discretization timestep.
    */
-  DifferentialDriveWheelVoltages Calculate(units::meters_per_second_t currentLVelocity,
-                                           units::meters_per_second_t nextLVelocity,
-                                           units::meters_per_second_t currentRVelocity,
-                                           units::meters_per_second_t nextRVelocity,
-                                           units::second_t dt);
+  DifferentialDriveWheelVoltages Calculate(
+      units::meters_per_second_t currentLVelocity,
+      units::meters_per_second_t nextLVelocity,
+      units::meters_per_second_t currentRVelocity,
+      units::meters_per_second_t nextRVelocity, units::second_t dt);
 };
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
+++ b/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
@@ -41,9 +41,8 @@ class WPILIB_DLLEXPORT DifferentialDriveFeedforward {
                                decltype(1_V / 1_mps_sq) kALinear,
                                decltype(1_V / 1_rad_per_s) kVAngular,
                                decltype(1_V / 1_rad_per_s_sq) kAAngular,
-                               units::meter_t trackwidth)
-      : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
-            kVLinear, kALinear, kVAngular, kAAngular, trackwidth)} {}
+                               units::meter_t trackwidth);
+
   /**
    * Creates a new DifferentialDriveFeedforward with the specified parameters.
    *
@@ -55,13 +54,10 @@ class WPILIB_DLLEXPORT DifferentialDriveFeedforward {
    * @param kAAngular The angular acceleration gain in volts per (meters per
    * second squared).
    */
-
   DifferentialDriveFeedforward(decltype(1_V / 1_mps) kVLinear,
                                decltype(1_V / 1_mps_sq) kALinear,
                                decltype(1_V / 1_mps) kVAngular,
-                               decltype(1_V / 1_mps_sq) kAAngular)
-      : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
-            kVLinear, kALinear, kVAngular, kAAngular)} {}
+                               decltype(1_V / 1_mps_sq) kAAngular);
 
   /**
    * Calculates the differential drive feedforward inputs given velocity

--- a/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
+++ b/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
@@ -44,6 +44,24 @@ class WPILIB_DLLEXPORT DifferentialDriveFeedforward {
                                units::meter_t trackwidth)
       : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
             kVLinear, kALinear, kVAngular, kAAngular, trackwidth)} {}
+  /**
+   * Creates a new DifferentialDriveFeedforward with the specified parameters.
+   *
+   * @param kVLinear The linear velocity gain in volts per (meters per second).
+   * @param kALinear The linear acceleration gain in volts per (meters per
+   * second squared).
+   * @param kVAngular The angular velocity gain in volts per (meters per
+   * second).
+   * @param kAAngular The angular acceleration gain in volts per (meters per
+   * second squared).
+   */
+
+  DifferentialDriveFeedforward(decltype(1_V / 1_mps) kVLinear,
+                               decltype(1_V / 1_mps_sq) kALinear,
+                               decltype(1_V / 1_mps) kVAngular,
+                               decltype(1_V / 1_mps_sq) kAAngular)
+      : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
+            kVLinear, kALinear, kVAngular, kAAngular)} {}
 
   /**
    * Calculates the differential drive feedforward inputs given velocity

--- a/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
+++ b/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
@@ -14,8 +14,10 @@
 #include "units/voltage.h"
 
 namespace frc {
-/** A helper class which computes the feedforward outputs for a differential
- * drive drivetrain. */
+/**
+ * A helper class which computes the feedforward outputs for a differential
+ * drive drivetrain.
+ */
 class DifferentialDriveFeedforward {
   frc::LinearSystem<2, 2, 2> m_plant;
 

--- a/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
+++ b/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
@@ -4,13 +4,14 @@
 
 #pragma once
 
-#include <wpi/MathExtras.h>
 #include <wpi/SymbolExports.h>
 
-#include "frc/EigenCore.h"
 #include "frc/controller/DifferentialDriveWheelVoltages.h"
-#include "frc/controller/LinearPlantInversionFeedforward.h"
-#include "frc/system/plant/LinearSystemId.h"
+#include "frc/system/LinearSystem.h"
+#include "units/acceleration.h"
+#include "units/angular_acceleration.h"
+#include "units/angular_velocity.h"
+#include "units/length.h"
 #include "units/time.h"
 #include "units/velocity.h"
 #include "units/voltage.h"

--- a/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
+++ b/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
@@ -6,7 +6,7 @@
 
 #include <wpi/MathExtras.h>
 #include <wpi/SymbolExports.h>
-
+#include <units/velocity.h>
 
 #include "frc/EigenCore.h"
 #include "frc/controller/DifferentialDriveWheelVoltages.h"
@@ -37,13 +37,13 @@ class WPILIB_DLLEXPORT DifferentialDriveFeedforward {
    * @param trackwidth The distance between the differential drive's left and
    * right wheels, in meters.
    */
-  DifferentialDriveFeedforward(units::volt_t kVLinear, units::volt_t kALinear,
-                               units::volt_t kVAngular, units::volt_t kAAngular,
+  DifferentialDriveFeedforward(decltype(1_V / 1_mps) kVLinear, decltype(1_V / 1_mps_sq) kALinear,
+                               decltype(1_V / 1_rad_per_s) kVAngular, decltype(1_V / 1_rad_per_s_sq) kAAngular,
                                units::meter_t trackwidth)
       : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
-            kVLinear / 1_mps, kALinear / 1_mps_sq,
-            kVAngular / 1_rad_per_s,
-            kAAngular / 1_rad_per_s_sq,
+            kVLinear, kALinear,
+            kVAngular,
+            kAAngular,
             trackwidth)} {}
 
   /**
@@ -58,12 +58,12 @@ class WPILIB_DLLEXPORT DifferentialDriveFeedforward {
    * drive in meters/second.
    * @param nextRVelocity The next right velocity of the differential drive in
    * meters/second.
-   * @param dtSeconds Discretization timestep.
+   * @param dt Discretization timestep.
    */
-  DifferentialDriveWheelVoltages Calculate(double currentLVelocity,
-                                           double nextLVelocity,
-                                           double currentRVelocity,
-                                           double nextRVelocity,
-                                           units::second_t dtSeconds);
+  DifferentialDriveWheelVoltages Calculate(units::meters_per_second_t currentLVelocity,
+                                           units::meters_per_second_t nextLVelocity,
+                                           units::meters_per_second_t currentRVelocity,
+                                           units::meters_per_second_t nextRVelocity,
+                                           units::second_t dt);
 };
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
+++ b/wpimath/src/main/native/include/frc/controller/DifferentialDriveFeedforward.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <wpi/MathExtras.h>
+#include <wpi/SymbolExports.h>
+
 
 #include "frc/EigenCore.h"
 #include "frc/controller/DifferentialDriveWheelVoltages.h"
@@ -18,12 +20,13 @@ namespace frc {
  * A helper class which computes the feedforward outputs for a differential
  * drive drivetrain.
  */
-class DifferentialDriveFeedforward {
+class WPILIB_DLLEXPORT DifferentialDriveFeedforward {
   frc::LinearSystem<2, 2, 2> m_plant;
 
  public:
   /**
    * Creates a new DifferentialDriveFeedforward with the specified parameters.
+   *
    * @param kVLinear The linear velocity gain in volts per (meters per second).
    * @param kALinear The linear acceleration gain in volts per (meters per
    * second squared).
@@ -34,18 +37,19 @@ class DifferentialDriveFeedforward {
    * @param trackwidth The distance between the differential drive's left and
    * right wheels, in meters.
    */
-  DifferentialDriveFeedforward(double kVLinear, double kALinear,
-                               double kVAngular, double kAAngular,
-                               double trackwidth)
+  DifferentialDriveFeedforward(units::volt_t kVLinear, units::volt_t kALinear,
+                               units::volt_t kVAngular, units::volt_t kAAngular,
+                               units::meter_t trackwidth)
       : m_plant{frc::LinearSystemId::IdentifyDrivetrainSystem(
-            units::volt_t{kVLinear} / 1_mps, units::volt_t{kALinear} / 1_mps_sq,
-            units::volt_t{kVAngular} / 1_rad_per_s,
-            units::volt_t{kAAngular} / 1_rad_per_s_sq,
-            units::meter_t{trackwidth})} {}
+            kVLinear / 1_mps, kALinear / 1_mps_sq,
+            kVAngular / 1_rad_per_s,
+            kAAngular / 1_rad_per_s_sq,
+            trackwidth)} {}
 
   /**
    * Calculates the differential drive feedforward inputs given velocity
    * setpoints.
+   *
    * @param currentLVelocity The current left velocity of the differential drive
    * in meters/second.
    * @param nextLVelocity The next left velocity of the differential drive in
@@ -56,10 +60,10 @@ class DifferentialDriveFeedforward {
    * meters/second.
    * @param dtSeconds Discretization timestep.
    */
-  DifferentialDriveWheelVoltages calculate(double currentLVelocity,
+  DifferentialDriveWheelVoltages Calculate(double currentLVelocity,
                                            double nextLVelocity,
                                            double currentRVelocity,
                                            double nextRVelocity,
-                                           double dtSeconds);
+                                           units::second_t dtSeconds);
 };
 }  // namespace frc

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
@@ -43,7 +43,7 @@ class DifferentialDriveFeedforwardTest {
                     dtSeconds);
             // left drivetrain check
             assertEquals(y.get(0, 0), nLVelocity, 1e-6);
-            // right drivetrain check)
+            // right drivetrain check
             assertEquals(y.get(1, 0), nRVelocity, 1e-6);
           }
         }

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
@@ -29,22 +29,26 @@ class DifferentialDriveFeedforwardTest {
     LinearSystem<N2, N2, N2> plant =
         LinearSystemId.identifyDrivetrainSystem(
             kVLinear, kALinear, kVAngular, kAAngular, trackwidth);
-    for (int cLVelocity = -4; cLVelocity <= 4; cLVelocity += 2) {
-      for (int cRVelocity = -4; cRVelocity <= 4; cRVelocity += 2) {
-        for (int nLVelocity = -4; nLVelocity <= 4; nLVelocity += 2) {
-          for (int nRVelocity = -4; nRVelocity <= 4; nRVelocity += 2) {
+    for (int currentLeftVelocity = -4; currentLeftVelocity <= 4; currentLeftVelocity += 2) {
+      for (int currentRightVelocity = -4; currentRightVelocity <= 4; currentRightVelocity += 2) {
+        for (int nextLeftVelocity = -4; nextLeftVelocity <= 4; nextLeftVelocity += 2) {
+          for (int nextRightVelocity = -4; nextRightVelocity <= 4; nextRightVelocity += 2) {
             DifferentialDriveWheelVoltages u =
                 differentialDriveFeedforward.calculate(
-                    cLVelocity, nLVelocity, cRVelocity, nRVelocity, dtSeconds);
+                    currentLeftVelocity,
+                    nextLeftVelocity,
+                    currentRightVelocity,
+                    nextRightVelocity,
+                    dtSeconds);
             Matrix<N2, N1> y =
                 plant.calculateX(
-                    VecBuilder.fill(cLVelocity, cRVelocity),
+                    VecBuilder.fill(currentLeftVelocity, currentRightVelocity),
                     VecBuilder.fill(u.left, u.right),
                     dtSeconds);
             // left drivetrain check
-            assertEquals(y.get(0, 0), nLVelocity, 1e-6);
+            assertEquals(y.get(0, 0), nextLeftVelocity, 1e-6);
             // right drivetrain check
-            assertEquals(y.get(1, 0), nRVelocity, 1e-6);
+            assertEquals(y.get(1, 0), nextRightVelocity, 1e-6);
           }
         }
       }

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
@@ -77,10 +77,8 @@ class DifferentialDriveFeedforwardTest {
                     VecBuilder.fill(currentLeftVelocity, currentRightVelocity),
                     VecBuilder.fill(u.left, u.right),
                     dtSeconds);
-            // left drivetrain check
-            assertEquals(y.get(0, 0), nextLeftVelocity, 1e-6);
-            // right drivetrain check
-            assertEquals(y.get(1, 0), nextRightVelocity, 1e-6);
+            assertEquals(nextX.get(0, 0), nextLeftVelocity, 1e-6);
+            assertEquals(nextX.get(1, 0), nextRightVelocity, 1e-6);
           }
         }
       }

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
@@ -43,7 +43,7 @@ class DifferentialDriveFeedforwardTest {
                     dtSeconds);
             // left drivetrain check
             assertEquals(y.get(0, 0), nLVelocity, 1e-6);
-            // right drivetrain check);
+            // right drivetrain check)
             assertEquals(y.get(1, 0), nRVelocity, 1e-6);
           }
         }

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
@@ -40,7 +40,7 @@ class DifferentialDriveFeedforwardTest {
                     currentRightVelocity,
                     nextRightVelocity,
                     dtSeconds);
-            Matrix<N2, N1> y =
+            Matrix<N2, N1> nextX =
                 plant.calculateX(
                     VecBuilder.fill(currentLeftVelocity, currentRightVelocity),
                     VecBuilder.fill(u.left, u.right),

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
@@ -1,0 +1,46 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.controller.DifferentialDriveFeedforward;
+import edu.wpi.first.math.controller.DifferentialDriveWheelVoltages;
+import edu.wpi.first.math.numbers.*;
+import edu.wpi.first.math.system.LinearSystem;
+import edu.wpi.first.math.system.plant.LinearSystemId;
+import org.junit.jupiter.api.Test;
+
+class DifferentialDriveFeedforwardTest {
+  private final double kVLinear = 1.0;
+  private final double kALinear = 1.0;
+  private final double kVAngular = 1.0;
+  private final double kAAngular = 1.0;
+  private final double trackwidth = 1.0;
+  private final double dtSeconds = .02;
+
+  @Test
+  public void testCalculate() {
+    DifferentialDriveFeedforward differentialDriveFeedforward =
+        new DifferentialDriveFeedforward(kVLinear, kALinear, kVAngular, kAAngular, trackwidth);
+    LinearSystem<N2, N2, N2> plant =
+        LinearSystemId.identifyDrivetrainSystem(
+            kVLinear, kALinear, kVAngular, kAAngular, trackwidth);
+    for (int cLVelocity = -4; cLVelocity <= 4; cLVelocity += 2) {
+      for (int cRVelocity = -4; cRVelocity <= 4; cRVelocity += 2) {
+        for (int nLVelocity = -4; nLVelocity <= 4; nLVelocity += 2) {
+          for (int nRVelocity = -4; nRVelocity <= 4; nRVelocity += 2) {
+            DifferentialDriveWheelVoltages u =
+                differentialDriveFeedforward.calculate(
+                    cLVelocity, nLVelocity, cRVelocity, nRVelocity, dtSeconds);
+            Matrix<N2, N1> y =
+                plant.calculateY(
+                    VecBuilder.fill(cLVelocity, cRVelocity), VecBuilder.fill(u.left, u.right));
+            // left drivetrain check
+            assertEquals(y.get(0, 0), nLVelocity, 0.0);
+            // right drivetrain check);
+            assertEquals(y.get(1, 0), nRVelocity, 0.0);
+          }
+        }
+      }
+    }
+  }
+}

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
@@ -23,12 +23,44 @@ class DifferentialDriveFeedforwardTest {
   private static final double dtSeconds = 0.02;
 
   @Test
-  void testCalculate() {
+  void testCalculateWithTrackwidth() {
     DifferentialDriveFeedforward differentialDriveFeedforward =
         new DifferentialDriveFeedforward(kVLinear, kALinear, kVAngular, kAAngular, trackwidth);
     LinearSystem<N2, N2, N2> plant =
         LinearSystemId.identifyDrivetrainSystem(
             kVLinear, kALinear, kVAngular, kAAngular, trackwidth);
+    for (int currentLeftVelocity = -4; currentLeftVelocity <= 4; currentLeftVelocity += 2) {
+      for (int currentRightVelocity = -4; currentRightVelocity <= 4; currentRightVelocity += 2) {
+        for (int nextLeftVelocity = -4; nextLeftVelocity <= 4; nextLeftVelocity += 2) {
+          for (int nextRightVelocity = -4; nextRightVelocity <= 4; nextRightVelocity += 2) {
+            DifferentialDriveWheelVoltages u =
+                differentialDriveFeedforward.calculate(
+                    currentLeftVelocity,
+                    nextLeftVelocity,
+                    currentRightVelocity,
+                    nextRightVelocity,
+                    dtSeconds);
+            Matrix<N2, N1> y =
+                plant.calculateX(
+                    VecBuilder.fill(currentLeftVelocity, currentRightVelocity),
+                    VecBuilder.fill(u.left, u.right),
+                    dtSeconds);
+            // left drivetrain check
+            assertEquals(y.get(0, 0), nextLeftVelocity, 1e-6);
+            // right drivetrain check
+            assertEquals(y.get(1, 0), nextRightVelocity, 1e-6);
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  void testCalculateWithoutTrackwidth() {
+    DifferentialDriveFeedforward differentialDriveFeedforward =
+        new DifferentialDriveFeedforward(kVLinear, kALinear, kVAngular, kAAngular);
+    LinearSystem<N2, N2, N2> plant =
+        LinearSystemId.identifyDrivetrainSystem(kVLinear, kALinear, kVAngular, kAAngular);
     for (int currentLeftVelocity = -4; currentLeftVelocity <= 4; currentLeftVelocity += 2) {
       for (int currentRightVelocity = -4; currentRightVelocity <= 4; currentRightVelocity += 2) {
         for (int nextLeftVelocity = -4; nextLeftVelocity <= 4; nextLeftVelocity += 2) {

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
@@ -72,7 +72,7 @@ class DifferentialDriveFeedforwardTest {
                     currentRightVelocity,
                     nextRightVelocity,
                     dtSeconds);
-            Matrix<N2, N1> y =
+            Matrix<N2, N1> nextX =
                 plant.calculateX(
                     VecBuilder.fill(currentLeftVelocity, currentRightVelocity),
                     VecBuilder.fill(u.left, u.right),

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
@@ -45,10 +45,8 @@ class DifferentialDriveFeedforwardTest {
                     VecBuilder.fill(currentLeftVelocity, currentRightVelocity),
                     VecBuilder.fill(u.left, u.right),
                     dtSeconds);
-            // left drivetrain check
-            assertEquals(y.get(0, 0), nextLeftVelocity, 1e-6);
-            // right drivetrain check
-            assertEquals(y.get(1, 0), nextRightVelocity, 1e-6);
+            assertEquals(nextX.get(0, 0), nextLeftVelocity, 1e-6);
+            assertEquals(nextX.get(1, 0), nextRightVelocity, 1e-6);
           }
         }
       }

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/DifferentialDriveFeedforwardTest.java
@@ -1,24 +1,29 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.math.controller;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
-import edu.wpi.first.math.controller.DifferentialDriveFeedforward;
-import edu.wpi.first.math.controller.DifferentialDriveWheelVoltages;
-import edu.wpi.first.math.numbers.*;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N2;
 import edu.wpi.first.math.system.LinearSystem;
 import edu.wpi.first.math.system.plant.LinearSystemId;
 import org.junit.jupiter.api.Test;
 
 class DifferentialDriveFeedforwardTest {
-  private final double kVLinear = 1.0;
-  private final double kALinear = 1.0;
-  private final double kVAngular = 1.0;
-  private final double kAAngular = 1.0;
-  private final double trackwidth = 1.0;
-  private final double dtSeconds = .02;
+  private static final double kVLinear = 1.0;
+  private static final double kALinear = 1.0;
+  private static final double kVAngular = 1.0;
+  private static final double kAAngular = 1.0;
+  private static final double trackwidth = 1.0;
+  private static final double dtSeconds = 0.02;
 
   @Test
-  public void testCalculate() {
+  void testCalculate() {
     DifferentialDriveFeedforward differentialDriveFeedforward =
         new DifferentialDriveFeedforward(kVLinear, kALinear, kVAngular, kAAngular, trackwidth);
     LinearSystem<N2, N2, N2> plant =
@@ -32,12 +37,14 @@ class DifferentialDriveFeedforwardTest {
                 differentialDriveFeedforward.calculate(
                     cLVelocity, nLVelocity, cRVelocity, nRVelocity, dtSeconds);
             Matrix<N2, N1> y =
-                plant.calculateY(
-                    VecBuilder.fill(cLVelocity, cRVelocity), VecBuilder.fill(u.left, u.right));
+                plant.calculateX(
+                    VecBuilder.fill(cLVelocity, cRVelocity),
+                    VecBuilder.fill(u.left, u.right),
+                    dtSeconds);
             // left drivetrain check
-            assertEquals(y.get(0, 0), nLVelocity, 0.0);
+            assertEquals(y.get(0, 0), nLVelocity, 1e-6);
             // right drivetrain check);
-            assertEquals(y.get(1, 0), nRVelocity, 0.0);
+            assertEquals(y.get(1, 0), nRVelocity, 1e-6);
           }
         }
       }

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -15,27 +15,27 @@
 #include "units/time.h"
 
 TEST(DifferentialDriveFeedforwardTest, Calculate) {
-  double kVLinear = 1.0;
-  double kALinear = 1.0;
-  double kVAngular = 1.0;
-  double kAAngular = 1.0;
-  double trackwidth = 1.0;
-  double dtSeconds = 0.02;
+    units::volt_t kVLinear = units::volt_t{1.0};
+    units::volt_t kALinear = units::volt_t{1.0};
+    units::volt_t kVAngular = units::volt_t{1.0};
+    units::volt_t kAAngular = units::volt_t{1.0};
+    units::meter_t trackwidth = units::meter_t{1.0};
+    units::second_t dtSeconds = units::second_t{0.02};
 
   frc::DifferentialDriveFeedforward differentialDriveFeedforward{
       kVLinear, kALinear, kVAngular, kAAngular, trackwidth};
   frc::LinearSystem<2, 2, 2> plant =
       frc::LinearSystemId::IdentifyDrivetrainSystem(
-          units::volt_t{kVLinear} / 1_mps, units::volt_t{kALinear} / 1_mps_sq,
-          units::volt_t{kVAngular} / 1_rad_per_s,
-          units::volt_t{kAAngular} / 1_rad_per_s_sq,
-          units::meter_t{trackwidth});
+          kVLinear / 1_mps, kALinear / 1_mps_sq,
+          kVAngular / 1_rad_per_s,
+          kAAngular / 1_rad_per_s_sq,
+          trackwidth);
   for (int cLVelocity = -4; cLVelocity <= 4; cLVelocity += 2) {
     for (int cRVelocity = -4; cRVelocity <= 4; cRVelocity += 2) {
       for (int nLVelocity = -4; nLVelocity <= 4; nLVelocity += 2) {
         for (int nRVelocity = -4; nRVelocity <= 4; nRVelocity += 2) {
           frc::DifferentialDriveWheelVoltages u =
-              differentialDriveFeedforward.calculate(
+              differentialDriveFeedforward.Calculate(
                   cLVelocity, nLVelocity, cRVelocity, nRVelocity, dtSeconds);
           frc::Matrixd<2, 1> y = plant.CalculateX(
               frc::Vectord<2>{cLVelocity, cRVelocity},

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -15,12 +15,12 @@
 #include "units/time.h"
 
 TEST(DifferentialDriveFeedforwardTest, Calculate) {
-    units::volt_t kVLinear = units::volt_t{1.0};
-    units::volt_t kALinear = units::volt_t{1.0};
-    units::volt_t kVAngular = units::volt_t{1.0};
-    units::volt_t kAAngular = units::volt_t{1.0};
-    units::meter_t trackwidth = units::meter_t{1.0};
-    units::second_t dtSeconds = units::second_t{0.02};
+    auto kVLinear = 1_V / 1_mps;
+    auto kALinear = 1_v / 1_mps_sq;
+    auto kVAngular = 1_V / 1_rad_per_s;
+    auto kAAngular = 1_V / 1_rad_per_s_sq;
+    auto trackwidth = 1_m;
+    auto dt = 20_ms;
 
   frc::DifferentialDriveFeedforward differentialDriveFeedforward{
       kVLinear, kALinear, kVAngular, kAAngular, trackwidth};

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -35,13 +35,13 @@ TEST(DifferentialDriveFeedforwardTest, CalculateWithTrackwidth) {
            nextLeftVelocity += 2_mps) {
         for (auto nextRightVelocity = -4_mps; nextRightVelocity <= 4_mps;
              nextRightVelocity += 2_mps) {
-          frc::DifferentialDriveWheelVoltages u =
+          auto [left, right] =
               differentialDriveFeedforward.Calculate(
                   currentLeftVelocity, nextLeftVelocity, currentRightVelocity,
                   nextRightVelocity, dt);
           frc::Matrixd<2, 1> y = plant.CalculateX(
               frc::Vectord<2>{currentLeftVelocity, currentRightVelocity},
-              frc::Vectord<2>{u.left, u.right}, dt);
+              frc::Vectord<2>{left, right}, dt);
           // left drivetrain check
           EXPECT_NEAR(y(0), nextLeftVelocity.value(), 1e-6);
           // right drivetrain check

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -27,21 +27,25 @@ TEST(DifferentialDriveFeedforwardTest, Calculate) {
   frc::LinearSystem<2, 2, 2> plant =
       frc::LinearSystemId::IdentifyDrivetrainSystem(
           kVLinear, kALinear, kVAngular, kAAngular, trackwidth);
-  for (auto cLVelocity = -4_mps; cLVelocity <= 4_mps; cLVelocity += 2_mps) {
-    for (auto cRVelocity = -4_mps; cRVelocity <= 4_mps; cRVelocity += 2_mps) {
-      for (auto nLVelocity = -4_mps; nLVelocity <= 4_mps; nLVelocity += 2_mps) {
-        for (auto nRVelocity = -4_mps; nRVelocity <= 4_mps;
-             nRVelocity += 2_mps) {
+  for (auto currentLeftVelocity = -4_mps; currentLeftVelocity <= 4_mps;
+       currentLeftVelocity += 2_mps) {
+    for (auto currentRightVelocity = -4_mps; currentRightVelocity <= 4_mps;
+         currentRightVelocity += 2_mps) {
+      for (auto nextLeftVelocity = -4_mps; nextLeftVelocity <= 4_mps;
+           nextLeftVelocity += 2_mps) {
+        for (auto nextRightVelocity = -4_mps; nextRightVelocity <= 4_mps;
+             nextRightVelocity += 2_mps) {
           frc::DifferentialDriveWheelVoltages u =
               differentialDriveFeedforward.Calculate(
-                  cLVelocity, nLVelocity, cRVelocity, nRVelocity, dt);
-          frc::Matrixd<2, 1> y =
-              plant.CalculateX(frc::Vectord<2>{cLVelocity, cRVelocity},
-                               frc::Vectord<2>{u.left, u.right}, dt);
+                  currentLeftVelocity, nextLeftVelocity, currentRightVelocity,
+                  nextRightVelocity, dt);
+          frc::Matrixd<2, 1> y = plant.CalculateX(
+              frc::Vectord<2>{currentLeftVelocity, currentRightVelocity},
+              frc::Vectord<2>{u.left, u.right}, dt);
           // left drivetrain check
-          EXPECT_NEAR(y[0], double{nLVelocity}, 1e-6);
+          EXPECT_NEAR(y[0], double{nextLeftVelocity}, 1e-6);
           // right drivetrain check
-          EXPECT_NEAR(y[1], double{nRVelocity}, 1e-6);
+          EXPECT_NEAR(y[1], double{nextRightVelocity}, 1e-6);
         }
       }
     }

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -62,8 +62,8 @@ TEST(DifferentialDriveFeedforwardTest, CalculateWithoutTrackwidth) {
   frc::DifferentialDriveFeedforward differentialDriveFeedforward{
       kVLinear, kALinear, kVAngular, kAAngular};
   frc::LinearSystem<2, 2, 2> plant =
-      frc::LinearSystemId::IdentifyDrivetrainSystem(
-          kVLinear, kALinear, kVAngular, kAAngular);
+      frc::LinearSystemId::IdentifyDrivetrainSystem(kVLinear, kALinear,
+                                                    kVAngular, kAAngular);
   for (auto currentLeftVelocity = -4_mps; currentLeftVelocity <= 4_mps;
        currentLeftVelocity += 2_mps) {
     for (auto currentRightVelocity = -4_mps; currentRightVelocity <= 4_mps;

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -43,9 +43,9 @@ TEST(DifferentialDriveFeedforwardTest, CalculateWithTrackwidth) {
               frc::Vectord<2>{currentLeftVelocity, currentRightVelocity},
               frc::Vectord<2>{u.left, u.right}, dt);
           // left drivetrain check
-          EXPECT_NEAR(y[0], double{nextLeftVelocity}, 1e-6);
+          EXPECT_NEAR(y(0), nextLeftVelocity.value(), 1e-6);
           // right drivetrain check
-          EXPECT_NEAR(y[1], double{nextRightVelocity}, 1e-6);
+          EXPECT_NEAR(y(1), nextRightVelocity.value(), 1e-6);
         }
       }
     }

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -26,9 +26,9 @@ TEST(DifferentialDriveFeedforwardTest, Calculate) {
       kVLinear, kALinear, kVAngular, kAAngular, trackwidth};
   frc::LinearSystem<2, 2, 2> plant =
       frc::LinearSystemId::IdentifyDrivetrainSystem(
-          kVLinear / 1_mps, kALinear / 1_mps_sq,
-          kVAngular / 1_rad_per_s,
-          kAAngular / 1_rad_per_s_sq,
+          kVLinear, kALinear,
+          kVAngular,
+          kAAngular,
           trackwidth);
   for (int cLVelocity = -4; cLVelocity <= 4; cLVelocity += 2) {
     for (int cRVelocity = -4; cRVelocity <= 4; cRVelocity += 2) {

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -16,7 +16,7 @@
 
 TEST(DifferentialDriveFeedforwardTest, Calculate) {
     auto kVLinear = 1_V / 1_mps;
-    auto kALinear = 1_v / 1_mps_sq;
+    auto kALinear = 1_V / 1_mps_sq;
     auto kVAngular = 1_V / 1_rad_per_s;
     auto kAAngular = 1_V / 1_rad_per_s_sq;
     auto trackwidth = 1_m;
@@ -30,20 +30,20 @@ TEST(DifferentialDriveFeedforwardTest, Calculate) {
           kVAngular,
           kAAngular,
           trackwidth);
-  for (int cLVelocity = -4; cLVelocity <= 4; cLVelocity += 2) {
-    for (int cRVelocity = -4; cRVelocity <= 4; cRVelocity += 2) {
-      for (int nLVelocity = -4; nLVelocity <= 4; nLVelocity += 2) {
-        for (int nRVelocity = -4; nRVelocity <= 4; nRVelocity += 2) {
+  for (units::meters_per_second_t cLVelocity = -4_mps; cLVelocity <= 4_mps; cLVelocity += 2_mps) {
+    for (units::meters_per_second_t cRVelocity = -4_mps; cRVelocity <= 4_mps; cRVelocity += 2_mps) {
+      for (units::meters_per_second_t nLVelocity = -4_mps; nLVelocity <= 4_mps; nLVelocity += 2_mps) {
+        for (units::meters_per_second_t nRVelocity = -4_mps; nRVelocity <= 4_mps; nRVelocity += 2_mps) {
           frc::DifferentialDriveWheelVoltages u =
               differentialDriveFeedforward.Calculate(
-                  cLVelocity, nLVelocity, cRVelocity, nRVelocity, dtSeconds);
+                  cLVelocity, nLVelocity, cRVelocity, nRVelocity, dt);
           frc::Matrixd<2, 1> y = plant.CalculateX(
               frc::Vectord<2>{cLVelocity, cRVelocity},
-              frc::Vectord<2>{u.left, u.right}, units::second_t{dtSeconds});
+              frc::Vectord<2>{u.left, u.right}, dt);
           // left drivetrain check
-          EXPECT_NEAR(y[0], nLVelocity, 1e-6);
+          EXPECT_NEAR(y[0], double{nLVelocity}, 1e-6);
           // right drivetrain check
-          EXPECT_NEAR(y[1], nRVelocity, 1e-6);
+          EXPECT_NEAR(y[1], double{nRVelocity}, 1e-6);
         }
       }
     }

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -30,10 +30,10 @@ TEST(DifferentialDriveFeedforwardTest, Calculate) {
           kVAngular,
           kAAngular,
           trackwidth);
-  for (units::meters_per_second_t cLVelocity = -4_mps; cLVelocity <= 4_mps; cLVelocity += 2_mps) {
-    for (units::meters_per_second_t cRVelocity = -4_mps; cRVelocity <= 4_mps; cRVelocity += 2_mps) {
-      for (units::meters_per_second_t nLVelocity = -4_mps; nLVelocity <= 4_mps; nLVelocity += 2_mps) {
-        for (units::meters_per_second_t nRVelocity = -4_mps; nRVelocity <= 4_mps; nRVelocity += 2_mps) {
+  for (auto cLVelocity = -4_mps; cLVelocity <= 4_mps; cLVelocity += 2_mps) {
+    for (auto cRVelocity = -4_mps; cRVelocity <= 4_mps; cRVelocity += 2_mps) {
+      for (auto nLVelocity = -4_mps; nLVelocity <= 4_mps; nLVelocity += 2_mps) {
+        for (auto nRVelocity = -4_mps; nRVelocity <= 4_mps; nRVelocity += 2_mps) {
           frc::DifferentialDriveWheelVoltages u =
               differentialDriveFeedforward.Calculate(
                   cLVelocity, nLVelocity, cRVelocity, nRVelocity, dt);

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "frc/EigenCore.h"
+#include "frc/controller/DifferentialDriveFeedforward.h"
+#include "frc/controller/LinearPlantInversionFeedforward.h"
+#include "frc/system/plant/LinearSystemId.h"
+#include "units/acceleration.h"
+#include "units/length.h"
+#include "units/time.h"
+
+TEST(DifferentialDriveFeedforwardTest, Calculate) {
+  double kVLinear = 1.0;
+  double kALinear = 1.0;
+  double kVAngular = 1.0;
+  double kAAngular = 1.0;
+  double trackwidth = 1.0;
+  double dtSeconds = 0.02;
+
+  frc::DifferentialDriveFeedforward differentialDriveFeedforward{
+      kVLinear, kALinear, kVAngular, kAAngular, trackwidth};
+  frc::LinearSystem<2, 2, 2> plant =
+      frc::LinearSystemId::IdentifyDrivetrainSystem(
+          units::volt_t{kVLinear} / 1_mps, units::volt_t{kALinear} / 1_mps_sq,
+          units::volt_t{kVAngular} / 1_rad_per_s,
+          units::volt_t{kAAngular} / 1_rad_per_s_sq,
+          units::meter_t{trackwidth});
+  for (int cLVelocity = -4; cLVelocity <= 4; cLVelocity += 2) {
+    for (int cRVelocity = -4; cRVelocity <= 4; cRVelocity += 2) {
+      for (int nLVelocity = -4; nLVelocity <= 4; nLVelocity += 2) {
+        for (int nRVelocity = -4; nRVelocity <= 4; nRVelocity += 2) {
+          frc::DifferentialDriveWheelVoltages u =
+              differentialDriveFeedforward.calculate(
+                  cLVelocity, nLVelocity, cRVelocity, nRVelocity, dtSeconds);
+          frc::Matrixd<2, 1> y = plant.CalculateX(
+              frc::Vectord<2>{cLVelocity, cRVelocity},
+              frc::Vectord<2>{u.left, u.right}, units::second_t{dtSeconds});
+          // left drivetrain check
+          EXPECT_NEAR(y[0], nLVelocity, 1e-6);
+          // right drivetrain check
+          EXPECT_NEAR(y[1], nRVelocity, 1e-6);
+        }
+      }
+    }
+  }
+}

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -15,31 +15,29 @@
 #include "units/time.h"
 
 TEST(DifferentialDriveFeedforwardTest, Calculate) {
-    auto kVLinear = 1_V / 1_mps;
-    auto kALinear = 1_V / 1_mps_sq;
-    auto kVAngular = 1_V / 1_rad_per_s;
-    auto kAAngular = 1_V / 1_rad_per_s_sq;
-    auto trackwidth = 1_m;
-    auto dt = 20_ms;
+  auto kVLinear = 1_V / 1_mps;
+  auto kALinear = 1_V / 1_mps_sq;
+  auto kVAngular = 1_V / 1_rad_per_s;
+  auto kAAngular = 1_V / 1_rad_per_s_sq;
+  auto trackwidth = 1_m;
+  auto dt = 20_ms;
 
   frc::DifferentialDriveFeedforward differentialDriveFeedforward{
       kVLinear, kALinear, kVAngular, kAAngular, trackwidth};
   frc::LinearSystem<2, 2, 2> plant =
       frc::LinearSystemId::IdentifyDrivetrainSystem(
-          kVLinear, kALinear,
-          kVAngular,
-          kAAngular,
-          trackwidth);
+          kVLinear, kALinear, kVAngular, kAAngular, trackwidth);
   for (auto cLVelocity = -4_mps; cLVelocity <= 4_mps; cLVelocity += 2_mps) {
     for (auto cRVelocity = -4_mps; cRVelocity <= 4_mps; cRVelocity += 2_mps) {
       for (auto nLVelocity = -4_mps; nLVelocity <= 4_mps; nLVelocity += 2_mps) {
-        for (auto nRVelocity = -4_mps; nRVelocity <= 4_mps; nRVelocity += 2_mps) {
+        for (auto nRVelocity = -4_mps; nRVelocity <= 4_mps;
+             nRVelocity += 2_mps) {
           frc::DifferentialDriveWheelVoltages u =
               differentialDriveFeedforward.Calculate(
                   cLVelocity, nLVelocity, cRVelocity, nRVelocity, dt);
-          frc::Matrixd<2, 1> y = plant.CalculateX(
-              frc::Vectord<2>{cLVelocity, cRVelocity},
-              frc::Vectord<2>{u.left, u.right}, dt);
+          frc::Matrixd<2, 1> y =
+              plant.CalculateX(frc::Vectord<2>{cLVelocity, cRVelocity},
+                               frc::Vectord<2>{u.left, u.right}, dt);
           // left drivetrain check
           EXPECT_NEAR(y[0], double{nLVelocity}, 1e-6);
           // right drivetrain check

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -50,11 +50,11 @@ TEST(DifferentialDriveFeedforwardTest, CalculateWithTrackwidth) {
 }
 
 TEST(DifferentialDriveFeedforwardTest, CalculateWithoutTrackwidth) {
-  auto kVLinear = 1_V / 1_mps;
-  auto kALinear = 1_V / 1_mps_sq;
-  auto kVAngular = 1_V / 1_mps;
-  auto kAAngular = 1_V / 1_mps_sq;
-  auto dt = 20_ms;
+  constexpr auto kVLinear = 1_V / 1_mps;
+  constexpr auto kALinear = 1_V / 1_mps_sq;
+  constexpr auto kVAngular = 1_V / 1_mps;
+  constexpr auto kAAngular = 1_V / 1_mps_sq;
+  constexpr auto dt = 20_ms;
 
   frc::DifferentialDriveFeedforward differentialDriveFeedforward{
       kVLinear, kALinear, kVAngular, kAAngular};

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -38,13 +38,11 @@ TEST(DifferentialDriveFeedforwardTest, CalculateWithTrackwidth) {
           auto [left, right] = differentialDriveFeedforward.Calculate(
               currentLeftVelocity, nextLeftVelocity, currentRightVelocity,
               nextRightVelocity, dt);
-          frc::Matrixd<2, 1> y = plant.CalculateX(
+          frc::Matrixd<2, 1> nextX = plant.CalculateX(
               frc::Vectord<2>{currentLeftVelocity, currentRightVelocity},
               frc::Vectord<2>{left, right}, dt);
-          // left drivetrain check
-          EXPECT_NEAR(y(0), nextLeftVelocity.value(), 1e-6);
-          // right drivetrain check
-          EXPECT_NEAR(y(1), nextRightVelocity.value(), 1e-6);
+          EXPECT_NEAR(nextX(0), nextLeftVelocity.value(), 1e-6);
+          EXPECT_NEAR(nextX(1), nextRightVelocity.value(), 1e-6);
         }
       }
     }

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -74,13 +74,11 @@ TEST(DifferentialDriveFeedforwardTest, CalculateWithoutTrackwidth) {
           auto [left, right] = differentialDriveFeedforward.Calculate(
               currentLeftVelocity, nextLeftVelocity, currentRightVelocity,
               nextRightVelocity, dt);
-          frc::Matrixd<2, 1> y = plant.CalculateX(
+          frc::Matrixd<2, 1> nextX = plant.CalculateX(
               frc::Vectord<2>{currentLeftVelocity, currentRightVelocity},
               frc::Vectord<2>{left, right}, dt);
-          // left drivetrain check
-          EXPECT_NEAR(y(0), nextLeftVelocity.value(), 1e-6);
-          // right drivetrain check
-          EXPECT_NEAR(y(1), nextRightVelocity.value(), 1e-6);
+          EXPECT_NEAR(nextX(0), nextLeftVelocity.value(), 1e-6);
+          EXPECT_NEAR(nextX(1), nextRightVelocity.value(), 1e-6);
         }
       }
     }

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -72,13 +72,13 @@ TEST(DifferentialDriveFeedforwardTest, CalculateWithoutTrackwidth) {
            nextLeftVelocity += 2_mps) {
         for (auto nextRightVelocity = -4_mps; nextRightVelocity <= 4_mps;
              nextRightVelocity += 2_mps) {
-          frc::DifferentialDriveWheelVoltages u =
+          auto [left, right] =
               differentialDriveFeedforward.Calculate(
                   currentLeftVelocity, nextLeftVelocity, currentRightVelocity,
                   nextRightVelocity, dt);
           frc::Matrixd<2, 1> y = plant.CalculateX(
               frc::Vectord<2>{currentLeftVelocity, currentRightVelocity},
-              frc::Vectord<2>{u.left, u.right}, dt);
+              frc::Vectord<2>{left, right}, dt);
           // left drivetrain check
           EXPECT_NEAR(y(0), nextLeftVelocity.value(), 1e-6);
           // right drivetrain check

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -15,12 +15,12 @@
 #include "units/time.h"
 
 TEST(DifferentialDriveFeedforwardTest, CalculateWithTrackwidth) {
-  auto kVLinear = 1_V / 1_mps;
-  auto kALinear = 1_V / 1_mps_sq;
-  auto kVAngular = 1_V / 1_rad_per_s;
-  auto kAAngular = 1_V / 1_rad_per_s_sq;
-  auto trackwidth = 1_m;
-  auto dt = 20_ms;
+  constexpr auto kVLinear = 1_V / 1_mps;
+  constexpr auto kALinear = 1_V / 1_mps_sq;
+  constexpr auto kVAngular = 1_V / 1_rad_per_s;
+  constexpr auto kAAngular = 1_V / 1_rad_per_s_sq;
+  constexpr auto trackwidth = 1_m;
+  constexpr auto dt = 20_ms;
 
   frc::DifferentialDriveFeedforward differentialDriveFeedforward{
       kVLinear, kALinear, kVAngular, kAAngular, trackwidth};

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -80,9 +80,9 @@ TEST(DifferentialDriveFeedforwardTest, CalculateWithoutTrackwidth) {
               frc::Vectord<2>{currentLeftVelocity, currentRightVelocity},
               frc::Vectord<2>{u.left, u.right}, dt);
           // left drivetrain check
-          EXPECT_NEAR(y[0], double{nextLeftVelocity}, 1e-6);
+          EXPECT_NEAR(y(0), nextLeftVelocity.value(), 1e-6);
           // right drivetrain check
-          EXPECT_NEAR(y[1], double{nextRightVelocity}, 1e-6);
+          EXPECT_NEAR(y(1), nextRightVelocity.value(), 1e-6);
         }
       }
     }

--- a/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/DifferentialDriveFeedforwardTest.cpp
@@ -35,10 +35,9 @@ TEST(DifferentialDriveFeedforwardTest, CalculateWithTrackwidth) {
            nextLeftVelocity += 2_mps) {
         for (auto nextRightVelocity = -4_mps; nextRightVelocity <= 4_mps;
              nextRightVelocity += 2_mps) {
-          auto [left, right] =
-              differentialDriveFeedforward.Calculate(
-                  currentLeftVelocity, nextLeftVelocity, currentRightVelocity,
-                  nextRightVelocity, dt);
+          auto [left, right] = differentialDriveFeedforward.Calculate(
+              currentLeftVelocity, nextLeftVelocity, currentRightVelocity,
+              nextRightVelocity, dt);
           frc::Matrixd<2, 1> y = plant.CalculateX(
               frc::Vectord<2>{currentLeftVelocity, currentRightVelocity},
               frc::Vectord<2>{left, right}, dt);
@@ -72,10 +71,9 @@ TEST(DifferentialDriveFeedforwardTest, CalculateWithoutTrackwidth) {
            nextLeftVelocity += 2_mps) {
         for (auto nextRightVelocity = -4_mps; nextRightVelocity <= 4_mps;
              nextRightVelocity += 2_mps) {
-          auto [left, right] =
-              differentialDriveFeedforward.Calculate(
-                  currentLeftVelocity, nextLeftVelocity, currentRightVelocity,
-                  nextRightVelocity, dt);
+          auto [left, right] = differentialDriveFeedforward.Calculate(
+              currentLeftVelocity, nextLeftVelocity, currentRightVelocity,
+              nextRightVelocity, dt);
           frc::Matrixd<2, 1> y = plant.CalculateX(
               frc::Vectord<2>{currentLeftVelocity, currentRightVelocity},
               frc::Vectord<2>{left, right}, dt);


### PR DESCRIPTION
This PR implements DifferentialDriveFeedforward classes which wrap LinearPlantInversionFeedforward.

Closes #3899 