### PR TITLE
[build] Update gradle cache repo name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -66,7 +66,7 @@ buildCache {
         enabled = !System.getenv().containsKey("CI")
     }
     remote(HttpBuildCache) {
-        url = "https://frcmaven.wpi.edu/artifactory/wpilib-generic-gradle-cache/"
+        url = "https://frcmaven.wpi.edu/artifactory/wpilib-generic-gradlecache/"
         String user = cred('ARTIFACTORY_PUBLISH_USERNAME')
         String pass = cred('ARTIFACTORY_PUBLISH_PASSWORD')
         if (user && pass) {


### PR DESCRIPTION
Artifactory now does not allow repos that end in -cache. Update virtual repo naming to track this new limitation