### PR TITLE
[ntcore] Add client disconnect function

### DIFF
--- a/ntcore/src/generate/java/NetworkTableInstance.java.jinja
+++ b/ntcore/src/generate/java/NetworkTableInstance.java.jinja
@@ -914,8 +914,6 @@ public final class NetworkTableInstance implements AutoCloseable {
   /**
    * Disconnects the client if it's running and connected. This will automatically start
    * reconnection attempts to the current server list.
-   *
-   * @param inst instance handle
    */
   public void disconnect() {
     NetworkTablesJNI.disconnect(m_handle);

--- a/ntcore/src/generate/java/NetworkTableInstance.java.jinja
+++ b/ntcore/src/generate/java/NetworkTableInstance.java.jinja
@@ -912,6 +912,16 @@ public final class NetworkTableInstance implements AutoCloseable {
   }
 
   /**
+   * Disconnects the client if it's running and connected. This will automatically start
+   * reconnection attempts to the current server list.
+   *
+   * @param inst instance handle
+   */
+  public void disconnect() {
+    NetworkTablesJNI.disconnect(m_handle);
+  }
+
+  /**
    * Starts requesting server address from Driver Station. This connects to the Driver Station
    * running on localhost to obtain the server IP address, and connects with the default port.
    */

--- a/ntcore/src/generate/java/NetworkTablesJNI.java.jinja
+++ b/ntcore/src/generate/java/NetworkTablesJNI.java.jinja
@@ -251,6 +251,8 @@ public final class NetworkTablesJNI {
 
   public static native void setServerTeam(int inst, int team, int port);
 
+  public static native void disconnect(int inst);
+
   public static native void startDSClient(int inst, int port);
 
   public static native void stopDSClient(int inst);

--- a/ntcore/src/main/native/cpp/INetworkClient.h
+++ b/ntcore/src/main/native/cpp/INetworkClient.h
@@ -18,6 +18,7 @@ class INetworkClient {
 
   virtual void SetServers(
       std::span<const std::pair<std::string, unsigned int>> servers) = 0;
+  virtual void Disconnect() = 0;
 
   virtual void StartDSClient(unsigned int port) = 0;
   virtual void StopDSClient() = 0;

--- a/ntcore/src/main/native/cpp/NetworkClient.cpp
+++ b/ntcore/src/main/native/cpp/NetworkClient.cpp
@@ -492,6 +492,11 @@ void NetworkClient::SetServers(
   m_impl->SetServers(servers, NT_DEFAULT_PORT4);
 }
 
+void NetworkClient::Disconnect() {
+  m_impl->m_loopRunner.ExecAsync(
+      [this](auto&) { m_impl->Disconnect("requested by application"); });
+}
+
 void NetworkClient::StartDSClient(unsigned int port) {
   m_impl->StartDSClient(port);
 }
@@ -533,6 +538,11 @@ NetworkClient3::~NetworkClient3() {
 void NetworkClient3::SetServers(
     std::span<const std::pair<std::string, unsigned int>> servers) {
   m_impl->SetServers(servers, NT_DEFAULT_PORT3);
+}
+
+void NetworkClient3::Disconnect() {
+  m_impl->m_loopRunner.ExecAsync(
+      [this](auto&) { m_impl->Disconnect("requested by application"); });
 }
 
 void NetworkClient3::StartDSClient(unsigned int port) {

--- a/ntcore/src/main/native/cpp/NetworkClient.h
+++ b/ntcore/src/main/native/cpp/NetworkClient.h
@@ -38,6 +38,7 @@ class NetworkClient final : public INetworkClient {
 
   void SetServers(
       std::span<const std::pair<std::string, unsigned int>> servers) final;
+  void Disconnect() final;
 
   void StartDSClient(unsigned int port) final;
   void StopDSClient() final;
@@ -59,6 +60,7 @@ class NetworkClient3 final : public INetworkClient {
 
   void SetServers(
       std::span<const std::pair<std::string, unsigned int>> servers) final;
+  void Disconnect() final;
 
   void StartDSClient(unsigned int port) final;
   void StopDSClient() final;

--- a/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
+++ b/ntcore/src/main/native/cpp/jni/NetworkTablesJNI.cpp
@@ -1300,6 +1300,18 @@ Java_edu_wpi_first_networktables_NetworkTablesJNI_setServerTeam
 
 /*
  * Class:     edu_wpi_first_networktables_NetworkTablesJNI
+ * Method:    disconnect
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_networktables_NetworkTablesJNI_disconnect
+  (JNIEnv* env, jclass, jint inst)
+{
+  nt::Disconnect(inst);
+}
+
+/*
+ * Class:     edu_wpi_first_networktables_NetworkTablesJNI
  * Method:    startDSClient
  * Signature: (II)V
  */

--- a/ntcore/src/main/native/cpp/ntcore_c.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_c.cpp
@@ -537,6 +537,10 @@ void NT_SetServerTeam(NT_Inst inst, unsigned int team, unsigned int port) {
   nt::SetServerTeam(inst, team, port);
 }
 
+void NT_Disconnect(NT_Inst inst) {
+  nt::Disconnect(inst);
+}
+
 void NT_StartDSClient(NT_Inst inst, unsigned int port) {
   nt::StartDSClient(inst, port);
 }

--- a/ntcore/src/main/native/cpp/ntcore_cpp.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_cpp.cpp
@@ -685,6 +685,14 @@ void SetServerTeam(NT_Inst inst, unsigned int team, unsigned int port) {
   }
 }
 
+void Disconnect(NT_Inst inst) {
+  if (auto ii = InstanceImpl::GetTyped(inst, Handle::kInstance)) {
+    if (auto client = ii->GetClient()) {
+      client->Disconnect();
+    }
+  }
+}
+
 void StartDSClient(NT_Inst inst, unsigned int port) {
   if (auto ii = InstanceImpl::GetTyped(inst, Handle::kInstance)) {
     if (auto client = ii->GetClient()) {

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
@@ -589,8 +589,6 @@ class NetworkTableInstance final {
   /**
    * Disconnects the client if it's running and connected. This will
    * automatically start reconnection attempts to the current server list.
-   *
-   * @param inst instance handle
    */
   void Disconnect();
 

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
@@ -587,6 +587,14 @@ class NetworkTableInstance final {
   void SetServerTeam(unsigned int team, unsigned int port = 0);
 
   /**
+   * Disconnects the client if it's running and connected. This will
+   * automatically start reconnection attempts to the current server list.
+   *
+   * @param inst instance handle
+   */
+  void Disconnect();
+
+  /**
    * Starts requesting server address from Driver Station.
    * This connects to the Driver Station running on localhost to obtain the
    * server IP address.

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
@@ -163,6 +163,10 @@ inline void NetworkTableInstance::SetServerTeam(unsigned int team,
   ::nt::SetServerTeam(m_handle, team, port);
 }
 
+inline void NetworkTableInstance::Disconnect() {
+  ::nt::Disconnect(m_handle);
+}
+
 inline void NetworkTableInstance::StartDSClient(unsigned int port) {
   ::nt::StartDSClient(m_handle, port);
 }

--- a/ntcore/src/main/native/include/ntcore_c.h
+++ b/ntcore/src/main/native/include/ntcore_c.h
@@ -1148,6 +1148,14 @@ void NT_SetServerMulti(NT_Inst inst, size_t count, const char** server_names,
 void NT_SetServerTeam(NT_Inst inst, unsigned int team, unsigned int port);
 
 /**
+ * Disconnects the client if it's running and connected. This will automatically
+ * start reconnection attempts to the current server list.
+ *
+ * @param inst instance handle
+ */
+void NT_Disconnect(NT_Inst inst);
+
+/**
  * Starts requesting server address from Driver Station.
  * This connects to the Driver Station running on localhost to obtain the
  * server IP address.

--- a/ntcore/src/main/native/include/ntcore_cpp.h
+++ b/ntcore/src/main/native/include/ntcore_cpp.h
@@ -1088,6 +1088,14 @@ void SetServer(
 void SetServerTeam(NT_Inst inst, unsigned int team, unsigned int port);
 
 /**
+ * Disconnects the client if it's running and connected. This will automatically
+ * start reconnection attempts to the current server list.
+ *
+ * @param inst instance handle
+ */
+void Disconnect(NT_Inst inst);
+
+/**
  * Starts requesting server address from Driver Station.
  * This connects to the Driver Station running on localhost to obtain the
  * server IP address.


### PR DESCRIPTION
As setServer doesn't disconnect, it's useful to have a function that disconnects without needing to completely stop the client.