### PR TITLE
[ntcore] Limit buffer pool size to 64KB per connection

### DIFF
--- a/ntcore/src/main/native/cpp/net3/UvStreamConnection3.cpp
+++ b/ntcore/src/main/native/cpp/net3/UvStreamConnection3.cpp
@@ -10,6 +10,8 @@
 using namespace nt;
 using namespace nt::net3;
 
+static constexpr size_t kMaxPoolSize = 16;
+
 UvStreamConnection3::UvStreamConnection3(wpi::uv::Stream& stream)
     : m_stream{stream}, m_os{m_buffers, [this] { return AllocBuf(); }} {}
 
@@ -26,7 +28,13 @@ void UvStreamConnection3::Flush() {
   ++m_sendsActive;
   m_stream.Write(m_buffers, [selfweak = weak_from_this()](auto bufs, auto) {
     if (auto self = selfweak.lock()) {
-      self->m_buf_pool.insert(self->m_buf_pool.end(), bufs.begin(), bufs.end());
+      size_t numToPool =
+          (std::min)(bufs.size(), kMaxPoolSize - self->m_buf_pool.size());
+      self->m_buf_pool.insert(self->m_buf_pool.end(), bufs.begin(),
+                              bufs.begin() + numToPool);
+      for (auto&& buf : bufs.subspan(numToPool)) {
+        buf.Deallocate();
+      }
       if (self->m_sendsActive > 0) {
         --self->m_sendsActive;
       }


### PR DESCRIPTION
Previously this was unlimited, which could result in holding on to a large amount of memory if the connection got backlogged or a burst of data transmission occurred.

64 KB might be too aggressive, but the only downside of exceeding this is additional heap traffic.