### PR TITLE
[cpp cmd] Add Requirements struct

### DIFF
--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -43,11 +43,7 @@ wpi::SmallSet<Subsystem*, 4> Command::GetRequirements() const {
   return m_requirements;
 }
 
-void Command::AddRequirements(std::initializer_list<Subsystem*> requirements) {
-  m_requirements.insert(requirements.begin(), requirements.end());
-}
-
-void Command::AddRequirements(std::span<Subsystem* const> requirements) {
+void Command::AddRequirements(Requirements requirements) {
   m_requirements.insert(requirements.begin(), requirements.end());
 }
 
@@ -96,27 +92,14 @@ CommandPtr Command::WithInterruptBehavior(
   return std::move(*this).ToPtr().WithInterruptBehavior(interruptBehavior);
 }
 
-CommandPtr Command::BeforeStarting(
-    std::function<void()> toRun,
-    std::initializer_list<Subsystem*> requirements) && {
-  return std::move(*this).BeforeStarting(
-      std::move(toRun), {requirements.begin(), requirements.end()});
-}
-
-CommandPtr Command::BeforeStarting(
-    std::function<void()> toRun, std::span<Subsystem* const> requirements) && {
+CommandPtr Command::BeforeStarting(std::function<void()> toRun,
+                                   Requirements requirements) && {
   return std::move(*this).ToPtr().BeforeStarting(std::move(toRun),
                                                  requirements);
 }
 
 CommandPtr Command::AndThen(std::function<void()> toRun,
-                            std::initializer_list<Subsystem*> requirements) && {
-  return std::move(*this).AndThen(std::move(toRun),
-                                  {requirements.begin(), requirements.end()});
-}
-
-CommandPtr Command::AndThen(std::function<void()> toRun,
-                            std::span<Subsystem* const> requirements) && {
+                            Requirements requirements) && {
   return std::move(*this).ToPtr().AndThen(std::move(toRun), requirements);
 }
 

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandPtr.cpp
@@ -86,15 +86,7 @@ CommandPtr CommandPtr::WithInterruptBehavior(
 }
 
 CommandPtr CommandPtr::AndThen(std::function<void()> toRun,
-                               std::span<Subsystem* const> requirements) && {
-  AssertValid();
-  return std::move(*this).AndThen(CommandPtr(
-      std::make_unique<InstantCommand>(std::move(toRun), requirements)));
-}
-
-CommandPtr CommandPtr::AndThen(
-    std::function<void()> toRun,
-    std::initializer_list<Subsystem*> requirements) && {
+                               Requirements requirements) && {
   AssertValid();
   return std::move(*this).AndThen(CommandPtr(
       std::make_unique<InstantCommand>(std::move(toRun), requirements)));
@@ -109,16 +101,8 @@ CommandPtr CommandPtr::AndThen(CommandPtr&& next) && {
   return std::move(*this);
 }
 
-CommandPtr CommandPtr::BeforeStarting(
-    std::function<void()> toRun, std::span<Subsystem* const> requirements) && {
-  AssertValid();
-  return std::move(*this).BeforeStarting(CommandPtr(
-      std::make_unique<InstantCommand>(std::move(toRun), requirements)));
-}
-
-CommandPtr CommandPtr::BeforeStarting(
-    std::function<void()> toRun,
-    std::initializer_list<Subsystem*> requirements) && {
+CommandPtr CommandPtr::BeforeStarting(std::function<void()> toRun,
+                                      Requirements requirements) && {
   AssertValid();
   return std::move(*this).BeforeStarting(CommandPtr(
       std::make_unique<InstantCommand>(std::move(toRun), requirements)));

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
@@ -29,36 +29,16 @@ CommandPtr cmd::Idle() {
 }
 
 CommandPtr cmd::RunOnce(std::function<void()> action,
-                        std::initializer_list<Subsystem*> requirements) {
+                        Requirements requirements) {
   return InstantCommand(std::move(action), requirements).ToPtr();
 }
 
-CommandPtr cmd::RunOnce(std::function<void()> action,
-                        std::span<Subsystem* const> requirements) {
-  return InstantCommand(std::move(action), requirements).ToPtr();
-}
-
-CommandPtr cmd::Run(std::function<void()> action,
-                    std::initializer_list<Subsystem*> requirements) {
-  return RunCommand(std::move(action), requirements).ToPtr();
-}
-
-CommandPtr cmd::Run(std::function<void()> action,
-                    std::span<Subsystem* const> requirements) {
+CommandPtr cmd::Run(std::function<void()> action, Requirements requirements) {
   return RunCommand(std::move(action), requirements).ToPtr();
 }
 
 CommandPtr cmd::StartEnd(std::function<void()> start, std::function<void()> end,
-                         std::initializer_list<Subsystem*> requirements) {
-  return FunctionalCommand(
-             std::move(start), [] {},
-             [end = std::move(end)](bool interrupted) { end(); },
-             [] { return false; }, requirements)
-      .ToPtr();
-}
-
-CommandPtr cmd::StartEnd(std::function<void()> start, std::function<void()> end,
-                         std::span<Subsystem* const> requirements) {
+                         Requirements requirements) {
   return FunctionalCommand(
              std::move(start), [] {},
              [end = std::move(end)](bool interrupted) { end(); },
@@ -67,15 +47,7 @@ CommandPtr cmd::StartEnd(std::function<void()> start, std::function<void()> end,
 }
 
 CommandPtr cmd::RunEnd(std::function<void()> run, std::function<void()> end,
-                       std::initializer_list<Subsystem*> requirements) {
-  return FunctionalCommand([] {}, std::move(run),
-                           [end = std::move(end)](bool interrupted) { end(); },
-                           [] { return false; }, requirements)
-      .ToPtr();
-}
-
-CommandPtr cmd::RunEnd(std::function<void()> run, std::function<void()> end,
-                       std::span<Subsystem* const> requirements) {
+                       Requirements requirements) {
   return FunctionalCommand([] {}, std::move(run),
                            [end = std::move(end)](bool interrupted) { end(); },
                            [] { return false; }, requirements)

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/FunctionalCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/FunctionalCommand.cpp
@@ -6,22 +6,11 @@
 
 using namespace frc2;
 
-FunctionalCommand::FunctionalCommand(
-    std::function<void()> onInit, std::function<void()> onExecute,
-    std::function<void(bool)> onEnd, std::function<bool()> isFinished,
-    std::initializer_list<Subsystem*> requirements)
-    : m_onInit{std::move(onInit)},
-      m_onExecute{std::move(onExecute)},
-      m_onEnd{std::move(onEnd)},
-      m_isFinished{std::move(isFinished)} {
-  AddRequirements(requirements);
-}
-
 FunctionalCommand::FunctionalCommand(std::function<void()> onInit,
                                      std::function<void()> onExecute,
                                      std::function<void(bool)> onEnd,
                                      std::function<bool()> isFinished,
-                                     std::span<Subsystem* const> requirements)
+                                     Requirements requirements)
     : m_onInit{std::move(onInit)},
       m_onExecute{std::move(onExecute)},
       m_onEnd{std::move(onEnd)},

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/InstantCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/InstantCommand.cpp
@@ -7,13 +7,7 @@
 using namespace frc2;
 
 InstantCommand::InstantCommand(std::function<void()> toRun,
-                               std::initializer_list<Subsystem*> requirements)
-    : CommandHelper(
-          std::move(toRun), [] {}, [](bool interrupted) {}, [] { return true; },
-          requirements) {}
-
-InstantCommand::InstantCommand(std::function<void()> toRun,
-                               std::span<Subsystem* const> requirements)
+                               Requirements requirements)
     : CommandHelper(
           std::move(toRun), [] {}, [](bool interrupted) {}, [] { return true; },
           requirements) {}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/MecanumControllerCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/MecanumControllerCommand.cpp
@@ -24,7 +24,7 @@ MecanumControllerCommand::MecanumControllerCommand(
     std::function<void(units::volt_t, units::volt_t, units::volt_t,
                        units::volt_t)>
         output,
-    std::initializer_list<Subsystem*> requirements)
+    Requirements requirements)
     : m_trajectory(std::move(trajectory)),
       m_pose(std::move(pose)),
       m_feedforward(feedforward),
@@ -61,81 +61,7 @@ MecanumControllerCommand::MecanumControllerCommand(
     std::function<void(units::volt_t, units::volt_t, units::volt_t,
                        units::volt_t)>
         output,
-    std::initializer_list<Subsystem*> requirements)
-    : m_trajectory(std::move(trajectory)),
-      m_pose(std::move(pose)),
-      m_feedforward(feedforward),
-      m_kinematics(kinematics),
-      m_controller(xController, yController, thetaController),
-      m_maxWheelVelocity(maxWheelVelocity),
-      m_frontLeftController(
-          std::make_unique<frc::PIDController>(frontLeftController)),
-      m_rearLeftController(
-          std::make_unique<frc::PIDController>(rearLeftController)),
-      m_frontRightController(
-          std::make_unique<frc::PIDController>(frontRightController)),
-      m_rearRightController(
-          std::make_unique<frc::PIDController>(rearRightController)),
-      m_currentWheelSpeeds(std::move(currentWheelSpeeds)),
-      m_outputVolts(std::move(output)),
-      m_usePID(true) {
-  AddRequirements(requirements);
-}
-
-MecanumControllerCommand::MecanumControllerCommand(
-    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::SimpleMotorFeedforward<units::meters> feedforward,
-    frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
-    frc::PIDController yController,
-    frc::ProfiledPIDController<units::radians> thetaController,
-    std::function<frc::Rotation2d()> desiredRotation,
-    units::meters_per_second_t maxWheelVelocity,
-    std::function<frc::MecanumDriveWheelSpeeds()> currentWheelSpeeds,
-    frc::PIDController frontLeftController,
-    frc::PIDController rearLeftController,
-    frc::PIDController frontRightController,
-    frc::PIDController rearRightController,
-    std::function<void(units::volt_t, units::volt_t, units::volt_t,
-                       units::volt_t)>
-        output,
-    std::span<Subsystem* const> requirements)
-    : m_trajectory(std::move(trajectory)),
-      m_pose(std::move(pose)),
-      m_feedforward(feedforward),
-      m_kinematics(kinematics),
-      m_controller(xController, yController, thetaController),
-      m_desiredRotation(std::move(desiredRotation)),
-      m_maxWheelVelocity(maxWheelVelocity),
-      m_frontLeftController(
-          std::make_unique<frc::PIDController>(frontLeftController)),
-      m_rearLeftController(
-          std::make_unique<frc::PIDController>(rearLeftController)),
-      m_frontRightController(
-          std::make_unique<frc::PIDController>(frontRightController)),
-      m_rearRightController(
-          std::make_unique<frc::PIDController>(rearRightController)),
-      m_currentWheelSpeeds(std::move(currentWheelSpeeds)),
-      m_outputVolts(std::move(output)),
-      m_usePID(true) {
-  AddRequirements(requirements);
-}
-
-MecanumControllerCommand::MecanumControllerCommand(
-    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::SimpleMotorFeedforward<units::meters> feedforward,
-    frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
-    frc::PIDController yController,
-    frc::ProfiledPIDController<units::radians> thetaController,
-    units::meters_per_second_t maxWheelVelocity,
-    std::function<frc::MecanumDriveWheelSpeeds()> currentWheelSpeeds,
-    frc::PIDController frontLeftController,
-    frc::PIDController rearLeftController,
-    frc::PIDController frontRightController,
-    frc::PIDController rearRightController,
-    std::function<void(units::volt_t, units::volt_t, units::volt_t,
-                       units::volt_t)>
-        output,
-    std::span<Subsystem* const> requirements)
+    Requirements requirements)
     : m_trajectory(std::move(trajectory)),
       m_pose(std::move(pose)),
       m_feedforward(feedforward),
@@ -166,7 +92,7 @@ MecanumControllerCommand::MecanumControllerCommand(
     std::function<void(units::meters_per_second_t, units::meters_per_second_t,
                        units::meters_per_second_t, units::meters_per_second_t)>
         output,
-    std::initializer_list<Subsystem*> requirements)
+    Requirements requirements)
     : m_trajectory(std::move(trajectory)),
       m_pose(std::move(pose)),
       m_kinematics(kinematics),
@@ -187,49 +113,7 @@ MecanumControllerCommand::MecanumControllerCommand(
     std::function<void(units::meters_per_second_t, units::meters_per_second_t,
                        units::meters_per_second_t, units::meters_per_second_t)>
         output,
-    std::initializer_list<Subsystem*> requirements)
-    : m_trajectory(std::move(trajectory)),
-      m_pose(std::move(pose)),
-      m_kinematics(kinematics),
-      m_controller(xController, yController, thetaController),
-      m_maxWheelVelocity(maxWheelVelocity),
-      m_outputVel(std::move(output)),
-      m_usePID(false) {
-  AddRequirements(requirements);
-}
-
-MecanumControllerCommand::MecanumControllerCommand(
-    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
-    frc::PIDController yController,
-    frc::ProfiledPIDController<units::radians> thetaController,
-    std::function<frc::Rotation2d()> desiredRotation,
-    units::meters_per_second_t maxWheelVelocity,
-    std::function<void(units::meters_per_second_t, units::meters_per_second_t,
-                       units::meters_per_second_t, units::meters_per_second_t)>
-        output,
-    std::span<Subsystem* const> requirements)
-    : m_trajectory(std::move(trajectory)),
-      m_pose(std::move(pose)),
-      m_kinematics(kinematics),
-      m_controller(xController, yController, thetaController),
-      m_desiredRotation(std::move(desiredRotation)),
-      m_maxWheelVelocity(maxWheelVelocity),
-      m_outputVel(std::move(output)),
-      m_usePID(false) {
-  AddRequirements(requirements);
-}
-
-MecanumControllerCommand::MecanumControllerCommand(
-    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
-    frc::PIDController yController,
-    frc::ProfiledPIDController<units::radians> thetaController,
-    units::meters_per_second_t maxWheelVelocity,
-    std::function<void(units::meters_per_second_t, units::meters_per_second_t,
-                       units::meters_per_second_t, units::meters_per_second_t)>
-        output,
-    std::span<Subsystem* const> requirements)
+    Requirements requirements)
     : m_trajectory(std::move(trajectory)),
       m_pose(std::move(pose)),
       m_kinematics(kinematics),

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/NotifierCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/NotifierCommand.cpp
@@ -8,14 +8,7 @@ using namespace frc2;
 
 NotifierCommand::NotifierCommand(std::function<void()> toRun,
                                  units::second_t period,
-                                 std::initializer_list<Subsystem*> requirements)
-    : m_toRun(toRun), m_notifier{std::move(toRun)}, m_period{period} {
-  AddRequirements(requirements);
-}
-
-NotifierCommand::NotifierCommand(std::function<void()> toRun,
-                                 units::second_t period,
-                                 std::span<Subsystem* const> requirements)
+                                 Requirements requirements)
     : m_toRun(toRun), m_notifier{std::move(toRun)}, m_period{period} {
   AddRequirements(requirements);
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/PIDCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/PIDCommand.cpp
@@ -12,19 +12,7 @@ PIDCommand::PIDCommand(frc::PIDController controller,
                        std::function<double()> measurementSource,
                        std::function<double()> setpointSource,
                        std::function<void(double)> useOutput,
-                       std::initializer_list<Subsystem*> requirements)
-    : m_controller{std::move(controller)},
-      m_measurement{std::move(measurementSource)},
-      m_setpoint{std::move(setpointSource)},
-      m_useOutput{std::move(useOutput)} {
-  AddRequirements(requirements);
-}
-
-PIDCommand::PIDCommand(frc::PIDController controller,
-                       std::function<double()> measurementSource,
-                       std::function<double()> setpointSource,
-                       std::function<void(double)> useOutput,
-                       std::span<Subsystem* const> requirements)
+                       Requirements requirements)
     : m_controller{std::move(controller)},
       m_measurement{std::move(measurementSource)},
       m_setpoint{std::move(setpointSource)},
@@ -35,15 +23,7 @@ PIDCommand::PIDCommand(frc::PIDController controller,
 PIDCommand::PIDCommand(frc::PIDController controller,
                        std::function<double()> measurementSource,
                        double setpoint, std::function<void(double)> useOutput,
-                       std::initializer_list<Subsystem*> requirements)
-    : PIDCommand(
-          controller, measurementSource, [setpoint] { return setpoint; },
-          useOutput, requirements) {}
-
-PIDCommand::PIDCommand(frc::PIDController controller,
-                       std::function<double()> measurementSource,
-                       double setpoint, std::function<void(double)> useOutput,
-                       std::span<Subsystem* const> requirements)
+                       Requirements requirements)
     : PIDCommand(
           controller, measurementSource, [setpoint] { return setpoint; },
           useOutput, requirements) {}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/RamseteCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/RamseteCommand.cpp
@@ -18,29 +18,7 @@ RamseteCommand::RamseteCommand(
     std::function<frc::DifferentialDriveWheelSpeeds()> wheelSpeeds,
     frc::PIDController leftController, frc::PIDController rightController,
     std::function<void(units::volt_t, units::volt_t)> output,
-    std::initializer_list<Subsystem*> requirements)
-    : m_trajectory(std::move(trajectory)),
-      m_pose(std::move(pose)),
-      m_controller(controller),
-      m_feedforward(feedforward),
-      m_kinematics(std::move(kinematics)),
-      m_speeds(std::move(wheelSpeeds)),
-      m_leftController(std::make_unique<frc::PIDController>(leftController)),
-      m_rightController(std::make_unique<frc::PIDController>(rightController)),
-      m_outputVolts(std::move(output)),
-      m_usePID(true) {
-  AddRequirements(requirements);
-}
-
-RamseteCommand::RamseteCommand(
-    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::RamseteController controller,
-    frc::SimpleMotorFeedforward<units::meters> feedforward,
-    frc::DifferentialDriveKinematics kinematics,
-    std::function<frc::DifferentialDriveWheelSpeeds()> wheelSpeeds,
-    frc::PIDController leftController, frc::PIDController rightController,
-    std::function<void(units::volt_t, units::volt_t)> output,
-    std::span<Subsystem* const> requirements)
+    Requirements requirements)
     : m_trajectory(std::move(trajectory)),
       m_pose(std::move(pose)),
       m_controller(controller),
@@ -60,23 +38,7 @@ RamseteCommand::RamseteCommand(
     frc::DifferentialDriveKinematics kinematics,
     std::function<void(units::meters_per_second_t, units::meters_per_second_t)>
         output,
-    std::initializer_list<Subsystem*> requirements)
-    : m_trajectory(std::move(trajectory)),
-      m_pose(std::move(pose)),
-      m_controller(controller),
-      m_kinematics(std::move(kinematics)),
-      m_outputVel(std::move(output)),
-      m_usePID(false) {
-  AddRequirements(requirements);
-}
-
-RamseteCommand::RamseteCommand(
-    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::RamseteController controller,
-    frc::DifferentialDriveKinematics kinematics,
-    std::function<void(units::meters_per_second_t, units::meters_per_second_t)>
-        output,
-    std::span<Subsystem* const> requirements)
+    Requirements requirements)
     : m_trajectory(std::move(trajectory)),
       m_pose(std::move(pose)),
       m_controller(controller),

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/RunCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/RunCommand.cpp
@@ -6,12 +6,6 @@
 
 using namespace frc2;
 
