### PR TITLE
[wpimath] Fix swerve kinematics util classes' equals function

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModulePosition.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModulePosition.java
@@ -32,7 +32,8 @@ public class SwerveModulePosition implements Comparable<SwerveModulePosition> {
   @Override
   public boolean equals(Object obj) {
     if (obj instanceof SwerveModulePosition) {
-      return Double.compare(distanceMeters, ((SwerveModulePosition) obj).distanceMeters) == 0;
+      SwerveModulePosition other = (SwerveModulePosition) obj;
+      return Double.compare(distanceMeters, other.distanceMeters) == 0 && angle.equals(other.angle);
     }
     return false;
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModulePosition.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModulePosition.java
@@ -33,14 +33,14 @@ public class SwerveModulePosition implements Comparable<SwerveModulePosition> {
   public boolean equals(Object obj) {
     if (obj instanceof SwerveModulePosition) {
       SwerveModulePosition other = (SwerveModulePosition) obj;
-      return Double.compare(distanceMeters, other.distanceMeters) == 0 && angle.equals(other.angle);
+      return Math.abs(other.distanceMeters - distanceMeters) < 1E-9 && angle.equals(other.angle);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(distanceMeters);
+    return Objects.hash(distanceMeters, angle);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModuleState.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModuleState.java
@@ -32,8 +32,9 @@ public class SwerveModuleState implements Comparable<SwerveModuleState> {
   @Override
   public boolean equals(Object obj) {
     if (obj instanceof SwerveModuleState) {
-      return Double.compare(speedMetersPerSecond, ((SwerveModuleState) obj).speedMetersPerSecond)
-          == 0;
+      SwerveModuleState other = (SwerveModuleState) obj;
+      return Double.compare(speedMetersPerSecond, other.speedMetersPerSecond) == 0
+          && angle.equals(other.angle);
     }
     return false;
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModuleState.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModuleState.java
@@ -33,7 +33,7 @@ public class SwerveModuleState implements Comparable<SwerveModuleState> {
   public boolean equals(Object obj) {
     if (obj instanceof SwerveModuleState) {
       SwerveModuleState other = (SwerveModuleState) obj;
-      return Math.abs(other.speedMetersPerSecond - speedMetersPerSecond) < 1E-9 
+      return Math.abs(other.speedMetersPerSecond - speedMetersPerSecond) < 1E-9
           && angle.equals(other.angle);
     }
     return false;

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModuleState.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveModuleState.java
@@ -33,7 +33,7 @@ public class SwerveModuleState implements Comparable<SwerveModuleState> {
   public boolean equals(Object obj) {
     if (obj instanceof SwerveModuleState) {
       SwerveModuleState other = (SwerveModuleState) obj;
-      return Double.compare(speedMetersPerSecond, other.speedMetersPerSecond) == 0
+      return Math.abs(other.speedMetersPerSecond - speedMetersPerSecond) < 1E-9 
           && angle.equals(other.angle);
     }
     return false;
@@ -41,7 +41,7 @@ public class SwerveModuleState implements Comparable<SwerveModuleState> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(speedMetersPerSecond);
+    return Objects.hash(speedMetersPerSecond, angle);
   }
 
   /**

--- a/wpimath/src/main/native/cpp/kinematics/SwerveModulePosition.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/SwerveModulePosition.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc/kinematics/SwerveModulePosition.h"
+#include "frc/kinematics/SwerveModuleState.h"
+
+#include "units/math.h"
+
+using namespace frc;
+
+bool SwerveModulePosition::operator==(const SwerveModulePosition& other) const {
+  return units::math::abs(distance - other.distance) < 1E-9_m && angle == other.angle;
+}

--- a/wpimath/src/main/native/cpp/kinematics/SwerveModulePosition.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/SwerveModulePosition.cpp
@@ -3,12 +3,13 @@
 // the WPILib BSD license file in the root directory of this project.
 
 #include "frc/kinematics/SwerveModulePosition.h"
-#include "frc/kinematics/SwerveModuleState.h"
 
+#include "frc/kinematics/SwerveModuleState.h"
 #include "units/math.h"
 
 using namespace frc;
 
 bool SwerveModulePosition::operator==(const SwerveModulePosition& other) const {
-  return units::math::abs(distance - other.distance) < 1E-9_m && angle == other.angle;
+  return units::math::abs(distance - other.distance) < 1E-9_m &&
+         angle == other.angle;
 }

--- a/wpimath/src/main/native/cpp/kinematics/SwerveModuleState.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/SwerveModuleState.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc/kinematics/SwerveModuleState.h"
+
+#include "units/math.h"
+
+using namespace frc;
+
+bool SwerveModuleState::operator==(const SwerveModuleState& other) const {
+  return units::math::abs(speed - other.speed) < 1E-9_mps && angle == other.angle;
+}
+
+SwerveModuleState SwerveModuleState::Optimize(const SwerveModuleState &desiredState, const Rotation2d &currentAngle) {
+    auto delta = desiredState.angle - currentAngle;
+    if (units::math::abs(delta.Degrees()) > 90_deg) {
+      return {-desiredState.speed, desiredState.angle + Rotation2d{180_deg}};
+    } else {
+      return {desiredState.speed, desiredState.angle};
+    }
+}

--- a/wpimath/src/main/native/cpp/kinematics/SwerveModuleState.cpp
+++ b/wpimath/src/main/native/cpp/kinematics/SwerveModuleState.cpp
@@ -9,14 +9,16 @@
 using namespace frc;
 
 bool SwerveModuleState::operator==(const SwerveModuleState& other) const {
-  return units::math::abs(speed - other.speed) < 1E-9_mps && angle == other.angle;
+  return units::math::abs(speed - other.speed) < 1E-9_mps &&
+         angle == other.angle;
 }
 
-SwerveModuleState SwerveModuleState::Optimize(const SwerveModuleState &desiredState, const Rotation2d &currentAngle) {
-    auto delta = desiredState.angle - currentAngle;
-    if (units::math::abs(delta.Degrees()) > 90_deg) {
-      return {-desiredState.speed, desiredState.angle + Rotation2d{180_deg}};
-    } else {
-      return {desiredState.speed, desiredState.angle};
-    }
+SwerveModuleState SwerveModuleState::Optimize(
+    const SwerveModuleState& desiredState, const Rotation2d& currentAngle) {
+  auto delta = desiredState.angle - currentAngle;
+  if (units::math::abs(delta.Degrees()) > 90_deg) {
+    return {-desiredState.speed, desiredState.angle + Rotation2d{180_deg}};
+  } else {
+    return {desiredState.speed, desiredState.angle};
+  }
 }

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveModulePosition.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveModulePosition.h
@@ -25,5 +25,13 @@ struct WPILIB_DLLEXPORT SwerveModulePosition {
    * Angle of the module.
    */
   Rotation2d angle;
+
+  /**
+   * Checks equality between this SwerveModulePosition and another object.
+   *
+   * @param other The other object.
+   * @return Whether the two objects are equal.
+   */
+  bool operator==(const SwerveModulePosition& other) const;
 };
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveModuleState.h
@@ -27,6 +27,14 @@ struct WPILIB_DLLEXPORT SwerveModuleState {
   Rotation2d angle;
 
   /**
+   * Checks equality between this SwerveModuleState and another object.
+   *
+   * @param other The other object.
+   * @return Whether the two objects are equal.
+   */
+  bool operator==(const SwerveModuleState& other) const;
+
+  /**
    * Minimize the change in heading the desired swerve module state would
    * require by potentially reversing the direction the wheel spins. If this is
    * used with the PIDController class's continuous input functionality, the
@@ -36,13 +44,6 @@ struct WPILIB_DLLEXPORT SwerveModuleState {
    * @param currentAngle The current module angle.
    */
   static SwerveModuleState Optimize(const SwerveModuleState& desiredState,
-                                    const Rotation2d& currentAngle) {
-    auto delta = desiredState.angle - currentAngle;
-    if (units::math::abs(delta.Degrees()) > 90_deg) {
-      return {-desiredState.speed, desiredState.angle + Rotation2d{180_deg}};
-    } else {
-      return {desiredState.speed, desiredState.angle};
-    }
-  }
+                                    const Rotation2d& currentAngle);
 };
 }  // namespace frc

--- a/wpimath/src/test/native/cpp/kinematics/SwerveModulePositionTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/SwerveModulePositionTest.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc/geometry/Rotation2d.h"
+#include "frc/kinematics/SwerveModulePosition.h"
+#include "gtest/gtest.h"
+
+TEST(SwerveModulePositionTest, Equality) {
+  frc::SwerveModulePosition position1{2_m, 90_deg};
+  frc::SwerveModulePosition position2{2_m, 90_deg};
+
+  EXPECT_EQ(position1, position2);
+}
+
+TEST(SwerveModulePositionTest, InEquality) {
+  frc::SwerveModulePosition position1{1_m, 90_deg};
+  frc::SwerveModulePosition position2{2_m, 90_deg};
+  frc::SwerveModulePosition position3{1_m, 89_deg};
+
+  EXPECT_NE(position1, position2);
+  EXPECT_NE(position1, position3);
+}

--- a/wpimath/src/test/native/cpp/kinematics/SwerveModulePositionTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/SwerveModulePositionTest.cpp
@@ -13,7 +13,7 @@ TEST(SwerveModulePositionTest, Equality) {
   EXPECT_EQ(position1, position2);
 }
 
-TEST(SwerveModulePositionTest, InEquality) {
+TEST(SwerveModulePositionTest, Inequality) {
   frc::SwerveModulePosition position1{1_m, 90_deg};
   frc::SwerveModulePosition position2{2_m, 90_deg};
   frc::SwerveModulePosition position3{1_m, 89_deg};

--- a/wpimath/src/test/native/cpp/kinematics/SwerveModuleStateTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/SwerveModuleStateTest.cpp
@@ -47,7 +47,7 @@ TEST(SwerveModuleStateTest, Equality) {
   EXPECT_EQ(state1, state2);
 }
 
-TEST(SwerveModuleStateTest, InEquality) {
+TEST(SwerveModuleStateTest, Inequality) {
   frc::SwerveModuleState state1{1_mps, 90_deg};
   frc::SwerveModuleState state2{2_mps, 90_deg};
   frc::SwerveModuleState state3{1_mps, 89_deg};

--- a/wpimath/src/test/native/cpp/kinematics/SwerveModuleStateTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/SwerveModuleStateTest.cpp
@@ -39,3 +39,19 @@ TEST(SwerveModuleStateTest, NoOptimize) {
   EXPECT_NEAR(optimizedB.speed.value(), -2.0, kEpsilon);
   EXPECT_NEAR(optimizedB.angle.Degrees().value(), -2.0, kEpsilon);
 }
+
+TEST(SwerveModuleStateTest, Equality) {
+  frc::SwerveModuleState state1{2_mps, 90_deg};
+  frc::SwerveModuleState state2{2_mps, 90_deg};
+
+  EXPECT_EQ(state1, state2);
+}
+
+TEST(SwerveModuleStateTest, InEquality) {
+  frc::SwerveModuleState state1{1_mps, 90_deg};
+  frc::SwerveModuleState state2{2_mps, 90_deg};
+  frc::SwerveModuleState state3{1_mps, 89_deg};
+
+  EXPECT_NE(state1, state2);
+  EXPECT_NE(state1, state3);
+}


### PR DESCRIPTION
~~Doesn't seem like this was a problem in C++~~. 
Should something be done about the compare to? (And it also doesn't seem like there is a compareTo implemented in C++)