### PR TITLE
[wpiutil, ntcore] Add structured data support

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,8 @@ jobs:
           - os: macOS-12
             name: macOS
             container: ""
-            flags: "-DCMAKE_BUILD_TYPE=Release -DWITH_JAVA=OFF -DWITH_EXAMPLES=ON"
+            env: "PATH=\"/usr/local/opt/protobuf@3/bin:$PATH\""
+            flags: "-DCMAKE_BUILD_TYPE=Release -DWITH_JAVA=OFF -DWITH_EXAMPLES=ON -DCMAKE_LIBRARY_PATH=/usr/local/opt/protobuf@3/lib -DProtobuf_INCLUDE_DIR=/usr/local/opt/protobuf@3/include -DProtobuf_PROTOC_EXECUTABLE=/usr/local/opt/protobuf@3/bin/protoc"
 
     name: "Build - ${{ matrix.name }}"
     runs-on: ${{ matrix.os }}
@@ -27,10 +28,14 @@ jobs:
     steps:
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libopencv-dev libopencv4.5-java python-is-python3 ninja-build
+        run: sudo apt-get update && sudo apt-get install -y libopencv-dev libopencv4.5-java python-is-python3 libprotobuf-dev protobuf-compiler ninja-build
+
+      - name: Install QuickBuffers (Linux)
+        if: runner.os == 'Linux'
+        run: wget https://github.com/HebiRobotics/QuickBuffers/releases/download/1.3.2/protoc-gen-quickbuf_1.3.2_amd64.deb && sudo apt install ./protoc-gen-quickbuf_1.3.2_amd64.deb
 
       - name: Install opencv (macOS)
-        run: brew install opencv ninja
+        run: brew install opencv protobuf@3 ninja
         if: runner.os == 'macOS'
 
       - name: Set up Python 3.8 (macOS)

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -29,7 +29,11 @@ jobs:
     container: wpilib/roborio-cross-ubuntu:2024-22.04
     steps:
       - name: Install Dependencies
-        run: sudo apt-get update && sudo apt-get install -y libopencv-dev libopencv4.5-java python-is-python3 clang-14
+        run: sudo apt-get update && sudo apt-get install -y libopencv-dev libopencv4.5-java python-is-python3 clang-14 libprotobuf-dev protobuf-compiler ninja-build
+
+      - name: Install QuickBuffers
+        if: runner.os == 'Linux'
+        run: wget https://github.com/HebiRobotics/QuickBuffers/releases/download/1.3.2/protoc-gen-quickbuf_1.3.2_amd64.deb && sudo apt install ./protoc-gen-quickbuf_1.3.2_amd64.deb
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
@@ -40,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: configure
-        run: mkdir build && cd build && cmake -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/clang-14 -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/clang++-14 ${{ matrix.cmake-flags }} ..
+        run: mkdir build && cd build && cmake -G Ninja -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/clang-14 -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/clang++-14 ${{ matrix.cmake-flags }} ..
         env:
           SCCACHE_GHA_ENABLED: "true"
 

--- a/.styleguide
+++ b/.styleguide
@@ -31,6 +31,7 @@ includeOtherLibs {
   ^cscore
   ^fmt/
   ^gtest/
+  ^google/
   ^hal/
   ^imgui
   ^implot

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,12 @@ endif()
 
 find_package(LIBSSH 0.7.1)
 
+find_package(Protobuf REQUIRED)
+find_program(Quickbuf_EXECUTABLE
+    NAMES protoc-gen-quickbuf
+    DOC "The Quickbuf protoc plugin"
+)
+
 if (WITH_FLAT_INSTALL)
 set(WPIUTIL_DEP_REPLACE "include($\{SELF_DIR\}/wpiutil-config.cmake)")
 set(WPINET_DEP_REPLACE "include($\{SELF_DIR\}/wpinet-config.cmake)")

--- a/README-CMAKE.md
+++ b/README-CMAKE.md
@@ -20,6 +20,8 @@ By default, all libraries except for the HAL and WPILib get built with a default
 
 The jinja2 pip package is needed to generate classes for NT4's pubsub.
 
+The protobuf library and compiler are needed for protobuf generation. The QuickBuffers protoc-gen package is also required when Java is being built.
+
 OpenCV needs to be findable by CMake. On systems like the Jetson, this is installed by default. Otherwise, you will need to build OpenCV from source and install it.
 
 If you want JNI and Java, you will need a JDK of at least version 11 installed. In addition, you need a `JAVA_HOME` environment variable set properly and set to the JDK directory.

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
     id 'com.diffplug.spotless' version '6.20.0' apply false
     id 'com.github.spotbugs' version '5.1.3' apply false
+    id 'com.google.protobuf' version '0.9.3' apply false
 }
 
 wpilibVersioning.buildServerMode = project.hasProperty('buildServer')

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -142,6 +142,8 @@ doxygen {
     //TODO: building memory docs causes search to break
     exclude 'wpi/memory/**'
 
+    exclude '*.pb.h'
+
     aliases 'effects=\\par <i>Effects:</i>^^',
             'notes=\\par <i>Notes:</i>^^',
             'requires=\\par <i>Requires:</i>^^',

--- a/glass/.styleguide
+++ b/glass/.styleguide
@@ -24,6 +24,7 @@ includeOtherLibs {
   ^fmt/
   ^fields/
   ^frc/
+  ^google/
   ^imgui
   ^networktables/
   ^ntcore

--- a/glass/src/libnt/native/include/glass/networktables/NetworkTables.h
+++ b/glass/src/libnt/native/include/glass/networktables/NetworkTables.h
@@ -18,6 +18,8 @@
 #include <ntcore_cpp.h>
 #include <wpi/DenseMap.h>
 #include <wpi/json.h>
+#include <wpi/protobuf/ProtobufMessageDatabase.h>
+#include <wpi/struct/DynamicStruct.h>
 
 #include "glass/Model.h"
 #include "glass/View.h"
@@ -31,7 +33,7 @@ class NetworkTablesModel : public Model {
   struct EntryValueTreeNode;
 
   struct ValueSource {
-    void UpdateFromValue(nt::Value&& v, std::string_view name,
+    void UpdateFromValue(NetworkTablesModel& model, std::string_view name,
                          std::string_view typeStr);
 
     /** The latest value. */
@@ -39,6 +41,9 @@ class NetworkTablesModel : public Model {
 
     /** String representation of the value (for arrays / complex values). */
     std::string valueStr;
+
+    /** Data type */
+    std::string typeStr;
 
     /** Data source (for numeric values). */
     std::unique_ptr<DataSource> source;
@@ -72,6 +77,10 @@ class NetworkTablesModel : public Model {
     Entry(const Entry&) = delete;
     Entry& operator=(const Entry&) = delete;
     ~Entry();
+
+    void UpdateFromValue(NetworkTablesModel& model) {
+      ValueSource::UpdateFromValue(model, info.name, info.type_str);
+    }
 
     void UpdateTopic(nt::Event&& event) {
       if (std::holds_alternative<nt::TopicInfo>(event.data)) {
@@ -158,6 +167,9 @@ class NetworkTablesModel : public Model {
   Entry* GetEntry(std::string_view name);
   Entry* AddEntry(NT_Topic topic);
 
+  wpi::StructDescriptorDatabase& GetStructDatabase() { return m_structDb; }
+  wpi::ProtobufMessageDatabase& GetProtobufDatabase() { return m_protoDb; }
+
  private:
   void RebuildTree();
   void RebuildTreeImpl(std::vector<TreeNode>* tree, int category);
@@ -177,6 +189,9 @@ class NetworkTablesModel : public Model {
 
   std::map<std::string, Client, std::less<>> m_clients;
   Client m_server;
+
+  wpi::StructDescriptorDatabase m_structDb;
+  wpi::ProtobufMessageDatabase m_protoDb;
 };
 
 using NetworkTablesFlags = int;

--- a/ntcore/CMakeLists.txt
+++ b/ntcore/CMakeLists.txt
@@ -54,6 +54,11 @@ if (WITH_JAVA)
     include(UseJava)
     set(CMAKE_JAVA_COMPILE_FLAGS "-encoding" "UTF8" "-Xlint:unchecked")
 
+    file(GLOB QUICKBUF_JAR
+        ${WPILIB_BINARY_DIR}/wpiutil/thirdparty/quickbuf/*.jar)
+
+    set(CMAKE_JAVA_INCLUDE_PATH wpimath.jar ${QUICKBUF_JAR})
+
     file(GLOB ntcore_jni_src
         src/main/native/cpp/jni/*.cpp
         ${WPILIB_BINARY_DIR}/ntcore/generated/main/native/cpp/jni/*.cpp)

--- a/ntcore/src/generate/java/NetworkTableInstance.java.jinja
+++ b/ntcore/src/generate/java/NetworkTableInstance.java.jinja
@@ -7,16 +7,22 @@ package edu.wpi.first.networktables;
 import edu.wpi.first.util.WPIUtilJNI;
 import edu.wpi.first.util.concurrent.Event;
 import edu.wpi.first.util.datalog.DataLog;
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.struct.Struct;
+import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
+import us.hebi.quickbuf.ProtoMessage;
 
 /**
  * NetworkTables Instance.
@@ -86,6 +92,7 @@ public final class NetworkTableInstance implements AutoCloseable {
   public synchronized void close() {
     if (m_owned && m_handle != 0) {
       m_listeners.close();
+      m_schemas.forEach((k, v) -> v.close());
       NetworkTablesJNI.destroyInstance(m_handle);
       m_handle = 0;
     }
@@ -176,15 +183,119 @@ public final class NetworkTableInstance implements AutoCloseable {
       handle = topic.getHandle();
     }
 
-    topic = new {{ t.TypeName }}Topic(this, handle);
-    m_topics.put(name, topic);
+    {{ t.TypeName }}Topic wrapTopic = new {{ t.TypeName }}Topic(this, handle);
+    m_topics.put(name, wrapTopic);
 
     // also cache by handle
-    m_topicsByHandle.put(handle, topic);
+    m_topicsByHandle.put(handle, wrapTopic);
 
-    return ({{ t.TypeName }}Topic) topic;
+    return wrapTopic;
   }
 {% endfor %}
+
+  /**
+   * Get protobuf-encoded value topic.
+   *
+   * @param <T> value class (inferred from proto)
+   * @param <MessageType> protobuf message type (inferred from proto)
+   * @param name topic name
+   * @param proto protobuf serialization implementation
+   * @return ProtobufTopic
+   */
+  public <T, MessageType extends ProtoMessage<?>>
+      ProtobufTopic<T> getProtobufTopic(String name, Protobuf<T, MessageType> proto) {
+    Topic topic = m_topics.get(name);
+    if (topic instanceof ProtobufTopic<?>
+        && ((ProtobufTopic<?>) topic).getProto().equals(proto)) {
+      @SuppressWarnings("unchecked")
+      ProtobufTopic<T> wrapTopic = (ProtobufTopic<T>) topic;
+      return wrapTopic;
+    }
+
+    int handle;
+    if (topic == null) {
+      handle = NetworkTablesJNI.getTopic(m_handle, name);
+    } else {
+      handle = topic.getHandle();
+    }
+
+    ProtobufTopic<T> wrapTopic = ProtobufTopic.wrap(this, handle, proto);
+    m_topics.put(name, wrapTopic);
+
+    // also cache by handle
+    m_topicsByHandle.put(handle, wrapTopic);
+
+    return wrapTopic;
+  }
+
+  /**
+   * Get struct-encoded value topic.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param name topic name
+   * @param struct struct serialization implementation
+   * @return StructTopic
+   */
+  public <T>
+      StructTopic<T> getStructTopic(String name, Struct<T> struct) {
+    Topic topic = m_topics.get(name);
+    if (topic instanceof StructTopic<?>
+        && ((StructTopic<?>) topic).getStruct().equals(struct)) {
+      @SuppressWarnings("unchecked")
+      StructTopic<T> wrapTopic = (StructTopic<T>) topic;
+      return wrapTopic;
+    }
+
+    int handle;
+    if (topic == null) {
+      handle = NetworkTablesJNI.getTopic(m_handle, name);
+    } else {
+      handle = topic.getHandle();
+    }
+
+    StructTopic<T> wrapTopic = StructTopic.wrap(this, handle, struct);
+    m_topics.put(name, wrapTopic);
+
+    // also cache by handle
+    m_topicsByHandle.put(handle, wrapTopic);
+
+    return wrapTopic;
+  }
+
+  /**
+   * Get struct-encoded value array topic.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param name topic name
+   * @param struct struct serialization implementation
+   * @return StructArrayTopic
+   */
+  public <T>
+      StructArrayTopic<T> getStructArrayTopic(String name, Struct<T> struct) {
+    Topic topic = m_topics.get(name);
+    if (topic instanceof StructArrayTopic<?>
+        && ((StructArrayTopic<?>) topic).getStruct().equals(struct)) {
+      @SuppressWarnings("unchecked")
+      StructArrayTopic<T> wrapTopic = (StructArrayTopic<T>) topic;
+      return wrapTopic;
+    }
+
+    int handle;
+    if (topic == null) {
+      handle = NetworkTablesJNI.getTopic(m_handle, name);
+    } else {
+      handle = topic.getHandle();
+    }
+
+    StructArrayTopic<T> wrapTopic = StructArrayTopic.wrap(this, handle, struct);
+    m_topics.put(name, wrapTopic);
+
+    // also cache by handle
+    m_topicsByHandle.put(handle, wrapTopic);
+
+    return wrapTopic;
+  }
+
   private Topic[] topicHandlesToTopics(int[] handles) {
     Topic[] topics = new Topic[handles.length];
     for (int i = 0; i < handles.length; i++) {
@@ -1050,6 +1161,78 @@ public final class NetworkTableInstance implements AutoCloseable {
     return m_listeners.addLogger(minLevel, maxLevel, func);
   }
 
+  /**
+   * Returns whether there is a data schema already registered with the given name that this
+   * instance has published. This does NOT perform a check as to whether the schema has already
+   * been published by another node on the network.
+   *
+   * @param name Name (the string passed as the data type for topics using this schema)
+   * @return True if schema already registered
+   */
+  public boolean hasSchema(String name) {
+    return m_schemas.containsKey("/.schema/" + name);
+  }
+
+  /**
+   * Registers a data schema. Data schemas provide information for how a certain data type string
+   * can be decoded. The type string of a data schema indicates the type of the schema itself (e.g.
+   * "protobuf" for protobuf schemas, "struct" for struct schemas, etc). In NetworkTables, schemas
+   * are published just like normal topics, with the name being generated from the provided name:
+   * "/.schema/name". Duplicate calls to this function with the same name are silently ignored.
+   *
+   * @param name Name (the string passed as the data type for topics using this schema)
+   * @param type Type of schema (e.g. "protobuf", "struct", etc)
+   * @param schema Schema data
+   */
+  public void addSchema(String name, String type, byte[] schema) {
+    m_schemas.computeIfAbsent("/.schema/" + name, k -> {
+      RawPublisher pub = getRawTopic(k).publishEx(type, "{\"retained\":true}");
+      pub.setDefault(schema);
+      return pub;
+    });
+  }
+
+  /**
+   * Registers a data schema. Data schemas provide information for how a certain data type string
+   * can be decoded. The type string of a data schema indicates the type of the schema itself (e.g.
+   * "protobuf" for protobuf schemas, "struct" for struct schemas, etc). In NetworkTables, schemas
+   * are published just like normal topics, with the name being generated from the provided name:
+   * "/.schema/name". Duplicate calls to this function with the same name are silently ignored.
+   *
+   * @param name Name (the string passed as the data type for topics using this schema)
+   * @param type Type of schema (e.g. "protobuf", "struct", etc)
+   * @param schema Schema data
+   */
+  public void addSchema(String name, String type, String schema) {
+    m_schemas.computeIfAbsent("/.schema/" + name, k -> {
+      RawPublisher pub = getRawTopic(k).publishEx(type, "{\"retained\":true}");
+      pub.setDefault(StandardCharsets.UTF_8.encode(schema));
+      return pub;
+    });
+  }
+
+  /**
+   * Registers a protobuf schema. Duplicate calls to this function with the same name are silently
+   * ignored.
+   *
+   * @param proto protobuf serialization object
+   */
+  public void addSchema(Protobuf<?, ?> proto) {
+    proto.forEachDescriptor(
+        this::hasSchema,
+        (typeString, schema) -> addSchema(typeString, "proto:FileDescriptorProto", schema));
+  }
+
+  /**
+   * Registers a struct schema. Duplicate calls to this function with the same name are silently
+   * ignored.
+   *
+   * @param struct struct serialization object
+   */
+  public void addSchema(Struct<?> struct) {
+    addSchemaImpl(struct, new HashSet<>());
+  }
+
   @Override
   public boolean equals(Object other) {
     if (other == this) {
@@ -1067,6 +1250,22 @@ public final class NetworkTableInstance implements AutoCloseable {
     return m_handle;
   }
 
+  private void addSchemaImpl(Struct<?> struct, Set<String> seen) {
+    String typeString = struct.getTypeString();
+    if (hasSchema(typeString)) {
+      return;
+    }
+    if (!seen.add(typeString)) {
+      throw new UnsupportedOperationException(typeString + ": circular reference with " + seen);
+    }
+    addSchema(typeString, "structschema", struct.getSchema());
+    for (Struct<?> inner : struct.getNested()) {
+      addSchemaImpl(inner, seen);
+    }
+    seen.remove(typeString);
+  }
+
   private boolean m_owned;
   private int m_handle;
+  private final ConcurrentMap<String, RawPublisher> m_schemas = new ConcurrentHashMap<>();
 }

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTable.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTable.java
@@ -4,6 +4,8 @@
 
 package edu.wpi.first.networktables;
 
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.struct.Struct;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -13,8 +15,10 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
+import us.hebi.quickbuf.ProtoMessage;
 
 /** A network table that knows its subtable path. */
+@SuppressWarnings("PMD.CouplingBetweenObjects")
 public final class NetworkTable {
   /** The path separator for sub-tables and keys. */
   public static final char PATH_SEPARATOR = '/';
@@ -248,6 +252,44 @@ public final class NetworkTable {
    */
   public StringArrayTopic getStringArrayTopic(String name) {
     return m_inst.getStringArrayTopic(m_pathWithSep + name);
+  }
+
+  /**
+   * Get protobuf-encoded value topic.
+   *
+   * @param <T> value class (inferred from proto)
+   * @param <MessageType> protobuf message type (inferred from proto)
+   * @param name topic name
+   * @param proto protobuf serialization implementation
+   * @return ProtobufTopic
+   */
+  public <T, MessageType extends ProtoMessage<?>> ProtobufTopic<T> getProtobufTopic(
+      String name, Protobuf<T, MessageType> proto) {
+    return m_inst.getProtobufTopic(m_pathWithSep + name, proto);
+  }
+
+  /**
+   * Get struct-encoded value topic.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param name topic name
+   * @param struct struct serialization implementation
+   * @return StructTopic
+   */
+  public <T> StructTopic<T> getStructTopic(String name, Struct<T> struct) {
+    return m_inst.getStructTopic(m_pathWithSep + name, struct);
+  }
+
+  /**
+   * Get struct-encoded value array topic.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param name topic name
+   * @param struct struct serialization implementation
+   * @return StructTopic
+   */
+  public <T> StructArrayTopic<T> getStructArrayTopic(String name, Struct<T> struct) {
+    return m_inst.getStructArrayTopic(m_pathWithSep + name, struct);
   }
 
   private final ConcurrentMap<String, NetworkTableEntry> m_entries = new ConcurrentHashMap<>();

--- a/ntcore/src/main/java/edu/wpi/first/networktables/ProtobufEntry.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/ProtobufEntry.java
@@ -1,0 +1,17 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+/**
+ * NetworkTables protobuf-encoded value entry.
+ *
+ * <p>Unlike NetworkTableEntry, the entry goes away when close() is called.
+ *
+ * @param <T> value class
+ */
+public interface ProtobufEntry<T> extends ProtobufSubscriber<T>, ProtobufPublisher<T> {
+  /** Stops publishing the entry if it's published. */
+  void unpublish();
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/ProtobufEntryImpl.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/ProtobufEntryImpl.java
@@ -1,0 +1,209 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import edu.wpi.first.util.protobuf.ProtobufBuffer;
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.nio.ByteBuffer;
+
+/**
+ * NetworkTables protobuf-encoded value implementation.
+ *
+ * @param <T> value class
+ */
+final class ProtobufEntryImpl<T> extends EntryBase implements ProtobufEntry<T> {
+  /**
+   * Constructor.
+   *
+   * @param topic Topic
+   * @param handle Native handle
+   * @param defaultValue Default value for get()
+   */
+  ProtobufEntryImpl(
+      ProtobufTopic<T> topic,
+      ProtobufBuffer<T, ?> buf,
+      int handle,
+      T defaultValue,
+      boolean schemaPublished) {
+    super(handle);
+    m_topic = topic;
+    m_defaultValue = defaultValue;
+    m_buf = buf;
+    m_schemaPublished = schemaPublished;
+  }
+
+  @Override
+  public ProtobufTopic<T> getTopic() {
+    return m_topic;
+  }
+
+  @Override
+  public T get() {
+    return fromRaw(NetworkTablesJNI.getRaw(m_handle, m_emptyRaw), m_defaultValue);
+  }
+
+  @Override
+  public T get(T defaultValue) {
+    return fromRaw(NetworkTablesJNI.getRaw(m_handle, m_emptyRaw), defaultValue);
+  }
+
+  @Override
+  public boolean getInto(T out) {
+    byte[] raw = NetworkTablesJNI.getRaw(m_handle, m_emptyRaw);
+    if (raw.length == 0) {
+      return false;
+    }
+    try {
+      synchronized (m_buf) {
+        m_buf.readInto(out, raw);
+        return true;
+      }
+    } catch (IOException e) {
+      // ignored
+    }
+    return false;
+  }
+
+  @Override
+  public TimestampedObject<T> getAtomic() {
+    return fromRaw(NetworkTablesJNI.getAtomicRaw(m_handle, m_emptyRaw), m_defaultValue);
+  }
+
+  @Override
+  public TimestampedObject<T> getAtomic(T defaultValue) {
+    return fromRaw(NetworkTablesJNI.getAtomicRaw(m_handle, m_emptyRaw), defaultValue);
+  }
+
+  @Override
+  public TimestampedObject<T>[] readQueue() {
+    TimestampedRaw[] raw = NetworkTablesJNI.readQueueRaw(m_handle);
+    @SuppressWarnings("unchecked")
+    TimestampedObject<T>[] arr = (TimestampedObject<T>[]) new TimestampedObject<?>[raw.length];
+    int err = 0;
+    for (int i = 0; i < raw.length; i++) {
+      arr[i] = fromRaw(raw[i], null);
+      if (arr[i].value == null) {
+        err++;
+      }
+    }
+
+    // discard bad values
+    if (err > 0) {
+      @SuppressWarnings("unchecked")
+      TimestampedObject<T>[] newArr =
+          (TimestampedObject<T>[]) new TimestampedObject<?>[raw.length - err];
+      int i = 0;
+      for (TimestampedObject<T> e : arr) {
+        if (e.value != null) {
+          arr[i] = e;
+          i++;
+        }
+      }
+      arr = newArr;
+    }
+
+    return arr;
+  }
+
+  @Override
+  public T[] readQueueValues() {
+    byte[][] raw = NetworkTablesJNI.readQueueValuesRaw(m_handle);
+    @SuppressWarnings("unchecked")
+    T[] arr = (T[]) Array.newInstance(m_topic.getProto().getTypeClass(), raw.length);
+    int err = 0;
+    for (int i = 0; i < raw.length; i++) {
+      arr[i] = fromRaw(raw[i], null);
+      if (arr[i] == null) {
+        err++;
+      }
+    }
+
+    // discard bad values
+    if (err > 0) {
+      @SuppressWarnings("unchecked")
+      T[] newArr = (T[]) Array.newInstance(m_topic.getProto().getTypeClass(), raw.length - err);
+      int i = 0;
+      for (T e : arr) {
+        if (e != null) {
+          arr[i] = e;
+          i++;
+        }
+      }
+      arr = newArr;
+    }
+
+    return arr;
+  }
+
+  @Override
+  public void set(T value, long time) {
+    try {
+      synchronized (m_buf) {
+        if (!m_schemaPublished) {
+          m_schemaPublished = true;
+          m_topic.getInstance().addSchema(m_buf.getProto());
+        }
+        ByteBuffer bb = m_buf.write(value);
+        NetworkTablesJNI.setRaw(m_handle, time, bb, 0, bb.position());
+      }
+    } catch (IOException e) {
+      // ignore
+    }
+  }
+
+  @Override
+  public void setDefault(T value) {
+    try {
+      synchronized (m_buf) {
+        if (!m_schemaPublished) {
+          m_schemaPublished = true;
+          m_topic.getInstance().addSchema(m_buf.getProto());
+        }
+        ByteBuffer bb = m_buf.write(value);
+        NetworkTablesJNI.setDefaultRaw(m_handle, 0, bb, 0, bb.position());
+      }
+    } catch (IOException e) {
+      // ignore
+    }
+  }
+
+  @Override
+  public void unpublish() {
+    NetworkTablesJNI.unpublish(m_handle);
+  }
+
+  private T fromRaw(byte[] raw, T defaultValue) {
+    if (raw.length == 0) {
+      return defaultValue;
+    }
+    try {
+      synchronized (m_buf) {
+        return m_buf.read(raw);
+      }
+    } catch (IOException e) {
+      return defaultValue;
+    }
+  }
+
+  private TimestampedObject<T> fromRaw(TimestampedRaw raw, T defaultValue) {
+    if (raw.value.length == 0) {
+      return new TimestampedObject<T>(0, 0, defaultValue);
+    }
+    try {
+      synchronized (m_buf) {
+        return new TimestampedObject<T>(raw.timestamp, raw.serverTime, m_buf.read(raw.value));
+      }
+    } catch (IOException e) {
+      return new TimestampedObject<T>(0, 0, defaultValue);
+    }
+  }
+
+  private final ProtobufTopic<T> m_topic;
+  private final T m_defaultValue;
+  private final ProtobufBuffer<T, ?> m_buf;
+  private boolean m_schemaPublished;
+  private static final byte[] m_emptyRaw = new byte[] {};
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/ProtobufPublisher.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/ProtobufPublisher.java
@@ -1,0 +1,52 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import java.util.function.Consumer;
+
+/**
+ * NetworkTables protobuf-encoded value publisher.
+ *
+ * @param <T> value class
+ */
+public interface ProtobufPublisher<T> extends Publisher, Consumer<T> {
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  @Override
+  ProtobufTopic<T> getTopic();
+
+  /**
+   * Publish a new value using current NT time.
+   *
+   * @param value value to publish
+   */
+  default void set(T value) {
+    set(value, 0);
+  }
+
+  /**
+   * Publish a new value.
+   *
+   * @param value value to publish
+   * @param time timestamp; 0 indicates current NT time should be used
+   */
+  void set(T value, long time);
+
+  /**
+   * Publish a default value. On reconnect, a default value will never be used in preference to a
+   * published value.
+   *
+   * @param value value
+   */
+  void setDefault(T value);
+
+  @Override
+  default void accept(T value) {
+    set(value);
+  }
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/ProtobufSubscriber.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/ProtobufSubscriber.java
@@ -1,0 +1,94 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import java.util.function.Supplier;
+
+/**
+ * NetworkTables protobuf-encoded value subscriber.
+ *
+ * @param <T> value class
+ */
+@SuppressWarnings("PMD.MissingOverride")
+public interface ProtobufSubscriber<T> extends Subscriber, Supplier<T> {
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  @Override
+  ProtobufTopic<T> getTopic();
+
+  /**
+   * Get the last published value. If no value has been published or the value cannot be unpacked,
+   * returns the stored default value.
+   *
+   * @return value
+   */
+  T get();
+
+  /**
+   * Get the last published value. If no value has been published or the value cannot be unpacked,
+   * returns the passed defaultValue.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return value
+   */
+  T get(T defaultValue);
+
+  /**
+   * Get the last published value, replacing the contents in place of an existing object. If no
+   * value has been published or the value cannot be unpacked, does not replace the contents and
+   * returns false. This function will not work (will throw UnsupportedOperationException) unless T
+   * is mutable (and the implementation of Struct implements unpackInto).
+   *
+   * <p>Note: due to Java language limitations, it's not possible to validate at compile time that
+   * the out parameter is mutable.
+   *
+   * @param out object to replace contents of; must be mutable
+   * @return true if successful
+   * @throws UnsupportedOperationException if T is immutable
+   */
+  boolean getInto(T out);
+
+  /**
+   * Get the last published value along with its timestamp. If no value has been published or the
+   * value cannot be unpacked, returns the stored default value and a timestamp of 0.
+   *
+   * @return timestamped value
+   */
+  TimestampedObject<T> getAtomic();
+
+  /**
+   * Get the last published value along with its timestamp. If no value has been published or the
+   * value cannot be unpacked, returns the passed defaultValue and a timestamp of 0.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return timestamped value
+   */
+  TimestampedObject<T> getAtomic(T defaultValue);
+
+  /**
+   * Get an array of all valid value changes since the last call to readQueue. Also provides a
+   * timestamp for each value. Values that cannot be unpacked are dropped.
+   *
+   * <p>The "poll storage" subscribe option can be used to set the queue depth.
+   *
+   * @return Array of timestamped values; empty array if no valid new changes have been published
+   *     since the previous call.
+   */
+  TimestampedObject<T>[] readQueue();
+
+  /**
+   * Get an array of all valid value changes since the last call to readQueue. Values that cannot be
+   * unpacked are dropped.
+   *
+   * <p>The "poll storage" subscribe option can be used to set the queue depth.
+   *
+   * @return Array of values; empty array if no valid new changes have been published since the
+   *     previous call.
+   */
+  T[] readQueueValues();
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/ProtobufTopic.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/ProtobufTopic.java
@@ -1,0 +1,178 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.protobuf.ProtobufBuffer;
+
+/**
+ * NetworkTables protobuf-encoded value topic.
+ *
+ * @param <T> value class
+ */
+public final class ProtobufTopic<T> extends Topic {
+  private ProtobufTopic(Topic topic, Protobuf<T, ?> proto) {
+    super(topic.m_inst, topic.m_handle);
+    m_proto = proto;
+  }
+
+  private ProtobufTopic(NetworkTableInstance inst, int handle, Protobuf<T, ?> proto) {
+    super(inst, handle);
+    m_proto = proto;
+  }
+
+  /**
+   * Create a ProtobufTopic from a generic topic.
+   *
+   * @param <T> value class (inferred from proto)
+   * @param topic generic topic
+   * @param proto protobuf serialization implementation
+   * @return ProtobufTopic for value class
+   */
+  public static <T> ProtobufTopic<T> wrap(Topic topic, Protobuf<T, ?> proto) {
+    return new ProtobufTopic<T>(topic, proto);
+  }
+
+  /**
+   * Create a ProtobufTopic from a native handle; generally NetworkTableInstance.getProtobufTopic()
+   * should be used instead.
+   *
+   * @param <T> value class (inferred from proto)
+   * @param inst Instance
+   * @param handle Native handle
+   * @param proto protobuf serialization implementation
+   * @return ProtobufTopic for value class
+   */
+  public static <T> ProtobufTopic<T> wrap(
+      NetworkTableInstance inst, int handle, Protobuf<T, ?> proto) {
+    return new ProtobufTopic<T>(inst, handle, proto);
+  }
+
+  /**
+   * Create a new subscriber to the topic.
+   *
+   * <p>The subscriber is only active as long as the returned object is not closed.
+   *
+   * <p>Subscribers that do not match the published data type do not return any values. To determine
+   * if the data type matches, use the appropriate Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a getter function
+   * @param options subscribe options
+   * @return subscriber
+   */
+  public ProtobufSubscriber<T> subscribe(T defaultValue, PubSubOption... options) {
+    return new ProtobufEntryImpl<T>(
+        this,
+        ProtobufBuffer.create(m_proto),
+        NetworkTablesJNI.subscribe(
+            m_handle, NetworkTableType.kRaw.getValue(), m_proto.getTypeString(), options),
+        defaultValue,
+        false);
+  }
+
+  /**
+   * Create a new publisher to the topic.
+   *
+   * <p>The publisher is only active as long as the returned object is not closed.
+   *
+   * <p>It is not possible to publish two different data types to the same topic. Conflicts between
+   * publishers are typically resolved by the server on a first-come, first-served basis. Any
+   * published values that do not match the topic's data type are dropped (ignored). To determine if
+   * the data type matches, use the appropriate Topic functions.
+   *
+   * @param options publish options
+   * @return publisher
+   */
+  public ProtobufPublisher<T> publish(PubSubOption... options) {
+    m_inst.addSchema(m_proto);
+    return new ProtobufEntryImpl<T>(
+        this,
+        ProtobufBuffer.create(m_proto),
+        NetworkTablesJNI.publish(
+            m_handle, NetworkTableType.kRaw.getValue(), m_proto.getTypeString(), options),
+        null,
+        true);
+  }
+
+  /**
+   * Create a new publisher to the topic, with type string and initial properties.
+   *
+   * <p>The publisher is only active as long as the returned object is not closed.
+   *
+   * <p>It is not possible to publish two different data types to the same topic. Conflicts between
+   * publishers are typically resolved by the server on a first-come, first-served basis. Any
+   * published values that do not match the topic's data type are dropped (ignored). To determine if
+   * the data type matches, use the appropriate Topic functions.
+   *
+   * @param properties JSON properties
+   * @param options publish options
+   * @return publisher
+   * @throws IllegalArgumentException if properties is not a JSON object
+   */
+  public ProtobufPublisher<T> publishEx(String properties, PubSubOption... options) {
+    m_inst.addSchema(m_proto);
+    return new ProtobufEntryImpl<T>(
+        this,
+        ProtobufBuffer.create(m_proto),
+        NetworkTablesJNI.publishEx(
+            m_handle,
+            NetworkTableType.kRaw.getValue(),
+            m_proto.getTypeString(),
+            properties,
+            options),
+        null,
+        true);
+  }
+
+  /**
+   * Create a new entry for the topic.
+   *
+   * <p>Entries act as a combination of a subscriber and a weak publisher. The subscriber is active
+   * as long as the entry is not closed. The publisher is created when the entry is first written
+   * to, and remains active until either unpublish() is called or the entry is closed.
+   *
+   * <p>It is not possible to use two different data types with the same topic. Conflicts between
+   * publishers are typically resolved by the server on a first-come, first-served basis. Any
+   * published values that do not match the topic's data type are dropped (ignored), and the entry
+   * will show no new values if the data type does not match. To determine if the data type matches,
+   * use the appropriate Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a getter function
+   * @param options publish and/or subscribe options
+   * @return entry
+   */
+  public ProtobufEntry<T> getEntry(T defaultValue, PubSubOption... options) {
+    return new ProtobufEntryImpl<T>(
+        this,
+        ProtobufBuffer.create(m_proto),
+        NetworkTablesJNI.getEntry(
+            m_handle, NetworkTableType.kRaw.getValue(), m_proto.getTypeString(), options),
+        defaultValue,
+        false);
+  }
+
+  public Protobuf<T, ?> getProto() {
+    return m_proto;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+    if (!(other instanceof ProtobufTopic)) {
+      return false;
+    }
+
+    return super.equals(other) && m_proto == ((ProtobufTopic<?>) other).m_proto;
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode() ^ m_proto.hashCode();
+  }
+
+  private final Protobuf<T, ?> m_proto;
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/StructArrayEntry.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/StructArrayEntry.java
@@ -1,0 +1,17 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+/**
+ * NetworkTables struct-encoded array value entry.
+ *
+ * <p>Unlike NetworkTableEntry, the entry goes away when close() is called.
+ *
+ * @param <T> value class
+ */
+public interface StructArrayEntry<T> extends StructArraySubscriber<T>, StructArrayPublisher<T> {
+  /** Stops publishing the entry if it's published. */
+  void unpublish();
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/StructArrayEntryImpl.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/StructArrayEntryImpl.java
@@ -1,0 +1,197 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import edu.wpi.first.util.struct.StructBuffer;
+import java.lang.reflect.Array;
+import java.nio.ByteBuffer;
+
+/**
+ * NetworkTables struct-encoded value implementation.
+ *
+ * @param <T> value class
+ */
+@SuppressWarnings("PMD.ArrayIsStoredDirectly")
+final class StructArrayEntryImpl<T> extends EntryBase implements StructArrayEntry<T> {
+  /**
+   * Constructor.
+   *
+   * @param topic Topic
+   * @param handle Native handle
+   * @param defaultValue Default value for get()
+   */
+  StructArrayEntryImpl(
+      StructArrayTopic<T> topic,
+      StructBuffer<T> buf,
+      int handle,
+      T[] defaultValue,
+      boolean schemaPublished) {
+    super(handle);
+    m_topic = topic;
+    m_defaultValue = defaultValue;
+    m_buf = buf;
+    m_schemaPublished = schemaPublished;
+  }
+
+  @Override
+  public StructArrayTopic<T> getTopic() {
+    return m_topic;
+  }
+
+  @Override
+  public T[] get() {
+    return fromRaw(NetworkTablesJNI.getRaw(m_handle, m_emptyRaw), m_defaultValue);
+  }
+
+  @Override
+  public T[] get(T[] defaultValue) {
+    return fromRaw(NetworkTablesJNI.getRaw(m_handle, m_emptyRaw), defaultValue);
+  }
+
+  @Override
+  public TimestampedObject<T[]> getAtomic() {
+    return fromRaw(NetworkTablesJNI.getAtomicRaw(m_handle, m_emptyRaw), m_defaultValue);
+  }
+
+  @Override
+  public TimestampedObject<T[]> getAtomic(T[] defaultValue) {
+    return fromRaw(NetworkTablesJNI.getAtomicRaw(m_handle, m_emptyRaw), defaultValue);
+  }
+
+  @Override
+  public TimestampedObject<T[]>[] readQueue() {
+    TimestampedRaw[] raw = NetworkTablesJNI.readQueueRaw(m_handle);
+    @SuppressWarnings("unchecked")
+    TimestampedObject<T[]>[] arr = (TimestampedObject<T[]>[]) new TimestampedObject<?>[raw.length];
+    int err = 0;
+    for (int i = 0; i < raw.length; i++) {
+      arr[i] = fromRaw(raw[i], null);
+      if (arr[i].value == null) {
+        err++;
+      }
+    }
+
+    // discard bad values
+    if (err > 0) {
+      @SuppressWarnings("unchecked")
+      TimestampedObject<T[]>[] newArr =
+          (TimestampedObject<T[]>[]) new TimestampedObject<?>[raw.length - err];
+      int i = 0;
+      for (TimestampedObject<T[]> e : arr) {
+        if (e.value != null) {
+          arr[i] = e;
+          i++;
+        }
+      }
+      arr = newArr;
+    }
+
+    return arr;
+  }
+
+  @Override
+  public T[][] readQueueValues() {
+    byte[][] raw = NetworkTablesJNI.readQueueValuesRaw(m_handle);
+    @SuppressWarnings("unchecked")
+    T[][] arr = (T[][]) Array.newInstance(Array.class, raw.length);
+    int err = 0;
+    for (int i = 0; i < raw.length; i++) {
+      arr[i] = fromRaw(raw[i], null);
+      if (arr[i] == null) {
+        err++;
+      }
+    }
+
+    // discard bad values
+    if (err > 0) {
+      @SuppressWarnings("unchecked")
+      T[][] newArr = (T[][]) Array.newInstance(Array.class, raw.length - err);
+      int i = 0;
+      for (T[] e : arr) {
+        if (e != null) {
+          arr[i] = e;
+          i++;
+        }
+      }
+      arr = newArr;
+    }
+
+    return arr;
+  }
+
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  @Override
+  public void set(T[] value, long time) {
+    try {
+      synchronized (m_buf) {
+        if (!m_schemaPublished) {
+          m_schemaPublished = true;
+          m_topic.getInstance().addSchema(m_buf.getStruct());
+        }
+        ByteBuffer bb = m_buf.writeArray(value);
+        NetworkTablesJNI.setRaw(m_handle, time, bb, 0, bb.position());
+      }
+    } catch (RuntimeException e) {
+      // ignore
+    }
+  }
+
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  @Override
+  public void setDefault(T[] value) {
+    try {
+      synchronized (m_buf) {
+        if (!m_schemaPublished) {
+          m_schemaPublished = true;
+          m_topic.getInstance().addSchema(m_buf.getStruct());
+        }
+        ByteBuffer bb = m_buf.writeArray(value);
+        NetworkTablesJNI.setDefaultRaw(m_handle, 0, bb, 0, bb.position());
+      }
+    } catch (RuntimeException e) {
+      // ignore
+    }
+  }
+
+  @Override
+  public void unpublish() {
+    NetworkTablesJNI.unpublish(m_handle);
+  }
+
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  private T[] fromRaw(byte[] raw, T[] defaultValue) {
+    if (raw.length == 0) {
+      return defaultValue;
+    }
+    try {
+      synchronized (m_buf) {
+        return m_buf.readArray(raw);
+      }
+    } catch (RuntimeException e) {
+      return defaultValue;
+    }
+  }
+
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  private TimestampedObject<T[]> fromRaw(TimestampedRaw raw, T[] defaultValue) {
+    if (raw.value.length == 0) {
+      return new TimestampedObject<T[]>(0, 0, defaultValue);
+    }
+    try {
+      synchronized (m_buf) {
+        return new TimestampedObject<T[]>(
+            raw.timestamp, raw.serverTime, m_buf.readArray(raw.value));
+      }
+    } catch (RuntimeException e) {
+      return new TimestampedObject<T[]>(0, 0, defaultValue);
+    }
+  }
+
+  private final StructArrayTopic<T> m_topic;
+  private final T[] m_defaultValue;
+  private final StructBuffer<T> m_buf;
+  private boolean m_schemaPublished;
+  private static final byte[] m_emptyRaw = new byte[] {};
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/StructArrayPublisher.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/StructArrayPublisher.java
@@ -1,0 +1,52 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import java.util.function.Consumer;
+
+/**
+ * NetworkTables struct-encoded array value publisher.
+ *
+ * @param <T> value class
+ */
+public interface StructArrayPublisher<T> extends Publisher, Consumer<T[]> {
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  @Override
+  StructArrayTopic<T> getTopic();
+
+  /**
+   * Publish a new value using current NT time.
+   *
+   * @param value value to publish
+   */
+  default void set(T[] value) {
+    set(value, 0);
+  }
+
+  /**
+   * Publish a new value.
+   *
+   * @param value value to publish
+   * @param time timestamp; 0 indicates current NT time should be used
+   */
+  void set(T[] value, long time);
+
+  /**
+   * Publish a default value. On reconnect, a default value will never be used in preference to a
+   * published value.
+   *
+   * @param value value
+   */
+  void setDefault(T[] value);
+
+  @Override
+  default void accept(T[] value) {
+    set(value);
+  }
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/StructArraySubscriber.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/StructArraySubscriber.java
@@ -1,0 +1,79 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import java.util.function.Supplier;
+
+/**
+ * NetworkTables struct-encoded array value subscriber.
+ *
+ * @param <T> value class
+ */
+@SuppressWarnings("PMD.MissingOverride")
+public interface StructArraySubscriber<T> extends Subscriber, Supplier<T[]> {
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  @Override
+  StructArrayTopic<T> getTopic();
+
+  /**
+   * Get the last published value. If no value has been published or the value cannot be unpacked,
+   * returns the stored default value.
+   *
+   * @return value
+   */
+  T[] get();
+
+  /**
+   * Get the last published value. If no value has been published or the value cannot be unpacked,
+   * returns the passed defaultValue.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return value
+   */
+  T[] get(T[] defaultValue);
+
+  /**
+   * Get the last published value along with its timestamp. If no value has been published or the
+   * value cannot be unpacked, returns the stored default value and a timestamp of 0.
+   *
+   * @return timestamped value
+   */
+  TimestampedObject<T[]> getAtomic();
+
+  /**
+   * Get the last published value along with its timestamp. If no value has been published or the
+   * value cannot be unpacked, returns the passed defaultValue and a timestamp of 0.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return timestamped value
+   */
+  TimestampedObject<T[]> getAtomic(T[] defaultValue);
+
+  /**
+   * Get an array of all valid value changes since the last call to readQueue. Also provides a
+   * timestamp for each value. Values that cannot be unpacked are dropped.
+   *
+   * <p>The "poll storage" subscribe option can be used to set the queue depth.
+   *
+   * @return Array of timestamped values; empty array if no valid new changes have been published
+   *     since the previous call.
+   */
+  TimestampedObject<T[]>[] readQueue();
+
+  /**
+   * Get an array of all valid value changes since the last call to readQueue. Values that cannot be
+   * unpacked are dropped.
+   *
+   * <p>The "poll storage" subscribe option can be used to set the queue depth.
+   *
+   * @return Array of values; empty array if no valid new changes have been published since the
+   *     previous call.
+   */
+  T[][] readQueueValues();
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/StructArrayTopic.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/StructArrayTopic.java
@@ -1,0 +1,178 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import edu.wpi.first.util.struct.Struct;
+import edu.wpi.first.util.struct.StructBuffer;
+
+/**
+ * NetworkTables struct-encoded array value topic.
+ *
+ * @param <T> value class
+ */
+public final class StructArrayTopic<T> extends Topic {
+  private StructArrayTopic(Topic topic, Struct<T> struct) {
+    super(topic.m_inst, topic.m_handle);
+    m_struct = struct;
+  }
+
+  private StructArrayTopic(NetworkTableInstance inst, int handle, Struct<T> struct) {
+    super(inst, handle);
+    m_struct = struct;
+  }
+
+  /**
+   * Create a StructArrayTopic from a generic topic.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param topic generic topic
+   * @param struct struct serialization implementation
+   * @return StructArrayTopic for value class
+   */
+  public static <T> StructArrayTopic<T> wrap(Topic topic, Struct<T> struct) {
+    return new StructArrayTopic<T>(topic, struct);
+  }
+
+  /**
+   * Create a StructArrayTopic from a native handle; generally
+   * NetworkTableInstance.getStructArrayTopic() should be used instead.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param inst Instance
+   * @param handle Native handle
+   * @param struct struct serialization implementation
+   * @return StructArrayTopic for value class
+   */
+  public static <T> StructArrayTopic<T> wrap(
+      NetworkTableInstance inst, int handle, Struct<T> struct) {
+    return new StructArrayTopic<T>(inst, handle, struct);
+  }
+
+  /**
+   * Create a new subscriber to the topic.
+   *
+   * <p>The subscriber is only active as long as the returned object is not closed.
+   *
+   * <p>Subscribers that do not match the published data type do not return any values. To determine
+   * if the data type matches, use the appropriate Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a getter function
+   * @param options subscribe options
+   * @return subscriber
+   */
+  public StructArraySubscriber<T> subscribe(T[] defaultValue, PubSubOption... options) {
+    return new StructArrayEntryImpl<T>(
+        this,
+        StructBuffer.create(m_struct),
+        NetworkTablesJNI.subscribe(
+            m_handle, NetworkTableType.kRaw.getValue(), m_struct.getTypeString() + "[]", options),
+        defaultValue,
+        false);
+  }
+
+  /**
+   * Create a new publisher to the topic.
+   *
+   * <p>The publisher is only active as long as the returned object is not closed.
+   *
+   * <p>It is not possible to publish two different data types to the same topic. Conflicts between
+   * publishers are typically resolved by the server on a first-come, first-served basis. Any
+   * published values that do not match the topic's data type are dropped (ignored). To determine if
+   * the data type matches, use the appropriate Topic functions.
+   *
+   * @param options publish options
+   * @return publisher
+   */
+  public StructArrayPublisher<T> publish(PubSubOption... options) {
+    m_inst.addSchema(m_struct);
+    return new StructArrayEntryImpl<T>(
+        this,
+        StructBuffer.create(m_struct),
+        NetworkTablesJNI.publish(
+            m_handle, NetworkTableType.kRaw.getValue(), m_struct.getTypeString() + "[]", options),
+        null,
+        true);
+  }
+
+  /**
+   * Create a new publisher to the topic, with type string and initial properties.
+   *
+   * <p>The publisher is only active as long as the returned object is not closed.
+   *
+   * <p>It is not possible to publish two different data types to the same topic. Conflicts between
+   * publishers are typically resolved by the server on a first-come, first-served basis. Any
+   * published values that do not match the topic's data type are dropped (ignored). To determine if
+   * the data type matches, use the appropriate Topic functions.
+   *
+   * @param properties JSON properties
+   * @param options publish options
+   * @return publisher
+   * @throws IllegalArgumentException if properties is not a JSON object
+   */
+  public StructArrayPublisher<T> publishEx(String properties, PubSubOption... options) {
+    m_inst.addSchema(m_struct);
+    return new StructArrayEntryImpl<T>(
+        this,
+        StructBuffer.create(m_struct),
+        NetworkTablesJNI.publishEx(
+            m_handle,
+            NetworkTableType.kRaw.getValue(),
+            m_struct.getTypeString() + "[]",
+            properties,
+            options),
+        null,
+        true);
+  }
+
+  /**
+   * Create a new entry for the topic.
+   *
+   * <p>Entries act as a combination of a subscriber and a weak publisher. The subscriber is active
+   * as long as the entry is not closed. The publisher is created when the entry is first written
+   * to, and remains active until either unpublish() is called or the entry is closed.
+   *
+   * <p>It is not possible to use two different data types with the same topic. Conflicts between
+   * publishers are typically resolved by the server on a first-come, first-served basis. Any
+   * published values that do not match the topic's data type are dropped (ignored), and the entry
+   * will show no new values if the data type does not match. To determine if the data type matches,
+   * use the appropriate Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a getter function
+   * @param options publish and/or subscribe options
+   * @return entry
+   */
+  public StructArrayEntry<T> getEntry(T[] defaultValue, PubSubOption... options) {
+    return new StructArrayEntryImpl<T>(
+        this,
+        StructBuffer.create(m_struct),
+        NetworkTablesJNI.getEntry(
+            m_handle, NetworkTableType.kRaw.getValue(), m_struct.getTypeString() + "[]", options),
+        defaultValue,
+        false);
+  }
+
+  public Struct<T> getStruct() {
+    return m_struct;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+    if (!(other instanceof StructArrayTopic)) {
+      return false;
+    }
+
+    return super.equals(other) && m_struct == ((StructArrayTopic<?>) other).m_struct;
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode() ^ m_struct.hashCode();
+  }
+
+  private final Struct<T> m_struct;
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/StructEntry.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/StructEntry.java
@@ -1,0 +1,17 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+/**
+ * NetworkTables struct-encoded value entry.
+ *
+ * <p>Unlike NetworkTableEntry, the entry goes away when close() is called.
+ *
+ * @param <T> value class
+ */
+public interface StructEntry<T> extends StructSubscriber<T>, StructPublisher<T> {
+  /** Stops publishing the entry if it's published. */
+  void unpublish();
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/StructEntryImpl.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/StructEntryImpl.java
@@ -1,0 +1,207 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import edu.wpi.first.util.struct.StructBuffer;
+import java.lang.reflect.Array;
+import java.nio.ByteBuffer;
+
+/**
+ * NetworkTables struct-encoded value implementation.
+ *
+ * @param <T> value class
+ */
+final class StructEntryImpl<T> extends EntryBase implements StructEntry<T> {
+  /**
+   * Constructor.
+   *
+   * @param topic Topic
+   * @param handle Native handle
+   * @param defaultValue Default value for get()
+   */
+  StructEntryImpl(
+      StructTopic<T> topic,
+      StructBuffer<T> buf,
+      int handle,
+      T defaultValue,
+      boolean schemaPublished) {
+    super(handle);
+    m_topic = topic;
+    m_defaultValue = defaultValue;
+    m_buf = buf;
+    m_schemaPublished = schemaPublished;
+  }
+
+  @Override
+  public StructTopic<T> getTopic() {
+    return m_topic;
+  }
+
+  @Override
+  public T get() {
+    return fromRaw(NetworkTablesJNI.getRaw(m_handle, m_emptyRaw), m_defaultValue);
+  }
+
+  @Override
+  public T get(T defaultValue) {
+    return fromRaw(NetworkTablesJNI.getRaw(m_handle, m_emptyRaw), defaultValue);
+  }
+
+  @Override
+  public boolean getInto(T out) {
+    byte[] raw = NetworkTablesJNI.getRaw(m_handle, m_emptyRaw);
+    if (raw.length == 0) {
+      return false;
+    }
+    synchronized (m_buf) {
+      m_buf.readInto(out, raw);
+      return true;
+    }
+  }
+
+  @Override
+  public TimestampedObject<T> getAtomic() {
+    return fromRaw(NetworkTablesJNI.getAtomicRaw(m_handle, m_emptyRaw), m_defaultValue);
+  }
+
+  @Override
+  public TimestampedObject<T> getAtomic(T defaultValue) {
+    return fromRaw(NetworkTablesJNI.getAtomicRaw(m_handle, m_emptyRaw), defaultValue);
+  }
+
+  @Override
+  public TimestampedObject<T>[] readQueue() {
+    TimestampedRaw[] raw = NetworkTablesJNI.readQueueRaw(m_handle);
+    @SuppressWarnings("unchecked")
+    TimestampedObject<T>[] arr = (TimestampedObject<T>[]) new TimestampedObject<?>[raw.length];
+    int err = 0;
+    for (int i = 0; i < raw.length; i++) {
+      arr[i] = fromRaw(raw[i], null);
+      if (arr[i].value == null) {
+        err++;
+      }
+    }
+
+    // discard bad values
+    if (err > 0) {
+      @SuppressWarnings("unchecked")
+      TimestampedObject<T>[] newArr =
+          (TimestampedObject<T>[]) new TimestampedObject<?>[raw.length - err];
+      int i = 0;
+      for (TimestampedObject<T> e : arr) {
+        if (e.value != null) {
+          arr[i] = e;
+          i++;
+        }
+      }
+      arr = newArr;
+    }
+
+    return arr;
+  }
+
+  @Override
+  public T[] readQueueValues() {
+    byte[][] raw = NetworkTablesJNI.readQueueValuesRaw(m_handle);
+    @SuppressWarnings("unchecked")
+    T[] arr = (T[]) Array.newInstance(m_topic.getStruct().getTypeClass(), raw.length);
+    int err = 0;
+    for (int i = 0; i < raw.length; i++) {
+      arr[i] = fromRaw(raw[i], null);
+      if (arr[i] == null) {
+        err++;
+      }
+    }
+
+    // discard bad values
+    if (err > 0) {
+      @SuppressWarnings("unchecked")
+      T[] newArr = (T[]) Array.newInstance(m_topic.getStruct().getTypeClass(), raw.length - err);
+      int i = 0;
+      for (T e : arr) {
+        if (e != null) {
+          arr[i] = e;
+          i++;
+        }
+      }
+      arr = newArr;
+    }
+
+    return arr;
+  }
+
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  @Override
+  public void set(T value, long time) {
+    try {
+      synchronized (m_buf) {
+        if (!m_schemaPublished) {
+          m_schemaPublished = true;
+          m_topic.getInstance().addSchema(m_buf.getStruct());
+        }
+        ByteBuffer bb = m_buf.write(value);
+        NetworkTablesJNI.setRaw(m_handle, time, bb, 0, bb.position());
+      }
+    } catch (RuntimeException e) {
+      // ignore
+    }
+  }
+
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  @Override
+  public void setDefault(T value) {
+    try {
+      synchronized (m_buf) {
+        if (!m_schemaPublished) {
+          m_schemaPublished = true;
+          m_topic.getInstance().addSchema(m_buf.getStruct());
+        }
+        ByteBuffer bb = m_buf.write(value);
+        NetworkTablesJNI.setDefaultRaw(m_handle, 0, bb, 0, bb.position());
+      }
+    } catch (RuntimeException e) {
+      // ignore
+    }
+  }
+
+  @Override
+  public void unpublish() {
+    NetworkTablesJNI.unpublish(m_handle);
+  }
+
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  private T fromRaw(byte[] raw, T defaultValue) {
+    if (raw.length == 0) {
+      return defaultValue;
+    }
+    try {
+      synchronized (m_buf) {
+        return m_buf.read(raw);
+      }
+    } catch (RuntimeException e) {
+      return defaultValue;
+    }
+  }
+
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  private TimestampedObject<T> fromRaw(TimestampedRaw raw, T defaultValue) {
+    if (raw.value.length == 0) {
+      return new TimestampedObject<T>(0, 0, defaultValue);
+    }
+    try {
+      synchronized (m_buf) {
+        return new TimestampedObject<T>(raw.timestamp, raw.serverTime, m_buf.read(raw.value));
+      }
+    } catch (RuntimeException e) {
+      return new TimestampedObject<T>(0, 0, defaultValue);
+    }
+  }
+
+  private final StructTopic<T> m_topic;
+  private final T m_defaultValue;
+  private final StructBuffer<T> m_buf;
+  private boolean m_schemaPublished;
+  private static final byte[] m_emptyRaw = new byte[] {};
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/StructPublisher.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/StructPublisher.java
@@ -1,0 +1,52 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import java.util.function.Consumer;
+
+/**
+ * NetworkTables struct-encoded value publisher.
+ *
+ * @param <T> value class
+ */
+public interface StructPublisher<T> extends Publisher, Consumer<T> {
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  @Override
+  StructTopic<T> getTopic();
+
+  /**
+   * Publish a new value using current NT time.
+   *
+   * @param value value to publish
+   */
+  default void set(T value) {
+    set(value, 0);
+  }
+
+  /**
+   * Publish a new value.
+   *
+   * @param value value to publish
+   * @param time timestamp; 0 indicates current NT time should be used
+   */
+  void set(T value, long time);
+
+  /**
+   * Publish a default value. On reconnect, a default value will never be used in preference to a
+   * published value.
+   *
+   * @param value value
+   */
+  void setDefault(T value);
+
+  @Override
+  default void accept(T value) {
+    set(value);
+  }
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/StructSubscriber.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/StructSubscriber.java
@@ -1,0 +1,94 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import java.util.function.Supplier;
+
+/**
+ * NetworkTables struct-encoded value subscriber.
+ *
+ * @param <T> value class
+ */
+@SuppressWarnings("PMD.MissingOverride")
+public interface StructSubscriber<T> extends Subscriber, Supplier<T> {
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  @Override
+  StructTopic<T> getTopic();
+
+  /**
+   * Get the last published value. If no value has been published or the value cannot be unpacked,
+   * returns the stored default value.
+   *
+   * @return value
+   */
+  T get();
+
+  /**
+   * Get the last published value. If no value has been published or the value cannot be unpacked,
+   * returns the passed defaultValue.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return value
+   */
+  T get(T defaultValue);
+
+  /**
+   * Get the last published value, replacing the contents in place of an existing object. If no
+   * value has been published or the value cannot be unpacked, does not replace the contents and
+   * returns false. This function will not work (will throw UnsupportedOperationException) unless T
+   * is mutable (and the implementation of Struct implements unpackInto).
+   *
+   * <p>Note: due to Java language limitations, it's not possible to validate at compile time that
+   * the out parameter is mutable.
+   *
+   * @param out object to replace contents of; must be mutable
+   * @return true if successful, false if no value has been published
+   * @throws UnsupportedOperationException if T is immutable
+   */
+  boolean getInto(T out);
+
+  /**
+   * Get the last published value along with its timestamp. If no value has been published or the
+   * value cannot be unpacked, returns the stored default value and a timestamp of 0.
+   *
+   * @return timestamped value
+   */
+  TimestampedObject<T> getAtomic();
+
+  /**
+   * Get the last published value along with its timestamp If no value has been published or the
+   * value cannot be unpacked, returns the passed defaultValue and a timestamp of 0.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return timestamped value
+   */
+  TimestampedObject<T> getAtomic(T defaultValue);
+
+  /**
+   * Get an array of all valid value changes since the last call to readQueue. Also provides a
+   * timestamp for each value. Values that cannot be unpacked are dropped.
+   *
+   * <p>The "poll storage" subscribe option can be used to set the queue depth.
+   *
+   * @return Array of timestamped values; empty array if no valid new changes have been published
+   *     since the previous call.
+   */
+  TimestampedObject<T>[] readQueue();
+
+  /**
+   * Get an array of all value changes since the last call to readQueue. Values that cannot be
+   * unpacked are dropped.
+   *
+   * <p>The "poll storage" subscribe option can be used to set the queue depth.
+   *
+   * @return Array of values; empty array if no valid new changes have been published since the
+   *     previous call.
+   */
+  T[] readQueueValues();
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/StructTopic.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/StructTopic.java
@@ -1,0 +1,177 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+import edu.wpi.first.util.struct.Struct;
+import edu.wpi.first.util.struct.StructBuffer;
+
+/**
+ * NetworkTables struct-encoded value topic.
+ *
+ * @param <T> value class
+ */
+public final class StructTopic<T> extends Topic {
+  private StructTopic(Topic topic, Struct<T> struct) {
+    super(topic.m_inst, topic.m_handle);
+    m_struct = struct;
+  }
+
+  private StructTopic(NetworkTableInstance inst, int handle, Struct<T> struct) {
+    super(inst, handle);
+    m_struct = struct;
+  }
+
+  /**
+   * Create a StructTopic from a generic topic.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param topic generic topic
+   * @param struct struct serialization implementation
+   * @return StructTopic for value class
+   */
+  public static <T> StructTopic<T> wrap(Topic topic, Struct<T> struct) {
+    return new StructTopic<T>(topic, struct);
+  }
+
+  /**
+   * Create a StructTopic from a native handle; generally NetworkTableInstance.getStructTopic()
+   * should be used instead.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param inst Instance
+   * @param handle Native handle
+   * @param struct struct serialization implementation
+   * @return StructTopic for value class
+   */
+  public static <T> StructTopic<T> wrap(NetworkTableInstance inst, int handle, Struct<T> struct) {
+    return new StructTopic<T>(inst, handle, struct);
+  }
+
+  /**
+   * Create a new subscriber to the topic.
+   *
+   * <p>The subscriber is only active as long as the returned object is not closed.
+   *
+   * <p>Subscribers that do not match the published data type do not return any values. To determine
+   * if the data type matches, use the appropriate Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a getter function
+   * @param options subscribe options
+   * @return subscriber
+   */
+  public StructSubscriber<T> subscribe(T defaultValue, PubSubOption... options) {
+    return new StructEntryImpl<T>(
+        this,
+        StructBuffer.create(m_struct),
+        NetworkTablesJNI.subscribe(
+            m_handle, NetworkTableType.kRaw.getValue(), m_struct.getTypeString(), options),
+        defaultValue,
+        false);
+  }
+
+  /**
+   * Create a new publisher to the topic.
+   *
+   * <p>The publisher is only active as long as the returned object is not closed.
+   *
+   * <p>It is not possible to publish two different data types to the same topic. Conflicts between
+   * publishers are typically resolved by the server on a first-come, first-served basis. Any
+   * published values that do not match the topic's data type are dropped (ignored). To determine if
+   * the data type matches, use the appropriate Topic functions.
+   *
+   * @param options publish options
+   * @return publisher
+   */
+  public StructPublisher<T> publish(PubSubOption... options) {
+    m_inst.addSchema(m_struct);
+    return new StructEntryImpl<T>(
+        this,
+        StructBuffer.create(m_struct),
+        NetworkTablesJNI.publish(
+            m_handle, NetworkTableType.kRaw.getValue(), m_struct.getTypeString(), options),
+        null,
+        true);
+  }
+
+  /**
+   * Create a new publisher to the topic, with type string and initial properties.
+   *
+   * <p>The publisher is only active as long as the returned object is not closed.
+   *
+   * <p>It is not possible to publish two different data types to the same topic. Conflicts between
+   * publishers are typically resolved by the server on a first-come, first-served basis. Any
+   * published values that do not match the topic's data type are dropped (ignored). To determine if
+   * the data type matches, use the appropriate Topic functions.
+   *
+   * @param properties JSON properties
+   * @param options publish options
+   * @return publisher
+   * @throws IllegalArgumentException if properties is not a JSON object
+   */
+  public StructPublisher<T> publishEx(String properties, PubSubOption... options) {
+    m_inst.addSchema(m_struct);
+    return new StructEntryImpl<T>(
+        this,
+        StructBuffer.create(m_struct),
+        NetworkTablesJNI.publishEx(
+            m_handle,
+            NetworkTableType.kRaw.getValue(),
+            m_struct.getTypeString(),
+            properties,
+            options),
+        null,
+        true);
+  }
+
+  /**
+   * Create a new entry for the topic.
+   *
+   * <p>Entries act as a combination of a subscriber and a weak publisher. The subscriber is active
+   * as long as the entry is not closed. The publisher is created when the entry is first written
+   * to, and remains active until either unpublish() is called or the entry is closed.
+   *
+   * <p>It is not possible to use two different data types with the same topic. Conflicts between
+   * publishers are typically resolved by the server on a first-come, first-served basis. Any
+   * published values that do not match the topic's data type are dropped (ignored), and the entry
+   * will show no new values if the data type does not match. To determine if the data type matches,
+   * use the appropriate Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a getter function
+   * @param options publish and/or subscribe options
+   * @return entry
+   */
+  public StructEntry<T> getEntry(T defaultValue, PubSubOption... options) {
+    return new StructEntryImpl<T>(
+        this,
+        StructBuffer.create(m_struct),
+        NetworkTablesJNI.getEntry(
+            m_handle, NetworkTableType.kRaw.getValue(), m_struct.getTypeString(), options),
+        defaultValue,
+        false);
+  }
+
+  public Struct<T> getStruct() {
+    return m_struct;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+    if (!(other instanceof StructTopic)) {
+      return false;
+    }
+
+    return super.equals(other) && m_struct == ((StructTopic<?>) other).m_struct;
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode() ^ m_struct.hashCode();
+  }
+
+  private final Struct<T> m_struct;
+}

--- a/ntcore/src/main/java/edu/wpi/first/networktables/TimestampedObject.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/TimestampedObject.java
@@ -1,0 +1,33 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.networktables;
+
+/** NetworkTables timestamped object. */
+public final class TimestampedObject<T> {
+  /**
+   * Create a timestamped value.
+   *
+   * @param timestamp timestamp in local time base
+   * @param serverTime timestamp in server time base
+   * @param value value
+   */
+  public TimestampedObject(long timestamp, long serverTime, T value) {
+    this.timestamp = timestamp;
+    this.serverTime = serverTime;
+    this.value = value;
+  }
+
+  /** Timestamp in local time base. */
+  @SuppressWarnings("MemberName")
+  public final long timestamp;
+
+  /** Timestamp in server time base. May be 0 or 1 for locally set values. */
+  @SuppressWarnings("MemberName")
+  public final long serverTime;
+
+  /** Value. */
+  @SuppressWarnings("MemberName")
+  public final T value;
+}

--- a/ntcore/src/main/native/cpp/LocalStorage.h
+++ b/ntcore/src/main/native/cpp/LocalStorage.h
@@ -321,6 +321,13 @@ class LocalStorage final : public net::ILocalStorage {
                              std::string_view logPrefix);
   void StopDataLog(NT_DataLogger logger);
 
+  //
+  // Schema functions
+  //
+  bool HasSchema(std::string_view name);
+  void AddSchema(std::string_view name, std::string_view type,
+                 std::span<const uint8_t> schema);
+
   void Reset();
 
  private:
@@ -548,6 +555,9 @@ class LocalStorage final : public net::ILocalStorage {
 
     // string-based listeners
     VectorSet<ListenerData*> m_topicPrefixListeners;
+
+    // schema publishers
+    wpi::StringMap<NT_Publisher> m_schemas;
 
     // topic functions
     void NotifyTopic(TopicData* topic, unsigned int eventFlags);

--- a/ntcore/src/main/native/cpp/networktables/Topic.cpp
+++ b/ntcore/src/main/native/cpp/networktables/Topic.cpp
@@ -7,8 +7,13 @@
 #include <wpi/json.h>
 
 #include "networktables/GenericEntry.h"
+#include "networktables/NetworkTableInstance.h"
 
 using namespace nt;
+
+NetworkTableInstance Topic::GetInstance() const {
+  return NetworkTableInstance{GetInstanceFromHandle(m_handle)};
+}
 
 wpi::json Topic::GetProperty(std::string_view name) const {
   return ::nt::GetTopicProperty(m_handle, name);

--- a/ntcore/src/main/native/cpp/ntcore_c.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_c.cpp
@@ -625,6 +625,15 @@ NT_Listener NT_AddPolledLogger(NT_ListenerPoller poller, unsigned int min_level,
   return nt::AddPolledLogger(poller, min_level, max_level);
 }
 
+NT_Bool NT_HasSchema(NT_Inst inst, const char* name) {
+  return nt::HasSchema(inst, name);
+}
+
+void NT_AddSchema(NT_Inst inst, const char* name, const char* type,
+                  const uint8_t* schema, size_t schemaSize) {
+  nt::AddSchema(inst, name, type, {schema, schemaSize});
+}
+
 void NT_DisposeValue(NT_Value* value) {
   switch (value->type) {
     case NT_UNASSIGNED:

--- a/ntcore/src/main/native/cpp/ntcore_cpp.cpp
+++ b/ntcore/src/main/native/cpp/ntcore_cpp.cpp
@@ -782,4 +782,19 @@ NT_Listener AddPolledLogger(NT_ListenerPoller poller, unsigned int minLevel,
   }
 }
 
+bool HasSchema(NT_Inst inst, std::string_view name) {
+  if (auto ii = InstanceImpl::GetTyped(inst, Handle::kInstance)) {
+    return ii->localStorage.HasSchema(name);
+  } else {
+    return false;
+  }
+}
+
+void AddSchema(NT_Inst inst, std::string_view name, std::string_view type,
+               std::span<const uint8_t> schema) {
+  if (auto ii = InstanceImpl::GetTyped(inst, Handle::kInstance)) {
+    ii->localStorage.AddSchema(name, type, schema);
+  }
+}
+
 }  // namespace nt

--- a/ntcore/src/main/native/include/networktables/NetworkTable.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTable.h
@@ -14,8 +14,11 @@
 
 #include <wpi/StringMap.h>
 #include <wpi/mutex.h>
+#include <wpi/protobuf/Protobuf.h>
+#include <wpi/struct/Struct.h>
 
 #include "networktables/NetworkTableEntry.h"
+#include "networktables/Topic.h"
 #include "ntcore_c.h"
 
 namespace nt {
@@ -29,9 +32,15 @@ class FloatTopic;
 class IntegerArrayTopic;
 class IntegerTopic;
 class NetworkTableInstance;
+template <wpi::ProtobufSerializable T>
+class ProtobufTopic;
 class RawTopic;
 class StringArrayTopic;
 class StringTopic;
+template <wpi::StructSerializable T>
+class StructArrayTopic;
+template <wpi::StructSerializable T>
+class StructTopic;
 class Topic;
 
 /**
@@ -219,6 +228,39 @@ class NetworkTable final {
    * @return StringArrayTopic
    */
   StringArrayTopic GetStringArrayTopic(std::string_view name) const;
+
+  /**
+   * Gets a protobuf serialized value topic.
+   *
+   * @param name topic name
+   * @return Topic
+   */
+  template <wpi::ProtobufSerializable T>
+  ProtobufTopic<T> GetProtobufTopic(std::string_view name) const {
+    return ProtobufTopic<T>{GetTopic(name)};
+  }
+
+  /**
+   * Gets a raw struct serialized value topic.
+   *
+   * @param name topic name
+   * @return Topic
+   */
+  template <wpi::StructSerializable T>
+  StructTopic<T> GetStructTopic(std::string_view name) const {
+    return StructTopic<T>{GetTopic(name)};
+  }
+
+  /**
+   * Gets a raw struct serialized array topic.
+   *
+   * @param name topic name
+   * @return Topic
+   */
+  template <wpi::StructSerializable T>
+  StructArrayTopic<T> GetStructArrayTopic(std::string_view name) const {
+    return StructArrayTopic<T>{GetTopic(name)};
+  }
 
   /**
    * Returns the table at the specified key. If there is no table at the

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
@@ -13,6 +13,9 @@
 #include <utility>
 #include <vector>
 
+#include <wpi/protobuf/Protobuf.h>
+#include <wpi/struct/Struct.h>
+
 #include "networktables/NetworkTable.h"
 #include "networktables/NetworkTableEntry.h"
 #include "ntcore_c.h"
@@ -29,9 +32,15 @@ class FloatTopic;
 class IntegerArrayTopic;
 class IntegerTopic;
 class MultiSubscriber;
+template <wpi::ProtobufSerializable T>
+class ProtobufTopic;
 class RawTopic;
 class StringArrayTopic;
 class StringTopic;
+template <wpi::StructSerializable T>
+class StructArrayTopic;
+template <wpi::StructSerializable T>
+class StructTopic;
 class Subscriber;
 class Topic;
 
@@ -237,6 +246,33 @@ class NetworkTableInstance final {
    * @return Topic
    */
   StringArrayTopic GetStringArrayTopic(std::string_view name) const;
+
+  /**
+   * Gets a protobuf serialized value topic.
+   *
+   * @param name topic name
+   * @return Topic
+   */
+  template <wpi::ProtobufSerializable T>
+  ProtobufTopic<T> GetProtobufTopic(std::string_view name) const;
+
+  /**
+   * Gets a raw struct serialized value topic.
+   *
+   * @param name topic name
+   * @return Topic
+   */
+  template <wpi::StructSerializable T>
+  StructTopic<T> GetStructTopic(std::string_view name) const;
+
+  /**
+   * Gets a raw struct serialized array topic.
+   *
+   * @param name topic name
+   * @return Topic
+   */
+  template <wpi::StructSerializable T>
+  StructArrayTopic<T> GetStructArrayTopic(std::string_view name) const;
 
   /**
    * Get Published Topics.
@@ -717,6 +753,75 @@ class NetworkTableInstance final {
                         ListenerCallback func);
 
   /** @} */
+
+  /**
+   * @{
+   * @name Schema Functions
+   */
+
+  /**
+   * Returns whether there is a data schema already registered with the given
+   * name. This does NOT perform a check as to whether the schema has already
+   * been published by another node on the network.
+   *
+   * @param name Name (the string passed as the data type for topics using this
+   *             schema)
+   * @return True if schema already registered
+   */
+  bool HasSchema(std::string_view name) const;
+
+  /**
+   * Registers a data schema.  Data schemas provide information for how a
+   * certain data type string can be decoded.  The type string of a data schema
+   * indicates the type of the schema itself (e.g. "protobuf" for protobuf
+   * schemas, "struct" for struct schemas, etc). In NetworkTables, schemas are
+   * published just like normal topics, with the name being generated from the
+   * provided name: "/.schema/<name>".  Duplicate calls to this function with
+   * the same name are silently ignored.
+   *
+   * @param name Name (the string passed as the data type for topics using this
+   *             schema)
+   * @param type Type of schema (e.g. "protobuf", "struct", etc)
+   * @param schema Schema data
+   */
+  void AddSchema(std::string_view name, std::string_view type,
+                 std::span<const uint8_t> schema);
+
+  /**
+   * Registers a data schema.  Data schemas provide information for how a
+   * certain data type string can be decoded.  The type string of a data schema
+   * indicates the type of the schema itself (e.g. "protobuf" for protobuf
+   * schemas, "struct" for struct schemas, etc). In NetworkTables, schemas are
+   * published just like normal topics, with the name being generated from the
+   * provided name: "/.schema/<name>".  Duplicate calls to this function with
+   * the same name are silently ignored.
+   *
+   * @param name Name (the string passed as the data type for topics using this
+   *             schema)
+   * @param type Type of schema (e.g. "protobuf", "struct", etc)
+   * @param schema Schema data
+   */
+  void AddSchema(std::string_view name, std::string_view type,
+                 std::string_view schema);
+
+  /**
+   * Registers a protobuf schema. Duplicate calls to this function with the same
+   * name are silently ignored.
+   *
+   * @tparam T protobuf serializable type
+   * @param msg protobuf message
+   */
+  template <wpi::ProtobufSerializable T>
+  void AddProtobufSchema(wpi::ProtobufMessage<T>& msg);
+
+  /**
+   * Registers a struct schema. Duplicate calls to this function with the same
+   * name are silently ignored.
+   *
+   * @param T struct serializable type
+   */
+  template <wpi::StructSerializable T>
+  void AddStructSchema();
 
   /**
    * Equality operator.  Returns true if both instances refer to the same

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
@@ -38,6 +38,24 @@ inline NT_Inst NetworkTableInstance::GetHandle() const {
   return m_handle;
 }
 
+template <wpi::ProtobufSerializable T>
+inline ProtobufTopic<T> NetworkTableInstance::GetProtobufTopic(
+    std::string_view name) const {
+  return ProtobufTopic<T>{GetTopic(name)};
+}
+
+template <wpi::StructSerializable T>
+inline StructTopic<T> NetworkTableInstance::GetStructTopic(
+    std::string_view name) const {
+  return StructTopic<T>{GetTopic(name)};
+}
+
+template <wpi::StructSerializable T>
+inline StructArrayTopic<T> NetworkTableInstance::GetStructArrayTopic(
+    std::string_view name) const {
+  return StructArrayTopic<T>{GetTopic(name)};
+}
+
 inline std::vector<Topic> NetworkTableInstance::GetTopics() {
   auto handles = ::nt::GetTopics(m_handle, "", 0);
   return {handles.begin(), handles.end()};
@@ -221,6 +239,38 @@ inline NT_Listener NetworkTableInstance::AddLogger(unsigned int min_level,
                                                    unsigned int max_level,
                                                    ListenerCallback func) {
   return ::nt::AddLogger(m_handle, min_level, max_level, std::move(func));
+}
+
+inline bool NetworkTableInstance::HasSchema(std::string_view name) const {
+  return ::nt::HasSchema(m_handle, name);
+}
+
+inline void NetworkTableInstance::AddSchema(std::string_view name,
+                                            std::string_view type,
+                                            std::span<const uint8_t> schema) {
+  ::nt::AddSchema(m_handle, name, type, schema);
+}
+
+inline void NetworkTableInstance::AddSchema(std::string_view name,
+                                            std::string_view type,
+                                            std::string_view schema) {
+  ::nt::AddSchema(m_handle, name, type, schema);
+}
+
+template <wpi::ProtobufSerializable T>
+void NetworkTableInstance::AddProtobufSchema(wpi::ProtobufMessage<T>& msg) {
+  msg.ForEachProtobufDescriptor(
+      [this](auto typeString) { return HasSchema(typeString); },
+      [this](auto typeString, auto schema) {
+        AddSchema(typeString, "proto:FileDescriptorProto", schema);
+      });
+}
+
+template <wpi::StructSerializable T>
+void NetworkTableInstance::AddStructSchema() {
+  wpi::ForEachStructSchema<T>([this](auto typeString, auto schema) {
+    AddSchema(typeString, "structschema", schema);
+  });
 }
 
 }  // namespace nt

--- a/ntcore/src/main/native/include/networktables/ProtobufTopic.h
+++ b/ntcore/src/main/native/include/networktables/ProtobufTopic.h
@@ -1,0 +1,474 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <stdint.h>
+
+#include <atomic>
+#include <concepts>
+#include <span>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <wpi/SmallVector.h>
+#include <wpi/mutex.h>
+#include <wpi/protobuf/Protobuf.h>
+
+#include "networktables/NetworkTableInstance.h"
+#include "networktables/Topic.h"
+#include "ntcore_cpp.h"
+
+namespace wpi {
+class json;
+}  // namespace wpi
+
+namespace nt {
+
+template <wpi::ProtobufSerializable T>
+class ProtobufTopic;
+
+/**
+ * NetworkTables protobuf-encoded value subscriber.
+ */
+template <wpi::ProtobufSerializable T>
+class ProtobufSubscriber : public Subscriber {
+ public:
+  using TopicType = ProtobufTopic<T>;
+  using ValueType = T;
+  using ParamType = const T&;
+  using TimestampedValueType = Timestamped<T>;
+
+  ProtobufSubscriber() = default;
+
+  /**
+   * Construct from a subscriber handle; recommended to use
+   * ProtobufTopic::Subscribe() instead.
+   *
+   * @param handle Native handle
+   * @param msg Protobuf message
+   * @param defaultValue Default value
+   */
+  ProtobufSubscriber(NT_Subscriber handle, wpi::ProtobufMessage<T> msg,
+                     T defaultValue)
+      : Subscriber{handle},
+        m_msg{std::move(msg)},
+        m_defaultValue{std::move(defaultValue)} {}
+
+  ProtobufSubscriber(const ProtobufSubscriber&) = delete;
+  ProtobufSubscriber& operator=(const ProtobufSubscriber&) = delete;
+
+  ProtobufSubscriber(ProtobufSubscriber&& rhs)
+      : Subscriber{std::move(rhs)},
+        m_msg{std::move(rhs.m_msg)},
+        m_defaultValue{std::move(rhs.defaultValue)} {}
+
+  ProtobufSubscriber& operator=(ProtobufSubscriber&& rhs) {
+    Subscriber::operator=(std::move(rhs));
+    m_msg = std::move(rhs.m_msg);
+    m_defaultValue = std::move(rhs.defaultValue);
+    return *this;
+  }
+
+  /**
+   * Get the last published value.
+   * If no value has been published or the value cannot be unpacked, returns the
+   * stored default value.
+   *
+   * @return value
+   */
+  ValueType Get() const { return Get(m_defaultValue); }
+
+  /**
+   * Get the last published value.
+   * If no value has been published or the value cannot be unpacked, returns the
+   * passed defaultValue.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return value
+   */
+  ValueType Get(const T& defaultValue) const {
+    return GetAtomic(defaultValue).value;
+  }
+
+  /**
+   * Get the last published value, replacing the contents in place of an
+   * existing object. If no value has been published or the value cannot be
+   * unpacked, does not replace the contents and returns false.
+   *
+   * @param[out] out object to replace contents of
+   * @return true if successful
+   */
+  bool GetInto(T* out) {
+    wpi::SmallVector<uint8_t, 128> buf;
+    TimestampedRawView view = ::nt::GetAtomicRaw(m_subHandle, buf, {});
+    if (view.value.empty()) {
+      return false;
+    } else {
+      std::scoped_lock lock{m_mutex};
+      return m_msg.UnpackInto(out, view.value);
+    }
+  }
+
+  /**
+   * Get the last published value along with its timestamp
+   * If no value has been published or the value cannot be unpacked, returns the
+   * stored default value and a timestamp of 0.
+   *
+   * @return timestamped value
+   */
+  TimestampedValueType GetAtomic() const { return GetAtomic(m_defaultValue); }
+
+  /**
+   * Get the last published value along with its timestamp.
+   * If no value has been published or the value cannot be unpacked, returns the
+   * passed defaultValue and a timestamp of 0.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return timestamped value
+   */
+  TimestampedValueType GetAtomic(const T& defaultValue) const {
+    wpi::SmallVector<uint8_t, 128> buf;
+    TimestampedRawView view = ::nt::GetAtomicRaw(m_subHandle, buf, {});
+    if (!view.value.empty()) {
+      std::scoped_lock lock{m_mutex};
+      if (auto optval = m_msg.Unpack(view.value)) {
+        return {view.time, view.serverTime, *optval};
+      }
+    }
+    return {0, 0, defaultValue};
+  }
+
+  /**
+   * Get an array of all valid value changes since the last call to ReadQueue.
+   * Also provides a timestamp for each value. Values that cannot be unpacked
+   * are dropped.
+   *
+   * @note The "poll storage" subscribe option can be used to set the queue
+   *     depth.
+   *
+   * @return Array of timestamped values; empty array if no valid new changes
+   *     have been published since the previous call.
+   */
+  std::vector<TimestampedValueType> ReadQueue() {
+    auto raw = ::nt::ReadQueueRaw(m_subHandle);
+    std::vector<TimestampedValueType> rv;
+    rv.reserve(raw.size());
+    std::scoped_lock lock{m_mutex};
+    for (auto&& r : raw) {
+      if (auto optval = m_msg.Unpack(r.value)) {
+        rv.emplace_back(r.time, r.serverTime, *optval);
+      }
+    }
+    return rv;
+  }
+
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  TopicType GetTopic() const {
+    return ProtobufTopic<T>{::nt::GetTopicFromHandle(m_subHandle)};
+  }
+
+ private:
+  wpi::mutex m_mutex;
+  wpi::ProtobufMessage<T> m_msg;
+  ValueType m_defaultValue;
+};
+
+/**
+ * NetworkTables protobuf-encoded value publisher.
+ */
+template <wpi::ProtobufSerializable T>
+class ProtobufPublisher : public Publisher {
+ public:
+  using TopicType = ProtobufTopic<T>;
+  using ValueType = T;
+  using ParamType = const T&;
+
+  using TimestampedValueType = Timestamped<T>;
+
+  ProtobufPublisher() = default;
+
+  /**
+   * Construct from a publisher handle; recommended to use
+   * ProtobufTopic::Publish() instead.
+   *
+   * @param handle Native handle
+   * @param msg Protobuf message
+   */
+  explicit ProtobufPublisher(NT_Publisher handle, wpi::ProtobufMessage<T> msg)
+      : Publisher{handle}, m_msg{std::move(msg)} {}
+
+  ProtobufPublisher(const ProtobufPublisher&) = delete;
+  ProtobufPublisher& operator=(const ProtobufPublisher&) = delete;
+
+  ProtobufPublisher(ProtobufPublisher&& rhs)
+      : Publisher{std::move(rhs)},
+        m_msg{std::move(rhs.m_msg)},
+        m_schemaPublished{rhs.m_schemaPublished} {}
+
+  ProtobufPublisher& operator=(ProtobufPublisher&& rhs) {
+    Publisher::operator=(std::move(rhs));
+    m_msg = std::move(rhs.m_msg);
+    m_schemaPublished.clear();
+    if (rhs.m_schemaPublished.test()) {
+      m_schemaPublished.test_and_set();
+    }
+    return *this;
+  }
+
+  /**
+   * Publish a new value.
+   *
+   * @param value value to publish
+   * @param time timestamp; 0 indicates current NT time should be used
+   */
+  void Set(const T& value, int64_t time = 0) {
+    wpi::SmallVector<uint8_t, 128> buf;
+    {
+      std::scoped_lock lock{m_mutex};
+      if (!m_schemaPublished.test_and_set()) {
+        GetTopic().GetInstance().template AddProtobufSchema<T>(m_msg);
+      }
+      m_msg.Pack(buf, value);
+    }
+    ::nt::SetRaw(m_pubHandle, buf, time);
+  }
+
+  /**
+   * Publish a default value.
+   * On reconnect, a default value will never be used in preference to a
+   * published value.
+   *
+   * @param value value
+   */
+  void SetDefault(const T& value) {
+    wpi::SmallVector<uint8_t, 128> buf;
+    {
+      std::scoped_lock lock{m_mutex};
+      if (!m_schemaPublished.test_and_set()) {
+        GetTopic().GetInstance().template AddProtobufSchema<T>(m_msg);
+      }
+      m_msg.Pack(buf, value);
+    }
+    ::nt::SetDefaultRaw(m_pubHandle, buf);
+  }
+
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  TopicType GetTopic() const {
+    return ProtobufTopic<T>{::nt::GetTopicFromHandle(m_pubHandle)};
+  }
+
+ private:
+  wpi::mutex m_mutex;
+  wpi::ProtobufMessage<T> m_msg;
+  std::atomic_flag m_schemaPublished = ATOMIC_FLAG_INIT;
+};
+
+/**
+ * NetworkTables protobuf-encoded value entry.
+ *
+ * @note Unlike NetworkTableEntry, the entry goes away when this is destroyed.
+ */
+template <wpi::ProtobufSerializable T>
+class ProtobufEntry final : public ProtobufSubscriber<T>,
+                            public ProtobufPublisher<T> {
+ public:
+  using SubscriberType = ProtobufSubscriber<T>;
+  using PublisherType = ProtobufPublisher<T>;
+  using TopicType = ProtobufTopic<T>;
+  using ValueType = T;
+  using ParamType = const T&;
+
+  using TimestampedValueType = Timestamped<T>;
+
+  ProtobufEntry() = default;
+
+  /**
+   * Construct from an entry handle; recommended to use
+   * ProtobufTopic::GetEntry() instead.
+   *
+   * @param handle Native handle
+   * @param msg Protobuf message
+   * @param defaultValue Default value
+   */
+  ProtobufEntry(NT_Entry handle, wpi::ProtobufMessage<T> msg, T defaultValue)
+      : ProtobufSubscriber<T>{handle, std::move(msg), std::move(defaultValue)},
+        ProtobufPublisher<T>{handle, {}} {}
+
+  /**
+   * Determines if the native handle is valid.
+   *
+   * @return True if the native handle is valid, false otherwise.
+   */
+  explicit operator bool() const { return this->m_subHandle != 0; }
+
+  /**
+   * Gets the native handle for the entry.
+   *
+   * @return Native handle
+   */
+  NT_Entry GetHandle() const { return this->m_subHandle; }
+
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  TopicType GetTopic() const {
+    return ProtobufTopic<T>{::nt::GetTopicFromHandle(this->m_subHandle)};
+  }
+
+  /**
+   * Stops publishing the entry if it's published.
+   */
+  void Unpublish() { ::nt::Unpublish(this->m_pubHandle); }
+};
+
+/**
+ * NetworkTables protobuf-encoded value topic.
+ */
+template <wpi::ProtobufSerializable T>
+class ProtobufTopic final : public Topic {
+ public:
+  using SubscriberType = ProtobufSubscriber<T>;
+  using PublisherType = ProtobufPublisher<T>;
+  using EntryType = ProtobufEntry<T>;
+  using ValueType = T;
+  using ParamType = const T&;
+  using TimestampedValueType = Timestamped<T>;
+
+  ProtobufTopic() = default;
+
+  /**
+   * Construct from a topic handle; recommended to use
+   * NetworkTableInstance::GetProtobufTopic() instead.
+   *
+   * @param handle Native handle
+   */
+  explicit ProtobufTopic(NT_Topic handle) : Topic{handle} {}
+
+  /**
+   * Construct from a generic topic.
+   *
+   * @param topic Topic
+   */
+  explicit ProtobufTopic(Topic topic) : Topic{topic} {}
+
+  /**
+   * Create a new subscriber to the topic.
+   *
+   * <p>The subscriber is only active as long as the returned object
+   * is not destroyed.
+   *
+   * @note Subscribers that do not match the published data type do not return
+   *     any values. To determine if the data type matches, use the appropriate
+   *     Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a
+   *        getter function
+   * @param options subscribe options
+   * @return subscriber
+   */
+  [[nodiscard]]
+  SubscriberType Subscribe(
+      T defaultValue, const PubSubOptions& options = kDefaultPubSubOptions) {
+    wpi::ProtobufMessage<T> msg;
+    auto typeString = msg.GetTypeString();
+    return ProtobufSubscriber<T>{
+        ::nt::Subscribe(m_handle, NT_RAW, typeString, options), std::move(msg),
+        std::move(defaultValue)};
+  }
+
+  /**
+   * Create a new publisher to the topic.
+   *
+   * The publisher is only active as long as the returned object
+   * is not destroyed.
+   *
+   * @note It is not possible to publish two different data types to the same
+   *     topic. Conflicts between publishers are typically resolved by the
+   *     server on a first-come, first-served basis. Any published values that
+   *     do not match the topic's data type are dropped (ignored). To determine
+   *     if the data type matches, use the appropriate Topic functions.
+   *
+   * @param options publish options
+   * @return publisher
+   */
+  [[nodiscard]]
+  PublisherType Publish(const PubSubOptions& options = kDefaultPubSubOptions) {
+    wpi::ProtobufMessage<T> msg;
+    auto typeString = msg.GetTypeString();
+    return ProtobufPublisher<T>{
+        ::nt::Publish(m_handle, NT_RAW, typeString, options), std::move(msg)};
+  }
+
+  /**
+   * Create a new publisher to the topic, with type string and initial
+   * properties.
+   *
+   * The publisher is only active as long as the returned object
+   * is not destroyed.
+   *
+   * @note It is not possible to publish two different data types to the same
+   *     topic. Conflicts between publishers are typically resolved by the
+   *     server on a first-come, first-served basis. Any published values that
+   *     do not match the topic's data type are dropped (ignored). To determine
+   *     if the data type matches, use the appropriate Topic functions.
+   *
+   * @param properties JSON properties
+   * @param options publish options
+   * @return publisher
+   */
+  [[nodiscard]]
+  PublisherType PublishEx(
+      const wpi::json& properties,
+      const PubSubOptions& options = kDefaultPubSubOptions) {
+    wpi::ProtobufMessage<T> msg;
+    auto typeString = msg.GetTypeString();
+    return ProtobufPublisher<T>{
+        ::nt::PublishEx(m_handle, NT_RAW, typeString, properties, options),
+        std::move(msg)};
+  }
+
+  /**
+   * Create a new entry for the topic.
+   *
+   * Entries act as a combination of a subscriber and a weak publisher. The
+   * subscriber is active as long as the entry is not destroyed. The publisher
+   * is created when the entry is first written to, and remains active until
+   * either Unpublish() is called or the entry is destroyed.
+   *
+   * @note It is not possible to use two different data types with the same
+   *     topic. Conflicts between publishers are typically resolved by the
+   *     server on a first-come, first-served basis. Any published values that
+   *     do not match the topic's data type are dropped (ignored), and the entry
+   *     will show no new values if the data type does not match. To determine
+   *     if the data type matches, use the appropriate Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a
+   *        getter function
+   * @param options publish and/or subscribe options
+   * @return entry
+   */
+  [[nodiscard]]
+  EntryType GetEntry(T defaultValue,
+                     const PubSubOptions& options = kDefaultPubSubOptions) {
+    wpi::ProtobufMessage<T> msg;
+    auto typeString = msg.GetTypeString();
+    return ProtobufEntry<T>{
+        ::nt::GetEntry(m_handle, NT_RAW, typeString, options), std::move(msg),
+        std::move(defaultValue)};
+  }
+};
+
+}  // namespace nt

--- a/ntcore/src/main/native/include/networktables/StructArrayTopic.h
+++ b/ntcore/src/main/native/include/networktables/StructArrayTopic.h
@@ -1,0 +1,593 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <stdint.h>
+
+#include <atomic>
+#include <ranges>
+#include <span>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <wpi/SmallVector.h>
+#include <wpi/mutex.h>
+#include <wpi/struct/Struct.h>
+
+#include "networktables/NetworkTableInstance.h"
+#include "networktables/Topic.h"
+#include "ntcore_cpp.h"
+
+namespace wpi {
+class json;
+}  // namespace wpi
+
+namespace nt {
+
+template <wpi::StructSerializable T>
+class StructArrayTopic;
+
+/**
+ * NetworkTables struct-encoded value array subscriber.
+ */
+template <wpi::StructSerializable T>
+class StructArraySubscriber : public Subscriber {
+  using S = wpi::Struct<T>;
+
+ public:
+  using TopicType = StructArrayTopic<T>;
+  using ValueType = std::vector<T>;
+  using ParamType = std::span<const T>;
+  using TimestampedValueType = Timestamped<ValueType>;
+
+  StructArraySubscriber() = default;
+
+  /**
+   * Construct from a subscriber handle; recommended to use
+   * StructTopic::Subscribe() instead.
+   *
+   * @param handle Native handle
+   * @param defaultValue Default value
+   */
+  template <typename U>
+#if __cpp_lib_ranges >= 201911L
+    requires std::ranges::range<U> &&
+                 std::convertible_to<std::ranges::range_value_t<U>, T>
+#endif
+  StructArraySubscriber(NT_Subscriber handle, U&& defaultValue)
+      : Subscriber{handle},
+        m_defaultValue{defaultValue.begin(), defaultValue.end()} {
+  }
+
+  /**
+   * Get the last published value.
+   * If no value has been published or the value cannot be unpacked, returns the
+   * stored default value.
+   *
+   * @return value
+   */
+  ValueType Get() const { return Get(m_defaultValue); }
+
+  /**
+   * Get the last published value.
+   * If no value has been published or the value cannot be unpacked, returns the
+   * passed defaultValue.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return value
+   */
+  template <typename U>
+#if __cpp_lib_ranges >= 201911L
+    requires std::ranges::range<U> &&
+             std::convertible_to<std::ranges::range_value_t<U>, T>
+#endif
+  ValueType Get(U&& defaultValue) const {
+    return GetAtomic(std::forward<U>(defaultValue)).value;
+  }
+
+  /**
+   * Get the last published value.
+   * If no value has been published or the value cannot be unpacked, returns the
+   * passed defaultValue.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return value
+   */
+  ValueType Get(std::span<const T> defaultValue) const {
+    return GetAtomic(defaultValue).value;
+  }
+
+  /**
+   * Get the last published value along with its timestamp
+   * If no value has been published or the value cannot be unpacked, returns the
+   * stored default value and a timestamp of 0.
+   *
+   * @return timestamped value
+   */
+  TimestampedValueType GetAtomic() const { return GetAtomic(m_defaultValue); }
+
+  /**
+   * Get the last published value along with its timestamp.
+   * If no value has been published or the value cannot be unpacked, returns the
+   * passed defaultValue and a timestamp of 0.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return timestamped value
+   */
+  template <typename U>
+#if __cpp_lib_ranges >= 201911L
+    requires std::ranges::range<U> &&
+             std::convertible_to<std::ranges::range_value_t<U>, T>
+#endif
+  TimestampedValueType GetAtomic(U&& defaultValue) const {
+    wpi::SmallVector<uint8_t, 128> buf;
+    TimestampedRawView view = ::nt::GetAtomicRaw(m_subHandle, buf, {});
+    if (view.value.size() == 0 || (view.value.size() % S::kSize) != 0) {
+      return {0, 0, std::forward<U>(defaultValue)};
+    }
+    TimestampedValueType rv{view.time, view.serverTime, {}};
+    rv.value.reserve(view.value.size() / S::kSize);
+    for (auto in = view.value.begin(), end = view.value.end(); in != end;
+         in += S::kSize) {
+      rv.value.emplace_back(
+          S::Unpack(std::span<const uint8_t, S::kSize>{in, in + S::kSize}));
+    }
+    return rv;
+  }
+
+  /**
+   * Get the last published value along with its timestamp.
+   * If no value has been published or the value cannot be unpacked, returns the
+   * passed defaultValue and a timestamp of 0.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return timestamped value
+   */
+  TimestampedValueType GetAtomic(std::span<const T> defaultValue) const {
+    wpi::SmallVector<uint8_t, 128> buf;
+    TimestampedRawView view = ::nt::GetAtomicRaw(m_subHandle, buf, {});
+    if (view.value.size() == 0 || (view.value.size() % S::kSize) != 0) {
+      return {0, 0, {defaultValue.begin(), defaultValue.end()}};
+    }
+    TimestampedValueType rv{view.time, view.serverTime, {}};
+    rv.value.reserve(view.value.size() / S::kSize);
+    for (auto in = view.value.begin(), end = view.value.end(); in != end;
+         in += S::kSize) {
+      rv.value.emplace_back(
+          S::Unpack(std::span<const uint8_t, S::kSize>{in, in + S::kSize}));
+    }
+    return rv;
+  }
+
+  /**
+   * Get an array of all valid value changes since the last call to ReadQueue.
+   * Also provides a timestamp for each value. Values that cannot be unpacked
+   * are dropped.
+   *
+   * @note The "poll storage" subscribe option can be used to set the queue
+   *     depth.
+   *
+   * @return Array of timestamped values; empty array if no valid new changes
+   *     have been published since the previous call.
+   */
+  std::vector<TimestampedValueType> ReadQueue() {
+    auto raw = ::nt::ReadQueueRaw(m_subHandle);
+    std::vector<TimestampedValueType> rv;
+    rv.reserve(raw.size());
+    for (auto&& r : raw) {
+      if (r.value.size() == 0 || (r.value.size() % S::kSize) != 0) {
+        continue;
+      }
+      std::vector<T> values;
+      values.reserve(r.value.size() / S::kSize);
+      for (auto in = r.value.begin(), end = r.value.end(); in != end;
+           in += S::kSize) {
+        values.emplace_back(
+            S::Unpack(std::span<const uint8_t, S::kSize>{in, in + S::kSize}));
+      }
+      rv.emplace_back(r.time, r.serverTime, std::move(values));
+    }
+    return rv;
+  }
+
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  TopicType GetTopic() const {
+    return StructArrayTopic<T>{::nt::GetTopicFromHandle(m_subHandle)};
+  }
+
+ private:
+  ValueType m_defaultValue;
+};
+
+/**
+ * NetworkTables struct-encoded value array publisher.
+ */
+template <wpi::StructSerializable T>
+class StructArrayPublisher : public Publisher {
+  using S = wpi::Struct<T>;
+
+ public:
+  using TopicType = StructArrayTopic<T>;
+  using ValueType = std::vector<T>;
+  using ParamType = std::span<const T>;
+
+  using TimestampedValueType = Timestamped<ValueType>;
+
+  StructArrayPublisher() = default;
+
+  /**
+   * Construct from a publisher handle; recommended to use
+   * StructTopic::Publish() instead.
+   *
+   * @param handle Native handle
+   */
+  explicit StructArrayPublisher(NT_Publisher handle) : Publisher{handle} {}
+
+  StructArrayPublisher(const StructArrayPublisher&) = delete;
+  StructArrayPublisher& operator=(const StructArrayPublisher&) = delete;
+
+  StructArrayPublisher(StructArrayPublisher&& rhs)
+      : Publisher{std::move(rhs)},
+        m_buf{std::move(rhs.m_buf)},
+        m_schemaPublished{rhs.m_schemaPublished} {}
+
+  StructArrayPublisher& operator=(StructArrayPublisher&& rhs) {
+    Publisher::operator=(std::move(rhs));
+    m_buf = std::move(rhs.m_buf);
+    m_schemaPublished.clear();
+    if (rhs.m_schemaPublished.test()) {
+      m_schemaPublished.test_and_set();
+    }
+    return *this;
+  }
+
+  /**
+   * Publish a new value.
+   *
+   * @param value value to publish
+   * @param time timestamp; 0 indicates current NT time should be used
+   */
+  template <typename U>
+#if __cpp_lib_ranges >= 201911L
+    requires std::ranges::range<U> &&
+             std::convertible_to<std::ranges::range_value_t<U>, T>
+#endif
+  void Set(U&& value, int64_t time = 0) {
+    if (!m_schemaPublished.test_and_set()) {
+      GetTopic().GetInstance().template AddStructSchema<T>();
+    }
+    m_buf.Write(std::forward<U>(value),
+                [&](auto bytes) { ::nt::SetRaw(m_pubHandle, bytes, time); });
+  }
+
+  /**
+   * Publish a new value.
+   *
+   * @param value value to publish
+   * @param time timestamp; 0 indicates current NT time should be used
+   */
+  void Set(std::span<const T> value, int64_t time = 0) {
+    m_buf.Write(value,
+                [&](auto bytes) { ::nt::SetRaw(m_pubHandle, bytes, time); });
+  }
+
+  /**
+   * Publish a default value.
+   * On reconnect, a default value will never be used in preference to a
+   * published value.
+   *
+   * @param value value
+   */
+  template <typename U>
+#if __cpp_lib_ranges >= 201911L
+    requires std::ranges::range<U> &&
+             std::convertible_to<std::ranges::range_value_t<U>, T>
+#endif
+  void SetDefault(U&& value) {
+    if (!m_schemaPublished.test_and_set()) {
+      GetTopic().GetInstance().template AddStructSchema<T>();
+    }
+    m_buf.Write(std::forward<U>(value),
+                [&](auto bytes) { ::nt::SetDefaultRaw(m_pubHandle, bytes); });
+  }
+
+  /**
+   * Publish a default value.
+   * On reconnect, a default value will never be used in preference to a
+   * published value.
+   *
+   * @param value value
+   */
+  void SetDefault(std::span<const T> value) {
+    m_buf.Write(value,
+                [&](auto bytes) { ::nt::SetDefaultRaw(m_pubHandle, bytes); });
+  }
+
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  TopicType GetTopic() const {
+    return StructArrayTopic<T>{::nt::GetTopicFromHandle(m_pubHandle)};
+  }
+
+ private:
+  wpi::StructArrayBuffer<T> m_buf;
+  std::atomic_flag m_schemaPublished = ATOMIC_FLAG_INIT;
+};
+
+/**
+ * NetworkTables struct-encoded value array entry.
+ *
+ * @note Unlike NetworkTableEntry, the entry goes away when this is destroyed.
+ */
+template <wpi::StructSerializable T>
+class StructArrayEntry final : public StructArraySubscriber<T>,
+                               public StructArrayPublisher<T> {
+ public:
+  using SubscriberType = StructArraySubscriber<T>;
+  using PublisherType = StructArrayPublisher<T>;
+  using TopicType = StructArrayTopic<T>;
+  using ValueType = std::vector<T>;
+  using ParamType = std::span<const T>;
+
+  using TimestampedValueType = Timestamped<ValueType>;
+
+  StructArrayEntry() = default;
+
+  /**
+   * Construct from an entry handle; recommended to use
+   * StructTopic::GetEntry() instead.
+   *
+   * @param handle Native handle
+   * @param defaultValue Default value
+   */
+  template <typename U>
+#if __cpp_lib_ranges >= 201911L
+    requires std::ranges::range<U> &&
+                 std::convertible_to<std::ranges::range_value_t<U>, T>
+#endif
+  StructArrayEntry(NT_Entry handle, U&& defaultValue)
+      : StructArraySubscriber<T>{handle, defaultValue},
+        StructArrayPublisher<T>{handle} {
+  }
+
+  /**
+   * Determines if the native handle is valid.
+   *
+   * @return True if the native handle is valid, false otherwise.
+   */
+  explicit operator bool() const { return this->m_subHandle != 0; }
+
+  /**
+   * Gets the native handle for the entry.
+   *
+   * @return Native handle
+   */
+  NT_Entry GetHandle() const { return this->m_subHandle; }
+
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  TopicType GetTopic() const {
+    return StructArrayTopic<T>{::nt::GetTopicFromHandle(this->m_subHandle)};
+  }
+
+  /**
+   * Stops publishing the entry if it's published.
+   */
+  void Unpublish() { ::nt::Unpublish(this->m_pubHandle); }
+};
+
+/**
+ * NetworkTables struct-encoded value array topic.
+ */
+template <wpi::StructSerializable T>
+class StructArrayTopic final : public Topic {
+ public:
+  using SubscriberType = StructArraySubscriber<T>;
+  using PublisherType = StructArrayPublisher<T>;
+  using EntryType = StructArrayEntry<T>;
+  using ValueType = std::vector<T>;
+  using ParamType = std::span<const T>;
+  using TimestampedValueType = Timestamped<ValueType>;
+
+  StructArrayTopic() = default;
+
+  /**
+   * Construct from a topic handle; recommended to use
+   * NetworkTableInstance::GetStructTopic() instead.
+   *
+   * @param handle Native handle
+   */
+  explicit StructArrayTopic(NT_Topic handle) : Topic{handle} {}
+
+  /**
+   * Construct from a generic topic.
+   *
+   * @param topic Topic
+   */
+  explicit StructArrayTopic(Topic topic) : Topic{topic} {}
+
+  /**
+   * Create a new subscriber to the topic.
+   *
+   * <p>The subscriber is only active as long as the returned object
+   * is not destroyed.
+   *
+   * @note Subscribers that do not match the published data type do not return
+   *     any values. To determine if the data type matches, use the appropriate
+   *     Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a
+   *        getter function
+   * @param options subscribe options
+   * @return subscriber
+   */
+  template <typename U>
+#if __cpp_lib_ranges >= 201911L
+    requires std::ranges::range<U> &&
+             std::convertible_to<std::ranges::range_value_t<U>, T>
+#endif
+  [[nodiscard]]
+  SubscriberType Subscribe(
+      U&& defaultValue, const PubSubOptions& options = kDefaultPubSubOptions) {
+    return StructArraySubscriber<T>{
+        ::nt::Subscribe(
+            m_handle, NT_RAW,
+            wpi::MakeStructArrayTypeString<T, std::dynamic_extent>(), options),
+        defaultValue};
+  }
+
+  /**
+   * Create a new subscriber to the topic.
+   *
+   * <p>The subscriber is only active as long as the returned object
+   * is not destroyed.
+   *
+   * @note Subscribers that do not match the published data type do not return
+   *     any values. To determine if the data type matches, use the appropriate
+   *     Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a
+   *        getter function
+   * @param options subscribe options
+   * @return subscriber
+   */
+  [[nodiscard]]
+  SubscriberType Subscribe(
+      std::span<const T> defaultValue,
+      const PubSubOptions& options = kDefaultPubSubOptions) {
+    return StructArraySubscriber<T>{
+        ::nt::Subscribe(
+            m_handle, NT_RAW,
+            wpi::MakeStructArrayTypeString<T, std::dynamic_extent>(), options),
+        defaultValue};
+  }
+
+  /**
+   * Create a new publisher to the topic.
+   *
+   * The publisher is only active as long as the returned object
+   * is not destroyed.
+   *
+   * @note It is not possible to publish two different data types to the same
+   *     topic. Conflicts between publishers are typically resolved by the
+   *     server on a first-come, first-served basis. Any published values that
+   *     do not match the topic's data type are dropped (ignored). To determine
+   *     if the data type matches, use the appropriate Topic functions.
+   *
+   * @param options publish options
+   * @return publisher
+   */
+  [[nodiscard]]
+  PublisherType Publish(const PubSubOptions& options = kDefaultPubSubOptions) {
+    return StructArrayPublisher<T>{::nt::Publish(
+        m_handle, NT_RAW,
+        wpi::MakeStructArrayTypeString<T, std::dynamic_extent>(), options)};
+  }
+
+  /**
+   * Create a new publisher to the topic, with type string and initial
+   * properties.
+   *
+   * The publisher is only active as long as the returned object
+   * is not destroyed.
+   *
+   * @note It is not possible to publish two different data types to the same
+   *     topic. Conflicts between publishers are typically resolved by the
+   *     server on a first-come, first-served basis. Any published values that
+   *     do not match the topic's data type are dropped (ignored). To determine
+   *     if the data type matches, use the appropriate Topic functions.
+   *
+   * @param properties JSON properties
+   * @param options publish options
+   * @return publisher
+   */
+  [[nodiscard]]
+  PublisherType PublishEx(
+      const wpi::json& properties,
+      const PubSubOptions& options = kDefaultPubSubOptions) {
+    return StructArrayPublisher<T>{::nt::PublishEx(
+        m_handle, NT_RAW,
+        wpi::MakeStructArrayTypeString<T, std::dynamic_extent>(), properties,
+        options)};
+  }
+
+  /**
+   * Create a new entry for the topic.
+   *
+   * Entries act as a combination of a subscriber and a weak publisher. The
+   * subscriber is active as long as the entry is not destroyed. The publisher
+   * is created when the entry is first written to, and remains active until
+   * either Unpublish() is called or the entry is destroyed.
+   *
+   * @note It is not possible to use two different data types with the same
+   *     topic. Conflicts between publishers are typically resolved by the
+   *     server on a first-come, first-served basis. Any published values that
+   *     do not match the topic's data type are dropped (ignored), and the entry
+   *     will show no new values if the data type does not match. To determine
+   *     if the data type matches, use the appropriate Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a
+   *        getter function
+   * @param options publish and/or subscribe options
+   * @return entry
+   */
+  template <typename U>
+#if __cpp_lib_ranges >= 201911L
+    requires std::ranges::range<U> &&
+             std::convertible_to<std::ranges::range_value_t<U>, T>
+#endif
+  [[nodiscard]]
+  EntryType GetEntry(U&& defaultValue,
+                     const PubSubOptions& options = kDefaultPubSubOptions) {
+    return StructArrayEntry<T>{
+        ::nt::GetEntry(m_handle, NT_RAW,
+                       wpi::MakeStructArrayTypeString<T, std::dynamic_extent>(),
+                       options),
+        defaultValue};
+  }
+
+  /**
+   * Create a new entry for the topic.
+   *
+   * Entries act as a combination of a subscriber and a weak publisher. The
+   * subscriber is active as long as the entry is not destroyed. The publisher
+   * is created when the entry is first written to, and remains active until
+   * either Unpublish() is called or the entry is destroyed.
+   *
+   * @note It is not possible to use two different data types with the same
+   *     topic. Conflicts between publishers are typically resolved by the
+   *     server on a first-come, first-served basis. Any published values that
+   *     do not match the topic's data type are dropped (ignored), and the entry
+   *     will show no new values if the data type does not match. To determine
+   *     if the data type matches, use the appropriate Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a
+   *        getter function
+   * @param options publish and/or subscribe options
+   * @return entry
+   */
+  [[nodiscard]]
+  EntryType GetEntry(std::span<const T> defaultValue,
+                     const PubSubOptions& options = kDefaultPubSubOptions) {
+    return StructArrayEntry<T>{
+        ::nt::GetEntry(m_handle, NT_RAW,
+                       wpi::MakeStructArrayTypeString<T, std::dynamic_extent>(),
+                       options),
+        defaultValue};
+  }
+};
+
+}  // namespace nt

--- a/ntcore/src/main/native/include/networktables/StructTopic.h
+++ b/ntcore/src/main/native/include/networktables/StructTopic.h
@@ -1,0 +1,438 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <stdint.h>
+
+#include <atomic>
+#include <concepts>
+#include <span>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <wpi/SmallVector.h>
+#include <wpi/struct/Struct.h>
+
+#include "networktables/NetworkTableInstance.h"
+#include "networktables/Topic.h"
+#include "ntcore_cpp.h"
+
+namespace wpi {
+class json;
+}  // namespace wpi
+
+namespace nt {
+
+template <wpi::StructSerializable T>
+class StructTopic;
+
+/**
+ * NetworkTables struct-encoded value subscriber.
+ */
+template <wpi::StructSerializable T>
+class StructSubscriber : public Subscriber {
+  using S = wpi::Struct<T>;
+
+ public:
+  using TopicType = StructTopic<T>;
+  using ValueType = T;
+  using ParamType = const T&;
+  using TimestampedValueType = Timestamped<T>;
+
+  StructSubscriber() = default;
+
+  /**
+   * Construct from a subscriber handle; recommended to use
+   * StructTopic::Subscribe() instead.
+   *
+   * @param handle Native handle
+   * @param defaultValue Default value
+   */
+  StructSubscriber(NT_Subscriber handle, T defaultValue)
+      : Subscriber{handle}, m_defaultValue{std::move(defaultValue)} {}
+
+  /**
+   * Get the last published value.
+   * If no value has been published or the value cannot be unpacked, returns the
+   * stored default value.
+   *
+   * @return value
+   */
+  ValueType Get() const { return Get(m_defaultValue); }
+
+  /**
+   * Get the last published value.
+   * If no value has been published or the value cannot be unpacked, returns the
+   * passed defaultValue.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return value
+   */
+  ValueType Get(const T& defaultValue) const {
+    return GetAtomic(defaultValue).value;
+  }
+
+  /**
+   * Get the last published value, replacing the contents in place of an
+   * existing object. If no value has been published or the value cannot be
+   * unpacked, does not replace the contents and returns false.
+   *
+   * @param[out] out object to replace contents of
+   * @return true if successful
+   */
+  bool GetInto(T* out) {
+    wpi::SmallVector<uint8_t, S::kSize> buf;
+    TimestampedRawView view = ::nt::GetAtomicRaw(m_subHandle, buf, {});
+    if (view.value.size() < S::kSize) {
+      return false;
+    } else {
+      wpi::UnpackStructInto(out, view.value.subspan<0, S::kSize>());
+      return true;
+    }
+  }
+
+  /**
+   * Get the last published value along with its timestamp
+   * If no value has been published or the value cannot be unpacked, returns the
+   * stored default value and a timestamp of 0.
+   *
+   * @return timestamped value
+   */
+  TimestampedValueType GetAtomic() const { return GetAtomic(m_defaultValue); }
+
+  /**
+   * Get the last published value along with its timestamp.
+   * If no value has been published or the value cannot be unpacked, returns the
+   * passed defaultValue and a timestamp of 0.
+   *
+   * @param defaultValue default value to return if no value has been published
+   * @return timestamped value
+   */
+  TimestampedValueType GetAtomic(const T& defaultValue) const {
+    wpi::SmallVector<uint8_t, S::kSize> buf;
+    TimestampedRawView view = ::nt::GetAtomicRaw(m_subHandle, buf, {});
+    if (view.value.size() < S::kSize) {
+      return {0, 0, defaultValue};
+    } else {
+      return {view.time, view.serverTime,
+              S::Unpack(view.value.subspan<0, S::kSize>())};
+    }
+  }
+
+  /**
+   * Get an array of all valid value changes since the last call to ReadQueue.
+   * Also provides a timestamp for each value. Values that cannot be unpacked
+   * are dropped.
+   *
+   * @note The "poll storage" subscribe option can be used to set the queue
+   *     depth.
+   *
+   * @return Array of timestamped values; empty array if no valid new changes
+   *     have been published since the previous call.
+   */
+  std::vector<TimestampedValueType> ReadQueue() {
+    auto raw = ::nt::ReadQueueRaw(m_subHandle);
+    std::vector<TimestampedValueType> rv;
+    rv.reserve(raw.size());
+    for (auto&& r : raw) {
+      if (r.value.size() < S::kSize) {
+        continue;
+      } else {
+        rv.emplace_back(
+            r.time, r.serverTime,
+            S::Unpack(
+                std::span<const uint8_t>(r.value).subspan<0, S::kSize>()));
+      }
+    }
+    return rv;
+  }
+
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  TopicType GetTopic() const {
+    return StructTopic<T>{::nt::GetTopicFromHandle(m_subHandle)};
+  }
+
+ private:
+  ValueType m_defaultValue;
+};
+
+/**
+ * NetworkTables struct-encoded value publisher.
+ */
+template <wpi::StructSerializable T>
+class StructPublisher : public Publisher {
+  using S = wpi::Struct<T>;
+
+ public:
+  using TopicType = StructTopic<T>;
+  using ValueType = T;
+  using ParamType = const T&;
+
+  using TimestampedValueType = Timestamped<T>;
+
+  StructPublisher() = default;
+
+  StructPublisher(const StructPublisher&) = delete;
+  StructPublisher& operator=(const StructPublisher&) = delete;
+
+  StructPublisher(StructPublisher&& rhs)
+      : Publisher{std::move(rhs)}, m_schemaPublished{rhs.m_schemaPublished} {}
+
+  StructPublisher& operator=(StructPublisher&& rhs) {
+    Publisher::operator=(std::move(rhs));
+    m_schemaPublished.clear();
+    if (rhs.m_schemaPublished.test()) {
+      m_schemaPublished.test_and_set();
+    }
+    return *this;
+  }
+
+  /**
+   * Construct from a publisher handle; recommended to use
+   * StructTopic::Publish() instead.
+   *
+   * @param handle Native handle
+   */
+  explicit StructPublisher(NT_Publisher handle) : Publisher{handle} {}
+
+  /**
+   * Publish a new value.
+   *
+   * @param value value to publish
+   * @param time timestamp; 0 indicates current NT time should be used
+   */
+  void Set(const T& value, int64_t time = 0) {
+    if (!m_schemaPublished.test_and_set()) {
+      GetTopic().GetInstance().template AddStructSchema<T>();
+    }
+    uint8_t buf[S::kSize];
+    S::Pack(buf, value);
+    ::nt::SetRaw(m_pubHandle, buf, time);
+  }
+
+  /**
+   * Publish a default value.
+   * On reconnect, a default value will never be used in preference to a
+   * published value.
+   *
+   * @param value value
+   */
+  void SetDefault(const T& value) {
+    if (!m_schemaPublished.test_and_set()) {
+      GetTopic().GetInstance().template AddStructSchema<T>();
+    }
+    uint8_t buf[S::kSize];
+    S::Pack(buf, value);
+    ::nt::SetDefaultRaw(m_pubHandle, buf);
+  }
+
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  TopicType GetTopic() const {
+    return StructTopic<T>{::nt::GetTopicFromHandle(m_pubHandle)};
+  }
+
+ private:
+  std::atomic_flag m_schemaPublished = ATOMIC_FLAG_INIT;
+};
+
+/**
+ * NetworkTables struct-encoded value entry.
+ *
+ * @note Unlike NetworkTableEntry, the entry goes away when this is destroyed.
+ */
+template <wpi::StructSerializable T>
+class StructEntry final : public StructSubscriber<T>,
+                          public StructPublisher<T> {
+ public:
+  using SubscriberType = StructSubscriber<T>;
+  using PublisherType = StructPublisher<T>;
+  using TopicType = StructTopic<T>;
+  using ValueType = T;
+  using ParamType = const T&;
+
+  using TimestampedValueType = Timestamped<T>;
+
+  StructEntry() = default;
+
+  /**
+   * Construct from an entry handle; recommended to use
+   * StructTopic::GetEntry() instead.
+   *
+   * @param handle Native handle
+   * @param defaultValue Default value
+   */
+  StructEntry(NT_Entry handle, T defaultValue)
+      : StructSubscriber<T>{handle, std::move(defaultValue)},
+        StructPublisher<T>{handle} {}
+
+  /**
+   * Determines if the native handle is valid.
+   *
+   * @return True if the native handle is valid, false otherwise.
+   */
+  explicit operator bool() const { return this->m_subHandle != 0; }
+
+  /**
+   * Gets the native handle for the entry.
+   *
+   * @return Native handle
+   */
+  NT_Entry GetHandle() const { return this->m_subHandle; }
+
+  /**
+   * Get the corresponding topic.
+   *
+   * @return Topic
+   */
+  TopicType GetTopic() const {
+    return StructTopic<T>{::nt::GetTopicFromHandle(this->m_subHandle)};
+  }
+
+  /**
+   * Stops publishing the entry if it's published.
+   */
+  void Unpublish() { ::nt::Unpublish(this->m_pubHandle); }
+};
+
+/**
+ * NetworkTables struct-encoded value topic.
+ */
+template <wpi::StructSerializable T>
+class StructTopic final : public Topic {
+ public:
+  using SubscriberType = StructSubscriber<T>;
+  using PublisherType = StructPublisher<T>;
+  using EntryType = StructEntry<T>;
+  using ValueType = T;
+  using ParamType = const T&;
+  using TimestampedValueType = Timestamped<T>;
+
+  StructTopic() = default;
+
+  /**
+   * Construct from a topic handle; recommended to use
+   * NetworkTableInstance::GetStructTopic() instead.
+   *
+   * @param handle Native handle
+   */
+  explicit StructTopic(NT_Topic handle) : Topic{handle} {}
+
+  /**
+   * Construct from a generic topic.
+   *
+   * @param topic Topic
+   */
+  explicit StructTopic(Topic topic) : Topic{topic} {}
+
+  /**
+   * Create a new subscriber to the topic.
+   *
+   * <p>The subscriber is only active as long as the returned object
+   * is not destroyed.
+   *
+   * @note Subscribers that do not match the published data type do not return
+   *     any values. To determine if the data type matches, use the appropriate
+   *     Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a
+   *        getter function
+   * @param options subscribe options
+   * @return subscriber
+   */
+  [[nodiscard]]
+  SubscriberType Subscribe(
+      T defaultValue, const PubSubOptions& options = kDefaultPubSubOptions) {
+    return StructSubscriber<T>{
+        ::nt::Subscribe(m_handle, NT_RAW, wpi::GetStructTypeString<T>(),
+                        options),
+        std::move(defaultValue)};
+  }
+
+  /**
+   * Create a new publisher to the topic.
+   *
+   * The publisher is only active as long as the returned object
+   * is not destroyed.
+   *
+   * @note It is not possible to publish two different data types to the same
+   *     topic. Conflicts between publishers are typically resolved by the
+   *     server on a first-come, first-served basis. Any published values that
+   *     do not match the topic's data type are dropped (ignored). To determine
+   *     if the data type matches, use the appropriate Topic functions.
+   *
+   * @param options publish options
+   * @return publisher
+   */
+  [[nodiscard]]
+  PublisherType Publish(const PubSubOptions& options = kDefaultPubSubOptions) {
+    return StructPublisher<T>{::nt::Publish(
+        m_handle, NT_RAW, wpi::GetStructTypeString<T>(), options)};
+  }
+
+  /**
+   * Create a new publisher to the topic, with type string and initial
+   * properties.
+   *
+   * The publisher is only active as long as the returned object
+   * is not destroyed.
+   *
+   * @note It is not possible to publish two different data types to the same
+   *     topic. Conflicts between publishers are typically resolved by the
+   *     server on a first-come, first-served basis. Any published values that
+   *     do not match the topic's data type are dropped (ignored). To determine
+   *     if the data type matches, use the appropriate Topic functions.
+   *
+   * @param properties JSON properties
+   * @param options publish options
+   * @return publisher
+   */
+  [[nodiscard]]
+  PublisherType PublishEx(
+      const wpi::json& properties,
+      const PubSubOptions& options = kDefaultPubSubOptions) {
+    return StructPublisher<T>{::nt::PublishEx(
+        m_handle, NT_RAW, wpi::GetStructTypeString<T>(), properties, options)};
+  }
+
+  /**
+   * Create a new entry for the topic.
+   *
+   * Entries act as a combination of a subscriber and a weak publisher. The
+   * subscriber is active as long as the entry is not destroyed. The publisher
+   * is created when the entry is first written to, and remains active until
+   * either Unpublish() is called or the entry is destroyed.
+   *
+   * @note It is not possible to use two different data types with the same
+   *     topic. Conflicts between publishers are typically resolved by the
+   *     server on a first-come, first-served basis. Any published values that
+   *     do not match the topic's data type are dropped (ignored), and the entry
+   *     will show no new values if the data type does not match. To determine
+   *     if the data type matches, use the appropriate Topic functions.
+   *
+   * @param defaultValue default value used when a default is not provided to a
+   *        getter function
+   * @param options publish and/or subscribe options
+   * @return entry
+   */
+  [[nodiscard]]
+  EntryType GetEntry(T defaultValue,
+                     const PubSubOptions& options = kDefaultPubSubOptions) {
+    return StructEntry<T>{
+        ::nt::GetEntry(m_handle, NT_RAW, wpi::GetStructTypeString<T>(),
+                       options),
+        std::move(defaultValue)};
+  }
+};
+
+}  // namespace nt

--- a/ntcore/src/main/native/include/networktables/Topic.inc
+++ b/ntcore/src/main/native/include/networktables/Topic.inc
@@ -6,17 +6,12 @@
 
 #include <string>
 
-#include "networktables/NetworkTableInstance.h"
 #include "networktables/NetworkTableType.h"
 #include "networktables/Topic.h"
 #include "ntcore_c.h"
 #include "ntcore_cpp.h"
 
 namespace nt {
-
-inline NetworkTableInstance Topic::GetInstance() const {
-  return NetworkTableInstance{GetInstanceFromHandle(m_handle)};
-}
 
 inline std::string Topic::GetName() const {
   return ::nt::GetTopicName(m_handle);

--- a/ntcore/src/main/native/include/ntcore_c.h
+++ b/ntcore/src/main/native/include/ntcore_c.h
@@ -1436,6 +1436,44 @@ NT_Listener NT_AddPolledLogger(NT_ListenerPoller poller, unsigned int min_level,
 /** @} */
 
 /**
+ * @defgroup ntcore_schema_cfunc Schema Functions
+ * @{
+ */
+
+/**
+ * Returns whether there is a data schema already registered with the given
+ * name. This does NOT perform a check as to whether the schema has already
+ * been published by another node on the network.
+ *
+ * @param inst instance
+ * @param name Name (the string passed as the data type for topics using this
+ *             schema)
+ * @return True if schema already registered
+ */
+NT_Bool NT_HasSchema(NT_Inst inst, const char* name);
+
+/**
+ * Registers a data schema.  Data schemas provide information for how a
+ * certain data type string can be decoded.  The type string of a data schema
+ * indicates the type of the schema itself (e.g. "protobuf" for protobuf
+ * schemas, "struct" for struct schemas, etc). In NetworkTables, schemas are
+ * published just like normal topics, with the name being generated from the
+ * provided name: "/.schema/<name>".  Duplicate calls to this function with
+ * the same name are silently ignored.
+ *
+ * @param inst instance
+ * @param name Name (the string passed as the data type for topics using this
+ *             schema)
+ * @param type Type of schema (e.g. "protobuf", "struct", etc)
+ * @param schema Schema data
+ * @param schemaSize Size of schema data
+ */
+void NT_AddSchema(NT_Inst inst, const char* name, const char* type,
+                  const uint8_t* schema, size_t schemaSize);
+
+/** @} */
+
+/**
  * @defgroup ntcore_interop_cfunc Interop Utility Functions
  * @{
  */

--- a/ntcore/src/main/native/include/ntcore_cpp.h
+++ b/ntcore/src/main/native/include/ntcore_cpp.h
@@ -1301,6 +1301,66 @@ NT_Listener AddPolledLogger(NT_ListenerPoller poller, unsigned int min_level,
                             unsigned int max_level);
 
 /** @} */
+
+/**
+ * @defgroup ntcore_schema_func Schema Functions
+ * @{
+ */
+
+/**
+ * Returns whether there is a data schema already registered with the given
+ * name. This does NOT perform a check as to whether the schema has already
+ * been published by another node on the network.
+ *
+ * @param inst instance
+ * @param name Name (the string passed as the data type for topics using this
+ *             schema)
+ * @return True if schema already registered
+ */
+bool HasSchema(NT_Inst inst, std::string_view name);
+
+/**
+ * Registers a data schema.  Data schemas provide information for how a
+ * certain data type string can be decoded.  The type string of a data schema
+ * indicates the type of the schema itself (e.g. "protobuf" for protobuf
+ * schemas, "struct" for struct schemas, etc). In NetworkTables, schemas are
+ * published just like normal topics, with the name being generated from the
+ * provided name: "/.schema/<name>".  Duplicate calls to this function with
+ * the same name are silently ignored.
+ *
+ * @param inst instance
+ * @param name Name (the string passed as the data type for topics using this
+ *             schema)
+ * @param type Type of schema (e.g. "protobuf", "struct", etc)
+ * @param schema Schema data
+ */
+void AddSchema(NT_Inst inst, std::string_view name, std::string_view type,
+               std::span<const uint8_t> schema);
+
+/**
+ * Registers a data schema.  Data schemas provide information for how a
+ * certain data type string can be decoded.  The type string of a data schema
+ * indicates the type of the schema itself (e.g. "protobuf" for protobuf
+ * schemas, "struct" for struct schemas, etc). In NetworkTables, schemas are
+ * published just like normal topics, with the name being generated from the
+ * provided name: "/.schema/<name>".  Duplicate calls to this function with
+ * the same name are silently ignored.
+ *
+ * @param inst instance
+ * @param name Name (the string passed as the data type for topics using this
+ *             schema)
+ * @param type Type of schema (e.g. "protobuf", "struct", etc)
+ * @param schema Schema data
+ */
+inline void AddSchema(NT_Inst inst, std::string_view name,
+                      std::string_view type, std::string_view schema) {
+  AddSchema(
+      inst, name, type,
+      std::span<const uint8_t>{reinterpret_cast<const uint8_t*>(schema.data()),
+                               schema.size()});
+}
+
+/** @} */
 /** @} */
 
 /**

--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'maven-publish'
 apply plugin: 'java-library'
 apply plugin: 'jacoco'
+apply plugin: 'com.google.protobuf'
 
 def baseArtifactId = project.baseId
 def artifactGroupId = project.groupId
@@ -139,5 +140,29 @@ jacocoTestReport {
     reports {
         xml.required = true
         html.required = true
+    }
+}
+
+protobuf {
+    protoc {
+        artifact = 'com.google.protobuf:protoc:3.21.12'
+    }
+    plugins {
+        quickbuf {
+            artifact = 'us.hebi.quickbuf:protoc-gen-quickbuf:1.3.2'
+        }
+    }
+    generateProtoTasks {
+        all().configureEach { task ->
+            task.builtins {
+                cpp {}
+                remove java
+            }
+            task.plugins {
+                quickbuf {
+                    option "gen_descriptors=true"
+                }
+            }
+        }
     }
 }

--- a/shared/javacpp/setupBuild.gradle
+++ b/shared/javacpp/setupBuild.gradle
@@ -30,11 +30,11 @@ model {
             sources {
                 cpp {
                     source {
-                        srcDirs 'src/main/native/cpp'
-                        include '**/*.cpp'
+                        srcDirs 'src/main/native/cpp', "$buildDir/generated/source/proto/main/cpp"
+                        include '**/*.cpp', '**/*.cc'
                     }
                     exportedHeaders {
-                        srcDirs 'src/main/native/include'
+                        srcDirs 'src/main/native/include', "$buildDir/generated/source/proto/main/cpp"
                     }
                 }
             }
@@ -42,6 +42,9 @@ model {
                 if (it instanceof SharedLibraryBinarySpec) {
                     it.buildable = false
                     return
+                }
+                it.tasks.withType(CppCompile) {
+                    it.dependsOn generateProto
                 }
                 if (project.hasProperty('extraSetup')) {
                     extraSetup(it)

--- a/shared/jni/setupBuild.gradle
+++ b/shared/jni/setupBuild.gradle
@@ -41,15 +41,15 @@ model {
             sources {
                 cpp {
                     source {
-                        srcDirs 'src/main/native/cpp'
+                        srcDirs 'src/main/native/cpp', "$buildDir/generated/source/proto/main/cpp"
                         if (project.hasProperty('generatedSources')) {
                             srcDir generatedSources
                         }
-                        include '**/*.cpp'
+                        include '**/*.cpp', '**/*.cc'
                         exclude '**/jni/**/*.cpp'
                     }
                     exportedHeaders {
-                        srcDir 'src/main/native/include'
+                        srcDirs 'src/main/native/include', "$buildDir/generated/source/proto/main/cpp"
                         if (project.hasProperty('generatedHeaders')) {
                             srcDir generatedHeaders
                         }
@@ -66,6 +66,9 @@ model {
                 it.cCompiler.define 'WPILIB_EXPORTS'
                 if (!project.hasProperty('noWpiutil')) {
                     lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
+                }
+                it.tasks.withType(CppCompile) {
+                    it.dependsOn generateProto
                 }
                 if (project.hasProperty('splitSetup')) {
                     splitSetup(it)

--- a/styleguide/checkstyle-suppressions.xml
+++ b/styleguide/checkstyle-suppressions.xml
@@ -10,4 +10,6 @@ suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN"
     checks="(LocalVariableName|MemberName|MethodName|MethodTypeParameterName|ParameterName)" />
   <suppress files=".*JNI.*"
     checks="(EmptyLineSeparator|LineLength|MissingJavadocMethod|ParameterName)" />
+  <suppress files=".*/quickbuf/.*"
+    checks="(CustomImportOrder|EmptyLineSeparator|LineLength|JavadocParagraph|MissingJavadocMethod|OverloadMethodsDeclarationOrder|SummaryJavadoc|UnnecessaryParentheses|OperatorWrap|JavadocMethod|JavadocTagContinuationIndentation)" />
 </suppressions>

--- a/styleguide/pmd-ruleset.xml
+++ b/styleguide/pmd-ruleset.xml
@@ -8,6 +8,7 @@
 
   <exclude-pattern>.*/*JNI.*</exclude-pattern>
   <exclude-pattern>.*/*IntegrationTests.*</exclude-pattern>
+  <exclude-pattern>.*/quickbuf/.*</exclude-pattern>
 
   <rule ref="category/java/bestpractices.xml">
     <exclude name="AccessorClassGeneration" />

--- a/wpimath/CMakeLists.txt
+++ b/wpimath/CMakeLists.txt
@@ -5,6 +5,49 @@ include(CompileWarnings)
 include(AddTest)
 include(DownloadAndCheck)
 
+file(GLOB wpimath_proto_src src/main/proto/*.proto)
+protobuf_generate_cpp(WPIMATH_PROTO_SRCS WPIMATH_PROTO_HDRS PROTOC_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/protobuf" PROTOS ${wpimath_proto_src})
+
+function(quickbuf_generate SRCS JAVA_PACKAGE)
+  if(NOT ARGN)
+    message(SEND_ERROR "Error: PROTOBUF_GENERATE_QUICKBUF() called without any proto files")
+    return()
+  endif()
+
+  set(_generated_srcs_all)
+  foreach(_proto ${ARGN})
+    get_filename_component(_abs_file ${_proto} ABSOLUTE)
+    get_filename_component(_abs_dir ${_abs_file} DIRECTORY)
+    get_filename_component(_basename ${_proto} NAME_WLE)
+    file(RELATIVE_PATH _rel_dir ${CMAKE_CURRENT_SOURCE_DIR} ${_abs_dir})
+
+    # convert to QuickBuffers Java case (geometry2d -> Geometry2D)
+    string(REGEX MATCHALL "[A-Za-z_]+|[0-9]+" _name_components ${_basename})
+    set(_name_components_out)
+    foreach(_part ${_name_components})
+      string(SUBSTRING ${_part} 0 1 _first_letter)
+      string(TOUPPER ${_first_letter} _first_letter)
+      string(REGEX REPLACE "^.(.*)" "${_first_letter}\\1" _part_out "${_part}")
+      list(APPEND _name_components_out ${_part_out})
+    endforeach()
+    list(JOIN _name_components_out "" _basename_title)
+
+    set(_generated_src "${CMAKE_CURRENT_BINARY_DIR}/quickbuf/${JAVA_PACKAGE}/${_basename_title}.java")
+
+    list(APPEND _generated_srcs_all ${_generated_src})
+
+    add_custom_command(
+      OUTPUT ${_generated_src}
+      COMMAND protobuf::protoc
+      ARGS --plugin=protoc-gen-quickbuf=${Quickbuf_EXECUTABLE} --quickbuf_out=gen_descriptors=true:${CMAKE_CURRENT_BINARY_DIR}/quickbuf -I${_abs_dir} ${_abs_file}
+      DEPENDS ${_abs_file} protobuf::protoc
+      COMMENT "Running quickbuf protocol buffer compiler on ${_proto}"
+      VERBATIM )
+  endforeach()
+
+  set(${SRCS} ${_generated_srcs_all} PARENT_SCOPE)
+endfunction()
+
 file(GLOB wpimath_jni_src src/main/native/cpp/jni/WPIMathJNI_DARE.cpp
                           src/main/native/cpp/jni/WPIMathJNI_Eigen.cpp
                           src/main/native/cpp/jni/WPIMathJNI_Exceptions.cpp
@@ -18,6 +61,8 @@ if (WITH_JAVA)
   find_package(JNI REQUIRED)
   include(UseJava)
   set(CMAKE_JAVA_COMPILE_FLAGS "-encoding" "UTF8" "-Xlint:unchecked")
+
+  quickbuf_generate(WPIMATH_QUICKBUF_SRCS "edu/wpi/first/math/proto" ${wpimath_proto_src})
 
   if(NOT EXISTS "${WPILIB_BINARY_DIR}/wpimath/thirdparty/ejml/ejml-simple-0.43.1.jar")
       set(BASE_URL "https://search.maven.org/remotecontent?filepath=")
@@ -45,8 +90,10 @@ if (WITH_JAVA)
 
   file(GLOB EJML_JARS "${WPILIB_BINARY_DIR}/wpimath/thirdparty/ejml/*.jar")
   file(GLOB JACKSON_JARS "${WPILIB_BINARY_DIR}/wpiutil/thirdparty/jackson/*.jar")
+  file(GLOB QUICKBUF_JAR
+        ${WPILIB_BINARY_DIR}/wpiutil/thirdparty/quickbuf/*.jar)
 
-  set(CMAKE_JAVA_INCLUDE_PATH wpimath.jar ${EJML_JARS} ${JACKSON_JARS})
+  set(CMAKE_JAVA_INCLUDE_PATH wpimath.jar ${EJML_JARS} ${JACKSON_JARS} ${QUICKBUF_JAR})
 
   execute_process(COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/generate_numbers.py ${WPILIB_BINARY_DIR}/wpimath RESULT_VARIABLE generateResult)
   if(NOT (generateResult EQUAL "0"))
@@ -61,7 +108,7 @@ if (WITH_JAVA)
 
   file(GLOB_RECURSE JAVA_SOURCES src/main/java/*.java ${WPILIB_BINARY_DIR}/wpimath/generated/*.java)
 
-  add_jar(wpimath_jar ${JAVA_SOURCES} INCLUDE_JARS ${EJML_JARS} wpiutil_jar OUTPUT_NAME wpimath GENERATE_NATIVE_HEADERS wpimath_jni_headers)
+  add_jar(wpimath_jar ${JAVA_SOURCES} ${WPIMATH_QUICKBUF_SRCS} INCLUDE_JARS ${EJML_JARS} wpiutil_jar OUTPUT_NAME wpimath GENERATE_NATIVE_HEADERS wpimath_jni_headers)
 
   get_property(WPIMATH_JAR_FILE TARGET wpimath_jar PROPERTY JAR_FILE)
   install(FILES ${WPIMATH_JAR_FILE} DESTINATION "${java_lib_dest}")
@@ -85,7 +132,7 @@ file(GLOB_RECURSE wpimath_native_src src/main/native/cpp/*.cpp)
 list(REMOVE_ITEM wpimath_native_src ${wpimath_jni_src})
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS FALSE)
-add_library(wpimath ${wpimath_native_src})
+add_library(wpimath ${wpimath_native_src} ${WPIMATH_PROTO_SRCS})
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 set_target_properties(wpimath PROPERTIES DEBUG_POSTFIX "d")
 
@@ -116,6 +163,7 @@ target_include_directories(wpimath SYSTEM PUBLIC
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/wpimath")
 target_include_directories(wpimath PUBLIC
                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main/native/include>
+                            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/protobuf>
                             $<INSTALL_INTERFACE:${include_dest}/wpimath>)
 
 install(TARGETS wpimath EXPORT wpimath)

--- a/wpimath/build.gradle
+++ b/wpimath/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-annotations:2.15.2"
     api "com.fasterxml.jackson.core:jackson-core:2.15.2"
     api "com.fasterxml.jackson.core:jackson-databind:2.15.2"
+    api "us.hebi.quickbuf:quickbuf-runtime:1.3.2"
 }
 
 def wpilibNumberFileInput = file("src/generate/GenericNumber.java.jinja")

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose2d.java
@@ -9,10 +9,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.wpi.first.math.interpolation.Interpolatable;
+import edu.wpi.first.math.proto.Geometry2D.ProtobufPose2d;
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.struct.Struct;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import us.hebi.quickbuf.Descriptors.Descriptor;
 
 /** Represents a 2D pose containing translational and rotational elements. */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -305,4 +310,83 @@ public class Pose2d implements Interpolatable<Pose2d> {
       return this.exp(scaledTwist);
     }
   }
+
+  public static final class AStruct implements Struct<Pose2d> {
+    @Override
+    public Class<Pose2d> getTypeClass() {
+      return Pose2d.class;
+    }
+
+    @Override
+    public String getTypeString() {
+      return "struct:Pose2d";
+    }
+
+    @Override
+    public int getSize() {
+      return Translation2d.struct.getSize() + Rotation2d.struct.getSize();
+    }
+
+    @Override
+    public String getSchema() {
+      return "Translation2d translation;Rotation2d rotation";
+    }
+
+    @Override
+    public Struct<?>[] getNested() {
+      return new Struct<?>[] {Translation2d.struct, Rotation2d.struct};
+    }
+
+    @Override
+    public Pose2d unpack(ByteBuffer bb) {
+      Translation2d translation = Translation2d.struct.unpack(bb);
+      Rotation2d rotation = Rotation2d.struct.unpack(bb);
+      return new Pose2d(translation, rotation);
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, Pose2d value) {
+      Translation2d.struct.pack(bb, value.m_translation);
+      Rotation2d.struct.pack(bb, value.m_rotation);
+    }
+  }
+
+  public static final AStruct struct = new AStruct();
+
+  public static final class AProto implements Protobuf<Pose2d, ProtobufPose2d> {
+    @Override
+    public Class<Pose2d> getTypeClass() {
+      return Pose2d.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+      return ProtobufPose2d.getDescriptor();
+    }
+
+    @Override
+    public Protobuf<?, ?>[] getNested() {
+      return new Protobuf<?, ?>[] {Translation2d.proto, Rotation2d.proto};
+    }
+
+    @Override
+    public ProtobufPose2d createMessage() {
+      return ProtobufPose2d.newInstance();
+    }
+
+    @Override
+    public Pose2d unpack(ProtobufPose2d msg) {
+      return new Pose2d(
+          Translation2d.proto.unpack(msg.getTranslation()),
+          Rotation2d.proto.unpack(msg.getRotation()));
+    }
+
+    @Override
+    public void pack(ProtobufPose2d msg, Pose2d value) {
+      Translation2d.proto.pack(msg.getMutableTranslation(), value.m_translation);
+      Rotation2d.proto.pack(msg.getMutableRotation(), value.m_rotation);
+    }
+  }
+
+  public static final AProto proto = new AProto();
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose3d.java
@@ -10,7 +10,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.wpi.first.math.WPIMathJNI;
 import edu.wpi.first.math.interpolation.Interpolatable;
+import edu.wpi.first.math.proto.Geometry3D.ProtobufPose3d;
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.struct.Struct;
+import java.nio.ByteBuffer;
 import java.util.Objects;
+import us.hebi.quickbuf.Descriptors.Descriptor;
 
 /** Represents a 3D pose containing translational and rotational elements. */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -318,4 +323,83 @@ public class Pose3d implements Interpolatable<Pose3d> {
       return this.exp(scaledTwist);
     }
   }
+
+  public static final class AStruct implements Struct<Pose3d> {
+    @Override
+    public Class<Pose3d> getTypeClass() {
+      return Pose3d.class;
+    }
+
+    @Override
+    public String getTypeString() {
+      return "struct:Pose3d";
+    }
+
+    @Override
+    public int getSize() {
+      return Translation3d.struct.getSize() + Rotation3d.struct.getSize();
+    }
+
+    @Override
+    public String getSchema() {
+      return "Translation3d translation;Rotation3d rotation";
+    }
+
+    @Override
+    public Struct<?>[] getNested() {
+      return new Struct<?>[] {Translation3d.struct, Rotation3d.struct};
+    }
+
+    @Override
+    public Pose3d unpack(ByteBuffer bb) {
+      Translation3d translation = Translation3d.struct.unpack(bb);
+      Rotation3d rotation = Rotation3d.struct.unpack(bb);
+      return new Pose3d(translation, rotation);
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, Pose3d value) {
+      Translation3d.struct.pack(bb, value.m_translation);
+      Rotation3d.struct.pack(bb, value.m_rotation);
+    }
+  }
+
+  public static final AStruct struct = new AStruct();
+
+  public static final class AProto implements Protobuf<Pose3d, ProtobufPose3d> {
+    @Override
+    public Class<Pose3d> getTypeClass() {
+      return Pose3d.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+      return ProtobufPose3d.getDescriptor();
+    }
+
+    @Override
+    public Protobuf<?, ?>[] getNested() {
+      return new Protobuf<?, ?>[] {Translation3d.proto, Rotation3d.proto};
+    }
+
+    @Override
+    public ProtobufPose3d createMessage() {
+      return ProtobufPose3d.newInstance();
+    }
+
+    @Override
+    public Pose3d unpack(ProtobufPose3d msg) {
+      return new Pose3d(
+          Translation3d.proto.unpack(msg.getTranslation()),
+          Rotation3d.proto.unpack(msg.getRotation()));
+    }
+
+    @Override
+    public void pack(ProtobufPose3d msg, Pose3d value) {
+      Translation3d.proto.pack(msg.getMutableTranslation(), value.m_translation);
+      Rotation3d.proto.pack(msg.getMutableRotation(), value.m_rotation);
+    }
+  }
+
+  public static final AProto proto = new AProto();
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Quaternion.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Quaternion.java
@@ -11,7 +11,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.Vector;
 import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.proto.Geometry3D.ProtobufQuaternion;
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.struct.Struct;
+import java.nio.ByteBuffer;
 import java.util.Objects;
+import us.hebi.quickbuf.Descriptors.Descriptor;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
@@ -400,4 +405,74 @@ public class Quaternion {
 
     return VecBuilder.fill(coeff * getX(), coeff * getY(), coeff * getZ());
   }
+
+  public static final class AStruct implements Struct<Quaternion> {
+    @Override
+    public Class<Quaternion> getTypeClass() {
+      return Quaternion.class;
+    }
+
+    @Override
+    public String getTypeString() {
+      return "struct:Quaternion";
+    }
+
+    @Override
+    public int getSize() {
+      return kSizeDouble * 4;
+    }
+
+    @Override
+    public String getSchema() {
+      return "double w;double x;double y;double z";
+    }
+
+    @Override
+    public Quaternion unpack(ByteBuffer bb) {
+      double w = bb.getDouble();
+      double x = bb.getDouble();
+      double y = bb.getDouble();
+      double z = bb.getDouble();
+      return new Quaternion(w, x, y, z);
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, Quaternion value) {
+      bb.putDouble(value.getW());
+      bb.putDouble(value.getX());
+      bb.putDouble(value.getY());
+      bb.putDouble(value.getZ());
+    }
+  }
+
+  public static final AStruct struct = new AStruct();
+
+  public static final class AProto implements Protobuf<Quaternion, ProtobufQuaternion> {
+    @Override
+    public Class<Quaternion> getTypeClass() {
+      return Quaternion.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+      return ProtobufQuaternion.getDescriptor();
+    }
+
+    @Override
+    public ProtobufQuaternion createMessage() {
+      return ProtobufQuaternion.newInstance();
+    }
+
+    @Override
+    public Quaternion unpack(ProtobufQuaternion msg) {
+      return new Quaternion(msg.getW(), msg.getX(), msg.getY(), msg.getZ());
+    }
+
+    @Override
+    public void pack(ProtobufQuaternion msg, Quaternion value) {
+      msg.setW(value.getW()).setX(value.getX()).setY(value.getY()).setZ(value.getZ());
+    }
+  }
+
+  public static final AProto proto = new AProto();
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation2d.java
@@ -10,8 +10,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.interpolation.Interpolatable;
+import edu.wpi.first.math.proto.Geometry2D.ProtobufRotation2d;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.struct.Struct;
+import java.nio.ByteBuffer;
 import java.util.Objects;
+import us.hebi.quickbuf.Descriptors.Descriptor;
 
 /**
  * A rotation in a 2D coordinate frame represented by a point on the unit circle (cosine and sine).
@@ -256,4 +261,67 @@ public class Rotation2d implements Interpolatable<Rotation2d> {
   public Rotation2d interpolate(Rotation2d endValue, double t) {
     return plus(endValue.minus(this).times(MathUtil.clamp(t, 0, 1)));
   }
+
+  public static final class AStruct implements Struct<Rotation2d> {
+    @Override
+    public Class<Rotation2d> getTypeClass() {
+      return Rotation2d.class;
+    }
+
+    @Override
+    public String getTypeString() {
+      return "struct:Rotation2d";
+    }
+
+    @Override
+    public int getSize() {
+      return kSizeDouble;
+    }
+
+    @Override
+    public String getSchema() {
+      return "double value";
+    }
+
+    @Override
+    public Rotation2d unpack(ByteBuffer bb) {
+      return new Rotation2d(bb.getDouble());
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, Rotation2d value) {
+      bb.putDouble(value.m_value);
+    }
+  }
+
+  public static final AStruct struct = new AStruct();
+
+  public static final class AProto implements Protobuf<Rotation2d, ProtobufRotation2d> {
+    @Override
+    public Class<Rotation2d> getTypeClass() {
+      return Rotation2d.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+      return ProtobufRotation2d.getDescriptor();
+    }
+
+    @Override
+    public ProtobufRotation2d createMessage() {
+      return ProtobufRotation2d.newInstance();
+    }
+
+    @Override
+    public Rotation2d unpack(ProtobufRotation2d msg) {
+      return new Rotation2d(msg.getValue());
+    }
+
+    @Override
+    public void pack(ProtobufRotation2d msg, Rotation2d value) {
+      msg.setValue(value.m_value);
+    }
+  }
+
+  public static final AProto proto = new AProto();
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Rotation3d.java
@@ -17,8 +17,13 @@ import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.Vector;
 import edu.wpi.first.math.interpolation.Interpolatable;
 import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.proto.Geometry3D.ProtobufRotation3d;
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.struct.Struct;
+import java.nio.ByteBuffer;
 import java.util.Objects;
 import org.ejml.dense.row.factory.DecompositionFactory_DDRM;
+import us.hebi.quickbuf.Descriptors.Descriptor;
 
 /** A rotation in a 3D coordinate frame represented by a quaternion. */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -434,4 +439,77 @@ public class Rotation3d implements Interpolatable<Rotation3d> {
   public Rotation3d interpolate(Rotation3d endValue, double t) {
     return plus(endValue.minus(this).times(MathUtil.clamp(t, 0, 1)));
   }
+
+  public static final class AStruct implements Struct<Rotation3d> {
+    @Override
+    public Class<Rotation3d> getTypeClass() {
+      return Rotation3d.class;
+    }
+
+    @Override
+    public String getTypeString() {
+      return "struct:Rotation3d";
+    }
+
+    @Override
+    public int getSize() {
+      return Quaternion.struct.getSize();
+    }
+
+    @Override
+    public String getSchema() {
+      return "Quaternion q";
+    }
+
+    @Override
+    public Struct<?>[] getNested() {
+      return new Struct<?>[] {Quaternion.struct};
+    }
+
+    @Override
+    public Rotation3d unpack(ByteBuffer bb) {
+      return new Rotation3d(Quaternion.struct.unpack(bb));
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, Rotation3d value) {
+      Quaternion.struct.pack(bb, value.m_q);
+    }
+  }
+
+  public static final AStruct struct = new AStruct();
+
+  public static final class AProto implements Protobuf<Rotation3d, ProtobufRotation3d> {
+    @Override
+    public Class<Rotation3d> getTypeClass() {
+      return Rotation3d.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+      return ProtobufRotation3d.getDescriptor();
+    }
+
+    @Override
+    public Protobuf<?, ?>[] getNested() {
+      return new Protobuf<?, ?>[] {Quaternion.proto};
+    }
+
+    @Override
+    public ProtobufRotation3d createMessage() {
+      return ProtobufRotation3d.newInstance();
+    }
+
+    @Override
+    public Rotation3d unpack(ProtobufRotation3d msg) {
+      return new Rotation3d(Quaternion.proto.unpack(msg.getQ()));
+    }
+
+    @Override
+    public void pack(ProtobufRotation3d msg, Rotation3d value) {
+      Quaternion.proto.pack(msg.getMutableQ(), value.m_q);
+    }
+  }
+
+  public static final AProto proto = new AProto();
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform2d.java
@@ -4,7 +4,12 @@
 
 package edu.wpi.first.math.geometry;
 
+import edu.wpi.first.math.proto.Geometry2D.ProtobufTransform2d;
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.struct.Struct;
+import java.nio.ByteBuffer;
 import java.util.Objects;
+import us.hebi.quickbuf.Descriptors.Descriptor;
 
 /** Represents a transformation for a Pose2d in the pose's frame. */
 public class Transform2d {
@@ -163,4 +168,83 @@ public class Transform2d {
   public int hashCode() {
     return Objects.hash(m_translation, m_rotation);
   }
+
+  public static final class AStruct implements Struct<Transform2d> {
+    @Override
+    public Class<Transform2d> getTypeClass() {
+      return Transform2d.class;
+    }
+
+    @Override
+    public String getTypeString() {
+      return "struct:Transform2d";
+    }
+
+    @Override
+    public int getSize() {
+      return Translation2d.struct.getSize() + Rotation2d.struct.getSize();
+    }
+
+    @Override
+    public String getSchema() {
+      return "Translation2d translation;Rotation2d rotation";
+    }
+
+    @Override
+    public Struct<?>[] getNested() {
+      return new Struct<?>[] {Translation2d.struct, Rotation2d.struct};
+    }
+
+    @Override
+    public Transform2d unpack(ByteBuffer bb) {
+      Translation2d translation = Translation2d.struct.unpack(bb);
+      Rotation2d rotation = Rotation2d.struct.unpack(bb);
+      return new Transform2d(translation, rotation);
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, Transform2d value) {
+      Translation2d.struct.pack(bb, value.m_translation);
+      Rotation2d.struct.pack(bb, value.m_rotation);
+    }
+  }
+
+  public static final AStruct struct = new AStruct();
+
+  public static final class AProto implements Protobuf<Transform2d, ProtobufTransform2d> {
+    @Override
+    public Class<Transform2d> getTypeClass() {
+      return Transform2d.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+      return ProtobufTransform2d.getDescriptor();
+    }
+
+    @Override
+    public Protobuf<?, ?>[] getNested() {
+      return new Protobuf<?, ?>[] {Translation2d.proto, Rotation2d.proto};
+    }
+
+    @Override
+    public ProtobufTransform2d createMessage() {
+      return ProtobufTransform2d.newInstance();
+    }
+
+    @Override
+    public Transform2d unpack(ProtobufTransform2d msg) {
+      return new Transform2d(
+          Translation2d.proto.unpack(msg.getTranslation()),
+          Rotation2d.proto.unpack(msg.getRotation()));
+    }
+
+    @Override
+    public void pack(ProtobufTransform2d msg, Transform2d value) {
+      Translation2d.proto.pack(msg.getMutableTranslation(), value.m_translation);
+      Rotation2d.proto.pack(msg.getMutableRotation(), value.m_rotation);
+    }
+  }
+
+  public static final AProto proto = new AProto();
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform3d.java
@@ -4,7 +4,12 @@
 
 package edu.wpi.first.math.geometry;
 
+import edu.wpi.first.math.proto.Geometry3D.ProtobufTransform3d;
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.struct.Struct;
+import java.nio.ByteBuffer;
 import java.util.Objects;
+import us.hebi.quickbuf.Descriptors.Descriptor;
 
 /** Represents a transformation for a Pose3d in the pose's frame. */
 public class Transform3d {
@@ -173,4 +178,83 @@ public class Transform3d {
   public int hashCode() {
     return Objects.hash(m_translation, m_rotation);
   }
+
+  public static final class AStruct implements Struct<Transform3d> {
+    @Override
+    public Class<Transform3d> getTypeClass() {
+      return Transform3d.class;
+    }
+
+    @Override
+    public String getTypeString() {
+      return "struct:Transform3d";
+    }
+
+    @Override
+    public int getSize() {
+      return Translation3d.struct.getSize() + Rotation3d.struct.getSize();
+    }
+
+    @Override
+    public String getSchema() {
+      return "Translation3d translation;Rotation3d rotation";
+    }
+
+    @Override
+    public Struct<?>[] getNested() {
+      return new Struct<?>[] {Translation3d.struct, Rotation3d.struct};
+    }
+
+    @Override
+    public Transform3d unpack(ByteBuffer bb) {
+      Translation3d translation = Translation3d.struct.unpack(bb);
+      Rotation3d rotation = Rotation3d.struct.unpack(bb);
+      return new Transform3d(translation, rotation);
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, Transform3d value) {
+      Translation3d.struct.pack(bb, value.m_translation);
+      Rotation3d.struct.pack(bb, value.m_rotation);
+    }
+  }
+
+  public static final AStruct struct = new AStruct();
+
+  public static final class AProto implements Protobuf<Transform3d, ProtobufTransform3d> {
+    @Override
+    public Class<Transform3d> getTypeClass() {
+      return Transform3d.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+      return ProtobufTransform3d.getDescriptor();
+    }
+
+    @Override
+    public Protobuf<?, ?>[] getNested() {
+      return new Protobuf<?, ?>[] {Translation3d.proto, Rotation3d.proto};
+    }
+
+    @Override
+    public ProtobufTransform3d createMessage() {
+      return ProtobufTransform3d.newInstance();
+    }
+
+    @Override
+    public Transform3d unpack(ProtobufTransform3d msg) {
+      return new Transform3d(
+          Translation3d.proto.unpack(msg.getTranslation()),
+          Rotation3d.proto.unpack(msg.getRotation()));
+    }
+
+    @Override
+    public void pack(ProtobufTransform3d msg, Transform3d value) {
+      Translation3d.proto.pack(msg.getMutableTranslation(), value.m_translation);
+      Rotation3d.proto.pack(msg.getMutableRotation(), value.m_rotation);
+    }
+  }
+
+  public static final AProto proto = new AProto();
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation2d.java
@@ -10,10 +10,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.interpolation.Interpolatable;
+import edu.wpi.first.math.proto.Geometry2D.ProtobufTranslation2d;
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.struct.Struct;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import us.hebi.quickbuf.Descriptors.Descriptor;
 
 /**
  * Represents a translation in 2D space. This object can be used to represent a point or a vector.
@@ -229,4 +234,70 @@ public class Translation2d implements Interpolatable<Translation2d> {
         MathUtil.interpolate(this.getX(), endValue.getX(), t),
         MathUtil.interpolate(this.getY(), endValue.getY(), t));
   }
+
+  public static final class AStruct implements Struct<Translation2d> {
+    @Override
+    public Class<Translation2d> getTypeClass() {
+      return Translation2d.class;
+    }
+
+    @Override
+    public String getTypeString() {
+      return "struct:Translation2d";
+    }
+
+    @Override
+    public int getSize() {
+      return kSizeDouble * 2;
+    }
+
+    @Override
+    public String getSchema() {
+      return "double x;double y";
+    }
+
+    @Override
+    public Translation2d unpack(ByteBuffer bb) {
+      double x = bb.getDouble();
+      double y = bb.getDouble();
+      return new Translation2d(x, y);
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, Translation2d value) {
+      bb.putDouble(value.m_x);
+      bb.putDouble(value.m_y);
+    }
+  }
+
+  public static final AStruct struct = new AStruct();
+
+  public static final class AProto implements Protobuf<Translation2d, ProtobufTranslation2d> {
+    @Override
+    public Class<Translation2d> getTypeClass() {
+      return Translation2d.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+      return ProtobufTranslation2d.getDescriptor();
+    }
+
+    @Override
+    public ProtobufTranslation2d createMessage() {
+      return ProtobufTranslation2d.newInstance();
+    }
+
+    @Override
+    public Translation2d unpack(ProtobufTranslation2d msg) {
+      return new Translation2d(msg.getX(), msg.getY());
+    }
+
+    @Override
+    public void pack(ProtobufTranslation2d msg, Translation2d value) {
+      msg.setX(value.m_x).setY(value.m_y);
+    }
+  }
+
+  public static final AProto proto = new AProto();
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Translation3d.java
@@ -10,7 +10,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.interpolation.Interpolatable;
+import edu.wpi.first.math.proto.Geometry3D.ProtobufTranslation3d;
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.struct.Struct;
+import java.nio.ByteBuffer;
 import java.util.Objects;
+import us.hebi.quickbuf.Descriptors.Descriptor;
 
 /**
  * Represents a translation in 3D space. This object can be used to represent a point or a vector.
@@ -231,4 +236,72 @@ public class Translation3d implements Interpolatable<Translation3d> {
         MathUtil.interpolate(this.getY(), endValue.getY(), t),
         MathUtil.interpolate(this.getZ(), endValue.getZ(), t));
   }
+
+  public static final class AStruct implements Struct<Translation3d> {
+    @Override
+    public Class<Translation3d> getTypeClass() {
+      return Translation3d.class;
+    }
+
+    @Override
+    public String getTypeString() {
+      return "struct:Translation3d";
+    }
+
+    @Override
+    public int getSize() {
+      return kSizeDouble * 3;
+    }
+
+    @Override
+    public String getSchema() {
+      return "double x;double y;double z";
+    }
+
+    @Override
+    public Translation3d unpack(ByteBuffer bb) {
+      double x = bb.getDouble();
+      double y = bb.getDouble();
+      double z = bb.getDouble();
+      return new Translation3d(x, y, z);
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, Translation3d value) {
+      bb.putDouble(value.m_x);
+      bb.putDouble(value.m_y);
+      bb.putDouble(value.m_z);
+    }
+  }
+
+  public static final AStruct struct = new AStruct();
+
+  public static final class AProto implements Protobuf<Translation3d, ProtobufTranslation3d> {
+    @Override
+    public Class<Translation3d> getTypeClass() {
+      return Translation3d.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+      return ProtobufTranslation3d.getDescriptor();
+    }
+
+    @Override
+    public ProtobufTranslation3d createMessage() {
+      return ProtobufTranslation3d.newInstance();
+    }
+
+    @Override
+    public Translation3d unpack(ProtobufTranslation3d msg) {
+      return new Translation3d(msg.getX(), msg.getY(), msg.getZ());
+    }
+
+    @Override
+    public void pack(ProtobufTranslation3d msg, Translation3d value) {
+      msg.setX(value.m_x).setY(value.m_y).setZ(value.m_z);
+    }
+  }
+
+  public static final AProto proto = new AProto();
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Twist2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Twist2d.java
@@ -4,7 +4,12 @@
 
 package edu.wpi.first.math.geometry;
 
+import edu.wpi.first.math.proto.Geometry2D.ProtobufTwist2d;
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.struct.Struct;
+import java.nio.ByteBuffer;
 import java.util.Objects;
+import us.hebi.quickbuf.Descriptors.Descriptor;
 
 /**
  * A change in distance along a 2D arc since the last pose update. We can use ideas from
@@ -62,4 +67,72 @@ public class Twist2d {
   public int hashCode() {
     return Objects.hash(dx, dy, dtheta);
   }
+
+  public static final class AStruct implements Struct<Twist2d> {
+    @Override
+    public Class<Twist2d> getTypeClass() {
+      return Twist2d.class;
+    }
+
+    @Override
+    public String getTypeString() {
+      return "struct:Twist2d";
+    }
+
+    @Override
+    public int getSize() {
+      return kSizeDouble * 3;
+    }
+
+    @Override
+    public String getSchema() {
+      return "double dx;double dy;double dtheta";
+    }
+
+    @Override
+    public Twist2d unpack(ByteBuffer bb) {
+      double dx = bb.getDouble();
+      double dy = bb.getDouble();
+      double dtheta = bb.getDouble();
+      return new Twist2d(dx, dy, dtheta);
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, Twist2d value) {
+      bb.putDouble(value.dx);
+      bb.putDouble(value.dy);
+      bb.putDouble(value.dtheta);
+    }
+  }
+
+  public static final AStruct struct = new AStruct();
+
+  public static final class AProto implements Protobuf<Twist2d, ProtobufTwist2d> {
+    @Override
+    public Class<Twist2d> getTypeClass() {
+      return Twist2d.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+      return ProtobufTwist2d.getDescriptor();
+    }
+
+    @Override
+    public ProtobufTwist2d createMessage() {
+      return ProtobufTwist2d.newInstance();
+    }
+
+    @Override
+    public Twist2d unpack(ProtobufTwist2d msg) {
+      return new Twist2d(msg.getDx(), msg.getDy(), msg.getDtheta());
+    }
+
+    @Override
+    public void pack(ProtobufTwist2d msg, Twist2d value) {
+      msg.setDx(value.dx).setDy(value.dy).setDtheta(value.dtheta);
+    }
+  }
+
+  public static final AProto proto = new AProto();
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Twist3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Twist3d.java
@@ -4,7 +4,12 @@
 
 package edu.wpi.first.math.geometry;
 
+import edu.wpi.first.math.proto.Geometry3D.ProtobufTwist3d;
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.struct.Struct;
+import java.nio.ByteBuffer;
 import java.util.Objects;
+import us.hebi.quickbuf.Descriptors.Descriptor;
 
 /**
  * A change in distance along a 3D arc since the last pose update. We can use ideas from
@@ -82,4 +87,84 @@ public class Twist3d {
   public int hashCode() {
     return Objects.hash(dx, dy, dz, rx, ry, rz);
   }
+
+  public static final class AStruct implements Struct<Twist3d> {
+    @Override
+    public Class<Twist3d> getTypeClass() {
+      return Twist3d.class;
+    }
+
+    @Override
+    public String getTypeString() {
+      return "struct:Twist3d";
+    }
+
+    @Override
+    public int getSize() {
+      return kSizeDouble * 6;
+    }
+
+    @Override
+    public String getSchema() {
+      return "double dx;double dy;double dz;double rx;double ry;double rz";
+    }
+
+    @Override
+    public Twist3d unpack(ByteBuffer bb) {
+      double dx = bb.getDouble();
+      double dy = bb.getDouble();
+      double dz = bb.getDouble();
+      double rx = bb.getDouble();
+      double ry = bb.getDouble();
+      double rz = bb.getDouble();
+      return new Twist3d(dx, dy, dz, rx, ry, rz);
+    }
+
+    @Override
+    public void pack(ByteBuffer bb, Twist3d value) {
+      bb.putDouble(value.dx);
+      bb.putDouble(value.dy);
+      bb.putDouble(value.dz);
+      bb.putDouble(value.rx);
+      bb.putDouble(value.ry);
+      bb.putDouble(value.rz);
+    }
+  }
+
+  public static final AStruct struct = new AStruct();
+
+  public static final class AProto implements Protobuf<Twist3d, ProtobufTwist3d> {
+    @Override
+    public Class<Twist3d> getTypeClass() {
+      return Twist3d.class;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+      return ProtobufTwist3d.getDescriptor();
+    }
+
+    @Override
+    public ProtobufTwist3d createMessage() {
+      return ProtobufTwist3d.newInstance();
+    }
+
+    @Override
+    public Twist3d unpack(ProtobufTwist3d msg) {
+      return new Twist3d(
+          msg.getDx(), msg.getDy(), msg.getDz(), msg.getRx(), msg.getRy(), msg.getRz());
+    }
+
+    @Override
+    public void pack(ProtobufTwist3d msg, Twist3d value) {
+      msg.setDx(value.dx)
+          .setDy(value.dy)
+          .setDz(value.dz)
+          .setRx(value.rx)
+          .setRy(value.ry)
+          .setRz(value.rz);
+    }
+  }
+
+  public static final AProto proto = new AProto();
 }

--- a/wpimath/src/main/native/cpp/geometry/Pose2d.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Pose2d.cpp
@@ -9,6 +9,7 @@
 #include <wpi/json.h>
 
 #include "frc/MathUtil.h"
+#include "geometry2d.pb.h"
 
 using namespace frc;
 
@@ -107,4 +108,24 @@ void frc::to_json(wpi::json& json, const Pose2d& pose) {
 void frc::from_json(const wpi::json& json, Pose2d& pose) {
   pose = Pose2d{json.at("translation").get<Translation2d>(),
                 json.at("rotation").get<Rotation2d>()};
+}
+
+google::protobuf::Message* wpi::Protobuf<frc::Pose2d>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufPose2d>(
+      arena);
+}
+
+frc::Pose2d wpi::Protobuf<frc::Pose2d>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m = static_cast<const wpi::proto::ProtobufPose2d*>(&msg);
+  return Pose2d{wpi::UnpackProtobuf<frc::Translation2d>(m->translation()),
+                wpi::UnpackProtobuf<frc::Rotation2d>(m->rotation())};
+}
+
+void wpi::Protobuf<frc::Pose2d>::Pack(google::protobuf::Message* msg,
+                                      const frc::Pose2d& value) {
+  auto m = static_cast<wpi::proto::ProtobufPose2d*>(msg);
+  wpi::PackProtobuf(m->mutable_translation(), value.Translation());
+  wpi::PackProtobuf(m->mutable_rotation(), value.Rotation());
 }

--- a/wpimath/src/main/native/cpp/geometry/Pose3d.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Pose3d.cpp
@@ -9,6 +9,8 @@
 #include <Eigen/Core>
 #include <wpi/json.h>
 
+#include "geometry3d.pb.h"
+
 using namespace frc;
 
 namespace {
@@ -186,4 +188,24 @@ void frc::to_json(wpi::json& json, const Pose3d& pose) {
 void frc::from_json(const wpi::json& json, Pose3d& pose) {
   pose = Pose3d{json.at("translation").get<Translation3d>(),
                 json.at("rotation").get<Rotation3d>()};
+}
+
+google::protobuf::Message* wpi::Protobuf<frc::Pose3d>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufPose3d>(
+      arena);
+}
+
+frc::Pose3d wpi::Protobuf<frc::Pose3d>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m = static_cast<const wpi::proto::ProtobufPose3d*>(&msg);
+  return Pose3d{wpi::UnpackProtobuf<frc::Translation3d>(m->translation()),
+                wpi::UnpackProtobuf<frc::Rotation3d>(m->rotation())};
+}
+
+void wpi::Protobuf<frc::Pose3d>::Pack(google::protobuf::Message* msg,
+                                      const frc::Pose3d& value) {
+  auto m = static_cast<wpi::proto::ProtobufPose3d*>(msg);
+  wpi::PackProtobuf(m->mutable_translation(), value.Translation());
+  wpi::PackProtobuf(m->mutable_rotation(), value.Rotation());
 }

--- a/wpimath/src/main/native/cpp/geometry/Quaternion.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Quaternion.cpp
@@ -8,6 +8,8 @@
 
 #include <wpi/json.h>
 
+#include "geometry3d.pb.h"
+
 using namespace frc;
 
 Quaternion::Quaternion(double w, double x, double y, double z)
@@ -229,4 +231,25 @@ void frc::from_json(const wpi::json& json, Quaternion& quaternion) {
   quaternion =
       Quaternion{json.at("W").get<double>(), json.at("X").get<double>(),
                  json.at("Y").get<double>(), json.at("Z").get<double>()};
+}
+
+google::protobuf::Message* wpi::Protobuf<frc::Quaternion>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufQuaternion>(
+      arena);
+}
+
+frc::Quaternion wpi::Protobuf<frc::Quaternion>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m = static_cast<const wpi::proto::ProtobufQuaternion*>(&msg);
+  return frc::Quaternion{m->w(), m->x(), m->y(), m->z()};
+}
+
+void wpi::Protobuf<frc::Quaternion>::Pack(google::protobuf::Message* msg,
+                                          const frc::Quaternion& value) {
+  auto m = static_cast<wpi::proto::ProtobufQuaternion*>(msg);
+  m->set_w(value.W());
+  m->set_x(value.X());
+  m->set_y(value.Y());
+  m->set_z(value.Z());
 }

--- a/wpimath/src/main/native/cpp/geometry/Rotation2d.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Rotation2d.cpp
@@ -8,6 +8,7 @@
 
 #include <wpi/json.h>
 
+#include "geometry2d.pb.h"
 #include "units/math.h"
 
 using namespace frc;
@@ -18,4 +19,22 @@ void frc::to_json(wpi::json& json, const Rotation2d& rotation) {
 
 void frc::from_json(const wpi::json& json, Rotation2d& rotation) {
   rotation = Rotation2d{units::radian_t{json.at("radians").get<double>()}};
+}
+
+google::protobuf::Message* wpi::Protobuf<frc::Rotation2d>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufRotation2d>(
+      arena);
+}
+
+frc::Rotation2d wpi::Protobuf<frc::Rotation2d>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m = static_cast<const wpi::proto::ProtobufRotation2d*>(&msg);
+  return frc::Rotation2d{units::radian_t{m->value()}};
+}
+
+void wpi::Protobuf<frc::Rotation2d>::Pack(google::protobuf::Message* msg,
+                                          const frc::Rotation2d& value) {
+  auto m = static_cast<wpi::proto::ProtobufRotation2d*>(msg);
+  m->set_value(value.Radians().value());
 }

--- a/wpimath/src/main/native/cpp/geometry/Rotation3d.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Rotation3d.cpp
@@ -13,6 +13,7 @@
 #include <wpi/json.h>
 
 #include "frc/fmt/Eigen.h"
+#include "geometry3d.pb.h"
 #include "units/math.h"
 #include "wpimath/MathShared.h"
 
@@ -260,4 +261,22 @@ void frc::to_json(wpi::json& json, const Rotation3d& rotation) {
 
 void frc::from_json(const wpi::json& json, Rotation3d& rotation) {
   rotation = Rotation3d{json.at("quaternion").get<Quaternion>()};
+}
+
+google::protobuf::Message* wpi::Protobuf<frc::Rotation3d>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufRotation3d>(
+      arena);
+}
+
+frc::Rotation3d wpi::Protobuf<frc::Rotation3d>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m = static_cast<const wpi::proto::ProtobufRotation3d*>(&msg);
+  return Rotation3d{wpi::UnpackProtobuf<frc::Quaternion>(m->q())};
+}
+
+void wpi::Protobuf<frc::Rotation3d>::Pack(google::protobuf::Message* msg,
+                                          const frc::Rotation3d& value) {
+  auto m = static_cast<wpi::proto::ProtobufRotation3d*>(msg);
+  wpi::PackProtobuf(m->mutable_q(), value.GetQuaternion());
 }

--- a/wpimath/src/main/native/cpp/geometry/Transform2d.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Transform2d.cpp
@@ -5,6 +5,7 @@
 #include "frc/geometry/Transform2d.h"
 
 #include "frc/geometry/Pose2d.h"
+#include "geometry2d.pb.h"
 
 using namespace frc;
 
@@ -20,4 +21,24 @@ Transform2d::Transform2d(Pose2d initial, Pose2d final) {
 
 Transform2d Transform2d::operator+(const Transform2d& other) const {
   return Transform2d{Pose2d{}, Pose2d{}.TransformBy(*this).TransformBy(other)};
+}
+
+google::protobuf::Message* wpi::Protobuf<frc::Transform2d>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<
+      wpi::proto::ProtobufTransform2d>(arena);
+}
+
+frc::Transform2d wpi::Protobuf<frc::Transform2d>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m = static_cast<const wpi::proto::ProtobufTransform2d*>(&msg);
+  return Transform2d{wpi::UnpackProtobuf<frc::Translation2d>(m->translation()),
+                     wpi::UnpackProtobuf<frc::Rotation2d>(m->rotation())};
+}
+
+void wpi::Protobuf<frc::Transform2d>::Pack(google::protobuf::Message* msg,
+                                           const frc::Transform2d& value) {
+  auto m = static_cast<wpi::proto::ProtobufTransform2d*>(msg);
+  wpi::PackProtobuf(m->mutable_translation(), value.Translation());
+  wpi::PackProtobuf(m->mutable_rotation(), value.Rotation());
 }

--- a/wpimath/src/main/native/cpp/geometry/Transform3d.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Transform3d.cpp
@@ -5,6 +5,7 @@
 #include "frc/geometry/Transform3d.h"
 
 #include "frc/geometry/Pose3d.h"
+#include "geometry3d.pb.h"
 
 using namespace frc;
 
@@ -34,4 +35,24 @@ Transform3d Transform3d::Inverse() const {
 
 Transform3d Transform3d::operator+(const Transform3d& other) const {
   return Transform3d{Pose3d{}, Pose3d{}.TransformBy(*this).TransformBy(other)};
+}
+
+google::protobuf::Message* wpi::Protobuf<frc::Transform3d>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<
+      wpi::proto::ProtobufTransform3d>(arena);
+}
+
+frc::Transform3d wpi::Protobuf<frc::Transform3d>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m = static_cast<const wpi::proto::ProtobufTransform3d*>(&msg);
+  return Transform3d{wpi::UnpackProtobuf<frc::Translation3d>(m->translation()),
+                     wpi::UnpackProtobuf<frc::Rotation3d>(m->rotation())};
+}
+
+void wpi::Protobuf<frc::Transform3d>::Pack(google::protobuf::Message* msg,
+                                           const frc::Transform3d& value) {
+  auto m = static_cast<wpi::proto::ProtobufTransform3d*>(msg);
+  wpi::PackProtobuf(m->mutable_translation(), value.Translation());
+  wpi::PackProtobuf(m->mutable_rotation(), value.Rotation());
 }

--- a/wpimath/src/main/native/cpp/geometry/Translation2d.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Translation2d.cpp
@@ -6,6 +6,7 @@
 
 #include <wpi/json.h>
 
+#include "geometry2d.pb.h"
 #include "units/math.h"
 
 using namespace frc;
@@ -47,4 +48,23 @@ void frc::to_json(wpi::json& json, const Translation2d& translation) {
 void frc::from_json(const wpi::json& json, Translation2d& translation) {
   translation = Translation2d{units::meter_t{json.at("x").get<double>()},
                               units::meter_t{json.at("y").get<double>()}};
+}
+
+google::protobuf::Message* wpi::Protobuf<frc::Translation2d>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<
+      wpi::proto::ProtobufTranslation2d>(arena);
+}
+
+frc::Translation2d wpi::Protobuf<frc::Translation2d>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m = static_cast<const wpi::proto::ProtobufTranslation2d*>(&msg);
+  return frc::Translation2d{units::meter_t{m->x()}, units::meter_t{m->y()}};
+}
+
+void wpi::Protobuf<frc::Translation2d>::Pack(google::protobuf::Message* msg,
+                                             const frc::Translation2d& value) {
+  auto m = static_cast<wpi::proto::ProtobufTranslation2d*>(msg);
+  m->set_x(value.X().value());
+  m->set_y(value.Y().value());
 }

--- a/wpimath/src/main/native/cpp/geometry/Translation3d.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Translation3d.cpp
@@ -6,6 +6,7 @@
 
 #include <wpi/json.h>
 
+#include "geometry3d.pb.h"
 #include "units/length.h"
 #include "units/math.h"
 
@@ -51,4 +52,25 @@ void frc::from_json(const wpi::json& json, Translation3d& translation) {
   translation = Translation3d{units::meter_t{json.at("x").get<double>()},
                               units::meter_t{json.at("y").get<double>()},
                               units::meter_t{json.at("z").get<double>()}};
+}
+
+google::protobuf::Message* wpi::Protobuf<frc::Translation3d>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<
+      wpi::proto::ProtobufTranslation3d>(arena);
+}
+
+frc::Translation3d wpi::Protobuf<frc::Translation3d>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m = static_cast<const wpi::proto::ProtobufTranslation3d*>(&msg);
+  return frc::Translation3d{units::meter_t{m->x()}, units::meter_t{m->y()},
+                            units::meter_t{m->z()}};
+}
+
+void wpi::Protobuf<frc::Translation3d>::Pack(google::protobuf::Message* msg,
+                                             const frc::Translation3d& value) {
+  auto m = static_cast<wpi::proto::ProtobufTranslation3d*>(msg);
+  m->set_x(value.X().value());
+  m->set_y(value.Y().value());
+  m->set_z(value.Z().value());
 }

--- a/wpimath/src/main/native/cpp/geometry/Twist2d.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Twist2d.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc/geometry/Twist2d.h"
+
+#include "geometry2d.pb.h"
+
+using namespace frc;
+
+google::protobuf::Message* wpi::Protobuf<frc::Twist2d>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufTwist2d>(
+      arena);
+}
+
+frc::Twist2d wpi::Protobuf<frc::Twist2d>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m = static_cast<const wpi::proto::ProtobufTwist2d*>(&msg);
+  return frc::Twist2d{units::meter_t{m->dx()}, units::meter_t{m->dy()},
+                      units::radian_t{m->dtheta()}};
+}
+
+void wpi::Protobuf<frc::Twist2d>::Pack(google::protobuf::Message* msg,
+                                       const frc::Twist2d& value) {
+  auto m = static_cast<wpi::proto::ProtobufTwist2d*>(msg);
+  m->set_dx(value.dx.value());
+  m->set_dy(value.dy.value());
+  m->set_dtheta(value.dtheta.value());
+}

--- a/wpimath/src/main/native/cpp/geometry/Twist3d.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Twist3d.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc/geometry/Twist3d.h"
+
+#include "geometry3d.pb.h"
+
+using namespace frc;
+
+google::protobuf::Message* wpi::Protobuf<frc::Twist3d>::New(
+    google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::CreateMessage<wpi::proto::ProtobufTwist3d>(
+      arena);
+}
+
+frc::Twist3d wpi::Protobuf<frc::Twist3d>::Unpack(
+    const google::protobuf::Message& msg) {
+  auto m = static_cast<const wpi::proto::ProtobufTwist3d*>(&msg);
+  return frc::Twist3d{units::meter_t{m->dx()},  units::meter_t{m->dy()},
+                      units::meter_t{m->dz()},  units::radian_t{m->rx()},
+                      units::radian_t{m->ry()}, units::radian_t{m->rz()}};
+}
+
+void wpi::Protobuf<frc::Twist3d>::Pack(google::protobuf::Message* msg,
+                                       const frc::Twist3d& value) {
+  auto m = static_cast<wpi::proto::ProtobufTwist3d*>(msg);
+  m->set_dx(value.dx.value());
+  m->set_dy(value.dy.value());
+  m->set_dz(value.dz.value());
+  m->set_rx(value.rx.value());
+  m->set_ry(value.ry.value());
+  m->set_rz(value.rz.value());
+}

--- a/wpimath/src/main/native/include/frc/geometry/Pose2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Pose2d.h
@@ -9,7 +9,10 @@
 
 #include <wpi/SymbolExports.h>
 #include <wpi/json_fwd.h>
+#include <wpi/protobuf/Protobuf.h>
+#include <wpi/struct/Struct.h>
 
+#include "frc/geometry/Rotation2d.h"
 #include "frc/geometry/Transform2d.h"
 #include "frc/geometry/Translation2d.h"
 #include "frc/geometry/Twist2d.h"
@@ -211,5 +214,39 @@ WPILIB_DLLEXPORT
 void from_json(const wpi::json& json, Pose2d& pose);
 
 }  // namespace frc
+
+template <>
+struct wpi::Struct<frc::Pose2d> {
+  static constexpr std::string_view kTypeString = "struct:Pose2d";
+  static constexpr size_t kSize = wpi::Struct<frc::Translation2d>::kSize +
+                                  wpi::Struct<frc::Rotation2d>::kSize;
+  static constexpr std::string_view kSchema =
+      "Translation2d translation;Rotation2d rotation";
+  static frc::Pose2d Unpack(std::span<const uint8_t, kSize> data) {
+    return {wpi::UnpackStruct<frc::Translation2d, 0>(data),
+            wpi::UnpackStruct<frc::Rotation2d, kRotationOff>(data)};
+  }
+  static void Pack(std::span<uint8_t, kSize> data, const frc::Pose2d& value) {
+    wpi::PackStruct<0>(data, value.Translation());
+    wpi::PackStruct<kRotationOff>(data, value.Rotation());
+  }
+  static void ForEachNested(
+      std::invocable<std::string_view, std::string_view> auto fn) {
+    wpi::ForEachStructSchema<frc::Translation2d>(fn);
+    wpi::ForEachStructSchema<frc::Rotation2d>(fn);
+  }
+
+ private:
+  static constexpr size_t kRotationOff = wpi::Struct<frc::Translation2d>::kSize;
+};
+
+static_assert(wpi::HasNestedStruct<frc::Pose2d>);
+
+template <>
+struct WPILIB_DLLEXPORT wpi::Protobuf<frc::Pose2d> {
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static frc::Pose2d Unpack(const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg, const frc::Pose2d& value);
+};
 
 #include "frc/geometry/Pose2d.inc"

--- a/wpimath/src/main/native/include/frc/geometry/Pose3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Pose3d.h
@@ -6,8 +6,11 @@
 
 #include <wpi/SymbolExports.h>
 #include <wpi/json_fwd.h>
+#include <wpi/protobuf/Protobuf.h>
+#include <wpi/struct/Struct.h>
 
 #include "frc/geometry/Pose2d.h"
+#include "frc/geometry/Rotation3d.h"
 #include "frc/geometry/Transform3d.h"
 #include "frc/geometry/Translation3d.h"
 #include "frc/geometry/Twist3d.h"
@@ -213,3 +216,37 @@ WPILIB_DLLEXPORT
 void from_json(const wpi::json& json, Pose3d& pose);
 
 }  // namespace frc
+
+template <>
+struct wpi::Struct<frc::Pose3d> {
+  static constexpr std::string_view kTypeString = "struct:Pose3d";
+  static constexpr size_t kSize = wpi::Struct<frc::Translation3d>::kSize +
+                                  wpi::Struct<frc::Rotation3d>::kSize;
+  static constexpr std::string_view kSchema =
+      "Translation3d translation;Rotation3d rotation";
+  static frc::Pose3d Unpack(std::span<const uint8_t, kSize> data) {
+    return {wpi::UnpackStruct<frc::Translation3d, 0>(data),
+            wpi::UnpackStruct<frc::Rotation3d, kRotationOff>(data)};
+  }
+  static void Pack(std::span<uint8_t, kSize> data, const frc::Pose3d& value) {
+    wpi::PackStruct<0>(data, value.Translation());
+    wpi::PackStruct<kRotationOff>(data, value.Rotation());
+  }
+  static void ForEachNested(
+      std::invocable<std::string_view, std::string_view> auto fn) {
+    wpi::ForEachStructSchema<frc::Translation3d>(fn);
+    wpi::ForEachStructSchema<frc::Rotation3d>(fn);
+  }
+
+ private:
+  static constexpr size_t kRotationOff = wpi::Struct<frc::Translation3d>::kSize;
+};
+
+static_assert(wpi::HasNestedStruct<frc::Pose3d>);
+
+template <>
+struct WPILIB_DLLEXPORT wpi::Protobuf<frc::Pose3d> {
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static frc::Pose3d Unpack(const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg, const frc::Pose3d& value);
+};

--- a/wpimath/src/main/native/include/frc/geometry/Quaternion.h
+++ b/wpimath/src/main/native/include/frc/geometry/Quaternion.h
@@ -7,6 +7,8 @@
 #include <Eigen/Core>
 #include <wpi/SymbolExports.h>
 #include <wpi/json_fwd.h>
+#include <wpi/protobuf/Protobuf.h>
+#include <wpi/struct/Struct.h>
 
 namespace frc {
 
@@ -187,3 +189,32 @@ WPILIB_DLLEXPORT
 void from_json(const wpi::json& json, Quaternion& quaternion);
 
 }  // namespace frc
+
+template <>
+struct wpi::Struct<frc::Quaternion> {
+  static constexpr std::string_view kTypeString = "struct:Quaternion";
+  static constexpr size_t kSize = 32;
+  static constexpr std::string_view kSchema =
+      "double w;double x;double y;double z";
+  static frc::Quaternion Unpack(std::span<const uint8_t, 32> data) {
+    return {wpi::UnpackStruct<double, 0>(data),
+            wpi::UnpackStruct<double, 8>(data),
+            wpi::UnpackStruct<double, 16>(data),
+            wpi::UnpackStruct<double, 24>(data)};
+  }
+  static void Pack(std::span<uint8_t, 32> data, const frc::Quaternion& value) {
+    wpi::PackStruct<0>(data, value.W());
+    wpi::PackStruct<8>(data, value.X());
+    wpi::PackStruct<16>(data, value.Y());
+    wpi::PackStruct<24>(data, value.Z());
+  }
+};
+
+template <>
+struct WPILIB_DLLEXPORT wpi::Protobuf<frc::Quaternion> {
+  static constexpr std::string_view kTypeString = "proto:Quaternion";
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static frc::Quaternion Unpack(const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg,
+                   const frc::Quaternion& value);
+};

--- a/wpimath/src/main/native/include/frc/geometry/Rotation2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Rotation2d.h
@@ -6,6 +6,8 @@
 
 #include <wpi/SymbolExports.h>
 #include <wpi/json_fwd.h>
+#include <wpi/protobuf/Protobuf.h>
+#include <wpi/struct/Struct.h>
 
 #include "units/angle.h"
 
@@ -175,5 +177,26 @@ WPILIB_DLLEXPORT
 void from_json(const wpi::json& json, Rotation2d& rotation);
 
 }  // namespace frc
+
+template <>
+struct wpi::Struct<frc::Rotation2d> {
+  static constexpr std::string_view kTypeString = "struct:Rotation2d";
+  static constexpr size_t kSize = 8;
+  static constexpr std::string_view kSchema = "double value";
+  static frc::Rotation2d Unpack(std::span<const uint8_t, 8> data) {
+    return units::radian_t{wpi::UnpackStruct<double>(data)};
+  }
+  static void Pack(std::span<uint8_t, 8> data, const frc::Rotation2d& value) {
+    wpi::PackStruct(data, value.Radians().value());
+  }
+};
+
+template <>
+struct WPILIB_DLLEXPORT wpi::Protobuf<frc::Rotation2d> {
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static frc::Rotation2d Unpack(const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg,
+                   const frc::Rotation2d& value);
+};
 
 #include "frc/geometry/Rotation2d.inc"

--- a/wpimath/src/main/native/include/frc/geometry/Rotation3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Rotation3d.h
@@ -7,6 +7,8 @@
 #include <Eigen/Core>
 #include <wpi/SymbolExports.h>
 #include <wpi/json_fwd.h>
+#include <wpi/protobuf/Protobuf.h>
+#include <wpi/struct/Struct.h>
 
 #include "frc/geometry/Quaternion.h"
 #include "frc/geometry/Rotation2d.h"
@@ -194,3 +196,31 @@ WPILIB_DLLEXPORT
 void from_json(const wpi::json& json, Rotation3d& rotation);
 
 }  // namespace frc
+
+template <>
+struct wpi::Struct<frc::Rotation3d> {
+  static constexpr std::string_view kTypeString = "struct:Rotation3d";
+  static constexpr size_t kSize = wpi::Struct<frc::Quaternion>::kSize;
+  static constexpr std::string_view kSchema = "Quaternion q";
+  static frc::Rotation3d Unpack(std::span<const uint8_t, kSize> data) {
+    return frc::Rotation3d{wpi::UnpackStruct<frc::Quaternion, 0>(data)};
+  }
+  static void Pack(std::span<uint8_t, kSize> data,
+                   const frc::Rotation3d& value) {
+    wpi::PackStruct<0>(data, value.GetQuaternion());
+  }
+  static void ForEachNested(
+      std::invocable<std::string_view, std::string_view> auto fn) {
+    wpi::ForEachStructSchema<frc::Quaternion>(fn);
+  }
+};
+
+static_assert(wpi::HasNestedStruct<frc::Rotation3d>);
+
+template <>
+struct WPILIB_DLLEXPORT wpi::Protobuf<frc::Rotation3d> {
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static frc::Rotation3d Unpack(const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg,
+                   const frc::Rotation3d& value);
+};

--- a/wpimath/src/main/native/include/frc/geometry/Transform2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Transform2d.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <wpi/SymbolExports.h>
+#include <wpi/protobuf/Protobuf.h>
+#include <wpi/struct/Struct.h>
 
 #include "frc/geometry/Translation2d.h"
 
@@ -123,5 +125,41 @@ class WPILIB_DLLEXPORT Transform2d {
   Rotation2d m_rotation;
 };
 }  // namespace frc
+
+template <>
+struct wpi::Struct<frc::Transform2d> {
+  static constexpr std::string_view kTypeString = "struct:Transform2d";
+  static constexpr size_t kSize = wpi::Struct<frc::Translation2d>::kSize +
+                                  wpi::Struct<frc::Rotation2d>::kSize;
+  static constexpr std::string_view kSchema =
+      "Translation2d translation;Rotation2d rotation";
+  static frc::Transform2d Unpack(std::span<const uint8_t, kSize> data) {
+    return {wpi::UnpackStruct<frc::Translation2d, 0>(data),
+            wpi::UnpackStruct<frc::Rotation2d, kRotationOff>(data)};
+  }
+  static void Pack(std::span<uint8_t, kSize> data,
+                   const frc::Transform2d& value) {
+    wpi::PackStruct<0>(data, value.Translation());
+    wpi::PackStruct<kRotationOff>(data, value.Rotation());
+  }
+  static void ForEachNested(
+      std::invocable<std::string_view, std::string_view> auto fn) {
+    wpi::ForEachStructSchema<frc::Translation2d>(fn);
+    wpi::ForEachStructSchema<frc::Rotation2d>(fn);
+  }
+
+ private:
+  static constexpr size_t kRotationOff = wpi::Struct<frc::Translation2d>::kSize;
+};
+
+static_assert(wpi::HasNestedStruct<frc::Transform2d>);
+
+template <>
+struct WPILIB_DLLEXPORT wpi::Protobuf<frc::Transform2d> {
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static frc::Transform2d Unpack(const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg,
+                   const frc::Transform2d& value);
+};
 
 #include "frc/geometry/Transform2d.inc"

--- a/wpimath/src/main/native/include/frc/geometry/Transform3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Transform3d.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <wpi/SymbolExports.h>
+#include <wpi/protobuf/Protobuf.h>
+#include <wpi/struct/Struct.h>
 
 #include "frc/geometry/Translation3d.h"
 
@@ -129,3 +131,39 @@ class WPILIB_DLLEXPORT Transform3d {
   Rotation3d m_rotation;
 };
 }  // namespace frc
+
+template <>
+struct wpi::Struct<frc::Transform3d> {
+  static constexpr std::string_view kTypeString = "struct:Transform3d";
+  static constexpr size_t kSize = wpi::Struct<frc::Translation3d>::kSize +
+                                  wpi::Struct<frc::Rotation3d>::kSize;
+  static constexpr std::string_view kSchema =
+      "Translation3d translation;Rotation3d rotation";
+  static frc::Transform3d Unpack(std::span<const uint8_t, kSize> data) {
+    return {wpi::UnpackStruct<frc::Translation3d, 0>(data),
+            wpi::UnpackStruct<frc::Rotation3d, kRotationOff>(data)};
+  }
+  static void Pack(std::span<uint8_t, kSize> data,
+                   const frc::Transform3d& value) {
+    wpi::PackStruct<0>(data, value.Translation());
+    wpi::PackStruct<kRotationOff>(data, value.Rotation());
+  }
+  static void ForEachNested(
+      std::invocable<std::string_view, std::string_view> auto fn) {
+    wpi::ForEachStructSchema<frc::Translation3d>(fn);
+    wpi::ForEachStructSchema<frc::Rotation3d>(fn);
+  }
+
+ private:
+  static constexpr size_t kRotationOff = wpi::Struct<frc::Translation3d>::kSize;
+};
+
+static_assert(wpi::HasNestedStruct<frc::Transform3d>);
+
+template <>
+struct WPILIB_DLLEXPORT wpi::Protobuf<frc::Transform3d> {
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static frc::Transform3d Unpack(const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg,
+                   const frc::Transform3d& value);
+};

--- a/wpimath/src/main/native/include/frc/geometry/Translation2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Translation2d.h
@@ -9,6 +9,8 @@
 
 #include <wpi/SymbolExports.h>
 #include <wpi/json_fwd.h>
+#include <wpi/protobuf/Protobuf.h>
+#include <wpi/struct/Struct.h>
 
 #include "frc/geometry/Rotation2d.h"
 #include "units/length.h"
@@ -197,5 +199,29 @@ WPILIB_DLLEXPORT
 void from_json(const wpi::json& json, Translation2d& state);
 
 }  // namespace frc
+
+template <>
+struct wpi::Struct<frc::Translation2d> {
+  static constexpr std::string_view kTypeString = "struct:Translation2d";
+  static constexpr size_t kSize = 16;
+  static constexpr std::string_view kSchema = "double x;double y";
+  static frc::Translation2d Unpack(std::span<const uint8_t, 16> data) {
+    return {units::meter_t{wpi::UnpackStruct<double, 0>(data)},
+            units::meter_t{wpi::UnpackStruct<double, 8>(data)}};
+  }
+  static void Pack(std::span<uint8_t, 16> data,
+                   const frc::Translation2d& value) {
+    wpi::PackStruct<0>(data, value.X().value());
+    wpi::PackStruct<8>(data, value.Y().value());
+  }
+};
+
+template <>
+struct WPILIB_DLLEXPORT wpi::Protobuf<frc::Translation2d> {
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static frc::Translation2d Unpack(const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg,
+                   const frc::Translation2d& value);
+};
 
 #include "frc/geometry/Translation2d.inc"

--- a/wpimath/src/main/native/include/frc/geometry/Translation3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Translation3d.h
@@ -6,6 +6,8 @@
 
 #include <wpi/SymbolExports.h>
 #include <wpi/json_fwd.h>
+#include <wpi/protobuf/Protobuf.h>
+#include <wpi/struct/Struct.h>
 
 #include "frc/geometry/Rotation3d.h"
 #include "frc/geometry/Translation2d.h"
@@ -182,5 +184,31 @@ WPILIB_DLLEXPORT
 void from_json(const wpi::json& json, Translation3d& state);
 
 }  // namespace frc
+
+template <>
+struct wpi::Struct<frc::Translation3d> {
+  static constexpr std::string_view kTypeString = "struct:Translation3d";
+  static constexpr size_t kSize = 24;
+  static constexpr std::string_view kSchema = "double x;double y;double z";
+  static frc::Translation3d Unpack(std::span<const uint8_t, 24> data) {
+    return {units::meter_t{wpi::UnpackStruct<double, 0>(data)},
+            units::meter_t{wpi::UnpackStruct<double, 8>(data)},
+            units::meter_t{wpi::UnpackStruct<double, 16>(data)}};
+  }
+  static void Pack(std::span<uint8_t, 24> data,
+                   const frc::Translation3d& value) {
+    wpi::PackStruct<0>(data, value.X().value());
+    wpi::PackStruct<8>(data, value.Y().value());
+    wpi::PackStruct<16>(data, value.Z().value());
+  }
+};
+
+template <>
+struct WPILIB_DLLEXPORT wpi::Protobuf<frc::Translation3d> {
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static frc::Translation3d Unpack(const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg,
+                   const frc::Translation3d& value);
+};
 
 #include "frc/geometry/Translation3d.inc"

--- a/wpimath/src/main/native/include/frc/geometry/Twist2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Twist2d.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <wpi/SymbolExports.h>
+#include <wpi/protobuf/Protobuf.h>
+#include <wpi/struct/Struct.h>
 
 #include "units/angle.h"
 #include "units/length.h"
@@ -57,3 +59,28 @@ struct WPILIB_DLLEXPORT Twist2d {
   }
 };
 }  // namespace frc
+
+template <>
+struct wpi::Struct<frc::Twist2d> {
+  static constexpr std::string_view kTypeString = "struct:Twist2d";
+  static constexpr size_t kSize = 24;
+  static constexpr std::string_view kSchema =
+      "double dx;double dy;double dtheta";
+  static frc::Twist2d Unpack(std::span<const uint8_t, 24> data) {
+    return {units::meter_t{wpi::UnpackStruct<double, 0>(data)},
+            units::meter_t{wpi::UnpackStruct<double, 8>(data)},
+            units::radian_t{wpi::UnpackStruct<double, 16>(data)}};
+  }
+  static void Pack(std::span<uint8_t, 24> data, const frc::Twist2d& value) {
+    wpi::PackStruct<0>(data, value.dx.value());
+    wpi::PackStruct<8>(data, value.dy.value());
+    wpi::PackStruct<16>(data, value.dtheta.value());
+  }
+};
+
+template <>
+struct WPILIB_DLLEXPORT wpi::Protobuf<frc::Twist2d> {
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static frc::Twist2d Unpack(const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg, const frc::Twist2d& value);
+};

--- a/wpimath/src/main/native/include/frc/geometry/Twist3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Twist3d.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <wpi/SymbolExports.h>
+#include <wpi/protobuf/Protobuf.h>
+#include <wpi/struct/Struct.h>
 
 #include "frc/geometry/Rotation3d.h"
 #include "units/angle.h"
@@ -77,3 +79,35 @@ struct WPILIB_DLLEXPORT Twist3d {
   }
 };
 }  // namespace frc
+
+template <>
+struct wpi::Struct<frc::Twist3d> {
+  static constexpr std::string_view kTypeString = "struct:Twist3d";
+  static constexpr size_t kSize = 48;
+  static constexpr std::string_view kSchema =
+      "double dx;double dy;double dz;double rx;double ry;double rz";
+  static frc::Twist3d Unpack(std::span<const uint8_t, 48> data) {
+    return {units::meter_t{wpi::UnpackStruct<double, 0>(data)},
+            units::meter_t{wpi::UnpackStruct<double, 8>(data)},
+            units::meter_t{wpi::UnpackStruct<double, 16>(data)},
+            units::radian_t{wpi::UnpackStruct<double, 24>(data)},
+            units::radian_t{wpi::UnpackStruct<double, 32>(data)},
+            units::radian_t{wpi::UnpackStruct<double, 40>(data)}};
+  }
+  static void Pack(std::span<uint8_t, 48> data, const frc::Twist3d& value) {
+    wpi::PackStruct<0>(data, value.dx.value());
+    wpi::PackStruct<8>(data, value.dy.value());
+    wpi::PackStruct<16>(data, value.dz.value());
+    wpi::PackStruct<24>(data, value.rx.value());
+    wpi::PackStruct<32>(data, value.ry.value());
+    wpi::PackStruct<40>(data, value.rz.value());
+  }
+};
+
+template <>
+struct WPILIB_DLLEXPORT wpi::Protobuf<frc::Twist3d> {
+  static constexpr std::string_view kTypeString = "proto:Twist3d";
+  static google::protobuf::Message* New(google::protobuf::Arena* arena);
+  static frc::Twist3d Unpack(const google::protobuf::Message& msg);
+  static void Pack(google::protobuf::Message* msg, const frc::Twist3d& value);
+};

--- a/wpimath/src/main/proto/controller.proto
+++ b/wpimath/src/main/proto/controller.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package wpi.proto;
+
+option java_package = "edu.wpi.first.math.proto";
+
+message ProtobufArmFeedforward {
+  double ks = 1;
+  double kg = 2;
+  double kv = 3;
+  double ka = 4;
+}
+
+message ProtobufDifferentialDriveFeedforward {
+  double kv_linear = 1;
+  double ka_linear = 2;
+  double kv_angular = 3;
+  double ka_angular = 4;
+}
+
+message ProtobufElevatorFeedforward {
+  double ks = 1;
+  double kg = 2;
+  double kv = 3;
+  double ka = 4;
+}
+
+message ProtobufSimpleMotorFeedforward {
+  double ks = 1;
+  double kv = 2;
+  double ka = 3;
+}
+
+message ProtobufDifferentialDriveWheelVoltages {
+  double left = 1;
+  double right = 2;
+}

--- a/wpimath/src/main/proto/geometry2d.proto
+++ b/wpimath/src/main/proto/geometry2d.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package wpi.proto;
+
+option java_package = "edu.wpi.first.math.proto";
+
+message ProtobufTranslation2d {
+  double x = 1;
+  double y = 2;
+}
+
+message ProtobufRotation2d {
+  double value = 1;
+}
+
+message ProtobufPose2d {
+  ProtobufTranslation2d translation = 1;
+  ProtobufRotation2d rotation = 2;
+}
+
+message ProtobufTransform2d {
+  ProtobufTranslation2d translation = 1;
+  ProtobufRotation2d rotation = 2;
+}
+
+message ProtobufTwist2d {
+  double dx = 1;
+  double dy = 2;
+  double dtheta = 3;
+}

--- a/wpimath/src/main/proto/geometry3d.proto
+++ b/wpimath/src/main/proto/geometry3d.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package wpi.proto;
+
+option java_package = "edu.wpi.first.math.proto";
+
+message ProtobufTranslation3d {
+  double x = 1;
+  double y = 2;
+  double z = 3;
+}
+
+message ProtobufQuaternion {
+  double w = 1;
+  double x = 2;
+  double y = 3;
+  double z = 4;
+}
+
+message ProtobufRotation3d {
+  ProtobufQuaternion q = 1;
+}
+
+message ProtobufPose3d {
+  ProtobufTranslation3d translation = 1;
+  ProtobufRotation3d rotation = 2;
+}
+
+message ProtobufTransform3d {
+  ProtobufTranslation3d translation = 1;
+  ProtobufRotation3d rotation = 2;
+}
+
+message ProtobufTwist3d {
+  double dx = 1;
+  double dy = 2;
+  double dz = 3;
+  double rx = 4;
+  double ry = 5;
+  double rz = 6;
+}

--- a/wpimath/src/main/proto/kinematics.proto
+++ b/wpimath/src/main/proto/kinematics.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package wpi.proto;
+
+import "geometry2d.proto";
+
+option java_package = "edu.wpi.first.math.proto";
+
+message ProtobufChassisSpeeds {
+  double vx = 1;
+  double vy = 2;
+  double omega = 3;
+}
+
+message ProtobufDifferentialDriveKinematics {
+  double track_width = 1;
+}
+
+message ProtobufDifferentialDriveWheelSpeeds {
+  double left = 1;
+  double right = 2;
+}
+
+message ProtobufMecanumDriveKinematics {
+  ProtobufTranslation2d front_left = 1;
+  ProtobufTranslation2d front_right = 2;
+  ProtobufTranslation2d rear_left = 3;
+  ProtobufTranslation2d rear_right = 4;
+}
+
+message ProtobufMecanumDriveMotorVoltages {
+  double front_left = 1;
+  double front_right = 2;
+  double rear_left = 3;
+  double rear_right = 4;
+}
+
+message ProtobufMecanumDriveWheelPositions {
+  double front_left = 1;
+  double front_right = 2;
+  double rear_left = 3;
+  double rear_right = 4;
+}
+
+message ProtobufMecanumDriveWheelSpeeds {
+  double front_left = 1;
+  double front_right = 2;
+  double rear_left = 3;
+  double rear_right = 4;
+}
+
+message ProtobufSwerveDriveKinematics {
+  repeated ProtobufTranslation2d modules = 1;
+}
+
+message ProtobufSwerveModulePosition {
+  double distance = 1;
+  ProtobufRotation2d angle = 2;
+}
+
+message ProtobufSwerveModuleState {
+  double speed = 1;
+  ProtobufRotation2d angle = 2;
+}

--- a/wpimath/src/main/proto/plant.proto
+++ b/wpimath/src/main/proto/plant.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package wpi.proto;
+
+option java_package = "edu.wpi.first.math.proto";
+
+message ProtobufDCMotor {
+  double nominal_voltage = 1;
+  double stall_torque = 2;
+  double stall_current = 3;
+  double free_current = 4;
+  double free_speed = 5;
+  double r = 6;
+  double kv = 7;
+  double kt = 8;
+}

--- a/wpimath/src/main/proto/spline.proto
+++ b/wpimath/src/main/proto/spline.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package wpi.proto;
+
+option java_package = "edu.wpi.first.math.proto";
+
+message ProtobufCubicHermiteSpline {
+  repeated double x_initial = 1;
+  repeated double x_final = 2;
+  repeated double y_initial = 3;
+  repeated double y_final = 4;
+}
+
+message ProtobufQuinticHermiteSpline {
+  repeated double x_initial = 1;
+  repeated double x_final = 2;
+  repeated double y_initial = 3;
+  repeated double y_final = 4;
+}

--- a/wpimath/src/main/proto/system.proto
+++ b/wpimath/src/main/proto/system.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package wpi.proto;
+
+import "wpimath.proto";
+
+option java_package = "edu.wpi.first.math.proto";
+
+message ProtobufLinearSystem {
+  uint32 num_states = 1;
+  uint32 num_inputs = 2;
+  uint32 num_outputs = 3;
+  ProtobufMatrix a = 4;
+  ProtobufMatrix b = 5;
+  ProtobufMatrix c = 6;
+  ProtobufMatrix d = 7;
+}

--- a/wpimath/src/main/proto/trajectory.proto
+++ b/wpimath/src/main/proto/trajectory.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package wpi.proto;
+
+import "geometry2d.proto";
+
+option java_package = "edu.wpi.first.math.proto";
+
+message ProtobufTrajectoryState {
+  double time = 1;
+  double velocity = 2;
+  double acceleration = 3;
+  ProtobufPose2d pose = 4;
+  double curvature = 5;
+}
+
+message ProtobufTrajectory {
+  double total_time = 1;
+  repeated ProtobufTrajectoryState states = 2;
+}

--- a/wpimath/src/main/proto/wpimath.proto
+++ b/wpimath/src/main/proto/wpimath.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package wpi.proto;
+
+option java_package = "edu.wpi.first.math.proto";
+
+message ProtobufMatrix {
+  uint32 num_rows = 1;
+  uint32 num_cols = 2;
+  repeated double data = 3;
+}
+
+message ProtobufVector {
+  repeated double rows = 1;
+}

--- a/wpiutil/.styleguide
+++ b/wpiutil/.styleguide
@@ -41,6 +41,7 @@ repoRootNameOverride {
 
 includeOtherLibs {
   ^fmt/
+  ^google/
   ^gmock/
   ^gtest/
 }

--- a/wpiutil/CMakeLists.txt
+++ b/wpiutil/CMakeLists.txt
@@ -34,13 +34,27 @@ if (WITH_JAVA)
   file(GLOB JACKSON_JARS
         ${WPILIB_BINARY_DIR}/wpiutil/thirdparty/jackson/*.jar)
 
-  set(CMAKE_JAVA_INCLUDE_PATH wpiutil.jar ${JACKSON_JARS})
+  if(NOT EXISTS "${WPILIB_BINARY_DIR}/wpiutil/thirdparty/quickbuf/quickbuf-runtime-1.3.2.jar")
+        set(BASE_URL "https://search.maven.org/remotecontent?filepath=")
+        set(JAR_ROOT "${WPILIB_BINARY_DIR}/wpiutil/thirdparty/quickbuf")
+
+        message(STATUS "Downloading Quickbuf jarfile...")
+        file(DOWNLOAD "${BASE_URL}us/hebi/quickbuf/quickbuf-runtime/1.3.2/quickbuf-runtime-1.3.2.jar"
+            "${JAR_ROOT}/quickbuf-runtime-1.3.2.jar")
+
+        message(STATUS "Downloaded.")
+  endif()
+
+  file(GLOB QUICKBUF_JAR
+        ${WPILIB_BINARY_DIR}/wpiutil/thirdparty/quickbuf/*.jar)
+
+  set(CMAKE_JAVA_INCLUDE_PATH wpiutil.jar ${JACKSON_JARS} ${QUICKBUF_JAR})
 
   set(CMAKE_JNI_TARGET true)
 
   file(GLOB_RECURSE JAVA_SOURCES src/main/java/*.java)
 
-  add_jar(wpiutil_jar ${JAVA_SOURCES} INCLUDE_JARS ${JACKSON_JARS} OUTPUT_NAME wpiutil GENERATE_NATIVE_HEADERS wpiutil_jni_headers)
+  add_jar(wpiutil_jar ${JAVA_SOURCES} INCLUDE_JARS ${JACKSON_JARS} ${QUICKBUF_JAR} OUTPUT_NAME wpiutil GENERATE_NATIVE_HEADERS wpiutil_jni_headers)
 
   get_property(WPIUTIL_JAR_FILE TARGET wpiutil_jar PROPERTY JAR_FILE)
   install(FILES ${WPIUTIL_JAR_FILE} DESTINATION "${java_lib_dest}")
@@ -98,7 +112,7 @@ if (MSVC)
     target_compile_definitions(wpiutil PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 wpilib_target_warnings(wpiutil)
-target_link_libraries(wpiutil Threads::Threads ${CMAKE_DL_LIBS})
+target_link_libraries(wpiutil protobuf::libprotobuf Threads::Threads ${CMAKE_DL_LIBS})
 
 if (ATOMIC)
     target_link_libraries(wpiutil ${ATOMIC})

--- a/wpiutil/build.gradle
+++ b/wpiutil/build.gradle
@@ -294,6 +294,7 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-annotations:2.15.2"
     api "com.fasterxml.jackson.core:jackson-core:2.15.2"
     api "com.fasterxml.jackson.core:jackson-databind:2.15.2"
+    api 'us.hebi.quickbuf:quickbuf-runtime:1.3.2'
 
     printlogImplementation sourceSets.main.output
 }

--- a/wpiutil/doc/struct.adoc
+++ b/wpiutil/doc/struct.adoc
@@ -1,0 +1,311 @@
+= WPILib Packed Struct Serialization Specification, Version 1.0
+WPILib Developers <wpilib@wpi.edu>
+Revision 1.0 (0x0100), 6/8/2023
+:toc:
+:toc-placement: preamble
+:sectanchors:
+
+A simple format and schema for serialization of packed fixed size structured data.
+
+[[motivation]]
+== Motivation
+
+Schema-based serialization formats such as Protobuf and Flatbuffers are extremely flexible and can handle data type evolution, complex nested data structures, variable size / repeated data, optional fields, etc. However, this flexibility comes at a cost in both serialized data size and processing overhead. Many simple data structures, such as screen coordinates or robot poses, are fixed in size and can be stored much more compactly and serialized/deserialized much more quickly, especially on embedded or real-time platforms.
+
+Simply storing a C-style packed structure is very compact and fast, but information about the layout of the structure and the meaning of each member must be separately communicated for introspection by other tools such as interactive dashboards for data analysis of individual structure members. The motivation for this standard layout and schema is to provide a standardized means to communicate this information and enable dynamic decoding.
+
+Python's struct module uses a character-based approach to describe data layout of structures, but has no provisions for naming each member to communicate intent/meaning.
+
+[[references]]
+== References
+
+[[c-struct-declaration]]
+* Struct declaration, https://en.cppreference.com/w/c/language/struct
+
+[[definitions]]
+== Definitions
+
+[[schema]]
+== Schema
+
+The schema is a text-based format with similar syntax to the list of variable declarations in a C structure. The C syntax is flexible, easy to parse, and matches the intent of specifying a fixed size structure.
+
+Each member of the struct is defined by a single declaration. Each declaration is either a standard declaration or a bit-field declaration. Declarations are separated by semicolons. The last declaration may optionally have a trailing semicolon. Empty declarations (e.g. two semicolons back-to-back or separated by only whitespace) are allowed but are ignored. Unlike C structures, every declaration must be separated by a semicolon; commas cannot be used to declare multiple members with the same type. Declarations may also start and end with whitespace.
+
+[[variable]]
+=== Standard Declaration
+
+Standard declarations declare a member of a certain type or a fixed-size array of that type. The structure of a standard declaration is:
+
+* optional enum specification (integer data types only)
+* optional whitespace
+* type name
+* whitespace
+* identifier name
+* optional array size, consisting of:
+  * optional whitespace
+  * `[`
+  * optional whitespace
+  * size of array
+  * optional whitespace
+  * `]`
+
+The type name may be one of these:
+
+[cols="1,1,3", options="header"]
+|===
+|Type Name|Description|Payload Data Contents
+|`bool`|boolean|single byte (0=false, 1=true)
+|`char`|character|single byte (assumed UTF-8)
+|`int8`|integer|1-byte (8-bit) signed value
+|`int16`|integer|2-byte (16-bit) signed value
+|`int32`|integer|4-byte (32-bit) signed value
+|`int64`|integer|8-byte (64-bit) signed value
+|`uint8`|unsigned integer|1-byte (8-bit) unsigned value
+|`uint16`|unsigned integer|2-byte (16-bit) unsigned value
+|`uint32`|unsigned integer|4-byte (32-bit) unsigned value
+|`uint64`|unsigned integer|8-byte (64-bit) unsigned value
+|`float` or `float32`|float|4-byte (32-bit) IEEE-754 value
+|`double` or `float64`|double|8-byte (64-bit) IEEE-754 value
+|===
+
+If it is not one of the above, the type name must be the name of another struct.
+
+Examples of valid standard declarations:
+
+* `bool value` (boolean value, 1 byte)
+* `double arr[4]` (array of 4 doubles, 32 bytes total)
+* `enum {a=1, b=2} int8 val` (enumerated value, 1 byte)
+
+[[enum]]
+==== Enum Specification
+
+Integer declarations may have an enum specification to provide meaning to specific values. Values that are not specified may be communicated, but have no specific defined meaning. The structure of an enum specification is:
+
+* optional `enum`
+* optional whitespace
+* `{`
+* zero or more enum values, consisting of:
+  * optional whitespace
+  * identifier
+  * optional whitespace
+  * `=`
+  * optional whitespace
+  * integer value
+  * optional whitespace
+  * comma (optional for last value)
+* optional whitespace
+* `}`
+
+Examples of valid enum specifications:
+
+* `enum{}`
+* `enum { a = 1 }`
+* `enum{a=1,b=2,}`
+* `{a=1}`
+
+Examples of invalid enum specifications:
+
+* `enum` (no `{}`)
+* `enum{=2}` (missing identifier)
+* `enum{a=1,b,c}` (missing values)
+
+[[]]
+=== Bit-field Declaration
+
+Bit-field declarations declare a member with an explicit width in bits. The structure of a bit-field declaration is:
+
+* optional enum specification (integer data types only)
+* optional whitespace
+* type name; must be boolean or one of the integer data types
+* whitespace
+* identifier name
+* optional whitespace
+* colon (`:`)
+* optional whitespace
+* integer number of bits; minimum 1; maximum 1 for boolean types; for integer types, maximum is the width of the type (e.g. 32 for int32)
+
+As with non-bit-field integer variable declarations, an enum can be specified for integer bit-fields (e.g. `enum {a=1, b=2} uint32 value : 2`).
+
+It is not possible to have an array of bit-fields.
+
+Examples of valid bit-field declarations:
+
+* `bool value : 1`
+* `enum{a=1,b=2}int8 value:2`
+
+Examples of invalid bit-field declarations:
+
+* `double val:2` (must be integer or boolean)
+* `int32 val[2]:2` (cannot be array)
+* `bool val:3` (bool must be 1 bit)
+* `int16 val:17` (bit field larger than storage size)
+
+[[layout]]
+== Data Layout
+
+Members are stored in the same order they appear in the schema. Individual members are stored in little-endian order. Members are not aligned to any particular boundary; no byte-level padding is present in the data.
+
+[source]
+----
+bool b;
+int16 i;
+----
+
+results in a 3-byte encoding:
+
+`bbbbbbbb iiiiiiii iiiiiiii`
+
+where the first `iiiiiiii` is the least significant byte of `i`.
+
+[[layout-array]]
+=== Array Data Layout
+
+For array members, the individual items of the array are stored consecutively with no padding between each item.
+
+[source]
+----
+int16 i[2];
+----
+
+results in a 4-byte encoding:
+
+`i0i0i0i0 i0i0i0i0 i1i1i1i1 i1i1i1i1`
+
+where `i0` is the first element of the array, `i1` is the second element.
+
+[[layout-nested-structure]]
+
+Nested structures also have no surrounding padding.
+
+Given the Inner schema
+
+[source]
+----
+int16 i;
+int8 x;
+----
+
+and an outer schema of
+
+[source]
+----
+char c;
+Inner s;
+bool b;
+----
+
+results in a 5-byte encoding:
+
+`cccccccc iiiiiiii iiiiiiii xxxxxxxx bbbbbbbb`
+
+[[layout-bit-field]]
+=== Bit-Field Data Layout
+
+Multiple adjacant bit-fields of the same integer type width are packed together to fit in the minimum number of multiples of that type. The bit-fields are packed, starting from the least significant bit, in the order they appear in the schema. Individual bit-fields must not span across multiple underlying types; if a bit-field is larger than the remaining space in the data type, a new element of that type is started and the bit-field starts from the least significant bit of the new element. Unused bits should be set to 0 during serialization and must be ignored during deserialization.
+
+Boolean bit-fields are always a single bit wide. The underlying data type is by default uint8, but if a boolean bit-field immediately follows a bit-field of another integer type (and fits), it is packed into that type.
+
+[source]
+----
+int8 a:4;
+int16 b:4;
+----
+
+results in a 3-byte encoding:
+
+`0000aaaa 0000bbbb 00000000`
+
+as the integer type widths are different, even though the bits would fit.
+
+[source]
+----
+int16 a:4;
+uint16 b:5;
+bool c:1;
+int16 d:7;
+----
+
+results in a 4-byte encoding:
+
+`bbbbaaaa 000000cb 0ddddddd 00000000`
+
+As `c` is packed into the preceding int16, and `d` is too large to fit in the remaining bits of the first type.
+
+[source]
+----
+uint8 a:4;
+int8 b:2;
+bool c:1;
+int16 d:1;
+----
+
+results in a 3-byte encoding:
+
+`0cbbaaaa 0000000d 00000000`
+
+as `d` is int16, versus the `int8` of the previous values.
+
+[source]
+----
+bool a:1;
+bool b:1;
+int8 c:2;
+----
+
+results in a 1-byte encoding:
+
+`0000ccba`
+
+as `c` is an int8.
+
+[source]
+----
+bool a:1;
+bool b:1;
+int16 c:2;
+----
+
+results in a 3-byte encoding:
+
+`000000ba 000000cc 00000000`
+
+as `c` is an int16.
+
+Bit-fields do not "look inside" of nested structures. Given Inner
+
+[source]
+----
+int8 a:1;
+----
+
+and outer
+
+[source]
+----
+int8 b:1;
+Outer s;
+int8 c:1;
+----
+
+the result is a 3-byte encoding:
+
+`0000000b 0000000a 0000000c`
+
+[[layout-character-arrays]]
+=== Character Array (String) Data Layout
+
+Character arrays, as with other arrays, must be fixed length. The text they contain should be UTF-8. If a string is shorter than the length of the character array, the string starts at the first byte of the array, and any unused bytes at the end of the array must be filled with 0.
+
+[source]
+----
+char s[4];
+----
+
+with a string of "a" results in:
+
+`01100001 00000000 00000000 00000000`
+
+with a string of "abcd" results in:
+
+`01100001 01100010 01100011 01100100`

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/DataLogJNI.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/DataLogJNI.java
@@ -18,6 +18,11 @@ public class DataLogJNI extends WPIUtilJNI {
 
   static native void resume(long impl);
 
+  static native void addSchema(long impl, String name, String type, byte[] schema, long timestamp);
+
+  static native void addSchemaString(
+      long impl, String name, String type, String schema, long timestamp);
+
   static native int start(long impl, String name, String type, String metadata, long timestamp);
 
   static native void finish(long impl, int entry, long timestamp);

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/ProtobufLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/ProtobufLogEntry.java
@@ -1,0 +1,117 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.datalog;
+
+import edu.wpi.first.util.protobuf.Protobuf;
+import edu.wpi.first.util.protobuf.ProtobufBuffer;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import us.hebi.quickbuf.ProtoMessage;
+
+/**
+ * Log protobuf-encoded values.
+ *
+ * @param <T> value class
+ */
+public final class ProtobufLogEntry<T> extends DataLogEntry {
+  private ProtobufLogEntry(
+      DataLog log, String name, Protobuf<T, ?> proto, String metadata, long timestamp) {
+    super(log, name, proto.getTypeString(), metadata, timestamp);
+    m_buf = ProtobufBuffer.create(proto);
+    log.addSchema(proto, timestamp);
+  }
+
+  /**
+   * Creates a protobuf-encoded log entry.
+   *
+   * @param <T> value class (inferred from proto)
+   * @param <MessageType> protobuf message type (inferred from proto)
+   * @param log datalog
+   * @param name name of the entry
+   * @param proto protobuf serialization implementation
+   * @param metadata metadata
+   * @param timestamp entry creation timestamp (0=now)
+   * @return ProtobufLogEntry
+   */
+  public static <T, MessageType extends ProtoMessage<?>> ProtobufLogEntry<T> create(
+      DataLog log, String name, Protobuf<T, MessageType> proto, String metadata, long timestamp) {
+    return new ProtobufLogEntry<T>(log, name, proto, metadata, timestamp);
+  }
+
+  /**
+   * Creates a protobuf-encoded log entry.
+   *
+   * @param <T> value class (inferred from proto)
+   * @param <MessageType> protobuf message type (inferred from proto)
+   * @param log datalog
+   * @param name name of the entry
+   * @param proto protobuf serialization implementation
+   * @param metadata metadata
+   * @return ProtobufLogEntry
+   */
+  public static <T, MessageType extends ProtoMessage<?>> ProtobufLogEntry<T> create(
+      DataLog log, String name, Protobuf<T, MessageType> proto, String metadata) {
+    return create(log, name, proto, metadata, 0);
+  }
+
+  /**
+   * Creates a protobuf-encoded log entry.
+   *
+   * @param <T> value class (inferred from proto)
+   * @param <MessageType> protobuf message type (inferred from proto)
+   * @param log datalog
+   * @param name name of the entry
+   * @param proto protobuf serialization implementation
+   * @param timestamp entry creation timestamp (0=now)
+   * @return ProtobufLogEntry
+   */
+  public static <T, MessageType extends ProtoMessage<?>> ProtobufLogEntry<T> create(
+      DataLog log, String name, Protobuf<T, MessageType> proto, long timestamp) {
+    return create(log, name, proto, "", timestamp);
+  }
+
+  /**
+   * Creates a protobuf-encoded log entry.
+   *
+   * @param <T> value class (inferred from proto)
+   * @param <MessageType> protobuf message type (inferred from proto)
+   * @param log datalog
+   * @param name name of the entry
+   * @param proto protobuf serialization implementation
+   * @return ProtobufLogEntry
+   */
+  public static <T, MessageType extends ProtoMessage<?>> ProtobufLogEntry<T> create(
+      DataLog log, String name, Protobuf<T, MessageType> proto) {
+    return create(log, name, proto, 0);
+  }
+
+  /**
+   * Appends a record to the log.
+   *
+   * @param value Value to record
+   * @param timestamp Time stamp (0 to indicate now)
+   */
+  public void append(T value, long timestamp) {
+    try {
+      synchronized (m_buf) {
+        ByteBuffer bb = m_buf.write(value);
+        m_log.appendRaw(m_entry, bb, 0, bb.position(), timestamp);
+      }
+    } catch (IOException e) {
+      // ignore
+    }
+  }
+
+  /**
+   * Appends a record to the log.
+   *
+   * @param value Value to record
+   */
+  public void append(T value) {
+    append(value, 0);
+  }
+
+  private final ProtobufBuffer<T, ?> m_buf;
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/StructArrayLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/StructArrayLogEntry.java
@@ -1,0 +1,140 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.datalog;
+
+import edu.wpi.first.util.struct.Struct;
+import edu.wpi.first.util.struct.StructBuffer;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+
+/**
+ * Log struct-encoded array values.
+ *
+ * @param <T> value class
+ */
+public final class StructArrayLogEntry<T> extends DataLogEntry {
+  private StructArrayLogEntry(
+      DataLog log, String name, Struct<T> struct, String metadata, long timestamp) {
+    super(log, name, struct.getTypeString() + "[]", metadata, timestamp);
+    m_buf = StructBuffer.create(struct);
+    log.addSchema(struct, timestamp);
+  }
+
+  /**
+   * Creates a struct-encoded array log entry.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param log datalog
+   * @param name name of the entry
+   * @param struct struct serialization implementation
+   * @param metadata metadata
+   * @param timestamp entry creation timestamp (0=now)
+   * @return StructArrayLogEntry
+   */
+  public static <T> StructArrayLogEntry<T> create(
+      DataLog log, String name, Struct<T> struct, String metadata, long timestamp) {
+    return new StructArrayLogEntry<T>(log, name, struct, metadata, timestamp);
+  }
+
+  /**
+   * Creates a struct-encoded array log entry.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param log datalog
+   * @param name name of the entry
+   * @param struct struct serialization implementation
+   * @param metadata metadata
+   * @return StructArrayLogEntry
+   */
+  public static <T> StructArrayLogEntry<T> create(
+      DataLog log, String name, Struct<T> struct, String metadata) {
+    return create(log, name, struct, metadata, 0);
+  }
+
+  /**
+   * Creates a struct-encoded array log entry.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param log datalog
+   * @param name name of the entry
+   * @param struct struct serialization implementation
+   * @param timestamp entry creation timestamp (0=now)
+   * @return StructArrayLogEntry
+   */
+  public static <T> StructArrayLogEntry<T> create(
+      DataLog log, String name, Struct<T> struct, long timestamp) {
+    return create(log, name, struct, "", timestamp);
+  }
+
+  /**
+   * Creates a struct-encoded array log entry.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param log datalog
+   * @param name name of the entry
+   * @param struct struct serialization implementation
+   * @return StructArrayLogEntry
+   */
+  public static <T> StructArrayLogEntry<T> create(DataLog log, String name, Struct<T> struct) {
+    return create(log, name, struct, 0);
+  }
+
+  /**
+   * Ensures sufficient buffer space is available for the given number of elements.
+   *
+   * @param nelem number of elements
+   */
+  public void reserve(int nelem) {
+    synchronized (m_buf) {
+      m_buf.reserve(nelem);
+    }
+  }
+
+  /**
+   * Appends a record to the log.
+   *
+   * @param value Value to record
+   * @param timestamp Time stamp (0 to indicate now)
+   */
+  public void append(T[] value, long timestamp) {
+    synchronized (this) {
+      ByteBuffer bb = m_buf.writeArray(value);
+      m_log.appendRaw(m_entry, bb, 0, bb.position(), timestamp);
+    }
+  }
+
+  /**
+   * Appends a record to the log.
+   *
+   * @param value Value to record
+   */
+  public void append(T[] value) {
+    append(value, 0);
+  }
+
+  /**
+   * Appends a record to the log.
+   *
+   * @param value Value to record
+   * @param timestamp Time stamp (0 to indicate now)
+   */
+  public void append(Collection<T> value, long timestamp) {
+    synchronized (m_buf) {
+      ByteBuffer bb = m_buf.writeArray(value);
+      m_log.appendRaw(m_entry, bb, 0, bb.position(), timestamp);
+    }
+  }
+
+  /**
+   * Appends a record to the log.
+   *
+   * @param value Value to record
+   */
+  public void append(Collection<T> value) {
+    append(value, 0);
+  }
+
+  private final StructBuffer<T> m_buf;
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/datalog/StructLogEntry.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/datalog/StructLogEntry.java
@@ -1,0 +1,106 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.datalog;
+
+import edu.wpi.first.util.struct.Struct;
+import edu.wpi.first.util.struct.StructBuffer;
+import java.nio.ByteBuffer;
+
+/**
+ * Log struct-encoded values.
+ *
+ * @param <T> value class
+ */
+public final class StructLogEntry<T> extends DataLogEntry {
+  private StructLogEntry(
+      DataLog log, String name, Struct<T> struct, String metadata, long timestamp) {
+    super(log, name, struct.getTypeString(), metadata, timestamp);
+    m_buf = StructBuffer.create(struct);
+    log.addSchema(struct, timestamp);
+  }
+
+  /**
+   * Creates a struct-encoded log entry.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param log datalog
+   * @param name name of the entry
+   * @param struct struct serialization implementation
+   * @param metadata metadata
+   * @param timestamp entry creation timestamp (0=now)
+   * @return StructLogEntry
+   */
+  public static <T> StructLogEntry<T> create(
+      DataLog log, String name, Struct<T> struct, String metadata, long timestamp) {
+    return new StructLogEntry<T>(log, name, struct, metadata, timestamp);
+  }
+
+  /**
+   * Creates a struct-encoded log entry.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param log datalog
+   * @param name name of the entry
+   * @param struct struct serialization implementation
+   * @param metadata metadata
+   * @return StructLogEntry
+   */
+  public static <T> StructLogEntry<T> create(
+      DataLog log, String name, Struct<T> struct, String metadata) {
+    return create(log, name, struct, metadata, 0);
+  }
+
+  /**
+   * Creates a struct-encoded log entry.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param log datalog
+   * @param name name of the entry
+   * @param struct struct serialization implementation
+   * @param timestamp entry creation timestamp (0=now)
+   * @return StructLogEntry
+   */
+  public static <T> StructLogEntry<T> create(
+      DataLog log, String name, Struct<T> struct, long timestamp) {
+    return create(log, name, struct, "", timestamp);
+  }
+
+  /**
+   * Creates a struct-encoded log entry.
+   *
+   * @param <T> value class (inferred from struct)
+   * @param log datalog
+   * @param name name of the entry
+   * @param struct struct serialization implementation
+   * @return StructLogEntry
+   */
+  public static <T> StructLogEntry<T> create(DataLog log, String name, Struct<T> struct) {
+    return create(log, name, struct, 0);
+  }
+
+  /**
+   * Appends a record to the log.
+   *
+   * @param value Value to record
+   * @param timestamp Time stamp (0 to indicate now)
+   */
+  public void append(T value, long timestamp) {
+    synchronized (m_buf) {
+      ByteBuffer bb = m_buf.write(value);
+      m_log.appendRaw(m_entry, bb, 0, bb.position(), timestamp);
+    }
+  }
+
+  /**
+   * Appends a record to the log.
+   *
+   * @param value Value to record
+   */
+  public void append(T value) {
+    append(value, 0);
+  }
+
+  private final StructBuffer<T> m_buf;
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/protobuf/Protobuf.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/protobuf/Protobuf.java
@@ -1,0 +1,121 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.protobuf;
+
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+import us.hebi.quickbuf.Descriptors.Descriptor;
+import us.hebi.quickbuf.Descriptors.FileDescriptor;
+import us.hebi.quickbuf.ProtoMessage;
+
+/**
+ * Interface for Protobuf serialization.
+ *
+ * <p>This is designed for serialization of more complex data structures including forward/backwards
+ * compatibility and repeated/nested/variable length members, etc. Serialization and deserialization
+ * code is auto-generated from .proto interface descriptions (the MessageType generic parameter).
+ *
+ * <p>Idiomatically, classes that support protobuf serialization should provide a static final
+ * member named "proto" that provides an instance of an implementation of this interface.
+ *
+ * @param <T> object type
+ * @param <MessageType> protobuf message type
+ */
+public interface Protobuf<T, MessageType extends ProtoMessage<?>> {
+  /**
+   * Gets the Class object for the stored value.
+   *
+   * @return Class
+   */
+  Class<T> getTypeClass();
+
+  /**
+   * Gets the type string (e.g. for NetworkTables). This should be globally unique and start with
+   * "proto:".
+   *
+   * @return type string
+   */
+  default String getTypeString() {
+    return "proto:" + getDescriptor().getFullName();
+  }
+
+  /**
+   * Gets the protobuf descriptor.
+   *
+   * @return descriptor
+   */
+  Descriptor getDescriptor();
+
+  /**
+   * Gets the list of protobuf types referenced by this protobuf.
+   *
+   * @return list of protobuf types
+   */
+  default Protobuf<?, ?>[] getNested() {
+    return new Protobuf<?, ?>[] {};
+  }
+
+  /**
+   * Creates protobuf message.
+   *
+   * @return protobuf message
+   */
+  MessageType createMessage();
+
+  /**
+   * Deserializes an object from a protobuf message.
+   *
+   * @param msg protobuf message
+   * @return New object
+   */
+  T unpack(MessageType msg);
+
+  /**
+   * Copies the object contents into a protobuf message. Implementations should call either
+   * msg.setMember(member) or member.copyToProto(msg.getMutableMember()) for each member.
+   *
+   * @param msg protobuf message
+   * @param value object to serialize
+   */
+  void pack(MessageType msg, T value);
+
+  /**
+   * Updates the object contents from a protobuf message. Implementations should call
+   * msg.getMember(member), MemberClass.makeFromProto(msg.getMember()), or
+   * member.updateFromProto(msg.getMember()) for each member.
+   *
+   * <p>Immutable classes cannot and should not implement this function. The default implementation
+   * throws UnsupportedOperationException.
+   *
+   * @param out object to update
+   * @param msg protobuf message
+   * @throws UnsupportedOperationException if the object is immutable
+   */
+  default void unpackInto(T out, MessageType msg) {
+    throw new UnsupportedOperationException("object does not support unpackInto");
+  }
+
+  /**
+   * Loops over all protobuf descriptors including nested/referenced descriptors.
+   *
+   * @param exists function that returns false if fn should be called for the given type string
+   * @param fn function to call for each descriptor
+   */
+  default void forEachDescriptor(Predicate<String> exists, BiConsumer<String, byte[]> fn) {
+    forEachDescriptorImpl(getDescriptor().getFile(), exists, fn);
+  }
+
+  private static void forEachDescriptorImpl(
+      FileDescriptor desc, Predicate<String> exists, BiConsumer<String, byte[]> fn) {
+    String name = "proto:" + desc.getFullName();
+    if (exists.test(name)) {
+      return;
+    }
+    for (FileDescriptor dep : desc.getDependencies()) {
+      forEachDescriptorImpl(dep, exists, fn);
+    }
+    fn.accept(name, desc.toProtoBytes());
+  }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/protobuf/ProtobufBuffer.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/protobuf/ProtobufBuffer.java
@@ -1,0 +1,164 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.protobuf;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import us.hebi.quickbuf.ProtoMessage;
+import us.hebi.quickbuf.ProtoSink;
+import us.hebi.quickbuf.ProtoSource;
+
+/**
+ * Reusable buffer for serialization/deserialization to/from a protobuf.
+ *
+ * @param <T> object type
+ * @param <MessageType> protobuf message type
+ */
+public final class ProtobufBuffer<T, MessageType extends ProtoMessage<?>> {
+  private ProtobufBuffer(Protobuf<T, MessageType> proto) {
+    m_buf = ByteBuffer.allocateDirect(1024);
+    m_sink = ProtoSink.newDirectSink();
+    m_sink.setOutput(m_buf);
+    m_source = ProtoSource.newDirectSource();
+    m_msg = proto.createMessage();
+    m_proto = proto;
+  }
+
+  public static <T, MessageType extends ProtoMessage<?>> ProtobufBuffer<T, MessageType> create(
+      Protobuf<T, MessageType> proto) {
+    return new ProtobufBuffer<T, MessageType>(proto);
+  }
+
+  /**
+   * Gets the protobuf object of the stored type.
+   *
+   * @return protobuf object
+   */
+  public Protobuf<T, MessageType> getProto() {
+    return m_proto;
+  }
+
+  /**
+   * Gets the type string.
+   *
+   * @return type string
+   */
+  public String getTypeString() {
+    return m_proto.getTypeString();
+  }
+
+  /**
+   * Serializes a value to a ByteBuffer. The returned ByteBuffer is a direct byte buffer with the
+   * position set to the end of the serialized data.
+   *
+   * @param value value
+   * @return byte buffer
+   * @throws IOException if serialization failed
+   */
+  public ByteBuffer write(T value) throws IOException {
+    m_msg.clearQuick();
+    m_proto.pack(m_msg, value);
+    int size = m_msg.getSerializedSize();
+    if (size < m_buf.capacity()) {
+      m_buf = ByteBuffer.allocateDirect(size * 2);
+      m_sink.setOutput(m_buf);
+    }
+    m_sink.reset();
+    m_msg.writeTo(m_sink);
+    m_buf.position(m_sink.getTotalBytesWritten());
+    return m_buf;
+  }
+
+  /**
+   * Deserializes a value from a byte array, creating a new object.
+   *
+   * @param buf byte array
+   * @param start starting location within byte array
+   * @param len length of serialized data
+   * @return new object
+   * @throws IOException if deserialization failed
+   */
+  public T read(byte[] buf, int start, int len) throws IOException {
+    m_msg.clearQuick();
+    m_source.setInput(buf, start, len);
+    m_msg.mergeFrom(m_source);
+    return m_proto.unpack(m_msg);
+  }
+
+  /**
+   * Deserializes a value from a byte array, creating a new object.
+   *
+   * @param buf byte array
+   * @return new object
+   * @throws IOException if deserialization failed
+   */
+  public T read(byte[] buf) throws IOException {
+    return read(buf, 0, buf.length);
+  }
+
+  /**
+   * Deserializes a value from a ByteBuffer, creating a new object.
+   *
+   * @param buf byte buffer
+   * @return new object
+   * @throws IOException if deserialization failed
+   */
+  public T read(ByteBuffer buf) throws IOException {
+    m_msg.clearQuick();
+    m_source.setInput(buf);
+    m_msg.mergeFrom(m_source);
+    return m_proto.unpack(m_msg);
+  }
+
+  /**
+   * Deserializes a value from a byte array into a mutable object.
+   *
+   * @param out object (will be updated with deserialized contents)
+   * @param buf byte array
+   * @param start starting location within byte array
+   * @param len length of serialized data
+   * @throws IOException if deserialization failed
+   * @throws UnsupportedOperationException if the object is immutable
+   */
+  public void readInto(T out, byte[] buf, int start, int len) throws IOException {
+    m_msg.clearQuick();
+    m_source.setInput(buf, start, len);
+    m_msg.mergeFrom(m_source);
+    m_proto.unpackInto(out, m_msg);
+  }
+
+  /**
+   * Deserializes a value from a byte array into a mutable object.
+   *
+   * @param out object (will be updated with deserialized contents)
+   * @param buf byte array
+   * @throws IOException if deserialization failed
+   * @throws UnsupportedOperationException if the object is immutable
+   */
+  public void readInto(T out, byte[] buf) throws IOException {
+    readInto(out, buf, 0, buf.length);
+  }
+
+  /**
+   * Deserializes a value from a ByteBuffer into a mutable object.
+   *
+   * @param out object (will be updated with deserialized contents)
+   * @param buf byte buffer
+   * @throws IOException if deserialization failed
+   * @throws UnsupportedOperationException if the object is immutable
+   */
+  public void readInto(T out, ByteBuffer buf) throws IOException {
+    m_msg.clearQuick();
+    m_source.setInput(buf);
+    m_msg.mergeFrom(m_source);
+    m_proto.unpackInto(out, m_msg);
+  }
+
+  private ByteBuffer m_buf;
+  private final ProtoSink m_sink;
+  private final ProtoSource m_source;
+  private final MessageType m_msg;
+  private final Protobuf<T, MessageType> m_proto;
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/BadSchemaException.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/BadSchemaException.java
@@ -1,0 +1,43 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct;
+
+public class BadSchemaException extends Exception {
+  private final String m_field;
+
+  public BadSchemaException(String s) {
+    super(s);
+    m_field = "";
+  }
+
+  public BadSchemaException(String message, Throwable cause) {
+    super(message, cause);
+    m_field = "";
+  }
+
+  public BadSchemaException(Throwable cause) {
+    super(cause);
+    m_field = "";
+  }
+
+  public BadSchemaException(String field, String s) {
+    super(s);
+    m_field = field;
+  }
+
+  public BadSchemaException(String field, String message, Throwable cause) {
+    super(message, cause);
+    m_field = field;
+  }
+
+  public String getField() {
+    return m_field;
+  }
+
+  @Override
+  public String toString() {
+    return m_field.isEmpty() ? getMessage() : "field " + m_field + ": " + getMessage();
+  }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/DynamicStruct.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/DynamicStruct.java
@@ -1,0 +1,632 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct;
+
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.ReadOnlyBufferException;
+import java.nio.charset.StandardCharsets;
+
+/** Dynamic (run-time) access to a serialized raw struct. */
+public final class DynamicStruct {
+  private DynamicStruct(StructDescriptor desc, ByteBuffer data) {
+    m_desc = desc;
+    m_data = data.order(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  /**
+   * Constructs a new dynamic struct object with internal storage. The descriptor must be valid. The
+   * internal storage is allocated using ByteBuffer.allocate().
+   *
+   * @param desc struct descriptor
+   * @return dynamic struct object
+   * @throws IllegalStateException if struct descriptor is invalid
+   */
+  public static DynamicStruct allocate(StructDescriptor desc) {
+    return new DynamicStruct(desc, ByteBuffer.allocate(desc.getSize()));
+  }
+
+  /**
+   * Constructs a new dynamic struct object with internal storage. The descriptor must be valid. The
+   * internal storage is allocated using ByteBuffer.allocateDirect().
+   *
+   * @param desc struct descriptor
+   * @return dynamic struct object
+   * @throws IllegalStateException if struct descriptor is invalid
+   */
+  public static DynamicStruct allocateDirect(StructDescriptor desc) {
+    return new DynamicStruct(desc, ByteBuffer.allocateDirect(desc.getSize()));
+  }
+
+  /**
+   * Constructs a new dynamic struct object. Note: the passed data buffer is not copied.
+   * Modifications to the passed buffer will be reflected in the struct and vice-versa.
+   *
+   * @param desc struct descriptor
+   * @param data byte buffer containing serialized data starting at current position
+   * @return dynamic struct object
+   */
+  public static DynamicStruct wrap(StructDescriptor desc, ByteBuffer data) {
+    return new DynamicStruct(desc, data.slice());
+  }
+
+  /**
+   * Gets the struct descriptor.
+   *
+   * @return struct descriptor
+   */
+  public StructDescriptor getDescriptor() {
+    return m_desc;
+  }
+
+  /**
+   * Gets the serialized backing data buffer.
+   *
+   * @return data buffer
+   */
+  public ByteBuffer getBuffer() {
+    return m_data.duplicate().position(0);
+  }
+
+  /**
+   * Overwrites the entire serialized struct by copying data from a byte array.
+   *
+   * @param data replacement data for the struct
+   * @throws BufferUnderflowException if data is smaller than the struct size
+   * @throws ReadOnlyBufferException if the underlying buffer is read-only
+   * @throws IllegalStateException if struct descriptor is invalid
+   */
+  public void setData(byte[] data) {
+    if (data.length < m_desc.getSize()) {
+      throw new BufferUnderflowException();
+    }
+    m_data.position(0).put(data);
+  }
+
+  /**
+   * Overwrites the entire serialized struct by copying data from a byte buffer.
+   *
+   * @param data replacement data for the struct; copy starts from current position
+   * @throws BufferUnderflowException if remaining data is smaller than the struct size
+   * @throws ReadOnlyBufferException if the underlying buffer is read-only
+   * @throws IllegalStateException if struct descriptor is invalid
+   */
+  public void setData(ByteBuffer data) {
+    if (data.remaining() < m_desc.getSize()) {
+      throw new BufferUnderflowException();
+    }
+    int oldLimit = data.limit();
+    m_data.position(0).put(data.limit(m_desc.getSize()));
+    data.limit(oldLimit);
+  }
+
+  /**
+   * Gets a struct field descriptor by name.
+   *
+   * @param name field name
+   * @return field descriptor, or null if no field with that name exists
+   */
+  public StructFieldDescriptor findField(String name) {
+    return m_desc.findFieldByName(name);
+  }
+
+  /**
+   * Gets the value of a boolean field.
+   *
+   * @param field field descriptor
+   * @param arrIndex array index (must be less than field array size)
+   * @return boolean field value
+   * @throws UnsupportedOperationException if field is not bool type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ArrayIndexOutOfBoundsException if array index is out of bounds
+   */
+  public boolean getBoolField(StructFieldDescriptor field, int arrIndex) {
+    if (field.getType() != StructFieldType.kBool) {
+      throw new UnsupportedOperationException("field is not bool type");
+    }
+    return getFieldImpl(field, arrIndex) != 0;
+  }
+
+  /**
+   * Gets the value of a boolean field.
+   *
+   * @param field field descriptor
+   * @return boolean field value
+   * @throws UnsupportedOperationException if field is not bool type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   */
+  public boolean getBoolField(StructFieldDescriptor field) {
+    return getBoolField(field, 0);
+  }
+
+  /**
+   * Sets the value of a boolean field.
+   *
+   * @param field field descriptor
+   * @param value boolean value
+   * @param arrIndex array index (must be less than field array size)
+   * @throws UnsupportedOperationException if field is not bool type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ArrayIndexOutOfBoundsException if array index is out of bounds
+   * @throws ReadOnlyBufferException if the underlying buffer is read-only
+   */
+  public void setBoolField(StructFieldDescriptor field, boolean value, int arrIndex) {
+    if (field.getType() != StructFieldType.kBool) {
+      throw new UnsupportedOperationException("field is not bool type");
+    }
+    setFieldImpl(field, value ? 1 : 0, arrIndex);
+  }
+
+  /**
+   * Sets the value of a boolean field.
+   *
+   * @param field field descriptor
+   * @param value boolean value
+   * @throws UnsupportedOperationException if field is not bool type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ReadOnlyBufferException if the underlying buffer is read-only
+   */
+  public void setBoolField(StructFieldDescriptor field, boolean value) {
+    setBoolField(field, value, 0);
+  }
+
+  /**
+   * Gets the value of an integer field.
+   *
+   * @param field field descriptor
+   * @param arrIndex array index (must be less than field array size)
+   * @return integer field value
+   * @throws UnsupportedOperationException if field is not integer type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ArrayIndexOutOfBoundsException if array index is out of bounds
+   */
+  public long getIntField(StructFieldDescriptor field, int arrIndex) {
+    if (!field.isInt() && !field.isUint()) {
+      throw new UnsupportedOperationException("field is not integer type");
+    }
+    return getFieldImpl(field, arrIndex);
+  }
+
+  /**
+   * Gets the value of an integer field.
+   *
+   * @param field field descriptor
+   * @return integer field value
+   * @throws UnsupportedOperationException if field is not integer type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   */
+  public long getIntField(StructFieldDescriptor field) {
+    return getIntField(field, 0);
+  }
+
+  /**
+   * Sets the value of an integer field.
+   *
+   * @param field field descriptor
+   * @param value integer value
+   * @param arrIndex array index (must be less than field array size)
+   * @throws UnsupportedOperationException if field is not integer type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ArrayIndexOutOfBoundsException if array index is out of bounds
+   * @throws ReadOnlyBufferException if the underlying buffer is read-only
+   */
+  public void setIntField(StructFieldDescriptor field, long value, int arrIndex) {
+    if (!field.isInt() && !field.isUint()) {
+      throw new UnsupportedOperationException("field is not integer type");
+    }
+    setFieldImpl(field, value, arrIndex);
+  }
+
+  /**
+   * Sets the value of an integer field.
+   *
+   * @param field field descriptor
+   * @param value integer value
+   * @throws UnsupportedOperationException if field is not integer type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ReadOnlyBufferException if the underlying buffer is read-only
+   */
+  public void setIntField(StructFieldDescriptor field, long value) {
+    setIntField(field, value, 0);
+  }
+
+  /**
+   * Gets the value of a float field.
+   *
+   * @param field field descriptor
+   * @param arrIndex array index (must be less than field array size)
+   * @return float field value
+   * @throws UnsupportedOperationException if field is not float type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ArrayIndexOutOfBoundsException if array index is out of bounds
+   */
+  public float getFloatField(StructFieldDescriptor field, int arrIndex) {
+    if (field.getType() != StructFieldType.kFloat) {
+      throw new UnsupportedOperationException("field is not float type");
+    }
+    return Float.intBitsToFloat((int) getFieldImpl(field, arrIndex));
+  }
+
+  /**
+   * Gets the value of a float field.
+   *
+   * @param field field descriptor
+   * @return float field value
+   * @throws UnsupportedOperationException if field is not float type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   */
+  public float getFloatField(StructFieldDescriptor field) {
+    return getFloatField(field, 0);
+  }
+
+  /**
+   * Sets the value of a float field.
+   *
+   * @param field field descriptor
+   * @param value float value
+   * @param arrIndex array index (must be less than field array size)
+   * @throws UnsupportedOperationException if field is not float type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ArrayIndexOutOfBoundsException if array index is out of bounds
+   * @throws ReadOnlyBufferException if the underlying buffer is read-only
+   */
+  public void setFloatField(StructFieldDescriptor field, float value, int arrIndex) {
+    if (field.getType() != StructFieldType.kFloat) {
+      throw new UnsupportedOperationException("field is not float type");
+    }
+    setFieldImpl(field, Float.floatToIntBits(value), arrIndex);
+  }
+
+  /**
+   * Sets the value of a float field.
+   *
+   * @param field field descriptor
+   * @param value float value
+   * @throws UnsupportedOperationException if field is not float type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ReadOnlyBufferException if the underlying buffer is read-only
+   */
+  public void setFloatField(StructFieldDescriptor field, float value) {
+    setFloatField(field, value, 0);
+  }
+
+  /**
+   * Gets the value of a double field.
+   *
+   * @param field field descriptor
+   * @param arrIndex array index (must be less than field array size)
+   * @return double field value
+   * @throws UnsupportedOperationException if field is not double type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ArrayIndexOutOfBoundsException if array index is out of bounds
+   */
+  public double getDoubleField(StructFieldDescriptor field, int arrIndex) {
+    if (field.getType() != StructFieldType.kDouble) {
+      throw new UnsupportedOperationException("field is not double type");
+    }
+    return Double.longBitsToDouble(getFieldImpl(field, arrIndex));
+  }
+
+  /**
+   * Gets the value of a double field.
+   *
+   * @param field field descriptor
+   * @return double field value
+   * @throws UnsupportedOperationException if field is not double type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   */
+  public double getDoubleField(StructFieldDescriptor field) {
+    return getDoubleField(field, 0);
+  }
+
+  /**
+   * Sets the value of a double field.
+   *
+   * @param field field descriptor
+   * @param value double value
+   * @param arrIndex array index (must be less than field array size)
+   * @throws UnsupportedOperationException if field is not double type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ArrayIndexOutOfBoundsException if array index is out of bounds
+   * @throws ReadOnlyBufferException if the underlying buffer is read-only
+   */
+  public void setDoubleField(StructFieldDescriptor field, double value, int arrIndex) {
+    if (field.getType() != StructFieldType.kDouble) {
+      throw new UnsupportedOperationException("field is not double type");
+    }
+    setFieldImpl(field, Double.doubleToLongBits(value), arrIndex);
+  }
+
+  /**
+   * Sets the value of a double field.
+   *
+   * @param field field descriptor
+   * @param value double value
+   * @throws UnsupportedOperationException if field is not double type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ReadOnlyBufferException if the underlying buffer is read-only
+   */
+  public void setDoubleField(StructFieldDescriptor field, double value) {
+    setDoubleField(field, value, 0);
+  }
+
+  /**
+   * Gets the value of a character or character array field.
+   *
+   * @param field field descriptor
+   * @return field value
+   * @throws UnsupportedOperationException if field is not char type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   */
+  public String getStringField(StructFieldDescriptor field) {
+    if (field.getType() != StructFieldType.kChar) {
+      throw new UnsupportedOperationException("field is not char type");
+    }
+    if (!field.getParent().equals(m_desc)) {
+      throw new IllegalArgumentException("field is not part of this struct");
+    }
+    if (!m_desc.isValid()) {
+      throw new IllegalStateException("struct descriptor is not valid");
+    }
+    byte[] bytes = new byte[field.m_arraySize];
+    m_data.position(field.m_offset).get(bytes, 0, field.m_arraySize);
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Sets the value of a character or character array field.
+   *
+   * @param field field descriptor
+   * @param value field value
+   * @throws UnsupportedOperationException if field is not char type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   */
+  public void setStringField(StructFieldDescriptor field, String value) {
+    if (field.getType() != StructFieldType.kChar) {
+      throw new UnsupportedOperationException("field is not char type");
+    }
+    if (!field.getParent().equals(m_desc)) {
+      throw new IllegalArgumentException("field is not part of this struct");
+    }
+    if (!m_desc.isValid()) {
+      throw new IllegalStateException("struct descriptor is not valid");
+    }
+    ByteBuffer bb = StandardCharsets.UTF_8.encode(value);
+    int len = Math.min(bb.remaining(), field.m_arraySize);
+    m_data.position(field.m_offset).put(bb.limit(len));
+    for (int i = len; i < field.m_arraySize; i++) {
+      m_data.put((byte) 0);
+    }
+  }
+
+  /**
+   * Gets the value of a struct field.
+   *
+   * @param field field descriptor
+   * @param arrIndex array index (must be less than field array size)
+   * @return field value
+   * @throws UnsupportedOperationException if field is not of struct type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ArrayIndexOutOfBoundsException if array index is out of bounds
+   */
+  public DynamicStruct getStructField(StructFieldDescriptor field, int arrIndex) {
+    if (field.getType() != StructFieldType.kStruct) {
+      throw new UnsupportedOperationException("field is not struct type");
+    }
+    if (!field.getParent().equals(m_desc)) {
+      throw new IllegalArgumentException("field is not part of this struct");
+    }
+    if (!m_desc.isValid()) {
+      throw new IllegalStateException("struct descriptor is not valid");
+    }
+    if (arrIndex < 0 || arrIndex >= field.m_arraySize) {
+      throw new ArrayIndexOutOfBoundsException(
+          "arrIndex (" + arrIndex + ") is larger than array size (" + field.m_arraySize + ")");
+    }
+    StructDescriptor struct = field.getStruct();
+    return wrap(struct, m_data.position(field.m_offset + arrIndex * struct.m_size));
+  }
+
+  /**
+   * Gets the value of a struct field.
+   *
+   * @param field field descriptor
+   * @return field value
+   * @throws UnsupportedOperationException if field is not of struct type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   */
+  public DynamicStruct getStructField(StructFieldDescriptor field) {
+    return getStructField(field, 0);
+  }
+
+  /**
+   * Sets the value of a struct field.
+   *
+   * @param field field descriptor
+   * @param value struct value
+   * @param arrIndex array index (must be less than field array size)
+   * @throws UnsupportedOperationException if field is not struct type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ArrayIndexOutOfBoundsException if array index is out of bounds
+   * @throws ReadOnlyBufferException if the underlying buffer is read-only
+   */
+  public void setStructField(StructFieldDescriptor field, DynamicStruct value, int arrIndex) {
+    if (field.getType() != StructFieldType.kStruct) {
+      throw new UnsupportedOperationException("field is not struct type");
+    }
+    if (!field.getParent().equals(m_desc)) {
+      throw new IllegalArgumentException("field is not part of this struct");
+    }
+    if (!m_desc.isValid()) {
+      throw new IllegalStateException("struct descriptor is not valid");
+    }
+    StructDescriptor struct = field.getStruct();
+    if (!value.getDescriptor().equals(struct)) {
+      throw new IllegalArgumentException("value's struct type does not match field struct type");
+    }
+    if (!value.getDescriptor().isValid()) {
+      throw new IllegalStateException("value's struct descriptor is not valid");
+    }
+    if (arrIndex < 0 || arrIndex >= field.m_arraySize) {
+      throw new ArrayIndexOutOfBoundsException(
+          "arrIndex (" + arrIndex + ") is larger than array size (" + field.m_arraySize + ")");
+    }
+    m_data
+        .position(field.m_offset + arrIndex * struct.m_size)
+        .put(value.m_data.position(0).limit(value.getDescriptor().getSize()));
+  }
+
+  /**
+   * Sets the value of a struct field.
+   *
+   * @param field field descriptor
+   * @param value struct value
+   * @throws UnsupportedOperationException if field is not struct type
+   * @throws IllegalArgumentException if field is not a member of this struct
+   * @throws IllegalStateException if struct descriptor is invalid
+   * @throws ReadOnlyBufferException if the underlying buffer is read-only
+   */
+  public void setStructField(StructFieldDescriptor field, DynamicStruct value) {
+    setStructField(field, value, 0);
+  }
+
+  private long getFieldImpl(StructFieldDescriptor field, int arrIndex) {
+    if (!field.getParent().equals(m_desc)) {
+      throw new IllegalArgumentException("field is not part of this struct");
+    }
+    if (!m_desc.isValid()) {
+      throw new IllegalStateException("struct descriptor is not valid");
+    }
+    if (arrIndex < 0 || arrIndex >= field.m_arraySize) {
+      throw new ArrayIndexOutOfBoundsException(
+          "arrIndex (" + arrIndex + ") is larger than array size (" + field.m_arraySize + ")");
+    }
+
+    long val;
+    switch (field.m_size) {
+      case 1:
+        val = m_data.get(field.m_offset + arrIndex);
+        break;
+      case 2:
+        val = m_data.getShort(field.m_offset + arrIndex * 2);
+        break;
+      case 4:
+        val = m_data.getInt(field.m_offset + arrIndex * 4);
+        break;
+      case 8:
+        val = m_data.getLong(field.m_offset + arrIndex * 8);
+        break;
+      default:
+        throw new IllegalStateException("invalid field size");
+    }
+
+    if (field.isUint() || field.getType() == StructFieldType.kBool) {
+      // for unsigned fields, we can simply logical shift and mask
+      return (val >>> field.m_bitShift) & field.getBitMask();
+    } else {
+      // to get sign extension, shift so the sign bit within the bitfield goes to the long's sign
+      // bit (also clearing all higher bits), then shift back down (also clearing all lower bits);
+      // since upper and lower bits are cleared with the shifts, the bitmask is unnecessary
+      return (val << (64 - field.m_bitShift - field.getBitWidth())) >> (64 - field.getBitWidth());
+    }
+  }
+
+  private void setFieldImpl(StructFieldDescriptor field, long value, int arrIndex) {
+    if (!field.getParent().equals(m_desc)) {
+      throw new IllegalArgumentException("field is not part of this struct");
+    }
+    if (!m_desc.isValid()) {
+      throw new IllegalStateException("struct descriptor is not valid");
+    }
+    if (arrIndex < 0 || arrIndex >= field.m_arraySize) {
+      throw new ArrayIndexOutOfBoundsException(
+          "arrIndex (" + arrIndex + ") is larger than array size (" + field.m_arraySize + ")");
+    }
+
+    // common case is no bit shift and no masking
+    if (!field.isBitField()) {
+      switch (field.m_size) {
+        case 1:
+          m_data.put(field.m_offset + arrIndex, (byte) value);
+          break;
+        case 2:
+          m_data.putShort(field.m_offset + arrIndex * 2, (short) value);
+          break;
+        case 4:
+          m_data.putInt(field.m_offset + arrIndex * 4, (int) value);
+          break;
+        case 8:
+          m_data.putLong(field.m_offset + arrIndex * 8, value);
+          break;
+        default:
+          throw new IllegalStateException("invalid field size");
+      }
+      return;
+    }
+
+    // handle bit shifting and masking into current value
+    switch (field.m_size) {
+      case 1:
+        {
+          byte val = m_data.get(field.m_offset + arrIndex);
+          val &= ~(field.getBitMask() << field.m_bitShift);
+          val |= (value & field.getBitMask()) << field.m_bitShift;
+          m_data.put(field.m_offset + arrIndex, val);
+          break;
+        }
+      case 2:
+        {
+          short val = m_data.getShort(field.m_offset + arrIndex * 2);
+          val &= ~(field.getBitMask() << field.m_bitShift);
+          val |= (value & field.getBitMask()) << field.m_bitShift;
+          m_data.putShort(field.m_offset + arrIndex * 2, val);
+          break;
+        }
+      case 4:
+        {
+          int val = m_data.getInt(field.m_offset + arrIndex * 4);
+          val &= ~(field.getBitMask() << field.m_bitShift);
+          val |= (value & field.getBitMask()) << field.m_bitShift;
+          m_data.putInt(field.m_offset + arrIndex * 4, val);
+          break;
+        }
+      case 8:
+        {
+          long val = m_data.getLong(field.m_offset + arrIndex * 8);
+          val &= ~(field.getBitMask() << field.m_bitShift);
+          val |= (value & field.getBitMask()) << field.m_bitShift;
+          m_data.putLong(field.m_offset + arrIndex * 8, val);
+          break;
+        }
+      default:
+        throw new IllegalStateException("invalid field size");
+    }
+  }
+
+  private final StructDescriptor m_desc;
+  private final ByteBuffer m_data;
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/Struct.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/Struct.java
@@ -1,0 +1,116 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Interface for raw struct serialization.
+ *
+ * <p>This is designed for serializing small fixed-size data structures in the fastest and most
+ * compact means possible. Serialization consists of making relative put() calls to a ByteBuffer and
+ * deserialization consists of making relative get() calls from a ByteBuffer.
+ *
+ * <p>Idiomatically, classes that support raw struct serialization should provide a static final
+ * member named "struct" that provides an instance of an implementation of this interface.
+ *
+ * @param <T> object type
+ */
+public interface Struct<T> {
+  /** Serialized size of a "bool" value. */
+  int kSizeBool = 1;
+
+  /** Serialized size of an "int8" or "uint8" value. */
+  int kSizeInt8 = 1;
+
+  /** Serialized size of an "int16" or "uint16" value. */
+  int kSizeInt16 = 2;
+
+  /** Serialized size of an "int32" or "uint32" value. */
+  int kSizeInt32 = 4;
+
+  /** Serialized size of an "int64" or "uint64" value. */
+  int kSizeInt64 = 8;
+
+  /** Serialized size of an "float" or "float32" value. */
+  int kSizeFloat = 4;
+
+  /** Serialized size of an "double" or "float64" value. */
+  int kSizeDouble = 8;
+
+  /**
+   * Gets the Class object for the stored value.
+   *
+   * @return Class
+   */
+  Class<T> getTypeClass();
+
+  /**
+   * Gets the type string (e.g. for NetworkTables). This should be globally unique and start with
+   * "struct:".
+   *
+   * @return type string
+   */
+  String getTypeString();
+
+  /**
+   * Gets the serialized size (in bytes). This should always be a constant.
+   *
+   * @return serialized size
+   */
+  int getSize();
+
+  /**
+   * Gets the schema.
+   *
+   * @return schema
+   */
+  String getSchema();
+
+  /**
+   * Gets the list of struct types referenced by this struct.
+   *
+   * @return list of struct types
+   */
+  default Struct<?>[] getNested() {
+    return new Struct<?>[] {};
+  }
+
+  /**
+   * Deserializes an object from a raw struct serialized ByteBuffer starting at the current
+   * position. Will increment the ByteBuffer position by getStructSize() bytes. Will not otherwise
+   * modify the ByteBuffer (e.g. byte order will not be changed).
+   *
+   * @param bb ByteBuffer
+   * @return New object
+   */
+  T unpack(ByteBuffer bb);
+
+  /**
+   * Puts object contents to a ByteBuffer starting at the current position. Will increment the
+   * ByteBuffer position by getStructSize() bytes. Will not otherwise modify the ByteBuffer (e.g.
+   * byte order will not be changed).
+   *
+   * @param bb ByteBuffer
+   * @param value object to serialize
+   */
+  void pack(ByteBuffer bb, T value);
+
+  /**
+   * Updates object contents from a raw struct serialized ByteBuffer starting at the current
+   * position. Will increment the ByteBuffer position by getStructSize() bytes. Will not otherwise
+   * modify the ByteBuffer (e.g. byte order will not be changed).
+   *
+   * <p>Immutable classes cannot and should not implement this function. The default implementation
+   * throws UnsupportedOperationException.
+   *
+   * @param out object to update
+   * @param bb ByteBuffer
+   * @throws UnsupportedOperationException if the object is immutable
+   */
+  default void unpackInto(T out, ByteBuffer bb) {
+    throw new UnsupportedOperationException("object does not support unpackInto");
+  }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/StructBuffer.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/StructBuffer.java
@@ -1,0 +1,224 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct;
+
+import java.lang.reflect.Array;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Collection;
+
+/**
+ * Reusable buffer for serialization/deserialization to/from a raw struct.
+ *
+ * @param <T> object type
+ */
+public final class StructBuffer<T> {
+  private StructBuffer(Struct<T> struct) {
+    m_structSize = struct.getSize();
+    m_buf = ByteBuffer.allocateDirect(m_structSize).order(ByteOrder.LITTLE_ENDIAN);
+    m_struct = struct;
+  }
+
+  public static <T> StructBuffer<T> create(Struct<T> struct) {
+    return new StructBuffer<T>(struct);
+  }
+
+  /**
+   * Gets the struct object of the stored type.
+   *
+   * @return struct object
+   */
+  public Struct<T> getStruct() {
+    return m_struct;
+  }
+
+  /**
+   * Gets the type string.
+   *
+   * @return type string
+   */
+  public String getTypeString() {
+    return m_struct.getTypeString();
+  }
+
+  /**
+   * Ensures sufficient buffer space is available for the given number of elements.
+   *
+   * @param nelem number of elements
+   */
+  public void reserve(int nelem) {
+    if ((nelem * m_structSize) > m_buf.capacity()) {
+      m_buf = ByteBuffer.allocateDirect(nelem * m_structSize).order(ByteOrder.LITTLE_ENDIAN);
+    }
+  }
+
+  /**
+   * Serializes a value to a ByteBuffer. The returned ByteBuffer is a direct byte buffer with the
+   * position set to the end of the serialized data.
+   *
+   * @param value value
+   * @return byte buffer
+   */
+  public ByteBuffer write(T value) {
+    m_buf.position(0);
+    m_struct.pack(m_buf, value);
+    return m_buf;
+  }
+
+  /**
+   * Deserializes a value from a byte array, creating a new object.
+   *
+   * @param buf byte array
+   * @param start starting location within byte array
+   * @param len length of serialized data
+   * @return new object
+   */
+  public T read(byte[] buf, int start, int len) {
+    return read(ByteBuffer.wrap(buf, start, len));
+  }
+
+  /**
+   * Deserializes a value from a byte array, creating a new object.
+   *
+   * @param buf byte array
+   * @return new object
+   */
+  public T read(byte[] buf) {
+    return read(buf, 0, buf.length);
+  }
+
+  /**
+   * Deserializes a value from a ByteBuffer, creating a new object.
+   *
+   * @param buf byte buffer
+   * @return new object
+   */
+  public T read(ByteBuffer buf) {
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+    return m_struct.unpack(buf);
+  }
+
+  /**
+   * Deserializes a value from a byte array into a mutable object.
+   *
+   * @param out object (will be updated with deserialized contents)
+   * @param buf byte array
+   * @param start starting location within byte array
+   * @param len length of serialized data
+   * @throws UnsupportedOperationException if T is immutable
+   */
+  public void readInto(T out, byte[] buf, int start, int len) {
+    readInto(out, ByteBuffer.wrap(buf, start, len));
+  }
+
+  /**
+   * Deserializes a value from a byte array into a mutable object.
+   *
+   * @param out object (will be updated with deserialized contents)
+   * @param buf byte array
+   * @throws UnsupportedOperationException if T is immutable
+   */
+  public void readInto(T out, byte[] buf) {
+    readInto(out, buf, 0, buf.length);
+  }
+
+  /**
+   * Deserializes a value from a ByteBuffer into a mutable object.
+   *
+   * @param out object (will be updated with deserialized contents)
+   * @param buf byte buffer
+   * @throws UnsupportedOperationException if T is immutable
+   */
+  public void readInto(T out, ByteBuffer buf) {
+    m_struct.unpackInto(out, buf);
+  }
+
+  /**
+   * Serializes a collection of values to a ByteBuffer. The returned ByteBuffer is a direct byte
+   * buffer with the position set to the end of the serialized data.
+   *
+   * @param values values
+   * @return byte buffer
+   */
+  public ByteBuffer writeArray(Collection<T> values) {
+    m_buf.position(0);
+    if ((values.size() * m_structSize) > m_buf.capacity()) {
+      m_buf =
+          ByteBuffer.allocateDirect(values.size() * m_structSize * 2)
+              .order(ByteOrder.LITTLE_ENDIAN);
+    }
+    for (T v : values) {
+      m_struct.pack(m_buf, v);
+    }
+    return m_buf;
+  }
+
+  /**
+   * Serializes an array of values to a ByteBuffer. The returned ByteBuffer is a direct byte buffer
+   * with the position set to the end of the serialized data.
+   *
+   * @param values values
+   * @return byte buffer
+   */
+  public ByteBuffer writeArray(T[] values) {
+    m_buf.position(0);
+    if ((values.length * m_structSize) > m_buf.capacity()) {
+      m_buf =
+          ByteBuffer.allocateDirect(values.length * m_structSize * 2)
+              .order(ByteOrder.LITTLE_ENDIAN);
+    }
+    for (T v : values) {
+      m_struct.pack(m_buf, v);
+    }
+    return m_buf;
+  }
+
+  /**
+   * Deserializes an array of values from a byte array, creating an array of new objects.
+   *
+   * @param buf byte array
+   * @param start starting location within byte array
+   * @param len length of serialized data
+   * @return new object array
+   */
+  public T[] readArray(byte[] buf, int start, int len) {
+    return readArray(ByteBuffer.wrap(buf, start, len));
+  }
+
+  /**
+   * Deserializes an array of values from a byte array, creating an array of new objects.
+   *
+   * @param buf byte array
+   * @return new object array
+   */
+  public T[] readArray(byte[] buf) {
+    return readArray(buf, 0, buf.length);
+  }
+
+  /**
+   * Deserializes an array of values from a ByteBuffer, creating an array of new objects.
+   *
+   * @param buf byte buffer
+   * @return new object array
+   */
+  public T[] readArray(ByteBuffer buf) {
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+    int len = buf.limit() - buf.position();
+    if ((len % m_structSize) != 0) {
+      throw new RuntimeException("buffer size not a multiple of struct size");
+    }
+    int nelem = len / m_structSize;
+    @SuppressWarnings("unchecked")
+    T[] arr = (T[]) Array.newInstance(m_struct.getClass(), nelem);
+    for (int i = 0; i < nelem; i++) {
+      arr[i] = m_struct.unpack(buf);
+    }
+    return arr;
+  }
+
+  private ByteBuffer m_buf;
+  private final Struct<T> m_struct;
+  private final int m_structSize;
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/StructDescriptor.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/StructDescriptor.java
@@ -1,0 +1,156 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+/** Raw struct dynamic struct descriptor. */
+public class StructDescriptor {
+  StructDescriptor(String name) {
+    m_name = name;
+  }
+
+  /**
+   * Gets the struct name.
+   *
+   * @return name
+   */
+  public String getName() {
+    return m_name;
+  }
+
+  /**
+   * Gets the struct schema.
+   *
+   * @return schema
+   */
+  public String getSchema() {
+    return m_schema;
+  }
+
+  /**
+   * Returns whether the struct is valid (e.g. the struct is fully defined and field offsets
+   * computed).
+   *
+   * @return true if valid
+   */
+  public boolean isValid() {
+    return m_valid;
+  }
+
+  /**
+   * Returns the struct size, in bytes. Not valid unless IsValid() is true.
+   *
+   * @return size in bytes
+   * @throws IllegalStateException if descriptor is invalid
+   */
+  public int getSize() {
+    if (!m_valid) {
+      throw new IllegalStateException("descriptor is invalid");
+    }
+    return m_size;
+  }
+
+  /**
+   * Gets a field descriptor by name. Note the field cannot be accessed until the struct is valid.
+   *
+   * @param name field name
+   * @return field descriptor, or nullptr if not found
+   */
+  public StructFieldDescriptor findFieldByName(String name) {
+    return m_fieldsByName.get(name);
+  }
+
+  /**
+   * Gets all field descriptors. Note fields cannot be accessed until the struct is valid.
+   *
+   * @return field descriptors
+   */
+  public List<StructFieldDescriptor> getFields() {
+    return m_fields;
+  }
+
+  boolean checkCircular(Stack<StructDescriptor> stack) {
+    stack.push(this);
+    for (StructDescriptor ref : m_references) {
+      if (stack.contains(ref)) {
+        return false;
+      }
+      if (!ref.checkCircular(stack)) {
+        return false;
+      }
+    }
+    stack.pop();
+    return true;
+  }
+
+  void calculateOffsets(Stack<StructDescriptor> stack) {
+    int offset = 0;
+    int shift = 0;
+    int prevBitfieldSize = 0;
+    for (StructFieldDescriptor field : m_fields) {
+      if (!field.isBitField()) {
+        shift = 0; // reset shift on non-bitfield element
+        offset += prevBitfieldSize; // finish bitfield if active
+        prevBitfieldSize = 0; // previous is now not bitfield
+        field.m_offset = offset;
+        StructDescriptor struct = field.getStruct();
+        if (struct != null) {
+          if (!struct.isValid()) {
+            m_valid = false;
+            return;
+          }
+          field.m_size = struct.m_size;
+        }
+        offset += field.m_size * field.m_arraySize;
+      } else {
+        int bitWidth = field.getBitWidth();
+        if (field.getType() == StructFieldType.kBool
+            && prevBitfieldSize != 0
+            && (shift + 1) <= (prevBitfieldSize * 8)) {
+          // bool takes on size of preceding bitfield type (if it fits)
+          field.m_size = prevBitfieldSize;
+        } else if (field.m_size != prevBitfieldSize || (shift + bitWidth) > (field.m_size * 8)) {
+          shift = 0;
+          offset += prevBitfieldSize;
+        }
+        prevBitfieldSize = field.m_size;
+        field.m_offset = offset;
+        field.m_bitShift = shift;
+        shift += bitWidth;
+      }
+    }
+
+    // update struct size
+    m_size = offset + prevBitfieldSize;
+    m_valid = true;
+
+    // now that we're valid, referring types may be too
+    stack.push(this);
+    for (StructDescriptor ref : m_references) {
+      if (stack.contains(ref)) {
+        throw new IllegalStateException(
+            "internal error (inconsistent data): circular struct reference between "
+                + m_name
+                + " and "
+                + ref.m_name);
+      }
+      ref.calculateOffsets(stack);
+    }
+    stack.pop();
+  }
+
+  private final String m_name;
+  String m_schema;
+  final List<StructDescriptor> m_references = new ArrayList<>();
+  final List<StructFieldDescriptor> m_fields = new ArrayList<>();
+  final Map<String, StructFieldDescriptor> m_fieldsByName = new HashMap<>();
+  int m_size;
+  boolean m_valid;
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/StructDescriptorDatabase.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/StructDescriptorDatabase.java
@@ -1,0 +1,148 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct;
+
+import edu.wpi.first.util.struct.parser.ParseException;
+import edu.wpi.first.util.struct.parser.ParsedDeclaration;
+import edu.wpi.first.util.struct.parser.ParsedSchema;
+import edu.wpi.first.util.struct.parser.Parser;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Stack;
+
+/** Database of raw struct dynamic descriptors. */
+public class StructDescriptorDatabase {
+  /**
+   * Adds a structure schema to the database. If the struct references other structs that have not
+   * yet been added, it will not be valid until those structs are also added.
+   *
+   * @param name structure name
+   * @param schema structure schema
+   * @return Added struct dynamic descriptor
+   * @throws BadSchemaException if schema invalid
+   */
+  public StructDescriptor add(String name, String schema) throws BadSchemaException {
+    Parser parser = new Parser(schema);
+    ParsedSchema parsed;
+    try {
+      parsed = parser.parse();
+    } catch (ParseException e) {
+      throw new BadSchemaException("parse error", e);
+    }
+
+    // turn parsed schema into descriptors
+    StructDescriptor theStruct = m_structs.computeIfAbsent(name, k -> new StructDescriptor(k));
+    theStruct.m_schema = schema;
+    theStruct.m_fields.clear();
+    boolean isValid = true;
+    for (ParsedDeclaration decl : parsed.declarations) {
+      StructFieldType type = StructFieldType.fromString(decl.typeString);
+      int size = type.size;
+
+      // bitfield checks
+      if (decl.bitWidth != 0) {
+        // only integer or boolean types are allowed
+        if (!type.isInt && !type.isUint && type != StructFieldType.kBool) {
+          throw new BadSchemaException(
+              decl.name, "type " + decl.typeString + " cannot be bitfield");
+        }
+
+        // bit width cannot be larger than field size
+        if (decl.bitWidth > (size * 8)) {
+          throw new BadSchemaException(
+              decl.name, "bit width " + decl.bitWidth + " exceeds type size");
+        }
+
+        // bit width must be 1 for booleans
+        if (type == StructFieldType.kBool && decl.bitWidth != 1) {
+          throw new BadSchemaException(decl.name, "bit width must be 1 for bool type");
+        }
+
+        // cannot combine array and bitfield (shouldn't parse, but double-check)
+        if (decl.arraySize > 1) {
+          throw new BadSchemaException(decl.name, "cannot combine array and bitfield");
+        }
+      }
+
+      // struct handling
+      StructDescriptor structDesc = null;
+      if (type == StructFieldType.kStruct) {
+        // recursive definitions are not allowed
+        if (decl.typeString.equals(name)) {
+          throw new BadSchemaException(decl.name, "recursive struct reference");
+        }
+
+        // cross-reference struct, creating a placeholder if necessary
+        StructDescriptor aStruct =
+            m_structs.computeIfAbsent(decl.typeString, k -> new StructDescriptor(k));
+
+        // if the struct isn't valid, we can't be valid either
+        if (aStruct.isValid()) {
+          size = aStruct.getSize();
+        } else {
+          isValid = false;
+        }
+
+        // add to cross-references for when the struct does become valid
+        aStruct.m_references.add(theStruct);
+        structDesc = aStruct;
+      }
+
+      // create field
+      StructFieldDescriptor fieldDesc =
+          new StructFieldDescriptor(
+              theStruct,
+              decl.name,
+              type,
+              size,
+              decl.arraySize,
+              decl.bitWidth,
+              decl.enumValues,
+              structDesc);
+      if (theStruct.m_fieldsByName.put(decl.name, fieldDesc) != null) {
+        throw new BadSchemaException(decl.name, "duplicate field name");
+      }
+
+      theStruct.m_fields.add(fieldDesc);
+    }
+
+    theStruct.m_valid = isValid;
+    Stack<StructDescriptor> stack = new Stack<>();
+    if (isValid) {
+      // we have all the info needed, so calculate field offset & shift
+      theStruct.calculateOffsets(stack);
+    } else {
+      // check for circular reference
+      if (!theStruct.checkCircular(stack)) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("circular struct reference: ");
+        boolean first = true;
+        for (StructDescriptor elem : stack) {
+          if (!first) {
+            builder.append(" <- ");
+          } else {
+            first = false;
+          }
+          builder.append(elem.getName());
+        }
+        throw new BadSchemaException(builder.toString());
+      }
+    }
+
+    return theStruct;
+  }
+
+  /**
+   * Finds a structure in the database by name.
+   *
+   * @param name structure name
+   * @return struct descriptor, or null if not found
+   */
+  public StructDescriptor find(String name) {
+    return m_structs.get(name);
+  }
+
+  private final Map<String, StructDescriptor> m_structs = new HashMap<>();
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/StructFieldDescriptor.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/StructFieldDescriptor.java
@@ -1,0 +1,241 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct;
+
+import java.util.Map;
+
+/** Raw struct dynamic field descriptor. */
+public class StructFieldDescriptor {
+  private static int toBitWidth(int size, int bitWidth) {
+    if (bitWidth == 0) {
+      return size * 8;
+    } else {
+      return bitWidth;
+    }
+  }
+
+  private static long toBitMask(int size, int bitWidth) {
+    if (size == 0) {
+      return 0;
+    } else {
+      return -1L >>> (64 - toBitWidth(size, bitWidth));
+    }
+  }
+
+  // does not fill in offset, shift
+  StructFieldDescriptor(
+      StructDescriptor parent,
+      String name,
+      StructFieldType type,
+      int size,
+      int arraySize,
+      int bitWidth,
+      Map<String, Long> enumValues,
+      StructDescriptor structDesc) {
+    m_parent = parent;
+    m_name = name;
+    m_size = size;
+    m_arraySize = arraySize;
+    m_enum = enumValues;
+    m_struct = structDesc;
+    m_bitMask = toBitMask(size, bitWidth);
+    m_type = type;
+    m_bitWidth = toBitWidth(size, bitWidth);
+  }
+
+  /**
+   * Gets the dynamic struct this field is contained in.
+   *
+   * @return struct descriptor
+   */
+  public StructDescriptor getParent() {
+    return m_parent;
+  }
+
+  /**
+   * Gets the field name.
+   *
+   * @return field name
+   */
+  public String getName() {
+    return m_name;
+  }
+
+  /**
+   * Gets the field type.
+   *
+   * @return field type
+   */
+  public StructFieldType getType() {
+    return m_type;
+  }
+
+  /**
+   * Returns whether the field type is a signed integer.
+   *
+   * @return true if signed integer, false otherwise
+   */
+  public boolean isInt() {
+    return m_type.isInt;
+  }
+
+  /**
+   * Returns whether the field type is an unsigned integer.
+   *
+   * @return true if unsigned integer, false otherwise
+   */
+  public boolean isUint() {
+    return m_type.isUint;
+  }
+
+  /**
+   * Gets the underlying storage size of the field, in bytes.
+   *
+   * @return number of bytes
+   */
+  public int getSize() {
+    return m_size;
+  }
+
+  /**
+   * Gets the storage offset of the field, in bytes.
+   *
+   * @return number of bytes from the start of the struct
+   */
+  public int getOffset() {
+    return m_offset;
+  }
+
+  /**
+   * Gets the bit width of the field, in bits.
+   *
+   * @return number of bits
+   */
+  public int getBitWidth() {
+    return m_bitWidth == 0 ? m_size * 8 : m_bitWidth;
+  }
+
+  /**
+   * Gets the bit mask for the field. The mask is always the least significant bits (it is not
+   * shifted).
+   *
+   * @return bit mask
+   */
+  public long getBitMask() {
+    return m_bitMask;
+  }
+
+  /**
+   * Gets the bit shift for the field (LSB=0).
+   *
+   * @return number of bits
+   */
+  public int getBitShift() {
+    return m_bitShift;
+  }
+
+  /**
+   * Returns whether the field is an array.
+   *
+   * @return true if array
+   */
+  public boolean isArray() {
+    return m_arraySize > 1;
+  }
+
+  /**
+   * Gets the array size. Returns 1 if non-array.
+   *
+   * @return number of elements
+   */
+  public int getArraySize() {
+    return m_arraySize;
+  }
+
+  /**
+   * Returns whether the field has enumerated values.
+   *
+   * @return true if there are enumerated values
+   */
+  public boolean hasEnum() {
+    return m_enum != null;
+  }
+
+  /**
+   * Gets the enumerated values.
+   *
+   * @return set of enumerated values
+   */
+  public Map<String, Long> getEnumValues() {
+    return m_enum;
+  }
+
+  /**
+   * Gets the struct descriptor for a struct data type.
+   *
+   * @return struct descriptor; returns null for non-struct
+   */
+  public StructDescriptor getStruct() {
+    return m_struct;
+  }
+
+  /**
+   * Gets the minimum unsigned integer value that can be stored in this field.
+   *
+   * @return minimum value
+   */
+  public long getUintMin() {
+    return 0;
+  }
+
+  /**
+   * Gets the maximum unsigned integer value that can be stored in this field. Note this is not the
+   * actual maximum for uint64 (due to Java lacking support for 64-bit unsigned integers).
+   *
+   * @return maximum value
+   */
+  public long getUintMax() {
+    return m_bitMask;
+  }
+
+  /**
+   * Gets the minimum signed integer value that can be stored in this field.
+   *
+   * @return minimum value
+   */
+  public long getIntMin() {
+    return (-(m_bitMask >> 1)) - 1;
+  }
+
+  /**
+   * Gets the maximum signed integer value that can be stored in this field.
+   *
+   * @return maximum value
+   */
+  public long getIntMax() {
+    return m_bitMask >> 1;
+  }
+
+  /**
+   * Returns whether the field is a bitfield.
+   *
+   * @return true if bitfield
+   */
+  public boolean isBitField() {
+    return m_bitShift != 0 || m_bitWidth != (m_size * 8);
+  }
+
+  private final StructDescriptor m_parent;
+  private final String m_name;
+  int m_size;
+  int m_offset;
+  final int m_arraySize; // 1 for non-arrays
+  private final Map<String, Long> m_enum;
+  private final StructDescriptor m_struct; // null for non-structs
+  private final long m_bitMask;
+  private final StructFieldType m_type;
+  private final int m_bitWidth;
+  int m_bitShift;
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/StructFieldType.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/StructFieldType.java
@@ -1,0 +1,67 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct;
+
+/** Known data types for raw struct dynamic fields (see StructFieldDescriptor). */
+public enum StructFieldType {
+  kBool("bool", false, false, 1),
+  kChar("char", false, false, 1),
+  kInt8("int8", true, false, 1),
+  kInt16("int16", true, false, 2),
+  kInt32("int32", true, false, 4),
+  kInt64("int64", true, false, 8),
+  kUint8("uint8", false, true, 1),
+  kUint16("uint16", false, true, 2),
+  kUint32("uint32", false, true, 4),
+  kUint64("uint64", false, true, 8),
+  kFloat("float", false, false, 4),
+  kDouble("double", false, false, 8),
+  kStruct("struct", false, false, 0);
+
+  @SuppressWarnings("MemberName")
+  public final String name;
+
+  @SuppressWarnings("MemberName")
+  public final boolean isInt;
+
+  @SuppressWarnings("MemberName")
+  public final boolean isUint;
+
+  @SuppressWarnings("MemberName")
+  public final int size;
+
+  StructFieldType(String name, boolean isInt, boolean isUint, int size) {
+    this.name = name;
+    this.isInt = isInt;
+    this.isUint = isUint;
+    this.size = size;
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  /**
+   * Get field type from string.
+   *
+   * @param str string
+   * @return field type
+   */
+  public static StructFieldType fromString(String str) {
+    for (StructFieldType type : StructFieldType.values()) {
+      if (type.name.equals(str)) {
+        return type;
+      }
+    }
+    if ("float32".equals(str)) {
+      return kFloat;
+    } else if ("float64".equals(str)) {
+      return kDouble;
+    } else {
+      return kStruct;
+    }
+  }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/parser/Lexer.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/parser/Lexer.java
@@ -1,0 +1,132 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct.parser;
+
+/** Raw struct schema lexer. */
+public class Lexer {
+  /**
+   * Construct a raw struct schema lexer.
+   *
+   * @param in schema
+   */
+  public Lexer(String in) {
+    m_in = in;
+  }
+
+  /**
+   * Gets the next token.
+   *
+   * @return Token kind; the token text can be retrieved using getTokenText()
+   */
+  public TokenKind scan() {
+    // skip whitespace
+    do {
+      get();
+    } while (m_current == ' ' || m_current == '\t' || m_current == '\n' || m_current == '\r');
+    m_tokenStart = m_pos - 1;
+
+    switch (m_current) {
+      case '[':
+        return TokenKind.kLeftBracket;
+      case ']':
+        return TokenKind.kRightBracket;
+      case '{':
+        return TokenKind.kLeftBrace;
+      case '}':
+        return TokenKind.kRightBrace;
+      case ':':
+        return TokenKind.kColon;
+      case ';':
+        return TokenKind.kSemicolon;
+      case ',':
+        return TokenKind.kComma;
+      case '=':
+        return TokenKind.kEquals;
+      case '-':
+      case '0':
+      case '1':
+      case '2':
+      case '3':
+      case '4':
+      case '5':
+      case '6':
+      case '7':
+      case '8':
+      case '9':
+        return scanInteger();
+      case '\0':
+        return TokenKind.kEndOfInput;
+      default:
+        if (Character.isLetter(m_current) || m_current == '_') {
+          return scanIdentifier();
+        }
+        return TokenKind.kUnknown;
+    }
+  }
+
+  /**
+   * Gets the text of the last lexed token.
+   *
+   * @return token text
+   */
+  public String getTokenText() {
+    if (m_tokenStart >= m_in.length()) {
+      return "";
+    }
+    return m_in.substring(m_tokenStart, m_pos);
+  }
+
+  /**
+   * Gets the starting position of the last lexed token.
+   *
+   * @return position (0 = first character)
+   */
+  public int getPosition() {
+    return m_tokenStart;
+  }
+
+  private TokenKind scanInteger() {
+    do {
+      get();
+    } while (Character.isDigit(m_current));
+    unget();
+    return TokenKind.kInteger;
+  }
+
+  private TokenKind scanIdentifier() {
+    do {
+      get();
+    } while (Character.isLetterOrDigit(m_current) || m_current == '_');
+    unget();
+    return TokenKind.kIdentifier;
+  }
+
+  private void get() {
+    if (m_pos < m_in.length()) {
+      m_current = m_in.charAt(m_pos);
+    } else {
+      m_current = '\0';
+    }
+    ++m_pos;
+  }
+
+  private void unget() {
+    if (m_pos > 0) {
+      m_pos--;
+      if (m_pos < m_in.length()) {
+        m_current = m_in.charAt(m_pos);
+      } else {
+        m_current = '\0';
+      }
+    } else {
+      m_current = '\0';
+    }
+  }
+
+  final String m_in;
+  char m_current;
+  int m_tokenStart;
+  int m_pos;
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/parser/ParseException.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/parser/ParseException.java
@@ -1,0 +1,33 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct.parser;
+
+public class ParseException extends Exception {
+  private final int m_pos;
+
+  public ParseException(int pos, String s) {
+    super(s);
+    m_pos = pos;
+  }
+
+  public ParseException(int pos, String message, Throwable cause) {
+    super(message, cause);
+    m_pos = pos;
+  }
+
+  public ParseException(int pos, Throwable cause) {
+    super(cause);
+    m_pos = pos;
+  }
+
+  public int getPosition() {
+    return m_pos;
+  }
+
+  @Override
+  public String toString() {
+    return m_pos + ": " + getMessage();
+  }
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/parser/ParsedDeclaration.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/parser/ParsedDeclaration.java
@@ -1,0 +1,25 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct.parser;
+
+import java.util.Map;
+
+/** Raw struct schema declaration. */
+public class ParsedDeclaration {
+  @SuppressWarnings("MemberName")
+  public String typeString;
+
+  @SuppressWarnings("MemberName")
+  public String name;
+
+  @SuppressWarnings("MemberName")
+  public Map<String, Long> enumValues;
+
+  @SuppressWarnings("MemberName")
+  public int arraySize = 1;
+
+  @SuppressWarnings("MemberName")
+  public int bitWidth;
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/parser/ParsedSchema.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/parser/ParsedSchema.java
@@ -1,0 +1,14 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Raw struct schema. */
+public class ParsedSchema {
+  @SuppressWarnings("MemberName")
+  public List<ParsedDeclaration> declarations = new ArrayList<>();
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/parser/Parser.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/parser/Parser.java
@@ -1,0 +1,157 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct.parser;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Raw struct schema parser. */
+public class Parser {
+  /**
+   * Construct a raw struct schema parser.
+   *
+   * @param in schema
+   */
+  public Parser(String in) {
+    m_lexer = new Lexer(in);
+  }
+
+  /**
+   * Parses the schema.
+   *
+   * @return parsed schema object
+   * @throws ParseException on parse error
+   */
+  public ParsedSchema parse() throws ParseException {
+    ParsedSchema schema = new ParsedSchema();
+    do {
+      getNextToken();
+      if (m_token == TokenKind.kSemicolon) {
+        continue;
+      }
+      if (m_token == TokenKind.kEndOfInput) {
+        break;
+      }
+      schema.declarations.add(parseDeclaration());
+    } while (m_token != TokenKind.kEndOfInput);
+    return schema;
+  }
+
+  private ParsedDeclaration parseDeclaration() throws ParseException {
+    ParsedDeclaration decl = new ParsedDeclaration();
+
+    // optional enum specification
+    if (m_token == TokenKind.kIdentifier && "enum".equals(m_lexer.getTokenText())) {
+      getNextToken();
+      expect(TokenKind.kLeftBrace);
+      decl.enumValues = parseEnum();
+      getNextToken();
+    } else if (m_token == TokenKind.kLeftBrace) {
+      decl.enumValues = parseEnum();
+      getNextToken();
+    }
+
+    // type name
+    expect(TokenKind.kIdentifier);
+    decl.typeString = m_lexer.getTokenText();
+    getNextToken();
+
+    // identifier name
+    expect(TokenKind.kIdentifier);
+    decl.name = m_lexer.getTokenText();
+    getNextToken();
+
+    // array or bit field
+    if (m_token == TokenKind.kLeftBracket) {
+      getNextToken();
+      expect(TokenKind.kInteger);
+      String valueStr = m_lexer.getTokenText();
+      int value;
+      try {
+        value = Integer.parseInt(valueStr);
+      } catch (NumberFormatException e) {
+        value = 0;
+      }
+      if (value > 0) {
+        decl.arraySize = value;
+      } else {
+        throw new ParseException(
+            m_lexer.m_pos, "array size '" + valueStr + "' is not a positive integer");
+      }
+      getNextToken();
+      expect(TokenKind.kRightBracket);
+      getNextToken();
+    } else if (m_token == TokenKind.kColon) {
+      getNextToken();
+      expect(TokenKind.kInteger);
+      String valueStr = m_lexer.getTokenText();
+      int value;
+      try {
+        value = Integer.parseInt(valueStr);
+      } catch (NumberFormatException e) {
+        value = 0;
+      }
+      if (value > 0) {
+        decl.bitWidth = value;
+      } else {
+        throw new ParseException(
+            m_lexer.m_pos, "bitfield width '" + valueStr + "' is not a positive integer");
+      }
+      getNextToken();
+    }
+
+    // declaration must end with EOF or semicolon
+    if (m_token != TokenKind.kEndOfInput) {
+      expect(TokenKind.kSemicolon);
+    }
+
+    return decl;
+  }
+
+  private Map<String, Long> parseEnum() throws ParseException {
+    Map<String, Long> map = new HashMap<>();
+
+    // we start with current = '{'
+    getNextToken();
+    while (m_token != TokenKind.kRightBrace) {
+      expect(TokenKind.kIdentifier);
+      final String name = m_lexer.getTokenText();
+      getNextToken();
+      expect(TokenKind.kEquals);
+      getNextToken();
+      expect(TokenKind.kInteger);
+      String valueStr = m_lexer.getTokenText();
+      long value;
+      try {
+        value = Long.parseLong(valueStr);
+      } catch (NumberFormatException e) {
+        throw new ParseException(m_lexer.m_pos, "could not parse enum value '" + valueStr + "'");
+      }
+      map.put(name, value);
+      getNextToken();
+      if (m_token == TokenKind.kRightBrace) {
+        break;
+      }
+      expect(TokenKind.kComma);
+      getNextToken();
+    }
+    return map;
+  }
+
+  private TokenKind getNextToken() {
+    m_token = m_lexer.scan();
+    return m_token;
+  }
+
+  private void expect(TokenKind kind) throws ParseException {
+    if (m_token != kind) {
+      throw new ParseException(
+          m_lexer.m_pos, "expected " + kind + ", got '" + m_lexer.getTokenText() + "'");
+    }
+  }
+
+  final Lexer m_lexer;
+  TokenKind m_token;
+}

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/parser/TokenKind.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/parser/TokenKind.java
@@ -1,0 +1,32 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct.parser;
+
+/** A lexed raw struct schema token. */
+public enum TokenKind {
+  kUnknown("unknown"),
+  kInteger("integer"),
+  kIdentifier("identifier"),
+  kLeftBracket("'['"),
+  kRightBracket("']'"),
+  kLeftBrace("'{'"),
+  kRightBrace("'}'"),
+  kColon("':'"),
+  kSemicolon("';'"),
+  kComma("','"),
+  kEquals("'='"),
+  kEndOfInput("<EOF>");
+
+  private final String m_name;
+
+  TokenKind(String name) {
+    this.m_name = name;
+  }
+
+  @Override
+  public String toString() {
+    return m_name;
+  }
+}

--- a/wpiutil/src/main/native/cpp/jni/DataLogJNI.cpp
+++ b/wpiutil/src/main/native/cpp/jni/DataLogJNI.cpp
@@ -113,6 +113,47 @@ Java_edu_wpi_first_util_datalog_DataLogJNI_resume
 
 /*
  * Class:     edu_wpi_first_util_datalog_DataLogJNI
+ * Method:    addSchema
+ * Signature: (JLjava/lang/String;Ljava/lang/String;[BJ)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_util_datalog_DataLogJNI_addSchema
+  (JNIEnv* env, jclass, jlong impl, jstring name, jstring type,
+   jbyteArray schema, jlong timestamp)
+{
+  if (impl == 0) {
+    wpi::ThrowNullPointerException(env, "impl is null");
+    return;
+  }
+  reinterpret_cast<DataLog*>(impl)->AddSchema(
+      JStringRef{env, name}, JStringRef{env, type},
+      JSpan<const jbyte>{env, schema}.uarray(), timestamp);
+}
+
+/*
+ * Class:     edu_wpi_first_util_datalog_DataLogJNI
+ * Method:    addSchemaString
+ * Signature: (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;J)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_util_datalog_DataLogJNI_addSchemaString
+  (JNIEnv* env, jclass, jlong impl, jstring name, jstring type, jstring schema,
+   jlong timestamp)
+{
+  if (impl == 0) {
+    wpi::ThrowNullPointerException(env, "impl is null");
+    return;
+  }
+  JStringRef schemaStr{env, schema};
+  std::string_view schemaView = schemaStr.str();
+  reinterpret_cast<DataLog*>(impl)->AddSchema(
+      JStringRef{env, name}, JStringRef{env, type},
+      {reinterpret_cast<const uint8_t*>(schemaView.data()), schemaView.size()},
+      timestamp);
+}
+
+/*
+ * Class:     edu_wpi_first_util_datalog_DataLogJNI
  * Method:    start
  * Signature: (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;J)I
  */

--- a/wpiutil/src/main/native/cpp/protobuf/Protobuf.cpp
+++ b/wpiutil/src/main/native/cpp/protobuf/Protobuf.cpp
@@ -1,0 +1,194 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "wpi/protobuf/Protobuf.h"
+
+#include <fmt/format.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor.pb.h>
+#include <google/protobuf/io/zero_copy_stream.h>
+#include <google/protobuf/message.h>
+
+#include "wpi/SmallVector.h"
+
+using namespace wpi;
+
+using google::protobuf::Arena;
+using google::protobuf::FileDescriptor;
+using google::protobuf::FileDescriptorProto;
+
+namespace {
+class VectorOutputStream final
+    : public google::protobuf::io::ZeroCopyOutputStream {
+ public:
+  // Create a StringOutputStream which appends bytes to the given string.
+  // The string remains property of the caller, but it is mutated in arbitrary
+  // ways and MUST NOT be accessed in any way until you're done with the
+  // stream. Either be sure there's no further usage, or (safest) destroy the
+  // stream before using the contents.
+  //
+  // Hint:  If you call target->reserve(n) before creating the stream,
+  //   the first call to Next() will return at least n bytes of buffer
+  //   space.
+  explicit VectorOutputStream(std::vector<uint8_t>& target) : target_{target} {}
+  VectorOutputStream(const VectorOutputStream&) = delete;
+  ~VectorOutputStream() override = default;
+
+  VectorOutputStream& operator=(const VectorOutputStream&) = delete;
+
+  // implements ZeroCopyOutputStream ---------------------------------
+  bool Next(void** data, int* size) override;
+  void BackUp(int count) override { target_.resize(target_.size() - count); }
+  int64_t ByteCount() const override { return target_.size(); }
+
+ private:
+  static constexpr size_t kMinimumSize = 16;
+
+  std::vector<uint8_t>& target_;
+};
+
+class SmallVectorOutputStream final
+    : public google::protobuf::io::ZeroCopyOutputStream {
+ public:
+  // Create a StringOutputStream which appends bytes to the given string.
+  // The string remains property of the caller, but it is mutated in arbitrary
+  // ways and MUST NOT be accessed in any way until you're done with the
+  // stream. Either be sure there's no further usage, or (safest) destroy the
+  // stream before using the contents.
+  //
+  // Hint:  If you call target->reserve(n) before creating the stream,
+  //   the first call to Next() will return at least n bytes of buffer
+  //   space.
+  explicit SmallVectorOutputStream(wpi::SmallVectorImpl<uint8_t>& target)
+      : target_{target} {
+    target.resize(0);
+  }
+  SmallVectorOutputStream(const SmallVectorOutputStream&) = delete;
+  ~SmallVectorOutputStream() override = default;
+
+  SmallVectorOutputStream& operator=(const SmallVectorOutputStream&) = delete;
+
+  // implements ZeroCopyOutputStream ---------------------------------
+  bool Next(void** data, int* size) override;
+  void BackUp(int count) override { target_.resize(target_.size() - count); }
+  int64_t ByteCount() const override { return target_.size(); }
+
+ private:
+  static constexpr size_t kMinimumSize = 16;
+
+  wpi::SmallVectorImpl<uint8_t>& target_;
+};
+}  // namespace
+
+bool VectorOutputStream::Next(void** data, int* size) {
+  size_t old_size = target_.size();
+
+  // Grow the string.
+  size_t new_size;
+  if (old_size < target_.capacity()) {
+    // Resize to match its capacity, since we can get away
+    // without a memory allocation this way.
+    new_size = target_.capacity();
+  } else {
+    // Size has reached capacity, try to double it.
+    new_size = old_size * 2;
+  }
+  // Avoid integer overflow in returned '*size'.
+  new_size = (std::min)(new_size, old_size + (std::numeric_limits<int>::max)());
+  // Increase the size, also make sure that it is at least kMinimumSize.
+  target_.resize((std::max)(new_size, kMinimumSize));
+
+  *data = target_.data() + old_size;
+  *size = target_.size() - old_size;
+  return true;
+}
+
+bool SmallVectorOutputStream::Next(void** data, int* size) {
+  size_t old_size = target_.size();
+
+  // Grow the string.
+  size_t new_size;
+  if (old_size < target_.capacity()) {
+    // Resize to match its capacity, since we can get away
+    // without a memory allocation this way.
+    new_size = target_.capacity();
+  } else {
+    // Size has reached capacity, try to double it.
+    new_size = old_size * 2;
+  }
+  // Avoid integer overflow in returned '*size'.
+  new_size = (std::min)(new_size, old_size + (std::numeric_limits<int>::max)());
+  // Increase the size, also make sure that it is at least kMinimumSize.
+  target_.resize_for_overwrite((std::max)(new_size, kMinimumSize));
+
+  *data = target_.data() + old_size;
+  *size = target_.size() - old_size;
+  return true;
+}
+
+void detail::DeleteProtobuf(google::protobuf::Message* msg) {
+  if (msg && !msg->GetArena()) {
+    delete msg;
+  }
+}
+
+bool detail::ParseProtobuf(google::protobuf::Message* msg,
+                           std::span<const uint8_t> data) {
+  return msg->ParseFromArray(data.data(), data.size());
+}
+
+bool detail::SerializeProtobuf(wpi::SmallVectorImpl<uint8_t>& out,
+                               const google::protobuf::Message& msg) {
+  SmallVectorOutputStream stream{out};
+  return msg.SerializeToZeroCopyStream(&stream);
+}
+
+bool detail::SerializeProtobuf(std::vector<uint8_t>& out,
+                               const google::protobuf::Message& msg) {
+  VectorOutputStream stream{out};
+  return msg.SerializeToZeroCopyStream(&stream);
+}
+
+std::string detail::GetTypeString(const google::protobuf::Message& msg) {
+  return fmt::format("proto:{}", msg.GetDescriptor()->full_name());
+}
+
+static void ForEachProtobufDescriptorImpl(
+    const FileDescriptor* desc,
+    function_ref<bool(std::string_view typeString)> exists,
+    function_ref<void(std::string_view typeString,
+                      std::span<const uint8_t> schema)>
+        fn,
+    Arena* arena, FileDescriptorProto** descproto) {
+  std::string name = fmt::format("proto:{}", desc->name());
+  if (exists(name)) {
+    return;
+  }
+  for (int i = 0, ndep = desc->dependency_count(); i < ndep; ++i) {
+    ForEachProtobufDescriptorImpl(desc->dependency(i), exists, fn, arena,
+                                  descproto);
+  }
+  if (!*descproto) {
+    *descproto = Arena::CreateMessage<FileDescriptorProto>(arena);
+  }
+  (*descproto)->Clear();
+  desc->CopyTo(*descproto);
+  SmallVector<uint8_t, 128> buf;
+  detail::SerializeProtobuf(buf, **descproto);
+  fn(name, buf);
+}
+
+void detail::ForEachProtobufDescriptor(
+    const google::protobuf::Message& msg,
+    function_ref<bool(std::string_view filename)> exists,
+    function_ref<void(std::string_view filename,
+                      std::span<const uint8_t> descriptor)>
+        fn) {
+  FileDescriptorProto* descproto = nullptr;
+  ForEachProtobufDescriptorImpl(msg.GetDescriptor()->file(), exists, fn,
+                                msg.GetArena(), &descproto);
+  if (descproto && !msg.GetArena()) {
+    delete descproto;
+  }
+}

--- a/wpiutil/src/main/native/cpp/protobuf/ProtobufMessageDatabase.cpp
+++ b/wpiutil/src/main/native/cpp/protobuf/ProtobufMessageDatabase.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "wpi/protobuf/ProtobufMessageDatabase.h"
+
+#include <google/protobuf/descriptor.h>
+
+using namespace wpi;
+
+using google::protobuf::Arena;
+using google::protobuf::FileDescriptorProto;
+using google::protobuf::Message;
+
+void ProtobufMessageDatabase::Add(std::string_view filename,
+                                  std::span<const uint8_t> data) {
+  auto& file = m_files[filename];
+  if (file.complete) {
+    file.complete = false;
+
+    // rebuild the pool EXCEPT for this descriptor
+    m_pool = std::make_unique<google::protobuf::DescriptorPool>();
+
+    for (auto&& p : m_files) {
+      p.second.inPool = false;
+    }
+    for (auto&& p : m_files) {
+      if (p.second.complete && !p.second.inPool) {
+        Rebuild(p.second);
+      }
+    }
+
+    // clear messages and reset factory; Find() will recreate as needed
+    m_msgs.clear();
+    m_factory = std::make_unique<google::protobuf::DynamicMessageFactory>();
+  }
+
+  if (!file.proto) {
+    file.proto = std::unique_ptr<FileDescriptorProto>{
+        Arena::CreateMessage<FileDescriptorProto>(nullptr)};
+  } else {
+    // replacing an existing one; remove any previously existing refs
+    for (auto&& dep : file.proto->dependency()) {
+      auto& depFile = m_files[dep];
+      std::erase(depFile.uses, filename);
+    }
+    file.proto->Clear();
+  }
+
+  // parse data
+  if (!file.proto->ParseFromArray(data.data(), data.size())) {
+    return;
+  }
+
+  Build(filename, file);
+}
+
+Message* ProtobufMessageDatabase::Find(std::string_view name) const {
+  // cached
+  auto& msg = m_msgs[name];
+  if (msg) {
+    return msg.get();
+  }
+
+  // need to create it
+  auto desc = m_pool->FindMessageTypeByName(std::string{name});
+  if (!desc) {
+    return nullptr;
+  }
+  msg = std::unique_ptr<Message>{m_factory->GetPrototype(desc)->New(nullptr)};
+  return msg.get();
+}
+
+void ProtobufMessageDatabase::Build(std::string_view filename,
+                                    ProtoFile& file) {
+  if (file.complete) {
+    return;
+  }
+  // are all of the dependencies complete?
+  bool complete = true;
+  for (auto&& dep : file.proto->dependency()) {
+    auto& depFile = m_files[dep];
+    if (!depFile.complete) {
+      complete = false;
+    }
+    depFile.uses.emplace_back(filename);
+  }
+  if (!complete) {
+    return;
+  }
+
+  // add to pool
+  if (!m_pool->BuildFile(*file.proto)) {
+    return;
+  }
+  file.inPool = true;
+  file.complete = true;
+
+  // recursively validate all uses
+  for (auto&& use : file.uses) {
+    Build(use, m_files[use]);
+  }
+}
+
+bool ProtobufMessageDatabase::Rebuild(ProtoFile& file) {
+  for (auto&& dep : file.proto->dependency()) {
+    auto& depFile = m_files[dep];
+    if (!depFile.inPool) {
+      if (!Rebuild(depFile)) {
+        return false;
+      }
+    }
+  }
+  if (!m_pool->BuildFile(*file.proto)) {
+    return false;
+  }
+  file.inPool = true;
+  return true;
+}

--- a/wpiutil/src/main/native/cpp/struct/DynamicStruct.cpp
+++ b/wpiutil/src/main/native/cpp/struct/DynamicStruct.cpp
@@ -1,0 +1,444 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "wpi/struct/DynamicStruct.h"
+
+#include <algorithm>
+
+#include <fmt/format.h>
+
+#include "wpi/Endian.h"
+#include "wpi/SmallString.h"
+#include "wpi/SmallVector.h"
+#include "wpi/raw_ostream.h"
+#include "wpi/struct/SchemaParser.h"
+
+using namespace wpi;
+
+static size_t TypeToSize(StructFieldType type) {
+  switch (type) {
+    case StructFieldType::kBool:
+    case StructFieldType::kChar:
+    case StructFieldType::kInt8:
+    case StructFieldType::kUint8:
+      return 1;
+    case StructFieldType::kInt16:
+    case StructFieldType::kUint16:
+      return 2;
+    case StructFieldType::kInt32:
+    case StructFieldType::kUint32:
+    case StructFieldType::kFloat:
+      return 4;
+    case StructFieldType::kInt64:
+    case StructFieldType::kUint64:
+    case StructFieldType::kDouble:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+static StructFieldType TypeStringToType(std::string_view str) {
+  if (str == "bool") {
+    return StructFieldType::kBool;
+  } else if (str == "char") {
+    return StructFieldType::kChar;
+  } else if (str == "int8") {
+    return StructFieldType::kInt8;
+  } else if (str == "int16") {
+    return StructFieldType::kInt16;
+  } else if (str == "int32") {
+    return StructFieldType::kInt32;
+  } else if (str == "int64") {
+    return StructFieldType::kInt64;
+  } else if (str == "uint8") {
+    return StructFieldType::kUint8;
+  } else if (str == "uint16") {
+    return StructFieldType::kUint16;
+  } else if (str == "uint32") {
+    return StructFieldType::kUint32;
+  } else if (str == "uint64") {
+    return StructFieldType::kUint64;
+  } else if (str == "float" || str == "float32") {
+    return StructFieldType::kFloat;
+  } else if (str == "double" || str == "float64") {
+    return StructFieldType::kDouble;
+  } else {
+    return StructFieldType::kStruct;
+  }
+}
+
+static inline unsigned int ToBitWidth(size_t size, unsigned int bitWidth) {
+  if (bitWidth == 0) {
+    return size * 8;
+  } else {
+    return bitWidth;
+  }
+}
+
+static inline uint64_t ToBitMask(size_t size, unsigned int bitWidth) {
+  if (size == 0) {
+    return 0;
+  } else {
+    return UINT64_MAX >> (64 - ToBitWidth(size, bitWidth));
+  }
+}
+
+StructFieldDescriptor::StructFieldDescriptor(
+    const StructDescriptor* parent, std::string_view name, StructFieldType type,
+    size_t size, size_t arraySize, unsigned int bitWidth, EnumValues enumValues,
+    const StructDescriptor* structDesc, const private_init&)
+    : m_parent{parent},
+      m_name{name},
+      m_size{size},
+      m_arraySize{arraySize},
+      m_enum{std::move(enumValues)},
+      m_struct{structDesc},
+      m_bitMask{ToBitMask(size, bitWidth)},
+      m_type{type},
+      m_bitWidth{ToBitWidth(size, bitWidth)} {}
+
+const StructFieldDescriptor* StructDescriptor::FindFieldByName(
+    std::string_view name) const {
+  auto it = m_fieldsByName.find(name);
+  if (it == m_fieldsByName.end()) {
+    return nullptr;
+  }
+  return &m_fields[it->second];
+}
+
+bool StructDescriptor::CheckCircular(
+    wpi::SmallVectorImpl<const StructDescriptor*>& stack) const {
+  stack.emplace_back(this);
+  for (auto&& ref : m_references) {
+    if (std::find(stack.begin(), stack.end(), ref) != stack.end()) {
+      [[unlikely]] return false;
+    }
+    if (!ref->CheckCircular(stack)) {
+      [[unlikely]] return false;
+    }
+  }
+  stack.pop_back();
+  return true;
+}
+
+std::string StructDescriptor::CalculateOffsets(
+    wpi::SmallVectorImpl<const StructDescriptor*>& stack) {
+  size_t offset = 0;
+  unsigned int shift = 0;
+  size_t prevBitfieldSize = 0;
+  for (auto&& field : m_fields) {
+    if (!field.IsBitField()) {
+      [[likely]] shift = 0;        // reset shift on non-bitfield element
+      offset += prevBitfieldSize;  // finish bitfield if active
+      prevBitfieldSize = 0;        // previous is now not bitfield
+      field.m_offset = offset;
+      if (field.m_struct) {
+        if (!field.m_struct->IsValid()) {
+          m_valid = false;
+          [[unlikely]] return {};
+        }
+        field.m_size = field.m_struct->m_size;
+      }
+      offset += field.m_size * field.m_arraySize;
+    } else {
+      if (field.m_type == StructFieldType::kBool && prevBitfieldSize != 0 &&
+          (shift + 1) <= (prevBitfieldSize * 8)) {
+        // bool takes on size of preceding bitfield type (if it fits)
+        field.m_size = prevBitfieldSize;
+      } else if (field.m_size != prevBitfieldSize ||
+                 (shift + field.m_bitWidth) > (field.m_size * 8)) {
+        shift = 0;
+        offset += prevBitfieldSize;
+      }
+      prevBitfieldSize = field.m_size;
+      field.m_offset = offset;
+      field.m_bitShift = shift;
+      shift += field.m_bitWidth;
+    }
+  }
+
+  // update struct size
+  m_size = offset + prevBitfieldSize;
+  m_valid = true;
+
+  // now that we're valid, referring types may be too
+  stack.emplace_back(this);
+  for (auto&& ref : m_references) {
+    if (std::find(stack.begin(), stack.end(), ref) != stack.end()) {
+      [[unlikely]] return fmt::format(
+          "internal error (inconsistent data): circular struct reference "
+          "between {} and {}",
+          m_name, ref->m_name);
+    }
+    auto err = ref->CalculateOffsets(stack);
+    if (!err.empty()) {
+      [[unlikely]] return err;
+    }
+  }
+  stack.pop_back();
+  return {};
+}
+
+const StructDescriptor* StructDescriptorDatabase::Add(std::string_view name,
+                                                      std::string_view schema,
+                                                      std::string* err) {
+  structparser::Parser parser{schema};
+  structparser::ParsedSchema parsed;
+  if (!parser.Parse(&parsed)) {
+    *err = fmt::format("parse error: {}", parser.GetError());
+    [[unlikely]] return nullptr;
+  }
+
+  // turn parsed schema into descriptors
+  auto& theStruct = m_structs[name];
+  if (!theStruct) {
+    theStruct = std::make_unique<StructDescriptor>(
+        name, StructDescriptor::private_init{});
+  }
+  theStruct->m_schema = schema;
+  theStruct->m_fields.clear();
+  theStruct->m_fields.reserve(parsed.declarations.size());
+  bool isValid = true;
+  for (auto&& decl : parsed.declarations) {
+    auto type = TypeStringToType(decl.typeString);
+    size_t size = TypeToSize(type);
+
+    // bitfield checks
+    if (decl.bitWidth != 0) {
+      // only integer or boolean types are allowed
+      if (type == StructFieldType::kChar || type == StructFieldType::kFloat ||
+          type == StructFieldType::kDouble ||
+          type == StructFieldType::kStruct) {
+        *err = fmt::format("field {}: type {} cannot be bitfield", decl.name,
+                           decl.typeString);
+        [[unlikely]] return nullptr;
+      }
+
+      // bit width cannot be larger than field size
+      if (decl.bitWidth > (size * 8)) {
+        *err = fmt::format("field {}: bit width {} exceeds type size",
+                           decl.name, decl.bitWidth);
+        [[unlikely]] return nullptr;
+      }
+
+      // bit width must be 1 for booleans
+      if (type == StructFieldType::kBool && decl.bitWidth != 1) {
+        *err = fmt::format("field {}: bit width must be 1 for bool type",
+                           decl.name);
+        [[unlikely]] return nullptr;
+      }
+
+      // cannot combine array and bitfield (shouldn't parse, but double-check)
+      if (decl.arraySize > 1) {
+        *err = fmt::format("field {}: cannot combine array and bitfield",
+                           decl.name);
+        [[unlikely]] return nullptr;
+      }
+    }
+
+    // struct handling
+    const StructDescriptor* structDesc = nullptr;
+    if (type == StructFieldType::kStruct) {
+      // recursive definitions are not allowed
+      if (decl.typeString == name) {
+        *err = fmt::format("field {}: recursive struct reference", decl.name);
+        [[unlikely]] return nullptr;
+      }
+
+      // cross-reference struct, creating a placeholder if necessary
+      auto& aStruct = m_structs[decl.typeString];
+      if (!aStruct) {
+        aStruct = std::make_unique<StructDescriptor>(
+            decl.typeString, StructDescriptor::private_init{});
+      }
+
+      // if the struct isn't valid, we can't be valid either
+      if (aStruct->IsValid()) {
+        size = aStruct->GetSize();
+      } else {
+        isValid = false;
+      }
+
+      // add to cross-references for when the struct does become valid
+      aStruct->m_references.emplace_back(theStruct.get());
+      structDesc = aStruct.get();
+    }
+
+    // create field
+    if (!theStruct->m_fieldsByName
+             .insert({decl.name, theStruct->m_fields.size()})
+             .second) {
+      *err = fmt::format("duplicate field {}", decl.name);
+      [[unlikely]] return nullptr;
+    }
+
+    theStruct->m_fields.emplace_back(theStruct.get(), decl.name, type, size,
+                                     decl.arraySize, decl.bitWidth,
+                                     std::move(decl.enumValues), structDesc,
+                                     StructFieldDescriptor::private_init{});
+  }
+
+  theStruct->m_valid = isValid;
+  if (isValid) {
+    // we have all the info needed, so calculate field offset & shift
+    wpi::SmallVector<const StructDescriptor*, 16> stack;
+    auto err2 = theStruct->CalculateOffsets(stack);
+    if (!err2.empty()) {
+      *err = std::move(err2);
+      [[unlikely]] return nullptr;
+    }
+  } else {
+    // check for circular reference
+    wpi::SmallVector<const StructDescriptor*, 16> stack;
+    if (!theStruct->CheckCircular(stack)) {
+      wpi::SmallString<128> buf;
+      wpi::raw_svector_ostream os{buf};
+      for (auto&& elem : stack) {
+        if (!buf.empty()) {
+          os << " <- ";
+        }
+        os << elem->GetName();
+      }
+      *err = fmt::format("circular struct reference: {}", os.str());
+      [[unlikely]] return nullptr;
+    }
+  }
+
+  return theStruct.get();
+}
+
+const StructDescriptor* StructDescriptorDatabase::Find(
+    std::string_view name) const {
+  auto it = m_structs.find(name);
+  if (it == m_structs.end()) {
+    return nullptr;
+  }
+  return it->second.get();
+}
+
+uint64_t DynamicStruct::GetFieldImpl(const StructFieldDescriptor* field,
+                                     size_t arrIndex) const {
+  assert(field->m_parent == m_desc);
+  assert(m_desc->IsValid());
+  assert(arrIndex < field->m_arraySize);
+  uint64_t val;
+  switch (field->m_size) {
+    case 1:
+      val = m_data[field->m_offset + arrIndex];
+      break;
+    case 2:
+      val = support::endian::read16le(&m_data[field->m_offset + arrIndex * 2]);
+      break;
+    case 4:
+      val = support::endian::read32le(&m_data[field->m_offset + arrIndex * 4]);
+      break;
+    case 8:
+      val = support::endian::read64le(&m_data[field->m_offset + arrIndex * 8]);
+      break;
+    default:
+      assert(false && "invalid field size");
+      return 0;
+  }
+  return (val >> field->m_bitShift) & field->m_bitMask;
+}
+
+void MutableDynamicStruct::SetData(std::span<const uint8_t> data) {
+  assert(data.size() >= m_desc->GetSize());
+  std::copy(data.begin(), data.begin() + m_desc->GetSize(), m_data.begin());
+}
+
+void MutableDynamicStruct::SetStringField(const StructFieldDescriptor* field,
+                                          std::string_view value) {
+  assert(field->m_type == StructFieldType::kChar);
+  assert(field->m_parent == m_desc);
+  assert(m_desc->IsValid());
+  size_t len = (std::min)(field->m_arraySize, value.size());
+  std::copy(value.begin(), value.begin() + len,
+            reinterpret_cast<char*>(&m_data[field->m_offset]));
+  std::fill(&m_data[field->m_offset + len],
+            &m_data[field->m_offset + field->m_arraySize], 0);
+}
+
+void MutableDynamicStruct::SetStructField(const StructFieldDescriptor* field,
+                                          const DynamicStruct& value,
+                                          size_t arrIndex) {
+  assert(field->m_type == StructFieldType::kStruct);
+  assert(field->m_parent == m_desc);
+  assert(m_desc->IsValid());
+  assert(value.GetDescriptor() == field->m_struct);
+  assert(value.GetDescriptor()->IsValid());
+  assert(arrIndex < field->m_arraySize);
+  auto source = value.GetData();
+  size_t len = field->m_struct->GetSize();
+  std::copy(source.begin(), source.begin() + len,
+            m_data.begin() + field->m_offset + arrIndex * len);
+}
+
+void MutableDynamicStruct::SetFieldImpl(const StructFieldDescriptor* field,
+                                        uint64_t value, size_t arrIndex) {
+  assert(field->m_parent == m_desc);
+  assert(m_desc->IsValid());
+  assert(arrIndex < field->m_arraySize);
+
+  // common case is no bit shift and no masking
+  if (!field->IsBitField()) {
+    switch (field->m_size) {
+      case 1:
+        m_data[field->m_offset + arrIndex] = value;
+        break;
+      case 2:
+        support::endian::write16le(&m_data[field->m_offset + arrIndex * 2],
+                                   value);
+        break;
+      case 4:
+        support::endian::write32le(&m_data[field->m_offset + arrIndex * 4],
+                                   value);
+        break;
+      case 8:
+        support::endian::write64le(&m_data[field->m_offset + arrIndex * 8],
+                                   value);
+        break;
+      default:
+        assert(false && "invalid field size");
+    }
+    return;
+  }
+
+  // handle bit shifting and masking into current value
+  switch (field->m_size) {
+    case 1: {
+      uint8_t* data = &m_data[field->m_offset + arrIndex];
+      *data &= ~(field->m_bitMask << field->m_bitShift);
+      *data |= (value & field->m_bitMask) << field->m_bitShift;
+      break;
+    }
+    case 2: {
+      uint8_t* data = &m_data[field->m_offset + arrIndex * 2];
+      uint16_t val = support::endian::read16le(data);
+      val &= ~(field->m_bitMask << field->m_bitShift);
+      val |= (value & field->m_bitMask) << field->m_bitShift;
+      support::endian::write16le(data, val);
+      break;
+    }
+    case 4: {
+      uint8_t* data = &m_data[field->m_offset + arrIndex * 4];
+      uint32_t val = support::endian::read32le(data);
+      val &= ~(field->m_bitMask << field->m_bitShift);
+      val |= (value & field->m_bitMask) << field->m_bitShift;
+      support::endian::write32le(data, val);
+      break;
+    }
+    case 8: {
+      uint8_t* data = &m_data[field->m_offset + arrIndex * 8];
+      uint64_t val = support::endian::read64le(data);
+      val &= ~(field->m_bitMask << field->m_bitShift);
+      val |= (value & field->m_bitMask) << field->m_bitShift;
+      support::endian::write64le(data, val);
+      break;
+    }
+    default:
+      assert(false && "invalid field size");
+  }
+}

--- a/wpiutil/src/main/native/cpp/struct/SchemaParser.cpp
+++ b/wpiutil/src/main/native/cpp/struct/SchemaParser.cpp
@@ -1,0 +1,238 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "wpi/struct/SchemaParser.h"
+
+#include <fmt/format.h>
+
+#include "wpi/StringExtras.h"
+
+using namespace wpi::structparser;
+
+std::string_view wpi::structparser::ToString(Token::Kind kind) {
+  switch (kind) {
+    case Token::kInteger:
+      return "integer";
+    case Token::kIdentifier:
+      return "identifier";
+    case Token::kLeftBracket:
+      return "'['";
+    case Token::kRightBracket:
+      return "']'";
+    case Token::kLeftBrace:
+      return "'{'";
+    case Token::kRightBrace:
+      return "'}'";
+    case Token::kColon:
+      return "':'";
+    case Token::kSemicolon:
+      return "';'";
+    case Token::kComma:
+      return "','";
+    case Token::kEquals:
+      return "'='";
+    case Token::kEndOfInput:
+      return "<EOF>";
+    default:
+      return "unknown";
+  }
+}
+
+Token Lexer::Scan() {
+  // skip whitespace
+  do {
+    Get();
+  } while (m_current == ' ' || m_current == '\t' || m_current == '\n' ||
+           m_current == '\r');
+  m_tokenStart = m_pos - 1;
+
+  switch (m_current) {
+    case '[':
+      return MakeToken(Token::kLeftBracket);
+    case ']':
+      return MakeToken(Token::kRightBracket);
+    case '{':
+      return MakeToken(Token::kLeftBrace);
+    case '}':
+      return MakeToken(Token::kRightBrace);
+    case ':':
+      return MakeToken(Token::kColon);
+    case ';':
+      return MakeToken(Token::kSemicolon);
+    case ',':
+      return MakeToken(Token::kComma);
+    case '=':
+      return MakeToken(Token::kEquals);
+    case '-':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+      return ScanInteger();
+    case -1:
+      return {Token::kEndOfInput, {}};
+    default:
+      if (isAlpha(m_current) || m_current == '_') {
+        [[likely]] return ScanIdentifier();
+      }
+      return MakeToken(Token::kUnknown);
+  }
+}
+
+Token Lexer::ScanInteger() {
+  do {
+    Get();
+  } while (isDigit(m_current));
+  Unget();
+  return MakeToken(Token::kInteger);
+}
+
+Token Lexer::ScanIdentifier() {
+  do {
+    Get();
+  } while (isAlnum(m_current) || m_current == '_');
+  Unget();
+  return MakeToken(Token::kIdentifier);
+}
+
+void Parser::FailExpect(Token::Kind desired) {
+  Fail(fmt::format("expected {}, got '{}'", ToString(desired), m_token.text));
+}
+
+void Parser::Fail(std::string_view msg) {
+  m_error = fmt::format("{}: {}", m_lexer.GetPosition(), msg);
+}
+
+bool Parser::Parse(ParsedSchema* out) {
+  do {
+    GetNextToken();
+    if (m_token.Is(Token::kSemicolon)) {
+      continue;
+    }
+    if (m_token.Is(Token::kEndOfInput)) {
+      break;
+    }
+    if (!ParseDeclaration(&out->declarations.emplace_back())) {
+      [[unlikely]] return false;
+    }
+  } while (m_token.kind != Token::kEndOfInput);
+  return true;
+}
+
+bool Parser::ParseDeclaration(ParsedDeclaration* out) {
+  // optional enum specification
+  if (m_token.Is(Token::kIdentifier) && m_token.text == "enum") {
+    GetNextToken();
+    if (!Expect(Token::kLeftBrace)) {
+      [[unlikely]] return false;
+    }
+    if (!ParseEnum(&out->enumValues)) {
+      [[unlikely]] return false;
+    }
+    GetNextToken();
+  } else if (m_token.Is(Token::kLeftBrace)) {
+    if (!ParseEnum(&out->enumValues)) {
+      [[unlikely]] return false;
+    }
+    GetNextToken();
+  }
+
+  // type name
+  if (!Expect(Token::kIdentifier)) {
+    [[unlikely]] return false;
+  }
+  out->typeString = m_token.text;
+  GetNextToken();
+
+  // identifier name
+  if (!Expect(Token::kIdentifier)) {
+    [[unlikely]] return false;
+  }
+  out->name = m_token.text;
+  GetNextToken();
+
+  // array or bit field
+  if (m_token.Is(Token::kLeftBracket)) {
+    GetNextToken();
+    if (!Expect(Token::kInteger)) {
+      [[unlikely]] return false;
+    }
+    auto val = parse_integer<uint64_t>(m_token.text, 10);
+    if (val && *val > 0) {
+      out->arraySize = *val;
+    } else {
+      Fail(fmt::format("array size '{}' is not a positive integer",
+                       m_token.text));
+      [[unlikely]] return false;
+    }
+    GetNextToken();
+    if (!Expect(Token::kRightBracket)) {
+      [[unlikely]] return false;
+    }
+    GetNextToken();
+  } else if (m_token.Is(Token::kColon)) {
+    GetNextToken();
+    if (!Expect(Token::kInteger)) {
+      [[unlikely]] return false;
+    }
+    auto val = parse_integer<unsigned int>(m_token.text, 10);
+    if (val && *val > 0) {
+      out->bitWidth = *val;
+    } else {
+      Fail(fmt::format("bitfield width '{}' is not a positive integer",
+                       m_token.text));
+      [[unlikely]] return false;
+    }
+    GetNextToken();
+  }
+
+  // declaration must end with EOF or semicolon
+  if (m_token.Is(Token::kEndOfInput)) {
+    return true;
+  }
+  return Expect(Token::kSemicolon);
+}
+
+bool Parser::ParseEnum(EnumValues* out) {
+  // we start with current = '{'
+  GetNextToken();
+  while (!m_token.Is(Token::kRightBrace)) {
+    if (!Expect(Token::kIdentifier)) {
+      [[unlikely]] return false;
+    }
+    std::string name;
+    name = m_token.text;
+    GetNextToken();
+    if (!Expect(Token::kEquals)) {
+      [[unlikely]] return false;
+    }
+    GetNextToken();
+    if (!Expect(Token::kInteger)) {
+      [[unlikely]] return false;
+    }
+    int64_t value;
+    if (auto val = parse_integer<int64_t>(m_token.text, 10)) {
+      value = *val;
+    } else {
+      Fail(fmt::format("could not parse enum value '{}'", m_token.text));
+      [[unlikely]] return false;
+    }
+    out->emplace_back(std::move(name), value);
+    GetNextToken();
+    if (m_token.Is(Token::kRightBrace)) {
+      break;
+    }
+    if (!Expect(Token::kComma)) {
+      [[unlikely]] return false;
+    }
+    GetNextToken();
+  }
+  return true;
+}

--- a/wpiutil/src/main/native/include/wpi/protobuf/Protobuf.h
+++ b/wpiutil/src/main/native/include/wpi/protobuf/Protobuf.h
@@ -1,0 +1,260 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <stdint.h>
+
+#include <concepts>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "wpi/function_ref.h"
+
+namespace google::protobuf {
+class Arena;
+class Message;
+}  // namespace google::protobuf
+
+namespace wpi {
+
+template <typename T>
+class SmallVectorImpl;
+
+/**
+ * Protobuf serialization template. Unspecialized class has no members; only
+ * specializations of this class are useful, and only if they meet the
+ * ProtobufSerializable concept.
+ *
+ * @tparam T type to serialize/deserialize
+ */
+template <typename T>
+struct Protobuf {};
+
+/**
+ * Specifies that a type is capable of protobuf serialization and
+ * deserialization.
+ *
+ * This is designed for serializing complex flexible data structures using
+ * code generated from a .proto file. Serialization consists of writing
+ * values into a mutable protobuf Message and deserialization consists of
+ * reading values from an immutable protobuf Message.
+ *
+ * Implementations must define a template specialization for wpi::Protobuf with
+ * T being the type that is being serialized/deserialized, with the following
+ * static members (as enforced by this concept):
+ * - google::protobuf::Message* New(google::protobuf::Arena*): create a protobuf
+ *   message
+ * - T Unpack(const google::protobuf::Message&): function for deserialization
+ * - void Pack(google::protobuf::Message*, T&& value): function for
+ *   serialization
+ *
+ * To avoid pulling in the protobuf headers, these functions use
+ * google::protobuf::Message instead of a more specific type; implementations
+ * will need to static_cast to the correct type as created by New().
+ *
+ * Additionally: In a static block, call StructRegistry.registerClass() to
+ * register the class
+ */
+template <typename T>
+concept ProtobufSerializable = requires(
+    google::protobuf::Arena* arena, const google::protobuf::Message& inmsg,
+    google::protobuf::Message* outmsg, const T& value) {
+  typename Protobuf<typename std::remove_cvref_t<T>>;
+  {
+    Protobuf<typename std::remove_cvref_t<T>>::New(arena)
+  } -> std::same_as<google::protobuf::Message*>;
+  {
+    Protobuf<typename std::remove_cvref_t<T>>::Unpack(inmsg)
+  } -> std::same_as<typename std::remove_cvref_t<T>>;
+  Protobuf<typename std::remove_cvref_t<T>>::Pack(outmsg, value);
+};
+
+/**
+ * Specifies that a type is capable of in-place protobuf deserialization.
+ *
+ * In addition to meeting ProtobufSerializable, implementations must define a
+ * wpi::Protobuf<T> static member
+ * `void UnpackInto(T*, const google::protobuf::Message&)` to update the
+ * pointed-to T with the contents of the message.
+ */
+template <typename T>
+concept MutableProtobufSerializable =
+    ProtobufSerializable<T> &&
+    requires(T* out, const google::protobuf::Message& msg) {
+      Protobuf<typename std::remove_cvref_t<T>>::UnpackInto(out, msg);
+    };
+
+/**
+ * Unpack a serialized protobuf message.
+ *
+ * @tparam T object type
+ * @param msg protobuf message
+ * @return Deserialized object
+ */
+template <ProtobufSerializable T>
+inline T UnpackProtobuf(const google::protobuf::Message& msg) {
+  return Protobuf<T>::Unpack(msg);
+}
+
+/**
+ * Pack a serialized protobuf message.
+ *
+ * @param msg protobuf message (mutable, output)
+ * @param value object
+ */
+template <ProtobufSerializable T>
+inline void PackProtobuf(google::protobuf::Message* msg, const T& value) {
+  Protobuf<typename std::remove_cvref_t<T>>::Pack(msg, value);
+}
+
+/**
+ * Unpack a serialized struct into an existing object, overwriting its contents.
+ *
+ * @param out object (output)
+ * @param msg protobuf message
+ */
+template <ProtobufSerializable T>
+inline void UnpackProtobufInto(T* out, const google::protobuf::Message& msg) {
+  if constexpr (MutableProtobufSerializable<T>) {
+    Protobuf<T>::UnpackInto(out, msg);
+  } else {
+    *out = UnpackProtobuf<T>(msg);
+  }
+}
+
+// these detail functions avoid the need to include protobuf headers
+namespace detail {
+void DeleteProtobuf(google::protobuf::Message* msg);
+bool ParseProtobuf(google::protobuf::Message* msg,
+                   std::span<const uint8_t> data);
+bool SerializeProtobuf(wpi::SmallVectorImpl<uint8_t>& out,
+                       const google::protobuf::Message& msg);
+bool SerializeProtobuf(std::vector<uint8_t>& out,
+                       const google::protobuf::Message& msg);
+std::string GetTypeString(const google::protobuf::Message& msg);
+void ForEachProtobufDescriptor(
+    const google::protobuf::Message& msg,
+    function_ref<bool(std::string_view filename)> wants,
+    function_ref<void(std::string_view filename,
+                      std::span<const uint8_t> descriptor)>
+        fn);
+}  // namespace detail
+
+/**
+ * Owning wrapper (ala std::unique_ptr) for google::protobuf::Message* that does
+ * not require the protobuf headers be included. Note this object is not thread
+ * safe; users of this object are required to provide any necessary thread
+ * safety.
+ *
+ * @tparam T serialized object type
+ */
+template <ProtobufSerializable T>
+class ProtobufMessage {
+ public:
+  explicit ProtobufMessage(google::protobuf::Arena* arena = nullptr)
+      : m_msg{Protobuf<T>::New(arena)} {}
+  ~ProtobufMessage() { detail::DeleteProtobuf(m_msg); }
+  ProtobufMessage(const ProtobufMessage&) = delete;
+  ProtobufMessage& operator=(const ProtobufMessage&) = delete;
+  ProtobufMessage(ProtobufMessage&& rhs) : m_msg{rhs.m_msg} {
+    rhs.m_msg = nullptr;
+  }
+  ProtobufMessage& operator=(ProtobufMessage&& rhs) {
+    std::swap(m_msg, rhs.m_msg);
+    return *this;
+  }
+
+  /**
+   * Gets the stored message object.
+   *
+   * @return google::protobuf::Message*
+   */
+  google::protobuf::Message* GetMessage() { return m_msg; }
+  const google::protobuf::Message* GetMessage() const { return m_msg; }
+
+  /**
+   * Unpacks from a byte array.
+   *
+   * @param data byte array
+   * @return Optional; empty if parsing failed
+   */
+  std::optional<T> Unpack(std::span<const uint8_t> data) {
+    if (!detail::ParseProtobuf(m_msg, data)) {
+      return std::nullopt;
+    }
+    return Protobuf<T>::Unpack(*m_msg);
+  }
+
+  /**
+   * Unpacks from a byte array into an existing object.
+   *
+   * @param[out] out output object
+   * @param[in] data byte array
+   * @return true if successful
+   */
+  bool UnpackInto(T* out, std::span<const uint8_t> data) {
+    if (!detail::ParseProtobuf(m_msg, data)) {
+      return false;
+    }
+    UnpackProtobufInto(out, *m_msg);
+    return true;
+  }
+
+  /**
+   * Packs object into a SmallVector.
+   *
+   * @param[out] out output bytes
+   * @param[in] value value
+   * @return true if successful
+   */
+  bool Pack(wpi::SmallVectorImpl<uint8_t>& out, const T& value) {
+    Protobuf<T>::Pack(m_msg, value);
+    return detail::SerializeProtobuf(out, *m_msg);
+  }
+
+  /**
+   * Packs object into a std::vector.
+   *
+   * @param[out] out output bytes
+   * @param[in] value value
+   * @return true if successful
+   */
+  bool Pack(std::vector<uint8_t>& out, const T& value) {
+    Protobuf<T>::Pack(m_msg, value);
+    return detail::SerializeProtobuf(out, *m_msg);
+  }
+
+  /**
+   * Gets the type string for the message.
+   *
+   * @return type string
+   */
+  std::string GetTypeString() const { return detail::GetTypeString(*m_msg); }
+
+  /**
+   * Loops over all protobuf descriptors including nested/referenced
+   * descriptors.
+   *
+   * @param exists function that returns false if fn should be called for the
+   *               given type string
+   * @param fn function to call for each descriptor
+   */
+  void ForEachProtobufDescriptor(
+      function_ref<bool(std::string_view filename)> exists,
+      function_ref<void(std::string_view filename,
+                        std::span<const uint8_t> descriptor)>
+          fn) {
+    detail::ForEachProtobufDescriptor(*m_msg, exists, fn);
+  }
+
+ private:
+  google::protobuf::Message* m_msg = nullptr;
+};
+
+}  // namespace wpi

--- a/wpiutil/src/main/native/include/wpi/protobuf/ProtobufMessageDatabase.h
+++ b/wpiutil/src/main/native/include/wpi/protobuf/ProtobufMessageDatabase.h
@@ -1,0 +1,76 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <google/protobuf/descriptor.pb.h>
+#include <google/protobuf/descriptor_database.h>
+#include <google/protobuf/dynamic_message.h>
+
+#include "wpi/StringMap.h"
+
+namespace wpi {
+
+/**
+ * Database of protobuf dynamic messages. Unlike the protobuf descriptor pools
+ * and databases, this gracefully handles adding descriptors out of order and
+ * descriptors being replaced.
+ */
+class ProtobufMessageDatabase {
+ public:
+  /**
+   * Adds a file descriptor to the database. If the file references other
+   * files that have not yet been added, no messages in that file will be
+   * available until those files are added. Replaces any existing file with
+   * the same name.
+   *
+   * @param filename filename
+   * @param data FileDescriptorProto serialized data
+   */
+  void Add(std::string_view filename, std::span<const uint8_t> data);
+
+  /**
+   * Finds a message in the database by name.
+   *
+   * @param name type name
+   * @return protobuf message, or nullptr if not found
+   */
+  google::protobuf::Message* Find(std::string_view name) const;
+
+  /**
+   * Gets message factory.
+   *
+   * @return message factory
+   */
+  google::protobuf::MessageFactory* GetMessageFactory() {
+    return m_factory.get();
+  }
+
+ private:
+  struct ProtoFile {
+    std::unique_ptr<google::protobuf::FileDescriptorProto> proto;
+    std::vector<std::string> uses;
+    bool complete = false;
+    bool inPool = false;
+  };
+
+  void Build(std::string_view filename, ProtoFile& file);
+  bool Rebuild(ProtoFile& file);
+
+  std::unique_ptr<google::protobuf::DescriptorPool> m_pool =
+      std::make_unique<google::protobuf::DescriptorPool>();
+  std::unique_ptr<google::protobuf::DynamicMessageFactory> m_factory =
+      std::make_unique<google::protobuf::DynamicMessageFactory>();
+  wpi::StringMap<ProtoFile> m_files;  // indexed by filename
+  // indexed by type string
+  mutable wpi::StringMap<std::unique_ptr<google::protobuf::Message>> m_msgs;
+};
+
+}  // namespace wpi

--- a/wpiutil/src/main/native/include/wpi/struct/DynamicStruct.h
+++ b/wpiutil/src/main/native/include/wpi/struct/DynamicStruct.h
@@ -1,0 +1,682 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <stdint.h>
+
+#include <cassert>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "wpi/MathExtras.h"
+#include "wpi/StringMap.h"
+#include "wpi/bit.h"
+
+namespace wpi {
+
+template <typename T>
+class SmallVectorImpl;
+
+class DynamicStruct;
+class MutableDynamicStruct;
+class StructDescriptor;
+class StructDescriptorDatabase;
+
+/**
+ * Known data types for raw struct dynamic fields (see StructFieldDescriptor).
+ */
+enum class StructFieldType {
+  kBool,
+  kChar,
+  kInt8,
+  kInt16,
+  kInt32,
+  kInt64,
+  kUint8,
+  kUint16,
+  kUint32,
+  kUint64,
+  kFloat,
+  kDouble,
+  kStruct
+};
+
+/**
+ * Raw struct dynamic field descriptor.
+ */
+class StructFieldDescriptor {
+  struct private_init {};
+  friend class DynamicStruct;
+  friend class MutableDynamicStruct;
+  friend class StructDescriptor;
+  friend class StructDescriptorDatabase;
+
+ public:
+  /**
+   * Set of enumerated values.
+   */
+  using EnumValues = std::vector<std::pair<std::string, int64_t>>;
+
+  StructFieldDescriptor(const StructDescriptor* parent, std::string_view name,
+                        StructFieldType type, size_t size, size_t arraySize,
+                        unsigned int bitWidth, EnumValues enumValues,
+                        const StructDescriptor* structDesc,
+                        const private_init&);
+
+  /**
+   * Gets the dynamic struct this field is contained in.
+   *
+   * @return struct descriptor
+   */
+  const StructDescriptor* GetParent() const { return m_parent; }
+
+  /**
+   * Gets the field name.
+   *
+   * @return field name
+   */
+  const std::string& GetName() const { return m_name; }
+
+  /**
+   * Gets the field type.
+   *
+   * @return field type
+   */
+  StructFieldType GetType() const { return m_type; }
+
+  /**
+   * Returns whether the field type is a signed integer.
+   *
+   * @return true if signed integer, false otherwise
+   */
+  bool IsInt() const {
+    return m_type == StructFieldType::kInt8 ||
+           m_type == StructFieldType::kInt16 ||
+           m_type == StructFieldType::kInt32 ||
+           m_type == StructFieldType::kInt64;
+  }
+
+  /**
+   * Returns whether the field type is an unsigned integer.
+   *
+   * @return true if unsigned integer, false otherwise
+   */
+  bool IsUint() const {
+    return m_type == StructFieldType::kUint8 ||
+           m_type == StructFieldType::kUint16 ||
+           m_type == StructFieldType::kUint32 ||
+           m_type == StructFieldType::kUint64;
+  }
+
+  /**
+   * Gets the underlying storage size of the field, in bytes.
+   *
+   * @return number of bytes
+   */
+  size_t GetSize() const { return m_size; }
+
+  /**
+   * Gets the storage offset of the field, in bytes.
+   *
+   * @return number of bytes from the start of the struct
+   */
+  size_t GetOffset() const { return m_offset; }
+
+  /**
+   * Gets the bit width of the field, in bits.
+   *
+   * @return number of bits
+   */
+  unsigned int GetBitWidth() const {
+    return m_bitWidth == 0 ? m_size * 8 : m_bitWidth;
+  }
+
+  /**
+   * Gets the bit mask for the field. The mask is always the least significant
+   * bits (it is not shifted).
+   *
+   * @return bit mask
+   */
+  uint64_t GetBitMask() const { return m_bitMask; }
+
+  /**
+   * Gets the bit shift for the field (LSB=0).
+   *
+   * @return number of bits
+   */
+  unsigned int GetBitShift() const { return m_bitShift; }
+
+  /**
+   * Returns whether the field is an array.
+   *
+   * @return true if array
+   */
+  bool IsArray() const { return m_arraySize > 1; }
+
+  /**
+   * Gets the array size. Returns 1 if non-array.
+   *
+   * @return number of elements
+   */
+  size_t GetArraySize() const { return m_arraySize; }
+
+  /**
+   * Returns whether the field has enumerated values.
+   *
+   * @return true if there are enumerated values
+   */
+  bool HasEnum() const { return !m_enum.empty(); }
+
+  /**
+   * Gets the enumerated values.
+   *
+   * @return set of enumerated values
+   */
+  const EnumValues& GetEnumValues() { return m_enum; }
+
+  /**
+   * Gets the struct descriptor for a struct data type.
+   *
+   * @return struct descriptor; returns null for non-struct
+   */
+  const StructDescriptor* GetStruct() const { return m_struct; }
+
+  /**
+   * Gets the minimum unsigned integer value that can be stored in this field.
+   *
+   * @return minimum value
+   */
+  uint64_t GetUintMin() const { return 0; }
+
+  /**
+   * Gets the maximum unsigned integer value that can be stored in this field.
+   *
+   * @return maximum value
+   */
+  uint64_t GetUintMax() const { return m_bitMask; }
+
+  /**
+   * Gets the minimum signed integer value that can be stored in this field.
+   *
+   * @return minimum value
+   */
+  int64_t GetIntMin() const {
+    return static_cast<int64_t>(-(m_bitMask >> 1)) - 1;
+  }
+
+  /**
+   * Gets the maximum signed integer value that can be stored in this field.
+   *
+   * @return maximum value
+   */
+  int64_t GetIntMax() const { return m_bitMask >> 1; }
+
+  /**
+   * Returns whether the field is a bitfield.
+   *
+   * @return true if bitfield
+   */
+  bool IsBitField() const {
+    return m_bitShift != 0 || m_bitWidth != (m_size * 8);
+  }
+
+ private:
+  // note: constructor fills in everything except offset and shift
+  const StructDescriptor* m_parent;
+  std::string m_name;
+  size_t m_size;
+  size_t m_offset = 0;
+  size_t m_arraySize;  // 1 for non-arrays
+  EnumValues m_enum;
+  const StructDescriptor* m_struct;  // nullptr for non-structs
+  uint64_t m_bitMask;
+  StructFieldType m_type;
+  unsigned int m_bitWidth;
+  unsigned int m_bitShift = 0;
+};
+
+/**
+ * Raw struct dynamic struct descriptor.
+ */
+class StructDescriptor {
+  struct private_init {};
+  friend class StructDescriptorDatabase;
+
+ public:
+  StructDescriptor(std::string_view name, const private_init&) : m_name{name} {}
+
+  /**
+   * Gets the struct name.
+   *
+   * @return name
+   */
+  const std::string& GetName() const { return m_name; }
+
+  /**
+   * Gets the struct schema.
+   *
+   * @return schema
+   */
+  const std::string& GetSchema() const { return m_schema; }
+
+  /**
+   * Returns whether the struct is valid (e.g. the struct is fully defined and
+   * field offsets computed).
+   *
+   * @return true if valid
+   */
+  bool IsValid() const { return m_valid; }
+
+  /**
+   * Returns the struct size, in bytes. Not valid unless IsValid() is true.
+   *
+   * @return size in bytes
+   */
+  size_t GetSize() const {
+    assert(m_valid);
+    return m_size;
+  }
+
+  /**
+   * Gets a field descriptor by name. Note the field cannot be accessed until
+   * the struct is valid.
+   *
+   * @param name field name
+   * @return field descriptor, or nullptr if not found
+   */
+  const StructFieldDescriptor* FindFieldByName(std::string_view name) const;
+
+  /**
+   * Gets all field descriptors. Note fields cannot be accessed until the struct
+   * is valid.
+   *
+   * @return field descriptors
+   */
+  const std::vector<StructFieldDescriptor>& GetFields() const {
+    return m_fields;
+  }
+
+ private:
+  bool CheckCircular(
+      wpi::SmallVectorImpl<const StructDescriptor*>& stack) const;
+  std::string CalculateOffsets(
+      wpi::SmallVectorImpl<const StructDescriptor*>& stack);
+
+  std::string m_name;
+  std::string m_schema;
+  std::vector<StructDescriptor*> m_references;
+  std::vector<StructFieldDescriptor> m_fields;
+  StringMap<size_t> m_fieldsByName;
+  size_t m_size = 0;
+  bool m_valid = false;
+};
+
+/**
+ * Database of raw struct dynamic descriptors.
+ */
+class StructDescriptorDatabase {
+ public:
+  /**
+   * Adds a structure schema to the database. If the struct references other
+   * structs that have not yet been added, it will not be valid until those
+   * structs are also added.
+   *
+   * @param[in] name structure name
+   * @param[in] schema structure schema
+   * @param[out] err detailed error, if nullptr is returned
+   * @return Added struct, or nullptr on error
+   */
+  const StructDescriptor* Add(std::string_view name, std::string_view schema,
+                              std::string* err);
+
+  /**
+   * Finds a structure in the database by name.
+   *
+   * @param name structure name
+   * @return struct descriptor, or nullptr if not found
+   */
+  const StructDescriptor* Find(std::string_view name) const;
+
+ private:
+  StringMap<std::unique_ptr<StructDescriptor>> m_structs;
+};
+
+/**
+ * Dynamic (run-time) read-only access to a serialized raw struct.
+ */
+class DynamicStruct {
+ public:
+  /**
+   * Constructs a new dynamic struct. Note: the passed data is a span; no copy
+   * is made, so it's necessary for the lifetime of the referenced data to be
+   * longer than this object.
+   *
+   * @param desc struct descriptor
+   * @param data serialized data
+   */
+  DynamicStruct(const StructDescriptor* desc, std::span<const uint8_t> data)
+      : m_desc{desc}, m_data{data} {}
+
+  /**
+   * Gets the struct descriptor.
+   *
+   * @return struct descriptor
+   */
+  const StructDescriptor* GetDescriptor() const { return m_desc; }
+
+  /**
+   * Gets the serialized data.
+   *
+   * @return data
+   */
+  std::span<const uint8_t> GetData() const { return m_data; }
+
+  /**
+   * Gets a struct field descriptor by name.
+   *
+   * @param name field name
+   * @return field descriptor, or nullptr if no field with that name exists
+   */
+  const StructFieldDescriptor* FindField(std::string_view name) const {
+    return m_desc->FindFieldByName(name);
+  }
+
+  /**
+   * Gets the value of a boolean field.
+   *
+   * @param field field descriptor
+   * @param arrIndex array index (must be less than field array size)
+   * @return field value
+   */
+  bool GetBoolField(const StructFieldDescriptor* field,
+                    size_t arrIndex = 0) const {
+    assert(field->m_type == StructFieldType::kBool);
+    return GetFieldImpl(field, arrIndex);
+  }
+
+  /**
+   * Gets the value of a signed integer field.
+   *
+   * @param field field descriptor
+   * @param arrIndex array index (must be less than field array size)
+   * @return field value
+   */
+  int64_t GetIntField(const StructFieldDescriptor* field,
+                      size_t arrIndex = 0) const {
+    assert(field->IsInt());
+    return GetFieldImpl(field, arrIndex);
+  }
+
+  /**
+   * Gets the value of an unsigned integer field.
+   *
+   * @param field field descriptor
+   * @param arrIndex array index (must be less than field array size)
+   * @return field value
+   */
+  uint64_t GetUintField(const StructFieldDescriptor* field,
+                        size_t arrIndex = 0) const {
+    assert(field->IsUint());
+    return GetFieldImpl(field, arrIndex);
+  }
+
+  /**
+   * Gets the value of a float field.
+   *
+   * @param field field descriptor
+   * @param arrIndex array index (must be less than field array size)
+   * @return field value
+   */
+  float GetFloatField(const StructFieldDescriptor* field,
+                      size_t arrIndex = 0) const {
+    assert(field->m_type == StructFieldType::kFloat);
+    return bit_cast<float>(
+        static_cast<uint32_t>(GetFieldImpl(field, arrIndex)));
+  }
+
+  /**
+   * Gets the value of a double field.
+   *
+   * @param field field descriptor
+   * @param arrIndex array index (must be less than field array size)
+   * @return field value
+   */
+  double GetDoubleField(const StructFieldDescriptor* field,
+                        size_t arrIndex = 0) const {
+    assert(field->m_type == StructFieldType::kDouble);
+    return bit_cast<double>(GetFieldImpl(field, arrIndex));
+  }
+
+  /**
+   * Gets the value of a char or char array field.
+   *
+   * @param field field descriptor
+   * @return field value
+   */
+  std::string_view GetStringField(const StructFieldDescriptor* field) const {
+    assert(field->m_type == StructFieldType::kChar);
+    assert(field->m_parent == m_desc);
+    assert(m_desc->IsValid());
+    return {reinterpret_cast<const char*>(&m_data[field->m_offset]),
+            field->m_arraySize};
+  }
+
+  /**
+   * Gets the value of a struct field.
+   *
+   * @param field field descriptor
+   * @param arrIndex array index (must be less than field array size)
+   * @return field value
+   */
+  DynamicStruct GetStructField(const StructFieldDescriptor* field,
+                               size_t arrIndex = 0) const {
+    assert(field->m_type == StructFieldType::kStruct);
+    assert(field->m_parent == m_desc);
+    assert(m_desc->IsValid());
+    assert(arrIndex < field->m_arraySize);
+    return DynamicStruct{field->m_struct,
+                         m_data.subspan(field->m_offset +
+                                        arrIndex * field->m_struct->GetSize())};
+  }
+
+ protected:
+  const StructDescriptor* m_desc;
+
+ private:
+  uint64_t GetFieldImpl(const StructFieldDescriptor* field,
+                        size_t arrIndex) const;
+
+  std::span<const uint8_t> m_data;
+};
+
+/**
+ * Dynamic (run-time) mutable access to a serialized raw struct.
+ */
+class MutableDynamicStruct : public DynamicStruct {
+ public:
+  /**
+   * Constructs a new dynamic struct. Note: the passed data is a span; no copy
+   * is made, so it's necessary for the lifetime of the referenced data to be
+   * longer than this object.
+   *
+   * @param desc struct descriptor
+   * @param data serialized data
+   */
+  MutableDynamicStruct(const StructDescriptor* desc, std::span<uint8_t> data)
+      : DynamicStruct{desc, data}, m_data{data} {}
+
+  /**
+   * Gets the serialized data.
+   *
+   * @return data
+   */
+  std::span<uint8_t> GetData() { return m_data; }
+
+  using DynamicStruct::GetData;
+
+  /**
+   * Overwrites the entire serialized struct by copying data from a span.
+   *
+   * @param data replacement data for the struct
+   */
+  void SetData(std::span<const uint8_t> data);
+
+  /**
+   * Sets the value of a boolean field.
+   *
+   * @param field field descriptor
+   * @param value field value
+   * @param arrIndex array index (must be less than field array size)
+   */
+  void SetBoolField(const StructFieldDescriptor* field, bool value,
+                    size_t arrIndex = 0) {
+    assert(field->m_type == StructFieldType::kBool);
+    SetFieldImpl(field, value ? 1 : 0, arrIndex);
+  }
+
+  /**
+   * Sets the value of a signed integer field.
+   *
+   * @param field field descriptor
+   * @param value field value
+   * @param arrIndex array index (must be less than field array size)
+   */
+  void SetIntField(const StructFieldDescriptor* field, int64_t value,
+                   size_t arrIndex = 0) {
+    assert(field->IsInt());
+    SetFieldImpl(field, value, arrIndex);
+  }
+
+  /**
+   * Sets the value of an unsigned integer field.
+   *
+   * @param field field descriptor
+   * @param value field value
+   * @param arrIndex array index (must be less than field array size)
+   */
+  void SetUintField(const StructFieldDescriptor* field, uint64_t value,
+                    size_t arrIndex = 0) {
+    assert(field->IsUint());
+    SetFieldImpl(field, value, arrIndex);
+  }
+
+  /**
+   * Sets the value of a float field.
+   *
+   * @param field field descriptor
+   * @param value field value
+   * @param arrIndex array index (must be less than field array size)
+   */
+  void SetFloatField(const StructFieldDescriptor* field, float value,
+                     size_t arrIndex = 0) {
+    assert(field->m_type == StructFieldType::kFloat);
+    SetFieldImpl(field, bit_cast<uint32_t>(value), arrIndex);
+  }
+
+  /**
+   * Sets the value of a double field.
+   *
+   * @param field field descriptor
+   * @param value field value
+   * @param arrIndex array index (must be less than field array size)
+   */
+  void SetDoubleField(const StructFieldDescriptor* field, double value,
+                      size_t arrIndex = 0) {
+    assert(field->m_type == StructFieldType::kDouble);
+    SetFieldImpl(field, bit_cast<uint64_t>(value), arrIndex);
+  }
+
+  /**
+   * Sets the value of a char or char array field.
+   *
+   * @param field field descriptor
+   * @param value field value
+   */
+  void SetStringField(const StructFieldDescriptor* field,
+                      std::string_view value);
+
+  /**
+   * Sets the value of a struct field.
+   *
+   * @param field field descriptor
+   * @param value field value
+   * @param arrIndex array index (must be less than field array size)
+   */
+  void SetStructField(const StructFieldDescriptor* field,
+                      const DynamicStruct& value, size_t arrIndex = 0);
+
+  /**
+   * Gets the value of a struct field.
+   *
+   * @param field field descriptor
+   * @param arrIndex array index (must be less than field array size)
+   * @return field value
+   */
+  MutableDynamicStruct GetStructField(const StructFieldDescriptor* field,
+                                      size_t arrIndex = 0) {
+    assert(field->m_type == StructFieldType::kStruct);
+    assert(field->m_parent == m_desc);
+    assert(m_desc->IsValid());
+    assert(arrIndex < field->m_arraySize);
+    return MutableDynamicStruct{
+        field->m_struct, m_data.subspan(field->m_offset +
+                                        arrIndex * field->m_struct->GetSize())};
+  }
+
+  using DynamicStruct::GetStructField;
+
+ private:
+  void SetFieldImpl(const StructFieldDescriptor* field, uint64_t value,
+                    size_t arrIndex);
+
+  std::span<uint8_t> m_data;
+};
+
+namespace impl {
+struct DSOData {
+  explicit DSOData(size_t size) : m_dataStore(size) {}
+  explicit DSOData(std::span<const uint8_t> data)
+      : m_dataStore{data.begin(), data.end()} {}
+
+  std::vector<uint8_t> m_dataStore;
+};
+}  // namespace impl
+
+/**
+ * Dynamic (run-time) mutable access to a serialized raw struct, with internal
+ * data storage.
+ */
+class DynamicStructObject : private impl::DSOData, public MutableDynamicStruct {
+  /**
+   * Constructs a new dynamic struct object. The descriptor must be valid.
+   *
+   * @param desc struct descriptor
+   */
+  explicit DynamicStructObject(const StructDescriptor* desc)
+      : DSOData{desc->GetSize()}, MutableDynamicStruct{desc, m_dataStore} {}
+
+  /**
+   * Constructs a new dynamic struct object. Makes a copy of the serialized
+   * data so there are no lifetime constraints on the data parameter.
+   *
+   * @param desc struct descriptor
+   * @param data serialized data
+   */
+  DynamicStructObject(const StructDescriptor* desc,
+                      std::span<const uint8_t> data)
+      : DSOData{data}, MutableDynamicStruct{desc, m_dataStore} {
+    assert(data.size() >= desc->GetSize());
+  }
+
+  // can't be movable due to span references
+  DynamicStructObject(DynamicStructObject&&) = delete;
+  DynamicStructObject& operator=(DynamicStructObject&&) = delete;
+};
+
+}  // namespace wpi

--- a/wpiutil/src/main/native/include/wpi/struct/SchemaParser.h
+++ b/wpiutil/src/main/native/include/wpi/struct/SchemaParser.h
@@ -1,0 +1,186 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <stdint.h>
+
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace wpi::structparser {
+
+/**
+ * A lexed raw struct schema token.
+ */
+struct Token {
+  enum Kind {
+    kUnknown,
+    kInteger,
+    kIdentifier,
+    kLeftBracket,
+    kRightBracket,
+    kLeftBrace,
+    kRightBrace,
+    kColon,
+    kSemicolon,
+    kComma,
+    kEquals,
+    kEndOfInput,
+  };
+
+  Token() = default;
+  Token(Kind kind, std::string_view text) : kind{kind}, text{text} {}
+
+  bool Is(Kind k) const { return kind == k; }
+
+  Kind kind = kUnknown;
+  std::string_view text;
+};
+
+std::string_view ToString(Token::Kind kind);
+
+/**
+ * Raw struct schema lexer.
+ */
+class Lexer {
+ public:
+  /**
+   * Construct a raw struct schema lexer.
+   *
+   * @param in schema
+   */
+  explicit Lexer(std::string_view in) : m_in{in} {}
+
+  /**
+   * Gets the next token.
+   *
+   * @return Token
+   */
+  [[nodiscard]]
+  Token Scan();
+
+  /**
+   * Gets the starting position of the last lexed token.
+   *
+   * @return position (0 = first character)
+   */
+  size_t GetPosition() const { return m_tokenStart; }
+
+ private:
+  Token ScanInteger();
+  Token ScanIdentifier();
+
+  void Get() {
+    if (m_pos < m_in.size()) {
+      [[likely]] m_current = m_in[m_pos];
+    } else {
+      m_current = -1;
+    }
+    ++m_pos;
+  }
+
+  void Unget() {
+    if (m_pos > 0) {
+      [[likely]] m_pos--;
+      if (m_pos < m_in.size()) {
+        [[likely]] m_current = m_in[m_pos];
+      } else {
+        m_current = -1;
+      }
+    } else {
+      m_current = -1;
+    }
+  }
+
+  Token MakeToken(Token::Kind kind) {
+    return {kind, m_in.substr(m_tokenStart, m_pos - m_tokenStart)};
+  }
+
+  std::string_view m_in;
+  int m_current = -1;
+  size_t m_tokenStart = 0;
+  size_t m_pos = 0;
+};
+
+/**
+ * Raw struct set of enumerated values.
+ */
+using EnumValues = std::vector<std::pair<std::string, int64_t>>;
+
+/**
+ * Raw struct schema declaration.
+ */
+struct ParsedDeclaration {
+  std::string typeString;
+  std::string name;
+  EnumValues enumValues;
+  size_t arraySize = 1;
+  unsigned int bitWidth = 0;
+};
+
+/**
+ * Raw struct schema.
+ */
+struct ParsedSchema {
+  std::vector<ParsedDeclaration> declarations;
+};
+
+/**
+ * Raw struct schema parser.
+ */
+class Parser {
+ public:
+  /**
+   * Construct a raw struct schema parser.
+   *
+   * @param in schema
+   */
+  explicit Parser(std::string_view in) : m_lexer{in} {}
+
+  /**
+   * Parses the schema.
+   *
+   * @param[out] out parsed schema object
+   * @return true on success, false on failure (use GetError() to get error)
+   */
+  [[nodiscard]]
+  bool Parse(ParsedSchema* out);
+
+  /**
+   * Gets the parser error if one occurred.
+   *
+   * @return parser error; blank if no error occurred
+   */
+  const std::string& GetError() const { return m_error; }
+
+ private:
+  [[nodiscard]]
+  bool ParseDeclaration(ParsedDeclaration* out);
+  [[nodiscard]]
+  bool ParseEnum(EnumValues* out);
+
+  Token::Kind GetNextToken() {
+    m_token = m_lexer.Scan();
+    return m_token.kind;
+  }
+  [[nodiscard]]
+  bool Expect(Token::Kind kind) {
+    if (m_token.Is(kind)) {
+      [[likely]] return true;
+    }
+    FailExpect(kind);
+    return false;
+  }
+  void FailExpect(Token::Kind desired);
+  void Fail(std::string_view msg);
+
+  Lexer m_lexer;
+  Token m_token;
+  std::string m_error;
+};
+
+}  // namespace wpi::structparser

--- a/wpiutil/src/main/native/include/wpi/struct/Struct.h
+++ b/wpiutil/src/main/native/include/wpi/struct/Struct.h
@@ -1,0 +1,533 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <stdint.h>
+
+#include <concepts>
+#include <span>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "wpi/Endian.h"
+#include "wpi/MathExtras.h"
+#include "wpi/bit.h"
+#include "wpi/ct_string.h"
+#include "wpi/function_ref.h"
+#include "wpi/mutex.h"
+
+namespace wpi {
+
+/**
+ * Struct serialization template. Unspecialized class has no members; only
+ * specializations of this class are useful, and only if they meet the
+ * StructSerializable concept.
+ *
+ * @tparam T type to serialize/deserialize
+ */
+template <typename T>
+struct Struct {};
+
+/**
+ * Specifies that a type is capable of raw struct serialization and
+ * deserialization.
+ *
+ * This is designed for serializing small fixed-size data structures in the
+ * fastest and most compact means possible. Serialization consists of writing
+ * values into a mutable std::span and deserialization consists of reading
+ * values from an immutable std::span.
+ *
+ * Implementations must define a template specialization for wpi::Struct with
+ * T being the type that is being serialized/deserialized, with the following
+ * static members (as enforced by this concept):
+ * - std::string_view kTypeString: the type string
+ * - size_t kSize: the structure size in bytes
+ * - std::string_view kSchema: the struct schema
+ * - T Unpack(std::span<const uint8_t, kSize>): function for deserialization
+ * - void Pack(std::span<uint8_t, kSize>, T&& value): function for
+ *   serialization
+ *
+ * If the struct has nested structs, implementations should also meet the
+ * requirements of HasNestedStruct<T>.
+ */
+template <typename T>
+concept StructSerializable =
+    requires(std::span<const uint8_t> in, std::span<uint8_t> out, T&& value) {
+      typename Struct<typename std::remove_cvref_t<T>>;
+      {
+        Struct<typename std::remove_cvref_t<T>>::kTypeString
+      } -> std::convertible_to<std::string_view>;
+      {
+        Struct<typename std::remove_cvref_t<T>>::kSize
+      } -> std::convertible_to<size_t>;
+      {
+        Struct<typename std::remove_cvref_t<T>>::kSchema
+      } -> std::convertible_to<std::string_view>;
+      {
+        Struct<typename std::remove_cvref_t<T>>::Unpack(
+            in.subspan<0, Struct<typename std::remove_cvref_t<T>>::kSize>())
+      } -> std::same_as<typename std::remove_cvref_t<T>>;
+      Struct<typename std::remove_cvref_t<T>>::Pack(
+          out.subspan<0, Struct<typename std::remove_cvref_t<T>>::kSize>(),
+          std::forward<T>(value));
+    };
+
+/**
+ * Specifies that a type is capable of in-place raw struct deserialization.
+ *
+ * In addition to meeting StructSerializable, implementations must define a
+ * wpi::Struct<T> static member `void UnpackInto(T*, std::span<const uint8_t>)`
+ * to update the pointed-to T with the contents of the span.
+ */
+template <typename T>
+concept MutableStructSerializable =
+    StructSerializable<T> && requires(T* out, std::span<const uint8_t> in) {
+      Struct<typename std::remove_cvref_t<T>>::UnpackInto(
+          out, in.subspan<0, Struct<typename std::remove_cvref_t<T>>::kSize>());
+    };
+
+/**
+ * Specifies that a struct type has nested struct declarations.
+ *
+ * In addition to meeting StructSerializable, implementations must define a
+ * wpi::Struct<T> static member
+ * `void ForEachNested(std::invocable<std::string_view, std::string_view) auto
+ * fn)` (or equivalent) and call ForEachNestedStruct<Type> on each nested struct
+ * type.
+ */
+template <typename T>
+concept HasNestedStruct =
+    StructSerializable<T> &&
+    requires(function_ref<void(std::string_view, std::string_view)> fn) {
+      Struct<typename std::remove_cvref_t<T>>::ForEachNested(fn);
+    };
+
+/**
+ * Unpack a serialized struct.
+ *
+ * @tparam T object type
+ * @param data raw struct data
+ * @return Deserialized object
+ */
+template <StructSerializable T>
+inline T UnpackStruct(std::span<const uint8_t, Struct<T>::kSize> data) {
+  return Struct<T>::Unpack(data);
+}
+
+/**
+ * Unpack a serialized struct starting at a given offset within the data.
+ * This is primarily useful in unpack implementations to unpack nested structs.
+ *
+ * @tparam T object type
+ * @tparam Offset starting offset
+ * @param data raw struct data
+ * @return Deserialized object
+ */
+template <StructSerializable T, size_t Offset>
+inline T UnpackStruct(std::span<const uint8_t> data) {
+  return Struct<T>::Unpack(data.template subspan<Offset, Struct<T>::kSize>());
+}
+
+/**
+ * Pack a serialized struct.
+ *
+ * @param data struct storage (mutable, output)
+ * @param value object
+ */
+template <StructSerializable T>
+inline void PackStruct(
+    std::span<uint8_t, Struct<typename std::remove_cvref_t<T>>::kSize> data,
+    T&& value) {
+  Struct<typename std::remove_cvref_t<T>>::Pack(data, std::forward<T>(value));
+}
+
+/**
+ * Pack a serialized struct starting at a given offset within the data. This is
+ * primarily useful in pack implementations to pack nested structs.
+ *
+ * @tparam Offset starting offset
+ * @param data struct storage (mutable, output)
+ * @param value object
+ */
+template <size_t Offset, StructSerializable T>
+inline void PackStruct(std::span<uint8_t> data, T&& value) {
+  Struct<typename std::remove_cvref_t<T>>::Pack(
+      data.template subspan<Offset,
+                            Struct<typename std::remove_cvref_t<T>>::kSize>(),
+      std::forward<T>(value));
+}
+
+/**
+ * Unpack a serialized struct into an existing object, overwriting its contents.
+ *
+ * @param out object (output)
+ * @param data raw struct data
+ */
+template <StructSerializable T>
+inline void UnpackStructInto(T* out,
+                             std::span<const uint8_t, Struct<T>::kSize> data) {
+  if constexpr (MutableStructSerializable<T>) {
+    Struct<T>::UnpackInto(out, data);
+  } else {
+    *out = UnpackStruct<T>(data);
+  }
+}
+
+/**
+ * Unpack a serialized struct into an existing object, overwriting its contents,
+ * and starting at a given offset within the data.
+ * This is primarily useful in unpack implementations to unpack nested structs.
+ *
+ * @tparam Offset starting offset
+ * @param out object (output)
+ * @param data raw struct data
+ */
+template <size_t Offset, StructSerializable T>
+inline void UnpackStructInto(T* out, std::span<const uint8_t> data) {
+  if constexpr (MutableStructSerializable<T>) {
+    Struct<T>::UnpackInto(out,
+                          data.template subspan<Offset, Struct<T>::kSize>());
+  } else {
+    *out = UnpackStruct<T, Offset>(data);
+  }
+}
+
+/**
+ * Get the type string for a raw struct serializable type
+ *
+ * @tparam T serializable type
+ * @return type string
+ */
+template <StructSerializable T>
+constexpr auto GetStructTypeString() {
+  return Struct<T>::kTypeString;
+}
+
+template <StructSerializable T, size_t N>
+consteval auto MakeStructArrayTypeString() {
+  using namespace literals;
+  if constexpr (N == std::dynamic_extent) {
+    return Concat(
+        ct_string<char, std::char_traits<char>, Struct<T>::kTypeString.size()>{
+            Struct<T>::kTypeString},
+        "[]"_ct_string);
+  } else {
+    return Concat(
+        ct_string<char, std::char_traits<char>, Struct<T>::kTypeString.size()>{
+            Struct<T>::kTypeString},
+        "["_ct_string, NumToCtString<N>(), "]"_ct_string);
+  }
+}
+
+template <StructSerializable T, size_t N>
+consteval auto MakeStructArraySchema() {
+  using namespace literals;
+  if constexpr (N == std::dynamic_extent) {
+    return Concat(
+        ct_string<char, std::char_traits<char>, Struct<T>::kSchema.size()>{
+            Struct<T>::kSchema},
+        "[]"_ct_string);
+  } else {
+    return Concat(
+        ct_string<char, std::char_traits<char>, Struct<T>::kSchema.size()>{
+            Struct<T>::kSchema},
+        "["_ct_string, NumToCtString<N>(), "]"_ct_string);
+  }
+}
+
+template <StructSerializable T>
+constexpr std::string_view GetStructSchema() {
+  return Struct<T>::kSchema;
+}
+
+template <StructSerializable T>
+constexpr std::span<const uint8_t> GetStructSchemaBytes() {
+  return {reinterpret_cast<const uint8_t*>(Struct<T>::kSchema.data()),
+          Struct<T>::kSchema.size()};
+}
+
+template <StructSerializable T>
+void ForEachStructSchema(
+    std::invocable<std::string_view, std::string_view> auto fn) {
+  if constexpr (HasNestedStruct<T>) {
+    Struct<T>::ForEachNested(fn);
+  }
+  fn(Struct<T>::kTypeString, Struct<T>::kSchema);
+}
+
+template <StructSerializable T>
+class StructArrayBuffer {
+  using S = Struct<T>;
+
+ public:
+  StructArrayBuffer() = default;
+  StructArrayBuffer(const StructArrayBuffer&) = delete;
+  StructArrayBuffer& operator=(const StructArrayBuffer&) = delete;
+  StructArrayBuffer(StructArrayBuffer&& rhs) : m_buf{std::move(rhs.m_buf)} {}
+  StructArrayBuffer& operator=(StructArrayBuffer&& rhs) {
+    m_buf = std::move(rhs.m_buf);
+    return *this;
+  }
+
+  template <typename U, typename F>
+    requires
+#if __cpp_lib_ranges >= 201911L
+      std::ranges::range<U> &&
+      std::convertible_to<std::ranges::range_value_t<U>, T> &&
+#endif
+      std::invocable<F, std::span<const uint8_t>>
+    void Write(U&& data, F&& func) {
+    if ((std::size(data) * S::kSize) < 256) {
+      // use the stack
+      uint8_t buf[256];
+      auto out = buf;
+      for (auto&& val : data) {
+        S::Pack(std::span<uint8_t, S::kSize>{out, out + S::kSize},
+                std::forward<decltype(val)>(val));
+        out += S::kSize;
+      }
+      func(std::span<uint8_t>{buf, out});
+    } else {
+      std::scoped_lock lock{m_mutex};
+      m_buf.resize(std::size(data) * S::kSize);
+      auto out = m_buf.begin();
+      for (auto&& val : data) {
+        S::Pack(std::span<uint8_t, S::kSize>{out, out + S::kSize},
+                std::forward<decltype(val)>(val));
+        out += S::kSize;
+      }
+      func(m_buf);
+    }
+  }
+
+ private:
+  wpi::mutex m_mutex;
+  std::vector<uint8_t> m_buf;
+};
+
+/**
+ * Raw struct support for fixed-size arrays of other structs.
+ */
+template <StructSerializable T, size_t N>
+struct Struct<std::array<T, N>> {
+  static constexpr auto kTypeString = MakeStructArrayTypeString<T, N>();
+  static constexpr size_t kSize = N * Struct<T>::kSize;
+  static constexpr auto kSchema = MakeStructArraySchema<T, N>();
+  static std::array<T, N> Unpack(std::span<const uint8_t, kSize> data) {
+    std::array<T, N> result;
+    for (size_t i = 0; i < N; ++i) {
+      result[i] = UnpackStruct<T, 0>(data);
+      data = data.subspan(Struct<T>::kSize);
+    }
+    return result;
+  }
+  static void Pack(std::span<uint8_t, kSize> data,
+                   std::span<const T, N> values) {
+    std::span<uint8_t> unsizedData = data;
+    for (auto&& val : values) {
+      PackStruct<0>(unsizedData, val);
+      unsizedData = unsizedData.subspan(Struct<T>::kSize);
+    }
+  }
+  static void UnpackInto(std::array<T, N>* out,
+                         std::span<const uint8_t, kSize> data) {
+    UnpackInto(std::span{*out}, data);
+  }
+  // alternate span-based function
+  static void UnpackInto(std::span<T, N> out,
+                         std::span<const uint8_t, kSize> data) {
+    std::span<const uint8_t> unsizedData = data;
+    for (size_t i = 0; i < N; ++i) {
+      UnpackStructInto<0, T>(&out[i], unsizedData);
+      unsizedData = unsizedData.subspan(Struct<T>::kSize);
+    }
+  }
+};
+
+/**
+ * Raw struct support for boolean values.
+ * Primarily useful for higher level struct implementations.
+ */
+template <>
+struct Struct<bool> {
+  static constexpr std::string_view kTypeString = "struct:bool";
+  static constexpr size_t kSize = 1;
+  static constexpr std::string_view kSchema = "bool value";
+  static bool Unpack(std::span<const uint8_t, 1> data) { return data[0]; }
+  static void Pack(std::span<uint8_t, 1> data, bool value) {
+    data[0] = static_cast<char>(value ? 1 : 0);
+  }
+};
+
+/**
+ * Raw struct support for uint8_t values.
+ * Primarily useful for higher level struct implementations.
+ */
+template <>
+struct Struct<uint8_t> {
+  static constexpr std::string_view kTypeString = "struct:uint8";
+  static constexpr size_t kSize = 1;
+  static constexpr std::string_view kSchema = "uint8 value";
+  static uint8_t Unpack(std::span<const uint8_t, 1> data) { return data[0]; }
+  static void Pack(std::span<uint8_t, 1> data, uint8_t value) {
+    data[0] = value;
+  }
+};
+
+/**
+ * Raw struct support for int8_t values.
+ * Primarily useful for higher level struct implementations.
+ */
+template <>
+struct Struct<int8_t> {
+  static constexpr std::string_view kTypeString = "struct:int8";
+  static constexpr size_t kSize = 1;
+  static constexpr std::string_view kSchema = "int8 value";
+  static int8_t Unpack(std::span<const uint8_t, 1> data) { return data[0]; }
+  static void Pack(std::span<uint8_t, 1> data, int8_t value) {
+    data[0] = value;
+  }
+};
+
+/**
+ * Raw struct support for uint16_t values.
+ * Primarily useful for higher level struct implementations.
+ */
+template <>
+struct Struct<uint16_t> {
+  static constexpr std::string_view kTypeString = "struct:uint16";
+  static constexpr size_t kSize = 2;
+  static constexpr std::string_view kSchema = "uint16 value";
+  static uint16_t Unpack(std::span<const uint8_t, 2> data) {
+    return support::endian::read16le(data.data());
+  }
+  static void Pack(std::span<uint8_t, 2> data, uint16_t value) {
+    support::endian::write16le(data.data(), value);
+  }
+};
+
+/**
+ * Raw struct support for int16_t values.
+ * Primarily useful for higher level struct implementations.
+ */
+template <>
+struct Struct<int16_t> {
+  static constexpr std::string_view kTypeString = "struct:int16";
+  static constexpr size_t kSize = 2;
+  static constexpr std::string_view kSchema = "int16 value";
+  static int16_t Unpack(std::span<const uint8_t, 2> data) {
+    return support::endian::read16le(data.data());
+  }
+  static void Pack(std::span<uint8_t, 2> data, int16_t value) {
+    support::endian::write16le(data.data(), value);
+  }
+};
+
+/**
+ * Raw struct support for uint32_t values.
+ * Primarily useful for higher level struct implementations.
+ */
+template <>
+struct Struct<uint32_t> {
+  static constexpr std::string_view kTypeString = "struct:uint32";
+  static constexpr size_t kSize = 4;
+  static constexpr std::string_view kSchema = "uint32 value";
+  static uint32_t Unpack(std::span<const uint8_t, 4> data) {
+    return support::endian::read32le(data.data());
+  }
+  static void Pack(std::span<uint8_t, 4> data, uint32_t value) {
+    support::endian::write32le(data.data(), value);
+  }
+};
+
+/**
+ * Raw struct support for int32_t values.
+ * Primarily useful for higher level struct implementations.
+ */
+template <>
+struct Struct<int32_t> {
+  static constexpr std::string_view kTypeString = "struct:int32";
+  static constexpr size_t kSize = 4;
+  static constexpr std::string_view kSchema = "int32 value";
+  static int32_t Unpack(std::span<const uint8_t, 4> data) {
+    return support::endian::read32le(data.data());
+  }
+  static void Pack(std::span<uint8_t, 4> data, int32_t value) {
+    support::endian::write32le(data.data(), value);
+  }
+};
+
+/**
+ * Raw struct support for uint64_t values.
+ * Primarily useful for higher level struct implementations.
+ */
+template <>
+struct Struct<uint64_t> {
+  static constexpr std::string_view kTypeString = "struct:uint64";
+  static constexpr size_t kSize = 8;
+  static constexpr std::string_view kSchema = "uint64 value";
+  static uint64_t Unpack(std::span<const uint8_t, 8> data) {
+    return support::endian::read64le(data.data());
+  }
+  static void Pack(std::span<uint8_t, 8> data, uint64_t value) {
+    support::endian::write64le(data.data(), value);
+  }
+};
+
+/**
+ * Raw struct support for int64_t values.
+ * Primarily useful for higher level struct implementations.
+ */
+template <>
+struct Struct<int64_t> {
+  static constexpr std::string_view kTypeString = "struct:int64";
+  static constexpr size_t kSize = 8;
+  static constexpr std::string_view kSchema = "int64 value";
+  static int64_t Unpack(std::span<const uint8_t, 8> data) {
+    return support::endian::read64le(data.data());
+  }
+  static void Pack(std::span<uint8_t, 8> data, int64_t value) {
+    support::endian::write64le(data.data(), value);
+  }
+};
+
+/**
+ * Raw struct support for float values.
+ * Primarily useful for higher level struct implementations.
+ */
+template <>
+struct Struct<float> {
+  static constexpr std::string_view kTypeString = "struct:float";
+  static constexpr size_t kSize = 4;
+  static constexpr std::string_view kSchema = "float value";
+  static float Unpack(std::span<const uint8_t, 4> data) {
+    return bit_cast<float>(support::endian::read32le(data.data()));
+  }
+  static void Pack(std::span<uint8_t, 4> data, float value) {
+    support::endian::write32le(data.data(), bit_cast<uint32_t>(value));
+  }
+};
+
+/**
+ * Raw struct support for double values.
+ * Primarily useful for higher level struct implementations.
+ */
+template <>
+struct Struct<double> {
+  static constexpr std::string_view kTypeString = "struct:double";
+  static constexpr size_t kSize = 8;
+  static constexpr std::string_view kSchema = "double value";
+  static double Unpack(std::span<const uint8_t, 8> data) {
+    return bit_cast<double>(support::endian::read64le(data.data()));
+  }
+  static void Pack(std::span<uint8_t, 8> data, double value) {
+    support::endian::write64le(data.data(), bit_cast<uint64_t>(value));
+  }
+};
+
+}  // namespace wpi

--- a/wpiutil/src/test/java/edu/wpi/first/util/struct/DynamicStructTest.java
+++ b/wpiutil/src/test/java/edu/wpi/first/util/struct/DynamicStructTest.java
@@ -1,0 +1,390 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DynamicStructTest {
+  @SuppressWarnings("MemberName")
+  private StructDescriptorDatabase db;
+
+  @BeforeEach
+  public void init() {
+    db = new StructDescriptorDatabase();
+  }
+
+  @Test
+  void testEmpty() {
+    var desc = assertDoesNotThrow(() -> db.add("test", ""));
+    assertEquals(desc.getName(), "test");
+    assertEquals(desc.getSchema(), "");
+    assertTrue(desc.getFields().isEmpty());
+    assertTrue(desc.isValid());
+    assertEquals(desc.getSize(), 0);
+  }
+
+  @Test
+  void testNestedStruct() {
+    var desc = assertDoesNotThrow(() -> db.add("test", "int32 a"));
+    assertTrue(desc.isValid());
+    var desc2 = assertDoesNotThrow(() -> db.add("test2", "test a"));
+    assertTrue(desc2.isValid());
+    assertEquals(desc2.getSize(), 4);
+  }
+
+  @Test
+  void testDelayedValid() {
+    var desc = assertDoesNotThrow(() -> db.add("test", "foo a"));
+    assertFalse(desc.isValid());
+    var desc2 = assertDoesNotThrow(() -> db.add("test2", "foo a[2]"));
+    assertFalse(desc2.isValid());
+    var desc3 = assertDoesNotThrow(() -> db.add("foo", "int32 a"));
+    assertTrue(desc3.isValid());
+    assertTrue(desc.isValid());
+    assertEquals(desc.getSize(), 4);
+    assertTrue(desc2.isValid());
+    assertEquals(desc2.getSize(), 8);
+  }
+
+  @Test
+  void testInvalidBitfield() {
+    assertThrows(
+        BadSchemaException.class,
+        () -> db.add("test", "float a:1"),
+        "field a: type float cannot be bitfield");
+    assertThrows(
+        BadSchemaException.class,
+        () -> db.add("test", "double a:1"),
+        "field a: type double cannot be bitfield");
+    assertThrows(
+        BadSchemaException.class,
+        () -> db.add("test", "foo a:1"),
+        "field a: type foo cannot be bitfield");
+  }
+
+  @Test
+  void testCircularStructReference() {
+    assertThrows(
+        BadSchemaException.class,
+        () -> db.add("test", "test a"),
+        "field a: recursive struct reference");
+  }
+
+  @Test
+  void testNestedCircularStructRef() {
+    assertDoesNotThrow(() -> db.add("test", "foo a"));
+    assertDoesNotThrow(() -> db.add("foo", "bar a"));
+    assertThrows(
+        BadSchemaException.class,
+        () -> db.add("bar", "test a"),
+        "circular struct reference: bar <- foo <- test");
+
+    // ok
+    var desc = assertDoesNotThrow(() -> db.add("baz", "bar a"));
+    assertFalse(desc.isValid());
+  }
+
+  @Test
+  void testNestedCircularStructRef2() {
+    assertDoesNotThrow(() -> db.add("test", "foo a"));
+    assertDoesNotThrow(() -> db.add("bar", "test a"));
+    assertThrows(
+        BadSchemaException.class,
+        () -> db.add("foo", "bar a"),
+        "circular struct reference: foo <- test <- bar");
+  }
+
+  @Test
+  void testBitfieldBasic() {
+    var desc = assertDoesNotThrow(() -> db.add("test", "int32 a:2; uint32 b:30"));
+    assertEquals(desc.getSize(), 4);
+    var fields = desc.getFields();
+    assertEquals(fields.size(), 2);
+    var field = fields.get(0);
+    assertEquals(field.getBitWidth(), 2);
+    assertEquals(field.getBitShift(), 0);
+    assertEquals(field.getBitMask(), 0x3);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 4);
+    field = fields.get(1);
+    assertEquals(field.getBitWidth(), 30);
+    assertEquals(field.getBitShift(), 2);
+    assertEquals(field.getBitMask(), 0x3fffffff);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 4);
+  }
+
+  @Test
+  void testBitfieldDiffType() {
+    var desc = assertDoesNotThrow(() -> db.add("test", "int32 a:2; int16 b:2"));
+    assertEquals(desc.getSize(), 6);
+    var fields = desc.getFields();
+    assertEquals(fields.size(), 2);
+    var field = fields.get(0);
+    assertEquals(field.getBitWidth(), 2);
+    assertEquals(field.getBitShift(), 0);
+    assertEquals(field.getBitMask(), 0x3);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 4);
+    field = fields.get(1);
+    assertEquals(field.getBitWidth(), 2);
+    assertEquals(field.getBitShift(), 0);
+    assertEquals(field.getBitMask(), 0x3);
+    assertEquals(field.getOffset(), 4);
+    assertEquals(field.getSize(), 2);
+  }
+
+  @Test
+  void testBitfieldOverflow() {
+    var desc = assertDoesNotThrow(() -> db.add("test", "int8 a:4; int8 b:5"));
+    assertEquals(desc.getSize(), 2);
+    var fields = desc.getFields();
+    assertEquals(fields.size(), 2);
+    var field = fields.get(0);
+    assertEquals(field.getBitWidth(), 4);
+    assertEquals(field.getBitShift(), 0);
+    assertEquals(field.getBitMask(), 0xf);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 1);
+    field = fields.get(1);
+    assertEquals(field.getBitWidth(), 5);
+    assertEquals(field.getBitMask(), 0x1f);
+    assertEquals(field.getBitShift(), 0);
+    assertEquals(field.getOffset(), 1);
+    assertEquals(field.getSize(), 1);
+  }
+
+  @Test
+  void testBitfieldBoolBegin8() {
+    var desc = assertDoesNotThrow(() -> db.add("test", "bool a:1; int8 b:5"));
+    assertEquals(desc.getSize(), 1);
+    var fields = desc.getFields();
+    assertEquals(fields.size(), 2);
+    var field = fields.get(0);
+    assertEquals(field.getBitWidth(), 1);
+    assertEquals(field.getBitShift(), 0);
+    assertEquals(field.getBitMask(), 0x1);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 1);
+    field = fields.get(1);
+    assertEquals(field.getBitWidth(), 5);
+    assertEquals(field.getBitMask(), 0x1f);
+    assertEquals(field.getBitShift(), 1);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 1);
+  }
+
+  @Test
+  void testBitfieldBoolBegin16() {
+    var desc = assertDoesNotThrow(() -> db.add("test", "bool a:1; int16 b:5"));
+    assertEquals(desc.getSize(), 3);
+    var fields = desc.getFields();
+    assertEquals(fields.size(), 2);
+    var field = fields.get(0);
+    assertEquals(field.getBitWidth(), 1);
+    assertEquals(field.getBitShift(), 0);
+    assertEquals(field.getBitMask(), 0x1);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 1);
+    field = fields.get(1);
+    assertEquals(field.getBitWidth(), 5);
+    assertEquals(field.getBitMask(), 0x1f);
+    assertEquals(field.getBitShift(), 0);
+    assertEquals(field.getOffset(), 1);
+    assertEquals(field.getSize(), 2);
+  }
+
+  @Test
+  void testBitfieldBoolMid() {
+    var desc =
+        assertDoesNotThrow(() -> db.add("test", "int16 a:2; bool b:1; bool c:1; uint16 d:5"));
+    assertEquals(desc.getSize(), 2);
+    var fields = desc.getFields();
+    assertEquals(fields.size(), 4);
+    var field = fields.get(0);
+    assertEquals(field.getBitWidth(), 2);
+    assertEquals(field.getBitShift(), 0);
+    assertEquals(field.getBitMask(), 0x3);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 2);
+    field = fields.get(1);
+    assertEquals(field.getBitWidth(), 1);
+    assertEquals(field.getBitMask(), 0x1);
+    assertEquals(field.getBitShift(), 2);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 2);
+    field = fields.get(2);
+    assertEquals(field.getBitWidth(), 1);
+    assertEquals(field.getBitMask(), 0x1);
+    assertEquals(field.getBitShift(), 3);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 2);
+    field = fields.get(3);
+    assertEquals(field.getBitWidth(), 5);
+    assertEquals(field.getBitMask(), 0x1f);
+    assertEquals(field.getBitShift(), 4);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 2);
+  }
+
+  @Test
+  void testBitfieldBoolEnd() {
+    var desc = assertDoesNotThrow(() -> db.add("test", "int16 a:15; bool b:1"));
+    assertEquals(desc.getSize(), 2);
+    var fields = desc.getFields();
+    assertEquals(fields.size(), 2);
+    var field = fields.get(0);
+    assertEquals(field.getBitWidth(), 15);
+    assertEquals(field.getBitShift(), 0);
+    assertEquals(field.getBitMask(), 0x7fff);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 2);
+    field = fields.get(1);
+    assertEquals(field.getBitWidth(), 1);
+    assertEquals(field.getBitMask(), 0x1);
+    assertEquals(field.getBitShift(), 15);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 2);
+  }
+
+  @Test
+  void testBitfieldBoolEnd2() {
+    var desc = assertDoesNotThrow(() -> db.add("test", "int16 a:16; bool b:1"));
+    assertEquals(desc.getSize(), 3);
+    var fields = desc.getFields();
+    assertEquals(fields.size(), 2);
+    var field = fields.get(0);
+    assertEquals(field.getBitWidth(), 16);
+    assertEquals(field.getBitShift(), 0);
+    assertEquals(field.getBitMask(), 0xffff);
+    assertEquals(field.getOffset(), 0);
+    assertEquals(field.getSize(), 2);
+    field = fields.get(1);
+    assertEquals(field.getBitWidth(), 1);
+    assertEquals(field.getBitMask(), 0x1);
+    assertEquals(field.getBitShift(), 0);
+    assertEquals(field.getOffset(), 2);
+    assertEquals(field.getSize(), 1);
+  }
+
+  @Test
+  void testBitfieldBoolWrongSize() {
+    assertThrows(
+        BadSchemaException.class,
+        () -> db.add("test", "bool a:2"),
+        "field a: bit width must be 1 for bool type");
+  }
+
+  @Test
+  void testBitfieldTooBig() {
+    assertThrows(
+        BadSchemaException.class,
+        () -> db.add("test", "int16 a:17"),
+        "field a: bit width 17 exceeds type size");
+  }
+
+  @Test
+  void testDuplicateFieldName() {
+    assertThrows(
+        BadSchemaException.class,
+        () -> db.add("test", "int16 a; int8 a"),
+        "field a: duplicate field name");
+  }
+
+  private static Stream<Arguments> provideSimpleTestParams() {
+    return Stream.of(
+        Arguments.of("bool a", 1, StructFieldType.kBool, false, false, 8, 0xff),
+        Arguments.of("char a", 1, StructFieldType.kChar, false, false, 8, 0xff),
+        Arguments.of("int8 a", 1, StructFieldType.kInt8, true, false, 8, 0xff),
+        Arguments.of("int16 a", 2, StructFieldType.kInt16, true, false, 16, 0xffff),
+        Arguments.of("int32 a", 4, StructFieldType.kInt32, true, false, 32, 0xffffffffL),
+        Arguments.of("int64 a", 8, StructFieldType.kInt64, true, false, 64, -1),
+        Arguments.of("uint8 a", 1, StructFieldType.kUint8, false, true, 8, 0xff),
+        Arguments.of("uint16 a", 2, StructFieldType.kUint16, false, true, 16, 0xffff),
+        Arguments.of("uint32 a", 4, StructFieldType.kUint32, false, true, 32, 0xffffffffL),
+        Arguments.of("uint64 a", 8, StructFieldType.kUint64, false, true, 64, -1),
+        Arguments.of("float a", 4, StructFieldType.kFloat, false, false, 32, 0xffffffffL),
+        Arguments.of("float32 a", 4, StructFieldType.kFloat, false, false, 32, 0xffffffffL),
+        Arguments.of("double a", 8, StructFieldType.kDouble, false, false, 64, -1),
+        Arguments.of("float64 a", 8, StructFieldType.kDouble, false, false, 64, -1),
+        Arguments.of("foo a", 0, StructFieldType.kStruct, false, false, 0, 0));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSimpleTestParams")
+  void testStandardCheck(
+      String schema,
+      int size,
+      StructFieldType type,
+      boolean isInt,
+      boolean isUint,
+      int bitWidth,
+      long bitMask) {
+    var desc = assertDoesNotThrow(() -> db.add("test", schema));
+    assertEquals(desc.getName(), "test");
+    assertEquals(desc.getSchema(), schema);
+    var fields = desc.getFields();
+    assertEquals(fields.size(), 1);
+    var field = fields.get(0);
+    assertEquals(field.getParent(), desc);
+    assertEquals(field.getName(), "a");
+    assertEquals(field.isInt(), isInt);
+    assertEquals(field.isUint(), isUint);
+    assertFalse(field.isArray());
+    if (type != StructFieldType.kStruct) {
+      assertTrue(desc.isValid());
+      assertEquals(desc.getSize(), size);
+      assertEquals(field.getSize(), size);
+      assertEquals(field.getBitWidth(), bitWidth);
+      assertEquals(field.getBitMask(), bitMask);
+    } else {
+      assertFalse(desc.isValid());
+      assertNotNull(field.getStruct());
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSimpleTestParams")
+  void testStandardArray(
+      String schema,
+      int size,
+      StructFieldType type,
+      boolean isInt,
+      boolean isUint,
+      int bitWidth,
+      long bitMask) {
+    var desc = assertDoesNotThrow(() -> db.add("test", schema + "[2]"));
+    assertEquals(desc.getName(), "test");
+    assertEquals(desc.getSchema(), schema + "[2]");
+    var fields = desc.getFields();
+    assertEquals(fields.size(), 1);
+    var field = fields.get(0);
+    assertEquals(field.getParent(), desc);
+    assertEquals(field.getName(), "a");
+    assertEquals(field.isInt(), isInt);
+    assertEquals(field.isUint(), isUint);
+    assertTrue(field.isArray());
+    assertEquals(field.getArraySize(), 2);
+    if (type != StructFieldType.kStruct) {
+      assertTrue(desc.isValid());
+      assertEquals(desc.getSize(), size * 2);
+    } else {
+      assertFalse(desc.isValid());
+      assertNotNull(field.getStruct());
+    }
+  }
+}

--- a/wpiutil/src/test/java/edu/wpi/first/util/struct/parser/ParserTest.java
+++ b/wpiutil/src/test/java/edu/wpi/first/util/struct/parser/ParserTest.java
@@ -1,0 +1,212 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.util.struct.parser;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ParserTest {
+  @Test
+  void testEmpty() {
+    Parser p = new Parser("");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertTrue(schema.declarations.isEmpty());
+  }
+
+  @Test
+  void testEmptySemicolon() {
+    Parser p = new Parser(";");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertTrue(schema.declarations.isEmpty());
+  }
+
+  @Test
+  void testSimple() {
+    Parser p = new Parser("int32 a");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertEquals(schema.declarations.size(), 1);
+    var decl = schema.declarations.get(0);
+    assertEquals(decl.typeString, "int32");
+    assertEquals(decl.name, "a");
+    assertEquals(decl.arraySize, 1);
+  }
+
+  @Test
+  void testSimpleTrailingSemi() {
+    Parser p = new Parser("int32 a;");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertEquals(schema.declarations.size(), 1);
+  }
+
+  @Test
+  void testArray() {
+    Parser p = new Parser("int32 a[2]");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertEquals(schema.declarations.size(), 1);
+    var decl = schema.declarations.get(0);
+    assertEquals(decl.typeString, "int32");
+    assertEquals(decl.name, "a");
+    assertEquals(decl.arraySize, 2);
+  }
+
+  @Test
+  void testArrayTrailingSemi() {
+    Parser p = new Parser("int32 a[2];");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertEquals(schema.declarations.size(), 1);
+  }
+
+  @Test
+  void testBitfield() {
+    Parser p = new Parser("int32 a:2");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertEquals(schema.declarations.size(), 1);
+    var decl = schema.declarations.get(0);
+    assertEquals(decl.typeString, "int32");
+    assertEquals(decl.name, "a");
+    assertEquals(decl.bitWidth, 2);
+  }
+
+  @Test
+  void testBitfieldTrailingSemi() {
+    Parser p = new Parser("int32 a:2;");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertEquals(schema.declarations.size(), 1);
+  }
+
+  @Test
+  void testEnumKeyword() {
+    Parser p = new Parser("enum {x=1} int32 a;");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertEquals(schema.declarations.size(), 1);
+    var decl = schema.declarations.get(0);
+    assertEquals(decl.typeString, "int32");
+    assertEquals(decl.name, "a");
+    assertEquals(decl.enumValues.size(), 1);
+    assertEquals(decl.enumValues.get("x"), 1);
+  }
+
+  @Test
+  void testEnumNoKeyword() {
+    Parser p = new Parser("{x=1} int32 a;");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertEquals(schema.declarations.size(), 1);
+    var decl = schema.declarations.get(0);
+    assertEquals(decl.typeString, "int32");
+    assertEquals(decl.name, "a");
+    assertEquals(decl.enumValues.size(), 1);
+    assertEquals(decl.enumValues.get("x"), 1);
+  }
+
+  @Test
+  void testEnumNoValues() {
+    Parser p = new Parser("{} int32 a;");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertEquals(schema.declarations.size(), 1);
+    var decl = schema.declarations.get(0);
+    assertEquals(decl.typeString, "int32");
+    assertEquals(decl.name, "a");
+    assertTrue(decl.enumValues.isEmpty());
+  }
+
+  @Test
+  void testEnumMultipleValues() {
+    Parser p = new Parser("{x=1,y=-2} int32 a;");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertEquals(schema.declarations.size(), 1);
+    var decl = schema.declarations.get(0);
+    assertEquals(decl.typeString, "int32");
+    assertEquals(decl.name, "a");
+    assertEquals(decl.enumValues.size(), 2);
+    assertEquals(decl.enumValues.get("x"), 1);
+    assertEquals(decl.enumValues.get("y"), -2);
+  }
+
+  @Test
+  void testEnumTrailingComma() {
+    Parser p = new Parser("{x=1,y=2,} int32 a;");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertEquals(schema.declarations.size(), 1);
+    var decl = schema.declarations.get(0);
+    assertEquals(decl.typeString, "int32");
+    assertEquals(decl.name, "a");
+    assertEquals(decl.enumValues.size(), 2);
+    assertEquals(decl.enumValues.get("x"), 1);
+    assertEquals(decl.enumValues.get("y"), 2);
+  }
+
+  @Test
+  void testMultipleNoTrailingSemi() {
+    Parser p = new Parser("int32 a; int16 b");
+    ParsedSchema schema = assertDoesNotThrow(() -> p.parse());
+    assertEquals(schema.declarations.size(), 2);
+    assertEquals(schema.declarations.get(0).typeString, "int32");
+    assertEquals(schema.declarations.get(0).name, "a");
+    assertEquals(schema.declarations.get(1).typeString, "int16");
+    assertEquals(schema.declarations.get(1).name, "b");
+  }
+
+  @Test
+  void testErrBitfieldArray() {
+    Parser p = new Parser("int32 a[1]:2");
+    assertThrows(ParseException.class, () -> p.parse(), "10: expected ';', got ':'");
+  }
+
+  @Test
+  void testErrNoArrayValue() {
+    Parser p = new Parser("int32 a[]");
+    assertThrows(ParseException.class, () -> p.parse(), "8: expected integer, got ']'");
+  }
+
+  @Test
+  void testErrNoBitfieldValue() {
+    Parser p = new Parser("int32 a:");
+    assertThrows(ParseException.class, () -> p.parse(), "8: expected integer, got ''");
+  }
+
+  @Test
+  void testErrNoNameArray() {
+    Parser p = new Parser("int32 [2]");
+    assertThrows(ParseException.class, () -> p.parse(), "6: expected identifier, got '['");
+  }
+
+  @Test
+  void testErrNoNameBitField() {
+    Parser p = new Parser("int32 :2");
+    assertThrows(ParseException.class, () -> p.parse(), "6: expected identifier, got ':'");
+  }
+
+  @Test
+  void testNegativeBitField() {
+    Parser p = new Parser("int32 a:-1");
+    assertThrows(
+        ParseException.class, () -> p.parse(), "8: bitfield width '-1' is not a positive integer");
+  }
+
+  @Test
+  void testNegativeArraySize() {
+    Parser p = new Parser("int32 a[-1]");
+    assertThrows(
+        ParseException.class, () -> p.parse(), "8: array size '-1' is not a positive integer");
+  }
+
+  @Test
+  void testZeroBitField() {
+    Parser p = new Parser("int32 a:0");
+    assertThrows(
+        ParseException.class, () -> p.parse(), "8: bitfield width '0' is not a positive integer");
+  }
+
+  @Test
+  void testZeroArraySize() {
+    Parser p = new Parser("int32 a[0]");
+    assertThrows(
+        ParseException.class, () -> p.parse(), "8: array size '0' is not a positive integer");
+  }
+}

--- a/wpiutil/src/test/native/cpp/struct/DynamicStructTest.cpp
+++ b/wpiutil/src/test/native/cpp/struct/DynamicStructTest.cpp
@@ -1,0 +1,358 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "wpi/struct/DynamicStruct.h"  // NOLINT(build/include_order)
+
+#include <stdint.h>
+
+#include <gtest/gtest.h>
+
+using namespace wpi;
+
+class DynamicStructTest : public ::testing::Test {
+ protected:
+  StructDescriptorDatabase db;
+  std::string err;
+};
+
+TEST_F(DynamicStructTest, Empty) {
+  auto desc = db.Add("test", "", &err);
+  ASSERT_TRUE(desc);
+  ASSERT_EQ(desc->GetName(), "test");
+  ASSERT_EQ(desc->GetSchema(), "");
+  ASSERT_TRUE(desc->GetFields().empty());
+  ASSERT_TRUE(desc->IsValid());
+  ASSERT_EQ(desc->GetSize(), 0u);
+}
+
+TEST_F(DynamicStructTest, NestedStruct) {
+  auto desc = db.Add("test", "int32 a", &err);
+  ASSERT_TRUE(desc);
+  ASSERT_TRUE(desc->IsValid());
+  auto desc2 = db.Add("test2", "test a", &err);
+  ASSERT_TRUE(desc2);
+  ASSERT_TRUE(desc2->IsValid());
+  ASSERT_EQ(desc2->GetSize(), 4u);
+}
+
+TEST_F(DynamicStructTest, DelayedValid) {
+  auto desc = db.Add("test", "foo a", &err);
+  ASSERT_TRUE(desc);
+  ASSERT_FALSE(desc->IsValid());
+  auto desc2 = db.Add("test2", "foo a[2]", &err);
+  ASSERT_TRUE(desc2);
+  ASSERT_FALSE(desc2->IsValid());
+  auto desc3 = db.Add("foo", "int32 a", &err);
+  ASSERT_TRUE(desc3);
+  ASSERT_TRUE(desc3->IsValid());
+  ASSERT_TRUE(desc->IsValid());
+  ASSERT_EQ(desc->GetSize(), 4u);
+  ASSERT_TRUE(desc2->IsValid());
+  ASSERT_EQ(desc2->GetSize(), 8u);
+}
+
+TEST_F(DynamicStructTest, InvalidBitfield) {
+  auto desc = db.Add("test", "float a:1", &err);
+  EXPECT_FALSE(desc);
+  EXPECT_EQ(err, "field a: type float cannot be bitfield");
+
+  desc = db.Add("test", "double a:1", &err);
+  EXPECT_FALSE(desc);
+  EXPECT_EQ(err, "field a: type double cannot be bitfield");
+
+  desc = db.Add("test", "foo a:1", &err);
+  EXPECT_FALSE(desc);
+  EXPECT_EQ(err, "field a: type foo cannot be bitfield");
+}
+
+TEST_F(DynamicStructTest, CircularStructReference) {
+  auto desc = db.Add("test", "test a", &err);
+  ASSERT_FALSE(desc);
+  ASSERT_EQ(err, "field a: recursive struct reference");
+}
+
+TEST_F(DynamicStructTest, NestedCircularStructRef) {
+  auto desc = db.Add("test", "foo a", &err);
+  ASSERT_TRUE(desc);
+  auto desc2 = db.Add("foo", "bar a", &err);
+  ASSERT_TRUE(desc2);
+  auto desc3 = db.Add("bar", "test a", &err);
+  ASSERT_FALSE(desc3);
+  ASSERT_EQ(err, "circular struct reference: bar <- foo <- test");
+
+  // ok
+  auto desc4 = db.Add("baz", "bar a", &err);
+  ASSERT_TRUE(desc4);
+  ASSERT_FALSE(desc4->IsValid());
+}
+
+TEST_F(DynamicStructTest, NestedCircularStructRef2) {
+  auto desc = db.Add("test", "foo a", &err);
+  ASSERT_TRUE(desc);
+  auto desc2 = db.Add("bar", "test a", &err);
+  ASSERT_TRUE(desc2);
+  auto desc3 = db.Add("foo", "bar a", &err);
+  ASSERT_FALSE(desc3);
+  ASSERT_EQ(err, "circular struct reference: foo <- test <- bar");
+}
+
+TEST_F(DynamicStructTest, BitfieldBasic) {
+  auto desc = db.Add("test", "int32 a:2; uint32 b:30", &err);
+  ASSERT_TRUE(desc);
+  EXPECT_EQ(desc->GetSize(), 4u);
+  auto& fields = desc->GetFields();
+  ASSERT_EQ(fields.size(), 2u);
+  EXPECT_EQ(fields[0].GetBitWidth(), 2u);
+  EXPECT_EQ(fields[0].GetBitShift(), 0u);
+  EXPECT_EQ(fields[0].GetBitMask(), 0x3u);
+  EXPECT_EQ(fields[0].GetOffset(), 0u);
+  EXPECT_EQ(fields[0].GetSize(), 4u);
+  EXPECT_EQ(fields[1].GetBitWidth(), 30u);
+  EXPECT_EQ(fields[1].GetBitShift(), 2u);
+  EXPECT_EQ(fields[1].GetBitMask(), 0x3fffffffu);
+  EXPECT_EQ(fields[1].GetOffset(), 0u);
+  EXPECT_EQ(fields[1].GetSize(), 4u);
+}
+
+TEST_F(DynamicStructTest, BitfieldDiffType) {
+  auto desc = db.Add("test", "int32 a:2; int16 b:2", &err);
+  ASSERT_TRUE(desc);
+  EXPECT_EQ(desc->GetSize(), 6u);
+  auto& fields = desc->GetFields();
+  ASSERT_EQ(fields.size(), 2u);
+  EXPECT_EQ(fields[0].GetBitWidth(), 2u);
+  EXPECT_EQ(fields[0].GetBitShift(), 0u);
+  EXPECT_EQ(fields[0].GetBitMask(), 0x3u);
+  EXPECT_EQ(fields[0].GetOffset(), 0u);
+  EXPECT_EQ(fields[0].GetSize(), 4u);
+  EXPECT_EQ(fields[1].GetBitWidth(), 2u);
+  EXPECT_EQ(fields[1].GetBitShift(), 0u);
+  EXPECT_EQ(fields[1].GetBitMask(), 0x3u);
+  EXPECT_EQ(fields[1].GetOffset(), 4u);
+  EXPECT_EQ(fields[1].GetSize(), 2u);
+}
+
+TEST_F(DynamicStructTest, BitfieldOverflow) {
+  auto desc = db.Add("test", "int8 a:4; int8 b:5", &err);
+  ASSERT_TRUE(desc);
+  EXPECT_EQ(desc->GetSize(), 2u);
+  auto& fields = desc->GetFields();
+  ASSERT_EQ(fields.size(), 2u);
+  EXPECT_EQ(fields[0].GetBitWidth(), 4u);
+  EXPECT_EQ(fields[0].GetBitShift(), 0u);
+  EXPECT_EQ(fields[0].GetBitMask(), 0xfu);
+  EXPECT_EQ(fields[0].GetOffset(), 0u);
+  EXPECT_EQ(fields[0].GetSize(), 1u);
+  EXPECT_EQ(fields[1].GetBitWidth(), 5u);
+  EXPECT_EQ(fields[1].GetBitMask(), 0x1fu);
+  EXPECT_EQ(fields[1].GetBitShift(), 0u);
+  EXPECT_EQ(fields[1].GetOffset(), 1u);
+  EXPECT_EQ(fields[1].GetSize(), 1u);
+}
+
+TEST_F(DynamicStructTest, BitfieldBoolBegin8) {
+  auto desc = db.Add("test", "bool a:1; int8 b:5", &err);
+  ASSERT_TRUE(desc);
+  EXPECT_EQ(desc->GetSize(), 1u);
+  auto& fields = desc->GetFields();
+  ASSERT_EQ(fields.size(), 2u);
+  EXPECT_EQ(fields[0].GetBitWidth(), 1u);
+  EXPECT_EQ(fields[0].GetBitShift(), 0u);
+  EXPECT_EQ(fields[0].GetBitMask(), 0x1u);
+  EXPECT_EQ(fields[0].GetOffset(), 0u);
+  EXPECT_EQ(fields[0].GetSize(), 1u);
+  EXPECT_EQ(fields[1].GetBitWidth(), 5u);
+  EXPECT_EQ(fields[1].GetBitMask(), 0x1fu);
+  EXPECT_EQ(fields[1].GetBitShift(), 1u);
+  EXPECT_EQ(fields[1].GetOffset(), 0u);
+  EXPECT_EQ(fields[1].GetSize(), 1u);
+}
+
+TEST_F(DynamicStructTest, BitfieldBoolBegin16) {
+  auto desc = db.Add("test", "bool a:1; int16 b:5", &err);
+  ASSERT_TRUE(desc);
+  EXPECT_EQ(desc->GetSize(), 3u);
+  auto& fields = desc->GetFields();
+  ASSERT_EQ(fields.size(), 2u);
+  EXPECT_EQ(fields[0].GetBitWidth(), 1u);
+  EXPECT_EQ(fields[0].GetBitShift(), 0u);
+  EXPECT_EQ(fields[0].GetBitMask(), 0x1u);
+  EXPECT_EQ(fields[0].GetOffset(), 0u);
+  EXPECT_EQ(fields[0].GetSize(), 1u);
+  EXPECT_EQ(fields[1].GetBitWidth(), 5u);
+  EXPECT_EQ(fields[1].GetBitMask(), 0x1fu);
+  EXPECT_EQ(fields[1].GetBitShift(), 0u);
+  EXPECT_EQ(fields[1].GetOffset(), 1u);
+  EXPECT_EQ(fields[1].GetSize(), 2u);
+}
+
+TEST_F(DynamicStructTest, BitfieldBoolMid) {
+  auto desc = db.Add("test", "int16 a:2; bool b:1; bool c:1; uint16 d:5", &err);
+  ASSERT_TRUE(desc);
+  EXPECT_EQ(desc->GetSize(), 2u);
+  auto& fields = desc->GetFields();
+  ASSERT_EQ(fields.size(), 4u);
+  EXPECT_EQ(fields[0].GetBitWidth(), 2u);
+  EXPECT_EQ(fields[0].GetBitShift(), 0u);
+  EXPECT_EQ(fields[0].GetBitMask(), 0x3u);
+  EXPECT_EQ(fields[0].GetOffset(), 0u);
+  EXPECT_EQ(fields[0].GetSize(), 2u);
+  EXPECT_EQ(fields[1].GetBitWidth(), 1u);
+  EXPECT_EQ(fields[1].GetBitMask(), 0x1u);
+  EXPECT_EQ(fields[1].GetBitShift(), 2u);
+  EXPECT_EQ(fields[1].GetOffset(), 0u);
+  EXPECT_EQ(fields[1].GetSize(), 2u);
+  EXPECT_EQ(fields[2].GetBitWidth(), 1u);
+  EXPECT_EQ(fields[2].GetBitMask(), 0x1u);
+  EXPECT_EQ(fields[2].GetBitShift(), 3u);
+  EXPECT_EQ(fields[2].GetOffset(), 0u);
+  EXPECT_EQ(fields[2].GetSize(), 2u);
+  EXPECT_EQ(fields[3].GetBitWidth(), 5u);
+  EXPECT_EQ(fields[3].GetBitMask(), 0x1fu);
+  EXPECT_EQ(fields[3].GetBitShift(), 4u);
+  EXPECT_EQ(fields[3].GetOffset(), 0u);
+  EXPECT_EQ(fields[3].GetSize(), 2u);
+}
+
+TEST_F(DynamicStructTest, BitfieldBoolEnd) {
+  auto desc = db.Add("test", "int16 a:15; bool b:1", &err);
+  ASSERT_TRUE(desc);
+  EXPECT_EQ(desc->GetSize(), 2u);
+  auto& fields = desc->GetFields();
+  ASSERT_EQ(fields.size(), 2u);
+  EXPECT_EQ(fields[0].GetBitWidth(), 15u);
+  EXPECT_EQ(fields[0].GetBitShift(), 0u);
+  EXPECT_EQ(fields[0].GetBitMask(), 0x7fffu);
+  EXPECT_EQ(fields[0].GetOffset(), 0u);
+  EXPECT_EQ(fields[0].GetSize(), 2u);
+  EXPECT_EQ(fields[1].GetBitWidth(), 1u);
+  EXPECT_EQ(fields[1].GetBitMask(), 0x1u);
+  EXPECT_EQ(fields[1].GetBitShift(), 15u);
+  EXPECT_EQ(fields[1].GetOffset(), 0u);
+  EXPECT_EQ(fields[1].GetSize(), 2u);
+}
+
+TEST_F(DynamicStructTest, BitfieldBoolEnd2) {
+  auto desc = db.Add("test", "int16 a:16; bool b:1", &err);
+  ASSERT_TRUE(desc);
+  EXPECT_EQ(desc->GetSize(), 3u);
+  auto& fields = desc->GetFields();
+  ASSERT_EQ(fields.size(), 2u);
+  EXPECT_EQ(fields[0].GetBitWidth(), 16u);
+  EXPECT_EQ(fields[0].GetBitShift(), 0u);
+  EXPECT_EQ(fields[0].GetBitMask(), 0xffffu);
+  EXPECT_EQ(fields[0].GetOffset(), 0u);
+  EXPECT_EQ(fields[0].GetSize(), 2u);
+  EXPECT_EQ(fields[1].GetBitWidth(), 1u);
+  EXPECT_EQ(fields[1].GetBitMask(), 0x1u);
+  EXPECT_EQ(fields[1].GetBitShift(), 0u);
+  EXPECT_EQ(fields[1].GetOffset(), 2u);
+  EXPECT_EQ(fields[1].GetSize(), 1u);
+}
+
+TEST_F(DynamicStructTest, BitfieldBoolWrongSize) {
+  auto desc = db.Add("test", "bool a:2", &err);
+  ASSERT_FALSE(desc);
+  ASSERT_EQ(err, "field a: bit width must be 1 for bool type");
+}
+
+TEST_F(DynamicStructTest, BitfieldTooBig) {
+  auto desc = db.Add("test", "int16 a:17", &err);
+  ASSERT_FALSE(desc);
+  ASSERT_EQ(err, "field a: bit width 17 exceeds type size");
+}
+
+TEST_F(DynamicStructTest, DuplicateFieldName) {
+  auto desc = db.Add("test", "int16 a; int8 a", &err);
+  ASSERT_FALSE(desc);
+  ASSERT_EQ(err, "duplicate field a");
+}
+
+struct SimpleTestParam {
+  const char* schema;
+  size_t size;
+  StructFieldType type;
+  bool isInt;
+  bool isUint;
+  unsigned int bitWidth;
+  uint64_t bitMask;
+};
+
+std::ostream& operator<<(std::ostream& os, const SimpleTestParam& param) {
+  return os << "SimpleTestParam(Schema: \"" << param.schema << "\")";
+}
+
+class DynamicSimpleStructTest
+    : public ::testing::TestWithParam<SimpleTestParam> {
+ protected:
+  StructDescriptorDatabase db;
+  std::string err;
+};
+
+TEST_P(DynamicSimpleStructTest, Check) {
+  auto desc = db.Add("test", GetParam().schema, &err);
+  ASSERT_TRUE(desc);
+  ASSERT_EQ(desc->GetName(), "test");
+  ASSERT_EQ(desc->GetSchema(), GetParam().schema);
+  auto& fields = desc->GetFields();
+  ASSERT_EQ(fields.size(), 1u);
+  EXPECT_EQ(fields[0].GetParent(), desc);
+  EXPECT_EQ(fields[0].GetName(), "a");
+  EXPECT_EQ(fields[0].IsInt(), GetParam().isInt);
+  EXPECT_EQ(fields[0].IsUint(), GetParam().isUint);
+  EXPECT_FALSE(fields[0].IsArray());
+  if (GetParam().type != StructFieldType::kStruct) {
+    ASSERT_TRUE(desc->IsValid());
+    ASSERT_EQ(desc->GetSize(), GetParam().size);
+    ASSERT_EQ(fields[0].GetSize(), GetParam().size);
+    ASSERT_EQ(fields[0].GetBitWidth(), GetParam().bitWidth);
+    ASSERT_EQ(fields[0].GetBitMask(), GetParam().bitMask);
+  } else {
+    ASSERT_FALSE(desc->IsValid());
+    ASSERT_TRUE(fields[0].GetStruct());
+  }
+}
+
+TEST_P(DynamicSimpleStructTest, Array) {
+  auto desc = db.Add("test", GetParam().schema + std::string{"[2]"}, &err);
+  ASSERT_TRUE(desc);
+  ASSERT_EQ(desc->GetName(), "test");
+  ASSERT_EQ(desc->GetSchema(), GetParam().schema + std::string{"[2]"});
+  auto& fields = desc->GetFields();
+  ASSERT_EQ(fields.size(), 1u);
+  EXPECT_EQ(fields[0].GetParent(), desc);
+  EXPECT_EQ(fields[0].GetName(), "a");
+  EXPECT_EQ(fields[0].IsInt(), GetParam().isInt);
+  EXPECT_EQ(fields[0].IsUint(), GetParam().isUint);
+  EXPECT_TRUE(fields[0].IsArray());
+  EXPECT_EQ(fields[0].GetArraySize(), 2u);
+  if (GetParam().type != StructFieldType::kStruct) {
+    ASSERT_TRUE(desc->IsValid());
+    ASSERT_EQ(desc->GetSize(), GetParam().size * 2u);
+  } else {
+    ASSERT_FALSE(desc->IsValid());
+    ASSERT_TRUE(fields[0].GetStruct());
+  }
+}
+
+static SimpleTestParam simpleTests[] = {
+    {"bool a", 1, StructFieldType::kBool, false, false, 8, UINT8_MAX},
+    {"char a", 1, StructFieldType::kChar, false, false, 8, UINT8_MAX},
+    {"int8 a", 1, StructFieldType::kInt8, true, false, 8, UINT8_MAX},
+    {"int16 a", 2, StructFieldType::kInt16, true, false, 16, UINT16_MAX},
+    {"int32 a", 4, StructFieldType::kInt32, true, false, 32, UINT32_MAX},
+    {"int64 a", 8, StructFieldType::kInt64, true, false, 64, UINT64_MAX},
+    {"uint8 a", 1, StructFieldType::kUint8, false, true, 8, UINT8_MAX},
+    {"uint16 a", 2, StructFieldType::kUint16, false, true, 16, UINT16_MAX},
+    {"uint32 a", 4, StructFieldType::kUint32, false, true, 32, UINT32_MAX},
+    {"uint64 a", 8, StructFieldType::kUint64, false, true, 64, UINT64_MAX},
+    {"float a", 4, StructFieldType::kFloat, false, false, 32, UINT32_MAX},
+    {"float32 a", 4, StructFieldType::kFloat, false, false, 32, UINT32_MAX},
+    {"double a", 8, StructFieldType::kDouble, false, false, 64, UINT64_MAX},
+    {"float64 a", 8, StructFieldType::kDouble, false, false, 64, UINT64_MAX},
+    {"foo a", 0, StructFieldType::kStruct, false, false, 0, 0},
+};
+
+INSTANTIATE_TEST_SUITE_P(DynamicSimpleStructTests, DynamicSimpleStructTest,
+                         ::testing::ValuesIn(simpleTests));

--- a/wpiutil/src/test/native/cpp/struct/SchemaParserTest.cpp
+++ b/wpiutil/src/test/native/cpp/struct/SchemaParserTest.cpp
@@ -1,0 +1,218 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "wpi/struct/SchemaParser.h"  // NOLINT(build/include_order)
+
+#include <gtest/gtest.h>
+
+using namespace wpi::structparser;
+
+TEST(StructParserTest, Empty) {
+  Parser p{""};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_TRUE(schema.declarations.empty());
+}
+
+TEST(StructParserTest, EmptySemicolon) {
+  Parser p{";"};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_TRUE(schema.declarations.empty());
+}
+
+TEST(StructParserTest, Simple) {
+  Parser p{"int32 a"};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_EQ(schema.declarations.size(), 1u);
+  auto& decl = schema.declarations[0];
+  EXPECT_EQ(decl.typeString, "int32");
+  EXPECT_EQ(decl.name, "a");
+  EXPECT_EQ(decl.arraySize, 1u);
+}
+
+TEST(StructParserTest, SimpleTrailingSemi) {
+  Parser p{"int32 a;"};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_EQ(schema.declarations.size(), 1u);
+}
+
+TEST(StructParserTest, Array) {
+  Parser p{"int32 a[2]"};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_EQ(schema.declarations.size(), 1u);
+  auto& decl = schema.declarations[0];
+  EXPECT_EQ(decl.typeString, "int32");
+  EXPECT_EQ(decl.name, "a");
+  EXPECT_EQ(decl.arraySize, 2u);
+}
+
+TEST(StructParserTest, ArrayTrailingSemi) {
+  Parser p{"int32 a[2];"};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_EQ(schema.declarations.size(), 1u);
+}
+
+TEST(StructParserTest, Bitfield) {
+  Parser p{"int32 a:2"};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_EQ(schema.declarations.size(), 1u);
+  auto& decl = schema.declarations[0];
+  EXPECT_EQ(decl.typeString, "int32");
+  EXPECT_EQ(decl.name, "a");
+  EXPECT_EQ(decl.bitWidth, 2u);
+}
+
+TEST(StructParserTest, BitfieldTrailingSemi) {
+  Parser p{"int32 a:2;"};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_EQ(schema.declarations.size(), 1u);
+}
+
+TEST(StructParserTest, EnumKeyword) {
+  Parser p{"enum {x=1} int32 a;"};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_EQ(schema.declarations.size(), 1u);
+  auto& decl = schema.declarations[0];
+  EXPECT_EQ(decl.typeString, "int32");
+  EXPECT_EQ(decl.name, "a");
+  ASSERT_EQ(decl.enumValues.size(), 1u);
+  EXPECT_EQ(decl.enumValues[0].first, "x");
+  EXPECT_EQ(decl.enumValues[0].second, 1);
+}
+
+TEST(StructParserTest, EnumNoKeyword) {
+  Parser p{"{x=1} int32 a;"};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_EQ(schema.declarations.size(), 1u);
+  auto& decl = schema.declarations[0];
+  EXPECT_EQ(decl.typeString, "int32");
+  EXPECT_EQ(decl.name, "a");
+  ASSERT_EQ(decl.enumValues.size(), 1u);
+  EXPECT_EQ(decl.enumValues[0].first, "x");
+  EXPECT_EQ(decl.enumValues[0].second, 1);
+}
+
+TEST(StructParserTest, EnumNoValues) {
+  Parser p{"{} int32 a;"};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_EQ(schema.declarations.size(), 1u);
+  auto& decl = schema.declarations[0];
+  EXPECT_EQ(decl.typeString, "int32");
+  EXPECT_EQ(decl.name, "a");
+  ASSERT_TRUE(decl.enumValues.empty());
+}
+
+TEST(StructParserTest, EnumMultipleValues) {
+  Parser p{"{x=1,y=-2} int32 a;"};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_EQ(schema.declarations.size(), 1u);
+  auto& decl = schema.declarations[0];
+  EXPECT_EQ(decl.typeString, "int32");
+  EXPECT_EQ(decl.name, "a");
+  ASSERT_EQ(decl.enumValues.size(), 2u);
+  EXPECT_EQ(decl.enumValues[0].first, "x");
+  EXPECT_EQ(decl.enumValues[0].second, 1);
+  EXPECT_EQ(decl.enumValues[1].first, "y");
+  EXPECT_EQ(decl.enumValues[1].second, -2);
+}
+
+TEST(StructParserTest, EnumTrailingComma) {
+  Parser p{"{x=1,y=2,} int32 a;"};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_EQ(schema.declarations.size(), 1u);
+  auto& decl = schema.declarations[0];
+  EXPECT_EQ(decl.typeString, "int32");
+  EXPECT_EQ(decl.name, "a");
+  ASSERT_EQ(decl.enumValues.size(), 2u);
+  EXPECT_EQ(decl.enumValues[0].first, "x");
+  EXPECT_EQ(decl.enumValues[0].second, 1);
+  EXPECT_EQ(decl.enumValues[1].first, "y");
+  EXPECT_EQ(decl.enumValues[1].second, 2);
+}
+
+TEST(StructParserTest, MultipleNoTrailingSemi) {
+  Parser p{"int32 a; int16 b"};
+  ParsedSchema schema;
+  ASSERT_TRUE(p.Parse(&schema));
+  ASSERT_EQ(schema.declarations.size(), 2u);
+  EXPECT_EQ(schema.declarations[0].typeString, "int32");
+  EXPECT_EQ(schema.declarations[0].name, "a");
+  EXPECT_EQ(schema.declarations[1].typeString, "int16");
+  EXPECT_EQ(schema.declarations[1].name, "b");
+}
+
+TEST(StructParserTest, ErrBitfieldArray) {
+  Parser p{"int32 a[1]:2"};
+  ParsedSchema schema;
+  ASSERT_FALSE(p.Parse(&schema));
+  ASSERT_EQ(p.GetError(), "10: expected ';', got ':'");
+}
+
+TEST(StructParserTest, ErrNoArrayValue) {
+  Parser p{"int32 a[]"};
+  ParsedSchema schema;
+  ASSERT_FALSE(p.Parse(&schema));
+  ASSERT_EQ(p.GetError(), "8: expected integer, got ']'");
+}
+
+TEST(StructParserTest, ErrNoBitfieldValue) {
+  Parser p{"int32 a:"};
+  ParsedSchema schema;
+  ASSERT_FALSE(p.Parse(&schema));
+  ASSERT_EQ(p.GetError(), "8: expected integer, got ''");
+}
+
+TEST(StructParserTest, ErrNoNameArray) {
+  Parser p{"int32 [2]"};
+  ParsedSchema schema;
+  ASSERT_FALSE(p.Parse(&schema));
+  ASSERT_EQ(p.GetError(), "6: expected identifier, got '['");
+}
+
+TEST(StructParserTest, ErrNoNameBitField) {
+  Parser p{"int32 :2"};
+  ParsedSchema schema;
+  ASSERT_FALSE(p.Parse(&schema));
+  ASSERT_EQ(p.GetError(), "6: expected identifier, got ':'");
+}
+
+TEST(StructParserTest, NegativeBitField) {
+  Parser p{"int32 a:-1"};
+  ParsedSchema schema;
+  ASSERT_FALSE(p.Parse(&schema));
+  ASSERT_EQ(p.GetError(), "8: bitfield width '-1' is not a positive integer");
+}
+
+TEST(StructParserTest, NegativeArraySize) {
+  Parser p{"int32 a[-1]"};
+  ParsedSchema schema;
+  ASSERT_FALSE(p.Parse(&schema));
+  ASSERT_EQ(p.GetError(), "8: array size '-1' is not a positive integer");
+}
+
+TEST(StructParserTest, ZeroBitField) {
+  Parser p{"int32 a:0"};
+  ParsedSchema schema;
+  ASSERT_FALSE(p.Parse(&schema));
+  ASSERT_EQ(p.GetError(), "8: bitfield width '0' is not a positive integer");
+}
+
+TEST(StructParserTest, ZeroArraySize) {
+  Parser p{"int32 a[0]"};
+  ParsedSchema schema;
+  ASSERT_FALSE(p.Parse(&schema));
+  ASSERT_EQ(p.GetError(), "8: array size '0' is not a positive integer");
+}


### PR DESCRIPTION
This adds support for two serialization formats for complex data types:
- Protobuf for complex objects with variable length internals that need forward and backward wire compatibility (lower speed, more flexible)
- Raw struct (ByteBuffer-style) for fixed-length objects (higher speed, less flexible)

Deserialization can be done either by creating a new object (for immutable objects) or overwriting the contents of an existing object (for mutable objects).

Implementing classes should provide inner classes that implement the `Protobuf` or `Struct` interface (in Java) or specialize the `wpi::Protobuf` or `wpi::Struct` struct (in C++).  It is possible for classes to implement both. If the class itself does not implement serialization, it's possible for third parties/users to provide an implementation instead.

Uses the Google protobuf implementation for C++ and the QuickBuffers alternative protobuf implementation for Java.

TODO:
- [x] auto-publishing of Java protobuf descriptors to DataLog
- [x] auto-publishing of Java protobuf descriptors to NT
- [ ] implement for many more types (only geometry classes done so far)
- [x] ~~use hash of schema to ensure unique struct type string when publishing~~ (deferred)
- [x] C++ raw struct schema parser for introspection/reflection
- [x] Java raw struct schema parser for introspection/reflection
- [x] glass support (extract/show introspected fields broken out in NT outline view)
- [x] ~~SendableBuilder class support~~ (deferred to telemetry redesign)
- [x] ~~SmartDashboard/Shuffleboard class support~~ (deferred, may do as part of telemetry redesign instead)
- [ ] examples
- [ ] tests
- [ ] documentation

Fixes #4587.