### PR TITLE
[glass] Fix order of loading window settings

### DIFF
--- a/glass/src/lib/native/cpp/Context.cpp
+++ b/glass/src/lib/native/cpp/Context.cpp
@@ -178,8 +178,6 @@ static bool LoadStorageRootImpl(Context* ctx, const std::string& filename,
 
 static bool LoadStorageImpl(Context* ctx, std::string_view dir,
                             std::string_view name) {
-  WorkspaceResetImpl();
-
   bool rv = true;
   for (auto&& root : ctx->storageRoots) {
     std::string filename;
@@ -421,6 +419,7 @@ std::string glass::GetStorageDir() {
 bool glass::LoadStorage(std::string_view dir) {
   SaveStorage();
   SetStorageDir(dir);
+  WorkspaceResetImpl();
   LoadWindowStorageImpl((fs::path{gContext->storageLoadDir} /
                          fmt::format("{}-window.json", gContext->storageName))
                             .string());


### PR DESCRIPTION
Fixes 6036.

Tested on Ubuntu 22.04, using cmake and gradle

The change is simply to move the WorkspaceResetImpl() before LoadWindowStorageImpl() instead of after.

It looks to me like this has always been broken, which doesn't make any sense to me, maybe somebody more familiar can help figure it out.  Regardless of the former scope of the issue, it seems good now, which is what I wanted.