### PR TITLE
[wpimath] Consolidated LinearFilter and MedianFilter into a common interface

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
@@ -47,7 +47,7 @@ import org.ejml.simple.SimpleMatrix;
  * then want to run it at 200Hz! Combining this with Note 1 - the impetus is on YOU as a developer
  * to make sure calculate() gets called at the desired, constant frequency!
  */
-public class LinearFilter {
+public class LinearFilter implements SlidingWindowNumericFilter {
   private final CircularBuffer m_inputs;
   private final CircularBuffer m_outputs;
   private final double[] m_inputGains;
@@ -236,18 +236,13 @@ public class LinearFilter {
     return finiteDifference(derivative, stencil, period);
   }
 
-  /** Reset the filter state. */
+  @Override
   public void reset() {
     m_inputs.clear();
     m_outputs.clear();
   }
 
-  /**
-   * Calculates the next value of the filter.
-   *
-   * @param input Current input value.
-   * @return The filtered value at this step
-   */
+  @Override
   public double calculate(double input) {
     double retVal = 0.0;
 

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/MedianFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/MedianFilter.java
@@ -14,7 +14,7 @@ import java.util.List;
  * especially with processes that generate occasional, extreme outliers (such as values from vision
  * processing, LIDAR, or ultrasonic sensors).
  */
-public class MedianFilter {
+public class MedianFilter implements SlidingWindowNumericFilter {
   private final CircularBuffer m_valueBuffer;
   private final List<Double> m_orderedValues;
   private final int m_size;
@@ -33,12 +33,7 @@ public class MedianFilter {
     m_size = size;
   }
 
-  /**
-   * Calculates the moving-window median for the next value of the input stream.
-   *
-   * @param next The next input value.
-   * @return The median of the moving window, updated to include the next value.
-   */
+  @Override
   public double calculate(double next) {
     // Find insertion point for next value
     int index = Collections.binarySearch(m_orderedValues, next);
@@ -72,7 +67,7 @@ public class MedianFilter {
     }
   }
 
-  /** Resets the filter, clearing the window of all elements. */
+  @Override
   public void reset() {
     m_orderedValues.clear();
     m_valueBuffer.clear();

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlidingWindowNumericFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlidingWindowNumericFilter.java
@@ -1,0 +1,22 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.math.filter;
+
+/**
+ * Interface for sliding window filters that operate by repeatedly taking in new values and
+ * returning what the current value should be as modulated through the filter.
+ */
+public interface SlidingWindowNumericFilter {
+  /** Resets the filter to initial conditions. */
+  void reset();
+
+  /**
+   * Calculates the next value of the filter.
+   *
+   * @param input Current input value.
+   * @return The filtered value at this step.
+   */
+  double calculate(double input);
+}


### PR DESCRIPTION
Added `SlidingWindowNumericFilter` interface that declares the common `calculate` and `reset` methods between `LinearFilter` and `MedianFilter` and changed those two filters to declare implementation of the interface. This change is in relation to https://github.com/wpilibsuite/allwpilib/issues/5083.

**Explanation**

Intent is to simplify tuning of filtered systems (especially autonomous drive systems like the auto-balance logic for the 2023 competition season) by making it easier to write code that uses NetworkTables to select between filter types to test different approaches. Without a common interface, `MedianFilter` is not polymorphic with the linear filters (single pole IIR, high pass, moving average, etc.), which requires generic code to do special handling for that one filter type.

**Alternatives considered**

Considered making `SlidingWindowNumericFilter` into a `SlidingWindowFilter<TYPE>` generic so that the Debouncer and SlewRateLimiter could be adopted into the interface, but neither of these have compatible `reset` methods. Adding such a method would be straightforward, but there was no obvious need for it; if adding it would be preferable, we can expand the interface and add zero-argument `reset` methods with sensible defaults to those classes.

**Testing**

* `./gradlew check` and `./gradlew test` executed. Since this is an interface-only change, the compiler and existing tests should cover all our bases here.
  * **Note**: `./gradlew test` reported two test failures (separately, on separate runs), but these test failures did not reproduce on repeated runs.
```
WatchdogTest > isExpiredTest() FAILED
    org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
        at app//org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
        at app//org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:40)
        at app//org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:35)
        at app//org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:179)
        at app//edu.wpi.first.wpilibj.WatchdogTest.isExpiredTest(WatchdogTest.java:125)
```

```
ArmSimulationTest > teleopTest(double) > edu.wpi.first.wpilibj.examples.armsimulation.ArmSimulationTest.teleopTest(double)[2] FAILED
    org.opentest4j.AssertionFailedError: expected: <25.0> but was: <23.466796875>
        at app//org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
        at app//org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:86)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:81)
        at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1010)
        at app//edu.wpi.first.wpilibj.examples.armsimulation.ArmSimulationTest.teleopTest(ArmSimulationTest.java:105)
Warning at edu.wpi.first.wpilibj.I2C.<init>(I2C.java:51): Onboard I2C port is subject to system lockups. See Known Issues page for details
```