### PR TITLE
[wpilibc] Add unit-aware Joystick.GetDirection()

### DIFF
--- a/wpilibc/src/main/native/cpp/Joystick.cpp
+++ b/wpilibc/src/main/native/cpp/Joystick.cpp
@@ -8,6 +8,8 @@
 #include <numbers>
 
 #include <hal/FRCUsageReporting.h>
+#include <units/dimensionless.h>
+#include <units/math.h>
 
 #include "frc/event/BooleanEvent.h"
 
@@ -125,4 +127,9 @@ double Joystick::GetDirectionRadians() const {
 
 double Joystick::GetDirectionDegrees() const {
   return (180 / std::numbers::pi) * GetDirectionRadians();
+}
+
+units::radian_t Joystick::GetDirection() const {
+  return units::math::atan2(units::dimensionless::scalar_t{GetX()},
+                            units::dimensionless::scalar_t{-GetY()});
 }

--- a/wpilibc/src/main/native/cpp/Joystick.cpp
+++ b/wpilibc/src/main/native/cpp/Joystick.cpp
@@ -126,6 +126,7 @@ double Joystick::GetDirectionRadians() const {
 }
 
 double Joystick::GetDirectionDegrees() const {
+  WPI_IGNORE_DEPRECATED
   return (180 / std::numbers::pi) * GetDirectionRadians();
 }
 

--- a/wpilibc/src/main/native/include/frc/Joystick.h
+++ b/wpilibc/src/main/native/include/frc/Joystick.h
@@ -6,6 +6,9 @@
 
 #include <array>
 
+#include <units/angle.h>
+#include <wpi/deprecated.h>
+
 #include "frc/GenericHID.h"
 
 namespace frc {
@@ -226,7 +229,9 @@ class Joystick : public GenericHID {
    * in radians.
    *
    * @return The direction of the vector in radians
+   * @deprecated Use GetDirection() instead.
    */
+  WPI_DEPRECATED("Use GetDirection() instead.")
   double GetDirectionRadians() const;
 
   /**
@@ -234,8 +239,17 @@ class Joystick : public GenericHID {
    * in degrees.
    *
    * @return The direction of the vector in degrees
+   * @deprecated Use GetDirection() instead.
    */
+  WPI_DEPRECATED("Use GetDirection() instead.")
   double GetDirectionDegrees() const;
+
+  /**
+   * Get the direction of the vector formed by the joystick and its origin.
+   *
+   * @return The direction of the vector.
+   */
+  units::radian_t GetDirection() const;
 
  private:
   enum Axis { kX, kY, kZ, kTwist, kThrottle, kNumAxes };

--- a/wpilibc/src/test/native/cpp/JoystickTest.cpp
+++ b/wpilibc/src/test/native/cpp/JoystickTest.cpp
@@ -23,3 +23,46 @@ AXIS_TEST(Joystick, Twist)
 
 BUTTON_TEST(Joystick, Trigger)
 BUTTON_TEST(Joystick, Top)
+
+TEST(JoystickTest, GetMagnitude) {
+  Joystick joy{1};
+  sim::JoystickSim joysim{1};
+
+  joysim.SetX(0.5);
+  joysim.SetY(0);
+  joysim.NotifyNewData();
+  ASSERT_NEAR(0.5, joy.GetMagnitude(), 0.001);
+
+  joysim.SetX(0);
+  joysim.SetY(-.5);
+  joysim.NotifyNewData();
+  ASSERT_NEAR(0.5, joy.GetMagnitude(), 0.001);
+
+  joysim.SetX(0.5);
+  joysim.SetY(-0.5);
+  joysim.NotifyNewData();
+  ASSERT_NEAR(0.70710678118, joy.GetMagnitude(), 0.001);
+}
+
+TEST(JoystickTest, GetDirection) {
+  Joystick joy{1};
+  sim::JoystickSim joysim{1};
+
+  joysim.SetX(0.5);
+  joysim.SetY(0);
+  joysim.NotifyNewData();
+  ASSERT_NEAR(units::radian_t{90_deg}.value(), joy.GetDirection().value(),
+              0.001);
+
+  joysim.SetX(0);
+  joysim.SetY(-.5);
+  joysim.NotifyNewData();
+  ASSERT_NEAR(units::radian_t{0_deg}.value(), joy.GetDirection().value(),
+              0.001);
+
+  joysim.SetX(0.5);
+  joysim.SetY(-0.5);
+  joysim.NotifyNewData();
+  ASSERT_NEAR(units::radian_t{45_deg}.value(), joy.GetDirection().value(),
+              0.001);
+}


### PR DESCRIPTION
Deprecate unitless `GetDirectionRadians()` and `GetDirectionDegrees()`
Add unit tests for `GetDirection` and `GetMagnitude`