### PR TITLE
[ntcoreffi] Link to NI libraries

### DIFF
--- a/ntcoreffi/build.gradle
+++ b/ntcoreffi/build.gradle
@@ -61,6 +61,9 @@ model {
                 project(':ntcore').addNtcoreDependency(binary, 'static')
                 lib project: ':wpinet', library: 'wpinet', linkage: 'static'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                    nativeUtils.useRequiredLibrary(it, 'ni_link_libraries')
+                }
             }
         }
     }

--- a/ntcoreffi/build.gradle
+++ b/ntcoreffi/build.gradle
@@ -61,8 +61,8 @@ model {
                 project(':ntcore').addNtcoreDependency(binary, 'static')
                 lib project: ':wpinet', library: 'wpinet', linkage: 'static'
                 lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    nativeUtils.useRequiredLibrary(it, 'ni_link_libraries')
+                if (binary.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                    nativeUtils.useRequiredLibrary(binary, 'ni_link_libraries')
                 }
             }
         }


### PR DESCRIPTION
This is required because wpiutil depends on these libraries and is statically linked.