### PR TITLE
Expose power rail disable and cpu temp functionality

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/PowerJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/PowerJNI.java
@@ -160,4 +160,11 @@ public class PowerJNI extends JNIWrapper {
    * @see "HAL_GetBrownoutVoltage"
    */
   public static native double getBrownoutVoltage();
+
+  /**
+   * Get the current CPU temperature in degrees Celsius.
+   *
+   * @return current CPU temperature in degrees Celsius
+   */
+  public static native double getCPUTemp();
 }

--- a/hal/src/main/java/edu/wpi/first/hal/PowerJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/PowerJNI.java
@@ -43,6 +43,13 @@ public class PowerJNI extends JNIWrapper {
   public static native double getUserCurrent6V();
 
   /**
+   * Enables or disables the 6V rail.
+   *
+   * @param enabled whether the rail should be enabled
+   */
+  public static native void setUserEnabled6V(boolean enabled);
+
+  /**
    * Gets the active state of the 6V rail.
    *
    * @return true if the rail is active, otherwise false
@@ -75,6 +82,13 @@ public class PowerJNI extends JNIWrapper {
   public static native double getUserCurrent5V();
 
   /**
+   * Enables or disables the 5V rail.
+   *
+   * @param enabled whether the rail should be enabled
+   */
+  public static native void setUserEnabled5V(boolean enabled);
+
+  /**
    * Gets the active state of the 5V rail.
    *
    * @return true if the rail is active, otherwise false
@@ -105,6 +119,13 @@ public class PowerJNI extends JNIWrapper {
    * @see "HAL_GetUserCurrent3V3"
    */
   public static native double getUserCurrent3V3();
+
+  /**
+   * Enables or disables the 3V3 rail.
+   *
+   * @param enabled whether the rail should be enabled
+   */
+  public static native void setUserEnabled3V3(boolean enabled);
 
   /**
    * Gets the active state of the 3V3 rail.

--- a/hal/src/main/native/athena/Power.cpp
+++ b/hal/src/main/native/athena/Power.cpp
@@ -61,6 +61,11 @@ int32_t HAL_GetUserCurrentFaults6V(int32_t* status) {
       power->readFaultCounts_OverCurrentFaultCount6V(status));
 }
 
+void HAL_SetUserRailEnabled6V(HAL_Bool enabled, int32_t* status) {
+  initializePower(status);
+  power->writeDisable_User6V(!enabled, status);
+}
+
 double HAL_GetUserVoltage5V(int32_t* status) {
   initializePower(status);
   return power->readUserVoltage5V(status) / 4.096 * 0.005962 - 0.013;
@@ -80,6 +85,11 @@ int32_t HAL_GetUserCurrentFaults5V(int32_t* status) {
   initializePower(status);
   return static_cast<int32_t>(
       power->readFaultCounts_OverCurrentFaultCount5V(status));
+}
+
+void HAL_SetUserRailEnabled5V(HAL_Bool enabled, int32_t* status) {
+  initializePower(status);
+  power->writeDisable_User5V(!enabled, status);
 }
 
 double HAL_GetUserVoltage3V3(int32_t* status) {
@@ -103,6 +113,11 @@ int32_t HAL_GetUserCurrentFaults3V3(int32_t* status) {
       power->readFaultCounts_OverCurrentFaultCount3V3(status));
 }
 
+void HAL_SetUserRailEnabled3V3(HAL_Bool enabled, int32_t* status) {
+  initializePower(status);
+  power->writeDisable_User3V3(!enabled, status);
+}
+
 void HAL_SetBrownoutVoltage(double voltage, int32_t* status) {
   initializePower(status);
   if (voltage < 0) {
@@ -119,6 +134,12 @@ double HAL_GetBrownoutVoltage(int32_t* status) {
   initializePower(status);
   auto brownout = power->readBrownoutVoltage250mV(status);
   return brownout / 4.0;
+}
+
+int16_t HAL_ReadCPUTemp(int32_t* status) {
+  initializePower(status);
+  //TODO figure out what this outputs
+  return power->readOnChipTemperature(status);
 }
 
 }  // extern "C"

--- a/hal/src/main/native/athena/Power.cpp
+++ b/hal/src/main/native/athena/Power.cpp
@@ -138,8 +138,8 @@ double HAL_GetBrownoutVoltage(int32_t* status) {
 
 int16_t HAL_GetCPUTemp(int32_t* status) {
   initializePower(status);
-  //TODO figure out what this outputs
-  //Outputs ~2600 at idle...no way to compare against true chip temperature
+  // TODO figure out what this outputs
+  // Outputs ~2600 at idle...no way to compare against true chip temperature
   return power->readOnChipTemperature(status);
 }
 

--- a/hal/src/main/native/athena/Power.cpp
+++ b/hal/src/main/native/athena/Power.cpp
@@ -136,9 +136,10 @@ double HAL_GetBrownoutVoltage(int32_t* status) {
   return brownout / 4.0;
 }
 
-int16_t HAL_ReadCPUTemp(int32_t* status) {
+int16_t HAL_GetCPUTemp(int32_t* status) {
   initializePower(status);
   //TODO figure out what this outputs
+  //Outputs ~2600 at idle...no way to compare against true chip temperature
   return power->readOnChipTemperature(status);
 }
 

--- a/hal/src/main/native/athena/Power.cpp
+++ b/hal/src/main/native/athena/Power.cpp
@@ -136,11 +136,9 @@ double HAL_GetBrownoutVoltage(int32_t* status) {
   return brownout / 4.0;
 }
 
-int16_t HAL_GetCPUTemp(int32_t* status) {
+double HAL_GetCPUTemp(int32_t* status) {
   initializePower(status);
-  // TODO figure out what this outputs
-  // Outputs ~2600 at idle...no way to compare against true chip temperature
-  return power->readOnChipTemperature(status);
+  return power->readOnChipTemperature(status) / 4096.0 * 503.975 - 273.15;
 }
 
 }  // extern "C"

--- a/hal/src/main/native/athena/mockdata/RoboRioData.cpp
+++ b/hal/src/main/native/athena/mockdata/RoboRioData.cpp
@@ -28,6 +28,7 @@ DEFINE_CAPI(int32_t, UserFaults6V, 0)
 DEFINE_CAPI(int32_t, UserFaults5V, 0)
 DEFINE_CAPI(int32_t, UserFaults3V3, 0)
 DEFINE_CAPI(double, BrownoutVoltage, 6.75)
+DEFINE_CAPI(int32_t, CPUTemp, 16)
 
 int32_t HALSIM_RegisterRoboRioSerialNumberCallback(
     HAL_RoboRioStringCallback callback, void* param, HAL_Bool initialNotify) {

--- a/hal/src/main/native/cpp/jni/PowerJNI.cpp
+++ b/hal/src/main/native/cpp/jni/PowerJNI.cpp
@@ -293,4 +293,19 @@ Java_edu_wpi_first_hal_PowerJNI_getBrownoutVoltage
   return val;
 }
 
+/*
+ * Class:     edu_wpi_first_hal_PowerJNI
+ * Method:    getCPUTemp
+ * Signature: ()D
+ */
+JNIEXPORT jdouble JNICALL
+Java_edu_wpi_first_hal_PowerJNI_getCPUTemp
+  (JNIEnv* env, jclass)
+{
+  int32_t status = 0;
+  double val = HAL_GetCPUTemp(&status);
+  CheckStatus(env, status);
+  return val;
+}
+
 }  // extern "C"

