### PR TITLE
[wpimath] Make Java Quaternion use doubles instead of Vector

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Quaternion.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Quaternion.java
@@ -188,17 +188,17 @@ public class Quaternion {
     // https://arxiv.org/pdf/1107.1119.pdf
     double norm = Math.sqrt(getX() * getX() + getY() * getY() + getZ() * getZ());
 
+    double coeff;
     if (norm < 1e-9) {
-      double coeff = 2.0 / getW() - 2.0 / 3.0 * norm * norm / (getW() * getW() * getW());
-      return VecBuilder.fill(coeff * getX(), coeff * getY(), coeff * getZ());
+      coeff = 2.0 / getW() - 2.0 / 3.0 * norm * norm / (getW() * getW() * getW());
     } else {
       if (getW() < 0.0) {
-        double coeff = 2.0 * Math.atan2(-norm, -getW()) / norm;
-        return VecBuilder.fill(coeff * getX(), coeff * getY(), coeff * getZ());
+        coeff = 2.0 * Math.atan2(-norm, -getW()) / norm;
       } else {
-        double coeff = 2.0 * Math.atan2(norm, getW()) / norm;
-        return VecBuilder.fill(coeff * getX(), coeff * getY(), coeff * getZ());
+        coeff = 2.0 * Math.atan2(norm, getW()) / norm;
       }
     }
+
+    return VecBuilder.fill(coeff * getX(), coeff * getY(), coeff * getZ());
   }
 }

--- a/wpimath/src/main/native/cpp/geometry/Quaternion.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Quaternion.cpp
@@ -26,15 +26,18 @@ Quaternion Quaternion::operator*(const Quaternion& other) const {
   // v = r₁v₂ + r₂v₁ + v₁ x v₂
   Eigen::Vector3d v = r1 * v2 + r2 * v1 + cross;
 
-  return Quaternion{r1 * r2 - v1.dot(v2), v(0), v(1), v(2)};
+  return Quaternion{// r = r₁r₂ − v₁ ⋅ v₂
+                    r1 * r2 - v1.dot(v2),
+                    // v = r₁v₂ + r₂v₁ + v₁ x v₂
+                    v(0), v(1), v(2)};
 }
 
 bool Quaternion::operator==(const Quaternion& other) const {
-  return std::abs(m_r * other.m_r + m_v.dot(other.m_v)) > 1.0 - 1E-9;
+  return std::abs(W() * other.W() + m_v.dot(other.m_v)) > 1.0 - 1E-9;
 }
 
 Quaternion Quaternion::Inverse() const {
-  return Quaternion{m_r, -m_v(0), -m_v(1), -m_v(2)};
+  return Quaternion{W(), -X(), -Y(), -Z()};
 }
 
 Quaternion Quaternion::Normalize() const {

--- a/wpimath/src/main/native/include/frc/geometry/Quaternion.h
+++ b/wpimath/src/main/native/include/frc/geometry/Quaternion.h
@@ -84,7 +84,10 @@ class WPILIB_DLLEXPORT Quaternion {
   Eigen::Vector3d ToRotationVector() const;
 
  private:
+  // Scalar r in versor form
   double m_r = 1.0;
+
+  // Vector v in versor form
   Eigen::Vector3d m_v{0.0, 0.0, 0.0};
 };
 


### PR DESCRIPTION
This avoids allocation overhead on construction. times() was also rewritten to not allocate any temporary objects.

Getter calls in the C++ Quaternion class were modified for parity.