### PR TITLE
Switch EventLoop to ArrayList

### DIFF
--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/event/EventLoop.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/event/EventLoop.java
@@ -4,14 +4,14 @@
 
 package edu.wpi.first.wpilibj.event;
 
-import java.util.Collection;
-import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A declarative way to bind a set of actions to a loop and execute them when the loop is polled.
  */
 public final class EventLoop {
-  private final Collection<Runnable> m_bindings = new LinkedHashSet<>();
+  private final List<Runnable> m_bindings = new ArrayList<>();
 
   /**
    * Bind a new action to run when the loop is polled.


### PR DESCRIPTION
LinkedHashSet has a lot of overhead for what this is expected to do. All we do is add items and iterate through them. Just use an ArrayList, it will be faster and allocate a lot less.