### PR TITLE
[examples] Add main include directory to test builds

### DIFF
--- a/wpilibcExamples/CMakeLists.txt
+++ b/wpilibcExamples/CMakeLists.txt
@@ -16,7 +16,9 @@ foreach(example ${EXAMPLES})
   if (WITH_TESTS AND EXISTS ${CMAKE_SOURCE_DIR}/wpilibcExamples/src/test/cpp/examples/${example})
     wpilib_add_test(${example} src/test/cpp/examples/${example}/cpp)
     target_sources(${example}_test PRIVATE ${sources})
-    target_include_directories(${example}_test PRIVATE src/test/cpp/examples/${example}/include)
+    target_include_directories(${example}_test PRIVATE
+                               src/main/cpp/examples/${example}/include
+                               src/test/cpp/examples/${example}/include)
     target_compile_definitions(${example}_test PUBLIC RUNNING_FRC_TESTS)
     target_link_libraries(${example}_test wpilibc wpilibNewCommands gmock_main)
   endif()


### PR DESCRIPTION
This fixes the following compilation errors:
```
/home/tav/frc/wpilib/allwpilib/wpilibcExamples/src/main/cpp/examples/UnitTest/cpp/subsystems/Intake.cpp:5:10: fatal error: subsystems/Intake.h: No such file or directory
    5 | #include "subsystems/Intake.h"
      |          ^~~~~~~~~~~~~~~~~~~~~

/home/tav/frc/wpilib/allwpilib/wpilibcExamples/src/test/cpp/examples/UnitTest/cpp/subsystems/IntakeTest.cpp:11:10: fatal error: Constants.h: No such file or directory
   11 | #include "Constants.h"
      |          ^~~~~~~~~~~~~
```