### PR TITLE
[ntcore] Queue current value on subscriber creation

### DIFF
--- a/ntcore/src/test/native/cpp/LocalStorageTest.cpp
+++ b/ntcore/src/test/native/cpp/LocalStorageTest.cpp
@@ -197,9 +197,6 @@ TEST_F(LocalStorageTest, SubscribeNoTypeLocalPubPre) {
   ASSERT_TRUE(value.IsBoolean());
   EXPECT_EQ(value.GetBoolean(), true);
   EXPECT_EQ(value.time(), 5);
-
-  auto vals = storage.ReadQueueValue(sub);  // read queue won't get anything
-  ASSERT_TRUE(vals.empty());
 }
 
 TEST_F(LocalStorageTest, EntryNoTypeLocalSet) {


### PR DESCRIPTION
This fixes a potential race condition in code that only uses readQueue.