-RunCommand::RunCommand(std::function<void()> toRun,
-                       std::initializer_list<Subsystem*> requirements)
-    : CommandHelper([] {}, std::move(toRun), [](bool interrupted) {},
-                    [] { return false; }, requirements) {}
-
-RunCommand::RunCommand(std::function<void()> toRun,
-                       std::span<Subsystem* const> requirements)
+RunCommand::RunCommand(std::function<void()> toRun, Requirements requirements)
     : CommandHelper([] {}, std::move(toRun), [](bool interrupted) {},
                     [] { return false; }, requirements) {}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/StartEndCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/StartEndCommand.cpp
@@ -8,15 +8,7 @@ using namespace frc2;
 
 StartEndCommand::StartEndCommand(std::function<void()> onInit,
                                  std::function<void()> onEnd,
-                                 std::initializer_list<Subsystem*> requirements)
-    : CommandHelper(
-          std::move(onInit), [] {},
-          [onEnd = std::move(onEnd)](bool interrupted) { onEnd(); },
-          [] { return false; }, requirements) {}
-
-StartEndCommand::StartEndCommand(std::function<void()> onInit,
-                                 std::function<void()> onEnd,
-                                 std::span<Subsystem* const> requirements)
+                                 Requirements requirements)
     : CommandHelper(
           std::move(onInit), [] {},
           [onEnd = std::move(onEnd)](bool interrupted) { onEnd(); },

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -15,6 +15,7 @@
 #include <wpi/SmallSet.h>
 #include <wpi/sendable/Sendable.h>
 
+#include "frc2/command/Requirements.h"
 #include "frc2/command/Subsystem.h"
 
 namespace frc2 {
@@ -104,23 +105,15 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * is scheduled, so this method should normally be called from the command's
    * constructor.
    *
-   * @param requirements the Subsystem requirements to add
+   * While this overload can be used with {@code AddRequirements({&subsystem1,
+   * &subsystem2})}, {@code AddRequirements({&subsystem})} selects the {@code
+   * AddRequirements(Subsystem*)} overload, which will function identically but
+   * may cause warnings about redundant braces.
+   *
+   * @param requirements the Subsystem requirements to add, which can be
+   * implicitly constructed from an initializer list or a span
    */
-  void AddRequirements(std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Adds the specified Subsystem requirements to the command.
-   *
-   * The scheduler will prevent two commands that require the same subsystem
-   * from being scheduled simultaneously.
-   *
-   * Note that the scheduler determines the requirements of a command when it
-   * is scheduled, so this method should normally be called from the command's
-   * constructor.
-   *
-   * @param requirements the Subsystem requirements to add
-   */
-  void AddRequirements(std::span<Subsystem* const> requirements);
+  void AddRequirements(Requirements requirements);
 
   /**
    * Adds the specified Subsystem requirements to the command.
@@ -238,18 +231,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    */
   [[nodiscard]]
   CommandPtr BeforeStarting(std::function<void()> toRun,
-                            std::initializer_list<Subsystem*> requirements) &&;
-
-  /**
-   * Decorates this command with a runnable to run before this command starts.
-   *
-   * @param toRun the Runnable to run
-   * @param requirements the required subsystems
-   * @return the decorated command
-   */
-  [[nodiscard]]
-  CommandPtr BeforeStarting(std::function<void()> toRun,
-                            std::span<Subsystem* const> requirements = {}) &&;
+                            Requirements requirements = {}) &&;
 
   /**
    * Decorates this command with a runnable to run after the command finishes.
@@ -260,18 +242,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    */
   [[nodiscard]]
   CommandPtr AndThen(std::function<void()> toRun,
-                     std::initializer_list<Subsystem*> requirements) &&;
-
-  /**
-   * Decorates this command with a runnable to run after the command finishes.
-   *
-   * @param toRun the Runnable to run
-   * @param requirements the required subsystems
-   * @return the decorated command
-   */
-  [[nodiscard]]
-  CommandPtr AndThen(std::function<void()> toRun,
-                     std::span<Subsystem* const> requirements = {}) &&;
+                     Requirements requirements = {}) &&;
 
   /**
    * Decorates this command to run repeatedly, restarting it when it ends, until

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandPtr.h
@@ -88,18 +88,7 @@ class CommandPtr final {
    */
   [[nodiscard]]
   CommandPtr AndThen(std::function<void()> toRun,
-                     std::span<Subsystem* const> requirements = {}) &&;
-
-  /**
-   * Decorates this command with a runnable to run after the command finishes.
-   *
-   * @param toRun the Runnable to run
-   * @param requirements the required subsystems
-   * @return the decorated command
-   */
-  [[nodiscard]]
-  CommandPtr AndThen(std::function<void()> toRun,
-                     std::initializer_list<Subsystem*> requirements) &&;
+                     Requirements requirements = {}) &&;
 
   /**
    * Decorates this command with a set of commands to run after it in sequence.
@@ -121,18 +110,7 @@ class CommandPtr final {
    */
   [[nodiscard]]
   CommandPtr BeforeStarting(std::function<void()> toRun,
-                            std::initializer_list<Subsystem*> requirements) &&;
-
-  /**
-   * Decorates this command with a runnable to run before this command starts.
-   *
-   * @param toRun the Runnable to run
-   * @param requirements the required subsystems
-   * @return the decorated command
-   */
-  [[nodiscard]]
-  CommandPtr BeforeStarting(std::function<void()> toRun,
-                            std::span<Subsystem* const> requirements = {}) &&;
+                            Requirements requirements = {}) &&;
 
   /**
    * Decorates this command with another command to run before this command

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -49,17 +49,7 @@ CommandPtr Idle();
  */
 [[nodiscard]]
 CommandPtr RunOnce(std::function<void()> action,
-                   std::initializer_list<Subsystem*> requirements);
-
-/**
- * Constructs a command that runs an action once and finishes.
- *
- * @param action the action to run
- * @param requirements subsystems the action requires
- */
-[[nodiscard]]
-CommandPtr RunOnce(std::function<void()> action,
-                   std::span<Subsystem* const> requirements = {});
+                   Requirements requirements = {});
 
 /**
  * Constructs a command that runs an action every iteration until interrupted.
@@ -68,18 +58,7 @@ CommandPtr RunOnce(std::function<void()> action,
  * @param requirements subsystems the action requires
  */
 [[nodiscard]]