--- a/hal/src/main/native/cpp/jni/PowerJNI.cpp
+++ b/hal/src/main/native/cpp/jni/PowerJNI.cpp
@@ -74,6 +74,20 @@ Java_edu_wpi_first_hal_PowerJNI_getUserCurrent6V
 
 /*
  * Class:     edu_wpi_first_hal_PowerJNI
+ * Method:    setUserEnabled6V
+ * Signature: (Z)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_PowerJNI_setUserEnabled6V
+  (JNIEnv* env, jclass, jboolean enabled)
+{
+  int32_t status = 0;
+  HAL_SetUserRailEnabled6V(enabled, &status);
+  CheckStatus(env, status);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_PowerJNI
  * Method:    getUserActive6V
  * Signature: ()Z
  */
@@ -134,6 +148,20 @@ Java_edu_wpi_first_hal_PowerJNI_getUserCurrent5V
 
 /*
  * Class:     edu_wpi_first_hal_PowerJNI
+ * Method:    setUserEnabled5V
+ * Signature: (Z)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_PowerJNI_setUserEnabled5V
+  (JNIEnv* env, jclass, jboolean enabled)
+{
+  int32_t status = 0;
+  HAL_SetUserRailEnabled5V(enabled, &status);
+  CheckStatus(env, status);
+}
+
+/*
+ * Class:     edu_wpi_first_hal_PowerJNI
  * Method:    getUserActive5V
  * Signature: ()Z
  */
