### PR TITLE
Expand unit conversion features for the Falcon500

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
@@ -60,7 +60,7 @@ public final class FalconUnitConversion {
      * @return linear velocity of rotating object in meters per second
      */
     public static double falcon500VelocityToLinearVelocity(double falconVelocity, double radius, double gearRatio) {
-        return Units.rpmToLinearVelocity(falcon500VelocityToRPM(falconVelocity), radius) / gearRatio;
+        return Units.rotationsPerMinuteToMetersPerSecond(falcon500VelocityToRPM(falconVelocity), radius) / gearRatio;
     }
 
     /**
@@ -83,7 +83,7 @@ public final class FalconUnitConversion {
      * @return Falcon500 native velocity units, ticks per 100ms
      */
     public static double linearVelocityToFalcon500Velocity(double linearVelocity, double radius, double gearRatio) {
-        return rpmToFalcon500Velocity(Units.linearVelocityToRPM(linearVelocity, radius)) * gearRatio;
+        return rpmToFalcon500Velocity(Units.metersPerSecondToRotationPerMinute(linearVelocity, radius)) * gearRatio;
     }
 
     /**

--- a/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
@@ -15,8 +15,8 @@ public final class FalconUnitConversion {
      * @param gearRatio gear ratio between motor and rotating object
      * @return angular velocity of rotating object in rad/s
      */
-    public static double falcon500VelocityToAngularVelocity(double falconVelocity, double gearRatio) {
-        return Units.rotationsPerMinuteToRadiansPerSecond(falcon500VelocityToRPM(falconVelocity)) / gearRatio;
+    public static double falcon500VelocityToRadiansPerSecond(double falconVelocity, double gearRatio) {
+        return Units.rotationsPerMinuteToRadiansPerSecond(falcon500VelocityToRotationsPerMinute(falconVelocity)) / gearRatio;
     }
 
     /**
@@ -25,8 +25,8 @@ public final class FalconUnitConversion {
      * @param falconVelocity velocity reported by Falcon500. ticks per 100ms
      * @return angular velocity of rotating object in rad/s
      */
-    public static double falcon500VelocityToAngularVelocity(double falconVelocity) {
-        return falcon500VelocityToAngularVelocity(falconVelocity, 1);
+    public static double falcon500VelocityToRadiansPerSecond(double falconVelocity) {
+        return falcon500VelocityToRadiansPerSecond(falconVelocity, 1);
     }
 
     /**
@@ -36,8 +36,8 @@ public final class FalconUnitConversion {
      * @param gearRatio gear ratio between motor and rotating object
      * @return Falcon500 native velocity units, ticks per 100ms
      */
-    public static double angularVelocityToFalcon500Velocity(double angularVelocity, double gearRatio) {
-        return rpmToFalcon500Velocity(Units.radiansPerSecondToRotationsPerMinute(angularVelocity)) * gearRatio;
+    public static double radiansPerSecondToFalcon500Velocity(double angularVelocity, double gearRatio) {
+        return rotationsPerMinuteToFalcon500Velocity(Units.radiansPerSecondToRotationsPerMinute(angularVelocity)) * gearRatio;
     }
 
     /**
@@ -47,8 +47,8 @@ public final class FalconUnitConversion {
      * @param angularVelocity angular velocity of object in rad/s
      * @return Falcon500 native velocity units, ticks per 100ms
      */
-    public static double angularVelocityToFalcon500Velocity(double angularVelocity) {
-        return angularVelocityToFalcon500Velocity(angularVelocity, 1);
+    public static double radiansPerSecondToFalcon500Velocity(double angularVelocity) {
+        return radiansPerSecondToFalcon500Velocity(angularVelocity, 1);
     }
 
     /**
@@ -59,8 +59,8 @@ public final class FalconUnitConversion {
      * @param gearRatio gear ratio between motor and rotating object
      * @return linear velocity of rotating object in meters per second
      */
-    public static double falcon500VelocityToLinearVelocity(double falconVelocity, double radius, double gearRatio) {
-        return Units.rotationsPerMinuteToMetersPerSecond(falcon500VelocityToRPM(falconVelocity), radius) / gearRatio;
+    public static double falcon500VelocityToMetersPerSecond(double falconVelocity, double radius, double gearRatio) {
+        return Units.rotationsPerMinuteToMetersPerSecond(falcon500VelocityToRotationsPerMinute(falconVelocity), radius) / gearRatio;
     }
 
     /**
@@ -70,8 +70,8 @@ public final class FalconUnitConversion {
      * @param radius radius of rotating object in meters
      * @return linear velocity of rotating object in meters per second
      */
-    public static double falcon500VelocityToLinearVelocity(double falconVelocity, double radius) {
-        return falcon500VelocityToLinearVelocity(falconVelocity, radius, 1);
+    public static double falcon500VelocityToMetersPerSecond(double falconVelocity, double radius) {
+        return falcon500VelocityToMetersPerSecond(falconVelocity, radius, 1);
     }
 
     /**
@@ -82,8 +82,8 @@ public final class FalconUnitConversion {
      * @param gearRatio gear ratio between motor and rotating object
      * @return Falcon500 native velocity units, ticks per 100ms
      */
-    public static double linearVelocityToFalcon500Velocity(double linearVelocity, double radius, double gearRatio) {
-        return rpmToFalcon500Velocity(Units.metersPerSecondToRotationPerMinute(linearVelocity, radius)) * gearRatio;
+    public static double metersPerSecondToFalcon500Velocity(double linearVelocity, double radius, double gearRatio) {
+        return rotationsPerMinuteToFalcon500Velocity(Units.metersPerSecondToRotationPerMinute(linearVelocity, radius)) * gearRatio;
     }
 
     /**
@@ -93,8 +93,8 @@ public final class FalconUnitConversion {
      * @param radius radius of rotating object
      * @return Falcon500 native velocity units, ticks per 100ms
      */
-    public static double linearVelocityToFalcon500Velocity(double linearVelocity, double radius) {
-        return linearVelocityToFalcon500Velocity(linearVelocity, radius, 1);
+    public static double metersPerSecondToFalcon500Velocity(double linearVelocity, double radius) {
+        return metersPerSecondToFalcon500Velocity(linearVelocity, radius, 1);
     }
 
     /**
@@ -103,7 +103,7 @@ public final class FalconUnitConversion {
      * @param falconVelocity Falcon500 native velocity units, ticks per 100ms, of rotating object
      * @return rotations per minute
      */
-    public static double falcon500VelocityToRPM(double falconVelocity) {
+    public static double falcon500VelocityToRotationsPerMinute(double falconVelocity) {
         return falconVelocity * 600.0 / kFalconIntegratedEncoderResolution;
     }
 
@@ -113,7 +113,7 @@ public final class FalconUnitConversion {
      * @param rpm rotations per minute
      * @return Falcon500 native velocity units, ticks per 100ms, of rotating object
      */
-    public static double rpmToFalcon500Velocity(double rpm) {
+    public static double rotationsPerMinuteToFalcon500Velocity(double rpm) {
         return rpm * kFalconIntegratedEncoderResolution / 600.0;
     }
 

--- a/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
@@ -1,160 +1,182 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package edu.wpi.first.math.util;
 
 public final class FalconUnitConversion {
-    private static final double kFalconIntegratedEncoderResolution = 2048;
+  private static final double kFalconIntegratedEncoderResolution = 2048;
 
-    /** Utility class, so constructor is private. */
-    private FalconUnitConversion() {
-        throw new UnsupportedOperationException("This is a utility class!");
-    }
+  /** Utility class, so constructor is private. */
+  private FalconUnitConversion() {
+    throw new UnsupportedOperationException("This is a utility class!");
+  }
 
-    /**
-     * Convert Falcon500 integrated encoder velocity to angular velocity
-     *
-     * @param falconVelocity velocity reported by Falcon500. ticks per 100ms
-     * @param gearRatio gear ratio between motor and rotating object. Number of input rotations / number of output rotations
-     * @return angular velocity of rotating object in rad/s
-     */
-    public static double falcon500VelocityToRadiansPerSecond(double falconVelocity, double gearRatio) {
-        return Units.rotationsPerMinuteToRadiansPerSecond(falcon500VelocityToRotationsPerMinute(falconVelocity)) / gearRatio;
-    }
+  /**
+   * Convert Falcon500 integrated encoder velocity to angular velocity
+   *
+   * @param falconVelocity velocity reported by Falcon500. ticks per 100ms
+   * @param gearRatio gear ratio between motor and rotating object. Number of input rotations /
+   *     number of output rotations
+   * @return angular velocity of rotating object in rad/s
+   */
+  public static double falcon500VelocityToRadiansPerSecond(
+      double falconVelocity, double gearRatio) {
+    return Units.rotationsPerMinuteToRadiansPerSecond(
+            falcon500VelocityToRotationsPerMinute(falconVelocity))
+        / gearRatio;
+  }
 
-    /**
-     * Convert Falcon500 integrated encoder velocity to angular velocity. Assumes there is no gearbox
-     *
-     * @param falconVelocity velocity reported by Falcon500. ticks per 100ms
-     * @return angular velocity of rotating object in rad/s
-     */
-    public static double falcon500VelocityToRadiansPerSecond(double falconVelocity) {
-        return falcon500VelocityToRadiansPerSecond(falconVelocity, 1);
-    }
+  /**
+   * Convert Falcon500 integrated encoder velocity to angular velocity. Assumes there is no gearbox
+   *
+   * @param falconVelocity velocity reported by Falcon500. ticks per 100ms
+   * @return angular velocity of rotating object in rad/s
+   */
+  public static double falcon500VelocityToRadiansPerSecond(double falconVelocity) {
+    return falcon500VelocityToRadiansPerSecond(falconVelocity, 1);
+  }
 
-    /**
-     * Convert angular velocity of an object to Falcon500 native velocity units, ticks per 100ms
-     *
-     * @param angularVelocity angular velocity of object in rad/s
-     * @param gearRatio gear ratio between motor and rotating object. Number of input rotations / number of output rotations
-     * @return Falcon500 native velocity units, ticks per 100ms
-     */
-    public static double radiansPerSecondToFalcon500Velocity(double angularVelocity, double gearRatio) {
-        return rotationsPerMinuteToFalcon500Velocity(Units.radiansPerSecondToRotationsPerMinute(angularVelocity)) * gearRatio;
-    }
+  /**
+   * Convert angular velocity of an object to Falcon500 native velocity units, ticks per 100ms
+   *
+   * @param angularVelocity angular velocity of object in rad/s
+   * @param gearRatio gear ratio between motor and rotating object. Number of input rotations /
+   *     number of output rotations
+   * @return Falcon500 native velocity units, ticks per 100ms
+   */
+  public static double radiansPerSecondToFalcon500Velocity(
+      double angularVelocity, double gearRatio) {
+    return rotationsPerMinuteToFalcon500Velocity(
+            Units.radiansPerSecondToRotationsPerMinute(angularVelocity))
+        * gearRatio;
+  }
 
-    /**
-     * Convert angular velocity of an object to Falcon500 native velocity units, ticks per 100ms.
-     * Assumes there is no gearbox
-     *
-     * @param angularVelocity angular velocity of object in rad/s
-     * @return Falcon500 native velocity units, ticks per 100ms
-     */
-    public static double radiansPerSecondToFalcon500Velocity(double angularVelocity) {
-        return radiansPerSecondToFalcon500Velocity(angularVelocity, 1);
-    }
+  /**
+   * Convert angular velocity of an object to Falcon500 native velocity units, ticks per 100ms.
+   * Assumes there is no gearbox
+   *
+   * @param angularVelocity angular velocity of object in rad/s
+   * @return Falcon500 native velocity units, ticks per 100ms
+   */
+  public static double radiansPerSecondToFalcon500Velocity(double angularVelocity) {
+    return radiansPerSecondToFalcon500Velocity(angularVelocity, 1);
+  }
 
-    /**
-     * Convert Falcon500 native velocity units, ticks per 100ms to linear velocity
-     *
-     * @param falconVelocity linear velocity in meters per second
-     * @param radius radius of rotating object in meters
-     * @param gearRatio gear ratio between motor and rotating object. Number of input rotations / number of output rotations
-     * @return linear velocity of rotating object in meters per second
-     */
-    public static double falcon500VelocityToMetersPerSecond(double falconVelocity, double radius, double gearRatio) {
-        return Units.rotationsPerMinuteToMetersPerSecond(falcon500VelocityToRotationsPerMinute(falconVelocity), radius) / gearRatio;
-    }
+  /**
+   * Convert Falcon500 native velocity units, ticks per 100ms to linear velocity
+   *
+   * @param falconVelocity linear velocity in meters per second
+   * @param radius radius of rotating object in meters
+   * @param gearRatio gear ratio between motor and rotating object. Number of input rotations /
+   *     number of output rotations
+   * @return linear velocity of rotating object in meters per second
+   */
+  public static double falcon500VelocityToMetersPerSecond(
+      double falconVelocity, double radius, double gearRatio) {
+    return Units.rotationsPerMinuteToMetersPerSecond(
+            falcon500VelocityToRotationsPerMinute(falconVelocity), radius)
+        / gearRatio;
+  }
 
-    /**
-     * Convert Falcon500 native velocity units, ticks per 100ms to linear velocity. Assumes there is no gearbox
-     *
-     * @param falconVelocity linear velocity in meters per second
-     * @param radius radius of rotating object in meters
-     * @return linear velocity of rotating object in meters per second
-     */
-    public static double falcon500VelocityToMetersPerSecond(double falconVelocity, double radius) {
-        return falcon500VelocityToMetersPerSecond(falconVelocity, radius, 1);
-    }
+  /**
+   * Convert Falcon500 native velocity units, ticks per 100ms to linear velocity. Assumes there is
+   * no gearbox
+   *
+   * @param falconVelocity linear velocity in meters per second
+   * @param radius radius of rotating object in meters
+   * @return linear velocity of rotating object in meters per second
+   */
+  public static double falcon500VelocityToMetersPerSecond(double falconVelocity, double radius) {
+    return falcon500VelocityToMetersPerSecond(falconVelocity, radius, 1);
+  }
 
-    /**
-     * Convert linear velocity to Falcon500 native velocity units, ticks per 100ms.
-     *
-     * @param linearVelocity of object in meters per second
-     * @param radius radius of rotating object
-     * @param gearRatio gear ratio between motor and rotating object. Number of input rotations / number of output rotations
-     * @return Falcon500 native velocity units, ticks per 100ms
-     */
-    public static double metersPerSecondToFalcon500Velocity(double linearVelocity, double radius, double gearRatio) {
-        return rotationsPerMinuteToFalcon500Velocity(Units.metersPerSecondToRotationPerMinute(linearVelocity, radius)) * gearRatio;
-    }
+  /**
+   * Convert linear velocity to Falcon500 native velocity units, ticks per 100ms.
+   *
+   * @param linearVelocity of object in meters per second
+   * @param radius radius of rotating object
+   * @param gearRatio gear ratio between motor and rotating object. Number of input rotations /
+   *     number of output rotations
+   * @return Falcon500 native velocity units, ticks per 100ms
+   */
+  public static double metersPerSecondToFalcon500Velocity(
+      double linearVelocity, double radius, double gearRatio) {
+    return rotationsPerMinuteToFalcon500Velocity(
+            Units.metersPerSecondToRotationPerMinute(linearVelocity, radius))
+        * gearRatio;
+  }
 
-    /**
-     * Convert linear velocity to Falcon500 native velocity units, ticks per 100ms. Assumes there is no gearbox
-     *
-     * @param linearVelocity of object in meters per second
-     * @param radius radius of rotating object
-     * @return Falcon500 native velocity units, ticks per 100ms
-     */
-    public static double metersPerSecondToFalcon500Velocity(double linearVelocity, double radius) {
-        return metersPerSecondToFalcon500Velocity(linearVelocity, radius, 1);
-    }
+  /**
+   * Convert linear velocity to Falcon500 native velocity units, ticks per 100ms. Assumes there is
+   * no gearbox
+   *
+   * @param linearVelocity of object in meters per second
+   * @param radius radius of rotating object
+   * @return Falcon500 native velocity units, ticks per 100ms
+   */
+  public static double metersPerSecondToFalcon500Velocity(double linearVelocity, double radius) {
+    return metersPerSecondToFalcon500Velocity(linearVelocity, radius, 1);
+  }
 
-    /**
-     * Convert Falcon500 native velocity units, ticks per 100ms, to RPM
-     *
-     * @param falconVelocity Falcon500 native velocity units, ticks per 100ms, of rotating object
-     * @return rotations per minute
-     */
-    public static double falcon500VelocityToRotationsPerMinute(double falconVelocity) {
-        return falconVelocity * 600.0 / kFalconIntegratedEncoderResolution;
-    }
+  /**
+   * Convert Falcon500 native velocity units, ticks per 100ms, to RPM
+   *
+   * @param falconVelocity Falcon500 native velocity units, ticks per 100ms, of rotating object
+   * @return rotations per minute
+   */
+  public static double falcon500VelocityToRotationsPerMinute(double falconVelocity) {
+    return falconVelocity * 600.0 / kFalconIntegratedEncoderResolution;
+  }
 
-    /**
-     * Convert RPM to Falcon500 native velocity units, ticks per 100ms
-     *
-     * @param rpm rotations per minute
-     * @return Falcon500 native velocity units, ticks per 100ms, of rotating object
-     */
-    public static double rotationsPerMinuteToFalcon500Velocity(double rpm) {
-        return rpm * kFalconIntegratedEncoderResolution / 600.0;
-    }
+  /**
+   * Convert RPM to Falcon500 native velocity units, ticks per 100ms
+   *
+   * @param rpm rotations per minute
+   * @return Falcon500 native velocity units, ticks per 100ms, of rotating object
+   */
+  public static double rotationsPerMinuteToFalcon500Velocity(double rpm) {
+    return rpm * kFalconIntegratedEncoderResolution / 600.0;
+  }
 
-    /**
-     * Convert the position reported by the Falcon500 integrated encoder position to degrees
-     *
-     * @param falconPosition Falcon500 native position units
-     * @return Encoder position in degrees
-     */
-    public static double falcon500PositionToDegrees(double falconPosition) {
-        return (falconPosition / kFalconIntegratedEncoderResolution) * 360;
-    }
+  /**
+   * Convert the position reported by the Falcon500 integrated encoder position to degrees
+   *
+   * @param falconPosition Falcon500 native position units
+   * @return Encoder position in degrees
+   */
+  public static double falcon500PositionToDegrees(double falconPosition) {
+    return (falconPosition / kFalconIntegratedEncoderResolution) * 360;
+  }
 
-    /**
-     * Convert the position reported by the Falcon500 integrated encoder position to radians
-     *
-     * @param falconPosition Falcon500 native position units
-     * @return Encoder position in radians
-     */
-    public static double falcon500PositionToRadians(double falconPosition) {
-        return Math.toRadians(falcon500PositionToDegrees(falconPosition));
-    }
+  /**
+   * Convert the position reported by the Falcon500 integrated encoder position to radians
+   *
+   * @param falconPosition Falcon500 native position units
+   * @return Encoder position in radians
+   */
+  public static double falcon500PositionToRadians(double falconPosition) {
+    return Math.toRadians(falcon500PositionToDegrees(falconPosition));
+  }
 
-    /**
-     * Convert position in degrees to Falcon500 native position units
-     *
-     * @param positionDegrees position in degrees
-     * @return Falcon500 native position units
-     */
-    public static double degreesToFalcon500Position(double positionDegrees) {
-        double optimizedPosition = positionDegrees % 360;
-        return (optimizedPosition / 360.0) * kFalconIntegratedEncoderResolution;
-    }
+  /**
+   * Convert position in degrees to Falcon500 native position units
+   *
+   * @param positionDegrees position in degrees
+   * @return Falcon500 native position units
+   */
+  public static double degreesToFalcon500Position(double positionDegrees) {
+    double optimizedPosition = positionDegrees % 360;
+    return (optimizedPosition / 360.0) * kFalconIntegratedEncoderResolution;
+  }
 
-    /**
-     * Convert position in radians to Falcon500 native position units
-     *
-     * @param positionRadians position in radians
-     * @return Falcon500 native position units
-     */
-    public static double radiansToFalcon500Position(double positionRadians) {
-        return degreesToFalcon500Position(Math.toDegrees(positionRadians));
-    }
+  /**
+   * Convert position in radians to Falcon500 native position units
+   *
+   * @param positionRadians position in radians
+   * @return Falcon500 native position units
+   */
+  public static double radiansToFalcon500Position(double positionRadians) {
+    return degreesToFalcon500Position(Math.toDegrees(positionRadians));
+  }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
@@ -1,0 +1,68 @@
+package edu.wpi.first.math.util;
+
+public final class FalconUnitConversion {
+    private static final double kFalconIntegratedEncoderResolution = 2048;
+
+    /** Utility class, so constructor is private. */
+    private FalconUnitConversion() {
+        throw new UnsupportedOperationException("This is a utility class!");
+    }
+
+    public static double falcon500VelocityToAngularVelocity(double falconVelocity, double gearRatio) {
+        return Units.rpmToAngularVelocity(falcon500VelocityToRPM(falconVelocity)) / gearRatio;
+    }
+
+    public static double falcon500VelocityToAngularVelocity(double falconVelocity) {
+        return falcon500VelocityToAngularVelocity(falconVelocity, 1);
+    }
+
+    public static double angularVelocityToFalcon500Velocity(double angularVelocity, double gearRatio) {
+        return rpmToFalcon500Velocity(Units.angularVelocityToRPM(angularVelocity)) * gearRatio;
+    }
+
+    public static double angularVelocityToFalcon500Velocity(double angularVelocity) {
+        return angularVelocityToFalcon500Velocity(angularVelocity, 1);
+    }
+
+    public static double falcon500VelocityToLinearVelocity(double falconVelocity, double radius, double gearRatio) {
+        return Units.rpmToLinearVelocity(falcon500VelocityToRPM(falconVelocity), radius) / gearRatio;
+    }
+
+    public static double falcon500VelocityToLinearVelocity(double falconVelocity, double radius) {
+        return falcon500VelocityToLinearVelocity(falconVelocity, radius, 1);
+    }
+
+    public static double linearVelocityToFalcon500Velocity(double linearVelocity, double radius, double gearRatio) {
+        return rpmToFalcon500Velocity(Units.linearVelocityToRPM(linearVelocity, radius)) * gearRatio;
+    }
+
+    public static double linearVelocityToFalcon500Velocity(double linearVelocity, double radius) {
+        return linearVelocityToFalcon500Velocity(linearVelocity, radius, 1);
+    }
+
+    public static double falcon500VelocityToRPM(double falconVelocity) {
+        return falconVelocity * 600.0 / kFalconIntegratedEncoderResolution;
+    }
+
+    public static double rpmToFalcon500Velocity(double rpm) {
+        return rpm * kFalconIntegratedEncoderResolution / 600.0;
+    }
+
+    public static double falcon500PositionToDegrees(double falconPosition) {
+        return (falconPosition / kFalconIntegratedEncoderResolution) * 360;
+    }
+
+    public static double falcon500PositionToRadians(double falconPosition) {
+        return Math.toRadians(falcon500PositionToDegrees(falconPosition));
+    }
+
+    public static double degreesToFalcon500Position(double positionDegrees) {
+        double optimizedPosition = positionDegrees % 360;
+        return (optimizedPosition / 360.0) * kFalconIntegratedEncoderResolution;
+    }
+
+    public static double radiansToFalcon500Position(double positionRadians) {
+        double optimizedPosition = positionRadians % (2 * Math.PI);
+        return degreesToFalcon500Position(Math.toDegrees(optimizedPosition));
+    }
+}

--- a/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
@@ -12,7 +12,7 @@ public final class FalconUnitConversion {
      * Convert Falcon500 integrated encoder velocity to angular velocity
      *
      * @param falconVelocity velocity reported by Falcon500. ticks per 100ms
-     * @param gearRatio gear ratio between motor and rotating object
+     * @param gearRatio gear ratio between motor and rotating object. Number of input rotations / number of output rotations
      * @return angular velocity of rotating object in rad/s
      */
     public static double falcon500VelocityToRadiansPerSecond(double falconVelocity, double gearRatio) {
@@ -33,7 +33,7 @@ public final class FalconUnitConversion {
      * Convert angular velocity of an object to Falcon500 native velocity units, ticks per 100ms
      *
      * @param angularVelocity angular velocity of object in rad/s
-     * @param gearRatio gear ratio between motor and rotating object
+     * @param gearRatio gear ratio between motor and rotating object. Number of input rotations / number of output rotations
      * @return Falcon500 native velocity units, ticks per 100ms
      */
     public static double radiansPerSecondToFalcon500Velocity(double angularVelocity, double gearRatio) {
@@ -56,7 +56,7 @@ public final class FalconUnitConversion {
      *
      * @param falconVelocity linear velocity in meters per second
      * @param radius radius of rotating object in meters
-     * @param gearRatio gear ratio between motor and rotating object
+     * @param gearRatio gear ratio between motor and rotating object. Number of input rotations / number of output rotations
      * @return linear velocity of rotating object in meters per second
      */
     public static double falcon500VelocityToMetersPerSecond(double falconVelocity, double radius, double gearRatio) {
@@ -79,7 +79,7 @@ public final class FalconUnitConversion {
      *
      * @param linearVelocity of object in meters per second
      * @param radius radius of rotating object
-     * @param gearRatio gear ratio between motor and rotating object
+     * @param gearRatio gear ratio between motor and rotating object. Number of input rotations / number of output rotations
      * @return Falcon500 native velocity units, ticks per 100ms
      */
     public static double metersPerSecondToFalcon500Velocity(double linearVelocity, double radius, double gearRatio) {

--- a/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
@@ -16,7 +16,7 @@ public final class FalconUnitConversion {
      * @return angular velocity of rotating object in rad/s
      */
     public static double falcon500VelocityToAngularVelocity(double falconVelocity, double gearRatio) {
-        return Units.rpmToAngularVelocity(falcon500VelocityToRPM(falconVelocity)) / gearRatio;
+        return Units.rotationsPerMinuteToRadiansPerSecond(falcon500VelocityToRPM(falconVelocity)) / gearRatio;
     }
 
     /**
@@ -37,7 +37,7 @@ public final class FalconUnitConversion {
      * @return Falcon500 native velocity units, ticks per 100ms
      */
     public static double angularVelocityToFalcon500Velocity(double angularVelocity, double gearRatio) {
-        return rpmToFalcon500Velocity(Units.angularVelocityToRPM(angularVelocity)) * gearRatio;
+        return rpmToFalcon500Velocity(Units.radiansPerSecondToRotationsPerMinute(angularVelocity)) * gearRatio;
     }
 
     /**

--- a/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/FalconUnitConversion.java
@@ -8,61 +8,153 @@ public final class FalconUnitConversion {
         throw new UnsupportedOperationException("This is a utility class!");
     }
 
+    /**
+     * Convert Falcon500 integrated encoder velocity to angular velocity
+     *
+     * @param falconVelocity velocity reported by Falcon500. ticks per 100ms
+     * @param gearRatio gear ratio between motor and rotating object
+     * @return angular velocity of rotating object in rad/s
+     */
     public static double falcon500VelocityToAngularVelocity(double falconVelocity, double gearRatio) {
         return Units.rpmToAngularVelocity(falcon500VelocityToRPM(falconVelocity)) / gearRatio;
     }
 
+    /**
+     * Convert Falcon500 integrated encoder velocity to angular velocity. Assumes there is no gearbox
+     *
+     * @param falconVelocity velocity reported by Falcon500. ticks per 100ms
+     * @return angular velocity of rotating object in rad/s
+     */
     public static double falcon500VelocityToAngularVelocity(double falconVelocity) {
         return falcon500VelocityToAngularVelocity(falconVelocity, 1);
     }
 
+    /**
+     * Convert angular velocity of an object to Falcon500 native velocity units, ticks per 100ms
+     *
+     * @param angularVelocity angular velocity of object in rad/s
+     * @param gearRatio gear ratio between motor and rotating object
+     * @return Falcon500 native velocity units, ticks per 100ms
+     */
     public static double angularVelocityToFalcon500Velocity(double angularVelocity, double gearRatio) {
         return rpmToFalcon500Velocity(Units.angularVelocityToRPM(angularVelocity)) * gearRatio;
     }
 
+    /**
+     * Convert angular velocity of an object to Falcon500 native velocity units, ticks per 100ms.
+     * Assumes there is no gearbox
+     *
+     * @param angularVelocity angular velocity of object in rad/s
+     * @return Falcon500 native velocity units, ticks per 100ms
+     */
     public static double angularVelocityToFalcon500Velocity(double angularVelocity) {
         return angularVelocityToFalcon500Velocity(angularVelocity, 1);
     }
 
+    /**
+     * Convert Falcon500 native velocity units, ticks per 100ms to linear velocity
+     *
+     * @param falconVelocity linear velocity in meters per second
+     * @param radius radius of rotating object in meters
+     * @param gearRatio gear ratio between motor and rotating object
+     * @return linear velocity of rotating object in meters per second
+     */
     public static double falcon500VelocityToLinearVelocity(double falconVelocity, double radius, double gearRatio) {
         return Units.rpmToLinearVelocity(falcon500VelocityToRPM(falconVelocity), radius) / gearRatio;
     }
 
+    /**
+     * Convert Falcon500 native velocity units, ticks per 100ms to linear velocity. Assumes there is no gearbox
+     *
+     * @param falconVelocity linear velocity in meters per second
+     * @param radius radius of rotating object in meters
+     * @return linear velocity of rotating object in meters per second
+     */
     public static double falcon500VelocityToLinearVelocity(double falconVelocity, double radius) {
         return falcon500VelocityToLinearVelocity(falconVelocity, radius, 1);
     }
 
+    /**
+     * Convert linear velocity to Falcon500 native velocity units, ticks per 100ms.
+     *
+     * @param linearVelocity of object in meters per second
+     * @param radius radius of rotating object
+     * @param gearRatio gear ratio between motor and rotating object
+     * @return Falcon500 native velocity units, ticks per 100ms
+     */
     public static double linearVelocityToFalcon500Velocity(double linearVelocity, double radius, double gearRatio) {
         return rpmToFalcon500Velocity(Units.linearVelocityToRPM(linearVelocity, radius)) * gearRatio;
     }
 
+    /**
+     * Convert linear velocity to Falcon500 native velocity units, ticks per 100ms. Assumes there is no gearbox
+     *
+     * @param linearVelocity of object in meters per second
+     * @param radius radius of rotating object
+     * @return Falcon500 native velocity units, ticks per 100ms
+     */
     public static double linearVelocityToFalcon500Velocity(double linearVelocity, double radius) {
         return linearVelocityToFalcon500Velocity(linearVelocity, radius, 1);
     }
 
+    /**
+     * Convert Falcon500 native velocity units, ticks per 100ms, to RPM
+     *
+     * @param falconVelocity Falcon500 native velocity units, ticks per 100ms, of rotating object
+     * @return rotations per minute
+     */
     public static double falcon500VelocityToRPM(double falconVelocity) {
         return falconVelocity * 600.0 / kFalconIntegratedEncoderResolution;
     }
 
+    /**
+     * Convert RPM to Falcon500 native velocity units, ticks per 100ms
+     *
+     * @param rpm rotations per minute
+     * @return Falcon500 native velocity units, ticks per 100ms, of rotating object
+     */
     public static double rpmToFalcon500Velocity(double rpm) {
         return rpm * kFalconIntegratedEncoderResolution / 600.0;
     }
 
+    /**
+     * Convert the position reported by the Falcon500 integrated encoder position to degrees
+     *
+     * @param falconPosition Falcon500 native position units
+     * @return Encoder position in degrees
+     */
     public static double falcon500PositionToDegrees(double falconPosition) {
         return (falconPosition / kFalconIntegratedEncoderResolution) * 360;
     }
 
+    /**
+     * Convert the position reported by the Falcon500 integrated encoder position to radians
+     *
+     * @param falconPosition Falcon500 native position units
+     * @return Encoder position in radians
+     */
     public static double falcon500PositionToRadians(double falconPosition) {
         return Math.toRadians(falcon500PositionToDegrees(falconPosition));
     }
 
+    /**
+     * Convert position in degrees to Falcon500 native position units
+     *
+     * @param positionDegrees position in degrees
+     * @return Falcon500 native position units
+     */
     public static double degreesToFalcon500Position(double positionDegrees) {
         double optimizedPosition = positionDegrees % 360;
         return (optimizedPosition / 360.0) * kFalconIntegratedEncoderResolution;
     }
 
+    /**
+     * Convert position in radians to Falcon500 native position units
+     *
+     * @param positionRadians position in radians
+     * @return Falcon500 native position units
+     */
     public static double radiansToFalcon500Position(double positionRadians) {
-        double optimizedPosition = positionRadians % (2 * Math.PI);
-        return degreesToFalcon500Position(Math.toDegrees(optimizedPosition));
+        return degreesToFalcon500Position(Math.toDegrees(positionRadians));
     }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
@@ -200,16 +200,6 @@ public final class Units {
   }
 
   /**
-   * Convert the RPM of a rotating object to its angular velocity
-   *
-   * @param rpm rotations per minute of object
-   * @return Angular velocity in rad/s
-   */
-  public static double rpmToAngularVelocity(double rpm) {
-    return rpm * (Math.PI / 30.0);
-  }
-
-  /**
    * Convert the RPM of a rotating object to its linear velocity
    *
    * @param rpm rotations per minute of object
@@ -217,17 +207,7 @@ public final class Units {
    * @return Linear velocity in meters per second
    */
   public static double rpmToLinearVelocity(double rpm, double radius) {
-    return rpmToAngularVelocity(rpm) * radius;
-  }
-
-  /**
-   * Convert the angular velocity of a rotating object to its RPM
-   *
-   * @param angularVelocity angular velocity of object
-   * @return RPM of object
-   */
-  public static double angularVelocityToRPM(double angularVelocity) {
-    return angularVelocity * (30.0 / Math.PI);
+    return rotationsPerMinuteToRadiansPerSecond(rpm) * radius;
   }
 
   /**
@@ -238,6 +218,6 @@ public final class Units {
    * @return RPM of object
    */
   public static double linearVelocityToRPM(double linearVelocity, double radius) {
-    return angularVelocityToRPM(linearVelocity / radius);
+    return radiansPerSecondToRotationsPerMinute(linearVelocity / radius);
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
@@ -207,7 +207,7 @@ public final class Units {
    * @return Linear velocity in meters per second
    */
   public static double rotationsPerMinuteToMetersPerSecond(double rpm, double radius) {
-    return rotationsPerMinuteToRadiansPerSecond(rpm) * radius;
+    return radiansPerSecondToMetersPerSecond(rotationsPerMinuteToRadiansPerSecond(rpm), radius);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
@@ -184,7 +184,7 @@ public final class Units {
    * @param radius radius of object in meters
    * @return angular velocity of object in rad/s
    */
-  public static double linearVelocityToAngularVelocity(double linearVelocity, double radius) {
+  public static double metersPerSecondToRadiansPerSecond(double linearVelocity, double radius) {
     return linearVelocity / radius;
   }
 
@@ -195,7 +195,7 @@ public final class Units {
    * @param radius radius of rotating object in meters
    * @return linear velocity of object in meters per second
    */
-  public static double angularVelocityToLinearVelocity(double angularVelocity, double radius) {
+  public static double radiansPerSecondToMetersPerSecond(double angularVelocity, double radius) {
     return angularVelocity * radius;
   }
 
@@ -206,7 +206,7 @@ public final class Units {
    * @param radius radius of object in meters
    * @return Linear velocity in meters per second
    */
-  public static double rpmToLinearVelocity(double rpm, double radius) {
+  public static double rotationsPerMinuteToMetersPerSecond(double rpm, double radius) {
     return rotationsPerMinuteToRadiansPerSecond(rpm) * radius;
   }
 
@@ -217,7 +217,7 @@ public final class Units {
    * @param radius radius of rotating object
    * @return RPM of object
    */
-  public static double linearVelocityToRPM(double linearVelocity, double radius) {
-    return radiansPerSecondToRotationsPerMinute(linearVelocity / radius);
+  public static double metersPerSecondToRotationPerMinute(double linearVelocity, double radius) {
+    return radiansPerSecondToRotationsPerMinute(metersPerSecondToRadiansPerSecond(linearVelocity, radius));
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
@@ -176,4 +176,68 @@ public final class Units {
   public static double lbsToKilograms(double lbs) {
     return lbs * kKilogramsPerLb;
   }
+
+  /**
+   * Convert the linear velocity of an object to its angular velocity
+   *
+   * @param linearVelocity linear velocity in meters per second
+   * @param radius radius of object in meters
+   * @return angular velocity of object in rad/s
+   */
+  public static double linearVelocityToAngularVelocity(double linearVelocity, double radius) {
+    return linearVelocity / radius;
+  }
+
+  /**
+   * Convert the angular velocity of an object to its linear velocity
+   *
+   * @param angularVelocity angular velocity in rad/s
+   * @param radius radius of rotating object in meters
+   * @return linear velocity of object in meters per second
+   */
+  public static double angularVelocityToLinearVelocity(double angularVelocity, double radius) {
+    return angularVelocity * radius;
+  }
+
+  /**
+   * Convert the RPM of a rotating object to its angular velocity
+   *
+   * @param rpm rotations per minute of object
+   * @return Angular velocity in rad/s
+   */
+  public static double rpmToAngularVelocity(double rpm) {
+    return rpm * (Math.PI / 30.0);
+  }
+
+  /**
+   * Convert the RPM of a rotating object to its linear velocity
+   *
+   * @param rpm rotations per minute of object
+   * @param radius radius of object in meters
+   * @return Linear velocity in meters per second
+   */
+  public static double rpmToLinearVelocity(double rpm, double radius) {
+    return rpmToAngularVelocity(rpm) * radius;
+  }
+
+  /**
+   * Convert the angular velocity of a rotating object to its RPM
+   *
+   * @param angularVelocity angular velocity of object
+   * @return RPM of object
+   */
+  public static double angularVelocityToRPM(double angularVelocity) {
+    return angularVelocity * (30.0 / Math.PI);
+  }
+
+  /**
+   * Convert the angular velocity of a rotating object to its RPM
+   *
+   * @param linearVelocity linear velocity of rotating object
+   * @param radius radius of rotating object
+   * @return RPM of object
+   */
+  public static double linearVelocityToRPM(double linearVelocity, double radius) {
+    return angularVelocityToRPM(linearVelocity / radius);
+  }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/util/Units.java
@@ -218,6 +218,7 @@ public final class Units {
    * @return RPM of object
    */
   public static double metersPerSecondToRotationPerMinute(double linearVelocity, double radius) {
-    return radiansPerSecondToRotationsPerMinute(metersPerSecondToRadiansPerSecond(linearVelocity, radius));
+    return radiansPerSecondToRotationsPerMinute(
+        metersPerSecondToRadiansPerSecond(linearVelocity, radius));
   }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/util/FalconUnitConversionTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/util/FalconUnitConversionTest.java
@@ -1,0 +1,61 @@
+package edu.wpi.first.math.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.wpilibj.UtilityClassTest;
+import org.junit.jupiter.api.Test;
+public class FalconUnitConversionTest extends UtilityClassTest<FalconUnitConversion> {
+    FalconUnitConversionTest() {
+        super(FalconUnitConversion.class);
+    }
+
+    @Test
+    void falcon500VelocityToRadiansPerSecond() {
+        assertEquals(29.1456349698, FalconUnitConversion.falcon500VelocityToRadiansPerSecond(950), 1e-2);
+    }
+
+    @Test
+    void radiansPerSecondToFalcon500Velocity() {
+        assertEquals(0.894176881888, FalconUnitConversion.falcon500VelocityToRadiansPerSecond(29.1456349698), 1e-2);
+    }
+
+    @Test
+    void falcon500VelocityToMetersPerSecond() {
+        assertEquals(349.75, FalconUnitConversion.falcon500VelocityToMetersPerSecond(950, 12), 1e-2);
+    }
+
+    @Test
+    void metersPerSecondToFalcon500Velocity() {
+        assertEquals(950, FalconUnitConversion.metersPerSecondToFalcon500Velocity(349.75, 12), 1e-2);
+    }
+
+    @Test
+    void falcon500VelocityToRotationsPerMinute() {
+        assertEquals(950, FalconUnitConversion.falcon500VelocityToRotationsPerMinute(3242.66666667), 1e-2);
+    }
+
+    @Test
+    void rotationsPerMinuteToFalcon500Velocity() {
+        assertEquals(3242.66666667, FalconUnitConversion.rotationsPerMinuteToFalcon500Velocity(950), 1e-2);
+    }
+
+    @Test
+    void falcon500PositionToDegrees() {
+        assertEquals(14.0625, FalconUnitConversion.falcon500PositionToDegrees(80), 1e-2);
+    }
+
+    @Test
+    void falcon500PositionToRadians() {
+        assertEquals(0.245436926062, FalconUnitConversion.falcon500PositionToRadians(80), 1e-2);
+    }
+
+    @Test
+    void degreesToFalcon500Position() {
+        assertEquals(1177.6, FalconUnitConversion.degreesToFalcon500Position(207), 1e-2);
+    }
+
+    @Test
+    void radiansToFalcon500Position() {
+        assertEquals(488.923985178, FalconUnitConversion.radiansToFalcon500Position(1.5), 1e-2);
+    }
+}

--- a/wpimath/src/test/java/edu/wpi/first/math/util/FalconUnitConversionTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/util/FalconUnitConversionTest.java
@@ -1,61 +1,72 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package edu.wpi.first.math.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import edu.wpi.first.wpilibj.UtilityClassTest;
 import org.junit.jupiter.api.Test;
+
 public class FalconUnitConversionTest extends UtilityClassTest<FalconUnitConversion> {
-    FalconUnitConversionTest() {
-        super(FalconUnitConversion.class);
-    }
+  FalconUnitConversionTest() {
+    super(FalconUnitConversion.class);
+  }
 
-    @Test
-    void falcon500VelocityToRadiansPerSecond() {
-        assertEquals(29.1456349698, FalconUnitConversion.falcon500VelocityToRadiansPerSecond(950), 1e-2);
-    }
+  @Test
+  void falcon500VelocityToRadiansPerSecond() {
+    assertEquals(
+        29.1456349698, FalconUnitConversion.falcon500VelocityToRadiansPerSecond(950), 1e-2);
+  }
 
-    @Test
-    void radiansPerSecondToFalcon500Velocity() {
-        assertEquals(0.894176881888, FalconUnitConversion.falcon500VelocityToRadiansPerSecond(29.1456349698), 1e-2);
-    }
+  @Test
+  void radiansPerSecondToFalcon500Velocity() {
+    assertEquals(
+        0.894176881888,
+        FalconUnitConversion.falcon500VelocityToRadiansPerSecond(29.1456349698),
+        1e-2);
+  }
 
-    @Test
-    void falcon500VelocityToMetersPerSecond() {
-        assertEquals(349.75, FalconUnitConversion.falcon500VelocityToMetersPerSecond(950, 12), 1e-2);
-    }
+  @Test
+  void falcon500VelocityToMetersPerSecond() {
+    assertEquals(349.75, FalconUnitConversion.falcon500VelocityToMetersPerSecond(950, 12), 1e-2);
+  }
 
-    @Test
-    void metersPerSecondToFalcon500Velocity() {
-        assertEquals(950, FalconUnitConversion.metersPerSecondToFalcon500Velocity(349.75, 12), 1e-2);
-    }
+  @Test
+  void metersPerSecondToFalcon500Velocity() {
+    assertEquals(950, FalconUnitConversion.metersPerSecondToFalcon500Velocity(349.75, 12), 1e-2);
+  }
 
-    @Test
-    void falcon500VelocityToRotationsPerMinute() {
-        assertEquals(950, FalconUnitConversion.falcon500VelocityToRotationsPerMinute(3242.66666667), 1e-2);
-    }
+  @Test
+  void falcon500VelocityToRotationsPerMinute() {
+    assertEquals(
+        950, FalconUnitConversion.falcon500VelocityToRotationsPerMinute(3242.66666667), 1e-2);
+  }
 
-    @Test
-    void rotationsPerMinuteToFalcon500Velocity() {
-        assertEquals(3242.66666667, FalconUnitConversion.rotationsPerMinuteToFalcon500Velocity(950), 1e-2);
-    }
+  @Test
+  void rotationsPerMinuteToFalcon500Velocity() {
+    assertEquals(
+        3242.66666667, FalconUnitConversion.rotationsPerMinuteToFalcon500Velocity(950), 1e-2);
+  }
 
-    @Test
-    void falcon500PositionToDegrees() {
-        assertEquals(14.0625, FalconUnitConversion.falcon500PositionToDegrees(80), 1e-2);
-    }
+  @Test
+  void falcon500PositionToDegrees() {
+    assertEquals(14.0625, FalconUnitConversion.falcon500PositionToDegrees(80), 1e-2);
+  }
 
-    @Test
-    void falcon500PositionToRadians() {
-        assertEquals(0.245436926062, FalconUnitConversion.falcon500PositionToRadians(80), 1e-2);
-    }
+  @Test
+  void falcon500PositionToRadians() {
+    assertEquals(0.245436926062, FalconUnitConversion.falcon500PositionToRadians(80), 1e-2);
+  }
 
-    @Test
-    void degreesToFalcon500Position() {
-        assertEquals(1177.6, FalconUnitConversion.degreesToFalcon500Position(207), 1e-2);
-    }
+  @Test
+  void degreesToFalcon500Position() {
+    assertEquals(1177.6, FalconUnitConversion.degreesToFalcon500Position(207), 1e-2);
+  }
 
-    @Test
-    void radiansToFalcon500Position() {
-        assertEquals(488.923985178, FalconUnitConversion.radiansToFalcon500Position(1.5), 1e-2);
-    }
+  @Test
+  void radiansToFalcon500Position() {
+    assertEquals(488.923985178, FalconUnitConversion.radiansToFalcon500Position(1.5), 1e-2);
+  }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/util/UnitsTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/util/UnitsTest.java
@@ -73,4 +73,24 @@ class UnitsTest extends UtilityClassTest<Units> {
   void lbsToKilogramsTest() {
     assertEquals(0.453592, Units.lbsToKilograms(1), 1e-2);
   }
+
+  @Test
+  void metersPerSecondToRadiansPerSecond() {
+    assertEquals(2.0, Units.metersPerSecondToRadiansPerSecond(4.0, 2.0), 1e-2);
+  }
+
+  @Test
+  void radiansPerSecondToMetersPerSecond() {
+    assertEquals(4.0, Units.radiansPerSecondToMetersPerSecond(2.0, 2.0), 1e-2);
+  }
+
+  @Test
+  void rotationsPerMinuteToMetersPerSecond() {
+    assertEquals(377, Units.rotationsPerMinuteToMetersPerSecond(300, 12), 1e-2);
+  }
+
+  @Test
+  void metersPerSecondToRotationPerMinute() {
+    assertEquals(300, Units.metersPerSecondToRotationPerMinute(377, 12), 1e-2);
+  }
 }


### PR DESCRIPTION
expands upon #4356 

Add the following things:

- Convert from linear to angular velocity in Units class
- Convert from angular to linear velocity in Units class
- Convert from RPM to linear velocity in Units class
- Convert from linear velocity to RPM in Units class
- Convert from Falcon500 velocity to angular velocity.
    - with or without a gearbox between the connected object and motor
- Convert from Angular velocity to Falcon500 velocity
    - with or without a gearbox between the connected object and motor
- Convert from Falcon500 velocity to linear velocity.
    - with or without a gearbox between the connected object and motor
- Convert from linear velocity to Falcon500 velocity
    - with or without a gearbox between the connected object and motor
- Convert from Falcon500 velocity to RPM
    - with or without a gearbox between the connected object and motor
- Convert from RPM to Falcon500 velocity
    - with or without a gearbox between the connected object and motor
- Falcon500 encoder position to degrees
- Falcon500 encoder position to radians
- degrees to Falcon500 position, automatically optimizes angle
- radians to Falcon500 position, automatically optimizes angle

I also wrote tests for all of this in Java. I am not great at c++ and don't fully understand how WPI units work in c++. 