### PR TITLE
[java cmd] Make SelectCommand generic

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -144,6 +144,7 @@ public final class Commands {
   /**
    * Runs one of several commands, based on the selector function.
    *
+   * @param <K> The type of key used to select the command
    * @param selector the selector function
    * @param commands map of commands to select from
    * @return the command

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -149,8 +149,8 @@ public final class Commands {
    * @return the command
    * @see SelectCommand
    */
-  public static Command select(Map<Object, Command> commands, Supplier<Object> selector) {
-    return new SelectCommand(commands, selector);
+  public static <K> Command select(Map<K, Command> commands, Supplier<? extends K> selector) {
+    return new SelectCommand<>(commands, selector);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SelectCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SelectCommand.java
@@ -20,7 +20,7 @@ import java.util.function.Supplier;
  *
  * <p>This class is provided by the NewCommands VendorDep
  *
- * @param <K> The type of key that the selector uses
+ * @param <K> The type of key used to select the command
  */
 public class SelectCommand<K> extends Command {
   private final Map<K, Command> m_commands;

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SelectCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SelectCommand.java
@@ -19,10 +19,12 @@ import java.util.function.Supplier;
  * subsystems its components require.
  *
  * <p>This class is provided by the NewCommands VendorDep
+ *
+ * @param <K> The type of key that the selector uses
  */
-public class SelectCommand extends Command {
-  private final Map<Object, Command> m_commands;
-  private final Supplier<Object> m_selector;
+public class SelectCommand<K> extends Command {
+  private final Map<K, Command> m_commands;
+  private final Supplier<? extends K> m_selector;
   private Command m_selectedCommand;
   private boolean m_runsWhenDisabled = true;
   private InterruptionBehavior m_interruptBehavior = InterruptionBehavior.kCancelIncoming;
@@ -36,7 +38,7 @@ public class SelectCommand extends Command {
    * @param commands the map of commands to choose from
    * @param selector the selector to determine which command to run
    */
-  public SelectCommand(Map<Object, Command> commands, Supplier<Object> selector) {
+  public SelectCommand(Map<K, Command> commands, Supplier<? extends K> selector) {
     m_commands = requireNonNullParam(commands, "commands", "SelectCommand");
     m_selector = requireNonNullParam(selector, "selector", "SelectCommand");
 

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/RobotDisabledCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/RobotDisabledCommandTest.java
@@ -141,8 +141,8 @@ class RobotDisabledCommandTest extends CommandTestBase {
     MockCommandHolder command4Holder = new MockCommandHolder(false);
     Command command4 = command4Holder.getMock();
 
-    Command runWhenDisabled = new SelectCommand(Map.of(1, command1, 2, command2), () -> 1);
-    Command dontRunWhenDisabled = new SelectCommand(Map.of(1, command3, 2, command4), () -> 1);
+    Command runWhenDisabled = new SelectCommand<>(Map.of(1, command1, 2, command2), () -> 1);
+    Command dontRunWhenDisabled = new SelectCommand<>(Map.of(1, command3, 2, command4), () -> 1);
 
     try (CommandScheduler scheduler = new CommandScheduler()) {
       scheduler.schedule(runWhenDisabled, dontRunWhenDisabled);

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SelectCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SelectCommandTest.java
@@ -13,7 +13,8 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class SelectCommandTest extends CommandTestBase implements MultiCompositionTestBase<SelectCommand<Integer>> {
+class SelectCommandTest extends CommandTestBase
+    implements MultiCompositionTestBase<SelectCommand<Integer>> {
   @Test
   void selectCommandTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {

--- a/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SelectCommandTest.java
+++ b/wpilibNewCommands/src/test/java/edu/wpi/first/wpilibj2/command/SelectCommandTest.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class SelectCommandTest extends CommandTestBase implements MultiCompositionTestBase<SelectCommand> {
+class SelectCommandTest extends CommandTestBase implements MultiCompositionTestBase<SelectCommand<Integer>> {
   @Test
   void selectCommandTest() {
     try (CommandScheduler scheduler = new CommandScheduler()) {
@@ -25,8 +25,8 @@ class SelectCommandTest extends CommandTestBase implements MultiCompositionTestB
       MockCommandHolder command3Holder = new MockCommandHolder(true);
       Command command3 = command3Holder.getMock();
 
-      SelectCommand selectCommand =
-          new SelectCommand(
+      SelectCommand<String> selectCommand =
+          new SelectCommand<>(
               Map.ofEntries(
                   Map.entry("one", command1),
                   Map.entry("two", command2),
@@ -61,8 +61,8 @@ class SelectCommandTest extends CommandTestBase implements MultiCompositionTestB
       MockCommandHolder command3Holder = new MockCommandHolder(true);
       Command command3 = command3Holder.getMock();
 
-      SelectCommand selectCommand =
-          new SelectCommand(
+      SelectCommand<String> selectCommand =
+          new SelectCommand<>(
               Map.ofEntries(
                   Map.entry("one", command1),
                   Map.entry("two", command2),
@@ -88,8 +88,8 @@ class SelectCommandTest extends CommandTestBase implements MultiCompositionTestB
       MockCommandHolder command3Holder = new MockCommandHolder(true, system3, system4);
       Command command3 = command3Holder.getMock();
 
-      SelectCommand selectCommand =
-          new SelectCommand(
+      SelectCommand<String> selectCommand =
+          new SelectCommand<>(
               Map.ofEntries(
                   Map.entry("one", command1),
                   Map.entry("two", command2),
@@ -108,11 +108,11 @@ class SelectCommandTest extends CommandTestBase implements MultiCompositionTestB
   }
 
   @Override
-  public SelectCommand compose(Command... members) {
-    var map = new HashMap<Object, Command>();
+  public SelectCommand<Integer> compose(Command... members) {
+    var map = new HashMap<Integer, Command>();
     for (int i = 0; i < members.length; i++) {
       map.put(i, members[i]);
     }
-    return new SelectCommand(map, () -> 0);
+    return new SelectCommand<>(map, () -> 0);
   }
 }

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/selectcommand/RobotContainer.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/selectcommand/RobotContainer.java
@@ -36,7 +36,7 @@ public class RobotContainer {
   // selector does not have to be an enum; it could be any desired type (string, integer,
   // boolean, double...)
   private final Command m_exampleSelectCommand =
-      new SelectCommand(
+      new SelectCommand<>(
           // Maps selector values to commands
           Map.ofEntries(
               Map.entry(CommandSelector.ONE, new PrintCommand("Command one was selected!")),


### PR DESCRIPTION
This allows users to use any type of map and selector without needing to explicitly match `Map<Object, Command>`