### PR TITLE
[docs] Exclude eigen and protobuf from doxygen

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -144,6 +144,10 @@ doxygen {
 
     exclude '*.pb.h'
 
+    // Save space by excluding protobuf and eigen
+    exclude 'Eigen/**'
+    exclude 'google/protobuf/**'
+
     aliases 'effects=\\par <i>Effects:</i>^^',
             'notes=\\par <i>Notes:</i>^^',
             'requires=\\par <i>Requires:</i>^^',


### PR DESCRIPTION
They take up a significant portion of the generated output (protobuf ~55MB, eigen ~119MB)