### PR TITLE
Allow sim device creation to be disabled

### DIFF
--- a/hal/src/main/native/athena/SimDevice.cpp
+++ b/hal/src/main/native/athena/SimDevice.cpp
@@ -10,6 +10,8 @@ HAL_SimDeviceHandle HAL_CreateSimDevice(const char* name) {
   return 0;
 }
 
+void HAL_DisableSimDeviceCreation(bool disabled) {}
+
 void HAL_FreeSimDevice(HAL_SimDeviceHandle handle) {}
 
 const char* HAL_GetSimDeviceName(HAL_SimDeviceHandle handle) {

--- a/hal/src/main/native/include/hal/SimDevice.h
+++ b/hal/src/main/native/include/hal/SimDevice.h
@@ -58,6 +58,17 @@ extern "C" {
 HAL_SimDeviceHandle HAL_CreateSimDevice(const char* name);
 
 /**
+ * Disables future creation of sim devices.
+ *
+ * Sim devices that have already been created will remain enabled. There is
+ * usually no reason to call this in a normal program. This is meant as an
+ * override for simulation extensions that allow interaction with real hardware.
+ *
+ * @param disabled Whether or not sim device creation is disabled
+ */
+void HAL_DisableSimDeviceCreation(bool disabled);
+
+/**
  * Frees a simulated device.
  *
  * This also allows the same device name to be used again.

--- a/hal/src/main/native/include/hal/SimDevice.h
+++ b/hal/src/main/native/include/hal/SimDevice.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/hal/src/main/native/sim/SimDevice.cpp
+++ b/hal/src/main/native/sim/SimDevice.cpp
@@ -21,7 +21,7 @@ bool gSimDeviceCreationDisabled = false;
 
 HAL_SimDeviceHandle HAL_CreateSimDevice(const char* name) {
   hal::init::CheckInit();
-  if (disabled) {
+  if (gSimDeviceCreationDisabled) {
     return 0;
   }
   return SimSimDeviceData->CreateDevice(name);

--- a/hal/src/main/native/sim/SimDevice.cpp
+++ b/hal/src/main/native/sim/SimDevice.cpp
@@ -17,9 +17,18 @@ void InitializeSimDevice() {}
 
 extern "C" {
 
+bool gSimDeviceCreationDisabled = false;
+
 HAL_SimDeviceHandle HAL_CreateSimDevice(const char* name) {
   hal::init::CheckInit();
+  if (disabled) {
+    return 0;
+  }
   return SimSimDeviceData->CreateDevice(name);
+}
+
+void HAL_DisableSimDeviceCreation(bool disabled) {
+  gSimDeviceCreationDisabled = disabled;
 }
 
 void HAL_FreeSimDevice(HAL_SimDeviceHandle handle) {


### PR DESCRIPTION
The use case for this is to allow the use and creation of simulation extensions that interact with real hardware. When using the simulation HAL, hardware objects will use `SimDevice` to control various values, like motor speeds. However, some teams may want to write a simulation extension that interacts with real IO, like SPI, CAN, or I2C. Instead of having to use the callbacks for each   device they want to use, and possibly reimplementing the data processing for each device (read: parsing SPI/CAN/I2C packets) they can use `HAL_DisableSimDeviceCreation` to allow the devices to use their non-simulation SPI/CAN/I2C code, and simply implement the IO layer.

Basically, if I want to implement a simulation extension that uses simulation callbacks and something like Linux's `open` to allow communication with a SPI bus, I want the devices to use their non-sim SPI code so I don't have to parse SPI packets and use individiual device callbacks.