### PR TITLE
[glass] Don't check IsConnected for NT widgets

### DIFF
--- a/glass/src/libnt/native/cpp/NTCommandScheduler.cpp
+++ b/glass/src/libnt/native/cpp/NTCommandScheduler.cpp
@@ -43,5 +43,5 @@ void NTCommandSchedulerModel::Update() {
 }
 
 bool NTCommandSchedulerModel::Exists() {
-  return m_inst.IsConnected() && m_commands.Exists();
+  return m_commands.Exists();
 }

--- a/glass/src/libnt/native/cpp/NTCommandSelector.cpp
+++ b/glass/src/libnt/native/cpp/NTCommandSelector.cpp
@@ -37,5 +37,5 @@ void NTCommandSelectorModel::Update() {
 }
 
 bool NTCommandSelectorModel::Exists() {
-  return m_inst.IsConnected() && m_running.Exists();
+  return m_running.Exists();
 }

--- a/glass/src/libnt/native/cpp/NTDifferentialDrive.cpp
+++ b/glass/src/libnt/native/cpp/NTDifferentialDrive.cpp
@@ -56,5 +56,5 @@ void NTDifferentialDriveModel::Update() {
 }
 
 bool NTDifferentialDriveModel::Exists() {
-  return m_inst.IsConnected() && m_lPercent.Exists();
+  return m_lPercent.Exists();
 }

--- a/glass/src/libnt/native/cpp/NTDigitalInput.cpp
+++ b/glass/src/libnt/native/cpp/NTDigitalInput.cpp
@@ -33,5 +33,5 @@ void NTDigitalInputModel::Update() {
 }
 
 bool NTDigitalInputModel::Exists() {
-  return m_inst.IsConnected() && m_value.Exists();
+  return m_value.Exists();
 }

--- a/glass/src/libnt/native/cpp/NTDigitalOutput.cpp
+++ b/glass/src/libnt/native/cpp/NTDigitalOutput.cpp
@@ -40,5 +40,5 @@ void NTDigitalOutputModel::Update() {
 }
 
 bool NTDigitalOutputModel::Exists() {
-  return m_inst.IsConnected() && m_value.Exists();
+  return m_value.Exists();
 }

--- a/glass/src/libnt/native/cpp/NTFMS.cpp
+++ b/glass/src/libnt/native/cpp/NTFMS.cpp
@@ -73,5 +73,5 @@ void NTFMSModel::Update() {
 }
 
 bool NTFMSModel::Exists() {
-  return m_inst.IsConnected() && m_controlWord.Exists();
+  return m_controlWord.Exists();
 }

--- a/glass/src/libnt/native/cpp/NTField2D.cpp
+++ b/glass/src/libnt/native/cpp/NTField2D.cpp
@@ -171,7 +171,7 @@ void NTField2DModel::Update() {
 }
 
 bool NTField2DModel::Exists() {
-  return m_inst.IsConnected() && m_nameTopic.Exists();
+  return m_nameTopic.Exists();
 }
 
 bool NTField2DModel::IsReadOnly() {

--- a/glass/src/libnt/native/cpp/NTGyro.cpp
+++ b/glass/src/libnt/native/cpp/NTGyro.cpp
@@ -30,5 +30,5 @@ void NTGyroModel::Update() {
 }
 
 bool NTGyroModel::Exists() {
-  return m_inst.IsConnected() && m_angle.Exists();
+  return m_angle.Exists();
 }

--- a/glass/src/libnt/native/cpp/NTMecanumDrive.cpp
+++ b/glass/src/libnt/native/cpp/NTMecanumDrive.cpp
@@ -81,5 +81,5 @@ void NTMecanumDriveModel::Update() {
 }
 
 bool NTMecanumDriveModel::Exists() {
-  return m_inst.IsConnected() && m_flPercent.Exists();
+  return m_flPercent.Exists();
 }

--- a/glass/src/libnt/native/cpp/NTMechanism2D.cpp
+++ b/glass/src/libnt/native/cpp/NTMechanism2D.cpp
@@ -335,7 +335,7 @@ void NTMechanism2DModel::Update() {
 }
 
 bool NTMechanism2DModel::Exists() {
-  return m_inst.IsConnected() && m_nameTopic.Exists();
+  return m_nameTopic.Exists();
 }
 
 bool NTMechanism2DModel::IsReadOnly() {

--- a/glass/src/libnt/native/cpp/NTPIDController.cpp
+++ b/glass/src/libnt/native/cpp/NTPIDController.cpp
@@ -70,5 +70,5 @@ void NTPIDControllerModel::Update() {
 }
 
 bool NTPIDControllerModel::Exists() {
-  return m_inst.IsConnected() && m_setpoint.Exists();
+  return m_setpoint.Exists();
 }

--- a/glass/src/libnt/native/cpp/NTSpeedController.cpp
+++ b/glass/src/libnt/native/cpp/NTSpeedController.cpp
@@ -40,5 +40,5 @@ void NTSpeedControllerModel::Update() {
 }
 
 bool NTSpeedControllerModel::Exists() {
-  return m_inst.IsConnected() && m_value.Exists();
+  return m_value.Exists();
 }

--- a/glass/src/libnt/native/cpp/NTStringChooser.cpp
+++ b/glass/src/libnt/native/cpp/NTStringChooser.cpp
@@ -60,5 +60,5 @@ void NTStringChooserModel::Update() {
 }
 
 bool NTStringChooserModel::Exists() {
-  return m_inst.IsConnected() && m_options.Exists();
+  return m_options.Exists();
 }

--- a/glass/src/libnt/native/cpp/NTSubsystem.cpp
+++ b/glass/src/libnt/native/cpp/NTSubsystem.cpp
@@ -34,5 +34,5 @@ void NTSubsystemModel::Update() {
 }
 
 bool NTSubsystemModel::Exists() {
-  return m_inst.IsConnected() && m_defaultCommand.Exists();
+  return m_defaultCommand.Exists();
 }

--- a/glass/src/libnt/native/cpp/NetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTables.cpp
@@ -552,7 +552,7 @@ void NetworkTablesModel::RebuildTreeImpl(std::vector<TreeNode>* tree,
 }
 
 bool NetworkTablesModel::Exists() {
-  return m_inst.IsConnected();
+  return true;
 }
 
 NetworkTablesModel::Entry* NetworkTablesModel::GetEntry(std::string_view name) {


### PR DESCRIPTION
Checking this isn't required, and prevented these widgets from working in the simulation GUI without another NT client connected.

Fixes wpilibsuite/BetaTest#107.