### PR TITLE
Create constants file in differentialdrivebot example

### DIFF
--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Constants.java
@@ -6,10 +6,34 @@ package edu.wpi.first.wpilibj.examples.differentialdrivebot;
 
 public class Constants {
   public static final class DriveConstants {
+    public static final int kLeftMotor1Port = 1;
+    public static final int kLeftMotor2Port = 2;
+    public static final int kRightMotor1Port = 3;
+    public static final int kRightMotor2Port = 4;
 
+    public static final int kLeftEncoderPorts[] = new int[] {0, 1};
+    public static final int kRightEncoderPorts[] = new int[] {2, 3};
+
+    public static final int kGyroPort = 0;
+
+    public static final double kMaxSpeed = 3.0; // meters per second
+    public static final double kMaxAngularSpeed = 2 * Math.PI; // one rotation per second
+
+    public static final double kTrackWidth = 0.381 * 2; // meters
+    public static final double kWheelRadius = 0.0508; // meters
+    public static final int kEncoderResolution = 4096;
+
+    public static final double kLeftVelP = 1;
+    public static final double kRightVelP = 1;
+
+    public static final double kFeedforwardS = 1;
+    public static final double kFeedforwardV = 3;
+
+    public static final double kVelSlewRate = 3;
+    public static final double kRotSlewRate = 3;
   }
 
   public static final class OIConstants {
-    
+    public static final int kDriverControllerPort = 0;
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Constants.java
@@ -1,0 +1,15 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj.examples.differentialdrivebot;
+
+public class Constants {
+  public static final class DriveConstants {
+
+  }
+
+  public static final class OIConstants {
+    
+  }
+}

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Constants.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Constants.java
@@ -11,8 +11,8 @@ public class Constants {
     public static final int kRightMotor1Port = 3;
     public static final int kRightMotor2Port = 4;
 
-    public static final int kLeftEncoderPorts[] = new int[] {0, 1};
-    public static final int kRightEncoderPorts[] = new int[] {2, 3};
+    public static final int[] kLeftEncoderPorts = new int[] {0, 1};
+    public static final int[] kRightEncoderPorts = new int[] {2, 3};
 
     public static final int kGyroPort = 0;
 

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Robot.java
@@ -7,6 +7,7 @@ package edu.wpi.first.wpilibj.examples.differentialdrivebot;
 import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.examples.differentialdrivebot.subsystems.Drivetrain;
 
 public class Robot extends TimedRobot {
   private final XboxController m_controller = new XboxController(0);

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Robot.java
@@ -7,15 +7,17 @@ package edu.wpi.first.wpilibj.examples.differentialdrivebot;
 import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.examples.differentialdrivebot.Constants.DriveConstants;
+import edu.wpi.first.wpilibj.examples.differentialdrivebot.Constants.OIConstants;
 import edu.wpi.first.wpilibj.examples.differentialdrivebot.subsystems.Drivetrain;
 
 public class Robot extends TimedRobot {
-  private final XboxController m_controller = new XboxController(0);
+  private final XboxController m_controller = new XboxController(OIConstants.kDriverControllerPort);
   private final Drivetrain m_drive = new Drivetrain();
 
   // Slew rate limiters to make joystick inputs more gentle; 1/3 sec from 0 to 1.
-  private final SlewRateLimiter m_speedLimiter = new SlewRateLimiter(3);
-  private final SlewRateLimiter m_rotLimiter = new SlewRateLimiter(3);
+  private final SlewRateLimiter m_speedLimiter = new SlewRateLimiter(DriveConstants.kVelSlewRate);
+  private final SlewRateLimiter m_rotLimiter = new SlewRateLimiter(DriveConstants.kRotSlewRate);
 
   @Override
   public void autonomousPeriodic() {
@@ -27,13 +29,13 @@ public class Robot extends TimedRobot {
   public void teleopPeriodic() {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    final var xSpeed = -m_speedLimiter.calculate(m_controller.getLeftY()) * Drivetrain.kMaxSpeed;
+    final var xSpeed = -m_speedLimiter.calculate(m_controller.getLeftY()) * DriveConstants.kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    final var rot = -m_rotLimiter.calculate(m_controller.getRightX()) * Drivetrain.kMaxAngularSpeed;
+    final var rot = -m_rotLimiter.calculate(m_controller.getRightX()) * DriveConstants.kMaxAngularSpeed;
 
     m_drive.drive(xSpeed, rot);
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/Robot.java
@@ -29,13 +29,15 @@ public class Robot extends TimedRobot {
   public void teleopPeriodic() {
     // Get the x speed. We are inverting this because Xbox controllers return
     // negative values when we push forward.
-    final var xSpeed = -m_speedLimiter.calculate(m_controller.getLeftY()) * DriveConstants.kMaxSpeed;
+    final var xSpeed =
+        -m_speedLimiter.calculate(m_controller.getLeftY()) * DriveConstants.kMaxSpeed;
 
     // Get the rate of angular rotation. We are inverting this because we want a
     // positive value when we pull to the left (remember, CCW is positive in
     // mathematics). Xbox controllers return positive values when you pull to
     // the right by default.
-    final var rot = -m_rotLimiter.calculate(m_controller.getRightX()) * DriveConstants.kMaxAngularSpeed;
+    final var rot =
+        -m_rotLimiter.calculate(m_controller.getRightX()) * DriveConstants.kMaxAngularSpeed;
 
     m_drive.drive(xSpeed, rot);
   }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/subsystems/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/subsystems/Drivetrain.java
@@ -19,14 +19,15 @@ import edu.wpi.first.wpilibj.motorcontrol.PWMSparkMax;
 
 /** Represents a differential drive style drivetrain. */
 public class Drivetrain {
-
   private final MotorController m_leftLeader = new PWMSparkMax(DriveConstants.kLeftMotor1Port);
   private final MotorController m_leftFollower = new PWMSparkMax(DriveConstants.kLeftMotor2Port);
   private final MotorController m_rightLeader = new PWMSparkMax(DriveConstants.kRightMotor1Port);
   private final MotorController m_rightFollower = new PWMSparkMax(DriveConstants.kRightMotor2Port);
 
-  private final Encoder m_leftEncoder = new Encoder(DriveConstants.kLeftEncoderPorts[0], DriveConstants.kLeftEncoderPorts[1]);
-  private final Encoder m_rightEncoder = new Encoder(DriveConstants.kRightEncoderPorts[0], DriveConstants.kRightEncoderPorts[1]);
+  private final Encoder m_leftEncoder =
+      new Encoder(DriveConstants.kLeftEncoderPorts[0], DriveConstants.kLeftEncoderPorts[1]);
+  private final Encoder m_rightEncoder =
+      new Encoder(DriveConstants.kRightEncoderPorts[0], DriveConstants.kRightEncoderPorts[1]);
 
   private final MotorControllerGroup m_leftGroup =
       new MotorControllerGroup(m_leftLeader, m_leftFollower);
@@ -35,8 +36,10 @@ public class Drivetrain {
 
   private final AnalogGyro m_gyro = new AnalogGyro(DriveConstants.kGyroPort);
 
-  private final PIDController m_leftPIDController = new PIDController(DriveConstants.kLeftVelP, 0, 0);
-  private final PIDController m_rightPIDController = new PIDController(DriveConstants.kRightVelP, 0, 0);
+  private final PIDController m_leftPIDController =
+      new PIDController(DriveConstants.kLeftVelP, 0, 0);
+  private final PIDController m_rightPIDController =
+      new PIDController(DriveConstants.kRightVelP, 0, 0);
 
   private final DifferentialDriveKinematics m_kinematics =
       new DifferentialDriveKinematics(DriveConstants.kTrackWidth);
@@ -44,7 +47,8 @@ public class Drivetrain {
   private final DifferentialDriveOdometry m_odometry;
 
   // Gains are for example purposes only - must be determined for your own robot!
-  private final SimpleMotorFeedforward m_feedforward = new SimpleMotorFeedforward(DriveConstants.kFeedforwardS, DriveConstants.kFeedforwardV);
+  private final SimpleMotorFeedforward m_feedforward =
+      new SimpleMotorFeedforward(DriveConstants.kFeedforwardS, DriveConstants.kFeedforwardV);
 
   /**
    * Constructs a differential drive object. Sets the encoder distance per pulse and resets the
@@ -61,8 +65,10 @@ public class Drivetrain {
     // Set the distance per pulse for the drive encoders. We can simply use the
     // distance traveled for one rotation of the wheel divided by the encoder
     // resolution.
-    m_leftEncoder.setDistancePerPulse(2 * Math.PI * DriveConstants.kWheelRadius / DriveConstants.kEncoderResolution);
-    m_rightEncoder.setDistancePerPulse(2 * Math.PI * DriveConstants.kWheelRadius / DriveConstants.kEncoderResolution);
+    m_leftEncoder.setDistancePerPulse(
+        2 * Math.PI * DriveConstants.kWheelRadius / DriveConstants.kEncoderResolution);
+    m_rightEncoder.setDistancePerPulse(
+        2 * Math.PI * DriveConstants.kWheelRadius / DriveConstants.kEncoderResolution);
 
     m_leftEncoder.reset();
     m_rightEncoder.reset();

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/subsystems/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/subsystems/Drivetrain.java
@@ -2,7 +2,7 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package edu.wpi.first.wpilibj.examples.differentialdrivebot;
+package edu.wpi.first.wpilibj.examples.differentialdrivebot.subsystems;
 
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/subsystems/Drivetrain.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot/subsystems/Drivetrain.java
@@ -12,44 +12,39 @@ import edu.wpi.first.math.kinematics.DifferentialDriveOdometry;
 import edu.wpi.first.math.kinematics.DifferentialDriveWheelSpeeds;
 import edu.wpi.first.wpilibj.AnalogGyro;
 import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.examples.differentialdrivebot.Constants.DriveConstants;
 import edu.wpi.first.wpilibj.motorcontrol.MotorController;
 import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup;
 import edu.wpi.first.wpilibj.motorcontrol.PWMSparkMax;
 
 /** Represents a differential drive style drivetrain. */
 public class Drivetrain {
-  public static final double kMaxSpeed = 3.0; // meters per second
-  public static final double kMaxAngularSpeed = 2 * Math.PI; // one rotation per second
 
-  private static final double kTrackWidth = 0.381 * 2; // meters
-  private static final double kWheelRadius = 0.0508; // meters
-  private static final int kEncoderResolution = 4096;
+  private final MotorController m_leftLeader = new PWMSparkMax(DriveConstants.kLeftMotor1Port);
+  private final MotorController m_leftFollower = new PWMSparkMax(DriveConstants.kLeftMotor2Port);
+  private final MotorController m_rightLeader = new PWMSparkMax(DriveConstants.kRightMotor1Port);
+  private final MotorController m_rightFollower = new PWMSparkMax(DriveConstants.kRightMotor2Port);
 
-  private final MotorController m_leftLeader = new PWMSparkMax(1);
-  private final MotorController m_leftFollower = new PWMSparkMax(2);
-  private final MotorController m_rightLeader = new PWMSparkMax(3);
-  private final MotorController m_rightFollower = new PWMSparkMax(4);
-
-  private final Encoder m_leftEncoder = new Encoder(0, 1);
-  private final Encoder m_rightEncoder = new Encoder(2, 3);
+  private final Encoder m_leftEncoder = new Encoder(DriveConstants.kLeftEncoderPorts[0], DriveConstants.kLeftEncoderPorts[1]);
+  private final Encoder m_rightEncoder = new Encoder(DriveConstants.kRightEncoderPorts[0], DriveConstants.kRightEncoderPorts[1]);
 
   private final MotorControllerGroup m_leftGroup =
       new MotorControllerGroup(m_leftLeader, m_leftFollower);
   private final MotorControllerGroup m_rightGroup =
       new MotorControllerGroup(m_rightLeader, m_rightFollower);
 
-  private final AnalogGyro m_gyro = new AnalogGyro(0);
+  private final AnalogGyro m_gyro = new AnalogGyro(DriveConstants.kGyroPort);
 
-  private final PIDController m_leftPIDController = new PIDController(1, 0, 0);
-  private final PIDController m_rightPIDController = new PIDController(1, 0, 0);
+  private final PIDController m_leftPIDController = new PIDController(DriveConstants.kLeftVelP, 0, 0);
+  private final PIDController m_rightPIDController = new PIDController(DriveConstants.kRightVelP, 0, 0);
 
   private final DifferentialDriveKinematics m_kinematics =
-      new DifferentialDriveKinematics(kTrackWidth);
+      new DifferentialDriveKinematics(DriveConstants.kTrackWidth);
 
   private final DifferentialDriveOdometry m_odometry;
 
   // Gains are for example purposes only - must be determined for your own robot!
-  private final SimpleMotorFeedforward m_feedforward = new SimpleMotorFeedforward(1, 3);
+  private final SimpleMotorFeedforward m_feedforward = new SimpleMotorFeedforward(DriveConstants.kFeedforwardS, DriveConstants.kFeedforwardV);
 
   /**
    * Constructs a differential drive object. Sets the encoder distance per pulse and resets the
@@ -66,8 +61,8 @@ public class Drivetrain {
     // Set the distance per pulse for the drive encoders. We can simply use the
     // distance traveled for one rotation of the wheel divided by the encoder
     // resolution.
-    m_leftEncoder.setDistancePerPulse(2 * Math.PI * kWheelRadius / kEncoderResolution);
-    m_rightEncoder.setDistancePerPulse(2 * Math.PI * kWheelRadius / kEncoderResolution);
+    m_leftEncoder.setDistancePerPulse(2 * Math.PI * DriveConstants.kWheelRadius / DriveConstants.kEncoderResolution);
+    m_rightEncoder.setDistancePerPulse(2 * Math.PI * DriveConstants.kWheelRadius / DriveConstants.kEncoderResolution);
 
     m_leftEncoder.reset();
     m_rightEncoder.reset();


### PR DESCRIPTION
Creates a `Constants.java` file for the Java differentialdrivebot example.

Contributes to resolving https://github.com/wpilibsuite/allwpilib/issues/1948, but not sure if required because this example is not directly mentioned in the issue.

Changes are only made in Java so far, and must be made on the C++ side too.