### PR TITLE
Fix generated source set location in the HAL

### DIFF
--- a/hal/build.gradle
+++ b/hal/build.gradle
@@ -50,7 +50,7 @@ ext {
 
 apply from: "${rootDir}/shared/jni/setupBuild.gradle"
 
-sourceSets.main.java.srcDir "src/generated/main/java/edu/wpi/first/hal/"
+sourceSets.main.java.srcDir "${projectDir}/src/generated/main/java"
 
 cppSourcesZip {
     from('src/main/native/athena') {


### PR DESCRIPTION
The existing one worked for build, but it had the base classpath wrong, so it didn't work for intellisense. Fixes it to match the othr generated classes.