### PR TITLE
Allow loop epochs to be logged to DataLog and published to NT

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -126,7 +126,7 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   }
 
   /**
-   * Starts publishing loop timings to NetworkTables.
+   * Starts publishing loop timings to NetworkTables. Subsequent calls will do nothing.
    *
    * <p>This will publish how long it takes for methods in the command-based framework to execute;
    * periodic methods in subsystems, execute methods in commands, etc.
@@ -138,7 +138,7 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   }
 
   /**
-   * Starts logging loop timings to the data log.
+   * Starts logging loop timings to the data log. Subsequent calls will do nothing.
    *
    * <p>This will log how long it takes for methods in the command-based framework to execute;
    * periodic methods in subsystems, execute methods in commands, etc.

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -127,9 +127,8 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   /**
    * Starts publishing loop timings to NetworkTables.
    *
-   * <p>This will publish how long it takes for methods in the command-based
-   * framework to execute; periodic methods in subsystems, execute methods in
-   * commands, etc.
+   * <p>This will publish how long it takes for methods in the command-based framework to execute;
+   * periodic methods in subsystems, execute methods in commands, etc.
    *
    * @param topicName The NetworkTables topic to publish to
    */
@@ -140,9 +139,9 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   /**
    * Starts logging loop timings to the data log.
    *
-   * <p>This will log how long it takes for methods in the command-based
-   * framework to execute; periodic methods in subsystems, execute methods in
-   * commands, etc.
+   * <p>This will log how long it takes for methods in the command-based framework to execute;
+   * periodic methods in subsystems, execute methods in commands, etc.
+   *
    * @param dataLog The data log to log loop timings to
    * @param entry The name of the entry to log to
    */

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -127,8 +127,7 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   /**
    * Starts publishing loop timings to NetworkTables.
    *
-   * <p>
-   * This will publish how long it takes for methods in the command-based
+   * <p>This will publish how long it takes for methods in the command-based
    * framework to execute; periodic methods in subsystems, execute methods in
    * commands, etc.
    *
@@ -141,8 +140,7 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   /**
    * Starts logging loop timings to the data log.
    *
-   * <p>
-   * This will log how long it takes for methods in the command-based
+   * <p>This will log how long it takes for methods in the command-based
    * framework to execute; periodic methods in subsystems, execute methods in
    * commands, etc.
    * @param dataLog The data log to log loop timings to

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -125,6 +125,34 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   }
 
   /**
+   * Starts publishing added epochs to NetworkTables.
+   *
+   * @param topicName The NetworkTables topic to publish to
+   */
+  public void publishToNetworkTables(String topicName) {
+    m_watchdog.publishToNetworkTables(topicName);
+  }
+
+  /**
+   * Starts logging added epochs to the data log. Default entry is "Epochs"
+   *
+   * @param dataLog The data log to log epochs to
+   */
+  public void startDataLog(DataLog dataLog) {
+    m_watchdog.startDataLog(dataLog);
+  }
+
+  /**
+   * Starts logging added epochs to the data log.
+   *
+   * @param dataLog The data log to log epochs to
+   * @param entry The name of the entry to log to
+   */
+  public void startDataLog(DataLog dataLog, String entry) {
+    m_watchdog.startDataLog(dataLog);
+  }
+
+  /**
    * Get the default button poll.
    *
    * @return a reference to the default {@link EventLoop} object polling buttons.

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -9,6 +9,7 @@ import static edu.wpi.first.util.ErrorMessages.requireNonNullParam;
 import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
+import edu.wpi.first.util.datalog.DataLog;
 import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.util.sendable.SendableRegistry;

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -134,22 +134,13 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   }
 
   /**
-   * Starts logging added epochs to the data log. Default entry is "Epochs"
-   *
-   * @param dataLog The data log to log epochs to
-   */
-  public void startDataLog(DataLog dataLog) {
-    m_watchdog.startDataLog(dataLog);
-  }
-
-  /**
    * Starts logging added epochs to the data log.
    *
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */
   public void startDataLog(DataLog dataLog, String entry) {
-    m_watchdog.startDataLog(dataLog);
+    m_watchdog.startDataLog(dataLog, entry);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -132,7 +132,7 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
    *
    * @param topicName The NetworkTables topic to publish to
    */
-  public void publishToNetworkTables(String topicName) {
+  public void publishLoopTimingsToNetworkTables(String topicName) {
     m_watchdog.publishToNetworkTables(topicName);
   }
 
@@ -145,7 +145,7 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
    * @param dataLog The data log to log loop timings to
    * @param entry The name of the entry to log to
    */
-  public void startDataLog(DataLog dataLog, String entry) {
+  public void startLoopTimingsDataLog(DataLog dataLog, String entry) {
     m_watchdog.startDataLog(dataLog, entry);
   }
 

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -125,7 +125,12 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   }
 
   /**
-   * Starts publishing added epochs to NetworkTables.
+   * Starts publishing loop timings to NetworkTables.
+   *
+   * <p>
+   * This will publish how long it takes for methods in the command-based
+   * framework to execute; periodic methods in subsystems, execute methods in
+   * commands, etc.
    *
    * @param topicName The NetworkTables topic to publish to
    */
@@ -134,9 +139,13 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
   }
 
   /**
-   * Starts logging added epochs to the data log.
+   * Starts logging loop timings to the data log.
    *
-   * @param dataLog The data log to log epochs to
+   * <p>
+   * This will log how long it takes for methods in the command-based
+   * framework to execute; periodic methods in subsystems, execute methods in
+   * commands, etc.
+   * @param dataLog The data log to log loop timings to
    * @param entry The name of the entry to log to
    */
   public void startDataLog(DataLog dataLog, String entry) {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -96,12 +96,13 @@ void CommandScheduler::SetPeriod(units::second_t period) {
   m_watchdog.SetTimeout(period);
 }
 
-void CommandScheduler::PublishToNetworkTables(std::string_view topicName) {
+void CommandScheduler::PublishLoopTimingsToNetworkTables(
+    std::string_view topicName) {
   m_watchdog.PublishToNetworkTables(topicName);
 }
 
-void CommandScheduler::StartDataLog(wpi::log::DataLog& dataLog,
-                                    std::string_view entry) {
+void CommandScheduler::StartLoopTimingsDataLog(wpi::log::DataLog& dataLog,
+                                               std::string_view entry) {
   m_watchdog.StartDataLog(dataLog, entry);
 }
 

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -105,7 +105,7 @@ void CommandScheduler::StartDataLog(wpi::log::DataLog dataLog) {
 }
 
 void CommandScheduler::StartDataLog(wpi::log::DataLog dataLog,
-                                      std::string_view entry) {
+                                    std::string_view entry) {
   m_watchdog.StartDataLog(dataLog, entry);
 }
 

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -100,10 +100,6 @@ void CommandScheduler::PublishToNetworkTables(std::string_view topicName) {
   m_watchdog.PublishToNetworkTables(topicName);
 }
 
-void CommandScheduler::StartDataLog(wpi::log::DataLog dataLog) {
-  m_watchdog.StartDataLog(dataLog);
-}
-
 void CommandScheduler::StartDataLog(wpi::log::DataLog dataLog,
                                     std::string_view entry) {
   m_watchdog.StartDataLog(dataLog, entry);

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -100,7 +100,7 @@ void CommandScheduler::PublishToNetworkTables(std::string_view topicName) {
   m_watchdog.PublishToNetworkTables(topicName);
 }
 
-void CommandScheduler::StartDataLog(wpi::log::DataLog dataLog,
+void CommandScheduler::StartDataLog(wpi::log::DataLog& dataLog,
                                     std::string_view entry) {
   m_watchdog.StartDataLog(dataLog, entry);
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -96,6 +96,19 @@ void CommandScheduler::SetPeriod(units::second_t period) {
   m_watchdog.SetTimeout(period);
 }
 
+void CommandScheduler::PublishToNetworkTables(std::string_view topicName) {
+  m_watchdog.PublishToNetworkTables(topicName);
+}
+
+void CommandScheduler::StartDataLog(wpi::log::DataLog dataLog) {
+  m_watchdog.StartDataLog(dataLog);
+}
+
+void CommandScheduler::StartDataLog(wpi::log::DataLog dataLog,
+                                      std::string_view entry) {
+  m_watchdog.StartDataLog(dataLog, entry);
+}
+
 frc::EventLoop* CommandScheduler::GetActiveButtonLoop() const {
   return m_impl->activeButtonLoop;
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -60,7 +60,8 @@ class CommandScheduler final : public wpi::Sendable,
   void SetPeriod(units::second_t period);
 
   /**
-   * Starts publishing loop timings to NetworkTables. Subsequent calls will do nothing.
+   * Starts publishing loop timings to NetworkTables. Subsequent calls will do
+   * nothing.
    *
    * This will publish how long it takes for methods in the command-based
    * framework to execute; periodic methods in subsystems, execute methods in
@@ -70,7 +71,8 @@ class CommandScheduler final : public wpi::Sendable,
   void PublishLoopTimingsToNetworkTables(std::string_view topicName);
 
   /**
-   * Starts logging loop timings to the data log. Subsequent calls will do nothing.
+   * Starts logging loop timings to the data log. Subsequent calls will do
+   * nothing.
    *
    * This will log how long it takes for methods in the command-based
    * framework to execute; periodic methods in subsystems, execute methods in

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -60,7 +60,7 @@ class CommandScheduler final : public wpi::Sendable,
   void SetPeriod(units::second_t period);
 
   /**
-   * Starts publishing loop timings to NetworkTables.
+   * Starts publishing loop timings to NetworkTables. Subsequent calls will do nothing.
    *
    * This will publish how long it takes for methods in the command-based
    * framework to execute; periodic methods in subsystems, execute methods in
@@ -70,7 +70,7 @@ class CommandScheduler final : public wpi::Sendable,
   void PublishLoopTimingsToNetworkTables(std::string_view topicName);
 
   /**
-   * Starts logging loop timings to the data log.
+   * Starts logging loop timings to the data log. Subsequent calls will do nothing.
    *
    * This will log how long it takes for methods in the command-based
    * framework to execute; periodic methods in subsystems, execute methods in

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -67,7 +67,7 @@ class CommandScheduler final : public wpi::Sendable,
    * commands, etc.
    * @param topicName The NetworkTables topic to publish to
    */
-  void PublishToNetworkTables(std::string_view topicName);
+  void PublishLoopTimingsToNetworkTables(std::string_view topicName);
 
   /**
    * Starts logging loop timings to the data log.
@@ -78,7 +78,8 @@ class CommandScheduler final : public wpi::Sendable,
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */
-  void StartDataLog(wpi::log::DataLog& dataLog, std::string_view entry);
+  void StartLoopTimingsDataLog(wpi::log::DataLog& dataLog,
+                               std::string_view entry);
 
   /**
    * Get the active button poll.

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -72,7 +72,6 @@ class CommandScheduler final : public wpi::Sendable,
   /**
    * Starts logging loop timings to the data log.
    *
-   * <p>
    * This will log how long it takes for methods in the command-based
    * framework to execute; periodic methods in subsystems, execute methods in
    * commands, etc.

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -16,6 +16,7 @@
 #include <frc/Watchdog.h>
 #include <frc/event/EventLoop.h>
 #include <units/time.h>
+#include <wpi/DataLog.h>
 #include <wpi/FunctionExtras.h>
 #include <wpi/sendable/Sendable.h>
 #include <wpi/sendable/SendableHelper.h>
@@ -57,6 +58,28 @@ class CommandScheduler final : public wpi::Sendable,
    * sync with the TimedRobot period.
    */
   void SetPeriod(units::second_t period);
+
+  /**
+   * Starts publishing added epochs to NetworkTables.
+   *
+   * @param topicName The NetworkTables topic to publish to
+   */
+  void PublishToNetworkTables(std::string_view topicName);
+
+  /**
+   * Starts logging added epochs to the data log. Default entry is "Epochs"
+   *
+   * @param dataLog The data log to log epochs to
+   */
+  void StartDataLog(wpi::log::DataLog dataLog);
+
+  /**
+   * Starts logging added epochs to the data log.
+   *
+   * @param dataLog The data log to log epochs to
+   * @param entry The name of the entry to log to
+   */
+  void StartDataLog(wpi::log::DataLog dataLog, std::string_view entry);
 
   /**
    * Get the active button poll.

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -79,7 +79,7 @@ class CommandScheduler final : public wpi::Sendable,
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */
-  void StartDataLog(wpi::log::DataLog dataLog, std::string_view entry);
+  void StartDataLog(wpi::log::DataLog& dataLog, std::string_view entry);
 
   /**
    * Get the active button poll.

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandScheduler.h
@@ -60,22 +60,22 @@ class CommandScheduler final : public wpi::Sendable,
   void SetPeriod(units::second_t period);
 
   /**
-   * Starts publishing added epochs to NetworkTables.
+   * Starts publishing loop timings to NetworkTables.
    *
+   * This will publish how long it takes for methods in the command-based
+   * framework to execute; periodic methods in subsystems, execute methods in
+   * commands, etc.
    * @param topicName The NetworkTables topic to publish to
    */
   void PublishToNetworkTables(std::string_view topicName);
 
   /**
-   * Starts logging added epochs to the data log. Default entry is "Epochs"
+   * Starts logging loop timings to the data log.
    *
-   * @param dataLog The data log to log epochs to
-   */
-  void StartDataLog(wpi::log::DataLog dataLog);
-
-  /**
-   * Starts logging added epochs to the data log.
-   *
+   * <p>
+   * This will log how long it takes for methods in the command-based
+   * framework to execute; periodic methods in subsystems, execute methods in
+   * commands, etc.
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */

--- a/wpilibc/src/main/native/cpp/IterativeRobotBase.cpp
+++ b/wpilibc/src/main/native/cpp/IterativeRobotBase.cpp
@@ -97,7 +97,7 @@ void IterativeRobotBase::PublishToNetworkTables(std::string_view topicName) {
   m_watchdog.PublishToNetworkTables(topicName);
 }
 
-void IterativeRobotBase::StartDataLog(wpi::log::DataLog dataLog,
+void IterativeRobotBase::StartDataLog(wpi::log::DataLog& dataLog,
                                       std::string_view entry) {
   m_watchdog.StartDataLog(dataLog, entry);
 }

--- a/wpilibc/src/main/native/cpp/IterativeRobotBase.cpp
+++ b/wpilibc/src/main/native/cpp/IterativeRobotBase.cpp
@@ -97,10 +97,6 @@ void IterativeRobotBase::PublishToNetworkTables(std::string_view topicName) {
   m_watchdog.PublishToNetworkTables(topicName);
 }
 
-void IterativeRobotBase::StartDataLog(wpi::log::DataLog dataLog) {
-  m_watchdog.StartDataLog(dataLog);
-}
-
 void IterativeRobotBase::StartDataLog(wpi::log::DataLog dataLog,
                                       std::string_view entry) {
   m_watchdog.StartDataLog(dataLog, entry);

--- a/wpilibc/src/main/native/cpp/IterativeRobotBase.cpp
+++ b/wpilibc/src/main/native/cpp/IterativeRobotBase.cpp
@@ -93,12 +93,13 @@ void IterativeRobotBase::TeleopExit() {}
 
 void IterativeRobotBase::TestExit() {}
 
-void IterativeRobotBase::PublishToNetworkTables(std::string_view topicName) {
+void IterativeRobotBase::PublishLoopTimingsToNetworkTables(
+    std::string_view topicName) {
   m_watchdog.PublishToNetworkTables(topicName);
 }
 
-void IterativeRobotBase::StartDataLog(wpi::log::DataLog& dataLog,
-                                      std::string_view entry) {
+void IterativeRobotBase::StartLoopTimingsDataLog(wpi::log::DataLog& dataLog,
+                                                 std::string_view entry) {
   m_watchdog.StartDataLog(dataLog, entry);
 }
 

--- a/wpilibc/src/main/native/cpp/IterativeRobotBase.cpp
+++ b/wpilibc/src/main/native/cpp/IterativeRobotBase.cpp
@@ -93,6 +93,19 @@ void IterativeRobotBase::TeleopExit() {}
 
 void IterativeRobotBase::TestExit() {}
 
+void IterativeRobotBase::PublishToNetworkTables(std::string_view topicName) {
+  m_watchdog.PublishToNetworkTables(topicName);
+}
+
+void IterativeRobotBase::StartDataLog(wpi::log::DataLog dataLog) {
+  m_watchdog.StartDataLog(dataLog);
+}
+
+void IterativeRobotBase::StartDataLog(wpi::log::DataLog dataLog,
+                                      std::string_view entry) {
+  m_watchdog.StartDataLog(dataLog, entry);
+}
+
 void IterativeRobotBase::SetNetworkTablesFlushEnabled(bool enabled) {
   m_ntFlushEnabled = enabled;
 }

--- a/wpilibc/src/main/native/cpp/Tracer.cpp
+++ b/wpilibc/src/main/native/cpp/Tracer.cpp
@@ -17,17 +17,21 @@ Tracer::Tracer() {
 }
 
 void Tracer::PublishToNetworkTables(std::string_view topicName) {
+  if (!m_publishNT){
   m_publishNT = true;
   m_inst = nt::NetworkTableInstance::GetDefault();
   m_ntTopic = topicName;
   m_publisherCache = wpi::StringMap<std::shared_ptr<nt::IntegerPublisher>>(10);
+  }
 }
 
 void Tracer::StartDataLog(wpi::log::DataLog& dataLog, std::string_view entry) {
+  if (!m_dataLogEnabled){
+  m_dataLogEnabled = true;
   m_dataLog = &dataLog;
   m_dataLogEntry = entry;
-  m_dataLogEnabled = true;
   m_entryCache = wpi::StringMap<int>(10);
+  }
 }
 
 void Tracer::ResetTimer() {

--- a/wpilibc/src/main/native/cpp/Tracer.cpp
+++ b/wpilibc/src/main/native/cpp/Tracer.cpp
@@ -17,21 +17,23 @@ Tracer::Tracer() {
 }
 
 void Tracer::PublishToNetworkTables(std::string_view topicName) {
-  if (!m_publishNT){
+  if (!m_publishNT) {
+    return;
+  }
   m_publishNT = true;
   m_inst = nt::NetworkTableInstance::GetDefault();
   m_ntTopic = topicName;
   m_publisherCache = wpi::StringMap<std::shared_ptr<nt::IntegerPublisher>>(10);
-  }
 }
 
 void Tracer::StartDataLog(wpi::log::DataLog& dataLog, std::string_view entry) {
-  if (!m_dataLogEnabled){
+  if (!m_dataLogEnabled) {
+    return;
+  }
   m_dataLogEnabled = true;
   m_dataLog = &dataLog;
   m_dataLogEntry = entry;
   m_entryCache = wpi::StringMap<int>(10);
-  }
 }
 
 void Tracer::ResetTimer() {

--- a/wpilibc/src/main/native/cpp/Tracer.cpp
+++ b/wpilibc/src/main/native/cpp/Tracer.cpp
@@ -17,7 +17,7 @@ Tracer::Tracer() {
 }
 
 void Tracer::PublishToNetworkTables(std::string_view topicName) {
-  if (!m_publishNT) {
+  if (m_publishNT) {
     return;
   }
   m_publishNT = true;
@@ -27,7 +27,7 @@ void Tracer::PublishToNetworkTables(std::string_view topicName) {
 }
 
 void Tracer::StartDataLog(wpi::log::DataLog& dataLog, std::string_view entry) {
-  if (!m_dataLogEnabled) {
+  if (m_dataLogEnabled) {
     return;
   }
   m_dataLogEnabled = true;

--- a/wpilibc/src/main/native/cpp/Tracer.cpp
+++ b/wpilibc/src/main/native/cpp/Tracer.cpp
@@ -22,11 +22,6 @@ void Tracer::PublishToNetworkTables(std::string_view topicName) {
   m_ntTopic = topicName;
 }
 
-void Tracer::StartDataLog(wpi::log::DataLog dataLog) {
-  m_dataLog = dataLog;
-  m_dataLogEnabled = true;
-}
-
 void Tracer::StartDataLog(wpi::log::DataLog dataLog, std::string_view entry) {
   m_dataLog = dataLog;
   m_dataLogEntry = entry;
@@ -56,7 +51,7 @@ void Tracer::AddEpoch(std::string_view epochName) {
   }
   if (m_dataLogEnabled) {
     m_dataLog.AppendInteger(
-        m_dataLog.Start(m_dataLogEntry + "/" + epochName, "int64"), epoch, 0);
+        m_dataLog.Start(m_dataLogEntry + "/" + epochName, "int64"), epoch.count(), 0);
   }
   m_startTime = currentTime;
 }

--- a/wpilibc/src/main/native/cpp/Tracer.cpp
+++ b/wpilibc/src/main/native/cpp/Tracer.cpp
@@ -19,6 +19,7 @@ Tracer::Tracer() {
 
 void Tracer::PublishToNetworkTables(std::string_view topicName) {
   m_publishNT = true;
+  m_inst = nt::NetworkTableInstance::GetDefault();
   m_ntTopic = topicName;
 }
 
@@ -42,8 +43,8 @@ void Tracer::AddEpoch(std::string_view epochName) {
   auto epoch = currentTime - m_startTime;
   m_epochs[epochName] = epoch;
   if (m_publishNT) {
-    auto topic = nt::NetworkTableInstance::GetDefault().GetIntegerTopic(
-        m_ntTopic.data() + "/" + epochName.data());
+    auto topic =
+        m_inst.GetIntegerTopic(m_ntTopic.data() + "/" + epochName.data());
     auto pub = topic.Publish();
     pub.SetDefault(0);
     topic.SetRetained(true);
@@ -51,7 +52,8 @@ void Tracer::AddEpoch(std::string_view epochName) {
   }
   if (m_dataLogEnabled) {
     m_dataLog.AppendInteger(
-        m_dataLog.Start(m_dataLogEntry + "/" + epochName, "int64"), epoch.count(), 0);
+        m_dataLog.Start(m_dataLogEntry + "/" + epochName, "int64"),
+        epoch.count(), 0);
   }
   m_startTime = currentTime;
 }

--- a/wpilibc/src/main/native/cpp/Tracer.cpp
+++ b/wpilibc/src/main/native/cpp/Tracer.cpp
@@ -20,7 +20,7 @@ void Tracer::PublishToNetworkTables(std::string_view topicName) {
   m_publishNT = true;
   m_inst = nt::NetworkTableInstance::GetDefault();
   m_ntTopic = topicName;
-  m_publisherCache = wpi::StringMap<nt::IntegerPublisher*>(10);
+  m_publisherCache = wpi::StringMap<std::shared_ptr<nt::IntegerPublisher>>(10);
 }
 
 void Tracer::StartDataLog(wpi::log::DataLog& dataLog, std::string_view entry) {
@@ -50,8 +50,8 @@ void Tracer::AddEpoch(std::string_view epochName) {
       // Create and prep the epoch publisher
       auto topic =
           m_inst.GetIntegerTopic(fmt::format("{}/{}", m_ntTopic, epochName));
-      auto pub = topic.Publish();
-      m_publisherCache.insert(std::pair(epochName, &pub));
+      auto pub = std::make_shared<nt::IntegerPublisher>(topic.Publish());
+      m_publisherCache.insert(std::pair(epochName, pub));
     }
     m_publisherCache.lookup(epochName)->Set(epoch.count());
   }

--- a/wpilibc/src/main/native/cpp/Watchdog.cpp
+++ b/wpilibc/src/main/native/cpp/Watchdog.cpp
@@ -164,6 +164,18 @@ Watchdog& Watchdog::operator=(Watchdog&& rhs) {
   return *this;
 }
 
+void Watchdog::PublishToNetworkTables(std::string_view topicName) {
+  m_tracer.PublishToNetworkTables(topicName);
+}
+
+void Watchdog::StartDataLog(wpi::log::DataLog dataLog) {
+  m_tracer.StartDataLog(dataLog);
+}
+
+void Watchdog::StartDataLog(wpi::log::DataLog dataLog, std::string_view entry) {
+  m_tracer.StartDataLog(dataLog, entry);
+}
+
 units::second_t Watchdog::GetTime() const {
   return Timer::GetFPGATimestamp() - m_startTime;
 }

--- a/wpilibc/src/main/native/cpp/Watchdog.cpp
+++ b/wpilibc/src/main/native/cpp/Watchdog.cpp
@@ -168,10 +168,6 @@ void Watchdog::PublishToNetworkTables(std::string_view topicName) {
   m_tracer.PublishToNetworkTables(topicName);
 }
 
-void Watchdog::StartDataLog(wpi::log::DataLog dataLog) {
-  m_tracer.StartDataLog(dataLog);
-}
-
 void Watchdog::StartDataLog(wpi::log::DataLog dataLog, std::string_view entry) {
   m_tracer.StartDataLog(dataLog, entry);
 }

--- a/wpilibc/src/main/native/cpp/Watchdog.cpp
+++ b/wpilibc/src/main/native/cpp/Watchdog.cpp
@@ -168,7 +168,8 @@ void Watchdog::PublishToNetworkTables(std::string_view topicName) {
   m_tracer.PublishToNetworkTables(topicName);
 }
 
-void Watchdog::StartDataLog(wpi::log::DataLog dataLog, std::string_view entry) {
+void Watchdog::StartDataLog(wpi::log::DataLog& dataLog,
+                            std::string_view entry) {
   m_tracer.StartDataLog(dataLog, entry);
 }
 

--- a/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
+++ b/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
@@ -206,7 +206,7 @@ class IterativeRobotBase : public RobotBase {
   virtual void TestExit();
 
   /**
-   * Starts publishing loop timings to NetworkTables.
+   * Starts publishing loop timings to NetworkTables. Subsequent calls will do nothing.
    *
    * This will publish the execution time of method calls in the robot loop;
    * methods like robot periodic and init methods, various NT
@@ -218,7 +218,7 @@ class IterativeRobotBase : public RobotBase {
   void PublishLoopTimingsToNetworkTables(std::string_view topicName);
 
   /**
-   * Starts logging loop timings to the data log.
+   * Starts logging loop timings to the data log. Subsequent calls will do nothing.
    *
    * This will publish the execution time of method calls in the robot loop;
    * methods like robot periodic and init methods, various NT

--- a/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
+++ b/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
@@ -206,7 +206,8 @@ class IterativeRobotBase : public RobotBase {
   virtual void TestExit();
 
   /**
-   * Starts publishing loop timings to NetworkTables. Subsequent calls will do nothing.
+   * Starts publishing loop timings to NetworkTables. Subsequent calls will do
+   * nothing.
    *
    * This will publish the execution time of method calls in the robot loop;
    * methods like robot periodic and init methods, various NT
@@ -218,7 +219,8 @@ class IterativeRobotBase : public RobotBase {
   void PublishLoopTimingsToNetworkTables(std::string_view topicName);
 
   /**
-   * Starts logging loop timings to the data log. Subsequent calls will do nothing.
+   * Starts logging loop timings to the data log. Subsequent calls will do
+   * nothing.
    *
    * This will publish the execution time of method calls in the robot loop;
    * methods like robot periodic and init methods, various NT

--- a/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
+++ b/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
@@ -213,13 +213,6 @@ class IterativeRobotBase : public RobotBase {
   void PublishToNetworkTables(std::string_view topicName);
 
   /**
-   * Starts logging added epochs to the data log. Default entry is "Epochs"
-   *
-   * @param dataLog The data log to log epochs to
-   */
-  void StartDataLog(wpi::log::DataLog dataLog);
-
-  /**
    * Starts logging added epochs to the data log.
    *
    * @param dataLog The data log to log epochs to

--- a/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
+++ b/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
@@ -211,7 +211,8 @@ class IterativeRobotBase : public RobotBase {
    * This will publish the execution time of method calls in the robot loop;
    * methods like robot periodic and init methods, various NT
    * updates (SmartDashboard.update(), Shuffleboard.updateValues(),
-   * LiveWindow.updateValues(),) etc.
+   * LiveWindow.updateValues()) etc.
+   *
    * @param topicName The NetworkTables topic to publish to
    */
   void PublishLoopTimingsToNetworkTables(std::string_view topicName);
@@ -222,7 +223,8 @@ class IterativeRobotBase : public RobotBase {
    * This will publish the execution time of method calls in the robot loop;
    * methods like robot periodic and init methods, various NT
    * updates (SmartDashboard.update(), Shuffleboard.updateValues(),
-   * LiveWindow.updateValues(),) etc.
+   * LiveWindow.updateValues()) etc.
+   *
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */

--- a/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
+++ b/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
@@ -206,7 +206,7 @@ class IterativeRobotBase : public RobotBase {
   virtual void TestExit();
 
   /**
-   * Starts publishing added epochs to NetworkTables.
+   * Starts publishing loop timings to NetworkTables.
    *
    * This will publish the execution time of method calls in the robot loop;
    * methods like robot periodic and init methods, various NT
@@ -217,7 +217,7 @@ class IterativeRobotBase : public RobotBase {
   void PublishToNetworkTables(std::string_view topicName);
 
   /**
-   * Starts logging added epochs to the data log.
+   * Starts logging loop timings to the data log.
    *
    * This will publish the execution time of method calls in the robot loop;
    * methods like robot periodic and init methods, various NT

--- a/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
+++ b/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
@@ -214,7 +214,7 @@ class IterativeRobotBase : public RobotBase {
    * LiveWindow.updateValues(),) etc.
    * @param topicName The NetworkTables topic to publish to
    */
-  void PublishToNetworkTables(std::string_view topicName);
+  void PublishLoopTimingsToNetworkTables(std::string_view topicName);
 
   /**
    * Starts logging loop timings to the data log.
@@ -226,7 +226,8 @@ class IterativeRobotBase : public RobotBase {
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */
-  void StartDataLog(wpi::log::DataLog& dataLog, std::string_view entry);
+  void StartLoopTimingsDataLog(wpi::log::DataLog& dataLog,
+                               std::string_view entry);
 
   /**
    * Enables or disables flushing NetworkTables every loop iteration.

--- a/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
+++ b/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
@@ -208,6 +208,10 @@ class IterativeRobotBase : public RobotBase {
   /**
    * Starts publishing added epochs to NetworkTables.
    *
+   * This will publish the execution time of method calls in the robot loop;
+   * methods like robot periodic and init methods, various NT
+   * updates (SmartDashboard.update(), Shuffleboard.updateValues(),
+   * LiveWindow.updateValues(),) etc.
    * @param topicName The NetworkTables topic to publish to
    */
   void PublishToNetworkTables(std::string_view topicName);
@@ -215,6 +219,10 @@ class IterativeRobotBase : public RobotBase {
   /**
    * Starts logging added epochs to the data log.
    *
+   * This will publish the execution time of method calls in the robot loop;
+   * methods like robot periodic and init methods, various NT
+   * updates (SmartDashboard.update(), Shuffleboard.updateValues(),
+   * LiveWindow.updateValues(),) etc.
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */

--- a/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
+++ b/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <units/time.h>
+#include <wpi/DataLog.h>
 
 #include "frc/RobotBase.h"
 #include "frc/Watchdog.h"
@@ -203,6 +204,28 @@ class IterativeRobotBase : public RobotBase {
    * the robot exits test mode.
    */
   virtual void TestExit();
+
+  /**
+   * Starts publishing added epochs to NetworkTables.
+   *
+   * @param topicName The NetworkTables topic to publish to
+   */
+  void PublishToNetworkTables(std::string_view topicName);
+
+  /**
+   * Starts logging added epochs to the data log. Default entry is "Epochs"
+   *
+   * @param dataLog The data log to log epochs to
+   */
+  void StartDataLog(wpi::log::DataLog dataLog);
+
+  /**
+   * Starts logging added epochs to the data log.
+   *
+   * @param dataLog The data log to log epochs to
+   * @param entry The name of the entry to log to
+   */
+  void StartDataLog(wpi::log::DataLog dataLog, std::string_view entry);
 
   /**
    * Enables or disables flushing NetworkTables every loop iteration.

--- a/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
+++ b/wpilibc/src/main/native/include/frc/IterativeRobotBase.h
@@ -226,7 +226,7 @@ class IterativeRobotBase : public RobotBase {
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */
-  void StartDataLog(wpi::log::DataLog dataLog, std::string_view entry);
+  void StartDataLog(wpi::log::DataLog& dataLog, std::string_view entry);
 
   /**
    * Enables or disables flushing NetworkTables every loop iteration.

--- a/wpilibc/src/main/native/include/frc/Tracer.h
+++ b/wpilibc/src/main/native/include/frc/Tracer.h
@@ -9,8 +9,8 @@
 #include <string_view>
 
 #include <hal/cpp/fpga_clock.h>
-#include <networktables/NetworkTableInstance.h>
 #include <networktables/IntegerTopic.h>
+#include <networktables/NetworkTableInstance.h>
 #include <wpi/DataLog.h>
 #include <wpi/StringMap.h>
 

--- a/wpilibc/src/main/native/include/frc/Tracer.h
+++ b/wpilibc/src/main/native/include/frc/Tracer.h
@@ -35,14 +35,14 @@ class Tracer {
   Tracer();
 
   /**
-   * Starts publishing added epochs to NetworkTables.
+   * Starts publishing added epochs to NetworkTables. Subsequent calls will do nothing.
    *
    * @param topicName The NetworkTables topic to publish to
    */
   void PublishToNetworkTables(std::string_view topicName);
 
   /**
-   * Starts logging added epochs to the data log.
+   * Starts logging added epochs to the data log. Subsequent calls will do nothing.
    *
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to

--- a/wpilibc/src/main/native/include/frc/Tracer.h
+++ b/wpilibc/src/main/native/include/frc/Tracer.h
@@ -35,14 +35,16 @@ class Tracer {
   Tracer();
 
   /**
-   * Starts publishing added epochs to NetworkTables. Subsequent calls will do nothing.
+   * Starts publishing added epochs to NetworkTables. Subsequent calls will do
+   * nothing.
    *
    * @param topicName The NetworkTables topic to publish to
    */
   void PublishToNetworkTables(std::string_view topicName);
 
   /**
-   * Starts logging added epochs to the data log. Subsequent calls will do nothing.
+   * Starts logging added epochs to the data log. Subsequent calls will do
+   * nothing.
    *
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to

--- a/wpilibc/src/main/native/include/frc/Tracer.h
+++ b/wpilibc/src/main/native/include/frc/Tracer.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <chrono>
+#include <memory>
 #include <string_view>
 
 #include <hal/cpp/fpga_clock.h>
@@ -87,7 +88,7 @@ class Tracer {
   bool m_publishNT;
   nt::NetworkTableInstance m_inst;
   std::string_view m_ntTopic;
-  wpi::StringMap<nt::IntegerPublisher*> m_publisherCache;
+  wpi::StringMap<std::shared_ptr<nt::IntegerPublisher>> m_publisherCache;
   bool m_dataLogEnabled = false;
   wpi::log::DataLog* m_dataLog;
   std::string_view m_dataLogEntry;

--- a/wpilibc/src/main/native/include/frc/Tracer.h
+++ b/wpilibc/src/main/native/include/frc/Tracer.h
@@ -9,6 +9,7 @@
 #include <string_view>
 
 #include <hal/cpp/fpga_clock.h>
+#include <networktables/NetworkTableInstance.h>
 #include <networktables/IntegerTopic.h>
 #include <wpi/DataLog.h>
 #include <wpi/StringMap.h>

--- a/wpilibc/src/main/native/include/frc/Tracer.h
+++ b/wpilibc/src/main/native/include/frc/Tracer.h
@@ -45,7 +45,7 @@ class Tracer {
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */
-  void StartDataLog(wpi::log::DataLog dataLog, std::string_view entry);
+  void StartDataLog(wpi::log::DataLog& dataLog, std::string_view entry);
 
   /**
    * Restarts the epoch timer.
@@ -87,9 +87,9 @@ class Tracer {
   bool m_publishNT;
   nt::NetworkTableInstance m_inst;
   std::string_view m_ntTopic;
-  wpi::StringMap<nt::IntegerPublisher> m_publisherCache;
-  bool m_dataLogEnabled;
-  wpi::log::DataLog m_dataLog;
+  wpi::StringMap<nt::IntegerPublisher*> m_publisherCache;
+  bool m_dataLogEnabled = false;
+  wpi::log::DataLog* m_dataLog;
   std::string_view m_dataLogEntry;
   wpi::StringMap<int> m_entryCache;
 

--- a/wpilibc/src/main/native/include/frc/Tracer.h
+++ b/wpilibc/src/main/native/include/frc/Tracer.h
@@ -8,6 +8,7 @@
 #include <string_view>
 
 #include <hal/cpp/fpga_clock.h>
+#include <networktables/IntegerTopic.h>
 #include <wpi/DataLog.h>
 #include <wpi/StringMap.h>
 
@@ -86,9 +87,11 @@ class Tracer {
   bool m_publishNT;
   nt::NetworkTableInstance m_inst;
   std::string_view m_ntTopic;
+  wpi::StringMap<nt::IntegerPublisher> m_publisherCache;
   bool m_dataLogEnabled;
   wpi::log::DataLog m_dataLog;
   std::string_view m_dataLogEntry;
+  wpi::StringMap<int> m_entryCache;
 
   wpi::StringMap<std::chrono::nanoseconds> m_epochs;
 };

--- a/wpilibc/src/main/native/include/frc/Tracer.h
+++ b/wpilibc/src/main/native/include/frc/Tracer.h
@@ -84,9 +84,10 @@ class Tracer {
   hal::fpga_clock::time_point m_startTime;
   hal::fpga_clock::time_point m_lastEpochsPrintTime = hal::fpga_clock::epoch();
   bool m_publishNT;
+  nt::NetworkTableInstance m_inst;
+  std::string_view m_ntTopic;
   bool m_dataLogEnabled;
   wpi::log::DataLog m_dataLog;
-  std::string_view m_ntTopic;
   std::string_view m_dataLogEntry;
 
   wpi::StringMap<std::chrono::nanoseconds> m_epochs;

--- a/wpilibc/src/main/native/include/frc/Tracer.h
+++ b/wpilibc/src/main/native/include/frc/Tracer.h
@@ -39,13 +39,6 @@ class Tracer {
   void PublishToNetworkTables(std::string_view topicName);
 
   /**
-   * Starts logging added epochs to the data log. Default entry is "Epochs"
-   *
-   * @param dataLog The data log to log epochs to
-   */
-  void StartDataLog(wpi::log::DataLog dataLog);
-
-  /**
    * Starts logging added epochs to the data log.
    *
    * @param dataLog The data log to log epochs to
@@ -94,7 +87,7 @@ class Tracer {
   bool m_dataLogEnabled;
   wpi::log::DataLog m_dataLog;
   std::string_view m_ntTopic;
-  std::string_view m_dataLogEntry = "Epochs";
+  std::string_view m_dataLogEntry;
 
   wpi::StringMap<std::chrono::nanoseconds> m_epochs;
 };

--- a/wpilibc/src/main/native/include/frc/Tracer.h
+++ b/wpilibc/src/main/native/include/frc/Tracer.h
@@ -8,6 +8,7 @@
 #include <string_view>
 
 #include <hal/cpp/fpga_clock.h>
+#include <wpi/DataLog.h>
 #include <wpi/StringMap.h>
 
 namespace wpi {
@@ -29,6 +30,28 @@ class Tracer {
    * Constructs a Tracer instance.
    */
   Tracer();
+
+  /**
+   * Starts publishing added epochs to NetworkTables.
+   *
+   * @param topicName The NetworkTables topic to publish to
+   */
+  void PublishToNetworkTables(std::string_view topicName);
+
+  /**
+   * Starts logging added epochs to the data log. Default entry is "Epochs"
+   *
+   * @param dataLog The data log to log epochs to
+   */
+  void StartDataLog(wpi::log::DataLog dataLog);
+
+  /**
+   * Starts logging added epochs to the data log.
+   *
+   * @param dataLog The data log to log epochs to
+   * @param entry The name of the entry to log to
+   */
+  void StartDataLog(wpi::log::DataLog dataLog, std::string_view entry);
 
   /**
    * Restarts the epoch timer.
@@ -67,6 +90,11 @@ class Tracer {
 
   hal::fpga_clock::time_point m_startTime;
   hal::fpga_clock::time_point m_lastEpochsPrintTime = hal::fpga_clock::epoch();
+  bool m_publishNT;
+  bool m_dataLogEnabled;
+  wpi::log::DataLog m_dataLog;
+  std::string_view m_ntTopic;
+  std::string_view m_dataLogEntry = "Epochs";
 
   wpi::StringMap<std::chrono::nanoseconds> m_epochs;
 };

--- a/wpilibc/src/main/native/include/frc/Tracer.h
+++ b/wpilibc/src/main/native/include/frc/Tracer.h
@@ -85,7 +85,7 @@ class Tracer {
 
   hal::fpga_clock::time_point m_startTime;
   hal::fpga_clock::time_point m_lastEpochsPrintTime = hal::fpga_clock::epoch();
-  bool m_publishNT;
+  bool m_publishNT = false;
   nt::NetworkTableInstance m_inst;
   std::string_view m_ntTopic;
   wpi::StringMap<std::shared_ptr<nt::IntegerPublisher>> m_publisherCache;

--- a/wpilibc/src/main/native/include/frc/Watchdog.h
+++ b/wpilibc/src/main/native/include/frc/Watchdog.h
@@ -46,14 +46,16 @@ class Watchdog {
   Watchdog& operator=(Watchdog&& rhs);
 
   /**
-   * Starts publishing added epochs to NetworkTables. Subsequent calls will do nothing.
+   * Starts publishing added epochs to NetworkTables. Subsequent calls will do
+   * nothing.
    *
    * @param topicName The NetworkTables topic to publish to
    */
   void PublishToNetworkTables(std::string_view topicName);
 
   /**
-   * Starts logging added epochs to the data log. Subsequent calls will do nothing.
+   * Starts logging added epochs to the data log. Subsequent calls will do
+   * nothing.
    *
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to

--- a/wpilibc/src/main/native/include/frc/Watchdog.h
+++ b/wpilibc/src/main/native/include/frc/Watchdog.h
@@ -46,14 +46,14 @@ class Watchdog {
   Watchdog& operator=(Watchdog&& rhs);
 
   /**
-   * Starts publishing added epochs to NetworkTables.
+   * Starts publishing added epochs to NetworkTables. Subsequent calls will do nothing.
    *
    * @param topicName The NetworkTables topic to publish to
    */
   void PublishToNetworkTables(std::string_view topicName);
 
   /**
-   * Starts logging added epochs to the data log.
+   * Starts logging added epochs to the data log. Subsequent calls will do nothing.
    *
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to

--- a/wpilibc/src/main/native/include/frc/Watchdog.h
+++ b/wpilibc/src/main/native/include/frc/Watchdog.h
@@ -53,13 +53,6 @@ class Watchdog {
   void PublishToNetworkTables(std::string_view topicName);
 
   /**
-   * Starts logging added epochs to the data log. Default entry is "Epochs"
-   *
-   * @param dataLog The data log to log epochs to
-   */
-  void StartDataLog(wpi::log::DataLog dataLog);
-
-  /**
    * Starts logging added epochs to the data log.
    *
    * @param dataLog The data log to log epochs to

--- a/wpilibc/src/main/native/include/frc/Watchdog.h
+++ b/wpilibc/src/main/native/include/frc/Watchdog.h
@@ -46,6 +46,28 @@ class Watchdog {
   Watchdog& operator=(Watchdog&& rhs);
 
   /**
+   * Starts publishing added epochs to NetworkTables.
+   *
+   * @param topicName The NetworkTables topic to publish to
+   */
+  void PublishToNetworkTables(std::string_view topicName);
+
+  /**
+   * Starts logging added epochs to the data log. Default entry is "Epochs"
+   *
+   * @param dataLog The data log to log epochs to
+   */
+  void StartDataLog(wpi::log::DataLog dataLog);
+
+  /**
+   * Starts logging added epochs to the data log.
+   *
+   * @param dataLog The data log to log epochs to
+   * @param entry The name of the entry to log to
+   */
+  void StartDataLog(wpi::log::DataLog dataLog, std::string_view entry);
+
+  /**
    * Returns the time since the watchdog was last fed.
    */
   units::second_t GetTime() const;

--- a/wpilibc/src/main/native/include/frc/Watchdog.h
+++ b/wpilibc/src/main/native/include/frc/Watchdog.h
@@ -58,7 +58,7 @@ class Watchdog {
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */
-  void StartDataLog(wpi::log::DataLog dataLog, std::string_view entry);
+  void StartDataLog(wpi::log::DataLog& dataLog, std::string_view entry);
 
   /**
    * Returns the time since the watchdog was last fed.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -252,7 +252,7 @@ public abstract class IterativeRobotBase extends RobotBase {
   public void testExit() {}
 
   /**
-   * Starts publishing loop timings to NetworkTables.
+   * Starts publishing loop timings to NetworkTables. Subsequent calls will do nothing.
    *
    * <p>This will publish the execution time of method calls in the robot loop; methods like robot
    * periodic and init methods, various NT updates (SmartDashboard.update(),
@@ -265,7 +265,7 @@ public abstract class IterativeRobotBase extends RobotBase {
   }
 
   /**
-   * Starts logging loop timings to the data log.
+   * Starts logging loop timings to the data log. Subsequent calls will do nothing.
    *
    * <p>This will log the execution time of method calls in the robot loop; methods like robot
    * periodic and init methods, various NT updates (SmartDashboard.update(),

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -59,7 +59,7 @@ import java.util.ConcurrentModificationException;
  *   <li>testExit() -- called each and every time test is exited
  * </ul>
  */
-public abstract class IterativeRobotBase extends RobotBase, Loggable {
+public abstract class IterativeRobotBase extends RobotBase {
   private enum Mode {
     kNone,
     kDisabled,

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -260,7 +260,7 @@ public abstract class IterativeRobotBase extends RobotBase {
    *
    * @param topicName The NetworkTables topic to publish to
    */
-  public void publishToNetworkTables(String topicName) {
+  public void publishLoopTimingsToNetworkTables(String topicName) {
     m_watchdog.publishToNetworkTables(topicName);
   }
 
@@ -274,7 +274,7 @@ public abstract class IterativeRobotBase extends RobotBase {
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */
-  public void startDataLog(DataLog dataLog, String entry) {
+  public void startLoopTimingsDataLog(DataLog dataLog, String entry) {
     m_watchdog.startDataLog(dataLog, entry);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -261,22 +261,13 @@ public abstract class IterativeRobotBase extends RobotBase {
   }
 
   /**
-   * Starts logging added epochs to the data log. Default entry is "Epochs"
-   *
-   * @param dataLog The data log to log epochs to
-   */
-  public void startDataLog(DataLog dataLog) {
-    m_watchdog.startDataLog(dataLog);
-  }
-
-  /**
    * Starts logging added epochs to the data log.
    *
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */
   public void startDataLog(DataLog dataLog, String entry) {
-    m_watchdog.startDataLog(dataLog);
+    m_watchdog.startDataLog(dataLog, entry);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -259,7 +259,7 @@ public abstract class IterativeRobotBase extends RobotBase {
    * methods like robot periodic and init methods, various NT
    * updates (SmartDashboard.update(), Shuffleboard.updateValues(),
    * LiveWindow.updateValues(),) etc.
-   * 
+   *
    * @param topicName The NetworkTables topic to publish to
    */
   public void publishToNetworkTables(String topicName) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -251,13 +251,8 @@ public abstract class IterativeRobotBase extends RobotBase {
    */
   public void testExit() {}
 
-  /** Starts publishing added epochs to NetworkTables. Default topic is "Epochs" */
-  public void publishToNetworkTables() {
-    m_watchdog.publishToNetworkTables();
-  }
-
   /**
-   * Starts publishing added epochs to NetworkTables. Default topic is "Epochs"
+   * Starts publishing added epochs to NetworkTables.
    *
    * @param topicName The NetworkTables topic to publish to
    */
@@ -265,17 +260,22 @@ public abstract class IterativeRobotBase extends RobotBase {
     m_watchdog.publishToNetworkTables(topicName);
   }
 
-  /** Starts logging added epochs to the data log. Defaults to the default data log. */
-  public void startDataLog() {
-    m_watchdog.startDataLog();
+  /**
+   * Starts logging added epochs to the data log. Default entry is "Epochs"
+   *
+   * @param dataLog The data log to log epochs to
+   */
+  public void startDataLog(DataLog dataLog) {
+    m_watchdog.startDataLog(dataLog);
   }
 
   /**
    * Starts logging added epochs to the data log.
    *
    * @param dataLog The data log to log epochs to
+   * @param entry The name of the entry to log to
    */
-  public void startDataLog(DataLog dataLog) {
+  public void startDataLog(DataLog dataLog, String entry) {
     m_watchdog.startDataLog(dataLog);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -265,7 +265,7 @@ public abstract class IterativeRobotBase extends RobotBase {
   }
 
   /**
-   * Starts logging added epochs to the data log.
+   * Starts logging loop timings to the data log.
    *
    * <p>This will log the execution time of method calls in the robot loop; methods like robot
    * periodic and init methods, various NT updates (SmartDashboard.update(),

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -254,11 +254,9 @@ public abstract class IterativeRobotBase extends RobotBase {
   /**
    * Starts publishing loop timings to NetworkTables.
    *
-   * <p>
-   * This will publish the execution time of method calls in the robot loop;
-   * methods like robot periodic and init methods, various NT
-   * updates (SmartDashboard.update(), Shuffleboard.updateValues(),
-   * LiveWindow.updateValues(),) etc.
+   * <p>This will publish the execution time of method calls in the robot loop; methods like robot
+   * periodic and init methods, various NT updates (SmartDashboard.update(),
+   * Shuffleboard.updateValues(), LiveWindow.updateValues(),) etc.
    *
    * @param topicName The NetworkTables topic to publish to
    */
@@ -269,11 +267,10 @@ public abstract class IterativeRobotBase extends RobotBase {
   /**
    * Starts logging added epochs to the data log.
    *
-   * <p>
-   * This will log the execution time of method calls in the robot loop;
-   * methods like robot periodic and init methods, various NT
-   * updates (SmartDashboard.update(), Shuffleboard.updateValues(),
-   * LiveWindow.updateValues(),) etc.
+   * <p>This will log the execution time of method calls in the robot loop; methods like robot
+   * periodic and init methods, various NT updates (SmartDashboard.update(),
+   * Shuffleboard.updateValues(), LiveWindow.updateValues(),) etc.
+   *
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -59,7 +59,7 @@ import java.util.ConcurrentModificationException;
  *   <li>testExit() -- called each and every time test is exited
  * </ul>
  */
-public abstract class IterativeRobotBase extends RobotBase {
+public abstract class IterativeRobotBase extends RobotBase, Loggable {
   private enum Mode {
     kNone,
     kDisabled,

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -256,10 +256,11 @@ public abstract class IterativeRobotBase extends RobotBase {
     m_watchdog.publishToNetworkTables();
   }
 
-  /** Starts publishing added epochs to NetworkTables. Default topic is "Epochs" 
-   * 
+  /**
+   * Starts publishing added epochs to NetworkTables. Default topic is "Epochs"
+   *
    * @param topicName The NetworkTables topic to publish to
-  */
+   */
   public void publishToNetworkTables(String topicName) {
     m_watchdog.publishToNetworkTables(topicName);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -9,6 +9,7 @@ import edu.wpi.first.hal.FRCNetComm.tInstances;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.util.datalog.DataLog;
 import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -249,6 +250,33 @@ public abstract class IterativeRobotBase extends RobotBase {
    * test mode.
    */
   public void testExit() {}
+
+  /** Starts publishing added epochs to NetworkTables. Default topic is "Epochs" */
+  public void publishToNetworkTables() {
+    m_watchdog.publishToNetworkTables();
+  }
+
+  /** Starts publishing added epochs to NetworkTables. Default topic is "Epochs" 
+   * 
+   * @param topicName The NetworkTables topic to publish to
+  */
+  public void publishToNetworkTables(String topicName) {
+    m_watchdog.publishToNetworkTables(topicName);
+  }
+
+  /** Starts logging added epochs to the data log. Defaults to the default data log. */
+  public void startDataLog() {
+    m_watchdog.startDataLog();
+  }
+
+  /**
+   * Starts logging added epochs to the data log.
+   *
+   * @param dataLog The data log to log epochs to
+   */
+  public void startDataLog(DataLog dataLog) {
+    m_watchdog.startDataLog(dataLog);
+  }
 
   /**
    * Enables or disables flushing NetworkTables every loop iteration. By default, this is enabled.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -256,7 +256,7 @@ public abstract class IterativeRobotBase extends RobotBase {
    *
    * <p>This will publish the execution time of method calls in the robot loop; methods like robot
    * periodic and init methods, various NT updates (SmartDashboard.update(),
-   * Shuffleboard.updateValues(), LiveWindow.updateValues(),) etc.
+   * Shuffleboard.updateValues(), LiveWindow.updateValues()) etc.
    *
    * @param topicName The NetworkTables topic to publish to
    */
@@ -269,7 +269,7 @@ public abstract class IterativeRobotBase extends RobotBase {
    *
    * <p>This will log the execution time of method calls in the robot loop; methods like robot
    * periodic and init methods, various NT updates (SmartDashboard.update(),
-   * Shuffleboard.updateValues(), LiveWindow.updateValues(),) etc.
+   * Shuffleboard.updateValues(), LiveWindow.updateValues()) etc.
    *
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/IterativeRobotBase.java
@@ -252,8 +252,14 @@ public abstract class IterativeRobotBase extends RobotBase {
   public void testExit() {}
 
   /**
-   * Starts publishing added epochs to NetworkTables.
+   * Starts publishing loop timings to NetworkTables.
    *
+   * <p>
+   * This will publish the execution time of method calls in the robot loop;
+   * methods like robot periodic and init methods, various NT
+   * updates (SmartDashboard.update(), Shuffleboard.updateValues(),
+   * LiveWindow.updateValues(),) etc.
+   * 
    * @param topicName The NetworkTables topic to publish to
    */
   public void publishToNetworkTables(String topicName) {
@@ -263,6 +269,11 @@ public abstract class IterativeRobotBase extends RobotBase {
   /**
    * Starts logging added epochs to the data log.
    *
+   * <p>
+   * This will log the execution time of method calls in the robot loop;
+   * methods like robot periodic and init methods, various NT
+   * updates (SmartDashboard.update(), Shuffleboard.updateValues(),
+   * LiveWindow.updateValues(),) etc.
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
@@ -41,28 +41,32 @@ public class Tracer {
   }
 
   /**
-   * Starts publishing added epochs to NetworkTables.
+   * Starts publishing added epochs to NetworkTables. Subsequent calls will do nothing.
    *
    * @param topicName The NetworkTables topic to publish to
    */
   public void publishToNetworkTables(String topicName) {
-    m_publishNT = true;
-    m_inst = NetworkTableInstance.getDefault();
-    m_ntTopic = topicName;
-    m_publisherCache = new HashMap<>(10);
+    if (!m_publishNT) {
+      m_publishNT = true;
+      m_inst = NetworkTableInstance.getDefault();
+      m_ntTopic = topicName;
+      m_publisherCache = new HashMap<>(10);
+    }
   }
 
   /**
-   * Starts logging added epochs to the data log.
+   * Starts logging added epochs to the data log. Subsequent calls will do nothing.
    *
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */
   public void startDataLog(DataLog dataLog, String entry) {
-    m_dataLog = dataLog;
-    m_dataLogEntry = entry;
-    m_dataLogEnabled = true;
-    m_entryCache = new HashMap<>(10);
+    if (!m_dataLogEnabled) {
+      m_dataLog = dataLog;
+      m_dataLogEntry = entry;
+      m_dataLogEnabled = true;
+      m_entryCache = new HashMap<>(10);
+    }
   }
 
   /** Clears all epochs. */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
@@ -53,12 +53,13 @@ public class Tracer implements AutoCloseable {
    * @param topicName The NetworkTables topic to publish to
    */
   public void publishToNetworkTables(String topicName) {
-    if (!m_publishNT) {
-      m_publishNT = true;
-      m_inst = NetworkTableInstance.getDefault();
-      m_ntTopic = topicName;
-      m_publisherCache = new HashMap<>(10);
+    if (m_publishNT) {
+      return;
     }
+    m_publishNT = true;
+    m_inst = NetworkTableInstance.getDefault();
+    m_ntTopic = topicName;
+    m_publisherCache = new HashMap<>(10);
   }
 
   /**
@@ -69,11 +70,12 @@ public class Tracer implements AutoCloseable {
    */
   public void startDataLog(DataLog dataLog, String entry) {
     if (!m_dataLogEnabled) {
-      m_dataLog = dataLog;
-      m_dataLogEntry = entry;
-      m_dataLogEnabled = true;
-      m_entryCache = new HashMap<>(10);
+      return;
     }
+    m_dataLog = dataLog;
+    m_dataLogEntry = entry;
+    m_dataLogEnabled = true;
+    m_entryCache = new HashMap<>(10);
   }
 
   /** Clears all epochs. */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
@@ -42,8 +42,10 @@ public class Tracer implements AutoCloseable {
 
   @Override
   public void close() {
-    for (IntegerPublisher pub : m_publisherCache.values()) {
-      pub.close();
+    if (m_entryCache != null) {
+      for (IntegerPublisher pub : m_publisherCache.values()) {
+        pub.close();
+      }
     }
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
@@ -42,7 +42,7 @@ public class Tracer implements AutoCloseable {
 
   @Override
   public void close() {
-    if (m_entryCache != null) {
+    if (m_publisherCache != null) {
       for (IntegerPublisher pub : m_publisherCache.values()) {
         pub.close();
       }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
  * <p>Epochs are a way to partition the time elapsed so that when overruns occur, one can determine
  * which parts of an operation consumed the most time.
  */
-public class Tracer {
+public class Tracer implements AutoCloseable {
   private static final long kMinPrintPeriod = 1000000; // microseconds
 
   private long m_lastEpochsPrintTime; // microseconds
@@ -38,6 +38,13 @@ public class Tracer {
   /** Tracer constructor. */
   public Tracer() {
     resetTimer();
+  }
+
+  @Override
+  public void close() {
+    for (IntegerPublisher pub : m_publisherCache.values()) {
+      pub.close();
+    }
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
@@ -26,9 +26,10 @@ public class Tracer {
   private long m_lastEpochsPrintTime; // microseconds
   private long m_startTime; // microseconds
   private boolean m_publishNT;
+  private NetworkTableInstance m_inst;
+  private String m_ntTopic;
   private boolean m_dataLogEnabled;
   private DataLog m_dataLog;
-  private String m_ntTopic;
   private String m_dataLogEntry;
 
   private final Map<String, Long> m_epochs = new HashMap<>(); // microseconds
@@ -45,6 +46,7 @@ public class Tracer {
    */
   public void publishToNetworkTables(String topicName) {
     m_publishNT = true;
+    m_inst = NetworkTableInstance.getDefault();
     m_ntTopic = topicName;
   }
 
@@ -87,8 +89,7 @@ public class Tracer {
     long epoch = currentTime - m_startTime;
     m_epochs.put(epochName, epoch);
     if (m_publishNT) {
-      IntegerTopic topic =
-          NetworkTableInstance.getDefault().getIntegerTopic(m_ntTopic + "/" + epochName);
+      IntegerTopic topic = m_inst.getIntegerTopic(m_ntTopic + "/" + epochName);
       IntegerPublisher pub = topic.publish();
       pub.setDefault(0);
       topic.setRetained(true);

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
@@ -29,7 +29,7 @@ public class Tracer {
   private boolean m_dataLogEnabled;
   private DataLog m_dataLog;
   private String m_ntTopic;
-  private String m_dataLogEntry = "Epochs";
+  private String m_dataLogEntry;
 
   private final Map<String, Long> m_epochs = new HashMap<>(); // microseconds
 
@@ -46,16 +46,6 @@ public class Tracer {
   public void publishToNetworkTables(String topicName) {
     m_publishNT = true;
     m_ntTopic = topicName;
-  }
-
-  /**
-   * Starts logging added epochs to the data log. Default entry is "Epochs"
-   *
-   * @param dataLog The data log to log epochs to
-   */
-  public void startDataLog(DataLog dataLog) {
-    m_dataLog = dataLog;
-    m_dataLogEnabled = true;
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Tracer.java
@@ -5,7 +5,6 @@
 package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.networktables.IntegerPublisher;
-import edu.wpi.first.networktables.IntegerTopic;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.util.datalog.DataLog;
 import java.util.HashMap;
@@ -95,7 +94,7 @@ public class Tracer {
     // Topics are cached with the epoch name as the key, and the publisher object as the value
     if (m_publishNT) {
       if (!m_publisherCache.containsKey(epochName)) {
-      // Create and prep the epoch publisher
+        // Create and prep the epoch publisher
         var topic = m_inst.getIntegerTopic(m_ntTopic + "/" + epochName);
         var pub = topic.publish();
         m_publisherCache.put(epochName, pub);
@@ -103,15 +102,15 @@ public class Tracer {
       m_publisherCache.get(epochName).set(epoch);
     }
     if (m_dataLogEnabled) {
-    // Epochs are cached with the epoch name as the key, and the entry index as
-    // the value
+      // Epochs are cached with the epoch name as the key, and the entry index as
+      // the value
       if (!m_entryCache.containsKey(epochName)) {
         // Start a data log entry
         int entryIndex = m_dataLog.start(m_dataLogEntry + "/" + epochName, "int64");
         // Cache the entry index with the epoch name as the key
         m_entryCache.put(epochName, entryIndex);
       }
-m_dataLog.appendInteger(m_entryCache.get(epochName), epoch, 0);
+      m_dataLog.appendInteger(m_entryCache.get(epochName), epoch, 0);
     }
     m_startTime = currentTime;
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -58,6 +58,7 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
 
   @Override
   public void close() {
+    m_tracer.close();
     disable();
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -93,7 +93,7 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
   /**
    * Starts logging added epochs to the data log.
    *
-   *  @param dataLog The data log to log epochs to
+   * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */
   public void startDataLog(DataLog dataLog, String entry) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -82,7 +82,7 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
   }
 
   /**
-   * Starts publishing added epochs to NetworkTables. Default topic is "Epochs"
+   * Starts publishing added epochs to NetworkTables.
    *
    * @param topicName The NetworkTables topic to publish to
    */
@@ -93,7 +93,7 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
   /**
    * Starts logging added epochs to the data log.
    *
-   * @param dataLog The data log to log epochs to
+   *  @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */
   public void startDataLog(DataLog dataLog, String entry) {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -81,11 +81,6 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
     return Double.compare(m_expirationTimeSeconds, rhs.m_expirationTimeSeconds);
   }
 
-  /** Starts publishing added epochs to NetworkTables. Default topic is "Epochs" */
-  public void publishToNetworkTables() {
-    m_tracer.publishToNetworkTables();
-  }
-
   /**
    * Starts publishing added epochs to NetworkTables. Default topic is "Epochs"
    *
@@ -95,17 +90,22 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
     m_tracer.publishToNetworkTables(topicName);
   }
 
-  /** Starts logging added epochs to the data log. Defaults to the default data log. */
-  public void startDataLog() {
-    m_tracer.startDataLog();
+  /**
+   * Starts logging added epochs to the data log. Default entry is "Epochs"
+   *
+   * @param dataLog The data log to log epochs to
+   */
+  public void startDataLog(DataLog dataLog) {
+    m_tracer.startDataLog(dataLog);
   }
 
   /**
    * Starts logging added epochs to the data log.
    *
    * @param dataLog The data log to log epochs to
+   * @param entry The name of the entry to log to
    */
-  public void startDataLog(DataLog dataLog) {
+  public void startDataLog(DataLog dataLog, String entry) {
     m_tracer.startDataLog(dataLog);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -91,22 +91,13 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
   }
 
   /**
-   * Starts logging added epochs to the data log. Default entry is "Epochs"
-   *
-   * @param dataLog The data log to log epochs to
-   */
-  public void startDataLog(DataLog dataLog) {
-    m_tracer.startDataLog(dataLog);
-  }
-
-  /**
    * Starts logging added epochs to the data log.
    *
    * @param dataLog The data log to log epochs to
    * @param entry The name of the entry to log to
    */
   public void startDataLog(DataLog dataLog, String entry) {
-    m_tracer.startDataLog(dataLog);
+    m_tracer.startDataLog(dataLog, entry);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -5,6 +5,7 @@
 package edu.wpi.first.wpilibj;
 
 import edu.wpi.first.hal.NotifierJNI;
+import edu.wpi.first.util.datalog.DataLog;
 import java.io.Closeable;
 import java.util.PriorityQueue;
 import java.util.concurrent.locks.ReentrantLock;
@@ -78,6 +79,33 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
     // Elements with sooner expiration times are sorted as lesser. The head of
     // Java's PriorityQueue is the least element.
     return Double.compare(m_expirationTimeSeconds, rhs.m_expirationTimeSeconds);
+  }
+
+  /** Starts publishing added epochs to NetworkTables. Default topic is "Epochs" */
+  public void publishToNetworkTables() {
+    m_tracer.publishToNetworkTables();
+  }
+
+  /** Starts publishing added epochs to NetworkTables. Default topic is "Epochs"
+   * 
+   * @param topicName The NetworkTables topic to publish to
+   */
+  public void publishToNetworkTables(String topicName) {
+    m_tracer.publishToNetworkTables(topicName);
+  }
+
+  /** Starts logging added epochs to the data log. Defaults to the default data log. */
+  public void startDataLog() {
+    m_tracer.startDataLog();
+  }
+
+  /**
+   * Starts logging added epochs to the data log.
+   *
+   * @param dataLog The data log to log epochs to
+   */
+  public void startDataLog(DataLog dataLog) {
+    m_tracer.startDataLog(dataLog);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Watchdog.java
@@ -86,8 +86,9 @@ public class Watchdog implements Closeable, Comparable<Watchdog> {
     m_tracer.publishToNetworkTables();
   }
 
-  /** Starts publishing added epochs to NetworkTables. Default topic is "Epochs"
-   * 
+  /**
+   * Starts publishing added epochs to NetworkTables. Default topic is "Epochs"
+   *
    * @param topicName The NetworkTables topic to publish to
    */
   public void publishToNetworkTables(String topicName) {


### PR DESCRIPTION
Includes methods to enable DataLog logging or NT publishing. The first time an epoch is added, an NT publisher is created and a DataLog entry is started (if they're enabled), both of which are cached for future use. Everytime an epoch is added, it gets published to NT and logged to DataLog (if they're enabled). Addresses a part of #5314. Resolves #609.