### PR TITLE
[cmd] Add DeferredCommand

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -7,6 +7,7 @@ package edu.wpi.first.wpilibj2.command;
 import static edu.wpi.first.util.ErrorMessages.requireNonNullParam;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
@@ -149,6 +150,18 @@ public final class Commands {
    */
   public static Command select(Map<Object, Command> commands, Supplier<Object> selector) {
     return new SelectCommand(commands, selector);
+  }
+
+  /**
+   * Runs the command supplied by the supplier.
+   *
+   * @param supplier the command supplier
+   * @param requirements the set of requirements for this command
+   * @return the command
+   * @see DeferredCommand
+   */
+  public static Command defer(Supplier<Command> supplier, Set<Subsystem> requirements) {
+    return new DeferredCommand(supplier, requirements);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
@@ -11,9 +11,9 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 /**
- * Runs the command returned by the supplier when this command is initialized, and ends when it
- * ends. Useful for performing runtime tasks before creating a new command. If this command is
- * interrupted, it will cancel the command.
+ * Defers Command construction to runtime. Runs the command returned by the supplier when this
+ * command is initialized, and ends when it ends. Useful for performing runtime tasks before
+ * creating a new command. If this command is interrupted, it will cancel the command.
  *
  * <p>Note that the supplier <i>must</i> create a new Command each call. For selecting one of a
  * preallocated set of commands, use {@link SelectCommand}.
@@ -72,6 +72,6 @@ public class DeferredCommand extends Command {
   public void initSendable(SendableBuilder builder) {
     super.initSendable(builder);
     builder.addStringProperty(
-        "deferred", () -> m_command.equals(m_nullCommand) ? "null" : m_command.getName(), null);
+        "deferred", () -> m_command == m_nullCommand ? "null" : m_command.getName(), null);
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
@@ -69,6 +69,7 @@ public class DeferredCommand extends Command {
   }
 
   @Override
+  @SuppressWarnings("PMD.CompareObjectsWithEquals")
   public void initSendable(SendableBuilder builder) {
     super.initSendable(builder);
     builder.addStringProperty(

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
@@ -18,8 +18,11 @@ import java.util.function.Supplier;
  * <p>This class is provided by the NewCommands VendorDep
  */
 public class DeferredCommand extends Command {
+  private final Command m_nullCommand =
+      new PrintCommand("[DeferredCommand] Supplied command was null!");
+
   private final Supplier<Command> m_supplier;
-  private Command m_command;
+  private Command m_command = m_nullCommand;
 
   /**
    * Creates a new DeferredCommand that runs the supplied command when initialized, and ends when it
@@ -33,7 +36,6 @@ public class DeferredCommand extends Command {
   public DeferredCommand(Supplier<Command> supplier, Set<Subsystem> requirements) {
     m_supplier = requireNonNullParam(supplier, "supplier", "DeferredCommand");
     addRequirements(requirements.toArray(new Subsystem[0]));
-    resetInternalCommand();
   }
 
   @Override
@@ -41,8 +43,8 @@ public class DeferredCommand extends Command {
     var cmd = m_supplier.get();
     if (cmd != null) {
       m_command = cmd;
+      CommandScheduler.getInstance().registerComposedCommands(m_command);
     }
-    CommandScheduler.getInstance().registerComposedCommands(m_command);
     m_command.initialize();
   }
 
@@ -59,7 +61,7 @@ public class DeferredCommand extends Command {
   @Override
   public void end(boolean interrupted) {
     m_command.end(interrupted);
-    resetInternalCommand();
+    m_command = m_nullCommand;
   }
 
   @Override
@@ -67,9 +69,5 @@ public class DeferredCommand extends Command {
     super.initSendable(builder);
     builder.addStringProperty(
         "deferred", () -> m_command == null ? "null" : m_command.getName(), null);
-  }
-
-  private void resetInternalCommand() {
-    m_command = new PrintCommand("[DeferredCommand] Supplied command was null!");
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
@@ -34,7 +34,8 @@ public class DeferredCommand extends Command {
    *
    * @param supplier The command supplier
    * @param requirements The command requirements. This is a {@link Set} to prevent accidental
-   *     omission of command requirements.
+   *     omission of command requirements. Use {@link Set#of()} to easily construct a requirement
+   *     set.
    */
   public DeferredCommand(Supplier<Command> supplier, Set<Subsystem> requirements) {
     m_supplier = requireNonNullParam(supplier, "supplier", "DeferredCommand");

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
@@ -11,9 +11,12 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 /**
- * Runs the given command when this command is initialized, and ends when it ends. Useful for
- * performing runtime tasks before creating a new command. If this command is interrupted, it will
- * cancel the command.
+ * Runs the command returned by the supplier when this command is initialized, and ends when it
+ * ends. Useful for performing runtime tasks before creating a new command. If this command is
+ * interrupted, it will cancel the command.
+ *
+ * <p>Note that the supplier <i>must</i> create a new Command each call. For selecting one of a
+ * preallocated set of commands, use {@link SelectCommand}.
  *
  * <p>This class is provided by the NewCommands VendorDep
  */

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
@@ -68,6 +68,6 @@ public class DeferredCommand extends Command {
   public void initSendable(SendableBuilder builder) {
     super.initSendable(builder);
     builder.addStringProperty(
-        "deferred", () -> m_command == null ? "null" : m_command.getName(), null);
+        "deferred", () -> m_command == m_nullCommand ? "null" : m_command.getName(), null);
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
@@ -68,6 +68,6 @@ public class DeferredCommand extends Command {
   public void initSendable(SendableBuilder builder) {
     super.initSendable(builder);
     builder.addStringProperty(
-        "deferred", () -> m_command == m_nullCommand ? "null" : m_command.getName(), null);
+        "deferred", () -> m_command.equals(m_nullCommand) ? "null" : m_command.getName(), null);
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/DeferredCommand.java
@@ -1,0 +1,75 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj2.command;
+
+import static edu.wpi.first.util.ErrorMessages.requireNonNullParam;
+
+import edu.wpi.first.util.sendable.SendableBuilder;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * Runs the given command when this command is initialized, and ends when it ends. Useful for
+ * performing runtime tasks before creating a new command. If this command is interrupted, it will
+ * cancel the command.
+ *
+ * <p>This class is provided by the NewCommands VendorDep
+ */
+public class DeferredCommand extends Command {
+  private final Supplier<Command> m_supplier;
+  private Command m_command;
+
+  /**
+   * Creates a new DeferredCommand that runs the supplied command when initialized, and ends when it
+   * ends. Useful for lazily creating commands at runtime. The {@link Supplier} will be called each
+   * time this command is initialized. The Supplier <i>must</i> create a new Command each call.
+   *
+   * @param supplier The command supplier
+   * @param requirements The command requirements. This is a {@link Set} to prevent accidental
+   *     omission of command requirements.
+   */
+  public DeferredCommand(Supplier<Command> supplier, Set<Subsystem> requirements) {
+    m_supplier = requireNonNullParam(supplier, "supplier", "DeferredCommand");
+    addRequirements(requirements.toArray(new Subsystem[0]));
+    resetInternalCommand();
+  }
+
+  @Override
+  public void initialize() {
+    var cmd = m_supplier.get();
+    if (cmd != null) {
+      m_command = cmd;
+    }
+    CommandScheduler.getInstance().registerComposedCommands(m_command);
+    m_command.initialize();
+  }
+
+  @Override
+  public void execute() {
+    m_command.execute();
+  }
+
+  @Override
+  public boolean isFinished() {
+    return m_command.isFinished();
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    m_command.end(interrupted);
+    resetInternalCommand();
+  }
+
+  @Override
+  public void initSendable(SendableBuilder builder) {
+    super.initSendable(builder);
+    builder.addStringProperty(
+        "deferred", () -> m_command == null ? "null" : m_command.getName(), null);
+  }
+
+  private void resetInternalCommand() {
+    m_command = new PrintCommand("[DeferredCommand] Supplied command was null!");
+  }
+}

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
@@ -136,4 +136,16 @@ public interface Subsystem {
   default Command runEnd(Runnable run, Runnable end) {
     return Commands.runEnd(run, end, this);
   }
+
+  /**
+   * Constructs a {@link DeferredCommand} with the provided supplier. This subsystem is added as a
+   * requirement.
+   *
+   * @param supplier the command supplier.
+   * @return the command.
+   * @see DeferredCommand
+   */
+  default Command defer(Supplier<Command> supplier) {
+    return Commands.defer(supplier, Set.of(this));
+  }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
@@ -4,6 +4,9 @@
 
 package edu.wpi.first.wpilibj2.command;
 
+import java.util.function.Supplier;
+import java.util.Set;
+
 /**
  * A robot subsystem. Subsystems are the basic unit of robot organization in the Command-based
  * framework; they encapsulate low-level hardware objects (motor controllers, sensors, etc.) and

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
@@ -4,8 +4,8 @@
 
 package edu.wpi.first.wpilibj2.command;
 
-import java.util.function.Supplier;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A robot subsystem. Subsystems are the basic unit of robot organization in the Command-based

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
@@ -84,22 +84,12 @@ CommandPtr cmd::Either(CommandPtr&& onTrue, CommandPtr&& onFalse,
 }
 
 CommandPtr cmd::Defer(wpi::unique_function<Command*()> supplier,
-                      std::span<Subsystem* const> requirements) {
-  return DeferredCommand(std::move(supplier), requirements).ToPtr();
-}
-
-CommandPtr cmd::Defer(wpi::unique_function<Command*()> supplier,
-                      std::initializer_list<Subsystem*> requirements) {
+                      Requirements requirements) {
   return DeferredCommand(std::move(supplier), requirements).ToPtr();
 }
 
 CommandPtr cmd::Defer(wpi::unique_function<CommandPtr()> supplier,
-                      std::span<Subsystem* const> requirements) {
-  return DeferredCommand(std::move(supplier), requirements).ToPtr();
-}
-
-CommandPtr cmd::Defer(wpi::unique_function<CommandPtr()> supplier,
-                      std::initializer_list<Subsystem*> requirements) {
+                      Requirements requirements) {
   return DeferredCommand(std::move(supplier), requirements).ToPtr();
 }
 

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
@@ -5,6 +5,7 @@
 #include "frc2/command/Commands.h"
 
 #include "frc2/command/ConditionalCommand.h"
+#include "frc2/command/DeferredCommand.h"
 #include "frc2/command/FunctionalCommand.h"
 #include "frc2/command/InstantCommand.h"
 #include "frc2/command/ParallelCommandGroup.h"
@@ -80,6 +81,16 @@ CommandPtr cmd::Either(CommandPtr&& onTrue, CommandPtr&& onFalse,
   return ConditionalCommand(std::move(onTrue).Unwrap(),
                             std::move(onFalse).Unwrap(), std::move(selector))
       .ToPtr();
+}
+
+CommandPtr cmd::Defer(wpi::unique_function<Command*()> supplier,
+                      std::span<Subsystem* const> requirements) {
+  return DeferredCommand(std::move(supplier), requirements).ToPtr();
+}
+
+CommandPtr cmd::Defer(wpi::unique_function<Command*()> supplier,
+                      std::initializer_list<Subsystem*> requirements) {
+  return DeferredCommand(std::move(supplier), requirements).ToPtr();
 }
 
 CommandPtr cmd::Sequence(std::vector<CommandPtr>&& commands) {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
@@ -83,11 +83,6 @@ CommandPtr cmd::Either(CommandPtr&& onTrue, CommandPtr&& onFalse,
       .ToPtr();
 }
 
-CommandPtr cmd::Defer(wpi::unique_function<Command*()> supplier,
-                      Requirements requirements) {
-  return DeferredCommand(std::move(supplier), requirements).ToPtr();
-}
-
 CommandPtr cmd::Defer(wpi::unique_function<CommandPtr()> supplier,
                       Requirements requirements) {
   return DeferredCommand(std::move(supplier), requirements).ToPtr();

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
@@ -93,6 +93,16 @@ CommandPtr cmd::Defer(wpi::unique_function<Command*()> supplier,
   return DeferredCommand(std::move(supplier), requirements).ToPtr();
 }
 
+CommandPtr cmd::Defer(wpi::unique_function<CommandPtr()> supplier,
+                      std::span<Subsystem* const> requirements) {
+  return DeferredCommand(std::move(supplier), requirements).ToPtr();
+}
+
+CommandPtr cmd::Defer(wpi::unique_function<CommandPtr()> supplier,
+                      std::initializer_list<Subsystem*> requirements) {
+  return DeferredCommand(std::move(supplier), requirements).ToPtr();
+}
+
 CommandPtr cmd::Sequence(std::vector<CommandPtr>&& commands) {
   return SequentialCommandGroup(CommandPtr::UnwrapVector(std::move(commands)))
       .ToPtr();

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/DeferredCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/DeferredCommand.cpp
@@ -11,29 +11,13 @@
 using namespace frc2;
 
 DeferredCommand::DeferredCommand(wpi::unique_function<Command*()> supplier,
-                                 std::span<Subsystem* const> requirements)
-    : m_supplier{std::move(supplier)} {
-  AddRequirements(requirements);
-}
-
-DeferredCommand::DeferredCommand(wpi::unique_function<Command*()> supplier,
-                                 std::initializer_list<Subsystem*> requirements)
+                                 Requirements requirements)
     : m_supplier{std::move(supplier)} {
   AddRequirements(requirements);
 }
 
 DeferredCommand::DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
-                                 std::span<Subsystem* const> requirements)
-    : DeferredCommand(
-          [lambdaSupplier = std::move(supplier),
-           holder = std::optional<CommandPtr>{}]() mutable {
-            holder = lambdaSupplier();
-            return holder->get();
-          },
-          requirements) {}
-
-DeferredCommand::DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
-                                 std::initializer_list<Subsystem*> requirements)
+                                 Requirements requirements)
     : DeferredCommand(
           [lambdaSupplier = std::move(supplier),
            holder = std::optional<CommandPtr>{}]() mutable {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/DeferredCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/DeferredCommand.cpp
@@ -6,33 +6,20 @@
 
 #include <wpi/sendable/SendableBuilder.h>
 
-#include "frc2/command/PrintCommand.h"
+#include "frc2/command/Commands.h"
 
 using namespace frc2;
 
-DeferredCommand::DeferredCommand(wpi::unique_function<Command*()> supplier,
+DeferredCommand::DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
                                  Requirements requirements)
     : m_supplier{std::move(supplier)} {
   AddRequirements(requirements);
 }
 
-DeferredCommand::DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
-                                 Requirements requirements)
-    : DeferredCommand(
-          [lambdaSupplier = std::move(supplier),
-           holder = std::optional<CommandPtr>{}]() mutable {
-            holder = lambdaSupplier();
-            return holder->get();
-          },
-          requirements) {}
-
 void DeferredCommand::Initialize() {
-  auto cmd = m_supplier();
-  if (cmd != nullptr) {
-    m_command = cmd;
-    CommandScheduler::GetInstance().RequireUngrouped(m_command);
-    m_command->SetComposed(true);
-  }
+  m_command = m_supplier().Unwrap();
+  CommandScheduler::GetInstance().RequireUngrouped(m_command.get());
+  m_command->SetComposed(true);
   m_command->Initialize();
 }
 
@@ -42,7 +29,10 @@ void DeferredCommand::Execute() {
 
 void DeferredCommand::End(bool interrupted) {
   m_command->End(interrupted);
-  m_command = &m_nullCommand;
+  m_command =
+      cmd::Print("[DeferredCommand] Lifecycle function called out-of-order!")
+          .WithName("none")
+          .Unwrap();
 }
 
 bool DeferredCommand::IsFinished() {
@@ -52,13 +42,5 @@ bool DeferredCommand::IsFinished() {
 void DeferredCommand::InitSendable(wpi::SendableBuilder& builder) {
   Command::InitSendable(builder);
   builder.AddStringProperty(
-      "deferred",
-      [this] {
-        if (m_command != &m_nullCommand) {
-          return m_command->GetName();
-        } else {
-          return std::string{"null"};
-        }
-      },
-      nullptr);
+      "deferred", [this] { return m_command->GetName(); }, nullptr);
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/DeferredCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/DeferredCommand.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc2/command/DeferredCommand.h"
+
+#include <wpi/sendable/SendableBuilder.h>
+
+#include "frc2/command/PrintCommand.h"
+
+using namespace frc2;
+
+DeferredCommand::DeferredCommand(wpi::unique_function<Command*()> supplier,
+                                 std::span<Subsystem* const> requirements)
+    : m_supplier{std::move(supplier)} {
+  AddRequirements(requirements);
+  ResetInternalCommand();
+}
+
+DeferredCommand::DeferredCommand(wpi::unique_function<Command*()> supplier,
+                                 std::initializer_list<Subsystem*> requirements)
+    : m_supplier{std::move(supplier)} {
+  AddRequirements(requirements);
+  ResetInternalCommand();
+}
+
+void DeferredCommand::Initialize() {
+  auto cmd = m_supplier();
+  if (cmd != nullptr) {
+    m_command = cmd;
+  }
+  CommandScheduler::GetInstance().RequireUngrouped(m_command);
+  m_command->SetComposed(true);
+  m_command->Initialize();
+}
+
+void DeferredCommand::Execute() {
+  m_command->Execute();
+}
+
+void DeferredCommand::End(bool interrupted) {
+  m_command->End(interrupted);
+}
+
+bool DeferredCommand::IsFinished() {
+  return m_command->IsFinished();
+}
+
+void DeferredCommand::InitSendable(wpi::SendableBuilder& builder) {
+  Command::InitSendable(builder);
+  builder.AddStringProperty(
+      "proxied",
+      [this] {
+        if (m_command) {
+          return m_command->GetName();
+        } else {
+          return std::string{"null"};
+        }
+      },
+      nullptr);
+}
+
+void DeferredCommand::ResetInternalCommand() {
+  m_command = new PrintCommand("[DeferredCommand] Supplied command was null!");
+}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/DeferredCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/DeferredCommand.cpp
@@ -50,7 +50,7 @@ void DeferredCommand::InitSendable(wpi::SendableBuilder& builder) {
   builder.AddStringProperty(
       "deferred",
       [this] {
-        if (m_command) {
+        if (m_command != &m_nullCommand) {
           return m_command->GetName();
         } else {
           return std::string{"null"};

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/DeferredCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/DeferredCommand.cpp
@@ -22,6 +22,26 @@ DeferredCommand::DeferredCommand(wpi::unique_function<Command*()> supplier,
   AddRequirements(requirements);
 }
 
+DeferredCommand::DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
+                                 std::span<Subsystem* const> requirements)
+    : DeferredCommand(
+          [lambdaSupplier = std::move(supplier),
+           holder = std::optional<CommandPtr>{}]() mutable {
+            holder = lambdaSupplier();
+            return holder->get();
+          },
+          requirements) {}
+
+DeferredCommand::DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
+                                 std::initializer_list<Subsystem*> requirements)
+    : DeferredCommand(
+          [lambdaSupplier = std::move(supplier),
+           holder = std::optional<CommandPtr>{}]() mutable {
+            holder = lambdaSupplier();
+            return holder->get();
+          },
+          requirements) {}
+
 void DeferredCommand::Initialize() {
   auto cmd = m_supplier();
   if (cmd != nullptr) {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/DeferredCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/DeferredCommand.cpp
@@ -49,7 +49,7 @@ bool DeferredCommand::IsFinished() {
 void DeferredCommand::InitSendable(wpi::SendableBuilder& builder) {
   Command::InitSendable(builder);
   builder.AddStringProperty(
-      "proxied",
+      "deferred",
       [this] {
         if (m_command) {
           return m_command->GetName();

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Subsystem.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Subsystem.cpp
@@ -54,3 +54,11 @@ CommandPtr Subsystem::RunEnd(std::function<void()> run,
                              std::function<void()> end) {
   return cmd::RunEnd(std::move(run), std::move(end), {this});
 }
+
+CommandPtr Subsystem::Defer(wpi::unique_function<Command*()> supplier) {
+  return cmd::Defer(std::move(supplier), {this});
+}
+
+CommandPtr Subsystem::Defer(wpi::unique_function<CommandPtr()> supplier) {
+  return cmd::Defer(std::move(supplier), {this});
+}

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Subsystem.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Subsystem.cpp
@@ -55,10 +55,6 @@ CommandPtr Subsystem::RunEnd(std::function<void()> run,
   return cmd::RunEnd(std::move(run), std::move(end), {this});
 }
 
-CommandPtr Subsystem::Defer(wpi::unique_function<Command*()> supplier) {
-  return cmd::Defer(std::move(supplier), {this});
-}
-
 CommandPtr Subsystem::Defer(wpi::unique_function<CommandPtr()> supplier) {
   return cmd::Defer(std::move(supplier), {this});
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -142,6 +142,26 @@ CommandPtr Select(std::function<Key()> selector,
 }
 
 /**
+ * Runs the command supplied by the supplier.
+ *
+ * @param supplier the command supplier
+ * @param requirements the set of requirements for this command
+ */
+[[nodiscard]]
+CommandPtr Defer(wpi::unique_function<Command*()> supplier,
+                 std::span<Subsystem* const> requirements);
+
+/**
+ * Runs the command supplied by the supplier.
+ *
+ * @param supplier the command supplier
+ * @param requirements the set of requirements for this command
+ */
+[[nodiscard]]
+CommandPtr Defer(wpi::unique_function<Command*()> supplier,
+                 std::initializer_list<Subsystem*> requirements);
+
+/**
  * Constructs a command that schedules the command returned from the supplier
  * when initialized, and ends when it is no longer scheduled. The supplier is
  * called when the command is initialized.

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -162,6 +162,26 @@ CommandPtr Defer(wpi::unique_function<Command*()> supplier,
                  std::initializer_list<Subsystem*> requirements);
 
 /**
+ * Runs the command supplied by the supplier.
+ *
+ * @param supplier the command supplier
+ * @param requirements the set of requirements for this command
+ */
+[[nodiscard]]
+CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier,
+                 std::span<Subsystem* const> requirements);
+
+/**
+ * Runs the command supplied by the supplier.
+ *
+ * @param supplier the command supplier
+ * @param requirements the set of requirements for this command
+ */
+[[nodiscard]]
+CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier,
+                 std::initializer_list<Subsystem*> requirements);
+
+/**
  * Constructs a command that schedules the command returned from the supplier
  * when initialized, and ends when it is no longer scheduled. The supplier is
  * called when the command is initialized.

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -148,16 +148,6 @@ CommandPtr Select(std::function<Key()> selector,
  * @param requirements the set of requirements for this command
  */
 [[nodiscard]]
-CommandPtr Defer(wpi::unique_function<Command*()> supplier,
-                 Requirements requirements);
-
-/**
- * Runs the command supplied by the supplier.
- *
- * @param supplier the command supplier
- * @param requirements the set of requirements for this command
- */
-[[nodiscard]]
 CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier,
                  Requirements requirements);
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -149,17 +149,7 @@ CommandPtr Select(std::function<Key()> selector,
  */
 [[nodiscard]]
 CommandPtr Defer(wpi::unique_function<Command*()> supplier,
-                 std::span<Subsystem* const> requirements);
-
-/**
- * Runs the command supplied by the supplier.
- *
- * @param supplier the command supplier
- * @param requirements the set of requirements for this command
- */
-[[nodiscard]]
-CommandPtr Defer(wpi::unique_function<Command*()> supplier,
-                 std::initializer_list<Subsystem*> requirements);
+                 Requirements requirements);
 
 /**
  * Runs the command supplied by the supplier.
@@ -169,17 +159,7 @@ CommandPtr Defer(wpi::unique_function<Command*()> supplier,
  */
 [[nodiscard]]
 CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier,
-                 std::span<Subsystem* const> requirements);
-
-/**
- * Runs the command supplied by the supplier.
- *
- * @param supplier the command supplier
- * @param requirements the set of requirements for this command
- */
-[[nodiscard]]
-CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier,
-                 std::initializer_list<Subsystem*> requirements);
+                 Requirements requirements);
 
 /**
  * Constructs a command that schedules the command returned from the supplier

--- a/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
@@ -39,20 +39,6 @@ class DeferredCommand : public CommandHelper<Command, DeferredCommand> {
    * @param requirements The command requirements.
    *
    */
-  DeferredCommand(wpi::unique_function<Command*()> supplier,
-                  Requirements requirements);
-
-  /**
-   * Creates a new DeferredCommand that runs the supplied command when
-   * initialized, and ends when it ends. Useful for lazily
-   * creating commands at runtime. The supplier will be called each time this
-   * command is initialized. The supplier <i>must</i> create a new Command each
-   * call.
-   *
-   * @param supplier The command supplier
-   * @param requirements The command requirements.
-   *
-   */
   DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
                   Requirements requirements);
 
