### PR TITLE
Don't enforce WITH_FLAT_INSTALL with MSVC missing parts

### DIFF
--- a/wpilibNewCommands/CMakeLists.txt
+++ b/wpilibNewCommands/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(wpilibNewCommands PUBLIC
 install(TARGETS wpilibNewCommands EXPORT wpilibNewCommands DESTINATION "${main_lib_dest}")
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/wpilibNewCommands")
 
-if (MSVC OR FLAT_INSTALL_WPILIB)
+if (FLAT_INSTALL_WPILIB)
      set(wpilibNewCommands_config_dir ${wpilib_dest})
  else()
      set(wpilibNewCommands_config_dir share/wpilibNewCommands)


### PR DESCRIPTION
Missing part from https://github.com/wpilibsuite/allwpilib/pull/5515