### PR TITLE
Make dev configuration inherit dependencies from main configuration

### DIFF
--- a/apriltag/build.gradle
+++ b/apriltag/build.gradle
@@ -35,7 +35,6 @@ apply from: "${rootDir}/shared/opencv.gradle"
 
 dependencies {
     implementation project(':wpimath')
-    devImplementation project(':wpimath')
 }
 
 sourceSets {

--- a/cameraserver/build.gradle
+++ b/cameraserver/build.gradle
@@ -14,10 +14,6 @@ dependencies {
     implementation project(':wpinet')
     implementation project(':ntcore')
     implementation project(':cscore')
-    devImplementation project(':wpiutil')
-    devImplementation project(':wpinet')
-    devImplementation project(':ntcore')
-    devImplementation project(':cscore')
 }
 
 ext {

--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -96,6 +96,10 @@ sourceSets {
     dev
 }
 
+configurations {
+    devImplementation.extendsFrom(implementation)
+}
+
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs = [
         '--release',

--- a/wpilibNewCommands/build.gradle
+++ b/wpilibNewCommands/build.gradle
@@ -1,6 +1,6 @@
 ext {
     nativeName = 'wpilibNewCommands'
-    devMain = 'edu.wpi.first.wpilibj.commands.DevMain'
+    devMain = 'edu.wpi.first.wpilibj2.commands.DevMain'
 }
 
 evaluationDependsOn(':ntcore')
@@ -21,13 +21,6 @@ dependencies {
     implementation project(':hal')
     implementation project(':wpimath')
     implementation project(':wpilibj')
-    devImplementation project(':wpiutil')
-    devImplementation project(':wpinet')
-    devImplementation project(':ntcore')
-    devImplementation project(':cscore')
-    devImplementation project(':hal')
-    devImplementation project(':wpimath')
-    devImplementation project(':wpilibj')
     testImplementation 'org.mockito:mockito-core:4.1.0'
 }
 

--- a/wpilibj/build.gradle
+++ b/wpilibj/build.gradle
@@ -70,13 +70,6 @@ dependencies {
     implementation project(':cscore')
     implementation project(':cameraserver')
     testImplementation 'org.mockito:mockito-core:4.1.0'
-    devImplementation project(':hal')
-    devImplementation project(':wpiutil')
-    devImplementation project(':wpinet')
-    devImplementation project(':wpimath')
-    devImplementation project(':ntcore')
-    devImplementation project(':cscore')
-    devImplementation project(':cameraserver')
     devImplementation sourceSets.main.output
 }
 


### PR DESCRIPTION
This makes dependencies added to `implementation` also appear in `devImplementation`, making `project:run` work without needing to manually add the dependencies to `devImplementation` as well as `implementation`.
This also fixes the classpath in `wpilibNewCommands`.