@@ -69,8 +55,7 @@ class DeferredCommand : public CommandHelper<Command, DeferredCommand> {
   void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
-  PrintCommand m_nullCommand{"[DeferredCommand] Supplied command was null!"};
-  wpi::unique_function<Command*()> m_supplier;
-  Command* m_command{&m_nullCommand};
+  wpi::unique_function<CommandPtr()> m_supplier;
+  std::unique_ptr<Command> m_command;
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
@@ -1,0 +1,71 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <memory>
+#include <span>
+
+#include <wpi/FunctionExtras.h>
+
+#include "frc2/command/Command.h"
+#include "frc2/command/CommandHelper.h"
+#include "frc2/command/SetUtilities.h"
+
+namespace frc2 {
+/**
+ * Runs the given command when this command is initialized, and ends when it
+ * ends. Useful for performing runtime tasks before creating a new command. If
+ * this command is interrupted, it will cancel the command.
+ *
+ * <p>This class is provided by the NewCommands VendorDep
+ */
+class DeferredCommand : public CommandHelper<Command, DeferredCommand> {
+ public:
+  /**
+   * Creates a new DeferredCommand that runs the supplied command when
+   * initialized, and ends when it ends. Useful for lazily
+   * creating commands at runtime. The supplier will be called each time this
+   * command is initialized. The supplier <i>must</i> create a new Command each
+   * call.
+   *
+   * @param supplier The command supplier
+   * @param requirements The command requirements.
+   *
+   */
+  explicit DeferredCommand(wpi::unique_function<Command*()> supplier,
+                           std::span<Subsystem* const> requirements);
+
+  /**
+   * Creates a new DeferredCommand that runs the supplied command when
+   * initialized, and ends when it ends. Useful for lazily
+   * creating commands at runtime. The supplier will be called each time this
+   * command is initialized. The supplier <i>must</i> create a new Command each
+   * call.
+   *
+   * @param supplier The command supplier
+   * @param requirements The command requirements.
+   *
+   */
+  explicit DeferredCommand(wpi::unique_function<Command*()> supplier,
+                           std::initializer_list<Subsystem*> requirements);
+
+  DeferredCommand(DeferredCommand&& other) = default;
+
+  void Initialize() override;
+
+  void Execute() override;
+
+  void End(bool interrupted) override;
+
+  bool IsFinished() override;
+
+  void InitSendable(wpi::SendableBuilder& builder) override;
+
+ private:
+  wpi::unique_function<Command*()> m_supplier;
+  Command* m_command;
+  void ResetInternalCommand();
+};
+}  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
@@ -51,6 +51,34 @@ class DeferredCommand : public CommandHelper<Command, DeferredCommand> {
   explicit DeferredCommand(wpi::unique_function<Command*()> supplier,
                            std::initializer_list<Subsystem*> requirements);
 
+  /**
+   * Creates a new DeferredCommand that runs the supplied command when
+   * initialized, and ends when it ends. Useful for lazily
+   * creating commands at runtime. The supplier will be called each time this
+   * command is initialized. The supplier <i>must</i> create a new Command each
+   * call.
+   *
+   * @param supplier The command supplier
+   * @param requirements The command requirements.
+   *
+   */
+  explicit DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
+                           std::span<Subsystem* const> requirements);
+
+  /**
+   * Creates a new DeferredCommand that runs the supplied command when
+   * initialized, and ends when it ends. Useful for lazily
+   * creating commands at runtime. The supplier will be called each time this
+   * command is initialized. The supplier <i>must</i> create a new Command each
+   * call.
+   *
+   * @param supplier The command supplier
+   * @param requirements The command requirements.
+   *
+   */
+  explicit DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
+                           std::initializer_list<Subsystem*> requirements);
+
   DeferredCommand(DeferredCommand&& other) = default;
 
   void Initialize() override;

