### PR TITLE
[simulation] Autodisable the robot program if the DS is not connected

### DIFF
--- a/simulation/halsim_ds_socket/src/main/native/cpp/DSCommPacket.cpp
+++ b/simulation/halsim_ds_socket/src/main/native/cpp/DSCommPacket.cpp
@@ -146,7 +146,9 @@ void DSCommPacket::DecodeUDP(std::span<const uint8_t> packet) {
   m_lo = packet[1];
   // Comm Version is packet 2, ignore
   SetControl(packet[3], packet[4]);
-  SetAlliance(packet[5]);
+  // DS sends values 0, 1, and 2 for Red, but kUnknown is 0, so the value needs
+  // to be offset by one
+  SetAlliance(packet[5] + 1);
 
   // Return if packet finished
   if (packet.size() == 6) {

--- a/simulation/halsim_ds_socket/src/main/native/cpp/DSCommPacket.cpp
+++ b/simulation/halsim_ds_socket/src/main/native/cpp/DSCommPacket.cpp
@@ -11,9 +11,6 @@
 #include <thread>
 #include <vector>
 
-#include <hal/simulation/DriverStationData.h>
-#include <hal/simulation/MockHooks.h>
-
 using namespace halsim;
 
 DSCommPacket::DSCommPacket() {

--- a/simulation/halsim_ds_socket/src/main/native/cpp/DSCommPacket.cpp
+++ b/simulation/halsim_ds_socket/src/main/native/cpp/DSCommPacket.cpp
@@ -11,6 +11,9 @@
 #include <thread>
 #include <vector>
 
+#include <hal/simulation/DriverStationData.h>
+#include <hal/simulation/MockHooks.h>
+
 using namespace halsim;
 
 DSCommPacket::DSCommPacket() {

--- a/simulation/halsim_ds_socket/src/main/native/cpp/DSCommPacket.cpp
+++ b/simulation/halsim_ds_socket/src/main/native/cpp/DSCommPacket.cpp
@@ -146,9 +146,7 @@ void DSCommPacket::DecodeUDP(std::span<const uint8_t> packet) {
   m_lo = packet[1];
   // Comm Version is packet 2, ignore
   SetControl(packet[3], packet[4]);
-  // DS sends values 0, 1, and 2 for Red, but kUnknown is 0, so the value needs
-  // to be offset by one
-  SetAlliance(packet[5] + 1);
+  SetAlliance(packet[5]);
 
   // Return if packet finished
   if (packet.size() == 6) {

--- a/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
+++ b/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
@@ -16,8 +16,9 @@
 #include <atomic>
 #include <cstdio>
 #include <cstring>
-#include <string_view>
 #include <exception>
+#include <string_view>
+
 #include <DSCommPacket.h>
 #include <fmt/format.h>
 #include <hal/Extensions.h>

--- a/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
+++ b/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
@@ -124,6 +124,7 @@ static void SetupUdp(wpi::uv::Loop& loop) {
     });
   });
   simLoopTimer->Start(Timer::Time{100}, Timer::Time{100});
+  // DS Timeout
   int timeoutMs = 100;
   auto envTimeout = std::getenv("DS_TIMEOUT_MS");
   if (envTimeout) {
@@ -131,7 +132,7 @@ static void SetupUdp(wpi::uv::Loop& loop) {
   }
   auto autoDisableTimer = Timer::Create(loop);
   autoDisableTimer->timeout.connect([] { HALSIM_SetDriverStationEnabled(0); });
-  autoDisableTimer->Start(Timer::Time(timeoutMs));
+
   // UDP Receive then send
   udp->received.connect(
       [udpLocal = udp.get(), autoDisableTimer, timeoutMs](

--- a/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
+++ b/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
@@ -17,7 +17,6 @@
 #include <cstdio>
 #include <cstring>
 #include <string_view>
-#include <iostream>
 #include <exception>
 #include <DSCommPacket.h>
 #include <fmt/format.h>
@@ -131,7 +130,7 @@ static void SetupUdp(wpi::uv::Loop& loop) {
     try {
       timeoutMs = std::stoi(envTimeout);
     } catch (const std::exception& e) {
-      std::cerr << e.what() << '\n';
+      fmt::print(stderr, "Error parsing DS_TIMEOUT_MS: {}\n", e.what());
     }
   }
   auto autoDisableTimer = Timer::Create(loop);

--- a/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
+++ b/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
@@ -135,7 +135,6 @@ static void SetupUdp(wpi::uv::Loop& loop) {
   auto envTimeout = std::getenv("DS_TIMEOUT_MS");
   if (envTimeout) {
     timeoutMs = std::stoi(envTimeout);
-    std::cout << timeoutMs << std::endl;
   }
   // UDP Receive then send
   udp->received.connect(

--- a/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
+++ b/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
@@ -17,7 +17,8 @@
 #include <cstdio>
 #include <cstring>
 #include <string_view>
-
+#include <iostream>
+#include <exception>
 #include <DSCommPacket.h>
 #include <fmt/format.h>
 #include <hal/Extensions.h>
@@ -126,9 +127,12 @@ static void SetupUdp(wpi::uv::Loop& loop) {
   simLoopTimer->Start(Timer::Time{100}, Timer::Time{100});
   // DS Timeout
   int timeoutMs = 100;
-  auto envTimeout = std::getenv("DS_TIMEOUT_MS");
-  if (envTimeout) {
-    timeoutMs = std::stoi(envTimeout);
+  if (auto envTimeout = std::getenv("DS_TIMEOUT_MS")) {
+    try {
+      timeoutMs = std::stoi(envTimeout);
+    } catch (const std::exception& e) {
+      std::cerr << e.what() << '\n';
+    }
   }
   auto autoDisableTimer = Timer::Create(loop);
   autoDisableTimer->timeout.connect([] { HALSIM_SetDriverStationEnabled(0); });

--- a/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
+++ b/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
@@ -176,7 +176,7 @@ static void SetupEventLoop(wpi::uv::Loop& loop) {
       HALSIM_SetDriverStationEnabled(0);
     }
   });
-  autoDisableTimer->Start(Timer::Time(100), Timer::Time(100));
+  autoDisableTimer->Start(Timer::Time(0), Timer::Time(20));
 }
 
 static std::unique_ptr<wpi::EventLoopRunner> eventLoopRunner;

--- a/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
+++ b/simulation/halsim_ds_socket/src/main/native/cpp/main.cpp
@@ -21,7 +21,6 @@
 #include <DSCommPacket.h>
 #include <fmt/format.h>
 #include <hal/Extensions.h>
-#include <hal/HAL.h>
 #include <wpinet/EventLoopRunner.h>
 #include <wpinet/raw_uv_ostream.h>
 #include <wpinet/uv/Tcp.h>


### PR DESCRIPTION
If the DS extension is loaded, the robot program will continue to be enabled if the DS disconnects or closes. This adds timers to auto disable the program when it's been more than 100ms since the last DS packet.