### PR TITLE
[wpinet] WebSocket: Fix write behavior

### DIFF
--- a/wpinet/src/main/native/cpp/WebSocketSerializer.h
+++ b/wpinet/src/main/native/cpp/WebSocketSerializer.h
@@ -130,7 +130,7 @@ int WebSocketWriteReqBase::Continue(Stream& stream, std::shared_ptr<Req> req) {
   }
 
   m_continueFramePos = offIt - m_continueFrameOffs.begin();
-  m_continueBufPos = &(*bufIt) - &(*m_frames.m_bufs.begin());
+  m_continueBufPos += bufIt - bufs.begin();
 
   if (writeBufs.empty()) {
     WS_DEBUG("Write Done\n");
@@ -256,7 +256,6 @@ std::span<const WebSocket::Frame> TrySendFrames(
       // continuation (so the caller isn't responsible for doing this)
       size_t continuePos = 0;
       while (frameStart != frameEnd && !isFin) {
-        req->m_continueFrameOffs.emplace_back(continuePos);
         if (offIt != offEnd) {
           // we already generated the wire buffers for this frame, use them
           while (pos < *offIt && bufIt != bufEnd) {
@@ -271,6 +270,7 @@ std::span<const WebSocket::Frame> TrySendFrames(
           // need to generate and add this frame
           continuePos += req->m_frames.AddFrame(*frameStart, server);
         }
+        req->m_continueFrameOffs.emplace_back(continuePos);
         isFin = (frameStart->opcode & WebSocket::kFlagFin) != 0;
         ++frameStart;
       }

--- a/wpinet/src/main/native/include/wpinet/WebSocket.h
+++ b/wpinet/src/main/native/include/wpinet/WebSocket.h
@@ -514,7 +514,8 @@ class WebSocket : public std::enable_shared_from_this<WebSocket> {
   // outgoing write request
   bool m_writeInProgress = false;
   class WriteReq;
-  std::weak_ptr<WriteReq> m_writeReq;
+  std::weak_ptr<WriteReq> m_curWriteReq;
+  std::weak_ptr<WriteReq> m_lastWriteReq;
 
   // operating state
   State m_state = CONNECTING;

--- a/wpinet/src/test/native/cpp/WebSocketIntegrationTest.cpp
+++ b/wpinet/src/test/native/cpp/WebSocketIntegrationTest.cpp
@@ -4,6 +4,7 @@
 
 #include "wpinet/WebSocketServer.h"  // NOLINT(build/include_order)
 
+#include <fmt/format.h>
 #include <wpi/SmallString.h>
 
 #include "WebSocketTest.h"
@@ -150,18 +151,24 @@ TEST_F(WebSocketIntegrationTest, ClientSendText) {
 TEST_F(WebSocketIntegrationTest, ServerSendPing) {
   int gotPing = 0;
   int gotPong = 0;
+  int gotData = 0;
 
   serverPipe->Listen([&]() {
     auto conn = serverPipe->Accept();
     auto server = WebSocketServer::Create(*conn);
     server->connected.connect([&](std::string_view, WebSocket& ws) {
+      ws.SendText({{"hello"}}, [&](auto, uv::Error) {});
       ws.SendPing({uv::Buffer{"\x03\x04", 2}}, [&](auto, uv::Error) {});
+      ws.SendPing({uv::Buffer{"\x03\x04", 2}}, [&](auto, uv::Error) {});
+      ws.SendText({{"hello"}}, [&](auto, uv::Error) {});
       ws.pong.connect([&](auto data) {
         ++gotPong;
         std::vector<uint8_t> recvData{data.begin(), data.end()};
         std::vector<uint8_t> expectData{0x03, 0x04};
         ASSERT_EQ(recvData, expectData);
-        ws.Close();
+        if (gotPong == 2) {
+          ws.Close();
+        }
       });
     });
   });
@@ -180,12 +187,17 @@ TEST_F(WebSocketIntegrationTest, ServerSendPing) {
       std::vector<uint8_t> expectData{0x03, 0x04};
       ASSERT_EQ(recvData, expectData);
     });
+    ws->text.connect([&](std::string_view data, bool) {
+      ++gotData;
+      ASSERT_EQ(data, "hello");
+    });
   });
 
   loop->Run();
 
-  ASSERT_EQ(gotPing, 1);
-  ASSERT_EQ(gotPong, 1);
+  ASSERT_EQ(gotPing, 2);
+  ASSERT_EQ(gotPong, 2);
+  ASSERT_EQ(gotData, 2);
 }
 
 }  // namespace wpi

--- a/wpinet/src/test/native/cpp/WebSocketIntegrationTest.cpp
+++ b/wpinet/src/test/native/cpp/WebSocketIntegrationTest.cpp
@@ -4,7 +4,6 @@
 
 #include "wpinet/WebSocketServer.h"  // NOLINT(build/include_order)
 
-#include <fmt/format.h>
 #include <wpi/SmallString.h>
 
 #include "WebSocketTest.h"

--- a/wpinet/src/test/native/cpp/WebSocketSerializerTest.cpp
+++ b/wpinet/src/test/native/cpp/WebSocketSerializerTest.cpp
@@ -281,10 +281,14 @@ TEST_F(WebSocketTrySendTest, ServerPartialMidFrameMidBuf0) {
   std::array<uv::Buffer, 2> remBufs{std::span{m_buf0data}.subspan(2),
                                     m_bufs[1]};
   std::array<uv::Buffer, 2> contBufs{m_frameHeaders[1], m_bufs[2]};
+  std::array<int, 1> contFrameOffs{static_cast<int>(m_serialized[1].size())};
   EXPECT_CALL(stream, DoWrite(wpi::SpanEq(remBufs), _));
   CheckTrySendFrames({}, std::span{m_frames}.subspan(2));
   ASSERT_EQ(makeReqCalled, 1);
   ASSERT_THAT(req->m_frames.m_bufs, SpanEq(contBufs));
+  ASSERT_EQ(req->m_continueBufPos, 0u);
+  ASSERT_EQ(req->m_continueFramePos, 0u);
+  ASSERT_THAT(req->m_continueFrameOffs, SpanEq(contFrameOffs));
   ASSERT_EQ(callbackCalled, 0);
 }
 


### PR DESCRIPTION
On Windows, TryWrite will always return 0 if there is a Write in progress. The previous behavior for SendFrames and SendControl just used a normal Write, which caused issues with code that combined these with TrySendFrames. Instead, have SendFrames and SendControl also use TryWrite under the hood if possible, and create write requests if not. The implementation preserves the priority of SendControl against an existing write request with multiple frames.

Fixes #5817 (the root cause for that was it was not sending the subscription frame due to the WS ping SendControl always occurring immediately before the TrySendFrames).