### PR TITLE
[wpimath] HolonomicDriveController: Add getters for the controllers

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/controller/HolonomicDriveController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/HolonomicDriveController.java
@@ -133,4 +133,25 @@ public class HolonomicDriveController {
   public void setEnabled(boolean enabled) {
     m_enabled = enabled;
   }
+
+  /**
+   * Returns the rotation ProfiledPIDController
+   */
+  public ProfiledPIDController getThetaController(){
+    return m_thetaController;
+  }
+
+  /**
+   * Returns the X PIDController
+   */
+  public PIDController getXController(){
+    return m_xController;
+  }
+
+  /**
+   * Returns the Y PIDController
+   */
+  public PIDController getYController(){
+    return m_yController;
+  }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/HolonomicDriveController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/HolonomicDriveController.java
@@ -144,7 +144,7 @@ public class HolonomicDriveController {
   }
 
   /**
-   * Returns the y controller.
+   * Returns the x controller.
    *
    * @return X PIDController
    */

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/HolonomicDriveController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/HolonomicDriveController.java
@@ -135,23 +135,29 @@ public class HolonomicDriveController {
   }
 
   /**
-   * Returns the rotation ProfiledPIDController
+   * Returns the heading controller.
+   *
+   * @return heading ProfiledPIDController
    */
-  public ProfiledPIDController getThetaController(){
+  public ProfiledPIDController getThetaController() {
     return m_thetaController;
   }
 
   /**
-   * Returns the X PIDController
+   * Returns the y controller.
+   *
+   * @return X PIDController
    */
-  public PIDController getXController(){
+  public PIDController getXController() {
     return m_xController;
   }
 
   /**
-   * Returns the Y PIDController
+   * Returns the y controller.
+   *
+   * @return Y PIDController
    */
-  public PIDController getYController(){
+  public PIDController getYController() {
     return m_yController;
   }
 }

--- a/wpimath/src/main/native/cpp/controller/HolonomicDriveController.cpp
+++ b/wpimath/src/main/native/cpp/controller/HolonomicDriveController.cpp
@@ -77,14 +77,14 @@ void HolonomicDriveController::SetEnabled(bool enabled) {
   m_enabled = enabled;
 }
 
-ProfiledPIDController& HolonomicDriveController::getThetaController(){
+ProfiledPIDController<units::radian>& HolonomicDriveController::getThetaController() {
   return m_thetaController;
 }
 
-PIDController& HolonomicDriveController::getXController(){
+PIDController& HolonomicDriveController::getXController() {
   return m_xController;
 }
 
-PIDController& HolonomicDriveController::getYController(){
+PIDController& HolonomicDriveController::getYController() {
   return m_yController;
 }

--- a/wpimath/src/main/native/cpp/controller/HolonomicDriveController.cpp
+++ b/wpimath/src/main/native/cpp/controller/HolonomicDriveController.cpp
@@ -77,7 +77,8 @@ void HolonomicDriveController::SetEnabled(bool enabled) {
   m_enabled = enabled;
 }
 
-ProfiledPIDController<units::radian>& HolonomicDriveController::getThetaController() {
+ProfiledPIDController<units::radian>&
+HolonomicDriveController::getThetaController() {
   return m_thetaController;
 }
 

--- a/wpimath/src/main/native/cpp/controller/HolonomicDriveController.cpp
+++ b/wpimath/src/main/native/cpp/controller/HolonomicDriveController.cpp
@@ -76,3 +76,15 @@ ChassisSpeeds HolonomicDriveController::Calculate(
 void HolonomicDriveController::SetEnabled(bool enabled) {
   m_enabled = enabled;
 }
+
+ProfiledPIDController& HolonomicDriveController::getThetaController(){
+  return m_thetaController;
+}
+
+PIDController& HolonomicDriveController::getXController(){
+  return m_xController;
+}
+
+PIDController& HolonomicDriveController::getYController(){
+  return m_yController;
+}

--- a/wpimath/src/main/native/include/frc/controller/HolonomicDriveController.h
+++ b/wpimath/src/main/native/include/frc/controller/HolonomicDriveController.h
@@ -97,6 +97,21 @@ class WPILIB_DLLEXPORT HolonomicDriveController {
    */
   void SetEnabled(bool enabled);
 
+  /**
+   * Returns the rotation ProfiledPIDController
+   */
+  ProfiledPIDController<units::radian>& getThetaController();
+
+  /**
+   * Returns the X PIDController
+   */
+  frc2::PIDController& xController();
+
+  /**
+   * Returns the Y PIDController
+   */
+  frc2::PIDController& yController();
+
  private:
   Pose2d m_poseError;
   Rotation2d m_rotationError;

--- a/wpimath/src/main/native/include/frc/controller/HolonomicDriveController.h
+++ b/wpimath/src/main/native/include/frc/controller/HolonomicDriveController.h
@@ -105,12 +105,12 @@ class WPILIB_DLLEXPORT HolonomicDriveController {
   /**
    * Returns the X PIDController
    */
-  frc2::PIDController& xController();
+  PIDController& getXController();
 
   /**
    * Returns the Y PIDController
    */
-  frc2::PIDController& yController();
+  PIDController& getYController();
 
  private:
   Pose2d m_poseError;


### PR DESCRIPTION
Since the PIDControllers are private and, in c++, are passed by value to the constructor there is no way to access the controllers, for example to call reset on the rotation controller. This change allows you to get a reference to the controllers which also allows you to change the pid gains or constraints without creating new objects.
I also made the change in java to keep it consistent even though I don't think you would have the same issue in java.