### PR TITLE
strip JNI path from user.dir

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Filesystem.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Filesystem.java
@@ -23,7 +23,13 @@ public final class Filesystem {
    * @return The current working directory (launch directory)
    */
   public static File getLaunchDirectory() {
-    return new File(System.getProperty("user.dir")).getAbsoluteFile();
+    // workaround for
+    // https://www.chiefdelphi.com/t/filesystem-getdeploydirectory-returning-wrong-location-how-to-fix/427292
+    String path =
+        System.getProperty("user.dir")
+            .replace(
+                File.separator + "build" + File.separator + "jni" + File.separator + "release", "");
+    return new File(path).getAbsoluteFile();
   }
 
   /**


### PR DESCRIPTION
Fixes
https://www.chiefdelphi.com/t/filesystem-getdeploydirectory-returning-wrong-location-how-to-fix/427292 when unit tests are run with VS Code's java test runner due to VS Code extension setting working directory which changes user.dir.