@@ -190,6 +218,20 @@ Java_edu_wpi_first_hal_PowerJNI_getUserCurrent3V3
   double val = HAL_GetUserCurrent3V3(&status);
   CheckStatus(env, status);
   return val;
+}
+
+/*
+ * Class:     edu_wpi_first_hal_PowerJNI
+ * Method:    setUserEnabled3V3
+ * Signature: (Z)V
+ */
+JNIEXPORT void JNICALL
+Java_edu_wpi_first_hal_PowerJNI_setUserEnabled3V3
+  (JNIEnv* env, jclass, jboolean enabled)
+{
+  int32_t status = 0;
+  HAL_SetUserRailEnabled3V3(enabled, &status);
+  CheckStatus(env, status);
 }
 
 /*

--- a/hal/src/main/native/include/hal/Power.h
+++ b/hal/src/main/native/include/hal/Power.h
@@ -67,6 +67,14 @@ HAL_Bool HAL_GetUserActive6V(int32_t* status);
 int32_t HAL_GetUserCurrentFaults6V(int32_t* status);
 
 /**
+ * Enables or disables the 6V rail.
+ *
+ * @param enabled whether the rail should be enabled
+ * @param[out] status the error code, or 0 for success
+ */
+void HAL_SetUserRailEnabled6V(HAL_Bool enabled, int32_t* status);
+
+/**
  * Gets the 5V rail voltage.
  *
  * @param[out] status the error code, or 0 for success
@@ -97,6 +105,14 @@ HAL_Bool HAL_GetUserActive5V(int32_t* status);
  * @return the number of 5V fault counts
  */
 int32_t HAL_GetUserCurrentFaults5V(int32_t* status);
+
+/**
+ * Enables or disables the 5V rail.
+ *
+ * @param enabled whether the rail should be enabled
+ * @param[out] status the error code, or 0 for success
+ */
+void HAL_SetUserRailEnabled5V(HAL_Bool enabled, int32_t* status);
 
 /**
  * Gets the 3V3 rail voltage.
@@ -131,6 +147,14 @@ HAL_Bool HAL_GetUserActive3V3(int32_t* status);
 int32_t HAL_GetUserCurrentFaults3V3(int32_t* status);
 
 /**
+ * Enables or disables the 3V3 rail.
+ *
+ * @param enabled whether the rail should be enabled
+ * @param[out] status the error code, or 0 for success
+ */
+void HAL_SetUserRailEnabled3V3(HAL_Bool enabled, int32_t* status);
+
+/**
  * Get the current brownout voltage setting.
  *
  * @param[out] status the error code, or 0 for success
@@ -148,6 +172,8 @@ double HAL_GetBrownoutVoltage(int32_t* status);
  * @param[out] status the error code, or 0 for success
  */
 void HAL_SetBrownoutVoltage(double voltage, int32_t* status);
+
+int16_t HAL_GetCPUTemp(int32_t* status);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/hal/src/main/native/include/hal/Power.h
+++ b/hal/src/main/native/include/hal/Power.h
@@ -173,7 +173,13 @@ double HAL_GetBrownoutVoltage(int32_t* status);
  */
 void HAL_SetBrownoutVoltage(double voltage, int32_t* status);
 
