### PR TITLE
[wpiutil] SafeThread: Provide start/stop hooks

### DIFF
--- a/wpiutil/src/main/native/cpp/SafeThread.cpp
+++ b/wpiutil/src/main/native/cpp/SafeThread.cpp
@@ -27,7 +27,8 @@ namespace wpi::impl {
 void SetSafeThreadNotifers(OnThreadStartFn OnStart, OnThreadEndFn OnEnd) {
   std::unique_lock lock(gSafeThreadNotifierLock);
   if (gSafeThreadRefcount != 0) {
-    throw std::runtime_error("cannot set notifier while safe threads are running");
+    throw std::runtime_error(
+        "cannot set notifier while safe threads are running");
   }
   gOnSafeThreadStart = OnStart ? OnStart : DefaultOnThreadStart;
   gOnSafeThreadEnd = OnEnd ? OnEnd : DefaultOnThreadEnd;

--- a/wpiutil/src/main/native/cpp/SafeThread.cpp
+++ b/wpiutil/src/main/native/cpp/SafeThread.cpp
@@ -24,7 +24,7 @@ static OnThreadStartFn gOnSafeThreadStart{DefaultOnThreadStart};
 static OnThreadEndFn gOnSafeThreadEnd{DefaultOnThreadEnd};
 
 namespace wpi::impl {
-void SetSafeThreadNotifers(OnThreadStartFn OnStart, OnThreadEndFn OnEnd) {
+void SetSafeThreadNotifiers(OnThreadStartFn OnStart, OnThreadEndFn OnEnd) {
   std::unique_lock lock(gSafeThreadNotifierLock);
   if (gSafeThreadRefcount != 0) {
     throw std::runtime_error(

--- a/wpiutil/src/main/native/cpp/SafeThread.cpp
+++ b/wpiutil/src/main/native/cpp/SafeThread.cpp
@@ -2,9 +2,9 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include <atomic>
-
 #include "wpi/SafeThread.h"
+
+#include <atomic>
 
 using namespace wpi;
 


### PR DESCRIPTION
This is to facilitate setting up Python's thread state when a thread starts. Currently pybind11 will set up its own state the first time that it's called on a thread, and then delete it as soon as the last GIL is released. For threads that potentially have python callbacks, that would cause the thread state to be created/destroyed over and over again... this should be more efficient to do it this way. Should be effectively zero overhead for anyone else.