### PR TITLE
[wpimath] Move PIDController from frc2 to frc namespace

### DIFF
--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/MecanumControllerCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/MecanumControllerCommand.cpp
@@ -11,16 +11,16 @@ using namespace frc2;
 MecanumControllerCommand::MecanumControllerCommand(
     frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
     frc::SimpleMotorFeedforward<units::meters> feedforward,
-    frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-    frc2::PIDController yController,
+    frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+    frc::PIDController yController,
     frc::ProfiledPIDController<units::radians> thetaController,
     std::function<frc::Rotation2d()> desiredRotation,
     units::meters_per_second_t maxWheelVelocity,
     std::function<frc::MecanumDriveWheelSpeeds()> currentWheelSpeeds,
-    frc2::PIDController frontLeftController,
-    frc2::PIDController rearLeftController,
-    frc2::PIDController frontRightController,
-    frc2::PIDController rearRightController,
+    frc::PIDController frontLeftController,
+    frc::PIDController rearLeftController,
+    frc::PIDController frontRightController,
+    frc::PIDController rearRightController,
     std::function<void(units::volt_t, units::volt_t, units::volt_t,
                        units::volt_t)>
         output,
@@ -33,13 +33,13 @@ MecanumControllerCommand::MecanumControllerCommand(
       m_desiredRotation(std::move(desiredRotation)),
       m_maxWheelVelocity(maxWheelVelocity),
       m_frontLeftController(
-          std::make_unique<frc2::PIDController>(frontLeftController)),
+          std::make_unique<frc::PIDController>(frontLeftController)),
       m_rearLeftController(
-          std::make_unique<frc2::PIDController>(rearLeftController)),
+          std::make_unique<frc::PIDController>(rearLeftController)),
       m_frontRightController(
-          std::make_unique<frc2::PIDController>(frontRightController)),
+          std::make_unique<frc::PIDController>(frontRightController)),
       m_rearRightController(
-          std::make_unique<frc2::PIDController>(rearRightController)),
+          std::make_unique<frc::PIDController>(rearRightController)),
       m_currentWheelSpeeds(std::move(currentWheelSpeeds)),
       m_outputVolts(std::move(output)),
       m_usePID(true) {
@@ -49,15 +49,15 @@ MecanumControllerCommand::MecanumControllerCommand(
 MecanumControllerCommand::MecanumControllerCommand(
     frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
     frc::SimpleMotorFeedforward<units::meters> feedforward,
-    frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-    frc2::PIDController yController,
+    frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+    frc::PIDController yController,
     frc::ProfiledPIDController<units::radians> thetaController,
     units::meters_per_second_t maxWheelVelocity,
     std::function<frc::MecanumDriveWheelSpeeds()> currentWheelSpeeds,
-    frc2::PIDController frontLeftController,
-    frc2::PIDController rearLeftController,
-    frc2::PIDController frontRightController,
-    frc2::PIDController rearRightController,
+    frc::PIDController frontLeftController,
+    frc::PIDController rearLeftController,
+    frc::PIDController frontRightController,
+    frc::PIDController rearRightController,
     std::function<void(units::volt_t, units::volt_t, units::volt_t,
                        units::volt_t)>
         output,
@@ -69,13 +69,13 @@ MecanumControllerCommand::MecanumControllerCommand(
       m_controller(xController, yController, thetaController),
       m_maxWheelVelocity(maxWheelVelocity),
       m_frontLeftController(
-          std::make_unique<frc2::PIDController>(frontLeftController)),
+          std::make_unique<frc::PIDController>(frontLeftController)),
       m_rearLeftController(
-          std::make_unique<frc2::PIDController>(rearLeftController)),
+          std::make_unique<frc::PIDController>(rearLeftController)),
       m_frontRightController(
-          std::make_unique<frc2::PIDController>(frontRightController)),
+          std::make_unique<frc::PIDController>(frontRightController)),
       m_rearRightController(
-          std::make_unique<frc2::PIDController>(rearRightController)),
+          std::make_unique<frc::PIDController>(rearRightController)),
       m_currentWheelSpeeds(std::move(currentWheelSpeeds)),
       m_outputVolts(std::move(output)),
       m_usePID(true) {
@@ -85,16 +85,16 @@ MecanumControllerCommand::MecanumControllerCommand(
 MecanumControllerCommand::MecanumControllerCommand(
     frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
     frc::SimpleMotorFeedforward<units::meters> feedforward,
-    frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-    frc2::PIDController yController,
+    frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+    frc::PIDController yController,
     frc::ProfiledPIDController<units::radians> thetaController,
     std::function<frc::Rotation2d()> desiredRotation,
     units::meters_per_second_t maxWheelVelocity,
     std::function<frc::MecanumDriveWheelSpeeds()> currentWheelSpeeds,
-    frc2::PIDController frontLeftController,
-    frc2::PIDController rearLeftController,
-    frc2::PIDController frontRightController,
-    frc2::PIDController rearRightController,
+    frc::PIDController frontLeftController,
+    frc::PIDController rearLeftController,
+    frc::PIDController frontRightController,
+    frc::PIDController rearRightController,
     std::function<void(units::volt_t, units::volt_t, units::volt_t,
                        units::volt_t)>
         output,
@@ -107,13 +107,13 @@ MecanumControllerCommand::MecanumControllerCommand(
       m_desiredRotation(std::move(desiredRotation)),
       m_maxWheelVelocity(maxWheelVelocity),
       m_frontLeftController(
-          std::make_unique<frc2::PIDController>(frontLeftController)),
+          std::make_unique<frc::PIDController>(frontLeftController)),
       m_rearLeftController(
-          std::make_unique<frc2::PIDController>(rearLeftController)),
+          std::make_unique<frc::PIDController>(rearLeftController)),
       m_frontRightController(
-          std::make_unique<frc2::PIDController>(frontRightController)),
+          std::make_unique<frc::PIDController>(frontRightController)),
       m_rearRightController(
-          std::make_unique<frc2::PIDController>(rearRightController)),
+          std::make_unique<frc::PIDController>(rearRightController)),
       m_currentWheelSpeeds(std::move(currentWheelSpeeds)),
       m_outputVolts(std::move(output)),
       m_usePID(true) {
@@ -123,15 +123,15 @@ MecanumControllerCommand::MecanumControllerCommand(
 MecanumControllerCommand::MecanumControllerCommand(
     frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
     frc::SimpleMotorFeedforward<units::meters> feedforward,
-    frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-    frc2::PIDController yController,
+    frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+    frc::PIDController yController,
     frc::ProfiledPIDController<units::radians> thetaController,
     units::meters_per_second_t maxWheelVelocity,
     std::function<frc::MecanumDriveWheelSpeeds()> currentWheelSpeeds,
-    frc2::PIDController frontLeftController,
-    frc2::PIDController rearLeftController,
-    frc2::PIDController frontRightController,
-    frc2::PIDController rearRightController,
+    frc::PIDController frontLeftController,
+    frc::PIDController rearLeftController,
+    frc::PIDController frontRightController,
+    frc::PIDController rearRightController,
     std::function<void(units::volt_t, units::volt_t, units::volt_t,
                        units::volt_t)>
         output,
@@ -143,13 +143,13 @@ MecanumControllerCommand::MecanumControllerCommand(
       m_controller(xController, yController, thetaController),
       m_maxWheelVelocity(maxWheelVelocity),
       m_frontLeftController(
-          std::make_unique<frc2::PIDController>(frontLeftController)),
+          std::make_unique<frc::PIDController>(frontLeftController)),
       m_rearLeftController(
-          std::make_unique<frc2::PIDController>(rearLeftController)),
+          std::make_unique<frc::PIDController>(rearLeftController)),
       m_frontRightController(
-          std::make_unique<frc2::PIDController>(frontRightController)),
+          std::make_unique<frc::PIDController>(frontRightController)),
       m_rearRightController(
-          std::make_unique<frc2::PIDController>(rearRightController)),
+          std::make_unique<frc::PIDController>(rearRightController)),
       m_currentWheelSpeeds(std::move(currentWheelSpeeds)),
       m_outputVolts(std::move(output)),
       m_usePID(true) {
@@ -158,8 +158,8 @@ MecanumControllerCommand::MecanumControllerCommand(
 
 MecanumControllerCommand::MecanumControllerCommand(
     frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-    frc2::PIDController yController,
+    frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+    frc::PIDController yController,
     frc::ProfiledPIDController<units::radians> thetaController,
     std::function<frc::Rotation2d()> desiredRotation,
     units::meters_per_second_t maxWheelVelocity,
@@ -180,8 +180,8 @@ MecanumControllerCommand::MecanumControllerCommand(
 
 MecanumControllerCommand::MecanumControllerCommand(
     frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-    frc2::PIDController yController,
+    frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+    frc::PIDController yController,
     frc::ProfiledPIDController<units::radians> thetaController,
     units::meters_per_second_t maxWheelVelocity,
     std::function<void(units::meters_per_second_t, units::meters_per_second_t,
@@ -200,8 +200,8 @@ MecanumControllerCommand::MecanumControllerCommand(
 
 MecanumControllerCommand::MecanumControllerCommand(
     frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-    frc2::PIDController yController,
+    frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+    frc::PIDController yController,
     frc::ProfiledPIDController<units::radians> thetaController,
     std::function<frc::Rotation2d()> desiredRotation,
     units::meters_per_second_t maxWheelVelocity,
@@ -222,8 +222,8 @@ MecanumControllerCommand::MecanumControllerCommand(
 
 MecanumControllerCommand::MecanumControllerCommand(
     frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-    frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-    frc2::PIDController yController,
+    frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+    frc::PIDController yController,
     frc::ProfiledPIDController<units::radians> thetaController,
     units::meters_per_second_t maxWheelVelocity,
     std::function<void(units::meters_per_second_t, units::meters_per_second_t,

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/PIDCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/PIDCommand.cpp
@@ -8,7 +8,7 @@
 
 using namespace frc2;
 
-PIDCommand::PIDCommand(PIDController controller,
+PIDCommand::PIDCommand(frc::PIDController controller,
                        std::function<double()> measurementSource,
                        std::function<double()> setpointSource,
                        std::function<void(double)> useOutput,
@@ -20,7 +20,7 @@ PIDCommand::PIDCommand(PIDController controller,
   AddRequirements(requirements);
 }
 
-PIDCommand::PIDCommand(PIDController controller,
+PIDCommand::PIDCommand(frc::PIDController controller,
                        std::function<double()> measurementSource,
                        std::function<double()> setpointSource,
                        std::function<void(double)> useOutput,
@@ -32,7 +32,7 @@ PIDCommand::PIDCommand(PIDController controller,
   AddRequirements(requirements);
 }
 
-PIDCommand::PIDCommand(PIDController controller,
+PIDCommand::PIDCommand(frc::PIDController controller,
                        std::function<double()> measurementSource,
                        double setpoint, std::function<void(double)> useOutput,
                        std::initializer_list<Subsystem*> requirements)
@@ -40,7 +40,7 @@ PIDCommand::PIDCommand(PIDController controller,
           controller, measurementSource, [setpoint] { return setpoint; },
           useOutput, requirements) {}
 
-PIDCommand::PIDCommand(PIDController controller,
+PIDCommand::PIDCommand(frc::PIDController controller,
                        std::function<double()> measurementSource,
                        double setpoint, std::function<void(double)> useOutput,
                        std::span<Subsystem* const> requirements)
@@ -60,6 +60,6 @@ void PIDCommand::End(bool interrupted) {
   m_useOutput(0);
 }
 
-PIDController& PIDCommand::GetController() {
+frc::PIDController& PIDCommand::GetController() {
   return m_controller;
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/PIDSubsystem.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/PIDSubsystem.cpp
@@ -8,7 +8,8 @@
 
 using namespace frc2;
 
-PIDSubsystem::PIDSubsystem(PIDController controller, double initialPosition)
+PIDSubsystem::PIDSubsystem(frc::PIDController controller,
+                           double initialPosition)
     : m_controller{std::move(controller)} {
   SetSetpoint(initialPosition);
   AddChild("PID Controller", &m_controller);
@@ -42,6 +43,6 @@ bool PIDSubsystem::IsEnabled() {
   return m_enabled;
 }
 
-PIDController& PIDSubsystem::GetController() {
+frc::PIDController& PIDSubsystem::GetController() {
   return m_controller;
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/RamseteCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/RamseteCommand.cpp
@@ -16,7 +16,7 @@ RamseteCommand::RamseteCommand(
     frc::SimpleMotorFeedforward<units::meters> feedforward,
     frc::DifferentialDriveKinematics kinematics,
     std::function<frc::DifferentialDriveWheelSpeeds()> wheelSpeeds,
-    frc2::PIDController leftController, frc2::PIDController rightController,
+    frc::PIDController leftController, frc::PIDController rightController,
     std::function<void(units::volt_t, units::volt_t)> output,
     std::initializer_list<Subsystem*> requirements)
     : m_trajectory(std::move(trajectory)),
@@ -25,8 +25,8 @@ RamseteCommand::RamseteCommand(
       m_feedforward(feedforward),
       m_kinematics(std::move(kinematics)),
       m_speeds(std::move(wheelSpeeds)),
-      m_leftController(std::make_unique<frc2::PIDController>(leftController)),
-      m_rightController(std::make_unique<frc2::PIDController>(rightController)),
+      m_leftController(std::make_unique<frc::PIDController>(leftController)),
+      m_rightController(std::make_unique<frc::PIDController>(rightController)),
       m_outputVolts(std::move(output)),
       m_usePID(true) {
   AddRequirements(requirements);
@@ -38,7 +38,7 @@ RamseteCommand::RamseteCommand(
     frc::SimpleMotorFeedforward<units::meters> feedforward,
     frc::DifferentialDriveKinematics kinematics,
     std::function<frc::DifferentialDriveWheelSpeeds()> wheelSpeeds,
-    frc2::PIDController leftController, frc2::PIDController rightController,
+    frc::PIDController leftController, frc::PIDController rightController,
     std::function<void(units::volt_t, units::volt_t)> output,
     std::span<Subsystem* const> requirements)
     : m_trajectory(std::move(trajectory)),
@@ -47,8 +47,8 @@ RamseteCommand::RamseteCommand(
       m_feedforward(feedforward),
       m_kinematics(std::move(kinematics)),
       m_speeds(std::move(wheelSpeeds)),
-      m_leftController(std::make_unique<frc2::PIDController>(leftController)),
-      m_rightController(std::make_unique<frc2::PIDController>(rightController)),
+      m_leftController(std::make_unique<frc::PIDController>(leftController)),
+      m_rightController(std::make_unique<frc::PIDController>(rightController)),
       m_outputVolts(std::move(output)),
       m_usePID(true) {
   AddRequirements(requirements);

--- a/wpilibNewCommands/src/main/native/include/frc2/command/MecanumControllerCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/MecanumControllerCommand.h
@@ -89,16 +89,16 @@ class MecanumControllerCommand
   MecanumControllerCommand(
       frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
       frc::SimpleMotorFeedforward<units::meters> feedforward,
-      frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-      frc2::PIDController yController,
+      frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+      frc::PIDController yController,
       frc::ProfiledPIDController<units::radians> thetaController,
       std::function<frc::Rotation2d()> desiredRotation,
       units::meters_per_second_t maxWheelVelocity,
       std::function<frc::MecanumDriveWheelSpeeds()> currentWheelSpeeds,
-      frc2::PIDController frontLeftController,
-      frc2::PIDController rearLeftController,
-      frc2::PIDController frontRightController,
-      frc2::PIDController rearRightController,
+      frc::PIDController frontLeftController,
+      frc::PIDController rearLeftController,
+      frc::PIDController frontRightController,
+      frc::PIDController rearRightController,
       std::function<void(units::volt_t, units::volt_t, units::volt_t,
                          units::volt_t)>
           output,
@@ -143,15 +143,15 @@ class MecanumControllerCommand
   MecanumControllerCommand(
       frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
       frc::SimpleMotorFeedforward<units::meters> feedforward,
-      frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-      frc2::PIDController yController,
+      frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+      frc::PIDController yController,
       frc::ProfiledPIDController<units::radians> thetaController,
       units::meters_per_second_t maxWheelVelocity,
       std::function<frc::MecanumDriveWheelSpeeds()> currentWheelSpeeds,
-      frc2::PIDController frontLeftController,
-      frc2::PIDController rearLeftController,
-      frc2::PIDController frontRightController,
-      frc2::PIDController rearRightController,
+      frc::PIDController frontLeftController,
+      frc::PIDController rearLeftController,
+      frc::PIDController frontRightController,
+      frc::PIDController rearRightController,
       std::function<void(units::volt_t, units::volt_t, units::volt_t,
                          units::volt_t)>
           output,
@@ -193,16 +193,16 @@ class MecanumControllerCommand
   MecanumControllerCommand(
       frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
       frc::SimpleMotorFeedforward<units::meters> feedforward,
-      frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-      frc2::PIDController yController,
+      frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+      frc::PIDController yController,
       frc::ProfiledPIDController<units::radians> thetaController,
       std::function<frc::Rotation2d()> desiredRotation,
       units::meters_per_second_t maxWheelVelocity,
       std::function<frc::MecanumDriveWheelSpeeds()> currentWheelSpeeds,
-      frc2::PIDController frontLeftController,
-      frc2::PIDController rearLeftController,
-      frc2::PIDController frontRightController,
-      frc2::PIDController rearRightController,
+      frc::PIDController frontLeftController,
+      frc::PIDController rearLeftController,
+      frc::PIDController frontRightController,
+      frc::PIDController rearRightController,
       std::function<void(units::volt_t, units::volt_t, units::volt_t,
                          units::volt_t)>
           output,
@@ -247,15 +247,15 @@ class MecanumControllerCommand
   MecanumControllerCommand(
       frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
       frc::SimpleMotorFeedforward<units::meters> feedforward,
-      frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-      frc2::PIDController yController,
+      frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+      frc::PIDController yController,
       frc::ProfiledPIDController<units::radians> thetaController,
       units::meters_per_second_t maxWheelVelocity,
       std::function<frc::MecanumDriveWheelSpeeds()> currentWheelSpeeds,
-      frc2::PIDController frontLeftController,
-      frc2::PIDController rearLeftController,
-      frc2::PIDController frontRightController,
-      frc2::PIDController rearRightController,
+      frc::PIDController frontLeftController,
+      frc::PIDController rearLeftController,
+      frc::PIDController frontRightController,
+      frc::PIDController rearRightController,
       std::function<void(units::volt_t, units::volt_t, units::volt_t,
                          units::volt_t)>
           output,
@@ -288,8 +288,8 @@ class MecanumControllerCommand
    */
   MecanumControllerCommand(
       frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-      frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-      frc2::PIDController yController,
+      frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+      frc::PIDController yController,
       frc::ProfiledPIDController<units::radians> thetaController,
       std::function<frc::Rotation2d()> desiredRotation,
       units::meters_per_second_t maxWheelVelocity,
@@ -329,8 +329,8 @@ class MecanumControllerCommand
    */
   MecanumControllerCommand(
       frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-      frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-      frc2::PIDController yController,
+      frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+      frc::PIDController yController,
       frc::ProfiledPIDController<units::radians> thetaController,
       units::meters_per_second_t maxWheelVelocity,
       std::function<void(units::meters_per_second_t, units::meters_per_second_t,
@@ -366,8 +366,8 @@ class MecanumControllerCommand
    */
   MecanumControllerCommand(
       frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-      frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-      frc2::PIDController yController,
+      frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+      frc::PIDController yController,
       frc::ProfiledPIDController<units::radians> thetaController,
       std::function<frc::Rotation2d()> desiredRotation,
       units::meters_per_second_t maxWheelVelocity,
@@ -407,8 +407,8 @@ class MecanumControllerCommand
    */
   MecanumControllerCommand(
       frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
-      frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
-      frc2::PIDController yController,
+      frc::MecanumDriveKinematics kinematics, frc::PIDController xController,
+      frc::PIDController yController,
       frc::ProfiledPIDController<units::radians> thetaController,
       units::meters_per_second_t maxWheelVelocity,
       std::function<void(units::meters_per_second_t, units::meters_per_second_t,
@@ -433,10 +433,10 @@ class MecanumControllerCommand
   frc::HolonomicDriveController m_controller;
   std::function<frc::Rotation2d()> m_desiredRotation;
   const units::meters_per_second_t m_maxWheelVelocity;
-  std::unique_ptr<frc2::PIDController> m_frontLeftController;
-  std::unique_ptr<frc2::PIDController> m_rearLeftController;
-  std::unique_ptr<frc2::PIDController> m_frontRightController;
-  std::unique_ptr<frc2::PIDController> m_rearRightController;
+  std::unique_ptr<frc::PIDController> m_frontLeftController;
+  std::unique_ptr<frc::PIDController> m_rearLeftController;
+  std::unique_ptr<frc::PIDController> m_frontRightController;
+  std::unique_ptr<frc::PIDController> m_rearRightController;
   std::function<frc::MecanumDriveWheelSpeeds()> m_currentWheelSpeeds;
   std::function<void(units::meters_per_second_t, units::meters_per_second_t,
                      units::meters_per_second_t, units::meters_per_second_t)>

--- a/wpilibNewCommands/src/main/native/include/frc2/command/PIDCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/PIDCommand.h
@@ -36,7 +36,7 @@ class PIDCommand : public CommandHelper<Command, PIDCommand> {
    * @param useOutput         the controller's output
    * @param requirements      the subsystems required by this command
    */
-  PIDCommand(PIDController controller,
+  PIDCommand(frc::PIDController controller,
              std::function<double()> measurementSource,
              std::function<double()> setpointSource,
              std::function<void(double)> useOutput,
@@ -52,7 +52,7 @@ class PIDCommand : public CommandHelper<Command, PIDCommand> {
    * @param useOutput         the controller's output
    * @param requirements      the subsystems required by this command
    */
-  PIDCommand(PIDController controller,
+  PIDCommand(frc::PIDController controller,
              std::function<double()> measurementSource,
              std::function<double()> setpointSource,
              std::function<void(double)> useOutput,
@@ -68,7 +68,7 @@ class PIDCommand : public CommandHelper<Command, PIDCommand> {
    * @param useOutput         the controller's output
    * @param requirements      the subsystems required by this command
    */
-  PIDCommand(PIDController controller,
+  PIDCommand(frc::PIDController controller,
              std::function<double()> measurementSource, double setpoint,
              std::function<void(double)> useOutput,
              std::initializer_list<Subsystem*> requirements);
@@ -83,7 +83,7 @@ class PIDCommand : public CommandHelper<Command, PIDCommand> {
    * @param useOutput         the controller's output
    * @param requirements      the subsystems required by this command
    */
-  PIDCommand(PIDController controller,
+  PIDCommand(frc::PIDController controller,
              std::function<double()> measurementSource, double setpoint,
              std::function<void(double)> useOutput,
              std::span<Subsystem* const> requirements = {});
@@ -103,10 +103,10 @@ class PIDCommand : public CommandHelper<Command, PIDCommand> {
    *
    * @return The PIDController
    */
-  PIDController& GetController();
+  frc::PIDController& GetController();
 
  protected:
-  PIDController m_controller;
+  frc::PIDController m_controller;
   std::function<double()> m_measurement;
   std::function<double()> m_setpoint;
   std::function<void(double)> m_useOutput;

--- a/wpilibNewCommands/src/main/native/include/frc2/command/PIDSubsystem.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/PIDSubsystem.h
@@ -25,7 +25,8 @@ class PIDSubsystem : public SubsystemBase {
    * @param controller the PIDController to use
    * @param initialPosition the initial setpoint of the subsystem
    */
-  explicit PIDSubsystem(PIDController controller, double initialPosition = 0);
+  explicit PIDSubsystem(frc::PIDController controller,
+                        double initialPosition = 0);
 
   void Periodic() override;
 
@@ -65,10 +66,10 @@ class PIDSubsystem : public SubsystemBase {
    *
    * @return The controller.
    */
-  PIDController& GetController();
+  frc::PIDController& GetController();
 
  protected:
-  PIDController m_controller;
+  frc::PIDController m_controller;
   bool m_enabled{false};
 
   /**

--- a/wpilibNewCommands/src/main/native/include/frc2/command/RamseteCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/RamseteCommand.h
@@ -76,8 +76,8 @@ class RamseteCommand : public CommandHelper<Command, RamseteCommand> {
                  frc::SimpleMotorFeedforward<units::meters> feedforward,
                  frc::DifferentialDriveKinematics kinematics,
                  std::function<frc::DifferentialDriveWheelSpeeds()> wheelSpeeds,
-                 frc2::PIDController leftController,
-                 frc2::PIDController rightController,
+                 frc::PIDController leftController,
+                 frc::PIDController rightController,
                  std::function<void(units::volt_t, units::volt_t)> output,
                  std::initializer_list<Subsystem*> requirements);
 
@@ -113,8 +113,8 @@ class RamseteCommand : public CommandHelper<Command, RamseteCommand> {
                  frc::SimpleMotorFeedforward<units::meters> feedforward,
                  frc::DifferentialDriveKinematics kinematics,
                  std::function<frc::DifferentialDriveWheelSpeeds()> wheelSpeeds,
-                 frc2::PIDController leftController,
-                 frc2::PIDController rightController,
+                 frc::PIDController leftController,
+                 frc::PIDController rightController,
                  std::function<void(units::volt_t, units::volt_t)> output,
                  std::span<Subsystem* const> requirements = {});
 
@@ -183,8 +183,8 @@ class RamseteCommand : public CommandHelper<Command, RamseteCommand> {
   frc::SimpleMotorFeedforward<units::meters> m_feedforward;
   frc::DifferentialDriveKinematics m_kinematics;
   std::function<frc::DifferentialDriveWheelSpeeds()> m_speeds;
-  std::unique_ptr<frc2::PIDController> m_leftController;
-  std::unique_ptr<frc2::PIDController> m_rightController;
+  std::unique_ptr<frc::PIDController> m_leftController;
+  std::unique_ptr<frc::PIDController> m_rightController;
   std::function<void(units::volt_t, units::volt_t)> m_outputVolts;
   std::function<void(units::meters_per_second_t, units::meters_per_second_t)>
       m_outputVel;

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SwerveControllerCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SwerveControllerCommand.h
@@ -89,7 +89,7 @@ class SwerveControllerCommand
   SwerveControllerCommand(
       frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
       frc::SwerveDriveKinematics<NumModules> kinematics,
-      frc2::PIDController xController, frc2::PIDController yController,
+      frc::PIDController xController, frc::PIDController yController,
       frc::ProfiledPIDController<units::radians> thetaController,
       std::function<frc::Rotation2d()> desiredRotation,
       std::function<void(std::array<frc::SwerveModuleState, NumModules>)>
@@ -128,7 +128,7 @@ class SwerveControllerCommand
   SwerveControllerCommand(
       frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
       frc::SwerveDriveKinematics<NumModules> kinematics,
-      frc2::PIDController xController, frc2::PIDController yController,
+      frc::PIDController xController, frc::PIDController yController,
       frc::ProfiledPIDController<units::radians> thetaController,
       std::function<void(std::array<frc::SwerveModuleState, NumModules>)>
           output,
@@ -164,7 +164,7 @@ class SwerveControllerCommand
   SwerveControllerCommand(
       frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
       frc::SwerveDriveKinematics<NumModules> kinematics,
-      frc2::PIDController xController, frc2::PIDController yController,
+      frc::PIDController xController, frc::PIDController yController,
       frc::ProfiledPIDController<units::radians> thetaController,
       std::function<frc::Rotation2d()> desiredRotation,
       std::function<void(std::array<frc::SwerveModuleState, NumModules>)>
@@ -203,7 +203,7 @@ class SwerveControllerCommand
   SwerveControllerCommand(
       frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
       frc::SwerveDriveKinematics<NumModules> kinematics,
-      frc2::PIDController xController, frc2::PIDController yController,
+      frc::PIDController xController, frc::PIDController yController,
       frc::ProfiledPIDController<units::radians> thetaController,
       std::function<void(std::array<frc::SwerveModuleState, NumModules>)>
           output,

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SwerveControllerCommand.inc
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SwerveControllerCommand.inc
@@ -16,7 +16,7 @@ template <size_t NumModules>
 SwerveControllerCommand<NumModules>::SwerveControllerCommand(
     frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
     frc::SwerveDriveKinematics<NumModules> kinematics,
-    frc2::PIDController xController, frc2::PIDController yController,
+    frc::PIDController xController, frc::PIDController yController,
     frc::ProfiledPIDController<units::radians> thetaController,
     std::function<frc::Rotation2d()> desiredRotation,
     std::function<void(std::array<frc::SwerveModuleState, NumModules>)> output,
@@ -34,7 +34,7 @@ template <size_t NumModules>
 SwerveControllerCommand<NumModules>::SwerveControllerCommand(
     frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
     frc::SwerveDriveKinematics<NumModules> kinematics,
-    frc2::PIDController xController, frc2::PIDController yController,
+    frc::PIDController xController, frc::PIDController yController,
     frc::ProfiledPIDController<units::radians> thetaController,
     std::function<void(std::array<frc::SwerveModuleState, NumModules>)> output,
     std::initializer_list<Subsystem*> requirements)
@@ -50,7 +50,7 @@ template <size_t NumModules>
 SwerveControllerCommand<NumModules>::SwerveControllerCommand(
     frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
     frc::SwerveDriveKinematics<NumModules> kinematics,
-    frc2::PIDController xController, frc2::PIDController yController,
+    frc::PIDController xController, frc::PIDController yController,
     frc::ProfiledPIDController<units::radians> thetaController,
     std::function<frc::Rotation2d()> desiredRotation,
     std::function<void(std::array<frc::SwerveModuleState, NumModules>)> output,
@@ -68,7 +68,7 @@ template <size_t NumModules>
 SwerveControllerCommand<NumModules>::SwerveControllerCommand(
     frc::Trajectory trajectory, std::function<frc::Pose2d()> pose,
     frc::SwerveDriveKinematics<NumModules> kinematics,
-    frc2::PIDController xController, frc2::PIDController yController,
+    frc::PIDController xController, frc::PIDController yController,
     frc::ProfiledPIDController<units::radians> thetaController,
     std::function<void(std::array<frc::SwerveModuleState, NumModules>)> output,
     std::span<Subsystem* const> requirements)

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/MecanumControllerCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/MecanumControllerCommandTest.cpp
@@ -100,7 +100,7 @@ TEST_F(MecanumControllerCommandTest, ReachesReference) {
   auto command = frc2::MecanumControllerCommand(
       trajectory, [&]() { return getRobotPose(); }, m_kinematics,
 
-      frc2::PIDController(0.6, 0, 0), frc2::PIDController(0.6, 0, 0),
+      frc::PIDController(0.6, 0, 0), frc::PIDController(0.6, 0, 0),
       m_rotController, 8.8_mps,
       [&](units::meters_per_second_t frontLeft,
           units::meters_per_second_t rearLeft,

--- a/wpilibNewCommands/src/test/native/cpp/frc2/command/SwerveControllerCommandTest.cpp
+++ b/wpilibNewCommands/src/test/native/cpp/frc2/command/SwerveControllerCommandTest.cpp
@@ -85,7 +85,7 @@ TEST_F(SwerveControllerCommandTest, ReachesReference) {
   auto command = frc2::SwerveControllerCommand<4>(
       trajectory, [&]() { return getRobotPose(); }, m_kinematics,
 
-      frc2::PIDController(0.6, 0, 0), frc2::PIDController(0.6, 0, 0),
+      frc::PIDController(0.6, 0, 0), frc::PIDController(0.6, 0, 0),
       m_rotController,
       [&](auto moduleStates) { m_moduleStates = moduleStates; }, {&subsystem});
 

--- a/wpilibc/src/test/native/cpp/simulation/DCMotorSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/DCMotorSimTest.cpp
@@ -63,7 +63,7 @@ TEST(DCMotorSimTest, PositionFeedbackControl) {
   frc::sim::DCMotorSim sim{gearbox, 1.0,
                            units::kilogram_square_meter_t{0.0005}};
 
-  frc2::PIDController controller{0.04, 0.0, 0.001};
+  frc::PIDController controller{0.04, 0.0, 0.001};
 
   frc::Encoder encoder{0, 1};
   frc::sim::EncoderSim encoderSim{encoder};

--- a/wpilibc/src/test/native/cpp/simulation/ElevatorSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/ElevatorSimTest.cpp
@@ -22,7 +22,7 @@
 TEST(ElevatorSimTest, StateSpaceSim) {
   frc::sim::ElevatorSim sim(frc::DCMotor::Vex775Pro(4), 14.67, 8_kg, 0.75_in,
                             0_m, 3_m, true, 0_m, {0.01});
-  frc2::PIDController controller(10, 0.0, 0.0);
+  frc::PIDController controller(10, 0.0, 0.0);
 
   frc::PWMVictorSPX motor(0);
   frc::Encoder encoder(0, 1);

--- a/wpilibc/src/test/native/cpp/simulation/StateSpaceSimTest.cpp
+++ b/wpilibc/src/test/native/cpp/simulation/StateSpaceSimTest.cpp
@@ -26,7 +26,7 @@ TEST(StateSpaceSimTest, FlywheelSim) {
       frc::LinearSystemId::IdentifyVelocitySystem<units::radian>(
           0.02_V / 1_rad_per_s, 0.01_V / 1_rad_per_s_sq);
   frc::sim::FlywheelSim sim{plant, frc::DCMotor::NEO(2), 1.0};
-  frc2::PIDController controller{0.2, 0.0, 0.0};
+  frc::PIDController controller{0.2, 0.0, 0.0};
   frc::SimpleMotorFeedforward<units::radian> feedforward{
       0_V, 0.02_V / 1_rad_per_s, 0.01_V / 1_rad_per_s_sq};
   frc::Encoder encoder{0, 1};

--- a/wpilibcExamples/src/main/cpp/commands/pidcommand/ReplaceMePIDCommand.cpp
+++ b/wpilibcExamples/src/main/cpp/commands/pidcommand/ReplaceMePIDCommand.cpp
@@ -8,7 +8,7 @@
 // For more information, see:
 // https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
 ReplaceMePIDCommand::ReplaceMePIDCommand()
-    : CommandHelper{frc2::PIDController{0, 0, 0},
+    : CommandHelper{frc::PIDController{0, 0, 0},
                     // This should return the measurement
                     [] { return 0; },
                     // This should return the setpoint (can also be a constant)

--- a/wpilibcExamples/src/main/cpp/commands/pidsubsystem2/ReplaceMePIDSubsystem2.cpp
+++ b/wpilibcExamples/src/main/cpp/commands/pidsubsystem2/ReplaceMePIDSubsystem2.cpp
@@ -6,7 +6,7 @@
 
 ReplaceMePIDSubsystem2::ReplaceMePIDSubsystem2()
     // The PIDController used by the subsystem
-    : PIDSubsystem{frc2::PIDController{0, 0, 0}} {}
+    : PIDSubsystem{frc::PIDController{0, 0, 0}} {}
 
 void ReplaceMePIDSubsystem2::UseOutput(double output, double setpoint) {
   // Use the output here

--- a/wpilibcExamples/src/main/cpp/examples/ArmSimulation/include/subsystems/Arm.h
+++ b/wpilibcExamples/src/main/cpp/examples/ArmSimulation/include/subsystems/Arm.h
@@ -37,7 +37,7 @@ class Arm {
   frc::DCMotor m_armGearbox = frc::DCMotor::Vex775Pro(2);
 
   // Standard classes for controlling our arm
-  frc2::PIDController m_controller{m_armKp, 0, 0};
+  frc::PIDController m_controller{m_armKp, 0, 0};
   frc::Encoder m_encoder{kEncoderAChannel, kEncoderBChannel};
   frc::PWMSparkMax m_motor{kMotorPort};
 

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDriveBot/include/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDriveBot/include/Drivetrain.h
@@ -69,8 +69,8 @@ class Drivetrain {
   frc::Encoder m_leftEncoder{0, 1};
   frc::Encoder m_rightEncoder{2, 3};
 
-  frc2::PIDController m_leftPIDController{1.0, 0.0, 0.0};
-  frc2::PIDController m_rightPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_leftPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_rightPIDController{1.0, 0.0, 0.0};
 
   frc::AnalogGyro m_gyro{0};
 

--- a/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/include/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/DifferentialDrivePoseEstimator/include/Drivetrain.h
@@ -146,8 +146,8 @@ class Drivetrain {
   frc::Encoder m_leftEncoder{0, 1};
   frc::Encoder m_rightEncoder{2, 3};
 
-  frc2::PIDController m_leftPIDController{1.0, 0.0, 0.0};
-  frc2::PIDController m_rightPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_leftPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_rightPIDController{1.0, 0.0, 0.0};
 
   frc::AnalogGyro m_gyro{0};
 

--- a/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/subsystems/ShooterSubsystem.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/Frisbeebot/cpp/subsystems/ShooterSubsystem.cpp
@@ -11,7 +11,7 @@
 using namespace ShooterConstants;
 
 ShooterSubsystem::ShooterSubsystem()
-    : PIDSubsystem{frc2::PIDController{kP, kI, kD}},
+    : PIDSubsystem{frc::PIDController{kP, kI, kD}},
       m_shooterMotor(kShooterMotorPort),
       m_feederMotor(kFeederMotorPort),
       m_shooterEncoder(kEncoderPorts[0], kEncoderPorts[1]),

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/DriveStraight.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/DriveStraight.cpp
@@ -10,7 +10,7 @@
 
 DriveStraight::DriveStraight(double distance, Drivetrain& drivetrain)
     : frc2::CommandHelper<frc2::PIDCommand, DriveStraight>{
-          frc2::PIDController{4, 0, 0},
+          frc::PIDController{4, 0, 0},
           [&drivetrain] { return drivetrain.GetDistance(); },
           distance,
           [&drivetrain](double output) { drivetrain.Drive(output, output); },

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetDistanceToBox.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/commands/SetDistanceToBox.cpp
@@ -10,7 +10,7 @@
 
 SetDistanceToBox::SetDistanceToBox(double distance, Drivetrain& drivetrain)
     : frc2::CommandHelper<frc2::PIDCommand, SetDistanceToBox>{
-          frc2::PIDController{-2, 0, 0},
+          frc::PIDController{-2, 0, 0},
           [&drivetrain] { return drivetrain.GetDistanceToObstacle(); },
           distance,
           [&drivetrain](double output) { drivetrain.Drive(output, output); },

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Elevator.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Elevator.cpp
@@ -9,7 +9,7 @@
 #include <frc/smartdashboard/SmartDashboard.h>
 
 Elevator::Elevator()
-    : frc2::PIDSubsystem{frc2::PIDController{kP_real, kI_real, 0}} {
+    : frc2::PIDSubsystem{frc::PIDController{kP_real, kI_real, 0}} {
 #ifdef SIMULATION  // Check for simulation and update PID values
   GetPIDController()->SetPID(kP_simulation, kI_simulation, 0, 0);
 #endif

--- a/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Wrist.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GearsBot/cpp/subsystems/Wrist.cpp
@@ -7,7 +7,7 @@
 #include <frc/controller/PIDController.h>
 #include <frc/smartdashboard/SmartDashboard.h>
 
-Wrist::Wrist() : frc2::PIDSubsystem{frc2::PIDController{kP, 0, 0}} {
+Wrist::Wrist() : frc2::PIDSubsystem{frc::PIDController{kP, 0, 0}} {
   m_controller.SetTolerance(2.5);
 
   SetName("Wrist");

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/RobotContainer.cpp
@@ -35,8 +35,8 @@ void RobotContainer::ConfigureButtonBindings() {
   frc2::JoystickButton(&m_driverController, frc::PS4Controller::Button::kL1)
       .WhileTrue(
           frc2::PIDCommand(
-              frc2::PIDController{dc::kStabilizationP, dc::kStabilizationI,
-                                  dc::kStabilizationD},
+              frc::PIDController{dc::kStabilizationP, dc::kStabilizationI,
+                                 dc::kStabilizationD},
               // Close the loop on the turn rate
               [this] { return m_drive.GetTurnRate(); },
               // Setpoint is 0

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/commands/TurnToAngle.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/cpp/commands/TurnToAngle.cpp
@@ -9,7 +9,7 @@
 using namespace DriveConstants;
 
 TurnToAngle::TurnToAngle(units::degree_t target, DriveSubsystem* drive)
-    : CommandHelper{frc2::PIDController{kTurnP, kTurnI, kTurnD},
+    : CommandHelper{frc::PIDController{kTurnP, kTurnI, kTurnD},
                     // Close loop on heading
                     [drive] { return drive->GetHeading().value(); },
                     // Set reference to target

--- a/wpilibcExamples/src/main/cpp/examples/MecanumBot/include/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumBot/include/Drivetrain.h
@@ -59,10 +59,10 @@ class Drivetrain {
   frc::Translation2d m_backLeftLocation{-0.381_m, 0.381_m};
   frc::Translation2d m_backRightLocation{-0.381_m, -0.381_m};
 
-  frc2::PIDController m_frontLeftPIDController{1.0, 0.0, 0.0};
-  frc2::PIDController m_frontRightPIDController{1.0, 0.0, 0.0};
-  frc2::PIDController m_backLeftPIDController{1.0, 0.0, 0.0};
-  frc2::PIDController m_backRightPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_frontLeftPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_frontRightPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_backLeftPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_backRightPIDController{1.0, 0.0, 0.0};
 
   frc::AnalogGyro m_gyro{0};
 

--- a/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/cpp/RobotContainer.cpp
@@ -71,8 +71,8 @@ frc2::Command* RobotContainer::GetAutonomousCommand() {
       frc::SimpleMotorFeedforward<units::meters>(ks, kv, ka),
       DriveConstants::kDriveKinematics,
 
-      frc2::PIDController{AutoConstants::kPXController, 0, 0},
-      frc2::PIDController{AutoConstants::kPYController, 0, 0},
+      frc::PIDController{AutoConstants::kPXController, 0, 0},
+      frc::PIDController{AutoConstants::kPYController, 0, 0},
       frc::ProfiledPIDController<units::radians>(
           AutoConstants::kPThetaController, 0, 0,
           AutoConstants::kThetaControllerConstraints),
@@ -89,10 +89,10 @@ frc2::Command* RobotContainer::GetAutonomousCommand() {
                 m_drive.GetRearRightEncoder().GetRate()}};
       },
 
-      frc2::PIDController{DriveConstants::kPFrontLeftVel, 0, 0},
-      frc2::PIDController{DriveConstants::kPRearLeftVel, 0, 0},
-      frc2::PIDController{DriveConstants::kPFrontRightVel, 0, 0},
-      frc2::PIDController{DriveConstants::kPRearRightVel, 0, 0},
+      frc::PIDController{DriveConstants::kPFrontLeftVel, 0, 0},
+      frc::PIDController{DriveConstants::kPRearLeftVel, 0, 0},
+      frc::PIDController{DriveConstants::kPFrontRightVel, 0, 0},
+      frc::PIDController{DriveConstants::kPRearRightVel, 0, 0},
 
       [this](units::volt_t frontLeft, units::volt_t rearLeft,
              units::volt_t frontRight, units::volt_t rearRight) {

--- a/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/cpp/Drivetrain.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/cpp/Drivetrain.cpp
@@ -24,7 +24,7 @@ frc::MecanumDriveWheelPositions Drivetrain::GetCurrentDistances() const {
 
 void Drivetrain::SetSpeeds(const frc::MecanumDriveWheelSpeeds& wheelSpeeds) {
   std::function<void(units::meters_per_second_t, const frc::Encoder&,
-                     frc2::PIDController&, frc::PWMSparkMax&)>
+                     frc::PIDController&, frc::PWMSparkMax&)>
       calcAndSetSpeeds = [&m_feedforward = m_feedforward](
                              units::meters_per_second_t speed,
                              const auto& encoder, auto& controller,

--- a/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/include/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumDrivePoseEstimator/include/Drivetrain.h
@@ -59,10 +59,10 @@ class Drivetrain {
   frc::Translation2d m_backLeftLocation{-0.381_m, 0.381_m};
   frc::Translation2d m_backRightLocation{-0.381_m, -0.381_m};
 
-  frc2::PIDController m_frontLeftPIDController{1.0, 0.0, 0.0};
-  frc2::PIDController m_frontRightPIDController{1.0, 0.0, 0.0};
-  frc2::PIDController m_backLeftPIDController{1.0, 0.0, 0.0};
-  frc2::PIDController m_backRightPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_frontLeftPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_frontRightPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_backLeftPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_backRightPIDController{1.0, 0.0, 0.0};
 
   frc::AnalogGyro m_gyro{0};
 

--- a/wpilibcExamples/src/main/cpp/examples/PotentiometerPID/include/Robot.h
+++ b/wpilibcExamples/src/main/cpp/examples/PotentiometerPID/include/Robot.h
@@ -48,7 +48,7 @@ class Robot : public frc::TimedRobot {
   frc::AnalogPotentiometer m_potentiometer{kPotChannel, kFullHeight.value()};
 
   frc::PWMSparkMax m_elevatorMotor{kMotorChannel};
-  frc2::PIDController m_pidController{kP, kI, kD};
+  frc::PIDController m_pidController{kP, kI, kD};
   frc::Joystick m_joystick{kJoystickChannel};
 
   size_t m_index;

--- a/wpilibcExamples/src/main/cpp/examples/RamseteCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/RamseteCommand/cpp/RobotContainer.cpp
@@ -76,8 +76,8 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand() {
           DriveConstants::ks, DriveConstants::kv, DriveConstants::ka},
       DriveConstants::kDriveKinematics,
       [this] { return m_drive.GetWheelSpeeds(); },
-      frc2::PIDController{DriveConstants::kPDriveVel, 0, 0},
-      frc2::PIDController{DriveConstants::kPDriveVel, 0, 0},
+      frc::PIDController{DriveConstants::kPDriveVel, 0, 0},
+      frc::PIDController{DriveConstants::kPDriveVel, 0, 0},
       [this](auto left, auto right) { m_drive.TankDriveVolts(left, right); },
       {&m_drive})};
 

--- a/wpilibcExamples/src/main/cpp/examples/RamseteController/include/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/RamseteController/include/Drivetrain.h
@@ -70,8 +70,8 @@ class Drivetrain {
   frc::Encoder m_leftEncoder{0, 1};
   frc::Encoder m_rightEncoder{2, 3};
 
-  frc2::PIDController m_leftPIDController{1.0, 0.0, 0.0};
-  frc2::PIDController m_rightPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_leftPIDController{1.0, 0.0, 0.0};
+  frc::PIDController m_rightPIDController{1.0, 0.0, 0.0};
 
   frc::AnalogGyro m_gyro{0};
 

--- a/wpilibcExamples/src/main/cpp/examples/SimpleDifferentialDriveSimulation/include/Drivetrain.h
+++ b/wpilibcExamples/src/main/cpp/examples/SimpleDifferentialDriveSimulation/include/Drivetrain.h
@@ -86,8 +86,8 @@ class Drivetrain {
   frc::Encoder m_leftEncoder{0, 1};
   frc::Encoder m_rightEncoder{2, 3};
 
-  frc2::PIDController m_leftPIDController{8.5, 0.0, 0.0};
-  frc2::PIDController m_rightPIDController{8.5, 0.0, 0.0};
+  frc::PIDController m_leftPIDController{8.5, 0.0, 0.0};
+  frc::PIDController m_rightPIDController{8.5, 0.0, 0.0};
 
   frc::AnalogGyro m_gyro{0};
 

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/RobotContainer.cpp
@@ -91,8 +91,8 @@ frc2::Command* RobotContainer::GetAutonomousCommand() {
           DriveConstants::ks, DriveConstants::kv, DriveConstants::ka),
       DriveConstants::kDriveKinematics,
       [this] { return m_drive.GetWheelSpeeds(); },
-      frc2::PIDController{DriveConstants::kPDriveVel, 0, 0},
-      frc2::PIDController{DriveConstants::kPDriveVel, 0, 0},
+      frc::PIDController{DriveConstants::kPDriveVel, 0, 0},
+      frc::PIDController{DriveConstants::kPDriveVel, 0, 0},
       [this](auto left, auto right) { m_drive.TankDriveVolts(left, right); },
       {&m_drive});
 

--- a/wpilibcExamples/src/main/cpp/examples/SwerveBot/include/SwerveModule.h
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveBot/include/SwerveModule.h
@@ -42,7 +42,7 @@ class SwerveModule {
   frc::Encoder m_driveEncoder;
   frc::Encoder m_turningEncoder;
 
-  frc2::PIDController m_drivePIDController{1.0, 0, 0};
+  frc::PIDController m_drivePIDController{1.0, 0, 0};
   frc::ProfiledPIDController<units::radians> m_turningPIDController{
       1.0,
       0.0,

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/cpp/RobotContainer.cpp
@@ -78,8 +78,8 @@ frc2::Command* RobotContainer::GetAutonomousCommand() {
 
       m_drive.kDriveKinematics,
 
-      frc2::PIDController{AutoConstants::kPXController, 0, 0},
-      frc2::PIDController{AutoConstants::kPYController, 0, 0}, thetaController,
+      frc::PIDController{AutoConstants::kPXController, 0, 0},
+      frc::PIDController{AutoConstants::kPYController, 0, 0}, thetaController,
 
       [this](auto moduleStates) { m_drive.SetModuleStates(moduleStates); },
 

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/include/subsystems/SwerveModule.h
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/include/subsystems/SwerveModule.h
@@ -50,7 +50,7 @@ class SwerveModule {
   bool m_reverseDriveEncoder;
   bool m_reverseTurningEncoder;
 
-  frc2::PIDController m_drivePIDController{
+  frc::PIDController m_drivePIDController{
       ModuleConstants::kPModuleDriveController, 0, 0};
   frc::ProfiledPIDController<units::radians> m_turningPIDController{
       ModuleConstants::kPModuleTurningController,

--- a/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/include/SwerveModule.h
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveDrivePoseEstimator/include/SwerveModule.h
@@ -42,7 +42,7 @@ class SwerveModule {
   frc::Encoder m_driveEncoder;
   frc::Encoder m_turningEncoder;
 
-  frc2::PIDController m_drivePIDController{1.0, 0, 0};
+  frc::PIDController m_drivePIDController{1.0, 0, 0};
   frc::ProfiledPIDController<units::radians> m_turningPIDController{
       1.0,
       0.0,

--- a/wpilibcExamples/src/main/cpp/examples/UltrasonicPID/include/Robot.h
+++ b/wpilibcExamples/src/main/cpp/examples/UltrasonicPID/include/Robot.h
@@ -47,5 +47,5 @@ class Robot : public frc::TimedRobot {
   frc::PWMSparkMax m_left{kLeftMotorPort};
   frc::PWMSparkMax m_right{kRightMotorPort};
   frc::DifferentialDrive m_robotDrive{m_left, m_right};
-  frc2::PIDController m_pidController{kP, kI, kD};
+  frc::PIDController m_pidController{kP, kI, kD};
 };

--- a/wpilibcIntegrationTests/src/main/native/cpp/MotorEncoderTest.cpp
+++ b/wpilibcIntegrationTests/src/main/native/cpp/MotorEncoderTest.cpp
@@ -139,7 +139,7 @@ TEST_P(MotorEncoderTest, ClampSpeed) {
 TEST_P(MotorEncoderTest, PositionPIDController) {
   Reset();
   double goal = 1000;
-  frc2::PIDController pidController(0.001, 0.01, 0.0);
+  frc::PIDController pidController(0.001, 0.01, 0.0);
   pidController.SetTolerance(50.0);
   pidController.SetIntegratorRange(-0.2, 0.2);
   pidController.SetSetpoint(goal);
@@ -166,7 +166,7 @@ TEST_P(MotorEncoderTest, PositionPIDController) {
 TEST_P(MotorEncoderTest, VelocityPIDController) {
   Reset();
 
-  frc2::PIDController pidController(1e-5, 0.0, 0.0006);
+  frc::PIDController pidController(1e-5, 0.0, 0.0006);
   pidController.SetTolerance(200.0);
   pidController.SetSetpoint(600);
 

--- a/wpimath/src/main/native/cpp/controller/HolonomicDriveController.cpp
+++ b/wpimath/src/main/native/cpp/controller/HolonomicDriveController.cpp
@@ -11,7 +11,7 @@
 using namespace frc;
 
 HolonomicDriveController::HolonomicDriveController(
-    frc2::PIDController xController, frc2::PIDController yController,
+    PIDController xController, PIDController yController,
     ProfiledPIDController<units::radian> thetaController)
     : m_xController(std::move(xController)),
       m_yController(std::move(yController)),

--- a/wpimath/src/main/native/cpp/controller/PIDController.cpp
+++ b/wpimath/src/main/native/cpp/controller/PIDController.cpp
@@ -13,7 +13,7 @@
 #include "frc/MathUtil.h"
 #include "wpimath/MathShared.h"
 
-using namespace frc2;
+using namespace frc;
 
 PIDController::PIDController(double Kp, double Ki, double Kd,
                              units::second_t period)
@@ -95,7 +95,7 @@ void PIDController::SetSetpoint(double setpoint) {
   if (m_continuous) {
     double errorBound = (m_maximumInput - m_minimumInput) / 2.0;
     m_positionError =
-        frc::InputModulus(m_setpoint - m_measurement, -errorBound, errorBound);
+        InputModulus(m_setpoint - m_measurement, -errorBound, errorBound);
   } else {
     m_positionError = m_setpoint - m_measurement;
   }
@@ -156,7 +156,7 @@ double PIDController::Calculate(double measurement) {
   if (m_continuous) {
     double errorBound = (m_maximumInput - m_minimumInput) / 2.0;
     m_positionError =
-        frc::InputModulus(m_setpoint - m_measurement, -errorBound, errorBound);
+        InputModulus(m_setpoint - m_measurement, -errorBound, errorBound);
   } else {
     m_positionError = m_setpoint - m_measurement;
   }

--- a/wpimath/src/main/native/include/frc/controller/HolonomicDriveController.h
+++ b/wpimath/src/main/native/include/frc/controller/HolonomicDriveController.h
@@ -42,7 +42,7 @@ class WPILIB_DLLEXPORT HolonomicDriveController {
    * angle.
    */
   HolonomicDriveController(
-      frc2::PIDController xController, frc2::PIDController yController,
+      PIDController xController, PIDController yController,
       ProfiledPIDController<units::radian> thetaController);
 
   HolonomicDriveController(const HolonomicDriveController&) = default;
@@ -124,8 +124,8 @@ class WPILIB_DLLEXPORT HolonomicDriveController {
   Pose2d m_poseTolerance;
   bool m_enabled = true;
 
-  frc2::PIDController m_xController;
-  frc2::PIDController m_yController;
+  PIDController m_xController;
+  PIDController m_yController;
   ProfiledPIDController<units::radian> m_thetaController;
 
   bool m_firstRun = true;

--- a/wpimath/src/main/native/include/frc/controller/PIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/PIDController.h
@@ -13,7 +13,7 @@
 
 #include "units/time.h"
 
-namespace frc2 {
+namespace frc {
 
 /**
  * Implements a PID control loop.
@@ -278,11 +278,5 @@ class WPILIB_DLLEXPORT PIDController
   bool m_haveSetpoint = false;
   bool m_haveMeasurement = false;
 };
-
-}  // namespace frc2
-
-namespace frc {
-
-using frc2::PIDController;
 
 }  // namespace frc

--- a/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
+++ b/wpimath/src/main/native/include/frc/controller/ProfiledPIDController.h
@@ -405,7 +405,7 @@ class ProfiledPIDController
   }
 
  private:
-  frc2::PIDController m_controller;
+  PIDController m_controller;
   Distance_t m_minimumInput{0};
   Distance_t m_maximumInput{0};
   typename frc::TrapezoidProfile<Distance>::State m_goal;

--- a/wpimath/src/test/native/cpp/controller/HolonomicDriveControllerTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/HolonomicDriveControllerTest.cpp
@@ -22,7 +22,7 @@ static constexpr units::radian_t kAngularTolerance{2.0 * std::numbers::pi /
 
 TEST(HolonomicDriveControllerTest, ReachesReference) {
   frc::HolonomicDriveController controller{
-      frc2::PIDController{1.0, 0.0, 0.0}, frc2::PIDController{1.0, 0.0, 0.0},
+      frc::PIDController{1.0, 0.0, 0.0}, frc::PIDController{1.0, 0.0, 0.0},
       frc::ProfiledPIDController<units::radian>{
           1.0, 0.0, 0.0,
           frc::TrapezoidProfile<units::radian>::Constraints{
@@ -54,7 +54,7 @@ TEST(HolonomicDriveControllerTest, ReachesReference) {
 
 TEST(HolonomicDriveControllerTest, DoesNotRotateUnnecessarily) {
   frc::HolonomicDriveController controller{
-      frc2::PIDController{1, 0, 0}, frc2::PIDController{1, 0, 0},
+      frc::PIDController{1, 0, 0}, frc::PIDController{1, 0, 0},
       frc::ProfiledPIDController<units::radian>{
           1, 0, 0,
           frc::TrapezoidProfile<units::radian>::Constraints{

--- a/wpimath/src/test/native/cpp/controller/PIDInputOutputTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/PIDInputOutputTest.cpp
@@ -8,9 +8,9 @@
 
 class PIDInputOutputTest : public testing::Test {
  protected:
-  frc2::PIDController* controller;
+  frc::PIDController* controller;
 
-  void SetUp() override { controller = new frc2::PIDController{0, 0, 0}; }
+  void SetUp() override { controller = new frc::PIDController{0, 0, 0}; }
 
   void TearDown() override { delete controller; }
 };

--- a/wpimath/src/test/native/cpp/controller/PIDToleranceTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/PIDToleranceTest.cpp
@@ -11,14 +11,14 @@ static constexpr double kRange = 200;
 static constexpr double kTolerance = 10.0;
 
 TEST(PIDToleranceTest, InitialTolerance) {
-  frc2::PIDController controller{0.5, 0.0, 0.0};
+  frc::PIDController controller{0.5, 0.0, 0.0};
   controller.EnableContinuousInput(-kRange / 2, kRange / 2);
 
   EXPECT_FALSE(controller.AtSetpoint());
 }
 
 TEST(PIDToleranceTest, AbsoluteTolerance) {
-  frc2::PIDController controller{0.5, 0.0, 0.0};
+  frc::PIDController controller{0.5, 0.0, 0.0};
   controller.EnableContinuousInput(-kRange / 2, kRange / 2);
 
   EXPECT_FALSE(controller.AtSetpoint());


### PR DESCRIPTION
The old PIDController class in the frc namespace was removed for the 2023 season.