### PR TITLE
[docs] Add jinja2 to CMake prerequisites

### DIFF
--- a/README-CMAKE.md
+++ b/README-CMAKE.md
@@ -18,9 +18,11 @@ By default, all libraries except for the HAL and WPILib get built with a default
 
 ## Prerequisites
 
-The most common prerequisite is going to be OpenCV. OpenCV needs to be findable by CMake. On systems like the Jetson, this is installed by default. Otherwise, you will need to build OpenCV from source and install it.
+The jinja2 pip package is needed to generate classes for NT4's pubsub.
 
-In addition, if you want JNI and Java, you will need a JDK of at least version 11 installed. In addition, you need a `JAVA_HOME` environment variable set properly and set to the JDK directory.
+OpenCV needs to be findable by CMake. On systems like the Jetson, this is installed by default. Otherwise, you will need to build OpenCV from source and install it.
+
+If you want JNI and Java, you will need a JDK of at least version 11 installed. In addition, you need a `JAVA_HOME` environment variable set properly and set to the JDK directory.
 
 If you are building with unit tests or simulation modules, you will also need an Internet connection for the initial setup process, as CMake will clone google-test and imgui from GitHub.
 


### PR DESCRIPTION
Fixes #5769.