### PR TITLE
[commands] Allow setting of SubsystemBase name in ctor

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SubsystemBase.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/SubsystemBase.java
@@ -15,11 +15,22 @@ import edu.wpi.first.util.sendable.SendableRegistry;
  * <p>This class is provided by the NewCommands VendorDep
  */
 public abstract class SubsystemBase implements Subsystem, Sendable {
-  /** Constructor. */
+  /** Constructor. Telemetry/log name defaults to the classname. */
   @SuppressWarnings("this-escape")
   public SubsystemBase() {
     String name = this.getClass().getSimpleName();
     name = name.substring(name.lastIndexOf('.') + 1);
+    SendableRegistry.addLW(this, name, name);
+    CommandScheduler.getInstance().registerSubsystem(this);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param name Name of the subsystem for telemetry and logging.
+   */
+  @SuppressWarnings("this-escape")
+  public SubsystemBase(String name) {
     SendableRegistry.addLW(this, name, name);
     CommandScheduler.getInstance().registerSubsystem(this);
   }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/SubsystemBase.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/SubsystemBase.cpp
@@ -17,6 +17,11 @@ SubsystemBase::SubsystemBase() {
   CommandScheduler::GetInstance().RegisterSubsystem({this});
 }
 
+SubsystemBase::SubsystemBase(std::string_view name) {
+  wpi::SendableRegistry::AddLW(this, name);
+  CommandScheduler::GetInstance().RegisterSubsystem({this});
+}
+
 void SubsystemBase::InitSendable(wpi::SendableBuilder& builder) {
   builder.SetSmartDashboardType("Subsystem");
   builder.AddBooleanProperty(

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SubsystemBase.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SubsystemBase.h
@@ -63,6 +63,15 @@ class SubsystemBase : public Subsystem,
   void AddChild(std::string name, wpi::Sendable* child);
 
  protected:
+  /**
+   * Constructor.  Telemetry/log name defaults to the classname.
+   */
   SubsystemBase();
+  /**
+   * Constructor.
+   *
+   * @param name Name of the subsystem for telemetry and logging.
+   */
+  explicit SubsystemBase(std::string_view name);
 };
 }  // namespace frc2


### PR DESCRIPTION
This is important for correct reporting of subsystem names in any logging utilities that are initialized at initial construction-time.