--- a/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
@@ -11,7 +11,7 @@
 
 #include "frc2/command/Command.h"
 #include "frc2/command/CommandHelper.h"
-#include "frc2/command/SetUtilities.h"
+#include "frc2/command/PrintCommand.h"
 
 namespace frc2 {
 /**
@@ -64,8 +64,8 @@ class DeferredCommand : public CommandHelper<Command, DeferredCommand> {
   void InitSendable(wpi::SendableBuilder& builder) override;
 
  private:
+  PrintCommand m_nullCommand{"[DeferredCommand] Supplied command was null!"};
   wpi::unique_function<Command*()> m_supplier;
-  Command* m_command;
-  void ResetInternalCommand();
+  Command* m_command{&m_nullCommand};
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
@@ -15,9 +15,10 @@
 
 namespace frc2 {
 /**
- * Runs the command returned by the supplier when this command is initialized,
- * and ends when it ends. Useful for performing runtime tasks before creating a
- * new command. If this command is interrupted, it will cancel the command.
+ * Defers Command construction to runtime. Runs the command returned by the
+ * supplier when this command is initialized, and ends when it ends. Useful for
+ * performing runtime tasks before creating a new command. If this command is
+ * interrupted, it will cancel the command.
  *
  * Note that the supplier <i>must</i> create a new Command each call. For
  * selecting one of a preallocated set of commands, use SelectCommand.

--- a/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
@@ -38,8 +38,8 @@ class DeferredCommand : public CommandHelper<Command, DeferredCommand> {
    * @param requirements The command requirements.
    *
    */
-  explicit DeferredCommand(wpi::unique_function<Command*()> supplier,
-                           std::span<Subsystem* const> requirements);
+  DeferredCommand(wpi::unique_function<Command*()> supplier,
+                  std::span<Subsystem* const> requirements);
 
   /**
    * Creates a new DeferredCommand that runs the supplied command when
@@ -52,8 +52,8 @@ class DeferredCommand : public CommandHelper<Command, DeferredCommand> {
    * @param requirements The command requirements.
    *
    */
-  explicit DeferredCommand(wpi::unique_function<Command*()> supplier,
-                           std::initializer_list<Subsystem*> requirements);
+  DeferredCommand(wpi::unique_function<Command*()> supplier,
+                  std::initializer_list<Subsystem*> requirements);
 
   /**
    * Creates a new DeferredCommand that runs the supplied command when
@@ -66,8 +66,8 @@ class DeferredCommand : public CommandHelper<Command, DeferredCommand> {
    * @param requirements The command requirements.
    *
    */
-  explicit DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
-                           std::span<Subsystem* const> requirements);
+  DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
+                  std::span<Subsystem* const> requirements);
 
   /**
    * Creates a new DeferredCommand that runs the supplied command when
@@ -80,8 +80,8 @@ class DeferredCommand : public CommandHelper<Command, DeferredCommand> {
    * @param requirements The command requirements.
    *
    */
