### PR TITLE
[wpimath] Add timestamp getter to MathShared

### DIFF
--- a/wpilibc/src/main/native/cppcs/RobotBase.cpp
+++ b/wpilibc/src/main/native/cppcs/RobotBase.cpp
@@ -141,7 +141,7 @@ class WPILibMathShared : public wpi::math::MathShared {
   }
 
   units::second_t GetTimestamp() override {
-    return units::microsecond_t(wpi::Now());
+    return units::second_t{wpi::Now() * 1.0e-6};
   }
 };
 }  // namespace

--- a/wpilibc/src/main/native/cppcs/RobotBase.cpp
+++ b/wpilibc/src/main/native/cppcs/RobotBase.cpp
@@ -15,6 +15,7 @@
 #include <hal/FRCUsageReporting.h>
 #include <hal/HALBase.h>
 #include <networktables/NetworkTableInstance.h>
+#include <wpi/timestamp.h>
 #include <wpimath/MathShared.h>
 
 #include "WPILibVersion.h"
@@ -137,6 +138,10 @@ class WPILibMathShared : public wpi::math::MathShared {
                    count);
         break;
     }
+  }
+
+  uint64_t GetTimestamp() override {
+    return wpi::Now();
   }
 };
 }  // namespace

--- a/wpilibc/src/main/native/cppcs/RobotBase.cpp
+++ b/wpilibc/src/main/native/cppcs/RobotBase.cpp
@@ -140,7 +140,9 @@ class WPILibMathShared : public wpi::math::MathShared {
     }
   }
 
-  uint64_t GetTimestamp() override { return wpi::Now(); }
+  units::second_t GetTimestamp() override {
+    return units::microsecond_t(wpi::Now());
+  }
 };
 }  // namespace
 

--- a/wpilibc/src/main/native/cppcs/RobotBase.cpp
+++ b/wpilibc/src/main/native/cppcs/RobotBase.cpp
@@ -140,9 +140,7 @@ class WPILibMathShared : public wpi::math::MathShared {
     }
   }
 
-  uint64_t GetTimestamp() override {
-    return wpi::Now();
-  }
+  uint64_t GetTimestamp() override { return wpi::Now(); }
 };
 }  // namespace
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -16,6 +16,7 @@ import edu.wpi.first.math.MathSharedStore;
 import edu.wpi.first.math.MathUsageId;
 import edu.wpi.first.networktables.MultiSubscriber;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.util.WPIUtilJNI;
 import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.util.WPILibVersion;
@@ -127,6 +128,11 @@ public abstract class RobotBase implements AutoCloseable {
               default:
                 break;
             }
+          }
+
+          @Override
+          public long getTimestamp() {
+            return WPIUtilJNI.now();
           }
         });
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -131,8 +131,8 @@ public abstract class RobotBase implements AutoCloseable {
           }
 
           @Override
