### PR TITLE
[sysid] Filter valid test names

### DIFF
--- a/sysid/src/main/native/cpp/view/DataSelector.cpp
+++ b/sysid/src/main/native/cpp/view/DataSelector.cpp
@@ -91,6 +91,31 @@ void DataSelector::Display() {
   if (m_testsFuture.valid() &&
       m_testsFuture.wait_for(0s) == std::future_status::ready) {
     m_tests = m_testsFuture.get();
+    for (auto it = m_tests.begin(); it != m_tests.end();) {
+      if (it->first != "quasistatic" && it->first != "dynamic") {
+        WPI_WARNING(m_logger, "Unrecognized test {}, removing", it->first);
+        it = m_tests.erase(it);
+        continue;
+      }
+      for (auto it2 = it->second.begin(); it2 != it->second.end();) {
+        auto direction = wpi::rsplit(it2->first, '-').second;
+        if (direction != "forward" && direction != "reverse") {
+          WPI_WARNING(m_logger, "Unrecognized direction {}, removing",
+                      direction);
+          it2 = it->second.erase(it2);
+          continue;
+        }
+        WPI_INFO(m_logger, "Loaded test state {}", it2->first);
+        ++it2;
+      }
+      if (it->second.empty()) {
+        WPI_WARNING(m_logger, "No data for test {}, removing", it->first);
+        it = m_tests.erase(it);
+        continue;
+      }
+      ++it;
+    }
+    WPI_INFO(m_logger, "Loaded {} tests", m_tests.size());
   }
 
   if (m_tests.empty()) {

--- a/sysid/src/main/native/include/sysid/view/DataSelector.h
+++ b/sysid/src/main/native/include/sysid/view/DataSelector.h
@@ -38,7 +38,7 @@ class DataSelector : public glass::View {
    * @param logger The program logger
    */
   explicit DataSelector(glass::Storage& storage, wpi::Logger& logger)
-  /*: m_logger{logger}*/ {}
+      : m_logger{logger} {}
 
   /**
    * Displays the log loader window.
@@ -57,7 +57,7 @@ class DataSelector : public glass::View {
   std::function<void(TestData)> testdata;
 
  private:
-  // wpi::Logger& m_logger;
+  wpi::Logger& m_logger;
   using Runs = std::vector<std::pair<int64_t, int64_t>>;
   using State = std::map<std::string, Runs, std::less<>>;   // full name
   using Tests = std::map<std::string, State, std::less<>>;  // e.g. "dynamic"


### PR DESCRIPTION
Currently the analysis portion only supports quasistatic and dynamic, forward and reverse. Check for anything not matching and remove it, along with providing diagnostics of what is being loaded.

Fixes #6188.