### PR TITLE
Tweak and use Color HSV formula for AddressableLED

### DIFF
--- a/wpilibc/src/main/native/include/frc/util/Color.h
+++ b/wpilibc/src/main/native/include/frc/util/Color.h
@@ -782,10 +782,10 @@ class Color {
     int chroma = (s * v) >> 8;
 
     // Beacuse hue is 0-180 rather than 0-360 use 30 not 60
-    int region = h / 30;
+    int region = (h / 30) % 6;
 
-    // Remainder converted from 0-30 to roughly 0-255
-    int remainder = (h - (region * 30)) * 9;
+    // Remainder converted from 0-30 to 0-255
+    int remainder = static_cast<int>((h % 30) * (255 / 30.0));
 
     // Value of the lowest rgb component
     int m = v - chroma;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AddressableLEDBuffer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AddressableLEDBuffer.java
@@ -59,7 +59,7 @@ public class AddressableLEDBuffer {
     // that changes (X) from low to high (X+m) or high to low (v-X)
 
     // Difference between highest and lowest value of any rgb component
-    final int chroma = (s * v) >> 8;
+    final int chroma = (s * v) / 255;
 
     // Beacuse hue is 0-180 rather than 0-360 use 30 not 60
     final int region = (h / 30) % 6;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AddressableLEDBuffer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AddressableLEDBuffer.java
@@ -39,43 +39,12 @@ public class AddressableLEDBuffer {
    * Sets a specific led in the buffer.
    *
    * @param index the index to write
-   * @param h the h value [0-180]
+   * @param h the h value [0-180)
    * @param s the s value [0-255]
    * @param v the v value [0-255]
    */
   public void setHSV(final int index, final int h, final int s, final int v) {
-    if (s == 0) {
-      setRGB(index, v, v, v);
-      return;
-    }
-
-    final int region = h / 30;
-    final int remainder = (h - (region * 30)) * 6;
-
-    final int p = (v * (255 - s)) >> 8;
-    final int q = (v * (255 - ((s * remainder) >> 8))) >> 8;
-    final int t = (v * (255 - ((s * (255 - remainder)) >> 8))) >> 8;
-
-    switch (region) {
-      case 0:
-        setRGB(index, v, t, p);
-        break;
-      case 1:
-        setRGB(index, q, v, p);
-        break;
-      case 2:
-        setRGB(index, p, v, t);
-        break;
-      case 3:
-        setRGB(index, p, q, v);
-        break;
-      case 4:
-        setRGB(index, t, p, v);
-        break;
-      default:
-        setRGB(index, v, p, q);
-        break;
-    }
+    setLED(index, Color.fromHSV(h, s, v));
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AddressableLEDBuffer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AddressableLEDBuffer.java
@@ -92,6 +92,7 @@ public class AddressableLEDBuffer {
       default:
         setRGB(index, v, m, v - X);
         break;
+    }
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
@@ -85,7 +85,7 @@ public class Color {
     // that changes (X) from low to high (X+m) or high to low (v-X)
 
     // Difference between highest and lowest value of any rgb component
-    final int chroma = (s * v) >> 8;
+    final int chroma = (s * v) / 255;
 
     // Beacuse hue is 0-180 rather than 0-360 use 30 not 60
     final int region = (h / 30) % 6;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
@@ -90,7 +90,7 @@ public class Color {
     // Beacuse hue is 0-180 rather than 0-360 use 30 not 60
     final int region = (h / 30) % 6;
 
-    // Remainder converted from 0-30 to roughly 0-255
+    // Remainder converted from 0-30 to 0-255
     final int remainder = (int) Math.round((h % 30) * (255 / 30.0));
 
     // Value of the lowest rgb component

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/util/Color.java
@@ -88,10 +88,10 @@ public class Color {
     final int chroma = (s * v) >> 8;
 
     // Beacuse hue is 0-180 rather than 0-360 use 30 not 60
-    final int region = h / 30;
+    final int region = (h / 30) % 6;
 
     // Remainder converted from 0-30 to roughly 0-255
-    final int remainder = (h - (region * 30)) * 9;
+    final int remainder = (int) Math.round((h % 30) * (255 / 30.0));
 
     // Value of the lowest rgb component
     final int m = v - chroma;

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/AddressableLEDBufferTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/AddressableLEDBufferTest.java
@@ -35,16 +35,16 @@ class AddressableLEDBufferTest {
         arguments(0, 255, 255, 255, 0, 0), // Red
         arguments(60, 255, 255, 0, 255, 0), // Lime
         arguments(120, 255, 255, 0, 0, 255), // Blue
-        arguments(30, 255, 255, 254, 255, 0), // Yellow (ish)
-        arguments(90, 255, 255, 0, 254, 255), // Cyan (ish)
-        arguments(150, 255, 255, 255, 0, 254), // Magenta (ish)
+        arguments(30, 255, 255, 255, 255, 0), // Yellow
+        arguments(90, 255, 255, 0, 255, 255), // Cyan
+        arguments(150, 255, 255, 255, 0, 255), // Magenta
         arguments(0, 0, 191, 191, 191, 191), // Silver
         arguments(0, 0, 128, 128, 128, 128), // Gray
         arguments(0, 255, 128, 128, 0, 0), // Maroon
-        arguments(30, 255, 128, 127, 128, 0), // Olive (ish)
+        arguments(30, 255, 128, 128, 128, 0), // Olive
         arguments(60, 255, 128, 0, 128, 0), // Green
-        arguments(150, 255, 128, 128, 0, 127), // Purple (ish)
-        arguments(90, 255, 128, 0, 127, 128), // Teal (ish)
+        arguments(150, 255, 128, 128, 0, 128), // Purple
+        arguments(90, 255, 128, 0, 128, 128), // Teal
         arguments(120, 255, 128, 0, 0, 128) // Navy
         );
   }


### PR DESCRIPTION
Rewrites `AddressableLEDBuffer.setHSV` to use `Color.fromHSV` to reduce redundancy between two HSV formulas and bring AddressableLED up to speed with Color's recent formula change.

Also, tweaks the Color algorithm to:
a) not produce incorrect values if the user happens to input a hue outside the `[0, 180)` range, and
b) more accurately convert the hue remainder from range 0-30 to 0-255. The current conversion vastly overshoots the multiplier (converts 0-30 to 0-270) and relies on clamping the value when constructing the Color object to produce a slightly incorrect result.

Fixes #4647.