### PR TITLE
Fix RawFrame class not being loaded in JNI

### DIFF
--- a/cscore/src/main/native/cpp/jni/CameraServerJNI.cpp
+++ b/cscore/src/main/native/cpp/jni/CameraServerJNI.cpp
@@ -42,7 +42,8 @@ static JNIEnv* listenerEnv = nullptr;
 static const JClassInit classes[] = {
     {"edu/wpi/first/cscore/UsbCameraInfo", &usbCameraInfoCls},
     {"edu/wpi/first/cscore/VideoMode", &videoModeCls},
-    {"edu/wpi/first/cscore/VideoEvent", &videoEventCls}};
+    {"edu/wpi/first/cscore/VideoEvent", &videoEventCls},
+    {"edu/wpi/first/util/RawFrame", &rawFrameCls}};
 
 static const JExceptionInit exceptions[] = {
     {"edu/wpi/first/cscore/VideoException", &videoEx},


### PR DESCRIPTION
Closes https://github.com/wpilibsuite/2024Beta/issues/51

Broken in https://github.com/wpilibsuite/allwpilib/pull/5923, the class load was removed instead of changed to the new class.