### PR TITLE
[wpilibj] Shuffleboard: Check for null sendable

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ContainerHelper.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ContainerHelper.java
@@ -57,6 +57,7 @@ final class ContainerHelper {
   }
 
   ComplexWidget add(String title, Sendable sendable) {
+    Objects.requireNonNull(sendable, "sendable cannot be null");
     checkTitle(title);
     ComplexWidget widget = new ComplexWidget(m_container, title, sendable);
     m_components.add(widget);
@@ -64,6 +65,7 @@ final class ContainerHelper {
   }
 
   ComplexWidget add(Sendable sendable) {
+    Objects.requireNonNull(sendable, "sendable cannot be null");
     String name = SendableRegistry.getName(sendable);
     if (name.isEmpty()) {
       throw new IllegalArgumentException("Sendable must have a name");
@@ -170,6 +172,7 @@ final class ContainerHelper {
   }
 
   private static void checkNtType(Object data) {
+    Objects.requireNonNull(data, "data cannot be null");
     if (!NetworkTableEntry.isValidDataType(data)) {
       throw new IllegalArgumentException(
           "Cannot add data of type " + data.getClass().getName() + " to Shuffleboard");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ContainerHelper.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ContainerHelper.java
@@ -10,6 +10,7 @@ import edu.wpi.first.networktables.NetworkTableType;
 import edu.wpi.first.util.function.FloatSupplier;
 import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.util.sendable.SendableRegistry;
+import edu.wpi.first.wpilibj.util.ErrorMessages;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -57,7 +58,7 @@ final class ContainerHelper {
   }
 
   ComplexWidget add(String title, Sendable sendable) {
-    Objects.requireNonNull(sendable, "sendable cannot be null");
+    ErrorMessages.requireNonNullParam(sendable, "sendable", "add");
     checkTitle(title);
     ComplexWidget widget = new ComplexWidget(m_container, title, sendable);
     m_components.add(widget);
@@ -65,7 +66,7 @@ final class ContainerHelper {
   }
 
   ComplexWidget add(Sendable sendable) {
-    Objects.requireNonNull(sendable, "sendable cannot be null");
+    ErrorMessages.requireNonNullParam(sendable, "sendable", "add");
     String name = SendableRegistry.getName(sendable);
     if (name.isEmpty()) {
       throw new IllegalArgumentException("Sendable must have a name");
@@ -172,7 +173,6 @@ final class ContainerHelper {
   }
 
   private static void checkNtType(Object data) {
-    Objects.requireNonNull(data, "data cannot be null");
     if (!NetworkTableEntry.isValidDataType(data)) {
       throw new IllegalArgumentException(
           "Cannot add data of type " + data.getClass().getName() + " to Shuffleboard");


### PR DESCRIPTION
Adding a null sendable to a container could result in a delayed NullPointerException.

Fixes https://github.com/wpilibsuite/BetaTest/issues/154

C++ doesn't have this issue because it takes a Sendable reference rather than a pointer.