### PR TITLE
[wpiutil] Guard MSVC pragma in SymbolExports.h

### DIFF
--- a/wpiutil/src/main/native/include/wpi/SymbolExports.h
+++ b/wpiutil/src/main/native/include/wpi/SymbolExports.h
@@ -5,7 +5,9 @@
 #pragma once
 
 #ifdef _WIN32
+#ifndef __GNUC__
 #pragma warning(disable : 4251)
+#endif
 
 #ifdef WPILIB_EXPORTS
 #ifdef __GNUC__

--- a/wpiutil/src/main/native/include/wpi/SymbolExports.h
+++ b/wpiutil/src/main/native/include/wpi/SymbolExports.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #ifdef _WIN32
-#ifndef __GNUC__
+#ifdef _MSC_VER
 #pragma warning(disable : 4251)
 #endif
 


### PR DESCRIPTION
MinGW gives an unknown pragma warning on Windows.