### PR TITLE
[wpilibcExamples] Add "inline" specifier to constants.h constants

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/ArmBot/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBot/include/Constants.h
@@ -21,54 +21,54 @@
  */
 
 namespace DriveConstants {
-constexpr int kLeftMotor1Port = 0;
-constexpr int kLeftMotor2Port = 1;
-constexpr int kRightMotor1Port = 2;
-constexpr int kRightMotor2Port = 3;
+inline constexpr int kLeftMotor1Port = 0;
+inline constexpr int kLeftMotor2Port = 1;
+inline constexpr int kRightMotor1Port = 2;
+inline constexpr int kRightMotor2Port = 3;
 
-constexpr int kLeftEncoderPorts[]{0, 1};
-constexpr int kRightEncoderPorts[]{2, 3};
-constexpr bool kLeftEncoderReversed = false;
-constexpr bool kRightEncoderReversed = true;
+inline constexpr int kLeftEncoderPorts[]{0, 1};
+inline constexpr int kRightEncoderPorts[]{2, 3};
+inline constexpr bool kLeftEncoderReversed = false;
+inline constexpr bool kRightEncoderReversed = true;
 
-constexpr int kEncoderCPR = 1024;
-constexpr double kWheelDiameterInches = 6;
-constexpr double kEncoderDistancePerPulse =
+inline constexpr int kEncoderCPR = 1024;
+inline constexpr double kWheelDiameterInches = 6;
+inline constexpr double kEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     (kWheelDiameterInches * std::numbers::pi) /
     static_cast<double>(kEncoderCPR);
 }  // namespace DriveConstants
 
 namespace ArmConstants {
-constexpr int kMotorPort = 4;
+inline constexpr int kMotorPort = 4;
 
-constexpr double kP = 1;
+inline constexpr double kP = 1;
 
 // These are fake gains; in actuality these must be determined individually for
 // each robot
-constexpr auto kS = 1_V;
-constexpr auto kG = 1_V;
-constexpr auto kV = 0.5_V * 1_s / 1_rad;
-constexpr auto kA = 0.1_V * 1_s * 1_s / 1_rad;
+inline constexpr auto kS = 1_V;
+inline constexpr auto kG = 1_V;
+inline constexpr auto kV = 0.5_V * 1_s / 1_rad;
+inline constexpr auto kA = 0.1_V * 1_s * 1_s / 1_rad;
 
-constexpr auto kMaxVelocity = 3_rad_per_s;
-constexpr auto kMaxAcceleration = 10_rad / (1_s * 1_s);
+inline constexpr auto kMaxVelocity = 3_rad_per_s;
+inline constexpr auto kMaxAcceleration = 10_rad / (1_s * 1_s);
 
-constexpr int kEncoderPorts[]{4, 5};
-constexpr int kEncoderPPR = 256;
-constexpr auto kEncoderDistancePerPulse =
+inline constexpr int kEncoderPorts[]{4, 5};
+inline constexpr int kEncoderPPR = 256;
+inline constexpr auto kEncoderDistancePerPulse =
     2.0_rad * std::numbers::pi / kEncoderPPR;
 
 // The offset of the arm from the horizontal in its neutral position,
 // measured from the horizontal
-constexpr auto kArmOffset = 0.5_rad;
+inline constexpr auto kArmOffset = 0.5_rad;
 }  // namespace ArmConstants
 
 namespace AutoConstants {
-constexpr auto kAutoTimeoutSeconds = 12_s;
-constexpr auto kAutoShootTimeSeconds = 7_s;
+inline constexpr auto kAutoTimeoutSeconds = 12_s;
+inline constexpr auto kAutoShootTimeSeconds = 7_s;
 }  // namespace AutoConstants
 
 namespace OIConstants {
-constexpr int kDriverControllerPort = 0;
+inline constexpr int kDriverControllerPort = 0;
 }  // namespace OIConstants

