### PR TITLE
Limit error bit correction in April Tag examples

### DIFF
--- a/wpilibcExamples/src/main/cpp/examples/AprilTagsVision/cpp/Robot.cpp
+++ b/wpilibcExamples/src/main/cpp/examples/AprilTagsVision/cpp/Robot.cpp
@@ -37,8 +37,8 @@ class Robot : public frc::TimedRobot {
  private:
   static void VisionThread() {
     frc::AprilTagDetector detector;
-    // look for tag36h11, correct 7 error bits
-    detector.AddFamily("tag36h11", 7);
+    // look for tag36h11, correct 3 error bits
+    detector.AddFamily("tag36h11", 3);
 
     // Set up Pose Estimator - parameters are for a Microsoft Lifecam HD-3000
     // (https://www.chiefdelphi.com/t/wpilib-apriltagdetector-sample-code/421411/21)

--- a/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/apriltagsvision/Robot.java
+++ b/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/apriltagsvision/Robot.java
@@ -39,8 +39,8 @@ public class Robot extends TimedRobot {
 
   void apriltagVisionThreadProc() {
     var detector = new AprilTagDetector();
-    // look for tag136h11, correct 7 error bits
-    detector.addFamily("tag36h11", 7);
+    // look for tag136h11, correct 3 error bits
+    detector.addFamily("tag36h11", 3);
 
     // Set up Pose Estimator - parameters are for a Microsoft Lifecam HD-3000
     // (https://www.chiefdelphi.com/t/wpilib-apriltagdetector-sample-code/421411/21)


### PR DESCRIPTION
Values >3 are not supported. https://github.com/wpilibsuite/apriltag/blob/64be6ab26abf5e995321997fd0752c609a7e30f4/apriltag.c#L261-L266