### PR TITLE
[wpimath] Fix computation of C for DARE (A, C) detectability check

### DIFF
--- a/wpimath/src/main/native/include/frc/DARE.h
+++ b/wpimath/src/main/native/include/frc/DARE.h
@@ -73,10 +73,13 @@ void CheckDARE_ABQ(const Eigen::Matrix<double, States, States>& A,
   }
 
   // Require (A, C) pair be detectable where Q = CᵀC
+  //
+  // Q = CᵀC = LDLᵀ
+  // C = √(D)Lᵀ
   {
     Eigen::Matrix<double, States, States> C =
-        Eigen::Matrix<double, States, States>{Q_ldlt.matrixL()} *
-        Q_ldlt.vectorD().cwiseSqrt().asDiagonal();
+        Q_ldlt.vectorD().cwiseSqrt().asDiagonal() *
+        Eigen::Matrix<double, States, States>{Q_ldlt.matrixL().transpose()};
 
     if (!IsDetectable<States, States>(A, C)) {
       std::string msg = fmt::format(


### PR DESCRIPTION
If Q has off-diagonal entries, C and Cᵀ are different.