### PR TITLE
[build] Add CMake option to build Java sources jars

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,8 @@ ENDIF("${isSystemDir}" STREQUAL "-1")
 
 # Options for building certain parts of the repo. Everything is built by default.
 option(BUILD_SHARED_LIBS "Build with shared libs (needed for JNI)" ON)
-option(WITH_JAVA "Include java and JNI in the build" ON)
+option(WITH_JAVA "Include Java and JNI in the build" ON)
+option(WITH_JAVA_SOURCE "Build Java source jars" ON)
 option(WITH_CSCORE "Build cscore (needs OpenCV)" ON)
 option(WITH_NTCORE "Build ntcore" ON)
 option(WITH_WPIMATH "Build wpimath" ON)

--- a/README-CMAKE.md
+++ b/README-CMAKE.md
@@ -35,7 +35,7 @@ The following build options are available:
 * `WITH_JAVA` (ON Default)
   * This option will enable Java and JNI builds. If this is on, `WITH_SHARED_LIBS` must be on. Otherwise CMake will error.
 * `WITH_JAVA_SOURCE` (ON Default)
-  * This option will build Java source jars for each enabled Java library. This does not require `WITH_JAVA` to be on, allowing source jars to be built without the compiled jars if desired.
+  * This option will build Java source JARs for each enabled Java library. This does not require `WITH_JAVA` to be on, allowing source JARs to be built without the compiled JARs if desired.
 * `WITH_SHARED_LIBS` (ON Default)
   * This option will cause cmake to build static libraries instead of shared libraries. If this is off, `WITH_JAVA` must be off. Otherwise CMake will error.
 * `WITH_CSCORE` (ON Default)

--- a/README-CMAKE.md
+++ b/README-CMAKE.md
@@ -34,6 +34,8 @@ The following build options are available:
 
 * `WITH_JAVA` (ON Default)
   * This option will enable Java and JNI builds. If this is on, `WITH_SHARED_LIBS` must be on. Otherwise CMake will error.
+* `WITH_JAVA_SOURCE` (ON Default)
+  * This option will build Java source jars for each enabled Java library. This does not require `WITH_JAVA` to be on, allowing source jars to be built without the compiled jars if desired.
 * `WITH_SHARED_LIBS` (ON Default)
   * This option will cause cmake to build static libraries instead of shared libraries. If this is off, `WITH_JAVA` must be off. Otherwise CMake will error.
 * `WITH_CSCORE` (ON Default)

