### PR TITLE
[build] Specify zlib for debug info compression

### DIFF
--- a/cmake/modules/CompileWarnings.cmake
+++ b/cmake/modules/CompileWarnings.cmake
@@ -15,6 +15,6 @@ macro(wpilib_target_warnings target)
 
     # Compress debug info with GCC
     if (${CMAKE_BUILD_TYPE} STREQUAL "Debug" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
-      target_compile_options(${target} PRIVATE -gz)
+      target_compile_options(${target} PRIVATE -gz=zlib)
     endif()
 endmacro()

--- a/shared/config.gradle
+++ b/shared/config.gradle
@@ -46,7 +46,7 @@ nativeUtils.platformConfigs.each {
 // Compress debug info on Linux
 nativeUtils.platformConfigs.each {
   if (it.name.contains('linux')) {
-    it.cppCompiler.debugArgs.add("-gz")
+    it.cppCompiler.debugArgs.add("-gz=zlib")
   }
 }
 


### PR DESCRIPTION
This was required to make compression actually occur on my local machine.