### PR TITLE
Fix HAL_GetRuntimeType being slow on the roboRIO

### DIFF
--- a/hal/src/main/native/athena/HAL.cpp
+++ b/hal/src/main/native/athena/HAL.cpp
@@ -253,12 +253,10 @@ const char* HAL_GetErrorMessage(int32_t code) {
   }
 }
 
+static HAL_RuntimeType runtimeType = HAL_Runtime_RoboRIO;
+
 HAL_RuntimeType HAL_GetRuntimeType(void) {
-  nLoadOut::tTargetClass targetClass = nLoadOut::getTargetClass();
-  if (targetClass == nLoadOut::kTargetClass_RoboRIO2) {
-    return HAL_Runtime_RoboRIO2;
-  }
-  return HAL_Runtime_RoboRIO;
+  return runtimeType;
 }
 
 int32_t HAL_GetFPGAVersion(int32_t* status) {
@@ -521,6 +519,13 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
 
   if (status != 0) {
     return false;
+  }
+
+  nLoadOut::tTargetClass targetClass = nLoadOut::getTargetClass();
+  if (targetClass == nLoadOut::kTargetClass_RoboRIO2) {
+    runtimeType = HAL_Runtime_RoboRIO2;
+  } else {
+    runtimeType = HAL_Runtime_RoboRIO;
   }
 
   InterruptManager::Initialize(global->getSystemInterface());


### PR DESCRIPTION
Correct fix for #5129

HAL_GetRuntimeType used to be a free call before the roboRIO2 was added. However, nLoadOut::getTargetClass() is not a free call, and I think it actually hits the IPC layer. Cache this value so its not called every time.