### PR TITLE
[wpimath] Upgrade to EJML 0.42

### DIFF
--- a/wpimath/CMakeLists.txt
+++ b/wpimath/CMakeLists.txt
@@ -13,26 +13,26 @@ if (WITH_JAVA)
   include(UseJava)
   set(CMAKE_JAVA_COMPILE_FLAGS "-encoding" "UTF8" "-Xlint:unchecked")
 
-  if(NOT EXISTS "${WPILIB_BINARY_DIR}/wpimath/thirdparty/ejml/ejml-simple-0.41.jar")
+  if(NOT EXISTS "${WPILIB_BINARY_DIR}/wpimath/thirdparty/ejml/ejml-simple-0.42.jar")
       set(BASE_URL "https://search.maven.org/remotecontent?filepath=")
       set(JAR_ROOT "${WPILIB_BINARY_DIR}/wpimath/thirdparty/ejml")
 
       message(STATUS "Downloading EJML jarfiles...")
 
-      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-cdense/0.41/ejml-cdense-0.41.jar"
-          "${JAR_ROOT}/ejml-cdense-0.41.jar")
-      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-core/0.41/ejml-core-0.41.jar"
-          "${JAR_ROOT}/ejml-core-0.41.jar")
-      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-ddense/0.41/ejml-ddense-0.41.jar"
-          "${JAR_ROOT}/ejml-ddense-0.41.jar")
-      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-dsparse/0.41/ejml-dsparse-0.41.jar"
-          "${JAR_ROOT}/ejml-dsparse-0.41.jar")
-      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-fdense/0.41/ejml-fdense-0.41.jar"
-          "${JAR_ROOT}/ejml-fdense-0.41.jar")
-      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-simple/0.41/ejml-simple-0.41.jar"
-          "${JAR_ROOT}/ejml-simple-0.41.jar")
-      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-zdense/0.41/ejml-zdense-0.41.jar"
-          "${JAR_ROOT}/ejml-zdense-0.41.jar")
+      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-cdense/0.42/ejml-cdense-0.42.jar"
+          "${JAR_ROOT}/ejml-cdense-0.42.jar")
+      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-core/0.42/ejml-core-0.42.jar"
+          "${JAR_ROOT}/ejml-core-0.42.jar")
+      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-ddense/0.42/ejml-ddense-0.42.jar"
+          "${JAR_ROOT}/ejml-ddense-0.42.jar")
+      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-dsparse/0.42/ejml-dsparse-0.42.jar"
+          "${JAR_ROOT}/ejml-dsparse-0.42.jar")
+      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-fdense/0.42/ejml-fdense-0.42.jar"
+          "${JAR_ROOT}/ejml-fdense-0.42.jar")
+      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-simple/0.42/ejml-simple-0.42.jar"
+          "${JAR_ROOT}/ejml-simple-0.42.jar")
+      file(DOWNLOAD "${BASE_URL}org/ejml/ejml-zdense/0.42/ejml-zdense-0.42.jar"
+          "${JAR_ROOT}/ejml-zdense-0.42.jar")
 
       message(STATUS "All files downloaded.")
   endif()

