### PR TITLE
[glass] Fix NT view UpdateClients() bug

### DIFF
--- a/glass/src/libnt/native/cpp/NetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTables.cpp
@@ -478,6 +478,10 @@ void NetworkTablesModel::Update() {
             entry->info.type_str == "msgpack") {
           // meta topic handling
           if (entry->info.name == "$clients") {
+            // need to remove deleted entries as UpdateClients() uses GetEntry()
+            if (updateTree) {
+              std::erase(m_sortedEntries, nullptr);
+            }
             UpdateClients(entry->value.GetRaw());
           } else if (entry->info.name == "$serverpub") {
             m_server.UpdatePublishers(entry->value.GetRaw());
@@ -505,9 +509,7 @@ void NetworkTablesModel::Update() {
   }
 
   // remove deleted entries
-  m_sortedEntries.erase(
-      std::remove(m_sortedEntries.begin(), m_sortedEntries.end(), nullptr),
-      m_sortedEntries.end());
+  std::erase(m_sortedEntries, nullptr);
 
   RebuildTree();
 }


### PR DESCRIPTION
If UpdateClients() was called in the same update batch as an entry removal, it could crash in GetEntry() due to a null entry caused by deletion before a removal erase pass was made.