### PR TITLE
[commands] Add default command removal method to Subsystem

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
@@ -51,9 +51,8 @@ public interface Subsystem {
   }
 
   /**
-   * Removes the default command for the subsystem. The current default command will run until
-   * another command is scheduled that requires the subsystem, at which point the current default
-   * command will not be re-scheduled.
+   * Removes the default command for the subsystem. This will not cancel the default command if
+   * it is currently running.
    */
   default void removeDefaultCommand() {
     CommandScheduler.getInstance().removeDefaultCommand(this);

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
@@ -51,8 +51,8 @@ public interface Subsystem {
   }
 
   /**
-   * Removes the default command for the subsystem. This will not cancel the default command if
-   * it is currently running.
+   * Removes the default command for the subsystem. This will not cancel the default command if it
+   * is currently running.
    */
   default void removeDefaultCommand() {
     CommandScheduler.getInstance().removeDefaultCommand(this);

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
@@ -51,6 +51,15 @@ public interface Subsystem {
   }
 
   /**
+   * Removes the default command for the subsystem. The current default command will run until
+   * another command is scheduled that requires the subsystem, at which point the current default
+   * command will not be re-scheduled.
+   */
+  default void removeDefaultCommand() {
+    CommandScheduler.getInstance().removeDefaultCommand(this);
+  }
+
+  /**
    * Gets the default command for this subsystem. Returns null if no default command is currently
    * associated with the subsystem.
    *

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Subsystem.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Subsystem.cpp
@@ -21,6 +21,10 @@ void Subsystem::SetDefaultCommand(CommandPtr&& defaultCommand) {
                                                     std::move(defaultCommand));
 }
 
+void Subsystem::RemoveDefaultCommand() {
+  CommandScheduler::GetInstance().RemoveDefaultCommand(this);
+}
+
 Command* Subsystem::GetDefaultCommand() const {
   return CommandScheduler::GetInstance().GetDefaultCommand(this);
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
@@ -82,6 +82,13 @@ class Subsystem {
    * @param defaultCommand the default command to associate with this subsystem
    */
   void SetDefaultCommand(CommandPtr&& defaultCommand);
+ 
+  /**
+   * Removes the default command for the subsystem.  The current default command
+   * will run until another command is scheduled that requires the subsystem, at
+   * which point the current default command will not be re-scheduled.
+   */
+  void RemoveDefaultCommand();
 
   /**
    * Gets the default command for this subsystem.  Returns null if no default

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
@@ -82,7 +82,7 @@ class Subsystem {
    * @param defaultCommand the default command to associate with this subsystem
    */
   void SetDefaultCommand(CommandPtr&& defaultCommand);
- 
+
   /**
    * Removes the default command for the subsystem.  The current default command
    * will run until another command is scheduled that requires the subsystem, at

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
@@ -84,9 +84,8 @@ class Subsystem {
   void SetDefaultCommand(CommandPtr&& defaultCommand);
 
   /**
-   * Removes the default command for the subsystem.  The current default command
-   * will run until another command is scheduled that requires the subsystem, at
-   * which point the current default command will not be re-scheduled.
+   * Removes the default command for the subsystem.  This will not cancel the
+   * default command if it is currently running.
    */
   void RemoveDefaultCommand();
 


### PR DESCRIPTION
An addendum to #4621 that allows `removeDefaultCommand` to be ran directly from the Subsystem, rather than from the CommandScheduler; this matches it with the style of the other Subsystem-specific methods.