### PR TITLE
Create separate archive with just units headers

### DIFF
--- a/shared/jni/publish.gradle
+++ b/shared/jni/publish.gradle
@@ -6,6 +6,7 @@ def outputsFolder = file("$buildDir/outputs")
 def baseArtifactId = nativeName
 def artifactGroupId = "edu.wpi.first.${nativeName}"
 def zipBaseName = "_GROUP_edu_wpi_first_${nativeName}_ID_${nativeName}-cpp_CLS"
+ext.zipBaseName = zipBaseName
 def jniBaseName = "_GROUP_edu_wpi_first_${nativeName}_ID_${nativeName}-jni_CLS"
 def jniCvStaticBaseName = "_GROUP_edu_wpi_first_${nativeName}_ID_${nativeName}-jnicvstatic_CLS"
 

--- a/wpimath/build.gradle
+++ b/wpimath/build.gradle
@@ -125,3 +125,25 @@ task generateNat() {
 sourceSets.main.java.srcDir "${buildDir}/generated/java"
 compileJava.dependsOn generateNumbers
 compileJava.dependsOn generateNat
+
+task unitsHeaders(type: Zip) {
+    destinationDirectory = file("$buildDir/outputs")
+    archiveBaseName = zipBaseName
+    archiveClassifier = "units"
+
+    from(licenseFile) {
+        into '/'
+    }
+
+    ext.includeDirs = [
+        project.file('src/main/native/include/units')
+    ]
+
+    ext.includeDirs.each {
+        from(it) {
+            into '/units'
+        }
+    }
+}
+
+addTaskToCopyAllOutputs(unitsHeaders)


### PR DESCRIPTION
This will allow very low level deps to use the same units library we ship with wpilib.

Closes #5362