### PR TITLE
Replace static_cast<void>() with [[maybe_unused]] attribute

### DIFF
--- a/crossConnIntegrationTests/src/main/native/include/LifetimeWrappers.h
+++ b/crossConnIntegrationTests/src/main/native/include/LifetimeWrappers.h
@@ -190,12 +190,12 @@ struct RelayHandle {
   HAL_RelayHandle handle = 0;
 };
 
-#define ASSERT_LAST_ERROR_STATUS(status, x)                          \
-  do {                                                               \
-    ASSERT_EQ(status, HAL_USE_LAST_ERROR);                           \
-    const char* lastErrorMessageInMacro = HAL_GetLastError(&status); \
-    static_cast<void>(lastErrorMessageInMacro);                      \
-    ASSERT_EQ(status, x);                                            \
+#define ASSERT_LAST_ERROR_STATUS(status, x)                \
+  do {                                                     \
+    ASSERT_EQ(status, HAL_USE_LAST_ERROR);                 \
+    [[maybe_unused]] const char* lastErrorMessageInMacro = \
+        HAL_GetLastError(&status);                         \
+    ASSERT_EQ(status, x);                                  \
   } while (0)
 
 }  // namespace hlt

--- a/wpimath/src/test/native/cpp/StateSpaceUtilTest.cpp
+++ b/wpimath/src/test/native/cpp/StateSpaceUtilTest.cpp
@@ -63,13 +63,12 @@ TEST(StateSpaceUtilTest, CovArray) {
 }
 
 TEST(StateSpaceUtilTest, WhiteNoiseVectorParameterPack) {
-  frc::Vectord<2> vec = frc::MakeWhiteNoiseVector(2.0, 3.0);
-  static_cast<void>(vec);
+  [[maybe_unused]] frc::Vectord<2> vec = frc::MakeWhiteNoiseVector(2.0, 3.0);
 }
 
 TEST(StateSpaceUtilTest, WhiteNoiseVectorArray) {
-  frc::Vectord<2> vec = frc::MakeWhiteNoiseVector<2>({2.0, 3.0});
-  static_cast<void>(vec);
+  [[maybe_unused]] frc::Vectord<2> vec =
+      frc::MakeWhiteNoiseVector<2>({2.0, 3.0});
 }
 
 TEST(StateSpaceUtilTest, IsStabilizable) {

--- a/wpimath/src/test/native/cpp/estimator/ExtendedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/ExtendedKalmanFilterTest.cpp
@@ -49,15 +49,13 @@ frc::Vectord<5> Dynamics(const frc::Vectord<5>& x, const frc::Vectord<2>& u) {
           k1.value() * ((C1 * vr).value() + (C2 * Vr).value())};
 }
 
-frc::Vectord<3> LocalMeasurementModel(const frc::Vectord<5>& x,
-                                      const frc::Vectord<2>& u) {
-  static_cast<void>(u);
+frc::Vectord<3> LocalMeasurementModel(
+    const frc::Vectord<5>& x, [[maybe_unused]] const frc::Vectord<2>& u) {
   return frc::Vectord<3>{x(2), x(3), x(4)};
 }
 
-frc::Vectord<5> GlobalMeasurementModel(const frc::Vectord<5>& x,
-                                       const frc::Vectord<2>& u) {
-  static_cast<void>(u);
+frc::Vectord<5> GlobalMeasurementModel(
+    const frc::Vectord<5>& x, [[maybe_unused]] const frc::Vectord<2>& u) {
   return frc::Vectord<5>{x(0), x(1), x(2), x(3), x(4)};
 }
 }  // namespace

--- a/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
+++ b/wpimath/src/test/native/cpp/estimator/UnscentedKalmanFilterTest.cpp
@@ -51,15 +51,13 @@ frc::Vectord<5> Dynamics(const frc::Vectord<5>& x, const frc::Vectord<2>& u) {
           k1.value() * ((C1 * vr).value() + (C2 * Vr).value())};
 }
 
