### PR TITLE
[upstream_utils] Handle edge case in filename matches

### DIFF
--- a/upstream_utils/update_fmt.py
+++ b/upstream_utils/update_fmt.py
@@ -35,13 +35,13 @@ def main():
 
     # Copy fmt source files into allwpilib
     src_files = walk_cwd_and_copy_if(
-        lambda dp, f: dp.endswith("src") and f.endswith(".cc") and f != "fmt.cc",
+        lambda dp, f: dp.startswith("./src") and f.endswith(".cc") and f != "fmt.cc",
         os.path.join(wpiutil, "src/main/native/thirdparty/fmtlib"),
     )
 
     # Copy fmt header files into allwpilib
     include_files = walk_cwd_and_copy_if(
-        lambda dp, f: dp.endswith("include/fmt"),
+        lambda dp, f: dp.startswith("./include/fmt"),
         os.path.join(wpiutil, "src/main/native/thirdparty/fmtlib"),
     )
 

--- a/upstream_utils/update_gcem.py
+++ b/upstream_utils/update_gcem.py
@@ -30,9 +30,7 @@ def main():
 
     # Copy gcem include files into allwpilib
     include_files = walk_cwd_and_copy_if(
-        lambda dp, f: dp.endswith("include")
-        or dp.endswith("gcem_incl")
-        or dp.endswith("quadrature"),
+        lambda dp, f: dp.startswith("./include"),
         os.path.join(wpimath, "src/main/native/thirdparty/gcem"),
     )
 

--- a/upstream_utils/update_libuv.py
+++ b/upstream_utils/update_libuv.py
@@ -45,7 +45,7 @@ def main():
     ]
 
     include_files = walk_cwd_and_copy_if(
-        lambda dp, f: "include" in dp and f not in include_ignorelist,
+        lambda dp, f: dp.startswith("./include") and f not in include_ignorelist,
         os.path.join(wpinet, "src/main/native/thirdparty/libuv"),
     )
 
@@ -66,7 +66,7 @@ def main():
         "sysinfo-memory.c",
     ]
     src_files = walk_cwd_and_copy_if(
-        lambda dp, f: "src" in dp and "docs" not in dp and f not in src_ignorelist,
+        lambda dp, f: dp.startswith("./src") and f not in src_ignorelist,
         os.path.join(wpinet, "src/main/native/thirdparty/libuv"),
     )
 


### PR DESCRIPTION
endswith() leaves files out from subdirectories, which means projects that add new subdirectories won't have those files included when they probably should be.