### PR TITLE
Notify DriverStationSim in CommandTestBaseWithParam

### DIFF
--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.cpp
@@ -15,12 +15,12 @@ CommandTestBase::CommandTestBase() {
   SetDSEnabled(true);
 }
 
-CommandScheduler CommandTestBase::GetScheduler() {
-  return CommandScheduler();
+CommandTestBase::~CommandTestBase() {
+  CommandScheduler::GetInstance().GetActiveButtonLoop()->Clear();
 }
 
-void CommandTestBase::TearDown() {
-  CommandScheduler::GetInstance().GetActiveButtonLoop()->Clear();
+CommandScheduler CommandTestBase::GetScheduler() {
+  return CommandScheduler();
 }
 
 void CommandTestBase::SetDSEnabled(bool enabled) {

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.cpp
@@ -24,6 +24,7 @@ void CommandTestBase::TearDown() {
 }
 
 void CommandTestBase::SetDSEnabled(bool enabled) {
+  frc::sim::DriverStationSim::SetDsAttached(true);
   frc::sim::DriverStationSim::SetEnabled(enabled);
   frc::sim::DriverStationSim::NotifyNewData();
 }

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.cpp
@@ -18,8 +18,7 @@ CommandScheduler CommandTestBase::GetScheduler() {
 }
 
 void CommandTestBase::SetUp() {
-  frc::sim::DriverStationSim::SetEnabled(true);
-  frc::sim::DriverStationSim::NotifyNewData();
+  SetDSEnabled(true);
 }
 
 void CommandTestBase::TearDown() {

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.cpp
@@ -11,14 +11,12 @@ CommandTestBase::CommandTestBase() {
   scheduler.CancelAll();
   scheduler.Enable();
   scheduler.GetActiveButtonLoop()->Clear();
+
+  SetDSEnabled(true);
 }
 
 CommandScheduler CommandTestBase::GetScheduler() {
   return CommandScheduler();
-}
-
-void CommandTestBase::SetUp() {
-  SetDSEnabled(true);
 }
 
 void CommandTestBase::TearDown() {

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.h
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.h
@@ -106,7 +106,10 @@ class CommandTestBaseWithParam : public ::testing::TestWithParam<T> {
  protected:
   CommandScheduler GetScheduler() { return CommandScheduler(); }
 
-  void SetUp() override { frc::sim::DriverStationSim::SetEnabled(true); }
+  void SetUp() override {
+    frc::sim::DriverStationSim::SetEnabled(true);
+    frc::sim::DriverStationSim::NotifyNewData();
+  }
 
   void TearDown() override {
     CommandScheduler::GetInstance().GetActiveButtonLoop()->Clear();
@@ -114,6 +117,7 @@ class CommandTestBaseWithParam : public ::testing::TestWithParam<T> {
 
   void SetDSEnabled(bool enabled) {
     frc::sim::DriverStationSim::SetEnabled(enabled);
+    frc::sim::DriverStationSim::NotifyNewData();
   }
 };
 

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.h
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.h
@@ -83,10 +83,10 @@ class CommandTestBase : public ::testing::Test {
  public:
   CommandTestBase();
 
+  ~CommandTestBase() override;
+
  protected:
   CommandScheduler GetScheduler();
-
-  void TearDown() override;
 
   void SetDSEnabled(bool enabled);
 };
@@ -103,12 +103,12 @@ class CommandTestBaseWithParam : public ::testing::TestWithParam<T> {
     SetDSEnabled(true);
   }
 
- protected:
-  CommandScheduler GetScheduler() { return CommandScheduler(); }
-
-  void TearDown() override {
+  ~CommandTestBaseWithParam() override {
     CommandScheduler::GetInstance().GetActiveButtonLoop()->Clear();
   }
+
+ protected:
+  CommandScheduler GetScheduler() { return CommandScheduler(); }
 
   void SetDSEnabled(bool enabled) {
     frc::sim::DriverStationSim::SetDsAttached(true);

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.h
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.h
@@ -86,8 +86,6 @@ class CommandTestBase : public ::testing::Test {
  protected:
   CommandScheduler GetScheduler();
 
-  void SetUp() override;
-
   void TearDown() override;
 
   void SetDSEnabled(bool enabled);
@@ -101,14 +99,12 @@ class CommandTestBaseWithParam : public ::testing::TestWithParam<T> {
     scheduler.CancelAll();
     scheduler.Enable();
     scheduler.GetActiveButtonLoop()->Clear();
+
+    SetDSEnabled(true);
   }
 
  protected:
   CommandScheduler GetScheduler() { return CommandScheduler(); }
-
-  void SetUp() override {
-    SetDSEnabled(true);
-  }
 
   void TearDown() override {
     CommandScheduler::GetInstance().GetActiveButtonLoop()->Clear();

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.h
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.h
@@ -107,8 +107,7 @@ class CommandTestBaseWithParam : public ::testing::TestWithParam<T> {
   CommandScheduler GetScheduler() { return CommandScheduler(); }
 
   void SetUp() override {
-    frc::sim::DriverStationSim::SetEnabled(true);
-    frc::sim::DriverStationSim::NotifyNewData();
+    SetDSEnabled(true);
   }
 
   void TearDown() override {

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.h
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandTestBase.h
@@ -111,6 +111,7 @@ class CommandTestBaseWithParam : public ::testing::TestWithParam<T> {
   }
 
   void SetDSEnabled(bool enabled) {
+    frc::sim::DriverStationSim::SetDsAttached(true);
     frc::sim::DriverStationSim::SetEnabled(enabled);
     frc::sim::DriverStationSim::NotifyNewData();
   }

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulingRecursionTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/SchedulingRecursionTest.cpp
@@ -57,7 +57,7 @@ TEST_F(SchedulingRecursionTest, CancelFromInitialize) {
 }
 
 TEST_P(SchedulingRecursionTest,
-       DISABLED_DefaultCommandGetsRescheduledAfterSelfCanceling) {
+       DefaultCommandGetsRescheduledAfterSelfCanceling) {
   CommandScheduler scheduler = GetScheduler();
   bool hasOtherRun = false;
   TestSubsystem requirement;


### PR DESCRIPTION
Fixes #5396 (SchedulingRecursionTest failing on Linux).

I'm not sure why this didn't manifest before, but `CommandTestBaseWithParam` (which is only used by `SchedulingRecursionTest`) was missing the call to notify the sim DS of new data (which was added last October by 3787 to just `CommandTestBase`).