-frc::Vectord<3> LocalMeasurementModel(const frc::Vectord<5>& x,
-                                      const frc::Vectord<2>& u) {
-  static_cast<void>(u);
+frc::Vectord<3> LocalMeasurementModel(
+    const frc::Vectord<5>& x, [[maybe_unused]] const frc::Vectord<2>& u) {
   return frc::Vectord<3>{x(2), x(3), x(4)};
 }
 
-frc::Vectord<5> GlobalMeasurementModel(const frc::Vectord<5>& x,
-                                       const frc::Vectord<2>& u) {
-  static_cast<void>(u);
+frc::Vectord<5> GlobalMeasurementModel(
+    const frc::Vectord<5>& x, [[maybe_unused]] const frc::Vectord<2>& u) {
   return frc::Vectord<5>{x(0), x(1), x(2), x(3), x(4)};
 }
 }  // namespace

--- a/wpimath/src/test/native/cpp/spline/CubicHermiteSplineTest.cpp
+++ b/wpimath/src/test/native/cpp/spline/CubicHermiteSplineTest.cpp
@@ -21,9 +21,6 @@ class CubicHermiteSplineTest : public ::testing::Test {
  protected:
   static void Run(const Pose2d& a, const std::vector<Translation2d>& waypoints,
                   const Pose2d& b) {
-    // Start the timer.
-    const auto start = std::chrono::high_resolution_clock::now();
-
     // Generate and parameterize the spline.
 
     const auto [startCV, endCV] =
@@ -39,13 +36,6 @@ class CubicHermiteSplineTest : public ::testing::Test {
       auto x = SplineParameterizer::Parameterize(spline);
       poses.insert(std::end(poses), std::begin(x) + 1, std::end(x));
     }
-
-    // End timer.
-    const auto finish = std::chrono::high_resolution_clock::now();
-
-    // Calculate the duration (used when benchmarking)
-    const auto duration =
-        std::chrono::duration_cast<std::chrono::microseconds>(finish - start);
 
     for (unsigned int i = 0; i < poses.size() - 1; i++) {
       auto& p0 = poses[i];
@@ -87,8 +77,6 @@ class CubicHermiteSplineTest : public ::testing::Test {
     EXPECT_NEAR(poses.back().first.Y().value(), b.Y().value(), 1E-9);
     EXPECT_NEAR(poses.back().first.Rotation().Radians().value(),
                 b.Rotation().Radians().value(), 1E-9);
-
-    static_cast<void>(duration);
   }
 };
 }  // namespace frc

--- a/wpimath/src/test/native/cpp/spline/QuinticHermiteSplineTest.cpp
+++ b/wpimath/src/test/native/cpp/spline/QuinticHermiteSplineTest.cpp
@@ -20,19 +20,9 @@ namespace frc {
 class QuinticHermiteSplineTest : public ::testing::Test {
  protected:
   static void Run(const Pose2d& a, const Pose2d& b) {
-    // Start the timer.
-    const auto start = std::chrono::high_resolution_clock::now();
-
     // Generate and parameterize the spline.
     const auto spline = SplineHelper::QuinticSplinesFromWaypoints({a, b})[0];
     const auto poses = SplineParameterizer::Parameterize(spline);
-
-    // End timer.
-    const auto finish = std::chrono::high_resolution_clock::now();
-
-    // Calculate the duration (used when benchmarking)
-    const auto duration =
-        std::chrono::duration_cast<std::chrono::microseconds>(finish - start);
 
     for (unsigned int i = 0; i < poses.size() - 1; i++) {
       auto& p0 = poses[i];
@@ -59,8 +49,6 @@ class QuinticHermiteSplineTest : public ::testing::Test {
     EXPECT_NEAR(poses.back().first.Y().value(), b.Y().value(), 1E-9);
     EXPECT_NEAR(poses.back().first.Rotation().Radians().value(),
                 b.Rotation().Radians().value(), 1E-9);
-
-    static_cast<void>(duration);
   }
 };
 }  // namespace frc

--- a/wpiutil/src/test/native/cpp/ArrayTest.cpp
+++ b/wpiutil/src/test/native/cpp/ArrayTest.cpp
@@ -16,20 +16,17 @@ class MoveOnlyType {
 }  // namespace
 
 TEST(ArrayTest, CopyableTypeCompiles) {
-  constexpr wpi::array<int, 3> arr1{1, 2, 3};
-  static_cast<void>(arr1);
+  [[maybe_unused]] constexpr wpi::array<int, 3> arr1{1, 2, 3};
 
   // Test deduction guide
-  constexpr wpi::array arr2{1, 2, 3};
-  static_cast<void>(arr2);
+  [[maybe_unused]] constexpr wpi::array arr2{1, 2, 3};
 }
 
 TEST(ArrayTest, MoveOnlyTypeCompiles) {
-  constexpr wpi::array<MoveOnlyType, 3> arr1{MoveOnlyType{}, MoveOnlyType{},
-                                             MoveOnlyType{}};
-  static_cast<void>(arr1);
+  [[maybe_unused]] constexpr wpi::array<MoveOnlyType, 3> arr1{
+      MoveOnlyType{}, MoveOnlyType{}, MoveOnlyType{}};
 
   // Test deduction guide
-  constexpr wpi::array arr2{MoveOnlyType{}, MoveOnlyType{}, MoveOnlyType{}};
-  static_cast<void>(arr2);
+  [[maybe_unused]] constexpr wpi::array arr2{MoveOnlyType{}, MoveOnlyType{},
+                                             MoveOnlyType{}};
 }


### PR DESCRIPTION
This clarifies intent. I didn't do this for thirdparty libraries or structured binding variables.