### PR TITLE
[build] Fix running apriltagsvision Java example

### DIFF
--- a/wpilibjExamples/build.gradle
+++ b/wpilibjExamples/build.gradle
@@ -95,6 +95,7 @@ model {
             }
             binaries.all { binary ->
                 lib project: ':apriltag', library: 'apriltag', linkage: 'shared'
+                lib project: ':apriltag', library: 'apriltagJNIShared', linkage: 'shared'
                 lib project: ':wpimath', library: 'wpimath', linkage: 'shared'
                 lib project: ':wpimath', library: 'wpimathJNIShared', linkage: 'shared'
                 project(':ntcore').addNtcoreDependency(binary, 'shared')


### PR DESCRIPTION
Before:
```
$ ./gradlew wpilibjExamples:runapriltagsvision
[...]
********** Robot program startup complete **********
java.io.IOException: apriltagjni could not be loaded from path or an embedded resource.
        attempted to load for platform /osx/universal/
Last Load Error:
no apriltagjni in java.library.path: /Users/davidv/dev/frc/wpilibsuite/allwpilib/wpilibjExamples/build/install/wpilibjExamplesDev/osxuniversal/lib

        at edu.wpi.first.util.RuntimeLoader.loadLibrary(RuntimeLoader.java:98)
        at edu.wpi.first.apriltag.jni.AprilTagJNI.<clinit>(AprilTagJNI.java:54)
        at edu.wpi.first.apriltag.AprilTagDetector.<init>(AprilTagDetector.java:213)
        at edu.wpi.first.wpilibj.examples.apriltagsvision.Robot.apriltagVisionThreadProc(Robot.java:41)
        at java.base/java.lang.Thread.run(Thread.java:840)
```