### PR TITLE
[cscore] Convert YUYV and UYVY directly to grayscale

### DIFF
--- a/cscore/src/main/native/cpp/Frame.cpp
+++ b/cscore/src/main/native/cpp/Frame.cpp
@@ -401,7 +401,7 @@ Image* Frame::ConvertYUYVToGray(Image* image) {
     return nullptr;
   }
 
-  // Allocate a BGR image
+  // Allocate a grayscale image
   auto newImage =
       m_impl->source.AllocImage(VideoMode::kGray, image->width, image->height,
                                 image->width * image->height);
@@ -445,7 +445,7 @@ Image* Frame::ConvertUYVYToGray(Image* image) {
     return nullptr;
   }
 
-  // Allocate a BGR image
+  // Allocate a grayscale image
   auto newImage =
       m_impl->source.AllocImage(VideoMode::kGray, image->width, image->height,
                                 image->width * image->height);

--- a/cscore/src/main/native/cpp/Frame.h
+++ b/cscore/src/main/native/cpp/Frame.h
@@ -195,7 +195,9 @@ class Frame {
   Image* ConvertMJPEGToBGR(Image* image);
   Image* ConvertMJPEGToGray(Image* image);
   Image* ConvertYUYVToBGR(Image* image);
+  Image* ConvertYUYVToGray(Image* image);
   Image* ConvertUYVYToBGR(Image* image);
+  Image* ConvertUYVYToGray(Image* image);
   Image* ConvertBGRToRGB565(Image* image);
   Image* ConvertRGB565ToBGR(Image* image);
   Image* ConvertBGRToGray(Image* image);


### PR DESCRIPTION
This is significantly more efficient than converting by way of BGR.