### PR TITLE
Fix protobuf generation when building with make

### DIFF
--- a/wpimath/CMakeLists.txt
+++ b/wpimath/CMakeLists.txt
@@ -5,6 +5,8 @@ include(CompileWarnings)
 include(AddTest)
 include(DownloadAndCheck)
 
+# workaround for makefiles - for some reason parent directories aren't created.
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/protobuf")
 file(GLOB wpimath_proto_src src/main/proto/*.proto)
 protobuf_generate_cpp(WPIMATH_PROTO_SRCS WPIMATH_PROTO_HDRS PROTOC_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/protobuf" PROTOS ${wpimath_proto_src})
 


### PR DESCRIPTION
For some reason, cmake does not create `PROTOC_OUT_DIR` when building using Make, so protoc can't generate code. This works around that by creating the appropriate folder.
fixes #5803 