### PR TITLE
Remove extra semicolon in RoboRioData

### DIFF
--- a/hal/src/main/native/athena/mockdata/RoboRioData.cpp
+++ b/hal/src/main/native/athena/mockdata/RoboRioData.cpp
@@ -29,7 +29,7 @@ DEFINE_CAPI(int32_t, UserFaults5V, 0)
 DEFINE_CAPI(int32_t, UserFaults3V3, 0)
 DEFINE_CAPI(double, BrownoutVoltage, 6.75)
 DEFINE_CAPI(double, CPUTemp, 45.0)
-DEFINE_CAPI(int32_t, TeamNumber, 0);
+DEFINE_CAPI(int32_t, TeamNumber, 0)
 
 int32_t HALSIM_RegisterRoboRioSerialNumberCallback(
     HAL_RoboRioStringCallback callback, void* param, HAL_Bool initialNotify) {


### PR DESCRIPTION
Sometimes the compiler would throw an error about this, but it's inconsistent about that. Regardless, none of the other macros have a semicolon at the end.