### PR TITLE
Remove BooleanEvent references in EventLoop documentation

### DIFF
--- a/wpilibc/src/main/native/include/frc/event/EventLoop.h
+++ b/wpilibc/src/main/native/include/frc/event/EventLoop.h
@@ -10,8 +10,8 @@
 #include <wpi/FunctionExtras.h>
 
 namespace frc {
-/** The loop polling BooleanEvent objects and executing the actions bound to
- * them. */
+/** A declarative way to bind a set of actions to a loop and execute them when
+ * the loop is polled. */
 class EventLoop {
  public:
   EventLoop();
@@ -20,7 +20,7 @@ class EventLoop {
   EventLoop& operator=(const EventLoop&) = delete;
 
   /**
-   * Bind a new action to run.
+   * Bind a new action to run when the loop is polled.
    *
    * @param action the action to run.
    */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/event/EventLoop.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/event/EventLoop.java
@@ -7,12 +7,14 @@ package edu.wpi.first.wpilibj.event;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 
-/** The loop polling {@link BooleanEvent} objects and executing the actions bound to them. */
+/**
+ * A declarative way to bind a set of actions to a loop and execute them when the loop is polled.
+ */
 public final class EventLoop {
   private final Collection<Runnable> m_bindings = new LinkedHashSet<>();
 
   /**
-   * Bind a new action to run whenever the condition is true.
+   * Bind a new action to run when the loop is polled.
    *
    * @param action the action to run.
    */


### PR DESCRIPTION
Fixes #4868.
I feel like the documentation is inadequate, but `EventLoop` by itself doesn't do much; there's basically nothing that can be documented.