### PR TITLE
Add reset method to SwerveDriveKinematics

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
@@ -89,10 +89,11 @@ public class SwerveDriveKinematics
 
   /**
    * Reset the internal swerve module headings.
-   * @param moduleHeadings The swerve module headings. The order of the module headings should be same as
-   * passed into the constructor of this class.
+   *
+   * @param moduleHeadings The swerve module headings. The order of the module headings should be
+   *     same as passed into the constructor of this class.
    */
-  public void resetHeadings(Rotation2d... moduleHeadings){
+  public void resetHeadings(Rotation2d... moduleHeadings) {
     m_moduleHeadings = moduleHeadings;
   }
 
@@ -119,9 +120,9 @@ public class SwerveDriveKinematics
    */
   public SwerveModuleState[] toSwerveModuleStates(
       ChassisSpeeds chassisSpeeds, Translation2d centerOfRotationMeters) {
-   var moduleStates = new SwerveModuleState[m_numModules];
+    var moduleStates = new SwerveModuleState[m_numModules];
 
-   if (chassisSpeeds.vxMetersPerSecond == 0.0
+    if (chassisSpeeds.vxMetersPerSecond == 0.0
         && chassisSpeeds.vyMetersPerSecond == 0.0
         && chassisSpeeds.omegaRadiansPerSecond == 0.0) {
       for (int i = 0; i < m_numModules; i++) {

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
@@ -94,7 +94,14 @@ public class SwerveDriveKinematics
    *     same as passed into the constructor of this class.
    */
   public void resetHeadings(Rotation2d... moduleHeadings) {
-    m_moduleHeadings = moduleHeadings;
+    if (moduleHeadings.length != m_numModules) {
+      throw new IllegalArgumentException(
+          "Number of headings is not consistent with number of module locations provided in "
+              + "constructor");
+    }
+    for (int i = 0; i < moduleHeadings.length; i++) {
+      m_moduleHeadings[i] = moduleHeadings[i];
+    }
   }
 
   /**
@@ -168,6 +175,7 @@ public class SwerveDriveKinematics
       Rotation2d angle = new Rotation2d(x, y);
 
       moduleStates[i] = new SwerveModuleState(speed, angle);
+      m_moduleHeadings[i] = angle;
     }
 
     return moduleStates;

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
@@ -99,9 +99,7 @@ public class SwerveDriveKinematics
           "Number of headings is not consistent with number of module locations provided in "
               + "constructor");
     }
-    for (int i = 0; i < moduleHeadings.length; i++) {
-      m_moduleHeadings[i] = moduleHeadings[i];
-    }
+    m_moduleHeadings = Arrays.copyOf(moduleHeadings, 4);
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.java
@@ -55,7 +55,7 @@ public class SwerveDriveKinematics
 
   private final int m_numModules;
   private final Translation2d[] m_modules;
-  private SwerveModuleState[] m_moduleStates;
+  private Rotation2d[] m_moduleHeadings;
   private Translation2d m_prevCoR = new Translation2d();
 
   /**
@@ -74,8 +74,8 @@ public class SwerveDriveKinematics
     }
     m_numModules = moduleTranslationsMeters.length;
     m_modules = Arrays.copyOf(moduleTranslationsMeters, m_numModules);
-    m_moduleStates = new SwerveModuleState[m_numModules];
-    Arrays.fill(m_moduleStates, new SwerveModuleState());
+    m_moduleHeadings = new Rotation2d[m_numModules];
+    Arrays.fill(m_moduleHeadings, new Rotation2d());
     m_inverseKinematics = new SimpleMatrix(m_numModules * 2, 3);
 
     for (int i = 0; i < m_numModules; i++) {
@@ -85,6 +85,15 @@ public class SwerveDriveKinematics
     m_forwardKinematics = m_inverseKinematics.pseudoInverse();
 
     MathSharedStore.reportUsage(MathUsageId.kKinematics_SwerveDrive, 1);
+  }
+
+  /**
+   * Reset the internal swerve module headings.
+   * @param moduleHeadings The swerve module headings. The order of the module headings should be same as
+   * passed into the constructor of this class.
+   */
+  public void resetHeadings(Rotation2d... moduleHeadings){
+    m_moduleHeadings = moduleHeadings;
   }
 
   /**
@@ -108,19 +117,18 @@ public class SwerveDriveKinematics
    *     attainable max velocity. Use the {@link #desaturateWheelSpeeds(SwerveModuleState[], double)
    *     DesaturateWheelSpeeds} function to rectify this issue.
    */
-  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public SwerveModuleState[] toSwerveModuleStates(
       ChassisSpeeds chassisSpeeds, Translation2d centerOfRotationMeters) {
-    if (chassisSpeeds.vxMetersPerSecond == 0.0
+   var moduleStates = new SwerveModuleState[m_numModules];
+
+   if (chassisSpeeds.vxMetersPerSecond == 0.0
         && chassisSpeeds.vyMetersPerSecond == 0.0
         && chassisSpeeds.omegaRadiansPerSecond == 0.0) {
-      SwerveModuleState[] newStates = new SwerveModuleState[m_numModules];
       for (int i = 0; i < m_numModules; i++) {
-        newStates[i] = new SwerveModuleState(0.0, m_moduleStates[i].angle);
+        moduleStates[i] = new SwerveModuleState(0.0, m_moduleHeadings[i]);
       }
 
-      m_moduleStates = newStates;
-      return m_moduleStates;
+      return moduleStates;
     }
 
     if (!centerOfRotationMeters.equals(m_prevCoR)) {
@@ -151,7 +159,6 @@ public class SwerveDriveKinematics
 
     var moduleStatesMatrix = m_inverseKinematics.mult(chassisSpeedsVector);
 
-    m_moduleStates = new SwerveModuleState[m_numModules];
     for (int i = 0; i < m_numModules; i++) {
       double x = moduleStatesMatrix.get(i * 2, 0);
       double y = moduleStatesMatrix.get(i * 2 + 1, 0);
@@ -159,10 +166,10 @@ public class SwerveDriveKinematics
       double speed = Math.hypot(x, y);
       Rotation2d angle = new Rotation2d(x, y);
 
-      m_moduleStates[i] = new SwerveModuleState(speed, angle);
+      moduleStates[i] = new SwerveModuleState(speed, angle);
     }
 
-    return m_moduleStates;
+    return moduleStates;
   }
 
   /**

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.h
@@ -69,7 +69,7 @@ class SwerveDriveKinematics
   template <std::convertible_to<Translation2d>... ModuleTranslations>
     requires(sizeof...(ModuleTranslations) == NumModules)
   explicit SwerveDriveKinematics(ModuleTranslations&&... moduleTranslations)
-      : m_modules{moduleTranslations...}, m_moduleStates(wpi::empty_array) {
+      : m_modules{moduleTranslations...}, m_moduleHeadings(wpi::empty_array) {
     for (size_t i = 0; i < NumModules; i++) {
       // clang-format off
       m_inverseKinematics.template block<2, 3>(i * 2, 0) <<
@@ -86,7 +86,7 @@ class SwerveDriveKinematics
 
   explicit SwerveDriveKinematics(
       const wpi::array<Translation2d, NumModules>& modules)
-      : m_modules{modules}, m_moduleStates(wpi::empty_array) {
+      : m_modules{modules}, m_moduleHeadings(wpi::empty_array) {
     for (size_t i = 0; i < NumModules; i++) {
       // clang-format off
       m_inverseKinematics.template block<2, 3>(i * 2, 0) <<
@@ -102,6 +102,13 @@ class SwerveDriveKinematics
   }
 
   SwerveDriveKinematics(const SwerveDriveKinematics&) = default;
+
+  /**
+   * Reset the internal swerve module headings.
+   * @param moduleHeadings The swerve module headings. The order of the module
+   * headings should be same as passed into the constructor of this class.
+   */
+  void ResetHeadings(wpi::array<Rotation2d, NumModules>& moduleHeadings);
 
   /**
    * Performs inverse kinematics to return the module states from a desired
@@ -270,7 +277,7 @@ class SwerveDriveKinematics
   mutable Matrixd<NumModules * 2, 3> m_inverseKinematics;
   Eigen::HouseholderQR<Matrixd<NumModules * 2, 3>> m_forwardKinematics;
   wpi::array<Translation2d, NumModules> m_modules;
-  mutable wpi::array<SwerveModuleState, NumModules> m_moduleStates;
+  mutable wpi::array<Rotation2d, NumModules> m_moduleHeadings;
 
   mutable Translation2d m_previousCoR;
 };

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.h
@@ -108,7 +108,6 @@ class SwerveDriveKinematics
    * @param moduleHeadings The swerve module headings. The order of the module
    * headings should be same as passed into the constructor of this class.
    */
-
   template <std::convertible_to<Rotation2d>... ModuleHeadings>
     requires(sizeof...(ModuleHeadings) == NumModules)
   void ResetHeadings(ModuleHeadings&&... moduleHeadings) {

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.h
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.h
@@ -108,7 +108,20 @@ class SwerveDriveKinematics
    * @param moduleHeadings The swerve module headings. The order of the module
    * headings should be same as passed into the constructor of this class.
    */
-  void ResetHeadings(wpi::array<Rotation2d, NumModules>& moduleHeadings);
+
+  template <std::convertible_to<Rotation2d>... ModuleHeadings>
+    requires(sizeof...(ModuleHeadings) == NumModules)
+  void ResetHeadings(ModuleHeadings&&... moduleHeadings) {
+    return this->ResetHeadings(
+        wpi::array<Rotation2d, NumModules>{moduleHeadings...});
+  }
+
+  /**
+   * Reset the internal swerve module headings.
+   * @param moduleHeadings The swerve module headings. The order of the module
+   * headings should be same as passed into the constructor of this class.
+   */
+  void ResetHeadings(wpi::array<Rotation2d, NumModules> moduleHeadings);
 
   /**
    * Performs inverse kinematics to return the module states from a desired

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.inc
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.inc
@@ -18,17 +18,25 @@ SwerveDriveKinematics(ModuleTranslation, ModuleTranslations...)
     -> SwerveDriveKinematics<1 + sizeof...(ModuleTranslations)>;
 
 template <size_t NumModules>
+void SwerveDriveKinematics<NumModules>::ResetHeadings(
+    wpi::array<Rotation2d, NumModules>& moduleHeadings) {
+  m_moduleHeadings = moduleHeadings;
+}
+
+template <size_t NumModules>
 wpi::array<SwerveModuleState, NumModules>
 SwerveDriveKinematics<NumModules>::ToSwerveModuleStates(
     const ChassisSpeeds& chassisSpeeds,
     const Translation2d& centerOfRotation) const {
+  wpi::array<SwerveModuleState, NumModules> moduleStates(wpi::empty_array);
+
   if (chassisSpeeds.vx == 0_mps && chassisSpeeds.vy == 0_mps &&
       chassisSpeeds.omega == 0_rad_per_s) {
     for (size_t i = 0; i < NumModules; i++) {
-      m_moduleStates[i].speed = 0_mps;
+      moduleStates[i] = {0_mps, m_moduleHeadings[i]};
     }
 
-    return m_moduleStates;
+    return moduleStates;
   }
 
   // We have a new center of rotation. We need to compute the matrix again.
@@ -58,10 +66,10 @@ SwerveDriveKinematics<NumModules>::ToSwerveModuleStates(
     auto speed = units::math::hypot(x, y);
     Rotation2d rotation{x.value(), y.value()};
 
-    m_moduleStates[i] = {speed, rotation};
+    moduleStates[i] = {speed, rotation};
   }
 
-  return m_moduleStates;
+  return moduleStates;
 }
 
 template <size_t NumModules>

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.inc
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.inc
@@ -20,7 +20,9 @@ SwerveDriveKinematics(ModuleTranslation, ModuleTranslations...)
 template <size_t NumModules>
 void SwerveDriveKinematics<NumModules>::ResetHeadings(
     wpi::array<Rotation2d, NumModules> moduleHeadings) {
-  m_moduleHeadings = moduleHeadings;
+  for (size_t i = 0; i < NumModules; i++) {
+    m_moduleHeadings[i] = moduleHeadings[i];
+  }
 }
 
 template <size_t NumModules>

--- a/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.inc
+++ b/wpimath/src/main/native/include/frc/kinematics/SwerveDriveKinematics.inc
@@ -19,7 +19,7 @@ SwerveDriveKinematics(ModuleTranslation, ModuleTranslations...)
 
 template <size_t NumModules>
 void SwerveDriveKinematics<NumModules>::ResetHeadings(
-    wpi::array<Rotation2d, NumModules>& moduleHeadings) {
+    wpi::array<Rotation2d, NumModules> moduleHeadings) {
   m_moduleHeadings = moduleHeadings;
 }
 
@@ -67,6 +67,7 @@ SwerveDriveKinematics<NumModules>::ToSwerveModuleStates(
     Rotation2d rotation{x.value(), y.value()};
 
     moduleStates[i] = {speed, rotation};
+    m_moduleHeadings[i] = rotation;
   }
 
   return moduleStates;

--- a/wpimath/src/test/java/edu/wpi/first/math/kinematics/SwerveDriveKinematicsTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/kinematics/SwerveDriveKinematicsTest.java
@@ -120,6 +120,28 @@ class SwerveDriveKinematicsTest {
   }
 
   @Test
+  void testResetWheelAngle() {
+    Rotation2d fl = new Rotation2d(0);
+    Rotation2d fr = new Rotation2d(Math.PI / 2);
+    Rotation2d bl = new Rotation2d(Math.PI);
+    Rotation2d br = new Rotation2d(3 * Math.PI / 2);
+    m_kinematics.resetHeadings(fl, fr, bl, br);
+    var moduleStates = m_kinematics.toSwerveModuleStates(new ChassisSpeeds());
+
+    // Robot is stationary, but module angles are preserved.
+
+    assertAll(
+        () -> assertEquals(0.0, moduleStates[0].speedMetersPerSecond, kEpsilon),
+        () -> assertEquals(0.0, moduleStates[1].speedMetersPerSecond, kEpsilon),
+        () -> assertEquals(0.0, moduleStates[2].speedMetersPerSecond, kEpsilon),
+        () -> assertEquals(0.0, moduleStates[3].speedMetersPerSecond, kEpsilon),
+        () -> assertEquals(0.0, moduleStates[0].angle.getDegrees(), kEpsilon),
+        () -> assertEquals(90.0, moduleStates[1].angle.getDegrees(), kEpsilon),
+        () -> assertEquals(180.0, moduleStates[2].angle.getDegrees(), kEpsilon),
+        () -> assertEquals(270.0, moduleStates[3].angle.getDegrees(), kEpsilon));
+  }
+
+  @Test
   void testTurnInPlaceInverseKinematics() {
     ChassisSpeeds speeds = new ChassisSpeeds(0, 0, 2 * Math.PI);
     var moduleStates = m_kinematics.toSwerveModuleStates(speeds);

--- a/wpimath/src/test/native/cpp/kinematics/SwerveDriveKinematicsTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/SwerveDriveKinematicsTest.cpp
@@ -126,10 +126,10 @@ TEST_F(SwerveDriveKinematicsTest, ConserveWheelAngle) {
   EXPECT_NEAR(br.angle.Degrees().value(), -45.0, kEpsilon);
 }
 TEST_F(SwerveDriveKinematicsTest, ResetWheelAngle) {
-  Rotation2d fl = {90_deg};
+  Rotation2d fl = {0_deg};
   Rotation2d fr = {90_deg};
-  Rotation2d bl = {90_deg};
-  Rotation2d br = {90_deg};
+  Rotation2d bl = {180_deg};
+  Rotation2d br = {270_deg};
   m_kinematics.ResetHeadings(fl, fr, bl, br);
   auto [flMod, frMod, blMod, brMod] =
       m_kinematics.ToSwerveModuleStates(ChassisSpeeds{});
@@ -139,10 +139,10 @@ TEST_F(SwerveDriveKinematicsTest, ResetWheelAngle) {
   EXPECT_NEAR(blMod.speed.value(), 0.0, kEpsilon);
   EXPECT_NEAR(brMod.speed.value(), 0.0, kEpsilon);
 
-  EXPECT_NEAR(flMod.angle.Degrees().value(), 90.0, kEpsilon);
+  EXPECT_NEAR(flMod.angle.Degrees().value(), 0.0, kEpsilon);
   EXPECT_NEAR(frMod.angle.Degrees().value(), 90.0, kEpsilon);
-  EXPECT_NEAR(blMod.angle.Degrees().value(), 90.0, kEpsilon);
-  EXPECT_NEAR(brMod.angle.Degrees().value(), 90.0, kEpsilon);
+  EXPECT_NEAR(blMod.angle.Degrees().value(), 180.0, kEpsilon);
+  EXPECT_NEAR(brMod.angle.Degrees().value(), 270.0, kEpsilon);
 }
 
 TEST_F(SwerveDriveKinematicsTest, TurnInPlaceForwardKinematics) {

--- a/wpimath/src/test/native/cpp/kinematics/SwerveDriveKinematicsTest.cpp
+++ b/wpimath/src/test/native/cpp/kinematics/SwerveDriveKinematicsTest.cpp
@@ -125,6 +125,25 @@ TEST_F(SwerveDriveKinematicsTest, ConserveWheelAngle) {
   EXPECT_NEAR(bl.angle.Degrees().value(), -135.0, kEpsilon);
   EXPECT_NEAR(br.angle.Degrees().value(), -45.0, kEpsilon);
 }
+TEST_F(SwerveDriveKinematicsTest, ResetWheelAngle) {
+  Rotation2d fl = {90_deg};
+  Rotation2d fr = {90_deg};
+  Rotation2d bl = {90_deg};
+  Rotation2d br = {90_deg};
+  m_kinematics.ResetHeadings(fl, fr, bl, br);
+  auto [flMod, frMod, blMod, brMod] =
+      m_kinematics.ToSwerveModuleStates(ChassisSpeeds{});
+
+  EXPECT_NEAR(flMod.speed.value(), 0.0, kEpsilon);
+  EXPECT_NEAR(frMod.speed.value(), 0.0, kEpsilon);
+  EXPECT_NEAR(blMod.speed.value(), 0.0, kEpsilon);
+  EXPECT_NEAR(brMod.speed.value(), 0.0, kEpsilon);
+
+  EXPECT_NEAR(flMod.angle.Degrees().value(), 90.0, kEpsilon);
+  EXPECT_NEAR(frMod.angle.Degrees().value(), 90.0, kEpsilon);
+  EXPECT_NEAR(blMod.angle.Degrees().value(), 90.0, kEpsilon);
+  EXPECT_NEAR(brMod.angle.Degrees().value(), 90.0, kEpsilon);
+}
 
 TEST_F(SwerveDriveKinematicsTest, TurnInPlaceForwardKinematics) {
   SwerveModuleState fl{106.629_mps, 135_deg};


### PR DESCRIPTION
Fixes #5167, #5029, and supersedes #5123. Adds a reset method where teams can pass in module headings for the kinematics object to use if it gets an all-zero `ChassisSpeeds` while converting `ChassisSpeeds` to module states. Also removes internal states array, replacing it with an internal headings array.