### PR TITLE
[hal] Fix Java REVPH faults bitfield (take 2)

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/REVPHFaults.java
+++ b/hal/src/main/java/edu/wpi/first/hal/REVPHFaults.java
@@ -56,27 +56,27 @@ public class REVPHFaults {
    * @param faults the fault bitfields
    */
   public REVPHFaults(int faults) {
-    Channel0Fault = (faults & 0x1) != 0;
-    Channel1Fault = (faults & 0x2) != 0;
-    Channel2Fault = (faults & 0x4) != 0;
-    Channel3Fault = (faults & 0x8) != 0;
-    Channel4Fault = (faults & 0x10) != 0;
-    Channel5Fault = (faults & 0x20) != 0;
-    Channel6Fault = (faults & 0x40) != 0;
-    Channel7Fault = (faults & 0x80) != 0;
-    Channel8Fault = (faults & 0x100) != 0;
-    Channel9Fault = (faults & 0x200) != 0;
-    Channel10Fault = (faults & 0x400) != 0;
-    Channel11Fault = (faults & 0x800) != 0;
-    Channel12Fault = (faults & 0x1000) != 0;
-    Channel13Fault = (faults & 0x2000) != 0;
-    Channel14Fault = (faults & 0x4000) != 0;
-    Channel15Fault = (faults & 0x8000) != 0;
-    CompressorOverCurrent = (faults & 0x10000) != 0;
-    CompressorOpen = (faults & 0x20000) != 0;
-    SolenoidOverCurrent = (faults & 0x40000) != 0;
-    Brownout = (faults & 0x80000) != 0;
-    CanWarning = (faults & 0x1000000) != 0;
-    HardwareFault = (faults & 0x200000) != 0;
+    Channel0Fault = (faults & (1 << 0)) != 0;
+    Channel1Fault = (faults & (1 << 1)) != 0;
+    Channel2Fault = (faults & (1 << 2)) != 0;
+    Channel3Fault = (faults & (1 << 3)) != 0;
+    Channel4Fault = (faults & (1 << 4)) != 0;
+    Channel5Fault = (faults & (1 << 5)) != 0;
+    Channel6Fault = (faults & (1 << 6)) != 0;
+    Channel7Fault = (faults & (1 << 7)) != 0;
+    Channel8Fault = (faults & (1 << 8)) != 0;
+    Channel9Fault = (faults & (1 << 9)) != 0;
+    Channel10Fault = (faults & (1 << 10)) != 0;
+    Channel11Fault = (faults & (1 << 11)) != 0;
+    Channel12Fault = (faults & (1 << 12)) != 0;
+    Channel13Fault = (faults & (1 << 13)) != 0;
+    Channel14Fault = (faults & (1 << 14)) != 0;
+    Channel15Fault = (faults & (1 << 15)) != 0;
+    CompressorOverCurrent = (faults & (1 << 16)) != 0;
+    CompressorOpen = (faults & (1 << 17)) != 0;
+    SolenoidOverCurrent = (faults & (1 << 18)) != 0;
+    Brownout = (faults & (1 << 19)) != 0;
+    CanWarning = (faults & (1 << 20)) != 0;
+    HardwareFault = (faults & (1 << 21)) != 0;
   }
 }


### PR DESCRIPTION
The previous PR had a typo in one of the bitmasks. Change to using 1 << N.