### PR TITLE
Convert the unitless joystick inputs to actual physical units

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
@@ -40,7 +40,8 @@ RobotContainer::RobotContainer() {
             // max speed forwards], converting them to actual units.
             m_driverController.GetLeftY() * AutoConstants::kMaxSpeed,
             m_driverController.GetLeftX() * AutoConstants::kMaxSpeed,
-            m_driverController.GetRightX() * AutoConstants::kMaxAngularSpeed, false);
+            m_driverController.GetRightX() * AutoConstants::kMaxAngularSpeed,
+            false);
       },
       {&m_drive}));
 }

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
@@ -34,10 +34,9 @@ RobotContainer::RobotContainer() {
   // Turning is controlled by the X axis of the right stick.
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.Drive(
-            units::meters_per_second_t{m_driverController.GetLeftY()},
-            units::meters_per_second_t{m_driverController.GetLeftX()},
-            units::radians_per_second_t{m_driverController.GetRightX()}, false);
+        m_drive.Drive(m_driverController.GetLeftY() * kMaxSpeed,
+            m_driverController.GetLeftX() * kMaxSpeed,
+            m_driverController.GetRightX() * kMaxAngularSpeed, false);
       },
       {&m_drive}));
 }

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
@@ -35,9 +35,9 @@ RobotContainer::RobotContainer() {
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
         m_drive.Drive(
-            // Multiply by max speed to map the joystick unitless inputs to actual units.
-            // This will map the [-1, 1] to [max speed backwards, max speed forwards],
-            // converting them to actual units.
+            // Multiply by max speed to map the joystick unitless inputs to
+            // actual units. This will map the [-1, 1] to [max speed backwards,
+            // max speed forwards], converting them to actual units.
             m_driverController.GetLeftY() * kMaxSpeed,
             m_driverController.GetLeftX() * kMaxSpeed,
             m_driverController.GetRightX() * kMaxAngularSpeed, false);

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
@@ -38,9 +38,9 @@ RobotContainer::RobotContainer() {
             // Multiply by max speed to map the joystick unitless inputs to
             // actual units. This will map the [-1, 1] to [max speed backwards,
             // max speed forwards], converting them to actual units.
-            m_driverController.GetLeftY() * kMaxSpeed,
-            m_driverController.GetLeftX() * kMaxSpeed,
-            m_driverController.GetRightX() * kMaxAngularSpeed, false);
+            m_driverController.GetLeftY() * AutoConstants::kMaxSpeed,
+            m_driverController.GetLeftX() * AutoConstants::kMaxSpeed,
+            m_driverController.GetRightX() * AutoConstants::kMaxAngularSpeed, false);
       },
       {&m_drive}));
 }

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
@@ -34,9 +34,13 @@ RobotContainer::RobotContainer() {
   // Turning is controlled by the X axis of the right stick.
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
-        m_drive.Drive(m_driverController.GetLeftY() * kMaxSpeed,
-                      m_driverController.GetLeftX() * kMaxSpeed,
-                      m_driverController.GetRightX() * kMaxAngularSpeed, false);
+        m_drive.Drive(
+            // Multiply by max speed to map the joystick unitless inputs to actual units.
+            // This will map the [-1, 1] to [max speed backwards, max speed forwards],
+            // converting them to actual units.
+            m_driverController.GetLeftY() * kMaxSpeed,
+            m_driverController.GetLeftX() * kMaxSpeed,
+            m_driverController.GetRightX() * kMaxAngularSpeed, false);
       },
       {&m_drive}));
 }

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
@@ -35,8 +35,8 @@ RobotContainer::RobotContainer() {
   m_drive.SetDefaultCommand(frc2::RunCommand(
       [this] {
         m_drive.Drive(m_driverController.GetLeftY() * kMaxSpeed,
-            m_driverController.GetLeftX() * kMaxSpeed,
-            m_driverController.GetRightX() * kMaxAngularSpeed, false);
+                      m_driverController.GetLeftX() * kMaxSpeed,
+                      m_driverController.GetRightX() * kMaxAngularSpeed, false);
       },
       {&m_drive}));
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/RobotContainer.java
@@ -15,6 +15,7 @@ import edu.wpi.first.math.trajectory.TrajectoryGenerator;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.examples.swervecontrollercommand.Constants.AutoConstants;
 import edu.wpi.first.wpilibj.examples.swervecontrollercommand.Constants.DriveConstants;
+import edu.wpi.first.wpilibj.examples.swervecontrollercommand.Constants.ModuleConstants;
 import edu.wpi.first.wpilibj.examples.swervecontrollercommand.Constants.OIConstants;
 import edu.wpi.first.wpilibj.examples.swervecontrollercommand.subsystems.DriveSubsystem;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -48,9 +49,11 @@ public class RobotContainer {
         new RunCommand(
             () ->
                 m_robotDrive.drive(
-                    m_driverController.getLeftY(),
-                    m_driverController.getLeftX(),
-                    m_driverController.getRightX(),
+                    // Multiply by max speed to map the joystick unitless inputs to actual units.
+                    // This will map the [-1, 1] to [max speed backwards, max speed forwards], converting them to actual units.
+                    m_driverController.getLeftY() * DriveConstants.kMaxSpeedMetersPerSecond,
+                    m_driverController.getLeftX() * DriveConstants.kMaxSpeedMetersPerSecond,
+                    m_driverController.getRightX() * ModuleConstants.kMaxModuleAngularSpeedRadiansPerSecond,
                     false),
             m_robotDrive));
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervecontrollercommand/RobotContainer.java
@@ -50,10 +50,12 @@ public class RobotContainer {
             () ->
                 m_robotDrive.drive(
                     // Multiply by max speed to map the joystick unitless inputs to actual units.
-                    // This will map the [-1, 1] to [max speed backwards, max speed forwards], converting them to actual units.
+                    // This will map the [-1, 1] to [max speed backwards, max speed forwards],
+                    // converting them to actual units.
                     m_driverController.getLeftY() * DriveConstants.kMaxSpeedMetersPerSecond,
                     m_driverController.getLeftX() * DriveConstants.kMaxSpeedMetersPerSecond,
-                    m_driverController.getRightX() * ModuleConstants.kMaxModuleAngularSpeedRadiansPerSecond,
+                    m_driverController.getRightX()
+                        * ModuleConstants.kMaxModuleAngularSpeedRadiansPerSecond,
                     false),
             m_robotDrive));
   }


### PR DESCRIPTION
Taking the joystick inputs from -1 to 1, multiply them by the max speed (as defined in `Constants.java`) to get the target speed, rather than using the unitless raw joystick inputs.

This resolves issue https://github.com/wpilibsuite/allwpilib/issues/5417.