### PR TITLE
Go back to specifying PH voltage thresholds for a 5V rail that is exactly 5V

### DIFF
--- a/wpilibc/src/main/native/cpp/PneumaticHub.cpp
+++ b/wpilibc/src/main/native/cpp/PneumaticHub.cpp
@@ -161,11 +161,14 @@ void PneumaticHub::EnableCompressorAnalog(
                         "maxPressure must be between 0 and 120 PSI, got {}",
                         maxPressure);
   }
+  
+  // Send the voltage as it would be if the 5V rail was at exactly 5V.
+  // The firmware will compensate for the real 5V rail voltage, which
+  // can fluctuate somewhat over time.
+  units::volt_t minAnalogVoltage = PSIToVolts(minPressure, 5_V);
+  units::volt_t maxAnalogVoltage = PSIToVolts(maxPressure, 5_V);
+
   int32_t status = 0;
-  units::volt_t minAnalogVoltage =
-      PSIToVolts(minPressure, Get5VRegulatedVoltage());
-  units::volt_t maxAnalogVoltage =
-      PSIToVolts(maxPressure, Get5VRegulatedVoltage());
   HAL_SetREVPHClosedLoopControlAnalog(m_handle, minAnalogVoltage.value(),
                                       maxAnalogVoltage.value(), &status);
   FRC_ReportError(status, "Module {}", m_module);
@@ -188,11 +191,14 @@ void PneumaticHub::EnableCompressorHybrid(
                         "maxPressure must be between 0 and 120 PSI, got {}",
                         maxPressure);
   }
+ 
+  // Send the voltage as it would be if the 5V rail was at exactly 5V.
+  // The firmware will compensate for the real 5V rail voltage, which
+  // can fluctuate somewhat over time.
+  units::volt_t minAnalogVoltage = PSIToVolts(minPressure, 5_V);
+  units::volt_t maxAnalogVoltage = PSIToVolts(maxPressure, 5_V);
+
   int32_t status = 0;
-  units::volt_t minAnalogVoltage =
-      PSIToVolts(minPressure, Get5VRegulatedVoltage());
-  units::volt_t maxAnalogVoltage =
-      PSIToVolts(maxPressure, Get5VRegulatedVoltage());
   HAL_SetREVPHClosedLoopControlHybrid(m_handle, minAnalogVoltage.value(),
                                       maxAnalogVoltage.value(), &status);
   FRC_ReportError(status, "Module {}", m_module);

--- a/wpilibc/src/main/native/cpp/PneumaticHub.cpp
+++ b/wpilibc/src/main/native/cpp/PneumaticHub.cpp
@@ -161,7 +161,7 @@ void PneumaticHub::EnableCompressorAnalog(
                         "maxPressure must be between 0 and 120 PSI, got {}",
                         maxPressure);
   }
-  
+
   // Send the voltage as it would be if the 5V rail was at exactly 5V.
   // The firmware will compensate for the real 5V rail voltage, which
   // can fluctuate somewhat over time.
@@ -191,7 +191,7 @@ void PneumaticHub::EnableCompressorHybrid(
                         "maxPressure must be between 0 and 120 PSI, got {}",
                         maxPressure);
   }
- 
+
   // Send the voltage as it would be if the 5V rail was at exactly 5V.
   // The firmware will compensate for the real 5V rail voltage, which
   // can fluctuate somewhat over time.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
@@ -294,7 +294,7 @@ public class PneumaticHub implements PneumaticsBase {
       throw new IllegalArgumentException(
           "maxPressure must be between 0 and 120 PSI, got " + maxPressure);
     }
-    
+
     // Send the voltage as it would be if the 5V rail was at exactly 5V.
     // The firmware will compensate for the real 5V rail voltage, which
     // can fluctuate somewhat over time.
@@ -343,7 +343,7 @@ public class PneumaticHub implements PneumaticsBase {
       throw new IllegalArgumentException(
           "maxPressure must be between 0 and 120 PSI, got " + maxPressure);
     }
-    
+
     // Send the voltage as it would be if the 5V rail was at exactly 5V.
     // The firmware will compensate for the real 5V rail voltage, which
     // can fluctuate somewhat over time.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PneumaticHub.java
@@ -294,8 +294,12 @@ public class PneumaticHub implements PneumaticsBase {
       throw new IllegalArgumentException(
           "maxPressure must be between 0 and 120 PSI, got " + maxPressure);
     }
-    double minAnalogVoltage = psiToVolts(minPressure, get5VRegulatedVoltage());
-    double maxAnalogVoltage = psiToVolts(maxPressure, get5VRegulatedVoltage());
+    
+    // Send the voltage as it would be if the 5V rail was at exactly 5V.
+    // The firmware will compensate for the real 5V rail voltage, which
+    // can fluctuate somewhat over time.
+    double minAnalogVoltage = psiToVolts(minPressure, 5);
+    double maxAnalogVoltage = psiToVolts(maxPressure, 5);
     REVPHJNI.setClosedLoopControlAnalog(m_handle, minAnalogVoltage, maxAnalogVoltage);
   }
 
@@ -339,8 +343,12 @@ public class PneumaticHub implements PneumaticsBase {
       throw new IllegalArgumentException(
           "maxPressure must be between 0 and 120 PSI, got " + maxPressure);
     }
-    double minAnalogVoltage = psiToVolts(minPressure, get5VRegulatedVoltage());
-    double maxAnalogVoltage = psiToVolts(maxPressure, get5VRegulatedVoltage());
+    
+    // Send the voltage as it would be if the 5V rail was at exactly 5V.
+    // The firmware will compensate for the real 5V rail voltage, which
+    // can fluctuate somewhat over time.
+    double minAnalogVoltage = psiToVolts(minPressure, 5);
+    double maxAnalogVoltage = psiToVolts(maxPressure, 5);
     REVPHJNI.setClosedLoopControlHybrid(m_handle, minAnalogVoltage, maxAnalogVoltage);
   }
 


### PR DESCRIPTION
@calcmogul @sciencewhiz @PeterJohnson 

The reason why I was surprised that we hadn't already done #5115 is that we did do it, **in firmware**. The problem with the technique intended by #5115 is that it assumes that the voltage of the 5V rail won't change at all over the course of the match. We had recognized this, and intended for the voltage thresholds to be specified as if the 5V rail was at exactly 5V. The firmware then continually adjusts the thresholds based on the current voltage of the 5V rail. I added comments to explain this in the code, so that the same mistake doesn't get made again in the future.

We're taking this opportunity to double-check that the code in the firmware that does this is working as intended.