### PR TITLE
[upstream_utils] Fix deprecation warning in LLVM for C++23

### DIFF
--- a/upstream_utils/llvm_patches/0001-Fix-spelling-language-errors.patch
+++ b/upstream_utils/llvm_patches/0001-Fix-spelling-language-errors.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 20:50:26 -0400
-Subject: [PATCH 01/30] Fix spelling/language errors
+Subject: [PATCH 01/31] Fix spelling/language errors
 
 ---
  llvm/include/llvm/Support/ErrorHandling.h | 2 +-

--- a/upstream_utils/llvm_patches/0002-Remove-StringRef-ArrayRef-and-Optional.patch
+++ b/upstream_utils/llvm_patches/0002-Remove-StringRef-ArrayRef-and-Optional.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:09:18 -0400
-Subject: [PATCH 02/30] Remove StringRef, ArrayRef, and Optional
+Subject: [PATCH 02/31] Remove StringRef, ArrayRef, and Optional
 
 ---
  llvm/include/llvm/ADT/PointerUnion.h          |  1 -

--- a/upstream_utils/llvm_patches/0003-Wrap-std-min-max-calls-in-parens-for-Windows-warning.patch
+++ b/upstream_utils/llvm_patches/0003-Wrap-std-min-max-calls-in-parens-for-Windows-warning.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:12:41 -0400
-Subject: [PATCH 03/30] Wrap std::min/max calls in parens, for Windows warnings
+Subject: [PATCH 03/31] Wrap std::min/max calls in parens, for Windows warnings
 
 ---
  llvm/include/llvm/ADT/DenseMap.h       |  4 ++--

--- a/upstream_utils/llvm_patches/0004-Change-unique_function-storage-size.patch
+++ b/upstream_utils/llvm_patches/0004-Change-unique_function-storage-size.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:13:55 -0400
-Subject: [PATCH 04/30] Change unique_function storage size
+Subject: [PATCH 04/31] Change unique_function storage size
 
 ---
  llvm/include/llvm/ADT/FunctionExtras.h | 4 ++--

--- a/upstream_utils/llvm_patches/0005-Threading-updates.patch
+++ b/upstream_utils/llvm_patches/0005-Threading-updates.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:17:19 -0400
-Subject: [PATCH 05/30] Threading updates
+Subject: [PATCH 05/31] Threading updates
 
 - Remove guards for threads and exception
 - Prefer scope gaurd over lock gaurd

--- a/upstream_utils/llvm_patches/0006-ifdef-guard-safety.patch
+++ b/upstream_utils/llvm_patches/0006-ifdef-guard-safety.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:28:13 -0400
-Subject: [PATCH 06/30] \#ifdef guard safety
+Subject: [PATCH 06/31] \#ifdef guard safety
 
 Prevents redefinition if someone is pulling in real LLVM, since the macros are in global namespace
 ---

--- a/upstream_utils/llvm_patches/0007-Explicitly-use-std.patch
+++ b/upstream_utils/llvm_patches/0007-Explicitly-use-std.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:37:34 -0400
-Subject: [PATCH 07/30] Explicitly use std::
+Subject: [PATCH 07/31] Explicitly use std::
 
 ---
  llvm/include/llvm/ADT/SmallSet.h       |  2 +-

--- a/upstream_utils/llvm_patches/0008-Remove-format_provider.patch
+++ b/upstream_utils/llvm_patches/0008-Remove-format_provider.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sat, 7 May 2022 22:53:50 -0400
-Subject: [PATCH 08/30] Remove format_provider
+Subject: [PATCH 08/31] Remove format_provider
 
 ---
  llvm/include/llvm/Support/Chrono.h      | 109 ------------------------

--- a/upstream_utils/llvm_patches/0009-Add-compiler-warning-pragmas.patch
+++ b/upstream_utils/llvm_patches/0009-Add-compiler-warning-pragmas.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 13:34:07 -0400
-Subject: [PATCH 09/30] Add compiler warning pragmas
+Subject: [PATCH 09/31] Add compiler warning pragmas
 
 ---
  llvm/include/llvm/ADT/FunctionExtras.h | 11 +++++++++++

--- a/upstream_utils/llvm_patches/0010-Remove-unused-functions.patch
+++ b/upstream_utils/llvm_patches/0010-Remove-unused-functions.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 13:43:50 -0400
-Subject: [PATCH 10/30] Remove unused functions
+Subject: [PATCH 10/31] Remove unused functions
 
 ---
  llvm/include/llvm/ADT/SmallString.h      |  85 +-----

