### PR TITLE
[wpinet] ParallelTcpConnector: don't connect to duplicate addresses

### DIFF
--- a/wpinet/src/main/native/cpp/ParallelTcpConnector.cpp
+++ b/wpinet/src/main/native/cpp/ParallelTcpConnector.cpp
@@ -76,8 +76,8 @@ static bool AddressEquals(const sockaddr& a, const sockaddr& b) {
            reinterpret_cast<const sockaddr_in&>(b).sin_addr.s_addr;
   }
   if (a.sa_family == AF_INET6) {
-    return std::memcmp(&reinterpret_cast<const sockaddr_in6&>(a).sin6_addr,
-                       &reinterpret_cast<const sockaddr_in6&>(b).sin6_addr,
+    return std::memcmp(&(reinterpret_cast<const sockaddr_in6&>(a).sin6_addr),
+                       &(reinterpret_cast<const sockaddr_in6&>(b).sin6_addr),
                        sizeof(in6_addr)) == 0;
   }
   return false;

--- a/wpinet/src/main/native/include/wpinet/ParallelTcpConnector.h
+++ b/wpinet/src/main/native/include/wpinet/ParallelTcpConnector.h
@@ -115,7 +115,8 @@ class ParallelTcpConnector
   std::shared_ptr<wpi::uv::Timer> m_reconnectTimer;
   std::vector<std::pair<std::string, unsigned int>> m_servers;
   std::vector<std::weak_ptr<wpi::uv::GetAddrInfoReq>> m_resolvers;
-  std::vector<std::weak_ptr<wpi::uv::Tcp>> m_attempts;
+  std::vector<std::pair<sockaddr_storage, std::weak_ptr<wpi::uv::Tcp>>>
+      m_attempts;
   bool m_isConnected{false};
 };
 


### PR DESCRIPTION
There can be duplicate addresses coming out of name resolution; if we already started connecting to an address, don't start another connection attempt.