### PR TITLE
[wpilib] DataLogManager: increase time for datetime to be valid

### DIFF
--- a/wpilibc/src/main/native/cpp/DataLogManager.cpp
+++ b/wpilibc/src/main/native/cpp/DataLogManager.cpp
@@ -186,7 +186,7 @@ void Thread::Main() {
       } else {
         dsAttachCount = 0;
       }
-      if (dsAttachCount > 50) {  // 1 second
+      if (dsAttachCount > 300) {  // 6 seconds
         std::time_t now = std::time(nullptr);
         auto tm = std::gmtime(&now);
         if (tm->tm_year > 100) {
@@ -207,7 +207,7 @@ void Thread::Main() {
       } else {
         fmsAttachCount = 0;
       }
-      if (fmsAttachCount > 100) {  // 2 seconds
+      if (fmsAttachCount > 250) {  // 5 seconds
         // match info comes through TCP, so we need to double-check we've
         // actually received it
         auto matchType = DriverStation::GetMatchType();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DataLogManager.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DataLogManager.java
@@ -316,7 +316,7 @@ public final class DataLogManager {
         } else {
           dsAttachCount = 0;
         }
-        if (dsAttachCount > 50) { // 1 second
+        if (dsAttachCount > 300) { // 6 seconds
           LocalDateTime now = LocalDateTime.now(m_utc);
           if (now.getYear() > 2000) {
             // assume local clock is now synchronized to DS, so rename based on
@@ -336,7 +336,7 @@ public final class DataLogManager {
         } else {
           fmsAttachCount = 0;
         }
-        if (fmsAttachCount > 100) { // 2 seconds
+        if (fmsAttachCount > 250) { // 5 seconds
           // match info comes through TCP, so we need to double-check we've
           // actually received it
           DriverStation.MatchType matchType = DriverStation.getMatchType();


### PR DESCRIPTION
There's no signal from NetComm as to when it is valid, and 1 second seems to be marginal.  Increase to 6 seconds for just DS, 5 seconds for FMS attached.