### PR TITLE
Update Team Number Setter Capitalization

### DIFF
--- a/roborioteamnumbersetter/src/main/native/cpp/DeploySession.cpp
+++ b/roborioteamnumbersetter/src/main/native/cpp/DeploySession.cpp
@@ -85,7 +85,7 @@ bool DeploySession::ChangeTeamNumber(const std::string& macAddress,
             session.Execute(fmt::format(
                 "/usr/local/natinst/bin/nirtcfg "
                 "--file=/etc/natinst/share/ni-rt.ini --set "
-                "section=systemsettings,token=host_name,value=roborio-{"
+                "section=systemsettings,token=host_name,value=roboRIO-{"
                 "}-FRC ; sync",
                 teamNumber));
           } catch (const SshSession::SshException& e) {


### PR DESCRIPTION
The current Team Number Setter tool incorrectly configures the roboRIO's hostname to `roborio-TEAM-FRC`, while the roboRIO Imaging Tool configures the hostname to `roboRIO-TEAM-FRC` (note the capitalization).
This PR aims to resolve this discrepancy by making the Team Number Setter tool match the behavior of the Imaging Tool.