### PR TITLE
[build] Clean up Gradle configs

### DIFF
--- a/cscore/build.gradle
+++ b/cscore/build.gradle
@@ -219,13 +219,9 @@ model {
                                 nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
                             }
                         }
-                        sources {
-                            cpp {
-                                source {
-                                    srcDirs 'examples/' + "${key}"
-                                    include '**/*.cpp'
-                                }
-                            }
+                        sources.cpp.source {
+                            srcDirs 'examples/' + "${key}"
+                            include '**/*.cpp'
                         }
                     }
                 }
@@ -240,13 +236,9 @@ model {
                             nativeUtils.useRequiredLibrary(it, 'ni_link_libraries', 'ni_runtime_libraries')
                         }
                     }
-                    sources {
-                        cpp {
-                            source {
-                                srcDirs 'examples/' + "${key}"
-                                include '**/*.cpp'
-                            }
-                        }
+                    sources.cpp.source {
+                        srcDirs 'examples/' + "${key}"
+                        include '**/*.cpp'
                     }
                 }
             }

--- a/datalogtool/build.gradle
+++ b/datalogtool/build.gradle
@@ -1,126 +1,123 @@
 import org.gradle.internal.os.OperatingSystem
 
-if (!project.hasProperty('onlylinuxathena')) {
-
-    description = "roboRIO Team Number Setter"
-
-    apply plugin: 'cpp'
-    apply plugin: 'c'
-    apply plugin: 'google-test-test-suite'
-    apply plugin: 'visual-studio'
-    apply plugin: 'edu.wpi.first.NativeUtils'
-
-    if (OperatingSystem.current().isWindows()) {
-        apply plugin: 'windows-resources'
-    }
-
-    ext {
-        nativeName = 'datalogtool'
-    }
-
-    apply from: "${rootDir}/shared/resources.gradle"
-    apply from: "${rootDir}/shared/config.gradle"
-
-    def wpilibVersionFileInput = file("src/main/generate/WPILibVersion.cpp.in")
-    def wpilibVersionFileOutput = file("$buildDir/generated/main/cpp/WPILibVersion.cpp")
-
-    apply from: "${rootDir}/shared/libssh.gradle"
-    apply from: "${rootDir}/shared/imgui.gradle"
-
-    task generateCppVersion() {
-        description = 'Generates the wpilib version class'
-        group = 'WPILib'
-
-        outputs.file wpilibVersionFileOutput
-        inputs.file wpilibVersionFileInput
-
-        if (wpilibVersioning.releaseMode) {
-            outputs.upToDateWhen { false }
-        }
-
-        // We follow a simple set of checks to determine whether we should generate a new version file:
-        // 1. If the release type is not development, we generate a new version file
-        // 2. If there is no generated version number, we generate a new version file
-        // 3. If there is a generated build number, and the release type is development, then we will
-        //    only generate if the publish task is run.
-        doLast {
-            def version = wpilibVersioning.version.get()
-            println "Writing version ${version} to $wpilibVersionFileOutput"
-
-            if (wpilibVersionFileOutput.exists()) {
-                wpilibVersionFileOutput.delete()
-            }
-            def read = wpilibVersionFileInput.text.replace('${wpilib_version}', version)
-            wpilibVersionFileOutput.write(read)
-        }
-    }
-
-    gradle.taskGraph.addTaskExecutionGraphListener { graph ->
-        def willPublish = graph.hasTask(publish)
-        if (willPublish) {
-            generateCppVersion.outputs.upToDateWhen { false }
-        }
-    }
-
-    def generateTask = createGenerateResourcesTask('main', 'DLT', 'dlt', project)
-
-    project(':').libraryBuild.dependsOn build
-    tasks.withType(CppCompile) {
-        dependsOn generateTask
-        dependsOn generateCppVersion
-    }
-
-    model {
-        components {
-            // By default, a development executable will be generated. This is to help the case of
-            // testing specific functionality of the library.
-            "${nativeName}"(NativeExecutableSpec) {
-                baseName = 'datalogtool'
-                sources {
-                    cpp {
-                        source {
-                            srcDirs 'src/main/native/cpp', "$buildDir/generated/main/cpp"
-                            include '**/*.cpp'
-                        }
-                        exportedHeaders {
-                            srcDirs 'src/main/native/include'
-                        }
-                    }
-                    if (OperatingSystem.current().isWindows()) {
-                        rc {
-                            source {
-                                srcDirs 'src/main/native/win'
-                                include '*.rc'
-                            }
-                        }
-                    }
-                }
-                binaries.all {
-                    if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        it.buildable = false
-                        return
-                    }
-                    it.cppCompiler.define("LIBSSH_STATIC")
-                    lib project: ':glass', library: 'glass', linkage: 'static'
-                    lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
-                    lib project: ':wpigui', library: 'wpigui', linkage: 'static'
-                    nativeUtils.useRequiredLibrary(it, 'imgui', 'libssh')
-                    if (it.targetPlatform.operatingSystem.isWindows()) {
-                        it.linker.args << 'Gdi32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'
-                        it.linker.args << 'ws2_32.lib' << 'advapi32.lib' << 'crypt32.lib' << 'user32.lib'
-                    } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
-                        it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
-                        it.linker.args << '-framework' << 'Kerberos'
-                    } else {
-                        it.linker.args << '-lX11'
-                        if (it.targetPlatform.name.startsWith('linuxarm')) {
-                            it.linker.args << '-lGL'
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    apply from: 'publish.gradle'
+if (project.hasProperty('onlylinuxathena')) {
+    return;
 }
+
+description = "roboRIO Team Number Setter"
+
+apply plugin: 'cpp'
+apply plugin: 'visual-studio'
+apply plugin: 'edu.wpi.first.NativeUtils'
+
+if (OperatingSystem.current().isWindows()) {
+    apply plugin: 'windows-resources'
+}
+
+ext {
+    nativeName = 'datalogtool'
+}
+
+apply from: "${rootDir}/shared/resources.gradle"
+apply from: "${rootDir}/shared/config.gradle"
+
+def wpilibVersionFileInput = file("src/main/generate/WPILibVersion.cpp.in")
+def wpilibVersionFileOutput = file("$buildDir/generated/main/cpp/WPILibVersion.cpp")
+
+apply from: "${rootDir}/shared/libssh.gradle"
+apply from: "${rootDir}/shared/imgui.gradle"
+
+task generateCppVersion() {
+    description = 'Generates the wpilib version class'
+    group = 'WPILib'
+
+    outputs.file wpilibVersionFileOutput
+    inputs.file wpilibVersionFileInput
+
+    if (wpilibVersioning.releaseMode) {
+        outputs.upToDateWhen { false }
+    }
+
+    // We follow a simple set of checks to determine whether we should generate a new version file:
+    // 1. If the release type is not development, we generate a new version file
+    // 2. If there is no generated version number, we generate a new version file
+    // 3. If there is a generated build number, and the release type is development, then we will
+    //    only generate if the publish task is run.
+    doLast {
+        def version = wpilibVersioning.version.get()
+        println "Writing version ${version} to $wpilibVersionFileOutput"
+
+        if (wpilibVersionFileOutput.exists()) {
+            wpilibVersionFileOutput.delete()
+        }
+        def read = wpilibVersionFileInput.text.replace('${wpilib_version}', version)
+        wpilibVersionFileOutput.write(read)
+    }
+}
+
+gradle.taskGraph.addTaskExecutionGraphListener { graph ->
+    def willPublish = graph.hasTask(publish)
+    if (willPublish) {
+        generateCppVersion.outputs.upToDateWhen { false }
+    }
+}
+
+def generateTask = createGenerateResourcesTask('main', 'DLT', 'dlt', project)
+
+project(':').libraryBuild.dependsOn build
+tasks.withType(CppCompile) {
+    dependsOn generateTask
+    dependsOn generateCppVersion
+}
+
+model {
+    components {
+        // By default, a development executable will be generated. This is to help the case of
+        // testing specific functionality of the library.
+        "${nativeName}"(NativeExecutableSpec) {
+            baseName = 'datalogtool'
+            sources {
+                cpp {
+                    source {
+                        srcDirs 'src/main/native/cpp', "$buildDir/generated/main/cpp"
+                        include '**/*.cpp'
+                    }
+                    exportedHeaders {
+                        srcDirs 'src/main/native/include'
+                    }
+                }
+                if (OperatingSystem.current().isWindows()) {
+                    rc.source {
+                        srcDirs 'src/main/native/win'
+                        include '*.rc'
+                    }
+                }
+            }
+            binaries.all {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                    it.buildable = false
+                    return
+                }
+                it.cppCompiler.define("LIBSSH_STATIC")
+                lib project: ':glass', library: 'glass', linkage: 'static'
+                lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
+                lib project: ':wpigui', library: 'wpigui', linkage: 'static'
+                nativeUtils.useRequiredLibrary(it, 'imgui', 'libssh')
+                if (it.targetPlatform.operatingSystem.isWindows()) {
+                    it.linker.args << 'Gdi32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'
+                    it.linker.args << 'ws2_32.lib' << 'advapi32.lib' << 'crypt32.lib' << 'user32.lib'
+                } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
+                    it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
+                    it.linker.args << '-framework' << 'Kerberos'
+                } else {
+                    it.linker.args << '-lX11'
+                    if (it.targetPlatform.name.startsWith('linuxarm')) {
+                        it.linker.args << '-lGL'
+                    }
+                }
+            }
+        }
+    }
+}
+
+apply from: 'publish.gradle'

--- a/fieldImages/build.gradle
+++ b/fieldImages/build.gradle
@@ -1,76 +1,69 @@
 import org.gradle.internal.os.OperatingSystem
 
-if (!project.hasProperty('onlylinuxathena')) {
+if (project.hasProperty('onlylinuxathena')) {
+    return;
+}
 
-    apply plugin: 'cpp'
-    apply plugin: 'c'
-    apply plugin: 'java'
-    apply plugin: 'google-test-test-suite'
-    apply plugin: 'visual-studio'
-    apply plugin: 'edu.wpi.first.NativeUtils'
+apply plugin: 'cpp'
+apply plugin: 'java'
+apply plugin: 'visual-studio'
+apply plugin: 'edu.wpi.first.NativeUtils'
 
-    if (OperatingSystem.current().isWindows()) {
-        apply plugin: 'windows-resources'
-    }
+if (OperatingSystem.current().isWindows()) {
+    apply plugin: 'windows-resources'
+}
 
-    dependencies {
-        implementation "com.fasterxml.jackson.core:jackson-annotations:2.15.2"
-        implementation "com.fasterxml.jackson.core:jackson-core:2.15.2"
-        implementation "com.fasterxml.jackson.core:jackson-databind:2.15.2"
-    }
+dependencies {
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.15.2"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.15.2"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.15.2"
+}
 
-    ext {
-        nativeName = 'fieldImages'
-        baseId = nativeName
-        groupId = 'edu.wpi.first.fieldImages'
-        devMain = "edu.wpi.first.fieldImages.DevMain"
-    }
+ext {
+    nativeName = 'fieldImages'
+    baseId = nativeName
+    groupId = 'edu.wpi.first.fieldImages'
+    devMain = "edu.wpi.first.fieldImages.DevMain"
+}
 
-    apply from: "${rootDir}/shared/resources.gradle"
-    apply from: "${rootDir}/shared/config.gradle"
-    apply from: "${rootDir}/shared/java/javacommon.gradle"
+apply from: "${rootDir}/shared/resources.gradle"
+apply from: "${rootDir}/shared/config.gradle"
+apply from: "${rootDir}/shared/java/javacommon.gradle"
 
-    def generateTask = createGenerateResourcesTask('main', 'FIELDS', 'fields', project)
+def generateTask = createGenerateResourcesTask('main', 'FIELDS', 'fields', project)
 
-    project(':').libraryBuild.dependsOn build
-    tasks.withType(CppCompile) {
-        dependsOn generateTask
-    }
+project(':').libraryBuild.dependsOn build
+tasks.withType(CppCompile) {
+    dependsOn generateTask
+}
 
-    sourceSets {
-        main {
-            resources {
-                srcDirs 'src/main/native/resources'
-            }
-        }
-    }
+sourceSets.main.resources {
+    srcDirs 'src/main/native/resources'
+}
 
-    model {
-        components {
-            "${nativeName}"(NativeLibrarySpec) {
-                baseName = 'fieldImages'
-                sources {
-                    cpp {
-                        source {
-                            srcDirs 'src/main/native/cpp', "$buildDir/generated/main/cpp"
-                            include '**/*.cpp'
-                        }
-                        exportedHeaders {
-                            srcDirs 'src/main/native/include'
-                        }
+model {
+    components {
+        "${nativeName}"(NativeLibrarySpec) {
+            baseName = 'fieldImages'
+            sources {
+                cpp {
+                    source {
+                        srcDirs 'src/main/native/cpp', "$buildDir/generated/main/cpp"
+                        include '**/*.cpp'
                     }
-                    if (OperatingSystem.current().isWindows()) {
-                        rc {
-                            source {
-                                srcDirs 'src/main/native/win'
-                                include '*.rc'
-                            }
-                        }
+                    exportedHeaders {
+                        srcDirs 'src/main/native/include'
+                    }
+                }
+                if (OperatingSystem.current().isWindows()) {
+                    rc.source {
+                        srcDirs 'src/main/native/win'
+                        include '*.rc'
                     }
                 }
             }
         }
     }
-
-    apply from: 'publish.gradle'
 }
+
+apply from: 'publish.gradle'

--- a/glass/build.gradle
+++ b/glass/build.gradle
@@ -1,208 +1,201 @@
 import org.gradle.internal.os.OperatingSystem
 
-if (!project.hasProperty('onlylinuxathena')) {
-
-    description = "A different kind of dashboard"
-
-    apply plugin: 'cpp'
-    apply plugin: 'c'
-    apply plugin: 'google-test-test-suite'
-    apply plugin: 'visual-studio'
-    apply plugin: 'edu.wpi.first.NativeUtils'
-
-    if (OperatingSystem.current().isWindows()) {
-        apply plugin: 'windows-resources'
-    }
-
-    ext {
-        nativeName = 'glass'
-    }
-
-    apply from: "${rootDir}/shared/resources.gradle"
-    apply from: "${rootDir}/shared/config.gradle"
-
-    def wpilibVersionFileInput = file("src/app/generate/WPILibVersion.cpp.in")
-    def wpilibVersionFileOutput = file("$buildDir/generated/app/cpp/WPILibVersion.cpp")
-
-    apply from: "${rootDir}/shared/imgui.gradle"
-
-    task generateCppVersion() {
-        description = 'Generates the wpilib version class'
-        group = 'WPILib'
-
-        outputs.file wpilibVersionFileOutput
-        inputs.file wpilibVersionFileInput
-
-        if (wpilibVersioning.releaseMode) {
-            outputs.upToDateWhen { false }
-        }
-
-        // We follow a simple set of checks to determine whether we should generate a new version file:
-        // 1. If the release type is not development, we generate a new version file
-        // 2. If there is no generated version number, we generate a new version file
-        // 3. If there is a generated build number, and the release type is development, then we will
-        //    only generate if the publish task is run.
-        doLast {
-            def version = wpilibVersioning.version.get()
-            println "Writing version ${version} to $wpilibVersionFileOutput"
-
-            if (wpilibVersionFileOutput.exists()) {
-                wpilibVersionFileOutput.delete()
-            }
-            def read = wpilibVersionFileInput.text.replace('${wpilib_version}', version)
-            wpilibVersionFileOutput.write(read)
-        }
-    }
-
-    gradle.taskGraph.addTaskExecutionGraphListener { graph ->
-        def willPublish = graph.hasTask(publish)
-        if (willPublish) {
-            generateCppVersion.outputs.upToDateWhen { false }
-        }
-    }
-
-    def generateTask = createGenerateResourcesTask('app', 'GLASS', 'glass', project)
-
-    project(':').libraryBuild.dependsOn build
-    tasks.withType(CppCompile) {
-        dependsOn generateTask
-        dependsOn generateCppVersion
-    }
-
-    nativeUtils.exportsConfigs {
-        glass {
-            x64ExcludeSymbols = [
-                '_CT??_R0?AV_System_error',
-                '_CT??_R0?AVexception',
-                '_CT??_R0?AVfailure',
-                '_CT??_R0?AVruntime_error',
-                '_CT??_R0?AVsystem_error',
-                '_CTA5?AVfailure',
-                '_TI5?AVfailure',
-                '_CT??_R0?AVout_of_range',
-                '_CTA3?AVout_of_range',
-                '_TI3?AVout_of_range',
-                '_CT??_R0?AVbad_cast'
-            ]
-        }
-    }
-
-    model {
-        components {
-            "${nativeName}"(NativeLibrarySpec) {
-                sources {
-                    cpp {
-                        source {
-                            srcDirs 'src/lib/native/cpp'
-                            include '**/*.cpp'
-                        }
-                        exportedHeaders {
-                            srcDirs 'src/lib/native/include'
-                        }
-                    }
-                }
-                binaries.all {
-                    if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        it.buildable = false
-                        return
-                    }
-                    if (it instanceof SharedLibraryBinarySpec) {
-                        it.buildable = false
-                        return
-                    }
-                    lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-                    lib project: ':wpimath', library: 'wpimath', linkage: 'shared'
-                    lib project: ':wpigui', library: 'wpigui', linkage: 'static'
-                    lib project: ':fieldImages', library: 'fieldImages', linkage: 'shared'
-                    nativeUtils.useRequiredLibrary(it, 'imgui')
-                }
-                appendDebugPathToBinaries(binaries)
-            }
-            "${nativeName}nt"(NativeLibrarySpec) {
-                sources {
-                    cpp {
-                        source {
-                            srcDirs = ['src/libnt/native/cpp']
-                            include '**/*.cpp'
-                        }
-                        exportedHeaders {
-                            srcDirs 'src/libnt/native/include'
-                        }
-                    }
-                }
-                binaries.all {
-                    if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        it.buildable = false
-                        return
-                    }
-                    if (it instanceof SharedLibraryBinarySpec) {
-                        it.buildable = false
-                        return
-                    }
-                    lib library: nativeName, linkage: 'static'
-                    project(':ntcore').addNtcoreDependency(it, 'shared')
-                    lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
-                    lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-                    lib project: ':wpimath', library: 'wpimath', linkage: 'shared'
-                    lib project: ':wpigui', library: 'wpigui', linkage: 'static'
-                    lib project: ':fieldImages', library: 'fieldImages', linkage: 'shared'
-                    nativeUtils.useRequiredLibrary(it, 'imgui')
-                }
-                appendDebugPathToBinaries(binaries)
-            }
-            // By default, a development executable will be generated. This is to help the case of
-            // testing specific functionality of the library.
-            "${nativeName}App"(NativeExecutableSpec) {
-                baseName = 'glass'
-                sources {
-                    cpp {
-                        source {
-                            srcDirs 'src/app/native/cpp', "$buildDir/generated/app/cpp"
-                            include '**/*.cpp'
-                        }
-                        exportedHeaders {
-                            srcDirs 'src/app/native/include'
-                        }
-                    }
-                    if (OperatingSystem.current().isWindows()) {
-                        rc {
-                            source {
-                                srcDirs 'src/app/native/win'
-                            }
-                        }
-                    }
-                }
-                binaries.all {
-                    if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        it.buildable = false
-                        return
-                    }
-                    lib project: ':cscore', library: 'cscore', linkage: 'static'
-                    lib library: 'glassnt', linkage: 'static'
-                    lib library: nativeName, linkage: 'static'
-                    project(':ntcore').addNtcoreDependency(it, 'static')
-                    lib project: ':wpinet', library: 'wpinet', linkage: 'static'
-                    lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
-                    lib project: ':wpimath', library: 'wpimath', linkage: 'static'
-                    lib project: ':wpigui', library: 'wpigui', linkage: 'static'
-                    lib project: ':fieldImages', library: 'fieldImages', linkage: 'static'
-                    nativeUtils.useRequiredLibrary(it, 'opencv_static')
-                    nativeUtils.useRequiredLibrary(it, 'imgui')
-                    if (it.targetPlatform.operatingSystem.isWindows()) {
-                        it.linker.args << 'Gdi32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'
-                        it.linker.args << '/DELAYLOAD:MF.dll' << '/DELAYLOAD:MFReadWrite.dll' << '/DELAYLOAD:MFPlat.dll' << '/delay:nobind'
-                    } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
-                        it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
-                    } else {
-                        it.linker.args << '-lX11'
-                        if (it.targetPlatform.name.startsWith('linuxarm')) {
-                            it.linker.args << '-lGL'
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    apply from: 'publish.gradle'
+if (project.hasProperty('onlylinuxathena')) {
+    return;
 }
+
+description = "A different kind of dashboard"
+
+apply plugin: 'cpp'
+apply plugin: 'visual-studio'
+apply plugin: 'edu.wpi.first.NativeUtils'
+
+if (OperatingSystem.current().isWindows()) {
+    apply plugin: 'windows-resources'
+}
+
+ext {
+    nativeName = 'glass'
+}
+
+apply from: "${rootDir}/shared/resources.gradle"
+apply from: "${rootDir}/shared/config.gradle"
+
+def wpilibVersionFileInput = file("src/app/generate/WPILibVersion.cpp.in")
+def wpilibVersionFileOutput = file("$buildDir/generated/app/cpp/WPILibVersion.cpp")
+
+apply from: "${rootDir}/shared/imgui.gradle"
+
+task generateCppVersion() {
+    description = 'Generates the wpilib version class'
+    group = 'WPILib'
+
+    outputs.file wpilibVersionFileOutput
+    inputs.file wpilibVersionFileInput
+
+    if (wpilibVersioning.releaseMode) {
+        outputs.upToDateWhen { false }
+    }
+
+    // We follow a simple set of checks to determine whether we should generate a new version file:
+    // 1. If the release type is not development, we generate a new version file
+    // 2. If there is no generated version number, we generate a new version file
+    // 3. If there is a generated build number, and the release type is development, then we will
+    //    only generate if the publish task is run.
+    doLast {
+        def version = wpilibVersioning.version.get()
+        println "Writing version ${version} to $wpilibVersionFileOutput"
+
+        if (wpilibVersionFileOutput.exists()) {
+            wpilibVersionFileOutput.delete()
+        }
+        def read = wpilibVersionFileInput.text.replace('${wpilib_version}', version)
+        wpilibVersionFileOutput.write(read)
+    }
+}
+
+gradle.taskGraph.addTaskExecutionGraphListener { graph ->
+    def willPublish = graph.hasTask(publish)
+    if (willPublish) {
+        generateCppVersion.outputs.upToDateWhen { false }
+    }
+}
+
+def generateTask = createGenerateResourcesTask('app', 'GLASS', 'glass', project)
+
+project(':').libraryBuild.dependsOn build
+tasks.withType(CppCompile) {
+    dependsOn generateTask
+    dependsOn generateCppVersion
+}
+
+nativeUtils.exportsConfigs {
+    glass {
+        x64ExcludeSymbols = [
+            '_CT??_R0?AV_System_error',
+            '_CT??_R0?AVexception',
+            '_CT??_R0?AVfailure',
+            '_CT??_R0?AVruntime_error',
+            '_CT??_R0?AVsystem_error',
+            '_CTA5?AVfailure',
+            '_TI5?AVfailure',
+            '_CT??_R0?AVout_of_range',
+            '_CTA3?AVout_of_range',
+            '_TI3?AVout_of_range',
+            '_CT??_R0?AVbad_cast'
+        ]
+    }
+}
+
+model {
+    components {
+        "${nativeName}"(NativeLibrarySpec) {
+            sources.cpp {
+                source {
+                    srcDirs 'src/lib/native/cpp'
+                    include '**/*.cpp'
+                }
+                exportedHeaders {
+                    srcDirs 'src/lib/native/include'
+                }
+            }
+            binaries.all {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                    it.buildable = false
+                    return
+                }
+                if (it instanceof SharedLibraryBinarySpec) {
+                    it.buildable = false
+                    return
+                }
+                lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
+                lib project: ':wpimath', library: 'wpimath', linkage: 'shared'
+                lib project: ':wpigui', library: 'wpigui', linkage: 'static'
+                lib project: ':fieldImages', library: 'fieldImages', linkage: 'shared'
+                nativeUtils.useRequiredLibrary(it, 'imgui')
+            }
+            appendDebugPathToBinaries(binaries)
+        }
+        "${nativeName}nt"(NativeLibrarySpec) {
+            sources.cpp {
+                source {
+                    srcDirs = ['src/libnt/native/cpp']
+                    include '**/*.cpp'
+                }
+                exportedHeaders {
+                    srcDirs 'src/libnt/native/include'
+                }
+            }
+            binaries.all {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                    it.buildable = false
+                    return
+                }
+                if (it instanceof SharedLibraryBinarySpec) {
+                    it.buildable = false
+                    return
+                }
+                lib library: nativeName, linkage: 'static'
+                project(':ntcore').addNtcoreDependency(it, 'shared')
+                lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
+                lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
+                lib project: ':wpimath', library: 'wpimath', linkage: 'shared'
+                lib project: ':wpigui', library: 'wpigui', linkage: 'static'
+                lib project: ':fieldImages', library: 'fieldImages', linkage: 'shared'
+                nativeUtils.useRequiredLibrary(it, 'imgui')
+            }
+            appendDebugPathToBinaries(binaries)
+        }
+        // By default, a development executable will be generated. This is to help the case of
+        // testing specific functionality of the library.
+        "${nativeName}App"(NativeExecutableSpec) {
+            baseName = 'glass'
+            sources {
+                cpp {
+                    source {
+                        srcDirs 'src/app/native/cpp', "$buildDir/generated/app/cpp"
+                        include '**/*.cpp'
+                    }
+                    exportedHeaders {
+                        srcDirs 'src/app/native/include'
+                    }
+                }
+                if (OperatingSystem.current().isWindows()) {
+                    rc.source {
+                        srcDirs 'src/app/native/win'
+                    }
+                }
+            }
+            binaries.all {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                    it.buildable = false
+                    return
+                }
+                lib project: ':cscore', library: 'cscore', linkage: 'static'
+                lib library: 'glassnt', linkage: 'static'
+                lib library: nativeName, linkage: 'static'
+                project(':ntcore').addNtcoreDependency(it, 'static')
+                lib project: ':wpinet', library: 'wpinet', linkage: 'static'
+                lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
+                lib project: ':wpimath', library: 'wpimath', linkage: 'static'
+                lib project: ':wpigui', library: 'wpigui', linkage: 'static'
+                lib project: ':fieldImages', library: 'fieldImages', linkage: 'static'
+                nativeUtils.useRequiredLibrary(it, 'opencv_static')
+                nativeUtils.useRequiredLibrary(it, 'imgui')
+                if (it.targetPlatform.operatingSystem.isWindows()) {
+                    it.linker.args << 'Gdi32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'
+                    it.linker.args << '/DELAYLOAD:MF.dll' << '/DELAYLOAD:MFReadWrite.dll' << '/DELAYLOAD:MFPlat.dll' << '/delay:nobind'
+                } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
+                    it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
+                } else {
+                    it.linker.args << '-lX11'
+                    if (it.targetPlatform.name.startsWith('linuxarm')) {
+                        it.linker.args << '-lGL'
+                    }
+                }
+            }
+        }
+    }
+}
+
+apply from: 'publish.gradle'

--- a/outlineviewer/build.gradle
+++ b/outlineviewer/build.gradle
@@ -1,126 +1,123 @@
 import org.gradle.internal.os.OperatingSystem
 
-if (!project.hasProperty('onlylinuxathena')) {
-
-    description = "NetworkTables Viewer"
-
-    apply plugin: 'cpp'
-    apply plugin: 'c'
-    apply plugin: 'google-test-test-suite'
-    apply plugin: 'visual-studio'
-    apply plugin: 'edu.wpi.first.NativeUtils'
-
-    if (OperatingSystem.current().isWindows()) {
-        apply plugin: 'windows-resources'
-    }
-
-    ext {
-        nativeName = 'outlineviewer'
-    }
-
-    apply from: "${rootDir}/shared/resources.gradle"
-    apply from: "${rootDir}/shared/config.gradle"
-
-    def wpilibVersionFileInput = file("src/main/generate/WPILibVersion.cpp.in")
-    def wpilibVersionFileOutput = file("$buildDir/generated/main/cpp/WPILibVersion.cpp")
-
-    apply from: "${rootDir}/shared/imgui.gradle"
-
-    task generateCppVersion() {
-        description = 'Generates the wpilib version class'
-        group = 'WPILib'
-
-        outputs.file wpilibVersionFileOutput
-        inputs.file wpilibVersionFileInput
-
-        if (wpilibVersioning.releaseMode) {
-            outputs.upToDateWhen { false }
-        }
-
-        // We follow a simple set of checks to determine whether we should generate a new version file:
-        // 1. If the release type is not development, we generate a new version file
-        // 2. If there is no generated version number, we generate a new version file
-        // 3. If there is a generated build number, and the release type is development, then we will
-        //    only generate if the publish task is run.
-        doLast {
-            def version = wpilibVersioning.version.get()
-            println "Writing version ${version} to $wpilibVersionFileOutput"
-
-            if (wpilibVersionFileOutput.exists()) {
-                wpilibVersionFileOutput.delete()
-            }
-            def read = wpilibVersionFileInput.text.replace('${wpilib_version}', version)
-            wpilibVersionFileOutput.write(read)
-        }
-    }
-
-    gradle.taskGraph.addTaskExecutionGraphListener { graph ->
-        def willPublish = graph.hasTask(publish)
-        if (willPublish) {
-            generateCppVersion.outputs.upToDateWhen { false }
-        }
-    }
-
-    def generateTask = createGenerateResourcesTask('main', 'OV', 'ov', project)
-
-    project(':').libraryBuild.dependsOn build
-    tasks.withType(CppCompile) {
-        dependsOn generateTask
-        dependsOn generateCppVersion
-    }
-
-    model {
-        components {
-            // By default, a development executable will be generated. This is to help the case of
-            // testing specific functionality of the library.
-            "${nativeName}"(NativeExecutableSpec) {
-                baseName = 'outlineviewer'
-                sources {
-                    cpp {
-                        source {
-                            srcDirs 'src/main/native/cpp', "$buildDir/generated/main/cpp"
-                            include '**/*.cpp'
-                        }
-                        exportedHeaders {
-                            srcDirs 'src/main/native/include'
-                        }
-                    }
-                    if (OperatingSystem.current().isWindows()) {
-                        rc {
-                            source {
-                                srcDirs 'src/main/native/win'
-                                include '*.rc'
-                            }
-                        }
-                    }
-                }
-                binaries.all {
-                    if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        it.buildable = false
-                        return
-                    }
-                    lib project: ':glass', library: 'glassnt', linkage: 'static'
-                    lib project: ':glass', library: 'glass', linkage: 'static'
-                    project(':ntcore').addNtcoreDependency(it, 'static')
-                    lib project: ':wpinet', library: 'wpinet', linkage: 'static'
-                    lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
-                    lib project: ':wpigui', library: 'wpigui', linkage: 'static'
-                    lib project: ':fieldImages', library: 'fieldImages', linkage: 'static'
-                    nativeUtils.useRequiredLibrary(it, 'imgui')
-                    if (it.targetPlatform.operatingSystem.isWindows()) {
-                        it.linker.args << 'Gdi32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'
-                    } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
-                        it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
-                    } else {
-                        it.linker.args << '-lX11'
-                        if (it.targetPlatform.name.startsWith('linuxarm')) {
-                            it.linker.args << '-lGL'
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    apply from: 'publish.gradle'
+if (project.hasProperty('onlylinuxathena')) {
+    return;
 }
+
+description = "NetworkTables Viewer"
+
+apply plugin: 'cpp'
+apply plugin: 'visual-studio'
+apply plugin: 'edu.wpi.first.NativeUtils'
+
+if (OperatingSystem.current().isWindows()) {
+    apply plugin: 'windows-resources'
+}
+
+ext {
+    nativeName = 'outlineviewer'
+}
+
+apply from: "${rootDir}/shared/resources.gradle"
+apply from: "${rootDir}/shared/config.gradle"
+
+def wpilibVersionFileInput = file("src/main/generate/WPILibVersion.cpp.in")
+def wpilibVersionFileOutput = file("$buildDir/generated/main/cpp/WPILibVersion.cpp")
+
+apply from: "${rootDir}/shared/imgui.gradle"
+
+task generateCppVersion() {
+    description = 'Generates the wpilib version class'
+    group = 'WPILib'
+
+    outputs.file wpilibVersionFileOutput
+    inputs.file wpilibVersionFileInput
+
+    if (wpilibVersioning.releaseMode) {
+        outputs.upToDateWhen { false }
+    }
+
+    // We follow a simple set of checks to determine whether we should generate a new version file:
+    // 1. If the release type is not development, we generate a new version file
+    // 2. If there is no generated version number, we generate a new version file
+    // 3. If there is a generated build number, and the release type is development, then we will
+    //    only generate if the publish task is run.
+    doLast {
+        def version = wpilibVersioning.version.get()
+        println "Writing version ${version} to $wpilibVersionFileOutput"
+
+        if (wpilibVersionFileOutput.exists()) {
+            wpilibVersionFileOutput.delete()
+        }
+        def read = wpilibVersionFileInput.text.replace('${wpilib_version}', version)
+        wpilibVersionFileOutput.write(read)
+    }
+}
+
+gradle.taskGraph.addTaskExecutionGraphListener { graph ->
+    def willPublish = graph.hasTask(publish)
+    if (willPublish) {
+        generateCppVersion.outputs.upToDateWhen { false }
+    }
+}
+
+def generateTask = createGenerateResourcesTask('main', 'OV', 'ov', project)
+
+project(':').libraryBuild.dependsOn build
+tasks.withType(CppCompile) {
+    dependsOn generateTask
+    dependsOn generateCppVersion
+}
+
+model {
+    components {
+        // By default, a development executable will be generated. This is to help the case of
+        // testing specific functionality of the library.
+        "${nativeName}"(NativeExecutableSpec) {
+            baseName = 'outlineviewer'
+            sources {
+                cpp {
+                    source {
+                        srcDirs 'src/main/native/cpp', "$buildDir/generated/main/cpp"
+                        include '**/*.cpp'
+                    }
+                    exportedHeaders {
+                        srcDirs 'src/main/native/include'
+                    }
+                }
+                if (OperatingSystem.current().isWindows()) {
+                    rc.source {
+                        srcDirs 'src/main/native/win'
+                        include '*.rc'
+                    }
+                }
+            }
+            binaries.all {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                    it.buildable = false
+                    return
+                }
+                lib project: ':glass', library: 'glassnt', linkage: 'static'
+                lib project: ':glass', library: 'glass', linkage: 'static'
+                project(':ntcore').addNtcoreDependency(it, 'static')
+                lib project: ':wpinet', library: 'wpinet', linkage: 'static'
+                lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
+                lib project: ':wpigui', library: 'wpigui', linkage: 'static'
+                lib project: ':fieldImages', library: 'fieldImages', linkage: 'static'
+                nativeUtils.useRequiredLibrary(it, 'imgui')
+                if (it.targetPlatform.operatingSystem.isWindows()) {
+                    it.linker.args << 'Gdi32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'
+                } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
+                    it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
+                } else {
+                    it.linker.args << '-lX11'
+                    if (it.targetPlatform.name.startsWith('linuxarm')) {
+                        it.linker.args << '-lGL'
+                    }
+                }
+            }
+        }
+    }
+}
+
+apply from: 'publish.gradle'

--- a/processstarter/build.gradle
+++ b/processstarter/build.gradle
@@ -1,77 +1,78 @@
 import org.gradle.internal.os.OperatingSystem
 
-if (!project.hasProperty('onlylinuxathena')) {
+if (project.hasProperty('onlylinuxathena')) {
+    return;
+}
 
-    description = "Process Starter"
+description = "Process Starter"
 
-    apply plugin: 'cpp'
-    apply plugin: 'objective-cpp'
-    apply plugin: 'visual-studio'
-    apply plugin: 'edu.wpi.first.NativeUtils'
+apply plugin: 'cpp'
+apply plugin: 'objective-cpp'
+apply plugin: 'visual-studio'
+apply plugin: 'edu.wpi.first.NativeUtils'
 
-    ext {
-        nativeName = 'processstarter'
-    }
+ext {
+    nativeName = 'processstarter'
+}
 
-    apply from: "${rootDir}/shared/config.gradle"
+apply from: "${rootDir}/shared/config.gradle"
 
-    // Replace shared crt with static crt.
-    // Note this means no wpilib binaries can be dependencies
-    nativeUtils.platformConfigs.named(nativeUtils.wpi.platforms.windowsx64).configure {
-        cppCompiler.debugArgs.remove('/MDd')
-        cppCompiler.debugArgs.add('/MTd')
-        cppCompiler.releaseArgs.remove('/MD')
-        cppCompiler.releaseArgs.add('/MT')
-    }
+// Replace shared crt with static crt.
+// Note this means no wpilib binaries can be dependencies
+nativeUtils.platformConfigs.named(nativeUtils.wpi.platforms.windowsx64).configure {
+    cppCompiler.debugArgs.remove('/MDd')
+    cppCompiler.debugArgs.add('/MTd')
+    cppCompiler.releaseArgs.remove('/MD')
+    cppCompiler.releaseArgs.add('/MT')
+}
 
-    project(':').libraryBuild.dependsOn build
+project(':').libraryBuild.dependsOn build
 
-    model {
-        components {
-            "${nativeName}"(NativeExecutableSpec) {
-                baseName = 'processstarter'
-                binaries.all {
-                    if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        it.buildable = false
-                        return
+model {
+    components {
+        "${nativeName}"(NativeExecutableSpec) {
+            baseName = 'processstarter'
+            binaries.all {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                    it.buildable = false
+                    return
+                }
+                if (it.targetPlatform.operatingSystem.isMacOsX()) {
+                    it.sources {
+                        macObjCpp(ObjectiveCppSourceSet) {
+                            source {
+                                srcDirs 'src/main/native/osx'
+                                include '**/*.mm'
+                            }
+                            exportedHeaders {
+                                srcDirs 'src/main/native/include'
+                                include '**/*.h'
+                            }
+                        }
                     }
-                    if (it.targetPlatform.operatingSystem.isMacOsX()) {
-                        it.sources {
-                            macObjCpp(ObjectiveCppSourceSet) {
-                                source {
-                                    srcDirs 'src/main/native/osx'
-                                    include '**/*.mm'
-                                }
-                                exportedHeaders {
-                                    srcDirs 'src/main/native/include'
-                                    include '**/*.h'
-                                }
+                } else if (it.targetPlatform.operatingSystem.isLinux()) {
+                    it.sources {
+                        linuxCpp(CppSourceSet) {
+                            source {
+                                srcDirs 'src/main/native/linux'
+                                include '**/*.cpp'
+                            }
+                            exportedHeaders {
+                                srcDirs 'src/main/native/include'
+                                include '**/*.h'
                             }
                         }
-                    } else if (it.targetPlatform.operatingSystem.isLinux()) {
-                        it.sources {
-                            linuxCpp(CppSourceSet) {
-                                source {
-                                    srcDirs 'src/main/native/linux'
-                                    include '**/*.cpp'
-                                }
-                                exportedHeaders {
-                                    srcDirs 'src/main/native/include'
-                                    include '**/*.h'
-                                }
+                    }
+                } else if (it.targetPlatform.operatingSystem.isWindows()) {
+                    it.sources {
+                        windowsCpp(CppSourceSet) {
+                            source {
+                                srcDirs 'src/main/native/windows'
+                                include '**/*.cpp'
                             }
-                        }
-                    } else if (it.targetPlatform.operatingSystem.isWindows()) {
-                        it.sources {
-                            windowsCpp(CppSourceSet) {
-                                source {
-                                    srcDirs 'src/main/native/windows'
-                                    include '**/*.cpp'
-                                }
-                                exportedHeaders {
-                                    srcDirs 'src/main/native/include'
-                                    include '**/*.h'
-                                }
+                            exportedHeaders {
+                                srcDirs 'src/main/native/include'
+                                include '**/*.h'
                             }
                         }
                     }
@@ -79,6 +80,6 @@ if (!project.hasProperty('onlylinuxathena')) {
             }
         }
     }
-
-    apply from: 'publish.gradle'
 }
+
+apply from: 'publish.gradle'

--- a/roborioteamnumbersetter/build.gradle
+++ b/roborioteamnumbersetter/build.gradle
@@ -1,127 +1,124 @@
 import org.gradle.internal.os.OperatingSystem
 
-if (!project.hasProperty('onlylinuxathena')) {
-
-    description = "roboRIO Team Number Setter"
-
-    apply plugin: 'cpp'
-    apply plugin: 'c'
-    apply plugin: 'google-test-test-suite'
-    apply plugin: 'visual-studio'
-    apply plugin: 'edu.wpi.first.NativeUtils'
-
-    if (OperatingSystem.current().isWindows()) {
-        apply plugin: 'windows-resources'
-    }
-
-    ext {
-        nativeName = 'roborioteamnumbersetter'
-    }
-
-    apply from: "${rootDir}/shared/resources.gradle"
-    apply from: "${rootDir}/shared/config.gradle"
-
-    def wpilibVersionFileInput = file("src/main/generate/WPILibVersion.cpp.in")
-    def wpilibVersionFileOutput = file("$buildDir/generated/main/cpp/WPILibVersion.cpp")
-
-    apply from: "${rootDir}/shared/libssh.gradle"
-    apply from: "${rootDir}/shared/imgui.gradle"
-
-    task generateCppVersion() {
-        description = 'Generates the wpilib version class'
-        group = 'WPILib'
-
-        outputs.file wpilibVersionFileOutput
-        inputs.file wpilibVersionFileInput
-
-        if (wpilibVersioning.releaseMode) {
-            outputs.upToDateWhen { false }
-        }
-
-        // We follow a simple set of checks to determine whether we should generate a new version file:
-        // 1. If the release type is not development, we generate a new version file
-        // 2. If there is no generated version number, we generate a new version file
-        // 3. If there is a generated build number, and the release type is development, then we will
-        //    only generate if the publish task is run.
-        doLast {
-            def version = wpilibVersioning.version.get()
-            println "Writing version ${version} to $wpilibVersionFileOutput"
-
-            if (wpilibVersionFileOutput.exists()) {
-                wpilibVersionFileOutput.delete()
-            }
-            def read = wpilibVersionFileInput.text.replace('${wpilib_version}', version)
-            wpilibVersionFileOutput.write(read)
-        }
-    }
-
-    gradle.taskGraph.addTaskExecutionGraphListener { graph ->
-        def willPublish = graph.hasTask(publish)
-        if (willPublish) {
-            generateCppVersion.outputs.upToDateWhen { false }
-        }
-    }
-
-    def generateTask = createGenerateResourcesTask('main', 'RTNS', 'rtns', project)
-
-    project(':').libraryBuild.dependsOn build
-    tasks.withType(CppCompile) {
-        dependsOn generateTask
-        dependsOn generateCppVersion
-    }
-
-    model {
-        components {
-            // By default, a development executable will be generated. This is to help the case of
-            // testing specific functionality of the library.
-            "${nativeName}"(NativeExecutableSpec) {
-                baseName = 'roborioteamnumbersetter'
-                sources {
-                    cpp {
-                        source {
-                            srcDirs 'src/main/native/cpp', "$buildDir/generated/main/cpp"
-                            include '**/*.cpp'
-                        }
-                        exportedHeaders {
-                            srcDirs 'src/main/native/include'
-                        }
-                    }
-                    if (OperatingSystem.current().isWindows()) {
-                        rc {
-                            source {
-                                srcDirs 'src/main/native/win'
-                                include '*.rc'
-                            }
-                        }
-                    }
-                }
-                binaries.all {
-                    if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        it.buildable = false
-                        return
-                    }
-                    it.cppCompiler.define("LIBSSH_STATIC")
-                    lib project: ':glass', library: 'glass', linkage: 'static'
-                    lib project: ':wpinet', library: 'wpinet', linkage: 'static'
-                    lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
-                    lib project: ':wpigui', library: 'wpigui', linkage: 'static'
-                    nativeUtils.useRequiredLibrary(it, 'imgui', 'libssh')
-                    if (it.targetPlatform.operatingSystem.isWindows()) {
-                        it.linker.args << 'Gdi32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'
-                        it.linker.args << 'ws2_32.lib' << 'advapi32.lib' << 'crypt32.lib' << 'user32.lib'
-                    } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
-                        it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
-                        it.linker.args << '-framework' << 'Kerberos'
-                    } else {
-                        it.linker.args << '-lX11'
-                        if (it.targetPlatform.name.startsWith('linuxarm')) {
-                            it.linker.args << '-lGL'
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    apply from: 'publish.gradle'
+if (project.hasProperty('onlylinuxathena')) {
+    return;
 }
+
+description = "roboRIO Team Number Setter"
+
+apply plugin: 'cpp'
+apply plugin: 'visual-studio'
+apply plugin: 'edu.wpi.first.NativeUtils'
+
+if (OperatingSystem.current().isWindows()) {
+    apply plugin: 'windows-resources'
+}
+
+ext {
+    nativeName = 'roborioteamnumbersetter'
+}
+
+apply from: "${rootDir}/shared/resources.gradle"
+apply from: "${rootDir}/shared/config.gradle"
+
+def wpilibVersionFileInput = file("src/main/generate/WPILibVersion.cpp.in")
+def wpilibVersionFileOutput = file("$buildDir/generated/main/cpp/WPILibVersion.cpp")
+
+apply from: "${rootDir}/shared/libssh.gradle"
+apply from: "${rootDir}/shared/imgui.gradle"
+
+task generateCppVersion() {
+    description = 'Generates the wpilib version class'
+    group = 'WPILib'
+
+    outputs.file wpilibVersionFileOutput
+    inputs.file wpilibVersionFileInput
+
+    if (wpilibVersioning.releaseMode) {
+        outputs.upToDateWhen { false }
+    }
+
+    // We follow a simple set of checks to determine whether we should generate a new version file:
+    // 1. If the release type is not development, we generate a new version file
+    // 2. If there is no generated version number, we generate a new version file
+    // 3. If there is a generated build number, and the release type is development, then we will
+    //    only generate if the publish task is run.
+    doLast {
+        def version = wpilibVersioning.version.get()
+        println "Writing version ${version} to $wpilibVersionFileOutput"
+
+        if (wpilibVersionFileOutput.exists()) {
+            wpilibVersionFileOutput.delete()
+        }
+        def read = wpilibVersionFileInput.text.replace('${wpilib_version}', version)
+        wpilibVersionFileOutput.write(read)
+    }
+}
+
+gradle.taskGraph.addTaskExecutionGraphListener { graph ->
+    def willPublish = graph.hasTask(publish)
+    if (willPublish) {
+        generateCppVersion.outputs.upToDateWhen { false }
+    }
+}
+
+def generateTask = createGenerateResourcesTask('main', 'RTNS', 'rtns', project)
+
+project(':').libraryBuild.dependsOn build
+tasks.withType(CppCompile) {
+    dependsOn generateTask
+    dependsOn generateCppVersion
+}
+
+model {
+    components {
+        // By default, a development executable will be generated. This is to help the case of
+        // testing specific functionality of the library.
+        "${nativeName}"(NativeExecutableSpec) {
+            baseName = 'roborioteamnumbersetter'
+            sources {
+                cpp {
+                    source {
+                        srcDirs 'src/main/native/cpp', "$buildDir/generated/main/cpp"
+                        include '**/*.cpp'
+                    }
+                    exportedHeaders {
+                        srcDirs 'src/main/native/include'
+                    }
+                }
+                if (OperatingSystem.current().isWindows()) {
+                    rc.source {
+                        srcDirs 'src/main/native/win'
+                        include '*.rc'
+                    }
+                }
+            }
+            binaries.all {
+                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                    it.buildable = false
+                    return
+                }
+                it.cppCompiler.define("LIBSSH_STATIC")
+                lib project: ':glass', library: 'glass', linkage: 'static'
+                lib project: ':wpinet', library: 'wpinet', linkage: 'static'
+                lib project: ':wpiutil', library: 'wpiutil', linkage: 'static'
+                lib project: ':wpigui', library: 'wpigui', linkage: 'static'
+                nativeUtils.useRequiredLibrary(it, 'imgui', 'libssh')
+                if (it.targetPlatform.operatingSystem.isWindows()) {
+                    it.linker.args << 'Gdi32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'
+                    it.linker.args << 'ws2_32.lib' << 'advapi32.lib' << 'crypt32.lib' << 'user32.lib'
+                } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
+                    it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
+                    it.linker.args << '-framework' << 'Kerberos'
+                } else {
+                    it.linker.args << '-lX11'
+                    if (it.targetPlatform.name.startsWith('linuxarm')) {
+                        it.linker.args << '-lGL'
+                    }
+                }
+            }
+        }
+    }
+}
+
+apply from: 'publish.gradle'

--- a/simulation/halsim_ds_socket/build.gradle
+++ b/simulation/halsim_ds_socket/build.gradle
@@ -1,3 +1,7 @@
+if (project.hasProperty('onlylinuxathena')) {
+    return;
+}
+
 description = "A plugin that listens on a socket so that you can use the real Driver Station software to connect to the simulation"
 
 ext {
@@ -6,7 +10,6 @@ ext {
 }
 
 apply plugin: 'google-test-test-suite'
-
 
 ext {
     staticGtestConfigs = [:]
@@ -17,28 +20,22 @@ apply from: "${rootDir}/shared/googletest.gradle"
 
 apply from: "${rootDir}/shared/plugins/setupBuild.gradle"
 
-
 model {
     testSuites {
-        def comps = $.components
-        if (!project.hasProperty('onlylinuxathena')) {
-            "${pluginName}Test"(GoogleTestTestSuiteSpec) {
-                for(NativeComponentSpec c : comps) {
-                    if (c.name == pluginName) {
-                        testing c
-                        break
-                    }
+        "${pluginName}Test"(GoogleTestTestSuiteSpec) {
+            for(NativeComponentSpec c : $.components) {
+                if (c.name == pluginName) {
+                    testing c
+                    break
                 }
-                sources {
-                    cpp {
-                        source {
-                            srcDirs 'src/test/native/cpp'
-                            include '**/*.cpp'
-                        }
-                        exportedHeaders {
-                            srcDirs 'src/test/native/include', 'src/main/native/cpp'
-                        }
-                    }
+            }
+            sources.cpp {
+                source {
+                    srcDirs 'src/test/native/cpp'
+                    include '**/*.cpp'
+                }
+                exportedHeaders {
+                    srcDirs 'src/test/native/include', 'src/main/native/cpp'
                 }
             }
         }

--- a/simulation/halsim_gui/build.gradle
+++ b/simulation/halsim_gui/build.gradle
@@ -1,51 +1,51 @@
-if (!project.hasProperty('onlylinuxathena')) {
+if (project.hasProperty('onlylinuxathena')) {
+    return;
+}
 
-    description = "A plugin that creates a simulation gui"
+description = "A plugin that creates a simulation gui"
 
-    ext {
-        pluginName = 'halsim_gui'
-    }
+ext {
+    pluginName = 'halsim_gui'
+}
 
-    apply plugin: 'google-test-test-suite'
+apply plugin: 'google-test-test-suite'
+
+ext {
+    staticGtestConfigs = [:]
+}
+
+staticGtestConfigs["${pluginName}Test"] = []
+apply from: "${rootDir}/shared/googletest.gradle"
+
+apply from: "${rootDir}/shared/plugins/setupBuild.gradle"
 
 
-    ext {
-        staticGtestConfigs = [:]
-    }
+apply from: "${rootDir}/shared/imgui.gradle"
 
-    staticGtestConfigs["${pluginName}Test"] = []
-    apply from: "${rootDir}/shared/googletest.gradle"
-
-    apply from: "${rootDir}/shared/plugins/setupBuild.gradle"
-
-
-    apply from: "${rootDir}/shared/imgui.gradle"
-
-    model {
-        binaries {
-            all {
-                lib project: ':glass', library: 'glassnt', linkage: 'static'
-                lib project: ':glass', library: 'glass', linkage: 'static'
-                lib project: ':wpigui', library: 'wpigui', linkage: 'static'
-                lib project: ':wpimath', library: 'wpimath', linkage: 'shared'
-                project(':ntcore').addNtcoreDependency(it, 'shared')
-                lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
-                lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
-                lib project: ':fieldImages', library: 'fieldImages', linkage: 'static'
-                nativeUtils.useRequiredLibrary(it, 'imgui')
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    it.buildable = false
-                    return
-                }
-                if (it.targetPlatform.operatingSystem.isWindows()) {
-                    it.linker.args << 'Gdi32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'
-                } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
-                    it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
-                } else {
-                    it.linker.args << '-lX11'
-                    if (it.targetPlatform.name.startsWith('linuxarm')) {
-                        it.linker.args << '-lGL'
-                    }
+model {
+    binaries {
+        all {
+            lib project: ':glass', library: 'glassnt', linkage: 'static'
+            lib project: ':glass', library: 'glass', linkage: 'static'
+            lib project: ':wpigui', library: 'wpigui', linkage: 'static'
+            lib project: ':wpimath', library: 'wpimath', linkage: 'shared'
+            project(':ntcore').addNtcoreDependency(it, 'shared')
+            lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
+            lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
+            lib project: ':fieldImages', library: 'fieldImages', linkage: 'static'
+            nativeUtils.useRequiredLibrary(it, 'imgui')
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                it.buildable = false
+                return
+            }
+            if (it.targetPlatform.operatingSystem.isWindows()) {
+                it.linker.args << 'Gdi32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'
+            } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
+                it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
+            } else {
+                it.linker.args << '-lX11'
+                if (it.targetPlatform.name.startsWith('linuxarm')) {
+                    it.linker.args << '-lGL'
                 }
             }
         }

--- a/simulation/halsim_ws_client/build.gradle
+++ b/simulation/halsim_ws_client/build.gradle
@@ -1,35 +1,35 @@
-if (!project.hasProperty('onlylinuxathena')) {
+if (project.hasProperty('onlylinuxathena')) {
+    return;
+}
 
-    description = "WebSocket Client Extension"
+description = "WebSocket Client Extension"
 
-    ext {
-        includeWpiutil = true
-        pluginName = 'halsim_ws_client'
-    }
+ext {
+    includeWpiutil = true
+    pluginName = 'halsim_ws_client'
+}
 
-    apply plugin: 'google-test-test-suite'
+apply plugin: 'google-test-test-suite'
 
+ext {
+    staticGtestConfigs = [:]
+}
 
-    ext {
-        staticGtestConfigs = [:]
-    }
+staticGtestConfigs["${pluginName}Test"] = []
+apply from: "${rootDir}/shared/googletest.gradle"
 
-    staticGtestConfigs["${pluginName}Test"] = []
-    apply from: "${rootDir}/shared/googletest.gradle"
+apply from: "${rootDir}/shared/plugins/setupBuild.gradle"
 
-    apply from: "${rootDir}/shared/plugins/setupBuild.gradle"
-
-    model {
-        binaries {
-            all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    it.buildable = false
-                    return
-                }
-
-                lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
-                lib project: ":simulation:halsim_ws_core", library: "halsim_ws_core", linkage: "static"
+model {
+    binaries {
+        all {
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                it.buildable = false
+                return
             }
+
+            lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
+            lib project: ":simulation:halsim_ws_core", library: "halsim_ws_core", linkage: "static"
         }
     }
 }

--- a/simulation/halsim_ws_core/build.gradle
+++ b/simulation/halsim_ws_core/build.gradle
@@ -1,58 +1,57 @@
+if (project.hasProperty('onlylinuxathena')) {
+    return;
+}
+
 apply plugin: 'cpp'
 apply plugin: 'edu.wpi.first.NativeUtils'
 apply plugin: ExtraTasks
 
-if (!project.hasProperty('onlylinuxathena')) {
+description = "Core library for WebSocket extensions"
 
-    description = "Core library for WebSocket extensions"
+ext {
+    includeWpiutil = true
+    includeWpinet = true
+    pluginName = 'halsim_ws_core'
+}
 
-    ext {
-        includeWpiutil = true
-        includeWpinet = true
-        pluginName = 'halsim_ws_core'
-    }
-
-    apply plugin: 'google-test-test-suite'
+apply plugin: 'google-test-test-suite'
 
 
-    ext {
-        staticGtestConfigs = [:]
-    }
+ext {
+    staticGtestConfigs = [:]
+}
 
-    staticGtestConfigs["${pluginName}Test"] = []
-    apply from: "${rootDir}/shared/googletest.gradle"
+staticGtestConfigs["${pluginName}Test"] = []
+apply from: "${rootDir}/shared/googletest.gradle"
 
-    apply from: "${rootDir}/shared/config.gradle"
-    apply from: "${rootDir}/shared/plugins/publish.gradle"
+apply from: "${rootDir}/shared/config.gradle"
+apply from: "${rootDir}/shared/plugins/publish.gradle"
 
-    model {
-        components {
-            halsim_ws_core(NativeLibrarySpec) {
-                sources {
-                    cpp {
-                        source {
-                            srcDirs = ['src/main/native/cpp']
-                            includes = ["**/*.cpp"]
-                        }
-                        exportedHeaders {
-                            srcDirs = ["src/main/native/include"]
-                        }
-                    }
+model {
+    components {
+        halsim_ws_core(NativeLibrarySpec) {
+            sources.cpp {
+                source {
+                    srcDirs = ['src/main/native/cpp']
+                    includes = ["**/*.cpp"]
                 }
-                binaries.all {
-                    project(':hal').addHalDependency(it, 'shared')
-                    lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
-                    lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
+                exportedHeaders {
+                    srcDirs = ["src/main/native/include"]
                 }
-                appendDebugPathToBinaries(binaries)
             }
+            binaries.all {
+                project(':hal').addHalDependency(it, 'shared')
+                lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
+                lib project: ':wpiutil', library: 'wpiutil', linkage: 'shared'
+            }
+            appendDebugPathToBinaries(binaries)
         }
-        binaries {
-            all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    it.buildable = false
-                    return
-                }
+    }
+    binaries {
+        all {
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                it.buildable = false
+                return
             }
         }
     }

--- a/simulation/halsim_ws_server/build.gradle
+++ b/simulation/halsim_ws_server/build.gradle
@@ -1,3 +1,6 @@
+if (project.hasProperty('onlylinuxathena')) {
+    return;
+}
 
 description = "WebSocket Server Extension"
 
@@ -20,25 +23,20 @@ apply from: "${rootDir}/shared/plugins/setupBuild.gradle"
 
 model {
     testSuites {
-        def comps = $.components
-        if (!project.hasProperty('onlylinuxathena')) {
-            "${pluginName}Test"(GoogleTestTestSuiteSpec) {
-                for(NativeComponentSpec c : comps) {
-                    if (c.name == pluginName) {
-                        testing c
-                        break
-                    }
+        "${pluginName}Test"(GoogleTestTestSuiteSpec) {
+            for(NativeComponentSpec c : $.components) {
+                if (c.name == pluginName) {
+                    testing c
+                    break
                 }
-                sources {
-                    cpp {
-                        source {
-                            srcDirs 'src/test/native/cpp'
-                            include '**/*.cpp'
-                        }
-                        exportedHeaders {
-                            srcDirs 'src/test/native/include', 'src/main/native/cpp'
-                        }
-                    }
+            }
+            sources.cpp {
+                source {
+                    srcDirs 'src/test/native/cpp'
+                    include '**/*.cpp'
+                }
+                exportedHeaders {
+                    srcDirs 'src/test/native/include', 'src/main/native/cpp'
                 }
             }
         }

--- a/simulation/halsim_xrp/build.gradle
+++ b/simulation/halsim_xrp/build.gradle
@@ -1,35 +1,35 @@
-if (!project.hasProperty('onlylinuxathena')) {
+if (project.hasProperty('onlylinuxathena')) {
+    return;
+}
 
-    description = "XRP Extension"
+description = "XRP Extension"
 
-    ext {
-        includeWpiutil = true
-        pluginName = 'halsim_xrp'
-    }
+ext {
+    includeWpiutil = true
+    pluginName = 'halsim_xrp'
+}
 
-    apply plugin: 'google-test-test-suite'
+apply plugin: 'google-test-test-suite'
 
+ext {
+    staticGtestConfigs = [:]
+}
 
-    ext {
-        staticGtestConfigs = [:]
-    }
+staticGtestConfigs["${pluginName}Test"] = []
+apply from: "${rootDir}/shared/googletest.gradle"
 
-    staticGtestConfigs["${pluginName}Test"] = []
-    apply from: "${rootDir}/shared/googletest.gradle"
+apply from: "${rootDir}/shared/plugins/setupBuild.gradle"
 
-    apply from: "${rootDir}/shared/plugins/setupBuild.gradle"
-
-    model {
-        binaries {
-            all {
-                if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                    it.buildable = false
-                    return
-                }
-
-                lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
-                lib project: ":simulation:halsim_ws_core", library: "halsim_ws_core", linkage: "static"
+model {
+    binaries {
+        all {
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                it.buildable = false
+                return
             }
+
+            lib project: ':wpinet', library: 'wpinet', linkage: 'shared'
+            lib project: ":simulation:halsim_ws_core", library: "halsim_ws_core", linkage: "static"
         }
     }
 }

--- a/wpigui/build.gradle
+++ b/wpigui/build.gradle
@@ -1,146 +1,143 @@
 import org.gradle.internal.os.OperatingSystem
 
-if (!project.hasProperty('onlylinuxathena')) {
+if (project.hasProperty('onlylinuxathena')) {
+    return;
+}
 
-    apply plugin: 'cpp'
-    if (OperatingSystem.current().isMacOsX()) {
-        apply plugin: 'objective-cpp'
+apply plugin: 'cpp'
+if (OperatingSystem.current().isMacOsX()) {
+    apply plugin: 'objective-cpp'
+}
+apply plugin: 'visual-studio'
+apply plugin: 'edu.wpi.first.NativeUtils'
+
+ext {
+    nativeName = 'wpigui'
+}
+
+apply from: "${rootDir}/shared/config.gradle"
+apply from: "${rootDir}/shared/imgui.gradle"
+
+nativeUtils.exportsConfigs {
+    wpigui {
+        x64ExcludeSymbols = [
+            '_CT??_R0?AV_System_error',
+            '_CT??_R0?AVexception',
+            '_CT??_R0?AVfailure',
+            '_CT??_R0?AVruntime_error',
+            '_CT??_R0?AVsystem_error',
+            '_CTA5?AVfailure',
+            '_TI5?AVfailure',
+            '_CT??_R0?AVout_of_range',
+            '_CTA3?AVout_of_range',
+            '_TI3?AVout_of_range',
+            '_CT??_R0?AVbad_cast'
+        ]
     }
-    apply plugin: 'visual-studio'
-    apply plugin: 'edu.wpi.first.NativeUtils'
+}
 
-    ext {
-        nativeName = 'wpigui'
-    }
-
-    apply from: "${rootDir}/shared/config.gradle"
-    apply from: "${rootDir}/shared/imgui.gradle"
-
-    nativeUtils.exportsConfigs {
-        wpigui {
-            x64ExcludeSymbols = [
-                '_CT??_R0?AV_System_error',
-                '_CT??_R0?AVexception',
-                '_CT??_R0?AVfailure',
-                '_CT??_R0?AVruntime_error',
-                '_CT??_R0?AVsystem_error',
-                '_CTA5?AVfailure',
-                '_TI5?AVfailure',
-                '_CT??_R0?AVout_of_range',
-                '_CTA3?AVout_of_range',
-                '_TI3?AVout_of_range',
-                '_CT??_R0?AVbad_cast'
-            ]
-        }
-    }
-
-    model {
-        components {
-            "${nativeName}"(NativeLibrarySpec) {
-                sources {
-                    cpp {
-                        source {
-                            srcDirs "src/main/native/cpp"
-                            include '*.cpp'
-                        }
-                        exportedHeaders {
-                            srcDirs 'src/main/native/include'
-                        }
-                    }
+model {
+    components {
+        "${nativeName}"(NativeLibrarySpec) {
+            sources.cpp {
+                source {
+                    srcDirs "src/main/native/cpp"
+                    include '*.cpp'
                 }
-                binaries.all {
-                    nativeUtils.useRequiredLibrary(it, 'imgui')
-                    if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
-                        it.buildable = false
-                        return
-                    }
-                    if (it.targetPlatform.operatingSystem.isWindows()) {
-                        it.sources {
-                            wpiguiWindowsCpp(CppSourceSet) {
-                                source {
-                                    srcDirs 'src/main/native/directx11'
-                                    include '*.cpp'
-                                }
-                            }
-                        }
-                    } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
-                        it.sources {
-                            wpiguiMacObjectiveCpp(ObjectiveCppSourceSet) {
-                                source {
-                                    srcDirs 'src/main/native/metal'
-                                    include '*.mm'
-                                }
-                            }
-                        }
-                    } else if (it.targetPlatform.name.startsWith('linuxarm')) {
-                        it.sources {
-                            wpiguiUnixGl2Cpp(CppSourceSet) {
-                                source {
-                                    srcDirs 'src/main/native/opengl2'
-                                    include '*.cpp'
-                                }
-                            }
-                        }
-                    } else {
-                        it.sources {
-                            wpiguiUnixGl3Cpp(CppSourceSet) {
-                                source {
-                                    srcDirs 'src/main/native/opengl3'
-                                    include '*.cpp'
-                                }
-                            }
-                        }
-                    }
-                    it.sources.each {
-                        it.exportedHeaders {
-                            srcDirs 'src/main/native/include'
-                        }
-                    }
+                exportedHeaders {
+                    srcDirs 'src/main/native/include'
                 }
             }
-            // By default, a development executable will be generated. This is to help the case of
-            // testing specific functionality of the library.
-            "${nativeName}Dev"(NativeExecutableSpec) {
-                targetBuildTypes 'debug'
-                sources {
-                    cpp {
-                        source {
-                            srcDirs 'src/dev/native/cpp'
-                            include '**/*.cpp'
-                        }
-                        exportedHeaders {
-                            srcDirs 'src/dev/native/include'
-                        }
-                    }
-                }
-                binaries.all {
-                    lib library: 'wpigui'
-                    nativeUtils.useRequiredLibrary(it, 'imgui')
-                }
-            }
-        }
-        binaries {
-            all {
+            binaries.all {
+                nativeUtils.useRequiredLibrary(it, 'imgui')
                 if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
                     it.buildable = false
                     return
                 }
                 if (it.targetPlatform.operatingSystem.isWindows()) {
-                    it.linker.args << 'Gdi32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'
+                    it.sources {
+                        wpiguiWindowsCpp(CppSourceSet) {
+                            source {
+                                srcDirs 'src/main/native/directx11'
+                                include '*.cpp'
+                            }
+                        }
+                    }
                 } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
-                    it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
+                    it.sources {
+                        wpiguiMacObjectiveCpp(ObjectiveCppSourceSet) {
+                            source {
+                                srcDirs 'src/main/native/metal'
+                                include '*.mm'
+                            }
+                        }
+                    }
+                } else if (it.targetPlatform.name.startsWith('linuxarm')) {
+                    it.sources {
+                        wpiguiUnixGl2Cpp(CppSourceSet) {
+                            source {
+                                srcDirs 'src/main/native/opengl2'
+                                include '*.cpp'
+                            }
+                        }
+                    }
                 } else {
-                    it.linker.args << '-lX11'
-                    if (it.targetPlatform.name.startsWith('linuxarm')) {
-                        it.linker.args << '-lGL'
+                    it.sources {
+                        wpiguiUnixGl3Cpp(CppSourceSet) {
+                            source {
+                                srcDirs 'src/main/native/opengl3'
+                                include '*.cpp'
+                            }
+                        }
+                    }
+                }
+                it.sources.each {
+                    it.exportedHeaders {
+                        srcDirs 'src/main/native/include'
                     }
                 }
             }
-            withType(SharedLibraryBinarySpec) {
-                buildable = false
+        }
+        // By default, a development executable will be generated. This is to help the case of
+        // testing specific functionality of the library.
+        "${nativeName}Dev"(NativeExecutableSpec) {
+            targetBuildTypes 'debug'
+            sources.cpp {
+                source {
+                    srcDirs 'src/dev/native/cpp'
+                    include '**/*.cpp'
+                }
+                exportedHeaders {
+                    srcDirs 'src/dev/native/include'
+                }
+            }
+            binaries.all {
+                lib library: 'wpigui'
+                nativeUtils.useRequiredLibrary(it, 'imgui')
             }
         }
     }
-
-    apply from: 'publish.gradle'
+    binaries {
+        all {
+            if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
+                it.buildable = false
+                return
+            }
+            if (it.targetPlatform.operatingSystem.isWindows()) {
+                it.linker.args << 'Gdi32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'
+            } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
+                it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
+            } else {
+                it.linker.args << '-lX11'
+                if (it.targetPlatform.name.startsWith('linuxarm')) {
+                    it.linker.args << '-lGL'
+                }
+            }
+        }
+        withType(SharedLibraryBinarySpec) {
+            buildable = false
+        }
+    }
 }
+
+apply from: 'publish.gradle'


### PR DESCRIPTION
Putting an early exit if statement at the top instead of wrapping the whole file contents unbreaks unit test configs, as was discovered for SysId. It reduces nesting as well.

Unused plugins were removed from the beginnings of files as well.