### PR TITLE
[ci] Disable combine on PR builds

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -187,6 +187,9 @@ jobs:
     name: Combine
     needs: [build-docker, build-host, build-documentation]
     runs-on: ubuntu-22.04
+    if: |
+      github.repository_owner == 'wpilibsuite' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
It takes 30 minutes, and the artifacts aren't used. The combine step changes so infrequently that it's unlikely to break in PRs, so it's a net benefit to speed up PR builds.