--- a/upstream_utils/llvm_patches/0011-Detemplatize-SmallVectorBase.patch
+++ b/upstream_utils/llvm_patches/0011-Detemplatize-SmallVectorBase.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Thu, 5 May 2022 23:18:34 -0400
-Subject: [PATCH 11/30] Detemplatize SmallVectorBase
+Subject: [PATCH 11/31] Detemplatize SmallVectorBase
 
 ---
  llvm/include/llvm/ADT/SmallVector.h | 27 +++++++--------------

--- a/upstream_utils/llvm_patches/0012-Add-vectors-to-raw_ostream.patch
+++ b/upstream_utils/llvm_patches/0012-Add-vectors-to-raw_ostream.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 13:48:59 -0400
-Subject: [PATCH 12/30] Add vectors to raw_ostream
+Subject: [PATCH 12/31] Add vectors to raw_ostream
 
 ---
  llvm/include/llvm/Support/raw_ostream.h | 115 ++++++++++++++++++++++++

--- a/upstream_utils/llvm_patches/0013-Extra-collections-features.patch
+++ b/upstream_utils/llvm_patches/0013-Extra-collections-features.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 3 May 2022 22:16:10 -0400
-Subject: [PATCH 13/30] Extra collections features
+Subject: [PATCH 13/31] Extra collections features
 
 ---
  llvm/include/llvm/ADT/StringMap.h | 103 +++++++++++++++++++++++++++++-

--- a/upstream_utils/llvm_patches/0014-EpochTracker-ABI-macro.patch
+++ b/upstream_utils/llvm_patches/0014-EpochTracker-ABI-macro.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Wed, 4 May 2022 00:01:00 -0400
-Subject: [PATCH 14/30] EpochTracker ABI macro
+Subject: [PATCH 14/31] EpochTracker ABI macro
 
 ---
  llvm/include/llvm/ADT/EpochTracker.h | 2 +-

--- a/upstream_utils/llvm_patches/0015-Delete-numbers-from-MathExtras.patch
+++ b/upstream_utils/llvm_patches/0015-Delete-numbers-from-MathExtras.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Thu, 5 May 2022 18:09:45 -0400
-Subject: [PATCH 15/30] Delete numbers from MathExtras
+Subject: [PATCH 15/31] Delete numbers from MathExtras
 
 ---
  llvm/include/llvm/Support/MathExtras.h | 36 --------------------------

--- a/upstream_utils/llvm_patches/0016-Add-lerp-and-sgn.patch
+++ b/upstream_utils/llvm_patches/0016-Add-lerp-and-sgn.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 3 May 2022 22:50:24 -0400
-Subject: [PATCH 16/30] Add lerp and sgn
+Subject: [PATCH 16/31] Add lerp and sgn
 
 ---
  llvm/include/llvm/Support/MathExtras.h | 20 ++++++++++++++++++++

--- a/upstream_utils/llvm_patches/0017-Fixup-includes.patch
+++ b/upstream_utils/llvm_patches/0017-Fixup-includes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:38:11 -0400
-Subject: [PATCH 17/30] Fixup includes
+Subject: [PATCH 17/31] Fixup includes
 
 ---
  llvm/include/llvm/ADT/StringMap.h                 |  4 ++++

--- a/upstream_utils/llvm_patches/0018-Use-std-is_trivially_copy_constructible.patch
+++ b/upstream_utils/llvm_patches/0018-Use-std-is_trivially_copy_constructible.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:42:09 -0400
-Subject: [PATCH 18/30] Use std::is_trivially_copy_constructible
+Subject: [PATCH 18/31] Use std::is_trivially_copy_constructible
 
 ---
  llvm/include/llvm/Support/type_traits.h | 37 ++-----------------------

--- a/upstream_utils/llvm_patches/0019-Windows-support.patch
+++ b/upstream_utils/llvm_patches/0019-Windows-support.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Tue, 3 May 2022 20:22:38 -0400
-Subject: [PATCH 19/30] Windows support
+Subject: [PATCH 19/31] Windows support
 
 ---
  .../llvm/Support/Windows/WindowsSupport.h     | 45 +++++----

