### PR TITLE
[cmd] Add GetName to Subsystem, use in Scheduler tracer epochs

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/CommandScheduler.java
@@ -261,7 +261,7 @@ public final class CommandScheduler implements Sendable, AutoCloseable {
       if (RobotBase.isSimulation()) {
         subsystem.simulationPeriodic();
       }
-      m_watchdog.addEpoch(subsystem.getClass().getSimpleName() + ".periodic()");
+      m_watchdog.addEpoch(subsystem.getName() + ".periodic()");
     }
 
     // Cache the active instance to avoid concurrency problems if setActiveLoop() is called from

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Subsystem.java
@@ -41,6 +41,15 @@ public interface Subsystem {
   default void simulationPeriodic() {}
 
   /**
+   * Gets the subsystem name of this Subsystem.
+   *
+   * @return Subsystem name
+   */
+  default String getName() {
+    return this.getClass().getSimpleName();
+  }
+
+  /**
    * Sets the default {@link Command} of the subsystem. The default command will be automatically
    * scheduled when no other commands are scheduled that require the subsystem. Default commands
    * should generally not end on their own, i.e. their {@link Command#isFinished()} method should

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SubsystemBase.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SubsystemBase.java
@@ -28,6 +28,7 @@ public abstract class SubsystemBase implements Subsystem, Sendable {
    *
    * @return Name
    */
+  @Override
   public String getName() {
     return SendableRegistry.getName(this);
   }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/CommandScheduler.cpp
@@ -183,7 +183,7 @@ void CommandScheduler::Run() {
     if constexpr (frc::RobotBase::IsSimulation()) {
       subsystem.getFirst()->SimulationPeriodic();
     }
-    m_watchdog.AddEpoch("Subsystem Periodic()");
+    m_watchdog.AddEpoch(subsystem.getFirst()->GetName() + ".Periodic()");
   }
 
   // Cache the active instance to avoid concurrency problems if SetActiveLoop()

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Subsystem.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Subsystem.cpp
@@ -4,6 +4,8 @@
 
 #include "frc2/command/Subsystem.h"
 
+#include <wpi/Demangle.h>
+
 #include "frc2/command/CommandPtr.h"
 #include "frc2/command/Commands.h"
 
@@ -15,6 +17,10 @@ Subsystem::~Subsystem() {
 void Subsystem::Periodic() {}
 
 void Subsystem::SimulationPeriodic() {}
+
+std::string Subsystem::GetName() const {
+  return wpi::GetTypeName(*this);
+}
 
 void Subsystem::SetDefaultCommand(CommandPtr&& defaultCommand) {
   CommandScheduler::GetInstance().SetDefaultCommand(this,

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -18,11 +18,6 @@
 
 namespace frc2 {
 
-template <typename T>
-std::string GetTypeName(const T& type) {
-  return wpi::Demangle(typeid(type).name());
-}
-
 /**
  * A state machine representing a complete action to be performed by the robot.
  * Commands are run by the CommandScheduler, and can be composed into

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Subsystem.h
@@ -6,6 +6,7 @@
 
 #include <concepts>
 #include <functional>
+#include <string>
 #include <utility>
 
 #include <wpi/FunctionExtras.h>
@@ -58,6 +59,13 @@ class Subsystem {
    * sensor readings.
    */
   virtual void SimulationPeriodic();
+
+  /**
+   * Gets the name of this Subsystem.
+   *
+   * @return Name
+   */
+  virtual std::string GetName() const;
 
   /**
    * Sets the default Command of the subsystem.  The default command will be

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SubsystemBase.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SubsystemBase.h
@@ -30,7 +30,7 @@ class SubsystemBase : public Subsystem,
    *
    * @return Name
    */
-  std::string GetName() const;
+  std::string GetName() const override;
 
   /**
    * Sets the name of this Subsystem.

--- a/wpiutil/src/main/native/include/wpi/Demangle.h
+++ b/wpiutil/src/main/native/include/wpi/Demangle.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <string_view>
+#include <typeinfo>
 
 namespace wpi {
 
@@ -17,6 +18,15 @@ namespace wpi {
  * @return The demangled symbol, or mangledSymbol if demangling fails.
  */
 std::string Demangle(std::string_view mangledSymbol);
+
+/**
+ * Returns the type name of an object
+ * @param type The object
+ */
+template <typename T>
+std::string GetTypeName(const T& type) {
+  return Demangle(typeid(type).name());
+}
 
 }  // namespace wpi
 


### PR DESCRIPTION
Continuation from #4199 
Fixes #4191

My only concern is calling typeid in C++ may be expensive (as mentioned in #4199). Ideally, Subsystem handles generating the name, rather than CommandScheduler caching it. The problem is that Subsystem can't access the subclass' type info at construction time. Any ideas would be helpful