### PR TITLE
[ntcore] Fix client flush behavior

### DIFF
--- a/ntcore/src/main/native/cpp/net/ClientImpl.h
+++ b/ntcore/src/main/native/cpp/net/ClientImpl.h
@@ -44,7 +44,7 @@ class ClientImpl {
   void HandleLocal(std::vector<ClientMessage>&& msgs);
 
   void SendControl(uint64_t curTimeMs);
-  void SendValues(uint64_t curTimeMs);
+  void SendValues(uint64_t curTimeMs, bool flush);
 
   void SetLocal(LocalInterface* local);
   void SendInitial();

--- a/ntcore/src/main/native/cpp/net3/ClientImpl3.h
+++ b/ntcore/src/main/native/cpp/net3/ClientImpl3.h
@@ -38,7 +38,7 @@ class ClientImpl3 {
   void ProcessIncoming(std::span<const uint8_t> data);
   void HandleLocal(std::span<const net::ClientMessage> msgs);
 
-  void SendPeriodic(uint64_t curTimeMs);
+  void SendPeriodic(uint64_t curTimeMs, bool flush);
 
   void SetLocal(net::LocalInterface* local);
 


### PR DESCRIPTION
We need to ignore per-publisher send periods when flushing.

Also fix NT4 client to use flush async's (same as NT3 client).

Fixes #4902.