-  explicit DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
-                           std::initializer_list<Subsystem*> requirements);
+  DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
+                  std::initializer_list<Subsystem*> requirements);
 
   DeferredCommand(DeferredCommand&& other) = default;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
@@ -15,9 +15,12 @@
 
 namespace frc2 {
 /**
- * Runs the given command when this command is initialized, and ends when it
- * ends. Useful for performing runtime tasks before creating a new command. If
- * this command is interrupted, it will cancel the command.
+ * Runs the command returned by the supplier when this command is initialized,
+ * and ends when it ends. Useful for performing runtime tasks before creating a
+ * new command. If this command is interrupted, it will cancel the command.
+ *
+ * Note that the supplier <i>must</i> create a new Command each call. For
+ * selecting one of a preallocated set of commands, use SelectCommand.
  *
  * <p>This class is provided by the NewCommands VendorDep
  */

--- a/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/DeferredCommand.h
@@ -12,6 +12,7 @@
 #include "frc2/command/Command.h"
 #include "frc2/command/CommandHelper.h"
 #include "frc2/command/PrintCommand.h"
+#include "frc2/command/Requirements.h"
 
 namespace frc2 {
 /**
@@ -39,21 +40,7 @@ class DeferredCommand : public CommandHelper<Command, DeferredCommand> {
    *
    */
   DeferredCommand(wpi::unique_function<Command*()> supplier,
-                  std::span<Subsystem* const> requirements);
-
-  /**
-   * Creates a new DeferredCommand that runs the supplied command when
-   * initialized, and ends when it ends. Useful for lazily
-   * creating commands at runtime. The supplier will be called each time this
-   * command is initialized. The supplier <i>must</i> create a new Command each
-   * call.
-   *
-   * @param supplier The command supplier
-   * @param requirements The command requirements.
-   *
-   */
-  DeferredCommand(wpi::unique_function<Command*()> supplier,
-                  std::initializer_list<Subsystem*> requirements);
+                  Requirements requirements);
 
   /**
    * Creates a new DeferredCommand that runs the supplied command when
@@ -67,21 +54,7 @@ class DeferredCommand : public CommandHelper<Command, DeferredCommand> {
    *
    */
   DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
-                  std::span<Subsystem* const> requirements);
-
-  /**
-   * Creates a new DeferredCommand that runs the supplied command when
-   * initialized, and ends when it ends. Useful for lazily
-   * creating commands at runtime. The supplier will be called each time this
-   * command is initialized. The supplier <i>must</i> create a new Command each
-   * call.
-   *
-   * @param supplier The command supplier
-   * @param requirements The command requirements.
-   *
-   */
-  DeferredCommand(wpi::unique_function<CommandPtr()> supplier,
-                  std::initializer_list<Subsystem*> requirements);
+                  Requirements requirements);
 
   DeferredCommand(DeferredCommand&& other) = default;
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
@@ -8,6 +8,8 @@
 #include <functional>
 #include <utility>
 
