### PR TITLE
[wpinet] uv::Stream::TryWrite(): Return 0 on EAGAIN

### DIFF
--- a/wpinet/src/main/native/cpp/uv/Stream.cpp
+++ b/wpinet/src/main/native/cpp/uv/Stream.cpp
@@ -114,7 +114,7 @@ int Stream::TryWrite(std::span<const Buffer> bufs) {
     return UV_ECANCELED;
   }
   int val = uv_try_write(GetRawStream(), bufs.data(), bufs.size());
-  if (val < 0) {
+  if (val < 0 && val != UV_EAGAIN) {
     this->ReportError(val);
     return val;
   }
@@ -127,7 +127,7 @@ int Stream::TryWrite2(std::span<const Buffer> bufs, Stream& send) {
   }
   int val = uv_try_write2(GetRawStream(), bufs.data(), bufs.size(),
                           send.GetRawStream());
-  if (val < 0) {
+  if (val < 0 && val != UV_EAGAIN) {
     this->ReportError(val);
     return val;
   }

--- a/wpinet/src/main/native/cpp/uv/Stream.cpp
+++ b/wpinet/src/main/native/cpp/uv/Stream.cpp
@@ -114,7 +114,10 @@ int Stream::TryWrite(std::span<const Buffer> bufs) {
     return UV_ECANCELED;
   }
   int val = uv_try_write(GetRawStream(), bufs.data(), bufs.size());
-  if (val < 0 && val != UV_EAGAIN) {
+  if (val == UV_EAGAIN) {
+    return 0;
+  }
+  if (val < 0) {
     this->ReportError(val);
     return val;
   }
@@ -127,7 +130,10 @@ int Stream::TryWrite2(std::span<const Buffer> bufs, Stream& send) {
   }
   int val = uv_try_write2(GetRawStream(), bufs.data(), bufs.size(),
                           send.GetRawStream());
-  if (val < 0 && val != UV_EAGAIN) {
+  if (val == UV_EAGAIN) {
+    return 0;
+  }
+  if (val < 0) {
     this->ReportError(val);
     return val;
   }


### PR DESCRIPTION
In the TryWrite case, EAGAIN is a normal return value, but we want to just map it to 0 rather than handling it as an error.