### PR TITLE
[ntcore] Use int64 for datalog type string

### DIFF
--- a/datalogtool/src/main/native/cpp/Exporter.cpp
+++ b/datalogtool/src/main/native/cpp/Exporter.cpp
@@ -466,7 +466,8 @@ static void ValueToCsv(wpi::raw_ostream& os, const Entry& entry,
       fmt::print(os, "{}", val);
       return;
     }
-  } else if (entry.type == "int64") {
+  } else if (entry.type == "int64" || entry.type == "int") {
+    // support "int" for compatibility with old NT4 datalogs
     int64_t val;
     if (record.GetInteger(&val)) {
       fmt::print(os, "{}", val);

--- a/ntcore/src/main/native/cpp/LocalStorage.cpp
+++ b/ntcore/src/main/native/cpp/LocalStorage.cpp
@@ -243,7 +243,7 @@ struct DataLoggerData {
   int Start(TopicData* topic, int64_t time) {
     return log.Start(fmt::format("{}{}", logPrefix,
                                  wpi::drop_front(topic->name, prefix.size())),
-                     topic->typeStr,
+                     topic->typeStr == "int" ? "int64" : topic->typeStr,
                      DataLoggerEntry::MakeMetadata(topic->propertiesStr), time);
   }
 


### PR DESCRIPTION
There's a spec difference between NT4 and datalog for integers; NT4 uses "int", datalog uses "int64". We were using "int" for datalog as well.

Also add backwards compatibility support to datalogtool for treating "int" as "int64".

Fixes #5182.