### PR TITLE
[examples] Update april tag family to 36h11 in examples

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/AprilTagsVision/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/AprilTagsVision/cpp/Robot.cpp
@@ -37,13 +37,13 @@ class Robot : public frc::TimedRobot {
  private:
   static void VisionThread() {
     frc::AprilTagDetector detector;
-    // look for tag16h5, don't correct any error bits
-    detector.AddFamily("tag16h5", 0);
+    // look for tag36h11, correct 7 error bits
+    detector.AddFamily("tag36h11", 7);
 
     // Set up Pose Estimator - parameters are for a Microsoft Lifecam HD-3000
     // (https://www.chiefdelphi.com/t/wpilib-apriltagdetector-sample-code/421411/21)
     frc::AprilTagPoseEstimator::Config poseEstConfig = {
-        .tagSize = units::length::inch_t(6.0),
+        .tagSize = units::length::inch_t(6.5),
         .fx = 699.3778103158814,
         .fy = 677.7161226393544,
         .cx = 345.6059345433618,

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/apriltagsvision/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/apriltagsvision/Robot.java
@@ -39,14 +39,14 @@ public class Robot extends TimedRobot {
 
   void apriltagVisionThreadProc() {
     var detector = new AprilTagDetector();
-    // look for tag16h5, don't correct any error bits
-    detector.addFamily("tag16h5", 0);
+    // look for tag136h11, correct 7 error bits
+    detector.addFamily("tag36h11", 7);
 
     // Set up Pose Estimator - parameters are for a Microsoft Lifecam HD-3000
     // (https://www.chiefdelphi.com/t/wpilib-apriltagdetector-sample-code/421411/21)
     var poseEstConfig =
         new AprilTagPoseEstimator.Config(
-            0.1524, 699.3778103158814, 677.7161226393544, 345.6059345433618, 207.12741326228522);
+            0.1651, 699.3778103158814, 677.7161226393544, 345.6059345433618, 207.12741326228522);
     var estimator = new AprilTagPoseEstimator(poseEstConfig);
 
     // Get the UsbCamera from CameraServer


### PR DESCRIPTION
Changes size to 6.5 inches per https://www.firstinspires.org/robotics/frc/blog/2023-technology-updates-past-present-future-and-beyond 
Uses 7 error bit correction as recommended in photonvision docs 
Fixes #5763