### PR TITLE
Add method to check deadband values from within HID device classes

### DIFF
--- a/wpilibc/src/main/native/cpp/Joystick.cpp
+++ b/wpilibc/src/main/native/cpp/Joystick.cpp
@@ -6,6 +6,7 @@
 
 #include <cmath>
 #include <numbers>
+#include <frc/MathUtil.h>
 
 #include <hal/FRCUsageReporting.h>
 
@@ -67,12 +68,24 @@ double Joystick::GetX() const {
   return GetRawAxis(m_axes[Axis::kX]);
 }
 
+double Joystick::GetDeadbandX(double deadband) const {
+    return frc::ApplyDeadband(GetX(), deadband, 1.0);
+}
+
 double Joystick::GetY() const {
   return GetRawAxis(m_axes[Axis::kY]);
 }
 
+double Joystick::GetDeadbandY(double deadband) const {
+    return frc::ApplyDeadband(GetY(), deadband, 1.0);
+}
+
 double Joystick::GetZ() const {
   return GetRawAxis(m_axes[Axis::kZ]);
+}
+
+double Joystick::GetDeadbandZ(double deadband) const {
+    return frc::ApplyDeadband(GetZ(), deadband, 1.0);
 }
 
 double Joystick::GetTwist() const {

--- a/wpilibc/src/main/native/cpp/Joystick.cpp
+++ b/wpilibc/src/main/native/cpp/Joystick.cpp
@@ -4,9 +4,10 @@
 
 #include "frc/Joystick.h"
 
+#include <frc/MathUtil.h>
+
 #include <cmath>
 #include <numbers>
-#include <frc/MathUtil.h>
 
 #include <hal/FRCUsageReporting.h>
 
@@ -69,7 +70,7 @@ double Joystick::GetX() const {
 }
 
 double Joystick::GetDeadbandX(double deadband) const {
-    return frc::ApplyDeadband(GetX(), deadband, 1.0);
+  return frc::ApplyDeadband(GetX(), deadband, 1.0);
 }
 
 double Joystick::GetY() const {
@@ -77,7 +78,7 @@ double Joystick::GetY() const {
 }
 
 double Joystick::GetDeadbandY(double deadband) const {
-    return frc::ApplyDeadband(GetY(), deadband, 1.0);
+  return frc::ApplyDeadband(GetY(), deadband, 1.0);
 }
 
 double Joystick::GetZ() const {
@@ -85,7 +86,7 @@ double Joystick::GetZ() const {
 }
 
 double Joystick::GetDeadbandZ(double deadband) const {
-    return frc::ApplyDeadband(GetZ(), deadband, 1.0);
+  return frc::ApplyDeadband(GetZ(), deadband, 1.0);
 }
 
 double Joystick::GetTwist() const {

--- a/wpilibc/src/main/native/cpp/PS4Controller.cpp
+++ b/wpilibc/src/main/native/cpp/PS4Controller.cpp
@@ -4,11 +4,11 @@
 
 #include "frc/PS4Controller.h"
 
+#include <frc/MathUtil.h>
+
 #include <hal/FRCUsageReporting.h>
 
 #include "frc/event/BooleanEvent.h"
-
-#include <frc/MathUtil.h>
 
 using namespace frc;
 
@@ -37,7 +37,7 @@ double PS4Controller::GetLeftY() const {
 }
 
 double PS4Controller::GetDeadbandLeftY(double deadband) const {
-    return frc::ApplyDeadband(GetLeftY(), deadband, 1.0);
+  return frc::ApplyDeadband(GetLeftY(), deadband, 1.0);
 }
 
 double PS4Controller::GetRightY() const {
@@ -45,7 +45,7 @@ double PS4Controller::GetRightY() const {
 }
 
 double PS4Controller::GetDeadbandRightY(double deadband) const {
-    return frc::ApplyDeadband(GetRightY(), deadband, 1.0);
+  return frc::ApplyDeadband(GetRightY(), deadband, 1.0);
 }
 
 double PS4Controller::GetL2Axis() const {

--- a/wpilibc/src/main/native/cpp/PS4Controller.cpp
+++ b/wpilibc/src/main/native/cpp/PS4Controller.cpp
@@ -8,6 +8,8 @@
 
 #include "frc/event/BooleanEvent.h"
 
+#include <frc/MathUtil.h>
+
 using namespace frc;
 
 PS4Controller::PS4Controller(int port) : GenericHID(port) {
@@ -18,16 +20,32 @@ double PS4Controller::GetLeftX() const {
   return GetRawAxis(Axis::kLeftX);
 }
 
+double PS4Controller::GetDeadbandLeftX(double deadband) const {
+  return frc::ApplyDeadband(GetLeftX(), deadband, 1.0);
+}
+
 double PS4Controller::GetRightX() const {
   return GetRawAxis(Axis::kRightX);
+}
+
+double PS4Controller::GetDeadbandRightX(double deadband) const {
+  return frc::ApplyDeadband(GetRightX(), deadband, 1.0);
 }
 
 double PS4Controller::GetLeftY() const {
   return GetRawAxis(Axis::kLeftY);
 }
 
+double PS4Controller::GetDeadbandLeftY(double deadband) const {
+    return frc::ApplyDeadband(GetLeftY(), deadband, 1.0);
+}
+
 double PS4Controller::GetRightY() const {
   return GetRawAxis(Axis::kRightY);
+}
+
+double PS4Controller::GetDeadbandRightY(double deadband) const {
+    return frc::ApplyDeadband(GetRightY(), deadband, 1.0);
 }
 
 double PS4Controller::GetL2Axis() const {

--- a/wpilibc/src/main/native/cpp/XboxController.cpp
+++ b/wpilibc/src/main/native/cpp/XboxController.cpp
@@ -8,6 +8,8 @@
 
 #include "frc/event/BooleanEvent.h"
 
+#include <frc/MathUtil.h>
+
 using namespace frc;
 
 XboxController::XboxController(int port) : GenericHID(port) {
@@ -18,16 +20,32 @@ double XboxController::GetLeftX() const {
   return GetRawAxis(Axis::kLeftX);
 }
 
+double XboxController::GetDeadbandLeftX(double deadband) const {
+  return frc::ApplyDeadband(GetLeftX(), deadband, 1.0);
+}
+
 double XboxController::GetRightX() const {
   return GetRawAxis(Axis::kRightX);
+}
+
+double XboxController::GetDeadbandRightX(double deadband) const {
+  return frc::ApplyDeadband(GetRightX(), deadband, 1.0);
 }
 
 double XboxController::GetLeftY() const {
   return GetRawAxis(Axis::kLeftY);
 }
 
+double XboxController::GetDeadbandLeftY(double deadband) const {
+    return frc::ApplyDeadband(GetLeftY(), deadband, 1.0);
+}
+
 double XboxController::GetRightY() const {
   return GetRawAxis(Axis::kRightY);
+}
+
+double XboxController::GetDeadbandRightY(double deadband) const {
+    return frc::ApplyDeadband(GetRightY(), deadband, 1.0);
 }
 
 double XboxController::GetLeftTriggerAxis() const {

--- a/wpilibc/src/main/native/cpp/XboxController.cpp
+++ b/wpilibc/src/main/native/cpp/XboxController.cpp
@@ -4,11 +4,11 @@
 
 #include "frc/XboxController.h"
 
+#include <frc/MathUtil.h>
+
 #include <hal/FRCUsageReporting.h>
 
 #include "frc/event/BooleanEvent.h"
-
-#include <frc/MathUtil.h>
 
 using namespace frc;
 
@@ -37,7 +37,7 @@ double XboxController::GetLeftY() const {
 }
 
 double XboxController::GetDeadbandLeftY(double deadband) const {
-    return frc::ApplyDeadband(GetLeftY(), deadband, 1.0);
+  return frc::ApplyDeadband(GetLeftY(), deadband, 1.0);
 }
 
 double XboxController::GetRightY() const {
@@ -45,7 +45,7 @@ double XboxController::GetRightY() const {
 }
 
 double XboxController::GetDeadbandRightY(double deadband) const {
-    return frc::ApplyDeadband(GetRightY(), deadband, 1.0);
+  return frc::ApplyDeadband(GetRightY(), deadband, 1.0);
 }
 
 double XboxController::GetLeftTriggerAxis() const {

--- a/wpilibc/src/main/native/include/frc/Joystick.h
+++ b/wpilibc/src/main/native/include/frc/Joystick.h
@@ -20,6 +20,8 @@ namespace frc {
  */
 class Joystick : public GenericHID {
  public:
+ static constexpr double kDefaultDeadband = 0.1;
+
   static constexpr int kDefaultXChannel = 0;
   static constexpr int kDefaultYChannel = 1;
   static constexpr int kDefaultZChannel = 2;
@@ -122,6 +124,15 @@ class Joystick : public GenericHID {
   double GetX() const;
 
   /**
+   * Get the deadband checked X value of the joystick. This depends on the mapping of the joystick connected to the
+   * current port. This value is already scaled if it is greater than the deadband values.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked X value of the joystick.
+   */
+  double GetDeadbandX(double deadband = kDefaultDeadband) const;
+
+  /**
    * Get the Y value of the current joystick.
    *
    * This depends on the mapping of the joystick connected to the current port.
@@ -129,11 +140,29 @@ class Joystick : public GenericHID {
   double GetY() const;
 
   /**
+   * Get the deadband checked Y value of the joystick. This depends on the mapping of the joystick connected to the
+   * current port. This value is already scaled if it is greater than the deadband values.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked Y value of the joystick.
+   */
+  double GetDeadbandY(double deadband = kDefaultDeadband) const;
+
+  /**
    * Get the Z value of the current joystick.
    *
    * This depends on the mapping of the joystick connected to the current port.
    */
   double GetZ() const;
+
+  /**
+   * Get the deadband checked Z value of the joystick. This depends on the mapping of the joystick connected to the
+   * current port. This value is already scaled if it is greater than the deadband values.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked Z value of the joystick.
+   */
+  double GetDeadbandZ(double deadband = kDefaultDeadband) const;
 
   /**
    * Get the twist value of the current joystick.

--- a/wpilibc/src/main/native/include/frc/Joystick.h
+++ b/wpilibc/src/main/native/include/frc/Joystick.h
@@ -20,7 +20,7 @@ namespace frc {
  */
 class Joystick : public GenericHID {
  public:
- static constexpr double kDefaultDeadband = 0.1;
+  static constexpr double kDefaultDeadband = 0.1;
 
   static constexpr int kDefaultXChannel = 0;
   static constexpr int kDefaultYChannel = 1;
@@ -124,8 +124,9 @@ class Joystick : public GenericHID {
   double GetX() const;
 
   /**
-   * Get the deadband checked X value of the joystick. This depends on the mapping of the joystick connected to the
-   * current port. This value is already scaled if it is greater than the deadband values.
+   * Get the deadband checked X value of the joystick. This depends on the
+   * mapping of the joystick connected to the current port. This value is
+   * already scaled if it is greater than the deadband values.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked X value of the joystick.
@@ -140,8 +141,9 @@ class Joystick : public GenericHID {
   double GetY() const;
 
   /**
-   * Get the deadband checked Y value of the joystick. This depends on the mapping of the joystick connected to the
-   * current port. This value is already scaled if it is greater than the deadband values.
+   * Get the deadband checked Y value of the joystick. This depends on the
+   * mapping of the joystick connected to the current port. This value is
+   * already scaled if it is greater than the deadband values.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked Y value of the joystick.
@@ -156,8 +158,9 @@ class Joystick : public GenericHID {
   double GetZ() const;
 
   /**
-   * Get the deadband checked Z value of the joystick. This depends on the mapping of the joystick connected to the
-   * current port. This value is already scaled if it is greater than the deadband values.
+   * Get the deadband checked Z value of the joystick. This depends on the
+   * mapping of the joystick connected to the current port. This value is
+   * already scaled if it is greater than the deadband values.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked Z value of the joystick.

--- a/wpilibc/src/main/native/include/frc/PS4Controller.h
+++ b/wpilibc/src/main/native/include/frc/PS4Controller.h
@@ -41,8 +41,9 @@ class PS4Controller : public GenericHID {
   double GetLeftX() const;
 
   /**
-   * Check the value of the X axis value of left side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband.
+   * Check the value of the X axis value of left side of the controller against
+   * the provided deadband value. The value returned from the axis is already
+   * scaled if greater than the deadband.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked axis value.
@@ -55,8 +56,9 @@ class PS4Controller : public GenericHID {
   double GetRightX() const;
 
   /**
-   * Check the value of the X axis value of right side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband.
+   * Check the value of the X axis value of right side of the controller against
+   * the provided deadband value. The value returned from the axis is already
+   * scaled if greater than the deadband.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked axis value.
@@ -68,13 +70,14 @@ class PS4Controller : public GenericHID {
    */
   double GetLeftY() const;
 
-    /**
-     * Check the value of the Y axis value of left side of the controller against the provided deadband value.
-     * The value returned from the axis is already scaled if greater than the deadband.
-     *
-     * @param deadband range around zero deadband value.
-     * @return The deadband checked axis value.
-     */
+  /**
+   * Check the value of the Y axis value of left side of the controller against
+   * the provided deadband value. The value returned from the axis is already
+   * scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
   double GetDeadbandLeftY(double deadband = kDefaultDeadband) const;
 
   /**
@@ -82,13 +85,14 @@ class PS4Controller : public GenericHID {
    */
   double GetRightY() const;
 
-    /**
-     * Check the value of the Y axis value of right side of the controller against the provided deadband value.
-     * The value returned from the axis is already scaled if greater than the deadband.
-     *
-     * @param deadband range around zero deadband value.
-     * @return The deadband checked axis value.
-     */
+  /**
+   * Check the value of the Y axis value of right side of the controller against
+   * the provided deadband value. The value returned from the axis is already
+   * scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
   double GetDeadbandRightY(double deadband = kDefaultDeadband) const;
 
   /**

--- a/wpilibc/src/main/native/include/frc/PS4Controller.h
+++ b/wpilibc/src/main/native/include/frc/PS4Controller.h
@@ -18,6 +18,8 @@ namespace frc {
  */
 class PS4Controller : public GenericHID {
  public:
+  static constexpr double kDefaultDeadband = 0.05;
+
   /**
    * Construct an instance of an PS4 controller.
    *
@@ -35,31 +37,59 @@ class PS4Controller : public GenericHID {
 
   /**
    * Get the X axis value of left side of the controller.
-   *
-   * @return the axis value.
    */
   double GetLeftX() const;
 
   /**
-   * Get the X axis value of right side of the controller.
+   * Check the value of the X axis value of left side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband.
    *
-   * @return the axis value.
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
+  double GetDeadbandLeftX(double deadband = kDefaultDeadband) const;
+
+  /**
+   * Get the X axis value of right side of the controller.
    */
   double GetRightX() const;
 
   /**
-   * Get the Y axis value of left side of the controller.
+   * Check the value of the X axis value of right side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband.
    *
-   * @return the axis value.
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
+  double GetDeadbandRightX(double deadband = kDefaultDeadband) const;
+
+  /**
+   * Get the Y axis value of left side of the controller.
    */
   double GetLeftY() const;
 
+    /**
+     * Check the value of the Y axis value of left side of the controller against the provided deadband value.
+     * The value returned from the axis is already scaled if greater than the deadband.
+     *
+     * @param deadband range around zero deadband value.
+     * @return The deadband checked axis value.
+     */
+  double GetDeadbandLeftY(double deadband = kDefaultDeadband) const;
+
   /**
    * Get the Y axis value of right side of the controller.
-   *
-   * @return the axis value.
    */
   double GetRightY() const;
+
+    /**
+     * Check the value of the Y axis value of right side of the controller against the provided deadband value.
+     * The value returned from the axis is already scaled if greater than the deadband.
+     *
+     * @param deadband range around zero deadband value.
+     * @return The deadband checked axis value.
+     */
+  double GetDeadbandRightY(double deadband = kDefaultDeadband) const;
 
   /**
    * Get the L2 axis value of the controller. Note that this axis is bound to

--- a/wpilibc/src/main/native/include/frc/XboxController.h
+++ b/wpilibc/src/main/native/include/frc/XboxController.h
@@ -42,8 +42,9 @@ class XboxController : public GenericHID {
   double GetLeftX() const;
 
   /**
-   * Check the value of the X axis value of left side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband.
+   * Check the value of the X axis value of left side of the controller against
+   * the provided deadband value. The value returned from the axis is already
+   * scaled if greater than the deadband.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked axis value.
@@ -56,8 +57,9 @@ class XboxController : public GenericHID {
   double GetRightX() const;
 
   /**
-   * Check the value of the X axis value of right side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband.
+   * Check the value of the X axis value of right side of the controller against
+   * the provided deadband value. The value returned from the axis is already
+   * scaled if greater than the deadband.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked axis value.
@@ -69,13 +71,14 @@ class XboxController : public GenericHID {
    */
   double GetLeftY() const;
 
-    /**
-     * Check the value of the Y axis value of left side of the controller against the provided deadband value.
-     * The value returned from the axis is already scaled if greater than the deadband.
-     *
-     * @param deadband range around zero deadband value.
-     * @return The deadband checked axis value.
-     */
+  /**
+   * Check the value of the Y axis value of left side of the controller against
+   * the provided deadband value. The value returned from the axis is already
+   * scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
   double GetDeadbandLeftY(double deadband = kDefaultDeadband) const;
 
   /**
@@ -83,13 +86,14 @@ class XboxController : public GenericHID {
    */
   double GetRightY() const;
 
-    /**
-     * Check the value of the Y axis value of right side of the controller against the provided deadband value.
-     * The value returned from the axis is already scaled if greater than the deadband.
-     *
-     * @param deadband range around zero deadband value.
-     * @return The deadband checked axis value.
-     */
+  /**
+   * Check the value of the Y axis value of right side of the controller against
+   * the provided deadband value. The value returned from the axis is already
+   * scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
   double GetDeadbandRightY(double deadband = kDefaultDeadband) const;
 
   /**

--- a/wpilibc/src/main/native/include/frc/XboxController.h
+++ b/wpilibc/src/main/native/include/frc/XboxController.h
@@ -19,6 +19,8 @@ namespace frc {
  */
 class XboxController : public GenericHID {
  public:
+  static constexpr double kDefaultDeadband = 0.05;
+
   /**
    * Construct an instance of an Xbox controller.
    *
@@ -40,19 +42,55 @@ class XboxController : public GenericHID {
   double GetLeftX() const;
 
   /**
+   * Check the value of the X axis value of left side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
+  double GetDeadbandLeftX(double deadband = kDefaultDeadband) const;
+
+  /**
    * Get the X axis value of right side of the controller.
    */
   double GetRightX() const;
+
+  /**
+   * Check the value of the X axis value of right side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
+  double GetDeadbandRightX(double deadband = kDefaultDeadband) const;
 
   /**
    * Get the Y axis value of left side of the controller.
    */
   double GetLeftY() const;
 
+    /**
+     * Check the value of the Y axis value of left side of the controller against the provided deadband value.
+     * The value returned from the axis is already scaled if greater than the deadband.
+     *
+     * @param deadband range around zero deadband value.
+     * @return The deadband checked axis value.
+     */
+  double GetDeadbandLeftY(double deadband = kDefaultDeadband) const;
+
   /**
    * Get the Y axis value of right side of the controller.
    */
   double GetRightY() const;
+
+    /**
+     * Check the value of the Y axis value of right side of the controller against the provided deadband value.
+     * The value returned from the axis is already scaled if greater than the deadband.
+     *
+     * @param deadband range around zero deadband value.
+     * @return The deadband checked axis value.
+     */
+  double GetDeadbandRightY(double deadband = kDefaultDeadband) const;
 
   /**
    * Get the left trigger (LT) axis value of the controller. Note that this axis

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/GenericHID.java
@@ -26,6 +26,7 @@ public class GenericHID {
     kBothRumble
   }
 
+  /** Represents the different types of HID devices */
   public enum HIDType {
     kUnknown(-1),
     kXInputUnknown(0),

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
@@ -173,8 +173,9 @@ public class Joystick extends GenericHID {
   }
 
   /**
-   * Get the deadband checked X value of the joystick. This depends on the mapping of the joystick connected to the
-   * current port. This value is already scaled if it is greater than the deadband values.
+   * Get the deadband checked X value of the joystick. This depends on the mapping of the joystick
+   * connected to the current port. This value is already scaled if it is greater than the deadband
+   * values.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked X value of the joystick.
@@ -184,8 +185,9 @@ public class Joystick extends GenericHID {
   }
 
   /**
-   * Get the deadband checked X value of the joystick. This depends on the mapping of the joystick connected to the
-   * current port. This value is already scaled if it is greater than the deadband values. Uses the default deadband value {@link Joystick#kDefaultDeadband}.
+   * Get the deadband checked X value of the joystick. This depends on the mapping of the joystick
+   * connected to the current port. This value is already scaled if it is greater than the deadband
+   * values. Uses the default deadband value {@link Joystick#kDefaultDeadband}.
    *
    * @return The deadband checked X value of the joystick.
    */
@@ -204,8 +206,9 @@ public class Joystick extends GenericHID {
   }
 
   /**
-   * Get the deadband checked Y value of the joystick. This depends on the mapping of the joystick connected to the
-   * current port. This value is already scaled if it is greater than the deadband values.
+   * Get the deadband checked Y value of the joystick. This depends on the mapping of the joystick
+   * connected to the current port. This value is already scaled if it is greater than the deadband
+   * values.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked Y value of the joystick.
@@ -215,8 +218,9 @@ public class Joystick extends GenericHID {
   }
 
   /**
-   * Get the deadband checked Y value of the joystick. This depends on the mapping of the joystick connected to the
-   * current port. This value is already scaled if it is greater than the deadband values. Uses the default deadband value {@link Joystick#kDefaultDeadband}.
+   * Get the deadband checked Y value of the joystick. This depends on the mapping of the joystick
+   * connected to the current port. This value is already scaled if it is greater than the deadband
+   * values. Uses the default deadband value {@link Joystick#kDefaultDeadband}.
    *
    * @return The deadband checked Y value of the joystick.
    */
@@ -234,8 +238,9 @@ public class Joystick extends GenericHID {
   }
 
   /**
-   * Get the deadband checked Z value of the joystick. This depends on the mapping of the joystick connected to the
-   * current port. This value is already scaled if it is greater than the deadband values.
+   * Get the deadband checked Z value of the joystick. This depends on the mapping of the joystick
+   * connected to the current port. This value is already scaled if it is greater than the deadband
+   * values.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked Z value of the joystick.
@@ -245,8 +250,9 @@ public class Joystick extends GenericHID {
   }
 
   /**
-   * Get the deadband checked Z value of the joystick. This depends on the mapping of the joystick connected to the
-   * current port. This value is already scaled if it is greater than the deadband values. Uses the default deadband value {@link Joystick#kDefaultDeadband}.
+   * Get the deadband checked Z value of the joystick. This depends on the mapping of the joystick
+   * connected to the current port. This value is already scaled if it is greater than the deadband
+   * values. Uses the default deadband value {@link Joystick#kDefaultDeadband}.
    *
    * @return The deadband checked Z value of the joystick.
    */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Joystick.java
@@ -6,6 +6,7 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.event.BooleanEvent;
 import edu.wpi.first.wpilibj.event.EventLoop;
 
@@ -17,6 +18,8 @@ import edu.wpi.first.wpilibj.event.EventLoop;
  * and the mapping of ports to hardware buttons depends on the code in the Driver Station.
  */
 public class Joystick extends GenericHID {
+  public static final double kDefaultDeadband = 0.1;
+
   public static final byte kDefaultXChannel = 0;
   public static final byte kDefaultYChannel = 1;
   public static final byte kDefaultZChannel = 2;
@@ -170,6 +173,27 @@ public class Joystick extends GenericHID {
   }
 
   /**
+   * Get the deadband checked X value of the joystick. This depends on the mapping of the joystick connected to the
+   * current port. This value is already scaled if it is greater than the deadband values.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked X value of the joystick.
+   */
+  public double getDeadbandX(double deadband) {
+    return MathUtil.applyDeadband(getX(), deadband, 1);
+  }
+
+  /**
+   * Get the deadband checked X value of the joystick. This depends on the mapping of the joystick connected to the
+   * current port. This value is already scaled if it is greater than the deadband values. Uses the default deadband value {@link Joystick#kDefaultDeadband}.
+   *
+   * @return The deadband checked X value of the joystick.
+   */
+  public double getDeadbandX() {
+    return getDeadbandX(kDefaultDeadband);
+  }
+
+  /**
    * Get the Y value of the joystick. This depends on the mapping of the joystick connected to the
    * current port.
    *
@@ -180,12 +204,54 @@ public class Joystick extends GenericHID {
   }
 
   /**
+   * Get the deadband checked Y value of the joystick. This depends on the mapping of the joystick connected to the
+   * current port. This value is already scaled if it is greater than the deadband values.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked Y value of the joystick.
+   */
+  public double getDeadbandY(double deadband) {
+    return MathUtil.applyDeadband(getY(), deadband, 1);
+  }
+
+  /**
+   * Get the deadband checked Y value of the joystick. This depends on the mapping of the joystick connected to the
+   * current port. This value is already scaled if it is greater than the deadband values. Uses the default deadband value {@link Joystick#kDefaultDeadband}.
+   *
+   * @return The deadband checked Y value of the joystick.
+   */
+  public double getDeadbandY() {
+    return getDeadbandY(kDefaultDeadband);
+  }
+
+  /**
    * Get the z position of the HID.
    *
    * @return the z position
    */
   public double getZ() {
     return getRawAxis(m_axes[AxisType.kZ.value]);
+  }
+
+  /**
+   * Get the deadband checked Z value of the joystick. This depends on the mapping of the joystick connected to the
+   * current port. This value is already scaled if it is greater than the deadband values.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked Z value of the joystick.
+   */
+  public double getDeadbandZ(double deadband) {
+    return MathUtil.applyDeadband(getZ(), deadband, 1);
+  }
+
+  /**
+   * Get the deadband checked Z value of the joystick. This depends on the mapping of the joystick connected to the
+   * current port. This value is already scaled if it is greater than the deadband values. Uses the default deadband value {@link Joystick#kDefaultDeadband}.
+   *
+   * @return The deadband checked Z value of the joystick.
+   */
+  public double getDeadbandZ() {
+    return getDeadbandZ(kDefaultDeadband);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PS4Controller.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PS4Controller.java
@@ -114,8 +114,9 @@ public class PS4Controller extends GenericHID {
   }
 
   /**
-   * Check the value of the X axis value of left side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband.
+   * Check the value of the X axis value of left side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked axis value.
@@ -125,8 +126,9 @@ public class PS4Controller extends GenericHID {
   }
 
   /**
-   * Check the value of the X axis value of left side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link PS4Controller#kDefaultDeadband}
+   * Check the value of the X axis value of left side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband. Uses the default deadband value {@link PS4Controller#kDefaultDeadband}
    *
    * @return The deadband checked axis value.
    */
@@ -144,8 +146,9 @@ public class PS4Controller extends GenericHID {
   }
 
   /**
-   * Check the value of the X axis value of right side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband.
+   * Check the value of the X axis value of right side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked axis value.
@@ -155,8 +158,9 @@ public class PS4Controller extends GenericHID {
   }
 
   /**
-   * Check the value of the X axis value of right side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link PS4Controller#kDefaultDeadband}
+   * Check the value of the X axis value of right side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband. Uses the default deadband value {@link PS4Controller#kDefaultDeadband}
    *
    * @return The deadband checked axis value.
    */
@@ -174,8 +178,9 @@ public class PS4Controller extends GenericHID {
   }
 
   /**
-   * Check the value of the Y axis value of left side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband.
+   * Check the value of the Y axis value of left side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked axis value.
@@ -185,8 +190,9 @@ public class PS4Controller extends GenericHID {
   }
 
   /**
-   * Check the value of the Y axis value of left side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link PS4Controller#kDefaultDeadband}
+   * Check the value of the Y axis value of left side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband. Uses the default deadband value {@link PS4Controller#kDefaultDeadband}
    *
    * @return The deadband checked axis value.
    */
@@ -204,8 +210,9 @@ public class PS4Controller extends GenericHID {
   }
 
   /**
-   * Check the value of the Y axis value of right side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband.
+   * Check the value of the Y axis value of right side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked axis value.
@@ -215,8 +222,9 @@ public class PS4Controller extends GenericHID {
   }
 
   /**
-   * Check the value of the Y axis value of right side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link PS4Controller#kDefaultDeadband}
+   * Check the value of the Y axis value of right side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband. Uses the default deadband value {@link PS4Controller#kDefaultDeadband}
    *
    * @return The deadband checked axis value.
    */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PS4Controller.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PS4Controller.java
@@ -6,6 +6,7 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.event.BooleanEvent;
 import edu.wpi.first.wpilibj.event.EventLoop;
 
@@ -17,6 +18,8 @@ import edu.wpi.first.wpilibj.event.EventLoop;
  * and the mapping of ports to hardware buttons depends on the code in the Driver Station.
  */
 public class PS4Controller extends GenericHID {
+  public static final double kDefaultDeadband = 0.05;
+
   /**
    * Construct an instance of a device.
    *
@@ -104,37 +107,121 @@ public class PS4Controller extends GenericHID {
   /**
    * Get the X axis value of left side of the controller.
    *
-   * @return the axis value.
+   * @return The axis value.
    */
   public double getLeftX() {
-    return getRawAxis(Axis.kLeftX.value);
+    return getRawAxis(XboxController.Axis.kLeftX.value);
+  }
+
+  /**
+   * Check the value of the X axis value of left side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandLeftX(double deadband) {
+    return MathUtil.applyDeadband(getLeftX(), deadband, 1);
+  }
+
+  /**
+   * Check the value of the X axis value of left side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link PS4Controller#kDefaultDeadband}
+   *
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandLeftX() {
+    return getDeadbandLeftX(kDefaultDeadband);
   }
 
   /**
    * Get the X axis value of right side of the controller.
    *
-   * @return the axis value.
+   * @return The axis value.
    */
   public double getRightX() {
-    return getRawAxis(Axis.kRightX.value);
+    return getRawAxis(XboxController.Axis.kRightX.value);
+  }
+
+  /**
+   * Check the value of the X axis value of right side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandRightX(double deadband) {
+    return MathUtil.applyDeadband(getRightX(), deadband, 1);
+  }
+
+  /**
+   * Check the value of the X axis value of right side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link PS4Controller#kDefaultDeadband}
+   *
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandRightX() {
+    return getDeadbandRightX(kDefaultDeadband);
   }
 
   /**
    * Get the Y axis value of left side of the controller.
    *
-   * @return the axis value.
+   * @return The axis value.
    */
   public double getLeftY() {
-    return getRawAxis(Axis.kLeftY.value);
+    return getRawAxis(XboxController.Axis.kLeftY.value);
+  }
+
+  /**
+   * Check the value of the Y axis value of left side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandLeftY(double deadband) {
+    return MathUtil.applyDeadband(getLeftY(), deadband, 1);
+  }
+
+  /**
+   * Check the value of the Y axis value of left side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link PS4Controller#kDefaultDeadband}
+   *
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandLeftY() {
+    return getDeadbandLeftY(kDefaultDeadband);
   }
 
   /**
    * Get the Y axis value of right side of the controller.
    *
-   * @return the axis value.
+   * @return The axis value.
    */
   public double getRightY() {
-    return getRawAxis(Axis.kRightY.value);
+    return getRawAxis(XboxController.Axis.kRightY.value);
+  }
+
+  /**
+   * Check the value of the Y axis value of right side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandRightY(double deadband) {
+    return MathUtil.applyDeadband(getRightY(), deadband, 1);
+  }
+
+  /**
+   * Check the value of the Y axis value of right side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link PS4Controller#kDefaultDeadband}
+   *
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandRightY() {
+    return getDeadbandRightY(kDefaultDeadband);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/XboxController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/XboxController.java
@@ -111,8 +111,9 @@ public class XboxController extends GenericHID {
   }
 
   /**
-   * Check the value of the X axis value of left side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband.
+   * Check the value of the X axis value of left side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked axis value.
@@ -122,8 +123,9 @@ public class XboxController extends GenericHID {
   }
 
   /**
-   * Check the value of the X axis value of left side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link XboxController#kDefaultDeadband}
+   * Check the value of the X axis value of left side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband. Uses the default deadband value {@link XboxController#kDefaultDeadband}
    *
    * @return The deadband checked axis value.
    */
@@ -141,8 +143,9 @@ public class XboxController extends GenericHID {
   }
 
   /**
-   * Check the value of the X axis value of right side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband.
+   * Check the value of the X axis value of right side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked axis value.
@@ -152,8 +155,9 @@ public class XboxController extends GenericHID {
   }
 
   /**
-   * Check the value of the X axis value of right side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link XboxController#kDefaultDeadband}
+   * Check the value of the X axis value of right side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband. Uses the default deadband value {@link XboxController#kDefaultDeadband}
    *
    * @return The deadband checked axis value.
    */
@@ -171,8 +175,9 @@ public class XboxController extends GenericHID {
   }
 
   /**
-   * Check the value of the Y axis value of left side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband.
+   * Check the value of the Y axis value of left side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked axis value.
@@ -182,8 +187,9 @@ public class XboxController extends GenericHID {
   }
 
   /**
-   * Check the value of the Y axis value of left side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link XboxController#kDefaultDeadband}
+   * Check the value of the Y axis value of left side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband. Uses the default deadband value {@link XboxController#kDefaultDeadband}
    *
    * @return The deadband checked axis value.
    */
@@ -201,8 +207,9 @@ public class XboxController extends GenericHID {
   }
 
   /**
-   * Check the value of the Y axis value of right side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband.
+   * Check the value of the Y axis value of right side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband.
    *
    * @param deadband range around zero deadband value.
    * @return The deadband checked axis value.
@@ -212,8 +219,9 @@ public class XboxController extends GenericHID {
   }
 
   /**
-   * Check the value of the Y axis value of right side of the controller against the provided deadband value.
-   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link XboxController#kDefaultDeadband}
+   * Check the value of the Y axis value of right side of the controller against the provided
+   * deadband value. The value returned from the axis is already scaled if greater than the
+   * deadband. Uses the default deadband value {@link XboxController#kDefaultDeadband}
    *
    * @return The deadband checked axis value.
    */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/XboxController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/XboxController.java
@@ -6,6 +6,7 @@ package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.event.BooleanEvent;
 import edu.wpi.first.wpilibj.event.EventLoop;
 
@@ -17,6 +18,8 @@ import edu.wpi.first.wpilibj.event.EventLoop;
  * and the mapping of ports to hardware buttons depends on the code in the Driver Station.
  */
 public class XboxController extends GenericHID {
+  public static final double kDefaultDeadband = 0.05;
+
   /** Represents a digital button on an XboxController. */
   public enum Button {
     kLeftBumper(5),
@@ -108,12 +111,54 @@ public class XboxController extends GenericHID {
   }
 
   /**
+   * Check the value of the X axis value of left side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandLeftX(double deadband) {
+    return MathUtil.applyDeadband(getLeftX(), deadband, 1);
+  }
+
+  /**
+   * Check the value of the X axis value of left side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link XboxController#kDefaultDeadband}
+   *
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandLeftX() {
+    return getDeadbandLeftX(kDefaultDeadband);
+  }
+
+  /**
    * Get the X axis value of right side of the controller.
    *
    * @return The axis value.
    */
   public double getRightX() {
     return getRawAxis(Axis.kRightX.value);
+  }
+
+  /**
+   * Check the value of the X axis value of right side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandRightX(double deadband) {
+    return MathUtil.applyDeadband(getRightX(), deadband, 1);
+  }
+
+  /**
+   * Check the value of the X axis value of right side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link XboxController#kDefaultDeadband}
+   *
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandRightX() {
+    return getDeadbandRightX(kDefaultDeadband);
   }
 
   /**
@@ -126,12 +171,54 @@ public class XboxController extends GenericHID {
   }
 
   /**
+   * Check the value of the Y axis value of left side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandLeftY(double deadband) {
+    return MathUtil.applyDeadband(getLeftY(), deadband, 1);
+  }
+
+  /**
+   * Check the value of the Y axis value of left side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link XboxController#kDefaultDeadband}
+   *
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandLeftY() {
+    return getDeadbandLeftY(kDefaultDeadband);
+  }
+
+  /**
    * Get the Y axis value of right side of the controller.
    *
    * @return The axis value.
    */
   public double getRightY() {
     return getRawAxis(Axis.kRightY.value);
+  }
+
+  /**
+   * Check the value of the Y axis value of right side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband.
+   *
+   * @param deadband range around zero deadband value.
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandRightY(double deadband) {
+    return MathUtil.applyDeadband(getRightY(), deadband, 1);
+  }
+
+  /**
+   * Check the value of the Y axis value of right side of the controller against the provided deadband value.
+   * The value returned from the axis is already scaled if greater than the deadband. Uses the default deadband value {@link XboxController#kDefaultDeadband}
+   *
+   * @return The deadband checked axis value.
+   */
+  public double getDeadbandRightY() {
+    return getDeadbandRightY(kDefaultDeadband);
   }
 
   /**


### PR DESCRIPTION
Adds method(s) to the HID classes for Joystick, XboxControllers, and PS4Controllers to get the Axis values if they pass a deadband value. Checks using the `MathUtil.checkDeadband()` method.

Still need to add methods to the Command classes

- [ ] CommandJoystick
- [ ] CommandXboxController
- [ ] CommandPS4Controller