### PR TITLE
[hal] Sim: use setvbuf() instead of setlinebuf()

### DIFF
--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -379,10 +379,8 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
   }
 #endif  // _WIN32
 
-#ifndef _WIN32
-  setlinebuf(stdin);
-  setlinebuf(stdout);
-#endif
+  setvbuf(stdin, nullptr, _IOLBF, 0);
+  setvbuf(stdout, nullptr, _IOLBF, 0);
 
   if (HAL_LoadExtensions() < 0) {
     return false;

--- a/hal/src/main/native/sim/HAL.cpp
+++ b/hal/src/main/native/sim/HAL.cpp
@@ -379,8 +379,8 @@ HAL_Bool HAL_Initialize(int32_t timeout, int32_t mode) {
   }
 #endif  // _WIN32
 
-  setvbuf(stdin, nullptr, _IOLBF, 0);
-  setvbuf(stdout, nullptr, _IOLBF, 0);
+  std::setvbuf(stdin, nullptr, _IOLBF, 0);
+  std::setvbuf(stdout, nullptr, _IOLBF, 0);
 
   if (HAL_LoadExtensions() < 0) {
     return false;


### PR DESCRIPTION
This makes buffering work the same on Windows as well as Linux (setlinebuf is a Linux extension).