### PR TITLE
[wpilib] Revert throw on nonexistent SimDevice name in SimDeviceSim

### DIFF
--- a/wpilibc/src/main/native/cpp/simulation/SimDeviceSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/SimDeviceSim.cpp
@@ -11,37 +11,20 @@
 #include <hal/SimDevice.h>
 #include <hal/simulation/SimDeviceData.h>
 
-#include "frc/Errors.h"
-
 using namespace frc;
 using namespace frc::sim;
 
 SimDeviceSim::SimDeviceSim(const char* name)
-    : m_handle{HALSIM_GetSimDeviceHandle(name)} {
-  if (m_handle == 0) {
-    throw FRC_MakeError(err::InvalidParameter,
-                        "No sim device exists with name '{}'.", name);
-  }
-}
+    : m_handle{HALSIM_GetSimDeviceHandle(name)} {}
 
 SimDeviceSim::SimDeviceSim(const char* name, int index) {
   m_handle =
       HALSIM_GetSimDeviceHandle(fmt::format("{}[{}]", name, index).c_str());
-  if (m_handle == 0) {
-    throw FRC_MakeError(err::InvalidParameter,
-                        "No sim device exists with name '{}[{}]'.", name,
-                        index);
-  }
 }
 
 SimDeviceSim::SimDeviceSim(const char* name, int index, int channel) {
   m_handle = HALSIM_GetSimDeviceHandle(
       fmt::format("{}[{},{}]", name, index, channel).c_str());
-  if (m_handle == 0) {
-    throw FRC_MakeError(err::InvalidParameter,
-                        "No sim device exists with name '{}[{},{}]'.", name,
-                        index, channel);
-  }
 }
 
 SimDeviceSim::SimDeviceSim(HAL_SimDeviceHandle handle) : m_handle(handle) {}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimDeviceSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SimDeviceSim.java
@@ -25,9 +25,6 @@ public class SimDeviceSim {
    */
   public SimDeviceSim(String name) {
     this(SimDeviceDataJNI.getSimDeviceHandle(name));
-    if (m_handle == 0) {
-      throw new IllegalArgumentException("No sim device exists with name '" + name + "'.");
-    }
   }
 
   /**


### PR DESCRIPTION
This breaks current vendor use of SimDeviceSim.

This reverts commit d991f6e435a193ed447d0c2db06d27d9b62b1a29 (#5041).