### PR TITLE
Add IdleCommand to wpilibJ2 command framework

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -204,6 +204,18 @@ public final class Commands {
     return new ParallelDeadlineGroup(deadline, commands);
   }
 
+  /**
+   * Constructs a command that does nothing until interrupted
+   *
+   * @param requirements subsystems the action requires
+   * @return the command
+   * @see IdleCommand
+   */
+  public static Command idle(Subsystem... requirements) {
+    return new IdleCommand(requirements);
+  }
+
+
   private Commands() {
     throw new UnsupportedOperationException("This is a utility class");
   }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/IdleCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/IdleCommand.java
@@ -1,0 +1,22 @@
+package edu.wpi.first.wpilibj2.command;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * A command that runs nothing. Has no end condition as-is; either subclass it or
+ * use {@link Command#withTimeout(double)} or {@link Command#until(BooleanSupplier)} to give it one.
+ * Used mainly for making a {@link Subsystem#setDefaultCommand(Command)} only run once
+ *
+ * <p>This class is provided by the NewCommands VendorDep
+ */
+public class IdleCommand extends RunCommand {
+    /**
+     * Creates a new IdleCommand. The IdleCommand will run until interrupted without doing any action.
+     * Useful for making a continuously scheduled command only run once.
+     *
+     * @param requirements the subsystems to require
+     */
+    public IdleCommand(Subsystem... requirements){
+        super(()-> {}, requirements);
+    }
+}


### PR DESCRIPTION
Implemented an IdleCommand class and a builder for this class in the Commands class. These changes provide a way to construct commands that do nothing until they're interrupted. This could be useful when creating continuously scheduled commands that are intended to run only once, such as subsystem default commands.

Fixes wpilibsuite/allwpilib#5548