### PR TITLE
[wpiutil] SpanExtras: Add take_back and take_front

### DIFF
--- a/wpiutil/src/main/native/include/wpi/SpanExtras.h
+++ b/wpiutil/src/main/native/include/wpi/SpanExtras.h
@@ -10,19 +10,49 @@
 namespace wpi {
 
 /// Drop the first \p N elements of the array.
-template <typename T>
-constexpr std::span<T> drop_front(std::span<T> in,
+template <typename T, size_t N>
+constexpr std::span<T> drop_front(std::span<T, N> in,
                                   typename std::span<T>::size_type n = 1) {
   assert(in.size() >= n && "Dropping more elements than exist");
   return in.subspan(n, in.size() - n);
 }
 
 /// Drop the last \p N elements of the array.
-template <typename T>
-constexpr std::span<T> drop_back(std::span<T> in,
+template <typename T, size_t N>
+constexpr std::span<T> drop_back(std::span<T, N> in,
                                  typename std::span<T>::size_type n = 1) {
   assert(in.size() >= n && "Dropping more elements than exist");
   return in.subspan(0, in.size() - n);
+}
+
+/**
+ * Returns a span equal to @p in but with only the first @p n
+ * elements remaining.  If @p n is greater than the length of the
+ * span, the entire span is returned.
+ */
+template <typename T, size_t N>
+constexpr std::span<T> take_front(std::span<T, N> in,
+                                  typename std::span<T>::size_type n = 1) {
+  auto length = in.size();
+  if (n >= length) {
+    return in;
+  }
+  return drop_back(in, length - n);
+}
+
+/**
+ * Returns a span equal to @p in but with only the last @p n
+ * elements remaining.  If @p n is greater than the length of the
+ * span, the entire span is returned.
+ */
+template <typename T, size_t N>
+constexpr std::span<T> take_back(std::span<T, N> in,
+                                 typename std::span<T>::size_type n = 1) {
+  auto length = in.size();
+  if (n >= length) {
+    return in;
+  }
+  return drop_front(in, length - n);
 }
 
 }  // namespace wpi


### PR DESCRIPTION
Also allow sized spans as input for drop_front and drop_back (return is always dynamic size).