### PR TITLE
[wpiutil] MemoryBuffer: Fix GetMemoryBufferForStream

### DIFF
--- a/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/MemoryBuffer.cpp
+++ b/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/MemoryBuffer.cpp
@@ -237,16 +237,16 @@ static std::unique_ptr<WritableMemoryBuffer> GetMemoryBufferForStream(
 #endif
   // Read into Buffer until we hit EOF.
   do {
-    size_t size = buffer.size();
-    buffer.resize_for_overwrite(size + ChunkSize);
+    size_t prevSize = buffer.size();
+    buffer.resize_for_overwrite(prevSize + ChunkSize);
 #ifdef _WIN32
     if (!ReadFile(f, buffer.begin() + size, ChunkSize, &readBytes, nullptr)) {
       ec = mapWindowsError(GetLastError());
       return nullptr;
     }
 #else
-    readBytes =
-        sys::RetryAfterSignal(-1, ::read, f, buffer.begin() + size, ChunkSize);
+    readBytes = sys::RetryAfterSignal(-1, ::read, f, buffer.begin() + prevSize,
+                                      ChunkSize);
     if (readBytes == -1) {
       ec = std::error_code(errno, std::generic_category());
       return nullptr;

--- a/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/MemoryBuffer.cpp
+++ b/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/MemoryBuffer.cpp
@@ -240,7 +240,8 @@ static std::unique_ptr<WritableMemoryBuffer> GetMemoryBufferForStream(
     size_t prevSize = buffer.size();
     buffer.resize_for_overwrite(prevSize + ChunkSize);
 #ifdef _WIN32
-    if (!ReadFile(f, buffer.begin() + size, ChunkSize, &readBytes, nullptr)) {
+    if (!ReadFile(f, buffer.begin() + prevSize, ChunkSize, &readBytes,
+                  nullptr)) {
       ec = mapWindowsError(GetLastError());
       return nullptr;
     }

--- a/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/MemoryBuffer.cpp
+++ b/wpiutil/src/main/native/thirdparty/llvm/cpp/llvm/MemoryBuffer.cpp
@@ -237,14 +237,16 @@ static std::unique_ptr<WritableMemoryBuffer> GetMemoryBufferForStream(
 #endif
   // Read into Buffer until we hit EOF.
   do {
-    buffer.resize_for_overwrite(buffer.size() + ChunkSize);
+    size_t size = buffer.size();
+    buffer.resize_for_overwrite(size + ChunkSize);
 #ifdef _WIN32
-    if (!ReadFile(f, buffer.end(), ChunkSize, &readBytes, nullptr)) {
+    if (!ReadFile(f, buffer.begin() + size, ChunkSize, &readBytes, nullptr)) {
       ec = mapWindowsError(GetLastError());
       return nullptr;
     }
 #else
-    readBytes = sys::RetryAfterSignal(-1, ::read, f, buffer.end(), ChunkSize);
+    readBytes =
+        sys::RetryAfterSignal(-1, ::read, f, buffer.begin() + size, ChunkSize);
     if (readBytes == -1) {
       ec = std::error_code(errno, std::generic_category());
       return nullptr;


### PR DESCRIPTION
This would previously just write past the end of the buffer, smashing the stack.  It's only called in the case when a non-file or block device is used as the file.

Fixes #5016.