### PR TITLE
Fix tool builds with multiple arm platforms installed

### DIFF
--- a/glass/publish.gradle
+++ b/glass/publish.gradle
@@ -84,6 +84,31 @@ model {
                         def applicationPath = binary.executable.file
                         def icon = file("$project.projectDir/src/app/native/mac/glass.icns")
 
+                        // Create the ZIP.
+                        def task = project.tasks.create("copyGlassExecutable" + binary.targetPlatform.operatingSystem.name + binary.targetPlatform.architecture.name, Zip) {
+                            description("Copies the Glass executable to the outputs directory.")
+                            destinationDirectory = outputsFolder
+
+                            archiveBaseName = '_M_' + zipBaseName
+                            duplicatesStrategy = 'exclude'
+                            archiveClassifier = nativeUtils.getPublishClassifier(binary)
+
+                            from(licenseFile) {
+                                into '/'
+                            }
+
+                            from(applicationPath)
+
+                            if (binary.targetPlatform.operatingSystem.isWindows()) {
+                                def exePath = binary.executable.file.absolutePath
+                                exePath = exePath.substring(0, exePath.length() - 4)
+                                def pdbPath = new File(exePath + '.pdb')
+                                from(pdbPath)
+                            }
+
+                            into(nativeUtils.getPlatformPath(binary))
+                        }
+
                         if (binary.targetPlatform.operatingSystem.isMacOsX()) {
                             // Create the macOS bundle.
                             def bundleTask = project.tasks.create("bundleGlassOsxApp" + binary.targetPlatform.architecture.name, Copy) {
@@ -129,33 +154,6 @@ model {
                             bundleTask.dependsOn binary.tasks.link
                             task.dependsOn(bundleTask)
                         }
-
-                        // Create the ZIP.
-                        def task = project.tasks.create("copyGlassExecutable" + binary.targetPlatform.operatingSystem.name + binary.targetPlatform.architecture.name, Zip) {
-                            description("Copies the Glass executable to the outputs directory.")
-                            destinationDirectory = outputsFolder
-
-                            archiveBaseName = '_M_' + zipBaseName
-                            duplicatesStrategy = 'exclude'
-                            archiveClassifier = nativeUtils.getPublishClassifier(binary)
-
-                            from(licenseFile) {
-                                into '/'
-                            }
-
-                            from(applicationPath)
-
-                            if (binary.targetPlatform.operatingSystem.isWindows()) {
-                                def exePath = binary.executable.file.absolutePath
-                                exePath = exePath.substring(0, exePath.length() - 4)
-                                def pdbPath = new File(exePath + '.pdb')
-                                from(pdbPath)
-                            }
-
-                            into(nativeUtils.getPlatformPath(binary))
-                        }
-
-
 
                         task.dependsOn binary.tasks.link
                         glassAppTaskList.add(task)

--- a/glass/publish.gradle
+++ b/glass/publish.gradle
@@ -84,51 +84,54 @@ model {
                         def applicationPath = binary.executable.file
                         def icon = file("$project.projectDir/src/app/native/mac/glass.icns")
 
-                        // Create the macOS bundle.
-                        def bundleTask = project.tasks.create("bundleGlassOsxApp" + binary.targetPlatform.architecture.name, Copy) {
-                            description("Creates a macOS application bundle for Glass")
-                            from(file("$project.projectDir/Info.plist"))
-                            into(file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/Glass.app/Contents"))
-                            into("MacOS") {
-                                with copySpec {
-                                    from binary.executable.file
+                        if (binary.targetPlatform.operatingSystem.isMacOsX()) {
+                            // Create the macOS bundle.
+                            def bundleTask = project.tasks.create("bundleGlassOsxApp" + binary.targetPlatform.architecture.name, Copy) {
+                                description("Creates a macOS application bundle for Glass")
+                                from(file("$project.projectDir/Info.plist"))
+                                into(file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/Glass.app/Contents"))
+                                into("MacOS") {
+                                    with copySpec {
+                                        from binary.executable.file
+                                    }
                                 }
-                            }
-                            into("Resources") {
-                                with copySpec {
-                                    from icon
+                                into("Resources") {
+                                    with copySpec {
+                                        from icon
+                                    }
                                 }
-                            }
 
-                            inputs.property "HasDeveloperId", project.hasProperty("developerID")
+                                inputs.property "HasDeveloperId", project.hasProperty("developerID")
 
-                            doLast {
-                                if (project.hasProperty("developerID")) {
-                                    // Get path to binary.
-                                    exec {
-                                        workingDir rootDir
-                                        def args = [
-                                            "sh",
-                                            "-c",
-                                            "codesign --force --strict --deep " +
-                                            "--timestamp --options=runtime " +
-                                            "--verbose -s ${project.findProperty("developerID")} " +
-                                            "$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/Glass.app/"
-                                        ]
-                                        commandLine args
+                                doLast {
+                                    if (project.hasProperty("developerID")) {
+                                        // Get path to binary.
+                                        exec {
+                                            workingDir rootDir
+                                            def args = [
+                                                "sh",
+                                                "-c",
+                                                "codesign --force --strict --deep " +
+                                                "--timestamp --options=runtime " +
+                                                "--verbose -s ${project.findProperty("developerID")} " +
+                                                "$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/Glass.app/"
+                                            ]
+                                            commandLine args
+                                        }
                                     }
                                 }
                             }
-                        }
 
-                        // Reset the application path if we are creating a bundle.
-                        if (binary.targetPlatform.operatingSystem.isMacOsX()) {
+                            // Reset the application path if we are creating a bundle.
                             applicationPath = file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name")
                             project.build.dependsOn bundleTask
+
+                            bundleTask.dependsOn binary.tasks.link
+                            task.dependsOn(bundleTask)
                         }
 
                         // Create the ZIP.
-                        def task = project.tasks.create("copyGlassExecutable" + binary.targetPlatform.architecture.name, Zip) {
+                        def task = project.tasks.create("copyGlassExecutable" + binary.targetPlatform.operatingSystem.name + binary.targetPlatform.architecture.name, Zip) {
                             description("Copies the Glass executable to the outputs directory.")
                             destinationDirectory = outputsFolder
 
@@ -152,10 +155,7 @@ model {
                             into(nativeUtils.getPlatformPath(binary))
                         }
 
-                        if (binary.targetPlatform.operatingSystem.isMacOsX()) {
-                            bundleTask.dependsOn binary.tasks.link
-                            task.dependsOn(bundleTask)
-                        }
+
 
                         task.dependsOn binary.tasks.link
                         glassAppTaskList.add(task)

--- a/roborioteamnumbersetter/publish.gradle
+++ b/roborioteamnumbersetter/publish.gradle
@@ -29,6 +29,31 @@ model {
                         def applicationPath = binary.executable.file
                         def icon = file("$project.projectDir/src/main/native/mac/rtns.icns")
 
+                        // Create the ZIP.
+                        def task = project.tasks.create("copyroboRIOTeamNumberSetterExecutable" + binary.targetPlatform.operatingSystem.name + binary.targetPlatform.architecture.name, Zip) {
+                            description("Copies the roboRIOTeamNumberSetter executable to the outputs directory.")
+                            destinationDirectory = outputsFolder
+
+                            archiveBaseName = '_M_' + zipBaseName
+                            duplicatesStrategy = 'exclude'
+                            archiveClassifier = nativeUtils.getPublishClassifier(binary)
+
+                            from(licenseFile) {
+                                into '/'
+                            }
+
+                            from(applicationPath)
+
+                            if (binary.targetPlatform.operatingSystem.isWindows()) {
+                                def exePath = binary.executable.file.absolutePath
+                                exePath = exePath.substring(0, exePath.length() - 4)
+                                def pdbPath = new File(exePath + '.pdb')
+                                from(pdbPath)
+                            }
+
+                            into(nativeUtils.getPlatformPath(binary))
+                        }
+
                         if (binary.targetPlatform.operatingSystem.isMacOsX()) {
                             // Create the macOS bundle.
                             def bundleTask = project.tasks.create("bundleroboRIOTeamNumberSetterOsxApp" + binary.targetPlatform.architecture.name, Copy) {
@@ -73,31 +98,6 @@ model {
 
                             bundleTask.dependsOn binary.tasks.link
                             task.dependsOn(bundleTask)
-                        }
-
-                        // Create the ZIP.
-                        def task = project.tasks.create("copyroboRIOTeamNumberSetterExecutable" + binary.targetPlatform.operatingSystem.name + binary.targetPlatform.architecture.name, Zip) {
-                            description("Copies the roboRIOTeamNumberSetter executable to the outputs directory.")
-                            destinationDirectory = outputsFolder
-
-                            archiveBaseName = '_M_' + zipBaseName
-                            duplicatesStrategy = 'exclude'
-                            archiveClassifier = nativeUtils.getPublishClassifier(binary)
-
-                            from(licenseFile) {
-                                into '/'
-                            }
-
-                            from(applicationPath)
-
-                            if (binary.targetPlatform.operatingSystem.isWindows()) {
-                                def exePath = binary.executable.file.absolutePath
-                                exePath = exePath.substring(0, exePath.length() - 4)
-                                def pdbPath = new File(exePath + '.pdb')
-                                from(pdbPath)
-                            }
-
-                            into(nativeUtils.getPlatformPath(binary))
                         }
 
                         task.dependsOn binary.tasks.link

--- a/roborioteamnumbersetter/publish.gradle
+++ b/roborioteamnumbersetter/publish.gradle
@@ -29,51 +29,54 @@ model {
                         def applicationPath = binary.executable.file
                         def icon = file("$project.projectDir/src/main/native/mac/rtns.icns")
 
-                        // Create the macOS bundle.
-                        def bundleTask = project.tasks.create("bundleroboRIOTeamNumberSetterOsxApp" + binary.targetPlatform.architecture.name, Copy) {
-                            description("Creates a macOS application bundle for roboRIO Team Number Setter")
-                            from(file("$project.projectDir/Info.plist"))
-                            into(file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/roboRIOTeamNumberSetter.app/Contents"))
-                            into("MacOS") {
-                                with copySpec {
-                                    from binary.executable.file
+                        if (binary.targetPlatform.operatingSystem.isMacOsX()) {
+                            // Create the macOS bundle.
+                            def bundleTask = project.tasks.create("bundleroboRIOTeamNumberSetterOsxApp" + binary.targetPlatform.architecture.name, Copy) {
+                                description("Creates a macOS application bundle for roboRIO Team Number Setter")
+                                from(file("$project.projectDir/Info.plist"))
+                                into(file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/roboRIOTeamNumberSetter.app/Contents"))
+                                into("MacOS") {
+                                    with copySpec {
+                                        from binary.executable.file
+                                    }
                                 }
-                            }
-                            into("Resources") {
-                                with copySpec {
-                                    from icon
+                                into("Resources") {
+                                    with copySpec {
+                                        from icon
+                                    }
                                 }
-                            }
 
-                            inputs.property "HasDeveloperId", project.hasProperty("developerID")
+                                inputs.property "HasDeveloperId", project.hasProperty("developerID")
 
-                            doLast {
-                                if (project.hasProperty("developerID")) {
-                                    // Get path to binary.
-                                    exec {
-                                        workingDir rootDir
-                                        def args = [
-                                            "sh",
-                                            "-c",
-                                            "codesign --force --strict --deep " +
-                                            "--timestamp --options=runtime " +
-                                            "--verbose -s ${project.findProperty("developerID")} " +
-                                            "$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/roboRIOTeamNumberSetter.app/"
-                                        ]
-                                        commandLine args
+                                doLast {
+                                    if (project.hasProperty("developerID")) {
+                                        // Get path to binary.
+                                        exec {
+                                            workingDir rootDir
+                                            def args = [
+                                                "sh",
+                                                "-c",
+                                                "codesign --force --strict --deep " +
+                                                "--timestamp --options=runtime " +
+                                                "--verbose -s ${project.findProperty("developerID")} " +
+                                                "$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name/roboRIOTeamNumberSetter.app/"
+                                            ]
+                                            commandLine args
+                                        }
                                     }
                                 }
                             }
-                        }
 
-                        // Reset the application path if we are creating a bundle.
-                        if (binary.targetPlatform.operatingSystem.isMacOsX()) {
+                            // Reset the application path if we are creating a bundle.
                             applicationPath = file("$project.buildDir/outputs/bundles/$binary.targetPlatform.architecture.name")
                             project.build.dependsOn bundleTask
+
+                            bundleTask.dependsOn binary.tasks.link
+                            task.dependsOn(bundleTask)
                         }
 
                         // Create the ZIP.
-                        def task = project.tasks.create("copyroboRIOTeamNumberSetterExecutable" + binary.targetPlatform.architecture.name, Zip) {
+                        def task = project.tasks.create("copyroboRIOTeamNumberSetterExecutable" + binary.targetPlatform.operatingSystem.name + binary.targetPlatform.architecture.name, Zip) {
                             description("Copies the roboRIOTeamNumberSetter executable to the outputs directory.")
                             destinationDirectory = outputsFolder
 
@@ -95,11 +98,6 @@ model {
                             }
 
                             into(nativeUtils.getPlatformPath(binary))
-                        }
-
-                        if (binary.targetPlatform.operatingSystem.isMacOsX()) {
-                            bundleTask.dependsOn binary.tasks.link
-                            task.dependsOn(bundleTask)
                         }
 
                         task.dependsOn binary.tasks.link


### PR DESCRIPTION
The logic we had for doing the mac bundles is very bad, and actually would have broken if building on macOS with the linux arm64 compiler installed. Fix it to make it slightly better and not break that case.