### PR TITLE
Add method to detect if the CAN Stream has overflowed

### DIFF
--- a/hal/src/main/java/edu/wpi/first/hal/can/CANJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANJNI.java
@@ -31,5 +31,6 @@ public class CANJNI extends JNIWrapper {
   public static native void closeCANStreamSession(int sessionHandle);
 
   public static native int readCANStreamSession(
-      int sessionHandle, CANStreamMessage[] messages, int messagesToRead) throws CANStreamOverflowException;
+      int sessionHandle, CANStreamMessage[] messages, int messagesToRead)
+      throws CANStreamOverflowException;
 }

--- a/hal/src/main/java/edu/wpi/first/hal/can/CANJNI.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANJNI.java
@@ -31,5 +31,5 @@ public class CANJNI extends JNIWrapper {
   public static native void closeCANStreamSession(int sessionHandle);
 
   public static native int readCANStreamSession(
-      int sessionHandle, CANStreamMessage[] messages, int messagesToRead);
+      int sessionHandle, CANStreamMessage[] messages, int messagesToRead) throws CANStreamOverflowException;
 }

--- a/hal/src/main/java/edu/wpi/first/hal/can/CANStreamOverflowException.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANStreamOverflowException.java
@@ -17,12 +17,14 @@ public class CANStreamOverflowException extends IOException {
    * @param messages The messages
    * @param messagesRead The length of messages read
    */
+  @SuppressWarnings("PMD.ArrayIsStoredDirectly")
   public CANStreamOverflowException(CANStreamMessage[] messages, int messagesRead) {
     super("A CAN Stream has overflowed. Data will be missed");
     this.m_messages = messages;
     this.m_messagesRead = messagesRead;
   }
 
+  @SuppressWarnings("PMD.MethodReturnsInternalArray")
   public CANStreamMessage[] getMessages() {
     return m_messages;
   }

--- a/hal/src/main/java/edu/wpi/first/hal/can/CANStreamOverflowException.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANStreamOverflowException.java
@@ -8,20 +8,26 @@ import edu.wpi.first.hal.CANStreamMessage;
 import java.io.IOException;
 
 public class CANStreamOverflowException extends IOException {
-  private final CANStreamMessage[] messages;
-  private final int length;
+  private final CANStreamMessage[] m_messages;
+  private final int m_messagesRead;
 
-  public CANStreamOverflowException(CANStreamMessage[] messages, int length) {
+  /**
+   * Constructs a new CANStreamOverflowException.
+   * 
+   * @param messages The messages
+   * @param messagesRead The length of messages read
+   */
+  public CANStreamOverflowException(CANStreamMessage[] messages, int messagesRead) {
     super("A CAN Stream has overflowed. Data will be missed");
-    this.messages = messages;
-    this.length = length;
+    this.m_messages = messages;
+    this.m_messagesRead = messagesRead;
   }
 
   public CANStreamMessage[] getMessages() {
-    return messages;
+    return m_messages;
   }
 
-  public int getLength() {
-    return length;
+  public int getMessagesRead() {
+    return m_messagesRead;
   }
 }

--- a/hal/src/main/java/edu/wpi/first/hal/can/CANStreamOverflowException.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANStreamOverflowException.java
@@ -1,8 +1,11 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package edu.wpi.first.hal.can;
 
-import java.io.IOException;
-
 import edu.wpi.first.hal.CANStreamMessage;
+import java.io.IOException;
 
 public class CANStreamOverflowException extends IOException {
   private final CANStreamMessage[] messages;

--- a/hal/src/main/java/edu/wpi/first/hal/can/CANStreamOverflowException.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANStreamOverflowException.java
@@ -1,0 +1,24 @@
+package edu.wpi.first.hal.can;
+
+import java.io.IOException;
+
+import edu.wpi.first.hal.CANStreamMessage;
+
+public class CANStreamOverflowException extends IOException {
+  private final CANStreamMessage[] messages;
+  private final int length;
+
+  public CANStreamOverflowException(CANStreamMessage[] messages, int length) {
+    super("A CAN Stream has overflowed. Data will be missed");
+    this.messages = messages;
+    this.length = length;
+  }
+
+  public CANStreamMessage[] getMessages() {
+    return messages;
+  }
+
+  public int getLength() {
+    return length;
+  }
+}

--- a/hal/src/main/java/edu/wpi/first/hal/can/CANStreamOverflowException.java
+++ b/hal/src/main/java/edu/wpi/first/hal/can/CANStreamOverflowException.java
@@ -13,7 +13,7 @@ public class CANStreamOverflowException extends IOException {
 
   /**
    * Constructs a new CANStreamOverflowException.
-   * 
+   *
    * @param messages The messages
    * @param messagesRead The length of messages read
    */

--- a/hal/src/main/native/cpp/jni/CANJNI.cpp
+++ b/hal/src/main/native/cpp/jni/CANJNI.cpp
@@ -151,7 +151,7 @@ Java_edu_wpi_first_hal_can_CANJNI_readCANStreamSession
     return 0;
   }
 
-  if (!CheckStatus(env, status)) {
+  if (status != HAL_ERR_CANSessionMux_SessionOverrun && !CheckStatus(env, status)) {
     return 0;
   }
 
@@ -172,6 +172,11 @@ Java_edu_wpi_first_hal_can_CANJNI_readCANStreamSession
     }
     env->SetByteArrayRegion(toSetArray, 0, msg->dataSize,
                             reinterpret_cast<jbyte*>(msg->data));
+  }
+
+  if (status == HAL_ERR_CANSessionMux_SessionOverrun) {
+    ThrowCANStreamOverflowException(env, messages, static_cast<jint>(messagesRead));
+    return 0;
   }
 
   return static_cast<jint>(messagesRead);

--- a/hal/src/main/native/cpp/jni/CANJNI.cpp
+++ b/hal/src/main/native/cpp/jni/CANJNI.cpp
@@ -151,7 +151,8 @@ Java_edu_wpi_first_hal_can_CANJNI_readCANStreamSession
     return 0;
   }
 
-  if (status != HAL_ERR_CANSessionMux_SessionOverrun && !CheckStatus(env, status)) {
+  if (status != HAL_ERR_CANSessionMux_SessionOverrun &&
+      !CheckStatus(env, status)) {
     return 0;
   }
 
@@ -175,7 +176,8 @@ Java_edu_wpi_first_hal_can_CANJNI_readCANStreamSession
   }
 
   if (status == HAL_ERR_CANSessionMux_SessionOverrun) {
-    ThrowCANStreamOverflowException(env, messages, static_cast<jint>(messagesRead));
+    ThrowCANStreamOverflowException(env, messages,
+                                    static_cast<jint>(messagesRead));
     return 0;
   }
 

--- a/hal/src/main/native/cpp/jni/HALUtil.cpp
+++ b/hal/src/main/native/cpp/jni/HALUtil.cpp
@@ -46,6 +46,7 @@ static JException canMessageNotFoundExCls;
 static JException canMessageNotAllowedExCls;
 static JException canNotInitializedExCls;
 static JException uncleanStatusExCls;
+static JException canStreamOverflowExCls;
 static JClass powerDistributionVersionCls;
 static JClass pwmConfigDataResultCls;
 static JClass canStatusCls;
@@ -82,7 +83,8 @@ static const JExceptionInit exceptions[] = {
      &canMessageNotAllowedExCls},
     {"edu/wpi/first/hal/can/CANNotInitializedException",
      &canNotInitializedExCls},
-    {"edu/wpi/first/hal/util/UncleanStatusException", &uncleanStatusExCls}};
+    {"edu/wpi/first/hal/util/UncleanStatusException", &uncleanStatusExCls},
+    {"edu/wpi/first/hal/can/CANStreamOverflowException", &canStreamOverflowExCls}};
 
 namespace hal {
 
@@ -207,6 +209,12 @@ void ReportCANError(JNIEnv* env, int32_t status, int message_id) {
       break;
     }
   }