-CommandPtr Run(std::function<void()> action,
-               std::initializer_list<Subsystem*> requirements);
-
-/**
- * Constructs a command that runs an action every iteration until interrupted.
- *
- * @param action the action to run
- * @param requirements subsystems the action requires
- */
-[[nodiscard]]
-CommandPtr Run(std::function<void()> action,
-               std::span<Subsystem* const> requirements = {});
+CommandPtr Run(std::function<void()> action, Requirements requirements = {});
 
 /**
  * Constructs a command that runs an action once and another action when the
@@ -91,19 +70,7 @@ CommandPtr Run(std::function<void()> action,
  */
 [[nodiscard]]
 CommandPtr StartEnd(std::function<void()> start, std::function<void()> end,
-                    std::initializer_list<Subsystem*> requirements);
-
-/**
- * Constructs a command that runs an action once and another action when the
- * command is interrupted.
- *
- * @param start the action to run on start
- * @param end the action to run on interrupt
- * @param requirements subsystems the action requires
- */
-[[nodiscard]]
-CommandPtr StartEnd(std::function<void()> start, std::function<void()> end,
-                    std::span<Subsystem* const> requirements = {});
+                    Requirements requirements = {});
 
 /**
  * Constructs a command that runs an action every iteration until interrupted,
@@ -115,19 +82,7 @@ CommandPtr StartEnd(std::function<void()> start, std::function<void()> end,
  */
 [[nodiscard]]
 CommandPtr RunEnd(std::function<void()> run, std::function<void()> end,
-                  std::initializer_list<Subsystem*> requirements);
-
-/**
- * Constructs a command that runs an action every iteration until interrupted,
- * and then runs a second action.
- *
- * @param run the action to run every iteration
- * @param end the action to run on interrupt
- * @param requirements subsystems the action requires
- */
-[[nodiscard]]
-CommandPtr RunEnd(std::function<void()> run, std::function<void()> end,
-                  std::span<Subsystem* const> requirements = {});
+                  Requirements requirements = {});
 
 /**
  * Constructs a command that prints a message and finishes.

--- a/wpilibNewCommands/src/main/native/include/frc2/command/FunctionalCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/FunctionalCommand.h
@@ -37,23 +37,7 @@ class FunctionalCommand : public CommandHelper<Command, FunctionalCommand> {
                     std::function<void()> onExecute,
                     std::function<void(bool)> onEnd,
                     std::function<bool()> isFinished,
-                    std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Creates a new FunctionalCommand.
-   *
-   * @param onInit       the function to run on command initialization
-   * @param onExecute    the function to run on command execution
-   * @param onEnd        the function to run on command end
-   * @param isFinished   the function that determines whether the command has
-   * finished
-   * @param requirements the subsystems required by this command
-   */
-  FunctionalCommand(std::function<void()> onInit,
-                    std::function<void()> onExecute,
-                    std::function<void(bool)> onEnd,
-                    std::function<bool()> isFinished,
-                    std::span<Subsystem* const> requirements = {});
+                    Requirements requirements = {});
 
   FunctionalCommand(FunctionalCommand&& other) = default;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/InstantCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/InstantCommand.h
