### PR TITLE
[wpilibj, cmd] Allow sendable properties to be cached to avoid unnecessary calculations

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelRaceGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ParallelRaceGroup.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.wpilibj2.command;
 
+import edu.wpi.first.util.sendable.SendableBuilder;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -100,5 +101,25 @@ public class ParallelRaceGroup extends Command {
   @Override
   public InterruptionBehavior getInterruptionBehavior() {
     return m_interruptBehavior;
+  }
+
+  @Override
+  public void initSendable(SendableBuilder builder) {
+    super.initSendable(builder);
+
+    builder.caching(
+        "Commands",
+        m_commands::hashCode,
+        () -> {
+          var names = new String[m_commands.size()];
+          int i = 0;
+          for (var command : m_commands) {
+            names[i] = command.getName();
+            i++;
+          }
+          return names;
+        },
+        null,
+        builder::addStringArrayProperty);
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ScheduleCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/ScheduleCommand.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.wpilibj2.command;
 
+import edu.wpi.first.util.sendable.SendableBuilder;
 import java.util.Set;
 
 /**
@@ -40,5 +41,25 @@ public class ScheduleCommand extends Command {
   @Override
   public boolean runsWhenDisabled() {
     return true;
+  }
+
+  @Override
+  public void initSendable(SendableBuilder builder) {
+    super.initSendable(builder);
+
+    builder.caching(
+        "Commands",
+        m_toSchedule::hashCode,
+        () -> {
+          var names = new String[m_toSchedule.size()];
+          int i = 0;
+          for (Command command : m_toSchedule) {
+            names[i] = command.getName();
+            i++;
+          }
+          return names;
+        },
+        null,
+        builder::addStringArrayProperty);
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SelectCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SelectCommand.java
@@ -92,5 +92,20 @@ public class SelectCommand<K> extends Command {
 
     builder.addStringProperty(
         "selected", () -> m_selectedCommand == null ? "null" : m_selectedCommand.getName(), null);
+
+    builder.caching(
+        "Options",
+        m_commands::hashCode,
+        () -> {
+          var names = new String[m_commands.size()];
+          int i = 0;
+          for (var command : m_commands.values()) {
+            names[i] = command.getName();
+            i++;
+          }
+          return names;
+        },
+        null,
+        builder::addStringArrayProperty);
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SequentialCommandGroup.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SequentialCommandGroup.java
@@ -114,5 +114,18 @@ public class SequentialCommandGroup extends Command {
     super.initSendable(builder);
 
     builder.addIntegerProperty("index", () -> m_currentCommandIndex, null);
+
+    builder.caching(
+        "Commands",
+        m_commands::hashCode,
+        () -> {
+          var names = new String[m_commands.size()];
+          for (int i = 0; i < m_commands.size(); i++) {
+            names[i] = m_commands.get(i).getName();
+          }
+          return names;
+        },
+        null,
+        builder::addStringArrayProperty);
   }
 }

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/WrapperCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/WrapperCommand.java
@@ -4,6 +4,7 @@
 
 package edu.wpi.first.wpilibj2.command;
 
+import edu.wpi.first.util.sendable.SendableBuilder;
 import java.util.Set;
 
 /**
@@ -97,5 +98,12 @@ public abstract class WrapperCommand extends Command {
   @Override
   public InterruptionBehavior getInterruptionBehavior() {
     return m_command.getInterruptionBehavior();
+  }
+
+  @Override
+  public void initSendable(SendableBuilder builder) {
+    super.initSendable(builder);
+
+    builder.addStringProperty("Command", m_command::getName, null);
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
@@ -116,18 +116,18 @@ public class SendableBuilderImpl implements NTSendableBuilder {
     void publish(long time) {
       int hash = m_hashFunction.getAsInt();
 
-      if (hash != m_previousHash || !m_cached) {
+      if (m_firstRun || hash != m_previousHash) {
         // Cache is dirty, update the wrapped property and reset the saved previous hash
         m_property.publish(time);
         m_previousHash = hash;
-        m_cached = true;
+        m_firstRun = false;
       }
     }
 
     final Property<P, S> m_property;
     final IntSupplier m_hashFunction;
     int m_previousHash;
-    boolean m_cached = false;
+    boolean m_firstRun = true;
   }
 
   private final List<Property<?, ?>> m_properties = new ArrayList<>();

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImpl.java
@@ -752,7 +752,15 @@ public class SendableBuilderImpl implements NTSendableBuilder {
       Supplier<T> getter,
       Consumer<T> setter,
       PropertyFn<T> property) {
+    int initialPropertyCount = m_properties.size();
     property.addProperty(key, getter, setter);
+
+    if (m_properties.size() != initialPropertyCount + 1) {
+      // The callback function didn't create a property for us to cache; bail. This can happen if
+      // the callback function doesn't adhere to the contract of creating a new sendable property
+      // when called
+      return;
+    }
 
     // Remove the property added above, wrap it, and add the wrapper in its place
     var originalProperty = m_properties.get(m_properties.size() - 1);

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImplTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImplTest.java
@@ -1,3 +1,7 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package edu.wpi.first.wpilibj.smartdashboard;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/wpilibj/src/test/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImplTest.java
+++ b/wpilibj/src/test/java/edu/wpi/first/wpilibj/smartdashboard/SendableBuilderImplTest.java
@@ -4,7 +4,7 @@
 
 package edu.wpi.first.wpilibj.smartdashboard;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import edu.wpi.first.networktables.NetworkTableInstance;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableBuilder.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/sendable/SendableBuilder.java
@@ -242,15 +242,15 @@ public interface SendableBuilder extends AutoCloseable {
    * via a method reference to a SendableBuilder instance in a Sendable implementation's {@code
    * initSendable} method in conjunction with {@link #caching the builder's caching function}.
    *
-   * <p>
+   * <p>For example:
    *
    * <pre>
    *  {@literal @}Override
    *   public void initSendable(SendableBuilder builder) {
    *     builder.caching(
    *       "Things",
-   *       () -> m_things.hashCode(),
-   *       () -> m_things.stream().map(Thing::getName).toArray(String[]::new),
+   *       () -&gt; m_things.hashCode(),
+   *       () -&gt; m_things.stream().map(Thing::getName).toArray(String[]::new),
    *       null,
    *       builder::addStringArrayProperty
    *     );
@@ -277,7 +277,7 @@ public interface SendableBuilder extends AutoCloseable {
    * properties when it is possible to know ahead of time if the property value will change. This
    * function can only be applied to string and array-type properties.
    *
-   * <p>
+   * <p>For example:
    *
    * <pre>
    *   private List&lt;Thing&gt; m_list;
@@ -287,7 +287,7 @@ public interface SendableBuilder extends AutoCloseable {
    *     builder.caching(
    *       "Thing Names",
    *       m_list::hashCode,
-   *       () -> m_list.stream().map(Thing::getName).toArray(String[]::new),
+   *       () -&gt; m_list.stream().map(Thing::getName).toArray(String[]::new),
    *       null,
    *       builder::addStringArrayProperty
    *     )


### PR DESCRIPTION
Relies on user-provided hash functions to determine if the value of a cached property needs to be recomputed

Update command compositions to include information about the commands within them, for debugging purposes. This uses the sendable caching functionality to avoid recalculating string arrays on every loop when the values wouldn't change (for example, the names of every command in a sequential command group)

Somewhat addresses #6029 by showing information about the commands inside a command composition, but only from its sendable implementation, not at the scheduler level