### PR TITLE
Fix trivial errorprone warnings (NFC)

### DIFF
--- a/ntcore/src/generate/main/java/NetworkTableEntry.java.jinja
+++ b/ntcore/src/generate/main/java/NetworkTableEntry.java.jinja
@@ -608,6 +608,6 @@ public final class NetworkTableEntry implements Publisher, Subscriber {
   }
 
   private final Topic m_topic;
-  protected int m_handle;
+  private final int m_handle;
 }
 

--- a/ntcore/src/generated/main/java/edu/wpi/first/networktables/NetworkTableEntry.java
+++ b/ntcore/src/generated/main/java/edu/wpi/first/networktables/NetworkTableEntry.java
@@ -1009,5 +1009,5 @@ public final class NetworkTableEntry implements Publisher, Subscriber {
   }
 
   private final Topic m_topic;
-  protected int m_handle;
+  private final int m_handle;
 }

--- a/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTable.java
+++ b/ntcore/src/main/java/edu/wpi/first/networktables/NetworkTable.java
@@ -330,7 +330,7 @@ public final class NetworkTable {
    * @return true if the table as a value assigned to the given key
    */
   public boolean containsKey(String key) {
-    return !("".equals(key)) && getTopic(key).exists();
+    return !"".equals(key) && getTopic(key).exists();
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16448_IMU.java
@@ -383,7 +383,7 @@ public class ADIS16448_IMU implements AutoCloseable, Sendable {
 
   /** */
   private static int toShort(int... buf) {
-    return (short) (((buf[0] & 0xFF) << 8) + ((buf[1] & 0xFF)));
+    return (short) (((buf[0] & 0xFF) << 8) + (buf[1] & 0xFF));
   }
 
   /** */

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16470_IMU.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/ADIS16470_IMU.java
@@ -453,7 +453,7 @@ public class ADIS16470_IMU implements AutoCloseable, Sendable {
    * @return
    */
   private static int toUShort(ByteBuffer buf) {
-    return (buf.getShort(0)) & 0xFFFF;
+    return buf.getShort(0) & 0xFFFF;
   }
 
   /**
@@ -469,7 +469,7 @@ public class ADIS16470_IMU implements AutoCloseable, Sendable {
    * @return
    */
   private static int toShort(int... buf) {
-    return (short) (((buf[0] & 0xFF) << 8) + ((buf[1] & 0xFF)));
+    return (short) (((buf[0] & 0xFF) << 8) + (buf[1] & 0xFF));
   }
 
   /**
@@ -693,7 +693,7 @@ public class ADIS16470_IMU implements AutoCloseable, Sendable {
   private void writeRegister(int reg, int val) {
     ByteBuffer buf = ByteBuffer.allocateDirect(2);
     // low byte
-    buf.put(0, (byte) ((0x80 | reg)));
+    buf.put(0, (byte) (0x80 | reg));
     buf.put(1, (byte) (val & 0xff));
     m_spi.write(buf, 2);
     // high byte

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/Servo.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/Servo.java
@@ -84,7 +84,7 @@ public class Servo extends PWM {
       degrees = kMaxServoAngle;
     }
 
-    setPosition(((degrees - kMinServoAngle)) / getServoAngleRange());
+    setPosition((degrees - kMinServoAngle) / getServoAngleRange());
   }
 
   /**

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/DifferentialDrive.java
@@ -368,7 +368,7 @@ public class DifferentialDrive extends RobotDriveBase implements Sendable, AutoC
     builder.setSmartDashboardType("DifferentialDrive");
     builder.setActuator(true);
     builder.setSafeState(this::stopMotor);
-    builder.addDoubleProperty("Left Motor Speed", () -> m_leftOutput, m_leftMotor::accept);
-    builder.addDoubleProperty("Right Motor Speed", () -> m_rightOutput, m_rightMotor::accept);
+    builder.addDoubleProperty("Left Motor Speed", () -> m_leftOutput, m_leftMotor);
+    builder.addDoubleProperty("Right Motor Speed", () -> m_rightOutput, m_rightMotor);
   }
 }

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/drive/MecanumDrive.java
@@ -321,13 +321,10 @@ public class MecanumDrive extends RobotDriveBase implements Sendable, AutoClosea
     builder.setSmartDashboardType("MecanumDrive");
     builder.setActuator(true);
     builder.setSafeState(this::stopMotor);
+    builder.addDoubleProperty("Front Left Motor Speed", () -> m_frontLeftOutput, m_frontLeftMotor);
     builder.addDoubleProperty(
-        "Front Left Motor Speed", () -> m_frontLeftOutput, m_frontLeftMotor::accept);
-    builder.addDoubleProperty(
-        "Front Right Motor Speed", () -> m_frontRightOutput, m_frontRightMotor::accept);
-    builder.addDoubleProperty(
-        "Rear Left Motor Speed", () -> m_rearLeftOutput, m_rearLeftMotor::accept);
-    builder.addDoubleProperty(
-        "Rear Right Motor Speed", () -> m_rearRightOutput, m_rearRightMotor::accept);
+        "Front Right Motor Speed", () -> m_frontRightOutput, m_frontRightMotor);
+    builder.addDoubleProperty("Rear Left Motor Speed", () -> m_rearLeftOutput, m_rearLeftMotor);
+    builder.addDoubleProperty("Rear Right Motor Speed", () -> m_rearRightOutput, m_rearRightMotor);
   }
 }

--- a/wpimath/src/main/java/edu/wpi/first/math/StateSpaceUtil.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/StateSpaceUtil.java
@@ -80,7 +80,7 @@ public final class StateSpaceUtil {
       if (tolerances.get(i, 0) == Double.POSITIVE_INFINITY) {
         result.set(i, i, 0.0);
       } else {
-        result.set(i, i, 1.0 / (Math.pow(tolerances.get(i, 0), 2)));
+        result.set(i, i, 1.0 / Math.pow(tolerances.get(i, 0), 2));
       }
     }
 

--- a/wpimath/src/main/java/edu/wpi/first/math/controller/ControlAffinePlantInversionFeedforward.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/controller/ControlAffinePlantInversionFeedforward.java
@@ -181,7 +181,7 @@ public class ControlAffinePlantInversionFeedforward<States extends Num, Inputs e
    * @return The calculated feedforward.
    */
   public Matrix<Inputs, N1> calculate(Matrix<States, N1> r, Matrix<States, N1> nextR) {
-    var rDot = (nextR.minus(r)).div(m_dt);
+    var rDot = nextR.minus(r).div(m_dt);
 
     // ṙ = f(r) + Bu
     // Bu = ṙ − f(r)

--- a/wpimath/src/main/java/edu/wpi/first/math/estimator/SteadyStateKalmanFilter.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/estimator/SteadyStateKalmanFilter.java
@@ -114,7 +114,7 @@ public class SteadyStateKalmanFilter<States extends Num, Inputs extends Num, Out
     // K = (Sᵀ.solve(CPᵀ))ᵀ
     m_K =
         new Matrix<>(
-            S.transpose().getStorage().solve((C.times(P.transpose())).getStorage()).transpose());
+            S.transpose().getStorage().solve(C.times(P.transpose()).getStorage()).transpose());
 
     reset();
   }

--- a/wpimath/src/main/java/edu/wpi/first/math/path/TravelingSalesman.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/path/TravelingSalesman.java
@@ -62,7 +62,7 @@ public class TravelingSalesman {
                 sum +=
                     m_cost.applyAsDouble(
                         poses[(int) state.get(i, 0)],
-                        poses[(int) (state.get((i + 1) % poses.length, 0))]);
+                        poses[(int) state.get((i + 1) % poses.length, 0)]);
               }
               return sum;
             });