@@ -28,18 +28,8 @@ class InstantCommand : public CommandHelper<FunctionalCommand, InstantCommand> {
    * @param toRun        the Runnable to run
    * @param requirements the subsystems required by this command
    */
-  InstantCommand(std::function<void()> toRun,
-                 std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Creates a new InstantCommand that runs the given Runnable with the given
-   * requirements.
-   *
-   * @param toRun        the Runnable to run
-   * @param requirements the subsystems required by this command
-   */
   explicit InstantCommand(std::function<void()> toRun,
-                          std::span<Subsystem* const> requirements = {});
+                          Requirements requirements = {});
 
   InstantCommand(InstantCommand&& other) = default;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/MecanumControllerCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/MecanumControllerCommand.h
@@ -102,7 +102,7 @@ class MecanumControllerCommand
       std::function<void(units::volt_t, units::volt_t, units::volt_t,
                          units::volt_t)>
           output,
-      std::initializer_list<Subsystem*> requirements);
+      Requirements requirements = {});
 
   /**
    * Constructs a new MecanumControllerCommand that when executed will follow
@@ -155,111 +155,7 @@ class MecanumControllerCommand
       std::function<void(units::volt_t, units::volt_t, units::volt_t,
                          units::volt_t)>
           output,
-      std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Constructs a new MecanumControllerCommand that when executed will follow
-   * the provided trajectory. PID control and feedforward are handled
-   * internally. Outputs are scaled from -12 to 12 as a voltage output to the
-   * motor.
-   *
-   * <p>Note: The controllers will *not* set the outputVolts to zero upon
-   * completion of the path this is left to the user, since it is not
-   * appropriate for paths with nonstationary endstates.
-   *
-   * @param trajectory           The trajectory to follow.
-   * @param pose                 A function that supplies the robot pose,
-   *                             provided by the odometry class.
-   * @param feedforward          The feedforward to use for the drivetrain.
-   * @param kinematics           The kinematics for the robot drivetrain.
-   * @param xController          The Trajectory Tracker PID controller
-   *                             for the robot's x position.
-   * @param yController          The Trajectory Tracker PID controller
-   *                             for the robot's y position.
-   * @param thetaController      The Trajectory Tracker PID controller
-   *                             for angle for the robot.
-   * @param desiredRotation      The angle that the robot should be facing.
-   *                             This is sampled at each time step.
-   * @param maxWheelVelocity     The maximum velocity of a drivetrain wheel.
-   * @param frontLeftController  The front left wheel velocity PID.
-   * @param rearLeftController   The rear left wheel velocity PID.
-   * @param frontRightController The front right wheel velocity PID.
-   * @param rearRightController  The rear right wheel velocity PID.
-   * @param currentWheelSpeeds   A MecanumDriveWheelSpeeds object containing
-   *                             the current wheel speeds.
-   * @param output               The output of the velocity PIDs.
-   * @param requirements         The subsystems to require.
-   */
-  MecanumControllerCommand(
-      frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-      frc::SimpleMotorFeedforward<units::meters> feedforward,
-      frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
-      frc::PIDController yController,
-      frc::ProfiledPIDController<units::radians> thetaController,
-      std::function<frc::Rotation2d()> desiredRotation,
-      units::meters_per_second_t maxWheelVelocity,
-      std::function<frc::MecanumDriveWheelSpeeds()> currentWheelSpeeds,
-      frc::PIDController frontLeftController,
-      frc::PIDController rearLeftController,
-      frc::PIDController frontRightController,
-      frc::PIDController rearRightController,
-      std::function<void(units::volt_t, units::volt_t, units::volt_t,
-                         units::volt_t)>
-          output,
-      std::span<Subsystem* const> requirements = {});
-
-  /**
-   * Constructs a new MecanumControllerCommand that when executed will follow
-   * the provided trajectory. PID control and feedforward are handled
-   * internally. Outputs are scaled from -12 to 12 as a voltage output to the
-   * motor.
-   *
-   * <p>Note: The controllers will *not* set the outputVolts to zero upon
-   * completion of the path this is left to the user, since it is not
-   * appropriate for paths with nonstationary endstates.
-   *
-   * <p>Note 2: The final rotation of the robot will be set to the rotation of
-   * the final pose in the trajectory. The robot will not follow the rotations
-   * from the poses at each timestep. If alternate rotation behavior is desired,
-   * the other constructor with a supplier for rotation should be used.
-   *
-   * @param trajectory           The trajectory to follow.
-   * @param pose                 A function that supplies the robot pose,
-   *                             provided by the odometry class.
-   * @param feedforward          The feedforward to use for the drivetrain.
-   * @param kinematics           The kinematics for the robot drivetrain.
-   * @param xController          The Trajectory Tracker PID controller
-   *                             for the robot's x position.
-   * @param yController          The Trajectory Tracker PID controller
-   *                             for the robot's y position.
-   * @param thetaController      The Trajectory Tracker PID controller
-   *                             for angle for the robot.
-   * @param maxWheelVelocity     The maximum velocity of a drivetrain wheel.
-   * @param frontLeftController  The front left wheel velocity PID.
-   * @param rearLeftController   The rear left wheel velocity PID.
-   * @param frontRightController The front right wheel velocity PID.
-   * @param rearRightController  The rear right wheel velocity PID.
-   * @param currentWheelSpeeds   A MecanumDriveWheelSpeeds object containing
-   *                             the current wheel speeds.
-   * @param output               The output of the velocity PIDs.
-   * @param requirements         The subsystems to require.
-   */
-  MecanumControllerCommand(
-      frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-      frc::SimpleMotorFeedforward<units::meters> feedforward,
-      frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
-      frc::PIDController yController,
-      frc::ProfiledPIDController<units::radians> thetaController,
-      units::meters_per_second_t maxWheelVelocity,
-      std::function<frc::MecanumDriveWheelSpeeds()> currentWheelSpeeds,
-      frc::PIDController frontLeftController,
-      frc::PIDController rearLeftController,
-      frc::PIDController frontRightController,
-      frc::PIDController rearRightController,
-      std::function<void(units::volt_t, units::volt_t, units::volt_t,
-                         units::volt_t)>
-          output,
-      std::span<Subsystem* const> requirements = {});
+      Requirements requirements = {});
 
   /**
    * Constructs a new MecanumControllerCommand that when executed will follow
@@ -297,7 +193,7 @@ class MecanumControllerCommand
                          units::meters_per_second_t,
                          units::meters_per_second_t)>
           output,
-      std::initializer_list<Subsystem*> requirements);
+      Requirements requirements);
 
   /**
    * Constructs a new MecanumControllerCommand that when executed will follow
@@ -337,85 +233,7 @@ class MecanumControllerCommand
                          units::meters_per_second_t,
                          units::meters_per_second_t)>
           output,
-      std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Constructs a new MecanumControllerCommand that when executed will follow
-   * the provided trajectory. The user should implement a velocity PID on the
-   * desired output wheel velocities.
-   *
-   * <p>Note: The controllers will *not* set the outputVolts to zero upon
-   * completion of the path - this is left to the user, since it is not
-   * appropriate for paths with nonstationary end-states.
-   *
-   * @param trajectory       The trajectory to follow.
-   * @param pose             A function that supplies the robot pose - use one
-   * of the odometry classes to provide this.
-   * @param kinematics       The kinematics for the robot drivetrain.
-   * @param xController      The Trajectory Tracker PID controller
-   *                         for the robot's x position.
-   * @param yController      The Trajectory Tracker PID controller
-   *                         for the robot's y position.
-   * @param thetaController  The Trajectory Tracker PID controller
-   *                         for angle for the robot.
-   * @param desiredRotation  The angle that the robot should be facing.
-   *                         This is sampled at every time step.
-   * @param maxWheelVelocity The maximum velocity of a drivetrain wheel.
-   * @param output           The output of the position PIDs.
-   * @param requirements     The subsystems to require.
-   */
-  MecanumControllerCommand(
-      frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-      frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
-      frc::PIDController yController,
-      frc::ProfiledPIDController<units::radians> thetaController,
-      std::function<frc::Rotation2d()> desiredRotation,
-      units::meters_per_second_t maxWheelVelocity,
-      std::function<void(units::meters_per_second_t, units::meters_per_second_t,
-                         units::meters_per_second_t,
-                         units::meters_per_second_t)>
-          output,
-      std::span<Subsystem* const> requirements = {});
-
-  /**
-   * Constructs a new MecanumControllerCommand that when executed will follow
-   * the provided trajectory. The user should implement a velocity PID on the
-   * desired output wheel velocities.
-   *
-   * <p>Note: The controllers will *not* set the outputVolts to zero upon
-   * completion of the path - this is left to the user, since it is not
-   * appropriate for paths with nonstationary end-states.
-   *
-   * <p>Note2: The final rotation of the robot will be set to the rotation of
-   * the final pose in the trajectory. The robot will not follow the rotations
-   * from the poses at each timestep. If alternate rotation behavior is desired,
-   * the other constructor with a supplier for rotation should be used.
-   *
-   * @param trajectory       The trajectory to follow.
-   * @param pose             A function that supplies the robot pose - use one
-   * of the odometry classes to provide this.
-   * @param kinematics       The kinematics for the robot drivetrain.
-   * @param xController      The Trajectory Tracker PID controller
-   *                         for the robot's x position.
-   * @param yController      The Trajectory Tracker PID controller
-   *                         for the robot's y position.
-   * @param thetaController  The Trajectory Tracker PID controller
-   *                         for angle for the robot.
-   * @param maxWheelVelocity The maximum velocity of a drivetrain wheel.
-   * @param output           The output of the position PIDs.
-   * @param requirements     The subsystems to require.
-   */
-  MecanumControllerCommand(
-      frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-      frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
-      frc::PIDController yController,
-      frc::ProfiledPIDController<units::radians> thetaController,
-      units::meters_per_second_t maxWheelVelocity,
-      std::function<void(units::meters_per_second_t, units::meters_per_second_t,
-                         units::meters_per_second_t,
-                         units::meters_per_second_t)>
-          output,
-      std::span<Subsystem* const> requirements = {});
+      Requirements requirements = {});
 
   void Initialize() override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/NotifierCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/NotifierCommand.h
@@ -37,17 +37,7 @@ class NotifierCommand : public CommandHelper<Command, NotifierCommand> {
    * @param requirements the subsystems required by this command
    */
   NotifierCommand(std::function<void()> toRun, units::second_t period,
-                  std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Creates a new NotifierCommand.
-   *
-   * @param toRun        the runnable for the notifier to run
-   * @param period       the period at which the notifier should run
-   * @param requirements the subsystems required by this command
-   */
-  NotifierCommand(std::function<void()> toRun, units::second_t period,
-                  std::span<Subsystem* const> requirements = {});
+                  Requirements requirements = {});
 
   NotifierCommand(NotifierCommand&& other);
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/PIDCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/PIDCommand.h
@@ -40,23 +40,7 @@ class PIDCommand : public CommandHelper<Command, PIDCommand> {
              std::function<double()> measurementSource,
              std::function<double()> setpointSource,
              std::function<void(double)> useOutput,
-             std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Creates a new PIDCommand, which controls the given output with a
-   * PIDController.
-   *
-   * @param controller        the controller that controls the output.
-   * @param measurementSource the measurement of the process variable
-   * @param setpointSource   the controller's reference (aka setpoint)
-   * @param useOutput         the controller's output
-   * @param requirements      the subsystems required by this command
-   */
-  PIDCommand(frc::PIDController controller,
-             std::function<double()> measurementSource,
-             std::function<double()> setpointSource,
-             std::function<void(double)> useOutput,
-             std::span<Subsystem* const> requirements = {});
+             Requirements requirements = {});
 
   /**
    * Creates a new PIDCommand, which controls the given output with a
@@ -71,22 +55,7 @@ class PIDCommand : public CommandHelper<Command, PIDCommand> {
   PIDCommand(frc::PIDController controller,
              std::function<double()> measurementSource, double setpoint,
              std::function<void(double)> useOutput,
-             std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Creates a new PIDCommand, which controls the given output with a
-   * PIDController with a constant setpoint.
-   *
-   * @param controller        the controller that controls the output.
-   * @param measurementSource the measurement of the process variable
-   * @param setpoint         the controller's setpoint (aka setpoint)
-   * @param useOutput         the controller's output
-   * @param requirements      the subsystems required by this command
-   */
-  PIDCommand(frc::PIDController controller,
-             std::function<double()> measurementSource, double setpoint,
-             std::function<void(double)> useOutput,
-             std::span<Subsystem* const> requirements = {});
+             Requirements requirements = {});
 
   PIDCommand(PIDCommand&& other) = default;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/ProfiledPIDCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/ProfiledPIDCommand.h
