### PR TITLE
[wpiutil] ct_string: Use inline namespace for literals

### DIFF
--- a/wpiutil/src/main/native/include/wpi/ct_string.h
+++ b/wpiutil/src/main/native/include/wpi/ct_string.h
@@ -80,7 +80,7 @@ struct ct_string {
 template <typename Char, size_t M>
 ct_string(Char const (&s)[M]) -> ct_string<Char, std::char_traits<Char>, M - 1>;
 
-namespace literals {
+inline namespace literals {
 template <ct_string S>
 consteval auto operator""_ct_string() {
   return S;


### PR DESCRIPTION
This avoids a conflict with json.