+#include <wpi/FunctionExtras.h>
+
 #include "frc2/command/CommandScheduler.h"
 
 namespace frc2 {

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
@@ -150,5 +150,25 @@ class Subsystem {
    */
   [[nodiscard]]
   CommandPtr RunEnd(std::function<void()> run, std::function<void()> end);
+
+  /**
+   * Constructs a DeferredCommand with the provided supplier. This subsystem is
+   * added as a requirement.
+   *
+   * @param supplier the command supplier.
+   * @return the command.
+   */
+  [[nodiscard]]
+  CommandPtr Defer(wpi::unique_function<Command*()> supplier);
+
+  /**
+   * Constructs a DeferredCommand with the provided supplier. This subsystem is
+   * added as a requirement.
+   *
+   * @param supplier the command supplier.
+   * @return the command.
+   */
+  [[nodiscard]]
+  CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier);
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
@@ -159,16 +159,6 @@ class Subsystem {
    * @return the command.
    */
   [[nodiscard]]
-  CommandPtr Defer(wpi::unique_function<Command*()> supplier);
-
-  /**
-   * Constructs a DeferredCommand with the provided supplier. This subsystem is
-   * added as a requirement.
-   *
-   * @param supplier the command supplier.
-   * @return the command.
-   */
-  [[nodiscard]]
   CommandPtr Defer(wpi::unique_function<CommandPtr()> supplier);
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/DeferredCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/DeferredCommandTest.java
@@ -1,0 +1,81 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj2.command;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DeferredCommandTest extends CommandTestBase {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void deferredFunctionsTest(boolean interrupted) {
+    MockCommandHolder innerCommand = new MockCommandHolder(false);
+    DeferredCommand command = new DeferredCommand(() -> innerCommand.getMock(), Set.of());
+
+    command.initialize();
+    verify(innerCommand.getMock()).initialize();
+
+    command.execute();
+    verify(innerCommand.getMock()).execute();
+
+    assertFalse(command.isFinished());
+    verify(innerCommand.getMock()).isFinished();
+
+    innerCommand.setFinished(true);
+    assertTrue(command.isFinished());
+    verify(innerCommand.getMock(), times(2)).isFinished();
+
+    command.end(interrupted);
+    verify(innerCommand.getMock()).end(interrupted);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void deferredSupplierOnlyCalledDuringInit() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      Supplier<Command> supplier = (Supplier<Command>) mock(Supplier.class);
+      when(supplier.get()).thenReturn(Commands.none(), Commands.none());
+
+      DeferredCommand command = new DeferredCommand(supplier, Set.of());
+      verify(supplier, never()).get();
+
+      scheduler.schedule(command);
+      verify(supplier, only()).get();
+      scheduler.run();
+
+      scheduler.schedule(command);
+      verify(supplier, times(2)).get();
+    }
+  }
+
+  @Test
+  void deferredRequirementsTest() {
+    Subsystem subsystem = new Subsystem() {};
+    DeferredCommand command = new DeferredCommand(() -> Commands.none(), Set.of(subsystem));
+
+    assertTrue(command.getRequirements().contains(subsystem));
+  }
+
+  @Test
+  void deferredNullCommandTest() {
+    try (CommandScheduler scheduler = new CommandScheduler()) {
+      DeferredCommand command = new DeferredCommand(() -> null, Set.of());
+      assertDoesNotThrow(() -> scheduler.schedule(command));
+    }
+  }
+}

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/DeferredCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/DeferredCommandTest.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "CommandTestBase.h"
+#include "frc2/command/Commands.h"
+#include "frc2/command/DeferredCommand.h"
+
+using namespace frc2;
+
+class DeferredCommandTest : public CommandTestBase {
+ public:
+  void DeferredFunctionsTest(bool interrupted) {
+    std::unique_ptr<MockCommand> innerHolder = std::make_unique<MockCommand>();
+    MockCommand* innerCommand = innerHolder.get();
+    DeferredCommand deferred{[innerCommand] { return innerCommand; }, {}};
+
+    EXPECT_CALL(*innerCommand, Initialize());
+    EXPECT_CALL(*innerCommand, Execute());
+    EXPECT_CALL(*innerCommand, End(interrupted));
+
+    deferred.Initialize();
+    deferred.Execute();
+    EXPECT_FALSE(deferred.IsFinished());
+    innerCommand->SetFinished(true);
+    EXPECT_TRUE(deferred.IsFinished());
+    deferred.End(interrupted);
+  }
+};
+
+TEST_F(DeferredCommandTest, DeferredFunctions) {
+  DeferredFunctionsTest(false);
+  DeferredFunctionsTest(true);
+}
+
+TEST_F(DeferredCommandTest, DeferredSupplierOnlyCalledDuringInit) {
+  int count = 0;
+  DeferredCommand command{[&count] {
+                            count++;
+                            return cmd::None();
+                          },
+                          {}};
+
+  EXPECT_EQ(0, count);
+  command.Initialize();
+  EXPECT_EQ(1, count);
+  command.Execute();
+  command.IsFinished();
+  command.End(false);
+  EXPECT_EQ(1, count);
+}
+
+TEST_F(DeferredCommandTest, DeferredRequirements) {
+  TestSubsystem subsystem;
+  DeferredCommand command{cmd::None, {&subsystem}};
+
+  EXPECT_TRUE(command.GetRequirements().contains(&subsystem));
+}
+
+TEST_F(DeferredCommandTest, DeferredNullCommand) {
+  DeferredCommand command{[] { return nullptr; }, {}};
+
+  EXPECT_NO_THROW({
+    command.Initialize();
+    command.Execute();
+    command.IsFinished();
+    command.End(false);
+  });
+}

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/DeferredCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/DeferredCommandTest.cpp
@@ -9,51 +9,48 @@
 
 using namespace frc2;
 
-class DeferredCommandTest : public CommandTestBase {
- public:
-  void DeferredFunctionsTest(bool testInterrupted) {
-    int initializeCount = 0;
-    int executeCount = 0;
-    int isFinishedCount = 0;
-    int endCount = 0;
-    bool finished = false;
+class DeferredFunctionsTest : public CommandTestBaseWithParam<bool> {};
 
-    DeferredCommand deferred{[&] {
-                               return FunctionalCommand{
-                                   [&] { initializeCount++; },
-                                   [&] { executeCount++; },
-                                   [&](bool interrupted) {
-                                     EXPECT_EQ(interrupted, testInterrupted);
-                                     endCount++;
-                                   },
-                                   [&] {
-                                     isFinishedCount++;
-                                     return finished;
-                                   }}
-                                   .ToPtr();
-                             },
-                             {}};
+TEST_P(DeferredFunctionsTest, DeferredFunctions) {
+  int initializeCount = 0;
+  int executeCount = 0;
+  int isFinishedCount = 0;
+  int endCount = 0;
+  bool finished = false;
 
-    deferred.Initialize();
-    EXPECT_EQ(1, initializeCount);
-    deferred.Execute();
-    EXPECT_EQ(1, executeCount);
-    EXPECT_FALSE(deferred.IsFinished());
-    EXPECT_EQ(1, isFinishedCount);
-    finished = true;
-    EXPECT_TRUE(deferred.IsFinished());
-    EXPECT_EQ(2, isFinishedCount);
-    deferred.End(testInterrupted);
-    EXPECT_EQ(1, endCount);
-  }
-};
+  DeferredCommand deferred{[&] {
+                             return FunctionalCommand{
+                                 [&] { initializeCount++; },
+                                 [&] { executeCount++; },
+                                 [&](bool interrupted) {
+                                   EXPECT_EQ(interrupted, GetParam());
+                                   endCount++;
+                                 },
+                                 [&] {
+                                   isFinishedCount++;
+                                   return finished;
+                                 }}
+                                 .ToPtr();
+                           },
+                           {}};
 
-TEST_F(DeferredCommandTest, DeferredFunctions) {
-  DeferredFunctionsTest(false);
-  DeferredFunctionsTest(true);
+  deferred.Initialize();
+  EXPECT_EQ(1, initializeCount);
+  deferred.Execute();
+  EXPECT_EQ(1, executeCount);
+  EXPECT_FALSE(deferred.IsFinished());
+  EXPECT_EQ(1, isFinishedCount);
+  finished = true;
+  EXPECT_TRUE(deferred.IsFinished());
+  EXPECT_EQ(2, isFinishedCount);
+  deferred.End(GetParam());
+  EXPECT_EQ(1, endCount);
 }
 
-TEST_F(DeferredCommandTest, DeferredSupplierOnlyCalledDuringInit) {
+INSTANTIATE_TEST_SUITE_P(DeferredCommandTests, DeferredFunctionsTest,
+                         testing::Values(true, false));
+
+TEST(DeferredCommandTest, DeferredSupplierOnlyCalledDuringInit) {
   int count = 0;
   DeferredCommand command{[&count] {
                             count++;
@@ -70,7 +67,7 @@ TEST_F(DeferredCommandTest, DeferredSupplierOnlyCalledDuringInit) {
   EXPECT_EQ(1, count);
 }
 
-TEST_F(DeferredCommandTest, DeferredRequirements) {
+TEST(DeferredCommandTest, DeferredRequirements) {
   TestSubsystem subsystem;
   DeferredCommand command{cmd::None, {&subsystem}};
 

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/DeferredCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/DeferredCommandTest.cpp
@@ -5,26 +5,46 @@
 #include "CommandTestBase.h"
 #include "frc2/command/Commands.h"
 #include "frc2/command/DeferredCommand.h"
+#include "frc2/command/FunctionalCommand.h"
 
 using namespace frc2;
 
 class DeferredCommandTest : public CommandTestBase {
  public:
-  void DeferredFunctionsTest(bool interrupted) {
-    std::unique_ptr<MockCommand> innerHolder = std::make_unique<MockCommand>();
-    MockCommand* innerCommand = innerHolder.get();
-    DeferredCommand deferred{[innerCommand] { return innerCommand; }, {}};
+  void DeferredFunctionsTest(bool testInterrupted) {
+    int initializeCount = 0;
+    int executeCount = 0;
+    int isFinishedCount = 0;
+    int endCount = 0;
+    bool finished = false;
 
-    EXPECT_CALL(*innerCommand, Initialize());
-    EXPECT_CALL(*innerCommand, Execute());
-    EXPECT_CALL(*innerCommand, End(interrupted));
+    DeferredCommand deferred{[&] {
+                               return FunctionalCommand{
+                                   [&] { initializeCount++; },
+                                   [&] { executeCount++; },
+                                   [&](bool interrupted) {
+                                     EXPECT_EQ(interrupted, testInterrupted);
+                                     endCount++;
+                                   },
+                                   [&] {
+                                     isFinishedCount++;
+                                     return finished;
+                                   }}
+                                   .ToPtr();
+                             },
+                             {}};
 
     deferred.Initialize();
+    EXPECT_EQ(1, initializeCount);
     deferred.Execute();
+    EXPECT_EQ(1, executeCount);
     EXPECT_FALSE(deferred.IsFinished());
-    innerCommand->SetFinished(true);
+    EXPECT_EQ(1, isFinishedCount);
+    finished = true;
     EXPECT_TRUE(deferred.IsFinished());
-    deferred.End(interrupted);
+    EXPECT_EQ(2, isFinishedCount);
+    deferred.End(testInterrupted);
+    EXPECT_EQ(1, endCount);
   }
 };
 
@@ -55,15 +75,4 @@ TEST_F(DeferredCommandTest, DeferredRequirements) {
   DeferredCommand command{cmd::None, {&subsystem}};
 
   EXPECT_TRUE(command.GetRequirements().contains(&subsystem));
-}
-
-TEST_F(DeferredCommandTest, DeferredNullCommand) {
-  DeferredCommand command{[] { return nullptr; }, {}};
-
-  EXPECT_NO_THROW({
-    command.Initialize();
-    command.Execute();
-    command.IsFinished();
-    command.End(false);
-  });
 }


### PR DESCRIPTION
Closes #5150
Allows commands to be constructed at runtime without proxying.

Requirements must be specified explicitly, even if there are no requirements. Java uses a `Set<Subsystem>`. Not sure how to accomplish this in c++. The reason for this is that requirements must be known before runtime (and therefore before the contained command is constructed, and users will likely forget to include the proper requirements. 

The other potential tripping point is that the supplier *must* create a new command each time it's called, because this is considered a command composition, so we don't want the supplied commands being used for other compositions or being scheduled directly.

Still needs c++ tests, will finish those up this weekend.