-          public long getTimestamp() {
-            return WPIUtilJNI.now();
+          public double getTimestamp() {
+            return WPIUtilJNI.now() * 1.0e-6;
           }
         });
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/MathShared.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathShared.java
@@ -21,6 +21,10 @@ public interface MathShared {
    */
   void reportUsage(MathUsageId id, int count);
 
-  /** Get the time in seconds. */
+  /**
+   * Get the current time.
+   *
+   * @return Time in seconds
+   */
   double getTimestamp();
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/MathShared.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathShared.java
@@ -20,4 +20,7 @@ public interface MathShared {
    * @param count the usage count
    */
   void reportUsage(MathUsageId id, int count);
+
+  /** Get the time in microseconds. */
+  long getTimestamp();
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/MathShared.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathShared.java
@@ -21,6 +21,6 @@ public interface MathShared {
    */
   void reportUsage(MathUsageId id, int count);
 
-  /** Get the time in microseconds. */
-  long getTimestamp();
+  /** Get the time in seconds. */
+  double getTimestamp();
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/MathSharedStore.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathSharedStore.java
@@ -4,6 +4,8 @@
 
 package edu.wpi.first.math;
 
+import edu.wpi.first.util.WPIUtilJNI;
+
 public final class MathSharedStore {
   private static MathShared mathShared;
 
@@ -25,8 +27,8 @@ public final class MathSharedStore {
             public void reportUsage(MathUsageId id, int count) {}
 
             @Override
-            public long getTimestamp() {
-              return 0;
+            public double getTimestamp() {
+              return WPIUtilJNI.now() * 1.0e-6;
             }
           };
     }
@@ -62,8 +64,12 @@ public final class MathSharedStore {
     getMathShared().reportUsage(id, count);
   }
 
-  /** Get the time in microseconds. */
-  public static long getTimestamp() {
+  /**
+   * Get the time.
+   *
+   * @return The time in seconds.
+   */
+  public static double getTimestamp() {
     return getMathShared().getTimestamp();
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/MathSharedStore.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/MathSharedStore.java
@@ -23,6 +23,11 @@ public final class MathSharedStore {
 
             @Override
             public void reportUsage(MathUsageId id, int count) {}
+
+            @Override
+            public long getTimestamp() {
+              return 0;
+            }
           };
     }
     return mathShared;
@@ -55,5 +60,10 @@ public final class MathSharedStore {
    */
   public static void reportUsage(MathUsageId id, int count) {
     getMathShared().reportUsage(id, count);
+  }
+
+  /** Get the time in microseconds. */
+  public static long getTimestamp() {
+    return getMathShared().getTimestamp();
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.math.estimator;
 
+import edu.wpi.first.math.MathSharedStore;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.Nat;
@@ -17,7 +18,6 @@ import edu.wpi.first.math.kinematics.DifferentialDriveKinematics;
 import edu.wpi.first.math.kinematics.DifferentialDriveOdometry;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
-import edu.wpi.first.util.WPIUtilJNI;
 import java.util.Map;
 import java.util.Objects;
 
@@ -287,7 +287,10 @@ public class DifferentialDrivePoseEstimator {
   public Pose2d update(
       Rotation2d gyroAngle, double distanceLeftMeters, double distanceRightMeters) {
     return updateWithTime(
-        WPIUtilJNI.now() * 1.0e-6, gyroAngle, distanceLeftMeters, distanceRightMeters);
+        MathSharedStore.getTimestamp() * 1.0e-6,
+        gyroAngle,
+        distanceLeftMeters,
+        distanceRightMeters);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/DifferentialDrivePoseEstimator.java
@@ -287,10 +287,7 @@ public class DifferentialDrivePoseEstimator {
   public Pose2d update(
       Rotation2d gyroAngle, double distanceLeftMeters, double distanceRightMeters) {
     return updateWithTime(
-        MathSharedStore.getTimestamp() * 1.0e-6,
-        gyroAngle,
-        distanceLeftMeters,
-        distanceRightMeters);
+        MathSharedStore.getTimestamp(), gyroAngle, distanceLeftMeters, distanceRightMeters);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.math.estimator;
 
+import edu.wpi.first.math.MathSharedStore;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.Nat;
@@ -18,7 +19,6 @@ import edu.wpi.first.math.kinematics.MecanumDriveOdometry;
 import edu.wpi.first.math.kinematics.MecanumDriveWheelPositions;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
-import edu.wpi.first.util.WPIUtilJNI;
 import java.util.Map;
 import java.util.Objects;
 
@@ -264,7 +264,7 @@ public class MecanumDrivePoseEstimator {
    * @return The estimated pose of the robot in meters.
    */
   public Pose2d update(Rotation2d gyroAngle, MecanumDriveWheelPositions wheelPositions) {
-    return updateWithTime(WPIUtilJNI.now() * 1.0e-6, gyroAngle, wheelPositions);
+    return updateWithTime(MathSharedStore.getTimestamp() * 1.0e-6, gyroAngle, wheelPositions);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/MecanumDrivePoseEstimator.java
@@ -264,7 +264,7 @@ public class MecanumDrivePoseEstimator {
    * @return The estimated pose of the robot in meters.
    */
   public Pose2d update(Rotation2d gyroAngle, MecanumDriveWheelPositions wheelPositions) {
-    return updateWithTime(MathSharedStore.getTimestamp() * 1.0e-6, gyroAngle, wheelPositions);
+    return updateWithTime(MathSharedStore.getTimestamp(), gyroAngle, wheelPositions);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -266,7 +266,7 @@ public class SwerveDrivePoseEstimator {
    * @return The estimated pose of the robot in meters.
    */
   public Pose2d update(Rotation2d gyroAngle, SwerveModulePosition[] modulePositions) {
-    return updateWithTime(MathSharedStore.getTimestamp() * 1.0e-6, gyroAngle, modulePositions);
+    return updateWithTime(MathSharedStore.getTimestamp(), gyroAngle, modulePositions);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SwerveDrivePoseEstimator.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.math.estimator;
 
+import edu.wpi.first.math.MathSharedStore;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.Nat;
@@ -18,7 +19,6 @@ import edu.wpi.first.math.kinematics.SwerveDriveOdometry;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
-import edu.wpi.first.util.WPIUtilJNI;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -266,7 +266,7 @@ public class SwerveDrivePoseEstimator {
    * @return The estimated pose of the robot in meters.
    */
   public Pose2d update(Rotation2d gyroAngle, SwerveModulePosition[] modulePositions) {
-    return updateWithTime(WPIUtilJNI.now() * 1.0e-6, gyroAngle, modulePositions);
+    return updateWithTime(MathSharedStore.getTimestamp() * 1.0e-6, gyroAngle, modulePositions);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -4,7 +4,7 @@
 
 package edu.wpi.first.math.filter;
 
-import edu.wpi.first.util.WPIUtilJNI;
+import edu.wpi.first.math.MathSharedStore;
 
 /**
  * A simple debounce filter for boolean streams. Requires that the boolean change value from
@@ -60,11 +60,11 @@ public class Debouncer {
   }
 
   private void resetTimer() {
-    m_prevTimeSeconds = WPIUtilJNI.now() * 1e-6;
+    m_prevTimeSeconds = MathSharedStore.getTimestamp() * 1e-6;
   }
 
   private boolean hasElapsed() {
-    return (WPIUtilJNI.now() * 1e-6) - m_prevTimeSeconds >= m_debounceTimeSeconds;
+    return (MathSharedStore.getTimestamp() * 1e-6) - m_prevTimeSeconds >= m_debounceTimeSeconds;
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java
@@ -60,11 +60,11 @@ public class Debouncer {
   }
 
   private void resetTimer() {
-    m_prevTimeSeconds = MathSharedStore.getTimestamp() * 1e-6;
+    m_prevTimeSeconds = MathSharedStore.getTimestamp();
   }
 
   private boolean hasElapsed() {
-    return (MathSharedStore.getTimestamp() * 1e-6) - m_prevTimeSeconds >= m_debounceTimeSeconds;
+    return MathSharedStore.getTimestamp() - m_prevTimeSeconds >= m_debounceTimeSeconds;
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
@@ -33,7 +33,7 @@ public class SlewRateLimiter {
     m_positiveRateLimit = positiveRateLimit;
     m_negativeRateLimit = negativeRateLimit;
     m_prevVal = initialValue;
-    m_prevTime = MathSharedStore.getTimestamp() * 1e-6;
+    m_prevTime = MathSharedStore.getTimestamp();
   }
 
   /**
@@ -67,7 +67,7 @@ public class SlewRateLimiter {
    * @return The filtered value, which will not change faster than the slew rate.
    */
   public double calculate(double input) {
-    double currentTime = MathSharedStore.getTimestamp() * 1e-6;
+    double currentTime = MathSharedStore.getTimestamp();
     double elapsedTime = currentTime - m_prevTime;
     m_prevVal +=
         MathUtil.clamp(
@@ -85,6 +85,6 @@ public class SlewRateLimiter {
    */
   public void reset(double value) {
     m_prevVal = value;
-    m_prevTime = MathSharedStore.getTimestamp() * 1e-6;
+    m_prevTime = MathSharedStore.getTimestamp();
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/SlewRateLimiter.java
@@ -4,8 +4,8 @@
 
 package edu.wpi.first.math.filter;
 
+import edu.wpi.first.math.MathSharedStore;
 import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.util.WPIUtilJNI;
 
 /**
  * A class that limits the rate of change of an input value. Useful for implementing voltage,
@@ -33,7 +33,7 @@ public class SlewRateLimiter {
     m_positiveRateLimit = positiveRateLimit;
     m_negativeRateLimit = negativeRateLimit;
     m_prevVal = initialValue;
-    m_prevTime = WPIUtilJNI.now() * 1e-6;
+    m_prevTime = MathSharedStore.getTimestamp() * 1e-6;
   }
 
   /**
@@ -67,7 +67,7 @@ public class SlewRateLimiter {
    * @return The filtered value, which will not change faster than the slew rate.
    */
   public double calculate(double input) {
-    double currentTime = WPIUtilJNI.now() * 1e-6;
+    double currentTime = MathSharedStore.getTimestamp() * 1e-6;
     double elapsedTime = currentTime - m_prevTime;
     m_prevVal +=
         MathUtil.clamp(
@@ -85,6 +85,6 @@ public class SlewRateLimiter {
    */
   public void reset(double value) {
     m_prevVal = value;
-    m_prevTime = WPIUtilJNI.now() * 1e-6;
+    m_prevTime = MathSharedStore.getTimestamp() * 1e-6;
   }
 }

--- a/wpimath/src/main/native/cpp/MathShared.cpp
+++ b/wpimath/src/main/native/cpp/MathShared.cpp
@@ -5,6 +5,7 @@
 #include "wpimath/MathShared.h"
 
 #include <wpi/mutex.h>
+#include <wpi/timestamp.h>
 
 using namespace wpi::math;
 
@@ -15,7 +16,9 @@ class DefaultMathShared : public MathShared {
   void ReportWarningV(fmt::string_view format, fmt::format_args args) override {
   }
   void ReportUsage(MathUsageId id, int count) override {}
-  uint64_t GetTimestamp() override { return 0; }
+  units::second_t GetTimestamp() override {
+    return units::microsecond_t(wpi::Now());
+  }
 };
 }  // namespace
 

--- a/wpimath/src/main/native/cpp/MathShared.cpp
+++ b/wpimath/src/main/native/cpp/MathShared.cpp
@@ -15,6 +15,9 @@ class DefaultMathShared : public MathShared {
   void ReportWarningV(fmt::string_view format, fmt::format_args args) override {
   }
   void ReportUsage(MathUsageId id, int count) override {}
+  uint64_t GetTimestamp() override {
+    return 0;
+  }
 };
 }  // namespace
 

--- a/wpimath/src/main/native/cpp/MathShared.cpp
+++ b/wpimath/src/main/native/cpp/MathShared.cpp
@@ -7,6 +7,8 @@
 #include <wpi/mutex.h>
 #include <wpi/timestamp.h>
 
+#include "units/time.h"
+
 using namespace wpi::math;
 
 namespace {

--- a/wpimath/src/main/native/cpp/MathShared.cpp
+++ b/wpimath/src/main/native/cpp/MathShared.cpp
@@ -15,9 +15,7 @@ class DefaultMathShared : public MathShared {
   void ReportWarningV(fmt::string_view format, fmt::format_args args) override {
   }
   void ReportUsage(MathUsageId id, int count) override {}
-  uint64_t GetTimestamp() override {
-    return 0;
-  }
+  uint64_t GetTimestamp() override { return 0; }
 };
 }  // namespace
 

--- a/wpimath/src/main/native/cpp/MathShared.cpp
+++ b/wpimath/src/main/native/cpp/MathShared.cpp
@@ -19,7 +19,7 @@ class DefaultMathShared : public MathShared {
   }
   void ReportUsage(MathUsageId id, int count) override {}
   units::second_t GetTimestamp() override {
-    return units::microsecond_t(wpi::Now());
+    return units::second_t{wpi::Now() * 1.0e-6};
   }
 };
 }  // namespace

--- a/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
@@ -153,9 +153,7 @@ void DifferentialDrivePoseEstimator::AddVisionMeasurement(
 Pose2d DifferentialDrivePoseEstimator::Update(const Rotation2d& gyroAngle,
                                               units::meter_t leftDistance,
                                               units::meter_t rightDistance) {
-  return UpdateWithTime(
-      units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()),
-      gyroAngle, leftDistance, rightDistance);
+  return UpdateWithTime(wpi::math::MathSharedStore::GetTimestamp(), gyroAngle, leftDistance, rightDistance);
 }
 
 Pose2d DifferentialDrivePoseEstimator::UpdateWithTime(

--- a/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
@@ -8,7 +8,6 @@
 
 #include "frc/StateSpaceUtil.h"
 #include "frc/estimator/AngleStatistics.h"
-
 #include "wpimath/MathShared.h"
 
 using namespace frc;
@@ -154,8 +153,9 @@ void DifferentialDrivePoseEstimator::AddVisionMeasurement(
 Pose2d DifferentialDrivePoseEstimator::Update(const Rotation2d& gyroAngle,
                                               units::meter_t leftDistance,
                                               units::meter_t rightDistance) {
-  return UpdateWithTime(units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()), gyroAngle,
-                        leftDistance, rightDistance);
+  return UpdateWithTime(
+      units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()),
+      gyroAngle, leftDistance, rightDistance);
 }
 
 Pose2d DifferentialDrivePoseEstimator::UpdateWithTime(

--- a/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
@@ -153,7 +153,8 @@ void DifferentialDrivePoseEstimator::AddVisionMeasurement(
 Pose2d DifferentialDrivePoseEstimator::Update(const Rotation2d& gyroAngle,
                                               units::meter_t leftDistance,
                                               units::meter_t rightDistance) {
-  return UpdateWithTime(wpi::math::MathSharedStore::GetTimestamp(), gyroAngle, leftDistance, rightDistance);
+  return UpdateWithTime(wpi::math::MathSharedStore::GetTimestamp(), gyroAngle,
+                        leftDistance, rightDistance);
 }
 
 Pose2d DifferentialDrivePoseEstimator::UpdateWithTime(

--- a/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/DifferentialDrivePoseEstimator.cpp
@@ -9,6 +9,8 @@
 #include "frc/StateSpaceUtil.h"
 #include "frc/estimator/AngleStatistics.h"
 
+#include "wpimath/MathShared.h"
+
 using namespace frc;
 
 DifferentialDrivePoseEstimator::InterpolationRecord
@@ -152,7 +154,7 @@ void DifferentialDrivePoseEstimator::AddVisionMeasurement(
 Pose2d DifferentialDrivePoseEstimator::Update(const Rotation2d& gyroAngle,
                                               units::meter_t leftDistance,
                                               units::meter_t rightDistance) {
-  return UpdateWithTime(units::microsecond_t(wpi::Now()), gyroAngle,
+  return UpdateWithTime(units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()), gyroAngle,
                         leftDistance, rightDistance);
 }
 

--- a/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
@@ -163,9 +163,7 @@ void frc::MecanumDrivePoseEstimator::AddVisionMeasurement(
 Pose2d frc::MecanumDrivePoseEstimator::Update(
     const Rotation2d& gyroAngle,
     const MecanumDriveWheelPositions& wheelPositions) {
-  return UpdateWithTime(
-      units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()),
-      gyroAngle, wheelPositions);
+  return UpdateWithTime(wpi::math::MathSharedStore::GetTimestamp(), gyroAngle, wheelPositions);
 }
 
 Pose2d frc::MecanumDrivePoseEstimator::UpdateWithTime(

--- a/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
@@ -163,7 +163,8 @@ void frc::MecanumDrivePoseEstimator::AddVisionMeasurement(
 Pose2d frc::MecanumDrivePoseEstimator::Update(
     const Rotation2d& gyroAngle,
     const MecanumDriveWheelPositions& wheelPositions) {
-  return UpdateWithTime(wpi::math::MathSharedStore::GetTimestamp(), gyroAngle, wheelPositions);
+  return UpdateWithTime(wpi::math::MathSharedStore::GetTimestamp(), gyroAngle,
+                        wheelPositions);
 }
 
 Pose2d frc::MecanumDrivePoseEstimator::UpdateWithTime(

--- a/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
@@ -8,7 +8,6 @@
 
 #include "frc/StateSpaceUtil.h"
 #include "frc/estimator/AngleStatistics.h"
-
 #include "wpimath/MathShared.h"
 
 using namespace frc;
@@ -164,8 +163,9 @@ void frc::MecanumDrivePoseEstimator::AddVisionMeasurement(
 Pose2d frc::MecanumDrivePoseEstimator::Update(
     const Rotation2d& gyroAngle,
     const MecanumDriveWheelPositions& wheelPositions) {
-  return UpdateWithTime(units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()), gyroAngle,
-                        wheelPositions);
+  return UpdateWithTime(
+      units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()),
+      gyroAngle, wheelPositions);
 }
 
 Pose2d frc::MecanumDrivePoseEstimator::UpdateWithTime(

--- a/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
+++ b/wpimath/src/main/native/cpp/estimator/MecanumDrivePoseEstimator.cpp
@@ -9,6 +9,8 @@
 #include "frc/StateSpaceUtil.h"
 #include "frc/estimator/AngleStatistics.h"
 
+#include "wpimath/MathShared.h"
+
 using namespace frc;
 
 frc::MecanumDrivePoseEstimator::InterpolationRecord
@@ -162,7 +164,7 @@ void frc::MecanumDrivePoseEstimator::AddVisionMeasurement(
 Pose2d frc::MecanumDrivePoseEstimator::Update(
     const Rotation2d& gyroAngle,
     const MecanumDriveWheelPositions& wheelPositions) {
-  return UpdateWithTime(units::microsecond_t(wpi::Now()), gyroAngle,
+  return UpdateWithTime(units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()), gyroAngle,
                         wheelPositions);
 }
 

--- a/wpimath/src/main/native/cpp/filter/Debouncer.cpp
+++ b/wpimath/src/main/native/cpp/filter/Debouncer.cpp
@@ -23,13 +23,11 @@ Debouncer::Debouncer(units::second_t debounceTime, DebounceType type)
 }
 
 void Debouncer::ResetTimer() {
-  m_prevTime = units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp());
+  m_prevTime = wpi::math::MathSharedStore::GetTimestamp();
 }
 
 bool Debouncer::HasElapsed() const {
-  return units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()) -
-             m_prevTime >=
-         m_debounceTime;
+  return wpi::math::MathSharedStore::GetTimestamp() - m_prevTime >= m_debounceTime;
 }
 
 bool Debouncer::Calculate(bool input) {

--- a/wpimath/src/main/native/cpp/filter/Debouncer.cpp
+++ b/wpimath/src/main/native/cpp/filter/Debouncer.cpp
@@ -27,7 +27,8 @@ void Debouncer::ResetTimer() {
 }
 
 bool Debouncer::HasElapsed() const {
-  return wpi::math::MathSharedStore::GetTimestamp() - m_prevTime >= m_debounceTime;
+  return wpi::math::MathSharedStore::GetTimestamp() - m_prevTime >=
+         m_debounceTime;
 }
 
 bool Debouncer::Calculate(bool input) {

--- a/wpimath/src/main/native/cpp/filter/Debouncer.cpp
+++ b/wpimath/src/main/native/cpp/filter/Debouncer.cpp
@@ -4,6 +4,8 @@
 
 #include "frc/filter/Debouncer.h"
 
+#include "wpimath/MathShared.h"
+
 using namespace frc;
 
 Debouncer::Debouncer(units::second_t debounceTime, DebounceType type)
@@ -21,11 +23,11 @@ Debouncer::Debouncer(units::second_t debounceTime, DebounceType type)
 }
 
 void Debouncer::ResetTimer() {
-  m_prevTime = units::microsecond_t(wpi::Now());
+  m_prevTime = units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp());
 }
 
 bool Debouncer::HasElapsed() const {
-  return units::microsecond_t(wpi::Now()) - m_prevTime >= m_debounceTime;
+  return units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()) - m_prevTime >= m_debounceTime;
 }
 
 bool Debouncer::Calculate(bool input) {

--- a/wpimath/src/main/native/cpp/filter/Debouncer.cpp
+++ b/wpimath/src/main/native/cpp/filter/Debouncer.cpp
@@ -27,7 +27,9 @@ void Debouncer::ResetTimer() {
 }
 
 bool Debouncer::HasElapsed() const {
-  return units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()) - m_prevTime >= m_debounceTime;
+  return units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()) -
+             m_prevTime >=
+         m_debounceTime;
 }
 
 bool Debouncer::Calculate(bool input) {

--- a/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
@@ -18,7 +18,6 @@
 #include "frc/kinematics/SwerveDriveKinematics.h"
 #include "frc/kinematics/SwerveDriveOdometry.h"
 #include "units/time.h"
-
 #include "wpimath/MathShared.h"
 
 namespace frc {
@@ -273,8 +272,9 @@ class SwerveDrivePoseEstimator {
   Pose2d Update(
       const Rotation2d& gyroAngle,
       const wpi::array<SwerveModulePosition, NumModules>& modulePositions) {
-    return UpdateWithTime(units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()), gyroAngle,
-                          modulePositions);
+    return UpdateWithTime(
+        units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()),
+        gyroAngle, modulePositions);
   }
 
   /**

--- a/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
@@ -19,6 +19,8 @@
 #include "frc/kinematics/SwerveDriveOdometry.h"
 #include "units/time.h"
 
+#include "wpimath/MathShared.h"
+
 namespace frc {
 
 /**
@@ -271,7 +273,7 @@ class SwerveDrivePoseEstimator {
   Pose2d Update(
       const Rotation2d& gyroAngle,
       const wpi::array<SwerveModulePosition, NumModules>& modulePositions) {
-    return UpdateWithTime(units::microsecond_t(wpi::Now()), gyroAngle,
+    return UpdateWithTime(units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()), gyroAngle,
                           modulePositions);
   }
 

--- a/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
@@ -272,7 +272,8 @@ class SwerveDrivePoseEstimator {
   Pose2d Update(
       const Rotation2d& gyroAngle,
       const wpi::array<SwerveModulePosition, NumModules>& modulePositions) {
-    return UpdateWithTime(wpi::math::MathSharedStore::GetTimestamp(), gyroAngle, modulePositions);
+    return UpdateWithTime(wpi::math::MathSharedStore::GetTimestamp(), gyroAngle,
+                          modulePositions);
   }
 
   /**

--- a/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
+++ b/wpimath/src/main/native/include/frc/estimator/SwerveDrivePoseEstimator.h
@@ -272,9 +272,7 @@ class SwerveDrivePoseEstimator {
   Pose2d Update(
       const Rotation2d& gyroAngle,
       const wpi::array<SwerveModulePosition, NumModules>& modulePositions) {
-    return UpdateWithTime(
-        units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp()),
-        gyroAngle, modulePositions);
+    return UpdateWithTime(wpi::math::MathSharedStore::GetTimestamp(), gyroAngle, modulePositions);
   }
 
   /**

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -9,6 +9,8 @@
 #include <wpi/deprecated.h>
 #include <wpi/timestamp.h>
 
+#include "wpimath/MathShared.h"
+
 #include "units/time.h"
 
 namespace frc {
@@ -45,7 +47,7 @@ class SlewRateLimiter {
       : m_positiveRateLimit{positiveRateLimit},
         m_negativeRateLimit{negativeRateLimit},
         m_prevVal{initialValue},
-        m_prevTime{units::microsecond_t(wpi::Now())} {}
+        m_prevTime{units::microsecond_t(wpi::math::MathStoredStore::GetTimestamp())} {}
 
   /**
    * Creates a new SlewRateLimiter with the given positive rate limit and
@@ -77,7 +79,7 @@ class SlewRateLimiter {
    * rate.
    */
   Unit_t Calculate(Unit_t input) {
-    units::second_t currentTime = units::microsecond_t(wpi::Now());
+    units::second_t currentTime = units::microsecond_t(wpi::math::MathStoredStore::GetTimestamp());
     units::second_t elapsedTime = currentTime - m_prevTime;
     m_prevVal +=
         std::clamp(input - m_prevVal, m_negativeRateLimit * elapsedTime,
@@ -94,7 +96,7 @@ class SlewRateLimiter {
    */
   void Reset(Unit_t value) {
     m_prevVal = value;
-    m_prevTime = units::microsecond_t(wpi::Now());
+    m_prevTime = units::microsecond_t(wpi::math::MathStoredStore::GetTimestamp());
   }
 
  private:

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -47,7 +47,7 @@ class SlewRateLimiter {
         m_negativeRateLimit{negativeRateLimit},
         m_prevVal{initialValue},
         m_prevTime{
-            units::microsecond_t(wpi::math::MathStoredStore::GetTimestamp())} {}
+            units::microsecond_t(wpi::math::MathSharedStore::GetTimestamp())} {}
 
   /**
    * Creates a new SlewRateLimiter with the given positive rate limit and
@@ -79,8 +79,7 @@ class SlewRateLimiter {
    * rate.
    */
   Unit_t Calculate(Unit_t input) {
-    units::second_t currentTime =
-        units::microsecond_t(wpi::math::MathStoredStore::GetTimestamp());
+    units::second_t currentTime = wpi::math::MathSharedStore::GetTimestamp();
     units::second_t elapsedTime = currentTime - m_prevTime;
     m_prevVal +=
         std::clamp(input - m_prevVal, m_negativeRateLimit * elapsedTime,
@@ -97,8 +96,7 @@ class SlewRateLimiter {
    */
   void Reset(Unit_t value) {
     m_prevVal = value;
-    m_prevTime =
-        units::microsecond_t(wpi::math::MathStoredStore::GetTimestamp());
+    m_prevTime = wpi::math::MathSharedStore::GetTimestamp();
   }
 
  private:

--- a/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
+++ b/wpimath/src/main/native/include/frc/filter/SlewRateLimiter.h
@@ -9,9 +9,8 @@
 #include <wpi/deprecated.h>
 #include <wpi/timestamp.h>
 
-#include "wpimath/MathShared.h"
-
 #include "units/time.h"
+#include "wpimath/MathShared.h"
 
 namespace frc {
 /**
@@ -47,7 +46,8 @@ class SlewRateLimiter {
       : m_positiveRateLimit{positiveRateLimit},
         m_negativeRateLimit{negativeRateLimit},
         m_prevVal{initialValue},
-        m_prevTime{units::microsecond_t(wpi::math::MathStoredStore::GetTimestamp())} {}
+        m_prevTime{
+            units::microsecond_t(wpi::math::MathStoredStore::GetTimestamp())} {}
 
   /**
    * Creates a new SlewRateLimiter with the given positive rate limit and
@@ -79,7 +79,8 @@ class SlewRateLimiter {
    * rate.
    */
   Unit_t Calculate(Unit_t input) {
-    units::second_t currentTime = units::microsecond_t(wpi::math::MathStoredStore::GetTimestamp());
+    units::second_t currentTime =
+        units::microsecond_t(wpi::math::MathStoredStore::GetTimestamp());
     units::second_t elapsedTime = currentTime - m_prevTime;
     m_prevVal +=
         std::clamp(input - m_prevVal, m_negativeRateLimit * elapsedTime,
@@ -96,7 +97,8 @@ class SlewRateLimiter {
    */
   void Reset(Unit_t value) {
     m_prevVal = value;
-    m_prevTime = units::microsecond_t(wpi::math::MathStoredStore::GetTimestamp());
+    m_prevTime =
+        units::microsecond_t(wpi::math::MathStoredStore::GetTimestamp());
   }
 
  private:

--- a/wpimath/src/main/native/include/wpimath/MathShared.h
+++ b/wpimath/src/main/native/include/wpimath/MathShared.h
@@ -31,6 +31,7 @@ class WPILIB_DLLEXPORT MathShared {
   virtual void ReportWarningV(fmt::string_view format,
                               fmt::format_args args) = 0;
   virtual void ReportUsage(MathUsageId id, int count) = 0;
+  virtual uint64_t GetTimestamp() = 0;
 
   template <typename S, typename... Args>
   inline void ReportError(const S& format, Args&&... args) {
@@ -69,6 +70,10 @@ class WPILIB_DLLEXPORT MathSharedStore {
 
   static void ReportUsage(MathUsageId id, int count) {
     GetMathShared().ReportUsage(id, count);
+  }
+
+  static uint64_t GetTimestamp() {
+    return GetMathShared().GetTimestamp();
   }
 };
 

--- a/wpimath/src/main/native/include/wpimath/MathShared.h
+++ b/wpimath/src/main/native/include/wpimath/MathShared.h
@@ -31,7 +31,7 @@ class WPILIB_DLLEXPORT MathShared {
   virtual void ReportWarningV(fmt::string_view format,
                               fmt::format_args args) = 0;
   virtual void ReportUsage(MathUsageId id, int count) = 0;
-  virtual uint64_t GetTimestamp() = 0;
+  virtual units::second_t GetTimestamp() = 0;
 
   template <typename S, typename... Args>
   inline void ReportError(const S& format, Args&&... args) {
@@ -72,7 +72,7 @@ class WPILIB_DLLEXPORT MathSharedStore {
     GetMathShared().ReportUsage(id, count);
   }
 
-  static uint64_t GetTimestamp() { return GetMathShared().GetTimestamp(); }
+  static units::second_t GetTimestamp() { return GetMathShared().GetTimestamp(); }
 };
 
 }  // namespace wpi::math

--- a/wpimath/src/main/native/include/wpimath/MathShared.h
+++ b/wpimath/src/main/native/include/wpimath/MathShared.h
@@ -74,7 +74,9 @@ class WPILIB_DLLEXPORT MathSharedStore {
     GetMathShared().ReportUsage(id, count);
   }
 
-  static units::second_t GetTimestamp() { return GetMathShared().GetTimestamp(); }
+  static units::second_t GetTimestamp() {
+    return GetMathShared().GetTimestamp();
+  }
 };
 
 }  // namespace wpi::math

--- a/wpimath/src/main/native/include/wpimath/MathShared.h
+++ b/wpimath/src/main/native/include/wpimath/MathShared.h
@@ -72,9 +72,7 @@ class WPILIB_DLLEXPORT MathSharedStore {
     GetMathShared().ReportUsage(id, count);
   }
 
-  static uint64_t GetTimestamp() {
-    return GetMathShared().GetTimestamp();
-  }
+  static uint64_t GetTimestamp() { return GetMathShared().GetTimestamp(); }
 };
 
 }  // namespace wpi::math

--- a/wpimath/src/main/native/include/wpimath/MathShared.h
+++ b/wpimath/src/main/native/include/wpimath/MathShared.h
@@ -9,6 +9,8 @@
 #include <fmt/format.h>
 #include <wpi/SymbolExports.h>
 
+#include "units/time.h"
+
 namespace wpi::math {
 
 enum class MathUsageId {


### PR DESCRIPTION
This makes it possible to mock the timestamp for wpimath without affecting the rest of the library, related to [Mechanical-Advantage#33](https://github.com/Mechanical-Advantage/AdvantageKit/issues/33). Still TBD:

- Should the default implementation (before being overriden by RobotBase) return zero or use wpi::now?
- Should the C++ function include units or return an int like wpi::now?