### PR TITLE
Fix usage reporting for static classes

### DIFF
--- a/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
@@ -34,8 +34,12 @@ ShuffleboardInstance::ShuffleboardInstance(nt::NetworkTableInstance ntInstance)
 
 ShuffleboardInstance::~ShuffleboardInstance() = default;
 
+static bool gReported = false;
+
 frc::ShuffleboardTab& ShuffleboardInstance::GetTab(std::string_view title) {
-  HAL_Report(HALUsageReporting::kResourceType_Shuffleboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   if (m_impl->tabs.find(title) == m_impl->tabs.end()) {
     m_impl->tabs.try_emplace(title,
                              std::make_unique<ShuffleboardTab>(*this, title));

--- a/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
@@ -6,7 +6,6 @@
 
 #include <hal/FRCUsageReporting.h>
 #include <networktables/NetworkTable.h>
-#include <networktables/NetworkTableEntry.h>
 #include <networktables/NetworkTableInstance.h>
 #include <wpi/SmallVector.h>
 #include <wpi/StringMap.h>

--- a/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
@@ -40,6 +40,7 @@ static bool gReported = false;
 frc::ShuffleboardTab& ShuffleboardInstance::GetTab(std::string_view title) {
   if (!gReported) {
     HAL_Report(HALUsageReporting::kResourceType_Shuffleboard, 0);
+    gReported = true;
   }
   if (m_impl->tabs.find(title) == m_impl->tabs.end()) {
     m_impl->tabs.try_emplace(title,

--- a/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
@@ -30,12 +30,12 @@ ShuffleboardInstance::ShuffleboardInstance(nt::NetworkTableInstance ntInstance)
   m_impl->selectedTabPub =
       m_impl->rootMetaTable->GetStringTopic("Selected")
           .Publish(nt::PubSubOptions{.keepDuplicates = true});
-  HAL_Report(HALUsageReporting::kResourceType_Shuffleboard, 0);
 }
 
 ShuffleboardInstance::~ShuffleboardInstance() = default;
 
 frc::ShuffleboardTab& ShuffleboardInstance::GetTab(std::string_view title) {
+  HAL_Report(HALUsageReporting::kResourceType_Shuffleboard, 0);
   if (m_impl->tabs.find(title) == m_impl->tabs.end()) {
     m_impl->tabs.try_emplace(title,
                              std::make_unique<ShuffleboardTab>(*this, title));

--- a/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
@@ -6,6 +6,7 @@
 
 #include <hal/FRCUsageReporting.h>
 #include <networktables/NetworkTable.h>
+#include <networktables/NetworkTableEntry.h>
 #include <networktables/NetworkTableInstance.h>
 #include <wpi/SmallVector.h>
 #include <wpi/StringMap.h>

--- a/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
+++ b/wpilibc/src/main/native/cpp/shuffleboard/ShuffleboardInstance.cpp
@@ -38,7 +38,7 @@ static bool gReported = false;
 
 frc::ShuffleboardTab& ShuffleboardInstance::GetTab(std::string_view title) {
   if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+    HAL_Report(HALUsageReporting::kResourceType_Shuffleboard, 0);
   }
   if (m_impl->tabs.find(title) == m_impl->tabs.end()) {
     m_impl->tabs.try_emplace(title,

--- a/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
@@ -74,7 +74,7 @@ nt::NetworkTableEntry SmartDashboard::GetEntry(std::string_view key) {
   if (!gReported) {
     HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   }
-  return GetEntry(key);
+  return GetInstance().table->GetEntry(key);
 }
 
 void SmartDashboard::PutData(std::string_view key, wpi::Sendable* data) {

--- a/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
@@ -46,6 +46,8 @@ void ResetSmartDashboardInstance() {
 }  // namespace frc::impl
 #endif
 
+static bool gReported = false;
+
 void SmartDashboard::init() {
   GetInstance();
 }
@@ -78,7 +80,9 @@ void SmartDashboard::PutData(std::string_view key, wpi::Sendable* data) {
   if (!data) {
     throw FRC_MakeError(err::NullParameter, "value");
   }
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   auto& inst = GetInstance();
   std::scoped_lock lock(inst.tablesToDataMutex);
   auto& uid = inst.tablesToData[key];
@@ -116,13 +120,20 @@ wpi::Sendable* SmartDashboard::GetData(std::string_view key) {
 }
 
 bool SmartDashboard::PutBoolean(std::string_view keyName, bool value) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(keyName).SetBoolean(value);
 }
 
 bool SmartDashboard::SetDefaultBoolean(std::string_view key,
                                        bool defaultValue) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(key).SetDefaultBoolean(defaultValue);
 }
 
@@ -131,13 +142,17 @@ bool SmartDashboard::GetBoolean(std::string_view keyName, bool defaultValue) {
 }
 
 bool SmartDashboard::PutNumber(std::string_view keyName, double value) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(keyName).SetDouble(value);
 }
 
 bool SmartDashboard::SetDefaultNumber(std::string_view key,
                                       double defaultValue) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(key).SetDefaultDouble(defaultValue);
 }
 
@@ -148,13 +163,17 @@ double SmartDashboard::GetNumber(std::string_view keyName,
 
 bool SmartDashboard::PutString(std::string_view keyName,
                                std::string_view value) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(keyName).SetString(value);
 }
 
 bool SmartDashboard::SetDefaultString(std::string_view key,
                                       std::string_view defaultValue) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(key).SetDefaultString(defaultValue);
 }
 
@@ -165,13 +184,17 @@ std::string SmartDashboard::GetString(std::string_view keyName,
 
 bool SmartDashboard::PutBooleanArray(std::string_view key,
                                      std::span<const int> value) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(key).SetBooleanArray(value);
 }
 
 bool SmartDashboard::SetDefaultBooleanArray(std::string_view key,
                                             std::span<const int> defaultValue) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(key).SetDefaultBooleanArray(
       defaultValue);
 }
@@ -183,13 +206,17 @@ std::vector<int> SmartDashboard::GetBooleanArray(
 
 bool SmartDashboard::PutNumberArray(std::string_view key,
                                     std::span<const double> value) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(key).SetDoubleArray(value);
 }
 
 bool SmartDashboard::SetDefaultNumberArray(
     std::string_view key, std::span<const double> defaultValue) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(key).SetDefaultDoubleArray(defaultValue);
 }
 
@@ -200,13 +227,17 @@ std::vector<double> SmartDashboard::GetNumberArray(
 
 bool SmartDashboard::PutStringArray(std::string_view key,
                                     std::span<const std::string> value) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(key).SetStringArray(value);
 }
 
 bool SmartDashboard::SetDefaultStringArray(
     std::string_view key, std::span<const std::string> defaultValue) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(key).SetDefaultStringArray(defaultValue);
 }
 
@@ -217,13 +248,17 @@ std::vector<std::string> SmartDashboard::GetStringArray(
 
 bool SmartDashboard::PutRaw(std::string_view key,
                             std::span<const uint8_t> value) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(key).SetRaw(value);
 }
 
 bool SmartDashboard::SetDefaultRaw(std::string_view key,
                                    std::span<const uint8_t> defaultValue) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(key).SetDefaultRaw(defaultValue);
 }
 
@@ -234,13 +269,17 @@ std::vector<uint8_t> SmartDashboard::GetRaw(
 
 bool SmartDashboard::PutValue(std::string_view keyName,
                               const nt::Value& value) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(keyName).SetValue(value);
 }
 
 bool SmartDashboard::SetDefaultValue(std::string_view key,
                                      const nt::Value& defaultValue) {
-  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetInstance().table->GetEntry(key).SetDefaultValue(defaultValue);
 }
 

--- a/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
@@ -19,8 +19,6 @@ using namespace frc;
 
 namespace {
 struct Instance {
-  Instance() {}
-
   detail::ListenerExecutor listenerExecutor;
   std::shared_ptr<nt::NetworkTable> table =
       nt::NetworkTableInstance::GetDefault().GetTable("SmartDashboard");
@@ -52,6 +50,14 @@ void SmartDashboard::init() {
   GetInstance();
 }
 
+
+nt::NetworkTableEntry GetEntry(std::string_view name) {
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
+  return GetInstance().table->GetEntry(key);
+}
+
 bool SmartDashboard::ContainsKey(std::string_view key) {
   return GetInstance().table->ContainsKey(key);
 }
@@ -61,19 +67,19 @@ std::vector<std::string> SmartDashboard::GetKeys(int types) {
 }
 
 void SmartDashboard::SetPersistent(std::string_view key) {
-  GetInstance().table->GetEntry(key).SetPersistent();
+  GetEntry(key).SetPersistent();
 }
 
 void SmartDashboard::ClearPersistent(std::string_view key) {
-  GetInstance().table->GetEntry(key).ClearPersistent();
+  GetEntry(key).ClearPersistent();
 }
 
 bool SmartDashboard::IsPersistent(std::string_view key) {
-  return GetInstance().table->GetEntry(key).IsPersistent();
+  return GetEntry(key).IsPersistent();
 }
 
 nt::NetworkTableEntry SmartDashboard::GetEntry(std::string_view key) {
-  return GetInstance().table->GetEntry(key);
+  return GetEntry(key);
 }
 
 void SmartDashboard::PutData(std::string_view key, wpi::Sendable* data) {
@@ -120,21 +126,12 @@ wpi::Sendable* SmartDashboard::GetData(std::string_view key) {
 }
 
 bool SmartDashboard::PutBoolean(std::string_view keyName, bool value) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
   return GetInstance().table->GetEntry(keyName).SetBoolean(value);
 }
 
 bool SmartDashboard::SetDefaultBoolean(std::string_view key,
                                        bool defaultValue) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  return GetInstance().table->GetEntry(key).SetDefaultBoolean(defaultValue);
+  return GetEntry(key).SetDefaultBoolean(defaultValue);
 }
 
 bool SmartDashboard::GetBoolean(std::string_view keyName, bool defaultValue) {
@@ -142,18 +139,12 @@ bool SmartDashboard::GetBoolean(std::string_view keyName, bool defaultValue) {
 }
 
 bool SmartDashboard::PutNumber(std::string_view keyName, double value) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
   return GetInstance().table->GetEntry(keyName).SetDouble(value);
 }
 
 bool SmartDashboard::SetDefaultNumber(std::string_view key,
                                       double defaultValue) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  return GetInstance().table->GetEntry(key).SetDefaultDouble(defaultValue);
+  return GetEntry(key).SetDefaultDouble(defaultValue);
 }
 
 double SmartDashboard::GetNumber(std::string_view keyName,
@@ -163,18 +154,12 @@ double SmartDashboard::GetNumber(std::string_view keyName,
 
 bool SmartDashboard::PutString(std::string_view keyName,
                                std::string_view value) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
   return GetInstance().table->GetEntry(keyName).SetString(value);
 }
 
 bool SmartDashboard::SetDefaultString(std::string_view key,
                                       std::string_view defaultValue) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  return GetInstance().table->GetEntry(key).SetDefaultString(defaultValue);
+  return GetEntry(key).SetDefaultString(defaultValue);
 }
 
 std::string SmartDashboard::GetString(std::string_view keyName,
@@ -184,103 +169,73 @@ std::string SmartDashboard::GetString(std::string_view keyName,
 
 bool SmartDashboard::PutBooleanArray(std::string_view key,
                                      std::span<const int> value) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  return GetInstance().table->GetEntry(key).SetBooleanArray(value);
+  return GetEntry(key).SetBooleanArray(value);
 }
 
 bool SmartDashboard::SetDefaultBooleanArray(std::string_view key,
                                             std::span<const int> defaultValue) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  return GetInstance().table->GetEntry(key).SetDefaultBooleanArray(
+  return GetEntry(key).SetDefaultBooleanArray(
       defaultValue);
 }
 
 std::vector<int> SmartDashboard::GetBooleanArray(
     std::string_view key, std::span<const int> defaultValue) {
-  return GetInstance().table->GetEntry(key).GetBooleanArray(defaultValue);
+  return GetEntry(key).GetBooleanArray(defaultValue);
 }
 
 bool SmartDashboard::PutNumberArray(std::string_view key,
                                     std::span<const double> value) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  return GetInstance().table->GetEntry(key).SetDoubleArray(value);
+  return GetEntry(key).SetDoubleArray(value);
 }
 
 bool SmartDashboard::SetDefaultNumberArray(
     std::string_view key, std::span<const double> defaultValue) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  return GetInstance().table->GetEntry(key).SetDefaultDoubleArray(defaultValue);
+  return GetEntry(key).SetDefaultDoubleArray(defaultValue);
 }
 
 std::vector<double> SmartDashboard::GetNumberArray(
     std::string_view key, std::span<const double> defaultValue) {
-  return GetInstance().table->GetEntry(key).GetDoubleArray(defaultValue);
+  return GetEntry(key).GetDoubleArray(defaultValue);
 }
 
 bool SmartDashboard::PutStringArray(std::string_view key,
                                     std::span<const std::string> value) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  return GetInstance().table->GetEntry(key).SetStringArray(value);
+  return GetEntry(key).SetStringArray(value);
 }
 
 bool SmartDashboard::SetDefaultStringArray(
     std::string_view key, std::span<const std::string> defaultValue) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  return GetInstance().table->GetEntry(key).SetDefaultStringArray(defaultValue);
