### PR TITLE
ProxyAll and explicit requireUnion command factories

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -6,6 +6,8 @@ package edu.wpi.first.wpilibj2.command;
 
 import static edu.wpi.first.util.ErrorMessages.requireNonNullParam;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -151,6 +153,18 @@ public final class Commands {
     return new SelectCommand(commands, selector);
   }
 
+  // Command Groups
+
+  /**
+   * Maps a list by proxying all of its elements using {@link Command#asProxy()}.
+   * 
+   * @param commands a list of commands
+   * @return a list of proxied commands
+   */
+  public static Command[] proxyAll(Command... commands) {
+    return Arrays.stream(commands).map(Command::asProxy).toArray(Command[]::new);
+  }
+
   /**
    * Runs a group of commands in series, one after the other.
    *
@@ -159,10 +173,20 @@ public final class Commands {
    * @see SequentialCommandGroup
    */
   public static Command sequence(Command... commands) {
-    return new SequentialCommandGroup(commands);
+    return sequence(true, commands);
   }
 
-  // Command Groups
+  /**
+   * Runs a group of commands in series, one after the other.
+   *
+   * @param requireUnion whether the group should require the union of its member commands' requirements
+   * @param commands the commands to include
+   * @return the command group
+   * @see SequentialCommandGroup
+   */
+  public static Command sequence(boolean requireUnion, Command... commands) {
+    return new SequentialCommandGroup(requireUnion ? commands : proxyAll(commands));
+  }
 
   /**
    * Runs a group of commands in series, one after the other. Once the last command ends, the group
@@ -185,7 +209,19 @@ public final class Commands {
    * @see ParallelCommandGroup
    */
   public static Command parallel(Command... commands) {
-    return new ParallelCommandGroup(commands);
+    return parallel(true, commands);
+  }
+
+  /**
+   * Runs a group of commands at the same time. Ends once all commands in the group finish.
+   *
+   * @param requireUnion whether the group should require the union of its member commands' requirements
+   * @param commands the commands to include
+   * @return the command
+   * @see ParallelCommandGroup
+   */
+  public static Command parallel(boolean requireUnion, Command... commands) {
+    return new ParallelCommandGroup(requireUnion ? commands : proxyAll(commands));
   }
 
   /**
@@ -197,7 +233,20 @@ public final class Commands {
    * @see ParallelRaceGroup
    */
   public static Command race(Command... commands) {
-    return new ParallelRaceGroup(commands);
+    return race(true, commands);
+  }
+
+  /**
+   * Runs a group of commands at the same time. Ends once any command in the group finishes, and
+   * cancels the others.
+   *
+   * @param requireUnion whether the group should require the union of its member commands' requirements
+   * @param commands the commands to include
+   * @return the command group
+   * @see ParallelRaceGroup
+   */
+  public static Command race(boolean requireUnion, Command... commands) {
+    return new ParallelRaceGroup(requireUnion ? commands : proxyAll(commands));
   }
 
   /**
@@ -210,7 +259,21 @@ public final class Commands {
    * @see ParallelDeadlineGroup
    */
   public static Command deadline(Command deadline, Command... commands) {
-    return new ParallelDeadlineGroup(deadline, commands);
+    return deadline(true, deadline, commands);
+  }
+
+  /**
+   * Runs a group of commands at the same time. Ends once a specific command finishes, and cancels
+   * the others.
+   *
+   * @param requireUnion whether the group should require the union of its member commands' requirements, excluding the deadline command
+   * @param deadline the deadline command
+   * @param commands the commands to include
+   * @return the command group
+   * @see ParallelDeadlineGroup
+   */
+  public static Command deadline(boolean requireUnion, Command deadline, Command... commands) {
+    return new ParallelDeadlineGroup(deadline, requireUnion ? commands : proxyAll(commands));
   }
 
   private Commands() {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
@@ -101,7 +101,14 @@ CommandPtr cmd::Either(CommandPtr&& onTrue, CommandPtr&& onFalse,
       .ToPtr();
 }
 
-CommandPtr cmd::Sequence(std::vector<CommandPtr>&& commands) {
+std::vector<CommandPtr> cmd::ProxyAll(std::vector<CommandPtr>&& commands) {
+  auto unwrapped = CommandPtr::UnwrapVector(std::move(commands));
+  std::vector<std::unique_ptr<frc2::Command>> out(commands.size());
+  std::transform(unwrapped.begin(), unwrapped.end(), out, Command::AsProxy);
+  return out.ToPtr();
+}
+
+CommandPtr cmd::Sequence(bool requireUnion = false, std::vector<CommandPtr>&& commands) {
   return SequentialCommandGroup(CommandPtr::UnwrapVector(std::move(commands)))
       .ToPtr();
 }

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -204,6 +204,9 @@ std::vector<CommandPtr> MakeVector(Args&&... args) {
 
 }  // namespace impl
 
+[[nodiscard]]
+std::vector<CommandPtr> ProxyAll(std::vector<CommandPtr>&& commands);
+
 /**
  * Runs a group of commands in series, one after the other.
  */


### PR DESCRIPTION
resolves #5604 and #5294

Based on further discussion in the discord, mutable command requirements shouldn't be supported.  That leaves several possible implementations for optionally not requiring the union of member commands in command groups.

```java
Commands.sequence(score(...), drive.followPath(...)).withUnionRequirements(false);

Commands.sequence(Commands.proxyAll(score(...), drive.followPath(...)));

Commands.sequence(score(...), drive.followPath(...)).withDefaultCommands(arm.holdState());

Commands.sequence(false, score(...), drive.followPath(...));
```

Out of these options, `withUnionRequirements` and `withDefaultCommands` would be methods of both `SequentialCommandGroup` and `ParallelComandGroup`. Currently, WPILib's command classes don't extend beyond the `Command` interface at all, meaning these methods would be a strange exception for configuring `CommandGroup` specific features. The implication of this, a general `CommandGroup` superclass is undesirable, since it introduces an unnecessary inheritance tree to an otherwise simple framework.

One advantage that `withUnionRequirements` over `proxyAll` has is that it focuses more on results than implementation, resulting in a more obvious api. Discoverability is very important in this api, since teams must be able to easily and consistently avoid the pitfalls of default commands being blocked by requirement unions. `proxyAll` is not discoverable enough, since every member of a programming team would need to constantly think about requirements to understand where to put `proxyAll`, and could easily miss somewhere.

Instead, this pr introduces `proxyAll` as a utility function for more discoverable command factory overloads.
For example, an auto sequence could be formed using:
```java
Commands.sequence(false, score(Location.HIGH), drive.followPath(path), intake());
```
and existing commands such as
```java
public Command followPath(Path path) {
    return Commands.sequence(resetOdometry(path.start()), new ExamplePathFolowingCommand(path, odometry, kinematics, this::setVoltages), stop());
}
would still work.