### PR TITLE
Fix compilation of MathExtras.h on Windows with /sdl

### DIFF
--- a/upstream_utils/llvm_patches/0032-Fix-compilation-of-MathExtras.h-on-Windows-with-sdl.patch
+++ b/upstream_utils/llvm_patches/0032-Fix-compilation-of-MathExtras.h-on-Windows-with-sdl.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benjamin Hall <bhallctre@gmail.com>
+Date: Mon, 23 Oct 2023 21:36:40 -0400
+Subject: [PATCH 32/32] Fix compilation of MathExtras.h on Windows with /sdl
+
+See https://github.com/llvm/llvm-project/pull/68978
+---
+ llvm/include/llvm/Support/MathExtras.h | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/llvm/include/llvm/Support/MathExtras.h b/llvm/include/llvm/Support/MathExtras.h
+index 5f034b694989d8ef24e0b249abd12a5c20146b97..03db6e4d92cb3b62ac3d8b3cbd97783817c6326b 100644
+--- a/llvm/include/llvm/Support/MathExtras.h
++++ b/llvm/include/llvm/Support/MathExtras.h
+@@ -356,7 +356,10 @@ inline uint64_t alignTo(uint64_t Value, uint64_t Align) {
+ inline uint64_t alignToPowerOf2(uint64_t Value, uint64_t Align) {
+   assert(Align != 0 && (Align & (Align - 1)) == 0 &&
+          "Align must be a power of 2");
+-  return (Value + Align - 1) & -Align;
++  // Replace unary minus to avoid compilation error on Windows:
++  // "unary minus operator applied to unsigned type, result still unsigned"
++  uint64_t negAlign = (~Align) + 1;
++  return (Value + Align - 1) & negAlign;
+ }
+ 
+ /// If non-zero \p Skew is specified, the return value will be a minimal integer

--- a/upstream_utils/update_llvm.py
+++ b/upstream_utils/update_llvm.py
@@ -209,6 +209,7 @@ def main():
         "0029-Use-C-20-bit-header.patch",
         "0030-Remove-DenseMap-GTest-printer-test.patch",
         "0031-Replace-deprecated-std-aligned_storage_t.patch",
+        "0032-Fix-compilation-of-MathExtras.h-on-Windows-with-sdl.patch",
     ]:
         git_am(
             os.path.join(wpilib_root, "upstream_utils/llvm_patches", f),

--- a/wpiutil/src/main/native/thirdparty/llvm/include/wpi/MathExtras.h
+++ b/wpiutil/src/main/native/thirdparty/llvm/include/wpi/MathExtras.h
@@ -356,7 +356,10 @@ inline uint64_t alignTo(uint64_t Value, uint64_t Align) {
 inline uint64_t alignToPowerOf2(uint64_t Value, uint64_t Align) {
   assert(Align != 0 && (Align & (Align - 1)) == 0 &&
          "Align must be a power of 2");
-  return (Value + Align - 1) & -Align;
+  // Replace unary minus to avoid compilation error on Windows:
+  // "unary minus operator applied to unsigned type, result still unsigned"
+  uint64_t negAlign = (~Align) + 1;
+  return (Value + Align - 1) & negAlign;
 }
 
 /// If non-zero \p Skew is specified, the return value will be a minimal integer


### PR DESCRIPTION
On Windows, compilation fails with [error C4146](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146?view=msvc-170) on the MathExtras.h header when using the /sdl compiler flag. Since unary minus performs two's complement, it is equivalent to performing ones' complement (bitwise NOT) on the unsigned number and adding one.

This fix was copied from the LLVM main branch: https://github.com/llvm/llvm-project/pull/68978