### PR TITLE
Add supplier constructor to WaitCommand

### DIFF
--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/Commands.java
@@ -9,6 +9,7 @@ import static edu.wpi.first.util.ErrorMessages.requireNonNullParam;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
+import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 
 /**
@@ -113,6 +114,18 @@ public final class Commands {
    */
   public static Command waitSeconds(double seconds) {
     return new WaitCommand(seconds);
+  }
+
+  /**
+   * Constructs a command that does nothing, finishing after the duration returned by the provided
+   * supplier.
+   *
+   * @param durationSupplier Function that provides the time to wait, in seconds.
+   * @return the command
+   * @see WaitCommand#WaitCommand(DoubleSupplier)
+   */
+  public static Command waitSeconds(DoubleSupplier durationSupplier) {
+    return new WaitCommand(durationSupplier);
   }
 
   /**

--- a/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/WaitCommand.java
+++ b/wpilibNewCommands/src/main/java/edu/wpi/first/wpilibj2/command/WaitCommand.java
@@ -5,8 +5,8 @@
 package edu.wpi.first.wpilibj2.command;
 
 import edu.wpi.first.util.sendable.SendableBuilder;
-import edu.wpi.first.util.sendable.SendableRegistry;
 import edu.wpi.first.wpilibj.Timer;
+import java.util.function.DoubleSupplier;
 
 /**
  * A command that does nothing but takes a specified amount of time to finish.
@@ -17,27 +17,39 @@ public class WaitCommand extends Command {
   /** The timer used for waiting. */
   protected Timer m_timer = new Timer();
 
-  private final double m_duration;
+  private double m_duration;
+  private final DoubleSupplier m_durationSupplier;
 
   /**
    * Creates a new WaitCommand. This command will do nothing, and end after the specified duration.
    *
    * @param seconds the time to wait, in seconds
    */
-  @SuppressWarnings("this-escape")
   public WaitCommand(double seconds) {
-    m_duration = seconds;
-    SendableRegistry.setName(this, getName() + ": " + seconds + " seconds");
+    this(() -> seconds);
+    setName(getName() + ": " + seconds + " seconds");
+  }
+
+  /**
+   * Creates a new WaitCommand. This command will do nothing, and end after the duration returned by
+   * the provided supplier. The supplier will be called once each time the command is initialized.
+   *
+   * @param durationSupplier Function that provides the time to wait, in seconds.
+   */
+  public WaitCommand(DoubleSupplier durationSupplier) {
+    m_durationSupplier = durationSupplier;
   }
 
   @Override
   public void initialize() {
+    m_duration = m_durationSupplier.getAsDouble();
     m_timer.restart();
   }
 
   @Override
   public void end(boolean interrupted) {
     m_timer.stop();
+    m_duration = 0;
   }
 
   @Override

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/Commands.cpp
@@ -72,6 +72,10 @@ CommandPtr cmd::Wait(units::second_t duration) {
   return WaitCommand(duration).ToPtr();
 }
 
+CommandPtr cmd::Wait(std::function<units::second_t()> durationSupplier) {
+  return WaitCommand(durationSupplier).ToPtr();
+}
+
 CommandPtr cmd::WaitUntil(std::function<bool()> condition) {
   return WaitUntilCommand(condition).ToPtr();
 }

--- a/wpilibNewCommands/src/main/native/cpp/frc2/command/WaitCommand.cpp
+++ b/wpilibNewCommands/src/main/native/cpp/frc2/command/WaitCommand.cpp
@@ -9,16 +9,22 @@
 
 using namespace frc2;
 
-WaitCommand::WaitCommand(units::second_t duration) : m_duration{duration} {
+WaitCommand::WaitCommand(units::second_t duration)
+    : WaitCommand{[duration] { return duration; }} {
   SetName(fmt::format("{}: {}", GetName(), duration));
 }
 
+WaitCommand::WaitCommand(std::function<units::second_t()> durationSupplier)
+    : m_durationSupplier{durationSupplier} {}
+
 void WaitCommand::Initialize() {
+  m_duration = m_durationSupplier();
   m_timer.Restart();
 }
 
 void WaitCommand::End(bool interrupted) {
   m_timer.Stop();
+  m_duration = 0_s;
 }
 
 bool WaitCommand::IsFinished() {

--- a/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/Commands.h
@@ -103,6 +103,14 @@ CommandPtr Print(std::string_view msg);
 CommandPtr Wait(units::second_t duration);
 
 /**
+ * Constructs a command that does nothing, finishing after the duration returned
+ * by the provided supplier.
+ *
+ * @param durationSupplier Function that provides the time to wait, in seconds.
+ */
+CommandPtr Wait(std::function<units::second_t()> durationSupplier);
+
+/**
  * Constructs a command that does nothing, finishing once a condition becomes
  * true.
  *

--- a/wpilibNewCommands/src/main/native/include/frc2/command/WaitCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/WaitCommand.h
@@ -26,6 +26,15 @@ class WaitCommand : public CommandHelper<Command, WaitCommand> {
    */
   explicit WaitCommand(units::second_t duration);
 
+  /**
+   * Creates a new WaitCommand. This command will do nothing, and end after the
+   * duration returned by the provided function. The function will be called
+   * once each time the command is initialized.
+   * @param durationSupplier Function that provides the time to wait, in
+   * seconds.
+   */
+  explicit WaitCommand(std::function<units::second_t()> durationSupplier);
+
   WaitCommand(WaitCommand&& other) = default;
 
   WaitCommand(const WaitCommand& other) = default;
@@ -45,6 +54,7 @@ class WaitCommand : public CommandHelper<Command, WaitCommand> {
   frc::Timer m_timer;
 
  private:
+  std::function<units::second_t()> m_durationSupplier;
   units::second_t m_duration;
 };
 }  // namespace frc2

--- a/wpilibNewCommands/src/main/native/include/frc2/command/WaitCommand.h
+++ b/wpilibNewCommands/src/main/native/include/frc2/command/WaitCommand.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include <frc/Timer.h>
 #include <units/time.h>
 


### PR DESCRIPTION
Closes #6239

RE: comments in #6239 
Supplier is only polled at initialization rather than constantly

Not sure whether this should wrap DeferredCommand or not. The way it's implemented currently does allow for less GC'd allocation overall, but I'm not sure how much of a concern that is in this case.

edit: somehow missed the 2 PRs for that issue.... feel free to close this