### PR TITLE
[wpilibj] Implement caching in RobotBase.getRuntimeType()

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -80,6 +80,8 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
   private EventLoop m_activeButtonLoop = m_defaultButtonLoop;
 
   private boolean m_disabled;
+  
+  private final boolean m_simulation;
 
   // Lists of user-supplied actions to be executed on scheduling events for every command.
   private final List<Consumer<Command>> m_initActions = new ArrayList<>();
@@ -104,6 +106,8 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
           cancelAll();
         });
     LiveWindow.setDisabledListener(this::enable);
+    
+    m_simulation = RobotBase.isSimulation();
   }
 
   /**
@@ -278,7 +282,7 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
     // Run the periodic method of all registered subsystems.
     for (Subsystem subsystem : m_subsystems.keySet()) {
       subsystem.periodic();
-      if (RobotBase.isSimulation()) {
+      if (m_simulation) {
         subsystem.simulationPeriodic();
       }
       m_watchdog.addEpoch(subsystem.getClass().getSimpleName() + ".periodic()");

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotBase.java
@@ -42,7 +42,7 @@ public abstract class RobotBase implements AutoCloseable {
 
   private final MultiSubscriber m_suball;
 
-  private static RuntimeType m_runtimeType = RuntimeType.getValue(HALUtil.getHALRuntimeType());
+  private static RuntimeType m_runtimeType;
 
   private static void setupCameraServerShared() {
     CameraServerShared shared =
@@ -193,6 +193,10 @@ public abstract class RobotBase implements AutoCloseable {
    * @return Current runtime type.
    */
   public static RuntimeType getRuntimeType() {
+    if (m_runtimeType == null) {
+      m_runtimeType = RuntimeType.getValue(HALUtil.getHALRuntimeType();
+    }
+
     return m_runtimeType;
   }
 


### PR DESCRIPTION
Testing from Team 694, StuyPulse has shown that this function call is taking over 50% of the execution time on the robot. 

Here is a profiler to prove it:
![image](https://user-images.githubusercontent.com/28713194/220787801-256ef5bd-45e5-484f-8fc3-eb3f8f6e3f3c.png)
