### PR TITLE
Update MotorControllerGroup deprecation message

### DIFF
--- a/wpilibc/src/main/native/include/frc/motorcontrol/MotorControllerGroup.h
+++ b/wpilibc/src/main/native/include/frc/motorcontrol/MotorControllerGroup.h
@@ -21,8 +21,8 @@ namespace frc {
  * Allows multiple MotorController objects to be linked together.
  */
 class [[deprecated(
-    "Use CAN motor controller followers or "
-    "PWMMotorController::AddFollower()")]] MotorControllerGroup
+    "Use PWMMotorController::AddFollower() or if using CAN motor controllers,"
+    "use their method of following.")]] MotorControllerGroup
     : public wpi::Sendable,
       public MotorController,
       public wpi::SendableHelper<MotorControllerGroup> {

--- a/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/MotorControllerGroup.java
+++ b/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/MotorControllerGroup.java
@@ -12,8 +12,8 @@ import java.util.Arrays;
 /**
  * Allows multiple {@link MotorController} objects to be linked together.
  *
- * @deprecated Use CAN motor controller followers or {@link
- *     PWMMotorController#addFollower(PWMMotorController)}.
+ * @deprecated Use {@link PWMMotorController#addFollower(PWMMotorController)} or if using CAN motor
+ *     controllers, use their method of following.
  */
 @SuppressWarnings("removal")
 @Deprecated(forRemoval = true, since = "2024")


### PR DESCRIPTION
The current message could be read as encouraging the use of CAN motor controllers. This tries to make it more clear.