--- a/upstream_utils/llvm_patches/0020-Prefer-fmtlib.patch
+++ b/upstream_utils/llvm_patches/0020-Prefer-fmtlib.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:46:20 -0400
-Subject: [PATCH 20/30] Prefer fmtlib
+Subject: [PATCH 20/31] Prefer fmtlib
 
 ---
  llvm/lib/Support/ErrorHandling.cpp | 20 ++++++--------------

--- a/upstream_utils/llvm_patches/0021-Prefer-wpi-s-fs.h.patch
+++ b/upstream_utils/llvm_patches/0021-Prefer-wpi-s-fs.h.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 16:49:36 -0400
-Subject: [PATCH 21/30] Prefer wpi's fs.h
+Subject: [PATCH 21/31] Prefer wpi's fs.h
 
 ---
  llvm/include/llvm/Support/raw_ostream.h | 7 ++-----

--- a/upstream_utils/llvm_patches/0022-Remove-unused-functions.patch
+++ b/upstream_utils/llvm_patches/0022-Remove-unused-functions.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 19:16:51 -0400
-Subject: [PATCH 22/30] Remove unused functions
+Subject: [PATCH 22/31] Remove unused functions
 
 ---
  llvm/include/llvm/Support/DJB.h         |  3 -

--- a/upstream_utils/llvm_patches/0023-OS-specific-changes.patch
+++ b/upstream_utils/llvm_patches/0023-OS-specific-changes.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Sun, 8 May 2022 19:30:43 -0400
-Subject: [PATCH 23/30] OS-specific changes
+Subject: [PATCH 23/31] OS-specific changes
 
 ---
  llvm/lib/Support/ErrorHandling.cpp | 16 +++++++---------

--- a/upstream_utils/llvm_patches/0024-Use-SmallVector-for-UTF-conversion.patch
+++ b/upstream_utils/llvm_patches/0024-Use-SmallVector-for-UTF-conversion.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Mon, 9 May 2022 00:04:30 -0400
-Subject: [PATCH 24/30] Use SmallVector for UTF conversion
+Subject: [PATCH 24/31] Use SmallVector for UTF conversion
 
 ---
  llvm/include/llvm/Support/ConvertUTF.h    |  6 +++---

--- a/upstream_utils/llvm_patches/0025-Prefer-to-use-static-pointers-in-raw_ostream.patch
+++ b/upstream_utils/llvm_patches/0025-Prefer-to-use-static-pointers-in-raw_ostream.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Thu, 19 May 2022 00:58:36 -0400
-Subject: [PATCH 25/30] Prefer to use static pointers in raw_ostream
+Subject: [PATCH 25/31] Prefer to use static pointers in raw_ostream
 
 See #1401
 ---

--- a/upstream_utils/llvm_patches/0026-constexpr-endian-byte-swap.patch
+++ b/upstream_utils/llvm_patches/0026-constexpr-endian-byte-swap.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PJ Reiniger <pj.reiniger@gmail.com>
 Date: Thu, 19 May 2022 01:12:41 -0400
-Subject: [PATCH 26/30] constexpr endian byte swap
+Subject: [PATCH 26/31] constexpr endian byte swap
 
 ---
  llvm/include/llvm/Support/Endian.h | 4 +++-

--- a/upstream_utils/llvm_patches/0027-Copy-type-traits-from-STLExtras.h-into-PointerUnion..patch
+++ b/upstream_utils/llvm_patches/0027-Copy-type-traits-from-STLExtras.h-into-PointerUnion..patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Wed, 10 Aug 2022 17:07:52 -0700
-Subject: [PATCH 27/30] Copy type traits from STLExtras.h into PointerUnion.h
+Subject: [PATCH 27/31] Copy type traits from STLExtras.h into PointerUnion.h
 
 ---
  llvm/include/llvm/ADT/PointerUnion.h | 46 ++++++++++++++++++++++++++++

--- a/upstream_utils/llvm_patches/0028-Remove-StringMap-test-for-llvm-sort.patch
+++ b/upstream_utils/llvm_patches/0028-Remove-StringMap-test-for-llvm-sort.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Wed, 10 Aug 2022 22:35:00 -0700
-Subject: [PATCH 28/30] Remove StringMap test for llvm::sort()
+Subject: [PATCH 28/31] Remove StringMap test for llvm::sort()
 
 ---
  llvm/unittests/ADT/StringMapTest.cpp | 14 --------------

