### PR TITLE
[wpilib] Close MotorSafety objects, add tests

### DIFF
--- a/wpilibc/src/test/native/cpp/MotorSafetyTest.cpp
+++ b/wpilibc/src/test/native/cpp/MotorSafetyTest.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "frc/MotorSafety.h"  // NOLINT(build/include_order)
+
+#include <gtest/gtest.h>
+#include "frc/simulation/DriverStationSim.h"
+#include "frc/simulation/SimHooks.h"
+
+using namespace frc;
+
+class MockMotorSafety : public MotorSafety {
+public:
+  MockMotorSafety() {
+    SetSafetyEnabled(true);
+  }
+
+  int counter{0};
+
+  void StopMotor() override {
+    counter++;
+  }
+
+  std::string GetDescription() const override {
+    return "test";
+  }
+};
+
+TEST(MotorSafetyTest, Monitor) {
+  MockMotorSafety motorSafety;
+  frc::sim::DriverStationSim::SetEnabled(true);
+  frc::sim::DriverStationSim::SetAutonomous(false);
+  frc::sim::DriverStationSim::SetTest(false);
+  frc::sim::DriverStationSim::NotifyNewData();
+
+  motorSafety.Feed();
+  EXPECT_TRUE(motorSafety.IsAlive());
+  EXPECT_EQ(0, motorSafety.counter);
+
+  for (int i = 0; i <= 6; i++) {
+    frc::sim::StepTiming(0.02_s);
+    frc::sim::DriverStationSim::NotifyNewData();
+  }
+
+  EXPECT_FALSE(motorSafety.IsAlive());
+  EXPECT_EQ(1, motorSafety.counter);
+}

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/MotorSafety.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/MotorSafety.java
@@ -18,7 +18,7 @@ import java.util.Set;
  *
  * <p>The subclass should call feed() whenever the motor value is updated.
  */
-public abstract class MotorSafety {
+public abstract class MotorSafety implements AutoCloseable {
   private static final double kDefaultSafetyExpiration = 0.1;
 
   private double m_expiration = kDefaultSafetyExpiration;
@@ -188,4 +188,16 @@ public abstract class MotorSafety {
   public abstract void stopMotor();
 
   public abstract String getDescription();
+
+  @Override
+  public void close() {
+    synchronized (m_listMutex) {
+      m_instanceList.remove(this);
+      // If this was the last object, shut down the monitor thread
+      if (m_instanceList.isEmpty()) {
+        m_safetyThread.interrupt();
+        m_safetyThread = null;
+      }
+    }
+  }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Relay.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Relay.java
@@ -128,6 +128,7 @@ public class Relay extends MotorSafety implements Sendable, AutoCloseable {
 
   @Override
   public void close() {
+    super.close();
     SendableRegistry.remove(this);
     freeRelay();
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -142,6 +142,7 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
 
   @Override
   public void close() {
+    super.close();
     SendableRegistry.remove(this);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
@@ -128,6 +128,7 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
 
   @Override
   public void close() {
+    super.close();
     SendableRegistry.remove(this);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/NidecBrushless.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/NidecBrushless.java
@@ -49,6 +49,7 @@ public class NidecBrushless extends MotorSafety
 
   @Override
   public void close() {
+    super.close();
     SendableRegistry.remove(this);
     m_dio.close();
     m_pwm.close();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/PWMMotorController.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/PWMMotorController.java
@@ -31,6 +31,7 @@ public abstract class PWMMotorController extends MotorSafety
   /** Free the resource associated with the PWM channel and set the value to 0. */
   @Override
   public void close() {
+    super.close();
     SendableRegistry.remove(this);
     m_pwm.close();
   }

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/MotorSafetyTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/MotorSafetyTest.java
@@ -1,0 +1,86 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package edu.wpi.first.wpilibj;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.simulation.DriverStationSim;
+import edu.wpi.first.wpilibj.simulation.SimHooks;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ResourceLock("timing")
+class MotorSafetyTest {
+  AtomicInteger m_counter;
+  MotorSafety m_motorSafety;
+
+  @BeforeEach
+  void setUp() {
+    HAL.initialize(500, 0);
+    m_counter = new AtomicInteger();
+    m_motorSafety = new MotorSafety() {
+      {
+        this.setSafetyEnabled(true);
+      }
+      @Override
+      public void stopMotor() {
+        m_counter.incrementAndGet();
+      }
+
+      @Override
+      public String getDescription() {
+        return "test";
+      }
+    };
+  }
+
+  @AfterEach
+  void tearDown() {
+    m_motorSafety.close();
+    m_motorSafety = null;
+    m_counter = null;
+  }
+
+  @Test
+  void monitorTest() {
+    DriverStationSim.setEnabled(true);
+    DriverStationSim.setAutonomous(false);
+    DriverStationSim.setTest(false);
+    DriverStationSim.notifyNewData();
+
+    m_motorSafety.feed();
+    assertTrue(m_motorSafety.isAlive());
+    assertEquals(0, m_counter.get());
+
+    for (int i = 0; i <= 6; i++) {
+      SimHooks.stepTiming(0.02);
+      DriverStationSim.notifyNewData();
+    }
+
+    forceContextSwitch();
+    assertFalse(m_motorSafety.isAlive());
+    assertEquals(1, m_counter.get());
+  }
+
+  /**
+   * Sometimes during tests the assertions occur before a context switch to the MotorSafety thread,
+   * so this forces the context switch.
+   *
+   * <p>Outside of unit tests, this shouldn't be a problem.
+   */
+  private static void forceContextSwitch() {
+    try {
+      Thread.sleep(10);
+    } catch (InterruptedException e) {
+      fail(e);
+    }
+  }
+}
+


### PR DESCRIPTION
C++ handled removing MotorSafety objects via virtual dtors; this PR does the same for Java.
Also, add tests (closes #1692).
