### PR TITLE
[wpilibc,ntcoreffi] DataLogManager: join on Stop() call

### DIFF
--- a/ntcoreffi/src/main/native/cpp/DataLogManager.cpp
+++ b/ntcoreffi/src/main/native/cpp/DataLogManager.cpp
@@ -482,7 +482,7 @@ void DataLogManager::Start(std::string_view dir, std::string_view filename,
 void DataLogManager::Stop() {
   auto& inst = GetInstance();
   inst.owner.GetThread()->m_log.Stop();
-  inst.owner.Stop();
+  inst.owner.Join();
 }
 
 void DataLogManager::Log(std::string_view message) {

--- a/wpilibc/src/main/native/cpp/DataLogManager.cpp
+++ b/wpilibc/src/main/native/cpp/DataLogManager.cpp
@@ -328,7 +328,7 @@ void DataLogManager::Start(std::string_view dir, std::string_view filename,
 void DataLogManager::Stop() {
   auto& inst = GetInstance();
   inst.owner.GetThread()->m_log.Stop();
-  inst.owner.Stop();
+  inst.owner.Join();
 }
 
 void DataLogManager::Log(std::string_view message) {


### PR DESCRIPTION
This ensures the thread has finished prior to returning from Stop().