### PR TITLE
[wpiutil] Struct: Add info template parameter pack

### DIFF
--- a/ntcore/src/main/native/include/networktables/NetworkTable.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTable.h
@@ -37,9 +37,11 @@ class ProtobufTopic;
 class RawTopic;
 class StringArrayTopic;
 class StringTopic;
-template <wpi::StructSerializable T>
+template <typename T, typename... I>
+  requires wpi::StructSerializable<T, I...>
 class StructArrayTopic;
-template <wpi::StructSerializable T>
+template <typename T, typename... I>
+  requires wpi::StructSerializable<T, I...>
 class StructTopic;
 class Topic;
 

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
@@ -37,9 +37,11 @@ class ProtobufTopic;
 class RawTopic;
 class StringArrayTopic;
 class StringTopic;
-template <wpi::StructSerializable T>
+template <typename T, typename... I>
+  requires wpi::StructSerializable<T, I...>
 class StructArrayTopic;
-template <wpi::StructSerializable T>
+template <typename T, typename... I>
+  requires wpi::StructSerializable<T, I...>
 class StructTopic;
 class Subscriber;
 class Topic;
@@ -262,8 +264,9 @@ class NetworkTableInstance final {
    * @param name topic name
    * @return Topic
    */
-  template <wpi::StructSerializable T>
-  StructTopic<T> GetStructTopic(std::string_view name) const;
+  template <typename T, typename... I>
+    requires wpi::StructSerializable<T, I...>
+  StructTopic<T, I...> GetStructTopic(std::string_view name) const;
 
   /**
    * Gets a raw struct serialized array topic.
@@ -271,8 +274,9 @@ class NetworkTableInstance final {
    * @param name topic name
    * @return Topic
    */
-  template <wpi::StructSerializable T>
-  StructArrayTopic<T> GetStructArrayTopic(std::string_view name) const;
+  template <typename T, typename... I>
+    requires wpi::StructSerializable<T, I...>
+  StructArrayTopic<T, I...> GetStructArrayTopic(std::string_view name) const;
 
   /**
    * Get Published Topics.
@@ -818,10 +822,12 @@ class NetworkTableInstance final {
    * Registers a struct schema. Duplicate calls to this function with the same
    * name are silently ignored.
    *
-   * @param T struct serializable type
+   * @tparam T struct serializable type
+   * @param info optional struct type info
    */
-  template <wpi::StructSerializable T>
-  void AddStructSchema();
+  template <typename T, typename... I>
+    requires wpi::StructSerializable<T, I...>
+  void AddStructSchema(const I&... info);
 
   /**
    * Equality operator.  Returns true if both instances refer to the same

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
@@ -267,8 +267,7 @@ class NetworkTableInstance final {
    */
   template <typename T, typename... I>
     requires wpi::StructSerializable<T, I...>
-  StructTopic<T, I...> GetStructTopic(std::string_view name,
-                                      const I&... info) const;
+  StructTopic<T, I...> GetStructTopic(std::string_view name, I... info) const;
 
   /**
    * Gets a raw struct serialized array topic.

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
@@ -273,11 +273,13 @@ class NetworkTableInstance final {
    * Gets a raw struct serialized array topic.
    *
    * @param name topic name
+   * @param info optional struct type info
    * @return Topic
    */
   template <typename T, typename... I>
     requires wpi::StructSerializable<T, I...>
-  StructArrayTopic<T, I...> GetStructArrayTopic(std::string_view name) const;
+  StructArrayTopic<T, I...> GetStructArrayTopic(std::string_view name,
+                                                I... info) const;
 
   /**
    * Get Published Topics.

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.h
@@ -262,11 +262,13 @@ class NetworkTableInstance final {
    * Gets a raw struct serialized value topic.
    *
    * @param name topic name
+   * @param info optional struct type info
    * @return Topic
    */
   template <typename T, typename... I>
     requires wpi::StructSerializable<T, I...>
-  StructTopic<T, I...> GetStructTopic(std::string_view name) const;
+  StructTopic<T, I...> GetStructTopic(std::string_view name,
+                                      const I&... info) const;
 
   /**
    * Gets a raw struct serialized array topic.

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
@@ -44,16 +44,18 @@ inline ProtobufTopic<T> NetworkTableInstance::GetProtobufTopic(
   return ProtobufTopic<T>{GetTopic(name)};
 }
 
-template <wpi::StructSerializable T>
-inline StructTopic<T> NetworkTableInstance::GetStructTopic(
+template <typename T, typename... I>
+  requires wpi::StructSerializable<T, I...>
+inline StructTopic<T, I...> NetworkTableInstance::GetStructTopic(
     std::string_view name) const {
-  return StructTopic<T>{GetTopic(name)};
+  return StructTopic<T, I...>{GetTopic(name)};
 }
 
-template <wpi::StructSerializable T>
-inline StructArrayTopic<T> NetworkTableInstance::GetStructArrayTopic(
+template <typename T, typename... I>
+  requires wpi::StructSerializable<T, I...>
+inline StructArrayTopic<T, I...> NetworkTableInstance::GetStructArrayTopic(
     std::string_view name) const {
-  return StructArrayTopic<T>{GetTopic(name)};
+  return StructArrayTopic<T, I...>{GetTopic(name)};
 }
 
 inline std::vector<Topic> NetworkTableInstance::GetTopics() {
@@ -272,11 +274,14 @@ void NetworkTableInstance::AddProtobufSchema(wpi::ProtobufMessage<T>& msg) {
       });
 }
 
-template <wpi::StructSerializable T>
-void NetworkTableInstance::AddStructSchema() {
-  wpi::ForEachStructSchema<T>([this](auto typeString, auto schema) {
-    AddSchema(typeString, "structschema", schema);
-  });
+template <typename T, typename... I>
+  requires wpi::StructSerializable<T, I...>
+void NetworkTableInstance::AddStructSchema(const I&... info) {
+  wpi::ForEachStructSchema<T>(
+      [this](auto typeString, auto schema) {
+        AddSchema(typeString, "structschema", schema);
+      },
+      info...);
 }
 
 #ifdef __clang__

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
@@ -47,8 +47,8 @@ inline ProtobufTopic<T> NetworkTableInstance::GetProtobufTopic(
 template <typename T, typename... I>
   requires wpi::StructSerializable<T, I...>
 inline StructTopic<T, I...> NetworkTableInstance::GetStructTopic(
-    std::string_view name, const I&... info) const {
-  return StructTopic<T, I...>{GetTopic(name), info...};
+    std::string_view name, I... info) const {
+  return StructTopic<T, I...>{GetTopic(name), std::move(info)...};
 }
 
 template <typename T, typename... I>

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
@@ -54,8 +54,8 @@ inline StructTopic<T, I...> NetworkTableInstance::GetStructTopic(
 template <typename T, typename... I>
   requires wpi::StructSerializable<T, I...>
 inline StructArrayTopic<T, I...> NetworkTableInstance::GetStructArrayTopic(
-    std::string_view name) const {
-  return StructArrayTopic<T, I...>{GetTopic(name)};
+    std::string_view name, I... info) const {
+  return StructArrayTopic<T, I...>{GetTopic(name), std::move(info)...};
 }
 
 inline std::vector<Topic> NetworkTableInstance::GetTopics() {

--- a/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
+++ b/ntcore/src/main/native/include/networktables/NetworkTableInstance.inc
@@ -47,8 +47,8 @@ inline ProtobufTopic<T> NetworkTableInstance::GetProtobufTopic(
 template <typename T, typename... I>
   requires wpi::StructSerializable<T, I...>
 inline StructTopic<T, I...> NetworkTableInstance::GetStructTopic(
-    std::string_view name) const {
-  return StructTopic<T, I...>{GetTopic(name)};
+    std::string_view name, const I&... info) const {
+  return StructTopic<T, I...>{GetTopic(name), info...};
 }
 
 template <typename T, typename... I>

--- a/ntcore/src/main/native/include/networktables/StructArrayTopic.h
+++ b/ntcore/src/main/native/include/networktables/StructArrayTopic.h
@@ -264,7 +264,8 @@ class StructArrayPublisher : public Publisher {
   StructArrayPublisher(StructArrayPublisher&& rhs)
       : Publisher{std::move(rhs)},
         m_buf{std::move(rhs.m_buf)},
-        m_schemaPublished{rhs.m_schemaPublished},
+        m_schemaPublished{
+            rhs.m_schemaPublished.load(std::memory_order_relaxed)},
         m_info{std::move(rhs.m_info)} {}
 
   StructArrayPublisher& operator=(StructArrayPublisher&& rhs) {

--- a/ntcore/src/main/native/include/networktables/StructTopic.h
+++ b/ntcore/src/main/native/include/networktables/StructTopic.h
@@ -354,9 +354,7 @@ class StructEntry final : public StructSubscriber<T, I...>,
    *
    * @return Topic
    */
-  TopicType GetTopic() const {
-    return StructSubscriber<T, I...>::GetTopic();
-  }
+  TopicType GetTopic() const { return StructSubscriber<T, I...>::GetTopic(); }
 
   /**
    * Stops publishing the entry if it's published.

--- a/ntcore/src/main/native/include/networktables/StructTopic.h
+++ b/ntcore/src/main/native/include/networktables/StructTopic.h
@@ -205,7 +205,8 @@ class StructPublisher : public Publisher {
 
   StructPublisher(StructPublisher&& rhs)
       : Publisher{std::move(rhs)},
-        m_schemaPublished{rhs.m_schemaPublished},
+        m_schemaPublished{
+            rhs.m_schemaPublished.load(std::memory_order_relaxed)},
         m_info{std::move(rhs.m_info)} {}
 
   StructPublisher& operator=(StructPublisher&& rhs) {

--- a/ntcore/src/main/native/include/networktables/StructTopic.h
+++ b/ntcore/src/main/native/include/networktables/StructTopic.h
@@ -43,7 +43,7 @@ class StructSubscriber : public Subscriber {
   using ParamType = const T&;
   using TimestampedValueType = Timestamped<T>;
 
-  explicit StructSubscriber(const I&... info) : m_info{std::cref(info)...} {}
+  StructSubscriber() = default;
 
   /**
    * Construct from a subscriber handle; recommended to use
@@ -53,10 +53,10 @@ class StructSubscriber : public Subscriber {
    * @param defaultValue Default value
    * @param info optional struct type info
    */
-  StructSubscriber(NT_Subscriber handle, T defaultValue, const I&... info)
+  StructSubscriber(NT_Subscriber handle, T defaultValue, I... info)
       : Subscriber{handle},
         m_defaultValue{std::move(defaultValue)},
-        m_info{std::cref(info)...} {}
+        m_info{std::move(info)...} {}
 
   /**
    * Get the last published value.
@@ -180,7 +180,7 @@ class StructSubscriber : public Subscriber {
 
  private:
   ValueType m_defaultValue;
-  [[no_unique_address]] std::tuple<const I&...> m_info;
+  [[no_unique_address]] std::tuple<I...> m_info;
 };
 
 /**
@@ -198,7 +198,7 @@ class StructPublisher : public Publisher {
 
   using TimestampedValueType = Timestamped<T>;
 
-  explicit StructPublisher(const I&... info) : m_info{std::cref(info)...} {}
+  StructPublisher() = default;
 
   StructPublisher(const StructPublisher&) = delete;
   StructPublisher& operator=(const StructPublisher&) = delete;
@@ -224,8 +224,8 @@ class StructPublisher : public Publisher {
    * @param handle Native handle
    * @param info optional struct type info
    */
-  explicit StructPublisher(NT_Publisher handle, const I&... info)
-      : Publisher{handle}, m_info{std::cref(info)...} {}
+  explicit StructPublisher(NT_Publisher handle, I... info)
+      : Publisher{handle}, m_info{std::move(info)...} {}
 
   /**
    * Publish a new value.
@@ -300,7 +300,7 @@ class StructPublisher : public Publisher {
 
  private:
   std::atomic_bool m_schemaPublished{false};
-  [[no_unique_address]] std::tuple<const I&...> m_info;
+  [[no_unique_address]] std::tuple<I...> m_info;
 };
 
 /**
@@ -321,8 +321,7 @@ class StructEntry final : public StructSubscriber<T, I...>,
 
   using TimestampedValueType = Timestamped<T>;
 
-  explicit StructEntry(const I&... info)
-      : StructSubscriber<T, I...>{info...}, StructPublisher<T, I...>{info...} {}
+  StructEntry() = default;
 
   /**
    * Construct from an entry handle; recommended to use
@@ -379,7 +378,7 @@ class StructTopic final : public Topic {
   using ParamType = const T&;
   using TimestampedValueType = Timestamped<T>;
 
-  explicit StructTopic(const I&... info) : m_info{std::cref(info)...} {}
+  StructTopic() = default;
 
   /**
    * Construct from a topic handle; recommended to use
@@ -388,8 +387,8 @@ class StructTopic final : public Topic {
    * @param handle Native handle
    * @param info optional struct type info
    */
-  explicit StructTopic(NT_Topic handle, const I&... info)
-      : Topic{handle}, m_info{std::cref(info)...} {}
+  explicit StructTopic(NT_Topic handle, I... info)
+      : Topic{handle}, m_info{std::move(info)...} {}
 
   /**
    * Construct from a generic topic.
@@ -397,8 +396,8 @@ class StructTopic final : public Topic {
    * @param topic Topic
    * @param info optional struct type info
    */
-  explicit StructTopic(Topic topic, const I&... info)
-      : Topic{topic}, m_info{std::cref(info)...} {}
+  explicit StructTopic(Topic topic, I... info)
+      : Topic{topic}, m_info{std::move(info)...} {}
 
   /**
    * Create a new subscriber to the topic.
@@ -524,7 +523,7 @@ class StructTopic final : public Topic {
   }
 
  private:
-  [[no_unique_address]] std::tuple<const I&...> m_info;
+  [[no_unique_address]] std::tuple<I...> m_info;
 };
 
 }  // namespace nt

--- a/ntcore/src/test/native/cpp/StructTest.cpp
+++ b/ntcore/src/test/native/cpp/StructTest.cpp
@@ -410,20 +410,20 @@ TEST_F(StructTest, StructB) {
 TEST_F(StructTest, StructArrayB) {
   Info1 info;
   nt::StructArrayTopic<ThingB, Info1> topic =
-      inst.GetStructArrayTopic<ThingB, Info1>("b");
-  nt::StructArrayPublisher<ThingB, Info1> pub = topic.Publish(info);
-  nt::StructArrayPublisher<ThingB, Info1> pub2 = topic.PublishEx({{}}, info);
-  nt::StructArraySubscriber<ThingB, Info1> sub = topic.Subscribe({}, info);
-  nt::StructArrayEntry<ThingB, Info1> entry = topic.GetEntry({}, info);
-  pub.SetDefault({{ThingB{}, ThingB{}}}, info);
-  pub.Set({{ThingB{}, ThingB{}}}, info, 5);
-  sub.Get(info);
-  sub.Get({}, info);
-  sub.GetAtomic(info);
-  sub.GetAtomic({}, info);
-  entry.SetDefault({{ThingB{}, ThingB{}}}, info);
-  entry.Set({{ThingB{}, ThingB{}}}, info, 6);
-  entry.Get({}, info);
+      inst.GetStructArrayTopic<ThingB, Info1>("b", info);
+  nt::StructArrayPublisher<ThingB, Info1> pub = topic.Publish();
+  nt::StructArrayPublisher<ThingB, Info1> pub2 = topic.PublishEx({{}});
+  nt::StructArraySubscriber<ThingB, Info1> sub = topic.Subscribe({});
+  nt::StructArrayEntry<ThingB, Info1> entry = topic.GetEntry({});
+  pub.SetDefault({{ThingB{}, ThingB{}}});
+  pub.Set({{ThingB{}, ThingB{}}}, 5);
+  sub.Get();
+  sub.Get({});
+  sub.GetAtomic();
+  sub.GetAtomic({});
+  entry.SetDefault({{ThingB{}, ThingB{}}});
+  entry.Set({{ThingB{}, ThingB{}}}, 6);
+  entry.Get({});
 }
 
 TEST_F(StructTest, StructFixedArrayB) {

--- a/ntcore/src/test/native/cpp/StructTest.cpp
+++ b/ntcore/src/test/native/cpp/StructTest.cpp
@@ -433,10 +433,8 @@ TEST_F(StructTest, StructFixedArrayB) {
   nt::StructPublisher<std::array<ThingB, 2>, Info1> pub = topic.Publish();
   nt::StructPublisher<std::array<ThingB, 2>, Info1> pub2 =
       topic.PublishEx({{}});
-  nt::StructSubscriber<std::array<ThingB, 2>, Info1> sub =
-      topic.Subscribe({});
-  nt::StructEntry<std::array<ThingB, 2>, Info1> entry =
-      topic.GetEntry({});
+  nt::StructSubscriber<std::array<ThingB, 2>, Info1> sub = topic.Subscribe({});
+  nt::StructEntry<std::array<ThingB, 2>, Info1> entry = topic.GetEntry({});
   std::array<ThingB, 2> arr;
   pub.SetDefault(arr);
   pub.Set(arr, 5);

--- a/ntcore/src/test/native/cpp/StructTest.cpp
+++ b/ntcore/src/test/native/cpp/StructTest.cpp
@@ -391,20 +391,20 @@ TEST_F(StructTest, StructFixedArrayA) {
 TEST_F(StructTest, StructB) {
   Info1 info;
   nt::StructTopic<ThingB, Info1> topic =
-      inst.GetStructTopic<ThingB, Info1>("b");
-  nt::StructPublisher<ThingB, Info1> pub = topic.Publish(info);
-  nt::StructPublisher<ThingB, Info1> pub2 = topic.PublishEx({{}}, info);
-  nt::StructSubscriber<ThingB, Info1> sub = topic.Subscribe({}, info);
-  nt::StructEntry<ThingB, Info1> entry = topic.GetEntry({}, info);
-  pub.SetDefault({}, info);
-  pub.Set({}, info, 5);
-  sub.Get(info);
-  sub.Get({}, info);
-  sub.GetAtomic(info);
-  sub.GetAtomic({}, info);
-  entry.SetDefault({}, info);
-  entry.Set({}, info, 6);
-  entry.Get({}, info);
+      inst.GetStructTopic<ThingB, Info1>("b", info);
+  nt::StructPublisher<ThingB, Info1> pub = topic.Publish();
+  nt::StructPublisher<ThingB, Info1> pub2 = topic.PublishEx({{}});
+  nt::StructSubscriber<ThingB, Info1> sub = topic.Subscribe({});
+  nt::StructEntry<ThingB, Info1> entry = topic.GetEntry({});
+  pub.SetDefault({});
+  pub.Set({}, 5);
+  sub.Get();
+  sub.Get({});
+  sub.GetAtomic();
+  sub.GetAtomic({});
+  entry.SetDefault({});
+  entry.Set({}, 6);
+  entry.Get({});
 }
 
 TEST_F(StructTest, StructArrayB) {
@@ -429,24 +429,24 @@ TEST_F(StructTest, StructArrayB) {
 TEST_F(StructTest, StructFixedArrayB) {
   Info1 info;
   nt::StructTopic<std::array<ThingB, 2>, Info1> topic =
-      inst.GetStructTopic<std::array<ThingB, 2>, Info1>("b");
-  nt::StructPublisher<std::array<ThingB, 2>, Info1> pub = topic.Publish(info);
+      inst.GetStructTopic<std::array<ThingB, 2>, Info1>("b", info);
+  nt::StructPublisher<std::array<ThingB, 2>, Info1> pub = topic.Publish();
   nt::StructPublisher<std::array<ThingB, 2>, Info1> pub2 =
-      topic.PublishEx({{}}, info);
+      topic.PublishEx({{}});
   nt::StructSubscriber<std::array<ThingB, 2>, Info1> sub =
-      topic.Subscribe({}, info);
+      topic.Subscribe({});
   nt::StructEntry<std::array<ThingB, 2>, Info1> entry =
-      topic.GetEntry({}, info);
+      topic.GetEntry({});
   std::array<ThingB, 2> arr;
-  pub.SetDefault(arr, info);
-  pub.Set(arr, info, 5);
-  sub.Get(info);
-  sub.Get(arr, info);
-  sub.GetAtomic(info);
-  sub.GetAtomic(arr, info);
-  entry.SetDefault(arr, info);
-  entry.Set(arr, info, 6);
-  entry.Get(arr, info);
+  pub.SetDefault(arr);
+  pub.Set(arr, 5);
+  sub.Get();
+  sub.Get(arr);
+  sub.GetAtomic();
+  sub.GetAtomic(arr);
+  entry.SetDefault(arr);
+  entry.Set(arr, 6);
+  entry.Get(arr);
 }
 
 }  // namespace nt

--- a/wpiutil/src/main/native/include/wpi/DataLog.h
+++ b/wpiutil/src/main/native/include/wpi/DataLog.h
@@ -957,13 +957,13 @@ class StructLogEntry : public DataLogEntry {
   using S = Struct<T, I...>;
 
  public:
-  explicit StructLogEntry(const I&... info) : m_info{std::cref(info)...} {}
-  StructLogEntry(DataLog& log, std::string_view name, const I&... info,
+  StructLogEntry() = default;
+  StructLogEntry(DataLog& log, std::string_view name, I... info,
                  int64_t timestamp = 0)
-      : StructLogEntry{log, name, {}, info..., timestamp} {}
+      : StructLogEntry{log, name, {}, std::move(info)..., timestamp} {}
   StructLogEntry(DataLog& log, std::string_view name, std::string_view metadata,
-                 const I&... info, int64_t timestamp = 0)
-      : m_info{std::cref(info)...} {
+                 I... info, int64_t timestamp = 0)
+      : m_info{std::move(info)...} {
     m_log = &log;
     log.AddStructSchema<T, I...>(info..., timestamp);
     m_entry = log.Start(name, S::GetTypeString(info...), metadata, timestamp);
@@ -991,7 +991,7 @@ class StructLogEntry : public DataLogEntry {
   }
 
  private:
-  [[no_unique_address]] std::tuple<const I&...> m_info;
+  [[no_unique_address]] std::tuple<I...> m_info;
 };
 
 /**
@@ -1003,14 +1003,14 @@ class StructArrayLogEntry : public DataLogEntry {
   using S = Struct<T, I...>;
 
  public:
-  explicit StructArrayLogEntry(const I&... info) : m_info{std::cref(info)...} {}
-  StructArrayLogEntry(DataLog& log, std::string_view name, const I&... info,
+  StructArrayLogEntry() = default;
+  StructArrayLogEntry(DataLog& log, std::string_view name, I... info,
                       int64_t timestamp = 0)
-      : StructArrayLogEntry{log, name, {}, info..., timestamp} {}
+      : StructArrayLogEntry{log, name, {}, std::move(info)..., timestamp} {}
   StructArrayLogEntry(DataLog& log, std::string_view name,
-                      std::string_view metadata, const I&... info,
+                      std::string_view metadata, I... info,
                       int64_t timestamp = 0)
-      : m_info{std::cref(info)...} {
+      : m_info{std::move(info)...} {
     m_log = &log;
     log.AddStructSchema<T, I...>(info..., timestamp);
     m_entry = log.Start(
@@ -1059,7 +1059,7 @@ class StructArrayLogEntry : public DataLogEntry {
 
  private:
   StructArrayBuffer<T, I...> m_buf;
-  [[no_unique_address]] std::tuple<const I&...> m_info;
+  [[no_unique_address]] std::tuple<I...> m_info;
 };
 
 /**

--- a/wpiutil/src/main/native/include/wpi/struct/Struct.h
+++ b/wpiutil/src/main/native/include/wpi/struct/Struct.h
@@ -32,8 +32,9 @@ namespace wpi {
  * StructSerializable concept.
  *
  * @tparam T type to serialize/deserialize
+ * @tparam I optional struct type info
  */
-template <typename T>
+template <typename T, typename... I>
 struct Struct {};
 
 /**
@@ -63,23 +64,31 @@ struct Struct {};
  * If the struct has nested structs, implementations should also meet the
  * requirements of HasNestedStruct<T>.
  */
-template <typename T>
+template <typename T, typename... I>
 concept StructSerializable = requires(std::span<const uint8_t> in,
-                                      std::span<uint8_t> out, T&& value) {
-  typename Struct<typename std::remove_cvref_t<T>>;
+                                      std::span<uint8_t> out, T&& value,
+                                      const I&... info) {
+  typename Struct<typename std::remove_cvref_t<T>,
+                  typename std::remove_cvref_t<I>...>;
   {
-    Struct<typename std::remove_cvref_t<T>>::GetTypeString()
+    Struct<typename std::remove_cvref_t<T>,
+           typename std::remove_cvref_t<I>...>::GetTypeString(info...)
   } -> std::convertible_to<std::string_view>;
   {
-    Struct<typename std::remove_cvref_t<T>>::GetSize()
+    Struct<typename std::remove_cvref_t<T>,
+           typename std::remove_cvref_t<I>...>::GetSize(info...)
   } -> std::convertible_to<size_t>;
   {
-    Struct<typename std::remove_cvref_t<T>>::GetSchema()
+    Struct<typename std::remove_cvref_t<T>,
+           typename std::remove_cvref_t<I>...>::GetSchema(info...)
   } -> std::convertible_to<std::string_view>;
   {
-    Struct<typename std::remove_cvref_t<T>>::Unpack(in)
+    Struct<typename std::remove_cvref_t<T>,
+           typename std::remove_cvref_t<I>...>::Unpack(in, info...)
   } -> std::same_as<typename std::remove_cvref_t<T>>;
-  Struct<typename std::remove_cvref_t<T>>::Pack(out, std::forward<T>(value));
+  Struct<typename std::remove_cvref_t<T>,
+         typename std::remove_cvref_t<I>...>::Pack(out, std::forward<T>(value),
+                                                   info...);
 };
 
 /**
@@ -89,10 +98,12 @@ concept StructSerializable = requires(std::span<const uint8_t> in,
  * wpi::Struct<T> static member `void UnpackInto(T*, std::span<const uint8_t>)`
  * to update the pointed-to T with the contents of the span.
  */
-template <typename T>
+template <typename T, typename... I>
 concept MutableStructSerializable =
-    StructSerializable<T> && requires(T* out, std::span<const uint8_t> in) {
-      Struct<typename std::remove_cvref_t<T>>::UnpackInto(out, in);
+    StructSerializable<T, I...> &&
+    requires(T* out, std::span<const uint8_t> in, const I&... info) {
+      Struct<typename std::remove_cvref_t<T>,
+             typename std::remove_cvref_t<I>...>::UnpackInto(out, in, info...);
     };
 
 /**
@@ -104,11 +115,13 @@ concept MutableStructSerializable =
  * fn)` (or equivalent) and call ForEachNestedStruct<Type> on each nested struct
  * type.
  */
-template <typename T>
+template <typename T, typename... I>
 concept HasNestedStruct =
-    StructSerializable<T> &&
-    requires(function_ref<void(std::string_view, std::string_view)> fn) {
-      Struct<typename std::remove_cvref_t<T>>::ForEachNested(fn);
+    StructSerializable<T, I...> &&
+    requires(function_ref<void(std::string_view, std::string_view)> fn,
+             const I&... info) {
+      Struct<typename std::remove_cvref_t<T>,
+             typename std::remove_cvref_t<I>...>::ForEachNested(fn, info...);
     };
 
 /**
@@ -116,11 +129,13 @@ concept HasNestedStruct =
  *
  * @tparam T object type
  * @param data raw struct data
+ * @param info optional struct type info
  * @return Deserialized object
  */
-template <StructSerializable T>
-inline T UnpackStruct(std::span<const uint8_t> data) {
-  return Struct<T>::Unpack(data);
+template <StructSerializable T, typename... I>
+inline T UnpackStruct(std::span<const uint8_t> data, const I&... info) {
+  using S = Struct<T, typename std::remove_cvref_t<I>...>;
+  return S::Unpack(data, info...);
 }
 
 /**
@@ -130,11 +145,14 @@ inline T UnpackStruct(std::span<const uint8_t> data) {
  * @tparam T object type
  * @tparam Offset starting offset
  * @param data raw struct data
+ * @param info optional struct type info
  * @return Deserialized object
  */
-template <StructSerializable T, size_t Offset>
-inline T UnpackStruct(std::span<const uint8_t> data) {
-  return Struct<T>::Unpack(data.subspan(Offset));
+template <typename T, size_t Offset, typename... I>
+  requires StructSerializable<T, I...>
+inline T UnpackStruct(std::span<const uint8_t> data, const I&... info) {
+  using S = Struct<T, typename std::remove_cvref_t<I>...>;
+  return S::Unpack(data.subspan(Offset), info...);
 }
 
 /**
@@ -142,10 +160,14 @@ inline T UnpackStruct(std::span<const uint8_t> data) {
  *
  * @param data struct storage (mutable, output)
  * @param value object
+ * @param info optional struct type info
  */
-template <StructSerializable T>
-inline void PackStruct(std::span<uint8_t> data, T&& value) {
-  Struct<typename std::remove_cvref_t<T>>::Pack(data, std::forward<T>(value));
+template <typename T, typename... I>
+  requires StructSerializable<T, I...>
+inline void PackStruct(std::span<uint8_t> data, T&& value, const I&... info) {
+  using S = Struct<typename std::remove_cvref_t<T>,
+                   typename std::remove_cvref_t<I>...>;
+  S::Pack(data, std::forward<T>(value), info...);
 }
 
 /**
@@ -155,11 +177,14 @@ inline void PackStruct(std::span<uint8_t> data, T&& value) {
  * @tparam Offset starting offset
  * @param data struct storage (mutable, output)
  * @param value object
+ * @param info optional struct type info
  */
-template <size_t Offset, StructSerializable T>
-inline void PackStruct(std::span<uint8_t> data, T&& value) {
-  Struct<typename std::remove_cvref_t<T>>::Pack(data.subspan(Offset),
-                                                std::forward<T>(value));
+template <size_t Offset, typename T, typename... I>
+  requires StructSerializable<T, I...>
+inline void PackStruct(std::span<uint8_t> data, T&& value, const I&... info) {
+  using S = Struct<typename std::remove_cvref_t<T>,
+                   typename std::remove_cvref_t<I>...>;
+  S::Pack(data.subspan(Offset), std::forward<T>(value), info...);
 }
 
 /**
@@ -167,13 +192,17 @@ inline void PackStruct(std::span<uint8_t> data, T&& value) {
  *
  * @param out object (output)
  * @param data raw struct data
+ * @param info optional struct type info
  */
-template <StructSerializable T>
-inline void UnpackStructInto(T* out, std::span<const uint8_t> data) {
-  if constexpr (MutableStructSerializable<T>) {
-    Struct<T>::UnpackInto(out, data);
+template <typename T, typename... I>
+  requires StructSerializable<T, I...>
+inline void UnpackStructInto(T* out, std::span<const uint8_t> data,
+                             const I&... info) {
+  using S = Struct<T, typename std::remove_cvref_t<I>...>;
+  if constexpr (MutableStructSerializable<T, I...>) {
+    S::UnpackInto(out, data, info...);
   } else {
-    *out = UnpackStruct<T>(data);
+    *out = UnpackStruct<T>(data, info...);
   }
 }
 
@@ -185,13 +214,17 @@ inline void UnpackStructInto(T* out, std::span<const uint8_t> data) {
  * @tparam Offset starting offset
  * @param out object (output)
  * @param data raw struct data
+ * @param info optional struct type info
  */
-template <size_t Offset, StructSerializable T>
-inline void UnpackStructInto(T* out, std::span<const uint8_t> data) {
-  if constexpr (MutableStructSerializable<T>) {
-    Struct<T>::UnpackInto(out, data.subspan(Offset));
+template <size_t Offset, typename T, typename... I>
+  requires StructSerializable<T, I...>
+inline void UnpackStructInto(T* out, std::span<const uint8_t> data,
+                             const I&... info) {
+  using S = Struct<T, typename std::remove_cvref_t<I>...>;
+  if constexpr (MutableStructSerializable<T, I...>) {
+    S::UnpackInto(out, data.subspan(Offset), info...);
   } else {
-    *out = UnpackStruct<T, Offset>(data);
+    *out = UnpackStruct<T, Offset>(data, info...);
   }
 }
 
@@ -199,28 +232,37 @@ inline void UnpackStructInto(T* out, std::span<const uint8_t> data) {
  * Get the type string for a raw struct serializable type
  *
  * @tparam T serializable type
+ * @param info optional struct type info
  * @return type string
  */
-template <StructSerializable T>
-constexpr auto GetStructTypeString() {
-  return Struct<T>::GetTypeString();
+template <typename T, typename... I>
+  requires StructSerializable<T, I...>
+constexpr auto GetStructTypeString(const I&... info) {
+  using S = Struct<T, typename std::remove_cvref_t<I>...>;
+  return S::GetTypeString(info...);
 }
 
 /**
  * Get the size for a raw struct serializable type
  *
  * @tparam T serializable type
+ * @param info optional struct type info
  * @return size
  */
-template <StructSerializable T>
-constexpr size_t GetStructSize() {
-  return Struct<T>::GetSize();
+template <typename T, typename... I>
+  requires StructSerializable<T, I...>
+constexpr size_t GetStructSize(const I&... info) {
+  using S = Struct<T, typename std::remove_cvref_t<I>...>;
+  return S::GetSize(info...);
 }
 
-template <StructSerializable T, size_t N>
-constexpr auto MakeStructArrayTypeString() {
-  if constexpr (is_constexpr([] { Struct<T>::GetTypeString(); })) {
-    constexpr auto typeString = Struct<T>::GetTypeString();
+template <typename T, size_t N, typename... I>
+  requires StructSerializable<T, I...>
+constexpr auto MakeStructArrayTypeString(const I&... info) {
+  using S = Struct<T, typename std::remove_cvref_t<I>...>;
+  if constexpr (sizeof...(I) == 0 &&
+                is_constexpr([&] { S::GetTypeString(info...); })) {
+    constexpr auto typeString = S::GetTypeString(info...);
     using namespace literals;
     if constexpr (N == std::dynamic_extent) {
       return Concat(
@@ -235,17 +277,20 @@ constexpr auto MakeStructArrayTypeString() {
     }
   } else {
     if constexpr (N == std::dynamic_extent) {
-      return fmt::format("{}[]", Struct<T>::GetTypeString());
+      return fmt::format("{}[]", S::GetTypeString(info...));
     } else {
-      return fmt::format("{}[{}]", Struct<T>::GetTypeString(), N);
+      return fmt::format("{}[{}]", S::GetTypeString(info...), N);
     }
   }
 }
 
-template <StructSerializable T, size_t N>
-consteval auto MakeStructArraySchema() {
-  if constexpr (is_constexpr([] { Struct<T>::GetSchema(); })) {
-    constexpr auto schema = Struct<T>::GetSchema();
+template <typename T, size_t N, typename... I>
+  requires StructSerializable<T, I...>
+constexpr auto MakeStructArraySchema(const I&... info) {
+  using S = Struct<T, typename std::remove_cvref_t<I>...>;
+  if constexpr (sizeof...(I) == 0 &&
+                is_constexpr([&] { S::GetSchema(info...); })) {
+    constexpr auto schema = S::GetSchema(info...);
     using namespace literals;
     if constexpr (N == std::dynamic_extent) {
       return Concat(
@@ -258,36 +303,45 @@ consteval auto MakeStructArraySchema() {
     }
   } else {
     if constexpr (N == std::dynamic_extent) {
-      return fmt::format("{}[]", Struct<T>::GetSchema());
+      return fmt::format("{}[]", S::GetSchema(info...));
     } else {
-      return fmt::format("{}[{}]", Struct<T>::GetSchema(), N);
+      return fmt::format("{}[{}]", S::GetSchema(info...), N);
     }
   }
 }
 
-template <StructSerializable T>
-constexpr std::string_view GetStructSchema() {
-  return Struct<T>::GetSchema();
+template <typename T, typename... I>
+  requires StructSerializable<T, I...>
+constexpr std::string_view GetStructSchema(const I&... info) {
+  using S = Struct<T, typename std::remove_cvref_t<I>...>;
+  return S::GetSchema(info...);
 }
 
-template <StructSerializable T>
-constexpr std::span<const uint8_t> GetStructSchemaBytes() {
-  auto schema = Struct<T>::GetSchema();
+template <typename T, typename... I>
+  requires StructSerializable<T, I...>
+constexpr std::span<const uint8_t> GetStructSchemaBytes(const I&... info) {
+  using S = Struct<T, typename std::remove_cvref_t<I>...>;
+  auto schema = S::GetSchema(info...);
   return {reinterpret_cast<const uint8_t*>(schema.data()), schema.size()};
 }
 
-template <StructSerializable T>
+template <typename T, typename... I>
+  requires StructSerializable<T, I...>
 void ForEachStructSchema(
-    std::invocable<std::string_view, std::string_view> auto fn) {
-  if constexpr (HasNestedStruct<T>) {
-    Struct<typename std::remove_cvref_t<T>>::ForEachNested(fn);
+    std::invocable<std::string_view, std::string_view> auto fn,
+    const I&... info) {
+  using S = Struct<typename std::remove_cvref_t<T>,
+                   typename std::remove_cvref_t<I>...>;
+  if constexpr (HasNestedStruct<T, I...>) {
+    S::ForEachNested(fn, info...);
   }
-  fn(Struct<T>::GetTypeString(), Struct<T>::GetSchema());
+  fn(S::GetTypeString(info...), S::GetSchema(info...));
 }
 
-template <StructSerializable T>
+template <typename T, typename... I>
+  requires StructSerializable<T, I...>
 class StructArrayBuffer {
-  using S = Struct<T>;
+  using S = Struct<T, I...>;
 
  public:
   StructArrayBuffer() = default;
@@ -306,15 +360,15 @@ class StructArrayBuffer {
       std::convertible_to<std::ranges::range_value_t<U>, T> &&
 #endif
       std::invocable<F, std::span<const uint8_t>>
-    void Write(U&& data, F&& func) {
-    auto size = S::GetSize();
+    void Write(U&& data, F&& func, const I&... info) {
+    auto size = S::GetSize(info...);
     if ((std::size(data) * size) < 256) {
       // use the stack
       uint8_t buf[256];
       auto out = buf;
       for (auto&& val : data) {
         S::Pack(std::span<uint8_t>{std::to_address(out), size},
-                std::forward<decltype(val)>(val));
+                std::forward<decltype(val)>(val), info...);
         out += size;
       }
       func(std::span<uint8_t>{buf, out});
@@ -324,7 +378,7 @@ class StructArrayBuffer {
       auto out = m_buf.begin();
       for (auto&& val : data) {
         S::Pack(std::span<uint8_t>{std::to_address(out), size},
-                std::forward<decltype(val)>(val));
+                std::forward<decltype(val)>(val), info...);
         out += size;
       }
       func(m_buf);
@@ -339,39 +393,48 @@ class StructArrayBuffer {
 /**
  * Raw struct support for fixed-size arrays of other structs.
  */
-template <StructSerializable T, size_t N>
-struct Struct<std::array<T, N>> {
-  static constexpr auto GetTypeString() {
-    return MakeStructArrayTypeString<T, N>();
+template <typename T, size_t N, typename... I>
+  requires StructSerializable<T, I...>
+struct Struct<std::array<T, N>, I...> {
+  static constexpr auto GetTypeString(const I&... info) {
+    return MakeStructArrayTypeString<T, N>(info...);
   }
-  static constexpr size_t GetSize() { return N * GetStructSize<T>(); }
-  static constexpr auto GetSchema() { return MakeStructArraySchema<T, N>(); }
-  static std::array<T, N> Unpack(std::span<const uint8_t> data) {
-    auto size = GetStructSize<T>();
+  static constexpr size_t GetSize(const I&... info) {
+    return N * GetStructSize<T>(info...);
+  }
+  static constexpr auto GetSchema(const I&... info) {
+    return MakeStructArraySchema<T, N>(info...);
+  }
+  static std::array<T, N> Unpack(std::span<const uint8_t> data,
+                                 const I&... info) {
+    auto size = GetStructSize<T>(info...);
     std::array<T, N> result;
     for (size_t i = 0; i < N; ++i) {
-      result[i] = UnpackStruct<T, 0>(data);
+      result[i] = UnpackStruct<T, 0>(data, info...);
       data = data.subspan(size);
     }
     return result;
   }
-  static void Pack(std::span<uint8_t> data, std::span<const T, N> values) {
-    auto size = GetStructSize<T>();
+  static void Pack(std::span<uint8_t> data, std::span<const T, N> values,
+                   const I&... info) {
+    auto size = GetStructSize<T>(info...);
     std::span<uint8_t> unsizedData = data;
     for (auto&& val : values) {
-      PackStruct(unsizedData, val);
+      PackStruct(unsizedData, val, info...);
       unsizedData = unsizedData.subspan(size);
     }
   }
-  static void UnpackInto(std::array<T, N>* out, std::span<const uint8_t> data) {
-    UnpackInto(std::span{*out}, data);
+  static void UnpackInto(std::array<T, N>* out, std::span<const uint8_t> data,
+                         const I&... info) {
+    UnpackInto(std::span{*out}, data, info...);
   }
   // alternate span-based function
-  static void UnpackInto(std::span<T, N> out, std::span<const uint8_t> data) {
-    auto size = GetStructSize<T>();
+  static void UnpackInto(std::span<T, N> out, std::span<const uint8_t> data,
+                         const I&... info) {
+    auto size = GetStructSize<T>(info...);
     std::span<const uint8_t> unsizedData = data;
     for (size_t i = 0; i < N; ++i) {
-      UnpackStructInto(&out[i], unsizedData);
+      UnpackStructInto(&out[i], unsizedData, info...);
       unsizedData = unsizedData.subspan(size);
     }
   }

--- a/wpiutil/src/main/native/include/wpi/struct/Struct.h
+++ b/wpiutil/src/main/native/include/wpi/struct/Struct.h
@@ -132,7 +132,8 @@ concept HasNestedStruct =
  * @param info optional struct type info
  * @return Deserialized object
  */
-template <StructSerializable T, typename... I>
+template <typename T, typename... I>
+  requires StructSerializable<T, I...>
 inline T UnpackStruct(std::span<const uint8_t> data, const I&... info) {
   using S = Struct<T, typename std::remove_cvref_t<I>...>;
   return S::Unpack(data, info...);

--- a/wpiutil/src/test/native/cpp/DataLogTest.cpp
+++ b/wpiutil/src/test/native/cpp/DataLogTest.cpp
@@ -157,7 +157,7 @@ TEST(DataLogTest, StructFixedArrayA) {
 TEST(DataLogTest, StructB) {
   wpi::log::DataLog log{[](auto) {}};
   Info1 info;
-  [[maybe_unused]] wpi::log::StructLogEntry<ThingB, Info1> entry0{info};
+  [[maybe_unused]] wpi::log::StructLogEntry<ThingB, Info1> entry0;
   wpi::log::StructLogEntry<ThingB, Info1> entry{log, "b", info, 5};
   entry.Append(ThingB{});
   entry.Append(ThingB{}, 7);
@@ -166,7 +166,7 @@ TEST(DataLogTest, StructB) {
 TEST(DataLogTest, StructArrayB) {
   wpi::log::DataLog log{[](auto) {}};
   Info1 info;
-  [[maybe_unused]] wpi::log::StructArrayLogEntry<ThingB, Info1> entry0{info};
+  [[maybe_unused]] wpi::log::StructArrayLogEntry<ThingB, Info1> entry0;
   wpi::log::StructArrayLogEntry<ThingB, Info1> entry{log, "a", info, 5};
   entry.Append({{ThingB{}, ThingB{}}});
   entry.Append({{ThingB{}, ThingB{}}}, 7);

--- a/wpiutil/src/test/native/cpp/DataLogTest.cpp
+++ b/wpiutil/src/test/native/cpp/DataLogTest.cpp
@@ -131,6 +131,7 @@ TEST(DataLogTest, SimpleInt) {
 
 TEST(DataLogTest, StructA) {
   wpi::log::DataLog log{[](auto) {}};
+  [[maybe_unused]] wpi::log::StructLogEntry<ThingA> entry0;
   wpi::log::StructLogEntry<ThingA> entry{log, "a", 5};
   entry.Append(ThingA{});
   entry.Append(ThingA{}, 7);
@@ -138,6 +139,7 @@ TEST(DataLogTest, StructA) {
 
 TEST(DataLogTest, StructArrayA) {
   wpi::log::DataLog log{[](auto) {}};
+  [[maybe_unused]] wpi::log::StructArrayLogEntry<ThingA> entry0;
   wpi::log::StructArrayLogEntry<ThingA> entry{log, "a", 5};
   entry.Append({{ThingA{}, ThingA{}}});
   entry.Append({{ThingA{}, ThingA{}}}, 7);
@@ -145,6 +147,7 @@ TEST(DataLogTest, StructArrayA) {
 
 TEST(DataLogTest, StructFixedArrayA) {
   wpi::log::DataLog log{[](auto) {}};
+  [[maybe_unused]] wpi::log::StructArrayLogEntry<std::array<ThingA, 2>> entry0;
   wpi::log::StructLogEntry<std::array<ThingA, 2>> entry{log, "a", 5};
   std::array<ThingA, 2> arr;
   entry.Append(arr);
@@ -154,17 +157,19 @@ TEST(DataLogTest, StructFixedArrayA) {
 TEST(DataLogTest, StructB) {
   wpi::log::DataLog log{[](auto) {}};
   Info1 info;
+  [[maybe_unused]] wpi::log::StructLogEntry<ThingB, Info1> entry0{info};
   wpi::log::StructLogEntry<ThingB, Info1> entry{log, "b", info, 5};
-  entry.Append(ThingB{}, info);
-  entry.Append(ThingB{}, info, 7);
+  entry.Append(ThingB{});
+  entry.Append(ThingB{}, 7);
 }
 
 TEST(DataLogTest, StructArrayB) {
   wpi::log::DataLog log{[](auto) {}};
   Info1 info;
+  [[maybe_unused]] wpi::log::StructArrayLogEntry<ThingB, Info1> entry0{info};
   wpi::log::StructArrayLogEntry<ThingB, Info1> entry{log, "a", info, 5};
-  entry.Append({{ThingB{}, ThingB{}}}, info);
-  entry.Append({{ThingB{}, ThingB{}}}, info, 7);
+  entry.Append({{ThingB{}, ThingB{}}});
+  entry.Append({{ThingB{}, ThingB{}}}, 7);
 }
 
 TEST(DataLogTest, StructFixedArrayB) {
@@ -173,8 +178,8 @@ TEST(DataLogTest, StructFixedArrayB) {
   wpi::log::StructLogEntry<std::array<ThingB, 2>, Info1> entry{log, "a", info,
                                                                5};
   std::array<ThingB, 2> arr;
-  entry.Append(arr, info);
-  entry.Append(arr, info, 7);
+  entry.Append(arr);
+  entry.Append(arr, 7);
 }
 
 TEST(DataLogTest, StructC) {
@@ -187,14 +192,14 @@ TEST(DataLogTest, StructC) {
   {
     Info1 info;
     wpi::log::StructLogEntry<ThingC, Info1> entry{log, "c1", info, 5};
-    entry.Append(ThingC{}, info);
-    entry.Append(ThingC{}, info, 7);
+    entry.Append(ThingC{});
+    entry.Append(ThingC{}, 7);
   }
   {
     Info2 info;
     wpi::log::StructLogEntry<ThingC, Info2> entry{log, "c2", info, 5};
-    entry.Append(ThingC{}, info);
-    entry.Append(ThingC{}, info, 7);
+    entry.Append(ThingC{});
+    entry.Append(ThingC{}, 7);
   }
 }
 
@@ -208,14 +213,14 @@ TEST(DataLogTest, StructArrayC) {
   {
     Info1 info;
     wpi::log::StructArrayLogEntry<ThingC, Info1> entry{log, "c1", info, 5};
-    entry.Append({{ThingC{}, ThingC{}}}, info);
-    entry.Append({{ThingC{}, ThingC{}}}, info, 7);
+    entry.Append({{ThingC{}, ThingC{}}});
+    entry.Append({{ThingC{}, ThingC{}}}, 7);
   }
   {
     Info2 info;
     wpi::log::StructArrayLogEntry<ThingC, Info2> entry{log, "c2", info, 5};
-    entry.Append({{ThingC{}, ThingC{}}}, info);
-    entry.Append({{ThingC{}, ThingC{}}}, info, 7);
+    entry.Append({{ThingC{}, ThingC{}}});
+    entry.Append({{ThingC{}, ThingC{}}}, 7);
   }
 }
 
@@ -231,14 +236,14 @@ TEST(DataLogTest, StructFixedArrayC) {
     Info1 info;
     wpi::log::StructLogEntry<std::array<ThingC, 2>, Info1> entry{log, "c1",
                                                                  info, 5};
-    entry.Append(arr, info);
-    entry.Append(arr, info, 7);
+    entry.Append(arr);
+    entry.Append(arr, 7);
   }
   {
     Info2 info;
     wpi::log::StructLogEntry<std::array<ThingC, 2>, Info2> entry{log, "c2",
                                                                  info, 5};
-    entry.Append(arr, info);
-    entry.Append(arr, info, 7);
+    entry.Append(arr);
+    entry.Append(arr, 7);
   }
 }

--- a/wpiutil/src/test/native/cpp/DataLogTest.cpp
+++ b/wpiutil/src/test/native/cpp/DataLogTest.cpp
@@ -2,9 +2,121 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
+#include <array>
+
 #include <gtest/gtest.h>
 
 #include "wpi/DataLog.h"
+
+namespace {
+struct ThingA {
+  int x = 0;
+};
+
+struct ThingB {
+  int x = 0;
+};
+
+struct ThingC {
+  int x = 0;
+};
+
+struct Info1 {
+  int info = 0;
+};
+
+struct Info2 {
+  int info = 0;
+};
+}  // namespace
+
+template <>
+struct wpi::Struct<ThingA> {
+  static constexpr std::string_view GetTypeString() { return "struct:ThingA"; }
+  static constexpr size_t GetSize() { return 1; }
+  static constexpr std::string_view GetSchema() { return "uint8 value"; }
+  static ThingA Unpack(std::span<const uint8_t> data) {
+    return ThingA{.x = data[0]};
+  }
+  static void Pack(std::span<uint8_t> data, const ThingA& value) {
+    data[0] = value.x;
+  }
+};
+
+template <>
+struct wpi::Struct<ThingB, Info1> {
+  static constexpr std::string_view GetTypeString(const Info1&) {
+    return "struct:ThingB";
+  }
+  static constexpr size_t GetSize(const Info1&) { return 1; }
+  static constexpr std::string_view GetSchema(const Info1&) {
+    return "uint8 value";
+  }
+  static ThingB Unpack(std::span<const uint8_t> data, const Info1&) {
+    return ThingB{.x = data[0]};
+  }
+  static void Pack(std::span<uint8_t> data, const ThingB& value, const Info1&) {
+    data[0] = value.x;
+  }
+};
+
+template <>
+struct wpi::Struct<ThingC> {
+  static constexpr std::string_view GetTypeString() { return "struct:ThingC"; }
+  static constexpr size_t GetSize() { return 1; }
+  static constexpr std::string_view GetSchema() { return "uint8 value"; }
+  static ThingC Unpack(std::span<const uint8_t> data) {
+    return ThingC{.x = data[0]};
+  }
+  static void Pack(std::span<uint8_t> data, const ThingC& value) {
+    data[0] = value.x;
+  }
+};
+
+template <>
+struct wpi::Struct<ThingC, Info1> {
+  static constexpr std::string_view GetTypeString(const Info1&) {
+    return "struct:ThingC";
+  }
+  static constexpr size_t GetSize(const Info1&) { return 1; }
+  static constexpr std::string_view GetSchema(const Info1&) {
+    return "uint8 value";
+  }
+  static ThingC Unpack(std::span<const uint8_t> data, const Info1&) {
+    return ThingC{.x = data[0]};
+  }
+  static void Pack(std::span<uint8_t> data, const ThingC& value, const Info1&) {
+    data[0] = value.x;
+  }
+};
+
+template <>
+struct wpi::Struct<ThingC, Info2> {
+  static constexpr std::string_view GetTypeString(const Info2&) {
+    return "struct:ThingC";
+  }
+  static constexpr size_t GetSize(const Info2&) { return 1; }
+  static constexpr std::string_view GetSchema(const Info2&) {
+    return "uint8 value";
+  }
+  static ThingC Unpack(std::span<const uint8_t> data, const Info2&) {
+    return ThingC{.x = data[0]};
+  }
+  static void Pack(std::span<uint8_t> data, const ThingC& value, const Info2&) {
+    data[0] = value.x;
+  }
+};
+
+static_assert(wpi::StructSerializable<ThingA>);
+static_assert(!wpi::StructSerializable<ThingA, Info1>);
+
+static_assert(!wpi::StructSerializable<ThingB>);
+static_assert(wpi::StructSerializable<ThingB, Info1>);
+static_assert(!wpi::StructSerializable<ThingB, Info2>);
+
+static_assert(wpi::StructSerializable<ThingC>);
+static_assert(wpi::StructSerializable<ThingC, Info1>);
+static_assert(wpi::StructSerializable<ThingC, Info2>);
 
 TEST(DataLogTest, SimpleInt) {
   std::vector<uint8_t> data;
@@ -15,4 +127,118 @@ TEST(DataLogTest, SimpleInt) {
     log.AppendInteger(entry, 1, 0);
   }
   ASSERT_EQ(data.size(), 66u);
+}
+
+TEST(DataLogTest, StructA) {
+  wpi::log::DataLog log{[](auto) {}};
+  wpi::log::StructLogEntry<ThingA> entry{log, "a", 5};
+  entry.Append(ThingA{});
+  entry.Append(ThingA{}, 7);
+}
+
+TEST(DataLogTest, StructArrayA) {
+  wpi::log::DataLog log{[](auto) {}};
+  wpi::log::StructArrayLogEntry<ThingA> entry{log, "a", 5};
+  entry.Append({{ThingA{}, ThingA{}}});
+  entry.Append({{ThingA{}, ThingA{}}}, 7);
+}
+
+TEST(DataLogTest, StructFixedArrayA) {
+  wpi::log::DataLog log{[](auto) {}};
+  wpi::log::StructLogEntry<std::array<ThingA, 2>> entry{log, "a", 5};
+  std::array<ThingA, 2> arr;
+  entry.Append(arr);
+  entry.Append(arr, 7);
+}
+
+TEST(DataLogTest, StructB) {
+  wpi::log::DataLog log{[](auto) {}};
+  Info1 info;
+  wpi::log::StructLogEntry<ThingB, Info1> entry{log, "b", info, 5};
+  entry.Append(ThingB{}, info);
+  entry.Append(ThingB{}, info, 7);
+}
+
+TEST(DataLogTest, StructArrayB) {
+  wpi::log::DataLog log{[](auto) {}};
+  Info1 info;
+  wpi::log::StructArrayLogEntry<ThingB, Info1> entry{log, "a", info, 5};
+  entry.Append({{ThingB{}, ThingB{}}}, info);
+  entry.Append({{ThingB{}, ThingB{}}}, info, 7);
+}
+
+TEST(DataLogTest, StructFixedArrayB) {
+  wpi::log::DataLog log{[](auto) {}};
+  Info1 info;
+  wpi::log::StructLogEntry<std::array<ThingB, 2>, Info1> entry{log, "a", info,
+                                                               5};
+  std::array<ThingB, 2> arr;
+  entry.Append(arr, info);
+  entry.Append(arr, info, 7);
+}
+
+TEST(DataLogTest, StructC) {
+  wpi::log::DataLog log{[](auto) {}};
+  {
+    wpi::log::StructLogEntry<ThingC> entry{log, "c", 5};
+    entry.Append(ThingC{});
+    entry.Append(ThingC{}, 7);
+  }
+  {
+    Info1 info;
+    wpi::log::StructLogEntry<ThingC, Info1> entry{log, "c1", info, 5};
+    entry.Append(ThingC{}, info);
+    entry.Append(ThingC{}, info, 7);
+  }
+  {
+    Info2 info;
+    wpi::log::StructLogEntry<ThingC, Info2> entry{log, "c2", info, 5};
+    entry.Append(ThingC{}, info);
+    entry.Append(ThingC{}, info, 7);
+  }
+}
+
+TEST(DataLogTest, StructArrayC) {
+  wpi::log::DataLog log{[](auto) {}};
+  {
+    wpi::log::StructArrayLogEntry<ThingC> entry{log, "c", 5};
+    entry.Append({{ThingC{}, ThingC{}}});
+    entry.Append({{ThingC{}, ThingC{}}}, 7);
+  }
+  {
+    Info1 info;
+    wpi::log::StructArrayLogEntry<ThingC, Info1> entry{log, "c1", info, 5};
+    entry.Append({{ThingC{}, ThingC{}}}, info);
+    entry.Append({{ThingC{}, ThingC{}}}, info, 7);
+  }
+  {
+    Info2 info;
+    wpi::log::StructArrayLogEntry<ThingC, Info2> entry{log, "c2", info, 5};
+    entry.Append({{ThingC{}, ThingC{}}}, info);
+    entry.Append({{ThingC{}, ThingC{}}}, info, 7);
+  }
+}
+
+TEST(DataLogTest, StructFixedArrayC) {
+  wpi::log::DataLog log{[](auto) {}};
+  std::array<ThingC, 2> arr;
+  {
+    wpi::log::StructLogEntry<std::array<ThingC, 2>> entry{log, "c", 5};
+    entry.Append(arr);
+    entry.Append(arr, 7);
+  }
+  {
+    Info1 info;
+    wpi::log::StructLogEntry<std::array<ThingC, 2>, Info1> entry{log, "c1",
+                                                                 info, 5};
+    entry.Append(arr, info);
+    entry.Append(arr, info, 7);
+  }
+  {
+    Info2 info;
+    wpi::log::StructLogEntry<std::array<ThingC, 2>, Info2> entry{log, "c2",
+                                                                 info, 5};
+    entry.Append(arr, info);
+    entry.Append(arr, info, 7);
+  }
 }


### PR DESCRIPTION
This allows using Struct in a dynamically typed environment by passing additional information to the Struct serialization functions.

Fixes #5964.