### PR TITLE
Provide mechanism to reset internals of NT instance

### DIFF
--- a/ntcore/src/main/native/cpp/InstanceImpl.cpp
+++ b/ntcore/src/main/native/cpp/InstanceImpl.cpp
@@ -183,6 +183,6 @@ void InstanceImpl::Reset() {
   networkMode = NT_NET_MODE_NONE;
 
   listenerStorage.Reset();
-  //connectionList should have been cleared by destroying networkClient/server
+  // connectionList should have been cleared by destroying networkClient/server
   localStorage.Reset();
 }

--- a/ntcore/src/main/native/cpp/InstanceImpl.cpp
+++ b/ntcore/src/main/native/cpp/InstanceImpl.cpp
@@ -174,3 +174,15 @@ std::shared_ptr<INetworkClient> InstanceImpl::GetClient() {
   std::scoped_lock lock{m_mutex};
   return m_networkClient;
 }
+
+void InstanceImpl::Reset() {
+  std::scoped_lock lock{m_mutex};
+  m_networkServer.reset();
+  m_networkClient.reset();
+  m_servers.clear();
+  networkMode = NT_NET_MODE_NONE;
+
+  listenerStorage.Reset();
+  //connectionList should have been cleared by destroying networkClient/server
+  localStorage.Reset();
+}

