### PR TITLE
[cmd docs] CommandScheduler.isComposed: Remove incorrect throws clause (NFC)

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -626,7 +626,6 @@ public final class CommandScheduler implements NTSendable, AutoCloseable {
    *
    * @param command The command to check
    * @return true if composed
-   * @throws IllegalArgumentException if the given commands have already been composed.
    */
   public boolean isComposed(Command command) {
     return getComposedCommands().contains(command);


### PR DESCRIPTION
The `@throws` clause on this comment is wrong.
https://discord.com/channels/176186766946992128/368993897495527424/1084239227996348516