--- a/wpimath/src/main/java/edu/wpi/first/math/system/LinearSystem.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/LinearSystem.java
@@ -180,7 +180,7 @@ public class LinearSystem<States extends Num, Inputs extends Num, Outputs extend
       Matrix<States, N1> x, Matrix<Inputs, N1> clampedU, double dtSeconds) {
     var discABpair = Discretization.discretizeAB(m_A, m_B, dtSeconds);
 
-    return (discABpair.getFirst().times(x)).plus(discABpair.getSecond().times(clampedU));
+    return discABpair.getFirst().times(x).plus(discABpair.getSecond().times(clampedU));
   }
 
   /**

--- a/wpimath/src/main/java/edu/wpi/first/math/system/LinearSystemLoop.java
+++ b/wpimath/src/main/java/edu/wpi/first/math/system/LinearSystemLoop.java
@@ -292,7 +292,7 @@ public class LinearSystemLoop<States extends Num, Inputs extends Num, Outputs ex
    * @return The error at that index.
    */
   public double getError(int index) {
-    return (getController().getR().minus(m_observer.getXhat())).get(index, 0);
+    return getController().getR().minus(m_observer.getXhat()).get(index, 0);
   }
 
   /**

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/LinearQuadraticRegulatorTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/LinearQuadraticRegulatorTest.java
@@ -78,8 +78,8 @@ class LinearQuadraticRegulatorTest {
    *
    * <p>This is used to test the QRN overload of LQR.
    *
-   * @param States Number of states.
-   * @param Inputs Number of inputs.
+   * @param <States> Number of states.
+   * @param <Inputs> Number of inputs.
    * @param A State matrix.
    * @param B Input matrix.
    * @param Q State cost matrix.
@@ -119,10 +119,10 @@ class LinearQuadraticRegulatorTest {
 
     // QR overload
     var K = new LinearQuadraticRegulator<>(A, B, Q, R, 0.005).getK();
-    assertEquals(0.99750312499512261, K.get(0, 0), 1e-10);
+    assertEquals(0.9975031249951226, K.get(0, 0), 1e-10);
     assertEquals(0.0, K.get(0, 1), 1e-10);
     assertEquals(0.0, K.get(1, 0), 1e-10);
-    assertEquals(0.99750312499512261, K.get(1, 1), 1e-10);
+    assertEquals(0.9975031249951226, K.get(1, 1), 1e-10);
 
     // QRN overload
     var N = MatBuilder.fill(Nat.N2(), Nat.N2(), 1, 0, 0, 1);
@@ -146,13 +146,13 @@ class LinearQuadraticRegulatorTest {
     // QR overload
     var K = new LinearQuadraticRegulator<>(A, B, Q, R, 0.005).getK();
     assertEquals(1.9960017786537287, K.get(0, 0), 1e-10);
-    assertEquals(0.51182128351092726, K.get(0, 1), 1e-10);
+    assertEquals(0.5118212835109273, K.get(0, 1), 1e-10);
 
     // QRN overload
     var Aref = MatBuilder.fill(Nat.N2(), Nat.N2(), 0, 1, 0, -Kv / (Ka * 5.0));
     var Kimf = getImplicitModelFollowingK(A, B, Q, R, Aref, 0.005);
     assertEquals(0.0, Kimf.get(0, 0), 1e-10);
-    assertEquals(-6.9190500116751458e-05, Kimf.get(0, 1), 1e-10);
+    assertEquals(-6.919050011675146e-05, Kimf.get(0, 1), 1e-10);
   }
 
   @Test

--- a/wpimath/src/test/java/edu/wpi/first/math/controller/SimpleMotorFeedforwardTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/controller/SimpleMotorFeedforwardTest.java
@@ -29,7 +29,7 @@ class SimpleMotorFeedforwardTest {
     var r = VecBuilder.fill(2.0);
     var nextR = VecBuilder.fill(3.0);
 
-    assertEquals(37.524995834325161 + 0.5, simpleMotor.calculate(2.0, 3.0, dt), 0.002);
+    assertEquals(37.52499583432516 + 0.5, simpleMotor.calculate(2.0, 3.0, dt), 0.002);
     assertEquals(
         plantInversion.calculate(r, nextR).get(0, 0) + Ks,
         simpleMotor.calculate(2.0, 3.0, dt),

--- a/wpimath/src/test/java/edu/wpi/first/math/geometry/QuaternionTest.java
+++ b/wpimath/src/test/java/edu/wpi/first/math/geometry/QuaternionTest.java
@@ -125,7 +125,7 @@ class QuaternionTest {
     // Identity
     var q =
         new Quaternion(
-            0.72760687510899891, 0.29104275004359953, 0.38805700005813276, 0.48507125007266594);
+            0.7276068751089989, 0.29104275004359953, 0.38805700005813276, 0.48507125007266594);
     final var actual2 = q.times(q.inverse());
     assertAll(
         () -> assertEquals(1.0, actual2.getW()),

--- a/wpiunits/src/main/java/edu/wpi/first/units/Mult.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/Mult.java
@@ -48,7 +48,7 @@ public class Mult<A extends Unit<A>, B extends Unit<B>> extends Unit<Mult<A, B>>
    */
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static <A extends Unit<A>, B extends Unit<B>> Mult<A, B> combine(A a, B b) {
-    final long key = ((long) a.hashCode()) << 32L | ((long) b.hashCode()) & 0xFFFFFFFFL;
+    final long key = ((long) a.hashCode()) << 32L | (((long) b.hashCode()) & 0xFFFFFFFFL);
     if (cache.containsKey(key)) {
       return cache.get(key);
     }

--- a/wpiunits/src/main/java/edu/wpi/first/units/Per.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/Per.java
@@ -58,7 +58,7 @@ public class Per<N extends Unit<N>, D extends Unit<D>> extends Unit<Per<N, D>> {
   public static <N extends Unit<N>, D extends Unit<D>> Per<N, D> combine(
       N numerator, D denominator) {
     final long key =
-        ((long) numerator.hashCode()) << 32L | ((long) denominator.hashCode()) & 0xFFFFFFFFL;
+        ((long) numerator.hashCode()) << 32L | (((long) denominator.hashCode()) & 0xFFFFFFFFL);
 
     var existing = cache.get(key);
     if (existing != null) {

--- a/wpiunits/src/main/java/edu/wpi/first/units/Velocity.java
+++ b/wpiunits/src/main/java/edu/wpi/first/units/Velocity.java
@@ -33,7 +33,7 @@ public class Velocity<D extends Unit<D>> extends Unit<Velocity<D>> {
 
   /** Generates a cache key used for cache lookups. */
   private static long cacheKey(Unit<?> numerator, Unit<?> denominator) {
-    return ((long) numerator.hashCode()) << 32L | ((long) denominator.hashCode()) & 0xFFFFFFFFL;
+    return ((long) numerator.hashCode()) << 32L | (((long) denominator.hashCode()) & 0xFFFFFFFFL);
   }
 
   /**

--- a/wpiunits/src/test/java/edu/wpi/first/units/MeasureTest.java
+++ b/wpiunits/src/test/java/edu/wpi/first/units/MeasureTest.java
@@ -173,7 +173,7 @@ class MeasureTest {
     var measure = Units.Volts.of(343);
     assertEquals("343.0 Volt", measure.toLongString());
     assertEquals("343.0001 Volt", Units.Volts.of(343.0001).toLongString());
-    assertEquals("1.2345678912345679E8 Volt", Units.Volts.of(123456789.123456789).toLongString());
+    assertEquals("1.2345678912345678E8 Volt", Units.Volts.of(123456789.12345678).toLongString());
   }
 
   @Test

--- a/wpiutil/src/main/java/edu/wpi/first/util/struct/StructFieldDescriptor.java
+++ b/wpiutil/src/main/java/edu/wpi/first/util/struct/StructFieldDescriptor.java
@@ -206,7 +206,7 @@ public class StructFieldDescriptor {
    * @return minimum value
    */
   public long getIntMin() {
-    return (-(m_bitMask >> 1)) - 1;
+    return -(m_bitMask >> 1) - 1;
   }
 
   /**


### PR DESCRIPTION
This squashes a few Error Prone warnings:

- https://errorprone.info/bugpattern/FloatingPointLiteralPrecision
- https://errorprone.info/bugpattern/InvalidParam
- https://errorprone.info/bugpattern/ProtectedMembersInFinalClass
- https://errorprone.info/bugpattern/UnnecessaryMethodReference
- https://errorprone.info/bugpattern/UnnecessaryParentheses
- https://errorprone.info/bugpattern/OperatorPrecedence (bitwise ops only, checkstyle conflicts)