### PR TITLE
[examples] Add missing compiler flags and fix warnings

### DIFF
--- a/hal/src/dev/native/cpp/main.cpp
+++ b/hal/src/dev/native/cpp/main.cpp
@@ -8,5 +8,5 @@
 
 int main() {
   fmt::print("Hello World\n");
-  fmt::print("{}\n", HAL_GetRuntimeType());
+  fmt::print("{}\n", static_cast<int32_t>(HAL_GetRuntimeType()));
 }

--- a/hal/src/main/native/athena/PortsInternal.h
+++ b/hal/src/main/native/athena/PortsInternal.h
@@ -23,7 +23,8 @@ constexpr int32_t kNumDigitalChannels =
     kNumDigitalHeaders + kNumDigitalMXPChannels + kNumDigitalSPIPortChannels;
 constexpr int32_t kNumPWMChannels = tPWM::kNumMXPRegisters + kNumPWMHeaders;
 constexpr int32_t kNumDigitalPWMOutputs =
-    tDIO::kNumPWMDutyCycleAElements + tDIO::kNumPWMDutyCycleBElements;
+    static_cast<int32_t>(tDIO::kNumPWMDutyCycleAElements) +
+    static_cast<int32_t>(tDIO::kNumPWMDutyCycleBElements);
 constexpr int32_t kNumEncoders = tEncoder::kNumSystems;
 constexpr int32_t kNumInterrupts = tInterrupt::kNumSystems;
 constexpr int32_t kNumRelayChannels = 8;

