### PR TITLE
[wpilibc] ShuffleboardComponent.WithProperties: Update type

### DIFF
--- a/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardComponent.h
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardComponent.h
@@ -37,8 +37,7 @@ class ShuffleboardComponent : public ShuffleboardComponentBase {
    * @param properties the properties for this component
    * @return this component
    */
-  Derived& WithProperties(
-      const wpi::StringMap<std::shared_ptr<nt::Value>>& properties);
+  Derived& WithProperties(const wpi::StringMap<nt::Value>& properties);
 
   /**
    * Sets the position of this component in the tab. This has no effect if this

--- a/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardComponent.inc
+++ b/wpilibc/src/main/native/include/frc/shuffleboard/ShuffleboardComponent.inc
@@ -21,7 +21,7 @@ ShuffleboardComponent<Derived>::ShuffleboardComponent(
 
 template <typename Derived>
 Derived& ShuffleboardComponent<Derived>::WithProperties(
-    const wpi::StringMap<std::shared_ptr<nt::Value>>& properties) {
+    const wpi::StringMap<nt::Value>& properties) {
   m_properties = properties;
   m_metadataDirty = true;
   return *static_cast<Derived*>(this);


### PR DESCRIPTION
ShuffleboardComponentBase::m_properties is now a StringMap<nt::Value>.