### PR TITLE
Add constants to java gearsbot example

### DIFF
--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
@@ -1,18 +1,16 @@
 package edu.wpi.first.wpilibj.examples.gearsbot;
 
+public final class Constants {
 
-public  final class Constants {
-  
-  public static final class DriveConstants{
+  public static final class DriveConstants {
     public static final int leftMotorPort1 = 0;
     public static final int leftMotorPort2 = 1;
 
     public static final int rightMotorPort1 = 2;
     public static final int rightMotorPort2 = 3;
 
-
-    public static final int[] leftEncoderPorts = {0,1};
-    public static final int[] rightEncoderPorts = {2,3};
+    public static final int[] leftEncoderPorts = {0, 1};
+    public static final int[] rightEncoderPorts = {2, 3};
     public static final boolean leftEncoderReversed = false;
     public static final boolean rightEncoderReversed = false;
 
@@ -21,21 +19,20 @@ public  final class Constants {
 
     public static final int encoderCPR = 1024;
     public static final double wheelDiameterInches = 6;
-    public static final double encoderDistancePerPulse = 
-      // Assumes the encoders are directly mounted on the wheel shafts
-      (wheelDiameterInches * Math.PI) / (double) encoderCPR;
-
+    public static final double encoderDistancePerPulse =
+        // Assumes the encoders are directly mounted on the wheel shafts
+        (wheelDiameterInches * Math.PI) / (double) encoderCPR;
   }
 
-  public static final class ClawConstants{
+  public static final class ClawConstants {
     public static final int motorPort = 7;
-    public static final int contactPort = 5; 
+    public static final int contactPort = 5;
   }
 
-  public static final class WristConstants{
+  public static final class WristConstants {
     public static final int motorPort = 6;
 
-    //these pid constants are not real, and will need to be tuned
+    // these pid constants are not real, and will need to be tuned
     public static final double kP = 0.1;
     public static final double kI = 0.0;
     public static final double kD = 0.0;
@@ -43,54 +40,53 @@ public  final class Constants {
     public static final double kTolerance = 2.5;
 
     public static final int potentiometerPort = 3;
-  };
-  
-  public static final class ElevatorConstants{
+  }
+
+  public static final class ElevatorConstants {
     public static final int motorPort = 5;
     public static final int potentiometerPort = 2;
-    
-    //these pid constants are not real, and will need to be tuned
+
+    // these pid constants are not real, and will need to be tuned
     public static final double kP_real = 4;
     public static final double kI_real = 0.007;
-    
+
     public static final double kP_simulation = 18;
     public static final double kI_simulation = 0.2;
 
     public static final double kD = 0.0;
 
     public static final double kTolerance = 0.005;
-  };
+  }
 
-  public static final class AutoConstants{
+  public static final class AutoConstants {
     public static final double distToBox1 = 0.10;
     public static final double distToBox2 = 0.60;
 
     public static final double wristSetpoint = -45.0;
   }
 
-  public static final class DriveStraightConstants{
-    //these pid constants are not real, and will need to be tuned
+  public static final class DriveStraightConstants {
+    // these pid constants are not real, and will need to be tuned
     public static final double kP = 4.0;
     public static final double kI = 0.0;
     public static final double kD = 0.0;
-    
   }
 
-  public static final class Positions{
+  public static final class Positions {
 
-    public static final class Pickup{
-      public static double wristSetpoint = -45.0;
-      public static double elevatorSetpoint = 0.25;
+    public static final class Pickup {
+      public static final double wristSetpoint = -45.0;
+      public static final double elevatorSetpoint = 0.25;
     }
 
-    public static final class Place{
-      public static double wristSetpoint = 0.0;
-      public static double elevatorSetpoint = 0.25;
+    public static final class Place {
+      public static final double wristSetpoint = 0.0;
+      public static final double elevatorSetpoint = 0.25;
     }
 
-    public static final class PrepareToPickup{
-      public static double wristSetpoint = 0.0;
-      public static double elevatorSetpoint = 0.0;
+    public static final class PrepareToPickup {
+      public static final double wristSetpoint = 0.0;
+      public static final double elevatorSetpoint = 0.0;
     }
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
@@ -1,7 +1,10 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package edu.wpi.first.wpilibj.examples.gearsbot;
 
 public final class Constants {
-
   public static final class DriveConstants {
     public static final int leftMotorPort1 = 0;
     public static final int leftMotorPort2 = 1;
@@ -73,7 +76,6 @@ public final class Constants {
   }
 
   public static final class Positions {
-
     public static final class Pickup {
       public static final double wristSetpoint = -45.0;
       public static final double elevatorSetpoint = 0.25;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
@@ -64,6 +64,8 @@ public  final class Constants {
   public static final class AutoConstants{
     public static final double distToBox1 = 0.10;
     public static final double distToBox2 = 0.60;
+
+    public static final double wristSetpoint = -45.0;
   }
 
   public static final class DriveStraightConstants{

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
@@ -65,4 +65,12 @@ public  final class Constants {
     public static final double distToBox1 = 0.10;
     public static final double distToBox2 = 0.60;
   }
+
+  public static final class DriveStraightConstants{
+    //these pid constants are not real, and will need to be tuned
+    public static final double kP = 4.0;
+    public static final double kI = 0.0;
+    public static final double kD = 0.0;
+    
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
@@ -31,4 +31,17 @@ public  final class Constants {
     public static final int motorPort = 7;
     public static final int contactPort = 5; 
   }
+
+  public static final class WristConstants{
+    public static final int motorPort = 6;
+
+    //these pid constants are not real, and will need to be tuned
+    public static final double kP = 0.1;
+    public static final double kI = 0.0;
+    public static final double kD = 0.0;
+
+    public static final double kTolerance = 2.5;
+
+    public static final int potentiometerPort = 3;
+  };
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
@@ -6,34 +6,34 @@ package edu.wpi.first.wpilibj.examples.gearsbot;
 
 public final class Constants {
   public static final class DriveConstants {
-    public static final int leftMotorPort1 = 0;
-    public static final int leftMotorPort2 = 1;
+    public static final int kLeftMotorPort1 = 0;
+    public static final int kLeftMotorPort2 = 1;
 
-    public static final int rightMotorPort1 = 2;
-    public static final int rightMotorPort2 = 3;
+    public static final int kRightMotorPort1 = 2;
+    public static final int kRightMotorPort2 = 3;
 
-    public static final int[] leftEncoderPorts = {0, 1};
-    public static final int[] rightEncoderPorts = {2, 3};
-    public static final boolean leftEncoderReversed = false;
-    public static final boolean rightEncoderReversed = false;
+    public static final int[] kLeftEncoderPorts = {0, 1};
+    public static final int[] kRightEncoderPorts = {2, 3};
+    public static final boolean kLeftEncoderReversed = false;
+    public static final boolean kRightEncoderReversed = false;
 
-    public static final int rangeFinderPort = 6;
-    public static final int analogGyroPort = 1;
+    public static final int kRangeFinderPort = 6;
+    public static final int kAnalogGyroPort = 1;
 
-    public static final int encoderCPR = 1024;
-    public static final double wheelDiameterInches = 6;
-    public static final double encoderDistancePerPulse =
+    public static final int kEncoderCPR = 1024;
+    public static final double kWheelDiameterInches = 6;
+    public static final double kEncoderDistancePerPulse =
         // Assumes the encoders are directly mounted on the wheel shafts
-        (wheelDiameterInches * Math.PI) / (double) encoderCPR;
+        (kWheelDiameterInches * Math.PI) / (double) kEncoderCPR;
   }
 
   public static final class ClawConstants {
-    public static final int motorPort = 7;
-    public static final int contactPort = 5;
+    public static final int kMotorPort = 7;
+    public static final int kContactPort = 5;
   }
 
   public static final class WristConstants {
-    public static final int motorPort = 6;
+    public static final int kMotorPort = 6;
 
     // these pid constants are not real, and will need to be tuned
     public static final double kP = 0.1;
@@ -42,12 +42,12 @@ public final class Constants {
 
     public static final double kTolerance = 2.5;
 
-    public static final int potentiometerPort = 3;
+    public static final int kPotentiometerPort = 3;
   }
 
   public static final class ElevatorConstants {
-    public static final int motorPort = 5;
-    public static final int potentiometerPort = 2;
+    public static final int kMotorPort = 5;
+    public static final int kPotentiometerPort = 2;
 
     // these pid constants are not real, and will need to be tuned
     public static final double kP_real = 4;
@@ -62,10 +62,10 @@ public final class Constants {
   }
 
   public static final class AutoConstants {
-    public static final double distToBox1 = 0.10;
-    public static final double distToBox2 = 0.60;
+    public static final double kDistToBox1 = 0.10;
+    public static final double kDistToBox2 = 0.60;
 
-    public static final double wristSetpoint = -45.0;
+    public static final double kWristSetpoint = -45.0;
   }
 
   public static final class DriveStraightConstants {
@@ -77,18 +77,18 @@ public final class Constants {
 
   public static final class Positions {
     public static final class Pickup {
-      public static final double wristSetpoint = -45.0;
-      public static final double elevatorSetpoint = 0.25;
+      public static final double kWristSetpoint = -45.0;
+      public static final double kElevatorSetpoint = 0.25;
     }
 
     public static final class Place {
-      public static final double wristSetpoint = 0.0;
-      public static final double elevatorSetpoint = 0.25;
+      public static final double kWristSetpoint = 0.0;
+      public static final double kElevatorSetpoint = 0.25;
     }
 
     public static final class PrepareToPickup {
-      public static final double wristSetpoint = 0.0;
-      public static final double elevatorSetpoint = 0.0;
+      public static final double kWristSetpoint = 0.0;
+      public static final double kElevatorSetpoint = 0.0;
     }
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
@@ -73,4 +73,22 @@ public  final class Constants {
     public static final double kD = 0.0;
     
   }
+
+  public static final class Positions{
+
+    public static final class Pickup{
+      public static double wristSetpoint = -45.0;
+      public static double elevatorSetpoint = 0.25;
+    }
+
+    public static final class Place{
+      public static double wristSetpoint = 0.0;
+      public static double elevatorSetpoint = 0.25;
+    }
+
+    public static final class PrepareToPickup{
+      public static double wristSetpoint = 0.0;
+      public static double elevatorSetpoint = 0.0;
+    }
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
@@ -22,8 +22,13 @@ public  final class Constants {
     public static final int encoderCPR = 1024;
     public static final double wheelDiameterInches = 6;
     public static final double encoderDistancePerPulse = 
-        // Assumes the encoders are directly mounted on the wheel shafts
-        (wheelDiameterInches * Math.PI) / (double) encoderCPR;
+      // Assumes the encoders are directly mounted on the wheel shafts
+      (wheelDiameterInches * Math.PI) / (double) encoderCPR;
 
+  }
+
+  public static final class ClawConstants{
+    public static final int motorPort = 7;
+    public static final int contactPort = 5; 
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
@@ -60,4 +60,9 @@ public  final class Constants {
 
     public static final double kTolerance = 0.005;
   };
+
+  public static final class AutoConstants{
+    public static final double distToBox1 = 0.10;
+    public static final double distToBox2 = 0.60;
+  }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
@@ -44,4 +44,20 @@ public  final class Constants {
 
     public static final int potentiometerPort = 3;
   };
+  
+  public static final class ElevatorConstants{
+    public static final int motorPort = 5;
+    public static final int potentiometerPort = 2;
+    
+    //these pid constants are not real, and will need to be tuned
+    public static final double kP_real = 4;
+    public static final double kI_real = 0.007;
+    
+    public static final double kP_simulation = 18;
+    public static final double kI_simulation = 0.2;
+
+    public static final double kD = 0.0;
+
+    public static final double kTolerance = 0.005;
+  };
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/Constants.java
@@ -1,0 +1,29 @@
+package edu.wpi.first.wpilibj.examples.gearsbot;
+
+
+public  final class Constants {
+  
+  public static final class DriveConstants{
+    public static final int leftMotorPort1 = 0;
+    public static final int leftMotorPort2 = 1;
+
+    public static final int rightMotorPort1 = 2;
+    public static final int rightMotorPort2 = 3;
+
+
+    public static final int[] leftEncoderPorts = {0,1};
+    public static final int[] rightEncoderPorts = {2,3};
+    public static final boolean leftEncoderReversed = false;
+    public static final boolean rightEncoderReversed = false;
+
+    public static final int rangeFinderPort = 6;
+    public static final int analogGyroPort = 1;
+
+    public static final int encoderCPR = 1024;
+    public static final double wheelDiameterInches = 6;
+    public static final double encoderDistancePerPulse = 
+        // Assumes the encoders are directly mounted on the wheel shafts
+        (wheelDiameterInches * Math.PI) / (double) encoderCPR;
+
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Autonomous.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Autonomous.java
@@ -25,7 +25,6 @@ public class Autonomous extends SequentialCommandGroup {
         new SetDistanceToBox(AutoConstants.kDistToBox2, drive),
         // new DriveStraight(-2), // Use Encoders if ultrasonic is broken
         Commands.parallel(
-            new SetWristSetpoint(AutoConstants.kWristSetpoint, wrist),
-            new CloseClaw(claw)));   
+            new SetWristSetpoint(AutoConstants.kWristSetpoint, wrist), new CloseClaw(claw)));
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Autonomous.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Autonomous.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Claw;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Drivetrain;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Elevator;
@@ -18,10 +19,10 @@ public class Autonomous extends SequentialCommandGroup {
     addCommands(
         new PrepareToPickup(claw, wrist, elevator),
         new Pickup(claw, wrist, elevator),
-        new SetDistanceToBox(0.10, drive),
+        new SetDistanceToBox(Constants.AutoConstants.distToBox1, drive),
         // new DriveStraight(4), // Use encoders if ultrasonic is broken
         new Place(claw, wrist, elevator),
-        new SetDistanceToBox(0.60, drive),
+        new SetDistanceToBox(Constants.AutoConstants.distToBox2, drive),
         // new DriveStraight(-2), // Use Encoders if ultrasonic is broken
         Commands.parallel(new SetWristSetpoint(-45, wrist), new CloseClaw(claw)));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Autonomous.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Autonomous.java
@@ -17,13 +17,17 @@ public class Autonomous extends SequentialCommandGroup {
   /** Create a new autonomous command. */
   public Autonomous(Drivetrain drive, Claw claw, Wrist wrist, Elevator elevator) {
     addCommands(
-        new PrepareToPickup(claw, wrist, elevator),
-        new Pickup(claw, wrist, elevator),
-        new SetDistanceToBox(Constants.AutoConstants.distToBox1, drive),
-        // new DriveStraight(4), // Use encoders if ultrasonic is broken
-        new Place(claw, wrist, elevator),
-        new SetDistanceToBox(Constants.AutoConstants.distToBox2, drive),
-        // new DriveStraight(-2), // Use Encoders if ultrasonic is broken
-        Commands.parallel(new SetWristSetpoint(-45, wrist), new CloseClaw(claw)));
+      new PrepareToPickup(claw, wrist, elevator),
+      new Pickup(claw, wrist, elevator),
+      new SetDistanceToBox(Constants.AutoConstants.distToBox1, drive),
+      // new DriveStraight(4), // Use encoders if ultrasonic is broken
+      new Place(claw, wrist, elevator),
+      new SetDistanceToBox(Constants.AutoConstants.distToBox2, drive),
+      // new DriveStraight(-2), // Use Encoders if ultrasonic is broken
+      Commands.parallel(
+        new SetWristSetpoint(Constants.AutoConstants.wristSetpoint, wrist),
+        new CloseClaw(claw)
+      )
+    );
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Autonomous.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Autonomous.java
@@ -4,7 +4,7 @@
 
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
-import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants.AutoConstants;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Claw;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Drivetrain;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Elevator;
@@ -19,13 +19,13 @@ public class Autonomous extends SequentialCommandGroup {
     addCommands(
         new PrepareToPickup(claw, wrist, elevator),
         new Pickup(claw, wrist, elevator),
-        new SetDistanceToBox(Constants.AutoConstants.distToBox1, drive),
+        new SetDistanceToBox(AutoConstants.kDistToBox1, drive),
         // new DriveStraight(4), // Use encoders if ultrasonic is broken
         new Place(claw, wrist, elevator),
-        new SetDistanceToBox(Constants.AutoConstants.distToBox2, drive),
+        new SetDistanceToBox(AutoConstants.kDistToBox2, drive),
         // new DriveStraight(-2), // Use Encoders if ultrasonic is broken
         Commands.parallel(
-            new SetWristSetpoint(Constants.AutoConstants.wristSetpoint, wrist),
-            new CloseClaw(claw)));
+            new SetWristSetpoint(AutoConstants.kWristSetpoint, wrist),
+            new CloseClaw(claw)));   
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Autonomous.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Autonomous.java
@@ -17,17 +17,15 @@ public class Autonomous extends SequentialCommandGroup {
   /** Create a new autonomous command. */
   public Autonomous(Drivetrain drive, Claw claw, Wrist wrist, Elevator elevator) {
     addCommands(
-      new PrepareToPickup(claw, wrist, elevator),
-      new Pickup(claw, wrist, elevator),
-      new SetDistanceToBox(Constants.AutoConstants.distToBox1, drive),
-      // new DriveStraight(4), // Use encoders if ultrasonic is broken
-      new Place(claw, wrist, elevator),
-      new SetDistanceToBox(Constants.AutoConstants.distToBox2, drive),
-      // new DriveStraight(-2), // Use Encoders if ultrasonic is broken
-      Commands.parallel(
-        new SetWristSetpoint(Constants.AutoConstants.wristSetpoint, wrist),
-        new CloseClaw(claw)
-      )
-    );
+        new PrepareToPickup(claw, wrist, elevator),
+        new Pickup(claw, wrist, elevator),
+        new SetDistanceToBox(Constants.AutoConstants.distToBox1, drive),
+        // new DriveStraight(4), // Use encoders if ultrasonic is broken
+        new Place(claw, wrist, elevator),
+        new SetDistanceToBox(Constants.AutoConstants.distToBox2, drive),
+        // new DriveStraight(-2), // Use Encoders if ultrasonic is broken
+        Commands.parallel(
+            new SetWristSetpoint(Constants.AutoConstants.wristSetpoint, wrist),
+            new CloseClaw(claw)));
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
@@ -5,6 +5,7 @@
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
 import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Drivetrain;
 import edu.wpi.first.wpilibj2.command.PIDCommand;
 
@@ -23,7 +24,14 @@ public class DriveStraight extends PIDCommand {
    */
   public DriveStraight(double distance, Drivetrain drivetrain) {
     super(
-        new PIDController(4, 0, 0), drivetrain::getDistance, distance, d -> drivetrain.drive(d, d));
+      new PIDController(
+        Constants.DriveStraightConstants.kP,
+        Constants.DriveStraightConstants.kI,
+        Constants.DriveStraightConstants.kD
+      ), 
+      drivetrain::getDistance,
+      distance, d -> drivetrain.drive(d, d)
+    );
 
     m_drivetrain = drivetrain;
     addRequirements(m_drivetrain);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
@@ -30,7 +30,8 @@ public class DriveStraight extends PIDCommand {
         Constants.DriveStraightConstants.kD
       ), 
       drivetrain::getDistance,
-      distance, d -> drivetrain.drive(d, d)
+      distance,
+      d -> drivetrain.drive(d, d)
     );
 
     m_drivetrain = drivetrain;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
@@ -24,15 +24,13 @@ public class DriveStraight extends PIDCommand {
    */
   public DriveStraight(double distance, Drivetrain drivetrain) {
     super(
-      new PIDController(
-        Constants.DriveStraightConstants.kP,
-        Constants.DriveStraightConstants.kI,
-        Constants.DriveStraightConstants.kD
-      ), 
-      drivetrain::getDistance,
-      distance,
-      d -> drivetrain.drive(d, d)
-    );
+        new PIDController(
+            Constants.DriveStraightConstants.kP,
+            Constants.DriveStraightConstants.kI,
+            Constants.DriveStraightConstants.kD),
+        drivetrain::getDistance,
+        distance,
+        d -> drivetrain.drive(d, d));
 
     m_drivetrain = drivetrain;
     addRequirements(m_drivetrain);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
@@ -25,9 +25,7 @@ public class DriveStraight extends PIDCommand {
   public DriveStraight(double distance, Drivetrain drivetrain) {
     super(
         new PIDController(
-            DriveStraightConstants.kP,
-            DriveStraightConstants.kI,
-            DriveStraightConstants.kD),
+            DriveStraightConstants.kP, DriveStraightConstants.kI, DriveStraightConstants.kD),
         drivetrain::getDistance,
         distance,
         d -> drivetrain.drive(d, d));

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/DriveStraight.java
@@ -5,7 +5,7 @@
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
 import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants.DriveStraightConstants;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Drivetrain;
 import edu.wpi.first.wpilibj2.command.PIDCommand;
 
@@ -25,9 +25,9 @@ public class DriveStraight extends PIDCommand {
   public DriveStraight(double distance, Drivetrain drivetrain) {
     super(
         new PIDController(
-            Constants.DriveStraightConstants.kP,
-            Constants.DriveStraightConstants.kI,
-            Constants.DriveStraightConstants.kD),
+            DriveStraightConstants.kP,
+            DriveStraightConstants.kI,
+            DriveStraightConstants.kD),
         drivetrain::getDistance,
         distance,
         d -> drivetrain.drive(d, d));

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Pickup.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Pickup.java
@@ -4,10 +4,11 @@
 
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Claw;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Elevator;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Wrist;
-import edu.wpi.first.wpilibj2.command.Commands;
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 /**
@@ -23,8 +24,11 @@ public class Pickup extends SequentialCommandGroup {
    */
   public Pickup(Claw claw, Wrist wrist, Elevator elevator) {
     addCommands(
-        new CloseClaw(claw),
-        Commands.parallel(
-            new SetWristSetpoint(-45, wrist), new SetElevatorSetpoint(0.25, elevator)));
+      new CloseClaw(claw),
+      new ParallelCommandGroup(
+        new SetWristSetpoint(Constants.Positions.Pickup.wristSetpoint, wrist),
+        new SetElevatorSetpoint(Constants.Positions.Pickup.elevatorSetpoint, elevator)
+      )
+    );
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Pickup.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Pickup.java
@@ -4,7 +4,7 @@
 
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
-import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants.Positions;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Claw;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Elevator;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Wrist;
@@ -26,7 +26,7 @@ public class Pickup extends SequentialCommandGroup {
     addCommands(
         new CloseClaw(claw),
         Commands.parallel(
-            new SetWristSetpoint(Constants.Positions.Pickup.wristSetpoint, wrist),
-            new SetElevatorSetpoint(Constants.Positions.Pickup.elevatorSetpoint, elevator)));
+            new SetWristSetpoint(Positions.Pickup.kWristSetpoint, wrist),
+            new SetElevatorSetpoint(Positions.Pickup.kElevatorSetpoint, elevator)));
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Pickup.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Pickup.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Claw;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Elevator;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Wrist;
-import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 /**
@@ -25,7 +25,7 @@ public class Pickup extends SequentialCommandGroup {
   public Pickup(Claw claw, Wrist wrist, Elevator elevator) {
     addCommands(
       new CloseClaw(claw),
-      new ParallelCommandGroup(
+      Commands.parallel(
         new SetWristSetpoint(Constants.Positions.Pickup.wristSetpoint, wrist),
         new SetElevatorSetpoint(Constants.Positions.Pickup.elevatorSetpoint, elevator)
       )

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Pickup.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Pickup.java
@@ -24,11 +24,9 @@ public class Pickup extends SequentialCommandGroup {
    */
   public Pickup(Claw claw, Wrist wrist, Elevator elevator) {
     addCommands(
-      new CloseClaw(claw),
-      Commands.parallel(
-        new SetWristSetpoint(Constants.Positions.Pickup.wristSetpoint, wrist),
-        new SetElevatorSetpoint(Constants.Positions.Pickup.elevatorSetpoint, elevator)
-      )
-    );
+        new CloseClaw(claw),
+        Commands.parallel(
+            new SetWristSetpoint(Constants.Positions.Pickup.wristSetpoint, wrist),
+            new SetElevatorSetpoint(Constants.Positions.Pickup.elevatorSetpoint, elevator)));
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Place.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Place.java
@@ -4,7 +4,7 @@
 
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
-import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants.Positions;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Claw;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Elevator;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Wrist;
@@ -21,8 +21,8 @@ public class Place extends SequentialCommandGroup {
    */
   public Place(Claw claw, Wrist wrist, Elevator elevator) {
     addCommands(
-        new SetElevatorSetpoint(Constants.Positions.Place.elevatorSetpoint, elevator),
-        new SetWristSetpoint(Constants.Positions.Place.wristSetpoint, wrist),
+        new SetElevatorSetpoint(Positions.Place.kElevatorSetpoint, elevator),
+        new SetWristSetpoint(Positions.Place.kWristSetpoint, wrist),
         new OpenClaw(claw));
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Place.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Place.java
@@ -21,9 +21,8 @@ public class Place extends SequentialCommandGroup {
    */
   public Place(Claw claw, Wrist wrist, Elevator elevator) {
     addCommands(
-      new SetElevatorSetpoint(Constants.Positions.Place.elevatorSetpoint, elevator),
-      new SetWristSetpoint(Constants.Positions.Place.wristSetpoint, wrist),
-      new OpenClaw(claw)
-    );
+        new SetElevatorSetpoint(Constants.Positions.Place.elevatorSetpoint, elevator),
+        new SetWristSetpoint(Constants.Positions.Place.wristSetpoint, wrist),
+        new OpenClaw(claw));
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Place.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/Place.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Claw;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Elevator;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Wrist;
@@ -20,8 +21,9 @@ public class Place extends SequentialCommandGroup {
    */
   public Place(Claw claw, Wrist wrist, Elevator elevator) {
     addCommands(
-        new SetElevatorSetpoint(0.25, elevator),
-        new SetWristSetpoint(0, wrist),
-        new OpenClaw(claw));
+      new SetElevatorSetpoint(Constants.Positions.Place.elevatorSetpoint, elevator),
+      new SetWristSetpoint(Constants.Positions.Place.wristSetpoint, wrist),
+      new OpenClaw(claw)
+    );
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/PrepareToPickup.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/PrepareToPickup.java
@@ -25,7 +25,6 @@ public class PrepareToPickup extends SequentialCommandGroup {
         new OpenClaw(claw),
         Commands.parallel(
             new SetWristSetpoint(Positions.PrepareToPickup.kWristSetpoint, wrist),
-            new SetElevatorSetpoint(
-                Positions.PrepareToPickup.kElevatorSetpoint, elevator)));
+            new SetElevatorSetpoint(Positions.PrepareToPickup.kElevatorSetpoint, elevator)));
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/PrepareToPickup.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/PrepareToPickup.java
@@ -4,7 +4,7 @@
 
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
-import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants.Positions;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Claw;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Elevator;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Wrist;
@@ -24,8 +24,8 @@ public class PrepareToPickup extends SequentialCommandGroup {
     addCommands(
         new OpenClaw(claw),
         Commands.parallel(
-            new SetWristSetpoint(Constants.Positions.PrepareToPickup.wristSetpoint, wrist),
+            new SetWristSetpoint(Positions.PrepareToPickup.kWristSetpoint, wrist),
             new SetElevatorSetpoint(
-                Constants.Positions.PrepareToPickup.elevatorSetpoint, elevator)));
+                Positions.PrepareToPickup.kElevatorSetpoint, elevator)));
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/PrepareToPickup.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/PrepareToPickup.java
@@ -22,11 +22,10 @@ public class PrepareToPickup extends SequentialCommandGroup {
    */
   public PrepareToPickup(Claw claw, Wrist wrist, Elevator elevator) {
     addCommands(
-      new OpenClaw(claw),
-      Commands.parallel(
-        new SetWristSetpoint(Constants.Positions.PrepareToPickup.wristSetpoint, wrist),
-        new SetElevatorSetpoint(Constants.Positions.PrepareToPickup.elevatorSetpoint, elevator)
-        )
-      );
+        new OpenClaw(claw),
+        Commands.parallel(
+            new SetWristSetpoint(Constants.Positions.PrepareToPickup.wristSetpoint, wrist),
+            new SetElevatorSetpoint(
+                Constants.Positions.PrepareToPickup.elevatorSetpoint, elevator)));
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/PrepareToPickup.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/PrepareToPickup.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Claw;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Elevator;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Wrist;
-import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 /** Make sure the robot is in a state to pickup soda cans. */
@@ -23,7 +23,7 @@ public class PrepareToPickup extends SequentialCommandGroup {
   public PrepareToPickup(Claw claw, Wrist wrist, Elevator elevator) {
     addCommands(
       new OpenClaw(claw),
-      new ParallelCommandGroup(
+      Commands.parallel(
         new SetWristSetpoint(Constants.Positions.PrepareToPickup.wristSetpoint, wrist),
         new SetElevatorSetpoint(Constants.Positions.PrepareToPickup.elevatorSetpoint, elevator)
         )

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/PrepareToPickup.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/commands/PrepareToPickup.java
@@ -4,10 +4,11 @@
 
 package edu.wpi.first.wpilibj.examples.gearsbot.commands;
 
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Claw;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Elevator;
 import edu.wpi.first.wpilibj.examples.gearsbot.subsystems.Wrist;
-import edu.wpi.first.wpilibj2.command.Commands;
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 /** Make sure the robot is in a state to pickup soda cans. */
@@ -21,7 +22,11 @@ public class PrepareToPickup extends SequentialCommandGroup {
    */
   public PrepareToPickup(Claw claw, Wrist wrist, Elevator elevator) {
     addCommands(
-        new OpenClaw(claw),
-        Commands.parallel(new SetWristSetpoint(0, wrist), new SetElevatorSetpoint(0, elevator)));
+      new OpenClaw(claw),
+      new ParallelCommandGroup(
+        new SetWristSetpoint(Constants.Positions.PrepareToPickup.wristSetpoint, wrist),
+        new SetElevatorSetpoint(Constants.Positions.PrepareToPickup.elevatorSetpoint, elevator)
+        )
+      );
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Claw.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Claw.java
@@ -5,7 +5,7 @@
 package edu.wpi.first.wpilibj.examples.gearsbot.subsystems;
 
 import edu.wpi.first.wpilibj.DigitalInput;
-import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants.ClawConstants;
 import edu.wpi.first.wpilibj.motorcontrol.Victor;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -15,8 +15,8 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
  * motors, you should probably use a sensor so that the motors don't stall.
  */
 public class Claw extends SubsystemBase {
-  private final Victor m_motor = new Victor(Constants.ClawConstants.motorPort);
-  private final DigitalInput m_contact = new DigitalInput(Constants.ClawConstants.contactPort);
+  private final Victor m_motor = new Victor(ClawConstants.kMotorPort);
+  private final DigitalInput m_contact = new DigitalInput(ClawConstants.kContactPort);
 
   /** Create a new claw subsystem. */
   public Claw() {

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Claw.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Claw.java
@@ -5,6 +5,7 @@
 package edu.wpi.first.wpilibj.examples.gearsbot.subsystems;
 
 import edu.wpi.first.wpilibj.DigitalInput;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
 import edu.wpi.first.wpilibj.motorcontrol.Victor;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -14,8 +15,8 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
  * motors, you should probably use a sensor so that the motors don't stall.
  */
 public class Claw extends SubsystemBase {
-  private final Victor m_motor = new Victor(7);
-  private final DigitalInput m_contact = new DigitalInput(5);
+  private final Victor m_motor = new Victor(Constants.ClawConstants.motorPort);
+  private final DigitalInput m_contact = new DigitalInput(Constants.ClawConstants.contactPort);
 
   /** Create a new claw subsystem. */
   public Claw() {

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Drivetrain.java
@@ -43,8 +43,7 @@ public class Drivetrain extends SubsystemBase {
           DriveConstants.kRightEncoderPorts[0],
           DriveConstants.kRightEncoderPorts[1],
           DriveConstants.kRightEncoderReversed);
-  private final AnalogInput m_rangefinder =
-      new AnalogInput(DriveConstants.kRangeFinderPort);
+  private final AnalogInput m_rangefinder = new AnalogInput(DriveConstants.kRangeFinderPort);
   private final AnalogGyro m_gyro = new AnalogGyro(DriveConstants.kAnalogGyroPort);
 
   /** Create a new drivetrain subsystem. */

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Drivetrain.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj.AnalogGyro;
 import edu.wpi.first.wpilibj.AnalogInput;
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
-import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants.DriveConstants;
 import edu.wpi.first.wpilibj.examples.gearsbot.Robot;
 import edu.wpi.first.wpilibj.motorcontrol.MotorController;
 import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup;
@@ -23,29 +23,29 @@ public class Drivetrain extends SubsystemBase {
    */
   private final MotorController m_leftMotor =
       new MotorControllerGroup(
-          new PWMSparkMax(Constants.DriveConstants.leftMotorPort1),
-          new PWMSparkMax(Constants.DriveConstants.leftMotorPort2));
+          new PWMSparkMax(DriveConstants.kLeftMotorPort1),
+          new PWMSparkMax(DriveConstants.kLeftMotorPort1));
 
   private final MotorController m_rightMotor =
       new MotorControllerGroup(
-          new PWMSparkMax(Constants.DriveConstants.rightMotorPort1),
-          new PWMSparkMax(Constants.DriveConstants.rightMotorPort2));
+          new PWMSparkMax(DriveConstants.kRightMotorPort2),
+          new PWMSparkMax(DriveConstants.kLeftMotorPort2));
 
   private final DifferentialDrive m_drive = new DifferentialDrive(m_leftMotor, m_rightMotor);
 
   private final Encoder m_leftEncoder =
       new Encoder(
-          Constants.DriveConstants.leftEncoderPorts[0],
-          Constants.DriveConstants.leftEncoderPorts[1],
-          Constants.DriveConstants.leftEncoderReversed);
+          DriveConstants.kLeftEncoderPorts[0],
+          DriveConstants.kLeftEncoderPorts[1],
+          DriveConstants.kLeftEncoderReversed);
   private final Encoder m_rightEncoder =
       new Encoder(
-          Constants.DriveConstants.rightEncoderPorts[0],
-          Constants.DriveConstants.rightEncoderPorts[1],
-          Constants.DriveConstants.rightEncoderReversed);
+          DriveConstants.kRightEncoderPorts[0],
+          DriveConstants.kRightEncoderPorts[1],
+          DriveConstants.kRightEncoderReversed);
   private final AnalogInput m_rangefinder =
-      new AnalogInput(Constants.DriveConstants.rangeFinderPort);
-  private final AnalogGyro m_gyro = new AnalogGyro(Constants.DriveConstants.analogGyroPort);
+      new AnalogInput(DriveConstants.kRangeFinderPort);
+  private final AnalogGyro m_gyro = new AnalogGyro(DriveConstants.kAnalogGyroPort);
 
   /** Create a new drivetrain subsystem. */
   public Drivetrain() {
@@ -62,8 +62,8 @@ public class Drivetrain extends SubsystemBase {
     // simulate 360 tick encoders. This if statement allows for the
     // real robot to handle this difference in devices.
     if (Robot.isReal()) {
-      m_leftEncoder.setDistancePerPulse(Constants.DriveConstants.encoderDistancePerPulse);
-      m_rightEncoder.setDistancePerPulse(Constants.DriveConstants.encoderDistancePerPulse);
+      m_leftEncoder.setDistancePerPulse(DriveConstants.kEncoderDistancePerPulse);
+      m_rightEncoder.setDistancePerPulse(DriveConstants.kEncoderDistancePerPulse);
     } else {
       // Circumference = diameter in feet * pi. 360 tick simulated encoders.
       m_leftEncoder.setDistancePerPulse((4.0 / 12.0 * Math.PI) / 360.0);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Drivetrain.java
@@ -21,29 +21,30 @@ public class Drivetrain extends SubsystemBase {
    * The Drivetrain subsystem incorporates the sensors and actuators attached to the robots chassis.
    * These include four drive motors, a left and right encoder and a gyro.
    */
-  private final MotorController m_leftMotor = new MotorControllerGroup(
-    new PWMSparkMax(Constants.DriveConstants.leftMotorPort1),
-    new PWMSparkMax(Constants.DriveConstants.leftMotorPort2)
-  );
+  private final MotorController m_leftMotor =
+      new MotorControllerGroup(
+          new PWMSparkMax(Constants.DriveConstants.leftMotorPort1),
+          new PWMSparkMax(Constants.DriveConstants.leftMotorPort2));
 
-  private final MotorController m_rightMotor =new MotorControllerGroup(
-    new PWMSparkMax(Constants.DriveConstants.rightMotorPort1),
-    new PWMSparkMax(Constants.DriveConstants.rightMotorPort2)
-  );
+  private final MotorController m_rightMotor =
+      new MotorControllerGroup(
+          new PWMSparkMax(Constants.DriveConstants.rightMotorPort1),
+          new PWMSparkMax(Constants.DriveConstants.rightMotorPort2));
 
   private final DifferentialDrive m_drive = new DifferentialDrive(m_leftMotor, m_rightMotor);
 
-  private final Encoder m_leftEncoder = new Encoder(
-    Constants.DriveConstants.leftEncoderPorts[0],
-    Constants.DriveConstants.leftEncoderPorts[1],
-    Constants.DriveConstants.leftEncoderReversed
-    );
-  private final Encoder m_rightEncoder = new Encoder(
-    Constants.DriveConstants.rightEncoderPorts[0],
-    Constants.DriveConstants.rightEncoderPorts[1],
-    Constants.DriveConstants.rightEncoderReversed
-  );
-  private final AnalogInput m_rangefinder = new AnalogInput(Constants.DriveConstants.rangeFinderPort);
+  private final Encoder m_leftEncoder =
+      new Encoder(
+          Constants.DriveConstants.leftEncoderPorts[0],
+          Constants.DriveConstants.leftEncoderPorts[1],
+          Constants.DriveConstants.leftEncoderReversed);
+  private final Encoder m_rightEncoder =
+      new Encoder(
+          Constants.DriveConstants.rightEncoderPorts[0],
+          Constants.DriveConstants.rightEncoderPorts[1],
+          Constants.DriveConstants.rightEncoderReversed);
+  private final AnalogInput m_rangefinder =
+      new AnalogInput(Constants.DriveConstants.rangeFinderPort);
   private final AnalogGyro m_gyro = new AnalogGyro(Constants.DriveConstants.analogGyroPort);
 
   /** Create a new drivetrain subsystem. */

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Drivetrain.java
@@ -8,6 +8,7 @@ import edu.wpi.first.wpilibj.AnalogGyro;
 import edu.wpi.first.wpilibj.AnalogInput;
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
 import edu.wpi.first.wpilibj.examples.gearsbot.Robot;
 import edu.wpi.first.wpilibj.motorcontrol.MotorController;
 import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup;
@@ -20,18 +21,30 @@ public class Drivetrain extends SubsystemBase {
    * The Drivetrain subsystem incorporates the sensors and actuators attached to the robots chassis.
    * These include four drive motors, a left and right encoder and a gyro.
    */
-  private final MotorController m_leftMotor =
-      new MotorControllerGroup(new PWMSparkMax(0), new PWMSparkMax(1));
+  private final MotorController m_leftMotor = new MotorControllerGroup(
+    new PWMSparkMax(Constants.DriveConstants.leftMotorPort1),
+    new PWMSparkMax(Constants.DriveConstants.leftMotorPort2)
+  );
 
-  private final MotorController m_rightMotor =
-      new MotorControllerGroup(new PWMSparkMax(2), new PWMSparkMax(3));
+  private final MotorController m_rightMotor =new MotorControllerGroup(
+    new PWMSparkMax(Constants.DriveConstants.rightMotorPort1),
+    new PWMSparkMax(Constants.DriveConstants.rightMotorPort2)
+  );
 
   private final DifferentialDrive m_drive = new DifferentialDrive(m_leftMotor, m_rightMotor);
 
-  private final Encoder m_leftEncoder = new Encoder(1, 2);
-  private final Encoder m_rightEncoder = new Encoder(3, 4);
-  private final AnalogInput m_rangefinder = new AnalogInput(6);
-  private final AnalogGyro m_gyro = new AnalogGyro(1);
+  private final Encoder m_leftEncoder = new Encoder(
+    Constants.DriveConstants.leftEncoderPorts[0],
+    Constants.DriveConstants.leftEncoderPorts[1],
+    Constants.DriveConstants.leftEncoderReversed
+    );
+  private final Encoder m_rightEncoder = new Encoder(
+    Constants.DriveConstants.rightEncoderPorts[0],
+    Constants.DriveConstants.rightEncoderPorts[1],
+    Constants.DriveConstants.rightEncoderReversed
+  );
+  private final AnalogInput m_rangefinder = new AnalogInput(Constants.DriveConstants.rangeFinderPort);
+  private final AnalogGyro m_gyro = new AnalogGyro(Constants.DriveConstants.analogGyroPort);
 
   /** Create a new drivetrain subsystem. */
   public Drivetrain() {
@@ -48,8 +61,8 @@ public class Drivetrain extends SubsystemBase {
     // simulate 360 tick encoders. This if statement allows for the
     // real robot to handle this difference in devices.
     if (Robot.isReal()) {
-      m_leftEncoder.setDistancePerPulse(0.042);
-      m_rightEncoder.setDistancePerPulse(0.042);
+      m_leftEncoder.setDistancePerPulse(Constants.DriveConstants.encoderDistancePerPulse);
+      m_rightEncoder.setDistancePerPulse(Constants.DriveConstants.encoderDistancePerPulse);
     } else {
       // Circumference = diameter in feet * pi. 360 tick simulated encoders.
       m_leftEncoder.setDistancePerPulse((4.0 / 12.0 * Math.PI) / 360.0);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
@@ -24,9 +24,7 @@ public class Elevator extends PIDSubsystem {
   public Elevator() {
     super(
         new PIDController(
-            ElevatorConstants.kP_real,
-            ElevatorConstants.kI_real,
-            ElevatorConstants.kD));
+            ElevatorConstants.kP_real, ElevatorConstants.kI_real, ElevatorConstants.kD));
 
     if (Robot.isSimulation()) { // Check for simulation and update PID values
       getController()
@@ -44,7 +42,7 @@ public class Elevator extends PIDSubsystem {
       m_pot = new AnalogPotentiometer(ElevatorConstants.kPotentiometerPort, -2.0 / 5);
     } else {
       // Defaults to meters
-      m_pot = new AnalogPotentiometer(ElevatorConstants.kPotentiometerPort); 
+      m_pot = new AnalogPotentiometer(ElevatorConstants.kPotentiometerPort);
     }
 
     // Let's name everything on the LiveWindow

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
@@ -6,6 +6,7 @@ package edu.wpi.first.wpilibj.examples.gearsbot.subsystems;
 
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj.AnalogPotentiometer;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
 import edu.wpi.first.wpilibj.examples.gearsbot.Robot;
 import edu.wpi.first.wpilibj.motorcontrol.Victor;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -16,32 +17,24 @@ import edu.wpi.first.wpilibj2.command.PIDSubsystem;
  * values for simulation are different than in the real world do to minor differences.
  */
 public class Elevator extends PIDSubsystem {
-  private final Victor m_motor;
+  private final Victor m_motor= new Victor(Constants.ElevatorConstants.motorPort);
   private final AnalogPotentiometer m_pot;
-
-  private static final double kP_real = 4;
-  private static final double kI_real = 0.07;
-  private static final double kP_simulation = 18;
-  private static final double kI_simulation = 0.2;
 
   /** Create a new elevator subsystem. */
   public Elevator() {
-    super(new PIDController(kP_real, kI_real, 0));
-    if (Robot.isSimulation()) { // Check for simulation and update PID values
-      getController().setPID(kP_simulation, kI_simulation, 0);
-    }
-    getController().setTolerance(0.005);
-
-    m_motor = new Victor(5);
+    super(
+      new PIDController(
+        Robot.isSimulation() ? Constants.ElevatorConstants.kP_simulation : Constants.ElevatorConstants.kP_real,
+        Robot.isSimulation() ? Constants.ElevatorConstants.kI_simulation : Constants.ElevatorConstants.kI_real,
+        Constants.ElevatorConstants.kD
+      )
+    );
+    getController().setTolerance(Constants.ElevatorConstants.kTolerance);
 
     // Conversion value of potentiometer varies between the real world and
     // simulation
-    if (Robot.isReal()) {
-      m_pot = new AnalogPotentiometer(2, -2.0 / 5);
-    } else {
-      m_pot = new AnalogPotentiometer(2); // Defaults to meters
-    }
-
+    m_pot = new AnalogPotentiometer(Constants.ElevatorConstants.potentiometerPort,Robot.isReal()? -2.0 / 5 : 1);
+    
     // Let's name everything on the LiveWindow
     addChild("Motor", m_motor);
     addChild("Pot", m_pot);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
@@ -17,7 +17,7 @@ import edu.wpi.first.wpilibj2.command.PIDSubsystem;
  * values for simulation are different than in the real world do to minor differences.
  */
 public class Elevator extends PIDSubsystem {
-  private final Victor m_motor = new Victor(Constants.ElevatorConstants.motorPort);
+  private final Victor m_motor = new Victor(Constants.ElevatorConstants.kMotorPort);
   private final AnalogPotentiometer m_pot;
 
   /** Create a new elevator subsystem. */

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
@@ -24,17 +24,30 @@ public class Elevator extends PIDSubsystem {
   public Elevator() {
     super(
       new PIDController(
-        Robot.isSimulation() ? Constants.ElevatorConstants.kP_simulation : Constants.ElevatorConstants.kP_real,
-        Robot.isSimulation() ? Constants.ElevatorConstants.kI_simulation : Constants.ElevatorConstants.kI_real,
+        Constants.ElevatorConstants.kP_real,
+        Constants.ElevatorConstants.kI_real,
         Constants.ElevatorConstants.kD
       )
     );
+
+    if (Robot.isSimulation()) { // Check for simulation and update PID values
+      getController().setPID(
+        Constants.ElevatorConstants.kP_simulation,
+        Constants.ElevatorConstants.kI_simulation,
+        Constants.ElevatorConstants.kD
+      );
+    }
     getController().setTolerance(Constants.ElevatorConstants.kTolerance);
 
     // Conversion value of potentiometer varies between the real world and
     // simulation
-    m_pot = new AnalogPotentiometer(Constants.ElevatorConstants.potentiometerPort,Robot.isReal()? -2.0 / 5 : 1);
     
+    if (Robot.isReal()) {
+      m_pot = new AnalogPotentiometer(2, -2.0 / 5);
+    } else {
+      m_pot = new AnalogPotentiometer(2); // Defaults to meters
+    }
+
     // Let's name everything on the LiveWindow
     addChild("Motor", m_motor);
     addChild("Pot", m_pot);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
@@ -6,7 +6,7 @@ package edu.wpi.first.wpilibj.examples.gearsbot.subsystems;
 
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj.AnalogPotentiometer;
-import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants.ElevatorConstants;
 import edu.wpi.first.wpilibj.examples.gearsbot.Robot;
 import edu.wpi.first.wpilibj.motorcontrol.Victor;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -17,33 +17,34 @@ import edu.wpi.first.wpilibj2.command.PIDSubsystem;
  * values for simulation are different than in the real world do to minor differences.
  */
 public class Elevator extends PIDSubsystem {
-  private final Victor m_motor = new Victor(Constants.ElevatorConstants.kMotorPort);
+  private final Victor m_motor = new Victor(ElevatorConstants.kMotorPort);
   private final AnalogPotentiometer m_pot;
 
   /** Create a new elevator subsystem. */
   public Elevator() {
     super(
         new PIDController(
-            Constants.ElevatorConstants.kP_real,
-            Constants.ElevatorConstants.kI_real,
-            Constants.ElevatorConstants.kD));
+            ElevatorConstants.kP_real,
+            ElevatorConstants.kI_real,
+            ElevatorConstants.kD));
 
     if (Robot.isSimulation()) { // Check for simulation and update PID values
       getController()
           .setPID(
-              Constants.ElevatorConstants.kP_simulation,
-              Constants.ElevatorConstants.kI_simulation,
-              Constants.ElevatorConstants.kD);
+              ElevatorConstants.kP_simulation,
+              ElevatorConstants.kI_simulation,
+              ElevatorConstants.kD);
     }
-    getController().setTolerance(Constants.ElevatorConstants.kTolerance);
+    getController().setTolerance(ElevatorConstants.kTolerance);
 
     // Conversion value of potentiometer varies between the real world and
     // simulation
 
     if (Robot.isReal()) {
-      m_pot = new AnalogPotentiometer(2, -2.0 / 5);
+      m_pot = new AnalogPotentiometer(ElevatorConstants.kPotentiometerPort, -2.0 / 5);
     } else {
-      m_pot = new AnalogPotentiometer(2); // Defaults to meters
+      // Defaults to meters
+      m_pot = new AnalogPotentiometer(ElevatorConstants.kPotentiometerPort); 
     }
 
     // Let's name everything on the LiveWindow

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Elevator.java
@@ -17,31 +17,29 @@ import edu.wpi.first.wpilibj2.command.PIDSubsystem;
  * values for simulation are different than in the real world do to minor differences.
  */
 public class Elevator extends PIDSubsystem {
-  private final Victor m_motor= new Victor(Constants.ElevatorConstants.motorPort);
+  private final Victor m_motor = new Victor(Constants.ElevatorConstants.motorPort);
   private final AnalogPotentiometer m_pot;
 
   /** Create a new elevator subsystem. */
   public Elevator() {
     super(
-      new PIDController(
-        Constants.ElevatorConstants.kP_real,
-        Constants.ElevatorConstants.kI_real,
-        Constants.ElevatorConstants.kD
-      )
-    );
+        new PIDController(
+            Constants.ElevatorConstants.kP_real,
+            Constants.ElevatorConstants.kI_real,
+            Constants.ElevatorConstants.kD));
 
     if (Robot.isSimulation()) { // Check for simulation and update PID values
-      getController().setPID(
-        Constants.ElevatorConstants.kP_simulation,
-        Constants.ElevatorConstants.kI_simulation,
-        Constants.ElevatorConstants.kD
-      );
+      getController()
+          .setPID(
+              Constants.ElevatorConstants.kP_simulation,
+              Constants.ElevatorConstants.kI_simulation,
+              Constants.ElevatorConstants.kD);
     }
     getController().setTolerance(Constants.ElevatorConstants.kTolerance);
 
     // Conversion value of potentiometer varies between the real world and
     // simulation
-    
+
     if (Robot.isReal()) {
       m_pot = new AnalogPotentiometer(2, -2.0 / 5);
     } else {

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Wrist.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Wrist.java
@@ -21,11 +21,7 @@ public class Wrist extends PIDSubsystem {
 
   /** Create a new wrist subsystem. */
   public Wrist() {
-    super(
-        new PIDController(
-            WristConstants.kP,
-            WristConstants.kI,
-            WristConstants.kD));
+    super(new PIDController(WristConstants.kP, WristConstants.kI, WristConstants.kD));
     getController().setTolerance(WristConstants.kTolerance);
 
     // Conversion value of potentiometer varies between the real world and

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Wrist.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Wrist.java
@@ -21,20 +21,18 @@ public class Wrist extends PIDSubsystem {
 
   /** Create a new wrist subsystem. */
   public Wrist() {
-    super(new PIDController(
-      Constants.WristConstants.kP,
-      Constants.WristConstants.kI,
-      Constants.WristConstants.kD
-    ));
+    super(
+        new PIDController(
+            Constants.WristConstants.kP, Constants.WristConstants.kI, Constants.WristConstants.kD));
     getController().setTolerance(Constants.WristConstants.kTolerance);
-
 
     // Conversion value of potentiometer varies between the real world and
     // simulation
     if (Robot.isReal()) {
       m_pot = new AnalogPotentiometer(Constants.WristConstants.potentiometerPort, -270.0 / 5);
     } else {
-      m_pot = new AnalogPotentiometer(Constants.WristConstants.potentiometerPort); // Defaults to degrees
+      // Defaults to degrees
+      m_pot = new AnalogPotentiometer(Constants.WristConstants.potentiometerPort);
     }
 
     // Let's name everything on the LiveWindow

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Wrist.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Wrist.java
@@ -6,7 +6,7 @@ package edu.wpi.first.wpilibj.examples.gearsbot.subsystems;
 
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj.AnalogPotentiometer;
-import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants.WristConstants;
 import edu.wpi.first.wpilibj.examples.gearsbot.Robot;
 import edu.wpi.first.wpilibj.motorcontrol.Victor;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -16,23 +16,25 @@ import edu.wpi.first.wpilibj2.command.PIDSubsystem;
  * The wrist subsystem is like the elevator, but with a rotational joint instead of a linear joint.
  */
 public class Wrist extends PIDSubsystem {
-  private final Victor m_motor = new Victor(Constants.WristConstants.motorPort);
+  private final Victor m_motor = new Victor(WristConstants.kMotorPort);
   private final AnalogPotentiometer m_pot;
 
   /** Create a new wrist subsystem. */
   public Wrist() {
     super(
         new PIDController(
-            Constants.WristConstants.kP, Constants.WristConstants.kI, Constants.WristConstants.kD));
-    getController().setTolerance(Constants.WristConstants.kTolerance);
+            WristConstants.kP,
+            WristConstants.kI,
+            WristConstants.kD));
+    getController().setTolerance(WristConstants.kTolerance);
 
     // Conversion value of potentiometer varies between the real world and
     // simulation
     if (Robot.isReal()) {
-      m_pot = new AnalogPotentiometer(Constants.WristConstants.potentiometerPort, -270.0 / 5);
+      m_pot = new AnalogPotentiometer(WristConstants.kPotentiometerPort, -270.0 / 5);
     } else {
       // Defaults to degrees
-      m_pot = new AnalogPotentiometer(Constants.WristConstants.potentiometerPort);
+      m_pot = new AnalogPotentiometer(WristConstants.kPotentiometerPort);
     }
 
     // Let's name everything on the LiveWindow

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Wrist.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/gearsbot/subsystems/Wrist.java
@@ -6,6 +6,7 @@ package edu.wpi.first.wpilibj.examples.gearsbot.subsystems;
 
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj.AnalogPotentiometer;
+import edu.wpi.first.wpilibj.examples.gearsbot.Constants;
 import edu.wpi.first.wpilibj.examples.gearsbot.Robot;
 import edu.wpi.first.wpilibj.motorcontrol.Victor;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -15,24 +16,25 @@ import edu.wpi.first.wpilibj2.command.PIDSubsystem;
  * The wrist subsystem is like the elevator, but with a rotational joint instead of a linear joint.
  */
 public class Wrist extends PIDSubsystem {
-  private final Victor m_motor;
+  private final Victor m_motor = new Victor(Constants.WristConstants.motorPort);
   private final AnalogPotentiometer m_pot;
-
-  private static final double kP = 1;
 
   /** Create a new wrist subsystem. */
   public Wrist() {
-    super(new PIDController(kP, 0, 0));
-    getController().setTolerance(2.5);
+    super(new PIDController(
+      Constants.WristConstants.kP,
+      Constants.WristConstants.kI,
+      Constants.WristConstants.kD
+    ));
+    getController().setTolerance(Constants.WristConstants.kTolerance);
 
-    m_motor = new Victor(6);
 
     // Conversion value of potentiometer varies between the real world and
     // simulation
     if (Robot.isReal()) {
-      m_pot = new AnalogPotentiometer(3, -270.0 / 5);
+      m_pot = new AnalogPotentiometer(Constants.WristConstants.potentiometerPort, -270.0 / 5);
     } else {
-      m_pot = new AnalogPotentiometer(3); // Defaults to degrees
+      m_pot = new AnalogPotentiometer(Constants.WristConstants.potentiometerPort); // Defaults to degrees
     }
 
     // Let's name everything on the LiveWindow


### PR DESCRIPTION
Creates a `Constants.java` file for the java GearsBot example, and implements it everywhere applicable.
There are also a few minor changes including replacing `Commands.parallel()` with `new ParallelCommandGroup()` in two instances, and replacing an if gate with a ternary operator in `Elevator.java`, to improve readability

This fixes half of #1948, but these changes are also required on the C++ example