### PR TITLE
[hal] WS Simulation: Add message filtering capability

### DIFF
--- a/simulation/halsim_ws_client/src/main/native/cpp/HALSimWSClientConnection.cpp
+++ b/simulation/halsim_ws_client/src/main/native/cpp/HALSimWSClientConnection.cpp
@@ -74,6 +74,17 @@ void HALSimWSClientConnection::OnSimValueChanged(const wpi::json& msg) {
   if (msg.empty()) {
     return;
   }
+
+  // Skip sending if this message is not in the allowed filter list
+  try {
+    auto& type = msg.at("type").get_ref<const std::string&>();
+    if (!m_client->CanSendMessage(type)) {
+      return;
+    }
+  } catch (wpi::json::exception& e) {
+    fmt::print(stderr, "Error with message: {}\n", e.what());
+  }
+
   wpi::SmallVector<uv::Buffer, 4> sendBufs;
   wpi::raw_uv_ostream os{sendBufs, [this]() -> uv::Buffer {
                            std::lock_guard lock(m_buffers_mutex);

--- a/simulation/halsim_ws_client/src/main/native/include/HALSimWS.h
+++ b/simulation/halsim_ws_client/src/main/native/include/HALSimWS.h
@@ -7,9 +7,11 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include <WSProviderContainer.h>
 #include <WSProvider_SimDevice.h>
+#include <wpi/StringMap.h>
 #include <wpinet/uv/Async.h>
 #include <wpinet/uv/Loop.h>
 #include <wpinet/uv/Tcp.h>
@@ -41,6 +43,8 @@ class HALSimWS : public std::enable_shared_from_this<HALSimWS> {
 
   void OnNetValueChanged(const wpi::json& msg);
 
+  bool CanSendMessage(std::string_view type);
+
   const std::string& GetTargetHost() const { return m_host; }
   const std::string& GetTargetUri() const { return m_uri; }
   int GetTargetPort() const { return m_port; }
@@ -67,6 +71,9 @@ class HALSimWS : public std::enable_shared_from_this<HALSimWS> {
   std::string m_host;
   std::string m_uri;
   int m_port;
+
+  bool m_useMsgFiltering;
+  wpi::StringMap<bool> m_msgFilters;
 };
 
 }  // namespace wpilibws

--- a/simulation/halsim_ws_server/src/main/native/cpp/HALSimHttpConnection.cpp
+++ b/simulation/halsim_ws_server/src/main/native/cpp/HALSimHttpConnection.cpp
@@ -76,6 +76,16 @@ void HALSimHttpConnection::ProcessWsUpgrade() {
 }
 
 void HALSimHttpConnection::OnSimValueChanged(const wpi::json& msg) {
+  // Skip sending if this message is not in the allowed filter list
+  try {
+    auto& type = msg.at("type").get_ref<const std::string&>();
+    if (!m_server->CanSendMessage(type)) {
+      return;
+    }
+  } catch (wpi::json::exception& e) {
+    fmt::print(stderr, "Error with message: {}\n", e.what());
+  }
+
   // render json to buffers
   wpi::SmallVector<uv::Buffer, 4> sendBufs;
   wpi::raw_uv_ostream os{sendBufs, [this]() -> uv::Buffer {

--- a/simulation/halsim_ws_server/src/main/native/include/HALSimWeb.h
+++ b/simulation/halsim_ws_server/src/main/native/include/HALSimWeb.h
@@ -7,10 +7,12 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include <WSBaseProvider.h>
 #include <WSProviderContainer.h>
 #include <WSProvider_SimDevice.h>
+#include <wpi/StringMap.h>
 #include <wpinet/uv/Async.h>
 #include <wpinet/uv/Loop.h>
 #include <wpinet/uv/Tcp.h>
@@ -41,6 +43,8 @@ class HALSimWeb : public std::enable_shared_from_this<HALSimWeb> {
   // network -> sim
   void OnNetValueChanged(const wpi::json& msg);
 
+  bool CanSendMessage(std::string_view type);
+
   const std::string& GetWebrootSys() const { return m_webroot_sys; }
   const std::string& GetWebrootUser() const { return m_webroot_user; }
   const std::string& GetServerUri() const { return m_uri; }
@@ -69,6 +73,9 @@ class HALSimWeb : public std::enable_shared_from_this<HALSimWeb> {
 
   std::string m_uri;
   int m_port;
+
+  bool m_useMsgFiltering;
+  wpi::StringMap<bool> m_msgFilters;
 };
 
 }  // namespace wpilibws


### PR DESCRIPTION
The WebSocket HAL interface tends to be a little chatty and this was overwhelming the Pico W that powers the XRP robot. This PR provides the ability to filter the WS message by type that gets sent from WPILib.

Adding a line like `wpi.sim.envVar("HALSIMWS_FILTERS", "Gyro,DriverStation,DIO,AIO,Encoder")` to a robot project `build.gradle` file will only allow the listed message types to be sent over the wire.