### PR TITLE
[build] cmake: fix protobuf dependency finding for certain distributions

### DIFF
--- a/wpiutil/wpiutil-config.cmake.in
+++ b/wpiutil/wpiutil-config.cmake.in
@@ -2,7 +2,7 @@ include(CMakeFindDependencyMacro)
 @FILENAME_DEP_REPLACE@
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_dependency(Threads)
-find_dependency(protobuf)
+find_dependency(Protobuf)
 @FMTLIB_SYSTEM_REPLACE@
 
 if(@USE_SYSTEM_FMTLIB@)


### PR DESCRIPTION
For one reason or another, some Linux distributions like Ubuntu/Debian seem to require the `Protobuf` dependency to be capitalized. Not sure why. This still works on other distributions, including Arch Linux, but this will need to be tested on Windows.