### PR TITLE
Add constructors to pose estimators with default standard deviations

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
@@ -52,6 +52,32 @@ public class DifferentialDrivePoseEstimator {
       TimeInterpolatableBuffer.createBuffer(1.5);
 
   /**
+   * Constructs a DifferentialDrivePoseEstimator with default standard deviations 
+   * for the model and vision measurements.
+   * 
+   * The default standard deviations of the model states are 
+   * 0.02 meters for x, 0.02 meters for y, and 0.01 radians for heading.
+   * The default standard deviations of the vision measurements are 
+   * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
+   *
+   * @param kinematics A correctly-configured kinematics object for your drivetrain.
+   * @param gyroAngle The current gyro angle.
+   * @param leftDistanceMeters The distance traveled by the left encoder.
+   * @param rightDistanceMeters The distance traveled by the right encoder.
+   * @param initialPoseMeters The starting pose estimate.
+   */
+  public DifferentialDrivePoseEstimator(
+      DifferentialDriveKinematics kinematics,
+      Rotation2d gyroAngle,
+      double leftDistanceMeters,
+      double rightDistanceMeters,
+      Pose2d initialPoseMeters) {
+    this(kinematics, gyroAngle, leftDistanceMeters, rightDistanceMeters, initialPoseMeters, 
+      VecBuilder.fill(0.02, 0.02, 0.01),
+      VecBuilder.fill(0.1, 0.1, 0.1));
+  }
+
+  /**
    * Constructs a DifferentialDrivePoseEstimator.
    *
    * @param kinematics A correctly-configured kinematics object for your drivetrain.

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
@@ -52,12 +52,11 @@ public class DifferentialDrivePoseEstimator {
       TimeInterpolatableBuffer.createBuffer(1.5);
 
   /**
-   * Constructs a DifferentialDrivePoseEstimator with default standard deviations 
-   * for the model and vision measurements.
-   * 
-   * The default standard deviations of the model states are 
-   * 0.02 meters for x, 0.02 meters for y, and 0.01 radians for heading.
-   * The default standard deviations of the vision measurements are 
+   * Constructs a DifferentialDrivePoseEstimator with default standard deviations for the model and
+   * vision measurements.
+   *
+   * <p>The default standard deviations of the model states are 0.02 meters for x, 0.02 meters for
+   * y, and 0.01 radians for heading. The default standard deviations of the vision measurements are
    * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
    *
    * @param kinematics A correctly-configured kinematics object for your drivetrain.
@@ -72,9 +71,14 @@ public class DifferentialDrivePoseEstimator {
       double leftDistanceMeters,
       double rightDistanceMeters,
       Pose2d initialPoseMeters) {
-    this(kinematics, gyroAngle, leftDistanceMeters, rightDistanceMeters, initialPoseMeters, 
-      VecBuilder.fill(0.02, 0.02, 0.01),
-      VecBuilder.fill(0.1, 0.1, 0.1));
+    this(
+        kinematics,
+        gyroAngle,
+        leftDistanceMeters,
+        rightDistanceMeters,
+        initialPoseMeters,
+        VecBuilder.fill(0.02, 0.02, 0.01),
+        VecBuilder.fill(0.1, 0.1, 0.1));
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -77,6 +77,7 @@ public class MecanumDrivePoseEstimator {
         VecBuilder.fill(0.1, 0.1, 0.1),
         VecBuilder.fill(0.45, 0.45, 0.45));
   }
+  
   /**
    * Constructs a MecanumDrivePoseEstimator.
    *

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -77,7 +77,7 @@ public class MecanumDrivePoseEstimator {
         VecBuilder.fill(0.1, 0.1, 0.1),
         VecBuilder.fill(0.45, 0.45, 0.45));
   }
-  
+
   /**
    * Constructs a MecanumDrivePoseEstimator.
    *

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -52,6 +52,29 @@ public class MecanumDrivePoseEstimator {
       TimeInterpolatableBuffer.createBuffer(1.5);
 
   /**
+   * Constructs a MecanumDrivePoseEstimator with default standard deviations
+   * for the model and vision measurements.
+   * 
+   * The default standard deviations of the model states are 
+   * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
+   * The default standard deviations of the vision measurements are 
+   * 0.45 meters for x, 0.45 meters for y, and 0.45 radians for heading.
+   *
+   * @param kinematics A correctly-configured kinematics object for your drivetrain.
+   * @param gyroAngle The current gyro angle.
+   * @param wheelPositions The distances driven by each wheel.
+   * @param initialPoseMeters The starting pose estimate.
+   */
+  public MecanumDrivePoseEstimator(
+      MecanumDriveKinematics kinematics,
+      Rotation2d gyroAngle,
+      MecanumDriveWheelPositions wheelPositions,
+      Pose2d initialPoseMeters) {
+    this(kinematics, gyroAngle, wheelPositions, initialPoseMeters, 
+      VecBuilder.fill(0.1, 0.1, 0.1),
+      VecBuilder.fill(0.45, 0.45, 0.45));
+  }
+  /**
    * Constructs a MecanumDrivePoseEstimator.
    *
    * @param kinematics A correctly-configured kinematics object for your drivetrain.

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -52,12 +52,11 @@ public class MecanumDrivePoseEstimator {
       TimeInterpolatableBuffer.createBuffer(1.5);
 
   /**
-   * Constructs a MecanumDrivePoseEstimator with default standard deviations
-   * for the model and vision measurements.
-   * 
-   * The default standard deviations of the model states are 
-   * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
-   * The default standard deviations of the vision measurements are 
+   * Constructs a MecanumDrivePoseEstimator with default standard deviations for the model and
+   * vision measurements.
+   *
+   * <p>The default standard deviations of the model states are 0.1 meters for x, 0.1 meters for y,
+   * and 0.1 radians for heading. The default standard deviations of the vision measurements are
    * 0.45 meters for x, 0.45 meters for y, and 0.45 radians for heading.
    *
    * @param kinematics A correctly-configured kinematics object for your drivetrain.
@@ -70,9 +69,13 @@ public class MecanumDrivePoseEstimator {
       Rotation2d gyroAngle,
       MecanumDriveWheelPositions wheelPositions,
       Pose2d initialPoseMeters) {
-    this(kinematics, gyroAngle, wheelPositions, initialPoseMeters, 
-      VecBuilder.fill(0.1, 0.1, 0.1),
-      VecBuilder.fill(0.45, 0.45, 0.45));
+    this(
+        kinematics,
+        gyroAngle,
+        wheelPositions,
+        initialPoseMeters,
+        VecBuilder.fill(0.1, 0.1, 0.1),
+        VecBuilder.fill(0.45, 0.45, 0.45));
   }
   /**
    * Constructs a MecanumDrivePoseEstimator.

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -51,6 +51,29 @@ public class SwerveDrivePoseEstimator {
       TimeInterpolatableBuffer.createBuffer(1.5);
 
   /**
+   * Constructs a SwerveDrivePoseEstimator with default standard deviations
+   * for the model and vision measurements.
+   * 
+   * The default standard deviations of the model states are 
+   * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
+   * The default standard deviations of the vision measurements are 
+   * 0.9 meters for x, 0.9 meters for y, and 0.9 radians for heading.
+   *
+   * @param kinematics A correctly-configured kinematics object for your drivetrain.
+   * @param gyroAngle The current gyro angle.
+   * @param modulePositions The current distance measurements and rotations of the swerve modules.
+   * @param initialPoseMeters The starting pose estimate.
+   */
+  public SwerveDrivePoseEstimator(
+      SwerveDriveKinematics kinematics,
+      Rotation2d gyroAngle,
+      SwerveModulePosition[] modulePositions,
+      Pose2d initialPoseMeters) {
+    this(kinematics, gyroAngle, modulePositions, initialPoseMeters, 
+      VecBuilder.fill(0.1, 0.1, 0.1),
+      VecBuilder.fill(0.9, 0.9, 0.9));
+  }
+  /**
    * Constructs a SwerveDrivePoseEstimator.
    *
    * @param kinematics A correctly-configured kinematics object for your drivetrain.

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -76,6 +76,7 @@ public class SwerveDrivePoseEstimator {
         VecBuilder.fill(0.1, 0.1, 0.1),
         VecBuilder.fill(0.9, 0.9, 0.9));
   }
+  
   /**
    * Constructs a SwerveDrivePoseEstimator.
    *

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -76,7 +76,7 @@ public class SwerveDrivePoseEstimator {
         VecBuilder.fill(0.1, 0.1, 0.1),
         VecBuilder.fill(0.9, 0.9, 0.9));
   }
-  
+
   /**
    * Constructs a SwerveDrivePoseEstimator.
    *

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -51,13 +51,12 @@ public class SwerveDrivePoseEstimator {
       TimeInterpolatableBuffer.createBuffer(1.5);
 
   /**
-   * Constructs a SwerveDrivePoseEstimator with default standard deviations
-   * for the model and vision measurements.
-   * 
-   * The default standard deviations of the model states are 
-   * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
-   * The default standard deviations of the vision measurements are 
-   * 0.9 meters for x, 0.9 meters for y, and 0.9 radians for heading.
+   * Constructs a SwerveDrivePoseEstimator with default standard deviations for the model and vision
+   * measurements.
+   *
+   * <p>The default standard deviations of the model states are 0.1 meters for x, 0.1 meters for y,
+   * and 0.1 radians for heading. The default standard deviations of the vision measurements are 0.9
+   * meters for x, 0.9 meters for y, and 0.9 radians for heading.
    *
    * @param kinematics A correctly-configured kinematics object for your drivetrain.
    * @param gyroAngle The current gyro angle.
@@ -69,9 +68,13 @@ public class SwerveDrivePoseEstimator {
       Rotation2d gyroAngle,
       SwerveModulePosition[] modulePositions,
       Pose2d initialPoseMeters) {
-    this(kinematics, gyroAngle, modulePositions, initialPoseMeters, 
-      VecBuilder.fill(0.1, 0.1, 0.1),
-      VecBuilder.fill(0.9, 0.9, 0.9));
+    this(
+        kinematics,
+        gyroAngle,
+        modulePositions,
+        initialPoseMeters,
+        VecBuilder.fill(0.1, 0.1, 0.1),
+        VecBuilder.fill(0.9, 0.9, 0.9));
   }
   /**
    * Constructs a SwerveDrivePoseEstimator.

--- a/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
@@ -43,11 +43,8 @@ DifferentialDrivePoseEstimator::DifferentialDrivePoseEstimator(
     units::meter_t leftDistance, units::meter_t rightDistance,
     const Pose2d& initialPose)
     : DifferentialDrivePoseEstimator{
-      kinematics, gyroAngle, 
-      leftDistance, rightDistance, 
-      initialPose, {0.02, 0.02, 0.01}, 
-      {0.1, 0.1, 0.1}}
-    {}
+          kinematics,  gyroAngle,          leftDistance,   rightDistance,
+          initialPose, {0.02, 0.02, 0.01}, {0.1, 0.1, 0.1}} {}
 
 DifferentialDrivePoseEstimator::DifferentialDrivePoseEstimator(
     DifferentialDriveKinematics& kinematics, const Rotation2d& gyroAngle,

--- a/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
@@ -41,6 +41,17 @@ DifferentialDrivePoseEstimator::InterpolationRecord::Interpolate(
 DifferentialDrivePoseEstimator::DifferentialDrivePoseEstimator(
     DifferentialDriveKinematics& kinematics, const Rotation2d& gyroAngle,
     units::meter_t leftDistance, units::meter_t rightDistance,
+    const Pose2d& initialPose)
+    : DifferentialDrivePoseEstimator{
+      kinematics, gyroAngle, 
+      leftDistance, rightDistance, 
+      initialPose, {0.02, 0.02, 0.01}, 
+      {0.1, 0.1, 0.1}}
+    {}
+
+DifferentialDrivePoseEstimator::DifferentialDrivePoseEstimator(
+    DifferentialDriveKinematics& kinematics, const Rotation2d& gyroAngle,
+    units::meter_t leftDistance, units::meter_t rightDistance,
     const Pose2d& initialPose, const wpi::array<double, 3>& stateStdDevs,
     const wpi::array<double, 3>& visionMeasurementStdDevs)
     : m_kinematics{kinematics},

--- a/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
@@ -53,6 +53,15 @@ frc::MecanumDrivePoseEstimator::InterpolationRecord::Interpolate(
 
 frc::MecanumDrivePoseEstimator::MecanumDrivePoseEstimator(
     MecanumDriveKinematics& kinematics, const Rotation2d& gyroAngle,
+    const MecanumDriveWheelPositions& wheelPositions, const Pose2d& initialPose)
+    : MecanumDrivePoseEstimator{
+      kinematics, gyroAngle,
+      wheelPositions, initialPose, 
+      {0.1, 0.1, 0.1}, {0.45, 0.45, 0.45}}
+  {}
+
+frc::MecanumDrivePoseEstimator::MecanumDrivePoseEstimator(
+    MecanumDriveKinematics& kinematics, const Rotation2d& gyroAngle,
     const MecanumDriveWheelPositions& wheelPositions, const Pose2d& initialPose,
     const wpi::array<double, 3>& stateStdDevs,
     const wpi::array<double, 3>& visionMeasurementStdDevs)

--- a/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
@@ -54,11 +54,9 @@ frc::MecanumDrivePoseEstimator::InterpolationRecord::Interpolate(
 frc::MecanumDrivePoseEstimator::MecanumDrivePoseEstimator(
     MecanumDriveKinematics& kinematics, const Rotation2d& gyroAngle,
     const MecanumDriveWheelPositions& wheelPositions, const Pose2d& initialPose)
-    : MecanumDrivePoseEstimator{
-      kinematics, gyroAngle,
-      wheelPositions, initialPose, 
-      {0.1, 0.1, 0.1}, {0.45, 0.45, 0.45}}
-  {}
+    : MecanumDrivePoseEstimator{kinematics,      gyroAngle,
+                                wheelPositions,  initialPose,
+                                {0.1, 0.1, 0.1}, {0.45, 0.45, 0.45}} {}
 
 frc::MecanumDrivePoseEstimator::MecanumDrivePoseEstimator(
     MecanumDriveKinematics& kinematics, const Rotation2d& gyroAngle,

--- a/wpimath/src/main/native/include/frc/estimator/DifferentialDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/DifferentialDrivePoseEstimator.h
@@ -45,6 +45,27 @@ namespace frc {
 class WPILIB_DLLEXPORT DifferentialDrivePoseEstimator {
  public:
   /**
+   * Constructs a DifferentialDrivePoseEstimator with default standard deviations 
+   * for the model and vision measurements.
+   * 
+   * The default standard deviations of the model states are 
+   * 0.02 meters for x, 0.02 meters for y, and 0.01 radians for heading.
+   * The default standard deviations of the vision measurements are 
+   * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
+   *
+   * @param kinematics               A correctly-configured kinematics object
+   *                                 for your drivetrain.
+   * @param gyroAngle                The gyro angle of the robot.
+   * @param leftDistance The distance traveled by the left encoder.
+   * @param rightDistance The distance traveled by the right encoder.
+   * @param initialPose              The estimated initial pose.
+   */
+  DifferentialDrivePoseEstimator(
+      DifferentialDriveKinematics& kinematics, const Rotation2d& gyroAngle,
+      units::meter_t leftDistance, units::meter_t rightDistance,
+      const Pose2d& initialPose);
+    
+  /**
    * Constructs a DifferentialDrivePoseEstimator.
    *
    * @param kinematics               A correctly-configured kinematics object

--- a/wpimath/src/main/native/include/frc/estimator/DifferentialDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/DifferentialDrivePoseEstimator.h
@@ -45,12 +45,12 @@ namespace frc {
 class WPILIB_DLLEXPORT DifferentialDrivePoseEstimator {
  public:
   /**
-   * Constructs a DifferentialDrivePoseEstimator with default standard deviations 
-   * for the model and vision measurements.
-   * 
-   * The default standard deviations of the model states are 
+   * Constructs a DifferentialDrivePoseEstimator with default standard
+   * deviations for the model and vision measurements.
+   *
+   * The default standard deviations of the model states are
    * 0.02 meters for x, 0.02 meters for y, and 0.01 radians for heading.
-   * The default standard deviations of the vision measurements are 
+   * The default standard deviations of the vision measurements are
    * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
    *
    * @param kinematics               A correctly-configured kinematics object
@@ -60,11 +60,12 @@ class WPILIB_DLLEXPORT DifferentialDrivePoseEstimator {
    * @param rightDistance The distance traveled by the right encoder.
    * @param initialPose              The estimated initial pose.
    */
-  DifferentialDrivePoseEstimator(
-      DifferentialDriveKinematics& kinematics, const Rotation2d& gyroAngle,
-      units::meter_t leftDistance, units::meter_t rightDistance,
-      const Pose2d& initialPose);
-    
+  DifferentialDrivePoseEstimator(DifferentialDriveKinematics& kinematics,
+                                 const Rotation2d& gyroAngle,
+                                 units::meter_t leftDistance,
+                                 units::meter_t rightDistance,
+                                 const Pose2d& initialPose);
+
   /**
    * Constructs a DifferentialDrivePoseEstimator.
    *

--- a/wpimath/src/main/native/include/frc/estimator/MecanumDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/MecanumDrivePoseEstimator.h
@@ -47,10 +47,10 @@ class WPILIB_DLLEXPORT MecanumDrivePoseEstimator {
   /**
    * Constructs a MecanumDrivePoseEstimator with default standard deviations
    * for the model and vision measurements.
-   * 
-   * The default standard deviations of the model states are 
+   *
+   * The default standard deviations of the model states are
    * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
-   * The default standard deviations of the vision measurements are 
+   * The default standard deviations of the vision measurements are
    * 0.45 meters for x, 0.45 meters for y, and 0.45 radians for heading.
    *
    * @param kinematics               A correctly-configured kinematics object
@@ -59,10 +59,10 @@ class WPILIB_DLLEXPORT MecanumDrivePoseEstimator {
    * @param wheelPositions           The distance measured by each wheel.
    * @param initialPose              The starting pose estimate.
    */
-  MecanumDrivePoseEstimator(
-      MecanumDriveKinematics& kinematics, const Rotation2d& gyroAngle,
-      const MecanumDriveWheelPositions& wheelPositions,
-      const Pose2d& initialPose);
+  MecanumDrivePoseEstimator(MecanumDriveKinematics& kinematics,
+                            const Rotation2d& gyroAngle,
+                            const MecanumDriveWheelPositions& wheelPositions,
+                            const Pose2d& initialPose);
 
   /**
    * Constructs a MecanumDrivePoseEstimator.

--- a/wpimath/src/main/native/include/frc/estimator/MecanumDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/MecanumDrivePoseEstimator.h
@@ -45,6 +45,26 @@ namespace frc {
 class WPILIB_DLLEXPORT MecanumDrivePoseEstimator {
  public:
   /**
+   * Constructs a MecanumDrivePoseEstimator with default standard deviations
+   * for the model and vision measurements.
+   * 
+   * The default standard deviations of the model states are 
+   * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
+   * The default standard deviations of the vision measurements are 
+   * 0.45 meters for x, 0.45 meters for y, and 0.45 radians for heading.
+   *
+   * @param kinematics               A correctly-configured kinematics object
+   *                                 for your drivetrain.
+   * @param gyroAngle                The current gyro angle.
+   * @param wheelPositions           The distance measured by each wheel.
+   * @param initialPose              The starting pose estimate.
+   */
+  MecanumDrivePoseEstimator(
+      MecanumDriveKinematics& kinematics, const Rotation2d& gyroAngle,
+      const MecanumDriveWheelPositions& wheelPositions,
+      const Pose2d& initialPose);
+
+  /**
    * Constructs a MecanumDrivePoseEstimator.
    *
    * @param kinematics               A correctly-configured kinematics object

--- a/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
@@ -45,6 +45,40 @@ template <size_t NumModules>
 class SwerveDrivePoseEstimator {
  public:
   /**
+   * Constructs a SwerveDrivePoseEstimator with default standard deviations
+   * for the model and vision measurements.
+   * 
+   * The default standard deviations of the model states are 
+   * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
+   * The default standard deviations of the vision measurements are 
+   * 0.9 meters for x, 0.9 meters for y, and 0.9 radians for heading.
+   *
+   * @param kinematics               A correctly-configured kinematics object
+   *                                 for your drivetrain.
+   * @param gyroAngle                The current gyro angle.
+   * @param modulePositions          The current distance and rotation
+   *                                 measurements of the swerve modules.
+   * @param initialPose              The starting pose estimate.
+   * @param stateStdDevs             Standard deviations of model states.
+   *                                 Increase these numbers to trust your
+   *                                 model's state estimates less. This matrix
+   *                                 is in the form [x, y, theta]ᵀ, with units
+   *                                 in meters and radians.
+   * @param visionMeasurementStdDevs Standard deviations of the vision
+   *                                 measurements. Increase these numbers to
+   *                                 trust global measurements from vision
+   *                                 less. This matrix is in the form
+   *                                 [x, y, theta]ᵀ, with units in meters and
+   *                                 radians.
+   */
+  SwerveDrivePoseEstimator(
+      SwerveDriveKinematics<NumModules>& kinematics,
+      const Rotation2d& gyroAngle,
+      const wpi::array<SwerveModulePosition, NumModules>& modulePositions,
+      const Pose2d& initialPose)
+      : SwerveDrivePoseEstimator{kinematics, gyroAngle, modulePositions, initialPose, {0.1, 0.1, 0.1}, {0.9, 0.9, 0.9}} {}
+
+  /**
    * Constructs a SwerveDrivePoseEstimator.
    *
    * @param kinematics               A correctly-configured kinematics object

--- a/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
@@ -59,17 +59,6 @@ class SwerveDrivePoseEstimator {
    * @param modulePositions          The current distance and rotation
    *                                 measurements of the swerve modules.
    * @param initialPose              The starting pose estimate.
-   * @param stateStdDevs             Standard deviations of model states.
-   *                                 Increase these numbers to trust your
-   *                                 model's state estimates less. This matrix
-   *                                 is in the form [x, y, theta]ᵀ, with units
-   *                                 in meters and radians.
-   * @param visionMeasurementStdDevs Standard deviations of the vision
-   *                                 measurements. Increase these numbers to
-   *                                 trust global measurements from vision
-   *                                 less. This matrix is in the form
-   *                                 [x, y, theta]ᵀ, with units in meters and
-   *                                 radians.
    */
   SwerveDrivePoseEstimator(
       SwerveDriveKinematics<NumModules>& kinematics,

--- a/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
@@ -47,10 +47,10 @@ class SwerveDrivePoseEstimator {
   /**
    * Constructs a SwerveDrivePoseEstimator with default standard deviations
    * for the model and vision measurements.
-   * 
-   * The default standard deviations of the model states are 
+   *
+   * The default standard deviations of the model states are
    * 0.1 meters for x, 0.1 meters for y, and 0.1 radians for heading.
-   * The default standard deviations of the vision measurements are 
+   * The default standard deviations of the vision measurements are
    * 0.9 meters for x, 0.9 meters for y, and 0.9 radians for heading.
    *
    * @param kinematics               A correctly-configured kinematics object
@@ -65,7 +65,9 @@ class SwerveDrivePoseEstimator {
       const Rotation2d& gyroAngle,
       const wpi::array<SwerveModulePosition, NumModules>& modulePositions,
       const Pose2d& initialPose)
-      : SwerveDrivePoseEstimator{kinematics, gyroAngle, modulePositions, initialPose, {0.1, 0.1, 0.1}, {0.9, 0.9, 0.9}} {}
+      : SwerveDrivePoseEstimator{kinematics,      gyroAngle,
+                                 modulePositions, initialPose,
+                                 {0.1, 0.1, 0.1}, {0.9, 0.9, 0.9}} {}
 
   /**
    * Constructs a SwerveDrivePoseEstimator.


### PR DESCRIPTION
Add constructors with default standard deviations to DifferentialDrive, Mecanum, and Swerve pose estimators, per #4753.