### PR TITLE
[wpilib] ElevatorSim: Fix WouldHitLimit methods

### DIFF
--- a/wpilibc/src/main/native/cpp/simulation/ElevatorSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/ElevatorSim.cpp
@@ -41,11 +41,11 @@ ElevatorSim::ElevatorSim(const DCMotor& gearbox, double gearing,
       m_simulateGravity(simulateGravity) {}
 
 bool ElevatorSim::WouldHitLowerLimit(units::meter_t elevatorHeight) const {
-  return elevatorHeight < m_minHeight;
+  return elevatorHeight <= m_minHeight;
 }
 
 bool ElevatorSim::WouldHitUpperLimit(units::meter_t elevatorHeight) const {
-  return elevatorHeight > m_maxHeight;
+  return elevatorHeight >= m_maxHeight;
 }
 
 bool ElevatorSim::HasHitLowerLimit() const {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/ElevatorSim.java
@@ -162,7 +162,7 @@ public class ElevatorSim extends LinearSystemSim<N2, N1, N1> {
    * @return Whether the elevator would hit the lower limit.
    */
   public boolean wouldHitLowerLimit(double elevatorHeightMeters) {
-    return elevatorHeightMeters < this.m_minHeight;
+    return elevatorHeightMeters <= this.m_minHeight;
   }
 
   /**
@@ -172,7 +172,7 @@ public class ElevatorSim extends LinearSystemSim<N2, N1, N1> {
    * @return Whether the elevator would hit the upper limit.
    */
   public boolean wouldHitUpperLimit(double elevatorHeightMeters) {
-    return elevatorHeightMeters > this.m_maxHeight;
+    return elevatorHeightMeters >= this.m_maxHeight;
   }
 
   /**


### PR DESCRIPTION
Expected behavior:
`hasHitLowerLimit()` should return true if the ElevatorSim position is at the minimum height.

Actual behavior:
`hasHitLowerLimit()` will never return true because the position is clamped between the min and max heights. 

Solution:
Include `=` in the `wouldHitLowerLimit` and `wouldHitUpperLimit` methods