### PR TITLE
[wpiutil] Fix Java struct array unpacking

### DIFF
--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/StructBuffer.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/StructBuffer.java
@@ -211,7 +211,7 @@ public final class StructBuffer<T> {
     }
     int nelem = len / m_structSize;
     @SuppressWarnings("unchecked")
-    T[] arr = (T[]) Array.newInstance(m_struct.getClass(), nelem);
+    T[] arr = (T[]) Array.newInstance(m_struct.getTypeClass(), nelem);
     for (int i = 0; i < nelem; i++) {
       arr[i] = m_struct.unpack(buf);
     }


### PR DESCRIPTION
`readArray` throws an `ArrayStoreException` because the class of the struct (`Struct<T>`) doesn't match the decoded type (`T`). Using `getTypeClass()` instead of `getClass()` fixes the issue.