### PR TITLE
Fix flaky ShuffleboardInstance test

### DIFF
--- a/wpilibc/src/test/native/cpp/shuffleboard/ShuffleboardInstanceTest.cpp
+++ b/wpilibc/src/test/native/cpp/shuffleboard/ShuffleboardInstanceTest.cpp
@@ -123,7 +123,7 @@ TEST(ShuffleboardInstanceTest, DuplicateSelectTabs) {
 
   shuffleboardInst.SelectTab("tab1");
   shuffleboardInst.SelectTab("tab1");
-  EXPECT_TRUE(ntInst.inst.WaitForListenerQueue(0.005))
+  EXPECT_TRUE(ntInst.inst.WaitForListenerQueue(1.0))
       << "Listener queue timed out!";
   EXPECT_EQ(2, counter);
 }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstanceTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstanceTest.java
@@ -141,7 +141,7 @@ class ShuffleboardInstanceTest {
 
       m_shuffleboardInstance.selectTab("tab1");
       m_shuffleboardInstance.selectTab("tab1");
-      assertTrue(m_ntInstance.waitForListenerQueue(0.005), "Listener queue timed out!");
+      assertTrue(m_ntInstance.waitForListenerQueue(1.0), "Listener queue timed out!");
       assertEquals(2, counter.get());
 
     } finally {


### PR DESCRIPTION
Extends the timeout to 1 second, consistent with other tests that use `waitForListenerQueue`. Cause of failure was likely just the timeout being too short, particularly in Java.