### PR TITLE
[glass] Add type information to SmartDashboard menu

### DIFF
--- a/glass/src/libnt/native/cpp/NetworkTablesProvider.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTablesProvider.cpp
@@ -83,6 +83,18 @@ void NetworkTablesProvider::DisplayMenu() {
       // FIXME: enabled?
       // data is the last item, so is guaranteed to be null-terminated
       ImGui::MenuItem(path.back().data(), nullptr, &visible, true);
+      // Add type label to smartdashboard sendables
+      if (wpi::starts_with(entry->name, "/SmartDashboard/")) {
+        auto typeEntry = m_typeCache.FindValue(entry->name);
+        if (typeEntry) {
+          ImGui::SameLine();
+          ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
+          ImGui::Text(typeEntry->stringVal.c_str());
+          ImGui::PopStyleColor();
+          ImGui::SameLine();
+          ImGui::Dummy(ImVec2(10.0f, 0.0f));
+        }
+      }
       if (!wasVisible && visible) {
         Show(entry.get(), entry->window);
       } else if (wasVisible && !visible && entry->window) {

--- a/glass/src/libnt/native/cpp/NetworkTablesProvider.cpp
+++ b/glass/src/libnt/native/cpp/NetworkTablesProvider.cpp
@@ -89,7 +89,7 @@ void NetworkTablesProvider::DisplayMenu() {
         if (typeEntry) {
           ImGui::SameLine();
           ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(96, 96, 96, 255));
-          ImGui::Text(typeEntry->stringVal.c_str());
+          ImGui::Text("%s", typeEntry->stringVal.c_str());
           ImGui::PopStyleColor();
           ImGui::SameLine();
           ImGui::Dummy(ImVec2(10.0f, 0.0f));


### PR DESCRIPTION
Currently glass does not display any other information within the Networktables->SmartDashboard menu other than the name of the sendable/widget.  This adds the sendable type (obtained from NT ``.type``) along side the widget name. 
![image](https://github.com/wpilibsuite/allwpilib/assets/13669738/38f0e120-c96a-4011-af16-20fcc488f721)