+  return GetEntry(key).SetDefaultStringArray(defaultValue);
 }
 
 std::vector<std::string> SmartDashboard::GetStringArray(
     std::string_view key, std::span<const std::string> defaultValue) {
-  return GetInstance().table->GetEntry(key).GetStringArray(defaultValue);
+  return GetEntry(key).GetStringArray(defaultValue);
 }
 
 bool SmartDashboard::PutRaw(std::string_view key,
                             std::span<const uint8_t> value) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  return GetInstance().table->GetEntry(key).SetRaw(value);
+  return GetEntry(key).SetRaw(value);
 }
 
 bool SmartDashboard::SetDefaultRaw(std::string_view key,
                                    std::span<const uint8_t> defaultValue) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  return GetInstance().table->GetEntry(key).SetDefaultRaw(defaultValue);
+  return GetEntry(key).SetDefaultRaw(defaultValue);
 }
 
 std::vector<uint8_t> SmartDashboard::GetRaw(
     std::string_view key, std::span<const uint8_t> defaultValue) {
-  return GetInstance().table->GetEntry(key).GetRaw(defaultValue);
+  return GetEntry(key).GetRaw(defaultValue);
 }
 
 bool SmartDashboard::PutValue(std::string_view keyName,
                               const nt::Value& value) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
   return GetInstance().table->GetEntry(keyName).SetValue(value);
 }
 
 bool SmartDashboard::SetDefaultValue(std::string_view key,
                                      const nt::Value& defaultValue) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  return GetInstance().table->GetEntry(key).SetDefaultValue(defaultValue);
