### PR TITLE
[ntcore] Use full handle when subscribing

### DIFF
--- a/ntcore/src/main/native/cpp/net/WireEncoder.cpp
+++ b/ntcore/src/main/native/cpp/net/WireEncoder.cpp
@@ -142,10 +142,9 @@ bool nt::net::WireEncodeText(wpi::raw_ostream& os, const ClientMessage& msg) {
   } else if (auto m = std::get_if<SetPropertiesMsg>(&msg.contents)) {
     WireEncodeSetProperties(os, m->name, m->update);
   } else if (auto m = std::get_if<SubscribeMsg>(&msg.contents)) {
-    WireEncodeSubscribe(os, Handle{m->subHandle}.GetIndex(), m->topicNames,
-                        m->options);
+    WireEncodeSubscribe(os, m->subHandle, m->topicNames, m->options);
   } else if (auto m = std::get_if<UnsubscribeMsg>(&msg.contents)) {
-    WireEncodeUnsubscribe(os, Handle{m->subHandle}.GetIndex());
+    WireEncodeUnsubscribe(os, m->subHandle);
   } else {
     return false;
   }

--- a/ntcore/src/test/native/cpp/net/WireEncoderTest.cpp
+++ b/ntcore/src/test/native/cpp/net/WireEncoderTest.cpp
@@ -172,14 +172,15 @@ TEST_F(WireEncoderTextTest, MessageSubscribe) {
   ASSERT_TRUE(net::WireEncodeText(os, msg));
   ASSERT_EQ(os.str(),
             "{\"method\":\"subscribe\",\"params\":{"
-            "\"options\":{},\"topics\":[\"a\",\"b\"],\"subuid\":5}}");
+            "\"options\":{},\"topics\":[\"a\",\"b\"],\"subuid\":402653189}}");
 }
 
 TEST_F(WireEncoderTextTest, MessageUnsubscribe) {
   net::ClientMessage msg{
       net::UnsubscribeMsg{Handle{0, 5, Handle::kSubscriber}}};
   ASSERT_TRUE(net::WireEncodeText(os, msg));
-  ASSERT_EQ(os.str(), "{\"method\":\"unsubscribe\",\"params\":{\"subuid\":5}}");
+  ASSERT_EQ(os.str(),
+            "{\"method\":\"unsubscribe\",\"params\":{\"subuid\":402653189}}");
 }
 
 TEST_F(WireEncoderTextTest, MessageAnnounce) {


### PR DESCRIPTION
Just using the index is insufficient because of Subscriber overlap with MultiSubscriber.