### PR TITLE
[gradle] Use Task Avoidance API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,48 +57,45 @@ if (project.hasProperty("publishVersion")) {
 
 wpilibVersioning.version.finalizeValue()
 
-File outputsFolder = file("$buildDir/allOutputs")
+def outputsFolder = file("$buildDir/allOutputs")
 
-File versionFile = file("$outputsFolder/version.txt")
+def versionFile = file("$outputsFolder/version.txt")
 
-TaskProvider<Task> outputVersions = tasks.register('outputVersions') { Task t ->
-    t.description = 'Prints the versions of wpilib to a file for use by the downstream packaging project'
-    t.group = 'Build'
-    t.outputs.files(versionFile)
+task outputVersions() {
+    description = 'Prints the versions of wpilib to a file for use by the downstream packaging project'
+    group = 'Build'
+    outputs.files(versionFile)
 
-    t.doFirst {
+    doFirst {
         buildDir.mkdir()
         outputsFolder.mkdir()
     }
 
-    t.doLast {
+    doLast {
         versionFile.write wpilibVersioning.version.get()
     }
 }
 
 task libraryBuild() {}
 
-TaskProvider<Copy> copyAllOutputs = tasks.register('copyAllOutputs', Copy) { Copy t ->
-    t.destinationDir outputsFolder
-    t.dependsOn outputVersions
+build.dependsOn outputVersions
+
+task copyAllOutputs(type: Copy) {
+    destinationDir outputsFolder
 }
 
-tasks.named('build') { Task build ->
-    build.dependsOn outputVersions
-    build.dependsOn copyAllOutputs
-}
+build.dependsOn copyAllOutputs
+copyAllOutputs.dependsOn outputVersions
 
 def copyReleaseOnly = project.hasProperty('ciReleaseOnly')
 
-ext.addTaskToCopyAllOutputs = { Zip zip ->
-    if (copyReleaseOnly && zip.name.contains('debug')) {
+ext.addTaskToCopyAllOutputs = { task ->
+    if (copyReleaseOnly && task.name.contains('debug')) {
         return
     }
-    copyAllOutputs.configure { Copy c ->
-        c.dependsOn zip
-        c.inputs.file zip.archiveFile.get()
-        c.from zip.archiveFile.get()
-    }
+    copyAllOutputs.dependsOn task
+    copyAllOutputs.inputs.file task.archivePath
+    copyAllOutputs.from task.archivePath
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -57,45 +57,48 @@ if (project.hasProperty("publishVersion")) {
 
 wpilibVersioning.version.finalizeValue()
 
-def outputsFolder = file("$buildDir/allOutputs")
+File outputsFolder = file("$buildDir/allOutputs")
 
-def versionFile = file("$outputsFolder/version.txt")
+File versionFile = file("$outputsFolder/version.txt")
 
-task outputVersions() {
-    description = 'Prints the versions of wpilib to a file for use by the downstream packaging project'
-    group = 'Build'
-    outputs.files(versionFile)
+TaskProvider<Task> outputVersions = tasks.register('outputVersions') { Task t ->
+    t.description = 'Prints the versions of wpilib to a file for use by the downstream packaging project'
+    t.group = 'Build'
+    t.outputs.files(versionFile)
 
-    doFirst {
+    t.doFirst {
         buildDir.mkdir()
         outputsFolder.mkdir()
     }
 
-    doLast {
+    t.doLast {
         versionFile.write wpilibVersioning.version.get()
     }
 }
 
 task libraryBuild() {}
 
-build.dependsOn outputVersions
-
-task copyAllOutputs(type: Copy) {
-    destinationDir outputsFolder
+TaskProvider<Copy> copyAllOutputs = tasks.register('copyAllOutputs', Copy) { Copy t ->
+    t.destinationDir outputsFolder
+    t.dependsOn outputVersions
 }
 
-build.dependsOn copyAllOutputs
-copyAllOutputs.dependsOn outputVersions
+tasks.named('build') { Task build ->
+    build.dependsOn outputVersions
+    build.dependsOn copyAllOutputs
+}
 
 def copyReleaseOnly = project.hasProperty('ciReleaseOnly')
 
-ext.addTaskToCopyAllOutputs = { task ->
-    if (copyReleaseOnly && task.name.contains('debug')) {
+ext.addTaskToCopyAllOutputs = { Zip zip ->
+    if (copyReleaseOnly && zip.name.contains('debug')) {
         return
     }
-    copyAllOutputs.dependsOn task
-    copyAllOutputs.inputs.file task.archivePath
-    copyAllOutputs.from task.archivePath
+    copyAllOutputs.configure { Copy c ->
+        c.dependsOn zip
+        c.inputs.file zip.archiveFile.get()
+        c.from zip.archiveFile.get()
+    }
 }
 
 subprojects {

--- a/datalogtool/build.gradle
+++ b/datalogtool/build.gradle
@@ -21,21 +21,21 @@ if (!project.hasProperty('onlylinuxathena')) {
     apply from: "${rootDir}/shared/resources.gradle"
     apply from: "${rootDir}/shared/config.gradle"
 
-    def wpilibVersionFileInput = file("src/main/generate/WPILibVersion.cpp.in")
-    def wpilibVersionFileOutput = file("$buildDir/generated/main/cpp/WPILibVersion.cpp")
+    File wpilibVersionFileInput = file("src/main/generate/WPILibVersion.cpp.in")
+    File wpilibVersionFileOutput = file("$buildDir/generated/main/cpp/WPILibVersion.cpp")
 
     apply from: "${rootDir}/shared/libssh.gradle"
     apply from: "${rootDir}/shared/imgui.gradle"
 
-    task generateCppVersion() {
-        description = 'Generates the wpilib version class'
-        group = 'WPILib'
+    TaskProvider<Task> generateCppVersion = tasks.register('generateCppVersion') { Task t ->
+        t.description = 'Generates the wpilib version class'
+        t.group = 'WPILib'
 
-        outputs.file wpilibVersionFileOutput
-        inputs.file wpilibVersionFileInput
+        t.outputs.file wpilibVersionFileOutput
+        t.inputs.file wpilibVersionFileInput
 
         if (wpilibVersioning.releaseMode) {
-            outputs.upToDateWhen { false }
+            t.outputs.upToDateWhen { false }
         }
 
         // We follow a simple set of checks to determine whether we should generate a new version file:
@@ -43,7 +43,7 @@ if (!project.hasProperty('onlylinuxathena')) {
         // 2. If there is no generated version number, we generate a new version file
         // 3. If there is a generated build number, and the release type is development, then we will
         //    only generate if the publish task is run.
-        doLast {
+        t.doLast {
             def version = wpilibVersioning.version.get()
             println "Writing version ${version} to $wpilibVersionFileOutput"
 
@@ -58,7 +58,9 @@ if (!project.hasProperty('onlylinuxathena')) {
     gradle.taskGraph.addTaskExecutionGraphListener { graph ->
         def willPublish = graph.hasTask(publish)
         if (willPublish) {
-            generateCppVersion.outputs.upToDateWhen { false }
+            generateCppVersion.configure { Task t ->
+                t.outputs.upToDateWhen { false }
+            }
         }
     }
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -15,15 +15,15 @@ evaluationDependsOn(':wpimath')
 evaluationDependsOn(':wpinet')
 evaluationDependsOn(':wpiutil')
 
-def baseArtifactIdCpp = 'documentation'
-def artifactGroupIdCpp = 'edu.wpi.first.wpilibc'
-def zipBaseNameCpp = '_GROUP_edu_wpi_first_wpilibc_ID_documentation_CLS'
+String baseArtifactIdCpp = 'documentation'
+String artifactGroupIdCpp = 'edu.wpi.first.wpilibc'
+String zipBaseNameCpp = '_GROUP_edu_wpi_first_wpilibc_ID_documentation_CLS'
 
-def baseArtifactIdJava = 'documentation'
-def artifactGroupIdJava = 'edu.wpi.first.wpilibj'
-def zipBaseNameJava = '_GROUP_edu_wpi_first_wpilibj_ID_documentation_CLS'
+String baseArtifactIdJava = 'documentation'
+String artifactGroupIdJava = 'edu.wpi.first.wpilibj'
+String zipBaseNameJava = '_GROUP_edu_wpi_first_wpilibj_ID_documentation_CLS'
 
-def outputsFolder = file("$project.buildDir/outputs")
+File outputsFolder = file("$project.buildDir/outputs")
 
 def cppProjectZips = []
 def cppIncludeRoots = []
@@ -174,12 +174,12 @@ doxygen {
     }
 }
 
-tasks.register("zipCppDocs", Zip) {
-    archiveBaseName = zipBaseNameCpp
-    destinationDirectory = outputsFolder
-    dependsOn doxygen
-    from ("$buildDir/docs/doxygen/html")
-    into '/'
+TaskProvider<Zip> zipCppDocs = tasks.register("zipCppDocs", Zip) { Zip zip ->
+    zip.archiveBaseName = zipBaseNameCpp
+    zip.destinationDirectory = outputsFolder
+    zip.dependsOn doxygen
+    zip.from ("$buildDir/docs/doxygen/html")
+    zip.into '/'
 }
 
 // Java
@@ -200,33 +200,33 @@ ext {
 
 apply from: "${rootDir}/shared/opencv.gradle"
 
-task generateJavaDocs(type: Javadoc) {
-    classpath += project(":wpimath").sourceSets.main.compileClasspath
-    options.links("https://docs.oracle.com/en/java/javase/11/docs/api/")
-    options.addStringOption("tag", "pre:a:Pre-Condition")
-    options.addBooleanOption("Xdoclint:html,missing,reference,syntax", true)
-    options.addBooleanOption('html5', true)
-    options.linkSource(true)
-    dependsOn project(':hal').generateUsageReporting
-    dependsOn project(':ntcore').ntcoreGenerateJavaTypes
-    dependsOn project(':wpilibj').generateJavaVersion
-    dependsOn project(':wpimath').generateNat
-    source project(':apriltag').sourceSets.main.java
-    source project(':cameraserver').sourceSets.main.java
-    source project(':cscore').sourceSets.main.java
-    source project(':hal').sourceSets.main.java
-    source project(':ntcore').sourceSets.main.java
-    source project(':wpilibNewCommands').sourceSets.main.java
-    source project(':wpilibj').sourceSets.main.java
-    source project(':wpimath').sourceSets.main.java
-    source project(':wpinet').sourceSets.main.java
-    source project(':wpiutil').sourceSets.main.java
-    source configurations.javaSource.collect { zipTree(it) }
-    include '**/*.java'
-    failOnError = true
+TaskProvider<Javadoc> generateJavaDocs = tasks.register('generateJavaDocs') { Javadoc t ->
+    t.classpath += project(":wpimath").sourceSets.main.compileClasspath
+    t.options.links("https://docs.oracle.com/en/java/javase/11/docs/api/")
+    t.options.addStringOption("tag", "pre:a:Pre-Condition")
+    t.options.addBooleanOption("Xdoclint:html,missing,reference,syntax", true)
+    t.options.addBooleanOption('html5', true)
+    t.options.linkSource(true)
+    t.dependsOn project(':hal').tasks.named('generateUsageReporting')
+    t.dependsOn project(':ntcore').tasks.named('ntcoreGenerateJavaTypes')
+    t.dependsOn project(':wpilibj').tasks.named('generateJavaVersion')
+    t.dependsOn project(':wpimath').tasks.named('generateNat')
+    t.source project(':apriltag').sourceSets.main.java
+    t.source project(':cameraserver').sourceSets.main.java
+    t.source project(':cscore').sourceSets.main.java
+    t.source project(':hal').sourceSets.main.java
+    t.source project(':ntcore').sourceSets.main.java
+    t.source project(':wpilibNewCommands').sourceSets.main.java
+    t.source project(':wpilibj').sourceSets.main.java
+    t.source project(':wpimath').sourceSets.main.java
+    t.source project(':wpinet').sourceSets.main.java
+    t.source project(':wpiutil').sourceSets.main.java
+    t.source configurations.javaSource.collect { zipTree(it) }
+    t.include '**/*.java'
+    t.failOnError = true
 
-    title = "WPILib API ${wpilibVersioning.version.get()}"
-    ext.entryPoint = "$destinationDir/index.html"
+    t.title = "WPILib API ${wpilibVersioning.version.get()}"
+    ext.entryPoint = "${t.destinationDir}/index.html"
 
     if (JavaVersion.current().isJava8Compatible() && project.hasProperty('docWarningsAsErrors')) {
         // Treat javadoc warnings as errors.
@@ -238,33 +238,33 @@ task generateJavaDocs(type: Javadoc) {
         // See JDK-8200363 (https://bugs.openjdk.java.net/browse/JDK-8200363)
         // for information about the nonstandard -Xwerror option. JDK 15+ has
         // -Werror.
-        options.addStringOption('Xwerror', '-quiet')
+        t.options.addStringOption('Xwerror', '-quiet')
     }
 
     if (JavaVersion.current().isJava11Compatible()) {
         if (!JavaVersion.current().isJava12Compatible()) {
-            options.addBooleanOption('-no-module-directories', true)
+            t.options.addBooleanOption('-no-module-directories', true)
         }
-        doLast {
+        t.doLast {
             // This is a work-around for https://bugs.openjdk.java.net/browse/JDK-8211194. Can be removed once that issue is fixed on JDK's side
             // Since JDK 11, package-list is missing from javadoc output files and superseded by element-list file, but a lot of external tools still need it
             // Here we generate this file manually
-            new File(destinationDir, 'package-list').text = new File(destinationDir, 'element-list').text
+            new File(t.destinationDir, 'package-list').text = new File(t.destinationDir, 'element-list').text
         }
     }
 }
 
-tasks.register("zipJavaDocs", Zip) {
-    archiveBaseName = zipBaseNameJava
-    destinationDirectory = outputsFolder
-    dependsOn generateJavaDocs
-    from ("$buildDir/docs/javadoc")
-    into '/'
+TaskProvider<Zip> zipJavaDocs = tasks.register("zipJavaDocs", Zip) { Zip zip ->
+    zip.archiveBaseName = zipBaseNameJava
+    zip.destinationDirectory = outputsFolder
+    zip.dependsOn generateJavaDocs
+    zip.from ("$buildDir/docs/javadoc")
+    zip.into '/'
 }
 
-tasks.register("zipDocs") {
-    dependsOn zipCppDocs
-    dependsOn zipJavaDocs
+tasks.register("zipDocs") { Task t ->
+    t.dependsOn zipCppDocs
+    t.dependsOn zipJavaDocs
 }
 
 apply plugin: 'maven-publish'

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -200,7 +200,7 @@ ext {
 
 apply from: "${rootDir}/shared/opencv.gradle"
 
-TaskProvider<Javadoc> generateJavaDocs = tasks.register('generateJavaDocs') { Javadoc t ->
+TaskProvider<Javadoc> generateJavaDocs = tasks.register('generateJavaDocs', Javadocs) { Javadoc t ->
     t.classpath += project(":wpimath").sourceSets.main.compileClasspath
     t.options.links("https://docs.oracle.com/en/java/javase/11/docs/api/")
     t.options.addStringOption("tag", "pre:a:Pre-Condition")

--- a/glass/build.gradle
+++ b/glass/build.gradle
@@ -21,20 +21,20 @@ if (!project.hasProperty('onlylinuxathena')) {
     apply from: "${rootDir}/shared/resources.gradle"
     apply from: "${rootDir}/shared/config.gradle"
 
-    def wpilibVersionFileInput = file("src/app/generate/WPILibVersion.cpp.in")
-    def wpilibVersionFileOutput = file("$buildDir/generated/app/cpp/WPILibVersion.cpp")
+    File wpilibVersionFileInput = file("src/app/generate/WPILibVersion.cpp.in")
+    File wpilibVersionFileOutput = file("$buildDir/generated/app/cpp/WPILibVersion.cpp")
 
     apply from: "${rootDir}/shared/imgui.gradle"
 
-    task generateCppVersion() {
-        description = 'Generates the wpilib version class'
-        group = 'WPILib'
+    TaskProvider<Task> generateCppVersion = tasks.register('generateCppVersion') { Task t ->
+        t.description = 'Generates the wpilib version class'
+        t.group = 'WPILib'
 
-        outputs.file wpilibVersionFileOutput
-        inputs.file wpilibVersionFileInput
+        t.outputs.file wpilibVersionFileOutput
+        t.inputs.file wpilibVersionFileInput
 
         if (wpilibVersioning.releaseMode) {
-            outputs.upToDateWhen { false }
+            t.outputs.upToDateWhen { false }
         }
 
         // We follow a simple set of checks to determine whether we should generate a new version file:
@@ -42,7 +42,7 @@ if (!project.hasProperty('onlylinuxathena')) {
         // 2. If there is no generated version number, we generate a new version file
         // 3. If there is a generated build number, and the release type is development, then we will
         //    only generate if the publish task is run.
-        doLast {
+        t.doLast {
             def version = wpilibVersioning.version.get()
             println "Writing version ${version} to $wpilibVersionFileOutput"
 
@@ -57,7 +57,9 @@ if (!project.hasProperty('onlylinuxathena')) {
     gradle.taskGraph.addTaskExecutionGraphListener { graph ->
         def willPublish = graph.hasTask(publish)
         if (willPublish) {
-            generateCppVersion.outputs.upToDateWhen { false }
+            generateCppVersion.configure { Task t ->
+                t.outputs.upToDateWhen { false }
+            }
         }
     }
 

--- a/outlineviewer/build.gradle
+++ b/outlineviewer/build.gradle
@@ -21,20 +21,20 @@ if (!project.hasProperty('onlylinuxathena')) {
     apply from: "${rootDir}/shared/resources.gradle"
     apply from: "${rootDir}/shared/config.gradle"
 
-    def wpilibVersionFileInput = file("src/main/generate/WPILibVersion.cpp.in")
-    def wpilibVersionFileOutput = file("$buildDir/generated/main/cpp/WPILibVersion.cpp")
+    File wpilibVersionFileInput = file("src/main/generate/WPILibVersion.cpp.in")
+    File wpilibVersionFileOutput = file("$buildDir/generated/main/cpp/WPILibVersion.cpp")
 
     apply from: "${rootDir}/shared/imgui.gradle"
 
-    task generateCppVersion() {
-        description = 'Generates the wpilib version class'
-        group = 'WPILib'
+    TaskProvider<Task> generateCppVersion = tasks.register('generateCppVersion') { Task t ->
+        t.description = 'Generates the wpilib version class'
+        t.group = 'WPILib'
 
-        outputs.file wpilibVersionFileOutput
-        inputs.file wpilibVersionFileInput
+        t.outputs.file wpilibVersionFileOutput
+        t.inputs.file wpilibVersionFileInput
 
         if (wpilibVersioning.releaseMode) {
-            outputs.upToDateWhen { false }
+            t.outputs.upToDateWhen { false }
         }
 
         // We follow a simple set of checks to determine whether we should generate a new version file:
@@ -42,7 +42,7 @@ if (!project.hasProperty('onlylinuxathena')) {
         // 2. If there is no generated version number, we generate a new version file
         // 3. If there is a generated build number, and the release type is development, then we will
         //    only generate if the publish task is run.
-        doLast {
+        t.doLast {
             def version = wpilibVersioning.version.get()
             println "Writing version ${version} to $wpilibVersionFileOutput"
 
@@ -57,7 +57,9 @@ if (!project.hasProperty('onlylinuxathena')) {
     gradle.taskGraph.addTaskExecutionGraphListener { graph ->
         def willPublish = graph.hasTask(publish)
         if (willPublish) {
-            generateCppVersion.outputs.upToDateWhen { false }
+            generateCppVersion.configure { Task t ->
+                t.outputs.upToDateWhen { false }
+            }
         }
     }
 

--- a/roborioteamnumbersetter/build.gradle
+++ b/roborioteamnumbersetter/build.gradle
@@ -21,21 +21,21 @@ if (!project.hasProperty('onlylinuxathena')) {
     apply from: "${rootDir}/shared/resources.gradle"
     apply from: "${rootDir}/shared/config.gradle"
 
-    def wpilibVersionFileInput = file("src/main/generate/WPILibVersion.cpp.in")
-    def wpilibVersionFileOutput = file("$buildDir/generated/main/cpp/WPILibVersion.cpp")
+    File wpilibVersionFileInput = file("src/main/generate/WPILibVersion.cpp.in")
+    File wpilibVersionFileOutput = file("$buildDir/generated/main/cpp/WPILibVersion.cpp")
 
     apply from: "${rootDir}/shared/libssh.gradle"
     apply from: "${rootDir}/shared/imgui.gradle"
 
-    task generateCppVersion() {
-        description = 'Generates the wpilib version class'
-        group = 'WPILib'
+    TaskProvider<Task> generateCppVersion = tasks.register('generateCppVersion') { Task t ->
+        t.description = 'Generates the wpilib version class'
+        t.group = 'WPILib'
 
-        outputs.file wpilibVersionFileOutput
-        inputs.file wpilibVersionFileInput
+        t.outputs.file wpilibVersionFileOutput
+        t.inputs.file wpilibVersionFileInput
 
         if (wpilibVersioning.releaseMode) {
-            outputs.upToDateWhen { false }
+            t.outputs.upToDateWhen { false }
         }
 
         // We follow a simple set of checks to determine whether we should generate a new version file:
@@ -43,7 +43,7 @@ if (!project.hasProperty('onlylinuxathena')) {
         // 2. If there is no generated version number, we generate a new version file
         // 3. If there is a generated build number, and the release type is development, then we will
         //    only generate if the publish task is run.
-        doLast {
+        t.doLast {
             def version = wpilibVersioning.version.get()
             println "Writing version ${version} to $wpilibVersionFileOutput"
 

--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -8,30 +8,35 @@ def javaBaseName = "_GROUP_edu_wpi_first_${project.baseId}_ID_${project.baseId}-
 
 def outputsFolder = file("$project.buildDir/outputs")
 
-task sourcesJar(type: Jar, dependsOn: classes) {
+tasks.register('sourcesJar', Jar) {
+    dependsOn 'classes'
     classifier = 'sources'
     from sourceSets.main.allSource
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
+tasks.register('javadocJar', Jar) {
+    dependsOn 'javadoc'
     classifier = 'javadoc'
     from javadoc.destinationDir
 }
 
-task outputJar(type: Jar, dependsOn: classes) {
+tasks.register('outputJar', Jar) {
+    dependsOn 'classes'
     archiveBaseName = javaBaseName
     destinationDirectory = outputsFolder
     from sourceSets.main.output
 }
 
-task outputSourcesJar(type: Jar, dependsOn: classes) {
+tasks.register('outputSourcesJar', Jar) {
+    dependsOn 'classes'
     archiveBaseName = javaBaseName
     destinationDirectory = outputsFolder
     classifier = 'sources'
     from sourceSets.main.allSource
 }
 
-task outputJavadocJar(type: Jar, dependsOn: javadoc) {
+tasks.register('outputJavadocJar', Jar) {
+    dependsOn 'javadoc'
     archiveBaseName = javaBaseName
     destinationDirectory = outputsFolder
     classifier = 'javadoc'
@@ -119,7 +124,7 @@ dependencies {
     devImplementation sourceSets.main.output
 }
 
-task run(type: JavaExec) {
+tasks.register('run', JavaExec) {
     classpath = sourceSets.dev.runtimeClasspath
 
     mainClass = project.devMain

--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -6,47 +6,41 @@ def baseArtifactId = project.baseId
 def artifactGroupId = project.groupId
 def javaBaseName = "_GROUP_edu_wpi_first_${project.baseId}_ID_${project.baseId}-java_CLS"
 
-File outputsFolder = file("$project.buildDir/outputs")
+def outputsFolder = file("$project.buildDir/outputs")
 
-TaskProvider<Jar> sourcesJar = tasks.register('sourcesJar', Jar) {
+tasks.register('sourcesJar', Jar) {
     dependsOn 'classes'
     classifier = 'sources'
     from sourceSets.main.allSource
 }
 
-TaskProvider<org.gradle.jvm.tasks.Jar> javadocJar = tasks.register('javadocJar', Jar) {
+tasks.register('javadocJar', Jar) {
     dependsOn 'javadoc'
     classifier = 'javadoc'
     from javadoc.destinationDir
 }
 
-TaskProvider<Jar> outputJar = tasks.register('outputJar', Jar) { Jar j ->
-    j.dependsOn 'classes'
-    j.archiveBaseName = javaBaseName
-    j.destinationDirectory = outputsFolder
-    j.from sourceSets.main.output
-
-    addTaskToCopyAllOutputs(j)
+tasks.register('outputJar', Jar) {
+    dependsOn 'classes'
+    archiveBaseName = javaBaseName
+    destinationDirectory = outputsFolder
+    from sourceSets.main.output
 }
 
-TaskProvider<Jar> outputSourcesJar = tasks.register('outputSourcesJar', Jar) { Jar j ->
-    j.dependsOn 'classes'
-    j.archiveBaseName = javaBaseName
-    j.destinationDirectory = outputsFolder
-    j.classifier = 'sources'
-    j.from sourceSets.main.allSource
-
-    addTaskToCopyAllOutputs(j)
+tasks.register('outputSourcesJar', Jar) {
+    dependsOn 'classes'
+    archiveBaseName = javaBaseName
+    destinationDirectory = outputsFolder
+    classifier = 'sources'
+    from sourceSets.main.allSource
 }
 
-TaskProvider<Jar> outputJavadocJar = tasks.register('outputJavadocJar', Jar) { Jar j ->
-    j.dependsOn 'javadoc'
-    j.archiveBaseName = javaBaseName
-    j.destinationDirectory = outputsFolder
-    j.classifier = 'javadoc'
-    j.from javadoc.destinationDir
-
-    addTaskToCopyAllOutputs(j)
+tasks.register('outputJavadocJar', Jar) {
+    dependsOn 'javadoc'
+    archiveBaseName = javaBaseName
+    destinationDirectory = outputsFolder
+    classifier = 'javadoc'
+    from javadoc.destinationDir
 }
 
 artifacts {
@@ -57,13 +51,15 @@ artifacts {
     archives outputJavadocJar
 }
 
-tasks.named('build') { Task build ->
-    build.dependsOn outputSourcesJar
-    build.dependsOn outputJavadocJar
-    build.dependsOn outputJar
+addTaskToCopyAllOutputs(outputSourcesJar)
+addTaskToCopyAllOutputs(outputJavadocJar)
+addTaskToCopyAllOutputs(outputJar)
 
-    project(':').libraryBuild.dependsOn build
-}
+build.dependsOn outputSourcesJar
+build.dependsOn outputJavadocJar
+build.dependsOn outputJar
+
+project(':').libraryBuild.dependsOn build
 
 publishing {
     publications {
@@ -80,18 +76,18 @@ publishing {
     }
 }
 
-tasks.named('test', Test) { Test t ->
-    t.useJUnitPlatform()
-    t.systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
-    t.testLogging {
+test {
+    useJUnitPlatform()
+    systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
+    testLogging {
         events "failed"
         exceptionFormat "full"
     }
-    t.finalizedBy tasks.named('jacocoTestReport', JacocoReport)
+    finalizedBy jacocoTestReport
+}
 
-    if (project.hasProperty('onlylinuxathena') || project.hasProperty('onlylinuxarm32') || project.hasProperty('onlylinuxarm64')) {
-        t.enabled = false
-    }
+if (project.hasProperty('onlylinuxathena') || project.hasProperty('onlylinuxarm32') || project.hasProperty('onlylinuxarm64')) {
+    test.enabled = false
 }
 
 repositories {
@@ -105,8 +101,8 @@ sourceSets {
     dev
 }
 
-tasks.withType(JavaCompile).configureEach { JavaCompile javac ->
-    javac.options.compilerArgs = [
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs = [
         '--release',
         '11',
         '-encoding',
@@ -128,22 +124,20 @@ dependencies {
     devImplementation sourceSets.main.output
 }
 
-tasks.register('run', JavaExec) { JavaExec run ->
-    run.classpath = sourceSets.dev.runtimeClasspath
+tasks.register('run', JavaExec) {
+    classpath = sourceSets.dev.runtimeClasspath
 
-    run.mainClass = project.devMain
+    mainClass = project.devMain
 }
 
-tasks.named('build') { Task build ->
-    build.dependsOn devClasses
-}
+build.dependsOn devClasses
 
 jacoco {
     toolVersion = "0.8.8"
 }
 
-tasks.named('jacocoTestReport', JacocoReport) { JacocoReport task ->
-    task.reports {
+jacocoTestReport {
+    reports {
         xml.required = true
         html.required = true
     }

--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -6,41 +6,47 @@ def baseArtifactId = project.baseId
 def artifactGroupId = project.groupId
 def javaBaseName = "_GROUP_edu_wpi_first_${project.baseId}_ID_${project.baseId}-java_CLS"
 
-def outputsFolder = file("$project.buildDir/outputs")
+File outputsFolder = file("$project.buildDir/outputs")
 
-tasks.register('sourcesJar', Jar) {
+TaskProvider<Jar> sourcesJar = tasks.register('sourcesJar', Jar) {
     dependsOn 'classes'
     classifier = 'sources'
     from sourceSets.main.allSource
 }
 
-tasks.register('javadocJar', Jar) {
+TaskProvider<org.gradle.jvm.tasks.Jar> javadocJar = tasks.register('javadocJar', Jar) {
     dependsOn 'javadoc'
     classifier = 'javadoc'
     from javadoc.destinationDir
 }
 
-tasks.register('outputJar', Jar) {
-    dependsOn 'classes'
-    archiveBaseName = javaBaseName
-    destinationDirectory = outputsFolder
-    from sourceSets.main.output
+TaskProvider<Jar> outputJar = tasks.register('outputJar', Jar) { Jar j ->
+    j.dependsOn 'classes'
+    j.archiveBaseName = javaBaseName
+    j.destinationDirectory = outputsFolder
+    j.from sourceSets.main.output
+
+    addTaskToCopyAllOutputs(j)
 }
 
-tasks.register('outputSourcesJar', Jar) {
-    dependsOn 'classes'
-    archiveBaseName = javaBaseName
-    destinationDirectory = outputsFolder
-    classifier = 'sources'
-    from sourceSets.main.allSource
+TaskProvider<Jar> outputSourcesJar = tasks.register('outputSourcesJar', Jar) { Jar j ->
+    j.dependsOn 'classes'
+    j.archiveBaseName = javaBaseName
+    j.destinationDirectory = outputsFolder
+    j.classifier = 'sources'
+    j.from sourceSets.main.allSource
+
+    addTaskToCopyAllOutputs(j)
 }
 
-tasks.register('outputJavadocJar', Jar) {
-    dependsOn 'javadoc'
-    archiveBaseName = javaBaseName
-    destinationDirectory = outputsFolder
-    classifier = 'javadoc'
-    from javadoc.destinationDir
+TaskProvider<Jar> outputJavadocJar = tasks.register('outputJavadocJar', Jar) { Jar j ->
+    j.dependsOn 'javadoc'
+    j.archiveBaseName = javaBaseName
+    j.destinationDirectory = outputsFolder
+    j.classifier = 'javadoc'
+    j.from javadoc.destinationDir
+
+    addTaskToCopyAllOutputs(j)
 }
 
 artifacts {
@@ -51,15 +57,13 @@ artifacts {
     archives outputJavadocJar
 }
 
-addTaskToCopyAllOutputs(outputSourcesJar)
-addTaskToCopyAllOutputs(outputJavadocJar)
-addTaskToCopyAllOutputs(outputJar)
+tasks.named('build') { Task build ->
+    build.dependsOn outputSourcesJar
+    build.dependsOn outputJavadocJar
+    build.dependsOn outputJar
 
-build.dependsOn outputSourcesJar
-build.dependsOn outputJavadocJar
-build.dependsOn outputJar
-
-project(':').libraryBuild.dependsOn build
+    project(':').libraryBuild.dependsOn build
+}
 
 publishing {
     publications {
@@ -76,18 +80,18 @@ publishing {
     }
 }
 
-test {
-    useJUnitPlatform()
-    systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
-    testLogging {
+tasks.named('test', Test) { Test t ->
+    t.useJUnitPlatform()
+    t.systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
+    t.testLogging {
         events "failed"
         exceptionFormat "full"
     }
-    finalizedBy jacocoTestReport
-}
+    t.finalizedBy tasks.named('jacocoTestReport', JacocoReport)
 
-if (project.hasProperty('onlylinuxathena') || project.hasProperty('onlylinuxarm32') || project.hasProperty('onlylinuxarm64')) {
-    test.enabled = false
+    if (project.hasProperty('onlylinuxathena') || project.hasProperty('onlylinuxarm32') || project.hasProperty('onlylinuxarm64')) {
+        t.enabled = false
+    }
 }
 
 repositories {
@@ -101,8 +105,8 @@ sourceSets {
     dev
 }
 
-tasks.withType(JavaCompile).configureEach {
-    options.compilerArgs = [
+tasks.withType(JavaCompile).configureEach { JavaCompile javac ->
+    javac.options.compilerArgs = [
         '--release',
         '11',
         '-encoding',
@@ -124,20 +128,22 @@ dependencies {
     devImplementation sourceSets.main.output
 }
 
-tasks.register('run', JavaExec) {
-    classpath = sourceSets.dev.runtimeClasspath
+tasks.register('run', JavaExec) { JavaExec run ->
+    run.classpath = sourceSets.dev.runtimeClasspath
 
-    mainClass = project.devMain
+    run.mainClass = project.devMain
 }
 
-build.dependsOn devClasses
+tasks.named('build') { Task build ->
+    build.dependsOn devClasses
+}
 
 jacoco {
     toolVersion = "0.8.8"
 }
 
-jacocoTestReport {
-    reports {
+tasks.named('jacocoTestReport', JacocoReport) { JacocoReport task ->
+    task.reports {
         xml.required = true
         html.required = true
     }

--- a/shared/java/javastyle.gradle
+++ b/shared/java/javastyle.gradle
@@ -71,8 +71,8 @@ if (!project.hasProperty('skipJavaFormat')) {
     }
 }
 
-task javaFormat {
+tasks.register('javaFormat') {
     dependsOn(tasks.withType(Checkstyle))
     dependsOn(tasks.withType(Pmd))
+    dependsOn(tasks.named('spotlessApply'))
 }
-javaFormat.dependsOn 'spotlessApply'

--- a/shared/resources.gradle
+++ b/shared/resources.gradle
@@ -1,25 +1,25 @@
 import groovy.io.FileType
 
-ext.createGenerateResourcesTask = { name, prefix, namespace, project ->
-    def generatedOutputDir = file("$buildDir/generated/$name/cpp")
+ext.createGenerateResourcesTask = { String name, String prefix, String namespace, Project project ->
+    File generatedOutputDir = file("$buildDir/generated/$name/cpp")
 
-    def inputDir = file("$projectDir/src/$name/native/resources")
+    File inputDir = file("$projectDir/src/$name/native/resources")
 
     if (!prefix.isEmpty()) prefix += '_'
 
-    def task = project.tasks.create("generateResources-$name") {
-        outputs.dir generatedOutputDir
-        inputs.dir inputDir
+    def task = project.tasks.register("generateResources-$name") { Task t ->
+        t.outputs.dir generatedOutputDir
+        t.inputs.dir inputDir
 
-        doLast {
+        t.doLast {
             generatedOutputDir.mkdirs()
             inputDir.eachFileRecurse (FileType.FILES) { inputFile ->
                 if (inputFile.name.startsWith('.')) return
                     def fileBytes = inputFile.bytes
-                def outputFile = file("$generatedOutputDir/${inputFile.name}.cpp")
-                def funcName = "GetResource_" + inputFile.name.replaceAll('[^a-zA-Z0-9]', '_')
-                outputFile.withWriter { out ->
-                    def inputBytes = inputFile.bytes
+                File outputFile = file("$generatedOutputDir/${inputFile.name}.cpp")
+                String funcName = "GetResource_" + inputFile.name.replaceAll('[^a-zA-Z0-9]', '_')
+                outputFile.withWriter { BufferedWriter out ->
+                    byte[] inputBytes = inputFile.bytes
                     out.print '''#include <stddef.h>
 #include <string_view>
 extern "C" {

--- a/wpilibc/build.gradle
+++ b/wpilibc/build.gradle
@@ -12,18 +12,18 @@ ext {
 
 apply from: "${rootDir}/shared/config.gradle"
 
-def wpilibVersionFileInput = file("src/generate/WPILibVersion.cpp.in")
-def wpilibVersionFileOutput = file("$buildDir/generated/cpp/WPILibVersion.cpp")
+File wpilibVersionFileInput = file("src/generate/WPILibVersion.cpp.in")
+File wpilibVersionFileOutput = file("$buildDir/generated/cpp/WPILibVersion.cpp")
 
-task generateCppVersion() {
-    description = 'Generates the wpilib version class'
-    group = 'WPILib'
+tasks.register('generateCppVersion') { Task t ->
+    t.description = 'Generates the wpilib version class'
+    t.group = 'WPILib'
 
-    outputs.file wpilibVersionFileOutput
-    inputs.file wpilibVersionFileInput
+    t.outputs.file wpilibVersionFileOutput
+    t.inputs.file wpilibVersionFileInput
 
     if (wpilibVersioning.releaseMode) {
-        outputs.upToDateWhen { false }
+        t.outputs.upToDateWhen { false }
     }
 
     // We follow a simple set of checks to determine whether we should generate a new version file:
@@ -31,7 +31,7 @@ task generateCppVersion() {
     // 2. If there is no generated version number, we generate a new version file
     // 3. If there is a generated build number, and the release type is development, then we will
     //    only generate if the publish task is run.
-    doLast {
+    t.doLast {
         def version = wpilibVersioning.version.get()
         println "Writing version ${version} to $wpilibVersionFileOutput"
 

--- a/wpilibc/build.gradle
+++ b/wpilibc/build.gradle
@@ -15,7 +15,7 @@ apply from: "${rootDir}/shared/config.gradle"
 File wpilibVersionFileInput = file("src/generate/WPILibVersion.cpp.in")
 File wpilibVersionFileOutput = file("$buildDir/generated/cpp/WPILibVersion.cpp")
 
-tasks.register('generateCppVersion') { Task t ->
+TaskProvider<Task> generateCppVersion = tasks.register('generateCppVersion') { Task t ->
     t.description = 'Generates the wpilib version class'
     t.group = 'WPILib'
 
@@ -46,7 +46,9 @@ tasks.register('generateCppVersion') { Task t ->
 gradle.taskGraph.addTaskExecutionGraphListener { graph ->
     def willPublish = graph.hasTask(publish)
     if (willPublish) {
-        generateCppVersion.outputs.upToDateWhen { false }
+        generateCppVersion.configure { Task t ->
+            t.outputs.upToDateWhen { false }
+        }
     }
 }
 

--- a/wpilibc/publish.gradle
+++ b/wpilibc/publish.gradle
@@ -23,7 +23,7 @@ task cppSourcesZip(type: Zip) {
     }
 }
 
-cppSourcesZip.dependsOn generateCppVersion
+cppSourcesZip.dependsOn tasks.named('generateCppVersion')
 
 task cppHeadersZip(type: Zip) {
     destinationDirectory = outputsFolder

--- a/wpilibj/build.gradle
+++ b/wpilibj/build.gradle
@@ -14,7 +14,7 @@ apply from: "${rootDir}/shared/java/javacommon.gradle"
 File wpilibVersionFileInput = file("src/generate/WPILibVersion.java.in")
 File wpilibVersionFileOutput = file("$buildDir/generated/java/edu/wpi/first/wpilibj/util/WPILibVersion.java")
 
-tasks.register('generateJavaVersion') { Task t ->
+TaskProvider<Task> generateJavaVersion = tasks.register('generateJavaVersion') { Task t ->
     t.description = 'Generates the wpilib version class'
     t.group = 'WPILib'
 
@@ -45,14 +45,16 @@ tasks.register('generateJavaVersion') { Task t ->
 gradle.taskGraph.addTaskExecutionGraphListener { graph ->
     def willPublish = graph.hasTask(publish)
     if (willPublish) {
-        generateJavaVersion.outputs.upToDateWhen { false }
+        generateJavaVersion.configure { Task t ->
+            t.outputs.upToDateWhen { false }
+        }
     }
 }
 
 sourceSets.main.java.srcDir "${buildDir}/generated/java/"
 
-compileJava {
-    dependsOn generateJavaVersion
+tasks.named('compileJava', JavaCompile) { JavaCompile javaCompile ->
+    javaCompile.dependsOn generateJavaVersion
 }
 
 repositories {

--- a/wpilibj/build.gradle
+++ b/wpilibj/build.gradle
@@ -11,18 +11,18 @@ ext {
 
 apply from: "${rootDir}/shared/java/javacommon.gradle"
 
-def wpilibVersionFileInput = file("src/generate/WPILibVersion.java.in")
-def wpilibVersionFileOutput = file("$buildDir/generated/java/edu/wpi/first/wpilibj/util/WPILibVersion.java")
+File wpilibVersionFileInput = file("src/generate/WPILibVersion.java.in")
+File wpilibVersionFileOutput = file("$buildDir/generated/java/edu/wpi/first/wpilibj/util/WPILibVersion.java")
 
-task generateJavaVersion() {
-    description = 'Generates the wpilib version class'
-    group = 'WPILib'
+tasks.register('generateJavaVersion') { Task t ->
+    t.description = 'Generates the wpilib version class'
+    t.group = 'WPILib'
 
-    outputs.file wpilibVersionFileOutput
-    inputs.file wpilibVersionFileInput
+    t.outputs.file wpilibVersionFileOutput
+    t.inputs.file wpilibVersionFileInput
 
     if (wpilibVersioning.releaseMode) {
-        outputs.upToDateWhen { false }
+        t.outputs.upToDateWhen { false }
     }
 
     // We follow a simple set of checks to determine whether we should generate a new version file:
@@ -30,7 +30,7 @@ task generateJavaVersion() {
     // 2. If there is no generated version number, we generate a new version file
     // 3. If there is a generated build number, and the release type is development, then we will
     //    only generate if the publish task is run.
-    doLast {
+   t.doLast {
         def version = wpilibVersioning.version.get()
         println "Writing version ${version} to $wpilibVersionFileOutput"
 

--- a/wpimath/build.gradle
+++ b/wpimath/build.gradle
@@ -63,20 +63,20 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-databind:2.12.4"
 }
 
-def wpilibNumberFileInput = file("src/generate/GenericNumber.java.jinja")
-def natFileInput = file("src/generate/Nat.java.jinja")
-def wpilibNumberFileOutputDir = file("$buildDir/generated/java/edu/wpi/first/math/numbers")
-def wpilibNatFileOutput = file("$buildDir/generated/java/edu/wpi/first/math/Nat.java")
-def maxNum = 20
+File wpilibNumberFileInput = file("src/generate/GenericNumber.java.jinja")
+File natFileInput = file("src/generate/Nat.java.jinja")
+File wpilibNumberFileOutputDir = file("$buildDir/generated/java/edu/wpi/first/math/numbers")
+File wpilibNatFileOutput = file("$buildDir/generated/java/edu/wpi/first/math/Nat.java")
+int maxNum = 20
 
-task generateNumbers() {
-    description = "Generates generic number classes from template"
-    group = "WPILib"
+TaskProvider<Task> generateNumbers = tasks.register('generateNumbers') { Task t ->
+    t.description = "Generates generic number classes from template"
+    t.group = "WPILib"
 
-    inputs.file wpilibNumberFileInput
-    outputs.dir wpilibNumberFileOutputDir
+    t.inputs.file wpilibNumberFileInput
+    t.outputs.dir wpilibNumberFileOutputDir
 
-    doLast {
+    t.doLast {
         if(wpilibNumberFileOutputDir.exists()) {
             wpilibNumberFileOutputDir.delete()
         }
@@ -97,14 +97,14 @@ task generateNumbers() {
     }
 }
 
-task generateNat() {
-    description = "Generates Nat.java"
-    group = "WPILib"
-    inputs.file natFileInput
-    outputs.file wpilibNatFileOutput
-    dependsOn generateNumbers
+TaskProvider<Task> generateNat = tasks.register('generateNat') { Task t ->
+    t.description = "Generates Nat.java"
+    t.group = "WPILib"
+    t.inputs.file natFileInput
+    t.outputs.file wpilibNatFileOutput
+    t.dependsOn generateNumbers
 
-    doLast {
+    t.doLast {
         if(wpilibNatFileOutput.exists()) {
             wpilibNatFileOutput.delete()
         }
@@ -123,5 +123,8 @@ task generateNat() {
 }
 
 sourceSets.main.java.srcDir "${buildDir}/generated/java"
-compileJava.dependsOn generateNumbers
-compileJava.dependsOn generateNat
+
+tasks.named('compileJava', JavaCompile) { JavaCompile compileJava ->
+    compileJava.dependsOn generateNumbers
+    compileJava.dependsOn generateNat
+}

--- a/wpiutil/build.gradle
+++ b/wpiutil/build.gradle
@@ -265,10 +265,10 @@ sourceSets {
     printlog
 }
 
-task runPrintLog(type: JavaExec) {
-    classpath = sourceSets.printlog.runtimeClasspath
+tasks.register('runPrintLog', JavaExec) { JavaExec it ->
+    it.classpath = sourceSets.printlog.runtimeClasspath
 
-    mainClass = 'printlog.PrintLog'
+    it.mainClass = 'printlog.PrintLog'
 }
 
 dependencies {


### PR DESCRIPTION
Many of the tasks are created eagerly, increasing configuration time. This refactors task declarations to be created lazily.