### PR TITLE
[wpigui] Limit frame rate to 120 fps by default

### DIFF
--- a/datalogtool/src/main/native/cpp/App.cpp
+++ b/datalogtool/src/main/native/cpp/App.cpp
@@ -104,6 +104,8 @@ static void DisplayMainMenu() {
     ImGui::Text("v%s", GetWPILibVersion());
     ImGui::Separator();
     ImGui::Text("Save location: %s", glass::GetStorageDir().c_str());
+    ImGui::Text("%.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate,
+                ImGui::GetIO().Framerate);
     if (ImGui::Button("Close")) {
       ImGui::CloseCurrentPopup();
     }

--- a/glass/src/app/native/cpp/main.cpp
+++ b/glass/src/app/native/cpp/main.cpp
@@ -265,6 +265,8 @@ int main(int argc, char** argv) {
       ImGui::Text("v%s", GetWPILibVersion());
       ImGui::Separator();
       ImGui::Text("Save location: %s", glass::GetStorageDir().c_str());
+      ImGui::Text("%.3f ms/frame (%.1f FPS)",
+                  1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
       if (ImGui::Button("Close")) {
         ImGui::CloseCurrentPopup();
       }

--- a/outlineviewer/src/main/native/cpp/main.cpp
+++ b/outlineviewer/src/main/native/cpp/main.cpp
@@ -183,6 +183,8 @@ static void DisplayGui() {
     ImGui::Text("v%s", GetWPILibVersion());
     ImGui::Separator();
     ImGui::Text("Save location: %s", glass::GetStorageDir().c_str());
+    ImGui::Text("%.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate,
+                ImGui::GetIO().Framerate);
     if (ImGui::Button("Close")) {
       ImGui::CloseCurrentPopup();
     }

--- a/roborioteamnumbersetter/src/main/native/cpp/App.cpp
+++ b/roborioteamnumbersetter/src/main/native/cpp/App.cpp
@@ -127,6 +127,8 @@ static void DisplayGui() {
                 static_cast<int>(multicastResolver->HasImplementation()));
     ImGui::Separator();
     ImGui::Text("Save location: %s", glass::GetStorageDir().c_str());
+    ImGui::Text("%.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate,
+                ImGui::GetIO().Framerate);
     if (ImGui::Button("Close")) {
       ImGui::CloseCurrentPopup();
     }

--- a/wpigui/src/main/native/cpp/wpigui.cpp
+++ b/wpigui/src/main/native/cpp/wpigui.cpp
@@ -4,6 +4,8 @@
 
 #include "wpigui.h"
 
+#include <stdint.h>
+
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
@@ -364,7 +366,7 @@ void gui::Main() {
       double sleepTime = (1.0 / gContext->fps) - (glfwGetTime() - startTime);
       if (sleepTime > 1e-6) {
         std::this_thread::sleep_for(
-            std::chrono::microseconds(static_cast<long>(sleepTime * 1e6)));
+            std::chrono::microseconds(static_cast<int64_t>(sleepTime * 1e6)));
       }
     }
   }

--- a/wpigui/src/main/native/include/wpigui.h
+++ b/wpigui/src/main/native/include/wpigui.h
@@ -163,6 +163,13 @@ enum Style { kStyleClassic = 0, kStyleDark, kStyleLight };
 void SetStyle(Style style);
 
 /**
+ * Sets the FPS limit.  Using this function makes this setting persistent.
+ *
+ * @param fps FPS (0=vsync)
+ */
+void SetFPS(int fps);
+
+/**
  * Sets the clear (background) color.
  *
  * @param color Color

--- a/wpigui/src/main/native/include/wpigui_internal.h
+++ b/wpigui/src/main/native/include/wpigui_internal.h
@@ -24,6 +24,7 @@ struct SavedSettings {
   int yPos = -1;
   int userScale = 2;
   int style = 0;
+  int fps = 120;
 };
 
 constexpr int kFontScaledLevels = 9;


### PR DESCRIPTION
Limiting with vsync is apparently unreliable on a number of systems; this resulted in high CPU/GPU usage.

Also add current actual frame rate to about dialog of GUI tools.