### PR TITLE
Use char instead of uint8_t for json::parse

### DIFF
--- a/apriltag/src/main/native/cpp/AprilTagFieldLayout.cpp
+++ b/apriltag/src/main/native/cpp/AprilTagFieldLayout.cpp
@@ -22,7 +22,7 @@ AprilTagFieldLayout::AprilTagFieldLayout(std::string_view path) {
     throw std::runtime_error(fmt::format("Cannot open file: {}", path));
   }
 
-  wpi::json json = wpi::json::parse(fileBuffer->begin(), fileBuffer->end());
+  wpi::json json = wpi::json::parse(fileBuffer->GetCharBuffer());
 
   for (const auto& tag : json.at("tags").get<std::vector<AprilTag>>()) {
     m_apriltags[tag.ID] = tag;

--- a/cameraserver/multiCameraServer/src/main/native/cpp/main.cpp
+++ b/cameraserver/multiCameraServer/src/main/native/cpp/main.cpp
@@ -105,7 +105,7 @@ bool ReadConfig() {
   // parse file
   wpi::json j;
   try {
-    j = wpi::json::parse(fileBuffer->begin(), fileBuffer->end());
+    j = wpi::json::parse(fileBuffer->GetCharBuffer());
   } catch (const wpi::json::parse_error& e) {
     fmt::print(stderr, "config error in '{}': byte {}: {}\n", configFile,
                e.byte, e.what());

--- a/glass/src/lib/native/cpp/Context.cpp
+++ b/glass/src/lib/native/cpp/Context.cpp
@@ -137,9 +137,8 @@ static bool LoadWindowStorageImpl(const std::string& filename) {
     return false;
   } else {
     try {
-      return JsonToWindow(
-          wpi::json::parse(fileBuffer->begin(), fileBuffer->end()),
-          filename.c_str());
+      return JsonToWindow(wpi::json::parse(fileBuffer->GetCharBuffer()),
+                          filename.c_str());
     } catch (wpi::json::parse_error& e) {
       ImGui::LogText("Error loading %s: %s", filename.c_str(), e.what());
       return false;
@@ -164,9 +163,8 @@ static bool LoadStorageRootImpl(Context* ctx, const std::string& filename,
       createdStorage = true;
     }
     try {
-      storage->FromJson(
-          wpi::json::parse(fileBuffer->begin(), fileBuffer->end()),
-          filename.c_str());
+      storage->FromJson(wpi::json::parse(fileBuffer->GetCharBuffer()),
+                        filename.c_str());
     } catch (wpi::json::parse_error& e) {
       ImGui::LogText("Error loading %s: %s", filename.c_str(), e.what());
       if (createdStorage) {

--- a/sysid/src/main/native/cpp/analysis/AnalysisManager.cpp
+++ b/sysid/src/main/native/cpp/analysis/AnalysisManager.cpp
@@ -457,7 +457,7 @@ AnalysisManager::AnalysisManager(std::string_view path, Settings& settings,
       throw FileReadingError(path);
     }
 
-    m_json = wpi::json::parse(fileBuffer->begin(), fileBuffer->end());
+    m_json = wpi::json::parse(fileBuffer->GetCharBuffer());
 
     WPI_INFO(m_logger, "Read {}", path);
   }
@@ -475,7 +475,7 @@ AnalysisManager::AnalysisManager(std::string_view path, Settings& settings,
       throw FileReadingError(newPath);
     }
 
-    m_json = wpi::json::parse(fileBuffer->begin(), fileBuffer->end());
+    m_json = wpi::json::parse(fileBuffer->GetCharBuffer());
 
     WPI_INFO(m_logger, "Read {}", newPath);
   }

--- a/sysid/src/main/native/cpp/analysis/JSONConverter.cpp
+++ b/sysid/src/main/native/cpp/analysis/JSONConverter.cpp
@@ -40,7 +40,7 @@ static wpi::json GetJSON(std::string_view path, wpi::Logger& logger) {
     throw std::runtime_error(fmt::format("Unable to read: {}", path));
   }
 
-  wpi::json json = wpi::json::parse(fileBuffer->begin(), fileBuffer->end());
+  wpi::json json = wpi::json::parse(fileBuffer->GetCharBuffer());
   WPI_INFO(logger, "Read frc-characterization JSON from {}", path);
   return json;
 }

--- a/wpimath/src/main/native/cpp/trajectory/TrajectoryUtil.cpp
+++ b/wpimath/src/main/native/cpp/trajectory/TrajectoryUtil.cpp
@@ -35,7 +35,7 @@ Trajectory TrajectoryUtil::FromPathweaverJson(std::string_view path) {
     throw std::runtime_error(fmt::format("Cannot open file: {}", path));
   }
 
-  wpi::json json = wpi::json::parse(fileBuffer->begin(), fileBuffer->end());
+  wpi::json json = wpi::json::parse(fileBuffer->GetCharBuffer());
 
   return Trajectory{json.get<std::vector<Trajectory::State>>()};
 }

--- a/wpiutil/src/main/native/thirdparty/llvm/include/wpi/MemoryBuffer.h
+++ b/wpiutil/src/main/native/thirdparty/llvm/include/wpi/MemoryBuffer.h
@@ -62,6 +62,11 @@ class MemoryBuffer {
 
   std::span<const uint8_t> GetBuffer() const { return {begin(), end()}; }
 
+  std::span<const char> GetCharBuffer() const {
+    return {reinterpret_cast<const char*>(begin()),
+            reinterpret_cast<const char*>(end())};
+  }
+
   /// Return an identifier for this buffer, typically the filename it was read
   /// from.
   virtual std::string_view GetBufferIdentifier() const {
@@ -145,6 +150,10 @@ class WritableMemoryBuffer : public MemoryBuffer {
   uint8_t* begin() { return const_cast<uint8_t*>(MemoryBuffer::begin()); }
   uint8_t* end() { return const_cast<uint8_t*>(MemoryBuffer::end()); }
   std::span<uint8_t> GetBuffer() { return {begin(), end()}; }
+  std::span<char> GetCharBuffer() const {
+    return {reinterpret_cast<char*>(const_cast<uint8_t*>(begin())),
+            reinterpret_cast<char*>(const_cast<uint8_t*>(end()))};
+  }
 
   static std::unique_ptr<WritableMemoryBuffer> GetFile(
       std::string_view filename, std::error_code& ec, int64_t fileSize = -1);
@@ -196,6 +205,10 @@ class WriteThroughMemoryBuffer : public MemoryBuffer {
   uint8_t* begin() { return const_cast<uint8_t*>(MemoryBuffer::begin()); }
   uint8_t* end() { return const_cast<uint8_t*>(MemoryBuffer::end()); }
   std::span<uint8_t> GetBuffer() { return {begin(), end()}; }
+  std::span<char> GetCharBuffer() const {
+    return {reinterpret_cast<char*>(const_cast<uint8_t*>(begin())),
+            reinterpret_cast<char*>(const_cast<uint8_t*>(end()))};
+  }
 
   static std::unique_ptr<WriteThroughMemoryBuffer> GetFile(
       std::string_view filename, std::error_code& ec, int64_t fileSize = -1);


### PR DESCRIPTION
Add GetCharBuffer() to MemoryBuffer classes to make this easy.

Fixes #5876.