### PR TITLE
Fix compatibility with fmtlib 10

### DIFF
--- a/wpiutil/src/main/native/include/wpi/Synchronization.h
+++ b/wpiutil/src/main/native/include/wpi/Synchronization.h
@@ -442,6 +442,9 @@ class SignalObject final {
   T m_handle;
 };
 
+template<typename T>
+auto format_as(const SignalObject<T> &s) { return s.GetHandle(); }
+
 }  // namespace wpi
 
 extern "C" {


### PR DESCRIPTION
From https://github.com/fmtlib/fmt/releases/tag/10.0.0:
> Removed deprecated implicit conversions for enums and conversions to primitive types for compatibility with std::format and to prevent potential ODR violations. Use format_as instead.