### PR TITLE
Don't enforce WITH_FLAT_INSTALL with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,11 +81,6 @@ if (NOT CMAKE_BUILD_TYPE)
     set (CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "" FORCE)
 endif()
 
-# We always want flat install with MSVC.
-if (MSVC)
-  set(WITH_FLAT_INSTALL ON)
-endif()
-
 if (WITH_JAVA AND NOT BUILD_SHARED_LIBS)
     message(FATAL_ERROR "
 FATAL: Cannot build static libs with Java enabled.


### PR DESCRIPTION
I have not found a justification for this. 

Fixes https://github.com/wpilibsuite/allwpilib/issues/5514