### PR TITLE
[wpimath] Disallow LTV controller max velocities above 15 m/s

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/controller/LTVDifferentialDriveController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/LTVDifferentialDriveController.java
@@ -65,7 +65,8 @@ public class LTVDifferentialDriveController {
    * @param qelems The maximum desired error tolerance for each state.
    * @param relems The maximum desired control effort for each input.
    * @param dt Discretization timestep in seconds.
-   * @throws IllegalArgumentException if max velocity of plant with 12 V input &lt;= 0.
+   * @throws IllegalArgumentException if max velocity of plant with 12 V input &lt;= 0 m/s or &gt;=
+   *     15 m/s.
    */
   public LTVDifferentialDriveController(
       LinearSystem<N2, N2, N2> plant,
@@ -134,7 +135,11 @@ public class LTVDifferentialDriveController {
 
     if (maxV <= 0.0) {
       throw new IllegalArgumentException(
-          "Max velocity of plant with 12 V input must be greater than zero.");
+          "Max velocity of plant with 12 V input must be greater than 0 m/s.");
+    }
+    if (maxV >= 15.0) {
+      throw new IllegalArgumentException(
+          "Max velocity of plant with 12 V input must be less than 15 m/s.");
     }
 
     for (double velocity = -maxV; velocity < maxV; velocity += 0.01) {

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/LTVUnicycleController.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/LTVUnicycleController.java
@@ -99,12 +99,15 @@ public class LTVUnicycleController {
    * @param dt Discretization timestep in seconds.
    * @param maxVelocity The maximum velocity in meters per second for the controller gain lookup
    *     table. The default is 9 m/s.
-   * @throws IllegalArgumentException if maxVelocity &lt;= 0.
+   * @throws IllegalArgumentException if maxVelocity &lt;= 0 m/s or &gt;= 15 m/s.
    */
   public LTVUnicycleController(
       Vector<N3> qelems, Vector<N2> relems, double dt, double maxVelocity) {
     if (maxVelocity <= 0.0) {
-      throw new IllegalArgumentException("Max velocity must be greater than zero.");
+      throw new IllegalArgumentException("Max velocity must be greater than 0 m/s.");
+    }
+    if (maxVelocity >= 15.0) {
+      throw new IllegalArgumentException("Max velocity must be less than 15 m/s.");
     }
 
     // The change in global pose for a unicycle is defined by the following

--- a/wpimath/src/main/native/cpp/controller/LTVDifferentialDriveController.cpp
+++ b/wpimath/src/main/native/cpp/controller/LTVDifferentialDriveController.cpp
@@ -68,7 +68,11 @@ LTVDifferentialDriveController::LTVDifferentialDriveController(
 
   if (maxV <= 0_mps) {
     throw std::domain_error(
-        "Max velocity of plant with 12 V input must be greater than zero.");
+        "Max velocity of plant with 12 V input must be greater than 0 m/s.");
+  }
+  if (maxV >= 15_mps) {
+    throw std::domain_error(
+        "Max velocity of plant with 12 V input must be less than 15 m/s.");
   }
 
   for (auto velocity = -maxV; velocity < maxV; velocity += 0.01_mps) {

--- a/wpimath/src/main/native/cpp/controller/LTVUnicycleController.cpp
+++ b/wpimath/src/main/native/cpp/controller/LTVUnicycleController.cpp
@@ -40,7 +40,10 @@ LTVUnicycleController::LTVUnicycleController(
     const wpi::array<double, 3>& Qelems, const wpi::array<double, 2>& Relems,
     units::second_t dt, units::meters_per_second_t maxVelocity) {
   if (maxVelocity <= 0_mps) {
-    throw std::domain_error("Max velocity must be greater than zero.");
+    throw std::domain_error("Max velocity must be greater than 0 m/s.");
+  }
+  if (maxVelocity >= 15_mps) {
+    throw std::domain_error("Max velocity must be less than 15 m/s.");
   }
 
   // The change in global pose for a unicycle is defined by the following three

--- a/wpimath/src/main/native/include/frc/controller/LTVDifferentialDriveController.h
+++ b/wpimath/src/main/native/include/frc/controller/LTVDifferentialDriveController.h
@@ -45,7 +45,8 @@ class WPILIB_DLLEXPORT LTVDifferentialDriveController {
    * @param Qelems     The maximum desired error tolerance for each state.
    * @param Relems     The maximum desired control effort for each input.
    * @param dt         Discretization timestep.
-   * @throws std::domain_error if max velocity of plant with 12 V input <= 0.
+   * @throws std::domain_error if max velocity of plant with 12 V input <= 0 m/s
+   *     or >= 15 m/s.
    */
   LTVDifferentialDriveController(const frc::LinearSystem<2, 2, 2>& plant,
                                  units::meter_t trackwidth,

--- a/wpimath/src/main/native/include/frc/controller/LTVUnicycleController.h
+++ b/wpimath/src/main/native/include/frc/controller/LTVUnicycleController.h
@@ -53,7 +53,7 @@ class WPILIB_DLLEXPORT LTVUnicycleController {
    * @param dt     Discretization timestep.
    * @param maxVelocity The maximum velocity for the controller gain lookup
    *                    table.
-   * @throws std::domain_error if maxVelocity &lt;= 0.
+   * @throws std::domain_error if maxVelocity <= 0 m/s or >= 15 m/s.
    */
   LTVUnicycleController(const wpi::array<double, 3>& Qelems,
                         const wpi::array<double, 2>& Relems, units::second_t dt,


### PR DESCRIPTION
15 m/s is about 50 ft/s, which is way above what FRC robots should be able to achieve. This limit lets us catch user errors from bad unit conversions immediately instead of the LUT generation in the LTV controllers hanging for a really long time.

Fixes #5027.