### PR TITLE
[build] Upgrade to googletest 1.12.1

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY  https://github.com/google/googletest.git
-    GIT_TAG         e2239ee6043f73722e7aa812a459f54a28552929 # 1.11.0
+    GIT_TAG         58d77fa8070e8cec2dc1ed015d66b454c8d78850 # 1.12.1
 )
 
 FetchContent_GetProperties(googletest)

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -15,7 +15,7 @@ nativeUtils {
         configureDependencies {
             niLibVersion = "2023.1.0"
             opencvVersion = "4.6.0-3"
-            googleTestVersion = "1.11.0-4"
+            googleTestVersion = "1.12.1-1"
         }
     }
 }


### PR DESCRIPTION
This fixes GCC 12 warnings for googletest internals that cause my local CMake build to fail.