### PR TITLE
Replace std::snprintf() with fmt::format_to_n()

### DIFF
--- a/glass/src/app/native/cpp/main.cpp
+++ b/glass/src/app/native/cpp/main.cpp
@@ -8,6 +8,7 @@
 #include <fmt/format.h>
 #include <imgui.h>
 #include <ntcore_cpp.h>
+#include <wpi/StringExtras.h>
 #include <wpigui.h>
 
 #include "glass/Context.h"
@@ -317,16 +318,12 @@ int main(int argc, char** argv) {
       char nameBuf[32];
       const char* name = glfwGetKeyName(*gEnterKey, 0);
       if (!name) {
-        const auto result =
-            fmt::format_to_n(nameBuf, sizeof(nameBuf) - 1, "{}", *gEnterKey);
-        *result.out = '\0';
+        wpi::format_to_n_c_str(nameBuf, sizeof(nameBuf), "{}", *gEnterKey);
 
         name = nameBuf;
       }
-      const auto result =
-          fmt::format_to_n(editLabel, sizeof(editLabel) - 1, "{}###edit",
-                           gKeyEdit ? "(press key)" : name);
-      *result.out = '\0';
+      wpi::format_to_n_c_str(editLabel, sizeof(editLabel), "{}###edit",
+                             gKeyEdit ? "(press key)" : name);
 
       if (ImGui::SmallButton(editLabel)) {
         gKeyEdit = true;

--- a/glass/src/app/native/cpp/main.cpp
+++ b/glass/src/app/native/cpp/main.cpp
@@ -317,11 +317,17 @@ int main(int argc, char** argv) {
       char nameBuf[32];
       const char* name = glfwGetKeyName(*gEnterKey, 0);
       if (!name) {
-        std::snprintf(nameBuf, sizeof(nameBuf), "%d", *gEnterKey);
+        const auto result =
+            fmt::format_to_n(nameBuf, sizeof(nameBuf) - 1, "{}", *gEnterKey);
+        *result.out = '\0';
+
         name = nameBuf;
       }
-      std::snprintf(editLabel, sizeof(editLabel), "%s###edit",
-                    gKeyEdit ? "(press key)" : name);
+      const auto result =
+          fmt::format_to_n(editLabel, sizeof(editLabel) - 1, "{}###edit",
+                           gKeyEdit ? "(press key)" : name);
+      *result.out = '\0';
+
       if (ImGui::SmallButton(editLabel)) {
         gKeyEdit = true;
       }

--- a/glass/src/lib/native/cpp/Context.cpp
+++ b/glass/src/lib/native/cpp/Context.cpp
@@ -532,8 +532,7 @@ void glass::PushID(const char* str_id_begin, const char* str_id_end) {
 
 void glass::PushID(int int_id) {
   char buf[16];
-  const auto result = fmt::format_to_n(buf, sizeof(buf) - 1, "{}", int_id);
-  *result.out = '\0';
+  wpi::format_to_n_c_str(buf, sizeof(buf), "{}", int_id);
 
   PushStorageStack(buf);
   ImGui::PushID(int_id);

--- a/glass/src/lib/native/cpp/Context.cpp
+++ b/glass/src/lib/native/cpp/Context.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cinttypes>
-#include <cstdio>
 #include <filesystem>
 
 #include <fmt/format.h>
@@ -533,7 +532,9 @@ void glass::PushID(const char* str_id_begin, const char* str_id_end) {
 
 void glass::PushID(int int_id) {
   char buf[16];
-  std::snprintf(buf, sizeof(buf), "%d", int_id);
+  const auto result = fmt::format_to_n(buf, sizeof(buf) - 1, "{}", int_id);
+  *result.out = '\0';
+
   PushStorageStack(buf);
   ImGui::PushID(int_id);
 }

--- a/glass/src/lib/native/cpp/MainMenuBar.cpp
+++ b/glass/src/lib/native/cpp/MainMenuBar.cpp
@@ -4,8 +4,8 @@
 
 #include "glass/MainMenuBar.h"
 
-#include <fmt/format.h>
 #include <imgui.h>
+#include <wpi/StringExtras.h>
 #include <wpigui.h>
 
 #include "glass/Context.h"
@@ -51,10 +51,9 @@ void MainMenuBar::Display() {
 
 #if 0
   char str[64];
-  const auto result = fmt::format_to_n(
-      str, sizeof(str) - 1, "{:.3f} ms/frame ({:.1f} FPS)",
-      1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
-  *result.out = '\0';
+  wpi::format_to_n_c_str(str, sizeof(str), "{:.3f} ms/frame ({:.1f} FPS)",
+                         1000.0f / ImGui::GetIO().Framerate,
+                         ImGui::GetIO().Framerate);
 
   ImGui::SameLine(ImGui::GetWindowWidth() - ImGui::CalcTextSize(str).x - 10);
   ImGui::Text("%s", str);

--- a/glass/src/lib/native/cpp/MainMenuBar.cpp
+++ b/glass/src/lib/native/cpp/MainMenuBar.cpp
@@ -4,8 +4,7 @@
 
 #include "glass/MainMenuBar.h"
 
-#include <cstdio>
-
+#include <fmt/format.h>
 #include <imgui.h>
 #include <wpigui.h>
 
@@ -52,11 +51,12 @@ void MainMenuBar::Display() {
 
 #if 0
   char str[64];
-  std::snprintf(str, sizeof(str), "%.3f ms/frame (%.1f FPS)",
-                1000.0f / ImGui::GetIO().Framerate,
-                ImGui::GetIO().Framerate);
-  ImGui::SameLine(ImGui::GetWindowWidth() - ImGui::CalcTextSize(str).x -
-                  10);
+  const auto result = fmt::format_to_n(
+      str, sizeof(str) - 1, "{:.3f} ms/frame ({:.1f} FPS)",
+      1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
+  *result.out = '\0';
+
+  ImGui::SameLine(ImGui::GetWindowWidth() - ImGui::CalcTextSize(str).x - 10);
   ImGui::Text("%s", str);
 #endif
   ImGui::EndMainMenuBar();

--- a/glass/src/lib/native/cpp/Window.cpp
+++ b/glass/src/lib/native/cpp/Window.cpp
@@ -4,7 +4,6 @@
 
 #include "glass/Window.h"
 
-#include <fmt/format.h>
 #include <imgui.h>
 #include <imgui_internal.h>
 #include <wpi/StringExtras.h>
@@ -58,13 +57,10 @@ void Window::Display() {
 
   char label[128];
   if (m_name.empty()) {
-    const auto result = fmt::format_to_n(label, sizeof(label) - 1, "{}###{}",
-                                         m_defaultName, m_id);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(label, sizeof(label), "{}###{}", m_defaultName,
+                           m_id);
   } else {
-    const auto result =
-        fmt::format_to_n(label, sizeof(label) - 1, "{}###{}", m_name, m_id);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(label, sizeof(label), "{}###{}", m_name, m_id);
   }
 
   if (Begin(label, &m_visible, m_flags)) {

--- a/glass/src/lib/native/cpp/Window.cpp
+++ b/glass/src/lib/native/cpp/Window.cpp
@@ -4,6 +4,7 @@
 
 #include "glass/Window.h"
 
+#include <fmt/format.h>
 #include <imgui.h>
 #include <imgui_internal.h>
 #include <wpi/StringExtras.h>
@@ -56,9 +57,15 @@ void Window::Display() {
   }
 
   char label[128];
-  std::snprintf(label, sizeof(label), "%s###%s",
-                m_name.empty() ? m_defaultName.c_str() : m_name.c_str(),
-                m_id.c_str());
+  if (m_name.empty()) {
+    const auto result = fmt::format_to_n(label, sizeof(label) - 1, "{}###{}",
+                                         m_defaultName, m_id);
+    *result.out = '\0';
+  } else {
+    const auto result =
+        fmt::format_to_n(label, sizeof(label) - 1, "{}###{}", m_name, m_id);
+    *result.out = '\0';
+  }
 
   if (Begin(label, &m_visible, m_flags)) {
     if (m_renamePopupEnabled || m_view->HasSettings()) {

--- a/glass/src/lib/native/cpp/hardware/AnalogGyro.cpp
+++ b/glass/src/lib/native/cpp/hardware/AnalogGyro.cpp
@@ -4,7 +4,7 @@
 
 #include "glass/hardware/AnalogGyro.h"
 
-#include <fmt/format.h>
+#include <wpi/StringExtras.h>
 
 #include "glass/DataSource.h"
 #include "glass/other/DeviceTree.h"
@@ -13,9 +13,7 @@ using namespace glass;
 
 void glass::DisplayAnalogGyroDevice(AnalogGyroModel* model, int index) {
   char name[32];
-  const auto result =
-      fmt::format_to_n(name, sizeof(name) - 1, "AnalogGyro[{}]", index);
-  *result.out = '\0';
+  wpi::format_to_n_c_str(name, sizeof(name), "AnalogGyro[{}]", index);
 
   if (BeginDevice(name)) {
     // angle

--- a/glass/src/lib/native/cpp/hardware/AnalogGyro.cpp
+++ b/glass/src/lib/native/cpp/hardware/AnalogGyro.cpp
@@ -4,6 +4,8 @@
 
 #include "glass/hardware/AnalogGyro.h"
 
+#include <fmt/format.h>
+
 #include "glass/DataSource.h"
 #include "glass/other/DeviceTree.h"
 
@@ -11,7 +13,10 @@ using namespace glass;
 
 void glass::DisplayAnalogGyroDevice(AnalogGyroModel* model, int index) {
   char name[32];
-  std::snprintf(name, sizeof(name), "AnalogGyro[%d]", index);
+  const auto result =
+      fmt::format_to_n(name, sizeof(name) - 1, "AnalogGyro[{}]", index);
+  *result.out = '\0';
+
   if (BeginDevice(name)) {
     // angle
     if (auto angleData = model->GetAngleData()) {

--- a/glass/src/lib/native/cpp/hardware/AnalogInput.cpp
+++ b/glass/src/lib/native/cpp/hardware/AnalogInput.cpp
@@ -4,8 +4,8 @@
 
 #include "glass/hardware/AnalogInput.h"
 
-#include <fmt/format.h>
 #include <imgui.h>
+#include <wpi/StringExtras.h>
 
 #include "glass/Context.h"
 #include "glass/DataSource.h"
@@ -23,13 +23,9 @@ void glass::DisplayAnalogInput(AnalogInputModel* model, int index) {
   std::string& name = GetStorage().GetString("name");
   char label[128];
   if (!name.empty()) {
-    const auto result = fmt::format_to_n(label, sizeof(label) - 1,
-                                         "{} [{}]###name", name, index);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(label, sizeof(label), "{} [{}]###name", name, index);
   } else {
-    const auto result =
-        fmt::format_to_n(label, sizeof(label) - 1, "In[{}]###name", index);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(label, sizeof(label), "In[{}]###name", index);
   }
 
   if (model->IsGyro()) {

--- a/glass/src/lib/native/cpp/hardware/AnalogInput.cpp
+++ b/glass/src/lib/native/cpp/hardware/AnalogInput.cpp
@@ -4,6 +4,7 @@
 
 #include "glass/hardware/AnalogInput.h"
 
+#include <fmt/format.h>
 #include <imgui.h>
 
 #include "glass/Context.h"
@@ -22,9 +23,13 @@ void glass::DisplayAnalogInput(AnalogInputModel* model, int index) {
   std::string& name = GetStorage().GetString("name");
   char label[128];
   if (!name.empty()) {
-    std::snprintf(label, sizeof(label), "%s [%d]###name", name.c_str(), index);
+    const auto result = fmt::format_to_n(label, sizeof(label) - 1,
+                                         "{} [{}]###name", name, index);
+    *result.out = '\0';
   } else {
-    std::snprintf(label, sizeof(label), "In[%d]###name", index);
+    const auto result =
+        fmt::format_to_n(label, sizeof(label) - 1, "In[{}]###name", index);
+    *result.out = '\0';
   }
 
   if (model->IsGyro()) {

--- a/glass/src/lib/native/cpp/hardware/AnalogOutput.cpp
+++ b/glass/src/lib/native/cpp/hardware/AnalogOutput.cpp
@@ -4,6 +4,8 @@
 
 #include "glass/hardware/AnalogOutput.h"
 
+#include <fmt/format.h>
+
 #include "glass/Context.h"
 #include "glass/DataSource.h"
 #include "glass/Storage.h"
@@ -30,9 +32,13 @@ void glass::DisplayAnalogOutputsDevice(AnalogOutputsModel* model) {
       std::string& name = GetStorage().GetString("name");
       char label[128];
       if (!name.empty()) {
-        std::snprintf(label, sizeof(label), "%s [%d]###name", name.c_str(), i);
+        const auto result = fmt::format_to_n(label, sizeof(label) - 1,
+                                             "{} [{}]###name", name, i);
+        *result.out = '\0';
       } else {
-        std::snprintf(label, sizeof(label), "Out[%d]###name", i);
+        const auto result =
+            fmt::format_to_n(label, sizeof(label) - 1, "Out[{}]###name", i);
+        *result.out = '\0';
       }
 
       double value = analogOutData->GetValue();

--- a/glass/src/lib/native/cpp/hardware/AnalogOutput.cpp
+++ b/glass/src/lib/native/cpp/hardware/AnalogOutput.cpp
@@ -4,7 +4,7 @@
 
 #include "glass/hardware/AnalogOutput.h"
 
-#include <fmt/format.h>
+#include <wpi/StringExtras.h>
 
 #include "glass/Context.h"
 #include "glass/DataSource.h"
@@ -32,13 +32,9 @@ void glass::DisplayAnalogOutputsDevice(AnalogOutputsModel* model) {
       std::string& name = GetStorage().GetString("name");
       char label[128];
       if (!name.empty()) {
-        const auto result = fmt::format_to_n(label, sizeof(label) - 1,
-                                             "{} [{}]###name", name, i);
-        *result.out = '\0';
+        wpi::format_to_n_c_str(label, sizeof(label), "{} [{}]###name", name, i);
       } else {
-        const auto result =
-            fmt::format_to_n(label, sizeof(label) - 1, "Out[{}]###name", i);
-        *result.out = '\0';
+        wpi::format_to_n_c_str(label, sizeof(label), "Out[{}]###name", i);
       }
 
       double value = analogOutData->GetValue();

--- a/glass/src/lib/native/cpp/hardware/Encoder.cpp
+++ b/glass/src/lib/native/cpp/hardware/Encoder.cpp
@@ -6,6 +6,7 @@
 
 #include <fmt/format.h>
 #include <imgui.h>
+#include <wpi/StringExtras.h>
 
 #include "glass/Context.h"
 #include "glass/DataSource.h"
@@ -70,13 +71,11 @@ void glass::DisplayEncoder(EncoderModel* model) {
   std::string& name = GetStorage().GetString("name");
   char label[128];
   if (!name.empty()) {
-    const auto result = fmt::format_to_n(label, sizeof(label) - 1,
-                                         "{} [{},{}]###header", name, chA, chB);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(label, sizeof(label), "{} [{},{}]###header", name,
+                           chA, chB);
   } else {
-    const auto result = fmt::format_to_n(label, sizeof(label) - 1,
-                                         "Encoder[{},{}]###header", chA, chB);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(label, sizeof(label), "Encoder[{},{}]###header", chA,
+                           chB);
   }
 
   // header

--- a/glass/src/lib/native/cpp/hardware/Encoder.cpp
+++ b/glass/src/lib/native/cpp/hardware/Encoder.cpp
@@ -70,10 +70,13 @@ void glass::DisplayEncoder(EncoderModel* model) {
   std::string& name = GetStorage().GetString("name");
   char label[128];
   if (!name.empty()) {
-    std::snprintf(label, sizeof(label), "%s [%d,%d]###header", name.c_str(),
-                  chA, chB);
+    const auto result = fmt::format_to_n(label, sizeof(label) - 1,
+                                         "{} [{},{}]###header", name, chA, chB);
+    *result.out = '\0';
   } else {
-    std::snprintf(label, sizeof(label), "Encoder[%d,%d]###header", chA, chB);
+    const auto result = fmt::format_to_n(label, sizeof(label) - 1,
+                                         "Encoder[{},{}]###header", chA, chB);
+    *result.out = '\0';
   }
 
   // header

--- a/glass/src/lib/native/cpp/hardware/Gyro.cpp
+++ b/glass/src/lib/native/cpp/hardware/Gyro.cpp
@@ -5,13 +5,13 @@
 #include "glass/hardware/Gyro.h"
 
 #include <cmath>
+#include <numbers>
 
 #define IMGUI_DEFINE_MATH_OPERATORS
 
-#include <fmt/format.h>
 #include <imgui.h>
 #include <imgui_internal.h>
-#include <numbers>
+#include <wpi/StringExtras.h>
 
 #include "glass/Context.h"
 #include "glass/DataSource.h"
@@ -66,8 +66,7 @@ void glass::DisplayGyro(GyroModel* m) {
                   color, 1.2f);
     if (major) {
       char txt[16];
-      const auto result = fmt::format_to_n(txt, sizeof(txt) - 1, "{}°", i);
-      *result.out = '\0';
+      wpi::format_to_n_c_str(txt, sizeof(txt), "{}°", i);
 
       draw->AddText(
           center + (direction * radius * 1.25) - ImGui::CalcTextSize(txt) * 0.5,

--- a/glass/src/lib/native/cpp/hardware/Gyro.cpp
+++ b/glass/src/lib/native/cpp/hardware/Gyro.cpp
@@ -8,6 +8,7 @@
 
 #define IMGUI_DEFINE_MATH_OPERATORS
 
+#include <fmt/format.h>
 #include <imgui.h>
 #include <imgui_internal.h>
 #include <numbers>
@@ -65,7 +66,9 @@ void glass::DisplayGyro(GyroModel* m) {
                   color, 1.2f);
     if (major) {
       char txt[16];
-      std::snprintf(txt, sizeof(txt), "%d°", i);
+      const auto result = fmt::format_to_n(txt, sizeof(txt) - 1, "{}°", i);
+      *result.out = '\0';
+
       draw->AddText(
           center + (direction * radius * 1.25) - ImGui::CalcTextSize(txt) * 0.5,
           primaryColor, txt, nullptr);

--- a/glass/src/lib/native/cpp/hardware/PCM.cpp
+++ b/glass/src/lib/native/cpp/hardware/PCM.cpp
@@ -7,9 +7,9 @@
 #include <cstdio>
 #include <cstring>
 
-#include <fmt/format.h>
 #include <imgui.h>
 #include <wpi/SmallVector.h>
+#include <wpi/StringExtras.h>
 
 #include "glass/Context.h"
 #include "glass/DataSource.h"
@@ -47,13 +47,10 @@ bool glass::DisplayPCMSolenoids(PCMModel* model, int index,
   std::string& name = GetStorage().GetString("name");
   char label[128];
   if (!name.empty()) {
-    const auto result = fmt::format_to_n(label, sizeof(label) - 1,
-                                         "{} [{}]###header", name, index);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(label, sizeof(label), "{} [{}]###header", name,
+                           index);
   } else {
-    const auto result =
-        fmt::format_to_n(label, sizeof(label) - 1, "PCM[{}]###header", index);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(label, sizeof(label), "PCM[{}]###header", index);
   }
 
   // header
@@ -115,9 +112,7 @@ void glass::DisplayCompressorDevice(PCMModel* model, int index,
 void glass::DisplayCompressorDevice(CompressorModel* model, int index,
                                     bool outputsEnabled) {
   char name[32];
-  const auto result =
-      fmt::format_to_n(name, sizeof(name) - 1, "Compressor[{}]", index);
-  *result.out = '\0';
+  wpi::format_to_n_c_str(name, sizeof(name), "Compressor[{}]", index);
 
   if (BeginDevice(name)) {
     // output enabled

--- a/glass/src/lib/native/cpp/hardware/PCM.cpp
+++ b/glass/src/lib/native/cpp/hardware/PCM.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstring>
 
+#include <fmt/format.h>
 #include <imgui.h>
 #include <wpi/SmallVector.h>
 
@@ -46,10 +47,13 @@ bool glass::DisplayPCMSolenoids(PCMModel* model, int index,
   std::string& name = GetStorage().GetString("name");
   char label[128];
   if (!name.empty()) {
-    std::snprintf(label, sizeof(label), "%s [%d]###header", name.c_str(),
-                  index);
+    const auto result = fmt::format_to_n(label, sizeof(label) - 1,
+                                         "{} [{}]###header", name, index);
+    *result.out = '\0';
   } else {
-    std::snprintf(label, sizeof(label), "PCM[%d]###header", index);
+    const auto result =
+        fmt::format_to_n(label, sizeof(label) - 1, "PCM[{}]###header", index);
+    *result.out = '\0';
   }
 
   // header
@@ -111,7 +115,10 @@ void glass::DisplayCompressorDevice(PCMModel* model, int index,
 void glass::DisplayCompressorDevice(CompressorModel* model, int index,
                                     bool outputsEnabled) {
   char name[32];
-  std::snprintf(name, sizeof(name), "Compressor[%d]", index);
+  const auto result =
+      fmt::format_to_n(name, sizeof(name) - 1, "Compressor[{}]", index);
+  *result.out = '\0';
+
   if (BeginDevice(name)) {
     // output enabled
     if (auto runningData = model->GetRunningData()) {

--- a/glass/src/lib/native/cpp/hardware/PWM.cpp
+++ b/glass/src/lib/native/cpp/hardware/PWM.cpp
@@ -4,8 +4,8 @@
 
 #include "glass/hardware/PWM.h"
 
-#include <fmt/format.h>
 #include <imgui.h>
+#include <wpi/StringExtras.h>
 
 #include "glass/Context.h"
 #include "glass/DataSource.h"
@@ -23,13 +23,9 @@ void glass::DisplayPWM(PWMModel* model, int index, bool outputsEnabled) {
   std::string& name = GetStorage().GetString("name");
   char label[128];
   if (!name.empty()) {
-    const auto result = fmt::format_to_n(label, sizeof(label) - 1,
-                                         "{} [{}]###name", name, index);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(label, sizeof(label), "{} [{}]###name", name, index);
   } else {
-    const auto result =
-        fmt::format_to_n(label, sizeof(label) - 1, "PWM[{}]###name", index);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(label, sizeof(label), "PWM[{}]###name", index);
   }
 
   int led = model->GetAddressableLED();

--- a/glass/src/lib/native/cpp/hardware/PWM.cpp
+++ b/glass/src/lib/native/cpp/hardware/PWM.cpp
@@ -4,6 +4,7 @@
 
 #include "glass/hardware/PWM.h"
 
+#include <fmt/format.h>
 #include <imgui.h>
 
 #include "glass/Context.h"
@@ -22,9 +23,13 @@ void glass::DisplayPWM(PWMModel* model, int index, bool outputsEnabled) {
   std::string& name = GetStorage().GetString("name");
   char label[128];
   if (!name.empty()) {
-    std::snprintf(label, sizeof(label), "%s [%d]###name", name.c_str(), index);
+    const auto result = fmt::format_to_n(label, sizeof(label) - 1,
+                                         "{} [{}]###name", name, index);
+    *result.out = '\0';
   } else {
-    std::snprintf(label, sizeof(label), "PWM[%d]###name", index);
+    const auto result =
+        fmt::format_to_n(label, sizeof(label) - 1, "PWM[{}]###name", index);
+    *result.out = '\0';
   }
 
   int led = model->GetAddressableLED();

--- a/glass/src/lib/native/cpp/hardware/PowerDistribution.cpp
+++ b/glass/src/lib/native/cpp/hardware/PowerDistribution.cpp
@@ -5,8 +5,8 @@
 #include "glass/hardware/PowerDistribution.h"
 
 #include <algorithm>
-#include <cstdio>
 
+#include <fmt/format.h>
 #include <imgui.h>
 
 #include "glass/Context.h"
@@ -36,7 +36,10 @@ static float DisplayChannel(PowerDistributionModel& pdp, int channel) {
 
 void glass::DisplayPowerDistribution(PowerDistributionModel* model, int index) {
   char name[128];
-  std::snprintf(name, sizeof(name), "PowerDistribution[%d]", index);
+  const auto result =
+      fmt::format_to_n(name, sizeof(name) - 1, "PowerDistribution[{}]", index);
+  *result.out = '\0';
+
   if (CollapsingHeader(name)) {
     // temperature
     if (auto tempData = model->GetTemperatureData()) {

--- a/glass/src/lib/native/cpp/hardware/PowerDistribution.cpp
+++ b/glass/src/lib/native/cpp/hardware/PowerDistribution.cpp
@@ -6,8 +6,8 @@
 
 #include <algorithm>
 
-#include <fmt/format.h>
 #include <imgui.h>
+#include <wpi/StringExtras.h>
 
 #include "glass/Context.h"
 #include "glass/DataSource.h"
@@ -36,9 +36,7 @@ static float DisplayChannel(PowerDistributionModel& pdp, int channel) {
 
 void glass::DisplayPowerDistribution(PowerDistributionModel* model, int index) {
   char name[128];
-  const auto result =
-      fmt::format_to_n(name, sizeof(name) - 1, "PowerDistribution[{}]", index);
-  *result.out = '\0';
+  wpi::format_to_n_c_str(name, sizeof(name), "PowerDistribution[{}]", index);
 
   if (CollapsingHeader(name)) {
     // temperature

--- a/glass/src/lib/native/cpp/other/DeviceTree.cpp
+++ b/glass/src/lib/native/cpp/other/DeviceTree.cpp
@@ -6,6 +6,7 @@
 
 #include <cinttypes>
 
+#include <fmt/format.h>
 #include <imgui.h>
 
 #include "glass/Context.h"
@@ -53,8 +54,15 @@ bool glass::BeginDevice(const char* id, ImGuiTreeNodeFlags flags) {
   // build label
   std::string& name = GetStorage().GetString("name");
   char label[128];
-  std::snprintf(label, sizeof(label), "%s###header",
-                name.empty() ? id : name.c_str());
+  if (name.empty()) {
+    const auto result =
+        fmt::format_to_n(label, sizeof(label) - 1, "{}###header", id);
+    *result.out = '\0';
+  } else {
+    const auto result =
+        fmt::format_to_n(label, sizeof(label) - 1, "{}###header", name);
+    *result.out = '\0';
+  }
 
   bool open = CollapsingHeader(label, flags);
   PopupEditName("header", &name);

--- a/glass/src/lib/native/cpp/other/DeviceTree.cpp
+++ b/glass/src/lib/native/cpp/other/DeviceTree.cpp
@@ -6,8 +6,8 @@
 
 #include <cinttypes>
 
-#include <fmt/format.h>
 #include <imgui.h>
+#include <wpi/StringExtras.h>
 
 #include "glass/Context.h"
 #include "glass/ContextInternal.h"
@@ -55,13 +55,9 @@ bool glass::BeginDevice(const char* id, ImGuiTreeNodeFlags flags) {
   std::string& name = GetStorage().GetString("name");
   char label[128];
   if (name.empty()) {
-    const auto result =
-        fmt::format_to_n(label, sizeof(label) - 1, "{}###header", id);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(label, sizeof(label), "{}###header", id);
   } else {
-    const auto result =
-        fmt::format_to_n(label, sizeof(label) - 1, "{}###header", name);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(label, sizeof(label), "{}###header", name);
   }
 
   bool open = CollapsingHeader(label, flags);

--- a/glass/src/lib/native/cpp/other/Plot.cpp
+++ b/glass/src/lib/native/cpp/other/Plot.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <wpi/StringExtras.h>
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
@@ -320,10 +321,8 @@ PlotSeries::Action PlotSeries::EmitPlot(PlotView& view, double now, size_t i,
   CheckSource();
 
   char label[128];
-  const auto result =
-      fmt::format_to_n(label, sizeof(label) - 1, "{}###name{}_{}", GetName(),
-                       static_cast<int>(i), static_cast<int>(plotIndex));
-  *result.out = '\0';
+  wpi::format_to_n_c_str(label, sizeof(label), "{}###name{}_{}", GetName(),
+                         static_cast<int>(i), static_cast<int>(plotIndex));
 
   int size = m_size;
   int offset = m_offset;
@@ -581,9 +580,8 @@ void Plot::EmitPlot(PlotView& view, double now, bool paused, size_t i) {
   }
 
   char label[128];
-  const auto result = fmt::format_to_n(label, sizeof(label) - 1, "{}###plot{}",
-                                       m_name, static_cast<int>(i));
-  *result.out = '\0';
+  wpi::format_to_n_c_str(label, sizeof(label), "{}###plot{}", m_name,
+                         static_cast<int>(i));
 
   ImPlotFlags plotFlags = (m_legend ? 0 : ImPlotFlags_NoLegend) |
                           (m_crosshairs ? ImPlotFlags_Crosshairs : 0) |
@@ -940,19 +938,15 @@ void PlotView::Settings() {
 
     char name[64];
     if (!plot->GetName().empty()) {
-      const auto result = fmt::format_to_n(name, sizeof(name) - 1, "{}",
-                                           plot->GetName().c_str());
-      *result.out = '\0';
+      wpi::format_to_n_c_str(name, sizeof(name), "{}", plot->GetName().c_str());
     } else {
-      const auto result = fmt::format_to_n(name, sizeof(name) - 1, "Plot {}",
-                                           static_cast<int>(i));
-      *result.out = '\0';
+      wpi::format_to_n_c_str(name, sizeof(name), "Plot {}",
+                             static_cast<int>(i));
     }
 
     char label[90];
-    const auto result = fmt::format_to_n(
-        label, sizeof(label) - 1, "{}###header{}", name, static_cast<int>(i));
-    *result.out = '\0';
+    wpi::format_to_n_c_str(label, sizeof(label), "{}###header{}", name,
+                           static_cast<int>(i));
 
     bool open = ImGui::CollapsingHeader(label);
 
@@ -1021,9 +1015,7 @@ void PlotProvider::DisplayMenu() {
     char id[32];
     size_t numWindows = m_windows.size();
     for (size_t i = 0; i <= numWindows; ++i) {
-      const auto result = fmt::format_to_n(id, sizeof(id) - 1, "Plot <{}>",
-                                           static_cast<int>(i));
-      *result.out = '\0';
+      wpi::format_to_n_c_str(id, sizeof(id), "Plot <{}>", static_cast<int>(i));
 
       bool match = false;
       for (size_t j = 0; j < numWindows; ++j) {

--- a/glass/src/lib/native/cpp/other/Plot.cpp
+++ b/glass/src/lib/native/cpp/other/Plot.cpp
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 #include <atomic>
-#include <cstdio>
 #include <cstring>
 #include <memory>
 #include <string>
@@ -321,8 +320,10 @@ PlotSeries::Action PlotSeries::EmitPlot(PlotView& view, double now, size_t i,
   CheckSource();
 
   char label[128];
-  std::snprintf(label, sizeof(label), "%s###name%d_%d", GetName(),
-                static_cast<int>(i), static_cast<int>(plotIndex));
+  const auto result =
+      fmt::format_to_n(label, sizeof(label) - 1, "{}###name{}_{}", GetName(),
+                       static_cast<int>(i), static_cast<int>(plotIndex));
+  *result.out = '\0';
 
   int size = m_size;
   int offset = m_offset;
@@ -580,8 +581,10 @@ void Plot::EmitPlot(PlotView& view, double now, bool paused, size_t i) {
   }
 
   char label[128];
-  std::snprintf(label, sizeof(label), "%s###plot%d", m_name.c_str(),
-                static_cast<int>(i));
+  const auto result = fmt::format_to_n(label, sizeof(label) - 1, "{}###plot{}",
+                                       m_name, static_cast<int>(i));
+  *result.out = '\0';
+
   ImPlotFlags plotFlags = (m_legend ? 0 : ImPlotFlags_NoLegend) |
                           (m_crosshairs ? ImPlotFlags_Crosshairs : 0) |
                           (m_mousePosition ? 0 : ImPlotFlags_NoMouseText);
@@ -937,14 +940,19 @@ void PlotView::Settings() {
 
     char name[64];
     if (!plot->GetName().empty()) {
-      std::snprintf(name, sizeof(name), "%s", plot->GetName().c_str());
+      const auto result = fmt::format_to_n(name, sizeof(name) - 1, "{}",
+                                           plot->GetName().c_str());
+      *result.out = '\0';
     } else {
-      std::snprintf(name, sizeof(name), "Plot %d", static_cast<int>(i));
+      const auto result = fmt::format_to_n(name, sizeof(name) - 1, "Plot {}",
+                                           static_cast<int>(i));
+      *result.out = '\0';
     }
 
     char label[90];
-    std::snprintf(label, sizeof(label), "%s###header%d", name,
-                  static_cast<int>(i));
+    const auto result = fmt::format_to_n(
+        label, sizeof(label) - 1, "{}###header{}", name, static_cast<int>(i));
+    *result.out = '\0';
 
     bool open = ImGui::CollapsingHeader(label);
 
@@ -1013,7 +1021,10 @@ void PlotProvider::DisplayMenu() {
     char id[32];
     size_t numWindows = m_windows.size();
     for (size_t i = 0; i <= numWindows; ++i) {
-      std::snprintf(id, sizeof(id), "Plot <%d>", static_cast<int>(i));
+      const auto result = fmt::format_to_n(id, sizeof(id) - 1, "Plot <{}>",
+                                           static_cast<int>(i));
+      *result.out = '\0';
+
       bool match = false;
       for (size_t j = 0; j < numWindows; ++j) {
         if (m_windows[j]->GetId() == id) {

--- a/glass/src/lib/native/cpp/support/NameSetting.cpp
+++ b/glass/src/lib/native/cpp/support/NameSetting.cpp
@@ -4,7 +4,6 @@
 
 #include "glass/support/NameSetting.h"
 
-#include <fmt/format.h>
 #include <imgui_internal.h>
 #include <imgui_stdlib.h>
 #include <wpi/StringExtras.h>
@@ -14,91 +13,70 @@ using namespace glass;
 void NameSetting::GetName(char* buf, size_t size,
                           const char* defaultName) const {
   if (!m_name.empty()) {
-    const auto result = fmt::format_to_n(buf, size - 1, "{}", m_name);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(buf, size, "{}", m_name);
   } else {
-    const auto result = fmt::format_to_n(buf, size - 1, "{}", defaultName);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(buf, size, "{}", defaultName);
   }
 }
 
 void NameSetting::GetName(char* buf, size_t size, const char* defaultName,
                           int index) const {
   if (!m_name.empty()) {
-    const auto result =
-        fmt::format_to_n(buf, size - 1, "{} [{}]", m_name, index);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(buf, size, "{} [{}]", m_name, index);
   } else {
-    const auto result =
-        fmt::format_to_n(buf, size - 1, "{}[{}]", defaultName, index);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(buf, size, "{}[{}]", defaultName, index);
   }
 }
 
 void NameSetting::GetName(char* buf, size_t size, const char* defaultName,
                           int index, int index2) const {
   if (!m_name.empty()) {
-    const auto result =
-        fmt::format_to_n(buf, size - 1, "{} [{},{}]", m_name, index, index2);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(buf, size, "{} [{},{}]", m_name, index, index2);
   } else {
-    const auto result = fmt::format_to_n(buf, size - 1, "{}[{},{}]",
-                                         defaultName, index, index2);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(buf, size, "{}[{},{}]", defaultName, index, index2);
   }
 }
 
 void NameSetting::GetLabel(char* buf, size_t size,
                            const char* defaultName) const {
   if (!m_name.empty()) {
-    const auto result =
-        fmt::format_to_n(buf, size - 1, "{}###Name{}", m_name, defaultName);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(buf, size, "{}###Name{}", m_name, defaultName);
   } else {
-    const auto result = fmt::format_to_n(buf, size - 1, "{}###Name{}",
-                                         defaultName, defaultName);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(buf, size, "{}###Name{}", defaultName, defaultName);
   }
 }
 
 void NameSetting::GetLabel(char* buf, size_t size, const char* defaultName,
                            int index) const {
   if (!m_name.empty()) {
-    const auto result = fmt::format_to_n(buf, size - 1, "{} [{}]###Name{}",
-                                         m_name, index, index);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(buf, size, "{} [{}]###Name{}", m_name, index, index);
   } else {
-    const auto result = fmt::format_to_n(buf, size - 1, "{}[{}]###Name{}",
-                                         defaultName, index, index);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(buf, size, "{}[{}]###Name{}", defaultName, index,
+                           index);
   }
 }
 
 void NameSetting::GetLabel(char* buf, size_t size, const char* defaultName,
                            int index, int index2) const {
   if (!m_name.empty()) {
-    const auto result = fmt::format_to_n(buf, size - 1, "{} [{},{}]###Name{}",
-                                         m_name, index, index2, index);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(buf, size, "{} [{},{}]###Name{}", m_name, index,
+                           index2, index);
   } else {
-    const auto result = fmt::format_to_n(buf, size - 1, "{}[{},{}]###Name{}",
-                                         defaultName, index, index2, index);
-    *result.out = '\0';
+    wpi::format_to_n_c_str(buf, size, "{}[{},{}]###Name{}", defaultName, index,
+                           index2, index);
   }
 }
 
 void NameSetting::PushEditNameId(int index) {
   char id[64];
-  const auto result = fmt::format_to_n(id, sizeof(id) - 1, "Name{}", index);
-  *result.out = '\0';
+  wpi::format_to_n_c_str(id, sizeof(id), "Name{}", index);
 
   ImGui::PushID(id);
 }
 
 void NameSetting::PushEditNameId(const char* name) {
   char id[128];
-  const auto result = fmt::format_to_n(id, sizeof(id) - 1, "Name{}", name);
-  *result.out = '\0';
+  wpi::format_to_n_c_str(id, sizeof(id), "Name{}", name);
 
   ImGui::PushID(id);
 }
@@ -107,8 +85,7 @@ bool NameSetting::PopupEditName(int index) {
   bool rv = false;
 
   char id[64];
-  const auto result = fmt::format_to_n(id, sizeof(id) - 1, "Name{}", index);
-  *result.out = '\0';
+  wpi::format_to_n_c_str(id, sizeof(id), "Name{}", index);
 
   if (ImGui::BeginPopupContextItem(id)) {
     ImGui::Text("Edit name:");
@@ -128,8 +105,7 @@ bool NameSetting::PopupEditName(const char* name) {
   bool rv = false;
 
   char id[128];
-  const auto result = fmt::format_to_n(id, sizeof(id) - 1, "Name{}", name);
-  *result.out = '\0';
+  wpi::format_to_n_c_str(id, sizeof(id), "Name{}", name);
 
   if (ImGui::BeginPopupContextItem(id)) {
     ImGui::Text("Edit name:");

--- a/glass/src/lib/native/cpp/support/NameSetting.cpp
+++ b/glass/src/lib/native/cpp/support/NameSetting.cpp
@@ -4,9 +4,7 @@
 
 #include "glass/support/NameSetting.h"
 
-#include <cstdio>
-#include <cstring>
-
+#include <fmt/format.h>
 #include <imgui_internal.h>
 #include <imgui_stdlib.h>
 #include <wpi/StringExtras.h>
@@ -16,75 +14,102 @@ using namespace glass;
 void NameSetting::GetName(char* buf, size_t size,
                           const char* defaultName) const {
   if (!m_name.empty()) {
-    std::snprintf(buf, size, "%s", m_name.c_str());
+    const auto result = fmt::format_to_n(buf, size - 1, "{}", m_name);
+    *result.out = '\0';
   } else {
-    std::snprintf(buf, size, "%s", defaultName);
+    const auto result = fmt::format_to_n(buf, size - 1, "{}", defaultName);
+    *result.out = '\0';
   }
 }
 
 void NameSetting::GetName(char* buf, size_t size, const char* defaultName,
                           int index) const {
   if (!m_name.empty()) {
-    std::snprintf(buf, size, "%s [%d]", m_name.c_str(), index);
+    const auto result =
+        fmt::format_to_n(buf, size - 1, "{} [{}]", m_name, index);
+    *result.out = '\0';
   } else {
-    std::snprintf(buf, size, "%s[%d]", defaultName, index);
+    const auto result =
+        fmt::format_to_n(buf, size - 1, "{}[{}]", defaultName, index);
+    *result.out = '\0';
   }
 }
 
 void NameSetting::GetName(char* buf, size_t size, const char* defaultName,
                           int index, int index2) const {
   if (!m_name.empty()) {
-    std::snprintf(buf, size, "%s [%d,%d]", m_name.c_str(), index, index2);
+    const auto result =
+        fmt::format_to_n(buf, size - 1, "{} [{},{}]", m_name, index, index2);
+    *result.out = '\0';
   } else {
-    std::snprintf(buf, size, "%s[%d,%d]", defaultName, index, index2);
+    const auto result = fmt::format_to_n(buf, size - 1, "{}[{},{}]",
+                                         defaultName, index, index2);
+    *result.out = '\0';
   }
 }
 
 void NameSetting::GetLabel(char* buf, size_t size,
                            const char* defaultName) const {
   if (!m_name.empty()) {
-    std::snprintf(buf, size, "%s###Name%s", m_name.c_str(), defaultName);
+    const auto result =
+        fmt::format_to_n(buf, size - 1, "{}###Name{}", m_name, defaultName);
+    *result.out = '\0';
   } else {
-    std::snprintf(buf, size, "%s###Name%s", defaultName, defaultName);
+    const auto result = fmt::format_to_n(buf, size - 1, "{}###Name{}",
+                                         defaultName, defaultName);
+    *result.out = '\0';
   }
 }
 
 void NameSetting::GetLabel(char* buf, size_t size, const char* defaultName,
                            int index) const {
   if (!m_name.empty()) {
-    std::snprintf(buf, size, "%s [%d]###Name%d", m_name.c_str(), index, index);
+    const auto result = fmt::format_to_n(buf, size - 1, "{} [{}]###Name{}",
+                                         m_name, index, index);
+    *result.out = '\0';
   } else {
-    std::snprintf(buf, size, "%s[%d]###Name%d", defaultName, index, index);
+    const auto result = fmt::format_to_n(buf, size - 1, "{}[{}]###Name{}",
+                                         defaultName, index, index);
+    *result.out = '\0';
   }
 }
 
 void NameSetting::GetLabel(char* buf, size_t size, const char* defaultName,
                            int index, int index2) const {
   if (!m_name.empty()) {
-    std::snprintf(buf, size, "%s [%d,%d]###Name%d", m_name.c_str(), index,
-                  index2, index);
+    const auto result = fmt::format_to_n(buf, size - 1, "{} [{},{}]###Name{}",
+                                         m_name, index, index2, index);
+    *result.out = '\0';
   } else {
-    std::snprintf(buf, size, "%s[%d,%d]###Name%d", defaultName, index, index2,
-                  index);
+    const auto result = fmt::format_to_n(buf, size - 1, "{}[{},{}]###Name{}",
+                                         defaultName, index, index2, index);
+    *result.out = '\0';
   }
 }
 
 void NameSetting::PushEditNameId(int index) {
   char id[64];
-  std::snprintf(id, sizeof(id), "Name%d", index);
+  const auto result = fmt::format_to_n(id, sizeof(id) - 1, "Name{}", index);
+  *result.out = '\0';
+
   ImGui::PushID(id);
 }
 
 void NameSetting::PushEditNameId(const char* name) {
   char id[128];
-  std::snprintf(id, sizeof(id), "Name%s", name);
+  const auto result = fmt::format_to_n(id, sizeof(id) - 1, "Name{}", name);
+  *result.out = '\0';
+
   ImGui::PushID(id);
 }
 
 bool NameSetting::PopupEditName(int index) {
   bool rv = false;
+
   char id[64];
-  std::snprintf(id, sizeof(id), "Name%d", index);
+  const auto result = fmt::format_to_n(id, sizeof(id) - 1, "Name{}", index);
+  *result.out = '\0';
+
   if (ImGui::BeginPopupContextItem(id)) {
     ImGui::Text("Edit name:");
     if (InputTextName("##edit")) {
@@ -101,8 +126,11 @@ bool NameSetting::PopupEditName(int index) {
 
 bool NameSetting::PopupEditName(const char* name) {
   bool rv = false;
+
   char id[128];
-  std::snprintf(id, sizeof(id), "Name%s", name);
+  const auto result = fmt::format_to_n(id, sizeof(id) - 1, "Name{}", name);
+  *result.out = '\0';
+
   if (ImGui::BeginPopupContextItem(id)) {
     ImGui::Text("Edit name:");
     if (InputTextName("##edit")) {

--- a/glass/src/libnt/native/cpp/NetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTables.cpp
@@ -6,7 +6,6 @@
 
 #include <cinttypes>
 #include <concepts>
-#include <cstdio>
 #include <cstring>
 #include <initializer_list>
 #include <memory>
@@ -1177,12 +1176,20 @@ static void EmitValueTree(
     ImGui::TableNextRow();
     ImGui::TableNextColumn();
     EmitValueName(child.source.get(), child.name.c_str(), child.path.c_str());
+
     ImGui::TableNextColumn();
     if (!child.valueChildren.empty()) {
       char label[64];
-      std::snprintf(label, sizeof(label),
-                    child.valueChildrenMap ? "{...}##v_%s" : "[...]##v_%s",
-                    child.name.c_str());
+      if (child.valueChildrenMap) {
+        const auto result = fmt::format_to_n(label, sizeof(label) - 1,
+                                             "{{...}}##v_{}", child.name);
+        *result.out = '\0';
+      } else {
+        const auto result = fmt::format_to_n(label, sizeof(label) - 1,
+                                             "[...]##v_{}", child.name);
+        *result.out = '\0';
+      }
+
       if (TreeNodeEx(label, ImGuiTreeNodeFlags_SpanFullWidth)) {
         EmitValueTree(child.valueChildren, flags);
         TreePop();
@@ -1208,10 +1215,18 @@ static void EmitEntry(NetworkTablesModel* model,
   ImGui::TableNextColumn();
   if (!entry.valueChildren.empty()) {
     auto pos = ImGui::GetCursorPos();
+
     char label[64];
-    std::snprintf(label, sizeof(label),
-                  entry.valueChildrenMap ? "{...}##v_%s" : "[...]##v_%s",
-                  entry.info.name.c_str());
+    if (entry.valueChildrenMap) {
+      const auto result = fmt::format_to_n(
+          label, sizeof(label) - 1, "{{...}}##v_{}", entry.info.name.c_str());
+      *result.out = '\0';
+    } else {
+      const auto result = fmt::format_to_n(
+          label, sizeof(label) - 1, "[...]##v_{}", entry.info.name.c_str());
+      *result.out = '\0';
+    }
+
     valueChildrenOpen =
         TreeNodeEx(label, ImGuiTreeNodeFlags_SpanFullWidth |
                               ImGuiTreeNodeFlags_AllowItemOverlap);

--- a/glass/src/libnt/native/cpp/NetworkTables.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTables.cpp
@@ -1181,13 +1181,10 @@ static void EmitValueTree(
     if (!child.valueChildren.empty()) {
       char label[64];
       if (child.valueChildrenMap) {
-        const auto result = fmt::format_to_n(label, sizeof(label) - 1,
-                                             "{{...}}##v_{}", child.name);
-        *result.out = '\0';
+        wpi::format_to_n_c_str(label, sizeof(label), "{{...}}##v_{}",
+                               child.name);
       } else {
-        const auto result = fmt::format_to_n(label, sizeof(label) - 1,
-                                             "[...]##v_{}", child.name);
-        *result.out = '\0';
+        wpi::format_to_n_c_str(label, sizeof(label), "[...]##v_{}", child.name);
       }
 
       if (TreeNodeEx(label, ImGuiTreeNodeFlags_SpanFullWidth)) {
@@ -1218,13 +1215,11 @@ static void EmitEntry(NetworkTablesModel* model,
 
     char label[64];
     if (entry.valueChildrenMap) {
-      const auto result = fmt::format_to_n(
-          label, sizeof(label) - 1, "{{...}}##v_{}", entry.info.name.c_str());
-      *result.out = '\0';
+      wpi::format_to_n_c_str(label, sizeof(label), "{{...}}##v_{}",
+                             entry.info.name.c_str());
     } else {
-      const auto result = fmt::format_to_n(
-          label, sizeof(label) - 1, "[...]##v_{}", entry.info.name.c_str());
-      *result.out = '\0';
+      wpi::format_to_n_c_str(label, sizeof(label), "[...]##v_{}",
+                             entry.info.name.c_str());
     }
 
     valueChildrenOpen =

--- a/hal/src/main/native/cpp/jni/simulation/DriverStationDataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/DriverStationDataJNI.cpp
@@ -4,7 +4,7 @@
 
 #include <jni.h>
 
-#include <fmt/format.h>
+#include <wpi/StringExtras.h>
 #include <wpi/jni_util.h>
 
 #include "CallbackStore.h"
@@ -538,21 +538,12 @@ Java_edu_wpi_first_hal_simulation_DriverStationDataJNI_setMatchInfo
   JStringRef gameSpecificMessageRef{env, gameSpecificMessage};
 
   HAL_MatchInfo halMatchInfo;
-
-  {
-    const auto result = fmt::format_to_n(halMatchInfo.eventName,
-                                         sizeof(halMatchInfo.eventName) - 1,
-                                         "{}", eventNameRef.str());
-    *result.out = '\0';
-  }
-  {
-    const auto result = fmt::format_to_n(
-        reinterpret_cast<char*>(halMatchInfo.gameSpecificMessage),
-        sizeof(halMatchInfo.gameSpecificMessage) - 1, "{}",
-        gameSpecificMessageRef.str());
-    *result.out = '\0';
-  }
-
+  wpi::format_to_n_c_str(halMatchInfo.eventName, sizeof(halMatchInfo.eventName),
+                         "{}", eventNameRef.str());
+  wpi::format_to_n_c_str(
+      reinterpret_cast<char*>(halMatchInfo.gameSpecificMessage),
+      sizeof(halMatchInfo.gameSpecificMessage), "{}",
+      gameSpecificMessageRef.str());
   halMatchInfo.gameSpecificMessageSize = gameSpecificMessageRef.size();
   halMatchInfo.matchType = (HAL_MatchType)matchType;
   halMatchInfo.matchNumber = matchNumber;

--- a/hal/src/main/native/cpp/jni/simulation/DriverStationDataJNI.cpp
+++ b/hal/src/main/native/cpp/jni/simulation/DriverStationDataJNI.cpp
@@ -4,8 +4,7 @@
 
 #include <jni.h>
 
-#include <cstring>
-
+#include <fmt/format.h>
 #include <wpi/jni_util.h>
 
 #include "CallbackStore.h"
@@ -539,11 +538,21 @@ Java_edu_wpi_first_hal_simulation_DriverStationDataJNI_setMatchInfo
   JStringRef gameSpecificMessageRef{env, gameSpecificMessage};
 
   HAL_MatchInfo halMatchInfo;
-  std::snprintf(halMatchInfo.eventName, sizeof(halMatchInfo.eventName), "%s",
-                eventNameRef.c_str());
-  std::snprintf(reinterpret_cast<char*>(halMatchInfo.gameSpecificMessage),
-                sizeof(halMatchInfo.gameSpecificMessage), "%s",
-                gameSpecificMessageRef.c_str());
+
+  {
+    const auto result = fmt::format_to_n(halMatchInfo.eventName,
+                                         sizeof(halMatchInfo.eventName) - 1,
+                                         "{}", eventNameRef.str());
+    *result.out = '\0';
+  }
+  {
+    const auto result = fmt::format_to_n(
+        reinterpret_cast<char*>(halMatchInfo.gameSpecificMessage),
+        sizeof(halMatchInfo.gameSpecificMessage) - 1, "{}",
+        gameSpecificMessageRef.str());
+    *result.out = '\0';
+  }
+
   halMatchInfo.gameSpecificMessageSize = gameSpecificMessageRef.size();
   halMatchInfo.matchType = (HAL_MatchType)matchType;
   halMatchInfo.matchNumber = matchNumber;

--- a/hal/src/main/native/sim/Notifier.cpp
+++ b/hal/src/main/native/sim/Notifier.cpp
@@ -10,8 +10,8 @@
 #include <cstring>
 #include <string>
 
-#include <fmt/format.h>
 #include <wpi/SmallVector.h>
+#include <wpi/StringExtras.h>
 #include <wpi/condition_variable.h>
 #include <wpi/mutex.h>
 
@@ -317,10 +317,9 @@ int32_t HALSIM_GetNotifierInfo(struct HALSIM_NotifierInfo* arr, int32_t size) {
     if (num < size) {
       arr[num].handle = handle;
       if (notifier->name.empty()) {
-        const auto result = fmt::format_to_n(
-            arr[num].name, sizeof(arr[num].name) - 1, "Notifier{}",
-            static_cast<int>(getHandleIndex(handle)));
-        *result.out = '\0';
+        wpi::format_to_n_c_str(arr[num].name, sizeof(arr[num].name),
+                               "Notifier{}",
+                               static_cast<int>(getHandleIndex(handle)));
       } else {
         std::strncpy(arr[num].name, notifier->name.c_str(),
                      sizeof(arr[num].name) - 1);

--- a/hal/src/main/native/sim/Notifier.cpp
+++ b/hal/src/main/native/sim/Notifier.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <string>
 
+#include <fmt/format.h>
 #include <wpi/SmallVector.h>
 #include <wpi/condition_variable.h>
 #include <wpi/mutex.h>
@@ -316,8 +317,10 @@ int32_t HALSIM_GetNotifierInfo(struct HALSIM_NotifierInfo* arr, int32_t size) {
     if (num < size) {
       arr[num].handle = handle;
       if (notifier->name.empty()) {
-        std::snprintf(arr[num].name, sizeof(arr[num].name), "Notifier%d",
-                      static_cast<int>(getHandleIndex(handle)));
+        const auto result = fmt::format_to_n(
+            arr[num].name, sizeof(arr[num].name) - 1, "Notifier{}",
+            static_cast<int>(getHandleIndex(handle)));
+        *result.out = '\0';
       } else {
         std::strncpy(arr[num].name, notifier->name.c_str(),
                      sizeof(arr[num].name) - 1);

--- a/hal/src/test/native/cpp/mockdata/DriverStationDataTest.cpp
+++ b/hal/src/test/native/cpp/mockdata/DriverStationDataTest.cpp
@@ -4,6 +4,7 @@
 
 #include <cstring>
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include "hal/HAL.h"
@@ -117,13 +118,22 @@ TEST(DriverStationTest, Joystick) {
 }
 
 TEST(DriverStationTest, EventInfo) {
-  std::string eventName = "UnitTest";
-  std::string gameData = "Insert game specific info here :D";
+  constexpr std::string_view eventName = "UnitTest";
+  constexpr std::string_view gameData = "Insert game specific info here :D";
   HAL_MatchInfo info;
-  std::snprintf(info.eventName, sizeof(info.eventName), "%s",
-                eventName.c_str());
-  std::snprintf(reinterpret_cast<char*>(info.gameSpecificMessage),
-                sizeof(info.gameSpecificMessage), "%s", gameData.c_str());
+
+  {
+    const auto result =
+        fmt::format_to_n(info.eventName, sizeof(info.eventName) - 1, eventName);
+    *result.out = '\0';
+  }
+  {
+    const auto result =
+        fmt::format_to_n(reinterpret_cast<char*>(info.gameSpecificMessage),
+                         sizeof(info.gameSpecificMessage) - 1, gameData);
+    *result.out = '\0';
+  }
+
   info.gameSpecificMessageSize = gameData.size();
   info.matchNumber = 5;
   info.matchType = HAL_MatchType::HAL_kMatchType_qualification;
@@ -136,7 +146,7 @@ TEST(DriverStationTest, EventInfo) {
   std::string gsm{reinterpret_cast<char*>(dataBack.gameSpecificMessage),
                   dataBack.gameSpecificMessageSize};
 
-  EXPECT_STREQ(eventName.c_str(), dataBack.eventName);
+  EXPECT_EQ(eventName, dataBack.eventName);
   EXPECT_EQ(gameData, gsm);
   EXPECT_EQ(5, dataBack.matchNumber);
   EXPECT_EQ(HAL_MatchType::HAL_kMatchType_qualification, dataBack.matchType);

--- a/hal/src/test/native/cpp/mockdata/DriverStationDataTest.cpp
+++ b/hal/src/test/native/cpp/mockdata/DriverStationDataTest.cpp
@@ -4,8 +4,8 @@
 
 #include <cstring>
 
-#include <fmt/format.h>
 #include <gtest/gtest.h>
+#include <wpi/StringExtras.h>
 
 #include "hal/HAL.h"
 #include "hal/simulation/DriverStationData.h"
@@ -121,19 +121,9 @@ TEST(DriverStationTest, EventInfo) {
   constexpr std::string_view eventName = "UnitTest";
   constexpr std::string_view gameData = "Insert game specific info here :D";
   HAL_MatchInfo info;
-
-  {
-    const auto result =
-        fmt::format_to_n(info.eventName, sizeof(info.eventName) - 1, eventName);
-    *result.out = '\0';
-  }
-  {
-    const auto result =
-        fmt::format_to_n(reinterpret_cast<char*>(info.gameSpecificMessage),
-                         sizeof(info.gameSpecificMessage) - 1, gameData);
-    *result.out = '\0';
-  }
-
+  wpi::format_to_n_c_str(info.eventName, sizeof(info.eventName), eventName);
+  wpi::format_to_n_c_str(reinterpret_cast<char*>(info.gameSpecificMessage),
+                         sizeof(info.gameSpecificMessage), gameData);
   info.gameSpecificMessageSize = gameData.size();
   info.matchNumber = 5;
   info.matchType = HAL_MatchType::HAL_kMatchType_qualification;

--- a/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
@@ -555,16 +555,8 @@ KeyboardJoystick::KeyboardJoystick(glass::Storage& storage, int index)
       m_axisStorage{storage.GetChildArray("axisConfig")},
       m_buttonKey{storage.GetIntArray("buttonKeys")},
       m_povStorage{storage.GetChildArray("povConfig")} {
-  {
-    const auto result =
-        fmt::format_to_n(m_name, sizeof(m_name) - 1, "Keyboard {}", index);
-    *result.out = '\0';
-  }
-  {
-    const auto result =
-        fmt::format_to_n(m_guid, sizeof(m_guid) - 1, "Keyboard{}", index);
-    *result.out = '\0';
-  }
+  wpi::format_to_n_c_str(m_name, sizeof(m_name), "Keyboard {}", index);
+  wpi::format_to_n_c_str(m_guid, sizeof(m_guid), "Keyboard{}", index);
 
   // init axes
   for (auto&& axisConfig : m_axisStorage) {
@@ -598,13 +590,10 @@ void KeyboardJoystick::EditKey(const char* label, int* key) {
 
   char editLabel[32];
   if (s_keyEdit == key) {
-    const auto result = fmt::format_to_n(editLabel, sizeof(editLabel) - 1,
-                                         "(press key)###edit");
-    *result.out = '\0';
+    wpi::format_to_n_c_str(editLabel, sizeof(editLabel), "(press key)###edit");
   } else {
-    const auto result = fmt::format_to_n(editLabel, sizeof(editLabel) - 1,
-                                         "{}###edit", GetKeyName(*key));
-    *result.out = '\0';
+    wpi::format_to_n_c_str(editLabel, sizeof(editLabel), "{}###edit",
+                           GetKeyName(*key));
   }
 
   if (ImGui::SmallButton(editLabel)) {
@@ -650,9 +639,7 @@ void KeyboardJoystick::SettingsDisplay() {
       m_axisConfig.emplace_back(*m_axisStorage.back());
     }
     for (int i = 0; i < m_axisCount; ++i) {
-      const auto result =
-          fmt::format_to_n(label, sizeof(label) - 1, "Axis {}", i);
-      *result.out = '\0';
+      wpi::format_to_n_c_str(label, sizeof(label), "Axis {}", i);
 
       if (ImGui::TreeNodeEx(label, ImGuiTreeNodeFlags_DefaultOpen)) {
         EditKey("Increase", &m_axisConfig[i].incKey);
@@ -686,9 +673,7 @@ void KeyboardJoystick::SettingsDisplay() {
       m_buttonKey.emplace_back(-1);
     }
     for (int i = 0; i < m_buttonCount; ++i) {
-      const auto result =
-          fmt::format_to_n(label, sizeof(label) - 1, "Button {}", i + 1);
-      *result.out = '\0';
+      wpi::format_to_n_c_str(label, sizeof(label), "Button {}", i + 1);
 
       EditKey(label, &m_buttonKey[i]);
     }
@@ -711,9 +696,7 @@ void KeyboardJoystick::SettingsDisplay() {
       m_povConfig.emplace_back(*m_povStorage.back());
     }
     for (int i = 0; i < m_povCount; ++i) {
-      const auto result =
-          fmt::format_to_n(label, sizeof(label) - 1, "POV {}", i);
-      *result.out = '\0';
+      wpi::format_to_n_c_str(label, sizeof(label), "POV {}", i);
 
       if (ImGui::TreeNodeEx(label, ImGuiTreeNodeFlags_DefaultOpen)) {
         EditKey("  0 deg", &m_povConfig[i].key0);
@@ -1200,9 +1183,7 @@ bool FMSSimModel::IsReadOnly() {
 
 static void DisplaySystemJoystick(SystemJoystick& joy, int i) {
   char label[64];
-  const auto result =
-      fmt::format_to_n(label, sizeof(label) - 1, "{}: {}", i, joy.GetName());
-  *result.out = '\0';
+  wpi::format_to_n_c_str(label, sizeof(label), "{}: {}", i, joy.GetName());
 
   // highlight if any buttons pressed
   bool anyButtonPressed = joy.IsAnyButtonPressed();
@@ -1236,9 +1217,7 @@ static void DisplaySystemJoysticks() {
     DisplaySystemJoystick(*joy, i + GLFW_JOYSTICK_LAST + 1);
     if (ImGui::BeginPopupContextItem()) {
       char buf[64];
-      const auto result =
-          fmt::format_to_n(buf, sizeof(buf) - 1, "{} Settings", joy->GetName());
-      *result.out = '\0';
+      wpi::format_to_n_c_str(buf, sizeof(buf), "{} Settings", joy->GetName());
 
       if (ImGui::MenuItem(buf)) {
         if (auto win = DriverStationGui::dsManager->GetWindow(buf)) {
@@ -1324,9 +1303,7 @@ static void DisplayJoysticks() {
       for (int j = 0; j < joy.data.axes.count; ++j) {
         if (source && source->axes[j]) {
           char label[64];
-          const auto result =
-              fmt::format_to_n(label, sizeof(label) - 1, "Axis[{}]", j);
-          *result.out = '\0';
+          wpi::format_to_n_c_str(label, sizeof(label), "Axis[{}]", j);
 
           ImGui::Selectable(label);
           source->axes[j]->EmitDrag();
@@ -1340,9 +1317,7 @@ static void DisplayJoysticks() {
       for (int j = 0; j < joy.data.povs.count; ++j) {
         if (source && source->povs[j]) {
           char label[64];
-          const auto result =
-              fmt::format_to_n(label, sizeof(label) - 1, "POVs[{}]", j);
-          *result.out = '\0';
+          wpi::format_to_n_c_str(label, sizeof(label), "POVs[{}]", j);
 
           ImGui::Selectable(label);
           source->povs[j]->EmitDrag();
@@ -1443,9 +1418,8 @@ void DriverStationGui::GlobalInit() {
     int i = 0;
     for (auto&& joy : gKeyboardJoysticks) {
       char label[64];
-      const auto result = fmt::format_to_n(label, sizeof(label) - 1,
-                                           "{} Settings", joy->GetName());
-      *result.out = '\0';
+      wpi::format_to_n_c_str(label, sizeof(label), "{} Settings",
+                             joy->GetName());
 
       if (auto win = dsManager->AddWindow(
               label, [j = joy.get()] { j->SettingsDisplay(); },

--- a/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
+++ b/simulation/halsim_gui/src/main/native/cpp/DriverStationGui.cpp
@@ -555,8 +555,16 @@ KeyboardJoystick::KeyboardJoystick(glass::Storage& storage, int index)
       m_axisStorage{storage.GetChildArray("axisConfig")},
       m_buttonKey{storage.GetIntArray("buttonKeys")},
       m_povStorage{storage.GetChildArray("povConfig")} {
-  std::snprintf(m_name, sizeof(m_name), "Keyboard %d", index);
-  std::snprintf(m_guid, sizeof(m_guid), "Keyboard%d", index);
+  {
+    const auto result =
+        fmt::format_to_n(m_name, sizeof(m_name) - 1, "Keyboard {}", index);
+    *result.out = '\0';
+  }
+  {
+    const auto result =
+        fmt::format_to_n(m_guid, sizeof(m_guid) - 1, "Keyboard{}", index);
+    *result.out = '\0';
+  }
 
   // init axes
   for (auto&& axisConfig : m_axisStorage) {
@@ -587,9 +595,18 @@ void KeyboardJoystick::EditKey(const char* label, int* key) {
   ImGui::PushID(label);
   ImGui::Text("%s", label);
   ImGui::SameLine();
+
   char editLabel[32];
-  std::snprintf(editLabel, sizeof(editLabel), "%s###edit",
-                s_keyEdit == key ? "(press key)" : GetKeyName(*key));
+  if (s_keyEdit == key) {
+    const auto result = fmt::format_to_n(editLabel, sizeof(editLabel) - 1,
+                                         "(press key)###edit");
+    *result.out = '\0';
+  } else {
+    const auto result = fmt::format_to_n(editLabel, sizeof(editLabel) - 1,
+                                         "{}###edit", GetKeyName(*key));
+    *result.out = '\0';
+  }
+
   if (ImGui::SmallButton(editLabel)) {
     s_keyEdit = key;
   }
@@ -633,7 +650,10 @@ void KeyboardJoystick::SettingsDisplay() {
       m_axisConfig.emplace_back(*m_axisStorage.back());
     }
     for (int i = 0; i < m_axisCount; ++i) {
-      std::snprintf(label, sizeof(label), "Axis %d", i);
+      const auto result =
+          fmt::format_to_n(label, sizeof(label) - 1, "Axis {}", i);
+      *result.out = '\0';
+
       if (ImGui::TreeNodeEx(label, ImGuiTreeNodeFlags_DefaultOpen)) {
         EditKey("Increase", &m_axisConfig[i].incKey);
         EditKey("Decrease", &m_axisConfig[i].decKey);
@@ -666,7 +686,10 @@ void KeyboardJoystick::SettingsDisplay() {
       m_buttonKey.emplace_back(-1);
     }
     for (int i = 0; i < m_buttonCount; ++i) {
-      std::snprintf(label, sizeof(label), "Button %d", i + 1);
+      const auto result =
+          fmt::format_to_n(label, sizeof(label) - 1, "Button {}", i + 1);
+      *result.out = '\0';
+
       EditKey(label, &m_buttonKey[i]);
     }
     ImGui::PopID();
@@ -688,7 +711,10 @@ void KeyboardJoystick::SettingsDisplay() {
       m_povConfig.emplace_back(*m_povStorage.back());
     }
     for (int i = 0; i < m_povCount; ++i) {
-      std::snprintf(label, sizeof(label), "POV %d", i);
+      const auto result =
+          fmt::format_to_n(label, sizeof(label) - 1, "POV {}", i);
+      *result.out = '\0';
+
       if (ImGui::TreeNodeEx(label, ImGuiTreeNodeFlags_DefaultOpen)) {
         EditKey("  0 deg", &m_povConfig[i].key0);
         EditKey(" 45 deg", &m_povConfig[i].key45);
@@ -1174,7 +1200,9 @@ bool FMSSimModel::IsReadOnly() {
 
 static void DisplaySystemJoystick(SystemJoystick& joy, int i) {
   char label[64];
-  std::snprintf(label, sizeof(label), "%d: %s", i, joy.GetName());
+  const auto result =
+      fmt::format_to_n(label, sizeof(label) - 1, "{}: {}", i, joy.GetName());
+  *result.out = '\0';
 
   // highlight if any buttons pressed
   bool anyButtonPressed = joy.IsAnyButtonPressed();
@@ -1208,7 +1236,10 @@ static void DisplaySystemJoysticks() {
     DisplaySystemJoystick(*joy, i + GLFW_JOYSTICK_LAST + 1);
     if (ImGui::BeginPopupContextItem()) {
       char buf[64];
-      std::snprintf(buf, sizeof(buf), "%s Settings", joy->GetName());
+      const auto result =
+          fmt::format_to_n(buf, sizeof(buf) - 1, "{} Settings", joy->GetName());
+      *result.out = '\0';
+
       if (ImGui::MenuItem(buf)) {
         if (auto win = DriverStationGui::dsManager->GetWindow(buf)) {
           win->SetVisible(true);
@@ -1293,7 +1324,10 @@ static void DisplayJoysticks() {
       for (int j = 0; j < joy.data.axes.count; ++j) {
         if (source && source->axes[j]) {
           char label[64];
-          std::snprintf(label, sizeof(label), "Axis[%d]", j);
+          const auto result =
+              fmt::format_to_n(label, sizeof(label) - 1, "Axis[{}]", j);
+          *result.out = '\0';
+
           ImGui::Selectable(label);
           source->axes[j]->EmitDrag();
           ImGui::SameLine();
@@ -1306,7 +1340,10 @@ static void DisplayJoysticks() {
       for (int j = 0; j < joy.data.povs.count; ++j) {
         if (source && source->povs[j]) {
           char label[64];
-          std::snprintf(label, sizeof(label), "POVs[%d]", j);
+          const auto result =
+              fmt::format_to_n(label, sizeof(label) - 1, "POVs[{}]", j);
+          *result.out = '\0';
+
           ImGui::Selectable(label);
           source->povs[j]->EmitDrag();
           ImGui::SameLine();
@@ -1406,7 +1443,10 @@ void DriverStationGui::GlobalInit() {
     int i = 0;
     for (auto&& joy : gKeyboardJoysticks) {
       char label[64];
-      std::snprintf(label, sizeof(label), "%s Settings", joy->GetName());
+      const auto result = fmt::format_to_n(label, sizeof(label) - 1,
+                                           "{} Settings", joy->GetName());
+      *result.out = '\0';
+
       if (auto win = dsManager->AddWindow(
               label, [j = joy.get()] { j->SettingsDisplay(); },
               glass::Window::kHide)) {

--- a/wpilibc/src/main/native/cpp/smartdashboard/Mechanism2d.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/Mechanism2d.cpp
@@ -4,7 +4,6 @@
 
 #include "frc/smartdashboard/Mechanism2d.h"
 
-#include <cstdio>
 #include <string_view>
 
 #include <networktables/NTSendableBuilder.h>

--- a/wpilibc/src/main/native/cpp/smartdashboard/MechanismLigament2d.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/MechanismLigament2d.cpp
@@ -4,7 +4,7 @@
 
 #include "frc/smartdashboard/MechanismLigament2d.h"
 
-#include <cstdio>
+#include <fmt/format.h>
 
 using namespace frc;
 
@@ -36,8 +36,12 @@ void MechanismLigament2d::UpdateEntries(
 
 void MechanismLigament2d::SetColor(const Color8Bit& color) {
   std::scoped_lock lock(m_mutex);
-  std::snprintf(m_color, sizeof(m_color), "#%02X%02X%02X", color.red,
-                color.green, color.blue);
+
+  const auto result =
+      fmt::format_to_n(m_color, sizeof(m_color) - 1, "#{:02X}{:02X}{:02X}",
+                       color.red, color.green, color.blue);
+  *result.out = '\0';
+
   if (m_colorEntry) {
     m_colorEntry.Set(m_color);
   }

--- a/wpilibc/src/main/native/cpp/smartdashboard/MechanismLigament2d.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/MechanismLigament2d.cpp
@@ -4,7 +4,7 @@
 
 #include "frc/smartdashboard/MechanismLigament2d.h"
 
-#include <fmt/format.h>
+#include <wpi/StringExtras.h>
 
 using namespace frc;
 
@@ -37,10 +37,8 @@ void MechanismLigament2d::UpdateEntries(
 void MechanismLigament2d::SetColor(const Color8Bit& color) {
   std::scoped_lock lock(m_mutex);
 
-  const auto result =
-      fmt::format_to_n(m_color, sizeof(m_color) - 1, "#{:02X}{:02X}{:02X}",
-                       color.red, color.green, color.blue);
-  *result.out = '\0';
+  wpi::format_to_n_c_str(m_color, sizeof(m_color), "#{:02X}{:02X}{:02X}",
+                         color.red, color.green, color.blue);
 
   if (m_colorEntry) {
     m_colorEntry.Set(m_color);

--- a/wpinet/src/main/native/thirdparty/tcpsockets/cpp/TCPStream.cpp
+++ b/wpinet/src/main/native/thirdparty/tcpsockets/cpp/TCPStream.cpp
@@ -36,6 +36,8 @@
 
 #include <cerrno>
 
+#include <fmt/format.h>
+
 using namespace wpi;
 
 TCPStream::TCPStream(int sd, sockaddr_in* address)
@@ -85,12 +87,11 @@ size_t TCPStream::send(const char* buffer, size_t len, Error* err) {
   }
   if (!result) {
     char Buffer[128];
-#ifdef _MSC_VER
-    sprintf_s(Buffer, "Send() failed: WSA error=%d\n", WSAGetLastError());
-#else
-    std::snprintf(Buffer, sizeof(Buffer), "Send() failed: WSA error=%d\n",
-                  WSAGetLastError());
-#endif
+    const auto result =
+        fmt::format_to_n(Buffer, sizeof(Buffer) - 1,
+                         "Send() failed: WSA error={}\n", WSAGetLastError());
+    *result.out = '\0';
+
     OutputDebugStringA(Buffer);
     *err = kConnectionReset;
     return 0;

--- a/wpinet/src/main/native/thirdparty/tcpsockets/cpp/TCPStream.cpp
+++ b/wpinet/src/main/native/thirdparty/tcpsockets/cpp/TCPStream.cpp
@@ -36,7 +36,7 @@
 
 #include <cerrno>
 
-#include <fmt/format.h>
+#include <wpi/StringExtras.h>
 
 using namespace wpi;
 
@@ -87,10 +87,8 @@ size_t TCPStream::send(const char* buffer, size_t len, Error* err) {
   }
   if (!result) {
     char Buffer[128];
-    const auto result =
-        fmt::format_to_n(Buffer, sizeof(Buffer) - 1,
-                         "Send() failed: WSA error={}\n", WSAGetLastError());
-    *result.out = '\0';
+    wpi::format_to_n_c_str(Buffer, sizeof(Buffer),
+                           "Send() failed: WSA error={}\n", WSAGetLastError());
 
     OutputDebugStringA(Buffer);
     *err = kConnectionReset;

--- a/wpiutil/build.gradle
+++ b/wpiutil/build.gradle
@@ -91,7 +91,7 @@ ext {
                         include '**/*.cpp'
                     }
                     exportedHeaders {
-                        srcDirs 'src/main/native/include', 'src/main/native/cpp', 'src/main/native/thirdparty/llvm/include', 'src/main/native/thirdparty/sigslot/include', 'src/main/native/thirdparty/mpack/include'
+                        srcDirs 'src/main/native/include', 'src/main/native/cpp', 'src/main/native/thirdparty/llvm/include', 'src/main/native/thirdparty/fmtlib/include', 'src/main/native/thirdparty/sigslot/include', 'src/main/native/thirdparty/mpack/include'
                         include '**/*.h'
                     }
                 }

--- a/wpiutil/src/main/native/thirdparty/llvm/include/wpi/StringExtras.h
+++ b/wpiutil/src/main/native/thirdparty/llvm/include/wpi/StringExtras.h
@@ -17,12 +17,15 @@
 
 #pragma once
 
+#include <iterator>
 #include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>
+
+#include <fmt/format.h>
 
 namespace wpi {
 
@@ -720,5 +723,24 @@ std::optional<long double> parse_float<long double>(
  */
 std::pair<std::string_view, std::string_view> UnescapeCString(
     std::string_view str, SmallVectorImpl<char>& buf);
+
+/**
+ * Like std::format_to_n() in that it writes at most n bytes to the output
+ * buffer, but also includes a terminating null byte in n.
+ *
+ * This is essentially a more performant replacement for std::snprintf().
+ *
+ * @param out The output buffer.
+ * @param n The size of the output buffer.
+ * @param fmt The format string.
+ * @param args The format string arguments.
+ */
+template <class OutputIt, class... Args>
+void format_to_n_c_str(OutputIt out, std::iter_difference_t<OutputIt> n,
+                       fmt::format_string<Args...> fmt, Args&&... args) {
+  const auto result =
+      fmt::format_to_n(out, n - 1, fmt, std::forward<Args>(args)...);
+  *result.out = '\0';
+}
 
 }  // namespace wpi

--- a/wpiutil/src/main/native/thirdparty/llvm/include/wpi/StringExtras.h
+++ b/wpiutil/src/main/native/thirdparty/llvm/include/wpi/StringExtras.h
@@ -736,8 +736,8 @@ std::pair<std::string_view, std::string_view> UnescapeCString(
  * @param args The format string arguments.
  */
 template <class OutputIt, class... Args>
-void format_to_n_c_str(OutputIt out, std::iter_difference_t<OutputIt> n,
-                       fmt::format_string<Args...> fmt, Args&&... args) {
+inline void format_to_n_c_str(OutputIt out, std::iter_difference_t<OutputIt> n,
+                              fmt::format_string<Args...> fmt, Args&&... args) {
   const auto result =
       fmt::format_to_n(out, n - 1, fmt, std::forward<Args>(args)...);
   *result.out = '\0';


### PR DESCRIPTION
fmtlib uses consteval format string processing, which makes it more efficient than std::snprintf().

snprintf()s in libuv, mpack, processstarter, and wpigui were left alone. processstarter uses stdlib only, and wpigui only depends on imgui.

fmt::format_to_n() is analogous to std::format_to_n() (https://en.cppreference.com/w/cpp/utility/format/format_to_n)