### PR TITLE
[ntcore] Add RTT-only subprotocol

### DIFF
--- a/ntcore/doc/networktables4.adoc
+++ b/ntcore/doc/networktables4.adoc
@@ -95,7 +95,7 @@ With a version 4.1 connection, both the client and the server should send period
 
 As the WebSockets protocol allows PONG responses to be sent in the middle of another message stream, WebSockets PING messages are preferred, as this allows for a shorter timeout period that is not dependent on the size of the transmitted messages. Sending a ping every 200 ms with a timeout of 1 second is recommended in this case.
 
-If using timestamp messages for aliveness checking, the client should use a timeout long enough to account for the largest expected message size (as the server can only respond after such a message has been completely transmitted). Sending a ping every 1 second with a timeout of 3 seconds is recommended in this case.
+If using timestamp messages for aliveness checking on the primary connection, the client should use a timeout long enough to account for the largest expected message size (as the server can only respond after such a message has been completely transmitted). Sending a ping every 1 second with a timeout of 3 seconds is recommended in this case. If provided by the server, the <<rtt-subprotocol>> can be used in addition to the primary connection for aliveness testing with a shorter timeout.
 
 [[reconnection]]
 === Caching and Reconnection Handling
@@ -342,6 +342,11 @@ The unsecure standard server port number shall be 5810, the secure standard port
 Combining multiple text or binary messages into a single WebSockets frame should be limited such that the WebSockets frame does not exceed the MTU unless otherwise required to fit the total binary data size.
 
 Client and server implementations should fragment WebSockets messages to roughly the network MTU in order to facilitate rapid handling of PING and PONG messages.
+
+[[rtt-subprotocol]]
+=== RTT Subprotocol
+
+Servers should provide subprotocol `rtt.networktables.first.wpi.edu` for RTT-only messages. This subprotocol provides a separate channel that can be used for RTT messages to avoid delays caused by other value transmissions. Clients that cannot send WebSocket PING messages are recommended to use this subprotocol (if available) for aliveness testing. Connections using this subprotocol do not appear in the client connections list. No text frames are used; only <<binary-frames>> with Topic ID of -1 (RTT measurement) should be sent by the client and responded to by the server.
 
 [[data-types]]
 == Supported Data Types

--- a/ntcore/src/main/native/cpp/NetworkServer.cpp
+++ b/ntcore/src/main/native/cpp/NetworkServer.cpp
@@ -244,6 +244,7 @@ void NetworkServer::ServerConnection4::ProcessWsUpgrade() {
         *m_websocket, m_info.protocol_version);
 
     if (protocol == "rtt.networktables.first.wpi.edu") {
+      INFO("CONNECTED RTT client (from {})", m_connInfo);
       m_websocket->binary.connect([this](std::span<const uint8_t> data, bool) {
         while (!data.empty()) {
           // decode message
@@ -262,6 +263,11 @@ void NetworkServer::ServerConnection4::ProcessWsUpgrade() {
             });
           }
         }
+      });
+      m_websocket->closed.connect([this](uint16_t, std::string_view reason) {
+        auto realReason = m_wire->GetDisconnectReason();
+        INFO("DISCONNECTED RTT client (from {}): {}", m_connInfo,
+             realReason.empty() ? reason : realReason);
       });
       return;
     }

--- a/ntcore/src/main/native/cpp/NetworkServer.cpp
+++ b/ntcore/src/main/native/cpp/NetworkServer.cpp
@@ -260,7 +260,6 @@ void NetworkServer::ServerConnection4::ProcessWsUpgrade() {
             m_wire->SendBinary([&](auto& os) {
               net::WireEncodeBinary(os, -1, wpi::Now(), value);
             });
-            continue;
           }
         }
       });

--- a/ntcore/src/main/native/cpp/NetworkServer.cpp
+++ b/ntcore/src/main/native/cpp/NetworkServer.cpp
@@ -17,6 +17,7 @@
 #include <wpi/fs.h>
 #include <wpi/mutex.h>
 #include <wpi/raw_ostream.h>
+#include <wpi/timestamp.h>
 #include <wpinet/HttpUtil.h>
 #include <wpinet/HttpWebSocketServerConnection.h>
 #include <wpinet/UrlParser.h>
@@ -28,6 +29,8 @@
 #include "InstanceImpl.h"
 #include "Log.h"
 #include "net/WebSocketConnection.h"
+#include "net/WireDecoder.h"
+#include "net/WireEncoder.h"
 #include "net3/UvStreamConnection3.h"
 
 using namespace nt;
@@ -82,9 +85,10 @@ class NetworkServer::ServerConnection4 final
                     std::string_view addr, unsigned int port,
                     wpi::Logger& logger)
       : ServerConnection{server, addr, port, logger},
-        HttpWebSocketServerConnection(stream,
-                                      {"v4.1.networktables.first.wpi.edu",
-                                       "networktables.first.wpi.edu"}) {
+        HttpWebSocketServerConnection(
+            stream,
+            {"v4.1.networktables.first.wpi.edu", "networktables.first.wpi.edu",
+             "rtt.networktables.first.wpi.edu"}) {
     m_info.protocol_version = 0x0400;
   }
 
@@ -238,6 +242,31 @@ void NetworkServer::ServerConnection4::ProcessWsUpgrade() {
         protocol == "v4.1.networktables.first.wpi.edu" ? 0x0401 : 0x0400;
     m_wire = std::make_shared<net::WebSocketConnection>(
         *m_websocket, m_info.protocol_version);
+
+    if (protocol == "rtt.networktables.first.wpi.edu") {
+      m_websocket->binary.connect([this](std::span<const uint8_t> data, bool) {
+        while (!data.empty()) {
+          // decode message
+          int64_t pubuid;
+          Value value;
+          std::string error;
+          if (!net::WireDecodeBinary(&data, &pubuid, &value, &error, 0)) {
+            m_wire->Disconnect(fmt::format("binary decode error: {}", error));
+            break;
+          }
+
+          // respond to RTT ping
+          if (pubuid == -1) {
+            m_wire->SendBinary([&](auto& os) {
+              net::WireEncodeBinary(os, -1, wpi::Now(), value);
+            });
+            continue;
+          }
+        }
+      });
+      return;
+    }
+
     // TODO: set local flag appropriately
     std::string dedupName;
     std::tie(dedupName, m_clientId) = m_server.m_serverImpl.AddClient(


### PR DESCRIPTION
This is useful for aliveness checking by clients that can't send WebSocket PING messages.