### PR TITLE
[ntcore] Don't deadlock server on early destroy

### DIFF
--- a/ntcore/src/main/native/cpp/InstanceImpl.cpp
+++ b/ntcore/src/main/native/cpp/InstanceImpl.cpp
@@ -113,12 +113,15 @@ void InstanceImpl::StartServer(std::string_view persistFilename,
 }
 
 void InstanceImpl::StopServer() {
-  std::scoped_lock lock{m_mutex};
-  if ((networkMode & NT_NET_MODE_SERVER) == 0) {
-    return;
+  std::shared_ptr<NetworkServer> server;
+  {
+    std::scoped_lock lock{m_mutex};
+    if ((networkMode & NT_NET_MODE_SERVER) == 0) {
+      return;
+    }
+    server = std::move(m_networkServer);
+    networkMode = NT_NET_MODE_NONE;
   }
-  m_networkServer.reset();
-  networkMode = NT_NET_MODE_NONE;
 }
 
 void InstanceImpl::StartClient3(std::string_view identity) {


### PR DESCRIPTION
It was possible to deadlock on instance destroy if the server had started but had not yet fully initialized its handles.

This is a patch fix.  We should fix this more globally in the libuv wrappers but that's high risk at this point in the release cycle.