--- a/wpimath/build.gradle
+++ b/wpimath/build.gradle
@@ -37,7 +37,7 @@ model {
 }
 
 dependencies {
-    api "org.ejml:ejml-simple:0.41"
+    api "org.ejml:ejml-simple:0.42"
     api "com.fasterxml.jackson.core:jackson-annotations:2.12.4"
     api "com.fasterxml.jackson.core:jackson-core:2.12.4"
     api "com.fasterxml.jackson.core:jackson-databind:2.12.4"

--- a/wpimath/src/main/java/edu/wpi/first/math/DARE.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/DARE.java
@@ -21,14 +21,14 @@ public final class DARE {
    * @return Solution of DARE.
    */
   public static SimpleMatrix dare(SimpleMatrix A, SimpleMatrix B, SimpleMatrix Q, SimpleMatrix R) {
-    var S = new SimpleMatrix(A.numRows(), A.numCols());
+    var S = new SimpleMatrix(A.getNumRows(), A.getNumCols());
     WPIMathJNI.dare(
         A.getDDRM().getData(),
         B.getDDRM().getData(),
         Q.getDDRM().getData(),
         R.getDDRM().getData(),
-        A.numCols(),
-        B.numCols(),
+        A.getNumCols(),
+        B.getNumCols(),
         S.getDDRM().getData());
     return S;
   }
@@ -70,14 +70,14 @@ public final class DARE {
     var scrA = A.minus(B.mult(R.solve(N.transpose())));
     var scrQ = Q.minus(N.mult(R.solve(N.transpose())));
 
-    var S = new SimpleMatrix(A.numRows(), A.numCols());
+    var S = new SimpleMatrix(A.getNumRows(), A.getNumCols());
     WPIMathJNI.dare(
         scrA.getDDRM().getData(),
         B.getDDRM().getData(),
         scrQ.getDDRM().getData(),
         R.getDDRM().getData(),
-        A.numCols(),
-        B.numCols(),
+        A.getNumCols(),
+        B.getNumCols(),
         S.getDDRM().getData());
     return S;
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/Matrix.java
@@ -80,7 +80,7 @@ public class Matrix<R extends Num, C extends Num> {
    * @return The number of columns, according to the internal storage.
    */
   public final int getNumCols() {
-    return this.m_storage.numCols();
+    return this.m_storage.getNumCols();
   }
 
   /**
@@ -89,7 +89,7 @@ public class Matrix<R extends Num, C extends Num> {
    * @return The number of rows, according to the internal storage.
    */
   public final int getNumRows() {
-    return this.m_storage.numRows();
+    return this.m_storage.getNumRows();
   }
 
   /**
@@ -582,7 +582,7 @@ public class Matrix<R extends Num, C extends Num> {
     SimpleMatrix temp = m_storage.copy();
 
     CholeskyDecomposition_F64<DMatrixRMaj> chol =
-        DecompositionFactory_DDRM.chol(temp.numRows(), lowerTriangular);
+        DecompositionFactory_DDRM.chol(temp.getNumRows(), lowerTriangular);
     if (!chol.decompose(temp.getMatrix())) {
       // check that the input is not all zeros -- if they are, we special case and return all
       // zeros.
@@ -592,7 +592,7 @@ public class Matrix<R extends Num, C extends Num> {
         isZeros &= Math.abs(matDatum) < 1e-6;
       }
       if (isZeros) {
-        return new Matrix<>(new SimpleMatrix(temp.numRows(), temp.numCols()));
+        return new Matrix<>(new SimpleMatrix(temp.getNumRows(), temp.getNumCols()));
       }
 
       throw new RuntimeException(

--- a/wpimath/src/main/java/edu/wpi/first/math/SimpleMatrixUtils.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/SimpleMatrixUtils.java
@@ -68,7 +68,7 @@ public final class SimpleMatrixUtils {
 
   private static Pair<SimpleMatrix, SimpleMatrix> pade3(SimpleMatrix A) {
     double[] b = new double[] {120, 60, 12, 1};
-    SimpleMatrix ident = eye(A.numRows(), A.numCols());
+    SimpleMatrix ident = eye(A.getNumRows(), A.getNumCols());
 
     SimpleMatrix A2 = A.mult(A);
     SimpleMatrix U = A.mult(A2.mult(ident.scale(b[1]).plus(b[3])));
@@ -78,7 +78,7 @@ public final class SimpleMatrixUtils {
 
   private static Pair<SimpleMatrix, SimpleMatrix> pade5(SimpleMatrix A) {
     double[] b = new double[] {30240, 15120, 3360, 420, 30, 1};
-    SimpleMatrix ident = eye(A.numRows(), A.numCols());
+    SimpleMatrix ident = eye(A.getNumRows(), A.getNumCols());
     SimpleMatrix A2 = A.mult(A);
     SimpleMatrix A4 = A2.mult(A2);
 
@@ -90,7 +90,7 @@ public final class SimpleMatrixUtils {
 
   private static Pair<SimpleMatrix, SimpleMatrix> pade7(SimpleMatrix A) {
     double[] b = new double[] {17297280, 8648640, 1995840, 277200, 25200, 1512, 56, 1};
-    SimpleMatrix ident = eye(A.numRows(), A.numCols());
+    SimpleMatrix ident = eye(A.getNumRows(), A.getNumCols());
     SimpleMatrix A2 = A.mult(A);
     SimpleMatrix A4 = A2.mult(A2);
     SimpleMatrix A6 = A4.mult(A2);
@@ -108,7 +108,7 @@ public final class SimpleMatrixUtils {
         new double[] {
           17643225600.0, 8821612800.0, 2075673600, 302702400, 30270240, 2162160, 110880, 3960, 90, 1
         };
-    SimpleMatrix ident = eye(A.numRows(), A.numCols());
+    SimpleMatrix ident = eye(A.getNumRows(), A.getNumCols());
     SimpleMatrix A2 = A.mult(A);
     SimpleMatrix A4 = A2.mult(A2);
     SimpleMatrix A6 = A4.mult(A2);
@@ -149,7 +149,7 @@ public final class SimpleMatrixUtils {
           182,
           1
         };
-    SimpleMatrix ident = eye(A.numRows(), A.numCols());
+    SimpleMatrix ident = eye(A.getNumRows(), A.getNumCols());
 
     SimpleMatrix A2 = A.mult(A);
     SimpleMatrix A4 = A2.mult(A2);
@@ -213,7 +213,7 @@ public final class SimpleMatrixUtils {
     SimpleMatrix temp = src.copy();
 
     CholeskyDecomposition_F64<DMatrixRMaj> chol =
-        DecompositionFactory_DDRM.chol(temp.numRows(), lowerTriangular);
+        DecompositionFactory_DDRM.chol(temp.getNumRows(), lowerTriangular);
     if (!chol.decompose(temp.getMatrix())) {
       // check that the input is not all zeros -- if they are, we special case and return all
       // zeros.
@@ -223,7 +223,7 @@ public final class SimpleMatrixUtils {
         isZeros &= Math.abs(matDatum) < 1e-6;
       }
       if (isZeros) {
-        return new SimpleMatrix(temp.numRows(), temp.numCols());
+        return new SimpleMatrix(temp.getNumRows(), temp.getNumCols());
       }
 
       throw new RuntimeException("Cholesky decomposition failed! Input matrix:\n" + src.toString());
@@ -239,8 +239,8 @@ public final class SimpleMatrixUtils {
    * @return the exponential of A.
    */
   public static SimpleMatrix exp(SimpleMatrix A) {
-    SimpleMatrix toReturn = new SimpleMatrix(A.numRows(), A.numRows());
-    WPIMathJNI.exp(A.getDDRM().getData(), A.numRows(), toReturn.getDDRM().getData());
+    SimpleMatrix toReturn = new SimpleMatrix(A.getNumRows(), A.getNumRows());
+    WPIMathJNI.exp(A.getDDRM().getData(), A.getNumRows(), toReturn.getDDRM().getData());
     return toReturn;
   }
 }

--- a/wpimath/src/test/java/edu/wpi/first/math/DARETest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/DARETest.java
@@ -16,8 +16,8 @@ class DARETest extends UtilityClassTest<DARE> {
   }
 
   public static void assertMatrixEqual(SimpleMatrix A, SimpleMatrix B) {
-    for (int i = 0; i < A.numRows(); i++) {
-      for (int j = 0; j < A.numCols(); j++) {
+    for (int i = 0; i < A.getNumRows(); i++) {
+      for (int j = 0; j < A.getNumCols(); j++) {
         assertEquals(A.get(i, j), B.get(i, j), 1e-4);
       }
     }
@@ -35,7 +35,7 @@ class DARETest extends UtilityClassTest<DARE> {
                     .mult((B.transpose().mult(X).mult(B).plus(R)).invert())
                     .mult(B.transpose().mult(X).mult(A)))
             .plus(Q);
-    assertMatrixEqual(new SimpleMatrix(Y.numRows(), Y.numCols()), Y);
+    assertMatrixEqual(new SimpleMatrix(Y.getNumRows(), Y.getNumCols()), Y);
   }
 
   void assertDARESolution(
@@ -55,7 +55,7 @@ class DARETest extends UtilityClassTest<DARE> {
                     .mult((B.transpose().mult(X).mult(B).plus(R)).invert())
                     .mult(B.transpose().mult(X).mult(A).plus(N.transpose())))
             .plus(Q);
-    assertMatrixEqual(new SimpleMatrix(Y.numRows(), Y.numCols()), Y);
+    assertMatrixEqual(new SimpleMatrix(Y.getNumRows(), Y.getNumCols()), Y);
   }
 
   @Test


### PR DESCRIPTION
EJML deprecated `numRows()` and `numCols()` in favor of `getNumRows()` and `getNumCols()` respectively. Our Matrix class already uses the new naming in its API.