### PR TITLE
[java cmd] Rename wait factory to waitSeconds

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -100,7 +100,7 @@ public final class Commands {
    * @return the command
    * @see WaitCommand
    */
-  public static CommandBase wait(double seconds) {
+  public static CommandBase waitSeconds(double seconds) {
     return new WaitCommand(seconds);
   }
 


### PR DESCRIPTION
Renaming to avoid confusion with `Object.wait(long)`. C++ doesn't have this problem.