### PR TITLE
[gradle] Add missing task dependency in examples

### DIFF
--- a/wpilibjExamples/build.gradle
+++ b/wpilibjExamples/build.gradle
@@ -196,6 +196,8 @@ model {
                                         setFailOnNoMatchingTests(false)
                                     }
                                     testTask.classpath = sourceSets.test.runtimeClasspath
+                                    testTask.dependsOn it.tasks.install
+
                                     testTask.systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
                                     testTask.testLogging {
                                         events "failed"


### PR DESCRIPTION
This didn't fail until now because the JNI object was there in CI/full builds due to other tasks.