### PR TITLE
Adds GetTags to C++ version of AprilTagFieldLayout

### DIFF
--- a/apriltag/src/main/native/cpp/AprilTagFieldLayout.cpp
+++ b/apriltag/src/main/native/cpp/AprilTagFieldLayout.cpp
@@ -50,7 +50,8 @@ units::meter_t AprilTagFieldLayout::GetFieldWidth() const {
 }
 
 std::vector<AprilTag> AprilTagFieldLayout::GetTags() const {
-  std::vector<AprilTag> tags{m_apriltags.size()};
+  std::vector<AprilTag> tags;
+  tags.reserve(m_apriltags.size());
   for (const auto& tag : m_apriltags) {
     tags.emplace_back(tag.second);
   }

--- a/apriltag/src/main/native/cpp/AprilTagFieldLayout.cpp
+++ b/apriltag/src/main/native/cpp/AprilTagFieldLayout.cpp
@@ -4,7 +4,6 @@
 
 #include "frc/apriltag/AprilTagFieldLayout.h"
 
-#include <ranges>
 #include <system_error>
 
 #include <units/angle.h>
@@ -51,8 +50,11 @@ units::meter_t AprilTagFieldLayout::GetFieldWidth() const {
 }
 
 std::vector<AprilTag> AprilTagFieldLayout::GetTags() const {
-  auto vals = std::views::values(m_apriltags);
-  return std::vector<AprilTag>{vals.begin(), vals.end()};
+  std::vector<AprilTag> tags{m_apriltags.size()};
+  for (const auto& tag : m_apriltags) {
+    tags.emplace_back(tag.second);
+  }
+  return tags;
 }
 
 void AprilTagFieldLayout::SetOrigin(OriginPosition origin) {

--- a/apriltag/src/main/native/cpp/AprilTagFieldLayout.cpp
+++ b/apriltag/src/main/native/cpp/AprilTagFieldLayout.cpp
@@ -4,6 +4,7 @@
 
 #include "frc/apriltag/AprilTagFieldLayout.h"
 
+#include <ranges>
 #include <system_error>
 
 #include <units/angle.h>
@@ -47,6 +48,11 @@ units::meter_t AprilTagFieldLayout::GetFieldLength() const {
 
 units::meter_t AprilTagFieldLayout::GetFieldWidth() const {
   return m_fieldWidth;
+}
+
+std::vector<AprilTag> AprilTagFieldLayout::GetTags() const {
+  auto vals = std::views::values(m_apriltags);
+  return std::vector<AprilTag>{vals.begin(), vals.end()};
 }
 
 void AprilTagFieldLayout::SetOrigin(OriginPosition origin) {

--- a/apriltag/src/main/native/include/frc/apriltag/AprilTagFieldLayout.h
+++ b/apriltag/src/main/native/include/frc/apriltag/AprilTagFieldLayout.h
@@ -75,6 +75,12 @@ class WPILIB_DLLEXPORT AprilTagFieldLayout {
   units::meter_t GetFieldWidth() const;
 
   /**
+   * Returns a vector of all the april tags used in this layout.
+   * @return list of tags
+   */
+  std::vector<AprilTag> GetTags() const;
+
+  /**
    * Sets the origin based on a predefined enumeration of coordinate frame
    * origins. The origins are calculated from the field dimensions.
    *


### PR DESCRIPTION
This adds a small function to return a list of AprilTag objects to the C++ version of the AprilTag library. This already exists in Java.