### PR TITLE
[wpimath] Expose InterpolatingDoubleTreeMap constructor

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/interpolation/InterpolatingDoubleTreeMap.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/interpolation/InterpolatingDoubleTreeMap.java
@@ -9,7 +9,7 @@ package edu.wpi.first.math.interpolation;
  * from points that are defined. This uses linear interpolation.
  */
 public class InterpolatingDoubleTreeMap extends InterpolatingTreeMap<Double, Double> {
-  InterpolatingDoubleTreeMap() {
+  public InterpolatingDoubleTreeMap() {
     super(InverseInterpolator.forDouble(), Interpolator.forDouble());
   }
 }


### PR DESCRIPTION
InterpolatingDoubleTreeMap has a private constructor, which appears to be an oversight.