### PR TITLE
[examples] MecanumDrive: Fix axis comment in C++ example (NFC)

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/MecanumDrive/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumDrive/cpp/Robot.cpp
@@ -21,7 +21,7 @@ class Robot : public frc::TimedRobot {
   }
 
   void TeleopPeriodic() override {
-    /* Use the joystick X axis for forward movement, Y axis for lateral
+    /* Use the joystick Y axis for forward movement, X axis for lateral
      * movement, and Z axis for rotation.
      */
     m_robotDrive.DriveCartesian(-m_stick.GetY(), -m_stick.GetX(),


### PR DESCRIPTION
Fixes #5075