### PR TITLE
[wpiutil] Get more precise system time on Windows

### DIFF
--- a/wpiutil/src/main/native/cpp/timestamp.cpp
+++ b/wpiutil/src/main/native/cpp/timestamp.cpp
@@ -120,7 +120,7 @@ static uint64_t time_since_epoch() noexcept {
   uint64_t tmpres = 0;
   // 100-nanosecond intervals since January 1, 1601 (UTC)
   // which means 0.1 us
-  GetSystemTimeAsFileTime(&ft);
+  GetSystemTimePreciseAsFileTime(&ft);
   tmpres |= ft.dwHighDateTime;
   tmpres <<= 32;
   tmpres |= ft.dwLowDateTime;


### PR DESCRIPTION
Windows 8 added GetSystemTimePreciseAsFileTime().