### PR TITLE
[wpilib] Fix SendableChooser test

### DIFF
--- a/wpilibc/src/test/native/cpp/smartdashboard/SendableChooserTest.cpp
+++ b/wpilibc/src/test/native/cpp/smartdashboard/SendableChooserTest.cpp
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include <fmt/core.h>
 #include <gtest/gtest.h>
 #include <networktables/NetworkTableInstance.h>
 #include <networktables/StringTopic.h>
@@ -21,11 +22,14 @@ TEST_P(SendableChooserTest, ReturnsSelected) {
   }
   chooser.SetDefaultOption("0", 0);
 
-  auto pub = nt::NetworkTableInstance::GetDefault()
-                 .GetStringTopic("/SmartDashboard/chooser/selected")
-                 .Publish();
+  auto pub =
+      nt::NetworkTableInstance::GetDefault()
+          .GetStringTopic(fmt::format(
+              "/SmartDashboard/ReturnsSelectedChooser{}/selected", GetParam()))
+          .Publish();
 
-  frc::SmartDashboard::PutData("chooser", &chooser);
+  frc::SmartDashboard::PutData(
+      fmt::format("ReturnsSelectedChooser{}", GetParam()), &chooser);
   frc::SmartDashboard::UpdateValues();
   pub.Set(std::to_string(GetParam()));
   frc::SmartDashboard::UpdateValues();
@@ -65,9 +69,9 @@ TEST(SendableChooserTest, ChangeListener) {
   int currentVal = 0;
   chooser.OnChange([&](int val) { currentVal = val; });
 
-  frc::SmartDashboard::PutData("chooser", &chooser);
+  frc::SmartDashboard::PutData("ChangeListenerChooser", &chooser);
   frc::SmartDashboard::UpdateValues();
-  frc::SmartDashboard::PutString("chooser/selected", "3");
+  frc::SmartDashboard::PutString("ChangeListenerChooser/selected", "3");
   frc::SmartDashboard::UpdateValues();
 
   EXPECT_EQ(3, currentVal);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooserTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/smartdashboard/SendableChooserTest.java
@@ -28,13 +28,16 @@ class SendableChooserTest {
   @ParameterizedTest
   void returnsSelected(int toSelect) {
     try (var chooser = new SendableChooser<Integer>();
-        var publisher = m_inst.getStringTopic("/SmartDashboard/chooser/selected").publish()) {
+        var publisher =
+            m_inst
+                .getStringTopic("/SmartDashboard/returnsSelectedChooser" + toSelect + "/selected")
+                .publish()) {
       for (int i = 1; i <= 3; i++) {
         chooser.addOption(String.valueOf(i), i);
       }
       chooser.setDefaultOption(String.valueOf(0), 0);
 
-      SmartDashboard.putData("chooser", chooser);
+      SmartDashboard.putData("returnsSelectedChooser" + toSelect, chooser);
       SmartDashboard.updateValues();
       publisher.set(String.valueOf(toSelect));
       SmartDashboard.updateValues();
@@ -74,9 +77,9 @@ class SendableChooserTest {
       AtomicInteger currentVal = new AtomicInteger();
       chooser.onChange(val -> currentVal.set(val));
 
-      SmartDashboard.putData("chooser", chooser);
+      SmartDashboard.putData("changeListenerChooser", chooser);
       SmartDashboard.updateValues();
-      SmartDashboard.putString("chooser/selected", "3");
+      SmartDashboard.putString("changeListenerChooser/selected", "3");
       SmartDashboard.updateValues();
       assertEquals(3, currentVal.get());
     }


### PR DESCRIPTION
Using unique NT keys for each test seems to resolve the failure on Linux. Changed Java as well, for completeness.

Failed test log, for future reference
```
[----------] 4 tests from SendableChooserTests/SendableChooserTest
[ RUN      ] SendableChooserTests/SendableChooserTest.ReturnsSelected/0
/work/wpilibc/src/test/native/cpp/smartdashboard/SendableChooserTest.cpp:32: Failure
Expected equality of these values:
  GetParam()
    Which is: 0
  chooser.GetSelected()
    Which is: 3

[  FAILED  ] SendableChooserTests/SendableChooserTest.ReturnsSelected/0, where GetParam() = 0 (0 ms)
[ RUN      ] SendableChooserTests/SendableChooserTest.ReturnsSelected/1
/work/wpilibc/src/test/native/cpp/smartdashboard/SendableChooserTest.cpp:32: Failure
Expected equality of these values:
  GetParam()
    Which is: 1
  chooser.GetSelected()
    Which is: 0

[  FAILED  ] SendableChooserTests/SendableChooserTest.ReturnsSelected/1, where GetParam() = 1 (0 ms)
[ RUN      ] SendableChooserTests/SendableChooserTest.ReturnsSelected/2
/work/wpilibc/src/test/native/cpp/smartdashboard/SendableChooserTest.cpp:32: Failure
Expected equality of these values:
  GetParam()
    Which is: 2
  chooser.GetSelected()
    Which is: 1

[  FAILED  ] SendableChooserTests/SendableChooserTest.ReturnsSelected/2, where GetParam() = 2 (0 ms)
[ RUN      ] SendableChooserTests/SendableChooserTest.ReturnsSelected/3
/work/wpilibc/src/test/native/cpp/smartdashboard/SendableChooserTest.cpp:32: Failure
Expected equality of these values:
  GetParam()
    Which is: 3
  chooser.GetSelected()
    Which is: 2

[  FAILED  ] SendableChooserTests/SendableChooserTest.ReturnsSelected/3, where GetParam() = 3 (0 ms)
[----------] 4 tests from SendableChooserTests/SendableChooserTest (0 ms total)
```