### PR TITLE
Update Spotless

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
     id 'visual-studio'
     id 'net.ltgt.errorprone' version '2.0.2' apply false
     id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
-    id 'com.diffplug.spotless' version '6.4.2' apply false
+    id 'com.diffplug.spotless' version '6.12.0' apply false
     id 'com.github.spotbugs' version '5.0.8' apply false
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,0 @@
-# The --add-exports flags work around a bug with spotless and JDK 17
-# https://github.com/diffplug/spotless/issues/834
-org.gradle.jvmargs=-Xmx2g \
-  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
@@ -951,7 +951,9 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
     return compAngle;
   }
 
-  /** @return Yaw axis angle in degrees (CCW positive) */
+  /**
+   * @return Yaw axis angle in degrees (CCW positive)
+   */
   public synchronized double getAngle() {
     switch (m_yaw_axis) {
       case kX:
@@ -965,7 +967,9 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
     }
   }
 
-  /** @return Yaw axis angular rate in degrees per second (CCW positive) */
+  /**
+   * @return Yaw axis angular rate in degrees per second (CCW positive)
+   */
   public synchronized double getRate() {
     switch (m_yaw_axis) {
       case kX:
@@ -979,12 +983,16 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
     }
   }
 
-  /** @return Yaw Axis */
+  /**
+   * @return Yaw Axis
+   */
   public IMUAxis getYawAxis() {
     return m_yaw_axis;
   }
 
