### PR TITLE
[wpiutil] Fix UnescapeCString overflow when input size < 2

### DIFF
--- a/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/StringExtras.cpp
+++ b/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/StringExtras.cpp
@@ -362,7 +362,7 @@ std::optional<long double> wpi::parse_float<long double>(
 std::pair<std::string_view, std::string_view> wpi::UnescapeCString(
     std::string_view str, wpi::SmallVectorImpl<char>& buf) {
   buf.clear();
-  buf.reserve(str.size() - 2);
+  buf.reserve(str.size());
   const char* s = str.data();
   const char* end = str.data() + str.size();
   for (; s != end && *s != '"'; ++s) {

--- a/wpiutil/src/test/native/cpp/UnescapeCStringTest.cpp
+++ b/wpiutil/src/test/native/cpp/UnescapeCStringTest.cpp
@@ -52,4 +52,23 @@ TEST(UnescapeCStringTest, Octal) {
   EXPECT_TRUE(rem.empty());
 }
 
+TEST(UnescapeCStringTest, EmptyString) {
+  SmallString<64> buf;
+  auto [out, rem] = UnescapeCString("", buf);
+  EXPECT_EQ(out, "");
+}
+
+TEST(UnescapeCStringTest, ShortString) {
+  SmallString<64> buf;
+  auto [out, rem] = UnescapeCString("a", buf);
+  EXPECT_EQ(out, "a");
+}
+
+TEST(UnescapeCStringTest, NoEscapesString) {
+  SmallString<64> buf;
+  std::string_view input = "abcdefghijklmnopqrstuvwxyz1234567890";
+  auto [out, rem] = UnescapeCString(input, buf);
+  EXPECT_EQ(out, input);
+}
+
 }  // namespace


### PR DESCRIPTION
Add tests for empty, small, and string without escapes