### PR TITLE
Zero out roborio system timestamp

### DIFF
--- a/wpiutil/src/main/native/cpp/timestamp.cpp
+++ b/wpiutil/src/main/native/cpp/timestamp.cpp
@@ -267,7 +267,7 @@ uint64_t wpi::Now() {
   // Same code as HAL_GetFPGATime()
   if (!hmbInitialized.test()) {
     if (nowUseDefaultOnFailure.test()) {
-      return (now_impl.load())();
+      return timestamp() - offset_val;
     } else {
       fmt::print(
           stderr,


### PR DESCRIPTION
There was also an issue where the clock zero offset would be incorrect due to the system time updating. This solves that issue for the rio