### PR TITLE
Make EventLoop cloneable

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/event/EventLoop.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/event/EventLoop.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 
 /** The loop polling {@link BooleanEvent} objects and executing the actions bound to them. */
-public final class EventLoop {
+public final class EventLoop implements Cloneable {
   private final Collection<Runnable> m_bindings = new LinkedHashSet<>();
 
   /**
@@ -28,5 +28,10 @@ public final class EventLoop {
   /** Clear all bindings. */
   public void clear() {
     m_bindings.clear();
+  }
+
+  @Override
+  protected Object clone() throws CloneNotSupportedException {
+    return super.clone();
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/event/EventLoop.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/event/EventLoop.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 
 /** The loop polling {@link BooleanEvent} objects and executing the actions bound to them. */
-public final class EventLoop implements Cloneable {
+public final class EventLoop {
   private final Collection<Runnable> m_bindings = new LinkedHashSet<>();
 
   /**
@@ -30,8 +30,11 @@ public final class EventLoop implements Cloneable {
     m_bindings.clear();
   }
 
-  @Override
-  protected Object clone() throws CloneNotSupportedException {
-    return super.clone();
+  public EventLoop copy() {
+    EventLoop newLoop = new EventLoop();
+    for (Runnable binding : m_bindings) {
+      newLoop.bind(binding);
+    }
+    return newLoop;
   }
 }


### PR DESCRIPTION
Implements the Cloneable interface on EventLoop, allowing it to be cloned.  This is useful when you want to bind more methods to a EventLoop, but don't want to modify the original EventLoop.

I do not know C++ well enough to know if it also should have this change or how, so just let me know.