### PR TITLE
[wpinet] Leak multicast handles during windows shutdown

### DIFF
--- a/wpinet/src/main/native/cpp/MulticastHandleManager.cpp
+++ b/wpinet/src/main/native/cpp/MulticastHandleManager.cpp
@@ -10,3 +10,17 @@ MulticastHandleManager& wpi::GetMulticastManager() {
   static MulticastHandleManager manager;
   return manager;
 }
+
+#ifdef _WIN32
+MulticastHandleManager::~MulticastHandleManager() {
+  // Multicast handles cannot be safely destructed on windows during shutdown.
+  // Just leak all handles.
+  for (auto&& i : resolvers) {
+    i.second.release();
+  }
+
+  for (auto&& i : announcers) {
+    i.second.release();
+  }
+}
+#endif

--- a/wpinet/src/main/native/cpp/MulticastHandleManager.h
+++ b/wpinet/src/main/native/cpp/MulticastHandleManager.h
@@ -20,6 +20,9 @@ struct MulticastHandleManager {
       resolvers;
   wpi::DenseMap<size_t, std::unique_ptr<wpi::MulticastServiceAnnouncer>>
       announcers;
+#ifdef _WIN32
+  ~MulticastHandleManager() noexcept;
+#endif
 };
 
 MulticastHandleManager& GetMulticastManager();

--- a/wpinet/src/main/native/cpp/MulticastHandleManager.h
+++ b/wpinet/src/main/native/cpp/MulticastHandleManager.h
@@ -21,7 +21,7 @@ struct MulticastHandleManager {
   wpi::DenseMap<size_t, std::unique_ptr<wpi::MulticastServiceAnnouncer>>
       announcers;
 #ifdef _WIN32
-  ~MulticastHandleManager() noexcept;
+  ~MulticastHandleManager();
 #endif
 };
 


### PR DESCRIPTION
Destructing either of the multicast objects during process shutdown will result in a crash due to attempting to start a task on the non existant thread pool.

Solve this by just leaking all the handles upon destruction of the static multicast manager. This won't solve the case where the user statically allocates the object, but solves Java and C access, and most cases wouldn't be statically allocation the service anouncer anyway in C++