### PR TITLE
Add getPath method to SendableBuilder

### DIFF
--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTable.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTable.java
@@ -439,7 +439,7 @@ public final class NetworkTable {
   }
 
   /**
-   * Get the path of the NetworkTable.
+   * Get the path of the NetworkTable. Does not include the trailing "/".
    *
    * @return The path of the NetworkTable.
    */

--- a/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SendableBuilderImpl.cpp
@@ -115,6 +115,10 @@ void SendableBuilderImpl::SetUpdateTable(wpi::unique_function<void()> func) {
   m_updateTables.emplace_back(std::move(func));
 }
 
+std::string_view SendableBuilderImpl::GetPath() const {
+  return m_table->GetPath();
+}
+
 nt::Topic SendableBuilderImpl::GetTopic(std::string_view key) {
   return m_table->GetTopic(key);
 }

--- a/wpilibc/src/main/native/include/frc/smartdashboard/SendableBuilderImpl.h
+++ b/wpilibc/src/main/native/include/frc/smartdashboard/SendableBuilderImpl.h
@@ -37,6 +37,12 @@ class SendableBuilderImpl : public nt::NTSendableBuilder {
   void SetTable(std::shared_ptr<nt::NetworkTable> table);
 
   /**
+   * Gets the path where properties will be published.
+   * @return The path
+   */
+  std::string_view GetPath() const override;
+
+  /**
    * Get the network table.
    * @return The network table
    */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
@@ -153,6 +153,11 @@ public class SendableBuilderImpl implements NTSendableBuilder {
     return m_table;
   }
 
+  @Override
+  public String getPath() {
+      return m_table.getPath();
+  }
+
   /**
    * Return whether this sendable has an associated table.
    *

--- a/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableBuilder.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableBuilder.java
@@ -148,6 +148,12 @@ public interface SendableBuilder extends AutoCloseable {
       String key, String typeString, Supplier<byte[]> getter, Consumer<byte[]> setter);
 
   /**
+   * Gets the path where properties will be published.
+   * @return The path
+   */
+  String getPath();
+
+  /**
    * Gets the kind of backend being used.
    *
    * @return Backend kind

--- a/wpiutil/src/main/native/include/wpi/sendable/SendableBuilder.h
+++ b/wpiutil/src/main/native/include/wpi/sendable/SendableBuilder.h
@@ -265,6 +265,12 @@ class SendableBuilder {
       std::function<void(std::span<const uint8_t>)> setter) = 0;
 
   /**
+   * Gets the path where properties will be published.
+   * @return The path
+   */
+  virtual std::string_view GetPath() const = 0;
+
+  /**
    * Gets the kind of backend being used.
    *
    * @return Backend kind


### PR DESCRIPTION
Designed to be equivalent to `NTSendable`'s `getTopic`, but backend agnostic. It returns a string representation of the path where the properties will be placed, e.g. `/Epochs/Scheduler` or `/SmartDashboard/Scheduler/Epochs`. This allows for topics to be dynamically created. The implementing class would call `getPath` in `initSendable` and store the path in a member variable (actually two, one for NT and another for DataLog), and would use it with NT publishers and DataLog to publish values. It would be up to the implementing class to support all backends (I don't think delegating dynamic topics to `SendableBuilder` is the right path). Unblocks #5375.