### PR TITLE
[wpimath] Add overloads for Transform2d and Transform3d

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform2d.java
@@ -41,7 +41,8 @@ public class Transform2d {
   }
 
   /**
-   * Constructs a transform with the given x, y, and rotation components.
+   * Constructs a transform with x and y translations instead of a separate
+   * Translation2d.
    *
    * @param x The x component of the translational component of the transform.
    * @param y The y component of the translational component of the transform.

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform2d.java
@@ -41,8 +41,7 @@ public class Transform2d {
   }
 
   /**
-   * Constructs a transform with x and y translations instead of a separate
-   * Translation2d.
+   * Constructs a transform with x and y translations instead of a separate Translation2d.
    *
    * @param x The x component of the translational component of the transform.
    * @param y The y component of the translational component of the transform.

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform2d.java
@@ -47,7 +47,7 @@ public class Transform2d {
    * @param y The y component of the translational component of the transform.
    * @param rotation The rotational component of the transform.
    */
-   public Transform2d(double x, double y, Rotation2d rotation) {
+  public Transform2d(double x, double y, Rotation2d rotation) {
     m_translation = new Translation2d(x, y);
     m_rotation = rotation;
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform2d.java
@@ -40,6 +40,18 @@ public class Transform2d {
     m_rotation = rotation;
   }
 
+  /**
+   * Constructs a transform with the given x, y, and rotation components.
+   * 
+   * @param x The x component of the translational component of the transform.
+   * @param y The y component of the translational component of the transform.
+   * @param rotation The rotational component of the transform.
+   */
+   public Transform2d(double x, double y, Rotation2d rotation) {
+    m_translation = new Translation2d(x, y);
+    m_rotation = rotation;
+  }
+
   /** Constructs the identity transform -- maps an initial pose to itself. */
   public Transform2d() {
     m_translation = new Translation2d();

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform2d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform2d.java
@@ -42,7 +42,7 @@ public class Transform2d {
 
   /**
    * Constructs a transform with the given x, y, and rotation components.
-   * 
+   *
    * @param x The x component of the translational component of the transform.
    * @param y The y component of the translational component of the transform.
    * @param rotation The rotational component of the transform.

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform3d.java
@@ -40,8 +40,9 @@ public class Transform3d {
     m_rotation = rotation;
   }
 
-  /** 
-   * Constructs a transform with the given x, y, z and rotation components.
+  /**
+   * Constructs a transform with x, y, and z translations instead of a separate
+   * Translation3d.
    *
    * @param x The x component of the translational component of the transform.
    * @param y The y component of the translational component of the transform.

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform3d.java
@@ -40,6 +40,18 @@ public class Transform3d {
     m_rotation = rotation;
   }
 
+  /** Constructs a transform with the given x, y, z and rotation components
+   * 
+   * @param x The x component of the translational component of the transform.
+   * @param y The y component of the translational component of the transform.
+   * @param z The z component of the translational component of the transform.
+   * @param rotation The rotational component of the transform.
+   */
+  public Transform3d(double x, double y, double z, Rotation3d rotation) {
+    m_translation = new Translation3d(x, y, z);
+    m_rotation = rotation;
+  }
+
   /** Constructs the identity transform -- maps an initial pose to itself. */
   public Transform3d() {
     m_translation = new Translation3d();

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform3d.java
@@ -41,7 +41,7 @@ public class Transform3d {
   }
 
   /** Constructs a transform with the given x, y, z and rotation components
-   * 
+   *
    * @param x The x component of the translational component of the transform.
    * @param y The y component of the translational component of the transform.
    * @param z The z component of the translational component of the transform.

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform3d.java
@@ -41,8 +41,7 @@ public class Transform3d {
   }
 
   /**
-   * Constructs a transform with x, y, and z translations instead of a separate
-   * Translation3d.
+   * Constructs a transform with x, y, and z translations instead of a separate Translation3d.
    *
    * @param x The x component of the translational component of the transform.
    * @param y The y component of the translational component of the transform.

--- a/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform3d.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/geometry/Transform3d.java
@@ -40,7 +40,8 @@ public class Transform3d {
     m_rotation = rotation;
   }
 
-  /** Constructs a transform with the given x, y, z and rotation components
+  /** 
+   * Constructs a transform with the given x, y, z and rotation components.
    *
    * @param x The x component of the translational component of the transform.
    * @param y The y component of the translational component of the transform.

--- a/wpimath/src/main/native/cpp/geometry/Transform3d.cpp
+++ b/wpimath/src/main/native/cpp/geometry/Transform3d.cpp
@@ -21,6 +21,10 @@ Transform3d::Transform3d(Pose3d initial, Pose3d final) {
 Transform3d::Transform3d(Translation3d translation, Rotation3d rotation)
     : m_translation(std::move(translation)), m_rotation(std::move(rotation)) {}
 
+Transform3d::Transform3d(units::meter_t x, units::meter_t y, units::meter_t z,
+                         Rotation3d rotation)
+    : m_translation(x, y, z), m_rotation(std::move(rotation)) {}
+
 Transform3d Transform3d::Inverse() const {
   // We are rotating the difference between the translations
   // using a clockwise rotation matrix. This transforms the global

--- a/wpimath/src/main/native/include/frc/geometry/Transform2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Transform2d.h
@@ -34,10 +34,11 @@ class WPILIB_DLLEXPORT Transform2d {
   constexpr Transform2d(Translation2d translation, Rotation2d rotation);
 
   /**
-   * Constructs a transform with the given x, y and rotation components.
+   * Constructs a transform with x and y translations instead of a separate
+   * Translation2d.
    *
-   * @param x The x component of the translation.
-   * @param y The y component of the translation.
+   * @param x The x component of the translational component of the transform.
+   * @param y The y component of the translational component of the transform.
    * @param rotation The rotational component of the transform.
    */
   constexpr Transform2d(units::meter_t x, units::meter_t y,

--- a/wpimath/src/main/native/include/frc/geometry/Transform2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Transform2d.h
@@ -38,9 +38,9 @@ class WPILIB_DLLEXPORT Transform2d {
    * 
    * @param x The x component of the translation.
    * @param y The y component of the translation.
-   * @param heading The heading component of the transform.
+   * @param rotation The rotational component of the transform.
    */
-  constexpr Transform2d(units::meter_t x, units::meter_t y, units::degree_t heading);
+  constexpr Transform2d(units::meter_t x, units::meter_t y, Rotation2d rotation);
 
   /**
    * Constructs the identity transform -- maps an initial pose to itself.

--- a/wpimath/src/main/native/include/frc/geometry/Transform2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Transform2d.h
@@ -34,13 +34,14 @@ class WPILIB_DLLEXPORT Transform2d {
   constexpr Transform2d(Translation2d translation, Rotation2d rotation);
 
   /**
-   * Constructs a transform with the given x, y and heading components.
-   * 
+   * Constructs a transform with the given x, y and rotation components.
+   *
    * @param x The x component of the translation.
    * @param y The y component of the translation.
    * @param rotation The rotational component of the transform.
    */
-  constexpr Transform2d(units::meter_t x, units::meter_t y, Rotation2d rotation);
+  constexpr Transform2d(units::meter_t x, units::meter_t y,
+                        Rotation2d rotation);
 
   /**
    * Constructs the identity transform -- maps an initial pose to itself.

--- a/wpimath/src/main/native/include/frc/geometry/Transform2d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Transform2d.h
@@ -34,6 +34,15 @@ class WPILIB_DLLEXPORT Transform2d {
   constexpr Transform2d(Translation2d translation, Rotation2d rotation);
 
   /**
+   * Constructs a transform with the given x, y and heading components.
+   * 
+   * @param x The x component of the translation.
+   * @param y The y component of the translation.
+   * @param heading The heading component of the transform.
+   */
+  constexpr Transform2d(units::meter_t x, units::meter_t y, units::degree_t heading);
+
+  /**
    * Constructs the identity transform -- maps an initial pose to itself.
    */
   constexpr Transform2d() = default;

--- a/wpimath/src/main/native/include/frc/geometry/Transform2d.inc
+++ b/wpimath/src/main/native/include/frc/geometry/Transform2d.inc
@@ -17,8 +17,8 @@ constexpr Transform2d::Transform2d(Translation2d translation,
     : m_translation(std::move(translation)), m_rotation(std::move(rotation)) {}
 
 constexpr Transform2d::Transform2d(units::meter_t x, units::meter_t y,
-                                   units::degree_t heading)
-    : m_translation(x, y), m_rotation(heading)) {}
+                                   Rotation2d rotation)
+    : m_translation(x, y), m_rotation(std::move(rotation))) {}
 
 constexpr Transform2d Transform2d::Inverse() const {
   // We are rotating the difference between the translations

--- a/wpimath/src/main/native/include/frc/geometry/Transform2d.inc
+++ b/wpimath/src/main/native/include/frc/geometry/Transform2d.inc
@@ -18,7 +18,7 @@ constexpr Transform2d::Transform2d(Translation2d translation,
 
 constexpr Transform2d::Transform2d(units::meter_t x, units::meter_t y,
                                    Rotation2d rotation)
-    : m_translation(x, y), m_rotation(std::move(rotation))) {}
+    : m_translation(x, y), m_rotation(std::move(rotation)) {}
 
 constexpr Transform2d Transform2d::Inverse() const {
   // We are rotating the difference between the translations

--- a/wpimath/src/main/native/include/frc/geometry/Transform2d.inc
+++ b/wpimath/src/main/native/include/frc/geometry/Transform2d.inc
@@ -16,6 +16,10 @@ constexpr Transform2d::Transform2d(Translation2d translation,
                                    Rotation2d rotation)
     : m_translation(std::move(translation)), m_rotation(std::move(rotation)) {}
 
+constexpr Transform2d::Transform2d(units::meter_t x, units::meter_t y,
+                                   units::degree_t heading)
+    : m_translation(x, y), m_rotation(heading)) {}
+
 constexpr Transform2d Transform2d::Inverse() const {
   // We are rotating the difference between the translations
   // using a clockwise rotation matrix. This transforms the global

--- a/wpimath/src/main/native/include/frc/geometry/Transform3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Transform3d.h
@@ -34,6 +34,17 @@ class WPILIB_DLLEXPORT Transform3d {
   Transform3d(Translation3d translation, Rotation3d rotation);
 
   /**
+   * Constructs a transform with the given x, y, z and rotation components.
+   * 
+   * @param x The x component of the translation.
+   * @param y The y component of the translation.
+   * @param z The z component of the translation.
+   * @param rotation The rotational component of the transform.
+   */
+  Transform3d(units::meter_t x, units::meter_t y, units::meter_t z,
+              Rotation3d rotation);
+
+  /**
    * Constructs the identity transform -- maps an initial pose to itself.
    */
   constexpr Transform3d() = default;

--- a/wpimath/src/main/native/include/frc/geometry/Transform3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Transform3d.h
@@ -34,11 +34,12 @@ class WPILIB_DLLEXPORT Transform3d {
   Transform3d(Translation3d translation, Rotation3d rotation);
 
   /**
-   * Constructs a transform with the given x, y, z and rotation components.
+   * Constructs a transform with x, y, and z translations instead of a separate
+   * Translation3d.
    *
-   * @param x The x component of the translation.
-   * @param y The y component of the translation.
-   * @param z The z component of the translation.
+   * @param x The x component of the translational component of the transform.
+   * @param y The y component of the translational component of the transform.
+   * @param z The z component of the translational component of the transform.
    * @param rotation The rotational component of the transform.
    */
   Transform3d(units::meter_t x, units::meter_t y, units::meter_t z,

--- a/wpimath/src/main/native/include/frc/geometry/Transform3d.h
+++ b/wpimath/src/main/native/include/frc/geometry/Transform3d.h
@@ -35,7 +35,7 @@ class WPILIB_DLLEXPORT Transform3d {
 
   /**
    * Constructs a transform with the given x, y, z and rotation components.
-   * 
+   *
    * @param x The x component of the translation.
    * @param y The y component of the translation.
    * @param z The z component of the translation.


### PR DESCRIPTION
Adds overloads for Transform2d() constructor to accept x, y, and heading and for Transform3d() to accept x, y, z and rotation as a shorthand for the normal constructors.
Completes issue #5748.