### PR TITLE
Fix game specific message behavior when over 64 characters

### DIFF
--- a/hal/src/main/native/athena/FRCDriverStation.cpp
+++ b/hal/src/main/native/athena/FRCDriverStation.cpp
@@ -168,7 +168,7 @@ static int32_t HAL_GetMatchInfoInternal(HAL_MatchInfo* info) {
       info->gameSpecificMessage, &info->gameSpecificMessageSize);
 
   if (info->gameSpecificMessageSize > sizeof(info->gameSpecificMessage)) {
-    info->gameSpecificMessageSize = 0;
+    info->gameSpecificMessageSize = sizeof(info->gameSpecificMessage);
   }
 
   info->matchType = static_cast<HAL_MatchType>(matchType);


### PR DESCRIPTION
Previously `GetGameSpecificMessage` would return an empty string when the received game specific message was over 64 characters.