-int16_t HAL_GetCPUTemp(int32_t* status);
+/**
+ * Get the current CPU temperature in degrees Celsius
+ *
+ * @param[out] status the error code, or 0 for success
+ * @return current CPU temperature in degrees Celsius
+ */
+double HAL_GetCPUTemp(int32_t* status);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/hal/src/main/native/include/hal/simulation/RoboRioData.h
+++ b/hal/src/main/native/include/hal/simulation/RoboRioData.h
@@ -142,8 +142,8 @@ void HALSIM_RegisterRoboRioAllCallbacks(HAL_NotifyCallback callback,
                                         void* param, HAL_Bool initialNotify);
 
 int32_t HALSIM_RegisterRoboRioCPUTempCallback(HAL_NotifyCallback callback,
-                                                    void* param,
-                                                    HAL_Bool initialNotify);
+                                              void* param,
+                                              HAL_Bool initialNotify);
 void HALSIM_CancelRoboRioCPUTempCallback(int32_t uid);
 HAL_Bool HALSIM_GetRoboRioCPUTemp(void);
 void HALSIM_SetRoboRioUserCPUTemp(HAL_Bool userActive3V3);

--- a/hal/src/main/native/include/hal/simulation/RoboRioData.h
+++ b/hal/src/main/native/include/hal/simulation/RoboRioData.h
@@ -141,6 +141,13 @@ void HALSIM_SetRoboRioComments(const char* comments, size_t size);
 void HALSIM_RegisterRoboRioAllCallbacks(HAL_NotifyCallback callback,
                                         void* param, HAL_Bool initialNotify);
 
+int32_t HALSIM_RegisterRoboRioCPUTempCallback(HAL_NotifyCallback callback,
+                                                    void* param,
+                                                    HAL_Bool initialNotify);
+void HALSIM_CancelRoboRioCPUTempCallback(int32_t uid);
+HAL_Bool HALSIM_GetRoboRioCPUTemp(void);
+void HALSIM_SetRoboRioUserCPUTemp(HAL_Bool userActive3V3);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/hal/src/main/native/sim/Power.cpp
+++ b/hal/src/main/native/sim/Power.cpp
@@ -66,6 +66,6 @@ double HAL_GetBrownoutVoltage(int32_t* status) {
   return SimRoboRioData->brownoutVoltage;
 }
 int16_t HAL_GetCPUTemp(int32_t* status) {
-  return 0;
+  return SimRoboRioData->cpuTemp;
 }
 }  // extern "C"