--- a/apriltag/CMakeLists.txt
+++ b/apriltag/CMakeLists.txt
@@ -71,9 +71,9 @@ if (WITH_JAVA_SOURCE)
   include(UseJava)
   file(GLOB APRILTAG_SOURCES src/main/java/edu/wpi/first/apriltag/*.java)
   add_jar(apriltag_src_jar
-    RESOURCES NAMESPACE "edu/wpi/first/apriltag" ${APRILTAG_SOURCES}
-    NAMESPACE "edu/wpi/first/apriltag/jni" src/main/java/edu/wpi/first/apriltag/jni/AprilTagJNI.java
-    OUTPUT_NAME apriltag-sources)
+  RESOURCES NAMESPACE "edu/wpi/first/apriltag" ${APRILTAG_SOURCES}
+  NAMESPACE "edu/wpi/first/apriltag/jni" src/main/java/edu/wpi/first/apriltag/jni/AprilTagJNI.java
+  OUTPUT_NAME apriltag-sources)
 
   get_property(APRILTAG_SRC_JAR_FILE TARGET apriltag_src_jar PROPERTY JAR_FILE)
   install(FILES ${APRILTAG_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")

--- a/apriltag/CMakeLists.txt
+++ b/apriltag/CMakeLists.txt
@@ -66,6 +66,21 @@ if (WITH_JAVA)
 
 endif()
 
+if (WITH_JAVA_SOURCE)
+  find_package(Java REQUIRED)
+  include(UseJava)
+  file(GLOB APRILTAG_SOURCES src/main/java/edu/wpi/first/apriltag/*.java)
+  add_jar(apriltag_src_jar
+    RESOURCES NAMESPACE "edu/wpi/first/apriltag" ${APRILTAG_SOURCES}
+    NAMESPACE "edu/wpi/first/apriltag/jni" src/main/java/edu/wpi/first/apriltag/jni/AprilTagJNI.java
+    OUTPUT_NAME apriltag-sources)
+
+  get_property(APRILTAG_SRC_JAR_FILE TARGET apriltag_src_jar PROPERTY JAR_FILE)
+  install(FILES ${APRILTAG_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
+
+  set_property(TARGET apriltag_src_jar PROPERTY FOLDER "java")
+endif()
+
 generate_resources(src/main/native/resources/edu/wpi/first/apriltag generated/main/cpp APRILTAG frc apriltag_resources_src)
 
 file(GLOB apriltag_native_src src/main/native/cpp/*.cpp)

--- a/cameraserver/CMakeLists.txt
+++ b/cameraserver/CMakeLists.txt
@@ -28,6 +28,22 @@ if (WITH_JAVA)
 
 endif()
 
+if (WITH_JAVA_SOURCE)
+    find_package(Java REQUIRED)
+    include(UseJava)
+    file(GLOB CAMERASERVER_SOURCES src/main/java/edu/wpi/first/cameraserver/*.java)
+    file(GLOB VISION_SOURCES src/main/java/edu/wpi/first/vision/*.java)
+    add_jar(cameraserver_src_jar
+    RESOURCES NAMESPACE "edu/wpi/first/cameraserver" ${CAMERASERVER_SOURCES}
+    NAMESPACE "edu/wpi/first/vision" ${VISION_SOURCES}
+    OUTPUT_NAME cameraserver-sources)
+
+    get_property(CAMERASERVER_SRC_JAR_FILE TARGET cameraserver_src_jar PROPERTY JAR_FILE)
+    install(FILES ${CAMERASERVER_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
+
+    set_property(TARGET cameraserver_src_jar PROPERTY FOLDER "java")
+endif()
+
 file(GLOB_RECURSE
     cameraserver_native_src src/main/native/cpp/*.cpp)
 add_library(cameraserver ${cameraserver_native_src})

--- a/cscore/CMakeLists.txt
+++ b/cscore/CMakeLists.txt
@@ -133,6 +133,22 @@ if (WITH_JAVA)
 
 endif()
 
+if (WITH_JAVA_SOURCE)
+    find_package(Java REQUIRED)
+    include(UseJava)
+    file(GLOB CSCORE_SOURCES src/main/java/edu/wpi/first/cscore/*.java)
+    file(GLOB CSCORE_RAW_SOURCES src/main/java/edu/wpi/first/cscore/raw/*.java)
+    add_jar(cscore_src_jar
+    RESOURCES NAMESPACE "edu/wpi/first/cscore" ${CSCORE_SOURCES}
+    NAMESPACE "edu/wpi/first/cscore/raw" ${CSCORE_RAW_SOURCES}
+    OUTPUT_NAME cscore-sources)
+
+    get_property(CSCORE_SRC_JAR_FILE TARGET cscore_src_jar PROPERTY JAR_FILE)
+    install(FILES ${CSCORE_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
+
+    set_property(TARGET cscore_src_jar PROPERTY FOLDER "java")
+endif()
+
 if (WITH_TESTS)
     wpilib_add_test(cscore src/test/native/cpp)
     target_link_libraries(cscore_test cscore gmock)

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -118,7 +118,7 @@ if (WITH_JAVA_SOURCE)
     file(GLOB HAL_SIMULATION_SOURCES src/main/java/edu/wpi/first/hal/simulation/*.java)
     file(GLOB HAL_UTIL_SOURCES src/main/java/edu/wpi/first/hal/util/*.java)
     add_jar(hal_src_jar
-    RESOURCES NAMESPACE "edu/wpi/first/hal" ${HAL_SOURCES} ${WPILIB_BINARY_DIR}/hal/FRCNetComm.java
+    RESOURCES NAMESPACE "edu/wpi/first/hal" ${HAL_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/FRCNetComm.java
     NAMESPACE "edu/wpi/first/hal/can" ${HAL_CAN_SOURCES}
     NAMESPACE "edu/wpi/first/hal/communication" src/main/java/edu/wpi/first/hal/communication/NIRioStatus.java
     NAMESPACE "edu/wpi/first/hal/simulation" ${HAL_SIMULATION_SOURCES}

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -112,6 +112,27 @@ if (WITH_JAVA)
 
 endif()
 
+if (WITH_JAVA_SOURCE)
+    find_package(Java REQUIRED)
+    include(UseJava)
+    file(GLOB HAL_SOURCES src/main/java/edu/wpi/first/hal/*.java)
+    file(GLOB HAL_CAN_SOURCES src/main/java/edu/wpi/first/hal/can/*.java)
+    file(GLOB HAL_SIMULATION_SOURCES src/main/java/edu/wpi/first/hal/simulation/*.java)
+    file(GLOB HAL_UTIL_SOURCES src/main/java/edu/wpi/first/hal/util/*.java)
+    add_jar(hal_src_jar
+    RESOURCES NAMESPACE "edu/wpi/first/hal" ${HAL_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/FRCNetComm.java
+    NAMESPACE "edu/wpi/first/hal/can" ${HAL_CAN_SOURCES}
+    NAMESPACE "edu/wpi/first/hal/communication" src/main/java/edu/wpi/first/hal/communication/NIRioStatus.java
+    NAMESPACE "edu/wpi/first/hal/simulation" ${HAL_SIMULATION_SOURCES}
+    NAMESPACE "edu/wpi/first/hal/util" ${HAL_UTIL_SOURCES}
+    OUTPUT_NAME wpiHal-sources)
+
+    get_property(HAL_SRC_JAR_FILE TARGET hal_src_jar PROPERTY JAR_FILE)
+    install(FILES ${HAL_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
+
+    set_property(TARGET hal_src_jar PROPERTY FOLDER "java")
+endif()
+
 if (WITH_TESTS)
     wpilib_add_test(hal src/test/native/cpp)
     target_link_libraries(hal_test hal gtest)

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -80,12 +80,10 @@ if (WITH_JAVA)
 
     file(GLOB_RECURSE hal_shared_jni_src src/main/native/cpp/jni/*.cpp)
 
-    file(GLOB_RECURSE JAVA_SOURCES
-        ${CMAKE_CURRENT_BINARY_DIR}/FRCNetComm.java
-        src/main/java/*.java)
+    file(GLOB_RECURSE JAVA_SOURCES src/main/java/*.java)
     set(CMAKE_JNI_TARGET true)
 
-    add_jar(hal_jar ${JAVA_SOURCES} INCLUDE_JARS wpiutil_jar OUTPUT_NAME wpiHal GENERATE_NATIVE_HEADERS hal_jni_headers)
+    add_jar(hal_jar ${JAVA_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/FRCNetComm.java INCLUDE_JARS wpiutil_jar OUTPUT_NAME wpiHal GENERATE_NATIVE_HEADERS hal_jni_headers)
 
     get_property(HAL_JAR_FILE TARGET hal_jar PROPERTY JAR_FILE)
     install(FILES ${HAL_JAR_FILE} DESTINATION "${java_lib_dest}")
@@ -120,7 +118,7 @@ if (WITH_JAVA_SOURCE)
     file(GLOB HAL_SIMULATION_SOURCES src/main/java/edu/wpi/first/hal/simulation/*.java)
     file(GLOB HAL_UTIL_SOURCES src/main/java/edu/wpi/first/hal/util/*.java)
     add_jar(hal_src_jar
-    RESOURCES NAMESPACE "edu/wpi/first/hal" ${HAL_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/FRCNetComm.java
+    RESOURCES NAMESPACE "edu/wpi/first/hal" ${HAL_SOURCES} ${WPILIB_BINARY_DIR}/hal/FRCNetComm.java
     NAMESPACE "edu/wpi/first/hal/can" ${HAL_CAN_SOURCES}
     NAMESPACE "edu/wpi/first/hal/communication" src/main/java/edu/wpi/first/hal/communication/NIRioStatus.java
     NAMESPACE "edu/wpi/first/hal/simulation" ${HAL_SIMULATION_SOURCES}

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -113,12 +113,12 @@ endif()
 if (WITH_JAVA_SOURCE)
     find_package(Java REQUIRED)
     include(UseJava)
-    file(GLOB HAL_SOURCES src/main/java/edu/wpi/first/hal/*.java)
+    file(GLOB HAL_SOURCES src/main/java/edu/wpi/first/hal/*.java ${CMAKE_CURRENT_BINARY_DIR}/FRCNetComm.java)
     file(GLOB HAL_CAN_SOURCES src/main/java/edu/wpi/first/hal/can/*.java)
     file(GLOB HAL_SIMULATION_SOURCES src/main/java/edu/wpi/first/hal/simulation/*.java)
     file(GLOB HAL_UTIL_SOURCES src/main/java/edu/wpi/first/hal/util/*.java)
     add_jar(hal_src_jar
-    RESOURCES NAMESPACE "edu/wpi/first/hal" ${HAL_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/FRCNetComm.java
+    RESOURCES NAMESPACE "edu/wpi/first/hal" ${HAL_SOURCES}
     NAMESPACE "edu/wpi/first/hal/can" ${HAL_CAN_SOURCES}
     NAMESPACE "edu/wpi/first/hal/communication" src/main/java/edu/wpi/first/hal/communication/NIRioStatus.java
     NAMESPACE "edu/wpi/first/hal/simulation" ${HAL_SIMULATION_SOURCES}

--- a/ntcore/CMakeLists.txt
+++ b/ntcore/CMakeLists.txt
@@ -90,6 +90,20 @@ if (WITH_JAVA)
 
 endif()
 
+if (WITH_JAVA_SOURCE)
+    find_package(Java REQUIRED)
+    include(UseJava)
+    file(GLOB NTCORE_SOURCES src/main/java/edu/wpi/first/networktables/*.java ${WPILIB_BINARY_DIR}/ntcore/generated/*.java)
+    add_jar(ntcore_src_jar
+    RESOURCES NAMESPACE "edu/wpi/first/networktables" ${NTCORE_SOURCES}
+    OUTPUT_NAME ntcore-sources)
+
+    get_property(NTCORE_SRC_JAR_FILE TARGET ntcore_src_jar PROPERTY JAR_FILE)
+    install(FILES ${NTCORE_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
+
+    set_property(TARGET ntcore_src_jar PROPERTY FOLDER "java")
+endif()
+
 add_executable(ntcoredev src/dev/native/cpp/main.cpp)
 wpilib_target_warnings(ntcoredev)
 target_link_libraries(ntcoredev ntcore)

--- a/romiVendordep/CMakeLists.txt
+++ b/romiVendordep/CMakeLists.txt
@@ -24,6 +24,20 @@ if (WITH_JAVA)
   endif()
 endif()
 
+if (WITH_JAVA_SOURCE)
+  find_package(Java REQUIRED)
+  include(UseJava)
+  file(GLOB_RECURSE ROMIVENDORDEP_SOURCES src/main/java/*.java)
+  add_jar(romiVendordep_src_jar
+  RESOURCES NAMESPACE "edu/wpi/first/wpilibj/romi" ${ROMIVENDORDEP_SOURCES}
+  OUTPUT_NAME romiVendordep-sources)
+
+  get_property(ROMIVENDORDEP_SRC_JAR_FILE TARGET romiVendordep_src_jar PROPERTY JAR_FILE)
+  install(FILES ${ROMIVENDORDEP_JAR_FILE} DESTINATION "${java_lib_dest}")
+
+  set_property(TARGET romiVendordep_src_jar PROPERTY FOLDER "java")
+endif()
+
 file(GLOB_RECURSE romiVendordep_native_src src/main/native/cpp/*.cpp)
 add_library(romiVendordep ${romiVendordep_native_src})
 set_target_properties(romiVendordep PROPERTIES DEBUG_POSTFIX "d")

--- a/wpilibNewCommands/CMakeLists.txt
+++ b/wpilibNewCommands/CMakeLists.txt
@@ -24,6 +24,22 @@ if (WITH_JAVA)
   endif()
 endif()
 
+if (WITH_JAVA_SOURCE)
+  find_package(Java REQUIRED)
+  include(UseJava)
+  file(GLOB WPILIBNEWCOMMANDS_SOURCES src/main/java/edu/wpi/first/wpilibj2/command/*.java)
+  file(GLOB WPILIBNEWCOMMANDS_BUTTON_SOURCES src/main/java/edu/wpi/first/wpilibj2/command/button*.java)
+  add_jar(wpilibNewCommands_src_jar
+  RESOURCES NAMESPACE "edu/wpi/first/wpilibj2/command" ${WPILIBNEWCOMMANDS_SOURCES}
+  NAMESPACE "edu/wpi/first/wpilibj2/command/button" ${WPILIBNEWCOMMANDS_BUTTON_SOURCES}
+  OUTPUT_NAME wpilibNewCommands-sources)
+
+  get_property(WPILIBNEWCOMMANDS_SRC_JAR_FILE TARGET wpilibNewCommands_src_jar PROPERTY JAR_FILE)
+  install(FILES ${WPILIBNEWCOMMANDS_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
+
+  set_property(TARGET wpilibNewCommands_src_jar PROPERTY FOLDER "java")
+endif()
+
 file(GLOB_RECURSE wpilibNewCommands_native_src src/main/native/cpp/*.cpp)
 add_library(wpilibNewCommands ${wpilibNewCommands_native_src})
 set_target_properties(wpilibNewCommands PROPERTIES DEBUG_POSTFIX "d")

--- a/wpilibj/CMakeLists.txt
+++ b/wpilibj/CMakeLists.txt
@@ -32,3 +32,36 @@ if (WITH_JAVA)
 
     install(FILES wpilibj-config.cmake DESTINATION ${wpilibj_config_dir})
 endif()
+
+if (WITH_JAVA_SOURCES)
+    find_package(Java REQUIRED)
+    include(UseJava)
+    file(GLOB WPILIBJ_SOURCES src/main/java/edu/wpi/first/wpilibj/*.java)
+    file(GLOB WPILIBJ_COUNTER_SOURCES src/main/java/edu/wpi/first/wpilibj/counter/*.java)
+    file(GLOB WPILIBJ_DRIVE_SOURCES src/main/java/edu/wpi/first/wpilibj/drive/*.java)
+    file(GLOB WPILIBJ_EVENT__SOURCES src/main/java/edu/wpi/first/wpilibj/event/*.java)
+    file(GLOB WPILIBJ_INTERFACES_SOURCES src/main/java/edu/wpi/first/wpilibj/interfaces/*.java)
+    file(GLOB WPILIBJ_MOTORCONTROL_SOURCES src/main/java/edu/wpi/first/wpilibj/motorcontrol*.java)
+    file(GLOB WPILIBJ_SHUFFLEBOARD_SOURCES src/main/java/edu/wpi/first/wpilibj/shuffleboard*.java)
+    file(GLOB WPILIBJ_SIMULATION_SOURCES src/main/java/edu/wpi/first/wpilibj/simulation*.java)
+    file(GLOB WPILIBJ_SMARTDASHBOARD_SOURCES src/main/java/edu/wpi/first/wpilibj/*.java)
+    file(GLOB WPILIBJ_UTIL_SOURCES src/main/java/edu/wpi/first/wpilibj/*.java)
+    add_jar(wpilibj_src_jar
+    RESOURCES NAMESPACE "edu/wpi/first/wpilibj" ${WPILIBJ_SOURCES}
+    NAMESPACE "edu/wpi/first/wpilibj/counter" ${WPILIBJ_COUNTER_SOURCES}
+    NAMESPACE "edu/wpi/first/wpilibj/drive" ${WPILIBJ_DRIVE_SOURCES}
+    NAMESPACE "edu/wpi/first/wpilibj/event" ${WPILIBJ_EVENT__SOURCES}
+    NAMESPACE "edu/wpi/first/wpilibj/interfaces" ${WPILIBJ_INTERFACES_SOURCES}
+    NAMESPACE "edu/wpi/first/wpilibj/internal" src/main/java/edu/wpi/first/wpilibj/internal/DriverStationModeThread.java
+    NAMESPACE "edu/wpi/first/wpilibj/livewindow" src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
+    NAMESPACE "edu/wpi/first/wpilibj/motorcontrol" ${WPILIBJ_MOTORCONTROL_SOURCES}
+    NAMESPACE "edu/wpi/first/wpilibj/shuffleboard" ${WPILIBJ_SHUFFLEBOARD_SOURCES}
+    NAMESPACE "edu/wpi/first/wpilibj/simulation" ${WPILIBJ_SIMULATION_SOURCES}
+    NAMESPACE "edu/wpi/first/wpilibj/smartdashboard" ${WPILIBJ_SMARTDASHBOARD_SOURCES}
+    NAMESPACE "edu/wpi/first/wpilibj/util" ${WPILIBJ_UTIL_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/WPILibVersion.java)
+
+    get_property(WPILIBJ_SRC_JAR_FILE TARGET wpilibj_src_jar PROPERTY JAR_FILE)
+    install(FILES ${WPILIBJ_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
+
+    set_property(TARGET wpilibj_src_jar PROPERTY FOLDER "java")
+endif()

--- a/wpilibj/CMakeLists.txt
+++ b/wpilibj/CMakeLists.txt
@@ -33,13 +33,13 @@ if (WITH_JAVA)
     install(FILES wpilibj-config.cmake DESTINATION ${wpilibj_config_dir})
 endif()
 
-if (WITH_JAVA_SOURCES)
+if (WITH_JAVA_SOURCE)
     find_package(Java REQUIRED)
     include(UseJava)
     file(GLOB WPILIBJ_SOURCES src/main/java/edu/wpi/first/wpilibj/*.java)
     file(GLOB WPILIBJ_COUNTER_SOURCES src/main/java/edu/wpi/first/wpilibj/counter/*.java)
     file(GLOB WPILIBJ_DRIVE_SOURCES src/main/java/edu/wpi/first/wpilibj/drive/*.java)
-    file(GLOB WPILIBJ_EVENT__SOURCES src/main/java/edu/wpi/first/wpilibj/event/*.java)
+    file(GLOB WPILIBJ_EVENT_SOURCES src/main/java/edu/wpi/first/wpilibj/event/*.java)
     file(GLOB WPILIBJ_INTERFACES_SOURCES src/main/java/edu/wpi/first/wpilibj/interfaces/*.java)
     file(GLOB WPILIBJ_MOTORCONTROL_SOURCES src/main/java/edu/wpi/first/wpilibj/motorcontrol*.java)
     file(GLOB WPILIBJ_SHUFFLEBOARD_SOURCES src/main/java/edu/wpi/first/wpilibj/shuffleboard*.java)
@@ -50,7 +50,7 @@ if (WITH_JAVA_SOURCES)
     RESOURCES NAMESPACE "edu/wpi/first/wpilibj" ${WPILIBJ_SOURCES}
     NAMESPACE "edu/wpi/first/wpilibj/counter" ${WPILIBJ_COUNTER_SOURCES}
     NAMESPACE "edu/wpi/first/wpilibj/drive" ${WPILIBJ_DRIVE_SOURCES}
-    NAMESPACE "edu/wpi/first/wpilibj/event" ${WPILIBJ_EVENT__SOURCES}
+    NAMESPACE "edu/wpi/first/wpilibj/event" ${WPILIBJ_EVENT_SOURCES}
     NAMESPACE "edu/wpi/first/wpilibj/interfaces" ${WPILIBJ_INTERFACES_SOURCES}
     NAMESPACE "edu/wpi/first/wpilibj/internal" src/main/java/edu/wpi/first/wpilibj/internal/DriverStationModeThread.java
     NAMESPACE "edu/wpi/first/wpilibj/livewindow" src/main/java/edu/wpi/first/wpilibj/livewindow/LiveWindow.java
@@ -58,7 +58,8 @@ if (WITH_JAVA_SOURCES)
     NAMESPACE "edu/wpi/first/wpilibj/shuffleboard" ${WPILIBJ_SHUFFLEBOARD_SOURCES}
     NAMESPACE "edu/wpi/first/wpilibj/simulation" ${WPILIBJ_SIMULATION_SOURCES}
     NAMESPACE "edu/wpi/first/wpilibj/smartdashboard" ${WPILIBJ_SMARTDASHBOARD_SOURCES}
-    NAMESPACE "edu/wpi/first/wpilibj/util" ${WPILIBJ_UTIL_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/WPILibVersion.java)
+    NAMESPACE "edu/wpi/first/wpilibj/util" ${WPILIBJ_UTIL_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/WPILibVersion.java
+    OUTPUT_NAME wpilibj-sources)
 
     get_property(WPILIBJ_SRC_JAR_FILE TARGET wpilibj_src_jar PROPERTY JAR_FILE)
     install(FILES ${WPILIBJ_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")

--- a/wpilibj/CMakeLists.txt
+++ b/wpilibj/CMakeLists.txt
@@ -45,7 +45,7 @@ if (WITH_JAVA_SOURCE)
     file(GLOB WPILIBJ_SHUFFLEBOARD_SOURCES src/main/java/edu/wpi/first/wpilibj/shuffleboard*.java)
     file(GLOB WPILIBJ_SIMULATION_SOURCES src/main/java/edu/wpi/first/wpilibj/simulation*.java)
     file(GLOB WPILIBJ_SMARTDASHBOARD_SOURCES src/main/java/edu/wpi/first/wpilibj/*.java)
-    file(GLOB WPILIBJ_UTIL_SOURCES src/main/java/edu/wpi/first/wpilibj/*.java)
+    file(GLOB WPILIBJ_UTIL_SOURCES src/main/java/edu/wpi/first/wpilibj/*.java ${CMAKE_CURRENT_BINARY_DIR}/WPILibVersion.java)
     add_jar(wpilibj_src_jar
     RESOURCES NAMESPACE "edu/wpi/first/wpilibj" ${WPILIBJ_SOURCES}
     NAMESPACE "edu/wpi/first/wpilibj/counter" ${WPILIBJ_COUNTER_SOURCES}
@@ -58,7 +58,7 @@ if (WITH_JAVA_SOURCE)
     NAMESPACE "edu/wpi/first/wpilibj/shuffleboard" ${WPILIBJ_SHUFFLEBOARD_SOURCES}
     NAMESPACE "edu/wpi/first/wpilibj/simulation" ${WPILIBJ_SIMULATION_SOURCES}
     NAMESPACE "edu/wpi/first/wpilibj/smartdashboard" ${WPILIBJ_SMARTDASHBOARD_SOURCES}
-    NAMESPACE "edu/wpi/first/wpilibj/util" ${WPILIBJ_UTIL_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/WPILibVersion.java
+    NAMESPACE "edu/wpi/first/wpilibj/util" ${WPILIBJ_UTIL_SOURCES}
     OUTPUT_NAME wpilibj-sources)
 
     get_property(WPILIBJ_SRC_JAR_FILE TARGET wpilibj_src_jar PROPERTY JAR_FILE)

--- a/wpimath/CMakeLists.txt
+++ b/wpimath/CMakeLists.txt
@@ -136,9 +136,9 @@ if (WITH_JAVA_SOURCE)
   file(GLOB WPIMATH_ESTIMATOR_SOURCES src/main/java/edu/wpi/first/math/estimator/*.java)
   file(GLOB WPIMATH_FILTER_SOURCES src/main/java/edu/wpi/first/math/filter/*.java)
   file(GLOB WPIMATH_GEOMETRY_SOURCES src/main/java/edu/wpi/first/math/geometry/*.java)
-  file(GLOB WPIMATH_INTERPOLATIoN_SOURCES src/main/java/edu/wpi/first/math/interpolation/*.java)
+  file(GLOB WPIMATH_INTERPOLATION_SOURCES src/main/java/edu/wpi/first/math/interpolation/*.java)
   file(GLOB WPIMATH_KINEMATICS_SOURCES src/main/java/edu/wpi/first/math/kinematics/*.java)
-  file(GLOB WPIMATH_NUMBERS_SOURCES ${WPILIB_BINARY_DIR}/wpimath/generated/main/java/edu/wpi/first/math/numbers)
+  file(GLOB WPIMATH_NUMBERS_SOURCES ${WPILIB_BINARY_DIR}/wpimath/generated/main/java/edu/wpi/first/math/numbers/*.java)
   file(GLOB WPIMATH_SPLINE_SOURCES src/main/java/edu/wpi/first/math/spline/*.java)
   file(GLOB WPIMATH_SYSTEM_SOURCES src/main/java/edu/wpi/first/math/system/*.java)
   file(GLOB WPIMATH_SYSTEM_PLANT_SOURCES src/main/java/edu/wpi/first/math/system/plant/*.java)
@@ -150,7 +150,7 @@ if (WITH_JAVA_SOURCE)
   NAMESPACE "edu/wpi/first/math/estimator" ${WPIMATH_ESTIMATOR_SOURCES}
   NAMESPACE "edu/wpi/first/math/filter" ${WPIMATH_FILTER_SOURCES}
   NAMESPACE "edu/wpi/first/math/geometry" ${WPIMATH_GEOMETRY_SOURCES}
-  NAMESPACE "edu/wpi/first/math/interpolation" ${WPIMATH_INTERPOLATIoN_SOURCES}
+  NAMESPACE "edu/wpi/first/math/interpolation" ${WPIMATH_INTERPOLATION_SOURCES}
   NAMESPACE "edu/wpi/first/math/kinematics" ${WPIMATH_KINEMATICS_SOURCES}
   NAMESPACE "edu/wpi/first/math/spline" ${WPIMATH_SPLINE_SOURCES}
   NAMESPACE "edu/wpi/first/math/system" ${WPIMATH_SYSTEM_SOURCES}

--- a/wpimath/CMakeLists.txt
+++ b/wpimath/CMakeLists.txt
@@ -128,6 +128,44 @@ if (WITH_JAVA)
 
 endif()
 
+if (WITH_JAVA_SOURCE)
+  find_package(Java REQUIRED)
+  include(UseJava)
+  file(GLOB WPIMATH_SOURCES src/main/java/edu/wpi/first/math/*.java ${WPILIB_BINARY_DIR}/wpimath/generated/main/java/edu/wpi/first/math/Nat.java)
+  file(GLOB WPIMATH_CONTROLLER_SOURCES src/main/java/edu/wpi/first/math/controller/*.java)
+  file(GLOB WPIMATH_ESTIMATOR_SOURCES src/main/java/edu/wpi/first/math/estimator/*.java)
+  file(GLOB WPIMATH_FILTER_SOURCES src/main/java/edu/wpi/first/math/filter/*.java)
+  file(GLOB WPIMATH_GEOMETRY_SOURCES src/main/java/edu/wpi/first/math/geometry/*.java)
+  file(GLOB WPIMATH_INTERPOLATIoN_SOURCES src/main/java/edu/wpi/first/math/interpolation/*.java)
+  file(GLOB WPIMATH_KINEMATICS_SOURCES src/main/java/edu/wpi/first/math/kinematics/*.java)
+  file(GLOB WPIMATH_NUMBERS_SOURCES ${WPILIB_BINARY_DIR}/wpimath/generated/main/java/edu/wpi/first/math/numbers)
+  file(GLOB WPIMATH_SPLINE_SOURCES src/main/java/edu/wpi/first/math/spline/*.java)
+  file(GLOB WPIMATH_SYSTEM_SOURCES src/main/java/edu/wpi/first/math/system/*.java)
+  file(GLOB WPIMATH_SYSTEM_PLANT_SOURCES src/main/java/edu/wpi/first/math/system/plant/*.java)
+  file(GLOB WPIMATH_TRAJECTORY_SOURCES src/main/java/edu/wpi/first/math/trajectory/*.java)
+  file(GLOB WPIMATH_TRAJECTORY_CONSTRAINT_SOURCES src/main/java/edu/wpi/first/math/trajectory/constraint/*.java)
+  add_jar(wpimath_src_jar
+  RESOURCES NAMESPACE "edu/wpi/first/math" ${WPIMATH_SOURCES}
+  NAMESPACE "edu/wpi/first/math/controller" ${WPIMATH_CONTROLLER_SOURCES}
+  NAMESPACE "edu/wpi/first/math/estimator" ${WPIMATH_ESTIMATOR_SOURCES}
+  NAMESPACE "edu/wpi/first/math/filter" ${WPIMATH_FILTER_SOURCES}
+  NAMESPACE "edu/wpi/first/math/geometry" ${WPIMATH_GEOMETRY_SOURCES}
+  NAMESPACE "edu/wpi/first/math/interpolation" ${WPIMATH_INTERPOLATIoN_SOURCES}
+  NAMESPACE "edu/wpi/first/math/kinematics" ${WPIMATH_KINEMATICS_SOURCES}
+  NAMESPACE "edu/wpi/first/math/spline" ${WPIMATH_SPLINE_SOURCES}
+  NAMESPACE "edu/wpi/first/math/system" ${WPIMATH_SYSTEM_SOURCES}
+  NAMESPACE "edu/wpi/first/math/system/plant" ${WPIMATH_SYSTEM_PLANT_SOURCES}
+  NAMESPACE "edu/wpi/first/math/trajectory" ${WPIMATH_TRAJECTORY_SOURCES}
+  NAMESPACE "edu/wpi/first/math/trajectory/constraint" ${WPIMATH_TRAJECTORY_CONSTRAINT_SOURCES}
+  NAMESPACE "edu/wpi/first/math/util" src/main/java/edu/wpi/first/math/util/Units.java
+  OUTPUT_NAME wpimath-sources)
+
+  get_property(WPIMATH_SRC_JAR_FILE TARGET wpimath_src_jar PROPERTY JAR_FILE)
+  install(FILES ${WPIMATH_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
+
+  set_property(TARGET wpimath_src_jar PROPERTY FOLDER "java")
+endif()
+
 file(GLOB_RECURSE wpimath_native_src src/main/native/cpp/*.cpp)
 list(REMOVE_ITEM wpimath_native_src ${wpimath_jni_src})
 

--- a/wpinet/CMakeLists.txt
+++ b/wpinet/CMakeLists.txt
@@ -38,6 +38,20 @@ if (WITH_JAVA)
 
 endif()
 
+if (WITH_JAVA_SOURCE)
+  find_package(Java REQUIRED)
+  include(UseJava)
+  file(GLOB WPINET_SOURCES src/main/java/edu/wpi/first/net/*.java)
+  add_jar(wpinet_src_jar
+  RESOURCES NAMESPACE "edu/wpi/first/net" ${WPINET_SOURCES}
+  OUTPUT_NAME wpinet-sources)
+
+  get_property(WPINET_SRC_JAR_FILE TARGET wpinet_src_jar PROPERTY JAR_FILE)
+  install(FILES ${WPINET_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
+
+  set_property(TARGET wpinet_src_jar PROPERTY FOLDER "java")
+endif()
+
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 

--- a/wpiutil/CMakeLists.txt
+++ b/wpiutil/CMakeLists.txt
@@ -74,6 +74,30 @@ if (WITH_JAVA)
 
 endif()
 
+if (WITH_JAVA_SOURCE)
+  find_package(Java REQUIRED)
+  include(UseJava)
+  file(GLOB WPIUTIL_SOURCES src/main/java/edu/wpi/first/util/*.java)
+  file(GLOB WPIUTIL_CLEANUP_SOURCES src/main/java/edu/wpi/first/util/cleanup/*.java)
+  file(GLOB WPIUTIL_CONCURRENT_SOURCES src/main/java/edu/wpi/first/util/concurrent/*.java)
+  file(GLOB WPIUTIL_DATALOG_SOURCES src/main/java/edu/wpi/first/util/datalog/*.java)
+  file(GLOB WPIUTIL_FUNCTION_SOURCES src/main/java/edu/wpi/first/util/function/*.java)
+  file(GLOB WPIUTIL_SENDABLE_SOURCES src/main/java/edu/wpi/first/util/sendable/*.java)
+  add_jar(wpiutil_src_jar
+  RESOURCES NAMESPACE "edu/wpi/first/util" ${WPIUTIL_SOURCES}
+  NAMESPACE "edu/wpi/first/util/cleanup" ${WPIUTIL_CLEANUP_SOURCES}
+  NAMESPACE "edu/wpi/first/util/concurrent" ${WPIUTIL_CONCURRENT_SOURCES}
+  NAMESPACE "edu/wpi/first/util/datalog" ${WPIUTIL_DATALOG_SOURCES}
+  NAMESPACE "edu/wpi/first/util/function" ${WPIUTIL_FUNCTION_SOURCES}
+  NAMESPACE "edu/wpi/first/util/sendable" ${WPIUTIL_SENDABLE_SOURCES}
+  OUTPUT_NAME wpiutil-sources)
+
+  get_property(WPIUTIL_SRC_JAR_FILE TARGET wpiutil_src_jar PROPERTY JAR_FILE)
+  install(FILES ${WPIUTIL_SRC_JAR_FILE} DESTINATION "${java_lib_dest}")
+
+  set_property(TARGET wpiutil_src_jar PROPERTY FOLDER "java")
+endif()
+
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 

--- a/xrpVendordep/CMakeLists.txt
+++ b/xrpVendordep/CMakeLists.txt
@@ -24,6 +24,20 @@ if (WITH_JAVA)
   endif()
 endif()
 
+if (WITH_JAVA_SOURCE)
+  find_package(Java REQUIRED)
+  include(UseJava)
+  file(GLOB XRPVENDORDEP_SOURCES src/main/java/edu/wpi/first/wpilibj/xrp/*.java)
+  add_jar(xrpVendordep_src_jar
+  RESOURCES NAMESPACE "edu/wpi/first/wpilibj/xrp" ${XRPVENDORDEP_SOURCES}
+  OUTPUT_NAME xrpVendordep-sources)
+
+  get_property(xrpVendordep_src_JAR_FILE TARGET xrpVendordep_src_jar PROPERTY JAR_FILE)
+  install(FILES ${xrpVendordep_src_JAR_FILE} DESTINATION "${java_lib_dest}")
+
+  set_property(TARGET xrpVendordep_src_jar PROPERTY FOLDER "java")
+endif()
+
 file(GLOB_RECURSE xrpVendordep_native_src src/main/native/cpp/*.cpp)
 add_library(xrpVendordep ${xrpVendordep_native_src})
 set_target_properties(xrpVendordep PROPERTIES DEBUG_POSTFIX "d")


### PR DESCRIPTION
I built it twice this time and it doesn't complain about a duplicate class. The fix had nothing to do with the source jars, but with the HAL jar itself. When I noticed the error came from building the compiled jar, I confirmed it when building the HAL source jar target worked perfectly fine, but building the actual compiled HAL jar failed. The fix was to include `FRCNetComm.java` directly in `add_jar` instead of globbing it with the other Java files. This is actually how wpilibj includes its version file, and explains why I never saw wpilibj fail in my testing.
Some additional fixes are included to fix things that I missed the first time.

Also, is there some sort of styleguide/formatter for CMakeLists? They're a mix of 2/4 spaces, and spacing seems inconsistent in other areas.