### PR TITLE
Reenable wpiutil jni check task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin' version '2023.0.0'
     id 'edu.wpi.first.wpilib.repositories.WPILibRepositoriesPlugin' version '2020.2'
     id 'edu.wpi.first.NativeUtils' apply false
-    id 'edu.wpi.first.GradleJni' version '1.0.0'
+    id 'edu.wpi.first.GradleJni' version '1.1.0'
     id 'edu.wpi.first.GradleVsCode'
     id 'idea'
     id 'visual-studio'

--- a/shared/jni/setupBuild.gradle
+++ b/shared/jni/setupBuild.gradle
@@ -104,6 +104,10 @@ model {
                 baseName = nativeName + 'jni'
             }
 
+            if (project.hasProperty('skipJniSymbols')) {
+                checkSkipSymbols = skipJniSymbols
+            }
+
             enableCheckTask !project.hasProperty('skipJniCheck')
             javaCompileTasks << compileJava
             jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.roborio)
@@ -146,6 +150,10 @@ model {
                 baseName = setBaseName + 'jni'
             } else {
                 baseName = nativeName + 'jni'
+            }
+
+            if (project.hasProperty('skipJniSymbols')) {
+                checkSkipSymbols = skipJniSymbols
             }
 
             enableCheckTask !project.hasProperty('skipJniCheck')

--- a/wpiutil/build.gradle
+++ b/wpiutil/build.gradle
@@ -2,7 +2,9 @@ apply from: "${rootDir}/shared/resources.gradle"
 
 ext {
     noWpiutil = true
-    skipJniCheck = true
+    skipJniSymbols = [
+        'Java_edu_wpi_first_util_CombinedRuntimeLoader_setDllDirectory'
+    ]
     baseId = 'wpiutil'
     groupId = 'edu.wpi.first.wpiutil'
 


### PR DESCRIPTION
New option was added to JNI plugin to allow skipping specific symbols. This let us generally reenable the check task in wpiutil.