### PR TITLE
[build] Bump macOS deployment target to 12

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -61,7 +61,7 @@ jobs:
 
   build-host:
     env:
-      MACOSX_DEPLOYMENT_TARGET: 11
+      MACOSX_DEPLOYMENT_TARGET: 12
     strategy:
       fail-fast: false
       matrix:

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,5 +9,5 @@ repositories {
     }
 }
 dependencies {
-    implementation "edu.wpi.first:native-utils:2024.3.1"
+    implementation "edu.wpi.first:native-utils:2024.3.2"
 }


### PR DESCRIPTION
Depends on https://github.com/wpilibsuite/native-utils/pull/174.