@@ -50,29 +50,7 @@ class ProfiledPIDCommand
                      std::function<Distance_t()> measurementSource,
                      std::function<State()> goalSource,
                      std::function<void(double, State)> useOutput,
-                     std::initializer_list<Subsystem*> requirements)
-      : m_controller{controller},
-        m_measurement{std::move(measurementSource)},
-        m_goal{std::move(goalSource)},
-        m_useOutput{std::move(useOutput)} {
-    this->AddRequirements(requirements);
-  }
-
-  /**
-   * Creates a new PIDCommand, which controls the given output with a
-   * ProfiledPIDController.
-   *
-   * @param controller        the controller that controls the output.
-   * @param measurementSource the measurement of the process variable
-   * @param goalSource   the controller's goal
-   * @param useOutput         the controller's output
-   * @param requirements      the subsystems required by this command
-   */
-  ProfiledPIDCommand(frc::ProfiledPIDController<Distance> controller,
-                     std::function<Distance_t()> measurementSource,
-                     std::function<State()> goalSource,
-                     std::function<void(double, State)> useOutput,
-                     std::span<Subsystem* const> requirements = {})
+                     Requirements requirements = {})
       : m_controller{controller},
         m_measurement{std::move(measurementSource)},
         m_goal{std::move(goalSource)},
@@ -94,29 +72,7 @@ class ProfiledPIDCommand
                      std::function<Distance_t()> measurementSource,
                      std::function<Distance_t()> goalSource,
                      std::function<void(double, State)> useOutput,
-                     std::initializer_list<Subsystem*> requirements)
-      : ProfiledPIDCommand(
-            controller, measurementSource,
-            [goalSource = std::move(goalSource)]() {
-              return State{goalSource(), Velocity_t{0}};
-            },
-            useOutput, requirements) {}
-
-  /**
-   * Creates a new PIDCommand, which controls the given output with a
-   * ProfiledPIDController.
-   *
-   * @param controller        the controller that controls the output.
-   * @param measurementSource the measurement of the process variable
-   * @param goalSource   the controller's goal
-   * @param useOutput         the controller's output
-   * @param requirements      the subsystems required by this command
-   */
-  ProfiledPIDCommand(frc::ProfiledPIDController<Distance> controller,
-                     std::function<Distance_t()> measurementSource,
-                     std::function<Distance_t()> goalSource,
-                     std::function<void(double, State)> useOutput,
-                     std::span<Subsystem* const> requirements = {})
+                     Requirements requirements = {})
       : ProfiledPIDCommand(
             controller, measurementSource,
             [goalSource = std::move(goalSource)]() {
@@ -137,25 +93,7 @@ class ProfiledPIDCommand
   ProfiledPIDCommand(frc::ProfiledPIDController<Distance> controller,
                      std::function<Distance_t()> measurementSource, State goal,
                      std::function<void(double, State)> useOutput,
-                     std::initializer_list<Subsystem*> requirements)
-      : ProfiledPIDCommand(
-            controller, measurementSource, [goal] { return goal; }, useOutput,
-            requirements) {}
-
-  /**
-   * Creates a new PIDCommand, which controls the given output with a
-   * ProfiledPIDController with a constant goal.
-   *
-   * @param controller        the controller that controls the output.
-   * @param measurementSource the measurement of the process variable
-   * @param goal         the controller's goal
-   * @param useOutput         the controller's output
-   * @param requirements      the subsystems required by this command
-   */
-  ProfiledPIDCommand(frc::ProfiledPIDController<Distance> controller,
-                     std::function<Distance_t()> measurementSource, State goal,
-                     std::function<void(double, State)> useOutput,
-                     std::span<Subsystem* const> requirements = {})
+                     Requirements requirements = {})
       : ProfiledPIDCommand(
             controller, measurementSource, [goal] { return goal; }, useOutput,
             requirements) {}
@@ -174,26 +112,7 @@ class ProfiledPIDCommand
                      std::function<Distance_t()> measurementSource,
                      Distance_t goal,
                      std::function<void(double, State)> useOutput,
-                     std::initializer_list<Subsystem*> requirements)
-      : ProfiledPIDCommand(
-            controller, measurementSource, [goal] { return goal; }, useOutput,
-            requirements) {}
-
-  /**
-   * Creates a new PIDCommand, which controls the given output with a
-   * ProfiledPIDController with a constant goal.
-   *
-   * @param controller        the controller that controls the output.
-   * @param measurementSource the measurement of the process variable
-   * @param goal         the controller's goal
-   * @param useOutput         the controller's output
-   * @param requirements      the subsystems required by this command
-   */
-  ProfiledPIDCommand(frc::ProfiledPIDController<Distance> controller,
-                     std::function<Distance_t()> measurementSource,
-                     Distance_t goal,
-                     std::function<void(double, State)> useOutput,
-                     std::span<Subsystem* const> requirements = {})
+                     Requirements requirements = {})
       : ProfiledPIDCommand(
             controller, measurementSource, [goal] { return goal; }, useOutput,
             requirements) {}

--- a/wpilibNewCommands/src/main/native/include/frc2/command/RamseteCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/RamseteCommand.h
@@ -79,44 +79,7 @@ class RamseteCommand : public CommandHelper<Command, RamseteCommand> {
                  frc::PIDController leftController,
                  frc::PIDController rightController,
                  std::function<void(units::volt_t, units::volt_t)> output,
-                 std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Constructs a new RamseteCommand that, when executed, will follow the
-   * provided trajectory. PID control and feedforward are handled internally,
-   * and outputs are scaled -12 to 12 representing units of volts.
-   *
-   * <p>Note: The controller will *not* set the outputVolts to zero upon
-   * completion of the path - this is left to the user, since it is not
-   * appropriate for paths with nonstationary endstates.
-   *
-   * @param trajectory      The trajectory to follow.
-   * @param pose            A function that supplies the robot pose - use one of
-   * the odometry classes to provide this.
-   * @param controller      The RAMSETE controller used to follow the
-   * trajectory.
-   * @param feedforward     A component for calculating the feedforward for the
-   * drive.
-   * @param kinematics      The kinematics for the robot drivetrain.
-   * @param wheelSpeeds     A function that supplies the speeds of the left
-   * and right sides of the robot drive.
-   * @param leftController  The PIDController for the left side of the robot
-   * drive.
-   * @param rightController The PIDController for the right side of the robot
-   * drive.
-   * @param output          A function that consumes the computed left and right
-   * outputs (in volts) for the robot drive.
-   * @param requirements    The subsystems to require.
-   */
-  RamseteCommand(frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-                 frc::RamseteController controller,
-                 frc::SimpleMotorFeedforward<units::meters> feedforward,
-                 frc::DifferentialDriveKinematics kinematics,
-                 std::function<frc::DifferentialDriveWheelSpeeds()> wheelSpeeds,
-                 frc::PIDController leftController,
-                 frc::PIDController rightController,
-                 std::function<void(units::volt_t, units::volt_t)> output,
-                 std::span<Subsystem* const> requirements = {});
+                 Requirements requirements = {});
 
   /**
    * Constructs a new RamseteCommand that, when executed, will follow the
@@ -140,31 +103,7 @@ class RamseteCommand : public CommandHelper<Command, RamseteCommand> {
                  std::function<void(units::meters_per_second_t,
                                     units::meters_per_second_t)>
                      output,
-                 std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Constructs a new RamseteCommand that, when executed, will follow the
-   * provided trajectory. Performs no PID control and calculates no
-   * feedforwards; outputs are the raw wheel speeds from the RAMSETE controller,
-   * and will need to be converted into a usable form by the user.
-   *
-   * @param trajectory      The trajectory to follow.
-   * @param pose            A function that supplies the robot pose - use one of
-   * the odometry classes to provide this.
-   * @param controller      The RAMSETE controller used to follow the
-   * trajectory.
-   * @param kinematics      The kinematics for the robot drivetrain.
-   * @param output          A function that consumes the computed left and right
-   * wheel speeds.
-   * @param requirements    The subsystems to require.
-   */
-  RamseteCommand(frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-                 frc::RamseteController controller,
-                 frc::DifferentialDriveKinematics kinematics,
-                 std::function<void(units::meters_per_second_t,
-                                    units::meters_per_second_t)>
-                     output,
-                 std::span<Subsystem* const> requirements = {});
+                 Requirements requirements = {});
 
   void Initialize() override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Requirements.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Requirements.h
