### PR TITLE
Allow multiple vision measurements from same timestamp

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
@@ -212,7 +212,16 @@ public class DifferentialDrivePoseEstimator {
         sample.get().rightMeters,
         sample.get().poseMeters.exp(scaledTwist));
 
-    // Step 6: Replay odometry inputs between sample time and latest recorded sample to update the
+    // Step 6: Record the current pose to allow multiple measurements from the same timestamp
+    m_poseBuffer.addSample(
+        timestampSeconds,
+        new InterpolationRecord(
+            getEstimatedPosition(),
+            sample.get().gyroAngle,
+            sample.get().leftMeters,
+            sample.get().rightMeters));
+
+    // Step 7: Replay odometry inputs between sample time and latest recorded sample to update the
     // pose buffer and correct odometry.
     for (Map.Entry<Double, InterpolationRecord> entry :
         m_poseBuffer.getInternalBuffer().tailMap(timestampSeconds).entrySet()) {

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -199,7 +199,13 @@ public class MecanumDrivePoseEstimator {
         sample.get().wheelPositions,
         sample.get().poseMeters.exp(scaledTwist));
 
-    // Step 6: Replay odometry inputs between sample time and latest recorded sample to update the
+    // Step 6: Record the current pose to allow multiple measurements from the same timestamp
+    m_poseBuffer.addSample(
+        timestampSeconds,
+        new InterpolationRecord(
+            getEstimatedPosition(), sample.get().gyroAngle, sample.get().wheelPositions));
+
+    // Step 7: Replay odometry inputs between sample time and latest recorded sample to update the
     // pose buffer and correct odometry.
     for (Map.Entry<Double, InterpolationRecord> entry :
         m_poseBuffer.getInternalBuffer().tailMap(timestampSeconds).entrySet()) {

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -201,7 +201,13 @@ public class SwerveDrivePoseEstimator {
         sample.get().modulePositions,
         sample.get().poseMeters.exp(scaledTwist));
 
-    // Step 6: Replay odometry inputs between sample time and latest recorded sample to update the
+    // Step 6: Record the current pose to allow multiple measurements from the same timestamp
+    m_poseBuffer.addSample(
+        timestampSeconds,
+        new InterpolationRecord(
+            getEstimatedPosition(), sample.get().gyroAngle, sample.get().modulePositions));
+
+    // Step 7: Replay odometry inputs between sample time and latest recorded sample to update the
     // pose buffer and correct odometry.
     for (Map.Entry<Double, InterpolationRecord> entry :
         m_poseBuffer.getInternalBuffer().tailMap(timestampSeconds).entrySet()) {

--- a/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
@@ -121,7 +121,13 @@ void DifferentialDrivePoseEstimator::AddVisionMeasurement(
       sample.value().gyroAngle, sample.value().leftDistance,
       sample.value().rightDistance, sample.value().pose.Exp(scaledTwist));
 
-  // Step 6: Replay odometry inputs between sample time and latest recorded
+  // Step 6: Record the current pose to allow multiple measurements from the
+  // same timestamp
+  m_poseBuffer.AddSample(
+      timestamp, {GetEstimatedPosition(), sample.value().gyroAngle,
+                  sample.get().leftDistance, sample.value().rightDistance});
+
+  // Step 7: Replay odometry inputs between sample time and latest recorded
   // sample to update the pose buffer and correct odometry.
   auto internal_buf = m_poseBuffer.GetInternalBuffer();
 

--- a/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
@@ -125,7 +125,7 @@ void DifferentialDrivePoseEstimator::AddVisionMeasurement(
   // same timestamp
   m_poseBuffer.AddSample(
       timestamp, {GetEstimatedPosition(), sample.value().gyroAngle,
-                  sample.get().leftDistance, sample.value().rightDistance});
+                  sample.value().leftDistance, sample.value().rightDistance});
 
   // Step 7: Replay odometry inputs between sample time and latest recorded
   // sample to update the pose buffer and correct odometry.

--- a/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
@@ -132,7 +132,13 @@ void frc::MecanumDrivePoseEstimator::AddVisionMeasurement(
                            sample.value().wheelPositions,
                            sample.value().pose.Exp(scaledTwist));
 
-  // Step 6: Replay odometry inputs between sample time and latest recorded
+  // Step 6: Record the current pose to allow multiple measurements from the
+  // same timestamp
+  m_poseBuffer.AddSample(timestamp,
+                         {GetEstimatedPosition(), sample.value().gyroAngle,
+                          sample.get().wheelPositions});
+
+  // Step 7: Replay odometry inputs between sample time and latest recorded
   // sample to update the pose buffer and correct odometry.
   auto internal_buf = m_poseBuffer.GetInternalBuffer();
 

--- a/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
@@ -136,7 +136,7 @@ void frc::MecanumDrivePoseEstimator::AddVisionMeasurement(
   // same timestamp
   m_poseBuffer.AddSample(timestamp,
                          {GetEstimatedPosition(), sample.value().gyroAngle,
-                          sample.get().wheelPositions});
+                          sample.value().wheelPositions});
 
   // Step 7: Replay odometry inputs between sample time and latest recorded
   // sample to update the pose buffer and correct odometry.

--- a/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
@@ -197,7 +197,13 @@ class SwerveDrivePoseEstimator {
                              sample.value().modulePostions,
                              sample.value().pose.Exp(scaledTwist));
 
-    // Step 6: Replay odometry inputs between sample time and latest recorded
+    // Step 6: Record the current pose to allow multiple measurements from the
+    // same timestamp
+    m_poseBuffer.AddSample(timestamp,
+                           {GetEstimatedPosition(), sample.value().gyroAngle,
+                            sample.get().modulePositions});
+
+    // Step 7: Replay odometry inputs between sample time and latest recorded
     // sample to update the pose buffer and correct odometry.
     auto internal_buf = m_poseBuffer.GetInternalBuffer();
 

--- a/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
@@ -194,14 +194,14 @@ class SwerveDrivePoseEstimator {
 
     // Step 5: Reset Odometry to state at sample with vision adjustment.
     m_odometry.ResetPosition(sample.value().gyroAngle,
-                             sample.value().modulePostions,
+                             sample.value().modulePositions,
                              sample.value().pose.Exp(scaledTwist));
 
     // Step 6: Record the current pose to allow multiple measurements from the
     // same timestamp
     m_poseBuffer.AddSample(timestamp,
                            {GetEstimatedPosition(), sample.value().gyroAngle,
-                            sample.get().modulePositions});
+                            sample.value().modulePositions});
 
     // Step 7: Replay odometry inputs between sample time and latest recorded
     // sample to update the pose buffer and correct odometry.
