### PR TITLE
Add system ID gain constructors to sim physics classes

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
@@ -54,6 +54,35 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
   /**
    * Creates a simulated DC motor mechanism.
    *
+   * @param kV The velocity gain, in volts/(unit/sec)
+   * @param kA The acceleration gain, in volts/(unit/sec²)
+   * @param gearbox The type of and number of motors in the DC motor gearbox.
+   * @param gearing The gearing of the DC motor (numbers greater than 1 represent reductions).
+   */
+  public DCMotorSim(double kV, double kA, DCMotor gearbox, double gearing) {
+    super(identifySystem(kV, kA));
+    m_gearbox = gearbox;
+    m_gearing = gearing;
+  }
+
+  /**
+   * Creates a simulated DC motor mechanism.
+   *
+   * @param kV The velocity gain, in volts/(unit/sec)
+   * @param kA The acceleration gain, in volts/(unit/sec²)
+   * @param gearbox The type of and number of motors in the DC motor gearbox.
+   * @param gearing The gearing of the DC motor (numbers greater than 1 represent reductions).
+   * @param measurementStdDevs The standard deviations of the measurements.
+   */
+  public DCMotorSim(double kV, double kA, DCMotor gearbox, double gearing, Matrix<N2, N1> measurementStdDevs) {
+    super(identifySystem(kV, kA), measurementStdDevs);
+    m_gearbox = gearbox;
+    m_gearing = gearing;
+  }
+
+  /**
+   * Creates a simulated DC motor mechanism.
+   *
    * @param gearbox The type of and number of motors in the DC motor gearbox.
    * @param gearing The gearing of the DC motor (numbers greater than 1 represent reductions).
    * @param jKgMetersSquared The moment of inertia of the DC motor. If this is unknown, use the
@@ -139,5 +168,29 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
    */
   public void setInputVoltage(double volts) {
     setInput(volts);
+  }
+
+  /**
+   * 
+   * 
+   * @param kV The velocity gain, in volts/(unit/sec)
+   * @param kA The acceleration gain, in volts/(unit/sec²)
+   * @return A LinearSystem representing the given characterized constants.
+   * @throws IllegalArgumentException if kV &lt;= 0 or kA &lt;= 0.
+   * @see <a href="https://github.com/wpilibsuite/sysid">https://github.com/wpilibsuite/sysid</a>
+   */
+  public static LinearSystemSim<N2, N1, N2> identifySystem(double kV, double kA) {
+    if (kV <= 0.0) {
+      throw new IllegalArgumentException("Kv must be greater than zero.");
+    }
+    if (kA <= 0.0) {
+      throw new IllegalArgumentException("Ka must be greater than zero.");
+    }
+
+    return new LinearSystem<N2, N1, N2>(
+        Matrix.mat(Nat.N2(), Nat.N2()).fill(0.0, 1.0, 0.0, -kV / kA),
+        Matrix.mat(Nat.N2(), Nat.N1()).fill(0, 1.0 / kA),
+        Matrix.eye(Nat.N2()),
+        Matrix.mat(Nat.N2(), Nat.N1()).fill(0.0, 0.0));
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
@@ -183,7 +183,7 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
    * @throws IllegalArgumentException if kV &lt;= 0 or kA &lt;= 0.
    * @see <a href="https://github.com/wpilibsuite/sysid">https://github.com/wpilibsuite/sysid</a>
    */
-  public static LinearSystem<N2, N1, N2> identifySystem(double kV, double kA) {
+  private static LinearSystem<N2, N1, N2> identifySystem(double kV, double kA) {
     if (kV <= 0.0) {
       throw new IllegalArgumentException("Kv must be greater than zero.");
     }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
@@ -54,8 +54,8 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
   /**
    * Creates a simulated DC motor mechanism.
    *
-   * @param kV The velocity gain, in volts/(unit/sec)
-   * @param kA The acceleration gain, in volts/(unit/sec²)
+   * @param kV The velocity gain, in volts/(unit/sec).
+   * @param kA The acceleration gain, in volts/(unit/sec²).
    * @param gearbox The type of and number of motors in the DC motor gearbox.
    * @param gearing The gearing of the DC motor (numbers greater than 1 represent reductions).
    */
@@ -66,8 +66,8 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
   /**
    * Creates a simulated DC motor mechanism.
    *
-   * @param kV The velocity gain, in volts/(unit/sec)
-   * @param kA The acceleration gain, in volts/(unit/sec²)
+   * @param kV The velocity gain, in volts/(unit/sec).
+   * @param kA The acceleration gain, in volts/(unit/sec²).
    * @param gearbox The type of and number of motors in the DC motor gearbox.
    * @param gearing The gearing of the DC motor (numbers greater than 1 represent reductions).
    * @param measurementStdDevs The standard deviations of the measurements.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.wpilibj.simulation;
 
 import edu.wpi.first.math.Matrix;
-import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N2;
 import edu.wpi.first.math.system.LinearSystem;
@@ -61,9 +60,7 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
    * @param gearing The gearing of the DC motor (numbers greater than 1 represent reductions).
    */
   public DCMotorSim(double kV, double kA, DCMotor gearbox, double gearing) {
-    super(identifySystem(kV, kA));
-    m_gearbox = gearbox;
-    m_gearing = gearing;
+    this(kV, kA, gearbox, gearing, null);
   }
 
   /**
@@ -77,7 +74,9 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
    */
   public DCMotorSim(
       double kV, double kA, DCMotor gearbox, double gearing, Matrix<N2, N1> measurementStdDevs) {
-    super(identifySystem(kV, kA), measurementStdDevs);
+    super(
+        LinearSystemSim.convertControlToSim(LinearSystemId.identifyPositionSystem(kV, kA)),
+        measurementStdDevs);
     m_gearbox = gearbox;
     m_gearing = gearing;
   }
@@ -170,31 +169,5 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
    */
   public void setInputVoltage(double volts) {
     setInput(volts);
-  }
-
-  /**
-   * Identifies a position and velocity system, based on velocity and acceleration gains.
-   *
-   * <p>This is useful for identifying a state space system for use with {@link DCMotorSim}.
-   *
-   * @param kV The velocity gain, in volts/(unit/sec)
-   * @param kA The acceleration gain, in volts/(unit/sec²)
-   * @return A LinearSystem representing the given characterized constants.
-   * @throws IllegalArgumentException if kV &lt;= 0 or kA &lt;= 0.
-   * @see <a href="https://github.com/wpilibsuite/sysid">https://github.com/wpilibsuite/sysid</a>
-   */
-  private static LinearSystem<N2, N1, N2> identifySystem(double kV, double kA) {
-    if (kV <= 0.0) {
-      throw new IllegalArgumentException("Kv must be greater than zero.");
-    }
-    if (kA <= 0.0) {
-      throw new IllegalArgumentException("Ka must be greater than zero.");
-    }
-
-    return new LinearSystem<N2, N1, N2>(
-        Matrix.mat(Nat.N2(), Nat.N2()).fill(0.0, 1.0, 0.0, -kV / kA),
-        Matrix.mat(Nat.N2(), Nat.N1()).fill(0, 1.0 / kA),
-        Matrix.eye(Nat.N2()),
-        new Matrix<>(Nat.N2(), Nat.N1()));
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/DCMotorSim.java
@@ -5,6 +5,7 @@
 package edu.wpi.first.wpilibj.simulation;
 
 import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N2;
 import edu.wpi.first.math.system.LinearSystem;
@@ -74,7 +75,8 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
    * @param gearing The gearing of the DC motor (numbers greater than 1 represent reductions).
    * @param measurementStdDevs The standard deviations of the measurements.
    */
-  public DCMotorSim(double kV, double kA, DCMotor gearbox, double gearing, Matrix<N2, N1> measurementStdDevs) {
+  public DCMotorSim(
+      double kV, double kA, DCMotor gearbox, double gearing, Matrix<N2, N1> measurementStdDevs) {
     super(identifySystem(kV, kA), measurementStdDevs);
     m_gearbox = gearbox;
     m_gearing = gearing;
@@ -171,15 +173,17 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
   }
 
   /**
-   * 
-   * 
+   * Identifies a position and velocity system, based on velocity and acceleration gains.
+   *
+   * <p>This is useful for identifying a state space system for use with {@link DCMotorSim}.
+   *
    * @param kV The velocity gain, in volts/(unit/sec)
    * @param kA The acceleration gain, in volts/(unit/sec²)
    * @return A LinearSystem representing the given characterized constants.
    * @throws IllegalArgumentException if kV &lt;= 0 or kA &lt;= 0.
    * @see <a href="https://github.com/wpilibsuite/sysid">https://github.com/wpilibsuite/sysid</a>
    */
-  public static LinearSystemSim<N2, N1, N2> identifySystem(double kV, double kA) {
+  public static LinearSystem<N2, N1, N2> identifySystem(double kV, double kA) {
     if (kV <= 0.0) {
       throw new IllegalArgumentException("Kv must be greater than zero.");
     }
@@ -191,6 +195,6 @@ public class DCMotorSim extends LinearSystemSim<N2, N1, N2> {
         Matrix.mat(Nat.N2(), Nat.N2()).fill(0.0, 1.0, 0.0, -kV / kA),
         Matrix.mat(Nat.N2(), Nat.N1()).fill(0, 1.0 / kA),
         Matrix.eye(Nat.N2()),
-        Matrix.mat(Nat.N2(), Nat.N1()).fill(0.0, 0.0));
+        new Matrix<>(Nat.N2(), Nat.N1()));
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
@@ -14,7 +14,7 @@ import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
 
 /** Represents a simulated elevator mechanism. */
-public class ElevatorSim extends LinearSystemSim<N2, N1, N1> {
+public class ElevatorSim extends LinearSystemSim<N2, N1, N2> {
   // Gearbox for the elevator.
   private final DCMotor m_gearbox;
 
@@ -83,8 +83,8 @@ public class ElevatorSim extends LinearSystemSim<N2, N1, N1> {
       double minHeightMeters,
       double maxHeightMeters,
       boolean simulateGravity,
-      Matrix<N1, N1> measurementStdDevs) {
-    super(plant, measurementStdDevs);
+      Matrix<N2, N1> measurementStdDevs) {
+    super(LinearSystemSim.convertControlToSim(plant), measurementStdDevs);
     m_gearbox = gearbox;
     m_gearing = gearing;
     m_drumRadius = drumRadiusMeters;
@@ -114,8 +114,10 @@ public class ElevatorSim extends LinearSystemSim<N2, N1, N1> {
       double drumRadiusMeters,
       double minHeightMeters,
       double maxHeightMeters,
-      Matrix<N1, N1> measurementStdDevs) {
-    super(LinearSystemId.identifyPositionSystem(kV, kA), measurementStdDevs);
+      Matrix<N2, N1> measurementStdDevs) {
+    super(
+        LinearSystemSim.convertControlToSim(LinearSystemId.identifyPositionSystem(kV, kA)),
+        measurementStdDevs);
     m_gearbox = gearbox;
     m_gearing = gearing;
     m_drumRadius = drumRadiusMeters;
@@ -174,9 +176,11 @@ public class ElevatorSim extends LinearSystemSim<N2, N1, N1> {
       double minHeightMeters,
       double maxHeightMeters,
       boolean simulateGravity,
-      Matrix<N1, N1> measurementStdDevs) {
+      Matrix<N2, N1> measurementStdDevs) {
     super(
-        LinearSystemId.createElevatorSystem(gearbox, carriageMassKg, drumRadiusMeters, gearing),
+        LinearSystemSim.convertControlToSim(
+            LinearSystemId.createElevatorSystem(
+                gearbox, carriageMassKg, drumRadiusMeters, gearing)),
         measurementStdDevs);
     m_gearbox = gearbox;
     m_gearing = gearing;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.wpilibj.simulation;
 
 import edu.wpi.first.math.Matrix;
-import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N2;
@@ -116,7 +115,7 @@ public class ElevatorSim extends LinearSystemSim<N2, N1, N1> {
       double minHeightMeters,
       double maxHeightMeters,
       Matrix<N1, N1> measurementStdDevs) {
-    super(identifySystem(kV, kA), measurementStdDevs);
+    super(LinearSystemId.identifyPositionSystem(kV, kA), measurementStdDevs);
     m_gearbox = gearbox;
     m_gearing = gearing;
     m_drumRadius = drumRadiusMeters;
@@ -267,35 +266,6 @@ public class ElevatorSim extends LinearSystemSim<N2, N1, N1> {
    */
   public void setInputVoltage(double volts) {
     setInput(volts);
-  }
-
-  /**
-   * Identifies 1dof system, based on velocity and acceleration gains.
-   *
-   * <p>
-   * This is useful for identifying a state space system for use with
-   * {@link ElevatorSim}.
-   *
-   * @param kV The velocity gain, in volts/(unit/sec)
-   * @param kA The acceleration gain, in volts/(unit/sec²)
-   * @return A LinearSystem representing the given characterized constants.
-   * @throws IllegalArgumentException if kV &lt;= 0 or kA &lt;= 0.
-   * @see <a href=
-   *      "https://github.com/wpilibsuite/sysid">https://github.com/wpilibsuite/sysid</a>
-   */
-  private static LinearSystem<N2, N1, N1> identifySystem(double kV, double kA) {
-    if (kV <= 0.0) {
-      throw new IllegalArgumentException("Kv must be greater than zero.");
-    }
-    if (kA <= 0.0) {
-      throw new IllegalArgumentException("Ka must be greater than zero.");
-    }
-
-    return new LinearSystem<N2, N1, N1>(
-        Matrix.mat(Nat.N2(), Nat.N2()).fill(0.0, 1.0, 0.0, -kV / kA),
-        Matrix.mat(Nat.N2(), Nat.N1()).fill(0, 1.0 / kA),
-        Matrix.mat(Nat.N1(), Nat.N2()).fill(1, 0),
-        new Matrix<>(Nat.N1(), Nat.N1()));
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
@@ -93,6 +93,18 @@ public class ElevatorSim extends LinearSystemSim<N2, N1, N2> {
     m_gravityAccel = simulateGravity ? -9.81 : 0;
   }
 
+  /**
+   * Creates a simulated elevator mechanism.
+   *
+   * @param kG The gravity gain, in volts.
+   * @param kV The velocity gain, in volts/(unit/sec).
+   * @param kA The acceleration gain, in volts/(unit/sec²).
+   * @param gearbox The type of and number of motors in the elevator gearbox.
+   * @param gearing The gearing of the elevator (numbers greater than 1 represent reductions).
+   * @param drumRadiusMeters The radius of the drum that the elevator spool is wrapped around.
+   * @param minHeightMeters The min allowable height of the elevator.
+   * @param maxHeightMeters The max allowable height of the elevator.
+   */
   public ElevatorSim(
       double kG,
       double kV,
@@ -105,6 +117,19 @@ public class ElevatorSim extends LinearSystemSim<N2, N1, N2> {
     this(kG, kV, kA, gearbox, gearing, drumRadiusMeters, minHeightMeters, maxHeightMeters, null);
   }
 
+  /**
+   * Creates a simulated elevator mechanism.
+   *
+   * @param kG The gravity gain, in volts.
+   * @param kV The velocity gain, in volts/(unit/sec).
+   * @param kA The acceleration gain, in volts/(unit/sec²).
+   * @param gearbox The type of and number of motors in the elevator gearbox.
+   * @param gearing The gearing of the elevator (numbers greater than 1 represent reductions).
+   * @param drumRadiusMeters The radius of the drum that the elevator spool is wrapped around.
+   * @param minHeightMeters The min allowable height of the elevator.
+   * @param maxHeightMeters The max allowable height of the elevator.
+   * @param measurementStdDevs The standard deviations of the measurements.
+   */
   public ElevatorSim(
       double kG,
       double kV,
@@ -243,7 +268,7 @@ public class ElevatorSim extends LinearSystemSim<N2, N1, N2> {
    * @return The velocity of the elevator.
    */
   public double getVelocityMetersPerSecond() {
-    return m_x.get(1, 0);
+    return getOutput(1);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/FlywheelSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/FlywheelSim.java
@@ -50,12 +50,29 @@ public class FlywheelSim extends LinearSystemSim<N1, N1, N1> {
     m_gearing = gearing;
   }
 
+  /**
+   * Creates a simulated flywheel mechanism.
+   *
+   * @param kV The velocity gain, in volts/(unit/sec).
+   * @param kA The acceleration gain, in volts/(unit/sec²).
+   * @param gearbox The type of and number of motors in the flywheel gearbox.
+   * @param gearing The gearing of the flywheel (numbers greater than 1 represent reductions).
+   */
   public FlywheelSim(double kV, double kA, DCMotor gearbox, double gearing) {
     super(LinearSystemId.identifyVelocitySystem(kV, kA));
     m_gearbox = gearbox;
     m_gearing = gearing;
   }
 
+  /**
+   * Creates a simulated flywheel mechanism.
+   *
+   * @param kV The velocity gain, in volts/(unit/sec).
+   * @param kA The acceleration gain, in volts/(unit/sec²).
+   * @param gearbox The type of and number of motors in the flywheel gearbox.
+   * @param gearing The gearing of the flywheel (numbers greater than 1 represent reductions).
+   * @param measurementStdDevs The standard deviations of the measurements.
+   */
   public FlywheelSim(
       double kV, double kA, DCMotor gearbox, double gearing, Matrix<N1, N1> measurementStdDevs) {
     super(LinearSystemId.identifyVelocitySystem(kV, kA), measurementStdDevs);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/FlywheelSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/FlywheelSim.java
@@ -50,6 +50,19 @@ public class FlywheelSim extends LinearSystemSim<N1, N1, N1> {
     m_gearing = gearing;
   }
 
+  public FlywheelSim(double kV, double kA, DCMotor gearbox, double gearing) {
+    super(LinearSystemId.identifyVelocitySystem(kV, kA));
+    m_gearbox = gearbox;
+    m_gearing = gearing;
+  }
+
+  public FlywheelSim(
+      double kV, double kA, DCMotor gearbox, double gearing, Matrix<N1, N1> measurementStdDevs) {
+    super(LinearSystemId.identifyVelocitySystem(kV, kA), measurementStdDevs);
+    m_gearbox = gearbox;
+    m_gearing = gearing;
+  }
+
   /**
    * Creates a simulated flywheel mechanism.
    *

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/LinearSystemSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/LinearSystemSim.java
@@ -188,9 +188,10 @@ public class LinearSystemSim<States extends Num, Inputs extends Num, Outputs ext
    * <p>This method exists to convert common linear systems used for state space control into their
    * simulation equivalents. Linear systems used in simulation are different from those used in
    * control because control typically measures only one output (eg. position), while both outputs
-   * are necessary in simulation. The input system is a <N2, N1, N1> linear system because that is
-   * commonly returned in {@link edu.wpi.first.math.system.plant.LinearSystemId} and type erasure
-   * prevents it from being any size.
+   * are necessary in simulation. The input system is a {@literal <}N2, N1, N1{@literal >} linear
+   * system because that is commonly returned in {@link
+   * edu.wpi.first.math.system.plant.LinearSystemId} and type erasure prevents it from being any
+   * size.
    *
    * @param system The original linear system, with 2 states, 1 input, and 1 output.
    * @return A modified linear system, with 2 states, 1 input, and 2 outputs for use in simulation.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/LinearSystemSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/LinearSystemSim.java
@@ -5,9 +5,12 @@
 package edu.wpi.first.wpilibj.simulation;
 
 import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.Num;
 import edu.wpi.first.math.StateSpaceUtil;
+import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N2;
 import edu.wpi.first.math.system.LinearSystem;
 import edu.wpi.first.wpilibj.RobotController;
 import org.ejml.MatrixDimensionException;
@@ -177,5 +180,24 @@ public class LinearSystemSim<States extends Num, Inputs extends Num, Outputs ext
    */
   protected Matrix<Inputs, N1> clampInput(Matrix<Inputs, N1> u) {
     return StateSpaceUtil.desaturateInputVector(u, RobotController.getBatteryVoltage());
+  }
+
+  /**
+   * Convert from a 1-DOF linear system used for controls to a linear system used for simulation.
+   *
+   * <p>This method exists to convert common linear systems used for state space control into their
+   * simulation equivalents. Linear systems used in simulation are different from those used in
+   * control because control typically measures only one output (eg. position), while both outputs
+   * are necessary in simulation. The input system is a <N2, N1, N1> linear system because that is
+   * commonly returned in {@link edu.wpi.first.math.system.plant.LinearSystemId} and type erasure
+   * prevents it from being any size.
+   *
+   * @param system The original linear system, with 2 states, 1 input, and 1 output.
+   * @return A modified linear system, with 2 states, 1 input, and 2 outputs for use in simulation.
+   * @see ElevatorSim
+   */
+  protected static LinearSystem<N2, N1, N2> convertControlToSim(LinearSystem<N2, N1, N1> system) {
+    return new LinearSystem<>(
+        system.getA(), system.getB(), Matrix.eye(Nat.N2()), VecBuilder.fill(0.0, 0.0));
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
@@ -14,7 +14,7 @@ import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
 
 /** Represents a simulated single jointed arm mechanism. */
-public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
+public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N2> {
   // The gearbox for the arm.
   private final DCMotor m_gearbox;
 
@@ -83,8 +83,8 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
       double minAngleRads,
       double maxAngleRads,
       boolean simulateGravity,
-      Matrix<N1, N1> measurementStdDevs) {
-    super(plant, measurementStdDevs);
+      Matrix<N2, N1> measurementStdDevs) {
+    super(LinearSystemSim.convertControlToSim(plant), measurementStdDevs);
     m_gearbox = gearbox;
     m_gearing = gearing;
     m_armLenMeters = armLengthMeters;
@@ -114,8 +114,10 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
       double armLengthMeters,
       double minAngleRads,
       double maxAngleRads,
-      Matrix<N1, N1> measurementStdDevs) {
-    super(LinearSystemId.identifyPositionSystem(kV, kA), measurementStdDevs);
+      Matrix<N2, N1> measurementStdDevs) {
+    super(
+        LinearSystemSim.convertControlToSim(LinearSystemId.identifyPositionSystem(kV, kA)),
+        measurementStdDevs);
     m_gearbox = gearbox;
     m_gearing = gearing;
     m_armLenMeters = armLengthMeters;
@@ -174,9 +176,10 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
       double minAngleRads,
       double maxAngleRads,
       boolean simulateGravity,
-      Matrix<N1, N1> measurementStdDevs) {
+      Matrix<N2, N1> measurementStdDevs) {
     super(
-        LinearSystemId.createSingleJointedArmSystem(gearbox, jKgMetersSquared, gearing),
+        LinearSystemSim.convertControlToSim(
+            LinearSystemId.createSingleJointedArmSystem(gearbox, jKgMetersSquared, gearing)),
         measurementStdDevs);
     m_gearbox = gearbox;
     m_gearing = gearing;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
@@ -93,6 +93,18 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N2> {
     m_gravityAccel = simulateGravity ? -9.81 : 0;
   }
 
+  /**
+   * Creates a simulated arm mechanism.
+   *
+   * @param kG The gravity gain, in volts.
+   * @param kV The velocity gain, in volts/(unit/sec).
+   * @param kA The acceleration gain, in volts/(unit/sec²).
+   * @param gearbox The type of and number of motors in the arm gearbox.
+   * @param gearing The gearing of the arm (numbers greater than 1 represent reductions).
+   * @param armLengthMeters The length of the arm.
+   * @param minAngleRads The minimum angle that the arm is capable of.
+   * @param maxAngleRads The maximum angle that the arm is capable of.
+   */
   public SingleJointedArmSim(
       double kG,
       double kV,
@@ -105,6 +117,19 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N2> {
     this(kG, kV, kA, gearbox, gearing, armLengthMeters, minAngleRads, maxAngleRads, null);
   }
 
+  /**
+   * Creates a simulated arm mechanism.
+   *
+   * @param kG The gravity gain, in volts.
+   * @param kV The velocity gain, in volts/(unit/sec).
+   * @param kA The acceleration gain, in volts/(unit/sec²).
+   * @param gearbox The type of and number of motors in the arm gearbox.
+   * @param gearing The gearing of the arm (numbers greater than 1 represent reductions).
+   * @param armLengthMeters The length of the arm.
+   * @param minAngleRads The minimum angle that the arm is capable of.
+   * @param maxAngleRads The maximum angle that the arm is capable of.
+   * @param measurementStdDevs The standard deviations of the measurements.
+   */
   public SingleJointedArmSim(
       double kG,
       double kV,
@@ -233,7 +258,7 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N2> {
    * @return The current arm angle.
    */
   public double getAngleRads() {
-    return m_y.get(0, 0);
+    return getOutput(0);
   }
 
   /**
@@ -242,7 +267,7 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N2> {
    * @return The current arm velocity.
    */
   public double getVelocityRadPerSec() {
-    return m_x.get(1, 0);
+    return getOutput(1);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.wpilibj.simulation;
 
 import edu.wpi.first.math.Matrix;
-import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N2;
@@ -116,7 +115,7 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
       double minAngleRads,
       double maxAngleRads,
       Matrix<N1, N1> measurementStdDevs) {
-    super(identifySystem(kV, kA), measurementStdDevs);
+    super(LinearSystemId.identifyPositionSystem(kV, kA), measurementStdDevs);
     m_gearbox = gearbox;
     m_gearing = gearing;
     m_armLenMeters = armLengthMeters;
@@ -274,21 +273,6 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
    */
   public static double estimateMOI(double lengthMeters, double massKg) {
     return 1.0 / 3.0 * massKg * lengthMeters * lengthMeters;
-  }
-
-  public static LinearSystem<N2, N1, N1> identifySystem(double kV, double kA) {
-    if (kV <= 0.0) {
-      throw new IllegalArgumentException("Kv must be greater than zero.");
-    }
-    if (kA <= 0.0) {
-      throw new IllegalArgumentException("Ka must be greater than zero.");
-    }
-
-    return new LinearSystem<N2, N1, N1>(
-        Matrix.mat(Nat.N2(), Nat.N2()).fill(0.0, 1.0, 0.0, -kV / kA),
-        Matrix.mat(Nat.N2(), Nat.N1()).fill(0, 1.0 / kA),
-        Matrix.mat(Nat.N1(), Nat.N2()).fill(1, 0),
-        new Matrix<>(Nat.N1(), Nat.N1()));
   }
 
   /**

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ElevatorSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/ElevatorSimTest.java
@@ -33,7 +33,7 @@ class ElevatorSimTest {
             0.0,
             3.0,
             true,
-            VecBuilder.fill(0.01));
+            VecBuilder.fill(0.01, 0.01));
 
     try (var motor = new PWMVictorSPX(0);
         var encoder = new Encoder(0, 1)) {
@@ -71,7 +71,7 @@ class ElevatorSimTest {
             0.0,
             1.0,
             true,
-            VecBuilder.fill(0.01));
+            VecBuilder.fill(0.01, 0.01));
 
     for (int i = 0; i < 100; i++) {
       sim.setInput(VecBuilder.fill(0));

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armsimulation/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/armsimulation/Robot.java
@@ -68,7 +68,7 @@ public class Robot extends TimedRobot {
           Units.degreesToRadians(-75),
           Units.degreesToRadians(255),
           true,
-          VecBuilder.fill(kArmEncoderDistPerPulse) // Add noise with a std-dev of 1 tick
+          VecBuilder.fill(kArmEncoderDistPerPulse, 0) // Add noise with a std-dev of 1 tick
           );
   private final EncoderSim m_encoderSim = new EncoderSim(m_encoder);
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/elevatorsimulation/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/elevatorsimulation/Robot.java
@@ -60,7 +60,7 @@ public class Robot extends TimedRobot {
           kMinElevatorHeight,
           kMaxElevatorHeight,
           true,
-          VecBuilder.fill(0.01));
+          VecBuilder.fill(0.01, 0.01));
   private final EncoderSim m_encoderSim = new EncoderSim(m_encoder);
 
   // Create a Mechanism2d visualization of the elevator


### PR DESCRIPTION
This pr adds constructors with feedforward gains to the LinearSystemSim derivative classes (DCMotorSim, FlywheelSim, SingleJointedArmSim, ElevatorSim). This should make it easier for teams to use more accurate simulation without the methods in LinearSystemId, which take in measurements about the mechanism, rather than ff gains.
The system which ElevatorSim and SingleJointedArmSim has also internally changed, using a gravityAccel value, rather than a simulateGravity flag to store the acceleration due to gravity.

The new static `identifySystem` static methods are probably misleading, since they return a generic 1dof state space model, rather than a model which would work with a real mechanism of their class' type. I'm working on adding more documentation and porting the changes to c++. Resolves #5010. Thoughts?