### PR TITLE
[hal] Fix segfault in various HAL functions

### DIFF
--- a/hal/src/main/native/athena/CANAPI.cpp
+++ b/hal/src/main/native/athena/CANAPI.cpp
@@ -85,6 +85,9 @@ HAL_CANHandle HAL_InitializeCAN(HAL_CANManufacturer manufacturer,
 
 void HAL_CleanCAN(HAL_CANHandle handle) {
   auto data = canHandles->Free(handle);
+  if (data == nullptr) {
+    return;
+  }
 
   std::scoped_lock lock(data->mapMutex);
 

--- a/hal/src/main/native/athena/DMA.cpp
+++ b/hal/src/main/native/athena/DMA.cpp
@@ -710,6 +710,9 @@ void HAL_StopDMA(HAL_DMAHandle handle, int32_t* status) {
 
 void* HAL_GetDMADirectPointer(HAL_DMAHandle handle) {
   auto dma = dmaHandles->Get(handle);
+  if (dma == nullptr) {
+    return nullptr;
+  }
   return dma.get();
 }
 

--- a/hal/src/main/native/cpp/jni/simulation/BufferCallbackStore.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/BufferCallbackStore.cpp
@@ -123,6 +123,9 @@ SIM_JniHandle sim::AllocateBufferCallback(
 void sim::FreeBufferCallback(JNIEnv* env, SIM_JniHandle handle, jint index,
                              FreeBufferCallbackFunc freeCallback) {
   auto callback = callbackHandles->Free(handle);
+  if (callback == nullptr) {
+    return;
+  }
   freeCallback(index, callback->getCallbackId());
   callback->free(env);
 }

--- a/hal/src/main/native/cpp/jni/simulation/ConstBufferCallbackStore.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/ConstBufferCallbackStore.cpp
@@ -116,6 +116,9 @@ SIM_JniHandle sim::AllocateConstBufferCallback(
 void sim::FreeConstBufferCallback(JNIEnv* env, SIM_JniHandle handle, jint index,
                                   FreeConstBufferCallbackFunc freeCallback) {
   auto callback = callbackHandles->Free(handle);
+  if (callback == nullptr) {
+    return;
+  }
   freeCallback(index, callback->getCallbackId());
   callback->free(env);
 }

--- a/hal/src/main/native/cpp/jni/simulation/SimDeviceDataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/SimDeviceDataJNI.cpp
@@ -242,6 +242,9 @@ static SIM_JniHandle AllocateDeviceCallback(
 static void FreeDeviceCallback(JNIEnv* env, SIM_JniHandle handle,
                                FreeDeviceCallbackFunc freeCallback) {
   auto callback = deviceCallbackHandles->Free(handle);
+  if (callback == nullptr) {
+    return;
+  }
   freeCallback(callback->getCallbackId());
   callback->free(env);
 }
@@ -296,6 +299,9 @@ static SIM_JniHandle AllocateValueCallback(
 static void FreeValueCallback(JNIEnv* env, SIM_JniHandle handle,
                               FreeValueCallbackFunc freeCallback) {
   auto callback = valueCallbackHandles->Free(handle);
+  if (callback == nullptr) {
+    return;
+  }
   freeCallback(callback->getCallbackId());
   callback->free(env);
 }

--- a/hal/src/main/native/cpp/jni/simulation/SpiReadAutoReceiveBufferCallbackStore.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/SpiReadAutoReceiveBufferCallbackStore.cpp
@@ -127,6 +127,9 @@ SIM_JniHandle sim::AllocateSpiBufferCallback(
 void sim::FreeSpiBufferCallback(JNIEnv* env, SIM_JniHandle handle, jint index,
                                 FreeSpiBufferCallbackFunc freeCallback) {
   auto callback = callbackHandles->Free(handle);
+  if (callback == nullptr) {
+    return;
+  }
   freeCallback(index, callback->getCallbackId());
   callback->free(env);
 }

--- a/hal/src/main/native/sim/CANAPI.cpp
+++ b/hal/src/main/native/sim/CANAPI.cpp
@@ -93,6 +93,9 @@ HAL_CANHandle HAL_InitializeCAN(HAL_CANManufacturer manufacturer,
 
 void HAL_CleanCAN(HAL_CANHandle handle) {
   auto data = canHandles->Free(handle);
+  if (data == nullptr) {
+    return;
+  }
 
   std::scoped_lock lock(data->mapMutex);
 

--- a/hal/src/main/native/sim/Encoder.cpp
+++ b/hal/src/main/native/sim/Encoder.cpp
@@ -53,7 +53,7 @@ bool GetEncoderBaseHandle(HAL_EncoderHandle handle,
                           HAL_FPGAEncoderHandle* fpgaHandle,
                           HAL_CounterHandle* counterHandle) {
   auto encoder = encoderHandles->Get(handle);
-  if (!handle) {
+  if (!encoder) {
     return false;
   }
 


### PR DESCRIPTION
- Return values of ->Get and ->Free weren't being checked in a few places

I found the CleanCAN one when debugging @auscompgeek's crash example, and I did a survey of all instances of ->Get(handle) and ->Free(handle) and found these others.