+}
+
+void ThrowCANStreamOverflowException(JNIEnv* env, jobjectArray messages, jint length) {
+  static jmethodID constructor = env->GetMethodID(canStreamOverflowExCls, "<init>", "([Ledu/wpi/first/hal/CANStreamMessage;I)V");
+  jobject exception = env->NewObject(canStreamOverflowExCls, constructor, messages, length);
+  env->Throw(static_cast<jthrowable>(exception));
 }
 
 void ThrowIllegalArgumentException(JNIEnv* env, std::string_view msg) {

--- a/hal/src/main/native/cpp/jni/HALUtil.cpp
+++ b/hal/src/main/native/cpp/jni/HALUtil.cpp
@@ -84,7 +84,8 @@ static const JExceptionInit exceptions[] = {
     {"edu/wpi/first/hal/can/CANNotInitializedException",
      &canNotInitializedExCls},
     {"edu/wpi/first/hal/util/UncleanStatusException", &uncleanStatusExCls},
-    {"edu/wpi/first/hal/can/CANStreamOverflowException", &canStreamOverflowExCls}};
+    {"edu/wpi/first/hal/can/CANStreamOverflowException",
+     &canStreamOverflowExCls}};
 
 namespace hal {
 
@@ -211,9 +212,13 @@ void ReportCANError(JNIEnv* env, int32_t status, int message_id) {
   }
 }
 
