### PR TITLE
Switch to Java 17 api docs

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -209,7 +209,7 @@ apply from: "${rootDir}/shared/opencv.gradle"
 
 task generateJavaDocs(type: Javadoc) {
     classpath += project(":wpimath").sourceSets.main.compileClasspath
-    options.links("https://docs.oracle.com/en/java/javase/11/docs/api/")
+    options.links("https://docs.oracle.com/en/java/javase/17/docs/api/")
     options.addStringOption("tag", "pre:a:Pre-Condition")
     options.addBooleanOption("Xdoclint:html,missing,reference,syntax", true)
     options.addBooleanOption('html5', true)


### PR DESCRIPTION
Since user projects now use JDK 17, we should link to JDK 17 docs