@@ -1,0 +1,46 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <initializer_list>
+#include <span>
+#include <vector>
+
+#include "frc2/command/Subsystem.h"
+
+namespace frc2 {
+
+/**
+ * Represents requirements for a command, which is a set of (pointers to)
+ * subsystems. This class is implicitly convertible from std::initializer_list
+ * and std::span.
+ */
+class Requirements {
+ public:
+  // NOLINTNEXTLINE
+  /*implicit*/ Requirements(std::initializer_list<Subsystem*> requirements)
+      : m_subsystems{requirements.begin(), requirements.end()} {}
+
+  // NOLINTNEXTLINE
+  /*implicit*/ Requirements(std::span<Subsystem* const> requirements)
+      : m_subsystems{requirements.begin(), requirements.end()} {}
+
+  Requirements() = default;
+
+  Requirements(const Requirements&) = default;
+
+  std::vector<Subsystem*>::const_iterator begin() const {
+    return m_subsystems.begin();
+  }
+
+  std::vector<Subsystem*>::const_iterator end() const {
+    return m_subsystems.end();
+  }
+
+ private:
+  std::vector<Subsystem*> m_subsystems;
+};
+
+}  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/RunCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/RunCommand.h
@@ -29,18 +29,8 @@ class RunCommand : public CommandHelper<FunctionalCommand, RunCommand> {
    * @param toRun        the Runnable to run
    * @param requirements the subsystems to require
    */
-  RunCommand(std::function<void()> toRun,
-             std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Creates a new RunCommand.  The Runnable will be run continuously until the
-   * command ends.  Does not run when disabled.
-   *
-   * @param toRun        the Runnable to run
-   * @param requirements the subsystems to require
-   */
   explicit RunCommand(std::function<void()> toRun,
-                      std::span<Subsystem* const> requirements = {});
+                      Requirements requirements = {});
 
   RunCommand(RunCommand&& other) = default;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/StartEndCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/StartEndCommand.h
@@ -33,18 +33,7 @@ class StartEndCommand
    * @param requirements the subsystems required by this command
    */
   StartEndCommand(std::function<void()> onInit, std::function<void()> onEnd,
-                  std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Creates a new StartEndCommand.  Will run the given runnables when the
-   * command starts and when it ends.
-   *
-   * @param onInit       the Runnable to run on command init
-   * @param onEnd        the Runnable to run on command end
-   * @param requirements the subsystems required by this command
-   */
-  StartEndCommand(std::function<void()> onInit, std::function<void()> onEnd,
-                  std::span<Subsystem* const> requirements = {});
+                  Requirements requirements = {});
 
   StartEndCommand(StartEndCommand&& other) = default;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SwerveControllerCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SwerveControllerCommand.h
@@ -94,7 +94,7 @@ class SwerveControllerCommand
       std::function<frc::Rotation2d()> desiredRotation,
       std::function<void(std::array<frc::SwerveModuleState, NumModules>)>
           output,
-      std::initializer_list<Subsystem*> requirements);
+      Requirements requirements = {});
 
   /**
    * Constructs a new SwerveControllerCommand that when executed will follow the
@@ -132,82 +132,7 @@ class SwerveControllerCommand
       frc::ProfiledPIDController<units::radians> thetaController,
       std::function<void(std::array<frc::SwerveModuleState, NumModules>)>
           output,
-      std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Constructs a new SwerveControllerCommand that when executed will follow the
-   * provided trajectory. This command will not return output voltages but
-   * rather raw module states from the position controllers which need to be put
-   * into a velocity PID.
-   *
-   * <p>Note: The controllers will *not* set the outputVolts to zero upon
-   * completion of the path- this is left to the user, since it is not
-   * appropriate for paths with nonstationary endstates.
-   *
-   *
-   * @param trajectory      The trajectory to follow.
-   * @param pose            A function that supplies the robot pose,
-   *                        provided by the odometry class.
-   * @param kinematics      The kinematics for the robot drivetrain.
-   * @param xController     The Trajectory Tracker PID controller
-   *                        for the robot's x position.
-   * @param yController     The Trajectory Tracker PID controller
-   *                        for the robot's y position.
-   * @param thetaController The Trajectory Tracker PID controller
-   *                        for angle for the robot.
-   * @param desiredRotation The angle that the drivetrain should be
-   *                        facing. This is sampled at each time step.
-   * @param output          The raw output module states from the
-   *                        position controllers.
-   * @param requirements    The subsystems to require.
-   */
-  SwerveControllerCommand(
-      frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-      frc::SwerveDriveKinematics<NumModules> kinematics,
-      frc::PIDController xController, frc::PIDController yController,
-      frc::ProfiledPIDController<units::radians> thetaController,
-      std::function<frc::Rotation2d()> desiredRotation,
-      std::function<void(std::array<frc::SwerveModuleState, NumModules>)>
-          output,
-      std::span<Subsystem* const> requirements = {});
-
-  /**
-   * Constructs a new SwerveControllerCommand that when executed will follow the
-   * provided trajectory. This command will not return output voltages but
-   * rather raw module states from the position controllers which need to be put
-   * into a velocity PID.
-   *
-   * <p>Note: The controllers will *not* set the outputVolts to zero upon
-   * completion of the path- this is left to the user, since it is not
-   * appropriate for paths with nonstationary endstates.
-   *
-   * <p>Note 2: The final rotation of the robot will be set to the rotation of
-   * the final pose in the trajectory. The robot will not follow the rotations
-   * from the poses at each timestep. If alternate rotation behavior is desired,
-   * the other constructor with a supplier for rotation should be used.
-   *
-   * @param trajectory      The trajectory to follow.
-   * @param pose            A function that supplies the robot pose,
-   *                        provided by the odometry class.
-   * @param kinematics      The kinematics for the robot drivetrain.
-   * @param xController     The Trajectory Tracker PID controller
-   *                        for the robot's x position.
-   * @param yController     The Trajectory Tracker PID controller
-   *                        for the robot's y position.
-   * @param thetaController The Trajectory Tracker PID controller
-   *                        for angle for the robot.
-   * @param output          The raw output module states from the
-   *                        position controllers.
-   * @param requirements    The subsystems to require.
-   */
-  SwerveControllerCommand(
-      frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-      frc::SwerveDriveKinematics<NumModules> kinematics,
-      frc::PIDController xController, frc::PIDController yController,
-      frc::ProfiledPIDController<units::radians> thetaController,
-      std::function<void(std::array<frc::SwerveModuleState, NumModules>)>
-          output,
-      std::span<Subsystem* const> requirements = {});
+      Requirements requirements = {});
 
   /**
    * Constructs a new SwerveControllerCommand that when executed will follow the
@@ -237,7 +162,7 @@ class SwerveControllerCommand
       std::function<frc::Rotation2d()> desiredRotation,
       std::function<void(std::array<frc::SwerveModuleState, NumModules>)>
           output,
-      std::initializer_list<Subsystem*> requirements);
+      Requirements requirements = {});
 
   /**
    * Constructs a new SwerveControllerCommand that when executed will follow the
@@ -269,70 +194,7 @@ class SwerveControllerCommand
       frc::HolonomicDriveController controller,
       std::function<void(std::array<frc::SwerveModuleState, NumModules>)>
           output,
-      std::initializer_list<Subsystem*> requirements);
-
-  /**
-   * Constructs a new SwerveControllerCommand that when executed will follow the
-   * provided trajectory. This command will not return output voltages but
-   * rather raw module states from the position controllers which need to be put
-   * into a velocity PID.
-   *
-   * <p>Note: The controllers will *not* set the outputVolts to zero upon
-   * completion of the path- this is left to the user, since it is not
-   * appropriate for paths with nonstationary endstates.
-   *
-   *
-   * @param trajectory      The trajectory to follow.
-   * @param pose            A function that supplies the robot pose,
-   *                        provided by the odometry class.
-   * @param kinematics      The kinematics for the robot drivetrain.
-   * @param controller     The HolonomicDriveController for the robot.
-   * @param desiredRotation The angle that the drivetrain should be
-   *                        facing. This is sampled at each time step.
-   * @param output          The raw output module states from the
-   *                        position controllers.
-   * @param requirements    The subsystems to require.
-   */
-  SwerveControllerCommand(
-      frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-      frc::SwerveDriveKinematics<NumModules> kinematics,
-      frc::HolonomicDriveController controller,
-      std::function<frc::Rotation2d()> desiredRotation,
-      std::function<void(std::array<frc::SwerveModuleState, NumModules>)>
-          output,
-      std::span<Subsystem* const> requirements = {});
-
-  /**
-   * Constructs a new SwerveControllerCommand that when executed will follow the
-   * provided trajectory. This command will not return output voltages but
-   * rather raw module states from the position controllers which need to be put
-   * into a velocity PID.
-   *
-   * <p>Note: The controllers will *not* set the outputVolts to zero upon
-   * completion of the path- this is left to the user, since it is not
-   * appropriate for paths with nonstationary endstates.
-   *
-   * <p>Note 2: The final rotation of the robot will be set to the rotation of
-   * the final pose in the trajectory. The robot will not follow the rotations
-   * from the poses at each timestep. If alternate rotation behavior is desired,
-   * the other constructor with a supplier for rotation should be used.
-   *
-   * @param trajectory      The trajectory to follow.
-   * @param pose            A function that supplies the robot pose,
-   *                        provided by the odometry class.
-   * @param kinematics      The kinematics for the robot drivetrain.
-   * @param controller      The HolonomicDriveController for the drivetrain.
-   * @param output          The raw output module states from the
-   *                        position controllers.
-   * @param requirements    The subsystems to require.
-   */
-  SwerveControllerCommand(
-      frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-      frc::SwerveDriveKinematics<NumModules> kinematics,
-      frc::HolonomicDriveController controller,
-      std::function<void(std::array<frc::SwerveModuleState, NumModules>)>
-          output,
-      std::span<Subsystem* const> requirements = {});
+      Requirements requirements = {});
 
   void Initialize() override;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SwerveControllerCommand.inc
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SwerveControllerCommand.inc
@@ -20,7 +20,7 @@ SwerveControllerCommand<NumModules>::SwerveControllerCommand(
     frc::ProfiledPIDController<units::radians> thetaController,
     std::function<frc::Rotation2d()> desiredRotation,
     std::function<void(std::array<frc::SwerveModuleState, NumModules>)> output,
-    std::initializer_list<Subsystem*> requirements)
+    Requirements requirements)
     : m_trajectory(std::move(trajectory)),
       m_pose(std::move(pose)),
       m_kinematics(kinematics),
