### PR TITLE
Improve documentation of addRequirements (NFC)

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandBase.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandBase.java
@@ -26,12 +26,11 @@ public abstract class CommandBase implements Sendable, Command {
   }
 
   /**
-   * Adds the specified subsystems to the requirements of the command.
-   * The scheduler will prevent two commands that require the same subsystem
-   * from being scheduled simultaneously.  
+   * Adds the specified subsystems to the requirements of the command. The scheduler will prevent
+   * two commands that require the same subsystem from being scheduled simultaneously.
    *
-   * Note that the scheduler determines the requirements of a command when it
-   * is scheduled, so this method should normally be called from the command's constructor.
+   * <p>Note that the scheduler determines the requirements of a command when it is scheduled, so
+   * this method should normally be called from the command's constructor.
    *
    * @param requirements the requirements to add
    */

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandBase.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandBase.java
@@ -26,7 +26,12 @@ public abstract class CommandBase implements Sendable, Command {
   }
 
   /**
-   * Adds the specified requirements to the command.
+   * Adds the specified subsystems to the requirements of the command.
+   * The scheduler will prevent two commands that require the same subsystem
+   * from being scheduled simultaneously.  
+   *
+   * Note that the scheduler determines the requirements of a command when it
+   * is scheduled, so this method should normally be called from the command's constructor.
    *
    * @param requirements the requirements to add
    */

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandBase.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandBase.h
@@ -29,10 +29,11 @@ class CommandBase : public Command,
    * Adds the specified Subsystem requirements to the command.
    *
    * The scheduler will prevent two commands that require the same subsystem
-   * from being scheduled simultaneously.  
+   * from being scheduled simultaneously.
    *
    * Note that the scheduler determines the requirements of a command when it
-   * is scheduled, so this method should normally be called from the command's constructor.
+   * is scheduled, so this method should normally be called from the command's
+   * constructor.
    *
    * @param requirements the Subsystem requirements to add
    */
@@ -42,10 +43,11 @@ class CommandBase : public Command,
    * Adds the specified Subsystem requirements to the command.
    *
    * The scheduler will prevent two commands that require the same subsystem
-   * from being scheduled simultaneously.  
+   * from being scheduled simultaneously.
    *
    * Note that the scheduler determines the requirements of a command when it
-   * is scheduled, so this method should normally be called from the command's constructor.
+   * is scheduled, so this method should normally be called from the command's
+   * constructor.
    *
    * @param requirements the Subsystem requirements to add
    */
@@ -55,10 +57,11 @@ class CommandBase : public Command,
    * Adds the specified Subsystem requirements to the command.
    *
    * The scheduler will prevent two commands that require the same subsystem
-   * from being scheduled simultaneously.  
+   * from being scheduled simultaneously.
    *
    * Note that the scheduler determines the requirements of a command when it
-   * is scheduled, so this method should normally be called from the command's constructor.
+   * is scheduled, so this method should normally be called from the command's
+   * constructor.
    *
    * @param requirements the Subsystem requirements to add
    */
@@ -68,10 +71,11 @@ class CommandBase : public Command,
    * Adds the specified Subsystem requirement to the command.
    *
    * The scheduler will prevent two commands that require the same subsystem
-   * from being scheduled simultaneously.  
+   * from being scheduled simultaneously.
    *
    * Note that the scheduler determines the requirements of a command when it
-   * is scheduled, so this method should normally be called from the command's constructor.
+   * is scheduled, so this method should normally be called from the command's
+   * constructor.
    *
    * @param requirement the Subsystem requirement to add
    */

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandBase.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandBase.h
@@ -28,12 +28,24 @@ class CommandBase : public Command,
   /**
    * Adds the specified Subsystem requirements to the command.
    *
+   * The scheduler will prevent two commands that require the same subsystem
+   * from being scheduled simultaneously.  
+   *
+   * Note that the scheduler determines the requirements of a command when it
+   * is scheduled, so this method should normally be called from the command's constructor.
+   *
    * @param requirements the Subsystem requirements to add
    */
   void AddRequirements(std::initializer_list<Subsystem*> requirements);
 
   /**
    * Adds the specified Subsystem requirements to the command.
+   *
+   * The scheduler will prevent two commands that require the same subsystem
+   * from being scheduled simultaneously.  
+   *
+   * Note that the scheduler determines the requirements of a command when it
+   * is scheduled, so this method should normally be called from the command's constructor.
    *
    * @param requirements the Subsystem requirements to add
    */
@@ -42,12 +54,24 @@ class CommandBase : public Command,
   /**
    * Adds the specified Subsystem requirements to the command.
    *
+   * The scheduler will prevent two commands that require the same subsystem
+   * from being scheduled simultaneously.  
+   *
+   * Note that the scheduler determines the requirements of a command when it
+   * is scheduled, so this method should normally be called from the command's constructor.
+   *
    * @param requirements the Subsystem requirements to add
    */
   void AddRequirements(wpi::SmallSet<Subsystem*, 4> requirements);
 
   /**
    * Adds the specified Subsystem requirement to the command.
+   *
+   * The scheduler will prevent two commands that require the same subsystem
+   * from being scheduled simultaneously.  
+   *
+   * Note that the scheduler determines the requirements of a command when it
+   * is scheduled, so this method should normally be called from the command's constructor.
    *
    * @param requirement the Subsystem requirement to add
    */


### PR DESCRIPTION
I see robot code where `addRequirements` is being called in the command `initialize` method, which won't do much good, but the documentation doesn't make this clear.