### PR TITLE
Declare platform launcher dependency explicitly

### DIFF
--- a/shared/java/javacommon.gradle
+++ b/shared/java/javacommon.gradle
@@ -117,9 +117,8 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     devImplementation sourceSets.main.output
 }

--- a/wpilibjExamples/build.gradle
+++ b/wpilibjExamples/build.gradle
@@ -25,9 +25,8 @@ dependencies {
     implementation project(':romiVendordep')
     implementation project(':xrpVendordep')
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 jacoco {


### PR DESCRIPTION
This fixes the warning message about automatic loading of test framework imlementation dependencies:

```
The automatic loading of test framework implementation dependencies has been deprecated. This is scheduled to be removed in Gradle 9.0. Declare the desired test framework directly on the test suite or explicitly declare the test framework implementation dependencies on the test's runtime classpath. Consult the upgrading guide for further information: https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#test_framework_implementation_dependencies
```

This *does not* fix the issue for wpilibjExamples- while I did update it for consistency, I believe the way the tests are created necessitates a different fix.

Applying the `junit-jupiter` dependency pulls in `junit-bom` to resolve versions, and also pulls `junit-jupiter-api`, `junit-jupiter-params`, and `junit-jupiter-engine`