### PR TITLE
[build] Add NO_WERROR option to CMake to disable -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,9 @@ option(USE_SYSTEM_EIGEN "Use system eigen" OFF)
 # Options for location of OpenCV Java.
 set(OPENCV_JAVA_INSTALL_DIR "" CACHE PATH "Location to search for the OpenCV jar file")
 
+# Options for compilation flags.
+option(NO_WERROR "Disable -Werror flag during compilation" OFF)
+
 # Set default build type to release with debug info (i.e. release mode optimizations
 # are performed, but debug info still exists).
 if(NOT CMAKE_BUILD_TYPE)

--- a/README-CMAKE.md
+++ b/README-CMAKE.md
@@ -63,6 +63,8 @@ The following build options are available:
   * TODO
 * `OPENCV_JAVA_INSTALL_DIR`
   * Set this option to the location of the archive of the OpenCV Java bindings (it should be called opencv-xxx.jar, with the x'es being version numbers). NOTE: set it to the LOCATION of the file, not the file itself!
+* `NO_WERROR` (OFF Default)
+  * This option will disable the `-Werror` compilation flag for non-MSVC builds.
 
 ## Build Setup
 

--- a/cmake/modules/CompileWarnings.cmake
+++ b/cmake/modules/CompileWarnings.cmake
@@ -1,15 +1,16 @@
 macro(wpilib_target_warnings target)
-    set(WARNING_FLAGS
-        -Wall
-        -pedantic
-        -Wextra
-        -Wno-unused-parameter
-        ${WPILIB_TARGET_WARNINGS}
-    )
-    if(NOT NO_WERROR)
-        set(WARNING_FLAGS "${WARNING_FLAGS}" -Werror)
-    endif()
     if(NOT MSVC)
+        set(WARNING_FLAGS
+            -Wall
+            -pedantic
+            -Wextra
+            -Wno-unused-parameter
+            ${WPILIB_TARGET_WARNINGS}
+        )
+        if(NOT NO_WERROR)
+            set(WARNING_FLAGS "${WARNING_FLAGS}" -Werror)
+        endif()
+
         target_compile_options(${target} PRIVATE ${WARNING_FLAGS})
     else()
         target_compile_options(

--- a/cmake/modules/CompileWarnings.cmake
+++ b/cmake/modules/CompileWarnings.cmake
@@ -1,13 +1,16 @@
 macro(wpilib_target_warnings target)
-    set(WARNING_FLAGS -Wall -pedantic -Wextra -Wno-unused-parameter ${WPILIB_TARGET_WARNINGS})
-    if (NOT NO_WERROR)
+    set(WARNING_FLAGS
+        -Wall
+        -pedantic
+        -Wextra
+        -Wno-unused-parameter
+        ${WPILIB_TARGET_WARNINGS}
+    )
+    if(NOT NO_WERROR)
         set(WARNING_FLAGS "${WARNING_FLAGS}" -Werror)
     endif()
     if(NOT MSVC)
-        target_compile_options(
-            ${target}
-            PRIVATE ${WARNING_FLAGS}
-        )
+        target_compile_options(${target} PRIVATE ${WARNING_FLAGS})
     else()
         target_compile_options(
             ${target}

--- a/cmake/modules/CompileWarnings.cmake
+++ b/cmake/modules/CompileWarnings.cmake
@@ -1,8 +1,12 @@
 macro(wpilib_target_warnings target)
+    set(WARNING_FLAGS -Wall -pedantic -Wextra -Wno-unused-parameter ${WPILIB_TARGET_WARNINGS})
+    if (NOT NO_WERROR)
+        set(WARNING_FLAGS "${WARNING_FLAGS}" -Werror)
+    endif()
     if(NOT MSVC)
         target_compile_options(
             ${target}
-            PRIVATE -Wall -pedantic -Wextra -Werror -Wno-unused-parameter ${WPILIB_TARGET_WARNINGS}
+            PRIVATE ${WARNING_FLAGS}
         )
     else()
         target_compile_options(

--- a/cmake/modules/CompileWarnings.cmake
+++ b/cmake/modules/CompileWarnings.cmake
@@ -8,7 +8,7 @@ macro(wpilib_target_warnings target)
             ${WPILIB_TARGET_WARNINGS}
         )
         if(NOT NO_WERROR)
-            set(WARNING_FLAGS "${WARNING_FLAGS}" -Werror)
+            set(WARNING_FLAGS ${WARNING_FLAGS} -Werror)
         endif()
 
         target_compile_options(${target} PRIVATE ${WARNING_FLAGS})


### PR DESCRIPTION
-Werror always being enabled is relatively inconvenient, as it frequently requires patching to get it to build (like in https://aur.archlinux.org/packages/wpimath)