### PR TITLE
[ntcore] NT4 client: close timed-out connections

### DIFF
--- a/ntcore/src/main/native/cpp/NetworkClient.cpp
+++ b/ntcore/src/main/native/cpp/NetworkClient.cpp
@@ -495,7 +495,7 @@ void NCImpl4::WsConnected(wpi::WebSocket& ws, uv::Tcp& tcp) {
   });
   ws.binary.connect([this](std::span<const uint8_t> data, bool) {
     if (m_clientImpl) {
-      m_clientImpl->ProcessIncomingBinary(data);
+      m_clientImpl->ProcessIncomingBinary(m_loop.Now().count(), data);
     }
   });
 }

--- a/ntcore/src/main/native/cpp/net/ClientImpl.h
+++ b/ntcore/src/main/native/cpp/net/ClientImpl.h
@@ -40,7 +40,7 @@ class ClientImpl {
   ~ClientImpl();
 
   void ProcessIncomingText(std::string_view data);
-  void ProcessIncomingBinary(std::span<const uint8_t> data);
+  void ProcessIncomingBinary(uint64_t curTimeMs, std::span<const uint8_t> data);
   void HandleLocal(std::vector<ClientMessage>&& msgs);
 
   void SendControl(uint64_t curTimeMs);


### PR DESCRIPTION
Pings are sent every 3 seconds.  If we don't see a response to the last ping before it's time to send the next one, close the connection.

Fixes #5146.