### PR TITLE
[ntcore] Fix crash on disconnect

### DIFF
--- a/ntcore/src/main/native/cpp/net/NetworkOutgoingQueue.h
+++ b/ntcore/src/main/native/cpp/net/NetworkOutgoingQueue.h
@@ -280,9 +280,15 @@ void NetworkOutgoingQueue<MessageType>::SendOutgoing(uint64_t curTimeMs,
         });
       }
     }
+    if (unsent < 0) {
+      return;  // error
+    }
     if (unsent == 0) {
       // finish writing any partial buffers
       unsent = m_wire.Flush();
+      if (unsent < 0) {
+        return;  // error
+      }
     }
     int delta = it - msgs.begin() - unsent;
     for (auto&& msg : std::span{msgs}.subspan(0, delta)) {

--- a/ntcore/src/main/native/cpp/net/ServerImpl.cpp
+++ b/ntcore/src/main/native/cpp/net/ServerImpl.cpp
@@ -524,6 +524,9 @@ void ServerImpl::ClientData4::SendAnnounce(TopicData* topic,
       WireEncodeAnnounce(os, topic->name, topic->id, topic->typeStr,
                          topic->properties, pubuid);
     });
+    if (unsent < 0) {
+      return;  // error
+    }
     if (unsent == 0 && m_wire.Flush() == 0) {
       return;
     }
@@ -544,6 +547,9 @@ void ServerImpl::ClientData4::SendUnannounce(TopicData* topic) {
   if (m_local) {
     int unsent = m_wire.WriteText(
         [&](auto& os) { WireEncodeUnannounce(os, topic->name, topic->id); });
+    if (unsent < 0) {
+      return;  // error
+    }
     if (unsent == 0 && m_wire.Flush() == 0) {
       return;
     }
@@ -565,6 +571,9 @@ void ServerImpl::ClientData4::SendPropertiesUpdate(TopicData* topic,
     int unsent = m_wire.WriteText([&](auto& os) {
       WireEncodePropertiesUpdate(os, topic->name, update, ack);
     });
+    if (unsent < 0) {
+      return;  // error
+    }
     if (unsent == 0 && m_wire.Flush() == 0) {
       return;
     }

--- a/ntcore/src/main/native/cpp/net/WebSocketConnection.cpp
+++ b/ntcore/src/main/native/cpp/net/WebSocketConnection.cpp
@@ -186,7 +186,8 @@ int WebSocketConnection::Flush() {
   m_ws_frames.reserve(m_frames.size());
   for (auto&& frame : m_frames) {
     m_ws_frames.emplace_back(
-        frame.opcode, std::span{&m_bufs[frame.start], &m_bufs[frame.end]});
+        frame.opcode,
+        std::span{m_bufs}.subspan(frame.start, frame.end - frame.start));
   }
 
   auto unsentFrames = m_ws.TrySendFrames(


### PR DESCRIPTION
The object was being destroyed in the middle of a send due to the error handling path closing the connection. Instead, defer to the next loop cycle using a one-shot timer.

Properly handle error return values from Send functions.

Fix UB in accessing one past the end of a vector.