### PR TITLE
[ntcore] Fix undefined behavior when array is empty

### DIFF
--- a/ntcore/src/main/native/cpp/Value.cpp
+++ b/ntcore/src/main/native/cpp/Value.cpp
@@ -317,8 +317,7 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_boolean.size != rhs.m_val.data.arr_boolean.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_boolean.arr == nullptr &&
-          rhs.m_val.data.arr_boolean.arr == nullptr) {
+      if (lhs.m_val.data.arr_boolean.arr == nullptr || rhs.m_val.data.arr_boolean.arr == nullptr){
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_boolean.arr,
@@ -329,8 +328,7 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_int.size != rhs.m_val.data.arr_int.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_int.arr == nullptr &&
-          rhs.m_val.data.arr_int.arr == nullptr) {
+      if (lhs.m_val.data.arr_int.arr == nullptr || rhs.m_val.data.arr_int.arr == nullptr){
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_int.arr, rhs.m_val.data.arr_int.arr,
@@ -340,8 +338,7 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_float.size != rhs.m_val.data.arr_float.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_float.arr == nullptr &&
-          rhs.m_val.data.arr_float.arr == nullptr) {
+      if (lhs.m_val.data.arr_float.arr == nullptr || rhs.m_val.data.arr_float.arr == nullptr){
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_float.arr,
@@ -352,8 +349,7 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_double.size != rhs.m_val.data.arr_double.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_double.arr == nullptr &&
-          rhs.m_val.data.arr_double.arr == nullptr) {
+      if (lhs.m_val.data.arr_double.arr == nullptr || rhs.m_val.data.arr_double.arr == nullptr){
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_double.arr,
@@ -361,8 +357,7 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
                          lhs.m_val.data.arr_double.size *
                              sizeof(lhs.m_val.data.arr_double.arr[0])) == 0;
     case NT_STRING_ARRAY:
-      if (lhs.m_val.data.arr_string.arr == nullptr &&
-          rhs.m_val.data.arr_string.arr == nullptr) {
+      if (lhs.m_val.data.arr_string.arr == nullptr || rhs.m_val.data.arr_string.arr == nullptr){
         return true;
       }
       return static_cast<StringArrayStorage*>(lhs.m_storage.get())->strings ==

--- a/ntcore/src/main/native/cpp/Value.cpp
+++ b/ntcore/src/main/native/cpp/Value.cpp
@@ -317,8 +317,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_boolean.size != rhs.m_val.data.arr_boolean.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_boolean.arr == nullptr ||
-          rhs.m_val.data.arr_boolean.arr == nullptr) {
+      if (lhs.m_val.data.arr_boolean.size == 0 ||
+          rhs.m_val.data.arr_boolean.size == 0) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_boolean.arr,
@@ -329,8 +329,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_int.size != rhs.m_val.data.arr_int.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_int.arr == nullptr ||
-          rhs.m_val.data.arr_int.arr == nullptr) {
+      if (lhs.m_val.data.arr_int.size == 0 ||
+          rhs.m_val.data.arr_int.size == 0) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_int.arr, rhs.m_val.data.arr_int.arr,
@@ -340,8 +340,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_float.size != rhs.m_val.data.arr_float.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_float.arr == nullptr ||
-          rhs.m_val.data.arr_float.arr == nullptr) {
+      if (lhs.m_val.data.arr_float.size == 0 ||
+          rhs.m_val.data.arr_float.size == 0) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_float.arr,
@@ -352,8 +352,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_double.size != rhs.m_val.data.arr_double.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_double.arr == nullptr ||
-          rhs.m_val.data.arr_double.arr == nullptr) {
+      if (lhs.m_val.data.arr_double.size == 0 ||
+          rhs.m_val.data.arr_double.size == 0) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_double.arr,
@@ -361,8 +361,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
                          lhs.m_val.data.arr_double.size *
                              sizeof(lhs.m_val.data.arr_double.arr[0])) == 0;
     case NT_STRING_ARRAY:
-      if (lhs.m_val.data.arr_string.arr == nullptr ||
-          rhs.m_val.data.arr_string.arr == nullptr) {
+      if (lhs.m_val.data.arr_string.size == 0 ||
+          rhs.m_val.data.arr_string.size == 0) {
         return true;
       }
       return static_cast<StringArrayStorage*>(lhs.m_storage.get())->strings ==

--- a/ntcore/src/main/native/cpp/Value.cpp
+++ b/ntcore/src/main/native/cpp/Value.cpp
@@ -317,7 +317,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_boolean.size != rhs.m_val.data.arr_boolean.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_boolean.arr == nullptr && rhs.m_val.data.arr_boolean.arr == nullptr){
+      if (lhs.m_val.data.arr_boolean.arr == nullptr &&
+          rhs.m_val.data.arr_boolean.arr == nullptr) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_boolean.arr,
@@ -328,7 +329,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_int.size != rhs.m_val.data.arr_int.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_int.arr == nullptr && rhs.m_val.data.arr_int.arr == nullptr){
+      if (lhs.m_val.data.arr_int.arr == nullptr &&
+          rhs.m_val.data.arr_int.arr == nullptr) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_int.arr, rhs.m_val.data.arr_int.arr,
@@ -338,7 +340,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_float.size != rhs.m_val.data.arr_float.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_float.arr == nullptr && rhs.m_val.data.arr_float.arr == nullptr){
+      if (lhs.m_val.data.arr_float.arr == nullptr &&
+          rhs.m_val.data.arr_float.arr == nullptr) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_float.arr,
@@ -349,7 +352,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_double.size != rhs.m_val.data.arr_double.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_double.arr == nullptr && rhs.m_val.data.arr_double.arr == nullptr){
+      if (lhs.m_val.data.arr_double.arr == nullptr &&
+          rhs.m_val.data.arr_double.arr == nullptr) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_double.arr,
@@ -357,7 +361,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
                          lhs.m_val.data.arr_double.size *
                              sizeof(lhs.m_val.data.arr_double.arr[0])) == 0;
     case NT_STRING_ARRAY:
-      if (lhs.m_val.data.arr_string.arr == nullptr && rhs.m_val.data.arr_string.arr == nullptr){
+      if (lhs.m_val.data.arr_string.arr == nullptr &&
+          rhs.m_val.data.arr_string.arr == nullptr) {
         return true;
       }
       return static_cast<StringArrayStorage*>(lhs.m_storage.get())->strings ==

--- a/ntcore/src/main/native/cpp/Value.cpp
+++ b/ntcore/src/main/native/cpp/Value.cpp
@@ -317,6 +317,9 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_boolean.size != rhs.m_val.data.arr_boolean.size) {
         return false;
       }
+      if (lhs.m_val.data.arr_boolean.arr == nullptr && rhs.m_val.data.arr_boolean.arr == nullptr){
+        return true;
+      }
       return std::memcmp(lhs.m_val.data.arr_boolean.arr,
                          rhs.m_val.data.arr_boolean.arr,
                          lhs.m_val.data.arr_boolean.size *
@@ -335,6 +338,9 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_float.size != rhs.m_val.data.arr_float.size) {
         return false;
       }
+      if (lhs.m_val.data.arr_float.arr == nullptr && rhs.m_val.data.arr_float.arr == nullptr){
+        return true;
+      }
       return std::memcmp(lhs.m_val.data.arr_float.arr,
                          rhs.m_val.data.arr_float.arr,
                          lhs.m_val.data.arr_float.size *
@@ -343,11 +349,17 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_double.size != rhs.m_val.data.arr_double.size) {
         return false;
       }
+      if (lhs.m_val.data.arr_double.arr == nullptr && rhs.m_val.data.arr_double.arr == nullptr){
+        return true;
+      }
       return std::memcmp(lhs.m_val.data.arr_double.arr,
                          rhs.m_val.data.arr_double.arr,
                          lhs.m_val.data.arr_double.size *
                              sizeof(lhs.m_val.data.arr_double.arr[0])) == 0;
     case NT_STRING_ARRAY:
+      if (lhs.m_val.data.arr_string.arr == nullptr && rhs.m_val.data.arr_string.arr == nullptr){
+        return true;
+      }
       return static_cast<StringArrayStorage*>(lhs.m_storage.get())->strings ==
              static_cast<StringArrayStorage*>(rhs.m_storage.get())->strings;
     default:

--- a/ntcore/src/main/native/cpp/Value.cpp
+++ b/ntcore/src/main/native/cpp/Value.cpp
@@ -317,8 +317,7 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_boolean.size != rhs.m_val.data.arr_boolean.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_boolean.size == 0 ||
-          rhs.m_val.data.arr_boolean.size == 0) {
+      if (lhs.m_val.data.arr_boolean.size == 0) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_boolean.arr,
@@ -329,8 +328,7 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_int.size != rhs.m_val.data.arr_int.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_int.size == 0 ||
-          rhs.m_val.data.arr_int.size == 0) {
+      if (lhs.m_val.data.arr_int.size == 0) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_int.arr, rhs.m_val.data.arr_int.arr,
@@ -340,8 +338,7 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_float.size != rhs.m_val.data.arr_float.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_float.size == 0 ||
-          rhs.m_val.data.arr_float.size == 0) {
+      if (lhs.m_val.data.arr_float.size == 0) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_float.arr,
@@ -352,8 +349,7 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_double.size != rhs.m_val.data.arr_double.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_double.size == 0 ||
-          rhs.m_val.data.arr_double.size == 0) {
+      if (lhs.m_val.data.arr_double.size == 0) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_double.arr,
@@ -361,8 +357,7 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
                          lhs.m_val.data.arr_double.size *
                              sizeof(lhs.m_val.data.arr_double.arr[0])) == 0;
     case NT_STRING_ARRAY:
-      if (lhs.m_val.data.arr_string.size == 0 ||
-          rhs.m_val.data.arr_string.size == 0) {
+      if (lhs.m_val.data.arr_string.size == 0) {
         return true;
       }
       return static_cast<StringArrayStorage*>(lhs.m_storage.get())->strings ==

--- a/ntcore/src/main/native/cpp/Value.cpp
+++ b/ntcore/src/main/native/cpp/Value.cpp
@@ -317,7 +317,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_boolean.size != rhs.m_val.data.arr_boolean.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_boolean.arr == nullptr || rhs.m_val.data.arr_boolean.arr == nullptr){
+      if (lhs.m_val.data.arr_boolean.arr == nullptr ||
+          rhs.m_val.data.arr_boolean.arr == nullptr) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_boolean.arr,
@@ -328,7 +329,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_int.size != rhs.m_val.data.arr_int.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_int.arr == nullptr || rhs.m_val.data.arr_int.arr == nullptr){
+      if (lhs.m_val.data.arr_int.arr == nullptr ||
+          rhs.m_val.data.arr_int.arr == nullptr) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_int.arr, rhs.m_val.data.arr_int.arr,
@@ -338,7 +340,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_float.size != rhs.m_val.data.arr_float.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_float.arr == nullptr || rhs.m_val.data.arr_float.arr == nullptr){
+      if (lhs.m_val.data.arr_float.arr == nullptr ||
+          rhs.m_val.data.arr_float.arr == nullptr) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_float.arr,
@@ -349,7 +352,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_double.size != rhs.m_val.data.arr_double.size) {
         return false;
       }
-      if (lhs.m_val.data.arr_double.arr == nullptr || rhs.m_val.data.arr_double.arr == nullptr){
+      if (lhs.m_val.data.arr_double.arr == nullptr ||
+          rhs.m_val.data.arr_double.arr == nullptr) {
         return true;
       }
       return std::memcmp(lhs.m_val.data.arr_double.arr,
@@ -357,7 +361,8 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
                          lhs.m_val.data.arr_double.size *
                              sizeof(lhs.m_val.data.arr_double.arr[0])) == 0;
     case NT_STRING_ARRAY:
-      if (lhs.m_val.data.arr_string.arr == nullptr || rhs.m_val.data.arr_string.arr == nullptr){
+      if (lhs.m_val.data.arr_string.arr == nullptr ||
+          rhs.m_val.data.arr_string.arr == nullptr) {
         return true;
       }
       return static_cast<StringArrayStorage*>(lhs.m_storage.get())->strings ==

--- a/ntcore/src/main/native/cpp/Value.cpp
+++ b/ntcore/src/main/native/cpp/Value.cpp
@@ -325,6 +325,9 @@ bool nt::operator==(const Value& lhs, const Value& rhs) {
       if (lhs.m_val.data.arr_int.size != rhs.m_val.data.arr_int.size) {
         return false;
       }
+      if (lhs.m_val.data.arr_int.arr == nullptr && rhs.m_val.data.arr_int.arr == nullptr){
+        return true;
+      }
       return std::memcmp(lhs.m_val.data.arr_int.arr, rhs.m_val.data.arr_int.arr,
                          lhs.m_val.data.arr_int.size *
                              sizeof(lhs.m_val.data.arr_int.arr[0])) == 0;

--- a/ntcore/src/test/native/cpp/ValueTest.cpp
+++ b/ntcore/src/test/native/cpp/ValueTest.cpp
@@ -336,6 +336,58 @@ TEST_F(ValueTest, BooleanArrayComparison) {
   vec = {1, 0};
   v2 = Value::MakeBooleanArray(vec);
   ASSERT_NE(v1, v2);
+
+  // empty
+  vec = {};
+  v1 = Value::MakeBooleanArray(vec);
+  v2 = Value::MakeBooleanArray(vec);
+  ASSERT_EQ(v1, v2);
+}
+
+TEST_F(ValueTest, IntegerArrayComparison) {
+  std::vector<int64_t> vec{-42, 0, 1};
+  auto v1 = Value::MakeIntegerArray(vec);
+  auto v2 = Value::MakeIntegerArray(vec);
+  ASSERT_EQ(v1, v2);
+
+  // different contents
+  vec = {-42, 1, 1};
+  v2 = Value::MakeIntegerArray(vec);
+  ASSERT_NE(v1, v2);
+
+  // different size
+  vec = {-42, 0};
+  v2 = Value::MakeIntegerArray(vec);
+  ASSERT_NE(v1, v2);
+
+  // empty
+  vec = {};
+  v1 = Value::MakeIntegerArray(vec);
+  v2 = Value::MakeIntegerArray(vec);
+  ASSERT_EQ(v1, v2);
+}
+
+TEST_F(ValueTest, FloatArrayComparison) {
+  std::vector<float> vec{0.5, 0.25, 0.5};
+  auto v1 = Value::MakeFloatArray(vec);
+  auto v2 = Value::MakeFloatArray(vec);
+  ASSERT_EQ(v1, v2);
+
+  // different contents
+  vec = {0.5, 0.5, 0.5};
+  v2 = Value::MakeFloatArray(vec);
+  ASSERT_NE(v1, v2);
+
+  // different size
+  vec = {0.5, 0.25};
+  v2 = Value::MakeFloatArray(vec);
+  ASSERT_NE(v1, v2);
+
+  // empty
+  vec = {};
+  v1 = Value::MakeDoubleArray(vec);
+  v2 = Value::MakeDoubleArray(vec);
+  ASSERT_EQ(v1, v2);
 }
 
 TEST_F(ValueTest, DoubleArrayComparison) {
@@ -353,6 +405,12 @@ TEST_F(ValueTest, DoubleArrayComparison) {
   vec = {0.5, 0.25};
   v2 = Value::MakeDoubleArray(vec);
   ASSERT_NE(v1, v2);
+
+  // empty
+  vec = {};
+  v1 = Value::MakeDoubleArray(vec);
+  v2 = Value::MakeDoubleArray(vec);
+  ASSERT_EQ(v1, v2);
 }
 
 TEST_F(ValueTest, StringArrayComparison) {
@@ -390,6 +448,12 @@ TEST_F(ValueTest, StringArrayComparison) {
   vec.push_back("goodbye");
   v2 = Value::MakeStringArray(std::move(vec));
   ASSERT_NE(v1, v2);
+
+  // empty
+  vec.clear();
+  v1 = Value::MakeStringArray(vec);
+  v2 = Value::MakeStringArray(std::move(vec));
+  ASSERT_EQ(v1, v2);
 }
 
 }  // namespace nt

--- a/ntcore/src/test/native/cpp/ValueTest.cpp
+++ b/ntcore/src/test/native/cpp/ValueTest.cpp
@@ -385,8 +385,8 @@ TEST_F(ValueTest, FloatArrayComparison) {
 
   // empty
   vec = {};
-  v1 = Value::MakeDoubleArray(vec);
-  v2 = Value::MakeDoubleArray(vec);
+  v1 = Value::MakeFloatArray(vec);
+  v2 = Value::MakeFloatArray(vec);
   ASSERT_EQ(v1, v2);
 }
 


### PR DESCRIPTION
If both arrays are empty, it returns true, avoiding UB with `memcmp`.