### PR TITLE
[cpp cmd] Deprecate TransferOwnership()

### DIFF
--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -432,6 +432,7 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
    * Transfers ownership of this command to a unique pointer.  Used for
    * decorator methods.
    */
+  [[deprecated("Use ToPtr() instead")]]
   virtual std::unique_ptr<Command> TransferOwnership() && = 0;
 
   std::optional<std::string> m_previousComposition;

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -428,12 +428,6 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
 
   wpi::SmallSet<Subsystem*, 4> m_requirements;
 
-  /**
-   * Transfers ownership of this command to a unique pointer.  Used for
-   * decorator methods.
-   */
-  virtual std::unique_ptr<Command> TransferOwnership() && = 0;
-
   std::optional<std::string> m_previousComposition;
 };
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Command.h
@@ -428,6 +428,12 @@ class Command : public wpi::Sendable, public wpi::SendableHelper<Command> {
 
   wpi::SmallSet<Subsystem*, 4> m_requirements;
 
+  /**
+   * Transfers ownership of this command to a unique pointer.  Used for
+   * decorator methods.
+   */
+  virtual std::unique_ptr<Command> TransferOwnership() && = 0;
+
   std::optional<std::string> m_previousComposition;
 };
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandHelper.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandHelper.h
@@ -34,7 +34,9 @@ class CommandHelper : public Base {
   }
 
  protected:
-  std::unique_ptr<Command> TransferOwnership() && override {
+  [[deprecated("Use ToPtr() instead")]]
+      std::unique_ptr<Command> TransferOwnership() &&
+      override {
     return std::make_unique<CRTP>(std::move(*static_cast<CRTP*>(this)));
   }
 };

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandHelper.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandHelper.h
@@ -8,6 +8,8 @@
 #include <memory>
 #include <utility>
 
+#include <wpi/deprecated.h>
+
 #include "frc2/command/Command.h"
 #include "frc2/command/CommandPtr.h"
 
@@ -34,9 +36,8 @@ class CommandHelper : public Base {
   }
 
  protected:
-  [[deprecated("Use ToPtr() instead")]]
-      std::unique_ptr<Command> TransferOwnership() &&
-      override {
+  WPI_DEPRECATED("Use ToPtr() instead")
+  std::unique_ptr<Command> TransferOwnership() && override {
     return std::make_unique<CRTP>(std::move(*static_cast<CRTP*>(this)));
   }
 };

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandHelper.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandHelper.h
@@ -32,10 +32,5 @@ class CommandHelper : public Base {
     return CommandPtr(
         std::make_unique<CRTP>(std::move(*static_cast<CRTP*>(this))));
   }
-
- protected:
-  std::unique_ptr<Command> TransferOwnership() && override {
-    return std::make_unique<CRTP>(std::move(*static_cast<CRTP*>(this)));
-  }
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/CommandHelper.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/CommandHelper.h
@@ -32,5 +32,10 @@ class CommandHelper : public Base {
     return CommandPtr(
         std::make_unique<CRTP>(std::move(*static_cast<CRTP*>(this))));
   }
+
+ protected:
+  std::unique_ptr<Command> TransferOwnership() && override {
+    return std::make_unique<CRTP>(std::move(*static_cast<CRTP*>(this)));
+  }
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SelectCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SelectCommand.h
@@ -133,11 +133,6 @@ class SelectCommand : public CommandHelper<Command, SelectCommand<Key>> {
         nullptr);
   }
 
- protected:
-  std::unique_ptr<Command> TransferOwnership() && override {
-    return std::make_unique<SelectCommand>(std::move(*this));
-  }
-
  private:
   std::unordered_map<Key, std::unique_ptr<Command>> m_commands;
   std::function<Key()> m_selector;

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SelectCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SelectCommand.h
@@ -134,7 +134,9 @@ class SelectCommand : public CommandHelper<Command, SelectCommand<Key>> {
   }
 
  protected:
-  std::unique_ptr<Command> TransferOwnership() && override {
+  [[deprecated("Use ToPtr() instead")]]
+      std::unique_ptr<Command> TransferOwnership() &&
+      override {
     return std::make_unique<SelectCommand>(std::move(*this));
   }
 

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SelectCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SelectCommand.h
@@ -133,6 +133,11 @@ class SelectCommand : public CommandHelper<Command, SelectCommand<Key>> {
         nullptr);
   }
 
+ protected:
+  std::unique_ptr<Command> TransferOwnership() && override {
+    return std::make_unique<SelectCommand>(std::move(*this));
+  }
+
  private:
   std::unordered_map<Key, std::unique_ptr<Command>> m_commands;
   std::function<Key()> m_selector;

--- a/wpilibNewCommands/src/main/native/include/frc2/command/SelectCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/SelectCommand.h
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include <wpi/deprecated.h>
 #include <wpi/sendable/SendableBuilder.h>
 
 #include "frc2/command/Command.h"
@@ -134,9 +135,8 @@ class SelectCommand : public CommandHelper<Command, SelectCommand<Key>> {
   }
 
  protected:
-  [[deprecated("Use ToPtr() instead")]]
-      std::unique_ptr<Command> TransferOwnership() &&
-      override {
+  WPI_DEPRECATED("Use ToPtr() instead")
+  std::unique_ptr<Command> TransferOwnership() && override {
     return std::make_unique<SelectCommand>(std::move(*this));
   }
 


### PR DESCRIPTION
It was completely replaced with `ToPtr()`.