### PR TITLE
Fix spacing in command composition exception

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -602,7 +602,7 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
   public void requireNotComposed(Command command) {
     if (m_composedCommands.contains(command)) {
       throw new IllegalArgumentException(
-          "Commands that have been composed may not be added to another composition or scheduled"
+          "Commands that have been composed may not be added to another composition or scheduled "
               + "individually!");
     }
   }
@@ -616,7 +616,7 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
   public void requireNotComposed(Collection<Command> commands) {
     if (!Collections.disjoint(commands, getComposedCommands())) {
       throw new IllegalArgumentException(
-          "Commands that have been composed may not be added to another composition or scheduled"
+          "Commands that have been composed may not be added to another composition or scheduled "
               + "individually!");
     }
   }


### PR DESCRIPTION
The current error looks like this:

`Unhandled exception: java.lang.IllegalArgumentException: Commands that have been composed may not be added to another composition or scheduledindividually!`