### PR TITLE
[ntcore] Only datalog meta-topics if specifically requested

### DIFF
--- a/ntcore/src/main/native/cpp/LocalStorage.cpp
+++ b/ntcore/src/main/native/cpp/LocalStorage.cpp
@@ -130,9 +130,7 @@ void LocalStorage::Impl::NotifyTopic(TopicData* topic,
     if (!m_dataloggers.empty()) {
       auto now = Now();
       for (auto&& datalogger : m_dataloggers) {
-        if (wpi::starts_with(topic->name, datalogger->prefix) &&
-            (!datalogger->prefix.empty() ||
-             !wpi::starts_with(topic->name, '$'))) {
+        if (PrefixMatch(topic->name, datalogger->prefix, topic->special)) {
           auto it = std::find_if(topic->datalogs.begin(), topic->datalogs.end(),
                                  [&](const auto& elem) {
                                    return elem.logger == datalogger->handle;
@@ -1450,8 +1448,7 @@ NT_DataLogger LocalStorage::StartDataLog(wpi::log::DataLog& log,
   // start logging any matching topics
   auto now = nt::Now();
   for (auto&& topic : m_impl.m_topics) {
-    if (!wpi::starts_with(topic->name, prefix) ||
-        (prefix.empty() && wpi::starts_with(topic->name, '$')) ||
+    if (!PrefixMatch(topic->name, prefix, topic->special) ||
         topic->type == NT_UNASSIGNED || topic->typeStr.empty()) {
       continue;
     }

--- a/ntcore/src/main/native/cpp/LocalStorage.cpp
+++ b/ntcore/src/main/native/cpp/LocalStorage.cpp
@@ -130,7 +130,9 @@ void LocalStorage::Impl::NotifyTopic(TopicData* topic,
     if (!m_dataloggers.empty()) {
       auto now = Now();
       for (auto&& datalogger : m_dataloggers) {
-        if (wpi::starts_with(topic->name, datalogger->prefix)) {
+        if (wpi::starts_with(topic->name, datalogger->prefix) &&
+            (!datalogger->prefix.empty() ||
+             !wpi::starts_with(topic->name, '$'))) {
           auto it = std::find_if(topic->datalogs.begin(), topic->datalogs.end(),
                                  [&](const auto& elem) {
                                    return elem.logger == datalogger->handle;
@@ -1449,6 +1451,7 @@ NT_DataLogger LocalStorage::StartDataLog(wpi::log::DataLog& log,
   auto now = nt::Now();
   for (auto&& topic : m_impl.m_topics) {
     if (!wpi::starts_with(topic->name, prefix) ||
+        (prefix.empty() && wpi::starts_with(topic->name, '$')) ||
         topic->type == NT_UNASSIGNED || topic->typeStr.empty()) {
       continue;
     }


### PR DESCRIPTION
In general, we shouldn't need or want to log `$pub$` and `$sub$` values and the like, only if specifically directed to log `$` prefixes.  This matches the behavior of subscriptions in general.