### PR TITLE
[docs] Link to external OpenCV docs

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -208,20 +208,10 @@ configurations {
     }
 }
 
-ext {
-    sharedCvConfigs = [:]
-    staticCvConfigs = [:]
-    useJava = true
-    useCpp = false
-    skipDev = true
-    useDocumentation = true
-}
-
-apply from: "${rootDir}/shared/opencv.gradle"
-
 task generateJavaDocs(type: Javadoc) {
-    classpath += project(":wpimath").sourceSets.main.compileClasspath
+    classpath += project(":wpilibj").sourceSets.main.compileClasspath
     options.links("https://docs.oracle.com/en/java/javase/17/docs/api/")
+    options.links("https://docs.opencv.org/4.x/javadoc/")
     options.addStringOption("tag", "pre:a:Pre-Condition")
     options.addBooleanOption("Xdoclint:html,missing,reference,syntax", true)
     options.addBooleanOption('html5', true)


### PR DESCRIPTION
This avoids thousands of warnings from JavaDoc 17 parsing the OpenCV source.