### PR TITLE
[docs] Fix dangling SelectCommand documentation (NFC)

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SelectCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SelectCommand.java
@@ -11,8 +11,8 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 /**
- * A command composition that runs one of a selection of commands, either using a selector and a key
- * to command mapping, or a supplier that returns the command directly at runtime.
+ * A command composition that runs one of a selection of commands using a selector and a key to
+ * command mapping.
  *
  * <p>The rules for command compositions apply: command instances that are passed to it cannot be
  * added to any other composition or scheduled individually, and the composition requires all

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SelectCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SelectCommand.h
@@ -24,9 +24,8 @@
 
 namespace frc2 {
 /**
- * A command composition that runs one of a selection of commands, either using
- * a selector and a key to command mapping, or a supplier that returns the
- * command directly at runtime.
+ * A command composition that runs one of a selection of commands using a
+ * selector and a key to command mapping.
  *
  * <p>The rules for command compositions apply: command instances that are
  * passed to it are owned by the composition and cannot be added to any other


### PR DESCRIPTION
Leftover description from removed Supplier constructor