### PR TITLE
[wpimath] Simplify Pose Estimator Corrections

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
@@ -212,20 +212,21 @@ public class DifferentialDrivePoseEstimator {
    *     or sync the epochs.
    */
   public void addVisionMeasurement(Pose2d visionRobotPoseMeters, double timestampSeconds) {
-    // Step 1: Get the pose odometry measured at the moment the vision measurement was made.
+    // Step 1: Get the odometry pose measured at the moment the vision measurement was made.
     var sample = m_poseBuffer.getSample(timestampSeconds);
 
     if (sample.isEmpty()) {
       return;
     }
 
-    // Step 2: Apply the odometry delta in the time since the vision timestamp to estimate the
-    // "current" vision pose
+    // Step 2: Get the odometry delta in the time since the vision measurement,
     var delta = new Transform2d(sample.get().poseMeters, m_odometry.getPoseMeters());
-    visionRobotPoseMeters = visionRobotPoseMeters.transformBy(delta);
+    // and apply its inverse to the current pose estimate to get the estimate at the time
+    // of the vision measurement
+    var old_estimate = m_poseEstimate.transformBy(delta.inverse());
 
-    // Step 3: Measure the twist between the estimated pose and the "current" vision pose
-    var twist = m_poseEstimate.log(visionRobotPoseMeters);
+    // Step 3: Measure the twist between the "old" estimated pose and the vision pose
+    var twist = old_estimate.log(visionRobotPoseMeters);
 
     // Step 4: We should not trust the twist entirely, so instead we scale this twist by a Kalman
     // gain matrix representing how much we trust vision measurements compared to our current pose.
@@ -243,8 +244,11 @@ public class DifferentialDrivePoseEstimator {
     double[] scaledTwistVals = weighted_k_times_twist.getData();
     var scaledTwist = new Twist2d(scaledTwistVals[0], scaledTwistVals[1], scaledTwistVals[2]);
 
-    // Step 6: Apply scaled twist to the last estimated pose
-    m_poseEstimate = m_poseEstimate.exp(scaledTwist);
+    // Step 6: Apply scaled twist to the "old" estimated pose
+    old_estimate = old_estimate.exp(scaledTwist);
+
+    // Step 7: Re-apply odometry delta to get the "current" estimated pose
+    m_poseEstimate = old_estimate.transformBy(delta);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
@@ -170,6 +170,27 @@ public class DifferentialDrivePoseEstimator {
   public Pose2d getEstimatedPosition() {
     return m_poseEstimate;
   }
+  /**
+   * Gets the estimated robot pose at timestampSeconds.
+   *
+   * @param timestampSeconds The timestamp of the vision measurement in seconds. Note that if you
+   *     don't use your own time source by calling {@link
+   *     DifferentialDrivePoseEstimator#updateWithTime(double,Rotation2d,double,double)} then you
+   *     must use a timestamp with an epoch since FPGA startup (i.e., the epoch of this timestamp is
+   *     the same epoch as {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()}.) This means that
+   *     you should use {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()} as your time source
+   *     or sync the epochs.
+   * @return The estimated robot pose in meters.
+   */
+  public Pose2d getEstimatedPosition(double timestampSeconds) {
+    if(m_poseBuffer.getInternalBuffer().isEmpty()) return m_poseEstimate;
+    // current to old odometry delta
+    var delta = new Transform2d(
+      m_odometry.getPoseMeters(),
+      m_poseBuffer.getSample(timestampSeconds).get().poseMeters
+    );
+    return m_poseEstimate.transformBy(delta);
+  }
 
   /**
    * Adds a vision measurement to the Kalman Filter. This will correct the odometry pose estimate

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
@@ -183,12 +183,11 @@ public class DifferentialDrivePoseEstimator {
    * @return The estimated robot pose in meters.
    */
   public Pose2d getEstimatedPosition(double timestampSeconds) {
-    if(m_poseBuffer.getInternalBuffer().isEmpty()) return m_poseEstimate;
+    if (m_poseBuffer.getInternalBuffer().isEmpty()) return m_poseEstimate;
     // current to old odometry delta
-    var delta = new Transform2d(
-      m_odometry.getPoseMeters(),
-      m_poseBuffer.getSample(timestampSeconds).get().poseMeters
-    );
+    var delta =
+        new Transform2d(
+            m_odometry.getPoseMeters(), m_poseBuffer.getSample(timestampSeconds).get().poseMeters);
     return m_poseEstimate.transformBy(delta);
   }
 
@@ -224,10 +223,10 @@ public class DifferentialDrivePoseEstimator {
     // "current" vision pose
     var delta = new Transform2d(sample.get().poseMeters, m_odometry.getPoseMeters());
     visionRobotPoseMeters = visionRobotPoseMeters.transformBy(delta);
-    
+
     // Step 3: Measure the twist between the estimated pose and the "current" vision pose
     var twist = m_poseEstimate.log(visionRobotPoseMeters);
-    
+
     // Step 4: We should not trust the twist entirely, so instead we scale this twist by a Kalman
     // gain matrix representing how much we trust vision measurements compared to our current pose.
     var k_times_twist = m_visionK.times(VecBuilder.fill(twist.dx, twist.dy, twist.dtheta));
@@ -235,15 +234,15 @@ public class DifferentialDrivePoseEstimator {
     // Step 5: The Kalman gains scale the vision twists independent of other vision measurements,
     // so applying multiple vision measurements before the next update will have different results
     // depending on the order they are applied in. We can sum the Kalman gains applied before the
-    // next update and use that to effectively average the twist for multiple vision measurements. 
-    var weighted_k_times_twist = k_times_twist.elementTimes(
-            m_visionKSum.diag().extractColumnVector(0).elementPower(-1));
+    // next update and use that to effectively average the twist for multiple vision measurements.
+    var weighted_k_times_twist =
+        k_times_twist.elementTimes(m_visionKSum.diag().extractColumnVector(0).elementPower(-1));
     m_visionKSum = m_visionKSum.plus(m_visionK);
 
     // Step 5: Convert back to Twist2d.
     double[] scaledTwistVals = weighted_k_times_twist.getData();
     var scaledTwist = new Twist2d(scaledTwistVals[0], scaledTwistVals[1], scaledTwistVals[2]);
-    
+
     // Step 6: Apply scaled twist to the last estimated pose
     m_poseEstimate = m_poseEstimate.exp(scaledTwist);
   }
@@ -318,8 +317,7 @@ public class DifferentialDrivePoseEstimator {
     var currOdom = m_odometry.update(gyroAngle, distanceLeftMeters, distanceRightMeters);
     m_poseBuffer.addSample(
         currentTimeSeconds,
-        new InterpolationRecord(
-            currOdom, distanceLeftMeters, distanceRightMeters));
+        new InterpolationRecord(currOdom, distanceLeftMeters, distanceRightMeters));
 
     // apply odometry update to pose estimate
     m_poseEstimate = m_poseEstimate.transformBy(new Transform2d(lastOdom, currOdom));
@@ -351,8 +349,7 @@ public class DifferentialDrivePoseEstimator {
      * @param leftMeters The distance traveled by the left encoder.
      * @param rightMeters The distanced traveled by the right encoder.
      */
-    private InterpolationRecord(
-        Pose2d poseMeters, double leftMeters, double rightMeters) {
+    private InterpolationRecord(Pose2d poseMeters, double leftMeters, double rightMeters) {
       this.poseMeters = poseMeters;
       this.leftMeters = leftMeters;
       this.rightMeters = rightMeters;

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
@@ -20,7 +20,6 @@ import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.util.WPIUtilJNI;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * This class wraps {@link DifferentialDriveOdometry Differential Drive Odometry} to fuse
@@ -40,7 +39,6 @@ public class DifferentialDrivePoseEstimator {
   private final DifferentialDriveOdometry m_odometry;
   private final Matrix<N3, N1> m_q = new Matrix<>(Nat.N3(), Nat.N1());
   private Matrix<N3, N3> m_visionK = new Matrix<>(Nat.N3(), Nat.N3());
-  private Matrix<N3, N3> m_visionKSum = Matrix.eye(Nat.N3());
   private Pose2d m_poseEstimate;
 
   private final TimeInterpolatableBuffer<InterpolationRecord> m_poseBuffer =
@@ -160,7 +158,6 @@ public class DifferentialDrivePoseEstimator {
     m_odometry.resetPosition(gyroAngle, leftPositionMeters, rightPositionMeters, poseMeters);
     m_poseEstimate = poseMeters;
     m_poseBuffer.clear();
-    m_visionKSum = Matrix.eye(Nat.N3());
   }
 
   /**
@@ -170,35 +167,6 @@ public class DifferentialDrivePoseEstimator {
    */
   public Pose2d getEstimatedPosition() {
     return m_poseEstimate;
-  }
-
-  /**
-   * Gets the estimated robot pose at timestampSeconds. If the buffer is empty, or the requested
-   * timestamp is outside the buffer history, an empty Optional is returned. The buffer history size
-   * used is 1.5 seconds.
-   *
-   * @param timestampSeconds The timestamp of the vision measurement in seconds. Note that if you
-   *     don't use your own time source by calling {@link
-   *     DifferentialDrivePoseEstimator#updateWithTime(double,Rotation2d,double,double)} then you
-   *     must use a timestamp with an epoch since FPGA startup (i.e., the epoch of this timestamp is
-   *     the same epoch as {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()}.) This means that
-   *     you should use {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()} as your time source
-   *     or sync the epochs.
-   * @return The estimated robot pose in meters at that timestamp or an empty Optional.
-   */
-  public Optional<Pose2d> getEstimatedPosition(double timestampSeconds) {
-    var bufferMap = m_poseBuffer.getInternalBuffer();
-    if (bufferMap.isEmpty()
-        || timestampSeconds < bufferMap.firstKey()
-        || timestampSeconds > bufferMap.lastKey()) {
-      return Optional.empty();
-    }
-    // Find the odometry delta between now and the given timestamp,
-    var delta =
-        new Transform2d(
-            m_odometry.getPoseMeters(), m_poseBuffer.getSample(timestampSeconds).get().poseMeters);
-    // and apply it to the current pose estimate.
-    return Optional.of(m_poseEstimate.transformBy(delta));
   }
 
   /**
@@ -247,16 +215,8 @@ public class DifferentialDrivePoseEstimator {
     // gain matrix representing how much we trust vision measurements compared to our current pose.
     var k_times_twist = m_visionK.times(VecBuilder.fill(twist.dx, twist.dy, twist.dtheta));
 
-    // Step 5: The Kalman gains scale the vision twists independent of other vision measurements,
-    // so applying multiple vision measurements before the next update will have different results
-    // depending on the order they are applied in. We can sum the Kalman gains applied before the
-    // next update and use that to effectively average the twist for multiple vision measurements.
-    var weighted_k_times_twist =
-        k_times_twist.elementTimes(m_visionKSum.diag().extractColumnVector(0).elementPower(-1));
-    m_visionKSum = m_visionKSum.plus(m_visionK);
-
     // Step 5: Convert back to Twist2d.
-    double[] scaledTwistVals = weighted_k_times_twist.getData();
+    double[] scaledTwistVals = k_times_twist.getData();
     var scaledTwist = new Twist2d(scaledTwistVals[0], scaledTwistVals[1], scaledTwistVals[2]);
 
     // Step 6: Apply scaled twist to the "old" estimated pose.
@@ -340,9 +300,6 @@ public class DifferentialDrivePoseEstimator {
 
     // Apply this odometry update to the current pose estimate as well.
     m_poseEstimate = m_poseEstimate.transformBy(new Transform2d(lastOdom, currOdom));
-
-    // Reset the Kalman gain sum matrix.
-    m_visionKSum = Matrix.eye(Nat.N3());
 
     return getEstimatedPosition();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
@@ -20,6 +20,7 @@ import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.util.WPIUtilJNI;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * This class wraps {@link DifferentialDriveOdometry Differential Drive Odometry} to fuse
@@ -163,7 +164,7 @@ public class DifferentialDrivePoseEstimator {
   }
 
   /**
-   * Gets the estimated robot pose.
+   * Gets the current estimated robot pose.
    *
    * @return The estimated robot pose in meters.
    */
@@ -172,7 +173,9 @@ public class DifferentialDrivePoseEstimator {
   }
 
   /**
-   * Gets the estimated robot pose at timestampSeconds.
+   * Gets the estimated robot pose at timestampSeconds. If the buffer is empty, or the requested
+   * timestamp is outside the buffer history, an empty Optional is returned. The buffer history size
+   * used is 1.5 seconds.
    *
    * @param timestampSeconds The timestamp of the vision measurement in seconds. Note that if you
    *     don't use your own time source by calling {@link
@@ -181,18 +184,21 @@ public class DifferentialDrivePoseEstimator {
    *     the same epoch as {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()}.) This means that
    *     you should use {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()} as your time source
    *     or sync the epochs.
-   * @return The estimated robot pose in meters.
+   * @return The estimated robot pose in meters at that timestamp or an empty Optional.
    */
-  public Pose2d getEstimatedPosition(double timestampSeconds) {
-    if (m_poseBuffer.getInternalBuffer().isEmpty()) {
-      return m_poseEstimate;
+  public Optional<Pose2d> getEstimatedPosition(double timestampSeconds) {
+    var bufferMap = m_poseBuffer.getInternalBuffer();
+    if (bufferMap.isEmpty()
+        || timestampSeconds < bufferMap.firstKey()
+        || timestampSeconds > bufferMap.lastKey()) {
+      return Optional.empty();
     }
     // Find the odometry delta between now and the given timestamp,
     var delta =
         new Transform2d(
             m_odometry.getPoseMeters(), m_poseBuffer.getSample(timestampSeconds).get().poseMeters);
     // and apply it to the current pose estimate.
-    return m_poseEstimate.transformBy(delta);
+    return Optional.of(m_poseEstimate.transformBy(delta));
   }
 
   /**
@@ -200,7 +206,10 @@ public class DifferentialDrivePoseEstimator {
    * while still accounting for measurement noise.
    *
    * <p>This method can be called as infrequently as you want, as long as you are calling {@link
-   * DifferentialDrivePoseEstimator#update} every loop.
+   * DifferentialDrivePoseEstimator#update} every loop beforehand.
+   *
+   * <p>Vision measurements with timestamps outside of the odometry pose buffer will be ignored. The
+   * buffer history size used is 1.5 seconds.
    *
    * <p>To promote stability of the pose estimate and make it robust to bad vision data, we
    * recommend only adding vision measurements that are already within one meter or so of the
@@ -219,7 +228,9 @@ public class DifferentialDrivePoseEstimator {
     // Step 1: Get the odometry pose measured at the moment the vision measurement was made.
     var sample = m_poseBuffer.getSample(timestampSeconds);
 
-    if (sample.isEmpty()) {
+    if (sample.isEmpty()
+        || timestampSeconds < m_poseBuffer.getInternalBuffer().firstKey()
+        || timestampSeconds > m_poseBuffer.getInternalBuffer().lastKey()) {
       return;
     }
 

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
@@ -170,6 +170,7 @@ public class DifferentialDrivePoseEstimator {
   public Pose2d getEstimatedPosition() {
     return m_poseEstimate;
   }
+
   /**
    * Gets the estimated robot pose at timestampSeconds.
    *
@@ -183,7 +184,9 @@ public class DifferentialDrivePoseEstimator {
    * @return The estimated robot pose in meters.
    */
   public Pose2d getEstimatedPosition(double timestampSeconds) {
-    if (m_poseBuffer.getInternalBuffer().isEmpty()) return m_poseEstimate;
+    if (m_poseBuffer.getInternalBuffer().isEmpty()) {
+      return m_poseEstimate;
+    }
     // current to old odometry delta
     var delta =
         new Transform2d(

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -158,6 +158,27 @@ public class MecanumDrivePoseEstimator {
   public Pose2d getEstimatedPosition() {
     return m_poseEstimate;
   }
+  /**
+   * Gets the estimated robot pose at timestampSeconds.
+   *
+   * @param timestampSeconds The timestamp of the vision measurement in seconds. Note that if you
+   *     don't use your own time source by calling {@link
+   *     MecanumDrivePoseEstimator#updateWithTime(double,Rotation2d,MecanumDriveWheelPositions)}
+   *     then you must use a timestamp with an epoch since FPGA startup (i.e., the epoch of this
+   *     timestamp is the same epoch as {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()}.)
+   *     This means that you should use {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()} as
+   *     your time source or sync the epochs.
+   * @return The estimated robot pose in meters.
+   */
+  public Pose2d getEstimatedPosition(double timestampSeconds) {
+    if(m_poseBuffer.getInternalBuffer().isEmpty()) return m_poseEstimate;
+    // current to old odometry delta
+    var delta = new Transform2d(
+      m_odometry.getPoseMeters(),
+      m_poseBuffer.getSample(timestampSeconds).get().poseMeters
+    );
+    return m_poseEstimate.transformBy(delta);
+  }
 
   /**
    * Adds a vision measurement to the Kalman Filter. This will correct the odometry pose estimate

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -158,6 +158,7 @@ public class MecanumDrivePoseEstimator {
   public Pose2d getEstimatedPosition() {
     return m_poseEstimate;
   }
+
   /**
    * Gets the estimated robot pose at timestampSeconds.
    *
@@ -171,7 +172,9 @@ public class MecanumDrivePoseEstimator {
    * @return The estimated robot pose in meters.
    */
   public Pose2d getEstimatedPosition(double timestampSeconds) {
-    if (m_poseBuffer.getInternalBuffer().isEmpty()) return m_poseEstimate;
+    if (m_poseBuffer.getInternalBuffer().isEmpty()) {
+      return m_poseEstimate;
+    }
     // current to old odometry delta
     var delta =
         new Transform2d(

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -171,12 +171,11 @@ public class MecanumDrivePoseEstimator {
    * @return The estimated robot pose in meters.
    */
   public Pose2d getEstimatedPosition(double timestampSeconds) {
-    if(m_poseBuffer.getInternalBuffer().isEmpty()) return m_poseEstimate;
+    if (m_poseBuffer.getInternalBuffer().isEmpty()) return m_poseEstimate;
     // current to old odometry delta
-    var delta = new Transform2d(
-      m_odometry.getPoseMeters(),
-      m_poseBuffer.getSample(timestampSeconds).get().poseMeters
-    );
+    var delta =
+        new Transform2d(
+            m_odometry.getPoseMeters(), m_poseBuffer.getSample(timestampSeconds).get().poseMeters);
     return m_poseEstimate.transformBy(delta);
   }
 
@@ -212,10 +211,10 @@ public class MecanumDrivePoseEstimator {
     // "current" vision pose
     var delta = new Transform2d(sample.get().poseMeters, m_odometry.getPoseMeters());
     visionRobotPoseMeters = visionRobotPoseMeters.transformBy(delta);
-    
+
     // Step 3: Measure the twist between the estimated pose and the "current" vision pose
     var twist = m_poseEstimate.log(visionRobotPoseMeters);
-    
+
     // Step 4: We should not trust the twist entirely, so instead we scale this twist by a Kalman
     // gain matrix representing how much we trust vision measurements compared to our current pose.
     var k_times_twist = m_visionK.times(VecBuilder.fill(twist.dx, twist.dy, twist.dtheta));
@@ -223,15 +222,15 @@ public class MecanumDrivePoseEstimator {
     // Step 5: The Kalman gains scale the vision twists independent of other vision measurements,
     // so applying multiple vision measurements before the next update will have different results
     // depending on the order they are applied in. We can sum the Kalman gains applied before the
-    // next update and use that to effectively average the twist for multiple vision measurements. 
-    var weighted_k_times_twist = k_times_twist.elementTimes(
-            m_visionKSum.diag().extractColumnVector(0).elementPower(-1));
+    // next update and use that to effectively average the twist for multiple vision measurements.
+    var weighted_k_times_twist =
+        k_times_twist.elementTimes(m_visionKSum.diag().extractColumnVector(0).elementPower(-1));
     m_visionKSum = m_visionKSum.plus(m_visionK);
 
     // Step 5: Convert back to Twist2d.
     double[] scaledTwistVals = weighted_k_times_twist.getData();
     var scaledTwist = new Twist2d(scaledTwistVals[0], scaledTwistVals[1], scaledTwistVals[2]);
-    
+
     // Step 6: Apply scaled twist to the last estimated pose
     m_poseEstimate = m_poseEstimate.exp(scaledTwist);
   }
@@ -333,8 +332,7 @@ public class MecanumDrivePoseEstimator {
      * @param pose The pose observed given the current sensor inputs and the previous pose.
      * @param wheelPositions The distances traveled by each wheel encoder.
      */
-    private InterpolationRecord(
-        Pose2d poseMeters, MecanumDriveWheelPositions wheelPositions) {
+    private InterpolationRecord(Pose2d poseMeters, MecanumDriveWheelPositions wheelPositions) {
       this.poseMeters = poseMeters;
       this.wheelPositions = wheelPositions;
     }

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -200,20 +200,21 @@ public class MecanumDrivePoseEstimator {
    *     your time source or sync the epochs.
    */
   public void addVisionMeasurement(Pose2d visionRobotPoseMeters, double timestampSeconds) {
-    // Step 1: Get the pose odometry measured at the moment the vision measurement was made.
+    // Step 1: Get the odometry pose measured at the moment the vision measurement was made.
     var sample = m_poseBuffer.getSample(timestampSeconds);
 
     if (sample.isEmpty()) {
       return;
     }
 
-    // Step 2: Apply the odometry delta in the time since the vision timestamp to estimate the
-    // "current" vision pose
+    // Step 2: Get the odometry delta in the time since the vision measurement,
     var delta = new Transform2d(sample.get().poseMeters, m_odometry.getPoseMeters());
-    visionRobotPoseMeters = visionRobotPoseMeters.transformBy(delta);
+    // and apply its inverse to the current pose estimate to get the estimate at the time
+    // of the vision measurement
+    var old_estimate = m_poseEstimate.transformBy(delta.inverse());
 
-    // Step 3: Measure the twist between the estimated pose and the "current" vision pose
-    var twist = m_poseEstimate.log(visionRobotPoseMeters);
+    // Step 3: Measure the twist between the "old" estimated pose and the vision pose
+    var twist = old_estimate.log(visionRobotPoseMeters);
 
     // Step 4: We should not trust the twist entirely, so instead we scale this twist by a Kalman
     // gain matrix representing how much we trust vision measurements compared to our current pose.
@@ -231,8 +232,11 @@ public class MecanumDrivePoseEstimator {
     double[] scaledTwistVals = weighted_k_times_twist.getData();
     var scaledTwist = new Twist2d(scaledTwistVals[0], scaledTwistVals[1], scaledTwistVals[2]);
 
-    // Step 6: Apply scaled twist to the last estimated pose
-    m_poseEstimate = m_poseEstimate.exp(scaledTwist);
+    // Step 6: Apply scaled twist to the "old" estimated pose
+    old_estimate = old_estimate.exp(scaledTwist);
+
+    // Step 7: Re-apply odometry delta to get the "current" estimated pose
+    m_poseEstimate = old_estimate.transformBy(delta);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -175,10 +175,11 @@ public class MecanumDrivePoseEstimator {
     if (m_poseBuffer.getInternalBuffer().isEmpty()) {
       return m_poseEstimate;
     }
-    // current to old odometry delta
+    // Find the odometry delta between now and the given timestamp,
     var delta =
         new Transform2d(
             m_odometry.getPoseMeters(), m_poseBuffer.getSample(timestampSeconds).get().poseMeters);
+    // and apply it to the current pose estimate.
     return m_poseEstimate.transformBy(delta);
   }
 
@@ -213,10 +214,10 @@ public class MecanumDrivePoseEstimator {
     // Step 2: Get the odometry delta in the time since the vision measurement,
     var delta = new Transform2d(sample.get().poseMeters, m_odometry.getPoseMeters());
     // and apply its inverse to the current pose estimate to get the estimate at the time
-    // of the vision measurement
+    // of the vision measurement.
     var old_estimate = m_poseEstimate.transformBy(delta.inverse());
 
-    // Step 3: Measure the twist between the "old" estimated pose and the vision pose
+    // Step 3: Measure the twist between the "old" estimated pose and the vision pose.
     var twist = old_estimate.log(visionRobotPoseMeters);
 
     // Step 4: We should not trust the twist entirely, so instead we scale this twist by a Kalman
@@ -235,10 +236,10 @@ public class MecanumDrivePoseEstimator {
     double[] scaledTwistVals = weighted_k_times_twist.getData();
     var scaledTwist = new Twist2d(scaledTwistVals[0], scaledTwistVals[1], scaledTwistVals[2]);
 
-    // Step 6: Apply scaled twist to the "old" estimated pose
+    // Step 6: Apply scaled twist to the "old" estimated pose.
     old_estimate = old_estimate.exp(scaledTwist);
 
-    // Step 7: Re-apply odometry delta to get the "current" estimated pose
+    // Step 7: Re-apply odometry delta to get the "current" estimated pose.
     m_poseEstimate = old_estimate.transformBy(delta);
   }
 
@@ -300,7 +301,7 @@ public class MecanumDrivePoseEstimator {
    */
   public Pose2d updateWithTime(
       double currentTimeSeconds, Rotation2d gyroAngle, MecanumDriveWheelPositions wheelPositions) {
-    // update odometry
+    // Update the internal odometry.
     var lastOdom = m_odometry.getPoseMeters();
     var currOdom = m_odometry.update(gyroAngle, wheelPositions);
     m_poseBuffer.addSample(
@@ -313,10 +314,10 @@ public class MecanumDrivePoseEstimator {
                 wheelPositions.rearLeftMeters,
                 wheelPositions.rearRightMeters)));
 
-    // apply odometry update to pose estimate
+    // Apply this odometry update to the current pose estimate as well.
     m_poseEstimate = m_poseEstimate.transformBy(new Transform2d(lastOdom, currOdom));
 
-    // reset kalman gain sum matrix
+    // Reset the Kalman gain sum matrix.
     m_visionKSum = Matrix.eye(Nat.N3());
 
     return getEstimatedPosition();

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -10,6 +10,7 @@ import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Twist2d;
 import edu.wpi.first.math.interpolation.Interpolatable;
 import edu.wpi.first.math.interpolation.TimeInterpolatableBuffer;
@@ -19,7 +20,6 @@ import edu.wpi.first.math.kinematics.MecanumDriveWheelPositions;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.util.WPIUtilJNI;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -38,6 +38,8 @@ public class MecanumDrivePoseEstimator {
   private final MecanumDriveOdometry m_odometry;
   private final Matrix<N3, N1> m_q = new Matrix<>(Nat.N3(), Nat.N1());
   private Matrix<N3, N3> m_visionK = new Matrix<>(Nat.N3(), Nat.N3());
+  private Matrix<N3, N3> m_visionKSum = Matrix.eye(Nat.N3());
+  private Pose2d m_poseEstimate;
 
   private final TimeInterpolatableBuffer<InterpolationRecord> m_poseBuffer =
       TimeInterpolatableBuffer.createBuffer(1.5);
@@ -92,6 +94,7 @@ public class MecanumDrivePoseEstimator {
       Matrix<N3, N1> visionMeasurementStdDevs) {
     m_kinematics = kinematics;
     m_odometry = new MecanumDriveOdometry(kinematics, gyroAngle, wheelPositions, initialPoseMeters);
+    m_poseEstimate = m_odometry.getPoseMeters();
 
     for (int i = 0; i < 3; ++i) {
       m_q.set(i, 0, stateStdDevs.get(i, 0) * stateStdDevs.get(i, 0));
@@ -142,7 +145,9 @@ public class MecanumDrivePoseEstimator {
       Rotation2d gyroAngle, MecanumDriveWheelPositions wheelPositions, Pose2d poseMeters) {
     // Reset state estimate and error covariance
     m_odometry.resetPosition(gyroAngle, wheelPositions, poseMeters);
+    m_poseEstimate = poseMeters;
     m_poseBuffer.clear();
+    m_visionKSum = Matrix.eye(Nat.N3());
   }
 
   /**
@@ -151,7 +156,7 @@ public class MecanumDrivePoseEstimator {
    * @return The estimated robot pose in meters.
    */
   public Pose2d getEstimatedPosition() {
-    return m_odometry.getPoseMeters();
+    return m_poseEstimate;
   }
 
   /**
@@ -182,35 +187,32 @@ public class MecanumDrivePoseEstimator {
       return;
     }
 
-    // Step 2: Measure the twist between the odometry pose and the vision pose.
-    var twist = sample.get().poseMeters.log(visionRobotPoseMeters);
-
-    // Step 3: We should not trust the twist entirely, so instead we scale this twist by a Kalman
+    // Step 2: Apply the odometry delta in the time since the vision timestamp to estimate the
+    // "current" vision pose
+    var delta = new Transform2d(sample.get().poseMeters, m_odometry.getPoseMeters());
+    visionRobotPoseMeters = visionRobotPoseMeters.transformBy(delta);
+    
+    // Step 3: Measure the twist between the estimated pose and the "current" vision pose
+    var twist = m_poseEstimate.log(visionRobotPoseMeters);
+    
+    // Step 4: We should not trust the twist entirely, so instead we scale this twist by a Kalman
     // gain matrix representing how much we trust vision measurements compared to our current pose.
     var k_times_twist = m_visionK.times(VecBuilder.fill(twist.dx, twist.dy, twist.dtheta));
 
-    // Step 4: Convert back to Twist2d.
-    var scaledTwist =
-        new Twist2d(k_times_twist.get(0, 0), k_times_twist.get(1, 0), k_times_twist.get(2, 0));
+    // Step 5: The Kalman gains scale the vision twists independent of other vision measurements,
+    // so applying multiple vision measurements before the next update will have different results
+    // depending on the order they are applied in. We can sum the Kalman gains applied before the
+    // next update and use that to effectively average the twist for multiple vision measurements. 
+    var weighted_k_times_twist = k_times_twist.elementTimes(
+            m_visionKSum.diag().extractColumnVector(0).elementPower(-1));
+    m_visionKSum = m_visionKSum.plus(m_visionK);
 
-    // Step 5: Reset Odometry to state at sample with vision adjustment.
-    m_odometry.resetPosition(
-        sample.get().gyroAngle,
-        sample.get().wheelPositions,
-        sample.get().poseMeters.exp(scaledTwist));
-
-    // Step 6: Record the current pose to allow multiple measurements from the same timestamp
-    m_poseBuffer.addSample(
-        timestampSeconds,
-        new InterpolationRecord(
-            getEstimatedPosition(), sample.get().gyroAngle, sample.get().wheelPositions));
-
-    // Step 7: Replay odometry inputs between sample time and latest recorded sample to update the
-    // pose buffer and correct odometry.
-    for (Map.Entry<Double, InterpolationRecord> entry :
-        m_poseBuffer.getInternalBuffer().tailMap(timestampSeconds).entrySet()) {
-      updateWithTime(entry.getKey(), entry.getValue().gyroAngle, entry.getValue().wheelPositions);
-    }
+    // Step 5: Convert back to Twist2d.
+    double[] scaledTwistVals = weighted_k_times_twist.getData();
+    var scaledTwist = new Twist2d(scaledTwistVals[0], scaledTwistVals[1], scaledTwistVals[2]);
+    
+    // Step 6: Apply scaled twist to the last estimated pose
+    m_poseEstimate = m_poseEstimate.exp(scaledTwist);
   }
 
   /**
@@ -271,18 +273,24 @@ public class MecanumDrivePoseEstimator {
    */
   public Pose2d updateWithTime(
       double currentTimeSeconds, Rotation2d gyroAngle, MecanumDriveWheelPositions wheelPositions) {
-    m_odometry.update(gyroAngle, wheelPositions);
-
+    // update odometry
+    var lastOdom = m_odometry.getPoseMeters();
+    var currOdom = m_odometry.update(gyroAngle, wheelPositions);
     m_poseBuffer.addSample(
         currentTimeSeconds,
         new InterpolationRecord(
-            getEstimatedPosition(),
-            gyroAngle,
+            currOdom,
             new MecanumDriveWheelPositions(
                 wheelPositions.frontLeftMeters,
                 wheelPositions.frontRightMeters,
                 wheelPositions.rearLeftMeters,
                 wheelPositions.rearRightMeters)));
+
+    // apply odometry update to pose estimate
+    m_poseEstimate = m_poseEstimate.transformBy(new Transform2d(lastOdom, currOdom));
+
+    // reset kalman gain sum matrix
+    m_visionKSum = Matrix.eye(Nat.N3());
 
     return getEstimatedPosition();
   }
@@ -295,9 +303,6 @@ public class MecanumDrivePoseEstimator {
     // The pose observed given the current sensor inputs and the previous pose.
     private final Pose2d poseMeters;
 
-    // The current gyro angle.
-    private final Rotation2d gyroAngle;
-
     // The distances traveled by each wheel encoder.
     private final MecanumDriveWheelPositions wheelPositions;
 
@@ -305,13 +310,11 @@ public class MecanumDrivePoseEstimator {
      * Constructs an Interpolation Record with the specified parameters.
      *
      * @param pose The pose observed given the current sensor inputs and the previous pose.
-     * @param gyro The current gyro angle.
      * @param wheelPositions The distances traveled by each wheel encoder.
      */
     private InterpolationRecord(
-        Pose2d poseMeters, Rotation2d gyro, MecanumDriveWheelPositions wheelPositions) {
+        Pose2d poseMeters, MecanumDriveWheelPositions wheelPositions) {
       this.poseMeters = poseMeters;
-      this.gyroAngle = gyro;
       this.wheelPositions = wheelPositions;
     }
 
@@ -357,13 +360,13 @@ public class MecanumDrivePoseEstimator {
                 wheels_lerp.rearRightMeters - this.wheelPositions.rearRightMeters);
 
         // Find the new gyro angle.
-        var gyro_lerp = gyroAngle.interpolate(endValue.gyroAngle, t);
+        var gyro_lerp = poseMeters.getRotation().interpolate(endValue.poseMeters.getRotation(), t);
 
         // Create a twist to represent this change based on the interpolated sensor inputs.
         Twist2d twist = m_kinematics.toTwist2d(wheels_delta);
-        twist.dtheta = gyro_lerp.minus(gyroAngle).getRadians();
+        twist.dtheta = gyro_lerp.minus(poseMeters.getRotation()).getRadians();
 
-        return new InterpolationRecord(poseMeters.exp(twist), gyro_lerp, wheels_lerp);
+        return new InterpolationRecord(poseMeters.exp(twist), wheels_lerp);
       }
     }
 
@@ -376,14 +379,13 @@ public class MecanumDrivePoseEstimator {
         return false;
       }
       InterpolationRecord record = (InterpolationRecord) obj;
-      return Objects.equals(gyroAngle, record.gyroAngle)
-          && Objects.equals(wheelPositions, record.wheelPositions)
+      return Objects.equals(wheelPositions, record.wheelPositions)
           && Objects.equals(poseMeters, record.poseMeters);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(gyroAngle, wheelPositions, poseMeters);
+      return Objects.hash(wheelPositions, poseMeters);
     }
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -22,6 +22,7 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.util.WPIUtilJNI;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * This class wraps {@link SwerveDriveOdometry Swerve Drive Odometry} to fuse latency-compensated
@@ -153,7 +154,7 @@ public class SwerveDrivePoseEstimator {
   }
 
   /**
-   * Gets the estimated robot pose.
+   * Gets the current estimated robot pose.
    *
    * @return The estimated robot pose in meters.
    */
@@ -162,7 +163,9 @@ public class SwerveDrivePoseEstimator {
   }
 
   /**
-   * Gets the estimated robot pose at timestampSeconds.
+   * Gets the estimated robot pose at timestampSeconds. If the buffer is empty, or the requested
+   * timestamp is outside the buffer history, an empty Optional is returned. The buffer history size
+   * used is 1.5 seconds.
    *
    * @param timestampSeconds The timestamp of the pose estimate in seconds. Note that if you don't
    *     use your own time source by calling {@link
@@ -171,18 +174,21 @@ public class SwerveDrivePoseEstimator {
    *     the same epoch as {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()}.) This means that
    *     you should use {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()} as your time source
    *     or sync the epochs.
-   * @return The estimated robot pose in meters.
+   * @return The estimated robot pose in meters at that timestamp or an empty Optional.
    */
-  public Pose2d getEstimatedPosition(double timestampSeconds) {
-    if (m_poseBuffer.getInternalBuffer().isEmpty()) {
-      return m_poseEstimate;
+  public Optional<Pose2d> getEstimatedPosition(double timestampSeconds) {
+    var bufferMap = m_poseBuffer.getInternalBuffer();
+    if (bufferMap.isEmpty()
+        || timestampSeconds < bufferMap.firstKey()
+        || timestampSeconds > bufferMap.lastKey()) {
+      return Optional.empty();
     }
     // Find the odometry delta between now and the given timestamp,
     var delta =
         new Transform2d(
             m_odometry.getPoseMeters(), m_poseBuffer.getSample(timestampSeconds).get().poseMeters);
     // and apply it to the current pose estimate.
-    return m_poseEstimate.transformBy(delta);
+    return Optional.of(m_poseEstimate.transformBy(delta));
   }
 
   /**
@@ -190,7 +196,10 @@ public class SwerveDrivePoseEstimator {
    * while still accounting for measurement noise.
    *
    * <p>This method can be called as infrequently as you want, as long as you are calling {@link
-   * SwerveDrivePoseEstimator#update} every loop.
+   * SwerveDrivePoseEstimator#update} every loop beforehand.
+   *
+   * <p>Vision measurements with timestamps outside of the odometry pose buffer will be ignored. The
+   * buffer history size used is 1.5 seconds.
    *
    * <p>To promote stability of the pose estimate and make it robust to bad vision data, we
    * recommend only adding vision measurements that are already within one meter or so of the
@@ -209,7 +218,9 @@ public class SwerveDrivePoseEstimator {
     // Step 1: Get the odometry pose measured at the moment the vision measurement was made.
     var sample = m_poseBuffer.getSample(timestampSeconds);
 
-    if (sample.isEmpty()) {
+    if (sample.isEmpty()
+        || timestampSeconds < m_poseBuffer.getInternalBuffer().firstKey()
+        || timestampSeconds > m_poseBuffer.getInternalBuffer().lastKey()) {
       return;
     }
 

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -177,10 +177,11 @@ public class SwerveDrivePoseEstimator {
     if (m_poseBuffer.getInternalBuffer().isEmpty()) {
       return m_poseEstimate;
     }
-    // current to old odometry delta
+    // Find the odometry delta between now and the given timestamp,
     var delta =
         new Transform2d(
             m_odometry.getPoseMeters(), m_poseBuffer.getSample(timestampSeconds).get().poseMeters);
+    // and apply it to the current pose estimate.
     return m_poseEstimate.transformBy(delta);
   }
 
@@ -215,10 +216,10 @@ public class SwerveDrivePoseEstimator {
     // Step 2: Get the odometry delta in the time since the vision measurement,
     var delta = new Transform2d(sample.get().poseMeters, m_odometry.getPoseMeters());
     // and apply its inverse to the current pose estimate to get the estimate at the time
-    // of the vision measurement
+    // of the vision measurement.
     var old_estimate = m_poseEstimate.transformBy(delta.inverse());
 
-    // Step 3: Measure the twist between the "old" estimated pose and the vision pose
+    // Step 3: Measure the twist between the "old" estimated pose and the vision pose.
     var twist = old_estimate.log(visionRobotPoseMeters);
 
     // Step 4: We should not trust the twist entirely, so instead we scale this twist by a Kalman
@@ -237,10 +238,10 @@ public class SwerveDrivePoseEstimator {
     double[] scaledTwistVals = weighted_k_times_twist.getData();
     var scaledTwist = new Twist2d(scaledTwistVals[0], scaledTwistVals[1], scaledTwistVals[2]);
 
-    // Step 6: Apply scaled twist to the "old" estimated pose
+    // Step 6: Apply scaled twist to the "old" estimated pose.
     old_estimate = old_estimate.exp(scaledTwist);
 
-    // Step 7: Re-apply odometry delta to get the "current" estimated pose
+    // Step 7: Re-apply odometry delta to get the "current" estimated pose.
     m_poseEstimate = old_estimate.transformBy(delta);
   }
 
@@ -315,16 +316,16 @@ public class SwerveDrivePoseEstimator {
           new SwerveModulePosition(modulePositions[i].distanceMeters, modulePositions[i].angle);
     }
 
-    // update odometry
+    // Update the internal odometry.
     var lastOdom = m_odometry.getPoseMeters();
     var currOdom = m_odometry.update(gyroAngle, modulePositions);
     m_poseBuffer.addSample(
         currentTimeSeconds, new InterpolationRecord(currOdom, internalModulePositions));
 
-    // apply odometry update to pose estimate
+    // Apply this odometry update to the current pose estimate as well.
     m_poseEstimate = m_poseEstimate.transformBy(new Transform2d(lastOdom, currOdom));
 
-    // reset kalman gain sum matrix
+    // Reset the Kalman gain sum matrix.
     m_visionKSum = Matrix.eye(Nat.N3());
 
     return getEstimatedPosition();

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -10,6 +10,7 @@ import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Twist2d;
 import edu.wpi.first.math.interpolation.Interpolatable;
 import edu.wpi.first.math.interpolation.TimeInterpolatableBuffer;
@@ -20,7 +21,6 @@ import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.util.WPIUtilJNI;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -39,6 +39,8 @@ public class SwerveDrivePoseEstimator {
   private final Matrix<N3, N1> m_q = new Matrix<>(Nat.N3(), Nat.N1());
   private final int m_numModules;
   private Matrix<N3, N3> m_visionK = new Matrix<>(Nat.N3(), Nat.N3());
+  private Matrix<N3, N3> m_visionKSum = Matrix.eye(Nat.N3());
+  private Pose2d m_poseEstimate;
 
   private final TimeInterpolatableBuffer<InterpolationRecord> m_poseBuffer =
       TimeInterpolatableBuffer.createBuffer(1.5);
@@ -93,6 +95,7 @@ public class SwerveDrivePoseEstimator {
       Matrix<N3, N1> visionMeasurementStdDevs) {
     m_kinematics = kinematics;
     m_odometry = new SwerveDriveOdometry(kinematics, gyroAngle, modulePositions, initialPoseMeters);
+    m_poseEstimate = m_odometry.getPoseMeters();
 
     for (int i = 0; i < 3; ++i) {
       m_q.set(i, 0, stateStdDevs.get(i, 0) * stateStdDevs.get(i, 0));
@@ -144,7 +147,9 @@ public class SwerveDrivePoseEstimator {
       Rotation2d gyroAngle, SwerveModulePosition[] modulePositions, Pose2d poseMeters) {
     // Reset state estimate and error covariance
     m_odometry.resetPosition(gyroAngle, modulePositions, poseMeters);
+    m_poseEstimate = poseMeters;
     m_poseBuffer.clear();
+    m_visionKSum = Matrix.eye(Nat.N3());
   }
 
   /**
@@ -153,7 +158,7 @@ public class SwerveDrivePoseEstimator {
    * @return The estimated robot pose in meters.
    */
   public Pose2d getEstimatedPosition() {
-    return m_odometry.getPoseMeters();
+    return m_poseEstimate;
   }
 
   /**
@@ -183,36 +188,33 @@ public class SwerveDrivePoseEstimator {
     if (sample.isEmpty()) {
       return;
     }
-
-    // Step 2: Measure the twist between the odometry pose and the vision pose.
-    var twist = sample.get().poseMeters.log(visionRobotPoseMeters);
-
-    // Step 3: We should not trust the twist entirely, so instead we scale this twist by a Kalman
+    
+    // Step 2: Apply the odometry delta in the time since the vision timestamp to estimate the
+    // "current" vision pose
+    var delta = new Transform2d(sample.get().poseMeters, m_odometry.getPoseMeters());
+    visionRobotPoseMeters = visionRobotPoseMeters.transformBy(delta);
+    
+    // Step 3: Measure the twist between the estimated pose and the "current" vision pose
+    var twist = m_poseEstimate.log(visionRobotPoseMeters);
+    
+    // Step 4: We should not trust the twist entirely, so instead we scale this twist by a Kalman
     // gain matrix representing how much we trust vision measurements compared to our current pose.
     var k_times_twist = m_visionK.times(VecBuilder.fill(twist.dx, twist.dy, twist.dtheta));
 
-    // Step 4: Convert back to Twist2d.
-    var scaledTwist =
-        new Twist2d(k_times_twist.get(0, 0), k_times_twist.get(1, 0), k_times_twist.get(2, 0));
+    // Step 5: The Kalman gains scale the vision twists independent of other vision measurements,
+    // so applying multiple vision measurements before the next update will have different results
+    // depending on the order they are applied in. We can sum the Kalman gains applied before the
+    // next update and use that to effectively average the twist for multiple vision measurements. 
+    var weighted_k_times_twist = k_times_twist.elementTimes(
+            m_visionKSum.diag().extractColumnVector(0).elementPower(-1));
+    m_visionKSum = m_visionKSum.plus(m_visionK);
 
-    // Step 5: Reset Odometry to state at sample with vision adjustment.
-    m_odometry.resetPosition(
-        sample.get().gyroAngle,
-        sample.get().modulePositions,
-        sample.get().poseMeters.exp(scaledTwist));
-
-    // Step 6: Record the current pose to allow multiple measurements from the same timestamp
-    m_poseBuffer.addSample(
-        timestampSeconds,
-        new InterpolationRecord(
-            getEstimatedPosition(), sample.get().gyroAngle, sample.get().modulePositions));
-
-    // Step 7: Replay odometry inputs between sample time and latest recorded sample to update the
-    // pose buffer and correct odometry.
-    for (Map.Entry<Double, InterpolationRecord> entry :
-        m_poseBuffer.getInternalBuffer().tailMap(timestampSeconds).entrySet()) {
-      updateWithTime(entry.getKey(), entry.getValue().gyroAngle, entry.getValue().modulePositions);
-    }
+    // Step 5: Convert back to Twist2d.
+    double[] scaledTwistVals = weighted_k_times_twist.getData();
+    var scaledTwist = new Twist2d(scaledTwistVals[0], scaledTwistVals[1], scaledTwistVals[2]);
+    
+    // Step 6: Apply scaled twist to the last estimated pose
+    m_poseEstimate = m_poseEstimate.exp(scaledTwist);
   }
 
   /**
@@ -285,12 +287,17 @@ public class SwerveDrivePoseEstimator {
       internalModulePositions[i] =
           new SwerveModulePosition(modulePositions[i].distanceMeters, modulePositions[i].angle);
     }
+    
+    // update odometry
+    var lastOdom = m_odometry.getPoseMeters();
+    var currOdom = m_odometry.update(gyroAngle, modulePositions);
+    m_poseBuffer.addSample(currentTimeSeconds, new InterpolationRecord(currOdom, internalModulePositions));
 
-    m_odometry.update(gyroAngle, internalModulePositions);
+    // apply odometry update to pose estimate
+    m_poseEstimate = m_poseEstimate.transformBy(new Transform2d(lastOdom, currOdom));
 
-    m_poseBuffer.addSample(
-        currentTimeSeconds,
-        new InterpolationRecord(getEstimatedPosition(), gyroAngle, internalModulePositions));
+    // reset kalman gain sum matrix
+    m_visionKSum = Matrix.eye(Nat.N3());
 
     return getEstimatedPosition();
   }
@@ -303,9 +310,6 @@ public class SwerveDrivePoseEstimator {
     // The pose observed given the current sensor inputs and the previous pose.
     private final Pose2d poseMeters;
 
-    // The current gyro angle.
-    private final Rotation2d gyroAngle;
-
     // The distances and rotations measured at each module.
     private final SwerveModulePosition[] modulePositions;
 
@@ -313,13 +317,11 @@ public class SwerveDrivePoseEstimator {
      * Constructs an Interpolation Record with the specified parameters.
      *
      * @param pose The pose observed given the current sensor inputs and the previous pose.
-     * @param gyro The current gyro angle.
      * @param wheelPositions The distances and rotations measured at each wheel.
      */
     private InterpolationRecord(
-        Pose2d poseMeters, Rotation2d gyro, SwerveModulePosition[] modulePositions) {
+        Pose2d poseMeters, SwerveModulePosition[] modulePositions) {
       this.poseMeters = poseMeters;
-      this.gyroAngle = gyro;
       this.modulePositions = modulePositions;
     }
 
@@ -358,13 +360,13 @@ public class SwerveDrivePoseEstimator {
         }
 
         // Find the new gyro angle.
-        var gyro_lerp = gyroAngle.interpolate(endValue.gyroAngle, t);
+        var gyro_lerp = poseMeters.getRotation().interpolate(endValue.poseMeters.getRotation(), t);
 
         // Create a twist to represent this change based on the interpolated sensor inputs.
         Twist2d twist = m_kinematics.toTwist2d(moduleDeltas);
-        twist.dtheta = gyro_lerp.minus(gyroAngle).getRadians();
+        twist.dtheta = gyro_lerp.minus(poseMeters.getRotation()).getRadians();
 
-        return new InterpolationRecord(poseMeters.exp(twist), gyro_lerp, modulePositions);
+        return new InterpolationRecord(poseMeters.exp(twist), modulePositions);
       }
     }
 
@@ -377,14 +379,13 @@ public class SwerveDrivePoseEstimator {
         return false;
       }
       InterpolationRecord record = (InterpolationRecord) obj;
-      return Objects.equals(gyroAngle, record.gyroAngle)
-          && Arrays.equals(modulePositions, record.modulePositions)
+      return Arrays.equals(modulePositions, record.modulePositions)
           && Objects.equals(poseMeters, record.poseMeters);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(gyroAngle, Arrays.hashCode(modulePositions), poseMeters);
+      return Objects.hash(Arrays.hashCode(modulePositions), poseMeters);
     }
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -160,7 +160,28 @@ public class SwerveDrivePoseEstimator {
   public Pose2d getEstimatedPosition() {
     return m_poseEstimate;
   }
-
+  /**
+   * Gets the estimated robot pose at timestampSeconds.
+   *
+   * @param timestampSeconds The timestamp of the pose estimate in seconds. Note that if you
+   *     don't use your own time source by calling {@link
+   *     SwerveDrivePoseEstimator#updateWithTime(double,Rotation2d,SwerveModulePosition[])} then you
+   *     must use a timestamp with an epoch since FPGA startup (i.e., the epoch of this timestamp is
+   *     the same epoch as {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()}.) This means that
+   *     you should use {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()} as your time source
+   *     or sync the epochs.
+   * @return The estimated robot pose in meters.
+   */
+  public Pose2d getEstimatedPosition(double timestampSeconds) {
+    if(m_poseBuffer.getInternalBuffer().isEmpty()) return m_poseEstimate;
+    // current to old odometry delta
+    var delta = new Transform2d(
+      m_odometry.getPoseMeters(),
+      m_poseBuffer.getSample(timestampSeconds).get().poseMeters
+    );
+    return m_poseEstimate.transformBy(delta);
+  }
+  
   /**
    * Adds a vision measurement to the Kalman Filter. This will correct the odometry pose estimate
    * while still accounting for measurement noise.

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -22,7 +22,6 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.util.WPIUtilJNI;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * This class wraps {@link SwerveDriveOdometry Swerve Drive Odometry} to fuse latency-compensated
@@ -40,7 +39,6 @@ public class SwerveDrivePoseEstimator {
   private final Matrix<N3, N1> m_q = new Matrix<>(Nat.N3(), Nat.N1());
   private final int m_numModules;
   private Matrix<N3, N3> m_visionK = new Matrix<>(Nat.N3(), Nat.N3());
-  private Matrix<N3, N3> m_visionKSum = Matrix.eye(Nat.N3());
   private Pose2d m_poseEstimate;
 
   private final TimeInterpolatableBuffer<InterpolationRecord> m_poseBuffer =
@@ -150,7 +148,6 @@ public class SwerveDrivePoseEstimator {
     m_odometry.resetPosition(gyroAngle, modulePositions, poseMeters);
     m_poseEstimate = poseMeters;
     m_poseBuffer.clear();
-    m_visionKSum = Matrix.eye(Nat.N3());
   }
 
   /**
@@ -160,35 +157,6 @@ public class SwerveDrivePoseEstimator {
    */
   public Pose2d getEstimatedPosition() {
     return m_poseEstimate;
-  }
-
-  /**
-   * Gets the estimated robot pose at timestampSeconds. If the buffer is empty, or the requested
-   * timestamp is outside the buffer history, an empty Optional is returned. The buffer history size
-   * used is 1.5 seconds.
-   *
-   * @param timestampSeconds The timestamp of the pose estimate in seconds. Note that if you don't
-   *     use your own time source by calling {@link
-   *     SwerveDrivePoseEstimator#updateWithTime(double,Rotation2d,SwerveModulePosition[])} then you
-   *     must use a timestamp with an epoch since FPGA startup (i.e., the epoch of this timestamp is
-   *     the same epoch as {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()}.) This means that
-   *     you should use {@link edu.wpi.first.wpilibj.Timer#getFPGATimestamp()} as your time source
-   *     or sync the epochs.
-   * @return The estimated robot pose in meters at that timestamp or an empty Optional.
-   */
-  public Optional<Pose2d> getEstimatedPosition(double timestampSeconds) {
-    var bufferMap = m_poseBuffer.getInternalBuffer();
-    if (bufferMap.isEmpty()
-        || timestampSeconds < bufferMap.firstKey()
-        || timestampSeconds > bufferMap.lastKey()) {
-      return Optional.empty();
-    }
-    // Find the odometry delta between now and the given timestamp,
-    var delta =
-        new Transform2d(
-            m_odometry.getPoseMeters(), m_poseBuffer.getSample(timestampSeconds).get().poseMeters);
-    // and apply it to the current pose estimate.
-    return Optional.of(m_poseEstimate.transformBy(delta));
   }
 
   /**
@@ -237,16 +205,8 @@ public class SwerveDrivePoseEstimator {
     // gain matrix representing how much we trust vision measurements compared to our current pose.
     var k_times_twist = m_visionK.times(VecBuilder.fill(twist.dx, twist.dy, twist.dtheta));
 
-    // Step 5: The Kalman gains scale the vision twists independent of other vision measurements,
-    // so applying multiple vision measurements before the next update will have different results
-    // depending on the order they are applied in. We can sum the Kalman gains applied before the
-    // next update and use that to effectively average the twist for multiple vision measurements.
-    var weighted_k_times_twist =
-        k_times_twist.elementTimes(m_visionKSum.diag().extractColumnVector(0).elementPower(-1));
-    m_visionKSum = m_visionKSum.plus(m_visionK);
-
     // Step 5: Convert back to Twist2d.
-    double[] scaledTwistVals = weighted_k_times_twist.getData();
+    double[] scaledTwistVals = k_times_twist.getData();
     var scaledTwist = new Twist2d(scaledTwistVals[0], scaledTwistVals[1], scaledTwistVals[2]);
 
     // Step 6: Apply scaled twist to the "old" estimated pose.
@@ -335,9 +295,6 @@ public class SwerveDrivePoseEstimator {
 
     // Apply this odometry update to the current pose estimate as well.
     m_poseEstimate = m_poseEstimate.transformBy(new Transform2d(lastOdom, currOdom));
-
-    // Reset the Kalman gain sum matrix.
-    m_visionKSum = Matrix.eye(Nat.N3());
 
     return getEstimatedPosition();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -202,20 +202,21 @@ public class SwerveDrivePoseEstimator {
    *     or sync the epochs.
    */
   public void addVisionMeasurement(Pose2d visionRobotPoseMeters, double timestampSeconds) {
-    // Step 1: Get the pose odometry measured at the moment the vision measurement was made.
+    // Step 1: Get the odometry pose measured at the moment the vision measurement was made.
     var sample = m_poseBuffer.getSample(timestampSeconds);
 
     if (sample.isEmpty()) {
       return;
     }
 
-    // Step 2: Apply the odometry delta in the time since the vision timestamp to estimate the
-    // "current" vision pose
+    // Step 2: Get the odometry delta in the time since the vision measurement,
     var delta = new Transform2d(sample.get().poseMeters, m_odometry.getPoseMeters());
-    visionRobotPoseMeters = visionRobotPoseMeters.transformBy(delta);
+    // and apply its inverse to the current pose estimate to get the estimate at the time
+    // of the vision measurement
+    var old_estimate = m_poseEstimate.transformBy(delta.inverse());
 
-    // Step 3: Measure the twist between the estimated pose and the "current" vision pose
-    var twist = m_poseEstimate.log(visionRobotPoseMeters);
+    // Step 3: Measure the twist between the "old" estimated pose and the vision pose
+    var twist = old_estimate.log(visionRobotPoseMeters);
 
     // Step 4: We should not trust the twist entirely, so instead we scale this twist by a Kalman
     // gain matrix representing how much we trust vision measurements compared to our current pose.
@@ -233,8 +234,11 @@ public class SwerveDrivePoseEstimator {
     double[] scaledTwistVals = weighted_k_times_twist.getData();
     var scaledTwist = new Twist2d(scaledTwistVals[0], scaledTwistVals[1], scaledTwistVals[2]);
 
-    // Step 6: Apply scaled twist to the last estimated pose
-    m_poseEstimate = m_poseEstimate.exp(scaledTwist);
+    // Step 6: Apply scaled twist to the "old" estimated pose
+    old_estimate = old_estimate.exp(scaledTwist);
+
+    // Step 7: Re-apply odometry delta to get the "current" estimated pose
+    m_poseEstimate = old_estimate.transformBy(delta);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -160,6 +160,7 @@ public class SwerveDrivePoseEstimator {
   public Pose2d getEstimatedPosition() {
     return m_poseEstimate;
   }
+
   /**
    * Gets the estimated robot pose at timestampSeconds.
    *
@@ -173,7 +174,9 @@ public class SwerveDrivePoseEstimator {
    * @return The estimated robot pose in meters.
    */
   public Pose2d getEstimatedPosition(double timestampSeconds) {
-    if (m_poseBuffer.getInternalBuffer().isEmpty()) return m_poseEstimate;
+    if (m_poseBuffer.getInternalBuffer().isEmpty()) {
+      return m_poseEstimate;
+    }
     // current to old odometry delta
     var delta =
         new Transform2d(


### PR DESCRIPTION
- Separates the estimated pose from the odometry buffer so that replaying all inputs since an old vision timestamp is simplified to a single transform. This performs identically while being faster(not that it really matters) and simpler.
- ~~Adds a getter for the estimated pose at a previous timestamp.~~ (Moved to #5025)
- ~~The Kalman gains of vision measurements following the first and applied before the next odometry update are divided by the sum of all previous gains + 1, effectively averaging them and guaranteeing that applying vision measurements in different orders will give the same result.~~

Fixes #4952 

Needs C++