### PR TITLE
Fix formatting of HAL_ENUM enums

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -145,6 +145,8 @@ LambdaBodyIndentation: Signature
 LineEnding:      DeriveLF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
+Macros:
+  - 'HAL_ENUM(name)=enum name'
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Never

--- a/hal/src/main/native/include/hal/Accelerometer.h
+++ b/hal/src/main/native/include/hal/Accelerometer.h
@@ -12,7 +12,6 @@
  * @{
  */
 
-// clang-format off
 /**
  * The acceptable accelerometer ranges.
  */
@@ -21,7 +20,6 @@ HAL_ENUM(HAL_AccelerometerRange) {
   HAL_AccelerometerRange_k4G = 1,
   HAL_AccelerometerRange_k8G = 2,
 };
-// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/hal/AnalogTrigger.h
+++ b/hal/src/main/native/include/hal/AnalogTrigger.h
@@ -14,7 +14,6 @@
  * @{
  */
 
-// clang-format off
 /**
  * The type of analog trigger to trigger on.
  */
@@ -24,7 +23,6 @@ HAL_ENUM(HAL_AnalogTriggerType) {
   HAL_Trigger_kRisingPulse = 2,
   HAL_Trigger_kFallingPulse = 3
 };
-// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/hal/CANAPITypes.h
+++ b/hal/src/main/native/include/hal/CANAPITypes.h
@@ -14,7 +14,6 @@
  * @{
  */
 
-// clang-format off
 /**
  * The CAN device type.
  *
@@ -60,5 +59,4 @@ HAL_ENUM(HAL_CANManufacturer) {
   HAL_CAN_Man_kAndyMark = 15,
   HAL_CAN_Man_kVividHosting = 16
 };
-// clang-format on
 /** @} */

--- a/hal/src/main/native/include/hal/Counter.h
+++ b/hal/src/main/native/include/hal/Counter.h
@@ -15,7 +15,6 @@
  * @{
  */
 
-// clang-format off
 /**
  * The counter mode.
  */
@@ -25,7 +24,6 @@ HAL_ENUM(HAL_Counter_Mode) {
   HAL_Counter_kPulseLength = 2,
   HAL_Counter_kExternalDirection = 3
 };
-// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/hal/DMA.h
+++ b/hal/src/main/native/include/hal/DMA.h
@@ -13,7 +13,6 @@
  * @{
  */
 
-// clang-format off
 /**
  * The DMA Read Status.
  */
@@ -22,7 +21,6 @@ HAL_ENUM(HAL_DMAReadStatus) {
   HAL_DMA_TIMEOUT = 2,
   HAL_DMA_ERROR = 3,
 };
-// clang-format on
 
 /**
  * Buffer for containing all DMA data for a specific sample.

--- a/hal/src/main/native/include/hal/DriverStationTypes.h
+++ b/hal/src/main/native/include/hal/DriverStationTypes.h
@@ -40,7 +40,6 @@ struct HAL_ControlWord {
 };
 typedef struct HAL_ControlWord HAL_ControlWord;
 
-// clang-format off
 HAL_ENUM(HAL_AllianceStationID) {
   HAL_AllianceStationID_kUnknown = 0,
   HAL_AllianceStationID_kRed1,
@@ -57,7 +56,6 @@ HAL_ENUM(HAL_MatchType) {
   HAL_kMatchType_qualification,
   HAL_kMatchType_elimination,
 };
-// clang-format on
 
 /* The maximum number of axes that will be stored in a single HALJoystickAxes
  * struct. This is used for allocating buffers, not bounds checking, since

--- a/hal/src/main/native/include/hal/Encoder.h
+++ b/hal/src/main/native/include/hal/Encoder.h
@@ -15,7 +15,6 @@
  * @{
  */
 
-// clang-format off
 /**
  * The type of index pulse for the encoder.
  */
@@ -34,7 +33,6 @@ HAL_ENUM(HAL_EncoderEncodingType) {
   HAL_Encoder_k2X,
   HAL_Encoder_k4X
 };
-// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/hal/HALBase.h
+++ b/hal/src/main/native/include/hal/HALBase.h
@@ -22,9 +22,11 @@
  * @{
  */
 
-// clang-format off
-HAL_ENUM(HAL_RuntimeType) { HAL_Runtime_RoboRIO, HAL_Runtime_RoboRIO2, HAL_Runtime_Simulation };
-// clang-format on
+HAL_ENUM(HAL_RuntimeType) {
+  HAL_Runtime_RoboRIO,
+  HAL_Runtime_RoboRIO2,
+  HAL_Runtime_Simulation
+};
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/hal/I2CTypes.h
+++ b/hal/src/main/native/include/hal/I2CTypes.h
@@ -14,9 +14,11 @@
  * @{
  */
 
-// clang-format off
-HAL_ENUM(HAL_I2CPort) { HAL_I2C_kInvalid = -1, HAL_I2C_kOnboard, HAL_I2C_kMXP };
-// clang-format on
+HAL_ENUM(HAL_I2CPort) {
+  HAL_I2C_kInvalid = -1,
+  HAL_I2C_kOnboard,
+  HAL_I2C_kMXP
+};
 
 #ifdef __cplusplus
 namespace hal {

--- a/hal/src/main/native/include/hal/LEDs.h
+++ b/hal/src/main/native/include/hal/LEDs.h
@@ -5,8 +5,12 @@
 #pragma once
 #include "hal/Types.h"
 
-HAL_ENUM(HAL_RadioLEDState){HAL_RadioLED_kOff = 0, HAL_RadioLED_kGreen = 1,
-                            HAL_RadioLED_kRed = 2, HAL_RadioLED_kOrange = 3};
+HAL_ENUM(HAL_RadioLEDState) {
+  HAL_RadioLED_kOff = 0,
+  HAL_RadioLED_kGreen = 1,
+  HAL_RadioLED_kRed = 2,
+  HAL_RadioLED_kOrange = 3
+};
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/hal/PowerDistribution.h
+++ b/hal/src/main/native/include/hal/PowerDistribution.h
@@ -15,7 +15,6 @@
  * @{
  */
 
-// clang-format off
 /**
  * The types of power distribution devices.
  */
@@ -24,7 +23,6 @@ HAL_ENUM(HAL_PowerDistributionType) {
   HAL_PowerDistributionType_kCTRE = 1,
   HAL_PowerDistributionType_kRev = 2,
 };
-// clang-format on
 
 #define HAL_DEFAULT_POWER_DISTRIBUTION_MODULE -1
 

--- a/hal/src/main/native/include/hal/REVPH.h
+++ b/hal/src/main/native/include/hal/REVPH.h
@@ -17,11 +17,11 @@
 /**
  * The compressor configuration type
  */
-HAL_ENUM(HAL_REVPHCompressorConfigType){
-    HAL_REVPHCompressorConfigType_kDisabled = 0,
-    HAL_REVPHCompressorConfigType_kDigital = 1,
-    HAL_REVPHCompressorConfigType_kAnalog = 2,
-    HAL_REVPHCompressorConfigType_kHybrid = 3,
+HAL_ENUM(HAL_REVPHCompressorConfigType) {
+  HAL_REVPHCompressorConfigType_kDisabled = 0,
+  HAL_REVPHCompressorConfigType_kDigital = 1,
+  HAL_REVPHCompressorConfigType_kAnalog = 2,
+  HAL_REVPHCompressorConfigType_kHybrid = 3,
 };
 
 /**

--- a/hal/src/main/native/include/hal/SPITypes.h
+++ b/hal/src/main/native/include/hal/SPITypes.h
@@ -14,7 +14,6 @@
  * @{
  */
 
-// clang-format off
 HAL_ENUM(HAL_SPIPort) {
   HAL_SPI_kInvalid = -1,
   HAL_SPI_kOnboardCS0,
@@ -23,16 +22,13 @@ HAL_ENUM(HAL_SPIPort) {
   HAL_SPI_kOnboardCS3,
   HAL_SPI_kMXP
 };
-// clang-format on
 
-// clang-format off
 HAL_ENUM(HAL_SPIMode) {
   HAL_SPI_kMode0 = 0,
   HAL_SPI_kMode1 = 1,
   HAL_SPI_kMode2 = 2,
   HAL_SPI_kMode3 = 3,
 };
-// clang-format on
 
 #ifdef __cplusplus
 namespace hal {

--- a/hal/src/main/native/include/hal/SerialPort.h
+++ b/hal/src/main/native/include/hal/SerialPort.h
@@ -14,14 +14,12 @@
  * @{
  */
 
-// clang-format off
 HAL_ENUM(HAL_SerialPort) {
   HAL_SerialPort_Onboard = 0,
   HAL_SerialPort_MXP = 1,
   HAL_SerialPort_USB1 = 2,
   HAL_SerialPort_USB2 = 3
 };
-// clang-format on
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/src/main/native/include/hal/SimDevice.h
+++ b/hal/src/main/native/include/hal/SimDevice.h
@@ -30,13 +30,11 @@
 /**
  * Direction of a simulated value (from the perspective of user code).
  */
-// clang-format off
 HAL_ENUM(HAL_SimValueDirection) {
-  HAL_SimValueInput = 0,  /**< input to user code from the simulator */
-  HAL_SimValueOutput,     /**< output from user code to the simulator */
-  HAL_SimValueBidir       /**< bidirectional between user code and simulator */
+  HAL_SimValueInput = 0, /**< input to user code from the simulator */
+  HAL_SimValueOutput,    /**< output from user code to the simulator */
+  HAL_SimValueBidir      /**< bidirectional between user code and simulator */
 };
-// clang-format on
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The [Macros](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#macros) option is new in clang-format 17.