-void ThrowCANStreamOverflowException(JNIEnv* env, jobjectArray messages, jint length) {
-  static jmethodID constructor = env->GetMethodID(canStreamOverflowExCls, "<init>", "([Ledu/wpi/first/hal/CANStreamMessage;I)V");
-  jobject exception = env->NewObject(canStreamOverflowExCls, constructor, messages, length);
+void ThrowCANStreamOverflowException(JNIEnv* env, jobjectArray messages,
+                                     jint length) {
+  static jmethodID constructor =
+      env->GetMethodID(canStreamOverflowExCls, "<init>",
+                       "([Ledu/wpi/first/hal/CANStreamMessage;I)V");
+  jobject exception =
+      env->NewObject(canStreamOverflowExCls, constructor, messages, length);
   env->Throw(static_cast<jthrowable>(exception));
 }
 

--- a/hal/src/main/native/cpp/jni/HALUtil.cpp
+++ b/hal/src/main/native/cpp/jni/HALUtil.cpp
@@ -46,7 +46,6 @@ static JException canMessageNotFoundExCls;
 static JException canMessageNotAllowedExCls;
 static JException canNotInitializedExCls;
 static JException uncleanStatusExCls;
-static JException canStreamOverflowExCls;
 static JClass powerDistributionVersionCls;
 static JClass pwmConfigDataResultCls;
 static JClass canStatusCls;
@@ -57,6 +56,7 @@ static JClass canStreamMessageCls;
 static JClass halValueCls;
 static JClass baseStoreCls;
 static JClass revPHVersionCls;
+static JClass canStreamOverflowExCls;
 
 static const JClassInit classes[] = {
     {"edu/wpi/first/hal/PowerDistributionVersion",
@@ -69,7 +69,9 @@ static const JClassInit classes[] = {
     {"edu/wpi/first/hal/CANStreamMessage", &canStreamMessageCls},
     {"edu/wpi/first/hal/HALValue", &halValueCls},
     {"edu/wpi/first/hal/DMAJNISample$BaseStore", &baseStoreCls},
-    {"edu/wpi/first/hal/REVPHVersion", &revPHVersionCls}};
+    {"edu/wpi/first/hal/REVPHVersion", &revPHVersionCls},
+    {"edu/wpi/first/hal/can/CANStreamOverflowException",
+     &canStreamOverflowExCls}};
 
 static const JExceptionInit exceptions[] = {
     {"java/lang/IllegalArgumentException", &illegalArgExCls},
@@ -83,9 +85,7 @@ static const JExceptionInit exceptions[] = {
      &canMessageNotAllowedExCls},
     {"edu/wpi/first/hal/can/CANNotInitializedException",
      &canNotInitializedExCls},
-    {"edu/wpi/first/hal/util/UncleanStatusException", &uncleanStatusExCls},
-    {"edu/wpi/first/hal/can/CANStreamOverflowException",
-     &canStreamOverflowExCls}};
+    {"edu/wpi/first/hal/util/UncleanStatusException", &uncleanStatusExCls}};
 
 namespace hal {
 

--- a/hal/src/main/native/cpp/jni/HALUtil.h
+++ b/hal/src/main/native/cpp/jni/HALUtil.h
@@ -51,6 +51,7 @@ inline bool CheckCANStatus(JNIEnv* env, int32_t status, int32_t message_id) {
   return status == 0;
 }
 
+void ThrowCANStreamOverflowException(JNIEnv* env, jobjectArray messages, jint length);
 void ThrowIllegalArgumentException(JNIEnv* env, std::string_view msg);
 void ThrowBoundaryException(JNIEnv* env, double value, double lower,
                             double upper);

--- a/hal/src/main/native/cpp/jni/HALUtil.h
+++ b/hal/src/main/native/cpp/jni/HALUtil.h
@@ -51,7 +51,8 @@ inline bool CheckCANStatus(JNIEnv* env, int32_t status, int32_t message_id) {
   return status == 0;
 }
 
-void ThrowCANStreamOverflowException(JNIEnv* env, jobjectArray messages, jint length);
+void ThrowCANStreamOverflowException(JNIEnv* env, jobjectArray messages,
+                                     jint length);
 void ThrowIllegalArgumentException(JNIEnv* env, std::string_view msg);
 void ThrowBoundaryException(JNIEnv* env, double value, double lower,
                             double upper);


### PR DESCRIPTION
Currently a stream overflow will just throw an exception. We want the exception to contain the data that was read, as there is still valid data. Its just that some data was lost.