### PR TITLE
[upstream_utils] Fix fmt compilation errors on Windows

### DIFF
--- a/upstream_utils/fmt_patches/0001-Don-t-throw-on-write-failure.patch
+++ b/upstream_utils/fmt_patches/0001-Don-t-throw-on-write-failure.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Wed, 18 May 2022 10:21:49 -0700
-Subject: [PATCH 1/2] Don't throw on write failure
+Subject: [PATCH 1/3] Don't throw on write failure
 
 ---
  include/fmt/format-inl.h | 4 +---

--- a/upstream_utils/fmt_patches/0002-Suppress-warnings-we-can-t-fix.patch
+++ b/upstream_utils/fmt_patches/0002-Suppress-warnings-we-can-t-fix.patch
@@ -1,14 +1,14 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tyler Veness <calcmogul@gmail.com>
 Date: Tue, 16 May 2023 13:49:18 -0700
-Subject: [PATCH 2/2] Suppress warnings we can't fix
+Subject: [PATCH 2/3] Suppress warnings we can't fix
 
 ---
  include/fmt/format.h | 7 +++++++
  1 file changed, 7 insertions(+)
 
 diff --git a/include/fmt/format.h b/include/fmt/format.h
-index e5bd8b110efe49e12a12b004ea246a4dba671a6f..f11be0d6d58f3d992d7d06adb3d9576f81ecfe11 100644
+index 87a34b972ce6af4e2209e4d6cf78e8401e8f0037..ac0f52def2f3e2bc88d11903f5532efd89af454d 100644
 --- a/include/fmt/format.h
 +++ b/include/fmt/format.h
 @@ -1324,7 +1324,14 @@ inline auto equal2(const char* lhs, const char* rhs) -> bool {

--- a/upstream_utils/fmt_patches/0003-Remove-this-from-decltype.patch
+++ b/upstream_utils/fmt_patches/0003-Remove-this-from-decltype.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Peter Johnson <johnson.peter@gmail.com>
+Date: Mon, 20 Nov 2023 23:29:02 -0800
+Subject: [PATCH 3/3] Remove this from decltype
+
+This doesn't work on the most recent version of MSVC.
+---
+ include/fmt/core.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/fmt/core.h b/include/fmt/core.h
+index 1fe13888a00263a085032272482475e5dafbef26..915d8952d5f6d5255f5a1aab956ef56245b80dc4 100644
+--- a/include/fmt/core.h
++++ b/include/fmt/core.h
+@@ -1435,7 +1435,7 @@ template <typename Context> struct arg_mapper {
+   // Only map owning types because mapping views can be unsafe.
+   template <typename T, typename U = format_as_t<T>,
+             FMT_ENABLE_IF(std::is_arithmetic<U>::value)>
+-  FMT_CONSTEXPR FMT_INLINE auto map(const T& val) -> decltype(this->map(U())) {
++  FMT_CONSTEXPR FMT_INLINE auto map(const T& val) -> decltype(map(U())) {
+     return map(format_as(val));
+   }
+ 
+@@ -1459,13 +1459,13 @@ template <typename Context> struct arg_mapper {
+                           !is_string<U>::value && !is_char<U>::value &&
+                           !is_named_arg<U>::value &&
+                           !std::is_arithmetic<format_as_t<U>>::value)>
+-  FMT_CONSTEXPR FMT_INLINE auto map(T& val) -> decltype(this->do_map(val)) {
++  FMT_CONSTEXPR FMT_INLINE auto map(T& val) -> decltype(do_map(val)) {
+     return do_map(val);
+   }
+ 
+   template <typename T, FMT_ENABLE_IF(is_named_arg<T>::value)>
+   FMT_CONSTEXPR FMT_INLINE auto map(const T& named_arg)
+-      -> decltype(this->map(named_arg.value)) {
++      -> decltype(map(named_arg.value)) {
+     return map(named_arg.value);
+   }
+ 

--- a/upstream_utils/update_fmt.py
+++ b/upstream_utils/update_fmt.py
@@ -22,6 +22,7 @@ def main():
     for f in [
         "0001-Don-t-throw-on-write-failure.patch",
         "0002-Suppress-warnings-we-can-t-fix.patch",
+        "0003-Remove-this-from-decltype.patch",
     ]:
         git_am(os.path.join(wpilib_root, "upstream_utils/fmt_patches", f))
 

--- a/wpiutil/src/main/native/thirdparty/fmtlib/include/fmt/core.h
+++ b/wpiutil/src/main/native/thirdparty/fmtlib/include/fmt/core.h
@@ -1435,7 +1435,7 @@ template <typename Context> struct arg_mapper {
   // Only map owning types because mapping views can be unsafe.
   template <typename T, typename U = format_as_t<T>,
             FMT_ENABLE_IF(std::is_arithmetic<U>::value)>
-  FMT_CONSTEXPR FMT_INLINE auto map(const T& val) -> decltype(this->map(U())) {
+  FMT_CONSTEXPR FMT_INLINE auto map(const T& val) -> decltype(map(U())) {
     return map(format_as(val));
   }
 
@@ -1459,13 +1459,13 @@ template <typename Context> struct arg_mapper {
                           !is_string<U>::value && !is_char<U>::value &&
                           !is_named_arg<U>::value &&
                           !std::is_arithmetic<format_as_t<U>>::value)>
-  FMT_CONSTEXPR FMT_INLINE auto map(T& val) -> decltype(this->do_map(val)) {
+  FMT_CONSTEXPR FMT_INLINE auto map(T& val) -> decltype(do_map(val)) {
     return do_map(val);
   }
 
   template <typename T, FMT_ENABLE_IF(is_named_arg<T>::value)>
   FMT_CONSTEXPR FMT_INLINE auto map(const T& named_arg)
-      -> decltype(this->map(named_arg.value)) {
+      -> decltype(map(named_arg.value)) {
     return map(named_arg.value);
   }
 


### PR DESCRIPTION
Using `this->` in decltype doesn't work in the latest MSVC.