### PR TITLE
Allocate CANStreamMessage in JNI if null

### DIFF
--- a/hal/src/main/native/cpp/jni/CANJNI.cpp
+++ b/hal/src/main/native/cpp/jni/CANJNI.cpp
@@ -160,8 +160,15 @@ Java_edu_wpi_first_hal_can_CANJNI_readCANStreamSession
     JLocal<jobject> elem{
         env, static_cast<jstring>(env->GetObjectArrayElement(messages, i))};
     if (!elem) {
-      // TODO decide if should throw
-      continue;
+      // If element doesn't exist, construct it in place. If that fails, we are OOM,
+      // just return
+      elem = JLocal<jobject>{env, CreateCANStreamMessage(env)};
+      if (elem) {
+        printf("Allocated and set object\n");
+        env->SetObjectArrayElement(messages, i, elem);
+      } else {
+        return 0;
+      }
     }
     JLocal<jbyteArray> toSetArray{
         env, SetCANStreamObject(env, elem, msg->dataSize, msg->messageID,

--- a/hal/src/main/native/cpp/jni/CANJNI.cpp
+++ b/hal/src/main/native/cpp/jni/CANJNI.cpp
@@ -160,11 +160,11 @@ Java_edu_wpi_first_hal_can_CANJNI_readCANStreamSession
     JLocal<jobject> elem{
         env, static_cast<jstring>(env->GetObjectArrayElement(messages, i))};
     if (!elem) {
-      // If element doesn't exist, construct it in place. If that fails, we are OOM,
-      // just return
+      // If element doesn't exist, construct it in place. If that fails, we are
+      // OOM, just return
       elem = JLocal<jobject>{env, CreateCANStreamMessage(env)};
       if (elem) {
-        printf("Allocated and set object\n");
+        std::printf("Allocated and set object\n");
         env->SetObjectArrayElement(messages, i, elem);
       } else {
         return 0;

--- a/hal/src/main/native/cpp/jni/HALUtil.cpp
+++ b/hal/src/main/native/cpp/jni/HALUtil.cpp
@@ -365,6 +365,12 @@ jobject CreatePowerDistributionVersion(JNIEnv* env, uint32_t firmwareMajor,
       static_cast<jint>(hardwareMajor), static_cast<jint>(uniqueId));
 }
 
+jobject CreateCANStreamMessage(JNIEnv* env) {
+  static jmethodID constructor =
+      env->GetMethodID(canStreamMessageCls, "<init>", "()V");
+  return env->NewObject(canStreamMessageCls, constructor);
+}
+
 JavaVM* GetJVM() {
   return jvm;
 }

--- a/hal/src/main/native/cpp/jni/HALUtil.h
+++ b/hal/src/main/native/cpp/jni/HALUtil.h
@@ -93,6 +93,8 @@ jobject CreatePowerDistributionVersion(JNIEnv* env, uint32_t firmwareMajor,
                                        uint32_t hardwareMajor,
                                        uint32_t uniqueId);
 
+jobject CreateCANStreamMessage(JNIEnv* env);
+
 JavaVM* GetJVM();
 
 }  // namespace hal


### PR DESCRIPTION
Currently if you only initialize the array and not inner objects, those values will just be skipped over. Solve this by just allocating in place.