### PR TITLE
Fix PS5 Controller mappings

### DIFF
--- a/wpilibc/src/main/native/include/frc/PS5Controller.h
+++ b/wpilibc/src/main/native/include/frc/PS5Controller.h
@@ -500,9 +500,9 @@ class PS5Controller : public GenericHID {
   BooleanEvent Touchpad(EventLoop* loop) const;
 
   struct Button {
-    static constexpr int kSquare = 3;
-    static constexpr int kCross = 1;
-    static constexpr int kCircle = 2;
+    static constexpr int kSquare = 1;
+    static constexpr int kCross = 2;
+    static constexpr int kCircle = 3;
     static constexpr int kTriangle = 4;
     static constexpr int kL1 = 5;
     static constexpr int kR1 = 6;
@@ -510,19 +510,19 @@ class PS5Controller : public GenericHID {
     static constexpr int kR2 = 8;
     static constexpr int kCreate = 9;
     static constexpr int kOptions = 10;
-    static constexpr int kL3 = 12;
-    static constexpr int kR3 = 13;
-    static constexpr int kPS = 11;
+    static constexpr int kL3 = 11;
+    static constexpr int kR3 = 12;
+    static constexpr int kPS = 13;
     static constexpr int kTouchpad = 14;
   };
 
   struct Axis {
     static constexpr int kLeftX = 0;
     static constexpr int kLeftY = 1;
-    static constexpr int kRightX = 3;
-    static constexpr int kRightY = 4;
-    static constexpr int kL2 = 2;
-    static constexpr int kR2 = 5;
+    static constexpr int kRightX = 2;
+    static constexpr int kRightY = 5;
+    static constexpr int kL2 = 3;
+    static constexpr int kR2 = 4;
   };
 };
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/PS5Controller.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/PS5Controller.java
@@ -27,9 +27,9 @@ public class PS5Controller extends GenericHID {
 
   /** Represents a digital button on a PS5Controller. */
   public enum Button {
-    kCross(1),
-    kCircle(2),
-    kSquare(3),
+    kSquare(1),
+    kCross(2),
+    kCircle(3),
     kTriangle(4),
     kL1(5),
     kR1(6),
@@ -37,9 +37,9 @@ public class PS5Controller extends GenericHID {
     kR2(8),
     kCreate(9),
     kOptions(10),
-    kPS(11),
-    kL3(12),
-    kR3(13),
+    kL3(11),
+    kR3(12),
+    kPS(13),
     kTouchpad(14);
 
     public final int value;
@@ -70,10 +70,10 @@ public class PS5Controller extends GenericHID {
   public enum Axis {
     kLeftX(0),
     kLeftY(1),
-    kL2(2),
-    kRightX(3),
-    kRightY(4),
-    kR2(5);
+    kL2(3),
+    kRightX(2),
+    kRightY(5),
+    kR2(4);
 
     public final int value;
 


### PR DESCRIPTION
It's likely the original mappings were done from Linux sim, which had a kernel bug in the past where the mappings were not right. This matches the official DS with an official PS5 Controller. 

Closes https://github.com/wpilibsuite/2024Beta/issues/43