### PR TITLE
[wpimath] Fix SwerveDriveKinematics not initializing a new array each time

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
@@ -97,10 +97,12 @@ public class SwerveDriveKinematics {
     if (chassisSpeeds.vxMetersPerSecond == 0.0
         && chassisSpeeds.vyMetersPerSecond == 0.0
         && chassisSpeeds.omegaRadiansPerSecond == 0.0) {
+      SwerveModuleState[] newStates = new SwerveModuleState[m_numModules];
       for (int i = 0; i < m_numModules; i++) {
-        m_moduleStates[i].speedMetersPerSecond = 0.0;
+        newStates[i] = new SwerveModuleState(0.0, m_moduleStates[i].angle);
       }
 
+      m_moduleStates = newStates;
       return m_moduleStates;
     }
 

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
@@ -39,7 +39,7 @@ public class SwerveDriveKinematics {
 
   private final int m_numModules;
   private final Translation2d[] m_modules;
-  private final SwerveModuleState[] m_moduleStates;
+  private SwerveModuleState[] m_moduleStates;
   private Translation2d m_prevCoR = new Translation2d();
 
   /**
@@ -132,6 +132,7 @@ public class SwerveDriveKinematics {
 
     var moduleStatesMatrix = m_inverseKinematics.mult(chassisSpeedsVector);
 
+    m_moduleStates = new SwerveModuleState[m_numModules];
     for (int i = 0; i < m_numModules; i++) {
       double x = moduleStatesMatrix.get(i * 2, 0);
       double y = moduleStatesMatrix.get(i * 2 + 1, 0);


### PR DESCRIPTION
This is problematic if you call it twice before utilizing the result.

Example:
```java
ChassisSpeeds speeds1 = new ChassisSpeeds(1, 1, 1);
SwerveModuleState[] states1 = KINEMATICS.toSwerveModuleStates(speeds1);

ChassisSpeeds speeds2 = new ChassisSpeeds(32.001, -2.001, 253.001);

SwerveModuleState[] states2 = KINEMATICS.toSwerveModuleStates(speeds2);
System.out.println(Arrays.toString(states1));
System.out.println(Arrays.toString(states2));
```
Outputs:
```
[SwerveModuleState(Speed: 231.40 m/s, Angle: Rotation2d(Rads: 2.26, Deg: 129.74)), SwerveModuleState(Speed: 276.73 m/s, Angle: Rotation2d(Rads: 0.70, Deg: 40.02)), SwerveModuleState(Speed: 234.49 m/s, Angle: Rotation2d(Rads: -2.25, Deg: -129.11)), SwerveModuleState(Speed: 279.32 m/s, Angle: Rotation2d(Rads: -0.71, Deg: -40.64))]
[SwerveModuleState(Speed: 231.40 m/s, Angle: Rotation2d(Rads: 2.26, Deg: 129.74)), SwerveModuleState(Speed: 276.73 m/s, Angle: Rotation2d(Rads: 0.70, Deg: 40.02)), SwerveModuleState(Speed: 234.49 m/s, Angle: Rotation2d(Rads: -2.25, Deg: -129.11)), SwerveModuleState(Speed: 279.32 m/s, Angle: Rotation2d(Rads: -0.71, Deg: -40.64))]
```