### PR TITLE
[build] cmake: add wpinet dependency to cscore-config.cmake

### DIFF
--- a/cscore/cscore-config.cmake.in
+++ b/cscore/cscore-config.cmake.in
@@ -1,6 +1,7 @@
 include(CMakeFindDependencyMacro)
 @FILENAME_DEP_REPLACE@
 @WPIUTIL_DEP_REPLACE@
+@WPINET_DEP_REPLACE@
 find_dependency(OpenCV)
 
 @FILENAME_DEP_REPLACE@


### PR DESCRIPTION
Attempting to build with cscore results in the project being unable to find wpinet unless explicitly found with `find_package` earlier.