### PR TITLE
[wpinet] uv::Error: Change default error to 0

### DIFF
--- a/wpinet/src/main/native/include/wpinet/uv/Error.h
+++ b/wpinet/src/main/native/include/wpinet/uv/Error.h
@@ -38,7 +38,7 @@ class Error {
   const char* name() const { return uv_err_name(m_err); }
 
  private:
-  int m_err{UV_UNKNOWN};
+  int m_err{0};
 };
 
 }  // namespace wpi::uv


### PR DESCRIPTION
Was previously UV_UNKNOWN, which meant a default-constructed uv::Error was actually an error.