@@ -37,41 +37,7 @@ SwerveControllerCommand<NumModules>::SwerveControllerCommand(
     frc::PIDController xController, frc::PIDController yController,
     frc::ProfiledPIDController<units::radians> thetaController,
     std::function<void(std::array<frc::SwerveModuleState, NumModules>)> output,
-    std::initializer_list<Subsystem*> requirements)
-    : m_trajectory(std::move(trajectory)),
-      m_pose(std::move(pose)),
-      m_kinematics(kinematics),
-      m_controller(xController, yController, thetaController),
-      m_outputStates(output) {
-  this->AddRequirements(requirements);
-}
-
-template <size_t NumModules>
-SwerveControllerCommand<NumModules>::SwerveControllerCommand(
-    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::SwerveDriveKinematics<NumModules> kinematics,
-    frc::PIDController xController, frc::PIDController yController,
-    frc::ProfiledPIDController<units::radians> thetaController,
-    std::function<frc::Rotation2d()> desiredRotation,
-    std::function<void(std::array<frc::SwerveModuleState, NumModules>)> output,
-    std::span<Subsystem* const> requirements)
-    : m_trajectory(std::move(trajectory)),
-      m_pose(std::move(pose)),
-      m_kinematics(kinematics),
-      m_controller(xController, yController, thetaController),
-      m_desiredRotation(std::move(desiredRotation)),
-      m_outputStates(output) {
-  this->AddRequirements(requirements);
-}
-
-template <size_t NumModules>
-SwerveControllerCommand<NumModules>::SwerveControllerCommand(
-    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::SwerveDriveKinematics<NumModules> kinematics,
-    frc::PIDController xController, frc::PIDController yController,
-    frc::ProfiledPIDController<units::radians> thetaController,
-    std::function<void(std::array<frc::SwerveModuleState, NumModules>)> output,
-    std::span<Subsystem* const> requirements)
+    Requirements requirements)
     : m_trajectory(std::move(trajectory)),
       m_pose(std::move(pose)),
       m_kinematics(kinematics),
@@ -87,7 +53,7 @@ SwerveControllerCommand<NumModules>::SwerveControllerCommand(
     frc::HolonomicDriveController controller,
     std::function<frc::Rotation2d()> desiredRotation,
     std::function<void(std::array<frc::SwerveModuleState, NumModules>)> output,
-    std::initializer_list<Subsystem*> requirements)
+    Requirements requirements)
     : m_trajectory(std::move(trajectory)),
       m_pose(std::move(pose)),
       m_kinematics(kinematics),
@@ -103,39 +69,7 @@ SwerveControllerCommand<NumModules>::SwerveControllerCommand(
     frc::SwerveDriveKinematics<NumModules> kinematics,
     frc::HolonomicDriveController controller,
     std::function<void(std::array<frc::SwerveModuleState, NumModules>)> output,
-    std::initializer_list<Subsystem*> requirements)
-    : m_trajectory(std::move(trajectory)),
-      m_pose(std::move(pose)),
-      m_kinematics(kinematics),
-      m_controller(std::move(controller)),
-      m_outputStates(output) {
-  this->AddRequirements(requirements);
-}
-
-template <size_t NumModules>
-SwerveControllerCommand<NumModules>::SwerveControllerCommand(
-    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::SwerveDriveKinematics<NumModules> kinematics,
-    frc::HolonomicDriveController controller,
-    std::function<frc::Rotation2d()> desiredRotation,
-    std::function<void(std::array<frc::SwerveModuleState, NumModules>)> output,
-    std::span<Subsystem* const> requirements)
-    : m_trajectory(std::move(trajectory)),
-      m_pose(std::move(pose)),
-      m_kinematics(kinematics),
-      m_controller(std::move(controller)),
-      m_desiredRotation(std::move(desiredRotation)),
-      m_outputStates(output) {
-  this->AddRequirements(requirements);
-}
-
-template <size_t NumModules>
-SwerveControllerCommand<NumModules>::SwerveControllerCommand(
-    frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::SwerveDriveKinematics<NumModules> kinematics,
-    frc::HolonomicDriveController controller,
-    std::function<void(std::array<frc::SwerveModuleState, NumModules>)> output,
-    std::span<Subsystem* const> requirements)
+    Requirements requirements)
     : m_trajectory(std::move(trajectory)),
       m_pose(std::move(pose)),
       m_kinematics(kinematics),

--- a/wpilibNewCommands/src/main/native/include/frc2/command/TrapezoidProfileCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/TrapezoidProfileCommand.h
@@ -47,30 +47,7 @@ class TrapezoidProfileCommand
                           std::function<void(State)> output,
                           std::function<State()> goal,
                           std::function<State()> currentState,
-                          std::initializer_list<Subsystem*> requirements)
-      : m_profile(profile),
-        m_output(output),
-        m_goal(goal),
-        m_currentState(currentState) {
-    this->AddRequirements(requirements);
-    m_newAPI = true;
-  }
-
-  /**
-   * Creates a new TrapezoidProfileCommand that will execute the given
-   * TrapezoidalProfile. Output will be piped to the provided consumer function.
-   *
-   * @param profile      The motion profile to execute.
-   * @param output       The consumer for the profile output.
-   * @param goal The supplier for the desired state
-   * @param currentState The current state
-   * @param requirements The list of requirements.
-   */
-  TrapezoidProfileCommand(frc::TrapezoidProfile<Distance> profile,
-                          std::function<void(State)> output,
-                          std::function<State()> goal,
-                          std::function<State()> currentState,
-                          std::span<Subsystem* const> requirements = {})
+                          Requirements requirements = {})
       : m_profile(profile),
         m_output(output),
         m_goal(goal),
