### PR TITLE
[wpimath] Struct cleanup

### DIFF
--- a/wpimath/src/main/native/cpp/controller/struct/ArmFeedforwardStruct.cpp
+++ b/wpimath/src/main/native/cpp/controller/struct/ArmFeedforwardStruct.cpp
@@ -13,7 +13,7 @@ constexpr size_t kKaOff = kKvOff + 8;
 
 using StructType = wpi::Struct<frc::ArmFeedforward>;
 
-frc::ArmFeedforward StructType::Unpack(std::span<const uint8_t, kSize> data) {
+frc::ArmFeedforward StructType::Unpack(std::span<const uint8_t> data) {
   return frc::ArmFeedforward{
       units::volt_t{wpi::UnpackStruct<double, kKsOff>(data)},
       units::volt_t{wpi::UnpackStruct<double, kKgOff>(data)},
@@ -24,7 +24,7 @@ frc::ArmFeedforward StructType::Unpack(std::span<const uint8_t, kSize> data) {
   };
 }
 
-void StructType::Pack(std::span<uint8_t, kSize> data,
+void StructType::Pack(std::span<uint8_t> data,
                       const frc::ArmFeedforward& value) {
   wpi::PackStruct<kKsOff>(data, value.kS());
   wpi::PackStruct<kKgOff>(data, value.kG());

--- a/wpimath/src/main/native/cpp/controller/struct/DifferentialDriveWheelVoltagesStruct.cpp
+++ b/wpimath/src/main/native/cpp/controller/struct/DifferentialDriveWheelVoltagesStruct.cpp
@@ -12,14 +12,14 @@ constexpr size_t kRightOff = kLeftOff + 8;
 using StructType = wpi::Struct<frc::DifferentialDriveWheelVoltages>;
 
 frc::DifferentialDriveWheelVoltages StructType::Unpack(
-    std::span<const uint8_t, kSize> data) {
+    std::span<const uint8_t> data) {
   return frc::DifferentialDriveWheelVoltages{
       units::volt_t{wpi::UnpackStruct<double, kLeftOff>(data)},
       units::volt_t{wpi::UnpackStruct<double, kRightOff>(data)},
   };
 }
 
-void StructType::Pack(std::span<uint8_t, kSize> data,
+void StructType::Pack(std::span<uint8_t> data,
                       const frc::DifferentialDriveWheelVoltages& value) {
   wpi::PackStruct<kLeftOff>(data, value.left.value());
   wpi::PackStruct<kRightOff>(data, value.right.value());

--- a/wpimath/src/main/native/cpp/controller/struct/ElevatorFeedforwardStruct.cpp
+++ b/wpimath/src/main/native/cpp/controller/struct/ElevatorFeedforwardStruct.cpp
@@ -13,8 +13,7 @@ constexpr size_t kKaOff = kKvOff + 8;
 
 using StructType = wpi::Struct<frc::ElevatorFeedforward>;
 
-frc::ElevatorFeedforward StructType::Unpack(
-    std::span<const uint8_t, kSize> data) {
+frc::ElevatorFeedforward StructType::Unpack(std::span<const uint8_t> data) {
   return frc::ElevatorFeedforward{
       units::volt_t{wpi::UnpackStruct<double, kKsOff>(data)},
       units::volt_t{wpi::UnpackStruct<double, kKgOff>(data)},
@@ -25,7 +24,7 @@ frc::ElevatorFeedforward StructType::Unpack(
   };
 }
 
-void StructType::Pack(std::span<uint8_t, kSize> data,
+void StructType::Pack(std::span<uint8_t> data,
                       const frc::ElevatorFeedforward& value) {
   wpi::PackStruct<kKsOff>(data, value.kS());
   wpi::PackStruct<kKgOff>(data, value.kG());

--- a/wpimath/src/main/native/cpp/system/plant/struct/DCMotorStruct.cpp
+++ b/wpimath/src/main/native/cpp/system/plant/struct/DCMotorStruct.cpp
@@ -14,7 +14,7 @@ constexpr size_t kFreeSpeedOff = kFreeCurrentOff + 8;
 
 using StructType = wpi::Struct<frc::DCMotor>;
 
-frc::DCMotor StructType::Unpack(std::span<const uint8_t, kSize> data) {
+frc::DCMotor StructType::Unpack(std::span<const uint8_t> data) {
   return frc::DCMotor{
       units::volt_t{wpi::UnpackStruct<double, kNominalVoltageOff>(data)},
       units::newton_meter_t{wpi::UnpackStruct<double, kStallTorqueOff>(data)},
@@ -25,8 +25,7 @@ frc::DCMotor StructType::Unpack(std::span<const uint8_t, kSize> data) {
   };
 }
 
-void StructType::Pack(std::span<uint8_t, kSize> data,
-                      const frc::DCMotor& value) {
+void StructType::Pack(std::span<uint8_t> data, const frc::DCMotor& value) {
   wpi::PackStruct<kNominalVoltageOff>(data, value.nominalVoltage.value());
   wpi::PackStruct<kStallTorqueOff>(data, value.stallTorque.value());
   wpi::PackStruct<kStallCurrentOff>(data, value.stallCurrent.value());

--- a/wpimath/src/main/native/include/frc/controller/struct/ArmFeedforwardStruct.h
+++ b/wpimath/src/main/native/include/frc/controller/struct/ArmFeedforwardStruct.h
@@ -22,3 +22,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::ArmFeedforward> {
   static frc::ArmFeedforward Unpack(std::span<const uint8_t> data);
   static void Pack(std::span<uint8_t> data, const frc::ArmFeedforward& value);
 };
+
+static_assert(wpi::StructSerializable<frc::ArmFeedforward>);

--- a/wpimath/src/main/native/include/frc/controller/struct/ArmFeedforwardStruct.h
+++ b/wpimath/src/main/native/include/frc/controller/struct/ArmFeedforwardStruct.h
@@ -11,12 +11,14 @@
 
 template <>
 struct WPILIB_DLLEXPORT wpi::Struct<frc::ArmFeedforward> {
-  static constexpr std::string_view kTypeString = "struct:ArmFeedforward";
-  static constexpr size_t kSize = 32;
-  static constexpr std::string_view kSchema =
-      "double ks;double kg;double kv;double ka";
+  static constexpr std::string_view GetTypeString() {
+    return "struct:ArmFeedforward";
+  }
+  static constexpr size_t GetSize() { return 32; }
+  static constexpr std::string_view GetSchema() {
+    return "double ks;double kg;double kv;double ka";
+  }
 
-  static frc::ArmFeedforward Unpack(std::span<const uint8_t, kSize> data);
-  static void Pack(std::span<uint8_t, kSize> data,
-                   const frc::ArmFeedforward& value);
+  static frc::ArmFeedforward Unpack(std::span<const uint8_t> data);
+  static void Pack(std::span<uint8_t> data, const frc::ArmFeedforward& value);
 };

--- a/wpimath/src/main/native/include/frc/controller/struct/DifferentialDriveWheelVoltagesStruct.h
+++ b/wpimath/src/main/native/include/frc/controller/struct/DifferentialDriveWheelVoltagesStruct.h
@@ -11,13 +11,16 @@
 
 template <>
 struct WPILIB_DLLEXPORT wpi::Struct<frc::DifferentialDriveWheelVoltages> {
-  static constexpr std::string_view kTypeString =
-      "struct:DifferentialDriveWheelVoltages";
-  static constexpr size_t kSize = 16;
-  static constexpr std::string_view kSchema = "double left;double right";
+  static constexpr std::string_view GetTypeString() {
+    return "struct:DifferentialDriveWheelVoltages";
+  }
+  static constexpr size_t GetSize() { return 16; }
+  static constexpr std::string_view GetSchema() {
+    return "double left;double right";
+  }
 
   static frc::DifferentialDriveWheelVoltages Unpack(
-      std::span<const uint8_t, kSize> data);
-  static void Pack(std::span<uint8_t, kSize> data,
+      std::span<const uint8_t> data);
+  static void Pack(std::span<uint8_t> data,
                    const frc::DifferentialDriveWheelVoltages& value);
 };

--- a/wpimath/src/main/native/include/frc/controller/struct/DifferentialDriveWheelVoltagesStruct.h
+++ b/wpimath/src/main/native/include/frc/controller/struct/DifferentialDriveWheelVoltagesStruct.h
@@ -24,3 +24,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::DifferentialDriveWheelVoltages> {
   static void Pack(std::span<uint8_t> data,
                    const frc::DifferentialDriveWheelVoltages& value);
 };
+
+static_assert(wpi::StructSerializable<frc::DifferentialDriveWheelVoltages>);

--- a/wpimath/src/main/native/include/frc/controller/struct/ElevatorFeedforwardStruct.h
+++ b/wpimath/src/main/native/include/frc/controller/struct/ElevatorFeedforwardStruct.h
@@ -11,12 +11,15 @@
 
 template <>
 struct WPILIB_DLLEXPORT wpi::Struct<frc::ElevatorFeedforward> {
-  static constexpr std::string_view kTypeString = "struct:ElevatorFeedforward";
-  static constexpr size_t kSize = 32;
-  static constexpr std::string_view kSchema =
-      "double ks;double kg;double kv;double ka";
+  static constexpr std::string_view GetTypeString() {
+    return "struct:ElevatorFeedforward";
+  }
+  static constexpr size_t GetSize() { return 32; }
+  static constexpr std::string_view GetSchema() {
+    return "double ks;double kg;double kv;double ka";
+  }
 
-  static frc::ElevatorFeedforward Unpack(std::span<const uint8_t, kSize> data);
-  static void Pack(std::span<uint8_t, kSize> data,
+  static frc::ElevatorFeedforward Unpack(std::span<const uint8_t> data);
+  static void Pack(std::span<uint8_t> data,
                    const frc::ElevatorFeedforward& value);
 };

--- a/wpimath/src/main/native/include/frc/controller/struct/ElevatorFeedforwardStruct.h
+++ b/wpimath/src/main/native/include/frc/controller/struct/ElevatorFeedforwardStruct.h
@@ -23,3 +23,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::ElevatorFeedforward> {
   static void Pack(std::span<uint8_t> data,
                    const frc::ElevatorFeedforward& value);
 };
+
+static_assert(wpi::StructSerializable<frc::ElevatorFeedforward>);

--- a/wpimath/src/main/native/include/frc/geometry/struct/Pose2dStruct.h
+++ b/wpimath/src/main/native/include/frc/geometry/struct/Pose2dStruct.h
@@ -29,4 +29,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::Pose2d> {
   }
 };
 
+static_assert(wpi::StructSerializable<frc::Pose2d>);
 static_assert(wpi::HasNestedStruct<frc::Pose2d>);

--- a/wpimath/src/main/native/include/frc/geometry/struct/Pose3dStruct.h
+++ b/wpimath/src/main/native/include/frc/geometry/struct/Pose3dStruct.h
@@ -29,4 +29,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::Pose3d> {
   }
 };
 
+static_assert(wpi::StructSerializable<frc::Pose3d>);
 static_assert(wpi::HasNestedStruct<frc::Pose3d>);

--- a/wpimath/src/main/native/include/frc/geometry/struct/QuaternionStruct.h
+++ b/wpimath/src/main/native/include/frc/geometry/struct/QuaternionStruct.h
@@ -22,3 +22,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::Quaternion> {
   static frc::Quaternion Unpack(std::span<const uint8_t> data);
   static void Pack(std::span<uint8_t> data, const frc::Quaternion& value);
 };
+
+static_assert(wpi::StructSerializable<frc::Quaternion>);

--- a/wpimath/src/main/native/include/frc/geometry/struct/Rotation2dStruct.h
+++ b/wpimath/src/main/native/include/frc/geometry/struct/Rotation2dStruct.h
@@ -20,3 +20,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::Rotation2d> {
   static frc::Rotation2d Unpack(std::span<const uint8_t> data);
   static void Pack(std::span<uint8_t> data, const frc::Rotation2d& value);
 };
+
+static_assert(wpi::StructSerializable<frc::Rotation2d>);

--- a/wpimath/src/main/native/include/frc/geometry/struct/Rotation3dStruct.h
+++ b/wpimath/src/main/native/include/frc/geometry/struct/Rotation3dStruct.h
@@ -27,4 +27,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::Rotation3d> {
   }
 };
 
+static_assert(wpi::StructSerializable<frc::Rotation3d>);
 static_assert(wpi::HasNestedStruct<frc::Rotation3d>);

--- a/wpimath/src/main/native/include/frc/geometry/struct/Transform2dStruct.h
+++ b/wpimath/src/main/native/include/frc/geometry/struct/Transform2dStruct.h
@@ -31,4 +31,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::Transform2d> {
   }
 };
 
+static_assert(wpi::StructSerializable<frc::Transform2d>);
 static_assert(wpi::HasNestedStruct<frc::Transform2d>);

--- a/wpimath/src/main/native/include/frc/geometry/struct/Transform3dStruct.h
+++ b/wpimath/src/main/native/include/frc/geometry/struct/Transform3dStruct.h
@@ -31,4 +31,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::Transform3d> {
   }
 };
 
+static_assert(wpi::StructSerializable<frc::Transform3d>);
 static_assert(wpi::HasNestedStruct<frc::Transform3d>);

--- a/wpimath/src/main/native/include/frc/geometry/struct/Translation2dStruct.h
+++ b/wpimath/src/main/native/include/frc/geometry/struct/Translation2dStruct.h
@@ -20,3 +20,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::Translation2d> {
   static frc::Translation2d Unpack(std::span<const uint8_t> data);
   static void Pack(std::span<uint8_t> data, const frc::Translation2d& value);
 };
+
+static_assert(wpi::StructSerializable<frc::Translation2d>);

--- a/wpimath/src/main/native/include/frc/geometry/struct/Translation3dStruct.h
+++ b/wpimath/src/main/native/include/frc/geometry/struct/Translation3dStruct.h
@@ -22,3 +22,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::Translation3d> {
   static frc::Translation3d Unpack(std::span<const uint8_t> data);
   static void Pack(std::span<uint8_t> data, const frc::Translation3d& value);
 };
+
+static_assert(wpi::StructSerializable<frc::Translation3d>);

--- a/wpimath/src/main/native/include/frc/geometry/struct/Twist2dStruct.h
+++ b/wpimath/src/main/native/include/frc/geometry/struct/Twist2dStruct.h
@@ -20,3 +20,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::Twist2d> {
   static frc::Twist2d Unpack(std::span<const uint8_t> data);
   static void Pack(std::span<uint8_t> data, const frc::Twist2d& value);
 };
+
+static_assert(wpi::StructSerializable<frc::Twist2d>);

--- a/wpimath/src/main/native/include/frc/geometry/struct/Twist3dStruct.h
+++ b/wpimath/src/main/native/include/frc/geometry/struct/Twist3dStruct.h
@@ -20,3 +20,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::Twist3d> {
   static frc::Twist3d Unpack(std::span<const uint8_t> data);
   static void Pack(std::span<uint8_t> data, const frc::Twist3d& value);
 };
+
+static_assert(wpi::StructSerializable<frc::Twist3d>);

--- a/wpimath/src/main/native/include/frc/kinematics/struct/ChassisSpeedsStruct.h
+++ b/wpimath/src/main/native/include/frc/kinematics/struct/ChassisSpeedsStruct.h
@@ -22,3 +22,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::ChassisSpeeds> {
   static frc::ChassisSpeeds Unpack(std::span<const uint8_t> data);
   static void Pack(std::span<uint8_t> data, const frc::ChassisSpeeds& value);
 };
+
+static_assert(wpi::StructSerializable<frc::ChassisSpeeds>);

--- a/wpimath/src/main/native/include/frc/kinematics/struct/DifferentialDriveKinematicsStruct.h
+++ b/wpimath/src/main/native/include/frc/kinematics/struct/DifferentialDriveKinematicsStruct.h
@@ -21,3 +21,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::DifferentialDriveKinematics> {
   static void Pack(std::span<uint8_t> data,
                    const frc::DifferentialDriveKinematics& value);
 };
+
+static_assert(wpi::StructSerializable<frc::DifferentialDriveKinematics>);

--- a/wpimath/src/main/native/include/frc/kinematics/struct/DifferentialDriveWheelSpeedsStruct.h
+++ b/wpimath/src/main/native/include/frc/kinematics/struct/DifferentialDriveWheelSpeedsStruct.h
@@ -24,3 +24,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::DifferentialDriveWheelSpeeds> {
   static void Pack(std::span<uint8_t> data,
                    const frc::DifferentialDriveWheelSpeeds& value);
 };
+
+static_assert(wpi::StructSerializable<frc::DifferentialDriveWheelSpeeds>);

--- a/wpimath/src/main/native/include/frc/kinematics/struct/MecanumDriveKinematicsStruct.h
+++ b/wpimath/src/main/native/include/frc/kinematics/struct/MecanumDriveKinematicsStruct.h
@@ -31,4 +31,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::MecanumDriveKinematics> {
   }
 };
 
+static_assert(wpi::StructSerializable<frc::MecanumDriveKinematics>);
 static_assert(wpi::HasNestedStruct<frc::MecanumDriveKinematics>);

--- a/wpimath/src/main/native/include/frc/kinematics/struct/MecanumDriveWheelPositionsStruct.h
+++ b/wpimath/src/main/native/include/frc/kinematics/struct/MecanumDriveWheelPositionsStruct.h
@@ -24,3 +24,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::MecanumDriveWheelPositions> {
   static void Pack(std::span<uint8_t> data,
                    const frc::MecanumDriveWheelPositions& value);
 };
+
+static_assert(wpi::StructSerializable<frc::MecanumDriveWheelPositions>);

--- a/wpimath/src/main/native/include/frc/kinematics/struct/MecanumDriveWheelSpeedsStruct.h
+++ b/wpimath/src/main/native/include/frc/kinematics/struct/MecanumDriveWheelSpeedsStruct.h
@@ -24,3 +24,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::MecanumDriveWheelSpeeds> {
   static void Pack(std::span<uint8_t> data,
                    const frc::MecanumDriveWheelSpeeds& value);
 };
+
+static_assert(wpi::StructSerializable<frc::MecanumDriveWheelSpeeds>);

--- a/wpimath/src/main/native/include/frc/kinematics/struct/SwerveModulePositionStruct.h
+++ b/wpimath/src/main/native/include/frc/kinematics/struct/SwerveModulePositionStruct.h
@@ -30,4 +30,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::SwerveModulePosition> {
   }
 };
 
+static_assert(wpi::StructSerializable<frc::SwerveModulePosition>);
 static_assert(wpi::HasNestedStruct<frc::SwerveModulePosition>);

--- a/wpimath/src/main/native/include/frc/kinematics/struct/SwerveModuleStateStruct.h
+++ b/wpimath/src/main/native/include/frc/kinematics/struct/SwerveModuleStateStruct.h
@@ -30,4 +30,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::SwerveModuleState> {
   }
 };
 
+static_assert(wpi::StructSerializable<frc::SwerveModuleState>);
 static_assert(wpi::HasNestedStruct<frc::SwerveModuleState>);

--- a/wpimath/src/main/native/include/frc/system/plant/struct/DCMotorStruct.h
+++ b/wpimath/src/main/native/include/frc/system/plant/struct/DCMotorStruct.h
@@ -11,12 +11,14 @@
 
 template <>
 struct WPILIB_DLLEXPORT wpi::Struct<frc::DCMotor> {
-  static constexpr std::string_view kTypeString = "struct:DCMotor";
-  static constexpr size_t kSize = 40;
-  static constexpr std::string_view kSchema =
-      "double nominal_voltage;double stall_torque;double stall_current;double "
-      "free_current;double free_speed";
+  static constexpr std::string_view GetTypeString() { return "struct:DCMotor"; }
+  static constexpr size_t GetSize() { return 40; }
+  static constexpr std::string_view GetSchema() {
+    return "double nominal_voltage;double stall_torque;double "
+           "stall_current;double "
+           "free_current;double free_speed";
+  }
 
-  static frc::DCMotor Unpack(std::span<const uint8_t, kSize> data);
-  static void Pack(std::span<uint8_t, kSize> data, const frc::DCMotor& value);
+  static frc::DCMotor Unpack(std::span<const uint8_t> data);
+  static void Pack(std::span<uint8_t> data, const frc::DCMotor& value);
 };

--- a/wpimath/src/main/native/include/frc/system/plant/struct/DCMotorStruct.h
+++ b/wpimath/src/main/native/include/frc/system/plant/struct/DCMotorStruct.h
@@ -22,3 +22,5 @@ struct WPILIB_DLLEXPORT wpi::Struct<frc::DCMotor> {
   static frc::DCMotor Unpack(std::span<const uint8_t> data);
   static void Pack(std::span<uint8_t> data, const frc::DCMotor& value);
 };
+
+static_assert(wpi::StructSerializable<frc::DCMotor>);

--- a/wpimath/src/test/native/cpp/controller/struct/ArmFeedforwardStructTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/struct/ArmFeedforwardStructTest.cpp
@@ -20,8 +20,8 @@ const ArmFeedforward kExpectedData{Ks, Kg, Kv, Ka};
 }  // namespace
 
 TEST(ArmFeedforwardStructTest, Roundtrip) {
-  uint8_t buffer[StructType::kSize];
-  std::memset(buffer, 0, StructType::kSize);
+  uint8_t buffer[StructType::GetSize()];
+  std::memset(buffer, 0, StructType::GetSize());
   StructType::Pack(buffer, kExpectedData);
 
   ArmFeedforward unpacked_data = StructType::Unpack(buffer);

--- a/wpimath/src/test/native/cpp/controller/struct/DifferentialDriveWheelVoltagesStructTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/struct/DifferentialDriveWheelVoltagesStructTest.cpp
@@ -16,8 +16,8 @@ const DifferentialDriveWheelVoltages kExpectedData{
 }  // namespace
 
 TEST(DifferentialDriveWheelVoltagesStructTest, Roundtrip) {
-  uint8_t buffer[StructType::kSize];
-  std::memset(buffer, 0, StructType::kSize);
+  uint8_t buffer[StructType::GetSize()];
+  std::memset(buffer, 0, StructType::GetSize());
   StructType::Pack(buffer, kExpectedData);
 
   DifferentialDriveWheelVoltages unpacked_data = StructType::Unpack(buffer);

--- a/wpimath/src/test/native/cpp/controller/struct/ElevatorFeedforwardStructTest.cpp
+++ b/wpimath/src/test/native/cpp/controller/struct/ElevatorFeedforwardStructTest.cpp
@@ -21,8 +21,8 @@ constexpr ElevatorFeedforward kExpectedData{Ks, Kg, Kv, Ka};
 }  // namespace
 
 TEST(ElevatorFeedforwardStructTest, Roundtrip) {
-  uint8_t buffer[StructType::kSize];
-  std::memset(buffer, 0, StructType::kSize);
+  uint8_t buffer[StructType::GetSize()];
+  std::memset(buffer, 0, StructType::GetSize());
   StructType::Pack(buffer, kExpectedData);
 
   ElevatorFeedforward unpacked_data = StructType::Unpack(buffer);

--- a/wpimath/src/test/native/cpp/system/plant/struct/DCMotorStructTest.cpp
+++ b/wpimath/src/test/native/cpp/system/plant/struct/DCMotorStructTest.cpp
@@ -20,8 +20,8 @@ const DCMotor kExpectedData = DCMotor{units::volt_t{1.91},
 }  // namespace
 
 TEST(DCMotorStructTest, Roundtrip) {
-  uint8_t buffer[StructType::kSize];
-  std::memset(buffer, 0, StructType::kSize);
+  uint8_t buffer[StructType::GetSize()];
+  std::memset(buffer, 0, StructType::GetSize());
   StructType::Pack(buffer, kExpectedData);
 
   DCMotor unpacked_data = StructType::Unpack(buffer);

--- a/wpiutil/src/main/native/include/wpi/struct/Struct.h
+++ b/wpiutil/src/main/native/include/wpi/struct/Struct.h
@@ -51,8 +51,8 @@ struct Struct {};
  * - std::string_view GetTypeString(): function that returns the type string
  * - size_t GetSize(): function that returns the structure size in bytes
  * - std::string_view GetSchema(): function that returns the struct schema
- * - T Unpack(std::span<const uint8_t, kSize>): function for deserialization
- * - void Pack(std::span<uint8_t, kSize>, T&& value): function for
+ * - T Unpack(std::span<const uint8_t>): function for deserialization
+ * - void Pack(std::span<uint8_t>, T&& value): function for
  *   serialization
  *
  * If possible, the GetTypeString(), GetSize(), and GetSchema() functions should
@@ -411,9 +411,9 @@ struct Struct<uint8_t> {
  */
 template <>
 struct Struct<int8_t> {
-  static constexpr std::string_view kTypeString = "struct:int8";
-  static constexpr size_t kSize = 1;
-  static constexpr std::string_view kSchema = "int8 value";
+  static constexpr std::string_view GetTypeString() { return "struct:int8"; }
+  static constexpr size_t GetSize() { return 1; }
+  static constexpr std::string_view GetSchema() { return "int8 value"; }
   static int8_t Unpack(std::span<const uint8_t, 1> data) { return data[0]; }
   static void Pack(std::span<uint8_t, 1> data, int8_t value) {
     data[0] = value;


### PR DESCRIPTION
* Fixes usages of `kSize` and co. that were left after #5992
* Adds `wpi::StructSerializable<T>` static asserts
