### PR TITLE
[cmd docs] Clean up Command doc comments (NFC)

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Command.java
@@ -64,8 +64,7 @@ public interface Command {
 
   /**
    * Decorates this command with a timeout. If the specified timeout is exceeded before the command
-   * finishes normally, the command will be interrupted and un-scheduled. Note that the timeout only
-   * applies to the command returned by this method; the calling command is not itself changed.
+   * finishes normally, the command will be interrupted and un-scheduled.
    *
    * <p>Note: This decorator works by adding this command to a composition. The command the
    * decorator was called on cannot be scheduled independently or be added to a different
@@ -108,8 +107,8 @@ public interface Command {
    * commands with {@link CommandScheduler#removeComposedCommand(Command)}. The command composition
    * returned from this method can be further decorated without issue.
    *
-   * @param condition the interrupt condition
-   * @return the command with the interrupt condition added
+   * @param condition the run condition
+   * @return the command with the run condition added
    * @see #until(BooleanSupplier)
    */
   default ParallelRaceGroup onlyWhile(BooleanSupplier condition) {
@@ -118,9 +117,7 @@ public interface Command {
 
   /**
    * Decorates this command with an interrupt condition. If the specified condition becomes true
-   * before the command finishes normally, the command will be interrupted and un-scheduled. Note
-   * that this only applies to the command returned by this method; the calling command is not
-   * itself changed.
+   * before the command finishes normally, the command will be interrupted and un-scheduled.
    *
    * <p>Note: This decorator works by adding this command to a composition. The command the
    * decorator was called on cannot be scheduled independently or be added to a different

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -116,10 +116,9 @@ class Command {
   friend class CommandPtr;
 
   /**
-   * Decorates this command with a timeout.  If the specified timeout is
+   * Decorates this command with a timeout. If the specified timeout is
    * exceeded before the command finishes normally, the command will be
-   * interrupted and un-scheduled.  Note that the timeout only applies to the
-   * command returned by this method; the calling command is not itself changed.
+   * interrupted and un-scheduled.
    *
    * @param duration the timeout duration
    * @return the command with the timeout added
@@ -127,10 +126,9 @@ class Command {
   [[nodiscard]] CommandPtr WithTimeout(units::second_t duration) &&;
 
   /**
-   * Decorates this command with an interrupt condition.  If the specified
+   * Decorates this command with an interrupt condition. If the specified
    * condition becomes true before the command finishes normally, the command
-   * will be interrupted and un-scheduled. Note that this only applies to the
-   * command returned by this method; the calling command is not itself changed.
+   * will be interrupted and un-scheduled.
    *
    * @param condition the interrupt condition
    * @return the command with the interrupt condition added
@@ -138,21 +136,19 @@ class Command {
   [[nodiscard]] CommandPtr Until(std::function<bool()> condition) &&;
 
   /**
-   * Decorates this command with a run condition.  If the specified condition
+   * Decorates this command with a run condition. If the specified condition
    * becomes false before the command finishes normally, the command will be
-   * interrupted and un-scheduled. Note that this only applies to the command
-   * returned by this method; the calling command is not itself changed.
+   * interrupted and un-scheduled.
    *
-   * @param condition the interrupt condition
-   * @return the command with the interrupt condition added
+   * @param condition the run condition
+   * @return the command with the run condition added
    */
   [[nodiscard]] CommandPtr OnlyWhile(std::function<bool()> condition) &&;
 
   /**
    * Decorates this command with an interrupt condition.  If the specified
    * condition becomes true before the command finishes normally, the command
-   * will be interrupted and un-scheduled. Note that this only applies to the
-   * command returned by this method; the calling command is not itself changed.
+   * will be interrupted and un-scheduled.
    *
    * @param condition the interrupt condition
    * @return the command with the interrupt condition added
@@ -276,9 +272,9 @@ safe) semantics.
   [[nodiscard]] CommandPtr IgnoringDisable(bool doesRunWhenDisabled) &&;
 
   /**
-   * Decorates this command to run or stop when disabled.
+   * Decorates this command to have a different interrupt behavior.
    *
-   * @param interruptBehavior true to run when disabled.
+   * @param interruptBehavior the desired interrupt behavior
    * @return the decorated command
    */
   [[nodiscard]] CommandPtr WithInterruptBehavior(

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
@@ -60,15 +60,15 @@ class CommandPtr final {
   /**
    * Decorates this command to run or stop when disabled.
    *
-   * @param doesRunWhenDisabled true to run when disabled.
+   * @param doesRunWhenDisabled true to run when disabled
    * @return the decorated command
    */
   [[nodiscard]] CommandPtr IgnoringDisable(bool doesRunWhenDisabled) &&;
 
   /**
-   * Decorates this command to run or stop when disabled.
+   * Decorates this command to have a different interrupt behavior.
    *
-   * @param interruptBehavior true to run when disabled.
+   * @param interruptBehavior the desired interrupt behavior
    * @return the decorated command
    */
   [[nodiscard]] CommandPtr WithInterruptBehavior(
@@ -138,10 +138,9 @@ class CommandPtr final {
   [[nodiscard]] CommandPtr BeforeStarting(CommandPtr&& before) &&;
 
   /**
-   * Decorates this command with a timeout.  If the specified timeout is
+   * Decorates this command with a timeout. If the specified timeout is
    * exceeded before the command finishes normally, the command will be
-   * interrupted and un-scheduled.  Note that the timeout only applies to the
-   * command returned by this method; the calling command is not itself changed.
+   * interrupted and un-scheduled.
    *
    * @param duration the timeout duration
    * @return the command with the timeout added
@@ -149,10 +148,9 @@ class CommandPtr final {
   [[nodiscard]] CommandPtr WithTimeout(units::second_t duration) &&;
 
   /**
-   * Decorates this command with an interrupt condition.  If the specified
+   * Decorates this command with an interrupt condition. If the specified
    * condition becomes true before the command finishes normally, the command
-   * will be interrupted and un-scheduled. Note that this only applies to the
-   * command returned by this method; the calling command is not itself changed.
+   * will be interrupted and un-scheduled.
    *
    * @param condition the interrupt condition
    * @return the command with the interrupt condition added
@@ -160,13 +158,12 @@ class CommandPtr final {
   [[nodiscard]] CommandPtr Until(std::function<bool()> condition) &&;
 
   /**
-   * Decorates this command with a run condition.  If the specified condition
+   * Decorates this command with a run condition. If the specified condition
    * becomes false before the command finishes normally, the command will be
-   * interrupted and un-scheduled. Note that this only applies to the command
-   * returned by this method; the calling command is not itself changed.
+   * interrupted and un-scheduled.
    *
-   * @param condition the interrupt condition
-   * @return the command with the interrupt condition added
+   * @param condition the run condition
+   * @return the command with the run condition added
    */
   [[nodiscard]] CommandPtr OnlyWhile(std::function<bool()> condition) &&;
 
@@ -228,7 +225,7 @@ class CommandPtr final {
    * the command's inherent Command::End(bool) method.
    *
    * @param end a lambda accepting a boolean parameter specifying whether the
-   * command was interrupted.
+   * command was interrupted
    * @return the decorated command
    */
   [[nodiscard]] CommandPtr FinallyDo(std::function<void(bool)> end) &&;


### PR DESCRIPTION
Removes the sentence on not reusing decorated commands from a few methods
Corrects onlyWhile/OnlyWhile param and return blocks to use "run" instead of "interrupt"
Fixes C++ WithInterruptBehavior doc comment
Removes a few double spaces
Removes periods from the end of a two param blocks (Mostly accidental- Waiting to hear if a consistent format should be applied or not)