### PR TITLE
[wpilib] Make protected fields in accelerometers/gyros private

### DIFF
--- a/wpilibc/src/main/native/include/frc/ADXL345_I2C.h
+++ b/wpilibc/src/main/native/include/frc/ADXL345_I2C.h
@@ -100,7 +100,7 @@ class ADXL345_I2C : public nt::NTSendable,
 
   void InitSendable(nt::NTSendableBuilder& builder) override;
 
- protected:
+ private:
   I2C m_i2c;
 
   hal::SimDevice m_simDevice;

--- a/wpilibc/src/main/native/include/frc/ADXL345_SPI.h
+++ b/wpilibc/src/main/native/include/frc/ADXL345_SPI.h
@@ -93,7 +93,7 @@ class ADXL345_SPI : public nt::NTSendable,
 
   void InitSendable(nt::NTSendableBuilder& builder) override;
 
- protected:
+ private:
   SPI m_spi;
 
   hal::SimDevice m_simDevice;

--- a/wpilibc/src/main/native/include/frc/AnalogGyro.h
+++ b/wpilibc/src/main/native/include/frc/AnalogGyro.h
@@ -218,10 +218,8 @@ class AnalogGyro : public wpi::Sendable,
 
   void InitSendable(wpi::SendableBuilder& builder) override;
 
- protected:
-  std::shared_ptr<AnalogInput> m_analog;
-
  private:
+  std::shared_ptr<AnalogInput> m_analog;
   hal::Handle<HAL_GyroHandle> m_gyroHandle;
 };
 

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_I2C.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_I2C.java
@@ -70,13 +70,13 @@ public class ADXL345_I2C implements NTSendable, AutoCloseable {
     public double ZAxis;
   }
 
-  protected I2C m_i2c;
+  private I2C m_i2c;
 
-  protected SimDevice m_simDevice;
-  protected SimEnum m_simRange;
-  protected SimDouble m_simX;
-  protected SimDouble m_simY;
-  protected SimDouble m_simZ;
+  private SimDevice m_simDevice;
+  private SimEnum m_simRange;
+  private SimDouble m_simX;
+  private SimDouble m_simY;
+  private SimDouble m_simZ;
 
   /**
    * Constructs the ADXL345 Accelerometer with I2C address 0x1D.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_SPI.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADXL345_SPI.java
@@ -67,13 +67,13 @@ public class ADXL345_SPI implements NTSendable, AutoCloseable {
     public double ZAxis;
   }
 
-  protected SPI m_spi;
+  private SPI m_spi;
 
-  protected SimDevice m_simDevice;
-  protected SimEnum m_simRange;
-  protected SimDouble m_simX;
-  protected SimDouble m_simY;
-  protected SimDouble m_simZ;
+  private SimDevice m_simDevice;
+  private SimEnum m_simRange;
+  private SimDouble m_simX;
+  private SimDouble m_simY;
+  private SimDouble m_simZ;
 
   /**
    * Constructor.

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogGyro.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/AnalogGyro.java
@@ -25,7 +25,7 @@ import edu.wpi.first.util.sendable.SendableRegistry;
  */
 public class AnalogGyro implements Sendable, AutoCloseable {
   private static final double kDefaultVoltsPerDegreePerSecond = 0.007;
-  protected AnalogInput m_analog;
+  private AnalogInput m_analog;
   private boolean m_channelAllocated;
 
   private int m_gyroHandle;


### PR DESCRIPTION
This avoids needing add redundant JavaDocs to them, and better reflects how we design our modern classes (the classes modified here were around with minimal changes since 2008 or so).