### PR TITLE
Remove spaces in NOLINT comments

### DIFF
--- a/ntcore/src/test/native/cpp/ValueTest.cpp
+++ b/ntcore/src/test/native/cpp/ValueTest.cpp
@@ -12,7 +12,7 @@
 
 using namespace std::string_view_literals;
 
-namespace std {  // NOLINT (clang-tidy.cert-dcl58-cpp)
+namespace std {  // NOLINT(clang-tidy.cert-dcl58-cpp)
 template <typename T, typename U>
 inline bool operator==(std::span<T> lhs, std::span<U> rhs) {
   if (lhs.size() != rhs.size()) {

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
@@ -32,7 +32,7 @@ class CommandPtr final {
       : m_ptr(std::move(command)) {}
 
   template <std::derived_from<Command> T>
-  // NOLINTNEXTLINE (bugprone-forwarding-reference-overload)
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   explicit CommandPtr(T&& command)
       : CommandPtr(
             std::make_unique<std::decay_t<T>>(std::forward<T>(command))) {}

--- a/wpilibNewCommands/src/main/native/include/frc2/command/PerpetualCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/PerpetualCommand.h
@@ -69,7 +69,7 @@ class PerpetualCommand : public CommandHelper<CommandBase, PerpetualCommand> {
       "be valid. This was unsafe/undefined behavior from the start, and "
       "RepeatCommand provides an easy way to achieve similar end results "
       "with slightly different (and safe) semantics.")
-  // NOLINTNEXTLINE (bugprone-forwarding-reference-overload)
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   explicit PerpetualCommand(T&& command)
       : PerpetualCommand(
             std::make_unique<std::decay_t<T>>(std::forward<T>(command))) {}

--- a/wpilibNewCommands/src/main/native/include/frc2/command/RepeatCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/RepeatCommand.h
@@ -46,7 +46,7 @@ class RepeatCommand : public CommandHelper<CommandBase, RepeatCommand> {
    * @param command the command to run repeatedly
    */
   template <std::derived_from<Command> T>
-  // NOLINTNEXTLINE (bugprone-forwarding-reference-overload)
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   explicit RepeatCommand(T&& command)
       : RepeatCommand(
             std::make_unique<std::decay_t<T>>(std::forward<T>(command))) {}

--- a/wpilibNewCommands/src/main/native/include/frc2/command/WrapperCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/WrapperCommand.h
@@ -41,7 +41,7 @@ class WrapperCommand : public CommandHelper<CommandBase, WrapperCommand> {
    * command or add it to a group will throw an exception.
    */
   template <std::derived_from<Command> T>
-  // NOLINTNEXTLINE (bugprone-forwarding-reference-overload)
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   explicit WrapperCommand(T&& command)
       : WrapperCommand(
             std::make_unique<std::decay_t<T>>(std::forward<T>(command))) {}

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandPtrTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/CommandPtrTest.cpp
@@ -27,7 +27,7 @@ TEST_F(CommandPtrTest, MovedFrom) {
   EXPECT_NO_FATAL_FAILURE(scheduler.Cancel(movedTo));
 
   EXPECT_THROW(scheduler.Schedule(movedFrom), frc::RuntimeError);
-  // NOLINTNEXTLINE (clang-analyzer-cplusplus.Move)
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move)
   EXPECT_THROW(movedFrom.IsScheduled(), frc::RuntimeError);
   EXPECT_THROW(static_cast<void>(std::move(movedFrom).Repeatedly()),
                frc::RuntimeError);

--- a/wpimath/src/test/native/cpp/DARETest.cpp
+++ b/wpimath/src/test/native/cpp/DARETest.cpp
@@ -71,7 +71,7 @@ void ExpectDARESolution(const Eigen::Ref<const Eigen::MatrixXd>& A,
   ExpectMatrixEqual(Y, Eigen::MatrixXd::Zero(X.rows(), X.cols()), 1e-10);
 }
 
-// NOLINTNEXTLINE (google-readability-avoid-underscore-in-googletest-name)
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(DARETest, NonInvertibleA_ABQR) {
   // Example 2 of "On the Numerical Solution of the Discrete-Time Algebraic
   // Riccati Equation"
@@ -91,7 +91,7 @@ TEST(DARETest, NonInvertibleA_ABQR) {
   ExpectDARESolution(A, B, Q, R, X);
 }
 
-// NOLINTNEXTLINE (google-readability-avoid-underscore-in-googletest-name)
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(DARETest, NonInvertibleA_ABQRN) {
   // Example 2 of "On the Numerical Solution of the Discrete-Time Algebraic
   // Riccati Equation"
@@ -117,7 +117,7 @@ TEST(DARETest, NonInvertibleA_ABQRN) {
   ExpectDARESolution(A, B, Q, R, N, X);
 }
 
-// NOLINTNEXTLINE (google-readability-avoid-underscore-in-googletest-name)
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(DARETest, InvertibleA_ABQR) {
   Eigen::MatrixXd A{2, 2};
   A << 1, 1, 0, 1;
@@ -134,7 +134,7 @@ TEST(DARETest, InvertibleA_ABQR) {
   ExpectDARESolution(A, B, Q, R, X);
 }
 
-// NOLINTNEXTLINE (google-readability-avoid-underscore-in-googletest-name)
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(DARETest, InvertibleA_ABQRN) {
   Eigen::MatrixXd A{2, 2};
   A << 1, 1, 0, 1;
@@ -157,7 +157,7 @@ TEST(DARETest, InvertibleA_ABQRN) {
   ExpectDARESolution(A, B, Q, R, N, X);
 }
 
-// NOLINTNEXTLINE (google-readability-avoid-underscore-in-googletest-name)
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(DARETest, FirstGeneralizedEigenvalueOfSTIsStable_ABQR) {
   // The first generalized eigenvalue of (S, T) is stable
 
@@ -176,7 +176,7 @@ TEST(DARETest, FirstGeneralizedEigenvalueOfSTIsStable_ABQR) {
   ExpectDARESolution(A, B, Q, R, X);
 }
 
-// NOLINTNEXTLINE (google-readability-avoid-underscore-in-googletest-name)
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(DARETest, FirstGeneralizedEigenvalueOfSTIsStable_ABQRN) {
   // The first generalized eigenvalue of (S, T) is stable
 
@@ -201,7 +201,7 @@ TEST(DARETest, FirstGeneralizedEigenvalueOfSTIsStable_ABQRN) {
   ExpectDARESolution(A, B, Q, R, N, X);
 }
 
-// NOLINTNEXTLINE (google-readability-avoid-underscore-in-googletest-name)
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(DARETest, IdentitySystem_ABQR) {
   const Eigen::MatrixXd A{Eigen::Matrix2d::Identity()};
   const Eigen::MatrixXd B{Eigen::Matrix2d::Identity()};
@@ -214,7 +214,7 @@ TEST(DARETest, IdentitySystem_ABQR) {
   ExpectDARESolution(A, B, Q, R, X);
 }
 
-// NOLINTNEXTLINE (google-readability-avoid-underscore-in-googletest-name)
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(DARETest, IdentitySystem_ABQRN) {
   const Eigen::MatrixXd A{Eigen::Matrix2d::Identity()};
   const Eigen::MatrixXd B{Eigen::Matrix2d::Identity()};

--- a/wpiutil/src/test/native/cpp/ScopeExitTest.cpp
+++ b/wpiutil/src/test/native/cpp/ScopeExitTest.cpp
@@ -23,7 +23,7 @@ TEST(ScopeExitTest, Release) {
   {
     wpi::scope_exit exit1{[&] { ++exitCount; }};
     wpi::scope_exit exit2 = std::move(exit1);
-    // NOLINTNEXTLINE (clang-analyzer-cplusplus.Move)
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move)
     wpi::scope_exit exit3 = std::move(exit1);
     EXPECT_EQ(0, exitCount);
   }


### PR DESCRIPTION
clang-tidy ignores the category filter if there's a space. wpiformat now ignores categories it doesn't understand, so we can remove the spaces.