### PR TITLE
Remove unnecessary CMake config installs

### DIFF
--- a/romiVendordep/CMakeLists.txt
+++ b/romiVendordep/CMakeLists.txt
@@ -22,8 +22,6 @@ if (WITH_JAVA)
   else()
       set (romiVendordep_config_dir share/romiVendordep)
   endif()
-
-  install(FILES romiVendordep-config.cmake DESTINATION ${romiVendordep_config_dir})
 endif()
 
 file(GLOB_RECURSE romiVendordep_native_src src/main/native/cpp/*.cpp)

--- a/wpilibNewCommands/CMakeLists.txt
+++ b/wpilibNewCommands/CMakeLists.txt
@@ -22,8 +22,6 @@ if (WITH_JAVA)
   else()
       set (wpilibNewCommands_config_dir share/wpilibNewCommands)
   endif()
-
-  install(FILES ${WPILIB_BINARY_DIR}/wpilibNewCommands-config.cmake DESTINATION ${wpilibNewCommands_config_dir})
 endif()
 
 file(GLOB_RECURSE wpilibNewCommands_native_src src/main/native/cpp/*.cpp)

--- a/xrpVendordep/CMakeLists.txt
+++ b/xrpVendordep/CMakeLists.txt
@@ -22,8 +22,6 @@ if (WITH_JAVA)
   else()
       set (xrpVendordep_config_dir share/xrpVendordep)
   endif()
-
-  install(FILES xrpVendordep-config.cmake DESTINATION ${xrpVendordep_config_dir})
 endif()
 
 file(GLOB_RECURSE xrpVendordep_native_src src/main/native/cpp/*.cpp)


### PR DESCRIPTION
The Romi and XRP vendordeps as well as wpilibNewCommands had 2 install commands for the config files, one for WITH_JAVA and another at the end of the file. This removes the extra install command in the WITH_JAVA block, as the other install command is enough.