### PR TITLE
[build] Remove CMake flat install option 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,8 +163,6 @@ set( include_dest include )
 set( java_lib_dest java )
 set( jni_lib_dest jni )
 
-set(wpilib_config_dir share/wpilib)
-
 if (USE_SYSTEM_LIBUV)
 set (LIBUV_SYSTEM_REPLACE "
 find_dependency(libuv CONFIG)
@@ -335,4 +333,4 @@ if (WITH_SIMULATION_MODULES AND NOT WITH_EXTERNAL_HAL)
 endif()
 
 configure_file(wpilib-config.cmake.in ${WPILIB_BINARY_DIR}/wpilib-config.cmake )
-install(FILES ${WPILIB_BINARY_DIR}/wpilib-config.cmake DESTINATION ${wpilib_config_dir})
+install(FILES ${WPILIB_BINARY_DIR}/wpilib-config.cmake DESTINATION share/wpilib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,6 @@ option(USE_SYSTEM_FMTLIB "Use system fmtlib" OFF)
 option(USE_SYSTEM_LIBUV "Use system libuv" OFF)
 option(USE_SYSTEM_EIGEN "Use system eigen" OFF)
 
-# Options for installation.
-option(WITH_FLAT_INSTALL "Use a flat install directory" OFF)
-
 # Options for location of OpenCV Java.
 set(OPENCV_JAVA_INSTALL_DIR "" CACHE PATH "Location to search for the OpenCV jar file")
 
@@ -162,16 +159,11 @@ FATAL: Cannot build Java wpimath without wpiunits.
 ")
 endif()
 
-set( wpilib_dest "")
 set( include_dest include )
 set( java_lib_dest java )
 set( jni_lib_dest jni )
 
-if (WITH_FLAT_INSTALL)
-    set (wpilib_config_dir ${wpilib_dest})
-else()
-    set (wpilib_config_dir share/wpilib)
-endif()
+set(wpilib_config_dir share/wpilib)
 
 if (USE_SYSTEM_LIBUV)
 set (LIBUV_SYSTEM_REPLACE "
@@ -191,18 +183,6 @@ find_program(Quickbuf_EXECUTABLE
     DOC "The Quickbuf protoc plugin"
 )
 
-if (WITH_FLAT_INSTALL)
-set(WPIUTIL_DEP_REPLACE "include($\{SELF_DIR\}/wpiutil-config.cmake)")
-set(WPINET_DEP_REPLACE "include($\{SELF_DIR\}/wpinet-config.cmake)")
-set(NTCORE_DEP_REPLACE "include($\{SELF_DIR\}/ntcore-config.cmake)")
-set(CSCORE_DEP_REPLACE_IMPL "include(\${SELF_DIR}/cscore-config.cmake)")
-set(CAMERASERVER_DEP_REPLACE_IMPL "include(\${SELF_DIR}/cameraserver-config.cmake)")
-set(HAL_DEP_REPLACE_IMPL "include(\${SELF_DIR}/hal-config.cmake)")
-set(WPIMATH_DEP_REPLACE "include($\{SELF_DIR\}/wpimath-config.cmake)")
-set(WPIUNITS_DEP_REPLACE "include($\{SELF_DIR\}/wpiunits-config.cmake)")
-set(WPILIBC_DEP_REPLACE_IMPL "include(\${SELF_DIR}/wpilibc-config.cmake)")
-set(WPILIBNEWCOMMANDS_DEP_REPLACE "include(\${SELF_DIR}/wpilibNewcommands-config.cmake)")
-else()
 set(WPIUTIL_DEP_REPLACE "find_dependency(wpiutil)")
 set(WPINET_DEP_REPLACE "find_dependency(wpinet)")
 set(NTCORE_DEP_REPLACE "find_dependency(ntcore)")
@@ -213,7 +193,6 @@ set(WPIMATH_DEP_REPLACE "find_dependency(wpimath)")
 set(WPIUNITS_DEP_REPLACE "find_dependency(wpiunits)")
 set(WPILIBC_DEP_REPLACE_IMPL "find_dependency(wpilibc)")
 set(WPILIBNEWCOMMANDS_DEP_REPLACE "find_dependency(wpilibNewCommands)")
-endif()
 
 set(FILENAME_DEP_REPLACE "get_filename_component(SELF_DIR \"$\{CMAKE_CURRENT_LIST_FILE\}\" PATH)")
 set(SELF_DIR "$\{SELF_DIR\}")

--- a/apriltag/CMakeLists.txt
+++ b/apriltag/CMakeLists.txt
@@ -108,11 +108,10 @@ target_include_directories(apriltag PUBLIC
 install(TARGETS apriltag EXPORT apriltag)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/apriltag")
 
-set(apriltag_config_dir share/apriltag)
 
 configure_file(apriltag-config.cmake.in ${WPILIB_BINARY_DIR}/apriltag-config.cmake )
-install(FILES ${WPILIB_BINARY_DIR}/apriltag-config.cmake DESTINATION ${apriltag_config_dir})
-install(EXPORT apriltag DESTINATION ${apriltag_config_dir})
+install(FILES ${WPILIB_BINARY_DIR}/apriltag-config.cmake DESTINATION share/apriltag)
+install(EXPORT apriltag DESTINATION share/apriltag)
 
 if (WITH_TESTS)
     wpilib_add_test(apriltag src/test/native/cpp)

--- a/apriltag/CMakeLists.txt
+++ b/apriltag/CMakeLists.txt
@@ -108,11 +108,7 @@ target_include_directories(apriltag PUBLIC
 install(TARGETS apriltag EXPORT apriltag)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/apriltag")
 
-if (WITH_FLAT_INSTALL)
-    set (apriltag_config_dir ${wpilib_dest})
-else()
-    set (apriltag_config_dir share/apriltag)
-endif()
+set(apriltag_config_dir share/apriltag)
 
 configure_file(apriltag-config.cmake.in ${WPILIB_BINARY_DIR}/apriltag-config.cmake )
 install(FILES ${WPILIB_BINARY_DIR}/apriltag-config.cmake DESTINATION ${apriltag_config_dir})

--- a/cameraserver/CMakeLists.txt
+++ b/cameraserver/CMakeLists.txt
@@ -59,11 +59,7 @@ set_property(TARGET cameraserver PROPERTY FOLDER "libraries")
 install(TARGETS cameraserver EXPORT cameraserver)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/cameraserver")
 
-if (WITH_FLAT_INSTALL)
-    set (cameraserver_config_dir ${wpilib_dest})
-else()
-    set (cameraserver_config_dir share/cameraserver)
-endif()
+set(cameraserver_config_dir share/cameraserver)
 
 configure_file(cameraserver-config.cmake.in ${WPILIB_BINARY_DIR}/cameraserver-config.cmake )
 install(FILES ${WPILIB_BINARY_DIR}/cameraserver-config.cmake DESTINATION ${cameraserver_config_dir})

--- a/cameraserver/CMakeLists.txt
+++ b/cameraserver/CMakeLists.txt
@@ -59,11 +59,9 @@ set_property(TARGET cameraserver PROPERTY FOLDER "libraries")
 install(TARGETS cameraserver EXPORT cameraserver)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/cameraserver")
 
-set(cameraserver_config_dir share/cameraserver)
-
 configure_file(cameraserver-config.cmake.in ${WPILIB_BINARY_DIR}/cameraserver-config.cmake )
-install(FILES ${WPILIB_BINARY_DIR}/cameraserver-config.cmake DESTINATION ${cameraserver_config_dir})
-install(EXPORT cameraserver DESTINATION ${cameraserver_config_dir})
+install(FILES ${WPILIB_BINARY_DIR}/cameraserver-config.cmake DESTINATION share/cameraserver)
+install(EXPORT cameraserver DESTINATION share/cameraserver)
 
 file(GLOB multiCameraServer_src multiCameraServer/src/main/native/cpp/*.cpp)
 add_executable(multiCameraServer ${multiCameraServer_src})

--- a/cscore/CMakeLists.txt
+++ b/cscore/CMakeLists.txt
@@ -43,13 +43,9 @@ set_property(TARGET cscore PROPERTY FOLDER "libraries")
 install(TARGETS cscore EXPORT cscore)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/cscore")
 
-set(cscore_config_dir share/cscore)
-
-
-
 configure_file(cscore-config.cmake.in ${WPILIB_BINARY_DIR}/cscore-config.cmake )
-install(FILES ${WPILIB_BINARY_DIR}/cscore-config.cmake DESTINATION ${cscore_config_dir})
-install(EXPORT cscore DESTINATION ${cscore_config_dir})
+install(FILES ${WPILIB_BINARY_DIR}/cscore-config.cmake DESTINATION share/cscore)
+install(EXPORT cscore DESTINATION share/cscore)
 
 subdir_list(cscore_examples "${CMAKE_CURRENT_SOURCE_DIR}/examples")
 foreach(example ${cscore_examples})

--- a/cscore/CMakeLists.txt
+++ b/cscore/CMakeLists.txt
@@ -43,11 +43,9 @@ set_property(TARGET cscore PROPERTY FOLDER "libraries")
 install(TARGETS cscore EXPORT cscore)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/cscore")
 
-if (WITH_FLAT_INSTALL)
-    set (cscore_config_dir ${wpilib_dest})
-else()
-    set (cscore_config_dir share/cscore)
-endif()
+set(cscore_config_dir share/cscore)
+
+
 
 configure_file(cscore-config.cmake.in ${WPILIB_BINARY_DIR}/cscore-config.cmake )
 install(FILES ${WPILIB_BINARY_DIR}/cscore-config.cmake DESTINATION ${cscore_config_dir})

--- a/glass/CMakeLists.txt
+++ b/glass/CMakeLists.txt
@@ -73,13 +73,3 @@ if (WIN32)
 elseif(APPLE)
     set_target_properties(glass PROPERTIES MACOSX_BUNDLE YES OUTPUT_NAME "Glass")
 endif()
-
-#if (MSVC OR FLAT_INSTALL_WPILIB)
-#    set (wpigui_config_dir ${wpilib_dest})
-#else()
-#    set (wpigui_config_dir share/wpigui)
-#endif()
-
-#configure_file(wpigui-config.cmake.in ${CMAKE_BINARY_DIR}/wpigui-config.cmake )
-#install(FILES ${CMAKE_BINARY_DIR}/wpigui-config.cmake DESTINATION ${wpigui_config_dir})
-#install(EXPORT wpigui DESTINATION ${wpigui_config_dir})

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -59,11 +59,7 @@ install(TARGETS hal EXPORT hal)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/hal")
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gen/ DESTINATION "${include_dest}/hal")
 
-if (WITH_FLAT_INSTALL)
-    set (hal_config_dir ${wpilib_dest})
-else()
-    set (hal_config_dir share/hal)
-endif()
+set(hal_config_dir share/hal)
 
 configure_file(hal-config.cmake.in ${WPILIB_BINARY_DIR}/hal-config.cmake )
 install(FILES ${WPILIB_BINARY_DIR}/hal-config.cmake DESTINATION ${hal_config_dir})

--- a/hal/CMakeLists.txt
+++ b/hal/CMakeLists.txt
@@ -59,11 +59,9 @@ install(TARGETS hal EXPORT hal)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/hal")
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gen/ DESTINATION "${include_dest}/hal")
 
-set(hal_config_dir share/hal)
-
 configure_file(hal-config.cmake.in ${WPILIB_BINARY_DIR}/hal-config.cmake )
-install(FILES ${WPILIB_BINARY_DIR}/hal-config.cmake DESTINATION ${hal_config_dir})
-install(EXPORT hal DESTINATION ${hal_config_dir})
+install(FILES ${WPILIB_BINARY_DIR}/hal-config.cmake DESTINATION share/hal)
+install(EXPORT hal DESTINATION share/hal)
 
 # Java bindings
 if (WITH_JAVA)

--- a/ntcore/CMakeLists.txt
+++ b/ntcore/CMakeLists.txt
@@ -37,11 +37,9 @@ install(TARGETS ntcore EXPORT ntcore)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/ntcore")
 install(DIRECTORY ${WPILIB_BINARY_DIR}/ntcore/generated/main/native/include/ DESTINATION "${include_dest}/ntcore")
 
-set(ntcore_config_dir share/ntcore)
-
 configure_file(ntcore-config.cmake.in ${WPILIB_BINARY_DIR}/ntcore-config.cmake )
-install(FILES ${WPILIB_BINARY_DIR}/ntcore-config.cmake DESTINATION ${ntcore_config_dir})
-install(EXPORT ntcore DESTINATION ${ntcore_config_dir})
+install(FILES ${WPILIB_BINARY_DIR}/ntcore-config.cmake DESTINATION share/ntcore)
+install(EXPORT ntcore DESTINATION share/ntcore)
 
 # Java bindings
 if (WITH_JAVA)

--- a/ntcore/CMakeLists.txt
+++ b/ntcore/CMakeLists.txt
@@ -37,11 +37,7 @@ install(TARGETS ntcore EXPORT ntcore)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/ntcore")
 install(DIRECTORY ${WPILIB_BINARY_DIR}/ntcore/generated/main/native/include/ DESTINATION "${include_dest}/ntcore")
 
-if (WITH_FLAT_INSTALL)
-    set (ntcore_config_dir ${wpilib_dest})
-else()
-    set (ntcore_config_dir share/ntcore)
-endif()
+set(ntcore_config_dir share/ntcore)
 
 configure_file(ntcore-config.cmake.in ${WPILIB_BINARY_DIR}/ntcore-config.cmake )
 install(FILES ${WPILIB_BINARY_DIR}/ntcore-config.cmake DESTINATION ${ntcore_config_dir})

--- a/romiVendordep/CMakeLists.txt
+++ b/romiVendordep/CMakeLists.txt
@@ -16,8 +16,6 @@ if (WITH_JAVA)
   install(FILES ${ROMIVENDORDEP_JAR_FILE} DESTINATION "${java_lib_dest}")
 
   set_property(TARGET romiVendordep_jar PROPERTY FOLDER "java")
-
-  set(romiVendordep_config_dir share/romiVendordep)
 endif()
 
 if (WITH_JAVA_SOURCE)
@@ -50,11 +48,9 @@ target_include_directories(romiVendordep PUBLIC
 install(TARGETS romiVendordep EXPORT romiVendordep DESTINATION "${main_lib_dest}")
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/romiVendordep")
 
-set(romiVendordep_config_dir share/romiVendordep)
-
- configure_file(romiVendordep-config.cmake.in ${WPILIB_BINARY_DIR}/romiVendordep-config.cmake)
- install(FILES ${WPILIB_BINARY_DIR}/romiVendordep-config.cmake DESTINATION ${romiVendordep_config_dir})
- install(EXPORT romiVendordep DESTINATION ${romiVendordep_config_dir})
+configure_file(romiVendordep-config.cmake.in ${WPILIB_BINARY_DIR}/romiVendordep-config.cmake)
+install(FILES ${WPILIB_BINARY_DIR}/romiVendordep-config.cmake DESTINATION share/romiVendordep)
+install(EXPORT romiVendordep DESTINATION share/romiVendordep)
 
  if (WITH_TESTS)
      wpilib_add_test(romiVendordep src/test/native/cpp)

--- a/romiVendordep/CMakeLists.txt
+++ b/romiVendordep/CMakeLists.txt
@@ -17,11 +17,7 @@ if (WITH_JAVA)
 
   set_property(TARGET romiVendordep_jar PROPERTY FOLDER "java")
 
-  if (WITH_FLAT_INSTALL)
-      set (romiVendordep_config_dir ${wpilib_dest})
-  else()
-      set (romiVendordep_config_dir share/romiVendordep)
-  endif()
+  set(romiVendordep_config_dir share/romiVendordep)
 endif()
 
 if (WITH_JAVA_SOURCE)
@@ -54,11 +50,7 @@ target_include_directories(romiVendordep PUBLIC
 install(TARGETS romiVendordep EXPORT romiVendordep DESTINATION "${main_lib_dest}")
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/romiVendordep")
 
-if (FLAT_INSTALL_WPILIB)
-     set(romiVendordep_config_dir ${wpilib_dest})
- else()
-     set(romiVendordep_config_dir share/romiVendordep)
- endif()
+set(romiVendordep_config_dir share/romiVendordep)
 
  configure_file(romiVendordep-config.cmake.in ${WPILIB_BINARY_DIR}/romiVendordep-config.cmake)
  install(FILES ${WPILIB_BINARY_DIR}/romiVendordep-config.cmake DESTINATION ${romiVendordep_config_dir})

--- a/wpigui/CMakeLists.txt
+++ b/wpigui/CMakeLists.txt
@@ -44,13 +44,3 @@ target_link_libraries(wpiguidev wpigui)
 
 install(TARGETS wpigui EXPORT wpigui)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/wpigui")
-
-#if (WITH_FLAT_INSTALL)
-#    set (wpigui_config_dir ${wpilib_dest})
-#else()
-#    set (wpigui_config_dir share/wpigui)
-#endif()
-
-#configure_file(wpigui-config.cmake.in ${WPILIB_BINARY_DIR}/wpigui-config.cmake )
-#install(FILES ${WPILIB_BINARY_DIR}/wpigui-config.cmake DESTINATION ${wpigui_config_dir})
-#install(EXPORT wpigui DESTINATION ${wpigui_config_dir})

--- a/wpilibNewCommands/CMakeLists.txt
+++ b/wpilibNewCommands/CMakeLists.txt
@@ -16,8 +16,6 @@ if (WITH_JAVA)
   install(FILES ${WPILIBNEWCOMMANDS_JAR_FILE} DESTINATION "${java_lib_dest}")
 
   set_property(TARGET wpilibNewCommands_jar PROPERTY FOLDER "java")
-
-  set(wpilibNewCommands_config_dir share/wpilibNewCommands)
 endif()
 
 if (WITH_JAVA_SOURCE)
@@ -52,11 +50,9 @@ target_include_directories(wpilibNewCommands PUBLIC
 install(TARGETS wpilibNewCommands EXPORT wpilibNewCommands)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/wpilibNewCommands")
 
-set(wpilibNewCommands_config_dir share/wpilibNewCommands)
-
- configure_file(wpilibNewCommands-config.cmake.in ${WPILIB_BINARY_DIR}/wpilibNewCommands-config.cmake)
- install(FILES ${WPILIB_BINARY_DIR}/wpilibNewCommands-config.cmake DESTINATION ${wpilibNewCommands_config_dir})
- install(EXPORT wpilibNewCommands DESTINATION ${wpilibNewCommands_config_dir})
+configure_file(wpilibNewCommands-config.cmake.in ${WPILIB_BINARY_DIR}/wpilibNewCommands-config.cmake)
+install(FILES ${WPILIB_BINARY_DIR}/wpilibNewCommands-config.cmake DESTINATION share/wpilibNewCommands)
+install(EXPORT wpilibNewCommands DESTINATION share/wpilibNewCommands)
 
  if (WITH_TESTS)
      wpilib_add_test(wpilibNewCommands src/test/native/cpp)

--- a/wpilibNewCommands/CMakeLists.txt
+++ b/wpilibNewCommands/CMakeLists.txt
@@ -17,11 +17,7 @@ if (WITH_JAVA)
 
   set_property(TARGET wpilibNewCommands_jar PROPERTY FOLDER "java")
 
-  if (WITH_FLAT_INSTALL)
-      set (wpilibNewCommands_config_dir ${wpilib_dest})
-  else()
-      set (wpilibNewCommands_config_dir share/wpilibNewCommands)
-  endif()
+  set(wpilibNewCommands_config_dir share/wpilibNewCommands)
 endif()
 
 if (WITH_JAVA_SOURCE)
@@ -56,11 +52,7 @@ target_include_directories(wpilibNewCommands PUBLIC
 install(TARGETS wpilibNewCommands EXPORT wpilibNewCommands)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/wpilibNewCommands")
 
-if (FLAT_INSTALL_WPILIB)
-     set(wpilibNewCommands_config_dir ${wpilib_dest})
- else()
-     set(wpilibNewCommands_config_dir share/wpilibNewCommands)
- endif()
+set(wpilibNewCommands_config_dir share/wpilibNewCommands)
 
  configure_file(wpilibNewCommands-config.cmake.in ${WPILIB_BINARY_DIR}/wpilibNewCommands-config.cmake)
  install(FILES ${WPILIB_BINARY_DIR}/wpilibNewCommands-config.cmake DESTINATION ${wpilibNewCommands_config_dir})

--- a/wpilibc/CMakeLists.txt
+++ b/wpilibc/CMakeLists.txt
@@ -33,11 +33,7 @@ set_property(TARGET wpilibc PROPERTY FOLDER "libraries")
 install(TARGETS wpilibc EXPORT wpilibc)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/wpilibc")
 
-if (WITH_FLAT_INSTALL)
-    set (wpilibc_config_dir ${wpilib_dest})
-else()
-    set (wpilibc_config_dir share/wpilibc)
-endif()
+set(wpilibc_config_dir share/wpilibc)
 
 configure_file(wpilibc-config.cmake.in ${WPILIB_BINARY_DIR}/wpilibc-config.cmake )
 install(FILES ${WPILIB_BINARY_DIR}/wpilibc-config.cmake DESTINATION ${wpilibc_config_dir})

--- a/wpilibc/CMakeLists.txt
+++ b/wpilibc/CMakeLists.txt
@@ -33,11 +33,9 @@ set_property(TARGET wpilibc PROPERTY FOLDER "libraries")
 install(TARGETS wpilibc EXPORT wpilibc)
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/wpilibc")
 
-set(wpilibc_config_dir share/wpilibc)
-
 configure_file(wpilibc-config.cmake.in ${WPILIB_BINARY_DIR}/wpilibc-config.cmake )
-install(FILES ${WPILIB_BINARY_DIR}/wpilibc-config.cmake DESTINATION ${wpilibc_config_dir})
-install(EXPORT wpilibc DESTINATION ${wpilibc_config_dir})
+install(FILES ${WPILIB_BINARY_DIR}/wpilibc-config.cmake DESTINATION share/wpilibc)
+install(EXPORT wpilibc DESTINATION share/wpilibc)
 
 if (WITH_TESTS)
     wpilib_add_test(wpilibc src/test/native/cpp)

--- a/wpilibj/CMakeLists.txt
+++ b/wpilibj/CMakeLists.txt
@@ -24,11 +24,7 @@ if (WITH_JAVA)
 
     set_property(TARGET wpilibj_jar PROPERTY FOLDER "java")
 
-    if (WITH_FLAT_INSTALL)
-        set (wpilibj_config_dir ${wpilib_dest})
-    else()
-        set (wpilibj_config_dir share/wpilibj)
-    endif()
+    set(wpilibj_config_dir share/wpilibj)
 
     install(FILES wpilibj-config.cmake DESTINATION ${wpilibj_config_dir})
 endif()

--- a/wpilibj/CMakeLists.txt
+++ b/wpilibj/CMakeLists.txt
@@ -24,9 +24,7 @@ if (WITH_JAVA)
 
     set_property(TARGET wpilibj_jar PROPERTY FOLDER "java")
 
-    set(wpilibj_config_dir share/wpilibj)
-
-    install(FILES wpilibj-config.cmake DESTINATION ${wpilibj_config_dir})
+    install(FILES wpilibj-config.cmake DESTINATION share/wpilibj)
 endif()
 
 if (WITH_JAVA_SOURCE)

--- a/wpimath/CMakeLists.txt
+++ b/wpimath/CMakeLists.txt
@@ -208,11 +208,9 @@ target_include_directories(wpimath PUBLIC
 
 install(TARGETS wpimath EXPORT wpimath)
 
-set(wpimath_config_dir share/wpimath)
-
 configure_file(wpimath-config.cmake.in ${WPILIB_BINARY_DIR}/wpimath-config.cmake )
-install(FILES ${WPILIB_BINARY_DIR}/wpimath-config.cmake DESTINATION ${wpimath_config_dir})
-install(EXPORT wpimath DESTINATION ${wpimath_config_dir})
+install(FILES ${WPILIB_BINARY_DIR}/wpimath-config.cmake DESTINATION share/wpimath)
+install(EXPORT wpimath DESTINATION share/wpimath)
 
 if (WITH_TESTS)
     wpilib_add_test(wpimath src/test/native/cpp)

--- a/wpimath/CMakeLists.txt
+++ b/wpimath/CMakeLists.txt
@@ -208,11 +208,7 @@ target_include_directories(wpimath PUBLIC
 
 install(TARGETS wpimath EXPORT wpimath)
 
-if (WITH_FLAT_INSTALL)
-    set (wpimath_config_dir ${wpilib_dest})
-else()
-    set (wpimath_config_dir share/wpimath)
-endif()
+set(wpimath_config_dir share/wpimath)
 
 configure_file(wpimath-config.cmake.in ${WPILIB_BINARY_DIR}/wpimath-config.cmake )
 install(FILES ${WPILIB_BINARY_DIR}/wpimath-config.cmake DESTINATION ${wpimath_config_dir})

--- a/wpinet/CMakeLists.txt
+++ b/wpinet/CMakeLists.txt
@@ -173,11 +173,9 @@ target_include_directories(wpinet PUBLIC
 
 install(TARGETS wpinet EXPORT wpinet)
 
-set(wpinet_config_dir share/wpinet)
-
 configure_file(wpinet-config.cmake.in ${WPILIB_BINARY_DIR}/wpinet-config.cmake )
-install(FILES ${WPILIB_BINARY_DIR}/wpinet-config.cmake DESTINATION ${wpinet_config_dir})
-install(EXPORT wpinet DESTINATION ${wpinet_config_dir})
+install(FILES ${WPILIB_BINARY_DIR}/wpinet-config.cmake DESTINATION share/wpinet)
+install(EXPORT wpinet DESTINATION share/wpinet)
 
 subdir_list(wpinet_examples "${CMAKE_CURRENT_SOURCE_DIR}/examples")
 foreach(example ${wpinet_examples})

--- a/wpinet/CMakeLists.txt
+++ b/wpinet/CMakeLists.txt
@@ -173,11 +173,7 @@ target_include_directories(wpinet PUBLIC
 
 install(TARGETS wpinet EXPORT wpinet)
 
-if (WITH_FLAT_INSTALL)
-    set (wpinet_config_dir ${wpilib_dest})
-else()
-    set (wpinet_config_dir share/wpinet)
-endif()
+set(wpinet_config_dir share/wpinet)
 
 configure_file(wpinet-config.cmake.in ${WPILIB_BINARY_DIR}/wpinet-config.cmake )
 install(FILES ${WPILIB_BINARY_DIR}/wpinet-config.cmake DESTINATION ${wpinet_config_dir})

--- a/wpiunits/CMakeLists.txt
+++ b/wpiunits/CMakeLists.txt
@@ -15,11 +15,7 @@ if (WITH_JAVA)
 
     set_property(TARGET wpiunits_jar PROPERTY FOLDER "java")
 
-    if (WITH_FLAT_INSTALL)
-        set (wpiunits_config_dir ${wpiunits_dest})
-    else()
-        set (wpiunits_config_dir share/wpiunits)
-    endif()
+    set(wpiunits_config_dir share/wpiunits)
 
     install(FILES wpiunits-config.cmake DESTINATION ${wpiunits_config_dir})
 endif()

--- a/wpiunits/CMakeLists.txt
+++ b/wpiunits/CMakeLists.txt
@@ -15,7 +15,5 @@ if (WITH_JAVA)
 
     set_property(TARGET wpiunits_jar PROPERTY FOLDER "java")
 
-    set(wpiunits_config_dir share/wpiunits)
-
-    install(FILES wpiunits-config.cmake DESTINATION ${wpiunits_config_dir})
+    install(FILES wpiunits-config.cmake DESTINATION share/wpiunits)
 endif()

--- a/wpiutil/CMakeLists.txt
+++ b/wpiutil/CMakeLists.txt
@@ -205,11 +205,9 @@ target_include_directories(wpiutil PUBLIC
 
 install(TARGETS wpiutil EXPORT wpiutil)
 
-set(wpiutil_config_dir share/wpiutil)
-
 configure_file(wpiutil-config.cmake.in ${WPILIB_BINARY_DIR}/wpiutil-config.cmake )
-install(FILES ${WPILIB_BINARY_DIR}/wpiutil-config.cmake DESTINATION ${wpiutil_config_dir})
-install(EXPORT wpiutil DESTINATION ${wpiutil_config_dir})
+install(FILES ${WPILIB_BINARY_DIR}/wpiutil-config.cmake DESTINATION share/wpiutil)
+install(EXPORT wpiutil DESTINATION share/wpiutil)
 
 subdir_list(wpiutil_examples "${CMAKE_CURRENT_SOURCE_DIR}/examples")
 foreach(example ${wpiutil_examples})

--- a/wpiutil/CMakeLists.txt
+++ b/wpiutil/CMakeLists.txt
@@ -205,11 +205,7 @@ target_include_directories(wpiutil PUBLIC
 
 install(TARGETS wpiutil EXPORT wpiutil)
 
-if (WITH_FLAT_INSTALL)
-    set (wpiutil_config_dir ${wpilib_dest})
-else()
-    set (wpiutil_config_dir share/wpiutil)
-endif()
+set(wpiutil_config_dir share/wpiutil)
 
 configure_file(wpiutil-config.cmake.in ${WPILIB_BINARY_DIR}/wpiutil-config.cmake )
 install(FILES ${WPILIB_BINARY_DIR}/wpiutil-config.cmake DESTINATION ${wpiutil_config_dir})

--- a/xrpVendordep/CMakeLists.txt
+++ b/xrpVendordep/CMakeLists.txt
@@ -17,11 +17,7 @@ if (WITH_JAVA)
 
   set_property(TARGET xrpVendordep_jar PROPERTY FOLDER "java")
 
-  if (WITH_FLAT_INSTALL)
-      set (xrpVendordep_config_dir ${wpilib_dest})
-  else()
-      set (xrpVendordep_config_dir share/xrpVendordep)
-  endif()
+  set(xrpVendordep_config_dir share/xrpVendordep)
 endif()
 
 if (WITH_JAVA_SOURCE)
@@ -54,11 +50,7 @@ target_include_directories(xrpVendordep PUBLIC
 install(TARGETS xrpVendordep EXPORT xrpVendordep DESTINATION "${main_lib_dest}")
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/xrpVendordep")
 
-if (FLAT_INSTALL_WPILIB)
-     set(xrpVendordep_config_dir ${wpilib_dest})
- else()
-     set(xrpVendordep_config_dir share/xrpVendordep)
- endif()
+set(xrpVendordep_config_dir share/xrpVendordep)
 
  configure_file(xrpVendordep-config.cmake.in ${WPILIB_BINARY_DIR}/xrpVendordep-config.cmake)
  install(FILES ${WPILIB_BINARY_DIR}/xrpVendordep-config.cmake DESTINATION ${xrpVendordep_config_dir})

--- a/xrpVendordep/CMakeLists.txt
+++ b/xrpVendordep/CMakeLists.txt
@@ -16,8 +16,6 @@ if (WITH_JAVA)
   install(FILES ${xrpVendordep_JAR_FILE} DESTINATION "${java_lib_dest}")
 
   set_property(TARGET xrpVendordep_jar PROPERTY FOLDER "java")
-
-  set(xrpVendordep_config_dir share/xrpVendordep)
 endif()
 
 if (WITH_JAVA_SOURCE)
@@ -50,11 +48,9 @@ target_include_directories(xrpVendordep PUBLIC
 install(TARGETS xrpVendordep EXPORT xrpVendordep DESTINATION "${main_lib_dest}")
 install(DIRECTORY src/main/native/include/ DESTINATION "${include_dest}/xrpVendordep")
 
-set(xrpVendordep_config_dir share/xrpVendordep)
-
- configure_file(xrpVendordep-config.cmake.in ${WPILIB_BINARY_DIR}/xrpVendordep-config.cmake)
- install(FILES ${WPILIB_BINARY_DIR}/xrpVendordep-config.cmake DESTINATION ${xrpVendordep_config_dir})
- install(EXPORT xrpVendordep DESTINATION ${xrpVendordep_config_dir})
+configure_file(xrpVendordep-config.cmake.in ${WPILIB_BINARY_DIR}/xrpVendordep-config.cmake)
+install(FILES ${WPILIB_BINARY_DIR}/xrpVendordep-config.cmake DESTINATION share/xrpVendordep)
+install(EXPORT xrpVendordep DESTINATION share/xrpVendordep)
 
  if (WITH_TESTS)
      wpilib_add_test(xrpVendordep src/test/native/cpp)


### PR DESCRIPTION
It's been broken for a while, and probably isn't useful, since people can use CMake to pull in all the files.

Also removes some commented out flat install code.