### PR TITLE
[command based] use C++ operator overloading to improve syntax for a variety of command functions

### DIFF
--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -9,7 +9,9 @@
 #include <wpi/sendable/SendableRegistry.h>
 
 #include "frc2/command/CommandHelper.h"
+#include "frc2/command/CommandPtr.h"
 #include "frc2/command/CommandScheduler.h"
+#include "frc2/command/Commands.h"
 #include "frc2/command/ConditionalCommand.h"
 #include "frc2/command/InstantCommand.h"
 #include "frc2/command/ParallelCommandGroup.h"
@@ -203,6 +205,18 @@ void Command::InitSendable(wpi::SendableBuilder& builder) {
       nullptr);
   builder.AddBooleanProperty(
       "runsWhenDisabled", [this] { return RunsWhenDisabled(); }, nullptr);
+}
+
+CommandPtr operator<<(Command *command, auto toRun) {
+  return command->AndThen(toRun);
+}
+
+CommandPtr operator|(CommandPtr command1, CommandPtr command2) {
+  return frc2::cmd::Parallel(std::move(command1), std::move(command2));
+}
+
+CommandPtr operator&(CommandPtr command1, CommandPtr command2) {
+  return frc2::cmd::Race(std::move(command1), std::move(command2));
 }
 
 namespace frc2 {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -211,6 +211,10 @@ CommandPtr operator<<(CommandPtr command, auto toRun) {
   return command.AndThen(toRun);
 }
 
+CommandPtr operator<<(Command* command, auto toRun) {
+  return command->AndThen(toRun);
+}
+
 CommandPtr operator|(CommandPtr command1, CommandPtr command2) {
   return frc2::cmd::Parallel(std::move(command1), std::move(command2));
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -207,8 +207,8 @@ void Command::InitSendable(wpi::SendableBuilder& builder) {
       "runsWhenDisabled", [this] { return RunsWhenDisabled(); }, nullptr);
 }
 
-CommandPtr operator<<(Command *command, auto toRun) {
-  return command->AndThen(toRun);
+CommandPtr operator<<(CommandPtr command, auto toRun) {
+  return command.AndThen(toRun);
 }
 
 CommandPtr operator|(CommandPtr command1, CommandPtr command2) {

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Command.cpp
@@ -207,21 +207,21 @@ void Command::InitSendable(wpi::SendableBuilder& builder) {
       "runsWhenDisabled", [this] { return RunsWhenDisabled(); }, nullptr);
 }
 
-CommandPtr operator<<(CommandPtr command, auto toRun) {
+CommandPtr operator|(CommandPtr command, auto toRun) {
   return command.AndThen(toRun);
 }
 
-CommandPtr operator<<(Command* command, auto toRun) {
+CommandPtr operator|(Command* command, auto toRun) {
   return command->AndThen(toRun);
 }
 
-CommandPtr operator|(CommandPtr command1, CommandPtr command2) {
-  return frc2::cmd::Parallel(std::move(command1), std::move(command2));
-}
+//CommandPtr operator|(CommandPtr command1, CommandPtr command2) {
+//  return frc2::cmd::Parallel(std::move(command1), std::move(command2));
+//}
 
-CommandPtr operator&(CommandPtr command1, CommandPtr command2) {
-  return frc2::cmd::Race(std::move(command1), std::move(command2));
-}
+//CommandPtr operator&(CommandPtr command1, CommandPtr command2) {
+//  return frc2::cmd::Race(std::move(command1), std::move(command2));
+//}
 
 namespace frc2 {
 bool RequirementsDisjoint(Command* first, Command* second) {


### PR DESCRIPTION
Resolves #6075