### PR TITLE
Remove all dependencies on SendableRegistry

### DIFF
--- a/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
+++ b/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
@@ -4,12 +4,16 @@
 
 #include "frc/livewindow/LiveWindow.h"
 
+#include <fmt/format.h>
 #include <networktables/BooleanTopic.h>
 #include <networktables/NetworkTable.h>
 #include <networktables/NetworkTableInstance.h>
 #include <networktables/StringTopic.h>
+#include <wpi/DenseMap.h>
+#include <wpi/UidVector.h>
 #include <wpi/mutex.h>
 #include <wpi/sendable/Sendable.h>
+#include <wpi/sendable/SendableBuilder.h>
 #include <wpi/sendable/SendableRegistry.h>
 
 #include "frc/smartdashboard/SendableBuilderImpl.h"
@@ -18,10 +22,23 @@ using namespace frc;
 
 namespace {
 struct Component {
+  wpi::Sendable* sendable = nullptr;
+  std::unique_ptr<wpi::SendableBuilder> builder;
+  std::string name;
+  std::string subsystem = "Ungrouped";
+  wpi::Sendable* parent = nullptr;
   bool firstTime = true;
   bool telemetryEnabled = false;
   nt::StringPublisher namePub;
   nt::StringPublisher typePub;
+
+  void SetName(std::string_view moduleType, int channel) {
+    name = fmt::format("{}[{}]", moduleType, channel);
+  }
+
+  void SetName(std::string_view moduleType, int moduleNumber, int channel) {
+    name = fmt::format("{}[{},{}]", moduleType, moduleNumber, channel);
+  }
 };
 
 struct Instance {
@@ -42,6 +59,8 @@ struct Instance {
   nt::BooleanPublisher enabledPub =
       statusTable->GetBooleanTopic("LW Enabled").Publish();
 
+  wpi::UidVector<std::unique_ptr<Component>, 32> components;
+  wpi::DenseMap<void*, LiveWindow::UID> componentMap;
   bool startLiveWindow = false;
   bool liveWindowEnabled = false;
   bool telemetryEnabled = false;
@@ -49,7 +68,7 @@ struct Instance {
   std::function<void()> enabled;
   std::function<void()> disabled;
 
-  std::shared_ptr<Component> GetOrAdd(wpi::Sendable* sendable);
+  Component& GetOrAdd(void* sendable);
 };
 }  // namespace
 
@@ -70,14 +89,189 @@ void ResetLiveWindow() {
 }  // namespace frc::impl
 #endif
 
-std::shared_ptr<Component> Instance::GetOrAdd(wpi::Sendable* sendable) {
-  auto data = std::static_pointer_cast<Component>(
-      wpi::SendableRegistry::GetData(sendable, dataHandle));
-  if (!data) {
-    data = std::make_shared<Component>();
-    wpi::SendableRegistry::SetData(sendable, dataHandle, data);
+Component& Instance::GetOrAdd(void* sendable) {
+  LiveWindow::UID& compUid = componentMap[sendable];
+  if (compUid == 0) {
+    compUid = components.emplace_back(std::make_unique<Component>()) + 1;
   }
-  return data;
+  return *components[compUid - 1];
+}
+
+void LiveWindow::AddLW(wpi::Sendable* sendable, std::string_view name) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto& comp = inst.GetOrAdd(sendable);
+  comp.sendable = sendable;
+  comp.name = name;
+}
+
+void LiveWindow::AddLW(wpi::Sendable* sendable, std::string_view moduleType,
+                       int channel) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto& comp = inst.GetOrAdd(sendable);
+  comp.sendable = sendable;
+  comp.SetName(moduleType, channel);
+}
+
+void LiveWindow::AddLW(wpi::Sendable* sendable, std::string_view moduleType,
+                       int moduleNumber, int channel) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto& comp = inst.GetOrAdd(sendable);
+  comp.sendable = sendable;
+  comp.SetName(moduleType, moduleNumber, channel);
+}
+
+void LiveWindow::AddLW(wpi::Sendable* sendable, std::string_view subsystem,
+                       std::string_view name) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto& comp = inst.GetOrAdd(sendable);
+  comp.sendable = sendable;
+  comp.name = name;
+  comp.subsystem = subsystem;
+}
+
+void LiveWindow::AddChild(wpi::Sendable* parent, wpi::Sendable* child) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto& comp = inst.GetOrAdd(child);
+  comp.parent = parent;
+}
+
+void LiveWindow::AddChild(wpi::Sendable* parent, void* child) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto& comp = inst.GetOrAdd(child);
+  comp.parent = parent;
+}
+
+bool LiveWindow::Remove(wpi::Sendable* sendable) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto it = inst.componentMap.find(sendable);
+  if (it == inst.componentMap.end()) {
+    return false;
+  }
+  UID compUid = it->getSecond();
+  inst.components.erase(compUid - 1);
+  inst.componentMap.erase(it);
+  // update any parent pointers
+  for (auto&& comp : inst.components) {
+    if (comp->parent == sendable) {
+      comp->parent = nullptr;
+    }
+  }
+  return true;
+}
+
+void LiveWindow::Move(wpi::Sendable* to, wpi::Sendable* from) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto it = inst.componentMap.find(from);
+  if (it == inst.componentMap.end() || !inst.components[it->getSecond() - 1]) {
+    return;
+  }
+  UID compUid = it->getSecond();
+  inst.componentMap.erase(it);
+  inst.componentMap[to] = compUid;
+  auto& comp = *inst.components[compUid - 1];
+  comp.sendable = to;
+  if (comp.builder && comp.builder->IsPublished()) {
+    // rebuild builder, as lambda captures can point to "from"
+    comp.builder->ClearProperties();
+    to->InitSendable(*comp.builder);
+  }
+  // update any parent pointers
+  for (auto&& comp : inst.components) {
+    if (comp->parent == from) {
+      comp->parent = to;
+    }
+  }
+}
+
+bool LiveWindow::Contains(const wpi::Sendable* sendable) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  return inst.componentMap.count(sendable) != 0;
+}
+
+std::string LiveWindow::GetName(const wpi::Sendable* sendable) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto it = inst.componentMap.find(sendable);
+  if (it == inst.componentMap.end() || !inst.components[it->getSecond() - 1]) {
+    return {};
+  }
+  return inst.components[it->getSecond() - 1]->name;
+}
+
+void LiveWindow::SetName(wpi::Sendable* sendable, std::string_view name) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto it = inst.componentMap.find(sendable);
+  if (it == inst.componentMap.end() || !inst.components[it->getSecond() - 1]) {
+    return;
+  }
+  inst.components[it->getSecond() - 1]->name = name;
+}
+
+void LiveWindow::SetName(wpi::Sendable* sendable, std::string_view moduleType,
+                         int channel) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto it = inst.componentMap.find(sendable);
+  if (it == inst.componentMap.end() || !inst.components[it->getSecond() - 1]) {
+    return;
+  }
+  inst.components[it->getSecond() - 1]->SetName(moduleType, channel);
+}
+
+void LiveWindow::SetName(wpi::Sendable* sendable, std::string_view moduleType,
+                         int moduleNumber, int channel) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto it = inst.componentMap.find(sendable);
+  if (it == inst.componentMap.end() || !inst.components[it->getSecond() - 1]) {
+    return;
+  }
+  inst.components[it->getSecond() - 1]->SetName(moduleType, moduleNumber,
+                                                channel);
+}
+
+void LiveWindow::SetName(wpi::Sendable* sendable, std::string_view subsystem,
+                         std::string_view name) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto it = inst.componentMap.find(sendable);
+  if (it == inst.componentMap.end() || !inst.components[it->getSecond() - 1]) {
+    return;
+  }
+  auto& comp = *inst.components[it->getSecond() - 1];
+  comp.name = name;
+  comp.subsystem = subsystem;
+}
+
+std::string LiveWindow::GetSubsystem(const wpi::Sendable* sendable) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto it = inst.componentMap.find(sendable);
+  if (it == inst.componentMap.end() || !inst.components[it->getSecond() - 1]) {
+    return {};
+  }
+  return inst.components[it->getSecond() - 1]->subsystem;
+}
+
+void LiveWindow::SetSubsystem(wpi::Sendable* sendable,
+                              std::string_view subsystem) {
+  auto& inst = GetInstance();
+  std::scoped_lock lock(inst.mutex);
+  auto it = inst.componentMap.find(sendable);
+  if (it == inst.componentMap.end() || !inst.components[it->getSecond() - 1]) {
+    return;
+  }
+  inst.components[it->getSecond() - 1]->subsystem = subsystem;
 }
 
 void LiveWindow::SetEnabledCallback(std::function<void()> func) {
@@ -93,37 +287,31 @@ void LiveWindow::EnableTelemetry(wpi::Sendable* sendable) {
   std::scoped_lock lock(inst.mutex);
   // Re-enable global setting in case DisableAllTelemetry() was called.
   inst.telemetryEnabled = true;
-  inst.GetOrAdd(sendable)->telemetryEnabled = true;
+  inst.GetOrAdd(sendable).telemetryEnabled = true;
 }
 
 void LiveWindow::DisableTelemetry(wpi::Sendable* sendable) {
   auto& inst = ::GetInstance();
   std::scoped_lock lock(inst.mutex);
-  inst.GetOrAdd(sendable)->telemetryEnabled = false;
+  inst.GetOrAdd(sendable).telemetryEnabled = false;
 }
 
 void LiveWindow::DisableAllTelemetry() {
   auto& inst = ::GetInstance();
   std::scoped_lock lock(inst.mutex);
   inst.telemetryEnabled = false;
-  wpi::SendableRegistry::ForeachLiveWindow(inst.dataHandle, [&](auto& cbdata) {
-    if (!cbdata.data) {
-      cbdata.data = std::make_shared<Component>();
-    }
-    std::static_pointer_cast<Component>(cbdata.data)->telemetryEnabled = false;
-  });
+  for (auto& comp : inst.components) {
+    comp->telemetryEnabled = false;
+  }
 }
 
 void LiveWindow::EnableAllTelemetry() {
   auto& inst = ::GetInstance();
   std::scoped_lock lock(inst.mutex);
   inst.telemetryEnabled = true;
-  wpi::SendableRegistry::ForeachLiveWindow(inst.dataHandle, [&](auto& cbdata) {
-    if (!cbdata.data) {
-      cbdata.data = std::make_shared<Component>();
-    }
-    std::static_pointer_cast<Component>(cbdata.data)->telemetryEnabled = true;
-  });
+  for (auto& comp : inst.components) {
+    comp->telemetryEnabled = true;
+  }
 }
 
 bool LiveWindow::IsEnabled() {
@@ -147,11 +335,10 @@ void LiveWindow::SetEnabled(bool enabled) {
       inst.enabled();
     }
   } else {
-    wpi::SendableRegistry::ForeachLiveWindow(
-        inst.dataHandle, [&](auto& cbdata) {
-          static_cast<SendableBuilderImpl&>(cbdata.builder)
-              .StopLiveWindowMode();
-        });
+    for (auto& comp : inst.components) {
+      static_cast<SendableBuilderImpl*>(comp->builder.get())
+          ->StopLiveWindowMode();
+    }
     if (inst.disabled) {
       inst.disabled();
     }
@@ -172,52 +359,46 @@ void LiveWindow::UpdateValuesUnsafe() {
     return;
   }
 
-  wpi::SendableRegistry::ForeachLiveWindow(inst.dataHandle, [&](auto& cbdata) {
-    if (!cbdata.sendable || cbdata.parent) {
+  for (auto& comp : inst.components) {
+    if (!comp->sendable || comp->parent) {
+      return;
+    }
+    if (!inst.liveWindowEnabled && !comp->telemetryEnabled) {
       return;
     }
 
-    if (!cbdata.data) {
-      cbdata.data = std::make_shared<Component>();
-    }
-
-    auto& comp = *std::static_pointer_cast<Component>(cbdata.data);
-
-    if (!inst.liveWindowEnabled && !comp.telemetryEnabled) {
-      return;
-    }
-
-    if (comp.firstTime) {
+    if (comp->firstTime) {
       // By holding off creating the NetworkTable entries, it allows the
       // components to be redefined. This allows default sensor and actuator
       // values to be created that are replaced with the custom names from
       // users calling setName.
-      if (cbdata.name.empty()) {
+      if (comp->name.empty()) {
         return;
       }
-      auto ssTable = inst.liveWindowTable->GetSubTable(cbdata.subsystem);
+      auto ssTable = inst.liveWindowTable->GetSubTable(comp->subsystem);
       std::shared_ptr<nt::NetworkTable> table;
       // Treat name==subsystem as top level of subsystem
-      if (cbdata.name == cbdata.subsystem) {
+      if (comp->name == comp->subsystem) {
         table = ssTable;
       } else {
-        table = ssTable->GetSubTable(cbdata.name);
+        table = ssTable->GetSubTable(comp->name);
       }
-      comp.namePub = nt::StringTopic{table->GetTopic(".name")}.Publish();
-      comp.namePub.Set(cbdata.name);
-      static_cast<SendableBuilderImpl&>(cbdata.builder).SetTable(table);
-      cbdata.sendable->InitSendable(cbdata.builder);
-      comp.typePub = nt::StringTopic{ssTable->GetTopic(".type")}.Publish();
-      comp.typePub.Set("LW Subsystem");
+      comp->namePub = nt::StringTopic{table->GetTopic(".name")}.Publish();
+      comp->namePub.Set(comp->name);
+      static_cast<SendableBuilderImpl*>(comp->builder.get())->SetTable(table);
+      comp->sendable->InitSendable(*comp->builder);
+      comp->typePub = nt::StringTopic{ssTable->GetTopic(".type")}.Publish();
+      comp->typePub.Set("LW Subsystem");
 
-      comp.firstTime = false;
+      comp->firstTime = false;
     }
 
     if (inst.startLiveWindow) {
-      static_cast<SendableBuilderImpl&>(cbdata.builder).StartLiveWindowMode();
+      static_cast<SendableBuilderImpl*>(comp->builder.get())
+          ->StartLiveWindowMode();
     }
-    cbdata.builder.Update();
-  });
+    comp->builder->Update();
+  };
 
   inst.startLiveWindow = false;
 }

--- a/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
+++ b/wpilibc/src/main/native/cpp/livewindow/LiveWindow.cpp
@@ -398,7 +398,7 @@ void LiveWindow::UpdateValuesUnsafe() {
           ->StartLiveWindowMode();
     }
     comp->builder->Update();
-  };
+  }
 
   inst.startLiveWindow = false;
 }

--- a/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
+++ b/wpilibc/src/main/native/include/frc/livewindow/LiveWindow.h
@@ -5,7 +5,8 @@
 #pragma once
 
 #include <functional>
-
+#include <string>
+#include <string_view>
 namespace wpi {
 class Sendable;
 }  // namespace wpi
@@ -18,6 +19,155 @@ namespace frc {
  */
 class LiveWindow final {
  public:
+   using UID = size_t;
+  /**
+   * Adds an object to LiveWindow.
+   *
+   * @param sendable Object to add
+   * @param name Component name
+   */
+  static void AddLW(wpi::Sendable* sendable, std::string_view name);
+
+  /**
+   * Adds an object to LiveWindow.
+   *
+   * @param sendable     Object to add
+   * @param moduleType   A string that defines the module name in the label for
+   *                     the value
+   * @param channel      The channel number the device is plugged into
+   */
+  static void AddLW(wpi::Sendable* sendable, std::string_view moduleType,
+                    int channel);
+
+  /**
+   * Adds an object to LiveWindow.
+   *
+   * @param sendable     Object to add
+   * @param moduleType   A string that defines the module name in the label for
+   *                     the value
+   * @param moduleNumber The number of the particular module type
+   * @param channel      The channel number the device is plugged into
+   */
+  static void AddLW(wpi::Sendable* sendable, std::string_view moduleType,
+                    int moduleNumber, int channel);
+
+  /**
+   * Adds an object to LiveWindow.
+   *
+   * @param sendable Object to add
+   * @param subsystem Subsystem name
+   * @param name Component name
+   */
+  static void AddLW(wpi::Sendable* sendable, std::string_view subsystem,
+                    std::string_view name);
+
+  /**
+   * Adds a child object to an object.  Adds the child object to LiveWindow
+   * if it's not already present.
+   *
+   * @param parent Parent object
+   * @param child Child object
+   */
+  static void AddChild(wpi::Sendable* parent, wpi::Sendable* child);
+
+  /**
+   * Adds a child object to an object.  Adds the child object to LiveWindow
+   * if it's not already present.
+   *
+   * @param parent Parent object
+   * @param child Child object
+   */
+  static void AddChild(wpi::Sendable* parent, void* child);
+
+  /**
+   * Removes an object from LiveWindow.
+   *
+   * @param sendable Object to remove
+   * @return True if the object was removed; false if it was not present
+   */
+  static bool Remove(wpi::Sendable* sendable);
+
+  /**
+   * Moves an object in LiveWindow (for use in move constructors/assignments).
+   *
+   * @param to New object
+   * @param from Old object
+   */
+  static void Move(wpi::Sendable* to, wpi::Sendable* from);
+
+  /**
+   * Determines if an object is in LiveWindow.
+   *
+   * @param sendable object to check
+   * @return True if in LiveWindow, false if not.
+   */
+  static bool Contains(const wpi::Sendable* sendable);
+
+  /**
+   * Gets the name of an object.
+   *
+   * @param sendable Object
+   * @return Name (empty if object is not in LiveWindow)
+   */
+  static std::string GetName(const wpi::Sendable* sendable);
+
+  /**
+   * Sets the name of an object.
+   *
+   * @param sendable Object
+   * @param name Name
+   */
+  static void SetName(wpi::Sendable* sendable, std::string_view name);
+
+  /**
+   * Sets the name of an object with a channel number.
+   *
+   * @param sendable   Object
+   * @param moduleType A string that defines the module name in the label for
+   *                   the value
+   * @param channel    The channel number the device is plugged into
+   */
+  static void SetName(wpi::Sendable* sendable, std::string_view moduleType,
+                      int channel);
+
+  /**
+   * Sets the name of an object with a module and channel number.
+   *
+   * @param sendable     Object
+   * @param moduleType   A string that defines the module name in the label for
+   *                     the value
+   * @param moduleNumber The number of the particular module type
+   * @param channel      The channel number the device is plugged into
+   */
+  static void SetName(wpi::Sendable* sendable, std::string_view moduleType,
+                      int moduleNumber, int channel);
+
+  /**
+   * Sets both the subsystem name and device name of an object.
+   *
+   * @param sendable Object
+   * @param subsystem Subsystem name
+   * @param name Device name
+   */
+  static void SetName(wpi::Sendable* sendable, std::string_view subsystem,
+                      std::string_view name);
+
+  /**
+   * Gets the subsystem name of an object.
+   *
+   * @param sendable Object
+   * @return Subsystem name (empty if object is not in LiveWindow)
+   */
+  static std::string GetSubsystem(const wpi::Sendable* sendable);
+
+  /**
+   * Sets the subsystem name of an object.
+   *
+   * @param sendable Object
+   * @param subsystem Subsystem name
+   */
+  static void SetSubsystem(wpi::Sendable* sendable, std::string_view subsystem);
+
   /**
    * Set function to be called when LiveWindow is enabled.
    *

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -10,16 +10,26 @@ import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StringPublisher;
 import edu.wpi.first.networktables.StringTopic;
 import edu.wpi.first.util.sendable.Sendable;
-import edu.wpi.first.util.sendable.SendableRegistry;
+import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.wpilibj.smartdashboard.SendableBuilderImpl;
+import java.lang.ref.WeakReference;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * The LiveWindow class is the public interface for putting sensors and actuators on the LiveWindow.
  */
 public final class LiveWindow {
   private static class Component implements AutoCloseable {
+    Component() {}
+
+    Component(Sendable sendable) {
+      m_sendable = new WeakReference<>(sendable);
+    }
+
     @Override
-    public void close() {
+    public void close() throws Exception {
+      m_builder.close();
       if (m_namePub != null) {
         m_namePub.close();
         m_namePub = null;
@@ -30,18 +40,31 @@ public final class LiveWindow {
       }
     }
 
+    WeakReference<Sendable> m_sendable;
+    SendableBuilder m_builder;
+    String m_name;
+    String m_subsystem = "Ungrouped";
+    WeakReference<Sendable> m_parent;
     boolean m_firstTime = true;
     boolean m_telemetryEnabled;
     StringPublisher m_namePub;
     StringPublisher m_typePub;
+
+    void setName(String moduleType, int channel) {
+      m_name = moduleType + "[" + channel + "]";
+    }
+
+    void setName(String moduleType, int moduleNumber, int channel) {
+      m_name = moduleType + "[" + moduleNumber + "," + channel + "]";
+    }
   }
 
-  private static final int dataHandle = SendableRegistry.getDataHandle();
   private static final NetworkTable liveWindowTable =
       NetworkTableInstance.getDefault().getTable("LiveWindow");
   private static final NetworkTable statusTable = liveWindowTable.getSubTable(".status");
   private static final BooleanPublisher enabledPub =
       statusTable.getBooleanTopic("LW Enabled").publish();
+  private static final Map<Object, Component> components = new WeakHashMap<>();
   private static boolean startLiveWindow;
   private static boolean liveWindowEnabled;
   private static boolean telemetryEnabled;
@@ -50,33 +73,250 @@ public final class LiveWindow {
   private static Runnable disabledListener;
 
   static {
-    SendableRegistry.setLiveWindowBuilderFactory(() -> new SendableBuilderImpl());
     enabledPub.set(false);
   }
 
   private static Component getOrAdd(Sendable sendable) {
-    Component data = (Component) SendableRegistry.getData(sendable, dataHandle);
-    if (data == null) {
-      data = new Component();
-      SendableRegistry.setData(sendable, dataHandle, data);
+    Component comp = components.get(sendable);
+    if (comp == null) {
+      comp = new Component(sendable);
+      components.put(sendable, comp);
+    } else {
+      if (comp.m_sendable == null) {
+        comp.m_sendable = new WeakReference<>(sendable);
+      }
     }
-    return data;
+    return comp;
   }
 
   private LiveWindow() {
     throw new UnsupportedOperationException("This is a utility class!");
   }
 
-  public static synchronized void setEnabledListener(Runnable runnable) {
-    enabledListener = runnable;
+  /**
+   * Adds an object to LiveWindow.
+   *
+   * @param sendable Object to add
+   * @param name Component name
+   */
+  public static synchronized void add(Sendable sendable, String name) {
+    Component comp = getOrAdd(sendable);
+    if (comp.m_builder != null) {
+      try {
+        comp.m_builder.close();
+      } catch (Exception e) {
+        // ignore
+      }
+    }
+    comp.m_builder = new SendableBuilderImpl();
+    comp.m_name = name;
   }
 
-  public static synchronized void setDisabledListener(Runnable runnable) {
-    disabledListener = runnable;
+  /**
+   * Adds an object to LiveWindow.
+   *
+   * @param sendable Object to add
+   * @param moduleType A string that defines the module name in the label for the value
+   * @param channel The channel number the device is plugged into
+   */
+  public static synchronized void add(Sendable sendable, String moduleType, int channel) {
+    Component comp = getOrAdd(sendable);
+    if (comp.m_builder != null) {
+      try {
+        comp.m_builder.close();
+      } catch (Exception e) {
+        // ignore
+      }
+    }
+    comp.m_builder = new SendableBuilderImpl();
+    comp.setName(moduleType, channel);
   }
 
-  public static synchronized boolean isEnabled() {
-    return liveWindowEnabled;
+  /**
+   * Adds an object to LiveWindow.
+   *
+   * @param sendable Object to add
+   * @param moduleType A string that defines the module name in the label for the value
+   * @param moduleNumber The number of the particular module type
+   * @param channel The channel number the device is plugged into
+   */
+  public static synchronized void add(
+      Sendable sendable, String moduleType, int moduleNumber, int channel) {
+    Component comp = getOrAdd(sendable);
+    if (comp.m_builder != null) {
+      try {
+        comp.m_builder.close();
+      } catch (Exception e) {
+        // ignore
+      }
+    }
+    comp.m_builder = new SendableBuilderImpl();
+    comp.setName(moduleType, moduleNumber, channel);
+  }
+
+  /**
+   * Adds an object to LiveWindow.
+   *
+   * @param sendable Object to add
+   * @param subsystem Subsystem name
+   * @param name Component name
+   */
+  public static synchronized void add(Sendable sendable, String subsystem, String name) {
+    Component comp = getOrAdd(sendable);
+    if (comp.m_builder != null) {
+      try {
+        comp.m_builder.close();
+      } catch (Exception e) {
+        // ignore
+      }
+    }
+    comp.m_builder = new SendableBuilderImpl();
+
+    comp.m_name = name;
+    comp.m_subsystem = subsystem;
+  }
+
+  /**
+   * Adds a child object to an object. Adds the child object to LiveWindow if it's not already
+   * present.
+   *
+   * @param parent Parent object
+   * @param child Child object
+   */
+  public static synchronized void addChild(Sendable parent, Object child) {
+    Component comp = components.get(child);
+    if (comp == null) {
+      comp = new Component();
+      components.put(child, comp);
+    }
+    comp.m_parent = new WeakReference<>(parent);
+  }
+
+  /**
+   * Removes an object from LiveWindow.
+   *
+   * @param sendable Object to remove
+   * @return True if the object was removed; false if it was not present
+   */
+  public static synchronized boolean remove(Sendable sendable) {
+    Component comp = components.remove(sendable);
+    if (comp != null) {
+      try {
+        comp.close();
+      } catch (Exception e) {
+        // ignore
+      }
+    }
+    return comp != null;
+  }
+  
+  /**
+   * Determines if an object is in LiveWindow.
+   *
+   * @param sendable Object to check
+   * @return True if in LiveWindow, false if not.
+   */
+  public static synchronized boolean contains(Sendable sendable) {
+    return components.containsKey(sendable);
+  }
+
+  /**
+   * Gets the name of an object.
+   *
+   * @param sendable Object
+   * @return Name (empty if object is not in LiveWindow)
+   */
+  public static synchronized String getName(Sendable sendable) {
+    Component comp = components.get(sendable);
+    if (comp == null) {
+      return "";
+    }
+    return comp.m_name;
+  }
+
+  /**
+   * Sets the name of an object.
+   *
+   * @param sendable Object
+   * @param name Name
+   */
+  public static synchronized void setName(Sendable sendable, String name) {
+    Component comp = components.get(sendable);
+    if (comp != null) {
+      comp.m_name = name;
+    }
+  }
+
+  /**
+   * Sets the name of an object with a channel number.
+   *
+   * @param sendable Object
+   * @param moduleType A string that defines the module name in the label for the value
+   * @param channel The channel number the device is plugged into
+   */
+  public static synchronized void setName(Sendable sendable, String moduleType, int channel) {
+    Component comp = components.get(sendable);
+    if (comp != null) {
+      comp.setName(moduleType, channel);
+    }
+  }
+
+  /**
+   * Sets the name of an object with a module and channel number.
+   *
+   * @param sendable Object
+   * @param moduleType A string that defines the module name in the label for the value
+   * @param moduleNumber The number of the particular module type
+   * @param channel The channel number the device is plugged into
+   */
+  public static synchronized void setName(
+      Sendable sendable, String moduleType, int moduleNumber, int channel) {
+    Component comp = components.get(sendable);
+    if (comp != null) {
+      comp.setName(moduleType, moduleNumber, channel);
+    }
+  }
+
+  /**
+   * Sets both the subsystem name and device name of an object.
+   *
+   * @param sendable Object
+   * @param subsystem Subsystem name
+   * @param name Device name
+   */
+  public static synchronized void setName(Sendable sendable, String subsystem, String name) {
+    Component comp = components.get(sendable);
+    if (comp != null) {
+      comp.m_name = name;
+      comp.m_subsystem = subsystem;
+    }
+  }
+
+  /**
+   * Gets the subsystem name of an object.
+   *
+   * @param sendable Object
+   * @return Subsystem name (empty if object is not in LiveWindow)
+   */
+  public static synchronized String getSubsystem(Sendable sendable) {
+    Component comp = components.get(sendable);
+    if (comp == null) {
+      return "";
+    }
+    return comp.m_subsystem;
+  }
+
+  /**
+   * Sets the subsystem name of an object.
+   *
+   * @param sendable Object
+   * @param subsystem Subsystem name
+   */
+  public static synchronized void setSubsystem(Sendable sendable, String subsystem) {
+    Component comp = components.get(sendable);
+    if (comp != null) {
+      comp.m_subsystem = subsystem;
+    }
   }
 
   /**
@@ -104,11 +344,9 @@ public final class LiveWindow {
         }
       } else {
         System.out.println("stopping live window mode.");
-        SendableRegistry.foreachLiveWindow(
-            dataHandle,
-            cbdata -> {
-              ((SendableBuilderImpl) cbdata.builder).stopLiveWindowMode();
-            });
+        for (Component comp : components.values()) {
+          ((SendableBuilderImpl) comp.m_builder).stopLiveWindowMode();
+        }
         if (disabledListener != null) {
           disabledListener.run();
         }
@@ -120,7 +358,7 @@ public final class LiveWindow {
   /**
    * Enable telemetry for a single component.
    *
-   * @param sendable component
+   * @param sendable Component
    */
   public static synchronized void enableTelemetry(Sendable sendable) {
     // Re-enable global setting in case disableAllTelemetry() was called.
@@ -131,7 +369,7 @@ public final class LiveWindow {
   /**
    * Disable telemetry for a single component.
    *
-   * @param sendable component
+   * @param sendable Component
    */
   public static synchronized void disableTelemetry(Sendable sendable) {
     getOrAdd(sendable).m_telemetryEnabled = false;
@@ -140,27 +378,17 @@ public final class LiveWindow {
   /** Disable ALL telemetry. */
   public static synchronized void disableAllTelemetry() {
     telemetryEnabled = false;
-    SendableRegistry.foreachLiveWindow(
-        dataHandle,
-        cbdata -> {
-          if (cbdata.data == null) {
-            cbdata.data = new Component();
-          }
-          ((Component) cbdata.data).m_telemetryEnabled = false;
-        });
+    for (Component comp : components.values()) {
+      comp.m_telemetryEnabled = false;
+    }
   }
 
   /** Enable ALL telemetry. */
   public static synchronized void enableAllTelemetry() {
     telemetryEnabled = true;
-    SendableRegistry.foreachLiveWindow(
-        dataHandle,
-        cbdata -> {
-          if (cbdata.data == null) {
-            cbdata.data = new Component();
-          }
-          ((Component) cbdata.data).m_telemetryEnabled = true;
-        });
+    for (Component comp : components.values()) {
+      comp.m_telemetryEnabled = true;
+    }
   }
 
   /**
@@ -175,54 +403,45 @@ public final class LiveWindow {
       return;
     }
 
-    SendableRegistry.foreachLiveWindow(
-        dataHandle,
-        cbdata -> {
-          if (cbdata.sendable == null || cbdata.parent != null) {
-            return;
-          }
+    for (Component comp : components.values()) {
+      if (comp.m_sendable == null || comp.m_parent != null) {
+        continue;
+      }
+      if (!liveWindowEnabled && !comp.m_telemetryEnabled) {
+        return;
+      }
 
-          if (cbdata.data == null) {
-            cbdata.data = new Component();
-          }
+      if (comp.m_firstTime) {
+        // By holding off creating the NetworkTable entries, it allows the
+        // components to be redefined. This allows default sensor and actuator
+        // values to be created that are replaced with the custom names from
+        // users calling setName.
+        if (comp.m_name.isEmpty()) {
+          return;
+        }
+        NetworkTable ssTable = liveWindowTable.getSubTable(comp.m_subsystem);
+        NetworkTable table;
+        // Treat name==subsystem as top level of subsystem
+        if (comp.m_name.equals(comp.m_subsystem)) {
+          table = ssTable;
+        } else {
+          table = ssTable.getSubTable(comp.m_name);
+        }
+        comp.m_namePub = new StringTopic(table.getTopic(".name")).publish();
+        comp.m_namePub.set(comp.m_name);
+        ((SendableBuilderImpl) comp.m_builder).setTable(table);
+        comp.m_sendable.get().initSendable(comp.m_builder);
+        comp.m_typePub = new StringTopic(ssTable.getTopic(".type")).publish();
+        comp.m_typePub.set("LW Subsystem");
 
-          Component component = (Component) cbdata.data;
+        comp.m_firstTime = false;
+      }
 
-          if (!liveWindowEnabled && !component.m_telemetryEnabled) {
-            return;
-          }
-
-          if (component.m_firstTime) {
-            // By holding off creating the NetworkTable entries, it allows the
-            // components to be redefined. This allows default sensor and actuator
-            // values to be created that are replaced with the custom names from
-            // users calling setName.
-            if (cbdata.name.isEmpty()) {
-              return;
-            }
-            NetworkTable ssTable = liveWindowTable.getSubTable(cbdata.subsystem);
-            NetworkTable table;
-            // Treat name==subsystem as top level of subsystem
-            if (cbdata.name.equals(cbdata.subsystem)) {
-              table = ssTable;
-            } else {
-              table = ssTable.getSubTable(cbdata.name);
-            }
-            component.m_namePub = new StringTopic(table.getTopic(".name")).publish();
-            component.m_namePub.set(cbdata.name);
-            ((SendableBuilderImpl) cbdata.builder).setTable(table);
-            cbdata.sendable.initSendable(cbdata.builder);
-            component.m_typePub = new StringTopic(ssTable.getTopic(".type")).publish();
-            component.m_typePub.set("LW Subsystem");
-
-            component.m_firstTime = false;
-          }
-
-          if (startLiveWindow) {
-            ((SendableBuilderImpl) cbdata.builder).startLiveWindowMode();
-          }
-          cbdata.builder.update();
-        });
+      if (startLiveWindow) {
+        ((SendableBuilderImpl) comp.m_builder).startLiveWindowMode();
+      }
+      comp.m_builder.update();
+    }
 
     startLiveWindow = false;
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -19,6 +19,7 @@ import java.util.WeakHashMap;
 /**
  * The LiveWindow class is the public interface for putting sensors and actuators on the LiveWindow.
  */
+@SuppressWarnings("PMD.AvoidCatchingGenericException")
 public final class LiveWindow {
   private static class Component implements AutoCloseable {
     Component() {}
@@ -209,7 +210,7 @@ public final class LiveWindow {
     }
     return comp != null;
   }
-  
+
   /**
    * Determines if an object is in LiveWindow.
    *
@@ -317,6 +318,18 @@ public final class LiveWindow {
     if (comp != null) {
       comp.m_subsystem = subsystem;
     }
+  }
+
+  public static synchronized void setEnabledListener(Runnable runnable) {
+    enabledListener = runnable;
+  }
+
+  public static synchronized void setDisabledListener(Runnable runnable) {
+    disabledListener = runnable;
+  }
+
+  public static synchronized boolean isEnabled() {
+    return liveWindowEnabled;
   }
 
   /**


### PR DESCRIPTION
Resolves #5481. `SmartDashboard` and `LiveWindow` now hold their own Sendables. It compiles, but there's no tests for `LiveWindow`, so I don't know if anything broke. The goal is for all instances of `SendableRegistry` to be replaced with `LiveWindow`. However, there are a few places where `SendableRegistry` is used where swapping it out for `LiveWindow` is problematic. These include `SendableCameraWrapper`, `Field2d`, `SendableChooser`, `Command`, and `ProfiledPIDController`. Some don't use `LiveWindow` (they call `SendableRegistry.add` and not `SendableRegistry.addLW`) and others can't depend on `LiveWindow` because its located in wpilib(c/j), so I'm not sure what to do with them.

Also, the `SmartDashboard` changes in C++ makes `TimedRobotTests/TimedRobotTest.TestMode/0` fail at line 346 where `frc::sim::StepTiming(kPeriod)` is called. After commenting out code to find the problematic line, I found `inst.dataToBuilders[uid] = std::move(builder)` causes the test to fail and I have no idea why.
