### PR TITLE
[examples] HatchbotInlined: Use Subsystem factories

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/RobotContainer.cpp
@@ -33,11 +33,9 @@ void RobotContainer::ConfigureButtonBindings() {
   // Configure your button bindings here
 
   // Grab the hatch when the 'Circle' button is pressed.
-  m_driverController.Circle().OnTrue(
-      frc2::cmd::RunOnce([this] { m_hatch.GrabHatch(); }, {&m_hatch}));
+  m_driverController.Circle().OnTrue(m_hatch.GrabHatchCommand());
   // Release the hatch when the 'Square' button is pressed.
-  m_driverController.Square().OnTrue(
-      frc2::cmd::RunOnce([this] { m_hatch.ReleaseHatch(); }, {&m_hatch}));
+  m_driverController.Square().OnTrue(m_hatch.ReleaseHatchCommand());
   // While holding R1, drive at half speed
   m_driverController.R1()
       .OnTrue(frc2::cmd::RunOnce([this] { m_drive.SetMaxOutput(0.5); }, {}))

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/commands/Autos.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/commands/Autos.cpp
@@ -51,7 +51,7 @@ frc2::CommandPtr autos::ComplexAuto(DriveSubsystem* drive,
           {drive})
           .ToPtr(),
       // Release the hatch
-      frc2::cmd::RunOnce([hatch] { hatch->ReleaseHatch(); }, {hatch}),
+      hatch->ReleaseHatchCommand(),
       // Drive backward the specified distance
       // Drive forward the specified distance
       frc2::FunctionalCommand(

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/subsystems/HatchSubsystem.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/subsystems/HatchSubsystem.cpp
@@ -10,10 +10,12 @@ HatchSubsystem::HatchSubsystem()
     : m_hatchSolenoid{frc::PneumaticsModuleType::CTREPCM,
                       kHatchSolenoidPorts[0], kHatchSolenoidPorts[1]} {}
 
-void HatchSubsystem::GrabHatch() {
-  m_hatchSolenoid.Set(frc::DoubleSolenoid::kForward);
+frc2::CommandPtr HatchSubsystem::GrabHatchCommand() {
+  // implicitly require `this`
+  return this->RunOnce([this] { m_hatchSolenoid.Set(frc::DoubleSolenoid::kForward); });
 }
 
-void HatchSubsystem::ReleaseHatch() {
-  m_hatchSolenoid.Set(frc::DoubleSolenoid::kReverse);
+frc2::CommandPtr HatchSubsystem::ReleaseHatchCommand() {
+  // implicitly require `this`
+  return this->RunOnce([this] { m_hatchSolenoid.Set(frc::DoubleSolenoid::kReverse); });
 }

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/subsystems/HatchSubsystem.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/cpp/subsystems/HatchSubsystem.cpp
@@ -12,10 +12,12 @@ HatchSubsystem::HatchSubsystem()
 
 frc2::CommandPtr HatchSubsystem::GrabHatchCommand() {
   // implicitly require `this`
-  return this->RunOnce([this] { m_hatchSolenoid.Set(frc::DoubleSolenoid::kForward); });
+  return this->RunOnce(
+      [this] { m_hatchSolenoid.Set(frc::DoubleSolenoid::kForward); });
 }
 
 frc2::CommandPtr HatchSubsystem::ReleaseHatchCommand() {
   // implicitly require `this`
-  return this->RunOnce([this] { m_hatchSolenoid.Set(frc::DoubleSolenoid::kReverse); });
+  return this->RunOnce(
+      [this] { m_hatchSolenoid.Set(frc::DoubleSolenoid::kReverse); });
 }

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/subsystems/HatchSubsystem.h
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/subsystems/HatchSubsystem.h
@@ -6,6 +6,7 @@
 
 #include <frc/DoubleSolenoid.h>
 #include <frc/PneumaticsControlModule.h>
+#include <frc2/command/CommandPtr.h>
 #include <frc2/command/SubsystemBase.h>
 
 #include "Constants.h"
@@ -19,12 +20,12 @@ class HatchSubsystem : public frc2::SubsystemBase {
   /**
    * Grabs the hatch.
    */
-  void GrabHatch();
+  frc2::CommandPtr GrabHatchCommand();
 
   /**
    * Releases the hatch.
    */
-  void ReleaseHatch();
+  frc2::CommandPtr ReleaseHatchCommand();
 
  private:
   // Components (e.g. motor controllers and sensors) should generally be

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
@@ -75,11 +75,11 @@ public class RobotContainer {
     // Grab the hatch when the Circle button is pressed.
     m_driverController
         .circle()
-        .onTrue(Commands.runOnce(m_hatchSubsystem::grabHatch, m_hatchSubsystem));
+        .onTrue(m_hatchSubsystem.grabHatchCommand());
     // Release the hatch when the Square button is pressed.
     m_driverController
         .square()
-        .onTrue(Commands.runOnce(m_hatchSubsystem::releaseHatch, m_hatchSubsystem));
+        .onTrue(m_hatchSubsystem.releaseHatchCommand());
     // While holding R1, drive at half speed
     m_driverController
         .R1()

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/RobotContainer.java
@@ -73,13 +73,9 @@ public class RobotContainer {
    */
   private void configureButtonBindings() {
     // Grab the hatch when the Circle button is pressed.
-    m_driverController
-        .circle()
-        .onTrue(m_hatchSubsystem.grabHatchCommand());
+    m_driverController.circle().onTrue(m_hatchSubsystem.grabHatchCommand());
     // Release the hatch when the Square button is pressed.
-    m_driverController
-        .square()
-        .onTrue(m_hatchSubsystem.releaseHatchCommand());
+    m_driverController.square().onTrue(m_hatchSubsystem.releaseHatchCommand());
     // While holding R1, drive at half speed
     m_driverController
         .R1()

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/commands/Autos.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/commands/Autos.java
@@ -47,7 +47,7 @@ public final class Autos {
             driveSubsystem),
 
         // Release the hatch
-        Commands.runOnce(hatchSubsystem::releaseHatch, hatchSubsystem),
+        hatchSubsystem.releaseHatchCommand(),
 
         // Drive backward the specified distance
         new FunctionalCommand(

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/subsystems/HatchSubsystem.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/hatchbotinlined/subsystems/HatchSubsystem.java
@@ -10,6 +10,7 @@ import static edu.wpi.first.wpilibj.DoubleSolenoid.Value.kReverse;
 import edu.wpi.first.wpilibj.DoubleSolenoid;
 import edu.wpi.first.wpilibj.PneumaticsModuleType;
 import edu.wpi.first.wpilibj.examples.hatchbotinlined.Constants.HatchConstants;
+import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 /** A hatch mechanism actuated by a single {@link edu.wpi.first.wpilibj.DoubleSolenoid}. */
@@ -21,12 +22,14 @@ public class HatchSubsystem extends SubsystemBase {
           HatchConstants.kHatchSolenoidPorts[1]);
 
   /** Grabs the hatch. */
-  public void grabHatch() {
-    m_hatchSolenoid.set(kForward);
+  public CommandBase grabHatchCommand() {
+    // implicitly require `this`
+    return this.runOnce(() -> m_hatchSolenoid.set(kForward));
   }
 
   /** Releases the hatch. */
-  public void releaseHatch() {
-    m_hatchSolenoid.set(kReverse);
+  public CommandBase releaseHatchCommand() {
+    // implicitly require `this`
+    return this.runOnce(() -> m_hatchSolenoid.set(kReverse));
   }
 }


### PR DESCRIPTION
This should show greater contrast between the traditional and inline, and provides comparison RLIs.