--- a/ntcore/src/main/native/cpp/InstanceImpl.h
+++ b/ntcore/src/main/native/cpp/InstanceImpl.h
@@ -56,6 +56,8 @@ class InstanceImpl {
   std::shared_ptr<NetworkServer> GetServer();
   std::shared_ptr<INetworkClient> GetClient();
 
+  void Reset();
+
   ListenerStorage listenerStorage;
   LoggerImpl logger_impl;
   wpi::Logger logger;

--- a/ntcore/src/main/native/cpp/ListenerStorage.cpp
+++ b/ntcore/src/main/native/cpp/ListenerStorage.cpp
@@ -320,6 +320,19 @@ bool ListenerStorage::WaitForListenerQueue(double timeout) {
   return wpi::WaitForObject(h, timeout, &timedOut);
 }
 
+void ListenerStorage::Reset() {
+  std::scoped_lock lock{m_mutex};
+  m_pollers.clear();
+  m_listeners.clear();
+  m_connListeners.clear();
+  m_topicListeners.clear();
+  m_valueListeners.clear();
+  m_logListeners.clear();
+  if (m_thread) {
+    m_thread.Stop();
+  }
+}
+
 std::vector<std::pair<NT_Listener, unsigned int>>
 ListenerStorage::DoRemoveListeners(std::span<const NT_Listener> handles) {
   std::vector<std::pair<NT_Listener, unsigned int>> rv;

--- a/ntcore/src/main/native/cpp/ListenerStorage.h
+++ b/ntcore/src/main/native/cpp/ListenerStorage.h
@@ -59,6 +59,8 @@ class ListenerStorage final : public IListenerStorage {
 
   bool WaitForListenerQueue(double timeout);
 
+  void Reset();
+
  private:
   // these assume the mutex is already held
   NT_Listener DoAddListener(NT_ListenerPoller pollerHandle);

--- a/ntcore/src/main/native/cpp/LocalStorage.cpp
+++ b/ntcore/src/main/native/cpp/LocalStorage.cpp
@@ -2187,3 +2187,8 @@ void LocalStorage::StopDataLog(NT_DataLogger logger) {
     }
   }
 }
+
+void LocalStorage::Reset() {
+  std::scoped_lock lock{m_mutex};
+  m_impl = std::make_unique<Impl>(m_impl->m_inst, m_impl->m_listenerStorage, m_impl->m_logger);
+}

--- a/ntcore/src/main/native/cpp/LocalStorage.cpp
+++ b/ntcore/src/main/native/cpp/LocalStorage.cpp
@@ -2190,5 +2190,6 @@ void LocalStorage::StopDataLog(NT_DataLogger logger) {
 
 void LocalStorage::Reset() {
   std::scoped_lock lock{m_mutex};
-  m_impl = std::make_unique<Impl>(m_impl->m_inst, m_impl->m_listenerStorage, m_impl->m_logger);
+  m_impl = std::make_unique<Impl>(m_impl->m_inst, m_impl->m_listenerStorage,
+                                  m_impl->m_logger);
 }

--- a/ntcore/src/main/native/cpp/LocalStorage.h
+++ b/ntcore/src/main/native/cpp/LocalStorage.h
@@ -209,6 +209,8 @@ class LocalStorage final : public net::ILocalStorage {
                              std::string_view logPrefix);
   void StopDataLog(NT_DataLogger logger);
 
+  void Reset();
+
  private:
   class Impl;
   std::unique_ptr<Impl> m_impl;

--- a/ntcore/src/main/native/cpp/ntcore_cpp.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_cpp.cpp
@@ -45,8 +45,7 @@ NT_Inst CreateInstance() {
   return Handle{InstanceImpl::Alloc(), 0, Handle::kInstance};
 }
 
-void ResetInstance(NT_Inst inst)
-{
+void ResetInstance(NT_Inst inst) {
   if (auto ii = InstanceImpl::GetTyped(inst, Handle::kInstance)) {
     ii->Reset();
   }

--- a/ntcore/src/main/native/cpp/ntcore_cpp.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_cpp.cpp
@@ -45,6 +45,13 @@ NT_Inst CreateInstance() {
   return Handle{InstanceImpl::Alloc(), 0, Handle::kInstance};
 }
 
+void ResetInstance(NT_Inst inst)
+{
+  if (auto ii = InstanceImpl::GetTyped(inst, Handle::kInstance)) {
+    ii->Reset();
+  }
+}
+
 void DestroyInstance(NT_Inst inst) {
   int i = Handle{inst}.GetTypedInst(Handle::kInstance);
   if (i < 0) {

--- a/ntcore/src/main/native/include/ntcore_cpp.h
+++ b/ntcore/src/main/native/include/ntcore_cpp.h
@@ -349,6 +349,13 @@ NT_Inst GetDefaultInstance();
 NT_Inst CreateInstance();
 
 /**
+ * Reset the internals of an instance. Every handle previously associated
+ * with this instance will no longer be valid, except for the instance
+ * handle.
+ */
+void ResetInstance(NT_Inst inst);
+
+/**
  * Destroy an instance.
  * The default instance cannot be destroyed.
  *

--- a/ntcore/src/test/native/cpp/NetworkTableTest.cpp
+++ b/ntcore/src/test/native/cpp/NetworkTableTest.cpp
@@ -89,3 +89,15 @@ TEST_F(NetworkTableTest, EmptyOrNoSlash) {
   ASSERT_TRUE(inst.GetEntry("/testkey").Exists());
   nt::NetworkTableInstance::Destroy(inst);
 }
+
+TEST_F(NetworkTableTest, ResetInstance) {
+  auto inst = nt::NetworkTableInstance::Create();
+  auto nt = inst.GetTable("containskey");
+  ASSERT_FALSE(nt->ContainsKey("testkey"));
+  nt->PutNumber("testkey", 5);
+  ASSERT_TRUE(nt->ContainsKey("testkey"));
+  ASSERT_TRUE(inst.GetEntry("/containskey/testkey").Exists());
+  nt::ResetInstance(inst.GetHandle());
+  ASSERT_FALSE(nt->ContainsKey("testkey"));
+  nt::NetworkTableInstance::Destroy(inst);
+}


### PR DESCRIPTION
Let's talk about this. I need some way to reset the contents of the default NT instance. pyfrc runs the robot code over and over again, and it seems reasonable that for each test NT has nothing in it.

Alternatives:

* Accessing InstanceImpl via shared_ptr and resetting that (rejected)
* Adding a reader/writer lock over the instanceimpl array of instances, but it feels like that would have a lot more overhead than the other one