### PR TITLE
Adds LinearFilter reset() overload to initialize input and output buffers

### DIFF
--- a/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
@@ -247,10 +247,9 @@ public class LinearFilter {
   }
 
   /**
-   * Resets the filter state, initializing internal buffers to the provided values. <br>
-   * <br>
+   * Resets the filter state, initializing internal buffers to the provided values.<br><br>
+   * 
    * These are the expected lengths of the buffers, depending on what type of linear filter used:
-   *
    * <table>
    * <tr><th>Type</th><th>Input Buffer Length</th><th>Output Buffer Length</th></tr>
    * <tr><td>Unspecified</td><td>length of {@code ffGains}</td><td>length of {@code fbGains}</td>

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
@@ -247,6 +247,42 @@ public class LinearFilter {
   }
 
   /**
+   * Resets the filter state, initializing internal buffers to the provided values. <br>
+   * <br>
+   * These are the expected lengths of the buffers, depending on what type of linear filter used:
+   *
+   * <table>
+   * <tr><th>Type</th><th>Input Buffer Length</th><th>Output Buffer Length</th></tr>
+   * <tr><td>Unspecified</td><td>length of {@code ffGains}</td><td>length of {@code fbGains}</td>
+   * </tr>
+   * <tr><td>Single Pole IIR</td><td>1</td><td>1</td></tr>
+   * <tr><td>High-Pass</td><td>2</td><td>1</td></tr>
+   * <tr><td>Moving Average</td><td>{@code taps}</td><td>0</td></tr>
+   * <tr><td>Finite Difference</td><td>length of {@code stencil}</td><td>0</td></tr>
+   * <tr><td>Backward Finite Difference</td><td>{@code samples}</td><td>0</td></tr>
+   * </table>
+   *
+   * @param inputBuffer Values to initialize input buffer.
+   * @param outputBuffer Values to initialize output buffer.
+   * @throws IllegalArgumentException if length of inputBuffer or outputBuffer does not match the
+   *     length of ffGains and fbGains provided in the constructor.
+   */
+  public void reset(double[] inputBuffer, double[] outputBuffer) {
+    reset(); // Clear buffers
+
+    if (inputBuffer.length != m_inputGains.length || outputBuffer.length != m_outputGains.length) {
+      throw new IllegalArgumentException("Incorrect length of inputBuffer or outputBuffer");
+    }
+
+    for (double input : inputBuffer) {
+      m_inputs.addFirst(input);
+    }
+    for (double output : outputBuffer) {
+      m_outputs.addFirst(output);
+    }
+  }
+
+  /**
    * Calculates the next value of the filter.
    *
    * @param input Current input value.

--- a/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/filter/LinearFilter.java
@@ -247,9 +247,10 @@ public class LinearFilter {
   }
 
   /**
-   * Resets the filter state, initializing internal buffers to the provided values.<br><br>
-   * 
-   * These are the expected lengths of the buffers, depending on what type of linear filter used:
+   * Resets the filter state, initializing internal buffers to the provided values.
+   *
+   * <p>These are the expected lengths of the buffers, depending on what type of linear filter used:
+   *
    * <table>
    * <tr><th>Type</th><th>Input Buffer Length</th><th>Output Buffer Length</th></tr>
    * <tr><td>Unspecified</td><td>length of {@code ffGains}</td><td>length of {@code fbGains}</td>
@@ -267,7 +268,8 @@ public class LinearFilter {
    *     length of ffGains and fbGains provided in the constructor.
    */
   public void reset(double[] inputBuffer, double[] outputBuffer) {
-    reset(); // Clear buffers
+    // Clear buffers
+    reset();
 
     if (inputBuffer.length != m_inputGains.length || outputBuffer.length != m_outputGains.length) {
       throw new IllegalArgumentException("Incorrect length of inputBuffer or outputBuffer");

--- a/wpimath/src/main/native/include/frc/filter/LinearFilter.h
+++ b/wpimath/src/main/native/include/frc/filter/LinearFilter.h
@@ -272,30 +272,64 @@ class LinearFilter {
   }
 
   /**
-   * Resets the filter state, initializing internal buffers to the provided values. <br><br>
-   * 
-   * These are the expected lengths of the buffers, depending on what type of linear filter used:
+   * Resets the filter state, initializing internal buffers to the provided
+   * values.
+   *
+   * These are the expected lengths of the buffers, depending on what type of
+   * linear filter used:
+   *
    * <table>
-   * <tr><th>Type</th><th>Input Buffer Size</th><th>Output Buffer Size</th></tr>
-   * <tr><td>Unspecified</td><td>size of {@code ffGains}</td><td>size of {@code fbGains}</td>
-   * </tr>
-   * <tr><td>Single Pole IIR</td><td>1</td><td>1</td></tr>
-   * <tr><td>High-Pass</td><td>2</td><td>1</td></tr>
-   * <tr><td>Moving Average</td><td>{@code taps}</td><td>0</td></tr>
-   * <tr><td>Finite Difference</td><td>size of {@code stencil}</td><td>0</td></tr>
-   * <tr><td>Backward Finite Difference</td><td>{@code Samples}</td><td>0</td></tr>
+   *   <tr>
+   *     <th>Type</th>
+   *     <th>Input Buffer Size</th>
+   *     <th>Output Buffer Size</th>
+   *   </tr>
+   *   <tr>
+   *     <td>Unspecified</td>
+   *     <td>size of {@code ffGains}</td>
+   *     <td>size of {@code fbGains}</td>
+   *   </tr>
+   *   <tr>
+   *     <td>Single Pole IIR</td>
+   *     <td>1</td>
+   *     <td>1</td>
+   *   </tr>
+   *   <tr>
+   *     <td>High-Pass</td>
+   *     <td>2</td>
+   *     <td>1</td>
+   *   </tr>
+   *   <tr>
+   *     <td>Moving Average</td>
+   *     <td>{@code taps}</td>
+   *     <td>0</td>
+   *   </tr>
+   *   <tr>
+   *     <td>Finite Difference</td>
+   *     <td>size of {@code stencil}</td>
+   *     <td>0</td>
+   *   </tr>
+   *   <tr>
+   *     <td>Backward Finite Difference</td>
+   *     <td>{@code Samples}</td>
+   *     <td>0</td>
+   *   </tr>
    * </table>
    *
    * @param inputBuffer Values to initialize input buffer.
    * @param outputBuffer Values to initialize output buffer.
-   * @throws std::runtime_error if size of inputBuffer or outputBuffer does not match the size of 
-   *     ffGains and fbGains provided in the constructor.
+   * @throws std::runtime_error if size of inputBuffer or outputBuffer does not
+   *   match the size of ffGains and fbGains provided in the constructor.
    */
-  void Reset(std::span<const double> inputBuffer, std::span<const double> outputBuffer) {
-    Reset(); // Clear buffers
-    
-    if (inputBuffer.size() != m_inputGains.size() || outputBuffer.size() != m_outputGains.size()) {
-      throw std::runtime_error("Incorrect length of inputBuffer or outputBuffer");
+  void Reset(std::span<const double> inputBuffer,
+             std::span<const double> outputBuffer) {
+    // Clear buffers
+    Reset();
+
+    if (inputBuffer.size() != m_inputGains.size() ||
+        outputBuffer.size() != m_outputGains.size()) {
+      throw std::runtime_error(
+          "Incorrect length of inputBuffer or outputBuffer");
     }
 
     for (size_t i = 0; i < inputBuffer.size(); ++i) {

--- a/wpimath/src/main/native/include/frc/filter/LinearFilter.h
+++ b/wpimath/src/main/native/include/frc/filter/LinearFilter.h
@@ -272,10 +272,9 @@ class LinearFilter {
   }
 
   /**
-   * Resets the filter state, initializing internal buffers to the provided values. <br>
-   * <br>
+   * Resets the filter state, initializing internal buffers to the provided values. <br><br>
+   * 
    * These are the expected lengths of the buffers, depending on what type of linear filter used:
-   *
    * <table>
    * <tr><th>Type</th><th>Input Buffer Size</th><th>Output Buffer Size</th></tr>
    * <tr><td>Unspecified</td><td>size of {@code ffGains}</td><td>size of {@code fbGains}</td>

--- a/wpimath/src/main/native/include/frc/filter/LinearFilter.h
+++ b/wpimath/src/main/native/include/frc/filter/LinearFilter.h
@@ -272,6 +272,42 @@ class LinearFilter {
   }
 
   /**
+   * Resets the filter state, initializing internal buffers to the provided values. <br>
+   * <br>
+   * These are the expected lengths of the buffers, depending on what type of linear filter used:
+   *
+   * <table>
+   * <tr><th>Type</th><th>Input Buffer Size</th><th>Output Buffer Size</th></tr>
+   * <tr><td>Unspecified</td><td>size of {@code ffGains}</td><td>size of {@code fbGains}</td>
+   * </tr>
+   * <tr><td>Single Pole IIR</td><td>1</td><td>1</td></tr>
+   * <tr><td>High-Pass</td><td>2</td><td>1</td></tr>
+   * <tr><td>Moving Average</td><td>{@code taps}</td><td>0</td></tr>
+   * <tr><td>Finite Difference</td><td>size of {@code stencil}</td><td>0</td></tr>
+   * <tr><td>Backward Finite Difference</td><td>{@code Samples}</td><td>0</td></tr>
+   * </table>
+   *
+   * @param inputBuffer Values to initialize input buffer.
+   * @param outputBuffer Values to initialize output buffer.
+   * @throws std::runtime_error if size of inputBuffer or outputBuffer does not match the size of 
+   *     ffGains and fbGains provided in the constructor.
+   */
+  void Reset(std::span<const double> inputBuffer, std::span<const double> outputBuffer) {
+    Reset(); // Clear buffers
+    
+    if (inputBuffer.size() != m_inputGains.size() || outputBuffer.size() != m_outputGains.size()) {
+      throw std::runtime_error("Incorrect length of inputBuffer or outputBuffer");
+    }
+
+    for (size_t i = 0; i < inputBuffer.size(); ++i) {
+      m_inputs.push_front(inputBuffer[i]);
+    }
+    for (size_t i = 0; i < outputBuffer.size(); ++i) {
+      m_outputs.push_front(outputBuffer[i]);
+    }
+  }
+
+  /**
    * Calculates the next value of the filter.
    *
    * @param input Current input value.


### PR DESCRIPTION
Resolves #5203 

Adds an overload `reset(double[] inputBuffer, double[] outputBuffer)` method (`Reset(std::span<const double> inputBuffer, std::span<const double> outputBuffer)` in C++) that resets the Linear Filter and initializes the internal input and output buffers with the values that the user specifies, to avoid the unexpected values returned initially (as seen [here](https://github.com/wpilibsuite/allwpilib/issues/5079)).

The documentation for these methods includes a table that specifies the expected number of inputs and outputs that each filter type has. This will throw an error if the sizes are not correct.