### PR TITLE
[ci] bump certificate signing action version to master

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -118,7 +118,7 @@ jobs:
           java-version: 17
           architecture: ${{ matrix.architecture }}
       - name: Import Developer ID Certificate
-        uses: wpilibsuite/import-signing-certificate@v1
+        uses: wpilibsuite/import-signing-certificate@master
         with:
           certificate-data: ${{ secrets.APPLE_CERTIFICATE_DATA }}
           certificate-passphrase: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}


### PR DESCRIPTION
Relies on [wpilibsuite/import-signing-certificate#5](https://github.com/wpilibsuite/import-signing-certificate/pull/5)