### PR TITLE
[wpilib] Joystick.getMagnitude(): use hypot() function

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandXboxController.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandXboxController.java
@@ -49,7 +49,7 @@ public class CommandXboxController extends CommandGenericHID {
   }
 
   /**
-   * Constructs an event instance around the left bumper's digital signal.
+   * Constructs an event instance around the right bumper's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
    * @return an event instance representing the right bumper's digital signal attached to the given
@@ -71,7 +71,7 @@ public class CommandXboxController extends CommandGenericHID {
   }
 
   /**
-   * Constructs an event instance around the right bumper's digital signal.
+   * Constructs an event instance around the left bumper's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
    * @return an event instance representing the left bumper's digital signal attached to the given

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandXboxController.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/button/CommandXboxController.java
@@ -49,7 +49,7 @@ public class CommandXboxController extends CommandGenericHID {
   }
 
   /**
-   * Constructs an event instance around the right bumper's digital signal.
+   * Constructs an event instance around the left bumper's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
    * @return an event instance representing the right bumper's digital signal attached to the given
@@ -71,7 +71,7 @@ public class CommandXboxController extends CommandGenericHID {
   }
 
   /**
-   * Constructs an event instance around the left bumper's digital signal.
+   * Constructs an event instance around the right bumper's digital signal.
    *
    * @param loop the event loop instance to attach the event to.
    * @return an event instance representing the left bumper's digital signal attached to the given

--- a/wpilibc/src/main/native/cpp/Joystick.cpp
+++ b/wpilibc/src/main/native/cpp/Joystick.cpp
@@ -116,7 +116,7 @@ BooleanEvent Joystick::Top(EventLoop* loop) const {
 }
 
 double Joystick::GetMagnitude() const {
-  return std::sqrt(std::pow(GetX(), 2) + std::pow(GetY(), 2));
+  return std::hypot(GetX(), GetY());
 }
 
 double Joystick::GetDirectionRadians() const {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
@@ -291,7 +291,7 @@ public class Joystick extends GenericHID {
    * @return The magnitude of the direction vector
    */
   public double getMagnitude() {
-    return Math.sqrt(Math.pow(getX(), 2) + Math.pow(getY(), 2));
+    return Math.hypot(getX(), getY());
   }
 
   /**


### PR DESCRIPTION
changes from manually taking the hypotenuse of the function to calling `Math.hypot` and `std::hypot` on the the `getX()` and `getY()` values