--- a/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/ArmBotOffboard/include/Constants.h
@@ -21,52 +21,52 @@
  */
 
 namespace DriveConstants {
-constexpr int kLeftMotor1Port = 0;
-constexpr int kLeftMotor2Port = 1;
-constexpr int kRightMotor1Port = 2;
-constexpr int kRightMotor2Port = 3;
+inline constexpr int kLeftMotor1Port = 0;
+inline constexpr int kLeftMotor2Port = 1;
+inline constexpr int kRightMotor1Port = 2;
+inline constexpr int kRightMotor2Port = 3;
 
-constexpr int kLeftEncoderPorts[]{0, 1};
-constexpr int kRightEncoderPorts[]{2, 3};
-constexpr bool kLeftEncoderReversed = false;
-constexpr bool kRightEncoderReversed = true;
+inline constexpr int kLeftEncoderPorts[]{0, 1};
+inline constexpr int kRightEncoderPorts[]{2, 3};
+inline constexpr bool kLeftEncoderReversed = false;
+inline constexpr bool kRightEncoderReversed = true;
 
-constexpr int kEncoderCPR = 1024;
-constexpr double kWheelDiameterInches = 6;
-constexpr double kEncoderDistancePerPulse =
+inline constexpr int kEncoderCPR = 1024;
+inline constexpr double kWheelDiameterInches = 6;
+inline constexpr double kEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     (kWheelDiameterInches * std::numbers::pi) /
     static_cast<double>(kEncoderCPR);
 }  // namespace DriveConstants
 
 namespace ArmConstants {
-constexpr int kMotorPort = 4;
+inline constexpr int kMotorPort = 4;
 
-constexpr double kP = 1;
+inline constexpr double kP = 1;
 
 // These are fake gains; in actuality these must be determined individually for
 // each robot
-constexpr auto kS = 1_V;
-constexpr auto kG = 1_V;
-constexpr auto kV = 0.5_V * 1_s / 1_rad;
-constexpr auto kA = 0.1_V * 1_s * 1_s / 1_rad;
+inline constexpr auto kS = 1_V;
+inline constexpr auto kG = 1_V;
+inline constexpr auto kV = 0.5_V * 1_s / 1_rad;
+inline constexpr auto kA = 0.1_V * 1_s * 1_s / 1_rad;
 
-constexpr auto kMaxVelocity = 3_rad_per_s;
-constexpr auto kMaxAcceleration = 10_rad / (1_s * 1_s);
+inline constexpr auto kMaxVelocity = 3_rad_per_s;
+inline constexpr auto kMaxAcceleration = 10_rad / (1_s * 1_s);
 
-constexpr int kEncoderPorts[]{4, 5};
-constexpr int kEncoderPPR = 256;
-constexpr auto kEncoderDistancePerPulse =
+inline constexpr int kEncoderPorts[]{4, 5};
+inline constexpr int kEncoderPPR = 256;
+inline constexpr auto kEncoderDistancePerPulse =
     2.0_rad * std::numbers::pi / kEncoderPPR;
 
 // The offset of the arm from the horizontal in its neutral position,
 // measured from the horizontal
-constexpr auto kArmOffset = 0.5_rad;
+inline constexpr auto kArmOffset = 0.5_rad;
 }  // namespace ArmConstants
 
 namespace AutoConstants {
-constexpr auto kAutoTimeoutSeconds = 12_s;
-constexpr auto kAutoShootTimeSeconds = 7_s;
+inline constexpr auto kAutoTimeoutSeconds = 12_s;
+inline constexpr auto kAutoShootTimeSeconds = 7_s;
 }  // namespace AutoConstants
 
 namespace OIConstants {

--- a/wpilibcExamples/src/main/cpp/examples/ArmSimulation/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/ArmSimulation/include/Constants.h
@@ -22,25 +22,25 @@
  * they are needed.
  */
 
-static constexpr int kMotorPort = 0;
-static constexpr int kEncoderAChannel = 0;
-static constexpr int kEncoderBChannel = 1;
-static constexpr int kJoystickPort = 0;
+inline constexpr int kMotorPort = 0;
+inline constexpr int kEncoderAChannel = 0;
+inline constexpr int kEncoderBChannel = 1;
+inline constexpr int kJoystickPort = 0;
 
-static constexpr std::string_view kArmPositionKey = "ArmPosition";
-static constexpr std::string_view kArmPKey = "ArmP";
+inline constexpr std::string_view kArmPositionKey = "ArmPosition";
+inline constexpr std::string_view kArmPKey = "ArmP";
 
-static constexpr double kDefaultArmKp = 50.0;
-static constexpr units::degree_t kDefaultArmSetpoint = 75.0_deg;
+inline constexpr double kDefaultArmKp = 50.0;
+inline constexpr units::degree_t kDefaultArmSetpoint = 75.0_deg;
 
-static constexpr units::radian_t kMinAngle = -75.0_deg;
-static constexpr units::radian_t kMaxAngle = 255.0_deg;
+inline constexpr units::radian_t kMinAngle = -75.0_deg;
+inline constexpr units::radian_t kMaxAngle = 255.0_deg;
 
-static constexpr double kArmReduction = 200.0;
-static constexpr units::kilogram_t kArmMass = 8.0_kg;
-static constexpr units::meter_t kArmLength = 30.0_in;
+inline constexpr double kArmReduction = 200.0;
+inline constexpr units::kilogram_t kArmMass = 8.0_kg;
+inline constexpr units::meter_t kArmLength = 30.0_in;
 
 // distance per pulse = (angle per revolution) / (pulses per revolution)
 //  = (2 * PI rads) / (4096 pulses)
-static constexpr double kArmEncoderDistPerPulse =
+inline constexpr double kArmEncoderDistPerPulse =
     2.0 * std::numbers::pi / 4096.0;

--- a/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/DriveDistanceOffboard/include/Constants.h
@@ -22,26 +22,26 @@
  */
 
 namespace DriveConstants {
-constexpr int kLeftMotor1Port = 0;
-constexpr int kLeftMotor2Port = 1;
-constexpr int kRightMotor1Port = 2;
-constexpr int kRightMotor2Port = 3;
+inline constexpr int kLeftMotor1Port = 0;
+inline constexpr int kLeftMotor2Port = 1;
+inline constexpr int kRightMotor1Port = 2;
+inline constexpr int kRightMotor2Port = 3;
 
 // These are example values only - DO NOT USE THESE FOR YOUR OWN ROBOT!
 // These characterization values MUST be determined either experimentally or
 // theoretically for *your* robot's drive. The SysId tool provides a convenient
 // method for obtaining these values for your robot.
-constexpr auto ks = 1_V;
-constexpr auto kv = 0.8_V * 1_s / 1_m;
-constexpr auto ka = 0.15_V * 1_s * 1_s / 1_m;
+inline constexpr auto ks = 1_V;
+inline constexpr auto kv = 0.8_V * 1_s / 1_m;
+inline constexpr auto ka = 0.15_V * 1_s * 1_s / 1_m;
 
-constexpr double kp = 1;
+inline constexpr double kp = 1;
 
-constexpr auto kMaxSpeed = 3_mps;
-constexpr auto kMaxAcceleration = 3_mps_sq;
+inline constexpr auto kMaxSpeed = 3_mps;
+inline constexpr auto kMaxAcceleration = 3_mps_sq;
 
 }  // namespace DriveConstants
 
 namespace OIConstants {
-constexpr int kDriverControllerPort = 0;
+inline constexpr int kDriverControllerPort = 0;
 }  // namespace OIConstants

--- a/wpilibcExamples/src/main/cpp/examples/ElevatorExponentialSimulation/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/ElevatorExponentialSimulation/include/Constants.h
@@ -25,33 +25,33 @@
 
 namespace Constants {
 
-static constexpr int kMotorPort = 0;
-static constexpr int kEncoderAChannel = 0;
-static constexpr int kEncoderBChannel = 1;
-static constexpr int kJoystickPort = 0;
+inline constexpr int kMotorPort = 0;
+inline constexpr int kEncoderAChannel = 0;
+inline constexpr int kEncoderBChannel = 1;
+inline constexpr int kJoystickPort = 0;
 
-static constexpr double kElevatorKp = 0.75;
-static constexpr double kElevatorKi = 0.0;
-static constexpr double kElevatorKd = 0.0;
+inline constexpr double kElevatorKp = 0.75;
+inline constexpr double kElevatorKi = 0.0;
+inline constexpr double kElevatorKd = 0.0;
 
-static constexpr units::volt_t kElevatorMaxV = 10_V;
-static constexpr units::volt_t kElevatorkS = 0.0_V;
-static constexpr units::volt_t kElevatorkG = 0.62_V;
-static constexpr auto kElevatorkV = 3.9_V / 1_mps;
-static constexpr auto kElevatorkA = 0.06_V / 1_mps_sq;
+inline constexpr units::volt_t kElevatorMaxV = 10_V;
+inline constexpr units::volt_t kElevatorkS = 0.0_V;
+inline constexpr units::volt_t kElevatorkG = 0.62_V;
+inline constexpr auto kElevatorkV = 3.9_V / 1_mps;
+inline constexpr auto kElevatorkA = 0.06_V / 1_mps_sq;
 
-static constexpr double kElevatorGearing = 5.0;
-static constexpr units::meter_t kElevatorDrumRadius = 1_in;
-static constexpr units::kilogram_t kCarriageMass = 12_lb;
+inline constexpr double kElevatorGearing = 5.0;
+inline constexpr units::meter_t kElevatorDrumRadius = 1_in;
+inline constexpr units::kilogram_t kCarriageMass = 12_lb;
 
-static constexpr units::meter_t kSetpoint = 42.875_in;
-static constexpr units::meter_t kLowerSetpoint = 15_in;
-static constexpr units::meter_t kMinElevatorHeight = 0_cm;
-static constexpr units::meter_t kMaxElevatorHeight = 50_in;
+inline constexpr units::meter_t kSetpoint = 42.875_in;
+inline constexpr units::meter_t kLowerSetpoint = 15_in;
+inline constexpr units::meter_t kMinElevatorHeight = 0_cm;
+inline constexpr units::meter_t kMaxElevatorHeight = 50_in;
 
 // distance per pulse = (distance per revolution) / (pulses per revolution)
 //  = (Pi * D) / ppr
-static constexpr double kArmEncoderDistPerPulse =
+inline constexpr double kArmEncoderDistPerPulse =
     2.0 * std::numbers::pi * kElevatorDrumRadius.value() / 4096.0;
 
 }  // namespace Constants

--- a/wpilibcExamples/src/main/cpp/examples/ElevatorSimulation/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/ElevatorSimulation/include/Constants.h
@@ -25,31 +25,31 @@
 
 namespace Constants {
 
-static constexpr int kMotorPort = 0;
-static constexpr int kEncoderAChannel = 0;
-static constexpr int kEncoderBChannel = 1;
-static constexpr int kJoystickPort = 0;
+inline constexpr int kMotorPort = 0;
+inline constexpr int kEncoderAChannel = 0;
+inline constexpr int kEncoderBChannel = 1;
+inline constexpr int kJoystickPort = 0;
 
-static constexpr double kElevatorKp = 5.0;
-static constexpr double kElevatorKi = 0.0;
-static constexpr double kElevatorKd = 0.0;
+inline constexpr double kElevatorKp = 5.0;
+inline constexpr double kElevatorKi = 0.0;
+inline constexpr double kElevatorKd = 0.0;
 
-static constexpr units::volt_t kElevatorkS = 0.0_V;
-static constexpr units::volt_t kElevatorkG = 0.762_V;
-static constexpr auto kElevatorkV = 0.762_V / 1_mps;
-static constexpr auto kElevatorkA = 0.0_V / 1_mps_sq;
+inline constexpr units::volt_t kElevatorkS = 0.0_V;
+inline constexpr units::volt_t kElevatorkG = 0.762_V;
+inline constexpr auto kElevatorkV = 0.762_V / 1_mps;
+inline constexpr auto kElevatorkA = 0.0_V / 1_mps_sq;
 
-static constexpr double kElevatorGearing = 10.0;
-static constexpr units::meter_t kElevatorDrumRadius = 2_in;
-static constexpr units::kilogram_t kCarriageMass = 4.0_kg;
+inline constexpr double kElevatorGearing = 10.0;
+inline constexpr units::meter_t kElevatorDrumRadius = 2_in;
+inline constexpr units::kilogram_t kCarriageMass = 4.0_kg;
 
-static constexpr units::meter_t kSetpoint = 75_cm;
-static constexpr units::meter_t kMinElevatorHeight = 0_cm;
-static constexpr units::meter_t kMaxElevatorHeight = 1.25_m;
+inline constexpr units::meter_t kSetpoint = 75_cm;
+inline constexpr units::meter_t kMinElevatorHeight = 0_cm;
+inline constexpr units::meter_t kMaxElevatorHeight = 1.25_m;
 
 // distance per pulse = (distance per revolution) / (pulses per revolution)
 //  = (Pi * D) / ppr
-static constexpr double kArmEncoderDistPerPulse =
+inline constexpr double kArmEncoderDistPerPulse =
     2.0 * std::numbers::pi * kElevatorDrumRadius.value() / 4096.0;
 
 }  // namespace Constants

--- a/wpilibcExamples/src/main/cpp/examples/Frisbeebot/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/Frisbeebot/include/Constants.h
@@ -20,56 +20,56 @@
  */
 
 namespace DriveConstants {
-constexpr int kLeftMotor1Port = 0;
-constexpr int kLeftMotor2Port = 1;
-constexpr int kRightMotor1Port = 2;
-constexpr int kRightMotor2Port = 3;
+inline constexpr int kLeftMotor1Port = 0;
+inline constexpr int kLeftMotor2Port = 1;
+inline constexpr int kRightMotor1Port = 2;
+inline constexpr int kRightMotor2Port = 3;
 
-constexpr int kLeftEncoderPorts[]{0, 1};
-constexpr int kRightEncoderPorts[]{2, 3};
-constexpr bool kLeftEncoderReversed = false;
-constexpr bool kRightEncoderReversed = true;
+inline constexpr int kLeftEncoderPorts[]{0, 1};
+inline constexpr int kRightEncoderPorts[]{2, 3};
+inline constexpr bool kLeftEncoderReversed = false;
+inline constexpr bool kRightEncoderReversed = true;
 
-constexpr int kEncoderCPR = 1024;
-constexpr double kWheelDiameterInches = 6;
-constexpr double kEncoderDistancePerPulse =
+inline constexpr int kEncoderCPR = 1024;
+inline constexpr double kWheelDiameterInches = 6;
+inline constexpr double kEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     (kWheelDiameterInches * std::numbers::pi) /
     static_cast<double>(kEncoderCPR);
 }  // namespace DriveConstants
 
 namespace ShooterConstants {
-constexpr int kEncoderPorts[]{4, 5};
-constexpr bool kEncoderReversed = false;
-constexpr int kEncoderCPR = 1024;
-constexpr double kEncoderDistancePerPulse =
+inline constexpr int kEncoderPorts[]{4, 5};
+inline constexpr bool kEncoderReversed = false;
+inline constexpr int kEncoderCPR = 1024;
+inline constexpr double kEncoderDistancePerPulse =
     // Distance units will be rotations
     1.0 / static_cast<double>(kEncoderCPR);
 
-constexpr int kShooterMotorPort = 4;
-constexpr int kFeederMotorPort = 5;
+inline constexpr int kShooterMotorPort = 4;
+inline constexpr int kFeederMotorPort = 5;
 
-constexpr auto kShooterFreeRPS = 5300_tr / 1_s;
-constexpr auto kShooterTargetRPS = 4000_tr / 1_s;
-constexpr auto kShooterToleranceRPS = 50_tr / 1_s;
+inline constexpr auto kShooterFreeRPS = 5300_tr / 1_s;
+inline constexpr auto kShooterTargetRPS = 4000_tr / 1_s;
+inline constexpr auto kShooterToleranceRPS = 50_tr / 1_s;
 
-constexpr double kP = 1;
-constexpr double kI = 0;
-constexpr double kD = 0;
+inline constexpr double kP = 1;
+inline constexpr double kI = 0;
+inline constexpr double kD = 0;
 
 // On a real robot the feedforward constants should be empirically determined;
 // these are reasonable guesses.
-constexpr auto kS = 0.05_V;
-constexpr auto kV =
+inline constexpr auto kS = 0.05_V;
+inline constexpr auto kV =
     // Should have value 12V at free speed...
     12_V / kShooterFreeRPS;
 
-constexpr double kFeederSpeed = 0.5;
+inline constexpr double kFeederSpeed = 0.5;
 }  // namespace ShooterConstants
 
 namespace AutoConstants {
-constexpr auto kAutoTimeoutSeconds = 12_s;
-constexpr auto kAutoShootTimeSeconds = 7_s;
+inline constexpr auto kAutoTimeoutSeconds = 12_s;
+inline constexpr auto kAutoShootTimeSeconds = 7_s;
 }  // namespace AutoConstants
 
 namespace OIConstants {

--- a/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/GyroDriveCommands/include/Constants.h
@@ -19,46 +19,46 @@
  */
 
 namespace DriveConstants {
-constexpr int kLeftMotor1Port = 0;
-constexpr int kLeftMotor2Port = 1;
-constexpr int kRightMotor1Port = 2;
-constexpr int kRightMotor2Port = 3;
+inline constexpr int kLeftMotor1Port = 0;
+inline constexpr int kLeftMotor2Port = 1;
+inline constexpr int kRightMotor1Port = 2;
+inline constexpr int kRightMotor2Port = 3;
 
-constexpr int kLeftEncoderPorts[]{0, 1};
-constexpr int kRightEncoderPorts[]{2, 3};
-constexpr bool kLeftEncoderReversed = false;
-constexpr bool kRightEncoderReversed = true;
+inline constexpr int kLeftEncoderPorts[]{0, 1};
+inline constexpr int kRightEncoderPorts[]{2, 3};
+inline constexpr bool kLeftEncoderReversed = false;
+inline constexpr bool kRightEncoderReversed = true;
 
-constexpr int kEncoderCPR = 1024;
-constexpr double kWheelDiameterInches = 6;
-constexpr double kEncoderDistancePerPulse =
+inline constexpr int kEncoderCPR = 1024;
+inline constexpr double kWheelDiameterInches = 6;
+inline constexpr double kEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     (kWheelDiameterInches * std::numbers::pi) /
     static_cast<double>(kEncoderCPR);
 
-constexpr bool kGyroReversed = true;
+inline constexpr bool kGyroReversed = true;
 
-constexpr double kStabilizationP = 1;
-constexpr double kStabilizationI = 0.5;
-constexpr double kStabilizationD = 0;
+inline constexpr double kStabilizationP = 1;
+inline constexpr double kStabilizationI = 0.5;
+inline constexpr double kStabilizationD = 0;
 
-constexpr double kTurnP = 1;
-constexpr double kTurnI = 0;
-constexpr double kTurnD = 0;
+inline constexpr double kTurnP = 1;
+inline constexpr double kTurnI = 0;
+inline constexpr double kTurnD = 0;
 
-constexpr auto kTurnTolerance = 5_deg;
-constexpr auto kTurnRateTolerance = 10_deg_per_s;
+inline constexpr auto kTurnTolerance = 5_deg;
+inline constexpr auto kTurnRateTolerance = 10_deg_per_s;
 
-constexpr auto kMaxTurnRate = 100_deg_per_s;
-constexpr auto kMaxTurnAcceleration = 300_deg_per_s / 1_s;
+inline constexpr auto kMaxTurnRate = 100_deg_per_s;
+inline constexpr auto kMaxTurnAcceleration = 300_deg_per_s / 1_s;
 }  // namespace DriveConstants
 
 namespace AutoConstants {
-constexpr double kAutoDriveDistanceInches = 60;
-constexpr double kAutoBackupDistanceInches = 20;
-constexpr double kAutoDriveSpeed = 0.5;
+inline constexpr double kAutoDriveDistanceInches = 60;
+inline constexpr double kAutoBackupDistanceInches = 20;
+inline constexpr double kAutoDriveSpeed = 0.5;
 }  // namespace AutoConstants
 
 namespace OIConstants {
-constexpr int kDriverControllerPort = 0;
+inline constexpr int kDriverControllerPort = 0;
 }  // namespace OIConstants

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotInlined/include/Constants.h
@@ -16,35 +16,35 @@
  */
 
 namespace DriveConstants {
-constexpr int kLeftMotor1Port = 0;
-constexpr int kLeftMotor2Port = 1;
-constexpr int kRightMotor1Port = 2;
-constexpr int kRightMotor2Port = 3;
+inline constexpr int kLeftMotor1Port = 0;
+inline constexpr int kLeftMotor2Port = 1;
+inline constexpr int kRightMotor1Port = 2;
+inline constexpr int kRightMotor2Port = 3;
 
-constexpr int kLeftEncoderPorts[]{0, 1};
-constexpr int kRightEncoderPorts[]{2, 3};
-constexpr bool kLeftEncoderReversed = false;
-constexpr bool kRightEncoderReversed = true;
+inline constexpr int kLeftEncoderPorts[]{0, 1};
+inline constexpr int kRightEncoderPorts[]{2, 3};
+inline constexpr bool kLeftEncoderReversed = false;
+inline constexpr bool kRightEncoderReversed = true;
 
-constexpr int kEncoderCPR = 1024;
-constexpr double kWheelDiameterInches = 6;
-constexpr double kEncoderDistancePerPulse =
+inline constexpr int kEncoderCPR = 1024;
+inline constexpr double kWheelDiameterInches = 6;
+inline constexpr double kEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     (kWheelDiameterInches * std::numbers::pi) /
     static_cast<double>(kEncoderCPR);
 }  // namespace DriveConstants
 
 namespace HatchConstants {
-constexpr int kHatchSolenoidModule = 0;
-constexpr int kHatchSolenoidPorts[]{0, 1};
+inline constexpr int kHatchSolenoidModule = 0;
+inline constexpr int kHatchSolenoidPorts[]{0, 1};
 }  // namespace HatchConstants
 
 namespace AutoConstants {
-constexpr double kAutoDriveDistanceInches = 60;
-constexpr double kAutoBackupDistanceInches = 20;
-constexpr double kAutoDriveSpeed = 0.5;
+inline constexpr double kAutoDriveDistanceInches = 60;
+inline constexpr double kAutoBackupDistanceInches = 20;
+inline constexpr double kAutoDriveSpeed = 0.5;
 }  // namespace AutoConstants
 
 namespace OIConstants {
-constexpr int kDriverControllerPort = 0;
+inline constexpr int kDriverControllerPort = 0;
 }  // namespace OIConstants

--- a/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/HatchbotTraditional/include/Constants.h
@@ -16,27 +16,27 @@
  */
 
 namespace DriveConstants {
-constexpr int kLeftMotor1Port = 0;
-constexpr int kLeftMotor2Port = 1;
-constexpr int kRightMotor1Port = 2;
-constexpr int kRightMotor2Port = 3;
+inline constexpr int kLeftMotor1Port = 0;
+inline constexpr int kLeftMotor2Port = 1;
+inline constexpr int kRightMotor1Port = 2;
+inline constexpr int kRightMotor2Port = 3;
 
-constexpr int kLeftEncoderPorts[]{0, 1};
-constexpr int kRightEncoderPorts[]{2, 3};
-constexpr bool kLeftEncoderReversed = false;
-constexpr bool kRightEncoderReversed = true;
+inline constexpr int kLeftEncoderPorts[]{0, 1};
+inline constexpr int kRightEncoderPorts[]{2, 3};
+inline constexpr bool kLeftEncoderReversed = false;
+inline constexpr bool kRightEncoderReversed = true;
 
-constexpr int kEncoderCPR = 1024;
-constexpr double kWheelDiameterInches = 6;
-constexpr double kEncoderDistancePerPulse =
+inline constexpr int kEncoderCPR = 1024;
+inline constexpr double kWheelDiameterInches = 6;
+inline constexpr double kEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     (kWheelDiameterInches * std::numbers::pi) /
     static_cast<double>(kEncoderCPR);
 }  // namespace DriveConstants
 
 namespace HatchConstants {
-constexpr int kHatchSolenoidModule = 0;
-constexpr int kHatchSolenoidPorts[]{0, 1};
+inline constexpr int kHatchSolenoidModule = 0;
+inline constexpr int kHatchSolenoidPorts[]{0, 1};
 }  // namespace HatchConstants
 
 namespace AutoConstants {

--- a/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/MecanumControllerCommand/include/Constants.h
@@ -28,30 +28,30 @@
  */
 
 namespace DriveConstants {
-constexpr int kFrontLeftMotorPort = 0;
-constexpr int kRearLeftMotorPort = 1;
-constexpr int kFrontRightMotorPort = 2;
-constexpr int kRearRightMotorPort = 3;
+inline constexpr int kFrontLeftMotorPort = 0;
+inline constexpr int kRearLeftMotorPort = 1;
+inline constexpr int kFrontRightMotorPort = 2;
+inline constexpr int kRearRightMotorPort = 3;
 
-constexpr int kFrontLeftEncoderPorts[]{0, 1};
-constexpr int kRearLeftEncoderPorts[]{2, 3};
-constexpr int kFrontRightEncoderPorts[]{4, 5};
-constexpr int kRearRightEncoderPorts[]{6, 7};
+inline constexpr int kFrontLeftEncoderPorts[]{0, 1};
+inline constexpr int kRearLeftEncoderPorts[]{2, 3};
+inline constexpr int kFrontRightEncoderPorts[]{4, 5};
+inline constexpr int kRearRightEncoderPorts[]{6, 7};
 
-constexpr bool kFrontLeftEncoderReversed = false;
-constexpr bool kRearLeftEncoderReversed = true;
-constexpr bool kFrontRightEncoderReversed = false;
-constexpr bool kRearRightEncoderReversed = true;
+inline constexpr bool kFrontLeftEncoderReversed = false;
+inline constexpr bool kRearLeftEncoderReversed = true;
+inline constexpr bool kFrontRightEncoderReversed = false;
+inline constexpr bool kRearRightEncoderReversed = true;
 
-constexpr auto kTrackWidth =
+inline constexpr auto kTrackWidth =
     0.5_m;  // Distance between centers of right and left wheels on robot
-constexpr auto kWheelBase =
+inline constexpr auto kWheelBase =
     0.7_m;  // Distance between centers of front and back wheels on robot
 extern const frc::MecanumDriveKinematics kDriveKinematics;
 
-constexpr int kEncoderCPR = 1024;
-constexpr double kWheelDiameterMeters = 0.15;
-constexpr double kEncoderDistancePerPulse =
+inline constexpr int kEncoderCPR = 1024;
+inline constexpr double kWheelDiameterMeters = 0.15;
+inline constexpr double kEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     (kWheelDiameterMeters * std::numbers::pi) /
     static_cast<double>(kEncoderCPR);
@@ -60,26 +60,26 @@ constexpr double kEncoderDistancePerPulse =
 // These characterization values MUST be determined either experimentally or
 // theoretically for *your* robot's drive. The SysId tool provides a convenient
 // method for obtaining these values for your robot.
-constexpr auto ks = 1_V;
-constexpr auto kv = 0.8 * 1_V * 1_s / 1_m;
-constexpr auto ka = 0.15 * 1_V * 1_s * 1_s / 1_m;
+inline constexpr auto ks = 1_V;
+inline constexpr auto kv = 0.8 * 1_V * 1_s / 1_m;
+inline constexpr auto ka = 0.15 * 1_V * 1_s * 1_s / 1_m;
 
 // Example value only - as above, this must be tuned for your drive!
-constexpr double kPFrontLeftVel = 0.5;
-constexpr double kPRearLeftVel = 0.5;
-constexpr double kPFrontRightVel = 0.5;
-constexpr double kPRearRightVel = 0.5;
+inline constexpr double kPFrontLeftVel = 0.5;
+inline constexpr double kPRearLeftVel = 0.5;
+inline constexpr double kPFrontRightVel = 0.5;
+inline constexpr double kPRearRightVel = 0.5;
 }  // namespace DriveConstants
 
 namespace AutoConstants {
-constexpr auto kMaxSpeed = 3_mps;
-constexpr auto kMaxAcceleration = 3_mps_sq;
-constexpr auto kMaxAngularSpeed = 3_rad_per_s;
-constexpr auto kMaxAngularAcceleration = 3_rad_per_s_sq;
+inline constexpr auto kMaxSpeed = 3_mps;
+inline constexpr auto kMaxAcceleration = 3_mps_sq;
+inline constexpr auto kMaxAngularSpeed = 3_rad_per_s;
+inline constexpr auto kMaxAngularAcceleration = 3_rad_per_s_sq;
 
-constexpr double kPXController = 0.5;
-constexpr double kPYController = 0.5;
-constexpr double kPThetaController = 0.5;
+inline constexpr double kPXController = 0.5;
+inline constexpr double kPYController = 0.5;
+inline constexpr double kPThetaController = 0.5;
 
 extern const frc::TrapezoidProfile<units::radians>::Constraints
     kThetaControllerConstraints;
@@ -87,5 +87,5 @@ extern const frc::TrapezoidProfile<units::radians>::Constraints
 }  // namespace AutoConstants
 
 namespace OIConstants {
-constexpr int kDriverControllerPort = 0;
+inline constexpr int kDriverControllerPort = 0;
 }  // namespace OIConstants

--- a/wpilibcExamples/src/main/cpp/examples/RamseteCommand/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/RamseteCommand/include/Constants.h
@@ -25,22 +25,22 @@
  */
 
 namespace DriveConstants {
-constexpr int kLeftMotor1Port = 0;
-constexpr int kLeftMotor2Port = 1;
-constexpr int kRightMotor1Port = 2;
-constexpr int kRightMotor2Port = 3;
+inline constexpr int kLeftMotor1Port = 0;
+inline constexpr int kLeftMotor2Port = 1;
+inline constexpr int kRightMotor1Port = 2;
+inline constexpr int kRightMotor2Port = 3;
 
-constexpr int kLeftEncoderPorts[]{0, 1};
-constexpr int kRightEncoderPorts[]{2, 3};
-constexpr bool kLeftEncoderReversed = false;
-constexpr bool kRightEncoderReversed = true;
+inline constexpr int kLeftEncoderPorts[]{0, 1};
+inline constexpr int kRightEncoderPorts[]{2, 3};
+inline constexpr bool kLeftEncoderReversed = false;
+inline constexpr bool kRightEncoderReversed = true;
 
-constexpr auto kTrackwidth = 0.69_m;
+inline constexpr auto kTrackwidth = 0.69_m;
 extern const frc::DifferentialDriveKinematics kDriveKinematics;
 
-constexpr int kEncoderCPR = 1024;
-constexpr units::meter_t kWheelDiameter = 6_in;
-constexpr auto kEncoderDistancePerPulse =
+inline constexpr int kEncoderCPR = 1024;
+inline constexpr units::meter_t kWheelDiameter = 6_in;
+inline constexpr auto kEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     (kWheelDiameter * std::numbers::pi) / static_cast<double>(kEncoderCPR);
 
@@ -49,24 +49,24 @@ constexpr auto kEncoderDistancePerPulse =
 // theoretically for *your* robot's drive. The Robot Characterization
 // Toolsuite provides a convenient tool for obtaining these values for your
 // robot.
-constexpr auto ks = 0.22_V;
-constexpr auto kv = 1.98 * 1_V * 1_s / 1_m;
-constexpr auto ka = 0.2 * 1_V * 1_s * 1_s / 1_m;
+inline constexpr auto ks = 0.22_V;
+inline constexpr auto kv = 1.98 * 1_V * 1_s / 1_m;
+inline constexpr auto ka = 0.2 * 1_V * 1_s * 1_s / 1_m;
 
 // Example value only - as above, this must be tuned for your drive!
-constexpr double kPDriveVel = 8.5;
+inline constexpr double kPDriveVel = 8.5;
 }  // namespace DriveConstants
 
 namespace AutoConstants {
-constexpr auto kMaxSpeed = 3_mps;
-constexpr auto kMaxAcceleration = 1_mps_sq;
+inline constexpr auto kMaxSpeed = 3_mps;
+inline constexpr auto kMaxAcceleration = 1_mps_sq;
 
 // Reasonable baseline values for a RAMSETE follower in units of meters and
 // seconds
-constexpr auto kRamseteB = 2.0 * 1_rad * 1_rad / (1_m * 1_m);
-constexpr auto kRamseteZeta = 0.7 / 1_rad;
+inline constexpr auto kRamseteB = 2.0 * 1_rad * 1_rad / (1_m * 1_m);
+inline constexpr auto kRamseteZeta = 0.7 / 1_rad;
 }  // namespace AutoConstants
 
 namespace OIConstants {
-constexpr int kDriverControllerPort = 0;
+inline constexpr int kDriverControllerPort = 0;
 }  // namespace OIConstants

--- a/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/RapidReactCommandBot/include/Constants.h
@@ -13,63 +13,63 @@
 #include <units/voltage.h>
 
 namespace DriveConstants {
-constexpr int kLeftMotor1Port = 0;
-constexpr int kLeftMotor2Port = 1;
-constexpr int kRightMotor1Port = 2;
-constexpr int kRightMotor2Port = 3;
+inline constexpr int kLeftMotor1Port = 0;
+inline constexpr int kLeftMotor2Port = 1;
+inline constexpr int kRightMotor1Port = 2;
+inline constexpr int kRightMotor2Port = 3;
 
-constexpr int kLeftEncoderPorts[]{0, 1};
-constexpr int kRightEncoderPorts[]{2, 3};
-constexpr bool kLeftEncoderReversed = false;
-constexpr bool kRightEncoderReversed = true;
+inline constexpr int kLeftEncoderPorts[]{0, 1};
+inline constexpr int kRightEncoderPorts[]{2, 3};
+inline constexpr bool kLeftEncoderReversed = false;
+inline constexpr bool kRightEncoderReversed = true;
 
-constexpr double kEncoderCPR = 1024;
-constexpr units::meter_t kWheelDiameter = 6.0_in;
-constexpr double kEncoderDistancePerPulse =
+inline constexpr double kEncoderCPR = 1024;
+inline constexpr units::meter_t kWheelDiameter = 6.0_in;
+inline constexpr double kEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     ((kWheelDiameter * std::numbers::pi) / kEncoderCPR).value();
 
 }  // namespace DriveConstants
 
 namespace IntakeConstants {
-constexpr int kMotorPort = 6;
-constexpr int kSolenoidPorts[]{0, 1};
+inline constexpr int kMotorPort = 6;
+inline constexpr int kSolenoidPorts[]{0, 1};
 }  // namespace IntakeConstants
 
 namespace StorageConstants {
-constexpr int kMotorPort = 7;
-constexpr int kBallSensorPort = 6;
+inline constexpr int kMotorPort = 7;
+inline constexpr int kBallSensorPort = 6;
 }  // namespace StorageConstants
 
 namespace ShooterConstants {
-constexpr int kEncoderPorts[]{4, 5};
-constexpr bool kEncoderReversed = false;
-constexpr double kEncoderCPR = 1024;
-constexpr double kEncoderDistancePerPulse =
+inline constexpr int kEncoderPorts[]{4, 5};
+inline constexpr bool kEncoderReversed = false;
+inline constexpr double kEncoderCPR = 1024;
+inline constexpr double kEncoderDistancePerPulse =
     // Distance units will be rotations
     1.0 / kEncoderCPR;
 
-constexpr int kShooterMotorPort = 4;
-constexpr int kFeederMotorPort = 5;
+inline constexpr int kShooterMotorPort = 4;
+inline constexpr int kFeederMotorPort = 5;
 
-constexpr auto kShooterFree = 5300_tps;
-constexpr auto kShooterTarget = 4000_tps;
-constexpr auto kShooterTolerance = 50_tps;
+inline constexpr auto kShooterFree = 5300_tps;
+inline constexpr auto kShooterTarget = 4000_tps;
+inline constexpr auto kShooterTolerance = 50_tps;
 
 // These are not real PID gains, and will have to be tuned for your specific
 // robot.
-constexpr double kP = 1;
+inline constexpr double kP = 1;
 
-constexpr units::volt_t kS = 0.05_V;
-constexpr auto kV =
+inline constexpr units::volt_t kS = 0.05_V;
+inline constexpr auto kV =
     // Should have value 12V at free speed...
     12.0_V / kShooterFree;
 
-constexpr double kFeederSpeed = 0.5;
+inline constexpr double kFeederSpeed = 0.5;
 }  // namespace ShooterConstants
 
 namespace OIConstants {
-constexpr int kDriverControllerPort = 0;
+inline constexpr int kDriverControllerPort = 0;
 }  // namespace OIConstants
 
 namespace AutoConstants {

--- a/wpilibcExamples/src/main/cpp/examples/RomiReference/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/RomiReference/include/Constants.h
@@ -14,6 +14,6 @@
  */
 
 namespace DriveConstants {
-constexpr double kCountsPerRevolution = 1440.0;
-constexpr double kWheelDiameterInch = 2.75;
+inline constexpr double kCountsPerRevolution = 1440.0;
+inline constexpr double kWheelDiameterInch = 2.75;
 }  // namespace DriveConstants

--- a/wpilibcExamples/src/main/cpp/examples/SelectCommand/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/SelectCommand/include/Constants.h
@@ -15,5 +15,5 @@
  */
 
 namespace OIConstants {
-constexpr int kDriverControllerPort = 0;
+inline constexpr int kDriverControllerPort = 0;
 }  // namespace OIConstants

--- a/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/include/Constants.h
@@ -27,22 +27,22 @@
  */
 
 namespace DriveConstants {
-constexpr int kLeftMotor1Port = 0;
-constexpr int kLeftMotor2Port = 1;
-constexpr int kRightMotor1Port = 2;
-constexpr int kRightMotor2Port = 3;
+inline constexpr int kLeftMotor1Port = 0;
+inline constexpr int kLeftMotor2Port = 1;
+inline constexpr int kRightMotor1Port = 2;
+inline constexpr int kRightMotor2Port = 3;
 
-constexpr int kLeftEncoderPorts[]{0, 1};
-constexpr int kRightEncoderPorts[]{2, 3};
-constexpr bool kLeftEncoderReversed = false;
-constexpr bool kRightEncoderReversed = true;
+inline constexpr int kLeftEncoderPorts[]{0, 1};
+inline constexpr int kRightEncoderPorts[]{2, 3};
+inline constexpr bool kLeftEncoderReversed = false;
+inline constexpr bool kRightEncoderReversed = true;
 
-constexpr auto kTrackwidth = 0.69_m;
+inline constexpr auto kTrackwidth = 0.69_m;
 extern const frc::DifferentialDriveKinematics kDriveKinematics;
 
-constexpr int kEncoderCPR = 1024;
-constexpr auto kWheelDiameter = 6_in;
-constexpr double kEncoderDistancePerPulse =
+inline constexpr int kEncoderCPR = 1024;
+inline constexpr auto kWheelDiameter = 6_in;
+inline constexpr double kEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     (kWheelDiameter.value() * std::numbers::pi) /
     static_cast<double>(kEncoderCPR);
@@ -52,33 +52,33 @@ constexpr double kEncoderDistancePerPulse =
 // theoretically for *your* robot's drive. The Robot Characterization
 // Toolsuite provides a convenient tool for obtaining these values for your
 // robot.
-constexpr auto ks = 0.22_V;
-constexpr auto kv = 1.98 * 1_V / 1_mps;
-constexpr auto ka = 0.2 * 1_V / 1_mps_sq;
+inline constexpr auto ks = 0.22_V;
+inline constexpr auto kv = 1.98 * 1_V / 1_mps;
+inline constexpr auto ka = 0.2 * 1_V / 1_mps_sq;
 
-constexpr auto kvAngular = 1.5 * 1_V / 1_mps;
-constexpr auto kaAngular = 0.3 * 1_V / 1_mps_sq;
+inline constexpr auto kvAngular = 1.5 * 1_V / 1_mps;
+inline constexpr auto kaAngular = 0.3 * 1_V / 1_mps_sq;
 
 extern const frc::LinearSystem<2, 2, 2> kDrivetrainPlant;
 
 // Example values only -- use what's on your physical robot!
-constexpr auto kDrivetrainGearbox = frc::DCMotor::CIM(2);
-constexpr auto kDrivetrainGearing = 8.0;
+inline constexpr auto kDrivetrainGearbox = frc::DCMotor::CIM(2);
+inline constexpr auto kDrivetrainGearing = 8.0;
 
 // Example value only - as above, this must be tuned for your drive!
-constexpr double kPDriveVel = 8.5;
+inline constexpr double kPDriveVel = 8.5;
 }  // namespace DriveConstants
 
 namespace AutoConstants {
-constexpr auto kMaxSpeed = 3_mps;
-constexpr auto kMaxAcceleration = 3_mps_sq;
+inline constexpr auto kMaxSpeed = 3_mps;
+inline constexpr auto kMaxAcceleration = 3_mps_sq;
 
 // Reasonable baseline values for a RAMSETE follower in units of meters and
 // seconds
-constexpr auto kRamseteB = 2 * 1_rad * 1_rad / (1_m * 1_m);
-constexpr auto kRamseteZeta = 0.7 / 1_rad;
+inline constexpr auto kRamseteB = 2 * 1_rad * 1_rad / (1_m * 1_m);
+inline constexpr auto kRamseteZeta = 0.7 / 1_rad;
 }  // namespace AutoConstants
 
 namespace OIConstants {
-constexpr int kDriverControllerPort = 0;
+inline constexpr int kDriverControllerPort = 0;
 }  // namespace OIConstants

--- a/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/SwerveControllerCommand/include/Constants.h
@@ -29,80 +29,80 @@
  */
 
 namespace DriveConstants {
-constexpr int kFrontLeftDriveMotorPort = 0;
-constexpr int kRearLeftDriveMotorPort = 2;
-constexpr int kFrontRightDriveMotorPort = 4;
-constexpr int kRearRightDriveMotorPort = 6;
+inline constexpr int kFrontLeftDriveMotorPort = 0;
+inline constexpr int kRearLeftDriveMotorPort = 2;
+inline constexpr int kFrontRightDriveMotorPort = 4;
+inline constexpr int kRearRightDriveMotorPort = 6;
 
-constexpr int kFrontLeftTurningMotorPort = 1;
-constexpr int kRearLeftTurningMotorPort = 3;
-constexpr int kFrontRightTurningMotorPort = 5;
-constexpr int kRearRightTurningMotorPort = 7;
+inline constexpr int kFrontLeftTurningMotorPort = 1;
+inline constexpr int kRearLeftTurningMotorPort = 3;
+inline constexpr int kFrontRightTurningMotorPort = 5;
+inline constexpr int kRearRightTurningMotorPort = 7;
 
-constexpr int kFrontLeftTurningEncoderPorts[2]{0, 1};
-constexpr int kRearLeftTurningEncoderPorts[2]{2, 3};
-constexpr int kFrontRightTurningEncoderPorts[2]{4, 5};
-constexpr int kRearRightTurningEncoderPorts[2]{6, 7};
+inline constexpr int kFrontLeftTurningEncoderPorts[2]{0, 1};
+inline constexpr int kRearLeftTurningEncoderPorts[2]{2, 3};
+inline constexpr int kFrontRightTurningEncoderPorts[2]{4, 5};
+inline constexpr int kRearRightTurningEncoderPorts[2]{6, 7};
 
-constexpr bool kFrontLeftTurningEncoderReversed = false;
-constexpr bool kRearLeftTurningEncoderReversed = true;
-constexpr bool kFrontRightTurningEncoderReversed = false;
-constexpr bool kRearRightTurningEncoderReversed = true;
+inline constexpr bool kFrontLeftTurningEncoderReversed = false;
+inline constexpr bool kRearLeftTurningEncoderReversed = true;
+inline constexpr bool kFrontRightTurningEncoderReversed = false;
+inline constexpr bool kRearRightTurningEncoderReversed = true;
 
-constexpr int kFrontLeftDriveEncoderPorts[2]{8, 9};
-constexpr int kRearLeftDriveEncoderPorts[2]{10, 11};
-constexpr int kFrontRightDriveEncoderPorts[2]{12, 13};
-constexpr int kRearRightDriveEncoderPorts[2]{14, 15};
+inline constexpr int kFrontLeftDriveEncoderPorts[2]{8, 9};
+inline constexpr int kRearLeftDriveEncoderPorts[2]{10, 11};
+inline constexpr int kFrontRightDriveEncoderPorts[2]{12, 13};
+inline constexpr int kRearRightDriveEncoderPorts[2]{14, 15};
 
-constexpr bool kFrontLeftDriveEncoderReversed = false;
-constexpr bool kRearLeftDriveEncoderReversed = true;
-constexpr bool kFrontRightDriveEncoderReversed = false;
-constexpr bool kRearRightDriveEncoderReversed = true;
+inline constexpr bool kFrontLeftDriveEncoderReversed = false;
+inline constexpr bool kRearLeftDriveEncoderReversed = true;
+inline constexpr bool kFrontRightDriveEncoderReversed = false;
+inline constexpr bool kRearRightDriveEncoderReversed = true;
 
 // If you call DriveSubsystem::Drive with a different period make sure to update
 // this.
-constexpr units::second_t kDrivePeriod = frc::TimedRobot::kDefaultPeriod;
+inline constexpr units::second_t kDrivePeriod = frc::TimedRobot::kDefaultPeriod;
 
 // These are example values only - DO NOT USE THESE FOR YOUR OWN ROBOT!
 // These characterization values MUST be determined either experimentally or
 // theoretically for *your* robot's drive. The SysId tool provides a convenient
 // method for obtaining these values for your robot.
-constexpr auto ks = 1_V;
-constexpr auto kv = 0.8 * 1_V * 1_s / 1_m;
-constexpr auto ka = 0.15 * 1_V * 1_s * 1_s / 1_m;
+inline constexpr auto ks = 1_V;
+inline constexpr auto kv = 0.8 * 1_V * 1_s / 1_m;
+inline constexpr auto ka = 0.15 * 1_V * 1_s * 1_s / 1_m;
 
 // Example value only - as above, this must be tuned for your drive!
-constexpr double kPFrontLeftVel = 0.5;
-constexpr double kPRearLeftVel = 0.5;
-constexpr double kPFrontRightVel = 0.5;
-constexpr double kPRearRightVel = 0.5;
+inline constexpr double kPFrontLeftVel = 0.5;
+inline constexpr double kPRearLeftVel = 0.5;
+inline constexpr double kPFrontRightVel = 0.5;
+inline constexpr double kPRearRightVel = 0.5;
 }  // namespace DriveConstants
 
 namespace ModuleConstants {
-constexpr int kEncoderCPR = 1024;
-constexpr double kWheelDiameterMeters = 0.15;
-constexpr double kDriveEncoderDistancePerPulse =
+inline constexpr int kEncoderCPR = 1024;
+inline constexpr double kWheelDiameterMeters = 0.15;
+inline constexpr double kDriveEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     (kWheelDiameterMeters * std::numbers::pi) /
     static_cast<double>(kEncoderCPR);
 
-constexpr double kTurningEncoderDistancePerPulse =
+inline constexpr double kTurningEncoderDistancePerPulse =
     // Assumes the encoders are directly mounted on the wheel shafts
     (std::numbers::pi * 2) / static_cast<double>(kEncoderCPR);
 
-constexpr double kPModuleTurningController = 1;
-constexpr double kPModuleDriveController = 1;
+inline constexpr double kPModuleTurningController = 1;
+inline constexpr double kPModuleDriveController = 1;
 }  // namespace ModuleConstants
 
 namespace AutoConstants {
-constexpr auto kMaxSpeed = 3_mps;
-constexpr auto kMaxAcceleration = 3_mps_sq;
-constexpr auto kMaxAngularSpeed = 3.142_rad_per_s;
-constexpr auto kMaxAngularAcceleration = 3.142_rad_per_s_sq;
+inline constexpr auto kMaxSpeed = 3_mps;
+inline constexpr auto kMaxAcceleration = 3_mps_sq;
+inline constexpr auto kMaxAngularSpeed = 3.142_rad_per_s;
+inline constexpr auto kMaxAngularAcceleration = 3.142_rad_per_s_sq;
 
-constexpr double kPXController = 0.5;
-constexpr double kPYController = 0.5;
-constexpr double kPThetaController = 0.5;
+inline constexpr double kPXController = 0.5;
+inline constexpr double kPYController = 0.5;
+inline constexpr double kPThetaController = 0.5;
 
 //
 
@@ -112,5 +112,5 @@ extern const frc::TrapezoidProfile<units::radians>::Constraints
 }  // namespace AutoConstants
 
 namespace OIConstants {
-constexpr int kDriverControllerPort = 0;
+inline constexpr int kDriverControllerPort = 0;
 }  // namespace OIConstants

--- a/wpilibcExamples/src/main/cpp/examples/UnitTest/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/UnitTest/include/Constants.h
@@ -14,13 +14,13 @@
  */
 
 namespace IntakeConstants {
-constexpr int kMotorPort = 1;
+inline constexpr int kMotorPort = 1;
 
-constexpr int kPistonFwdChannel = 0;
-constexpr int kPistonRevChannel = 1;
-constexpr double kIntakeSpeed = 0.5;
+inline constexpr int kPistonFwdChannel = 0;
+inline constexpr int kPistonRevChannel = 1;
+inline constexpr double kIntakeSpeed = 0.5;
 }  // namespace IntakeConstants
 
 namespace OperatorConstants {
-constexpr int kJoystickIndex = 0;
+inline constexpr int kJoystickIndex = 0;
 }  // namespace OperatorConstants

--- a/wpilibcExamples/src/main/cpp/examples/XRPReference/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/examples/XRPReference/include/Constants.h
@@ -14,6 +14,6 @@
  */
 
 namespace DriveConstants {
-constexpr double kCountsPerRevolution = 1440.0;
-constexpr double kWheelDiameterInch = 2.75;
+inline constexpr double kCountsPerRevolution = 1440.0;
+inline constexpr double kWheelDiameterInch = 2.75;
 }  // namespace DriveConstants

--- a/wpilibcExamples/src/main/cpp/templates/commandbased/include/Constants.h
+++ b/wpilibcExamples/src/main/cpp/templates/commandbased/include/Constants.h
@@ -16,6 +16,6 @@
 
 namespace OperatorConstants {
 
-constexpr int kDriverControllerPort = 0;
+inline constexpr int kDriverControllerPort = 0;
 
 }  // namespace OperatorConstants


### PR DESCRIPTION
Resolves #6047 

Note:
No adjustments made to sim examples because they used static specifier. This will ensure there is a new symbol of the same value push on the stack for every unit where the Constants.h file is included, however, I do not want to mess with those files because I don't know enough about sim. Let me know if those should be switched to 'inline constexpr' from 'static constexpr' 