--- a/upstream_utils/llvm_patches/0029-Unused-variable-in-release-mode.patch
+++ b/upstream_utils/llvm_patches/0029-Unused-variable-in-release-mode.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Leander Schulten <Leander.Schulten@rwth-aachen.de>
 Date: Mon, 10 Jul 2023 00:53:43 +0200
-Subject: [PATCH 29/30] Unused variable in release mode
+Subject: [PATCH 29/31] Unused variable in release mode
 
 ---
  llvm/include/llvm/ADT/DenseMap.h | 2 +-

--- a/upstream_utils/llvm_patches/0030-Use-C-20-bit-header.patch
+++ b/upstream_utils/llvm_patches/0030-Use-C-20-bit-header.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Tue, 11 Jul 2023 22:56:09 -0700
-Subject: [PATCH 30/30] Use C++20 <bit> header
+Subject: [PATCH 30/31] Use C++20 <bit> header
 
 ---
  llvm/include/llvm/ADT/bit.h            | 256 -------------------------

--- a/upstream_utils/llvm_patches/0031-Replace-deprecated-std-aligned_storage_t.patch
+++ b/upstream_utils/llvm_patches/0031-Replace-deprecated-std-aligned_storage_t.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tyler Veness <calcmogul@gmail.com>
+Date: Fri, 15 Sep 2023 18:16:50 -0700
+Subject: [PATCH 31/31] Replace deprecated std::aligned_storage_t
+
+---
+ llvm/include/llvm/ADT/FunctionExtras.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/llvm/include/llvm/ADT/FunctionExtras.h b/llvm/include/llvm/ADT/FunctionExtras.h
+index 07f9632bb871b1915b3016348d58938e738b3331..f6c04fe0209c4d9b64d7e23ff4dbbd15455dcac0 100644
+--- a/llvm/include/llvm/ADT/FunctionExtras.h
++++ b/llvm/include/llvm/ADT/FunctionExtras.h
+@@ -37,6 +37,7 @@
+ #include "llvm/ADT/STLForwardCompat.h"
+ #include "llvm/Support/MemAlloc.h"
+ #include "llvm/Support/type_traits.h"
++#include <cstddef>
+ #include <cstring>
+ #include <memory>
+ #include <type_traits>
+@@ -167,8 +168,7 @@ protected:
+     // provide four pointers worth of storage here.
+     // This is mutable as an inlined `const unique_function<void() const>` may
+     // still modify its own mutable members.
+-    mutable std::aligned_storage_t<InlineStorageSize, alignof(void *)>
+-        InlineStorage;
++    alignas(void*) mutable std::byte InlineStorage[InlineStorageSize];
+   } StorageUnion;
+ 
+   // A compressed pointer to either our dispatching callback or our table of

--- a/upstream_utils/update_llvm.py
+++ b/upstream_utils/update_llvm.py
@@ -208,6 +208,7 @@ def main():
         "0028-Remove-StringMap-test-for-llvm-sort.patch",
         "0029-Unused-variable-in-release-mode.patch",
         "0030-Use-C-20-bit-header.patch",
+        "0031-Replace-deprecated-std-aligned_storage_t.patch",
     ]:
         git_am(
             os.path.join(wpilib_root, "upstream_utils/llvm_patches", f),

--- a/wpiutil/src/main/native/thirdparty/llvm/include/wpi/FunctionExtras.h
+++ b/wpiutil/src/main/native/thirdparty/llvm/include/wpi/FunctionExtras.h
@@ -37,6 +37,7 @@
 #include "wpi/STLForwardCompat.h"
 #include "wpi/MemAlloc.h"
 #include "wpi/type_traits.h"
+#include <cstddef>
 #include <cstring>
 #include <memory>
 #include <type_traits>
@@ -167,8 +168,7 @@ protected:
     // provide four pointers worth of storage here.
     // This is mutable as an inlined `const unique_function<void() const>` may
     // still modify its own mutable members.
-    mutable std::aligned_storage_t<InlineStorageSize, alignof(void *)>
-        InlineStorage;
+    alignas(void*) mutable std::byte InlineStorage[InlineStorageSize];
   } StorageUnion;
 
   // A compressed pointer to either our dispatching callback or our table of


### PR DESCRIPTION
std::aligned_storage_t was deprecated in https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1413r3.pdf because it's extremely error-prone.