--- a/hal/src/main/native/athena/SPI.cpp
+++ b/hal/src/main/native/athena/SPI.cpp
@@ -125,8 +125,8 @@ void HAL_InitializeSPI(HAL_SPIPort port, int32_t* status) {
       // CS0 is not a DIO port, so nothing to allocate
       handle = open("/dev/spidev0.0", O_RDWR);
       if (handle < 0) {
-        fmt::print("Failed to open SPI port {}: {}\n", port,
-                   std::strerror(errno));
+        fmt::print("Failed to open SPI port {}: {}\n",
+                   static_cast<int32_t>(port), std::strerror(errno));
         CommonSPIPortFree();
         return;
       }
@@ -147,8 +147,8 @@ void HAL_InitializeSPI(HAL_SPIPort port, int32_t* status) {
       }
       handle = open("/dev/spidev0.1", O_RDWR);
       if (handle < 0) {
-        fmt::print("Failed to open SPI port {}: {}\n", port,
-                   std::strerror(errno));
+        fmt::print("Failed to open SPI port {}: {}\n",
+                   static_cast<int32_t>(port), std::strerror(errno));
         CommonSPIPortFree();
         HAL_FreeDIOPort(digitalHandles[0]);
         return;
@@ -170,8 +170,8 @@ void HAL_InitializeSPI(HAL_SPIPort port, int32_t* status) {
       }
       handle = open("/dev/spidev0.2", O_RDWR);
       if (handle < 0) {
-        fmt::print("Failed to open SPI port {}: {}\n", port,
-                   std::strerror(errno));
+        fmt::print("Failed to open SPI port {}: {}\n",
+                   static_cast<int32_t>(port), std::strerror(errno));
         CommonSPIPortFree();
         HAL_FreeDIOPort(digitalHandles[1]);
         return;
@@ -193,8 +193,8 @@ void HAL_InitializeSPI(HAL_SPIPort port, int32_t* status) {
       }
       handle = open("/dev/spidev0.3", O_RDWR);
       if (handle < 0) {
-        fmt::print("Failed to open SPI port {}: {}\n", port,
-                   std::strerror(errno));
+        fmt::print("Failed to open SPI port {}: {}\n",
+                   static_cast<int32_t>(port), std::strerror(errno));
         CommonSPIPortFree();
         HAL_FreeDIOPort(digitalHandles[2]);
         return;
@@ -240,8 +240,8 @@ void HAL_InitializeSPI(HAL_SPIPort port, int32_t* status) {
           digitalSystem->readEnableMXPSpecialFunction(status) | 0x00F0, status);
       handle = open("/dev/spidev1.0", O_RDWR);
       if (handle < 0) {
-        fmt::print("Failed to open SPI port {}: {}\n", port,
-                   std::strerror(errno));
+        fmt::print("Failed to open SPI port {}: {}\n",
+                   static_cast<int32_t>(port), std::strerror(errno));
         HAL_FreeDIOPort(digitalHandles[5]);  // free the first port allocated
         HAL_FreeDIOPort(digitalHandles[6]);  // free the second port allocated
         HAL_FreeDIOPort(digitalHandles[7]);  // free the third port allocated

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -41,6 +41,11 @@ nativeUtils.platformConfigs.each {
     }
 }
 
+// NativeUtils adds the following OpenCV warning suppression for Linux, but not
+// for macOS
+// https://github.com/opencv/opencv/issues/20269
+nativeUtils.platformConfigs.osxuniversal.cppCompiler.args.add("-Wno-deprecated-anon-enum-enum-conversion")
+
 // NativeUtils uses the wrong compiler arguments for roboRIO targets, but it's
 // too late to fix NativeUtils for the 2023 season. This temporarily overwrites
 // the flags.

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -46,7 +46,6 @@ nativeUtils.platformConfigs.each {
 // the flags.
 nativeUtils.platformConfigs.named(nativeUtils.wpi.platforms.roborio).configure {
     cppCompiler.args.remove('-Wno-error=deprecated-declarations')
-    cppCompiler.args.add('-Werror=deprecated-declarations')
 }
 
 nativeUtils.platformConfigs.linuxathena.linker.args.add("-Wl,--fatal-warnings")

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -41,14 +41,12 @@ nativeUtils.platformConfigs.each {
     }
 }
 
-// Suppress OpenCV warning
-// https://github.com/opencv/opencv/issues/20269
-nativeUtils.platformConfigs.each {
-    if (it.name == nativeUtils.wpi.platforms.linuxx64) {
-        it.cppCompiler.args.add("-Wno-deprecated-enum-enum-conversion")
-    } else if (it.name.contains('osx')) {
-        it.cppCompiler.args.add("-Wno-deprecated-anon-enum-enum-conversion")
-    }
+// NativeUtils uses the wrong compiler arguments for roboRIO targets, but it's
+// too late to fix NativeUtils for the 2023 season. This temporarily overwrites
+// the flags.
+nativeUtils.platformConfigs.named(nativeUtils.wpi.platforms.roborio).configure {
+    cppCompiler.args.remove('-Wno-error=deprecated-declarations')
+    cppCompiler.args.add('-Werror=deprecated-declarations')
 }
 
 nativeUtils.platformConfigs.linuxathena.linker.args.add("-Wl,--fatal-warnings")

--- a/wpilibc/src/dev/native/cpp/main.cpp
+++ b/wpilibc/src/dev/native/cpp/main.cpp
@@ -9,6 +9,6 @@
 
 int main() {
   fmt::print("Hello World\n");
-  fmt::print("{}\n", HAL_GetRuntimeType());
+  fmt::print("{}\n", static_cast<int32_t>(HAL_GetRuntimeType()));
   fmt::print("{}\n", GetWPILibVersion());
 }

--- a/wpilibcExamples/CMakeLists.txt
+++ b/wpilibcExamples/CMakeLists.txt
@@ -10,6 +10,7 @@ foreach(example ${EXAMPLES})
   file(GLOB_RECURSE sources src/main/cpp/examples/${example}/cpp/*.cpp
                             src/main/cpp/examples/${example}/c/*.c)
   add_executable(${example} ${sources})
+  wpilib_target_warnings(${example})
   target_include_directories(${example} PUBLIC src/main/cpp/examples/${example}/include)
   target_link_libraries(${example} wpilibc wpilibNewCommands)
 
@@ -28,6 +29,7 @@ foreach(template ${TEMPLATES})
   file(GLOB_RECURSE sources src/main/cpp/templates/${template}/cpp/*.cpp
                             src/main/cpp/templates/${template}/c/*.c)
   add_executable(${template} ${sources})
+  wpilib_target_warnings(${template})
   target_include_directories(${template} PUBLIC src/main/cpp/templates/${template}/include)
   target_link_libraries(${template} wpilibc wpilibNewCommands)
 endforeach()

--- a/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/include/ExampleGlobalMeasurementSensor.h
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/include/ExampleGlobalMeasurementSensor.h
@@ -19,6 +19,6 @@ class ExampleGlobalMeasurementSensor {
     return frc::Pose2d{estimatedRobotPose.X() + units::meter_t{randVec(0)},
                        estimatedRobotPose.Y() + units::meter_t{randVec(1)},
                        estimatedRobotPose.Rotation() +
-                           frc::Rotation2d{units::radian_t{randVec(3)}}};
+                           frc::Rotation2d{units::radian_t{randVec(2)}}};
   }
 };

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/include/RobotContainer.h
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/include/RobotContainer.h
@@ -51,7 +51,7 @@ class RobotContainer {
                         OnBoardIO::ChannelMode::INPUT};
 
   // Example button
-  frc2::Button m_onboardButtonA{
+  frc2::Trigger m_onboardButtonA{
       [this] { return m_onboardIO.GetButtonAPressed(); }};
 
   // Autonomous commands.

--- a/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/include/ExampleGlobalMeasurementSensor.h
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/include/ExampleGlobalMeasurementSensor.h
@@ -19,6 +19,6 @@ class ExampleGlobalMeasurementSensor {
     return frc::Pose2d{estimatedRobotPose.X() + units::meter_t{randVec(0)},
                        estimatedRobotPose.Y() + units::meter_t{randVec(1)},
                        estimatedRobotPose.Rotation() +
-                           frc::Rotation2d{units::radian_t{randVec(3)}}};
+                           frc::Rotation2d{units::radian_t{randVec(2)}}};
   }
 };


### PR DESCRIPTION
This makes the build fail on warnings. It caught two out-of-bounds reads and a deprecation warning.

Closes #4888.