### PR TITLE
[wpiutil] Fix MemoryBuffer initialization

### DIFF
--- a/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/MemoryBuffer.cpp
+++ b/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/MemoryBuffer.cpp
@@ -105,7 +105,7 @@ template <typename MB>
 class MemoryBufferMem : public MB {
  public:
   explicit MemoryBufferMem(std::span<const uint8_t> inputData) {
-    MemoryBuffer::Init(&*inputData.begin(), &*inputData.end());
+    MemoryBuffer::Init(inputData.data(), inputData.data() + inputData.size());
   }
 
   /// Disable sized deallocation for MemoryBufferMem, because it has


### PR DESCRIPTION
Dereferencing an `end` iterator is undefined behavior and causes a failed assertion when running in debug.