+  return GetEntry(key).SetDefaultValue(defaultValue);
 }
 
 nt::Value SmartDashboard::GetValue(std::string_view keyName) {

--- a/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
@@ -50,7 +50,7 @@ void SmartDashboard::init() {
   GetInstance();
 }
 
-nt::NetworkTableEntry GetEntry(std::string_view name) {
+nt::NetworkTableEntry GetEntry(std::string_view key) {
   if (!gReported) {
     HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   }

--- a/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
@@ -73,6 +73,7 @@ bool SmartDashboard::IsPersistent(std::string_view key) {
 nt::NetworkTableEntry SmartDashboard::GetEntry(std::string_view key) {
   if (!gReported) {
     HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+    gReported = true;
   }
   return GetInstance().table->GetEntry(key);
 }
@@ -83,6 +84,7 @@ void SmartDashboard::PutData(std::string_view key, wpi::Sendable* data) {
   }
   if (!gReported) {
     HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+    gReported = true;
   }
   auto& inst = GetInstance();
   std::scoped_lock lock(inst.tablesToDataMutex);

--- a/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
@@ -50,7 +50,6 @@ void SmartDashboard::init() {
   GetInstance();
 }
 
-
 nt::NetworkTableEntry GetEntry(std::string_view name) {
   if (!gReported) {
     HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
@@ -174,8 +173,7 @@ bool SmartDashboard::PutBooleanArray(std::string_view key,
 
 bool SmartDashboard::SetDefaultBooleanArray(std::string_view key,
                                             std::span<const int> defaultValue) {
-  return GetEntry(key).SetDefaultBooleanArray(
-      defaultValue);
+  return GetEntry(key).SetDefaultBooleanArray(defaultValue);
 }
 
 std::vector<int> SmartDashboard::GetBooleanArray(

--- a/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
@@ -50,13 +50,6 @@ void SmartDashboard::init() {
   GetInstance();
 }
 
-nt::NetworkTableEntry GetEntry(std::string_view key) {
-  if (!gReported) {
-    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
-  }
-  return GetInstance().table->GetEntry(key);
-}
-
 bool SmartDashboard::ContainsKey(std::string_view key) {
   return GetInstance().table->ContainsKey(key);
 }
@@ -78,6 +71,9 @@ bool SmartDashboard::IsPersistent(std::string_view key) {
 }
 
 nt::NetworkTableEntry SmartDashboard::GetEntry(std::string_view key) {
+  if (!gReported) {
+    HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
+  }
   return GetEntry(key);
 }
 

--- a/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
+++ b/wpilibc/src/main/native/cpp/smartdashboard/SmartDashboard.cpp
@@ -19,7 +19,7 @@ using namespace frc;
 
 namespace {
 struct Instance {
-  Instance() { HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0); }
+  Instance() {}
 
   detail::ListenerExecutor listenerExecutor;
   std::shared_ptr<nt::NetworkTable> table =
@@ -78,6 +78,7 @@ void SmartDashboard::PutData(std::string_view key, wpi::Sendable* data) {
   if (!data) {
     throw FRC_MakeError(err::NullParameter, "value");
   }
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   auto& inst = GetInstance();
   std::scoped_lock lock(inst.tablesToDataMutex);
   auto& uid = inst.tablesToData[key];
@@ -115,11 +116,13 @@ wpi::Sendable* SmartDashboard::GetData(std::string_view key) {
 }
 
 bool SmartDashboard::PutBoolean(std::string_view keyName, bool value) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(keyName).SetBoolean(value);
 }
 
 bool SmartDashboard::SetDefaultBoolean(std::string_view key,
                                        bool defaultValue) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(key).SetDefaultBoolean(defaultValue);
 }
 
@@ -128,11 +131,13 @@ bool SmartDashboard::GetBoolean(std::string_view keyName, bool defaultValue) {
 }
 
 bool SmartDashboard::PutNumber(std::string_view keyName, double value) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(keyName).SetDouble(value);
 }
 
 bool SmartDashboard::SetDefaultNumber(std::string_view key,
                                       double defaultValue) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(key).SetDefaultDouble(defaultValue);
 }
 
@@ -143,11 +148,13 @@ double SmartDashboard::GetNumber(std::string_view keyName,
 
 bool SmartDashboard::PutString(std::string_view keyName,
                                std::string_view value) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(keyName).SetString(value);
 }
 
 bool SmartDashboard::SetDefaultString(std::string_view key,
                                       std::string_view defaultValue) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(key).SetDefaultString(defaultValue);
 }
 
@@ -158,11 +165,13 @@ std::string SmartDashboard::GetString(std::string_view keyName,
 
 bool SmartDashboard::PutBooleanArray(std::string_view key,
                                      std::span<const int> value) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(key).SetBooleanArray(value);
 }
 
 bool SmartDashboard::SetDefaultBooleanArray(std::string_view key,
                                             std::span<const int> defaultValue) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(key).SetDefaultBooleanArray(
       defaultValue);
 }
@@ -174,11 +183,13 @@ std::vector<int> SmartDashboard::GetBooleanArray(
 
 bool SmartDashboard::PutNumberArray(std::string_view key,
                                     std::span<const double> value) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(key).SetDoubleArray(value);
 }
 
 bool SmartDashboard::SetDefaultNumberArray(
     std::string_view key, std::span<const double> defaultValue) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(key).SetDefaultDoubleArray(defaultValue);
 }
 
@@ -189,11 +200,13 @@ std::vector<double> SmartDashboard::GetNumberArray(
 
 bool SmartDashboard::PutStringArray(std::string_view key,
                                     std::span<const std::string> value) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(key).SetStringArray(value);
 }
 
 bool SmartDashboard::SetDefaultStringArray(
     std::string_view key, std::span<const std::string> defaultValue) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(key).SetDefaultStringArray(defaultValue);
 }
 
@@ -204,11 +217,13 @@ std::vector<std::string> SmartDashboard::GetStringArray(
 
 bool SmartDashboard::PutRaw(std::string_view key,
                             std::span<const uint8_t> value) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(key).SetRaw(value);
 }
 
 bool SmartDashboard::SetDefaultRaw(std::string_view key,
                                    std::span<const uint8_t> defaultValue) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(key).SetDefaultRaw(defaultValue);
 }
 
@@ -219,11 +234,13 @@ std::vector<uint8_t> SmartDashboard::GetRaw(
 
 bool SmartDashboard::PutValue(std::string_view keyName,
                               const nt::Value& value) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(keyName).SetValue(value);
 }
 
 bool SmartDashboard::SetDefaultValue(std::string_view key,
                                      const nt::Value& defaultValue) {
+  HAL_Report(HALUsageReporting::kResourceType_SmartDashboard, 0);
   return GetInstance().table->GetEntry(key).SetDefaultValue(defaultValue);
 }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
@@ -18,7 +18,7 @@ import java.util.function.Consumer;
 
 final class ShuffleboardInstance implements ShuffleboardRoot {
   private final Map<String, ShuffleboardTab> m_tabs = new LinkedHashMap<>();
-
+  private boolean m_reported = false;
   private boolean m_tabsChanged = false; // NOPMD redundant field initializer
   private final NetworkTable m_rootTable;
   private final NetworkTable m_rootMetaTable;
@@ -40,7 +40,10 @@ final class ShuffleboardInstance implements ShuffleboardRoot {
   @Override
   public ShuffleboardTab getTab(String title) {
     requireNonNullParam(title, "title", "getTab");
-    HAL.report(tResourceType.kResourceType_Shuffleboard, 0);
+    if (!m_reported) {
+      HAL.report(tResourceType.kResourceType_Shuffleboard, 0);
+      m_reported = true;
+    }
     if (!m_tabs.containsKey(title)) {
       m_tabs.put(title, new ShuffleboardTab(this, title));
       m_tabsChanged = true;
@@ -89,8 +92,10 @@ final class ShuffleboardInstance implements ShuffleboardRoot {
    * @param func the function to apply to all complex widgets
    */
   private void applyToAllComplexWidgets(Consumer<ComplexWidget> func) {
-    HAL.report(tResourceType.kResourceType_Shuffleboard, 0);
-
+    if (!m_reported) {
+      HAL.report(tResourceType.kResourceType_Shuffleboard, 0);
+      m_reported = true;
+    }
     for (ShuffleboardTab tab : m_tabs.values()) {
       apply(tab, func);
     }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
@@ -92,10 +92,6 @@ final class ShuffleboardInstance implements ShuffleboardRoot {
    * @param func the function to apply to all complex widgets
    */
   private void applyToAllComplexWidgets(Consumer<ComplexWidget> func) {
-    if (!m_reported) {
-      HAL.report(tResourceType.kResourceType_Shuffleboard, 0);
-      m_reported = true;
-    }
     for (ShuffleboardTab tab : m_tabs.values()) {
       apply(tab, func);
     }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
@@ -18,7 +18,7 @@ import java.util.function.Consumer;
 
 final class ShuffleboardInstance implements ShuffleboardRoot {
   private final Map<String, ShuffleboardTab> m_tabs = new LinkedHashMap<>();
-  private boolean m_reported = false;
+  private boolean m_reported = false; // NOPMD redundant field initializer
   private boolean m_tabsChanged = false; // NOPMD redundant field initializer
   private final NetworkTable m_rootTable;
   private final NetworkTable m_rootMetaTable;

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/shuffleboard/ShuffleboardInstance.java
@@ -35,12 +35,12 @@ final class ShuffleboardInstance implements ShuffleboardRoot {
     m_rootMetaTable = m_rootTable.getSubTable(".metadata");
     m_selectedTabPub =
         m_rootMetaTable.getStringTopic("Selected").publish(PubSubOption.keepDuplicates(true));
-    HAL.report(tResourceType.kResourceType_Shuffleboard, 0);
   }
 
   @Override
   public ShuffleboardTab getTab(String title) {
     requireNonNullParam(title, "title", "getTab");
+    HAL.report(tResourceType.kResourceType_Shuffleboard, 0);
     if (!m_tabs.containsKey(title)) {
       m_tabs.put(title, new ShuffleboardTab(this, title));
       m_tabsChanged = true;
@@ -89,6 +89,8 @@ final class ShuffleboardInstance implements ShuffleboardRoot {
    * @param func the function to apply to all complex widgets
    */
   private void applyToAllComplexWidgets(Consumer<ComplexWidget> func) {
+    HAL.report(tResourceType.kResourceType_Shuffleboard, 0);
+
     for (ShuffleboardTab tab : m_tabs.values()) {
       apply(tab, func);
     }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
@@ -35,6 +35,7 @@ public final class SmartDashboard {
   /** The executor for listener tasks; calls listener tasks synchronously from main thread. */
   private static final ListenerExecutor listenerExecutor = new ListenerExecutor();
 
+  private static boolean m_reported = false;
   static {
     setNetworkTableInstance(NetworkTableInstance.getDefault());
   }
@@ -63,7 +64,9 @@ public final class SmartDashboard {
    */
   @SuppressWarnings("PMD.CompareObjectsWithEquals")
   public static synchronized void putData(String key, Sendable data) {
-    HAL.report(tResourceType.kResourceType_SmartDashboard, 0);
+    if (!m_reported) {
+      HAL.report(tResourceType.kResourceType_SmartDashboard, 0);
+    }
     Sendable sddata = tablesToData.get(key);
     if (sddata == null || sddata != data) {
       tablesToData.put(key, data);
@@ -114,7 +117,9 @@ public final class SmartDashboard {
    * @return Network table entry.
    */
   public static NetworkTableEntry getEntry(String key) {
-    HAL.report(tResourceType.kResourceType_SmartDashboard, 0);
+    if (!m_reported) {
+      HAL.report(tResourceType.kResourceType_SmartDashboard, 0);
+    }
     return table.getEntry(key);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
@@ -37,7 +37,6 @@ public final class SmartDashboard {
 
   static {
     setNetworkTableInstance(NetworkTableInstance.getDefault());
-    HAL.report(tResourceType.kResourceType_SmartDashboard, 0);
   }
 
   private SmartDashboard() {
@@ -64,6 +63,7 @@ public final class SmartDashboard {
    */
   @SuppressWarnings("PMD.CompareObjectsWithEquals")
   public static synchronized void putData(String key, Sendable data) {
+    HAL.report(tResourceType.kResourceType_SmartDashboard, 0);
     Sendable sddata = tablesToData.get(key);
     if (sddata == null || sddata != data) {
       tablesToData.put(key, data);
@@ -114,6 +114,7 @@ public final class SmartDashboard {
    * @return Network table entry.
    */
   public static NetworkTableEntry getEntry(String key) {
+    HAL.report(tResourceType.kResourceType_SmartDashboard, 0);
     return table.getEntry(key);
   }
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
@@ -67,6 +67,7 @@ public final class SmartDashboard {
   public static synchronized void putData(String key, Sendable data) {
     if (!m_reported) {
       HAL.report(tResourceType.kResourceType_SmartDashboard, 0);
+      m_reported = true;
     }
     Sendable sddata = tablesToData.get(key);
     if (sddata == null || sddata != data) {
@@ -120,6 +121,7 @@ public final class SmartDashboard {
   public static NetworkTableEntry getEntry(String key) {
     if (!m_reported) {
       HAL.report(tResourceType.kResourceType_SmartDashboard, 0);
+      m_reported = true;
     }
     return table.getEntry(key);
   }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/smartdashboard/SmartDashboard.java
@@ -35,7 +35,8 @@ public final class SmartDashboard {
   /** The executor for listener tasks; calls listener tasks synchronously from main thread. */
   private static final ListenerExecutor listenerExecutor = new ListenerExecutor();
 
-  private static boolean m_reported = false;
+  private static boolean m_reported = false; // NOPMD redundant field initializer
+
   static {
     setNetworkTableInstance(NetworkTableInstance.getDefault());
   }


### PR DESCRIPTION
Shuffleboard will report usage if `getTab` is called. SmartDashboard will report usage on any `put` or `set` calls, but not `get` calls, since you can't get something without putting something there in the first place.

Fixes #6066.