### PR TITLE
Add requirements parameter to Commands.idle()

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -28,10 +28,11 @@ public final class Commands {
   /**
    * Constructs a command that does nothing until interrupted.
    *
+   * @param requirements Subsystems to require
    * @return the command
    */
-  public static Command idle() {
-    return run(() -> {});
+  public static Command idle(Subsystem... requirements) {
+    return run(() -> {}, requirements);
   }
 
   // Action Commands

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
@@ -25,8 +25,8 @@ CommandPtr cmd::None() {
   return InstantCommand().ToPtr();
 }
 
-CommandPtr cmd::Idle() {
-  return Run([] {});
+CommandPtr cmd::Idle(Requirements requirements) {
+  return Run([] {}, requirements);
 }
 
 CommandPtr cmd::RunOnce(std::function<void()> action,

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -33,10 +33,11 @@ CommandPtr None();
 /**
  * Constructs a command that does nothing until interrupted.
  *
+ * @param requirements Subsystems to require
  * @return the command
  */
 [[nodiscard]]
-CommandPtr Idle();
+CommandPtr Idle(Requirements requirements = {});
 
 // Action Commands
 


### PR DESCRIPTION
A command explicitly doing nothing and reserving a subsystem is a valid use, imo. It doesn't necessarily need to be inside a composition.