### PR TITLE
[wpilib] Counter: fix default distance per pulse, give c++ parity

### DIFF
--- a/wpilibc/src/main/native/cpp/Counter.cpp
+++ b/wpilibc/src/main/native/cpp/Counter.cpp
@@ -260,6 +260,18 @@ int Counter::GetFPGAIndex() const {
   return m_index;
 }
 
+void Counter::SetDistancePerPulse(double distancePerPulse) {
+  m_distancePerPulse = distancePerPulse;
+}
+
+double Counter::GetDistance() const {
+  return Get() * m_distancePerPulse;
+}
+
+double Counter::GetRate() const {
+  return m_distancePerPulse / GetPeriod().value();
+}
+
 int Counter::Get() const {
   int32_t status = 0;
   int value = HAL_GetCounter(m_counter, &status);

--- a/wpilibc/src/main/native/include/frc/Counter.h
+++ b/wpilibc/src/main/native/include/frc/Counter.h
@@ -343,6 +343,34 @@ class Counter : public CounterBase,
 
   int GetFPGAIndex() const;
 
+  /**
+   * Set the distance per pulse for this counter. This sets the multiplier used
+   * to determine the distance driven based on the count value from the encoder.
+   * Set this value based on the Pulses per Revolution and factor in any gearing
+   * reductions. This distance can be in any units you like, linear or angular.
+   *
+   * @param distancePerPulse The scale factor that will be used to convert
+   * pulses to useful units.
+   */
+  void SetDistancePerPulse(double distancePerPulse);
+
+  /**
+   * Read the current scaled counter value. Read the value at this instant,
+   * scaled by the distance per pulse (defaults to 1).
+   *
+   * @return The distance since the last reset
+   */
+  double GetDistance() const;
+
+  /**
+   * Get the current rate of the Counter. Read the current rate of the counter
+   * accounting for the distance per pulse value. The default value for distance
+   * per pulse (1) yields units of pulses per second.
+   *
+   * @return The rate in units/sec
+   */
+  double GetRate() const;
+
   // CounterBase interface
   /**
    * Read the current counter value.
@@ -434,6 +462,7 @@ class Counter : public CounterBase,
 
  private:
   int m_index = 0;  // The index of this counter.
+  double m_distancePerPulse = 1;
 
   friend class DigitalGlitchFilter;
 };

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Counter.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Counter.java
@@ -51,7 +51,7 @@ public class Counter implements CounterBase, Sendable, AutoCloseable {
   private boolean m_allocatedDownSource;
   int m_counter; // /< The FPGA counter object.
   private int m_index; // /< The index of this counter.
-  private double m_distancePerPulse; // distance of travel for each tick
+  private double m_distancePerPulse = 1; // distance of travel for each tick
 
   /**
    * Create an instance of a counter with the given mode.


### PR DESCRIPTION
default distance per pulse in java was 0 instead of 1
C++ didn't have that functionality at all.