### PR TITLE
[wpinet] Revert WebSocket: When Close() is called, call closed immediately

### DIFF
--- a/wpinet/src/main/native/cpp/WebSocket.cpp
+++ b/wpinet/src/main/native/cpp/WebSocket.cpp
@@ -126,7 +126,6 @@ void WebSocket::Close(uint16_t code, std::string_view reason) {
   SendClose(code, reason);
   if (m_state != FAILED && m_state != CLOSED) {
     m_state = CLOSING;
-    closed(code, reason);
   }
 }
 
@@ -338,11 +337,8 @@ void WebSocket::SetClosed(uint16_t code, std::string_view reason, bool failed) {
   if (m_state == FAILED || m_state == CLOSED) {
     return;
   }
-  bool wasClosing = m_state == CLOSING;
   m_state = failed ? FAILED : CLOSED;
-  if (!wasClosing) {
-    closed(code, reason);
-  }
+  closed(code, reason);
 }
 
 void WebSocket::Shutdown() {

--- a/wpinet/src/test/native/cpp/WebSocketIntegrationTest.cpp
+++ b/wpinet/src/test/native/cpp/WebSocketIntegrationTest.cpp
@@ -125,13 +125,13 @@ TEST_F(WebSocketIntegrationTest, ClientSendText) {
         ++gotData;
         ASSERT_EQ(data, "hello");
       });
-      ws.closed.connect([&](auto code, auto reason) { Finish(); });
     });
   });
 
   clientPipe->Connect(pipeName, [&] {
     auto ws = WebSocket::CreateClient(*clientPipe, "/test", pipeName);
     ws->closed.connect([&](uint16_t code, std::string_view reason) {
+      Finish();
       if (code != 1005 && code != 1006) {
         FAIL() << "Code: " << code << " Reason: " << reason;
       }


### PR DESCRIPTION
This caused crashes in ntcore.

This reverts commit b879a6f8c6a56469ccb2bbda8a84163709d00ede (#5047).