### PR TITLE
[wpiutil] DataLog: Ensure file is written on shutdown

### DIFF
--- a/wpiutil/src/main/native/cpp/DataLog.cpp
+++ b/wpiutil/src/main/native/cpp/DataLog.cpp
@@ -179,7 +179,7 @@ DataLog::DataLog(wpi::Logger& msglog,
 DataLog::~DataLog() {
   {
     std::scoped_lock lock{m_mutex};
-    m_state = kShutdown;
+    m_shutdown = true;
     m_doFlush = true;
   }
   m_cond.notify_all();
@@ -419,7 +419,7 @@ void DataLog::WriterThreadMain(std::string_view dir) {
   uintmax_t written = 0;
 
   std::unique_lock lock{m_mutex};
-  while (m_state != kShutdown) {
+  do {
     bool doFlush = false;
     auto timeoutTime = std::chrono::steady_clock::now() + periodTime;
     if (m_cond.wait_until(lock, timeoutTime) == std::cv_status::timeout) {
@@ -557,7 +557,7 @@ void DataLog::WriterThreadMain(std::string_view dir) {
       }
       toWrite.resize(0);
     }
-  }
+  } while (!m_shutdown);
 }
 
 void DataLog::WriterThreadMain(
@@ -580,7 +580,7 @@ void DataLog::WriterThreadMain(
   std::vector<Buffer> toWrite;
 
   std::unique_lock lock{m_mutex};
-  while (m_state != kShutdown) {
+  do {
     bool doFlush = false;
     auto timeoutTime = std::chrono::steady_clock::now() + periodTime;
     if (m_cond.wait_until(lock, timeoutTime) == std::cv_status::timeout) {
@@ -614,7 +614,7 @@ void DataLog::WriterThreadMain(
       }
       toWrite.resize(0);
     }
-  }
+  } while (!m_shutdown);
 
   write({});  // indicate EOF
 }

--- a/wpiutil/src/main/native/cpp/DataLog.cpp
+++ b/wpiutil/src/main/native/cpp/DataLog.cpp
@@ -743,8 +743,10 @@ void DataLog::AppendImpl(std::span<const uint8_t> data) {
     std::memcpy(buf, data.data(), kBlockSize);
     data = data.subspan(kBlockSize);
   }
-  uint8_t* buf = Reserve(data.size());
-  std::memcpy(buf, data.data(), data.size());
+  if (!data.empty()) {
+    uint8_t* buf = Reserve(data.size());
+    std::memcpy(buf, data.data(), data.size());
+  }
 }
 
 void DataLog::AppendStringImpl(std::string_view str) {

--- a/wpiutil/src/main/native/include/wpi/DataLog.h
+++ b/wpiutil/src/main/native/include/wpi/DataLog.h
@@ -486,12 +486,12 @@ class DataLog final {
   mutable wpi::mutex m_mutex;
   wpi::condition_variable m_cond;
   bool m_doFlush{false};
+  bool m_shutdown{false};
   enum State {
     kStart,
     kActive,
     kPaused,
     kStopped,
-    kShutdown,
   } m_state = kActive;
   double m_period;
   std::string m_extraHeader;

--- a/wpiutil/src/test/native/cpp/DataLogTest.cpp
+++ b/wpiutil/src/test/native/cpp/DataLogTest.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "wpi/DataLog.h"
+
+#include <gtest/gtest.h>
+
+TEST(DataLog, SimpleInt) {
+  std::vector<uint8_t> data;
+  {
+    wpi::log::DataLog log{
+        [&](auto out) { data.insert(data.end(), out.begin(), out.end()); }};
+    int entry = log.Start("test", "int64");
+    log.AppendInteger(entry, 1, 0);
+  }
+  ASSERT_EQ(data.size(), 66u);
+}

--- a/wpiutil/src/test/native/cpp/DataLogTest.cpp
+++ b/wpiutil/src/test/native/cpp/DataLogTest.cpp
@@ -2,11 +2,11 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-#include "wpi/DataLog.h"
-
 #include <gtest/gtest.h>
 
-TEST(DataLog, SimpleInt) {
+#include "wpi/DataLog.h"
+
+TEST(DataLogTest, SimpleInt) {
   std::vector<uint8_t> data;
   {
     wpi::log::DataLog log{


### PR DESCRIPTION
Previously the thread could end without the file being written.

Fixes #6085.