### PR TITLE
Use PH voltage to calc analog pressure switch threshold

### DIFF
--- a/wpilibc/src/main/native/cpp/PneumaticHub.cpp
+++ b/wpilibc/src/main/native/cpp/PneumaticHub.cpp
@@ -162,8 +162,10 @@ void PneumaticHub::EnableCompressorAnalog(
                         maxPressure);
   }
   int32_t status = 0;
-  units::volt_t minAnalogVoltage = PSIToVolts(minPressure, 5_V);
-  units::volt_t maxAnalogVoltage = PSIToVolts(maxPressure, 5_V);
+  units::volt_t minAnalogVoltage =
+      PSIToVolts(minPressure, Get5VRegulatedVoltage());
+  units::volt_t maxAnalogVoltage =
+      PSIToVolts(maxPressure, Get5VRegulatedVoltage());
   HAL_SetREVPHClosedLoopControlAnalog(m_handle, minAnalogVoltage.value(),
                                       maxAnalogVoltage.value(), &status);
   FRC_ReportError(status, "Module {}", m_module);
@@ -187,8 +189,10 @@ void PneumaticHub::EnableCompressorHybrid(
                         maxPressure);
   }
   int32_t status = 0;
-  units::volt_t minAnalogVoltage = PSIToVolts(minPressure, 5_V);
-  units::volt_t maxAnalogVoltage = PSIToVolts(maxPressure, 5_V);
+  units::volt_t minAnalogVoltage =
+      PSIToVolts(minPressure, Get5VRegulatedVoltage());
+  units::volt_t maxAnalogVoltage =
+      PSIToVolts(maxPressure, Get5VRegulatedVoltage());
   HAL_SetREVPHClosedLoopControlHybrid(m_handle, minAnalogVoltage.value(),
                                       maxAnalogVoltage.value(), &status);
   FRC_ReportError(status, "Module {}", m_module);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
@@ -294,8 +294,8 @@ public class PneumaticHub implements PneumaticsBase {
       throw new IllegalArgumentException(
           "maxPressure must be between 0 and 120 PSI, got " + maxPressure);
     }
-    double minAnalogVoltage = psiToVolts(minPressure, 5);
-    double maxAnalogVoltage = psiToVolts(maxPressure, 5);
+    double minAnalogVoltage = psiToVolts(minPressure, get5VRegulatedVoltage());
+    double maxAnalogVoltage = psiToVolts(maxPressure, get5VRegulatedVoltage());
     REVPHJNI.setClosedLoopControlAnalog(m_handle, minAnalogVoltage, maxAnalogVoltage);
   }
 
@@ -339,8 +339,8 @@ public class PneumaticHub implements PneumaticsBase {
       throw new IllegalArgumentException(
           "maxPressure must be between 0 and 120 PSI, got " + maxPressure);
     }
-    double minAnalogVoltage = psiToVolts(minPressure, 5);
-    double maxAnalogVoltage = psiToVolts(maxPressure, 5);
+    double minAnalogVoltage = psiToVolts(minPressure, get5VRegulatedVoltage());
+    double maxAnalogVoltage = psiToVolts(maxPressure, get5VRegulatedVoltage());
     REVPHJNI.setClosedLoopControlHybrid(m_handle, minAnalogVoltage, maxAnalogVoltage);
   }
 


### PR DESCRIPTION
The calculated analog pressure switch trigger voltages were calculated with a hard coded 5v. This introuduces error when the 5V provided to the Analog pressure sensor is not exactly 5v, as the pressure is a ratio of the analog voltage and provideed voltage.

This should improve
https://www.chiefdelphi.com/t/rev-pressure-sensor-enablecompressoranalog-not-reaching-configured-pressure/426868 where the 5v voltage was 4.92 volts, which introduces ~8 PSI of error.