@@ -213,7 +213,7 @@ class SwerveDrivePoseEstimator {
 
     for (auto entry = upper_bound; entry != internal_buf.end(); entry++) {
       UpdateWithTime(entry->first, entry->second.gyroAngle,
-                     entry->second.modulePostions);
+                     entry->second.modulePositions);
     }
   }
 
@@ -306,7 +306,7 @@ class SwerveDrivePoseEstimator {
     Rotation2d gyroAngle;
 
     // The distances traveled and rotations meaured at each module.
-    wpi::array<SwerveModulePosition, NumModules> modulePostions;
+    wpi::array<SwerveModulePosition, NumModules> modulePositions;
 
     /**
      * Checks equality between this InterpolationRecord and another object.
@@ -350,14 +350,14 @@ class SwerveDrivePoseEstimator {
 
         for (size_t i = 0; i < NumModules; i++) {
           modulePositions[i].distance =
-              wpi::Lerp(this->modulePostions[i].distance,
-                        endValue.modulePostions[i].distance, i);
+              wpi::Lerp(this->modulePositions[i].distance,
+                        endValue.modulePositions[i].distance, i);
           modulePositions[i].angle =
-              wpi::Lerp(this->modulePostions[i].angle,
-                        endValue.modulePostions[i].angle, i);
+              wpi::Lerp(this->modulePositions[i].angle,
+                        endValue.modulePositions[i].angle, i);
 
           modulesDelta[i].distance =
-              modulePositions[i].distance - this->modulePostions[i].distance;
+              modulePositions[i].distance - this->modulePositions[i].distance;
           modulesDelta[i].angle = modulePositions[i].angle;
         }
 

--- a/wpimath/src/main/native/include/frc/interpolation/TimeInterpolatableBuffer.h
+++ b/wpimath/src/main/native/include/frc/interpolation/TimeInterpolatableBuffer.h
@@ -76,7 +76,7 @@ class TimeInterpolatableBuffer {
 
       if (last_not_greater_than == m_pastSnapshots.begin() ||
           last_not_greater_than->first < time) {
-        // To cases handled together:
+        // Two cases handled together:
         // 1. All entries come after the sample
         // 2. Some entries come before the sample, but none are recorded with
         // the same time

--- a/wpimath/src/main/native/include/frc/interpolation/TimeInterpolatableBuffer.h
+++ b/wpimath/src/main/native/include/frc/interpolation/TimeInterpolatableBuffer.h
@@ -69,19 +69,18 @@ class TimeInterpolatableBuffer {
       m_pastSnapshots.emplace_back(time, sample);
     } else {
       auto first_after = std::upper_bound(
-              m_pastSnapshots.begin(), m_pastSnapshots.end(), time,
-              [](auto t, const auto& pair) { return t < pair.first; });
-
+          m_pastSnapshots.begin(), m_pastSnapshots.end(), time,
+          [](auto t, const auto& pair) { return t < pair.first; });
 
       auto last_not_greater_than = first_after - 1;
 
-      if (last_not_greater_than == m_pastSnapshots.begin() || last_not_greater_than->first < time) {
+      if (last_not_greater_than == m_pastSnapshots.begin() ||
+          last_not_greater_than->first < time) {
         // To cases handled together:
         // 1. All entries come after the sample
-        // 2. Some entries come before the sample, but none are recorded with the same time
-        m_pastSnapshots.insert(
-            first_after,
-            std::pair(time, sample));
+        // 2. Some entries come before the sample, but none are recorded with
+        // the same time
+        m_pastSnapshots.insert(first_after, std::pair(time, sample));
       } else {
         // Final case:
         // 3. An entry exists with the same recorded time.

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -227,4 +227,43 @@ class DifferentialDrivePoseEstimatorTest {
       assertEquals(0.0, maxError, 0.2, "Incorrect max error");
     }
   }
+
+  @Test
+  void testSimultaneousVisionMeasurements() {
+    var kinematics = new DifferentialDriveKinematics(1);
+
+    var estimator =
+        new DifferentialDrivePoseEstimator(
+            kinematics,
+            new Rotation2d(),
+            0,
+            0,
+            new Pose2d(1, 2, Rotation2d.fromDegrees(270)),
+            VecBuilder.fill(0.02, 0.02, 0.01),
+            VecBuilder.fill(0.1, 0.1, 0.1));
+
+    estimator.updateWithTime(0, new Rotation2d(), 0, 0);
+
+    var visionMeasurements = new Pose2d[]{
+        new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
+        new Pose2d(3, 1, Rotation2d.fromDegrees(90)),
+        new Pose2d(2, 4, Rotation2d.fromRadians(180)),
+    };
+
+    for (int i = 0; i < 1000; i++) {
+        for (var measurement : visionMeasurements) {
+            estimator.addVisionMeasurement(measurement, 0);
+        }
+    }
+
+    for (var measurement : visionMeasurements) {
+        var errorLog = "Estimator converged to one vision measurement: " + estimator.getEstimatedPosition().toString() + " -> " + measurement.toString();
+
+        var dx = Math.abs(measurement.getX() - estimator.getEstimatedPosition().getX());
+        var dy = Math.abs(measurement.getY() - estimator.getEstimatedPosition().getY());
+        var dtheta = Math.abs(measurement.getRotation().getDegrees() - estimator.getEstimatedPosition().getRotation().getDegrees());
+
+        assertEquals(dx > 0.08 || dy > 0.08 || dtheta > 0.08, true, errorLog);
+    }
+  }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -230,6 +230,10 @@ class DifferentialDrivePoseEstimatorTest {
 
   @Test
   void testSimultaneousVisionMeasurements() {
+    // This tests for multiple vision measurements appled at the same time. The expected behavior
+    // is that all measurements affect the estimated pose. The alternative result is that only one
+    // vision measurement affects the outcome. If that were the case, after 1000 measurements, the
+    // estimated pose would converge to that measurement.
     var kinematics = new DifferentialDriveKinematics(1);
 
     var estimator =

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimatorTest.java
@@ -244,26 +244,34 @@ class DifferentialDrivePoseEstimatorTest {
 
     estimator.updateWithTime(0, new Rotation2d(), 0, 0);
 
-    var visionMeasurements = new Pose2d[]{
-        new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
-        new Pose2d(3, 1, Rotation2d.fromDegrees(90)),
-        new Pose2d(2, 4, Rotation2d.fromRadians(180)),
-    };
+    var visionMeasurements =
+        new Pose2d[] {
+          new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
+          new Pose2d(3, 1, Rotation2d.fromDegrees(90)),
+          new Pose2d(2, 4, Rotation2d.fromRadians(180)),
+        };
 
     for (int i = 0; i < 1000; i++) {
-        for (var measurement : visionMeasurements) {
-            estimator.addVisionMeasurement(measurement, 0);
-        }
+      for (var measurement : visionMeasurements) {
+        estimator.addVisionMeasurement(measurement, 0);
+      }
     }
 
     for (var measurement : visionMeasurements) {
-        var errorLog = "Estimator converged to one vision measurement: " + estimator.getEstimatedPosition().toString() + " -> " + measurement.toString();
+      var errorLog =
+          "Estimator converged to one vision measurement: "
+              + estimator.getEstimatedPosition().toString()
+              + " -> "
+              + measurement.toString();
 
-        var dx = Math.abs(measurement.getX() - estimator.getEstimatedPosition().getX());
-        var dy = Math.abs(measurement.getY() - estimator.getEstimatedPosition().getY());
-        var dtheta = Math.abs(measurement.getRotation().getDegrees() - estimator.getEstimatedPosition().getRotation().getDegrees());
+      var dx = Math.abs(measurement.getX() - estimator.getEstimatedPosition().getX());
+      var dy = Math.abs(measurement.getY() - estimator.getEstimatedPosition().getY());
+      var dtheta =
+          Math.abs(
+              measurement.getRotation().getDegrees()
+                  - estimator.getEstimatedPosition().getRotation().getDegrees());
 
-        assertEquals(dx > 0.08 || dy > 0.08 || dtheta > 0.08, true, errorLog);
+      assertEquals(dx > 0.08 || dy > 0.08 || dtheta > 0.08, true, errorLog);
     }
   }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimatorTest.java
@@ -236,4 +236,47 @@ class MecanumDrivePoseEstimatorTest {
       assertEquals(0.0, maxError, 0.2, "Incorrect max error");
     }
   }
+
+  @Test
+  void testSimultaneousVisionMeasurements() {
+    var kinematics =
+        new MecanumDriveKinematics(
+            new Translation2d(1, 1), new Translation2d(1, -1),
+            new Translation2d(-1, -1), new Translation2d(-1, 1));
+
+    var wheelPositions = new MecanumDriveWheelPositions();
+
+    var estimator =
+        new MecanumDrivePoseEstimator(
+            kinematics,
+            new Rotation2d(),
+            wheelPositions,
+            new Pose2d(1, 2, Rotation2d.fromDegrees(270)),
+            VecBuilder.fill(0.1, 0.1, 0.1),
+            VecBuilder.fill(0.45, 0.45, 0.1));
+
+    estimator.updateWithTime(0, new Rotation2d(), wheelPositions);
+
+    var visionMeasurements = new Pose2d[]{
+        new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
+        new Pose2d(3, 1, Rotation2d.fromDegrees(90)),
+        new Pose2d(2, 4, Rotation2d.fromRadians(180)),
+    };
+
+    for (int i = 0; i < 1000; i++) {
+        for (var measurement : visionMeasurements) {
+            estimator.addVisionMeasurement(measurement, 0);
+        }
+    }
+
+    for (var measurement : visionMeasurements) {
+        var errorLog = "Estimator converged to one vision measurement: " + estimator.getEstimatedPosition().toString() + " -> " + measurement.toString();
+
+        var dx = Math.abs(measurement.getX() - estimator.getEstimatedPosition().getX());
+        var dy = Math.abs(measurement.getY() - estimator.getEstimatedPosition().getY());
+        var dtheta = Math.abs(measurement.getRotation().getDegrees() - estimator.getEstimatedPosition().getRotation().getDegrees());
+
+        assertEquals(dx > 0.08 || dy > 0.08 || dtheta > 0.08, true, errorLog);
+    }
+  }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimatorTest.java
@@ -239,6 +239,10 @@ class MecanumDrivePoseEstimatorTest {
 
   @Test
   void testSimultaneousVisionMeasurements() {
+    // This tests for multiple vision measurements appled at the same time. The expected behavior
+    // is that all measurements affect the estimated pose. The alternative result is that only one
+    // vision measurement affects the outcome. If that were the case, after 1000 measurements, the
+    // estimated pose would converge to that measurement.
     var kinematics =
         new MecanumDriveKinematics(
             new Translation2d(1, 1), new Translation2d(1, -1),

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimatorTest.java
@@ -257,26 +257,34 @@ class MecanumDrivePoseEstimatorTest {
 
     estimator.updateWithTime(0, new Rotation2d(), wheelPositions);
 
-    var visionMeasurements = new Pose2d[]{
-        new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
-        new Pose2d(3, 1, Rotation2d.fromDegrees(90)),
-        new Pose2d(2, 4, Rotation2d.fromRadians(180)),
-    };
+    var visionMeasurements =
+        new Pose2d[] {
+          new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
+          new Pose2d(3, 1, Rotation2d.fromDegrees(90)),
+          new Pose2d(2, 4, Rotation2d.fromRadians(180)),
+        };
 
     for (int i = 0; i < 1000; i++) {
-        for (var measurement : visionMeasurements) {
-            estimator.addVisionMeasurement(measurement, 0);
-        }
+      for (var measurement : visionMeasurements) {
+        estimator.addVisionMeasurement(measurement, 0);
+      }
     }
 
     for (var measurement : visionMeasurements) {
-        var errorLog = "Estimator converged to one vision measurement: " + estimator.getEstimatedPosition().toString() + " -> " + measurement.toString();
+      var errorLog =
+          "Estimator converged to one vision measurement: "
+              + estimator.getEstimatedPosition().toString()
+              + " -> "
+              + measurement.toString();
 
-        var dx = Math.abs(measurement.getX() - estimator.getEstimatedPosition().getX());
-        var dy = Math.abs(measurement.getY() - estimator.getEstimatedPosition().getY());
-        var dtheta = Math.abs(measurement.getRotation().getDegrees() - estimator.getEstimatedPosition().getRotation().getDegrees());
+      var dx = Math.abs(measurement.getX() - estimator.getEstimatedPosition().getX());
+      var dy = Math.abs(measurement.getY() - estimator.getEstimatedPosition().getY());
+      var dtheta =
+          Math.abs(
+              measurement.getRotation().getDegrees()
+                  - estimator.getEstimatedPosition().getRotation().getDegrees());
 
-        assertEquals(dx > 0.08 || dy > 0.08 || dtheta > 0.08, true, errorLog);
+      assertEquals(dx > 0.08 || dy > 0.08 || dtheta > 0.08, true, errorLog);
     }
   }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimatorTest.java
@@ -263,4 +263,52 @@ class SwerveDrivePoseEstimatorTest {
       assertEquals(0.0, maxError, 0.2, "Incorrect max error");
     }
   }
+
+  @Test
+  void testSimultaneousVisionMeasurements() {
+    var kinematics =
+        new SwerveDriveKinematics(
+            new Translation2d(1, 1),
+            new Translation2d(1, -1),
+            new Translation2d(-1, -1),
+            new Translation2d(-1, 1));
+
+    var fl = new SwerveModulePosition();
+    var fr = new SwerveModulePosition();
+    var bl = new SwerveModulePosition();
+    var br = new SwerveModulePosition();
+
+    var estimator =
+        new SwerveDrivePoseEstimator(
+            kinematics,
+            new Rotation2d(),
+            new SwerveModulePosition[] {fl, fr, bl, br},
+            new Pose2d(1, 2, Rotation2d.fromDegrees(270)),
+            VecBuilder.fill(0.1, 0.1, 0.1),
+            VecBuilder.fill(0.9, 0.9, 0.9));
+
+    estimator.updateWithTime(0, new Rotation2d(), new SwerveModulePosition[] {fl, fr, bl, br});
+
+    var visionMeasurements = new Pose2d[]{
+        new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
+        new Pose2d(3, 1, Rotation2d.fromDegrees(90)),
+        new Pose2d(2, 4, Rotation2d.fromRadians(180)),
+    };
+
+    for (int i = 0; i < 1000; i++) {
+        for (var measurement : visionMeasurements) {
+            estimator.addVisionMeasurement(measurement, 0);
+        }
+    }
+
+    for (var measurement : visionMeasurements) {
+        var errorLog = "Estimator converged to one vision measurement: " + estimator.getEstimatedPosition().toString() + " -> " + measurement.toString();
+
+        var dx = Math.abs(measurement.getX() - estimator.getEstimatedPosition().getX());
+        var dy = Math.abs(measurement.getY() - estimator.getEstimatedPosition().getY());
+        var dtheta = Math.abs(measurement.getRotation().getDegrees() - estimator.getEstimatedPosition().getRotation().getDegrees());
+
+        assertEquals(dx > 0.08 || dy > 0.08 || dtheta > 0.08, true, errorLog);
+    }
+  }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimatorTest.java
@@ -289,26 +289,34 @@ class SwerveDrivePoseEstimatorTest {
 
     estimator.updateWithTime(0, new Rotation2d(), new SwerveModulePosition[] {fl, fr, bl, br});
 
-    var visionMeasurements = new Pose2d[]{
-        new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
-        new Pose2d(3, 1, Rotation2d.fromDegrees(90)),
-        new Pose2d(2, 4, Rotation2d.fromRadians(180)),
-    };
+    var visionMeasurements =
+        new Pose2d[] {
+          new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
+          new Pose2d(3, 1, Rotation2d.fromDegrees(90)),
+          new Pose2d(2, 4, Rotation2d.fromRadians(180)),
+        };
 
     for (int i = 0; i < 1000; i++) {
-        for (var measurement : visionMeasurements) {
-            estimator.addVisionMeasurement(measurement, 0);
-        }
+      for (var measurement : visionMeasurements) {
+        estimator.addVisionMeasurement(measurement, 0);
+      }
     }
 
     for (var measurement : visionMeasurements) {
-        var errorLog = "Estimator converged to one vision measurement: " + estimator.getEstimatedPosition().toString() + " -> " + measurement.toString();
+      var errorLog =
+          "Estimator converged to one vision measurement: "
+              + estimator.getEstimatedPosition().toString()
+              + " -> "
+              + measurement.toString();
 
-        var dx = Math.abs(measurement.getX() - estimator.getEstimatedPosition().getX());
-        var dy = Math.abs(measurement.getY() - estimator.getEstimatedPosition().getY());
-        var dtheta = Math.abs(measurement.getRotation().getDegrees() - estimator.getEstimatedPosition().getRotation().getDegrees());
+      var dx = Math.abs(measurement.getX() - estimator.getEstimatedPosition().getX());
+      var dy = Math.abs(measurement.getY() - estimator.getEstimatedPosition().getY());
+      var dtheta =
+          Math.abs(
+              measurement.getRotation().getDegrees()
+                  - estimator.getEstimatedPosition().getRotation().getDegrees());
 
-        assertEquals(dx > 0.08 || dy > 0.08 || dtheta > 0.08, true, errorLog);
+      assertEquals(dx > 0.08 || dy > 0.08 || dtheta > 0.08, true, errorLog);
     }
   }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimatorTest.java
@@ -266,6 +266,10 @@ class SwerveDrivePoseEstimatorTest {
 
   @Test
   void testSimultaneousVisionMeasurements() {
+    // This tests for multiple vision measurements appled at the same time. The expected behavior
+    // is that all measurements affect the estimated pose. The alternative result is that only one
+    // vision measurement affects the outcome. If that were the case, after 1000 measurements, the
+    // estimated pose would converge to that measurement.
     var kinematics =
         new SwerveDriveKinematics(
             new Translation2d(1, 1),

--- a/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
@@ -209,6 +209,11 @@ TEST(DifferentialDrivePoseEstimatorTest, BadInitialPose) {
 }
 
 TEST(DifferentialDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
+  // This tests for multiple vision measurements appled at the same time.
+  // The expected behavior is that all measurements affect the estimated pose.
+  // The alternative result is that only one vision measurement affects the
+  // outcome. If that were the case, after 1000 measurements, the estimated
+  // pose would converge to that measurement.
   frc::DifferentialDriveKinematics kinematics{1.0_m};
 
   frc::DifferentialDrivePoseEstimator estimator{

--- a/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
@@ -207,3 +207,43 @@ TEST(DifferentialDrivePoseEstimatorTest, BadInitialPose) {
     }
   }
 }
+
+TEST(DifferentialDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
+  frc::DifferentialDriveKinematics kinematics{1.0_m};
+
+  frc::DifferentialDrivePoseEstimator estimator{
+      kinematics,         frc::Rotation2d{}, 0_m, 0_m, frc::Pose2d{1_m, 2_m, frc::Rotation2d{270_deg}},
+      {0.02, 0.02, 0.01}, {0.1, 0.1, 0.1}};
+  
+  estimator.UpdateWithTime(0_s, frc::Rotation2d{}, 0_m, 0_m);
+
+  for (int i = 0; i < 1000; i++) {
+    estimator.AddVisionMeasurement(frc::Pose2d{0_m, 0_m, frc::Rotation2d{0_deg}}, 0_s);
+    estimator.AddVisionMeasurement(frc::Pose2d{3_m, 1_m, frc::Rotation2d{90_deg}}, 0_s);
+    estimator.AddVisionMeasurement(frc::Pose2d{2_m, 4_m, frc::Rotation2d{180_deg}}, 0_s);
+  }
+
+  {
+    auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 0_m);
+    auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 0_m);
+    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 0_deg);
+
+    EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
+  }
+
+  {
+    auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 3_m);
+    auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 1_m);
+    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 90_deg);
+
+    EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
+  }
+
+  {
+    auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 2_m);
+    auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 4_m);
+    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 180_deg);
+
+    EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
+  }
+}

--- a/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/DifferentialDrivePoseEstimatorTest.cpp
@@ -212,21 +212,30 @@ TEST(DifferentialDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
   frc::DifferentialDriveKinematics kinematics{1.0_m};
 
   frc::DifferentialDrivePoseEstimator estimator{
-      kinematics,         frc::Rotation2d{}, 0_m, 0_m, frc::Pose2d{1_m, 2_m, frc::Rotation2d{270_deg}},
-      {0.02, 0.02, 0.01}, {0.1, 0.1, 0.1}};
-  
+      kinematics,
+      frc::Rotation2d{},
+      0_m,
+      0_m,
+      frc::Pose2d{1_m, 2_m, frc::Rotation2d{270_deg}},
+      {0.02, 0.02, 0.01},
+      {0.1, 0.1, 0.1}};
+
   estimator.UpdateWithTime(0_s, frc::Rotation2d{}, 0_m, 0_m);
 
   for (int i = 0; i < 1000; i++) {
-    estimator.AddVisionMeasurement(frc::Pose2d{0_m, 0_m, frc::Rotation2d{0_deg}}, 0_s);
-    estimator.AddVisionMeasurement(frc::Pose2d{3_m, 1_m, frc::Rotation2d{90_deg}}, 0_s);
-    estimator.AddVisionMeasurement(frc::Pose2d{2_m, 4_m, frc::Rotation2d{180_deg}}, 0_s);
+    estimator.AddVisionMeasurement(
+        frc::Pose2d{0_m, 0_m, frc::Rotation2d{0_deg}}, 0_s);
+    estimator.AddVisionMeasurement(
+        frc::Pose2d{3_m, 1_m, frc::Rotation2d{90_deg}}, 0_s);
+    estimator.AddVisionMeasurement(
+        frc::Pose2d{2_m, 4_m, frc::Rotation2d{180_deg}}, 0_s);
   }
 
   {
     auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 0_m);
     auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 0_m);
-    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 0_deg);
+    auto dtheta = units::math::abs(
+        estimator.GetEstimatedPosition().Rotation().Radians() - 0_deg);
 
     EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
   }
@@ -234,7 +243,8 @@ TEST(DifferentialDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
   {
     auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 3_m);
     auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 1_m);
-    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 90_deg);
+    auto dtheta = units::math::abs(
+        estimator.GetEstimatedPosition().Rotation().Radians() - 90_deg);
 
     EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
   }
@@ -242,7 +252,8 @@ TEST(DifferentialDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
   {
     auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 2_m);
     auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 4_m);
-    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 180_deg);
+    auto dtheta = units::math::abs(
+        estimator.GetEstimatedPosition().Rotation().Radians() - 180_deg);
 
     EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
   }

--- a/wpimath/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
@@ -214,22 +214,27 @@ TEST(MecanumDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
 
   frc::MecanumDriveWheelPositions wheelPositions;
 
-  frc::MecanumDrivePoseEstimator estimator{kinematics,      frc::Rotation2d{},
-                                           wheelPositions,  frc::Pose2d{1_m, 2_m, frc::Rotation2d{270_deg}},
-                                           {0.1, 0.1, 0.1}, {0.45, 0.45, 0.1}};
-  
+  frc::MecanumDrivePoseEstimator estimator{
+      kinematics,      frc::Rotation2d{},
+      wheelPositions,  frc::Pose2d{1_m, 2_m, frc::Rotation2d{270_deg}},
+      {0.1, 0.1, 0.1}, {0.45, 0.45, 0.1}};
+
   estimator.UpdateWithTime(0_s, frc::Rotation2d{}, wheelPositions);
 
   for (int i = 0; i < 1000; i++) {
-    estimator.AddVisionMeasurement(frc::Pose2d{0_m, 0_m, frc::Rotation2d{0_deg}}, 0_s);
-    estimator.AddVisionMeasurement(frc::Pose2d{3_m, 1_m, frc::Rotation2d{90_deg}}, 0_s);
-    estimator.AddVisionMeasurement(frc::Pose2d{2_m, 4_m, frc::Rotation2d{180_deg}}, 0_s);
+    estimator.AddVisionMeasurement(
+        frc::Pose2d{0_m, 0_m, frc::Rotation2d{0_deg}}, 0_s);
+    estimator.AddVisionMeasurement(
+        frc::Pose2d{3_m, 1_m, frc::Rotation2d{90_deg}}, 0_s);
+    estimator.AddVisionMeasurement(
+        frc::Pose2d{2_m, 4_m, frc::Rotation2d{180_deg}}, 0_s);
   }
 
   {
     auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 0_m);
     auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 0_m);
-    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 0_deg);
+    auto dtheta = units::math::abs(
+        estimator.GetEstimatedPosition().Rotation().Radians() - 0_deg);
 
     EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
   }
@@ -237,7 +242,8 @@ TEST(MecanumDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
   {
     auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 3_m);
     auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 1_m);
-    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 90_deg);
+    auto dtheta = units::math::abs(
+        estimator.GetEstimatedPosition().Rotation().Radians() - 90_deg);
 
     EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
   }
@@ -245,7 +251,8 @@ TEST(MecanumDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
   {
     auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 2_m);
     auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 4_m);
-    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 180_deg);
+    auto dtheta = units::math::abs(
+        estimator.GetEstimatedPosition().Rotation().Radians() - 180_deg);
 
     EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
   }

--- a/wpimath/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
@@ -206,3 +206,47 @@ TEST(MecanumDrivePoseEstimatorTest, BadInitialPose) {
     }
   }
 }
+
+TEST(MecanumDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
+  frc::MecanumDriveKinematics kinematics{
+      frc::Translation2d{1_m, 1_m}, frc::Translation2d{1_m, -1_m},
+      frc::Translation2d{-1_m, -1_m}, frc::Translation2d{-1_m, 1_m}};
+
+  frc::MecanumDriveWheelPositions wheelPositions;
+
+  frc::MecanumDrivePoseEstimator estimator{kinematics,      frc::Rotation2d{},
+                                           wheelPositions,  frc::Pose2d{1_m, 2_m, frc::Rotation2d{270_deg}},
+                                           {0.1, 0.1, 0.1}, {0.45, 0.45, 0.1}};
+  
+  estimator.UpdateWithTime(0_s, frc::Rotation2d{}, wheelPositions);
+
+  for (int i = 0; i < 1000; i++) {
+    estimator.AddVisionMeasurement(frc::Pose2d{0_m, 0_m, frc::Rotation2d{0_deg}}, 0_s);
+    estimator.AddVisionMeasurement(frc::Pose2d{3_m, 1_m, frc::Rotation2d{90_deg}}, 0_s);
+    estimator.AddVisionMeasurement(frc::Pose2d{2_m, 4_m, frc::Rotation2d{180_deg}}, 0_s);
+  }
+
+  {
+    auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 0_m);
+    auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 0_m);
+    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 0_deg);
+
+    EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
+  }
+
+  {
+    auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 3_m);
+    auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 1_m);
+    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 90_deg);
+
+    EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
+  }
+
+  {
+    auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 2_m);
+    auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 4_m);
+    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 180_deg);
+
+    EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
+  }
+}

--- a/wpimath/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/MecanumDrivePoseEstimatorTest.cpp
@@ -208,6 +208,11 @@ TEST(MecanumDrivePoseEstimatorTest, BadInitialPose) {
 }
 
 TEST(MecanumDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
+  // This tests for multiple vision measurements appled at the same time.
+  // The expected behavior is that all measurements affect the estimated pose.
+  // The alternative result is that only one vision measurement affects the
+  // outcome. If that were the case, after 1000 measurements, the estimated
+  // pose would converge to that measurement.
   frc::MecanumDriveKinematics kinematics{
       frc::Translation2d{1_m, 1_m}, frc::Translation2d{1_m, -1_m},
       frc::Translation2d{-1_m, -1_m}, frc::Translation2d{-1_m, 1_m}};

--- a/wpimath/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
@@ -8,13 +8,13 @@
 #include <tuple>
 
 #include <fmt/format.h>
+#include <wpi/timestamp.h>
 
 #include "frc/estimator/SwerveDrivePoseEstimator.h"
 #include "frc/geometry/Pose2d.h"
 #include "frc/kinematics/SwerveDriveKinematics.h"
 #include "frc/trajectory/TrajectoryGenerator.h"
 #include "gtest/gtest.h"
-#include "wpi/timestamp.h"
 
 void testFollowTrajectory(
     const frc::SwerveDriveKinematics<4>& kinematics,
@@ -218,7 +218,6 @@ TEST(SwerveDrivePoseEstimatorTest, BadInitialPose) {
 }
 
 TEST(SwerveDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
-
   frc::SwerveDriveKinematics<4> kinematics{
       frc::Translation2d{1_m, 1_m}, frc::Translation2d{1_m, -1_m},
       frc::Translation2d{-1_m, -1_m}, frc::Translation2d{-1_m, 1_m}};
@@ -229,21 +228,26 @@ TEST(SwerveDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
   frc::SwerveModulePosition br;
 
   frc::SwerveDrivePoseEstimator<4> estimator{
-      kinematics,    frc::Rotation2d{}, {fl, fr, bl, br},
-      frc::Pose2d{1_m, 2_m, frc::Rotation2d{270_deg}}, {0.1, 0.1, 0.1},   {0.45, 0.45, 0.45}};
-  
+      kinematics,       frc::Rotation2d{},
+      {fl, fr, bl, br}, frc::Pose2d{1_m, 2_m, frc::Rotation2d{270_deg}},
+      {0.1, 0.1, 0.1},  {0.45, 0.45, 0.45}};
+
   estimator.UpdateWithTime(0_s, frc::Rotation2d{}, {fl, fr, bl, br});
 
   for (int i = 0; i < 1000; i++) {
-    estimator.AddVisionMeasurement(frc::Pose2d{0_m, 0_m, frc::Rotation2d{0_deg}}, 0_s);
-    estimator.AddVisionMeasurement(frc::Pose2d{3_m, 1_m, frc::Rotation2d{90_deg}}, 0_s);
-    estimator.AddVisionMeasurement(frc::Pose2d{2_m, 4_m, frc::Rotation2d{180_deg}}, 0_s);
+    estimator.AddVisionMeasurement(
+        frc::Pose2d{0_m, 0_m, frc::Rotation2d{0_deg}}, 0_s);
+    estimator.AddVisionMeasurement(
+        frc::Pose2d{3_m, 1_m, frc::Rotation2d{90_deg}}, 0_s);
+    estimator.AddVisionMeasurement(
+        frc::Pose2d{2_m, 4_m, frc::Rotation2d{180_deg}}, 0_s);
   }
 
   {
     auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 0_m);
     auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 0_m);
-    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 0_deg);
+    auto dtheta = units::math::abs(
+        estimator.GetEstimatedPosition().Rotation().Radians() - 0_deg);
 
     EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
   }
@@ -251,7 +255,8 @@ TEST(SwerveDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
   {
     auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 3_m);
     auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 1_m);
-    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 90_deg);
+    auto dtheta = units::math::abs(
+        estimator.GetEstimatedPosition().Rotation().Radians() - 90_deg);
 
     EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
   }
@@ -259,7 +264,8 @@ TEST(SwerveDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
   {
     auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 2_m);
     auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 4_m);
-    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 180_deg);
+    auto dtheta = units::math::abs(
+        estimator.GetEstimatedPosition().Rotation().Radians() - 180_deg);
 
     EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
   }

--- a/wpimath/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
@@ -234,8 +234,6 @@ TEST(SwerveDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
   
   estimator.UpdateWithTime(0_s, frc::Rotation2d{}, {fl, fr, bl, br});
 
-  auto time = wpi::Now();
-
   for (int i = 0; i < 1000; i++) {
     estimator.AddVisionMeasurement(frc::Pose2d{0_m, 0_m, frc::Rotation2d{0_deg}}, 0_s);
     estimator.AddVisionMeasurement(frc::Pose2d{3_m, 1_m, frc::Rotation2d{90_deg}}, 0_s);

--- a/wpimath/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
@@ -218,6 +218,11 @@ TEST(SwerveDrivePoseEstimatorTest, BadInitialPose) {
 }
 
 TEST(SwerveDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
+  // This tests for multiple vision measurements appled at the same time.
+  // The expected behavior is that all measurements affect the estimated pose.
+  // The alternative result is that only one vision measurement affects the
+  // outcome. If that were the case, after 1000 measurements, the estimated
+  // pose would converge to that measurement.
   frc::SwerveDriveKinematics<4> kinematics{
       frc::Translation2d{1_m, 1_m}, frc::Translation2d{1_m, -1_m},
       frc::Translation2d{-1_m, -1_m}, frc::Translation2d{-1_m, 1_m}};

--- a/wpimath/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/SwerveDrivePoseEstimatorTest.cpp
@@ -14,6 +14,7 @@
 #include "frc/kinematics/SwerveDriveKinematics.h"
 #include "frc/trajectory/TrajectoryGenerator.h"
 #include "gtest/gtest.h"
+#include "wpi/timestamp.h"
 
 void testFollowTrajectory(
     const frc::SwerveDriveKinematics<4>& kinematics,
@@ -213,5 +214,55 @@ TEST(SwerveDrivePoseEstimatorTest, BadInitialPose) {
           initial_pose, {0_m, 0_m, frc::Rotation2d{45_deg}}, 0.02_s, 0.1_s,
           0.25_s, false, false);
     }
+  }
+}
+
+TEST(SwerveDrivePoseEstimatorTest, SimultaneousVisionMeasurements) {
+
+  frc::SwerveDriveKinematics<4> kinematics{
+      frc::Translation2d{1_m, 1_m}, frc::Translation2d{1_m, -1_m},
+      frc::Translation2d{-1_m, -1_m}, frc::Translation2d{-1_m, 1_m}};
+
+  frc::SwerveModulePosition fl;
+  frc::SwerveModulePosition fr;
+  frc::SwerveModulePosition bl;
+  frc::SwerveModulePosition br;
+
+  frc::SwerveDrivePoseEstimator<4> estimator{
+      kinematics,    frc::Rotation2d{}, {fl, fr, bl, br},
+      frc::Pose2d{1_m, 2_m, frc::Rotation2d{270_deg}}, {0.1, 0.1, 0.1},   {0.45, 0.45, 0.45}};
+  
+  estimator.UpdateWithTime(0_s, frc::Rotation2d{}, {fl, fr, bl, br});
+
+  auto time = wpi::Now();
+
+  for (int i = 0; i < 1000; i++) {
+    estimator.AddVisionMeasurement(frc::Pose2d{0_m, 0_m, frc::Rotation2d{0_deg}}, 0_s);
+    estimator.AddVisionMeasurement(frc::Pose2d{3_m, 1_m, frc::Rotation2d{90_deg}}, 0_s);
+    estimator.AddVisionMeasurement(frc::Pose2d{2_m, 4_m, frc::Rotation2d{180_deg}}, 0_s);
+  }
+
+  {
+    auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 0_m);
+    auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 0_m);
+    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 0_deg);
+
+    EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
+  }
+
+  {
+    auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 3_m);
+    auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 1_m);
+    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 90_deg);
+
+    EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
+  }
+
+  {
+    auto dx = units::math::abs(estimator.GetEstimatedPosition().X() - 2_m);
+    auto dy = units::math::abs(estimator.GetEstimatedPosition().Y() - 4_m);
+    auto dtheta = units::math::abs(estimator.GetEstimatedPosition().Rotation().Radians() - 180_deg);
+
+    EXPECT_TRUE(dx > 0.08_m || dy > 0.08_m || dtheta > 0.08_rad);
   }
 }


### PR DESCRIPTION
Without this PR, the pose estimate converges to the last vision measurement applied from the same timestamp. With it, it properly converges to a pose between the 3 of them.

Prior converged pose:
```
Observation: Pose2d(Translation2d(X: 9.12, Y: 1.19), Rotation2d(Rads: 0.30, Deg: 17.13))
Observation: Pose2d(Translation2d(X: 9.21, Y: 0.95), Rotation2d(Rads: 0.33, Deg: 19.12))
Observation: Pose2d(Translation2d(X: 8.89, Y: 1.31), Rotation2d(Rads: 0.25, Deg: 14.57))
Pose estimator: Pose2d(Translation2d(X: 8.89, Y: 1.31), Rotation2d(Rads: 0.25, Deg: 14.42))
```

After this PR:
```
Observation: Pose2d(Translation2d(X: 9.18, Y: 1.49), Rotation2d(Rads: 0.25, Deg: 14.42))
Observation: Pose2d(Translation2d(X: 9.13, Y: 1.46), Rotation2d(Rads: 0.25, Deg: 14.53))
Observation: Pose2d(Translation2d(X: 9.09, Y: 1.31), Rotation2d(Rads: 0.27, Deg: 15.35))
Observation: Pose2d(Translation2d(X: 9.48, Y: 12.63), Rotation2d(Rads: -1.10, Deg: -63.24))
Averaged: Pose2d(Translation2d(X: 7.42, Y: 4.90), Rotation2d(Rads: -0.13, Deg: -7.58))
```

