### PR TITLE
[json] Add forward definition header

### DIFF
--- a/apriltag/src/main/native/include/frc/apriltag/AprilTag.h
+++ b/apriltag/src/main/native/include/frc/apriltag/AprilTag.h
@@ -5,12 +5,9 @@
 #pragma once
 
 #include <wpi/SymbolExports.h>
+#include <wpi/json_fwd.h>
 
 #include "frc/geometry/Pose3d.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace frc {
 

--- a/apriltag/src/main/native/include/frc/apriltag/AprilTagFieldLayout.h
+++ b/apriltag/src/main/native/include/frc/apriltag/AprilTagFieldLayout.h
@@ -11,13 +11,10 @@
 
 #include <units/length.h>
 #include <wpi/SymbolExports.h>
+#include <wpi/json_fwd.h>
 
 #include "frc/apriltag/AprilTag.h"
 #include "frc/geometry/Pose3d.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace frc {
 /**

--- a/cscore/src/main/native/cpp/PropertyContainer.h
+++ b/cscore/src/main/native/cpp/PropertyContainer.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include <wpi/StringMap.h>
+#include <wpi/json_fwd.h>
 #include <wpi/mutex.h>
 
 #include "PropertyImpl.h"
@@ -23,7 +24,6 @@ namespace wpi {
 class Logger;
 template <typename T>
 class SmallVectorImpl;
-class json;
 }  // namespace wpi
 
 namespace cs {

--- a/cscore/src/main/native/cpp/SinkImpl.h
+++ b/cscore/src/main/native/cpp/SinkImpl.h
@@ -10,13 +10,10 @@
 #include <string_view>
 
 #include <wpi/Logger.h>
+#include <wpi/json_fwd.h>
 #include <wpi/mutex.h>
 
 #include "SourceImpl.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace cs {
 

--- a/cscore/src/main/native/cpp/SourceImpl.h
+++ b/cscore/src/main/native/cpp/SourceImpl.h
@@ -14,6 +14,7 @@
 
 #include <wpi/Logger.h>
 #include <wpi/condition_variable.h>
+#include <wpi/json_fwd.h>
 #include <wpi/mutex.h>
 
 #include "Frame.h"
@@ -21,10 +22,6 @@
 #include "Image.h"
 #include "PropertyContainer.h"
 #include "cscore_cpp.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace cs {
 

--- a/cscore/src/main/native/include/cscore_cpp.h
+++ b/cscore/src/main/native/include/cscore_cpp.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include <wpi/SmallVector.h>
+#include <wpi/json_fwd.h>
 
 #include "cscore_c.h"
 
@@ -22,10 +23,6 @@
 #pragma warning(push)
 #pragma warning(disable : 26495)
 #endif
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 /** CameraServer (cscore) namespace */
 namespace cs {

--- a/glass/src/lib/native/include/glass/Storage.h
+++ b/glass/src/lib/native/include/glass/Storage.h
@@ -16,10 +16,7 @@
 
 #include <wpi/StringMap.h>
 #include <wpi/iterator_range.h>
-
-namespace wpi {
-class json;
-}  // namespace wpi
+#include <wpi/json_fwd.h>
 
 namespace glass {
 

--- a/ntcore/src/generate/include/networktables/Topic.h.jinja
+++ b/ntcore/src/generate/include/networktables/Topic.h.jinja
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <wpi/json_fwd.h>
+
 #include "networktables/Topic.h"
 
 namespace wpi {

--- a/ntcore/src/generate/include/networktables/Topic.h.jinja
+++ b/ntcore/src/generate/include/networktables/Topic.h.jinja
@@ -11,12 +11,12 @@
 #include <string_view>
 #include <vector>
 
+#include <wpi/json_fwd.h>
 #include "networktables/Topic.h"
 
 namespace wpi {
 template <typename T>
 class SmallVectorImpl;
-class json;
 }  // namespace wpi
 
 namespace nt {

--- a/ntcore/src/main/native/cpp/net/NetworkInterface.h
+++ b/ntcore/src/main/native/cpp/net/NetworkInterface.h
@@ -8,11 +8,9 @@
 #include <string>
 #include <string_view>
 
-#include "ntcore_cpp.h"
+#include <wpi/json_fwd.h>
 
-namespace wpi {
-class json;
-}  // namespace wpi
+#include "ntcore_cpp.h"
 
 namespace nt {
 class PubSubOptionsImpl;

--- a/ntcore/src/main/native/cpp/net/WireDecoder.h
+++ b/ntcore/src/main/native/cpp/net/WireDecoder.h
@@ -11,9 +11,10 @@
 #include <string>
 #include <string_view>
 
+#include <wpi/json_fwd.h>
+
 namespace wpi {
 class Logger;
-class json;
 }  // namespace wpi
 
 namespace nt {

--- a/ntcore/src/main/native/cpp/net/WireEncoder.h
+++ b/ntcore/src/main/native/cpp/net/WireEncoder.h
@@ -9,8 +9,9 @@
 #include <string>
 #include <string_view>
 
+#include <wpi/json_fwd.h>
+
 namespace wpi {
-class json;
 class raw_ostream;
 }  // namespace wpi
 

--- a/ntcore/src/main/native/include/networktables/Topic.h
+++ b/ntcore/src/main/native/include/networktables/Topic.h
@@ -11,13 +11,11 @@
 #include <utility>
 #include <vector>
 
+#include <wpi/json_fwd.h>
+
 #include "networktables/NetworkTableType.h"
 #include "ntcore_c.h"
 #include "ntcore_cpp.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace nt {
 

--- a/ntcore/src/main/native/include/networktables/UnitTopic.h
+++ b/ntcore/src/main/native/include/networktables/UnitTopic.h
@@ -10,12 +10,10 @@
 #include <string_view>
 #include <vector>
 
+#include <wpi/json_fwd.h>
+
 #include "networktables/Topic.h"
 #include "ntcore_cpp.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace nt {
 

--- a/ntcore/src/main/native/include/ntcore_cpp.h
+++ b/ntcore/src/main/native/include/ntcore_cpp.h
@@ -17,6 +17,8 @@
 #include <variant>
 #include <vector>
 
+#include <wpi/json_fwd.h>
+
 #include "networktables/NetworkTableValue.h"
 #include "ntcore_c.h"
 #include "ntcore_cpp_types.h"
@@ -24,7 +26,6 @@
 namespace wpi {
 template <typename T>
 class SmallVectorImpl;
-class json;
 }  // namespace wpi
 
 namespace wpi::log {

--- a/simulation/halsim_ws_client/src/main/native/include/HALSimWS.h
+++ b/simulation/halsim_ws_client/src/main/native/include/HALSimWS.h
@@ -12,14 +12,11 @@
 #include <WSProviderContainer.h>
 #include <WSProvider_SimDevice.h>
 #include <wpi/StringMap.h>
+#include <wpi/json_fwd.h>
 #include <wpinet/uv/Async.h>
 #include <wpinet/uv/Loop.h>
 #include <wpinet/uv/Tcp.h>
 #include <wpinet/uv/Timer.h>
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace wpilibws {
 

--- a/simulation/halsim_ws_client/src/main/native/include/HALSimWSClientConnection.h
+++ b/simulation/halsim_ws_client/src/main/native/include/HALSimWSClientConnection.h
@@ -8,16 +8,13 @@
 #include <utility>
 
 #include <HALSimBaseWebSocketConnection.h>
+#include <wpi/json_fwd.h>
 #include <wpi/mutex.h>
 #include <wpinet/WebSocket.h>
 #include <wpinet/uv/Buffer.h>
 #include <wpinet/uv/Stream.h>
 
 #include "HALSimWS.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace wpilibws {
 

--- a/simulation/halsim_ws_core/src/main/native/include/HALSimBaseWebSocketConnection.h
+++ b/simulation/halsim_ws_core/src/main/native/include/HALSimBaseWebSocketConnection.h
@@ -6,7 +6,7 @@
 
 #include <memory>
 
-#include <wpi/json.h>
+#include <wpi/json_fwd.h>
 
 namespace wpilibws {
 

--- a/simulation/halsim_ws_core/src/main/native/include/WSHalProviders.h
+++ b/simulation/halsim_ws_core/src/main/native/include/WSHalProviders.h
@@ -10,7 +10,7 @@
 #include <string_view>
 
 #include <hal/simulation/NotifyListener.h>
-#include <wpi/json.h>
+#include <wpi/json_fwd.h>
 #include <wpi/mutex.h>
 
 #include "WSBaseProvider.h"

--- a/simulation/halsim_ws_server/src/main/native/include/HALSimHttpConnection.h
+++ b/simulation/halsim_ws_server/src/main/native/include/HALSimHttpConnection.h
@@ -10,16 +10,13 @@
 #include <utility>
 
 #include <HALSimBaseWebSocketConnection.h>
+#include <wpi/json_fwd.h>
 #include <wpi/mutex.h>
 #include <wpinet/HttpWebSocketServerConnection.h>
 #include <wpinet/uv/AsyncFunction.h>
 #include <wpinet/uv/Buffer.h>
 
 #include "HALSimWeb.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace wpilibws {
 

--- a/simulation/halsim_ws_server/src/main/native/include/HALSimWeb.h
+++ b/simulation/halsim_ws_server/src/main/native/include/HALSimWeb.h
@@ -13,13 +13,10 @@
 #include <WSProviderContainer.h>
 #include <WSProvider_SimDevice.h>
 #include <wpi/StringMap.h>
+#include <wpi/json_fwd.h>
 #include <wpinet/uv/Async.h>
 #include <wpinet/uv/Loop.h>
 #include <wpinet/uv/Tcp.h>
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace wpilibws {
 

--- a/simulation/halsim_xrp/src/main/native/cpp/XRP.cpp
+++ b/simulation/halsim_xrp/src/main/native/cpp/XRP.cpp
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 #include <wpi/Endian.h>
 #include <wpi/MathExtras.h>
+#include <wpi/json.h>
 
 using namespace wpilibxrp;
 

--- a/simulation/halsim_xrp/src/main/native/include/HALSimXRP.h
+++ b/simulation/halsim_xrp/src/main/native/include/HALSimXRP.h
@@ -12,6 +12,7 @@
 #include <HALSimBaseWebSocketConnection.h>
 #include <WSProviderContainer.h>
 #include <WSProvider_SimDevice.h>
+#include <wpi/json_fwd.h>
 #include <wpinet/uv/Async.h>
 #include <wpinet/uv/Buffer.h>
 #include <wpinet/uv/Loop.h>
@@ -19,10 +20,6 @@
 #include <wpinet/uv/Udp.h>
 
 #include "XRP.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace wpilibxrp {
 

--- a/simulation/halsim_xrp/src/main/native/include/XRP.h
+++ b/simulation/halsim_xrp/src/main/native/include/XRP.h
@@ -9,7 +9,7 @@
 #include <span>
 #include <string>
 
-#include <wpi/json.h>
+#include <wpi/json_fwd.h>
 #include <wpinet/raw_uv_ostream.h>
 
 #define XRP_TAG_MOTOR 0x12

--- a/wpimath/src/main/native/include/frc/geometry/Pose2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Pose2d.h
@@ -8,14 +8,11 @@
 #include <span>
 
 #include <wpi/SymbolExports.h>
+#include <wpi/json_fwd.h>
 
 #include "frc/geometry/Transform2d.h"
 #include "frc/geometry/Translation2d.h"
 #include "frc/geometry/Twist2d.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace frc {
 

--- a/wpimath/src/main/native/include/frc/geometry/Pose3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Pose3d.h
@@ -5,15 +5,12 @@
 #pragma once
 
 #include <wpi/SymbolExports.h>
+#include <wpi/json_fwd.h>
 
 #include "frc/geometry/Pose2d.h"
 #include "frc/geometry/Transform3d.h"
 #include "frc/geometry/Translation3d.h"
 #include "frc/geometry/Twist3d.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace frc {
 

--- a/wpimath/src/main/native/include/frc/geometry/Quaternion.h
+++ b/wpimath/src/main/native/include/frc/geometry/Quaternion.h
@@ -6,10 +6,7 @@
 
 #include <Eigen/Core>
 #include <wpi/SymbolExports.h>
-
-namespace wpi {
-class json;
-}  // namespace wpi
+#include <wpi/json_fwd.h>
 
 namespace frc {
 

--- a/wpimath/src/main/native/include/frc/geometry/Rotation2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Rotation2d.h
@@ -5,12 +5,9 @@
 #pragma once
 
 #include <wpi/SymbolExports.h>
+#include <wpi/json_fwd.h>
 
 #include "units/angle.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace frc {
 

--- a/wpimath/src/main/native/include/frc/geometry/Rotation3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Rotation3d.h
@@ -6,14 +6,11 @@
 
 #include <Eigen/Core>
 #include <wpi/SymbolExports.h>
+#include <wpi/json_fwd.h>
 
 #include "frc/geometry/Quaternion.h"
 #include "frc/geometry/Rotation2d.h"
 #include "units/angle.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace frc {
 

--- a/wpimath/src/main/native/include/frc/geometry/Translation2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Translation2d.h
@@ -8,13 +8,10 @@
 #include <span>
 
 #include <wpi/SymbolExports.h>
+#include <wpi/json_fwd.h>
 
 #include "frc/geometry/Rotation2d.h"
 #include "units/length.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace frc {
 

--- a/wpimath/src/main/native/include/frc/geometry/Translation3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Translation3d.h
@@ -5,14 +5,11 @@
 #pragma once
 
 #include <wpi/SymbolExports.h>
+#include <wpi/json_fwd.h>
 
 #include "frc/geometry/Rotation3d.h"
 #include "frc/geometry/Translation2d.h"
 #include "units/length.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace frc {
 

--- a/wpimath/src/main/native/include/frc/trajectory/Trajectory.h
+++ b/wpimath/src/main/native/include/frc/trajectory/Trajectory.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include <wpi/SymbolExports.h>
+#include <wpi/json_fwd.h>
 
 #include "frc/geometry/Pose2d.h"
 #include "frc/geometry/Transform2d.h"
@@ -14,10 +15,6 @@
 #include "units/curvature.h"
 #include "units/time.h"
 #include "units/velocity.h"
-
-namespace wpi {
-class json;
-}  // namespace wpi
 
 namespace frc {
 /**

--- a/wpiutil/src/main/native/thirdparty/json/include/wpi/json_fwd.h
+++ b/wpiutil/src/main/native/thirdparty/json/include/wpi/json_fwd.h
@@ -1,0 +1,5 @@
+
+
+namespace wpi {
+class json;
+}  // namespace wpi

--- a/wpiutil/src/main/native/thirdparty/json/include/wpi/json_fwd.h
+++ b/wpiutil/src/main/native/thirdparty/json/include/wpi/json_fwd.h
@@ -1,4 +1,8 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
 
+#pragma once
 
 namespace wpi {
 class json;


### PR DESCRIPTION
If I knew you were just going to blow away all of the custom json patches, I could have landed the updates a long time ago 😄 

This is a small prep PR to isolate the forward definition changes required for the json update. Once I saw you were blowing away all the patches in #5622 I quickly whipped up my own version that addresses [this](https://github.com/wpilibsuite/allwpilib/pull/5622#discussion_r1320997676) comment.

While #5675 goes through the landing process I think you land this as well, and then from there I can update the input / output adapter as necessary to minimize the allocations for all those json marshals, and to keep the actual "updating json" changes to the bare minimum for review.