### PR TITLE
[wpinet] uv::Request: Return shared_ptr from Release()

### DIFF
--- a/wpinet/src/main/native/cpp/uv/Stream.cpp
+++ b/wpinet/src/main/native/cpp/uv/Stream.cpp
@@ -97,8 +97,8 @@ void Stream::Write(std::span<const Buffer> bufs,
                if (status < 0) {
                  h.ReportError(status);
                }
+               auto ptr = h.Release();  // one-shot, but finish() may Keep()
                h.finish(Error(status));
-               h.Release();  // this is always a one-shot
              })) {
     req->Keep();
   }

--- a/wpinet/src/main/native/include/wpinet/uv/Request.h
+++ b/wpinet/src/main/native/include/wpinet/uv/Request.h
@@ -9,6 +9,7 @@
 
 #include <functional>
 #include <memory>
+#include <utility>
 
 #include "wpinet/uv/Error.h"
 

--- a/wpinet/src/main/native/include/wpinet/uv/Request.h
+++ b/wpinet/src/main/native/include/wpinet/uv/Request.h
@@ -92,8 +92,12 @@ class Request : public std::enable_shared_from_this<Request> {
    *
    * Derived classes can override this method for different memory management
    * approaches (e.g. pooled storage of requests).
+   *
+   * @return Previous shared pointer
    */
-  virtual void Release() noexcept { m_self.reset(); }
+  virtual std::shared_ptr<Request> Release() noexcept {
+    return std::move(m_self);
+  }
 
   /**
    * Error callback.  By default, this is set up to report errors to the handle


### PR DESCRIPTION
Use this in Stream to allow the finish() callback to reuse the request via calling Keep().