### PR TITLE
[cmd] Make Java fields private

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/FunctionalCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/FunctionalCommand.java
@@ -18,10 +18,10 @@ import java.util.function.Consumer;
  * <p>This class is provided by the NewCommands VendorDep
  */
 public class FunctionalCommand extends Command {
-  protected final Runnable m_onInit;
-  protected final Runnable m_onExecute;
-  protected final Consumer<Boolean> m_onEnd;
-  protected final BooleanSupplier m_isFinished;
+  private final Runnable m_onInit;
+  private final Runnable m_onExecute;
+  private final Consumer<Boolean> m_onEnd;
+  private final BooleanSupplier m_isFinished;
 
   /**
    * Creates a new FunctionalCommand.

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/NotifierCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/NotifierCommand.java
@@ -18,8 +18,8 @@ import edu.wpi.first.wpilibj.Notifier;
  * <p>This class is provided by the NewCommands VendorDep
  */
 public class NotifierCommand extends Command {
-  protected final Notifier m_notifier;
-  protected final double m_period;
+  private final Notifier m_notifier;
+  private final double m_period;
 
   /**
    * Creates a new NotifierCommand.

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RepeatCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/RepeatCommand.java
@@ -20,7 +20,7 @@ import edu.wpi.first.util.sendable.SendableBuilder;
  * <p>This class is provided by the NewCommands VendorDep
  */
 public class RepeatCommand extends Command {
-  protected final Command m_command;
+  private final Command m_command;
   private boolean m_ended;
 
   /**


### PR DESCRIPTION
They were already private in C++ and probably shouldn't be exposed. This also means we don't need to write redundant documentation for them.