### PR TITLE
[wpimath] Compile with UTF-8 encoding

### DIFF
--- a/wpimath/CMakeLists.txt
+++ b/wpimath/CMakeLists.txt
@@ -161,7 +161,7 @@ target_compile_definitions(wpimath PRIVATE WPILIB_EXPORTS)
 
 target_compile_features(wpimath PUBLIC cxx_std_20)
 if(MSVC)
-    target_compile_options(wpimath PUBLIC /bigobj)
+    target_compile_options(wpimath PUBLIC /utf-8 /bigobj)
 endif()
 wpilib_target_warnings(wpimath)
 target_link_libraries(wpimath wpiutil)


### PR DESCRIPTION
This allows using Greek letters in variable names, which is helpful to make implemented equations follow their source paper more closely.