### PR TITLE
[wpiunits] Overload Measure.per(Time) to return Measure<Velocity>

### DIFF
--- a/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/Measure.java
@@ -179,6 +179,21 @@ public interface Measure<U extends Unit<U>> extends Comparable<Measure<U>> {
   }
 
   /**
+   * Creates a velocity measure equivalent to this one per a unit of time.
+   *
+   * <pre>
+   *   Radians.of(3.14).per(Second) // Velocity&lt;Angle&gt; equivalent to RadiansPerSecond.of(3.14)
+   * </pre>
+   *
+   * @param time the unit of time
+   * @return the velocity measure
+   */
+  default Measure<Velocity<U>> per(Time time) {
+    var newUnit = unit().per(time);
+    return newUnit.of(magnitude());
+  }
+
+  /**
    * Adds another measure to this one. The resulting measure has the same unit as this one.
    *
    * @param other the measure to add to this one

--- a/wpiunits/src/test/java/edu/wpi/first/units/MeasureTest.java
+++ b/wpiunits/src/test/java/edu/wpi/first/units/MeasureTest.java
@@ -78,7 +78,7 @@ class MeasureTest {
   }
 
   @Test
-  void testPerUnitTime() {
+  void testPerMeasureTime() {
     var measure = Units.Kilograms.of(144);
     var dt = Units.Milliseconds.of(53);
 
@@ -86,6 +86,16 @@ class MeasureTest {
 
     var result = measure.per(dt);
     assertEquals(144_000.0 / 53, result.baseUnitMagnitude(), 1e-5);
+    assertEquals(Units.Kilograms.per(Units.Milliseconds), result.unit());
+  }
+
+  @Test
+  void testPerUnitTime() {
+    var measure = Units.Kilograms.of(144);
+    var result = measure.per(Units.Millisecond);
+
+    assertEquals(Velocity.class, result.unit().getClass());
+    assertEquals(144_000.0, result.baseUnitMagnitude(), 1e-5);
     assertEquals(Units.Kilograms.per(Units.Milliseconds), result.unit());
   }
 


### PR DESCRIPTION
As opposed to returning Measure<Per<U, Time>>
Now matches the overload on Unit
