### PR TITLE
Fix Checkstyle rules on Windows

### DIFF
--- a/styleguide/checkstyle-suppressions.xml
+++ b/styleguide/checkstyle-suppressions.xml
@@ -6,10 +6,10 @@ suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN"
   <suppress files=".*test.*" checks="MissingJavadocMethod" />
   <suppress files=".*wpilibjIntegrationTests.*"
     checks="MissingJavadocMethod" />
-  <suppress files="wpimath/*"
+  <suppress files="wpimath.*"
     checks="(LocalVariableName|MemberName|MethodName|MethodTypeParameterName|ParameterName)" />
   <suppress files=".*JNI.*"
     checks="(EmptyLineSeparator|LineLength|MissingJavadocMethod|ParameterName)" />
-  <suppress files=".*/quickbuf/.*"
+  <suppress files=".*quickbuf.*"
     checks="(CustomImportOrder|EmptyLineSeparator|LineLength|JavadocParagraph|MissingJavadocMethod|OverloadMethodsDeclarationOrder|SummaryJavadoc|UnnecessaryParentheses|OperatorWrap|JavadocMethod|JavadocTagContinuationIndentation)" />
 </suppressions>


### PR DESCRIPTION
Currently on main, the checkstyle rules for quickbuf and wpimath don't match on windows filepaths. This PR removes the file separator from the pattern, since they can be captured by wildcards without losing specificity.