### PR TITLE
[ntcore] Special-case default timestamps

### DIFF
--- a/ntcore/src/main/native/cpp/LocalStorage.cpp
+++ b/ntcore/src/main/native/cpp/LocalStorage.cpp
@@ -501,7 +501,8 @@ bool LSImpl::SetValue(TopicData* topic, const Value& value,
   if (topic->type != NT_UNASSIGNED && topic->type != value.type()) {
     return false;
   }
-  if (!topic->lastValue || value.time() >= topic->lastValue.time()) {
+  if (!topic->lastValue || topic->lastValue.time() == 0 ||
+      value.time() >= topic->lastValue.time()) {
     // TODO: notify option even if older value
     topic->type = value.type();
     topic->lastValue = value;

--- a/ntcore/src/main/native/cpp/net/ClientImpl.cpp
+++ b/ntcore/src/main/native/cpp/net/ClientImpl.cpp
@@ -268,6 +268,10 @@ void CImpl::SendValues(uint64_t curTimeMs, bool flush) {
         int64_t time = val.time();
         if (time != 0) {
           time += m_serverTimeOffsetUs;
+          // make sure resultant time isn't exactly 0
+          if (time == 0) {
+            time = 1;
+          }
         }
         WireEncodeBinary(writer.Add(), Handle{pub->handle}.GetIndex(), time,
                          val);

--- a/ntcore/src/main/native/cpp/net/ServerImpl.cpp
+++ b/ntcore/src/main/native/cpp/net/ServerImpl.cpp
@@ -2129,7 +2129,7 @@ void SImpl::SetFlags(ClientData* client, TopicData* topic, unsigned int flags) {
 void SImpl::SetValue(ClientData* client, TopicData* topic, const Value& value) {
   // update retained value if from same client or timestamp newer
   if (!topic->lastValue || topic->lastValueClient == client ||
-      value.time() >= topic->lastValue.time()) {
+      topic->lastValue.time() == 0 || value.time() >= topic->lastValue.time()) {
     DEBUG4("updating '{}' last value (time was {} is {})", topic->name,
            topic->lastValue.time(), value.time());
     topic->lastValue = value;


### PR DESCRIPTION
Previously, a setDefault() on the server could override a client doing a real set() if the time offset between client and server was negative, resulting in a negative timestamp from the client.  This is a not uncommon situation with robot code, as the robot code always starts at time 0, so any clients that set values earlier (in real time) would have negative timestamps.

Also improve special casing of 0 in the transmit side to make sure a normal timestamp will never get sent as 0.

Fixes #5002.

TODO:
- [x] Add tests