--- a/hal/src/main/native/sim/Power.cpp
+++ b/hal/src/main/native/sim/Power.cpp
@@ -65,7 +65,7 @@ void HAL_SetBrownoutVoltage(double voltage, int32_t* status) {
 double HAL_GetBrownoutVoltage(int32_t* status) {
   return SimRoboRioData->brownoutVoltage;
 }
-int16_t HAL_GetCPUTemp(int32_t* status) {
+double HAL_GetCPUTemp(int32_t* status) {
   return SimRoboRioData->cpuTemp;
 }
 }  // extern "C"

--- a/hal/src/main/native/sim/Power.cpp
+++ b/hal/src/main/native/sim/Power.cpp
@@ -32,6 +32,7 @@ HAL_Bool HAL_GetUserActive6V(int32_t* status) {
 int32_t HAL_GetUserCurrentFaults6V(int32_t* status) {
   return SimRoboRioData->userFaults6V;
 }
+void HAL_SetUserRailEnabled6V(HAL_Bool enabled, int32_t* status) {}
 double HAL_GetUserVoltage5V(int32_t* status) {
   return SimRoboRioData->userVoltage5V;
 }
@@ -44,6 +45,7 @@ HAL_Bool HAL_GetUserActive5V(int32_t* status) {
 int32_t HAL_GetUserCurrentFaults5V(int32_t* status) {
   return SimRoboRioData->userFaults5V;
 }
+void HAL_SetUserRailEnabled5V(HAL_Bool enabled, int32_t* status) {}
 double HAL_GetUserVoltage3V3(int32_t* status) {
   return SimRoboRioData->userVoltage3V3;
 }
@@ -56,10 +58,14 @@ HAL_Bool HAL_GetUserActive3V3(int32_t* status) {
 int32_t HAL_GetUserCurrentFaults3V3(int32_t* status) {
   return SimRoboRioData->userFaults3V3;
 }
+void HAL_SetUserRailEnabled3V3(HAL_Bool enabled, int32_t* status) {}
 void HAL_SetBrownoutVoltage(double voltage, int32_t* status) {
   SimRoboRioData->brownoutVoltage = voltage;
 }
 double HAL_GetBrownoutVoltage(int32_t* status) {
   return SimRoboRioData->brownoutVoltage;
+}
+int16_t HAL_GetCPUTemp(int32_t* status) {
+  return 0;
 }
 }  // extern "C"

--- a/hal/src/main/native/sim/mockdata/RoboRioData.cpp
+++ b/hal/src/main/native/sim/mockdata/RoboRioData.cpp
@@ -32,7 +32,7 @@ void RoboRioData::ResetData() {
   userFaults5V.Reset(0);
   userFaults3V3.Reset(0);
   brownoutVoltage.Reset(6.75);
-  cpuTemp.Reset(16);
+  cpuTemp.Reset(100);
   m_serialNumber = "";
   m_comments = "";
 }

--- a/hal/src/main/native/sim/mockdata/RoboRioData.cpp
+++ b/hal/src/main/native/sim/mockdata/RoboRioData.cpp
@@ -32,6 +32,7 @@ void RoboRioData::ResetData() {
   userFaults5V.Reset(0);
   userFaults3V3.Reset(0);
   brownoutVoltage.Reset(6.75);
+  cpuTemp.Reset(16);
   m_serialNumber = "";
   m_comments = "";
 }
@@ -132,6 +133,7 @@ DEFINE_CAPI(int32_t, UserFaults6V, userFaults6V)
 DEFINE_CAPI(int32_t, UserFaults5V, userFaults5V)
 DEFINE_CAPI(int32_t, UserFaults3V3, userFaults3V3)
 DEFINE_CAPI(double, BrownoutVoltage, brownoutVoltage)
+DEFINE_CAPI(int32_t, CPUTemp, cpuTemp)
 
 int32_t HALSIM_RegisterRoboRioSerialNumberCallback(
     HAL_RoboRioStringCallback callback, void* param, HAL_Bool initialNotify) {
@@ -187,5 +189,6 @@ void HALSIM_RegisterRoboRioAllCallbacks(HAL_NotifyCallback callback,
   REGISTER(userFaults5V);
   REGISTER(userFaults3V3);
   REGISTER(brownoutVoltage);
+  REGISTER(cpuTemp);
 }
 }  // extern "C"

--- a/hal/src/main/native/sim/mockdata/RoboRioDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/RoboRioDataInternal.h
@@ -30,6 +30,7 @@ class RoboRioData {
   HAL_SIMDATAVALUE_DEFINE_NAME(UserFaults5V)
   HAL_SIMDATAVALUE_DEFINE_NAME(UserFaults3V3)
   HAL_SIMDATAVALUE_DEFINE_NAME(BrownoutVoltage)
+  HAL_SIMDATAVALUE_DEFINE_NAME(CPUTemp)
 
   HAL_SIMCALLBACKREGISTRY_DEFINE_NAME(SerialNumber)
   HAL_SIMCALLBACKREGISTRY_DEFINE_NAME(Comments);
@@ -57,6 +58,7 @@ class RoboRioData {
   SimDataValue<int32_t, HAL_MakeInt, GetUserFaults3V3Name> userFaults3V3{0};
   SimDataValue<double, HAL_MakeDouble, GetBrownoutVoltageName> brownoutVoltage{
       6.75};
+  SimDataValue<int32_t, HAL_MakeInt, GetCPUTempName> cpuTemp{16};
 
   int32_t RegisterSerialNumberCallback(HAL_RoboRioStringCallback callback,
                                        void* param, HAL_Bool initialNotify);

--- a/hal/src/main/native/sim/mockdata/RoboRioDataInternal.h
+++ b/hal/src/main/native/sim/mockdata/RoboRioDataInternal.h
@@ -58,7 +58,7 @@ class RoboRioData {
   SimDataValue<int32_t, HAL_MakeInt, GetUserFaults3V3Name> userFaults3V3{0};
   SimDataValue<double, HAL_MakeDouble, GetBrownoutVoltageName> brownoutVoltage{
       6.75};
-  SimDataValue<int32_t, HAL_MakeInt, GetCPUTempName> cpuTemp{16};
+  SimDataValue<double, HAL_MakeDouble, GetCPUTempName> cpuTemp{100};
 
   int32_t RegisterSerialNumberCallback(HAL_RoboRioStringCallback callback,
                                        void* param, HAL_Bool initialNotify);

--- a/wpilibc/src/main/native/cpp/RobotController.cpp
+++ b/wpilibc/src/main/native/cpp/RobotController.cpp
@@ -111,6 +111,12 @@ double RobotController::GetCurrent3V3() {
   return retVal;
 }
 
+void RobotController::SetEnabled3V3(bool enabled) {
+  int32_t status = 0;
+  HAL_SetUserRailEnabled3V3(enabled, &status);
+  FRC_CheckErrorStatus(status, "SetEnabled3V3");
+}
+
 bool RobotController::GetEnabled3V3() {
   int32_t status = 0;
   bool retVal = HAL_GetUserActive3V3(&status);
@@ -139,6 +145,12 @@ double RobotController::GetCurrent5V() {
   return retVal;
 }
 
+void RobotController::SetEnabled5V(bool enabled) {
+  int32_t status = 0;
+  HAL_SetUserRailEnabled5V(enabled, &status);
+  FRC_CheckErrorStatus(status, "SetEnabled5V");
+}
+
 bool RobotController::GetEnabled5V() {
   int32_t status = 0;
   bool retVal = HAL_GetUserActive5V(&status);
@@ -165,6 +177,12 @@ double RobotController::GetCurrent6V() {
   double retVal = HAL_GetUserCurrent6V(&status);
   FRC_CheckErrorStatus(status, "GetCurrent6V");
   return retVal;
+}
+
+void RobotController::SetEnabled6V(bool enabled) {
+  int32_t status = 0;
+  HAL_SetUserRailEnabled6V(enabled, &status);
+  FRC_CheckErrorStatus(status, "SetEnabled6V");
 }
 
 bool RobotController::GetEnabled6V() {

--- a/wpilibc/src/main/native/cpp/RobotController.cpp
+++ b/wpilibc/src/main/native/cpp/RobotController.cpp
@@ -212,6 +212,13 @@ void RobotController::SetBrownoutVoltage(units::volt_t brownoutVoltage) {
   FRC_CheckErrorStatus(status, "SetBrownoutVoltage");
 }
 
+units::celsius_t RobotController::GetCPUTemp() {
+  int32_t status = 0;
+  double retVal = HAL_GetCPUTemp(&status);
+  FRC_CheckErrorStatus(status, "GetCPUTemp");
+  return units::celsius_t{retVal};
+}
+
 CANStatus RobotController::GetCANStatus() {
   int32_t status = 0;
   float percentBusUtilization = 0;

--- a/wpilibc/src/main/native/include/frc/RobotController.h
+++ b/wpilibc/src/main/native/include/frc/RobotController.h
@@ -136,9 +136,16 @@ class RobotController {
   static double GetCurrent3V3();
 
   /**
-   * Get the enabled state of the 3.3V rail. The rail may be disabled due to a
-   * controller brownout, a short circuit on the rail, or controller
-   * over-voltage.
+   * Enables or disables the 3.3V rail.
+   *
+   * @param enabled whether to enable the 3.3V rail.
+   */
+  static void SetEnabled3V3(bool enabled);
+
+  /**
+   * Get the enabled state of the 3.3V rail. The rail may be disabled due to
+   * calling SetEnabled3V3(), a controller brownout, a short circuit on the
+   * rail, or controller over-voltage.
    *
    * @return The controller 3.3V rail enabled value. True for enabled.
    */
@@ -167,9 +174,16 @@ class RobotController {
   static double GetCurrent5V();
 
   /**
-   * Get the enabled state of the 5V rail. The rail may be disabled due to a
-   * controller brownout, a short circuit on the rail, or controller
-   * over-voltage.
+   * Enables or disables the 5V rail.
+   *
+   * @param enabled whether to enable the 5V rail.
+   */
+  static void SetEnabled5V(bool enabled);
+
+  /**
+   * Get the enabled state of the 5V rail. The rail may be disabled due to
+   * calling SetEnabled5V(), a controller brownout, a short circuit on the rail,
+   * or controller over-voltage.
    *
    * @return The controller 5V rail enabled value. True for enabled.
    */
@@ -198,9 +212,16 @@ class RobotController {
   static double GetCurrent6V();
 
   /**
-   * Get the enabled state of the 6V rail. The rail may be disabled due to a
-   * controller brownout, a short circuit on the rail, or controller
-   * over-voltage.
+   * Enables or disables the 6V rail.
+   *
+   * @param enabled whether to enable the 6V rail.
+   */
+  static void SetEnabled6V(bool enabled);
+
+  /**
+   * Get the enabled state of the 6V rail. The rail may be disabled due to
+   * calling SetEnabled6V(), a controller brownout, a short circuit on the rail,
+   * or controller over-voltage.
    *
    * @return The controller 6V rail enabled value. True for enabled.
    */

--- a/wpilibc/src/main/native/include/frc/RobotController.h
+++ b/wpilibc/src/main/native/include/frc/RobotController.h
@@ -8,6 +8,7 @@
 
 #include <string>
 
+#include <units/temperature.h>
 #include <units/voltage.h>
 
 namespace frc {
@@ -251,6 +252,13 @@ class RobotController {
    * @param brownoutVoltage The brownout voltage
    */
   static void SetBrownoutVoltage(units::volt_t brownoutVoltage);
+
+  /**
+   * Get the current CPU temperature.
+   *
+   * @return current CPU temperature
+   */
+  static units::celsius_t GetCPUTemp();
 
   /**
    * Get the current status of the CAN bus.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotController.java
@@ -149,6 +149,15 @@ public final class RobotController {
   }
 
   /**
+   * Enables or disables the 3.3V rail.
+   *
+   * @param enabled whether to enable the 3.3V rail.
+   */
+  public static void setEnabled3V3(boolean enabled) {
+    PowerJNI.setUserEnabled3V3(enabled);
+  }
+
+  /**
    * Get the enabled state of the 3.3V rail. The rail may be disabled due to a controller brownout,
    * a short circuit on the rail, or controller over-voltage.
    *
@@ -186,6 +195,15 @@ public final class RobotController {
   }
 
   /**
+   * Enables or disables the 5V rail.
+   *
+   * @param enabled whether to enable the 5V rail.
+   */
+  public static void setEnabled5V(boolean enabled) {
+    PowerJNI.setUserEnabled5V(enabled);
+  }
+
+  /**
    * Get the enabled state of the 5V rail. The rail may be disabled due to a controller brownout, a
    * short circuit on the rail, or controller over-voltage.
    *
@@ -220,6 +238,15 @@ public final class RobotController {
    */
   public static double getCurrent6V() {
     return PowerJNI.getUserCurrent6V();
+  }
+
+  /**
+   * Enables or disables the 6V rail.
+   *
+   * @param enabled whether to enable the 6V rail.
+   */
+  public static void setEnabled6V(boolean enabled) {
+    PowerJNI.setUserEnabled6V(enabled);
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/RobotController.java
@@ -289,6 +289,15 @@ public final class RobotController {
   }
 
   /**
+   * Get the current CPU temperature in degrees Celsius.
+   *
+   * @return current CPU temperature in degrees Celsius
+   */
+  public static double getCPUTemp() {
+    return PowerJNI.getCPUTemp();
+  }
+
+  /**
    * Get the current status of the CAN bus.
    *
    * @return The status of the CAN bus


### PR DESCRIPTION
WIP

- Need to figure out what format `tPower.readOnChipTemperature()` returns data in... quick testing reads ~2600
  - https://docs.xilinx.com/r/en-US/ug480_7Series_XADC/Analog-Inputs
- not sure whether power rail disable functions should be simulated on our side- disabling affects the return values of GetUserVoltage* and GetUserActive*

