### PR TITLE
Add getters to SlewRateLimiter

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
@@ -87,4 +87,31 @@ public class SlewRateLimiter {
     m_prevVal = value;
     m_prevTime = WPIUtilJNI.now() * 1e-6;
   }
+
+  /**
+   * Provides the most recently calculated filtered value.
+   *
+   * @return The most recently calculated filtered value.
+   */
+  public double previousValue() {
+    return m_prevVal;
+  }
+
+  /**
+   * Provides the current positive rate limit.
+   *
+   * @return The current positive rate limit.
+   */
+  public double positiveRateLimit() {
+    return m_positiveRateLimit;
+  }
+
+  /**
+   * Provides the current negative rate limit.
+   *
+   * @return The current negative rate limit.
+   */
+  public double negativeRateLimit() {
+    return m_negativeRateLimit;
+  }
 }

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -102,21 +102,21 @@ class SlewRateLimiter {
    *
    * @return The most recently calculated filtered value.
    */
-  Unit_t previousValue() { return m_prevVal; }
+  Unit_t PreviousValue() { return m_prevVal; }
 
   /**
    * Provides the current positive rate limit.
    *
    * @return The current positive rate limit.
    */
-  Rate_t positiveRateLimit() { return m_positiveRateLimit; }
+  Rate_t PositiveRateLimit() { return m_positiveRateLimit; }
 
   /**
    * Provides the current negative rate limit.
    *
    * @return The current negative rate limit.
    */
-  Rate_t negativeRateLimit() { return m_negativeRateLimit; }
+  Rate_t NegativeRateLimit() { return m_negativeRateLimit; }
 
  private:
   Rate_t m_positiveRateLimit;

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -97,6 +97,33 @@ class SlewRateLimiter {
     m_prevTime = units::microsecond_t(wpi::Now());
   }
 
+  /**
+   * Provides the most recently calculated filtered value.
+   *
+   * @return The most recently calculated filtered value.
+   */
+  Unit_t previousValue() {
+    return m_prevVal;
+  }
+
+  /**
+   * Provides the current positive rate limit.
+   *
+   * @return The current positive rate limit.
+   */
+  Rate_t positiveRateLimit() {
+    return m_positiveRateLimit;
+  }
+
+  /**
+   * Provides the current negative rate limit.
+   *
+   * @return The current negative rate limit.
+   */
+  Rate_t negativeRateLimit() {
+    return m_negativeRateLimit;
+  }
+
  private:
   Rate_t m_positiveRateLimit;
   Rate_t m_negativeRateLimit;

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -102,27 +102,21 @@ class SlewRateLimiter {
    *
    * @return The most recently calculated filtered value.
    */
-  Unit_t previousValue() {
-    return m_prevVal;
-  }
+  Unit_t previousValue() { return m_prevVal; }
 
   /**
    * Provides the current positive rate limit.
    *
    * @return The current positive rate limit.
    */
-  Rate_t positiveRateLimit() {
-    return m_positiveRateLimit;
-  }
+  Rate_t positiveRateLimit() { return m_positiveRateLimit; }
 
   /**
    * Provides the current negative rate limit.
    *
    * @return The current negative rate limit.
    */
-  Rate_t negativeRateLimit() {
-    return m_negativeRateLimit;
-  }
+  Rate_t negativeRateLimit() { return m_negativeRateLimit; }
 
  private:
   Rate_t m_positiveRateLimit;


### PR DESCRIPTION
The existing SlewRateLimiter classes cannot be inspected. My team has a use case where this is required, so we've had to store the most recently returned value externally after calls to `calculate`. 

PR adds getters for the stored `m_prevVal`, `m_positiveRateLimit`, and `m_negativeRateLimit`. 