### PR TITLE
[wpilibj] DriverStation: Fix joystick data logs

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -286,6 +286,7 @@ public final class DriverStation {
       System.arraycopy(axes.m_axes, 0, m_prevAxes.m_axes, 0, count);
     }
 
+    @SuppressWarnings("PMD.AvoidArrayLoops")
     void appendPOVs(HALJoystickPOVs povs, long timestamp) {
       int count = povs.m_count;
       if (m_sizedPOVs == null || m_sizedPOVs.length != count) {


### PR DESCRIPTION
Was logging relative to cached value rather than previously logged value.  Was also logging cached value instead of current loop value.  C++ implementation is correct.

Fixes #5239.