@@ -94,28 +71,7 @@ class TrapezoidProfileCommand
       "current state. This allows you to change goals at runtime.")
   TrapezoidProfileCommand(frc::TrapezoidProfile<Distance> profile,
                           std::function<void(State)> output,
-                          std::initializer_list<Subsystem*> requirements)
-      : m_profile(profile), m_output(output) {
-    this->AddRequirements(requirements);
-    m_newAPI = false;
-  }
-
-  /**
-   * Creates a new TrapezoidProfileCommand that will execute the given
-   * TrapezoidalProfile. Output will be piped to the provided consumer function.
-   *
-   * @param profile      The motion profile to execute.
-   * @param output       The consumer for the profile output.
-   * @param requirements The list of requirements.
-   * @deprecated The new constructor allows you to pass in a supplier for
-   * desired and current state. This allows you to change goals at runtime.
-   */
-  WPI_DEPRECATED(
-      "The new constructor allows you to pass in a supplier for desired and "
-      "current state. This allows you to change goals at runtime.")
-  TrapezoidProfileCommand(frc::TrapezoidProfile<Distance> profile,
-                          std::function<void(State)> output,
-                          std::span<Subsystem* const> requirements = {})
+                          Requirements requirements = {})
       : m_profile(profile), m_output(output) {
     this->AddRequirements(requirements);
     m_newAPI = false;

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/AddRequirementsTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/AddRequirementsTest.cpp
@@ -1,0 +1,144 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include <wpi/array.h>
+
+#include "CommandTestBase.h"
+#include "frc2/command/Command.h"
+#include "frc2/command/RunCommand.h"
+
+using namespace frc2;
+
+// Class to verify the overload resolution of Command::AddRequirements. This
+// does not derive from Command because AddRequirements is non-virtual,
+// preventing overriding anyways.
+class MockAddRequirements {
+ public:
+  MOCK_METHOD(void, AddRequirements, (Requirements), ());
+  MOCK_METHOD(void, AddRequirements, ((wpi::SmallSet<Subsystem*, 4>)), ());
+  MOCK_METHOD(void, AddRequirements, (Subsystem*), ());
+};
+
+TEST(AddRequirementsTest, InitializerListOverloadResolution) {
+  TestSubsystem requirement;
+
+  MockAddRequirements overloadResolver;
+
+  EXPECT_CALL(overloadResolver, AddRequirements(testing::An<Requirements>()));
+
+  overloadResolver.AddRequirements({&requirement, &requirement});
+}
+
+TEST(AddRequirementsTest, SpanOverloadResolution) {
+  std::span<Subsystem* const> requirementsSpan;
+
+  MockAddRequirements overloadResolver;
+
+  EXPECT_CALL(overloadResolver, AddRequirements(testing::An<Requirements>()));
+
+  overloadResolver.AddRequirements(requirementsSpan);
+}
+
+TEST(AddRequirementsTest, SmallSetOverloadResolution) {
+  wpi::SmallSet<Subsystem*, 4> requirementsSet;
+
+  MockAddRequirements overloadResolver;
+
+  EXPECT_CALL(overloadResolver,
+              AddRequirements(testing::An<wpi::SmallSet<Subsystem*, 4>>()));
+
+  overloadResolver.AddRequirements(requirementsSet);
+}
+
+TEST(AddRequirementsTest, SubsystemOverloadResolution) {
+  TestSubsystem requirement;
+
+  MockAddRequirements overloadResolver;
+
+  EXPECT_CALL(overloadResolver, AddRequirements(testing::An<Subsystem*>()));
+
+  overloadResolver.AddRequirements(&requirement);
+}
+
+TEST(AddRequirementsTest, InitializerListSemantics) {
+  TestSubsystem requirement1;
+  TestSubsystem requirement2;
+
+  RunCommand command([] {});
+  command.AddRequirements({&requirement1, &requirement2});
+  EXPECT_TRUE(command.HasRequirement(&requirement1));
+  EXPECT_TRUE(command.HasRequirement(&requirement2));
+  EXPECT_EQ(command.GetRequirements().size(), 2u);
+}
+
+TEST(AddRequirementsTest, InitializerListDuplicatesSemantics) {
+  TestSubsystem requirement;
+
+  RunCommand command([] {});
+  command.AddRequirements({&requirement, &requirement});
+  EXPECT_TRUE(command.HasRequirement(&requirement));
+  EXPECT_EQ(command.GetRequirements().size(), 1u);
+}
+
+TEST(AddRequirementsTest, SpanSemantics) {
+  TestSubsystem requirement1;
+  TestSubsystem requirement2;
+
+  wpi::array<Subsystem* const, 2> requirementsArray(&requirement1,
+                                                    &requirement2);
+
+  RunCommand command([] {});
+  command.AddRequirements(std::span{requirementsArray});
+  EXPECT_TRUE(command.HasRequirement(&requirement1));
+  EXPECT_TRUE(command.HasRequirement(&requirement2));
+  EXPECT_EQ(command.GetRequirements().size(), 2u);
+}
+
+TEST(AddRequirementsTest, SpanDuplicatesSemantics) {
+  TestSubsystem requirement;
+
+  wpi::array<Subsystem* const, 2> requirementsArray(&requirement, &requirement);
+
+  RunCommand command([] {});
+  command.AddRequirements(std::span{requirementsArray});
+  EXPECT_TRUE(command.HasRequirement(&requirement));
+  EXPECT_EQ(command.GetRequirements().size(), 1u);
+}
+
+TEST(AddRequirementsTest, SmallSetSemantics) {
+  TestSubsystem requirement1;
+  TestSubsystem requirement2;
+
+  wpi::SmallSet<Subsystem*, 4> requirementsSet;
+  requirementsSet.insert(&requirement1);
+  requirementsSet.insert(&requirement2);
+
+  RunCommand command([] {});
+  command.AddRequirements(requirementsSet);
+  EXPECT_TRUE(command.HasRequirement(&requirement1));
+  EXPECT_TRUE(command.HasRequirement(&requirement2));
+  EXPECT_EQ(command.GetRequirements().size(), 2u);
+}
+
+TEST(AddRequirementsTest, SubsystemPointerSemantics) {
+  TestSubsystem requirement1;
+  TestSubsystem requirement2;
+
+  RunCommand command([] {});
+  command.AddRequirements(&requirement1);
+  command.AddRequirements(&requirement2);
+  EXPECT_TRUE(command.HasRequirement(&requirement1));
+  EXPECT_TRUE(command.HasRequirement(&requirement2));
+  EXPECT_EQ(command.GetRequirements().size(), 2u);
+}
+
+TEST(AddRequirementsTest, SubsystemPointerDuplicatesSemantics) {
+  TestSubsystem requirement;
+
+  RunCommand command([] {});
+  command.AddRequirements(&requirement);
+  command.AddRequirements(&requirement);
+  EXPECT_TRUE(command.HasRequirement(&requirement));
+  EXPECT_EQ(command.GetRequirements().size(), 1u);
+}

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/CloseClaw.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/CloseClaw.cpp
@@ -8,7 +8,7 @@
 
 CloseClaw::CloseClaw(Claw& claw) : m_claw(&claw) {
   SetName("CloseClaw");
-  AddRequirements({m_claw});
+  AddRequirements(m_claw);
 }
 
 // Called just before this Command runs the first time

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/OpenClaw.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/OpenClaw.cpp
@@ -9,7 +9,7 @@
 OpenClaw::OpenClaw(Claw& claw)
     : frc2::CommandHelper<frc2::WaitCommand, OpenClaw>(1_s), m_claw(&claw) {
   SetName("OpenClaw");
-  AddRequirements({m_claw});
+  AddRequirements(m_claw);
 }
 
 // Called just before this Command runs the first time

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetElevatorSetpoint.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetElevatorSetpoint.cpp
@@ -11,7 +11,7 @@
 SetElevatorSetpoint::SetElevatorSetpoint(double setpoint, Elevator& elevator)
     : m_setpoint(setpoint), m_elevator(&elevator) {
   SetName("SetElevatorSetpoint");
-  AddRequirements({m_elevator});
+  AddRequirements(m_elevator);
 }
 
 // Called just before this Command runs the first time

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetWristSetpoint.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetWristSetpoint.cpp
@@ -9,7 +9,7 @@
 SetWristSetpoint::SetWristSetpoint(double setpoint, Wrist& wrist)
     : m_setpoint(setpoint), m_wrist(&wrist) {
   SetName("SetWristSetpoint");
-  AddRequirements({m_wrist});
+  AddRequirements(m_wrist);
 }
 
 // Called just before this Command runs the first time

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/TankDrive.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/TankDrive.cpp
@@ -14,7 +14,7 @@ TankDrive::TankDrive(std::function<double()> left,
       m_right(std::move(right)),
       m_drivetrain(&drivetrain) {
   SetName("TankDrive");
-  AddRequirements({m_drivetrain});
+  AddRequirements(m_drivetrain);
 }
 
 // Called repeatedly when this Command is scheduled to run

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/commands/TurnToAngle.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/commands/TurnToAngle.cpp
@@ -25,7 +25,7 @@ TurnToAngle::TurnToAngle(units::degree_t target, DriveSubsystem* drive)
   // reference
   m_controller.SetTolerance(kTurnTolerance.value(), kTurnRateTolerance.value());
 
-  AddRequirements({drive});
+  AddRequirements(drive);
 }
 
 bool TurnToAngle::IsFinished() {

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/commands/TurnToAngleProfiled.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/commands/TurnToAngleProfiled.cpp
@@ -30,7 +30,7 @@ TurnToAngleProfiled::TurnToAngleProfiled(units::degree_t target,
   // reference
   GetController().SetTolerance(kTurnTolerance, kTurnRateTolerance);
 
-  AddRequirements({drive});
+  AddRequirements(drive);
 }
 
 bool TurnToAngleProfiled::IsFinished() {

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/commands/DefaultDrive.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/commands/DefaultDrive.cpp
@@ -12,7 +12,7 @@ DefaultDrive::DefaultDrive(DriveSubsystem* subsystem,
     : m_drive{subsystem},
       m_forward{std::move(forward)},
       m_rotation{std::move(rotation)} {
-  AddRequirements({subsystem});
+  AddRequirements(subsystem);
 }
 
 void DefaultDrive::Execute() {

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/commands/DriveDistance.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/commands/DriveDistance.cpp
@@ -9,7 +9,7 @@
 DriveDistance::DriveDistance(double inches, double speed,
                              DriveSubsystem* subsystem)
     : m_drive(subsystem), m_distance(inches), m_speed(speed) {
-  AddRequirements({subsystem});
+  AddRequirements(subsystem);
 }
 
 void DriveDistance::Initialize() {

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/commands/ReleaseHatch.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/cpp/commands/ReleaseHatch.cpp
@@ -5,7 +5,7 @@
 #include "commands/ReleaseHatch.h"
 
 ReleaseHatch::ReleaseHatch(HatchSubsystem* subsystem) : m_hatch(subsystem) {
-  AddRequirements({subsystem});
+  AddRequirements(subsystem);
 }
 
 void ReleaseHatch::Initialize() {

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/commands/TeleopArcadeDrive.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/cpp/commands/TeleopArcadeDrive.cpp
@@ -12,7 +12,7 @@ TeleopArcadeDrive::TeleopArcadeDrive(
     : m_drive{subsystem},
       m_xaxisSpeedSupplier{xaxisSpeedSupplier},
       m_zaxisRotateSupplier{zaxisRotateSuppplier} {
-  AddRequirements({subsystem});
+  AddRequirements(subsystem);
 }
 
 void TeleopArcadeDrive::Execute() {

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/include/commands/DriveDistance.h
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/include/commands/DriveDistance.h
@@ -14,7 +14,7 @@ class DriveDistance : public frc2::CommandHelper<frc2::Command, DriveDistance> {
  public:
   DriveDistance(double speed, units::meter_t distance, Drivetrain* drive)
       : m_speed(speed), m_distance(distance), m_drive(drive) {
-    AddRequirements({m_drive});
+    AddRequirements(m_drive);
   }
 
   void Initialize() override;

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/include/commands/DriveTime.h
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/include/commands/DriveTime.h
@@ -15,7 +15,7 @@ class DriveTime : public frc2::CommandHelper<frc2::Command, DriveTime> {
  public:
   DriveTime(double speed, units::second_t time, Drivetrain* drive)
       : m_speed(speed), m_duration(time), m_drive(drive) {
-    AddRequirements({m_drive});
+    AddRequirements(m_drive);
   }
 
   void Initialize() override;

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/include/commands/TurnDegrees.h
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/include/commands/TurnDegrees.h
@@ -15,7 +15,7 @@ class TurnDegrees : public frc2::CommandHelper<frc2::Command, TurnDegrees> {
  public:
   TurnDegrees(double speed, units::degree_t angle, Drivetrain* drive)
       : m_speed(speed), m_angle(angle), m_drive(drive) {
-    AddRequirements({m_drive});
+    AddRequirements(m_drive);
   }
 
   void Initialize() override;

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/include/commands/TurnTime.h
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/include/commands/TurnTime.h
@@ -15,7 +15,7 @@ class TurnTime : public frc2::CommandHelper<frc2::Command, TurnTime> {
  public:
   TurnTime(double speed, units::second_t time, Drivetrain* drive)
       : m_speed(speed), m_duration(time), m_drive(drive) {
-    AddRequirements({m_drive});
+    AddRequirements(m_drive);
   }
 
   void Initialize() override;


### PR DESCRIPTION
Fixes #4793

Potential changes to user code:
* Because `AddRequirements({subsystemPointer})` now selects the `Subsystem*` overload instead of the initializer list (now Requirements struct) overload, it causes warnings about the redundant braces. Adding an overload taking `std::initializer_list` (which could defer to the Requirements overload) would fix this issue, but I don't know how important that use case is.
* Additionally, any code using implicit conversions from a type to `std::initializer_list` or `std::span` would also need to be written so at least one of those conversions is explicit. (For example, `AddRequirements(array)` no longer works, but `AddRequirements(Requirements{array})` or `AddRequirements({array})` do.)

Notes:
* The parameters don't need to keep prevent duplicates, so we can use `std::vector`. However, Mac 12 doesn't seem to support the constexpr `std::vector` constructors (see https://discord.com/channels/176186766946992128/1137101704127578236), so it's left non-constexpr for now. If there's a fix, though, we could always implement that.
* Currently, every copy of the `Requirements` struct also copies the vector, which I'm pretty sure copies the pointers to subsystems. This could lead to a lot of copies in nested calls, such as `cmd::RunOnce -> InstantCommand -> FunctionalCommand -> AddRequirements`. This isn't necessarily expensive, but we \*could\* avoid them by making the backing structure a span, at the cost of leading to bugs if the struct is initialized from an initializer list and we use the struct outside of the function call (e.g., store it in an instance variable which we access later).
* This currently uses implicit conversions, which are documented in the Requirements struct and AddRequirements, but the conversions can be made explicit if desired (or more documentation could be added).
* This kind of pattern (struct taking initializer list and span overloads) could be useful elsewhere- e.g., `CommandScheduler::RegisterSubsystems`, `CommandScheduler::Cancel`, and potentially other parts of wpilib- but I think changing those usages would be out of the scope of this PR.