### PR TITLE
[wpimath] Fix Pose3d log returning Twist3d NaN for theta between 1E-9 and 1E-8

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose3d.java
@@ -212,7 +212,7 @@ public class Pose3d implements Interpolatable<Pose3d> {
     double A;
     double B;
     double C;
-    if (Math.abs(theta) < 1E-9) {
+    if (Math.abs(theta) < 1E-8) {
       // Taylor Expansions around θ = 0
       // A = 1/1! - θ²/3! + θ⁴/5!
       // B = 1/2! - θ²/4! + θ⁴/6!

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose3d.java
@@ -268,7 +268,7 @@ public class Pose3d implements Interpolatable<Pose3d> {
     final var thetaSq = theta * theta;
 
     double C;
-    if (Math.abs(theta) < 1E-9) {
+    if (Math.abs(theta) < 1E-8) {
       // Taylor Expansions around θ = 0
       // A = 1/1! - θ²/3! + θ⁴/5!
       // B = 1/2! - θ²/4! + θ⁴/6!

--- a/wpimath/src/main/native/cpp/geometry/Pose3d.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Pose3d.cpp
@@ -82,7 +82,7 @@ Pose3d Pose3d::Exp(const Twist3d& twist) const {
   double A;
   double B;
   double C;
-  if (std::abs(theta) < 1E-9) {
+  if (std::abs(theta) < 1E-8) {
     // Taylor Expansions around θ = 0
     // A = 1/1! - θ²/3! + θ⁴/5!
     // B = 1/2! - θ²/4! + θ⁴/6!
@@ -134,7 +134,7 @@ Twist3d Pose3d::Log(const Pose3d& end) const {
   double thetaSq = theta * theta;
 
   double C;
-  if (std::abs(theta) < 1E-9) {
+  if (std::abs(theta) < 1E-8) {
     // Taylor Expansions around θ = 0
     // A = 1/1! - θ²/3! + θ⁴/5!
     // B = 1/2! - θ²/4! + θ⁴/6!

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Pose3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Pose3dTest.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 class Pose3dTest {
-  private static final double kEpsilon = 1E-8;
+  private static final double kEpsilon = 1E-9;
 
   @Test
   void testTransformByRotations() {

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Pose3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Pose3dTest.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 class Pose3dTest {
-  private static final double kEpsilon = 1E-9;
+  private static final double kEpsilon = 1E-8;
 
   @Test
   void testTransformByRotations() {

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/Pose3dTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/Pose3dTest.java
@@ -6,6 +6,7 @@ package edu.wpi.first.math.geometry;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import edu.wpi.first.math.VecBuilder;
@@ -229,5 +230,27 @@ class Pose3dTest {
                   end.getRotation().getQuaternion().getZ(),
                   eps));
     }
+  }
+
+  @Test
+  void testTwistNaN() {
+    var initialPose =
+        new Pose3d(
+            new Translation3d(6.32, 4.12, 0.00),
+            new Rotation3d(new Quaternion(-0.9999999999999999, 0.0, 0.0, 1.9208309264993548E-8)));
+    var finalPose =
+        new Pose3d(
+            new Translation3d(6.33, 4.15, 0.00),
+            new Rotation3d(new Quaternion(-0.9999999999999999, 0.0, 0.0, 2.416890209039172E-8)));
+
+    var twist = initialPose.log(finalPose);
+
+    assertAll(
+        () -> assertFalse(((Double) twist.dx).isNaN()),
+        () -> assertFalse(((Double) twist.dy).isNaN()),
+        () -> assertFalse(((Double) twist.dz).isNaN()),
+        () -> assertFalse(((Double) twist.rx).isNaN()),
+        () -> assertFalse(((Double) twist.ry).isNaN()),
+        () -> assertFalse(((Double) twist.rz).isNaN()));
   }
 }

--- a/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
@@ -158,10 +158,10 @@ TEST(Pose3dTest, TwistNaN) {
 
   auto twist = initial.Log(final);
 
-  EXPECT_FALSE(std::isnan(twist.dx));
-  EXPECT_FALSE(std::isnan(twist.dy));
-  EXPECT_FALSE(std::isnan(twist.dz));
-  EXPECT_FALSE(std::isnan(twist.rx));
-  EXPECT_FALSE(std::isnan(twist.ry));
-  EXPECT_FALSE(std::isnan(twist.rz));
+  EXPECT_FALSE(std::isnan((double)twist.dx));
+  EXPECT_FALSE(std::isnan((double)twist.dy));
+  EXPECT_FALSE(std::isnan((double)twist.dz));
+  EXPECT_FALSE(std::isnan((double)twist.rx));
+  EXPECT_FALSE(std::isnan((double)twist.ry));
+  EXPECT_FALSE(std::isnan((double)twist.rz));
 }

--- a/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
@@ -158,10 +158,10 @@ TEST(Pose3dTest, TwistNaN) {
 
   auto twist = initial.Log(final);
 
-  EXPECT_FALSE(std::isnan((double)twist.dx));
-  EXPECT_FALSE(std::isnan((double)twist.dy));
-  EXPECT_FALSE(std::isnan((double)twist.dz));
-  EXPECT_FALSE(std::isnan((double)twist.rx));
-  EXPECT_FALSE(std::isnan((double)twist.ry));
-  EXPECT_FALSE(std::isnan((double)twist.rz));
+  EXPECT_FALSE(std::isnan(twist.dx.value()));
+  EXPECT_FALSE(std::isnan(twist.dy.value()));
+  EXPECT_FALSE(std::isnan(twist.dz.value()));
+  EXPECT_FALSE(std::isnan(twist.rx.value()));
+  EXPECT_FALSE(std::isnan(twist.ry.value()));
+  EXPECT_FALSE(std::isnan(twist.rz.value()));
 }

--- a/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
@@ -147,3 +147,19 @@ TEST(Pose3dTest, ComplexTwists) {
                 end.Rotation().GetQuaternion().Z(), eps);
   }
 }
+
+TEST(Pose3dTest, TwistNaN) {
+  const Pose3d initial{6.32_m, 4.12_m, 0.00_m,
+                       Rotation3d{Quaternion{-0.9999999999999999, 0.0, 0.0, 1.9208309264993548E-8}}};
+  const Pose3d final{6.33_m, 4.15_m, 0.00_m,
+                     Rotation3d{Quaternion{-0.9999999999999999, 0.0, 0.0, 2.416890209039172E-8}}};
+
+  auto twist = initialPose.Log(finalPose);
+
+  EXPECT_FALSE(std::isnan(twist.dx));
+  EXPECT_FALSE(std::isnan(twist.dy));
+  EXPECT_FALSE(std::isnan(twist.dz));
+  EXPECT_FALSE(std::isnan(twist.rx));
+  EXPECT_FALSE(std::isnan(twist.ry));
+  EXPECT_FALSE(std::isnan(twist.rz));
+}

--- a/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
@@ -156,7 +156,7 @@ TEST(Pose3dTest, TwistNaN) {
                      Rotation3d{Quaternion{-0.9999999999999999, 0.0, 0.0,
                                            2.416890209039172E-8}}};
 
-  auto twist = initialPose.Log(finalPose);
+  auto twist = initial.Log(final);
 
   EXPECT_FALSE(std::isnan(twist.dx));
   EXPECT_FALSE(std::isnan(twist.dy));

--- a/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
@@ -150,9 +150,11 @@ TEST(Pose3dTest, ComplexTwists) {
 
 TEST(Pose3dTest, TwistNaN) {
   const Pose3d initial{6.32_m, 4.12_m, 0.00_m,
-                       Rotation3d{Quaternion{-0.9999999999999999, 0.0, 0.0, 1.9208309264993548E-8}}};
+                       Rotation3d{Quaternion{-0.9999999999999999, 0.0, 0.0,
+                                             1.9208309264993548E-8}}};
   const Pose3d final{6.33_m, 4.15_m, 0.00_m,
-                     Rotation3d{Quaternion{-0.9999999999999999, 0.0, 0.0, 2.416890209039172E-8}}};
+                     Rotation3d{Quaternion{-0.9999999999999999, 0.0, 0.0,
+                                           2.416890209039172E-8}}};
 
   auto twist = initialPose.Log(finalPose);
 

--- a/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
@@ -12,7 +12,7 @@
 using namespace frc;
 
 TEST(Pose3dTest, TestTransformByRotations) {
-  const double kEpsilon = 1E-8;
+  const double kEpsilon = 1E-9;
 
   const Pose3d initialPose{0_m, 0_m, 0_m, Rotation3d{0_deg, 0_deg, 0_deg}};
   const Transform3d transform1{Translation3d{0_m, 0_m, 0_m},

--- a/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
+++ b/wpimath/src/test/native/cpp/geometry/Pose3dTest.cpp
@@ -12,7 +12,7 @@
 using namespace frc;
 
 TEST(Pose3dTest, TestTransformByRotations) {
-  const double kEpsilon = 1E-9;
+  const double kEpsilon = 1E-8;
 
   const Pose3d initialPose{0_m, 0_m, 0_m, Rotation3d{0_deg, 0_deg, 0_deg}};
   const Transform3d transform1{Translation3d{0_m, 0_m, 0_m},


### PR DESCRIPTION
When a Pose3d log Twist3d is calculated with a `theta` value between 1e-9 and 1e-8, the `C` value becomes infinity and the Twist3d returns with `NaN` values. 

This is particularly a problem in #4943, which is how I found the issue, as `lastOdom.log(currOdom)` is able to make this happen.

Does this break anything, as `1e-9` seems to be the accepted value when comparing floats across the math classes?