### PR TITLE
[cscore] Add Arducam OV9281 exposure quirk

### DIFF
--- a/cscore/src/main/native/linux/UsbCameraImpl.h
+++ b/cscore/src/main/native/linux/UsbCameraImpl.h
@@ -161,6 +161,7 @@ class UsbCameraImpl : public SourceImpl {
   // Quirks
   bool m_lifecam_exposure{false};    // Microsoft LifeCam exposure
   bool m_ps3eyecam_exposure{false};  // PS3 Eyecam exposure
+  bool m_ov9281_exposure{false};     // Arducam OV9281 exposure
   bool m_picamera{false};            // Raspberry Pi camera
 
   //


### PR DESCRIPTION
Reports exposure range as 1-5000 but real range is 1-75.