### PR TITLE
[wpilibc] Fix DataLogManager crash on exit in sim

### DIFF
--- a/wpilibc/src/main/native/cpp/DataLogManager.cpp
+++ b/wpilibc/src/main/native/cpp/DataLogManager.cpp
@@ -26,7 +26,7 @@ namespace {
 
 struct Thread final : public wpi::SafeThread {
   Thread(std::string_view dir, std::string_view filename, double period);
-  ~Thread();
+  ~Thread() override;
 
   void Main() final;
 

--- a/wpilibc/src/main/native/cpp/DataLogManager.cpp
+++ b/wpilibc/src/main/native/cpp/DataLogManager.cpp
@@ -44,9 +44,7 @@ struct Thread final : public wpi::SafeThread {
 struct Instance {
   Instance(std::string_view dir, std::string_view filename, double period);
   wpi::SafeThreadOwner<Thread> owner;
-  ~Instance() {
-    owner.GetThreadSharedPtr()->StopNTLog(); 
-  }
+  ~Instance() { owner.GetThreadSharedPtr()->StopNTLog(); }
 };
 
 }  // namespace

--- a/wpilibc/src/main/native/cpp/DataLogManager.cpp
+++ b/wpilibc/src/main/native/cpp/DataLogManager.cpp
@@ -283,7 +283,7 @@ Instance::Instance(std::string_view dir, std::string_view filename,
 }
 
 Instance::~Instance() {
-  owner.GetThreadSharedPtr()->StopNTLog(); 
+  owner.GetThreadSharedPtr()->StopNTLog();
 }
 
 static Instance& GetInstance(std::string_view dir = "",

--- a/wpilibc/src/main/native/cpp/DataLogManager.cpp
+++ b/wpilibc/src/main/native/cpp/DataLogManager.cpp
@@ -44,6 +44,9 @@ struct Thread final : public wpi::SafeThread {
 struct Instance {
   Instance(std::string_view dir, std::string_view filename, double period);
   wpi::SafeThreadOwner<Thread> owner;
+  ~Instance() {
+    owner.GetThreadSharedPtr()->StopNTLog(); 
+  }
 };
 
 }  // namespace

--- a/wpilibc/src/main/native/cpp/DataLogManager.cpp
+++ b/wpilibc/src/main/native/cpp/DataLogManager.cpp
@@ -44,7 +44,7 @@ struct Thread final : public wpi::SafeThread {
 struct Instance {
   Instance(std::string_view dir, std::string_view filename, double period);
   wpi::SafeThreadOwner<Thread> owner;
-  ~Instance() { owner.GetThreadSharedPtr()->StopNTLog(); }
+  ~Instance();
 };
 
 }  // namespace
@@ -280,6 +280,10 @@ Instance::Instance(std::string_view dir, std::string_view filename,
   }
 
   owner.Start(logDir, filename, period);
+}
+
+Instance::~Instance() {
+  owner.GetThreadSharedPtr()->StopNTLog(); 
 }
 
 static Instance& GetInstance(std::string_view dir = "",

--- a/wpilibc/src/main/native/cpp/DataLogManager.cpp
+++ b/wpilibc/src/main/native/cpp/DataLogManager.cpp
@@ -43,8 +43,8 @@ struct Thread final : public wpi::SafeThread {
 
 struct Instance {
   Instance(std::string_view dir, std::string_view filename, double period);
-  wpi::SafeThreadOwner<Thread> owner;
   ~Instance();
+  wpi::SafeThreadOwner<Thread> owner;
 };
 
 }  // namespace

--- a/wpilibc/src/main/native/cpp/DataLogManager.cpp
+++ b/wpilibc/src/main/native/cpp/DataLogManager.cpp
@@ -26,6 +26,7 @@ namespace {
 
 struct Thread final : public wpi::SafeThread {
   Thread(std::string_view dir, std::string_view filename, double period);
+  ~Thread();
 
   void Main() final;
 
@@ -43,7 +44,6 @@ struct Thread final : public wpi::SafeThread {
 
 struct Instance {
   Instance(std::string_view dir, std::string_view filename, double period);
-  ~Instance();
   wpi::SafeThreadOwner<Thread> owner;
 };
 
@@ -93,6 +93,10 @@ Thread::Thread(std::string_view dir, std::string_view filename, double period)
       m_log{dir, MakeLogFilename(filename), period},
       m_messageLog{m_log, "messages"} {
   StartNTLog();
+}
+
+Thread::~Thread() {
+  StopNTLog();
 }
 
 void Thread::Main() {
@@ -280,10 +284,6 @@ Instance::Instance(std::string_view dir, std::string_view filename,
   }
 
   owner.Start(logDir, filename, period);
-}
-
-Instance::~Instance() {
-  owner.GetThreadSharedPtr()->StopNTLog();
 }
 
 static Instance& GetInstance(std::string_view dir = "",


### PR DESCRIPTION
Closes #5120 

I added an Instance destructor that stops the network tables logging. This prevents the segmentation fault on exit.