### PR TITLE
[ntcore] Remove table multi-subscriber

### DIFF
--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTable.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTable.java
@@ -22,7 +22,6 @@ public final class NetworkTable {
   private final String m_path;
   private final String m_pathWithSep;
   private final NetworkTableInstance m_inst;
-  private final MultiSubscriber m_topicSub;
 
   /**
    * Gets the "base name" of a key. For example, "/foo/bar" becomes "bar". If the key has a trailing
@@ -115,8 +114,6 @@ public final class NetworkTable {
     m_path = path;
     m_pathWithSep = path + PATH_SEPARATOR;
     m_inst = inst;
-    m_topicSub =
-        new MultiSubscriber(inst, new String[] {m_pathWithSep}, PubSubOption.topicsOnly(true));
   }
 
   /**
@@ -533,7 +530,7 @@ public final class NetworkTable {
     final NetworkTable parent = this;
 
     return m_inst.addListener(
-        m_topicSub,
+        new String[] {m_pathWithSep},
         EnumSet.of(NetworkTableEvent.Kind.kPublish, NetworkTableEvent.Kind.kImmediate),
         new Consumer<NetworkTableEvent>() {
           final Set<String> m_notifiedTables = new HashSet<>();
@@ -582,9 +579,5 @@ public final class NetworkTable {
   @Override
   public int hashCode() {
     return Objects.hash(m_inst, m_path);
-  }
-
-  void close() {
-    m_topicSub.close();
   }
 }

--- a/ntcore/src/main/native/cpp/networktables/NetworkTable.cpp
+++ b/ntcore/src/main/native/cpp/networktables/NetworkTable.cpp
@@ -88,14 +88,9 @@ std::vector<std::string> NetworkTable::GetHierarchy(std::string_view key) {
 
 NetworkTable::NetworkTable(NT_Inst inst, std::string_view path,
                            const private_init&)
-    : m_inst(inst),
-      m_path(path),
-      m_topicSub{::nt::SubscribeMultiple(inst, {{fmt::format("{}/", path)}},
-                                         {{PubSubOption::TopicsOnly(true)}})} {}
+    : m_inst(inst), m_path(path) {}
 
-NetworkTable::~NetworkTable() {
-  ::nt::UnsubscribeMultiple(m_topicSub);
-}
+NetworkTable::~NetworkTable() = default;
 
 NetworkTableInstance NetworkTable::GetInstance() const {
   return NetworkTableInstance{m_inst};
@@ -405,8 +400,8 @@ NT_Listener NetworkTable::AddSubTableListener(SubTableListener listener) {
   // a shared_ptr to it.
   auto notified_tables = std::make_shared<wpi::StringMap<char>>();
 
-  return ::nt::AddListener(
-      m_topicSub, NT_EVENT_PUBLISH | NT_EVENT_IMMEDIATE,
+  return NetworkTableInstance{m_inst}.AddListener(
+      {{fmt::format("{}/", m_path)}}, NT_EVENT_PUBLISH | NT_EVENT_IMMEDIATE,
       [this, cb = std::move(listener), notified_tables](const Event& event) {
         auto topicInfo = event.GetTopicInfo();
         if (!topicInfo) {

--- a/ntcore/src/main/native/include/networktables/NetworkTable.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTable.h
@@ -48,7 +48,6 @@ class NetworkTable final {
  private:
   NT_Inst m_inst;
   std::string m_path;
-  NT_MultiSubscriber m_topicSub;
   mutable wpi::mutex m_mutex;
   mutable wpi::StringMap<NT_Entry> m_entries;
 


### PR DESCRIPTION
This wasn't well thought out, and leaks horribly in Java.

Reverts part of #4640.

Fixes #4788.