### PR TITLE
SingleJointedArmSim add option to set starting state

### DIFF
--- a/wpilibc/src/main/native/cpp/simulation/SingleJointedArmSim.cpp
+++ b/wpilibc/src/main/native/cpp/simulation/SingleJointedArmSim.cpp
@@ -19,6 +19,7 @@ SingleJointedArmSim::SingleJointedArmSim(
     const LinearSystem<2, 1, 1>& system, const DCMotor& gearbox, double gearing,
     units::meter_t armLength, units::radian_t minAngle,
     units::radian_t maxAngle, bool simulateGravity,
+    units::radian_t startingAngleRad,
     const std::array<double, 1>& measurementStdDevs)
     : LinearSystemSim<2, 1, 1>(system, measurementStdDevs),
       m_armLen(armLength),
@@ -26,12 +27,15 @@ SingleJointedArmSim::SingleJointedArmSim(
       m_maxAngle(maxAngle),
       m_gearbox(gearbox),
       m_gearing(gearing),
-      m_simulateGravity(simulateGravity) {}
+      m_simulateGravity(simulateGravity) {
+  SetState(frc::Vectord<2>{startingAngleRad, 0.0});
+}
 
 SingleJointedArmSim::SingleJointedArmSim(
     const DCMotor& gearbox, double gearing, units::kilogram_square_meter_t moi,
     units::meter_t armLength, units::radian_t minAngle,
     units::radian_t maxAngle, bool simulateGravity,
+    units::radian_t startingAngleRad,
     const std::array<double, 1>& measurementStdDevs)
     : SingleJointedArmSim(
           LinearSystemId::SingleJointedArmSystem(gearbox, moi, gearing),

--- a/wpilibc/src/main/native/include/frc/simulation/SingleJointedArmSim.h
+++ b/wpilibc/src/main/native/include/frc/simulation/SingleJointedArmSim.h
@@ -31,12 +31,14 @@ class SingleJointedArmSim : public LinearSystemSim<2, 1, 1> {
    * @param minAngle           The minimum angle that the arm is capable of.
    * @param maxAngle           The maximum angle that the arm is capable of.
    * @param simulateGravity    Whether gravity should be simulated or not.
+   * @param startingAngleRad   The initial position of the arm.
    * @param measurementStdDevs The standard deviations of the measurements.
    */
   SingleJointedArmSim(const LinearSystem<2, 1, 1>& system,
                       const DCMotor& gearbox, double gearing,
                       units::meter_t armLength, units::radian_t minAngle,
                       units::radian_t maxAngle, bool simulateGravity,
+                      units::radian_t startingAngleRad,
                       const std::array<double, 1>& measurementStdDevs = {0.0});
   /**
    * Creates a simulated arm mechanism.
@@ -50,12 +52,14 @@ class SingleJointedArmSim : public LinearSystemSim<2, 1, 1> {
    * @param minAngle           The minimum angle that the arm is capable of.
    * @param maxAngle           The maximum angle that the arm is capable of.
    * @param simulateGravity    Whether gravity should be simulated or not.
+   * @param startingAngleRad   The initial position of the arm.
    * @param measurementStdDevs The standard deviation of the measurement noise.
    */
   SingleJointedArmSim(const DCMotor& gearbox, double gearing,
                       units::kilogram_square_meter_t moi,
                       units::meter_t armLength, units::radian_t minAngle,
                       units::radian_t maxAngle, bool simulateGravity,
+                      units::radian_t startingAngleRad,
                       const std::array<double, 1>& measurementStdDevs = {0.0});
 
   /**

--- a/wpilibc/src/test/native/cpp/simulation/SingleJointedArmSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/SingleJointedArmSimTest.cpp
@@ -9,7 +9,7 @@
 
 TEST(SingleJointedArmTest, Disabled) {
   frc::sim::SingleJointedArmSim sim(frc::DCMotor::Vex775Pro(2), 300, 3_kg_sq_m,
-                                    30_in, -180_deg, 0_deg, true);
+                                    30_in, -180_deg, 0_deg, true, 90_deg);
   sim.SetState(frc::Vectord<2>{0.0, 0.0});
 
   for (size_t i = 0; i < 12 / 0.02; ++i) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSim.java
@@ -43,6 +43,8 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
    * @param minAngleRads The minimum angle that the arm is capable of.
    * @param maxAngleRads The maximum angle that the arm is capable of.
    * @param simulateGravity Whether gravity should be simulated or not.
+   * @param startingAngleRad The initial position of the Arm simulation in radians.
+   * @param measurementStdDevs The standard deviations of the measurements.
    */
   public SingleJointedArmSim(
       LinearSystem<N2, N1, N1> plant,
@@ -51,16 +53,18 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
       double armLengthMeters,
       double minAngleRads,
       double maxAngleRads,
-      boolean simulateGravity) {
-    this(
-        plant,
-        gearbox,
-        gearing,
-        armLengthMeters,
-        minAngleRads,
-        maxAngleRads,
-        simulateGravity,
-        null);
+      boolean simulateGravity,
+      double startingAngleRad,
+      Matrix<N1, N1> measurementStdDevs) {
+    super(plant, measurementStdDevs);
+    m_gearbox = gearbox;
+    m_gearing = gearing;
+    m_armLenMeters = armLengthMeters;
+    m_minAngle = minAngleRads;
+    m_maxAngle = maxAngleRads;
+    m_simulateGravity = simulateGravity;
+
+    setState(VecBuilder.fill(startingAngleRad, 0));
   }
 
   /**
@@ -73,24 +77,28 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
    * @param minAngleRads The minimum angle that the arm is capable of.
    * @param maxAngleRads The maximum angle that the arm is capable of.
    * @param simulateGravity Whether gravity should be simulated or not.
-   * @param measurementStdDevs The standard deviations of the measurements.
+   * @param startingAngleRad The initial position of the Arm simulation in radians.
+   *
    */
   public SingleJointedArmSim(
-      LinearSystem<N2, N1, N1> plant,
-      DCMotor gearbox,
-      double gearing,
-      double armLengthMeters,
-      double minAngleRads,
-      double maxAngleRads,
-      boolean simulateGravity,
-      Matrix<N1, N1> measurementStdDevs) {
-    super(plant, measurementStdDevs);
-    m_gearbox = gearbox;
-    m_gearing = gearing;
-    m_armLenMeters = armLengthMeters;
-    m_minAngle = minAngleRads;
-    m_maxAngle = maxAngleRads;
-    m_simulateGravity = simulateGravity;
+          LinearSystem<N2, N1, N1> plant,
+          DCMotor gearbox,
+          double gearing,
+          double armLengthMeters,
+          double minAngleRads,
+          double maxAngleRads,
+          boolean simulateGravity,
+          double startingAngleRad) {
+    this(
+            plant,
+            gearbox,
+            gearing,
+            armLengthMeters,
+            minAngleRads,
+            maxAngleRads,
+            simulateGravity,
+            startingAngleRad,
+            null);
   }
 
   /**
@@ -103,6 +111,7 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
    * @param minAngleRads The minimum angle that the arm is capable of.
    * @param maxAngleRads The maximum angle that the arm is capable of.
    * @param simulateGravity Whether gravity should be simulated or not.
+   * @param startingAngleRad The initial position of the Arm simulation in radians.
    */
   public SingleJointedArmSim(
       DCMotor gearbox,
@@ -111,7 +120,8 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
       double armLengthMeters,
       double minAngleRads,
       double maxAngleRads,
-      boolean simulateGravity) {
+      boolean simulateGravity,
+      double startingAngleRad) {
     this(
         gearbox,
         gearing,
@@ -120,6 +130,7 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
         minAngleRads,
         maxAngleRads,
         simulateGravity,
+        startingAngleRad,
         null);
   }
 
@@ -133,6 +144,7 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
    * @param minAngleRads The minimum angle that the arm is capable of.
    * @param maxAngleRads The maximum angle that the arm is capable of.
    * @param simulateGravity Whether gravity should be simulated or not.
+   * @param startingAngleRad The initial position of the Arm simulation in radians.
    * @param measurementStdDevs The standard deviations of the measurements.
    */
   public SingleJointedArmSim(
@@ -143,16 +155,19 @@ public class SingleJointedArmSim extends LinearSystemSim<N2, N1, N1> {
       double minAngleRads,
       double maxAngleRads,
       boolean simulateGravity,
+      double startingAngleRad,
       Matrix<N1, N1> measurementStdDevs) {
-    super(
-        LinearSystemId.createSingleJointedArmSystem(gearbox, jKgMetersSquared, gearing),
-        measurementStdDevs);
-    m_gearbox = gearbox;
-    m_gearing = gearing;
-    m_armLenMeters = armLengthMeters;
-    m_minAngle = minAngleRads;
-    m_maxAngle = maxAngleRads;
-    m_simulateGravity = simulateGravity;
+    this(
+      LinearSystemId.createSingleJointedArmSystem(gearbox, jKgMetersSquared, gearing),
+      gearbox,
+      gearing,
+      armLengthMeters,
+      minAngleRads,
+      maxAngleRads,
+      simulateGravity,
+      startingAngleRad,
+      measurementStdDevs
+    );
   }
 
   /**

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSimTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/simulation/SingleJointedArmSimTest.java
@@ -14,10 +14,11 @@ import org.junit.jupiter.api.Test;
 class SingleJointedArmSimTest {
   SingleJointedArmSim m_sim =
       new SingleJointedArmSim(
-          DCMotor.getVex775Pro(2), 300, 3.0, Units.inchesToMeters(30.0), -Math.PI, 0.0, true);
+          DCMotor.getVex775Pro(2), 300, 3.0, Units.inchesToMeters(30.0), -Math.PI, 0.0, true, Math.PI / 2.0);
 
   @Test
   void testArmDisabled() {
+    // Reset Arm angle to 0
     m_sim.setState(VecBuilder.fill(0.0, 0.0));
 
     for (int i = 0; i < 12 / 0.02; i++) {


### PR DESCRIPTION
- Add a constructor parameter to configure the initial angle of the arm.
- Also reorganizes cascading constructors for Java