### PR TITLE
Fix potential UB in LTV controllers

### DIFF
--- a/wpimath/src/main/native/cpp/controller/LTVDifferentialDriveController.cpp
+++ b/wpimath/src/main/native/cpp/controller/LTVDifferentialDriveController.cpp
@@ -76,6 +76,10 @@ LTVDifferentialDriveController::LTVDifferentialDriveController(
                      frc::LinearQuadraticRegulator<5, 2>{A, B, Q, R, dt}.K());
     }
   }
+
+  if (m_table.empty()) {
+    throw std::runtime_error("LTVDifferentialDriveController: invalid constructor arguments");
+  }
 }
 
 bool LTVDifferentialDriveController::AtReference() const {

--- a/wpimath/src/main/native/cpp/controller/LTVDifferentialDriveController.cpp
+++ b/wpimath/src/main/native/cpp/controller/LTVDifferentialDriveController.cpp
@@ -78,7 +78,8 @@ LTVDifferentialDriveController::LTVDifferentialDriveController(
   }
 
   if (m_table.empty()) {
-    throw std::runtime_error("LTVDifferentialDriveController: invalid constructor arguments");
+    throw std::runtime_error(
+        "LTVDifferentialDriveController: invalid constructor arguments");
   }
 }
 

--- a/wpimath/src/main/native/cpp/controller/LTVUnicycleController.cpp
+++ b/wpimath/src/main/native/cpp/controller/LTVUnicycleController.cpp
@@ -88,7 +88,8 @@ LTVUnicycleController::LTVUnicycleController(
   }
 
   if (m_table.empty()) {
-    throw std::runtime_error("LTVUnicycleController: invalid constructor arguments");
+    throw std::runtime_error(
+        "LTVUnicycleController: invalid constructor arguments");
   }
 }
 

--- a/wpimath/src/main/native/cpp/controller/LTVUnicycleController.cpp
+++ b/wpimath/src/main/native/cpp/controller/LTVUnicycleController.cpp
@@ -86,6 +86,10 @@ LTVUnicycleController::LTVUnicycleController(
                      frc::LinearQuadraticRegulator<3, 2>{A, B, Q, R, dt}.K());
     }
   }
+
+  if (m_table.empty()) {
+    throw std::runtime_error("LTVUnicycleController: invalid constructor arguments");
+  }
 }
 
 bool LTVUnicycleController::AtReference() const {

--- a/wpiutil/src/main/native/include/wpi/interpolating_map.h
+++ b/wpiutil/src/main/native/include/wpi/interpolating_map.h
@@ -80,6 +80,11 @@ class interpolating_map {
    */
   void clear() { m_container.clear(); }
 
+  /**
+   * This is invalid if empty
+   */
+  bool empty() { return m_container.empty(); }
+
  private:
   std::map<Key, Value> m_container;
 };


### PR DESCRIPTION
- If the constructor arguments are incorrect, the table will have zero entries, which will access invalid iterators in interpolating_map::operator[]

Only bad usages of https://github.com/wpilibsuite/allwpilib/issues/5139 I could see