### PR TITLE
[apriltag] AprilTagFieldLayout: Improve API shape for loading builtin JSONs

### DIFF
--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFieldLayout.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFieldLayout.java
@@ -191,8 +191,8 @@ public class AprilTagFieldLayout {
   /**
    * Deserializes a field layout from a resource within a internal jar file.
    *
-   * <p>Users should use {@link #AprilTagFieldLayout(String)} and use the deploy directory for
-   * custom layouts.
+   * <p>Users should use {@link AprilTagFields#loadAprilTagLayoutField()} to load official layouts
+   * and {@link #AprilTagFieldLayout(String)} for custom layouts.
    *
    * @param resourcePath The absolute path of the resource
    * @return The deserialized layout

--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFieldLayout.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFieldLayout.java
@@ -189,7 +189,10 @@ public class AprilTagFieldLayout {
   }
 
   /**
-   * Deserializes a field layout from a resource within a jar file.
+   * Deserializes a field layout from a resource within a internal jar file.
+   *
+   * <p>Users should use {@link #AprilTagFieldLayout(String)} and use the deploy directory for
+   * custom layouts.
    *
    * @param resourcePath The absolute path of the resource
    * @return The deserialized layout

--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFields.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFields.java
@@ -4,6 +4,8 @@
 
 package edu.wpi.first.apriltag;
 
+import java.io.IOException;
+
 public enum AprilTagFields {
   k2022RapidReact("2022-rapidreact.json"),
   k2023ChargedUp("2023-chargedup.json");
@@ -17,5 +19,15 @@ public enum AprilTagFields {
 
   AprilTagFields(String resourceFile) {
     m_resourceFile = kBaseResourceDir + resourceFile;
+  }
+
+  /**
+   * Get a {@link AprilTagFieldLayout} from the resource JSON.
+   *
+   * @return AprilTagFieldLayout of the field
+   * @throws IOException If the layout does not exist
+   */
+  public AprilTagFieldLayout getFieldLayout() throws IOException {
+    return AprilTagFieldLayout.loadFromResource(m_resourceFile);
   }
 }

--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFields.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTagFields.java
@@ -27,7 +27,7 @@ public enum AprilTagFields {
    * @return AprilTagFieldLayout of the field
    * @throws IOException If the layout does not exist
    */
-  public AprilTagFieldLayout getFieldLayout() throws IOException {
+  public AprilTagFieldLayout loadAprilTagLayoutField() throws IOException {
     return AprilTagFieldLayout.loadFromResource(m_resourceFile);
   }
 }

--- a/apriltag/src/test/java/edu/wpi/first/apriltag/LoadConfigTest.java
+++ b/apriltag/src/test/java/edu/wpi/first/apriltag/LoadConfigTest.java
@@ -23,13 +23,13 @@ class LoadConfigTest {
   @ParameterizedTest
   @EnumSource(AprilTagFields.class)
   void testLoad(AprilTagFields field) {
-    AprilTagFieldLayout layout = Assertions.assertDoesNotThrow(field::getFieldLayout);
+    AprilTagFieldLayout layout = Assertions.assertDoesNotThrow(field::loadAprilTagLayoutField);
     assertNotNull(layout);
   }
 
   @Test
   void test2022RapidReact() throws IOException {
-    AprilTagFieldLayout layout = AprilTagFields.k2022RapidReact.getFieldLayout();
+    AprilTagFieldLayout layout = AprilTagFields.k2022RapidReact.loadAprilTagLayoutField();
 
     // Blue Hangar Truss - Hub
     Pose3d expectedPose =

--- a/apriltag/src/test/java/edu/wpi/first/apriltag/LoadConfigTest.java
+++ b/apriltag/src/test/java/edu/wpi/first/apriltag/LoadConfigTest.java
@@ -23,16 +23,13 @@ class LoadConfigTest {
   @ParameterizedTest
   @EnumSource(AprilTagFields.class)
   void testLoad(AprilTagFields field) {
-    AprilTagFieldLayout layout =
-        Assertions.assertDoesNotThrow(
-            () -> AprilTagFieldLayout.loadFromResource(field.m_resourceFile));
+    AprilTagFieldLayout layout = Assertions.assertDoesNotThrow(field::getFieldLayout);
     assertNotNull(layout);
   }
 
   @Test
   void test2022RapidReact() throws IOException {
-    AprilTagFieldLayout layout =
-        AprilTagFieldLayout.loadFromResource(AprilTagFields.k2022RapidReact.m_resourceFile);
+    AprilTagFieldLayout layout = AprilTagFields.k2022RapidReact.getFieldLayout();
 
     // Blue Hangar Truss - Hub
     Pose3d expectedPose =


### PR DESCRIPTION
C++ had a method dedicated to loading a inbuilt field from the enum, Java however was missing this.  The unclear documentation on the AprilTagFieldLayout loadFromResource method led to users (read: me and my team) attempting to use it with non-internal fields.  This would NPE in a non-expected way.

This PR:
- Adds a specific method within AprilTagFields to get a AprilTagFieldLayout for the user
- Adds some documentation to ensure that users don't mistake loadFromResource for the constructor they want.