-  /** @return accumulated gyro angle in the X axis in degrees */
+  /**
+   * @return accumulated gyro angle in the X axis in degrees
+   */
   public synchronized double getGyroAngleX() {
     if (m_simGyroAngleX != null) {
       return m_simGyroAngleX.get();
@@ -992,7 +1000,9 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
     return m_integ_gyro_angle_x;
   }
 
-  /** @return accumulated gyro angle in the Y axis in degrees */
+  /**
+   * @return accumulated gyro angle in the Y axis in degrees
+   */
   public synchronized double getGyroAngleY() {
     if (m_simGyroAngleY != null) {
       return m_simGyroAngleY.get();
@@ -1000,7 +1010,9 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
     return m_integ_gyro_angle_y;
   }
 
-  /** @return accumulated gyro angle in the Z axis in degrees */
+  /**
+   * @return accumulated gyro angle in the Z axis in degrees
+   */
   public synchronized double getGyroAngleZ() {
     if (m_simGyroAngleZ != null) {
       return m_simGyroAngleZ.get();
@@ -1008,7 +1020,9 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
     return m_integ_gyro_angle_z;
   }
 
-  /** @return gyro angular rate in the X axis in degrees per second */
+  /**
+   * @return gyro angular rate in the X axis in degrees per second
+   */
   public synchronized double getGyroRateX() {
     if (m_simGyroRateX != null) {
       return m_simGyroRateX.get();
@@ -1016,7 +1030,9 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
     return m_gyro_rate_x;
   }
 
-  /** @return gyro angular rate in the Y axis in degrees per second */
+  /**
+   * @return gyro angular rate in the Y axis in degrees per second
+   */
   public synchronized double getGyroRateY() {
     if (m_simGyroRateY != null) {
       return m_simGyroRateY.get();
@@ -1024,7 +1040,9 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
     return m_gyro_rate_y;
   }
 
-  /** @return gyro angular rate in the Z axis in degrees per second */
+  /**
+   * @return gyro angular rate in the Z axis in degrees per second
+   */
   public synchronized double getGyroRateZ() {
     if (m_simGyroRateZ != null) {
       return m_simGyroRateZ.get();
@@ -1032,7 +1050,9 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
     return m_gyro_rate_z;
   }
 
-  /** @return urrent acceleration in the X axis in meters per second squared */
+  /**
+   * @return urrent acceleration in the X axis in meters per second squared
+   */
   public synchronized double getAccelX() {
     if (m_simAccelX != null) {
       return m_simAccelX.get();
@@ -1040,7 +1060,9 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
     return m_accel_x * 9.81;
   }
 
-  /** @return current acceleration in the Y axis in meters per second squared */
+  /**
+   * @return current acceleration in the Y axis in meters per second squared
+   */
   public synchronized double getAccelY() {
     if (m_simAccelY != null) {
       return m_simAccelY.get();
@@ -1048,7 +1070,9 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
     return m_accel_y * 9.81;
   }
 
-  /** @return current acceleration in the Z axis in meters per second squared */
+  /**
+   * @return current acceleration in the Z axis in meters per second squared
+   */
   public synchronized double getAccelZ() {
     if (m_simAccelZ != null) {
       return m_simAccelZ.get();
@@ -1056,51 +1080,69 @@ public class ADIS16448_IMU implements AutoCloseable, NTSendable {
     return m_accel_z * 9.81;
   }
 
-  /** @return Magnetic field strength in the X axis in Tesla */
+  /**
+   * @return Magnetic field strength in the X axis in Tesla
+   */
   public synchronized double getMagneticFieldX() {
     // mG to T
     return m_mag_x * 1e-7;
   }
 
-  /** @return Magnetic field strength in the Y axis in Tesla */
+  /**
+   * @return Magnetic field strength in the Y axis in Tesla
+   */
   public synchronized double getMagneticFieldY() {
     // mG to T
     return m_mag_y * 1e-7;
   }
 
-  /** @return Magnetic field strength in the Z axis in Tesla */
+  /**
+   * @return Magnetic field strength in the Z axis in Tesla
+   */
   public synchronized double getMagneticFieldZ() {
     // mG to T
     return m_mag_z * 1e-7;
   }
 
-  /** @return X axis complementary angle in degrees */
+  /**
+   * @return X axis complementary angle in degrees
+   */
   public synchronized double getXComplementaryAngle() {
     return m_compAngleX;
   }
 
-  /** @return Y axis complementary angle in degrees */
+  /**
+   * @return Y axis complementary angle in degrees
+   */
   public synchronized double getYComplementaryAngle() {
     return m_compAngleY;
   }
 
-  /** @return X axis filtered acceleration angle in degrees */
+  /**
+   * @return X axis filtered acceleration angle in degrees
+   */
   public synchronized double getXFilteredAccelAngle() {
     return m_accelAngleX;
   }
 
-  /** @return Y axis filtered acceleration angle in degrees */
+  /**
+   * @return Y axis filtered acceleration angle in degrees
+   */
   public synchronized double getYFilteredAccelAngle() {
     return m_accelAngleY;
   }
 
-  /** @return Barometric Pressure in PSI */
+  /**
+   * @return Barometric Pressure in PSI
+   */
   public synchronized double getBarometricPressure() {
     // mbar to PSI
     return m_baro * 0.0145;
   }
 
-  /** @return Temperature in degrees Celsius */
+  /**
+   * @return Temperature in degrees Celsius
+   */
   public synchronized double getTemperature() {
     return m_temp;
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16470_IMU.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16470_IMU.java
@@ -475,7 +475,9 @@ public class ADIS16470_IMU implements AutoCloseable, NTSendable {
     }
   }
 
-  /** @return */
+  /**
+   * @return
+   */
   boolean switchToAutoSPI() {
     // No SPI port has been set up. Go set one up first.
     if (m_spi == null) {
@@ -926,7 +928,9 @@ public class ADIS16470_IMU implements AutoCloseable, NTSendable {
     return compAngle;
   }
 
-  /** @return Yaw axis angle in degrees (CCW positive) */
+  /**
+   * @return Yaw axis angle in degrees (CCW positive)
+   */
   public synchronized double getAngle() {
     switch (m_yaw_axis) {
       case kX:
@@ -948,7 +952,9 @@ public class ADIS16470_IMU implements AutoCloseable, NTSendable {
     return m_integ_angle;
   }
 
-  /** @return Yaw axis angular rate in degrees per second (CCW positive) */
+  /**
+   * @return Yaw axis angular rate in degrees per second (CCW positive)
+   */
   public synchronized double getRate() {
     if (m_yaw_axis == IMUAxis.kX) {
       if (m_simGyroRateX != null) {
@@ -970,42 +976,58 @@ public class ADIS16470_IMU implements AutoCloseable, NTSendable {
     }
   }
 
-  /** @return Yaw Axis */
+  /**
+   * @return Yaw Axis
+   */
   public IMUAxis getYawAxis() {
     return m_yaw_axis;
   }
 
-  /** @return current acceleration in the X axis */
+  /**
+   * @return current acceleration in the X axis
+   */
   public synchronized double getAccelX() {
     return m_accel_x * 9.81;
   }
 
-  /** @return current acceleration in the Y axis */
+  /**
+   * @return current acceleration in the Y axis
+   */
   public synchronized double getAccelY() {
     return m_accel_y * 9.81;
   }
 
-  /** @return current acceleration in the Z axis */
+  /**
+   * @return current acceleration in the Z axis
+   */
   public synchronized double getAccelZ() {
     return m_accel_z * 9.81;
   }
 
-  /** @return X axis complementary angle */
+  /**
+   * @return X axis complementary angle
+   */
   public synchronized double getXComplementaryAngle() {
     return m_compAngleX;
   }
 
-  /** @return Y axis complementary angle */
+  /**
+   * @return Y axis complementary angle
+   */
   public synchronized double getYComplementaryAngle() {
     return m_compAngleY;
   }
 
-  /** @return X axis filtered acceleration angle */
+  /**
+   * @return X axis filtered acceleration angle
+   */
   public synchronized double getXFilteredAccelAngle() {
     return m_accelAngleX;
   }
 
-  /** @return Y axis filtered acceleration angle */
+  /**
+   * @return Y axis filtered acceleration angle
+   */
   public synchronized double getYFilteredAccelAngle() {
     return m_accelAngleY;
   }


### PR DESCRIPTION
Also removes JVM args workaround needed for old version of spotless to run on JDK 17

2 files had formatting updates for some reason.