### PR TITLE
[wpilib] Update getAlliance() docs (NFC)

### DIFF
--- a/wpilibc/src/main/native/include/frc/DriverStation.h
+++ b/wpilibc/src/main/native/include/frc/DriverStation.h
@@ -274,14 +274,13 @@ class DriverStation final {
   static int GetReplayNumber();
 
   /**
-   * Return the alliance that the driver station says it is on from the FMS.
+   * Get the current alliance from the FMS.
    *
    * If the FMS is not connected, it is set from the team alliance setting on
    * the driver station.
    *
-   * This could return kRed or kBlue.
-   *
-   * @return The Alliance enum (kRed, kBlue or kInvalid)
+   * @return The alliance (red or blue) or an empty optional if the alliance is
+   * invalid
    */
   static std::optional<Alliance> GetAlliance();
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/DriverStation.java
@@ -1113,7 +1113,7 @@ public final class DriverStation {
    *
    * <p>If the FMS is not connected, it is set from the team alliance setting on the driver station.
    *
-   * @return the current alliance
+   * @return The alliance (red or blue) or an empty optional if the alliance is invalid
    */
   public static Optional<Alliance> getAlliance() {
     AllianceStationID allianceStationID = DriverStationJNI.getAllianceStation();


### PR DESCRIPTION
kInvalid was replaced with an optional.