### PR TITLE
Fix for generating apriltags in java

### DIFF
--- a/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTag.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/AprilTag.java
@@ -54,9 +54,7 @@ public class AprilTag {
    * @return A RawFrame containing the AprilTag image
    */
   public static RawFrame generate16h5AprilTagImage(int id) {
-    RawFrame generatedImage = new RawFrame();
-    AprilTagJNI.generate16h5AprilTagImage(id, generatedImage.getDataPtr());
-    return generatedImage;
+    return AprilTagJNI.generate16h5AprilTagImage(id);
   }
 
   /**
@@ -66,8 +64,6 @@ public class AprilTag {
    * @return A RawFrame containing the AprilTag image
    */
   public static RawFrame generate36h11AprilTagImage(int id) {
-    RawFrame generatedImage = new RawFrame();
-    AprilTagJNI.generate36h11AprilTagImage(id, generatedImage.getDataPtr());
-    return generatedImage;
+    return AprilTagJNI.generate36h11AprilTagImage(id);
   }
 }

--- a/apriltag/src/main/java/edu/wpi/first/apriltag/jni/AprilTagJNI.java
+++ b/apriltag/src/main/java/edu/wpi/first/apriltag/jni/AprilTagJNI.java
@@ -8,6 +8,7 @@ import edu.wpi.first.apriltag.AprilTagDetection;
 import edu.wpi.first.apriltag.AprilTagDetector;
 import edu.wpi.first.apriltag.AprilTagPoseEstimate;
 import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.util.RawFrame;
 import edu.wpi.first.util.RuntimeLoader;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -190,7 +191,7 @@ public class AprilTagJNI {
       double cx,
       double cy);
 
-  public static native void generate16h5AprilTagImage(int id, long nativeAddr);
+  public static native RawFrame generate16h5AprilTagImage(int id);
 
-  public static native void generate36h11AprilTagImage(int id, long nativeAddr);
+  public static native RawFrame generate36h11AprilTagImage(int id);
 }

--- a/apriltag/src/main/native/cpp/jni/AprilTagJNI.cpp
+++ b/apriltag/src/main/native/cpp/jni/AprilTagJNI.cpp
@@ -326,10 +326,11 @@ static jobject MakeJObject(JNIEnv* env, const wpi::RawFrame& frame) {
       env->GetMethodID(rawFrameCls, "setData", "(Ljava/nio/ByteBuffer;JIIII)V");
 
   jobject retVal = env->NewObject(rawFrameCls, constructor);
-  env->CallVoidMethod(retVal, setData,
-                      env->NewDirectByteBuffer(frame.data, frame.totalData),
-                      frame.data, frame.dataLength, frame.width, frame.height,
-                      frame.pixelFormat);
+  env->CallVoidMethod(
+      retVal, setData, env->NewDirectByteBuffer(frame.data, frame.totalData),
+      static_cast<jlong>(reinterpret_cast<intptr_t>(frame.data)),
+      static_cast<jint>(frame.dataLength), static_cast<jint>(frame.width),
+      static_cast<jint>(frame.height), static_cast<jint>(frame.pixelFormat));
   return retVal;
 }
 


### PR DESCRIPTION
This fixes #6062 

However, there is an issue that I can't figure out. 

I think there is UB somewhere in this code. For some reason, sometimes when running, the image is corrupted at the top row only.

These images were generated from the same code, different runs.
![16h5tag0](https://github.com/wpilibsuite/allwpilib/assets/6174102/35d83d17-78e2-49aa-bf7e-bfb7f082e0d4)
![16h5tag0](https://github.com/wpilibsuite/allwpilib/assets/6174102/f86c015a-6ed7-4bef-8737-1388398105cd)
 
Any help is appreciated!