### PR TITLE
Allow unsetting a subsystem's default command

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -386,7 +386,8 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
    * registered. Default commands will run whenever there is no other command currently scheduled
    * that requires the subsystem. Default commands should be written to never end (i.e. their {@link
    * Command#isFinished()} method should return false), as they would simply be re-scheduled if they
-   * do. Default commands must also require their subsystem. Pass null as the command to unset the default command.
+   * do. Default commands must also require their subsystem. Pass null as the command to unset the
+   * default command.
    *
    * @param subsystem the subsystem whose default command will be set
    * @param defaultCommand the default command to associate with the subsystem

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -386,8 +386,7 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
    * registered. Default commands will run whenever there is no other command currently scheduled
    * that requires the subsystem. Default commands should be written to never end (i.e. their {@link
    * Command#isFinished()} method should return false), as they would simply be re-scheduled if they
-   * do. Default commands must also require their subsystem. Pass null as the command to unset the
-   * default command.
+   * do. Default commands must also require their subsystem.
    *
    * @param subsystem the subsystem whose default command will be set
    * @param defaultCommand the default command to associate with the subsystem
@@ -398,8 +397,7 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
       return;
     }
     if (defaultCommand == null) {
-      // Unset subsystem's default command.
-      m_subsystems.put(subsystem, null);
+      DriverStation.reportWarning("Tried to set a null default command", true);
       return;
     }
 
@@ -420,6 +418,22 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
     }
 
     m_subsystems.put(subsystem, defaultCommand);
+  }
+  
+  /**
+   * Removes the default command for a subsystem. The current default command will run until another
+   * command is scheduled that requires the subsystem, at which point the current default command
+   * will not be re-scheduled.
+   *
+   * @param subsystem the subsystem whose default command will be removed
+   */
+  public void removeDefaultCommand(Subsystem subsystem) {
+    if (subsystem == null) {
+      DriverStation.reportWarning("Tried to remove a default command for a null subsystem", true);
+      return;
+    }
+    
+    m_subsystems.put(subsystem, null);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -386,7 +386,7 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
    * registered. Default commands will run whenever there is no other command currently scheduled
    * that requires the subsystem. Default commands should be written to never end (i.e. their {@link
    * Command#isFinished()} method should return false), as they would simply be re-scheduled if they
-   * do. Default commands must also require their subsystem.
+   * do. Default commands must also require their subsystem. Pass null as the command to unset the default command.
    *
    * @param subsystem the subsystem whose default command will be set
    * @param defaultCommand the default command to associate with the subsystem
@@ -397,7 +397,8 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
       return;
     }
     if (defaultCommand == null) {
-      DriverStation.reportWarning("Tried to set a null default command", true);
+      // Unset subsystem's default command.
+      m_subsystems.put(subsystem, null);
       return;
     }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -423,7 +423,7 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
 
     m_subsystems.put(subsystem, defaultCommand);
   }
-  
+
   /**
    * Removes the default command for a subsystem. The current default command will run until another
    * command is scheduled that requires the subsystem, at which point the current default command
@@ -436,7 +436,7 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
       DriverStation.reportWarning("Tried to remove a default command for a null subsystem", true);
       return;
     }
-    
+
     m_subsystems.put(subsystem, null);
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -367,6 +367,10 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
         DriverStation.reportWarning("Tried to register a null subsystem", true);
         continue;
       }
+      if (m_subsystems.containsKey(subsystem)) {
+        DriverStation.reportWarning("Tried to register an already-registered subsystem", true);
+        continue;
+      }
       m_subsystems.put(subsystem, null);
     }
   }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -258,6 +258,12 @@ void CommandScheduler::Run() {
 }
 
 void CommandScheduler::RegisterSubsystem(Subsystem* subsystem) {
+  auto s = m_impl->subsystems.find(subsystem);
+  if (s != m_impl->subsystems.end()) {
+    std::puts("Tried to register an already-registered subsystem");
+    return;
+  }
+
   m_impl->subsystems[subsystem] = nullptr;
 }
 
@@ -308,6 +314,10 @@ void CommandScheduler::SetDefaultCommand(Subsystem* subsystem,
   }
 
   SetDefaultCommandImpl(subsystem, std::move(defaultCommand).Unwrap());
+}
+
+void CommandScheduler::RemoveDefaultCommand(Subsystem* subsystem) {
+  m_impl->subsystems[subsystem] = nullptr;
 }
 
 Command* CommandScheduler::GetDefaultCommand(const Subsystem* subsystem) const {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -258,8 +258,7 @@ void CommandScheduler::Run() {
 }
 
 void CommandScheduler::RegisterSubsystem(Subsystem* subsystem) {
-  auto s = m_impl->subsystems.find(subsystem);
-  if (s != m_impl->subsystems.end()) {
+  if (m_impl->subsystems.find(subsystem) != m_impl->subsystems.end()) {
     std::puts("Tried to register an already-registered subsystem");
     return;
   }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -205,6 +205,15 @@ class CommandScheduler final : public nt::NTSendable,
   void SetDefaultCommand(Subsystem* subsystem, CommandPtr&& defaultCommand);
 
   /**
+   * Removes the default command for a subsystem. The current default command
+   * will run until another command is scheduled that requires the subsystem, at
+   * which point the current default command will not be re-scheduled.
+   *
+   * @param subsystem the subsystem whose default command will be removed
+   */
+  void RemoveDefaultCommand(Subsystem* subsystem);
+
+  /**
    * Gets the default command associated with this subsystem.  Null if this
    * subsystem has no default command associated with it.
    *


### PR DESCRIPTION
Changes the behavior so calling `setDefaultCommand(subsystem, null)` unsets the default command of `subsystem`. I realize that calling `register` on the `subsystem` does the same thing, but this behavior is more explicit and intuitive.

I don't know how to do the C++ translation...